### PR TITLE
Hotfix to revert list.js

### DIFF
--- a/libs/blocks/list.js
+++ b/libs/blocks/list.js
@@ -1,19 +1,13 @@
 const blocks = [
   'adobetv',
-  'accordion',
   'caas',
-  'caas-config',
-  'columns',
   'faas',
-  'faas-config',
-  'footer',
+  'columns',
+  'faq',
   'fragment',
   'how-to',
-  'interlinks',
-  'modals',
+  'modal',
   'marquee',
-  'nofollow',
-  'section-metadata',
 ];
 
 export default blocks;


### PR DESCRIPTION
Reverting list.js as it introduced breaking changes to consumers. 

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/
- After: https://libs-hotfix--milo--adobecom.hlx.page/
