### PR TITLE
[MWPW-117906] Localnav and dropdown enhancements

### DIFF
--- a/libs/blocks/global-navigation/blocks/navDropdown/dropdown.css
+++ b/libs/blocks/global-navigation/blocks/navDropdown/dropdown.css
@@ -3,6 +3,7 @@
   --feds-color-navLink-description--light: #656565;
   --feds-borderColor-popup--light: #e1e1e1;
   --feds-color-headline--light: #505050;
+  --feds-background-promo--dark: #000;
 }
 
 .feds-navItem {
@@ -55,6 +56,11 @@
   content: "";
 }
 
+[dir = "rtl"] .feds-popup-headline:after {
+  right: unset;
+  left: 30px;
+}
+
 .feds-navLink--hoverCaret[aria-expanded = "true"] + .feds-popup,
 .feds-popup-headline[aria-expanded = "true"] + .feds-popup-items {
   display: flex;
@@ -68,6 +74,10 @@
 
 .feds-popup-items {
   border-bottom: solid 1px var(--feds-borderColor-popup--light);
+}
+
+.feds-popup .feds-navLink {
+  column-gap: 15px;
 }
 
 .feds-popup .feds-navLink,
@@ -90,6 +100,11 @@
   padding: 0;
 }
 
+.feds-promo {
+  display: none;
+}
+
+/* Start mobile styles */
 @media (min-width: 900px) {
   .feds-navItem {
     flex-direction: initial;
@@ -103,6 +118,8 @@
     position: absolute;
     top: 100%;
     left: 0;
+    padding: 0;
+    z-index: 1;
   }
 
   [dir = "rtl"] .feds-popup {
@@ -116,9 +133,36 @@
 
   .feds-navItem--megaMenu .feds-popup {
     right: 0;
-    justify-content: space-around;
-    padding: 32px 0;
+    justify-content: center;
+    padding: 20px 0;
   }
+
+  [dir = "rtl"] .feds-navItem--megaMenu .feds-popup {
+    left: 0;
+  }
+
+  .feds-popup-content {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    max-width: var(--feds-maxWidth-nav);
+  }
+
+  .feds-popup-column {
+    padding: 12px 0;
+  }
+
+  /* Uncomment if border between simple dropdown columns are needed */
+  /*
+  .feds-navItem:not(.feds-navItem--megaMenu) .feds-popup-column:not(:first-child) {
+    border-left: 1px solid var(--feds-borderColor-popup--light);
+  }
+
+  [dir = "rtl"] .feds-navItem:not(.feds-navItem--megaMenu) .feds-popup-column:not(:first-child) {
+    border-left: none;
+    border-right: 1px solid var(--feds-borderColor-popup--light);
+  }
+  */
 
   .feds-popup-headline {
     position: static;
@@ -146,11 +190,6 @@
     display: flex;
   }
 
-  .feds-navLink-image:nth-last-child(2):after {
-    content: '';
-    margin-left: 15px;
-  }
-
   .feds-navLink-image picture,
   .feds-navLink-image img {
     display: block;
@@ -169,5 +208,56 @@
   .feds-navLink:hover .feds-navLink-description,
   .feds-navLink:focus .feds-navLink-description {
     color: var(--feds-color-navLink-description--light);
+  }
+
+  .feds-promo-wrapper {
+    width: 260px;
+    padding: 0 32px;
+  }
+
+  .feds-promo {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    border: 1px solid var(--feds-color-border--light);
+    background: var(--feds-background-nav--light);
+    white-space: normal;
+  }
+
+  .feds-promo--dark {
+    background: var(--feds-background-promo--dark);
+  }
+
+  .feds-promo-image,
+  .feds-promo picture,
+  .feds-promo img {
+    width: 100%;
+    display: block;
+  }
+
+  /* Next two sets of rules are a compromise between
+  content auhtored manually and AEM-imported content */
+  .feds-promo > div {
+    padding: 8px 32px;
+  }
+
+  .feds-promo div {
+    display: flex;
+    flex-direction: column;
+    row-gap: 8px;
+  }
+
+  .feds-promo .feds-promo-image {
+    padding: 0;
+  }
+
+  .feds-promo--dark,
+  .feds-promo--dark a {
+    color: var(--feds-background-nav--light);
+  }
+
+  .feds-promo--dark a,
+  .feds-promo--dark a:hover {
+    text-decoration: underline;
   }
 }

--- a/libs/blocks/global-navigation/blocks/navDropdown/dropdown.js
+++ b/libs/blocks/global-navigation/blocks/navDropdown/dropdown.js
@@ -44,6 +44,7 @@ const decorateLinkGroup = (elem, index) => {
   if (!(elem instanceof HTMLElement) || !elem.querySelector('a')) return null;
 
   // TODO: could it be something other than a 'picture'?
+  // TODO: allow links with image and no label
   const image = elem.querySelector('picture');
   const link = elem.querySelector('a');
   const description = elem.querySelector('p:nth-child(2)');
@@ -65,31 +66,193 @@ const decorateLinkGroup = (elem, index) => {
   return linkGroup;
 };
 
-// Current limitations:
-// * can't add link group in small dropdown
-// * after an h5 is found in a dropdown column, no new sections can be without a heading
+// Decorate a list of simple links
+const decorateLinkList = ({ list, className = 'feds-navLink', includeCta = true } = {}) => {
+  list.querySelectorAll('a').forEach((link, index) => {
+    // If the link is wrapped in a 'strong' or 'em' tag, make it a CTA
+    if (includeCta
+      && (link.parentElement.tagName === 'STRONG' || link.parentElement.tagName === 'EM')) {
+      const type = link.parentElement.tagName === 'EM' ? 'secondaryCta' : 'primaryCta';
+      decorateCta({ elem: link, type, index: index + 1 });
+    // Otherwise add analytics attributes and proper class
+    } else {
+      link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
+      link.classList.add(className);
+    }
+  });
+};
+
+// Current limitation: we can only add one link
+const decoratePromo = (elem) => {
+  const isDarkTheme = elem.classList.contains('dark');
+  const isImageOnly = elem.classList.contains('image-only');
+  const imageElem = elem.querySelector('picture');
+
+  decorateLinkList({ list: elem, className: 'feds-promo-link', includeCta: false });
+
+  const decorateImage = () => {
+    const linkElem = elem.querySelector('a');
+    const imageWrapper = imageElem.closest('.gnav-promo > div');
+    let promoImageElem;
+
+    if (linkElem instanceof HTMLElement) {
+      promoImageElem = toFragment`<a class="feds-promo-image" href="${localizeLink(linkElem.href)}">
+          ${imageElem}
+        </a>`;
+    } else {
+      // TODO: is there really any use-case where a promo doesn't have a link?
+      promoImageElem = toFragment`<div class="feds-promo-image">
+          ${imageElem}
+        </div>`;
+    }
+
+    // If the promo is set to 'image-only',
+    // replace the whole promo content with the decorated image
+    if (isImageOnly) {
+      elem.replaceChildren(promoImageElem);
+    } else {
+    // Otherwise, just replace the image container with the decorated image
+      imageWrapper.replaceWith(promoImageElem);
+    }
+  };
+
+  // Wrap the image in an anchor tag
+  if (imageElem instanceof HTMLElement) {
+    decorateImage();
+  }
+
+  elem.classList = 'feds-promo';
+
+  if (isDarkTheme) {
+    elem.classList.add('feds-promo--dark');
+  }
+
+  return toFragment`<div class="feds-promo-wrapper">
+      ${elem}
+    </div>`;
+};
+
+// Decorate special elements from a popup
+const decoratePopupElement = (elem, index) => {
+  let decoratedElem;
+
+  // Decorate link group
+  if (elem.classList.contains('link-group')) {
+    decoratedElem = decorateLinkGroup(elem, index);
+  }
+
+  // Decorate Primary CTA
+  if (!elem.classList.contains('gnav-promo')
+   && elem.querySelector('strong > a')) {
+    decoratedElem = decorateCta({ elem, index });
+  }
+
+  // Decorate Secondary CTA
+  if (!elem.classList.contains('gnav-promo')
+   && elem.querySelector('em > a')) {
+    decoratedElem = decorateCta({ elem, type: 'secondaryCta', index });
+  }
+
+  return decoratedElem;
+};
+
+const decorateColumns = (content) => {
+  const hasMultipleColumns = content.children.length > 1;
+
+  // The resulting template structure should follow these rules:
+  // * a popup can have multiple columns;
+  // * a column can have multiple sections;
+  // * a section can have a headline and a collection of item(s)
+  Array.prototype.forEach.call(content.children, (column) => {
+    const wrapperClass = hasMultipleColumns ? 'feds-popup-column' : 'feds-popup-content';
+    const itemDestinationClass = hasMultipleColumns ? 'feds-popup-section' : 'feds-popup-column';
+    const wrapper = toFragment`<div class="${wrapperClass}"></div>`;
+    let itemDestination = toFragment`<div class="${itemDestinationClass}"></div>`;
+    let popupItems;
+    let currIndex = 0;
+
+    const resetDestination = () => {
+      // First, if the previous destination has children,
+      // append it to the wrapper
+      if (itemDestination.childElementCount) {
+        wrapper.append(itemDestination);
+        currIndex = 0;
+      }
+
+      // Create a new destination
+      itemDestination = toFragment`<div class="${itemDestinationClass}"></div>`;
+    };
+
+    while (column.children.length) {
+      const columnElem = column.firstElementChild;
+
+      if (columnElem.tagName === 'H5') {
+        // When encountering an h5, add the previous section to the column
+        resetDestination();
+
+        // Analysts requested no headings in the dropdowns,
+        // turning it into a simple div
+        const sectionHeadline = decorateHeadline(columnElem);
+        popupItems = toFragment`<div class="feds-popup-items"></div>`;
+        itemDestination.append(sectionHeadline, popupItems);
+      } else if (columnElem.classList.contains('gnav-promo')) {
+        // When encountering a promo, add the previous section to the column
+        resetDestination();
+
+        const promoElem = decoratePromo(columnElem);
+
+        itemDestination.append(promoElem);
+      } else {
+        currIndex += 1;
+        // Check whether the current element needs special decoration
+        const decoratedElem = decoratePopupElement(columnElem, currIndex);
+
+        // If element has been decorated, remove it
+        // from the initial list of column elements
+        if (decoratedElem) {
+          columnElem.remove();
+        }
+
+        // Leave lists and paragraphs intact, just add attributes to their links
+        if (columnElem && (columnElem.tagName === 'UL' || columnElem.tagName === 'P')) {
+          decorateLinkList({ list: columnElem });
+        }
+
+        // If an items template has been previously created,
+        // add the current element to it;
+        // otherwise append the element to the section
+        const elemDestination = popupItems || itemDestination;
+        elemDestination.append(decoratedElem || columnElem);
+      }
+    }
+
+    // Append the last column section to the column
+    wrapper.append(itemDestination);
+    // Replace column with parsed template
+    column.replaceWith(wrapper);
+  });
+};
+
+// Current limitation: after an h5 is found in a dropdown column,
+// no new sections can be created without a heading
 const decorateDropdown = async (config) => {
+  let popupTemplate;
+
   if (config.type === 'syncDropdownTrigger') {
     const itemTopParent = config.item.closest('div');
-    // The heading is already part of the item template,
+    // The initial heading is already part of the item template,
     // it can be safely removed
-    const headingElem = itemTopParent.querySelector('h2');
-    itemTopParent.removeChild(headingElem);
-    itemTopParent.classList.add('feds-popup');
+    const initialHeadingElem = itemTopParent.querySelector('h2');
+    itemTopParent.removeChild(initialHeadingElem);
 
-    Array.prototype.forEach.call(itemTopParent.children, (section) => {
-      // TODO: allow link groups in small dropdowns too?
-      section.querySelectorAll('a').forEach((link, index) => {
-        link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
-        link.classList.add('feds-navLink');
-      });
-    });
+    popupTemplate = toFragment`<div class="feds-popup">
+        ${itemTopParent}
+      </div>`;
 
-    config.template.append(itemTopParent);
+    decorateColumns(popupTemplate);
   }
 
   if (config.type === 'asyncDropdownTrigger') {
-    performance.mark('startAsyncDecoration');
     const pathElement = config.item.querySelector('a');
     if (!(pathElement instanceof HTMLElement)) return;
     const path = localizeLink(pathElement.href);
@@ -97,83 +260,17 @@ const decorateDropdown = async (config) => {
     const res = await fetch(`${path}.plain.html`);
     if (res.status !== 200) return;
     const content = await res.text();
-    const popupTemplate = toFragment`<div class="feds-popup">${content}</div>`;
+    popupTemplate = toFragment`<div class="feds-popup">
+        <div class="feds-popup-content">
+          ${content}
+        </div>
+      </div>`;
 
-    // The resulting template structure should follow these rules:
-    // * a popup can have multiple columns;
-    // * a column can have multiple sections;
-    // * a section can have a headline and a collection of item(s)
-    Array.prototype.forEach.call(popupTemplate.children, (column) => {
-      const columnTemplate = toFragment`<div class="feds-popup-column"></div>`;
-      let columnSection = toFragment`<div class="feds-popup-section"></div>`;
-      let sectionItems;
-      let currIndex = 0;
-
-      while (column.children.length) {
-        const columnElem = column.firstElementChild;
-
-        if (columnElem.tagName === 'H5') {
-          // When encountering an h5, add the previous section to the column
-          if (columnSection.childElementCount) {
-            columnTemplate.append(columnSection);
-            currIndex = 0;
-          }
-
-          // Analysts requested no headings in the dropdowns,
-          // turning it into a simple div
-          const sectionHeadline = decorateHeadline(columnElem);
-          sectionItems = toFragment`<div class="feds-popup-items"></div>`;
-          columnSection = toFragment`<div class="feds-popup-section">
-              ${sectionHeadline}
-              ${sectionItems}
-            </div>`;
-        } else {
-          currIndex += 1;
-          let decoratedElem;
-
-          // Decorate link group
-          if (columnElem.classList.contains('link-group')) {
-            // TODO: check if links with just images also work
-            decoratedElem = decorateLinkGroup(columnElem, currIndex);
-          }
-
-          // Decorate CTA
-          if (columnElem.querySelector('strong > a')) {
-            decoratedElem = decorateCta({ elem: columnElem, index: currIndex });
-          }
-
-          // If element has been decorated, remove it
-          // from the initial list of column elements
-          if (decoratedElem) {
-            columnElem.remove();
-          }
-
-          // Leave lists and paragraphs intact, just add attributes to their links
-          if (columnElem.tagName === 'UL' || columnElem.tagName === 'P') {
-            columnElem.querySelectorAll('a').forEach((link, index) => {
-              link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
-              link.classList.add('feds-navLink');
-            });
-          }
-
-          // If an items template has been previously created,
-          // add the current element to it;
-          // otherwise append the element to the section
-          const elemDestination = sectionItems || columnSection;
-          elemDestination.append(decoratedElem || columnElem);
-        }
-      }
-
-      // Append the last column section to the column
-      columnTemplate.append(columnSection);
-      // Replace column with parsed template
-      column.replaceWith(columnTemplate);
-    });
-
+    decorateColumns(popupTemplate.firstElementChild);
     config.template.classList.add('feds-navItem--megaMenu');
-    config.template.append(popupTemplate);
-    performance.mark('endAsyncDecoration');
   }
+
+  config.template.append(popupTemplate);
 };
 
 export default decorateDropdown;

--- a/libs/blocks/global-navigation/blocks/profile/profile.css
+++ b/libs/blocks/global-navigation/blocks/profile/profile.css
@@ -49,6 +49,7 @@
   display: flex;
   flex-direction: row;
   outline-offset: -3px;
+  column-gap: 15px;
 }
 
 .feds-profile-header .feds-profile-img {
@@ -57,13 +58,7 @@
 }
 
 .feds-profile-details {
-  margin-left: 16px;
   overflow: hidden;
-}
-
-[dir='rtl'] .feds-profile-details {
-  margin-left: 0;
-  margin-right: 16px;
 }
 
 .feds-profile-name {

--- a/libs/blocks/global-navigation/blocks/search/gnav-search.css
+++ b/libs/blocks/global-navigation/blocks/search/gnav-search.css
@@ -2,12 +2,15 @@
   display: none;
 }
 
+.feds-search-dropdown {
+  border-bottom: 1px solid var(--feds-color-border--light);
+  background-color: var(--feds-background-nav--light);
+}
+
 .feds-search-bar {
   padding: 20px 12px;
   display: flex;
   flex-direction: column;
-  background-color: var(--feds-background-nav--light);
-  /* TODO: add desktop top border */
 }
 
 .feds-search-field {
@@ -123,16 +126,25 @@
     display: flex;
   }
 
-  .feds-search-bar {
+  .feds-search-dropdown {
     position: absolute;
     top: 100%;
     left: 0;
     right: 0;
-    padding: 20px;
+    border-top: 1px solid var(--feds-color-border--light);
     display: none;
+    z-index: 1;
   }
 
-  .feds-search-trigger[aria-expanded = "true"] + .feds-search-bar {
+  .feds-search-bar {
+    width: 100%;
+    max-width: var(--feds-maxWidth-nav);
+    box-sizing: border-box;
+    padding: 20px 8px;
+  }
+
+  .feds-search-trigger[aria-expanded = "true"] + .feds-search-dropdown {
     display: flex;
+    justify-content: center;
   }
 }

--- a/libs/blocks/global-navigation/blocks/search/gnav-search.js
+++ b/libs/blocks/global-navigation/blocks/search/gnav-search.js
@@ -22,7 +22,7 @@ class Search {
   constructor(config) {
     this.icon = config.icon;
     this.trigger = config.trigger;
-    this.parent = config.parent;
+    this.parent = this.trigger.closest('.feds-nav-wrapper');
     this.curtain = config.curtain;
     this.isDesktop = window.matchMedia('(min-width: 900px)');
 
@@ -46,15 +46,17 @@ class Search {
     this.resultsList = toFragment`<ul class="feds-search-results" id="feds-search-results" role="region" daa-ll="search-results:suggested-search:click"></ul>`;
     this.clearButton = toFragment`<button tabindex="0" class="feds-search-clear" aria-label="${this.labels.clearResults}"></button>`;
     this.searchBar = toFragment`
-      <aside class="feds-search-bar">
-        <div class="feds-search-field">
-          ${this.input}
-          <div class="feds-search-icons">
-            ${this.icon}
-            ${this.clearButton}
+      <aside class="feds-search-dropdown">
+        <div class="feds-search-bar">
+          <div class="feds-search-field">
+            ${this.input}
+            <div class="feds-search-icons">
+              ${this.icon}
+              ${this.clearButton}
+            </div>
           </div>
+          ${this.resultsList}
         </div>
-        ${this.resultsList}
       </aside>`;
 
     this.trigger.after(this.searchBar);

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1,5 +1,6 @@
 :root {
   --feds-height-nav: 64px;
+  --feds-maxWidth-nav: 1440px;
   --feds-background-nav--light: #fff;
   --feds-color-border--light: #eaeaea;
   --feds-color-link--light: #2c2c2c;
@@ -55,15 +56,10 @@
   background-color: var(--feds-background-nav--light);
 }
 
-.global-navigation.has-breadcrumbs .feds-topnav-wrapper {
-  border-bottom: 1px solid var(--feds-color-border--light);
-}
-
 .feds-topnav {
-  position: relative;
   display: flex;
   width: 100%;
-  max-width: 1440px;
+  max-width: var(--feds-maxWidth-nav);
   height: inherit;
   justify-content: space-between;
 }
@@ -76,6 +72,7 @@
   display: none;
   flex-direction: column;
   height: 100vh;
+  border-top: 1px solid var(--feds-color-border--light);
   background-color: var(--feds-background-nav--light);
 }
 
@@ -99,6 +96,7 @@
   align-items: center;
   outline-offset: 2px;
   padding: 0 8px;
+  column-gap: 10px;
 }
 
 .feds-brand-image {
@@ -116,11 +114,6 @@
   font-weight: 700;
   font-size: 18px;
   color: var(--feds-color-adobeBrand);
-}
-
-.feds-brand-image + .feds-brand-label:before {
-  content: '';
-  margin-left: 10px;
 }
 
 /* Nav Links */
@@ -184,6 +177,11 @@
   padding-left: 32px;
 }
 
+[dir = "rtl"] .feds-navLink--hoverCaret:after {
+  right: unset;
+  left: 18px;
+}
+
 .feds-cta-wrapper {
   display: flex;
 }
@@ -222,6 +220,18 @@
   color: rgb(255, 255, 255);
 }
 
+.feds-cta--secondary {
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(75, 75, 75);
+  color: rgb(75, 75, 75);
+}
+
+.feds-cta--secondary:hover,
+.feds-cta--secondary:focus {
+  background-color: rgb(75, 75, 75);
+  color: rgb(255, 255, 255);
+}
+
 /* Search */
 .feds-search {
   order: -1;
@@ -247,11 +257,14 @@
 }
 
 /* Breadcrumbs */
-.feds-breadcrumbs {
+.feds-breadcrumbs-wrapper {
   display: flex;
+  order: -1;
+  border-bottom: 1px solid var(--feds-color-border--light);
+}
+
+.feds-breadcrumbs {
   padding: 0 12px;
-  order: -2;
-  border: 1px solid var(--feds-color-border--light);
   font-size: 12px;
 }
 
@@ -301,12 +314,17 @@
     padding-bottom: var(--feds-height-breadcrumbs);
   }
 
+  .feds-topnav-wrapper {
+    border-bottom: 1px solid var(--feds-color-border--light);
+  }
+
   .feds-nav-wrapper {
     position: static;
     display: flex;
     flex-direction: row;
     flex-grow: 1;
     height: unset;
+    border-bottom: unset;
     justify-content: space-between;
     background-color: transparent;
   }
@@ -328,10 +346,19 @@
     align-items: center;
   }
 
+  .feds-navItem--section {
+    border-left: 1px solid var(--feds-color-border--light);
+    border-right: 1px solid var(--feds-color-border--light);
+  }
+
   .feds-navLink,
   .feds-navLink--hoverCaret,
   [dir = "rtl"] .feds-navLink--hoverCaret {
     padding: 0 12px;
+  }
+
+  .feds-navItem--section > .feds-navLink {
+    padding: 0 20px;
   }
 
   .feds-navItem:not(:last-child) > .feds-navLink {
@@ -350,7 +377,8 @@
 
   [dir = "rtl"] .feds-navLink--hoverCaret:after {
     margin-left: 0;
-    margin-right: 5px;
+    /* Margin different than LTR due to transform origin effect */
+    margin-right: 7px;
   }
 
   /* Search */
@@ -391,13 +419,20 @@
   }
 
   /* Breadcrumbs */
-  .feds-breadcrumbs {
+  .feds-breadcrumbs-wrapper {
     position: absolute;
     top: 100%;
     left: 0;
     right: 0;
+    justify-content: center;
+    border-bottom: unset;
+  }
+
+  .feds-breadcrumbs {
     padding: 0 8px; /* TODO: more consistent approach to lateral spacing */
-    border: none;
+    width: 100%;
+    max-width: var(--feds-maxWidth-nav);
+    box-sizing: border-box;
   }
 
   .feds-breadcrumbs a:hover {
@@ -437,51 +472,9 @@ header.is-open button.gnav-toggle::after {
 }
 
 /* BEGIN MAINNAV */
-header .gnav-navitem {
-  font-size: 14px;
-  line-height: 1;
-  position: relative;
-}
-
-header .gnav-navitem a {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 18px 12px;
-  color: #4B4B4B;
-  transition: background-color .1s ease;
-}
-
-header .gnav-navitem > a {
-  border-bottom: solid 1px #EAEAEA;
-}
-
-header .gnav-navitem > a:hover {
-  background-color: #FAFAFA;
-}
-
-header .gnav-navitem.has-menu > a:after {
-  display: flex;
-  width: 5px;
-  height: 5px;
-  border-top-width: 0;
-  border-left-width: 0;
-  border-bottom-width: 1px;
-  border-right-width: 1px;
-  border-style: solid;
-  border-color: #2c2c2c;
-  transform-origin: 75% 75%;
-  transform: rotate(45deg);
-  transition: transform .1s ease;
-  content: '';
-  margin-left: 5px;
-  margin-right: 3px;
-}
-
 .last-link-blue ul li:last-of-type a {
   color: #1473E6;
 }
-
 /* END MAINNAV */
 
 /* APP LAUNCHER */
@@ -512,17 +505,7 @@ header .app-launcher {
 /* END APP LAUNCHER */
 
 @media (min-width: 900px) {
-  header .gnav-navitem {
-    display: flex;
-  }
-
-  header .gnav-navitem.section-menu {
-    border-left: 1px solid #EBEBEB;
-    border-right: 1px solid #EBEBEB;
-  }
-
   /* APP LAUNCHER */
-
   header .app-launcher {
     box-sizing: border-box;
     display: flex;
@@ -565,20 +548,6 @@ header .app-launcher {
   }
 
   /* END APP LAUNCHER */
-
-  header .gnav-navitem > a {
-    border-bottom: none;
-    padding: 0 12px;
-  }
-
-  header .gnav-navitem.section-menu > a {
-    padding: 20px;
-  }
-
-  header .gnav-navitem.section-menu + .gnav-navitem > a {
-    padding-left: 20px;
-  }
-
   header button.gnav-toggle {
     display: none;
   }

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -65,12 +65,14 @@ export function getAnalyticsValue(str, index) {
   return analyticsValue;
 }
 
-export function decorateCta({ elem, type = 'primary', index } = {}) {
+export function decorateCta({ elem, type = 'primaryCta', index } = {}) {
+  const modifier = type === 'secondaryCta' ? 'secondary' : 'primary';
+
   return toFragment`
     <div class="feds-cta-wrapper">
       <a 
         href="${localizeLink(elem.href)}"
-        class="feds-cta feds-cta--${type}"
+        class="feds-cta feds-cta--${modifier}"
         daa-ll="${getAnalyticsValue(elem.textContent, index)}">
           ${elem.textContent}
       </a>


### PR DESCRIPTION
This PR adds logic and styles for a few new features and updates:
- support for promos, including a dark theme;
- consistent styling for RTL locales;
- support for secondary CTAs;
- expand mega menu, search and breadcrumbs to the full width of the page when their dropdown is open;
- allow mixed content in non-mega menu dropdowns, we can now add link groups, CTAs and have multiple columns with headings;
- ensure dropdown menus are loaded ASAP after a menu item has been clicked;
- ensure correct focus order across devices for the main navigation, the Search section and the Breadcrumbs section.

Resolves: [MWPW-117906](https://jira.corp.adobe.com/browse/MWPW-117906)

**Test URLs:**
- Before: https://feds-gnav--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
- After: https://mwpw-117906-localnav-and-dropdowns--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
