### PR TITLE
Do not lana log IMS timeouts for the global nav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -213,7 +213,11 @@ class Gnav {
   ims = async () => loadIms()
     .then(() => this.imsReady())
     .catch((e) => {
-      if (e?.message !== 'IMS timeout') lanaLog({ message: 'GNAV: Error with IMS', e });
+      if (e?.message === 'IMS timeout') {
+        window.addEventListener('onImsLibInstance', () => this.imsReady());
+        return;
+      }
+      lanaLog({ message: 'GNAV: Error with IMS', e });
     });
 
   decorateTopNav = () => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -213,7 +213,7 @@ class Gnav {
   ims = async () => loadIms()
     .then(() => this.imsReady())
     .catch((e) => {
-      lanaLog({ message: 'GNAV: Error with IMS', e });
+      if (e?.message !== 'IMS timeout') lanaLog({ message: 'GNAV: Error with IMS', e });
     });
 
   decorateTopNav = () => {


### PR DESCRIPTION
Do not lana log IMS timeouts as we can't fix those and they unnecessarily pollute our lana logs [MWPW-134861](https://jira.corp.adobe.com/browse/MWPW-134861)

Instead we want to ensure we try to show the sign in/profile button even if the initial `loadIms()` call was rejected if it eventually loads.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ramuntea/gnav-refactor?martech=off#
- After: https://reduce-gnav-lana-logs--milo--mokimo.hlx.page/drafts/ramuntea/gnav-refactor?martech=off#
