### PR TITLE
[MWPW-122222] Feds gnav menu refactoring

### DIFF
--- a/libs/blocks/global-navigation/blocks/appLauncher/appLauncher.js
+++ b/libs/blocks/global-navigation/blocks/appLauncher/appLauncher.js
@@ -1,4 +1,4 @@
-import { createTag, makeRelative } from '../../utils/utils.js';
+import { createTag, localizeLink } from '../../../../utils/utils.js';
 
 const WAFFLE_ICON = '<svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS"><path d="M10 10H2V3a1 1 0 0 1 1-1h7zm4-8h8v8h-8zm20 8h-8V2h7a1 1 0 0 1 1 1zM2 14h8v8H2zm12 0h8v8h-8zm12 0h8v8h-8zM10 34H3a1 1 0 0 1-1-1v-7h8zm4-8h8v8h-8zm19 8h-7v-8h8v7a1 1 0 0 1-1 1z"></path></svg>';
 
@@ -32,7 +32,7 @@ function decorateAppsMenu(profileEl, appsDom, toggle) {
       target: '_blank',
     });
 
-    anchor.href = makeRelative(anchor.href, true);
+    anchor.href = localizeLink(anchor.href);
     li.replaceChildren();
     link.append(image, title);
     li.appendChild(link);
@@ -46,13 +46,13 @@ function decorateAppsMenu(profileEl, appsDom, toggle) {
   return appsNavItem;
 }
 
