### PR TITLE
Fix Marketo form scroll on iOS

### DIFF
--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -103,6 +103,13 @@ const readyForm = (error, form, formData) => {
   const formTexts = formEl.querySelectorAll('.mktoHtmlText');
   formTexts[formTexts.length - 1].closest('.mktoFormRow').classList.add('marketo-privacy');
 
+  formEl.addEventListener('focus', (e) => {
+    if (e.target.type === 'submit') return;
+    const pageTop = document.querySelector('header')?.offsetHeight ?? 0;
+    const targetPosition = e.target?.getBoundingClientRect().top ?? 0;
+    const offsetPosition = targetPosition + window.pageYOffset - pageTop - window.innerHeight /2 ;
+    window.scrollTo(0, offsetPosition);
+  }, true);
   form.onValidate((success) => formValidate(form, success, error, errorMessage));
   form.onSuccess(() => formSuccess(form, redirectUrl));
 };

--- a/test/blocks/marketo/marketo.test.js
+++ b/test/blocks/marketo/marketo.test.js
@@ -64,6 +64,16 @@ describe('marketo', () => {
     expect(error.classList.contains('alert')).to.be.true;
   });
 
+  it('marketo field error visible', async () => {
+    const button = await waitForElement('.marketo button');
+    button.click();
+
+    const firstField = document.querySelector('.mktoField');
+    const bounding = firstField.getBoundingClientRect();
+
+    expect(bounding.top >= 0 && bounding.bottom <= window.innerHeight).to.be.true;
+  });
+
   it('validate marketo fields success', async () => {
     const error = await waitForElement('.marketo-error');
     const errorMessage = 'There are some fields that require your attention';


### PR DESCRIPTION
* Fixes Marketo forms field with errors not getting scrolled into view on iOS devices.
* Places field in middle of screen to account for Android shift when opening keyboard.

![image](https://user-images.githubusercontent.com/681036/202572619-0cb17a7c-0870-4af2-a05b-fa714f46d5bb.png)

Resolves: [MWPW-121127](https://jira.corp.adobe.com/browse/MWPW-121127)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/bmarshal/marketo-example?martech=off
- After: https://bmarshal-marketo-scroll--milo--adobecom.hlx.page/drafts/bmarshal/marketo-example?martech=off
