### PR TITLE
MWPW-124632 [Milo] No character count in the review component text box

### DIFF
--- a/libs/blocks/review/components/review/Comments.js
+++ b/libs/blocks/review/components/review/Comments.js
@@ -12,9 +12,11 @@ function Comments({
   placeholderText,
   sendCtaText,
 }) {
+  const maxLength = 500;
   const [hasComment, setHasComment] = useState(false);
   const [displaySend, setDisplaySend] = useState(false);
   const [hasFocus, setHasFocus] = useState(false);
+  const [charCount, setCharCount] = useState(maxLength);
 
   const textArea = useRef(null);
 
@@ -27,6 +29,7 @@ function Comments({
   const onCommentChange = (e) => {
     const { value } = e.target;
     setHasComment(!!value);
+    setCharCount(maxLength - value.length);
     if (handleCommentChange) {
       handleCommentChange(value);
     }
@@ -53,6 +56,9 @@ function Comments({
     <input disabled=${!hasComment} type="submit" value=${sendCtaText} />
   `;
 
+  const charCountElement = html`
+    <span class="comment-counter">${charCount}/${maxLength}</span>
+  `
   return html`
     <fieldset className=${commentsClass}>
       <label htmlFor="rating-comments" />
@@ -60,7 +66,7 @@ function Comments({
         id="rating-comments"
         ref=${textArea}
         cols="40"
-        maxlength="4000"
+        maxlength=${maxLength}
         name="rating-comments"
         aria-label=${label}
         placeholder=${placeholderText}
@@ -69,8 +75,10 @@ function Comments({
         value=${comment}
         onBlur=${onBlur}
       />
-      <div id="ctaCover" onClick=${onCtaCoverClick}></div>
-      ${displaySend && disabledElement}
+      <div id="ctaCover" onClick=${onCtaCoverClick}>
+        ${charCountElement}
+      </div>
+        ${displaySend && disabledElement}
     </fieldset>
   `;
 }

--- a/libs/blocks/review/review.css
+++ b/libs/blocks/review/review.css
@@ -164,6 +164,11 @@
   display: flex;
 }
 
+.hlx-Review-commentFields .comment-counter {
+  color: #d3d3d3;
+  font-size: var(--type-body-xs-size);
+}
+
 .hlx-ReviewStats {
   display: none;
   font-size: 16px;


### PR DESCRIPTION
Adds the character counter for the ratings comment textarea, same as in currently active version e.g.[ here](https://www.adobe.com/ch_de/acrobat/online/rearrange-pdf.html).

Resolves: [MWPW-124632](https://jira.corp.adobe.com/browse/MWPW-124632)

**Test URLs:**
Before: https://main--milo--adobecom.hlx.page/drafts/msagolj/testpage
After: https://mwpw-124632--milo--adobecom.hlx.page/drafts/msagolj/testpage

To Test:
- open page
- scroll down to review rating
- select from 1 to 3 stars (4-5 will submit rating directly)
- Comment box opens
=> Before Page: No counter in the bottom left corner
=> After Page: char counter in bottom left, max 500 chars. 