### PR TITLE
Add title-append feature

### DIFF
--- a/libs/features/title-append/README.md
+++ b/libs/features/title-append/README.md
@@ -1,0 +1,11 @@
+# title-append
+
+The title-append feature allows you to append an arbitrary string to an HTML document's title by populating a "title-append" column for any given row in [Franklin's bulk-metadata](https://www.hlx.live/docs/bulk-metadata).
+
+## Example
+
+Create or choose a doc to test with, e.g. [milo/drafts/hgpa/test/title-append.docx](https://adobe.sharepoint.com/:w:/r/sites/adobecom/Shared%20Documents/milo/drafts/hgpa/test/title-append/title-append.docx?d=w8f45e22250a841f8bfe9a49f2b6bbd9f&csf=1&web=1&e=hboge3). Note it's current title.
+
+Next add a row to metadata spreadsheet targeting file or folder above. Create the `title-append` column if it does not exist. Populate the cell with the string you want to append, e.g. [milo/metadata.xlsx](https://adobe.sharepoint.com/:x:/r/sites/adobecom/Shared%20Documents/milo/metadata.xlsx?d=w0b3287f28ee948b3b1b25418bc8f9fc0&csf=1&web=1&e=uvd1IJ). Remember to preview / publish the metadata sheet to see changes reflected on your page.
+
+Confirm test doc has defined string prepended, e.g. https://milo.adobe.com/drafts/hgpa/test/title-append/title-append.

--- a/libs/features/title-append/title-append.js
+++ b/libs/features/title-append/title-append.js
@@ -1,0 +1,8 @@
+export default function titleAppend(appendage) {
+  if (!appendage) return;
+  document.title = `${document.title} ${appendage}`;
+  const ogTitleEl = document.querySelector('meta[property="og:title"]');
+  if (ogTitleEl) ogTitleEl.setAttribute('content', document.title);
+  const twitterTitleEl = document.querySelector('meta[name="twitter:title"]');
+  if (twitterTitleEl) twitterTitleEl.setAttribute('content', document.title);
+}

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -844,8 +844,7 @@ export async function loadArea(area = document) {
     }
     const appendage = getMetadata('title-append');
     if (appendage) {
-      const { default: titleAppend } = await import('../features/title-append/title-append.js');
-      titleAppend(appendage);
+      import('../features/title-append/title-append.js').then((module) => module.default(appendage));
     }
     const richResults = getMetadata('richresults');
     if (richResults) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -842,6 +842,11 @@ export async function loadArea(area = document) {
       const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
       loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);
     }
+    const appendage = getMetadata('title-append');
+    if (appendage) {
+      const { default: titleAppend } = await import('../features/title-append/title-append.js');
+      titleAppend(appendage);
+    }
     const richResults = getMetadata('richresults');
     if (richResults) {
       const { default: addRichResults } = await import('../features/richresults.js');

--- a/test/features/title-append/mocks/head-social.html
+++ b/test/features/title-append/mocks/head-social.html
@@ -1,0 +1,3 @@
+<title>Document Title</title>
+<meta property="og:title" content="Document Title">
+<meta name="twitter:title" content="Document Title">

--- a/test/features/title-append/mocks/head.html
+++ b/test/features/title-append/mocks/head.html
@@ -1,0 +1,1 @@
+<title>Document Title</title>

--- a/test/features/title-append/title-append.test.js
+++ b/test/features/title-append/title-append.test.js
@@ -1,0 +1,39 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import titleAppend from '../../../libs/features/title-append/title-append.js';
+
+describe('Title Append', () => {
+  describe('titleAppend', () => {
+    beforeEach(async () => {
+      document.head.innerHTML = await readFile({ path: './mocks/head.html' });
+    });
+
+    it('should not append when appendage is falsey', () => {
+      titleAppend('');
+      expect(document.title).to.equal('Document Title');
+    });
+
+    it('should append string to doc title', () => {
+      titleAppend('NOODLE');
+      expect(document.title).to.equal('Document Title NOODLE');
+    });
+  });
+  describe('titleAppend with social metdata', () => {
+    beforeEach(async () => {
+      document.head.innerHTML = await readFile({ path: './mocks/head-social.html' });
+    });
+
+    it('should append to og:title', () => {
+      titleAppend('NOODLE');
+      const actualTitle = document.querySelector('meta[property="og:title"]').getAttribute('content');
+      expect(actualTitle).to.equal('Document Title NOODLE');
+    });
+
+    it('should append string to twitter:title', () => {
+      titleAppend('NOODLE');
+      const actualTitle = document.querySelector('meta[name="twitter:title"]').getAttribute('content');
+      expect(actualTitle).to.equal('Document Title NOODLE');
+    });
+  });
+});

--- a/test/utils/mocks/head-title-append.html
+++ b/test/utils/mocks/head-title-append.html
@@ -1,0 +1,3 @@
+<meta name="title-append" content="NOODLE">
+<title>Document Title</title>
+<link rel="icon" href="data:,">

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -373,4 +373,14 @@ describe('Utils', () => {
       expect(io instanceof IntersectionObserver).to.be.true;
     });
   });
+
+  describe('title-append', async () => {
+    beforeEach(async () => {
+      document.head.innerHTML = await readFile({ path: './mocks/head-title-append.html' });
+    });
+    it('should append to title using string from metadata', async () => {
+      await utils.loadArea();
+      expect(document.title).to.equal('Document Title NOODLE');
+    });
+  });
 });

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -1,7 +1,7 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { waitForElement } from '../helpers/waitfor.js';
+import { delay, waitForElement } from '../helpers/waitfor.js';
 import { mockFetch } from '../helpers/generalHelpers.js';
 
 const utils = {};
@@ -380,6 +380,7 @@ describe('Utils', () => {
     });
     it('should append to title using string from metadata', async () => {
       await utils.loadArea();
+      await delay(100);
       expect(document.title).to.equal('Document Title NOODLE');
     });
   });


### PR DESCRIPTION
The title-append feature allows you to append an arbitrary string to an HTML document's title by populating a "title-append" column for any given row in [Franklin's bulk-metadata](https://www.hlx.live/docs/bulk-metadata). See README for more details.

Resolves: [MWPW-132671](https://jira.corp.adobe.com/browse/MWPW-132671)

**Test URLs:**
- Before: https://main--milo--hparra.hlx.page/drafts/hgpa/test/title-append/title-append?martech=off
- After: https://title-append--milo--hparra.hlx.page/drafts/hgpa/test/title-append/title-append?martech=off

Tip: You can see change happen in realtime -- open the "After" test URL in it own tab so you can see page title and refresh.