### PR TITLE
MWPW-134529 | Static Links class at block without section metadata for SEO

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -17,11 +17,6 @@
   color: rgb(34 34 34);
 }
 
-.section.static-links a:not([class*="button"]) {
-  color: inherit;
-  text-decoration: underline;
-}
-
 .section.hide-sticky-section,
 .section.close-sticky-section {
   display: none;

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -796,3 +796,8 @@ picture.bg-img img {
 .hide-block {
   display: none !important;
 }
+
+.static-links a:not([class*="button"]) {
+  color: inherit;
+  text-decoration: underline;
+}


### PR DESCRIPTION
Adding support to create a Marquee that can have link styles that inherit the text styling and not rely on adding a section as to negate SEO requirements. 

Resolves: [MWPW-134529](https://jira.corp.adobe.com/browse/MWPW-134529)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/mathuria/marqueeStaticLink/mwpw-134529?martech=off
- After: https://mstaticlnk--milo--aishwaryamathuria.hlx.page/drafts/mathuria/marqueeStaticLink/mwpw-134529?martech=off
