### PR TITLE
MWPW-136311: Fixes merge issue with docx having duplicate blocks

### DIFF
--- a/tools/loc/rollout.js
+++ b/tools/loc/rollout.js
@@ -142,8 +142,8 @@ function getMergedMdast(langstoreNowProcessedMdast, livecopyProcessedMdast) {
               return mergedArr;
           } else {
               resolvedBocks[content] = {status: false, type: 'added'};
-              mergedMdast.push({hashcode: content, classType:type});
-              return mergedMdast;
+              mergedArr.push({hashcode: content, classType:type});
+              return mergedArr;
           }
         } else if (mergedArr[i].classType === 'deleted' ) {
           if(type === 'added') {
@@ -158,8 +158,8 @@ function getMergedMdast(langstoreNowProcessedMdast, livecopyProcessedMdast) {
               return newArray;
           } else if(type==='deleted') {
               resolvedBocks[content] = {status: false, type: 'deleted'};
-              mergedMdast.push({hashcode: content, classType:type});
-              return mergedMdast;
+              mergedArr.push({hashcode: content, classType:type});
+              return mergedArr;
           }
         }
       }


### PR DESCRIPTION
Resolves: [MWPW-136311](https://jira.corp.adobe.com/browse/MWPW-136311)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Bd2ff782a-0c83-4217-b7d0-1e947204e083%257D%26action%3Deditnew
- After: https://fix-dup-block-merge--milo--adobecom.hlx.page/tools/loc/index.html?project=milo--adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Bd2ff782a-0c83-4217-b7d0-1e947204e083%257D%26action%3Deditnew
