### PR TITLE
MWPW-134209 Enable excel format localization

### DIFF
--- a/tools/loc/ui.js
+++ b/tools/loc/ui.js
@@ -610,7 +610,15 @@ async function copyFilesToLangstoreEn() {
   const previewStatuses = await Promise.all(
     copyStatuses
       .filter((status) => status.success)
-      .map((status) => simulatePreview(stripExtension(status.dstPath))),
+      .map((status) => {
+        let { dstPath } = status;
+        if (dstPath.endsWith('.xlsx')) {
+          dstPath = `${dstPath.slice(0, -5)}.json`;
+        } else {
+          dstPath = stripExtension(dstPath);
+        }
+        return simulatePreview(dstPath);
+      }),
   );
   loadingON('Completed Preview for copied files... ');
   const failedCopies = copyStatuses

--- a/tools/loc/utils.js
+++ b/tools/loc/utils.js
@@ -51,6 +51,10 @@ export function getDocPathFromUrl(url) {
   if (!path) {
     return undefined;
   }
+  if (path.endsWith('.json')) {
+    path = path.slice(0, -5);
+    return `${path}.xlsx`;
+  }
   if (path.endsWith('/')) {
     path += 'index';
   } else if (path.endsWith('.html')) {


### PR DESCRIPTION
MWPW-134209 Enable Excel Localization in Milo

### Context:
* More project teams are asking that we need to be able to localize xlsx format file through Milo.
* Milo uses GLaaS Adhoc workflow for docx. This workflow also supports xlsx as well.
* Therefore, Loc UI already technically supports xlsx format. The only following 2 bug fixes were needed.

### 2 Bugs to be fixed:

**Bug 1** tools/loc/utils.js::getDocPathFromUrl() always returns the **.docx** extension, so when copying the source **xlsx** to langstore/en, a wrong path was used such as /placeholders.json.docx:

```
sharepoint.js:99     POST https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com,d4a4a670-ea62-4d6e-b7b7-69815fe97232,7197dd77-3672-42c9-aeeb-1b93c89acd24/drives/b!cKak1GLqbk23t2mBX-lyMnfdl3FyNslCrusbk8iazSR5A_8Jgvb8TpmGobVZ-tWL/root://drafts/gwatanab/placeholders4.json.docx:/copy?@microsoft.graph.conflictBehavior=replace 404 (Not Found) 
```
Fix: Returning with **.xlsx** extension when the path ends with **.json**.

**Bug 2** After copying the source xlsx to langstore/en, at tools/loc/ui.js::copyFilesToLangstoreEn(), Milo tries to preview the langstore/en by stripping out the file extension, which fails for xlsx.

```
curl -X POST "https://admin.hlx.page/preview/gwatanab/clio/main/drafts/gwatanab/placeholders3"
>> RESPONSE: error from content-bus

Excel file needs to add ".json" in preview API.
 
curl -X POST "https://admin.hlx.page/preview/gwatanab/clio/main/drafts/gwatanab/placeholders3.json"
>> SUCCESS
```
Fix: Therefore, add **.json** extension in case the URL ends with **.xlsx**.

Resolves: [MWPW-134209](https://jira.corp.adobe.com/browse/MWPW-134209)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/localization/projects/gwatanab/gw-excel-0726.json
- After: https://enable-loc-excel2--milo--gwatanab.hlx.page/drafts/localization/projects/gwatanab/gw-excel-0726.json
