### PR TITLE
Address TODOs

### DIFF
--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -78,8 +78,6 @@ class ProfileDropdown {
         this.placeholders.manageEnterprise,
         this.placeholders.profileAvatar,
       ],
-      // TODO: sanity checks if the user is logged in and mandatory properties are set.
-      // If not, add logs providing guidance for developers
       { displayName: this.profileData.displayName, email: this.profileData.email },
     ] = await Promise.all([
       replaceKeyArray(

--- a/libs/blocks/global-navigation/features/search/gnav-search.js
+++ b/libs/blocks/global-navigation/features/search/gnav-search.js
@@ -129,8 +129,6 @@ class Search {
     this.isDesktop.addEventListener('change', () => {
       closeAllDropdowns();
     });
-
-    // TODO: search menu should close on scroll, but this should happen from the general Menu logic
   }
 
   getSuggestions(query = this.query) {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -256,14 +256,11 @@ class Gnav {
   };
 
   loadIMS = () => {
-    const { locale, imsClientId, env } = getConfig();
+    const { locale, imsClientId, imsScope, env } = getConfig();
     if (!imsClientId) return null;
-    // TODO-1 scopes should be defineable by the consumers
-    // We didn't have a use-case for that so far
-    // TODO-2 we should emit an event after the onReady callback
     window.adobeid = {
       client_id: imsClientId,
-      scope: 'AdobeID,openid,gnav',
+      scope: imsScope,
       locale: locale?.ietf?.replace('-', '_') || 'en_US',
       autoValidateToken: true,
       environment: env.ims,
@@ -337,7 +334,6 @@ class Gnav {
   };
 
   decorateAppLauncher = () => {
-    // TODO: review App Launcher component
     // const appLauncherBlock = this.body.querySelector('.app-launcher');
     // if (appLauncherBlock) {
     //   await this.loadDelayed();
@@ -633,7 +629,7 @@ class Gnav {
 
 export default async function init(header) {
   const { locale } = getConfig();
-  // TODO locale.contentRoot is not the fallback we want
+  // TODO locale.contentRoot is not the fallback we want if we implement centralized content
   const url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
   const resp = await fetch(`${url}.plain.html`);
   const html = await resp.text();

--- a/libs/blocks/global-navigation/utilities/keyboard/mainNav.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/mainNav.js
@@ -39,7 +39,6 @@ class MainNavItem {
             closeAllDropdowns();
             break;
           }
-          // TODO popup navigation logic.
           case 'ArrowLeft': {
             if (document.dir !== 'rtl') {
               if (this.prev === -1) break;

--- a/libs/blocks/global-navigation/utilities/onImsReady.js
+++ b/libs/blocks/global-navigation/utilities/onImsReady.js
@@ -1,0 +1,31 @@
+let ready = false;
+let existingCall = null;
+const onInstance = 'onImsLibInstance';
+
+const onImsReady = (timeout = 3000) => {
+  existingCall = existingCall || new Promise((resolve, reject) => {
+    const onFail = () => {
+      if (!ready) reject();
+    };
+    const waitTimeout = setTimeout(onFail, timeout);
+    const onSuccess = (data) => {
+      const instance = data?.detail?.instance;
+      if (!instance) {
+        reject();
+        return;
+      }
+
+      ready = true;
+      window.removeEventListener(onInstance, onSuccess);
+      clearTimeout(waitTimeout);
+      resolve(instance);
+    };
+
+    window.addEventListener(onInstance, onSuccess);
+    window.dispatchEvent(new window.CustomEvent('getImsLibInstance'));
+  });
+
+  return existingCall;
+};
+
+export default onImsReady;

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -123,7 +123,7 @@ export function closeAllDropdowns({ e } = {}) {
       el.setAttribute('daa-lh', 'header|Open');
     }
   });
-  // TODO the curtain will be refactored
+
   document.querySelector(selectors.curtain)?.classList.remove('is-open');
 }
 

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -109,6 +109,7 @@ const config = {
   fallbackRouting: 'on',
   links: 'on',
   imsClientId: 'milo',
+  imsScope: 'AdobeID,openid,gnav',
   codeRoot: '/libs',
   locales,
   prodDomains,


### PR DESCRIPTION
* Allow Milo consumers to configure ims custom scope
* Create `onImsReady` utility instead of dispatching an event; this should be more suitable for use-cases where logic is loaded **after** ims is ready.
* Call Subscriptions API using Milo configured language / locale
* Remove TODO for closing the search menu on scroll, this is not needed for sticky navigation
* There's a dedicated story for App Launcher, no need for an additional TODO - [MWPW-119227](https://jira.corp.adobe.com/browse/MWPW-119227)
* There's a dedicated story for refactoring the navigation curtain, no need for an additional TODO - [MWPW-131186](https://jira.corp.adobe.com/browse/MWPW-131186)
* Remove TODO for additional checks in Profile Menu dropdown, they are only needed in the standalone implementation which we're not doing anymore.
* Remove TODO from keyboard navigation logic, it has been already implemented.
* Update TODO for global navigation centralised content use-case; we need to check whether this is still required.

Resolves: [MWPW-131196](https://jira.corp.adobe.com/browse/MWPW-131196)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/narcis/default?martech=off
- After: https://quickfix--milo--narcis-radu.hlx.page/drafts/narcis/default?martech=off
