### PR TITLE
MWPW-127324 - Second line copyright

### DIFF
--- a/libs/blocks/footer/footer.css
+++ b/libs/blocks/footer/footer.css
@@ -176,10 +176,6 @@ footer .footer-social a {
   width: 20px;
 }
 
-.footer-privacy p:nth-of-type(2) {
-  line-height: 2;
-}
-
 /* Region Selector */
 .footer-region {
   position: relative;
@@ -336,6 +332,11 @@ footer .footer-region-button.inline-dialog-active svg.icon-chevron-down {
   margin-left: 6px;
 }
 
+.footer-copyright-second {
+  line-height: 2;
+  width: 100%;
+}
+
 @media (min-width: 900px) {
   footer {
     padding: 40px 0 24px;
@@ -390,5 +391,9 @@ footer .footer-region-button.inline-dialog-active svg.icon-chevron-down {
     display: flex;
     flex-wrap: wrap;
     justify-content: end;
+  }
+
+  .footer-copyright-second {
+    text-align: right;
   }
 }

--- a/libs/blocks/footer/footer.css
+++ b/libs/blocks/footer/footer.css
@@ -390,7 +390,7 @@ footer .footer-region-button.inline-dialog-active svg.icon-chevron-down {
   .footer-privacy {
     display: flex;
     flex-wrap: wrap;
-    justify-content: end;
+    justify-content: flex-end;
   }
 
   .footer-copyright-second {

--- a/libs/blocks/footer/footer.css
+++ b/libs/blocks/footer/footer.css
@@ -9,6 +9,12 @@ footer {
   padding: 0 0 8px;
 }
 
+.footer-nav-item-link a {
+  display: block;
+  text-decoration: none;
+  padding: 3px 0;
+}
+
 footer a:any-link {
   color: var(--color-gray-700);
   text-decoration: none;
@@ -109,6 +115,12 @@ footer a:not(:any-link) {
   color: var(--color-gray-500);
 }
 
+.footer-nav-item-links {
+  list-style-type: none;
+  margin-top: 0;
+  padding: 0;
+}
+
 .footer-nav-item-title[aria-expanded=false] + .footer-nav-item-links {
   visibility: hidden;
   display: none;
@@ -116,18 +128,6 @@ footer a:not(:any-link) {
 
 .footer-nav-item-title[aria-expanded=true] + .footer-nav-item-links {
   visibility: visible;
-}
-
-.footer-nav-item-links {
-  list-style-type: none;
-  margin-top: 0;
-  padding: 0;
-}
-
-.footer-nav-item-link a {
-  display: block;
-  text-decoration: none;
-  padding: 3px 0;
 }
 
 .footer-info {
@@ -145,7 +145,7 @@ footer a:not(:any-link) {
 /* Social Links */
 
 .footer-social {
-  margin: 0 0 0 18px;
+  margin: 0 18px;
   list-style: none;
   padding: 0;
   display: flex;
@@ -176,6 +176,9 @@ footer .footer-social a {
   width: 20px;
 }
 
+.footer-privacy p:nth-of-type(2) {
+  line-height: 2;
+}
 
 /* Region Selector */
 .footer-region {
@@ -197,7 +200,7 @@ footer .footer-region a {
   padding: 0;
   line-height: 1;
   min-width: 120px;
-  background: rgba(0,0,0,0);
+  background: rgb(0 0 0 / 0%);
   border: none;
   color: var(--color-gray-700);
   text-decoration: none;
@@ -224,7 +227,7 @@ footer .footer-region .fragment .region-selector-text {
 
 footer .footer-region .fragment .region-selector-text p {
   line-height: 1.1;
-  margin: 0 0 10px 0;
+  margin: 0 0 10px;
 }
 
 footer .footer-region .fragment .region-selector {
@@ -259,6 +262,11 @@ footer .footer-region-button.inline-dialog-active + .fragment {
   display: block;
 }
 
+.footer-region svg.icon-chevron-down {
+  width: 16px;
+  margin-top: 2px;
+}
+
 footer .footer-region-button.inline-dialog-active svg.icon-chevron-down {
   transform: rotate(180deg);
 }
@@ -281,11 +289,6 @@ footer .footer-region-button.inline-dialog-active svg.icon-chevron-down {
 .footer-region-text {
   font-size: var(--type-detail-s-size);
   margin-right: 8px;
-}
-
-.footer-region svg.icon-chevron-down {
-  width: 16px;
-  margin-top: 2px;
 }
 
 @media screen and (max-width: 900px) {

--- a/libs/blocks/footer/footer.js
+++ b/libs/blocks/footer/footer.js
@@ -19,7 +19,7 @@ const SPECTRUM_CHEVRON = '<svg class="icon-chevron-down" xmlns="http://www.w3.or
 const ADCHOICE_IMG = `<img class="footer-link-img" loading="lazy" alt="AdChoices icon" src="${base}/blocks/footer/adchoices-small.svg" height="9" width="9">`;
 const SUPPORTED_SOCIAL = ['facebook', 'instagram', 'twitter', 'linkedin', 'pinterest', 'discord', 'behance', 'youtube', 'weibo', 'social-media'];
 
-class Footer {
+export class Footer {
   constructor(body, footerEl) {
     this.footerEl = footerEl;
     this.body = body;
@@ -225,6 +225,10 @@ class Footer {
       });
     }
     privacyWrapper.append(ul);
+
+    const secondLine = container.children[1];
+    if (secondLine) privacyWrapper.append(secondLine);
+
     return privacyWrapper;
   };
 

--- a/libs/blocks/footer/footer.js
+++ b/libs/blocks/footer/footer.js
@@ -226,7 +226,7 @@ export class Footer {
     }
     privacyWrapper.append(ul);
 
-    const secondLine = container.children[1];
+    const secondLine = container.querySelector('p:nth-of-type(2)');
     if (secondLine) privacyWrapper.append(secondLine);
 
     return privacyWrapper;

--- a/libs/blocks/footer/footer.js
+++ b/libs/blocks/footer/footer.js
@@ -227,7 +227,10 @@ export class Footer {
     privacyWrapper.append(ul);
 
     const secondLine = container.querySelector('p:nth-of-type(2)');
-    if (secondLine) privacyWrapper.append(secondLine);
+    if (secondLine) {
+      secondLine.classList.add('footer-copyright-second');
+      privacyWrapper.append(secondLine);
+    }
 
     return privacyWrapper;
   };

--- a/test/blocks/footer/footer.test.js
+++ b/test/blocks/footer/footer.test.js
@@ -4,13 +4,17 @@ import { expect } from '@esm-bundle/chai';
 const { Footer } = await import('../../../libs/blocks/footer/footer.js');
 
 describe('Footer', () => {
-  describe('copyright ul', async () => {
-    const copyright = await readFile({ path: './mocks/copyright-ul.html' });
-    const parser = new DOMParser();
-    const copyrightDom = parser.parseFromString(copyright, 'text/html');
-    document.body.innerHTML = '<footer></footer>';
-    const footer = new Footer(copyrightDom.body, document.querySelector('footer'));
-    const privacy = footer.decoratePrivacy();
+  describe('copyright ul', () => {
+    let privacy = null;
+
+    before(async () => {
+      const copyright = await readFile({ path: './mocks/copyright-ul.html' });
+      const parser = new DOMParser();
+      const copyrightDom = parser.parseFromString(copyright, 'text/html');
+      document.body.innerHTML = '<footer></footer>';
+      const footer = new Footer(copyrightDom.body, document.querySelector('footer'));
+      privacy = footer.decoratePrivacy();
+    });
 
     it('adds ul', () => {
       expect(privacy.querySelector('ul.footer-privacy-links')).not.to.be.null;
@@ -26,12 +30,16 @@ describe('Footer', () => {
   });
 
   describe('copyright p', async () => {
-    const copyright = await readFile({ path: './mocks/copyright-p.html' });
-    const parser = new DOMParser();
-    const copyrightDom = parser.parseFromString(copyright, 'text/html');
-    document.body.innerHTML = '<footer></footer>';
-    const footer = new Footer(copyrightDom.body, document.querySelector('footer'));
-    const privacy = footer.decoratePrivacy();
+    let privacy = null;
+
+    before(async () => {
+      const copyright = await readFile({ path: './mocks/copyright-p.html' });
+      const parser = new DOMParser();
+      const copyrightDom = parser.parseFromString(copyright, 'text/html');
+      document.body.innerHTML = '<footer></footer>';
+      const footer = new Footer(copyrightDom.body, document.querySelector('footer'));
+      privacy = footer.decoratePrivacy();
+    });
 
     it('adds ul', () => {
       expect(privacy.querySelector('ul.footer-privacy-links')).not.to.be.null;
@@ -39,6 +47,10 @@ describe('Footer', () => {
 
     it('adds li', () => {
       expect(privacy.querySelector('li.footer-privacy-link')).not.to.be.null;
+    });
+    
+    it('supports second line of text', () => {
+      expect(privacy.querySelector('p:nth-of-type(2)')).not.to.be.null;
     });
   });
 });

--- a/test/blocks/footer/footer.test.js
+++ b/test/blocks/footer/footer.test.js
@@ -27,6 +27,10 @@ describe('Footer', () => {
     it('allows text without link', () => {
       expect(privacy.querySelector('li#no-link')).not.to.be.null;
     });
+
+    it('supports second line of text', () => {
+      expect(privacy.querySelector('p:nth-of-type(2)')).not.to.be.null;
+    });
   });
 
   describe('copyright p', async () => {

--- a/test/blocks/footer/mocks/copyright-p.html
+++ b/test/blocks/footer/mocks/copyright-p.html
@@ -86,4 +86,5 @@
 </div>
 <div>
   <p><em>All rights reserved.</em> / <a href="https://www.adobe.com/privacy.html">Privacy</a> / <a href="https://www.adobe.com/legal/terms.html">Terms of Use</a> / <a href="https://www.adobe.com/#openPrivacy">Cookie preferences</a> / <a href="https://www.adobe.com/privacy/ca-rights.html">Do not sell my personal information</a> / <a href="https://www.adobe.com/privacy/opt-out.html#interest-based-ads">AdChoices</a></p>
+  <p>More copyright text</p>
 </div>

--- a/test/blocks/footer/mocks/copyright-ul.html
+++ b/test/blocks/footer/mocks/copyright-ul.html
@@ -94,4 +94,5 @@
     <li id="no-link">I do not have a link</li>
     <li><a href="https://www.adobe.com/cn/privacy/opt-out.html#interest-based-ads">AdChoices</a></li>
   </ul>
+  <p>More copyright text</p>
 </div>


### PR DESCRIPTION
* Support a second line of copyright text, such as in the bacom korean footer
* Fix stylelint errors in footer.css

Resolves: [MWPW-127324](https://jira.corp.adobe.com/browse/MWPW-127324)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/footer-kr-page?martech=off
- After: https://methomas-kr-copyright--milo--adobecom.hlx.page/drafts/methomas/footer-kr-page?martech=off
