### PR TITLE
Skip personalization test for now

### DIFF
--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -6,8 +6,8 @@ import { applyPers } from '../../../libs/features/personalization/personalizatio
 // document.body.innerHTML = await readFile({ path: './mocks/head.html' });
 
 describe('Functional Test', () => {
-  it('replaceContent should replace an element with a fragment', async () => {
-    const manifestData = { test: true };
+  it.skip('replaceContent should replace an element with a fragment', async () => {
+    const manifestData = [{ test: true }];
     stubFetch(manifestData);
 
     const loadedlinkParams = {};
@@ -18,11 +18,11 @@ describe('Functional Test', () => {
 
     await applyPers(
       // Path doesn't matter as we stub fetch above
-      { persManifests: ['/path/to/manifest.json'] },
+      ['/path/to/manifest.json'],
       { createTag, getConfig, updateConfig, loadLink, loadScript: () => {} },
     );
 
-    expect(loadedlinkParams).to.deep({
+    expect(loadedlinkParams).to.deep.equal({
       url: '/path/to/manifest.json',
       options: { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' },
     });

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -1,10 +1,7 @@
-import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
-import { createTag, setConfig, getConfig, updateConfig } from '../../../libs/utils/utils.js';
-import { waitForElement } from '../../helpers/waitfor.js';
+import { createTag, getConfig, updateConfig } from '../../../libs/utils/utils.js';
 import { stubFetch } from '../../helpers/mockFetch.js';
-import { applyPersonalization } from '../../../libs/features/personalization/personalization.js';
+import { applyPers } from '../../../libs/features/personalization/personalization.js';
 
 // document.body.innerHTML = await readFile({ path: './mocks/head.html' });
 
@@ -19,7 +16,7 @@ describe('Functional Test', () => {
       loadedlinkParams.options = options;
     };
 
-    await applyPersonalization(
+    await applyPers(
       // Path doesn't matter as we stub fetch above
       { persManifests: ['/path/to/manifest.json'] },
       { createTag, getConfig, updateConfig, loadLink, loadScript: () => {} },
@@ -31,4 +28,3 @@ describe('Functional Test', () => {
     });
   });
 });
-


### PR DESCRIPTION
Remove unused imports in the personalization tests and the renamed `applyPers` function.
It seems like the test was written & then some refactorings have been made, hence let's skip the test until @chrischrischris has time to look at it properly

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live
- After: https://fix-pers-tests--milo--mokimo.hlx.live