### PR TITLE
Typo in feds-nav-wrapper markup

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -505,7 +505,7 @@ class Gnav {
     const breadcrumbs = isDesktop.matches ? '' : await this.decorateBreadcrumbs();
     this.elements.mainNav = toFragment`<div class="feds-nav"></div>`;
     this.elements.navWrapper = toFragment`
-      <div class="feds-nav-wrapper id="feds-nav-wrapper"">
+      <div class="feds-nav-wrapper" id="feds-nav-wrapper">
         ${breadcrumbs}
         ${isDesktop.matches ? '' : this.decorateSearch()}
         ${this.elements.mainNav}


### PR DESCRIPTION
This fixes a small typo in the markup for `.feds-nav-wrapper`, introduced in [this PR](https://github.com/adobecom/milo/commit/1c32ab872b34bc87d6b926a9772be40da04fe54f#diff-628bf5a25903978c5b36da4943ec813da171346d24bd64f80907f012a840b098L508).

Resolves: trivial issue spotted by chance

Screenshots:
| Before | After |
| ------------- | ------------- |
| <img width="426" alt="Typo" src="https://github.com/adobecom/milo/assets/11267498/f000c28d-b15b-4a7b-a263-75569886a519"> | <img width="420" alt="Typo fixed" src="https://github.com/adobecom/milo/assets/11267498/8efa2f9c-c3b4-49c4-bebe-c55eb7dceea1"> |

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
- After: https://nav-wrapper-typo--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
