### PR TITLE
Use "content-language" metadata for html lang attribute

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -166,7 +166,8 @@ export const [setConfig, updateConfig, getConfig] = (() => {
       config.base = config.miloLibs || config.codeRoot;
       config.locale = pathname ? getLocale(conf.locales, pathname) : getLocale(conf.locales);
       config.autoBlocks = conf.autoBlocks ? [...AUTO_BLOCKS, ...conf.autoBlocks] : AUTO_BLOCKS;
-      document.documentElement.setAttribute('lang', config.locale.lang || config.locale.ietf);
+      const lang = getMetadata('content-language') || config.locale.lang || config.locale.ietf;
+      document.documentElement.setAttribute('lang', lang);
       try {
         const dir = getMetadata('content-direction')
           || config.locale.dir


### PR DESCRIPTION
Use "content-language" metadata value as highest priority option for html lang attribute. This allows `<html lang>` to be driven from metadata.xlsx and avoid coupling with `locales`. Named "content-language" because it is similar to adjacent "content-direction" feature. 

Resolves: [MWPW-133115](https://jira.corp.adobe.com/browse/MWPW-133115)

**Test URLs:**
- Before: https://main--milo--hparra.hlx.live/drafts/hgpa/test/content-language/content-language?martech=off
- After: https://lang-metadata--milo--hparra.hlx.live/drafts/hgpa/test/content-language/content-language?martech=off
