### PR TITLE
Georouting text direction

### DIFF
--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -173,10 +173,11 @@ function openPicker(button, locales, country, event) {
 function buildContent(currentPage, locale, geoData, locales) {
   const fragment = new DocumentFragment();
   const lang = config.locales[currentPage.prefix]?.ietf ?? '';
+  const dirAttribute = config.locales[locale.prefix]?.dir ?? 'ltr';
   const geo = geoData.filter((c) => c.prefix === locale.prefix);
   const titleText = geo.length ? geo[0][currentPage.geo] : '';
-  const title = createTag('h3', { lang }, locale.title.replace('{{geo}}', titleText));
-  const text = createTag('p', { class: 'locale-text', lang }, locale.text);
+  const title = createTag('h3', { lang, dir: `${dirAttribute}` }, locale.title.replace('{{geo}}', titleText));
+  const text = createTag('p', { class: 'locale-text', lang, dir: `${dirAttribute}` }, locale.text);
   const flagFile = getCodes(locale).length > 1 ? 'globe-grid.png' : `flag-${locale.geo}.svg`;
   const img = createTag('img', {
     class: 'icon-milo',

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -101,6 +101,23 @@ const locales = {
   kr: { ietf: 'ko-KR', tk: 'qjs5sfm' },
   // Langstore Support.
   langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
+  // geo expansion
+  za: { ietf: 'en-GB', tk: 'pps7abe.css' },
+  ng: { ietf: 'en-GB', tk: 'pps7abe.css' },
+  cr: { ietf: 'es-419', tk: 'oln4yqj.css' },
+  ec: { ietf: 'es-419', tk: 'oln4yqj.css' },
+  pr: { ietf: 'es-419', tk: 'oln4yqj.css' },
+  gt: { ietf: 'es-419', tk: 'oln4yqj.css' },
+  eg_ar: { ietf: 'ar', tk: 'nwq1mna.css', dir: 'rtl' },
+  kw_ar: { ietf: 'ar', tk: 'nwq1mna.css', dir: 'rtl' },
+  qa_ar: { ietf: 'ar', tk: 'nwq1mna.css', dir: 'rtl' },
+  eg_en: { ietf: 'en-GB', tk: 'pps7abe.css' },
+  kw_en: { ietf: 'en-GB', tk: 'pps7abe.css' },
+  qa_en: { ietf: 'en-GB', tk: 'pps7abe.css' },
+  gr_el: { ietf: 'el', tk: 'fnx0rsr.css' },
+  el: { ietf: 'el', tk: 'aaz7dvd.css' },
+  vn_vi: { ietf: 'vi', tk: 'jii8bki.css' },
+  vn_en: { ietf: 'en-GB', tk: 'pps7abe.css' },
 };
 
 const config = {

--- a/test/features/georoutingv2/georoutingv2.test.js
+++ b/test/features/georoutingv2/georoutingv2.test.js
@@ -7,7 +7,7 @@ const { createTag, loadStyle, loadBlock, setConfig } = await import('../../../li
 
 const mockConfig = {
   locales: {
-    '': { ietf: 'us' }, ch_de: {}, ch_fr: {}, ch_it: {}, mena_en: {}, de: {}, africa: {},
+    '': { ietf: 'us' }, ch_de: {}, ch_fr: {}, ch_it: {}, mena_en: {}, de: {}, africa: {}, eg_ar: { dir: 'rtl' }, eg_en: { },
   },
   locale: { contentRoot: window.location.href, prefix: '' },
   env: 'test',
@@ -88,6 +88,26 @@ const mockGeoroutingJson = {
         languageOrder: '',
         geo: 'africa',
       },
+      {
+        prefix: 'eg_ar',
+        title: 'موقع Adobe هذا لا يتطابق مع موقعك.',
+        text: 'بناءً على موقعك ، نعتقد أنك قد تفضل موقع مصر ، حيث ستحصل على المحتوى الجغرافي والعروض والأسعار',
+        button: 'مصر - اللغة العربية',
+        akamaiCodes: 'EG',
+        language: 'عربي',
+        languageOrder: '1',
+        geo: 'eg',
+      },
+      {
+        prefix: 'eg_en',
+        title: "You're visiting Adobe.com for {{geo}}",
+        text: "Based on your location, we think you may prefer the Egypt website, where you'll get geoal content, offerings, and pricing",
+        button: 'Egypt',
+        akamaiCodes: 'EG',
+        language: 'English',
+        languageOrder: '2',
+        geo: 'eg',
+      },
     ],
   },
   geos: {
@@ -147,6 +167,25 @@ const mockGeoroutingJson = {
         mena: 'the Middle East & North Africa',
         africa: 'Africa',
       },
+      {
+        prefix: 'eg_ar',
+        us: 'الولايات المتحدة الأمريكية',
+        de: 'ألمانيا',
+        ch: 'سويسرا',
+        mena: 'الشرق الأوسط وشمال أفريقيا',
+        africa: 'أفريقيا',
+        eg: 'مصر',
+      },
+      {
+        prefix: 'eg_en',
+        us: 'the United States',
+        de: 'Germany',
+        ch: 'Switzerland',
+        mena: 'the Middle East & North Africa',
+        africa: 'Africa',
+        eg: 'Egypt',
+      },
+
     ],
   },
 };
@@ -290,6 +329,54 @@ describe('GeoRouting', () => {
     expect(italianTab.querySelector('p').textContent).to.be.equal(italianData.text);
     expect(italianTab.querySelector('.con-button').textContent).to.be.equal(italianData.button);
     expect(italianTab.querySelectorAll('a')[1].textContent).to.be.equal(usData.button);
+  });
+
+  it('If aiming for US page but IP in Egypt arabic content in geo routing modal is in rtl', async () => {
+    // prepare
+    setUserCountryFromIP('EG');
+    await init(mockConfig, createTag, getMetadata, loadBlock, loadStyle);
+    const modal = document.querySelector('.dialog-modal');
+    // assert
+    expect(modal).to.not.be.null;
+    const tabs = modal.querySelectorAll('.tabpanel');
+    expect(tabs.length).to.be.equal(2);
+    const arabicTab = tabs[0];
+    expect(arabicTab.querySelector('h3').getAttribute('dir')).to.be.equal('rtl');
+    expect(arabicTab.querySelector('p').getAttribute('dir')).to.be.equal('rtl');
+    // Cleanup
+    setUserCountryFromIP('CH');
+  });
+
+  it('If aiming for US page but IP in Egypt english content in geo routing modal is in ltr', async () => {
+    // prepare
+    setUserCountryFromIP('EG');
+    await init(mockConfig, createTag, getMetadata, loadBlock, loadStyle);
+    const modal = document.querySelector('.dialog-modal');
+    // assert
+    expect(modal).to.not.be.null;
+    const tabs = modal.querySelectorAll('.tabpanel');
+    expect(tabs.length).to.be.equal(2);
+    const englishTab = tabs[1];
+    expect(englishTab.querySelector('h3').getAttribute('dir')).to.be.equal('ltr');
+    expect(englishTab.querySelector('p').getAttribute('dir')).to.be.equal('ltr');
+    // Cleanup
+    setUserCountryFromIP('CH');
+  });
+
+  it('If aiming for Arabic page but IP in US english content in geo routing modal is in ltr', async () => {
+    // prepare
+    mockConfig.locale.prefix = 'eg_ar';
+    setUserCountryFromIP('US');
+    await init(mockConfig, createTag, getMetadata, loadBlock, loadStyle);
+    const modal = document.querySelector('.dialog-modal');
+    const wrapper = document.querySelector('.georouting-wrapper');
+    // assert
+    expect(modal).to.not.be.null;
+    expect(wrapper.querySelector('h3').getAttribute('dir')).to.be.equal('ltr');
+    expect(wrapper.querySelector('p').getAttribute('dir')).to.be.equal('ltr');
+    // Cleanup
+    setUserCountryFromIP('CH');
+    mockConfig.locale.prefix = '';
   });
 
   it('If aiming for CH page, IP in US, and session storage is DE shows DE links and CH continue', async () => {


### PR DESCRIPTION
* Fix for matching georouting modal text direction to modal language and not site

Resolves: [MWPW-131201](https://jira.corp.adobe.com/browse/MWPW-131201)

**Test URLs:**

If visiting ltr page from country with rtl language

- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/us-page-ar-ip?akamaiLocale=eg&martech=off
- After: https://georouting-text-direction--milo--ruchika4.hlx.page/drafts/ruchika/us-page-ar-ip?akamaiLocale=eg&martech=off

If visiting rtl page from country with ltr language

- Before: https://main--milo--adobecom.hlx.page/ae_ar/drafts/ruchika/ar-page-us-ip?martech=off
- After: https://georouting-text-direction--milo--ruchika4.hlx.page/ae_ar/drafts/ruchika/ar-page-us-ip?martech=off

Note: I have also added new geos in scripts.js as part of this PR as I wanted to add a unit test case for the exact case mentioned in the jira. Please let me know if it is a concern.

