### PR TITLE
con-button styles have bad defaults

### DIFF
--- a/libs/styles/typography.css
+++ b/libs/styles/typography.css
@@ -162,8 +162,8 @@
 }
 
 .dark .con-button {
-  border-color: #fff;
-  color: #fff;
+  border-color: var(--color-white);
+  color: var(--color-white);
 }
 
 .light .con-button {
@@ -179,15 +179,15 @@
 }
 
 .dark .con-button:hover {
-  background-color: #fff;
-  color: #000;
+  background-color: var(--color-white);
+  color: var(--color-black);
   text-decoration: none;
 }
 
 .con-button.blue {
   background: var(--color-accent);
   border-color: var(--color-accent);
-  color: #FFF;
+  color: var(--color-white);
 }
 
 .con-button.blue:hover,
@@ -199,26 +199,26 @@
 .con-button.fill {
   background: var(--text-color);
   border-color: var(--text-color);
-  color: #fff;
+  color: var(--color-white);
 }
 
 .con-button.fill:hover,
 .con-button.fill:active {
-  background: #000;
-  border-color: #000;
+  background: var(--color-black);
+  border-color: var(--color-black);
 }
 
 .dark .con-button.fill {
-  background: #fff;
-  border-color: #fff;
+  background: var(--color-white);
+  border-color: var(--color-white);
   color: var(--text-color);
 }
 
 .dark .con-button.fill:hover,
 .dark .con-button.fill:active {
-  background: #fff;
-  border-color: #fff;
-  color: #000;
+  background: var(--color-white);
+  border-color: var(--color-white);
+  color: var(--color-black);
 }
 
 svg.icon-milo, img.icon-milo {

--- a/libs/styles/typography.css
+++ b/libs/styles/typography.css
@@ -114,38 +114,44 @@
 .detail-l,
 .detail-m,
 .detail-s {
-  text-transform: uppercase;
   font-weight: 700;
+  text-transform: uppercase;
 }
 
 .con-button {
-  color: #FFF;
-  border: 2px solid;
   background-color: transparent;
   border-radius: 16px;
+  border: 2px solid var(--text-color);
+  color: var(--text-color);
   display: inline-block;
-  padding: 5px 14px;
-  text-decoration: none;
   font-size: 15px;
-  line-height: 16px;
   font-style: normal;
   font-weight: 700;
+  line-height: 16px;
+  padding: 5px 14px;
+  text-decoration: none;
+}
+
+.con-button:hover {
+  background-color: var(--color-black);
+  color: var(--color-white);
+  text-decoration: none;
 }
 
 .con-button.button-l {
-  padding: 7px 18px 8px;
-  line-height: 20px;
   border-radius: 20px;
   font-size: 17px;
+  line-height: 20px;
   min-height: 21px;
+  padding: 7px 18px 8px;
 }
 
 .con-button.button-xl {
-  padding: 10px 24px 8px;
-  line-height: 24px;
   border-radius: 25px;
   font-size: 19px;
+  line-height: 24px;
   min-height: 28px;
+  padding: 10px 24px 8px;
 }
 
 .con-button.button-justified {
@@ -154,14 +160,33 @@
   width: 100%;
 }
 
+.dark .con-button {
+  border-color: #fff;
+  color: #fff;
+}
+
 .light .con-button {
+  color: var(--text-color);
+  border-color: var(--text-color);
+}
+
+.light .con-button:hover,
+.light .con-button:active  {
+  background-color: var(--color-black);
+  border-color: var(--color-black);
+  color: var(--color-white);
+}
+
+.dark .con-button:hover {
+  background-color: #fff;
   color: #000;
+  text-decoration: none;
 }
 
 .con-button.blue {
-  color: #FFF;
   background: var(--color-accent);
-  border: 2px solid var(--color-accent);
+  border-color: var(--color-accent);
+  color: #FFF;
 }
 
 .con-button.blue:hover,
@@ -170,14 +195,10 @@
   border-color: var(--color-accent-hover);
 }
 
