### PR TITLE
Localization MVP - Rollout Fixes, GNAV Support

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -589,7 +589,7 @@ async function fetchGnav(url) {
 export default async function init(header) {
   const { locale, imsClientId } = getConfig();
   const name = imsClientId ? `|${imsClientId}` : '';
-  const url = getMetadata('gnav-source') || `${locale.prefix}/gnav`;
+  const url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
   const html = await fetchGnav(url);
   if (!html) return null;
   try {

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -86,7 +86,7 @@ const locales = {
   my_en: { ietf: 'en-GB', tk: 'pps7abe.css' },
   nz: { ietf: 'en-GB', tk: 'pps7abe.css' },
   ph_en: { ietf: 'en', tk: 'pps7abe.css' },
-  ph_fil: { ietf: 'en-US', tk: 'ict8rmp.css' },
+  ph_fil: { ietf: 'fil-PH', tk: 'ict8rmp.css' },
   sg: { ietf: 'en-SG', tk: 'pps7abe.css' },
   th_en: { ietf: 'en', tk: 'pps7abe.css' },
   in_hi: { ietf: 'hi', tk: 'aaa8deh.css' },
@@ -96,6 +96,8 @@ const locales = {
   tw: { ietf: 'zh-TW', tk: 'jay0ecd' },
   jp: { ietf: 'ja-JP', tk: 'dvg6awq' },
   kr: { ietf: 'ko-KR', tk: 'qjs5sfm' },
+  // Langstore Support.
+  langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
 };
 
 const config = {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -91,15 +91,25 @@ function getEnv(conf) {
 }
 
 // find out current locale based on pathname and existing locales object from config.
+export function getLocaleFromPath(locales, path) {
+  const split = path.split('/');
+  const localeString = split[1];
+  const locale = locales[localeString] || locales[''];
+  if (localeString === 'langstore') {
+    locale.prefix = split.length >= 3 ? `/${localeString}/${split[2]}` : '';
+    return locale;
+  }
+  locale.prefix = locale.ietf === 'en-US' ? '' : `/${localeString}`;
+  return locale;
+}
+
+// find out current locale based on pathname and existing locales object from config.
 export function getLocale(locales) {
   if (!locales) {
     return { ietf: 'en-US', tk: 'hah7vzn.css', prefix: '' };
   }
   const { pathname } = window.location;
-  const split = pathname.split('/');
-  const locale = locales[split[1]] || locales[''];
-  locale.prefix = locale.ietf === 'en-US' ? '' : `/${split[1]}`;
-  return locale;
+  return getLocaleFromPath(locales, pathname);
 }
 
 export const [setConfig, getConfig] = (() => {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -90,13 +90,12 @@ function getEnv(conf) {
   /* c8 ignore stop */
 }
 
-// find out current locale based on pathname and existing locales object from config.
 export function getLocaleFromPath(locales, path) {
   const split = path.split('/');
   const localeString = split[1];
   const locale = locales[localeString] || locales[''];
   if (localeString === 'langstore') {
-    locale.prefix = split.length >= 3 ? `/${localeString}/${split[2]}` : '';
+    locale.prefix = `/${localeString}/${split[2]}`;
     return locale;
   }
   locale.prefix = locale.ietf === 'en-US' ? '' : `/${localeString}`;

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -199,7 +199,6 @@ describe('Utils', () => {
     validateLocale('/page', { prefix: '', ietf: 'en-US', tk: 'hah7vzn.css' });
     validateLocale('/be_fr', { prefix: '/be_fr', ietf: 'fr-BE', tk: 'vrk5vyv.css' });
     validateLocale('/be_fr/page', { prefix: '/be_fr', ietf: 'fr-BE', tk: 'vrk5vyv.css' });
-    validateLocale('/langstore', { prefix: '', ietf: 'en-US', tk: 'hah7vzn.css' });
     validateLocale('/langstore/lv', { prefix: '/langstore/lv', ietf: 'en-US', tk: 'hah7vzn.css' });
     validateLocale('/langstore/lv/page', { prefix: '/langstore/lv', ietf: 'en-US', tk: 'hah7vzn.css' });
   });

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -181,6 +181,29 @@ describe('Utils', () => {
     expect(utils.getLocale().ietf).to.equal('en-US');
   });
 
+  it('getLocaleFromPath for different paths', () => {
+    const locales = {
+      '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+      langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
+      be_fr: { ietf: 'fr-BE', tk: 'vrk5vyv.css' },
+    };
+
+    function validateLocale(path, expectedOutput) {
+      const locale = utils.getLocaleFromPath(locales, path);
+      expect(locale.prefix).to.equal(expectedOutput.prefix);
+      expect(locale.ietf).to.equal(expectedOutput.ietf);
+      expect(locale.tk).to.equal(expectedOutput.tk);
+    }
+
+    validateLocale('/', { prefix: '', ietf: 'en-US', tk: 'hah7vzn.css' });
+    validateLocale('/page', { prefix: '', ietf: 'en-US', tk: 'hah7vzn.css' });
+    validateLocale('/be_fr', { prefix: '/be_fr', ietf: 'fr-BE', tk: 'vrk5vyv.css' });
+    validateLocale('/be_fr/page', { prefix: '/be_fr', ietf: 'fr-BE', tk: 'vrk5vyv.css' });
+    validateLocale('/langstore', { prefix: '', ietf: 'en-US', tk: 'hah7vzn.css' });
+    validateLocale('/langstore/lv', { prefix: '/langstore/lv', ietf: 'en-US', tk: 'hah7vzn.css' });
+    validateLocale('/langstore/lv/page', { prefix: '/langstore/lv', ietf: 'en-US', tk: 'hah7vzn.css' });
+  });
+
   it('creates an IntersectionObserver', (done) => {
     const block = document.createElement('div');
     block.id = 'myblock';

--- a/tools/loc/config.js
+++ b/tools/loc/config.js
@@ -12,7 +12,7 @@
 /* global */
 import { getUrlInfo } from './utils.js';
 
-const LOC_CONFIG = '/drafts/localization/configs/config-v3.json';
+const LOC_CONFIG = '/drafts/localization/configs/config.json';
 const DEFAULT_WORKFLOW = 'Standard';
 const GRAPH_API = 'https://graph.microsoft.com/v1.0';
 
@@ -21,7 +21,7 @@ let decoratedConfig;
 async function fetchConfigJson(configPath) {
   const configResponse = await fetch(configPath);
   if (!configResponse.ok) {
-    throw new Error('Config not found!');
+    throw new Error('Config not found!!');
   }
   return configResponse.json();
 }

--- a/tools/loc/config.js
+++ b/tools/loc/config.js
@@ -21,7 +21,7 @@ let decoratedConfig;
 async function fetchConfigJson(configPath) {
   const configResponse = await fetch(configPath);
   if (!configResponse.ok) {
-    throw new Error('Config not found!!');
+    throw new Error('Config not found!');
   }
   return configResponse.json();
 }

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -287,8 +287,7 @@ async function updateFile(dest, metadata, customMetadata = {}) {
 async function getMetadata(srcPath, file) {
   const metadata = {};
   if (file) {
-    metadata.rolloutTime = file?.uploadedFileJson?.lastModifiedDateTime
-      || file?.lastModifiedDateTime;
+    metadata.rolloutTime = new Date().toISOString();
     metadata.rolloutVersion = await getFileVersionInfo(srcPath);
   }
   return metadata;

--- a/tools/loc/utils.js
+++ b/tools/loc/utils.js
@@ -67,12 +67,13 @@ export function getUrlInfo() {
   function getParam(name) {
     return location.searchParams.get(name);
   }
-  const sub = location.hostname.split('.').shift().split('--');
+  const projectName = getParam('project');
+  const sub = projectName ? projectName.split('--') : [];
 
   const sp = getParam('referrer');
-  const owner = getParam('owner') || sub[2];
-  const repo = getParam('repo') || sub[1];
-  const ref = getParam('ref') || sub[0];
+  const owner = getParam('owner') || sub[1];
+  const repo = getParam('repo') || sub[0];
+  const ref = getParam('ref') || 'main';
 
   urlInfo = {
     sp,

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -12,7 +12,7 @@
       "id": "localize",
       "title": "Localize",
       "environments": [ "edit" ],
-      "url": "/tools/loc/index.html",
+      "url": "/tools/loc/index.html?project=milo--adobecom",
       "passReferrer": true,
       "includePaths": [ "**.xlsx**" ]
     },


### PR DESCRIPTION
- Update config to config.json instead of config-v3.json
- Fix Rollout Timestamp issue which can lead to accidental merging of word docs
- Update gnav to use locale.contentRoot instead of locale.prefix
- Add support for langstore in locales and locale prefix
- Add tests and increase coverage for getLocale method.

Resolves: MWPW-97626

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/langstore/en-gb/drafts/bhagwath/gnav-testing/gnav-embed?martech=off
- After:  https://loc--milo--adobecom.hlx.page/langstore/en-gb/drafts/bhagwath/gnav-testing/gnav-embed?martech=off