### PR TITLE
MWPW-135672 no changes fix

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -98,7 +98,7 @@ class Footer {
       await task();
     }
 
-    this.footerEl.setAttribute('daa-lh', `gnav|${getExperienceName()}|footer`);
+    this.footerEl.setAttribute('daa-lh', `gnav|${getExperienceName()}|footer|${document.body.dataset.mep}`);
 
     this.footerEl.append(this.elements.footer);
   };

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -440,7 +440,7 @@ export async function getPersConfig(name, variantLabel, manifestData, manifestPa
     config.selectedVariantName = selectedVariantName;
     config.selectedVariant = config.variants[selectedVariantName];
   } else {
-    /* c8 ignore next */
+    /* c8 ignore next 2 */
     config.selectedVariantName = 'default';
     config.selectedVariant = 'default';
   }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -565,7 +565,11 @@ export async function applyPers(manifests) {
     expFragments: consolidateObjects(results, 'fragments'),
   });
   const trackingManifests = results.map((r) => r.experiment.manifest.split('/').pop().replace('.json', ''));
-  const trackingVariants = results.map((r) => r.experiment.selectedVariantName);
+  const trackingVariants = results.map((r) => {
+    const { selectedVariantName } = r.experiment;
+    if (selectedVariantName === 'no changes') return 'default';
+    return selectedVariantName;
+  });
   document.body.dataset.mep = `${trackingVariants.join('--')}|${trackingManifests.join('--')}`;
 
   decoratePreviewCheck(config, experiments);

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -259,7 +259,7 @@ export function parseConfig(data) {
 
 /* c8 ignore start */
 function parsePlaceholders(placeholders, config, selectedVariantName = '') {
-  if (!placeholders?.length || selectedVariantName === 'no changes') return config;
+  if (!placeholders?.length || selectedVariantName === 'default') return config;
   const valueNames = [
     'value',
     selectedVariantName.toLowerCase(),
@@ -441,8 +441,8 @@ export async function getPersConfig(name, variantLabel, manifestData, manifestPa
     config.selectedVariant = config.variants[selectedVariantName];
   } else {
     /* c8 ignore next */
-    config.selectedVariantName = 'no changes';
-    config.selectedVariant = 'no changes';
+    config.selectedVariantName = 'default';
+    config.selectedVariant = 'default';
   }
 
   if (placeholders) {
@@ -480,7 +480,7 @@ export async function runPersonalization(info, config) {
 
   const { selectedVariant } = experiment;
   if (!selectedVariant) return {};
-  if (selectedVariant === 'no changes') {
+  if (selectedVariant === 'default') {
     return { experiment };
   }
 
@@ -565,11 +565,7 @@ export async function applyPers(manifests) {
     expFragments: consolidateObjects(results, 'fragments'),
   });
   const trackingManifests = results.map((r) => r.experiment.manifest.split('/').pop().replace('.json', ''));
-  const trackingVariants = results.map((r) => {
-    const { selectedVariantName } = r.experiment;
-    if (selectedVariantName === 'no changes') return 'default';
-    return selectedVariantName;
-  });
+  const trackingVariants = results.map((r) => r.experiment.selectedVariantName);
   document.body.dataset.mep = `${trackingVariants.join('--')}|${trackingManifests.join('--')}`;
 
   decoratePreviewCheck(config, experiments);

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -153,11 +153,11 @@ function createPreviewPill(manifests) {
     if (!manifest.variantNames.includes(manifest.selectedVariantName)) {
       checked.attribute = 'checked="checked"';
       checked.class = 'class="mep-manifest-selected-variant"';
-      manifestParameter.push(`${manifest.manifest}--NoChanges`);
+      manifestParameter.push(`${manifest.manifest}--default`);
     }
     radio += `<div>
-      <input type="radio" name="${manifest.manifest}" value="no changes" id="${manifest.manifest}--no changes" ${checked.attribute}>
-      <label for="${manifest.manifest}--no changes" ${checked.class}>No changes (control)</label>
+      <input type="radio" name="${manifest.manifest}" value="default" id="${manifest.manifest}--default" ${checked.attribute}>
+      <label for="${manifest.manifest}--default" ${checked.class}>Default (control)</label>
     </div>`;
     const targetTitle = manifest.name ? `${manifest.name}<br><i>${manifest.manifest}</i>` : manifest.manifest;
     manifestList += `<div class="mep-manifest-info">

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1027,7 +1027,7 @@ export async function loadArea(area = document) {
     areaBlocks.push(...sectionBlocks);
 
     areaBlocks.forEach((block) => {
-      if (!block.className('metadata')) block.dataset.block = '';
+      if (!block.className.includes('metadata')) block.dataset.block = '';
     });
   }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1027,7 +1027,7 @@ export async function loadArea(area = document) {
     areaBlocks.push(...sectionBlocks);
 
     areaBlocks.forEach((block) => {
-      block.dataset.block = '';
+      if (!block.className('metadata')) block.dataset.block = '';
     });
   }
 


### PR DESCRIPTION
The value for no manifest is "default|default" but the value for default when you have a manifest is "no changes|manifest name".  This changes "no changes" to "default" to be consistent.

For the before and after links, you can look at the data-mep attribute on `body` or the `daa-lh` values on `header` and all blocks to see the difference.

Resolves: [MWPW-135672](https://jira.corp.adobe.com/browse/MWPW-135672)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/vgoodric/pers-demo?martech=off
- After: https://mwpw-135672-no-changes-fix--milo--adobecom.hlx.page/drafts/vgoodric/pers-demo?martech=off
