### PR TITLE
MWPW-124277 - Link Localization not working for some links in Gnav and Footer

### DIFF
--- a/libs/blocks/footer/footer.js
+++ b/libs/blocks/footer/footer.js
@@ -1,6 +1,7 @@
 import {
   createTag,
   decorateAutoBlock,
+  decorateLinks,
   getConfig,
   getMetadata,
   loadBlock,
@@ -109,6 +110,7 @@ class Footer {
         const linksContainer = heading.nextElementSibling;
         linksContainer.classList = 'footer-nav-item-links';
         linksContainer.id = `${titleId}-menu`;
+        decorateLinks(linksContainer);
         const links = linksContainer.querySelectorAll('li');
         links.forEach((link) => {
           link.classList.add('footer-nav-item-link');

--- a/libs/blocks/footer/footer.js
+++ b/libs/blocks/footer/footer.js
@@ -42,6 +42,7 @@ class Footer {
     }
 
     this.addAnalytics(wrapper);
+    decorateLinks(wrapper);
     this.footerEl.append(wrapper);
   };
 
@@ -110,7 +111,6 @@ class Footer {
         const linksContainer = heading.nextElementSibling;
         linksContainer.classList = 'footer-nav-item-links';
         linksContainer.id = `${titleId}-menu`;
-        decorateLinks(linksContainer);
         const links = linksContainer.querySelectorAll('li');
         links.forEach((link) => {
           link.classList.add('footer-nav-item-link');

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -1,11 +1,9 @@
 import {
   createTag,
   decorateLinks,
-  decorateSVG,
   getConfig,
   getMetadata,
   loadScript,
-  localizeLink,
 } from '../../utils/utils.js';
 
 import {
@@ -100,7 +98,7 @@ class Gnav {
     if (breadcrumbs) {
       wrapper.append(breadcrumbs);
     }
-
+    decorateLinks(wrapper);
     this.el.append(this.curtain, wrapper);
   };
 
@@ -136,7 +134,6 @@ class Gnav {
     if (!brandBlock) return null;
     const brandLinks = [...brandBlock.querySelectorAll('a')];
     const brand = brandLinks.pop();
-    brand.href = localizeLink(brand.href);
     const brandTitle = brand.textContent;
     brand.className = brandBlock.className;
     const title = createTag('span', { class: 'gnav-brand-title' }, brandTitle);
@@ -145,7 +142,6 @@ class Gnav {
     if (brand.textContent !== '') brand.textContent = '';
     if (brand.classList.contains('logo')) {
       if (brandLinks.length > 0) {
-        decorateSVG(brandLinks[0]);
         brand.insertAdjacentElement('afterbegin', brandLinks[0].querySelector('img'));
       } else {
         brand.insertAdjacentHTML('afterbegin', BRAND_IMG);
@@ -158,7 +154,6 @@ class Gnav {
   decorateLogo = () => {
     const logo = this.body.querySelector('.adobe-logo a');
     if (!logo) return null;
-    logo.href = localizeLink(logo.href);
     logo.classList.add('gnav-logo');
     logo.setAttribute('aria-label', logo.textContent);
     logo.setAttribute('daa-ll', 'Logo');
@@ -178,7 +173,6 @@ class Gnav {
 
   buildMainNav = (mainNav, navLinks) => {
     navLinks.forEach((navLink, idx) => {
-      navLink.href = localizeLink(navLink.href);
       const navItem = createTag('div', { class: 'gnav-navitem' });
       const navBlock = navLink.closest('.large-menu');
       const menu = navLink.closest('div');
@@ -228,7 +222,6 @@ class Gnav {
       const subtitle = linkGroup.querySelector('p:last-of-type') || '';
       const titleWrapper = createTag('div');
       titleWrapper.className = 'link-group-title';
-      anchor.href = localizeLink(anchor.href);
       const link = createTag('a', { class: 'link-block', href: anchor.href });
 
       linkGroup.replaceChildren();
@@ -289,7 +282,6 @@ class Gnav {
       container.append(...Array.from(menu.children));
       menu.append(container);
     }
-    decorateLinks(menu);
     this.decorateLinkGroups(menu);
     this.decorateAnalytics(menu);
     navLink.addEventListener('focus', () => {
@@ -309,16 +301,11 @@ class Gnav {
 
   decorateLargeMenu = (navLink, navItem, menu) => {
     let path = navLink.href;
-    path = localizeLink(path);
     const promise = fetch(`${path}.plain.html`);
     promise.then(async (resp) => {
       if (resp.status === 200) {
         const text = await resp.text();
         menu.insertAdjacentHTML('beforeend', text);
-        const links = menu.querySelectorAll('a');
-        links.forEach((link) => {
-          decorateSVG(link);
-        });
         const decoratedMenu = this.decorateMenu(navItem, navLink, menu);
         const menuSections = decoratedMenu.querySelectorAll('.gnav-menu-container > div');
         menuSections.forEach((sec) => { sec.classList.add('section'); });
@@ -335,7 +322,6 @@ class Gnav {
   decorateCta = () => {
     const cta = this.body.querySelector('strong a');
     if (cta) {
-      cta.href = localizeLink(cta.href);
       const { origin } = new URL(cta.href);
       if (origin !== window.location.origin) {
         cta.target = '_blank';
@@ -507,7 +493,6 @@ class Gnav {
       const ul = parent.querySelector('ul');
       if (ul) {
         ul.querySelector('li:last-of-type')?.setAttribute('aria-current', 'page');
-        decorateLinks(ul);
         const nav = createTag('nav', { class: 'breadcrumbs', 'aria-label': 'Breadcrumb' }, ul);
         parent.remove();
         return nav;

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -1,5 +1,6 @@
 import {
   createTag,
+  decorateLinks,
   decorateSVG,
   getConfig,
   getMetadata,
@@ -135,6 +136,7 @@ class Gnav {
     if (!brandBlock) return null;
     const brandLinks = [...brandBlock.querySelectorAll('a')];
     const brand = brandLinks.pop();
+    brand.href = localizeLink(brand.href);
     const brandTitle = brand.textContent;
     brand.className = brandBlock.className;
     const title = createTag('span', { class: 'gnav-brand-title' }, brandTitle);
@@ -287,6 +289,7 @@ class Gnav {
       container.append(...Array.from(menu.children));
       menu.append(container);
     }
+    decorateLinks(menu);
     this.decorateLinkGroups(menu);
     this.decorateAnalytics(menu);
     navLink.addEventListener('focus', () => {
@@ -332,6 +335,7 @@ class Gnav {
   decorateCta = () => {
     const cta = this.body.querySelector('strong a');
     if (cta) {
+      cta.href = localizeLink(cta.href);
       const { origin } = new URL(cta.href);
       if (origin !== window.location.origin) {
         cta.target = '_blank';
@@ -503,6 +507,7 @@ class Gnav {
       const ul = parent.querySelector('ul');
       if (ul) {
         ul.querySelector('li:last-of-type')?.setAttribute('aria-current', 'page');
+        decorateLinks(ul);
         const nav = createTag('nav', { class: 'breadcrumbs', 'aria-label': 'Breadcrumb' }, ul);
         parent.remove();
         return nav;

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -18,7 +18,7 @@ import {
 } from '../utils/utils.js';
 
 // Production Domain
-const productionDomain = 'milo.adobe.com';
+const prodDomains = ['milo.adobe.com'];
 
 const locales = {
   // Americas
@@ -111,7 +111,7 @@ const config = {
   imsClientId: 'milo',
   codeRoot: '/libs',
   locales,
-  productionDomain,
+  prodDomains,
   marketoBaseURL: '//app-aba.marketo.com',
   marketoFormID: '1761',
   marketoMunchkinID: '345-TTI-184',

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -193,7 +193,7 @@ export function localizeLink(href, originHostName = window.location.hostname) {
   if (!locale || !locales) return processedHref;
   const isLocalizable = relative || productionDomain === url.hostname;
   if (!isLocalizable) return processedHref;
-  const isLocalizedLink = path.startsWith(`/${LANGSTORE}`) || Object.keys(locales).some((loc) => loc !== '' && path.startsWith(`/${loc}/`));
+  const isLocalizedLink = path.startsWith(`/${LANGSTORE}`) || Object.keys(locales).some((loc) => loc !== '' && (path.startsWith(`/${loc}/`) || path.endsWith(`/${loc}`)));
   if (isLocalizedLink) return processedHref;
   const urlPath = `${locale.prefix}${path}${url.search}${hash}`;
   return relative ? urlPath : `${url.origin}${urlPath}`;
@@ -399,7 +399,7 @@ export function decorateAutoBlock(a) {
   });
 }
 
-function decorateLinks(el) {
+export function decorateLinks(el) {
   const anchors = el.getElementsByTagName('a');
   return [...anchors].reduce((rdx, a) => {
     a.href = localizeLink(a.href);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -180,23 +180,28 @@ function getExtension(path) {
 }
 
 export function localizeLink(href, originHostName = window.location.hostname) {
-  const url = new URL(href);
-  const relative = url.hostname === originHostName;
-  const processedHref = relative ? href.replace(url.origin, '') : href;
-  const { hash } = url;
-  if (hash === '#_dnt') return processedHref.split('#')[0];
-  const path = url.pathname;
-  const extension = getExtension(path);
-  const allowedExts = ['', 'html', 'json'];
-  if (!allowedExts.includes(extension)) return processedHref;
-  const { locale, locales, productionDomain } = getConfig();
-  if (!locale || !locales) return processedHref;
-  const isLocalizable = relative || productionDomain === url.hostname;
-  if (!isLocalizable) return processedHref;
-  const isLocalizedLink = path.startsWith(`/${LANGSTORE}`) || Object.keys(locales).some((loc) => loc !== '' && (path.startsWith(`/${loc}/`) || path.endsWith(`/${loc}`)));
-  if (isLocalizedLink) return processedHref;
-  const urlPath = `${locale.prefix}${path}${url.search}${hash}`;
-  return relative ? urlPath : `${url.origin}${urlPath}`;
+  try {
+    const url = new URL(href);
+    const relative = url.hostname === originHostName;
+    const processedHref = relative ? href.replace(url.origin, '') : href;
+    const { hash } = url;
+    if (hash === '#_dnt') return processedHref.split('#')[0];
+    const path = url.pathname;
+    const extension = getExtension(path);
+    const allowedExts = ['', 'html', 'json'];
+    if (!allowedExts.includes(extension)) return processedHref;
+    const { locale, locales, prodDomains } = getConfig();
+    if (!locale || !locales) return processedHref;
+    const isLocalizable = relative || (prodDomains && prodDomains.includes(url.hostname));
+    if (!isLocalizable) return processedHref;
+    const isLocalizedLink = path.startsWith(`/${LANGSTORE}`) || Object.keys(locales)
+      .some((loc) => loc !== '' && (path.startsWith(`/${loc}/`) || path.endsWith(`/${loc}`)));
+    if (isLocalizedLink) return processedHref;
+    const urlPath = `${locale.prefix}${path}${url.search}${hash}`;
+    return relative ? urlPath : `${url.origin}${urlPath}`;
+  } catch (error) {
+    return href;
+  }
 }
 
 export function loadStyle(href, callback) {

--- a/test/blocks/gnav/gnav.test.js
+++ b/test/blocks/gnav/gnav.test.js
@@ -6,8 +6,12 @@ import { setConfig } from '../../../libs/utils/utils.js';
 
 window.lana = { log: stub() };
 
-document.head.innerHTML = await readFile({ path: './mocks/head.html' });
-document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+async function loadDefaultHtml() {
+  document.head.innerHTML = await readFile({ path: './mocks/head.html' });
+  document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+}
+
+await loadDefaultHtml();
 
 const mod = await import('../../../libs/blocks/gnav/gnav.js');
 let gnav;
@@ -129,5 +133,59 @@ describe('Gnav', () => {
     expect(script).to.be.null;
     // reset <head>
     document.head.innerHTML = await readFile({ path: './mocks/head.html' });
+  });
+});
+
+describe('Localized Gnav', () => {
+
+  before( async () => {
+    // Load Localized Gnav
+    await loadDefaultHtml();
+    document.head.getElementsByTagName('meta')[0].setAttribute('content', '/test/blocks/gnav/mocks/simple-gnav');
+    const localizedConfig = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' }, fi: { ietf: 'fi-FI', tk: 'aaz7dvd.css' }, } };
+    localizedConfig.pathname = '/fi/gnav';
+    localizedConfig.productionDomain = 'milo.adobe.com';
+    setConfig(localizedConfig);
+    gnav = await mod.default(document.querySelector('header'));
+  });
+
+  after (async () => {
+    // reset to regular Gnav
+    setConfig(config);
+    await loadDefaultHtml();
+    gnav = await mod.default(document.querySelector('header'));
+  })
+
+  it('Test Gnav Localized Links', async () => {
+    const links = document.getElementById('localized-links').getElementsByTagName('a');
+    links.forEach((anchor) => {
+      expect(anchor.href.startsWith('https://milo.adobe.com/fi/'), "Menu Links should be localized").true;
+    });
+  });
+
+  it('Test Gnav DNT Links', async () => {
+    const dntLinks = document.getElementById('dnt-links')
+      .getElementsByTagName('a');
+    dntLinks.forEach((anchor) => {
+      const dntLink = anchor.href;
+      expect(dntLink.startsWith('https://milo.adobe.com/fi/'), "Menu DNT Links should not be localized").false;
+      expect(dntLink.endsWith('#_dnt'), "#_dnt should be stripped").false;
+    });
+  });
+
+  it('Test Gnav Breadcrumb Links', async () => {
+    const breadcrumbLinks = document.querySelector('header nav.breadcrumbs').getElementsByTagName('a');
+    breadcrumbLinks.forEach((anchor) => {
+      expect(anchor.href.startsWith('http://localhost:2000/fi/'), "Breadcrumb Links should be localized").true;
+    });
+  });
+
+  it('Test Gnav Cta Link', async () => {
+    const ctaLink = document.querySelector('.gnav-cta').getElementsByTagName('a')[0];
+    expect(ctaLink.href.startsWith('http://localhost:2000/fi/'), "Cta Link should be localized").true;
+  });
+
+  it('Test Gnav Brand Link', async () => {
+    expect(document.querySelector('.gnav-brand').href.startsWith('http://localhost:2000/fi/'), "Brand Link should be localized").true;
   });
 });

--- a/test/blocks/gnav/gnav.test.js
+++ b/test/blocks/gnav/gnav.test.js
@@ -144,7 +144,7 @@ describe('Localized Gnav', () => {
     document.head.getElementsByTagName('meta')[0].setAttribute('content', '/test/blocks/gnav/mocks/simple-gnav');
     const localizedConfig = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' }, fi: { ietf: 'fi-FI', tk: 'aaz7dvd.css' }, } };
     localizedConfig.pathname = '/fi/gnav';
-    localizedConfig.productionDomain = 'milo.adobe.com';
+    localizedConfig.prodDomains = ['milo.adobe.com'];
     setConfig(localizedConfig);
     gnav = await mod.default(document.querySelector('header'));
   });

--- a/test/blocks/gnav/mocks/simple-gnav.plain.html
+++ b/test/blocks/gnav/mocks/simple-gnav.plain.html
@@ -1,0 +1,48 @@
+<html>
+<head></head>
+<body>
+<div>
+  <div class="gnav-brand--logo-">
+    <div>
+      <div>
+        <h2 id="helix-global-nav">
+          <a href="/">Helix Global Nav</a>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <h2 id="localized-links-menu">
+    <a href="https://business.adobe.com">Localized Links</a>
+  </h2>
+  <ul id="localized-links">
+    <li><a href="https://milo.adobe.com/about/">About Milo</a></li>
+    <li><a href="https://milo.adobe.com/about/index.html">About Milo Index</a></li>
+    <li><a href="https://milo.adobe.com/docs/">Milo Docs</a></li>
+  </ul>
+</div>
+<div>
+  <h2 id="dnt-menu">
+    <a href="https://business.adobe.com">Dnt Links</a>
+  </h2>
+  <ul id="dnt-links">
+    <li><a href="https://milo.adobe.com/docs#_dnt">Milo Docs English</a></li>
+  </ul>
+</div>
+<div>
+  <p>
+    <strong>
+      <a href="/about">Call to Action</a>
+    </strong>
+  </p>
+</div>
+<div class="adobe-logo">
+  <div>
+    <div>
+      <a href="https://www.adobe.com">Adobe</a>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -259,6 +259,7 @@ describe('Utils', () => {
     it('Same domain link that is already localized is returned as relative', () => {
       expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/be_fr/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
       expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/fi/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/fi/gnav/solutions');
+      expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/fi', 'main--milo--adobecom.hlx.page')).to.equal('/fi');
       expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/langstore/fr/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/langstore/fr/gnav/solutions');
     });
 

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -225,7 +225,7 @@ describe('Utils', () => {
         be_fr: { ietf: 'fr-BE', tk: 'vrk5vyv.css' },
         langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
       };
-      config.productionDomain = 'milo.adobe.com';
+      config.prodDomains = ['milo.adobe.com', 'www.adobe.com'];
       config.pathname = '/be_fr/page';
       config.origin = 'https://main--milo--adobecom';
       utils.setConfig(config);
@@ -277,12 +277,21 @@ describe('Utils', () => {
       expect(utils.localizeLink('https://milo.adobe.com/solutions/customer-experience-personalization-at-scale.html', 'main--milo--adobecom.hlx.page'))
         .to
         .equal('https://milo.adobe.com/be_fr/solutions/customer-experience-personalization-at-scale.html');
+      expect(utils.localizeLink('https://www.adobe.com/solutions/customer-experience-personalization-at-scale.html', 'main--milo--adobecom.hlx.page'))
+        .to
+        .equal('https://www.adobe.com/be_fr/solutions/customer-experience-personalization-at-scale.html');
     });
 
     it('Live domain html link with #_dnt is left absolute, not localized and #_dnt is removed', () => {
       expect(utils.localizeLink('https://milo.adobe.com/solutions/customer-experience-personalization-at-scale.html#_dnt', 'main--milo--adobecom.hlx.page'))
         .to
         .equal('https://milo.adobe.com/solutions/customer-experience-personalization-at-scale.html');
+    });
+
+    it('Invalid href fails gracefully', () => {
+      expect(utils.localizeLink('not-a-url', 'main--milo--adobecom.hlx.page'))
+        .to
+        .equal('not-a-url');
     });
   });
 


### PR DESCRIPTION
- call decorateLinks for gnav in gnav init instead of individual blocks
- removed decorateSVG and localizeLink instances as it is called in decorateLinks
- added tests to verify link localization in gnav menu, breadcrumb, cta, brand link
- call decorateLinks for footer links in init method
- added try catch in utils for empty href or malformed href
- fix https://business.adobe.com/au getting converted to https://business.adobe.com/au/au
- add test for this fix
- Support http://www.adobe.com/ link localization and add test for the same

Resolves: MWPW-124277

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/kr/customer-success-stories?martech=off
- After: https://main--bacom--adobecom.hlx.page/kr/customer-success-stories?milolibs=link-transform&martech=off
