### PR TITLE
[MWPW-134805] Remove borders when more sections are used

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -522,7 +522,7 @@ header.global-navigation {
     padding: 0 8px;
   }
 
-  .feds-navItem--section {
+  .feds-navItem--section:only-of-type {
     border-left: 1px solid var(--feds-borderColor--light);
     border-right: 1px solid var(--feds-borderColor--light);
   }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -585,10 +585,11 @@ class Gnav {
           </a>`;
 
         const isSectionMenu = item.closest('.section') instanceof HTMLElement;
+        const tag = isSectionMenu ? 'section' : 'div';
         const triggerTemplate = toFragment`
-          <div class="feds-navItem${isSectionMenu ? ' feds-navItem--section' : ''}">
+          <${tag} class="feds-navItem${isSectionMenu ? ' feds-navItem--section' : ''}">
             ${dropdownTrigger}
-          </div>`;
+          </${tag}>`;
 
         // Toggle trigger's dropdown on click
         dropdownTrigger.addEventListener('click', (e) => {

--- a/test/blocks/global-navigation/keyboard/mocks/global-nav-mobile.html
+++ b/test/blocks/global-navigation/keyboard/mocks/global-nav-mobile.html
@@ -92,7 +92,7 @@
           </aside>
         </div>
         <div class="feds-nav" style="padding-bottom: 64px">
-          <div
+          <section
             class="feds-navItem feds-navItem--section feds-navItem--megaMenu"
           >
             <a
@@ -455,7 +455,7 @@
                 </div>
               </div>
             </div>
-          </div>
+          </section>
           <div class="feds-navItem">
             <a
               href="#"

--- a/test/blocks/global-navigation/keyboard/mocks/global-nav.html
+++ b/test/blocks/global-navigation/keyboard/mocks/global-nav.html
@@ -23,7 +23,7 @@
       </div>
       <div class="feds-nav-wrapper">
         <div class="feds-nav">
-          <div
+          <section
             class="feds-navItem feds-navItem--section feds-navItem--megaMenu"
           >
             <a
@@ -352,7 +352,7 @@
                 </div>
               </div>
             </div>
-          </div>
+          </section>
           <div class="feds-navItem">
             <a
               href="#"


### PR DESCRIPTION
When multiple sections/cloud menus are added to the top navigation, the border between elements should be removed.

Simplest way to do this is by using `:only-of-type`, which checks whether a particular tag has just one occurrence in the context of its parent. Since we were calling cloud menus 'section' menus anyway, it made sense to use a `section` tag for this scenario.

I initially removed the `feds-navItem--section` modifier class and switched styles from `.feds-navItem--section` to `section.feds-navItem`, which worked well, but in the end I decided against increasing specificity and tag lookups.

Resolves: [MWPW-134805](https://jira.corp.adobe.com/browse/MWPW-134805)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/multiple-clouds?martech=off
- After: https://gnav-multiple-section-styling--milo--overmyheadandbody.hlx.page/drafts/ramuntea/multiple-clouds?martech=off
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
- After: https://gnav-multiple-section-styling--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off