### PR TITLE
[MWPW-131690] Update horizontal rule styles within text blocks

### DIFF
--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -42,7 +42,6 @@
   height: 100%;
 }
 
-
 .text-block .foreground {
   max-width: var(--grid-container-width);
   margin: 0 auto;
@@ -59,6 +58,11 @@
   gap: var(--spacing-s);
   flex-wrap: wrap;
   align-items: center;
+}
+
+.text-block hr {
+  border-color: #e1e1e1;
+  margin: var(--spacing-m) 0;
 }
 
 /* Alignment */

--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -62,6 +62,7 @@
 
 .text-block hr {
   border-color: #e1e1e1;
+  border-style: solid;
   margin: var(--spacing-m) 0;
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* The `<hr/>` shorthand in text blocks (`---`) produces a horizontal rule that doesn't quite match Consonant designs. This PR fixes that.

Resolves: [MWPW-131690](https://jira.corp.adobe.com/browse/MWPW-131690)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ebartholomew/text-block-hr?martech=off
- After: https://ebartholomew-hr-style-tweak--milo--adobecom.hlx.page/drafts/ebartholomew/text-block-hr?martech=off
