### PR TITLE
Set the edgeConfigId on window

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -36,6 +36,8 @@ export default async function init(config, loadScript) {
     },
   };
 
+  window.edgeConfigId = edgeConfigId;
+
   window.digitalData ??= {};
   window.digitalData.diagnostic ??= {};
   window.digitalData.diagnostic.franklin = { implementation: 'milo' };


### PR DESCRIPTION
Required by CaaS implementation.

See https://git.corp.adobe.com/Dexter/dexter/pull/2641/files

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/customer-success-stories/helly-hansen-case-study
- After: https://main--bacom--adobecom.hlx.page/customer-success-stories/helly-hansen-case-study?milolibs=c3-windowedgeconfigid
