### PR TITLE
[SEO-855] Expand favicon support

### DIFF
--- a/libs/utils/favicon.js
+++ b/libs/utils/favicon.js
@@ -1,11 +1,28 @@
-export default function loadFavicon({ getConfig, getMetadata }) {
-  const { codeRoot } = getConfig();
-  const name = getMetadata('favicon') || 'favicon';
-  const favBase = `${codeRoot}/img/favicons/${name}`;
+export const FAVICON_TYPES = {
+  gif: 'image/gif',
+  ico: 'image/x-icon',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+};
 
+export function getFileExt(str) {
+  return str.toLowerCase().split('.').pop();
+}
+
+export default function loadFavicon({ getConfig, getMetadata }) {
   const favicon = document.head.querySelector('link[rel="icon"]');
-  const tags = `<link rel="apple-touch-icon" href="${favBase}-180.png">
-                <link rel="manifest" href="${favBase}.webmanifest">`;
-  favicon.insertAdjacentHTML('afterend', tags);
-  favicon.href = `${favBase}.ico`;
+  const { codeRoot } = getConfig();
+
+  const faviconVal = getMetadata('favicon') || 'favicon';
+  const ext = getFileExt(faviconVal);
+  if (ext && ext in FAVICON_TYPES) {
+    favicon.href = faviconVal;
+    favicon.type = FAVICON_TYPES[ext];
+  } else {
+    const favBase = `${codeRoot}/img/favicons/${faviconVal}`;
+    const tags = `<link rel="apple-touch-icon" href="${favBase}-180.png">
+                  <link rel="manifest" href="${favBase}.webmanifest">`;
+    favicon.insertAdjacentHTML('afterend', tags);
+    favicon.href = `${favBase}.ico`;
+  }
 }

--- a/libs/utils/favicon.js
+++ b/libs/utils/favicon.js
@@ -1,5 +1,5 @@
-export default function loadFavicon(createTag, config, getMetadata) {
-  const { codeRoot } = config;
+export default function loadFavicon({ getConfig, getMetadata }) {
+  const { codeRoot } = getConfig();
   const name = getMetadata('favicon') || 'favicon';
   const favBase = `${codeRoot}/img/favicons/${name}`;
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -910,7 +910,7 @@ export async function loadArea(area = document) {
       addRichResults(richResults, { createTag, getMetadata });
     }
     loadFooter();
-    import('./favicon.js').then((module) => module.default(createTag, getConfig(), getMetadata));
+    import('./favicon.js').then((module) => module.default({ getConfig, getMetadata }));
     if (config.experiment?.selectedVariant?.scripts?.length) {
       config.experiment.selectedVariant.scripts.forEach((script) => loadScript(script));
     }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -910,8 +910,7 @@ export async function loadArea(area = document) {
       addRichResults(richResults, { createTag, getMetadata });
     }
     loadFooter();
-    const { default: loadFavIcon } = await import('./favicon.js');
-    loadFavIcon(createTag, getConfig(), getMetadata);
+    import('./favicon.js').then((module) => module.default(createTag, getConfig(), getMetadata));
     if (config.experiment?.selectedVariant?.scripts?.length) {
       config.experiment.selectedVariant.scripts.forEach((script) => loadScript(script));
     }

--- a/test/utils/favicon.test.js
+++ b/test/utils/favicon.test.js
@@ -12,21 +12,31 @@ describe('Favicon', () => {
     setConfig({});
   });
 
-  it('sets all default favicon props', async () => {
+  it('should set default favicon', async () => {
     const getMetadata = stub().withArgs('favicon').returns(null);
     const faviconEl = document.head.querySelector('link[rel="icon"]');
     loadFavIcons({ getConfig, getMetadata });
     const expected = 'http://localhost:2000/img/favicons/favicon.ico';
-    waitFor(() => faviconEl.href === expected);
+    await waitFor(() => faviconEl.href === expected);
     expect(faviconEl.href).to.equal(expected);
   });
 
-  it('sets metadata favicon', async () => {
+  it('should set favicon from metadata key (legacy)', async () => {
     const getMetadata = stub().withArgs('favicon').returns('otis');
     const faviconEl = document.head.querySelector('link[rel="icon"]');
     loadFavIcons({ getConfig, getMetadata });
     const expected = 'http://localhost:2000/img/favicons/otis.ico';
-    waitFor(() => faviconEl.href === expected);
+    await waitFor(() => faviconEl.href === expected);
     expect(faviconEl.href).to.equal(expected);
+  });
+
+  it('should set favicon from metadata path', async () => {
+    const getMetadata = stub().withArgs('favicon').returns('/favicon.ico');
+    const faviconEl = document.head.querySelector('link[rel="icon"]');
+    loadFavIcons({ getConfig, getMetadata });
+    const expected = 'http://localhost:2000/favicon.ico';
+    await waitFor(() => faviconEl.href === expected);
+    expect(faviconEl.href).to.equal(expected);
+    expect(faviconEl.type).to.equal('image/x-icon');
   });
 });

--- a/test/utils/favicon.test.js
+++ b/test/utils/favicon.test.js
@@ -1,30 +1,30 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
+import { stub } from 'sinon';
 import { waitFor } from '../helpers/waitfor.js';
-import { setConfig, createTag, getMetadata } from '../../libs/utils/utils.js';
+
+import { getConfig, setConfig } from '../../libs/utils/utils.js';
 import loadFavIcons from '../../libs/utils/favicon.js';
 
-document.head.innerHTML = await readFile({ path: './mocks/head.html' });
-document.body.innerHTML = await readFile({ path: './mocks/body.html' });
-
 describe('Favicon', () => {
-  it('sets all default favicon props', async () => {
-    const config = setConfig({});
+  beforeEach(async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/head.html' });
+    setConfig({});
+  });
 
+  it('sets all default favicon props', async () => {
+    const getMetadata = stub().withArgs('favicon').returns(null);
     const faviconEl = document.head.querySelector('link[rel="icon"]');
-    loadFavIcons(createTag, config, getMetadata);
+    loadFavIcons({ getConfig, getMetadata });
     const expected = 'http://localhost:2000/img/favicons/favicon.ico';
     waitFor(() => faviconEl.href === expected);
     expect(faviconEl.href).to.equal(expected);
   });
 
   it('sets metadata favicon', async () => {
-    const meta = createTag('meta', { name: 'favicon', content: 'otis' });
-    document.head.append(meta);
-    const config = setConfig({});
-
+    const getMetadata = stub().withArgs('favicon').returns('otis');
     const faviconEl = document.head.querySelector('link[rel="icon"]');
-    loadFavIcons(createTag, config, getMetadata);
+    loadFavIcons({ getConfig, getMetadata });
     const expected = 'http://localhost:2000/img/favicons/otis.ico';
     waitFor(() => faviconEl.href === expected);
     expect(faviconEl.href).to.equal(expected);

--- a/test/utils/favicon.test.js
+++ b/test/utils/favicon.test.js
@@ -1,5 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
+import { waitFor } from '../helpers/waitfor.js';
 import { setConfig, createTag, getMetadata } from '../../libs/utils/utils.js';
 import loadFavIcons from '../../libs/utils/favicon.js';
 
@@ -9,17 +10,23 @@ document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 describe('Favicon', () => {
   it('sets all default favicon props', async () => {
     const config = setConfig({});
-    const favicon = document.head.querySelector('link[rel="icon"]');
+
+    const faviconEl = document.head.querySelector('link[rel="icon"]');
     loadFavIcons(createTag, config, getMetadata);
-    expect(favicon.href).to.equal('http://localhost:2000/img/favicons/favicon.ico');
+    const expected = 'http://localhost:2000/img/favicons/favicon.ico';
+    waitFor(() => faviconEl.href === expected);
+    expect(faviconEl.href).to.equal(expected);
   });
 
   it('sets metadata favicon', async () => {
     const meta = createTag('meta', { name: 'favicon', content: 'otis' });
     document.head.append(meta);
     const config = setConfig({});
-    const favicon = document.head.querySelector('link[rel="icon"]');
+
+    const faviconEl = document.head.querySelector('link[rel="icon"]');
     loadFavIcons(createTag, config, getMetadata);
-    expect(favicon.href).to.equal('http://localhost:2000/img/favicons/otis.ico');
+    const expected = 'http://localhost:2000/img/favicons/otis.ico';
+    waitFor(() => faviconEl.href === expected);
+    expect(faviconEl.href).to.equal(expected);
   });
 });


### PR DESCRIPTION
Make favicon loading async and add support for specifying an arbitrary relative or absolute file path for `favicon` of any kind, while retaining existing behavior for "name" values with default icon, apple, and manifest elements.

Resolves: [SEO-855](https://jira.corp.adobe.com/browse/SEO-855)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/hgpa/test/favicon/favicon-absolute?martech=off
- After: https://feat-favicon-metadata--milo--hparra.hlx.page/drafts/hgpa/test/favicon/favicon-absolute?martech=off
- After: https://feat-favicon-metadata--milo--hparra.hlx.page/drafts/hgpa/test/favicon/favicon-relative?martech=off

