### PR TITLE
Update label email groups

### DIFF
--- a/.github/workflows/email-release.yaml
+++ b/.github/workflows/email-release.yaml
@@ -16,7 +16,8 @@ jobs:
       - name: Use email bot
         uses: adobecom/milo-email-bot@main
         env:
-          TO_EMAIL: ${{ secrets.TO_EMAIL }}
+          TO_EMAIL_NEW_FEATURE: ${{ secrets.TO_EMAIL_NEW_FEATURE }}
+          TO_EMAIL_HIGH_IMPACT: ${{ secrets.TO_EMAIL_HIGH_IMPACT }}
           FROM_EMAIL: 'bot@em2344.milo.pink'
           FROM_NAME: 'Milo Bot'
           SG_KEY: ${{ secrets.SG_KEY }}


### PR DESCRIPTION
Email bot now supports sending mail to 2 separate group lists.

NEW_FEATURE goes to everyone
HIGH_IMPACT goes to milo and consumer devs

milo email bot PR: https://github.com/adobecom/milo-email-bot/pull/8

Do not merge until changes to email bot and email config have been done.
