### PR TITLE
Unit tests - surface external requests

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -47,7 +47,7 @@ export default {
           window.fetch = async (resource, options) => {
             if (!resource.startsWith("/") && !resource.startsWith('http://localhost')) {
               console.error(
-                '** External resource fetch is disallowed in unit tests, please find a way to mock!',
+                '** fetch request for an external resource is disallowed in unit tests, please find a way to mock!',
                 resource
               );
             }
@@ -58,7 +58,7 @@ export default {
             let [method, url, asyn] = args;
             if (!resource.startsWith("/") && url.startsWith('http://localhost')) {
               console.error(
-                '** XMLHttpRequest request is disallowed in unit tests, please find a way to mock!',
+                '** XMLHttpRequest request for an external resource is disallowed in unit tests, please find a way to mock!',
                 url
               );
             }

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -39,4 +39,35 @@ export default {
     defaultReporter({ reportTestResults: true, reportTestProgress: true }),
     customReporter(),
   ],
+  testRunnerHtml: (testFramework) => `
+    <html>
+      <head>
+        <script type="module">
+          const oldFetch = window.fetch;
+          window.fetch = async (resource, options) => {
+            if (!resource.startsWith("/") && !resource.startsWith('http://localhost')) {
+              console.error(
+                '** External resource fetch is disallowed in unit tests, please find a way to mock!',
+                resource
+              );
+            }
+            return oldFetch.call(window, resource, options);
+          };
+          const oldXHROpen = XMLHttpRequest.prototype.open;
+          XMLHttpRequest.prototype.open = async function (...args) {
+            let [method, url, asyn] = args;
+            if (!resource.startsWith("/") && url.startsWith('http://localhost')) {
+              console.error(
+                '** XMLHttpRequest request is disallowed in unit tests, please find a way to mock!',
+                url
+              );
+            }
+            return oldXHROpen.apply(this, args);
+          };
+        </script>
+      </head>
+      <body>
+        <script type="module" src="${testFramework}"></script>
+      </body>
+    </html>`,
 };

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -42,10 +42,10 @@ export default {
   testRunnerHtml: (testFramework) => `
     <html>
       <head>
-        <script type="module">
+        <script type='module'>
           const oldFetch = window.fetch;
           window.fetch = async (resource, options) => {
-            if (!resource.startsWith("/") && !resource.startsWith('http://localhost')) {
+            if (!resource.startsWith('/') && !resource.startsWith('http://localhost')) {
               console.error(
                 '** fetch request for an external resource is disallowed in unit tests, please find a way to mock!',
                 resource
@@ -56,7 +56,7 @@ export default {
           const oldXHROpen = XMLHttpRequest.prototype.open;
           XMLHttpRequest.prototype.open = async function (...args) {
             let [method, url, asyn] = args;
-            if (!resource.startsWith("/") && url.startsWith('http://localhost')) {
+            if (!resource.startsWith('/') && url.startsWith('http://localhost')) {
               console.error(
                 '** XMLHttpRequest request for an external resource is disallowed in unit tests, please find a way to mock!',
                 url
@@ -67,7 +67,7 @@ export default {
         </script>
       </head>
       <body>
-        <script type="module" src="${testFramework}"></script>
+        <script type='module' src='${testFramework}'></script>
       </body>
     </html>`,
 };


### PR DESCRIPTION

## Description
**Log if a unit test does a request to an external resource.** 

## Relations
A step towards: [MWPW-129653](https://jira.corp.adobe.com/browse/MWPW-129653)

## Benefits
This takes up bandwidth, leads to slower unit tests and worst of all sporadically fails them if the resource isn't provided on time.
This should provide some feedback to devs writing unit tests and discourage requesting any resource that does not live on localhost.

## Example
![Screenshot 2023-05-31 at 14 07 09](https://github.com/adobecom/milo/assets/39759830/6ccc5586-e88f-454c-ad6d-537414252028)
