### PR TITLE
MWPW-113747 load chart data without blocking

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -428,30 +428,30 @@ const init = async (el) => {
 
   if (!chartType || !chartWrapper || !dataLink) return;
 
-  const data = await fetchData(dataLink);
-
-  if (!data) return;
-
-  const authoredColor = Array.from(chartStyles)?.find((style) => style in colorPalette);
-  const hasOverride = Object.keys(data?.data[0])?.some((header) => header.toLowerCase() === 'color');
-  const colors = hasOverride
-    ? getOverrideColors(authoredColor, data.data)
-    : getColors(authoredColor);
-
   updateContainerSize(chartWrapper, size, chartType);
 
   if (chartType !== 'oversizedNumber') {
-    loadScript('/libs/deps/echarts.common.min.js')
-      .then(() => {
-        const observerOptions = {
-          root: null,
-          rootMargin: '0px',
-          threshold: 0.5,
-        };
+    Promise.all([fetchData(dataLink), loadScript('/libs/deps/echarts.common.min.js')])
+      .then((values) => {
+        const data = values[0];
+
+        if (!data) return;
+
+        const authoredColor = Array.from(chartStyles)?.find((style) => style in colorPalette);
+        const hasOverride = Object.keys(data?.data[0])?.some((header) => header.toLowerCase() === 'color');
+        const colors = hasOverride
+          ? getOverrideColors(authoredColor, data.data)
+          : getColors(authoredColor);
 
         if (!(window.IntersectionObserver)) {
           initChart(chartWrapper, chartType, data, colors, size);
         } else {
+          const observerOptions = {
+            root: null,
+            rootMargin: '0px',
+            threshold: 0.5,
+          };
+
           const observer = new IntersectionObserver(
             handleIntersect(chartWrapper, chartType, data, colors, size),
             observerOptions,


### PR DESCRIPTION
* Reduce premature chart render by asynchronously loading the chart data to completing block initializing without waiting.
* Run `updateContainerSize` without waiting for the chart data JSON to download.
* Reduce load time by loading chart data and chart library at the same time.

Resolves: [MWPW-113747](https://jira.corp.adobe.com/browse/MWPW-113747)

**Test URLs:**
- Before: https://data-viz--milo--adobecom.hlx.page/drafts/bmarshal/many-charts
- After: https://async-chart-data--milo--adobecom.hlx.page/drafts/bmarshal/many-charts
