### PR TITLE
Add closing section marks for section-metadata in block library

### DIFF
--- a/libs/blocks/library-config/lists/blocks.js
+++ b/libs/blocks/library-config/lists/blocks.js
@@ -110,7 +110,9 @@ export default async function loadBlocks(blocks, list, query) {
       name.textContent = getAuthorName(pageBlock) || getBlockName(pageBlock);
       const copy = document.createElement('button');
       copy.addEventListener('click', (e) => {
-        const table = getTable(pageBlock, getBlockName(pageBlock), block.path);
+        const table = pageBlock.className === 'section-metadata'
+          ? `${getTable(pageBlock, getBlockName(pageBlock), block.path)} ---`
+          : getTable(pageBlock, getBlockName(pageBlock), block.path);
         e.target.classList.add('copied');
         setTimeout(() => { e.target.classList.remove('copied'); }, 3000);
         const blob = new Blob([table], { type: 'text/html' });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Minor update for copying the `section-metadata` block from the block library.
* Adds closing section markers (`---`) after the `section-metadata` block.
* Only adds section marker for `section-metadata blocks`. No other blocks are affected.

This is an effort to help authors author sections better in Milo and create a standard to always put the `section-metadata` block as the last element in the section.

![image](https://user-images.githubusercontent.com/2539954/226736538-0b59d673-527f-41ce-afae-b82d2b8de22b.png)


Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

### Test URLs:
- Before: https://main--milo--adobecom.hlx.page/tools/library?martech=off
- After: https://block-section-metadata--milo--adobecom.hlx.page/tools/library?martech=off

### Testing:
Add /tree/block-section-metadata to the milo repo name...
<img width="574" alt="image" src="https://user-images.githubusercontent.com/2539954/226740488-c2e95643-91ad-4829-b8d0-c38b8de61215.png">


After updating the sidekick with the details outlined above:
* Open a Word doc in the Milo folder
* Launch the library
* Click on "blocks"
* Drill down to any of the `section-metadata` blocks. 
* Click the copy icon
* Paste in your Word doc
* It should have the closing section characters (`---`) after the block.