### PR TITLE
MWPW-118743 table of contents error on older Safari and Firefox

### DIFF
--- a/libs/blocks/table-of-contents/table-of-contents.js
+++ b/libs/blocks/table-of-contents/table-of-contents.js
@@ -79,9 +79,10 @@ export default function init(el) {
   const navUl = createTag('ul', { class: 'toc-list' });
 
   children.forEach((section) => {
+    const sectionTags = Array.from(section.querySelectorAll('p'));
     const sectionTitle = section.querySelector('strong');
     const link = section.querySelector('a');
-    const subtitle = section.querySelector('p:not(:has(*))');
+    const subtitle = sectionTags.find((element) => element.childElementCount === 0);
     const target = link ? findAnchorTarget(link.textContent) : null;
     const item = getItem(sectionTitle?.textContent, subtitle?.textContent, target);
     navUl.append(item);


### PR DESCRIPTION
* Safari 15.3 and below and Firefox 103 does not support the :has selector

Resolves: [MWPW-118743](https://jira.corp.adobe.com/browse/MWPW-118743)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/denli/table-of-contentsmartech=off
- After: https://toc-has-fix--milo--adobecom.hlx.page/drafts/denli/table-of-contents?martech=off
