### PR TITLE
MWPW-119230: Feds Utilities

### DIFF
--- a/libs/blocks/global-navigation/utilities/getUserEntitlements.js
+++ b/libs/blocks/global-navigation/utilities/getUserEntitlements.js
@@ -66,11 +66,8 @@ const getSubscriptions = async ({ queryParams, locale }) => {
  * @returns {object} JIL Entitlements
  */
 const getUserEntitlements = async ({ params, locale } = {}) => {
-  if (!window.adobeIMS?.isSignedInUser()) {
-    return new Promise((resolve, reject) => {
-      reject(new Error('User not signed in'));
-    });
-  }
+  if (!window.adobeIMS?.isSignedInUser()) return Promise.reject(new Error('User not signed in'));
+
   const queryParams = getQueryParameters(params);
   if (entitlements[queryParams]) return entitlements[queryParams];
 

--- a/libs/blocks/global-navigation/utilities/getUserEntitlements.js
+++ b/libs/blocks/global-navigation/utilities/getUserEntitlements.js
@@ -1,0 +1,92 @@
+import { getConfig } from '../../../utils/utils.js';
+
+const API_WAIT_TIMEOUT = '10000';
+const entitlements = {};
+
+const getAcceptLanguage = (locale) => {
+  let languages = [];
+  if (!locale || Object.keys(locale).length === 0) {
+    return languages;
+  }
+
+  languages = [
+    `${locale.language}-${locale.country.toUpperCase()}`,
+    `${locale.language};q=0.9`,
+    'en;q=0.8',
+  ];
+  return languages;
+};
+
+const getQueryParameters = (params) => {
+  let result = '';
+  const query = [];
+  if (Array.isArray(params) && params.length) {
+    params.forEach((parameter = {}) => {
+      const { name, value } = parameter;
+      if (typeof name === 'string' && name.length) {
+        query.push(`${encodeURIComponent(name)}=${encodeURIComponent(value)}`);
+      }
+    });
+
+    if (query.length) {
+      result = `?${query.join('&')}`;
+    }
+  }
+
+  return result;
+};
+
+const getSubscriptions = async ({ queryParams, locale }) => {
+  const profile = await window.adobeIMS.getProfile();
+  const apiUrl = getConfig().env.name === 'prod'
+    ? `https://www.adobe.com/aos-api/users/${profile.userId}/subscriptions`
+    : `https://www.stage.adobe.com/aos-api/users/${profile.userId}/subscriptions`;
+  const res = await window
+    .fetch(`${apiUrl}${queryParams}`, {
+      method: 'GET',
+      cache: 'no-cache',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${window.adobeIMS.getAccessToken().token}`,
+        'X-Api-Key': window.adobeIMS.adobeIdData.client_id,
+        Accept: 'application/json',
+        'Accept-Language': getAcceptLanguage(locale).join(','),
+      },
+    })
+    .then((response) => (response.status === 200 ? response.json() : null));
+  return res;
+};
+
+/**
+ * @description Return the JIL User Entitlements
+ * @param {object} object required params
+ * @param {array} object.params array of name value query parameters [{name: 'Q', value: 'PARAM'}]
+ * @param {object} object.locale {country: 'CH', language: 'de'}
+ * @returns {object} JIL Entitlements
+ */
+const getUserEntitlements = async ({ params, locale } = {}) => {
+  if (!window.adobeIMS?.isSignedInUser()) {
+    return new Promise((resolve, reject) => {
+      reject(new Error('User not signed in'));
+    });
+  }
+  const queryParams = getQueryParameters(params);
+  if (entitlements[queryParams]) return entitlements[queryParams];
+
+  let resolve;
+  let reject;
+  entitlements[queryParams] = entitlements[queryParams]
+    || new Promise((_resolve, _reject) => {
+      resolve = _resolve;
+      reject = _reject;
+    });
+  setTimeout(() => reject('Subscriptions API Call timeout'), API_WAIT_TIMEOUT);
+  // TODO we might need to format data for analytics
+  const data = await getSubscriptions({ queryParams, locale });
+  if (data) resolve(data);
+  reject('No response from the aos-api');
+  return entitlements[queryParams];
+};
+
+export default getUserEntitlements;

--- a/libs/blocks/global-navigation/utilities/getUserEventHistory.js
+++ b/libs/blocks/global-navigation/utilities/getUserEventHistory.js
@@ -1,0 +1,31 @@
+/* eslint-disable no-promise-executor-return, no-async-promise-executor */
+import { getConfig } from '../../../utils/utils.js';
+
+let userEventHistory;
+const getUserEventHistory = async (id) => {
+  if (userEventHistory) return userEventHistory;
+  if (!window.adobeIMS?.isSignedInUser()) return new Promise((resolve, reject) => { reject(new Error('User not signed in')); });
+  let resolve;
+  let reject;
+  userEventHistory = userEventHistory || new Promise((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  const profile = await window.adobeIMS.getProfile();
+  const guid = profile.userId;
+  const apiUrl = getConfig().env.name === 'prod'
+    ? 'https://www.adobe.com/gating/api/realtime-profile'
+    : 'https://www.stage.adobe.com/gating/api/realtime-profile';
+  const res = await window
+    .fetch(`${apiUrl}?guid=${id || guid}`, {
+      method: 'GET',
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    })
+    .then((resp) => (resp.status === 200 ? resp.json() : null));
+  if (res) resolve(res);
+  reject(new Error('Error retrieving a response'));
+  return userEventHistory;
+};
+
+export default getUserEventHistory;

--- a/libs/blocks/global-navigation/utilities/getUserEventHistory.js
+++ b/libs/blocks/global-navigation/utilities/getUserEventHistory.js
@@ -4,7 +4,7 @@ import { getConfig } from '../../../utils/utils.js';
 let userEventHistory;
 const getUserEventHistory = async (id) => {
   if (userEventHistory) return userEventHistory;
-  if (!window.adobeIMS?.isSignedInUser()) return new Promise((resolve, reject) => { reject(new Error('User not signed in')); });
+  if (!window.adobeIMS?.isSignedInUser()) return Promise.reject(new Error('User not signed in'));
   let resolve;
   let reject;
   userEventHistory = userEventHistory || new Promise((_resolve, _reject) => {
@@ -12,12 +12,11 @@ const getUserEventHistory = async (id) => {
     reject = _reject;
   });
   const profile = await window.adobeIMS.getProfile();
-  const guid = profile.userId;
   const apiUrl = getConfig().env.name === 'prod'
     ? 'https://www.adobe.com/gating/api/realtime-profile'
     : 'https://www.stage.adobe.com/gating/api/realtime-profile';
   const res = await window
-    .fetch(`${apiUrl}?guid=${id || guid}`, {
+    .fetch(`${apiUrl}?guid=${id || profile.userId}`, {
       method: 'GET',
       'Content-Type': 'application/json',
       Accept: 'application/json',


### PR DESCRIPTION
### Relations
Resolves: [MWPW-119230](https://jira.corp.adobe.com/browse/MWPW-119230)

### Description
I've done an exhaustive review of all the FEDS related utilities that we currently offer in the aem based global navigation.
As a lot of the backwards compatibility isn't needed anymore (example: IMS does not need a wrapper anymore to support V1 and V2 with the same API, but we can just rely on the fact IMS v2 is used) only two crucial utilities will be exported, and users are free to consume them.

They do not occupy any space in the global navigation/FEDS anymore but serve as convenient wrapping functions anyone is free to consume.

### Usage
The scripts can either be consumed from a milo context or standalone when you import the absolute path equal to lana.
```js
import getUserEntitlements from './utilities/getUserEntitlements.js';
// Entitlements will be the unformatted response from the API
// https://www.adobe.com/aos-api/users/${profile.userId}/subscriptions
const entitlements = await getUserEntitlements().catch(err => console.log(err))
```

```js
import getUserEventHistory from './utilities/getUserEventHistory';
const historicallyRegistered = await getUserEventHistory().catch(e => console.log("handle error"))
```

**Test URLs:**
- Before: https://feds-gnav--milo--adobecom.hlx.page/?martech=off
- After: https://feds-gnav--milo--adobecom.hlx.page/?martech=off
