### PR TITLE
Make alt text links relative

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -485,8 +485,7 @@ export function decorateImageLinks(el) {
     const [source, alt, icon] = img.alt.split('|');
     try {
       const url = new URL(source.trim());
-      const hash = url.hash || '';
-      const href = url.hostname.includes('.hlx.') ? `${url.pathname}${hash}` : url.href;
+      const href = url.hostname.includes('.hlx.') ? `${url.pathname}${url.hash}` : url.href;
       if (alt?.trim().length) img.alt = alt.trim();
       const pic = img.closest('picture');
       const picParent = pic.parentElement;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -485,10 +485,12 @@ export function decorateImageLinks(el) {
     const [source, alt, icon] = img.alt.split('|');
     try {
       const url = new URL(source.trim());
+      const hash = url.hash || '';
+      const href = url.hostname.includes('.hlx.') ? `${url.pathname}${hash}` : url.href;
       if (alt?.trim().length) img.alt = alt.trim();
       const pic = img.closest('picture');
       const picParent = pic.parentElement;
-      const aTag = createTag('a', { href: url, class: 'image-link' });
+      const aTag = createTag('a', { href, class: 'image-link' });
       picParent.insertBefore(aTag, pic);
       if (icon) {
         import('./image-video-link.js').then((mod) => mod.default(picParent, aTag, icon));


### PR DESCRIPTION
Image alt links pointing to .hlx.* were not getting converted to relative links in prod.

Resolves: [MWPW-136429](https://jira.corp.adobe.com/browse/MWPW-136429)

<!-- Before submitting, please review all open PRs. -->

* Add your
* Specific
* Features or fixes

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs Milo**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/test/image-links?martech=off
- After: https://alt-image-links--milo--adobecom.hlx.page/drafts/rclayton/test/image-links?martech=off

**Test URLs BACOM:**
- Samples of image link, launching modal, background videos set to autoplay
  - Before: https://main--bacom--adobecom.hlx.page/drafts/rclayton/test/image-links?martech=off
  - After: https://main--bacom--adobecom.hlx.page/drafts/rclayton/test/image-links?milolibs=alt-image-links&martech=off
- The first link in the marquee contains `#_dnt` and image with play button launches modal.
  - Before: https://main--bacom--adobecom.hlx.page/africa/products/magento/store-fulfillment?martech=off
  - After: https://main--bacom--adobecom.hlx.page/africa/products/magento/store-fulfillment?milolibs=alt-image-links&martech=off
 - Play button over "Best of Adobe Summit" should launch modal with video.
    - Before: https://main--bacom--adobecom.hlx.page/jp/resources/webinars/best-of-adobe-summit-2023-top?martech=off
    - After: https://main--bacom--adobecom.hlx.page/jp/resources/webinars/best-of-adobe-summit-2023-top?milolibs=alt-image-links&martech=off
- The images in the body of the page “Automate” have the play button added over the image and should launch a modal that plays the video.
  - Before: https://main--bacom--adobecom.hlx.page/de/resources/webinars/automotive-dialogues/creativity-in-motion-dme?martech=off
  - After: https://main--bacom--adobecom.hlx.page/de/resources/webinars/automotive-dialogues/creativity-in-motion-dme?milolibs=alt-image-links&martech=off
  
  
