### PR TITLE
Fix global navigation tests

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -2,8 +2,7 @@
 import {
   getConfig,
   getMetadata,
-  loadIms as utilsLoadIms,
-  loadScript,
+  loadIms,
   localizeLink,
   decorateSVG,
 } from '../../utils/utils.js';
@@ -193,7 +192,7 @@ class Gnav {
       this.decorateTopNav,
       this.decorateTopnavWrapper,
       this.addChangeEventListener,
-      this.loadIMS,
+      () => loadIms(this.imsReady.bind(this)),
     ];
     this.el.addEventListener('click', this.loadDelayed);
     this.el.addEventListener('keydown', setupKeyboardNav);
@@ -292,24 +291,19 @@ class Gnav {
     return this.ready;
   };
 
-  loadIMS = () => {
-    const onReady = async () => {
-      const tasks = [
-        this.decorateProfile,
-        this.decorateAppLauncher,
-      ];
-      try {
-        for await (const task of tasks) {
-          await yieldToMain();
-          await task();
-        }
-      } catch (e) {
-        lanaLog({ message: 'GNAV: issues within onReady', e });
+  imsReady = async () => {
+    const tasks = [
+      this.decorateProfile,
+      this.decorateAppLauncher,
+    ];
+    try {
+      for await (const task of tasks) {
+        await yieldToMain();
+        await task();
       }
-    };
-
-    utilsLoadIms(onReady);
-    return null;
+    } catch (e) {
+      lanaLog({ message: 'GNAV: issues within onReady', e });
+    }
   };
 
   decorateProfile = async () => {

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -148,8 +148,7 @@ export const createFullGlobalNavigation = async ({
   ]);
 
   const instance = await initGnav(document.body.querySelector('header'));
-  instance.loadIMS();
-  window.adobeid.onReady();
+  instance.imsReady();
   await clock.runAllAsync();
   // We restore the clock here, because waitForElement uses setTimeout
   clock.restore();


### PR DESCRIPTION
With merging https://github.com/adobecom/milo/pull/874 the global navigation test suite doesn't seem to run anymore, as @meganthecoder mentioned [here](https://github.com/adobecom/milo/pull/910#issuecomment-1613886656).

This PR fixes the broken global navigation test suite.

### Test instructions
You should still be able to log in and see the profile on both URLs.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/gnav-1?martech=off#
- After: https://gnav--milo--adobecom.hlx.page/drafts/osahin/gnav-1?martech=off#
