### PR TITLE
MWPW-131607: Extend feds.entitlements with the offer ID

### DIFF
--- a/libs/blocks/global-navigation/utilities/getUserEntitlements.js
+++ b/libs/blocks/global-navigation/utilities/getUserEntitlements.js
@@ -29,6 +29,7 @@ const emptyEntitlements = {
   arrangment_codes: {},
   fulfilled_codes: {},
   offer_families: {},
+  offers: {},
   list: { fulfilled_codes: [] },
 };
 const CREATIVE_CLOUD = 'creative_cloud';
@@ -37,10 +38,10 @@ const EXPERIENCE_CLOUD = 'experience_cloud';
 
 /**
  * Breaks JIL offers(subscriptions) into easily addressable flat data structure.
- * @param {*} offers
+ * @param {*} allOffers
  */
-const mapSubscriptionCodes = (offers) => {
-  if (!Array.isArray(offers)) {
+const mapSubscriptionCodes = (allOffers) => {
+  if (!Array.isArray(allOffers)) {
     return emptyEntitlements;
   }
 
@@ -49,10 +50,11 @@ const mapSubscriptionCodes = (offers) => {
     arrangment_codes,
     fulfilled_codes,
     offer_families,
+    offers,
     list,
   } = emptyEntitlements;
 
-  offers.forEach(({ fulfilled_items, offer = {} }) => {
+  allOffers.forEach(({ fulfilled_items, offer = {} }) => {
     const cloud = offer.product_arrangement?.cloud;
     clouds[CREATIVE_CLOUD] = clouds[CREATIVE_CLOUD] || cloud === 'CREATIVE';
     clouds[DOCUMENT_CLOUD] = clouds[DOCUMENT_CLOUD] || cloud === 'DOCUMENT';
@@ -75,6 +77,11 @@ const mapSubscriptionCodes = (offers) => {
         }
       });
     }
+
+    if (Object.prototype.hasOwnProperty.call(offer, 'offer_id')) {
+      const { offer_id, ...rest } = offer;
+      offers[offer_id] = rest;
+    }
   });
 
   return {
@@ -82,6 +89,7 @@ const mapSubscriptionCodes = (offers) => {
     arrangment_codes,
     fulfilled_codes,
     offer_families,
+    offers,
     list,
   };
 };

--- a/test/blocks/global-navigation/mocks/subscriptionsAll.js
+++ b/test/blocks/global-navigation/mocks/subscriptionsAll.js
@@ -228,6 +228,7 @@ const formatted = {
     cc_all_apps: true,
     acrobat: true,
   },
+  offers: {},
   list: {
     fulfilled_codes: [
       'dma_reactor',

--- a/test/blocks/global-navigation/utilities/getUserEntitlements.test.js
+++ b/test/blocks/global-navigation/utilities/getUserEntitlements.test.js
@@ -10,6 +10,7 @@ const emptyEntitlements = {
   arrangment_codes: {},
   fulfilled_codes: {},
   offer_families: {},
+  offers: {},
   list: { fulfilled_codes: [] },
 };
 

--- a/test/blocks/global-navigation/utilities/getUserEntitlements.test.js
+++ b/test/blocks/global-navigation/utilities/getUserEntitlements.test.js
@@ -54,6 +54,11 @@ describe('getUserEntitlements', () => {
     const entitlementsRaw = await getUserEntitlements({ params: [{ name: 'Q', value: 'PARAM' }], format: 'raw' });
     expect(window.fetch.callCount).to.equal(2);
     expect(entitlementsRaw).to.deep.equal(res);
+
+    // empty entitlements should not have been modified
+    window.adobeIMS = { isSignedInUser: () => false };
+    const entitlements2 = await getUserEntitlements();
+    expect(entitlements2).to.deep.equal(emptyEntitlements);
   });
 
   it('should return the raw response if format is raw', async () => {


### PR DESCRIPTION
* Added the `offers` field in the `entitlements` object. This field will hold the offer IDs and offers data, which will be used on Titans to form the URL for the switch plan flow.

Resolves: [MWPW-131607](https://jira.corp.adobe.com/browse/MWPW-131607)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://<branch>--milo--adobecom.hlx.page/?martech=off
https://mwpw-131607-entitlements--milo--adobecom.hlx.page/?martech=off - link doesn't work, will add correct later
