### PR TITLE
[MWPW-132406] Long text links are not seen getting wrapped in Linkfarm

### DIFF
--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -126,8 +126,12 @@
 
 .link-farm.text-block .foreground {
   display: grid;
-  grid-template-columns: auto;
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--spacing-xl) var(--spacing-m);
+}
+
+.link-farm.text-block .foreground:first-child {
+  grid-template-columns: auto;
 }
 
 .link-farm.text-block h3 {
@@ -178,13 +182,13 @@
   }
   
   .link-farm.text-block .foreground {
-    grid-template-columns: repeat(2, auto);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 /* Desktop up */
 @media screen and (min-width: 1200px) {
   .link-farm.text-block .foreground {
-    grid-template-columns: repeat(4, auto);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* This fix resolves the link wrapping issue in link farm block

Resolves: [MWPW-132406](https://jira.corp.adobe.com/browse/MWPW-132406)

Before:
![image](https://github.com/adobecom/milo/assets/33101297/097d48e7-e44b-48db-9647-c29673f634ff)

After:
![image](https://github.com/adobecom/milo/assets/33101297/ac4ab150-2891-41c6-9c33-ea476e9f6197)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/Drashti/linkfarmblock
- After: https://linkfarmfix--milo--drashti1712.hlx.page/drafts/Drashti/linkfarmblock


