### PR TITLE
Finalized UAR Results

### DIFF
--- a/libs/blocks/uar-results/uar-results.css
+++ b/libs/blocks/uar-results/uar-results.css
@@ -1,3 +1,4 @@
+@import url("../section-metadata/section-metadata.css");
 .uar-results {
   visibility: hidden;
 }

--- a/libs/blocks/uar-results/uar-results.js
+++ b/libs/blocks/uar-results/uar-results.js
@@ -41,6 +41,8 @@ function setAnalytics(hashValue, debug) {
   }
 }
 
+export const loadingErrorText = 'Could not load UAR results:';
+
 export default async function init(el, debug = null, localStoreKey = null) {
   const data = getMetadata(el);
   const metaData = el.querySelectorAll('div');
@@ -57,7 +59,7 @@ export default async function init(el, debug = null, localStoreKey = null) {
 
   let results = localStorage.getItem(localStoreKey);
   if (!results) {
-    redirectPage(quizUrl, debug, 'Could not load UAR results: local storage missing');
+    redirectPage(quizUrl, debug, `${loadingErrorText} local storage missing`);
     return;
   }
   results = JSON.parse(results);
@@ -70,7 +72,7 @@ export default async function init(el, debug = null, localStoreKey = null) {
     const pageloadHash = results[HASH_KEY];
 
     if (!basic) {
-      redirectPage(quizUrl, debug, 'Could not load UAR results: Basic fragments are missing');
+      redirectPage(quizUrl, debug, `${loadingErrorText} Basic fragments are missing`);
       return;
     }
 

--- a/libs/blocks/uar-results/uar-results.js
+++ b/libs/blocks/uar-results/uar-results.js
@@ -1,10 +1,10 @@
-/* eslint-disable no-await-in-loop */
 import { createTag } from '../../utils/utils.js';
 import { getMetadata, handleStyle } from '../section-metadata/section-metadata.js';
 
 async function loadFragments(el, experiences) {
   // eslint-disable-next-line no-restricted-syntax
   for (const href of experiences) {
+    /* eslint-disable no-await-in-loop */
     const a = createTag('a', { href });
     el.append(a);
     const { default: createFragment } = await import('../fragment/fragment.js');
@@ -12,48 +12,83 @@ async function loadFragments(el, experiences) {
   }
 }
 
-function redirectPage(quizUrl) {
+function redirectPage(quizUrl, debug, message) {
   const url = (quizUrl) ? quizUrl.text : 'https://adobe.com';
-  console.log(`Invalid Result, redirecting to: ${url}`);
+  window.lana.log(message);
+
+  if (debug === 'uar') {
+    // eslint-disable-next-line no-console
+    console.log(`${message}, redirecting to: ${url}`);
+  } else {
+    window.location = url;
+  }
 }
 
-export default async function init(el) {
+function setAnalytics(hashValue, debug) {
+  /* eslint-disable no-underscore-dangle */
+  window.alloy_load ??= {};
+  window.alloy_load.data ??= {};
+  window.alloy_all ??= {};
+  window.alloy_all.data ??= {};
+  window.alloy_all.data._adobe_corpnew ??= {};
+  window.alloy_all.data._adobe_corpnew.digitalData ??= {};
+  window.alloy_all.data._adobe_corpnew.digitalData.page ??= {};
+  window.alloy_all.data._adobe_corpnew.digitalData.page.pageInfo ??= {};
+  window.alloy_all.data._adobe_corpnew.digitalData.page.pageInfo.customHash = hashValue;
+  if (debug === 'uar') {
+    // eslint-disable-next-line no-console
+    console.log(`Setting a custom hash for pageload to: ${window.alloy_all.data._adobe_corpnew.digitalData.page.pageInfo.customHash}`);
+  }
+}
+
+export default async function init(el, debug = null, localStoreKey = null) {
   const data = getMetadata(el);
   const metaData = el.querySelectorAll('div');
   const params = new URL(document.location).searchParams;
-  const localStoreKey = params.get('quizKey');
   const quizUrl = data['quiz-url'];
   const BASIC_KEY = 'basicFragments';
   const NESTED_KEY = 'nestedFragments';
+  const HASH_KEY = 'pageloadHash';
+
+  /* eslint-disable no-param-reassign */
+  // handle these two query param values in this way to facilitate unit tests
+  localStoreKey ??= params.get('quizKey');
+  debug ??= params.get('debug');
 
   let results = localStorage.getItem(localStoreKey);
-
-  for( const div of metaData){
-    div.remove();
-  }
-
   if (!results) {
-    redirectPage(quizUrl);
-    return
+    redirectPage(quizUrl, debug, 'Could not load UAR results: local storage missing');
+    return;
   }
-
   results = JSON.parse(results);
 
-  if(data['nested-fragments'] && el.classList.contains('nested')) {
+  if (data['nested-fragments'] && el.classList.contains('nested')) {
     const nested = results[NESTED_KEY][data['nested-fragments'].text];
     if (nested) loadFragments(el, nested);
   } else if (el.classList.contains('basic')) {
-    const structure = results[BASIC_KEY];
-    if (!structure) { 
-      redirectPage(quizUrl);
-      return
+    const basic = results[BASIC_KEY];
+    const pageloadHash = results[HASH_KEY];
+
+    if (!basic) {
+      redirectPage(quizUrl, debug, 'Could not load UAR results: Basic fragments are missing');
+      return;
     }
-    loadFragments(el, structure);
+
+    if (pageloadHash) {
+      setAnalytics(pageloadHash, debug);
+    }
+
+    loadFragments(el, basic);
   } else {
-    return
+    return;
   }
-  
-  if(data.style) {
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const div of metaData) {
+    div.remove();
+  }
+
+  if (data.style) {
     el.classList.add('section');
     handleStyle(data.style.text, el);
   }

--- a/test/blocks/uar-results/mocks/body.html
+++ b/test/blocks/uar-results/mocks/body.html
@@ -1,0 +1,34 @@
+<main>
+  <div class="uar-results basic-one basic">
+    <div>
+      <div>quiz-url</div>
+      <div>http://this-is-a-fake-redirect-url</div>
+    </div>
+  </div>
+  <div class="uar-results nested-one nested">
+    <div>
+      <div>nested-fragments</div>
+      <div>marquee-product</div>
+    </div>
+    <div>
+      <div>style</div>
+      <div>m-spacing</div>
+    </div>
+  </div>
+  <div class="uar-results nested-two nested">
+    <div>
+      <div>nested-fragments</div>
+      <div>marquee-product</div>
+    </div>
+    <div>
+      <div>style</div>
+      <div>m-spacing</div>
+    </div>
+  </div>
+  <div class="uar-results basic-two basic">
+    <div>
+      <div>quiz-url</div>
+      <div>http://this-is-a-fake-redirect-url</div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/uar-results/mocks/fragments/basic-frag.plain.html
+++ b/test/blocks/uar-results/mocks/fragments/basic-frag.plain.html
@@ -1,0 +1,3 @@
+<div>
+  <h1>This is a basic fragment</h1>
+</div>

--- a/test/blocks/uar-results/mocks/fragments/nested-frag.plain.html
+++ b/test/blocks/uar-results/mocks/fragments/nested-frag.plain.html
@@ -1,0 +1,3 @@
+<div>
+  <h2>This is a nested fragment</h2>
+</div>

--- a/test/blocks/uar-results/mocks/uar-results.mock-data.js
+++ b/test/blocks/uar-results/mocks/uar-results.mock-data.js
@@ -1,0 +1,35 @@
+const resultsMock = {
+  mockOne: {
+    badBasicFragments: [
+      '/test/blocks/uar-results/mocks/fragments/basic-frag',
+    ],
+    nestedFragments: {
+      'marquee-product': [
+        '/test/blocks/uar-results/mocks/fragments/nested-frag',
+      ],
+    },
+  },
+  mockTwo: {
+    basicFragments: [
+      '/test/blocks/uar-results/mocks/fragments/basic-frag',
+    ],
+    nestedFragments: {
+      'marquee-product': [
+        '/test/blocks/uar-results/mocks/fragments/nested-frag',
+      ],
+    },
+  },
+  mockThree: {
+    basicFragments: [
+      '/test/blocks/uar-results/mocks/fragments/basic-frag',
+    ],
+    nestedFragments: {
+      'marquee-product': [
+        '/test/blocks/uar-results/mocks/fragments/nested-frag',
+      ],
+    },
+    pageloadHash: 'test analytics value',
+  },
+};
+
+export default resultsMock;

--- a/test/blocks/uar-results/uar-results.test.js
+++ b/test/blocks/uar-results/uar-results.test.js
@@ -7,7 +7,7 @@ window.lana = { log: stub() };
 localStorage.clear();
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
-const { default: init } = await import('../../../libs/blocks/uar-results/uar-results.js');
+const { default: init, loadingErrorText } = await import('../../../libs/blocks/uar-results/uar-results.js');
 const { default: mockData } = await import('./mocks/uar-results.mock-data.js');
 
 describe('UAR Results', () => {
@@ -17,7 +17,7 @@ describe('UAR Results', () => {
 
     await init(el, 'uar', 'uar-test');
 
-    expect(window.lana.log.args[0][0]).to.equal('Could not load UAR results: local storage missing');
+    expect(window.lana.log.args[0][0]).to.equal(`${loadingErrorText} local storage missing`);
   });
   it('Doesnt load data without basicFragments in local storage', async () => {
     const el = document.body.querySelector('.basic-one');
@@ -25,7 +25,7 @@ describe('UAR Results', () => {
 
     await init(el, 'uar', 'uar-test');
 
-    expect(window.lana.log.args[1][0]).to.equal('Could not load UAR results: Basic fragments are missing');
+    expect(window.lana.log.args[1][0]).to.equal(`${loadingErrorText} Basic fragments are missing`);
   });
   it('Loads basic fragments', async () => {
     const el = document.body.querySelector('.basic-one');

--- a/test/blocks/uar-results/uar-results.test.js
+++ b/test/blocks/uar-results/uar-results.test.js
@@ -1,0 +1,66 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import { stub } from 'sinon';
+import { delay } from '../../helpers/waitfor.js';
+
+window.lana = { log: stub() };
+localStorage.clear();
+
+document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+const { default: init } = await import('../../../libs/blocks/uar-results/uar-results.js');
+const { default: mockData } = await import('./mocks/uar-results.mock-data.js');
+
+describe('UAR Results', () => {
+  it('Doesnt load data without local storage', async () => {
+    const el = document.body.querySelector('.basic');
+    localStorage.clear();
+
+    await init(el, 'uar', 'uar-test');
+
+    expect(window.lana.log.args[0][0]).to.equal('Could not load UAR results: local storage missing');
+  });
+  it('Doesnt load data without basicFragments in local storage', async () => {
+    const el = document.body.querySelector('.basic-one');
+    localStorage.setItem('uar-test', JSON.stringify(mockData.mockOne));
+
+    await init(el, 'uar', 'uar-test');
+
+    expect(window.lana.log.args[1][0]).to.equal('Could not load UAR results: Basic fragments are missing');
+  });
+  it('Loads basic fragments', async () => {
+    const el = document.body.querySelector('.basic-one');
+    localStorage.setItem('uar-test', JSON.stringify(mockData.mockTwo));
+
+    await init(el, 'uar', 'uar-test');
+
+    await delay(700);
+    expect(el.querySelector('h1')).to.be.exist;
+  });
+  it('Loads nested fragments', async () => {
+    const el = document.body.querySelector('.nested-one');
+    localStorage.setItem('uar-test', JSON.stringify(mockData.mockTwo));
+    await init(el, 'uar', 'uar-test');
+
+    await delay(700);
+    expect(el.querySelector('h2')).to.be.exist;
+  });
+  it('Sets style values', async () => {
+    const el = document.body.querySelector('.nested-two');
+    localStorage.setItem('uar-test', JSON.stringify(mockData.mockTwo));
+
+    await init(el, 'uar', 'uar-test');
+
+    await delay(700);
+    expect(el.classList.contains('section')).to.be.true;
+    expect(el.classList.contains('m-spacing')).to.be.true;
+  });
+  it('Sets analytics customHash', async () => {
+    const el = document.body.querySelector('.basic-two');
+    localStorage.setItem('uar-test', JSON.stringify(mockData.mockThree));
+
+    await init(el, 'uar', 'uar-test');
+
+    /* eslint-disable no-underscore-dangle */
+    expect(window.alloy_all.data._adobe_corpnew.digitalData.page.pageInfo.customHash).to.equal('test analytics value');
+  });
+});


### PR DESCRIPTION
* Lana logging  and a debug param to stop redirects (MWPW-125185)
* Set a value for pageload analytics (MWPW-128939)
* Unit tests (MWPW-130870)

Resolves: [MWPW-125185](https://jira.corp.adobe.com/browse/MWPW-125185)

Resolves: [MWPW-128939](https://jira.corp.adobe.com/browse/MWPW-128939)

Resolves: [MWPW-130870](https://jira.corp.adobe.com/browse/MWPW-130870)

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.page/drafts/colloyd/uar-results-block/uar-results?quizKey=cc-uar-result&martech=off
- After: https://uar-results-finalized--milo--colloyd.hlx.page/drafts/colloyd/uar-results-block/uar-results?quizKey=cc-uar-result&debug=uar&martech=off

To properly test this, you will need to add data to local storage for the before and after URL's. With quiz URL redirects now in place (for when the local store data is invalid), you must use the 'debug=uar' query param to manually set data. Ensure that you have the quizKey query param set like so: 

quizKey=cc-uar-result

Paste the following data into the cc-uar-result key in local storage:

{"primaryProducts":["lr","pr"],"secondaryProducts":["ps","au"],"umbrellaProduct":"cc","basicFragments":["https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-marquee-cc","https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-card-list"],"nestedFragments":{"marquee-product":["https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-marquee-product-lr","https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-marquee-product-pr"],"commerce-card":["https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-card-lr","https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-card-pr"]},"pageloadHash": "some-hash-value-that-matches-the-format-they-want-with-the-quiz-responses-that-were-chosen"}
