### PR TITLE
[Blog Migration] Article feed update to work with metadata

### DIFF
--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -8,6 +8,7 @@ import {
 
 import { createTag, getConfig, createIntersectionObserver } from '../../utils/utils.js';
 import { replaceKey } from '../../features/placeholders.js';
+import { updateLinkWithLangRoot } from '../../utils/helpers.js';
 
 const ROOT_MARGIN = 50;
 
@@ -74,9 +75,10 @@ export async function fetchBlogArticleIndex() {
   const pageSize = 500;
   const { feed } = blogIndex.config;
   const queryParams = `?limit=${pageSize}&offset=${blogIndex.offset}`;
+  const defaultPath = updateLinkWithLangRoot(`${getConfig().locale.contentRoot}/query-index.json`);
   const indexPath = feed
     ? `${feed}${queryParams}`
-    : `${getConfig().locale.contentRoot}/query-index.json${queryParams}`;
+    : `${defaultPath}${queryParams}`;
 
   if (blogIndex.complete) return (blogIndex);
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Add `lang-root` functionality to Article Feed block.
* * `lang-root` feature was added in https://github.com/adobecom/milo/pull/1101
* Defaults to link passed in (`${getConfig().locale.contentRoot}/query-index.json`) if `lang-root` isn't set.


This allows the Article Feed to use metadata (`lang-root`) to pass in a specific language folder to pull the query-index from.


Resolves: No ticket

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/taxonomy?martech=off
- After: https://article-feed-langroot--milo--adobecom.hlx.page/drafts/methomas/taxonomy?martech=off

**Blog Test URLs:**
- Before: https://main--blog--adobecom.hlx.page/en/topics/adobe-culture?martech=off
- After: https://main--blog--adobecom.hlx.page/en/topics/adobe-culture?martech=off&milolibs=article-feed-langroot

**Bacom Test URLs:**
- Before:  https://main--bacom-blog--adobecom.hlx.page/drafts/methomas/taxonomy-config?martech=off&milolibs=article-feed-langroot
- After: https://main--bacom-blog--adobecom.hlx.page/drafts/methomas/taxonomy-config?martech=off&milolibs=article-feed-langroot
