### PR TITLE
Tabs hot fix: `not block` styles are applied to tab content incorrectly

### DIFF
--- a/libs/blocks/tabs/tabs.css
+++ b/libs/blocks/tabs/tabs.css
@@ -89,6 +89,7 @@
   padding: 0 8.3%;
   width: var(--grid-container-width);
   margin: 0 auto;
+  box-sizing: content-box;
 }
 
 .tabs div[role="tablist"] {

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -116,6 +116,7 @@ const init = (e) => {
       const tabContentAttributes = {
         id: `tab-panel-${initCount}-${tabName}`,
         role: 'tabpanel',
+        class: `tabpanel-${tabName}`,
         tabindex: '0',
         'aria-labelledby': `tab-${initCount}-${tabName}`,
       };

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -116,7 +116,7 @@ const init = (e) => {
       const tabContentAttributes = {
         id: `tab-panel-${initCount}-${tabName}`,
         role: 'tabpanel',
-        class: `tabpanel-${tabName}`,
+        class: 'tabpanel',
         tabindex: '0',
         'aria-labelledby': `tab-${initCount}-${tabName}`,
       };


### PR DESCRIPTION
While updating a customer story document, We noticed the images in normal content was using our `not block` styles because the tab panel had no class. This caused the images to scale 100% width. 

* Updated our tab panels to have a class assigned. 
* Added box-sizing property to tab list to prevent app.min styles layout shift. 

**Test URLs:**
- [Before](https://main--bacom--adobecom.hlx.page/drafts/parrish/tabs)
- [After](https://main--bacom--adobecom.hlx.page/drafts/parrish/tabs?milolibs=tabs-fix)