### PR TITLE
Add draft support; Update sidekick for bacom consumption

### DIFF
--- a/tools/send-to-caas/send-to-caas.css
+++ b/tools/send-to-caas/send-to-caas.css
@@ -47,7 +47,7 @@
 
 .tingle-modal .tingle-btn.tingle-btn--grey {
     color: rgb(34, 34, 34);
-    background-color: rgb(230, 230, 230);
+    background-color: rgb(179, 179, 179);
     border-color: rgb(245, 245, 245);
 }
 
@@ -63,4 +63,18 @@
 .tingle-modal .tingle-btn.tingle-btn--danger:hover {
     background-color: rgb(174, 1, 1);
     border-color: transparent;
+}
+
+.tingle-modal .tingle-modal-box__footer #caas-draft-cb {
+    text-align: center;
+    background-color: rgb(230, 230, 230);
+    border-radius: 5px;
+    margin-bottom: 16px;
+    padding: 5px 0;
+    width: 300px;
+    margin: -10px auto 16px auto;
+}
+
+.tingle-modal .tingle-modal-box__footer #caas-draft-cb > label {
+    margin-left: 5px;
 }

--- a/tools/send-to-caas/sidekick.js
+++ b/tools/send-to-caas/sidekick.js
@@ -1,0 +1,26 @@
+const sendToCaaS = async (_, sk) => {
+  const SCRIPT_ID = 'send-caas-listener';
+  const dispatchEvent = () => document.dispatchEvent(
+    new CustomEvent('send-to-caas', {
+      detail: {
+        host: sk.config.host,
+        project: sk.config.project,
+        branch: sk.config.ref,
+        repo: sk.config.repo,
+        owner: sk.config.owner,
+      },
+    }),
+  );
+
+  if (!document.getElementById(SCRIPT_ID)) {
+    const script = document.createElement('script');
+    script.src = '/tools/send-to-caas/sendToCaasEventListener.js';
+    script.id = SCRIPT_ID;
+    script.onload = () => dispatchEvent();
+    document.head.appendChild(script);
+  } else {
+    dispatchEvent();
+  }
+};
+
+export default sendToCaaS;

--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -18,31 +18,6 @@ function hasSchema(host) {
   return false;
 }
 
-const sendToCaaS = async (_, sk) => {
-  const SCRIPT_ID = 'send-caas-listener';
-  const dispatchEvent = () => document.dispatchEvent(
-    new CustomEvent('send-to-caas', {
-      detail: {
-        host: sk.config.host,
-        project: sk.config.project,
-        branch: sk.config.ref,
-        repo: sk.config.repo,
-        owner: sk.config.owner,
-      },
-    }),
-  );
-
-  if (!document.getElementById(SCRIPT_ID)) {
-    const script = document.createElement('script');
-    script.src = '/tools/send-to-caas/sendToCaasEventListener.js';
-    script.id = SCRIPT_ID;
-    script.onload = () => dispatchEvent();
-    document.head.appendChild(script);
-  } else {
-    dispatchEvent();
-  }
-};
-
 // This file contains the project-specific configuration for the sidekick.
 (() => {
   window.hlx.initSidekick({
@@ -55,11 +30,14 @@ const sendToCaaS = async (_, sk) => {
     ],
     plugins: [
       {
-        id: 'register-caas',
+        id: 'send-to-caas',
         condition: (s) => s.isHelix() && s.isContent() && !window.location.pathname.endsWith('.json'),
         button: {
           text: 'Send to CaaS',
-          action: sendToCaaS,
+          action: async (_, sk) => {
+            const { default: sendToCaaS } = await import('/tools/send-to-caas/sidekick.js');
+            sendToCaaS(_, sk);
+          },
         },
       },
       // TOOLS ---------------------------------------------------------------------


### PR DESCRIPTION
* Adds ability to specify if page should only be registered as draft in CaaS
* Refactor sidekick code so that it can be consumed in other projects

Resolves: [MWPW-NUMBER](MWPW-URL)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/
- After: https://draftSidekick--milo--adobecom.hlx.page/
