### PR TITLE
Text block override - lowercase typography class names

### DIFF
--- a/libs/blocks/text/text.js
+++ b/libs/blocks/text/text.js
@@ -45,7 +45,7 @@ export default function init(el) {
   const overrides = ['-heading', '-body', '-detail'];
   overrides.forEach((override, index) => {
     const hasClass = [...el.classList].filter((listItem) => listItem.includes(override));
-    if (hasClass.length) config[index] = hasClass[0].split('-').shift().toUpperCase();
+    if (hasClass.length) config[index] = hasClass[0].split('-').shift().toLowerCase();
   });
   decorateBlockText(el, config);
   rows.forEach((row) => { row.classList.add('foreground'); });


### PR DESCRIPTION
 * Updated the text block javascript logic so the override decorator uses a lowercase typography class references. 
 
It was reported that the `text` block typography overrides were not working as expected. This is in association w/ the previously merged task to address style-lint warnings in our typography.css names.
[MWPW-126441] Unblock style-linting by lowercasing all t-shirt sizes in classnames | https://github.com/adobecom/milo/pull/503


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/text?martech=off
- After: https://rparrish-text-override--milo--adobecom.hlx.page/docs/library/kitchen-sink/text?martech=off

**Testing**

Review the before/after urls and scroll to the bottom of the page where the overrides section is.
Confirm the advertised typography overrides are working in the after example. 