### PR TITLE
Add ability to turn off martech via metadata

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -110,7 +110,7 @@ export const [setConfig, getConfig] = (() => {
       config.locale = getLocale(conf.locales);
       document.documentElement.setAttribute('lang', config.locale.ietf);
       try {
-        document.documentElement.setAttribute('dir',(new Intl.Locale(config.locale.ietf)).textInfo.direction);  
+        document.documentElement.setAttribute('dir',(new Intl.Locale(config.locale.ietf)).textInfo.direction);
       } catch (e) {
         console.log("Invalid or missing locale:",e)
       }
@@ -406,7 +406,7 @@ function decorateSections(el, isDoc) {
 
 async function loadMartech(config) {
   const query = new URL(window.location.href).searchParams.get('martech');
-  if (query !== 'off') {
+  if (query !== 'off' && getMetadata('martech') !== 'off') {
     const { default: martech } = await import('../martech/martech.js');
     martech(config, loadScript, getMetadata);
   }


### PR DESCRIPTION
Sometimes we don't want pages to ever run martech (mostly /tools pages)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://c3-martechmd--milo--adobecom.hlx.page/?martech=off
