### PR TITLE
MWPW-136769 | Removing extra space in modal link classlist

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -551,7 +551,7 @@ export function decorateAutoBlock(a) {
         a.dataset.modalPath = url.pathname;
         a.dataset.modalHash = url.hash;
         a.href = url.hash;
-        a.className = `modal link-block ${[...a.classList].join(' ')}`;
+        a.className = `modal link-block ${[...a.classList].join(' ')}`.trim();
         return true;
       }
     }


### PR DESCRIPTION
If modal link does not have a previously existing classlist then classname is getting an extra space (a.classList is empty)
Trimming the final className of any extra spaces.

Resolves: [MWPW-136769](https://jira.corp.adobe.com/browse/MWPW-136769)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/nala/blocks/modal/modal-text-intro?martech=off
- After: https://modalclass--milo--aishwaryamathuria.hlx.live/drafts/nala/blocks/modal/modal-text-intro?martech=off
