### PR TITLE
iframe window opened in mobile view is too small 

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -166,3 +166,11 @@
     max-width: calc((100% - 6px) - 2em);
   } 
 }
+
+@media (max-width: 1200px) {
+  .dialog-modal {
+    width:100%;
+    max-width:100%;
+    max-height:100%;
+  }
+}

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -168,9 +168,9 @@
 }
 
 @media (max-width: 1200px) {
-  .dialog-modal {
-    width:100%;
-    max-width:100%;
-    max-height:100%;
+  .dialog-modal.commerce-frame {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100%;
   }
 }

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -141,6 +141,7 @@
   margin: 0;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .region-selector .content {
   column-count: 1;
 }

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -8,6 +8,8 @@ const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="2
     <line x1="8" y1="8" transform="translate(10506 -3397)" fill="none" stroke="#fff" stroke-width="2"/>
   </g>
 </svg>`;
+const MOBILE_MAX = 599;
+const TABLET_MAX = 1199;
 
 export function findDetails(hash, el) {
   const id = hash.replace('#', '');
@@ -160,5 +162,17 @@ window.addEventListener('hashchange', (e) => {
   } else {
     const details = findDetails(window.location.hash, null);
     if (details) getModal(details);
+  }
+});
+
+function sendViewportDimensionsToiFrame(source) {
+  const viewportWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
+  source.postMessage({ mobileMax: MOBILE_MAX, tabletMax: TABLET_MAX, viewportWidth }, '*');
+}
+
+window.addEventListener('message', (t) => {
+  if (t.data === 'viewportWidth') {
+    sendViewportDimensionsToiFrame(t.source);
+    window.addEventListener('resize', () => sendViewportDimensionsToiFrame(t.source));
   }
 });

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -9,6 +9,7 @@ const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="2
     <line x1="8" y1="8" transform="translate(10506 -3397)" fill="none" stroke="#fff" stroke-width="2"/>
   </g>
 </svg>`;
+let isInitailPageLoad = true;
 const MOBILE_MAX = 599;
 const TABLET_MAX = 1199;
 
@@ -153,10 +154,13 @@ export async function getModal(details, custom) {
       .forEach((element) => element.setAttribute('aria-disabled', 'true'));
   }
   if (dialog.classList.contains('commerce-frame')) {
-    const { debounce } = await import('../../utils/action.js');
-    window.addEventListener('message', (messageInfo) => {
-      debounce(sendViewportDimensionsOnRequest(messageInfo));
-    });
+    if (isInitailPageLoad) {
+      const { debounce } = await import('../../utils/action.js');
+      window.addEventListener('message', (messageInfo) => {
+        debounce(sendViewportDimensionsOnRequest(messageInfo));
+      });
+      isInitailPageLoad = false;
+    }
   }
   return dialog;
 }

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -75,7 +75,7 @@ function sendViewportDimensionsToiFrame(source) {
   source.postMessage({ mobileMax: MOBILE_MAX, tabletMax: TABLET_MAX, viewportWidth }, '*');
 }
 
