### PR TITLE
MWPW-126915 Fix gnav link order

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -67,10 +67,6 @@ class Gnav {
 
     const mainNav = this.decorateMainNav();
     if (mainNav) {
-      const cta = this.decorateCta();
-      if (cta) {
-        mainNav.append(cta);
-      }
       scrollWrapper.append(mainNav);
     }
 
@@ -167,7 +163,7 @@ class Gnav {
 
   decorateMainNav = () => {
     const mainNav = createTag('div', { class: 'gnav-mainnav' });
-    const mainLinks = this.body.querySelectorAll('h2 > a');
+    const mainLinks = this.body.querySelectorAll('h2 > a, strong a');
     if (mainLinks.length > 0) {
       this.buildMainNav(mainNav, mainLinks);
     }
@@ -176,6 +172,11 @@ class Gnav {
 
   buildMainNav = (mainNav, navLinks) => {
     navLinks.forEach((navLink, idx) => {
+      if (navLink.parentElement.tagName === 'STRONG') {
+        const cta = this.decorateCta(navLink);
+        mainNav.append(cta);
+        return;
+      }
       navLink.href = localizeLink(navLink.href);
       const navItem = createTag('div', { class: 'gnav-navitem' });
       const navBlock = navLink.closest('.large-menu');
@@ -330,8 +331,7 @@ class Gnav {
     });
   };
 
-  decorateCta = () => {
-    const cta = this.body.querySelector('strong a');
+  decorateCta = (cta) => {
     if (cta) {
       const { origin } = new URL(cta.href);
       if (origin !== window.location.origin) {

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -172,7 +172,7 @@ class Gnav {
 
   buildMainNav = (mainNav, navLinks) => {
     navLinks.forEach((navLink, idx) => {
-      if (navLink.parentElement.tagName === 'STRONG') {
+      if (navLink.parentElement.nodeName === 'STRONG') {
         const cta = this.decorateCta(navLink);
         mainNav.append(cta);
         return;


### PR DESCRIPTION
* Fixes gnav so that the cta remains in the order that it's authored
* For example, the telephone number can now be added to the right of the cta

Resolves: [MWPW-126915](https://jira.corp.adobe.com/browse/MWPW-126915)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/gnav-phone-right?martech=off
- After: https://methomas-gnav-phone--milo--adobecom.hlx.page/drafts/methomas/gnav-phone-right?martech=off

Regression (gnav with phone authored to the left of the cta still works):
- After: https://methomas-gnav-phone--milo--adobecom.hlx.page/drafts/methomas/checkmark?martech=off
