### PR TITLE
Remove acomsis cookie on sign out.

### DIFF
--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -66,6 +66,10 @@ class ProfileDropdown {
     if (this.openOnInit) trigger({ element: this.buttonElem });
 
     this.decoratedElem.append(this.dropdown);
+
+    window.addEventListener('feds:signOut', () => {
+      document.cookie = 'acomsis=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    });
   }
 
   async getData() {


### PR DESCRIPTION
This is needed for homepage while it adds `acomsis` cookie when sign-in happens.
There should be removal for the cookie when sign-out.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/seanchoi/hhs-next-best-door-whitepaper?martech=off
- After: https://acomsis-signout-remove--milo--adobecom.hlx.page/drafts/seanchoi/hhs-next-best-door-whitepaper?martech=off
