### PR TITLE
MWPW-134481 - Add section xxs spacing variant

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -61,6 +61,10 @@
   padding: var(--spacing-xs) 0;
 }
 
+.section.xxs-spacing {
+  padding: var(--spacing-xxs) 0;
+}
+
 .section picture.section-background {
   display: block;
   position: absolute;


### PR DESCRIPTION
When the spacing variants were added to the section metadata the xxs size was missed. Adding it as an option for block spacing.

Resolves: [MWPW-134481](https://jira.corp.adobe.com/browse/MWPW-134481)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/klee/doc-test/text?martech=off
- After: https://sarchibeque-section-spacing--milo--adobecom.hlx.page/drafts/klee/doc-test/text?martech=off
