### PR TITLE
MWPW-128614 - [Core] breadcrumbs should be disabled by default

### DIFF
--- a/libs/blocks/gnav/gnav-breadcrumbs.js
+++ b/libs/blocks/gnav/gnav-breadcrumbs.js
@@ -1,4 +1,4 @@
-import { createTag, getMetadata } from '../../utils/utils.js';
+import { createTag, getConfig, getMetadata } from '../../utils/utils.js';
 
 const BREADCRUMBS_HIDE_LAST = 'breadcrumbs-hide-last';
 
@@ -141,11 +141,28 @@ function setBreadcrumbSEO(breadcrumbs) {
 }
 
 async function getBreadcrumbs(element) {
-  if (!element || getMetadata('breadcrumbs') === 'off') return null;
-  return getBreadcrumbsFromPageBlock(element)
-    || await getBreadcrumbsFromFile()
-    || await getBreadcrumbsFromUrl(document.location.pathname)
-    || null;
+  if (!element) return null;
+  const breadcrumbs = getBreadcrumbsFromPageBlock(element);
+  if (breadcrumbs) return breadcrumbs;
+  const breadcrumbsMetadata = getMetadata('breadcrumbs')?.toLowerCase();
+  if (breadcrumbsMetadata === 'on' || breadcrumbsMetadata === 'true') {
+    return await getBreadcrumbsFromFile()
+      || await getBreadcrumbsFromUrl(document.location.pathname)
+      || null;
+  }
+  if (breadcrumbsMetadata === 'off' || breadcrumbsMetadata === 'false') {
+    return null;
+  }
+  const breadcrumbsConf = getConfig().breadcrumbs;
+  if (breadcrumbsConf === 'on' || breadcrumbsConf === 'true') {
+    return await getBreadcrumbsFromFile()
+      || await getBreadcrumbsFromUrl(document.location.pathname)
+      || null;
+  }
+  if (breadcrumbsConf === 'off' || breadcrumbsConf === 'false') {
+    return null;
+  }
+  return null;
 }
 
 export default async function addBreadcrumbs(element, wrapper) {

--- a/libs/blocks/gnav/gnav-breadcrumbs.js
+++ b/libs/blocks/gnav/gnav-breadcrumbs.js
@@ -159,9 +159,6 @@ async function getBreadcrumbs(element) {
       || await getBreadcrumbsFromUrl(document.location.pathname)
       || null;
   }
-  if (breadcrumbsConf === 'off' || breadcrumbsConf === 'false') {
-    return null;
-  }
   return null;
 }
 

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -115,7 +115,6 @@ const config = {
   marketoBaseURL: '//app-aba.marketo.com',
   marketoFormID: '1761',
   marketoMunchkinID: '345-TTI-184',
-  breadcrumbs: 'off',
 };
 
 (async function loadLCPImage() {

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -115,6 +115,7 @@ const config = {
   marketoBaseURL: '//app-aba.marketo.com',
   marketoFormID: '1761',
   marketoMunchkinID: '345-TTI-184',
+  breadcrumbs: 'off',
 };
 
 (async function loadLCPImage() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3399,9 +3399,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001406",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
-      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
+      "version": "1.0.30001469",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
+      "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
       "dev": true,
       "funding": [
         {
@@ -13297,9 +13297,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001406",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001406.tgz",
-      "integrity": "sha512-bWTlaXUy/rq0BBtYShc/jArYfBPjEV95euvZ8JVtO43oQExEN/WquoqpufFjNu4kSpi5cy5kMbNvzztWDfv1Jg==",
+      "version": "1.0.30001469",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
+      "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
       "dev": true
     },
     "chai": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/adobecom/milo#readme",
   "dependencies": {
+    "@preact/signals": "1.0.4",
     "htm": "^3.1.1",
-    "preact": "^10.11.0",
-    "@preact/signals": "1.0.4"
+    "preact": "^10.11.0"
   },
   "devDependencies": {
     "@babel/core": "7.17.7",

--- a/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-off/level1/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-off/level1/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level1 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-off/level1/level2/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-off/level1/level2/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level2 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-off/level1/level2/level3/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-off/level1/level2/level3/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level3 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-off/level1/level2/level3/page.test.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-off/level1/level2/level3/page.test.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <meta name="breadcrumbs" content="off">
     <meta name="gnav-source" content="/test/blocks/gnav/mocks/gnav">
     <link rel="stylesheet" href="/libs/blocks/gnav/gnav.css">
 </head>
@@ -12,8 +13,10 @@
             <h1 id="welcome-to-the-gnav-test">Welcome to the Gnav/Breadcrumbs Test</h1>
             <div id="wrong" class="gnav" data-block-name="gnav" data-gnav-source="/test/blocks/gnav/mocks/wrong-gnav"></div>
             <div style="height: 1000px">
-                - no breadcrumbs block defined for this page.<br/>
-                - a breadscrumbs file is defined in the same folder as this page
+                - no breadcrumbs block defined for this page<br/>
+                - config.breadcrumbs = off <br/>
+                - breadcrumbs metadata = off <br/>
+                -> no breadcrumbs
             </div>
         </div>
     </div>
@@ -22,25 +25,20 @@
 <script type="module">
   import { runTests } from '@web/test-runner-mocha';
   import { expect } from '@esm-bundle/chai';
-  import { delay } from '../../../../../helpers/waitfor.js';
-  import gnav from '../../../../../../libs/blocks/gnav/gnav.js';
-  import getItems from '../utils.js';
-  import { setConfig } from '../../../../../../libs/utils/utils.js';
+  import { delay } from '../../../../../../../../helpers/waitfor.js';
+  import gnav from '../../../../../../../../../libs/blocks/gnav/gnav.js';
+  import getItems from '../../../../utils.js';
+  import { setConfig } from '../../../../../../../../../libs/utils/utils.js';
 
   runTests(() => {
-    const config = { breadcrumbs: 'on', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+    const config = { breadcrumbs: 'off', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
     setConfig(config);
 
     describe('breadcrumbs', () => {
-      it('breadcrumbs defined in the breadcrumbs file in the same folder', async () => {
+      it('config.breadcrumbs = off and breadcrumbs metadata = off', async () => {
         await gnav(document.querySelector('header'));
         await delay(300);
-        const expected = [
-          {href: 'http://www.google.com/', title: 'from-file'},
-          {href: 'http://www.adobe.com/', title: 'Actors'},
-          {href: 'http://www.day.com/', title: 'Players'},
-          {href: '', title: 'page.test.html'},
-        ];
+        const expected = [];
         expect(getItems()).to.eql(expected);
       });
     });

--- a/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level1 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/level2/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/level2/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level2 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/level2/level3/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/level2/level3/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level3 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/level2/level3/page.test.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/level2/level3/page.test.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="breadcrumbs-hide-last" content="on">
+    <meta name="breadcrumbs" content="on">
     <meta name="gnav-source" content="/test/blocks/gnav/mocks/gnav">
     <link rel="stylesheet" href="/libs/blocks/gnav/gnav.css">
 </head>
@@ -13,7 +13,10 @@
             <h1 id="welcome-to-the-gnav-test">Welcome to the Gnav/Breadcrumbs Test</h1>
             <div id="wrong" class="gnav" data-block-name="gnav" data-gnav-source="/test/blocks/gnav/mocks/wrong-gnav"></div>
             <div style="height: 1000px">
-                - last breadcrumbs item is hidden
+                - no breadcrumbs block defined for this page<br/>
+                - config.breadcrumbs = off <br/>
+                - breadcrumbs metadata = on <br/>
+                -> breadcrumbs is rendered
             </div>
         </div>
     </div>
@@ -22,17 +25,17 @@
 <script type="module">
   import { runTests } from '@web/test-runner-mocha';
   import { expect } from '@esm-bundle/chai';
-  import { delay } from '../../../../../helpers/waitfor.js';
-  import gnav from '../../../../../../libs/blocks/gnav/gnav.js';
-  import getItems from '../utils.js';
-  import { setConfig } from '../../../../../../libs/utils/utils.js';
+  import { delay } from '../../../../../../../../helpers/waitfor.js';
+  import gnav from '../../../../../../../../../libs/blocks/gnav/gnav.js';
+  import getItems from '../../../../utils.js';
+  import { setConfig } from '../../../../../../../../../libs/utils/utils.js';
 
   runTests(() => {
-    const config = { breadcrumbs: 'on', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+    const config = { breadcrumbs: 'off', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
     setConfig(config);
 
     describe('breadcrumbs', () => {
-      it('last breadcrumbs item is hidden', async () => {
+      it('breadcrumbs automatically generated from the URL', async () => {
         await gnav(document.querySelector('header'));
         await delay(300);
         const expected = [
@@ -42,8 +45,11 @@
           {href: '/test/blocks/gnav', title: 'gnav'},
           {href: '/test/blocks/gnav/mocks', title: 'mocks'},
           {href: '/test/blocks/gnav/mocks/breadcrumbs', title: 'breadcrumbs'},
-          {href: '/test/blocks/gnav/mocks/breadcrumbs/hide-last', title: 'hide-last'},
-          {href: '', title: ''},
+          {href: '/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on', title: 'config-off-metadata-on'},
+          {href: '/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1', title: 'level1 title'},
+          {href: '/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/level2', title: 'level2 title'},
+          {href: '/test/blocks/gnav/mocks/breadcrumbs/config-off-metadata-on/level1/level2/level3', title: 'level3 title'},
+          {href: '', title: 'page.test.html'},
         ];
         expect(getItems()).to.eql(expected);
       });

--- a/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-off/level1/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-off/level1/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level1 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-off/level1/level2/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-off/level1/level2/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level2 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-off/level1/level2/level3/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-off/level1/level2/level3/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level3 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-off/level1/level2/level3/page.test.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-off/level1/level2/level3/page.test.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+    <meta name="breadcrumbs" content="off">
     <meta name="gnav-source" content="/test/blocks/gnav/mocks/gnav">
     <link rel="stylesheet" href="/libs/blocks/gnav/gnav.css">
 </head>
@@ -12,8 +13,10 @@
             <h1 id="welcome-to-the-gnav-test">Welcome to the Gnav/Breadcrumbs Test</h1>
             <div id="wrong" class="gnav" data-block-name="gnav" data-gnav-source="/test/blocks/gnav/mocks/wrong-gnav"></div>
             <div style="height: 1000px">
-                - no breadcrumbs block defined for this page.<br/>
-                - a breadscrumbs file is defined in the same folder as this page
+                - no breadcrumbs block defined for this page<br/>
+                - config.breadcrumbs = on <br/>
+                - breadcrumbs metadata = off <br/>
+                -> no breadcrumbs
             </div>
         </div>
     </div>
@@ -22,25 +25,20 @@
 <script type="module">
   import { runTests } from '@web/test-runner-mocha';
   import { expect } from '@esm-bundle/chai';
-  import { delay } from '../../../../../helpers/waitfor.js';
-  import gnav from '../../../../../../libs/blocks/gnav/gnav.js';
-  import getItems from '../utils.js';
-  import { setConfig } from '../../../../../../libs/utils/utils.js';
+  import { delay } from '../../../../../../../../helpers/waitfor.js';
+  import gnav from '../../../../../../../../../libs/blocks/gnav/gnav.js';
+  import getItems from '../../../../utils.js';
+  import { setConfig } from '../../../../../../../../../libs/utils/utils.js';
 
   runTests(() => {
     const config = { breadcrumbs: 'on', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
     setConfig(config);
 
     describe('breadcrumbs', () => {
-      it('breadcrumbs defined in the breadcrumbs file in the same folder', async () => {
+      it('config.breadcrumbs = on && breadcrumbs metadata = off', async () => {
         await gnav(document.querySelector('header'));
         await delay(300);
-        const expected = [
-          {href: 'http://www.google.com/', title: 'from-file'},
-          {href: 'http://www.adobe.com/', title: 'Actors'},
-          {href: 'http://www.day.com/', title: 'Players'},
-          {href: '', title: 'page.test.html'},
-        ];
+        const expected = [];
         expect(getItems()).to.eql(expected);
       });
     });

--- a/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level1 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/level2/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/level2/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level2 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/level2/level3/index.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/level2/level3/index.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <title>level3 title</title>
+</head>
+</html>

--- a/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/level2/level3/page.test.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/level2/level3/page.test.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <meta name="breadcrumbs-hide-last" content="on">
+    <meta name="breadcrumbs" content="on">
     <meta name="gnav-source" content="/test/blocks/gnav/mocks/gnav">
     <link rel="stylesheet" href="/libs/blocks/gnav/gnav.css">
 </head>
@@ -13,7 +13,10 @@
             <h1 id="welcome-to-the-gnav-test">Welcome to the Gnav/Breadcrumbs Test</h1>
             <div id="wrong" class="gnav" data-block-name="gnav" data-gnav-source="/test/blocks/gnav/mocks/wrong-gnav"></div>
             <div style="height: 1000px">
-                - last breadcrumbs item is hidden
+                - no breadcrumbs block defined for this page<br/>
+                - config.breadcrumbs = on <br/>
+                - breadcrumbs metadata = on <br/>
+                -> breadcrumbs is rendered
             </div>
         </div>
     </div>
@@ -22,17 +25,17 @@
 <script type="module">
   import { runTests } from '@web/test-runner-mocha';
   import { expect } from '@esm-bundle/chai';
-  import { delay } from '../../../../../helpers/waitfor.js';
-  import gnav from '../../../../../../libs/blocks/gnav/gnav.js';
-  import getItems from '../utils.js';
-  import { setConfig } from '../../../../../../libs/utils/utils.js';
+  import { delay } from '../../../../../../../../helpers/waitfor.js';
+  import gnav from '../../../../../../../../../libs/blocks/gnav/gnav.js';
+  import getItems from '../../../../utils.js';
+  import { setConfig } from '../../../../../../../../../libs/utils/utils.js';
 
   runTests(() => {
     const config = { breadcrumbs: 'on', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
     setConfig(config);
 
     describe('breadcrumbs', () => {
-      it('last breadcrumbs item is hidden', async () => {
+      it('breadcrumbs automatically generated from the URL', async () => {
         await gnav(document.querySelector('header'));
         await delay(300);
         const expected = [
@@ -42,8 +45,11 @@
           {href: '/test/blocks/gnav', title: 'gnav'},
           {href: '/test/blocks/gnav/mocks', title: 'mocks'},
           {href: '/test/blocks/gnav/mocks/breadcrumbs', title: 'breadcrumbs'},
-          {href: '/test/blocks/gnav/mocks/breadcrumbs/hide-last', title: 'hide-last'},
-          {href: '', title: ''},
+          {href: '/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on', title: 'config-on-metadata-on'},
+          {href: '/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1', title: 'level1 title'},
+          {href: '/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/level2', title: 'level2 title'},
+          {href: '/test/blocks/gnav/mocks/breadcrumbs/config-on-metadata-on/level1/level2/level3', title: 'level3 title'},
+          {href: '', title: 'page.test.html'},
         ];
         expect(getItems()).to.eql(expected);
       });

--- a/test/blocks/gnav/mocks/breadcrumbs/from-ancestor-file/level1/level2/level3/page.test.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/from-ancestor-file/level1/level2/level3/page.test.html
@@ -28,7 +28,7 @@
   import { setConfig } from '../../../../../../../../../libs/utils/utils.js';
 
   runTests(() => {
-    const config = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+    const config = { breadcrumbs: 'on', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
     setConfig(config);
 
     describe('breadcrumbs', () => {

--- a/test/blocks/gnav/mocks/breadcrumbs/from-url/level1/level2/level3/page.test.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/from-url/level1/level2/level3/page.test.html
@@ -29,7 +29,7 @@
   import { setConfig } from '../../../../../../../../../libs/utils/utils.js';
 
   runTests(() => {
-    const config = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+    const config = { breadcrumbs: 'on', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
     setConfig(config);
 
     describe('breadcrumbs', () => {

--- a/test/blocks/gnav/mocks/breadcrumbs/hide-page/level1/level2/level3/page.test.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/hide-page/level1/level2/level3/page.test.html
@@ -30,7 +30,7 @@
   import { setConfig } from '../../../../../../../../../libs/utils/utils.js';
 
   runTests(() => {
-    const config = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+    const config = { breadcrumbs: 'on', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
     setConfig(config);
 
     describe('breadcrumbs', () => {

--- a/test/blocks/gnav/mocks/breadcrumbs/specific-title/page.test.html
+++ b/test/blocks/gnav/mocks/breadcrumbs/specific-title/page.test.html
@@ -28,7 +28,7 @@
   import { setConfig } from '../../../../../../libs/utils/utils.js';
 
   runTests(() => {
-    const config = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+    const config = { breadcrumbs: 'on', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
     setConfig(config);
 
     describe('breadcrumbs', () => {


### PR DESCRIPTION
- makes the automatic generation of the breadcrumb block (when a breadcrumb is not defined on the page) disabled by default.
- adds tests

The logic is as follows:
1) the page has a breadcrumbs block
-> render it
2) metadata.breadcrumbs = on
-> render the automated breadcrumbs (from file if any, otherwise from URL)
3) metadata.breadcrumbs = off
-> no breadcrumbs
4) config.breadcrumbs = on
-> render the automated breadcrumbs (from file if any, otherwise from URL)
5) config.breadcrumbs = off or undefined
-> no breadcrumbs

Resolves: 
[MWPW-128614](https://jira.corp.adobe.com/browse/MWPW-128614)

**Test URLs: the breadcrumbs block is defined in the current page:**
- Before: https://main--milo--adobecom.hlx.page/drafts/jck/breadcrumbs/1-from-page/test?martech=off
- After: https://breadcrumbs-disabled--milo--adobecom.hlx.page/drafts/jck/breadcrumbs/1-from-page/test?martech=off

