### PR TITLE
Add utils test coverage

### DIFF
--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -25,6 +25,9 @@
     <!-- SVGs -->
     <p><a href="https://milo.adobe.com/img/favicon.svg">https://milo.adobe.com/img/favicon.svg</a></p>
     <p><a href="https://www.adobe.com">https://milo.adobe.com/img/favicon.svg</a></p>
+    <p><a class="bad-url" href="https://www.adobe.com">img/favicon.svg</a></p>
+    <!-- #_blank -->
+    <p><a class="new-tab" href="https://www.adobe.com/test#_blank">New Tab</a></p>
     <!-- Nofollow -->
     <p><a href="https://analytics.google.com">Google analytics</a></p>
   </div>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -181,6 +181,25 @@ describe('Utils', () => {
     validateLocale('/langstore/lv/page', { prefix: '/langstore/lv', ietf: 'en-US', tk: 'hah7vzn.css' });
   });
 
+  it('Open link in new tab', () => {
+    const newTabLink = document.querySelector('.new-tab');
+    newTabLink.target = '_blank';
+    expect(newTabLink.target).to.contain('_blank');
+    newTabLink.href = newTabLink.href.replace('#_blank', '');
+    expect(newTabLink.href).to.equal('https://www.adobe.com/test');
+  });
+
+  describe('SVGs', () => {
+    it('Not a valid URL', () => {
+      const a = document.querySelector('.bad-url');
+      try {
+        const textContentUrl = new URL(a.textContent);
+      } catch (err) {
+        expect(err.message).to.equal("Failed to construct 'URL': Invalid URL");
+      }
+    });
+  });
+
   describe ('rtlSupport', () => {
     before(async () => {
       config.locales = {


### PR DESCRIPTION
* Added coverage for svg's
* Added coverage for #_blank

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://svg-tests--milo--adobecom.hlx.page/?martech=off
