### PR TITLE
Manifest data fix

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -418,7 +418,7 @@ export async function getPersConfig(name, variantLabel, manifestData, manifestPa
     placeholders = data.placeholders.data;
   }
 
-  const persData = data?.data || data?.experiences?.data || data?.experiments?.data;
+  const persData = data?.experiences?.data || data?.data || data;
   if (!persData) return null;
   const config = parseConfig(persData);
 

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -53,7 +53,7 @@ const handleAlloyResponse = (response) => {
 
       return {
         manifestPath: content.manifestLocation || content.manifestPath,
-        manifestData: content.manifestContent?.data || content.manifestContent?.experiments?.data,
+        manifestData: content.manifestContent?.data || content.manifestContent?.experiences?.data,
         name: item.meta['activity.name'],
         variantLabel: item.meta['experience.name'] && `target-${item.meta['experience.name']}`,
         meta: item.meta,

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -53,7 +53,7 @@ const handleAlloyResponse = (response) => {
 
       return {
         manifestPath: content.manifestLocation || content.manifestPath,
-        manifestData: content.manifestContent?.data || content.manifestContent?.experiences?.data,
+        manifestData: content.manifestContent?.experiences?.data || content.manifestContent?.data,
         name: item.meta['activity.name'],
         variantLabel: item.meta['experience.name'] && `target-${item.meta['experience.name']}`,
         meta: item.meta,

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -53,7 +53,7 @@ const handleAlloyResponse = (response) => {
 
       return {
         manifestPath: content.manifestLocation || content.manifestPath,
-        manifestData: content.manifestContent?.data,
+        manifestData: content.manifestContent?.data || content.manifestContent?.experiments?.data,
         name: item.meta['activity.name'],
         variantLabel: item.meta['experience.name'] && `target-${item.meta['experience.name']}`,
         meta: item.meta,


### PR DESCRIPTION
* manifests from Target not parsed correctly when 2 tabs are present in Excel and forces the manifest to be downloaded unnecessarily.  When comparing the 2 URLs below, the network tab shows that homepage-two-tabs.json is downloaded.  The after URL does not download it.

**Test URLs:**
- Before: https://stage--homepage--adobecom.hlx.page/homepage/index-loggedout?at_preview_token=JUDSndEyhg0ZdtCre6u_pA&at_preview_index=1_2&at_preview_listed_activities_only=true
- After: https://stage--homepage--adobecom.hlx.page/homepage/index-loggedout?milolibs=manifest-data-fix&at_preview_token=JUDSndEyhg0ZdtCre6u_pA&at_preview_index=1_2&at_preview_listed_activities_only=true
