### PR TITLE
Library Search UI Fix

### DIFF
--- a/libs/blocks/library-config/library-config.css
+++ b/libs/blocks/library-config/library-config.css
@@ -201,6 +201,14 @@ input.sk-library-search-input:focus {
   border-bottom: 1px solid #676767;
 }
 
+/* 
+ * Fixes block list getting cut off with search 
+ * Margin height equal to search bar height
+*/
+.sk-library ul.con-blocks-list.inset {
+  margin-bottom: 39px;
+}
+
 .sk-library .block-group::after,
 .sk-library .content-type::after {
   content: '';


### PR DESCRIPTION
Fix for block list cutting off the last item when search is in view.

**Not fixed**
![image](https://user-images.githubusercontent.com/2539954/217662288-673d8a7b-9cf0-4ea8-9e00-61a2098770a4.png)


**Fixed**
![image](https://user-images.githubusercontent.com/2539954/217662116-27ab4a45-34a4-404f-8afc-fb19a708f858.png)


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/library?martech=off
- After: https://library-search-update--milo--adobecom.hlx.page/tools/library?martech=off
