### PR TITLE
adding video controller for adobetv

### DIFF
--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -7,6 +7,12 @@ export default function init(a) {
   a.remove();
 }
 
+/**
+ * Take arg for video control for adobetv.
+ * currently supporting only 'play' and 'pause' command accodring to https://publish.tv.adobe.com/docs
+ * @param {*} arg argument for video control action.
+ * @param {*} el element that contains the iframe that has 'adobetv' as class.
+ */
 export function videoController(arg, el) {
   // get adobetv iframe.
   let adobetvIframe;

--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -6,3 +6,23 @@ export default function init(a) {
   a.insertAdjacentHTML('afterend', embed);
   a.remove();
 }
+
+export function videoController(arg, el) {
+  // get adobetv iframe.
+  let adobetvIframe;
+  if (el) {
+    adobetvIframe = el.querySelector('.adobetv') || el.parentElement.querySelector('.adobetv');
+  } else {
+    adobetvIframe = document.querySelector('.adobetv');
+  }
+
+  // do nothing if either of variable is not available.
+  if (!arg || !adobetvIframe) return;
+
+  // run the video control action.
+  const { origin } = new URL(adobetvIframe.src);
+  adobetvIframe.contentWindow.postMessage({
+    type: 'mpcAction',
+    action: arg,
+  }, origin);
+}

--- a/libs/blocks/modals/modals.js
+++ b/libs/blocks/modals/modals.js
@@ -1,5 +1,6 @@
 import getFragment from '../fragment/fragment.js';
 import { getMetadata, makeRelative } from '../../utils/utils.js';
+import { videoController } from '../adobetv/adobetv.js';
 
 function getDetails() {
   const details = { id: window.location.hash.replace('#', '') };
@@ -54,6 +55,12 @@ async function getModal() {
     document.body.append(dialog);
     dialog.showModal();
   }
+
+  dialog.addEventListener('close', (e) => {
+    window.location.hash = '#';
+    videoController('pause', e.target);
+  });
+
   return dialog;
 }
 


### PR DESCRIPTION
Resolves: [MWPW-110446](https://jira.corp.adobe.com/browse/MWPW-110446)

Test URLs:
- Before: https://main--milo--adobecom.hlx.page/docs/authoring/how-to-videos
- After: https://video-control--milo--adobecom.hlx.page/docs/authoring/how-to-videos

There are two ways to close the modal
1. Click the `x` on the right top corner of the modal.
2. Click outside of modal then press ESC key.

With case 2, it doesn't only keep playing the video in background but it doesn't also let user reopening same modal because the hash value doesn't get cleared.

This PR will fix the bug for both scenarios of closing  modal and clear the hash value as well.

@auniverseaway,  I also added the `how to videos` link on https://milo.adobe.com/docs/authoring/.  I hope this is right move.