### PR TITLE
Revert "fix(MWPW-133207):Intermittent screen freeze, backdrop does no…

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -42,7 +42,9 @@ function closeModal(modal) {
   sendAnalytics(closeEventAnalytics);
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
-    document.querySelector(`#${id}~.modal-curtain`).remove();
+    if (mod.nextElementSibling?.classList.contains('modal-curtain')) {
+      mod.nextElementSibling.remove();
+    }
     if (mod.classList.contains('dialog-modal')) {
       mod.remove();
     }


### PR DESCRIPTION
…t close when modal is closed. (#1250)"

* This reverts commit 2cd1e2e24a728587c78b228f896bac462c03a0bc.
* Created an issue in production where modal is impossible to close

Resolves: [MWPW-136555](https://jira.corp.adobe.com/browse/MWPW-136555)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://<branch>--milo--adobecom.hlx.page/?martech=off

Doc cloud:
https://stage--dc--adobecom.hlx.live/acrobat/online/rotate-pdf?milolibs=revert-1250-MWPW-133207--milo--adobecom

CC:
- Before: https://main--cc--adobecom.hlx.page/creativecloud/animation/discover#animate
- After: https://main--cc--adobecom.hlx.page/creativecloud/animation/discover?milolibs=revert-1250-MWPW-133207#animate
