### PR TITLE
MWPW-126597 load css for custom modals

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,4 +1,4 @@
-import { createTag, getMetadata, localizeLink } from '../../utils/utils.js';
+import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
 
 const FOCUSABLES = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
 const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
@@ -46,6 +46,8 @@ function isElementInView(element) {
 }
 
 function getCustomModal(custom, dialog) {
+  const { miloLibs, codeRoot } = getConfig();
+  loadStyle(`${miloLibs || codeRoot}/blocks/modal/modal.css`);
   if (custom.id) dialog.id = custom.id;
   if (custom.class) dialog.classList.add(custom.class);
   if (custom.closeEvent) {


### PR DESCRIPTION
MWPW-126597
* Loads modal CSS if it was not already loaded for custom modals. 
* To test on Milo, just try opening the preflight modal in the sidekick
* To test on Bacom, try getting the georouting Modal to open (Clear the site cache and fake change your country if necessary by setting this query param -> ?akamaiLocale=de)

Resolves: [MWPW-126597](https://jira.corp.adobe.com/browse/MWPW-126597)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/?martech=off
- After: https://vhargrave-modal-css--milo--adobecom.hlx.page/ch_de/?martech=off

**Bacom**
- Before: https://main--bacom--adobecom.hlx.page/resources/videos/marketo-product-tour?akamaiLocale=DE
- After: https://main--bacom--adobecom.hlx.page/resources/videos/marketo-product-tour?akamaiLocale=DE&milolibs=vhargrave-modal-css