### PR TITLE
Surface unit test errors and point to a solution source

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "wtr --config ./web-test-runner.config.mjs \"./test/**/*.test.(js|html)\" --node-resolve --port=2000 --coverage --concurrent-browsers 4",
     "test:watch": "npm test -- --watch",
     "test:file": "wtr --config ./web-test-runner.config.mjs --node-resolve --port=2000 --coverage",
+    "test:file:watch": "wtr --config ./web-test-runner.config.mjs --node-resolve --port=2000 --coverage --watch",
     "libs": "hlx up --port=6456",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint .",

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -47,7 +47,7 @@ export default {
           window.fetch = async (resource, options) => {
             if (!resource.startsWith('/') && !resource.startsWith('http://localhost')) {
               console.error(
-                '** fetch request for an external resource is disallowed in unit tests, please find a way to mock! https://github.com/adobecom/milo/pull/814 provides guidance on how to fix the issue.',
+                '** fetch request for an external resource is disallowed in unit tests, please find a way to mock! https://github.com/orgs/adobecom/discussions/814#discussioncomment-6060759 provides guidance on how to fix the issue.',
                 resource
               );
             }
@@ -59,7 +59,7 @@ export default {
             let [method, url, asyn] = args;
             if (!resource.startsWith('/') && url.startsWith('http://localhost')) {
               console.error(
-                '** XMLHttpRequest request for an external resource is disallowed in unit tests, please find a way to mock! https://github.com/adobecom/milo/pull/814 provides guidance on how to fix the issue.',
+                '** XMLHttpRequest request for an external resource is disallowed in unit tests, please find a way to mock! https://github.com/orgs/adobecom/discussions/814#discussioncomment-6060759 provides guidance on how to fix the issue.',
                 url
               );
             }
@@ -72,7 +72,7 @@ export default {
                 for(let node of mutation.addedNodes) {
                   if(node.nodeName === 'SCRIPT' && node.src && !node.src.startsWith('http://localhost')) {
                     console.error(
-                      '** An external 3rd script has been added. This is disallowed in unit tests, please find a way to mock! https://github.com/adobecom/milo/pull/814 provides guidance on how to fix the issue.',
+                      '** An external 3rd script has been added. This is disallowed in unit tests, please find a way to mock! https://github.com/orgs/adobecom/discussions/814#discussioncomment-6060891 provides guidance on how to fix the issue.',
                       node.src
                     );
                   }
@@ -87,4 +87,7 @@ export default {
         <script type='module' src='${testFramework}'></script>
       </body>
     </html>`,
+  // Comment in the files for selectively running test suites
+  // npm run test:file:watch allows to you to run single test file & view the result in a browser.
+  // files: ['**/utils.test.js'],
 };


### PR DESCRIPTION
### Description
I played around with directly supplying an import map for all tests and mocking [all the utils](https://github.com/mokimo/milo/blob/import-maps-TODO/web-test-runner.config.mjs#L42-L62) but the major drawback of import maps in this specific case are that they aren't compatible with dynamic imports. It leads to a lot of headache and confusion, so I've abandoned that approach.

Instead, we can just log unit-test smells and provide developers with enough guidance https://github.com/orgs/adobecom/discussions/814

Resolves: [MWPW-129653](https://jira.corp.adobe.com/browse/MWPW-129653)

### More logs for when external scripts are loaded
I'm not the biggest fan of having a lot of logs BUT it's the only viable way we can provide guidance to milo core developers on what to look out for when writing unit tests.
When running tests in isolation it's also not a tremendous amount of logs to watch out for.
![Screenshot 2023-06-01 at 15 00 30](https://github.com/adobecom/milo/assets/39759830/a72ca3b5-7a1a-4af6-9e96-e139de5ff99c)
