### PR TITLE
Revert "MWPW-135967: card container to support fragments (#1222)"

### DIFF
--- a/libs/blocks/card/card.css
+++ b/libs/blocks/card/card.css
@@ -10,8 +10,3 @@
   width: 100%;
   margin-bottom: var(--spacing-xs);
 }
-
-/* stylelint-disable-next-line selector-class-pattern */
-.consonant-Wrapper .fragment {
-  display: flex;
-}

--- a/libs/blocks/card/card.js
+++ b/libs/blocks/card/card.js
@@ -57,6 +57,8 @@ const init = (el) => {
   const base = miloLibs || codeRoot;
   loadStyle(`${base}/deps/caas.css`);
 
+  const section = el.closest('.section');
+  section.classList.add('milo-card-section');
   const row = el.querySelector(':scope > div');
   const picture = el.querySelector('picture');
   const styles = Array.from(el.classList);
@@ -66,7 +68,7 @@ const init = (el) => {
     .querySelectorAll('a') : el.querySelectorAll('a');
   let card = el;
 
-  addWrapper(el, cardType);
+  addWrapper(el, section, cardType);
 
   if (cardType === HALF_HEIGHT) {
     const [link] = links;

--- a/libs/blocks/card/cardUtils.js
+++ b/libs/blocks/card/cardUtils.js
@@ -36,16 +36,10 @@ export const addFooter = (links, container, merch) => {
   });
 };
 
-export const addWrapper = (el, cardType) => {
-  const fragment = el.closest('.fragment');
-  if (fragment) {
-    const fragmentSection = el.closest('.section');
-    fragmentSection?.replaceWith(el);
-  }
-  const section = el.closest('.section');
-  section.classList.add('milo-card-section');
+export const addWrapper = (el, section, cardType) => {
   const gridCl = 'consonant-CardsGrid';
-  const prevGrid = el.closest(`.consonant-Wrapper .${gridCl}`);
+  const prevGrid = section.querySelector(`.consonant-Wrapper .${gridCl}`);
+
   if (prevGrid) return;
   const card = el.classList[0];
   let upClass = getUpFromSectionMetadata(section);
@@ -63,10 +57,7 @@ export const addWrapper = (el, cardType) => {
   const collection = createTag('div', { class: 'consonant-Wrapper-collection' }, grid);
   const inner = createTag('div', { class: 'consonant-Wrapper-inner' }, collection);
   const wrapper = createTag('div', { class: 'milo-card-wrapper consonant-Wrapper consonant-Wrapper--1200MaxWidth' }, inner);
-  section.querySelectorAll('div > .fragment').forEach((child) => {
-    child.parentElement.replaceWith(child);
-  });
-  const cards = [...section.children].filter((child) => child.classList.contains(card) || child.classList.contains('fragment'));
+  const cards = section.querySelectorAll(`.${card}`);
   const prevSib = cards[0].previousElementSibling;
 
   grid.append(...cards);

--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -139,6 +139,8 @@ const init = (el) => {
   const headings = el.querySelectorAll('h1, h2, h3, h4, h5, h6');
   decorateLinkAnalytics(el, headings);
   loadStyle(`${base}/deps/caas.css`);
+  const section = el.closest('.section');
+  section.classList.add('milo-card-section');
   const images = el.querySelectorAll('picture');
   let image;
   const icons = [];
@@ -165,7 +167,7 @@ const init = (el) => {
       }
     }
   });
-  addWrapper(el, cardType);
+  addWrapper(el, section, cardType);
   merchCard.classList.add('consonant-Card', 'consonant-ProductCard', `consonant-${cardType}`);
   if (image) addBackgroundImg(image, cardType, merchCard);
   if (ribbonMetadata !== null) decorateRibbon(el, ribbonMetadata, cardType);

--- a/test/blocks/merch-card/merch-card.test.js
+++ b/test/blocks/merch-card/merch-card.test.js
@@ -60,20 +60,6 @@ describe('Merch Card', () => {
     expect(buttons[1].textContent).to.be.equal('Save now');
   });
 
-  it('Supports Card as a Fragment', async () => {
-    document.body.innerHTML = await readFile({ path: './mocks/special-offers.html' });
-    await init(document.querySelector('.special-offers-black-friday'));
-    const fragment = document.querySelector('.special-offers-fragment');
-    const fragmentSection = fragment.querySelector('.section');
-    const card = fragment.querySelector('.merch-card');
-
-    expect(fragment).to.exist;
-    expect(fragment.parentElement.childElementCount).to.be.equal(3);
-    expect(fragmentSection).to.not.exist;
-    expect(card).to.exist;
-    expect(card.classList.contains('consonant-Card')).to.be.true;
-  });
-
   describe('Plans Card', () => {
     before(async () => {
       document.body.innerHTML = await readFile({ path: './mocks/plans-card.html' });

--- a/test/blocks/merch-card/mocks/special-offers.html
+++ b/test/blocks/merch-card/mocks/special-offers.html
@@ -22,36 +22,4 @@
       </div>
     </div>
   </div>
-  <div>
-    <div class="fragment special-offers-fragment" data-path="/promotions/blackfriday/fragments/card" data-manifest-id="/promotions/blackfriday/blackfriday-special-offers-manifest.json">
-      <div class="section">
-        <div class="merch-card special-offers-black-friday">
-          <div>
-            <div>#EDCC2D, #000000</div>
-            <div>BLACK FRIDAY</div>
-          </div>
-          <div>
-            <div>
-              <p>
-                <picture>
-                  <source type="image/webp" srcset="" media="(min-width: 600px)">
-                  <source type="image/webp" srcset="">
-                  <source type="image/png" srcset="" media="(min-width: 600px)">
-                  <img loading="lazy" alt="" src="" width="5000" height="2812">
-                </picture>
-              </p>
-              <h4 id="blackfriday">BLACK FRIDAY</h4>
-              <h3 id="get-10-off-photoshop">Get 10% off Photoshop.</h3>
-              <p>Black Friday deal. Ends Mar 20.</p>
-              <p><a href="https://adobe.com/">See terms</a></p>
-              <p><em><a href="https://business.adobe.com/">Learn More</a></em> <strong><a href="https://business.adobe.com/">Save now</a></strong></p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <a href="https://main--cc--adobecom.hlx.page/promotions/blackfriday/fragments/card2" data-manifest-id="/promotions/blackfriday/blackfriday-special-offers-manifest.json" class="fragment link-block">https://main--cc--adobecom.hlx.page/promotions/blackfriday/fragments/card</a>
-  </div>
 </div>


### PR DESCRIPTION
Reverting this change since:
a. there is a use-case to use several cards in 1 frag and the change is breaking it
b. with the new inline feature suggested by @chrischrischris we might not need these extra content mutations.

<!-- Before submitting, please review all open PRs. -->

* Add your
* Specific
* Features or fixes

Resolves: [MWPW-136552](https://jira.corp.adobe.com/browse/MWPW-136552)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/mariia/promodemo/special-offers/special-offers?martech=off
- After: https://mwpw-135967--milo--adobecom.hlx.page/drafts/mariia/promodemo/special-offers/special-offers?martech=off
