### PR TITLE
Update pdf embed API url

### DIFF
--- a/libs/blocks/pdf-viewer/pdf-viewer.js
+++ b/libs/blocks/pdf-viewer/pdf-viewer.js
@@ -2,7 +2,7 @@
 
 import { createTag, getConfig, loadScript } from '../../utils/utils.js';
 
-const API_SOURCE_URL = 'https://documentcloud.adobe.com/view-sdk/viewer.js';
+const API_SOURCE_URL = 'https://acrobatservices.adobe.com/view-sdk/viewer.js';
 const PDF_RENDER_DIV_ID = 'adobe-dc-view';
 const CLIENT_ID_LIVE = '96e41871f28349e08b3562747a72dc75';
 

--- a/test/blocks/pdf-viewer/mocks/body.html
+++ b/test/blocks/pdf-viewer/mocks/body.html
@@ -1,2 +1,2 @@
 <a href="https://main--milo--adobecom.hlx.page/drafts/pdf-viewsdk/test.pdf"></a>
-<a href="https://documentcloud.adobe.com/view-sdk/PDFs/test.pdf"></a>
+<a href="https://acrobatservices.adobe.com/view-sdk/PDFs/test.pdf"></a>

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -17,7 +17,7 @@
     <!-- Auto Blocks -->
     <p><a href="https://www.youtube.com/watch?v=0EWdoiU8BXw">YouTube</a></p>
     <p><a href="https://milo.adobe.com/fragments/mock#otis">Open modal</a></p>
-    <p><a href="https://documentcloud.adobe.com/view-sdk/PDFs/test.pdf">View PDF</a></p>
+    <p><a href="https://acrobatservices.adobe.com/view-sdk/PDFs/test.pdf">View PDF</a></p>
     <!-- Fragments -->
     <p><a href="https://milo.adobe.com/fragments/mock">https://milo.adobe.com/fragments/mock</a></p>
     <p>My sibling content<a href="https://milo.adobe.com/fragments/mock">https://milo.adobe.com/fragments/mock</a></p>


### PR DESCRIPTION
* update pdf-viewer api url

Resolves: [MWPW-133054](https://jira.corp.adobe.com/browse/MWPW-133054)

**Test URLs:**
Bacom:
- Before: https://main--bacom--adobecom.hlx.page/resources/reports/connecting-the-dam-dots/thank-you?martech=off
- After: https://main--bacom--adobecom.hlx.page/resources/reports/connecting-the-dam-dots/thank-you?milolibs=pdf-viewer--milo--ruchika4&martech=off

CC:
- Before: https://main--cc--adobecom.hlx.page/drafts/ruchika/pdfembed?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/ruchika/pdfembed?martech=off&milolibs=pdf-viewer--milo--ruchika4

Note: Before after urls should work exactly the same. This is just a domain change from product team and all the features should work as before in pdf-viewer

