### PR TITLE
Use locale from getConfig (caas)

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -248,12 +248,9 @@ const getFilterArray = async (state) => {
   return filters;
 };
 
-export function getCountryAndLang(
-  { autoCountryLang, country, language },
-  miloConfig = pageConfig,
-) {
+export function getCountryAndLang({ autoCountryLang, country, language }) {
   if (autoCountryLang) {
-    const htmlLang = miloConfig?.locale?.ietf?.toLowerCase() || 'en-us';
+    const htmlLang = pageConfigHelper()?.locale?.ietf?.toLowerCase() || 'en-us';
     const [lang, cntry] = htmlLang.split('-');
     return {
       country: cntry,

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -250,9 +250,11 @@ const getFilterArray = async (state) => {
 
 const getCountryAndLang = ({ autoCountryLang, country, language }) => {
   if (autoCountryLang) {
+    const htmlLang = pageConfig.locale?.ietf;
+    const [lang, cntry] = htmlLang.split('-');
     return {
-      country: pageConfig?.locale?.reg,
-      language: pageConfig?.locale?.lang,
+      country: cntry,
+      language: lang,
     };
   }
   return {

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -250,11 +250,9 @@ const getFilterArray = async (state) => {
 
 const getCountryAndLang = ({ autoCountryLang, country, language }) => {
   if (autoCountryLang) {
-    const htmlLang = document.documentElement.getAttribute('lang')?.toLowerCase() || 'en-us';
-    const [lang, cntry] = htmlLang.split('-');
     return {
-      country: cntry,
-      language: lang,
+      country: pageConfig?.locale?.reg,
+      language: pageConfig?.locale?.lang,
     };
   }
   return {

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -253,7 +253,7 @@ export function getCountryAndLang(
   miloConfig = pageConfig,
 ) {
   if (autoCountryLang) {
-    const htmlLang = miloConfig.locale?.ietf;
+    const htmlLang = miloConfig?.locale?.ietf?.toLowerCase() || 'en-us';
     const [lang, cntry] = htmlLang.split('-');
     return {
       country: cntry,

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -248,9 +248,12 @@ const getFilterArray = async (state) => {
   return filters;
 };
 
-const getCountryAndLang = ({ autoCountryLang, country, language }) => {
+export function getCountryAndLang(
+  { autoCountryLang, country, language },
+  miloConfig = pageConfig,
+) {
   if (autoCountryLang) {
-    const htmlLang = pageConfig.locale?.ietf;
+    const htmlLang = miloConfig.locale?.ietf;
     const [lang, cntry] = htmlLang.split('-');
     return {
       country: cntry,
@@ -261,7 +264,7 @@ const getCountryAndLang = ({ autoCountryLang, country, language }) => {
     country: country ? country.split('/').pop() : 'us',
     language: language ? language.split('/').pop() : 'en',
   };
-};
+}
 
 export function arrayToObj(input = []) {
   const obj = {};

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -334,6 +334,7 @@ describe('getConfig', () => {
       language: 'caas:laguange/es',
     };
     const locale = { locale: { ietf: 'en-GB' } };
+
     it('should use country and lang from CaaS Config', () => {
       const expected = getCountryAndLang({
         ...caasCfg,
@@ -344,13 +345,35 @@ describe('getConfig', () => {
         language: 'es',
       });
     });
+
+    it('should use default country and lang from CaaS Config', () => {
+      const expected = getCountryAndLang({
+        autoCountryLang: false,
+      }, locale);
+      expect(expected).to.deep.eq({
+        country: 'us',
+        language: 'en',
+      });
+    });
+
     it('should use country and lang from locale in Milo Config', () => {
       const expected = getCountryAndLang({
         ...caasCfg,
         autoCountryLang: true,
       }, locale);
       expect(expected).to.deep.eq({
-        country: 'GB',
+        country: 'gb',
+        language: 'en',
+      });
+    });
+
+    it('should use default country and lang from locale in Milo Config', () => {
+      const expected = getCountryAndLang({
+        ...caasCfg,
+        autoCountryLang: true,
+      }, null);
+      expect(expected).to.deep.eq({
+        country: 'us',
         language: 'en',
       });
     });

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
-import { defaultState, getConfig, loadStrings, arrayToObj, getPageLocale } from '../../../libs/blocks/caas/utils.js';
+import { defaultState, getConfig, loadStrings, arrayToObj, getPageLocale, getCountryAndLang } from '../../../libs/blocks/caas/utils.js';
 
 const mockLocales = ['ar', 'br', 'ca', 'ca_fr', 'cl', 'co', 'la', 'mx', 'pe', '', 'africa', 'be_fr', 'be_en', 'be_nl',
   'cy_en', 'dk', 'de', 'ee', 'es', 'fr', 'gr_en', 'ie', 'il_en', 'it', 'lv', 'lt', 'lu_de', 'lu_en', 'lu_fr', 'hu',
@@ -325,6 +325,34 @@ describe('getConfig', () => {
         enabled: true,
         lastViewedSession: "",
       },
+    });
+  });
+
+  describe('getCountryAndLang', () => {
+    const caasCfg = {
+      country: 'caas:country/ec',
+      language: 'caas:laguange/es',
+    };
+    const locale = { locale: { ietf: 'en-GB' } };
+    it('should use country and lang from CaaS Config', () => {
+      const expected = getCountryAndLang({
+        ...caasCfg,
+        autoCountryLang: false,
+      }, locale);
+      expect(expected).to.deep.eq({
+        country: 'ec',
+        language: 'es',
+      });
+    });
+    it('should use country and lang from locale in Milo Config', () => {
+      const expected = getCountryAndLang({
+        ...caasCfg,
+        autoCountryLang: true,
+      }, locale);
+      expect(expected).to.deep.eq({
+        country: 'GB',
+        language: 'en',
+      });
     });
   });
 });

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -1,6 +1,14 @@
 import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
-import { defaultState, getConfig, loadStrings, arrayToObj, getPageLocale, getCountryAndLang } from '../../../libs/blocks/caas/utils.js';
+import { setConfig } from '../../../libs/utils/utils.js';
+import {
+  defaultState,
+  getConfig,
+  loadStrings,
+  arrayToObj,
+  getPageLocale,
+  getCountryAndLang,
+} from '../../../libs/blocks/caas/utils.js';
 
 const mockLocales = ['ar', 'br', 'ca', 'ca_fr', 'cl', 'co', 'la', 'mx', 'pe', '', 'africa', 'be_fr', 'be_en', 'be_nl',
   'cy_en', 'dk', 'de', 'ee', 'es', 'fr', 'gr_en', 'ie', 'il_en', 'it', 'lv', 'lt', 'lu_de', 'lu_en', 'lu_fr', 'hu',
@@ -333,13 +341,20 @@ describe('getConfig', () => {
       country: 'caas:country/ec',
       language: 'caas:laguange/es',
     };
-    const locale = { locale: { ietf: 'en-GB' } };
+    const cfg = {
+      pathname: '/be_fr/blah.html',
+      locales: {
+        '': { ietf: 'en-US' },
+        be_fr: { ietf: 'fr-BE' },
+      },
+    };
 
     it('should use country and lang from CaaS Config', () => {
+      setConfig(cfg);
       const expected = getCountryAndLang({
         ...caasCfg,
         autoCountryLang: false,
-      }, locale);
+      });
       expect(expected).to.deep.eq({
         country: 'ec',
         language: 'es',
@@ -347,9 +362,8 @@ describe('getConfig', () => {
     });
 
     it('should use default country and lang from CaaS Config', () => {
-      const expected = getCountryAndLang({
-        autoCountryLang: false,
-      }, locale);
+      setConfig(cfg);
+      const expected = getCountryAndLang({ autoCountryLang: false });
       expect(expected).to.deep.eq({
         country: 'us',
         language: 'en',
@@ -357,21 +371,26 @@ describe('getConfig', () => {
     });
 
     it('should use country and lang from locale in Milo Config', () => {
+      setConfig(cfg);
       const expected = getCountryAndLang({
         ...caasCfg,
         autoCountryLang: true,
-      }, locale);
+      });
       expect(expected).to.deep.eq({
-        country: 'gb',
-        language: 'en',
+        country: 'be',
+        language: 'fr',
       });
     });
 
     it('should use default country and lang from locale in Milo Config', () => {
+      setConfig({
+        ...cfg,
+        pathname: '/whatever/blah.html',
+      });
       const expected = getCountryAndLang({
         ...caasCfg,
         autoCountryLang: true,
-      }, null);
+      });
       expect(expected).to.deep.eq({
         country: 'us',
         language: 'en',


### PR DESCRIPTION
Use locale (ietf) from getConfig instead of from <html lang>.

Same type of change as #916. Needed to prevent adverse effects from https://github.com/adobecom/milo/pull/915. Discovered in https://github.com/adobecom/bacom/pull/130.

We want to maintain existing behavior for CaaS so I've left edge-cased lang/cntry split alone. I also tested using new locale values (lang/reg) but Chimera endpoint returns no cards when `country` parameter is `undefined` or unsupported, eg. new `la` value (419). This will have to be migrated later.

**Test URLs:**

- Before: https://main--milo--hparra.hlx.page/
- Before: https://main--bacom--adobecom.hlx.page/customer-success-stories?martech=off
- Before: https://main--bacom--adobecom.hlx.page/la/customer-success-stories?martech=off
- After: https://fix-caas-lang-reg--milo--hparra.hlx.page/
- After: https://main--bacom--adobecom.hlx.page/customer-success-stories?martech=off&milolibs=fix-caas-lang-reg--milo--hparra
- After: https://main--bacom--adobecom.hlx.page/la/customer-success-stories?martech=off&milolibs=fix-caas-lang-reg--milo--hparra
