### PR TITLE
[Global-navigation] Localise breadcrumb links

### DIFF
--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -1,4 +1,4 @@
-import { getMetadata } from '../../../../utils/utils.js';
+import { getMetadata, localizeLink } from '../../../../utils/utils.js';
 import { toFragment, lanaLog } from '../../utilities/utilities.js';
 
 const metadata = {
@@ -35,17 +35,11 @@ const setBreadcrumbSEO = (breadcrumbs) => {
   document.head.append(script);
 };
 
-const getHiddenEntries = (str) => str
-  ?.toLowerCase()
-  .split(',')
-  .map((item) => item.trim()) || [];
-
-const removeHiddenEntries = ({ ul }) => {
-  const hidden = getHiddenEntries(getMetadata(metadata.hiddenEntries));
-  if (!hidden.length) return;
-  ul.querySelectorAll('li').forEach(
-    (li) => hidden.includes(li.innerText?.toLowerCase().trim()) && li.remove(),
-  );
+const localizeEntries = (anchor) => {
+  if (!anchor) return null;
+  const href = anchor.getAttribute('href');
+  anchor.setAttribute('href', localizeLink(href));
+  return null;
 };
 
 const createBreadcrumbs = (element) => {
@@ -59,7 +53,18 @@ const createBreadcrumbs = (element) => {
       </li>
     `);
   }
-  removeHiddenEntries({ ul });
+
+  const hiddenEntries = getMetadata(metadata.hiddenEntries)
+    ?.toLowerCase()
+    .split(',')
+    .map((item) => item.trim()) || [];
+
+  ul.querySelectorAll('li').forEach(
+    (li) => {
+      if (hiddenEntries.includes(li.innerText?.toLowerCase().trim())) return li.remove();
+      return localizeEntries(li.querySelector('a'));
+    },
+  );
   const breadcrumbs = toFragment`
     <div class="feds-breadcrumbs-wrapper">
       <nav class="feds-breadcrumbs" aria-label="Breadcrumb">${ul}</nav>

--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -36,10 +36,9 @@ const setBreadcrumbSEO = (breadcrumbs) => {
 };
 
 const localizeEntries = (anchor) => {
-  if (!anchor) return null;
+  if (!anchor) return;
   const href = anchor.getAttribute('href');
   anchor.setAttribute('href', localizeLink(href));
-  return null;
 };
 
 const createBreadcrumbs = (element) => {

--- a/test/blocks/global-navigation/features/breadcrumbs.test.js
+++ b/test/blocks/global-navigation/features/breadcrumbs.test.js
@@ -3,6 +3,8 @@ import { stub } from 'sinon';
 import breadcrumbs from '../../../../libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js';
 import { toFragment } from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
 import { mockRes } from '../test-utilities.js';
+import { setConfig } from '../../../../libs/utils/utils.js';
+import { getConfig } from '../../../../tools/send-to-caas/send-utils.js';
 
 export const breadcrumbMock = () => toFragment`
   <div class="breadcrumbs">
@@ -10,7 +12,7 @@ export const breadcrumbMock = () => toFragment`
       <div>
         <ul>
           <li><a href="http://www.google.com/">1-from-page</a></li>
-          <li><a href="http://www.future-releases.com/">Future Releases</a></li>
+          <li><a href="http://localhost:2000/">Future Releases</a></li>
           <li><a href="http://www.adobe.com/">Actors</a></li>
           <li>Players</li>
         </ul>
@@ -85,7 +87,7 @@ describe('breadcrumbs', () => {
             '@type': 'ListItem',
             position: 2,
             name: 'Future Releases',
-            item: 'http://www.future-releases.com/',
+            item: 'http://localhost:2000/',
           },
           {
             '@type': 'ListItem',
@@ -127,5 +129,48 @@ describe('breadcrumbs', () => {
         .querySelector('ul li:last-of-type')
         .getAttribute('aria-current'),
     ).to.equal('page');
+  });
+
+  it('should localize breadcrumb links', async () => {
+    setConfig({
+      locales: {
+        '': { ietf: 'en-US' },
+        fi: { ietf: 'fi-FI' },
+      },
+      pathname: '/fi/',
+      prodDomains: 'http://localhost:2000',
+    });
+
+    await breadcrumbs(breadcrumbMock());
+    const script = document.querySelector('script');
+    expect(script).to.exist;
+    expect(script.type).to.equal('application/ld+json');
+    expect(JSON.parse(script.innerHTML)).to.deep.equal(
+      {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: '1-from-page',
+            item: 'http://www.google.com/',
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Future Releases',
+            item: 'http://localhost:2000/fi/', // <-- localised prod domain
+          },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: 'Actors',
+            item: 'http://www.adobe.com/',
+          },
+          { '@type': 'ListItem', position: 4, name: 'Players' },
+        ],
+      },
+    );
   });
 });

--- a/test/blocks/global-navigation/features/breadcrumbs.test.js
+++ b/test/blocks/global-navigation/features/breadcrumbs.test.js
@@ -4,7 +4,6 @@ import breadcrumbs from '../../../../libs/blocks/global-navigation/features/brea
 import { toFragment } from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
 import { mockRes } from '../test-utilities.js';
 import { setConfig } from '../../../../libs/utils/utils.js';
-import { getConfig } from '../../../../tools/send-to-caas/send-utils.js';
 
 export const breadcrumbMock = () => toFragment`
   <div class="breadcrumbs">


### PR DESCRIPTION
### Description
Breadcrumb links are currently not localised - but they should be.
Resolves: [MWPW-134457](https://jira.corp.adobe.com/browse/MWPW-134457)

**Before**
![Screenshot 2023-07-31 at 15 34 16](https://github.com/adobecom/milo/assets/39759830/ea3565d0-ff8e-4b55-93c3-f7578ac67ba2)

**After** 
![Screenshot 2023-07-31 at 15 33 52](https://github.com/adobecom/milo/assets/39759830/02d7af94-7185-48f0-ba38-0c09b16b5436)


**Test URLs:**
- Before: - https://internationalize-breadcrumbs--milo--mokimo.hlx.live?martech=off
- Before: https://main--bacom--adobecom.hlx.live/jp/customer-success-stories?headerqa=global-navigation
- After: https://main--bacom--adobecom.hlx.live/jp/customer-success-stories?headerqa=global-navigation&milolibs=internationalize-breadcrumbs--milo--mokimo

