### PR TITLE
Don't run UT or label checks if you edit PR title/body

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -2,7 +2,7 @@ name: Enforce PR labels
 
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, edited, synchronize]
+    types: [labeled, unlabeled, opened, synchronize]
 jobs:
   enforce-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
     branches:
       - main
 jobs:


### PR DESCRIPTION
They seem unnecessary if you're just updating description of PR. Improve dev velocity just a bit and reduce noise.

Reference: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=edited#pull_request

Actual test is editing this PR. Only `helix-psi-check` should need to rerun if body is edited.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/?martech=off
- After: https://hparra-patch-1--milo--adobecom.hlx.live/?martech=off
