### PR TITLE
MWPW-127984: Make OST locale- and metadata-aware

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1,8 +1,8 @@
 import { loadScript, getConfig, getMetadata } from '../../utils/utils.js';
 
 export const VERSION = '1.16.0';
-const ENV_PROD = 'prod';
-const CTA_PREFIX = /^CTA +/;
+export const ENV_PROD = 'prod';
+export const CTA_PREFIX = /^CTA +/;
 
 const SUPPORTED_LANGS = [
   'ar', 'bg', 'cs', 'da', 'de', 'en', 'es', 'et', 'fi', 'fr', 'he', 'hu', 'it', 'ja', 'ko',
@@ -17,6 +17,32 @@ const GEO_MAPPINGS = {
   id_id: 'in-ID',
   no: 'nb-NO',
 };
+
+// eslint-disable-next-line import/prefer-default-export
+export function getTacocatLocale(locale) {
+  if (!locale) {
+    return { country: 'US', language: 'en' };
+  }
+  const wcsLocale = (GEO_MAPPINGS[locale.prefix] ?? locale.ietf).split('-', 2);
+  let language = wcsLocale[0];
+  const country = wcsLocale[1] || 'US';
+  if (!SUPPORTED_LANGS.includes(language)) {
+    language = 'en';
+  }
+  return { country, language };
+}
+
+export function getTacocatEnv(envName, locale) {
+  const { country, language } = getTacocatLocale(locale);
+  const host = envName === ENV_PROD
+    ? 'https://www.adobe.com'
+    : 'https://www.stage.adobe.com';
+
+  const literalScriptUrl = `${host}/special/tacocat/literals/${language}.js`;
+  const scriptUrl = `${host}/special/tacocat/lib/${VERSION}/tacocat.js`;
+  const tacocatEnv = envName === ENV_PROD ? 'PRODUCTION' : 'STAGE';
+  return { country, language, literalScriptUrl, scriptUrl, tacocatEnv };
+}
 
 export const omitNullValues = (target) => {
   if (target != null) {
@@ -50,23 +76,6 @@ export const imsCountryPromise = () => new Promise((resolve) => {
   }, 200);
 });
 window.tacocat.imsCountryPromise = imsCountryPromise();
-
-export const getTacocatEnv = (envName, locale) => {
-  const wcsLocale = (GEO_MAPPINGS[locale.prefix] ?? locale.ietf).split('-', 2);
-  let language = wcsLocale[0];
-  const country = wcsLocale[1] || 'US';
-  if (!SUPPORTED_LANGS.includes(language)) {
-    language = 'en';
-  }
-  const host = envName === ENV_PROD
-    ? 'https://www.adobe.com'
-    : 'https://www.stage.adobe.com';
-
-  const literalScriptUrl = `${host}/special/tacocat/literals/${language}.js`;
-  const scriptUrl = `${host}/special/tacocat/lib/${VERSION}/tacocat.js`;
-  const tacocatEnv = envName === ENV_PROD ? 'PRODUCTION' : 'STAGE';
-  return { literalScriptUrl, scriptUrl, country, language, tacocatEnv };
-};
 
 export const runTacocat = (tacocatEnv, country, language) => {
   // init lana logger

--- a/libs/blocks/ost/README.md
+++ b/libs/blocks/ost/README.md
@@ -13,3 +13,13 @@ Offer Selector Tool will assume an offer selector returns always a single offer,
 Offer Selector Tool is loaded in Milo as external JS and CSS files hosted in Stage environment.
 
 For more info on Tacocat.js or Offer Selector Tool visit https://git.corp.adobe.com/Dexter/tacocat.js/tree/develop/packages/offer-selector-tool
+
+## Development
+
+To prevent IMS from redirecting to sign-in page and back,
+so to check OST in a PR branch when test URL is not supported by IMS,
+perform the following:
+- navigate to adobe.com,
+- open devtools console,
+- execute `copy(adobeIMS.getAccessToken().token)`,
+- add token to OST URL querystring, e.g.: `https://mwpw-127984--milo--vladen.hlx.page/tools/ost?token=eyJhb...`

--- a/libs/blocks/ost/ost.js
+++ b/libs/blocks/ost/ost.js
@@ -1,4 +1,5 @@
-import { loadScript, loadStyle } from '../../utils/utils.js';
+import { getConfig, getLocale, getMetadata, loadScript, loadStyle } from '../../utils/utils.js';
+import { ENV_PROD, getTacocatEnv } from '../merch/merch.js';
 
 const IMS_COMMERCE_CLIENT_ID = 'aos_milo_commerce';
 const IMS_PROD_URL = 'https://auth.services.adobe.com/imslib/imslib.min.js';
@@ -7,17 +8,17 @@ const OST_BASE = `https://www.stage.adobe.com/special/tacocat/ost/lib/${OST_VERS
 const OST_SCRIPT_URL = `${OST_BASE}/index.js`;
 const OST_STYLE_URL = `${OST_BASE}/index.css`;
 
-const ENVIRONMENT = 'PROD';
-const WCS_API_KEY = 'wcms-commerce-ims-ro-user-cc';
-const AOS_API_KEY = 'wcms-commerce-ims-user-prod';
-const CHECKOUT_CLIENT_ID = 'creative';
+export const AOS_API_KEY = 'wcms-commerce-ims-user-prod';
+export const CHECKOUT_CLIENT_ID = 'creative';
+export const WCS_API_KEY = 'wcms-commerce-ims-ro-user-cc';
 
-const searchParameters = new URLSearchParams(window.location.search);
-// this is only for testing PRs where test URLs are not supported by IMS.
-const token = searchParameters.get('token');
-if (token) {
-  searchParameters.delete('token');
-}
+/**
+ * Maps Franklin page metadata to OST properties.
+ * Only values present in this object will be provided to OST.
+ * Each key of the object is metadata key.
+ * Each value - OST property name.
+ */
+const METADATA_MAPPINGS = { 'checkout-type': 'checkoutType' };
 
 document.body.classList.add('tool', 'tool-ost');
 
@@ -77,46 +78,88 @@ export function createLinkMarkup(
   return link;
 }
 
-let rootElement;
+export async function loadOstEnv() {
+  const searchParameters = new URLSearchParams(window.location.search);
+  const aosAccessToken = searchParameters.get('token');
+  searchParameters.delete('token');
+  const owner = searchParameters.get('owner');
+  const referrer = searchParameters.get('referrer');
+  const repo = searchParameters.get('repo');
 
-function initOST({ token: aosAccessToken }) {
-  const country = 'US';
-  const language = 'en';
+  let country;
+  let language;
+  let locale;
+  const { locales } = getConfig();
+  const metadata = {};
+  let url;
 
-  const options = {
-    rootMargin: '0px',
-    threshold: 1.0,
+  if (owner && referrer && repo) {
+    try {
+      const res = await fetch(`//admin.hlx.page/status/${owner}/${repo}/main?editUrl=${referrer}`);
+      if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+      const json = await res.json();
+      url = new URL(json.preview.url);
+      locale = getLocale(locales, url.pathname);
+      ({ country, language } = getTacocatEnv(ENV_PROD, locale));
+    } catch (e) {
+      console.error('OST, failed to get env:', e.message);
+      ({ country, language } = getTacocatEnv());
+    }
+
+    if (url) {
+      try {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(await res.text(), 'text/html');
+        Object.entries(METADATA_MAPPINGS).forEach(
+          ([key, value]) => {
+            const content = getMetadata(key, doc);
+            if (content) metadata[value] = content;
+          },
+        );
+      } catch (e) {
+        console.error('OST, failed to get metadata:', e.message);
+      }
+    }
+  }
+
+  ({ country, language } = getTacocatEnv(ENV_PROD, locale));
+
+  return {
+    ...metadata,
+    aosAccessToken,
+    aosApiKey: AOS_API_KEY,
+    checkoutClientId: CHECKOUT_CLIENT_ID,
+    country,
+    environment: ENV_PROD.toUpperCase(),
+    language,
+    searchParameters,
+    wcsApiKey: WCS_API_KEY,
   };
