### PR TITLE
Chrome devtools breaks on parsing $`

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -136,7 +136,7 @@ function normalizePath(p) {
 
 const matchGlob = (searchStr, inputStr) => {
   const pattern = searchStr.replace(/\*\*/g, '.*');
-  const reg = new RegExp(`^${pattern}$`, 'i');
+  const reg = new RegExp(`^${pattern}$`, 'i'); // devtool bug needs this backtick: `
   return reg.test(inputStr);
 };
 


### PR DESCRIPTION
When a line contains a template literal that ends with a $:
`` `^${pattern}$` ``
Chrome devtools will show all the code after this literal as being part of a string literal:

<img width="702" alt="Screenshot 2023-09-01 at 9 06 03 AM" src="https://github.com/adobecom/milo/assets/9143715/2d7db5d1-5365-4865-b6e6-735ed4d62b2d">

Adding an end-of-line comment that ends in a backtick fixes it:

<img width="714" alt="Screenshot 2023-09-01 at 9 07 29 AM" src="https://github.com/adobecom/milo/assets/9143715/3108bf7c-41fb-443d-a000-a791b8e70500">

This is the only relevant chrome bug I could find:
https://bugs.chromium.org/p/chromium/issues/detail?id=659515

Resolves: N/A

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://devtoolssucks--milo--adobecom.hlx.page/?martech=off
