### PR TITLE
MWPW-135782 | Removing min height from mobile Asides

### DIFF
--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -16,18 +16,6 @@
   margin: 0;
 }
 
-.aside.small {
-  min-height: 420px;
-}
-
-.aside.medium {
-  min-height: 560px;
-}
-
-.aside.large {
-  min-height: 700px;
-}
-
 .aside.split picture {
   display: flex;
 }
@@ -505,6 +493,18 @@
 }
 
 @media screen and (min-width: 600px) {
+  .aside.small {
+    min-height: 420px;
+  }
+  
+  .aside.medium {
+    min-height: 560px;
+  }
+  
+  .aside.large {
+    min-height: 700px;
+  }
+  
   .aside .foreground.container {
     align-items: center;
     flex-direction: row;

--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -86,6 +86,10 @@
   padding: var(--spacing-xxxl) 0 var(--spacing-l) 0;
 }
 
+.aside.split.no-media .foreground.container .text {
+  padding: var(--spacing-xxxl) 0 var(--spacing-xxxl) 0;
+}
+
 .aside.split.large .foreground.container .text {
   padding: var(--spacing-l) 0 var(--spacing-xxxl) 0;
 }

--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -86,10 +86,6 @@
   padding: var(--spacing-xxxl) 0 var(--spacing-l) 0;
 }
 
-.aside.split.no-media .foreground.container .text {
-  padding: var(--spacing-xxxl) 0 var(--spacing-xxxl) 0;
-}
-
 .aside.split.large .foreground.container .text {
   padding: var(--spacing-l) 0 var(--spacing-xxxl) 0;
 }
@@ -494,6 +490,16 @@
   height: var(--icon-size-xxl);
   max-width: 300px;
   width: auto;
+}
+
+@media screen and (max-width: 600px) {
+  .aside.no-media:not(.notification) .foreground.container {
+    gap: 0;
+  }
+
+  .aside.split.no-media:not(.notification) .foreground.container .text {
+    padding: var(--spacing-xxxl) 0 var(--spacing-xxxl) 0;
+  }  
 }
 
 @media screen and (min-width: 600px) {

--- a/libs/blocks/aside/aside.js
+++ b/libs/blocks/aside/aside.js
@@ -123,13 +123,14 @@ function decorateLayout(el) {
   const iconArea = picture ? (picture.closest('p') || createTag('p', null, picture)) : null;
   iconArea?.classList.add('icon-area');
   const foregroundImage = foreground.querySelector(':scope > div:not(.text) img')?.closest('div');
-  const bgImage = el.querySelector(':scope > div:not(.text) img')?.closest('div');
+  const bgImage = el.querySelector(':scope > div:not(.text):not(.foreground) img')?.closest('div');
   const foregroundMedia = foreground.querySelector(':scope > div:not(.text) video')?.closest('div');
-  const bgMedia = el.querySelector(':scope > div:not(.text) video')?.closest('div');
+  const bgMedia = el.querySelector(':scope > div:not(.text):not(.foreground) video')?.closest('div');
   const image = foregroundImage ?? bgImage;
   const asideMedia = foregroundMedia ?? bgMedia ?? image;
+  const isSplit = el.classList.contains('split');
+  if (isSplit && !asideMedia) el.classList.add('no-media');
   if (asideMedia && !asideMedia.classList.contains('text')) {
-    const isSplit = el.classList.contains('split');
     asideMedia.classList.add(`${isSplit ? 'split-' : ''}image`);
     if (isSplit) {
       const position = [...asideMedia.parentNode.children].indexOf(asideMedia);

--- a/libs/blocks/aside/aside.js
+++ b/libs/blocks/aside/aside.js
@@ -128,9 +128,9 @@ function decorateLayout(el) {
   const bgMedia = el.querySelector(':scope > div:not(.text):not(.foreground) video')?.closest('div');
   const image = foregroundImage ?? bgImage;
   const asideMedia = foregroundMedia ?? bgMedia ?? image;
-  const isSplit = el.classList.contains('split');
-  if (isSplit && !asideMedia) el.classList.add('no-media');
+  if (!asideMedia) el.classList.add('no-media');
   if (asideMedia && !asideMedia.classList.contains('text')) {
+    const isSplit = el.classList.contains('split');
     asideMedia.classList.add(`${isSplit ? 'split-' : ''}image`);
     if (isSplit) {
       const position = [...asideMedia.parentNode.children].indexOf(asideMedia);


### PR DESCRIPTION
As per consonant the min-height in all in mobile view needs to be removed as long as all blocks show/maintain 80px padding/margin top and bottom.

Resolves: [MWPW-135782](https://jira.corp.adobe.com/browse/MWPW-135782)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/mathuria/aside/mwpw-135782?martech=off
- After: https://asidemobile--milo--aishwaryamathuria.hlx.page/docs/library/blocks/aside?martech=off
