### PR TITLE
MWPW-133747 Tag Selector Safari Style

### DIFF
--- a/libs/blocks/tag-selector/tag-selector.css
+++ b/libs/blocks/tag-selector/tag-selector.css
@@ -21,6 +21,7 @@
   width: 110px;
   margin-bottom: 5px;
   cursor: pointer;
+  right: 109px;
 }
 
 .tag-preview {

--- a/libs/blocks/tag-selector/tag-selector.css
+++ b/libs/blocks/tag-selector/tag-selector.css
@@ -19,7 +19,6 @@
   top: 5px;
   height: 32px;
   width: 110px;
-  margin-bottom: 5px;
   cursor: pointer;
   right: 109px;
 }

--- a/libs/ui/controls/tagSelector.css
+++ b/libs/ui/controls/tagSelector.css
@@ -282,6 +282,8 @@
   top: 15px;
   width: 30%;
   height: 32px;
+  appearance: none;
+  border: 1px solid grey;
 }
 
 .tagselect-picker-table .search-item:hover {


### PR DESCRIPTION
* Removes appearance, adds border, adjusts position of button to standardize ui across browsers

Resolves: [MWPW-133747](https://jira.corp.adobe.com/browse/MWPW-133747)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/tag-selector?martech=off
- After: https://mwpw-133747-tag-selector-style--milo--adobecom.hlx.page/tools/tag-selector?martech=off
