### PR TITLE
Updating milo to point to new location where CaaS files will be hosted

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -69,8 +69,8 @@ export const loadCaasFiles = async () => {
   const version = new URL(document.location.href)?.searchParams?.get('caasver') || 'stable';
 
   loadStyle(`https://www.adobe.com/special/chimera/caas-libs/${version}/app.css`);
-  await loadScript(`https://www.adobe.com/special/chimera/${version}/dist/dexter/react.umd.js`);
-  await loadScript(`https://www.adobe.com/special/chimera/${version}/dist/dexter/react.dom.umd.js`);
+  await loadScript(`https://www.adobe.com/special/chimera/caas-libs/${version}/react.umd.js`);
+  await loadScript(`https://www.adobe.com/special/chimera/caas-libs/${version}/react.dom.umd.js`);
   await loadScript(`https://www.adobe.com/special/chimera/caas-libs/${version}/main.min.js`);
 };
 

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -66,12 +66,12 @@ export const loadStrings = async (
 };
 
 export const loadCaasFiles = async () => {
-  const version = new URL(document.location.href)?.searchParams?.get('caasver') || 'latest';
+  const version = new URL(document.location.href)?.searchParams?.get('caasver') || 'stable';
 
-  loadStyle(`https://www.adobe.com/special/chimera/${version}/dist/dexter/app.min.css`);
+  loadStyle(`https://www.adobe.com/special/chimera/caas-libs/${version}/app.css`);
   await loadScript(`https://www.adobe.com/special/chimera/${version}/dist/dexter/react.umd.js`);
   await loadScript(`https://www.adobe.com/special/chimera/${version}/dist/dexter/react.dom.umd.js`);
-  await loadScript(`https://www.adobe.com/special/chimera/${version}/dist/dexter/app.min.js`);
+  await loadScript(`https://www.adobe.com/special/chimera/caas-libs/${version}/main.min.js`);
 };
 
 export const loadCaasTags = async (tagsUrl) => {


### PR DESCRIPTION
We have moved the location of where CaaS files are located on adobe.com's docroot. 

This PR is needed since this new location has all the latest CaaS code and Milo has been out of sync w/ new CaaS feature development for a couple of weeks at this point.

Resolves: MWPW-128300

**Test URLs:**
**Before:** 
https://main--milo--adobecom.hlx.page/tools/caas

**After:** 
For 0.6.2, CaaS released a breaking change, which can be reflected here (component doesn't load in milo):
- https://mwpw-128300--milo--adobecom.hlx.page/tools/caas?caasver=0.6.2

For 0.6.3, we fixed this breaking change and put that code in stable so milo will just skip caas release 0.6.2
- https://mwpw-128300--milo--adobecom.hlx.page/tools/caas?caasver=0.6.3
- https://mwpw-128300--milo--adobecom.hlx.page/tools/caas

Validating fix for consumer pages:
https://main--bacom--adobecom.hlx.page/customer-success-stories?milolibs=MWPW-128300
https://main--bacom--adobecom.hlx.page/customer-success-stories/ben-and-jerrys-case-study?milolibs=MWPW-128300