### PR TITLE
MWPW-135674 Set Modal Width & Height

### DIFF
--- a/libs/blocks/modal-metadata/modal-metadata.js
+++ b/libs/blocks/modal-metadata/modal-metadata.js
@@ -5,7 +5,7 @@ const setDimensions = (dimensions, mm, bp, m) => {
   const styleSheet = createTag('style');
   styleSheet.innerHTML = `@media (${mm}-width: ${bp}px) {.dialog-modal, .dialog-modal > .fragment { width: ${dimensions.text?.split(',')[0]}; height: ${dimensions.text?.split(',')[0]} }}`;
   m.append(styleSheet);
-}
+};
 
 export default function init(el) {
   const modal = el.closest('.dialog-modal');

--- a/libs/blocks/modal-metadata/modal-metadata.js
+++ b/libs/blocks/modal-metadata/modal-metadata.js
@@ -1,4 +1,11 @@
 import { getMetadata, handleStyle } from '../section-metadata/section-metadata.js';
+import { createTag } from '../../utils/utils.js';
+
+const setDimensions = (dimensions, mm, bp, m) => {
+  const styleSheet = createTag('style');
+  styleSheet.innerHTML = `@media (${mm}-width: ${bp}px) {.dialog-modal, .dialog-modal > .fragment { width: ${dimensions.text?.split(',')[0]}; height: ${dimensions.text?.split(',')[0]} }}`;
+  m.append(styleSheet);
+}
 
 export default function init(el) {
   const modal = el.closest('.dialog-modal');
@@ -6,4 +13,7 @@ export default function init(el) {
   const metadata = getMetadata(el);
   if (metadata.style) handleStyle(metadata.style.text, modal);
   if (metadata.curtain?.text === 'off') modal.classList.add('curtain-off');
+  if (metadata['mobile dimensions']) setDimensions(metadata['mobile dimensions'], 'max', '600', modal);
+  if (metadata['tablet dimensions']) setDimensions(metadata['tablet dimensions'], 'min', '600', modal);
+  if (metadata['desktop dimensions']) setDimensions(metadata['desktop dimensions'], 'min', '1200', modal);
 }


### PR DESCRIPTION
Adding functionality to allow authors to set width and height on modals. 
 
Resolves: [MWPW-135674 ](https://jira.corp.adobe.com/browse/MWPW-135674 )

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-135674--milo--adobecom.hlx.page/?martech=off
<img width="678" alt="Screenshot 2023-09-01 at 1 14 14 PM" src="https://github.com/adobecom/milo/assets/6355943/3c5a521b-b83f-498e-bb09-4ff4f0e6a23d">
