### PR TITLE
MWPW-136143: Autodetect not working, Milo not sending correct lang to CaaS

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -261,32 +261,33 @@ const getFilterArray = async (state, country, lang, strs) => {
 
 export function getCountryAndLang({ autoCountryLang, country, language }) {
   const locales = getMetadata('caas-locales');
-  if(locales){
+  if (locales) {
+    /* eslint-disable-next-line object-shorthand */
     return {
       country: '',
       language: '',
-      locales: locales
-    }
+      locales: locales,
+    };
   }
   if (autoCountryLang) {
-    let locale = pageConfigHelper()?.locale?.ietf || 'en-us';
+    const locale = pageConfigHelper()?.locale?.ietf || 'en-us';
     const region = pageConfigHelper()?.locale?.region || '';
-    let country = locale.split('-')[1];
-    if(!country){
+    country = locale.split('-')[1];
+    if (!country) {
       country = region;
     }
-    const language = locale.split('-')[0];
+    language = locale.split('-')[0];
 
     return {
-      country: country,
-      language: language,
-      locales: ''
+      country,
+      language,
+      locales: '',
     };
   }
   return {
     country: country ? country.split('/').pop() : 'us',
     language: language ? language.split('/').pop() : 'en',
-    locales: ''
+    locales: '',
   };
 }
 

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -272,6 +272,7 @@ export function getCountryAndLang({ autoCountryLang, country, language }) {
   if (autoCountryLang) {
     const locale = pageConfigHelper()?.locale?.ietf || 'en-us';
     const region = pageConfigHelper()?.locale?.region || '';
+    /* eslint-disable-next-line prefer-const */
     let [currCountry, currLang] = locale.split('-');
     if (!currCountry) {
       currCountry = region;

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -348,7 +348,7 @@ const getFilterArray = async (state, country, lang, strs) => {
 export function getCountryAndLang({ autoCountryLang, country, language }) {
   if (autoCountryLang) {
     const prefix = pageConfigHelper()?.locale?.prefix?.replace('/', '') || '';
-    const locale = LOCALES[prefix] || 'en-us'
+    const locale = LOCALES[prefix] || 'en-us';
     /* eslint-disable-next-line prefer-const */
     let [currCountry, currLang] = locale.split('-');
 

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -336,7 +336,7 @@ const addMissingStateProps = (state) => {
 export const getConfig = async (originalState, strs = {}) => {
   const state = addMissingStateProps(originalState);
   const originSelection = Array.isArray(state.source) ? state.source.join(',') : state.source;
-  const { country, language, locales } = getCountryAndLang(state);
+  const { country, language } = getCountryAndLang(state);
   const featuredCards = state.featuredCards && state.featuredCards.reduce(getContentIdStr, '');
   const excludedCards = state.excludedCards && state.excludedCards.reduce(getContentIdStr, '');
   const hideCtaIds = state.hideCtaIds ? state.hideCtaIds.reduce(getContentIdStr, '') : '';
@@ -344,7 +344,6 @@ export const getConfig = async (originalState, strs = {}) => {
   const targetActivity = state.targetEnabled
   && state.targetActivity ? `/${encodeURIComponent(state.targetActivity)}.json` : '';
   const flatFile = targetActivity ? '&flatFile=false' : '';
-  const localesQueryParam = locales ? `&locales=${locales}` : '';
   const collectionTags = state.includeTags ? state.includeTags.join(',') : '';
   const excludeContentWithTags = state.excludeTags ? state.excludeTags.join(',') : '';
 
@@ -368,7 +367,7 @@ export const getConfig = async (originalState, strs = {}) => {
         ',',
       )}&collectionTags=${collectionTags}&excludeContentWithTags=${excludeContentWithTags}&language=${language}&country=${country}&complexQuery=${complexQuery}&excludeIds=${excludedCards}&currentEntityId=&featuredCards=${featuredCards}&environment=&draft=${
         state.draftDb
-      }&size=${state.collectionSize || state.totalCardsToShow}${localesQueryParam}${flatFile}`,
+      }&size=${state.collectionSize || state.totalCardsToShow}${flatFile}`,
       fallbackEndpoint: state.fallbackEndpoint,
       totalCardsToShow: state.totalCardsToShow,
       cardStyle: state.cardStyle,

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -350,7 +350,7 @@ export function getCountryAndLang({ autoCountryLang, country, language }) {
     const prefix = pageConfigHelper()?.locale?.prefix?.replace('/', '') || '';
     const locale = LOCALES[prefix]?.ietf || 'en-us';
     /* eslint-disable-next-line prefer-const */
-    let [currCountry, currLang] = locale.split('-');
+    let [currLang, currCountry] = locale.split('-');
 
     return {
       country: currCountry,

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -8,6 +8,92 @@ const pageConfig = pageConfigHelper();
 const pageLocales = Object.keys(pageConfig.locales || {});
 const requestHeaders = [];
 
+const LOCALES = {
+  // Americas
+  ar: { ietf: 'es-AR' },
+  br: { ietf: 'pt-BR' },
+  ca: { ietf: 'en-CA' },
+  ca_fr: { ietf: 'fr-CA' },
+  cl: { ietf: 'es-CL' },
+  co: { ietf: 'es-CO' },
+  la: { ietf: 'es-LA' },
+  mx: { ietf: 'es-MX' },
+  pe: { ietf: 'es-PE' },
+  '': { ietf: 'en-US' },
+  // EMEA
+  africa: { ietf: 'en-africa' },
+  be_fr: { ietf: 'fr-BE' },
+  be_en: { ietf: 'en-BE' },
+  be_nl: { ietf: 'nl-BE' },
+  cy_en: { ietf: 'en-CY' },
+  dk: { ietf: 'da-DK' },
+  de: { ietf: 'de-DE' },
+  ee: { ietf: 'et-EE' },
+  es: { ietf: 'es-ES' },
+  fr: { ietf: 'fr-FR' },
+  gr_en: { ietf: 'en-GR' },
+  ie: { ietf: 'en-IE' },
+  il_en: { ietf: 'en-IL' },
+  it: { ietf: 'it-IT' },
+  lv: { ietf: 'lv-LV' },
+  lt: { ietf: 'lt-LT' },
+  lu_de: { ietf: 'de-LU' },
+  lu_en: { ietf: 'en-LU' },
+  lu_fr: { ietf: 'fr-LU' },
+  hu: { ietf: 'hu-HU' },
+  mt: { ietf: 'en-MT' },
+  mena: { ietf: 'en-mena' },
+  mena_en: { ietf: 'en-mena' },
+  mena_ar: { ietf: 'ar-mena' },
+  mena_fr: { ietf: 'fr-mena' },
+  nl: { ietf: 'nl-NL' },
+  no: { ietf: 'no-NO' },
+  pl: { ietf: 'pl-PL' },
+  pt: { ietf: 'pt-PT' },
+  ro: { ietf: 'ro-RO' },
+  sa_en: { ietf: 'en-sa' },
+  ch_fr: { ietf: 'fr-CH' },
+  ch_de: { ietf: 'de-CH' },
+  ch_it: { ietf: 'it-CH' },
+  si: { ietf: 'sl-SI' },
+  sk: { ietf: 'sk-SK' },
+  fi: { ietf: 'fi-FI' },
+  se: { ietf: 'sv-SE' },
+  tr: { ietf: 'tr-TR' },
+  ae_en: { ietf: 'en-ae' },
+  uk: { ietf: 'en-GB' },
+  at: { ietf: 'de-AT' },
+  cz: { ietf: 'cs-CZ' },
+  bg: { ietf: 'bg-BG' },
+  ru: { ietf: 'ru-RU' },
+  ua: { ietf: 'uk-UA' },
+  il_he: { ietf: 'he-il' },
+  ae_ar: { ietf: 'ar-ae' },
+  sa_ar: { ietf: 'ar-sa' },
+  // Asia Pacific
+  au: { ietf: 'en-AU' },
+  hk_en: { ietf: 'en-HK' },
+  in: { ietf: 'en-in' },
+  id_id: { ietf: 'id-id' },
+  id_en: { ietf: 'en-id' },
+  my_ms: { ietf: 'ms-my' },
+  my_en: { ietf: 'en-my' },
+  nz: { ietf: 'en-nz' },
+  ph_en: { ietf: 'en-ph' },
+  ph_fil: { ietf: 'fil-PH' },
+  sg: { ietf: 'en-SG' },
+  th_en: { ietf: 'en-th' },
+  in_hi: { ietf: 'hi-in' },
+  th_th: { ietf: 'th-th' },
+  cn: { ietf: 'zh-CN' },
+  hk_zh: { ietf: 'zh-HK' },
+  tw: { ietf: 'zh-TW' },
+  jp: { ietf: 'ja-JP' },
+  kr: { ietf: 'ko-KR' },
+  vn_en: { ietf: 'en-vn' },
+  vn_vi: { ietf: 'vi-VN' },
+};
+
 export function getPageLocale(currentPath, locales = pageLocales) {
   const possibleLocale = currentPath.split('/')[1];
   if (locales.includes(possibleLocale)) {
@@ -261,13 +347,10 @@ const getFilterArray = async (state, country, lang, strs) => {
 
 export function getCountryAndLang({ autoCountryLang, country, language }) {
   if (autoCountryLang) {
-    const locale = pageConfigHelper()?.locale?.ietf || 'en-us';
-    const region = pageConfigHelper()?.locale?.region || '';
+    const prefix = pageConfigHelper()?.locale?.prefix?.replace('/', '') || '';
+    const locale = LOCALES[prefix] || 'en-us'
     /* eslint-disable-next-line prefer-const */
     let [currCountry, currLang] = locale.split('-');
-    if (!currCountry) {
-      currCountry = region;
-    }
 
     return {
       country: currCountry,

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -348,7 +348,7 @@ const getFilterArray = async (state, country, lang, strs) => {
 export function getCountryAndLang({ autoCountryLang, country, language }) {
   if (autoCountryLang) {
     const prefix = pageConfigHelper()?.locale?.prefix?.replace('/', '') || '';
-    const locale = LOCALES[prefix] || 'en-us';
+    const locale = LOCALES[prefix]?.ietf || 'en-us';
     /* eslint-disable-next-line prefer-const */
     let [currCountry, currLang] = locale.split('-');
 

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -266,21 +266,20 @@ export function getCountryAndLang({ autoCountryLang, country, language }) {
     return {
       country: '',
       language: '',
-      locales: locales,
+      locales,
     };
   }
   if (autoCountryLang) {
     const locale = pageConfigHelper()?.locale?.ietf || 'en-us';
     const region = pageConfigHelper()?.locale?.region || '';
-    country = locale.split('-')[1];
-    if (!country) {
-      country = region;
+    let [currCountry, currLang] = locale.split('-');
+    if (!currCountry) {
+      currCountry = region;
     }
-    language = locale.split('-')[0];
 
     return {
-      country,
-      language,
+      country: currCountry,
+      language: currLang,
       locales: '',
     };
   }

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { loadScript, loadStyle, getMetadata, getConfig as pageConfigHelper } from '../../utils/utils.js';
+import { loadScript, loadStyle, getConfig as pageConfigHelper } from '../../utils/utils.js';
 import { fetchWithTimeout } from '../utils/utils.js';
 
 const URL_ENCODED_COMMA = '%2C';
@@ -260,15 +260,6 @@ const getFilterArray = async (state, country, lang, strs) => {
 };
 
 export function getCountryAndLang({ autoCountryLang, country, language }) {
-  const locales = getMetadata('caas-locales');
-  if (locales) {
-    /* eslint-disable-next-line object-shorthand */
-    return {
-      country: '',
-      language: '',
-      locales,
-    };
-  }
   if (autoCountryLang) {
     const locale = pageConfigHelper()?.locale?.ietf || 'en-us';
     const region = pageConfigHelper()?.locale?.region || '';
@@ -281,13 +272,11 @@ export function getCountryAndLang({ autoCountryLang, country, language }) {
     return {
       country: currCountry,
       language: currLang,
-      locales: '',
     };
   }
   return {
     country: country ? country.split('/').pop() : 'us',
     language: language ? language.split('/').pop() : 'en',
-    locales: '',
   };
 }
 

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -577,8 +577,8 @@ describe('getCountryAndLang', () => {
       autoCountryLang: true,
     });
     expect(expected).to.deep.eq({
-      country: 'be',
-      language: 'fr-be',
+      country: 'BE',
+      language: 'fr',
     });
   });
 
@@ -592,8 +592,8 @@ describe('getCountryAndLang', () => {
       autoCountryLang: true,
     });
     expect(expected).to.deep.eq({
-      country: 'us',
-      language: 'en-us',
+      country: 'US',
+      language: 'en',
     });
   });
 });


### PR DESCRIPTION
When using `autoDetect` (where Milo dynamically tries to figure out the correct country/lang to send to CaaS) it turns out it fails for every locale for CaaS.

The idea for this was to prevent authors from having to manually author the `country/lang` for every collection.

But the way this currently works in production is either:

- Authors are manually setting the lang/country at the collection level using tags (This is occurring for all Tier 1 locales and is actually how https://business.adobe.com/customer-success-stories.html is live right now)

<img width="1019" alt="image" src="https://github.com/adobecom/milo/assets/10876964/b1e93743-7671-47df-9208-76edc35dbd1b">

- For ones that aren't manually set, autoDetect sends a nonsense lang. Luckily CaaS's backend is able to a generate some search results for this BUT it gives us undefined behavior like a mix of English and translated content

<img width="1641" alt="image" src="https://github.com/adobecom/milo/assets/10876964/686c392f-08ed-40d0-a28b-d7ec0588c74a">


The way this is fixed is I added a map in the caas block with all the milo regions as keys and their values being the actual correct locales that should be sent to CaaS. 

This map:
- Is in sync with the one milo uses AND also maps to every locale that is used when someone sends to CaaS
- Is only loaded when a CaaS block is loaded on the page. I was originally going to put it in `scripts.js` but realized that would load unnecessary data for pages that aren't using CaaS.

Resolves: https://jira.corp.adobe.com/browse/MWPW-136143

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/la/customer-success-stories
- After: https://main--bacom--adobecom.hlx.live/la/customer-success-stories?milolibs=MWPW-136143
