### PR TITLE
Fix for CaaS Top Filters UI

### DIFF
--- a/libs/blocks/caas/caas.css
+++ b/libs/blocks/caas/caas.css
@@ -1,3 +1,7 @@
 a[href*="/tools/caas#"] {
   visibility: hidden !important;
 }
+
+main .consonant-TopFilters-filtersWrapper:first-child{
+  padding-top: 2px;
+}


### PR DESCRIPTION
Fixes a UI styling issue in Milo/Bacom where CaaS topFilters blue border, of the active filter, is getting cut off.

This should ultimately be fixed by the Chimera team.
https://github.com/adobecom/milo/blob/main/libs/blocks/caas/utils.js#L21

This problem is also present in AEM/Dexter:
https://www-author.corp.adobe.com/content/floodgate-pink-www/us/en/max/2022/shop/marketplace.html?wcmmode=disabled


Resolves: [MWPW-116265](https://jira.corp.adobe.com/browse/MWPW-116265)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/customer-success-stories/?martech=off
- After: https://main--bacom--adobecom.hlx.page/customer-success-stories?milolibs=caas-filter-ui&martech=off
