### PR TITLE
removing display none from accordion

### DIFF
--- a/libs/blocks/accordion/accordion.css
+++ b/libs/blocks/accordion/accordion.css
@@ -8,10 +8,6 @@
   color: #FFFFFF;
 }
 
-div.accordion {
-  display: none;
-}
-
 dl.accordion {
   max-width: var(--grid-container-width);
   margin: 0 auto;


### PR DESCRIPTION
Small patch to remove unnecessary display:none from accordion css that was causing clash with other components. 

**Test URLs:**
Before: https://main--milo--adobecom.hlx.page/drafts/bradjohn/accordion-how-to?martech=off
After: https://accordion-patch--milo--adobecom.hlx.page/drafts/bradjohn/accordion-how-to?martech=off

Bacom
- Before: https://main--bacom--adobecom.hlx.page/layouts/products/product-benefit?milolibs=accordion-patch?martech=off
- After: https://main--bacom--adobecom.hlx.page/layouts/products/product-benefit?milolibs=accordion-patch?martech=off
