### PR TITLE
UAR - quiz-card-list update

### DIFF
--- a/libs/blocks/quiz-results/quiz-results.css
+++ b/libs/blocks/quiz-results/quiz-results.css
@@ -16,14 +16,13 @@
 }
 
 .quiz-results .quiz-card-list {
-  align-items: center;
-  display: flex;
-  gap: var(--spacing-s);
+  display: grid;
   justify-content: center;
-  margin: 0 auto;
-  padding: var(--spacing-s) 0;
-  position: relative;
-  flex-wrap: wrap;
+  width: 100%;
+  max-width: 100%;
+  grid-template-columns: repeat(auto-fit,minmax(300px,max-content));
+  gap: 32px;
+  padding-bottom: 32px;
 }
 
 @media screen and (min-width: 600px) {


### PR DESCRIPTION
For quiz-results we use consonants card, they have already grid set.
In our case we need an extra class to correct the alignment as each card will be hold by a fragment, causing that the grid consonant do not get set, for our nested quiz-card-list

https://jira.corp.adobe.com/browse/MWPW-135730



**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.page/drafts/delta/app-recommender-test/?martech=off
- After: https://quiz-card-list--milo--elaineskpt.hlx.page/drafts/delta/app-recommender-test/?martech=off

To test in your own folder please update the card-list nested-fragment
Instead style center, three up
![Screenshot 2023-09-25 at 18 22 57](https://github.com/adobecom/milo/assets/62952234/4c7e8f0b-5988-4753-8c23-1ba0844f0c99)
to style quiz-card-list

![Screenshot 2023-09-25 at 18 39 12](https://github.com/adobecom/milo/assets/62952234/2320e359-9999-4959-b7a4-092175077d68)

