### PR TITLE
Correctly parse profile data for global-navigation

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -271,7 +271,7 @@ class Gnav {
       return;
     }
 
-    const [{ sections, user: { avatar } }] = await profileData.json();
+    const { sections, user: { avatar } } = await profileData.json();
 
     this.blocks.profile.buttonElem = await decorateProfileTrigger({ avatar });
     decoratedElem.append(this.blocks.profile.buttonElem);


### PR DESCRIPTION
### Description
Fixes a JS error for logged in users 
```
global-navigation.js:268 Uncaught (in promise) TypeError: (intermediate value) is not iterable
    at Gnav.decorateProfile (global-navigation.js:268:46)
```

Resolves: No ticket was raised

### How to test
Log in with a stage account and observe the profile missing on the main branch.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ramuntea/gnav-refactor?martech=off#
- After: https://gnav--milo--adobecom.hlx.page/drafts/ramuntea/gnav-refactor?martech=off#
