### PR TITLE
MWPW-136532 Quote block flexible authoring

### DIFF
--- a/libs/blocks/quote/quote.js
+++ b/libs/blocks/quote/quote.js
@@ -22,8 +22,10 @@ export default function init(el) {
   el.classList.add(...blockVarints);
   const allRows = el.querySelectorAll(':scope > div');
   const lastRow = allRows[allRows.length - 1];
+  const lastDiv = lastRow.querySelector('div');
+  if (!lastDiv.firstElementChild && lastDiv.textContent) lastDiv.append(createTag('p', null, lastDiv.textContent));
   const imageRow = allRows.length > 1 ? allRows[0] : false;
-  const copyNodes = lastRow.querySelectorAll('h1, h2, h3, h4, h5, h6, p');
+  const copyNodes = lastDiv.querySelectorAll(':scope > h1, :scope > h2, :scope > h3, :scope > h4, :scope > h5, :scope > h6, :scope > p, :scope > em, :scope > strong, :scope > blockquote p');
   const blockquote = createTag('blockquote', {}, copyNodes[0]);
   const figcaption = createTag('figcaption', {}, copyNodes[1]);
   const cite = createTag('cite', {}, copyNodes[2]);

--- a/test/blocks/quote/mocks/body.html
+++ b/test/blocks/quote/mocks/body.html
@@ -1,4 +1,4 @@
-<div class="quote">
+<div class="quote paragraph-with-captions-and-image">
   <div>
     <div>
       <picture>
@@ -15,10 +15,78 @@
   </div>
 </div>
 
-<div class="quote">
+<div class="quote italics">
+  <div>
+    <div><em>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</em></div>
+  </div>
+</div>
+
+<div class="quote italics-with-captions">
   <div>
     <div>
-      <p>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</p>
+      <p><em>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</em></p>
+      <p><strong>Benny Lee</strong></p>
+      <p>Global Manager of Experiential Design, Coca-Cola Company</p>
+    </div>
+  </div>
+</div>
+
+<div class="quote bold">
+  <div>
+    <div><strong>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</strong></div>
+  </div>
+</div>
+
+<div class="quote bold-with-captions">
+  <div>
+    <div>
+      <p><strong>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</strong></p>
+      <p><strong>Benny Lee</strong></p>
+      <p>Global Manager of Experiential Design, Coca-Cola Company</p>
+  </div>
+  </div>
+</div>
+
+<div class="quote single-line">
+  <div>
+    <div>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</div>
+  </div>
+</div>
+
+<div class="quote heading">
+  <div>
+    <div>
+      <h2>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</h2>
+    </div>
+  </div>
+</div>
+
+<div class="quote heading-with-captions">
+  <div>
+    <div>
+      <h2>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</h2>
+      <p><strong>Benny Lee</strong></p>
+      <p>Global Manager of Experiential Design, Coca-Cola Company</p>
+    </div>
+  </div>
+</div>
+
+<div class="quote blockquote">
+  <div>
+    <div>
+      <blockquote>
+        <p>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</p>
+      </blockquote>
+    </div>
+  </div>
+</div>
+
+<div class="quote blockquote-with-captions">
+  <div>
+    <div>
+      <blockquote>
+        <p>“3D is a crucial part of how we explore the brand in a digital workflow. Adobe Substance 3D Stager takes the barrier of entry out of 3D design by enabling us to skip physical mockups and look at feedback faster. We’ve been able to bring digital design entirely in-house.”</p>
+      </blockquote>
       <p><strong>Benny Lee</strong></p>
       <p>Global Manager of Experiential Design, Coca-Cola Company</p>
     </div>

--- a/test/blocks/quote/quote.test.js
+++ b/test/blocks/quote/quote.test.js
@@ -5,14 +5,40 @@ document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 const { default: init } = await import('../../../libs/blocks/quote/quote.js');
 const quotes = document.querySelectorAll('.quote');
 
-/* eslint-disable-next-line no-restricted-syntax */
-for await (const quote of quotes) {
-  await init(quote);
-}
+describe('Quote', () => {
+  quotes.forEach((quote) => {
+    const authorType = quote.classList[1].replaceAll('-', ' ');
+    describe(`authored as ${authorType}`, () => {
+      before(() => {
+        init(quote);
+      });
 
-describe('Blockquote', () => {
-  it('Renders as a blockquote element', async () => {
-    const quote = quotes[0].querySelector('blockquote');
-    expect(quote).to.exist;
+      if (authorType.includes('image')) {
+        it('has image', () => {
+          const image = quote.querySelector('img').src;
+          expect(image).to.exist;
+        });
+      }
+
+      it('has blockquote text', () => {
+        const blockquote = quote.querySelector('blockquote').textContent;
+        expect(blockquote).to.exist;
+        expect(blockquote).to.not.be.empty;
+      });
+
+      if (authorType.includes('caption')) {
+        it('has figcaption', () => {
+          const figcaption = quote.querySelector('.figcaption').textContent;
+          expect(figcaption).to.exist;
+          expect(figcaption).to.not.be.empty;
+        });
+
+        it('has cite', () => {
+          const cite = quote.querySelector('cite').textContent;
+          expect(cite).to.exist;
+          expect(cite).to.not.be.empty;
+        });
+      }
+    });
   });
 });


### PR DESCRIPTION
* Allow for more flexible authoring for primary text in quote block
* Can be: paragraph, single line of text, bold, italic, heading, or blockquote

Resolves: [MWPW-136532](https://jira.corp.adobe.com/browse/MWPW-136532)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/quote
- After: https://methomas-quote--milo--adobecom.hlx.page/drafts/methomas/quote?martech=off

Regression: https://methomas-quote--milo--adobecom.hlx.page/docs/library/blocks/quote?martech=off
