### PR TITLE
MWPW-134424 | Center notification buttons are not center aligned

### DIFF
--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -361,6 +361,10 @@
   justify-content: center;
 }
 
+.aside.notification.center .foreground.container .action-area {
+  justify-content: center;
+}
+
 .aside.notification.center.small .foreground.container .text,
 .aside.notification.center.small .foreground.container .text > * {
   justify-content: flex-start;


### PR DESCRIPTION
Medium center notification button are not center aligned. 
Adding the explicit center aligning for button section in notification center

Resolves: [MWPW-134424](https://jira.corp.adobe.com/browse/MWPW-134424)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/mathuria/aside/aside?martech=off
- After: https://notccenter--milo--aishwaryamathuria.hlx.page/drafts/mathuria/aside/aside?martech=off
