### PR TITLE
MWPW-135352 Adding checkboxes for Marketo

### DIFF
--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -168,8 +168,6 @@
   border: 0;
   border-radius: 2px;
   padding: 0;
-  width: 14px!important;
-  height: 14px;
   position: relative;
   top: 2px;
   margin-right: 10px;
@@ -191,9 +189,6 @@
   height: 10px;
   border: 2px solid var(--marketo-form-border);
   border-radius: 2px;
-  position: absolute;
-  top: 0;
-  left: 0;
 }
 
 .marketo .mktoForm .mktoCheckboxList.mktoInvalid input::before {

--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -191,8 +191,8 @@ export default function init(el) {
 
   createIntersectionObserver({
     el,
-    callback: (el) => {
-      loadMarketo(el, formData);
+    callback: (target) => {
+      loadMarketo(target, formData);
     },
   });
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding checkbox styles for Marketo forms.
  * Note: Use a country like Korea, South to see privacy checkboxes.
* Update mobile focus fix to only activate on select field types.
  * Necessary for testing checkboxes on mobile.

Resolves: [MWPW-135352](https://jira.corp.adobe.com/browse/MWPW-135352)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/bmarshal/mcz/marketo?martech=off
- After: https://bmarshal-marketo-checkbox--milo--adobecom.hlx.page/drafts/bmarshal/mcz/marketo?martech=off

**BACOM URLs:**
- Before: https://main--bacom--adobecom.hlx.live/uk/resources/reports/state-of-marketing-automation-b?martech=off
- After: https://main--bacom--adobecom.hlx.live/uk/resources/reports/state-of-marketing-automation-b?martech=off&milolibs=bmarshal-marketo-checkbox