### PR TITLE
Region Modal Styling

### DIFF
--- a/libs/blocks/footer/footer.css
+++ b/libs/blocks/footer/footer.css
@@ -340,20 +340,3 @@ footer a:not(:any-link) {
   content: '/';
   margin-left: 6px;
 }
-
-.region-selector-text {
-  padding: 0 32px;
-}
-.region-selector {
-  padding: 0 32px 32px 32px;
-}
-
-.region-selector .content {
-  column-count: 1;
-}
-
-@media (min-width: 900px) {
-  .region-selector .content {
-    column-count: 3;
-  }
-}

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -41,3 +41,40 @@ dialog > .fragment > .section > .content > *:last-child {
     width: 60vw;
   }
 }
+
+.region-selector > div > p,
+.region-selector > div > ul li {
+  line-height: 1.5;
+  margin-bottom: 8px;
+}
+
+.region-selector > div > p {
+  font-size: 20px;
+}
+
+.region-selector-text {
+  padding-top: 32px;
+}
+
+.region-selector-text > div > p {
+  margin: 0 0 6px;
+}
+
+.region-selector-text > div > p:first-of-type {
+  font-size: 24px;
+}
+
+dialog > .fragment > .section.region-selector-text > .content > p:last-of-type {
+  margin-bottom: 24px;
+}
+
+.region-selector > div > ul li > a:focus-visible {
+  text-decoration: underline;
+  outline: none;
+} 
+
+.region-selector ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -36,28 +36,23 @@ dialog > .fragment > .section > .content > *:last-child {
   margin-bottom: 0;
 }
 
-@media (min-width: 600px) {
-  dialog {
-    width: 60vw;
-  }
-}
-
 .region-selector > div > p,
 .region-selector > div > ul li {
-  line-height: 1.5;
-  margin-bottom: 8px;
+  line-height: 1.7;
 }
 
 .region-selector > div > p {
-  font-size: 20px;
+  font-size: 16px;
+  margin-bottom: 0;
 }
 
 .region-selector-text {
-  padding-top: 32px;
+  padding: 32px 32px 20px;
+  font-size: 16px;
 }
 
 .region-selector-text > div > p {
-  margin: 0 0 6px;
+  margin: 0 0 4px;
 }
 
 .region-selector-text > div > p:first-of-type {
@@ -65,16 +60,46 @@ dialog > .fragment > .section > .content > *:last-child {
 }
 
 dialog > .fragment > .section.region-selector-text > .content > p:last-of-type {
-  margin-bottom: 24px;
+  margin-bottom: 0;
 }
 
 .region-selector > div > ul li > a:focus-visible {
   text-decoration: underline;
   outline: none;
-} 
+}
+
+.region-selector {
+  padding: 0 32px 32px;
+  font-size: 14px;
+}
 
 .region-selector ul {
   list-style: none;
   padding-left: 0;
   margin: 0;
+}
+
+.region-selector .content {
+  column-count: 1;
+}
+
+@media (min-width: 600px) {
+  dialog {
+    max-width: 80vw;
+  }
+
+  .region-selector .content {
+    column-count: 3;
+  }
+}
+
+@media (min-width: 1200px) {
+  .region-selector .content {
+    column-count: 5;
+  }
+
+  dialog#langnav {
+    width: 1200px;
+    max-width: calc((100% - 6px) - 2em);
+  } 
 }


### PR DESCRIPTION
* Adds base styling for region modal
* Moved region selector styles from footer.css to modal.css to keep region modal styles all in one place.
* Updated breakpoints so content doesn't feel so cramped.

Resolves: [DOTCOM-72238](https://jira.corp.adobe.com/browse/DOTCOM-72238), [DOTCOM-71906](https://jira.corp.adobe.com/browse/DOTCOM-71906)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off#langnav
- After: https://region-modal-styling--milo--adobecom.hlx.page/?martech=off#langnav
