### PR TITLE
Ability to configure Google YOLO on desktop, mobile and both

### DIFF
--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -51,7 +51,10 @@ export const loadPrivacy = async (getConfig, loadScript) => {
 
 export const loadGoogleLogin = async (getMetadata, loadIms, loadScript) => {
   const googleLogin = getMetadata('google-login')?.toLowerCase();
-  if (googleLogin !== 'on' || window.adobeIMS?.isSignedInUser()) return;
+  if (!['mobile', 'desktop', 'on'].includes(googleLogin) || window.adobeIMS?.isSignedInUser()) return;
+  const desktopViewport = window.matchMedia('(min-width: 900px)').matches;
+  if (googleLogin === 'mobile' && desktopViewport) return;
+  if (googleLogin === 'desktop' && !desktopViewport) return;
 
   const { default: initGoogleLogin } = await import('../features/google-login.js');
   initGoogleLogin(loadIms, getMetadata, loadScript);

--- a/test/features/google-login/google-login.test.js
+++ b/test/features/google-login/google-login.test.js
@@ -1,12 +1,15 @@
 import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
-import { readFile } from '@web/test-runner-commands';
+import { readFile, setViewport } from '@web/test-runner-commands';
 import initGoogleLogin from '../../../libs/features/google-login.js';
+import { viewports } from '../../blocks/global-navigation/test-utilities.js';
 
 describe('Google Login', () => {
   let initializeSpy;
   let promptSpy;
+  let clock;
   beforeEach(async () => {
+    clock = sinon.useFakeTimers();
     document.body.innerHTML = await readFile({ path: './mocks/google-login.html' });
     window.google = window.google || {
       accounts: {
@@ -30,6 +33,7 @@ describe('Google Login', () => {
     promptSpy.restore();
     delete window.adobeid;
     delete window.google;
+    clock.restore();
   });
 
   it('should create a placeholder to inject DOM markup', async () => {
@@ -82,5 +86,65 @@ describe('Google Login', () => {
     await initGoogleLogin(Promise.reject, sinon.stub(), sinon.stub());
     expect(document.getElementById('feds-googleLogin')).not.to.exist;
     loggedInStub.restore();
+  });
+
+  describe('desktop', () => {
+    before(async () => {
+      await setViewport(viewports.desktop);
+    });
+
+    it('should load yolo metadata set to "desktop"', async () => {
+      const { loadGoogleLogin } = await import('../../../libs/scripts/delayed.js');
+      loadGoogleLogin(sinon.stub().returns('desktop'), sinon.stub(), sinon.stub());
+      await clock.runAllAsync();
+      expect(initializeSpy.called).to.be.true;
+    });
+
+    it('should not load yolo with metadata set to "mobile"', async () => {
+      const { loadGoogleLogin } = await import('../../../libs/scripts/delayed.js');
+      loadGoogleLogin(sinon.stub().returns('mobile'), sinon.stub(), sinon.stub());
+      await clock.runAllAsync();
+      expect(initializeSpy.called).to.be.false;
+    });
+  });
+
+  describe('tablet', () => {
+    before(async () => {
+      await setViewport(viewports.smallDesktop);
+    });
+
+    it('should load yolo with metadata set to "desktop"', async () => {
+      const { loadGoogleLogin } = await import('../../../libs/scripts/delayed.js');
+      loadGoogleLogin(sinon.stub().returns('desktop'), sinon.stub(), sinon.stub());
+      await clock.runAllAsync();
+      expect(initializeSpy.called).to.be.true;
+    });
+
+    it('should not load yolo with metadata set to "mobile"', async () => {
+      const { loadGoogleLogin } = await import('../../../libs/scripts/delayed.js');
+      loadGoogleLogin(sinon.stub().returns('mobile'), sinon.stub(), sinon.stub());
+      await clock.runAllAsync();
+      expect(initializeSpy.called).to.be.false;
+    });
+  });
+
+  describe('mobile', () => {
+    before(async () => {
+      await setViewport(viewports.mobile);
+    });
+
+    it('should load yolo metadata set to "mobile"', async () => {
+      const { loadGoogleLogin } = await import('../../../libs/scripts/delayed.js');
+      loadGoogleLogin(sinon.stub().returns('mobile'), sinon.stub(), sinon.stub());
+      await clock.runAllAsync();
+      expect(initializeSpy.called).to.be.true;
+    });
+
+    it('should not load yolo with metadata set to "desktop"', async () => {
+      const { loadGoogleLogin } = await import('../../../libs/scripts/delayed.js');
+      loadGoogleLogin(sinon.stub().returns('desktop'), sinon.stub(), sinon.stub());
+      await clock.runAllAsync();
+      expect(initializeSpy.called).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Description
- The metadata `google-login` field now supports `desktop` and `mobile` along side `on`

## Related Issue
Resolves: [MWPW-137389](https://jira.corp.adobe.com/browse/MWPW-137389)

## Testing instructions
Since there might be CORS issues, to simplify testing, you can check if the `google-login` module is loading or not.
![Screenshot 2023-10-06 at 14 25 20](https://github.com/adobecom/milo/assets/39759830/db3ff9a4-3d8e-4e37-b3e7-ef2d070193b8)

## Test URLs
**Milo:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/prs/mwpw-137389-desktop?martech=off
- After: https://ims--milo--adobecom.hlx.page/drafts/osahin/prs/mwpw-137389-desktop?martech=off

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/prs/mwpw-137389-mobile?martech=off
- After: https://ims--milo--adobecom.hlx.page/drafts/osahin/prs/mwpw-137389-mobile?martech=off

Note: the _after_ test URL is not allowed by IMS to authenticate, a full workflow test might not be possible until the code is merged.