### PR TITLE
MWPW-119166 - Fix chart date unit

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -355,7 +355,7 @@ export const getChartOptions = (chartType, dataset, series, headers, colors, siz
 
   if (units[0] === 'date') {
     xUnit = units[0];
-    yUnits = units.slice(1).length > 0 ? units.slice(1) : [''];
+    yUnits = units.length > 1 ? units.slice(1) : [''];
   }
 
   firstDataset.shift();

--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -375,7 +375,7 @@ export const getChartOptions = (chartType, dataset, series, headers, colors, siz
         if (isBar) return barTooltipFormatter(params, yUnits[0]);
         if (isPie) return pieTooltipFormatter(params, yUnits[0]);
         if (isDonut) return donutTooltipFormatter(params, yUnits[0]);
-        return tooltipFormatter(params, units);
+        return tooltipFormatter(params, yUnits);
       }),
       trigger: isBar || isPie || isDonut ? 'item' : 'axis',
       axisPointer: { type: isColumn ? 'none' : 'line' },

--- a/test/blocks/chart/chart.test.js
+++ b/test/blocks/chart/chart.test.js
@@ -537,7 +537,8 @@ describe('chart', () => {
   it('lineSeriesOptions returns correct options with marks', () => {
     const series = [{ Type: 'markArea', Name: 'Weekend', Axis: 'xAxis', Value: 'Saturday-Sunday' }, { Type: 'markLine', Name: 'Standout', Axis: 'xAxis', Value: 'Tuesday' }, { Type: 'markLine', Name: 'Average', Axis: 'yAxis', Value: '200' }];
     const firstDataset = [100, 156, 160];
-    const units = ['K'];
+    const xUnit = '';
+    const yUnits = ['K'];
     const expected = [
       {
         type: 'line',
@@ -596,7 +597,7 @@ describe('chart', () => {
       },
     ];
 
-    expect(lineSeriesOptions(series, firstDataset, units)).to.eql(expected);
+    expect(lineSeriesOptions(series, firstDataset, xUnit, yUnits)).to.eql(expected);
   });
 
   it('init donut chart', async () => {


### PR DESCRIPTION
* Adds support for "date" as the "Unit" in the data file for a Chart
* Maintains support for "date-" for backwards compatibility

Resolves: [MWPW-119166](https://jira.corp.adobe.com/browse/MWPW-119166)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/chart-date-dash?martech=off
- After: https://methomas-chart-date-dash--milo--adobecom.hlx.page/drafts/methomas/chart-date-dash?martech=off

For regression testing:
https://main--bacom--adobecom.hlx.page/resources/holiday-shopping-report?milolibs=methomas-chart-date-dash&martech=off
https://methomas-chart-date-dash--milo--adobecom.hlx.page/docs/library/blocks/chart?martech=off