### PR TITLE
Add divider-inherit css to support different color divider

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -88,6 +88,10 @@
   border-bottom: 1px solid #d8d8d8;
 }
 
+.section.divider-inherit {   
+  border-bottom: 1px solid; 
+}
+
 .section.center[class*='-up'] {
   justify-items: center;
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding a divider style row just adds a divider class.
* Extent the syntax to add an inherit option to not specify the color.
* That way, the divider would just follow the text color and give us what we would like. 

Resolves: [MWPW-131449](https://jira.corp.adobe.com/browse/MWPW-131449)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/fragments/xiasun/divider?martech=off
- After: https://main--milo--JackySun9.hlx.page/fragments/xiasun/divider?martech=off

I need to add an usage example to the section metadata documentation after the PR is merged.
