### PR TITLE
Accordion block - added martech attributes for analytics tracking

### DIFF
--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -1,4 +1,5 @@
 import { createTag } from '../../utils/utils.js';
+import { decorateBlockAnalytics, decorateLinkAnalytics } from '../../martech/attributes.js';
 
 const faq = { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity: [] };
 
@@ -64,4 +65,6 @@ export default function init(el) {
   el.classList.add('con-block', maxWidthClass || 'max-width-10-desktop');
   accordion.classList.add('foreground');
   el.append(accordion);
+  decorateBlockAnalytics(el);
+  decorateLinkAnalytics(accordion, headings);
 }


### PR DESCRIPTION


* Included and invoked the martech attributes for analytics tracking on the accordion block.

MWPW-125179: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-125179)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/accordion-test?martech=off
- After: https://rparrish-accordion-analytics--milo--adobecom.hlx.page/drafts/rparrish/accordion-test?martech=off

**Test URLs:**
- Before: https://main--dc--adobecom.hlx.page/acrobat/online/pdf-to-ppt
- After: https://main--dc--adobecom.hlx.page/acrobat/online/pdf-to-ppt?milolibs=rparrish-accordion-analytics
