### PR TITLE
MWPW-108710 - Handle Emdashes

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -75,8 +75,9 @@ export async function loadBlock(block) {
 }
 
 export function makeRelative(href) {
+  const fixedHref = href.replace(/\u2013|\u2014/g, '--');
   const hosts = [`${PROJECT_NAME}.hlx.page`, `${PROJECT_NAME}.hlx.live`, ...PRODUCTION_DOMAINS];
-  const url = new URL(href);
+  const url = new URL(fixedHref);
   const relative = hosts.some((host) => url.hostname.includes(host));
   return relative ? `${url.pathname}${url.search}${url.hash}` : href;
 }

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -80,4 +80,10 @@ describe('Utilities', () => {
     expect(scripts.getMetadata('og:title')).to.equal('Milo');
     expect(scripts.getMetadata('description')).to.equal('Website foundation technology.');
   });
+
+  it('Makes relative URLs', () => {
+    const emdashHref = 'https://main—milo—adobecom.hlx.page/img/bg-dots.svg';
+    const relativeUrl = scripts.makeRelative(emdashHref);
+    expect(relativeUrl).to.equal('/img/bg-dots.svg');
+  });
 });


### PR DESCRIPTION
* Change makeRelative to swap emdashes for double hyphen.

Resolves: MWPW-108710

Test URLs:
- After: https://handle-emdash--milo--adobecom.hlx.page/fr/
