### PR TITLE
MWPW-133754 - Support structured data API for SEO

### DIFF
--- a/libs/features/seotech/README.md
+++ b/libs/features/seotech/README.md
@@ -19,3 +19,17 @@ Video Platforms:
 - BYO HTML5: TBD
 
 See [video-metadata](../../blocks/video-metadata/) if you need to define a specific VideoObject on your page.
+
+## Structured Data
+
+This feature queries the SEOTECH service for structured data that should be added to the page.
+
+Metadata Properties:
+
+- `seotech-structured-data`: `on` to enable SEOTECH lookup
+- `seotech-sheet-url`: url of Franklin Spreadsheet JSON (Optional)
+
+You can also specify `seotech-sheet-url` as a query parameter.
+SEOTECH will search for _/structured-data.json_ at the root of the current page.
+
+Please see For more details see [SEOTECH](https://wiki.corp.adobe.com/display/seoteam/SEOTECH+API) (Corp Only) for list of supported structured data.

--- a/libs/features/seotech/README.md
+++ b/libs/features/seotech/README.md
@@ -1,7 +1,8 @@
 # SEOTECH
 
 Collection of SEO-related features that use the SEOTECH service.
-For more details see [SEOTECH API](https://wiki.corp.adobe.com/display/seoteam/SEOTECH+API) (Corp Only).
+See [structured-data](https://milo.adobe.com/docs/authoring/structured-data) for authoring documentation including examples.
+See [SEOTECH Wiki](https://wiki.corp.adobe.com/display/seoteam/SEOTECH) for documentation regarding the service.
 
 ## Video
 
@@ -32,4 +33,4 @@ Metadata Properties:
 You can also specify `seotech-sheet-url` as a query parameter.
 Otherwise SEOTECH will search for _/structured-data.json_ at the root of the current page.
 
-Please see For more details see [SEOTECH](https://wiki.corp.adobe.com/display/seoteam/SEOTECH+API) (Corp Only) for list of supported structured data.
+See [seotech page](https://git.corp.adobe.com/pages/wcms/seotech/) (Corp Only) for list of supported structured data types.

--- a/libs/features/seotech/README.md
+++ b/libs/features/seotech/README.md
@@ -30,6 +30,6 @@ Metadata Properties:
 - `seotech-sheet-url`: url of Franklin Spreadsheet JSON (Optional)
 
 You can also specify `seotech-sheet-url` as a query parameter.
-SEOTECH will search for _/structured-data.json_ at the root of the current page.
+Otherwise SEOTECH will search for _/structured-data.json_ at the root of the current page.
 
 Please see For more details see [SEOTECH](https://wiki.corp.adobe.com/display/seoteam/SEOTECH+API) (Corp Only) for list of supported structured data.

--- a/libs/features/seotech/seotech.js
+++ b/libs/features/seotech/seotech.js
@@ -28,7 +28,7 @@ export async function getStructuredData(url, sheetUrl, seotechAPIUrl) {
   if (sheetUrl) {
     apiUrl.searchParams.set('sheetUrl', sheetUrl);
   }
-  const resp = await fetch(apiUrl, { headers: { 'Content-Type': 'application/json' } });
+  const resp = await fetch(apiUrl.href, { headers: { 'Content-Type': 'application/json' } });
   const body = await resp?.json();
   if (!resp.ok) {
     throw new Error(`Failed to fetch structured data: ${body?.error}`);
@@ -36,7 +36,8 @@ export async function getStructuredData(url, sheetUrl, seotechAPIUrl) {
   return body.objects;
 }
 
-export async function appendScriptTag({ getMetadata, createTag, getConfig }) {
+export async function appendScriptTag({ locationUrl, getMetadata, createTag, getConfig }) {
+  const windowUrl = new URL(locationUrl);
   const seotechAPIUrl = getConfig()?.env?.name === 'prod'
     ? SEOTECH_API_URL_PROD : SEOTECH_API_URL_STAGE;
 
@@ -47,8 +48,8 @@ export async function appendScriptTag({ getMetadata, createTag, getConfig }) {
 
   const prs = [];
   if (getMetadata('seotech-structured-data') === 'on') {
-    const pageUrl = `${window.location.origin}${window.location.pathname}`;
-    const sheetUrl = (new URLSearchParams(window.location.search)).get('seotech-sheet-url');
+    const pageUrl = `${windowUrl.origin}${windowUrl.pathname}`;
+    const sheetUrl = (new URLSearchParams(windowUrl.search)).get('seotech-sheet-url');
     prs.push(getStructuredData(pageUrl, sheetUrl, seotechAPIUrl)
       .then((r) => r.forEach((obj) => append(obj)))
       .catch((e) => logError(e.message)));

--- a/libs/features/seotech/seotech.js
+++ b/libs/features/seotech/seotech.js
@@ -46,20 +46,20 @@ export async function appendScriptTag({ locationUrl, getMetadata, createTag, get
     document.head.append(script);
   };
 
-  const prs = [];
+  const promises = [];
   if (getMetadata('seotech-structured-data') === 'on') {
     const pageUrl = `${windowUrl.origin}${windowUrl.pathname}`;
     const sheetUrl = (new URLSearchParams(windowUrl.search)).get('seotech-sheet-url') || getMetadata('seotech-sheet-url');
-    prs.push(getStructuredData(pageUrl, sheetUrl, seotechAPIUrl)
-      .then((r) => r.forEach((obj) => append(obj)))
+    promises.push(getStructuredData(pageUrl, sheetUrl, seotechAPIUrl)
+      .then((objects) => objects.forEach((obj) => append(obj)))
       .catch((e) => logError(e.message)));
   }
   if (getMetadata('seotech-video-url')) {
-    prs.push(getVideoObject(getMetadata('seotech-video-url'), seotechAPIUrl)
-      .then((r) => append(r))
+    promises.push(getVideoObject(getMetadata('seotech-video-url'), seotechAPIUrl)
+      .then((videoObject) => append(videoObject))
       .catch((e) => logError(e.message)));
   }
-  return Promise.all(prs);
+  return Promise.all(promises);
 }
 
 export default appendScriptTag;

--- a/libs/features/seotech/seotech.js
+++ b/libs/features/seotech/seotech.js
@@ -49,7 +49,7 @@ export async function appendScriptTag({ locationUrl, getMetadata, createTag, get
   const prs = [];
   if (getMetadata('seotech-structured-data') === 'on') {
     const pageUrl = `${windowUrl.origin}${windowUrl.pathname}`;
-    const sheetUrl = (new URLSearchParams(windowUrl.search)).get('seotech-sheet-url');
+    const sheetUrl = (new URLSearchParams(windowUrl.search)).get('seotech-sheet-url') || getMetadata('seotech-sheet-url');
     prs.push(getStructuredData(pageUrl, sheetUrl, seotechAPIUrl)
       .then((r) => r.forEach((obj) => append(obj)))
       .catch((e) => logError(e.message)));

--- a/libs/features/seotech/seotech.js
+++ b/libs/features/seotech/seotech.js
@@ -21,9 +21,13 @@ export async function getVideoObject(url, seotechAPIUrl) {
   return body.videoObject;
 }
 
-export async function getStructuredData(url, seotechAPIUrl) {
-  const dataUrl = new URL(url)?.href;
-  const apiUrl = `${seotechAPIUrl}/api/v1/web/seotech/getStructuredData?url=${dataUrl}`;
+export async function getStructuredData(url, sheetUrl, seotechAPIUrl) {
+  const apiUrl = new URL(seotechAPIUrl);
+  apiUrl.pathname = '/api/v1/web/seotech/getStructuredData';
+  apiUrl.searchParams.set('url', url);
+  if (sheetUrl) {
+    apiUrl.searchParams.set('sheetUrl', sheetUrl);
+  }
   const resp = await fetch(apiUrl, { headers: { 'Content-Type': 'application/json' } });
   const body = await resp?.json();
   if (!resp.ok) {
@@ -43,7 +47,9 @@ export async function appendScriptTag({ getMetadata, createTag, getConfig }) {
 
   const prs = [];
   if (getMetadata('seotech-structured-data') === 'on') {
-    prs.push(getStructuredData(window.location.href, seotechAPIUrl)
+    const pageUrl = `${window.location.origin}${window.location.pathname}`;
+    const sheetUrl = (new URLSearchParams(window.location.search)).get('seotech-sheet-url');
+    prs.push(getStructuredData(pageUrl, sheetUrl, seotechAPIUrl)
       .then((r) => r.forEach((obj) => append(obj)))
       .catch((e) => logError(e.message)));
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -890,9 +890,10 @@ export async function loadArea(area = document) {
     if (appendage) {
       import('../features/title-append/title-append.js').then((module) => module.default(appendage));
     }
+    const seotechStructuredData = getMetadata('seotech-structured-data');
     const seotechVideoUrl = getMetadata('seotech-video-url');
-    if (seotechVideoUrl) {
-      import('../features/seotech/seotech.js').then((module) => module.default(seotechVideoUrl, { createTag, getConfig }));
+    if (seotechStructuredData === 'on' || seotechVideoUrl) {
+      import('../features/seotech/seotech.js').then((module) => module.default({ getMetadata, createTag, getConfig }));
     }
     const richResults = getMetadata('richresults');
     if (richResults) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -891,7 +891,9 @@ export async function loadArea(area = document) {
       import('../features/title-append/title-append.js').then((module) => module.default(appendage));
     }
     if (getMetadata('seotech-structured-data') === 'on' || getMetadata('seotech-video-url')) {
-      import('../features/seotech/seotech.js').then((module) => module.default({ getMetadata, createTag, getConfig }));
+      import('../features/seotech/seotech.js').then((module) => module.default(
+        { locationUrl: window.location.href, getMetadata, createTag, getConfig },
+      ));
     }
     const richResults = getMetadata('richresults');
     if (richResults) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -890,9 +890,7 @@ export async function loadArea(area = document) {
     if (appendage) {
       import('../features/title-append/title-append.js').then((module) => module.default(appendage));
     }
-    const seotechStructuredData = getMetadata('seotech-structured-data');
-    const seotechVideoUrl = getMetadata('seotech-video-url');
-    if (seotechStructuredData === 'on' || seotechVideoUrl) {
+    if (getMetadata('seotech-structured-data') === 'on' || getMetadata('seotech-video-url')) {
       import('../features/seotech/seotech.js').then((module) => module.default({ getMetadata, createTag, getConfig }));
     }
     const richResults = getMetadata('richresults');

--- a/test/features/seotech/seotech.test.js
+++ b/test/features/seotech/seotech.test.js
@@ -6,7 +6,62 @@ import { getConfig, createTag } from '../../../libs/utils/utils.js';
 import { appendScriptTag } from '../../../libs/features/seotech/seotech.js';
 
 describe('seotech', () => {
-  describe('appendVideoObjectScriptTag', () => {
+  describe('appendScriptTag + seotech-structured-data', () => {
+    beforeEach(async () => {
+      window.lana = { log: (s) => console.log(`LANA NOT STUBBED! ${s}`) };
+    });
+    afterEach(() => {
+      window.fetch?.restore?.();
+      window.lana?.restore?.();
+    });
+
+    it('should not append JSON-LD', async () => {
+      const lanaStub = stub(window.lana, 'log');
+      const getMetadata = stub().returns(null);
+      getMetadata.withArgs('seotech-structured-data').returns('on');
+      const fetchStub = stub(window, 'fetch');
+      fetchStub.returns(Promise.resolve(Response.json(
+        { error: 'ERROR!' },
+        { status: 400 },
+      )));
+      await appendScriptTag(
+        { locationUrl: window.location.href, getMetadata, getConfig, createTag },
+      );
+      const expectedApiCall = 'https://14257-seotech-stage.adobeioruntime.net/api/v1/web/seotech/getStructuredData?url=http%3A%2F%2Flocalhost%3A2000%2F';
+      expect(fetchStub.getCall(0).firstArg).to.equal(expectedApiCall);
+      expect(lanaStub.getCall(0).firstArg).to.equal('SEOTECH: Failed to fetch structured data: ERROR!');
+    });
+
+    it('should append JSON-LD', async () => {
+      // console.log(window.location);
+      const locationUrl = 'http://localhost:2000/?seotech-sheet-url=http://foo';
+      const lanaStub = stub(window.lana, 'log');
+      const fetchStub = stub(window, 'fetch');
+      const getConfigStub = stub().returns({ env: { name: 'prod' } });
+      const getMetadata = stub().returns(null);
+      getMetadata.withArgs('seotech-structured-data').returns('on');
+      const expectedObject = {
+        '@context': 'http://schema.org',
+        '@type': 'VideoObject',
+        name: 'fake',
+      };
+      fetchStub.returns(Promise.resolve(Response.json(
+        { objects: [expectedObject] },
+        { status: 200 },
+      )));
+      await appendScriptTag(
+        { locationUrl, getMetadata, getConfig: getConfigStub, createTag },
+      );
+      const expectedApiCall = 'https://14257-seotech.adobeioruntime.net/api/v1/web/seotech/getStructuredData?url=http%3A%2F%2Flocalhost%3A2000%2F&sheetUrl=http%3A%2F%2Ffoo';
+      expect(fetchStub.getCall(0).firstArg).to.equal(expectedApiCall);
+      const el = await waitForElement('script[type="application/ld+json"]');
+      const obj = JSON.parse(el.text);
+      expect(obj).to.deep.equal(expectedObject);
+      expect(lanaStub.called).to.be.false;
+    });
+  });
+
+  describe('appendScriptTag + seotech-video-url', () => {
     beforeEach(async () => {
       window.lana = { log: () => console.log('LANA NOT STUBBED!') };
     });
@@ -17,20 +72,26 @@ describe('seotech', () => {
 
     it('should not append JSON-LD if url is invalid', async () => {
       const lanaStub = stub(window.lana, 'log');
-      const getMetadata = stub().withArgs('seotech-video-url').returns('fake');
-      await appendScriptTag({ getMetadata, getConfig, createTag });
+      const getMetadata = stub().returns(null);
+      getMetadata.withArgs('seotech-video-url').returns('fake');
+      await appendScriptTag(
+        { locationUrl: window.location.href, getMetadata, getConfig, createTag },
+      );
       expect(lanaStub.calledOnceWith('SEOTECH: Failed to construct \'URL\': Invalid URL')).to.be.true;
     });
 
     it('should not append JSON-LD if url not found', async () => {
       const lanaStub = stub(window.lana, 'log');
-      const getMetadata = stub().withArgs('seotech-video-url').returns('http://fake');
+      const getMetadata = stub().returns(null);
+      getMetadata.withArgs('seotech-video-url').returns('http://fake');
       const fetchStub = stub(window, 'fetch');
       fetchStub.returns(Promise.resolve(Response.json(
         { error: 'ERROR!' },
         { status: 400 },
       )));
-      await appendScriptTag({ getMetadata, getConfig, createTag });
+      await appendScriptTag(
+        { locationUrl: window.location.href, getMetadata, getConfig, createTag },
+      );
       expect(fetchStub.calledOnceWith(
         'https://14257-seotech-stage.adobeioruntime.net/api/v1/web/seotech/getVideoObject?url=http://fake/',
       )).to.be.true;
@@ -38,8 +99,10 @@ describe('seotech', () => {
     });
 
     it('should append JSON-LD', async () => {
+      const lanaStub = stub(window.lana, 'log');
       const fetchStub = stub(window, 'fetch');
-      const getMetadata = stub().withArgs('seotech-video-url').returns('http://fake');
+      const getMetadata = stub().returns(null);
+      getMetadata.withArgs('seotech-video-url').returns('http://fake');
       const expectedVideoObject = {
         '@context': 'http://schema.org',
         '@type': 'VideoObject',
@@ -49,13 +112,16 @@ describe('seotech', () => {
         { videoObject: expectedVideoObject },
         { status: 200 },
       )));
-      await appendScriptTag({ getMetadata, getConfig, createTag });
+      await appendScriptTag(
+        { locationUrl: window.location.href, getMetadata, getConfig, createTag },
+      );
       expect(fetchStub.calledOnceWith(
         'https://14257-seotech-stage.adobeioruntime.net/api/v1/web/seotech/getVideoObject?url=http://fake/',
       )).to.be.true;
       const el = await waitForElement('script[type="application/ld+json"]');
       const obj = JSON.parse(el.text);
       expect(obj).to.deep.equal(expectedVideoObject);
+      expect(lanaStub.called).to.be.false;
     });
   });
 });

--- a/test/features/seotech/seotech.test.js
+++ b/test/features/seotech/seotech.test.js
@@ -3,7 +3,7 @@ import { stub } from 'sinon';
 import { waitForElement } from '../../helpers/waitfor.js';
 
 import { getConfig, createTag } from '../../../libs/utils/utils.js';
-import appendVideoObjectScriptTag from '../../../libs/features/seotech/seotech.js';
+import { appendScriptTag } from '../../../libs/features/seotech/seotech.js';
 
 describe('seotech', () => {
   describe('appendVideoObjectScriptTag', () => {
@@ -17,18 +17,20 @@ describe('seotech', () => {
 
     it('should not append JSON-LD if url is invalid', async () => {
       const lanaStub = stub(window.lana, 'log');
-      await appendVideoObjectScriptTag('', { getConfig, createTag });
+      const getMetadata = stub().withArgs('seotech-video-url').returns('fake');
+      await appendScriptTag({ getMetadata, getConfig, createTag });
       expect(lanaStub.calledOnceWith('SEOTECH: Failed to construct \'URL\': Invalid URL')).to.be.true;
     });
 
     it('should not append JSON-LD if url not found', async () => {
       const lanaStub = stub(window.lana, 'log');
+      const getMetadata = stub().withArgs('seotech-video-url').returns('http://fake');
       const fetchStub = stub(window, 'fetch');
       fetchStub.returns(Promise.resolve(Response.json(
         { error: 'ERROR!' },
         { status: 400 },
       )));
-      await appendVideoObjectScriptTag('http://fake', { getConfig, createTag });
+      await appendScriptTag({ getMetadata, getConfig, createTag });
       expect(fetchStub.calledOnceWith(
         'https://14257-seotech-stage.adobeioruntime.net/api/v1/web/seotech/getVideoObject?url=http://fake/',
       )).to.be.true;
@@ -37,6 +39,7 @@ describe('seotech', () => {
 
     it('should append JSON-LD', async () => {
       const fetchStub = stub(window, 'fetch');
+      const getMetadata = stub().withArgs('seotech-video-url').returns('http://fake');
       const expectedVideoObject = {
         '@context': 'http://schema.org',
         '@type': 'VideoObject',
@@ -46,7 +49,7 @@ describe('seotech', () => {
         { videoObject: expectedVideoObject },
         { status: 200 },
       )));
-      await appendVideoObjectScriptTag('http://fake', { getConfig, createTag });
+      await appendScriptTag({ getMetadata, getConfig, createTag });
       expect(fetchStub.calledOnceWith(
         'https://14257-seotech-stage.adobeioruntime.net/api/v1/web/seotech/getVideoObject?url=http://fake/',
       )).to.be.true;

--- a/test/features/seotech/seotech.test.js
+++ b/test/features/seotech/seotech.test.js
@@ -33,7 +33,6 @@ describe('seotech', () => {
     });
 
     it('should append JSON-LD', async () => {
-      // console.log(window.location);
       const locationUrl = 'http://localhost:2000/?seotech-sheet-url=http://foo';
       const lanaStub = stub(window.lana, 'log');
       const fetchStub = stub(window, 'fetch');


### PR DESCRIPTION
Add support for `seotech-structured-data` feature. We refactor existing support for `seotech-video-url` and add new tests and make improvements to existing ones.

Resolves: [MWPW-133754](https://jira.corp.adobe.com/browse/MWPW-133754)

**Test URLs:**

- Before: https://milo.adobe.com/drafts/hgpa/test/seotech-structured-data/structured-data?martech=off&seotech-sheet-url=https://milo.adobe.com/drafts/hgpa/test/seotech-structured-data/structured-data.json
- After: https://seotech-structured-data--milo--hparra.hlx.live/drafts/hgpa/test/seotech-structured-data/structured-data?martech=off&seotech-sheet-url=https://milo.adobe.com/drafts/hgpa/test/seotech-structured-data/structured-data.json

**Validation:**

The following should return a `FAQPage` JSON-LD object:

```js
JSON.parse(document.querySelector('script[type="application/ld+json"]').text)
```

**References:**

- https://github.com/adobecom/milo/pull/1065