### PR TITLE
MWPW-126724 - Support non-link text in copyright

### DIFF
--- a/libs/blocks/footer/footer.js
+++ b/libs/blocks/footer/footer.js
@@ -197,23 +197,38 @@ class Footer {
 
   decoratePrivacy = () => {
     const copyrightEl = this.body.querySelector('div > p > em');
-    const links = copyrightEl?.parentElement.querySelectorAll('a');
-    if (!copyrightEl || !links) return null;
+    if (!copyrightEl) return null;
+    const container = copyrightEl.closest('div');
     const privacyWrapper = createTag('div', { class: 'footer-privacy' });
     const copyright = createTag('p', { class: 'footer-privacy-copyright' });
     const year = new Date().getFullYear();
     copyright.textContent = `Copyright © ${year} ${copyrightEl.textContent}`;
     privacyWrapper.append(copyright);
-    const infoLinks = createTag('ul', { class: 'footer-privacy-links' });
-    links.forEach((link) => {
-      const li = createTag('li', { class: 'footer-privacy-link' });
-      if (link.hash === '#interest-based-ads') {
-        link.insertAdjacentHTML('afterbegin', ADCHOICE_IMG);
-      }
-      li.append(link);
-      infoLinks.append(li);
-    });
-    privacyWrapper.append(infoLinks);
+
+    const adchoice = container.querySelector('a[href*="#interest-based-ads"]');
+    adchoice?.insertAdjacentHTML('afterbegin', ADCHOICE_IMG);
+
+    const ulClass = 'footer-privacy-links';
+    const liClass = 'footer-privacy-link';
+    let ul = container.querySelector('ul');
+
+    if (ul) {
+      ul.classList.add(ulClass);
+      const listItems = ul.querySelectorAll('li');
+      [...listItems].forEach((item) => {
+        item.classList.add(liClass);
+      });
+    } else {
+      const links = container.querySelectorAll('a');
+      if (!links) return null;
+      ul = createTag('ul', { class: ulClass });
+      links.forEach((link) => {
+        const li = createTag('li', { class: liClass });
+        li.append(link);
+        ul.append(li);
+      });
+    }
+    privacyWrapper.append(ul);
     return privacyWrapper;
   };
 

--- a/test/blocks/footer/footer.test.js
+++ b/test/blocks/footer/footer.test.js
@@ -1,0 +1,44 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+const { Footer } = await import('../../../libs/blocks/footer/footer.js');
+
+describe('Footer', () => {
+  describe('copyright ul', async () => {
+    const copyright = await readFile({ path: './mocks/copyright-ul.html' });
+    const parser = new DOMParser();
+    const copyrightDom = parser.parseFromString(copyright, 'text/html');
+    document.body.innerHTML = '<footer></footer>';
+    const footer = new Footer(copyrightDom.body, document.querySelector('footer'));
+    const privacy = footer.decoratePrivacy();
+
+    it('adds ul', () => {
+      expect(privacy.querySelector('ul.footer-privacy-links')).not.to.be.null;
+    });
+
+    it('adds li', () => {
+      expect(privacy.querySelector('li.footer-privacy-link')).not.to.be.null;
+    });
+
+    it('allows text without link', () => {
+      expect(privacy.querySelector('li#no-link')).not.to.be.null;
+    });
+  });
+
+  describe('copyright p', async () => {
+    const copyright = await readFile({ path: './mocks/copyright-p.html' });
+    const parser = new DOMParser();
+    const copyrightDom = parser.parseFromString(copyright, 'text/html');
+    document.body.innerHTML = '<footer></footer>';
+    const footer = new Footer(copyrightDom.body, document.querySelector('footer'));
+    const privacy = footer.decoratePrivacy();
+
+    it('adds ul', () => {
+      expect(privacy.querySelector('ul.footer-privacy-links')).not.to.be.null;
+    });
+
+    it('adds li', () => {
+      expect(privacy.querySelector('li.footer-privacy-link')).not.to.be.null;
+    });
+  });
+});

--- a/test/blocks/footer/mocks/copyright-p.html
+++ b/test/blocks/footer/mocks/copyright-p.html
@@ -1,0 +1,89 @@
+<div>
+  <h2 id="contact-us">Contact Us</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/request-consultation/experience-cloud.html">Request a demo</a></li>
+    <li><a href="https://www.adobe.com/index.html">Adobe.com</a></li>
+  </ul>
+  <h2 id="why-adobe">Why Adobe</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/why-adobe/why-partner-with-us.html">Why partner with Adobe</a></li>
+    <li><a href="https://business.adobe.com/why-adobe/how-we-use-our-products.html">How we use our products</a></li>
+    <li><a href="https://business.adobe.com/customers/partners/main.html">Our partners</a></li>
+    <li><a href="https://business.adobe.com/resources/leader-in-experiences.html">Industry leadership</a></li>
+    <li><a href="https://www.adobe.com/creativecloud/business/enterprise.html">Creative Cloud for Enterprise</a></li>
+    <li><a href="https://www.adobe.com/documentcloud/business.html">Document Cloud for Business</a></li>
+  </ul>
+</div>
+<div>
+  <h2 id="about-experience-cloud">About Experience Cloud</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/products/adobe-experience-cloud-products.html">Explore all products</a></li>
+    <li><a href="https://business.adobe.com/products/experience-platform/adobe-experience-platform.html">Adobe Experience Platform</a></li>
+    <li><a href="https://business.adobe.com/products/analytics/adobe-analytics.html">Adobe Analytics</a></li>
+    <li><a href="https://business.adobe.com/products/experience-manager/sites/aem-sites.html">Adobe Experience Manager Sites (CMS)</a></li>
+    <li><a href="https://business.adobe.com/products/experience-manager/assets/aem-assets.html">Adobe Experience Manager Assets (DAM)</a></li>
+    <li><a href="https://business.adobe.com/products/marketo/adobe-marketo.html">Marketo Engage</a></li>
+    <li><a href="https://business.adobe.com/products/magento/magento-commerce.html">Adobe Commerce</a></li>
+  </ul>
+</div>
+<div>
+  <h2 id="our-solutions">Our solutions</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/solutions/data-insights-audiences.html">Data insights &#x26; audiences</a></li>
+    <li><a href="https://business.adobe.com/solutions/experience-management-platform.html">Experience management platform</a></li>
+    <li><a href="https://business.adobe.com/solutions/content-management.html">Content management</a></li>
+    <li><a href="https://business.adobe.com/solutions/commerce.html">Commerce</a></li>
+    <li><a href="https://business.adobe.com/solutions/customer-journeys.html">Customer journeys</a></li>
+    <li><a href="https://business.adobe.com/solutions/b2b-marketing.html">B2B marketing</a></li>
+    <li><a href="https://business.adobe.com/solutions/digital-enrollment-onboarding.html">Digital enrollment &#x26; onboarding</a></li>
+  </ul>
+</div>
+<div>
+  <h2 id="resources">Resources</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/resources/main.html">Resource center</a></li>
+    <li><a href="https://business.adobe.com/customer-success-stories/index.html">Customer success stories</a></li>
+    <li><a href="https://experienceleague.adobe.com/#home">Experience League (learn &#x26; support)</a></li>
+    <li><a href="https://experienceleaguecommunities.adobe.com/">Community forums</a></li>
+    <li><a href="https://business.adobe.com/glossary/index.html">Glossary</a></li>
+    <li><a href="https://www.adobe.io/apis/experiencecloud.html">Development resources</a></li>
+  </ul>
+</div>
+<div>
+  <h2 id="company">Company</h2>
+  <ul>
+    <li><a href="https://www.adobe.com/about-adobe.html">About Adobe</a></li>
+    <li><a href="https://www.adobe.com/careers.html">Careers</a></li>
+    <li><a href="https://news.adobe.com/">Newsroom</a></li>
+    <li><a href="https://www.adobe.com/corporate-responsibility.html">Corporate responsibility</a></li>
+    <li><a href="https://www.adobe.com/investor-relations.html">Investor relations</a></li>
+    <li><a href="https://www.adobe.com/corporate-responsibility/supply-chain.html">Supply chain</a></li>
+    <li><a href="https://www.adobe.com/trust.html">Trust center</a></li>
+    <li><a href="https://www.adobe.com/events.html">Events</a></li>
+    <li><a href="https://www.adobe.com/diversity.html">Diversity &#x26; inclusion</a></li>
+    <li><a href="https://www.adobe.com/about-adobe/integrity.html">Integrity</a></li>
+    <li><a href="https://www.adobe.com/covid-19-response.html">COVID-19</a></li>
+  </ul>
+</div>
+<div>
+  <div class="region-selector popup">
+    <div>
+      <div><a href="/fragments/regions#langnav">Change region</a></div>
+    </div>
+  </div>
+</div>
+<div>
+  <div class="social">
+    <div>
+      <div>
+        <p><a href="http://www.facebook.com/adobe">http://www.facebook.com/adobe</a></p>
+        <p><a href="https://twitter.com/Adobe">https://twitter.com/Adobe</a></p>
+        <p><a href="https://www.linkedin.com/company/adobe">https://www.linkedin.com/company/adobe</a></p>
+        <p><a href="https://www.instagram.com/adobe/">https://www.instagram.com/adobe/</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <p><em>All rights reserved.</em> / <a href="https://www.adobe.com/privacy.html">Privacy</a> / <a href="https://www.adobe.com/legal/terms.html">Terms of Use</a> / <a href="https://www.adobe.com/#openPrivacy">Cookie preferences</a> / <a href="https://www.adobe.com/privacy/ca-rights.html">Do not sell my personal information</a> / <a href="https://www.adobe.com/privacy/opt-out.html#interest-based-ads">AdChoices</a></p>
+</div>

--- a/test/blocks/footer/mocks/copyright-ul.html
+++ b/test/blocks/footer/mocks/copyright-ul.html
@@ -1,0 +1,97 @@
+<div>
+  <h2 id="联系我们">联系我们</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/request-consultation/experience-cloud.html">请求演示</a></li>
+    <li><a href="https://www.adobe.com/index.html">Adobe.com</a></li>
+  </ul>
+  <h2 id="为何选择-adobe">为何选择 Adobe</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/why-adobe/why-partner-with-us.html">为何选择 Adobe 作为合作伙伴</a></li>
+    <li><a href="https://business.adobe.com/why-adobe/how-we-use-our-products.html">我们如何使用自己的产品</a></li>
+    <li><a href="https://business.adobe.com/customers/partners/main.html">我们的合作伙伴</a></li>
+    <li><a href="https://business.adobe.com/resources/leader-in-experiences.html">行业领导力</a></li>
+    <li><a href="https://www.adobe.com/creativecloud/business/enterprise.html">适用于企业的 Creative Cloud</a></li>
+    <li><a href="https://www.adobe.com/documentcloud/business.html">Document Cloud 商业版</a></li>
+  </ul>
+</div>
+<div>
+  <h2 id="关于-experience-cloud">关于 Experience Cloud</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/products/adobe-experience-cloud-products.html">浏览所有产品</a></li>
+    <li><a href="https://business.adobe.com/products/experience-platform/adobe-experience-platform.html">Adobe Experience Platform</a></li>
+    <li><a href="https://business.adobe.com/products/analytics/adobe-analytics.html">Adobe Analytics</a></li>
+    <li><a href="https://business.adobe.com/products/experience-manager/sites/aem-sites.html">Adobe Experience Manager Sites (CMS)</a></li>
+    <li><a href="https://business.adobe.com/products/experience-manager/assets/aem-assets.html">Adobe Experience Manager Assets (DAM)</a></li>
+    <li><a href="https://business.adobe.com/products/marketo/adobe-marketo.html">Marketo Engage</a></li>
+    <li><a href="https://business.adobe.com/products/magento/magento-commerce.html">Adobe Commerce</a></li>
+  </ul>
+</div>
+<div>
+  <h2 id="解决方案">解决方案</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/solutions/data-insights-audiences.html">数据洞察和受众</a></li>
+    <li><a href="https://business.adobe.com/solutions/experience-management-platform.html">体验管理平台</a></li>
+    <li><a href="https://business.adobe.com/solutions/content-management.html">内容管理</a></li>
+    <li><a href="https://business.adobe.com/solutions/commerce.html">商务</a></li>
+    <li><a href="https://business.adobe.com/solutions/customer-journeys.html">客户旅程</a></li>
+    <li><a href="https://business.adobe.com/solutions/b2b-marketing.html">B2B 营销</a></li>
+    <li><a href="https://business.adobe.com/solutions/digital-enrollment-onboarding.html">数字登记和注册</a></li>
+  </ul>
+</div>
+<div>
+  <h2 id="资源">资源</h2>
+  <ul>
+    <li><a href="https://business.adobe.com/resources/main.html">资源中心</a></li>
+    <li><a href="https://business.adobe.com/cn/customer-success-stories.html">客户成功故事</a></li>
+    <li><a href="https://business.adobe.com/blog/#_dnt">Experience Cloud 博客</a></li>
+    <li><a href="https://experienceleague.adobe.com/#home">Experience League（学习和支持）</a></li>
+    <li><a href="https://experienceleaguecommunities.adobe.com/">社区论坛</a></li>
+    <li><a href="https://business.adobe.com/glossary/index.html#_dnt">术语表</a></li>
+    <li><a href="https://www.adobe.io/apis/experiencecloud.html">开发资源</a></li>
+  </ul>
+</div>
+<div>
+  <h2 id="公司">公司</h2>
+  <ul>
+    <li><a href="https://www.adobe.com/about-adobe.html">关于 Adobe</a></li>
+    <li><a href="https://www.adobe.com/careers.html">职业发展</a></li>
+    <li><a href="https://www.adobe.com/cn/about-adobe/newsroom.html">新闻中心</a></li>
+    <li><a href="https://www.adobe.com/corporate-responsibility.html">企业责任</a></li>
+    <li><a href="https://www.adobe.com/investor-relations.html#_dnt">投资者关系</a></li>
+    <li><a href="https://www.adobe.com/corporate-responsibility/supply-chain.html">供应链</a></li>
+    <li><a href="https://www.adobe.com/trust.html">信任中心</a></li>
+    <li><a href="https://www.adobe.com/events.html">活动</a></li>
+    <li><a href="https://www.adobe.com/diversity.html">多元化和包容性</a></li>
+    <li><a href="https://www.adobe.com/about-adobe/integrity.html">诚信</a></li>
+  </ul>
+</div>
+<div>
+  <div class="region-selector">
+    <div>
+      <div><a href="/fragments/regions#langnav">更改地区</a></div>
+    </div>
+  </div>
+</div>
+<div>
+  <div class="social">
+    <div>
+      <div>
+        <p><a href="https://www.linkedin.com/company/adobe">https://www.linkedin.com/company/adobe</a></p>
+        <p><a href="https://www.weibo.com/adobechina">https://www.weibo.com/adobechina</a></p>
+        <p><a href="https://www.adobe.com/cn/about-adobe/newsroom/social-media.html">https://www.adobe.com/cn/about-adobe/newsroom/social-media.html</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <p><em>保留所有权利。</em></p>
+  <ul>
+    <li><a href="https://www.adobe.com/privacy.html">隐私</a></li>
+    <li><a href="https://www.adobe.com/legal/terms.html">使用条款</a></li>
+    <li><a href="https://www.adobe.com/#openPrivacy">Cookie 偏好设置</a></li>
+    <li><a href="https://www.adobe.com/go/ca-rights">不得出售共享我的个人信息</a></li>
+    <li><a href="http://beian.miit.gov.cn/">京 ICP 备 10217899 号</a> 京公网安备 110105010404</li>
+    <li id="no-link">I do not have a link</li>
+    <li><a href="https://www.adobe.com/cn/privacy/opt-out.html#interest-based-ads">AdChoices</a></li>
+  </ul>
+</div>


### PR DESCRIPTION
* Allow footer copyright to be authored as unordered list `ul`
* If authored as `ul`, non-link text will remain visible in copyright
* Maintain support for existing single line `p` authoring

Resolves: [MWPW-126724](https://jira.corp.adobe.com/browse/MWPW-126724)

**Test URLs:**

New Authoring `ul`:
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/test-footer-text?martech=off
- After: https://methomas-footer-text--milo--adobecom.hlx.page/drafts/methomas/test-footer-text?martech=off

<img width="430" alt="Screen Shot 2023-02-23 at 10 52 48 AM" src="https://user-images.githubusercontent.com/19690988/221004809-e2b6639e-4e35-49d7-a458-75bd716136fc.png">

Existing Authoring `p` (for regression):
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/checkmark?martech=off
- After: https://methomas-footer-text--milo--adobecom.hlx.page/drafts/methomas/checkmark?martech=off

<img width="665" alt="Screen Shot 2023-02-23 at 10 53 22 AM" src="https://user-images.githubusercontent.com/19690988/221005282-e98cff7c-1dcc-43be-a751-7ee066eeecb0.png">