### PR TITLE
Only run when MEP or MEP param is enabled

### DIFF
--- a/libs/features/personalization/add-preview-to-config.js
+++ b/libs/features/personalization/add-preview-to-config.js
@@ -4,14 +4,13 @@ export default async function addPreviewToConfig({
   pageUrl,
   persEnabled,
   persManifests,
-  previewPage,
   targetEnabled,
 }) {
   const { mep: mepOverride, mepHighlight, mepButton } = Object.fromEntries(pageUrl.searchParams);
   const config = updateConfig({
     ...getConfig(),
     mep: {
-      preview: (mepButton !== 'off' && (mepOverride !== undefined || (previewPage && (persEnabled || targetEnabled)))),
+      preview: (mepButton !== 'off' && (mepOverride !== undefined || persEnabled || targetEnabled)),
       override: mepOverride ? decodeURIComponent(mepOverride) : '',
       highlight: (mepHighlight !== undefined && mepHighlight !== 'false'),
     },

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -739,16 +739,14 @@ async function checkForPageMods() {
       .filter((path) => path?.trim());
   }
 
-  const { mep: mepOverride } = Object.fromEntries(PAGE_URL.searchParams);
   const { env } = getConfig();
-  const previewPage = env?.name === 'stage' || env?.name === 'local';
-  if (mepOverride || mepOverride === '' || previewPage) {
+  const { mep } = Object.fromEntries(PAGE_URL.searchParams);
+  if (mep !== undefined || (env.name !== 'prod' && (persEnabled || targetEnabled))) {
     const { default: addPreviewToConfig } = await import('../features/personalization/add-preview-to-config.js');
     persManifests = await addPreviewToConfig({
       pageUrl: PAGE_URL,
       persEnabled,
       persManifests,
-      previewPage,
       targetEnabled,
     });
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -740,8 +740,8 @@ async function checkForPageMods() {
   }
 
   const { env } = getConfig();
-  const { mep } = Object.fromEntries(PAGE_URL.searchParams);
-  if (mep !== undefined || (env.name !== 'prod' && (persEnabled || targetEnabled))) {
+  const mep = PAGE_URL.searchParams.get('mep');
+  if (mep !== null || (env.name !== 'prod' && (persEnabled || targetEnabled))) {
     const { default: addPreviewToConfig } = await import('../features/personalization/add-preview-to-config.js');
     persManifests = await addPreviewToConfig({
       pageUrl: PAGE_URL,


### PR DESCRIPTION
`addPreviewToConfig` should only run when either:
1. the `mep` param is added to url
2. We are not on prod and target or MEP is activated for the page

Resolves: No Jira Ticket

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://meppreview--milo--adobecom.hlx.page/?martech=off
