### PR TITLE
A simple `reading-time` block to estimate the reading time of the article

### DIFF
--- a/libs/blocks/reading-time/reading-time.css
+++ b/libs/blocks/reading-time/reading-time.css
@@ -1,0 +1,10 @@
+main > .section > .content.reading-time > span {
+  color: var(--color-gray-600);
+  font-size: var(--type-body-s-size);
+  display: block;
+  margin: 0;
+}
+
+main > .section > .content.reading-time > span {
+  text-align: center;
+}

--- a/libs/blocks/reading-time/reading-time.js
+++ b/libs/blocks/reading-time/reading-time.js
@@ -1,0 +1,31 @@
+import { createTag } from '../../utils/utils.js';
+
+function getTextLength(node) {
+  let textLength = 0;
+  for (const childNode of node.childNodes) {
+    if (childNode.nodeType === Node.TEXT_NODE) {
+      if (childNode.textContent.match(/\S+/g)) {
+        const wordCount = childNode.textContent.match(/\S+/g).length;
+        textLength += wordCount;
+      }
+    } else {
+      textLength += getTextLength(childNode);
+    }
+  }
+  return textLength;
+}
+
+
+export default function init(el) {
+  el.innerHTML = '';
+  el.classList.add('content');
+  const span = createTag('span');
+  const readingSpeed = 200; // Assume that the average reader reads 200 words per minute
+  const textLength = getTextLength(document.body);
+  const readingTime = Math.ceil(textLength / readingSpeed);
+  span.innerHTML = `${readingTime} min read`;
+  el.append(span);
+
+  // to-do: Update the SEO with the reading time
+  
+}

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -41,6 +41,7 @@ const MILO_BLOCKS = [
   'youtube',
   'z-pattern',
   'share',
+  'reading-time',
 ];
 const AUTO_BLOCKS = [
   { adobetv: 'https://video.tv.adobe.com' },


### PR DESCRIPTION
A simple `reading-time` block to estimate the reading time of the article

**Test URL:**
- https://main--stock--adobecom.hlx.page/drafts/solene/article-example-2?milolibs=reading-time

<img width="418" alt="image" src="https://user-images.githubusercontent.com/62023521/207898423-d3a616a5-82b9-4111-8b06-cee66a6b3670.png">
<img width="617" alt="image" src="https://user-images.githubusercontent.com/62023521/207898540-7c0ebec2-c897-40f6-9668-8f16964805fa.png">

