### PR TITLE
MWPW-125675 - [Core] Milo Bulk Publish

### DIFF
--- a/libs/blocks/bulk-publish/bulk-publish.js
+++ b/libs/blocks/bulk-publish/bulk-publish.js
@@ -335,8 +335,8 @@ function BulkPublish({ user, storedOperation }) {
 function initUrlLimit() {
   if (urlLimit) return;
   const { searchParams } = new URL(window.location.href);
-  const limit = Number(searchParams.get('limit'));
-  urlLimit = !Number.isNaN(limit) ? limit : URLS_ENTRY_LIMIT;
+  const limit = searchParams.get('limit');
+  urlLimit = limit ? Number(limit) || URLS_ENTRY_LIMIT : URLS_ENTRY_LIMIT;
 }
 
 export default async function init(el) {


### PR DESCRIPTION
- fix: URLs max = 0 when the request has no limit param

Resolves: [MWPW-125675](https://jira.corp.adobe.com/browse/MWPW-125675)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/bulk-publish?martech=off&limit=25
- After: https://bulk-limit-2--milo--adobecom.hlx.page/tools/bulk-publish?martech=off&limit=25
