### PR TITLE
MWPW-114061 Fixing charts not displaying on older safari versions

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -304,7 +304,7 @@ export const getColors = (authoredColor) => {
 
   if (
     isNullish(authoredColor)
-    || !Object.hasOwn(colorPalette, authoredColor)
+    || !Object.hasOwnProperty.call(colorPalette, authoredColor)
   ) return colorList;
 
   const colorIndex = colorList.indexOf(colorPalette[authoredColor]);
@@ -434,7 +434,9 @@ const init = async (el) => {
 
   const authoredColor = Array.from(chartStyles)?.find((style) => style in colorPalette);
   const hasOverride = Object.keys(data?.data[0])?.some((header) => header.toLowerCase() === 'color');
-  const colors = hasOverride ? getOverrideColors(authoredColor, data.data) : getColors(authoredColor);
+  const colors = hasOverride
+    ? getOverrideColors(authoredColor, data.data)
+    : getColors(authoredColor);
 
   updateContainerSize(chartWrapper, size, chartType);
 


### PR DESCRIPTION
* Reverting from using `hasOwn` to `hasOwnProperty`
* `hasOwn` is not supported on safari versions below 15.4 (see browser compatibility for [hasOwn](https://caniuse.com/mdn-javascript_builtins_object_hasown) and [hasOwnProperty](https://caniuse.com/?search=hasOwnProperty))
* Since `colorPalette` is a pre-defined object and not created using `Object.create(null)`, which is the reason why using `hasOwn` is preferred, it is OK to stick with `hasOwnProperty` in this case  (see [MDN section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty#:~:text=Using%20hasOwnProperty%20as%20a%20property%20name) for more details)

Resolves: [MWPW-114061](https://jira.corp.adobe.com/browse/MWPW-114061)

**Test URLs:**
- Before: https://data-viz--milo--adobecom.hlx.page/drafts/saravana/data-viz
- After: https://chart-safari-fix--milo--adobecom.hlx.page/drafts/saravana/data-viz
