### PR TITLE
MWPW-135537 Add ability to hide a block

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -268,3 +268,7 @@ picture.bg-img img {
 .gnav-hide {
   opacity: 0;
 }
+
+.hide-block {
+  display: none !important;
+}

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -389,7 +389,11 @@ function checkForExpBlock(name, expBlocks) {
 }
 
 export async function loadBlock(block) {
-  if (block.classList.contains('hide-block')) return block;
+  if (block.classList.contains('hide-block')) {
+    block.remove();
+    return null;
+  }
+
   let name = block.classList[0];
   const { miloLibs, codeRoot, expBlocks } = getConfig();
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -389,6 +389,7 @@ function checkForExpBlock(name, expBlocks) {
 }
 
 export async function loadBlock(block) {
+  if (block.classList.contains('hide-block')) return block;
   let name = block.classList[0];
   const { miloLibs, codeRoot, expBlocks } = getConfig();
 


### PR DESCRIPTION
Authors can add `hide block` to the block classlist for it to be ignored and hidden (js & css for the block will not be loaded and the block will not be decorated).

Resolves: [MWPW-135537](https://jira.corp.adobe.com/browse/MWPW-135537)

**Test URLs:**
There are 2 quote blocks on the ben & jerry page that have "hide block" set, so all quotes will be hidden in the after branch.

- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/ben-and-jerrys-case-study?martech=off
- After: https://hideblock--milo--adobecom.hlx.page/drafts/cpeyer/ben-and-jerrys-case-study?martech=off
