### PR TITLE
Remove extra spaces and new lines from tracking attribute values

### DIFF
--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -8,7 +8,7 @@ export function decorateBlockAnalytics(blockEl) {
 
 export function decorateLinkAnalytics(textEl, headings) {
   const headingText = [...headings].map((heading) => heading.textContent);
-  textEl.setAttribute('daa-lh', headingText.join('|'));
+  textEl.setAttribute('daa-lh', headingText.join('|').replace(/\s+/g, ' ').trim());
   const links = textEl.querySelectorAll('a, button');
   links.forEach((link, i) => {
     let linkType = 'link';

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -16,7 +16,7 @@ export function decorateLinkAnalytics(textEl, headings) {
     if (classList.contains('con-button') && classList.contains('blue')) { linkType = 'filled'; }
     if (classList.contains('con-button') && classList.contains('outline')) { linkType = 'outline'; }
     const str = `${linkType}|${link.innerText} ${i + 1}`;
-    link.setAttribute('daa-ll', str);
+    link.setAttribute('daa-ll', str.replace(/\s+/g, ' ').trim());
   });
 }
 


### PR DESCRIPTION
* Remove extra spacing and new lines added to analytics tracking attribute value

Resolves: [MWPW-135652](https://jira.corp.adobe.com/browse/MWPW-135652)

**Test URLs:**

Milo
- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/accordion?martech=off
- After: https://accordion-analytics--milo--ruchika4.hlx.page/drafts/ruchika/accordion?martech=off

CC
- Before: https://main--cc--adobecom.hlx.page/creativecloud/file-types/image/raster/dwf-file
- After: https://main--cc--adobecom.hlx.page/creativecloud/file-types/image/raster/dwf-file?milolibs=accordion-analytics--milo--ruchika4

Note: To test go to accordion on the page and click on + sign to expand the accordion. In network tab search for /ee to see the analytics value.