### PR TITLE
Lana: Remove event handlers before import

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -759,9 +759,9 @@ export function loadLana(options = {}) {
 
   window.lana = {
     log: async (...args) => {
-      await import('./lana.js');
       window.removeEventListener('error', lanaError);
       window.removeEventListener('unhandledrejection', lanaError);
+      await import('./lana.js');
       return window.lana.log(...args);
     },
     debug: false,


### PR DESCRIPTION
If there is an unhandled error it will trigger a lana.log message, which tries importing ./lana.js, that will throw an error, which is then caught by the error listener which tries to log a lana message. 

This happens on DC when using the `milolibs` param as the DC CSP (Content Security Policy) doesn't allow loading of files from milobranch--main--adobecom.hlx.page.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://<branch>--milo--adobecom.hlx.page/?martech=off
