### PR TITLE
MWPW-127736 Fix Safari sign-in dropdown

### DIFF
--- a/libs/blocks/gnav/gnav.css
+++ b/libs/blocks/gnav/gnav.css
@@ -10,6 +10,10 @@ header {
   display: block;
 }
 
+header.gnav {
+  overflow: visible;
+}
+
 header.is-open .gnav-curtain,
 .gnav-curtain.is-open {
   position: fixed;

--- a/libs/blocks/gnav/gnav.css
+++ b/libs/blocks/gnav/gnav.css
@@ -59,7 +59,10 @@ header nav.gnav {
   grid-template-columns: 1fr 12px;
   grid-template-rows: 56px 36px;
   position: absolute;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 }
 
 header.has-breadcrumbs nav.gnav {

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -130,7 +130,7 @@ class Gnav {
         document.removeEventListener('click', closeToggleOnDocClick);
       }
     };
-    toggle.addEventListener('click', async (e) => {
+    toggle.addEventListener('click', async () => {
       if (this.el.classList.contains(IS_OPEN)) {
         this.el.classList.remove(IS_OPEN);
         this.desktop.removeEventListener('change', onMediaChange);

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -117,18 +117,31 @@ class Gnav {
 
   decorateToggle = () => {
     const toggle = createTag('button', { class: 'gnav-toggle', 'aria-label': 'Navigation menu', 'aria-expanded': false });
+    const closeToggleOnDocClick = ({ target }) => {
+      if (target !== toggle && !target.closest('.mainnav-wrapper')) {
+        this.el.classList.remove(IS_OPEN);
+        this.desktop.removeEventListener('change', onMediaChange);
+        document.removeEventListener('click', closeToggleOnDocClick);
+      }
+    };
     const onMediaChange = (e) => {
       if (e.matches) {
         this.el.classList.remove(IS_OPEN);
+        document.removeEventListener('click', closeToggleOnDocClick);
       }
     };
-    toggle.addEventListener('click', async () => {
+    toggle.addEventListener('click', async (e) => {
       if (this.el.classList.contains(IS_OPEN)) {
         this.el.classList.remove(IS_OPEN);
         this.desktop.removeEventListener('change', onMediaChange);
+        document.removeEventListener('click', closeToggleOnDocClick);
       } else {
+        if (this.state.openMenu) {
+          this.closeMenu();
+        }
         this.el.classList.add(IS_OPEN);
         this.desktop.addEventListener('change', onMediaChange);
+        document.addEventListener('click', closeToggleOnDocClick);
         this.loadSearch();
       }
     });
@@ -307,7 +320,6 @@ class Gnav {
     });
     navLink.addEventListener('click', (e) => {
       e.preventDefault();
-      e.stopPropagation();
       this.toggleMenu(navItem);
     });
     this.decorateButtons(menu);

--- a/test/blocks/gnav/gnav.test.js
+++ b/test/blocks/gnav/gnav.test.js
@@ -1,7 +1,7 @@
 import { readFile, resetMouse, setViewport, sendKeys, sendMouse } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon, { stub } from 'sinon';
-import { delay } from '../../helpers/waitfor.js';
+import { delay, waitForElement } from '../../helpers/waitfor.js';
 import { setConfig } from '../../../libs/utils/utils.js';
 
 window.lana = { log: stub() };
@@ -16,7 +16,7 @@ await loadDefaultHtml();
 const mod = await import('../../../libs/blocks/gnav/gnav.js');
 let gnav;
 
-const config = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+const config = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } }, imsClientId: 'milo' };
 setConfig(config);
 
 describe('Gnav', () => {
@@ -58,6 +58,26 @@ describe('Gnav', () => {
     expect(largeMenu.classList.contains(mod.IS_OPEN)).to.be.true;
     largeMenuBtn.click();
     expect(largeMenu.classList.contains(mod.IS_OPEN)).to.be.false;
+  });
+
+  it('doesn\'t have the toggle menu and sign-in dropdown open at the same time', async () => {
+    await waitForElement('.gnav-signin');
+    const signIn = document.querySelector('.gnav-signin');
+    const toggleButton = document.querySelector('.gnav-toggle');
+    const profile = document.querySelector('.gnav-profile');
+    const header = document.querySelector('header');
+
+    await setViewport({ width: 400, height: 640 });
+    signIn.click();
+    expect(profile.classList.contains(mod.IS_OPEN)).to.be.true;
+    toggleButton.click();
+    expect(header.classList.contains(mod.IS_OPEN)).to.be.true;
+    expect(profile.classList.contains(mod.IS_OPEN)).to.be.false;
+    signIn.click();
+    expect(header.classList.contains(mod.IS_OPEN)).to.be.false;
+    expect(profile.classList.contains(mod.IS_OPEN)).to.be.true;
+    signIn.click();
+    await setViewport({ width: 1250, height: 640 });
   });
 
   it('nav menu close on scroll', async () => {

--- a/test/blocks/gnav/mocks/gnav.plain.html
+++ b/test/blocks/gnav/mocks/gnav.plain.html
@@ -113,22 +113,28 @@
       <div class="profile">
         <div>
           <div>
-            <p>
-              <a href="https://www.adobe.com/login">Sign In</a>
-            </p>
-            <p>
-              <a href="https://account.adobe.com">View Account</a>
-            </p>
-            <p>
-              <a href="https://adminconsole.adobe.com/team">Manage Team</a>
-            </p>
-            <p>
-              <a href="https://adminconsole.adobe.com">Manage Enterprise</a>
-            </p>
-            <p>
-              <a href="https://account.adobe.com">Sign Out</a>
-            </p>
+            <p><a href="https://www.adobe.com/login">Sign In</a></p>
+            <p><a href="https://account.adobe.com/">View Account</a></p>
+            <p><a href="https://adminconsole.adobe.com/team">Manage Team</a></p>
+            <p><a href="https://adminconsole.adobe.com/">Manage Enterprise</a></p>
+            <p><a href="https://account.adobe.com/">Sign Out</a></p>
           </div>
+        </div>
+        <div>
+          <div>
+            <ul>
+              <li><a href="https://experiencecloud.adobe.com/exc-content/login.html">Experience Cloud</a></li>
+              <li><a href="https://account.magento.com/customer/account/login">Commerce (Magento)</a></li>
+              <li><a href="https://login.marketo.com/">Marketo Engage</a></li>
+              <li><a href="https://business.adobe.com/products/workfront/login.html">Workfront</a></li>
+              <li><a href="https://www.adobe.com/login">Adobe Account</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="app-launcher">
+        <div>
+          <div><a href="/gnav/app-launcher">App Launcher</a></div>
         </div>
       </div>
       <div class="adobe-logo">

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -7,6 +7,7 @@ export default {
       '**/node_modules/**',
       '**/test/**',
       '**/deps/**',
+      '**/imslib/imslib.min.js',
       // TODO: folders below need to have tests written for 100% coverage
       '**/ui/controls/**',
       '**/blocks/library-config/**',


### PR DESCRIPTION
* Fix issue where clicking "Sign in" on safari on mobile device didn't show dropdown
* Fix issue where "Sign in" button is inaccessible on Safari 14 mobile
* Fix issue where "Sign in" dropdown and toggle/hamburger menu can be open at the same time

Resolves: [MWPW-127736](https://jira.corp.adobe.com/browse/MWPW-127736)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/checkmark?martech=off
- After: https://methomas-sign-in-mobile--milo--adobecom.hlx.page/drafts/methomas/checkmark?martech=off

BACOM:
- Before: https://main--bacom--adobecom.hlx.page/customer-success-stories?martech=off
- After: https://main--bacom--adobecom.hlx.page/customer-success-stories?milolibs=methomas-sign-in-mobile&martech=off

Note: This only occurs on iOS, so you'll need to use browserstack to verify.