### PR TITLE
MWPW-116262 IE11 doesn't support default param vals

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -32,13 +32,13 @@
     });
   }
 
-  function log(msg, options = {}) {
+  function log(msg, options) {
     msg = msg && msg.stack ? msg.stack : msg;
     if (msg.length > MSG_LIMIT) {
       msg = msg.slice(0, MSG_LIMIT) + '<trunc>';
     }
 
-    const o = getOptions(options);
+    const o = getOptions(options || {});
     if (!o.clientId) {
       console.warn('LANA ClientID is not set in options.');
       return;


### PR DESCRIPTION
* Using a default function param is not supported in IE11

Resolves: [MWPW-116262](https://jira.corp.adobe.com/browse/MWPW-116262)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/
- After: https://lanaIeSucks--milo--adobecom.hlx.page/
