### PR TITLE
MWPW-129098 Add ability to disable autoblocking

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -423,15 +423,14 @@ export function decorateSVG(a) {
 }
 
 export function decorateAutoBlock(a) {
-  const { doNotAutoBlock = '' } = getConfig();
+  const { autoBlocks, doNotAutoBlock = null } = getConfig();
   if (a.closest(doNotAutoBlock)) {
     return false;
   }
-  const config = getConfig();
   const { hostname } = window.location;
   const url = new URL(a.href);
   const href = hostname === url.hostname ? `${url.pathname}${url.search}${url.hash}` : a.href;
-  return config.autoBlocks.find((candidate) => {
+  return autoBlocks.find((candidate) => {
     const key = Object.keys(candidate)[0];
     const match = href.includes(candidate[key]);
     if (match) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -79,6 +79,7 @@ const AUTO_BLOCKS = [
   { video: '.mp4' },
   { merch: '/tools/ost?' },
 ];
+const DO_NOT_AUTOBLOCK = '.card-metadata';
 const ENVS = {
   local: {
     name: 'local',
@@ -149,6 +150,7 @@ export const [setConfig, getConfig] = (() => {
       config.codeRoot = conf.codeRoot ? `${origin}${conf.codeRoot}` : origin;
       config.locale = pathname ? getLocale(conf.locales, pathname) : getLocale(conf.locales);
       config.autoBlocks = conf.autoBlocks ? [...AUTO_BLOCKS, ...conf.autoBlocks] : AUTO_BLOCKS;
+      config.doNotAutoBlock = conf.doNotAutoBlock ? `${DO_NOT_AUTOBLOCK},${conf.doNotAutoBlock}` : DO_NOT_AUTOBLOCK;
       document.documentElement.setAttribute('lang', config.locale.ietf);
       try {
         document.documentElement.setAttribute('dir', (new Intl.Locale(config.locale.ietf)).textInfo.direction);
@@ -421,6 +423,10 @@ export function decorateSVG(a) {
 }
 
 export function decorateAutoBlock(a) {
+  const { doNotAutoBlock = '' } = getConfig();
+  if (a.closest(doNotAutoBlock)) {
+    return false;
+  }
   const config = getConfig();
   const { hostname } = window.location;
   const url = new URL(a.href);
@@ -594,9 +600,9 @@ async function loadMartech(config) {
 async function loadPostLCP(config) {
   loadMartech(config);
   const header = document.querySelector('header');
-  if (header) { 
+  if (header) {
     header.classList.add('gnav-hide');
-    await loadBlock(header); 
+    await loadBlock(header);
     header.classList.remove('gnav-hide');
   }
   loadTemplate();

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -33,7 +33,18 @@
     <!-- Disable Auto Block-->
     <p><a class="disable-autoblock" href="https://www.instagram.com/#_dnb">Disable Autoblock</a></p>
     <!-- Auto Block -->
-    <p><a class="autoblock" href="https://twitter.com/Adobe">Auto Block</a></p>    
+    <p><a class="autoblock" href="https://twitter.com/Adobe">Auto Block</a></p>
+    <!-- DO_NOT_AUTOBLOCK -->
+    <div class="card-metadata">
+      <div>
+        <div>title</div>
+        <div>Card Title</div>
+      </div>
+      <div>
+        <div>playurl</div>
+        <div id="do-not-autoblock"><a href="https://video.tv.adobe.com/v/31986">https://video.tv.adobe.com/v/31986</a></div>
+      </div>
+    </div>
   </div>
   <!-- Default content -->
   <div>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -66,6 +66,12 @@ describe('Utils', () => {
         const autoBlockLink = document.querySelector('[href="https://twitter.com/Adobe"]');
         expect(autoBlockLink.className).to.equal('twitter link-block');
       });
+
+      it('DO_NOT_AUTOBLOCK blocks are left unchanged ', () => {
+        const autoBlockLink = document.getElementById('do-not-autoblock')?.firstElementChild;
+        expect(autoBlockLink?.nodeName).to.equal('A');
+        expect(autoBlockLink?.href).to.equal('https://video.tv.adobe.com/v/31986');
+      });
     });
 
     describe('Fragments', () => {


### PR DESCRIPTION
A comma separated list of block classname selectors can be set in the `DO_NOT_AUTOBLOCK` (for Milo) or in the project config under `doNotAutoBlock` for consumers.

Any blocks specified there will not have any links processed within the block.

Block classnames should be entered like: `'.card-metadata,.other-block'`.

Resolves: [MWPW-129098](https://jira.corp.adobe.com/browse/MWPW-129098)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/iscandar/videoonlycardaem?martech=off
- After: https://c3-donotautoblock--milo--adobecom.hlx.page/drafts/iscandar/videoonlycardaem?martech=off

To verify:
* In the first link under `main > .section > .card-metadata > 5th div  > 2nd div` The video link will be wrapped in `.milo-video` and set in an `iframe`.
* In the second link, same location, the link will be a regular `a` link that has not been transformed for video.
