### PR TITLE
Mwpw 12358 Review Block -> added initial value, fixed responsivness, fixed CTA overlay overlap

### DIFF
--- a/libs/blocks/review/README.md
+++ b/libs/blocks/review/README.md
@@ -16,6 +16,7 @@
 | thank you text      | Thank you for your Feedback                              |
 | tooltips            | Poor, Bad, Good, very good, Excellent                    |
 | tooltip delay       | 5                                                        |
+| intitial value      | 0                                                        |
 
 ```
 

--- a/libs/blocks/review/components/helixReview/HelixReview.js
+++ b/libs/blocks/review/components/helixReview/HelixReview.js
@@ -77,7 +77,7 @@ const HelixReview = ({
                 setInitialRating(
                   initialValue !== undefined
                     ? initialValue
-                    : Math.round(average)
+                    : 0 // Math.round(average)
                 );
 
               if (productJson) {

--- a/libs/blocks/review/components/helixReview/HelixReview.js
+++ b/libs/blocks/review/components/helixReview/HelixReview.js
@@ -77,7 +77,7 @@ const HelixReview = ({
                 setInitialRating(
                   initialValue !== undefined
                     ? initialValue
-                    : 0 // Math.round(average)
+                    : Math.round(average)
                 );
 
               if (productJson) {

--- a/libs/blocks/review/components/review/Ratings.js
+++ b/libs/blocks/review/components/review/Ratings.js
@@ -36,7 +36,7 @@ const Ratings = ({
         const hoveredRating = parseInt(fieldSetMouseOut.event.target.value, 10);
         setCurrentRating(hoveredRating);
         if (onRatingHover) onRatingHover({ rating: hoveredRating });
-
+        
         // Delay display of tooltips unless one is currently showing
         if (hoverIndex) {
           clearTimeout(timeoutId);
@@ -59,7 +59,7 @@ const Ratings = ({
     if (!fieldSetMouseLeave.hovering && rating !== currentRating) {
       setCurrentRating(rating);
     }
-  }, [fieldSetMouseOut.hovering, fieldSetMouseLeave.hovering, hoverIndex]);
+  }, [fieldSetMouseOut, fieldSetMouseLeave, hoverIndex]);
 
   useEffect(() => {
     setCurrentRating(rating);

--- a/libs/blocks/review/review.css
+++ b/libs/blocks/review/review.css
@@ -13,7 +13,7 @@
   --tooltipZIndex: 50;
   --ratingCommentsHeight: 58px;
   --ctaCommentHeight: 22px;
-  --commentFieldsHeight: var(--ratingCommentsHeight) + var(--ctaCommentHeight);
+  --commentFieldsHeight: calc(var(--ratingCommentsHeight) + var(--ctaCommentHeight));
 }
 
 .hlx-ReviewWrapper {
@@ -102,6 +102,7 @@
   border-radius: 4px;
   border: 2px solid #b3b3b3;
   height: var(--commentFieldsHeight);
+  box-sizing: content-box;
 }
 
 .hlx-Review-commentFields.has-focus {
@@ -214,7 +215,6 @@
   font-weight: 400;
   opacity: 0;
   transition: var(--tooltipTransitionTime);
-  opacity;
   visibility: hidden;
 }
 
@@ -225,10 +225,8 @@
   margin: 12px 1px 0 1px;
   border: 5px solid var(--tooltipBackground);
   border-color: transparent transparent var(--tooltipBackground);
-  transparent;
   opacity: 0;
   transition: var(--tooltipTransitionTime);
-  opacity;
   visibility: hidden;
 }
 

--- a/libs/blocks/review/review.js
+++ b/libs/blocks/review/review.js
@@ -40,6 +40,7 @@ const App = ({ rootEl, strings }) => html`
     postUrl=${strings.postUrl}
     visitorId=${getVisitorId()}
     reviewPath=${getReviewPath(strings.postUrl)}
+    initialValue=${strings.initialValue}
     onRatingSet=${({ rating, comment }) => {}}
     onRatingHover=${({ rating }) => {}}
     onReviewLoad=${({ hasRated, rating }) => {}}
@@ -61,6 +62,7 @@ const getStrings = (metaData) => {
     tooltips,
     hidetitle,
     reviewurl,
+    initialvalue
   } = metaData;
 
   return {
@@ -77,6 +79,7 @@ const getStrings = (metaData) => {
     hideTitleOnReload: hidetitle,
     tooltips: tooltips && tooltips.split(',').map((t) => t.trim()),
     postUrl: reviewurl,
+    initialValue: initialvalue
   };
 };
 


### PR DESCRIPTION
- Added `Initial Value` to list of settings authors can set , since by default It shows the rounded average rating when page gets loaded.
- Responsivness issues: hovering over the stars would not work properly, due to preact (milo) handling events differently then dexter (react).
- the cta overlay (the send button ) would overay the border of the comment box, due to a errors in CSS.
- some CSS cleanup.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/msagolj/testpage
- After: https://mwpw-12358--milo--adobecom.hlx.page/drafts/msagolj/testpage

To Test:
- you can now set 'Initial Value' in the block table, if not set it will render the average rounded rating
- the mouse hovering over the stars is now working properly, before it only worked by entring from bottom end of star.
- Click on a star,  the `Send` button should now bpe properly placed inside the comment box
- To test in context of a frictionless page: start milo with `npm run libs` on the` MWPW-12358` branch, and open `After ` link above with `?milolibs=local`