### PR TITLE
[MWPW-135717] Ensure dropdowns are visible on Safari

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -404,6 +404,7 @@ header.global-navigation {
   line-height: 1.4;
   white-space: nowrap;
   z-index: 1;
+  transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */
 }
 
 .feds-signIn[aria-expanded = "true"] + .feds-signIn-dropdown {
@@ -498,6 +499,7 @@ header.global-navigation {
     padding: 0;
     z-index: 1;
     box-shadow: 0 3px 3px 0 rgb(0 0 0 / 20%);
+    transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */
   }
 
   [dir = "rtl"] .feds-popup {


### PR DESCRIPTION
This addresses an issue in Safari well elements nested inside parents that have `position: sticky;` might have their `z-index` property disregarded.

Resolves: [MWPW-135717](https://jira.corp.adobe.com/browse/MWPW-135717)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
- After: https://dropdown-visibility--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off

**Consumer Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/products/product-analytics/pricing
- After: https://main--bacom--adobecom.hlx.page/products/product-analytics/pricing?milolibs=dropdown-visibility--milo--overmyheadandbody
