### PR TITLE
MWPW-113969 Updating legend inactive color per a11y standards

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -232,6 +232,7 @@ export const getChartOptions = (chartType, data, colors, size) => {
     color: colors,
     legend: {
       show: true,
+      inactiveColor: '#6C6C6C',
       type: 'scroll',
     },
     tooltip: {


### PR DESCRIPTION
* Updating default inactive color for the legend categories to the spectrum gray (#6C6C6C) color to meet color contrast requirements

Resolves: [MWPW-113969](https://jira.corp.adobe.com/browse/MWPW-113969)

**Test URLs:**
- Before: https://data-viz--milo--adobecom.hlx.page/drafts/saravana/data-viz
- After: https://legend-deselected-color--milo--adobecom.hlx.page/drafts/saravana/data-viz