### PR TITLE
MWPW-129907 Blog Tags

### DIFF
--- a/libs/blocks/tags/tags.js
+++ b/libs/blocks/tags/tags.js
@@ -2,7 +2,7 @@ import { getTaxonomyModule, loadTaxonomy, computeTaxonomyFromTopics, getLinkForT
 import { createTag } from '../../utils/utils.js';
 
 export default async function init(blockEl) {
-  let tags = blockEl.firstElementChild?.firstElementChild?.textContent;
+  const tags = blockEl.firstElementChild?.firstElementChild?.textContent;
 
   if (!tags) return;
 
@@ -11,7 +11,6 @@ export default async function init(blockEl) {
   }
 
   blockEl.innerHTML = '';
-  tags = tags.replace(/[^a-zA-Z0-9,\s-]/g, '');
   const tagsArray = tags.split(', ').map((tag) => tag.trim());
   const articleTax = computeTaxonomyFromTopics(tagsArray);
   const tagsWrapper = createTag('p');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

This fixes a bug where Blog tags were getting stripped down to the point they no longer matched what was listed in the related taxonomy file. Causing tags to not render on the page.

Resolves: [MWPW-129907](https://jira.corp.adobe.com/browse/MWPW-129907)

**Test URLs:**
- Before: https://main--blog--adobecom.hlx.page/ko/publish/2021/04/20/how-to-convert-psd-to-png-or-jpg?martech=off
- After: https://main--blog--adobecom.hlx.page/ko/publish/2021/04/20/how-to-convert-psd-to-png-or-jpg?milolibs=blog-tags&martech=off

- Before: https://main--blog--adobecom.hlx.page/fr/publish/2023/04/27/rapport-rse-2022-d-adobe-donner-du-sens-a-notre-leadership?martech=off
- After: https://main--blog--adobecom.hlx.page/fr/publish/2023/04/27/rapport-rse-2022-d-adobe-donner-du-sens-a-notre-leadership?milolibs=blog-tags&martech=off

**Testing notes:**
Tags are placed at the bottom of the page, just before the footer.

![image](https://github.com/adobecom/milo/assets/2539954/9864ad14-9064-4407-a9b0-c8e1cf26d6bd)