-
-  const main = document.querySelector('main');
-  const observer = new IntersectionObserver(() => {
-    observer.unobserve(main);
-    window.ost.openOfferSelectorTool({
-      country,
-      language,
-      environment: ENVIRONMENT,
-      wcsApiKey: WCS_API_KEY,
-      aosApiKey: AOS_API_KEY,
-      aosAccessToken,
-      checkoutClientId: CHECKOUT_CLIENT_ID,
-      searchParameters,
-      createLinkMarkup,
-      rootElement,
-    });
-  }, options);
-  observer.observe(main);
 }
 
 export default async function init(el) {
-  if (rootElement) return; // only one OST is supported per page
   el.innerHTML = '<div />';
-  rootElement = el.firstElementChild;
 
   loadStyle(OST_STYLE_URL);
-  await loadScript(OST_SCRIPT_URL);
-  await loadStyle('https://use.typekit.net/pps7abe.css');
-  if (token) {
-    initOST({ token });
+  loadStyle('https://use.typekit.net/pps7abe.css');
+
+  const [ostEnv] = await Promise.all([
+    loadOstEnv(),
+    loadScript(OST_SCRIPT_URL),
+  ]);
+
+  function openOst() {
+    window.ost.openOfferSelectorTool({
+      ...ostEnv,
+      createLinkMarkup,
+      rootElement: el.firstElementChild,
+    });
+  }
+
+  if (ostEnv.aosAccessToken) {
+    openOst();
   } else {
     window.adobeid = {
       client_id: IMS_COMMERCE_CLIENT_ID,
@@ -124,7 +167,10 @@ export default async function init(el) {
       optimizations: { fastEvents: true },
       autoValidateToken: true,
       scope: 'AdobeID,openid',
-      onAccessToken: initOST,
+      onAccessToken: ({ token }) => {
+        ostEnv.aosAccessToken = token;
+        openOst();
+      },
       onReady: () => {
         if (!window.adobeIMS.isSignedInUser()) {
           window.adobeIMS.signIn();

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -4,7 +4,15 @@ import sinon from 'sinon';
 import { createTag, setConfig } from '../../../libs/utils/utils.js';
 
 const config = setConfig({ codeRoot: '/libs', env: { name: 'local' } });
-const { default: merch, VERSION, getTacocatEnv, imsCountryPromise, runTacocat } = await import('../../../libs/blocks/merch/merch.js');
+const {
+  default: merch,
+  VERSION,
+  getTacocatEnv,
+  getTacocatLocale,
+  getTacocatMetadata,
+  imsCountryPromise,
+  runTacocat,
+} = await import('../../../libs/blocks/merch/merch.js');
 
 document.head.innerHTML = await readFile({ path: './mocks/head.html' });
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
@@ -365,6 +373,31 @@ describe('Merch Block', () => {
         country: 'US',
         language: 'en',
       })).to.be.true;
+    });
+  });
+
+  describe('Utils', () => {
+    describe('getTacocatLocale', () => {
+      it('returns default locale if argument is not provided', () => {
+        expect(getTacocatLocale()).to.deep.equal({
+          country: 'US',
+          language: 'en',
+        });
+      });
+
+      it('returns locale extracted from provided argument', () => {
+        expect(getTacocatLocale({ ietf: 'de-CH' })).to.deep.equal({
+          country: 'CH',
+          language: 'de',
+        });
+      });
+
+      it('returns locale geo-mapped from provided argument', () => {
+        expect(getTacocatLocale({ prefix: 'africa' })).to.deep.equal({
+          country: 'ZA',
+          language: 'en',
+        });
+      });
     });
   });
 });