-.con-button.blue:hover {
-  text-decoration: none;
-}
-
 .con-button.fill {
-  color: #fff;
   background: var(--text-color);
-  border: 2px solid var(--text-color);
+  border-color: var(--text-color);
+  color: #fff;
 }
 
 .con-button.fill:hover,
@@ -186,56 +207,31 @@
   border-color: #000;
 }
 
-.con-button.fill:hover {
-  text-decoration: none;
-}
-
-.con-button.outline {
-  border: 2px solid #000;
-  color: #000;
-}
-
-.con-button.outline:hover {
-  background-color: #000;
-  color: #fff;
-  text-decoration: none;
-}
-
 .dark .con-button.fill {
-  color: var(--text-color);
   background: #fff;
   border-color: #fff;
+  color: var(--text-color);
 }
 
 .dark .con-button.fill:hover,
 .dark .con-button.fill:active {
-  color: #000;
   background: #fff;
   border-color: #fff;
-}
-
-.dark .con-button.outline {
-  border: 2px solid #fff;
-  color: #fff;
-}
-
-.dark .con-button.outline:hover {
-  background-color: #fff;
   color: #000;
 }
 
 svg.icon-milo, img.icon-milo {
   height: 1em;
-  width: auto;
-  top: .1em;
-  position: relative;
   overflow: visible;
+  position: relative;
+  top: .1em;
+  width: auto;
 }
 
 .con-button svg.icon-milo {
+  display: inline-block;
   height: 1em;
   width: 1em;
-  display: inline-block;
 }
 
 span.icon.margin-right { margin-right: 8px; }

--- a/libs/styles/typography.css
+++ b/libs/styles/typography.css
@@ -134,6 +134,7 @@
 
 .con-button:hover {
   background-color: var(--color-black);
+  border-color: var(--color-black);
   color: var(--color-white);
   text-decoration: none;
 }
@@ -232,6 +233,25 @@ svg.icon-milo, img.icon-milo {
   display: inline-block;
   height: 1em;
   width: 1em;
+}
+
+.con-button[aria-disabled="true"],
+.con-button.blue[aria-disabled="true"], 
+.con-button.fill[aria-disabled="true"] {
+  border-color: var(--color-gray-500);
+  color: var(--color-gray-500);
+}
+
+.con-button.blue[aria-disabled="true"], 
+.con-button.fill[aria-disabled="true"] {
+  background-color: var(--color-gray-500);
+  color: var(--color-gray-300);
+}
+
+.con-button[aria-disabled="true"]:hover,
+.con-button.blue[aria-disabled="true"]:hover, 
+.con-button.fill[aria-disabled="true"]:hover {
+  cursor: default;
 }
 
 span.icon.margin-right { margin-right: 8px; }

--- a/libs/styles/typography.css
+++ b/libs/styles/typography.css
@@ -167,8 +167,8 @@
 }
 
 .light .con-button {
-  color: var(--text-color);
   border-color: var(--text-color);
+  color: var(--text-color);
 }
 
 .light .con-button:hover,

