### PR TITLE
Update static links style in section metadata to support modal links

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -17,7 +17,7 @@
   color: rgb(34 34 34);
 }
 
-.section.static-links a:not([class]) {
+.section.static-links a:not([class*="button"]) {
   color: inherit;
   text-decoration: underline;
 }


### PR DESCRIPTION
* Static links style in section meta data doesn't work on modal links because they contain classes.  So I'm just making the static-links rule more specific. The start free trial link in the before URL was not inheriting color.

**Test URLs:**
- Before: https://homepage-brick--homepage--adobecom.hlx.page/homepage/?mep=%2Fhomepage%2Fhomepage.json--target-cc-lapsed
- After: https://homepage-brick--homepage--adobecom.hlx.page/homepage/?mep=%2Fhomepage%2Fhomepage.json--target-cc-lapsed&milolibs=static-links-modal
