### PR TITLE
MWPW-132883: Add RTL attribute for RTL region's langstore file

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -141,7 +141,10 @@ export function getLocale(locales, pathname = window.location.pathname) {
   const locale = locales[localeString] || locales[''];
   if (localeString === LANGSTORE) {
     locale.prefix = `/${localeString}/${split[2]}`;
-    if (Object.values(locales).find((loc) => loc.ietf?.startsWith(split[2]))?.dir === 'rtl') locale.dir = 'rtl';
+    if (
+      Object.values(locales)
+        .find((loc) => loc.ietf?.startsWith(split[2]))?.dir === 'rtl'
+    ) locale.dir = 'rtl';
     return locale;
   }
   locale.prefix = locale.ietf === 'en-US' ? '' : `/${localeString}`;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -141,7 +141,7 @@ export function getLocale(locales, pathname = window.location.pathname) {
   const locale = locales[localeString] || locales[''];
   if (localeString === LANGSTORE) {
     locale.prefix = `/${localeString}/${split[2]}`;
-    if (Object.values(locales).find((loc) => loc.lang === split[2])?.dir === 'rtl') locale.dir = 'rtl';
+    if (Object.values(locales).find((loc) => loc.ietf?.startsWith(split[2]))?.dir === 'rtl') locale.dir = 'rtl';
     return locale;
   }
   locale.prefix = locale.ietf === 'en-US' ? '' : `/${localeString}`;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -141,6 +141,7 @@ export function getLocale(locales, pathname = window.location.pathname) {
   const locale = locales[localeString] || locales[''];
   if (localeString === LANGSTORE) {
     locale.prefix = `/${localeString}/${split[2]}`;
+    if (Object.values(locales).find((loc) => loc.lang === split[2])?.dir === 'rtl') locale.dir = 'rtl';
     return locale;
   }
   locale.prefix = locale.ietf === 'en-US' ? '' : `/${localeString}`;

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -243,10 +243,11 @@ describe('Utils', () => {
     describe('rtlSupport', () => {
       before(async () => {
         config.locales = {
-          '': { ietf: 'en-US', tk: 'hah7vzn.css' },
-          africa: { ietf: 'en', tk: 'pps7abe.css' },
-          il_he: { ietf: 'he', tk: 'nwq1mna.css', dir: 'rtl' },
-          mena_ar: { ietf: 'ar', tk: 'dis2dpj.css', dir: 'rtl' },
+          '': { ietf: 'en-US', lang: 'en', reg: 'US', tk: 'hah7vzn.css' },
+          africa: { ietf: 'en', lang: 'en', reg: '002', tk: 'pps7abe.css' },
+          il_he: { ietf: 'he', lang: 'he', reg: 'IL', tk: 'nwq1mna.css', dir: 'rtl' },
+          langstore: { ietf: 'en-US', lang: 'en', reg: 'US', tk: 'hah7vzn.css' },
+          mena_ar: { ietf: 'ar', lang: 'ar', reg: '', tk: 'dis2dpj.css', dir: 'rtl' },
           ua: { tk: 'aaz7dvd.css' },
         };
       });
@@ -262,10 +263,22 @@ describe('Utils', () => {
         expect(document.documentElement.getAttribute('dir')).to.equal('ltr');
       });
 
+      it('LTR Languages have dir as ltr for langstore path', () => {
+        setConfigWithPath('/langstore/en/solutions');
+        expect(document.documentElement.getAttribute('dir')).to.equal('ltr');
+      });
+
       it('RTL Languages have dir as rtl', () => {
         setConfigWithPath('/il_he/solutions');
         expect(document.documentElement.getAttribute('dir')).to.equal('rtl');
         setConfigWithPath('/mena_ar/solutions');
+        expect(document.documentElement.getAttribute('dir')).to.equal('rtl');
+      });
+
+      it('RTL Languages have dir as rtl for langstore path', () => {
+        setConfigWithPath('/langstore/he/solutions');
+        expect(document.documentElement.getAttribute('dir')).to.equal('rtl');
+        setConfigWithPath('/langstore/ar/solutions');
         expect(document.documentElement.getAttribute('dir')).to.equal('rtl');
       });
 

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -243,11 +243,11 @@ describe('Utils', () => {
     describe('rtlSupport', () => {
       before(async () => {
         config.locales = {
-          '': { ietf: 'en-US', lang: 'en', reg: 'US', tk: 'hah7vzn.css' },
-          africa: { ietf: 'en', lang: 'en', reg: '002', tk: 'pps7abe.css' },
-          il_he: { ietf: 'he', lang: 'he', reg: 'IL', tk: 'nwq1mna.css', dir: 'rtl' },
-          langstore: { ietf: 'en-US', lang: 'en', reg: 'US', tk: 'hah7vzn.css' },
-          mena_ar: { ietf: 'ar', lang: 'ar', reg: '', tk: 'dis2dpj.css', dir: 'rtl' },
+          '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+          africa: { ietf: 'en', tk: 'pps7abe.css' },
+          il_he: { ietf: 'he', tk: 'nwq1mna.css', dir: 'rtl' },
+          langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
+          mena_ar: { ietf: 'ar', tk: 'dis2dpj.css', dir: 'rtl' },
           ua: { tk: 'aaz7dvd.css' },
         };
       });


### PR DESCRIPTION
Currently RTL attribute is added for RTL regional file, but not for its langstore file.
This adds the RTL attribute for langstore file for RTL regions. One of the region from [locale config](https://github.com/adobecom/milo/blob/main/libs/scripts/scripts.js#L22) with same `lang` is checked for language's dir property.

Resolves: [MWPW-132883](https://jira.corp.adobe.com/browse/MWPW-132883)

**Test URLs:**
RTL langstore:
- Before: https://main--milo--adobecom.hlx.page/langstore/ar/drafts/nishantkaush/direction-issues/rtl-issue?martech=off
- After: https://mwpw-132883--milo--nishantka.hlx.page/langstore/ar/drafts/nishantkaush/direction-issues/rtl-issue?martech=off

LTR langstore: (unchanged)
- Before: https://main--milo--adobecom.hlx.page/langstore/en/drafts/nishantkaush/direction-issues/rtl-issue?martech=off
- After: https://mwpw-132883--milo--nishantka.hlx.page/langstore/en/drafts/nishantkaush/direction-issues/rtl-issue?martech=off