### PR TITLE
Make sure to always display the breadcrumbs when a base is set

### DIFF
--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -78,7 +78,8 @@ const createWithBase = async (element = toFragment`<div><ul></ul></div>`) => {
     const base = new DOMParser().parseFromString(text, 'text/html').body;
     element.querySelector('ul')?.prepend(...base.querySelectorAll('li'));
     return createBreadcrumbs(element);
-  } catch (error) {
+  } catch (e) {
+    lanaLog({ e, message: 'Breadcrumbs failed fetching base' });
     return null;
   }
 };
@@ -99,7 +100,9 @@ const fromUrl = () => {
 
 export default async function init(el) {
   try {
-    const breadcrumbsEl = (await createWithBase(el)) || createBreadcrumbs(el) || fromUrl();
+    const breadcrumbsEl = (await createWithBase(el || undefined))
+      || createBreadcrumbs(el)
+      || fromUrl();
     setBreadcrumbSEO(breadcrumbsEl);
     return breadcrumbsEl;
   } catch (e) {

--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -69,7 +69,8 @@ const createBreadcrumbs = (element) => {
   return breadcrumbs;
 };
 
-const createWithBase = async (element = toFragment`<div><ul></ul></div>`) => {
+const createWithBase = async (el) => {
+  const element = el || toFragment`<div><ul></ul></div>`;
   const url = getMetadata(metadata.base);
   if (!url) return null;
   try {
@@ -100,9 +101,7 @@ const fromUrl = () => {
 
 export default async function init(el) {
   try {
-    const breadcrumbsEl = (await createWithBase(el || undefined))
-      || createBreadcrumbs(el)
-      || fromUrl();
+    const breadcrumbsEl = await createWithBase(el) || createBreadcrumbs(el) || fromUrl();
     setBreadcrumbSEO(breadcrumbsEl);
     return breadcrumbsEl;
   } catch (e) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -564,9 +564,10 @@ function decorateHeader() {
   const metadataConfig = getMetadata('breadcrumbs')?.toLowerCase()
   || getConfig().breadcrumbs;
   if (metadataConfig === 'off') return;
+  const baseBreadcrumbs = getMetadata('breadcrumbs-base')?.length;
   const breadcrumbs = document.querySelector('.breadcrumbs');
   const autoBreadcrumbs = getMetadata('breadcrumbs-from-url') === 'on';
-  if (breadcrumbs || autoBreadcrumbs) header.classList.add('has-breadcrumbs');
+  if (baseBreadcrumbs || breadcrumbs || autoBreadcrumbs) header.classList.add('has-breadcrumbs');
   if (breadcrumbs) header.append(breadcrumbs);
 }
 


### PR DESCRIPTION
### Description
Ensure to show the breadcrumbs element if there is just a "base-breadcrumbs"

Resolves: [MWPW-134085](https://jira.corp.adobe.com/browse/MWPW-134085)

**Test URLs:**
- Before: - https://mwpw-134085--milo--mokimo.hlx.live/
- Before: https://main--bacom--adobecom.hlx.page/resources/leader-in-experiences-breadcrumb-in-url-test
- After: https://main--bacom--adobecom.hlx.page/resources/leader-in-experiences-breadcrumb-in-url-test?milolibs=mwpw-134085--milo--mokimo
