### PR TITLE
Fix lana bug found in MWPW-121954

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -41,7 +41,7 @@
   }
 
   function log(msg, options) {
-    msg = msg && msg.stack ? msg.stack : msg;
+    msg = msg && msg.stack ? msg.stack : (msg || '');
     if (msg.length > MSG_LIMIT) {
       msg = msg.slice(0, MSG_LIMIT) + '<trunc>';
     }

--- a/test/utils/lana.test.js
+++ b/test/utils/lana.test.js
@@ -76,6 +76,21 @@ describe('LANA', () => {
     Promise.reject('Promise Rejection');
   });
 
+  it('Catches errors without a message', (done) => {
+    const testCallback = () => {
+      window.removeEventListener('unhandledrejection', testCallback);
+      expect(xhrRequests.length).to.equal(1);
+      expect(xhrRequests[0].method).to.equal('GET');
+      expect(xhrRequests[0].url).to.equal(
+        'https://lana.adobeio.com/?m=&c=testClientId&s=100&t=i',
+      );
+      done();
+    };
+    window.addEventListener('unhandledrejection', testCallback);
+    /* eslint-disable-next-line prefer-promise-reject-errors */
+    Promise.reject();
+  });
+
   it('Will truncate the message', () => {
     const longMsg = 'm'.repeat(2100);
     const expectedMsg = `${'m'.repeat(2000)}%3Ctrunc%3E`;


### PR DESCRIPTION
### Description
If a promised has been rejected without a reason, the lana code will currently throw a JS error. IMO it still makes sense to log the error to get an indication of which pages have a lot of errors.

Resolves: [121954](https://jira.corp.adobe.com/browse/MWPW-121954)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://MWPW-121954-lana-fix--milo--adobecom.hlx.page/?martech=off
