### PR TITLE
MWPW-133759 - Adding logic to account for single products grouped together

### DIFF
--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -270,27 +270,9 @@ const findMatchForSelections = (results, selections) => {
   if (userSelectionLen < 1) {
     return defaultResult;
   }
-
-  let singleProductResults;
-
-  // Case 2 - when exactly one product is matched and it is not grouped with '&' in between.
-  if (userSelectionLen === 1) {
-    // eslint-disable-next-line max-len
-    singleProductResults = results.find((destination) => {
-      if (destination.result.indexOf('&') === -1 && destination.result.includes(selections.primary[0])) {
-        return destination;
-      }
-    });
-  }
-
-  if (singleProductResults) {
-    recommendations.push(singleProductResults);
-    return recommendations;
-  }
-
-  // Case 3 - when two or more products are matched and they are grouped with '&' in between.
+  // Case 2 - when you have clauses grouped with parenthesis.
   const compoundResults = results.find((destination) => {
-    if (destination.result.indexOf('&') !== -1 && destination.result.split('&').length === userSelectionLen) {
+    if (destination.result.indexOf('(') !== -1 && destination.result.split('&').length === userSelectionLen) {
       return destination;
     }
   });

--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -7,7 +7,6 @@ const STRINGS_EP_NAME = 'strings.json';
 const RESULTS_EP_NAME = 'results.json';
 
 let configPath; let quizKey; let analyticsType; let analyticsQuiz; let metaData;
-const { locale } = getConfig();
 
 const initConfigPath = (roolElm) => {
   const link = roolElm.querySelector('.quiz > div > div > a');
@@ -16,6 +15,7 @@ const initConfigPath = (roolElm) => {
 };
 
 const initQuizKey = () => {
+  const { locale } = getConfig();
   quizKey = metaData.storagepath?.text;
   return locale.ietf ? `${quizKey}-${locale.ietf}` : quizKey;
 };
@@ -266,10 +266,29 @@ const findMatchForSelections = (results, selections) => {
 
   const userSelectionLen = selections.primary.length; // 1 - lr
 
-  if (userSelectionLen <= 1) {
+  // Case 1 - when no user selection is matched default result is returned.
+  if (userSelectionLen < 1) {
     return defaultResult;
   }
 
+  let singleProductResults;
+
+  // Case 2 - when exactly one product is matched and it is not grouped with '&' in between.
+  if (userSelectionLen === 1) {
+    // eslint-disable-next-line max-len
+    singleProductResults = results.find((destination) => {
+      if (destination.result.indexOf('&') === -1 && destination.result.includes(selections.primary[0])) {
+        return destination;
+      }
+    });
+  }
+
+  if (singleProductResults) {
+    recommendations.push(singleProductResults);
+    return recommendations;
+  }
+
+  // Case 3 - when two or more products are matched and they are grouped with '&' in between.
   const compoundResults = results.find((destination) => {
     if (destination.result.indexOf('&') !== -1 && destination.result.split('&').length === userSelectionLen) {
       return destination;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Adding logic to account for 3 types of rules - 
1. **compound** (which has more than one product that is grouped with `&`). Ex - `(ai,ai-edu,ai-bus,ai-ind)&(ai,ai-edu,ai-bus,ai-ind)`
2. **simple** (which has one exact product **or** multiple comma-separated single products). Ex. 
`(ai,ai-edu,ai-bus,ai-ind,au-edu)`
3. **default** (when no products match based on the user's selection)

URL to test the specific scenario based on the uber data set - https://uar-grouped-single-product--milo--sabyamon.hlx.page/drafts/delta/app-recommender-test/?martech=off&hideGeorouting=on

Resolves (Hopefully): https://jira.corp.adobe.com/browse/MWPW-133759

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.page/drafts/sabya/quiz-3/?martech=off&hideGeorouting=on
- After: https://uar-grouped-single-product--milo--sabyamon.hlx.page/drafts/sabya/quiz-3/?martech=off&hideGeorouting=on
