### PR TITLE
Aside hotfix - failure with no body

### DIFF
--- a/libs/blocks/aside/aside.js
+++ b/libs/blocks/aside/aside.js
@@ -73,7 +73,7 @@ function decorateContent(el, type, size) {
   const bodyCopy = heading?.nextElementSibling.classList.length === 0 ? heading.nextElementSibling : text?.querySelector('p:not([class])');
   bodyCopy?.classList.add(bodyClass);
   const body = createTag('div', { class: 'body-area' });
-  bodyCopy.insertAdjacentElement('beforebegin', body);
+  bodyCopy?.insertAdjacentElement('beforebegin', body);
   body.append(bodyCopy);
   el.querySelector(':scope > div:not(.text) img')?.closest('div').classList.add('image');
 }


### PR DESCRIPTION
* Fixes Aside loading error when no description body is provided


**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/customer-success-stories/adobe-inside-adobe-case-study
- After: https://main--bacom--adobecom.hlx.page/customer-success-stories/adobe-inside-adobe-case-study?milolibs=methomas-aside-load-error
Milo:
- https://methomas-aside-load-error--milo--adobecom.hlx.page/drafts/methomas/aside?martech=off
