### PR TITLE
MWPW-124631 check if adobe logo block exists in document

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -155,6 +155,7 @@ class Gnav {
 
   decorateLogo = () => {
     const logo = this.body.querySelector('.adobe-logo a');
+    if (!logo) return null;
     logo.href = localizeLink(logo.href);
     logo.classList.add('gnav-logo');
     logo.setAttribute('aria-label', logo.textContent);


### PR DESCRIPTION
Adds the ability to remove the Adobe logo on the right. Currently if the `Adobe Logo` block is missing the rendering of the complete gnav fails.

Resolves: [MWPW-124631](https://jira.corp.adobe.com/browse/MWPW-124631)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/msagolj/testpage
- After:  https://mwpw-124631--milo--adobecom.hlx.page/drafts/msagolj/testpage

To Test:
- open Before link: Navigation fails to load, error in browser console
- open After link: Navigation renders without adobe logo on the right
