### PR TITLE
MWPW-129009: Video Loop Enhancement

### DIFF
--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -2,7 +2,7 @@ export default function init(a) {
   const { pathname, hash } = a;
 
   const isAutoplay = !!(hash?.includes('autoplay'));
-  const isNotLooped = !!(hash?.includes('noloop'));
+  const isNotLooped = !!(hash?.includes('autoplay1'));
 
   const attrs = isAutoplay ? `playsinline autoplay ${isNotLooped ? '' : 'loop'} muted` : 'playsinline controls';
   const video = `<video ${attrs}>

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -2,8 +2,9 @@ export default function init(a) {
   const { pathname, hash } = a;
 
   const isAutoplay = !!(hash?.includes('autoplay'));
+  const isNotLooped = !!(hash?.includes('noloop'));
 
-  const attrs = isAutoplay ? 'playsinline autoplay loop muted' : 'playsinline controls';
+  const attrs = isAutoplay ? `playsinline autoplay ${isNotLooped ? '' : 'loop'} muted` : 'playsinline controls';
   const video = `<video ${attrs}>
         <source src=".${pathname}" type="video/mp4" />
       </video>`;

--- a/test/blocks/video/mocks/body.html
+++ b/test/blocks/video/mocks/body.html
@@ -12,8 +12,8 @@
   </div>
 
   <div class="video autoplay no-loop">
-    <a href="https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4#autoplay&_noloop">
-      https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4#autoplay
+    <a href="https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4#autoplay1">
+      https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4#autoplay1
     </a>
   </div>
 </main>

--- a/test/blocks/video/mocks/body.html
+++ b/test/blocks/video/mocks/body.html
@@ -10,4 +10,10 @@
       https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4#autoplay
     </a>
   </div>
+
+  <div class="video autoplay no-loop">
+    <a href="https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4#autoplay&_noloop">
+      https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4#autoplay
+    </a>
+  </div>
 </main>

--- a/test/blocks/video/video.test.js
+++ b/test/blocks/video/video.test.js
@@ -29,4 +29,16 @@ describe('video uploaded using franklin bot', () => {
 
     expect(block.firstElementChild.hasAttribute('autoplay')).to.be.true;
   });
+
+  it('decorates video with autoplay and no loop', async () => {
+    const block = document.querySelector('.video.no-loop');
+    const a = block.querySelector('a');
+    const { href } = a;
+    a.textContent = href;
+    block.append(a);
+
+    init(a);
+
+    expect(block.firstElementChild.hasAttribute('loop')).to.be.false;
+  });
 });


### PR DESCRIPTION
* Adds the functionality to have videos loop once.  Adding `#autoplay1` at the end of a video url will ensure the video only place once instead of looping. 

Resolves: [MWPW-129009](https://jira.corp.adobe.com/browse/129009)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/slavin/digital-trends-report?martech=off
- After: https://video-loop-options--milo--adobecom.hlx.page/drafts/slavin/digital-trends-report?martech=off
