### PR TITLE
[MWPW-121449] Search dropdown width between 1200-1400px

### DIFF
--- a/libs/blocks/gnav/gnav.css
+++ b/libs/blocks/gnav/gnav.css
@@ -1136,7 +1136,6 @@ header .app-launcher {
 
   .gnav-search-results {
     margin: 0 auto;
-    max-width: 1400px;
   }
 
   .gnav-profile {
@@ -1152,7 +1151,8 @@ header .app-launcher {
 @media (min-width: 1200px) {
   .gnav-wrapper nav.gnav,
   .gnav-wrapper .breadcrumbs ul,
-  .gnav-search.is-open .gnav-search-field {
+  .gnav-search.is-open .gnav-search-field,
+  .gnav-search.is-open .gnav-search-results {
     max-width: 1200px;
   }
 }
@@ -1160,7 +1160,8 @@ header .app-launcher {
 @media (min-width: 1440px) {
   .gnav-wrapper nav.gnav,
   .gnav-wrapper .breadcrumbs ul,
-  .gnav-search.is-open .gnav-search-field {
+  .gnav-search.is-open .gnav-search-field,
+  .gnav-search.is-open .gnav-search-results {
     max-width: 1400px;
   }
 }


### PR DESCRIPTION
## Description
This fixes a width inconsistency issue for the search results dropdown between `1200px` and `1400px`.

## Screenshots
**Before**
<img width="1287" alt="Dropdown width insconsistent" src="https://user-images.githubusercontent.com/11267498/203066365-1353bff4-fdaa-415d-b550-78729b0b5edc.png">

**After**
<img width="1287" alt="Dropdown width consistent" src="https://user-images.githubusercontent.com/11267498/203066927-70e4266a-56d6-47bf-a539-df728300616a.png">

## JIRA issue
[MWPW-121449](https://jira.corp.adobe.com/browse/MWPW-121449)

## Test URLs
- Before: https://main--milo--adobecom.hlx.page/drafts/ramuntea/hello-milo?martech=off
- After: https://consistent-search-dropdown-width--milo--overmyheadandbody.hlx.page/drafts/ramuntea/hello-milo?martech=off