### PR TITLE
fix(MWPW-136057):background scrolls when modal is open fixed

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -150,6 +150,10 @@
   column-count: 1;
 }
 
+.modal-open {
+  overflow: hidden;
+}
+
 @media (min-width: 600px) {
   .dialog-modal {
     max-width: 80vw;

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -34,6 +34,7 @@ export function sendAnalytics(event) {
 function closeModal(modal) {
   const { id } = modal;
   const closeEvent = new Event('milo:modal:closed');
+  document.body.classList.remove('modal-open');
   window.dispatchEvent(closeEvent);
   const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
   const analyticsEventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
@@ -107,7 +108,7 @@ export async function sendViewportDimensionsOnRequest(messageInfo) {
 
 export async function getModal(details, custom) {
   if (!(details?.path || custom)) return null;
-
+  document.body.classList.add('modal-open');
   const { id } = details || custom;
 
   const dialog = createTag('div', { class: 'dialog-modal', id });


### PR DESCRIPTION
* body scroll/overflow  is hidden when a modal is open.

Resolves: [MWPW-136057](https://jira.corp.adobe.com/browse/MWPW-136057)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/creativecloud/animation/discover?martech=off
- After: https://main--cc--adobecom.hlx.page/creativecloud/animation/discover?martech=off&milolibs=MWPW-136057--milo--sharath-kannan#animate

**milo URLS**
- Before: https://main--milo--sharath-kannan.hlx.page/eg_ar/drafts/tat28144/blocks/marqueeblock?martech=off
-After: https://mwpw-136057--milo--sharath-kannan.hlx.page/eg_ar/drafts/tat28144/blocks/marqueeblock?martech=off
