### PR TITLE
Add list chart carousel MWPW-114550

### DIFF
--- a/libs/blocks/chart/chart.css
+++ b/libs/blocks/chart/chart.css
@@ -95,3 +95,95 @@
   transform: rotate(45deg);
   z-index: 0;
 }
+
+.chart.list .carousel-item {
+  display: none;
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+}
+
+.chart.list .carousel-item.active {
+  display: block;
+}
+
+.chart.list .chart_wrapper .title {
+  height: 58px;
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  background-color: rgb(22 129 217);
+  color: var(--white);
+}
+
+.chart.list .carousel .controls {
+  position: relative;
+}
+
+.chart.list .carousel .controls button {
+  position: absolute;
+  z-index: 10;
+  border: none;
+  padding: 0;
+  background: transparent;
+}
+
+.chart.list .carousel .controls button:focus {
+  outline: none;
+}
+
+.chart.list .carousel .controls button:focus::after {
+  content: "";
+  display: block;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  transition: box-shadow 0.13s ease-out, margin 0.13s ease-out;
+  border-radius: 5px;
+  box-shadow: 0 0 0 2px var(--white);
+  margin: -5px;
+}
+
+.chart.list .carousel .controls button.previous {
+  top: 18px;
+  left: 16px;
+}
+
+.chart.list .carousel .controls button.previous::before { 
+  position: relative;
+  content: "";
+  display: inline-block;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-right: 4px solid var(--white);
+  border-top: 4px solid var(--white);
+  -webkit-transform: rotate(225deg);
+  transform: rotate(225deg);
+}
+
+.chart.list .carousel .controls button.next {
+  top: 18px;
+  right: 16px;
+}
+
+.chart.list .carousel .controls button.next::before  { 
+  position: relative;
+  content: "";
+  display: inline-block;
+  top: 2px;
+  right: 2px;
+  width: 14px;
+  height: 14px;
+  border-right: 4px solid var(--white);
+  border-top: 4px solid var(--white);
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+}

--- a/test/blocks/chart/list.test.js
+++ b/test/blocks/chart/list.test.js
@@ -2,7 +2,7 @@
 /* global describe it */
 import { expect } from '@esm-bundle/chai';
 
-const { listChartData, getListHtml, listToLowerCase } = await import('../../../libs/blocks/chart/list.js');
+const { listChartData, getListHtml, getCarouselHtml, listToLowerCase } = await import('../../../libs/blocks/chart/list.js');
 
 describe('list', () => {
   it('fetch list data', () => {
@@ -13,6 +13,7 @@ describe('list', () => {
         limit: 2,
         data: [
           { Title: 'Black Friday Numbers Ordered', Sheet: 'Black Friday', Type: 'numbered' },
+          { Title: 'Cyber Monday', Sheet: 'N/A' },
         ],
       },
       'Black Friday': {
@@ -41,6 +42,10 @@ describe('list', () => {
         { name: 'Tickle me Elmo', extra: '1.01' },
       ],
       type: 'numbered',
+    }, {
+      list: [],
+      title: 'Cyber Monday',
+      type: undefined,
     }];
 
     expect(listChartData(fetchedData)).to.eql(processedData);
@@ -117,6 +122,30 @@ describe('list', () => {
   });
 
   it('getListHtml should output correct html', () => {
+    const data = {
+      title: 'Black Friday',
+      list: [
+        {
+          name: 'XBOX One S',
+          extra: '1.54',
+          image: 'image.png',
+          alt: 'Image 1',
+        },
+        {
+          name: 'Swiffer Xtreme',
+          extra: '1.27',
+          image: 'image.png',
+          alt: 'Image 2',
+        },
+      ],
+      type: 'numbered',
+    };
+    const html = '<article><section class="title">Black Friday</section><section class="body"><ol><li><img src="image.png" alt="Image 1" /><span class="name">XBOX One S</span><span class="extra">1.54</span></li><li><img src="image.png" alt="Image 2" /><span class="name">Swiffer Xtreme</span><span class="extra">1.27</span></li></ol></section></article>';
+
+    expect(getListHtml(data).replace(/\s{2,}|[\n]/g, '')).to.equal(html);
+  });
+
+  it('multi-item carousel should output correct html', () => {
     const data = [{
       title: 'Black Friday',
       list: [
@@ -134,10 +163,19 @@ describe('list', () => {
         },
       ],
       type: 'numbered',
+    }, {
+      title: 'Cyber Monday',
+      list: [
+        { name: 'XBOX One S' },
+        { name: 'Swiffer Xtreme' },
+        { name: 'Teddy Ruxpin' },
+        { name: 'Airpods' },
+        { name: 'Tickle me Elmo' },
+      ],
     }];
-    const html = '<article><section class="title">Black Friday</section><section class="body"><ol><li><img src="image.png" alt="Image 1" /><span class="name">XBOX One S</span><span class="extra">1.54</span></li><li><img src="image.png" alt="Image 2" /><span class="name">Swiffer Xtreme</span><span class="extra">1.27</span></li></ol></section></article>';
+    const html = '<section class="carousel"><div class="controls"><button type="button"class="previous"aria-controls="listChartCarousel-items"aria-label="Previous Chart"></button><button type="button"class="next"aria-controls="listChartCarousel-items"aria-label="Next Chart"></button></div><div id="listChartCarousel-items"class="carousel-items"aria-live="polite"><div class="carousel-item active"role="group"aria-roledescription="slide"aria-label="0 of 2"><article><section class="title">Black Friday</section><section class="body"><ol><li><img src="image.png" alt="Image 1" /><span class="name">XBOX One S</span><span class="extra">1.54</span></li><li><img src="image.png" alt="Image 2" /><span class="name">Swiffer Xtreme</span><span class="extra">1.27</span></li></ol></section></article></div><div class="carousel-item"role="group"aria-roledescription="slide"aria-label="1 of 2"><article><section class="title">Cyber Monday</section><section class="body"><ul><li><span class="name">XBOX One S</span></li><li><span class="name">Swiffer Xtreme</span></li><li><span class="name">Teddy Ruxpin</span></li><li><span class="name">Airpods</span></li><li><span class="name">Tickle me Elmo</span></li></ul></section></article></div></div></section>';
 
-    expect(getListHtml(data).replace(/\s{2,}|[\n]/g, '')).to.equal(html);
+    expect(getCarouselHtml(data).replace(/\s{2,}|[\n]/g, '')).to.equal(html);
   });
 
   it('listToLowerCase', () => {


### PR DESCRIPTION
* Add carousel to list chart if more than one list.
* Fix lists not rendering if named sheet is missing.

Resolves: [MWPW-114550](https://jira.corp.adobe.com/browse/MWPW-114550)

**Test URLs:**
- Before: https://data-viz--milo--adobecom.hlx.page/drafts/bmarshal/list-chart
- After: https://list-carousel--milo--adobecom.hlx.page/drafts/bmarshal/list-chart
