### PR TITLE
Action Blocks added to config for consumers

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -6,6 +6,8 @@ const MILO_TEMPLATES = [
 ];
 const MILO_BLOCKS = [
   'accordion',
+  'action-item',
+  'action-scroller',
   'adobetv',
   'article-feed',
   'article-header',


### PR DESCRIPTION
Adding both action-item and action-scroller blocks to the `/utils/utils.js` file for consumers.

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/?martech=off
- After: https://main--bacom--adobecom.hlx.page/?martech=off&milolibs=sarchibeque-actions-inlib
