### PR TITLE
[MWPW-136545] Ability to centralize Gnav content

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -31,17 +31,10 @@ const CONFIG = {
 };
 
 class Footer {
-  /**
-   * Footer constructor
-   * @param {Object} config Configuration object for Footer class
-   * @param {Element} config.contentUrl The raw content to decorate to populate the Footer
-   * @param {Element} config.footerEl The placeholder element where the Footer should be rendered
-   * @param {Boolean} [config.useFederatedContent] Whether the Footer loads from a central location
-   */
-  constructor(config) {
-    Object.keys(config).forEach((key) => {
-      this[key] = config[key];
-    });
+  constructor({ contentUrl, block, useFederatedContent } = {}) {
+    this.contentUrl = contentUrl;
+    this.block = block;
+    this.useFederatedContent = useFederatedContent;
 
     this.elements = {};
 
@@ -66,7 +59,7 @@ class Footer {
       }
     }, intersectionOptions);
 
-    observer.observe(this.footerEl);
+    observer.observe(this.block);
 
     // Set timeout after which we load the footer automatically
     decorationTimeout = setTimeout(() => {
@@ -112,9 +105,9 @@ class Footer {
       await task();
     }
 
-    this.footerEl.setAttribute('daa-lh', `gnav|${getExperienceName()}|footer|${document.body.dataset.mep}`);
+    this.block.setAttribute('daa-lh', `gnav|${getExperienceName()}|footer|${document.body.dataset.mep}`);
 
-    this.footerEl.append(this.elements.footer);
+    this.block.append(this.elements.footer);
   };
 
   fetchContent = async () => {
@@ -168,7 +161,7 @@ class Footer {
     const file = await fetch(`${base}/blocks/global-footer/icons.svg`);
     const content = await file.text();
     const elem = toFragment`<div class="feds-footer-icons">${content}</div>`;
-    this.footerEl.append(elem);
+    this.block.append(elem);
   };
 
   decorateProducts = async () => {
@@ -369,7 +362,7 @@ export default function init(block) {
       ? new URL(`${getFedsContentRoot()}${footerPath.pathname}`)
       : footerPath;
     const footer = new Footer({
-      footerEl: block,
+      block,
       contentUrl: footerUrl.href,
       useFederatedContent,
     });

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -31,21 +31,42 @@ export function toFragment(htmlStrings, ...values) {
   return fragment;
 }
 
-export const getFedsPlaceholderConfig = () => {
-  const { locale } = getConfig();
-  let libOrigin = 'https://milo.adobe.com';
+let fedsContentRoot;
+export const getFedsContentRoot = () => {
+  if (fedsContentRoot) return fedsContentRoot;
+
+  fedsContentRoot = 'https://milo.adobe.com';
   const { origin } = window.location;
 
   if (origin.includes('localhost') || origin.includes('.hlx.')) {
-    libOrigin = `https://main--milo--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
+    fedsContentRoot = `https://main--milo--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
   }
 
-  return {
+  return fedsContentRoot;
+};
+
+export const federatePictureSources = (section) => {
+  section?.querySelectorAll('[src], [srcset]').forEach((source) => {
+    const type = source.hasAttribute('src') ? 'src' : 'srcset';
+    source.setAttribute(type, source.getAttribute(type).replace(/^\.?\//, `${getFedsContentRoot()}/`));
+  });
+};
+
+let fedsPlaceholderConfig;
+export const getFedsPlaceholderConfig = ({ useCache = true } = {}) => {
+  if (useCache && fedsPlaceholderConfig) return fedsPlaceholderConfig;
+
+  const { locale } = getConfig();
+  const libOrigin = getFedsContentRoot();
+
+  fedsPlaceholderConfig = {
     locale: {
       ...locale,
       contentRoot: `${libOrigin}${locale.prefix}`,
     },
   };
+
+  return fedsPlaceholderConfig;
 };
 
 export function getAnalyticsValue(str, index) {

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -48,7 +48,9 @@ export const getFedsContentRoot = () => {
 export const federatePictureSources = (section) => {
   section?.querySelectorAll('[src], [srcset]').forEach((source) => {
     const type = source.hasAttribute('src') ? 'src' : 'srcset';
-    source.setAttribute(type, source.getAttribute(type).replace(/^\.?\//, `${getFedsContentRoot()}/`));
+    const value = source.getAttribute(type);
+    if (!value) return;
+    source.setAttribute(type, value.replace(/^\.?\//, `${getFedsContentRoot()}/`));
   });
 };
 

--- a/test/blocks/global-navigation/mocks/global-navigation.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation.plain.js
@@ -25,6 +25,17 @@ export default `<div>
   </div>
 </div>
 <div>
+  <div class="large-menu section feds">
+    <div>
+      <div>
+        <h2 id="feds-menu">
+          <a href="/feds-menu">FEDS Menu</a>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
   <h2 id="w-promo"><a href="https://business.adobe.com/">w/ Promo</a></h2>
   <ul>
     <li>
@@ -117,23 +128,23 @@ export default `<div>
         <picture>
           <source
             type="image/webp"
-            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+            srcset="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
             media="(min-width: 600px)"
           />
           <source
             type="image/webp"
-            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+            srcset="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
           />
           <source
             type="image/png"
-            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            srcset="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
             media="(min-width: 600px)"
           />
           <img
             loading="lazy"
             alt=""
             type="image/png"
-            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            src="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
             width="52"
             height="51"
           />

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -4,7 +4,6 @@ import sinon, { stub } from 'sinon';
 import { setViewport } from '@web/test-runner-commands';
 import initGnav from '../../../libs/blocks/global-navigation/global-navigation.js';
 import {
-  getLocale,
   setConfig,
   loadStyle,
 } from '../../../libs/utils/utils.js';
@@ -81,7 +80,6 @@ const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 export const config = {
   imsClientId: 'milo',
   codeRoot: '/libs',
-  contentRoot: `${window.location.origin}${getLocale(locales).prefix}`,
   locales,
 };
 
@@ -122,13 +120,15 @@ export const createFullGlobalNavigation = async ({
     // Intercept setTimeout and call the function immediately
     toFake: ['setTimeout'],
   });
-  setConfig(customConfig);
+  setConfig({ ...config, ...customConfig });
   await setViewport(viewports[viewport]);
   window.lana = { log: stub() };
   window.fetch = stub().callsFake((url) => {
     if (url.includes('profile')) { return mockRes({ payload: defaultProfile }); }
     if (url.includes('placeholders')) { return mockRes({ payload: placeholders || defaultPlaceholders }); }
     if (url.endsWith('large-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
+    if (url.includes('main--milo--adobecom.hlx.page')
+      && url.endsWith('feds-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
     if (url.includes('gnav')) { return mockRes({ payload: globalNavigation || globalNavigationMock }); }
     return null;
   });

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -62,7 +62,7 @@ describe('global navigation utilities', () => {
       federatePictureSources(template);
       document.querySelectorAll('source, img').forEach((source) => {
         const attr = source.hasAttribute('src') ? 'src' : 'srcset';
-        expect(source.getAttribute(attr) === `https://main--milo--adobecom.hlx.page/${imgPath}`);
+        expect(source.getAttribute(attr)).to.equal(`https://main--milo--adobecom.hlx.page/${imgPath}`);
       });
     });
   });


### PR DESCRIPTION
## Description
This allows for the header, footer and/or section menu(s) of the Global Navigation to be fetched from a centralised location. Content would be stored under the _Milo_ folder in the _adobecom_ Sharepoint, in _<locale>/libs/feds/gnav_ and _<locale>/libs/feds/footer_ (this isn't a hard technical requirement, it's what authors agreed on, other conventions are accepted).

Nothing changes for pages that are live today, as the feature would be opt-in and would require author intervention.

This is required since currently each consumer hosts their own section menu (cloud dropdown) and footer. This means content is not synced between consumers and making any updates (such as limited-time promos) requires a lot of authoring coordination. Also, the homepage needs easy access to all the cloud menus from the different consumers, having this centralised makes the most sense.

Documentation will be added shortly, but in a nutshell, here's how to centralise content:
- section menus: currently, creating such a menu is done by using a _Large Menu (Section)_ block. Adding an additional _Feds_ [1] modifier (_Large Menu (Section, Feds)_) and updating the path to use the proper folder structure would fetch the dropdown content from the centralised location;
- header/footer: a new metadata field can be used, _feds_. Its value can be comma-separated, so it can be either `header`, `footer` or `header, footer`. This would fetch the whole Global Navigation and/or Footer content from the centralised location. A discussion has been created to get some ideas on naming convention [2]

A few other things worth mentioning:
* a few TODO items in the footer have been addressed;
* a new `getFedsContentRoot` utility has been created to have easy access to the centralised content location;
* since most images have relative paths, a `federatePictureSources` has been defined to prepend the federated host where necessary;
* the `getFedsPlaceholderConfig` method has been updated to use caching by default, as this should not change during a page visit;
* JSDoc-like descriptions have been added for the Global Navigation and Footer classes to keep track of their arguments.

[1] The _Feds_ keyword was chosen to mimic the centralised 404 approach implemented in https://github.com/adobecom/milo/pull/845
[2] https://github.com/orgs/adobecom/discussions/1269

## Related Issue
Resolves: [MWPW-136545](https://jira.corp.adobe.com/browse/MWPW-136545)

## Testing instructions
This is a bit tricky, as it needs to be tested on individual consumers. Test documents can be created in the consumer folders and then use the _Feds_ approach for header/footer/section menus, then checking that they have been fetched from the _Milo_ folder.

Special attention should be given to images from the header/footer/dropdown menus, as their sources are always relative in Franklin. The logic should swap the source for the centralised content one.

## Screenshots
**Declaring that the footer should be fetched from a centralised location**
<img width="655" alt="Declaring that the footer should be fetched from a centralised location" src="https://github.com/adobecom/milo/assets/11267498/bcd59a68-da0e-41ed-b3e5-00744e8b8994">

**Using consumer section menus as well as centralised ones**
<img width="655" alt="Using consumer section menus as well as centralised ones" src="https://github.com/adobecom/milo/assets/11267498/d3deccc4-7d5e-4a13-af5f-da6e2b6377d1">

## Test URLs
**Acrobat (cloud menu and footer use federated content):**
- Before (section menu and footer will not load, as their path is using the centralised structure): https://main--dc--adobecom.hlx.page/ch_de/drafts/ramuntea/fetch-section-menu-from-milo?martech=off
- After: https://main--dc--adobecom.hlx.page/ch_de/drafts/ramuntea/fetch-section-menu-from-milo?milolibs=centralize-cloud-navs--milo--overmyheadandbody&martech=off

**BACOM (cloud menu and footer use federated content):**
- Before (section menu and footer will not load, as their path is using the centralised structure): https://main--bacom--adobecom.hlx.page/ch_de/drafts/ramuntea/fetch-section-menu-from-milo?maretch=off
- After: https://main--bacom--adobecom.hlx.page/ch_de/drafts/ramuntea/fetch-section-menu-from-milo?milolibs=centralize-cloud-navs--milo--overmyheadandbody&martech=off

**CC (whole Gnav uses federated content):**
- Before (gnav will not load, as its path is using the centralised structure): https://main--cc--adobecom.hlx.page/drafts/ramuntea/use-federated-gnav?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/ramuntea/use-federated-gnav?milolibs=centralize-cloud-navs--milo--overmyheadandbody&martech=off

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ramuntea/centralised-gnav?martech=off
- After: https://centralize-cloud-navs--milo--overmyheadandbody.hlx.page/drafts/ramuntea/centralised-gnav?martech=off

Centralisation doesn't make much sense within the Milo Sharepoint, but the test links are used for PSI and to check that nothing breaks by using federated content.