### PR TITLE
Provide default id for privacy

### DIFF
--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -21,13 +21,15 @@ export const loadJarvisChat = async (getConfig, getMetadata, loadScript, loadSty
 };
 
 export const loadPrivacy = async (getConfig, loadScript) => {
+  const acom = '7a5eb705-95ed-4cc4-a11d-0cc5760e93db';
   const ids = {
     'hlx.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271-test',
     'hlx.live': '926b16ce-cc88-4c6a-af45-21749f3167f3-test',
   };
 
   const otDomainId = ids?.[Object.keys(ids)
-    .find((domainId) => window.location.host.includes(domainId))] ?? getConfig()?.privacyId;
+    .find((domainId) => window.location.host.includes(domainId))]
+      ?? (getConfig()?.privacyId || acom);
   window.fedsConfig = {
     privacy: { otDomainId },
     documentLanguage: true,


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Default to acom privacy configuration if consumer does not provide a custom ID

Resolves: [MWPW-131663](https://jira.corp.adobe.com/browse/MWPW-131663)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/narcis/default?martech=off
- After: https://default-privacy--milo--narcis-radu.hlx.page/drafts/narcis/default?martech=off
