### PR TITLE
MWPW-124584

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -414,7 +414,11 @@ class Gnav {
     const profileEl = createTag('div', { class: 'gnav-profile' });
     if (blockEl.children.length > 1) profileEl.classList.add('has-menu');
 
-    const { locale, imsClientId, env } = getConfig();
+    const defaultOnReady = () => { 
+      this.imsReady(blockEl, profileEl); ;
+    }
+
+    const { locale, imsClientId, env, onReady } = getConfig();
     if (!imsClientId) return null;
     window.adobeid = {
       client_id: imsClientId,
@@ -423,7 +427,7 @@ class Gnav {
       autoValidateToken: true,
       environment: env.ims,
       useLocalStorage: false,
-      onReady: () => { this.imsReady(blockEl, profileEl); },
+      onReady: onReady || defaultOnReady,
     };
     loadScript('https://auth.services.adobe.com/imslib/imslib.min.js');
     return profileEl;


### PR DESCRIPTION
* Allows option to pass site specific function to `adobeid.onReady`. The frictionless pages need this option to go live. These new functions will be added to the consumer's script config options.
<img width="481" alt="Screenshot 2023-01-24 at 11 18 39 AM" src="https://user-images.githubusercontent.com/6355943/214376752-f4f05183-8908-4d10-9827-65e3302d4939.png">

Resolves: [MWPW-124584](https://jira.corp.adobe.com/browse/MWPW-124584)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://MWPW-124584--milo--adobecom.hlx.page/?martech=off
