### PR TITLE
Ensure multiple places can load IMS from the milo utils

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -48,7 +48,6 @@ const CONFIG = {
     'app-launcher',
     'adobe-logo',
   ],
-  imsReady: 'onImsLibInstance',
 };
 
 // signIn, decorateSignIn and decorateProfileTrigger can be removed if IMS takes over the profile
@@ -210,6 +209,8 @@ class Gnav {
     isDesktop.addEventListener('change', closeAllDropdowns);
   }, 'Error in global navigation init');
 
+  ims = async () => loadIms().then(() => this.imsReady()).catch(() => {});
+
   decorateTopNav = () => {
     this.elements.mobileToggle = this.decorateToggle();
     this.elements.topnav = toFragment`
@@ -233,14 +234,6 @@ class Gnav {
       </div>`;
 
     this.el.append(this.elements.curtain, this.elements.topnavWrapper);
-  };
-
-  ims = () => {
-    if (window.adobeIMS) {
-      if (window.adobeIMS.initialized) return this.imsReady();
-      return window.addEventListener(CONFIG.imsReady, this.imsReady, { once: true });
-    }
-    return loadIms(this.imsReady.bind(this));
   };
 
   addChangeEventListeners = () => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -209,7 +209,11 @@ class Gnav {
     isDesktop.addEventListener('change', closeAllDropdowns);
   }, 'Error in global navigation init');
 
-  ims = async () => loadIms().then(() => this.imsReady()).catch(() => {});
+  ims = async () => loadIms()
+    .then(() => this.imsReady())
+    .catch((e) => {
+      lanaLog({ message: 'GNAV: Error with IMS', e });
+    });
 
   decorateTopNav = () => {
     this.elements.mobileToggle = this.decorateToggle();

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -48,6 +48,7 @@ const CONFIG = {
     'app-launcher',
     'adobe-logo',
   ],
+  imsReady: 'onImsLibInstance',
 };
 
 // signIn, decorateSignIn and decorateProfileTrigger can be removed if IMS takes over the profile
@@ -193,7 +194,7 @@ class Gnav {
       this.decorateMainNav,
       this.decorateTopNav,
       this.decorateTopnavWrapper,
-      () => loadIms(this.imsReady.bind(this)),
+      this.ims,
       this.addChangeEventListeners,
     ];
     this.el.addEventListener('click', this.loadDelayed);
