### PR TITLE
MWPW-128378 Missing unit bug

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -46,7 +46,7 @@ export function processDataset(data) {
   const optionalHeaders = ['unit', 'group', 'color', 'subheading'];
   const headers = data?.[0];
   const unitKey = headers ? propertyNameCI(headers, 'unit') : null;
-  const units = headers?.[unitKey]?.split('-') || [];
+  const units = headers?.[unitKey]?.split('-') || [''];
   const cleanHeaders = Object.keys(headers).filter((header) => (
     !optionalHeaders.includes(header.toLowerCase())
   ));
@@ -342,7 +342,7 @@ export const pieSeriesOptions = (size) => {
  */
 export const getChartOptions = ({
   chartType,
-  processedData: { dataset, headers, units = [] } = {},
+  processedData: { dataset, headers, units = [''] } = {},
   series,
   size,
   colors,


### PR DESCRIPTION
* Fix bug where chart doesn't display if there's no unit (header) in the data

Resolves: [MWPW-128378](https://jira.corp.adobe.com/browse/MWPW-128378)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/chart-column-bug?martech=off
- After: https://methomas-chart-unit--milo--adobecom.hlx.page/drafts/methomas/chart-column-bug?martech=off

BACOM:
- Before: https://main--bacom--adobecom.hlx.page/drafts/methomas/chart-column-bug
- After: https://main--bacom--adobecom.hlx.page/drafts/methomas/chart-column-bug?milolibs=methomas-chart-unit
