### PR TITLE
MWPW-132092, MWPW-132094, MWPW-132096 - RTL gnav footer and region-nav fix

### DIFF
--- a/libs/blocks/footer/footer.css
+++ b/libs/blocks/footer/footer.css
@@ -107,6 +107,7 @@ footer a:not(:any-link) {
   content: '\2227';
   position: relative;
   left: -10px;
+  right: -10px;
   transform: scaleX(1.5);
   font-size: 12px;
 }

--- a/libs/blocks/footer/footer.css
+++ b/libs/blocks/footer/footer.css
@@ -98,6 +98,7 @@ footer a:not(:any-link) {
   content: '\2228';
   position: relative;
   left: -10px;
+  right: -10px;
   transform: scaleX(1.5);
   font-size: 12px;
 }

--- a/libs/blocks/gnav/gnav.css
+++ b/libs/blocks/gnav/gnav.css
@@ -507,6 +507,7 @@ header .gnav-navitem.has-menu.is-open .gnav-navitem-menu {
 
 header .gnav-navitem-menu ul {
   padding-left: 0;
+  padding-right: 0;
   margin: 0;
   list-style: none;
 }

--- a/libs/blocks/region-nav/region-nav.css
+++ b/libs/blocks/region-nav/region-nav.css
@@ -48,6 +48,7 @@
 .region-nav ul {
   list-style: none;
   padding-left: 0;
+  padding-right: 0;
   margin: 0;
 }
 


### PR DESCRIPTION
1. The caret displays outside of dividers in mobile view reading RTL (MWPW-132092)  -  The caret is aligned to be -10px left so that it is inside inside the dividers. When text is rtl same offset is not added. Adding -10px offset to bring caret in divider.
2. The region links doesn't align with the region title in change region modal (MWPW-132094) - Region titles do not have any left or right padding. Region links have only left padding 0 and right padding unassigned hence when text goes rtl it takes default 40px padding. Explicitly setting this padding to 0.
3. Alignment issues with the nav dropdown. Title and links not aligned (MWPW-132096) - gnav navitem title have left and right padding explicitly set to 0. For item links in ul this is not set hence it takes space from right. Setting padding right to be explicitly 0.

Resolves: [MWPW-132092](https://jira.corp.adobe.com/browse/MWPW-132092)
[MWPW-132094](https://jira.corp.adobe.com/browse/MWPW-132094)
[MWPW-132096](https://jira.corp.adobe.com/browse/MWPW-132096)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/mena_ar/customer-success-stories/dixons-carphone-case-study?martech=off
- After: https://main--bacom--aishwaryamathuria.hlx.page/mena_ar/customer-success-stories/dixons-carphone-case-study?martech=off&milolibs=bacomrtlissue--milo--aishwaryamathuria
