### PR TITLE
MWPW-137162: [LocUI] Temporarily remove exclude path for localization

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -30,7 +30,6 @@
       "url": "https://locui--milo--adobecom.hlx.page/tools/loc",
       "passReferrer": true,
       "passConfig": true,
-      "excludePaths": [ "/**" ],
       "includePaths": [ "**/:x**" ]
     },
     {


### PR DESCRIPTION
Due to recent update in helix-sidekick extension, the "excludePaths" is functionality is broken. Temporarily removing the exclude-path configuration for Localization's sidekick config to unblock QA for testing localization.
Resolves: [MWPW-137162](https://jira.corp.adobe.com/browse/MWPW-137162)

With this change, the "Localize Project" option will come for all documents not just excel.