### PR TITLE
Move section metadata to chart, auto assign size, rename chart container to border MWPW-113827

### DIFF
--- a/libs/blocks/chart/chart.css
+++ b/libs/blocks/chart/chart.css
@@ -21,21 +21,15 @@
 }
 
 @media (min-width: 1200px) {
-  .up-2 .small {
+  .up-2 .chart {
     width: calc(50% - 8px);
     max-width: calc(50% - 8px);
     flex: 1 1 auto;
   }
 
-  .up-3 .small {
+  .up-3 .chart {
     width: calc(33% - 8px);
     max-width: calc(33% - 8px);
-    flex: 1 1 auto;
-  }
-
-  .up-3 .medium {
-    width: calc(66% - 8px);
-    max-width: calc(66% - 8px);
     flex: 1 1 auto;
   }
 }
@@ -74,20 +68,21 @@
 }
 
 @media only screen and (min-width: 75rem) {
-  .chart-container [data-chart-type="area"] > div {
+  .chart [data-chart-type="area"] > div {
     height: 900px;
   }
 }
 
-.chart-container-shadows {
+.border {
   border-radius: 8px;
   background-color: var(--spectrum-global-color-static-white);
   box-shadow: 0 3px 10px 0 rgb(0 0 0 / 10%);
   padding: var(--chart-padding);
+  box-sizing: border-box;
 }
 
-.chart.small .chart-container-shadows,
-.chart.medium .chart-container-shadows {
+.chart.small.border,
+.chart.medium.border {
   padding: var(--chart-padding);
 }
 

--- a/libs/blocks/chart/chart.css
+++ b/libs/blocks/chart/chart.css
@@ -21,13 +21,13 @@
 }
 
 @media (min-width: 1200px) {
-  .up-2 .chart {
+  .up-2 > div:not(.section-metadata) {
     width: calc(50% - 8px);
     max-width: calc(50% - 8px);
     flex: 1 1 auto;
   }
 
-  .up-3 .chart {
+  .up-3 > div:not(.section-metadata) {
     width: calc(33% - 8px);
     max-width: calc(33% - 8px);
     flex: 1 1 auto;

--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -6,23 +6,21 @@ export const MEDIUM = 'medium';
 export const LARGE = 'large';
 export const DESKTOP_BREAKPOINT = 1200;
 export const TABLET_BREAKPOINT = 600;
-const CONTAINER_STYLES = 'container';
-const CONTAINER_STYLES_CLASSNAME = 'chart-container-shadows';
 const SECTION_CLASSNAME = 'chart-section';
 const colorPalette = {
-  'red': '#EA3829',
-  'orange': '#F48411',
-  'yellow': '#F5D704',
-  'chartreuse': '#A9D814',
-  'celery': '#26BB36',
-  'green': '#008F5D',
-  'seafoam': '#12B5AE',
-  'cyan': '#34C5E8',
-  'blue': '#3991F3',
-  'indigo': '#686DF4',
-  'purple': '#8A3CE7',
-  'fuchsia': '#E054E2',
-  'magenta': '#DE3C82',
+  red: '#EA3829',
+  orange: '#F48411',
+  yellow: '#F5D704',
+  chartreuse: '#A9D814',
+  celery: '#26BB36',
+  green: '#008F5D',
+  seafoam: '#12B5AE',
+  cyan: '#34C5E8',
+  blue: '#3991F3',
+  indigo: '#686DF4',
+  purple: '#8A3CE7',
+  fuchsia: '#E054E2',
+  magenta: '#DE3C82',
 };
 const chartTypes = [
   'bar',
@@ -307,17 +305,18 @@ const init = async (el) => {
   children[3]?.classList.add('footnote');
   chartWrapper?.classList.add('chart_wrapper');
 
-  const container = document.createElement('section');
-  container.className = 'chart-container';
-  container.append(...children);
-  el.appendChild(container);
+  const chartStyles = el?.classList;
+  const section = el?.parentElement?.matches('.section') ? el.parentElement : null;
+  const sectionChildren = section?.querySelectorAll(':scope > div:not(.section-metadata)');
+  const upNumber = sectionChildren?.length;
+  section?.classList.add(`up-${upNumber}`);
+  section?.classList.add(SECTION_CLASSNAME);
 
-  const chartStyles = el.parentElement.classList;
-  const authoredSize = Array.from(chartStyles)?.find((style) => (
-    style === SMALL || style === MEDIUM || style === LARGE
-  ));
+  let authoredSize = SMALL;
+  if (upNumber === 1) authoredSize = LARGE;
+  if (upNumber === 2) authoredSize = MEDIUM;
+
   const size = getResponsiveSize(authoredSize);
-  chartStyles.add(SECTION_CLASSNAME);
   el.classList.add(authoredSize);
   el.setAttribute('data-responsive-size', size);
 
@@ -334,10 +333,6 @@ const init = async (el) => {
 
   const authoredColor = Array.from(chartStyles)?.find((style) => style in colorPalette);
   const colors = getColors(authoredColor);
-
-  if (Array.from(chartStyles)?.includes(CONTAINER_STYLES)) {
-    container.classList.add(CONTAINER_STYLES_CLASSNAME);
-  }
 
   updateContainerSize(chartWrapper, size, chartType);
 


### PR DESCRIPTION
* Move color, size, and container styles from section metadata to chart
* Auto-assign size based on number of children in order to reduce authoring
* Rename chart container to border to reduce confusion with section container

Resolves: [MWPW-113827](https://jira.corp.adobe.com/browse/MWPW-113827)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/data-viz
- After: https://move-chart-styles--milo--adobecom.hlx.page/drafts/methomas/data-viz
