### PR TITLE
MWPW-135198 - Optimizes quiz-results DOM handling

### DIFF
--- a/libs/blocks/quiz-results/quiz-results.js
+++ b/libs/blocks/quiz-results/quiz-results.js
@@ -45,7 +45,6 @@ export const loadingErrorText = 'Could not load quiz results:';
 
 export default async function init(el, debug = null, localStoreKey = null) {
   const data = getMetadata(el);
-  const metaData = el.querySelectorAll('div');
   const params = new URL(document.location).searchParams;
   const quizUrl = data['quiz-url'];
   const BASIC_KEY = 'basicFragments';
@@ -56,6 +55,8 @@ export default async function init(el, debug = null, localStoreKey = null) {
   // handle these two query param values in this way to facilitate unit tests
   localStoreKey ??= params.get('quizKey');
   debug ??= params.get('debug');
+
+  el.replaceChildren();
 
   let results = localStorage.getItem(localStoreKey);
   if (!results) {
@@ -82,12 +83,8 @@ export default async function init(el, debug = null, localStoreKey = null) {
 
     loadFragments(el, basic);
   } else {
+    window.lana.log(`${loadingErrorText} The quiz-results block is misconfigured`);
     return;
-  }
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const div of metaData) {
-    div.remove();
   }
 
   if (data.style) {


### PR DESCRIPTION
* Removed a querySelectorAll
* Removed iteration through metadata divs
* Added lana logging if the block has been misconfigured and doesn't implement a proper variant

Resolves: [MWPW-135198](https://jira.corp.adobe.com/browse/MWPW-135198)

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.page/drafts/colloyd/quiz-results-block/quiz-results?quizKey=cc-quiz-result&debug=quiz-results&martech=off
- After: https://mwpw-135198-quiz-results-dom-optimization--milo--colloyd.hlx.page/drafts/colloyd/quiz-results-block/quiz-results?quizKey=cc-quiz-result&debug=quiz-results&martech=off

To properly test this, hit the test url and open dev tools. Add the 'cc-quiz-result' key to Local Storage and set the value to this:

{"primaryProducts":["lr","pr"],"secondaryProducts":["ps","au"],"umbrellaProduct":"cc","basicFragments":["https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-marquee-cc","https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-card-list"],"nestedFragments":{"marquee-product":["https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-marquee-product-lr","https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-marquee-product-pr"],"commerce-card":["https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-card-lr","https://main--milo--adobecom.hlx.page/fragments/colloyd/sample-uar-fragments/uar-sample-card-pr"]}}
