### PR TITLE
mwpw-134306: always show authored breadcrumbs-page-title

### DIFF
--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -51,11 +51,11 @@ const removeHiddenEntries = ({ ul }) => {
 const createBreadcrumbs = (element) => {
   if (!element) return null;
   const ul = element.querySelector('ul');
-
-  if (getMetadata(metadata.showCurrent) === 'on') {
+  const pageTitle = getMetadata(metadata.pageTitle);
+  if (pageTitle || getMetadata(metadata.showCurrent) === 'on') {
     ul.append(toFragment`
       <li>
-        ${getMetadata(metadata.pageTitle) || document.title}
+        ${pageTitle || document.title}
       </li>
     `);
   }

--- a/test/blocks/global-navigation/features/breadcrumbs.test.js
+++ b/test/blocks/global-navigation/features/breadcrumbs.test.js
@@ -58,6 +58,13 @@ describe('breadcrumbs', () => {
     expect(breadcrumb.querySelector('ul li:last-of-type').innerText.trim()).to.equal('Custom Title');
   });
 
+  it('should use a custom page title if its explicity set even without breadcrumbs-show-current-page:ON', async () => {
+    document.head.innerHTML = '<meta name="breadcrumbs-page-title" content="Custom Title">';
+    const breadcrumb = await breadcrumbs(breadcrumbMock());
+    assertBreadcrumb({ breadcrumb, length: 5 });
+    expect(breadcrumb.querySelector('ul li:last-of-type').innerText.trim()).to.equal('Custom Title');
+  });
+
   it('should create a breadcrumb SEO element', async () => {
     await breadcrumbs(breadcrumbMock());
     const script = document.querySelector('script');


### PR DESCRIPTION
### Description
The breadcrumbs has a few different configuration options, for this PR important 
- `breadcrumbs-show-current-page` shows the current page as last entry in the breadcrumb
- `breadcrumbs-page-title` alters the title for the last entry in the breadcrumb

Currently BOTH are required to be authored for the `breadcrumbs-page-title` to show up, as per default `breadcrumbs-show-current-page` is OFF. The default exists as otherwise other consumers would have multiple "last entries" in their breadcrumbs.

We should be able to safely assume that IF a `breadcrumbs-page-title` has been authored, the authors want that to show up - otherwise they would just not author it.

### Changelog
- Authored `breadcrumbs-page-title` should always show up when it has been authored.

Resolves: [MWPW-134306](https://jira.corp.adobe.com/browse/MWPW-134306)

**Test URLs:**
- Before: - https://mwpw-134306--milo--mokimo.hlx.live?martech=off
- Before: https://main--bacom--adobecom.hlx.page/solutions/b2b-marketing-base-breadcrumb
- After: https://main--bacom--adobecom.hlx.page/solutions/b2b-marketing-base-breadcrumb?milolibs=mwpw-134306
