### PR TITLE
mwpw-136633: safeguard scrolling

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -844,7 +844,7 @@ export function scrollToHashedElement(hash) {
   try {
     targetElement = document.querySelector(`#${elementId}:not(.dialog-modal)`);
   } catch (e) {
-    window.lana?.log(`Cannot make URL from metadata - ${elementId}: ${e.toString()}`);
+    window.lana?.log(`Could not query element because of invalid hash - ${elementId}: ${e.toString()}`);
   }
   if (!targetElement) return;
   const bufferHeight = document.querySelector('.global-navigation')?.offsetHeight || 0;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -840,7 +840,12 @@ async function loadPostLCP(config) {
 export function scrollToHashedElement(hash) {
   if (!hash) return;
   const elementId = hash.slice(1);
-  const targetElement = document.querySelector(`#${elementId}:not(.dialog-modal)`);
+  let targetElement;
+  try {
+    targetElement = document.querySelector(`#${elementId}:not(.dialog-modal)`);
+  } catch (e) {
+    window.lana?.log(`Cannot make URL from metadata - ${elementId}: ${e.toString()}`);
+  }
   if (!targetElement) return;
   const bufferHeight = document.querySelector('.global-navigation')?.offsetHeight || 0;
   const topOffset = targetElement.getBoundingClientRect().top + window.pageYOffset;


### PR DESCRIPTION
## Description
Some error has snuck in with https://github.com/adobecom/milo/pull/1081 blocking the log in from working (spotted only on stage environments so far)

@suhjainadobe would be great if you can have a deeper after the bug at hand as been fixed and write an additional unit test to ensure this can't happen in the future

## Related Issue
Resolves: [MWPW-136633](https://jira.corp.adobe.com/browse/MWPW-136633)

## Testing instructions
Try to log in ... the error might be a race condition, I've only managed to reproduce it on https://www.stage.adobe.com/acrobat/online/sign-pdf.html

## Screenshots (if appropriate):
No screenshot, but for the unit tests it might be valuable to have the output of _what_ failed.
```
Uncaught (in promise) DOMException: Failed to execute 'querySelector' on 'Document': '#property=foo&state=%7B%whatever%22%3A%22v99-v9.99.9-99-319d%22%2C%22test%22%3A%222188430%22%7D&otherprop=foo2&time=99999999:not(.dialog-modal)' is not a valid selector.
    at scrollToHashedElement (https://www.stage.adobe.com/libs/utils/utils.js:843:34)
    at loadArea (https://www.stage.adobe.com/libs/utils/utils.js:1018:5)
    at async loadPage (https://www.stage.adobe.com/homepage/scripts/scripts.js:76:3)
scrollToHashedElement @ utils.js:843
loadArea @ utils.js:1018
await in loadArea (async)
(anonymous) @ scripts.js:77
```

## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=ims--milo--adobecom

**BACOM:**
- Before: https://main--bacom--adobecom.hlx.live/?martech=off
- After: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=ims--milo--adobecom

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=ims--milo--adobecom

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://ims--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off