### PR TITLE
MWPW-114528 MWPW-112700 All dev/stage/author traffic goes to stage lana; revert dxdc fix

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -14,14 +14,6 @@
 
   const w = window;
 
-  function setClientId(id) {
-    w.lana.options.clientId = id;
-  }
-
-  function setDefaultOptions(options) {
-    w.lana.options = getOptions(options);
-  }
-
   function getOptions(op) {
     const o = w.lana.options;
     function getOpt(key) {
@@ -47,7 +39,10 @@
     }
 
     const o = getOptions(options);
-    if (!o.clientId) console.warn('LANA ClientID is not set.');
+    if (!o.clientId) {
+      console.warn('LANA ClientID is not set in options.');
+      return;
+    }
 
     const sampleRate = o.errorType === 'i' ? o.implicitSampleRate : o.sampleRate;
 
@@ -95,9 +90,15 @@
   w.lana = {
     debug: false,
     log: log,
-    setClientId: setClientId,
-    setDefaultOptions: setDefaultOptions,
     options: options || defaultOptions,
+    setClientId: function (id) {
+      console.warn('LANA setClientId is deprecated and will be removed in a future release.');
+      w.lana.options.clientId = id;
+    },
+    setDefaultOptions: function (options) {
+      console.warn('LANA setDefaultOptions is deprecated and will be removed in a future release.');
+      w.lana.options = getOptions(options);
+    },
   };
 
   /* c8 ignore next */

--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -49,15 +49,13 @@
     const o = getOptions(options);
     if (!o.clientId) console.warn('LANA ClientID is not set.');
 
-    let sampleRate = o.errorType === 'i' ? o.implicitSampleRate : o.sampleRate;
-
-    // TODO: Samplerate is being hardcoded to 1% due to dxdc mistakenly setting to 100.
-    // Revert this when they've fixed their end.
-    if (o.clientId === 'dxdc') sampleRate = 1;
+    const sampleRate = o.errorType === 'i' ? o.implicitSampleRate : o.sampleRate;
 
     if (!w.lana.debug && !w.lana.localhost && sampleRate <= Math.random() * 100) return;
 
-    const endpoint = o.useProd ? o.endpoint : o.endpointStage;
+    const isCorpAdobeCom = window.location.href.indexOf('.corp.adobe.com') !== -1;
+
+    const endpoint = (isCorpAdobeCom || !o.useProd) ? o.endpointStage : o.endpoint;
     const queryParams = [
       'm=' + encodeURIComponent(msg),
       'c=' + encodeURI(o.clientId),

--- a/libs/utils/lana.md
+++ b/libs/utils/lana.md
@@ -8,16 +8,18 @@ Errors can be logged using `window.lana.log`.
 
 Any uncaught errors (or Promise Rejections) will automatically be logged to LANA.
 
+Note that any errors that happen on a `*.corp.adobe.com` domain will automatically be logged to LANA Stage.  This is to ensure that any errors logged to production LANA will be customer facing errors.
+
 ### Syntax
 
 `window.lana.log(message, options)`
 
 ### Parameters
 
-* `message` - string: The message to be logged.
+* `message` - string: **REQUIRED** The message to be logged.
 
 * `options` - object:
-    * `clientId` - string: Defaults to `''`
+    * **`clientId`** - string: **REQUIRED**
         * The client ID to identify the which product team the error belongs to.
     * `endpoint` - string: Prod AdobeIO API endpoint for LANA to send messages to.
     * `endpointStage` - string: Stage AdobeIO API endpoint for LANA to send messages to.
@@ -37,13 +39,13 @@ Any uncaught errors (or Promise Rejections) will automatically be logged to LANA
         * Toggle between prod and stage endpoints
 ## Helper Functions
 
-`window.lana.setClientId(clientId)`: sets the client ID for the current page.
+The helper functions have been deprecated in favor of the options being passed with every lana call.
 
-It is recommended that the client ID is set for every page so that implicit errors are logged with that client ID.
+~~`window.lana.setClientId(clientId)`: sets the client ID for the current page.~~
 
-`window.lana.setDefaultOptions(options)`: Updates the default options.  Any params not defined in the options object will keep the existing default options.
+~~`window.lana.setDefaultOptions(options)`: Updates the default options.  Any params not defined in the options object will keep the existing default options.~~
 
-Note that the current option state is stored in `window.lana.options` and can also be directly changed there.
+Note that the default option state is stored in `window.lana.options` and can be directly changed there, though it is not recommended as multiple lana clients can co-exist on a single page.
 
 ## Debugging
 

--- a/test/libs/utils/lana.test.js
+++ b/test/libs/utils/lana.test.js
@@ -142,7 +142,7 @@ describe('LANA', () => {
   it('warns that clientId is not set', () => {
     window.lana.options.clientId = '';
     window.lana.log('Test log message');
-    expect(console.warn.args[0][0]).to.eql('LANA ClientID is not set.');
+    expect(console.warn.args[0][0]).to.eql('LANA ClientID is not set in options.');
   });
 
   it('sets tags if defined in options', () => {


### PR DESCRIPTION
* Reverts a fix for dxdc where the sample rate was fixed at 1% (Dxdc has fixed their end)
* Any traffic that is not from prod (dev/stage/author) gets funneled to lana stage so that lana prod only displays customer facing issues.
* ClientID is a required option parameter

Resolves:
[MWPW-114528](https://jira.corp.adobe.com/browse/MWPW-114528)
[MWPW-112700](https://jira.corp.adobe.com/browse/MWPW-112700)
[MWPW-112723](https://jira.corp.adobe.com/browse/MWPW-112723)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/
- After: https://lanaStage_MWPW-114528--milo--adobecom.hlx.page/
