### PR TITLE
[MWPW-136611] Replace default experience name with IMS client ID

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -60,7 +60,8 @@ export function getAnalyticsValue(str, index) {
 export function getExperienceName() {
   const experiencePath = getMetadata('gnav-source');
   const explicitExperience = experiencePath?.split('/').pop();
-  if (explicitExperience?.length) return explicitExperience;
+  if (explicitExperience?.length
+    && explicitExperience !== 'gnav') return explicitExperience;
 
   const { imsClientId } = getConfig();
   if (imsClientId?.length) return imsClientId;

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -134,6 +134,19 @@ describe('global navigation utilities', () => {
     expect(experienceName).to.equal(config.imsClientId);
   });
 
+  it('getExperienceName replaces default experience name with client ID', () => {
+    // If the experience name is the default one (gnav), the imsClientId should be used instead
+    const gnavSourceMeta = toFragment`<meta name="gnav-source" content="http://localhost:2000/ch_de/libs/feds/gnav">`;
+    document.head.append(gnavSourceMeta);
+    let experienceName = getExperienceName();
+    expect(experienceName).to.equal(config.imsClientId);
+    // If the experience name is not the default one, the custom name should be used
+    gnavSourceMeta.setAttribute('content', 'http://localhost:2000/ch_de/libs/feds/custom-gnav');
+    experienceName = getExperienceName();
+    expect(experienceName).to.equal('custom-gnav');
+    gnavSourceMeta.remove();
+  });
+
   it('getExperienceName is empty if no imsClientId is defined', () => {
     const ogImsClientId = config.imsClientId;
     delete config.imsClientId;


### PR DESCRIPTION
## Description
The default _gnav_ experience name is not of much use for Analytics purposes, thus we want to replace such strings with the IMS client ID. What is now `gnav|gnav` will become `gnav|acrobatmilo` for an Acrobat page, for example.

## Related Issue
Resolves: [MWPW-136611](https://jira.corp.adobe.com/browse/MWPW-136611)

## Testing instructions
On a test page, run `document.querySelector('.global-navigation').getAttribute('daa-lh')` to check the Analytics value being used. Ideally, there shouldn't be duplicated _gnav_ strings being used.

From the test URLs shared below, just the Acrobat page should see an update in the Analytics tracking attribute.

## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=gnav-analytics-naming--milo--overmyheadandbody

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=gnav-analytics-naming--milo--overmyheadandbody

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=gnav-analytics-naming--milo--overmyheadandbody

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://gnav-analytics-naming--milo--overmyheadandbody.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off