### PR TITLE
MWPW-129798-Fix image stretch issue in fragment

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -137,7 +137,7 @@ img {
 
 /* Not blocks */
 div:not([class]) > div > div img[src^="./media_"] {
-  width: 100%;
+  max-width: 100%;
 }
 
 .container {


### PR DESCRIPTION
* Fixes the issue of images in fragments getting stretched on a page

Resolves: [MWPW-129798](https://jira.corp.adobe.com/browse/MWPW-129798)

**Test URLs:**
Milo

- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/fragment-test?martech=off
- After: https://mwpw-129798-image-stretch-issue--milo--adobecom.hlx.page/drafts/ruchika/fragment-test?martech=off

CC

- Before: https://main--cc--adobecom.hlx.page/drafts/tkato/test-cc-overview?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/tkato/test-cc-overview?milolibs=MWPW-129798-image-stretch-issue&martech=off
