### PR TITLE
MWPW-122629 - Fix PDF Relative Link

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -300,7 +300,7 @@ export function decorateAutoBlock(a) {
     const key = Object.keys(candidate)[0];
     const match = href.includes(candidate[key]);
     if (match) {
-      if (key === 'pdf-viewer' && a.textContent !== decodeURI(a.href)) {
+      if (key === 'pdf-viewer' && !a.textContent.includes('.pdf')) {
         a.target = '_blank';
         return false;
       }


### PR DESCRIPTION
* Fixes issue where pdfs weren't autoblocking due to relative links
* Update: PDF will embed inline if ".pdf" is included in the link text (previously link text was require to be same as link href). Otherwise, it will remain a link and open in a new tab.

Resolves: [MWPW-122629](https://jira.corp.adobe.com/browse/MWPW-122629)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/pdf-viewsdk1?martech=off
- After: https://methomas-pdf-relative-link--milo--adobecom.hlx.page/drafts/methomas/pdf-viewsdk1?martech=off
