### PR TITLE
[MWPW-132443] Visible brand label if no image exists

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -443,7 +443,7 @@ header.global-navigation {
     display: flex;
   }
 
-  .feds-topnav--overflowing .feds-brand-label {
+  .feds-topnav--overflowing .feds-brand-label:nth-child(2) {
     display: none;
   }
 

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -912,7 +912,7 @@ describe('global navigation', () => {
 
       expect(getOverflowingTopnav()).to.equal(null);
 
-      await setViewport(viewports.desktop);
+      await setViewport(viewports.smallDesktop);
       isTangentToViewport.dispatchEvent(new Event('change'));
 
       expect(getOverflowingTopnav() instanceof HTMLElement).to.be.true;


### PR DESCRIPTION
An edge case has been uncovered with the merge of https://github.com/adobecom/milo/pull/882 and https://github.com/adobecom/milo/pull/893 - if the brand block is label-only and the navigation contents are overflowing, then the brand label is hidden. This PR ensures that the brand label remains visible in such cases.

Resolves: [MWPW-132443](https://jira.corp.adobe.com/browse/MWPW-132443)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/blog-new-gnav?martech=off
- After: https://gnav-blog-enhancements--milo--overmyheadandbody.hlx.page/drafts/ramuntea/blog-new-gnav?martech=off
