### PR TITLE
MWPW-136165 - Background reset for quiz footer

### DIFF
--- a/libs/blocks/quiz/quiz.css
+++ b/libs/blocks/quiz/quiz.css
@@ -267,6 +267,11 @@
   margin: 0 0 24px;
 }
 
+.quiz-footer .section,
+.quiz-footer .section.dark {
+  background: inherit;
+}
+
 @media screen and (min-width: 768px) {
   .quiz-foreground {
     margin: var(--spacing-xxxl) 0;


### PR DESCRIPTION
* Allow section metadata dark with static links style without background

Resolves: [MWPW-136165](https://jira.corp.adobe.com/browse/MWPW-136165)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/xiasun/quiz-2/?martech=off
- After: https://quiz-footer-link-color--milo--colloyd.hlx.page/drafts/xiasun/quiz-2/?martech=off

With this change, an author can force white text on links by adding section metadata to their footer fragment and adding both 'dark' and 'static links' to style. Unfortunately, using 'dark' also changes the background, where it will need to be transparent for quiz. This will reset the background to ensure that it is displayed properly within the quiz.

- example fragment: https://milo.adobe.com/fragments/xiasun/sample-uar-fragments/footer/footer2