### PR TITLE
Remove unnecessary white bar for the GNAV

### DIFF
--- a/libs/blocks/gnav/gnav.css
+++ b/libs/blocks/gnav/gnav.css
@@ -328,6 +328,10 @@ header .gnav-search-field:hover .gnav-search-input::placeholder {
   margin: 0;
 }
 
+.gnav-search-results > ul:empty {
+  display: none;
+}
+
 .gnav-search-results > ul li {
   font-size: 14px;
     line-height: 1;


### PR DESCRIPTION
Small visual fix for the gnav search in an empty state - Resolves: [120914](https://jira.corp.adobe.com/browse/MWPW-120914)

**Before**
![Screenshot 2022-11-14 at 16 30 56](https://user-images.githubusercontent.com/39759830/201700018-9fe833d3-3473-4703-80ee-a7fa8479b17c.png)

**After**
![Screenshot 2022-11-14 at 16 31 01](https://user-images.githubusercontent.com/39759830/201700026-e61caa11-ef38-438f-a61f-233f2c63f526.png)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/document?martech=off
- After: https://gnav-remove-white-bar--milo--adobecom.hlx.page/drafts/osahin/document?martech=off
- Before: https://main--bacom--adobecom.hlx.page/customer-success-stories?martech=off
- After: https://main--bacom--adobecom.hlx.page/customer-success-stories?milolibs=gnav-remove-white-bar&martech=off