### PR TITLE
MWPW-135977 Marketo Checkbox Error Icon

### DIFF
--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -315,6 +315,14 @@
   background-size: 19.5px, 1em 1em;
 }
 
+.marketo .mktoForm.show-warnings .mktoCheckboxList.mktoInvalid label::after {
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Cpath data-name='Path 356676' d='m10.564 2.206-9.249 16.55a.5.5 0 0 0 .436.744h18.5a.5.5 0 0 0 .436-.744l-9.251-16.55a.5.5 0 0 0-.872 0ZM12 17.25a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-1.5a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25Zm0-3.5a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-6a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25Z' fill='%23D7373F'/%3E%3C/svg%3E") no-repeat 100% 100%;
+  background-size: 19.5px;
+  display: inline-block;
+  height: 24px;
+  width: 28px;
+}
+
 .marketo .mktoForm.show-warnings .mktoError {
   width: 100%;
   font-size: 12px;


### PR DESCRIPTION
* Marketo block: Add error icon to checkboxes for accessibility

Resolves: [MWPW-135977](https://jira.corp.adobe.com/browse/MWPW-135977)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/bmarshal/mcz/marketo-block?martech=off
- After: https://methomas-marketo-icon--milo--adobecom.hlx.page/drafts/bmarshal/mcz/marketo-block?martech=off

(To test, select "Korea, South" for Country/Region and click submit. The first two checkboxes are required.)