### PR TITLE
MWPW-135447 Add useDotHtml in config to force .html links

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -114,9 +114,7 @@ ENVS.local = {
 };
 
 const LANGSTORE = 'langstore';
-
 const PAGE_URL = new URL(window.location.href);
-const DOT_HTML_PATH = PAGE_URL.pathname.endsWith('.html');
 
 function getEnv(conf) {
   const { host } = window.location;
@@ -185,6 +183,7 @@ export const [setConfig, updateConfig, getConfig] = (() => {
         console.log('Invalid or missing locale:', e);
       }
       config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot ?? ''}`;
+      config.useDotHtml = conf.useDotHtml ?? PAGE_URL.pathname.endsWith('.html');
       return config;
     },
     (conf) => (config = conf),
@@ -271,7 +270,8 @@ export function loadStyle(href, callback) {
 }
 
 export function appendHtmlToCanonicalUrl() {
-  if (!DOT_HTML_PATH) return;
+  const { useDotHtml } = getConfig();
+  if (!useDotHtml) return;
   const canonEl = document.head.querySelector('link[rel="canonical"]');
   if (!canonEl) return;
   const canonUrl = new URL(canonEl.href);
@@ -282,7 +282,8 @@ export function appendHtmlToCanonicalUrl() {
 }
 
 export function appendHtmlToLink(link) {
-  if (!DOT_HTML_PATH) return;
+  const { useDotHtml } = getConfig();
+  if (!useDotHtml) return;
   const href = link.getAttribute('href');
   if (!href?.length) return;
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -183,7 +183,8 @@ export const [setConfig, updateConfig, getConfig] = (() => {
         console.log('Invalid or missing locale:', e);
       }
       config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot ?? ''}`;
-      config.useDotHtml = conf.useDotHtml ?? PAGE_URL.pathname.endsWith('.html');
+      config.useDotHtml = !PAGE_URL.origin.includes('.hlx.')
+        && (conf.useDotHtml ?? PAGE_URL.pathname.endsWith('.html'));
       return config;
     },
     (conf) => (config = conf),

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -28,7 +28,7 @@
     <!-- Disable Auto Block-->
     <p><a class="disable-autoblock" href="https://www.instagram.com/#_dnb">Disable Autoblock</a></p>
     <!-- Auto Block -->
-    <p><a class="autoblock" href="https://twitter.com/Adobe#_dnb">Auto Block</a></p>    
+    <p><a class="autoblock" href="https://twitter.com/Adobe#_dnb">Auto Block</a></p>
   </div>
   <!-- Default content -->
   <div>

--- a/test/utils/mocks/useDotHtml.html
+++ b/test/utils/mocks/useDotHtml.html
@@ -1,0 +1,34 @@
+<main>
+  <div id="linklist">
+    <!-- Relative URLs -->
+    <p><a href="http://localhost:2000">http://localhost:2000</a></p>
+    <p><a class="has-html"href="http://localhost:2000/test/page">http://localhost:2000/test/page</a></p>
+    <p><a href="http://localhost:2000/ends/in/slash/">http://localhost:2000/ends/in/slash/</a></p>
+    <p><a href="http://localhost:2000/test/img.jpg">http://localhost:2000/test/img.jpg</a></p>
+    <p><a class="has-html" href="/test/page">/test/page</a></p>
+    <p><a href="/ends/in/slash/">/ends/in/slash/</a></p>
+    <p><a href="/test/img.jpg">/test/img.jpg</a></p>
+
+    <p><a class="has-html" href="/test/page#_withhash">/test/page#_withhash</a></p>
+    <p><a class="has-html"href="http://localhost:2000/test/page#_anotherhash#here">http://localhost:2000/test/page#_anotherhash#here</a></p>
+    <!-- htmlExclude -->
+    <p><a id="excluded" href="/exclude/this/page">/exclude/this/page</a></p>
+    <!-- Auto Blocks -->
+    <p><a href="https://www.youtube.com/watch?v=0EWdoiU8BXw#_dnb">YouTube</a></p>
+    <p><a href="https://milo.adobe.com/fragments/mock#otis#_dnb">Open modal</a></p>
+    <p><a href="https://acrobatservices.adobe.com/view-sdk/PDFs/test.pdf">View PDF</a></p>
+    <!-- Fragments -->
+    <p><a href="https://milo.adobe.com/fragments/mock">https://milo.adobe.com/fragments/mock</a></p>
+    <p><a href="/fragments/relative/path">/fragments/relative/path</a></p>
+    <!-- SVGs -->
+    <p><a href="http://localhost:2000/img/favicon.svg">http://localhost:2000/img/favicon.svg</a></p>
+    <!-- #_blank -->
+    <p><a class="new-tab" href="https://www.adobe.com/test#_blank">New Tab</a></p>
+    <!-- invalid url -->
+    <p><a href="http://localhost:2000/[is/]invalid">Invalid URL</a></p>
+  </div>
+</main>
+
+<p><a href="https://test--milo--adobecom.hlx.page/test">Milo Test</a></p>
+<p><a href="https://milo.adobe.com/test">Milo Test</a></p>
+<p><a href="https://www.adobe.com/test">Milo Test</a></p>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -422,4 +422,37 @@ describe('Utils', () => {
       expect(lanaStub.calledOnceWith(expectedError)).to.be.true;
     });
   });
+
+  describe('useDotHtml', async () => {
+    beforeEach(async () => {
+      window.lana = { log: (msg) => console.error(msg) };
+      document.body.innerHTML = await readFile({ path: './mocks/useDotHtml.html' });
+    });
+    afterEach(() => {
+      window.lana.release?.();
+    });
+    it('should add .html to relative links when enabled', async () => {
+      utils.setConfig({ useDotHtml: true, htmlExclude: [/exclude\/.*/gm] });
+      expect(utils.getConfig().useDotHtml).to.be.true;
+      await utils.decorateLinks(document.getElementById('linklist'));
+      expect(document.getElementById('excluded')?.getAttribute('href'))
+        .to.equal('/exclude/this/page');
+      const htmlLinks = document.querySelectorAll('.has-html');
+      htmlLinks.forEach((link) => {
+        expect(link.href).to.contain('.html');
+      });
+    });
+
+    it('should not add .html to relative links when disabled', async () => {
+      utils.setConfig({ useDotHtml: false, htmlExclude: [/exclude\/.*/gm] });
+      expect(utils.getConfig().useDotHtml).to.be.false;
+      await utils.decorateLinks(document.getElementById('linklist'));
+      expect(document.getElementById('excluded')?.getAttribute('href'))
+        .to.equal('/exclude/this/page');
+      const htmlLinks = document.querySelectorAll('.has-html');
+      htmlLinks.forEach((link) => {
+        expect(link.href).to.not.contain('.html');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Consumer projects can now set `config.useDotHtml = true` to force using .html on all pages for that project.

Resolves: [MWPW-135447](https://jira.corp.adobe.com/browse/MWPW-135447)

**Test URLs:**
Bacom link with working .html links: https://usedothtml--bacom--adobecom.hlx.page/?milolibs=homehtml&martech=off

- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://homehtml--milo--adobecom.hlx.page/?martech=off
