### PR TITLE
Move mark label options out of theme MWPW-113006

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -72,6 +72,26 @@ export function processMarkData(series) {
     return options;
   }, {});
 
+  if (seriesOptions.markLine) {
+    seriesOptions.markLine.label = {
+      show: false,
+      formatter: '{b}',
+      position: 'insideStartBottom',
+    };
+    seriesOptions.markLine.emphasis = { label: { show: true } };
+  }
+
+  if (seriesOptions.markArea) {
+    seriesOptions.markArea.label = { show: false };
+    seriesOptions.markArea.emphasis = {
+      label: {
+        show: true,
+        position: 'top',
+        distance: 0,
+      },
+    };
+  }
+
   return seriesOptions;
 }
 

--- a/libs/blocks/chart/chartLightTheme.js
+++ b/libs/blocks/chart/chartLightTheme.js
@@ -59,7 +59,7 @@ export default (deviceSize) => {
       ),
     },
     grid: {
-      top: 10,
+      top: 13,
       bottom: isLarge ? 60 : 90,
       left: 0,
       right: 20,
@@ -93,26 +93,6 @@ export default (deviceSize) => {
         alignWithLabel: true,
         length: 8,
         lineStyle: { color: axisColor },
-      },
-    },
-    // ToDo: Move line/area options into chart.js MWPW-113006
-    line: {
-      markLine: {
-        label: {
-          show: false,
-          formatter: '{b}',
-          position: 'insideStartBottom',
-        },
-        emphasis: { label: { show: true } },
-      },
-      markArea: {
-        label: { show: false },
-        emphasis: {
-          label: {
-            show: true,
-            position: 'top',
-          },
-        },
       },
     },
     aria: { enabled: true },

--- a/test/blocks/chart/chart.test.js
+++ b/test/blocks/chart/chart.test.js
@@ -178,33 +178,29 @@ describe('chart utils', () => {
       ],
     };
 
-    const seriesOptions = {
-      markArea: {
-        data: [
-          [{
-            name: 'Weekend Sale',
-            xAxis: 'Fri',
-          }, { xAxis: 'Sun' }],
-        ],
+    const markAreaData = [
+      [{
+        name: 'Weekend Sale',
+        xAxis: 'Fri',
+      }, { xAxis: 'Sun' }],
+    ];
+    const markLineData = [
+      {
+        name: 'Promotion',
+        xAxis: 'Mon',
       },
-      markLine: {
-        data: [
-          {
-            name: 'Promotion',
-            xAxis: 'Mon',
-          },
-          {
-            name: 'Campaign Launch',
-            xAxis: 'Thurs',
-          },
-          {
-            name: 'Goal',
-            yAxis: 200,
-          },
-        ],
+      {
+        name: 'Campaign Launch',
+        xAxis: 'Thurs',
       },
-    };
+      {
+        name: 'Goal',
+        yAxis: 200,
+      },
+    ];
+    const markData = processMarkData(fetchedData.series);
 
-    expect(processMarkData(fetchedData.series)).to.eql(seriesOptions);
+    expect(markData.markArea.data).to.eql(markAreaData);
+    expect(markData.markLine.data).to.eql(markLineData);
   });
 });


### PR DESCRIPTION
* Move label options for mark line and mark area out of theme
* Fix mark area label being cut off

Resolves: [MWPW-113006](https://jira.corp.adobe.com/browse/MWPW-113006)

**Test URLs:**
- Before: https://data-viz--milo--adobecom.hlx.page/drafts/methomas/data-viz
- After: https://line-chart-mark--milo--adobecom.hlx.page/drafts/methomas/data-viz
