### PR TITLE
Fixing faas issue with error icon style and fragment rendering issue.

### DIFF
--- a/libs/blocks/faas/faas.css
+++ b/libs/blocks/faas/faas.css
@@ -119,7 +119,7 @@ input[type="checkbox"] + label {
 
 .faas-form .error select {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCI+PHBhdGggZD0iTTguNTY0IDEuMjg5LjIgMTYuMjU2QS41LjUgMCAwIDAgLjYzNiAxN2gxNi43MjhhLjUuNSAwIDAgMCAuNS0uNS40OTQuNDk0IDAgMCAwLS4wNjQtLjI0NEw5LjQzNiAxLjI4OWEuNS41IDAgMCAwLS44NzIgMFpNMTAgMTQuNzVhLjI1LjI1IDAgMCAxLS4yNS4yNWgtMS41YS4yNS4yNSAwIDAgMS0uMjUtLjI1di0xLjVhLjI1LjI1IDAgMCAxIC4yNS0uMjVoMS41YS4yNS4yNSAwIDAgMSAuMjUuMjVabTAtM2EuMjUuMjUgMCAwIDEtLjI1LjI1aC0xLjVhLjI1LjI1IDAgMCAxLS4yNS0uMjV2LTZhLjI1LjI1IDAgMCAxIC4yNS0uMjVoMS41YS4yNS4yNSAwIDAgMSAuMjUuMjVaIiBmaWxsPSIjZDczNzNmIi8+PC9zdmc+'),url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii01OCAyOSAzMiAzNCIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAtNTggMjkgMzIgMzQiIHhtbDpzcGFjZT0icHJlc2VydmUiPjxwYXRoIGQ9Im0tNTYgNDMgNi0xMiA2IDEyaC0xMnpNLTQ0IDQ5bC02IDEyLTYtMTJoMTJ6IiBmaWxsPSIjNTM1MzUzIi8+PC9zdmc+');
-  background-position: 94%,100% 50%;
+  background-position: calc(100% - 20px),100% 50%;
   background-repeat: no-repeat;
   background-size: 18px,1em 1em;
   padding-right: 2.5rem;

--- a/libs/blocks/faas/utils.js
+++ b/libs/blocks/faas/utils.js
@@ -347,10 +347,12 @@ export const initFaas = (config, targetEl) => {
 
   const formEl = createTag('div', { class: 'faas-form-wrapper' });
   if (state.complete) {
-    Object.keys(state.js).forEach((key) => {
-      state[key] = state.js[key];
-    });
-    delete state.js;
+    if (state.js) {
+        Object.keys(state.js).forEach((key) => {
+        state[key] = state.js[key];
+      });
+      delete state.js;
+    }
     state.complete = false;
     state.e = { afterYiiLoadedCallback, beforeSubmitCallback };
     $(formEl).faas(state);


### PR DESCRIPTION
This will fix 
- style issue with faas form error icon for certain form size when it is 2-up
- some fragment rendering issue.

Resolves: 
- 
<img width="514" alt="image" src="https://user-images.githubusercontent.com/55804872/217376765-36cd1ea3-b2fb-462a-bbcd-645cf7060892.png">

- https://adobedotcom.slack.com/archives/C04KKJKTHKP/p1675777685201679

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/fragments/resources/modal/forms/accelerate-business-growth-by-delivering-the-worlds-most-powerful-shopping-experiences-with-magento-commerce
- After: https://main--bacom--adobecom.hlx.page/fragments/resources/modal/forms/accelerate-business-growth-by-delivering-the-worlds-most-powerful-shopping-experiences-with-magento-commerce?milolibs=faas-fix