### PR TITLE
Improve Codecov config for unexpected coverage changes

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,5 +1,5 @@
-codecov:
-  status:
+coverage:
+  status: 
     patch:
       default:
         target: 100%

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,10 @@
+codecov:
+  status:
+    patch:
+      default:
+        target: 100%
+        threshold: 0.1%
+    project:
+      default:
+        target: auto
+        threshold: 0.1%


### PR DESCRIPTION
- PRs should have full coverage but allow wiggle room for [unexpected coverage changes](https://docs.codecov.com/docs/unexpected-coverage-changes).
- main should have same wiggle room, just don't let coverage drop

Resolves one issue causing red builds. See https://github.com/orgs/adobecom/discussions/626

Resolves: [MWPW-129597](https://jira.corp.adobe.com/browse/MWPW-129597)

Test URL:

- https://codecov-changes--milo--hparra.hlx.page/

Validation: `curl -X POST --data-binary @codecov.yaml https://codecov.io/validate`

Documentation: https://docs.codecov.com/docs/codecovyml-reference