### PR TITLE
Fix flakey title-append test

### DIFF
--- a/test/helpers/waitfor.js
+++ b/test/helpers/waitfor.js
@@ -103,3 +103,28 @@ export const delay = (timeOut, cb) => new Promise((resolve) => {
     resolve((cb && cb()) || null);
   }, timeOut);
 });
+
+/**
+ * Waits for predicate function to be true or times out.
+ * @param {function} predicate Callback that returns boolean
+ * @param {number} timeout Timeout in milliseconds
+ * @param {number} interval Interval delay in milliseconds
+ * @returns {Promise}
+ */
+export function waitFor(predicate, timeout = 1000, interval = 100) {
+  return new Promise((resolve, reject) => {
+    if (predicate()) resolve();
+
+    const intervalId = setInterval(() => {
+      if (predicate()) {
+        clearInterval(intervalId);
+        resolve();
+      }
+    }, interval);
+
+    setTimeout(() => {
+      clearInterval(intervalId);
+      reject(new Error('Timed out waiting for predicate to be true'));
+    }, timeout);
+  });
+}

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -1,7 +1,7 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { delay, waitForElement } from '../helpers/waitfor.js';
+import { waitFor, waitForElement } from '../helpers/waitfor.js';
 import { mockFetch } from '../helpers/generalHelpers.js';
 
 const utils = {};
@@ -379,11 +379,10 @@ describe('Utils', () => {
       document.head.innerHTML = await readFile({ path: './mocks/head-title-append.html' });
     });
     it('should append to title using string from metadata', async () => {
+      const expected = 'Document Title NOODLE';
       await utils.loadArea();
-      await delay(100);
-      expect(document.title).to.equal('Document Title NOODLE');
+      await waitFor(() => document.title === expected);
+      expect(document.title).to.equal(expected);
     });
   });
 });
-
-// This comment was left here intentionally

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -41,6 +41,7 @@ describe('Utils', () => {
 
     afterEach(() => {
       window.fetch = ogFetch;
+      // eslint-disable-next-line no-console
       console.log.restore();
     });
 
@@ -159,6 +160,7 @@ describe('Utils', () => {
 
     it('Successfully dies parsing a bad config', () => {
       utils.parseEncodedConfig('error');
+      // eslint-disable-next-line no-console
       expect(console.log.args[0][0].name).to.equal('InvalidCharacterError');
     });
 


### PR DESCRIPTION
Fix my own flakey title-append test using `waitFor` introduced in #986.

Using an explicit delay is a last resort that we can avoid here.

**Test URLs:**
- Before: https://main--milo--hparra.hlx.live/?martech=off
- After: https://fix-title-append-flap--milo--hparra.hlx.live/?martech=off
