### PR TITLE
Make split marquees fully modularized

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -106,7 +106,7 @@
 }
 
 .marquee.split.has-credit {
-  margin-bottom: var(--spacing-m);
+  margin-bottom: var(--spacing-l);
 }
 
 .marquee.split .media-credit {
@@ -503,10 +503,6 @@
 
   .marquee.split.large p.action-area:last-of-type {
     margin-bottom: 0;
-  }
-
-  .marquee.split.has-credit {
-    margin-bottom: unset;
   }
 
   .marquee.split .text .icon-area img {


### PR DESCRIPTION
Currently, split-variant marquees require some extra spacing token (e.g. in the form of section metadata) if it contains a media credit for the credit to be guaranteed visible on desktop. This shouldn't be how it works -- authors should be able to just drop this block in anywhere and not have to think about extra steps required to make it behave as expected.

This PR updates the spacing token for split marquees that have media credits, allowing it to be more modularized.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/marquee-split?martech=off
- After: https://ebartholomew-fix-media-credits--milo--adobecom.hlx.page/docs/library/kitchen-sink/marquee-split?martech=off
