### PR TITLE
Add accordion to donotinline

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -91,6 +91,7 @@ const AUTO_BLOCKS = [
   { 'offer-preview': '/tools/commerce' },
 ];
 const DO_NOT_INLINE = [
+  'accordion',
   'columns',
   'z-pattern',
 ];


### PR DESCRIPTION
Some accordions have carousel fragments used in the block

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://exemptaccordion--milo--adobecom.hlx.page/?martech=off