--- a/test/blocks/ost/mocks/ost-utils.js
+++ b/test/blocks/ost/mocks/ost-utils.js
@@ -1,0 +1,104 @@
+import sinon from 'sinon';
+
+const ogFetch = window.fetch;
+const ogUrl = window.location.href;
+
+const getConfig = () => ({
+  env: { name: 'local' },
+  locales: {
+    '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+    ch_de: { ietf: 'de-CH', tk: 'vin7zsi.css' },
+  },
+});
+
+const getLocale = (locales, pathname) => locales[pathname.split('/', 2)[1]?.toLowerCase()] || locales[''];
+
+function getMetadata(name, doc = document) {
+  const attr = name && name.includes(':') ? 'property' : 'name';
+  const meta = doc.head.querySelector(`meta[${attr}="${name}"]`);
+  return meta && meta.content;
+}
+
+const loadScript = () => Promise.resolve();
+
+const loadStyle = () => Promise.resolve();
+
+const mockRes = ({ payload, status = 200 } = {}) => new Promise((resolve) => {
+  resolve({
+    status,
+    statusText: '',
+    ok: status === 200,
+    json: () => payload,
+    text: () => payload,
+  });
+});
+
+function mockOstDeps({ failStatus = false, failMetadata = false, mockToken } = {}) {
+  const options = {
+    checkoutType: 'UCv2',
+    country: 'CH',
+    language: 'de',
+  };
+
+  const params = {
+    ref: 'main',
+    repo: 'milo',
+    owner: 'adobecom',
+    host: 'milo.adobe.com',
+    project: 'Milo',
+    referrer: 'https://adobe.sharepoint.com/:w:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B341A5A28-4B2F-4BC0-B7D4-6467E22B275C%7D&file=index.docx&action=default&mobileredirect=true',
+    token: mockToken ? 'aos-access-token' : undefined,
+  };
+
+  window.fetch = sinon.stub()
+    .onFirstCall()
+    .callsFake(
+      () => (
+        failStatus
+          ? mockRes({ status: 500 })
+          : mockRes({ payload: { preview: { url: `https://hlx.page/${options.country}_${options.language}/drafts/page` } } })
+      ),
+    )
+    .onSecondCall()
+    .callsFake(
+      () => (
+        failMetadata
+          ? mockRes({ status: 500 })
+          : mockRes({ payload: `<head><meta name="checkout-type" content="${options.checkoutType}"></head>` })
+      ),
+    );
+
+  window.adobeIMS = {
+    isSignedInUser: sinon.stub().returns(false),
+    signIn: sinon.stub(),
+  };
+  window.ost = { openOfferSelectorTool: sinon.spy() };
+  window.tacocat = {
+    initLanaLogger: sinon.spy(),
+    tacocat: sinon.spy(),
+  };
+
+  const url = new URL(window.location.href);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value) url.searchParams.set(key, value);
+  });
+  window.history.replaceState({}, '', url);
+
+  document.body.innerHTML = '<main><div class="ost"><div /></div></main>';
+
+  return { options, params };
+}
+
+function unmockOstDeps() {
+  document.body.innerHTML = '';
+  delete window.ost;
+  delete window.tacocat;
+  delete window.adobeid;
+  delete window.adobeIMS;
+  window.fetch = ogFetch;
+  window.history.replaceState({}, '', ogUrl);
+}
+
+export {
+  getConfig, getLocale, getMetadata, loadScript, loadStyle, mockOstDeps, mockRes, unmockOstDeps,
+};

