### PR TITLE
[Workflow] MWPW-134543 Dispatch DC workflow when main is changed

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,32 @@
+name: Dispatch workflows
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch-dc:
+    name: Dispatch DC workflow
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3    
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'libs/**'    
+      - if: steps.changes.outputs.src == 'true'
+        name: Trigger DC Workflow
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DC_PAT }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'adobecom',
+              repo: 'dc',
+              workflow_id: 'test-milo.yml',
+              ref: 'main',
+            }) 


### PR DESCRIPTION
* It creates a workflow dispatch to DC repo when there is a change to main
* DC repo will trigger necessary tests to ensure the change in Milo doesn't break DC pages
* Will add PRs later when shift-left is needed
* Other consuming teams can add their dispatches to jobs

Resolves: [MWPW-134543](https://jira.corp.adobe.com/browse/MWPW-134543)

**Test URLs:**
- N/A
