### PR TITLE
Mock metadata block

### DIFF
--- a/libs/blocks/library-config/lists/blocks.js
+++ b/libs/blocks/library-config/lists/blocks.js
@@ -105,6 +105,11 @@ export function getHtml(container, path) {
   return container.elements.reduce((acc, element) => {
     decorateImages(element, path);
     handleLinks(element, path);
+
+    if (element.className === 'mock-metadata') {
+      element.className = 'metadata';
+    }
+
     const isBlock = element.nodeName === 'DIV' && element.className;
     const content = isBlock ? getTable(element) : element.outerHTML;
     return `${acc}${content}`;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Converts a block in the block library with the name `mock-metadata`  to `metadata` when pasted in to Word.

**Context:**
The block library currently doesn't allow the `metadata` block to be added - due to the huge list of properties and one offs per page.

**Use case:**
For blog.adobe.com every article pages needs to have a metadata block added to it with specific publishing properties. The blog team asked if this metadata block could be added to the block library for easy access and reduced training.

Resolves: No ticket

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mock-metadata--milo--adobecom.hlx.page/?martech=off



**Testing notes:**
Update your Milo sidekick to point to this branch.
<img width="573" alt="image" src="https://github.com/adobecom/milo/assets/2539954/ca95d6a5-73dd-4fbe-9fed-bc757016f055">

1. Navigate to a Word doc and pull up the block library. 
2. At the very bottom there is a block named "Test"
3. Expand the "Test" block.
4. Copy "Mock metadata" and paste it to a page (the block can have any custom name).
5. The block pastes into the page as "metadata" and can be used as a metadata block for the page.
6. The test block will be deleted once this PR is merged.

![image](https://github.com/adobecom/milo/assets/2539954/6e6fee06-d7f2-4fad-836d-3f635f9e671f)
![image](https://github.com/adobecom/milo/assets/2539954/2c82dddf-c2c8-40a4-9ea2-b4e1e5f4e138)

