### PR TITLE
[Blog Migration] Topics URL 404s on lang pages

### DIFF
--- a/libs/scripts/taxonomy.js
+++ b/libs/scripts/taxonomy.js
@@ -84,23 +84,19 @@ function parseTaxonomyJson(data, root) {
         : LEVEL_INDEX.level1);
 
     const name = level3 || level2 || level1;
-
     const category = row[TAXONOMY_FIELDS.type]?.trim().toLowerCase() || INTERNALS;
 
     // skip duplicates
     if (!isProduct(category) && taxonomy.topics[name]) return taxonomy;
     if (isProduct(category) && taxonomy.products[name]) return taxonomy;
 
-    const link = [row[TAXONOMY_FIELDS.link]].reduce((_url) => {
-      if (_url) {
-        const u = new URL(_url);
-        const current = new URL(window.location.href);
-        return `${current.origin}${u.pathname}`;
-      }
-
-      return `${root}/${generateUri(name)}`;
-    }, null);
-
+    const taxLink = row[TAXONOMY_FIELDS.link]
+      ? new URL([row[TAXONOMY_FIELDS.link]])
+      : generateUri(name);
+    const path = taxLink.pathname
+      ? taxLink.pathname?.replace('.html', '').split('/topics/').pop()
+      : taxLink;
+    const link = `${root}/${path}`;
     const hidden = !!row[TAXONOMY_FIELDS.hidden]?.trim();
     const skipMeta = !!row[TAXONOMY_FIELDS.excludeFromMetadata]?.trim();
 
@@ -178,16 +174,9 @@ export default async (config, route, target) => {
         NO_INTERLINKS,
 
         lookup(topic) {
-          // might be a product (product would have priori)
-          let t = this.get(topic, PRODUCTS);
-          if (!t) {
-            // might be a product without the leading Adobe
-            t = this.get(topic.replace('Adobe ', ''), PRODUCTS);
-            if (!t) {
-              t = this.get(topic);
-            }
-          }
-          return t;
+          return this.get(topic, PRODUCTS)
+            || this.get(topic.replace('Adobe ', ''), PRODUCTS)
+            || this.get(topic);
         },
 
         get(topic, cat) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fixes issue with malformed link to topic pages on lang pages.

Context:
Taxonmy.js is set up to capture a link from the link column if one is provided in taxonomy.json. If a link is not provided it grabs the category name and creates a url to topic pages.

There is a bug where the link in taxonomy.json is not getting captured so the category name is being used to create a link to topic pages. 

When viewing a landing page out side of english (/ko/, /jp/, /de/, /fr/, /it/) the category name is in the respective language. This creates malformed links to any topic pages in that language, resulting in the link 404ing.

Resolves: [MWPW-129907](https://jira.corp.adobe.com/browse/MWPW-129907)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- Before: https://blog-taxonomy--milo--adobecom.hlx.page/?martech=off

Blog URLs - Working pages
- **Japanese pages**
- Before: https://main--blog--adobecom.hlx.page/jp/?martech=off
- After: https://main--blog--adobecom.hlx.page/jp/?milolibs=blog-taxonomy&martech=off
- **English pages**
- Before: https://main--blog--adobecom.hlx.page/?martech=off
- After: https://main--blog--adobecom.hlx.page/?milolibs=blog-taxonomy&martech=off

To test: 
Visit a migrated blog page and hover over or click the topic or tag link.

Topic link can be found on any of the featured article, related article or article feed cards. It's the small details text (eyebrow). 
E.g. https://main--blog--adobecom.hlx.page/jp/?milolibs=blog-taxonomy
![image](https://github.com/adobecom/milo/assets/2539954/9c2fe8ca-6ca8-4568-a8d4-c0c56c2bfc1b)


Tag links are typically at the bottom of article pages.
E.g. https://main--blog--adobecom.hlx.page/jp/publish/2023/07/14/cc-photoshop-lyric-art-project?milolibs=blog-taxonomy
![image](https://github.com/adobecom/milo/assets/2539954/1932fac7-836e-4e1e-87da-3ea50555aa6b)


Example of **good** topic links:
![image](https://github.com/adobecom/milo/assets/2539954/f3be8ba7-540e-4af0-b005-394c1de8f489)

Example of **bad** topic links:
![image](https://github.com/adobecom/milo/assets/2539954/5f1bfece-b6a5-42be-b809-3605fc47de10)
