### PR TITLE
Removes temporary CSS code for Card-Logo from CAAS Configurator

### DIFF
--- a/libs/blocks/caas/caas.css
+++ b/libs/blocks/caas/caas.css
@@ -11,34 +11,6 @@ main > .section > .content .consonant-Wrapper--1600MaxWidth .consonant-Wrapper-i
   width: 100%;
 }
 
-/* temp fix for caas */
-[class$='Card-logo'] {
-  border: 1px solid transparent;
-  background-color: white;
-  border-bottom-right-radius: 4px;
-  border-top-right-radius: 4px;
-  min-height: 48px;
-  max-height: 48px;
-  bottom: 16px;
-  display: block;
-  font-size: 0;
-  left: 0;
-  line-height: 0;
-  padding: 8px 24px;
-  position: absolute;
-  z-index: 1;
-}
-
-[class$='Card-logo'] img {
-  height: auto;
-  min-height: 32px;
-  max-height: 32px;
-  max-width: 90px;
-  object-fit: contain;
-  user-select: none;
-  width: auto;
-}
-
 /* Dexter Modal CSS - can be removed when caas team fixes MWPW-118588*/
 .aem-Grid {
   display: block;


### PR DESCRIPTION
Removes temporary CSS code for Card-Logo from CAAS Configurator

Resolves: [MWPW-135200](https://jira.corp.adobe.com/browse/MWPW-135200)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/caas
- After: https://mwpw-135200--milo--adobecom.hlx.page/tools/caas