--- a/libs/styles/typography.css
+++ b/libs/styles/typography.css
@@ -238,6 +238,7 @@ svg.icon-milo, img.icon-milo {
 .con-button[aria-disabled="true"],
 .con-button.blue[aria-disabled="true"], 
 .con-button.fill[aria-disabled="true"] {
+  background-color: transparent;
   border-color: var(--color-gray-500);
   color: var(--color-gray-500);
 }
@@ -252,6 +253,17 @@ svg.icon-milo, img.icon-milo {
 .con-button.blue[aria-disabled="true"]:hover, 
 .con-button.fill[aria-disabled="true"]:hover {
   cursor: default;
+}
+
+.dark .con-button[aria-disabled="true"]:hover {
+  background-color: transparent;
+  color: var(--color-gray-500);
+}
+
+.dark .con-button.blue[aria-disabled="true"]:hover, 
+.dark .con-button.fill[aria-disabled="true"]:hover {
+  background-color: var(--color-gray-500);
+  color: var(--color-gray-300);
 }
 
 span.icon.margin-right { margin-right: 8px; }

--- a/libs/styles/typography.css
+++ b/libs/styles/typography.css
@@ -194,6 +194,7 @@
 .con-button.blue:active {
   background: var(--color-accent-hover);
   border-color: var(--color-accent-hover);
+  color: var(--color-white);
 }
 
 .con-button.fill {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -38,7 +38,7 @@ export function decorateBlockText(el, config = ['m', 's', 'm']) {
         decorateIconArea(el);
       }
     }
-    const emptyPs = el.querySelectorAll(':scope div > p:not([class])');
+    const emptyPs = el.querySelectorAll(':scope p:not([class])');
     if (emptyPs) emptyPs.forEach((p) => { p.classList.add(`body-${config[1]}`); });
   }
   decorateButtons(el);
@@ -69,4 +69,24 @@ export function getBlockSize(el, defaultSize = 1) {
   const sizes = ['small', 'medium', 'large', 'xlarge'];
   if (defaultSize < 0 || defaultSize > sizes.length - 1) return null;
   return sizes.find((size) => el.classList.contains(size)) || sizes[defaultSize];
+}
+
+function applyTextOverrides(el, override) {
+  const parts = override.split("-");
+  const type = parts[1];
+  const els = el.querySelectorAll(`[class^="${type}"]`);
+  if (!els.length) return;
+  els.forEach(elem => {
+    const replace = [...elem.classList].find(i => i.startsWith(type));
+    elem.classList.replace(replace, `${parts[1]}-${parts[0]}`);
+  });
+}
+
+export function decorateTextOverrides(el, options = ['-heading', '-body', '-detail']) {
+  const overrides = [...el.classList].filter(elClass => options.findIndex(ovClass => elClass.endsWith(ovClass)) >= 0);
+  if (!overrides.length) return;
+  overrides.forEach(override => {
+    applyTextOverrides(el, override);
+    el.classList.remove(override);
+  });
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -38,7 +38,7 @@ export function decorateBlockText(el, config = ['m', 's', 'm']) {
         decorateIconArea(el);
       }
     }
-    const emptyPs = el.querySelectorAll(':scope p:not([class])');
+    const emptyPs = el.querySelectorAll(':scope div > p:not([class])');
     if (emptyPs) emptyPs.forEach((p) => { p.classList.add(`body-${config[1]}`); });
   }
   decorateButtons(el);
@@ -69,24 +69,4 @@ export function getBlockSize(el, defaultSize = 1) {
   const sizes = ['small', 'medium', 'large', 'xlarge'];
   if (defaultSize < 0 || defaultSize > sizes.length - 1) return null;
   return sizes.find((size) => el.classList.contains(size)) || sizes[defaultSize];
-}
-
-function applyTextOverrides(el, override) {
-  const parts = override.split("-");
-  const type = parts[1];
-  const els = el.querySelectorAll(`[class^="${type}"]`);
-  if (!els.length) return;
-  els.forEach(elem => {
-    const replace = [...elem.classList].find(i => i.startsWith(type));
-    elem.classList.replace(replace, `${parts[1]}-${parts[0]}`);
-  });
-}
-
-export function decorateTextOverrides(el, options = ['-heading', '-body', '-detail']) {
-  const overrides = [...el.classList].filter(elClass => options.findIndex(ovClass => elClass.endsWith(ovClass)) >= 0);
-  if (!overrides.length) return;
-  overrides.forEach(override => {
-    applyTextOverrides(el, override);
-    el.classList.remove(override);
-  });
 }


### PR DESCRIPTION
The default `con-button` looks invisible without a `outline`, or `blue` style being set on the class list. 

* Updated the `con-button` default styles to match `outline` and removed any redundant styles
* Add to the `typography.css` file to support `aria-disabled="true"` styles and fixed sort order/css-linting

Resolves: [MWPW-130320](https://jira.corp.adobe.com/browse/MWPW-130320)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/buttons
- After: https://rparrish-button-default--milo--adobecom.hlx.page/drafts/rparrish/buttons
