### PR TITLE
modal removal on close.

### DIFF
--- a/libs/blocks/modals/modals.js
+++ b/libs/blocks/modals/modals.js
@@ -54,6 +54,12 @@ async function getModal() {
     document.body.append(dialog);
     dialog.showModal();
   }
+
+  dialog.addEventListener('close', (e) => {
+    window.location.hash = '#';
+    e.target.remove();
+  });
+
   return dialog;
 }
 

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -56,4 +56,14 @@ describe('Modals', () => {
       expect(modal).to.exist;
     });
   });
+
+  it('Remove a modal on close', async () => {
+    window.location.hash = '';
+    const prom = init(true);
+    window.location.hash = '#milo';
+    prom.then((modal) => {
+      modal.close();
+      expect(modal).to.be.null;
+    });
+  });
 });


### PR DESCRIPTION
@auniverseaway, here is new PR that removes modal on close.

Resolves: [MWPW-110446](https://jira.corp.adobe.com/browse/MWPW-110446)

Test URLs:
- Before: https://main--milo--adobecom.hlx.page/docs/authoring/how-to-videos
- After: https://video-control--milo--adobecom.hlx.page/docs/authoring/how-to-videos

There are two ways to close the modal
1. Click the `x` on the right top corner of the modal.
2. Click outside of modal then press ESC key.

With case 2, it doesn't only keep playing the video in background but it doesn't also let user reopening same modal because the hash value doesn't get cleared.

This PR will fix the bug for both scenarios of closing  modal and clear the hash value as well.

I also added the `how to videos` link on https://milo.adobe.com/docs/authoring/.  I hope this is right move.