### PR TITLE
MWPW-122756 - Fix PDF Viewer on Consumer Live

### DIFF
--- a/libs/blocks/pdf-viewer/pdf-viewer.js
+++ b/libs/blocks/pdf-viewer/pdf-viewer.js
@@ -13,7 +13,7 @@ export const getPdfConfig = () => {
   let reportSuiteId = env.consumer?.pdfViewerReportSuite || env.pdfViewerReportSuite;
 
   if (host.includes('hlx.live') || query === 'live') {
-    /* c8 ignore next */
+    /* c8 ignore next 2 */
     clientId = live?.pdfViewerClientId || CLIENT_ID_LIVE;
     reportSuiteId = live?.pdfViewerReportSuite || env.pdfViewerReportSuite;
   }

--- a/libs/blocks/pdf-viewer/pdf-viewer.js
+++ b/libs/blocks/pdf-viewer/pdf-viewer.js
@@ -5,18 +5,17 @@ const PDF_RENDER_DIV_ID = 'adobe-dc-view';
 const CLIENT_ID_LIVE = '96e41871f28349e08b3562747a72dc75';
 
 export const getPdfConfig = () => {
-  const { env } = getConfig();
+  const { env, live } = getConfig();
   const { host, href } = window.location;
   const location = new URL(href);
   const query = location.searchParams.get('env');
-  let clientId = env.consumer?.pdfViewerClientId;
+  let clientId = env.consumer?.pdfViewerClientId || env.pdfViewerClientId;
   let reportSuiteId = env.consumer?.pdfViewerReportSuite || env.pdfViewerReportSuite;
 
   if (host.includes('hlx.live') || query === 'live') {
     /* c8 ignore next */
-    clientId ??= CLIENT_ID_LIVE;
-  } else {
-    clientId ??= env.pdfViewerClientId;
+    clientId = live?.pdfViewerClientId || CLIENT_ID_LIVE;
+    reportSuiteId = live?.pdfViewerReportSuite || env.pdfViewerReportSuite;
   }
 
   return { clientId, reportSuiteId };


### PR DESCRIPTION
* Fix PDF Viewer getting incorrect client id on consumer on `.hlx.live`

Resolves: [MWPW-122756](https://jira.corp.adobe.com/browse/MWPW-122756)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/pdf-viewsdk1-a?martech=off
- After: https://methomas-pdf-consumer-live--milo--adobecom.hlx.page/drafts/methomas/pdf-viewsdk1-a?martech=off ("After" is expected to have errors because it has the branch name in the url)
- Consumer: https://main--bacom--adobecom.hlx.live/ab-test/resources/guides/take-the-road-to-implementation/thank-you?martech=off&milolibs=methomas-pdf-consumer-live