-export default async function getApps(profileEl, appLauncherBlock, toggle) {
+async function appLauncher(profileEl, appLauncherBlock, toggle) {
   const gnav = profileEl.closest('nav.gnav');
   gnav.classList.add('has-apps');
 
   const appsLink = appLauncherBlock.querySelector('a');
-  appsLink.href = makeRelative(appsLink.href, true);
-  
+  appsLink.href = localizeLink(appsLink.href);
+
   const path = appsLink.href;
   const resp = await fetch(`${path}.plain.html`);
   if (!resp.ok) return null;
@@ -63,3 +63,5 @@ export default async function getApps(profileEl, appLauncherBlock, toggle) {
   const appsDom = doc.querySelectorAll('body > div > ul > li');
   return decorateAppsMenu(profileEl, appsDom, toggle);
 }
+
+export default { appLauncher };

--- a/libs/blocks/global-navigation/blocks/navMenu/menu.css
+++ b/libs/blocks/global-navigation/blocks/navMenu/menu.css
@@ -1,0 +1,270 @@
+header .gnav-navitem-menu {
+  display: none;
+  padding: 14px 0;
+  background-color: #fafafa;
+}
+
+header .gnav-navitem.has-menu.is-open .gnav-navitem-menu {
+  display: block;
+}
+
+header .gnav-navitem.has-menu.is-open .gnav-navitem-menu.app-menu {
+  background-color: var(--color-white);
+  display: flex;
+  position: absolute;
+  left: unset;
+  right: 0;
+  border-radius: 0 0 4px 4px;
+  border-left-color: var(--apps-border-color);
+  border-right-color: var(--apps-border-color);
+  border-bottom-color: var(--apps-border-color);
+  box-shadow: 0 1px 4px rgb(0 0 0 / 15%);
+  width: 334px;
+}
+
+header .gnav-navitem-menu ul {
+  padding-left: 0;
+  margin: 0;
+  list-style: none;
+}
+
+header .gnav-navitem-menu a {
+  padding: 12px 36px;
+  white-space: nowrap;
+}
+
+header .gnav-navitem-menu a:hover:not(.con-button) {
+  color: #1473e6;
+  background-color: #f5f5f5;
+}
+
+.gnav .gnav-promo {
+  padding: 16px;
+  margin-top: 6px;
+  background: var(--color-white);
+}
+
+.gnav .gnav-promo.card {
+  width: 260px;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.gnav .gnav-promo.card > div:last-child {
+  padding-top: 20px;
+}
+
+.gnav .gnav-promo.image-only {
+  background: unset;
+}
+
+.gnav-promo {
+  border: solid 1px #eaeaea;
+}
+
+.gnav-promo p:first-child {
+  margin-top: 0;
+}
+
+.gnav-promo p:last-child {
+  margin-bottom: 0;
+}
+
+header .gnav-navitem .gnav-navitem-menu .gnav-promo a {
+  padding: 0;
+  color: #1473e6;
+}
+
+header .gnav-navitem-menu .gnav-promo a:hover {
+  background-color: unset;
+  color: unset;
+}
+
+.gnav-promo picture,
+.gnav-promo img {
+  display: block;
+}
+
+nav.gnav .gnav-navitem-menu .gnav-promo img {
+  width: 160px;
+  margin: 0 auto;
+}
+
+nav.gnav .gnav-navitem-menu .gnav-promo.card img {
+  width: 100%;
+}
+
+.gnav-navitem.large-menu .gnav-navitem-menu strong a {
+  display: inline-block;
+  padding: 0 14px;
+  line-height: 36px;
+  border-radius: 20px;
+}
+
+.gnav-navitem.large-menu h5 {
+  font-size: 14px;
+  color: #4b4b4b;
+  border-bottom: 1px solid #d1d1d1;
+  margin-top: 0;
+  margin-bottom: 16px;
+  padding-bottom: 5px;
+}
+
+.gnav-navitem.has-menu.is-open .gnav-menu-container,
+.gnav-navitem.has-menu.is-open .gnav-navitem-menu:scope > div {
+  display: flex;
+  flex-flow: column wrap;
+  padding: 0 24px;
+}
+
+.gnav-navitem.has-menu.is-open .gnav-navitem-menu {
+  padding-top: 0;
+  left: 0;
+  right: 0;
+}
+
+.gnav-navitem.has-menu.is-open .gnav-navitem-menu > div > div > ul {
+  margin: 0;
+}
+
+.gnav-navitem.has-menu.is-open .gnav-navitem-menu > div > div > h5 {
+  margin: 0;
+  padding: 18px 0;
+  line-height: 1;
+}
+
+.gnav-navitem.has-menu.is-open .gnav-navitem-menu > div > div > p {
+  margin-top: 10px;
+}
+
+.gnav-navitem.large-menu .gnav-navitem-menu a {
+  padding: 10px 12px;
+}
+
+.gnav-navitem.large-menu .gnav-navitem-menu li:first-child a {
+  margin-top: 4px;
+}
+
+.gnav-navitem.large-menu .link-group {
+  margin-top: 10px;
+}
+
+.gnav-navitem.large-menu .link-group a img {
+  width: 26px;
+  margin-right: 15px;
+}
+
+.gnav-navitem.large-menu .link-group .link-block,
+.gnav-navitem.large-menu .link-group .link-block picture {
+  display: flex;
+  align-items: center;
+  justify-content: start;
+}
+
+.gnav-navitem-menu a.link-block {
+  padding: 12px;
+}
+
+.gnav-navitem.large-menu.gnav-navitem.has-menu.is-open
+.link-group
+.link-block
+div {
+  padding-left: 0;
+  line-height: 1.3;
+}
+
+.gnav-navitem.large-menu .link-group .link-block p {
+  margin: 0;
+}
+
+.gnav-navitem.large-menu .link-group .link-block p:last-of-type {
+  -webkit-font-smoothing: auto;
+  font-size: 12px;
+  font-weight: 400;
+  color: #656565;
+}
+
+.gnav-menu-container .con-button {
+  margin-left: 12px;
+}
+
+@media (min-width: 900px) {
+  header .gnav-navitem.is-open > a {
+    background-color: #fafafa;
+  }
+
+  header .gnav-navitem .small-Variant ul a,
+  header .gnav-navitem .medium-Variant ul a {
+    padding: 6px 12px;
+  }
+
+  header .gnav-navitem.has-menu.is-open::before {
+    display: none;
+  }
+
+  header .gnav-navitem.has-menu.is-open > a {
+    font-weight: unset;
+  }
+
+
+  header .gnav-navitem.has-menu.is-open > a::before {
+    display: none;
+  }
+
+  header .gnav-navitem.has-menu.is-open .gnav-navitem-menu.small-Variant,
+  header .gnav-navitem.has-menu.is-open .gnav-navitem-menu.medium-Variant {
+    padding: 18px 20px;
+    position: absolute;
+    display: flex;
+    right: unset;
+    gap: 40px;
+  }
+
+  .gnav-navitem.has-menu.is-open .gnav-navitem-menu > div > div > h5 {
+    margin: 0 12px;
+    padding: 18px 0 6px 0;
+  }
+
+  .gnav-navitem.has-menu.is-open .gnav-navitem-menu,
+  .gnav-profile.gnav-navitem.has-menu.is-open .gnav-navitem-menu {
+    position: fixed;
+    margin-top: 64px;
+    padding: 0;
+    z-index: 1;
+  }
+
+  .gnav-navitem.has-menu.is-open .gnav-menu-container,
+  .gnav-navitem.has-menu.is-open .gnav-navitem-menu.large-Variant:scope > div {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+    padding: 24px 20px 60px;
+    margin: 0 auto;
+    gap: 100px;
+  }
+
+  .gnav-navitem.large-menu .link-group {
+    margin-top: 0;
+  }
+
+  .gnav-navitem.large-menu h5 + .link-group {
+    margin-top: 6px;
+  }
+
+  .gnav-navitem.large-menu .link-group:first-child {
+    margin-top: 6px;
+  }
+
+  .gnav-navitem.large-menu .gnav-navitem-menu strong a {
+    line-height: 28px;
+  }
+
+  .gnav .gnav-promo {
+    padding: 28px;
+    margin-top: unset;
+  }
+
+  .gnav .gnav-navitem.large-menu .gnav-promo {
+    margin-top: 20px;
+  }
+}

--- a/libs/blocks/global-navigation/blocks/navMenu/menu.js
+++ b/libs/blocks/global-navigation/blocks/navMenu/menu.js
@@ -5,113 +5,20 @@ import {
 import {
   createTag,
   decorateSVG,
-  makeRelative,
+  localizeLink,
 } from '../../../../utils/utils.js';
 
-const IS_OPEN = 'is-open';
-const state = {}
-const curtain = document.querySelector('.gnav-curtain')
 const isHeading = (el) => el?.nodeName.startsWith('H');
 
-const childIndexOf = (el) =>
-  [...el.parentElement.children]
-    .filter((e) => e.nodeName === 'DIV' || e.nodeName === 'P')
-    .indexOf(el);
+const childIndexOf = (el) => [...el.parentElement.children]
+  .filter((e) => e.nodeName === 'DIV' || e.nodeName === 'P')
+  .indexOf(el);
 
 const decorateButtons = (menu) => {
   const buttons = menu.querySelectorAll('strong a');
   buttons.forEach((btn) => {
     btn.classList.add('con-button', 'filled', 'blue', 'button-M');
   });
-};
-
-const closeOnEscape = (e) => {
-  if (e.code === 'Escape') {
-    toggleMenu(state.openMenu);
-  }
-};
-
-const closeOnDocClick = (e) => {
-  const closest = e.target.closest(`.${IS_OPEN}`);
-  const isCurtain = e.target === curtain;
-  if ((state.openMenu && !closest) || isCurtain) {
-    toggleMenu(state.openMenu);
-  }
-  if (isCurtain) {
-    curtain.classList.remove('is-open');
-  }
-};
-
-/**
- * Toggles menus when clicked directly
- * @param {HTMLElement} el the element to check
- */
-const toggleMenu = (el) => {
-  const isSearch = el.classList.contains('gnav-search');
-  const sameMenu = el === state.openMenu;
-  if (state.openMenu) {
-    closeMenu();
-  }
-  if (!sameMenu) {
-    openMenu(el, isSearch);
-  }
-};
-
-const closeMenu = () => {
-  state.openMenu.classList.remove(IS_OPEN);
-  curtain.classList.remove('is-open');
-  curtain.classList.remove('is-quiet');
-  document.removeEventListener('click', closeOnDocClick);
-  window.removeEventListener('keydown', closeOnEscape);
-  const menuToggle = state.openMenu.querySelector('[aria-expanded]');
-  menuToggle.setAttribute('aria-expanded', false);
-  menuToggle.setAttribute('daa-lh', 'header|Open');
-  state.openMenu = null;
-};
-
-const closeOnScroll = () => {
-  let scrolled;
-  if (!scrolled) {
-    if (state.openMenu) {
-      toggleMenu(state.openMenu);
-    }
-    scrolled = true;
-    document.removeEventListener('scroll', closeOnScroll);
-  }
-};
-
-const openMenu = (el, isSearch) => {
-  el.classList.add(IS_OPEN);
-
-  const menuToggle = el.querySelector('[aria-expanded]');
-  menuToggle.setAttribute('aria-expanded', true);
-  menuToggle.setAttribute('daa-lh', 'header|Close');
-
-  document.addEventListener('click', closeOnDocClick);
-  window.addEventListener('keydown', closeOnEscape);
-  if (!isSearch) {
-    const desktop = window.matchMedia('(min-width: 900px)');
-    if (desktop.matches) {
-      document.addEventListener('scroll', closeOnScroll, {
-        passive: true,
-      });
-      if (el.classList.contains('large-menu')) {
-        curtain.classList.add('is-open', 'is-quiet');
-      }
-    }
-  } else {
-    curtain.classList.add('is-open');
-    el.querySelector('.gnav-search-input').focus();
-  }
-  state.openMenu = el;
-};
-
-const toggleOnSpace = (e) => {
-  if (e.code === 'Space') {
-    e.preventDefault();
-    const parentEl = e.target.closest('.has-menu');
-    toggleMenu(parentEl);
-  }
 };
 
 const decorateLinkGroups = (menu) => {
@@ -123,7 +30,7 @@ const decorateLinkGroups = (menu) => {
     const subtitle = linkGroup.querySelector('p:last-of-type') || '';
     const titleWrapper = createTag('div');
     titleWrapper.className = 'link-group-title';
-    anchor.href = makeRelative(anchor.href, true);
+    anchor.href = localizeLink(anchor.href);
     const link = createTag('a', { class: 'link-block', href: anchor.href });
 
     linkGroup.replaceChildren();
@@ -138,12 +45,11 @@ const setMenuAnalytics = (el) => {
   switch (el.nodeName) {
     case 'DIV':
       if (el.classList.contains('link-group')) {
-        const title =
-          el.querySelector('.link-group-title')?.childNodes?.[0]?.textContent;
+        const title = el.querySelector('.link-group-title')?.childNodes?.[0]?.textContent;
         if (title) {
           el.firstChild.setAttribute(
             'daa-lh',
-            `${analyticsGetLabel(title)}-${childIndexOf(el) + 1}`
+            `${analyticsGetLabel(title)}-${childIndexOf(el) + 1}`,
           );
         }
       } else {
@@ -161,17 +67,16 @@ const setMenuAnalytics = (el) => {
       if (a) {
         a.setAttribute(
           'daa-ll',
-          `${analyticsGetLabel(a.textContent)}-${childIndexOf(el) + 1}`
+          `${analyticsGetLabel(a.textContent)}-${childIndexOf(el) + 1}`,
         );
       }
     }
   }
 };
 
-const decorateAnalytics = (menu) =>
-  [...menu.children].forEach((child) => setMenuAnalytics(child));
+const decorateAnalytics = (menu) => [...menu.children].forEach((child) => setMenuAnalytics(child));
 
-const decorateMenu = (navItem, navLink, menu) => {
+const decorateMenu = (navItem, navLink, menu, menuControls) => {
   menu.className = 'gnav-navitem-menu';
   menu.setAttribute('daa-lh', `header|${navLink.textContent}`);
   const childCount = menu.childElementCount;
@@ -188,49 +93,47 @@ const decorateMenu = (navItem, navLink, menu) => {
   decorateLinkGroups(menu);
   decorateAnalytics(menu);
   navLink.addEventListener('focus', () => {
-    window.addEventListener('keydown', toggleOnSpace);
+    window.addEventListener('keydown', menuControls.toggleOnSpace);
   });
   navLink.addEventListener('blur', () => {
-    window.removeEventListener('keydown', toggleOnSpace);
+    window.removeEventListener('keydown', menuControls.toggleOnSpace);
   });
   navLink.addEventListener('click', (e) => {
     e.preventDefault();
     e.stopPropagation();
-    toggleMenu(navItem);
+    menuControls.toggleMenu(navItem);
   });
   decorateButtons(menu);
   return menu;
 };
 
-const decorateLargeMenu = (navLink, navItem, menu) => {
+const decorateLargeMenu = async (navLink, navItem, menu, menuControls) => {
   let path = navLink.href;
-  path = makeRelative(path, true);
-  const promise = fetch(`${path}.plain.html`);
-  promise.then(async (resp) => {
-    if (resp.status === 200) {
-      const text = await resp.text();
-      menu.insertAdjacentHTML('beforeend', text);
-      const links = menu.querySelectorAll('a');
-      links.forEach((link) => {
-        decorateSVG(link);
-      });
-      const decoratedMenu = decorateMenu(navItem, navLink, menu);
-      const menuSections = decoratedMenu.querySelectorAll(
-        '.gnav-menu-container > div'
-      );
-      menuSections.forEach((sec) => {
-        sec.classList.add('section');
-      });
-      const sectionMetas = decoratedMenu.querySelectorAll('.section-metadata');
-      sectionMetas.forEach(async (meta) => {
-        const { default: sectionMetadata } = await import(
-          '../../../section-metadata/section-metadata.js'
-        );
-        sectionMetadata(meta);
-      });
-      navItem.appendChild(decoratedMenu);
-    }
+  path = localizeLink(path);
+  const res = await fetch(`${path}.plain.html`);
+  if (res.status !== 200) return;
+
+  const text = await res.text();
+  menu.insertAdjacentHTML('beforeend', text);
+  const links = menu.querySelectorAll('a');
+  links.forEach((link) => {
+    decorateSVG(link);
   });
+  const decoratedMenu = decorateMenu(navItem, navLink, menu, menuControls);
+  const menuSections = decoratedMenu.querySelectorAll(
+    '.gnav-menu-container > div',
+  );
+  menuSections.forEach((sec) => {
+    sec.classList.add('section');
+  });
+  const sectionMetas = decoratedMenu.querySelectorAll('.section-metadata');
+  sectionMetas.forEach(async (meta) => {
+    const { default: sectionMetadata } = await import(
+      '../../../section-metadata/section-metadata.js'
+    );
+    sectionMetadata(meta);
+  });
+  navItem.appendChild(decoratedMenu);
 };
 
 export default { decorateMenu, decorateLargeMenu };

--- a/libs/blocks/global-navigation/blocks/navMenu/menu.js
+++ b/libs/blocks/global-navigation/blocks/navMenu/menu.js
@@ -1,0 +1,236 @@
+import {
+  analyticsDecorateList,
+  analyticsGetLabel,
+} from '../../../../martech/attributes.js';
+import {
+  createTag,
+  decorateSVG,
+  makeRelative,
+} from '../../../../utils/utils.js';
+
+const IS_OPEN = 'is-open';
+const state = {}
+const curtain = document.querySelector('.gnav-curtain')
+const isHeading = (el) => el?.nodeName.startsWith('H');
+
+const childIndexOf = (el) =>
+  [...el.parentElement.children]
+    .filter((e) => e.nodeName === 'DIV' || e.nodeName === 'P')
+    .indexOf(el);
+
+const decorateButtons = (menu) => {
+  const buttons = menu.querySelectorAll('strong a');
+  buttons.forEach((btn) => {
+    btn.classList.add('con-button', 'filled', 'blue', 'button-M');
+  });
+};
+
+const closeOnEscape = (e) => {
+  if (e.code === 'Escape') {
+    toggleMenu(state.openMenu);
+  }
+};
+
+const closeOnDocClick = (e) => {
+  const closest = e.target.closest(`.${IS_OPEN}`);
+  const isCurtain = e.target === curtain;
+  if ((state.openMenu && !closest) || isCurtain) {
+    toggleMenu(state.openMenu);
+  }
+  if (isCurtain) {
+    curtain.classList.remove('is-open');
+  }
+};
+
+/**
+ * Toggles menus when clicked directly
+ * @param {HTMLElement} el the element to check
+ */
+const toggleMenu = (el) => {
+  const isSearch = el.classList.contains('gnav-search');
+  const sameMenu = el === state.openMenu;
+  if (state.openMenu) {
+    closeMenu();
+  }
+  if (!sameMenu) {
+    openMenu(el, isSearch);
+  }
+};
+
+const closeMenu = () => {
+  state.openMenu.classList.remove(IS_OPEN);
+  curtain.classList.remove('is-open');
+  curtain.classList.remove('is-quiet');
+  document.removeEventListener('click', closeOnDocClick);
+  window.removeEventListener('keydown', closeOnEscape);
+  const menuToggle = state.openMenu.querySelector('[aria-expanded]');
+  menuToggle.setAttribute('aria-expanded', false);
+  menuToggle.setAttribute('daa-lh', 'header|Open');
+  state.openMenu = null;
+};
+
+const closeOnScroll = () => {
+  let scrolled;
+  if (!scrolled) {
+    if (state.openMenu) {
+      toggleMenu(state.openMenu);
+    }
+    scrolled = true;
+    document.removeEventListener('scroll', closeOnScroll);
+  }
+};
+
+const openMenu = (el, isSearch) => {
+  el.classList.add(IS_OPEN);
+
+  const menuToggle = el.querySelector('[aria-expanded]');
+  menuToggle.setAttribute('aria-expanded', true);
+  menuToggle.setAttribute('daa-lh', 'header|Close');
+
+  document.addEventListener('click', closeOnDocClick);
+  window.addEventListener('keydown', closeOnEscape);
+  if (!isSearch) {
+    const desktop = window.matchMedia('(min-width: 900px)');
+    if (desktop.matches) {
+      document.addEventListener('scroll', closeOnScroll, {
+        passive: true,
+      });
+      if (el.classList.contains('large-menu')) {
+        curtain.classList.add('is-open', 'is-quiet');
+      }
+    }
+  } else {
+    curtain.classList.add('is-open');
+    el.querySelector('.gnav-search-input').focus();
+  }
+  state.openMenu = el;
+};
+
+const toggleOnSpace = (e) => {
+  if (e.code === 'Space') {
+    e.preventDefault();
+    const parentEl = e.target.closest('.has-menu');
+    toggleMenu(parentEl);
+  }
+};
+
+const decorateLinkGroups = (menu) => {
+  const linkGroups = menu.querySelectorAll('.link-group');
+  linkGroups.forEach((linkGroup) => {
+    const image = linkGroup.querySelector('picture');
+    const anchor = linkGroup.querySelector('a');
+    const title = anchor?.textContent;
+    const subtitle = linkGroup.querySelector('p:last-of-type') || '';
+    const titleWrapper = createTag('div');
+    titleWrapper.className = 'link-group-title';
+    anchor.href = makeRelative(anchor.href, true);
+    const link = createTag('a', { class: 'link-block', href: anchor.href });
+
+    linkGroup.replaceChildren();
+    titleWrapper.append(title, subtitle);
+    const contents = image ? [image, titleWrapper] : [titleWrapper];
+    link.append(...contents);
+    linkGroup.appendChild(link);
+  });
+};
+
+const setMenuAnalytics = (el) => {
+  switch (el.nodeName) {
+    case 'DIV':
+      if (el.classList.contains('link-group')) {
+        const title =
+          el.querySelector('.link-group-title')?.childNodes?.[0]?.textContent;
+        if (title) {
+          el.firstChild.setAttribute(
+            'daa-lh',
+            `${analyticsGetLabel(title)}-${childIndexOf(el) + 1}`
+          );
+        }
+      } else {
+        [...el.children].forEach((childEl) => setMenuAnalytics(childEl));
+      }
+      break;
+    case 'UL':
+      if (isHeading(el.previousElementSibling)) {
+        el.setAttribute('daa-lh', el.previousElementSibling.textContent);
+      }
+      [...el.children].forEach(analyticsDecorateList);
+      break;
+    default: {
+      const a = el.querySelector('a');
+      if (a) {
+        a.setAttribute(
+          'daa-ll',
+          `${analyticsGetLabel(a.textContent)}-${childIndexOf(el) + 1}`
+        );
+      }
+    }
+  }
+};
+
+const decorateAnalytics = (menu) =>
+  [...menu.children].forEach((child) => setMenuAnalytics(child));
+
+const decorateMenu = (navItem, navLink, menu) => {
+  menu.className = 'gnav-navitem-menu';
+  menu.setAttribute('daa-lh', `header|${navLink.textContent}`);
+  const childCount = menu.childElementCount;
+  if (childCount === 1) {
+    menu.classList.add('small-Variant');
+  } else if (childCount === 2) {
+    menu.classList.add('medium-Variant');
+  } else if (childCount >= 3) {
+    menu.classList.add('large-Variant');
+    const container = createTag('div', { class: 'gnav-menu-container' });
+    container.append(...Array.from(menu.children));
+    menu.append(container);
+  }
+  decorateLinkGroups(menu);
+  decorateAnalytics(menu);
+  navLink.addEventListener('focus', () => {
+    window.addEventListener('keydown', toggleOnSpace);
+  });
+  navLink.addEventListener('blur', () => {
+    window.removeEventListener('keydown', toggleOnSpace);
+  });
+  navLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toggleMenu(navItem);
+  });
+  decorateButtons(menu);
+  return menu;
+};
+
+const decorateLargeMenu = (navLink, navItem, menu) => {
+  let path = navLink.href;
+  path = makeRelative(path, true);
+  const promise = fetch(`${path}.plain.html`);
+  promise.then(async (resp) => {
+    if (resp.status === 200) {
+      const text = await resp.text();
+      menu.insertAdjacentHTML('beforeend', text);
+      const links = menu.querySelectorAll('a');
+      links.forEach((link) => {
+        decorateSVG(link);
+      });
+      const decoratedMenu = decorateMenu(navItem, navLink, menu);
+      const menuSections = decoratedMenu.querySelectorAll(
+        '.gnav-menu-container > div'
+      );
+      menuSections.forEach((sec) => {
+        sec.classList.add('section');
+      });
+      const sectionMetas = decoratedMenu.querySelectorAll('.section-metadata');
+      sectionMetas.forEach(async (meta) => {
+        const { default: sectionMetadata } = await import(
+          '../../../section-metadata/section-metadata.js'
+        );
+        sectionMetadata(meta);
+      });
+      navItem.appendChild(decoratedMenu);
+    }
+  });
+};
+
+export default { decorateMenu, decorateLargeMenu };

--- a/libs/blocks/global-navigation/blocks/profile/profile.js
+++ b/libs/blocks/global-navigation/blocks/profile/profile.js
@@ -1,4 +1,4 @@
-import { getConfig, createTag } from '../../utils/utils.js';
+import { getConfig, createTag } from '../../../../utils/utils.js';
 
 function decorateEmail(email) {
   const MAX_CHAR = 12;
@@ -82,7 +82,7 @@ function decorateProfileMenu(blockEl, profileEl, profiles, toggle) {
   profileEl.append(profileButton, profileMenu);
 }
 
-export default async function getProfile(blockEl, profileEl, toggle, ioResp) {
+async function profile(blockEl, profileEl, toggle, ioResp) {
   const gnav = profileEl.closest('nav.gnav');
   gnav.classList.add('signed-in');
 
@@ -91,3 +91,5 @@ export default async function getProfile(blockEl, profileEl, toggle, ioResp) {
   profiles.io = await ioResp.json();
   decorateProfileMenu(blockEl, profileEl, profiles, toggle);
 }
+
+export default { profile };

--- a/libs/blocks/global-navigation/delayed-utilities.js
+++ b/libs/blocks/global-navigation/delayed-utilities.js
@@ -1,0 +1,93 @@
+const IS_OPEN = 'is-open';
+const curtain = document.querySelector('.gnav-curtain');
+
+class MenuControls {
+  constructor() {
+    this.state = {};
+  }
+
+  toggleOnSpace = (e) => {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      const parentEl = e.target.closest('.has-menu');
+      this.toggleMenu(parentEl);
+    }
+  };
+
+  closeOnScroll = () => {
+    let scrolled;
+    if (!scrolled) {
+      if (this.state.openMenu) {
+        this.toggleMenu(this.state.openMenu);
+      }
+      scrolled = true;
+      document.removeEventListener('scroll', this.closeOnScroll);
+    }
+  };
+
+  toggleMenu = (el) => {
+    const isSearch = el.classList.contains('gnav-search');
+    const sameMenu = el === this.state.openMenu;
+    if (this.state.openMenu) {
+      this.closeMenu();
+    }
+    if (!sameMenu) {
+      this.openMenu(el, isSearch);
+    }
+  };
+
+  closeOnEscape = (e) => {
+    if (e.code === 'Escape') {
+      this.toggleMenu(this.state.openMenu);
+    }
+  };
+
+  closeOnDocClick = (e) => {
+    const closest = e.target.closest(`.${IS_OPEN}`);
+    const isCurtain = e.target === curtain;
+    if ((this.state.openMenu && !closest) || isCurtain) {
+      this.toggleMenu(this.state.openMenu);
+    }
+    if (isCurtain) {
+      curtain.classList.remove('is-open');
+    }
+  };
+
+  openMenu = (el, isSearch) => {
+    el.classList.add(IS_OPEN);
+
+    const menuToggle = el.querySelector('[aria-expanded]');
+    menuToggle.setAttribute('aria-expanded', true);
+    menuToggle.setAttribute('daa-lh', 'header|Close');
+
+    document.addEventListener('click', this.closeOnDocClick);
+    window.addEventListener('keydown', this.closeOnEscape);
+    if (!isSearch) {
+      const desktop = window.matchMedia('(min-width: 900px)');
+      if (desktop.matches) {
+        document.addEventListener('scroll', this.closeOnScroll, { passive: true });
+        if (el.classList.contains('large-menu')) {
+          curtain.classList.add('is-open', 'is-quiet');
+        }
+      }
+    } else {
+      curtain.classList.add('is-open');
+      el.querySelector('.gnav-search-input').focus();
+    }
+    this.state.openMenu = el;
+  };
+
+  closeMenu = () => {
+    this.state.openMenu.classList.remove(IS_OPEN);
+    curtain.classList.remove('is-open');
+    curtain.classList.remove('is-quiet');
+    document.removeEventListener('click', this.closeOnDocClick);
+    window.removeEventListener('keydown', this.closeOnEscape);
+    const menuToggle = this.state.openMenu.querySelector('[aria-expanded]');
+    menuToggle.setAttribute('aria-expanded', false);
+    menuToggle.setAttribute('daa-lh', 'header|Open');
+    this.state.openMenu = null;
+  };
+}
+
+export default { MenuControls };

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -430,120 +430,6 @@ header .gnav-navitem.has-menu > a:after {
   margin-right: 3px;
 }
 
-header .gnav-navitem.has-menu.is-open:before {
-  background: #969796;
-  position: absolute;
-  width: 2px;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  display: block;
-  content: '';
-  z-index: 1;
-}
-
-header .gnav-navitem.has-menu.is-open > a:after {
-  transform: rotate(-135deg);
-}
-
-header .gnav-navitem-menu {
-  display: none;
-  padding: 14px 0;
-  background-color: #FAFAFA;
-}
-
-header .gnav-navitem.has-menu.is-open .gnav-navitem-menu {
-  display: block;
-}
-
-header .gnav-navitem-menu ul {
-  padding-left: 0;
-  margin: 0;
-  list-style: none;
-}
-
-header .gnav-navitem.has-menu.is-open > a {
-  font-weight: 700;
-  position: relative;
-  border-bottom: none;
-}
-
-header .gnav-navitem.has-menu.is-open > a:before {
-  content: '';
-  position: absolute;
-  left: 12px;
-  right: 12px;
-  bottom: 0;
-  display: block;
-  border-bottom: 1px solid #D1D1D1;
-}
-
-header .gnav-navitem-menu a {
-  padding: 12px 36px;
-  white-space: nowrap;
-}
-
-header .gnav-navitem-menu a:hover:not(.con-button) {
-  color: #1473E6;
-  background-color: #F5F5F5;
-}
-
-.gnav .gnav-promo {
-  padding: 16px;
-  margin-top: 6px;
-  background: var(--color-white);
-}
-
-.gnav .gnav-promo.card {
-  width: 260px;
-  padding: 20px;
-  box-sizing: border-box;
-}
-
-.gnav .gnav-promo.card > div:last-child {
-  padding-top: 20px;
-}
-
-.gnav .gnav-promo.image-only {
-  background: unset;
-}
-
-.gnav-promo {
-  border: solid 1px #EAEAEA;
-}
-
-.gnav-promo p:first-child {
-  margin-top: 0;
-}
-
-.gnav-promo p:last-child {
-    margin-bottom: 0;
-}
-
-header .gnav-navitem .gnav-navitem-menu .gnav-promo a {
-  padding: 0;
-  color: #1473E6;
-}
-
-header .gnav-navitem-menu .gnav-promo a:hover {
-  background-color: unset;
-  color: unset;
-}
-
-.gnav-promo picture,
-.gnav-promo img {
-  display: block;
-}
-
-nav.gnav .gnav-navitem-menu .gnav-promo img {
-  width: 160px;
-  margin: 0 auto;
-}
-
-nav.gnav .gnav-navitem-menu .gnav-promo.card img {
-  width: 100%;
-}
-
 .gnav-cta {
   display: flex;
   align-items: center;
@@ -556,100 +442,8 @@ nav.gnav .gnav-navitem-menu .gnav-promo.card img {
   padding: 0 14px;
 }
 
-.gnav-navitem.large-menu .gnav-navitem-menu strong a {
-  display: inline-block;
-  padding: 0 14px;
-  line-height: 36px;
-  border-radius: 20px;
-}
-
-.gnav-navitem.large-menu h5 {
-  font-size: 14px;
-  color: #4B4B4B;
-  border-bottom: 1px solid #D1D1D1;
-  margin-top: 0;
-  margin-bottom: 16px;
-  padding-bottom: 5px;
-}
-
-.gnav-navitem.has-menu.is-open .gnav-menu-container,
-.gnav-navitem.has-menu.is-open .gnav-navitem-menu:scope > div {
-  display: flex;
-  flex-flow: column wrap;
-  padding: 0 24px;
-}
-
-.gnav-navitem.has-menu.is-open .gnav-navitem-menu {
-  padding-top: 0;
-  left: 0;
-  right: 0;
-}
-
-.gnav-navitem.has-menu.is-open .gnav-navitem-menu > div > div > ul {
-  margin: 0;
-}
-
-.gnav-navitem.has-menu.is-open .gnav-navitem-menu > div > div > h5 {
-  margin: 0;
-  padding: 18px 0;
-  line-height: 1;
-}
-
-
-.gnav-navitem.has-menu.is-open .gnav-navitem-menu > div > div > p {
-  margin-top: 10px;
-}
-
-.gnav-navitem.large-menu .gnav-navitem-menu a {
-  padding: 10px 12px;
-}
-
-.gnav-navitem.large-menu .gnav-navitem-menu li:first-child a {
-  margin-top: 4px;
-}
-
-.gnav-navitem.large-menu .link-group {
-  margin-top: 10px;
-}
-
-.gnav-navitem.large-menu .link-group a img {
-  width: 26px;
-  margin-right: 15px;
-}
-
-.gnav-navitem.large-menu .link-group .link-block,
-.gnav-navitem.large-menu .link-group .link-block picture {
-  display: flex;
-  align-items: center;
-  justify-content: start;
-}
-
-.gnav-navitem-menu a.link-block {
-  padding: 12px;
-}
-
-.gnav-navitem.large-menu.gnav-navitem.has-menu.is-open .link-group .link-block div {
-  padding-left: 0;
-  line-height: 1.3;
-}
-
-.gnav-navitem.large-menu .link-group .link-block p {
-  margin: 0;
-}
-
-.gnav-navitem.large-menu .link-group .link-block  p:last-of-type {
-  -webkit-font-smoothing: auto;
-  font-size: 12px;
-  font-weight: 400;
-  color: #656565;
-}
-
 .last-link-blue ul li:last-of-type a {
   color: #1473E6;
-}
-
-.gnav-menu-container .con-button {
-  margin-left: 12px;
 }
 
 /* END MAINNAV */
@@ -896,26 +690,9 @@ header .app-launcher {
     display: flex;
   }
 
-  header .gnav-navitem.has-menu.is-open:before {
-    display: none;
-  }
-
-  header .gnav-navitem.is-open > a {
-    background-color: #FAFAFA;
-}
-
   header .gnav-navitem.section-menu {
     border-left: 1px solid #EBEBEB;
     border-right: 1px solid #EBEBEB;
-  }
-
-  header .gnav-navitem.has-menu.is-open .gnav-navitem-menu.small-Variant,
-  header .gnav-navitem.has-menu.is-open .gnav-navitem-menu.medium-Variant {
-    padding: 18px 20px;
-    position: absolute;
-    display: flex;
-    right: unset;
-    gap: 40px;
   }
 
   /* PROFILE MULTI CLOUD SIGNIN OVERRIDE */
@@ -936,20 +713,6 @@ header .app-launcher {
     justify-content: center;
     position: relative;
     padding: 0 12px 0 0;
-  }
-
-  header .gnav-navitem.has-menu.is-open .gnav-navitem-menu.app-menu {
-    background-color: var(--color-white);
-    display: flex;
-    position: absolute;
-    left: unset;
-    right: 0;
-    border-radius: 0 0 4px 4px;
-    border-left-color: var(--apps-border-color);
-    border-right-color: var(--apps-border-color);
-    border-bottom-color: var(--apps-border-color);
-    box-shadow: 0 1px 4px rgb(0 0 0 / 15%);
-    width: 334px;
   }
 
   header .app-launcher .apps {
@@ -986,11 +749,6 @@ header .app-launcher {
   }
 
   /* END APP LAUNCHER */
-  
-  header .gnav-navitem .small-Variant ul a,
-  header .gnav-navitem .medium-Variant ul a {
-    padding: 6px 12px;
-  }
 
   header .gnav-navitem > a {
     border-bottom: none;
@@ -1001,64 +759,8 @@ header .app-launcher {
     padding: 20px;
   }
 
-  header .gnav-navitem.has-menu.is-open > a {
-    font-weight: unset;
-  }
-
-  .gnav-navitem.has-menu.is-open .gnav-navitem-menu > div > div > h5 {
-    margin: 0 12px;
-    padding: 18px 0 6px 0;
-  }
-
   header .gnav-navitem.section-menu + .gnav-navitem > a {
     padding-left: 20px;
-  }
-
-  header .gnav-navitem.has-menu.is-open > a:before {
-    display: none;
-  }
-
-  .gnav-navitem.has-menu.is-open .gnav-navitem-menu,
-  .gnav-profile.gnav-navitem.has-menu.is-open .gnav-navitem-menu {
-    position: fixed;
-    margin-top: 64px;
-    padding: 0;
-    z-index: 1;
-  }
-
-  .gnav-navitem.has-menu.is-open .gnav-menu-container,
-  .gnav-navitem.has-menu.is-open .gnav-navitem-menu.large-Variant:scope > div {
-      display: flex;
-      flex-flow: row nowrap;
-      justify-content: center;
-      padding: 24px 20px 60px;
-      margin: 0 auto;
-      gap: 100px;
-  }
-
-  .gnav-navitem.large-menu .link-group:first-child {
-    margin-top: 6px;
-  }
-
-  .gnav-navitem.large-menu h5 + .link-group {
-    margin-top: 6px;
-  }
-
-  .gnav-navitem.large-menu .link-group {
-      margin-top: 0;
-  }
-
-  .gnav-navitem.large-menu .gnav-navitem-menu strong a {
-    line-height: 28px;
-  }
-
-  .gnav .gnav-promo {
-    padding: 28px;
-    margin-top: unset;
-  }
-
-  .gnav .gnav-navitem.large-menu .gnav-promo {
-    margin-top: 20px;
   }
 
   .gnav-cta .con-button {

--- a/libs/blocks/global-navigation/utilities.js
+++ b/libs/blocks/global-navigation/utilities.js
@@ -1,10 +1,9 @@
 export function toFragment(htmlStrings, ...values) {
   const templateStr = htmlStrings.reduce((acc, htmlString, index) => {
     if (values[index] instanceof HTMLElement) {
-      return acc + htmlString + `<elem ref="${index}"></elem>`;
-    } else {
-      return acc + htmlString + (values[index] || '');
+      return `${acc + htmlString}<elem ref="${index}"></elem>`;
     }
+    return acc + htmlString + (values[index] || '');
   }, '');
 
   const fragment = document.createRange().createContextualFragment(templateStr).children[0];
@@ -15,7 +14,7 @@ export function toFragment(htmlStrings, ...values) {
   });
 
   return fragment;
-};
+}
 
 export function debounceCallback(callback, time = 200) {
   if (typeof callback !== 'function') return undefined;
@@ -23,7 +22,7 @@ export function debounceCallback(callback, time = 200) {
   let timeout = null;
 
   return (...args) => {
-      clearTimeout(timeout);
-      timeout = setTimeout(() => callback(...args), time);
+    clearTimeout(timeout);
+    timeout = setTimeout(() => callback(...args), time);
   };
-};
+}


### PR DESCRIPTION
### Description
As preparation for the Eurovision team to take over the GNAV block, this PR contains some refactorings that we are exploring and would like to have in our feds-gnav branch.

- Add a loadDelayed section which delays loading navigation related code not needed for LCP
- Refactor menu's and put them in their own file
- Start refactoring the profile/applauncher and put them in their own files
- adopt the toTemplate`` helper from @overmyheadandbody and start introducing it within the `global-navigation.js`
- Start splitting CSS|JS for into smaller chunks

Resolves: [MWPW-122222](https://jira.corp.adobe.com/browse/MWPW-122222)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/document2?martech=off
- After: https://feds-gnav-menu-refactoring--milo--mokimo.hlx.page/drafts/osahin/document?martech=off
