### PR TITLE
Refactor debounce from utils

### DIFF
--- a/libs/blocks/commerce/commerce.js
+++ b/libs/blocks/commerce/commerce.js
@@ -130,18 +130,12 @@ export const decorateOfferDetails = async (el, of, searchParams) => {
 export const handleSearch = async (event, el) => {
   let searchParams = {};
   const displaySearchError = () => {
-    const notValidUrl = createTag('h4', { class: 'not-valid-url' }, 'Not a valid offer link')
+    const notValidUrl = createTag('h4', { class: 'not-valid-url' }, 'Not a valid offer link');
     el.append(notValidUrl);
   };
   el.textContent = '';
   const search = event.target.value;
-  try {
-    searchParams = new URL(search).searchParams;
-  } catch (e) {
-    displaySearchError();
-    return;
-  }
-  const osi = searchParams.get('osi');
+  const osi = new URLSearchParams(search).get('osi');
   if (!osi) {
     displaySearchError();
     return;

--- a/libs/blocks/commerce/commerce.js
+++ b/libs/blocks/commerce/commerce.js
@@ -128,7 +128,6 @@ export const decorateOfferDetails = async (el, of, searchParams) => {
 };
 
 export const handleSearch = async (event, el) => {
-  let searchParams = {};
   const displaySearchError = () => {
     const notValidUrl = createTag('h4', { class: 'not-valid-url' }, 'Not a valid offer link');
     el.append(notValidUrl);
@@ -138,9 +137,9 @@ export const handleSearch = async (event, el) => {
   try {
     const url = new URL(search);
     const osi = url.searchParams.get('osi');
-    if(!osi) throw new Error('no osi query param in URL');
+    if(!osi) { displaySearchError(); return; }
     window.tacocat.wcs.resolveOfferSelector(osi).then(([offerDetails]) => {
-      decorateOfferDetails(el, offerDetails, searchParams);
+      decorateOfferDetails(el, offerDetails, url.searchParams);
     }).catch(displaySearchError);
   }
   catch (e) {

--- a/libs/blocks/commerce/commerce.js
+++ b/libs/blocks/commerce/commerce.js
@@ -1,4 +1,4 @@
-import { createTag, getConfig, loadScript, debounce } from '../../utils/utils.js';
+import { createTag, getConfig, loadScript } from '../../utils/utils.js';
 import { getTacocatEnv, runTacocat, buildCheckoutButton, getCheckoutContext, omitNullValues } from '../merch/merch.js';
 
 window.tacocat.loadPromise = new Promise((resolve) => {
@@ -23,6 +23,14 @@ window.tacocat.loadPromise = new Promise((resolve) => {
       resolve(true);
     });
 });
+
+function debounce(func, timeout = 300) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => { func.apply(this, args); }, timeout);
+  };
+}
 
 export const filterOfferDetails = (o) => {
   const formattedOffer = {};
@@ -98,18 +106,21 @@ export const decorateOfferDetails = async (el, of, searchParams) => {
 export const handleSearch = async (event, el) => {
   let searchParams = {};
   const displaySearchError = () => {
-    const notValidUrl = document.createElement('h4');
-    notValidUrl.classList.add('not-valid-url');
-    notValidUrl.textContent = 'Not a valid offer link';
+    const notValidUrl = createTag('h4', { class: 'not-valid-url' }, 'Not a valid offer link')
     el.append(notValidUrl);
   };
   el.textContent = '';
   const search = event.target.value;
-  searchParams = new URL(search).searchParams;
+  try {
+    searchParams = new URL(search).searchParams;
+  } catch (e) {
+    displaySearchError();
+    return;
+  }
   const osi = searchParams.get('osi');
   if (!osi) {
     displaySearchError();
-    return undefined;
+    return;
   }
   window.tacocat.wcs.resolveOfferSelector(osi).then(([offerDetails]) => {
     decorateOfferDetails(el, offerDetails, searchParams);

--- a/libs/blocks/commerce/commerce.js
+++ b/libs/blocks/commerce/commerce.js
@@ -145,7 +145,6 @@ export const handleSearch = async (event, el) => {
   }
   catch (e) {
     displaySearchError();
-    return;
   }
 };
 

--- a/libs/blocks/commerce/commerce.js
+++ b/libs/blocks/commerce/commerce.js
@@ -137,7 +137,7 @@ export const handleSearch = async (event, el) => {
   try {
     const url = new URL(search);
     const osi = url.searchParams.get('osi');
-    if(!osi) { displaySearchError(); return; }
+    if (!osi) { displaySearchError(); return; }
     window.tacocat.wcs.resolveOfferSelector(osi).then(([offerDetails]) => {
       decorateOfferDetails(el, offerDetails, url.searchParams);
     }).catch(displaySearchError);

--- a/libs/blocks/commerce/commerce.js
+++ b/libs/blocks/commerce/commerce.js
@@ -1,5 +1,6 @@
 import { createTag, getConfig, loadScript } from '../../utils/utils.js';
 import { getTacocatEnv, runTacocat, buildCheckoutButton, getCheckoutContext, omitNullValues } from '../merch/merch.js';
+import { debounce } from "../../utils/action.js";
 
 window.tacocat.loadPromise = new Promise((resolve) => {
   const { env, locale } = getConfig();
@@ -23,14 +24,6 @@ window.tacocat.loadPromise = new Promise((resolve) => {
       resolve(true);
     });
 });
-
-function debounce(func, timeout = 300) {
-  let timer;
-  return (...args) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => { func.apply(this, args); }, timeout);
-  };
-}
 
 export const filterOfferDetails = (o) => {
   const formattedOffer = {};

--- a/libs/blocks/commerce/commerce.js
+++ b/libs/blocks/commerce/commerce.js
@@ -135,14 +135,18 @@ export const handleSearch = async (event, el) => {
   };
   el.textContent = '';
   const search = event.target.value;
-  const osi = new URLSearchParams(search).get('osi');
-  if (!osi) {
+  try {
+    const url = new URL(search);
+    const osi = url.searchParams.get('osi');
+    if(!osi) throw new Error('no osi query param in URL');
+    window.tacocat.wcs.resolveOfferSelector(osi).then(([offerDetails]) => {
+      decorateOfferDetails(el, offerDetails, searchParams);
+    }).catch(displaySearchError);
+  }
+  catch (e) {
     displaySearchError();
     return;
   }
-  window.tacocat.wcs.resolveOfferSelector(osi).then(([offerDetails]) => {
-    decorateOfferDetails(el, offerDetails, searchParams);
-  }).catch(displaySearchError);
 };
 
 export const decorateSearch = (el) => {

--- a/libs/blocks/global-navigation/features/search/gnav-search.js
+++ b/libs/blocks/global-navigation/features/search/gnav-search.js
@@ -9,6 +9,7 @@ import {
 } from '../../utilities/utilities.js';
 import { replaceKeyArray } from '../../../../features/placeholders.js';
 import { getConfig } from '../../../../utils/utils.js';
+import { debounce } from "../../../../utils/action.js";
 
 const CONFIG = {
   suggestions: {
@@ -20,17 +21,6 @@ const CONFIG = {
     inputIsPopulated: 'feds-search-input--isPopulated',
   },
 };
-
-function debounceCallback(callback, time = 150) {
-  if (typeof callback !== 'function') return undefined;
-
-  let timeout = null;
-
-  return (...args) => {
-    clearTimeout(timeout);
-    timeout = setTimeout(() => callback(...args), time);
-  };
-}
 
 const { locale } = getConfig();
 const [, country = 'US'] = locale.ietf.split('-');
@@ -144,7 +134,7 @@ class Search {
       });
   }
 
-  onSearchInput = debounceCallback(() => {
+  onSearchInput = debounce(() => {
     const query = this.getQuery();
 
     if (!query.length) {
@@ -184,7 +174,7 @@ class Search {
           this.parent.classList.remove(CONFIG.selectors.hasResults);
         }
       });
-  });
+  }, 150);
 
   getQuery() {
     const query = this.input.value.trim();

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -27,14 +27,6 @@ const childIndexOf = (el) => [...el.parentElement.children]
   .filter((e) => (e.nodeName === 'DIV' || e.nodeName === 'P'))
   .indexOf(el);
 
-const debounce = (func, timeout = 300) => {
-  let timer;
-  return async (...args) => {
-    clearTimeout(timer);
-    timer = setTimeout(async () => func.apply(this, args), timeout);
-  };
-};
-
 function getBlockClasses(className) {
   const trimDashes = (str) => str.replace(/(^\s*-)|(-\s*$)/g, '');
   const blockWithVariants = className.split('--');
@@ -106,6 +98,7 @@ class Gnav {
     const { onSearchInput, getHelpxLink } = await import('./gnav-search.js');
     this.getHelpxLink = getHelpxLink;
 
+    const { debounce } = await import('../../utils/action.js');
     if (this.searchType === SEARCH_TYPE_CONTEXTUAL) {
       const { default: onContextualSearchInput } = await import('./gnav-contextual-search.js');
       this.onSearchInput = debounce(onContextualSearchInput, SEARCH_DEBOUNCE_MS);

--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -51,12 +51,12 @@ async function handleStickySection(sticky, section) {
   }
 }
 
-export function handleStyle(text, section) {
+export async function handleStyle(text, section) {
   if (!text || !section) return;
   const styles = text.split(', ').map((style) => style.replaceAll(' ', '-'));
   const sticky = styles.find((style) => style === 'sticky-top' || style === 'sticky-bottom');
   if (sticky) {
-    handleStickySection(sticky, section);
+    await handleStickySection(sticky, section);
   }
   section.classList.add(...styles);
 }
@@ -77,10 +77,10 @@ export const getMetadata = (el) => [...el.childNodes].reduce((rdx, row) => {
   return rdx;
 }, {});
 
-export default function init(el) {
+export default async function init(el) {
   const section = el.closest('.section');
   const metadata = getMetadata(el);
-  if (metadata.style) handleStyle(metadata.style.text, section);
+  if (metadata.style) await handleStyle(metadata.style.text, section);
   if (metadata.background) handleBackground(metadata, section);
   if (metadata.layout) handleLayout(metadata.layout.text, section);
 }

--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -55,9 +55,7 @@ export async function handleStyle(text, section) {
   if (!text || !section) return;
   const styles = text.split(', ').map((style) => style.replaceAll(' ', '-'));
   const sticky = styles.find((style) => style === 'sticky-top' || style === 'sticky-bottom');
-  if (sticky) {
-    await handleStickySection(sticky, section);
-  }
+  if (sticky) await handleStickySection(sticky, section);
   section.classList.add(...styles);
 }
 

--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -1,5 +1,3 @@
-import { debounce } from '../../utils/utils.js';
-
 function handleBackground(div, section) {
   const pic = div.background.content.querySelector('picture');
   if (pic) {
@@ -36,6 +34,14 @@ export function handleFocalpoint(pic, child, removeChild) {
 function handleTopHeight(section) {
   const headerHeight = document.querySelector('header').offsetHeight;
   section.style.top = `${headerHeight}px`;
+}
+
+function debounce(func, timeout = 300) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => { func.apply(this, args); }, timeout);
+  };
 }
 
 function handleStickySection(sticky, section) {

--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -35,19 +35,11 @@ function handleTopHeight(section) {
   const headerHeight = document.querySelector('header').offsetHeight;
   section.style.top = `${headerHeight}px`;
 }
-
-function debounce(func, timeout = 300) {
-  let timer;
-  return (...args) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => { func.apply(this, args); }, timeout);
-  };
-}
-
-function handleStickySection(sticky, section) {
+async function handleStickySection(sticky, section) {
   const main = document.querySelector('main');
   switch (sticky) {
     case 'sticky-top':
+      const { debounce } = await import('../../utils/action.js');
       window.addEventListener('resize', debounce(() => handleTopHeight(section)));
       main.prepend(section);
       break;

--- a/libs/utils/action.js
+++ b/libs/utils/action.js
@@ -1,0 +1,10 @@
+export function debounce(callback, time = 300) {
+    if (typeof callback !== 'function') return undefined;
+
+    let timer = null;
+
+    return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => callback(...args), time);
+    };
+}

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -904,11 +904,3 @@ export function loadLana(options = {}) {
   window.addEventListener('error', lanaError);
   window.addEventListener('unhandledrejection', lanaError);
 }
-
-export function debounce(func, timeout = 300) {
-  let timer;
-  return (...args) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => { func.apply(this, args); }, timeout);
-  };
-}

--- a/test/blocks/commerce/commerce.test.js
+++ b/test/blocks/commerce/commerce.test.js
@@ -1,3 +1,4 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
 
@@ -77,7 +78,12 @@ describe('decorateSearch', () => {
     expect(input.getAttribute('placeholder')).to.equal('Enter offer URL to preview');
   });
 
-  it('calls handle search correctly on keyup', () => {
+  it('calls handle search correctly on keyup', async () => {
+    const clock = sinon.useFakeTimers({
+      toFake: ['setTimeout'],
+      shouldAdvanceTime: true,
+    });
+
     const el = document.createElement('div');
     decorateSearch(el);
     const searchWrapper = el.querySelector('.offer-search-wrapper');
@@ -92,10 +98,11 @@ describe('decorateSearch', () => {
     input.dispatchEvent(e);
     let h4 = el.querySelector('h4');
     expect(h4).to.equal(null);
-    setTimeout(() => {
-      h4 = el.querySelector('h4');
-      expect(h4).to.not.equal(null);
-    }, 500)
+    clock.tick(500);
+    h4 = el.querySelector('h4');
+    expect(h4).to.not.equal(null);
+
+    clock.restore();
   });
 });
 

--- a/test/blocks/commerce/commerce.test.js
+++ b/test/blocks/commerce/commerce.test.js
@@ -71,4 +71,25 @@ describe('decorateSearch', () => {
     expect(input).to.exist;
     expect(input.getAttribute('placeholder')).to.equal('Enter offer URL to preview');
   });
+
+  it('calls handle search correctly on keyup', () => {
+    const el = document.createElement('div');
+    decorateSearch(el);
+    const searchWrapper = el.querySelector('.offer-search-wrapper');
+    const offerDetailsWrapper = el.querySelector('.offer-details-wrapper');
+    const input = searchWrapper.querySelector('.offer-search');
+    const e = new KeyboardEvent("keyup", {bubbles : false, cancelable : true, key : "Q", shiftKey : false});
+    Object.defineProperty(e, 'target', {
+      value: {
+        value: 'Q',
+      }
+    });
+    input.dispatchEvent(e);
+    let h4 = el.querySelector('h4');
+    expect(h4).to.equal(null);
+    setTimeout(() => {
+      h4 = el.querySelector('h4');
+      expect(h4).to.not.equal(null);
+    }, 500)
+  });
 });

--- a/test/blocks/section-metadata/section-meta.test.js
+++ b/test/blocks/section-metadata/section-meta.test.js
@@ -13,39 +13,39 @@ describe('Section Metdata', () => {
     expect(sec.classList.length).to.equal(0);
   });
 
-  it('Handles background image', () => {
+  it('Handles background image', async () => {
     const sec = document.querySelector('.section.image');
     const sm = sec.querySelector('.section-metadata');
-    init(sm);
+    await init(sm);
     expect(sec.classList.contains('has-background')).to.be.true;
   });
 
-  it('Handles background image focal point', async() => {
+  it('Handles background image focal point', async () => {
     const sec = document.querySelector('.section.image');
     const sm = sec.querySelector('.section-metadata');
-    init(sm);
+    await init(sm);
     const image = sec.querySelector('img');
     expect(image.style.objectPosition).to.equal('center bottom');
   });
 
-  it('Handles background color', () => {
+  it('Handles background color', async () => {
     const sec = document.querySelector('.section.color');
     const sm = sec.querySelector('.section-metadata');
-    init(sm);
+    await init(sm);
     expect(sec.style.background).to.equal('rgb(239, 239, 239)');
   });
 
-  it('Handles background gradient', () => {
+  it('Handles background gradient', async () => {
     const sec = document.querySelector('.section.gradient.color');
     const sm = sec.querySelector('.section-metadata');
-    init(sm);
+    await init(sm);
     expect(sec.style.background).to.equal('linear-gradient(red, yellow)');
   });
 
-  it('Adds class based on layout input', () => {
+  it('Adds class based on layout input', async () => {
     const sec = document.querySelector('.section.layout');
     const sm = sec.querySelector('.section-metadata');
-    init(sm);
+    await init(sm);
     expect(sec.classList.contains('grid-template-columns-1-2')).to.be.true;
   });
 
@@ -62,11 +62,11 @@ describe('Section Metdata', () => {
     expect(main.lastElementChild).to.be.eql(sec);
   });
 
-  it('add section to top', () => {
+  it('add section to top', async () => {
     const sec = document.querySelector('.section.sticky-top');
     const sm = sec.querySelector('.section-metadata');
     const main = document.querySelector('main');
-    init(sm);
+    await init(sm);
     expect(main.firstElementChild).to.be.eql(sec);
   });
 

--- a/test/utils/action.test.js
+++ b/test/utils/action.test.js
@@ -1,0 +1,24 @@
+import { expect } from '@esm-bundle/chai';
+import { debounce } from "../../libs/utils/action.js";
+
+
+describe('Input', () => {
+    it('Debounces callback correctly', async () => {
+        const header = document.createElement('h2')
+        header.setAttribute('id', 'debounce');
+        const setValue = () => {
+            header.textContent = 'debounced!';
+        };
+
+        debounce(setValue, 300)();
+
+        expect(header.textContent).to.equal('');
+        setTimeout(() => {
+            expect(header.textContent).to.equal('');
+        }, 100)
+        setTimeout(() => {
+            expect(header.textContent).to.equal('debounced!');
+            header.remove();
+        }, 300)
+    });
+});

--- a/test/utils/action.test.js
+++ b/test/utils/action.test.js
@@ -1,9 +1,15 @@
+import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { debounce } from "../../libs/utils/action.js";
 
 
 describe('Input', () => {
     it('Debounces callback correctly', async () => {
+        const clock = sinon.useFakeTimers({
+            toFake: ['setTimeout'],
+            shouldAdvanceTime: true,
+        });
+
         const header = document.createElement('h2')
         header.setAttribute('id', 'debounce');
         const setValue = () => {
@@ -13,12 +19,11 @@ describe('Input', () => {
         debounce(setValue, 300)();
 
         expect(header.textContent).to.equal('');
-        setTimeout(() => {
-            expect(header.textContent).to.equal('');
-        }, 100)
-        setTimeout(() => {
-            expect(header.textContent).to.equal('debounced!');
-            header.remove();
-        }, 300)
+        clock.tick(100);
+        expect(header.textContent).to.equal('');
+        clock.tick(300);
+        expect(header.textContent).to.equal('debounced!');
+        header.remove();
+        clock.restore();
     });
 });

--- a/test/utils/action.test.js
+++ b/test/utils/action.test.js
@@ -3,7 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import { debounce } from "../../libs/utils/action.js";
 
 
-describe('Input', () => {
+describe('Action', () => {
     it('Debounces callback correctly', async () => {
         const clock = sinon.useFakeTimers({
             toFake: ['setTimeout'],


### PR DESCRIPTION
Refactors debounce away from utils as requested here https://github.com/adobecom/milo/pull/711 

Resolves: [MWPW-133591](https://jira.corp.adobe.com/browse/MWPW-133591)

Test URLs:
Test search at top right in new gnav (debounce should be working)
Before: https://main--milo--adobecom.hlx.page/drafts/vhargrave/empty-page?martech=off&hideGeorouting=on
After: https://vhargrave-remove-debounce-utils--milo--adobecom.hlx.page/drafts/vhargrave/empty-page?martech=off&hideGeorouting=on

Test search at top right in old gnav (debounce should be working)
Before: https://main--bacom--adobecom.hlx.page/?martech=off&hideGeorouting=on
After: https://main--bacom--adobecom.hlx.page/?milolibs=vhargrave-remove-debounce-utils&martech=off&hideGeorouting=on

Before: https://main--milo--adobecom.hlx.page/tools/commerce?martech=off&hideGeorouting=on
After: https://vhargrave-remove-debounce-utils--milo--adobecom.hlx.page/tools/commerce?martech=off&hideGeorouting=on
