### PR TITLE
adds merch-card to utils block list

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -42,6 +42,7 @@ const MILO_BLOCKS = [
   'marquee-anchors',
   'media',
   'merch',
+  'merch-card',
   'modal',
   'modal-metadata',
   'pdf-viewer',


### PR DESCRIPTION
Adds merch card block to list of MILO_BLOCKS in utils.js so that Milo consumer sites can utilize this block and authors can start using it.

Resolves: [MWPW-133900](https://jira.corp.adobe.com/browse/MWPW-133900)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/discovery-hub/products-photoshop-segment-blade1
- After: [https://<branch>--milo--adobecom.hlx.page/?martech=off](https://main--cc--adobecom.hlx.page/cc-shared/fragments/discovery-hub/products-photoshop-segment-blade1?milolibs=MWPW-134233)
