### PR TITLE
MWPW-128369: Supports floodgating excel files

### DIFF
--- a/tools/floodgate/js/project.js
+++ b/tools/floodgate/js/project.js
@@ -1,16 +1,14 @@
 import { getConfig } from './config.js';
 import {
   getUrlInfo,
-  getDocPathFromUrl,
   fetchProjectFile,
 } from '../../loc/utils.js';
 import {
   getProjectFileStatus,
   getHelixAdminApiUrl,
-  readProjectFile,
 } from '../../loc/project.js';
 import { getSpFiles } from '../../loc/sharepoint.js';
-import { getFloodgateUrl } from './utils.js';
+import { getFloodgateUrl, handleExtension } from './utils.js';
 
 let project;
 
@@ -56,6 +54,15 @@ async function updateProjectWithDocs(projectDetail) {
   injectSharepointData(projectDetail.urls, filePaths, docPaths, fgSpBatchFiles, true);
 }
 
+async function readProjectFile(projectWebUrl) {
+  const resp = await fetch(projectWebUrl, { cache: 'no-store' });
+  const json = await resp.json();
+  if (json && json?.filepaths?.data) {
+    return json;
+  }
+  return undefined;
+}
+
 async function initProject() {
   if (project) return project;
   const config = await getConfig();
@@ -96,18 +103,18 @@ async function initProject() {
         return {};
       }
 
-      const urlsData = projectFileJson.urls.data;
+      const filesData = projectFileJson.filepaths.data;
       const urls = new Map();
       const filePaths = new Map();
-      urlsData.forEach((urlRow) => {
-        const url = urlRow.URL;
-        const docPath = getDocPathFromUrl(url);
-        urls.set(url, { doc: { filePath: docPath, url, fg: { url: getFloodgateUrl(url) } } });
+      filesData.forEach((filePathRow) => {
+        const filePath = filePathRow.FilePath;
+        const url = `${urlInfo.origin}${handleExtension(filePath)}`;
+        urls.set(url, { doc: { filePath, url, fg: { url: getFloodgateUrl(url) } } });
         // Add urls data to filePaths map
-        if (filePaths.has(docPath)) {
-          filePaths.get(docPath).push(url);
+        if (filePaths.has(filePath)) {
+          filePaths.get(filePath).push(url);
         } else {
-          filePaths.set(docPath, [url]);
+          filePaths.set(filePath, [url]);
         }
       });
 

--- a/tools/floodgate/js/project.js
+++ b/tools/floodgate/js/project.js
@@ -57,7 +57,7 @@ async function updateProjectWithDocs(projectDetail) {
 async function readProjectFile(projectWebUrl) {
   const resp = await fetch(projectWebUrl, { cache: 'no-store' });
   const json = await resp.json();
-  if (json && json?.filepaths?.data) {
+  if (json?.filepaths?.data) {
     return json;
   }
   return undefined;


### PR DESCRIPTION
* Adds supports for floodgating excel files 
* Project excel documents now expects paths instead of URLs

Resolves: [MWPW-128369](https://jira.corp.adobe.com/browse/MWPW-128369)

Sample FG project excel:
- [Before](https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B4EBD6F30-D51F-419B-BD0A-7485D4081302%7D&file=sample_fg_project.xlsx&action=default&mobileredirect=true) 
- [After](https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BDD97EC98-F756-4F8D-9F4F-8956523D5456%7D&file=fg_with_paths.xlsx&action=default&mobileredirect=true)

**Test URLs:**
- Before: [https://main--milo--adobecom.hlx.page/tools/floodgate/index.html](https://main--milo--adobecom.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B4EBD6F30-D51F-419B-BD0A-7485D4081302%257D%26file%3Dsample_fg_project.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue)

- After: [https://fg-with-paths--milo--sukamat.hlx.page/tools/floodgate/index.html](https://fg-with-paths--milo--sukamat.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257BDD97EC98-F756-4F8D-9F4F-8956523D5456%257D%26file%3Dfg_with_paths.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue)
