### PR TITLE
MWPW-129129: Improve user entitlements

### DIFF
--- a/libs/blocks/global-navigation/utilities/getUserEntitlements.js
+++ b/libs/blocks/global-navigation/utilities/getUserEntitlements.js
@@ -103,9 +103,6 @@ const mapSubscriptionCodes = (offers) => {
 };
 
 const getSubscriptions = async ({ queryParams, locale }) => {
-  const controller = new AbortController();
-  const { signal } = controller;
-  const timeout = setTimeout(() => controller.abort(), API_WAIT_TIMEOUT);
   const profile = await window.adobeIMS.getProfile();
   const apiUrl = getConfig().env.name === 'prod'
     ? `https://www.adobe.com/aos-api/users/${profile.userId}/subscriptions`
@@ -115,7 +112,7 @@ const getSubscriptions = async ({ queryParams, locale }) => {
       method: 'GET',
       cache: 'no-cache',
       credentials: 'same-origin',
-      signal,
+      signal: AbortSignal.timeout(API_WAIT_TIMEOUT),
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${window.adobeIMS.getAccessToken().token}`,
@@ -124,10 +121,7 @@ const getSubscriptions = async ({ queryParams, locale }) => {
         'Accept-Language': getAcceptLanguage(locale).join(','),
       },
     })
-    .then((response) => {
-      clearTimeout(timeout);
-      return response.status === 200 ? response.json() : emptyEntitlements;
-    });
+    .then((response) => (response.status === 200 ? response.json() : emptyEntitlements));
   return res;
 };
 

--- a/libs/blocks/global-navigation/utilities/getUserEntitlements.js
+++ b/libs/blocks/global-navigation/utilities/getUserEntitlements.js
@@ -126,7 +126,7 @@ const getSubscriptions = async ({ queryParams, locale }) => {
     })
     .then((response) => {
       clearTimeout(timeout);
-      return response.status === 200 ? response.json() : null;
+      return response.status === 200 ? response.json() : emptyEntitlements();
     });
   return res;
 };


### PR DESCRIPTION
### Description
We got some feedback for https://github.com/adobecom/milo/pull/522 the default response for the getUserEntitlements utility now looks similar to what we provide in the dexter world with `feds.utilities.getUserEntitlements().then(data => console.log(data))` 

An empty response will be provided in any case of error instead of rejecting the promise.
```js
// Example output import getEntitlements from './utilities/getUserEntitlements.js';
const res = await getEntitlements({params, locale});
res = {
    "clouds": {
        "creative_cloud": false,
        "document_cloud": false,
    },
    "arrangment_codes": {
        "arrangment_codes-1": true,
        "arrangment_codes-2": true
    },
    "fulfilled_codes": {
        "fulfilled_codes-1": true,
        "fulfilled_codes-2": true,
    },
    "offer_families": {
        "offer_families_string": true
    },
    "list": {
        "fulfilled_codes": [
            "fulfilled-code-string-1",
            "fulfilled-code-string-2",
        ]
    }
}
```

A raw response can still be retrieved
```js
// Example output import getEntitlements from './utilities/getUserEntitlements.js';
// const res = await getEntitlements({params, locale, format: 'raw'});
// res = raw/unformatted output from the JIL api from https://www.adobe.com/aos-api/users/${profile.userId}/subscriptions
```
Resolves: [MWPW-129129](https://jira.corp.adobe.com/browse/MWPW-129129)

**Test URLs:**
Not required, no live changes