### PR TITLE
MWPW-111697 Add tags support to lana

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -6,6 +6,7 @@ const defaultOptions = {
   endpointStage: 'https://www.stage.adobe.com/lana/ll',
   errorType: 'e',
   sampleRate: 1,
+  tags: '',
   implicitSampleRate: 1,
   useProd: true,
 };
@@ -56,6 +57,10 @@ function log(msg, options = {}) {
     's=' + sampleRate,
     't=' + encodeURI(o.errorType),
   ];
+
+  if (o.tags) {
+    queryParams.push('tags=' + encodeURI(o.tags));
+  }
 
   if (w.lana.debug || w.lana.localhost) console.log('LANA Msg: ', msg, '\nOpts:', o);
 

--- a/libs/utils/lana.md
+++ b/libs/utils/lana.md
@@ -29,6 +29,8 @@ Any uncaught errors (or Promise Rejections) will automatically be logged to LANA
         * `1` meaning log 1% of the errors to the server
         * `100` meaning every error will be logged
         * `0.01` meaning 0.01% of the errors will be logged
+    * `tags` - string: Defaults to `''`
+        * Any tags (comma separated) to be added to the message
     * `implicitSampleRate` - number: Defaults to 1
         * same as `sampleRate`
     * `useProd` - bool: Defaults to `true`

--- a/test/libs/utils/lana.test.js
+++ b/test/libs/utils/lana.test.js
@@ -22,6 +22,7 @@ it('verify default options', () => {
     endpointStage: 'https://www.stage.adobe.com/lana/ll',
     errorType: 'e',
     sampleRate: 1,
+    tags: '',
     implicitSampleRate: 1,
     useProd: true,
   });
@@ -106,6 +107,7 @@ describe('LANA', () => {
           errorType: 'e',
           implicitSampleRate: 100,
           sampleRate: 100,
+          tags: '',
           useProd: true,
         },
       ]);
@@ -128,6 +130,7 @@ describe('LANA', () => {
         errorType: 'e',
         implicitSampleRate: 100,
         sampleRate: 100,
+        tags: '',
         useProd: true,
       },
     ]);
@@ -140,5 +143,14 @@ describe('LANA', () => {
     window.lana.options.clientId = '';
     window.lana.log('Test log message');
     expect(console.warn.args[0][0]).to.eql('LANA ClientID is not set.');
+  });
+
+  it('sets tags if defined in options', () => {
+    window.lana.log('I set the client id', { tags: 'commerce,pricestore' });
+    expect(xhrRequests.length).to.equal(1);
+    expect(xhrRequests[0].method).to.equal('GET');
+    expect(xhrRequests[0].url).to.equal(
+      'https://lana.adobeio.com/?m=I%20set%20the%20client%20id&c=testClientId&s=100&t=e&tags=commerce,pricestore'
+    );
   });
 });

--- a/test/libs/utils/lanaDefaultOptions.test.js
+++ b/test/libs/utils/lanaDefaultOptions.test.js
@@ -7,6 +7,7 @@ const defaultTestOptions = {
   endpoint: 'https://lana.adobeio.com/',
   errorType: 'e',
   sampleRate: 100,
+  tags: '',
   implicitSampleRate: 100,
 };
 


### PR DESCRIPTION
Users can now pass `tags: 'tag1,tag2'` into the options

Resolves: [MWPW-111697](https://jira.corp.adobe.com/browse/MWPW-111697)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/
- After: https://lanaTags_MWPW-111697--milo--adobecom.hlx.page/
