### PR TITLE
mwpw-135988 - segment card styling fixes

### DIFF
--- a/libs/blocks/merch-card/merch-card.css
+++ b/libs/blocks/merch-card/merch-card.css
@@ -75,7 +75,8 @@
 }
 
 .merch-card .consonant-SpecialOffers-title h4,
-.merch-card .consonant-PlansCard-title h4 {
+.merch-card .consonant-PlansCard-title h4,
+.merch-card .consonant-SegmentBlade-title h4 {
   font-size: var(--type-heading-xxs-size);
 }
 
@@ -86,7 +87,7 @@
   font-weight: 500;
 }
 
-.merch-card.segment-blade {
+.merch-card.segment {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -288,6 +289,11 @@
   margin-left: auto;
   height: auto;
   width: auto;
+}
+
+.dark .merch-card .consonant-CardFooter .con-button.outline {
+  border-color: var(--color-black);
+  color: var(--color-black);
 }
 
 .merch-card .consonant-CardFooter-row .button--inactive {


### PR DESCRIPTION
Fixes Segment Merch card variant styles to match Consonant styles.

![Screenshot 2023-09-08 at 3 08 32 PM](https://github.com/adobecom/milo/assets/1179549/e091b458-8408-4f2d-879a-94a6bebdac6c)

This PR fixes the following:

- H4 title font-size for `segment` merch card variant.
- CSS Flex design on `segment` merch card variant to set equal width on all columns.
- `Outline` CTA button style on `dark` style of `section-metadata`

Resolves: [MWPW-135988](https://jira.corp.adobe.com/browse/MWPW-135988)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/axel/bug-fixes/segment-card-fixes?martech=off
- After: https://mwpw-135988--milo--adobecom.hlx.page/drafts/axel/bug-fixes/segment-card-fixes?martech=off
