### PR TITLE
MWPW-134986 - Rendering nested fragments in the order of products

### DIFF
--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -202,18 +202,20 @@ export const nestedFragments = (
 
 const getNestedFragments = (resultResources, productCodes, fragKey) => {
   const fragArray = [];
-  resultResources?.data?.forEach((row) => {
-    if (productCodes.length > 0 && productCodes.includes(row.product)) {
-      insertFragment();
-    }
-
-    function insertFragment() {
-      if (row[fragKey]) {
-        row[fragKey].split(',').forEach((val) => {
-          fragArray.push(val.trim());
-        });
+  productCodes?.forEach((product) => {
+    resultResources?.data?.forEach((row) => {
+      if (product && product === row?.product) {
+        insertFragment();
       }
-    }
+
+      function insertFragment() {
+        if (row[fragKey]) {
+          row[fragKey]?.split(',').forEach((val) => {
+            fragArray.push(val.trim());
+          });
+        }
+      }
+    });
   });
   return fragArray;
 };


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

With the existing logic, the rows were getting traversed and on the way, the secondary products were matched.
Hence, if the product code is defined in a different order in result resources compared to the product codes array, the fragments are picked in that order.

With this PR, we will be traversing the product array first and will match that with every result resource row.
It's obviously less performant as for each entry in the product code array (which is very small in size), we will be iterating all the rows of the result resources (which is relatively a much bigger array). But, this is a tradeoff we will have to bear to maintain the matched product code order.

Note - This does not fix the order for basic fragments for more than one primary product without an umbrella product.

Resolves: https://jira.corp.adobe.com/browse/MWPW-134986

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.live/drafts/xiasun/quiz-2/?martech=off
- After: https://uar-nested-frag-in-order--milo--sabyamon.hlx.page/drafts/xiasun/quiz-2/?martech=off
