### PR TITLE
[MWPW-135557] - Font size tweak to text links in Large Split Marquees

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -288,6 +288,10 @@
   line-height: var(--type-body-l-lh);
 }
 
+.marquee.large.split .action-area a:not(.con-button) {
+  font-size: var(--type-body-m-size);
+}
+
 @media screen and (min-width: 600px) {
   .marquee .action-area {
     display: flex;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* A font size exception was needed specifically for text links in Large Split Marquees, taking the font size from 20px to 18px. This PR adds the requisite CSS for this.

Resolves: [MWPW-135557](https://jira.corp.adobe.com/browse/MWPW-135557)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off
- After: https://ebartholomew-marquee-split-font-size--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off
