### PR TITLE
Keyboard support

### DIFF
--- a/libs/blocks/global-navigation/blocks/profile/dropdown.js
+++ b/libs/blocks/global-navigation/blocks/profile/dropdown.js
@@ -1,5 +1,5 @@
 import { getConfig } from '../../../../utils/utils.js';
-import { toFragment, getFedsPlaceholderConfig } from '../../utilities/utilities.js';
+import { toFragment, getFedsPlaceholderConfig, trigger, closeAllDropdowns } from '../../utilities/utilities.js';
 import { replaceKeyArray } from '../../../../features/placeholders.js';
 
 const getLanguage = (ietfLocale) => {
@@ -63,7 +63,7 @@ class ProfileDropdown {
     this.dropdown = this.decorateDropdown();
     this.addEventListeners();
 
-    if (this.openOnInit) this.toggleDropdown();
+    if (this.openOnInit) trigger({ element: this.buttonElem });
 
     this.decoratedElem.append(this.dropdown);
   }
@@ -170,14 +170,9 @@ class ProfileDropdown {
   }
 
   addEventListeners() {
-    this.buttonElem.addEventListener('click', () => {
-      this.toggleDropdown();
-    });
-  }
-
-  toggleDropdown() {
-    const currentState = this.buttonElem.getAttribute('aria-expanded');
-    this.buttonElem.setAttribute('aria-expanded', currentState === 'false');
+    this.buttonElem.addEventListener('click', () => trigger({ element: this.buttonElem }));
+    this.buttonElem.addEventListener('keydown', (e) => e.code === 'Escape' && closeAllDropdowns());
+    this.dropdown.addEventListener('keydown', (e) => e.code === 'Escape' && closeAllDropdowns());
   }
 }
 

--- a/libs/blocks/global-navigation/blocks/search/gnav-search.js
+++ b/libs/blocks/global-navigation/blocks/search/gnav-search.js
@@ -1,6 +1,8 @@
 import {
   toFragment,
   getFedsPlaceholderConfig,
+  trigger,
+  closeAllDropdowns,
 } from '../../utilities/utilities.js';
 import { replaceKeyArray } from '../../../../features/placeholders.js';
 import { getConfig } from '../../../../utils/utils.js';
@@ -95,7 +97,8 @@ class Search {
         if (this.input.value.length) {
           this.clearSearchForm();
         } else if (this.isDesktop.matches) {
-          this.closeDropdown();
+          this.clearSearchForm();
+          closeAllDropdowns();
           this.trigger.focus();
         }
       }
