### PR TITLE
MWPW-131190: Global-navigation correctly fetch placeholders for consumer .hlx. pages

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -24,19 +24,20 @@ export function toFragment(htmlStrings, ...values) {
   return fragment;
 }
 
-// TODO this is just prototyped
 export const getFedsPlaceholderConfig = () => {
-  const { locale, miloLibs, env } = getConfig();
+  const { locale } = getConfig();
   let libOrigin = 'https://milo.adobe.com';
+
   if (window.location.origin.includes('localhost')) {
     libOrigin = `${window.location.origin}`;
   }
 
-  if (window.location.origin.includes('.hlx.')) {
-    const baseMiloUrl = env.name === 'prod'
-      ? 'https://main--milo--adobecom.hlx.live'
-      : 'https://main--milo--adobecom.hlx.page';
-    libOrigin = miloLibs || `${baseMiloUrl}`;
+  if (window.location.origin.includes('.hlx.page')) {
+    libOrigin = 'https://main--milo--adobecom.hlx.page';
+  }
+
+  if (window.location.origin.includes('.hlx.live')) {
+    libOrigin = 'https://main--milo--adobecom.hlx.live';
   }
 
   return {


### PR DESCRIPTION
Correctly fetch placeholders from `.hlx.`-pages from the milo content path and not `/libs or miloLibs`

Resolves: [MWPW-131190](https://jira.corp.adobe.com/browse/MWPW-131190)

### Test instructions
- Observe the "sign in" label to be lowercase before, and capitalised after.
- And/or observe `placeholders` in the network tab to correctly return a 200 fetching from https://main--milo--adobecom.hlx.page/placeholders.json?sheet=feds

**Test URLs:**
- Before: https://main--stockpoc--adobecom.hlx.page/blog/?martech=off&headerqa=global-navigation
- After: https://main--stockpoc--adobecom.hlx.page/blog/?martech=off&headerqa=global-navigation&milolibs=mwpw-131190--milo--mokimo
