### PR TITLE
Add ability to pass in additional block library locations

### DIFF
--- a/libs/blocks/library-config/library-config.js
+++ b/libs/blocks/library-config/library-config.js
@@ -129,9 +129,17 @@ async function loadList(type, list) {
 export default function init(el) {
   const librarEls = el.querySelectorAll('a');
 
-  const paths = [...librarEls].map((lib) => { return lib.href; });
+  const blockPaths = [...librarEls].map((lib) => { return lib.href; });
 
-  const libraries = [ { text: 'Blocks', paths } ];
+  const { searchParams: sp } = new URL(window.location.href);
+  const additionalBlockLibs = sp.getAll('blocks')
+    .map((lib) => {
+      if (lib.startsWith('http')) return lib;
+      return `https://${lib}.hlx.page/docs/library/blocks.json`;
+    });
+  blockPaths.push(...additionalBlockLibs);
+
+  const libraries = [ { text: 'Blocks', paths: blockPaths } ];
 
   el.querySelector('div').remove();
 


### PR DESCRIPTION
Consumers can add additional block library locations using the query param `blocks`
Either:
* A fully qualified URL - e.g: https://main--bacom--adobecom.hlx.page/docs/library/blocks.json
* The `ref--repo--owner` string which will default to the above json location

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://c3-lib-additional-block-support--milo--adobecom.hlx.page/?martech=off
