### PR TITLE
MWPW-134907 - decorate plain text in text block

### DIFF
--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -10,6 +10,8 @@
 .text-block p,
 .text-block [class^="body-"] { margin: var(--spacing-xs) 0; }
 
+.text-block [class^="body-"]:only-child { margin: 0; }
+
 .text-block [class^="heading"] { margin: 0 0 var(--spacing-xs) 0; }
 
 .text-block [class^="detail"] { margin: 0 0 var(--spacing-xxs) 0; }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -46,6 +46,12 @@ export function decorateBlockText(el, config = ['m', 's', 'm']) {
     }
     const emptyPs = el.querySelectorAll(':scope p:not([class])');
     if (emptyPs) emptyPs.forEach((p) => { p.classList.add(`body-${config[1]}`); });
+    if (!headings?.length && !emptyPs?.length) {
+      const wrapper = el.querySelector(':scope > div');
+      [...wrapper.children]
+        .filter((child) => child.textContent.trim() !== '')
+        .forEach((text) => text.classList.add(`body-${config[1]}`));
+    }
   }
   decorateButtons(el);
   decorateLinkAnalytics(el, headings);


### PR DESCRIPTION
Applies default body styles to content in blocks that use `decorateBlockText` when no formatting is applied in document. Which supports ability to apply text block style overrides on plain text in the `text` block. Also removes margin in text block for body elements that are an only child.

Resolves: [MWPW-134907](https://jira.corp.adobe.com/browse/MWPW-134907)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/format-text?martech=off
- After: https://sarchibeque-mwpw-134907-text-overrides--milo--adobecom.hlx.page/drafts/sarchibeque/format-text?martech=off
