### PR TITLE
MWPW-130147 FaaS breakpoints and full width on mobile

### DIFF
--- a/libs/blocks/columns/columns.css
+++ b/libs/blocks/columns/columns.css
@@ -58,14 +58,12 @@
   letter-spacing: 1px;
 }
 
-@media screen and (min-width:900px) {
+/* tablet up */
+@media screen and (min-width:600px) {
   .columns > .row {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  }  
-}
+  }
 
-/* For desktop only */
-@media (min-width:600px) {
   .columns.table > .row {
     padding: var(--spacing-xs);
   }

--- a/libs/blocks/columns/columns.css
+++ b/libs/blocks/columns/columns.css
@@ -2,7 +2,7 @@
   display: grid;
   gap: var(--spacing-m);
   margin-bottom: var(--spacing-xs);
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: 1fr;
 }
 
 .columns.contained {
@@ -56,6 +56,12 @@
   font-size: 11px;
   font-weight: bold;
   letter-spacing: 1px;
+}
+
+@media screen and (min-width:900px) {
+  .columns > .row {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }  
 }
 
 /* For desktop only */

--- a/libs/blocks/faas/faas.css
+++ b/libs/blocks/faas/faas.css
@@ -387,7 +387,7 @@ input[type="checkbox"] + label {
 }
 
 /* for mobile */
-@media (max-width:799.99px) {
+@media (max-width:600px) {
   .faas-form label,
   .faas-form input:not([type=checkbox]):not([type=radio]):not([type=submit]),
   .faas-form select,

--- a/libs/blocks/faas/faas.css
+++ b/libs/blocks/faas/faas.css
@@ -386,7 +386,7 @@ input[type="checkbox"] + label {
   line-height: 1.375em;
 }
 
-/* for mobile */
+/* mobile only */
 @media (max-width:600px) {
   .faas-form label,
   .faas-form input:not([type=checkbox]):not([type=radio]):not([type=submit]),

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -134,15 +134,30 @@ main>.section[class*='-up']>.content {
 .section.four-up,
 .section.five-up {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(276px, 1fr));
+  grid-template-columns: 1fr;
   gap: var(--spacing-m);
   align-items: start;
   padding-left: var(--grid-margins-width);
   padding-right: var(--grid-margins-width);
 }
 
-.section.five-up {
-  grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
+@media screen and (min-width:900px){
+  .section.two-up,
+  .section.three-up,
+  .section.four-up {
+    grid-template-columns: repeat(auto-fit, minmax(234px, 1fr));
+  }
+
+  .section.five-up {
+    grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .section[class*='-up'] .mobile-max-width {
+    margin-left: calc(var(--grid-margins-width) * -1 / 2);
+    margin-right: calc(var(--grid-margins-width) * -1 / 2);
+  }
 }
 
 .section.sticky-top {

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -141,25 +141,6 @@ main>.section[class*='-up']>.content {
   padding-right: var(--grid-margins-width);
 }
 
-@media screen and (min-width:900px){
-  .section.two-up,
-  .section.three-up,
-  .section.four-up {
-    grid-template-columns: repeat(auto-fit, minmax(234px, 1fr));
-  }
-
-  .section.five-up {
-    grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
-  }
-}
-
-@media (max-width: 600px) {
-  .section[class*='-up'] .mobile-max-width {
-    margin-left: calc(var(--grid-margins-width) * -1 / 2);
-    margin-right: calc(var(--grid-margins-width) * -1 / 2);
-  }
-}
-
 .section.sticky-top {
   position: sticky;
   top: 57px;
@@ -174,18 +155,41 @@ main>.section[class*='-up']>.content {
   background-color: var(--color-white);
 }
 
+/* mobile only */
+@media (max-width: 600px) {
+  .section[class*='-up'] .max-width-mobile {
+    margin-left: calc(var(--grid-margins-width) * -1 / 2);
+    margin-right: calc(var(--grid-margins-width) * -1 / 2);
+  }
+}
+
+/* tablet up */
+@media screen and (min-width: 600px) {
+  .section.two-up,
+  .section.three-up,
+  .section.four-up {
+    grid-template-columns: repeat(auto-fit, minmax(234px, 1fr));
+  }
+
+  .section.five-up {
+    grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
+  }
+}
+
 @media (min-width: 900px) {
   .section.sticky-top {
     top: 64px;
   }
 }
 
+/* tablet up to desktop */
 @media screen and (min-width: 600px) and (max-width: 1200px) {
   .section.five-up {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 }
 
+/* desktop up */
 @media screen and (min-width: 1200px) {
   .section.grid-width-10 {
     padding-left: var(--grid-margins-width-10);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Match breakpoints for section columns and columns block at 600px.
* Update 2 column FaaS form breakpoint to 600px.
* Allow FaaS forms to be full width at 600px via text block (mobile max width).

Resolves: [MWPW-130147](https://jira.corp.adobe.com/browse/MWPW-130147)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/bmarshal/section-columns-breakpoint?martech=off
- After: https://bmarshal-faas-layout--milo--adobecom.hlx.page/drafts/bmarshal/section-columns-breakpoint?martech=off
- Before: https://main--milo--adobecom.hlx.page/drafts/bmarshal/column-block-breakpoints?martech=off
- After: https://bmarshal-faas-layout--milo--adobecom.hlx.page/drafts/bmarshal/column-block-breakpoints?martech=off

**BACOM URLs:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/bmarshal/faas-21?martech=off
- After: https://main--bacom--adobecom.hlx.page/drafts/bmarshal/faas-21?martech=off&milolibs=bmarshal-faas-layout
- Before: https://main--bacom--adobecom.hlx.page/resources/guides/solve-the-pain-of-mixing-agile-and-waterfall?martech=off
- After: https://main--bacom--adobecom.hlx.page/resources/guides/solve-the-pain-of-mixing-agile-and-waterfall?martech=off&milolibs=bmarshal-faas-layout