### PR TITLE
MWPW-134057 | Replace image links in place

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -446,8 +446,9 @@ export function decorateImageLinks(el) {
       if (alt?.trim().length) img.alt = alt.trim();
       const pic = img.closest('picture');
       const picParent = pic.parentElement;
-      const aTag = createTag('a', { href: url, class: 'image-link' }, pic);
-      picParent.append(aTag);
+      const aTag = createTag('a', { href: url, class: 'image-link' });
+      picParent.insertBefore(aTag, pic);
+      aTag.append(pic)
     } catch (e) {
       console.log('Error:', `${e.message} '${source.trim()}'`);
     }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -448,7 +448,7 @@ export function decorateImageLinks(el) {
       const picParent = pic.parentElement;
       const aTag = createTag('a', { href: url, class: 'image-link' });
       picParent.insertBefore(aTag, pic);
-      aTag.append(pic)
+      aTag.append(pic);
     } catch (e) {
       console.log('Error:', `${e.message} '${source.trim()}'`);
     }

--- a/test/utils/imageLinks.test.js
+++ b/test/utils/imageLinks.test.js
@@ -1,7 +1,7 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { decorateImageLinks } from '../../../libs/utils/utils.js';
+import { decorateImageLinks } from '../../libs/utils/utils.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/image-links.html' });
 

--- a/test/utils/imageLinks.test.js
+++ b/test/utils/imageLinks.test.js
@@ -22,6 +22,12 @@ describe('Image Link', () => {
     expect(links[0].nodeName).to.equal('A');
   });
 
+  it('Replaces the image in-place', () => {
+    const i = document.querySelector('#inline-image');
+    expect(i.children[1].nodeName).to.equal('A');
+    expect(i.querySelector('a picture')).to.exist;
+  });
+
   it('Fails gracefully', () => {
     const i = document.querySelector('.bad-url');
     expect(i.alt).to.equal('img/badurl#_blank | image link bad url');

--- a/test/utils/mocks/image-links.html
+++ b/test/utils/mocks/image-links.html
@@ -6,3 +6,5 @@
 
 <p><picture><img src="./test/utils/mocksmedia_.png" alt="img/badurl#_blank | image link bad url" class="image-link bad-url"/></picture></p>
 
+<p id="inline-image"><span>Suffix text</span><picture><img src="./test/utils/mocksmedia_.png" alt="https://www.adobe.com | image link" class="image-link"/></picture><span>Prefix text</span></p>
+


### PR DESCRIPTION
* If there is an image in Milo with alt text having '|' it is replaced with an a tag and the image element is added inside the a tag. The a tag is then added to the end of the parent element of image. This removes the image from its initial position in the parent element and adds it to the end of the container.
* The change in the PR replaces the image in place. The a tag is added before the image and then the image is shifted inside the 'a' tag keeping the image position same.

Resolves: [MWPW-134057](https://jira.corp.adobe.com/browse/MWPW-134057)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/mathuria/mwpw-134057?martech=off
- After: https://miloimglnk--milo--aishwaryamathuria.hlx.page/drafts/mathuria/mwpw-134057?martech=off
