### PR TITLE
Add support for Consonant code typography

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -100,6 +100,13 @@
   --type-detail-s-size: 10px;
   --type-detail-s-lh: 12px;
 
+  /* Code */
+  --type-code-all-weight: 400;
+  --type-code-all-lh: 1.5;
+  --type-code-l-size: 18px;
+  --type-code-m-size: 16px;
+  --type-code-s-size: 14px;
+
   /* grid sizes */
   --grid-container-width: 83.4%;
   --grid-column-width: calc(var(--grid-container-width) / 12);
@@ -190,9 +197,13 @@
 .detail-xl,
 .detail-l,
 .detail-m,
-.detail-s {
+.detail-s,
+.code-l,
+.code-m,
+.code-s {
   margin: 0;
 }
+
 
 .heading-xxxl {
   font-size: var(--type-heading-xxxl-size);
@@ -290,6 +301,25 @@
 .detail-s {
   font-weight: 700;
   text-transform: uppercase;
+}
+
+.code-l {
+  font-size: var(--type-code-l-size);
+}
+
+.code-m {
+  font-size: var(--type-code-m-size);
+}
+
+.code-s {
+  font-size: var(--type-code-s-size);
+}
+
+.code-l,
+.code-m,
+.code-s {
+  font-weight: var(--type-code-all-weight);
+  line-height: var(--type-code-all-lh);
 }
 
 .con-button {
@@ -666,6 +696,15 @@ a.static:hover {
 img {
   max-width: 100%;
   height: auto;
+}
+
+code {
+  font-family: var(--code-font-family);
+  line-height: var(--type-code-all-lh);
+}
+
+pre code {
+  display: block;
 }
 
 /* Tooltip */

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -33,7 +33,7 @@
 
   /* Fonts */
   --body-font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
-  --fixed-font-family: 'Roboto Mono', menlo, consolas, 'Liberation Mono', monospace;
+  --code-font-family: 'Source Code Pro', source-code-pro, monospace;
 
   /* Spacing */
   --spacing-xxs: 8px;

--- a/libs/utils/fonts.js
+++ b/libs/utils/fonts.js
@@ -6,6 +6,12 @@ function dynamicTypekit(kitId, d = document) {
   return h;
 }
 
+export function loadTypeKitFont(cssFile, loadStyle) {
+  return new Promise((resolve) => {
+    loadStyle(`https://use.typekit.net/${cssFile}`, resolve);
+  });
+}
+
 /**
  * Set the fonts of the page.
  *
@@ -17,9 +23,7 @@ function dynamicTypekit(kitId, d = document) {
 export default function loadFonts(locale, loadStyle) {
   const tkSplit = locale.tk.split('.');
   if (tkSplit[1] === 'css') {
-    return new Promise((resolve) => {
-      loadStyle(`https://use.typekit.net/${locale.tk}`, resolve);
-    });
+    return loadTypeKitFont(locale.tk, loadStyle);
   }
   return dynamicTypekit(locale.tk);
 }

--- a/libs/utils/fonts.js
+++ b/libs/utils/fonts.js
@@ -1,7 +1,7 @@
 // A gently modified version of the dynamic subsetting loader from Adobe Fonts
 function dynamicTypekit(kitId, d = document) {
   const config = { kitId, scriptTimeout: 3000, async: true };
-  /* c8 ignore next 1 */
+  // eslint-disable-next-line
   const h = d.documentElement; const t = setTimeout(() => { h.className = `${h.className.replace(/\bwf-loading\b/g, '')} wf-inactive`; }, config.scriptTimeout); const tk = d.createElement('script'); let f = false; const s = d.getElementsByTagName('script')[0]; let a; h.className += ' wf-loading'; tk.src = `https://use.typekit.net/${config.kitId}.js`; tk.async = true; tk.onload = tk.onreadystatechange = function () { a = this.readyState; if (f || a && a != 'complete' && a != 'loaded') return; f = true; clearTimeout(t); try { Typekit.load(config); } catch (e) {} }; s.parentNode.insertBefore(tk, s);
   return h;
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -784,8 +784,12 @@ async function loadPostLCP(config) {
     header.classList.remove('gnav-hide');
   }
   loadTemplate();
-  const { default: loadFonts } = await import('./fonts.js');
-  loadFonts(config.locale, loadStyle);
+  import('./fonts.js').then((module) => {
+    module.default(config.locale, loadStyle);
+    if (document.querySelector('code')) {
+      module.loadTypeKitFont('vih2anh.css', loadStyle);
+    }
+  });
 }
 
 export async function loadDeferred(area, blocks, config) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -775,6 +775,14 @@ async function checkForPageMods() {
   }
 }
 
+export async function loadFonts(config, { loadStyle: utilsLoadStyle }) {
+  const { default: loadTypeKitFonts, loadTypeKitFont } = await import('./fonts.js');
+  return Promise.allSettled([
+    loadTypeKitFonts(config.locale, utilsLoadStyle),
+    document.querySelector('code') && loadTypeKitFont('vih2anh.css', utilsLoadStyle),
+  ]);
+}
+
 async function loadPostLCP(config) {
   loadMartech(config);
   const header = document.querySelector('header');
@@ -784,12 +792,7 @@ async function loadPostLCP(config) {
     header.classList.remove('gnav-hide');
   }
   loadTemplate();
-  import('./fonts.js').then((module) => {
-    module.default(config.locale, loadStyle);
-    if (document.querySelector('code')) {
-      module.loadTypeKitFont('vih2anh.css', loadStyle);
-    }
-  });
+  loadFonts(config, { loadStyle });
 }
 
 export async function loadDeferred(area, blocks, config) {

--- a/test/utils/mocks/body-code.html
+++ b/test/utils/mocks/body-code.html
@@ -1,0 +1,6 @@
+<main>
+  <div>
+    <!-- Code -->
+    <p><code>const foo = 'bar'</code></p>
+  </div>
+</main>

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -29,6 +29,8 @@
     <p><a class="disable-autoblock" href="https://www.instagram.com/#_dnb">Disable Autoblock</a></p>
     <!-- Auto Block -->
     <p><a class="autoblock" href="https://twitter.com/Adobe#_dnb">Auto Block</a></p>
+    <!-- Code -->
+    <p><code>const foo = 'bar'</code></p>
   </div>
   <div class="quote borders contained hide-block">
     <div>

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -29,8 +29,6 @@
     <p><a class="disable-autoblock" href="https://www.instagram.com/#_dnb">Disable Autoblock</a></p>
     <!-- Auto Block -->
     <p><a class="autoblock" href="https://twitter.com/Adobe#_dnb">Auto Block</a></p>
-    <!-- Code -->
-    <p><code>const foo = 'bar'</code></p>
   </div>
   <div class="quote borders contained hide-block">
     <div>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -464,4 +464,36 @@ describe('Utils', () => {
       });
     });
   });
