### PR TITLE
MWPW-129539 : Update file overwrite logic during copy (COPY action)

### DIFF
--- a/tools/floodgate/js/copy.js
+++ b/tools/floodgate/js/copy.js
@@ -27,12 +27,9 @@ async function floodgateContent(project, projectDetail) {
       const srcPath = urlInfo.doc.filePath;
       loadingON(`Copying ${srcPath} to pink folder`);
       let copySuccess = false;
-      if (urlInfo.doc.fg?.sp?.status !== 200) {
-        const destinationFolder = `${srcPath.substring(0, srcPath.lastIndexOf('/'))}`;
-        copySuccess = await copyFile(srcPath, destinationFolder, undefined, true);
-        updateAndDisplayCopyStatus(copySuccess, srcPath);
-      } else {
-        // Get the source file
+      const destinationFolder = `${srcPath.substring(0, srcPath.lastIndexOf('/'))}`;
+      copySuccess = await copyFile(srcPath, destinationFolder, undefined, true);
+      if (copySuccess === false) {
         const file = await getFile(urlInfo.doc);
         if (file) {
           const destination = urlInfo.doc.filePath;
@@ -44,8 +41,8 @@ async function floodgateContent(project, projectDetail) {
             }
           }
         }
-        updateAndDisplayCopyStatus(copySuccess, srcPath);
       }
+      updateAndDisplayCopyStatus(copySuccess, srcPath);
       status.success = copySuccess;
       status.srcPath = srcPath;
       status.url = urlInfo.doc.url;

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -503,6 +503,7 @@ async function addWorksheetToExcel(excelPath, worksheetName) {
   throw new Error(`Failed to add worksheet ${worksheetName} to ${excelPath}.`);
 }
 
+
 export {
   connect,
   copyFile,

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -503,7 +503,6 @@ async function addWorksheetToExcel(excelPath, worksheetName) {
   throw new Error(`Failed to add worksheet ${worksheetName} to ${excelPath}.`);
 }
 
-
 export {
   connect,
   copyFile,

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -378,6 +378,7 @@ async function getMetadata(srcPath, file) {
 
 async function copyFile(srcPath, destinationFolder, newName, isFloodgate, isFloodgateLockedFile) {
   validateConnection();
+  await createFolder(destinationFolder, isFloodgate);
   const { sp } = isFloodgate ? await getFloodgateConfig() : await getConfig();
   const { baseURI, fgBaseURI } = sp.api.file.copy;
   const rootFolder = isFloodgate ? fgBaseURI.split('/').pop() : baseURI.split('/').pop();

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -86,7 +86,7 @@ function getAuthorizedRequestOption({
 let nextCallAfter = 0;
 const reqThresh = 5;
 let retryFlag = false;
-const TOO_MANY_REQUESTS = "429";
+const TOO_MANY_REQUESTS = '429';
 
 function enableRetry() {
   retryFlag = true;
@@ -378,10 +378,8 @@ async function getMetadata(srcPath, file) {
 
 async function copyFile(srcPath, destinationFolder, newName, isFloodgate, isFloodgateLockedFile) {
   validateConnection();
-  await createFolder(destinationFolder, isFloodgate);
   const { sp } = isFloodgate ? await getFloodgateConfig() : await getConfig();
-  const baseURI = sp.api.file.copy.baseURI;
-  const fgBaseURI = sp.api.file.copy.fgBaseURI;
+  const { baseURI, fgBaseURI } = sp.api.file.copy;
   const rootFolder = isFloodgate ? fgBaseURI.split('/').pop() : baseURI.split('/').pop();
 
   const payload = { ...sp.api.file.copy.payload, parentReference: { path: `${rootFolder}${destinationFolder}` } };
@@ -396,7 +394,7 @@ async function copyFile(srcPath, destinationFolder, newName, isFloodgate, isFloo
   // locked file copy happens in the floodgate content location
   // So baseURI is updated to reflect the destination accordingly
   const contentURI = isFloodgate && isFloodgateLockedFile ? fgBaseURI : baseURI;
-  const copyStatusInfo = await fetchWithRetry(`${contentURI}${srcPath}:/copy`, options);
+  const copyStatusInfo = await fetchWithRetry(`${contentURI}${srcPath}:/copy?@microsoft.graph.conflictBehavior=replace`, options);
   const statusUrl = copyStatusInfo.headers.get('Location');
   let copySuccess = false;
   let copyStatusJson = {};


### PR DESCRIPTION
Link to the ticket: https://jira.corp.adobe.com/browse/MWPW-129539

The PR does the following:

Right now, in copy action, saveFile() is called if the file exists at the destination. saveFile() makes several calls in order to handle locked files. The updated code in this PR calls saveFile() only if the file is locked or the folder is absent at the destination. Otherwise, it directly copies the file. This reduces the number of calls significantly.

Test URLs:

Before: https://main--milo--adobecom.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2Fdoc2.aspx%3Fsourcedoc%3D%257BB2136347-CE65-470B-842E-C1E55C7C86A4%257D%26file%3DfileOverwrite.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3D9f332e29-5a13-43a3-b2d7-fe2b630f2c13 
After: https://main--milo--nethraasivakumar.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257BB2136347-CE65-470B-842E-C1E55C7C86A4%257D%26file%3DfileOverwrite.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3D9f332e29-5a13-43a3-b2d7-fe2b630f2c13 