### PR TITLE
[MWPW-135217] Use decorateLinks before decorating Gnav

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -68,6 +68,16 @@ class Footer {
 
     // TODO: log to LANA if Footer content could not be found
     if (!this.body) return;
+    // TODO: revisit region picker and social links decoration logic
+    const regionAnchor = this.body.querySelector('.region-selector a');
+    if (regionAnchor?.href) {
+      regionAnchor.setAttribute('href', `${regionAnchor.getAttribute('href')}#_dnt#_dnb`);
+    }
+    const socialLinks = document.querySelectorAll('.social a');
+    socialLinks.forEach((socialLink) => {
+      socialLink.setAttribute('href', `${socialLink.getAttribute('href')}#_dnb`);
+    });
+    decorateLinks(this.body);
 
     // Order is important, decorateFooter makes use of elements
     // which have already been created in previous steps
@@ -264,9 +274,8 @@ class Footer {
       const link = socialBlock.querySelector(`a[href*="${platform}"]`);
       if (!link) return;
 
-      // Add '#_dnb' to the 'href' value, since certain social media platforms are also blocks
       const iconElem = toFragment`<li class="feds-social-item">
-          <a href="${link.href}#_dnb" class="feds-social-link" aria-label="${platform}">
+          <a href="${link.href}" class="feds-social-link" aria-label="${platform}" target="_blank">
             <svg xmlns="http://www.w3.org/2000/svg" class="feds-social-icon" alt="${platform} logo">
               <use href="#footer-icon-${platform}" />
             </svg>
@@ -325,8 +334,6 @@ class Footer {
           ${this.elements.legal}
         </div>
       </div>`;
-
-    decorateLinks(this.elements.footer);
 
     return this.elements.footer;
   };

--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -34,6 +34,7 @@
   display: flex;
   align-items: center;
   padding: 12px;
+  border: none;
   color: var(--feds-color-link--light);
   white-space: nowrap;
   flex-shrink: 0;

--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -1,4 +1,4 @@
-import { getMetadata, localizeLink } from '../../../../utils/utils.js';
+import { getMetadata } from '../../../../utils/utils.js';
 import { toFragment, lanaLog } from '../../utilities/utilities.js';
 
 const metadata = {
@@ -35,12 +35,6 @@ const setBreadcrumbSEO = (breadcrumbs) => {
   document.head.append(script);
 };
 
-const localizeEntries = (anchor) => {
-  if (!anchor) return;
-  const href = anchor.getAttribute('href');
-  anchor.setAttribute('href', localizeLink(href));
-};
-
 const createBreadcrumbs = (element) => {
   if (!element) return null;
   const ul = element.querySelector('ul');
@@ -58,12 +52,10 @@ const createBreadcrumbs = (element) => {
     .split(',')
     .map((item) => item.trim()) || [];
 
-  ul.querySelectorAll('li').forEach(
-    (li) => {
-      if (hiddenEntries.includes(li.innerText?.toLowerCase().trim())) return li.remove();
-      return localizeEntries(li.querySelector('a'));
-    },
-  );
+  ul.querySelectorAll('li').forEach((li) => {
+    if (hiddenEntries.includes(li.innerText?.toLowerCase().trim())) li.remove();
+  });
+
   const breadcrumbs = toFragment`
     <div class="feds-breadcrumbs-wrapper">
       <nav class="feds-breadcrumbs" aria-label="Breadcrumb">${ul}</nav>

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -3,8 +3,7 @@ import {
   getConfig,
   getMetadata,
   loadIms,
-  localizeLink,
-  decorateSVG,
+  decorateLinks,
 } from '../../utils/utils.js';
 import {
   toFragment,
@@ -131,18 +130,6 @@ const getBrandImage = (image) => {
   // Return the default Adobe logo if an image is not available
   if (!image) return CONFIG.icons.company;
 
-  try {
-    // Try to decorate image as SVG
-    const decoratedSvg = decorateSVG(image);
-    // 'decorateSVG' might return the original element if decoration fails
-    // or the picture wrapped in an anchor element in certain cases
-    const svg = decoratedSvg instanceof HTMLPictureElement
-      ? decoratedSvg : decoratedSvg.querySelector('picture');
-    if (svg) return svg;
-  } catch (e) {
-    // continue execution
-  }
-
   // Try to decorate image as PNG, JPG or JPEG
   const imgText = image?.textContent || '';
   const [source, alt] = imgText.split('|');
@@ -181,6 +168,7 @@ class Gnav {
 
     this.el = el;
     this.body = body;
+    decorateLinks(this.body);
     this.elements = {};
   }
 
@@ -445,7 +433,7 @@ class Gnav {
     if (!rawBlock) return '';
 
     // Get all non-image links
-    const imgRegex = /(\.png|\.svg|\.jpg|\.jpeg)/;
+    const imgRegex = /(\.png|\.jpg|\.jpeg)/;
     const blockLinks = [...rawBlock.querySelectorAll('a')];
     const link = blockLinks.find((blockLink) => !imgRegex.test(blockLink.href)
       && !imgRegex.test(blockLink.textContent));
@@ -459,24 +447,27 @@ class Gnav {
     if (!renderImage && !renderLabel) return '';
 
     // Create image element
-    let imageEl = '';
+    const getImageEl = () => {
+      const svgImg = rawBlock.querySelector('picture img[src$=".svg"]');
+      if (svgImg) return svgImg;
 
-    if (renderImage) {
       const image = blockLinks.find((blockLink) => imgRegex.test(blockLink.href)
         || imgRegex.test(blockLink.textContent));
-      imageEl = toFragment`<span class="${classPrefix}-image">${getBrandImage(image)}</span>`;
-    }
+      return getBrandImage(image);
+    };
+
+    const imageEl = renderImage
+      ? toFragment`<span class="${classPrefix}-image">${getImageEl()}</span>`
+      : '';
 
     // Create label element
-    let labelEl = '';
-
-    if (renderLabel) {
-      labelEl = toFragment`<span class="${classPrefix}-label">${link.textContent}</span>`;
-    }
+    const labelEl = renderLabel
+      ? toFragment`<span class="${classPrefix}-label">${link.textContent}</span>`
+      : '';
 
     // Create final template
     const decoratedElem = toFragment`
-      <a href="${localizeLink(link.getAttribute('href'))}" class="${classPrefix}" daa-ll="${analyticsValue}">
+      <a href="${link.href}" class="${classPrefix}" daa-ll="${analyticsValue}">
         ${imageEl}
         ${labelEl}
       </a>`;
@@ -573,16 +564,14 @@ class Gnav {
     switch (itemType) {
       case 'syncDropdownTrigger':
       case 'asyncDropdownTrigger': {
-        const dropdownTrigger = toFragment`<a
-          href="#"
+        const dropdownTrigger = toFragment`<button
           class="feds-navLink feds-navLink--hoverCaret"
-          role="button"
           aria-expanded="false"
           aria-haspopup="true"
           daa-ll="${getAnalyticsValue(item.textContent, index + 1)}"
           daa-lh="header|Open">
             ${item.textContent.trim()}
-          </a>`;
+          </button>`;
 
         const isSectionMenu = item.closest('.section') instanceof HTMLElement;
         const tag = isSectionMenu ? 'section' : 'div';
@@ -618,16 +607,12 @@ class Gnav {
           </div>`;
       case 'link': {
         const linkElem = item.querySelector('a');
-        const navLink = toFragment`<a
-          href="${localizeLink(linkElem.href)}"
-          class="feds-navLink"
-          daa-ll="${getAnalyticsValue(linkElem.textContent, index + 1)}">
-            ${linkElem.textContent.trim()}
-          </a>`;
+        linkElem.className = 'feds-navLink';
+        linkElem.setAttribute('daa-ll', getAnalyticsValue(linkElem.textContent, index + 1));
 
         const linkTemplate = toFragment`
           <div class="feds-navItem">
-            ${navLink}
+            ${linkElem}
           </div>`;
         return linkTemplate;
       }
@@ -645,8 +630,12 @@ class Gnav {
   decorateBreadcrumbs = async () => {
     if (!this.el.classList.contains('has-breadcrumbs')) return null;
     if (this.elements.breadcrumbsWrapper) return this.elements.breadcrumbsWrapper;
+    const breadcrumbsElem = this.el.querySelector('.breadcrumbs');
+    if (!breadcrumbsElem) return null;
+    // Breadcrumbs are not initially part of the nav, need to decorate the links
+    decorateLinks(breadcrumbsElem);
     const createBreadcrumbs = await loadBlock('../features/breadcrumbs/breadcrumbs.js');
-    this.elements.breadcrumbsWrapper = await createBreadcrumbs(this.el.querySelector('.breadcrumbs'));
+    this.elements.breadcrumbsWrapper = await createBreadcrumbs(breadcrumbsElem);
     return this.elements.breadcrumbsWrapper;
   };
 

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -9,7 +9,7 @@ import {
   trigger,
   isDesktop,
 } from '../utilities.js';
-import { decorateLinks, localizeLink } from '../../../../utils/utils.js';
+import { decorateLinks } from '../../../../utils/utils.js';
 import { replaceText } from '../../../../features/placeholders.js';
 
 const decorateHeadline = (elem) => {
@@ -74,6 +74,7 @@ const decorateLinkGroup = (elem, index) => {
       ${imageElem}
       ${contentElem}
     </a>`;
+  if (link?.target) linkGroup.target = link.target;
 
   return linkGroup;
 };
@@ -172,7 +173,6 @@ const decoratePromo = (elem, index) => {
 };
 
 const decorateColumns = async ({ content, separatorTagName = 'H5' } = {}) => {
-  decorateLinks(content);
   const hasMultipleColumns = content.children.length > 1;
 
   // The resulting template structure should follow these rules:
@@ -264,8 +264,7 @@ const decorateMenu = (config) => logErrorFor(async () => {
   if (config.type === 'asyncDropdownTrigger') {
     const pathElement = config.item.querySelector('a');
     if (!(pathElement instanceof HTMLElement)) return;
-    const path = localizeLink(pathElement.href);
-    const res = await fetch(`${path}.plain.html`);
+    const res = await fetch(`${pathElement.href}.plain.html`);
     if (res.status !== 200) return;
     const content = await res.text();
     const parsedContent = await replaceText(content, getFedsPlaceholderConfig(), /{{(.*?)}}/g, 'feds');
@@ -275,6 +274,8 @@ const decorateMenu = (config) => logErrorFor(async () => {
         </div>
       </div>`;
 
+    // Content has been fetched dynamically, need to decorate links
+    decorateLinks(menuTemplate);
     await decorateColumns({ content: menuTemplate.firstElementChild });
     config.template.classList.add('feds-navItem--megaMenu');
   }

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -110,14 +110,13 @@ export async function loadDecorateMenu() {
 export function decorateCta({ elem, type = 'primaryCta', index } = {}) {
   const modifier = type === 'secondaryCta' ? 'secondary' : 'primary';
 
+  const clone = elem.cloneNode(true);
+  clone.className = `feds-cta feds-cta--${modifier}`;
+  clone.setAttribute('daa-ll', getAnalyticsValue(clone.textContent, index));
+
   return toFragment`
     <div class="feds-cta-wrapper">
-      <a
-        href="${elem.href}"
-        class="feds-cta feds-cta--${modifier}"
-        daa-ll="${getAnalyticsValue(elem.textContent, index)}">
-          ${elem.textContent}
-      </a>
+      ${clone}
     </div>`;
 }
 

--- a/test/blocks/global-navigation/features/breadcrumbs.test.js
+++ b/test/blocks/global-navigation/features/breadcrumbs.test.js
@@ -2,8 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
 import breadcrumbs from '../../../../libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js';
 import { toFragment } from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
-import { mockRes } from '../test-utilities.js';
-import { setConfig } from '../../../../libs/utils/utils.js';
+import { mockRes, createFullGlobalNavigation } from '../test-utilities.js';
 
 export const breadcrumbMock = () => toFragment`
   <div class="breadcrumbs">
@@ -131,19 +130,19 @@ describe('breadcrumbs', () => {
   });
 
   it('should localize breadcrumb links', async () => {
-    setConfig({
+    const customConfig = {
       locales: {
         '': { ietf: 'en-US' },
         fi: { ietf: 'fi-FI' },
       },
       pathname: '/fi/',
       prodDomains: 'http://localhost:2000',
-    });
+    };
 
-    await breadcrumbs(breadcrumbMock());
-    const script = document.querySelector('script');
+    const breadcrumbsEl = breadcrumbMock();
+    await createFullGlobalNavigation({ breadcrumbsEl, customConfig });
+    const script = document.querySelector('script[type="application/ld+json"]');
     expect(script).to.exist;
-    expect(script.type).to.equal('application/ld+json');
     expect(JSON.parse(script.innerHTML)).to.deep.equal(
       {
         '@context': 'https://schema.org',
@@ -159,7 +158,7 @@ describe('breadcrumbs', () => {
             '@type': 'ListItem',
             position: 2,
             name: 'Future Releases',
-            item: 'http://localhost:2000/fi/', // <-- localised prod domain
+            item: 'http://localhost:2000/fi/', // <-- localized prod domain
           },
           {
             '@type': 'ListItem',

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -722,7 +722,7 @@ describe('global navigation', () => {
         signIn.click();
 
         const signInDropdown = document.querySelector(selectors.signInDropdown);
-        const dropdownSignIn = signInDropdown.querySelector('[href="https://adobe.com?sign-in=true"]');
+        const dropdownSignIn = signInDropdown.querySelector('[href$="?sign-in=true"]');
 
         window.adobeIMS = { signIn: sinon.spy() };
 
@@ -806,7 +806,7 @@ describe('global navigation', () => {
         signIn.click();
 
         const signInDropdown = document.querySelector(selectors.signInDropdown);
-        const dropdownSignIn = signInDropdown.querySelector('[href="https://adobe.com?sign-in=true"]');
+        const dropdownSignIn = signInDropdown.querySelector('[href$="?sign-in=true"]');
 
         window.adobeIMS = { signIn: sinon.spy() };
 

--- a/test/blocks/global-navigation/mocks/global-navigation-long.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-long.plain.js
@@ -1,16 +1,16 @@
 // Uses the franklin structure without any customizations
 export default `<div>
   <div class="gnav-brand logo">
+  <div>
     <div>
-      <div>
-        <p>
-          <a href="/drafts/ramuntea/adobe-logo.svg"
-            >http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg</a
-          >
-        </p>
-        <p><a href="https://www.adobe.com/">Adobe</a></p>
-      </div>
+      <p>
+        <a href="http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg">
+          http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg
+        </a>
+      </p>
+      <p><a href="https://www.adobe.com/">Adobe</a></p>
     </div>
+  </div>
   </div>
 </div>
 <div>
@@ -18,7 +18,7 @@ export default `<div>
     <div>
       <div>
         <h2 id="cloud-menu">
-          <a href="/libs/feds/drafts/ramuntea/large-menu">Cloud Menu</a>
+          <a href="./large-menu">Cloud Menu</a>
         </h2>
       </div>
     </div>

--- a/test/blocks/global-navigation/mocks/global-navigation-only-brand-no-image.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-only-brand-no-image.plain.js
@@ -4,7 +4,9 @@ export default `
   <div>
     <div>
       <p>
-        <a href="/drafts/ramuntea/adobe-logo.svg">http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg</a>
+        <a href="http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg">
+          http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg
+        </a>
       </p>
       <p><a href="https://www.adobe.com/">Adobe</a></p>
     </div>

--- a/test/blocks/global-navigation/mocks/global-navigation-only-brand.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-only-brand.plain.js
@@ -4,7 +4,9 @@ export default `
   <div>
     <div>
       <p>
-        <a href="/drafts/ramuntea/adobe-logo.svg">http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg</a>
+        <a href="http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg">
+          http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg
+        </a>
       </p>
       <p><a href="https://www.adobe.com/">Adobe</a></p>
     </div>

--- a/test/blocks/global-navigation/mocks/global-navigation-only-non-svg-brand.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-only-non-svg-brand.plain.js
@@ -4,7 +4,9 @@ export default `
   <div>
     <div>
       <p>
-        <a href="/drafts/ramuntea/adobe-logo.png">http://localhost:2000/test/blocks/global-navigation/mocks/profile-pic.png | Alternative text</a>
+        <a href="http://localhost:2000/test/blocks/global-navigation/mocks/profile-pic.png">
+        http://localhost:2000/test/blocks/global-navigation/mocks/profile-pic.png | Alternative text
+        </a>
       </p>
       <p><a href="https://www.adobe.com/">Adobe</a></p>
     </div>

--- a/test/blocks/global-navigation/mocks/global-navigation.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation.plain.js
@@ -4,9 +4,9 @@ export default `<div>
     <div>
       <div>
         <p>
-          <a href="/drafts/ramuntea/adobe-logo.svg"
-            >http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg</a
-          >
+          <a href="http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg">
+            http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg
+          </a>
         </p>
         <p><a href="https://www.adobe.com/">Adobe</a></p>
       </div>
@@ -18,7 +18,7 @@ export default `<div>
     <div>
       <div>
         <h2 id="cloud-menu">
-          <a href="/libs/feds/drafts/ramuntea/large-menu">Cloud Menu</a>
+          <a href="./large-menu">Cloud Menu</a>
         </h2>
       </div>
     </div>

--- a/test/blocks/global-navigation/mocks/large-menu.plain.html
+++ b/test/blocks/global-navigation/mocks/large-menu.plain.html
@@ -1,0 +1,376 @@
+<div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >What is Creative Cloud?</a
+          >
+        </p>
+        <p>Creative apps and services for everyone</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Photographers</a
+          >
+        </p>
+        <p>Lightroom, Photoshop, and more</p>
+      </div>
+    </div>
+  </div>
+  <h5 id="test-heading">Test heading</h5>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Students and Teachers</a
+          >
+        </p>
+        <p>Save over 60% on Creative Cloud</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Small and medium business</a
+          >
+        </p>
+        <p>Creative apps and services for teams</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Enterprise</a
+          >
+        </p>
+        <p>Solutions for large organizations</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <a href="https://business.adobe.com/what-is-experience-cloud.html"
+          >No subtitle</a
+        >
+      </div>
+    </div>
+  </div>
+  <p>
+    <a href="https://www.adobe.com/creativecloud/plans.html"
+      >View plans and pricing</a
+    >
+  </p>
+  <p>
+    <a href="https://www.adobe.com/creativecloud/plans.html"
+      >And another link</a
+    >
+  </p>
+</div>
+<div>
+  <h5 id="featured-products">Featured products</h5>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Photoshop</a
+          >
+        </p>
+        <p>Image editing and design</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Lightroom</a
+          >
+        </p>
+        <p>The cloud-based photo service</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Illustrator</a
+          >
+        </p>
+        <p>Vector graphics and illustration</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Premiere Pro</a
+          >
+        </p>
+        <p>Video editing and production</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Adobe Acrobat</a
+          >
+        </p>
+        <p>The complete PDF solution</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Adobe Stock</a
+          >
+        </p>
+        <p>High-quality licensable assets</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <a href="https://business.adobe.com/what-is-experience-cloud.html"
+          >No subtitle</a
+        >
+      </div>
+    </div>
+  </div>
+  <p>
+    <strong
+      ><a href="https://business.adobe.com/what-is-experience-cloud.html"
+        >View all Creative Cloud products</a
+      ></strong
+    >
+  </p>
+</div>
+<div>
+  <h5 id="explore">Explore</h5>
+  <ul>
+    <li><a href="http://google.com/">Photo</a></li>
+    <li><a href="http://google.com/">Graphic design</a></li>
+    <li><a href="http://google.com/">Video</a></li>
+    <li><a href="http://google.com/">Illustration</a></li>
+    <li><a href="http://google.com/">UI and UX</a></li>
+    <li><a href="http://google.com/">Social media</a></li>
+    <li><a href="http://google.com/">3D and AR</a></li>
+  </ul>
+</div>
+<div>
+  <div class="gnav-promo image-only">
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=2000&format=webply&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=750&format=png&optimize=medium"
+            width="375"
+            height="514"
+          />
+        </picture>
+      </div>
+    </div>
+    <div>
+      <div><a href="https://www.adobe.com/">https://www.adobe.com/</a></div>
+    </div>
+  </div>
+</div>

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -13,7 +13,7 @@ import defaultProfile from './mocks/profile.js';
 import largeMenuMock from './mocks/large-menu.plain.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
 import { isElementVisible, selectors as keyboardSelectors } from '../../../libs/blocks/global-navigation/utilities/keyboard/utils.js';
-import { selectors as baseSelectors } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
+import { selectors as baseSelectors, toFragment } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
 
 export { isElementVisible };
 
@@ -84,13 +84,28 @@ export const config = {
   locales,
 };
 
+const defaultBreadcrumbsEl = () => toFragment`
+  <div class="breadcrumbs">
+    <div>
+      <div>
+        <ul>
+          <li><a href="/drafts/osahin/document">Home</a></li>
+          <li><a href="https://milo.adobe.com/">Drafts</a></li>
+          <li>Marquee</li>
+        </ul>
+      </div>
+    </div>
+  </div>`;
+
 /**
  *
  * @param {Object} param0
- * @param {String} param0.mode Sets viewport: "mobile" | "smallDesktop" | "desktop"
+ * @param {String} param0.viewport Sets viewport: "mobile" | "smallDesktop" | "desktop"
  * @param {Object} param0.placeholders Supply custom placeholders - mocks/placeholders.js
- * @param {String} param0.globalNavigation Render a gnav, default mocks/global-navigation.plain.js
  * @param {Boolean} param0.signedIn Set to false to simulate a signed out user
+ * @param {Object} param0.customConfig Set a custom config; a default one is used if not specified
+ * @param {Element} param0.breadcrumbsEl Use a custom breadcrumbs element
+ * @param {String} param0.globalNavigation Render a gnav, default mocks/global-navigation.plain.js
  * @description Creates a full global navigation instance. CAUTION: Search is not fully created.
  * @returns global navigation instance
  */
@@ -98,13 +113,15 @@ export const createFullGlobalNavigation = async ({
   viewport = 'desktop',
   placeholders,
   signedIn = true,
+  customConfig = config,
+  breadcrumbsEl = defaultBreadcrumbsEl(),
   globalNavigation,
 } = {}) => {
   const clock = sinon.useFakeTimers({
     // Intercept setTimeout and call the function immediately
     toFake: ['setTimeout'],
   });
-  setConfig(config);
+  setConfig(customConfig);
   await setViewport(viewports[viewport]);
   window.lana = { log: stub() };
   window.fetch = stub().callsFake((url) => {
@@ -126,20 +143,11 @@ export const createFullGlobalNavigation = async ({
       }),
     ),
   };
-  document.body.innerHTML = `
+
+  document.body.replaceChildren(toFragment`
     <header class="global-navigation has-breadcrumbs" daa-im="true" daa-lh="gnav|milo">
-      <div class="breadcrumbs">
-        <div>
-          <div>
-            <ul>
-              <li><a href="/drafts/osahin/document">Home</a></li>
-              <li><a href="https://milo.adobe.com/">Drafts</a></li>
-              <li>Marquee</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </header>`;
+      ${breadcrumbsEl}
+    </header>`);
 
   await Promise.all([
     loadStyles('../../../../libs/styles/styles.css'),

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -61,7 +61,7 @@ describe('global navigation utilities', () => {
 
   describe('decorateCta', () => {
     it('should return a fragment for a primary cta', () => {
-      const elem = { href: 'test', textContent: 'test' };
+      const elem = toFragment`<a href="test">test</a>`;
       const el = decorateCta({ elem });
       expect(el.tagName).to.equal('DIV');
       expect(el.className).to.equal('feds-cta-wrapper');
@@ -73,7 +73,7 @@ describe('global navigation utilities', () => {
     });
 
     it('should return a fragment for a secondary cta', () => {
-      const elem = { href: 'test', textContent: 'test' };
+      const elem = toFragment`<a href="test">test</a>`;
       const el = decorateCta({ elem, type: 'secondaryCta' });
       expect(el.tagName).to.equal('DIV');
       expect(el.className).to.equal('feds-cta-wrapper');


### PR DESCRIPTION
This PR aims to better follow Milo patterns for link handling in Gnav, to allow authors to use `#_blank`, `#_dnt`, etc. in a consistent way and to ensure all links are localised properly and receive the `.html` extension if needed.

Some additional notes:
- for the footer, `decorateLinks` was called after our decoration logic, we're now calling it before, to follow the same pattern as the (updated) Gnav logic. This causes two loose ends, for which we're opening a follow-up story to address as soon as there is bandwidth (https://jira.corp.adobe.com/browse/MWPW-135656);
- social links in the footer now receive a `target="_blank"` attribute, as these links always lead outside of adobe.com pages;
- dropdown triggers have been transformed into buttons. These shouldn't count towards analytics link hits and this should be better in terms of accessibility. This also reduces the scope of links to be decorated and avoids potential localisation issues;
- the breadcrumb links are no longer localised on their own, as the main 'global-navigation.js' file decorates the links beforehand;
- the logic that handled SVG decoration has been removed from `getBrandImage`, as the SVG should have been decorated previously by the `decorateLinks` call;
- the `createFullGlobalNavigation` method from 'test-utilities.js' has been updated to have arguments for a custom config and breadcrumbs element to be used when creating a full navigation for unit testing purposes;
- a 'large-menu.plain.html' file has been created, as a 404 message was being logged to the console;

### Diffs
To make sure all links are decorated properly and no new issues are introduced, I cross-referenced diffs between the decorated header and footer between the current logic and the one from this PR. I'm attaching them here as well

 | Header | Footer |
| ------------- | ------------- |
| <img alt="Header diff" src="https://github.com/adobecom/milo/assets/11267498/87ea7c4d-e003-4b9b-a1c4-7edcd0cb453b"> | <img alt="Footer diff" src="https://github.com/adobecom/milo/assets/11267498/f4e2f537-fd31-4c46-bba8-06141c182c33"> |

Resolves: [MWPW-135217](https://jira.corp.adobe.com/browse/MWPW-135217), [MWPW-135073](https://jira.corp.adobe.com/browse/MWPW-135073)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://hash-in-gnav-links--milo--overmyheadandbody.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
