### PR TITLE
Removing whitespace for internal campaign id.

### DIFF
--- a/libs/blocks/faas/utils.js
+++ b/libs/blocks/faas/utils.js
@@ -279,7 +279,7 @@ export const makeFaasConfig = (targetState) => {
     q: {},
     p: {
       js: {
-        36: targetState.pjs36 || defaultState.p.js[36],
+        36: targetState.pjs36.trim() || defaultState.p.js[36],
         39: targetState.pjs39 || defaultState.p.js[39],
         77: 1,
         78: 1,

--- a/libs/blocks/faas/utils.js
+++ b/libs/blocks/faas/utils.js
@@ -279,7 +279,7 @@ export const makeFaasConfig = (targetState) => {
     q: {},
     p: {
       js: {
-        36: targetState.pjs36.trim() || defaultState.p.js[36],
+        36: targetState.pjs36?.trim() || defaultState.p.js[36],
         39: targetState.pjs39 || defaultState.p.js[39],
         77: 1,
         78: 1,


### PR DESCRIPTION
Resolves: [MWPW-121015](https://jira.corp.adobe.com/browse/MWPW-121015)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/faas?env=qa
- After: https://faas-fix--milo--adobecom.hlx.page/tools/faas?env=qa

QA note: Open the inspect and search for `faas-form-setting` then check if this empty space is removed for internal campaign id.
<img width="931" alt="Screen Shot 2022-11-18 at 10 56 17 AM" src="https://user-images.githubusercontent.com/55804872/202771388-175c5b81-cc16-4198-a191-1d90509fff0e.png">


