### PR TITLE
MWPW-126584 - Tabs language support bug fix

### DIFF
--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -39,8 +39,12 @@ function changeTabs(e) {
 }
 
 function getStringKeyName(str) {
-  // regex to omit all special characters except Japanese or Korean language characters
-  const regex = /[^\w\s\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3130-\u318F\uAC00-\uD7AF]+/g;
+  /* 
+  The [^...] character class is used to match any character that is not a valid CSS selector character. 
+  The #, ., -, and underscore characters are included as valid characters, 
+  and the \p{L} and \p{N} Unicode properties are used to match any letter or digit character in any language.
+  */
+  const regex = /[^#\. \p{L}\p{N}_-]/gu;
   return str.trim().toLowerCase().replace(regex, '').replace(/\s+/g, '-');
 }
 


### PR DESCRIPTION
* Fixed an issue w/ tabs - the associated section selector was breaking when using Chinese tab-list labels. 

Resolves: [MWPW-126584](https://jira.corp.adobe.com/browse/MWPW-126584)

**Test URLs:**

**Before:** 
- https://main--milo--adobecom.hlx.page/drafts/rparrish/tabs-kanji 
- https://main--cc--adobecom.hlx.page/drafts/yunlu/buying-plan1?martech=off

**After:**
- https://rparrish-tabs-cz--milo--adobecom.hlx.page/drafts/rparrish/tabs-kanji?martech=off
- https://main--cc--adobecom.hlx.page/drafts/yunlu/buying-plan1?milolibs=rparrish-tabs-cz&martech=off
