### PR TITLE
Revert "MWPW-136429 Transform Image alt links"

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -445,8 +445,6 @@ export async function loadBlock(block) {
   return block;
 }
 
-const convertHlxUrl = (url) => (url?.hostname?.includes('.hlx.') ? url.pathname : url);
-
 export function decorateSVG(a) {
   const { textContent, href } = a;
   if (!(textContent.includes('.svg') || href.includes('.svg'))) return a;
@@ -461,7 +459,7 @@ export function decorateSVG(a) {
       ? new URL(`${window.location.origin}${a.href}`)
       : new URL(a.href);
 
-    const src = convertHlxUrl(textUrl);
+    const src = textUrl.hostname.includes('.hlx.') ? textUrl.pathname : textUrl;
 
     const img = createTag('img', { loading: 'lazy', src });
     if (altText) img.alt = altText;
@@ -486,7 +484,7 @@ export function decorateImageLinks(el) {
   [...images].forEach((img) => {
     const [source, alt, icon] = img.alt.split('|');
     try {
-      const url = convertHlxUrl(new URL(source.trim()));
+      const url = new URL(source.trim());
       if (alt?.trim().length) img.alt = alt.trim();
       const pic = img.closest('picture');
       const picParent = pic.parentElement;


### PR DESCRIPTION
Reverts adobecom/milo#1367

Following issues have been reported hence the revert PR
1. Alt Text for image that links to video is not working anymore. The static images are not showing: https://main--bacom--adobecom.hlx.page/de/resources/webinars/automotive-dialogues/creativity-in-motion
2. video modal link in the image but video thumbnail is showing up instead of the image in the document: https://main--bacom--adobecom.hlx.page/jp/resources/webinars/best-of-adobe-summit-2023-top#
3. #_dnt not working