### PR TITLE
MWPW-134576: Fixing update fragments in CC folder

### DIFF
--- a/tools/loc/config.js
+++ b/tools/loc/config.js
@@ -108,6 +108,8 @@ function getSharepointConfig(config) {
   // ${sharepointConfig.site} - MS Graph API Url with site pointers.
   const baseURI = `${sharepointConfig.site}${drive}/root:${sharepointConfig.rootFolders}`;
   const fgBaseURI = `${sharepointConfig.site}${drive}/root:${sharepointConfig.fgRootFolder}`;
+  const baseItemsURI = `${sharepointConfig.site}${drive}/items`;
+  const fgBaseItemsURI = `${sharepointConfig.site}${drive}/items`;
   return {
     ...sharepointConfig,
     clientApp: {
@@ -162,9 +164,10 @@ function getSharepointConfig(config) {
         },
       },
       excel: {
+        get: { baseItemsURI, fgBaseItemsURI },
         update: {
-          baseURI,
-          fgBaseURI,
+          baseItemsURI,
+          fgBaseItemsURI,
           method: 'POST',
         },
       },

--- a/tools/loc/config.js
+++ b/tools/loc/config.js
@@ -109,7 +109,6 @@ function getSharepointConfig(config) {
   const baseURI = `${sharepointConfig.site}${drive}/root:${sharepointConfig.rootFolders}`;
   const fgBaseURI = `${sharepointConfig.site}${drive}/root:${sharepointConfig.fgRootFolder}`;
   const baseItemsURI = `${sharepointConfig.site}${drive}/items`;
-  const fgBaseItemsURI = `${sharepointConfig.site}${drive}/items`;
   return {
     ...sharepointConfig,
     clientApp: {
@@ -164,10 +163,9 @@ function getSharepointConfig(config) {
         },
       },
       excel: {
-        get: { baseItemsURI, fgBaseItemsURI },
+        get: { baseItemsURI },
         update: {
           baseItemsURI,
-          fgBaseItemsURI,
           method: 'POST',
         },
       },


### PR DESCRIPTION
In the CC folder, whenever "Update Fragments" was clicked, it was expected that the fragments from the documents would be extracted and added to the excel workbook. However, earlier the following error was observed "Fragments found, but failed to update excel. Please try again" and the fragments were not getting added to the excel sheet. 

This PR addresses the above issue by making the necessary configuration changes for folders other than "Milo". Initially the code was written to handle "Update Fragments" only for Milo folder (which is the default folder). With this change, it can handle the functionality for folders other than "Milo" (including CC folder where the issue was first identified).

Resolves: MWPW-134576 (https://jira.corp.adobe.com/browse/MWPW-134576)

**Test URLs:**
https://locstg--milo--adobecom.hlx.page/tools/loc/index.html?project=cc--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Bbcfcc8d2-42be-4012-805d-3ff2a6127e07%257D%26action%3Deditnew
