### PR TITLE
Updating LastRun status column from AIO action calls instead of reading from Project Excel file

### DIFF
--- a/tools/floodgate/js/floodgate.js
+++ b/tools/floodgate/js/floodgate.js
@@ -6,12 +6,10 @@ import {
   initProject,
   updateProjectWithDocs,
   purgeAndReloadProjectFile,
-  updateProjectStatus,
 } from './project.js';
 import {
   updateProjectInfo,
   updateProjectDetailsUI,
-  updateProjectStatusUIFromAction,
   updateProjectStatusUI,
 } from './ui.js';
 
@@ -24,7 +22,7 @@ async function floodgateContentAction(project, config) {
   const params = getParams(project, config);
   params.spToken = getAccessToken();
   const copyStatus = await postData(config.sp.aioCopyAction, params);
-  updateProjectStatusUIFromAction({ copyStatus });
+  updateProjectStatusUI({ copyStatus });
 }
 
 async function promoteContentAction(project, config) {
@@ -32,10 +30,10 @@ async function promoteContentAction(project, config) {
   params.spToken = getAccessToken();
   // Based on User selection on the Promote Dialog,
   // passing the param if user also wants to Publish the Promoted pages.
-  params.doPublish = 'promotePublish' ===
-    document.querySelector('input[name="promotePublishRadio"]:checked')?.value;
+  params.doPublish = document.querySelector('input[name="promotePublishRadio"]:checked')?.value
+    === 'promotePublish';
   const promoteStatus = await postData(config.sp.aioPromoteAction, params);
-  updateProjectStatusUIFromAction({ promoteStatus });
+  updateProjectStatusUI({ promoteStatus });
 }
 
 async function fetchStatusAction(project, config) {
@@ -48,7 +46,7 @@ async function fetchStatusAction(project, config) {
   // fetch promote status
   params = { projectRoot: config.sp.fgRootFolder };
   const promoteStatus = await postData(config.sp.aioStatusAction, params);
-  updateProjectStatusUIFromAction({ copyStatus, promoteStatus });
+  updateProjectStatusUI({ copyStatus, promoteStatus });
 }
 
 async function refreshPage(config, projectDetail, project) {
@@ -62,8 +60,6 @@ async function refreshPage(config, projectDetail, project) {
 
   // Read the project action status
   loadingON('Updating project status...');
-  const status = await updateProjectStatus(project);
-  updateProjectStatusUI(status);
 
   await fetchStatusAction(project, config);
   loadingON('UI updated..');

--- a/tools/floodgate/js/ui.js
+++ b/tools/floodgate/js/ui.js
@@ -98,18 +98,15 @@ async function updateProjectDetailsUI(projectDetail, config) {
 }
 
 function updateProjectStatusUI(status) {
-  document.querySelector('#copy-status-ts').innerHTML = status.copy.lastRun;
-  document.querySelector('#promote-status-ts').innerHTML = status.promote.lastRun;
-}
-
-function updateProjectStatusUIFromAction(status) {
   if (status?.copyStatus?.payload?.action?.type === 'copyAction') {
     document.querySelector('#copy-status').innerHTML = status.copyStatus.payload.action.status;
     document.querySelector('#copy-status-msg').innerHTML = status.copyStatus.payload.action.message;
+    document.querySelector('#copy-status-ts').innerHTML = status.copyStatus.payload.action.startTime;
   }
   if (status?.promoteStatus?.payload?.action?.type === 'promoteAction') {
     document.querySelector('#promote-status').innerHTML = status.promoteStatus.payload.action.status;
     document.querySelector('#promote-status-msg').innerHTML = status.promoteStatus.payload.action.message;
+    document.querySelector('#promote-status-ts').innerHTML = status.promoteStatus.payload.action.startTime;
   }
   document.querySelector('.project-status').hidden = false;
 }
@@ -118,6 +115,5 @@ export {
   updateProjectInfo,
   updateProjectDetailsUI,
   updateProjectStatusUI,
-  updateProjectStatusUIFromAction,
   ACTION_BUTTON_IDS,
 };


### PR DESCRIPTION
- Updating LastRun status column from AIO action calls instead of reading from Project Excel file

Resolves: [MWPW-131802](https://jira.corp.adobe.com/browse/MWPW-131802)

- milo-fg PR to store start and end times for fg actions - https://github.com/adobecom/milo-fg/pull/31


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B753F31A9-CA16-4B78-AE9C-BAD08AE0688A%257D%26file%3Dfgtest.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
- After: https://mwpw-131802--milo--sirivuri.hlx.page/tools/floodgate/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B753F31A9-CA16-4B78-AE9C-BAD08AE0688A%257D%26file%3Dfgtest.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue

