### PR TITLE
turn on impression tracking for accordion block

### DIFF
--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -119,7 +119,6 @@ function populateMedia(accordion, id, num, collection) {
 }
 
 export default function init(el) {
-  decorateBlockAnalytics(el);
   const id = getUniqueId(el);
   const accordion = createTag('dl', { class: 'accordion', id: `accordion-${id}`, role: 'presentation' });
   const accordionMedia = createTag('div', { class: 'accordion-media', id: `accordion-media-${id}` });
@@ -151,4 +150,5 @@ export default function init(el) {
     el.append(accordionMedia);
     defalutOpen(el);
   }
+  decorateBlockAnalytics(el);
 }

--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -1,5 +1,6 @@
 import { createTag } from '../../utils/utils.js';
 import { decorateButtons } from '../../utils/decorate.js';
+import { decorateBlockAnalytics } from '../../martech/attributes.js';
 
 const faq = { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity: [] };
 const mediaCollection = {};
@@ -118,6 +119,7 @@ function populateMedia(accordion, id, num, collection) {
 }
 
 export default function init(el) {
+  decorateBlockAnalytics(el);
   const id = getUniqueId(el);
   const accordion = createTag('dl', { class: 'accordion', id: `accordion-${id}`, role: 'presentation' });
   const accordionMedia = createTag('div', { class: 'accordion-media', id: `accordion-media-${id}` });


### PR DESCRIPTION
* Until analytics overhaul can be implemented, the accordion block needs impression tracking.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/accordion?martech=off
- After: https://accordion-impression--milo--adobecom.hlx.page/docs/library/blocks/accordion?martech=off
