### PR TITLE
MWPW-125032 Brand Block: using an SVG link for logo breaks gnav rendering

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -145,7 +145,7 @@ class Gnav {
     if (brand.classList.contains('logo')) {
       if (brandLinks.length > 0) {
         decorateSVG(brandLinks[0]);
-        brand.insertAdjacentElement('afterbegin', brandLinks[0].querySelector('img'));
+        brand.insertAdjacentElement('afterbegin', brandBlock.querySelector('img'));
       } else {
         brand.insertAdjacentHTML('afterbegin', BRAND_IMG);
       }


### PR DESCRIPTION
When trying to add a link to a SVG Logo in Brand Block like this:

![image-2023-01-26-13-34-01-095](https://user-images.githubusercontent.com/37147400/214839545-413f57e5-cc3d-4897-a7e0-ebf9ae2c8294.png)

 the rendering of the complete gnav block fails with:
```
gnav.js:635 Could not create global navigation: TypeError: Failed to execute 'insertAdjacentElement' on 'Element': parameter 2 is not of type 'Element'.
    at Gnav.decorateBrand (gnav.js:148:15)
    at Gnav.init (gnav.js:61:24)
    at init (gnav.js:629:10)
    at async utils.js:345:9
```

Resolves: [MWPW-125032](https://jira.corp.adobe.com/browse/MWPW-125032)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/msagolj/mwpw-125032?martech=off
- After: https://mwpw-125032--milo--adobecom.hlx.page/drafts/msagolj/mwpw-125032?martech=off
