### PR TITLE
fix potential JS error (reading 'firstChild' of null)

### DIFF
--- a/libs/blocks/share/share.js
+++ b/libs/blocks/share/share.js
@@ -20,6 +20,7 @@ export async function getSVGsfromFile(path, selectors) {
   return selectors.map((selector) => {
     const symbol = doc.querySelector(`#${selector}`);
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    if (!symbol) return null;
     while (symbol.firstChild) svg.appendChild(symbol.firstChild);
     [...symbol.attributes].forEach((attr) => svg.attributes.setNamedItem(attr.cloneNode()));
     svg.classList.add('icon');

--- a/libs/blocks/share/share.js
+++ b/libs/blocks/share/share.js
@@ -19,8 +19,8 @@ export async function getSVGsfromFile(path, selectors) {
 
   return selectors.map((selector) => {
     const symbol = doc.querySelector(`#${selector}`);
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     if (!symbol) return null;
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     while (symbol.firstChild) svg.appendChild(symbol.firstChild);
     [...symbol.attributes].forEach((attr) => svg.attributes.setNamedItem(attr.cloneNode()));
     svg.classList.add('icon');


### PR DESCRIPTION
I noticed an error that would come up if the icon doesn't exist:
<img width="253" alt="image" src="https://user-images.githubusercontent.com/62023521/199542408-a7755c85-5e0b-4082-8fda-2137f94cb2e5.png">

This PR should prevent it from happening
