### PR TITLE
Do not show current breadcrumb page by default

### DIFF
--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -5,7 +5,7 @@ const metadata = {
   seo: 'breadcrumbs-seo',
   seoLegacy: 'breadcrumb-seo',
   fromFile: 'breadcrumbs-from-file',
-  hideCurrent: 'breadcrumbs-hide-current-page',
+  showCurrent: 'breadcrumbs-show-current-page',
   hiddenEntries: 'breadcrumbs-hidden-entries',
   pageTitle: 'breadcrumbs-page-title',
   base: 'breadcrumbs-base',
@@ -52,7 +52,7 @@ const createBreadcrumbs = (element) => {
   if (!element) return null;
   const ul = element.querySelector('ul');
 
-  if (getMetadata(metadata.hideCurrent) !== 'on') {
+  if (getMetadata(metadata.showCurrent) === 'on') {
     ul.append(toFragment`
       <li>
         ${getMetadata(metadata.pageTitle) || document.title}

--- a/test/blocks/global-navigation/features/breadcrumbs.test.js
+++ b/test/blocks/global-navigation/features/breadcrumbs.test.js
@@ -36,29 +36,23 @@ describe('breadcrumbs', () => {
 
   it('should create a breadcrumb from markup', async () => {
     const breadcrumb = await breadcrumbs(breadcrumbMock());
-    assertBreadcrumb({ breadcrumb, length: 5 });
-  });
-
-  it('should show the last item', async () => {
-    document.head.innerHTML = '<meta name="breadcrumbs-show-current-page" content="on">';
-    const breadcrumb = await breadcrumbs(breadcrumbMock());
     assertBreadcrumb({ breadcrumb, length: 4 });
   });
 
   it('should hide multiple items', async () => {
     document.head.innerHTML = '<meta name="breadcrumbs-hidden-entries" content="Actors,Future Releases,Players">';
     const breadcrumb = await breadcrumbs(breadcrumbMock());
-    assertBreadcrumb({ breadcrumb, length: 2 });
+    assertBreadcrumb({ breadcrumb, length: 1 });
   });
 
   it('should hide multiple items with spaces and wrong capitalization', async () => {
     document.head.innerHTML = '<meta name="breadcrumbs-hidden-entries" content="ActOrs, PlaYers">';
     const breadcrumb = await breadcrumbs(breadcrumbMock());
-    assertBreadcrumb({ breadcrumb, length: 3 });
+    assertBreadcrumb({ breadcrumb, length: 2 });
   });
 
-  it("should use a custom page title if it's set", async () => {
-    document.head.innerHTML = '<meta name="breadcrumbs-page-title" content="Custom Title">';
+  it('should use a custom page title and show the current page if set', async () => {
+    document.head.innerHTML = '<meta name="breadcrumbs-page-title" content="Custom Title"><meta name="breadcrumbs-show-current-page" content="on">';
     const breadcrumb = await breadcrumbs(breadcrumbMock());
     assertBreadcrumb({ breadcrumb, length: 5 });
     expect(breadcrumb.querySelector('ul li:last-of-type').innerText.trim()).to.equal('Custom Title');
@@ -93,7 +87,6 @@ describe('breadcrumbs', () => {
             item: 'http://www.adobe.com/',
           },
           { '@type': 'ListItem', position: 4, name: 'Players' },
-          { '@type': 'ListItem', position: 5, name: '' },
         ],
       },
     );
@@ -109,7 +102,7 @@ describe('breadcrumbs', () => {
     document.head.innerHTML = '<meta name="breadcrumbs-base" content="https://mock.com/mock-isnt-called-anyway">';
     window.fetch = stub().callsFake(() => mockRes({ payload: breadcrumbMock().outerHTML }));
     const breadcrumb = await breadcrumbs();
-    expect(breadcrumb.querySelector('ul').children.length).to.equal(5);
+    expect(breadcrumb.querySelector('ul').children.length).to.equal(4);
     expect(
       breadcrumb
         .querySelector('ul li:last-of-type')
@@ -121,7 +114,7 @@ describe('breadcrumbs', () => {
     document.head.innerHTML = '<meta name="breadcrumbs-base" content="https://mock.com/mock-isnt-called-anyway">';
     window.fetch = stub().callsFake(() => mockRes({ payload: breadcrumbMock().outerHTML }));
     const breadcrumb = await breadcrumbs(breadcrumbMock());
-    expect(breadcrumb.querySelector('ul').children.length).to.equal(9);
+    expect(breadcrumb.querySelector('ul').children.length).to.equal(8);
     expect(
       breadcrumb
         .querySelector('ul li:last-of-type')

--- a/test/blocks/global-navigation/features/breadcrumbs.test.js
+++ b/test/blocks/global-navigation/features/breadcrumbs.test.js
@@ -39,8 +39,8 @@ describe('breadcrumbs', () => {
     assertBreadcrumb({ breadcrumb, length: 5 });
   });
 
-  it('should hide the last item', async () => {
-    document.head.innerHTML = '<meta name="breadcrumbs-hide-current-page" content="on">';
+  it('should show the last item', async () => {
+    document.head.innerHTML = '<meta name="breadcrumbs-show-current-page" content="on">';
     const breadcrumb = await breadcrumbs(breadcrumbMock());
     assertBreadcrumb({ breadcrumb, length: 4 });
   });

--- a/test/blocks/global-navigation/features/breadcrumbsFromFile.test.html
+++ b/test/blocks/global-navigation/features/breadcrumbsFromFile.test.html
@@ -12,7 +12,7 @@
         it('should create a breadcrumb from the url', async () => {
           document.head.innerHTML = '<meta name="breadcrumbs-from-url" content="on">';
           const breadcrumb = await breadcrumbs();
-          expect(breadcrumb.querySelectorAll('li').length).to.equal(6);
+          expect(breadcrumb.querySelectorAll('li').length).to.equal(5);
         });
 
         it('should not create a breadcrumb from the url if the config isnt on', async () => {


### PR DESCRIPTION
### Description
Change a breadcrumb metadata config to hide the current page by default

`breadcrumbs-hide-current-page: on/off (default: off)` to `breadcrumbs-show-current-page: on/off (default: off)` 

Resolves: [MWPW-117620](https://jira.corp.adobe.com/browse/MWPW-117620)

### Test instructions
In the breadcrumbs just under the global navigation you should not see the page title as extra breadcrumb entry.
`What Is Claymation? How Clay Animation Works | Adobe` should be hidden by default.

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/creativecloud/animation/discover/claymation
- After: https://main--cc--adobecom.hlx.live/creativecloud/animation/discover/claymation?milolibs=breadcrumbs-default-values--milo--mokimo
