### PR TITLE
[Blog to Milo] MWPW-135804 Add taxonomyRoot config

### DIFF
--- a/libs/blocks/article-feed/article-helpers.js
+++ b/libs/blocks/article-feed/article-helpers.js
@@ -115,7 +115,9 @@ export function getTaxonomyModule() {
 }
 
 export async function loadTaxonomy() {
-  taxonomyModule = await taxonomyLibrary.default(getConfig(), '/topics');
+  const config = getConfig();
+  const taxonomyRoot = config.taxonomyRoot || '/topics';
+  taxonomyModule = await taxonomyLibrary.default(config, taxonomyRoot);
   if (taxonomyModule) {
     // taxonomy loaded, post loading adjustments
     // fix the links which have been created before the taxonomy has been loaded

--- a/libs/blocks/featured-article/featured-article.js
+++ b/libs/blocks/featured-article/featured-article.js
@@ -5,7 +5,9 @@ async function createCategoryLink(el, category = 'News') {
   Promise.all(promises).then(async ([taxonomyMod, helpersMod]) => {
     const fetchTaxonomy = taxonomyMod.default;
     const { updateLinkWithLangRoot } = helpersMod;
-    const taxonomy = await fetchTaxonomy(getConfig(), '/topics');
+    const config = getConfig();
+    const taxonomyRoot = config.taxonomyRoot || '/topics';
+    const taxonomy = await fetchTaxonomy(config, taxonomyRoot);
     const categoryTaxonomy = taxonomy.get(category);
     const categoryLink = createTag('a', { href: updateLinkWithLangRoot(categoryTaxonomy?.link) }, categoryTaxonomy?.name);
     el.append(categoryLink);

--- a/libs/blocks/recommended-articles/recommended-articles.js
+++ b/libs/blocks/recommended-articles/recommended-articles.js
@@ -57,6 +57,7 @@ function getDecoratedCards(articles, taxonomy) {
 
 export default async function init(blockEl) {
   const children = [...blockEl.querySelectorAll(':scope > div')];
+  const config = getConfig();
   let content;
   let recommendedArticleLinks;
 
@@ -76,13 +77,12 @@ export default async function init(blockEl) {
   } else {
     blockEl.classList.add('recommended-articles-content-wrapper');
     if (!content) {
-      const text = await replaceKey('recommended-for-you', getConfig());
+      const text = await replaceKey('recommended-for-you', config);
       content = createTag('h3', null, text);
     }
   }
   blockEl.innerHTML = '';
 
-  const config = getConfig();
   const taxonomyRoot = config.taxonomyRoot || '/topics';
   const taxonomy = await fetchTaxonomy(config, taxonomyRoot);
   const unresolvedPromises = recommendedArticleLinks.map((article) => getArticleDetails(article));

--- a/libs/blocks/recommended-articles/recommended-articles.js
+++ b/libs/blocks/recommended-articles/recommended-articles.js
@@ -82,7 +82,9 @@ export default async function init(blockEl) {
   }
   blockEl.innerHTML = '';
 
-  const taxonomy = await fetchTaxonomy(getConfig(), '/topics');
+  const config = getConfig();
+  const taxonomyRoot = config.taxonomyRoot || '/topics';
+  const taxonomy = await fetchTaxonomy(config, taxonomyRoot);
   const unresolvedPromises = recommendedArticleLinks.map((article) => getArticleDetails(article));
   let articles = [];
   articles = await Promise.all(unresolvedPromises);

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -131,6 +131,7 @@ const config = {
   },
   privacyId: '7a5eb705-95ed-4cc4-a11d-0cc5760e93db', // valid for *.adobe.com
   breadcrumbs: 'on',
+  // taxonomyRoot: '/your-path-here',
 };
 
 const eagerLoad = (img) => {

--- a/test/blocks/article-header/article-header.test.js
+++ b/test/blocks/article-header/article-header.test.js
@@ -16,12 +16,15 @@ const { default: init } = await import('../../../libs/blocks/article-header/arti
 const invalidDoc = await readFile({ path: './mocks/body-invalid.html' });
 
 describe('article header', () => {
-  const block = document.body.querySelector('.article-header');
-
-  it('creates article header block', async () => {
+  before(async () => {
+    const block = document.body.querySelector('.article-header');
     config.locale.contentRoot = '/test/blocks/article-header/mocks';
+    config.taxonomyRoot = undefined;
 
     await init(block);
+  });
+
+  it('creates article header block', () => {
     expect(document.body.querySelector('.article-category')).to.exist;
     expect(document.body.querySelector('.article-title')).to.exist;
     expect(document.body.querySelector('.article-author-image')).to.exist;
@@ -67,6 +70,11 @@ describe('article header', () => {
 
     expect(tooltip).to.exist;
     writeTextStub.restore();
+  });
+
+  it('sets default taxonomy path to "topics"', () => {
+    const categoryLink = document.querySelector('.article-category a');
+    expect(categoryLink.href.includes('/topics/')).to.be.true;
   });
 });
 

--- a/test/blocks/recommended-articles/mocks/body.html
+++ b/test/blocks/recommended-articles/mocks/body.html
@@ -19,7 +19,7 @@
   </div>
 
   <div class="section">
-    <div class="recommended-articles">
+    <div id="default" class="recommended-articles">
       <div>
         <div>
           <p><a

--- a/test/blocks/recommended-articles/recommended-articles.test.js
+++ b/test/blocks/recommended-articles/recommended-articles.test.js
@@ -33,4 +33,12 @@ describe('creates feature article block', () => {
     const articleCards = articles[2].querySelector('.articles-cards');
     expect(articleCards).to.be.null;
   });
+
+  it('sets default taxonomy path to "topics"', async () => {
+    config.locale.contentRoot = '/test/blocks/recommended-articles/mocks';
+    config.taxonomyRoot = undefined;
+    await init(articles[1]);
+    const categoryLink = document.querySelector('.recommended-articles-content-wrapper .article-card-category a');
+    expect(categoryLink.href.includes('/topics/')).to.be.true;
+  });
 });

--- a/test/blocks/recommended-articles/recommended-articles.test.js
+++ b/test/blocks/recommended-articles/recommended-articles.test.js
@@ -7,7 +7,8 @@ const conf = { locales };
 setConfig(conf);
 const config = getConfig();
 
-document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+const bodyHTML = await readFile({ path: './mocks/body.html' });
+document.body.innerHTML = bodyHTML;
 const { default: init } = await import('../../../libs/blocks/recommended-articles/recommended-articles.js');
 
 describe('creates feature article block', () => {
@@ -35,10 +36,20 @@ describe('creates feature article block', () => {
   });
 
   it('sets default taxonomy path to "topics"', async () => {
+    document.body.innerHTML = bodyHTML;
     config.locale.contentRoot = '/test/blocks/recommended-articles/mocks';
     config.taxonomyRoot = undefined;
-    await init(articles[1]);
-    const categoryLink = document.querySelector('.recommended-articles-content-wrapper .article-card-category a');
+    await init(document.querySelector('#default'));
+    const categoryLink = document.querySelector('#default .article-card-category a');
     expect(categoryLink.href.includes('/topics/')).to.be.true;
+  });
+
+  it('sets taxonomy path to "tags"', async () => {
+    document.body.innerHTML = bodyHTML;
+    config.locale.contentRoot = '/test/blocks/recommended-articles/mocks';
+    config.taxonomyRoot = '/tags';
+    await init(document.querySelector('#default'));
+    const categoryLink = document.querySelector('#default .article-card-category a');
+    expect(categoryLink.href.includes('/tags/')).to.be.true;
   });
 });

--- a/test/blocks/tags/tags.test.js
+++ b/test/blocks/tags/tags.test.js
@@ -7,21 +7,23 @@ const conf = { locales };
 setConfig(conf);
 const config = getConfig();
 
-const ogDoc = document.body.innerHTML;
-
 const { default: init } = await import('../../../libs/blocks/tags/tags.js');
 
 describe('decorateTags', () => {
-  config.locale.contentRoot = '/test/blocks/tags/mocks';
-
-  afterEach(() => {
-    document.body.innerHTML = ogDoc;
+  before(async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+    config.locale.contentRoot = '/test/blocks/tags/mocks';
+    config.taxonomyRoot = undefined;
+    const block = document.querySelector('.tags');
+    await init(block);
   });
 
   it('renders tags block', async () => {
-    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
-    const block = document.querySelector('.tags');
-    await init(block);
     expect(document.body.querySelector('.tags')).to.exist;
+  });
+
+  it('sets default taxonomy path to "topics"', async () => {
+    const categoryLink = document.querySelector('.tags a');
+    expect(categoryLink.href.includes('/topics/')).to.be.true;
   });
 });


### PR DESCRIPTION
* Add support for a `taxonomyRoot` config to change path of taxonomy (eyebrow) links
* Default to `/topics` for backwards compatibility

Resolves: [MWPW-135804](https://jira.corp.adobe.com/browse/MWPW-135804)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/taxonomy?martech=off
- After: https://methomas-taxonomy--milo--adobecom.hlx.page/drafts/methomas/taxonomy?martech=off
(After has no change. Default `/topics`)

Bacom blog: https://methomas-tags--bacom-blog--adobecom.hlx.page/drafts/methomas/taxonomy-config?milolibs=methomas-taxonomy
(taxonomyRoot `/tags`)

Adobe blog: 
-  https://main--blog--adobecom.hlx.page/?milolibs=methomas-taxonomy
- https://main--blog--adobecom.hlx.page/en/publish/2023/08/15/discover-key-visual-trends-for-autumn-2023-from-adobe-stock?milolibs=methomas-taxonomy
(Default `/topics`)