### PR TITLE
[MWPW-136078] Ensure breadcrumbs based on URL are built

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -632,9 +632,8 @@ class Gnav {
     if (!this.el.classList.contains('has-breadcrumbs')) return null;
     if (this.elements.breadcrumbsWrapper) return this.elements.breadcrumbsWrapper;
     const breadcrumbsElem = this.el.querySelector('.breadcrumbs');
-    if (!breadcrumbsElem) return null;
     // Breadcrumbs are not initially part of the nav, need to decorate the links
-    decorateLinks(breadcrumbsElem);
+    if (breadcrumbsElem) decorateLinks(breadcrumbsElem);
     const createBreadcrumbs = await loadBlock('../features/breadcrumbs/breadcrumbs.js');
     this.elements.breadcrumbsWrapper = await createBreadcrumbs(breadcrumbsElem);
     return this.elements.breadcrumbsWrapper;


### PR DESCRIPTION
## Description
This ensures that breadcrumbs are being built on pages using the URL-generated breadcrumbs feature.

## Related Issue
Resolves: [MWPW-136078](https://jira.corp.adobe.com/browse/MWPW-136078)

## Testing instructions
On the Milo page, have a look at the After link and notice that breadcrumbs are being added as expected.

On consumer pages, no change should be visible, as the feature only impacts pages using the automatic breadcrumb generation based on URL.

## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=breadcrumbs-from-url--milo--overmyheadandbody

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=breadcrumbs-from-url--milo--overmyheadandbody

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=breadcrumbs-from-url--milo--overmyheadandbody

**Milo:**
- Before: https://main--milo--overmyheadandbody.hlx.page/ch_de/libs/feds/drafts/qa/breadcrumbs/feds-breadcrumbs-no-hidden-links?martech=off
- After: https://breadcrumbs-from-url--milo--overmyheadandbody.hlx.page/ch_de/libs/feds/drafts/qa/breadcrumbs/feds-breadcrumbs-no-hidden-links?martech=off