### PR TITLE
Mwpw 132409 - Optional Headings for Link Farms

### DIFF
--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -141,7 +141,7 @@
   line-height: var(--type-heading-xs-lh);
 }
 
-.link-farm.text-block [id^="no-heading"] {
+.link-farm.text-block .no-heading {
   margin: 0;
 }
 
@@ -190,7 +190,7 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .link-farm.text-block [id^="no-heading"] {
+  .link-farm.text-block .no-heading {
     height: var(--type-heading-m-size);
     margin: 0 0 var(--spacing-l);
   }

--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -141,6 +141,10 @@
   line-height: var(--type-heading-xs-lh);
 }
 
+.link-farm.text-block [id^="no-heading"] {
+  margin: 0;
+}
+
 .link-farm.text-block h2 {
   margin: 0 0 var(--spacing-m);
 }
@@ -181,9 +185,14 @@
   .inset.text-block .foreground > div {
     padding-left: var(--spacing-l);
   }
-  
+
   .link-farm.text-block .foreground {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .link-farm.text-block [id^="no-heading"] {
+    height: var(--type-heading-m-size);
+    margin: 0 0 var(--spacing-l);
   }
 }
 
@@ -191,5 +200,10 @@
 @media screen and (min-width: 1200px) {
   .link-farm.text-block .foreground {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .link-farm.text-block [id^="no-heading"] {
+    height: var(--type-heading-m-size);
+    margin: 0 0 var(--spacing-l);
   }
 }

--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -201,9 +201,4 @@
   .link-farm.text-block .foreground {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
-
-  .link-farm.text-block [id^="no-heading"] {
-    height: var(--type-heading-m-size);
-    margin: 0 0 var(--spacing-l);
-  }
 }

--- a/libs/blocks/text/text.js
+++ b/libs/blocks/text/text.js
@@ -51,8 +51,14 @@ export default function init(el) {
     if (elAction) elAction.classList.add('body-s');
   }
   if (el.classList.contains('link-farm')) {
-    el.querySelectorAll('[id^="no-heading"]').forEach(elem => {
-      elem.innerHTML = '';
+    const foregroundDiv = el.querySelectorAll('.foreground')[1];
+    const count = foregroundDiv.querySelectorAll('h3').length;
+    foregroundDiv.querySelectorAll('div').forEach(divElem => {
+      if (!divElem.querySelector('h3') && count) {
+        let headingElem = document.createElement('h3');
+        headingElem.setAttribute('id', 'no-heading');
+        divElem.insertBefore(headingElem, divElem.firstChild);
+      }
     });
   }
   el.classList.add(...helperClasses);

--- a/libs/blocks/text/text.js
+++ b/libs/blocks/text/text.js
@@ -1,4 +1,5 @@
 import { decorateBlockBg, decorateBlockText, getBlockSize, decorateTextOverrides } from '../../utils/decorate.js';
+import { createTag } from '../../utils/utils.js';
 
 // size: [heading, body, ...detail]
 const blockTypeSizes = {
@@ -55,8 +56,7 @@ export default function init(el) {
     const count = foregroundDiv.querySelectorAll('h3').length;
     foregroundDiv.querySelectorAll('div').forEach(divElem => {
       if (!divElem.querySelector('h3') && count) {
-        let headingElem = document.createElement('h3');
-        headingElem.setAttribute('id', 'no-heading');
+        const headingElem = createTag('h3', { class: 'no-heading'});
         divElem.insertBefore(headingElem, divElem.firstChild);
       }
     });

--- a/libs/blocks/text/text.js
+++ b/libs/blocks/text/text.js
@@ -50,6 +50,11 @@ export default function init(el) {
     const elAction = el.querySelector('.action-area');
     if (elAction) elAction.classList.add('body-s');
   }
+  if (el.classList.contains('link-farm')) {
+    el.querySelectorAll('[id^="no-heading"]').forEach(elem => {
+      elem.innerHTML = '';
+    });
+  }
   el.classList.add(...helperClasses);
   decorateTextOverrides(el);
 }

--- a/test/blocks/text/mocks/body.html
+++ b/test/blocks/text/mocks/body.html
@@ -99,3 +99,41 @@
     </div>
   </div>
 </div>
+<div class="text link-farm">
+  <div>
+    <div data-valign="middle">#fff</div>
+  </div>
+  <div>
+    <div data-valign="middle">
+      <h2 id="more-photography-tips-and-techniques-optional-headings">More photography tips and techniques (Optional headings)</h2>
+    </div>
+  </div>
+  <div>
+    <div data-valign="middle">
+      <h3 id="tips-for">Tips for...</h3>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/astrophotography.html">Astrophotography</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/headshot-photography.html">Headshot photography</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/photoshop-vs-gimp.html">Photoshop vs. Gimp</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/newborn-photography-props.html">Newborn photography props</a></p>
+    </div>
+    <div data-valign="middle">
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/portrait-lighting.html">Portrait lighting</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/pet-photography.html">Pet photography</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/photoshop-ideas.html">Photoshop Ideas</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/product-photography-props.html">Product photography props</a></p>
+    </div>
+    <div data-valign="middle">
+      <h3 id="how-to">How to...</h3>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/motion-blur-effect.html">Create a motion blur effect</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/duotone-effect.html">Create a duotone effect</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/neon-effect.html">Create a neon effect</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/maternity-photo-poses.html">Maternity photo poses</a></p>
+    </div>
+    <div data-valign="middle">
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/add-text-to-photos.html">Add text to photos</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/compress-image.html">Compress an image</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/photo-touch-up.html">Retouch a photo</a></p>
+      <p><a href="https://www.adobe.com/creativecloud/photography/discover/shutter-priority-mode.html">Shutter priority mode</a></p>
+    </div>
+  </div>
+</div>

--- a/test/blocks/text/text.test.js
+++ b/test/blocks/text/text.test.js
@@ -31,4 +31,33 @@ describe('text block', () => {
       expect(body).to.exist;
     });
   });
+
+  describe('Link Farm', () => {
+    it('should check if the "link-farm" class is present', () => {
+      const element = document.querySelector('.link-farm');
+      expect(element).to.exist;
+    });
+  
+    it('should check if the "h3" elements are added when necessary', () => {
+      const element = document.querySelector('.link-farm');
+      const foregroundDiv = element.querySelectorAll('.foreground')[1];
+      const headingElem = foregroundDiv.querySelectorAll('h3');
+      expect(headingElem.length).to.equal(4);
+    });
+    it('should add no-heading id to the h3 element', () => {
+      const element = document.querySelector('.link-farm');
+      const foregroundDiv = element.querySelectorAll('.foreground')[1];
+      const headingElem = foregroundDiv.querySelector('#no-heading');
+      expect(headingElem).to.exist;
+    });
+    it('should add h3 as the first element in the div', () => {
+      const element = document.querySelector('.link-farm');
+      const foregroundDiv = element.querySelectorAll('.foreground')[1];
+      const divElements = foregroundDiv.querySelectorAll('div');
+      divElements.forEach(div => {
+        const firstChild = div.children[0];
+        expect(firstChild.tagName).to.equal('H3');
+      });
+    })
+  });
 });

--- a/test/blocks/text/text.test.js
+++ b/test/blocks/text/text.test.js
@@ -44,10 +44,10 @@ describe('text block', () => {
       const headingElem = foregroundDiv.querySelectorAll('h3');
       expect(headingElem.length).to.equal(4);
     });
-    it('should add no-heading id to the h3 element', () => {
+    it('should add no-heading class to the h3 element', () => {
       const element = document.querySelector('.link-farm');
       const foregroundDiv = element.querySelectorAll('.foreground')[1];
-      const headingElem = foregroundDiv.querySelector('#no-heading');
+      const headingElem = foregroundDiv.querySelector('.no-heading');
       expect(headingElem).to.exist;
     });
     it('should add h3 as the first element in the div', () => {

--- a/test/blocks/text/text.test.js
+++ b/test/blocks/text/text.test.js
@@ -33,30 +33,23 @@ describe('text block', () => {
   });
 
   describe('Link Farm', () => {
-    it('should check if the "link-farm" class is present', () => {
+    it('is present', () => {
       const element = document.querySelector('.link-farm');
       expect(element).to.exist;
     });
   
-    it('should check if the "h3" elements are added when necessary', () => {
-      const element = document.querySelector('.link-farm');
-      const foregroundDiv = element.querySelectorAll('.foreground')[1];
-      const headingElem = foregroundDiv.querySelectorAll('h3');
-      expect(headingElem.length).to.equal(4);
+    it('adds h3 elements when necessary', () => {
+      const headingElements = document.querySelectorAll('.link-farm .foreground h3');
+      expect(headingElements.length).to.equal(4);
     });
-    it('should add no-heading class to the h3 element', () => {
-      const element = document.querySelector('.link-farm');
-      const foregroundDiv = element.querySelectorAll('.foreground')[1];
-      const headingElem = foregroundDiv.querySelector('.no-heading');
+    it('adds no-heading class to the h3 element', () => {
+      const headingElem = document.querySelector('.link-farm .foreground .no-heading');
       expect(headingElem).to.exist;
     });
-    it('should add h3 as the first element in the div', () => {
-      const element = document.querySelector('.link-farm');
-      const foregroundDiv = element.querySelectorAll('.foreground')[1];
-      const divElements = foregroundDiv.querySelectorAll('div');
+    it('adds h3 as the first element in the div', () => {
+      const divElements = document.querySelectorAll('.link-farm .foreground:nth-child(2) div');
       divElements.forEach(div => {
-        const firstChild = div.children[0];
-        expect(firstChild.tagName).to.equal('H3');
+        expect(div.children[0].tagName).to.equal('H3');
       });
     })
   });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* This extends the functionality of link farm variant of text blocks by allowing the authors to add optional Headings for the link columns. The solution, as discussed in the comments and with the consonant team, would be to add a [No-Heading] placeholder in the authoring for blocking a space for the heading as shown below. 
* Related to - https://jira.corp.adobe.com/browse/MWPW-129911, https://jira.corp.adobe.com/browse/MWPW-132409, https://jira.corp.adobe.com/browse/MWPW-132427
* Update: The solution was revised and we no longer need to add a [No-Heading] placeholder in authoring.

Resolves: [MWPW-132409](https://jira.corp.adobe.com/browse/MWPW-132409)

Authoring (updated):
![image](https://github.com/adobecom/milo/assets/33101297/3c6cd9ae-2e71-44fd-b8ce-e4ff61916c30)

Before:
![image](https://github.com/adobecom/milo/assets/33101297/79c8d0b0-8e1d-441c-942c-7fbf706e63c7)

After: 
![image](https://github.com/adobecom/milo/assets/33101297/3f143a5f-3e7b-4903-9a69-cbf839cac4c8)


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/Drashti/document
- After: https://mwpw-132409--milo--drashti1712.hlx.page/drafts/Drashti/document1#
