### PR TITLE
MWPW-134823 - QUIZ - Fix Acessibility warning

### DIFF
--- a/libs/blocks/quiz/quizoption.js
+++ b/libs/blocks/quiz/quizoption.js
@@ -18,7 +18,7 @@ export const OptionCard = ({
           ${cardIcon && cardIconHtml}
           ${coverImage && coverImageHtml}
         <div data-valign="middle">  
-          <h3 id="lorem-ipsum-dolor-sit-amet-3" class="consonant-OneHalfCard-title">${title}</h3>
+          <h3 class="consonant-OneHalfCard-title">${title}</h3>
           <p class="consonant-OneHalfCard-text">${text}</p>
         </div>
       </div>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* The h3 element in the card template in quizoptions.js contains an id that's hardcoded to a lorem ipsum value. It leads to duplicate id warnings in an accessibility checker and should be removed.

Resolves: https://jira.corp.adobe.com/browse/MWPW-134823

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.page/drafts/borges/end-to-end/?martech=off
- After: https://quiz-cleanup-lorems--milo--elaineskpt.hlx.page/drafts/borges/end-to-end/?martech=off
