### PR TITLE
MWPW-122827 - [SEO] Report on 404s

### DIFF
--- a/libs/templates/404/404.js
+++ b/libs/templates/404/404.js
@@ -44,6 +44,28 @@ async function load404() {
   sampleRUM('404', { source: document.referrer, target: window.location.href });
 }
 
+function log404() {
+  const logFile = '/drafts/jck/404-logs';
+  const requestDate = new Date().toISOString();
+  const requestUrl = window.location.href;
+  fetch(logFile, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      'data': {
+        'date': requestDate,
+        'url': requestUrl,
+      },
+    })
+  })
+    .catch((error) => {
+      console.error('Error logging the 404:', error);
+    });
+}
+
 (async function init() {
   load404();
+  log404();
 }());


### PR DESCRIPTION
- log 404 in an Excel/gdocs sheet

Resolves: [MWPW-122827](https://jira.corp.adobe.com/browse/MWPW-122827)

Note: it seems that tracking 404s should be done with Analytics tooling, not Milo (see the discussion in the ticket). In case the decision is revisited this draft can be used as a starting point.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://seo-log-404--milo--adobecom.hlx.page/?martech=off
