### PR TITLE
Cleanup of utils.js

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -9,11 +9,8 @@ import {
   useState,
 } from '../../deps/htm-preact.js';
 import {
-  updateObj,
-  cloneObj,
   getConfig,
-  getHashConfig,
-  isValidUuid,
+  parseEncodedConfig,
   loadStyle,
   utf8ToB64,
 } from '../../utils/utils.js';
@@ -25,6 +22,27 @@ import MultiField from '../../ui/controls/MultiField.js';
 import '../../utils/lana.js';
 
 const LS_KEY = 'caasConfiguratorState';
+
+const cloneObj = (obj) => JSON.parse(JSON.stringify(obj));
+
+const updateObj = (obj, defaultObj) => {
+  const ds = cloneObj(defaultObj);
+  Object.keys(ds).forEach((key) => {
+    if (obj[key] === undefined) obj[key] = ds[key];
+  });
+  return obj;
+};
+
+const isValidUuid = (id) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
+
+const getHashConfig = () => {
+  const { hash } = window.location;
+  if (!hash) return null;
+  window.location.hash = '';
+
+  const encodedConfig = hash.startsWith('#') ? hash.substring(1) : hash;
+  return parseEncodedConfig(encodedConfig);
+}
 
 const caasFilesLoaded = loadCaasFiles();
 
@@ -788,4 +806,11 @@ const init = async (el) => {
   render(app, el);
 };
 
-export { init as default, loadCaasTags };
+export {
+  init as default,
+  cloneObj,
+  getHashConfig,
+  isValidUuid,
+  loadCaasTags,
+  updateObj,
+};

--- a/libs/blocks/faas-config/faas-config.js
+++ b/libs/blocks/faas-config/faas-config.js
@@ -8,7 +8,7 @@ import {
   useState,
 } from '../../deps/htm-preact.js';
 import { faasHostUrl, defaultState, initFaas, loadFaasFiles } from '../faas/utils.js';
-import { loadStyle, getHashConfig, utf8ToB64 } from '../../utils/utils.js';
+import { loadStyle, parseEncodedConfig, utf8ToB64 } from '../../utils/utils.js';
 import Accordion from '../../ui/controls/Accordion.js';
 import MultiField from '../../ui/controls/MultiField.js';
 import { Input as FormInput } from '../../ui/controls/formControls.js';
@@ -23,6 +23,15 @@ const sortObjects = (obj) => Object.entries(obj).sort((a, b) => {
   // eslint-disable-next-line no-nested-ternary
   return x < y ? -1 : x > y ? 1 : 0;
 });
