### PR TITLE
Remove carousel styles from typography css

### DIFF
--- a/libs/blocks/carousel/carousel.css
+++ b/libs/blocks/carousel/carousel.css
@@ -130,7 +130,6 @@
   transition: opacity;
 }
 
-
 .carousel-slide.reference-slide {
   order: 1;
 }
@@ -138,17 +137,6 @@
 .carousel-slide.active {
   opacity: 1;
 } 
-
-/* Corrects backgournd images coming from section metadata */
-.carousel .carousel-slide.has-background {
-  position: relative;
-}
-
-/* Rest for nested text blocks background image */
-.carousel .carousel-slide .foreground {
-  max-width: unset;
-  margin: unset;
-}
 
 .carousel-slides.is-ready,
 .carousel-slides.is-ready.is-reversing,
@@ -319,6 +307,7 @@
 
 .carousel .carousel-expand img {
   background-color: var(--carousel-expand-background-color);
+  box-sizing: content-box;
   border: 1px solid var(--carousel-expand-border-color);
   border-radius: 4px;
   padding: 2px 1px 2px 3px;
@@ -357,6 +346,54 @@
 }
 
 /* End Lightbox */
+
+/* Corrects backgournd images coming from section metadata */
+.carousel .carousel-slide.has-background {
+  position: relative;
+}
+
+/* Rest for nested blocks foreground */
+.carousel.container .carousel-slide .foreground:not(.icon-block .foreground) {
+  max-width: unset;
+  margin: unset;
+}
+
+.carousel.show-2 .carousel-slide .foreground,
+.carousel.show-3 .carousel-slide .foreground
+.carousel.show-4 .carousel-slide .foreground
+.carousel.show-5 .carousel-slide .foreground
+.carousel.show-6 .carousel-slide .foreground { width: auto; }
+
+.carousel.container .carousel-slide .container {
+  width: unset;
+}
+
+/* Zero out spacing token on carousel-slide */
+.carousel.container .carousel-slide.section.xs-spacing,
+.carousel.container .carousel-slide.section.s-spacing,
+.carousel.container .carousel-slide.section.m-spacing,
+.carousel.container .carousel-slide.section.l-spacing,
+.carousel.container .carousel-slide.section.xl-spacing,
+.carousel.container .carousel-slide.section.xxl-spacing { padding: 0; }
+
+/* Apply spacing token to block inside of slide */
+.carousel.container .carousel-slide.xs-spacing > div,
+.carousel.container .carousel-slide .xs-spacing { padding: var(--spacing-xs); }
+
+.carousel.container .carousel-slide.s-spacing > div,
+.carousel.container .carousel-slide .s-spacing { padding: var(--spacing-s); }
+
+.carousel.container .carousel-slide.m-spacing > div,
+.carousel.container .carousel-slide .m-spacing { padding: var(--spacing-m);  }
+
+.carousel.container .carousel-slide.l-spacing > div,
+.carousel.container .carousel-slide .l-spacing { padding: var(--spacing-l); }
+
+.carousel.container .carousel-slide.xl-spacing > div,
+.carousel.container .carousel-slide .xl-spacing { padding: var(--spacing-xl); }
+
+.carousel.container .carousel-slide.xxl-spacing > div
+.carousel.container .carousel-slide .xxl-spacing { padding: var(--spacing-xxl); }
 
 @media (min-width: 900px) {
   .carousel.lightbox-active.container .carousel-wrapper {

--- a/libs/styles/typography.css
+++ b/libs/styles/typography.css
@@ -278,40 +278,13 @@ span.icon.margin-left { margin-left: 8px; }
 .con-block.xxl-spacing-static-bottom { padding-bottom: var(--spacing-xxl-static); }
 .con-block.xxxl-spacing-static-bottom { padding-bottom: var(--spacing-xxxl-static); }
 
-.carousel-slide .con-block.has-bg,
-div[class*='-up'] .con-block.has-bg,
-.carousel-slide[style*='background-color'] .con-block,
-.carousel-slide.has-background .con-block { padding: var(--spacing-m); }
-
-.carousel-slide .con-block.has-bg.xs-spacing,
-div[class*='-up'] .con-block.has-bg.xs-spacing,
-.carousel-slide[style*='background-color'] .con-block.xs-spacing,
-.carousel-slide.has-background .con-block.xs-spacing { padding: var(--spacing-xs); }
-
-.carousel-slide .con-block.has-bg.s-spacing,
-div[class*='-up'] .con-block.has-bg.s-spacing,
-.carousel-slide[style*='background-color'] .con-block.s-spacing,
-.carousel-slide.has-background .con-block.s-spacing { padding: var(--spacing-s); }
-
-.carousel-slide .con-block.has-bg.m-spacing,
-div[class*='-up'] .con-block.has-bg.m-spacing,
-.carousel-slide[style*='background-color'] .con-block.m-spacing,
-.carousel-slide.has-background .con-block.m-spacing { padding: var(--spacing-m); }
-
-.carousel-slide .con-block.has-bg.l-spacing,
-div[class*='-up'] .con-block.has-bg.l-spacing,
-.carousel-slide[style*='background-color'] .con-block.l-spacing,
-.carousel-slide.has-background .con-block.l-spacing { padding: var(--spacing-l); }
-
-.carousel-slide .con-block.has-bg.xl-spacing,
-div[class*='-up'] .con-block.has-bg.xl-spacing,
-.carousel-slide[style*='background-color'] .con-block.xl-spacing,
-.carousel-slide.has-background .con-block.xl-spacing { padding: var(--spacing-xl); }
-
-.carousel-slide .con-block.has-bg.xxl-spacing,
-div[class*='-up'] .con-block.has-bg.xxl-spacing,
-.carousel-slide[style*='background-color'] .con-block.xxl-spacing,
-.carousel-slide.has-background .con-block.xxl-spacing { padding: var(--spacing-xxl); }
+div[class*='-up'] .con-block.has-bg { padding: var(--spacing-m); }
+div[class*='-up'] .con-block.has-bg.xs-spacing { padding: var(--spacing-xs); }
+div[class*='-up'] .con-block.has-bg.s-spacing { padding: var(--spacing-s); }
+div[class*='-up'] .con-block.has-bg.m-spacing { padding: var(--spacing-m); }
+div[class*='-up'] .con-block.has-bg.l-spacing { padding: var(--spacing-l); }
+div[class*='-up'] .con-block.has-bg.xl-spacing { padding: var(--spacing-xl); }
+div[class*='-up'] .con-block.has-bg.xxl-spacing { padding: var(--spacing-xxl); }
 
 .con-block.max-width-6 .foreground { max-width: 600px; }
 .con-block.max-width-8 .foreground { max-width: 800px; }


### PR DESCRIPTION
* Removes carousel related styles from typography.css
* Isolates all carousel styling to carousel.css
* Updated spacing from section-metadata to work better with blocks in general
* Reset containers when inside carousel slides to avoid content being blown out in some cases.

Effort to clean up LCP

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/carousel-css?martech=off
- After: https://carousel-clean-up--milo--adobecom.hlx.page/drafts/rclayton/carousel-css?martech=off

Bacom:
- Before: https://main--bacom--adobecom.hlx.live/customer-success-stories/coca-cola-case-study
- After: https://main--bacom--adobecom.hlx.live/customer-success-stories/coca-cola-case-study?milolibs=carousel-clean-up