### PR TITLE
Modal analytics

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
 
 const FOCUSABLES = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
@@ -29,7 +30,8 @@ export function sendAnalytics(event) {
 
 function closeModal(modal) {
   const { id } = modal;
-  const eventName = window.location.hash ? window.location.hash.replaceAll('#', '') : 'localeModal';
+  const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
+  const eventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
   const closeEvent = new Event(`${eventName}:modalClose:buttonClose`);
   window.dispatchEvent(closeEvent);
   sendAnalytics(closeEvent);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -16,10 +16,23 @@ export function findDetails(hash, el) {
   return { id, path, isHash: hash === window.location.hash };
 }
 
+export function sendAnalytics(event) {
+  // eslint-disable-next-line no-underscore-dangle
+  window._satellite?.track('event', {
+    xdm: {},
+    data: {
+      web: { webInteraction: { name: event.type } },
+      _adobe_corpnew: { digitalData: event.data },
+    },
+  });
+}
+
 function closeModal(modal) {
   const { id } = modal;
-  const closeEvent = new Event('milo:modal:closed');
+  const eventName = window.location.hash ? window.location.hash.replaceAll('#', '') : 'localeModal';
+  const closeEvent = new Event(`${eventName}:modalClose:buttonClose`);
   window.dispatchEvent(closeEvent);
+  sendAnalytics(closeEvent);
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
     if (mod.nextElementSibling?.classList.contains('modal-curtain')) {

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -219,7 +219,7 @@ function buildContent(currentPage, locale, geoData, locales) {
     decorateForOnLinkClick(mainAction, locale.prefix);
   }
 
-  const altAction = createTag('a', { lang, href: currentPage.url }, currentPage.button);
+  const altAction = createTag('a', { lang, href: currentPage.url, 'daa-lh': `Stay:${currentPage.prefix.split('_')[0]}-${locale.prefix.split('_')[0]}|Geo_Routing_Modal` }, currentPage.button);
   decorateForOnLinkClick(altAction, currentPage.prefix);
   const linkWrapper = createTag('div', { class: 'link-wrapper' }, mainAction);
   linkWrapper.appendChild(altAction);

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -1,4 +1,5 @@
-import {sendAnalytics} from '../../blocks/modal/modal.js';
+/* eslint-disable import/no-cycle */
+import { sendAnalytics } from '../../blocks/modal/modal.js';
 
 let config;
 let createTag;
@@ -225,7 +226,7 @@ function buildContent(currentPage, locale, geoData, locales) {
     decorateForOnLinkClick(mainAction, locale.prefix);
   }
 
-  const altAction = createTag('a', { lang, href: currentPage.url, 'daa-lh': `Stay:${currentPage.prefix.split('_')[0]}-${locale.prefix.split('_')[0]}|Geo_Routing_Modal` }, currentPage.button);
+  const altAction = createTag('a', { lang, href: currentPage.url }, currentPage.button);
   decorateForOnLinkClick(altAction, currentPage.prefix, locale.prefix);
   const linkWrapper = createTag('div', { class: 'link-wrapper' }, mainAction);
   linkWrapper.appendChild(altAction);


### PR DESCRIPTION
* Add analytics tracking for:
Modal close
Geourouting load
On click of link on georouting pop up when selecting country other than your region (Visiting jp page from US and selecting JP from georouting modal)

All above events have been added to make it same as we see right now on dexter pages as per discussion with analytics team

Resolves: [MWPW-134229](https://jira.corp.adobe.com/browse/MWPW-134229)

**Test URLs:**

To verify georouting

- Before: https://modal-analytics--milo--adobecom.hlx.page/de/
- After: https://modal-analytics--milo--ruchika4.hlx.page/de/

To verify tracking on close for other modal (Click on Learn More button to open the modal):

- Before: https://modal-analytics--milo--adobecom.hlx.page/drafts/ruchika/iframe
- After: https://modal-analytics--milo--ruchika4.hlx.page/drafts/ruchika/iframe

