### PR TITLE
Fix typo in exposed LANA helper

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -12,7 +12,7 @@ const defaultOptions = {
 
 const w = window;
 
-function setClientdId(id) {
+function setClientId(id) {
   w.lana.options.clientId = id;
 }
 
@@ -86,7 +86,7 @@ function init() {
   w.lana = {
     debug: false,
     log: log,
-    setClientdId: setClientdId,
+    setClientId: setClientId,
     setDefaultOptions: setDefaultOptions,
     options: options || defaultOptions,
   };

--- a/test/libs/utils/lana.test.js
+++ b/test/libs/utils/lana.test.js
@@ -53,7 +53,7 @@ describe('LANA', () => {
   });
 
   it('Set the default clientId', () => {
-    window.lana.setClientdId('myClientId');
+    window.lana.setClientId('myClientId');
     window.lana.log('I set the client id');
     expect(xhrRequests.length).to.equal(1);
     expect(xhrRequests[0].method).to.equal('GET');


### PR DESCRIPTION
Fixes a typo in an exposed method for LANA

```
window.lana.setClientdId -> window.lana.setClientId
```

This is a **breaking change** for anyone that is already using this method, I'm not sure if it's already used.

If it's used, we can also support both the version with and without the typo