### PR TITLE
Fix cut off numbers on list MWPW-115996

### DIFF
--- a/libs/blocks/chart/list.css
+++ b/libs/blocks/chart/list.css
@@ -29,7 +29,7 @@
 
 .chart.list ol,
 .chart.list ul {
-  padding-left: 32px;
+  padding-left: 35px;
   padding-right: 16px;
   margin: 0;
 }


### PR DESCRIPTION
* Temporary fix for numbers in ordered list in list chart being cut off on safari

Resolves: [MWPW-115996](https://jira.corp.adobe.com/browse/MWPW-115996)

**Test URLs:**
- Before: https://data-viz--milo--adobecom.hlx.page/drafts/data-viz/list-qa
- After: https://list-safari--milo--adobecom.hlx.page/drafts/data-viz/list-qa
