### PR TITLE
MWPW-126981 Fix georouting modal scroll

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -78,7 +78,8 @@ export async function getModal(details, custom) {
   if (details) await getPathModal(details.path, dialog);
 
   const close = createTag('button', { class: 'dialog-close', 'aria-label': 'Close' }, CLOSE_ICON);
-
+ 
+  const focusVisible = { focusVisible: true };
   const focusablesOnLoad = [...dialog.querySelectorAll(FOCUSABLES)];
   const titleOnLoad = dialog.querySelector('h1, h2, h3, h4, h5');
   let firstFocusable;
@@ -99,12 +100,12 @@ export async function getModal(details, custom) {
 
     if (!isShiftKey && isTab && isCloseActive) {
       event.preventDefault();
-      firstFocusable.focus({ focusVisible: true });
+      firstFocusable.focus(focusVisible);
     }
 
     if (isTab && isShiftKey && document.activeElement === firstFocusable) {
       event.preventDefault();
-      close.focus({ focusVisible: true });
+      close.focus(focusVisible);
     }
   });
 
@@ -121,7 +122,7 @@ export async function getModal(details, custom) {
 
   dialog.append(close);
   document.body.append(dialog);
-  firstFocusable.focus({ preventScroll: true, focusVisible: true });
+  firstFocusable.focus({ preventScroll: true, ...focusVisible });
   window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -78,7 +78,7 @@ export async function getModal(details, custom) {
   if (details) await getPathModal(details.path, dialog);
 
   const close = createTag('button', { class: 'dialog-close', 'aria-label': 'Close' }, CLOSE_ICON);
- 
+
   const focusVisible = { focusVisible: true };
   const focusablesOnLoad = [...dialog.querySelectorAll(FOCUSABLES)];
   const titleOnLoad = dialog.querySelector('h1, h2, h3, h4, h5');

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -79,7 +79,6 @@ export async function getModal(details, custom) {
 
   const close = createTag('button', { class: 'dialog-close', 'aria-label': 'Close' }, CLOSE_ICON);
 
-  const focusVisible = { focusVisible: true };
   const focusablesOnLoad = [...dialog.querySelectorAll(FOCUSABLES)];
   const titleOnLoad = dialog.querySelector('h1, h2, h3, h4, h5');
   let firstFocusable;
@@ -100,12 +99,12 @@ export async function getModal(details, custom) {
 
     if (!isShiftKey && isTab && isCloseActive) {
       event.preventDefault();
-      firstFocusable.focus(focusVisible);
+      firstFocusable.focus({ focusVisible: true });
     }
 
     if (isTab && isShiftKey && document.activeElement === firstFocusable) {
       event.preventDefault();
-      close.focus(focusVisible);
+      close.focus({ focusVisible: true });
     }
   });
 
@@ -122,7 +121,7 @@ export async function getModal(details, custom) {
 
   dialog.append(close);
   document.body.append(dialog);
-  firstFocusable.focus(focusVisible);
+  firstFocusable.focus({ preventScroll: true, focusVisible: true });
   window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {


### PR DESCRIPTION
* Fix bug where page body scrolls to bottom when georouting modal is present

Resolves: [MWPW-126981](https://jira.corp.adobe.com/browse/MWPW-126981)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/de/drafts/methomas/georouting?martech=off
- After: https://methomas-georouting-jump--milo--adobecom.hlx.page/de/drafts/methomas/georouting?martech=off

BACOM:
- Before: https://main--bacom--adobecom.hlx.page/jp/customer-success-stories?martech=off
- After: https://main--bacom--adobecom.hlx.page/jp/customer-success-stories?martech=off&milolibs=methomas-georouting-jump

Note: Only saw this happen on Chrome >= 106. To get georouting modal to pop up, open an incognito browser, go to US page first, then go to jp (or other geo).
