### PR TITLE
Include analytics utility

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -235,7 +235,7 @@
   /* Split */
   .marquee.split {
     display: flex;
-    align-items: center;
+    justify-content: center;
   }
 
   .marquee.split .foreground.container .text {

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -14,6 +14,7 @@
  * Marquee - v6.0
  */
 import { decorateButtons, getBlockSize } from '../../utils/decorate.js';
+import { decorateBlockAnalytics, decorateLinkAnalytics } from '../../utils/analytics.js';
 
 const decorateVideo = (container) => {
   const link = container.querySelector('a[href$=".mp4"]');
@@ -74,6 +75,7 @@ function extendButtonsClass(text) {
 }
 
 export default function init(el) {
+  decorateBlockAnalytics(el);
   const isLight = el.classList.contains('light');
   if (!isLight) el.classList.add('dark');
   const children = el.querySelectorAll(':scope > div');
@@ -97,6 +99,8 @@ export default function init(el) {
 
   const size = getBlockSize(el);
   decorateButtons(text, size === 'large' ? 'button-XL' : 'button-L');
+  const headings = text.querySelectorAll('h1, h2, h3, h4, h5, h6');
+  decorateLinkAnalytics(text, headings);
   decorateText(text, size);
   extendButtonsClass(text);
   if (el.classList.contains('split')) {

--- a/libs/blocks/media/media.js
+++ b/libs/blocks/media/media.js
@@ -15,8 +15,10 @@
  */
 
 import { decorateBlockBg, decorateBlockText, getBlockSize } from '../../utils/decorate.js';
+import { decorateBlockAnalytics } from '../../utils/analytics.js';
 
 export default function init(el) {
+  decorateBlockAnalytics(el);
   const children = el.querySelectorAll(':scope > div');
   if (children[0]?.childElementCount === 1) {
     decorateBlockBg(el, children[0]);

--- a/libs/utils/analytics.js
+++ b/libs/utils/analytics.js
@@ -1,0 +1,19 @@
+export function decorateBlockAnalytics(blockEl) {
+  const lh = [];
+  const exclude = ['--', 'block'];
+  blockEl.classList.forEach((c) => {
+    if (!c.includes(exclude[0]) && c !== exclude[1]) lh.push(c);
+  });
+  blockEl.setAttribute('daa-im', 'true');
+  blockEl.setAttribute('daa-lh', lh.join('|'));
+}
+
+export function decorateLinkAnalytics(textEl, heading) {
+  textEl.setAttribute('daa-lh', heading.textContent);
+  const links = textEl.querySelectorAll('a, button');
+  links.forEach((link, i) => {
+    const linkType = (link.classList.contains('con-button')) ? 'cta' : 'link';
+    const str = `${linkType}|${link.innerText} ${i + 1}`;
+    link.setAttribute('daa-ll', str);
+  });
+}

--- a/libs/utils/analytics.js
+++ b/libs/utils/analytics.js
@@ -1,18 +1,17 @@
 export function decorateBlockAnalytics(blockEl) {
-  const lh = [];
-  const exclude = ['--', 'block'];
-  blockEl.classList.forEach((c) => {
-    if (!c.includes(exclude[0]) && c !== exclude[1]) lh.push(c);
-  });
   blockEl.setAttribute('daa-im', 'true');
-  blockEl.setAttribute('daa-lh', lh.join('|'));
+  blockEl.setAttribute('daa-lh', [...blockEl.classList].join('|'));
 }
 
-export function decorateLinkAnalytics(textEl, heading) {
-  textEl.setAttribute('daa-lh', heading.textContent);
+export function decorateLinkAnalytics(textEl, headings) {
+  const headingText = [...headings].map((heading) => heading.textContent);
+  textEl.setAttribute('daa-lh', headingText.join('|'));
   const links = textEl.querySelectorAll('a, button');
   links.forEach((link, i) => {
-    const linkType = (link.classList.contains('con-button')) ? 'cta' : 'link';
+    let linkType = 'link';
+    const { classList } = link;
+    if (classList.contains('con-button') && classList.contains('blue')) { linkType = 'filled'; }
+    if (classList.contains('con-button') && classList.contains('outline')) { linkType = 'outline'; }
     const str = `${linkType}|${link.innerText} ${i + 1}`;
     link.setAttribute('daa-ll', str);
   });

--- a/libs/utils/analytics.md
+++ b/libs/utils/analytics.md
@@ -1,0 +1,25 @@
+# Adobe analytics
+
+> Add tracking attributes to the DOM
+
+## Link hierarchy attributes
+
+### `daa-im`
+
+Simple attribute flag if set to true will capture impressions for each link in that container.
+
+### `daa-lh`
+
+Hierarchy values that are used to create a complete view of where each interaction is located. 
+
+Our code will combine hierarchy values to create where (unique identifier) for every interaction.
+
+## CTA attributes
+
+(CTA English value-CTA number in current box)
+
+### `daa-ll`
+
+Interaction identifier. Such as "Learn more" for a learn more link.
+
+[Home Page Link Tracking](https://wiki.corp.adobe.com/display/~cwest/PRD%3A+Home+Page+Link+Tracking)

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -41,7 +41,7 @@ export function decorateBlockText(el, size = 'small') {
   }
   decorateIcons(el);
   decorateButtons(el);
-  decorateLinkAnalytics(el, heading);
+  decorateLinkAnalytics(el, headings);
 }
 
 export function decorateBlockBg(block, node) {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -1,4 +1,4 @@
-// Decorate utils
+import { decorateLinkAnalytics } from './analytics.js';
 
 export function decorateButtons(el, size) {
   const buttons = el.querySelectorAll('em a, strong a');
@@ -41,6 +41,7 @@ export function decorateBlockText(el, size = 'small') {
   }
   decorateIcons(el);
   decorateButtons(el);
+  decorateLinkAnalytics(el, heading);
 }
 
 export function decorateBlockBg(block, node) {


### PR DESCRIPTION
* Added analytics utility script to include tracking attributes to a given block
* Imported `decorateBlockAnalytics` into the media.js and `decorateLinkAnalytics` into the shared decorateText() utility 

Resolves: Hidden - no jira ticket

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/media
- After: https://analytics--milo--adobecom.hlx.page/docs/library/blocks/media

**Testing notes**
 - Inspect the DOM to ensure the following data attributes are included. (daa-im, daa-lh, daa-ll) see utils/analytics.md for more details. 
 - FYI these are opt in. Needed blocks will require an include update to add these in their constructor.

