### PR TITLE
MWPW-121295 - Tabs block authoring bugs

### DIFF
--- a/libs/blocks/tabs/tabs.css
+++ b/libs/blocks/tabs/tabs.css
@@ -110,7 +110,20 @@
 
 .tabs .tabContent {
   padding: var(--spacing-s) 0;
-  border-bottom: 1px solid var(--tabs-border-color)
+  border-bottom: 1px solid var(--tabs-border-color);
+}
+
+.tabContent [role='tabpanel'] .section {
+  position: relative;
+}
+
+.tabContent [role='tabpanel'] .section picture.section-background {
+  z-index: 0;
+}
+
+.tabContent [role='tabpanel'] .section > .content {
+  z-index: 1;
+  position: relative;
 }
 
 /* contained tabs content */

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -146,13 +146,16 @@ const init = (e) => {
   allSections.forEach((e, i) => {
     const sectionMetadata = e.querySelector(':scope > .section-metadata');
     if (!sectionMetadata) return;
-    const metadata = sectionMetadata.querySelectorAll(':scope > div > div');
-    if (metadata[0].textContent === 'tab') {
-      const metaValue = getStringKeyName(metadata[1].textContent);
-      const section = sectionMetadata.closest('.section');
-      const assocTabItem = document.getElementById(`tab-panel-${initCount}-${metaValue}`);
-      if (assocTabItem) assocTabItem.append(section);
-    }
+    const metadatas = sectionMetadata.querySelectorAll(':scope > div');
+    metadatas.forEach((data) => {
+      const rowKey = getStringKeyName(data.children[0].textContent);
+      if (rowKey === 'tab') {
+        const metaValue = getStringKeyName(data.children[1].textContent);
+        const section = sectionMetadata.closest('.section');
+        const assocTabItem = document.getElementById(`tab-panel-${initCount}-${metaValue}`);
+        if (assocTabItem) assocTabItem.append(section);
+      }
+    });
   });
   initTabs(e, config);
   initCount++;

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -146,16 +146,14 @@ const init = (e) => {
   allSections.forEach((e, i) => {
     const sectionMetadata = e.querySelector(':scope > .section-metadata');
     if (!sectionMetadata) return;
-    const metadatas = sectionMetadata.querySelectorAll(':scope > div');
-    metadatas.forEach((data) => {
-      const rowKey = getStringKeyName(data.children[0].textContent);
-      if (rowKey === 'tab') {
-        const metaValue = getStringKeyName(data.children[1].textContent);
+    const metadata = sectionMetadata.querySelectorAll(':scope > div');
+    [...metadata].filter((d) => getStringKeyName(d.children[0].textContent) === 'tab')
+      .map((d) => {
+        const metaValue = getStringKeyName(d.children[1].textContent);
         const section = sectionMetadata.closest('.section');
         const assocTabItem = document.getElementById(`tab-panel-${initCount}-${metaValue}`);
         if (assocTabItem) assocTabItem.append(section);
-      }
-    });
+      });
   });
   initTabs(e, config);
   initCount++;


### PR DESCRIPTION
Addressed a few bugs that were reported w/ the `tabs` block. 
* Section metadata keyword reference is case sensitive
* Section metadata tab row only works when it's in the first table row
* Section metadata background has a z-index issue when used inside tab content

Resolves: [MWPW-121295](https://jira.corp.adobe.com/browse/MWPW-121295)

**Test URLs:**

- [Before](https://main--milo--adobecom.hlx.page/drafts/rparrish/tabs-content-model?martech=off)
- [After](https://rparrish-tabs-bug--milo--adobecom.hlx.page/drafts/rparrish/tabs-content-model?martech=off)
