### PR TITLE
MWPW-133738: Use a different comparison to process question values

### DIFF
--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -184,7 +184,7 @@ const parseResultData = async (answers) => {
         const key = resultRow[i][0];
         const val = resultRow[i][1];
 
-        if (key.startsWith('q-') && val) {
+        if (!key.startsWith('result-') && val) {
           const answer = answers.find((a) => a[0] === key);
           if (answer && answer[1].includes(val)) {
             hasMatch = true;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

When processing an object containing question, result-primary and result-secondary values, a comparison was separating the two types of values by assuming questions started with a "q-" prefix. Unfortunately, we can't make that assumption. However, we can enforce the "result-" prefix for the other values, so I just turned the comparison on its head. 

<img width="553" alt="Screenshot 2023-07-17 at 3 35 21 PM" src="https://github.com/adobecom/milo/assets/25230829/f72477e3-6b0c-4a63-994e-4915be2d404b">

Resolves: [MWPW-133738](https://jira.corp.adobe.com/browse/MWPW-133738)

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.page/drafts/sabya/quiz-3/?martech=off&hideGeorouting=on
- After: https://mwpw-133738--milo--echampio-at-adobe.hlx.page/drafts/sabya/quiz-3/?martech=off&hideGeorouting=on

