### PR TITLE
MWPW-135276 Fix video selector

### DIFF
--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -17,7 +17,7 @@ const decorateVideo = (container, src) => {
     const { pathname, hash } = src;
     const attrs = getVideoAttrs(hash);
     container.innerHTML = `<video ${attrs}>
-          <source src=".${pathname}" type="video/mp4" />
+          <source src="${pathname}" type="video/mp4" />
         </video>`;
   }
   return container.firstChild;

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -14,10 +14,10 @@ const decorateVideo = (container, src) => {
     </video>`;
     container.classList.add('has-video');
   } else {
-    const { pathname, hash } = src;
+    const { href, hash } = src;
     const attrs = getVideoAttrs(hash);
     container.innerHTML = `<video ${attrs}>
-          <source src="${pathname}" type="video/mp4" />
+          <source src="${href}" type="video/mp4" />
         </video>`;
   }
   return container.firstChild;

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -137,8 +137,8 @@ export default function init(el) {
     media.classList.add('media');
     const video = media.querySelector('video');
     if (video) applyHoverPlay(video);
-    if (media.querySelector('a[href$=".mp4"]')) {
-      decorateVideo(media);
+    if (media.querySelector('a[href*=".mp4"]')) {
+      decorateVideo(media, media.querySelector('a').href);
     } else {
       decorateImage(media);
     }

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -17,11 +17,36 @@ import { decorateButtons, getBlockSize, applyHoverPlay } from '../../utils/decor
 import { decorateBlockAnalytics, decorateLinkAnalytics } from '../../martech/attributes.js';
 import { createTag } from '../../utils/utils.js';
 
+function getAttrs(hash) {
+  const isAutoplay = hash?.includes('autoplay');
+  const isAutoplayOnce = hash?.includes('autoplay1');
+  const playOnHover = hash.includes('hoverplay');
+  if (isAutoplay && !isAutoplayOnce) {
+    return 'playsinline autoplay loop muted';
+  }
+  if (playOnHover && isAutoplayOnce) {
+    return 'playsinline autoplay muted data-hoverplay';
+  }
+  if (isAutoplayOnce) {
+    return 'playsinline autoplay muted';
+  }
+  return 'playsinline controls';
+}
+
 const decorateVideo = (container, src) => {
-  container.innerHTML = `<video preload="metadata" playsinline autoplay muted loop>
-    <source src="${src}" type="video/mp4" />
-  </video>`;
-  container.classList.add('has-video');
+  if (typeof src === 'string') {
+    // no special attrs handling
+    container.innerHTML = `<video preload="metadata" playsinline autoplay muted loop>
+      <source src="${src}" type="video/mp4" />
+    </video>`;
+    container.classList.add('has-video');
+  } else {
+    const { pathname, hash } = src;
+    const attrs = getAttrs(hash);
+    container.innerHTML = `<video ${attrs}>
+          <source src=".${pathname}" type="video/mp4" />
+        </video>`;
+  }
   return container.firstChild;
 };
 
@@ -137,8 +162,9 @@ export default function init(el) {
   if (media) {
     media.classList.add('media');
     let video = media.querySelector('video');
-    if (media.querySelector('a[href*=".mp4"]')) {
-      video = decorateVideo(media, media.querySelector('a').href);
+    const videoLink = media.querySelector('a[href*=".mp4"]');
+    if (videoLink) {
+      video = decorateVideo(media, videoLink);
     } else {
       decorateImage(media);
     }

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -42,7 +42,8 @@ const decorateBlockBg = (block, node) => {
     const videoElement = child.querySelector('a[href*=".mp4"], video source[src$=".mp4"]');
     if (videoElement) {
       const video = decorateVideo(child, videoElement.href || videoElement.src);
-      if (video.firstElementChild?.src.includes('autoplay1')) {
+      const hash = video.firstElementChild?.src.split('#')[1];
+      if (hash?.includes('autoplay1')) {
         video.removeAttribute('loop');
       }
     }

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -22,6 +22,7 @@ const decorateVideo = (container, src) => {
     <source src="${src}" type="video/mp4" />
   </video>`;
   container.classList.add('has-video');
+  return container.firstChild;
 };
 
 const decorateBlockBg = (block, node) => {
@@ -135,13 +136,13 @@ export default function init(el) {
 
   if (media) {
     media.classList.add('media');
-    const video = media.querySelector('video');
-    if (video) applyHoverPlay(video);
+    let video = media.querySelector('video');
     if (media.querySelector('a[href*=".mp4"]')) {
-      decorateVideo(media, media.querySelector('a').href);
+      video = decorateVideo(media, media.querySelector('a').href);
     } else {
       decorateImage(media);
     }
+    if (video) applyHoverPlay(video);
   }
 
   const firstDivInForeground = foreground.querySelector(':scope > div');

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -40,7 +40,7 @@ const decorateBlockBg = (block, node) => {
     if (childCount === 3) {
       child.classList.add(viewports[index]);
     }
-    const videoElement = child.querySelector('a[href$=".mp4"], video source[src$=".mp4"]');
+    const videoElement = child.querySelector('a[href*=".mp4"], video source[src$=".mp4"]');
     if (videoElement) {
       decorateVideo(child, videoElement.href || videoElement.src);
     }

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -1,37 +1,10 @@
 /*
- * Copyright 2022 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
- */
-
-/*
  * Marquee - v6.0
  */
-import { decorateButtons, getBlockSize, applyHoverPlay } from '../../utils/decorate.js';
+
+import { applyHoverPlay, decorateButtons, getBlockSize, getVideoAttrs } from '../../utils/decorate.js';
 import { decorateBlockAnalytics, decorateLinkAnalytics } from '../../martech/attributes.js';
 import { createTag } from '../../utils/utils.js';
-
-function getAttrs(hash) {
-  const isAutoplay = hash?.includes('autoplay');
-  const isAutoplayOnce = hash?.includes('autoplay1');
-  const playOnHover = hash.includes('hoverplay');
-  if (isAutoplay && !isAutoplayOnce) {
-    return 'playsinline autoplay loop muted';
-  }
-  if (playOnHover && isAutoplayOnce) {
-    return 'playsinline autoplay muted data-hoverplay';
-  }
-  if (isAutoplayOnce) {
-    return 'playsinline autoplay muted';
-  }
-  return 'playsinline controls';
-}
 
 const decorateVideo = (container, src) => {
   if (typeof src === 'string') {
@@ -42,7 +15,7 @@ const decorateVideo = (container, src) => {
     container.classList.add('has-video');
   } else {
     const { pathname, hash } = src;
-    const attrs = getAttrs(hash);
+    const attrs = getVideoAttrs(hash);
     container.innerHTML = `<video ${attrs}>
           <source src=".${pathname}" type="video/mp4" />
         </video>`;

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -7,7 +7,7 @@ import { decorateBlockAnalytics, decorateLinkAnalytics } from '../../martech/att
 import { createTag } from '../../utils/utils.js';
 
 const decorateVideo = (container, src) => {
-  if (typeof src === 'string') {
+  if (typeof src === 'string' || src?.href.endsWith('.mp4')) {
     // no special attrs handling
     container.innerHTML = `<video preload="metadata" playsinline autoplay muted loop>
       <source src="${src}" type="video/mp4" />

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -41,7 +41,10 @@ const decorateBlockBg = (block, node) => {
     }
     const videoElement = child.querySelector('a[href*=".mp4"], video source[src$=".mp4"]');
     if (videoElement) {
-      decorateVideo(child, videoElement.href || videoElement.src);
+      const video = decorateVideo(child, videoElement.href || videoElement.src);
+      if (video.firstElementChild?.src.includes('autoplay1')) {
+        video.removeAttribute('loop');
+      }
     }
 
     const pic = child.querySelector('picture');

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -1,24 +1,8 @@
-import { applyHoverPlay } from '../../utils/decorate.js';
-
-function getAttrs(hash) {
-  const isAutoplay = hash?.includes('autoplay');
-  const isAutoplayOnce = hash?.includes('autoplay1');
-  const playOnHover = hash.includes('hoverplay');
-  if (isAutoplay && !isAutoplayOnce) {
-    return 'playsinline autoplay loop muted';
-  }
-  if (playOnHover && isAutoplayOnce) {
-    return 'playsinline autoplay muted data-hoverplay';
-  }
-  if (isAutoplayOnce) {
-    return 'playsinline autoplay muted';
-  }
-  return 'playsinline controls';
-}
+import { applyHoverPlay, getVideoAttrs } from '../../utils/decorate.js';
 
 export default function init(a) {
   const { pathname, hash } = a;
-  const attrs = getAttrs(hash);
+  const attrs = getVideoAttrs(hash);
   const video = `<video ${attrs}>
         <source src=".${pathname}" type="video/mp4" />
       </video>`;

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -116,6 +116,22 @@ export function decorateIconStack(el) {
   });
 }
 
+export function getVideoAttrs(hash) {
+  const isAutoplay = hash?.includes('autoplay');
+  const isAutoplayOnce = hash?.includes('autoplay1');
+  const playOnHover = hash.includes('hoverplay');
+  if (isAutoplay && !isAutoplayOnce) {
+    return 'playsinline autoplay loop muted';
+  }
+  if (playOnHover && isAutoplayOnce) {
+    return 'playsinline autoplay muted data-hoverplay';
+  }
+  if (isAutoplayOnce) {
+    return 'playsinline autoplay muted';
+  }
+  return 'playsinline controls';
+}
+
 export function applyHoverPlay(video) {
   if (!video) return;
   if (video.hasAttribute('data-hoverplay') && !video.hasAttribute('data-mouseevent')) {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -117,6 +117,7 @@ export function decorateIconStack(el) {
 }
 
 export function applyHoverPlay(video) {
+  if (!video) return;
   if (video.hasAttribute('data-hoverplay') && !video.hasAttribute('data-mouseevent')) {
     video.addEventListener('mouseenter', () => { video.play(); });
     video.addEventListener('mouseleave', () => { video.pause(); });


### PR DESCRIPTION
Selector was looking for video links that end in .mp4, but if any hash was appended to video link then it would not match.

Changed selector to `*=` which will match any part of the string

This also adds support for `autoplay1` for marquee background videos (used to always loop).

Resolves: [MWPW-135276](https://jira.corp.adobe.com/browse/MWPW-135276)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/poc/video-samples?martech=off
- After: https://videofix--milo--adobecom.hlx.page/drafts/rclayton/poc/video-samples?martech=off
