### PR TITLE
interlinks in marquee anchor block fixed

### DIFF
--- a/libs/blocks/marquee-anchors/marquee-anchors.js
+++ b/libs/blocks/marquee-anchors/marquee-anchors.js
@@ -64,7 +64,7 @@ export default function init(el) {
       const content = i.querySelector(':scope > div');
       const hrefPathEqual = (aTag.href.split(/\?|#/)[0] === window.location.href.split(/\?|#/)[0]);
       const hrefUrl = (hrefPathEqual)
-        ? `${aTag.href}${aTag.textContent}`
+        ? `${aTag.textContent}`
         : `${aTag.href}`;
       const link = createTag('a', {
         class: 'anchor-link',


### PR DESCRIPTION
* The interlinks in marquee anchor block have been fixed by editing the url in anchor tag
* Specific
* Features or fixes

Resolves: [MWPW-135282](https://jira.corp.adobe.com/browse/MWPW-135282)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/Soujanya/marqueeanchor-18?martech=off
- After: https://mwpw-135282--milo--sharath-kannan.hlx.page/drafts/Soujanya/marqueeanchor-18?martech=off
