### PR TITLE
MWPW-117934 - Consumer Edge IDs

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -6,14 +6,14 @@ function getDetails(env) {
   if (env.name === 'prod') {
     return {
       url: 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-5dd5dd2177e6.min.js',
-      edgeConfigId: '2cba807b-7430-41ae-9aac-db2b0da742d5',
+      edgeConfigId: env.consumer?.edgeConfigId || env.edgeConfigId,
     };
   }
-  /* c8 ignore stop */
   return {
     url: 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-2c94beadc94f-development.min.js',
-    edgeConfigId: '8d2805dd-85bf-4748-82eb-f99fdad117a6',
+    edgeConfigId: env.consumer?.edgeConfigId || env.edgeConfigId,
   };
+  /* c8 ignore stop */
 }
 
 export default async function init(config, loadScript) {
@@ -34,7 +34,6 @@ export default async function init(config, loadScript) {
       alloy: { edgeConfigId },
       target: false,
     },
-    // TODO: Do we need to add diagnostic.page.aemimplementation
   };
 
   window.digitalData ??= {};

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -46,13 +46,17 @@ const AUTO_BLOCKS = [
   { 'pdf-viewer': '.pdf' },
 ];
 const ENVS = {
-  local: { name: 'local' },
+  local: {
+    name: 'local',
+    edgeConfigId: '8d2805dd-85bf-4748-82eb-f99fdad117a6',
+  },
   stage: {
     name: 'stage',
     ims: 'stg1',
     adobeIO: 'cc-collab-stage.adobe.io',
     adminconsole: 'stage.adminconsole.adobe.com',
     account: 'stage.account.adobe.com',
+    edgeConfigId: '8d2805dd-85bf-4748-82eb-f99fdad117a6',
   },
   prod: {
     name: 'prod',
@@ -60,19 +64,25 @@ const ENVS = {
     adobeIO: 'cc-collab.adobe.io',
     adminconsole: 'adminconsole.adobe.com',
     account: 'account.adobe.com',
+    edgeConfigId: '2cba807b-7430-41ae-9aac-db2b0da742d5',
   },
 };
 
-function getEnv() {
+function getEnv(conf) {
   const { host, href } = window.location;
   const location = new URL(href);
   const query = location.searchParams.get('env');
 
-  if (query) { return ENVS[query]; }
-  if (host.includes('localhost:')) return ENVS.local;
+  if (query) return { ...ENVS[query], consumer: conf[query] };
+  if (host.includes('localhost:')) return { ...ENVS.local, consumer: conf.local };
   /* c8 ignore start */
-  if (host.includes('hlx.page') || host.includes('hlx.live') || host.includes('corp.adobe')) return ENVS.stage;
-  return ENVS.prod;
+  if (host.includes('hlx.page')
+   || host.includes('hlx.live')
+   || host.includes('stage.adobe')
+   || host.includes('corp.adobe')) {
+    return { ...ENVS.stage, consumer: conf.stage };
+  }
+  return { ...conf.prod, consumer: conf.prod };
   /* c8 ignore stop */
 }
 
@@ -93,7 +103,7 @@ export const [setConfig, getConfig] = (() => {
   return [
     (conf) => {
       const { origin } = window.location;
-      config = { env: getEnv(), ...conf };
+      config = { env: getEnv(conf), ...conf };
       config.codeRoot = conf.codeRoot ? `${origin}${conf.codeRoot}` : origin;
       config.locale = getLocale(conf.locales);
       document.documentElement.setAttribute('lang', config.locale.ietf);
@@ -423,7 +433,7 @@ function loadPrivacy() {
     },
   };
 
-  const env = getEnv().name === 'prod' ? '' : 'stage.';
+  const env = getConfig().env.name === 'prod' ? '' : 'stage.';
   loadScript(`https://www.${env}adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js`);
 }
 


### PR DESCRIPTION
* Add ability for consumers to supply their own env params
* Moved global edge ids to utils
* Milo will try to use consumer edge ids and fall back to global
* Added stage.adobe as criteria for stage env

Resolves: [MWPW-117934](https://jira.corp.adobe.com/browse/MWPW-117934)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/
- After: https://edge-ids--milo--adobecom.hlx.page/
