### PR TITLE
MWPW-128694 Removing duplicated projectRoot param and using rootFolder and fgRoot…

### DIFF
--- a/tools/floodgate/js/floodgate.js
+++ b/tools/floodgate/js/floodgate.js
@@ -30,8 +30,6 @@ async function floodgateContentAction(project, config) {
 async function promoteContentAction(project, config) {
   const params = getParams(project, config);
   params.spToken = getAccessToken();
-  // consider fgRoot as the project path for promote action.
-  params.projectRoot = config.sp.fgRootFolder;
   const promoteStatus = await postData(config.sp.aioPromoteAction, params);
   updateProjectStatusUIFromAction({ promoteStatus });
 }

--- a/tools/floodgate/js/utils.js
+++ b/tools/floodgate/js/utils.js
@@ -74,7 +74,6 @@ export function getParams(project, config) {
   return {
     adminPageUri: window.location.href,
     projectExcelPath: project.excelPath,
-    projectRoot: config.sp.rootFolders,
     shareUrl: config.sp.shareUrl,
     fgShareUrl: config.sp.fgShareUrl,
     rootFolder: config.sp.rootFolders,


### PR DESCRIPTION
- Removing duplicate parameters for copy/promote action calls. 

Resolves:

- [MWPW-128694](https://jira.corp.adobe.com/browse/MWPW-128694)

Test URLs:

**Before**: https://main--milo--adobecom.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B753F31A9-CA16-4B78-AE9C-BAD08AE0688A%257D%26file%3Dfgtest.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
**After**: https://mwpw-128693-fg-actions-fetching-aio--milo--sirivuri.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B753F31A9-CA16-4B78-AE9C-BAD08AE0688A%257D%26file%3Dfgtest.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue