### PR TITLE
[MWPW-118520] Menuless gnav

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- Before submitting, please review all open PRs. -->
 
 * Add your
-* Specicic
+* Specific
 * Features or fixes
 
 Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -393,6 +393,8 @@ class Gnav {
   };
 
   decorateToggle = () => {
+    if (!this.mainNavItemCount) return '';
+
     const toggle = toFragment`<button
       class="feds-toggle"
       aria-expanded="false"
@@ -503,6 +505,9 @@ class Gnav {
     // Get all main menu items, but exclude any that are nested inside other features
     const items = [...this.body.querySelectorAll('h2, p:only-child > strong > a, p:only-child > em > a')]
       .filter((item) => CONFIG.features.every((feature) => !item.closest(`.${feature}`)));
+
+    // Save number of items to decide whether a hamburger menu is required
+    this.mainNavItemCount = items.length;
 
     for await (const [index, item] of items.entries()) {
       await yieldToMain();


### PR DESCRIPTION
When no menu items are authored to be added to the navigation, a hamburger menu (toggle) shouldn't be created.

This also fixes a minor typo in the Git PR template.

Resolves: [MWPW-118520](https://jira.corp.adobe.com/browse/MWPW-118520)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/limited-gnav?martech=off
- After: https://menuless-gnav--milo--overmyheadandbody.hlx.page/drafts/ramuntea/limited-gnav?martech=off
