### PR TITLE
MWPW-137171: Temp Fix for Sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -29,7 +29,6 @@
       "environments": [ "edit" ],
       "url": "/tools/loc/index.html?project=milo--adobecom",
       "passReferrer": true,
-      "excludePaths": [ "/**" ],
       "includePaths": [ "**/:x**" ]
     },
     {
@@ -39,7 +38,6 @@
       "environments": [ "edit" ],
       "url": "/tools/floodgate/index.html?project=milo--adobecom",
       "passReferrer": true,
-      "excludePaths": [ "/**" ],
       "includePaths": [ "**/:x**" ]
     },
     {


### PR DESCRIPTION
Helix Sidekick v6.30.3 seems to remove the Localize and Floodgate option from the Sidekick. Removing the `excludePaths` config seems to be fixing it. Temporarily removing that option to unblock. A discussion with Franklin team has been started to figure out the root cause.

Resolves: [MWPW-137171](https://jira.corp.adobe.com/browse/MWPW-137171)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/
- After: https://fix-sidekick-bug--milo--adobecom.hlx.page/
