### PR TITLE
Mep button on target only

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -475,10 +475,16 @@ function cleanManifestList(manifests) {
 }
 
 export async function applyPers(manifests) {
-  if (!manifests?.length) return;
-  const cleanedManifests = cleanManifestList(manifests);
-
   const config = getConfig();
+
+  if (!manifests?.length) {
+    if (config.mep?.preview) {
+      const { default: decoratePreviewMode } = await import('./preview.js');
+      decoratePreviewMode([]);
+    }
+    return;
+  }
+  const cleanedManifests = cleanManifestList(manifests);
 
   let results = [];
   for (const manifest of cleanedManifests) {

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -474,14 +474,18 @@ function cleanManifestList(manifests) {
   return cleanedList;
 }
 
+const decoratePreviewCheck = async (config, experiments) => {
+  if (config.mep?.preview) {
+    const { default: decoratePreviewMode } = await import('./preview.js');
+    decoratePreviewMode(experiments);
+  }
+};
+
 export async function applyPers(manifests) {
   const config = getConfig();
 
   if (!manifests?.length) {
-    if (config.mep?.preview) {
-      const { default: decoratePreviewMode } = await import('./preview.js');
-      decoratePreviewMode([]);
-    }
+    decoratePreviewCheck(config, []);
     return;
   }
   const cleanedManifests = cleanManifestList(manifests);
@@ -501,8 +505,5 @@ export async function applyPers(manifests) {
     expFragments: consolidateObjects(results, 'fragments'),
   });
 
-  if (config.mep?.preview) {
-    const { default: decoratePreviewMode } = await import('./preview.js');
-    decoratePreviewMode(experiments);
-  }
+  decoratePreviewCheck(config, experiments);
 }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -132,18 +132,11 @@ export default async function init({ persEnabled = false, persManifests }) {
   // eslint-disable-next-line no-underscore-dangle
   window._satellite.track('pageload');
 
-  if (persEnabled) {
-    const targetManifests = await getTargetPersonalization();
-    if (targetManifests || persManifests?.length) {
-      const { preloadManifests } = await import('../features/personalization/manifest-utils.js');
-      const manifests = preloadManifests({ targetManifests, persManifests });
-      const { applyPers } = await import('../features/personalization/personalization.js');
-      await applyPers(manifests);
-    }
-  }
-  if (config.mep.override || config.mep.override === '' || config.env.name === 'stage') {
-    import('../features/personalization/preview.js').then(({ default: decoratePreviewMode }) => {
-      decoratePreviewMode();
-    });
+  const targetManifests = await getTargetPersonalization();
+  if (targetManifests || persManifests?.length) {
+    const { preloadManifests } = await import('../features/personalization/manifest-utils.js');
+    const manifests = preloadManifests({ targetManifests, persManifests });
+    const { applyPers } = await import('../features/personalization/personalization.js');
+    await applyPers(manifests);
   }
 }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -141,4 +141,9 @@ export default async function init({ persEnabled = false, persManifests }) {
       await applyPers(manifests);
     }
   }
+  if (config.mep.override || config.mep.override === '' || config.env.name === 'stage') {
+    import('../features/personalization/preview.js').then(({ default: decoratePreviewMode }) => {
+      decoratePreviewMode();
+    });
+  }
 }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -134,11 +134,14 @@ export default async function init({ persEnabled = false, persManifests }) {
 
   if (persEnabled) {
     const targetManifests = await getTargetPersonalization();
-    if (targetManifests || persManifests?.length || config.mep.override !== undefined) {
+    if (targetManifests || persManifests?.length) {
       const { preloadManifests } = await import('../features/personalization/manifest-utils.js');
       const manifests = preloadManifests({ targetManifests, persManifests });
       const { applyPers } = await import('../features/personalization/personalization.js');
       await applyPers(manifests);
+    } else if (config.mep.override !== undefined) {
+      import('../features/personalization/preview.js')
+        .then(({ default: decoratePreviewMode }) => decoratePreviewMode([]));
     }
   }
 }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -139,9 +139,6 @@ export default async function init({ persEnabled = false, persManifests }) {
       const manifests = preloadManifests({ targetManifests, persManifests });
       const { applyPers } = await import('../features/personalization/personalization.js');
       await applyPers(manifests);
-    } else if (config.mep.override !== undefined) {
-      import('../features/personalization/preview.js')
-        .then(({ default: decoratePreviewMode }) => decoratePreviewMode([]));
     }
   }
 }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -132,11 +132,13 @@ export default async function init({ persEnabled = false, persManifests }) {
   // eslint-disable-next-line no-underscore-dangle
   window._satellite.track('pageload');
 
-  const targetManifests = await getTargetPersonalization();
-  if (targetManifests || persManifests?.length) {
-    const { preloadManifests } = await import('../features/personalization/manifest-utils.js');
-    const manifests = preloadManifests({ targetManifests, persManifests });
-    const { applyPers } = await import('../features/personalization/personalization.js');
-    await applyPers(manifests);
+  if (persEnabled) {
+    const targetManifests = await getTargetPersonalization();
+    if (targetManifests || persManifests?.length || config.mep.override !== undefined) {
+      const { preloadManifests } = await import('../features/personalization/manifest-utils.js');
+      const manifests = preloadManifests({ targetManifests, persManifests });
+      const { applyPers } = await import('../features/personalization/personalization.js');
+      await applyPers(manifests);
+    }
   }
 }


### PR DESCRIPTION
If a page has the mep parameter, the MEP button should show.  This was not happening if the following conditions were both true:
* Target was on
* There were no manifests
If there were manifests or Target was off, the button properly showed.

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.page/?mep
- After: https://main--homepage--adobecom.hlx.page/?milolibs=mep-button-on-target-only&mep
