### PR TITLE
MWPW-131263: Preview API call updates for Floodgate

### DIFF
--- a/tools/floodgate/js/copy.js
+++ b/tools/floodgate/js/copy.js
@@ -6,7 +6,7 @@ import {
 } from '../../loc/sharepoint.js';
 import { hideButtons, loadingON, showButtons, simulatePreview } from '../../loc/utils.js';
 import { ACTION_BUTTON_IDS } from './ui.js';
-import { handleExtension } from './utils.js';
+import { delay, handleExtension } from './utils.js';
 
 const BATCH_REQUEST_COPY = 20;
 const DELAY_TIME_COPY = 3000;
@@ -71,16 +71,21 @@ async function floodgateContent(project, projectDetail) {
       batchArray[i].map((files) => copyFilesToFloodgateTree(files[1])),
     ));
     // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
-    await new Promise((resolve) => setTimeout(resolve, DELAY_TIME_COPY));
+    await delay(DELAY_TIME_COPY);
   }
   const endCopy = new Date();
 
   loadingON('Previewing for copied files... ');
-  const previewStatuses = await Promise.all(
-    copyStatuses
-      .filter((status) => status.success)
-      .map((status) => simulatePreview(handleExtension(status.srcPath), 1, true)),
-  );
+  const previewStatuses = [];
+  for (let i = 0; i < copyStatuses.length; i += 1) {
+    if (copyStatuses[i].success) {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await simulatePreview(handleExtension(copyStatuses[i].srcPath), 1, true);
+      previewStatuses.push(result);
+    }
+    // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+    await delay();
+  }
   loadingON('Completed Preview for copied files... ');
 
   const failedCopies = copyStatuses.filter((status) => !status.success)

--- a/tools/floodgate/js/utils.js
+++ b/tools/floodgate/js/utils.js
@@ -55,3 +55,8 @@ export function getDocPathFromUrl(url) {
 
   return `${path}.docx`;
 }
+
+export async function delay(milliseconds = 100) {
+  // eslint-disable-next-line no-promise-executor-return
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}


### PR DESCRIPTION
- The preview API call is now sequential to handle large sets. Also adds a delay per call similar to the bulk publish util.

Resolves: [MWPW-131263](https://jira.corp.adobe.com/browse/MWPW-131263)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B4EBD6F30-D51F-419B-BD0A-7485D4081302%257D%26file%3Dsample_fg_project.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue

- After: https://main--milo--sukamat.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B4EBD6F30-D51F-419B-BD0A-7485D4081302%257D%26file%3Dsample_fg_project.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
