### PR TITLE
MWPW-124986 - [Caas] Changes in Milo to support Single Page Caas Publish & automated bulk publishing of content to CaaS

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -1,4 +1,5 @@
 import getUuid from '../../libs/utils/getUuid.js';
+import { getMetadata } from '../../libs/utils/utils.js';
 
 const CAAS_TAG_URL = 'https://www.adobe.com/chimera-api/tags';
 const HLX_ADMIN_STATUS = 'https://admin.hlx.page/status';
@@ -418,7 +419,10 @@ const props = {
   bookmarkicon: 0,
   cardimage: () => getCardImageUrl(),
   cardimagealttext: (s) => s || getCardImageAltText(),
-  contentid: (_, options) => getUuid(options.prodUrl),
+  contentid: (_, options) => {
+    const floodGateColor = getMetadata('floodGateColor') || '';
+    return getUuid(`${options.prodUrl}${floodGateColor}`);
+  },
   contenttype: (s) => s || getMetaContent('property', 'og:type') || 'Article',
   country: async (s, options) => {
     if (s) return s;
@@ -459,7 +463,7 @@ const props = {
   eventduration: 0,
   eventend: (s) => getDateProp(s, `Invalid Event End Date: ${s}`),
   eventstart: (s) => getDateProp(s, `Invalid Event Start Date: ${s}`),
-  floodgatecolor: (s) => s || 'default',
+  floodgatecolor: (s) => s || getMetadata('floodGateColor') || 'default',
   lang: async (s, options) => {
     if (s) return s;
     const { lang } = await getCountryAndLang(options);


### PR DESCRIPTION

* Adding Floodgate Color pink, based on the metadata.xslsx on the FG tree root
* Changing ContentId for pages under FG tree, to maintain uniqueness between the same page on default tree


Resolves: [MWPW-124986](https://jira.corp.adobe.com/browse/MWPW-124986)

**Test URLs:**
- Before: 
- After: 
