### PR TITLE
MWPW-135983 Support caas tags delimited by ;

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -222,7 +222,7 @@ const getTag = (tagName, errors) => {
 const getTags = (s) => {
   let rawTags = [];
   if (s) {
-    rawTags = s.toLowerCase().split(/,|(\s+)|(\\n)/g).filter((t) => t && t.trim() && t !== '\n');
+    rawTags = s.toLowerCase().split(/,|(\s+)|(\\n)|;/g).filter((t) => t && t.trim() && t !== '\n');
   }
 
   const errors = [];


### PR DESCRIPTION
The DC team has their caas tags separated by `;`, which is currently not supported.  Instead or updating all of those pages, this adds support for `;` as a delimiter.

Resolves: [MWPW-135983](https://jira.corp.adobe.com/browse/MWPW-135983)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://caassemicol--milo--adobecom.hlx.page/?martech=off
