### PR TITLE
Restrict changes done for MWPW-136057 to commerce modal

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -150,7 +150,7 @@
   column-count: 1;
 }
 
-.modal-open {
+.commerce-modal-open {
   overflow: hidden;
 }
 

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -34,7 +34,7 @@ export function sendAnalytics(event) {
 function closeModal(modal) {
   const { id } = modal;
   const closeEvent = new Event('milo:modal:closed');
-  if(document.body.classList.contains('modal-open')) {
+  if (document.body.classList.contains('modal-open')) {
     document.body.classList.remove('modal-open');
   }
   window.dispatchEvent(closeEvent);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -34,9 +34,7 @@ export function sendAnalytics(event) {
 function closeModal(modal) {
   const { id } = modal;
   const closeEvent = new Event('milo:modal:closed');
-  if (document.body.classList.contains('modal-open')) {
-    document.body.classList.remove('modal-open');
-  }
+  document.body.classList.remove('commerce-modal-open');
   window.dispatchEvent(closeEvent);
   const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
   const analyticsEventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
@@ -176,7 +174,7 @@ export async function getModal(details, custom) {
       .forEach((element) => element.setAttribute('aria-disabled', 'true'));
   }
   if (dialog.classList.contains('commerce-frame')) {
-    document.body.classList.add('modal-open');
+    document.body.classList.add('commerce-modal-open');
     if (isInitialPageLoad) {
       window.addEventListener('message', (messageInfo) => {
         sendViewportDimensionsOnRequest(messageInfo);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -34,7 +34,7 @@ export function sendAnalytics(event) {
 function closeModal(modal) {
   const { id } = modal;
   const closeEvent = new Event('milo:modal:closed');
-  if(document.body.classList.contains('modal-open') {
+  if(document.body.classList.contains('modal-open')) {
     document.body.classList.remove('modal-open');
   }
   window.dispatchEvent(closeEvent);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -34,7 +34,9 @@ export function sendAnalytics(event) {
 function closeModal(modal) {
   const { id } = modal;
   const closeEvent = new Event('milo:modal:closed');
-  document.body.classList.remove('modal-open');
+  if(document.body.classList.contains('modal-open') {
+    document.body.classList.remove('modal-open');
+  }
   window.dispatchEvent(closeEvent);
   const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
   const analyticsEventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
@@ -108,7 +110,6 @@ export async function sendViewportDimensionsOnRequest(messageInfo) {
 
 export async function getModal(details, custom) {
   if (!(details?.path || custom)) return null;
-  document.body.classList.add('modal-open');
   const { id } = details || custom;
 
   const dialog = createTag('div', { class: 'dialog-modal', id });
@@ -175,6 +176,7 @@ export async function getModal(details, custom) {
       .forEach((element) => element.setAttribute('aria-disabled', 'true'));
   }
   if (dialog.classList.contains('commerce-frame')) {
+    document.body.classList.add('modal-open');
     if (isInitialPageLoad) {
       window.addEventListener('message', (messageInfo) => {
         sendViewportDimensionsOnRequest(messageInfo);


### PR DESCRIPTION
* Restrict modal-open css class to commerce modal for CC

Resolves: [MWPW-136656](https://jira.corp.adobe.com/browse/MWPW-136656)

**Test URLs:**
Milo
- Before:  https://main--milo--adobecom.hlx.page/drafts/ruchika/discover1?martech=off
- After: https://modal--milo--ruchika4.hlx.page/drafts/ruchika/discover1?martech=off

DC
- Before:  https://main--dc--adobecom.hlx.page/acrobat/online/convert-pdf?martech=off
- After: https://main--dc--adobecom.hlx.page/acrobat/online/convert-pdf?milolibs=modal--milo--ruchika4&martech=off

CC
- Before: https://main--cc--adobecom.hlx.page/creativecloud/animation/discover?martech=off#after-effects
- After: https://main--cc--adobecom.hlx.page/creativecloud/animation/discover?martech=off&milolibs=modal--milo--ruchika4#after-effects


