### PR TITLE
Add analytics tracking to modal

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -30,11 +30,12 @@ export function sendAnalytics(event) {
 
 function closeModal(modal) {
   const { id } = modal;
-  const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
-  const eventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
-  const closeEvent = new Event(`${eventName}:modalClose:buttonClose`);
+  const closeEvent = new Event('milo:modal:closed');
   window.dispatchEvent(closeEvent);
-  sendAnalytics(closeEvent);
+  const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
+  const analyticsEventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
+  const closeEventAnalytics = new Event(`${analyticsEventName}:modalClose:buttonClose`);
+  sendAnalytics(closeEventAnalytics);
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
     if (mod.nextElementSibling?.classList.contains('modal-curtain')) {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
 
 const FOCUSABLES = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
@@ -29,7 +30,8 @@ export function sendAnalytics(event) {
 
 function closeModal(modal) {
   const { id } = modal;
-  const eventName = window.location.hash ? window.location.hash.replaceAll('#', '') : 'localeModal';
+  const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
+  const eventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
   const closeEvent = new Event(`${eventName}:modalClose:buttonClose`);
   window.dispatchEvent(closeEvent);
   sendAnalytics(closeEvent);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -16,10 +16,23 @@ export function findDetails(hash, el) {
   return { id, path, isHash: hash === window.location.hash };
 }
 
+export function sendAnalytics(event) {
+  // eslint-disable-next-line no-underscore-dangle
+  window._satellite?.track('event', {
+    xdm: {},
+    data: {
+      web: { webInteraction: { name: event.type } },
+      _adobe_corpnew: { digitalData: event.data },
+    },
+  });
+}
+
 function closeModal(modal) {
   const { id } = modal;
-  const closeEvent = new Event('milo:modal:closed');
+  const eventName = window.location.hash ? window.location.hash.replaceAll('#', '') : 'localeModal';
+  const closeEvent = new Event(`${eventName}:modalClose:buttonClose`);
   window.dispatchEvent(closeEvent);
+  sendAnalytics(closeEvent);
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
     if (mod.nextElementSibling?.classList.contains('modal-curtain')) {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -22,8 +22,8 @@ export function sendAnalytics(event) {
   window._satellite?.track('event', {
     xdm: {},
     data: {
-      web: { webInteraction: { name: event.type } },
-      _adobe_corpnew: { digitalData: event.data },
+      web: { webInteraction: { name: event?.type } },
+      _adobe_corpnew: { digitalData: event?.data },
     },
   });
 }

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -309,12 +309,12 @@ export default async function loadGeoRouting(
     // Show modal when url and cookie disagree
     if (urlLocale.split('_')[0] !== storedLocale.split('_')[0]) {
       const localeMatches = json.georouting.data.filter(
-        (d) => d.prefix === storedLocale
+        (d) => d.prefix === storedLocale,
       );
       const details = await getDetails(
         urlGeoData,
         localeMatches,
-        json.geos.data
+        json.geos.data,
       );
       if (details) {
         await showModal(details);
@@ -322,8 +322,8 @@ export default async function loadGeoRouting(
           new Event(
             `Load:${urlLocale.split('_')[0]}-${
               storedLocale.split('_')[0]
-            }|Geo_Routing_Modal`
-          )
+            }|Geo_Routing_Modal`,
+          ),
         );
       }
     }
@@ -339,7 +339,7 @@ export default async function loadGeoRouting(
       await showModal(details);
       const modUrlLocale = urlLocale || 'us';
       sendAnalytics(
-        new Event(`Load:${akamaiCode}-${modUrlLocale}|Geo_Routing_Modal`)
+        new Event(`Load:${akamaiCode}-${modUrlLocale}|Geo_Routing_Modal`),
       );
     }
   }

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -315,10 +315,8 @@ export default async function loadGeoRouting(
       const details = await getDetails(urlGeoData, localeMatches, json.geos.data);
       if (details) {
         await showModal(details);
-        const modUrlLocaleGeo = urlLocaleGeo || 'us';
-        const modStoredLocaleGeo = storedLocaleGeo || 'us';
         sendAnalyticsFunc(
-          new Event(`Load:${modUrlLocaleGeo}-${modStoredLocaleGeo}|Geo_Routing_Modal`),
+          new Event(`Load:${urlLocaleGeo || 'us'}-${storedLocaleGeo || 'us'}|Geo_Routing_Modal`),
         );
       }
     }
@@ -332,9 +330,8 @@ export default async function loadGeoRouting(
     const details = await getDetails(urlGeoData, localeMatches, json.geos.data);
     if (details) {
       await showModal(details);
-      const modUrlLocale = urlLocale || 'us';
       sendAnalyticsFunc(
-        new Event(`Load:${akamaiCode}-${modUrlLocale}|Geo_Routing_Modal`),
+        new Event(`Load:${akamaiCode || 'us'}-${urlLocale || 'us'}|Geo_Routing_Modal`),
       );
     }
   }

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -288,6 +288,7 @@ export default async function loadGeoRouting(
 
   const resp = await fetch(`${config.contentRoot ?? ''}/georoutingv2.json`);
   if (!resp.ok) {
+    // eslint-disable-next-line import/no-cycle
     const { default: loadGeoRoutingOld } = await import('../georouting/georouting.js');
     loadGeoRoutingOld(config, createTag, getMetadata);
     return;

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -272,7 +272,13 @@ async function showModal(details) {
   return getModal(null, { class: 'locale-modal-v2', id: 'locale-modal-v2', content: details, closeEvent: 'closeModal' });
 }
 
-export default async function loadGeoRouting(conf, createTagFunc, getMetadataFunc, loadBlockFunc, loadStyleFunc) {
+export default async function loadGeoRouting(
+  conf,
+  createTagFunc,
+  getMetadataFunc,
+  loadBlockFunc,
+  loadStyleFunc,
+) {
   if (getGeoroutingOverride()) return;
   config = conf;
   createTag = createTagFunc;
@@ -282,7 +288,9 @@ export default async function loadGeoRouting(conf, createTagFunc, getMetadataFun
 
   const resp = await fetch(`${config.contentRoot ?? ''}/georoutingv2.json`);
   if (!resp.ok) {
-    const { default: loadGeoRoutingOld } = await import('../georouting/georouting.js');
+    const { default: loadGeoRoutingOld } = await import(
+      '../georouting/georouting.js'
+    );
     loadGeoRoutingOld(config, createTag, getMetadata);
     return;
   }
@@ -300,11 +308,23 @@ export default async function loadGeoRouting(conf, createTagFunc, getMetadataFun
   if (storedLocale || storedLocale === '') {
     // Show modal when url and cookie disagree
     if (urlLocale.split('_')[0] !== storedLocale.split('_')[0]) {
-      const localeMatches = json.georouting.data.filter((d) => d.prefix === storedLocale);
-      const details = await getDetails(urlGeoData, localeMatches, json.geos.data);
+      const localeMatches = json.georouting.data.filter(
+        (d) => d.prefix === storedLocale
+      );
+      const details = await getDetails(
+        urlGeoData,
+        localeMatches,
+        json.geos.data
+      );
       if (details) {
         await showModal(details);
-        sendAnalytics(new Event(`Load:${urlLocale.split('_')[0]}-${storedLocale.split('_')[0]}|Geo_Routing_Modal`));
+        sendAnalytics(
+          new Event(
+            `Load:${urlLocale.split('_')[0]}-${
+              storedLocale.split('_')[0]
+            }|Geo_Routing_Modal`
+          )
+        );
       }
     }
     return;
@@ -318,7 +338,9 @@ export default async function loadGeoRouting(conf, createTagFunc, getMetadataFun
     if (details) {
       await showModal(details);
       const modUrlLocale = urlLocale || 'us';
-      sendAnalytics(new Event(`Load:${akamaiCode}-${modUrlLocale}|Geo_Routing_Modal`));
+      sendAnalytics(
+        new Event(`Load:${akamaiCode}-${modUrlLocale}|Geo_Routing_Modal`)
+      );
     }
   }
 }

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -111,16 +111,16 @@ function getGeoroutingOverride() {
   return hideGeorouting === 'on';
 }
 
-function decorateForOnLinkClick(link, prefix, currPrefix) {
+function decorateForOnLinkClick(link, urlPrefix, localePrefix) {
   link.addEventListener('click', () => {
-    const modPrefix = prefix || 'us';
+    const modPrefix = urlPrefix || 'us';
     // set cookie so legacy code on adobecom still works properly.
     const domain = window.location.host === 'adobe.com'
       || window.location.host.endsWith('.adobe.com') ? 'domain=adobe.com' : '';
     document.cookie = `international=${modPrefix};path=/;${domain}`;
     link.closest('.dialog-modal').dispatchEvent(new Event('closeModal'));
-    if (currPrefix !== undefined) {
-      const modCurrPrefix = currPrefix || 'us';
+    if (localePrefix !== undefined) {
+      const modCurrPrefix = localePrefix || 'us';
       sendAnalyticsFunc(new Event(`Stay:${modPrefix.split('_')[0]}-${modCurrPrefix.split('_')[0]}|Geo_Routing_Modal`));
     }
   });

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -318,7 +318,7 @@ export default async function loadGeoRouting(conf, createTagFunc, getMetadataFun
     if (details) {
       await showModal(details);
       const modUrlLocale = urlLocale || 'us';
-      sendAnalytics(new Event(`Load:${modUrlLocale}-${urlLocale.split('_')[0]}|Geo_Routing_Modal`));
+      sendAnalytics(new Event(`Load:${akamaiCode}-${modUrlLocale}|Geo_Routing_Modal`));
     }
   }
 }

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -317,8 +317,8 @@ export default async function loadGeoRouting(conf, createTagFunc, getMetadataFun
     const details = await getDetails(urlGeoData, localeMatches, json.geos.data);
     if (details) {
       await showModal(details);
-      const modAkamaiCode = akamaiCode || 'us';
-      sendAnalytics(new Event(`Load:${urlLocale.split('_')[0]}-${modAkamaiCode}|Geo_Routing_Modal`));
+      const modUrlLocale = urlLocale || 'us';
+      sendAnalytics(new Event(`Load:${modUrlLocale}-${urlLocale.split('_')[0]}|Geo_Routing_Modal`));
     }
   }
 }

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -1,11 +1,9 @@
-/* eslint-disable import/no-cycle */
-import { sendAnalytics } from '../../blocks/modal/modal.js';
-
 let config;
 let createTag;
 let getMetadata;
 let loadBlock;
 let loadStyle;
+let sendAnalyticsFunc;
 
 const createTabsContainer = (tabNames) => {
   const ol = createTag('ol');
@@ -123,7 +121,7 @@ function decorateForOnLinkClick(link, prefix, currPrefix) {
     link.closest('.dialog-modal').dispatchEvent(new Event('closeModal'));
     if (currPrefix !== undefined) {
       const modCurrPrefix = currPrefix || 'us';
-      sendAnalytics(new Event(`Stay:${modPrefix.split('_')[0]}-${modCurrPrefix.split('_')[0]}|Geo_Routing_Modal`));
+      sendAnalyticsFunc(new Event(`Stay:${modPrefix.split('_')[0]}-${modCurrPrefix.split('_')[0]}|Geo_Routing_Modal`));
     }
   });
 }
@@ -268,7 +266,8 @@ async function showModal(details) {
     loadStyle(`${miloLibs || codeRoot}/features/georoutingv2/georoutingv2.css`),
   ];
   await Promise.all(promises);
-  const { getModal } = await import('../../blocks/modal/modal.js');
+  const { getModal, sendAnalytics } = await import('../../blocks/modal/modal.js');
+  sendAnalyticsFunc = sendAnalytics;
   return getModal(null, { class: 'locale-modal-v2', id: 'locale-modal-v2', content: details, closeEvent: 'closeModal' });
 }
 
@@ -316,7 +315,7 @@ export default async function loadGeoRouting(
         await showModal(details);
         const modUrlLocaleGeo = urlLocaleGeo || 'us';
         const modStoredLocaleGeo = storedLocaleGeo || 'us';
-        sendAnalytics(
+        sendAnalyticsFunc(
           new Event(`Load:${modUrlLocaleGeo}-${modStoredLocaleGeo}|Geo_Routing_Modal`),
         );
       }
@@ -332,7 +331,7 @@ export default async function loadGeoRouting(
     if (details) {
       await showModal(details);
       const modUrlLocale = urlLocale || 'us';
-      sendAnalytics(
+      sendAnalyticsFunc(
         new Event(`Load:${akamaiCode}-${modUrlLocale}|Geo_Routing_Modal`),
       );
     }

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -316,7 +316,7 @@ export default async function loadGeoRouting(
       if (details) {
         await showModal(details);
         sendAnalyticsFunc(
-          new Event(`Load:${urlLocaleGeo || 'us'}-${storedLocaleGeo || 'us'}|Geo_Routing_Modal`),
+          new Event(`Load:${storedLocaleGeo || 'us'}-${urlLocaleGeo || 'us'}|Geo_Routing_Modal`),
         );
       }
     }
@@ -331,7 +331,7 @@ export default async function loadGeoRouting(
     if (details) {
       await showModal(details);
       sendAnalyticsFunc(
-        new Event(`Load:${akamaiCode || 'us'}-${urlLocale || 'us'}|Geo_Routing_Modal`),
+        new Event(`Load:${urlLocale || 'us'}-${akamaiCode || 'us'}|Geo_Routing_Modal`),
       );
     }
   }

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -219,7 +219,7 @@ function buildContent(currentPage, locale, geoData, locales) {
     decorateForOnLinkClick(mainAction, locale.prefix);
   }
 
-  const altAction = createTag('a', { lang, href: currentPage.url }, currentPage.button);
+  const altAction = createTag('a', { lang, href: currentPage.url, 'daa-lh': `Stay:${currentPage.prefix.split('_')[0]}-${locale.prefix.split('_')[0]}|Geo_Routing_Modal` }, currentPage.button);
   decorateForOnLinkClick(altAction, currentPage.prefix);
   const linkWrapper = createTag('div', { class: 'link-wrapper' }, mainAction);
   linkWrapper.appendChild(altAction);

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -1,4 +1,5 @@
-import {sendAnalytics} from '../../blocks/modal/modal.js';
+/* eslint-disable import/no-cycle */
+import { sendAnalytics } from '../../blocks/modal/modal.js';
 
 let config;
 let createTag;
@@ -225,7 +226,7 @@ function buildContent(currentPage, locale, geoData, locales) {
     decorateForOnLinkClick(mainAction, locale.prefix);
   }
 
-  const altAction = createTag('a', { lang, href: currentPage.url, 'daa-lh': `Stay:${currentPage.prefix.split('_')[0]}-${locale.prefix.split('_')[0]}|Geo_Routing_Modal` }, currentPage.button);
+  const altAction = createTag('a', { lang, href: currentPage.url }, currentPage.button);
   decorateForOnLinkClick(altAction, currentPage.prefix, locale.prefix);
   const linkWrapper = createTag('div', { class: 'link-wrapper' }, mainAction);
   linkWrapper.appendChild(altAction);

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -266,6 +266,7 @@ async function showModal(details) {
     loadStyle(`${miloLibs || codeRoot}/features/georoutingv2/georoutingv2.css`),
   ];
   await Promise.all(promises);
+  // eslint-disable-next-line import/no-cycle
   const { getModal, sendAnalytics } = await import('../../blocks/modal/modal.js');
   sendAnalyticsFunc = sendAnalytics;
   return getModal(null, { class: 'locale-modal-v2', id: 'locale-modal-v2', content: details, closeEvent: 'closeModal' });

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -317,7 +317,8 @@ export default async function loadGeoRouting(conf, createTagFunc, getMetadataFun
     const details = await getDetails(urlGeoData, localeMatches, json.geos.data);
     if (details) {
       await showModal(details);
-      sendAnalytics(new Event(`Load:${urlLocale.split('_')[0]}-${akamaiCode}|Geo_Routing_Modal`));
+      const modAkamaiCode = akamaiCode || 'us';
+      sendAnalytics(new Event(`Load:${urlLocale.split('_')[0]}-${modAkamaiCode}|Geo_Routing_Modal`));
     }
   }
 }


### PR DESCRIPTION
* Add analytics tracking for:
Modal close
Geourouting load
On click of link on georouting pop up when selecting country other than your region (Visiting jp page from US and selecting JP from georouting modal)

All above events have been added to make it same as we see right now on dexter pages as per discussion with analytics team

Resolves: [MWPW-134229](https://jira.corp.adobe.com/browse/MWPW-134229)
[MWPW-134229](https://jira.corp.adobe.com/browse/MWPW-130145)

**Test URLs:**

To verify georouting

- Before: https://modal-analytics--milo--adobecom.hlx.page/de/
- After: https://modal-analytics--milo--ruchika4.hlx.page/de/

To verify tracking on close for other modal (Click on Learn More button to open the modal):

- Before: https://modal-analytics--milo--adobecom.hlx.page/drafts/ruchika/iframe
- After: https://modal-analytics--milo--ruchika4.hlx.page/drafts/ruchika/iframe

CC:

- Before: https://main--cc--adobecom.hlx.page/creativecloud/animation/discover?akamaiLocale=ru
- After: https://main--cc--adobecom.hlx.page/creativecloud/animation/discover?milolibs=modal-analytics--milo--ruchika4&akamaiLocale=ru

Bacom:
- Before: https://main--bacom--adobecom.hlx.page/de/customer-success-stories
- After: https://main--bacom--adobecom.hlx.page/de/customer-success-stories?milolibs=modal-analytics--milo--ruchika4


