### PR TITLE
Move loadLana to utils

### DIFF
--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -13,6 +13,7 @@
 import {
   loadArea,
   loadDelayed,
+  loadLana,
   setConfig,
 } from '../utils/utils.js';
 
@@ -111,29 +112,6 @@ const config = {
   marketoMunchkinID: '345-TTI-184',
 };
 
-function loadLana() {
-  if (window.lana) return;
-
-  const lanaError = (e) => {
-    window.lana.log(e.reason || e.error || e.message, {
-      errorType: 'i',
-    });
-  }
-
-  window.lana = {
-    log: async (...args) => {
-      await import('../utils/lana.js');
-      window.removeEventListener('error', lanaError);
-      window.removeEventListener('unhandledrejection', lanaError);
-      return window.lana.log(...args);
-    },
-    debug: false,
-  };
-
-  window.addEventListener('error', lanaError);
-  window.addEventListener('unhandledrejection', lanaError);
-}
-
 (async function loadLCPImage() {
   const lcpImg = document.querySelector('img');
   lcpImg?.setAttribute('loading', 'eager');
@@ -141,7 +119,7 @@ function loadLana() {
 
 (async function loadPage() {
   setConfig(config);
-  loadLana();
+  loadLana({ clientId: 'milo' });
   await loadArea();
   loadDelayed();
 }());

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -593,3 +593,27 @@ export function createIntersectionObserver({ el, callback, once = true, options 
   io.observe(el);
   return io;
 }
+
+export function loadLana(options = {}) {
+  if (window.lana) return;
+
+  const lanaError = (e) => {
+    window.lana.log(e.reason || e.error || e.message, {
+      errorType: 'i',
+    });
+  }
+
+  window.lana = {
+    log: async (...args) => {
+      await import('../utils/lana.js');
+      window.removeEventListener('error', lanaError);
+      window.removeEventListener('unhandledrejection', lanaError);
+      return window.lana.log(...args);
+    },
+    debug: false,
+    options,
+  };
+
+  window.addEventListener('error', lanaError);
+  window.addEventListener('unhandledrejection', lanaError);
+}


### PR DESCRIPTION
Consumers can then import and call `loadLana` in their scripts.js file.

Resolves: [119602](https://jira.corp.adobe.com/browse/MWPW-119602)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://c3-loadlanautils--milo--adobecom.hlx.page/?martech=off