@@ -117,7 +120,7 @@ class Search {
     // Switching between a mobile and a desktop view
     // should close the search dropdown
     this.isDesktop.addEventListener('change', () => {
-      this.closeDropdown();
+      closeAllDropdowns();
     });
 
     // TODO: search menu should close on scroll, but this should happen from the general Menu logic
@@ -263,27 +266,17 @@ class Search {
     </li>`;
   }
 
-  closeDropdown() {
-    this.clearSearchForm();
-    this.trigger.setAttribute('aria-expanded', 'false');
-    this.curtain.classList.remove('is-open');
-  }
-
-  openDropdown() {
-    this.trigger.setAttribute('aria-expanded', 'true');
-    this.curtain.classList.add('is-open');
+  focusInput() {
     if (this.isDesktop.matches) {
       this.input.focus();
     }
   }
 
   toggleDropdown() {
-    const isOpen = this.trigger.getAttribute('aria-expanded') === 'true';
-
-    if (isOpen) {
-      this.closeDropdown();
-    } else {
-      this.openDropdown();
+    const hasBeenOpened = trigger({ element: this.trigger });
+    if (hasBeenOpened) {
+      this.curtain.classList.add('is-open');
+      this.focusInput();
     }
   }
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -5,7 +5,14 @@ import {
   localizeLink,
   loadStyle,
 } from '../../utils/utils.js';
-import { toFragment, getFedsPlaceholderConfig, getAnalyticsValue, decorateCta } from './utilities/utilities.js';
+import {
+  toFragment,
+  getFedsPlaceholderConfig,
+  getAnalyticsValue,
+  decorateCta,
+  trigger,
+  closeAllDropdowns,
+} from './utilities/utilities.js';
 import { replaceKey } from '../../features/placeholders.js';
 
 const CONFIG = {
@@ -57,15 +64,9 @@ const decorateSignIn = async ({ rawElem, decoratedElem }) => {
   } else {
     signInElem = toFragment`<a href="#" daa-ll="${signInLabel}" class="feds-signIn" role="button" aria-expanded="false" aria-haspopup="true">${signInLabel}</a>`;
 
-    signInElem.addEventListener('click', () => {
-      const isOpen = signInElem.getAttribute('aria-expanded') === 'true';
-
-      if (isOpen) {
-        signInElem.setAttribute('aria-expanded', 'false');
-      } else {
-        signInElem.setAttribute('aria-expanded', 'true');
-      }
-    });
+    signInElem.addEventListener('click', () => trigger({ element: signInElem }));
+    signInElem.addEventListener('keydown', (e) => e.code === 'Escape' && closeAllDropdowns());
+    dropdownElem.addEventListener('keydown', (e) => e.code === 'Escape' && closeAllDropdowns());
 
     dropdownElem.classList.add('feds-signIn-dropdown');
 
@@ -130,7 +131,6 @@ class Gnav {
 
   init = () => {
     this.elements.curtain = toFragment`<div class="feds-curtain"></div>`;
-
     this.elements.navWrapper = toFragment`
       <div class="feds-nav-wrapper">
         ${this.isDesktop.matches ? '' : this.decorateBreadcrumbs()}
@@ -157,6 +157,7 @@ class Gnav {
       </div>`;
 
     this.el.addEventListener('click', this.loadDelayed);
+    this.el.addEventListener('keydown', this.loadDelayed);
     setTimeout(() => this.loadDelayed(), 3000);
     this.loadIMS();
     this.el.append(this.elements.curtain, this.elements.topnavWrapper);
@@ -195,16 +196,19 @@ class Gnav {
     // eslint-disable-next-line no-async-promise-executor
     this.ready = this.ready || new Promise(async (resolve) => {
       this.el.removeEventListener('click', this.loadDelayed);
+      this.el.removeEventListener('keydown', this.loadDelayed);
       const [
         decorateDropdown,
         { appLauncher },
         ProfileDropdown,
         Search,
+        KeyboardNavigation,
       ] = await Promise.all([
         loadBlock('./blocks/navDropdown/dropdown.js'),
         loadBlock('./blocks/appLauncher/appLauncher.js'),
         loadBlock('./blocks/profile/dropdown.js'),
         loadBlock('./blocks/search/gnav-search.js'),
+        loadBlock('./utilities/keyboard/index.js'),
         loadStyles('./blocks/profile/dropdown.css'),
         loadStyles('./blocks/navDropdown/dropdown.css'),
         loadStyles('./blocks/search/gnav-search.css'),
@@ -213,6 +217,7 @@ class Gnav {
       this.ProfileDropdown = ProfileDropdown;
       this.appLauncher = appLauncher;
       this.Search = Search;
+      this.keyboardNavigation = new KeyboardNavigation();
       resolve();
     });
     return this.ready;
@@ -468,28 +473,6 @@ class Gnav {
           <div class="feds-navItem${isSectionMenu ? ' feds-navItem--section' : ''}">
             ${dropdownTrigger}
           </div>`;
-        // TODO: move proper logic to accessibility,
-        // this is just for demo functionality purposes
-        dropdownTrigger.addEventListener('click', (e) => {
-          e.preventDefault();
-
-          const openPopup = document.querySelector('.feds-navLink[aria-expanded = "true"]');
-
-          if (openPopup && openPopup !== dropdownTrigger) {
-            openPopup.setAttribute('aria-expanded', 'false');
-            openPopup.setAttribute('daa-lh', 'header|Open');
-          }
-
-          const currentState = dropdownTrigger.getAttribute('aria-expanded');
-
-          if (currentState === 'false') {
-            dropdownTrigger.setAttribute('aria-expanded', 'true');
-            dropdownTrigger.setAttribute('daa-lh', 'header|Close');
-          } else {
-            dropdownTrigger.setAttribute('aria-expanded', 'false');
-            dropdownTrigger.setAttribute('daa-lh', 'header|Open');
-          }
-        });
         delayDropdownDecoration(triggerTemplate);
         return triggerTemplate;
       }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -217,6 +217,7 @@ class Gnav {
       this.ProfileDropdown = ProfileDropdown;
       this.appLauncher = appLauncher;
       this.Search = Search;
+      // TODO we might only want to load the keyboard navigation on keydown when it's actually used
       this.keyboardNavigation = new KeyboardNavigation();
       resolve();
     });

--- a/libs/blocks/global-navigation/utilities/keyboard/index.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/index.js
@@ -1,0 +1,72 @@
+/* eslint-disable class-methods-use-this */
+import { getNextVisibleItemPosition, getPreviousVisibleItemPosition, selectors } from './utils.js';
+import MainNav from './mainNav.js';
+import { closeAllDropdowns } from '../utilities.js';
+
+const cycleOnOpenSearch = ({ e, isDesktop }) => {
+  const withoutBreadcrumbs = [
+    ...document.querySelectorAll(`
+      ${selectors.brand}, 
+      ${selectors.mainNavToggle},
+      ${selectors.mainNavItems},
+      ${selectors.searchTrigger},
+      ${selectors.searchField},
+      ${selectors.signIn},
+      ${selectors.profileButton},
+      ${selectors.logo}
+  `),
+  ];
+  const first = getNextVisibleItemPosition(-1, withoutBreadcrumbs);
+  const last = getPreviousVisibleItemPosition(withoutBreadcrumbs.length, withoutBreadcrumbs);
+  const openSearch = isDesktop && document.querySelector(selectors.openSearch);
+  if (openSearch && document.activeElement === withoutBreadcrumbs[e.shiftKey ? first : last]) {
+    e.preventDefault();
+    withoutBreadcrumbs[e.shiftKey ? last : first].focus();
+  }
+};
+
+const closeOnClickOutside = (e) => {
+  if (
+    !e.target.closest(selectors.globalNav)
+    || e.target.classList.contains(selectors.curtain.replace('.', ''))
+  ) {
+    closeAllDropdowns();
+  }
+};
+
+class KeyboardNavigation {
+  constructor() {
+    this.addEventListeners();
+    this.mainNav = new MainNav();
+    this.desktop = window.matchMedia('(min-width: 900px)');
+  }
+
+  addEventListeners = () => {
+    document.addEventListener('click', (e) => closeOnClickOutside(e));
+
+    document.querySelector(selectors.globalNav).addEventListener('keydown', (e) => {
+      switch (e.code) {
+        case 'Tab': {
+          cycleOnOpenSearch({ e, isDesktop: this.desktop.matches });
+          break;
+        }
+        case 'Enter': {
+          e.stopPropagation();
+          e.preventDefault();
+          e.target.click();
+          break;
+        }
+        case 'Space': {
+          e.stopPropagation();
+          e.preventDefault();
+          e.target.click();
+          break;
+        }
+        default:
+          break;
+      }
+    });
+  };
+}
+
+export default KeyboardNavigation;

--- a/libs/blocks/global-navigation/utilities/keyboard/mainNav.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/mainNav.js
@@ -1,0 +1,156 @@
+/* eslint-disable class-methods-use-this */
+import { selectors, getNextVisibleItemPosition, getPreviousVisibleItemPosition } from './utils.js';
+import Popup from './popup.js';
+import MobilePopup from './mobilePopup.js';
+import { closeAllDropdowns, trigger } from '../utilities.js';
+
+class MainNavItem {
+  constructor() {
+    this.desktop = window.matchMedia('(min-width: 900px)');
+    this.popup = new Popup({ mainNav: this });
+    this.mobilePopup = new MobilePopup({ mainNav: this });
+    this.addEventListeners();
+  }
+
+  addEventListeners() {
+    document.querySelector(selectors.globalNav)
+      .addEventListener('click', (e) => {
+        if (!e.target.closest(selectors.fedsNav) || e.target.closest(selectors.popup)) {
+          return;
+        }
+        const open = document.querySelector(selectors.expandedPopupTrigger);
+        closeAllDropdowns();
+        if (open !== e.target) this.open({ triggerEl: e.target });
+      });
+
+    document.querySelector(selectors.globalNav)
+      .addEventListener('keydown', (e) => {
+        if (!e.target.closest(selectors.fedsNav) || e.target.closest(selectors.popup)) {
+          return;
+        }
+        this.setActive(e.target);
+
+        switch (e.code) {
+          case 'Tab': {
+            if (e.shiftKey) {
+              const open = document.querySelector(selectors.expandedPopupTrigger);
+              if (open) {
+                if (this.prev === -1) {
+                  closeAllDropdowns();
+                } else {
+                  e.preventDefault();
+                  this.focusPrev({ focus: 'last' });
+                }
+              }
+            }
+            break;
+          }
+          case 'Escape': {
+            closeAllDropdowns();
+            break;
+          }
+          // TODO popup navigation logic.
+          case 'ArrowLeft': {
+            if (document.dir === 'ltr') {
+              if (this.prev === -1) break;
+              this.focusPrev({ focus: null });
+            } else {
+              if (this.next === -1) break;
+              this.focusNext({ focus: null });
+            }
+            break;
+          }
+          case 'ArrowUp': {
+            e.preventDefault();
+            e.stopPropagation();
+            this.focusPrev({ focus: 'last' });
+            break;
+          }
+          case 'ArrowRight': {
+            const open = document.querySelector(selectors.expandedPopupTrigger);
+            if (document.dir === 'ltr') {
+              if (this.next === -1) break;
+              this.focusNext();
+            } else {
+              if (this.prev === -1) break;
+              this.focusPrev({ focus: null });
+            }
+            if (open) {
+              this.open();
+            }
+            break;
+          }
+          case 'ArrowDown': {
+            e.stopPropagation();
+            e.preventDefault();
+            if (this.items[this.curr] && this.items[this.curr].hasAttribute('aria-haspopup')) {
+              this.open({ focus: 'first' });
+              return;
+            }
+            this.focusNext();
+            break;
+          }
+          default:
+            break;
+        }
+      });
+  }
+
+  setActive = (target) => {
+    if (!target) return;
+    this.items = [...document.querySelectorAll(selectors.mainNavItems)];
+    this.curr = this.items.findIndex((el) => el === target);
+    this.prev = getPreviousVisibleItemPosition(this.curr, this.items);
+    this.next = getNextVisibleItemPosition(this.curr, this.items);
+  };
+
+  focusPrev = ({ focus } = {}) => {
+    const open = document.querySelector(selectors.expandedPopupTrigger);
+    closeAllDropdowns();
+    if (this.prev === -1) return;
+    this.items[this.prev].focus();
+    this.setActive(this.items[this.prev]);
+    if (open) {
+      this.open({ focus });
+    }
+  };
+
+  focusNext = () => {
+    if (this.next === -1) return;
+    closeAllDropdowns();
+    this.items[this.next].focus();
+    this.setActive(this.items[this.next]);
+  };
+
+  open = ({ focus, triggerEl, e } = {}) => {
+    const triggerElement = triggerEl || this.items[this.curr];
+    if (!triggerElement || !triggerElement.hasAttribute('aria-haspopup')) return;
+    if (e) e.preventDefault();
+    if (triggerElement.getAttribute('aria-expanded') === 'false') {
+      trigger({ element: triggerElement });
+    }
+    const navItem = triggerElement.parentElement;
+    const popupEl = navItem.querySelector(selectors.popup);
+    if (popupEl) {
+      if (this.desktop.matches) {
+        this.popup.open({ focus });
+      } else {
+        this.mobilePopup.open({ focus });
+      }
+      return;
+    }
+
+    // We need to wait for the popup to be added to the DOM before we can open it.
+    const observer = new MutationObserver(() => {
+      observer.disconnect();
+      if (this.desktop.matches) {
+        this.popup.open({ focus });
+      } else {
+        this.mobilePopup.open({ focus });
+      }
+    });
+    observer.observe(navItem, { childList: true });
+  };
+}
+
+export default MainNavItem;

--- a/libs/blocks/global-navigation/utilities/keyboard/mobilePopup.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/mobilePopup.js
@@ -1,0 +1,196 @@
+/* eslint-disable class-methods-use-this */
+import {
+  getNextVisibleItemPosition,
+  getPreviousVisibleItemPosition,
+  isElementVisible,
+  getOpenPopup,
+  selectors,
+} from './utils.js';
+import { closeAllDropdowns } from '../utilities.js';
+
+const closeHeadlines = () => {
+  const open = [...document.querySelectorAll(`${selectors.headline}[aria-expanded="true"]`)];
+  open.forEach((el) => el.setAttribute('aria-expanded', 'false'));
+};
+
+const openHeadline = ({ headline, focus } = {}) => {
+  closeHeadlines();
+  if (headline.getAttribute('aria-haspopup') === 'true') {
+    headline.setAttribute('aria-expanded', 'true');
+    const section = headline.closest(selectors.section)
+      || headline.closest(selectors.column);
+    const items = [...section.querySelectorAll(selectors.popupItems)]
+      .filter((el) => isElementVisible(el));
+    if (focus === 'first') items[0].focus();
+    if (focus === 'last') items[items.length - 1].focus();
+  }
+};
+
+const getState = () => {
+  const popupEl = getOpenPopup();
+  if (!popupEl) return { popupItems: [] };
+  const popupItems = [...popupEl.querySelectorAll(selectors.popupItems)];
+  // In the markup either a section OR column can contain a expandable headline
+  // which is what we are interested in - so we can treat them both as sections.
+  const section = document.activeElement.closest(selectors.section)
+    || document.activeElement.closest(selectors.column);
+  let allSections = [...popupEl.querySelectorAll(selectors.section)];
+  if (!allSections.length) allSections = [...popupEl.querySelectorAll(selectors.column)];
+  const visibleSections = allSections.filter((el) => isElementVisible(el));
+  const currentSection = visibleSections.findIndex((node) => node.isEqualNode(section));
+  const firstHeadline = visibleSections[0]?.querySelector(selectors.headline);
+  const lastHeadline = visibleSections[visibleSections.length - 1]
+    ?.querySelector(selectors.headline);
+  const prevHeadline = visibleSections[currentSection - 1]
+    ?.querySelector(selectors.headline);
+  const nextHeadline = visibleSections[currentSection + 1]
+    ?.querySelector(selectors.headline);
+  return {
+    visibleSections,
+    currentSection,
+    firstHeadline,
+    lastHeadline,
+    prevHeadline,
+    nextHeadline,
+    popupItems,
+  };
+};
+
+class Popup {
+  constructor({ mainNav }) {
+    this.mainNav = mainNav;
+    this.addEventListeners();
+    this.desktop = window.matchMedia('(min-width: 900px)');
+  }
+
+  open({ focus } = {}) {
+    const { firstHeadline, lastHeadline, popupItems } = getState();
+    if (!popupItems.length) return;
+
+    const headline = focus === 'last' ? lastHeadline : firstHeadline;
+
+    if (headline && headline.getAttribute('aria-haspopup') === 'true') {
+      closeHeadlines();
+      headline.setAttribute('aria-expanded', 'true');
+    }
+
+    const first = getNextVisibleItemPosition(-1, popupItems);
+    const last = getPreviousVisibleItemPosition(popupItems.length, popupItems);
+    if (focus === 'first') popupItems[first].focus();
+    if (focus === 'last') popupItems[last].focus();
+  }
+
+  mobileArrowUp = ({ prev, curr }) => {
+    // Case 1:  Move focus to the previous item
+    if (prev !== -1 && curr - 1 === prev) {
+      const { currentSection, popupItems } = getState();
+      popupItems[prev].focus();
+      if (currentSection !== getState().currentSection) closeHeadlines();
+      return;
+    }
+
+    // Case 2: No headline + no previous item, move to the main nav
+    const { prevHeadline } = getState();
+    if (!prevHeadline) {
+      this.mainNav.items[this.mainNav.curr].focus();
+      return;
+    }
+
+    // Case 3: Open the previous headline
+    openHeadline({ headline: prevHeadline, focus: 'last' });
+  };
+
+  mobileArrowDown = ({ next }) => {
+    // Case 1: Move focus to the next item
+    if (next !== -1) {
+      const { currentSection, popupItems } = getState();
+      popupItems[next].focus();
+      if (currentSection !== getState().currentSection) closeHeadlines();
+      return;
+    }
+    // Case 2: No headline + no next item, move to the main nav
+    const { nextHeadline } = getState();
+    if (!nextHeadline) {
+      closeHeadlines();
+      this.mainNav.focusNext();
+      this.mainNav.open();
+      return;
+    }
+
+    // Case 3: Open the next headline
+    openHeadline({ headline: nextHeadline, focus: 'first' });
+  };
+
+  addEventListeners = () => {
+    document.querySelector(selectors.globalNav).addEventListener('keydown', (e) => {
+      const popupEl = getOpenPopup();
+      if (!e.target.closest(selectors.popup) || !popupEl || this.desktop.matches) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const popupItems = [...popupEl.querySelectorAll(selectors.popupItems)];
+      const curr = popupItems.findIndex((el) => el === e.target);
+      const prev = getPreviousVisibleItemPosition(curr, popupItems);
+      const next = getNextVisibleItemPosition(curr, popupItems);
+
+      switch (e.code) {
+        case 'Tab': {
+          if (e.shiftKey) {
+            this.mobileArrowUp({ prev, curr });
+          } else {
+            this.mobileArrowDown({ next });
+          }
+          break;
+        }
+        case 'Escape': {
+          closeAllDropdowns();
+          this.mainNav.items[this.mainNav.curr].focus();
+          break;
+        }
+        case 'ArrowLeft': {
+          const { prevHeadline, nextHeadline } = getState();
+          const headline = document.dir === 'ltr' ? prevHeadline : nextHeadline;
+          if (!headline) {
+            closeHeadlines();
+            if (document.dir === 'ltr') {
+              this.mainNav.items[this.mainNav.curr].focus();
+            } else {
+              this.mainNav.focusNext();
+              this.mainNav.open();
+            }
+            break;
+          }
+          openHeadline({ headline, focus: 'first' });
+          break;
+        }
+        case 'ArrowUp': {
+          this.mobileArrowUp({ prev, curr });
+          break;
+        }
+        case 'ArrowRight': {
+          const { prevHeadline, nextHeadline } = getState();
+          const headline = document.dir === 'ltr' ? nextHeadline : prevHeadline;
+          if (!headline) {
+            closeHeadlines();
+            if (document.dir === 'ltr') {
+              this.mainNav.focusNext();
+              this.mainNav.open();
+            } else {
+              this.mainNav.items[this.mainNav.curr].focus();
+            }
+            break;
+          }
+          openHeadline({ headline, focus: 'first' });
+          break;
+        }
+        case 'ArrowDown': {
+          this.mobileArrowDown({ next });
+          break;
+        }
+        default:
+          break;
+      }
+    });
+  };
+}
+
+export default Popup;

--- a/libs/blocks/global-navigation/utilities/keyboard/popup.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/popup.js
@@ -1,0 +1,132 @@
+/* eslint-disable class-methods-use-this */
+import {
+  getNextVisibleItemPosition,
+  getPreviousVisibleItemPosition,
+  getOpenPopup,
+  selectors,
+} from './utils.js';
+import { closeAllDropdowns } from '../utilities.js';
+
+const getState = ({ e } = {}) => {
+  const popupEl = getOpenPopup();
+  if (!popupEl) return {};
+  const popupItems = [...popupEl.querySelectorAll(selectors.popupItems)];
+  const curr = popupItems.findIndex((el) => el === e.target);
+  const prev = getPreviousVisibleItemPosition(curr, popupItems);
+  const next = getNextVisibleItemPosition(curr, popupItems);
+  const column = document.activeElement.closest(selectors.column);
+  const visibleColumns = [...popupEl.querySelectorAll(selectors.column)];
+  const currentColumn = visibleColumns.findIndex((node) => node.isEqualNode(column));
+  const prevColumn = visibleColumns[currentColumn - 1] || -1;
+  const nextColumn = visibleColumns[currentColumn + 1] || -1;
+
+  return {
+    popupItems,
+    curr,
+    prev,
+    next,
+    prevColumn,
+    nextColumn,
+  };
+};
+class Popup {
+  constructor({ mainNav }) {
+    this.mainNav = mainNav;
+    this.addEventListeners();
+    this.desktop = window.matchMedia('(min-width: 900px)');
+  }
+
+  open({ focus } = {}) {
+    const popupItems = [...(getOpenPopup()?.querySelectorAll(selectors.popupItems) || [])];
+    if (!popupItems.length) return;
+    const first = getNextVisibleItemPosition(-1, popupItems);
+    const last = getPreviousVisibleItemPosition(popupItems.length, popupItems);
+    if (focus === 'first') popupItems[first].focus();
+    if (focus === 'last') popupItems[last].focus();
+  }
+
+  addEventListeners = () => {
+    document.querySelector(selectors.globalNav).addEventListener('keydown', (e) => {
+      const popupEl = getOpenPopup();
+      if (!e.target.closest(selectors.popup) || !popupEl || !this.desktop.matches) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const { popupItems, prev, next, prevColumn, nextColumn } = getState({ e });
+
+      switch (e.code) {
+        case 'Tab': {
+          if (e.shiftKey) {
+            if (prev === -1) {
+              this.mainNav.items[this.mainNav.curr].focus();
+              break;
+            }
+            popupItems[prev].focus();
+          } else {
+            if (next === -1) {
+              this.mainNav.focusNext();
+              this.mainNav.open({});
+              break;
+            }
+            popupItems[next].focus();
+          }
+
+          break;
+        }
+        case 'Escape': {
+          closeAllDropdowns();
+          this.mainNav.items[this.mainNav.curr].focus();
+          break;
+        }
+        case 'ArrowLeft': {
+          const noPrev = (document.dir === 'ltr' && prevColumn === -1);
+          const noNext = (document.dir === 'rtl' && nextColumn === -1);
+          if (noPrev || noNext) {
+            this.mainNav.items[this.mainNav.curr].focus();
+            break;
+          }
+          if (document.dir === 'ltr') {
+            prevColumn.querySelector(selectors.popupItems).focus();
+          } else {
+            nextColumn.querySelector(selectors.popupItems).focus();
+          }
+          break;
+        }
+        case 'ArrowUp': {
+          if (prev === -1) {
+            this.mainNav.items[this.mainNav.curr].focus();
+            break;
+          }
+          popupItems[prev].focus();
+          break;
+        }
+        case 'ArrowRight': {
+          const noNext = document.dir === 'ltr' && nextColumn === -1;
+          const noPrev = document.dir === 'rtl' && prevColumn === -1;
+          if (noNext || noPrev) {
+            this.mainNav.items[this.mainNav.curr].focus();
+            break;
+          }
+          if (document.dir === 'ltr') {
+            nextColumn.querySelector(selectors.popupItems).focus();
+          } else {
+            prevColumn.querySelector(selectors.popupItems).focus();
+          }
+          break;
+        }
+        case 'ArrowDown': {
+          if (next === -1) {
+            this.mainNav.focusNext();
+            this.mainNav.open();
+            break;
+          }
+          popupItems[next].focus();
+          break;
+        }
+        default:
+          break;
+      }
+    });
+  };
+}
+
+export default Popup;

--- a/libs/blocks/global-navigation/utilities/keyboard/utils.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/utils.js
@@ -1,0 +1,64 @@
+const selectors = {
+  mainNavItems:
+    '.feds-navItem > a, .feds-navItem > .feds-cta-wrapper > .feds-cta',
+  brand: '.feds-brand',
+  mainNavToggle: '.gnav-toggle',
+  searchTrigger: '.feds-search-trigger',
+  searchField: '.feds-search-input',
+  signIn: '.feds-signin',
+  profileButton: '.feds-profile-button, .feds-signIn',
+  logo: '.gnav-logo',
+  breadCrumbItems: '.feds-breadcrumbs li > a',
+  expandedPopupTrigger: '.feds-navLink[aria-expanded = "true"]',
+  navLink: '.feds-navLink',
+  promoLink: '.feds-promo-link',
+  imagePromo: 'a.feds-promo-image',
+  fedsNav: '.feds-nav',
+  popup: '.feds-popup',
+  headline: '.feds-popup-headline',
+  section: '.feds-popup-section',
+  column: '.feds-popup-column',
+  cta: '.feds-cta',
+  curtain: '.feds-curtain',
+  openSearch: '.feds-search-trigger[aria-expanded = "true"]',
+  globalNav: '.global-navigation',
+};
+
+selectors.popupItems = `
+  ${selectors.navLink},
+  ${selectors.promoLink},
+  ${selectors.imagePromo},
+  ${selectors.cta}
+`;
+
+const isElementVisible = (elem) => !!(
+  elem
+    && elem instanceof HTMLElement
+    && (elem.offsetWidth && elem.offsetHeight)
+    && window.getComputedStyle(elem).getPropertyValue('visibility') !== 'hidden'
+);
+
+const getNextVisibleItemPosition = (position, items) => {
+  for (let newPosition = position + 1; newPosition < items.length; newPosition += 1) {
+    if (isElementVisible(items[newPosition])) return newPosition;
+  }
+  return -1;
+};
+
+const getPreviousVisibleItemPosition = (position, items) => {
+  for (let newPosition = position - 1; newPosition >= 0; newPosition -= 1) {
+    if (isElementVisible(items[newPosition])) return newPosition;
+  }
+  return -1;
+};
+
+const getOpenPopup = () => document.querySelector(selectors.expandedPopupTrigger)
+  ?.parentElement.querySelector(selectors.popup);
+
+export {
+  isElementVisible,
+  getNextVisibleItemPosition,
+  getPreviousVisibleItemPosition,
+  selectors,
+  getOpenPopup,
+};

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -82,7 +82,6 @@ export function closeAllDropdowns({ e } = {}) {
 }
 
 /**
- *
  * @param {*} param0
  * @param {*} param0.element - the DOM element of the trigger to expand
  * @returns true if the element has been expanded, false if it was already expanded

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -1,5 +1,8 @@
 import { getConfig } from '../../../utils/utils.js';
 
+const curtainSelector = '.feds-curtain';
+const navLinkClassName = 'feds-nav-link';
+const globalNavSelector = '.global-navigation';
 export function toFragment(htmlStrings, ...values) {
   const templateStr = htmlStrings.reduce((acc, htmlString, index) => {
     if (values[index] instanceof HTMLElement) {
@@ -62,4 +65,41 @@ export function decorateCta({ elem, type = 'primaryCta', index } = {}) {
           ${elem.textContent}
       </a>
     </div>`;
+}
+
+export function closeAllDropdowns({ e } = {}) {
+  const openElements = document.querySelectorAll(`${globalNavSelector} [aria-expanded='true']`);
+  if (!openElements) return;
+  if (e) e.preventDefault();
+  [...openElements].forEach((el) => {
+    el.setAttribute('aria-expanded', 'false');
+    if (el.classList.contains(navLinkClassName)) {
+      el.setAttribute('daa-lh', 'header|Open');
+    }
+  });
+  // TODO the curtain will be refactored
+  document.querySelector(curtainSelector)?.classList.remove('is-open');
+}
+
+/**
+ *
+ * @param {*} param0
+ * @param {*} param0.element - the DOM element of the trigger to expand
+ * @returns true if the element has been expanded, false if it was already expanded
+ */
+export function trigger({ element } = {}) {
+  const isOpen = element?.getAttribute('aria-expanded') === 'true';
+  closeAllDropdowns();
+  if (isOpen) return false;
+  element.setAttribute('aria-expanded', 'true');
+  return true;
+}
+
+export function expandTrigger({ element } = {}) {
+  if (!element) return;
+  closeAllDropdowns();
+  if (element.classList.contains(navLinkClassName)) {
+    element.setAttribute('daa-lh', 'header|Close');
+  }
+  element.setAttribute('aria-expanded', 'true');
 }

--- a/test/blocks/global-navigation/keyboard/keyboard.test.js
+++ b/test/blocks/global-navigation/keyboard/keyboard.test.js
@@ -1,0 +1,950 @@
+/* eslint-disable no-restricted-syntax */
+import { expect } from '@esm-bundle/chai';
+import { readFile, sendKeys } from '@web/test-runner-commands';
+import KeyboardNavigation from '../../../../libs/blocks/global-navigation/utilities/keyboard/index.js';
+import { selectors, isElementVisible, getNextVisibleItemPosition, getPreviousVisibleItemPosition } from '../../../../libs/blocks/global-navigation/utilities/keyboard/utils.js';
+import css from '../../../../libs/blocks/global-navigation/global-navigation.css' assert { type: 'css' };
+import searchCss from '../../../../libs/blocks/global-navigation/blocks/search/gnav-search.css' assert { type: 'css' };
+import signInCss from '../../../../libs/blocks/global-navigation/blocks/profile/signIn.css' assert { type: 'css' };
+import buttonCss from '../../../../libs/blocks/global-navigation/blocks/profile/button.css' assert { type: 'css' };
+import dropdownCss from '../../../../libs/blocks/global-navigation/blocks/profile/dropdown.css' assert { type: 'css' };
+import navDropdownCss from '../../../../libs/blocks/global-navigation/blocks/navDropdown/dropdown.css' assert { type: 'css' };
+import { setViewport } from '@web/test-runner-commands';
+
+const isOpen = (element) => element.getAttribute('aria-expanded') === 'true'
+  && element.hasAttribute('daa-lh', 'header|Close');
+const isClosed = (element) => element.getAttribute('aria-expanded') === 'false'
+  && element.hasAttribute('daa-lh', 'header|Open');
+const getPopup = (element) => element.parentElement.querySelector(selectors.popup);
+const getNavLinks = (trigger) => [...getPopup(trigger).querySelectorAll(`${selectors.navLink}, ${selectors.promoLink}, ${selectors.imagePromo}`)];
+let mainNavItems;
+let otherNavItems;
+let keyboardNavigation;
+let allNavItems;
+describe('keyboard navigation', () => {
+  before(() => {
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, css, searchCss, signInCss, buttonCss, dropdownCss, navDropdownCss]
+  });
+
+  beforeEach(async () => {
+    document.dir ="ltr"
+    setViewport({ width: 1500, height: 1500 })
+    document.body.innerHTML = await readFile({ path: './mocks/global-nav.html' });
+    keyboardNavigation = new KeyboardNavigation();
+    allNavItems = [
+      ...document.querySelectorAll(`
+     ${selectors.brand}, 
+     ${selectors.mainNavToggle},
+     ${selectors.searchTrigger},
+     ${selectors.mainNavItems},
+     ${selectors.searchField},
+     ${selectors.signIn},
+     ${selectors.profileButton},
+     ${selectors.logo},
+     ${selectors.breadCrumbItems}
+     `),
+    ];
+    mainNavItems = [...document.querySelectorAll(selectors.mainNavItems)];
+    otherNavItems = [
+      ...document.querySelectorAll(`
+     ${selectors.brand}, 
+     ${selectors.mainNavToggle},
+     ${selectors.searchTrigger},
+     ${selectors.searchField},
+     ${selectors.signIn},
+     ${selectors.profileButton},
+     ${selectors.logo},
+     ${selectors.breadCrumbItems}
+     `),
+    ];
+    keyboardNavigation.mainNav.popup.desktop = { matches: true };
+  });
+
+  describe('mainNav', () => {
+    describe('Tab', () => {
+      it('shifts focus', async () => {
+        allNavItems[5].focus(); // last main nav item
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement).to.equal(allNavItems[6]); // outside of main nav
+      });
+
+      it('does not open a popup', async () => {
+        const trigger = mainNavItems[0];
+        trigger.focus();
+        await sendKeys({ press: 'Tab' });
+        expect(isClosed(trigger)).to.equal(true);
+      });
+    });
+
+    describe('Shift+Tab', () => {
+      it('goes back on shift tab', async () => {
+        allNavItems[6].focus();
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+        expect(document.activeElement).to.equal(allNavItems[5]);
+      });
+
+      it("On the first item, closes the popup if it's open and shifts focus", async () => {
+        const trigger = mainNavItems[0];
+        trigger.focus();
+        keyboardNavigation.mainNav.setActive(trigger);
+        keyboardNavigation.mainNav.open();
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+        expect(isClosed(trigger)).to.equal(true);
+        expect(document.activeElement).to.equal(allNavItems[1]);
+      });
+    });
+
+    describe('ArrowRight', () => {
+      it('shifts focus', async () => {
+        mainNavItems[0].focus();
+        for await (const element of mainNavItems) {
+          expect(document.activeElement).to.equal(element);
+          await sendKeys({ press: 'ArrowRight' });
+          expect(element.attributes['aria-expanded']?.value || 'false').to.equal('false');
+        }
+        // does not go further to the right on the last element
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement).to.equal(mainNavItems[mainNavItems.length - 1]);
+      });
+
+      it('shifts focus with rtl', async () => {
+        document.dir = "rtl"
+        mainNavItems[mainNavItems.length - 1].focus();
+        const reversedMainNavItems = mainNavItems
+          .slice()
+          .reverse();
+        for await (const element of reversedMainNavItems) {
+          expect(document.activeElement).to.equal(element);
+          await sendKeys({ press: 'ArrowRight' });
+          expect(element.attributes['aria-expanded']?.value || 'false').to.equal('false');
+        }
+        // does not go further to the left on the first element
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement).to.equal(mainNavItems[0]);
+      });
+      
+      it('if a popup is open, it opens the next popup', async () => {
+        const triggerOne = mainNavItems[0];
+        const triggerTwo = mainNavItems[1];
+        triggerOne.focus();
+        keyboardNavigation.mainNav.setActive(triggerOne);
+        keyboardNavigation.mainNav.open();
+        expect(isOpen(triggerOne)).to.equal(true);
+        await sendKeys({ press: 'ArrowRight' });
+        expect(isClosed(triggerOne)).to.equal(true);
+        expect(isOpen(triggerTwo)).to.equal(true);
+      });
+
+      it('if a popup is open, but the next link has no popup - it closes the popup', async () => {
+        const triggerTwo = mainNavItems[1];
+        const triggerPrimaryCTA = mainNavItems[2];
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        await sendKeys({ press: 'ArrowRight' });
+        expect(isClosed(triggerTwo)).to.equal(true);
+        expect(isOpen(triggerPrimaryCTA)).to.equal(false);
+      });
+    });
+
+    describe('ArrowLeft', () => {
+      it('shifts focus', async () => {
+        mainNavItems[mainNavItems.length - 1].focus();
+        const reversedMainNavItems = mainNavItems
+          .slice()
+          .reverse();
+        for await (const element of reversedMainNavItems) {
+          expect(document.activeElement).to.equal(element);
+          await sendKeys({ press: 'ArrowLeft' });
+          expect(element.attributes['aria-expanded']?.value || 'false').to.equal('false');
+        }
+        // does not go further to the left on the first element
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement).to.equal(mainNavItems[0]);
+      });
+
+      it('shifts focus with rtl',async () => {
+        document.dir = "rtl"
+        mainNavItems[0].focus();
+        for await (const element of mainNavItems) {
+          expect(document.activeElement).to.equal(element);
+          await sendKeys({ press: 'ArrowLeft' });
+          expect(element.attributes['aria-expanded']?.value || 'false').to.equal('false');
+        }
+        // does not go further to the right on the last element
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement).to.equal(mainNavItems[mainNavItems.length - 1]);
+      })
+
+      it('if a popup is open, it opens the previous popup', async () => {
+        const triggerOne = mainNavItems[0];
+        const triggerTwo = mainNavItems[1];
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        expect(isOpen(triggerTwo)).to.equal(true);
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(isClosed(triggerTwo)).to.equal(true);
+        expect(isOpen(triggerOne)).to.equal(true);
+      });
+
+      it('if first link has an open popup, it opens', async () => {
+        const trigger = mainNavItems[0];
+        trigger.focus();
+        keyboardNavigation.mainNav.setActive(trigger);
+        keyboardNavigation.mainNav.open();
+        expect(isOpen(trigger)).to.equal(true);
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(isOpen(trigger)).to.equal(true);
+      });
+    });
+
+    describe('ArrowUp', () => {
+      it('cycles through', async () => {
+        mainNavItems[mainNavItems.length - 1].focus();
+        const reversed = mainNavItems
+          .slice()
+          .reverse();
+        for await (const element of reversed) {
+          expect(document.activeElement).to.equal(element);
+          await sendKeys({ press: 'ArrowUp' });
+          expect(
+            element.attributes['aria-expanded']?.value || 'false',
+          ).to.equal('false');
+        }
+        // does not go further to the left on the first element
+        await sendKeys({ press: 'ArrowUp' });
+        expect(document.activeElement).to.equal(mainNavItems[0]);
+      });
+
+      it('if first link has an open popup, it closes', async () => {
+        const triggerOne = mainNavItems[0];
+        triggerOne.focus();
+        keyboardNavigation.mainNav.setActive(triggerOne);
+        keyboardNavigation.mainNav.open();
+        expect(isOpen(triggerOne)).to.equal(true);
+        await sendKeys({ press: 'ArrowUp' });
+        expect(isClosed(triggerOne)).to.equal(true);
+      });
+
+      it('if second link has an open popup, it opens the previous popup and focusses the last item', async () => {
+        const triggerOne = mainNavItems[0];
+        const triggerTwo = mainNavItems[1];
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        expect(isOpen(triggerTwo)).to.equal(true);
+        await sendKeys({ press: 'ArrowUp' });
+        expect(isClosed(triggerTwo)).to.equal(true);
+        expect(isOpen(triggerOne)).to.equal(true);
+        expect(document.activeElement).to.not.equal(triggerOne);
+
+        // focus shifted to last item of the popup
+        const navLinks = [
+          ...triggerOne.parentElement.querySelectorAll(`
+        ${selectors.navLink}, 
+        ${selectors.promoLink},
+        ${selectors.imagePromo}
+      `),
+        ];
+        const lastNavLink = navLinks[navLinks.length - 1];
+        expect(lastNavLink).to.equal(document.activeElement);
+      });
+    });
+
+    describe('ArrowDown', () => {
+      it('without a popup, focusses the next element', async () => {
+        const cta = mainNavItems[2];
+        cta.focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(mainNavItems[3]).to.equal(document.activeElement);
+      });
+
+      it('last item without popup, does nothing', async () => {
+        const cta = mainNavItems[mainNavItems.length - 1];
+        cta.focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(cta).to.equal(document.activeElement);
+        expect(cta.attributes['aria-expanded']?.value || 'false').to.equal(
+          'false',
+        );
+      });
+
+      it('opens a popup', async () => {
+        const trigger = mainNavItems[0];
+        trigger.focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(isOpen(trigger)).to.equal(true);
+        const navLinks = getNavLinks(trigger);
+        const firstPopupItem = navLinks[0];
+        expect(firstPopupItem).to.equal(document.activeElement);
+      });
+    });
+
+    describe('Space', () => {
+      it('opens and closes a popup', async () => {
+        const trigger = mainNavItems[0];
+        trigger.focus();
+        await sendKeys({ press: 'Space' });
+        expect(isOpen(trigger)).to.equal(true);
+        await sendKeys({ press: 'Space' });
+        expect(isClosed(trigger)).to.equal(true);
+      });
+
+      it("emits a click event on links and CTAs", (done) => {
+        const cta = mainNavItems[2]
+        cta.focus()
+        cta.addEventListener('click', (e) => {
+          e.preventDefault()
+          done()
+        })
+        sendKeys({ press: 'Space' });
+      })  
+    })
+
+    describe('Enter', () => {
+      it('opens and closes a popup', async () => {
+        const trigger = mainNavItems[0];
+        trigger.focus();
+        await sendKeys({ press: 'Enter' });
+        expect(isOpen(trigger)).to.equal(true);
+        await sendKeys({ press: 'Enter' });
+        expect(isClosed(trigger)).to.equal(true);
+      });
+
+      it("emits a click event on links and CTAs", (done) => {
+        const cta = mainNavItems[2]
+        cta.focus()
+        cta.addEventListener('click', (e) => {
+          e.preventDefault()
+          done()
+        })
+        sendKeys({ press: 'Enter' });
+      })  
+    })
+
+    describe('Escape', () => {
+      it('closes a popup', async () => {
+        const trigger = mainNavItems[0];
+        trigger.focus();
+        keyboardNavigation.mainNav.setActive(trigger);
+        keyboardNavigation.mainNav.open();
+        expect(isOpen(trigger)).to.equal(true);
+        await sendKeys({ press: 'Escape' });
+        expect(isClosed(trigger)).to.equal(true);
+      })
+    })
+  });
+
+  describe('navigation that is not mainNav or popup', () => {
+    describe("Tab", () => {
+      it("cycles through the navigation if the search is open", async () => {
+        const search = document.querySelector(selectors.searchTrigger)
+        search.setAttribute('aria-expanded', 'true')
+        const withoutBreadcrumbs = [
+          ...document.querySelectorAll(`
+        ${selectors.brand}, 
+        ${selectors.mainNavToggle},
+        ${selectors.mainNavItems},
+        ${selectors.searchTrigger},
+        ${selectors.searchField},
+        ${selectors.signIn},
+        ${selectors.profileButton},
+        ${selectors.logo}
+        `),
+        ];
+        const first = getNextVisibleItemPosition(-1, withoutBreadcrumbs);
+        const last = getPreviousVisibleItemPosition(withoutBreadcrumbs.length, withoutBreadcrumbs);
+        
+        withoutBreadcrumbs[last].focus()
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement).to.equal(withoutBreadcrumbs[first])
+      })
+    })
+
+    describe("Shift + Tab", () => {
+      it("cycles through the navigation if the search is open", async () => {
+        const search = document.querySelector(selectors.searchTrigger)
+        search.setAttribute('aria-expanded', 'true')
+        const withoutBreadcrumbs = [
+          ...document.querySelectorAll(`
+        ${selectors.brand}, 
+        ${selectors.mainNavToggle},
+        ${selectors.mainNavItems},
+        ${selectors.searchTrigger},
+        ${selectors.searchField},
+        ${selectors.signIn},
+        ${selectors.profileButton},
+        ${selectors.logo}
+        `),
+        ];
+        const first = getNextVisibleItemPosition(-1, withoutBreadcrumbs);
+        const last = getPreviousVisibleItemPosition(withoutBreadcrumbs.length, withoutBreadcrumbs);
+        
+        withoutBreadcrumbs[first].focus()
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+        expect(document.activeElement).to.equal(withoutBreadcrumbs[last])
+      })
+    })
+
+    describe('ArrowRight', () => {
+      it('does nothing', async () => {
+
+        for await (const element of otherNavItems) {
+          if(!isElementVisible(element)) continue
+          element.focus();
+          await sendKeys({ press: 'ArrowRight' });
+          expect(document.activeElement).to.equal(element);
+        }
+      });
+    });
+
+    describe('ArrowLeft', () => {
+      it('does nothing', async () => {
+        for await (const element of otherNavItems) {
+          if(!isElementVisible(element)) continue
+          element.focus();
+          await sendKeys({ press: 'ArrowLeft' });
+          expect(document.activeElement).to.equal(element);
+        }
+      });
+    });
+
+    describe('ArrowUp', () => {
+      it('does nothing', async () => {
+        for await (const element of otherNavItems) {
+          if(!isElementVisible(element)) continue
+          element.focus();
+          await sendKeys({ press: 'ArrowUp' });
+          expect(document.activeElement).to.equal(element);
+        }
+      });
+    });
+
+    describe('ArrowDown', () => {
+      it('nothing', async () => {
+        // TODO - it opens search and profile
+        for await (const element of otherNavItems) {
+          if(!isElementVisible(element)) continue
+          element.focus();
+          await sendKeys({ press: 'ArrowDown' });
+          expect(document.activeElement).to.equal(element);
+        }
+      });
+    });
+
+    describe('Space', () => {
+      it("emits a click event on links and CTAs", (done) => {
+        const search = document.querySelector(selectors.searchTrigger)
+        search.focus()
+        search.addEventListener('click', (e) => {
+          e.preventDefault()
+          done()
+        })
+        sendKeys({ press: 'Space' });
+      })  
+    })
+
+    describe('Enter', () => {
+      it("emits a click event on links and CTAs", (done) => {
+        const search = document.querySelector(selectors.searchTrigger)
+        search.focus()
+        search.addEventListener('click', (e) => {
+          e.preventDefault()
+          done()
+        })
+        sendKeys({ press: 'Enter' });
+      })  
+    })
+  });
+
+  describe('popup', () => {
+    let navLinks;
+    let trigger;
+    let triggerTwo;
+    let firstPopupItem
+    beforeEach(async () => {
+      [trigger, triggerTwo] = mainNavItems;
+      trigger.focus();
+      keyboardNavigation.mainNav.setActive(trigger);
+      keyboardNavigation.mainNav.open();
+      navLinks = getNavLinks(trigger);
+      firstPopupItem = navLinks[0];
+      firstPopupItem.focus();
+    });
+
+    describe('Shift+Tab', () => {
+      it('shifts focus to the previous item', async () => {
+        navLinks[1].focus();
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+        expect(document.activeElement).to.equal(navLinks[0]);
+      });
+      it('shifts focus from the first popup item back to the trigger', async () => {
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+    });
+
+    describe('Shift', () => {
+      it('shifts focus to the next item', async () => {
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement).to.equal(navLinks[1]);
+      });
+
+      it('shifts focus from the last popup item, to the next trigger', async () => {
+        navLinks[navLinks.length - 1].focus();
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+
+      it('shifts focus to the next item if it is not a popup', async () => {
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        const navLinksTwo = getNavLinks(triggerTwo);
+        navLinksTwo[navLinksTwo.length - 1].focus();
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement.innerText).to.equal('Primary');
+      });
+    });
+
+    describe('ArrowRight', () => {
+      it('shifts focus to the next column', async () => {
+        expect(document.activeElement.innerText).to.equal('first-column-first-section-first-item');
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
+      });
+
+      it('shifts focus from the last popup item back to the trigger', async () => {
+        navLinks[navLinks.length - 1].focus();
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+
+      it('shifts focus to the previous column on RTL', async () => {
+        document.dir = "rtl"
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement.innerText).to.equal('first-column-first-section-first-item');
+      });
+
+      it('shifts focus from the first popup item back to the trigger on RTL', async () => {
+        document.dir = "rtl"
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+
+      it('shifts focus from the second popup item back to the trigger on RTL', async () => {
+        document.dir = "rtl"
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        const navLinksTwo = getNavLinks(triggerTwo);
+        navLinksTwo[1].focus();
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+    });
+
+    describe('ArrowLeft', () => {
+      it('shifts focus to the previous column', async () => {
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement.innerText).to.equal('first-column-first-section-first-item');
+      });
+
+      it('shifts focus from the first popup item back to the trigger', async () => {
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+
+      it('shifts focus from the second popup item back to the trigger', async () => {
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        const navLinksTwo = getNavLinks(triggerTwo);
+        navLinksTwo[1].focus();
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+
+      it('shifts focus to the next column on RTL', async () => {
+        document.dir = "rtl"
+        expect(document.activeElement.innerText).to.equal('first-column-first-section-first-item');
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
+      });
+
+      it('shifts focus from the last popup item back to the trigger on RTL', async () => {
+        document.dir = "rtl"
+        navLinks[navLinks.length - 1].focus();
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+    });
+
+    describe('ArrowUp', () => {
+      it('shifts focus from the first popup item back to the trigger', async () => {
+        await sendKeys({ press: 'ArrowUp' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+
+      it('focusses the previous item', async () => {
+        navLinks[1].focus();
+        await sendKeys({ press: 'ArrowUp' });
+        expect(document.activeElement).to.equal(navLinks[0]);
+      });
+    });
+
+    describe('ArrowDown', () => {
+      it('shifts focus to the next item', async () => {
+        await sendKeys({ press: 'ArrowDown' });
+        expect(document.activeElement).to.equal(navLinks[1]);
+      });
+
+      it('shifts focus from the last popup item, to the next trigger', async () => {
+        navLinks[navLinks.length - 1].focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+
+      it('shifts focus to the next item if it is not a popup', async () => {
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        const navLinksTwo = getNavLinks(triggerTwo);
+        navLinksTwo[navLinksTwo.length - 1].focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(document.activeElement.innerText).to.equal('Primary');
+      });
+    });
+
+    describe('Escape', () => {
+      it('closes the popup', async () => {
+        expect(isOpen(trigger)).to.equal(true);
+        await sendKeys({ press: 'Escape' });
+        expect(isClosed(trigger)).to.equal(true);
+      });
+    })
+
+    describe('Enter', () => {
+      it('Emits a click event when pressing space', (done) => {
+        firstPopupItem.addEventListener('click', (e) => {
+          e.preventDefault()
+          done()
+        })
+        sendKeys({ press: 'Enter' })
+      });
+    })
+
+    describe('Space', () => {
+      it('Emits a click event when pressing space', (done) => {
+        firstPopupItem.addEventListener('click', (e) => {
+          e.preventDefault()
+          done()
+        })
+        sendKeys({ press: 'Space' })
+      });
+    })
+  });
+
+  describe('mobile', () => {
+    let navLinks;
+    let trigger;
+    let triggerTwo;
+    let firstPopupItem
+    beforeEach(async () => {
+      setViewport({ width: 600, height: 600 })
+      document.body.innerHTML = await readFile({ path: './mocks/global-nav-mobile.html' });
+      keyboardNavigation = new KeyboardNavigation();
+      allNavItems = [
+        ...document.querySelectorAll(`
+       ${selectors.brand}, 
+       ${selectors.mainNavToggle},
+       ${selectors.searchTrigger},
+       ${selectors.mainNavItems},
+       ${selectors.searchField},
+       ${selectors.signIn},
+       ${selectors.profileButton},
+       ${selectors.logo},
+       ${selectors.breadCrumbItems}
+       `),
+      ];
+      mainNavItems = [...document.querySelectorAll(selectors.mainNavItems)];
+      otherNavItems = [
+        ...document.querySelectorAll(`
+       ${selectors.brand}, 
+       ${selectors.mainNavToggle},
+       ${selectors.searchTrigger},
+       ${selectors.searchField},
+       ${selectors.signIn},
+       ${selectors.profileButton},
+       ${selectors.logo},
+       ${selectors.breadCrumbItems}
+       `),
+      ];
+      keyboardNavigation.mainNav.popup.desktop = { matches: false };
+      [trigger, triggerTwo] = mainNavItems;
+      trigger.focus();
+      keyboardNavigation.mainNav.setActive(trigger);
+      keyboardNavigation.mainNav.open();
+      navLinks = getNavLinks(trigger);
+      firstPopupItem = navLinks[0];
+      firstPopupItem.focus();
+    });
+
+    describe('Shift+Tab', () => {
+      it('shifts focus backwards', async () => {
+        navLinks[1].focus();
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+        expect(document.activeElement).to.equal(navLinks[0]);
+
+        // further to the trigger from the first popup item
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+        expect(document.activeElement).to.equal(trigger);
+
+        // further to the search from the trigger
+        await sendKeys({ down: 'Shift' });
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ up: 'Shift' });
+        expect(document.activeElement.classList[0]).to.equal('feds-search-input');
+      });
+    });
+
+    describe('Shift', () => {
+      it('shifts focus to the next item', async () => {
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement).to.equal(navLinks[1]);
+      });
+
+      it('shifts focus from the last popup item, to the next trigger', async () => {
+        const section = navLinks[navLinks.length - 2].closest(selectors.section);
+        const headline = section.querySelector(selectors.headline);
+        headline.setAttribute('aria-expanded', true)
+        navLinks[navLinks.length - 2].focus();
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+
+      it('shifts focus to the next item if it is not a popup', async () => {
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        const navLinksTwo = getNavLinks(triggerTwo);
+        navLinksTwo[navLinksTwo.length - 1].focus();
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement.innerText).to.equal('Primary');
+      });
+
+      it('opens a headline', async () => {
+        await sendKeys({ press: 'Tab' });
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement.innerText).to.equal('first-column-second-section-first-item');
+        const section = document.activeElement.closest(selectors.section);
+        const headline = section.querySelector(selectors.headline);
+        expect(headline.getAttribute('aria-expanded')).to.equal('true');
+      });
+    });
+
+    describe('ArrowRight', () => {
+      it('shifts focus to the next section', async () => {
+        expect(document.activeElement.innerText).to.equal('first-column-first-section-first-item');
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement.innerText).to.equal('first-column-second-section-first-item');
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
+      });
+
+      it('shifts focus from the last popup item to the next trigger', async () => {
+        const section = navLinks[navLinks.length - 2].closest(selectors.section);
+        const headline = section.querySelector(selectors.headline);
+        headline.setAttribute('aria-expanded', true)
+        navLinks[navLinks.length - 2].focus();
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+
+      it('shifts focus to the previous section', async () => {
+        document.dir = 'rtl';
+        await sendKeys({ press: 'ArrowLeft' });
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement.innerText).to.equal('first-column-second-section-first-item');
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+
+      it('shifts focus from the first popup item back to the trigger', async () => {
+        document.dir = 'rtl';
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+
+      it('shifts focus from the second popup item back to the trigger', async () => {
+        document.dir = 'rtl';
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        const navLinksTwo = getNavLinks(triggerTwo);
+        navLinksTwo[1].focus();
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+    });
+
+    describe('ArrowLeft', () => {
+      it('shifts focus to the previous section', async () => {
+        await sendKeys({ press: 'ArrowRight' });
+        await sendKeys({ press: 'ArrowRight' });
+        expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement.innerText).to.equal('first-column-second-section-first-item');
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+
+      it('shifts focus from the first popup item back to the trigger', async () => {
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+
+      it('shifts focus from the second popup item back to the trigger', async () => {
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        const navLinksTwo = getNavLinks(triggerTwo);
+        navLinksTwo[1].focus();
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+
+      it('shifts focus to the next section', async () => {
+        document.dir = 'rtl';
+        expect(document.activeElement.innerText).to.equal('first-column-first-section-first-item');
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement.innerText).to.equal('first-column-second-section-first-item');
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
+      });
+
+      it('shifts focus from the last popup item to the next trigger', async () => {
+        document.dir = 'rtl';
+        const section = navLinks[navLinks.length - 2].closest(selectors.section);
+        const headline = section.querySelector(selectors.headline);
+        headline.setAttribute('aria-expanded', true)
+        navLinks[navLinks.length - 2].focus();
+        await sendKeys({ press: 'ArrowLeft' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+    });
+
+    describe('ArrowUp', () => {
+      it('shifts focus from the first popup item back to the trigger', async () => {
+        await sendKeys({ press: 'ArrowUp' });
+        expect(document.activeElement).to.equal(trigger);
+      });
+
+      it('focusses the previous item', async () => {
+        navLinks[1].focus();
+        await sendKeys({ press: 'ArrowUp' });
+        expect(document.activeElement).to.equal(navLinks[0]);
+      });
+
+      it('coming from trigger two, it will focus the last popup item of trigger one', async () => {
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        await sendKeys({ press: 'ArrowUp' });
+        expect(document.activeElement.innerText).to.equal('first-column-second-section-last-item');
+      })
+    });
+
+    describe('ArrowDown', () => {
+      it('shifts focus to the next item', async () => {
+        await sendKeys({ press: 'ArrowDown' });
+        expect(document.activeElement).to.equal(navLinks[1]);
+      });
+
+      it('shifts focus from the last popup item, to the next trigger', async () => {
+        const section = navLinks[navLinks.length - 2].closest(selectors.section);
+        const headline = section.querySelector(selectors.headline);
+        headline.setAttribute('aria-expanded', true)
+        navLinks[navLinks.length - 2].focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(document.activeElement).to.equal(triggerTwo);
+      });
+
+      it('shifts focus to the next item if it is not a popup', async () => {
+        triggerTwo.focus();
+        keyboardNavigation.mainNav.setActive(triggerTwo);
+        keyboardNavigation.mainNav.open();
+        const navLinksTwo = getNavLinks(triggerTwo);
+        navLinksTwo[navLinksTwo.length - 1].focus();
+        await sendKeys({ press: 'ArrowDown' });
+        expect(document.activeElement.innerText).to.equal('Primary');
+      });
+    });
+
+    describe('Space', () => {
+      it('opens a popup', async () => {
+        trigger.focus()
+        await sendKeys({ press: 'Space' }); 
+        expect(trigger.attributes['aria-expanded'].value).to.equal('false');
+        await sendKeys({ press: 'Space' }); 
+        expect(trigger.attributes['aria-expanded'].value).to.equal('true');
+      });
+
+      it("emits a click event on links and CTAs", (done) => {
+        firstPopupItem.addEventListener('click', (e) => {
+          e.preventDefault()
+          done()
+        })
+        sendKeys({ press: 'Space' });
+      }) 
+    })
+
+    describe('Enter', () => {
+      it('opens a popup', async () => {
+        trigger.focus()
+        await sendKeys({ press: 'Enter' }); 
+        expect(trigger.attributes['aria-expanded'].value).to.equal('false');
+        await sendKeys({ press: 'Enter' }); 
+        expect(trigger.attributes['aria-expanded'].value).to.equal('true');
+      });
+
+      it("emits a click event on links and CTAs", (done) => {
+        firstPopupItem.addEventListener('click', (e) => {
+          e.preventDefault()
+          done()
+        })
+        sendKeys({ press: 'Enter' });
+      }) 
+    })
+
+    describe('Escape', async () => {
+      it("closes the popup", async () => {
+        expect(isOpen(trigger)).to.equal(true)
+        await sendKeys({ press: 'Escape' });
+        expect(isClosed(trigger)).to.equal(true)
+      })
+    })
+  });
+
+});

--- a/test/blocks/global-navigation/keyboard/keyboard.test.js
+++ b/test/blocks/global-navigation/keyboard/keyboard.test.js
@@ -1,13 +1,9 @@
 /* eslint-disable no-restricted-syntax */
 import { expect } from '@esm-bundle/chai';
-import { readFile, sendKeys } from '@web/test-runner-commands';
+import { readFile, sendKeys, setViewport } from '@web/test-runner-commands';
+import { loadStyle } from '../../../../libs/utils/utils.js';
 import KeyboardNavigation from '../../../../libs/blocks/global-navigation/utilities/keyboard/index.js';
 import { selectors, isElementVisible, getNextVisibleItemPosition, getPreviousVisibleItemPosition } from '../../../../libs/blocks/global-navigation/utilities/keyboard/utils.js';
-import css from '../../../../libs/blocks/global-navigation/global-navigation.css' assert { type: 'css' };
-import searchCss from '../../../../libs/blocks/global-navigation/blocks/search/gnav-search.css' assert { type: 'css' };
-import dropdownCss from '../../../../libs/blocks/global-navigation/blocks/profile/dropdown.css' assert { type: 'css' };
-import navDropdownCss from '../../../../libs/blocks/global-navigation/blocks/navDropdown/dropdown.css' assert { type: 'css' };
-import { setViewport } from '@web/test-runner-commands';
 
 const isOpen = (element) => element.getAttribute('aria-expanded') === 'true'
   && element.hasAttribute('daa-lh', 'header|Close');
@@ -19,14 +15,24 @@ let mainNavItems;
 let otherNavItems;
 let keyboardNavigation;
 let allNavItems;
+
+const loadStyles = (path) => new Promise((resolve) => {
+  loadStyle(`../../../../libs/blocks/global-navigation/${path}`, resolve);
+});
+
 describe('keyboard navigation', () => {
-  before(() => {
-    document.adoptedStyleSheets = [...document.adoptedStyleSheets, css, searchCss, dropdownCss, navDropdownCss]
+  before(async () => {
+    await Promise.all([
+      loadStyles('global-navigation.css'),
+      loadStyles('blocks/search/gnav-search.css'),
+      loadStyles('blocks/profile/dropdown.css'),
+      loadStyles('blocks/navDropdown/dropdown.css'),
+    ]);
   });
 
   beforeEach(async () => {
-    document.dir ="ltr"
-    setViewport({ width: 1500, height: 1500 })
+    document.dir = 'ltr';
+    setViewport({ width: 1500, height: 1500 });
     document.body.innerHTML = await readFile({ path: './mocks/global-nav.html' });
     keyboardNavigation = new KeyboardNavigation();
     allNavItems = [
@@ -110,7 +116,7 @@ describe('keyboard navigation', () => {
       });
 
       it('shifts focus with rtl', async () => {
-        document.dir = "rtl"
+        document.dir = 'rtl';
         mainNavItems[mainNavItems.length - 1].focus();
         const reversedMainNavItems = mainNavItems
           .slice()
@@ -124,7 +130,7 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'ArrowRight' });
         expect(document.activeElement).to.equal(mainNavItems[0]);
       });
-      
+
       it('if a popup is open, it opens the next popup', async () => {
         const triggerOne = mainNavItems[0];
         const triggerTwo = mainNavItems[1];
@@ -165,8 +171,8 @@ describe('keyboard navigation', () => {
         expect(document.activeElement).to.equal(mainNavItems[0]);
       });
 
-      it('shifts focus with rtl',async () => {
-        document.dir = "rtl"
+      it('shifts focus with rtl', async () => {
+        document.dir = 'rtl';
         mainNavItems[0].focus();
         for await (const element of mainNavItems) {
           expect(document.activeElement).to.equal(element);
@@ -176,7 +182,7 @@ describe('keyboard navigation', () => {
         // does not go further to the right on the last element
         await sendKeys({ press: 'ArrowLeft' });
         expect(document.activeElement).to.equal(mainNavItems[mainNavItems.length - 1]);
-      })
+      });
 
       it('if a popup is open, it opens the previous popup', async () => {
         const triggerOne = mainNavItems[0];
@@ -293,16 +299,16 @@ describe('keyboard navigation', () => {
         expect(isClosed(trigger)).to.equal(true);
       });
 
-      it("emits a click event on links and CTAs", (done) => {
-        const cta = mainNavItems[2]
-        cta.focus()
+      it('emits a click event on links and CTAs', (done) => {
+        const cta = mainNavItems[2];
+        cta.focus();
         cta.addEventListener('click', (e) => {
-          e.preventDefault()
-          done()
-        })
+          e.preventDefault();
+          done();
+        });
         sendKeys({ press: 'Space' });
-      })  
-    })
+      });
+    });
 
     describe('Enter', () => {
       it('opens and closes a popup', async () => {
@@ -314,16 +320,16 @@ describe('keyboard navigation', () => {
         expect(isClosed(trigger)).to.equal(true);
       });
 
-      it("emits a click event on links and CTAs", (done) => {
-        const cta = mainNavItems[2]
-        cta.focus()
+      it('emits a click event on links and CTAs', (done) => {
+        const cta = mainNavItems[2];
+        cta.focus();
         cta.addEventListener('click', (e) => {
-          e.preventDefault()
-          done()
-        })
+          e.preventDefault();
+          done();
+        });
         sendKeys({ press: 'Enter' });
-      })  
-    })
+      });
+    });
 
     describe('Escape', () => {
       it('closes a popup', async () => {
@@ -334,15 +340,15 @@ describe('keyboard navigation', () => {
         expect(isOpen(trigger)).to.equal(true);
         await sendKeys({ press: 'Escape' });
         expect(isClosed(trigger)).to.equal(true);
-      })
-    })
+      });
+    });
   });
 
   describe('navigation that is not mainNav or popup', () => {
-    describe("Tab", () => {
-      it("cycles through the navigation if the search is open", async () => {
-        const search = document.querySelector(selectors.searchTrigger)
-        search.setAttribute('aria-expanded', 'true')
+    describe('Tab', () => {
+      it('cycles through the navigation if the search is open', async () => {
+        const search = document.querySelector(selectors.searchTrigger);
+        search.setAttribute('aria-expanded', 'true');
         const withoutBreadcrumbs = [
           ...document.querySelectorAll(`
         ${selectors.brand}, 
@@ -357,17 +363,17 @@ describe('keyboard navigation', () => {
         ];
         const first = getNextVisibleItemPosition(-1, withoutBreadcrumbs);
         const last = getPreviousVisibleItemPosition(withoutBreadcrumbs.length, withoutBreadcrumbs);
-        
-        withoutBreadcrumbs[last].focus()
-        await sendKeys({ press: 'Tab' });
-        expect(document.activeElement).to.equal(withoutBreadcrumbs[first])
-      })
-    })
 
-    describe("Shift + Tab", () => {
-      it("cycles through the navigation if the search is open", async () => {
-        const search = document.querySelector(selectors.searchTrigger)
-        search.setAttribute('aria-expanded', 'true')
+        withoutBreadcrumbs[last].focus();
+        await sendKeys({ press: 'Tab' });
+        expect(document.activeElement).to.equal(withoutBreadcrumbs[first]);
+      });
+    });
+
+    describe('Shift + Tab', () => {
+      it('cycles through the navigation if the search is open', async () => {
+        const search = document.querySelector(selectors.searchTrigger);
+        search.setAttribute('aria-expanded', 'true');
         const withoutBreadcrumbs = [
           ...document.querySelectorAll(`
         ${selectors.brand}, 
@@ -382,20 +388,19 @@ describe('keyboard navigation', () => {
         ];
         const first = getNextVisibleItemPosition(-1, withoutBreadcrumbs);
         const last = getPreviousVisibleItemPosition(withoutBreadcrumbs.length, withoutBreadcrumbs);
-        
-        withoutBreadcrumbs[first].focus()
+
+        withoutBreadcrumbs[first].focus();
         await sendKeys({ down: 'Shift' });
         await sendKeys({ press: 'Tab' });
         await sendKeys({ up: 'Shift' });
-        expect(document.activeElement).to.equal(withoutBreadcrumbs[last])
-      })
-    })
+        expect(document.activeElement).to.equal(withoutBreadcrumbs[last]);
+      });
+    });
 
     describe('ArrowRight', () => {
       it('does nothing', async () => {
-
         for await (const element of otherNavItems) {
-          if(!isElementVisible(element)) continue
+          if (!isElementVisible(element)) continue;
           element.focus();
           await sendKeys({ press: 'ArrowRight' });
           expect(document.activeElement).to.equal(element);
@@ -406,7 +411,7 @@ describe('keyboard navigation', () => {
     describe('ArrowLeft', () => {
       it('does nothing', async () => {
         for await (const element of otherNavItems) {
-          if(!isElementVisible(element)) continue
+          if (!isElementVisible(element)) continue;
           element.focus();
           await sendKeys({ press: 'ArrowLeft' });
           expect(document.activeElement).to.equal(element);
@@ -417,7 +422,7 @@ describe('keyboard navigation', () => {
     describe('ArrowUp', () => {
       it('does nothing', async () => {
         for await (const element of otherNavItems) {
-          if(!isElementVisible(element)) continue
+          if (!isElementVisible(element)) continue;
           element.focus();
           await sendKeys({ press: 'ArrowUp' });
           expect(document.activeElement).to.equal(element);
@@ -429,7 +434,7 @@ describe('keyboard navigation', () => {
       it('nothing', async () => {
         // TODO - it opens search and profile
         for await (const element of otherNavItems) {
-          if(!isElementVisible(element)) continue
+          if (!isElementVisible(element)) continue;
           element.focus();
           await sendKeys({ press: 'ArrowDown' });
           expect(document.activeElement).to.equal(element);
@@ -438,35 +443,35 @@ describe('keyboard navigation', () => {
     });
 
     describe('Space', () => {
-      it("emits a click event on links and CTAs", (done) => {
-        const search = document.querySelector(selectors.searchTrigger)
-        search.focus()
+      it('emits a click event on links and CTAs', (done) => {
+        const search = document.querySelector(selectors.searchTrigger);
+        search.focus();
         search.addEventListener('click', (e) => {
-          e.preventDefault()
-          done()
-        })
+          e.preventDefault();
+          done();
+        });
         sendKeys({ press: 'Space' });
-      })  
-    })
+      });
+    });
 
     describe('Enter', () => {
-      it("emits a click event on links and CTAs", (done) => {
-        const search = document.querySelector(selectors.searchTrigger)
-        search.focus()
+      it('emits a click event on links and CTAs', (done) => {
+        const search = document.querySelector(selectors.searchTrigger);
+        search.focus();
         search.addEventListener('click', (e) => {
-          e.preventDefault()
-          done()
-        })
+          e.preventDefault();
+          done();
+        });
         sendKeys({ press: 'Enter' });
-      })  
-    })
+      });
+    });
   });
 
   describe('popup', () => {
     let navLinks;
     let trigger;
     let triggerTwo;
-    let firstPopupItem
+    let firstPopupItem;
     beforeEach(async () => {
       [trigger, triggerTwo] = mainNavItems;
       trigger.focus();
@@ -530,7 +535,7 @@ describe('keyboard navigation', () => {
       });
 
       it('shifts focus to the previous column on RTL', async () => {
-        document.dir = "rtl"
+        document.dir = 'rtl';
         await sendKeys({ press: 'ArrowLeft' });
         expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
         await sendKeys({ press: 'ArrowRight' });
@@ -538,13 +543,13 @@ describe('keyboard navigation', () => {
       });
 
       it('shifts focus from the first popup item back to the trigger on RTL', async () => {
-        document.dir = "rtl"
+        document.dir = 'rtl';
         await sendKeys({ press: 'ArrowRight' });
         expect(document.activeElement).to.equal(trigger);
       });
 
       it('shifts focus from the second popup item back to the trigger on RTL', async () => {
-        document.dir = "rtl"
+        document.dir = 'rtl';
         triggerTwo.focus();
         keyboardNavigation.mainNav.setActive(triggerTwo);
         keyboardNavigation.mainNav.open();
@@ -579,14 +584,14 @@ describe('keyboard navigation', () => {
       });
 
       it('shifts focus to the next column on RTL', async () => {
-        document.dir = "rtl"
+        document.dir = 'rtl';
         expect(document.activeElement.innerText).to.equal('first-column-first-section-first-item');
         await sendKeys({ press: 'ArrowLeft' });
         expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
       });
 
       it('shifts focus from the last popup item back to the trigger on RTL', async () => {
-        document.dir = "rtl"
+        document.dir = 'rtl';
         navLinks[navLinks.length - 1].focus();
         await sendKeys({ press: 'ArrowLeft' });
         expect(document.activeElement).to.equal(trigger);
@@ -635,36 +640,36 @@ describe('keyboard navigation', () => {
         await sendKeys({ press: 'Escape' });
         expect(isClosed(trigger)).to.equal(true);
       });
-    })
+    });
 
     describe('Enter', () => {
       it('Emits a click event when pressing space', (done) => {
         firstPopupItem.addEventListener('click', (e) => {
-          e.preventDefault()
-          done()
-        })
-        sendKeys({ press: 'Enter' })
+          e.preventDefault();
+          done();
+        });
+        sendKeys({ press: 'Enter' });
       });
-    })
+    });
 
     describe('Space', () => {
       it('Emits a click event when pressing space', (done) => {
         firstPopupItem.addEventListener('click', (e) => {
-          e.preventDefault()
-          done()
-        })
-        sendKeys({ press: 'Space' })
+          e.preventDefault();
+          done();
+        });
+        sendKeys({ press: 'Space' });
       });
-    })
+    });
   });
 
   describe('mobile', () => {
     let navLinks;
     let trigger;
     let triggerTwo;
-    let firstPopupItem
+    let firstPopupItem;
     beforeEach(async () => {
-      setViewport({ width: 600, height: 600 })
+      setViewport({ width: 600, height: 600 });
       document.body.innerHTML = await readFile({ path: './mocks/global-nav-mobile.html' });
       keyboardNavigation = new KeyboardNavigation();
       allNavItems = [
@@ -734,7 +739,7 @@ describe('keyboard navigation', () => {
       it('shifts focus from the last popup item, to the next trigger', async () => {
         const section = navLinks[navLinks.length - 2].closest(selectors.section);
         const headline = section.querySelector(selectors.headline);
-        headline.setAttribute('aria-expanded', true)
+        headline.setAttribute('aria-expanded', true);
         navLinks[navLinks.length - 2].focus();
         await sendKeys({ press: 'Tab' });
         expect(document.activeElement).to.equal(triggerTwo);
@@ -772,7 +777,7 @@ describe('keyboard navigation', () => {
       it('shifts focus from the last popup item to the next trigger', async () => {
         const section = navLinks[navLinks.length - 2].closest(selectors.section);
         const headline = section.querySelector(selectors.headline);
-        headline.setAttribute('aria-expanded', true)
+        headline.setAttribute('aria-expanded', true);
         navLinks[navLinks.length - 2].focus();
         await sendKeys({ press: 'ArrowRight' });
         expect(document.activeElement).to.equal(triggerTwo);
@@ -846,7 +851,7 @@ describe('keyboard navigation', () => {
         document.dir = 'rtl';
         const section = navLinks[navLinks.length - 2].closest(selectors.section);
         const headline = section.querySelector(selectors.headline);
-        headline.setAttribute('aria-expanded', true)
+        headline.setAttribute('aria-expanded', true);
         navLinks[navLinks.length - 2].focus();
         await sendKeys({ press: 'ArrowLeft' });
         expect(document.activeElement).to.equal(triggerTwo);
@@ -871,7 +876,7 @@ describe('keyboard navigation', () => {
         keyboardNavigation.mainNav.open();
         await sendKeys({ press: 'ArrowUp' });
         expect(document.activeElement.innerText).to.equal('first-column-second-section-last-item');
-      })
+      });
     });
 
     describe('ArrowDown', () => {
@@ -883,7 +888,7 @@ describe('keyboard navigation', () => {
       it('shifts focus from the last popup item, to the next trigger', async () => {
         const section = navLinks[navLinks.length - 2].closest(selectors.section);
         const headline = section.querySelector(selectors.headline);
-        headline.setAttribute('aria-expanded', true)
+        headline.setAttribute('aria-expanded', true);
         navLinks[navLinks.length - 2].focus();
         await sendKeys({ press: 'ArrowDown' });
         expect(document.activeElement).to.equal(triggerTwo);
@@ -902,47 +907,46 @@ describe('keyboard navigation', () => {
 
     describe('Space', () => {
       it('opens a popup', async () => {
-        trigger.focus()
-        await sendKeys({ press: 'Space' }); 
+        trigger.focus();
+        await sendKeys({ press: 'Space' });
         expect(trigger.attributes['aria-expanded'].value).to.equal('false');
-        await sendKeys({ press: 'Space' }); 
+        await sendKeys({ press: 'Space' });
         expect(trigger.attributes['aria-expanded'].value).to.equal('true');
       });
 
-      it("emits a click event on links and CTAs", (done) => {
+      it('emits a click event on links and CTAs', (done) => {
         firstPopupItem.addEventListener('click', (e) => {
-          e.preventDefault()
-          done()
-        })
+          e.preventDefault();
+          done();
+        });
         sendKeys({ press: 'Space' });
-      }) 
-    })
+      });
+    });
 
     describe('Enter', () => {
       it('opens a popup', async () => {
-        trigger.focus()
-        await sendKeys({ press: 'Enter' }); 
+        trigger.focus();
+        await sendKeys({ press: 'Enter' });
         expect(trigger.attributes['aria-expanded'].value).to.equal('false');
-        await sendKeys({ press: 'Enter' }); 
+        await sendKeys({ press: 'Enter' });
         expect(trigger.attributes['aria-expanded'].value).to.equal('true');
       });
 
-      it("emits a click event on links and CTAs", (done) => {
+      it('emits a click event on links and CTAs', (done) => {
         firstPopupItem.addEventListener('click', (e) => {
-          e.preventDefault()
-          done()
-        })
+          e.preventDefault();
+          done();
+        });
         sendKeys({ press: 'Enter' });
-      }) 
-    })
+      });
+    });
 
     describe('Escape', async () => {
-      it("closes the popup", async () => {
-        expect(isOpen(trigger)).to.equal(true)
+      it('closes the popup', async () => {
+        expect(isOpen(trigger)).to.equal(true);
         await sendKeys({ press: 'Escape' });
-        expect(isClosed(trigger)).to.equal(true)
-      })
-    })
+        expect(isClosed(trigger)).to.equal(true);
+      });
+    });
   });
-
 });

--- a/test/blocks/global-navigation/keyboard/keyboard.test.js
+++ b/test/blocks/global-navigation/keyboard/keyboard.test.js
@@ -5,8 +5,6 @@ import KeyboardNavigation from '../../../../libs/blocks/global-navigation/utilit
 import { selectors, isElementVisible, getNextVisibleItemPosition, getPreviousVisibleItemPosition } from '../../../../libs/blocks/global-navigation/utilities/keyboard/utils.js';
 import css from '../../../../libs/blocks/global-navigation/global-navigation.css' assert { type: 'css' };
 import searchCss from '../../../../libs/blocks/global-navigation/blocks/search/gnav-search.css' assert { type: 'css' };
-import signInCss from '../../../../libs/blocks/global-navigation/blocks/profile/signIn.css' assert { type: 'css' };
-import buttonCss from '../../../../libs/blocks/global-navigation/blocks/profile/button.css' assert { type: 'css' };
 import dropdownCss from '../../../../libs/blocks/global-navigation/blocks/profile/dropdown.css' assert { type: 'css' };
 import navDropdownCss from '../../../../libs/blocks/global-navigation/blocks/navDropdown/dropdown.css' assert { type: 'css' };
 import { setViewport } from '@web/test-runner-commands';
@@ -23,7 +21,7 @@ let keyboardNavigation;
 let allNavItems;
 describe('keyboard navigation', () => {
   before(() => {
-    document.adoptedStyleSheets = [...document.adoptedStyleSheets, css, searchCss, signInCss, buttonCss, dropdownCss, navDropdownCss]
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, css, searchCss, dropdownCss, navDropdownCss]
   });
 
   beforeEach(async () => {

--- a/test/blocks/global-navigation/keyboard/mocks/global-nav-mobile.html
+++ b/test/blocks/global-navigation/keyboard/mocks/global-nav-mobile.html
@@ -118,29 +118,23 @@
                         <picture>
                           <source
                             type="image/webp"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
-                            "
+                            srcset=""
                             media="(min-width: 600px)"
                           />
                           <source
                             type="image/webp"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
-                            "
+                            srcset=""
                           />
                           <source
                             type="image/png"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
-                            "
+                            srcset=""
                             media="(min-width: 600px)"
                           />
                           <img
                             loading="lazy"
                             alt=""
                             type="image/png"
-                            src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                            src=""
                             width="52"
                             height="51"
                           />
@@ -162,29 +156,23 @@
                         <picture>
                           <source
                             type="image/webp"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
-                            "
+                            srcset=""
                             media="(min-width: 600px)"
                           />
                           <source
                             type="image/webp"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
-                            "
+                            srcset=""
                           />
                           <source
                             type="image/png"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
-                            "
+                            srcset=""
                             media="(min-width: 600px)"
                           />
                           <img
                             loading="lazy"
                             alt=""
                             type="image/png"
-                            src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                            src=""
                             width="52"
                             height="51"
                           />
@@ -218,29 +206,23 @@
                           <picture>
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                             />
                             <source
                               type="image/png"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <img
                               loading="lazy"
                               alt=""
                               type="image/png"
-                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              src=""
                               width="52"
                               height="51"
                             />
@@ -262,29 +244,23 @@
                           <picture>
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                             />
                             <source
                               type="image/png"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <img
                               loading="lazy"
                               alt=""
                               type="image/png"
-                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              src=""
                               width="52"
                               height="51"
                             />
@@ -307,29 +283,23 @@
                           <picture>
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                             />
                             <source
                               type="image/png"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <img
                               loading="lazy"
                               alt=""
                               type="image/png"
-                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              src=""
                               width="52"
                               height="51"
                             />
@@ -350,29 +320,23 @@
                           <picture>
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                             />
                             <source
                               type="image/png"
-                              srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <img
                               loading="lazy"
                               alt=""
                               type="image/png"
-                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              src=""
                               width="52"
                               height="51"
                             />
@@ -485,29 +449,23 @@
                           <picture>
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_19d04017ec658b2a785da17d565d92812077ccc08.png?width=2000&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <source
                               type="image/webp"
-                              srcset="
-                                ./media_19d04017ec658b2a785da17d565d92812077ccc08.png?width=750&amp;format=webply&amp;optimize=medium
-                              "
+                              srcset=""
                             />
                             <source
                               type="image/png"
-                              srcset="
-                                ./media_19d04017ec658b2a785da17d565d92812077ccc08.png?width=2000&amp;format=png&amp;optimize=medium
-                              "
+                              srcset=""
                               media="(min-width: 600px)"
                             />
                             <img
                               loading="lazy"
                               alt=""
                               type="image/png"
-                              src="./media_19d04017ec658b2a785da17d565d92812077ccc08.png?width=750&amp;format=png&amp;optimize=medium"
+                              src=""
                               width="375"
                               height="514"
                             />

--- a/test/blocks/global-navigation/keyboard/mocks/global-nav-mobile.html
+++ b/test/blocks/global-navigation/keyboard/mocks/global-nav-mobile.html
@@ -1,0 +1,634 @@
+<header
+  class="global-navigation has-breadcrumbs is-open"
+  daa-im="true"
+  daa-lh="gnav|feds-milo-local"
+>
+  <div class="feds-curtain is-open"></div>
+  <div class="feds-topnav-wrapper">
+    <nav class="feds-topnav" aria-label="Main">
+      <div class="feds-brand-container">
+        <button
+          class="gnav-toggle"
+          aria-label="Navigation menu"
+          aria-expanded="false"
+        ></button>
+        <a href="https://www.adobe.com/" class="feds-brand" daa-ll="Brand">
+          <span class="feds-brand-image"
+            ><img
+              src="https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/adobe-logo.svg"
+          /></span>
+          <span class="feds-brand-label">Adobe</span>
+        </a>
+      </div>
+      <div class="feds-nav-wrapper">
+        <div class="feds-breadcrumbs-wrapper">
+          <nav class="feds-breadcrumbs" aria-label="Breadcrumb">
+            <ul>
+              <li><a href="/drafts/osahin/document">Home</a></li>
+              <li><a href="https://milo.adobe.com/">Drafts</a></li>
+              <li aria-current="page">Marquee</li>
+            </ul>
+          </nav>
+        </div>
+
+        <div class="feds-search">
+          <button
+            class="feds-search-trigger"
+            aria-label="Search"
+            aria-expanded="true"
+            aria-controls="feds-search-bar"
+            daa-ll="Search"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              focusable="false"
+            >
+              <path
+                d="M14 2A8 8 0 0 0 7.4 14.5L2.4 19.4a1.5 1.5 0 0 0 2.1 2.1L9.5 16.6A8 8 0 1 0 14 2Zm0 14.1A6.1 6.1 0 1 1 20.1 10 6.1 6.1 0 0 1 14 16.1Z"
+              ></path>
+            </svg>
+            <span class="feds-search-close"></span>
+          </button>
+          <aside class="feds-search-dropdown">
+            <div class="feds-search-bar">
+              <div class="feds-search-field">
+                <input
+                  placeholder="Search"
+                  aria-label="Search"
+                  class="feds-search-input"
+                  autocomplete="off"
+                  aria-autocomplete="list"
+                  aria-controls="feds-search-results"
+                  daa-ll="search-results:standard search"
+                  spellcheck="false"
+                  data-ms-editor="true"
+                />
+                <div class="feds-search-icons">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    focusable="false"
+                  >
+                    <path
+                      d="M14 2A8 8 0 0 0 7.4 14.5L2.4 19.4a1.5 1.5 0 0 0 2.1 2.1L9.5 16.6A8 8 0 1 0 14 2Zm0 14.1A6.1 6.1 0 1 1 20.1 10 6.1 6.1 0 0 1 14 16.1Z"
+                    ></path>
+                  </svg>
+                  <button
+                    tabindex="0"
+                    class="feds-search-clear"
+                    aria-label="Clear results"
+                  ></button>
+                </div>
+              </div>
+              <ul
+                class="feds-search-results"
+                id="feds-search-results"
+                role="region"
+                daa-ll="search-results:suggested-search:click"
+              ></ul>
+            </div>
+          </aside>
+        </div>
+        <div class="feds-nav" style="padding-bottom: 64px">
+          <div
+            class="feds-navItem feds-navItem--section feds-navItem--megaMenu"
+          >
+            <a
+              href="#"
+              class="feds-navLink feds-navLink--hoverCaret"
+              role="button"
+              aria-expanded="false"
+              aria-haspopup="true"
+              daa-ll="Cloud_1-1"
+              daa-lh="header|Open"
+            >
+              Cloud
+            </a>
+            <div class="feds-popup">
+              <div class="feds-popup-content">
+                <div class="feds-popup-column">
+                  <div class="feds-popup-section">
+                    <a
+                      href="https://business.adobe.com/what-is-experience-cloud.html"
+                      class="feds-navLink"
+                      daa-ll="What_is_Creative_Cloud-1"
+                    >
+                      <div class="feds-navLink-image">
+                        <picture>
+                          <source
+                            type="image/webp"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                            "
+                            media="(min-width: 600px)"
+                          />
+                          <source
+                            type="image/webp"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                            "
+                          />
+                          <source
+                            type="image/png"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                            "
+                            media="(min-width: 600px)"
+                          />
+                          <img
+                            loading="lazy"
+                            alt=""
+                            type="image/png"
+                            src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                            width="52"
+                            height="51"
+                          />
+                        </picture>
+                      </div>
+                      <div class="feds-navLink-content">
+                        <div class="feds-navLink-title">
+                          first-column-first-section-first-item
+                        </div>
+                        <div class="feds-navLink-description">
+                        </div>
+                      </div> </a
+                    ><a
+                      href="https://business.adobe.com/what-is-experience-cloud.html"
+                      class="feds-navLink"
+                      daa-ll="Photographers-2"
+                    >
+                      <div class="feds-navLink-image">
+                        <picture>
+                          <source
+                            type="image/webp"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                            "
+                            media="(min-width: 600px)"
+                          />
+                          <source
+                            type="image/webp"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                            "
+                          />
+                          <source
+                            type="image/png"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                            "
+                            media="(min-width: 600px)"
+                          />
+                          <img
+                            loading="lazy"
+                            alt=""
+                            type="image/png"
+                            src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                            width="52"
+                            height="51"
+                          />
+                        </picture>
+                      </div>
+                      <div class="feds-navLink-content">
+                        <div class="feds-navLink-title">Photographers</div>
+                        <div class="feds-navLink-description">
+                          Lightroom, Photoshop, and more
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                  <div class="feds-popup-section">
+                    <div
+                      class="feds-popup-headline"
+                      role="heading"
+                      aria-level="2"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                    >
+                      Test heading
+                    </div>
+                    <div class="feds-popup-items">
+                      <a
+                        href="https://business.adobe.com/what-is-experience-cloud.html"
+                        class="feds-navLink"
+                        daa-ll="Students_and_Teachers-1"
+                      >
+                        <div class="feds-navLink-image">
+                          <picture>
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                              "
+                            />
+                            <source
+                              type="image/png"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <img
+                              loading="lazy"
+                              alt=""
+                              type="image/png"
+                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              width="52"
+                              height="51"
+                            />
+                          </picture>
+                        </div>
+                        <div class="feds-navLink-content">
+                          <div class="feds-navLink-title">
+                            first-column-second-section-first-item
+                          </div>
+                          <div class="feds-navLink-description">
+                          </div>
+                        </div> </a
+                      ><a
+                        href="https://business.adobe.com/what-is-experience-cloud.html"
+                        class="feds-navLink"
+                        daa-ll="Small_and_medium_business-2"
+                      >
+                        <div class="feds-navLink-image">
+                          <picture>
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                              "
+                            />
+                            <source
+                              type="image/png"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <img
+                              loading="lazy"
+                              alt=""
+                              type="image/png"
+                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              width="52"
+                              height="51"
+                            />
+                          </picture>
+                        </div>
+                        <div class="feds-navLink-content">
+                          <div class="feds-navLink-title">
+                            Small and medium business
+                          </div>
+                          <div class="feds-navLink-description">
+                            Creative apps and services for teams
+                          </div>
+                        </div> </a
+                      ><a
+                        href="https://business.adobe.com/what-is-experience-cloud.html"
+                        class="feds-navLink"
+                        daa-ll="Enterprise-3"
+                      >
+                        <div class="feds-navLink-image">
+                          <picture>
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                              "
+                            />
+                            <source
+                              type="image/png"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <img
+                              loading="lazy"
+                              alt=""
+                              type="image/png"
+                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              width="52"
+                              height="51"
+                            />
+                          </picture>
+                        </div>
+                        <div class="feds-navLink-content">
+                          <div class="feds-navLink-title">Enterprise</div>
+                          <div class="feds-navLink-description">
+                            Solutions for large organizations
+                          </div>
+                        </div> </a
+                      ><a
+                        href="https://business.adobe.com/what-is-experience-cloud.html"
+                        class="feds-navLink"
+                        daa-ll="No_subtitle-4"
+                      >
+                        <div class="feds-navLink-image">
+                          <picture>
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                              "
+                            />
+                            <source
+                              type="image/png"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <img
+                              loading="lazy"
+                              alt=""
+                              type="image/png"
+                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              width="52"
+                              height="51"
+                            />
+                          </picture>
+                        </div>
+                        <div class="feds-navLink-content">
+                          <div class="feds-navLink-title">No subtitle</div>
+                        </div>
+                      </a>
+                      <p>
+                        <a
+                          href="https://www.adobe.com/creativecloud/plans.html"
+                          daa-ll="View_plans_and_pricing-1"
+                          class="feds-navLink"
+                          >View plans and pricing</a
+                        >
+                      </p>
+                      <p>
+                        <a
+                          href="https://www.adobe.com/creativecloud/plans.html"
+                          daa-ll="And_another_link-1"
+                          class="feds-navLink"
+                          >first-column-first-section-last-item</a
+                        >
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="feds-popup-column">
+                  <div class="feds-popup-section">
+                    <div
+                      class="feds-popup-headline"
+                      role="heading"
+                      aria-level="2"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                    >
+                      Explore
+                    </div>
+                    <div class="feds-popup-items">
+                      <ul>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Photo-1"
+                            class="feds-navLink"
+                            >second-column-first-section-first-item</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Graphic_design-2"
+                            class="feds-navLink"
+                            >Graphic design</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Video-3"
+                            class="feds-navLink"
+                            >Video</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Illustration-4"
+                            class="feds-navLink"
+                            >Illustration</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="UI_and_UX-5"
+                            class="feds-navLink"
+                            >UI and UX</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Social_media-6"
+                            class="feds-navLink"
+                            >Social media</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="3D_and_AR-7"
+                            class="feds-navLink"
+                            >first-column-second-section-last-item</a
+                          >
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <div class="feds-popup-column">
+                  <div class="feds-popup-section">
+                    <div class="feds-promo-wrapper">
+                      <div class="feds-promo">
+                        <a
+                          class="feds-promo-image"
+                          href="https://www.adobe.com/"
+                        >
+                          <picture>
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_19d04017ec658b2a785da17d565d92812077ccc08.png?width=2000&amp;format=webply&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_19d04017ec658b2a785da17d565d92812077ccc08.png?width=750&amp;format=webply&amp;optimize=medium
+                              "
+                            />
+                            <source
+                              type="image/png"
+                              srcset="
+                                ./media_19d04017ec658b2a785da17d565d92812077ccc08.png?width=2000&amp;format=png&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <img
+                              loading="lazy"
+                              alt=""
+                              type="image/png"
+                              src="./media_19d04017ec658b2a785da17d565d92812077ccc08.png?width=750&amp;format=png&amp;optimize=medium"
+                              width="375"
+                              height="514"
+                            />
+                          </picture>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="feds-navItem">
+            <a
+              href="#"
+              class="feds-navLink feds-navLink--hoverCaret"
+              role="button"
+              aria-expanded="false"
+              aria-haspopup="true"
+              daa-ll="Small_Menu-2"
+              daa-lh="header|Open"
+            >
+              Small Menu
+            </a>
+            <div class="feds-popup">
+              <div class="feds-popup-content">
+                <div class="feds-popup-column">
+                  <ul>
+                    <li>
+                      <a
+                        href="https://www.adobe.com/"
+                        daa-ll="Creativity-1"
+                        class="feds-navLink"
+                        >Creativity</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="https://www.adobe.com/"
+                        daa-ll="Digital_Transformation-2"
+                        class="feds-navLink"
+                        >Digital Transformation</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="https://www.adobe.com/"
+                        daa-ll="Trends_Research-3"
+                        class="feds-navLink"
+                        >Trends &amp; Research</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="https://www.adobe.com/"
+                        daa-ll="Future_of_Work-4"
+                        class="feds-navLink"
+                        >Future of Work</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="feds-navItem feds-navItem--centered">
+            <div class="feds-cta-wrapper">
+              <a
+                href="https://www.adobe.com/"
+                class="feds-cta feds-cta--primary"
+                daa-ll="Primary-3"
+              >
+                Primary
+              </a>
+            </div>
+          </div>
+          <div class="feds-navItem feds-navItem--centered">
+            <div class="feds-cta-wrapper">
+              <a
+                href="https://www.adobe.com/"
+                class="feds-cta feds-cta--secondary"
+                daa-ll="Secondary-4"
+              >
+                Secondary
+              </a>
+            </div>
+          </div>
+          <div class="feds-navItem feds-navItem--centered">Random text</div>
+        </div>
+      </div>
+      <div class="feds-profile">
+        <a href="#" daa-ll="Sign In" class="feds-signIn">Sign In</a>
+      </div>
+      <a
+        href="https://www.adobe.com/"
+        class="gnav-logo"
+        aria-label="Adobe"
+        daa-ll="Logo"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.46 118.11">
+          <defs>
+            <style>
+              .cls-1 {
+                fill: #fa0f00;
+              }
+            </style>
+          </defs>
+          <polygon
+            class="cls-1"
+            points="84.13 0 133.46 0 133.46 118.11 84.13 0"
+          ></polygon>
+          <polygon
+            class="cls-1"
+            points="49.37 0 0 0 0 118.11 49.37 0"
+          ></polygon>
+          <polygon
+            class="cls-1"
+            points="66.75 43.53 98.18 118.11 77.58 118.11 68.18 94.36 45.18 94.36 66.75 43.53"
+          ></polygon>
+        </svg>
+      </a>
+    </nav>
+  </div>
+</header>

--- a/test/blocks/global-navigation/keyboard/mocks/global-nav.html
+++ b/test/blocks/global-navigation/keyboard/mocks/global-nav.html
@@ -1,0 +1,560 @@
+<header
+  class="global-navigation has-breadcrumbs"
+  daa-im="true"
+  daa-lh="gnav|feds-milo-local"
+>
+  <div class="feds-curtain"></div>
+  <div class="feds-topnav-wrapper">
+    <nav class="feds-topnav" aria-label="Main">
+      <div class="feds-brand-container">
+        <button
+          class="gnav-toggle"
+          aria-label="Navigation menu"
+          aria-expanded="false"
+        ></button>
+        <a href="https://www.adobe.com/" class="feds-brand" daa-ll="Brand">
+          <span class="feds-brand-image"
+            ><img
+              src="https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/adobe-logo.svg"
+          /></span>
+          <span class="feds-brand-label">Adobe</span>
+        </a>
+      </div>
+      <div class="feds-nav-wrapper">
+        <div class="feds-nav">
+          <div
+            class="feds-navItem feds-navItem--section feds-navItem--megaMenu"
+          >
+            <a
+              href="#"
+              class="feds-navLink feds-navLink--hoverCaret"
+              role="button"
+              aria-expanded="false"
+              aria-haspopup="true"
+              daa-ll="Cloud-1"
+              daa-lh="header|Open"
+            >
+              Cloud
+            </a>
+            <div class="feds-popup">
+              <div class="feds-popup-content">
+                <div class="feds-popup-column">
+                  <div class="feds-popup-section">
+                    <a
+                      href="https://business.adobe.com/what-is-experience-cloud.html"
+                      class="feds-navLink"
+                      daa-ll="What_is_Creative_Cloud-1"
+                    >
+                      <div class="feds-navLink-image">
+                        <picture>
+                          <source
+                            type="image/webp"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                            "
+                            media="(min-width: 600px)"
+                          />
+                          <source
+                            type="image/webp"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                            "
+                          />
+                          <source
+                            type="image/png"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                            "
+                            media="(min-width: 600px)"
+                          />
+                          <img
+                            loading="lazy"
+                            alt=""
+                            type="image/png"
+                            src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                            width="52"
+                            height="51"
+                          />
+                        </picture>
+                      </div>
+                      <div class="feds-navLink-content">
+                        <div class="feds-navLink-title">
+                          first-column-first-section-first-item
+                        </div>
+                        <div class="feds-navLink-description">
+                          
+                        </div>
+                      </div> </a
+                    ><a
+                      href="https://business.adobe.com/what-is-experience-cloud.html"
+                      class="feds-navLink"
+                      daa-ll="Photographers-2"
+                    >
+                      <div class="feds-navLink-image">
+                        <picture>
+                          <source
+                            type="image/webp"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                            "
+                            media="(min-width: 600px)"
+                          />
+                          <source
+                            type="image/webp"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                            "
+                          />
+                          <source
+                            type="image/png"
+                            srcset="
+                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                            "
+                            media="(min-width: 600px)"
+                          />
+                          <img
+                            loading="lazy"
+                            alt=""
+                            type="image/png"
+                            src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                            width="52"
+                            height="51"
+                          />
+                        </picture>
+                      </div>
+                      <div class="feds-navLink-content">
+                        <div class="feds-navLink-title">Photographers</div>
+                        <div class="feds-navLink-description">
+                          Lightroom, Photoshop, and more
+                        </div>
+                      </div>
+                    </a>
+                  </div>
+                  <div class="feds-popup-section">
+                    <div
+                      class="feds-popup-headline"
+                      role="heading"
+                      aria-level="2"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                    >
+                      Test heading
+                    </div>
+                    <div class="feds-popup-items">
+                      <a
+                        href="https://business.adobe.com/what-is-experience-cloud.html"
+                        class="feds-navLink"
+                        daa-ll="Students_and_Teachers-1"
+                      >
+                        <div class="feds-navLink-image">
+                          <picture>
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                              "
+                            />
+                            <source
+                              type="image/png"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <img
+                              loading="lazy"
+                              alt=""
+                              type="image/png"
+                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              width="52"
+                              height="51"
+                            />
+                          </picture>
+                        </div>
+                        <div class="feds-navLink-content">
+                          <div class="feds-navLink-title">
+                            first-column-second-section-first-item
+                          </div>
+                          <div class="feds-navLink-description">
+                          </div>
+                        </div> </a
+                      ><a
+                        href="https://business.adobe.com/what-is-experience-cloud.html"
+                        class="feds-navLink"
+                        daa-ll="Small_and_medium_business-2"
+                      >
+                        <div class="feds-navLink-image">
+                          <picture>
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                              "
+                            />
+                            <source
+                              type="image/png"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <img
+                              loading="lazy"
+                              alt=""
+                              type="image/png"
+                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              width="52"
+                              height="51"
+                            />
+                          </picture>
+                        </div>
+                        <div class="feds-navLink-content">
+                          <div class="feds-navLink-title">
+                            Small and medium business
+                          </div>
+                          <div class="feds-navLink-description">
+                            Creative apps and services for teams
+                          </div>
+                        </div> </a
+                      ><a
+                        href="https://business.adobe.com/what-is-experience-cloud.html"
+                        class="feds-navLink"
+                        daa-ll="Enterprise-3"
+                      >
+                        <div class="feds-navLink-image">
+                          <picture>
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                              "
+                            />
+                            <source
+                              type="image/png"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <img
+                              loading="lazy"
+                              alt=""
+                              type="image/png"
+                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              width="52"
+                              height="51"
+                            />
+                          </picture>
+                        </div>
+                        <div class="feds-navLink-content">
+                          <div class="feds-navLink-title">Enterprise</div>
+                          <div class="feds-navLink-description">
+                            Solutions for large organizations
+                          </div>
+                        </div> </a
+                      ><a
+                        href="https://business.adobe.com/what-is-experience-cloud.html"
+                        class="feds-navLink"
+                        daa-ll="No_subtitle-4"
+                      >
+                        <div class="feds-navLink-image">
+                          <picture>
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <source
+                              type="image/webp"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                              "
+                            />
+                            <source
+                              type="image/png"
+                              srcset="
+                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                              "
+                              media="(min-width: 600px)"
+                            />
+                            <img
+                              loading="lazy"
+                              alt=""
+                              type="image/png"
+                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              width="52"
+                              height="51"
+                            />
+                          </picture>
+                        </div>
+                        <div class="feds-navLink-content">
+                          <div class="feds-navLink-title">No subtitle</div>
+                        </div>
+                      </a>
+                      <p>
+                        <a
+                          href="https://www.adobe.com/creativecloud/plans.html"
+                          daa-ll="View_plans_and_pricing-1"
+                          class="feds-navLink"
+                          >View plans and pricing</a
+                        >
+                      </p>
+                      <p>
+                        <a
+                          href="https://www.adobe.com/creativecloud/plans.html"
+                          daa-ll="And_another_link-1"
+                          class="feds-navLink"
+                          >And another link</a
+                        >
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="feds-popup-column">
+                  <div class="feds-popup-section">
+                    <div
+                      class="feds-popup-headline"
+                      role="heading"
+                      aria-level="2"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                    >
+                      Explore
+                    </div>
+                    <div class="feds-popup-items">
+                      <ul>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Photo-1"
+                            class="feds-navLink"
+                            >second-column-first-section-first-item</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Graphic_design-2"
+                            class="feds-navLink"
+                            >Graphic design</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Video-3"
+                            class="feds-navLink"
+                            >Video</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Illustration-4"
+                            class="feds-navLink"
+                            >Illustration</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="UI_and_UX-5"
+                            class="feds-navLink"
+                            >UI and UX</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="Social_media-6"
+                            class="feds-navLink"
+                            >Social media</a
+                          >
+                        </li>
+                        <li>
+                          <a
+                            href="http://google.com/"
+                            daa-ll="3D_and_AR-7"
+                            class="feds-navLink"
+                            >3D and AR</a
+                          >
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="feds-navItem">
+            <a
+              href="#"
+              class="feds-navLink feds-navLink--hoverCaret"
+              role="button"
+              aria-expanded="false"
+              aria-haspopup="true"
+              daa-ll="Small_Menu-2"
+              daa-lh="header|Open"
+            >
+              Small Menu
+            </a>
+            <div class="feds-popup">
+              <div class="feds-popup-content">
+                <div class="feds-popup-column">
+                  <ul>
+                    <li>
+                      <a
+                        href="https://www.adobe.com/"
+                        daa-ll="Creativity-1"
+                        class="feds-navLink"
+                        >Creativity</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="https://www.adobe.com/"
+                        daa-ll="Digital_Transformation-2"
+                        class="feds-navLink"
+                        >Digital Transformation</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="https://www.adobe.com/"
+                        daa-ll="Trends_Research-3"
+                        class="feds-navLink"
+                        >Trends &amp; Research</a
+                      >
+                    </li>
+                    <li>
+                      <a
+                        href="https://www.adobe.com/"
+                        daa-ll="Future_of_Work-4"
+                        class="feds-navLink"
+                        >Future of Work</a
+                      >
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="feds-navItem feds-navItem--centered">
+            <div class="feds-cta-wrapper">
+              <a
+                href="https://www.adobe.com/"
+                class="feds-cta feds-cta--primary"
+                daa-ll="Primary-3"
+              >
+                Primary
+              </a>
+            </div>
+          </div>
+          <div class="feds-navItem feds-navItem--centered">
+            <div class="feds-cta-wrapper">
+              <a
+                href="https://www.adobe.com/"
+                class="feds-cta feds-cta--secondary"
+                daa-ll="Secondary-4"
+              >
+                Secondary
+              </a>
+            </div>
+          </div>
+          <div class="feds-navItem feds-navItem--centered">Random text</div>
+        </div>
+        <div class="feds-search">
+          <button
+            class="feds-search-trigger"
+            aria-label="Search"
+            aria-expanded="false"
+            aria-controls="feds-search-bar"
+            daa-ll="Search"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              focusable="false"
+            >
+              <path
+                d="M14 2A8 8 0 0 0 7.4 14.5L2.4 19.4a1.5 1.5 0 0 0 2.1 2.1L9.5 16.6A8 8 0 1 0 14 2Zm0 14.1A6.1 6.1 0 1 1 20.1 10 6.1 6.1 0 0 1 14 16.1Z"
+              ></path>
+            </svg>
+            <span class="feds-search-close"></span>
+          </button>
+        </div>
+      </div>
+      <div class="feds-profile"><a href="#" daa-ll="Sign In" class="feds-signIn" role="button" aria-expanded="false" aria-haspopup="true">Sign In</a><div class="feds-signIn-dropdown">
+        <div>
+          <ul>
+            <li><a href="https://experiencecloud.adobe.com/exc-content/login.html">Experience Cloud</a></li>
+            <li><a href="https://account.magento.com/customer/account/login">Commerce (Magento)</a></li>
+            <li><a href="https://login.marketo.com/">Marketo Engage</a></li>
+            <li><a href="https://business.adobe.com/products/workfront/login.html">Workfront</a></li>
+            <li><a href="https://adobe.com?sign-in=true">Adobe Account</a></li>
+          </ul>
+        </div>
+      </div></div>
+      <a
+        href="https://www.adobe.com/"
+        class="gnav-logo"
+        aria-label="Adobe"
+        daa-ll="Logo"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.46 118.11">
+          <defs>
+            <style>
+              .cls-1 {
+                fill: #fa0f00;
+              }
+            </style>
+          </defs>
+          <polygon
+            class="cls-1"
+            points="84.13 0 133.46 0 133.46 118.11 84.13 0"
+          ></polygon>
+          <polygon
+            class="cls-1"
+            points="49.37 0 0 0 0 118.11 49.37 0"
+          ></polygon>
+          <polygon
+            class="cls-1"
+            points="66.75 43.53 98.18 118.11 77.58 118.11 68.18 94.36 45.18 94.36 66.75 43.53"
+          ></polygon>
+        </svg>
+      </a>
+    </nav>
+    <div class="feds-breadcrumbs-wrapper">
+      <nav class="feds-breadcrumbs" aria-label="Breadcrumb">
+        <ul>
+          <li><a href="/drafts/osahin/document">Home</a></li>
+          <li><a href="https://milo.adobe.com/">Drafts</a></li>
+          <li aria-current="page">Marquee</li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</header>

--- a/test/blocks/global-navigation/keyboard/mocks/global-nav.html
+++ b/test/blocks/global-navigation/keyboard/mocks/global-nav.html
@@ -49,29 +49,23 @@
                         <picture>
                           <source
                             type="image/webp"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
-                            "
+                            srcset=""
                             media="(min-width: 600px)"
                           />
                           <source
                             type="image/webp"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
-                            "
+                            srcset=""
                           />
                           <source
                             type="image/png"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
-                            "
+                            srcset=""
                             media="(min-width: 600px)"
                           />
                           <img
                             loading="lazy"
                             alt=""
                             type="image/png"
-                            src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                            src=""
                             width="52"
                             height="51"
                           />
@@ -94,29 +88,23 @@
                         <picture>
                           <source
                             type="image/webp"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
-                            "
+                            srcset=""
                             media="(min-width: 600px)"
                           />
                           <source
                             type="image/webp"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
-                            "
+                            srcset=""
                           />
                           <source
                             type="image/png"
-                            srcset="
-                              ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
-                            "
+                            srcset=""
                             media="(min-width: 600px)"
                           />
                           <img
                             loading="lazy"
                             alt=""
                             type="image/png"
-                            src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                            src=""
                             width="52"
                             height="51"
                           />
@@ -151,20 +139,20 @@
                             <source
                               type="image/webp"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                                
                               "
                               media="(min-width: 600px)"
                             />
                             <source
                               type="image/webp"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                                
                               "
                             />
                             <source
                               type="image/png"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                                
                               "
                               media="(min-width: 600px)"
                             />
@@ -172,7 +160,7 @@
                               loading="lazy"
                               alt=""
                               type="image/png"
-                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              src=""
                               width="52"
                               height="51"
                             />
@@ -195,20 +183,20 @@
                             <source
                               type="image/webp"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                                
                               "
                               media="(min-width: 600px)"
                             />
                             <source
                               type="image/webp"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                                
                               "
                             />
                             <source
                               type="image/png"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                                
                               "
                               media="(min-width: 600px)"
                             />
@@ -216,7 +204,7 @@
                               loading="lazy"
                               alt=""
                               type="image/png"
-                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              src=""
                               width="52"
                               height="51"
                             />
@@ -240,20 +228,20 @@
                             <source
                               type="image/webp"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                                
                               "
                               media="(min-width: 600px)"
                             />
                             <source
                               type="image/webp"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                                
                               "
                             />
                             <source
                               type="image/png"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                                
                               "
                               media="(min-width: 600px)"
                             />
@@ -261,7 +249,7 @@
                               loading="lazy"
                               alt=""
                               type="image/png"
-                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              src=""
                               width="52"
                               height="51"
                             />
@@ -283,20 +271,20 @@
                             <source
                               type="image/webp"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=webply&amp;optimize=medium
+                                
                               "
                               media="(min-width: 600px)"
                             />
                             <source
                               type="image/webp"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=webply&amp;optimize=medium
+                                
                               "
                             />
                             <source
                               type="image/png"
                               srcset="
-                                ./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=2000&amp;format=png&amp;optimize=medium
+                                
                               "
                               media="(min-width: 600px)"
                             />
@@ -304,7 +292,7 @@
                               loading="lazy"
                               alt=""
                               type="image/png"
-                              src="./media_171222f137180f0ce50fa69a74f645addc0382249.png?width=750&amp;format=png&amp;optimize=medium"
+                              src=""
                               width="52"
                               height="51"
                             />


### PR DESCRIPTION
### Description
This brings the keyboard navigation feature that current exists in AEM to the milo feds-gnav. This has been a hard requirement for the AEM-Feds-GNAV in the past for accessibility reasons, which is why we need to port this to the milo navigation. Resolves: [MWPW-125255](https://jira.corp.adobe.com/browse/MWPW-125255)

### Feature
A few of the notable use-cases
- RTL support
- Shift+Tab support
- Cycle through the navigation if the search is open
- Close any open menu when you open a new one (E.g. only search OR profile OR a popup can be open)
- Arrow key support on the main nav & popups, also on mobile
- enter/space/escape keys should work on any element now
- In total ~80 test cases based on the old implementation which had a lot of back and forth with the accessibility team, there's a lot of small use-cases - so we ported those use-cases.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ramuntea/prev/gnav-refactor?martech=off
- After: https://keyboard-support--milo--adobecom.hlx.page/drafts/ramuntea/gnav-refactor?martech=off#
