### PR TITLE
Fix Manual Card title characters cut off on bottom MWPW-118021

### DIFF
--- a/libs/blocks/manual-card/manual-card.css
+++ b/libs/blocks/manual-card/manual-card.css
@@ -1,0 +1,4 @@
+/* stylelint-disable-next-line selector-class-pattern */
+.manual-card .consonant-ProductCard-title {
+  line-height: 1.375rem;
+}


### PR DESCRIPTION
* Fix Manual Card title characters cut off on bottom

Resolves: [MWPW-118021](https://jira.corp.adobe.com/browse/MWPW-118021)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/denli/manualconsonantcards?martech=off
- After: https://title-cut-off--milo--adobecom.hlx.page/drafts/denli/manualconsonantcards?martech=off
