### PR TITLE
MWPW-116732 Spoof VisitorAPI for CaaS

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -54,6 +54,7 @@ export const loadCaasTags = async (tagsUrl) => {
 
 const fixAlloyAnalytics = async () => {
   const sat = await window.__satelliteLoadedPromise;
+  if (!sat || !window.alloy) return;
   if (sat.getVisitorId() === null) {
     const identity = await window.alloy('getIdentity');
     const mcgvid = identity.identity.ECID;

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -62,6 +62,7 @@ const fixAlloyAnalytics = async () => {
 
     const ogSLP = window.__satelliteLoadedPromise;
     window.__satelliteLoadedPromise = Promise.resolve({
+      /* c8 ignore next 9 */
       getVisitorId: () => ({
         getMarketingCloudVisitorID: () => mcgvid,
         getSupplementalDataID: () => '',


### PR DESCRIPTION
CaaS does not support latest Alloy, so until it's fixed on their end this spoofs the object expected by CaaS

Resolves: [MWPW-116732](https://jira.corp.adobe.com/browse/MWPW-116732)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/caas-target
- After: https://caas-target--milo--adobecom.hlx.page/drafts/cpeyer/caas-target
