### PR TITLE
MWPW-131381 Move flags to sharepoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
       ImportDeclaration: { multiline: true, minProperties: 6 },
       ExportDeclaration: { multiline: true, minProperties: 6 },
     }],
+    'no-return-assign': ['error', 'except-parens'],
     'no-unused-expressions': 0,
     'chai-friendly/no-unused-expressions': 2,
 

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -179,11 +179,11 @@ function buildContent(currentPage, locale, geoData, locales) {
   const flagFile = getCodes(locale).length > 1 ? 'globe-grid.png' : `flag-${locale.geo}.svg`;
   const img = createTag('img', {
     class: 'icon-milo',
-    // src: `../../../libs/img/georouting/${flagFile}`,
     src: `${config.miloLibs || config.codeRoot}/img/georouting/${flagFile}`,
     width: 15,
     height: 15,
   });
+  img.addEventListener('error', () => (img.source = './img/globe-grid.png'), { once: true });
   const span = createTag('span', { class: 'icon margin-right' }, img);
   const mainAction = createTag('a', {
     class: 'con-button blue button-l', lang, role: 'button', 'aria-haspopup': !!locales, 'aria-expanded': false, href: '#',

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -179,11 +179,11 @@ function buildContent(currentPage, locale, geoData, locales) {
   const flagFile = getCodes(locale).length > 1 ? 'globe-grid.png' : `flag-${locale.geo}.svg`;
   const img = createTag('img', {
     class: 'icon-milo',
-    src: `${config.miloLibs || config.codeRoot}/img/georouting/${flagFile}`,
     width: 15,
     height: 15,
   });
-  img.addEventListener('error', () => (img.source = './img/globe-grid.png'), { once: true });
+  img.addEventListener('error', () => (img.src = './img/globe-grid.png'), { once: true });
+  img.src = `${config.miloLibs || config.codeRoot}/img/georouting/${flagFile}`;
   const span = createTag('span', { class: 'icon margin-right' }, img);
   const mainAction = createTag('a', {
     class: 'con-button blue button-l', lang, role: 'button', 'aria-haspopup': !!locales, 'aria-expanded': false, href: '#',

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -182,7 +182,11 @@ function buildContent(currentPage, locale, geoData, locales) {
     width: 15,
     height: 15,
   });
-  img.addEventListener('error', () => (img.src = './img/globe-grid.png'), { once: true });
+  img.addEventListener(
+    'error',
+    () => (img.src = `${config.miloLibs || config.codeRoot}/features/georoutingv2/img/globe-grid.png`),
+    { once: true },
+  );
   img.src = `${config.miloLibs || config.codeRoot}/img/georouting/${flagFile}`;
   const span = createTag('span', { class: 'icon margin-right' }, img);
   const mainAction = createTag('a', {

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -176,10 +176,11 @@ function buildContent(currentPage, locale, geoData, locales) {
   const titleText = geo.length ? geo[0][currentPage.geo] : '';
   const title = createTag('h3', { lang }, locale.title.replace('{{geo}}', titleText));
   const text = createTag('p', { class: 'locale-text', lang }, locale.text);
-  const flagFile = getCodes(locale).length > 1 ? 'globe-grid.png' : `flag_${locale.geo}.svg`;
+  const flagFile = getCodes(locale).length > 1 ? 'globe-grid.png' : `flag-${locale.geo}.svg`;
   const img = createTag('img', {
     class: 'icon-milo',
-    src: `${config.miloLibs || config.codeRoot}/features/georoutingv2/img/${flagFile}`,
+    // src: `../../../libs/img/georouting/${flagFile}`,
+    src: `${config.miloLibs || config.codeRoot}/img/georouting/${flagFile}`,
     width: 15,
     height: 15,
   });

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -100,6 +100,8 @@ const locales = {
   tw: { ietf: 'zh-TW', tk: 'jay0ecd' },
   jp: { ietf: 'ja-JP', tk: 'dvg6awq' },
   kr: { ietf: 'ko-KR', tk: 'qjs5sfm' },
+  // DEBUG
+  zz: { ietf: 'zz-ZZ', tk: 'qjs5sfm' },
   // Langstore Support.
   langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
 };

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -100,8 +100,6 @@ const locales = {
   tw: { ietf: 'zh-TW', tk: 'jay0ecd' },
   jp: { ietf: 'ja-JP', tk: 'dvg6awq' },
   kr: { ietf: 'ko-KR', tk: 'qjs5sfm' },
-  // DEBUG
-  zz: { ietf: 'zz-ZZ', tk: 'qjs5sfm' },
   // Langstore Support.
   langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
 };


### PR DESCRIPTION
This moves the loading of the country flag svgs from within the milo codebase:
https://milo.adobe.com/libs/features/georoutingv2/img/flag_ch.svg

to within sharepoint where authors can maintain the flag svgs:
https://milo.adobe.com/libs/img/georouting/flag-ch.svg

Note that _ have been changed to - since Franklin automatically converts underscores to dash.  I've also renamed all the flag files in sharepoint to use dashes instead of underscores in sharepoint/milo/libs/img/georouting/*.svg

Once we've verified the fix after merging we will be able to delete all of the flag files in /libs/features/georoutingv2/img

Resolves: [MWPW-131381](https://jira.corp.adobe.com/browse/MWPW-131381)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/experiment-test?akamaiLocale=ch&martech=off
- After: https://c3-flags--milo--adobecom.hlx.page/drafts/cpeyer/experiment-test?akamaiLocale=ch&martech=off

Testing Notes:
Inspect the country flag icon in the button.

For the "before" the img src will be to /libs/features/georoutingv2/img/flag_ch.svg

For the "after" the img src will be to /libs/img/georouting/flag-ch.svg