### PR TITLE
Relax global navigation sign profile dropdown in check

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -79,7 +79,7 @@ const decorateSignIn = async ({ rawElem, decoratedElem }) => {
     dropdownElem.classList.add('feds-signIn-dropdown');
 
     // TODO we don't have a good way of adding config properties to links
-    const dropdownSignIn = dropdownElem.querySelector('[href="https://adobe.com?sign-in=true"]');
+    const dropdownSignIn = dropdownElem.querySelector('[href$="?sign-in=true"]');
 
     if (dropdownSignIn) {
       dropdownSignIn.addEventListener('click', (e) => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -78,7 +78,6 @@ const decorateSignIn = async ({ rawElem, decoratedElem }) => {
 
     dropdownElem.classList.add('feds-signIn-dropdown');
 
-    // TODO we don't have a good way of adding config properties to links
     const dropdownSignIn = dropdownElem.querySelector('[href$="?sign-in=true"]');
 
     if (dropdownSignIn) {

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -9,6 +9,7 @@ import brandOnlyNav from './mocks/global-navigation-only-brand.plain.js';
 import nonSvgBrandOnlyNav from './mocks/global-navigation-only-non-svg-brand.plain.js';
 import longNav from './mocks/global-navigation-long.plain.js';
 import noLogoBrandOnlyNav from './mocks/global-navigation-only-brand-no-image.plain.js';
+import globalNavigationMock from './mocks/global-navigation.plain.js';
 
 const ogFetch = window.fetch;
 
@@ -722,6 +723,28 @@ describe('global navigation', () => {
 
         const signInDropdown = document.querySelector(selectors.signInDropdown);
         const dropdownSignIn = signInDropdown.querySelector('[href="https://adobe.com?sign-in=true"]');
+
+        window.adobeIMS = { signIn: sinon.spy() };
+
+        dropdownSignIn.click();
+
+        expect(window.adobeIMS.signIn.callCount).to.equal(1);
+
+        window.adobeIMS = undefined;
+      });
+
+      it('calls ims when clicking a link with a special href, ensuring it only verifies the end of the string', async () => {
+        const mockWithNewSignInHref = globalNavigationMock.replace('https://adobe.com?sign-in=true', 'i-messed-this-up/?sign-in=true');
+        await createFullGlobalNavigation({
+          signedIn: false,
+          globalNavigation: mockWithNewSignInHref,
+        });
+        const signIn = document.querySelector(selectors.signIn);
+
+        signIn.click();
+
+        const signInDropdown = document.querySelector(selectors.signInDropdown);
+        const dropdownSignIn = signInDropdown.querySelector('[href$="?sign-in=true"]');
 
         window.adobeIMS = { signIn: sinon.spy() };
 


### PR DESCRIPTION
### Description

Clicking the `Adobe Account` or Sign in dropdown link should work regardless of the author typing `https://www.adobe.com/?sign-in=true` or `https://www.adobe.com?sign-in=true` ... links might also be influenced when having a `.html` extension or not - hence we want to relax the check for how we connect a sign in button to adobeIms a bit.

Resolves: [MWPW-134874](https://jira.corp.adobe.com/browse/MWPW-134874)

### Test instructions
1. Click "Sign in"
2. Click "Adobe Account"
Before: Does not try to sign you in with IMS
After: Tries to sign you in with IMS

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/prs/mwpw-134874?martech=off
- After: https://mwpw-134874--milo--mokimo.hlx.page/drafts/osahin/prs/mwpw-134874?martech=off
- Before: https://main--bacom--adobecom.hlx.live/solutions/industries/government/electronic-signatures
- After: https://main--bacom--adobecom.hlx.live/solutions/industries/government/electronic-signatures?milolibs=mwpw-134874--milo--mokimo
