### PR TITLE
Merch Table: Fixing the double border and border on cell's text.

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -47,14 +47,14 @@
   margin-right: 8px;
 }
 
-.table.merch .row-heading .col {
+.table.merch .col {
   border-top: 1px var(--border-color) solid;
-}
-
-.table.merch [class*="col-"] {
-  border-bottom: 1px var(--border-color) solid;
   border-left: 1px var(--border-color) solid;
   border-right: 1px var(--border-color) solid;
+}
+
+.table.merch .col.border-bottom {
+  border-bottom: 1px var(--border-color) solid;
 }
 
 .table .row-highlight .col.col-highlight {


### PR DESCRIPTION
**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/authoring/tables?martech=off
- After: https://table-merch-borader--milo--adobecom.hlx.page/docs/authoring/tables?martech=off

This will fix the issue of the border on text for merch table.
<img width="477" alt="image" src="https://github.com/adobecom/milo/assets/55804872/0fa68b12-4461-4ba1-86e6-8f0312784355">
