### PR TITLE
MWPW-135903: If nestedObject[fragKey] exists, append to it instead of replacing

### DIFF
--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -190,19 +190,12 @@ export const nestedFragments = (
   nestedFragsSecondaryArray?.forEach((frag) => {
     if (!frag) return;
     const fragKey = frag.trim();
-    if (nestedObject[fragKey]) {
-      nestedObject[fragKey].push(...getNestedFragments(
-        resultResources,
-        secondaryProductCodes,
-        fragKey,
-      ));
-    } else {
-      nestedObject[fragKey] = getNestedFragments(
-        resultResources,
-        secondaryProductCodes,
-        fragKey,
-      );
-    }
+    if (!nestedObject[fragKey]) nestedObject[fragKey] = [];
+    nestedObject[fragKey].push(...getNestedFragments(
+      resultResources,
+      secondaryProductCodes,
+      fragKey,
+    ));
   });
 
   return nestedObject;

--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -190,11 +190,19 @@ export const nestedFragments = (
   nestedFragsSecondaryArray?.forEach((frag) => {
     if (!frag) return;
     const fragKey = frag.trim();
-    nestedObject[fragKey] = getNestedFragments(
-      resultResources,
-      secondaryProductCodes,
-      fragKey,
-    );
+    if (nestedObject[fragKey]) {
+      nestedObject[fragKey].push(...getNestedFragments(
+        resultResources,
+        secondaryProductCodes,
+        fragKey,
+      ));
+    } else {
+      nestedObject[fragKey] = getNestedFragments(
+        resultResources,
+        secondaryProductCodes,
+        fragKey,
+      );
+    }
   });
 
   return nestedObject;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

When building our array of nested fragments, if we find fragments for the same key for both primary and secondary products, the code currently replaces the primary product result with the secondary result. Instead, we need to concatenate the two. 

Resolves: [MWPW-135903](https://jira.corp.adobe.com/browse/MWPW-135903)

**Test URLs:**
- Before: [https://uar-integration--milo--adobecom.hlx.live/drafts/xiasun/quiz-2/?martech=off](https://uar-integration--milo--adobecom.hlx.live/drafts/xiasun/quiz-2/?martech=off)
- After: [https://mwpw-135903--milo--echampio-at-adobe.hlx.live/drafts/xiasun/quiz-2/?martech=off](https://mwpw-135903--milo--echampio-at-adobe.hlx.live/drafts/xiasun/quiz-2/?martech=off)

Here's a full set of test URLs, along with the value from local storage when you choose:
q-category=photo,video&q-rather=template&q-customer=educational

https://uar-integration--milo--adobecom.hlx.live/drafts/xiasun/quiz-2/?martech=off
https://uar-integration--milo--adobecom.hlx.live/drafts/xiasun/uar-results-block/uar-results?primary=express-photo-edu,express-video-edu&quizKey=cc-quiz-en-US&debug=quiz-results

```
{
  "primaryProducts": [
    "express-photo-edu",
    "express-video-edu"
  ],
  "secondaryProducts": [
    "cc-all-edu",
    "lr-edu",
    "pr-edu"
  ],
  "umbrellaProduct": "express-edu",
  "basicFragments": [
    "https://uar-integration--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/express-product/express-edu"
  ],
  "nestedFragments": {
    "commerce-card": [
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/card/lr",
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/card/pr"
    ],
    "media": [
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/media/express-edu"
    ],
    "templates": [
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/templates/express"
    ],
    "learn": [
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/learn/learn-express"
    ]
  },
  "pageloadHash": "type=cc:app-reco&quiz=uarv3&selectedOptions=q-category/photo/video|q-rather/template|q-customer/educational"
}
```


https://mwpw-135903--milo--echampio-at-adobe.hlx.live/drafts/xiasun/quiz-2/?martech=off
https://mwpw-135903--milo--echampio-at-adobe.hlx.live/drafts/xiasun/uar-results-block/uar-results?primary=express-photo-edu,express-video-edu&quizKey=cc-quiz-en-US&debug=quiz-results

```
{
  "primaryProducts": [
    "express-photo-edu",
    "express-video-edu"
  ],
  "secondaryProducts": [
    "cc-all-edu",
    "lr-edu",
    "pr-edu"
  ],
  "umbrellaProduct": "express-edu",
  "basicFragments": [
    "https://uar-integration--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/express-product/express-edu"
  ],
  "nestedFragments": {
    "commerce-card": [
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/card/cc-all-edu",
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/card/lr",
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/card/pr"
    ],
    "media": [
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/media/express-edu"
    ],
    "templates": [
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/templates/express"
    ],
    "learn": [
      "https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/learn/learn-express"
    ]
  },
  "pageloadHash": "type=cc:app-reco&quiz=uarv3&selectedOptions=q-category/photo/video|q-rather/template|q-customer/educational"
}
```

The difference between the two is the number of commerce-card nested fragments. 
