### PR TITLE
Tabs block bug - Fix JP and KN label associations. 

### DIFF
--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -40,7 +40,7 @@ function changeTabs(e) {
 
 function getStringKeyName(str) {
   // regex to omit all special characters except Japanese or Korean language characters
-  const regex = '/[^\w\s\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3130-\u318F\uAC00-\uD7AF]+/g';
+  const regex = /[^\w\s\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3130-\u318F\uAC00-\uD7AF]+/g;
   return str.trim().toLowerCase().replace(regex, '').replace(/ +/g, '-');
 }
 

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -39,7 +39,9 @@ function changeTabs(e) {
 }
 
 function getStringKeyName(str) {
-  return str.trim().toLowerCase().replace(/[^\w ]/g, '').replace(/ +/g, '-');
+  // regex to omit all special characters except Japanese or Korean language characters
+  const regex = '/[^\w\s\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3130-\u318F\uAC00-\uD7AF]+/g';
+  return str.trim().toLowerCase().replace(regex, '').replace(/ +/g, '-');
 }
 
 function configTabs(config) {
@@ -151,6 +153,8 @@ const init = (block) => {
     [...metadata].filter((d) => getStringKeyName(d.children[0].textContent) === 'tab')
       .forEach((d) => {
         const metaValue = getStringKeyName(d.children[1].textContent);
+
+        console.log('metaValue', metaValue, 'textContent', d.children[1].textContent);
         const section = sectionMetadata.closest('.section');
         const assocTabItem = document.getElementById(`tab-panel-${initCount}-${metaValue}`);
         if (assocTabItem) assocTabItem.append(section);

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -41,7 +41,7 @@ function changeTabs(e) {
 function getStringKeyName(str) {
   // regex to omit all special characters except Japanese or Korean language characters
   const regex = /[^\w\s\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3130-\u318F\uAC00-\uD7AF]+/g;
-  return str.trim().toLowerCase().replace(regex, '').replace(/ +/g, '-');
+  return str.trim().toLowerCase().replace(regex, '').replace(/\s+/g, '-');
 }
 
 function configTabs(config) {

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -153,8 +153,6 @@ const init = (block) => {
     [...metadata].filter((d) => getStringKeyName(d.children[0].textContent) === 'tab')
       .forEach((d) => {
         const metaValue = getStringKeyName(d.children[1].textContent);
-
-        console.log('metaValue', metaValue, 'textContent', d.children[1].textContent);
         const section = sectionMetadata.closest('.section');
         const assocTabItem = document.getElementById(`tab-panel-${initCount}-${metaValue}`);
         if (assocTabItem) assocTabItem.append(section);


### PR DESCRIPTION
* Fixed an issue w/ the tabs block content associations - The label/section key associated text was removing all non alphanumeric special characters and breaking the selector when a Japanese or Korean tab label/key was used. 

Resolves: [MWPW-126351](https://jira.corp.adobe.com/browse/MWPW-126351)

**Test URLs:**
- Before:
https://main--milo--adobecom.hlx.page/drafts/rparrish/tabs-kanji
https://main--cc--adobecom.hlx.page/drafts/tkato/0209-1640-test-toshi-cc-overview
- After: 
https://rparrish-tabs-kanji--milo--adobecom.hlx.page/drafts/rparrish/tabs-kanji
https://main--cc--adobecom.hlx.page/drafts/tkato/0209-1640-test-toshi-cc-overview?milolibs=rparrish-tabs-kanji
