### PR TITLE
[MWPW-128317] No hamburger when menu has no content

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -56,9 +56,6 @@ class Gnav {
     this.curtain = createTag('div', { class: 'gnav-curtain' });
     const nav = createTag('nav', { class: 'gnav', 'aria-label': 'Main' });
 
-    const mobileToggle = this.decorateToggle(nav);
-    nav.append(mobileToggle);
-
     const brand = this.decorateBrand();
     if (brand) {
       nav.append(brand);
@@ -67,7 +64,9 @@ class Gnav {
     const scrollWrapper = createTag('div', { class: 'mainnav-wrapper' });
 
     const mainNav = this.decorateMainNav();
-    if (mainNav) {
+    if (mainNav && mainNav.childElementCount) {
+      const mobileToggle = this.decorateToggle();
+      nav.prepend(mobileToggle);
       scrollWrapper.append(mainNav);
     }
 


### PR DESCRIPTION
When using the Milo Gnav, if no menu content is added to the navigation, there shouldn't be a hamburger menu on mobile devices.

Resolves: [MWPW-128317](https://jira.corp.adobe.com/browse/MWPW-128317)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/prev/gnav-barebones?martech=off
- After: https://mwpw-128317-no-hamburger-if-not-needed--milo--overmyheadandbody.hlx.page/drafts/ramuntea/prev/gnav-barebones?martech=off
