### PR TITLE
Remove undefined on Manual Card if no description MWPW-117924

### DIFF
--- a/libs/blocks/manual-card/manual-card.js
+++ b/libs/blocks/manual-card/manual-card.js
@@ -44,7 +44,6 @@ const addBackgroundImg = (picture, cardType, card) => {
   imageDiv.style.backgroundImage = `url(${url})`;
   imageDiv.classList.add(`consonant-${cardType}-img`);
   card.append(imageDiv);
-  picture.parentElement.remove();
 };
 
 const addInner = (el, cardType, card) => {
@@ -54,10 +53,11 @@ const addInner = (el, cardType, card) => {
 
   if (cardType === DOUBLE_WIDE) {
     inner = document.createElement('a');
-    inner.href = el.querySelector('a').href;
+    inner.href = el.querySelector('a')?.href || '';
     inner.rel = 'noopener noreferrer';
     inner.tabIndex = 0;
-    inner.append(title, text);
+    if (title) inner.append(title);
+    if (text) inner.append(text);
     el.querySelector(':scope > div:not([class])')?.remove();
   }
 
@@ -66,7 +66,7 @@ const addInner = (el, cardType, card) => {
 
   if (cardType === PRODUCT) {
     inner.querySelector(':scope > div')?.classList.add('consonant-ProductCard-row');
-    inner.append(text);
+    if (text) inner.append(text);
   }
 
   if (cardType === HALF_HEIGHT) {
@@ -90,7 +90,7 @@ const addFooter = (links, container) => {
   footer += '</div></div>';
 
   container.insertAdjacentHTML('beforeend', footer);
-  links[0].parentElement.remove();
+  links[0]?.parentElement?.remove();
 };
 
 const init = (el) => {
@@ -108,7 +108,7 @@ const init = (el) => {
 
   if (cardType === HALF_HEIGHT) {
     card = document.createElement('a');
-    card.href = links[0]?.href;
+    card.href = links[0]?.href || '';
     card.className = el.className;
 
     el.insertAdjacentElement('beforebegin', card);
@@ -118,12 +118,11 @@ const init = (el) => {
   card.classList.add('consonant-Card', `consonant-${cardType}`);
   if (!styles.includes('border')) card.classList.add('consonant-u-noBorders');
 
-  if (cardType === PRODUCT) {
-    picture?.parentElement.remove();
-  } else {
+  if (picture && cardType !== PRODUCT) {
     addBackgroundImg(picture, cardType, card);
   }
 
+  picture?.parentElement.remove();
   addInner(el, cardType, card);
   decorateButtons(el);
 

--- a/test/blocks/manual-card/manual-card.test.js
+++ b/test/blocks/manual-card/manual-card.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-expressions */
-/* global describe it */
+/* global describe it before */
 
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
@@ -27,10 +27,21 @@ describe('Manual Card', () => {
     expect(document.querySelector('.consonant-OneHalfCard')).to.exist;
   });
 
-  it('Supports Double Width card', async () => {
-    document.body.innerHTML = await readFile({ path: './mocks/double-width.html' });
-    init(document.querySelector('.manual-card'));
-    expect(document.querySelector('.consonant-DoubleWideCard')).to.exist;
+  describe('Double Width Card', () => {
+    before(async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/double-width.html' });
+    });
+
+    it('is supported', () => {
+      init(document.querySelector('.manual-card'));
+      expect(document.querySelector('.consonant-DoubleWideCard')).to.exist;
+    });
+  
+    it('does not display undefined if no content', async () => {
+      const el = document.querySelector('.manual-card.empty');
+      init(el);
+      expect(el.outerHTML.includes('undefined')).to.be.false;
+    });
   });
 
   it('Supports Product card', async () => {
@@ -39,9 +50,20 @@ describe('Manual Card', () => {
     expect(document.querySelector('.consonant-ProductCard')).to.exist;
   });
 
-  it('Supports Half Height card', async () => {
-    document.body.innerHTML = await readFile({ path: './mocks/half-height.html' });
-    init(document.querySelector('.manual-card'));
-    expect(document.querySelector('.consonant-HalfHeightCard')).to.exist;
+  describe('Half Height Card', () => {
+    before(async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/half-height.html' });
+    });
+
+    it('is supported', () => {
+      init(document.querySelector('.manual-card'));
+      expect(document.querySelector('.consonant-HalfHeightCard')).to.exist;
+    });
+  
+    it('does not display undefined if no content', async () => {
+      const el = document.querySelector('.manual-card.empty');
+      init(el);
+      expect(el.outerHTML.includes('undefined')).to.be.false;
+    });
   });
 });

--- a/test/blocks/manual-card/mocks/double-width.html
+++ b/test/blocks/manual-card/mocks/double-width.html
@@ -16,20 +16,9 @@
       </div>
     </div>
   </div>
-  <div class="manual-card double-width-card">
+  <div class="manual-card double-width-card empty">
     <div>
       <div>
-        <p>
-          <picture>
-            <source type="image/webp" srcset="./media_12a6837d8a5cdf59dafcc02afe4e3f2e7cbbaa990.jpeg?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 400px)">
-            <source type="image/webp" srcset="./media_12a6837d8a5cdf59dafcc02afe4e3f2e7cbbaa990.jpeg?width=750&amp;format=webply&amp;optimize=medium">
-            <source type="image/jpeg" srcset="./media_12a6837d8a5cdf59dafcc02afe4e3f2e7cbbaa990.jpeg?width=2000&amp;format=jpeg&amp;optimize=medium" media="(min-width: 400px)">
-            <img loading="lazy" alt="" type="image/jpeg" src="./media_12a6837d8a5cdf59dafcc02afe4e3f2e7cbbaa990.jpeg?width=750&amp;format=jpeg&amp;optimize=medium" width="1440" height="480">
-          </picture>
-        </p>
-        <h3 id="lorem-ipsum-dolor-sit-amet-6">Lorem ipsum dolor sit amet</h3>
-        <p>Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>
-        <p><em><a href="https://business.adobe.com/">Learn more about lorem ipsum</a></em></p>
       </div>
     </div>
   </div>

--- a/test/blocks/manual-card/mocks/half-height.html
+++ b/test/blocks/manual-card/mocks/half-height.html
@@ -1,5 +1,5 @@
 <div class="section">
-  <div class="manual-card half-height-card" data-failed="true" data-reason="Failed loading manual-card block.">
+  <div class="manual-card half-height-card">
     <div>
       <div>
         <p>
@@ -14,6 +14,11 @@
         <p>Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>
         <p><em><a href="https://business.adobe.com/">Sign up</a></em> <strong><a href="https://business.adobe.com/">Learn more</a></strong></p>
       </div>
+    </div>
+  </div>
+  <div class="manual-card half-height-card empty">
+    <div>
+      <div></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
* Fix bug where "undefined" shows up when there's no description
* Also added similar catches for image, title, and links

Resolves: [MWPW-117924](https://jira.corp.adobe.com/browse/MWPW-117924)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/denli/manualconsonantcards?martech=off
- After: https://manual-card-undefined--milo--adobecom.hlx.page/drafts/denli/manualconsonantcards?martech=off
