### PR TITLE
This is to match with AEM FaaS style.

### DIFF
--- a/libs/blocks/faas/faas.css
+++ b/libs/blocks/faas/faas.css
@@ -338,6 +338,11 @@ input[type="checkbox"] + label {
   bottom: -10px;
 }
 
+/* for bottom checkbox */
+.FaaS-35 {
+  width: 100%;
+}
+
 /* for modal */
 .dialog-modal .faas {
   font-size: 13px;

--- a/libs/blocks/faas/faas.css
+++ b/libs/blocks/faas/faas.css
@@ -159,6 +159,14 @@ input[type="checkbox"] + label {
   display: none !important;
 }
 
+.faas-form .legalnotice {
+  font-style: italic;
+}
+
+.faas-form .legalnotice a {
+  color: var(--link-color);
+}
+
 /* dark theme */
 .faas.dark {
   color: #fff;

--- a/libs/blocks/faas/faas.css
+++ b/libs/blocks/faas/faas.css
@@ -339,7 +339,7 @@ input[type="checkbox"] + label {
 }
 
 /* for bottom checkbox */
-.faas.column2 .faas-form .FaaS-35 {
+.faas.column2 .faas-form .row:not(.submit).FaaS-35 {
   width: 100%;
 }
 

--- a/libs/blocks/faas/faas.css
+++ b/libs/blocks/faas/faas.css
@@ -339,7 +339,7 @@ input[type="checkbox"] + label {
 }
 
 /* for bottom checkbox */
-.FaaS-35 {
+.faas.column2 .faas-form .FaaS-35 {
   width: 100%;
 }
 


### PR DESCRIPTION
Small style update.

This is how an AEM form looks like:
<img width="667" alt="image" src="https://user-images.githubusercontent.com/55804872/206594345-23fa999d-8a67-4e36-b396-b733af1f5afb.png">

Ours:

Before: https://main--bacom--adobecom.hlx.page/fragments/resources/modal/forms/achieve-content-personalization-with-adobe-experience-manager-and-adobe-analytics

After: https://main--bacom--adobecom.hlx.page/fragments/resources/modal/forms/achieve-content-personalization-with-adobe-experience-manager-and-adobe-analytics?milolibs=faas-style