### PR TITLE
Use Milo 'decorateLinks' for Gnav dropdown content

### DIFF
--- a/libs/blocks/global-navigation/blocks/navDropdown/dropdown.js
+++ b/libs/blocks/global-navigation/blocks/navDropdown/dropdown.js
@@ -1,5 +1,5 @@
 import { getAnalyticsValue, toFragment, decorateCta } from '../../utilities/utilities.js';
-import { localizeLink } from '../../../../utils/utils.js';
+import { decorateLinks } from '../../../../utils/utils.js';
 
 const decorateHeadline = (elem) => {
   if (!(elem instanceof HTMLElement)) return null;
@@ -50,7 +50,7 @@ const decorateLinkGroup = (elem, index) => {
       ${descriptionElem}
     </div>` : '';
   const linkGroup = toFragment`<a 
-    href="${localizeLink(link.href)}"
+    href="${link.href}"
     class="feds-navLink"
     daa-ll="${getAnalyticsValue(link.textContent, index)}">
       ${imageElem}
@@ -90,7 +90,7 @@ const decoratePromo = (elem) => {
     let promoImageElem;
 
     if (linkElem instanceof HTMLElement) {
-      promoImageElem = toFragment`<a class="feds-promo-image" href="${localizeLink(linkElem.href)}">
+      promoImageElem = toFragment`<a class="feds-promo-image" href="${linkElem.href}">
           ${imageElem}
         </a>`;
     } else {
@@ -135,22 +135,27 @@ const decoratePopupElement = (elem, index) => {
     decoratedElem = decorateLinkGroup(elem, index);
   }
 
-  // Decorate Primary CTA
-  if (!elem.classList.contains('gnav-promo')
-   && elem.querySelector('strong > a')) {
-    decoratedElem = decorateCta({ elem, index });
-  }
+  if (!elem.classList.contains('gnav-promo')) {
+    // Decorate Primary CTA
+    const primaryCta = elem.querySelector('strong > a');
 
-  // Decorate Secondary CTA
-  if (!elem.classList.contains('gnav-promo')
-   && elem.querySelector('em > a')) {
-    decoratedElem = decorateCta({ elem, type: 'secondaryCta', index });
+    if (primaryCta) {
+      decoratedElem = decorateCta({ elem: primaryCta, index });
+    }
+
+    // Decorate Secondary CTA
+    const secondaryCta = elem.querySelector('em > a');
+
+    if (secondaryCta) {
+      decoratedElem = decorateCta({ elem: secondaryCta, type: 'secondaryCta', index });
+    }
   }
 
   return decoratedElem;
 };
 
 const decorateColumns = (content) => {
+  decorateLinks(content);
   const hasMultipleColumns = content.children.length > 1;
 
   // The resulting template structure should follow these rules:
@@ -249,7 +254,7 @@ const decorateDropdown = async (config) => {
   if (config.type === 'asyncDropdownTrigger') {
     const pathElement = config.item.querySelector('a');
     if (!(pathElement instanceof HTMLElement)) return;
-    const path = localizeLink(pathElement.href);
+    const path = pathElement.href;
 
     const res = await fetch(`${path}.plain.html`);
     if (res.status !== 200) return;

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -1,4 +1,4 @@
-import { getConfig, localizeLink } from '../../../utils/utils.js';
+import { getConfig } from '../../../utils/utils.js';
 
 export function toFragment(htmlStrings, ...values) {
   const templateStr = htmlStrings.reduce((acc, htmlString, index) => {
@@ -56,7 +56,7 @@ export function decorateCta({ elem, type = 'primaryCta', index } = {}) {
   return toFragment`
     <div class="feds-cta-wrapper">
       <a 
-        href="${localizeLink(elem.href)}"
+        href="${elem.href}"
         class="feds-cta feds-cta--${modifier}"
         daa-ll="${getAnalyticsValue(elem.textContent, index)}">
           ${elem.textContent}


### PR DESCRIPTION
This implements feedback from the larger Gnav PR, https://github.com/adobecom/milo/pull/601.

The suggestion was to use `loadArea` for content fetched to render the navigation; however, the Global Navigation uses its own set of blocks, different than Milo's, thus that was not possible for the time being. For now, we're calling `decorateLinks` from Milo, which handles link localisation, setting `target` attribute values, etc.

After our MVP deadline, we'd like to perform some due diligence to assess the feasibility of moving the Global Navigation code under its own project to make the most out of what Franklin / Milo have to offer.

Resolves: [MWPW-128666](https://jira.corp.adobe.com/browse/MWPW-128666) 

**Test URLs:**
- Before: https://gnav--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
- After: https://use-decoratelinks-in-gnav-dropdowns--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor
