### PR TITLE
MWPW-126974: extracts URL string from html links in caas card-metadata

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -143,9 +143,16 @@ const prefixHttps = (url) => {
   return url;
 };
 
+const flattenLink = (link) => {
+  var htmlElement = document.createElement('div');
+  htmlElement.innerHTML = link;
+  return htmlElement.querySelector('a').getAttribute('href');
+};
+
 const checkUrl = (url, errorMsg) => {
   if (url === undefined) return url;
-  return isValidUrl(url) ? prefixHttps(url) : { error: errorMsg };
+  const flatUrl = (url.indexOf('href=')) ? flattenLink(url) : url;
+  return isValidUrl(flatUrl) ? prefixHttps(flatUrl) : { error: errorMsg };
 };
 
 // Case-insensitive search through tag name, path, id and title for the searchStr


### PR DESCRIPTION
Sometimes users accidentally convert URLs into html-links by entering space or return after the URL in SharePoint.

This PR extracts URL string from the html links in the caas card-metadata block during the send to caas workflow.
 
Resolves: [MWPW-126974](https://jira.corp.adobe.com/browse/MWPW-126974)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://126974--milo--adobecom.hlx.page/?martech=off
