### PR TITLE
MWPW-116861 - Fragment Unwrap

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -261,6 +261,16 @@ export function decorateAutoBlock(a) {
     const key = Object.keys(candidate)[0];
     const match = href.includes(candidate[key]);
     if (match) {
+      // Fragments
+      if (key === 'fragment' && url.hash === '') {
+        const { parentElement } = a;
+        const { nodeName, innerHTML } = parentElement;
+        const noText = innerHTML === a.outerHTML;
+        if (noText && nodeName === 'P') {
+          const div = createTag('div', null, a);
+          parentElement.parentElement.replaceChild(div, parentElement);
+        }
+      }
       // Modals
       if (key === 'fragment' && url.hash !== '') {
         a.dataset.modalPath = url.pathname;
@@ -358,8 +368,8 @@ async function loadFooter() {
 function decorateSections(el, isDoc) {
   const selector = isDoc ? 'body > main > div' : ':scope > div';
   return [...el.querySelectorAll(selector)].map((section, idx) => {
-    decorateDefaults(section);
     const links = decorateLinks(section);
+    decorateDefaults(section);
     const blocks = decorateBlocks(section);
     section.className = 'section';
     section.dataset.status = 'decorated';

--- a/test/blocks/section-metadata/mocks/body.html
+++ b/test/blocks/section-metadata/mocks/body.html
@@ -1,0 +1,36 @@
+<div>
+  <div class="section-metadata">
+    <div>
+      <div>style</div>
+      <div>Darkest, XXL Spacing</div>
+    </div>
+  </div>
+</div>
+<div class="section image">
+  <div class="section-metadata">
+    <div>
+      <div>style</div>
+      <div>Darkest, XXL Spacing</div>
+    </div>
+    <div>
+      <div>background</div>
+      <div>
+        <picture>
+          <img loading="lazy" alt="" type="image/png" src="./media_16ff044c655bcf354741ca13216a5139330b4f277.png?width=750&#x26;format=png&#x26;optimize=medium" width="681" height="454">
+        </picture>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="section color">
+  <div class="section-metadata">
+    <div>
+      <div>style</div>
+      <div>Darkest, XXL Spacing</div>
+    </div>
+    <div>
+      <div>background</div>
+      <div>rgb(239, 239, 239)</div>
+    </div>
+  </div>
+</div>

--- a/test/blocks/section-metadata/section-meta.test.js
+++ b/test/blocks/section-metadata/section-meta.test.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-unused-expressions */
+/* global describe it */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+const { default: init } = await import('../../../libs/blocks/section-metadata/section-metadata.js');
+
+describe('Section Metdata', () => {
+  it('Gracefully dies', () => {
+    const sec = document.querySelector('div');
+    const sm = sec.querySelector('.section-metadata');
+    init(sm);
+    expect(sec.classList.length).to.equal(0);
+  });
+
+  it('Handles background image', () => {
+    const sec = document.querySelector('.section.image');
+    const sm = sec.querySelector('.section-metadata');
+    init(sm);
+    expect(sec.classList.contains('has-background')).to.be.true;
+  });
+
+  it('Handles background image', () => {
+    const sec = document.querySelector('.section.color');
+    const sm = sec.querySelector('.section-metadata');
+    init(sm);
+    expect(sec.style.backgroundColor).to.equal('rgb(239, 239, 239)');
+  });
+});

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -17,6 +17,10 @@
     <!-- Auto Blocks -->
     <p><a href="https://www.youtube.com/watch?v=0EWdoiU8BXw">YouTube</a></p>
     <p><a href="https://milo.adobe.com/fragments/mock#otis">Open modal</a></p>
+    <!-- Fragments -->
+    <p><a href="https://milo.adobe.com/fragments/mock">https://milo.adobe.com/fragments/mock</a></p>
+    <p>My sibling content<a href="https://milo.adobe.com/fragments/mock">https://milo.adobe.com/fragments/mock</a></p>
+    <ul><li>My sibling content<a href="https://milo.adobe.com/fragments/mock">https://milo.adobe.com/fragments/mock</a></li></ul>
     <!-- SVGs -->
     <p><a href="https://milo.adobe.com/img/favicon.svg">https://milo.adobe.com/img/favicon.svg</a></p>
     <p><a href="https://www.adobe.com">https://milo.adobe.com/img/favicon.svg</a></p>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -46,6 +46,28 @@ describe('Utils', () => {
     });
   });
 
+  describe('Fragments', () => {
+    it('fully unwraps a fragment', () => {
+      const fragments = document.querySelectorAll('.link-block.fragment');
+      utils.decorateAutoBlock(fragments[0]);
+      expect(fragments[0].parentElement.nodeName).to.equal('DIV');
+    });
+
+    it('Does not unwrap when sibling content present', () => {
+      const fragments = document.querySelectorAll('.link-block.fragment');
+      utils.decorateAutoBlock(fragments[1]);
+      expect(fragments[1].parentElement.nodeName).to.equal('P');
+      expect(fragments[1].parentElement.textContent).to.contain('My sibling');
+    });
+
+    it('Does not unwrap when not in paragraph tag', () => {
+      const fragments = document.querySelectorAll('.link-block.fragment');
+      utils.decorateAutoBlock(fragments[1]);
+      expect(fragments[1].parentElement.nodeName).to.equal('P');
+      expect(fragments[1].parentElement.textContent).to.contain('My sibling');
+    });
+  });
+
   it('Loads a script', async () => {
     const script = await utils.loadScript('/test/utils/mocks/script.js', 'module');
     expect(script).to.exist;


### PR DESCRIPTION
* Unwrap a fragment if it is the only child of a paragraph tag.
* Gracefully handles scenarios where fragments are placed in lists or have sibling content.

Previous selector hierarchy:
```
.section > .content > p > .fragment
```

After this change:
```
.section > div > .fragment
```

Resolves: [MWPW-116861](https://jira.corp.adobe.com/browse/MWPW-116861)

**Milo Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/fragment-test?martech=off
- After: https://fragment-unwrap-update--milo--adobecom.hlx.page/drafts/rclayton/fragment-test?martech=off

**Bacom Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/customer-success-stories/princess-cruises-case-study?martech=off
- After: https://main--bacom--adobecom.hlx.page/customer-success-stories/princess-cruises-case-study?martech=off&milolibs=unwrap-fragments