### PR TITLE
MWPW-133942 Consumer can change martech urls

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -86,7 +86,6 @@ const getTargetPersonalization = async () => {
   return manifests;
 };
 
-
 const getDtmLib = (env) => ({
   edgeConfigId: env.consumer?.edgeConfigId || env.edgeConfigId,
   url:

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -90,9 +90,9 @@ const getDtmLib = (env) => ({
   edgeConfigId: env.consumer?.edgeConfigId || env.edgeConfigId,
   url:
     env.name === 'prod'
-      ? env.consumer?.MarTechUrl || 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-5dd5dd2177e6.min.js'
+      ? env.consumer?.marTechUrl || 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-5dd5dd2177e6.min.js'
       // TODO: This is a custom launch script for milo-target - update before merging to main
-      : env.consumer?.MarTechUrl || 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-a27b33fc2dc0-development.min.js',
+      : env.consumer?.marTechUrl || 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-a27b33fc2dc0-development.min.js',
 });
 
 export default async function init({ persEnabled = false, persManifests, utils: ogUtils }) {

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -86,13 +86,14 @@ const getTargetPersonalization = async () => {
   return manifests;
 };
 
+
 const getDtmLib = (env) => ({
   edgeConfigId: env.consumer?.edgeConfigId || env.edgeConfigId,
   url:
     env.name === 'prod'
-      ? 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-5dd5dd2177e6.min.js'
+      ? env.consumer?.MarTechUrl || 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-5dd5dd2177e6.min.js'
       // TODO: This is a custom launch script for milo-target - update before merging to main
-      : 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-a27b33fc2dc0-development.min.js',
+      : env.consumer?.MarTechUrl || 'https://assets.adobedtm.com/d4d114c60e50/a0e989131fd5/launch-a27b33fc2dc0-development.min.js',
 });
 
 export default async function init({ persEnabled = false, persManifests, utils: ogUtils }) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

DC Needs to load an alternative martech lib
Usage, in `/scipts.js`
```
  local: { edgeConfigId: 'da46a629-be9b-40e5-8843-4b1ac848745c', marTechUrl: 'DC Needs This '},
```

Resolves: [MWPW-133942](https://jira.corp.adobe.com/browse/MWPW-133942)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-133942--milo--adobecom.hlx.page/?martech=off
