### PR TITLE
MWPW-120796: Link Transformation Support for Relative and Absolute Links

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -122,7 +122,7 @@ export function processMarkData(series, xUnit) {
 }
 
 export async function fetchData(link) {
-  const resp = await fetch(link.href);
+  const resp = await fetch(link.href.toLowerCase());
 
   if (!resp.ok) return {};
 

--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -1,4 +1,4 @@
-import { localizeLink, loadScript, getConfig } from '../../utils/utils.js';
+import { loadScript, getConfig } from '../../utils/utils.js';
 import {
   throttle,
   parseValue,
@@ -122,8 +122,7 @@ export function processMarkData(series, xUnit) {
 }
 
 export async function fetchData(link) {
-  const path = localizeLink(link.href);
-  const resp = await fetch(path.toLowerCase());
+  const resp = await fetch(link.href);
 
   if (!resp.ok) return {};
 

--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -1,4 +1,4 @@
-import { makeRelative, loadScript, getConfig } from '../../utils/utils.js';
+import { localizeLink, loadScript, getConfig } from '../../utils/utils.js';
 import {
   throttle,
   parseValue,
@@ -122,7 +122,7 @@ export function processMarkData(series, xUnit) {
 }
 
 export async function fetchData(link) {
-  const path = makeRelative(link.href);
+  const path = localizeLink(link.href);
   const resp = await fetch(path.toLowerCase());
 
   if (!resp.ok) return {};

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -1,4 +1,4 @@
-import { createTag, loadArea, makeRelative } from '../../utils/utils.js';
+import { createTag, loadArea, localizeLink } from '../../utils/utils.js';
 import Tree from '../../utils/tree.js';
 
 const fragMap = {};
@@ -13,23 +13,23 @@ const isCircularRef = (href) => [...Object.values(fragMap)]
 
 const updateFragMap = (fragment, a, href) => {
   const fragLinks = [...fragment.querySelectorAll('a')]
-    .filter((link) => makeRelative(link.href).includes('/fragments/'));
+    .filter((link) => localizeLink(link.href).includes('/fragments/'));
   if (!fragLinks.length) return;
 
   if (document.body.contains(a)) { // is fragment on page (not nested)
     fragMap[href] = new Tree(href);
-    fragLinks.forEach((link) => fragMap[href].insert(href, makeRelative(removeHash(link.href))));
+    fragLinks.forEach((link) => fragMap[href].insert(href, localizeLink(removeHash(link.href))));
   } else {
     Object.values(fragMap).forEach((tree) => {
       if (tree.find(href)) {
-        fragLinks.forEach((link) => tree.insert(href, makeRelative(removeHash(link.href))));
+        fragLinks.forEach((link) => tree.insert(href, localizeLink(removeHash(link.href))));
       }
     });
   }
 };
 
 export default async function init(a, parent) {
-  const relHref = makeRelative(a.href);
+  const relHref = localizeLink(a.href);
   if (isCircularRef(relHref)) {
     console.log(`ERROR: Fragment Circular Reference loading ${a.href}`);
     return;

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -3,7 +3,7 @@ import Tree from '../../utils/tree.js';
 
 const fragMap = {};
 
-const removeHash = (url) => url?.split('#')[0];
+const removeHash = (url) => url?.endsWith('#_dnt') ? url : url?.split('#')[0];
 
 const isCircularRef = (href) => [...Object.values(fragMap)]
   .some((tree) => {

--- a/libs/blocks/gnav/gnav-appLauncher.js
+++ b/libs/blocks/gnav/gnav-appLauncher.js
@@ -1,4 +1,4 @@
-import { createTag, makeRelative } from '../../utils/utils.js';
+import { createTag, localizeLink } from '../../utils/utils.js';
 
 const WAFFLE_ICON = '<svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M10 10H2V3a1 1 0 0 1 1-1h7zm4-8h8v8h-8zm20 8h-8V2h7a1 1 0 0 1 1 1zM2 14h8v8H2zm12 0h8v8h-8zm12 0h8v8h-8zM10 34H3a1 1 0 0 1-1-1v-7h8zm4-8h8v8h-8zm19 8h-7v-8h8v7a1 1 0 0 1-1 1z"></path></svg>';
 
@@ -32,7 +32,7 @@ function decorateAppsMenu(profileEl, appsDom, toggle) {
       target: '_blank',
     });
 
-    anchor.href = makeRelative(anchor.href, true);
+    anchor.href = localizeLink(anchor.href, true);
     li.replaceChildren();
     link.append(image, title);
     li.appendChild(link);
@@ -51,8 +51,8 @@ export default async function getApps(profileEl, appLauncherBlock, toggle) {
   gnav.classList.add('has-apps');
 
   const appsLink = appLauncherBlock.querySelector('a');
-  appsLink.href = makeRelative(appsLink.href, true);
-  
+  appsLink.href = localizeLink(appsLink.href, true);
+
   const path = appsLink.href;
   const resp = await fetch(`${path}.plain.html`);
   if (!resp.ok) return null;

--- a/libs/blocks/gnav/gnav-appLauncher.js
+++ b/libs/blocks/gnav/gnav-appLauncher.js
@@ -1,4 +1,4 @@
-import { createTag, localizeLink } from '../../utils/utils.js';
+import { createTag } from '../../utils/utils.js';
 
 const WAFFLE_ICON = '<svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M10 10H2V3a1 1 0 0 1 1-1h7zm4-8h8v8h-8zm20 8h-8V2h7a1 1 0 0 1 1 1zM2 14h8v8H2zm12 0h8v8h-8zm12 0h8v8h-8zM10 34H3a1 1 0 0 1-1-1v-7h8zm4-8h8v8h-8zm19 8h-7v-8h8v7a1 1 0 0 1-1 1z"></path></svg>';
 
@@ -32,7 +32,6 @@ function decorateAppsMenu(profileEl, appsDom, toggle) {
       target: '_blank',
     });
 
-    anchor.href = localizeLink(anchor.href, true);
     li.replaceChildren();
     link.append(image, title);
     li.appendChild(link);
@@ -51,7 +50,6 @@ export default async function getApps(profileEl, appLauncherBlock, toggle) {
   gnav.classList.add('has-apps');
 
   const appsLink = appLauncherBlock.querySelector('a');
-  appsLink.href = localizeLink(appsLink.href, true);
 
   const path = appsLink.href;
   const resp = await fetch(`${path}.plain.html`);

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -4,7 +4,7 @@ import {
   getConfig,
   getMetadata,
   loadScript,
-  makeRelative,
+  localizeLink,
 } from '../../utils/utils.js';
 
 import {
@@ -155,7 +155,7 @@ class Gnav {
 
   decorateLogo = () => {
     const logo = this.body.querySelector('.adobe-logo a');
-    logo.href = makeRelative(logo.href, true);
+    logo.href = localizeLink(logo.href);
     logo.classList.add('gnav-logo');
     logo.setAttribute('aria-label', logo.textContent);
     logo.setAttribute('daa-ll', 'Logo');
@@ -175,7 +175,7 @@ class Gnav {
 
   buildMainNav = (mainNav, navLinks) => {
     navLinks.forEach((navLink, idx) => {
-      navLink.href = makeRelative(navLink.href, true);
+      navLink.href = localizeLink(navLink.href);
       const navItem = createTag('div', { class: 'gnav-navitem' });
       const navBlock = navLink.closest('.large-menu');
       const menu = navLink.closest('div');
@@ -225,7 +225,7 @@ class Gnav {
       const subtitle = linkGroup.querySelector('p:last-of-type') || '';
       const titleWrapper = createTag('div');
       titleWrapper.className = 'link-group-title';
-      anchor.href = makeRelative(anchor.href, true);
+      anchor.href = localizeLink(anchor.href);
       const link = createTag('a', { class: 'link-block', href: anchor.href });
 
       linkGroup.replaceChildren();
@@ -305,7 +305,7 @@ class Gnav {
 
   decorateLargeMenu = (navLink, navItem, menu) => {
     let path = navLink.href;
-    path = makeRelative(path, true);
+    path = localizeLink(path);
     const promise = fetch(`${path}.plain.html`);
     promise.then(async (resp) => {
       if (resp.status === 200) {
@@ -406,7 +406,7 @@ class Gnav {
     const { default: appLauncher } = await import('./gnav-appLauncher.js');
     appLauncher(profileEl, appLauncherBlock, this.toggleMenu);
   };
-  
+
   decorateProfile = () => {
     const blockEl = this.body.querySelector('.profile');
     if (!blockEl) return null;

--- a/libs/blocks/milonav/milonav.js
+++ b/libs/blocks/milonav/milonav.js
@@ -1,4 +1,4 @@
-import { getMetadata, makeRelative } from '../../utils/utils.js';
+import { getMetadata, localizeLink } from '../../utils/utils.js';
 
 /**
  * decorates the header, mainly the nav
@@ -15,7 +15,7 @@ export default async function init(block) {
 
     const anchors = doc.querySelectorAll('a');
     anchors.forEach((a) => {
-      a.href = makeRelative(a.href);
+      a.href = localizeLink(a.href);
     });
 
     const nav = document.createElement('nav');

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,4 +1,4 @@
-import { createTag, getMetadata, makeRelative } from '../../utils/utils.js';
+import { createTag, getMetadata, localizeLink } from '../../utils/utils.js';
 
 const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
   <g transform="translate(-10500 3403)">
@@ -17,7 +17,7 @@ function getDetails(el) {
   }
   const metaPath = getMetadata(`-${details.id}`);
   if (metaPath) {
-    details.path = makeRelative(metaPath);
+    details.path = localizeLink(metaPath);
     return details;
   }
   return null;

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -17,8 +17,8 @@ import {
   setConfig,
 } from '../utils/utils.js';
 
-// List of domains that should be localized.
-const liveDomains = ['milo.adobe.com'];
+// Production Domain
+const productionDomain = 'milo.adobe.com';
 
 const locales = {
   // Americas
@@ -111,7 +111,7 @@ const config = {
   imsClientId: 'milo',
   codeRoot: '/libs',
   locales,
-  liveDomains,
+  productionDomain,
   marketoBaseURL: '//app-aba.marketo.com',
   marketoFormID: '1761',
   marketoMunchkinID: '345-TTI-184',

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -17,6 +17,8 @@ import {
   setConfig,
 } from '../utils/utils.js';
 
+const liveDomains = ['milo.adobe.com'];
+
 const locales = {
   // Americas
   ar: { ietf: 'es-AR', tk: 'oln4yqj.css' },
@@ -108,6 +110,7 @@ const config = {
   imsClientId: 'milo',
   codeRoot: '/libs',
   locales,
+  liveDomains,
   marketoBaseURL: '//app-aba.marketo.com',
   marketoFormID: '1761',
   marketoMunchkinID: '345-TTI-184',

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -17,6 +17,7 @@ import {
   setConfig,
 } from '../utils/utils.js';
 
+// List of domains that should be localized.
 const liveDomains = ['milo.adobe.com'];
 
 const locales = {
@@ -75,10 +76,10 @@ const locales = {
   bg: { ietf: 'bg-BG', tk: 'aaz7dvd.css' },
   ru: { ietf: 'ru-RU', tk: 'aaz7dvd.css' },
   ua: { ietf: 'uk-UA', tk: 'aaz7dvd.css' },
-  il_he: { ietf: 'en', tk: 'aaz7dvd.css' },
-  ae_ar: { ietf: 'en', tk: 'aaz7dvd.css' },
-  mena_ar: { ietf: 'en', tk: 'aaz7dvd.css' },
-  sa_ar: { ietf: 'en', tk: 'aaz7dvd.css' },
+  il_he: { ietf: 'he', tk: 'nwq1mna.css' },
+  ae_ar: { ietf: 'ar', tk: 'nwq1mna.css' },
+  mena_ar: { ietf: 'ar', tk: 'dis2dpj.css' },
+  sa_ar: { ietf: 'ar', tk: 'nwq1mna.css' },
   // Asia Pacific
   au: { ietf: 'en-AU', tk: 'pps7abe.css' },
   hk_en: { ietf: 'en-HK', tk: 'pps7abe.css' },

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1,5 +1,7 @@
-const PROJECT_NAME = 'milo--adobecom';
-const PRODUCTION_DOMAINS = ['milo.adobe.com'];
+const PROJECTS_TO_PRODUCTION_DOMAINS = {
+  'bacom--adobecom': 'business.adobe.com',
+  'milo--adobecom': 'milo.adobe.com',
+};
 const MILO_TEMPLATES = [
   '404',
   'featured-story',
@@ -9,7 +11,6 @@ const MILO_BLOCKS = [
   'adobetv',
   'article-feed',
   'aside',
-  'author-header',
   'caas',
   'caas-config',
   'card-metadata',
@@ -18,8 +19,6 @@ const MILO_BLOCKS = [
   'columns',
   'faas',
   'faq',
-  'featured-article',
-  'figure',
   'fragment',
   'featured-article',
   'footer',
@@ -80,6 +79,7 @@ const ENVS = {
   },
 };
 const SUPPORTED_RICH_RESULTS_TYPES = ['NewsArticle'];
+const LANGSTORE = 'langstore';
 
 function getEnv(conf) {
   const { host, href } = window.location;
@@ -99,11 +99,15 @@ function getEnv(conf) {
   /* c8 ignore stop */
 }
 
-export function getLocaleFromPath(locales, path) {
-  const split = path.split('/');
+// find out current locale based on pathname and existing locales object from config.
+export function getLocale(locales, pathname = window.location.pathname) {
+  if (!locales) {
+    return { ietf: 'en-US', tk: 'hah7vzn.css', prefix: '' };
+  }
+  const split = pathname.split('/');
   const localeString = split[1];
   const locale = locales[localeString] || locales[''];
-  if (localeString === 'langstore') {
+  if (localeString === LANGSTORE) {
     locale.prefix = `/${localeString}/${split[2]}`;
     return locale;
   }
@@ -111,40 +115,36 @@ export function getLocaleFromPath(locales, path) {
   return locale;
 }
 
-// find out current locale based on pathname and existing locales object from config.
-export function getLocale(locales) {
-  if (!locales) {
-    return { ietf: 'en-US', tk: 'hah7vzn.css', prefix: '' };
-  }
-  const { pathname } = window.location;
-  return getLocaleFromPath(locales, pathname);
-}
-
 export const [setConfig, getConfig] = (() => {
   let config = {};
   return [
     (conf) => {
-      const { origin } = window.location;
+      const origin = conf.origin || window.location.origin;
+      const pathname = conf.pathname || window.location.pathname;
       config = { env: getEnv(conf), ...conf };
       config.codeRoot = conf.codeRoot ? `${origin}${conf.codeRoot}` : origin;
-      config.locale = getLocale(conf.locales);
+      config.locale = pathname ? getLocale(conf.locales, pathname) : getLocale(conf.locales);
       document.documentElement.setAttribute('lang', config.locale.ietf);
       try {
         document.documentElement.setAttribute('dir', (new Intl.Locale(config.locale.ietf)).textInfo.direction);
       } catch (e) {
+        // eslint-disable-next-line no-console
         console.log('Invalid or missing locale:', e);
       }
-      config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot ?? ''}`;
-
+      if (config.contentRoot) {
+        config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot}`;
+      } else {
+        config.locale.contentRoot = `${origin}${config.locale.prefix}`;
+      }
       return config;
     },
     () => config,
   ];
 })();
 
-export function getMetadata(name, doc = document) {
+export function getMetadata(name) {
   const attr = name && name.includes(':') ? 'property' : 'name';
-  const meta = doc.head.querySelector(`meta[${attr}="${name}"]`);
+  const meta = document.head.querySelector(`meta[${attr}="${name}"]`);
   return meta && meta.content;
 }
 
@@ -165,13 +165,48 @@ export function createTag(tag, attributes, html) {
   return el;
 }
 
-export function makeRelative(href) {
+function isInternalDomainUrl(urlHostName, originHostName) {
+  const split = originHostName.split('.').shift().split('--');
+  if (split[1] && split[2]) {
+    const projectName = `${split[1]}--${split[2]}`;
+    const liveDomain = PROJECTS_TO_PRODUCTION_DOMAINS[projectName];
+    return urlHostName === liveDomain;
+  }
+  return false;
+}
+
+function getLocaleLinkInfo(url, relative, originHostName) {
+  const { hash } = url;
+  if (hash === '#_dnt') {
+    return { prefix: '', hash: '' };
+  }
+  const urlHostName = url.hostname;
+  const { locale, locales } = getConfig();
+  if (!locale || !locales) {
+    return { prefix: '', hash };
+  }
+  if (relative || isInternalDomainUrl(urlHostName, originHostName)) {
+    const path = url.pathname;
+    // Handle only pages.
+    const valueAfterLastSlash = path.split('/').pop();
+    const extension = valueAfterLastSlash.includes('.') ? valueAfterLastSlash.split('.').pop() : '';
+    if (!extension || extension === 'html') {
+      const hasPrefix = path.startsWith(`/${LANGSTORE}`) || Object.keys(locales).some((loc) => loc !== '' && path.startsWith(`/${loc}`));
+      if (!hasPrefix) {
+        return { prefix: locale.prefix, hash };
+      }
+    }
+  }
+  return { prefix: '', hash };
+}
+
+export function localizeLink(href, originHostName = window.location.hostname) {
   const fixedHref = href.replace(/\u2013|\u2014/g, '--');
-  const hosts = [`${PROJECT_NAME}.hlx.page`, `${PROJECT_NAME}.hlx.live`, ...PRODUCTION_DOMAINS];
   const url = new URL(fixedHref);
-  const relative = hosts.some((host) => url.hostname.includes(host))
-    || url.hostname === window.location.hostname;
-  return relative ? `${url.pathname}${url.search}${url.hash}` : href;
+  const relative = url.hostname === originHostName;
+  const localeInfo = getLocaleLinkInfo(url, relative, originHostName);
+  const urlPath = `${localeInfo.prefix}${url.pathname}${url.search}${localeInfo.hash}`;
+  return relative ? urlPath : `${url.origin}${urlPath}`;
 }
 
 export function loadStyle(href, callback) {
@@ -327,7 +362,7 @@ export function decorateSVG(a) {
   const ext = textContent?.substr(textContent.lastIndexOf('.') + 1);
   if (ext !== 'svg') return;
   const img = document.createElement('img');
-  img.src = makeRelative(textContent);
+  img.src = localizeLink(textContent);
   const pic = document.createElement('picture');
   pic.append(img);
   if (img.src === href) {
@@ -346,7 +381,7 @@ export function decorateAutoBlock(a) {
     const key = Object.keys(candidate)[0];
     const match = href.includes(candidate[key]);
     if (match) {
-      if (key === 'pdf-viewer' && !a.textContent.includes('.pdf')) {
+      if (key === 'pdf-viewer' && a.textContent !== decodeURI(a.href)) {
         a.target = '_blank';
         return false;
       }
@@ -377,7 +412,7 @@ export function decorateAutoBlock(a) {
 function decorateLinks(el) {
   const anchors = el.getElementsByTagName('a');
   return [...anchors].reduce((rdx, a) => {
-    a.href = makeRelative(a.href);
+    a.href = localizeLink(a.href);
     decorateSVG(a);
     if (a.href.includes('#_blank')) {
       a.setAttribute('target', '_blank');
@@ -576,11 +611,6 @@ export async function loadArea(area = document) {
 
   // Post section loading on document
   if (isDoc) {
-    const georouting = getMetadata('georouting') || config.geoRouting;
-    if (georouting === 'on') {
-      const { default: loadGeoRouting } = await import('../features/georouting/georouting.js');
-      loadGeoRouting(config, createTag, getMetadata);
-    }
     const type = getMetadata('richresults');
     if (SUPPORTED_RICH_RESULTS_TYPES.includes(type)) {
       const { addRichResults } = await import('../features/richresults.js');

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -129,11 +129,7 @@ export const [setConfig, getConfig] = (() => {
         // eslint-disable-next-line no-console
         console.log('Invalid or missing locale:', e);
       }
-      if (config.contentRoot) {
-        config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot}`;
-      } else {
-        config.locale.contentRoot = `${origin}${config.locale.prefix}`;
-      }
+      config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot ?? ''}`;
       return config;
     },
     () => config,
@@ -173,27 +169,17 @@ export function localizeLink(href, originHostName = window.location.hostname) {
   const relative = url.hostname === originHostName;
   const processedHref = relative ? href.replace(url.origin, '') : href;
   const { hash } = url;
-  if (hash === '#_dnt') {
-    return processedHref.split('#')[0];
-  }
+  if (hash === '#_dnt') return processedHref.split('#')[0];
   const path = url.pathname;
   const extension = getExtension(path);
   const allowedExts = ['', 'html', 'json'];
-  if (!allowedExts.includes(extension)) {
-    return processedHref;
-  }
+  if (!allowedExts.includes(extension)) return processedHref;
   const { locale, locales, productionDomain } = getConfig();
-  if (!locale || !locales) {
-    return processedHref;
-  }
+  if (!locale || !locales) return processedHref;
   const isLocalizable = relative || productionDomain === url.hostname;
-  if (!isLocalizable) {
-    return processedHref;
-  }
+  if (!isLocalizable) return processedHref;
   const isLocalizedLink = path.startsWith(`/${LANGSTORE}`) || Object.keys(locales).some((loc) => loc !== '' && path.startsWith(`/${loc}/`));
-  if (isLocalizedLink) {
-    return processedHref;
-  }
+  if (isLocalizedLink) return processedHref;
   const urlPath = `${locale.prefix}${path}${url.search}${hash}`;
   return relative ? urlPath : `${url.origin}${urlPath}`;
 }

--- a/test/blocks/chart/chart.test.js
+++ b/test/blocks/chart/chart.test.js
@@ -468,9 +468,9 @@ describe('chart', () => {
   it('fetchData returns json given an anchor tag', async () => {
     const link = document.createElement('a');
     const linkRel = '/drafts/data-viz/line.json';
-    link.href = `https://data-viz--milo--adobecom.hlx.page${linkRel}`;
+    link.href = `${linkRel}`;
     const goodResponse = { ok: true, json: () => true };
-    fetch.withArgs(linkRel).resolves(goodResponse);
+    fetch.withArgs(link.href).resolves(goodResponse);
     const response = await fetchData(link);
     expect(response).to.be.true;
   });
@@ -604,7 +604,7 @@ describe('chart', () => {
     document.body.innerHTML = '<div class="chart"><div>Title</div><div>Subtitle</div><div><div><a href="/drafts/data-viz/chart.json"></a></div></div><div>Footnote</div></div>';
     const el = document.querySelector('.chart');
     const data = await readFile({ path: './mocks/donutChart.json' });
-    fetch.withArgs('/drafts/data-viz/chart.json').resolves({ ok: true, json: () => JSON.parse(data) });
+    fetch.withArgs(el.getElementsByTagName('a')[0].href).resolves({ ok: true, json: () => JSON.parse(data) });
     el.classList.add('donut');
     init(el);
     const svg = await waitForElement('svg');
@@ -617,11 +617,11 @@ describe('chart', () => {
 
   it('init generates list chart', async () => {
     const linkRel = '/drafts/data-viz/list.json';
-    document.body.innerHTML = `<div class="chart list"><div>Title</div><div>Subtitle</div><div><div><a href="https://data-viz--milo--adobecom.hlx.page${linkRel}"></a></div></div><div>Footnote</div></div>`;
+    document.body.innerHTML = `<div class="chart list"><div>Title</div><div>Subtitle</div><div><div><a href="${linkRel}"></a></div></div><div>Footnote</div></div>`;
     const data = await readFile({ path: './mocks/listChartSingleTable.json' });
     const parsedData = JSON.parse(data);
-    fetch.withArgs(linkRel).resolves({ ok: true, json: () => parsedData });
     const el = document.querySelector('.chart');
+    fetch.withArgs(el.getElementsByTagName('a')[0].href).resolves({ ok: true, json: () => parsedData });
     init(el);
     const listWrapper = await waitForElement('.list-wrapper');
     expect(listWrapper).to.exist;
@@ -631,7 +631,7 @@ describe('chart', () => {
     document.body.innerHTML = await readFile({ path: './mocks/chart.html' });
     const el = document.querySelector('.chart');
     const data = await readFile({ path: './mocks/areaChart.json' });
-    fetch.withArgs('/test/blocks/chart/mocks/chart.json').resolves({ ok: true, json: () => JSON.parse(data) });
+    fetch.withArgs(el.getElementsByTagName('a')[0].href).resolves({ ok: true, json: () => JSON.parse(data) });
     el.classList.add('area');
     init(el);
     const svg = await waitForElement('svg');
@@ -641,11 +641,11 @@ describe('chart', () => {
   it('init chart with echarts without intersection observer', async () => {
     window.IntersectionObserver = undefined;
     const linkRel = '/drafts/data-viz/column.json';
-    document.body.innerHTML = `<div class="chart column"><div>Title</div><div>Subtitle</div><div><div><a href="https://data-viz--milo--adobecom.hlx.page${linkRel}"></a></div></div><div>Footnote</div></div>`;
+    document.body.innerHTML = `<div class="chart column"><div>Title</div><div>Subtitle</div><div><div><a href="${linkRel}"></a></div></div><div>Footnote</div></div>`;
     const data = await readFile({ path: './mocks/columnChart.json' });
     const parsedData = JSON.parse(data);
-    fetch.withArgs(linkRel).resolves({ ok: true, json: () => parsedData });
     const el = document.querySelector('.chart');
+    fetch.withArgs(el.getElementsByTagName('a')[0].href).resolves({ ok: true, json: () => parsedData });
     init(el);
     const svg = await waitForElement('svg');
     expect(svg).to.exist;
@@ -683,11 +683,11 @@ describe('chart', () => {
 
   it('init generates oversized number chart', async () => {
     const linkRel = '/drafts/data-viz/oversized-number.json';
-    document.body.innerHTML = `<div class="chart oversized-number"><div>Title</div><div>Subtitle</div><div><div><a href="https://data-viz--milo--adobecom.hlx.page${linkRel}"></a></div></div><div>Footnote</div></div>`;
+    document.body.innerHTML = `<div class="chart oversized-number"><div>Title</div><div>Subtitle</div><div><div><a href="${linkRel}"></a></div></div><div>Footnote</div></div>`;
     const data = await readFile({ path: './mocks/oversized-number.json' });
     const parsedData = JSON.parse(data);
-    fetch.withArgs(linkRel).resolves({ ok: true, json: () => parsedData });
     const el = document.querySelector('.chart');
+    fetch.withArgs(el.getElementsByTagName('a')[0].href).resolves({ ok: true, json: () => parsedData });
     init(el);
     const svg = await waitForElement('svg');
     expect(svg).to.exist;

--- a/test/blocks/gnav/gnav.test.js
+++ b/test/blocks/gnav/gnav.test.js
@@ -2,6 +2,7 @@ import { readFile, resetMouse, setViewport, sendKeys, sendMouse } from '@web/tes
 import { expect } from '@esm-bundle/chai';
 import sinon, { stub } from 'sinon';
 import { delay } from '../../helpers/waitfor.js';
+import { setConfig } from '../../../libs/utils/utils.js';
 
 window.lana = { log: stub() };
 
@@ -10,6 +11,9 @@ document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
 const mod = await import('../../../libs/blocks/gnav/gnav.js');
 let gnav;
+
+const config = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+setConfig(config);
 
 describe('Gnav', () => {
   beforeEach(() => {

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -53,7 +53,7 @@ describe('Modals', () => {
   it('Opens an inherited modal', async () => {
     const meta = document.createElement('meta');
     meta.name = '-otis';
-    meta.content = 'https://milo.adobe.com/test/blocks/modals/mocks/otis';
+    meta.content = 'http://localhost:2000/test/blocks/modals/mocks/otis';
     document.head.append(meta);
     window.location.hash = '#otis';
     await waitForElement('#otis');
@@ -125,7 +125,7 @@ describe('Modals', () => {
   it('Focuses on close when there are no other focusables', async () => {
     const meta = document.createElement('meta');
     meta.name = '-paragraph';
-    meta.content = 'https://milo.adobe.com/test/blocks/modals/mocks/paragraph';
+    meta.content = 'http://localhost:2000/test/blocks/modals/mocks/paragraph';
     document.head.append(meta);
     window.location.hash = '#paragraph';
     await waitForElement('#paragraph');
@@ -138,7 +138,7 @@ describe('Modals', () => {
   it('Focuses on a header when there are no other focusables', async () => {
     const meta = document.createElement('meta');
     meta.name = '-title';
-    meta.content = 'https://milo.adobe.com/test/blocks/modals/mocks/title';
+    meta.content = 'http://localhost:2000/test/blocks/modals/mocks/title';
     document.head.append(meta);
     window.location.hash = '#title';
     await waitForElement('#title');

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -159,7 +159,7 @@ describe('Utils', () => {
     expect(utils.getLocale().ietf).to.equal('en-US');
   });
 
-  it('getLocaleFromPath for different paths', () => {
+  it('getLocale for different paths', () => {
     const locales = {
       '': { ietf: 'en-US', tk: 'hah7vzn.css' },
       langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
@@ -167,7 +167,7 @@ describe('Utils', () => {
     };
 
     function validateLocale(path, expectedOutput) {
-      const locale = utils.getLocaleFromPath(locales, path);
+      const locale = utils.getLocale(locales, path);
       expect(locale.prefix).to.equal(expectedOutput.prefix);
       expect(locale.ietf).to.equal(expectedOutput.ietf);
       expect(locale.tk).to.equal(expectedOutput.tk);
@@ -179,6 +179,63 @@ describe('Utils', () => {
     validateLocale('/be_fr/page', { prefix: '/be_fr', ietf: 'fr-BE', tk: 'vrk5vyv.css' });
     validateLocale('/langstore/lv', { prefix: '/langstore/lv', ietf: 'en-US', tk: 'hah7vzn.css' });
     validateLocale('/langstore/lv/page', { prefix: '/langstore/lv', ietf: 'en-US', tk: 'hah7vzn.css' });
+  });
+
+  describe('localizeLink', () => {
+    before(async () => {
+      config.locales = {
+        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+        fi: { ietf: 'fi-FI', tk: 'aaz7dvd.css' },
+        be_fr: { ietf: 'fr-BE', tk: 'vrk5vyv.css' },
+        langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
+      };
+      config.pathname = '/be_fr/page';
+      config.origin = 'https://main--bacom--adobecom';
+      utils.setConfig(config);
+    });
+
+    it('Same domain link is relative and localized', () => {
+      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/gnav/solutions', 'main--bacom--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
+    });
+
+    it('Same domain link that is already localized is returned as relative', () => {
+      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/be_fr/gnav/solutions', 'main--bacom--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
+      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/fi/gnav/solutions', 'main--bacom--adobecom.hlx.page')).to.equal('/fi/gnav/solutions');
+    });
+
+    it('Same domain PDF link is returned as relative and not localized', () => {
+      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/gnav/solutions.pdf', 'main--bacom--adobecom.hlx.page')).to.equal('/gnav/solutions.pdf');
+    });
+
+    it('Same domain link with #_dnt is returned as relative, #_dnt is removed and not localized', () => {
+      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/gnav/solutions#_dnt', 'main--bacom--adobecom.hlx.page'))
+        .to
+        .equal('/gnav/solutions');
+    });
+
+    it('Live domain html link  is absolute and localized', () => {
+      expect(utils.localizeLink('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html', 'main--bacom--adobecom.hlx.page'))
+        .to
+        .equal('https://business.adobe.com/be_fr/solutions/customer-experience-personalization-at-scale.html');
+    });
+
+    it('Live domain html link of another project is untouched', () => {
+      expect(utils.localizeLink('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html?offers=123', 'main--milo--adobecom.hlx.page'))
+        .to
+        .equal('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html?offers=123');
+    });
+
+    it('Live domain html link with #_dnt is left absolute, not localized and #_dnt is removed', () => {
+      expect(utils.localizeLink('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html#_dnt', 'main--bacom--adobecom.hlx.page'))
+        .to
+        .equal('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html');
+    });
+
+    it('Lower Environment Links of another project group are untouched', () => {
+      expect(utils.localizeLink('https://dev--milo--adobecom.hlx.page/gnav/solutions', 'main--bacom--adobecom.hlx.page'))
+        .to
+        .equal('https://dev--milo--adobecom.hlx.page/gnav/solutions');
+    });
   });
 
   it('creates an IntersectionObserver', (done) => {

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -189,52 +189,51 @@ describe('Utils', () => {
         be_fr: { ietf: 'fr-BE', tk: 'vrk5vyv.css' },
         langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
       };
+      config.liveDomains = ['milo.adobe.com'];
       config.pathname = '/be_fr/page';
-      config.origin = 'https://main--bacom--adobecom';
+      config.origin = 'https://main--milo--adobecom';
       utils.setConfig(config);
     });
 
     it('Same domain link is relative and localized', () => {
-      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/gnav/solutions', 'main--bacom--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
+    });
+
+    it('Same domain fragment link is relative and localized', () => {
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/fragments/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/fragments/gnav/solutions');
+    });
+
+    it('Same domain extensions /, .html, .json are handled', () => {
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/gnav/solutions.html', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions.html');
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/gnav/solutions.json', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions.json');
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/gnav/solutions/', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions/');
     });
 
     it('Same domain link that is already localized is returned as relative', () => {
-      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/be_fr/gnav/solutions', 'main--bacom--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
-      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/fi/gnav/solutions', 'main--bacom--adobecom.hlx.page')).to.equal('/fi/gnav/solutions');
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/be_fr/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/fi/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/fi/gnav/solutions');
     });
 
     it('Same domain PDF link is returned as relative and not localized', () => {
-      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/gnav/solutions.pdf', 'main--bacom--adobecom.hlx.page')).to.equal('/gnav/solutions.pdf');
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/gnav/solutions.pdf', 'main--milo--adobecom.hlx.page')).to.equal('/gnav/solutions.pdf');
     });
 
     it('Same domain link with #_dnt is returned as relative, #_dnt is removed and not localized', () => {
-      expect(utils.localizeLink('https://main--bacom--adobecom.hlx.page/gnav/solutions#_dnt', 'main--bacom--adobecom.hlx.page'))
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/gnav/solutions#_dnt', 'main--milo--adobecom.hlx.page'))
         .to
         .equal('/gnav/solutions');
     });
 
     it('Live domain html link  is absolute and localized', () => {
-      expect(utils.localizeLink('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html', 'main--bacom--adobecom.hlx.page'))
+      expect(utils.localizeLink('https://milo.adobe.com/solutions/customer-experience-personalization-at-scale.html', 'main--milo--adobecom.hlx.page'))
         .to
-        .equal('https://business.adobe.com/be_fr/solutions/customer-experience-personalization-at-scale.html');
-    });
-
-    it('Live domain html link of another project is untouched', () => {
-      expect(utils.localizeLink('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html?offers=123', 'main--milo--adobecom.hlx.page'))
-        .to
-        .equal('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html?offers=123');
+        .equal('https://milo.adobe.com/be_fr/solutions/customer-experience-personalization-at-scale.html');
     });
 
     it('Live domain html link with #_dnt is left absolute, not localized and #_dnt is removed', () => {
-      expect(utils.localizeLink('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html#_dnt', 'main--bacom--adobecom.hlx.page'))
+      expect(utils.localizeLink('https://milo.adobe.com/solutions/customer-experience-personalization-at-scale.html#_dnt', 'main--milo--adobecom.hlx.page'))
         .to
-        .equal('https://business.adobe.com/solutions/customer-experience-personalization-at-scale.html');
-    });
-
-    it('Lower Environment Links of another project group are untouched', () => {
-      expect(utils.localizeLink('https://dev--milo--adobecom.hlx.page/gnav/solutions', 'main--bacom--adobecom.hlx.page'))
-        .to
-        .equal('https://dev--milo--adobecom.hlx.page/gnav/solutions');
+        .equal('https://milo.adobe.com/solutions/customer-experience-personalization-at-scale.html');
     });
   });
 

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -225,7 +225,7 @@ describe('Utils', () => {
         be_fr: { ietf: 'fr-BE', tk: 'vrk5vyv.css' },
         langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
       };
-      config.liveDomains = ['milo.adobe.com'];
+      config.productionDomain = 'milo.adobe.com';
       config.pathname = '/be_fr/page';
       config.origin = 'https://main--milo--adobecom';
       utils.setConfig(config);

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -181,6 +181,42 @@ describe('Utils', () => {
     validateLocale('/langstore/lv/page', { prefix: '/langstore/lv', ietf: 'en-US', tk: 'hah7vzn.css' });
   });
 
+  describe ('rtlSupport', () => {
+    before(async () => {
+      config.locales = {
+        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+        africa: { ietf: 'en', tk: 'pps7abe.css' },
+        il_he: { ietf: 'he', tk: 'nwq1mna.css' },
+        mena_ar: { ietf: 'ar', tk: 'dis2dpj.css' },
+        ua: { tk: 'aaz7dvd.css' },
+      };
+    });
+
+    function setConfigWithPath(path) {
+      document.documentElement.removeAttribute('dir');
+      config.pathname = path;
+      utils.setConfig(config);
+    }
+
+    it('LTR Languages have dir as ltr', () => {
+      setConfigWithPath( '/africa/solutions');
+      expect(document.documentElement.getAttribute('dir')).to.equal('ltr');
+    });
+
+    it('RTL Languages have dir as rtl', () => {
+      setConfigWithPath( '/il_he/solutions');
+      expect(document.documentElement.getAttribute('dir')).to.equal('rtl');
+      setConfigWithPath( '/mena_ar/solutions');
+      expect(document.documentElement.getAttribute('dir')).to.equal('rtl');
+    });
+
+    it('Gracefully dies when locale ietf is missing and dir is not set.', () => {
+      setConfigWithPath( '/ua/solutions');
+      expect(document.documentElement.getAttribute('dir')).null;
+    });
+
+  });
+
   describe('localizeLink', () => {
     before(async () => {
       config.locales = {

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -231,12 +231,23 @@ describe('Utils', () => {
       utils.setConfig(config);
     });
 
+    function setConfigPath(path) {
+      config.pathname = path;
+      utils.setConfig(config);
+    }
+
     it('Same domain link is relative and localized', () => {
       expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
     });
 
     it('Same domain fragment link is relative and localized', () => {
       expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/fragments/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/fragments/gnav/solutions');
+    });
+
+    it('Same domain langstore link is relative and localized', () => {
+      setConfigPath('/langstore/fr/page');
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/langstore/fr/gnav/solutions');
+      setConfigPath('/be_fr/page');
     });
 
     it('Same domain extensions /, .html, .json are handled', () => {
@@ -248,6 +259,7 @@ describe('Utils', () => {
     it('Same domain link that is already localized is returned as relative', () => {
       expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/be_fr/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
       expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/fi/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/fi/gnav/solutions');
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/langstore/fr/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/langstore/fr/gnav/solutions');
     });
 
     it('Same domain PDF link is returned as relative and not localized', () => {


### PR DESCRIPTION
* makeRelative renamed to localizeLink
* removed PROJECT_NAME check since Franklin handles it by default
* production domains added to `script.js` so consumers can update their domains. 
*  removeHash method in `fragments.js` updated to not remove `#_dnt` if present.
* removed localizeLink from `gnav-appLauncher.js` and `chart.js` and updated tests accordingly
* Added tests for localizeLink 
* Fixed scripts.js for RTL lang codes
* Added tests for RTL support

Resolves: MWPW-120796

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/fr/drafts/bhagwath/demo/demo?martech=off
- After: https://link-transform--milo--adobecom.hlx.page/fr/drafts/bhagwath/demo/demo?martech=off
