### PR TITLE
[MWPW-132444] Save up nav space when content is overflowing

### DIFF
--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -103,6 +103,12 @@
     padding: 0 12px;
   }
 
+  .feds-topnav--overflowing .feds-navLink,
+  .feds-topnav--overflowing .feds-navLink--hoverCaret,
+  [dir = "rtl"] .feds-topnav--overflowing .feds-navLink--hoverCaret {
+    padding: 0 8px;
+  }
+
   .feds-navLink--hoverCaret {
     position: static;
   }
@@ -118,10 +124,20 @@
     margin-left: 5px;
   }
 
+  .feds-topnav--overflowing .feds-navLink--hoverCaret:after {
+    margin-left: 3px;
+  }
+
   [dir = "rtl"] .feds-navLink--hoverCaret:after {
     margin-left: 0;
     /* Margin different than LTR due to transform origin effect */
     margin-right: 7px;
+  }
+
+  [dir = "rtl"] .feds-topnav--overflowing .feds-navLink--hoverCaret:after {
+    margin-left: 0;
+    /* Margin different than LTR due to transform origin effect */
+    margin-right: 5px;
   }
 
   .feds-navLink-image {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -35,6 +35,7 @@ header.global-navigation {
   background-color: var(--feds-background-nav--light);
   visibility: visible;
   box-sizing: content-box;
+  overflow-x: clip;
 }
 
 .feds-topnav-wrapper {
@@ -106,6 +107,7 @@ header.global-navigation {
 /* Brand and Logo blocks */
 .feds-brand-container {
   display: flex;
+  flex-shrink: 0;
 }
 
 .feds-brand,
@@ -173,6 +175,10 @@ header.global-navigation {
   white-space: nowrap;
 }
 
+.feds-topnav--overflowing .feds-navItem {
+  font-size: 13px;
+}
+
 .feds-navItem--centered {
   padding: 12px;
 }
@@ -228,8 +234,16 @@ header.global-navigation {
   justify-content: center;
   overflow: visible;
   white-space: nowrap;
-  transition: all 130ms ease-out;
+  transition-property: color, border-color, background-color;
+  transition-duration: 130ms;
+  transition-timing-function: ease-out;
   cursor: pointer;
+}
+
+.feds-topnav--overflowing .feds-cta {
+  height: 30px;
+  padding: 0 10px;
+  font-size: 14px;
 }
 
 .feds-cta--primary {
@@ -429,6 +443,10 @@ header.global-navigation {
     display: flex;
   }
 
+  .feds-topnav--overflowing .feds-brand-label {
+    display: none;
+  }
+
   /* Item with active dropdown */
   .feds-dropdown--active::before {
     content: none;
@@ -473,6 +491,10 @@ header.global-navigation {
     align-items: center;
   }
 
+  .feds-topnav--overflowing .feds-navItem--centered {
+    padding: 0 8px;
+  }
+
   .feds-navItem--section {
     border-left: 1px solid var(--feds-borderColor--light);
     border-right: 1px solid var(--feds-borderColor--light);
@@ -480,6 +502,10 @@ header.global-navigation {
 
   .feds-navItem--section > .feds-navLink {
     padding: 0 20px;
+  }
+
+  .feds-topnav--overflowing .feds-navItem--section > .feds-navLink {
+    padding: 0 12px;
   }
 
   .feds-navItem:not(:last-child) > .feds-navLink {
@@ -557,5 +583,9 @@ header.global-navigation {
 @media (min-width: 1200px) {
   .feds-logo {
     display: flex;
+  }
+
+  .feds-topnav--overflowing .feds-logo {
+    display: none;
   }
 }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -21,6 +21,7 @@ import {
   loadBaseStyles,
   yieldToMain,
   isDesktop,
+  isTangentToViewport,
   setCurtainState,
   selectors,
   logErrorFor,
@@ -191,8 +192,8 @@ class Gnav {
       this.decorateMainNav,
       this.decorateTopNav,
       this.decorateTopnavWrapper,
-      this.addChangeEventListener,
       () => loadIms(this.imsReady.bind(this)),
+      this.addChangeEventListeners,
     ];
     this.el.addEventListener('click', this.loadDelayed);
     this.el.addEventListener('keydown', setupKeyboardNav);
@@ -231,7 +232,7 @@ class Gnav {
     this.el.append(this.elements.curtain, this.elements.topnavWrapper);
   };
 
-  addChangeEventListener = () => {
+  addChangeEventListeners = () => {
     // Ensure correct DOM order for elements between mobile and desktop
     isDesktop.addEventListener('change', () => {
       if (isDesktop.matches) {
@@ -260,6 +261,18 @@ class Gnav {
         }
       }
     });
+
+    // Add a modifier when the nav is tangent to the viewport and content is partly hidden
+    const toggleContraction = () => {
+      const isOverflowing = isTangentToViewport.matches
+        && this.elements.topnav?.scrollWidth
+        && this.elements.topnav.scrollWidth > document.body.clientWidth;
+
+      this.elements.topnav.classList.toggle(selectors.overflowingTopNav.slice(1), isOverflowing);
+    };
+
+    toggleContraction();
+    isTangentToViewport.addEventListener('change', toggleContraction);
   };
 
   loadDelayed = async () => {
@@ -457,22 +470,18 @@ class Gnav {
     return decoratedElem;
   };
 
-  decorateBrand = () => this.decorateGenericLogo(
-    {
-      selector: '.gnav-brand',
-      classPrefix: 'feds-brand',
-      analyticsValue: 'Brand',
-    },
-  );
+  decorateBrand = () => this.decorateGenericLogo({
+    selector: '.gnav-brand',
+    classPrefix: 'feds-brand',
+    analyticsValue: 'Brand',
+  });
 
-  decorateLogo = () => this.decorateGenericLogo(
-    {
-      selector: '.adobe-logo',
-      classPrefix: 'feds-logo',
-      includeLabel: false,
-      analyticsValue: 'Logo',
-    },
-  );
+  decorateLogo = () => this.decorateGenericLogo({
+    selector: '.adobe-logo',
+    classPrefix: 'feds-logo',
+    includeLabel: false,
+    analyticsValue: 'Logo',
+  });
 
   decorateMainNav = async () => {
     this.elements.mainNav = toFragment`<div class="feds-nav"></div>`;

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -6,6 +6,7 @@ export const selectors = {
   globalNav: '.global-navigation',
   curtain: '.feds-curtain',
   navLink: '.feds-navLink',
+  overflowingTopNav: '.feds-topnav--overflowing',
   navItem: '.feds-navItem',
   activeDropdown: '.feds-dropdown--active',
   menuSection: '.feds-menu-section',
@@ -131,6 +132,7 @@ export function setCurtainState(state) {
 }
 
 export const isDesktop = window.matchMedia('(min-width: 900px)');
+export const isTangentToViewport = window.matchMedia('(min-width: 900px) and (max-width: 1440px)');
 
 export function setActiveDropdown(elem) {
   const activeClass = selectors.activeDropdown.replace('.', '');

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -3,10 +3,11 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
 import { createFullGlobalNavigation, selectors, isElementVisible, mockRes, viewports } from './test-utilities.js';
-import { isDesktop } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
+import { isDesktop, isTangentToViewport } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
 import logoOnlyNav from './mocks/global-navigation-only-logo.plain.js';
 import brandOnlyNav from './mocks/global-navigation-only-brand.plain.js';
 import nonSvgBrandOnlyNav from './mocks/global-navigation-only-non-svg-brand.plain.js';
+import longNav from './mocks/global-navigation-long.plain.js';
 
 const ogFetch = window.fetch;
 
@@ -888,6 +889,31 @@ describe('global navigation', () => {
         .to.equal(document.querySelector(selectors.search));
       expect(document.querySelector(selectors.topNavWrapper).lastElementChild)
         .to.equal(document.querySelector(selectors.breadCrumbsWrapper));
+    });
+
+    it('should add a modifier class when nav content overflows', async () => {
+      const getOverflowingTopnav = () => document.querySelector(selectors.overflowingTopNav);
+
+      await createFullGlobalNavigation();
+      expect(getOverflowingTopnav()).to.equal(null);
+
+      await createFullGlobalNavigation({ globalNavigation: longNav });
+      expect(getOverflowingTopnav() instanceof HTMLElement).to.be.true;
+
+      await setViewport(viewports.wide);
+      isTangentToViewport.dispatchEvent(new Event('change'));
+
+      expect(getOverflowingTopnav()).to.equal(null);
+
+      await setViewport(viewports.desktop);
+      isTangentToViewport.dispatchEvent(new Event('change'));
+
+      expect(getOverflowingTopnav() instanceof HTMLElement).to.be.true;
+
+      await setViewport(viewports.mobile);
+      isTangentToViewport.dispatchEvent(new Event('change'));
+
+      expect(getOverflowingTopnav()).to.equal(null);
     });
   });
 });

--- a/test/blocks/global-navigation/mocks/global-navigation-long.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-long.plain.js
@@ -1,0 +1,294 @@
+// Uses the franklin structure without any customizations
+export default `<div>
+  <div class="gnav-brand logo">
+    <div>
+      <div>
+        <p>
+          <a href="/drafts/ramuntea/adobe-logo.svg"
+            >http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg</a
+          >
+        </p>
+        <p><a href="https://www.adobe.com/">Adobe</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <div class="large-menu section">
+    <div>
+      <div>
+        <h2 id="cloud-menu">
+          <a href="/libs/feds/drafts/ramuntea/large-menu">Cloud Menu</a>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <h2 id="w-promo"><a href="https://business.adobe.com/">w/ Promo</a></h2>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/topics/creativity.html#_blank"
+        >Creativity</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+        >Digital Transformation</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/trends--research.html"
+        >Trends &#x26; Research</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/future-of-work.html"
+        >Future Of Work</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/leadership.html">Leadership</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/customer-stories.html"
+        >Customer Stories</a
+      >
+    </li>
+    <li><a href="https://blog.adobe.com/en/topics/events.html">Events</a></li>
+  </ul>
+  <div class="gnav-promo dark">
+    <div>
+      <div>
+        <p><strong>Business Resilience: Leading Through Change</strong></p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas
+          porttitor congue massa.
+        </p>
+        <p><a href="https://adobe.com/">Check it out</a></p>
+      </div>
+    </div>
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+            width="215"
+            height="121"
+          />
+        </picture>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <h2 id="col">2 Col</h2>
+  <h5 id="column-1-heading">Column 1 heading</h5>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/creativity.html">Creativity</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+        >Digital Transformation</a
+      >
+    </li>
+  </ul>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >What is Creative Cloud?</a
+          >
+        </p>
+        <p>Creative apps and services for everyone</p>
+      </div>
+    </div>
+  </div>
+  <h5 id="column-2-heading">Column 2 heading</h5>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/future-of-work.html"
+        >Future Of Work</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/leadership.html">Leadership</a>
+    </li>
+  </ul>
+  <p>
+    <em><a href="https://blog.adobe.com/en/topics/events.html">Events</a></em>
+  </p>
+</div>
+<div>
+  <h2 id="col-1"><a href="https://business.adobe.com/">1 col</a></h2>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/creativity.html">Creativity</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+        >Digital Transformation</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/trends--research.html"
+        >Trends &#x26; Research</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/future-of-work.html"
+        >Future Of Work</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/leadership.html">Leadership</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/customer-stories.html"
+        >Customer Stories</a
+      >
+    </li>
+    <li><a href="https://blog.adobe.com/en/topics/events.html">Events</a></li>
+  </ul>
+</div>
+<div>
+  <p>
+    <strong
+      ><a href="https://helpx.adobe.com/#open-jarvis-chat">Primary</a></strong
+    >
+  </p>
+</div>
+<div>
+  <p>
+    <em
+      ><a href="http://localhost:6456/drafts/ramuntea/gnav-refactor"
+        >Secondary</a
+      ></em
+    >
+  </p>
+</div>
+<div>
+  <h2 id="random-text">Random text</h2>
+</div>
+<div>
+  <h2 id="no-dropdown"><a href="https://www.adobe.com/">No Dropdown</a></h2>
+</div>
+<div>
+  <h2 id="product-dropdown"><a href="https://www.adobe.com/">Product link</a></h2>
+</div>
+<div>
+  <h2 id="solution-link"><a href="https://www.adobe.com/">Solution link</a></h2>
+</div>
+<div>
+  <h2 id="unbelievably-long-link-label"><a href="https://www.adobe.com/">Unbelievably long link label</a></h2>
+</div>
+<div>
+  <div class="search">
+    <div>
+      <div>
+        <p>Search</p>
+        <p>Search</p>
+      </div>
+    </div>
+  </div>
+  <div class="profile">
+    <div>
+      <div>
+        <h5 id="local-menu-title">Local Menu Title</h5>
+        <p>
+          <a href="https://blog.adobe.com/en/topics/creativity.html"
+            >Creativity</a
+          >
+        </p>
+        <p>
+          <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+            >Digital Transformation</a
+          >
+        </p>
+        <p>
+          <a href="https://blog.adobe.com/en/topics/trends--research.html"
+            >Trends &#x26; Research</a
+          >
+        </p>
+      </div>
+    </div>
+    <div>
+      <div>
+        <ul>
+          <li>
+            <a href="https://experiencecloud.adobe.com/exc-content/login.html"
+              >Experience Cloud</a
+            >
+          </li>
+          <li>
+            <a href="https://account.magento.com/customer/account/login"
+              >Commerce (Magento)</a
+            >
+          </li>
+          <li><a href="https://login.marketo.com/">Marketo Engage</a></li>
+          <li>
+            <a href="https://business.adobe.com/products/workfront/login.html"
+              >Workfront</a
+            >
+          </li>
+          <li><a href="https://adobe.com?sign-in=true">Adobe Account</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="app-launcher">
+    <div>
+      <div><a href="/gnav/app-launcher">App Launcher</a></div>
+    </div>
+  </div>
+  <div class="adobe-logo">
+    <div>
+      <div><a href="https://www.adobe.com/">Adobe</a></div>
+    </div>
+  </div>
+</div>`;

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -45,6 +45,7 @@ export const viewports = {
   mobile: { width: 899, height: 1024 },
   smallDesktop: { width: 901, height: 1024 },
   desktop: { width: 1200, height: 1024 },
+  wide: { width: 1600, height: 1024 },
 };
 
 export const loadStyles = (path) => new Promise((resolve) => loadStyle(path, resolve));


### PR DESCRIPTION
Certain Gnav consumers add a lot of navigation content despite [Consonant's recommendations](https://consonant.adobe.com/1975e5ba1/p/48adfd-navigation/b/815684):
> Global nav items | Use five items max.

There have been dozens of discussions on the topic over the past years, but a perfect solution was never found to satisfy marketing/content requirements, ease of authoring, UX and performance concerns.

This PR aims to 'squeeze' a few extra pixels from all navigation items when the content is overflowing the viewport. This does not cover all possible use-cases, but is a good compromise for the moment. If the content overflows, the logic will add a modifier which in turn will:
- remove the brand label;
- remove the (right side) logo entirely;
- lower paddings and font-sizes for all main navigation items.

**Screenshots** @ 1200px viewport width:
| Before | After |
| ------------- | ------------- |
| <img width="1200" alt="AEC - before" src="https://github.com/adobecom/milo/assets/11267498/f5fa227a-d56f-4c79-b2b7-5713542b3702"> | <img width="1200" alt="AEC - after" src="https://github.com/adobecom/milo/assets/11267498/56e0cb86-200b-4ce7-9b16-6b6e17c92e62"> |

Resolves: [MWPW-132444](https://jira.corp.adobe.com/browse/MWPW-132444)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor-long?martech=off
- After: https://enhance-overflowing-gnav--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor-long?martech=off
