### PR TITLE
Fixing bug for Workfront template, Improve UX the pre-population section.

### DIFF
--- a/libs/blocks/faas-config/faas-config.js
+++ b/libs/blocks/faas-config/faas-config.js
@@ -303,7 +303,7 @@ const RequiredPanel = () => {
           setFieldMultiCampStyle(html`<${Input} label="Multi Campaign Radio Styling" prop="multicampaignradiostyle" type="checkbox" />`);
         }
       });
-      if (!isMultipleCampaign) {
+      if (!isMultipleCampaign && formId !== '63') {
         setFieldpjs36(html`<${Input} label="Internal Campagin ID" prop="pjs36" placeholder="ex) 70114000002XYvIAAW" />`);
       }
       // eslint-disable-next-line no-use-before-define

--- a/libs/blocks/faas/utils.js
+++ b/libs/blocks/faas/utils.js
@@ -22,6 +22,9 @@ export const getFaasHostSubDomain = (environment) => {
   if (faasEnv === 'dev') {
     return 'dev.';
   }
+  if (faasEnv === 'qa') {
+    return 'qa.';
+  }
   return 'qa.';
 };
 

--- a/libs/blocks/faas/utils.js
+++ b/libs/blocks/faas/utils.js
@@ -8,7 +8,7 @@ import {
 } from '../../utils/utils.js';
 
 const { env, miloLibs, codeRoot } = getConfig();
-let state;
+let state = {};
 
 export const getFaasHostSubDomain = (environment) => {
   const faasEnv = environment ?? env.name;
@@ -69,6 +69,10 @@ export const defaultState = {
   e: {},
   title_align: 'center',
   title_size: 'h3',
+  pc1: true,
+  pc2: true,
+  pc3: true,
+  pc4: true,
 };
 
 /* c8 ignore start */
@@ -272,15 +276,16 @@ export const makeFaasConfig = (targetState) => {
     q: {},
     p: {
       js: {
-        36: targetState.pjs36,
-        39: targetState.pjs39,
+        36: targetState.pjs36 || defaultState.p.js[36],
+        39: targetState.pjs39 || defaultState.p.js[39],
         77: 1,
         78: 1,
         79: 1,
         90: 'FAAS',
-        92: targetState.pjs92,
-        93: targetState.pjs93,
-        94: targetState.pjs94,
+        92: targetState.pjs92 || defaultState.p.js[92],
+        93: targetState.pjs93 || defaultState.p.js[93],
+        94: targetState.pjs94 || defaultState.p.js[94],
+        149: '',
       },
     },
     e: { 
@@ -304,7 +309,6 @@ export const makeFaasConfig = (targetState) => {
     Object.assign(config.q, { 103: { c: targetState.q103 } });
   }
 
-  state = config;
   return config;
 };
 
@@ -329,11 +333,13 @@ export const initFaas = (config, targetEl) => {
   }
 
   const formEl = createTag('div', { class: 'faas-form-wrapper' });
+
   if (state.complete) {
     state.e = { afterYiiLoadedCallback, beforeSubmitCallback };
     $(formEl).faas(state);
   } else {
-    makeFaasConfig(config);
+    state = makeFaasConfig(config);
+    console.log('beforeLoad', state);
     $(formEl).faas(state);
   }
 


### PR DESCRIPTION
Resolves: [MWPW-120799](https://jira.corp.adobe.com/browse/MWPW-120799) and [MWPW-120798](https://jira.corp.adobe.com/browse/MWPW-120798)
**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/faas?env=qa
- After: https://faas-fix--milo--adobecom.hlx.page/tools/faas?env=qa

For [MWPW-120799](https://jira.corp.adobe.com/browse/MWPW-120799), they need to enable custom javascript to see the checkbox. I set those pre-population fields to be checked as default for better UX. And there was a minor bug that I fixed - when they cleared the partner fields, it still was sending the previous data to faas.
