### PR TITLE
[Test PR] Do not merge

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -467,8 +467,8 @@ export function decorateAutoBlock(a) {
     url = new URL(a.href);
   } catch (e) {
     window.lana?.log(`Cannot make URL from decorateAutoBlock - ${a?.href}: ${e.toString()}`);
+    return false;
   }
-  if (!url) return false;
   const href = hostname === url.hostname ? `${url.pathname}${url.search}${url.hash}` : a.href;
   return config.autoBlocks.find((candidate) => {
     const key = Object.keys(candidate)[0];

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -502,7 +502,7 @@ export function decorateAutoBlock(a) {
       return false;
     });
   } catch (e) {
-    window.lana?.log(`Cannot make URL from decorateAutoBlock - ${a}: ${e.toString()}`);
+    window.lana?.log(`Error in decorateAutoBlock - href: ${a?.href} - ${e.toString()}`);
   }
   return false;
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -460,46 +460,51 @@ export function decorateImageLinks(el) {
 }
 
 export function decorateAutoBlock(a) {
-  const config = getConfig();
-  const { hostname } = window.location;
-  const url = new URL(a.href);
-  const href = hostname === url.hostname ? `${url.pathname}${url.search}${url.hash}` : a.href;
-  return config.autoBlocks.find((candidate) => {
-    const key = Object.keys(candidate)[0];
-    const match = href.includes(candidate[key]);
-    if (match) {
-      if (key === 'pdf-viewer' && !a.textContent.includes('.pdf')) {
-        a.target = '_blank';
-        return false;
-      }
-      if (key === 'fragment' && url.hash === '') {
-        const { parentElement } = a;
-        const { nodeName, innerHTML } = parentElement;
-        const noText = innerHTML === a.outerHTML;
-        if (noText && nodeName === 'P') {
-          const div = createTag('div', null, a);
-          parentElement.parentElement.replaceChild(div, parentElement);
+  try {
+    const config = getConfig();
+    const { hostname } = window.location;
+    const url = new URL(a.href);
+    const href = hostname === url.hostname ? `${url.pathname}${url.search}${url.hash}` : a.href;
+    return config.autoBlocks.find((candidate) => {
+      const key = Object.keys(candidate)[0];
+      const match = href.includes(candidate[key]);
+      if (match) {
+        if (key === 'pdf-viewer' && !a.textContent.includes('.pdf')) {
+          a.target = '_blank';
+          return false;
         }
-      }
-      // Modals
-      if (key === 'fragment' && url.hash !== '') {
-        a.dataset.modalPath = url.pathname;
-        a.dataset.modalHash = url.hash;
-        a.href = url.hash;
-        a.className = 'modal link-block';
+        if (key === 'fragment' && url.hash === '') {
+          const { parentElement } = a;
+          const { nodeName, innerHTML } = parentElement;
+          const noText = innerHTML === a.outerHTML;
+          if (noText && nodeName === 'P') {
+            const div = createTag('div', null, a);
+            parentElement.parentElement.replaceChild(div, parentElement);
+          }
+        }
+        // Modals
+        if (key === 'fragment' && url.hash !== '') {
+          a.dataset.modalPath = url.pathname;
+          a.dataset.modalHash = url.hash;
+          a.href = url.hash;
+          a.className = 'modal link-block';
+          return true;
+        }
+
+        // slack uploaded mp4s
+        if (key === 'video' && !a.textContent.match('media_.*.mp4')) {
+          return false;
+        }
+
+        a.className = `${key} link-block`;
         return true;
       }
-
-      // slack uploaded mp4s
-      if (key === 'video' && !a.textContent.match('media_.*.mp4')) {
-        return false;
-      }
-
-      a.className = `${key} link-block`;
-      return true;
-    }
-    return false;
-  });
+      return false;
+    });
+  } catch (e) {
+    window.lana?.log(`Cannot make URL from decorateAutoBlock - ${a}: ${e.toString()}`);
+  }
+  return false;
 }
 
 export function decorateLinks(el) {

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -79,6 +79,11 @@ describe('Utils', () => {
         const autoBlockLink = document.querySelector('[href="https://twitter.com/Adobe"]');
         expect(autoBlockLink.className).to.equal('twitter link-block');
       });
+
+      it('Does not error on invalid url', () => {
+        const autoBlock = utils.decorateAutoBlock('http://HostName:Port/lc/system/console/configMgr');
+        expect(autoBlock).to.equal(false);
+      });
     });
 
     describe('Fragments', () => {


### PR DESCRIPTION
### Description
Faulty links can lead to the whole page crashing. While it makes the issue visible, so no "faulty" links should be authored - with all the migrations and automatic imports going on this is hard to control.  We don't want end users to end up on white pages due to JS errors.

Resolves: [MWPW-134664](https://jira.corp.adobe.com/browse/MWPW-134664)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page?martech=off
- After: https://do-not-error-autoblocks--milo--mokimo.hlx.page?martech=off
- Before: https://main--helpx-internal--adobecom.hlx.page/content/help/en/aem-forms/internal-kb/not-able-to-edit-adaptive-form-on-aem-forms
- After: https://main--helpx-internal--adobecom.hlx.page/content/help/en/aem-forms/internal-kb/not-able-to-edit-adaptive-form-on-aem-forms?milolibs=do-not-error-autoblocks--milo--mokimo
