### PR TITLE
MWPW-129567: $batch API usage replaced in FG

### DIFF
--- a/tools/floodgate/js/floodgate.js
+++ b/tools/floodgate/js/floodgate.js
@@ -22,7 +22,7 @@ async function reloadProject() {
 
 async function refreshPage(config, projectDetail, project) {
   // Inject Sharepoint file metadata
-  loadingON('Updating Project with the Sharepoint Docs Data...');
+  loadingON('Updating Project with the Sharepoint Docs Data... please wait');
   await updateProjectWithDocs(projectDetail);
 
   // Render the data on the page

--- a/tools/floodgate/js/project.js
+++ b/tools/floodgate/js/project.js
@@ -8,7 +8,7 @@ import {
   getHelixAdminApiUrl,
   readProjectFile,
 } from '../../loc/project.js';
-import { getSpFiles } from '../../loc/sharepoint.js';
+import { getFilesData } from '../../loc/sharepoint.js';
 import { getDocPathFromUrl, getFloodgateUrl } from './utils.js';
 
 let project;
@@ -22,25 +22,27 @@ const PROJECT_STATUS = {
 /**
  * Makes the sharepoint file data part of `projectDetail` per URL.
  */
-function injectSharepointData(projectUrls, filePaths, docPaths, spBatchFiles, isFloodgate) {
-  spBatchFiles.forEach((spFiles) => {
-    if (!spFiles?.responses) return;
-    spFiles.responses.forEach(({ id, status, body }) => {
-      const filePath = docPaths[id];
-      const fileBody = status === 200 ? body : {};
-      const urls = filePaths.get(filePath);
-      urls.forEach((key) => {
-        const urlObjVal = projectUrls.get(key);
-        if (isFloodgate) {
-          urlObjVal.doc.fg.sp = fileBody;
-          urlObjVal.doc.fg.sp.status = status;
-        } else {
-          urlObjVal.doc.sp = fileBody;
-          urlObjVal.doc.sp.status = status;
-        }
-      });
+function injectSharepointData(projectUrls, filePaths, docPaths, spFiles, isFloodgate) {
+  for (let i = 0; i < spFiles.length; i += 1) {
+    let fileBody = {};
+    let status = 404;
+    if (!spFiles[i].error) {
+      fileBody = spFiles[i];
+      status = 200;
+    }
+    const filePath = docPaths[i];
+    const urls = filePaths.get(filePath);
+    urls.forEach((key) => {
+      const urlObjVal = projectUrls.get(key);
+      if (isFloodgate) {
+        urlObjVal.doc.fg.sp = fileBody;
+        urlObjVal.doc.fg.sp.status = status;
+      } else {
+        urlObjVal.doc.sp = fileBody;
+        urlObjVal.doc.sp.status = status;
+      }
     });
-  });
+  }
 }
 
 async function updateProjectWithDocs(projectDetail) {
@@ -49,10 +51,10 @@ async function updateProjectWithDocs(projectDetail) {
   }
   const { filePaths } = projectDetail;
   const docPaths = [...filePaths.keys()];
-  const spBatchFiles = await getSpFiles(docPaths);
-  injectSharepointData(projectDetail.urls, filePaths, docPaths, spBatchFiles);
-  const fgSpBatchFiles = await getSpFiles(docPaths, true);
-  injectSharepointData(projectDetail.urls, filePaths, docPaths, fgSpBatchFiles, true);
+  const spFiles = await getFilesData(docPaths);
+  injectSharepointData(projectDetail.urls, filePaths, docPaths, spFiles);
+  const fgSpFiles = await getFilesData(docPaths, true);
+  injectSharepointData(projectDetail.urls, filePaths, docPaths, fgSpFiles, true);
 }
 
 async function initProject() {

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -168,17 +168,17 @@ async function getSpFiles(filePaths, isFloodgate) {
   return Promise.all(spFileResponses.map((file) => file.json()));
 }
 
+async function getFileData(filePath, isFloodgate) {
+  validateConnection();
+  const { sp } = isFloodgate ? await getFloodgateConfig() : await getConfig();
+  const options = getAuthorizedRequestOption();
+  const baseURI = isFloodgate ? sp.api.directory.create.fgBaseURI : sp.api.directory.create.baseURI;
+  const resp = await fetchWithRetry(`${baseURI}${filePath}`, options);
+  const json = await resp.json();
+  return json;
+}
+
 async function getFilesData(filePaths, isFloodgate) {
-
-  async function getFileData(filePath, isFloodgate) {
-    validateConnection();
-    const { sp } = isFloodgate ? await getFloodgateConfig() : await getConfig();
-    const options = getAuthorizedRequestOption();
-    const baseURI = isFloodgate ? sp.api.directory.create.fgBaseURI : sp.api.directory.create.baseURI;
-    const resp = await fetchWithRetry(`${baseURI}${filePath}`, options);
-    return await resp.json();
-  }
-
   const batchArray = [];
   for (let i = 0; i < filePaths.length; i += BATCH_REQUEST_LIMIT) {
     const arrayChunk = filePaths.slice(i, i + BATCH_REQUEST_LIMIT);

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -14,6 +14,7 @@ import { getConfig as getFloodgateConfig } from '../floodgate/js/config.js';
 
 let accessToken;
 const BATCH_REQUEST_LIMIT = 20;
+const BATCH_DELAY_TIME = 200;
 
 const getAccessToken = () => accessToken;
 
@@ -191,7 +192,7 @@ async function getFilesData(filePaths, isFloodgate) {
       batchArray[i].map((file) => getFileData(file, isFloodgate)),
     ));
     // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, BATCH_DELAY_TIME));
   }
   return fileJsonResp;
 }


### PR DESCRIPTION
* MS's $batch API did not provide much benefit and error handling with RateLimit headers/429 is complex given how the responses are structured
* Updated to use custom batching similar to how copy/promote is currently done


Resolves: [MWPW-129567](https://jira.corp.adobe.com/browse/MWPW-129567)

**Test URLs:**
- Before: [https://main--milo--adobecom.hlx.page/tools/floodgate/index.html](https://main--milo--adobecom.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B2A168441-F440-4552-A195-90CB12A418A0%257D%26file%3Ddemo-fg.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue)

- After: [https://main--milo--sukamat.hlx.page/tools/floodgate/index.html](https://main--milo--sukamat.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B2A168441-F440-4552-A195-90CB12A418A0%257D%26file%3Ddemo-fg.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue)
