### PR TITLE
Call OnReady for gnav if IMS is already there

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -463,6 +463,10 @@ class Gnav {
 
     if (!window.adobeIMS) {
       loadIms(onReady || defaultOnReady);
+    } else if (onReady) {
+      onReady();
+    } else if (defaultOnReady) {
+      defaultOnReady();
     }
     return profileEl;
   };


### PR DESCRIPTION
Small fix for legacy gnav
