### PR TITLE
MWPW-133028 | Making aside button action area a flex container

### DIFF
--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -106,14 +106,9 @@
 
 .aside .foreground.container .text .action-area {
   margin-bottom: 0;
-}
-
-.aside .foreground.container .text .action-area > a {
-  margin-right: var(--spacing-s);
-}
-
-.aside .foreground.container .text .action-area > a:last-child {
-  margin-right: 0;
+  display: flex;
+  gap: var(--spacing-s);
+  flex-wrap: wrap;
 }
 
 .aside .foreground.container > div {

--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -109,6 +109,7 @@
   display: flex;
   gap: var(--spacing-s);
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .aside .foreground.container > div {

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -443,3 +443,15 @@ header.global-navigation {
   width: 30px;
   margin-right: 16px;
 }
+
+@media (max-width: 400px) {
+  .table,
+  .table.merch {
+    margin: 0 2px;
+    min-width: 395px;
+  }
+
+  .table.merch .col-merch .col-merch-content {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
* Aside buttons area currently add margin right to all 'a' tags and no right margin in last a tag. As a result when the screen size is previewed in responsive mode the buttons stack on a smaller screen size. The stacked buttons have no spacing.
* Converting the action-area container into a flex container to add a gap of spacing-s between elements and allow flex wrap. With this change if the buttons wrap to next line they will also have a top gap of spacing-s and will not stack without any space.

Screenshots without change

<img width="182" alt="Screenshot 2023-07-27 at 4 14 44 PM" src="https://github.com/adobecom/milo/assets/9293441/78f4dadb-7e24-4236-ab42-222dc36031bd">

Screenshots with change
<img width="182" alt="Screenshot 2023-07-27 at 4 15 14 PM" src="https://github.com/adobecom/milo/assets/9293441/8c0810dc-a776-41dd-a278-7cae1ee2f3d8">

Resolves: [MWPW-133028](https://jira.corp.adobe.com/browse/MWPW-133028)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/mathuria/aside/mwpw-133028?martech=off
- After: https://asidebtnstack--milo--aishwaryamathuria.hlx.page/drafts/mathuria/aside/mwpw-133028?martech=off
