### PR TITLE
Add support for sections

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -185,11 +185,8 @@ function handleCommands(commands, manifestId, rootEl = document) {
   commands.forEach((cmd) => {
     if (VALID_COMMANDS.includes(cmd.action)) {
       try {
-        let selectorEl = rootEl.querySelector(cmd.selector);
+        const selectorEl = rootEl.querySelector(cmd.selector);
         if (!selectorEl) return;
-        if (selectorEl.classList[0] === 'section-metadata') {
-          selectorEl = selectorEl.parentElement || selectorEl;
-        }
         COMMANDS[cmd.action](selectorEl, cmd.target, manifestId);
       } catch (e) {
         console.log('Invalid selector: ', cmd.selector);

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -49,19 +49,23 @@ const DATA_TYPE = {
   TEXT: 'text',
 };
 
-const createFrag = (url, manifestId) => {
+const createFrag = (el, url, manifestId) => {
   const a = createTag('a', { href: url }, url);
   if (manifestId) a.dataset.manifestId = manifestId;
-  const p = createTag('p', undefined, a);
+  let frag = createTag('p', undefined, a);
+  const isSection = el.parentElement.nodeName === 'MAIN';
+  if (isSection) {
+    frag = createTag('div', undefined, frag);
+  }
   loadLink(`${url}.plain.html`, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
-  return p;
+  return frag;
 };
 
 const COMMANDS = {
   insertcontentafter: (el, target, manifestId) => el
-    .insertAdjacentElement('afterend', createFrag(target, manifestId)),
+    .insertAdjacentElement('afterend', createFrag(el, target, manifestId)),
   insertcontentbefore: (el, target, manifestId) => el
-    .insertAdjacentElement('beforebegin', createFrag(target, manifestId)),
+    .insertAdjacentElement('beforebegin', createFrag(el, target, manifestId)),
   removecontent: (el, target, manifestId) => {
     if (target === 'false') return;
     if (manifestId) {
@@ -72,7 +76,7 @@ const COMMANDS = {
   },
   replacecontent: (el, target, manifestId) => {
     if (el.classList.contains(CLASS_EL_REPLACE)) return;
-    el.insertAdjacentElement('beforebegin', createFrag(target, manifestId));
+    el.insertAdjacentElement('beforebegin', createFrag(el, target, manifestId));
     el.classList.add(CLASS_EL_DELETE, CLASS_EL_REPLACE);
   },
 };


### PR DESCRIPTION
Personalization fragments that are inserted are normally wrapped in a p tag, but sections are expected to be wrapped in a div.

Resolves: [MWPW-137130](https://jira.corp.adobe.com/browse/MWPW-137130)

**Test URLs:**
- Before:https://main--milo--adobecom.hlx.page/drafts/cpeyer/mwpw-137130/replace-section?martech=off
- After: https://pers-replace-section--milo--adobecom.hlx.page/drafts/cpeyer/mwpw-137130/replace-section?martech=off
