### PR TITLE
Small global navigation improvements

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -19,6 +19,7 @@ import {
   closeAllDropdowns,
   loadBaseStyles,
   yieldToMain,
+  selectors,
 } from './utilities/utilities.js';
 
 import { replaceKey } from '../../features/placeholders.js';
@@ -120,6 +121,16 @@ const setupKeyboardNav = async () => {
   });
 };
 
+// TODO - when clicking the navigation the dropdowns currently do not close.
+const closeOnClickOutside = (e) => {
+  if (
+    !e.target.closest(selectors.globalNav)
+    || e.target.closest(selectors.curtain)
+  ) {
+    closeAllDropdowns();
+  }
+};
+
 class Gnav {
   constructor(body, el) {
     this.blocks = {
@@ -161,6 +172,8 @@ class Gnav {
       await yieldToMain();
       await task();
     }
+
+    document.addEventListener('click', (e) => closeOnClickOutside(e));
   };
 
   decorateTopNav = () => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -173,7 +173,7 @@ class Gnav {
       await task();
     }
 
-    document.addEventListener('click', (e) => closeOnClickOutside(e));
+    document.addEventListener('click', closeOnClickOutside);
   };
 
   decorateTopNav = () => {

--- a/libs/blocks/global-navigation/utilities/keyboard/index.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import { getNextVisibleItemPosition, getPreviousVisibleItemPosition, selectors } from './utils.js';
 import MainNav from './mainNav.js';
-import { closeAllDropdowns } from '../utilities.js';
 
 const cycleOnOpenSearch = ({ e, isDesktop }) => {
   const withoutBreadcrumbs = [
@@ -25,15 +24,6 @@ const cycleOnOpenSearch = ({ e, isDesktop }) => {
   }
 };
 
-const closeOnClickOutside = (e) => {
-  if (
-    !e.target.closest(selectors.globalNav)
-    || e.target.closest(selectors.curtain)
-  ) {
-    closeAllDropdowns();
-  }
-};
-
 class KeyboardNavigation {
   constructor() {
     this.addEventListeners();
@@ -42,8 +32,6 @@ class KeyboardNavigation {
   }
 
   addEventListeners = () => {
-    document.addEventListener('click', (e) => closeOnClickOutside(e));
-
     document.querySelector(selectors.globalNav).addEventListener('keydown', (e) => {
       switch (e.code) {
         case 'Tab': {

--- a/libs/blocks/global-navigation/utilities/keyboard/index.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/index.js
@@ -27,7 +27,7 @@ const cycleOnOpenSearch = ({ e, isDesktop }) => {
 
 const closeOnClickOutside = (e) => {
   if (
-    !e.target.closest(`${selectors.globalNav} [aria-expanded = 'true']`)
+    !e.target.closest(selectors.globalNav)
     || e.target.closest(selectors.curtain)
   ) {
     closeAllDropdowns();

--- a/libs/blocks/global-navigation/utilities/keyboard/mainNav.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/mainNav.js
@@ -41,7 +41,7 @@ class MainNavItem {
           }
           // TODO popup navigation logic.
           case 'ArrowLeft': {
-            if (document.dir === 'ltr') {
+            if (document.dir !== 'rtl') {
               if (this.prev === -1) break;
               this.focusPrev({ focus: null });
             } else {
@@ -58,7 +58,7 @@ class MainNavItem {
           }
           case 'ArrowRight': {
             const open = document.querySelector(selectors.expandedPopupTrigger);
-            if (document.dir === 'ltr') {
+            if (document.dir !== 'rtl') {
               if (this.next === -1) break;
               this.focusNext();
             } else {

--- a/libs/blocks/global-navigation/utilities/keyboard/mobilePopup.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/mobilePopup.js
@@ -148,10 +148,10 @@ class Popup {
         }
         case 'ArrowLeft': {
           const { prevHeadline, nextHeadline } = getState();
-          const headline = document.dir === 'ltr' ? prevHeadline : nextHeadline;
+          const headline = document.dir !== 'rtl' ? prevHeadline : nextHeadline;
           if (!headline) {
             closeHeadlines();
-            if (document.dir === 'ltr') {
+            if (document.dir !== 'rtl') {
               this.mainNav.items[this.mainNav.curr].focus();
             } else {
               this.mainNav.focusNext();
@@ -168,10 +168,10 @@ class Popup {
         }
         case 'ArrowRight': {
           const { prevHeadline, nextHeadline } = getState();
-          const headline = document.dir === 'ltr' ? nextHeadline : prevHeadline;
+          const headline = document.dir !== 'rtl' ? nextHeadline : prevHeadline;
           if (!headline) {
             closeHeadlines();
-            if (document.dir === 'ltr') {
+            if (document.dir !== 'rtl') {
               this.mainNav.focusNext();
               this.mainNav.open();
             } else {

--- a/libs/blocks/global-navigation/utilities/keyboard/popup.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/popup.js
@@ -78,13 +78,13 @@ class Popup {
           break;
         }
         case 'ArrowLeft': {
-          const noPrev = (document.dir === 'ltr' && prevColumn === -1);
+          const noPrev = (document.dir !== 'rtl' && prevColumn === -1);
           const noNext = (document.dir === 'rtl' && nextColumn === -1);
           if (noPrev || noNext) {
             this.mainNav.items[this.mainNav.curr].focus();
             break;
           }
-          if (document.dir === 'ltr') {
+          if (document.dir !== 'rtl') {
             prevColumn.querySelector(selectors.popupItems).focus();
           } else {
             nextColumn.querySelector(selectors.popupItems).focus();
@@ -100,13 +100,13 @@ class Popup {
           break;
         }
         case 'ArrowRight': {
-          const noNext = document.dir === 'ltr' && nextColumn === -1;
+          const noNext = document.dir !== 'rtl' && nextColumn === -1;
           const noPrev = document.dir === 'rtl' && prevColumn === -1;
           if (noNext || noPrev) {
             this.mainNav.items[this.mainNav.curr].focus();
             break;
           }
-          if (document.dir === 'ltr') {
+          if (document.dir !== 'rtl') {
             nextColumn.querySelector(selectors.popupItems).focus();
           } else {
             prevColumn.querySelector(selectors.popupItems).focus();

--- a/libs/blocks/global-navigation/utilities/keyboard/utils.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/utils.js
@@ -1,4 +1,7 @@
+import { selectors as baseSelectors } from '../utilities.js';
+
 const selectors = {
+  ...baseSelectors,
   mainNavItems:
     '.feds-navItem > a, .feds-navItem > .feds-cta-wrapper > .feds-cta',
   brand: '.feds-brand',
@@ -10,7 +13,6 @@ const selectors = {
   logo: '.gnav-logo',
   breadCrumbItems: '.feds-breadcrumbs li > a',
   expandedPopupTrigger: '.feds-navLink[aria-expanded = "true"]',
-  navLink: '.feds-navLink',
   promoLink: '.feds-promo-link',
   imagePromo: 'a.feds-promo-image',
   fedsNav: '.feds-nav',
@@ -19,9 +21,7 @@ const selectors = {
   section: '.feds-menu-section',
   column: '.feds-menu-column',
   cta: '.feds-cta',
-  curtain: '.feds-curtain',
   openSearch: '.feds-search-trigger[aria-expanded = "true"]',
-  globalNav: '.global-navigation',
 };
 
 selectors.popupItems = `

--- a/libs/blocks/global-navigation/utilities/keyboard/utils.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/utils.js
@@ -8,7 +8,7 @@ const selectors = {
   mainNavToggle: '.gnav-toggle',
   searchTrigger: '.feds-search-trigger',
   searchField: '.feds-search-input',
-  signIn: '.feds-signin',
+  signIn: '.feds-signIn',
   profileButton: '.feds-profile-button, .feds-signIn',
   logo: '.gnav-logo',
   breadCrumbItems: '.feds-breadcrumbs li > a',

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -1,8 +1,11 @@
 import { getConfig, getMetadata, loadStyle } from '../../../utils/utils.js';
 
-const curtainSelector = '.feds-curtain';
-const navLink = '.feds-navLink';
-const globalNavSelector = '.global-navigation';
+export const selectors = {
+  globalNav: '.global-navigation',
+  curtain: '.feds-curtain',
+  navLink: '.feds-nav-link',
+};
+
 export function toFragment(htmlStrings, ...values) {
   const templateStr = htmlStrings.reduce((acc, htmlString, index) => {
     if (values[index] instanceof HTMLElement) {
@@ -110,17 +113,17 @@ export function decorateCta({ elem, type = 'primaryCta', index } = {}) {
 }
 
 export function closeAllDropdowns({ e } = {}) {
-  const openElements = document.querySelectorAll(`${globalNavSelector} [aria-expanded='true']`);
+  const openElements = document.querySelectorAll(`${selectors.globalNav} [aria-expanded='true']`);
   if (!openElements) return;
   if (e) e.preventDefault();
   [...openElements].forEach((el) => {
     el.setAttribute('aria-expanded', 'false');
-    if (el.closest(navLink)) {
+    if (el.closest(selectors.navLink)) {
       el.setAttribute('daa-lh', 'header|Open');
     }
   });
   // TODO the curtain will be refactored
-  document.querySelector(curtainSelector)?.classList.remove('is-open');
+  document.querySelector(selectors.curtain)?.classList.remove('is-open');
 }
 
 /**
@@ -142,7 +145,7 @@ export function trigger({ element } = {}) {
 export function expandTrigger({ element } = {}) {
   if (!element) return;
   closeAllDropdowns();
-  if (element.closest(navLink)) {
+  if (element.closest(selectors.navLink)) {
     element.setAttribute('daa-lh', 'header|Close');
   }
   element.setAttribute('aria-expanded', 'true');

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -3,7 +3,7 @@ import { getConfig, getMetadata, loadStyle } from '../../../utils/utils.js';
 export const selectors = {
   globalNav: '.global-navigation',
   curtain: '.feds-curtain',
-  navLink: '.feds-nav-link',
+  navLink: '.feds-navLink',
 };
 
 export function toFragment(htmlStrings, ...values) {
@@ -135,7 +135,7 @@ export function trigger({ element } = {}) {
   const isOpen = element?.getAttribute('aria-expanded') === 'true';
   closeAllDropdowns();
   if (isOpen) return false;
-  if (element.closest(navLink)) {
+  if (element.closest(selectors.navLink)) {
     element.setAttribute('daa-lh', 'header|Close');
   }
   element.setAttribute('aria-expanded', 'true');

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -23,7 +23,7 @@ describe('global navigation', () => {
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.brandContainer))).to.equal(true);
-      expect(isElementVisible(document.querySelector(selectors.gnavToggle))).to.equal(false);
+      expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(false);
       expect(document.querySelectorAll(selectors.navItem).length).to.equal(8);
     });
 
@@ -35,7 +35,7 @@ describe('global navigation', () => {
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.brandContainer))).to.equal(true);
-      expect(isElementVisible(document.querySelector(selectors.gnavToggle))).to.equal(false);
+      expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(false);
       expect(document.querySelectorAll(selectors.navItem).length).to.equal(8);
     });
 
@@ -47,7 +47,7 @@ describe('global navigation', () => {
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(false);
       expect(isElementVisible(document.querySelector(selectors.brandContainer))).to.equal(true);
-      expect(isElementVisible(document.querySelector(selectors.gnavToggle))).to.equal(true);
+      expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(true);
       expect(document.querySelectorAll(selectors.navItem).length).to.equal(8);
     });
   });
@@ -122,7 +122,7 @@ describe('global navigation', () => {
       it('should be hidden', async () => {
         await createFullGlobalNavigation();
 
-        expect(isElementVisible(document.querySelector(selectors.gnavToggle))).to.equal(false);
+        expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(false);
       });
     });
 
@@ -130,7 +130,7 @@ describe('global navigation', () => {
       it('should be hidden', async () => {
         await createFullGlobalNavigation({ viewport: 'smallDesktop' });
 
-        expect(isElementVisible(document.querySelector(selectors.gnavToggle))).to.equal(false);
+        expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(false);
       });
     });
 
@@ -138,14 +138,14 @@ describe('global navigation', () => {
       it('should be visible', async () => {
         await createFullGlobalNavigation({ viewport: 'mobile' });
 
-        expect(isElementVisible(document.querySelector(selectors.gnavToggle))).to.equal(true);
+        expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(true);
       });
 
       it('should open navigation on click', async () => {
         await createFullGlobalNavigation({ viewport: 'mobile' });
 
         const header = document.querySelector(selectors.globalNav);
-        const toggle = document.querySelector(selectors.gnavToggle);
+        const toggle = document.querySelector(selectors.mainNavToggle);
         const curtain = document.querySelector(selectors.curtain);
 
         expect(header.classList.contains('is-open')).to.equal(false);
@@ -264,7 +264,7 @@ describe('global navigation', () => {
           expect(isElementVisible(el)).to.equal(false);
         });
 
-        document.querySelector(selectors.gnavToggle).click();
+        document.querySelector(selectors.mainNavToggle).click();
 
         [...document.querySelectorAll(selectors.navItem)].forEach((el) => {
           expect(isElementVisible(el)).to.equal(true);
@@ -301,7 +301,7 @@ describe('global navigation', () => {
       it('should render the promo', async () => {
         await createFullGlobalNavigation();
 
-        document.querySelector(selectors.gnavToggle).click();
+        document.querySelector(selectors.mainNavToggle).click();
         document.querySelector(selectors.navLink).click();
 
         expect(isElementVisible(document.querySelector(selectors.promoImage))).to.equal(true);
@@ -335,7 +335,7 @@ describe('global navigation', () => {
       it('should render the promo', async () => {
         await createFullGlobalNavigation({ viewport: 'smallDesktop' });
 
-        document.querySelector(selectors.gnavToggle).click();
+        document.querySelector(selectors.mainNavToggle).click();
         document.querySelector(selectors.navLink).click();
 
         expect(isElementVisible(document.querySelector(selectors.promoImage))).to.equal(true);
@@ -346,7 +346,7 @@ describe('global navigation', () => {
       it('should open a popup and headline on click', async () => {
         await createFullGlobalNavigation({ viewport: 'mobile' });
 
-        document.querySelector(selectors.gnavToggle).click();
+        document.querySelector(selectors.mainNavToggle).click();
 
         const navItem = document.querySelector(selectors.navItem);
         const navLink = navItem.querySelector(selectors.navLink);
@@ -379,7 +379,7 @@ describe('global navigation', () => {
       it('should not render the promo', async () => {
         await createFullGlobalNavigation({ viewport: 'mobile' });
 
-        document.querySelector(selectors.gnavToggle).click();
+        document.querySelector(selectors.mainNavToggle).click();
         document.querySelector(selectors.navLink).click();
 
         expect(isElementVisible(document.querySelector(selectors.promoImage))).to.equal(false);
@@ -437,7 +437,7 @@ describe('global navigation', () => {
         await clock.runAllAsync();
 
         const searchResults = document.querySelector(selectors.searchResults);
-        const searchInput = document.querySelector(selectors.searchInput);
+        const searchInput = document.querySelector(selectors.searchField);
         window.fetch = sinon.stub().callsFake(() => mockRes({
           payload:
           { query_prefix: 'f', locale: 'en-US', suggested_completions: [{ name: 'framemaker', score: 578.15875, scope: 'learn' }, { name: 'fuse', score: 578.15875, scope: 'learn' }, { name: 'flash player', score: 578.15875, scope: 'learn' }, { name: 'framemaker publishing server', score: 578.15875, scope: 'learn' }, { name: 'fill & sign', score: 578.15875, scope: 'learn' }, { name: 'font folio', score: 578.15875, scope: 'learn' }, { name: 'free fonts for photoshop', score: 577.25055, scope: 'learn' }, { name: 'free lightroom presets', score: 577.25055, scope: 'learn' }, { name: 'frame', score: 577.25055, scope: 'learn' }, { name: 'frame for creative cloud', score: 577.25055, scope: 'learn' }], elastic_search_time: 1440.750028 },
@@ -472,7 +472,7 @@ describe('global navigation', () => {
         await clock.runAllAsync();
 
         const searchResults = document.querySelector(selectors.searchResults);
-        const searchInput = document.querySelector(selectors.searchInput);
+        const searchInput = document.querySelector(selectors.searchField);
         window.fetch = sinon.stub().callsFake(() => mockRes({ payload: { query_prefix: 'qwe12', locale: 'en-US', suggested_completions: [], elastic_search_time: 406.624478 } }));
 
         expect(document.querySelectorAll(selectors.searchResult).length).to.equal(0);
@@ -528,7 +528,7 @@ describe('global navigation', () => {
         await clock.runAllAsync();
 
         const searchResults = document.querySelector(selectors.searchResults);
-        const searchInput = document.querySelector(selectors.searchInput);
+        const searchInput = document.querySelector(selectors.searchField);
         window.fetch = sinon.stub().callsFake(() => mockRes({
           payload:
           { query_prefix: 'f', locale: 'en-US', suggested_completions: [{ name: 'framemaker', score: 578.15875, scope: 'learn' }, { name: 'fuse', score: 578.15875, scope: 'learn' }, { name: 'flash player', score: 578.15875, scope: 'learn' }, { name: 'framemaker publishing server', score: 578.15875, scope: 'learn' }, { name: 'fill & sign', score: 578.15875, scope: 'learn' }, { name: 'font folio', score: 578.15875, scope: 'learn' }, { name: 'free fonts for photoshop', score: 577.25055, scope: 'learn' }, { name: 'free lightroom presets', score: 577.25055, scope: 'learn' }, { name: 'frame', score: 577.25055, scope: 'learn' }, { name: 'frame for creative cloud', score: 577.25055, scope: 'learn' }], elastic_search_time: 1440.750028 },
@@ -569,11 +569,11 @@ describe('global navigation', () => {
       });
 
       it('fetches results from the search and clears them', async () => {
-        document.querySelector(selectors.gnavToggle).click();
+        document.querySelector(selectors.mainNavToggle).click();
         await clock.runAllAsync();
 
         const searchResults = document.querySelector(selectors.searchResults);
-        const searchInput = document.querySelector(selectors.searchInput);
+        const searchInput = document.querySelector(selectors.searchField);
         window.fetch = sinon.stub().callsFake(() => mockRes({
           payload:
           { query_prefix: 'f', locale: 'en-US', suggested_completions: [{ name: 'framemaker', score: 578.15875, scope: 'learn' }, { name: 'fuse', score: 578.15875, scope: 'learn' }, { name: 'flash player', score: 578.15875, scope: 'learn' }, { name: 'framemaker publishing server', score: 578.15875, scope: 'learn' }, { name: 'fill & sign', score: 578.15875, scope: 'learn' }, { name: 'font folio', score: 578.15875, scope: 'learn' }, { name: 'free fonts for photoshop', score: 577.25055, scope: 'learn' }, { name: 'free lightroom presets', score: 577.25055, scope: 'learn' }, { name: 'frame', score: 577.25055, scope: 'learn' }, { name: 'frame for creative cloud', score: 577.25055, scope: 'learn' }], elastic_search_time: 1440.750028 },
@@ -768,7 +768,7 @@ describe('global navigation', () => {
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.brandContainer))).to.equal(true);
-      expect(isElementVisible(document.querySelector(selectors.gnavToggle))).to.equal(false);
+      expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(false);
       expect(document.querySelectorAll(selectors.navItem).length).to.equal(8);
 
       await setViewport(viewports.smallDesktop);
@@ -778,7 +778,7 @@ describe('global navigation', () => {
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.brandContainer))).to.equal(true);
-      expect(isElementVisible(document.querySelector(selectors.gnavToggle))).to.equal(false);
+      expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(false);
       expect(document.querySelectorAll(selectors.navItem).length).to.equal(8);
 
       await setViewport(viewports.mobile);
@@ -788,7 +788,7 @@ describe('global navigation', () => {
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(false);
       expect(isElementVisible(document.querySelector(selectors.brandContainer))).to.equal(true);
-      expect(isElementVisible(document.querySelector(selectors.gnavToggle))).to.equal(true);
+      expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(true);
       expect(document.querySelectorAll(selectors.navItem).length).to.equal(8);
     });
 

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -18,7 +18,7 @@ describe('global navigation', () => {
       const nav = await createFullGlobalNavigation();
 
       expect(nav).to.exist;
-      expect(isElementVisible(document.querySelector(selectors.globalNavigation))).to.equal(true);
+      expect(isElementVisible(document.querySelector(selectors.globalNav))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.search))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(true);
@@ -30,7 +30,7 @@ describe('global navigation', () => {
     it('should render the navigation on smallDesktop', async () => {
       await createFullGlobalNavigation({ viewport: 'smallDesktop' });
 
-      expect(isElementVisible(document.querySelector(selectors.globalNavigation))).to.equal(true);
+      expect(isElementVisible(document.querySelector(selectors.globalNav))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.search))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(true);
@@ -42,7 +42,7 @@ describe('global navigation', () => {
     it('should render the navigation on mobile', async () => {
       await createFullGlobalNavigation({ viewport: 'mobile' });
 
-      expect(isElementVisible(document.querySelector(selectors.globalNavigation))).to.equal(true);
+      expect(isElementVisible(document.querySelector(selectors.globalNav))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.search))).to.equal(false);
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(false);
@@ -144,7 +144,7 @@ describe('global navigation', () => {
       it('should open navigation on click', async () => {
         await createFullGlobalNavigation({ viewport: 'mobile' });
 
-        const header = document.querySelector(selectors.globalNavigation);
+        const header = document.querySelector(selectors.globalNav);
         const toggle = document.querySelector(selectors.gnavToggle);
         const curtain = document.querySelector(selectors.curtain);
 
@@ -763,7 +763,7 @@ describe('global navigation', () => {
       const nav = await createFullGlobalNavigation();
 
       expect(nav).to.exist;
-      expect(isElementVisible(document.querySelector(selectors.globalNavigation))).to.equal(true);
+      expect(isElementVisible(document.querySelector(selectors.globalNav))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.search))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(true);
@@ -773,7 +773,7 @@ describe('global navigation', () => {
 
       await setViewport(viewports.smallDesktop);
 
-      expect(isElementVisible(document.querySelector(selectors.globalNavigation))).to.equal(true);
+      expect(isElementVisible(document.querySelector(selectors.globalNav))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.search))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(true);
@@ -783,7 +783,7 @@ describe('global navigation', () => {
 
       await setViewport(viewports.mobile);
 
-      expect(isElementVisible(document.querySelector(selectors.globalNavigation))).to.equal(true);
+      expect(isElementVisible(document.querySelector(selectors.globalNav))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.search))).to.equal(false);
       expect(isElementVisible(document.querySelector(selectors.profile))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.logo))).to.equal(false);

--- a/test/blocks/global-navigation/mocks/global-navigation-only-brand.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-only-brand.plain.js
@@ -4,13 +4,10 @@ export default `
   <div>
     <div>
       <p>
-        <a href="/drafts/ramuntea/adobe-logo.svg"
-          >http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg</a
-        >
+        <a href="/drafts/ramuntea/adobe-logo.svg">http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg</a>
       </p>
       <p><a href="https://www.adobe.com/">Adobe</a></p>
     </div>
-  </div>
   </div>
 </div>
 `;

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -12,37 +12,30 @@ import defaultPlaceholders from './mocks/placeholders.js';
 import defaultProfile from './mocks/profile.js';
 import largeMenuMock from './mocks/large-menu.plain.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
-import { isElementVisible } from '../../../libs/blocks/global-navigation/utilities/keyboard/utils.js';
+import { isElementVisible, selectors as keyboardSelectors } from '../../../libs/blocks/global-navigation/utilities/keyboard/utils.js';
 import { selectors as baseSelectors } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
 
 export { isElementVisible };
 
 export const selectors = {
   ...baseSelectors,
+  ...keyboardSelectors,
   brandContainer: '.feds-brand-container',
   brandLabel: '.feds-brand-label',
   brandImage: '.feds-brand-image',
-  gnavToggle: '.gnav-toggle',
   largeMenu: '.feds-navItem--megaMenu',
   profile: '.feds-profile',
   profileMenu: '.feds-profile-menu',
   signInDropdown: '.feds-signIn-dropdown',
-  signIn: '.feds-signIn',
-  popup: '.feds-popup',
   navItem: '.feds-navItem',
   search: '.feds-search',
-  searchTrigger: '.feds-search-trigger',
   searchDropdown: '.feds-search-dropdown',
-  searchInput: '.feds-search-input',
   searchResults: '.feds-search-results',
   searchResult: '.feds-search-result',
   searchClear: '.feds-search-clear',
-  logo: '.gnav-logo',
   navWrapper: '.feds-nav-wrapper',
-  headline: '.feds-menu-headline',
   popupItems: '.feds-menu-items',
   promoImage: '.feds-promo-image',
-  column: '.feds-menu-column',
   topNavWrapper: '.feds-topnav-wrapper',
   breadCrumbsWrapper: '.feds-breadcrumbs-wrapper',
   mainNav: '.feds-nav',

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -13,10 +13,12 @@ import defaultProfile from './mocks/profile.js';
 import largeMenuMock from './mocks/large-menu.plain.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
 import { isElementVisible } from '../../../libs/blocks/global-navigation/utilities/keyboard/utils.js';
+import { selectors as baseSelectors } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
 
 export { isElementVisible };
 
 export const selectors = {
+  ...baseSelectors,
   brandContainer: '.feds-brand-container',
   brandLabel: '.feds-brand-label',
   brandImage: '.feds-brand-image',
@@ -28,8 +30,6 @@ export const selectors = {
   signIn: '.feds-signIn',
   popup: '.feds-popup',
   navItem: '.feds-navItem',
-  navLink: '.feds-navLink',
-  globalNavigation: '.global-navigation',
   search: '.feds-search',
   searchTrigger: '.feds-search-trigger',
   searchDropdown: '.feds-search-dropdown',
@@ -39,11 +39,10 @@ export const selectors = {
   searchClear: '.feds-search-clear',
   logo: '.gnav-logo',
   navWrapper: '.feds-nav-wrapper',
-  curtain: '.feds-curtain',
-  headline: '.feds-popup-headline',
-  popupItems: '.feds-popup-items',
+  headline: '.feds-menu-headline',
+  popupItems: '.feds-menu-items',
   promoImage: '.feds-promo-image',
-  column: '.feds-popup-column',
+  column: '.feds-menu-column',
   topNavWrapper: '.feds-topnav-wrapper',
   breadCrumbsWrapper: '.feds-breadcrumbs-wrapper',
   mainNav: '.feds-nav',

--- a/test/blocks/global-navigation/utilities/getUserEntitlements.test.js
+++ b/test/blocks/global-navigation/utilities/getUserEntitlements.test.js
@@ -27,7 +27,7 @@ describe('getUserEntitlements', () => {
   });
   afterEach(() => {
     window.fetch = ogFetch;
-    window.adobeIMS = undefined;
+    delete window.adobeIMS;
   });
 
   it('should return empty entitlements if a user is not signed in', async () => {


### PR DESCRIPTION
- Correct navigation on the main navigation using the right, left key if document.dir === 'ltr' is not set, example on Firefox
- Do not close innocent dropdowns that don't want to get closed, such as the search when the clear button is clicked.

Resolves: [MWPW-130481](https://jira.corp.adobe.com/browse/MWPW-130481)

**Test URLs:**
- Before: https://gnav--milo--adobecom.hlx.page/drafts/ramuntea/gnav-refactor?martech=off#
- After: https://gnav-improvements--milo--mokimo.hlx.page/drafts/ramuntea/gnav-refactor?martech=off#
