### PR TITLE
safeguard milo modals from invalid query selectors

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -202,10 +202,10 @@ window.addEventListener('hashchange', (e) => {
     let dialog;
     try {
       dialog = document.querySelector(`.dialog-modal${url.hash}`);
+      if (dialog) closeModal(dialog);
     } catch (error) {
       /* do nothing */
     }
-    if (dialog) closeModal(dialog);
   } else {
     const details = findDetails(window.location.hash, null);
     if (details) getModal(details);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -198,10 +198,9 @@ export default function init(el) {
 // Click-based modal
 window.addEventListener('hashchange', (e) => {
   if (!window.location.hash) {
-    const url = new URL(e.oldURL);
-    let dialog;
     try {
-      dialog = document.querySelector(`.dialog-modal${url.hash}`);
+      const url = new URL(e.oldURL);
+      const dialog = document.querySelector(`.dialog-modal${url.hash}`);
       if (dialog) closeModal(dialog);
     } catch (error) {
       /* do nothing */

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -199,7 +199,12 @@ export default function init(el) {
 window.addEventListener('hashchange', (e) => {
   if (!window.location.hash) {
     const url = new URL(e.oldURL);
-    const dialog = document.querySelector(`.dialog-modal${url.hash}`);
+    let dialog;
+    try {
+      dialog = document.querySelector(`.dialog-modal${url.hash}`);
+    } catch (error) {
+      /* do nothing */
+    }
     if (dialog) closeModal(dialog);
   } else {
     const details = findDetails(window.location.hash, null);

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -171,9 +171,19 @@ describe('Modals', () => {
     expect(window.innerWidth).not.equal(dialogmodal.offsetWidth);
   });
 
-  it('does not error for a modal with a non-querySelector compliant hash', () => {
-    // Test passing, means there was no error thrown
+  it('does not error for a modal with a non-querySelector compliant hash', async () => {
     window.location.hash = '#milo=&';
+
+    const hashChangeTriggered = new Promise((resolve) => {
+      window.addEventListener('hashchange', function onHashChange() {
+        window.removeEventListener('hashchange', onHashChange);
+        resolve();
+      });
+    });
+
     window.location.hash = '';
+
+    // Test passing, means there was no error thrown
+    await hashChangeTriggered;
   });
 });

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -170,4 +170,10 @@ describe('Modals', () => {
     dialogmodal.classList.remove('commerce-frame');
     expect(window.innerWidth).not.equal(dialogmodal.offsetWidth);
   });
+
+  it('does not error for a modal with a non-querySelector compliant hash', () => {
+    // Test passing, means there was no error thrown
+    window.location.hash = '#milo=&';
+    window.location.hash = '';
+  });
 });


### PR DESCRIPTION
### Description
We have a bunch of issues with querySelectors which were fixed here https://github.com/adobecom/milo/pull/1348 or here https://github.com/adobecom/milo/pull/1287 

**Question:** Should we find a more generic solution for this querySelector syntax errors ?
**Issue:** We ran into querySelector syntax errors 3x in a brief time frame now
**Proposal:** A milo utility wrapper for `querySelector/querySelectorAll` that adds a try/catch and you can just use `import {safeQuerySelector} from './action.js'` then

Resolves: [MWPW-136672](https://jira.corp.adobe.com/browse/MWPW-136672)

## Test instructions
1. Open a milo page with a modal
2. Change the hash to by pasting  `window.location.hash = '';` in the console
3. No error should appear on the **after** test URLs anymore.
![Screenshot 2023-09-26 at 17 32 43](https://github.com/adobecom/milo/assets/39759830/5460ae16-eeb1-4d2c-b4b0-94d1c0961406)


## Test URLs
**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off#milo=&
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=ims--milo--adobecom#milo=&

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off#milo=&
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=ims--milo--adobecom#milo=&

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off#milo=&
- After: https://ims--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off#milo=&