### PR TITLE
MWPW-120782 - Fix Chart Color Order

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -17,16 +17,16 @@ export const DESKTOP_BREAKPOINT = 1200;
 export const TABLET_BREAKPOINT = 600;
 export const colorPalette = {
   seafoam: '#0FB5AE',
-  orange: '#F68511',
   indigo: '#4046CA',
-  purple: '#7326D3',
-  blue: '#147AF3',
-  lime: '#72E06A',
-  lavender: '#7E84FA',
+  orange: '#F68511',
   magenta: '#DE3D82',
-  green: '#008F5D',
-  copper: '#CB5D00',
+  lavender: '#7E84FA',
+  lime: '#72E06A',
+  blue: '#147AF3',
+  purple: '#7326D3',
   yellow: '#E8C600',
+  copper: '#CB5D00',
+  green: '#008F5D',
   chartreuse: '#BCE931',
 };
 const SECTION_CLASSNAME = 'chart-section';

--- a/test/blocks/chart/chart.test.js
+++ b/test/blocks/chart/chart.test.js
@@ -106,7 +106,7 @@ describe('chart', () => {
 
   it('getColors returns rotated color list if color provided ', () => {
     const authoredColor = 'indigo';
-    const colors = ['#4046CA', '#7326D3', '#147AF3', '#72E06A', '#7E84FA', '#DE3D82', '#008F5D', '#CB5D00', '#E8C600', '#BCE931', '#0FB5AE', '#F68511'];
+    const colors = ['#4046CA', '#F68511', '#DE3D82', '#7E84FA', '#72E06A', '#147AF3', '#7326D3', '#E8C600', '#CB5D00', '#008F5D', '#BCE931', '#0FB5AE'];
 
     expect(getColors(authoredColor)).to.eql(colors);
   });


### PR DESCRIPTION
* Fix the Chart block color palette to match Spectrum's order

Resolves: [MWPW-120782](https://jira.corp.adobe.com/browse/MWPW-120782)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/chart-spectrum-colors?martech=off
- After: https://methomas-chart-spectrum-colors--milo--adobecom.hlx.page/drafts/methomas/chart-spectrum-colors?martech=off
- After: https://main--bacom--adobecom.hlx.page/resources/holiday-shopping-report?milolibs=methomas-chart-spectrum-colors