### PR TITLE
MWPW-133219: Hide default content before the preact app loads

### DIFF
--- a/libs/blocks/quiz/quiz.css
+++ b/libs/blocks/quiz/quiz.css
@@ -1,3 +1,7 @@
+div.quiz > div {
+  display:none;
+}
+
 .quiz { 
   min-height: 1000px;
   display: flex;
@@ -5,7 +9,7 @@
   flex-direction: column;
 }
 
-.quiz-container {
+div.quiz > div.quiz-container {
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/libs/blocks/quiz/quiz.css
+++ b/libs/blocks/quiz/quiz.css
@@ -1,7 +1,3 @@
-div.quiz > div {
-  display:none;
-}
-
 .quiz { 
   min-height: 1000px;
   display: flex;
@@ -9,7 +5,11 @@ div.quiz > div {
   flex-direction: column;
 }
 
-div.quiz > div.quiz-container {
+.quiz > div:not([class]) {
+  display:none;
+}
+
+.quiz-container {
   display: flex;
   align-items: center;
   justify-content: flex-start;

--- a/libs/blocks/quiz/quiz.css
+++ b/libs/blocks/quiz/quiz.css
@@ -28,11 +28,6 @@
   text-align: center;
 }
 
-.quiz-container ~ div { 
-  display: none; 
-  visibility: hidden; 
-}
-
 .quiz-option {
   display: flex;
   align-items: stretch;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Updating quiz.css to hide default content before the preact app loads. We had some code that previously made the attempt, by hiding sibling div elements of the .quiz-container, but by the time that element loads, it's rather late. 

Resolves: [MWPW-133219](https://jira.corp.adobe.com/browse/MWPW-133219)

**Test URLs:**
- Before: 
https://uar-integration--milo--adobecom.hlx.page/drafts/delta/app-recommender/?martech=off
https://pagespeed.web.dev/analysis/https-uar-integration--milo--adobecom-hlx-page-drafts-delta-app-recommender/ztj24kh6md?form_factor=mobile

- After: 
https://mwpw-133219--milo--echampio-at-adobe.hlx.page/drafts/delta/app-recommender/?martech=off
https://pagespeed.web.dev/analysis/https-mwpw-133219--milo--echampio-at-adobe-hlx-page-drafts-delta-app-recommender/svljqklln9?form_factor=mobile

