### PR TITLE
MWPW-135814 Add underline in static link

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -19,6 +19,7 @@
 
 .section.static-links a:not([class]) {
   color: inherit;
+  text-decoration: underline;
 }
 
 .section.hide-sticky-section,


### PR DESCRIPTION
Link and text is not differentiable in case of static links. Currently the default behaviour of links involve no-underline with underline on hover. When static link class is applied the text and links have same color and no underline makes it difficult to differentiate from the text. 
Adding underline in static link by default to be in-sync with notification static link style of a.static.(https://github.com/aishwaryamathuria/milo/blob/main/libs/styles/styles.css). 

Resolves: [MWPW-135814](https://jira.corp.adobe.com/browse/MWPW-135814)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/mathuria/aside/documentation/sectionmetadatadoc?martech=off
- After: https://staticlink--milo--aishwaryamathuria.hlx.page/drafts/mathuria/aside/documentation/sectionmetadatadoc?martech=off