+
+const getHashConfig = () => {
+  const { hash } = window.location;
+  if (!hash) return null;
+  window.location.hash = '';
+
+  const encodedConfig = hash.startsWith('#') ? hash.substring(1) : hash;
+  return parseEncodedConfig(encodedConfig);
+}
 
 const getInitialState = () => {
   const hashConfig = getHashConfig();
@@ -357,9 +366,9 @@ const PrepopulationPanel = () => html`
 const StylePanel = () => html`
   <${Select} label="Background Theme" prop="style_backgroundTheme" options="${{ white: 'White', dark: 'Dark' }}" />
   <${Select} label="Layout" prop="style_layout" options="${{ column1: '1 Column', column2: '2 Columns' }}" />
-  <${Select} 
+  <${Select}
     label="Title Size"
-    prop="title_size" 
+    prop="title_size"
     options="${{ h1: 'H1', h2: 'H2', h3: 'H3', h4: 'H4', h5: 'H5', h6: 'H6', p: 'P' }}" />
   <${Select} label="Title Alignment" prop="title_align" options="${{ left: 'Left', center: 'Center', right: 'Right' }}" />
   <${Select} label="Custom Theme" prop="style_customTheme" options="${{ none: 'None' }}" />

--- a/libs/blocks/footer/footer.js
+++ b/libs/blocks/footer/footer.js
@@ -1,11 +1,12 @@
 import {
-  analyticsDecorateList,
   createTag,
   decorateAutoBlock,
   getConfig,
   getMetadata,
   loadBlock,
 } from '../../utils/utils.js';
+
+import { analyticsDecorateList } from '../../martech/attributes.js';
 
 import { getSVGsfromFile } from '../share/share.js';
 

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -1,7 +1,9 @@
-import { createTag, loadArea, makeRelative, removeHash } from '../../utils/utils.js';
+import { createTag, loadArea, makeRelative } from '../../utils/utils.js';
 import Tree from '../../utils/tree.js';
 
 const fragMap = {};
+
+const removeHash = (url) => url?.split('#')[0];
 
 const isCircularRef = (href) => [...Object.values(fragMap)]
   .some((tree) => {

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -1,6 +1,4 @@
 import {
-  analyticsDecorateList,
-  analyticsGetLabel,
   createTag,
   decorateSVG,
   getConfig,
@@ -8,6 +6,11 @@ import {
   loadScript,
   makeRelative,
 } from '../../utils/utils.js';
+
+import {
+  analyticsDecorateList,
+  analyticsGetLabel,
+} from '../../martech/attributes.js';
 
 const COMPANY_IMG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.46 118.11"><defs><style>.cls-1{fill:#fa0f00;}</style></defs><polygon class="cls-1" points="84.13 0 133.46 0 133.46 118.11 84.13 0"/><polygon class="cls-1" points="49.37 0 0 0 0 118.11 49.37 0"/><polygon class="cls-1" points="66.75 43.53 98.18 118.11 77.58 118.11 68.18 94.36 45.18 94.36 66.75 43.53"/></svg>';
 const BRAND_IMG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 234"><defs><style>.cls-1{fill:#fa0f00;}.cls-2{fill:#fff;}</style></defs><rect class="cls-1" width="240" height="234" rx="42.5"/><path id="_256" data-name="256" class="cls-2" d="M186.617,175.95037H158.11058a6.24325,6.24325,0,0,1-5.84652-3.76911L121.31715,99.82211a1.36371,1.36371,0,0,0-2.61145-.034l-19.286,45.94252A1.63479,1.63479,0,0,0,100.92626,148h21.1992a3.26957,3.26957,0,0,1,3.01052,1.99409l9.2814,20.65452a3.81249,3.81249,0,0,1-3.5078,5.30176H53.734a3.51828,3.51828,0,0,1-3.2129-4.90437L99.61068,54.14376A6.639,6.639,0,0,1,105.843,50h28.31354a6.6281,6.6281,0,0,1,6.23289,4.14376L189.81885,171.046A3.51717,3.51717,0,0,1,186.617,175.95037Z"/></svg>';

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -4,7 +4,6 @@ import {
   createTag,
   decorateSVG,
   getConfig,
-  getBlockClasses,
   getMetadata,
   loadScript,
   makeRelative,
@@ -30,6 +29,14 @@ const debounce = (func, timeout = 300) => {
     timer = setTimeout(async () => func.apply(this, args), timeout);
   };
 };
+
+function getBlockClasses(className) {
+  const trimDashes = (str) => str.replace(/(^\s*-)|(-\s*$)/g, '');
+  const blockWithVariants = className.split('--');
+  const name = trimDashes(blockWithVariants.shift());
+  const variants = blockWithVariants.map((v) => trimDashes(v));
+  return { name, variants };
+}
 
 class Gnav {
   constructor(body, el) {

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -1,3 +1,6 @@
+const RE_ALPHANUM = /[^0-9a-z]/gi;
+const RE_TRIM_UNDERSCORE = /^_+|_+$/g;
+
 export function decorateBlockAnalytics(blockEl) {
   blockEl.setAttribute('daa-im', 'true');
   blockEl.setAttribute('daa-lh', [...blockEl.classList].join('|'));
@@ -16,3 +19,17 @@ export function decorateLinkAnalytics(textEl, headings) {
     link.setAttribute('daa-ll', str);
   });
 }
+
+export const analyticsGetLabel = (txt) => txt.replaceAll('&', 'and')
+  .replace(RE_ALPHANUM, '_')
+  .replace(RE_TRIM_UNDERSCORE, '');
+
+export const analyticsDecorateList = (li, idx) => {
+  const link = li.firstChild?.nodeName === 'A' && li.firstChild;
+  if (!link) return;
+
+  const label = link.textContent || link.getAttribute('aria-label');
+  if (!label) return;
+
+  link.setAttribute('daa-ll', `${analyticsGetLabel(label)}-${idx + 1}`);
+};

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -298,7 +298,6 @@ export function decorateAutoBlock(a) {
         a.target = '_blank';
         return false;
       }
-      // Fragments
       if (key === 'fragment' && url.hash === '') {
         const { parentElement } = a;
         const { nodeName, innerHTML } = parentElement;
@@ -449,20 +448,14 @@ export async function loadDeferred(area) {
   }
 }
 
-/**
-* Load the Privacy library
-*/
 function loadPrivacy() {
-  // Configure Privacy
   window.fedsConfig = {
     privacy: {
       otDomainId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db',
       footerLinkSelector: '[href="https://www.adobe.com/#openPrivacy"]',
     },
   };
-
-  const env = getConfig().env.name === 'prod' ? '' : 'stage.';
-  loadScript(`https://www.${env}adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js`);
+  loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/privacy-standalone.js');
 }
 
 function initSidekick() {
@@ -524,9 +517,7 @@ export async function loadArea(area = document) {
   await loadDeferred(area);
 }
 
-/**
- * Load everything that impacts performance later.
- */
+// Load everything that impacts performance later.
 export function loadDelayed(delay = 3000) {
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -540,14 +531,6 @@ export function loadDelayed(delay = 3000) {
       }
     }, delay);
   });
-}
-
-export function utf8ToB64(str) {
-  return window.btoa(unescape(encodeURIComponent(str)));
-}
-
-export function b64ToUtf8(str) {
-  return decodeURIComponent(escape(window.atob(str)));
 }
 
 const RE_ALPHANUM = /[^0-9a-z]/gi;
@@ -564,6 +547,9 @@ export const analyticsDecorateList = (li, idx) => {
   link.setAttribute('daa-ll', `${analyticsGetLabel(label)}-${idx + 1}`);
 };
 
+export const utf8ToB64 = (str) => window.btoa(unescape(encodeURIComponent(str)));
+export const b64ToUtf8 = (str) => decodeURIComponent(escape(window.atob(str)));
+
 export function parseEncodedConfig(encodedConfig) {
   try {
     return JSON.parse(b64ToUtf8(decodeURIComponent(encodedConfig)));
@@ -571,37 +557,6 @@ export function parseEncodedConfig(encodedConfig) {
     console.log(e);
   }
   return null;
-}
-
-export const removeHash = (url) => url?.split('#')[0];
-
-export function getHashConfig() {
-  const { hash } = window.location;
-  if (!hash) return null;
-  window.location.hash = '';
-
-  const encodedConfig = hash.startsWith('#') ? hash.substring(1) : hash;
-  return parseEncodedConfig(encodedConfig);
-}
-
-export const isValidUuid = (id) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
-
-export const cloneObj = (obj) => JSON.parse(JSON.stringify(obj));
-
-export function updateObj(obj, defaultObj) {
-  const ds = cloneObj(defaultObj);
-  Object.keys(ds).forEach((key) => {
-    if (obj[key] === undefined) obj[key] = ds[key];
-  });
-  return obj;
-}
-
-export function getBlockClasses(className) {
-  const trimDashes = (str) => str.replace(/(^\s*-)|(-\s*$)/g, '');
-  const blockWithVariants = className.split('--');
-  const name = trimDashes(blockWithVariants.shift());
-  const variants = blockWithVariants.map((v) => trimDashes(v));
-  return { name, variants };
 }
 
 export function createIntersectionObserver({ el, callback, once = true, options = {} }) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -533,20 +533,6 @@ export function loadDelayed(delay = 3000) {
   });
 }
 
-const RE_ALPHANUM = /[^0-9a-z]/gi;
-const RE_TRIM_UNDERSCORE = /^_+|_+$/g;
-export const analyticsGetLabel = (txt) => txt.replaceAll('&', 'and').replace(RE_ALPHANUM, '_').replace(RE_TRIM_UNDERSCORE, '');
-
-export const analyticsDecorateList = (li, idx) => {
-  const link = li.firstChild?.nodeName === 'A' && li.firstChild;
-  if (!link) return;
-
-  const label = link.textContent || link.getAttribute('aria-label');
-  if (!label) return;
-
-  link.setAttribute('daa-ll', `${analyticsGetLabel(label)}-${idx + 1}`);
-};
-
 export const utf8ToB64 = (str) => window.btoa(unescape(encodeURIComponent(str)));
 export const b64ToUtf8 = (str) => decodeURIComponent(escape(window.atob(str)));
 

--- a/test/blocks/caas-config/caas-config.test.html
+++ b/test/blocks/caas-config/caas-config.test.html
@@ -30,7 +30,7 @@
     import { runTests } from '@web/test-runner-mocha';
     import { expect } from '@esm-bundle/chai';
     import { stub } from 'sinon';
-    import init from '../../../libs/blocks/caas-config/caas-config.js';
+    import { default as init, cloneObj, updateObj, getHashConfig } from '../../../libs/blocks/caas-config/caas-config.js';
     import {
       findByLabel,
       tagSelectorDropdownChoose,
@@ -67,8 +67,6 @@
           subtree: true,
         });
       });
