### PR TITLE
MWPW-120801 - Fix US Font

### DIFF
--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -27,7 +27,7 @@ const locales = {
   la: { ietf: 'es-LA', tk: 'oln4yqj.css' },
   mx: { ietf: 'es-MX', tk: 'oln4yqj.css' },
   pe: { ietf: 'es-PE', tk: 'oln4yqj.css' },
-  '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+  '': { ietf: 'en-US', tk: 'aaz7dvd.css' },
   // EMEA
   africa: { ietf: 'en', tk: 'pps7abe.css' },
   be_fr: { ietf: 'fr-BE', tk: 'vrk5vyv.css' },
@@ -97,7 +97,7 @@ const locales = {
   jp: { ietf: 'ja-JP', tk: 'dvg6awq' },
   kr: { ietf: 'ko-KR', tk: 'qjs5sfm' },
   // Langstore Support.
-  langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
+  langstore: { ietf: 'en-US', tk: 'aaz7dvd.css' },
 };
 
 const config = {


### PR DESCRIPTION
* Fix Adobe Clean font for en-US

Resolves: [MWPW-120801](https://jira.corp.adobe.com/browse/MWPW-120801)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/text-center?martech=off
- After: https://methomas-adobe-clean-us--milo--adobecom.hlx.page/drafts/methomas/text-center?martech=off

Verification:

- Inspect text in Safari, open the details sidebar, click on the Font tab, verify the name
- To view in Chrome or Firefox, use browserstack so it won't pick up local fonts.

<img width="1920" alt="Screen Shot 2022-11-14 at 3 49 46 PM (2)" src="https://user-images.githubusercontent.com/19690988/202001911-76379272-dab0-45f8-9954-7c85c0b53983.png">
