### PR TITLE
MWPW-120503 - Move PDF Viewer Config

### DIFF
--- a/libs/blocks/pdf-viewer/pdf-viewer.js
+++ b/libs/blocks/pdf-viewer/pdf-viewer.js
@@ -2,16 +2,9 @@ import { createTag, getConfig, loadScript } from '../../utils/utils.js';
 
 const API_SOURCE_URL = 'https://documentcloud.adobe.com/view-sdk/viewer.js';
 const PDF_RENDER_DIV_ID = 'adobe-dc-view';
-const {
-  env,
-  pdfViewerClientIdStage,
-  pdfViewerClientIdProd,
-  pdfViewerReportSuiteQA,
-  pdfViewerReportSuiteProd,
-} = getConfig();
+const { env } = getConfig();
 
 const init = async (a) => {
-  const isProdEnv = env.name === 'prod';
   const url = a?.href;
 
   if (!url) return;
@@ -27,13 +20,19 @@ const init = async (a) => {
   await loadScript(API_SOURCE_URL);
   const fileName = decodeURI(url?.split('/').pop());
 
+  console.log({
+    clientId: env.consumer?.pdfViewerClientId || env.pdfViewerClientId,
+    divId: `${PDF_RENDER_DIV_ID}_${idSuffix}`,
+    reportSuiteId: env.consumer?.pdfViewerReportSuite || env.pdfViewerReportSuite,
+  });
+
   /* c8 ignore next 16 */
   const handleViewSdkReady = () => {
     const adobeDCView = new AdobeDC.View(
       {
-        clientId: isProdEnv ? pdfViewerClientIdProd : pdfViewerClientIdStage,
+        clientId: env.consumer?.pdfViewerClientId || env.pdfViewerClientId,
         divId: `${PDF_RENDER_DIV_ID}_${idSuffix}`,
-        reportSuiteId: isProdEnv ? pdfViewerReportSuiteProd : pdfViewerReportSuiteQA,
+        reportSuiteId: env.consumer?.pdfViewerReportSuite || env.pdfViewerReportSuite,
       },
     );
     adobeDCView.previewFile(

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -104,8 +104,6 @@ const config = {
   imsClientId: 'milo',
   codeRoot: '/libs',
   locales,
-  pdfViewerClientIdStage: '600a4521c23d4c7eb9c7b039bee534a0',
-  pdfViewerClientIdProd: '3c0a5ddf2cc04d3198d9e48efc390fa9',
   marketoBaseURL: '//app-aba.marketo.com',
   marketoFormID: '1761',
   marketoMunchkinID: '345-TTI-184',

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -53,6 +53,7 @@ const ENVS = {
   local: {
     name: 'local',
     edgeConfigId: '8d2805dd-85bf-4748-82eb-f99fdad117a6',
+    pdfViewerClientId: '600a4521c23d4c7eb9c7b039bee534a0',
   },
   stage: {
     name: 'stage',
@@ -61,6 +62,7 @@ const ENVS = {
     adminconsole: 'stage.adminconsole.adobe.com',
     account: 'stage.account.adobe.com',
     edgeConfigId: '8d2805dd-85bf-4748-82eb-f99fdad117a6',
+    pdfViewerClientId: '600a4521c23d4c7eb9c7b039bee534a0',
   },
   prod: {
     name: 'prod',
@@ -69,6 +71,7 @@ const ENVS = {
     adminconsole: 'adminconsole.adobe.com',
     account: 'account.adobe.com',
     edgeConfigId: '2cba807b-7430-41ae-9aac-db2b0da742d5',
+    pdfViewerClientId: '3c0a5ddf2cc04d3198d9e48efc390fa9',
   },
 };
 const SUPPORTED_RICH_RESULTS_TYPES = ['NewsArticle'];

--- a/test/blocks/pdf-viewer/pdf-viewer.test.js
+++ b/test/blocks/pdf-viewer/pdf-viewer.test.js
@@ -5,21 +5,9 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { setConfig } from '../../../libs/utils/utils.js';
 
-const config = {
-  env: 'stage',
-  pdfViewerClientIdStage: '600a4521c23d4c7eb9c7b039bee534a0',
-};
-
-setConfig(config);
-
-let pdfViewer;
+const { default: pdfViewer, getPdfConfig } = await import('../../../libs/blocks/pdf-viewer/pdf-viewer.js');
 
 describe('PDF Viewer', () => {
-  before(async () => {
-    const mod = await import('../../../libs/blocks/pdf-viewer/pdf-viewer.js');
-    pdfViewer = mod.default;
-  });
-
   it('does not render when there are no pdf links', async () => {
     await pdfViewer(undefined);
     expect(document.querySelectorAll('.pdf-container').length).to.equal(0);
@@ -35,5 +23,22 @@ describe('PDF Viewer', () => {
       expect(document.querySelector('iframe')).to.exist;
     });
     expect(document.querySelectorAll('.pdf-container').length).to.equal(2);
+  });
+
+  it('gets correct config for milo', () => {
+    setConfig({});
+    expect(getPdfConfig()).to.eql({ clientId: '600a4521c23d4c7eb9c7b039bee534a0', reportSuiteId: undefined });
+  });
+
+  it('gets correct config for client', () => {
+    const consumer = {
+      pdfViewerClientId: '3b685312b5784de6943647df19f1f492',
+      pdfViewerReportSuite: 'adbadobedxqa',
+    };
+    setConfig({
+      local: consumer,
+    });
+
+    expect(getPdfConfig()).to.eql({ clientId: consumer.pdfViewerClientId, reportSuiteId: consumer.pdfViewerReportSuite });
   });
 });


### PR DESCRIPTION
* Move PDF Viewer client ids into env-specific config
* Add support for hlx.live domain, which cannot share client id with hlx.page

Resolves: [MWPW-120503](https://jira.corp.adobe.com/browse/MWPW-120503)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/pdf-viewsdk?martech=off
- After: https://methomas-move-pdf-config--milo--adobecom.hlx.page/drafts/methomas/pdf-viewsdk?martech=off

Note: With the feature branch url, the PDF will show an error "Preview not available: This application domain is not authorized..." because the Viewer's client id is specifically for "main--milo--adobecom.hlx.page". We'll verify once it's merge into main. Any other errors should be flagged though.