### PR TITLE
feat(marquee): unit test fix

### DIFF
--- a/test/blocks/marquee/marquee.test.js
+++ b/test/blocks/marquee/marquee.test.js
@@ -38,13 +38,13 @@ describe('marquee', () => {
 
   describe('supports media credits', () => {
     it('has a media credit with text content', () => {
-      const mediaCredit = marquees[8].querySelector('.media-credit .body-s');
+      const mediaCredit = document.getElementById('media-credit-text').querySelector('.media-credit .body-s');
       expect(mediaCredit).to.exist;
       expect(mediaCredit.textContent.trim()).to.have.lengthOf.above(0);
     });
 
-    it.skip('has a media credit with element content', () => {
-      const mediaCredit = marquees[9].querySelector('.media-credit .body-s');
+    it('has a media credit with element content', () => {
+      const mediaCredit = document.getElementById('media-credit-element').querySelector('.media-credit').firstElementChild;
       expect(mediaCredit).to.exist;
     });
   });

--- a/test/blocks/marquee/mocks/body.html
+++ b/test/blocks/marquee/mocks/body.html
@@ -184,7 +184,7 @@
 
 <h2>Marquee (split)</h2>
 <p>small</p>
-<div class="marquee split small">
+<div class="marquee split small" id="media-credit-text">
   <div>
     <div>#000000</div>
   </div>
@@ -204,7 +204,7 @@
   </div>
 </div>
 <h2>Medium split medium light</h2>
-<div class="marquee split light">
+<div class="marquee split light" id="media-credit-element">
   <div>
     <div>#fafafa</div>
   </div>


### PR DESCRIPTION
Fixing the unit test for the Marquee block after introduction of element media credit types.

**Test URLs:**
- https://marquee-test-fix--milo--wbstry.hlx.live/
- Before: https://main--cc--adobecom.hlx.live/
- After: https://main--cc--adobecom.hlx.live/?milolibs=marquee-test-fix--milo--wbstry&martech=off