### PR TITLE
Personalization martech fix: also check for window._satellite presence

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -643,7 +643,8 @@ export function loadIms(onReadyFn) {
 }
 
 async function loadMartech({ persEnabled = false, persManifests = [] } = {}) {
-  if (window.marketingtech?.adobe?.launch !== undefined) {
+  // eslint-disable-next-line no-underscore-dangle
+  if (window.marketingtech?.adobe?.launch && window._satellite) {
     return true;
   }
 


### PR DESCRIPTION
Before running martech a check for `window.marketingtech.adobe.launch` is done to see if it's already loaded.  With the new setup we also need a check for `window._satellite`

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://martechfix--milo--adobecom.hlx.page/?martech=off
