### PR TITLE
MWPW-112820 Don't use arrow func for IE11 compatibility

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -24,7 +24,9 @@
 
   function getOptions(op) {
     const o = w.lana.options;
-    const getOpt = (key) => (op[key] !== undefined ? op[key] : o[key]);
+    function getOpt(key) {
+      return op[key] !== undefined ? op[key] : o[key];
+    }
 
     return Object.keys(defaultOptions).reduce(function (options, key) {
       options[key] = getOpt(key);


### PR DESCRIPTION
Lana needs to be IE11 compatible (unlike the rest of milo)

Resolves: [MWPW-112820](https://jira.corp.adobe.com/browse/MWPW-112820)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/
- After: https://lanaIeFix--milo--adobecom.hlx.page/
