### PR TITLE
MWPW-124277: Localize Gnav Sign In Link

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -454,6 +454,7 @@ class Gnav {
 
   decorateSignIn = (blockEl, profileEl) => {
     const dropDown = blockEl.querySelector(':scope > div:nth-child(2)');
+    decorateLinks(blockEl);
     const signIn = blockEl.querySelector('a');
 
     signIn.classList.add('gnav-signin');


### PR DESCRIPTION
- Call decorateLinks for gnav sign in

Resolves: MWPW-124277

**Test URLs:**
- https://main--bacom--adobecom.hlx.page/kr/customer-success-stories
- https://main--bacom--adobecom.hlx.page/kr/customer-success-stories?milolibs=link-transform
