### PR TITLE
Table sticky

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
   rules: {
     // allow reassigning param
     'no-param-reassign': [2, { props: false }],
-    'linebreak-style': ['error', 'unix'],
+    'linebreak-style': process.platform === 'win32' ? 0 : ['error', 'unix'],
     'import/extensions': ['error', { js: 'always' }],
     'object-curly-newline': ['error', {
       ObjectExpression: { multiline: true, minProperties: 6 },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
   rules: {
     // allow reassigning param
     'no-param-reassign': [2, { props: false }],
-    'linebreak-style': process.platform === 'win32' ? 0 : ['error', 'unix'],
+    'linebreak-style': ['error', 'unix'],
     'import/extensions': ['error', { js: 'always' }],
     'object-curly-newline': ['error', {
       ObjectExpression: { multiline: true, minProperties: 6 },

--- a/libs/blocks/table-metadata/table-metadata.js
+++ b/libs/blocks/table-metadata/table-metadata.js
@@ -1,26 +1,11 @@
-import { getMetadata, handleStyle } from '../section-metadata/section-metadata.js';
+import { getMetadata } from '../section-metadata/section-metadata.js';
 
 const getIndexedValues = (text) => text.split('\n').map((value) => value.split(/,(.*)/s).map((v) => v.trim()));
-
-function handleHighlight(text, table) {
-  if (!text) return;
-  const highLights = getIndexedValues(text);
-  highLights.forEach((hl) => {
-    const hlCol = hl[0];
-    const hlText = hl[1];
-    if (hlText) {
-      const highLightDiv = document.createElement('div');
-      highLightDiv.textContent = hlText;
-      table.querySelector(`.col-${hlCol}`).classList.add('col-highlight');
-      table.querySelector(`.col-${hlCol}`).prepend(highLightDiv);
-    }
-  });
-}
 
 function handleSectionHead(text, table) {
   if (!text) return;
   const sectionsHeads = text.split('\n');
-  sectionsHeads.forEach(sh => {
+  sectionsHeads.forEach((sh) => {
     const sectionHead = table.querySelector(`.row-${sh.trim()}`);
     sectionHead.classList.add('sectionHead');
   });
@@ -49,7 +34,7 @@ const handleColumnBgColor = (text, table, columnType) => {
 
 function handleCompare(text, table) {
   if (!(text || table)) return;
-  const comparisonGroup  = text.split('\n');
+  const comparisonGroup = text.split('\n');
   comparisonGroup.forEach((comp, i) => {
     const col = comp.trim().split(' ')[1];
     const comparable = table.querySelector(`.col-${col}`);
@@ -62,7 +47,6 @@ export default function init(el) {
   if (!table) return;
 
   const metadata = getMetadata(el);
-  if (metadata.highlight) handleHighlight(metadata.highlight.text, table);
   if (metadata.section) handleSectionHead(metadata.section.text, table);
   if (metadata.compare) handleCompare(metadata.compare.text, table);
   if (metadata['heading color']) handleColumnColor(metadata['heading color'].text, table, 'heading');

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -65,14 +65,13 @@
   background-color: grey;
 }
 
-.col-1 {
-  border: 2px red solid !important;
-  display: none;
+.table.table-sticky-on .row-highlight,
+.table.table-sticky-on .row-header {
+  z-index: 2;
+  position: fixed;
 }
 
-@media only screen and (max-width: 37.5rem) {
-  .table.merch > .row {
-    background-color: yellow;
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-  }
+.table.table-sticky-on .row-highlight > div,
+.table.table-sticky-on .row-header > div {
+  background-color: var(--color-white);
 }

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -12,9 +12,11 @@ const positionStickyRows = (table) => {
   const headerCells = headerRow.querySelectorAll(':scope > div');
   const nextRow = table.querySelector('.row-header + div');
   const nextCells = nextRow ? nextRow.querySelectorAll(':scope > div') : null;
+  const lastRow = table.querySelector(':scope > div:last-child');
+  const lastRowRec = lastRow.getBoundingClientRect();
 
   if (!nextRow) return;
-  if (tableRec.top < gnavHeight && tableBottom - 10 > headerRowBottom) {
+  if (tableRec.top < gnavHeight && tableBottom > gnavHeight) {
     nextCells.forEach((cell, index) => {
       const cellWidth = getComputedStyle(cell).width;
       if (highlightCells && highlightCells[index]) highlightCells[index].style.width = `${cellWidth}px`;
@@ -23,10 +25,21 @@ const positionStickyRows = (table) => {
     table.classList.add('table-sticky-on');
     nextRow.style.marginTop = `${highlightHeight + headerRowHeight}px`;
     headerRow.style.width = `${tableRec.width}px`;
-    headerRow.style.top = `${gnavHeight + highlightHeight}px`;
     if (highlightRow) {
       highlightRow.style.width = `${tableRec.width}px`;
-      highlightRow.style.top = `${gnavHeight}px`;
+    }
+    if (headerRowBottom < lastRowRec.top) {
+      // lock under gnav
+      if (highlightRow) {
+        highlightRow.style.top = `${gnavHeight}px`;
+      }
+      headerRow.style.top = `${gnavHeight + highlightHeight}px`;
+    } else {
+      // scroll off
+      if (highlightRow) {
+        highlightRow.style.top = `${lastRowRec.top - headerRowHeight - highlightHeight}px`;
+      }
+      headerRow.style.top = `${lastRowRec.top - headerRowHeight}px`;
     }
   } else {
     highlightCells?.forEach((cell) => {

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -1,11 +1,86 @@
+const positionStickyRows = (table) => {
+  const tableRec = table.getBoundingClientRect();
+  const tableBottom = tableRec.top + tableRec.height;
+  const gnav = document.querySelector('header');
+  const gnavHeight = gnav ? document.querySelector('header').getBoundingClientRect().height : 0;
+  const highlightRow = table.querySelector('.row-highlight');
+  const highlightHeight = highlightRow ? highlightRow.getBoundingClientRect().height : 0;
+  const highlightCells = highlightRow ? highlightRow.querySelectorAll(':scope > div') : null;
+  const headerRow = table.querySelector('.row-header');
+  const headerRowHeight = headerRow.getBoundingClientRect().height;
+  const headerRowBottom = gnavHeight + highlightHeight + headerRowHeight;
+  const headerCells = headerRow.querySelectorAll(':scope > div');
+  const nextRow = table.querySelector('.row-header + div');
+  const nextCells = nextRow ? nextRow.querySelectorAll(':scope > div') : null;
+
+  if (!nextRow) return;
+  if (tableRec.top < gnavHeight && tableBottom - 10 > headerRowBottom) {
+    nextCells.forEach((cell, index) => {
+      const cellWidth = getComputedStyle(cell).width;
+      if (highlightCells && highlightCells[index]) highlightCells[index].style.width = `${cellWidth}px`;
+      if (headerCells[index]) headerCells[index].style.width = `${cellWidth}px`;
+    });
+    table.classList.add('table-sticky-on');
+    nextRow.style.marginTop = `${highlightHeight + headerRowHeight}px`;
+    headerRow.style.width = `${tableRec.width}px`;
+    headerRow.style.top = `${gnavHeight + highlightHeight}px`;
+    if (highlightRow) {
+      highlightRow.style.width = `${tableRec.width}px`;
+      highlightRow.style.top = `${gnavHeight}px`;
+    }
+  } else {
+    highlightCells?.forEach((cell) => {
+      cell.style.width = null;
+    });
+    headerCells.forEach((cell) => {
+      cell.style.width = null;
+    });
+    table.classList.remove('table-sticky-on');
+    nextRow.style.marginTop = null;
+    headerRow.style.width = null;
+    headerRow.style.top = null;
+    if (highlightRow) {
+      highlightRow.style.width = null;
+      highlightRow.style.top = null;
+    }
+  }
+};
+
+const addStickyListeners = (table, highlightOn) => {
+  window.addEventListener('scroll', () => {
+    positionStickyRows(table, highlightOn);
+  });
+  window.addEventListener('resize', () => {
+    positionStickyRows(table, highlightOn);
+  });
+};
+
 export default function init(el) {
+  // remove top row if empty
+  const firstRow = el.querySelector(':scope > div:first-child');
+  if (firstRow.innerText.trim() === '') firstRow.remove();
+
+  const highlightOn = el.classList.contains('highlight');
   const rows = el.querySelectorAll(':scope > div');
   rows.forEach((row, rdx) => {
     row.className = `row row-${rdx + 1}`;
+    if (highlightOn && rdx === 0) {
+      row.classList.add('row-highlight');
+    } else if ((highlightOn && rdx === 1) || (!highlightOn && rdx === 0)) {
+      row.classList.add('row-header');
+    }
     const cols = row.querySelectorAll(':scope > div');
     cols.forEach((col, cdx) => {
       col.className = `col col-${cdx + 1}`;
-      if (rdx === 1) col.classList.add('col-heading');
+      if (row.classList.contains('row-header')) {
+        col.classList.add('col-heading');
+      } else if (
+        row.classList.contains('row-highlight')
+        && col.innerText !== ''
+      ) {
+        col.classList.add('col-highlight');
+      }
     });
   });
+  if (el.classList.contains('sticky-top')) addStickyListeners(el, highlightOn);
 }


### PR DESCRIPTION
* removed code for highlight from table-metadata block and moved it to the table block
* removed some temp CSS from table.css. It was causing issues to leave it in and I don't think it was meant to be permanent.
* supports first row being left empty if the author wants to keep it as a placeholder to add a highlight row later
* highlight is now a variant of the table block.  If highlight is on, the first row with content is treated as the highlight row. The 2nd row is assumed to be the header row. Otherwise, if highlight is off, the first row with content is the header row.
* sticky top added as a variant of table block. Locks header row and highlight row (if it exists). Added default background color of white so you cannot see the content of the lower rows passing behind the words.
* update to ESLint to work on windows

Resolves: [MWPW-129574](https://jira.corp.adobe.com/browse/MWPW-129574)

**Test URLs:**
- Before: https://tableblock--milo--adobecom.hlx.page/drafts/vgoodric/sticky-top?martech=off
- After: https://table-sticky--milo--adobecom.hlx.page/drafts/vgoodric/sticky-top?martech=off
