### PR TITLE
[MWPW-132443] Gnav updates for Blog migration

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -203,9 +203,12 @@ class Footer {
         </svg>
         ${regionPickerTextElem}
       </a>`;
-    this.elements.regionPicker = toFragment`<div class="feds-regionPicker-wrapper">
+    const regionPickerWrapperClass = 'feds-regionPicker-wrapper';
+    this.elements.regionPicker = toFragment`<div class="${regionPickerWrapperClass}">
         ${regionPickerElem}
       </div>`;
+
+    const isRegionPickerExpanded = () => regionPickerElem.getAttribute('aria-expanded') === 'true';
 
     // Note: the region picker currently works only with Milo modals/fragments;
     // in the future we'll need to update this for non-Milo consumers
@@ -215,7 +218,6 @@ class Footer {
       await loadBlock(regionPickerElem); // load modal logic and styles
       // 'decorateAutoBlock' logic replaces class name entirely, need to add it back
       regionPickerElem.classList.add(regionPickerClass);
-      const isRegionPickerExpanded = () => regionPickerElem.getAttribute('aria-expanded') === 'true';
       regionPickerElem.addEventListener('click', () => {
         if (!isRegionPickerExpanded()) {
           regionPickerElem.setAttribute('aria-expanded', 'true');
@@ -238,6 +240,13 @@ class Footer {
         e.preventDefault();
         const isDialogActive = regionPickerElem.getAttribute('aria-expanded') === 'true';
         regionPickerElem.setAttribute('aria-expanded', !isDialogActive);
+      });
+      // Close region picker dropdown on outside click
+      document.addEventListener('click', (e) => {
+        if (isRegionPickerExpanded()
+          && !e.target.closest(`.${regionPickerWrapperClass}`)) {
+          regionPickerElem.setAttribute('aria-expanded', false);
+        }
       });
     }
 

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -123,8 +123,8 @@ const decorateElements = ({ elem, className = 'feds-navLink', parseCtas = true, 
 
 // Current limitation: we can only add one link
 const decoratePromo = (elem, index) => {
-  const isDarkTheme = elem.classList.contains('dark');
-  const isImageOnly = elem.classList.contains('image-only');
+  const isDarkTheme = elem.matches('.dark');
+  const isImageOnly = elem.matches('.image-only');
   const imageElem = elem.querySelector('picture');
 
   decorateElements({ elem, className: 'feds-promo-link', parseCtas: false, index });

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -66,8 +66,13 @@ export function getAnalyticsValue(str, index) {
 
 export function getExperienceName() {
   const experiencePath = getMetadata('gnav-source');
+  const explicitExperience = experiencePath?.split('/').pop();
+  if (explicitExperience?.length) return explicitExperience;
 
-  return experiencePath?.split('/').pop() || '';
+  const { imsClientId } = getConfig();
+  if (imsClientId?.length) return imsClientId;
+
+  return '';
 }
 
 export function loadStyles(path) {

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -8,6 +8,7 @@ import logoOnlyNav from './mocks/global-navigation-only-logo.plain.js';
 import brandOnlyNav from './mocks/global-navigation-only-brand.plain.js';
 import nonSvgBrandOnlyNav from './mocks/global-navigation-only-non-svg-brand.plain.js';
 import longNav from './mocks/global-navigation-long.plain.js';
+import noLogoBrandOnlyNav from './mocks/global-navigation-only-brand-no-image.plain.js';
 
 const ogFetch = window.fetch;
 
@@ -95,6 +96,12 @@ describe('global navigation', () => {
         const brandImage = document.querySelector(`${selectors.brandImage} img`);
         expect(isElementVisible(brandImage)).to.equal(true);
         expect(brandImage.getAttribute('alt')).to.equal('Alternative text');
+      });
+
+      it('should not render an image if the "no-logo" modifier is used', async () => {
+        await createFullGlobalNavigation({ globalNavigation: noLogoBrandOnlyNav });
+        const brandImage = document.querySelector(`${selectors.brandImage}`);
+        expect(isElementVisible(brandImage)).to.equal(false);
       });
     });
 

--- a/test/blocks/global-navigation/mocks/global-navigation-only-brand-no-image.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-only-brand-no-image.plain.js
@@ -1,0 +1,13 @@
+// Uses the franklin structure without any customizations
+export default `
+<div class="gnav-brand no-logo">
+  <div>
+    <div>
+      <p>
+        <a href="/drafts/ramuntea/adobe-logo.svg">http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg</a>
+      </p>
+      <p><a href="https://www.adobe.com/">Adobe</a></p>
+    </div>
+  </div>
+</div>
+`;

--- a/test/blocks/global-navigation/mocks/subscriptionsAll.js
+++ b/test/blocks/global-navigation/mocks/subscriptionsAll.js
@@ -50,6 +50,7 @@ const res = [
         cloud: 'EXPERIENCE',
       },
       payment_structure: 'PAID_IN_ADVANCE',
+      offer_id: 'testOffer',
     },
     fulfilled_items: [{ code: 'dma_analytics' }],
   },
@@ -228,7 +229,19 @@ const formatted = {
     cc_all_apps: true,
     acrobat: true,
   },
-  offers: {},
+  offers: {
+    testOffer: {
+      product_code: 'DMA_ANALYTICS',
+      product_arrangement_code: 'dm_analytics_enterprise_ml',
+      product_arrangement: {
+        code: 'dm_analytics_enterprise_ml',
+        label: 'DM_ANALYTICS_ENTERPRISE_ML',
+        family: 'ANALYTICS',
+        cloud: 'EXPERIENCE',
+      },
+      payment_structure: 'PAID_IN_ADVANCE',
+    },
+  },
   list: {
     fulfilled_codes: [
       'dma_reactor',

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -77,7 +77,7 @@ export const waitForElement = (selector, parent) => new Promise((resolve, reject
 
 const ogFetch = window.fetch;
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
-const config = {
+export const config = {
   imsClientId: 'milo',
   codeRoot: '/libs',
   contentRoot: `${window.location.origin}${getLocale(locales).prefix}`,

--- a/test/blocks/global-navigation/utilities/getUserEntitlements.test.js
+++ b/test/blocks/global-navigation/utilities/getUserEntitlements.test.js
@@ -5,14 +5,14 @@ import { mockRes } from '../test-utilities.js';
 import { setConfig } from '../../../../libs/utils/utils.js';
 import { res, formatted } from '../mocks/subscriptionsAll.js';
 
-const emptyEntitlements = {
+const emptyEntitlements = () => ({
   clouds: {},
   arrangment_codes: {},
   fulfilled_codes: {},
   offer_families: {},
   offers: {},
   list: { fulfilled_codes: [] },
-};
+});
 
 describe('getUserEntitlements', () => {
   const ogFetch = window.fetch;
@@ -34,7 +34,7 @@ describe('getUserEntitlements', () => {
   it('should return empty entitlements if a user is not signed in', async () => {
     window.adobeIMS = { isSignedInUser: () => false };
     const entitlements = await getUserEntitlements();
-    expect(entitlements).to.deep.equal(emptyEntitlements);
+    expect(entitlements).to.deep.equal(emptyEntitlements());
   });
 
   it('should return a response with the formatted subscriptions', async () => {
@@ -58,11 +58,17 @@ describe('getUserEntitlements', () => {
     // empty entitlements should not have been modified
     window.adobeIMS = { isSignedInUser: () => false };
     const entitlements2 = await getUserEntitlements();
-    expect(entitlements2).to.deep.equal(emptyEntitlements);
+    expect(entitlements2).to.deep.equal(emptyEntitlements());
   });
 
   it('should return the raw response if format is raw', async () => {
     const entitlements = await getUserEntitlements({ format: 'raw' });
     expect(entitlements).to.deep.equal(res);
+  });
+
+  it('should return empty entitlements if response is not an array', async () => {
+    window.fetch = stub().callsFake(() => mockRes({ payload: '' }));
+    const entitlements = await getUserEntitlements({ params: [{ name: 'NOTARRAY', value: 'TRUE' }] });
+    expect(entitlements).to.deep.equal(emptyEntitlements());
   });
 });

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -133,4 +133,14 @@ describe('global navigation utilities', () => {
     const experienceName = getExperienceName();
     expect(experienceName).to.equal(config.imsClientId);
   });
+
+  it('getExperienceName is empty if no imsClientId is defined', () => {
+    const ogImsClientId = config.imsClientId;
+    delete config.imsClientId;
+    setConfig(config);
+    const experienceName = getExperienceName();
+    expect(experienceName).to.equal('');
+    config.imsClientId = ogImsClientId;
+    setConfig(config);
+  });
 });

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -6,9 +6,10 @@ import {
   decorateCta,
   closeAllDropdowns,
   trigger,
+  getExperienceName,
 } from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
 import { setConfig } from '../../../../libs/utils/utils.js';
-import { createFullGlobalNavigation } from '../test-utilities.js';
+import { createFullGlobalNavigation, config } from '../test-utilities.js';
 
 describe('global navigation utilities', () => {
   beforeEach(() => {
@@ -126,5 +127,10 @@ describe('global navigation utilities', () => {
     // Calling 'trigger' again should close the element
     expect(trigger({ element })).to.equal(false);
     expect(element.getAttribute('aria-expanded')).to.equal('false');
+  });
+
+  it('getExperienceName defaults to imsClientId', () => {
+    const experienceName = getExperienceName();
+    expect(experienceName).to.equal(config.imsClientId);
   });
 });


### PR DESCRIPTION
I would usually open this PR from my fork, but I got 404s when trying to use the https://branch--repo--owner.hlx.page approach. This branch will be deleted as soon as it is merged.

---

This aims to handle any gaps noticed while testing the FEDS Gnav on Blog. It:
- ensures the region picker dropdown is closed on outside click;
- adds a `No Logo` option to the 'Gnav Brand' and 'Adobe Logo' features. These blocks can now be authored to be just image, just text or both of them together;
- ensures that placeholders used in the global navigation documents are replaced. This was already in place for dropdown menus and the footer;
- provides an additional fallback (`imsClientId`) for the navigation experience name if one hasn't been explicitly defined.

There are still a few things required for a successful migration:
- a few authoring changes. These can be implemented right now and they have no side-effects when still using the Milo Gnav; details will be provided in [MWPW-132443](https://jira.corp.adobe.com/browse/MWPW-132443);
- implementation of contextual search. We're currently doing a due diligence for this feature.

Resolves: [MWPW-132443](https://jira.corp.adobe.com/browse/MWPW-132443)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ramuntea/blog-old-gnav?martech=off
- After: https://gnav-blog-migration-updates--milo--adobecom.hlx.page/drafts/ramuntea/blog-new-gnav?martech=off