### PR TITLE
Add no-lazy option to CaaS

### DIFF
--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -11,30 +11,36 @@ const getCaasStrings = (placeholderUrl) => new Promise((resolve) => {
   resolve({});
 });
 
+const loadCaas = async (a) => {
+  const encodedConfig = a.href.split('#')[1];
+  const state = parseEncodedConfig(encodedConfig);
+
+  const [caasStrs] = await Promise.all([
+    getCaasStrings(state.placeholderUrl),
+    loadCaasFiles(),
+  ]);
+
+  const block = document.createElement('div');
+  block.className = a.className;
+  block.id = 'caas';
+  const modalDiv = document.createElement('div');
+  modalDiv.className = 'modalContainer';
+  a.insertAdjacentElement('afterend', modalDiv);
+
+  a.insertAdjacentElement('afterend', block);
+  a.remove();
+
+  initCaas(state, caasStrs, block);
+};
+
 export default async function init(link) {
-  createIntersectionObserver({
-    el: link,
-    options: { rootMargin: `${ROOT_MARGIN}px` },
-    callback: async (a) => {
-      const encodedConfig = a.href.split('#')[1];
-      const state = parseEncodedConfig(encodedConfig);
-
-      const [caasStrs] = await Promise.all([
-        getCaasStrings(state.placeholderUrl),
-        loadCaasFiles(),
-      ]);
-
-      const block = document.createElement('div');
-      block.className = a.className;
-      block.id = 'caas';
-      const modalDiv = document.createElement('div');
-      modalDiv.className = 'modalContainer';
-      a.insertAdjacentElement('afterend', modalDiv);
-
-      a.insertAdjacentElement('afterend', block);
-      a.remove();
-
-      initCaas(state, caasStrs, block);
-    },
-  });
+  if (link.textContent.includes('no-lazy')) {
+    loadCaas(link);
+  } else {
+    createIntersectionObserver({
+      el: link,
+      options: { rootMargin: `${ROOT_MARGIN}px` },
+      callback: loadCaas,
+    });
+  }
 }


### PR DESCRIPTION
* Adds the ability for a CaaS collection to be loaded without using an IntersectionObserver
* To enable, the CaaS link "Content as a Service" text needs to be modified to include "no-lazy"
  * e.g: "Content as a Service no-lazy"

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/caas-target?martech=off
- After: https://caas_nolazy--milo--adobecom.hlx.page/drafts/cpeyer/caas-target?martech=off