+
+  describe('fonts', async () => {
+    const DEFAULT_FONT_CSS = 'https://use.typekit.net/hah7vzn.css';
+    const CODE_FONT_CSS = 'https://use.typekit.net/vih2anh.css';
+    beforeEach(async () => {
+      window.lana = { log: (msg) => console.error(msg) };
+    });
+    afterEach(() => {
+      window.lana.release?.();
+    });
+    it('should load default font', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+      const loadStyle = sinon.stub()
+        .withArgs(DEFAULT_FONT_CSS)
+        .yields(Promise.resolve());
+      await utils.loadFonts(utils.getConfig(), { loadStyle });
+      expect(loadStyle.calledOnce).to.be.true;
+      expect(loadStyle.calledWith(DEFAULT_FONT_CSS)).to.be.true;
+    });
+    it('should load code font when monospaced text is present', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/body-code.html' });
+      const loadStyle = sinon.stub()
+        .withArgs(DEFAULT_FONT_CSS)
+        .yields(Promise.resolve())
+        .withArgs(CODE_FONT_CSS)
+        .yields(Promise.resolve());
+      await utils.loadFonts(utils.getConfig(), { loadStyle });
+      expect(loadStyle.calledTwice).to.be.true;
+      expect(loadStyle.calledWith(DEFAULT_FONT_CSS)).to.be.true;
+      expect(loadStyle.calledWith(CODE_FONT_CSS)).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
Load font and styling to support [Consonant's code typography](https://consonant.adobe.com/1975e5ba1/v/32165/p/216c7e-typography/t/244b88) when document contains any inlined or blocked monospaced text.

<img width="965" alt="Screenshot 2023-08-30 at 19 17 02" src="https://github.com/adobecom/milo/assets/13532/15b436af-e3e8-42dc-8c11-56088c1d082b">

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/hgpa/test/code/code?martech=off
- After: https://feat-code-noblock--milo--hparra.hlx.live/drafts/hgpa/test/code/code?martech=off