### PR TITLE
Lana options hardening

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -22,10 +22,23 @@
     return false;
   }
 
-  function getOptions(op) {
-    const o = w.lana.options;
+  function mergeOptions(op1, op2) {
+    if (!op1) {
+      op1 = {};
+    }
+
+    if (!op2) {
+      op2 = {};
+    }
+
     function getOpt(key) {
-      return op[key] !== undefined ? op[key] : o[key];
+      if (op1[key] !== undefined) {
+        return op1[key]
+      }
+      if (op2[key] !== undefined) {
+        return op2[key];
+      }
+      return defaultOptions[key];
     }
 
     return Object.keys(defaultOptions).reduce(function (options, key) {
@@ -46,7 +59,7 @@
       msg = msg.slice(0, MSG_LIMIT) + '<trunc>';
     }
 
-    const o = getOptions(options || {});
+    const o = mergeOptions(options, w.lana.options);
     if (!o.clientId) {
       console.warn('LANA ClientID is not set in options.');
       return;
@@ -94,19 +107,10 @@
     return w.location.host.toLowerCase().indexOf('localhost') !== -1;
   }
 
-  const options = w.lana && w.lana.options;
   w.lana = {
     debug: false,
     log: log,
-    options: options || defaultOptions,
-    setClientId: function (id) {
-      console.warn('LANA setClientId is deprecated and will be removed in a future release.');
-      w.lana.options.clientId = id;
-    },
-    setDefaultOptions: function (options) {
-      console.warn('LANA setDefaultOptions is deprecated and will be removed in a future release.');
-      w.lana.options = getOptions(options);
-    },
+    options: mergeOptions(w.lana && w.lana.options),
   };
 
   /* c8 ignore next */

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -55,7 +55,6 @@ describe('Decorating', () => {
 
   it('Loads lana.js upon calling lana.log the first time', async () => {
     expect(window.lana.log).to.exist;
-    expect(window.lana.options).not.to.exist;
 
     sinon.spy(console, 'log');
 

--- a/test/utils/lana.test.js
+++ b/test/utils/lana.test.js
@@ -34,7 +34,7 @@ describe('LANA', () => {
       xhrRequests.push(req);
     };
 
-    window.lana.setDefaultOptions(defaultTestOptions);
+    window.lana.options = { ...defaultTestOptions };
     window.lana.debug = false;
     window.lana.localhost = false;
     sinon.spy(console, 'log');
@@ -49,16 +49,6 @@ describe('LANA', () => {
 
   it('Exists on the window object', () => {
     expect(window.lana).to.exist;
-  });
-
-  it('Set the default clientId', () => {
-    window.lana.setClientId('myClientId');
-    window.lana.log('I set the client id');
-    expect(xhrRequests.length).to.equal(1);
-    expect(xhrRequests[0].method).to.equal('GET');
-    expect(xhrRequests[0].url).to.equal(
-      'https://lana.adobeio.com/?m=I%20set%20the%20client%20id&c=myClientId&s=100&t=e',
-    );
   });
 
   it('Catches unhandled error', (done) => {
@@ -164,6 +154,20 @@ describe('LANA', () => {
     expect(xhrRequests[0].method).to.equal('GET');
     expect(xhrRequests[0].url).to.equal(
       'https://lana.adobeio.com/?m=I%20set%20the%20client%20id&c=testClientId&s=100&t=e&tags=commerce,pricestore',
+    );
+  });
+
+  it('uses default option values if not set in options object', () => {
+    window.lana.options = {
+      clientId: 'blah',
+      sampleRate: 100,
+      implicitSampleRate: 100,
+    };
+    window.lana.log('only the clientId set in window.lana.options');
+    expect(xhrRequests.length).to.equal(1);
+    expect(xhrRequests[0].method).to.equal('GET');
+    expect(xhrRequests[0].url).to.equal(
+      'https://www.adobe.com/lana/ll?m=only%20the%20clientId%20set%20in%20window.lana.options&c=blah&s=100&t=e',
     );
   });
 });

--- a/test/utils/lanaDefaultOptions.test.js
+++ b/test/utils/lanaDefaultOptions.test.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 
 const defaultTestOptions = {
   clientId: 'testClientId',
-  debug: false,
   endpoint: 'https://lana.adobeio.com/',
   errorType: 'e',
   sampleRate: 100,
@@ -13,5 +12,15 @@ const defaultTestOptions = {
 it('lana should load existing window.lana.options', async () => {
   window.lana = { options: defaultTestOptions };
   await import('../../libs/utils/lana.js');
-  expect(window.lana.options).to.be.eql(defaultTestOptions);
+
+  expect(window.lana.options).to.be.eql({
+    clientId: 'testClientId',
+    endpoint: 'https://lana.adobeio.com/',
+    errorType: 'e',
+    sampleRate: 100,
+    tags: '',
+    implicitSampleRate: 100,
+    endpointStage: "https://www.stage.adobe.com/lana/ll",
+    useProd: true,
+  });
 });


### PR DESCRIPTION
Also remove deprecated functions, I verified that they are not used by any consuming clients.

Resolves: [MWPW-119602](https://jira.corp.adobe.com/browse/MWPW-119602)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://c3-lanadefaultopt--milo--adobecom.hlx.page/?martech=off
