### PR TITLE
Updating chart libs base path for consumers

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -1,4 +1,4 @@
-import { makeRelative, loadScript } from '../../utils/utils.js';
+import { makeRelative, loadScript, getConfig } from '../../utils/utils.js';
 import {
   throttle,
   parseValue,
@@ -568,8 +568,11 @@ const init = (el) => {
   }
 
   if (chartType !== 'oversizedNumber') {
+    const { miloLibs, codeRoot } = getConfig();
+    const base = miloLibs || codeRoot;
+
     // Must use chained promise. Await will cause loading issues
-    Promise.all([fetchData(dataLink), loadScript('/libs/deps/echarts.common.min.js')])
+    Promise.all([fetchData(dataLink), loadScript(`${base}/deps/echarts.common.min.js`)])
       .then((values) => {
         const json = values[0];
         const data = chartData(json);

--- a/test/blocks/chart/chart.test.js
+++ b/test/blocks/chart/chart.test.js
@@ -5,6 +5,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { readFile } from '@web/test-runner-commands';
 import { waitForElement } from '../../helpers/selectors.js';
+import { setConfig } from '../../../libs/utils/utils.js';
 
 const {
   SMALL,
@@ -34,6 +35,9 @@ const {
   pieTooltipFormatter,
   pieSeriesOptions,
 } = await import('../../../libs/blocks/chart/chart.js');
+
+const config = { codeRoot: '/libs' };
+setConfig(config);
 
 describe('chart', () => {
   let fetch;


### PR DESCRIPTION
* Because of the hardcoding of libs, charts currently do not work on consumers.

Resolves: https://github.com/adobecom/milo/pull/141#issuecomment-1228935411

**Test URLs:**

- Before: https://data-viz--milo--adobecom.hlx.page/drafts/data-viz/holiday-report-dev
- After: https://chart-libs-base-path--milo--adobecom.hlx.page/drafts/data-viz/holiday-report-dev