### PR TITLE
Bulk preview/publish: increase throttling

### DIFF
--- a/libs/blocks/bulk-publish/bulk-publish-utils.js
+++ b/libs/blocks/bulk-publish/bulk-publish-utils.js
@@ -3,7 +3,7 @@ import { loadScript } from '../../utils/utils.js';
 import { getImsToken } from '../../../tools/utils/utils.js';
 
 export const ADMIN_BASE_URL = 'https://admin.hlx.page';
-const THROTTLING_DELAY_MS = 100;
+const THROTTLING_DELAY_MS = 300;
 export const BULK_CONFIG_FILE_PATH = '/tools/bulk-publish/config.json';
 export const BULK_REPORT_FILE_PATH = '/tools/bulk-publish/report';
 const BULK_AUTHORIZED_USERS = 'bulkAuthorizedUsers';


### PR DESCRIPTION
- increase throttling to defend against overwhelming Sharepoint when bulk previewing large set of URLs

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/bulk-publish?martech=off
- After: https://bulk-throttling--milo--adobecom.hlx.page/tools/bulk-publish?martech=off
