### PR TITLE
[Global-navigation] Fix an undefined error 

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -317,7 +317,6 @@ class Gnav {
   imsReady = async () => {
     const tasks = [
       this.decorateProfile,
-      this.decorateAppLauncher,
     ];
     try {
       for await (const task of tasks) {


### PR DESCRIPTION
### Description
We currently don't support the app launcher and removed the placeholder function here https://github.com/adobecom/milo/pull/1015/files

This rightfully pops up in the lana logs, no error is seen in the console as it's caught and logged to lana only.

**Test URLs:**
Before: https://main--milo--adobecom.hlx.page?martech=off
After: https://fix-undefined-error--milo--mokimo.hlx.page?martech=off