### PR TITLE
MWPW-130312 Adding Consumer Tags to Tag Selector

### DIFF
--- a/libs/blocks/tag-selector/tag-selector.css
+++ b/libs/blocks/tag-selector/tag-selector.css
@@ -76,3 +76,36 @@
   background: transparent;
   border: none;
 }
+
+/* SPINNER */
+.spinner {
+  border: 2px dotted var(--color-gray-100);
+  border-bottom: 2px dotted var(--color-gray-200);
+  border-left: 2px dotted var(--color-gray-400);
+  border-top: 2px dotted var(--color-gray-800);
+  border-radius: 50%;
+  width: 1.6rem;
+  height: 1.6rem;
+  -webkit-animation: spin 2s linear infinite;
+  animation: spin 2s linear infinite;
+}
+
+@-webkit-keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/libs/blocks/tag-selector/tag-selector.css
+++ b/libs/blocks/tag-selector/tag-selector.css
@@ -77,8 +77,8 @@
   border: none;
 }
 
-/* SPINNER */
-.spinner {
+.tag-selector .spinner {
+  margin-top: 10px;
   border: 2px dotted var(--color-gray-100);
   border-bottom: 2px dotted var(--color-gray-200);
   border-left: 2px dotted var(--color-gray-400);

--- a/libs/blocks/tag-selector/tag-selector.js
+++ b/libs/blocks/tag-selector/tag-selector.js
@@ -2,6 +2,17 @@ import { html, render, useState, useEffect } from '../../deps/htm-preact.js';
 import Picker from '../../ui/controls/TagSelectPicker.js';
 import { loadCaasTags } from '../caas/utils.js';
 
+const CAAS_LABEL = 'CaaS';
+
+async function fetchData(url) {
+  const resp = await fetch(url.toLowerCase());
+
+  if (!resp.ok) throw new Error('Network error');
+
+  const json = await resp.json();
+  return json;
+}
+
 const TagPreview = ({ selectedTags = [] }) => {
   const [copyText, setCopyText] = useState('Copy');
 
@@ -27,14 +38,17 @@ const TagPreview = ({ selectedTags = [] }) => {
   `;
 };
 
-const TagSelector = () => {
+const TagSelector = ({ consumerUrls = [] }) => {
+  const [tagSelectorTags, setTagSelectorTags] = useState({});
   const [options, setOptions] = useState();
   const [selectedTags, setSelectedTags] = useState([]);
-  const [optionMap, setOptionMap] = useState({});
-  const tagUrl = 'https://www.adobe.com/chimera-api/tags';
+  const [previewTags, setPreviewTags] = useState([]);
+  const [optionMap, setOptionMap] = useState();
+  const [selected, setSelected] = useState(CAAS_LABEL);
+  const caasTagUrl = 'https://www.adobe.com/chimera-api/tags';
 
   const getTagTree = (root) => {
-    const options = Object.entries(root).reduce((opts, [, tag]) => {
+    const caasOptions = Object.entries(root).reduce((opts, [, tag]) => {
       opts[tag.tagID] = {};
 
       if (Object.keys(tag.tags).length) {
@@ -46,19 +60,19 @@ const TagSelector = () => {
 
       return opts;
     }, {});
-    return options;
+    return caasOptions;
   };
 
   const createOptionMap = (root) => {
     const newOptionMap = {};
     const parseNode = (nodes, parent) => {
       Object.entries(nodes).forEach(([key, val]) => {
-        newOptionMap[key] = val;
+        newOptionMap[key] = { ...val };
         if (parent) {
           newOptionMap[key].parent = parent;
         }
         if (val.children) {
-          parseNode(val.children, val);
+          parseNode(val.children, newOptionMap[key]);
         }
       });
     };
@@ -66,20 +80,97 @@ const TagSelector = () => {
     return newOptionMap;
   };
 
-  useEffect(async () => {
-    const { tags: caasTags, errorMsg } = await loadCaasTags(tagUrl);
+  const splitChildren = (tag, path) => {
+    const parts = path.split(' | ');
+    parts.reduce((curr, value, i) => {
+      const label = value.trim();
+      const id = `${tag.label}/${parts.slice(0, i + 1).join('/')}`;
+      if (!curr[id]) {
+        curr[id] = {
+          label,
+          path: id,
+        };
+      }
+      if (i !== parts.length - 1) {
+        curr[id].children = curr[id].children || {};
+      }
+      return curr[id].children || curr;
+    }, tag.children);
+  };
+
+  const getConsumerTags = (data) => {
+    const tags = {};
+
+    data.forEach((item) => {
+      if (!item.Name || !item.Type) return;
+      const id = item.Type.toLowerCase();
+      if (!tags[id]) {
+        tags[id] = {
+          label: item.Type.trim(),
+          path: id.trim(),
+          children: {},
+        };
+      }
+      splitChildren(tags[id], item.Name);
+    });
+    return tags;
+  };
+
+  const fetchCasS = async () => {
+    const { tags, errorMsg } = await loadCaasTags(caasTagUrl);
     if (errorMsg) window.lana.log(`Tag Selector. Error fetching caas tags: ${errorMsg}`);
 
-    const opts = getTagTree(caasTags);
-    setOptions(opts);
+    setTagSelectorTags((prevConsumerTags) => ({ CaaS: tags, ...prevConsumerTags }));
+  };
 
+  const fetchConsumer = () => {
+    consumerUrls.forEach(({ title, url }) => {
+      fetchData(url).then((json) => {
+        const tags = getConsumerTags(json.data);
+        setTagSelectorTags((prevConsumerTags) => ({ [title]: tags, ...prevConsumerTags }));
+      });
+    });
+  };
+
+  const loadCaaS = () => {
+    const opts = getTagTree(tagSelectorTags.CaaS);
+    setOptions(opts);
     if (opts && Object.values(opts).some((value) => typeof value !== 'string')) {
       setOptionMap(createOptionMap(opts));
     } else {
       /* c8 ignore next 2 */
       setOptionMap(opts);
     }
+  };
+
+  const loadConsumer = () => {
+    if (!tagSelectorTags[selected]) return;
+    const opts = tagSelectorTags[selected];
+    setOptions(opts);
+    if (opts && Object.values(opts).some((value) => typeof value !== 'string')) {
+      setOptionMap(createOptionMap(opts));
+    } else {
+      /* c8 ignore next 2 */
+      setOptionMap(opts);
+    }
+  };
+
+  useEffect(() => {
+    fetchCasS();
+    fetchConsumer();
   }, []);
+
+  useEffect(() => {
+    if (selected === CAAS_LABEL && tagSelectorTags.CaaS) {
+      loadCaaS();
+    } else if (tagSelectorTags[selected]) {
+      loadConsumer();
+    }
+  }, [selected, tagSelectorTags]);
+
+  useEffect(() => {
+    setSelectedTags([]);
+  }, [selected]);
 
   const toggleTag = (value) => {
     setSelectedTags((tags) => {
@@ -90,27 +181,55 @@ const TagSelector = () => {
     });
   };
 
+  useEffect(() => {
+    if (selected === CAAS_LABEL) {
+      setPreviewTags(selectedTags);
+    } else {
+      setPreviewTags(selectedTags.map((tag) => optionMap[tag].label));
+    }
+  }, [selected, selectedTags, optionMap]);
+
+  const setTag = (event) => {
+    const tagName = event.target.dataset.tag;
+    setSelected(tagName);
+  };
+
   return html`
     <section class="tag-selector-sources">
       <div class="col">
-        <div class="tagselect-item expanded">
-          <button class="has-children">CaaS Tags</button>
+        <div class="tagselect-item ${selected === CAAS_LABEL ? 'expanded' : ''}">
+          <button class="has-children" data-tag="${CAAS_LABEL}" onClick=${setTag}>CaaS Tags</button>
         </div>
       </div>
+      ${consumerUrls.map(({ title }) => html`
+        <div class="col">
+          <div class="tagselect-item ${selected === title ? 'expanded' : ''}">
+            <button class="has-children" data-tag=${title} onClick=${setTag}>${title}</button>
+          </div>
+        </div>
+      `)}
     </section>
-    ${options
-      && optionMap
-      && html`<${Picker}
+    ${(options && optionMap)
+    ? html`<${Picker}
         toggleTag=${toggleTag}
         options=${options}
         optionMap=${optionMap}
         selectedTags=${selectedTags}
       />`
-}
-    <${TagPreview} selectedTags=${selectedTags} />
+    : html`<div class="tagselect-picker"><div class="spinner"></div></div>`}
+    <${TagPreview} selectedTags=${previewTags} />
   `;
 };
 
 export default async function init(el) {
-  render(html`<${TagSelector} />`, el);
+  const children = Array.from(el.querySelectorAll(':scope > div'));
+  const consumerUrls = [];
+  children.forEach((child) => {
+    const title = child.children[0].textContent;
+    const url = child.children[1].textContent;
+    child.style.display = 'none';
+    consumerUrls.push({ title, url });
+  });
+
+  render(html`<${TagSelector} consumerUrls=${consumerUrls} />`, el);
 }

--- a/libs/ui/controls/TagSelectPicker.js
+++ b/libs/ui/controls/TagSelectPicker.js
@@ -38,19 +38,18 @@ const Picker = ({
 
   useEffect(() => {
     const cols = [];
-    const addColumn = (option, expandedPath) => {
-      const expandedId = expandedPath ? `caas:${expandedPath}` : null;
+    const addColumn = (option, expandedPath = null) => {
       if (!option) {
-        cols.unshift(getCol(options, expandedId));
+        cols.unshift(getCol(options, expandedPath));
       } else {
-        cols.unshift(getCol(option, expandedId));
+        cols.unshift(getCol(option, expandedPath));
         addColumn(option.parent, option.path);
       }
     };
 
     addColumn(optionMap[selectedCol]);
     setColumns(cols);
-  }, [selectedCol, isSearching]);
+  }, [selectedCol, isSearching, options]);
 
   useEffect(() => {
     setIsSearching(debouncedSearchTerm?.length > 2);
@@ -111,7 +110,7 @@ const Picker = ({
         label=${option.label}
         hasChildren=${!!option.children}
         isChecked=${isChecked}
-        isExpanded=${expandedId === id}
+        isExpanded=${expandedId === id || `caas:${expandedId}` === id}
         onCheck=${onCheck}
         onExpand=${onExpand}
       />`;

--- a/libs/ui/controls/TagSelectPicker.js
+++ b/libs/ui/controls/TagSelectPicker.js
@@ -37,23 +37,22 @@ const Picker = ({
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
 
   useEffect(() => {
-    const cols = [];
-    const addColumn = (option, expandedPath = null) => {
-      if (!option) {
-        cols.unshift(getCol(options, expandedPath));
-      } else {
-        cols.unshift(getCol(option, expandedPath));
-        addColumn(option.parent, option.path);
-      }
-    };
-
-    addColumn(optionMap[selectedCol]);
-    setColumns(cols);
-  }, [selectedCol, isSearching, options]);
-
-  useEffect(() => {
     setIsSearching(debouncedSearchTerm?.length > 2);
   }, [debouncedSearchTerm]);
+
+  const onCheck = (e) => {
+    e.preventDefault();
+    const inputEl = e.currentTarget.firstChild;
+
+    if (singleSelect) {
+      toggleTag(inputEl.id);
+      close();
+      return;
+    }
+
+    inputEl.classList.toggle('checked');
+    toggleTag(inputEl.id);
+  };
 
   const getSearchResults = () => {
     const lowerSearchTerm = debouncedSearchTerm.toLowerCase();
@@ -73,20 +72,6 @@ const Picker = ({
       });
   };
 
-  const onCheck = (e) => {
-    e.preventDefault();
-    const inputEl = e.currentTarget.firstChild;
-
-    if (singleSelect) {
-      toggleTag(inputEl.id);
-      close();
-      return;
-    }
-
-    inputEl.classList.toggle('checked');
-    toggleTag(inputEl.id);
-  };
-
   const onExpand = (e) => {
     if (e.target.type === 'checkbox') {
       onCheck(e);
@@ -101,7 +86,7 @@ const Picker = ({
   };
 
   const getCol = (root, expandedId) => {
-    if (!root) return;
+    if (!root) return '';
 
     const items = Object.entries(root.children || root).map(([id, option]) => {
       const isChecked = selectedTags.includes(id);
@@ -117,6 +102,22 @@ const Picker = ({
     });
     return html`<div class="col">${items}</div>`;
   };
+
+  useEffect(() => {
+    const cols = [];
+    const addColumn = (option, expandedPath = null) => {
+      if (!option) {
+        cols.unshift(getCol(options, expandedPath));
+      } else {
+        cols.unshift(getCol(option, expandedPath));
+        addColumn(option.parent, option.path);
+      }
+    };
+
+    addColumn(optionMap[selectedCol]);
+    setColumns(cols);
+  // eslint-disable-next-line
+  }, [selectedCol, isSearching, options]);
 
   return html`
     <section class="tagselect-picker">

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -59,6 +59,7 @@ const MILO_BLOCKS = [
   'table',
   'table-metadata',
   'tags',
+  'tag-selector',
   'tiktok',
   'twitter',
   'video',

--- a/test/blocks/tag-selector/taxonomy.js
+++ b/test/blocks/tag-selector/taxonomy.js
@@ -1,0 +1,80 @@
+const taxonomy = {
+  total: 10,
+  offset: 0,
+  limit: 10,
+  data: [
+    {
+      Type: 'primaryProductName',
+      Name: 'Experience Cloud',
+      'Footer Promo Link': 'https://main--bacom--adobecom.hlx.page/footer-promo-experience',
+      'Other Data': '17',
+      ExcludeFromMetadata: '',
+    },
+    {
+      Type: 'primaryProductName',
+      Name: 'Creative Cloud',
+      'Footer Promo Link': '',
+      'Other Data': '',
+      ExcludeFromMetadata: '',
+    },
+    {
+      Type: 'primaryProductName',
+      Name: 'Document Cloud',
+      'Footer Promo Link': '',
+      'Other Data': '54',
+      ExcludeFromMetadata: '',
+    },
+    {
+      Type: 'tag',
+      Name: 'Insights & Inspiration',
+      'Footer Promo Link': '',
+      'Other Data': '90',
+      ExcludeFromMetadata: '',
+    },
+    {
+      Type: 'tag',
+      Name: 'Insights & Inspiration | Creativity',
+      'Footer Promo Link': '',
+      'Other Data': '',
+      ExcludeFromMetadata: '',
+    },
+    {
+      Type: 'tag',
+      Name: 'Insights & Inspiration | Creativity | 3D & AR',
+      'Footer Promo Link': 'https://main--bacom--adobecom.hlx.page/footer-promo-3d-ar',
+      'Other Data': '',
+      ExcludeFromMetadata: '',
+    },
+    {
+      Type: 'tag',
+      Name: 'Marketing',
+      'Footer Promo Link': '',
+      'Other Data': '',
+      ExcludeFromMetadata: '',
+    },
+    {
+      Type: 'tag',
+      Name: 'Marketing | Content Marketing',
+      'Footer Promo Link': '',
+      'Other Data': '',
+      ExcludeFromMetadata: '',
+    },
+    {
+      Type: 'tag',
+      Name: 'Marketing | Email Marketing',
+      'Footer Promo Link': '',
+      'Other Data': '',
+      ExcludeFromMetadata: '',
+    },
+    {
+      Type: 'tag',
+      Name: 'Marketing | Marketing Automation',
+      'Footer Promo Link': '',
+      'Other Data': '',
+      ExcludeFromMetadata: 'X',
+    },
+  ],
+  ':type': 'sheet',
+};
+
+export default taxonomy;


### PR DESCRIPTION
* Allow consumers to create their own Tag Selector with custom tags.
* Add tag groups by appending the name and URL to the tag selector block.
  * See: https://main--milo--adobecom.hlx.page/drafts/docs/authoring/tag-selector

Resolves: [MWPW-130312](https://jira.corp.adobe.com/browse/MWPW-130312)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/tag-selector?martech=off
- After: https://bmarshal-consumer-tags--milo--adobecom.hlx.page/tools/tag-selector?martech=off
- Before: https://main--milo--adobecom.hlx.page/tools/caas?martech=off
- After: https://bmarshal-consumer-tags--milo--adobecom.hlx.page/tools/caas?martech=off

**BACOM URLS**
- Before: https://main--bacom--adobecom.hlx.page/tools/tag-selector?martech=off
- After: https://main--bacom--adobecom.hlx.page/tools/tag-selector?milolibs=bmarshal-consumer-tags&martech=off