### PR TITLE
MWPW-136505 - Aside notification content alignment

### DIFF
--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -116,6 +116,7 @@
   max-width: none;
   padding-top: 0;
   padding-bottom: 0;
+  align-content: start;
 }
 
 .aside.notification .foreground.container .text a {
@@ -492,7 +493,6 @@
 .aside.split.bio .foreground.container .text .icon-area {
   display: none;
 }
-
 
 .aside.center:not(.notification) .foreground.container .text .icon-area {
   height: var(--icon-size-xxl);

--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -105,7 +105,6 @@
 .aside .foreground.container .text {
   display: flex;
   flex-wrap: wrap;
-  align-content: center;
 }
 
 .aside .foreground.container .image {
@@ -116,7 +115,6 @@
   max-width: none;
   padding-top: 0;
   padding-bottom: 0;
-  align-content: start;
 }
 
 .aside.notification .foreground.container .text a {


### PR DESCRIPTION
Looks like the notification variant of the aside is inheriting a style for setting its text content alignment. So adding the correct alignment property to the notification specific styles.

Update: actually ended up just removing the `align-content: center;` style because the correct alignment is being set from the center variant anyway. 

Resolves: [MWPW-136505](https://jira.corp.adobe.com/browse/MWPW-136505)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/aside-notification-poc?martech=off
- After: https://sarchibeque-mwpw-136505-aside-fix--milo--adobecom.hlx.page/drafts/sarchibeque/aside-notification-poc?martech=off
