### PR TITLE
MWPW-125401 Add backround color switching to click event for Safari

### DIFF
--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -14,9 +14,13 @@ function handleClick(el, dt, dd) {
   if (expanded) {
     el.setAttribute('aria-expanded', 'false');
     dd.setAttribute('hidden', '');
+    dt.classList.remove('has-focus');
+    dd.classList.remove('has-focus');
   } else {
     el.setAttribute('aria-expanded', 'true');
     dd.removeAttribute('hidden');
+    dt.classList.add('has-focus');
+    dd.classList.add('has-focus');
   }
   dt.classList.toggle('is-open');
   dd.classList.toggle('is-open');


### PR DESCRIPTION
For the accordion the background gets darkened when and entry gets selected. This is done using `focusin`, `focusout` events. Safari Browsers dont trigger these events on click so background will not change. We need to keep these events for accessiblity reasons (to be able to tab through the entries). So i added background switching also to the click event itself.

Resolves: [MWPW-125401](https://jira.corp.adobe.com/browse/MWPW-125401)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/msagolj/mwpw-125401
- After: https://mwpw-125401--milo--adobecom.hlx.page/drafts/msagolj/mwpw-125401

NOTE : To test, open above links on Safari 