### PR TITLE
fix(tabs): Allow for tab names to have multiple spaces

### DIFF
--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -5,7 +5,7 @@
 import { createTag } from '../../utils/utils.js';
 
 function getStringKeyName(str) {
-  return str.trim().replace(' ', '-').toLowerCase();
+  return str.trim().replaceAll(' ', '-').toLowerCase();
 }
 
 function initTabs(e, config) {


### PR DESCRIPTION
- This change allows for the tab names to contain multiple spaces without breaking.

I don't have access to the Milo project, so I'm not sure how to create a test URL for these PR's, but the fix is quite straightforward so it might not be necessary anyways.