-function sendViewportDimensionsOnRequest(messageInfo) {
+export function sendViewportDimensionsOnRequest(messageInfo) {
   if (messageInfo.data === 'viewportWidth') {
     sendViewportDimensionsToiFrame(messageInfo.source);
     window.addEventListener('resize', () => sendViewportDimensionsToiFrame(messageInfo.source));

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-cycle
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
 
 const FOCUSABLES = 'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
@@ -67,6 +68,7 @@ async function getPathModal(path, dialog) {
   const block = createTag('a', { href: path });
   dialog.append(block);
 
+  // eslint-disable-next-line import/no-cycle
   const { default: getFragment } = await import('../fragment/fragment.js');
   await getFragment(block);
 }
@@ -150,7 +152,7 @@ export async function getModal(details, custom) {
     [...document.querySelectorAll('header, main, footer')]
       .forEach((element) => element.setAttribute('aria-disabled', 'true'));
   }
-  if (dialog.classList.toString().includes('commerce-frame')) {
+  if (dialog.classList.contains('commerce-frame')) {
     const { debounce } = await import('../../utils/action.js');
     window.addEventListener('message', (messageInfo) => {
       debounce(sendViewportDimensionsOnRequest(messageInfo));

--- a/libs/styles/iframe.css
+++ b/libs/styles/iframe.css
@@ -25,3 +25,9 @@
     height: 1500px;
     padding-bottom: 0;
 }
+
+@media (max-width: 1200px) {
+  .milo-iframe{
+    padding-bottom:100vh;
+  }
+}

--- a/libs/styles/iframe.css
+++ b/libs/styles/iframe.css
@@ -27,7 +27,7 @@
 }
 
 @media (max-width: 1200px) {
-  .milo-iframe{
+  .dialog-modal.commerce-frame .milo-iframe{
     padding-bottom:100vh;
   }
 }

--- a/test/blocks/modals/mocks/body.html
+++ b/test/blocks/modals/mocks/body.html
@@ -5,6 +5,13 @@
   .modal-curtain.is-open {
     background: rgb(50 50 50 / 80%);
   }
+  @media (max-width: 1200px) {
+  .dialog-modal.commerce-frame {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100%;
+  }
+}
 </style>
 
 <a id="milo-modal-link" href="https://milo.adobe.com/test/blocks/modals/mocks/milo"

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -1,9 +1,9 @@
-import { readFile, sendKeys } from '@web/test-runner-commands';
+import { readFile, sendKeys, setViewport } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { delay, waitForElement, waitForRemoval } from '../../helpers/waitfor.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
-const { default: init, getModal } = await import('../../../libs/blocks/modal/modal.js');
+const { default: init, getModal, sendViewportDimensionsOnRequest } = await import('../../../libs/blocks/modal/modal.js');
 
 describe('Modals', () => {
   it('Doesnt load modals on page load with no hash', async () => {
@@ -152,5 +152,22 @@ describe('Modals', () => {
     expect(document.activeElement.getAttribute('id')).to.equal('test-title');
     window.location.hash = '';
     await waitForRemoval('#title');
+  });
+
+  it('checks if dialog modal has the 100% screen width when screen with is less than 1200', async () => {
+    await setViewport({ width: 600, height: 100 });
+    window.location.hash = '#milo';
+    await waitForElement('#milo');
+    await getModal({ id: 'animate', path: '/cc-shared/fragments/trial-modals/animate', isHash: true });
+    sendViewportDimensionsOnRequest({ data: 'viewportWidth', source: window });
+    const dialogmodal = document.getElementsByClassName('dialog-modal')[0];
+    dialogmodal.classList.add('commerce-frame');
+    expect(window.innerWidth).to.equal(dialogmodal.offsetWidth);
+  });
+
+  it('checks if dialog modal is less than screen size if it does not have commerce frame class and screen size is less than 1200', async () => {
+    const dialogmodal = document.getElementsByClassName('dialog-modal')[0];
+    dialogmodal.classList.remove('commerce-frame');
+    expect(window.innerWidth).not.equal(dialogmodal.offsetWidth);
   });
 });


### PR DESCRIPTION
* iframe window opened in mobile view is too small , not able to see the complete details to do the payment flow.

Resolves: [MWPW-133983](https://jira.corp.adobe.com/browse/MWPW-133983)

**Test URLs:**
- Before: https://stage--cc--adobecom.hlx.page/drafts/ruchika/discover1?martech=off#animate
- After: https://stage--cc--adobecom.hlx.page/drafts/ruchika/discover1?martech=off&milolibs=MWPW-133983--milo--sharath-kannan#animate

![before](https://github.com/adobecom/milo/assets/138484653/a5df8d65-cfee-4ba0-b406-89ae92d607f1)

This is how the modal should look after the PR merge.
<img width="1472" alt="After" src="https://github.com/adobecom/milo/assets/138484653/0c9cedd0-6e9c-4984-8aa0-d9ad2d507106">