@@ -232,6 +233,14 @@ class Gnav {
       </div>`;
 
     this.el.append(this.elements.curtain, this.elements.topnavWrapper);
+  };
+
+  ims = () => {
+    if (window.adobeIMS) {
+      if (window.adobeIMS.initialized) return this.imsReady();
+      return window.addEventListener(CONFIG.imsReady, this.imsReady, { once: true });
+    }
+    return loadIms(this.imsReady.bind(this));
   };
 
   addChangeEventListeners = () => {

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -454,22 +454,15 @@ class Gnav {
     const profileEl = createTag('div', { class: 'gnav-profile' });
     if (blockEl.children.length > 1) profileEl.classList.add('has-menu');
 
-    const defaultOnReady = () => {
-      this.imsReady(blockEl, profileEl);
-    };
-
-    const { imsClientId, onReady } = getConfig();
+    const { imsClientId } = getConfig();
     if (!imsClientId) return null;
 
-    if (!window.adobeIMS) {
-      loadIms(onReady || defaultOnReady);
-    } else if (onReady) {
-      if (window.adobeIMS.initialized) return onReady();
-      return window.addEventListener('onImsLibInstance', onReady, { once: true });
-    } else if (defaultOnReady) {
-      if (window.adobeIMS.initialized) return defaultOnReady();
-      return window.addEventListener('onImsLibInstance', defaultOnReady, { once: true });
-    }
+    loadIms()
+      .then(() => {
+        this.imsReady(blockEl, profileEl);
+      })
+      .catch(() => {});
+
     return profileEl;
   };
 

--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -464,9 +464,11 @@ class Gnav {
     if (!window.adobeIMS) {
       loadIms(onReady || defaultOnReady);
     } else if (onReady) {
-      onReady();
+      if (window.adobeIMS.initialized) return onReady();
+      return window.addEventListener('onImsLibInstance', onReady, { once: true });
     } else if (defaultOnReady) {
-      defaultOnReady();
+      if (window.adobeIMS.initialized) return defaultOnReady();
+      return window.addEventListener('onImsLibInstance', defaultOnReady, { once: true });
     }
     return profileEl;
   };

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -629,7 +629,7 @@ export async function loadIms() {
       reject(new Error('Missing IMS Client ID'));
       return;
     }
-    const timeout = setTimeout(() => reject(new Error('IMS timeout')), 3000);
+    const timeout = setTimeout(() => reject(new Error('IMS timeout')), 5000);
     window.adobeid = {
       client_id: imsClientId,
       scope: imsScope || 'AdobeID,openid,gnav',

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -621,22 +621,31 @@ function decorateFooterPromo(config) {
   document.querySelector('main > div:last-of-type').insertAdjacentElement('afterend', section);
 }
 
-export function loadIms(onReadyFn) {
-  if (window.adobeIMS) return;
-
-  const { locale, imsClientId, imsScope, env, onReady } = getConfig();
-  if (!imsClientId) return null;
-
-  window.adobeid = {
-    client_id: imsClientId,
-    scope: imsScope || 'AdobeID,openid,gnav',
-    locale: locale?.ietf?.replace('-', '_') || 'en_US',
-    autoValidateToken: true,
-    environment: env.ims,
-    useLocalStorage: false,
-    onReady: onReadyFn || onReady,
-  };
-  loadScript('https://auth.services.adobe.com/imslib/imslib.min.js');
+let imsLoaded;
+export async function loadIms() {
+  imsLoaded = imsLoaded || new Promise((resolve, reject) => {
+    const { locale, imsClientId, imsScope, env } = getConfig();
+    if (!imsClientId) {
+      reject(new Error('Missing IMS Client ID'));
+      return;
+    }
+    const timeout = setTimeout(() => reject(new Error('IMS timeout')), 3000);
+    window.adobeid = {
+      client_id: imsClientId,
+      scope: imsScope || 'AdobeID,openid,gnav',
+      locale: locale?.ietf?.replace('-', '_') || 'en_US',
+      autoValidateToken: true,
+      environment: env.ims,
+      useLocalStorage: false,
+      onReady: () => {
+        resolve();
+        clearTimeout(timeout);
+      },
+      onError: reject,
+    };
+    loadScript('https://auth.services.adobe.com/imslib/imslib.min.js');
+  });
+  return imsLoaded;
 }
 
 async function loadMartech({ persEnabled = false, persManifests = [] } = {}) {
@@ -651,7 +660,7 @@ async function loadMartech({ persEnabled = false, persManifests = [] } = {}) {
   }
 
   window.targetGlobalSettings = { bodyHidingEnabled: false };
-  loadIms();
+  loadIms().catch(() => {});
 
   const { default: initMartech } = await import('../martech/martech.js');
   await initMartech({

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -16,6 +16,10 @@ const ogFetch = window.fetch;
 // - test localization
 
 describe('global navigation', () => {
+  before(() => {
+    document.head.innerHTML = '<script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>';
+  });
+
   describe('basic sanity tests', () => {
     it('should render the navigation on desktop', async () => {
       const nav = await createFullGlobalNavigation();
@@ -695,7 +699,6 @@ describe('global navigation', () => {
 
       it('renders the sign in button and dropdown on click', async () => {
         await createFullGlobalNavigation({ signedIn: false });
-
         const signIn = document.querySelector(selectors.signIn);
         expect(isElementVisible(signIn)).to.equal(true);
         expect(signIn.getAttribute('aria-haspopup')).to.equal('true');
@@ -921,5 +924,9 @@ describe('global navigation', () => {
 
       expect(getOverflowingTopnav()).to.equal(null);
     });
+  });
+
+  describe('ims', () => {
+
   });
 });

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -925,8 +925,4 @@ describe('global navigation', () => {
       expect(getOverflowingTopnav()).to.equal(null);
     });
   });
-
-  describe('ims', () => {
-
-  });
 });

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -125,6 +125,7 @@ export const createFullGlobalNavigation = async ({
         });
       }),
     ),
+    initialized: true,
   };
   document.body.innerHTML = `
     <header class="global-navigation has-breadcrumbs" daa-im="true" daa-lh="gnav|milo">
@@ -149,7 +150,6 @@ export const createFullGlobalNavigation = async ({
   ]);
 
   const instance = await initGnav(document.body.querySelector('header'));
-  instance.imsReady();
   await clock.runAllAsync();
   // We restore the clock here, because waitForElement uses setTimeout
   clock.restore();

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -125,7 +125,6 @@ export const createFullGlobalNavigation = async ({
         });
       }),
     ),
-    initialized: true,
   };
   document.body.innerHTML = `
     <header class="global-navigation has-breadcrumbs" daa-im="true" daa-lh="gnav|milo">

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -150,6 +150,7 @@ export const createFullGlobalNavigation = async ({
   ]);
 
   const instance = await initGnav(document.body.querySelector('header'));
+  instance.imsReady();
   await clock.runAllAsync();
   // We restore the clock here, because waitForElement uses setTimeout
   clock.restore();


### PR DESCRIPTION
### Description
Refactor the milo core utils `loadIms` function so that any consumer can use the it as follows:
```js
loadIms()
  .then(() => {}) // ims available and instance has loaded
  .catch(() => {}) // error loading IMS and the instance is not ready
```

This is **NOT** a breaking change, as no consumer uses this [function yet]( https://github.com/search?q=org%3Aadobecom%20loadims&type=code)
This provides a more reliable way of knowing when IMS has finished loading and is ready to be used, especially when called from multiple places. (E.g. martech loads IMS, global-navigation loads IMS, consumer code loads IMS)

### Test instructions
Observe the sign in button to exist afterwards in the global navigation

Resolves: [MWPW-133665](https://jira.corp.adobe.com/browse/MWPW-133665)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/gnav-1
- After: https://mwpw-133665--milo--mokimo.hlx.page/drafts/osahin/gnav-1

- Before: https://main--bacom--adobecom.hlx.live/customer-success-stories
- After: https://main--bacom--adobecom.hlx.live/customer-success-stories?milolibs=mwpw-133665--milo--mokimo
