### PR TITLE
MWPW-125464 - Adding events to the modal on close and load

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -18,6 +18,8 @@ function findDetails(hash, el) {
 
 function closeModal(modal) {
   const { id } = modal;
+  const closeEvent = new Event('modal:closed');
+  window.dispatchEvent(closeEvent);
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
     if (mod.nextElementSibling?.classList.contains('modal-curtain')) {
@@ -66,6 +68,7 @@ export async function getModal(details, custom) {
   const { id } = details || custom;
 
   const dialog = createTag('div', { class: 'dialog-modal', id });
+  const loadedEvent = new Event('modal:loaded');
 
   if (custom) getCustomModal(custom, dialog);
   if (details) await getPathModal(details.path, dialog);
@@ -116,6 +119,7 @@ export async function getModal(details, custom) {
   dialog.append(close);
   document.body.append(dialog);
   firstFocusable.focus(focusVisible);
+  window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {
     const curtain = createTag('div', { class: 'modal-curtain is-open' });

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -18,14 +18,16 @@ function findDetails(hash, el) {
 
 function closeModal(modal) {
   const { id } = modal;
-  const closeEvent = new Event('modal:closed');
+  const closeEvent = new Event('milo:modal:closed');
   window.dispatchEvent(closeEvent);
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
     if (mod.nextElementSibling?.classList.contains('modal-curtain')) {
       mod.nextElementSibling.remove();
     }
-    mod.remove();
+    if (mod.classList.contains('dialog-modal')) {
+      mod.remove();
+    }
     document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();
   });
 
@@ -68,7 +70,7 @@ export async function getModal(details, custom) {
   const { id } = details || custom;
 
   const dialog = createTag('div', { class: 'dialog-modal', id });
-  const loadedEvent = new Event('modal:loaded');
+  const loadedEvent = new Event('milo:modal:loaded');
 
   if (custom) getCustomModal(custom, dialog);
   if (details) await getPathModal(details.path, dialog);


### PR DESCRIPTION
* Adds a 'milo:modal:closed' event on modal close
* Adds a 'milo:modal:loaded' event on modal open/load
* Adds a check to see if the modal item to be removed during close modal is the modal itself - resolves a bug @Brandon32  found while reviewing

Resolves: [MWPW-125464](https://jira.corp.adobe.com/browse/MWPW-125464)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/slavin/complex-modal?martech=off
- After: https://add-modal-events--milo--adobecom.hlx.page/drafts/slavin/complex-modal?martech=off

**To Test**
You can add the following functions in the console and observe that the console logs out when the modal is opened and closed:
```
window.addEventListener('milo:modal:closed', () => {
    console.log('closed');
})
window.addEventListener('milo:modal:loaded', () => {
    console.log('loaded');
})
```