### PR TITLE
MWPW-132977: Support global navigation link group modifier 'blue'

### DIFF
--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -48,6 +48,10 @@
   column-gap: 15px;
 }
 
+.feds-navLink--blue {
+  color: var(--feds-color-link--hover--light);
+}
+
 .feds-navLink--hoverCaret {
   position: relative;
   padding-right: 32px;

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -559,8 +559,3 @@ header.global-navigation {
     display: flex;
   }
 }
-
-/* TODO: Old styles, to be refactored */
-.last-link-blue ul li:last-of-type a {
-  color: #1473E6;
-}

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -58,7 +58,9 @@ const decorateLinkGroup = (elem, index) => {
   const image = elem.querySelector('picture');
   const link = elem.querySelector('a');
   const description = elem.querySelector('p:nth-child(2)');
-
+  const modifierClasses = [...elem.classList]
+    .filter((className) => className !== 'link-group')
+    .map((className) => `feds-navLink--${className}`);
   const imageElem = image ? toFragment`<div class="feds-navLink-image">${image}</div>` : '';
   const descriptionElem = description ? toFragment`<div class="feds-navLink-description">${description.textContent}</div>` : '';
   const contentElem = link ? toFragment`<div class="feds-navLink-content">
@@ -67,7 +69,7 @@ const decorateLinkGroup = (elem, index) => {
     </div>` : '';
   const linkGroup = toFragment`<a
     href="${link.href}"
-    class="feds-navLink"
+    class="feds-navLink${modifierClasses.length ? ` ${modifierClasses.join(' ')}` : ''}"
     daa-ll="${getAnalyticsValue(link.textContent, index)}">
       ${imageElem}
       ${contentElem}

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -351,6 +351,9 @@ describe('global navigation', () => {
         [...navLinks].forEach((link) => {
           expect(isElementVisible(link)).to.equal(true);
         });
+
+        const hasLinkgroupModifier = document.querySelector(`${selectors.navLink}--blue`) instanceof HTMLElement;
+        expect(hasLinkgroupModifier).to.equal(true);
       });
 
       it('should render the promo', async () => {
@@ -385,6 +388,9 @@ describe('global navigation', () => {
         [...navLinks].forEach((link) => {
           expect(isElementVisible(link)).to.equal(true);
         });
+
+        const hasLinkgroupModifier = document.querySelector(`${selectors.navLink}--blue`) instanceof HTMLElement;
+        expect(hasLinkgroupModifier).to.equal(true);
       });
 
       it('should render the promo', async () => {

--- a/test/blocks/global-navigation/mocks/global-navigation.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation.plain.js
@@ -111,7 +111,7 @@ export default `<div>
       >
     </li>
   </ul>
-  <div class="link-group">
+  <div class="link-group blue">
     <div>
       <div>
         <picture>


### PR DESCRIPTION
### Description
The bacom customer success stories have a "last link blue" feature which was previously achieved using section metadata. As we introduced the new global navigation, we also introduced a so called `link group` feature which acts and behaves like a block. The section metadata will have limitations in the future when adding `second-last-link-red` for example and wouldn't be very extensible. To have a more natural milo-style of authoring, we want to add modifiers.

### Authoring experience 
Allow authors to add modifiers to link groups
![Screenshot 2023-06-20 at 14 50 14](https://github.com/adobecom/milo/assets/39759830/fe1d6d7a-427b-4dd2-b1b5-33bc71f9b33d)

### Output
Style dropdown items, with this PR allow links to become blue.
![Screenshot 2023-06-20 at 14 50 48](https://github.com/adobecom/milo/assets/39759830/c91ca903-fdbc-43d3-aa52-12424f6b6ba3)


Resolves: [MWPW-132977](https://jira.corp.adobe.com/browse/MWPW-132977)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/gnav-1
- After: https://mwpw-132977--milo--mokimo.hlx.page/drafts/osahin/gnav-1