### PR TITLE
Fix iOS bug for animated marquee MWPW-117337

### DIFF
--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -18,7 +18,7 @@ import { decorateButtons, getBlockSize } from '../../utils/decorate.js';
 const decorateVideo = (container) => {
   const link = container.querySelector('a[href$=".mp4"]');
 
-  container.innerHTML = `<video preload="metadata" autoplay muted loop>
+  container.innerHTML = `<video preload="metadata" playsinline autoplay muted loop>
     <source src="${link.href}" type="video/mp4" />
   </video>`;
   container.classList.add('has-video');


### PR DESCRIPTION
* Fixes bug in marquee where video doesn't play on iOS

Resolves: [MWPW-117337](https://jira.corp.adobe.com/browse/MWPW-117337)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/marquee?martech=off
- After: https://ios-video-bug--milo--adobecom.hlx.page/drafts/methomas/marquee?martech=off
