### PR TITLE
MWPW-116066 Fixing list chart voiceover items

### DIFF
--- a/libs/blocks/chart/list.css
+++ b/libs/blocks/chart/list.css
@@ -9,6 +9,17 @@
   display: block;
 }
 
+.chart.list .carousel-screen-reader {
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}
+
 .chart.list .list-wrapper .title {
   display: -webkit-box;
   display: -moz-box;

--- a/libs/blocks/chart/list.js
+++ b/libs/blocks/chart/list.js
@@ -62,7 +62,7 @@ const getListHtml = (chart, hexcode) => {
 
   return `
     <article class="list-wrapper">
-      <section class="title" style="${hexcode ? `background-color: ${hexcode};` : ''}"}>${chart.title}</section>
+      <section class="title" style="${hexcode ? `background-color: ${hexcode};` : ''}">${chart.title}</section>
       <${listType} class="${hasIcon ? 'icon-list' : ''}">${listItems}</${listType}>
     </article>
   `;
@@ -92,24 +92,27 @@ const getCarouselHtml = (data, hexcode) => {
           aria-controls="listChartCarousel-items"
           aria-label="Next Chart"></button>
       </div>
-      <div id="listChartCarousel-items"
-        class="carousel-items"
-        aria-live="polite">
+      <div id="listChartCarousel-items" class="carousel-items">
         ${carouselItems}
       </div>
+      <div class="carousel-screen-reader" aria-live="polite"></div>
     </section>`;
 };
 
 const showCarouselItem = (element, index) => {
   const carouselItems = element.querySelectorAll('.carousel-item');
+  const carouselScreenReader = element.querySelector('.carousel-screen-reader');
 
-  carouselItems?.forEach((carousel, idx) => {
+  carouselItems?.forEach((slide, idx) => {
     if (idx === index) {
-      carousel.classList.add('active');
+      slide.classList.add('active');
+      carouselScreenReader.innerText = slide.querySelector('.title')?.innerText;
     } else {
-      carousel.classList.remove('active');
+      slide.classList.remove('active');
     }
   });
+
+  setTimeout(() => { carouselScreenReader.innerText = ''; }, 5000);
 };
 
 const initList = (element, json, hexcode) => {


### PR DESCRIPTION
* Update aria-live region so it only announces the slide title 
* Move aria-live region to the bottom so that speedy screen reader users don't get to it
* Clear aria-live region text after 5 seconds so it is not read after the chart content

Resolves: [MWPW-116066](https://jira.corp.adobe.com/browse/MWPW-116066)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/bmarshal/list-qa?martech=off
- After: https://list-aria-live--milo--adobecom.hlx.page/drafts/bmarshal/list-qa?martech=off
