### PR TITLE
Environment switch on FaaS form page for testing.

### DIFF
--- a/libs/blocks/faas/utils.js
+++ b/libs/blocks/faas/utils.js
@@ -6,11 +6,24 @@ import {
   getEnv,
 } from '../../utils/utils.js';
 
-const env = getEnv();
-const faasHostSubDomain = env === 'prod' ? 'staging.' : 'qa.';
-export const faasHostUrl = `https://${faasHostSubDomain}apps.enterprise.adobe.com`;
+export const getFaasHostSubDomain = (environment) => {
+  const env = environment ?? getEnv();
+  let faasHostSubDomain;
+  if (env === 'prod') {
+    faasHostSubDomain = 'staging.'; // TODO: this should be updated as '' when QA is done from FAAS team.
+  } else if (env === 'stage') {
+    faasHostSubDomain = 'staging.';
+  } else if (env === 'dev') {
+    faasHostSubDomain = 'dev.';
+  } else {
+    faasHostSubDomain = 'qa.';
+  }
+  return faasHostSubDomain;
+};
+
+export const faasHostUrl = `https://${getFaasHostSubDomain()}apps.enterprise.adobe.com`;
 let faasCurrentJS = `${faasHostUrl}/faas/service/jquery.faas-current.js`;
-if (env === 'local') {
+if (getEnv() === 'local') {
   faasCurrentJS = '/libs/deps/jquery.faas-current.js';
 }
 export const loadFaasFiles = () => {

--- a/libs/blocks/faas/utils.js
+++ b/libs/blocks/faas/utils.js
@@ -8,17 +8,14 @@ import {
 
 export const getFaasHostSubDomain = (environment) => {
   const env = environment ?? getEnv();
-  let faasHostSubDomain;
-  if (env === 'prod') {
-    faasHostSubDomain = 'staging.'; // TODO: this should be updated as '' when QA is done from FAAS team.
-  } else if (env === 'stage') {
-    faasHostSubDomain = 'staging.';
-  } else if (env === 'dev') {
-    faasHostSubDomain = 'dev.';
-  } else {
-    faasHostSubDomain = 'qa.';
+  // TODO: prod should be updated as '' when QA is done from FAAS team.
+  if (env === 'prod' || env === 'stage') {
+    return 'staging.';
   }
-  return faasHostSubDomain;
+  if (env === 'dev') {
+    return 'dev.';
+  }
+  return 'qa.';
 };
 
 export const faasHostUrl = `https://${getFaasHostSubDomain()}apps.enterprise.adobe.com`;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -10,10 +10,17 @@ const AUTO_BLOCKS = [
 ];
 
 export function getEnv() {
-  const { hostname } = window.location;
+  const { hostname, href } = window.location;
+  const location = new URL(href);
+  const env = location.searchParams.get('env');
+  if (env) {
+    return env;
+  }
   if (hostname.includes('localhost')) return 'local';
+
   /* c8 ignore start */
   if (hostname.includes('hlx.page') || hostname.includes('hlx.live')) return 'stage';
+
   return 'prod';
   /* c8 ignore stop */
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -13,12 +13,12 @@ export function getEnv() {
   const { hostname, href } = window.location;
   const location = new URL(href);
   const env = location.searchParams.get('env');
+
+  /* c8 ignore start */
   if (env) {
     return env;
   }
   if (hostname.includes('localhost')) return 'local';
-
-  /* c8 ignore start */
   if (hostname.includes('hlx.page') || hostname.includes('hlx.live')) return 'stage';
 
   return 'prod';

--- a/test/libs/blocks/faas/utils.test.js
+++ b/test/libs/blocks/faas/utils.test.js
@@ -8,7 +8,7 @@ import { waitForElement } from '../../../helpers/selectors.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 const { parseEncodedConfig } = await import('../../../../libs/utils/utils.js');
-const { loadFaasFiles, initFaas, makeFaasConfig, defaultState } = await import('../../../../libs/blocks/faas/utils.js');
+const { getFaasHostSubDomain, loadFaasFiles, initFaas, makeFaasConfig, defaultState } = await import('../../../../libs/blocks/faas/utils.js');
 
 describe('Faas', () => {
   beforeEach(() => {
@@ -65,5 +65,12 @@ describe('Faas', () => {
   it('FaaS Title', () => {
     const title = document.querySelector('.faas-title');
     expect(title).to.exist;
+  });
+
+  it('Test environment', () => {
+    expect(getFaasHostSubDomain('prod')).to.equal('staging.');
+    expect(getFaasHostSubDomain('stage')).to.equal('staging.');
+    expect(getFaasHostSubDomain('dev')).to.equal('dev.');
+    expect(getFaasHostSubDomain()).to.equal('qa.');
   });
 });


### PR DESCRIPTION
This patch is just for development and QA.

* Added a functionality that can listen parameter of `env` to switch different environment of FaaS form.

**Test URLs:**
Before: https://main--milo--adobecom.hlx.page/tools/faas?env=dev
After: https://faas-env--milo--adobecom.hlx.page/tools/faas?env=dev

QA note:
You will get CORS error with `faas-env` branch URL, and that is expected result. It means that actually trying to hit faas API from dev environment. (while main branch will pull from `qa` which is the default setting now)
You can also double check this from browser inspect -> network tab and lookup `jquery.faas-current.js` file to make sure it is getting from https://`dev`.apps.enterprise.adobe.com/faas/service/jquery.faas-current.js.

If you're having trouble with loading API with `qa` environment, check if you're connected with company VPN.

You can also try `stage` and `prod` instead `dev`.
They should both grab `staging`. 
Once FaaS team is done with their QA, we will need to update prod to grab prod environment.