### PR TITLE
Tabs bug: minor style color format fix

### DIFF
--- a/libs/blocks/tabs/tabs.css
+++ b/libs/blocks/tabs/tabs.css
@@ -7,7 +7,7 @@
   --tabs-active-text-color: #2C2C2C;
   --tabs-bg-color: #f1f1f1;
   --tabs-active-bg-color: #fff;
-  --tabs-list-bg-gradient: linear-gradient(rgb(255 255 255 / 0%) 60%, rgb(245 245 245 / .8%));
+  --tabs-list-bg-gradient: linear-gradient(rgb(255 255 255 / 0%) 60%, rgb(245 245 245 / 80%));
 }
 
 :root .dark {
@@ -16,7 +16,7 @@
   --tabs-active-text-color: #fff;
   --tabs-bg-color: #1a1a1a;
   --tabs-active-bg-color: #111;
-  --tabs-list-bg-gradient: linear-gradient(rgb(0 0 0 / 0%) 60%, rgb(0 0 0 / .8%));
+  --tabs-list-bg-gradient: linear-gradient(rgb(0 0 0 / 0%) 60%, rgb(0 0 0 / 80%));
 }
 
 .tabs {


### PR DESCRIPTION

* Addressed tabs style bug. `tabs.css` variable had an incorrect modern color format. 

There was some css linting clean up in the last PR and this was overlooked. 

Resolves: [MWPW-129763](https://jira.corp.adobe.com/browse/MWPW-129763)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/tabs?martech=off
- After: https://rparrish-tabs-style-bug--milo--adobecom.hlx.page/docs/library/blocks/tabs?martech=off

Testing note: Notice the subtle gradient in the tab-list background color on the after url. 
