### PR TITLE
[MWPW-135263] Adding variant to figure block

### DIFF
--- a/libs/blocks/figure/figure.css
+++ b/libs/blocks/figure/figure.css
@@ -13,6 +13,10 @@
   max-height: 600px;
 }
 
+.figure.full-height img {
+  max-height: unset;
+}
+
 .figure-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
* Adding the "full-height" variant to figure block for bacom-blog infographic replacement

Resolves: [MWPW-135263](https://jira.corp.adobe.com/browse/MWPW-135263)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/slavin/bacom-blog/infographic-test?martech=off
- After: https://figure-bacom-blog-variant--milo--jasonhowellslavin.hlx.page/drafts/slavin/bacom-blog/infographic-test?martech=off
