### PR TITLE
MWPW-112699 Hardcode lana to 1% for dxdc client

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -47,7 +47,11 @@
     const o = getOptions(options);
     if (!o.clientId) console.warn('LANA ClientID is not set.');
 
-    const sampleRate = o.errorType === 'i' ? o.implicitSampleRate : o.sampleRate;
+    let sampleRate = o.errorType === 'i' ? o.implicitSampleRate : o.sampleRate;
+
+    // TODO: Samplerate is being hardcoded to 1% due to dxdc mistakenly setting to 100.
+    // Revert this when they've fixed their end.
+    if (o.clientId === 'dxdc') sampleRate = 1;
 
     if (!w.lana.debug && !w.lana.localhost && sampleRate <= Math.random() * 100) return;
 


### PR DESCRIPTION
* Dxdc team has hardcoded lana to send errors 100% of the time
* It will take some time for them to get a fix in, so for now any dxdc lana logs are hardcoded to 1% sample rate.

https://jira.corp.adobe.com/browse/MWPW-112699

When DXDC has fixed the issue, https://jira.corp.adobe.com/browse/MWPW-112700 will track the reverting of this PR