### PR TITLE
Remove section-metadata as a supported block

### DIFF
--- a/libs/blocks/list.js
+++ b/libs/blocks/list.js
@@ -8,7 +8,6 @@ const blocks = [
   'how-to',
   'modal',
   'marquee',
-  'section-metadata',
   'review',
 ];
 


### PR DESCRIPTION
Changes made:
- I removed 'section-metadata' as a supported block.
