### PR TITLE
MWPW-133443: Fetch gnav placeholders from correct location

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -33,17 +33,10 @@ export function toFragment(htmlStrings, ...values) {
 export const getFedsPlaceholderConfig = () => {
   const { locale } = getConfig();
   let libOrigin = 'https://milo.adobe.com';
+  const { origin } = window.location;
 
-  if (window.location.origin.includes('localhost')) {
-    libOrigin = `${window.location.origin}`;
-  }
-
-  if (window.location.origin.includes('.hlx.page')) {
-    libOrigin = 'https://main--milo--adobecom.hlx.page';
-  }
-
-  if (window.location.origin.includes('.hlx.live')) {
-    libOrigin = 'https://main--milo--adobecom.hlx.live';
+  if (origin.includes('localhost') || origin.includes('.hlx.')) {
+    libOrigin = `https://main--milo--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
   }
 
   return {

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -34,7 +34,7 @@ describe('global navigation utilities', () => {
       const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig();
       expect(ietf).to.equal('en-US');
       expect(prefix).to.equal('');
-      expect(contentRoot).to.equal('http://localhost:2000');
+      expect(contentRoot).to.equal('https://main--milo--adobecom.hlx.page');
     });
 
     it('should return a config object for a specific locale', () => {
@@ -48,7 +48,7 @@ describe('global navigation utilities', () => {
       const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig();
       expect(ietf).to.equal('fi-FI');
       expect(prefix).to.equal('/fi');
-      expect(contentRoot).to.equal('http://localhost:2000/fi');
+      expect(contentRoot).to.equal('https://main--milo--adobecom.hlx.page/fi');
     });
   });
 


### PR DESCRIPTION
### Description
Do not 404 for the feds placeholders on localhost on milo consuming projects and fetch global navigation placeholders always from https://main--milo--adobecom.hlx.page rather than localhost. 

Resolves: [MWPW-133443](https://jira.corp.adobe.com/browse/MWPW-133443)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/gnav-1?martech=off#
- After: https://MWPW-133443--milo--mokimo.hlx.page/drafts/osahin/gnav-1?martech=off#
