### PR TITLE
[MWPW-135765] Visibility of Gnav absolute elements in Safari

### DIFF
--- a/libs/blocks/global-navigation/features/profile/dropdown.css
+++ b/libs/blocks/global-navigation/features/profile/dropdown.css
@@ -19,6 +19,7 @@
   line-height: 1;
   white-space: nowrap;
   z-index: 1;
+  transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */
 }
 
 [dir = "rtl"] .feds-profile-menu {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -436,6 +436,8 @@ header.global-navigation {
   position: absolute;
   top: 100%;
   right: 0;
+  z-index: 1;
+  transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */
 }
 
 [dir = "rtl"] #feds-googleLogin {
@@ -598,6 +600,7 @@ header.global-navigation {
     justify-content: center;
     border-bottom: unset;
     box-shadow: 0 3px 2px rgb(142 142 142 / 30%);
+    transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */
   }
 
   .feds-breadcrumbs {


### PR DESCRIPTION
With the latest release of Safari, there are issues with elements' position on the z axis, regardless of their `z-index` value, when `overflow: clip` and/or `position: sticky` are used. Activating hardware acceleration via the `transform` property solves the issue.

Resolves: [MWPW-135765](https://jira.corp.adobe.com/browse/MWPW-135765), [MWPW-135766](https://jira.corp.adobe.com/browse/MWPW-135766)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
- After: https://profile-dropdown-visibility--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
