### PR TITLE
MWPW-118172 RTL support

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -109,6 +109,8 @@ export const [setConfig, getConfig] = (() => {
       config.codeRoot = conf.codeRoot ? `${origin}${conf.codeRoot}` : origin;
       config.locale = getLocale(conf.locales);
       document.documentElement.setAttribute('lang', config.locale.ietf);
+      config.direction = (new Intl.Locale(config.locale.ietf)).textInfo.direction;
+      document.documentElement.setAttribute('dir',config.direction);
       if (config.contentRoot) {
         config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot}`;
       } else {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -109,8 +109,12 @@ export const [setConfig, getConfig] = (() => {
       config.codeRoot = conf.codeRoot ? `${origin}${conf.codeRoot}` : origin;
       config.locale = getLocale(conf.locales);
       document.documentElement.setAttribute('lang', config.locale.ietf);
-      config.direction = (new Intl.Locale(config.locale.ietf)).textInfo.direction;
-      document.documentElement.setAttribute('dir',config.direction);
+      try {
+        config.locale.direction = (new Intl.Locale(config.locale.ietf)).textInfo.direction;
+        document.documentElement.setAttribute('dir',config.locale.direction);  
+      } catch (e) {
+        console.log("Invalid or missing locale:",e)
+      }
       if (config.contentRoot) {
         config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot}`;
       } else {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -110,8 +110,7 @@ export const [setConfig, getConfig] = (() => {
       config.locale = getLocale(conf.locales);
       document.documentElement.setAttribute('lang', config.locale.ietf);
       try {
-        config.locale.direction = (new Intl.Locale(config.locale.ietf)).textInfo.direction;
-        document.documentElement.setAttribute('dir',config.locale.direction);  
+        document.documentElement.setAttribute('dir',(new Intl.Locale(config.locale.ietf)).textInfo.direction);  
       } catch (e) {
         console.log("Invalid or missing locale:",e)
       }


### PR DESCRIPTION
- Adds writing direction ( `rtl` , `ltr` ) to `config.direction` , based on active language.
- Sets the writing direction in the `dir` attribute in `html`  element.

Resolves: [MWPW-118172](https://jira.corp.adobe.com/browse/MWPW-118172)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://MWPW-118172--milo--adobecom.hlx.page/?martech=off
