### PR TITLE
MWPW-129907 Blog Article Typography Corrections

### DIFF
--- a/libs/blocks/featured-article/featured-article.css
+++ b/libs/blocks/featured-article/featured-article.css
@@ -53,7 +53,7 @@
 .featured-article-card-body h3 {
   font-size: var(--type-heading-l-size);
   color: var(--text-color);
-  line-height: var(--type-heading-l-lh);
+  line-height: var(--type-heading-base-lh);
   margin: 0;
   margin-bottom: 1rem;
   overflow: hidden;

--- a/libs/styles/article-card.css
+++ b/libs/styles/article-card.css
@@ -71,7 +71,7 @@ main a.article-card:any-link {
 
 .article-card-body h3 {
   font-size: var(--type-heading-xs-size);
-  line-height: 1.25;
+  line-height: 1.3;
   margin: 0;
   margin-bottom: 1rem;
   overflow: hidden;

--- a/libs/styles/variables.css
+++ b/libs/styles/variables.css
@@ -66,6 +66,9 @@
   --type-heading-xxs-size: 14px;
   --type-heading-xxs-lh: 18px;
 
+  /* Headings (General) */
+  --type-heading-base-lh: 1.2;
+
   /* Body (Consonant) */
   --type-body-xxl-size: 28px;
   --type-body-xxl-lh: 42px;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fixes typography getting cut off in Featured Article block
* Fixes typography getting cut off in  Article Card block

Resolves: [MWPW-129907](https://jira.corp.adobe.com/browse/MWPW-129907)

**Test URLs:**
- Before: https://main--blog--adobecom.hlx.page/fr/?martech=off
- After: https://main--blog--adobecom.hlx.page/fr/?milolibs=blog-article-block-styling&martech=off

![image](https://github.com/adobecom/milo/assets/2539954/8f1babf5-dee9-4ddd-a8f2-47e2754e8259)

![image](https://github.com/adobecom/milo/assets/2539954/bea5cd5a-6365-42d8-abcc-74295e72a5c4)

