### PR TITLE
MWPW-132150 - Strikethrough prices text style fix

### DIFF
--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -7,7 +7,7 @@ span[data-wcs-osi] {
   display: inline-block;
 }
 
-.price-strikethrough {
+span.placeholder-resolved[data-template="priceStrikethrough"] {
   text-decoration: line-through;
 }
 


### PR DESCRIPTION
MWPW-132150 - Strikethrough prices text style fix 

* Fixes line-through style decoration for strikethrough prices generated from OST.

Resolves: [MWPW-132150](https://jira.corp.adobe.com/browse/MWPW-132150)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/fredw/ost-test
- After: https://main--cc--adobecom.hlx.page/drafts/fredw/ost-test?milolibs=Mwpw-132150
