### PR TITLE
Improve navigation support when modals are displayed

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -31,6 +31,9 @@ function closeModal(modal) {
     document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();
   });
 
+  [...document.querySelectorAll('header, main, footer')]
+    .forEach((element) => element.removeAttribute('aria-disabled'));
+
   const hashId = window.location.hash.replace('#', '');
   if (hashId === modal.id) window.history.pushState('', document.title, `${window.location.pathname}${window.location.search}`);
 }
@@ -131,6 +134,8 @@ export async function getModal(details, custom) {
       if (e.target === curtain) closeModal(dialog);
     });
     dialog.insertAdjacentElement('afterend', curtain);
+    [...document.querySelectorAll('header, main, footer')]
+      .forEach((element) => element.setAttribute('aria-disabled', 'true'));
   }
 
   return dialog;

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -181,6 +181,7 @@ function buildContent(currentPage, locale, geoData, locales) {
     class: 'icon-milo',
     width: 15,
     height: 15,
+    alt: locale.button,
   });
   img.addEventListener(
     'error',


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Georouting modal: provide alternate text for country flags
* Modal: disable TAB navigation outside the modal when rendered
* Modal: ignore non-modal content when modal is rendered

Resolves: [MWPW-131868](https://jira.corp.adobe.com/browse/MWPW-131868)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/narcis/default?martech=off
- After: https://accessibility--milo--narcis-radu.hlx.page/drafts/narcis/default?martech=off
