### PR TITLE
Add text center style MWPW-115557

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -54,11 +54,12 @@
   width: 100%;
 }
 
-.section.heading-center h1,
-.section.heading-center h2,
-.section.heading-center h3,
-.section.heading-center h4,
-.section.heading-center h5,
-.section.heading-center h6 {
+.section.center .content > h1,
+.section.center .content > h2,
+.section.center .content > h3,
+.section.center .content > h4,
+.section.center .content > h5,
+.section.center .content > h6,
+.section.center .content > p {
   text-align: center;
 }


### PR DESCRIPTION
* Change "heading center" section metadata style to "center"
* And include p tags to center

Resolves: [MWPW-115557](https://jira.corp.adobe.com/browse/MWPW-115557)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/text-center
- After: https://text-center--milo--adobecom.hlx.page/drafts/methomas/text-center
