### PR TITLE
[marquee-anchors] enhancement - author-proof input, include link attributes.  

### DIFF
--- a/libs/blocks/marquee-anchors/marquee-anchors.js
+++ b/libs/blocks/marquee-anchors/marquee-anchors.js
@@ -62,22 +62,19 @@ export default function init(el) {
     const aTag = i.querySelector('a');
     if (aTag?.textContent.charAt(0) === '#') {
       const content = i.querySelector(':scope > div');
+      const aTagText = aTag.textContent.toLowerCase();
+      aTag.textContent = '';
+      aTag.classList.add('anchor-link');
+      i.parentElement.replaceChild(aTag, i);
+      aTag.append(content);
       const hrefPathEqual = (aTag.href.split(/\?|#/)[0] === window.location.href.split(/\?|#/)[0]);
-      const hrefUrl = (hrefPathEqual)
-        ? `${aTag.textContent.toLowerCase()}`
-        : `${aTag.href}`;
-      const link = createTag('a', {
-        class: 'anchor-link',
-        href: hrefUrl,
-      }, content);
-      if (aTag.hasAttribute('target')) link.target = aTag.target;
-      if (aTag.hasAttribute('daa-ll')) link.setAttribute('daa-ll', aTag.getAttribute('daa-ll'));
-      if (!hrefPathEqual) link.classList.add('external');
-      i.parentElement.replaceChild(link, i);
-      aTag.parentElement.remove();
+      if (hrefPathEqual) {
+        aTag.href = aTagText;
+      } else {
+        aTag.classList.add('external');
+      }
     }
   });
-
   const emptyLinkRows = links.querySelectorAll(':scope > div:not([class])');
   if (emptyLinkRows[0]) emptyLinkRows[0].classList.add('links-header');
   if (emptyLinkRows[1]) emptyLinkRows[1].classList.add('links-footer', 'body-s');

--- a/libs/blocks/marquee-anchors/marquee-anchors.js
+++ b/libs/blocks/marquee-anchors/marquee-anchors.js
@@ -64,12 +64,14 @@ export default function init(el) {
       const content = i.querySelector(':scope > div');
       const hrefPathEqual = (aTag.href.split(/\?|#/)[0] === window.location.href.split(/\?|#/)[0]);
       const hrefUrl = (hrefPathEqual)
-        ? `${aTag.textContent}`
+        ? `${aTag.textContent.toLowerCase()}`
         : `${aTag.href}`;
       const link = createTag('a', {
         class: 'anchor-link',
         href: hrefUrl,
       }, content);
+      if (aTag.hasAttribute('target')) link.target = aTag.target;
+      if (aTag.hasAttribute('daa-ll')) link.setAttribute('daa-ll', aTag.getAttribute('daa-ll'));
       if (!hrefPathEqual) link.classList.add('external');
       i.parentElement.replaceChild(link, i);
       aTag.parentElement.remove();

--- a/test/blocks/marquee-anchors/mocks/body.html
+++ b/test/blocks/marquee-anchors/mocks/body.html
@@ -24,7 +24,7 @@
     <div>
       <h4 id="marquee-label">Marquee Label</h4>
       <p>Actionable data that drives real-time personalization.</p>
-      <p><a href="">#marquee-block</a></p>
+      <p><a href="" target="_blank">#marquee-block</a></p>
     </div>
   </div>
   <div>


### PR DESCRIPTION
As an author in Milo, I want the following features available to the `marquee-anchor` block so that I can have control over the user experience. 

1. Authoring input sanitization for error prevention. 
Authors & word will use uppercase labels so we lowercase() the label associations to prevent errors. 
2. Add link target and tracking attributes. 
These attributes get automatically included w/ any anchor-link creation so they behave as expected. 

Resolves: [MWPW-133742](https://jira.corp.adobe.com/browse/MWPW-133742)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/marquee-nav?martech=off
- After: https://rparrish-marquee-anchors-fix--milo--adobecom.hlx.page/drafts/rparrish/marquee-nav?martech=off


Testing notes: 
1. In looking at the document, you will see the uppercase being used on the `#Marquee-block` anchor link row. 
2. The 2nd marquee example down, the Adobe.com external link should have a `target="_blank"` attribute. 