### PR TITLE
MWPW-129539 Update file overwrite logic during promote copy

### DIFF
--- a/tools/floodgate/js/promote.js
+++ b/tools/floodgate/js/promote.js
@@ -25,9 +25,9 @@ const MAX_CHILDREN = 1000;
  * Copies the Floodgated files back to the main content tree.
  * Creates intermediate folders if needed.
  */
- async function promoteCopy(srcPath, destinationFolder, newName, isFloodgate) {
+ async function promoteCopy(srcPath, destinationFolder, newName) {
   validateConnection();
-  const { sp } = isFloodgate ? await getFloodgateConfig() : await getConfig();
+  const { sp } = await getFloodgateConfig();
   const baseURI = sp.api.file.copy.baseURI;
   const fgBaseURI = sp.api.file.copy.fgBaseURI;
   const rootFolder = baseURI.split('/').pop();
@@ -107,7 +107,7 @@ async function promoteFloodgatedFiles(project) {
       loadingON(`Promoting ${filePath} ...`);
       const folder = getFolderFromPath(filePath);
       const filename = getFileNameFromPath(filePath);
-      const copyFileStatus = await promoteCopy(filePath, folder, filename, true, false);
+      const copyFileStatus = await promoteCopy(filePath, folder, filename);
       if (copyFileStatus) {
         promoteSuccess = true;
       } else {

--- a/tools/floodgate/js/promote.js
+++ b/tools/floodgate/js/promote.js
@@ -1,5 +1,6 @@
 import {
-  createFolder,
+  getFileNameFromPath,
+  getFolderFromPath,
   getAuthorizedRequestOption,
   saveFile,
   updateExcelTable,
@@ -24,20 +25,21 @@ const MAX_CHILDREN = 1000;
  * Copies the Floodgated files back to the main content tree.
  * Creates intermediate folders if needed.
  */
-async function promoteCopy(srcPath, destinationFolder) {
+ async function promoteCopy(srcPath, destinationFolder, newName, isFloodgate) {
   validateConnection();
-  await createFolder(destinationFolder);
-  const { sp } = await getFloodgateConfig();
-  const destRootFolder = `${sp.api.file.copy.baseURI}`.split('/').pop();
-
-  const payload = { ...sp.api.file.copy.payload, parentReference: { path: `${destRootFolder}${destinationFolder}` } };
+  const { sp } = isFloodgate ? await getFloodgateConfig() : await getConfig();
+  const baseURI = sp.api.file.copy.baseURI;
+  const fgBaseURI = sp.api.file.copy.fgBaseURI;
+  const rootFolder = baseURI.split('/').pop();
+  const payload = { ...sp.api.file.copy.payload, parentReference: { path: `${rootFolder}${destinationFolder}` } };
+  if (newName) {
+    payload.name = newName;
+  }
   const options = getAuthorizedRequestOption({
     method: sp.api.file.copy.method,
     body: JSON.stringify(payload),
   });
-
-  // copy source is the pink directory for promote
-  const copyStatusInfo = await fetchWithRetry(`${sp.api.file.copy.fgBaseURI}${srcPath}:/copy`, options);
+  const copyStatusInfo = await fetchWithRetry(`${fgBaseURI}${srcPath}:/copy?@microsoft.graph.conflictBehavior=replace`, options);
   const statusUrl = copyStatusInfo.headers.get('Location');
   let copySuccess = false;
   let copyStatusJson = {};
@@ -103,25 +105,17 @@ async function promoteFloodgatedFiles(project) {
     try {
       let promoteSuccess = false;
       loadingON(`Promoting ${filePath} ...`);
-      const { sp } = await getFloodgateConfig();
-      const options = getAuthorizedRequestOption();
-      const res = await fetchWithRetry(`${sp.api.file.get.baseURI}${filePath}`, options);
-      if (res.ok) {
-        // File exists at the destination (main content tree)
-        // Get the file in the pink directory using downloadUrl
-        const file = await getFile(downloadUrl);
-        if (file) {
-          // Save the file in the main content tree
-          const saveStatus = await saveFile(file, filePath);
-          if (saveStatus.success) {
-            promoteSuccess = true;
-          }
-        }
+      const folder = getFolderFromPath(filePath);
+      const filename = getFileNameFromPath(filePath);
+      const copyFileStatus = await promoteCopy(filePath, folder, filename, true, false);
+      if (copyFileStatus) {
+        promoteSuccess = true;
       } else {
-        // File does not exist at the destination (main content tree)
-        // File can be copied directly
-        const destinationFolder = `${filePath.substring(0, filePath.lastIndexOf('/'))}`;
-        promoteSuccess = await promoteCopy(filePath, destinationFolder);
+        const file = await getFile(downloadUrl);
+        const saveStatus = await saveFile(file, filePath);
+        if (saveStatus.success) {
+          promoteSuccess = true;
+        }
       }
       updateAndDisplayPromoteStatus(promoteSuccess, filePath);
       status.success = promoteSuccess;

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -526,4 +526,6 @@ export {
   createFolder,
   enableRetry,
   fetchWithRetry,
+  getFileNameFromPath,
+  getFolderFromPath,
 };


### PR DESCRIPTION
Link to the ticket: https://jira.corp.adobe.com/browse/MWPW-129539

The PR does the following:

Right now, in promote, saveFile() is called if the file exists at the destination. saveFile() makes several calls in order to handle locked files. The updated code in this PR calls saveFile() only if the file is locked or the folder is absent at the destination. Otherwise, it directly copies the file. This reduces the number of calls significantly (about 40%). 
 

**Test URLs:**

**Before**: https://main--milo--adobecom.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B59E5B572-A72C-40B8-96AF-4591908EA744%257D%26file%3Dtest_with_50.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3Df717e4fd-9317-4be7-8c50-932a39ae73b7
**After**: https://main--milo--nethraasivakumar.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B59E5B572-A72C-40B8-96AF-4591908EA744%257D%26file%3Dtest_with_50.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3Df717e4fd-9317-4be7-8c50-932a39ae73b7