### PR TITLE
MWPW-133600 - Floodgate for loading Caas Card Collections

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -98,8 +98,6 @@ const defaultOptions = {
       '14257-chimera.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection',
     '14257-chimera-stage.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':
       '14257-chimera-stage.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection',
-    '14257-chimera-dev.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':
-      '14257-chimera-dev.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection',
   },
   filterBuildPanel: {
     automatic: 'Automatic',

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -1,7 +1,9 @@
-import { initCaas, loadCaasFiles, loadStrings } from './utils.js';
-import { parseEncodedConfig, createIntersectionObserver } from '../../utils/utils.js';
+import { initCaas, loadCaasFiles, loadStrings, fgHeaderValue } from './utils.js';
+import { parseEncodedConfig, createIntersectionObserver, getMetadata, getConfig, b64ToUtf8 } from '../../utils/utils.js';
 
 const ROOT_MARGIN = 1000;
+const P_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
+const S_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS1zdGFnZS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
 
 const getCaasStrings = (placeholderUrl) => new Promise((resolve) => {
   if (placeholderUrl) {
@@ -29,6 +31,30 @@ const loadCaas = async (a) => {
 
   a.insertAdjacentElement('afterend', block);
   a.remove();
+
+  const floodGateColor = getMetadata('floodgatecolor') || '';
+  if (floodGateColor === fgHeaderValue) {
+    state.fetchCardsFromFloodgateTree = true;
+  }
+
+  const { env } = getConfig();
+  const { host } = window.location;
+  let chimeraEndpoint = 'www.adobe.com/chimera-api/collection';
+
+  if (host.includes('stage.adobe') || env?.name === 'local') {
+    chimeraEndpoint = S_CAAS_AIO;
+  } else if (host.includes('.hlx.')) {
+    // If invoking URL is not an Acom URL, then switch to AIO
+    chimeraEndpoint = P_CAAS_AIO;
+  }
+
+  if (host.includes('hlx.page') || env?.name === 'local') {
+    // Set draft=true if URL consisting hlx.page (if published url or hlx.live, then draft is false)
+    state.draftDb = true;
+  }
+
+  // Configure the Chimera Endpoint, based on the calling URI
+  state.endpoint = chimeraEndpoint;
 
   initCaas(state, caasStrs, block);
 };

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -3,6 +3,8 @@ import { loadScript, loadStyle, getConfig as pageConfigHelper } from '../../util
 import { fetchWithTimeout } from '../utils/utils.js';
 
 const URL_ENCODED_COMMA = '%2C';
+export const fgHeaderName = 'X-Adobe-Floodgate';
+export const fgHeaderValue = 'pink';
 
 const pageConfig = pageConfigHelper();
 const pageLocales = Object.keys(pageConfig.locales || {});
@@ -291,13 +293,10 @@ const findTupleIndex = (fgHeader) => {
  * @returns requestHeaders
  */
 const addFloodgateHeader = (state) => {
-  const fgHeader = 'X-Adobe-Floodgate';
-  const fgHeaderValue = 'pink';
-
   // Delete FG header if already exists, before adding pink to avoid duplicates in requestHeaders
-  requestHeaders.splice(findTupleIndex(fgHeader, 1));
+  requestHeaders.splice(findTupleIndex(fgHeaderName, 1));
   if (state.fetchCardsFromFloodgateTree) {
-    requestHeaders.push([fgHeader, fgHeaderValue]);
+    requestHeaders.push([fgHeaderName, fgHeaderValue]);
   }
   return requestHeaders;
 };

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -416,7 +416,7 @@ const props = {
   cardimage: () => getCardImageUrl(),
   cardimagealttext: (s) => s || getCardImageAltText(),
   contentid: (_, options) => {
-    const floodGateColor = getMetadata('floodGateColor') || '';
+    const floodGateColor = getMetadata('floodgatecolor') || '';
     return getUuid(`${options.prodUrl}${floodGateColor}`);
   },
   contenttype: (s) => s || getMetaContent('property', 'og:type') || getConfig().contentType,
@@ -459,7 +459,7 @@ const props = {
   eventduration: 0,
   eventend: (s) => getDateProp(s, `Invalid Event End Date: ${s}`),
   eventstart: (s) => getDateProp(s, `Invalid Event Start Date: ${s}`),
-  floodgatecolor: (s) => s || getMetadata('floodGateColor') || 'default',
+  floodgatecolor: (s) => s || getMetadata('floodgatecolor') || 'default',
   lang: async (s, options) => {
     if (s) return s;
     const { lang } = await getCountryAndLang(options);


### PR DESCRIPTION
- Fetch Caas from Floodgate, based on Metadata floodgatecolor attribute with pink as value
- Swap the Chimera endpoint to use AdobeIO endpoint instead of Adobe.com's chimera endpoint, to retain the FG header we attach (Akamai removes the header if it is invoked from a non Adobe.com URL)
- Added Draft=true for hlx.page URLs & for Local servers, to pull from Chimera's Draft container
- Remove the Dev Chimera Endpoint from Caas Configurator endpoints' list

Resolves: [MWPW-133600](https://jira.corp.adobe.com/browse/MWPW-133600)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/arshad/fg/fg-caas-test?martech=off
- After: https://main--milo--arshadparwaiz.hlx.page/drafts/arshad/fg/fg-caas-test?martech=off
