### PR TITLE
MWPW-133063-Fix for tabs in a fragment not loading on a page

### DIFF
--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -99,7 +99,7 @@ const handleDeferredImages = (block) => {
 }
 
 const init = (block) => {
-  const rootElem = block.closest('.georouting-wrapper.fragment') || document;
+  const rootElem = block.closest('.fragment') || document;
   const rows = block.querySelectorAll(':scope > div');
   const parentSection = block.closest('.section');
   /* c8 ignore next */
@@ -180,7 +180,7 @@ const init = (block) => {
         const values = row.children[1].textContent.split(',');
         id = values[0];
         val = getStringKeyName(String(values[1]));
-        assocTabItem = rootElem.getElementById(`tab-panel-${id}-${val}`);
+        assocTabItem = rootElem.querySelector(`#tab-panel-${id}-${val}`);
       }
       if (assocTabItem) {
         const section = sectionMetadata.closest('.section');

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -99,7 +99,7 @@ const handleDeferredImages = (block) => {
 }
 
 const init = (block) => {
-  const rootElem = block.closest('.fragment') || document;
+  const rootElem = block.closest('.georouting-wrapper.fragment') || document;
   const rows = block.querySelectorAll(':scope > div');
   const parentSection = block.closest('.section');
   /* c8 ignore next */

--- a/test/blocks/tabs/mocks/body.html
+++ b/test/blocks/tabs/mocks/body.html
@@ -6,16 +6,16 @@
     <div>
       <div>
         <ul>
-          <li>Tab 1</li>
-          <li>Tab 2</li>
-          <li>Tab 3</li>
+          <li>Tab, 1</li>
+          <li>Tab, 2</li>
+          <li>Tab, 3</li>
         </ul>
       </div>
     </div>
   </div>
 </div>
 <div class="section">
-  <p>Here is <strong>Tab 1</strong> content</p>
+  <p>Here is <strong>Tab, 1</strong> content</p>
   <p>
     <picture>
       <img loading="lazy" alt="" type="image/png" src="https://example.com/photos/1x1/photo.jpg" width="1" height="1">
@@ -24,7 +24,7 @@
   <div class="section-metadata">
     <div>
       <div>tab</div>
-      <div>Tab 1</div>
+      <div>Tab, 1</div>
     </div>
   </div>
 </div>
@@ -34,7 +34,7 @@
   <div class="section-metadata">
     <div>
       <div>tab</div>
-      <div>Tab 2</div>
+      <div>Tab, 2</div>
     </div>
   </div>
 </div>
@@ -43,7 +43,7 @@
   <div class="section-metadata">
     <div>
       <div>tab</div>
-      <div>Tab 3</div>
+      <div>Tab, 3</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@
   <div class="section-metadata">
     <div>
       <div>tab</div>
-      <div>Tab 2</div>
+      <div>Tab, 2</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION

* Fix for tabs in a fragment not loading on a page

Resolves: [MWPW-133063](https://jira.corp.adobe.com/browse/MWPW-133063)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/fragmentpage?martech=off
- After: https://tab-in-fragment--milo--ruchika4.hlx.page/drafts/ruchika/fragmentpage?martech=off

As I am updating a code change that was done to make sure tabs load fine in georouting modal as part of this [PR](https://github.com/adobecom/milo/pull/497/files) hnece adding urls to verify that georouting modal with tabs also works fine after this PR

Georouting URLs to verify tabs in modal

Milo

- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/fragmentpage?akamaiLocale=in
- After: https://tab-in-fragment--milo--ruchika4.hlx.page/drafts/ruchika/fragmentpage?akamaiLocale=in

Bacom
- Before: https://main--bacom--adobecom.hlx.page/?akamaiLocale=CH
- After: https://main--bacom--adobecom.hlx.page/?akamaiLocale=CH&milolibs=tab-in-fragment--milo--ruchika4


