### PR TITLE
MWPW-129018: Batch process content with some delay

### DIFF
--- a/tools/floodgate/js/copy.js
+++ b/tools/floodgate/js/copy.js
@@ -8,6 +8,9 @@ import { hideButtons, loadingON, showButtons, simulatePreview } from '../../loc/
 import { ACTION_BUTTON_IDS } from './ui.js';
 import { handleExtension } from './utils.js';
 
+const BATCH_REQUEST_COPY = 20;
+const DELAY_TIME_COPY = 3000;
+
 async function floodgateContent(project, projectDetail) {
   function updateAndDisplayCopyStatus(copyStatus, srcPath) {
     const copyDisplayText = copyStatus
@@ -55,9 +58,24 @@ async function floodgateContent(project, projectDetail) {
 
   hideButtons(ACTION_BUTTON_IDS);
   const startCopy = new Date();
-  const copyStatuses = await Promise.all(
-    [...projectDetail.urls].map((valueArray) => copyFilesToFloodgateTree(valueArray[1])),
-  );
+  // create batches to process the data
+  const contentToFloodgate = [...projectDetail.urls];
+  const batchArray = [];
+  for (let i = 0; i < contentToFloodgate.length; i += BATCH_REQUEST_COPY) {
+    const arrayChunk = contentToFloodgate.slice(i, i + BATCH_REQUEST_COPY);
+    batchArray.push(arrayChunk);
+  }
+
+  // process data in batches
+  const copyStatuses = [];
+  for (let i = 0; i < batchArray.length; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    copyStatuses.push(...await Promise.all(
+      batchArray[i].map((files) => copyFilesToFloodgateTree(files[1])),
+    ));
+    // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+    await new Promise((resolve) => setTimeout(resolve, DELAY_TIME_COPY));
+  }
   const endCopy = new Date();
 
   loadingON('Previewing for copied files... ');

--- a/tools/floodgate/js/promote.js
+++ b/tools/floodgate/js/promote.js
@@ -17,6 +17,7 @@ import { getFile, handleExtension } from './utils.js';
 
 const BATCH_REQUEST_PROMOTE = 20;
 const DELAY_TIME_PROMOTE = 3000;
+const MAX_CHILDREN = 1000;
 
 /**
  * Copies the Floodgated files back to the main content tree.
@@ -56,7 +57,7 @@ async function promoteCopy(srcPath, destinationFolder) {
  */
 async function findAllFloodgatedFiles(baseURI, options, rootFolder, fgFiles, fgFolders) {
   while (fgFolders.length !== 0) {
-    const uri = `${baseURI}${fgFolders.shift()}:/children`;
+    const uri = `${baseURI}${fgFolders.shift()}:/children?$top=${MAX_CHILDREN}`;
     // eslint-disable-next-line no-await-in-loop
     const res = await fetch(uri, options);
     if (res.ok) {

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -117,6 +117,7 @@ async function getSpFiles(filePaths, isFloodgate) {
       payload.requests.push(getSharepointFileRequest(sp, index, filePath, isFloodgate));
     }
     spFilePromises.push(loadSharepointData(spBatchApi, payload));
+    await new Promise((resolve) => setTimeout(resolve, 200));
   }
   const spFileResponses = await Promise.all(spFilePromises);
   return Promise.all(spFileResponses.map((file) => file.json()));


### PR DESCRIPTION
* With Floodgate Copy/Promote action, processes content sequentially in batches
* Adds a query param to Sharepoint's list children API to return a max of 1000 children (MS defaults it to 200)
* Adds a minor delay in between the batch API calls

Resolves: [MWPW-129018](https://jira.corp.adobe.com/browse/MWPW-129018)

**Test URLs:**
- Before: [https://main--milo--adobecom.hlx.page/tools/floodgate/index.html](https://main--milo--adobecom.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B4EBD6F30-D51F-419B-BD0A-7485D4081302%257D%26file%3Dsample-fg-project.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3D01fa655f-8f1e-4a0b-a06e-c32ca7c8110e)

- After: [https://batch-process--milo--sukamat.hlx.page/tools/floodgate/index.html](https://batch-process--milo--sukamat.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B59DF5741-640D-472A-9E92-2A8AFAF477C0%257D%26file%3Dstress-200.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue)
