### PR TITLE
MWPW-136619: Update CODEOWNERS for quiz and quiz-results

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,6 +35,8 @@
 /libs/blocks/merch-card/ @VKniaz @Axelcureno @ryanmparrish
 /libs/blocks/ost/ @Axelcureno @3ch023 @honstar @VKniaz @vladen @yesil @npeltier
 /libs/blocks/pdf-vewer/ @sanjayms01
+/libs/blocks/quiz/ @colloyd @sabyamon @@fullcolorcoder @JackySun9 @elaineskpt @echampio-at-adobe
+/libs/blocks/quiz-results/ @colloyd @sabyamon @@fullcolorcoder @JackySun9 @elaineskpt @echampio-at-adobe
 /libs/blocks/quote/ @ryanmparrish
 /libs/blocks/table-of-contents/ @Brandon32
 /libs/blocks/tabs/ @ryanmparrish

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,8 +35,8 @@
 /libs/blocks/merch-card/ @VKniaz @Axelcureno @ryanmparrish
 /libs/blocks/ost/ @Axelcureno @3ch023 @honstar @VKniaz @vladen @yesil @npeltier
 /libs/blocks/pdf-vewer/ @sanjayms01
-/libs/blocks/quiz/ @colloyd @sabyamon @@fullcolorcoder @JackySun9 @elaineskpt @echampio-at-adobe
-/libs/blocks/quiz-results/ @colloyd @sabyamon @@fullcolorcoder @JackySun9 @elaineskpt @echampio-at-adobe
+/libs/blocks/quiz/ @colloyd @sabyamon @fullcolorcoder @JackySun9 @elaineskpt @echampio-at-adobe
+/libs/blocks/quiz-results/ @colloyd @sabyamon @fullcolorcoder @JackySun9 @elaineskpt @echampio-at-adobe
 /libs/blocks/quote/ @ryanmparrish
 /libs/blocks/table-of-contents/ @Brandon32
 /libs/blocks/tabs/ @ryanmparrish


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Updating CODEOWNERS as requested in https://github.com/adobecom/milo/pull/1264

Resolves: [MWPW-136619](https://jira.corp.adobe.com/browse/MWPW-136619)

Test URLs:

Before: https://main--milo--adobecom.hlx.page/drafts/xiasun/quiz-2/?martech=off
After: https://uar-integration--milo--adobecom.hlx.page/drafts/xiasun/quiz-2/?martech=off
