### PR TITLE
Ensure the global navigation is displayed on top of page content

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -27,7 +27,7 @@
 header.global-navigation {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 10;
   background-color: var(--feds-background-nav--light);
   visibility: visible;
 }


### PR DESCRIPTION
Make sure the global navigation is displayed on top of existing page content when scrolling; the z-index value has been increased.

before:
<img width="854" alt="Screenshot 2023-05-18 at 13 00 29" src="https://github.com/adobecom/milo/assets/408175/006a4870-4c87-495c-8ce4-b81129ac821c">

after:
<img width="657" alt="Screenshot 2023-05-18 at 13 00 45" src="https://github.com/adobecom/milo/assets/408175/e43f7120-f48e-48dd-b00f-2b3cb31ee7c3">


Resolves: [MWPW-131203](https://jira.corp.adobe.com/browse/MWPW-131203)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/narcis/default?martech=off
- After: https://mwpw-131203--milo--narcis-radu.hlx.page/drafts/narcis/default?martech=off