-
-    const cloneObj = (obj) => JSON.parse(JSON.stringify(obj));
 
     runTests(async () => {
       await init(document.getElementById('caas-config'));
@@ -251,6 +249,30 @@
         await delay(50);
         const copyTextArea = document.querySelector('.copy-text');
         expect(copyTextArea.value.split('#')[1]).to.equal('eyJhbmFseXRpY3NDb2xsZWN0aW9uTmFtZSI6IiIsImFuYWx5dGljc1RyYWNrSW1wcmVzc2lvbiI6ZmFsc2UsImFuZExvZ2ljVGFncyI6W10sImJvb2ttYXJrSWNvblNlbGVjdCI6IiIsImJvb2ttYXJrSWNvblVuc2VsZWN0IjoiIiwiY2FyZFN0eWxlIjoiaGFsZi1oZWlnaHQiLCJjb2xsZWN0aW9uQnRuU3R5bGUiOiJwcmltYXJ5IiwiY29sbGVjdGlvbk5hbWUiOiIiLCJjb2xsZWN0aW9uU2l6ZSI6IiIsImNvbnRhaW5lciI6IjEyMDBNYXhXaWR0aCIsImNvbnRlbnRUeXBlVGFncyI6W10sImNvdW50cnkiOiJjYWFzOmNvdW50cnkvdXMiLCJkb05vdExhenlMb2FkIjpmYWxzZSwiZGlzYWJsZUJhbm5lcnMiOmZhbHNlLCJkcmFmdERiIjpmYWxzZSwiZW5kcG9pbnQiOiJ3d3cuYWRvYmUuY29tL2NoaW1lcmEtYXBpL2NvbGxlY3Rpb24iLCJlbnZpcm9ubWVudCI6IiIsImV4Y2x1ZGVkQ2FyZHMiOltdLCJleGNsdWRlVGFncyI6W10sImZhbGxiYWNrRW5kcG9pbnQiOiIiLCJmZWF0dXJlZENhcmRzIjpbXSwiZmlsdGVyRXZlbnQiOiIiLCJmaWx0ZXJMb2NhdGlvbiI6ImxlZnQiLCJmaWx0ZXJMb2dpYyI6Im9yIiwiZmlsdGVycyI6W10sImZpbHRlcnNTaG93RW1wdHkiOmZhbHNlLCJndXR0ZXIiOiI0eCIsImluY2x1ZGVUYWdzIjpbXSwibGFuZ3VhZ2UiOiJjYWFzOmxhbmd1YWdlL2VuIiwibGF5b3V0VHlwZSI6IjR1cCIsImxvYWRNb3JlQnRuU3R5bGUiOiJwcmltYXJ5Iiwib25seVNob3dCb29rbWFya2VkQ2FyZHMiOmZhbHNlLCJvckxvZ2ljVGFncyI6W10sInBhZ2luYXRpb25BbmltYXRpb25TdHlsZSI6InBhZ2VkIiwicGFnaW5hdGlvbkVuYWJsZWQiOmZhbHNlLCJwYWdpbmF0aW9uUXVhbnRpdHlTaG93biI6ZmFsc2UsInBhZ2luYXRpb25UeXBlIjoibm9uZSIsInBhZ2luYXRpb25Vc2VUaGVtZTMiOmZhbHNlLCJwbGFjZWhvbGRlclVybCI6IiIsInJlc3VsdHNQZXJQYWdlIjo1LCJzZWFyY2hGaWVsZHMiOltdLCJzZXRDYXJkQm9yZGVycyI6ZmFsc2UsInNob3dCb29rbWFya3NGaWx0ZXIiOmZhbHNlLCJzaG93Qm9va21hcmtzT25DYXJkcyI6ZmFsc2UsInNob3dGaWx0ZXJzIjpmYWxzZSwic2hvd1NlYXJjaCI6ZmFsc2UsInNob3dUb3RhbFJlc3VsdHMiOmZhbHNlLCJzb3J0RGF0ZUFzYyI6ZmFsc2UsInNvcnREYXRlRGVzYyI6ZmFsc2UsInNvcnREZWZhdWx0IjoiZGF0ZURlc2MiLCJzb3J0RW5hYmxlUG9wdXAiOmZhbHNlLCJzb3J0RW5hYmxlUmFuZG9tU2FtcGxpbmciOmZhbHNlLCJzb3J0RXZlbnRTb3J0IjpmYWxzZSwic29ydEZlYXR1cmVkIjpmYWxzZSwic29ydFJhbmRvbSI6ZmFsc2UsInNvcnRSZXNlcnZvaXJQb29sIjoxMDAwLCJzb3J0UmVzZXJ2b2lyU2FtcGxlIjozLCJzb3J0VGl0bGVBc2MiOmZhbHNlLCJzb3J0VGl0bGVEZXNjIjpmYWxzZSwic291cmNlIjpbImhhd2tzIl0sInRhZ3NVcmwiOiJ3d3cuYWRvYmUuY29tL2NoaW1lcmEtYXBpL3RhZ3MiLCJ0YXJnZXRBY3Rpdml0eSI6IiIsInRhcmdldEVuYWJsZWQiOmZhbHNlLCJ0aGVtZSI6ImxpZ2h0ZXN0IiwidG90YWxDYXJkc1RvU2hvdyI6MTAsInVzZUxpZ2h0VGV4dCI6ZmFsc2UsInVzZU92ZXJsYXlMaW5rcyI6ZmFsc2UsInVzZXJJbmZvIjpbXX0=')
+      });
+
+      it('Clones an object', () => {
+        const o = {
+          sortReservoirPool: 1000,
+          source: ['hawks'],
+          tagsUrl: 'www.adobe.com/chimera-api/tags',
+          targetActivity: '',
+          targetEnabled: false,
+        };
+        expect(cloneObj(o)).to.be.eql(o);
+      });
+
+      it('updateObj should add any missing keys to the obj', () => {
+        const allKeys = { a: 'one', b: 2, c: [6, 7, 8] };
+        expect(updateObj({}, allKeys)).to.eql(cloneObj(allKeys));
+        expect(updateObj({ a: 'blah', d: 1234 }, allKeys)).to.eql({ a: 'blah', b: 2, c: [6, 7, 8], d: 1234 });
+      });
+
+      it('Converts Base 64 to UTF-8', () => {
+        const hash = '#eyJjYXJkU3R5bGUiOiJmdWxsLWNhcmQiLCJjb2xsZWN0aW9uQnRuU3R5bGUiOiJwcmltYXJ5IiwiY29udGFpbmVyIjoiODNQZXJjZW50IiwiY291bnRyeSI6ImNhYXM6Y291bnRyeS91cyIsImNvbnRlbnRUeXBlVGFncyI6W10sImRpc2FibGVCYW5uZXJzIjpmYWxzZSwiZHJhZnREYiI6ZmFsc2UsImd1dHRlciI6IjR4IiwibGFuZ3VhZ2UiOiJjYWFzOmxhbmd1YWdlL2VuIiwibGF5b3V0VHlwZSI6IjN1cCIsImxvYWRNb3JlQnRuU3R5bGUiOiJwcmltYXJ5IiwicGFnaW5hdGlvbkFuaW1hdGlvblN0eWxlIjoicGFnZWQiLCJwYWdpbmF0aW9uRW5hYmxlZCI6ZmFsc2UsInBhZ2luYXRpb25RdWFudGl0eVNob3duIjpmYWxzZSwicGFnaW5hdGlvblVzZVRoZW1lMyI6ZmFsc2UsInBhZ2luYXRpb25UeXBlIjoibm9uZSIsInJlc3VsdHNQZXJQYWdlIjoiMSIsInNldENhcmRCb3JkZXJzIjpmYWxzZSwic2hvd0ZpbHRlcnMiOmZhbHNlLCJzaG93U2VhcmNoIjpmYWxzZSwic29ydERlZmF1bHQiOiJ0aXRsZURlc2MiLCJzb3J0RW5hYmxlUG9wdXAiOmZhbHNlLCJzb3J0RW5hYmxlUmFuZG9tU2FtcGxpbmciOmZhbHNlLCJzb3J0UmVzZXJ2b2lyU2FtcGxlIjozLCJzb3J0UmVzZXJ2b2lyUG9vbCI6MTAwMCwic291cmNlIjpbImhhd2tzIl0sInRoZW1lIjoibGlnaHRlc3QiLCJ0b3RhbENhcmRzVG9TaG93IjoiMyIsInVzZUxpZ2h0VGV4dCI6ZmFsc2V9';
+        window.location.hash = hash;
+        const hashConfig = getHashConfig();
+        expect(hashConfig.cardStyle).to.equal('half-height');
       });
 
     });

