### PR TITLE
[MWPW-136612] Gnav/Footer menus mobile accordion tracking

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -12,6 +12,7 @@ import {
   getExperienceName,
   loadDecorateMenu,
   getFedsPlaceholderConfig,
+  getAnalyticsValue,
   loadBaseStyles,
   yieldToMain,
 } from '../global-navigation/utilities/utilities.js';
@@ -268,14 +269,19 @@ class Footer {
     const socialBlock = this.body.querySelector('.social');
     if (!socialBlock) return this.elements.social;
 
-    const socialElem = toFragment`<ul class="feds-social"></ul>`;
+    const socialElem = toFragment`<ul class="feds-social" daa-lh="Social"></ul>`;
 
-    CONFIG.socialPlatforms.forEach((platform) => {
+    CONFIG.socialPlatforms.forEach((platform, index) => {
       const link = socialBlock.querySelector(`a[href*="${platform}"]`);
       if (!link) return;
 
       const iconElem = toFragment`<li class="feds-social-item">
-          <a href="${link.href}" class="feds-social-link" aria-label="${platform}" target="_blank">
+          <a
+            href="${link.href}"
+            class="feds-social-link"
+            aria-label="${platform}"
+            daa-ll="${getAnalyticsValue(platform, index + 1)}"
+            target="_blank">
             <svg xmlns="http://www.w3.org/2000/svg" class="feds-social-icon" alt="${platform} logo">
               <use href="#footer-icon-${platform}" />
             </svg>
@@ -310,12 +316,15 @@ class Footer {
         <use href="#footer-icon-adchoices" />
       </svg>`);
 
-    this.elements.legal = toFragment`<div class="feds-footer-legalWrapper"></div>`;
+    this.elements.legal = toFragment`<div class="feds-footer-legalWrapper" daa-lh="Legal"></div>`;
 
     while (privacyContent.children.length) {
       const privacySection = privacyContent.firstElementChild;
       privacySection.classList.add('feds-footer-privacySection');
-      privacySection.querySelectorAll('a').forEach((link) => link.classList.add('feds-footer-privacyLink'));
+      privacySection.querySelectorAll('a').forEach((link, index) => {
+        link.classList.add('feds-footer-privacyLink');
+        link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
+      });
       this.elements.legal.append(privacySection);
     }
 

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -12,7 +12,7 @@ import {
 import { decorateLinks } from '../../../../utils/utils.js';
 import { replaceText } from '../../../../features/placeholders.js';
 
-const decorateHeadline = (elem) => {
+const decorateHeadline = (elem, index) => {
   if (!(elem instanceof HTMLElement)) return null;
 
   const headline = toFragment`<div class="feds-menu-headline">
@@ -26,12 +26,14 @@ const decorateHeadline = (elem) => {
       headline.setAttribute('aria-level', 2);
       headline.removeAttribute('aria-haspopup', true);
       headline.removeAttribute('aria-expanded', false);
+      headline.removeAttribute('daa-ll');
     } else {
       headline.setAttribute('role', 'button');
       headline.setAttribute('tabindex', 0);
       headline.removeAttribute('aria-level');
       headline.setAttribute('aria-haspopup', true);
       headline.setAttribute('aria-expanded', false);
+      headline.setAttribute('daa-ll', getAnalyticsValue(headline.textContent, index));
     }
   };
 
@@ -79,14 +81,14 @@ const decorateLinkGroup = (elem, index) => {
   return linkGroup;
 };
 
-const decorateElements = ({ elem, className = 'feds-navLink', parseCtas = true, index = { position: 0 } } = {}) => {
+const decorateElements = ({ elem, className = 'feds-navLink', parseCtas = true, itemIndex = { position: 0 } } = {}) => {
   const decorateLink = (link) => {
     // Increase analytics index every time a link is decorated
-    index.position += 1;
+    itemIndex.position += 1;
 
     // Decorate link group
     if (link.matches('.link-group')) {
-      return decorateLinkGroup(link, index.position);
+      return decorateLinkGroup(link, itemIndex.position);
     }
 
     // If the link is wrapped in a 'strong' or 'em' tag, make it a CTA
@@ -96,11 +98,11 @@ const decorateElements = ({ elem, className = 'feds-navLink', parseCtas = true, 
       // Remove its 'em' or 'strong' wrapper
       link.parentElement.replaceWith(link);
 
-      return decorateCta({ elem: link, type, index: index.position });
+      return decorateCta({ elem: link, type, index: itemIndex.position });
     }
 
     // Simple links get analytics attributes and appropriate class name
-    link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index.position));
+    link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, itemIndex.position));
     link.classList.add(className);
 
     return link;
@@ -174,6 +176,8 @@ const decoratePromo = (elem, index) => {
 
 const decorateColumns = async ({ content, separatorTagName = 'H5' } = {}) => {
   const hasMultipleColumns = content.children.length > 1;
+  // Headline index is defined in the context of a whole menu
+  let headlineIndex = 0;
 
   // The resulting template structure should follow these rules:
   // * a menu can have multiple columns;
@@ -186,7 +190,8 @@ const decorateColumns = async ({ content, separatorTagName = 'H5' } = {}) => {
     const wrapper = toFragment`<div class="${wrapperClass}"></div>`;
     let itemDestination = toFragment`<div class="${itemDestinationClass}"></div>`;
     let menuItems;
-    const index = { position: 0 };
+    // Item index is defined in the context of a particular column
+    const itemIndex = { position: 0 };
 
     const resetDestination = () => {
       // First, if the previous destination has children,
@@ -204,28 +209,29 @@ const decorateColumns = async ({ content, separatorTagName = 'H5' } = {}) => {
       const columnElem = column.firstElementChild;
 
       if (columnElem.tagName === separatorTagName) {
+        headlineIndex += 1;
         // When encountering a separator (h5 for header, h2 for footer),
         // add the previous section to the column
         resetDestination();
         // If the separator splits content into columns, reset the analytics index
-        if (!hasMultipleColumns) index.position = 0;
+        if (!hasMultipleColumns) itemIndex.position = 0;
 
         // Analysts requested no headings in the dropdowns,
         // turning it into a simple div
-        const sectionHeadline = decorateHeadline(columnElem);
-        menuItems = toFragment`<div class="feds-menu-items" daa-lh="${sectionHeadline.textContent.trim()}"></div>`;
+        const sectionHeadline = decorateHeadline(columnElem, headlineIndex);
+        menuItems = toFragment`<div class="feds-menu-items" daa-lh="${getAnalyticsValue(sectionHeadline.textContent.trim())}"></div>`;
         itemDestination.append(sectionHeadline, menuItems);
       } else if (columnElem.classList.contains('gnav-promo')) {
         // When encountering a promo, add the previous section to the column
         resetDestination();
         // Since the promo is alone on a column, reset the analytics index
-        index.position = 0;
+        itemIndex.position = 0;
 
-        const promoElem = decoratePromo(columnElem, index);
+        const promoElem = decoratePromo(columnElem, itemIndex);
 
         itemDestination.append(promoElem);
       } else {
-        const decoratedElem = decorateElements({ elem: columnElem, index });
+        const decoratedElem = decorateElements({ elem: columnElem, itemIndex });
         columnElem.remove();
 
         // If an items template has been previously created,

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -876,8 +876,12 @@ describe('global navigation', () => {
       expect(isElementVisible(document.querySelector(selectors.brandContainer))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(false);
       expect(document.querySelectorAll(selectors.navItem).length).to.equal(8);
+      expect([...document.querySelectorAll(selectors.headline)]
+        .every((elem) => elem.getAttribute('daa-ll') === null))
+        .to.be.true;
 
       await setViewport(viewports.smallDesktop);
+      isDesktop.dispatchEvent(new Event('change'));
 
       expect(isElementVisible(document.querySelector(selectors.globalNav))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.search))).to.equal(true);
@@ -886,8 +890,12 @@ describe('global navigation', () => {
       expect(isElementVisible(document.querySelector(selectors.brandContainer))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(false);
       expect(document.querySelectorAll(selectors.navItem).length).to.equal(8);
+      expect([...document.querySelectorAll(selectors.headline)]
+        .every((elem) => elem.getAttribute('daa-ll') === null))
+        .to.be.true;
 
       await setViewport(viewports.mobile);
+      isDesktop.dispatchEvent(new Event('change'));
 
       expect(isElementVisible(document.querySelector(selectors.globalNav))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.search))).to.equal(false);
@@ -896,9 +904,12 @@ describe('global navigation', () => {
       expect(isElementVisible(document.querySelector(selectors.brandContainer))).to.equal(true);
       expect(isElementVisible(document.querySelector(selectors.mainNavToggle))).to.equal(true);
       expect(document.querySelectorAll(selectors.navItem).length).to.equal(8);
+      expect([...document.querySelectorAll(selectors.headline)]
+        .every((elem) => elem.getAttribute('daa-ll') !== null))
+        .to.be.true;
     });
 
-    it('should change the DOM order to ensure correct TAB behaviour for mobile|desktop', async () => {
+    it('should change the DOM order to ensure correct TAB behavior for mobile|desktop', async () => {
       await createFullGlobalNavigation();
 
       expect(document.querySelector(selectors.mainNav).nextElementSibling)


### PR DESCRIPTION
## Description
This adds `daa-ll` tracking attributes to menu accordion headers on mobile devices and misc footer links from the social and legal sections.

## Related Issue
Resolves: [MWPW-136612](https://jira.corp.adobe.com/browse/MWPW-136612)

## Testing instructions
Navigate to any 'after' URL on a mobile device. Inspect the accordion headers in either the header or footer sections and check that a `daa-ll` attribute exists. Inspect the social and legal section from the footer on both mobile and desktop devices and check that they have `daa-lh` and `daa-ll` attributes.

For testing purposes in the footer area, I've added some quick CSS that exposes the values to the UI so they're easier to follow, these styles can be used to make QA a bit easier (note that these will affect layout):

```
@media screen and (max-width: 899px) {
    .global-footer[daa-lh],
    .global-footer .feds-menu-content [daa-lh],
    .global-footer [daa-ll] {
        position: relative;
    }
    
    .global-footer[daa-lh]:before,
    .global-footer .feds-menu-content [daa-lh]:before,
    .global-footer .feds-menu-content [daa-ll]:before {
        position: absolute;
        display: flex;
    }
    
    .global-footer[daa-lh]:before,
    .global-footer [daa-lh]:before {
        top: 0;
        left: 10px;
        content: 'daa-lh: ' attr(daa-lh);
        color: darkorchid;
    }
    
    .global-footer [daa-ll]:before {
        top: 50%;
        transform: translateY(-50%);
        right: 45px;
        content: 'daa-ll: ' attr(daa-ll);
        color: blue;
        order: 1;
    }
}
```

## Screenshots (if appropriate):
I've applied the above CSS to a live CC page and these are the analytics values:
<img width="700" alt="CC Footer analytics" src="https://github.com/adobecom/milo/assets/11267498/34fa7f35-380a-4704-9692-e0ad6b7341db">

## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=footer-accordion-tracking--milo--overmyheadandbody

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=footer-accordion-tracking--milo--overmyheadandbody

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=footer-accordion-tracking--milo--overmyheadandbody

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://footer-accordion-tracking--milo--overmyheadandbody.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off