### PR TITLE
MWPW-127043 Fix Region Selector US Link

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -248,12 +248,12 @@ export function appendHtmlPostfix(area = document) {
 
   const HAS_EXTENSION = /\..*$/;
   const shouldNotConvert = (href) => {
-    let url;
+    let url = { pathname: href };
 
     try { url = new URL(href, pageUrl) } catch (e) {}
 
     if (!(href.startsWith('/') || href.startsWith(pageUrl.origin))
-      || url?.pathname.endsWith('/')
+      || url.pathname?.endsWith('/')
       || href === pageUrl.origin
       || HAS_EXTENSION.test(href.split('/').pop())
       || htmlExclude?.some((excludeRe) => excludeRe.test(href))) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -248,8 +248,12 @@ export function appendHtmlPostfix(area = document) {
 
   const HAS_EXTENSION = /\..*$/;
   const shouldNotConvert = (href) => {
+    let url;
+
+    try { url = new URL(href, pageUrl) } catch (e) {}
+
     if (!(href.startsWith('/') || href.startsWith(pageUrl.origin))
-      || href.endsWith('/')
+      || url?.pathname.endsWith('/')
       || href === pageUrl.origin
       || HAS_EXTENSION.test(href.split('/').pop())
       || htmlExclude?.some((excludeRe) => excludeRe.test(href))) {

--- a/test/utils/htmlpostfix.test.html
+++ b/test/utils/htmlpostfix.test.html
@@ -14,6 +14,12 @@
       <a href="http://localhost:2000/has/json/extension.json"></a>
       <a href="http://localhost:2000/has/css/extension.css"></a>
       <a href="http://localhost/wrongport"></a>
+      <a href="http://localhost:2000/#hash"></a>
+      <a href="http://localhost:2000/?q=puppies"></a>
+      <a href="http://localhost:2000/?q=puppies#hash"></a>
+      <a href="http://localhost:2000#hash"></a>
+      <a href="http://localhost:2000?q=puppies"></a>
+      <a href="http://localhost:2000?q=puppies#hash"></a>
     </div>
     <div id="relativelinks">
       <a href="/test/relative/link"></a>
@@ -67,7 +73,13 @@
           'http://localhost:2000/has/json/extension.json',
           'http://localhost:2000/has/css/extension.css',
           'http://localhost/wrongport',
-          ])
+          'http://localhost:2000/#hash',
+          'http://localhost:2000/?q=puppies',
+          'http://localhost:2000/?q=puppies#hash',
+          'http://localhost:2000#hash',
+          'http://localhost:2000?q=puppies',
+          'http://localhost:2000?q=puppies#hash',
+          ]);
         });
 
         it('relative links', async () => {


### PR DESCRIPTION
* Removes extra ".html" in url path for US link in region selector (e.g. `https://business.adobe.com/.html/customer-success-stories.html`)
* Fixes all links to US home with hash or query params on .html

Resolves: [MWPW-127043](https://jira.corp.adobe.com/browse/MWPW-127043)

**Test URLs:**
- Before: https://business.stage.adobe.com/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/customer-success-stories.html?milolibs=methomas-change-region-html&martech=off