--- a/test/blocks/caas/mocks/utils.js
+++ b/test/blocks/caas/mocks/utils.js
@@ -1,26 +1,12 @@
 import { stub } from 'sinon';
 
-export const isValidUuid = () => true;
-
-export const getHashConfig = stub();
-
 export const getConfig = () => ({});
-
-export const cloneObj = (obj) => JSON.parse(JSON.stringify(obj));
 
 export const loadStyle = stub();
 
 export const loadScript = stub();
 
 export const utf8ToB64 = (str) => window.btoa(unescape(encodeURIComponent(str)));
-
-export function updateObj(obj, defaultObj) {
-  const ds = cloneObj(defaultObj);
-  Object.keys(ds).forEach((key) => {
-    if (obj[key] === undefined) obj[key] = ds[key];
-  });
-  return obj;
-}
 
 export function createIntersectionObserver({ el, callback, once = true, options = {} }) {
   // fire immediately

--- a/test/utils/getUuid.test.js
+++ b/test/utils/getUuid.test.js
@@ -2,7 +2,7 @@
 
 import { expect } from '@esm-bundle/chai';
 import getUuid from '../../../libs/utils/getUuid.js';
-import { isValidUuid } from '../../../libs/utils/utils.js';
+import { isValidUuid } from '../../../libs/blocks/caas-config/caas-config.js';
 
 const LONG_STRING = 'go milo'.repeat(2000);
 describe('Get a UUID from a string', () => {

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -5,8 +5,6 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 
-const hash = '#eyJjYXJkU3R5bGUiOiJmdWxsLWNhcmQiLCJjb2xsZWN0aW9uQnRuU3R5bGUiOiJwcmltYXJ5IiwiY29udGFpbmVyIjoiODNQZXJjZW50IiwiY291bnRyeSI6ImNhYXM6Y291bnRyeS91cyIsImNvbnRlbnRUeXBlVGFncyI6W10sImRpc2FibGVCYW5uZXJzIjpmYWxzZSwiZHJhZnREYiI6ZmFsc2UsImd1dHRlciI6IjR4IiwibGFuZ3VhZ2UiOiJjYWFzOmxhbmd1YWdlL2VuIiwibGF5b3V0VHlwZSI6IjN1cCIsImxvYWRNb3JlQnRuU3R5bGUiOiJwcmltYXJ5IiwicGFnaW5hdGlvbkFuaW1hdGlvblN0eWxlIjoicGFnZWQiLCJwYWdpbmF0aW9uRW5hYmxlZCI6ZmFsc2UsInBhZ2luYXRpb25RdWFudGl0eVNob3duIjpmYWxzZSwicGFnaW5hdGlvblVzZVRoZW1lMyI6ZmFsc2UsInBhZ2luYXRpb25UeXBlIjoibm9uZSIsInJlc3VsdHNQZXJQYWdlIjoiMSIsInNldENhcmRCb3JkZXJzIjpmYWxzZSwic2hvd0ZpbHRlcnMiOmZhbHNlLCJzaG93U2VhcmNoIjpmYWxzZSwic29ydERlZmF1bHQiOiJ0aXRsZURlc2MiLCJzb3J0RW5hYmxlUG9wdXAiOmZhbHNlLCJzb3J0RW5hYmxlUmFuZG9tU2FtcGxpbmciOmZhbHNlLCJzb3J0UmVzZXJ2b2lyU2FtcGxlIjozLCJzb3J0UmVzZXJ2b2lyUG9vbCI6MTAwMCwic291cmNlIjpbImhhd2tzIl0sInRoZW1lIjoibGlnaHRlc3QiLCJ0b3RhbENhcmRzVG9TaG93IjoiMyIsInVzZUxpZ2h0VGV4dCI6ZmFsc2V9';
-
 const utils = {};
 
 const config = {
@@ -140,32 +138,9 @@ describe('Utils', () => {
     expect(b64).to.equal('hello world');
   });
 
-  it('Converts Base 64 to UTF-8', () => {
-    window.location.hash = hash;
-    const hashConfig = utils.getHashConfig();
-    expect(hashConfig.cardStyle).to.equal('full-card');
-  });
-
   it('Successfully dies parsing a bad config', () => {
     utils.parseEncodedConfig('error');
     expect(console.log.args[0][0].name).to.equal('InvalidCharacterError');
-  });
-
-  it('updateObj should add any missing keys to the obj', () => {
-    const allKeys = { a: 'one', b: 2, c: [6, 7, 8] };
-    expect(utils.updateObj({}, allKeys)).to.eql(utils.cloneObj(allKeys));
-    expect(utils.updateObj({ a: 'blah', d: 1234 }, allKeys)).to.eql({ a: 'blah', b: 2, c: [6, 7, 8], d: 1234 });
-  });
-
-  it('Clones an object', () => {
-    const o = {
-      sortReservoirPool: 1000,
-      source: ['hawks'],
-      tagsUrl: 'www.adobe.com/chimera-api/tags',
-      targetActivity: '',
-      targetEnabled: false,
-    };
-    expect(utils.cloneObj(o)).to.be.eql(o);
   });
 
   it('Decorates no nav', async () => {


### PR DESCRIPTION
Move funcs used in only one place out of utils

Trying to keep utils as small as possible.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://c3-utilcleanup--milo--adobecom.hlx.page/?martech=off