--- a/test/blocks/ost/ost.test.html
+++ b/test/blocks/ost/ost.test.html
@@ -1,0 +1,20 @@
+<html>
+  <head>
+    <script type="importmap">
+      {
+        "imports": {
+          "../../../libs/utils/utils.js": "./mocks/ost-utils.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <script type="module">
+      import { runTests } from '@web/test-runner-mocha';
+
+      runTests(async () => {
+        await import('./ost.test.html.js');
+      });
+    </script>
+  </body>
+</html>

--- a/test/blocks/ost/ost.test.html.js
+++ b/test/blocks/ost/ost.test.html.js
@@ -1,0 +1,142 @@
+import { expect } from '@esm-bundle/chai';
+
+import { mockOstDeps, unmockOstDeps } from './mocks/ost-utils.js';
+
+afterEach(() => {
+  unmockOstDeps();
+});
+
+describe('loadOstEnv', async () => {
+  it('fetches and returns page status and metadata', async () => {
+    const {
+      options: { checkoutType, country, language },
+      params,
+    } = mockOstDeps({ mockToken: true });
+
+    const {
+      AOS_API_KEY,
+      CHECKOUT_CLIENT_ID,
+      WCS_API_KEY,
+      loadOstEnv,
+    } = await import('../../../libs/blocks/ost/ost.js');
+
+    expect(await loadOstEnv()).to.include({
+      aosAccessToken: params.token,
+      aosApiKey: AOS_API_KEY,
+      checkoutClientId: CHECKOUT_CLIENT_ID,
+      checkoutType,
+      country,
+      environment: 'PROD',
+      language,
+      wcsApiKey: WCS_API_KEY,
+    });
+  });
+
+  it('tolerates page metadata request fail', async () => {
+    const { options: { country, language } } = mockOstDeps({ failMetadata: true });
+
+    const {
+      AOS_API_KEY,
+      CHECKOUT_CLIENT_ID,
+      WCS_API_KEY,
+      loadOstEnv,
+    } = await import('../../../libs/blocks/ost/ost.js');
+
+    expect(await loadOstEnv()).to.include({
+      aosAccessToken: null,
+      aosApiKey: AOS_API_KEY,
+      checkoutClientId: CHECKOUT_CLIENT_ID,
+      country,
+      environment: 'PROD',
+      language,
+      wcsApiKey: WCS_API_KEY,
+    });
+  });
+
+  it('tolerates page status request fail', async () => {
+    mockOstDeps({ failStatus: true });
+
+    const {
+      AOS_API_KEY,
+      CHECKOUT_CLIENT_ID,
+      WCS_API_KEY,
+      loadOstEnv,
+    } = await import('../../../libs/blocks/ost/ost.js');
+
+    expect(await loadOstEnv()).to.include({
+      aosAccessToken: null,
+      aosApiKey: AOS_API_KEY,
+      checkoutClientId: CHECKOUT_CLIENT_ID,
+      country: 'US',
+      environment: 'PROD',
+      language: 'en',
+      wcsApiKey: WCS_API_KEY,
+    });
+  });
+});
+
+describe('init', () => {
+  it('opens OST without waiting for IMS if query string includes token', async () => {
+    const {
+      options: { checkoutType, country, language },
+      params: { token },
+    } = mockOstDeps({ mockToken: true });
+
+    const {
+      AOS_API_KEY,
+      CHECKOUT_CLIENT_ID,
+      WCS_API_KEY,
+      default: init,
+    } = await import('../../../libs/blocks/ost/ost.js');
+    await init(document.body.firstChild);
+
+    expect(window.ost.openOfferSelectorTool.called).to.be.true;
+    expect(window.ost.openOfferSelectorTool.getCall(0).args[0]).to.include({
+      aosAccessToken: token,
+      aosApiKey: AOS_API_KEY,
+      checkoutClientId: CHECKOUT_CLIENT_ID,
+      checkoutType,
+      country,
+      environment: 'PROD',
+      language,
+      wcsApiKey: WCS_API_KEY,
+    });
+  });
+
+  it('waits for IMS callback to open OST if query string does not include token', async () => {
+    const { options: { checkoutType, country, language } } = mockOstDeps({ mockToken: false });
+
+    const token = 'test-token';
+    const {
+      AOS_API_KEY,
+      CHECKOUT_CLIENT_ID,
+      WCS_API_KEY,
+      default: init,
+    } = await import('../../../libs/blocks/ost/ost.js');
+    await init(document.body.firstChild);
+
+    expect(window.ost.openOfferSelectorTool.called).to.be.false;
+    window.adobeid.onAccessToken({ token });
+
+    expect(window.ost.openOfferSelectorTool.called).to.be.true;
+    expect(window.ost.openOfferSelectorTool.getCall(0).args[0]).to.include({
+      aosAccessToken: token,
+      aosApiKey: AOS_API_KEY,
+      checkoutClientId: CHECKOUT_CLIENT_ID,
+      checkoutType,
+      country,
+      environment: 'PROD',
+      language,
+      wcsApiKey: WCS_API_KEY,
+    });
+  });
+
+  it('forces IMS sign-in for anonymous user when IMS is ready', async () => {
+    mockOstDeps({ failStatus: true });
+
+    const { default: init } = await import('../../../libs/blocks/ost/ost.js');
+    await init(document.body.firstChild);
+    window.adobeid.onReady();
+    expect(window.adobeIMS.signIn.called).to.be.true;
+  });
+});

--- a/test/blocks/ost/ost.test.js
+++ b/test/blocks/ost/ost.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
-import { createLinkMarkup } from '../../../libs/blocks/ost/ost.js';
+
+const { createLinkMarkup } = await import('../../../libs/blocks/ost/ost.js');
 
 const data = await readFile({ path: './mocks/wcs-artifacts-mock.json' });
 const { stockOffer } = JSON.parse(data);
@@ -16,6 +17,7 @@ const placeholderOptions = {
   displayTax: true, // tax
   isPerpetual: true,
 };
+
 describe('test createLinkMarkup', () => {
   const WINDOW_LOCATION = 'https://main--milo--adobecom.hlx.page';
   const location = {

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -93,7 +93,9 @@
       "title": "Use offer",
       "environments": [ "edit", "dev", "preview" ],
       "url": "https://milo.adobe.com/tools/ost",
-      "includePaths": [ "**.docx**" ]
+      "includePaths": [ "**.docx**" ],
+      "passConfig": true,
+      "passReferrer": true
     }
   ]
 }


### PR DESCRIPTION
Resolves: [MWPW-127984](https://jira.corp.adobe.com/browse/MWPW-127984)

Milo OST block is updated to:

- accept "owner", "referrer", and "repo" querystring parameters,
  - these parameters are normally passed to any sidekick plugin configured with "passConfig" and "passReferrer",
- use these parameters to fetch page preview URL from the admin AP,
- use fetched preview url to:
  - determine page locale,
  - fetch page metadata,
- initialise OST with country, language and OST-related metadata (checkoutType etc.)

**Test URLs:**

> Please, first add your IMS token at the end test URL by following [this instruction](https://github.com/adobecom/milo/pull/771/files#diff-b8a8e71badbe17831d377dd74d796fa3e1e98ab182354e62bb86364fd01f1720R18)

This URL opens OST as if it was opened for page `/ch_de/drafts/vlassenko/merch`:
- https://mwpw-127984--milo--vladen.hlx.page/tools/ost?ref=mwpw-127984&repo=milo&owner=vladen&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Aw%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B973CA587-0213-4E91-A522-68EBE971CAAD%257D%26file%3Dmerch.docx%26action%3Ddefault%26mobileredirect%3Dtrue%26cid%3Dc4089511-e384-4737-8288-3fb233bcffe6&token=

![image](https://github.com/adobecom/milo/assets/7460740/81164b64-c7b4-40ca-a15b-f56c6c6b6c79)

