### PR TITLE
[MWPW-135720] Decorate video only when the element is visible.

### DIFF
--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -24,27 +24,34 @@ const decorateVideo = (container, src) => {
 };
 
 const decorateBlockBg = (block, node) => {
-  const viewports = ['mobile-only', 'tablet-only', 'desktop-only'];
+  const viewports = { 'mobile-only': 0, 'tablet-only': 600, 'desktop-only': 1200 };
+  const viewportsKeys = Object.keys(viewports);
+  const viewportWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
   const childCount = node.childElementCount;
   const { children } = node;
 
   node.classList.add('background');
 
   if (childCount === 2) {
-    children[0].classList.add(viewports[0], viewports[1]);
-    children[1].classList.add(viewports[2]);
+    children[0].classList.add(viewportsKeys[0], viewportsKeys[1]);
+    children[1].classList.add(viewportsKeys[2]);
   }
 
   [...children].forEach(async (child, index) => {
     if (childCount === 3) {
-      child.classList.add(viewports[index]);
+      child.classList.add(viewportsKeys[index]);
     }
-    const videoElement = child.querySelector('a[href*=".mp4"], video source[src$=".mp4"]');
-    if (videoElement) {
-      const video = decorateVideo(child, videoElement.href || videoElement.src);
-      const hash = video.firstElementChild?.src.split('#')[1];
-      if (hash?.includes('autoplay1')) {
-        video.removeAttribute('loop');
+
+    // Skip the fallback if current screen size isn't matching the child's viewport.
+    if (viewportWidth >= viewports[viewportsKeys[index]]) {
+      // decorateVideo as fallback of video autoblock.
+      const videoElement = child.querySelector('a[href*=".mp4"], video source[src$=".mp4"]');
+      if (videoElement) {
+        const video = decorateVideo(child, videoElement.href || videoElement.src);
+        const hash = video.firstElementChild?.src.split('#')[1];
+        if (hash?.includes('autoplay1')) {
+          video.removeAttribute('loop');
+        }
       }
     }
 

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -43,7 +43,9 @@ const decorateBlockBg = (block, node) => {
     }
 
     // Skip the fallback if current screen size isn't matching the child's viewport.
-    if (viewportWidth >= viewports[viewportsKeys[index]]) {
+    const nextChildViewportWidth = viewports[viewportsKeys[index + 1]] || 99999;
+    if (nextChildViewportWidth > viewportWidth
+      && viewportWidth >= viewports[viewportsKeys[index]]) {
       // decorateVideo as fallback of video autoblock.
       const videoElement = child.querySelector('a[href*=".mp4"], video source[src$=".mp4"]');
       if (videoElement) {

--- a/libs/blocks/video/video.css
+++ b/libs/blocks/video/video.css
@@ -1,3 +1,7 @@
+a[href*='.mp4'] {
+  visibility: hidden !important;
+}
+
 video {
   max-width: 100%;
   height: auto;

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -1,6 +1,9 @@
+import { createIntersectionObserver } from '../../utils/utils.js';
 import { applyHoverPlay, getVideoAttrs } from '../../utils/decorate.js';
 
-export default function init(a) {
+const ROOT_MARGIN = 1000;
+
+const loadVideo = async (a) => {
   const { pathname, hash } = a;
   const attrs = getVideoAttrs(hash);
   const video = `<video ${attrs}>
@@ -11,4 +14,16 @@ export default function init(a) {
   const videoElem = document.body.querySelector(`source[src=".${pathname}"]`)?.parentElement;
   applyHoverPlay(videoElem);
   a.remove();
+};
+
+export default async function init(a) {
+  if (a.textContent.includes('no-lazy')) {
+    loadVideo(a);
+  } else {
+    createIntersectionObserver({
+      el: a,
+      options: { rootMargin: `${ROOT_MARGIN}px` },
+      callback: loadVideo,
+    });
+  }
 }


### PR DESCRIPTION
Resolves: [MWPW-135720](https://jira.corp.adobe.com/browse/MWPW-135720)

- Added intersection observer for video auto block (with hiding the a link before decorating it)
- Added a logic for Marquee not to run the fallback decorateVideo() if current screen size doesn't meet the viewport that includes video.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/seanchoi/marquee-video?martech=off
- After: https://MWPW-135720-marquee-video--milo--adobecom.hlx.page/drafts/seanchoi/marquee-video?martech=off