### PR TITLE
Fix loadLana test

### DIFF
--- a/test/blocks/bulk-publish/bulk-publish-utils.test.js
+++ b/test/blocks/bulk-publish/bulk-publish-utils.test.js
@@ -126,7 +126,7 @@ describe('Bulk preview and publish', () => {
     localStorage.clear();
   });
 
-  it('Bulk preview URLs', async () => {
+  it.skip('Bulk preview URLs', async () => {
     const operation = 'preview';
     storeUrls(URLS);
     storeOperation(operation);

--- a/test/blocks/bulk-publish/bulk-publish-utils.test.js
+++ b/test/blocks/bulk-publish/bulk-publish-utils.test.js
@@ -126,7 +126,7 @@ describe('Bulk preview and publish', () => {
     localStorage.clear();
   });
 
-  it.skip('Bulk preview URLs', async () => {
+  it('Bulk preview URLs', async () => {
     const operation = 'preview';
     storeUrls(URLS);
     storeOperation(operation);

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -5,18 +5,24 @@ import { waitForElement } from '../helpers/waitfor.js';
 document.head.innerHTML = await readFile({ path: './mocks/head.html' });
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
-describe('Decorating', () => {
+describe('Decorating', async () => {
   before(async () => {
     await import('../../libs/scripts/scripts.js');
   });
 
-  it('Decorates auto blocks', async () => {
-    const autoBlock = document.querySelector('a[class]');
-    expect(autoBlock.className).to.equal('adobetv link-block');
+  it('Decorates adobetv autoblock', async () => {
+    const autoBlock = await waitForElement(
+      'iframe[class="adobetv"]',
+      { rootEl: document.body },
+    );
+    expect(autoBlock.className).to.equal('adobetv');
   });
 
   it('Decorates modal link', async () => {
-    const modalLink = document.querySelector('a[data-modal-path]');
+    const modalLink = await waitForElement(
+      'a[data-modal-path]',
+      { rootEl: document.body },
+    );
     expect(modalLink.dataset.modalPath).to.equal('/fragments/mock');
   });
 

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -1,6 +1,5 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { waitForElement } from '../helpers/waitfor.js';
 
 document.head.innerHTML = await readFile({ path: './mocks/head.html' });
@@ -28,23 +27,5 @@ describe('Decorating', () => {
     );
     expect(el).to.exist;
     expect(window.alloy_all).to.exist;
-  });
-
-  it('Loads lana.js upon calling lana.log the first time', async () => {
-    expect(window.lana.log).to.exist;
-
-    sinon.spy(console, 'log');
-
-    await window.lana.log('test', { clientId: 'myclient', sampleRate: 0 });
-    expect(window.lana.options).to.exist;
-    expect(console.log.args[0][0]).to.equal('LANA Msg: ');
-    expect(console.log.args[0][1]).to.equal('test');
-    console.log.restore();
-
-    sinon.spy(console, 'log');
-    await window.lana.log('test2', { clientId: 'myclient', sampleRate: 0 });
-    expect(console.log.args[0][0]).to.equal('LANA Msg: ');
-    expect(console.log.args[0][1]).to.equal('test2');
-    console.log.restore();
   });
 });

--- a/test/utils/loadLana.test.js
+++ b/test/utils/loadLana.test.js
@@ -1,0 +1,28 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { waitFor } from '../helpers/waitfor.js';
+import { loadLana } from '../../libs/utils/utils.js';
+
+describe('Utils loadLana', () => {
+  it('Loads lana.js upon calling lana.log the first time', async () => {
+    expect(window.lana?.log).not.to.exist;
+    loadLana();
+    expect(window.lana.log).to.exist;
+
+    const initialLana = window.lana.log;
+    sinon.spy(console, 'log');
+    await window.lana.log('test', { clientId: 'myclient', sampleRate: 0 });
+    await waitFor(() => initialLana !== window.lana.log);
+
+    expect(window.lana.options).to.exist;
+    expect(console.log.args[0][0]).to.equal('LANA Msg: ');
+    expect(console.log.args[0][1]).to.equal('test');
+    console.log.restore();
+
+    sinon.spy(console, 'log');
+    await window.lana.log('test2', { clientId: 'myclient', sampleRate: 0 });
+    expect(console.log.args[0][0]).to.equal('LANA Msg: ');
+    expect(console.log.args[0][1]).to.equal('test2');
+    console.log.restore();
+  });
+});


### PR DESCRIPTION
Moved the test into it's own file and call `loadLana` directly for testing.  When testing via scripts.test.js the lana test intermittently would fail.

**Test URLs:**

- https://loadlana--milo--adobecom.hlx.live/
