### PR TITLE
Update chart color palette MWPW-113921

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -8,19 +8,18 @@ export const LARGE = 'large';
 export const DESKTOP_BREAKPOINT = 1200;
 export const TABLET_BREAKPOINT = 600;
 export const colorPalette = {
-  red: '#EA3829',
-  orange: '#F48411',
-  yellow: '#F5D704',
-  chartreuse: '#A9D814',
-  celery: '#26BB36',
+  seafoam: '#0FB5AE',
+  orange: '#F68511',
+  indigo: '#4046CA',
+  purple: '#7326D3',
+  blue: '#147AF3',
+  lime: '#72E06A',
+  lavender: '#7E84FA',
+  magenta: '#DE3D82',
   green: '#008F5D',
-  seafoam: '#12B5AE',
-  cyan: '#34C5E8',
-  blue: '#3991F3',
-  indigo: '#686DF4',
-  purple: '#8A3CE7',
-  fuchsia: '#E054E2',
-  magenta: '#DE3C82',
+  copper: '#CB5D00',
+  yellow: '#E8C600',
+  chartreuse: '#BCE931',
 };
 const SECTION_CLASSNAME = 'chart-section';
 const chartTypes = [

--- a/test/blocks/chart/chart.test.js
+++ b/test/blocks/chart/chart.test.js
@@ -20,7 +20,7 @@ const {
   processMarkData,
 } = await import('../../../libs/blocks/chart/chart.js');
 
-describe('chart utils', () => {
+describe('chart', () => {
   it('getContainerSize provides default height and width', () => {
     expect(getContainerSize(LARGE, 'bar')).to.be.an('object')
       .that.has.all.keys('height', 'width');
@@ -87,22 +87,8 @@ describe('chart utils', () => {
   });
 
   it('getColors returns rotated color list if color provided ', () => {
-    const authoredColor = 'cyan';
-    const colors = [
-      '#34C5E8',
-      '#3991F3',
-      '#686DF4',
-      '#8A3CE7',
-      '#E054E2',
-      '#DE3C82',
-      '#EA3829',
-      '#F48411',
-      '#F5D704',
-      '#A9D814',
-      '#26BB36',
-      '#008F5D',
-      '#12B5AE',
-    ];
+    const authoredColor = 'indigo';
+    const colors = ['#4046CA', '#7326D3', '#147AF3', '#72E06A', '#7E84FA', '#DE3D82', '#008F5D', '#CB5D00', '#E8C600', '#BCE931', '#0FB5AE', '#F68511'];
 
     expect(getColors(authoredColor)).to.eql(colors);
   });
@@ -113,22 +99,14 @@ describe('chart utils', () => {
         { Day: 'Mon', Visitors: '150', Group: '', Unit: 'k', Color: '' },
         { Day: 'Tues', Visitors: '230', Group: '', Unit: '', Color: '' },
         { Day: 'Weds', Visitors: '224', Group: '', Unit: '', Color: '' },
-        { Day: 'Thurs', Visitors: '218', Group: '', Unit: '', Color: 'red' },
-        { Day: 'Fri', Visitors: '135', Group: '', Unit: '', Color: 'red' },
-        { Day: 'Sat', Visitors: '147', Group: '', Unit: '', Color: 'red' },
+        { Day: 'Thurs', Visitors: '218', Group: '', Unit: '', Color: 'magenta' },
+        { Day: 'Fri', Visitors: '135', Group: '', Unit: '', Color: 'magenta' },
+        { Day: 'Sat', Visitors: '147', Group: '', Unit: '', Color: 'magenta' },
         { Day: 'Sun', Visitors: '260', Group: '', Unit: '', Color: '' },
       ],
     };
-    const authoredColor = 'cyan';
-    const colors = [
-      '#34C5E8',
-      '#34C5E8',
-      '#34C5E8',
-      '#EA3829',
-      '#EA3829',
-      '#EA3829',
-      '#34C5E8',
-    ];
+    const authoredColor = 'indigo';
+    const colors = ['#4046CA', '#4046CA', '#4046CA', '#DE3D82', '#DE3D82', '#DE3D82', '#4046CA'];
 
     expect(getOverrideColors(authoredColor, fetchedData.data)).to.eql(colors);
   });


### PR DESCRIPTION
* Update chart color palette to the Spectrum data visualization categorical [12-color palette](https://spectrum.corp.adobe.com/page/color-for-data-visualization/)

Resolves: [MWPW-113921](https://jira.corp.adobe.com/browse/MWPW-113921)

**Test URLs:**
- Before: https://data-viz--milo--adobecom.hlx.page/drafts/data-viz/holiday-report-dev
- After: https://chart-colors--milo--adobecom.hlx.page/drafts/data-viz/holiday-report-dev
