### PR TITLE
Integrate Janus

### DIFF
--- a/.github/workflows/run-janus.yml
+++ b/.github/workflows/run-janus.yml
@@ -1,0 +1,19 @@
+name: Automated Tests
+
+on:
+  pull_request:
+    types: [ labeled, opened, synchronize, reopened ]
+
+jobs:
+  action:
+    name: Running tests
+    if: contains(github.event.pull_request.labels.*.name, 'run-janus')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Run Janus
+        uses: adobecom/janus@action
+        env:
+          branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Unit Tests
 on:
   push:
     branches:
@@ -8,7 +8,8 @@ on:
     branches:
       - main
 jobs:
-  build:
+  run-tests:
+    name: Running tests
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
* Run Janus when a pull request is submitted
* Runs Janus against the pull request branch name (?milolibs=the-branch)
* Only runs when the run-janus label is attached

Resolves: [MWPW-109693](https://jira.corp.adobe.com/browse/MWPW-109693)

URL for testing:

- https://integrate-janus--milo--adobecom.hlx.page/
