### PR TITLE
[MWPW-133763] Long breadcrumbs UI

### DIFF
--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -90,7 +90,7 @@ const fromUrl = () => {
   for (let i = 0; i < paths.length; i += 1) {
     list.append(toFragment`
       <li>
-        <a href="/${paths.slice(0, i + 1).join('/')}">${paths[i]}</a>
+        <a href="/${paths.slice(0, i + 1).join('/')}">${paths[i].replaceAll('-', ' ')}</a>
       </li>
     `);
   }

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -303,8 +303,9 @@ header.global-navigation {
 }
 
 .feds-breadcrumbs {
-  padding: 0 12px;
+  padding: 6px 12px;
   font-size: 12px;
+  overflow-y: auto;
 }
 
 .feds-breadcrumbs ul {
@@ -316,6 +317,22 @@ header.global-navigation {
 .feds-breadcrumbs li {
   display: flex;
   align-items: center;
+  flex-shrink: 0;
+}
+
+/* Hide all breadcrumbs except the first and last two */
+.feds-breadcrumbs li:nth-last-child(n+3):not(:first-child) {
+  display: none;
+}
+
+/* If first breadcrumb is not third to last, add ellipsis after it */
+.feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after {
+  content: '/\2003...';
+  padding: 0 0 0 12px;
+}
+
+[dir = "rtl"] .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after {
+  padding: 0 12px 0 0;
 }
 
 .feds-breadcrumbs a,
@@ -566,6 +583,14 @@ header.global-navigation {
     width: 100%;
     max-width: var(--feds-maxWidth-nav);
     box-sizing: border-box;
+  }
+
+  .feds-breadcrumbs li:nth-last-child(n+3):not(:first-child) {
+    display: flex;
+  }
+
+  .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after {
+    content: none;
   }
 
   .feds-breadcrumbs a:hover {

--- a/test/blocks/global-navigation/features/breadcrumbs-from-file.test.html
+++ b/test/blocks/global-navigation/features/breadcrumbs-from-file.test.html
@@ -13,9 +13,12 @@
           document.head.innerHTML = '<meta name="breadcrumbs-from-url" content="on">';
           const breadcrumb = await breadcrumbs();
           expect(breadcrumb.querySelectorAll('li').length).to.equal(5);
+          // The 'global-navigation' parent folder has a hyphen, it should be removed
+          const gnavBreadcrumb = breadcrumb.querySelector('a[href $= "/global-navigation"]');
+          expect(gnavBreadcrumb.textContent).to.equal('global navigation');
         });
 
-        it('should not create a breadcrumb from the url if the config isnt on', async () => {
+        it('should not create a breadcrumb from the url if the config isn\'t on', async () => {
           document.head.innerHTML = ''
           const breadcrumb = await breadcrumbs();
           expect(breadcrumb).to.equal(null);


### PR DESCRIPTION
This solves two issues for breadcrumbs:

### Mobile UI when too many breadcrumb elements are added
Each breadcrumb element would flow on multiple rows depending on available space. The logic has now been adapted to: 
- keep elements on just one row;
- allow scrolling if available space is exceeded;
- replace all but the first and last two breadcrumb elements with an ellipsis, if more than 3 breadcrumb elements are available. Similar behaviour is currently implemented on the AEM-based Global Navigation.

| Before | After |
| ------------- | ------------- |
| <img width="418" alt="Before breadcrumb UI updates" src="https://github.com/adobecom/milo/assets/11267498/850923fa-63c9-4c00-8061-e1eb3e817d42"> | <img width="418" alt="After breadcrumb UI updates" src="https://github.com/adobecom/milo/assets/11267498/479b4af7-e2a2-4595-af33-102ba9f2411f"> |

### Remove hyphenation when breadcrumbs are inferred from the URL
If the URL is used to build the breadcrumbs, path pieces such as 'customer-success-stories' are added as-is. We're now simply replacing hyphens with spaces.

| Before | After |
| ------------- | ------------- |
| <img width="596" alt="URL breadcrumbs before" src="https://github.com/adobecom/milo/assets/11267498/d5b494e0-0dd1-4bcf-bec8-d14e0d112689"> | <img width="596" alt="URL breadcrumbs after" src="https://github.com/adobecom/milo/assets/11267498/751fec2f-57d7-40f7-a7e7-71c344de71da"> |

---

**NOTE**: The `6px` top and bottom padding added to `.feds-breadcrumbs` should not cause CLS, since desktop remains unchanged, as seen [here](https://github.com/adobecom/milo/blob/main/libs/blocks/global-navigation/global-navigation.css#L565) and on mobile the breadcrumbs are nested inside the hamburger menu.

---

Resolves: [MWPW-133763](https://jira.corp.adobe.com/browse/MWPW-133763)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/Breadcrumbs/breadcrumbs-set-from-url?martech=off
- After: https://long-breadcrumbs-ui--milo--overmyheadandbody.hlx.page/drafts/ramuntea/Breadcrumbs/breadcrumbs-set-from-url?martech=off
