### PR TITLE
MWPW-126165 - Clean up meta URLs

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -625,6 +625,20 @@ function initSidekick() {
   }
 }
 
+function decorateMeta() {
+  const { origin } = window.location;
+  const contents = document.head.querySelectorAll('[content*=".hlx."]');
+  contents.forEach((meta) => {
+    try {
+      const url = new URL(meta.content);
+      meta.setAttribute('content', `${origin}${url.pathname}${url.search}${url.hash}`);
+    } catch (e) {
+      /* c8 ignore next 2 */
+      window.lana.log('Cannot make URL from metadata');
+    }
+  });
+}
+
 export async function loadArea(area = document) {
   const config = getConfig();
   const isDoc = area === document;
@@ -633,6 +647,7 @@ export async function loadArea(area = document) {
   await decoratePlaceholders(area, config);
 
   if (isDoc) {
+    decorateMeta();
     decorateHeader();
 
     import('./samplerum.js').then(({ addRumListeners }) => {

--- a/test/utils/mocks/head.html
+++ b/test/utils/mocks/head.html
@@ -1,2 +1,3 @@
 <meta name="interlinks" content="on">
 <link rel="icon" href="data:,">
+<meta name="hlx-url" content="https://www.hlx.live/otis">

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -151,17 +151,22 @@ describe('Utils', () => {
       expect(document.querySelector('header')).to.not.exist;
       expect(document.querySelector('footer')).to.not.exist;
     });
-  
+
     it('Decorates placeholder', () => {
       const paragraphs = [...document.querySelectorAll('p')];
       const lastPara = paragraphs.pop();
       expect(lastPara.textContent).to.equal('nothing to see here');
     });
-  
+
+    it('Decorates meta helix url', () => {
+      const meta = document.head.querySelector('[name="hlx-url"]');
+      expect(meta.content).to.equal('http://localhost:2000/otis');
+    });
+
     it('getLocale default return', () => {
       expect(utils.getLocale().ietf).to.equal('en-US');
     });
-  
+
     it('getLocale for different paths', () => {
       const locales = {
         '': { ietf: 'en-US', tk: 'hah7vzn.css' },


### PR DESCRIPTION
* Make .hlx. content in meta tags same-domain

Resolves: [MWPW-126165](https://jira.corp.adobe.com/browse/MWPW-126165)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cmillar/meta-urls?martech=off
- After: https://meta-urls--milo--adobecom.hlx.page/drafts/cmillar/meta-urls?martech=off

**Steps to reproduce**
1. View the first page
2. Inspect (not view-source) the head.
3. Note that there are many `main--milo--adobecom.hlx.page` URLs.

**Steps to test**
1. View the second page
2. Inspect (not view-source) the head.
3. Note that there are many `meta-urls--milo--adobecom.hlx.page` URLs. This is because any `.hlx.` URLs are fixed to be same origin.
