### PR TITLE
Fix hidden IG and /reel/ links

### DIFF
--- a/libs/blocks/instagram/instagram.js
+++ b/libs/blocks/instagram/instagram.js
@@ -3,12 +3,17 @@ import { createIntersectionObserver, createTag, loadScript, isInTextNode } from 
 export default function init(a) {
   if (isInTextNode(a)) return;
   const embedInstagram = async () => {
-    const anchor = createTag('a', { href: a.href });
+    const href = a.href.replace('/reel/', '/p/');
+    const anchor = createTag('a', { href });
     const blockquote = createTag('blockquote', { class: 'instagram-media', 'data-instgrm-captioned': '' }, anchor);
     const wrapper = createTag('div', { class: 'embed-instagram' }, blockquote);
     a.parentElement.replaceChild(wrapper, a);
 
-    loadScript('https://www.instagram.com/embed.js');
+    if (window.instgrm) {
+      window.instgrm.Embeds.process(wrapper);
+    } else {
+      loadScript('https://www.instagram.com/embed.js');
+    }
   };
 
   createIntersectionObserver({ el: a, callback: embedInstagram });


### PR DESCRIPTION
Instagrams that load with IO after the first IG is loaded were not displaying, this uses the instagram api to manually display them (`window.instgrm.Embeds.process`)

Also `/reel/` links were not working, so we replace that with `/p/`

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://instagfix--milo--adobecom.hlx.page/?martech=off
