### PR TITLE
{viewpoint}-only-{theme} feature for marquee

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -16,8 +16,12 @@
   margin-bottom: 0;
 }
 
-.marquee.light, .marquee.quiet, .marquee.inline {
+.marquee.light, .marquee.mobile-only-light, .marquee.quiet, .marquee.inline {
   color: var(--text-color);
+}
+
+.marquee.mobile-only-dark {
+  color: #FFF;
 }
 
 .marquee .foreground {
@@ -159,6 +163,10 @@
   background-color: black;
 }
 
+.marquee.large.mobile-only-light {
+  background-color: initial;
+}
+
 .marquee.large .text {
   display: flex;
   flex-direction: column;
@@ -296,6 +304,22 @@
     display: block;
   }
 
+  .marquee.large.tablet-only-dark {
+    background-color: black;
+  }
+
+  .marquee.large.tablet-only-light {
+    background-color: initial;
+  }
+
+  .marquee.tablet-only-light {
+    color: var(--text-color);
+  }
+
+  .marquee.tablet-only-dark {
+    color: #FFF;
+  }
+  
   .marquee .media {
     width: var(--grid-container-width); /* 10 grid / 83% */
   }
@@ -410,6 +434,22 @@
     display: block;
   }
 
+  .marquee.large.desktop-only-dark {
+    background-color: black;
+  }
+
+  .marquee.large.desktop-only-light {
+    background-color: initial;
+  }
+
+  .marquee.desktop-only-light {
+    color: var(--text-color);
+  }
+
+  .marquee.desktop-only-dark {
+    color: #FFF;
+  }
+  
   .marquee .foreground {
     flex-direction: row;
     align-items: center;

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -39,6 +39,12 @@ const decorateBlockBg = (block, node) => {
     if (childCount === 3) {
       child.classList.add(viewports[index]);
     }
+
+    if (child.textContent.trim()) {
+      block.classList.add(`${child.classList[child.classList.length - 1]}-${child.textContent.trim().toLowerCase()}`);
+      child.querySelector('p')?.remove();
+    }
+
     const videoElement = child.querySelector('a[href*=".mp4"], video source[src$=".mp4"]');
     if (videoElement) {
       const video = decorateVideo(child, videoElement.href || videoElement.src);

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -42,7 +42,6 @@ const decorateBlockBg = (block, node) => {
 
     if (child.textContent.trim()) {
       block.classList.add(`${child.classList[child.classList.length - 1]}-${child.textContent.trim().toLowerCase()}`);
-      child.querySelector('p')?.remove();
     }
 
     const videoElement = child.querySelector('a[href*=".mp4"], video source[src$=".mp4"]');


### PR DESCRIPTION
{viewpoint}-only-{theme} feature for marquee.

Resolves: [MWPW-135840](https://jira.corp.adobe.com/browse/MWPW-135840)

This will allow authors to have different themes (light or dark) for each veiwpoint (mobile, tablet, desktop) by simply adding theme text in the background cell

Example:
<img width="675" alt="image" src="https://github.com/adobecom/milo/assets/55804872/486f6380-2d60-44fc-9668-0fb2c675cdb9">


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/seanchoi/marquees?martech=off
- After: https://marquee-update--milo--adobecom.hlx.page/drafts/seanchoi/marquees?martech=off

*I also checked library to make sure that this doesn't break existing blocks
(https://marquee-update--milo--adobecom.hlx.page/docs/library/blocks/marquee)