### PR TITLE
ES lint fixes for section metadata and actions files

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -1,3 +1,20 @@
+export function handleFocalpoint(pic, child, removeChild) {
+  const image = pic.querySelector('img');
+  if (!child || !image) return;
+  let text = '';
+  if (child.childElementCount === 2) {
+    const dataElement = child.querySelectorAll('p')[1];
+    text = dataElement?.textContent;
+    if (removeChild) dataElement?.remove();
+  } else if (child.textContent) {
+    text = child.textContent;
+    const childData = child.childNodes;
+    if (removeChild) childData.forEach((c) => c.nodeType === Node.TEXT_NODE && c.remove());
+  }
+  const directions = text.trim().toLowerCase().split(',');
+  const [x, y = ''] = directions;
+  image.style.objectPosition = `${x} ${y}`;
+}
 function handleBackground(div, section) {
   const pic = div.background.content.querySelector('picture');
   if (pic) {
@@ -13,24 +30,6 @@ function handleBackground(div, section) {
   }
 }
 
-export function handleFocalpoint(pic, child, removeChild) {
-  const image = pic.querySelector('img');
-  if (!child || !image) return;
-  let text = '';
-  if (child.childElementCount === 2) {
-    const dataElement = child.querySelectorAll('p')[1];
-    text = dataElement?.textContent;
-    removeChild ? dataElement?.remove() : '';
-  } else if (child.textContent) {
-    text = child.textContent;
-    const childData = child.childNodes;
-    removeChild ? childData.forEach((c) => c.nodeType === Node.TEXT_NODE && c.remove()) : '';
-  }
-  const directions = text.trim().toLowerCase().split(',');
-  const [x, y = ''] = directions;
-  image.style.objectPosition = `${x} ${y}`;
-}
-
 function handleTopHeight(section) {
   const headerHeight = document.querySelector('header').offsetHeight;
   section.style.top = `${headerHeight}px`;
@@ -39,15 +38,19 @@ async function handleStickySection(sticky, section) {
   const main = document.querySelector('main');
   switch (sticky) {
     case 'sticky-top':
+    {
       const { debounce } = await import('../../utils/action.js');
       window.addEventListener('resize', debounce(() => handleTopHeight(section)));
       main.prepend(section);
       break;
+    }
     case 'sticky-bottom':
+    {
       main.append(section);
       break;
+    }
     default:
-      break;
+    { break; }
   }
 }
 

--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -16,14 +16,14 @@ export function handleFocalpoint(pic, child, removeChild) {
   image.style.objectPosition = `${x} ${y}`;
 }
 function handleBackground(div, section) {
-  const pic = div.background.content.querySelector('picture');
+  const pic = div.background.content?.querySelector('picture');
   if (pic) {
     section.classList.add('has-background');
     pic.classList.add('section-background');
     handleFocalpoint(pic, div.background.content);
     section.insertAdjacentElement('afterbegin', pic);
   } else {
-    const color = div.background.content.textContent;
+    const color = div.background.content?.textContent;
     if (color) {
       section.style.background = color;
     }
@@ -45,12 +45,10 @@ async function handleStickySection(sticky, section) {
       break;
     }
     case 'sticky-bottom':
-    {
       main.append(section);
       break;
-    }
     default:
-    { break; }
+      break;
   }
 }
 

--- a/libs/utils/action.js
+++ b/libs/utils/action.js
@@ -8,4 +8,5 @@ export function debounce(callback, time = 300) {
     timer = setTimeout(() => callback(...args), time);
   };
 }
+
 export default { debounce };

--- a/libs/utils/action.js
+++ b/libs/utils/action.js
@@ -8,3 +8,4 @@ export function debounce(callback, time = 300) {
     timer = setTimeout(() => callback(...args), time);
   };
 }
+export default { debounce };


### PR DESCRIPTION
* addresses as few eslint warnings showing up in the `section-metadata.js` & `action.js` files

Resolves: NA
Before
<img width="1343" alt="Screen Shot 2023-08-02 at 3 35 49 PM" src="https://github.com/adobecom/milo/assets/2086146/df1e5d40-9654-4878-b85c-3e1a66fbfb1f">

After
<img width="1423" alt="Screen Shot 2023-08-02 at 3 36 16 PM" src="https://github.com/adobecom/milo/assets/2086146/7e6dfec5-9aad-4ddb-a6b8-1de97c30564a">


**Test URLs:**
This update is all code format, there will be no difference between these before/after urls. 
- Before BG image test: https://main--milo--adobecom.hlx.page/drafts/suhjain/background-image-test?martech=off
- After BG image test: https://rparrish-section-lint--milo--adobecom.hlx.page/drafts/suhjain/background-image-test?martech=off

- Before sticky: https://main--milo--adobecom.hlx.page/drafts/rclayton/poc/sticky?martech=off
- After sticky: https://rparrish-section-lint--milo--adobecom.hlx.page/drafts/rclayton/poc/sticky?martech=off
