### PR TITLE
MWPW-128724 Clickable marquee image

### DIFF
--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -75,6 +75,18 @@ function extendButtonsClass(text) {
   buttons.forEach((button) => { button.classList.add('button-justified-mobile') });
 }
 
+const decorateImage = (media) => {
+  media.classList.add('image');
+
+  const imageLink = media.querySelector('a');
+  const picture = media.querySelector('picture');
+
+  if (imageLink && picture) {
+    imageLink.textContent = '';
+    imageLink.append(picture);
+  }
+};
+
 export default function init(el) {
   decorateBlockAnalytics(el);
   const isLight = el.classList.contains('light');
@@ -90,12 +102,15 @@ export default function init(el) {
   const text = headline.closest('div');
   text.classList.add('text');
   const media = foreground.querySelector(':scope > div:not([class])');
-  media?.classList.add('media');
 
-  if (media?.querySelector('a[href$=".mp4"]')) {
-    decorateVideo(media);
-  } else {
-    media?.classList.add('image');
+  if (media) {
+    media.classList.add('media');
+
+    if (media.querySelector('a[href$=".mp4"]')) {
+      decorateVideo(media);
+    } else {
+      decorateImage(media);
+    }
   }
 
   const firstDivInForeground = foreground.querySelector(':scope > div');

--- a/test/blocks/marquee/marquee.test.js
+++ b/test/blocks/marquee/marquee.test.js
@@ -29,6 +29,10 @@ describe('marquee', () => {
       const iconArea = marquees[1].querySelector('.icon-area');
       expect(iconArea).to.exist;
     });
+    it('wraps the picture in a link if provided', () => {
+      const picture = marquees[1].querySelector('.foreground .image a picture');
+      expect(picture).to.exist;
+    });
   });
 
   describe('supports media credits', () => {

--- a/test/blocks/marquee/mocks/body.html
+++ b/test/blocks/marquee/mocks/body.html
@@ -38,6 +38,7 @@
         <source media="(max-width: 400px)" srcset="./">
         <img alt="mock" loading="lazy" src="">
       </picture>
+      <a href="#modal">Link</a>
     </div>
     <div>
       <p><span class="icon icon-play"></span></p>


### PR DESCRIPTION
* Allows clickable foreground image in Marquee
* Author by adding link under image in doc

Resolves: [MWPW-128724](https://jira.corp.adobe.com/browse/MWPW-128724)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/adobe-real-time-customer-data-platform-demo?martech=off
- After: https://methomas-clickable-image--milo--adobecom.hlx.page/drafts/methomas/adobe-real-time-customer-data-platform-demo?martech=off

Bacom:
- Before: https://main--bacom--adobecom.hlx.page/drafts/methomas/adobe-real-time-customer-data-platform-demo
- After: https://main--bacom--adobecom.hlx.page/drafts/methomas/adobe-real-time-customer-data-platform-demo?milolibs=methomas-clickable-image
