### PR TITLE
MWPW-136429 Transform Image alt links

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -445,7 +445,7 @@ export async function loadBlock(block) {
   return block;
 }
 
-const convertHlxUrl = (url) => (url.hostname.includes('.hlx.') ? url.pathname : url);
+const convertHlxUrl = (url) => (url?.hostname?.includes('.hlx.') ? url.pathname : url);
 
 export function decorateSVG(a) {
   const { textContent, href } = a;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -445,7 +445,7 @@ export async function loadBlock(block) {
   return block;
 }
 
-const convertHlxLink = (url) => (url.hostname.includes('.hlx.') ? url.pathname : url);
+const convertHlxUrl = (url) => (url.hostname.includes('.hlx.') ? url.pathname : url);
 
 export function decorateSVG(a) {
   const { textContent, href } = a;
@@ -461,7 +461,7 @@ export function decorateSVG(a) {
       ? new URL(`${window.location.origin}${a.href}`)
       : new URL(a.href);
 
-    const src = convertHlxLink(textUrl);
+    const src = convertHlxUrl(textUrl);
 
     const img = createTag('img', { loading: 'lazy', src });
     if (altText) img.alt = altText;
@@ -486,7 +486,7 @@ export function decorateImageLinks(el) {
   [...images].forEach((img) => {
     const [source, alt, icon] = img.alt.split('|');
     try {
-      const url = convertHlxLink(new URL(source.trim()));
+      const url = convertHlxUrl(new URL(source.trim()));
       if (alt?.trim().length) img.alt = alt.trim();
       const pic = img.closest('picture');
       const picParent = pic.parentElement;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -445,6 +445,8 @@ export async function loadBlock(block) {
   return block;
 }
 
+const convertHlxLink = (url) => (url.hostname.includes('.hlx.') ? url.pathname : url);
+
 export function decorateSVG(a) {
   const { textContent, href } = a;
   if (!(textContent.includes('.svg') || href.includes('.svg'))) return a;
@@ -459,7 +461,7 @@ export function decorateSVG(a) {
       ? new URL(`${window.location.origin}${a.href}`)
       : new URL(a.href);
 
-    const src = textUrl.hostname.includes('.hlx.') ? textUrl.pathname : textUrl;
+    const src = convertHlxLink(textUrl);
 
     const img = createTag('img', { loading: 'lazy', src });
     if (altText) img.alt = altText;
@@ -484,7 +486,7 @@ export function decorateImageLinks(el) {
   [...images].forEach((img) => {
     const [source, alt, icon] = img.alt.split('|');
     try {
-      const url = new URL(source.trim());
+      const url = convertHlxLink(new URL(source.trim()));
       if (alt?.trim().length) img.alt = alt.trim();
       const pic = img.closest('picture');
       const picParent = pic.parentElement;


### PR DESCRIPTION
Image alt links pointing to .hlx.* were not getting converted to relative links in prod.

Resolves: [MWPW-136429](https://jira.corp.adobe.com/browse/MWPW-136429)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/mwpw-136429-image-links/image-link-issue-copy?martech=off
- After: https://136429-altlinks--milo--adobecom.hlx.page/drafts/cpeyer/mwpw-136429-image-links/image-link-issue-copy?martech=off
