### PR TITLE
Set display none at section-metadata.css so consumer sites can have it.

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -1,3 +1,7 @@
+.section-metadata {
+  display: none;
+}
+
 .section.darkest {
   background-color: rgb(0 0 0);
   color: rgb(255 255 255);

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -66,10 +66,6 @@ header + main {
   display: none;
 }
 
-.section-metadata {
-  display: none;
-}
-
 h1 {
   font-size: var(--type-heading-xl-size);
   line-height: var(--type-heading-xl-lh);


### PR DESCRIPTION
Related Issue: [MWPW-116998](https://jira.corp.adobe.com/browse/MWPW-116998)

**Test URLs:**
- Before: https://main--business-website--adobe.hlx.page/jp/blog/basics/account-based-marketing
- After: https://main--business-website--adobe.hlx.page/jp/blog/basics/account-based-marketing?milolibs=section-metadata-hide
