### PR TITLE
[MWPW-134624] Space out column sections in GNAV full-width dropdown

### DIFF
--- a/libs/blocks/global-navigation/utilities/menu/menu.css
+++ b/libs/blocks/global-navigation/utilities/menu/menu.css
@@ -76,7 +76,6 @@
   display: none;
 }
 
-/* Start mobile styles */
 @media (min-width: 900px) {
   .feds-menu-content {
     display: flex;
@@ -87,6 +86,10 @@
 
   .feds-menu-column {
     padding: 12px 0;
+  }
+
+  .feds-menu-section + .feds-menu-section {
+    margin-top: 12px;
   }
 
   .feds-menu-headline {


### PR DESCRIPTION
This spaces out consecutive sections in the full width dropdown menu columns to provide a visual representation of context separation. The `12px` value has been taken from how content producers authored the current AEM-based Gnav on production.

Screenshots:
| Before | After |
| ------------- | ------------- |
| <img width="1460" alt="No section gap" src="https://github.com/adobecom/milo/assets/11267498/dbb34164-e471-409d-956c-f30526883bce"> | <img width="1460" alt="Section gap" src="https://github.com/adobecom/milo/assets/11267498/e78e596c-4ebd-4450-80b2-8305d3765c22"> |

Resolves: [MWPW-134624](https://jira.corp.adobe.com/browse/MWPW-134624)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
- After: https://gnav-section-spacing--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
