### PR TITLE
Fix chart 2up/3up safari bug MWPW-116005

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -23,7 +23,6 @@ function handleStyle(div, section) {
 export default function init(el) {
   const section = el.closest('.section');
   if (!section) return;
-  section.className = 'section';
   const keyDivs = el.querySelectorAll(':scope > div > div:first-child');
   keyDivs.forEach((div) => {
     const valueDiv = div.nextElementSibling;


### PR DESCRIPTION
* Fix safari bug where charts wouldn't display as 2-up or 3-up

Resolves: [MWPW-116005](https://jira.corp.adobe.com/browse/MWPW-116005)

**Test URLs:**
- Before: https://data-viz--milo--adobecom.hlx.page/drafts/data-viz/chartsqa
- After: https://chart-bug-safari--milo--adobecom.hlx.page/drafts/data-viz/chartsqa