### PR TITLE
MWPW-134309: Milo to always use Prod WCS

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -40,7 +40,8 @@ export function getTacocatEnv(envName, locale) {
 
   const literalScriptUrl = `${host}/special/tacocat/literals/${language}.js`;
   const scriptUrl = `${host}/special/tacocat/lib/${VERSION}/tacocat.js`;
-  return { country, language, literalScriptUrl, scriptUrl, tacocatEnv: 'PRODUCTION' };
+  const tacocatEnv = getMetadata('tacocat-env') ?? 'PRODUCTION';
+  return { country, language, literalScriptUrl, scriptUrl, tacocatEnv };
 }
 
 export const omitNullValues = (target) => {
@@ -119,7 +120,7 @@ window.tacocat.loadPromise = new Promise((resolve) => {
       resolve(false);
     })
     .catch((error) => {
-      console.error('Failed to load tacocat', error);
+      window.lana.log(`Failed to load tacocat. ${error?.message}`);
       resolve(true);
     });
 });

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -40,8 +40,7 @@ export function getTacocatEnv(envName, locale) {
 
   const literalScriptUrl = `${host}/special/tacocat/literals/${language}.js`;
   const scriptUrl = `${host}/special/tacocat/lib/${VERSION}/tacocat.js`;
-  const tacocatEnv = envName === ENV_PROD ? 'PRODUCTION' : 'STAGE';
-  return { country, language, literalScriptUrl, scriptUrl, tacocatEnv };
+  return { country, language, literalScriptUrl, scriptUrl, tacocatEnv: 'PRODUCTION' };
 }
 
 export const omitNullValues = (target) => {

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -9,7 +9,6 @@ const {
   VERSION,
   getTacocatEnv,
   getTacocatLocale,
-  getTacocatMetadata,
   imsCountryPromise,
   runTacocat,
 } = await import('../../../libs/blocks/merch/merch.js');
@@ -307,24 +306,42 @@ describe('Merch Block', () => {
 
   describe('Tacocat config', () => {
     it('falls back to en for unsupported languages', async () => {
-      const { literalScriptUrl, language, tacocatEnv } = getTacocatEnv('local', { ietf: 'xx-US' });
+      const { literalScriptUrl, language } = getTacocatEnv('local', { ietf: 'xx-US' });
       expect(literalScriptUrl).to.equal(
         'https://www.stage.adobe.com/special/tacocat/literals/en.js',
       );
       expect(language).to.equal('en');
-      expect(tacocatEnv).to.equal('PRODUCTION');
     });
 
     it('returns production values', async () => {
-      const { scriptUrl, literalScriptUrl, country, language } = getTacocatEnv(
+      const { scriptUrl, literalScriptUrl, country, language, tacocatEnv } = getTacocatEnv(
         'prod',
         { ietf: 'fr-CA' },
       );
+      expect(tacocatEnv).to.equal('PRODUCTION');
       expect(scriptUrl).to.equal(
         `https://www.adobe.com/special/tacocat/lib/${VERSION}/tacocat.js`,
       );
       expect(literalScriptUrl).to.equal(
         'https://www.adobe.com/special/tacocat/literals/fr.js',
+      );
+      expect(country).to.equal('CA');
+      expect(language).to.equal('fr');
+    });
+
+    it('returns stage values', async () => {
+      const metadata = createTag('meta', { name: 'tacocat-env', content: 'STAGE' });
+      document.head.appendChild(metadata);
+      const { scriptUrl, literalScriptUrl, country, language, tacocatEnv } = getTacocatEnv(
+        'stage',
+        { ietf: 'fr-CA' },
+      );
+      expect(tacocatEnv).to.equal('STAGE');
+      expect(scriptUrl).to.equal(
+        `https://www.stage.adobe.com/special/tacocat/lib/${VERSION}/tacocat.js`,
+      );
+      expect(literalScriptUrl).to.equal(
+        'https://www.stage.adobe.com/special/tacocat/literals/fr.js',
       );
       expect(country).to.equal('CA');
       expect(language).to.equal('fr');

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -24,7 +24,7 @@ describe('Merch Block', () => {
       price: { optionProviders: [] },
       defaults: {
         apiKey: 'wcms-commerce-ims-ro-user-milo',
-        baseUrl: 'https://wcs.stage.adobe.com',
+        baseUrl: 'https://wcs.adobe.com',
         landscape: null,
         env: 'STAGE',
         environment: 'STAGE',
@@ -307,11 +307,12 @@ describe('Merch Block', () => {
 
   describe('Tacocat config', () => {
     it('falls back to en for unsupported languages', async () => {
-      const { literalScriptUrl, language } = getTacocatEnv('local', { ietf: 'xx-US' });
+      const { literalScriptUrl, language, tacocatEnv } = getTacocatEnv('local', { ietf: 'xx-US' });
       expect(literalScriptUrl).to.equal(
         'https://www.stage.adobe.com/special/tacocat/literals/en.js',
       );
       expect(language).to.equal('en');
+      expect(tacocatEnv).to.equal('PRODUCTION');
     });
 
     it('returns production values', async () => {

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -377,6 +377,15 @@ describe('Merch Block', () => {
       el = await merch(el);
       expect(el).to.be.undefined;
     });
+
+    it('does not initialize the block when tacocat fails to load', async () => {
+      const metadata = createTag('meta', { name: 'tacocat-env', content: 'invalidvalue' });
+      document.head.appendChild(metadata);
+      window.tacocat.loadPromise = Promise.resolve(true);
+      let el = document.querySelector('.merch.cta.notacocat');
+      el = await merch(el);
+      expect(el).to.be.undefined;
+    });
   });
 
   describe('Tacocat trigger', () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Switch Milo to only use 'wcs.adobe.com'.
'wcs.stage.adobe.com' should only be to test experimental features provided by the commerce team.

Resolves: [MWPW-134309](https://jira.corp.adobe.com/browse/MWPW-134309)


**Test URLs:**
- Before: [https://main--milo--adobecom.hlx.live/drafts/ilyas/merch?martech=off](https://main--milo--adobecom.hlx.live/drafts/ilyas/merch?martech=off)
- After: [https://mwpw-134309-wcs--milo--3ch023.hlx.page/drafts/ilyas/merch?martech=off](https://mwpw-134309-wcs--milo--3ch023.hlx.page/drafts/ilyas/merch?martech=off)
