### PR TITLE
MWPW-135645: remove image label from mdast

### DIFF
--- a/tools/loc/rollout.js
+++ b/tools/loc/rollout.js
@@ -65,7 +65,7 @@ function processMdast(nodes) {
   return arrayWithContentHash;
 }
 
-export const removeLabelForType = (node, type) => {
+function removeLabelForType(node, type) {
   if (node.children) {
     for (let i = 0; i < node.children.length; i++) {
       const child = node.children[i];

--- a/tools/loc/rollout.js
+++ b/tools/loc/rollout.js
@@ -65,7 +65,18 @@ function processMdast(nodes) {
   return arrayWithContentHash;
 }
 
+export const removeLabelForType = (node, type) => {
+  if (node.children) {
+    for (let i = 0; i < node.children.length; i++) {
+      const child = node.children[i];
+      if (child.type === type && child.label) child.label = "";
+      removeLabelForType(child, type);
+    }
+  }
+};
+
 async function getProcessedMdast(mdast) {
+  removeLabelForType(mdast, 'image')
   const nodes = mdast.children || [];
   return processMdast(nodes);
 }


### PR DESCRIPTION
Resolves: [MWPW-135645](https://jira.corp.adobe.com/browse/MWPW-135645)

The image label is set as per order of image in the document. So, when an image is added/removed from any section, it changes the label for all the images below it. Hence, the label can be reset in the mdast which is used to generate the docx. The markdown (from docx) generated with and without label in mdast is identical.

[md-without-label](https://main--milo--adobecom.hlx.page/ae_en/drafts/nishantkaush/samples/image-issue/without-label.md)
[md-with-label](https://main--milo--adobecom.hlx.page/ae_en/drafts/nishantkaush/samples/image-issue/with-image-label.md)

After removing 1st image in the doc:

Docx Before (other sections with images shown with track changes):
[merged-doc-with-image-label](https://adobe.sharepoint.com/:w:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B8B1255EB-39A0-46DD-AFE6-761925090CF6%7D&file=merged-with-image-label.docx&action=default&mobileredirect=true)

Docx After (only required section shown with track changes):
[merged-doc-without-image-label](https://adobe.sharepoint.com/:w:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BBC16C66A-A925-4DF6-A38C-1D4F165545A4%7D&file=merged-without-image-label.docx&action=default&mobileredirect=true)