### PR TITLE
[MWPW-125175] Nav Links refactor

### DIFF
--- a/libs/blocks/global-navigation/blocks/navDropdown/dropdown.css
+++ b/libs/blocks/global-navigation/blocks/navDropdown/dropdown.css
@@ -13,6 +13,10 @@
   background-color: var(--feds-background-popup--light);
 }
 
+.feds-popup p {
+  margin: 0;
+}
+
 .feds-popup,
 .feds-popup-items {
   display: none;

--- a/libs/blocks/global-navigation/blocks/navDropdown/dropdown.css
+++ b/libs/blocks/global-navigation/blocks/navDropdown/dropdown.css
@@ -1,0 +1,169 @@
+:root {
+  --feds-background-popup--light: #fafafa;
+  --feds-color-navLink-description--light: #656565;
+  --feds-borderColor-popup--light: #e1e1e1;
+  --feds-color-headline--light: #505050;
+}
+
+.feds-navItem {
+  flex-direction: column;
+}
+
+.feds-popup {
+  background-color: var(--feds-background-popup--light);
+}
+
+.feds-popup,
+.feds-popup-items {
+  display: none;
+  padding: 12px 0;
+}
+
+.feds-popup-headline {
+  position: relative;
+  padding: 12px 44px 12px 32px;
+  border-bottom: solid 1px var(--feds-borderColor-popup--light);
+  color: var(--feds-color-headline--light);
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+[dir = "rtl"] .feds-popup-headline {
+  padding-right: 32px;
+  padding-left: 44px;
+}
+
+.feds-popup-headline:after {
+  position: absolute;
+  right: 30px;
+  top: 50%;
+  display: flex;
+  width: 6px;
+  height: 6px;
+  margin-top: -3px;
+  border-width: 0 1px 1px 0;
+  border-style: solid;
+  border-color: var(--feds-color-link--light);
+  transform-origin: 75% 75%;
+  transform: rotateZ(45deg);
+  transition: transform 0.1s ease;
+  content: "";
+}
+
+.feds-navLink--hoverCaret[aria-expanded = "true"] + .feds-popup,
+.feds-popup-headline[aria-expanded = "true"] + .feds-popup-items {
+  display: flex;
+  flex-direction: column;
+}
+
+.feds-navLink--hoverCaret[aria-expanded = "true"]:after,
+.feds-popup-headline[aria-expanded = "true"]:after {
+  transform: rotateZ(-135deg);
+}
+
+.feds-popup-items {
+  border-bottom: solid 1px var(--feds-borderColor-popup--light);
+}
+
+.feds-popup .feds-navLink,
+.feds-popup-items .feds-cta-wrapper {
+  padding: 6px 32px;
+}
+
+.feds-popup .feds-navLink:hover,
+.feds-popup .feds-navLink:focus {
+  background-color: var(--feds-background-link--hover--light);
+}
+
+.feds-navLink-image,
+.feds-navLink-description {
+  display: none;
+}
+
+.feds-popup ul {
+  margin: 0;
+  padding: 0;
+}
+
+@media (min-width: 900px) {
+  .feds-navItem {
+    flex-direction: initial;
+  }
+
+  .feds-navItem--megaMenu {
+    position: static;
+  }
+
+  .feds-popup {
+    position: absolute;
+    top: 100%;
+    left: 0;
+  }
+
+  [dir = "rtl"] .feds-popup {
+    left: auto;
+    right: 0;
+  }
+
+  .feds-navLink--hoverCaret[aria-expanded = "true"] + .feds-popup {
+    flex-direction: row;
+  }
+
+  .feds-navItem--megaMenu .feds-popup {
+    right: 0;
+    justify-content: space-around;
+    padding: 32px 0;
+  }
+
+  .feds-popup-headline {
+    position: static;
+    margin: 0 32px;
+    cursor: default;
+  }
+
+  .feds-popup-headline,
+  [dir = "rtl"] .feds-popup-headline {
+    padding: 12px 0;
+  }
+
+  .feds-popup-headline:after {
+    content: none;
+  }
+
+  .feds-popup-headline + .feds-popup-items {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    border-bottom: none;
+  }
+
+  .feds-navLink-image {
+    display: flex;
+  }
+
+  .feds-navLink-image:nth-last-child(2):after {
+    content: '';
+    margin-left: 15px;
+  }
+
+  .feds-navLink-image picture,
+  .feds-navLink-image img {
+    display: block;
+  }
+
+  .feds-navLink-image picture {
+    width: 25px;
+  }
+
+  .feds-navLink-description {
+    display: flex;
+    font-size: 12px;
+    color: var(--feds-color-navLink-description--light);
+  }
+
+  .feds-navLink:hover .feds-navLink-description,
+  .feds-navLink:focus .feds-navLink-description {
+    color: var(--feds-color-navLink-description--light);
+  }
+}

--- a/libs/blocks/global-navigation/blocks/navDropdown/dropdown.js
+++ b/libs/blocks/global-navigation/blocks/navDropdown/dropdown.js
@@ -41,7 +41,7 @@ const decorateHeadline = (elem) => {
 };
 
 const decorateLinkGroup = (elem, index) => {
-  if (!(elem instanceof HTMLElement)) return null;
+  if (!(elem instanceof HTMLElement) || !elem.querySelector('a')) return null;
 
   // TODO: could it be something other than a 'picture'?
   const image = elem.querySelector('picture');
@@ -148,8 +148,8 @@ const decorateDropdown = async (config) => {
             columnElem.remove();
           }
 
-          // Leave lists intact, just add attributes to their links
-          if (columnElem.tagName === 'UL') {
+          // Leave lists and paragraphs intact, just add attributes to their links
+          if (columnElem.tagName === 'UL' || columnElem.tagName === 'P') {
             columnElem.querySelectorAll('a').forEach((link, index) => {
               link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
               link.classList.add('feds-navLink');

--- a/libs/blocks/global-navigation/blocks/navDropdown/dropdown.js
+++ b/libs/blocks/global-navigation/blocks/navDropdown/dropdown.js
@@ -1,0 +1,179 @@
+import { getAnalyticsValue, toFragment, decorateCta } from '../../utilities/utilities.js';
+import { localizeLink } from '../../../../utils/utils.js';
+
+const decorateHeadline = (elem) => {
+  if (!(elem instanceof HTMLElement)) return null;
+
+  // TODO: proper handling of aria-expanded across devices
+  const headline = toFragment`<div
+    class="feds-popup-headline"
+    role="heading"
+    aria-level="2"
+    aria-haspopup="true"
+    aria-expanded="false">
+    ${elem.textContent.trim()}
+  </div>`;
+
+  // TODO: move proper logic to accessibility,
+  // this is just for demo functionality purposes
+  headline.addEventListener('click', (e) => {
+    e.preventDefault();
+
+    const openPopup = document.querySelector('.feds-popup-headline[aria-expanded = "true"]');
+
+    if (openPopup && openPopup !== headline) {
+      openPopup.setAttribute('aria-expanded', 'false');
+    }
+
+    const currentState = headline.getAttribute('aria-expanded');
+
+    if (currentState === 'false') {
+      headline.setAttribute('aria-expanded', 'true');
+    } else {
+      headline.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  // Since heading is turned into a div, it can be safely removed
+  elem.remove();
+
+  return headline;
+};
+
+const decorateLinkGroup = (elem, index) => {
+  if (!(elem instanceof HTMLElement)) return null;
+
+  // TODO: could it be something other than a 'picture'?
+  const image = elem.querySelector('picture');
+  const link = elem.querySelector('a');
+  const description = elem.querySelector('p:nth-child(2)');
+
+  const imageElem = image ? toFragment`<div class="feds-navLink-image">${image}</div>` : '';
+  const descriptionElem = description ? toFragment`<div class="feds-navLink-description">${description.textContent}</div>` : '';
+  const contentElem = link ? toFragment`<div class="feds-navLink-content">
+      <div class="feds-navLink-title">${link.textContent}</div>
+      ${descriptionElem}
+    </div>` : '';
+  const linkGroup = toFragment`<a 
+    href="${localizeLink(link.href)}"
+    class="feds-navLink"
+    daa-ll="${getAnalyticsValue(link.textContent, index)}">
+      ${imageElem}
+      ${contentElem}
+    </a>`;
+
+  return linkGroup;
+};
+
+// Current limitations:
+// * can't add link group in small dropdown
+// * after an h5 is found in a dropdown column, no new sections can be without a heading
+const decorateDropdown = async (config) => {
+  if (config.type === 'syncDropdownTrigger') {
+    const itemTopParent = config.item.closest('div');
+    // The heading is already part of the item template,
+    // it can be safely removed
+    const headingElem = itemTopParent.querySelector('h2');
+    itemTopParent.removeChild(headingElem);
+    itemTopParent.classList.add('feds-popup');
+
+    Array.prototype.forEach.call(itemTopParent.children, (section) => {
+      // TODO: allow link groups in small dropdowns too?
+      section.querySelectorAll('a').forEach((link, index) => {
+        link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
+        link.classList.add('feds-navLink');
+      });
+    });
+
+    config.template.append(itemTopParent);
+  }
+
+  if (config.type === 'asyncDropdownTrigger') {
+    performance.mark('startAsyncDecoration');
+    const pathElement = config.item.querySelector('a');
+    if (!(pathElement instanceof HTMLElement)) return;
+    const path = localizeLink(pathElement.href);
+
+    const res = await fetch(`${path}.plain.html`);
+    if (res.status !== 200) return;
+    const content = await res.text();
+    const popupTemplate = toFragment`<div class="feds-popup">${content}</div>`;
+
+    // The resulting template structure should follow these rules:
+    // * a popup can have multiple columns;
+    // * a column can have multiple sections;
+    // * a section can have a headline and a collection of item(s)
+    Array.prototype.forEach.call(popupTemplate.children, (column) => {
+      const columnTemplate = toFragment`<div class="feds-popup-column"></div>`;
+      let columnSection = toFragment`<div class="feds-popup-section"></div>`;
+      let sectionItems;
+      let currIndex = 0;
+
+      while (column.children.length) {
+        const columnElem = column.firstElementChild;
+
+        if (columnElem.tagName === 'H5') {
+          // When encountering an h5, add the previous section to the column
+          if (columnSection.childElementCount) {
+            columnTemplate.append(columnSection);
+            currIndex = 0;
+          }
+
+          // Analysts requested no headings in the dropdowns,
+          // turning it into a simple div
+          const sectionHeadline = decorateHeadline(columnElem);
+          sectionItems = toFragment`<div class="feds-popup-items"></div>`;
+          columnSection = toFragment`<div class="feds-popup-section">
+              ${sectionHeadline}
+              ${sectionItems}
+            </div>`;
+        } else {
+          currIndex += 1;
+          let decoratedElem;
+
+          // Decorate link group
+          if (columnElem.classList.contains('link-group')) {
+            // TODO: check if links with just images also work
+            decoratedElem = decorateLinkGroup(columnElem, currIndex);
+          }
+
+          // Decorate CTA
+          if (columnElem.querySelector('strong > a')) {
+            decoratedElem = decorateCta({ elem: columnElem, index: currIndex });
+          }
+
+          // If element has been decorated, remove it
+          // from the initial list of column elements
+          if (decoratedElem) {
+            columnElem.remove();
+          }
+
+          // Leave lists intact, just add attributes to their links
+          if (columnElem.tagName === 'UL') {
+            columnElem.querySelectorAll('a').forEach((link, index) => {
+              link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
+              link.classList.add('feds-navLink');
+            });
+          }
+
+          // If an items template has been previously created,
+          // add the current element to it;
+          // otherwise append the element to the section
+          const elemDestination = sectionItems || columnSection;
+          elemDestination.append(decoratedElem || columnElem);
+        }
+      }
+
+      // Append the last column section to the column
+      columnTemplate.append(columnSection);
+      // Replace column with parsed template
+      column.replaceWith(columnTemplate);
+    });
+
+    config.template.classList.add('feds-navItem--megaMenu');
+    config.template.append(popupTemplate);
+    performance.mark('endAsyncDecoration');
+  }
+};
+
+export default decorateDropdown;

--- a/libs/blocks/global-navigation/blocks/profile/milo-wrapper.css
+++ b/libs/blocks/global-navigation/blocks/profile/milo-wrapper.css
@@ -6,6 +6,6 @@
 
 .feds-profile-button {
   padding: 5px var(--feds-spacing-utilityNav);
-  border-radius: var(--radius-utilityIcon);
+  border-radius: var(--feds-radius-utilityIcon);
   border: none;
 }

--- a/libs/blocks/global-navigation/blocks/profile/signIn.css
+++ b/libs/blocks/global-navigation/blocks/profile/signIn.css
@@ -1,8 +1,8 @@
 .feds-signin {
-  color: #2C2C2C;
   padding: 11px var(--feds-spacing-utilityNav);
-  border-radius: var(--radius-utilityIcon);
+  border-radius: var(--feds-radius-utilityIcon);
   color: #4B4B4B;
+  white-space: nowrap;
 }
 
 .feds-signin-dropdown {

--- a/libs/blocks/global-navigation/blocks/profile/standalone-wrapper.css
+++ b/libs/blocks/global-navigation/blocks/profile/standalone-wrapper.css
@@ -10,7 +10,7 @@
 
 .feds-signin {
   padding: 4px var(--feds-spacing-utilityNav);
-  border-radius: var(--radius-utilityIcon);
+  border-radius: var(--feds-radius-utilityIcon);
 }
 
 .feds-profile-img {
@@ -20,7 +20,7 @@
 
 .feds-profile-button {
   padding: 2px var(--feds-spacing-utilityNav);
-  border-radius: var(--radius-utilityIcon);
+  border-radius: var(--feds-radius-utilityIcon);
   border: none;
 }  
 

--- a/libs/blocks/global-navigation/blocks/search/gnav-search.css
+++ b/libs/blocks/global-navigation/blocks/search/gnav-search.css
@@ -1,7 +1,3 @@
-:root {
-  --background-nav--light: #fff;
-}
-
 .feds-nav-wrapper.has-results .feds-nav {
   display: none;
 }
@@ -10,7 +6,7 @@
   padding: 20px 12px;
   display: flex;
   flex-direction: column;
-  background-color: var(--background-nav--light);
+  background-color: var(--feds-background-nav--light);
   /* TODO: add desktop top border */
 }
 
@@ -72,7 +68,7 @@
   font-size: 20px;
   line-height: 1;
   color: #2d2d2d;
-  border-radius: var(--radius-utilityIcon);
+  border-radius: var(--feds-radius-utilityIcon);
   outline-offset: 2px;
 }
 
@@ -136,8 +132,7 @@
     display: none;
   }
 
-  /* TODO: better class naming than 'is-open'? */
-  .feds-search.is-open .feds-search-bar {
+  .feds-search-trigger[aria-expanded = "true"] + .feds-search-bar {
     display: flex;
   }
 }

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -484,43 +484,6 @@ header .gnav-navitem.has-menu > a:after {
 
 /* END MAINNAV */
 
-/* PROFILE */
-
-.feds-profile {
-  display: flex;
-  align-items: center;
-  font-size: 14px;
-  position: relative;
-  justify-content: end;
-}
-
-/* TODO temporarily more specificity until we improve the CSS */
-header .gnav-navitem .feds-signin {
-  padding: 11px var(--feds-spacing-utilityNav);
-  border-radius: var(--feds-radius-utilityIcon);
-  border-bottom: none;
-  color: #4B4B4B;
-  white-space: nowrap;
-}
-
-header .gnav-navitem .feds-signin:hover {
-  background-color: transparent;
-}
-
-.feds-profile-img {
-  max-height: 30px;
-  max-width: 30px;
-  display: block;
-}
-
-.feds-profile-button {
-  padding: 5px var(--feds-spacing-utilityNav);
-  border-radius: var(--feds-radius-utilityIcon);
-  border: none;
-}
-
-/* END PROFILE */
-
 /* APP LAUNCHER */
 
 header .app-launcher button.gnav-applications-button {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1,14 +1,15 @@
 :root {
-  --height-nav: 64px;
-  --background-nav--light: #fff;
-  --color-border--light: #eaeaea;
-  --color-link--light: #2d2d2d;
-  --color-link--hover--light: #2b9af3;
-  --color-focus-ring: #109cde;
-  --padding-utilityIcon: 4px;
+  --feds-height-nav: 64px;
+  --feds-background-nav--light: #fff;
+  --feds-color-border--light: #eaeaea;
+  --feds-color-link--light: #2c2c2c;
+  --feds-color-link--hover--light: #1473e6;
+  --feds-borderColor-link--light: #f3f3f3;
+  --feds-background-link--hover--light: #f5f5f5;
+  --feds-color-adobeBrand: #fa0f00;
   --feds-spacing-utilityNav: 8px;
-  --radius-utilityIcon: 4px;
-  --height-breadcrumbs: 33px;
+  --feds-radius-utilityIcon: 4px;
+  --feds-height-breadcrumbs: 33px;
 }
 
 /* Base */
@@ -41,18 +42,21 @@
   position: sticky;
   top: 0;
   z-index: 1;
-  background-color: var(--background-nav--light);
+  background-color: var(--feds-background-nav--light);
   visibility: visible;
 }
 
 .feds-topnav-wrapper {
+  position: relative;
+  z-index: 2;
   display: flex;
   justify-content: center;
-  height: var(--height-nav);
+  height: var(--feds-height-nav);
+  background-color: var(--feds-background-nav--light);
 }
 
 .global-navigation.has-breadcrumbs .feds-topnav-wrapper {
-  border-bottom: 1px solid var(--color-border--light);
+  border-bottom: 1px solid var(--feds-color-border--light);
 }
 
 .feds-topnav {
@@ -62,8 +66,6 @@
   max-width: 1440px;
   height: inherit;
   justify-content: space-between;
-  z-index: 2;
-  background-color: var(--background-nav--light);
 }
 
 .feds-nav-wrapper {
@@ -74,7 +76,7 @@
   display: none;
   flex-direction: column;
   height: 100vh;
-  background-color: var(--background-nav--light);
+  background-color: var(--feds-background-nav--light);
 }
 
 .global-navigation.is-open .feds-nav-wrapper {
@@ -113,12 +115,111 @@
   flex-shrink: 0;
   font-weight: 700;
   font-size: 18px;
-  color: #FA0F00;
+  color: var(--feds-color-adobeBrand);
 }
 
 .feds-brand-image + .feds-brand-label:before {
   content: '';
   margin-left: 10px;
+}
+
+/* Nav Links */
+.feds-navItem {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--feds-color-link--light);
+  white-space: nowrap;
+}
+
+.feds-navItem--centered {
+  padding: 12px;
+}
+
+.feds-navLink {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  color: var(--feds-color-link--light);
+  white-space: nowrap;
+}
+
+.feds-navLink:hover,
+.feds-navLink:focus {
+  color: var(--feds-color-link--hover--light);
+}
+
+.feds-navItem:not(:last-child) > .feds-navLink {
+  border-bottom: 1px solid var(--feds-borderColor-link--light);
+}
+
+.feds-navLink--hoverCaret {
+  position: relative;
+  padding-right: 32px;
+}
+
+.feds-navLink--hoverCaret:after {
+  position: absolute;
+  right: 18px;
+  top: 50%;
+  display: flex;
+  width: 6px;
+  height: 6px;
+  margin-top: -3px;
+  border-width: 0 1px 1px 0;
+  border-style: solid;
+  border-color: var(--feds-color-link--light);
+  transform-origin: 75% 75%;
+  transform: rotateZ(45deg);
+  transition: transform 0.1s ease;
+  content: "";
+}
+
+/* TODO: maybe don't load RTL styles if not currently on an RTL locale */
+[dir = "rtl"] .feds-navLink--hoverCaret {
+  padding-right: 12px;
+  padding-left: 32px;
+}
+
+.feds-cta-wrapper {
+  display: flex;
+}
+
+.feds-cta {
+  display: flex;
+  flex-shrink: 0;
+  height: 32px;
+  min-width: 72px;
+  padding: 0 14px;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 16px;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 0;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: center;
+  overflow: visible;
+  white-space: nowrap;
+  transition: all 130ms ease-out;
+  cursor: pointer;
+}
+
+.feds-cta--primary {
+  background-color: rgb(20, 115, 230);
+  border-color: rgb(20, 115, 230);
+  color: rgb(255, 255, 255);
+}
+
+.feds-cta--primary:hover,
+.feds-cta--primary:focus {
+  background-color: rgb(13, 102, 208);
+  border-color: rgb(13, 102, 208);
+  color: rgb(255, 255, 255);
 }
 
 /* Search */
@@ -134,11 +235,11 @@
   display: none;
   font-size: 20px;
   line-height: 1;
-  color: var(--color-link--light);
+  color: var(--feds-color-link--light);
 }
 
 .feds-search-close:hover {
-  color: var(--color-link--hover--light);
+  color: var(--feds-color-link--hover--light);
 }
 
 .feds-search-close:before {
@@ -150,7 +251,7 @@
   display: flex;
   padding: 0 12px;
   order: -2;
-  border: 1px solid var(--color-border--light);
+  border: 1px solid var(--feds-color-border--light);
   font-size: 12px;
 }
 
@@ -167,7 +268,7 @@
 
 .feds-breadcrumbs a,
 .feds-breadcrumbs [aria-current] {
-  line-height: var(--height-breadcrumbs);
+  line-height: var(--feds-height-breadcrumbs);
 }
 
 .feds-breadcrumbs a {
@@ -197,7 +298,7 @@
 @media (min-width: 900px) {
   /* General */
   .global-navigation.has-breadcrumbs {
-    padding-bottom: var(--height-breadcrumbs);
+    padding-bottom: var(--feds-height-breadcrumbs);
   }
 
   .feds-nav-wrapper {
@@ -221,6 +322,37 @@
     display: flex;
   }
 
+  /* Nav Links */
+  .feds-navItem--centered {
+    padding: 0 12px;
+    align-items: center;
+  }
+
+  .feds-navLink,
+  .feds-navLink--hoverCaret,
+  [dir = "rtl"] .feds-navLink--hoverCaret {
+    padding: 0 12px;
+  }
+
+  .feds-navItem:not(:last-child) > .feds-navLink {
+    border-bottom: none;
+  }
+
+  .feds-navLink--hoverCaret {
+    position: static;
+  }
+  
+  .feds-navLink--hoverCaret:after {
+    position: static;
+    margin-top: 0;
+    margin-left: 5px;
+  }
+
+  [dir = "rtl"] .feds-navLink--hoverCaret:after {
+    margin-left: 0;
+    margin-right: 5px;
+  }
+
   /* Search */
   .feds-search {
     display: flex;
@@ -232,7 +364,7 @@
     display: flex;
     padding: var(--feds-spacing-utilityNav);
     border: none;
-    border-radius: var(--radius-utilityIcon);
+    border-radius: var(--feds-radius-utilityIcon);
     outline-offset: 2px;
   }
 
@@ -251,11 +383,11 @@
   }
 
   .feds-search-trigger svg path {
-    fill: var(--color-link--light);
+    fill: var(--feds-color-link--light);
   }
 
   .feds-search-trigger:hover svg path {
-    fill: var(--color-link--hover--light);
+    fill: var(--feds-color-link--hover--light);
   }
 
   /* Breadcrumbs */
@@ -346,23 +478,48 @@ header .gnav-navitem.has-menu > a:after {
   margin-right: 3px;
 }
 
-.gnav-cta {
-  display: flex;
-  align-items: center;
-  padding: 20px 12px;
-}
-
-.gnav-cta .con-button {
-  line-height: 36px;
-  border-radius: 20px;
-  padding: 0 14px;
-}
-
 .last-link-blue ul li:last-of-type a {
   color: #1473E6;
 }
 
 /* END MAINNAV */
+
+/* PROFILE */
+
+.feds-profile {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  position: relative;
+  justify-content: end;
+}
+
+/* TODO temporarily more specificity until we improve the CSS */
+header .gnav-navitem .feds-signin {
+  padding: 11px var(--feds-spacing-utilityNav);
+  border-radius: var(--feds-radius-utilityIcon);
+  border-bottom: none;
+  color: #4B4B4B;
+  white-space: nowrap;
+}
+
+header .gnav-navitem .feds-signin:hover {
+  background-color: transparent;
+}
+
+.feds-profile-img {
+  max-height: 30px;
+  max-width: 30px;
+  display: block;
+}
+
+.feds-profile-button {
+  padding: 5px var(--feds-spacing-utilityNav);
+  border-radius: var(--feds-radius-utilityIcon);
+  border: none;
+}
+
+/* END PROFILE */
 
 /* APP LAUNCHER */
 
@@ -457,14 +614,6 @@ header .app-launcher {
 
   header .gnav-navitem.section-menu + .gnav-navitem > a {
     padding-left: 20px;
-  }
-
-  .gnav-cta .con-button {
-    line-height: unset;
-  }
-
-  .gnav-cta {
-    padding: 0 20px;
   }
 
   header button.gnav-toggle {

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -1,5 +1,4 @@
-/* eslint-disable no-underscore-dangle */
-import { getConfig } from '../../../utils/utils.js';
+import { getConfig, localizeLink } from '../../../utils/utils.js';
 
 export function toFragment(htmlStrings, ...values) {
   const templateStr = htmlStrings.reduce((acc, htmlString, index) => {
@@ -56,3 +55,24 @@ export const getFedsPlaceholderConfig = () => {
     },
   };
 };
+
+export function getAnalyticsValue(str, index) {
+  if (typeof str !== 'string' || !str.length) return str;
+
+  let analyticsValue = str.trim().replace(/[^\w]+/g, '_').replace(/^_+|_+$/g, '');
+  analyticsValue = typeof index === 'number' ? `${analyticsValue}-${index}` : analyticsValue;
+
+  return analyticsValue;
+}
+
+export function decorateCta({ elem, type = 'primary', index } = {}) {
+  return toFragment`
+    <div class="feds-cta-wrapper">
+      <a 
+        href="${localizeLink(elem.href)}"
+        class="feds-cta feds-cta--${type}"
+        daa-ll="${getAnalyticsValue(elem.textContent, index)}">
+          ${elem.textContent}
+      </a>
+    </div>`;
+}

--- a/test/blocks/gnav/gnav.test.js
+++ b/test/blocks/gnav/gnav.test.js
@@ -181,7 +181,7 @@ describe('Localized Gnav', () => {
   });
 
   it('Test Gnav Cta Link', async () => {
-    const ctaLink = document.querySelector('.gnav-cta').getElementsByTagName('a')[0];
+    const ctaLink = document.querySelector('.feds-cta').getElementsByTagName('a')[0];
     expect(ctaLink.href.startsWith('http://localhost:2000/fi/'), "Cta Link should be localized").true;
   });
 


### PR DESCRIPTION
This is a refactor of the Gnav links decoration, popups/dropdowns (sync or async, normal or mega-menu style), headliness and CTAs. It also scopes the CSS custom properties used by FEDS to avoid collision with other parts of the application.

A few additional improvements worth mentioning:
* the logic will now follow the structure as authored in Word, it is no longer opinionated on item order;
* the headlines now act as accordion headers for subsections on mobile.

This PR also fixes two bugs related to Search:
* https://jira.corp.adobe.com/browse/MWPW-127264 (ensure correct curtain styles when Search is open)
* https://jira.corp.adobe.com/browse/MWPW-127263 (clear Search input and results when trigger is clicked)

Resolves: [MWPW-125175](https://jira.corp.adobe.com/browse/MWPW-125175)

**Test URLs:**
- Before: https://feds-gnav--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
- After: https://mwpw-125175-nav-links--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
