### PR TITLE
add optional chaining operator to get hash value for hoverplay

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -119,7 +119,7 @@ export function decorateIconStack(el) {
 export function getVideoAttrs(hash) {
   const isAutoplay = hash?.includes('autoplay');
   const isAutoplayOnce = hash?.includes('autoplay1');
-  const playOnHover = hash.includes('hoverplay');
+  const playOnHover = hash?.includes('hoverplay');
   if (isAutoplay && !isAutoplayOnce) {
     return 'playsinline autoplay loop muted';
   }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Add optional chaining operator for hoverplay has value

Resolves: [MWPW-129910](https://jira.corp.adobe.com/browse/MWPW-129910)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/marquee1/?martech=off
- After: https://video--milo--adobecom.hlx.page/drafts/ruchika/marquee1/?martech=off

