### PR TITLE
Mwpw 128670 gnav logo is covering the page

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -662,7 +662,7 @@ export default async function init(header) {
   if (!html) return null;
 
   const link = document.head.querySelector(`link[href="${miloLibs}/blocks/gnav/gnav.css"]`);
-  if(!link.getAttribute('data-loaded') === 'true'){
+  if(link.getAttribute('data-loaded') !== 'true'){
     header.style.display = 'none';
     const isStyleLoaded = setInterval(() => {
       if(link.getAttribute('data-loaded') === 'true'){

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -655,11 +655,26 @@ async function fetchGnav(url) {
 }
 
 export default async function init(header) {
-  const { locale, imsClientId } = getConfig();
+  const { locale, imsClientId, miloLibs } = getConfig();
   const name = imsClientId ? `|${imsClientId}` : '';
   const url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
   const html = await fetchGnav(url);
   if (!html) return null;
+
+  const link = document.head.querySelector(`link[href="${miloLibs}/blocks/gnav/gnav.css"]`);
+  if(!link.getAttribute('data-loaded') === 'true'){
+    header.style.display = 'none';
+    const isStyleLoaded = setInterval(() => {
+      if(link.getAttribute('data-loaded') === 'true'){
+        clearInterval(isStyleLoaded);
+        header.removeAttribute('style');
+      }
+      if(link.getAttribute('data-loaded') === 'false'){
+        clearInterval(isStyleLoaded);
+      }
+    },10);
+  }
+
   try {
     const initEvent = new Event('gnav:init');
     const parser = new DOMParser();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -228,8 +228,14 @@ export function loadStyle(href, callback) {
     link.setAttribute('rel', 'stylesheet');
     link.setAttribute('href', href);
     if (callback) {
-      link.onload = (e) => callback(e.type);
-      link.onerror = (e) => callback(e.type);
+      link.onload = (e) => {
+        link.setAttribute('data-loaded', true);
+        callback(e.type)
+      }
+      link.onerror = (e) => {
+        link.setAttribute('data-loaded', false);
+        callback(e.type)
+      }
     }
     document.head.appendChild(link);
   } else if (callback) {


### PR DESCRIPTION
The problem is that on our stage env (https://www.stage.adobe.com/acrobat/online/jpg-to-pdf.html) sometimes gnav.plain.html is downloaded before the gnav.css and that leads to raw gnav html displaying before it is styled as you can see on attached images. The best way to reproduce the problem, is to open chrome in incognito mode and check 'Disable cache' option in Network tab in dev tools and to reload the page few times.

Resolves: https://jira.corp.adobe.com/browse/MWPW-128670

<img width="1682" alt="logo" src="https://user-images.githubusercontent.com/90400759/228804288-111a770d-8031-4b62-b369-369bce2e48c6.png">

<img width="1674" alt="gnav menu" src="https://user-images.githubusercontent.com/90400759/228804369-494fa1e9-3e5b-4dd9-af8b-e35bc43416f7.png">
