### PR TITLE
Remove contentRoot dependency to create locale path in georouting modal

### DIFF
--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -71,15 +71,20 @@ const getAkamaiCode = () => new Promise((resolve) => {
 async function getAvailableLocales(locales) {
   const fallback = getMetadata('fallbackrouting') || config.fallbackRouting;
 
-  const { contentRoot } = config.locale;
-  const path = window.location.href.replace(contentRoot, '');
+ /* const { contentRoot } = config.locale;
+  const path = window.location.href.replace(contentRoot, '');*/
+
+  const { prefix } = config.locale;
+  const path = window.location.href.replace(`${window.location.origin}${prefix}`, '')
+  console.log("path: "+path);
 
   const availableLocales = [];
   const pagesExist = [];
   locales.forEach((locale, index) => {
     const prefix = locale.prefix ? `/${locale.prefix}` : '';
-    const localeRoot = `${prefix}${config.contentRoot ?? ''}`;
-    const localePath = `${localeRoot}${path}`;
+    //const localeRoot = `${prefix}${config.contentRoot ?? ''}`;
+    const localePath = `${prefix}${path}`;
+    console.log("localePath: "+localePath);
 
     const pageExistsRequest = fetch(localePath, { method: 'HEAD' }).then((resp) => {
       if (resp.ok) {

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -71,20 +71,14 @@ const getAkamaiCode = () => new Promise((resolve) => {
 async function getAvailableLocales(locales) {
   const fallback = getMetadata('fallbackrouting') || config.fallbackRouting;
 
- /* const { contentRoot } = config.locale;
-  const path = window.location.href.replace(contentRoot, '');*/
-
   const { prefix } = config.locale;
   const path = window.location.href.replace(`${window.location.origin}${prefix}`, '')
-  console.log("path: "+path);
 
   const availableLocales = [];
   const pagesExist = [];
   locales.forEach((locale, index) => {
     const prefix = locale.prefix ? `/${locale.prefix}` : '';
-    //const  = `${prefix}${config.contentRoot ?? ''}`;
     const localePath = `${prefix}${path}`;
-    console.log("localePath: "+localePath);
 
     const pageExistsRequest = fetch(localePath, { method: 'HEAD' }).then((resp) => {
       if (resp.ok) {

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -82,7 +82,7 @@ async function getAvailableLocales(locales) {
   const pagesExist = [];
   locales.forEach((locale, index) => {
     const prefix = locale.prefix ? `/${locale.prefix}` : '';
-    //const localeRoot = `${prefix}${config.contentRoot ?? ''}`;
+    //const  = `${prefix}${config.contentRoot ?? ''}`;
     const localePath = `${prefix}${path}`;
     console.log("localePath: "+localePath);
 
@@ -91,7 +91,7 @@ async function getAvailableLocales(locales) {
         locale.url = localePath;
         availableLocales[index] = locale;
       } else if (fallback !== 'off') {
-        locale.url = `${localeRoot}/`;
+        locale.url = `${prefix}/`;
         availableLocales[index] = locale;
       }
     });


### PR DESCRIPTION
* Bug fix for georouting when content root is used.

Resolves: [MWPW-131669](https://jira.corp.adobe.com/browse/MWPW-131669)

**Test URLs:**
CC (which has contentRoot)
When page exists for all locales in the georouting popup

- Before: https://stage--cc--adobecom.hlx.page/de/creativecloud/photography/hub/guides/aperture-iris?akamaiLocale=fr&martech=off
- After: https://stage--cc--adobecom.hlx.page/de/creativecloud/photography/hub/guides/aperture-iris?akamaiLocale=fr&milolibs=georouting&martech=off

When page doesn't exists for one of the locales in the georouting popup

- Before: https://stage--cc--adobecom.hlx.page/creativecloud/video/hub/ideas/what-is-a-contrast-cut?akamaiLocale=in&martech=off
- After: https://stage--cc--adobecom.hlx.page/creativecloud/video/hub/ideas/what-is-a-contrast-cut?akamaiLocale=in&milolibs=georouting&martech=off

Bacom (which doesn't have contentRoot defined)
- Before: https://main--bacom--adobecom.hlx.page/kr/customer-success-stories?milolibs=georouting&martech=off
- After: https://main--bacom--adobecom.hlx.page/kr/customer-success-stories?milolibs=georouting&martech=off

Note:

I do need confirmation in the scenario when page doesn't exists for one of the locales in the georouting popup. Like here 
https://stage--cc--adobecom.hlx.page/creativecloud/video/hub/ideas/what-is-a-contrast-cut?akamaiLocale=in&milolibs=georouting&martech=off

The page it is redirecting to with this implementation is domain/locale (screenshot below). With current implementation it redirects to domain/locale/contentRoot
<img width="1378" alt="Screen Shot 2023-05-24 at 7 36 44 PM" src="https://github.com/adobecom/milo/assets/69535463/9db4baa8-e35c-438d-959a-fac8484ad437">




