### PR TITLE
Marquee: Make sure there's actually text before loading handleFocalPoint

### DIFF
--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -49,7 +49,7 @@ const decorateBlockBg = (block, node) => {
     }
 
     const pic = child.querySelector('picture');
-    if (pic && (child.childElementCount === 2 || child.textContent)) {
+    if (pic && (child.childElementCount === 2 || child.textContent?.trim())) {
       const { handleFocalpoint } = await import('../section-metadata/section-metadata.js');
       handleFocalpoint(pic, child, true);
     }


### PR DESCRIPTION
The marquee is loading section-metadata.js even when the `textContent` is just whitespace.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://marqueefocalfix--milo--adobecom.hlx.page/?martech=off
