### PR TITLE
MWPW-123765 - Fix link styles in icon block body

### DIFF
--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -195,8 +195,7 @@
   margin-top: var(--spacing-xs);
 }
 
-.icon-block.vertical .foreground .text-content .action-area > a:not(.con-button),
-.icon-block.vertical .foreground .text-content .action-area a:only-child {
+.icon-block.vertical .foreground .text-content .action-area > a:not(.con-button) {
   font-size: var(--type-body-xs-size);
   line-height: var(--type-body-xs-lh);
 }

--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -196,7 +196,7 @@
 }
 
 .icon-block.vertical .foreground .text-content .action-area > a:not(.con-button),
-.icon-block.vertical .foreground .text-content p.body-M a:only-child {
+.icon-block.vertical .foreground .text-content .action-area a:only-child {
   font-size: var(--type-body-xs-size);
   line-height: var(--type-body-xs-lh);
 }


### PR DESCRIPTION
Removing a style that is causing the links in the icon block body to get the same style as the CTA action area links. Turns out that with the updated decorators the style in question was no longer needed, but got overlooked.

Resolves: [MWPW-123765](https://jira.corp.adobe.com/browse/MWPW-123765)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/icon-block?martech=off
- After: https://MWPW-123765_linked_text_fix--milo--adobecom.hlx.page/docs/library/blocks/icon-block?martech=off
