### PR TITLE
Add a gnav PR template

### DIFF
--- a/.github/gnav.md
+++ b/.github/gnav.md
@@ -1,0 +1,30 @@
+## Description
+
+## Related Issue
+Resolves: [MWPW-111111](https://jira.corp.adobe.com/browse/MWPW-111111)
+
+## Testing instructions
+
+## Screenshots (if appropriate):
+
+## Types of changes
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+
+## Test URLs
+**Acrobat:**
+- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
+- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=branch--milo--owner
+
+**BACOM:**
+- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
+- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=branch--milo--owner
+
+**CC:**
+- Before: https://main--cc--adobecom.hlx.live/?martech=off
+- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=branch--milo--owner
+
+**Milo:**
+- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
+- After: https://branch--milo--owner.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off

--- a/.github/gnav.md
+++ b/.github/gnav.md
@@ -7,24 +7,20 @@ Resolves: [MWPW-111111](https://jira.corp.adobe.com/browse/MWPW-111111)
 
 ## Screenshots (if appropriate):
 
-## Types of changes
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
 
 ## Test URLs
 **Acrobat:**
 - Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
-- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=branch--milo--owner
+- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=<branch>--milo--<owner>
 
 **BACOM:**
 - Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
-- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=branch--milo--owner
+- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=<branch>--milo--<owner>
 
 **CC:**
 - Before: https://main--cc--adobecom.hlx.live/?martech=off
-- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=branch--milo--owner
+- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=<branch>--milo--<owner>
 
 **Milo:**
 - Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
-- After: https://branch--milo--owner.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
+- After: https://<branch>--milo--<owner>.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off


### PR DESCRIPTION
## Description
Adds a new gnav PR template that can be optionally used by adding a query param to the url. `https://github.com/adobecom/milo/compare/main...mokimo:gnav-pr-template?expand=1` 
-> `https://github.com/adobecom/milo/compare/main...mokimo:gnav-pr-template?expand=1&template=gnav.md`

## Related Issue
Resolves: N/A

## Testing instructions
Can't be tested until after this is merged

## Screenshots (if appropriate):
Make our lives easier
![Screenshot 2023-09-05 at 13 40 23](https://github.com/adobecom/milo/assets/39759830/681c888b-5e8f-44e5-a631-0791c3921a5c)


## Types of changes

- [x] Chore (Unit test, setup - no prod code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=gnav-pr-template--milo--mokimo

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=gnav-pr-template--milo--mokimo

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=gnav-pr-template--milo--mokimo

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://gnav-pr-template--milo--mokimo.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off