### PR TITLE
Chore: lana.js linting

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -1,4 +1,5 @@
-(function () {
+/* eslint no-console: 0 */
+(function lanaiife() {
   const MSG_LIMIT = 2000;
 
   const defaultOptions = {
@@ -24,15 +25,7 @@
     return false;
   }
 
-  function mergeOptions(op1, op2) {
-    if (!op1) {
-      op1 = {};
-    }
-
-    if (!op2) {
-      op2 = {};
-    }
-
+  function mergeOptions(op1 = {}, op2 = {}) {
     function getOpt(key) {
       if (op1[key] !== undefined) {
         return op1[key];
@@ -49,12 +42,8 @@
     }, {});
   }
 
-  function sendUnhandledError(e) {
-    log(e.reason || e.error || e.message, { errorType: 'i' });
-  }
-
-  function log(msg, options) {
-    msg = msg && msg.stack ? msg.stack : (msg || '');
+  function log(m, options) {
+    let msg = m && m.stack ? m.stack : (m || '');
     if (msg.length > MSG_LIMIT) {
       msg = `${msg.slice(0, MSG_LIMIT)}<trunc>`;
     }
@@ -62,12 +51,12 @@
     const o = mergeOptions(options, w.lana.options);
     if (!o.clientId) {
       console.warn('LANA ClientID is not set in options.');
-      return;
+      return undefined;
     }
 
     const sampleRate = o.errorType === 'i' ? o.implicitSampleRate : o.sampleRate;
 
-    if (!w.lana.debug && !w.lana.localhost && sampleRate <= Math.random() * 100) return;
+    if (!w.lana.debug && !w.lana.localhost && sampleRate <= Math.random() * 100) return undefined;
 
     const isProdDomain = isProd();
 
@@ -97,6 +86,12 @@
       xhr.send();
       return xhr;
     }
+
+    return undefined;
+  }
+
+  function sendUnhandledError(e) {
+    log(e.reason || e.error || e.message, { errorType: 'i' });
   }
 
   function hasDebugParam() {


### PR DESCRIPTION
Fix eslint errors/warnings found in lana.js via #986

```
hgpa@noface milo % npx eslint-nibble libs/utils/lana.js
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme

1 file checked.  0 passed.  1 failed.  4 warnings.  6 errors.

? Which rule would you like to view? (Use arrow keys)
❯ consistent-return:    1|  
  func-names:           1|  
  no-console:           3|    
  no-param-reassign:    4|     
  no-use-before-define: 1|  
```

**Test URLs:**
- Before: https://main--milo--hparra.hlx.live/?martech=off
- After: https://chore-lana-lint--milo--hparra.hlx.live/?martech=off
