### PR TITLE
Remove for..of, await in loop eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,26 +10,37 @@ module.exports = {
     requireConfigFile: false,
   },
   rules: {
-    // allow reassigning param
-    'no-param-reassign': [2, { props: false }],
-    'linebreak-style': ['error', 'unix'],
+    'chai-friendly/no-unused-expressions': 2,
     'import/extensions': ['error', { js: 'always' }],
+    'linebreak-style': ['error', 'unix'],
+    'no-await-in-loop': 0,
+    'no-param-reassign': [2, { props: false }],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ForInStatement',
+        message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+      },
+      {
+        selector: 'LabeledStatement',
+        message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+      },
+      {
+        selector: 'WithStatement',
+        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+      },
+    ],
+    'no-return-assign': ['error', 'except-parens'],
+    'no-unused-expressions': 0,
     'object-curly-newline': ['error', {
       ObjectExpression: { multiline: true, minProperties: 6 },
       ObjectPattern: { multiline: true, minProperties: 6 },
       ImportDeclaration: { multiline: true, minProperties: 6 },
       ExportDeclaration: { multiline: true, minProperties: 6 },
     }],
-    'no-return-assign': ['error', 'except-parens'],
-    'no-unused-expressions': 0,
-    'chai-friendly/no-unused-expressions': 2,
-
   },
   overrides: [
-    {
-      files: ['test/**/*.js'],
-      rules: { 'no-console': 'off' },
-    },
+    { files: ['test/**/*.js'] },
   ],
   ignorePatterns: [
     '/libs/deps/*',

--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -362,7 +362,6 @@ async function filterArticles(config, feed, limit, offset) {
 
   while ((feed.data.length < limit + offset) && (!feed.complete)) {
     const beforeLoading = new Date();
-    // eslint-disable-next-line no-await-in-loop
     const index = await fetchBlogArticleIndex();
     const indexChunk = index.data.slice(feed.cursor);
 

--- a/libs/blocks/bulk-publish/bulk-publish-utils.js
+++ b/libs/blocks/bulk-publish/bulk-publish-utils.js
@@ -170,9 +170,7 @@ export const executeActions = async (resume, setResult) => {
       if (isProcessed(url, results)) {
         status[action] = DUPLICATE_STATUS;
       } else {
-        // eslint-disable-next-line no-await-in-loop
         status[action] = await executeAction(action, url);
-        // eslint-disable-next-line no-await-in-loop
         await delay(THROTTLING_DELAY_MS);
       }
     }

--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-async-promise-executor */
-/* eslint-disable no-restricted-syntax */
 import {
   decorateAutoBlock,
   getConfig,

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-async-promise-executor */
-/* eslint-disable no-restricted-syntax */
 import {
   getConfig,
   getMetadata,

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 import {
   getAnalyticsValue,
   toFragment,
@@ -199,7 +198,6 @@ const decorateColumns = async ({ content, separatorTagName = 'H5' } = {}) => {
     };
 
     while (column.children.length) {
-      // eslint-disable-next-line no-await-in-loop
       await yieldToMain();
       const columnElem = column.firstElementChild;
 

--- a/libs/blocks/gnav/gnav-contextual-search.js
+++ b/libs/blocks/gnav/gnav-contextual-search.js
@@ -66,7 +66,6 @@ async function fetchResults(signal, terms) {
       }
     });
     if (hits.length < LIMIT && !complete) {
-      // eslint-disable-next-line no-await-in-loop
       ({ data, complete } = await fetchBlogArticleIndex());
     }
   }

--- a/libs/blocks/preflight/panels/seo.js
+++ b/libs/blocks/preflight/panels/seo.js
@@ -134,9 +134,7 @@ async function checkLinks() {
   const links = document.querySelectorAll('a[href^="/"]');
 
   let badLink;
-  // eslint-disable-next-line no-restricted-syntax
   for (const link of links) {
-    // eslint-disable-next-line no-await-in-loop
     const resp = await fetch(link.href, { method: 'HEAD' });
     if (!resp.ok) badLink = true;
   }

--- a/libs/utils/tree.js
+++ b/libs/utils/tree.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-syntax */
 /* eslint-disable max-classes-per-file */
 class Node {
   constructor(key, value = key, parent = null) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const MILO_TEMPLATES = [
   '404',
   'featured-story',
@@ -165,7 +167,6 @@ export const [setConfig, getConfig] = (() => {
           || 'ltr';
         document.documentElement.setAttribute('dir', dir);
       } catch (e) {
-        // eslint-disable-next-line no-console
         console.log('Invalid or missing locale:', e);
       }
       config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot ?? ''}`;
@@ -301,7 +302,6 @@ export function appendHtmlPostfix(area = document) {
       }
     } catch (err) {
       /* c8 ignore next 3 */
-      // eslint-disable-next-line no-console
       console.log(err);
     }
   });
@@ -355,7 +355,6 @@ export async function loadTemplate() {
       try {
         await import(`${base}/templates/${name}/${name}.js`);
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.log(`failed to load module for ${name}`, err);
       }
       resolve();
@@ -378,7 +377,6 @@ export async function loadBlock(block) {
         const { default: init } = await import(`${base}/blocks/${name}/${name}.js`);
         await init(block);
       } catch (err) {
-        // eslint-disable-next-line no-console
         console.log(`Failed loading ${name}`, err);
         const config = getConfig();
         if (config.env.name !== 'prod') {
@@ -695,16 +693,13 @@ export async function loadArea(area = document) {
   const sections = decorateSections(area, isDoc);
 
   const areaBlocks = [];
-  // eslint-disable-next-line no-restricted-syntax
   for (const section of sections) {
     const loaded = section.blocks.map((block) => loadBlock(block));
     areaBlocks.push(...section.blocks);
 
     // Only move on to the next section when all blocks are loaded.
-    // eslint-disable-next-line no-await-in-loop
     await Promise.all(loaded);
 
-    // eslint-disable-next-line no-await-in-loop
     await decorateIcons(section.el, config);
 
     // Post LCP operations.

--- a/test/helpers/selectors.js
+++ b/test/helpers/selectors.js
@@ -1,6 +1,4 @@
 /* eslint-disable no-plusplus */
-/* eslint-disable no-await-in-loop */
-/* eslint-disable no-restricted-syntax */
 import { delay, waitForElement, waitForUpdate } from './waitfor.js';
 
 const asyncSome = async (arr, predicate) => {

--- a/tools/floodgate/js/copy.js
+++ b/tools/floodgate/js/copy.js
@@ -66,11 +66,10 @@ async function floodgateContent(project, projectDetail) {
   // process data in batches
   const copyStatuses = [];
   for (let i = 0; i < batchArray.length; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     copyStatuses.push(...await Promise.all(
       batchArray[i].map((files) => copyFilesToFloodgateTree(files[1])),
     ));
-    // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+    // eslint-disable-next-line no-promise-executor-return
     await delay(DELAY_TIME_COPY);
   }
   const endCopy = new Date();
@@ -79,11 +78,10 @@ async function floodgateContent(project, projectDetail) {
   const previewStatuses = [];
   for (let i = 0; i < copyStatuses.length; i += 1) {
     if (copyStatuses[i].success) {
-      // eslint-disable-next-line no-await-in-loop
       const result = await simulatePreview(handleExtension(copyStatuses[i].srcPath), 1, true);
       previewStatuses.push(result);
     }
-    // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+    // eslint-disable-next-line no-promise-executor-return
     await delay();
   }
   loadingON('Completed Preview for copied files... ');

--- a/tools/floodgate/js/promote.js
+++ b/tools/floodgate/js/promote.js
@@ -43,10 +43,8 @@ async function promoteCopy(srcPath, destinationFolder, newName) {
   let copySuccess = false;
   let copyStatusJson = {};
   while (statusUrl && !copySuccess && copyStatusJson.status !== 'failed') {
-    // eslint-disable-next-line no-await-in-loop
     const status = await fetchWithRetry(statusUrl);
     if (status.ok) {
-      // eslint-disable-next-line no-await-in-loop
       copyStatusJson = await status.json();
       copySuccess = copyStatusJson.status === 'completed';
     }
@@ -60,10 +58,8 @@ async function promoteCopy(srcPath, destinationFolder, newName) {
 async function findAllFloodgatedFiles(baseURI, options, rootFolder, fgFiles, fgFolders) {
   while (fgFolders.length !== 0) {
     const uri = `${baseURI}${fgFolders.shift()}:/children?$top=${MAX_CHILDREN}`;
-    // eslint-disable-next-line no-await-in-loop
     const res = await fetchWithRetry(uri, options);
     if (res.ok) {
-      // eslint-disable-next-line no-await-in-loop
       const json = await res.json();
       const driveItems = json.value;
       driveItems?.forEach((item) => {
@@ -141,11 +137,10 @@ async function promoteFloodgatedFiles(project) {
   // process data in batches
   const promoteStatuses = [];
   for (let i = 0; i < batchArray.length; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     promoteStatuses.push(...await Promise.all(
       batchArray[i].map((file) => promoteFile(file.fileDownloadUrl, file.filePath)),
     ));
-    // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+    // eslint-disable-next-line no-promise-executor-return
     await delay(DELAY_TIME_PROMOTE);
   }
   const endPromote = new Date();
@@ -154,11 +149,10 @@ async function promoteFloodgatedFiles(project) {
   const previewStatuses = [];
   for (let i = 0; i < promoteStatuses.length; i += 1) {
     if (promoteStatuses[i].success) {
-      // eslint-disable-next-line no-await-in-loop
       const result = await simulatePreview(handleExtension(promoteStatuses[i].srcPath), 1);
       previewStatuses.push(result);
     }
-    // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+    // eslint-disable-next-line no-promise-executor-return
     await delay();
   }
   loadingON('Completed Preview for promoted files... ');

--- a/tools/loc/rollout.js
+++ b/tools/loc/rollout.js
@@ -172,7 +172,6 @@ function getMergedMdast(left, right) {
   const mergedMdast = { type: 'root', children: [] };
   let leftPointer = 0;
   const leftArray = Array.from(left.entries());
-  // eslint-disable-next-line no-restricted-syntax
   for (const [rightHash, rightOpInfo] of right) {
     if (left.has(rightHash)) {
       for (leftPointer; leftPointer < leftArray.length; leftPointer += 1) {

--- a/tools/loc/sharepoint.js
+++ b/tools/loc/sharepoint.js
@@ -187,11 +187,10 @@ async function getFilesData(filePaths, isFloodgate) {
   // process data in batches
   const fileJsonResp = [];
   for (let i = 0; i < batchArray.length; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     fileJsonResp.push(...await Promise.all(
       batchArray[i].map((file) => getFileData(file, isFloodgate)),
     ));
-    // eslint-disable-next-line no-await-in-loop, no-promise-executor-return
+    // eslint-disable-next-line no-promise-executor-return
     await new Promise((resolve) => setTimeout(resolve, BATCH_DELAY_TIME));
   }
   return fileJsonResp;
@@ -400,10 +399,8 @@ async function copyFile(srcPath, destinationFolder, newName, isFloodgate, isFloo
   let copySuccess = false;
   let copyStatusJson = {};
   while (statusUrl && !copySuccess && copyStatusJson.status !== 'failed') {
-    // eslint-disable-next-line no-await-in-loop
     const status = await fetchWithRetry(statusUrl);
     if (status.ok) {
-      // eslint-disable-next-line no-await-in-loop
       copyStatusJson = await status.json();
       copySuccess = copyStatusJson.status === 'completed';
     }

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 /* eslint-disable no-continue */
 import { loadScript, loadStyle } from '../../libs/utils/utils.js';
 import { getImsToken } from '../utils/utils.js';
@@ -109,7 +108,6 @@ const processData = async (data, accessToken) => {
     ? `https://main--${repo}--${owner}.hlx.page`
     : `https://${host}`;
 
-  // eslint-disable-next-line no-restricted-syntax
   for (const page of data) {
     if (!keepGoing) break;
 

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -564,9 +564,7 @@ const getCaaSMetadata = async (pageMd, options) => {
   let tagErrors = [];
   let tags = [];
   // for-of required to await any async computeVal's
-  // eslint-disable-next-line no-restricted-syntax
   for (const [key, computeFn] of Object.entries(props)) {
-    // eslint-disable-next-line no-await-in-loop
     const val = computeFn ? await computeFn(pageMd[key], options) : pageMd[key];
     if (val?.error) {
       errors.push(val.error);


### PR DESCRIPTION
We use await inside of for..of loops enough that we don't need to have an eslint warning for it.  Saves a bit of file size too.
