### PR TITLE
Fixed language specific paths for taxonomy and article-feed

### DIFF
--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -1,5 +1,4 @@
 import {
-  getPrefix,
   stamp,
   getTaxonomyModule,
   loadTaxonomy,
@@ -73,7 +72,7 @@ export async function fetchBlogArticleIndex() {
 
   if (blogIndex.complete) return (blogIndex);
 
-  return fetch(`${getPrefix()}/query-index.json?limit=${pageSize}&offset=${blogIndex.offset}`)
+  return fetch(`${getConfig().locale.contentRoot}/query-index.json?limit=${pageSize}&offset=${blogIndex.offset}`)
     .then((response) => response.json())
     .then((json) => {
       const complete = (json.limit + json.offset) === json.total;

--- a/libs/blocks/article-feed/article-helpers.js
+++ b/libs/blocks/article-feed/article-helpers.js
@@ -115,12 +115,6 @@ function loadArticleTaxonomy(article) {
   return clonedArticle;
 }
 
-/**
- * Returns the language dependent root path
- * @returns {string} The computed root path
- */
-export const getPrefix = () => (getConfig().locale?.prefix ? `/${getConfig().locale?.prefix}` : '');
-
 export function getTaxonomyModule() {
   return taxonomyModule;
 }

--- a/libs/scripts/taxonomy.js
+++ b/libs/scripts/taxonomy.js
@@ -146,6 +146,8 @@ function parseTaxonomyJson(data, root) {
   });
 }
 
+const formatPath = (str) => str?.replace(/^\/+/g, '').replace(/\/+$/, '');
+
 /**
  * Returns the taxonomy object
  * @param {string} config Environment's configurations
@@ -154,7 +156,9 @@ function parseTaxonomyJson(data, root) {
  * @returns {object} The taxonomy object
  */
 export default async (config, route, target) => {
-  const root = route || config.locale.contentRoot;
+  const root = route
+        ? `${config.locale.contentRoot}/${formatPath(route)}` 
+        : config.locale.contentRoot;
   const path = target || `${config.locale.contentRoot}/taxonomy.json`;
 
   return fetchTaxonomy(path)

--- a/libs/scripts/taxonomy.js
+++ b/libs/scripts/taxonomy.js
@@ -93,7 +93,7 @@ function parseTaxonomyJson(data, root) {
         return `${current.origin}${u.pathname}`;
       }
 
-      return `${generateUri(root)}/${generateUri(name)}`;
+      return `${root}/${generateUri(name)}`;
     }, null);
 
     const hidden = !!row[TAXONOMY_FIELDS.hidden]?.trim();


### PR DESCRIPTION
* Fixed language specific paths for taxonomy and article-feed
* `query-index.json` path was pointing to the root english folder on other languages
* Taxonomy topics sub-pages was pointing to the root english page on other languages

Resolves: [Article Feed Block](https://github.com/orgs/adobecom/projects/1/views/1)

**Test URLs:**
- Before: https://main--blog--adobecom.hlx.page/de/drafts/article-feed?martech=off
- After: https://main--blog--adobecom.hlx.page/de/drafts/article-feed?martech=off&milolibs=article-feed-locale
