### PR TITLE
MWPW-135442 - Fixing the issue of NOT operator when the order of selection is changed

### DIFF
--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -355,6 +355,7 @@ export const handleNext = (questionsData, selectedQuestion, userInputSelections,
   let nextQuizViews = [];
   let hasResultTigger = false;
   let lastStopValue;
+
   allcards.forEach((selection) => {
     // for each elem in current selection, find its coresponding
     // next element and push it to the next array.
@@ -386,16 +387,14 @@ export const handleNext = (questionsData, selectedQuestion, userInputSelections,
   });
 
   // Stripping off the next steps that are negated using 'NOT()'.
-  nextQuizViews.forEach((val) => {
-    let regexStepsToSkip;
-    if (val.startsWith('NOT(')) {
-      regexStepsToSkip = val;
-      const stepsToSkip = regexStepsToSkip.substring(
-        regexStepsToSkip.indexOf('(') + 1,
-        regexStepsToSkip.lastIndexOf(')'),
+  nextQuizViews.forEach((nextStep) => {
+    if (nextStep?.startsWith('NOT(')) {
+      const stepsToSkip = nextStep?.substring(
+        nextStep.indexOf('(') + 1,
+        nextStep.lastIndexOf(')'),
       );
-      const stepsToSkipArr = stepsToSkip.split(',');
-      stepsToSkipArr.forEach((skip) => {
+      const stepsToSkipArr = stepsToSkip?.split(',');
+      stepsToSkipArr?.forEach((skip) => {
         nextQuizViews = nextQuizViews.filter((view) => (view !== skip));
       });
     }

--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -355,7 +355,6 @@ export const handleNext = (questionsData, selectedQuestion, userInputSelections,
   let nextQuizViews = [];
   let hasResultTigger = false;
   let lastStopValue;
-
   allcards.forEach((selection) => {
     // for each elem in current selection, find its coresponding
     // next element and push it to the next array.
@@ -367,25 +366,6 @@ export const handleNext = (questionsData, selectedQuestion, userInputSelections,
     getAllSelectedQuestionsRelatedOptions.forEach(({ options, next }) => {
       if (options === selection) {
         const flowStepsList = next.split(',');
-
-        let regexStepsToSkip;
-        flowStepsList.forEach((step) => {
-          if (step.startsWith('NOT(')) regexStepsToSkip = step;
-        });
-
-        // regexStepsToSkip = 'NOT(q-rather)'
-        if (regexStepsToSkip) {
-          const stepsToSkip = regexStepsToSkip.substring(
-            regexStepsToSkip.indexOf('(') + 1,
-            regexStepsToSkip.lastIndexOf(')'),
-          );
-
-          // stepsToSkip = 'q-rather'
-          const stepsToSkipArr = stepsToSkip.split(',');
-          stepsToSkipArr.forEach((skip) => {
-            nextQuizViews = nextQuizViews.filter((val) => val !== skip);
-          });
-        }
         // RESET the queue and add only the next question.
         if (flowStepsList.includes('RESET')) { // Reset to intial question
           nextQuizViews = []; // Resetting the nextQuizViews
@@ -398,12 +378,31 @@ export const handleNext = (questionsData, selectedQuestion, userInputSelections,
           hasResultTigger = flowStepsList.includes('RESULT');
         }
 
-        const filteredNextSteps = flowStepsList.filter((val) => (val !== 'RESULT' && val !== 'RESET' && !val.startsWith('NOT(')));
+        const filteredNextSteps = flowStepsList.filter((val) => (val !== 'RESULT' && val !== 'RESET'));
 
         nextQuizViews = [...nextQuizViews, ...filteredNextSteps];
       }
     });
   });
+
+  // Stripping off the next steps that are negated using 'NOT()'.
+  nextQuizViews.forEach((val) => {
+    let regexStepsToSkip;
+    if (val.startsWith('NOT(')) {
+      regexStepsToSkip = val;
+      const stepsToSkip = regexStepsToSkip.substring(
+        regexStepsToSkip.indexOf('(') + 1,
+        regexStepsToSkip.lastIndexOf(')'),
+      );
+      const stepsToSkipArr = stepsToSkip.split(',');
+      stepsToSkipArr.forEach((skip) => {
+        nextQuizViews = nextQuizViews.filter((view) => (view !== skip));
+      });
+    }
+  });
+
+  // Filtering out the NOT() from the nextQuizViews.
+  nextQuizViews = nextQuizViews.filter((view) => view.startsWith('NOT(') === false);
 
   return { nextQuizViews: [...new Set([...userFlow, ...nextQuizViews])], lastStopValue };
 };


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

- Gathering all the next steps for the selected cards first and then filtering on the entire set to make sure ordering of card selection does not make any difference when it comes to the `NOT` operator.

Resolves: https://jira.corp.adobe.com/browse/MWPW-135442

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.live/drafts/xiasun/quiz-2/?martech=off
- After: https://uar-skip-order-of-selection--milo--sabyamon.hlx.page/drafts/xiasun/quiz-2/?martech=off
