### PR TITLE
MWPW-120357 - Make alt text links relative

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -485,10 +485,11 @@ export function decorateImageLinks(el) {
     const [source, alt, icon] = img.alt.split('|');
     try {
       const url = new URL(source.trim());
+      const href = url.hostname.includes('.hlx.') ? url.pathname : url.href;
       if (alt?.trim().length) img.alt = alt.trim();
       const pic = img.closest('picture');
       const picParent = pic.parentElement;
-      const aTag = createTag('a', { href: url, class: 'image-link' });
+      const aTag = createTag('a', { href, class: 'image-link' });
       picParent.insertBefore(aTag, pic);
       if (icon) {
         import('./image-video-link.js').then((mod) => mod.default(picParent, aTag, icon));


### PR DESCRIPTION
* Fix absolute links found in alt text

Resolves: [MWPW-120357](https://jira.corp.adobe.com/browse/MWPW-120357)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cmillar/about-adobe?martech=off
- After: https://relative-alt-links--milo--adobecom.hlx.page/drafts/cmillar/about-adobe?martech=off
