### PR TITLE
[MWPW-134522] Anchor link icons change when hash present

### DIFF
--- a/libs/blocks/marquee-anchors/marquee-anchors.js
+++ b/libs/blocks/marquee-anchors/marquee-anchors.js
@@ -62,7 +62,7 @@ export default function init(el) {
     const aTag = i.querySelector('a');
     if (aTag?.textContent.charAt(0) === '#') {
       const content = i.querySelector(':scope > div');
-      const hrefPathEqual = (aTag.href.split('?')[0] === window.location.href.split('?')[0]);
+      const hrefPathEqual = (aTag.href.split(/(\?|#)/)[0] === window.location.href.split(/(\?|#)/)[0]);
       const hrefUrl = (hrefPathEqual)
         ? `${aTag.href}${aTag.textContent}`
         : `${aTag.href}`;

--- a/libs/blocks/marquee-anchors/marquee-anchors.js
+++ b/libs/blocks/marquee-anchors/marquee-anchors.js
@@ -62,7 +62,7 @@ export default function init(el) {
     const aTag = i.querySelector('a');
     if (aTag?.textContent.charAt(0) === '#') {
       const content = i.querySelector(':scope > div');
-      const hrefPathEqual = (aTag.href.split(/(\?|#)/)[0] === window.location.href.split(/(\?|#)/)[0]);
+      const hrefPathEqual = (aTag.href.split(/\?|#/)[0] === window.location.href.split(/\?|#/)[0]);
       const hrefUrl = (hrefPathEqual)
         ? `${aTag.href}${aTag.textContent}`
         : `${aTag.href}`;

--- a/test/blocks/marquee-anchors/marquee-anchors.test.js
+++ b/test/blocks/marquee-anchors/marquee-anchors.test.js
@@ -30,4 +30,16 @@ describe('marquee-anchors', () => {
     const anchorLinks = marquees[0].querySelector('.links .anchor-link');
     expect(anchorLinks).to.exist;
   });
+
+  it('adds the correct classes for links', () => {
+    const links = marquees[1].querySelector('.external');
+    expect(links).to.exist;
+  });
+
+  it('does not add the external class if the window has a hash or query praram', () => {
+    window.location.hash = 'a-string';
+
+    const links = marquees[0].querySelector('.external');
+    expect(links).to.be.null;
+  });
 });

--- a/test/blocks/marquee-anchors/marquee-anchors.test.js
+++ b/test/blocks/marquee-anchors/marquee-anchors.test.js
@@ -31,7 +31,7 @@ describe('marquee-anchors', () => {
     expect(anchorLinks).to.exist;
   });
 
-  it('adds the correct classes for links', () => {
+  it('adds the external class for external links', () => {
     const links = marquees[1].querySelector('.external');
     expect(links).to.exist;
   });


### PR DESCRIPTION
A bug was observed where the down arrow icons would change to external icons when a hash was present in the url upon reload. Accounting for that behavior. 

* Changing split string to regex to account for both hash and query params in location href

Resolves: [MWPW-134522](https://jira.corp.adobe.com/browse/MWPW-134522)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/slavin/bacom-pages/content-management?martech=off#global-content-management-and-delivery-through-any-channel-and-at-every-scale
- After: https://mwpw-134522-marquee-anchor-icons--milo--jasonhowellslavin.hlx.page/drafts/slavin/bacom-pages/content-management?martech=off#global-content-management-and-delivery-through-any-channel-and-
