### PR TITLE
mep-add-marker-data-fix

### DIFF
--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -234,9 +234,11 @@ function createPreviewPill(manifests) {
 function addMarkerData(manifests) {
   manifests.forEach((manifest) => {
     manifest?.selectedVariant.useblockcode?.forEach((item) => {
-      document.querySelectorAll(`.${item.selector}`).forEach((el) => {
-        el.dataset.codeManifestId = manifest.manifest;
-      });
+      if (item.selector) {
+        document.querySelectorAll(`.${item.selector}`).forEach((el) => {
+          el.dataset.codeManifestId = manifest.manifest;
+        });
+      }
     });
     manifest?.selectedVariant.updatemetadata?.forEach((item) => {
       if (item.selector === 'gnav-source') {


### PR DESCRIPTION
* Add if condition inside mep function addMarkerData to avoid error on empty value

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/pers/pers-demo
- After: https://mep-add-marker-data-fix--milo--adobecom.hlx.page/drafts/cpeyer/pers/pers-demo
