### PR TITLE
MWPW-136515 - Icon Block: fix image distortion in smaller viewports

### DIFF
--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -69,7 +69,7 @@
 }
 
 .icon-block .foreground .icon-area img {
-  height: var(--icon-size-xxl);
+  max-height: var(--icon-size-xxl);
   width: auto;
 }
 


### PR DESCRIPTION
Update icon block foreground to use max height instead of height on main image in smaller viewports (width of 1170px or less) to stop the image from distorting to fit a fixed height.

Resolves: [MWPW-136515](https://jira.corp.adobe.com/browse/MWPW-136515)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/icon-block-imagesize?martech=off
- After: https://sarchibeque-mwpw-136515--milo--adobecom.hlx.page/drafts/sarchibeque/icon-block-imagesize?martech=off
