### PR TITLE
[MWPW-133763] Breadcrumbs mobile alignment

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -320,6 +320,15 @@ header.global-navigation {
   flex-shrink: 0;
 }
 
+.feds-breadcrumbs li:last-child:not(:first-child) {
+  padding-right: 12px;
+}
+
+[dir = "rtl"] .feds-breadcrumbs li:last-child:not(:first-child) {
+  padding-right: 0;
+  padding-left: 12px;
+}
+
 /* Hide all breadcrumbs except the first and last two */
 .feds-breadcrumbs li:nth-last-child(n+3):not(:first-child) {
   display: none;
@@ -327,7 +336,7 @@ header.global-navigation {
 
 /* If first breadcrumb is not third to last, add ellipsis after it */
 .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after {
-  content: '/\2003...';
+  content: '/\3000…';
   padding: 0 0 0 12px;
 }
 


### PR DESCRIPTION
This is a slight style enhancement for the mobile breadcrumbs. It ensures:
- the ellipsis element has equal spacing on both desktop browsers in responsive view and actual devices when browsing on Firefox or Safari;
- the last breadcrumb has lateral space if the breadcrumbs section is scrollable.

| Before | After |
| ------------- | ------------- |
| <img width="324" alt="Ellipsis spacing on FF - before" src="https://github.com/adobecom/milo/assets/11267498/5a534c15-9682-49cc-96c1-722aab7fc48c"> | <img width="324" alt="Ellipsis spacing on FF - after" src="https://github.com/adobecom/milo/assets/11267498/1c9075d6-0dad-4e53-a324-9df780097b13"> |
| <img width="324" alt="Last element spacing on FF - before" src="https://github.com/adobecom/milo/assets/11267498/7dcf99df-e7fd-407f-b425-40e6d8c7f6a6"> | <img width="324" alt="Last element spacing on FF - after" src="https://github.com/adobecom/milo/assets/11267498/fe8578e9-93b5-49a1-9c1a-37ef4db62dfd"> |

Resolves: [MWPW-133763](https://jira.corp.adobe.com/browse/MWPW-133763)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/footer-refactor-variant?martech=off
- After: https://breadcrumbs-mobile-spacing--milo--overmyheadandbody.hlx.page/drafts/ramuntea/footer-refactor-variant?martech=off
