### PR TITLE
Fix profile sign out button

### DIFF
--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -157,7 +157,7 @@ class ProfileDropdown {
   decorateSignOut() {
     const signOutLink = toFragment`
       <li>
-        <button class="feds-profile-action" daa-ll="${this.placeholders.signOut}">${this.placeholders.signOut}</button>
+        <a class="feds-profile-action" daa-ll="${this.placeholders.signOut}">${this.placeholders.signOut}</a>
       </li>
     `;
 


### PR DESCRIPTION
## Description
Due to limitations on testing the logged in experiences on branches a visual bug snuck in that we need to fix

## Related Issue
Resolves: [MWPW-133693](https://jira.corp.adobe.com/browse/MWPW-133693)

## Testing instructions
Log in and observe the profile sign out button looking correct again.

## Screenshots (if appropriate):
Before
![Screenshot 2023-09-06 at 14 33 47](https://github.com/adobecom/milo/assets/39759830/c4da9bb7-18be-46a0-bf10-43010be37d8c)

After
![Screenshot 2023-09-06 at 14 35 00](https://github.com/adobecom/milo/assets/39759830/163aa0b3-49a8-4aa4-8ac0-d96eb7d1954f)


## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=ims--milo--adobecom

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=ims--milo--adobecom

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=ims--milo--adobecom
**Milo:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://ims--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off