### PR TITLE
MWPW-122039 Tabs bugs

### DIFF
--- a/libs/blocks/tabs/tabs.css
+++ b/libs/blocks/tabs/tabs.css
@@ -110,7 +110,20 @@
 
 .tabs .tabContent {
   padding: var(--spacing-s) 0;
-  border-bottom: 1px solid var(--tabs-border-color)
+  border-bottom: 1px solid var(--tabs-border-color);
+}
+
+.tabContent [role='tabpanel'] .section {
+  position: relative;
+}
+
+.tabContent [role='tabpanel'] .section picture.section-background {
+  z-index: 0;
+}
+
+.tabContent [role='tabpanel'] .section > .content {
+  z-index: 1;
+  position: relative;
 }
 
 /* contained tabs content */

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -146,13 +146,16 @@ const init = (e) => {
   allSections.forEach((e, i) => {
     const sectionMetadata = e.querySelector(':scope > .section-metadata');
     if (!sectionMetadata) return;
-    const metadata = sectionMetadata.querySelectorAll(':scope > div > div');
-    if (metadata[0].textContent === 'tab') {
-      const metaValue = getStringKeyName(metadata[1].textContent);
-      const section = sectionMetadata.closest('.section');
-      const assocTabItem = document.getElementById(`tab-panel-${initCount}-${metaValue}`);
-      if (assocTabItem) assocTabItem.append(section);
-    }
+    const metadatas = sectionMetadata.querySelectorAll(':scope > div');
+    metadatas.forEach((data) => {
+      const rowKey = getStringKeyName(data.children[0].textContent);
+      if (rowKey === 'tab') {
+        const metaValue = getStringKeyName(data.children[1].textContent);
+        const section = sectionMetadata.closest('.section');
+        const assocTabItem = document.getElementById(`tab-panel-${initCount}-${metaValue}`);
+        if (assocTabItem) assocTabItem.append(section);
+      }
+    });
   });
   initTabs(e, config);
   initCount++;

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -146,16 +146,14 @@ const init = (e) => {
   allSections.forEach((e, i) => {
     const sectionMetadata = e.querySelector(':scope > .section-metadata');
     if (!sectionMetadata) return;
-    const metadatas = sectionMetadata.querySelectorAll(':scope > div');
-    metadatas.forEach((data) => {
-      const rowKey = getStringKeyName(data.children[0].textContent);
-      if (rowKey === 'tab') {
-        const metaValue = getStringKeyName(data.children[1].textContent);
+    const metadata = sectionMetadata.querySelectorAll(':scope > div');
+    [...metadata].filter((d) => getStringKeyName(d.children[0].textContent) === 'tab')
+      .map((d) => {
+        const metaValue = getStringKeyName(d.children[1].textContent);
         const section = sectionMetadata.closest('.section');
         const assocTabItem = document.getElementById(`tab-panel-${initCount}-${metaValue}`);
         if (assocTabItem) assocTabItem.append(section);
-      }
-    });
+      });
   });
   initTabs(e, config);
   initCount++;

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -39,7 +39,7 @@ function changeTabs(e) {
 }
 
 function getStringKeyName(str) {
-  return str.trim().replaceAll(' ', '-').toLowerCase();
+  return str.trim().toLowerCase().replace(/[^\w ]/g, '').replace(/ +/g, '-');
 }
 
 function configTabs(config) {
@@ -106,7 +106,7 @@ const init = (block) => {
         role: 'tab',
         class: btnClass,
         id: `tab-${initCount}-${tabName}`,
-        tabindex: (i > 0) ? '0' : '-1',
+        tabindex: '0',
         'aria-selected': (i === 0) ? 'true' : 'false',
         'aria-controls': `tab-panel-${initCount}-${tabName}`,
       };


### PR DESCRIPTION
Fixed the following issues

1) The Milo `Tabs` block skips the first tab when using keyboard navigation to select tabs and view its related content.

2) When using special characters ex. `&` in a tab key, the associated tab content doesn't work. 

Resolves: [MWPW-122039](https://jira.corp.adobe.com/browse/MWPW-122039)

**Test URLs:**
- [Before](https://main--milo--adobecom.hlx.page/drafts/rparrish/tabs-content-model?martech=off)
- [After](https://rparrish-tabs-bug--milo--adobecom.hlx.page/drafts/rparrish/tabs-content-model?martech=off)

FYI, I also addressed a number of linting warnings in the tabs.js file
