### PR TITLE
Rename helix-cli to aem-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .hlx/*
+.aem/*
 coverage/*
 logs/*
 node_modules/*

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Milo is a shared set of features and services to power Franklin-based websites o
 
 ### Detailed
 1. Fork this repo.
-1. Install the [Helix Bot](https://github.com/apps/helix-bot) on your forked repo.
+1. Install the [AEM Code Sync](https://github.com/apps/aem-code-sync) on your forked repo.
 1. Clone your forked repo down to your computer.
 1. Install the [AEM CLI](https://github.com/adobe/helix-cli) using your terminal: `sudo npm install -g @adobe/aem-cli`
 1. In a terminal, run `aem up` your repo's folder on your computer. It will open a browser.

--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ Milo is a shared set of features and services to power Franklin-based websites o
 
 ### TL;DR
 1. Clone this repo to your computer.
-1. Install the [Helix CLI](https://github.com/adobe/helix-cli): `sudo npm install -g @adobe/helix-cli`
-1. In a terminal, run `hlx up` this repo's folder.
+1. Install the [AEM CLI](https://github.com/adobe/helix-cli): `sudo npm install -g @adobe/aem-cli`
+1. In a terminal, run `aem up` this repo's folder.
 1. Start coding.
 
 ### Detailed
 1. Fork this repo.
 1. Install the [Helix Bot](https://github.com/apps/helix-bot) on your forked repo.
 1. Clone your forked repo down to your computer.
-1. Install the [Helix CLI](https://github.com/adobe/helix-cli) using your terminal: `sudo npm install -g @adobe/helix-cli`
-1. In a terminal, run `hlx up` your repo's folder on your computer. It will open a browser.
+1. Install the [AEM CLI](https://github.com/adobe/helix-cli) using your terminal: `sudo npm install -g @adobe/aem-cli`
+1. In a terminal, run `aem up` your repo's folder on your computer. It will open a browser.
 1. Open your repo's folder in your favorite code editor and start coding.
 
 ### Even more detailed

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:watch": "npm test -- --watch",
     "test:file": "wtr --config ./web-test-runner.config.mjs --node-resolve --port=2000 --coverage",
     "test:file:watch": "wtr --config ./web-test-runner.config.mjs --node-resolve --port=2000 --coverage --watch",
-    "libs": "hlx up --port=6456",
+    "libs": "aem up --port=6456",
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint .",
     "lint:js:nibble": "eslint-nibble .",


### PR DESCRIPTION
### Description
As per the [announcement](https://discord.com/channels/1131492224371277874/1134435772422955109/1158410421309538416) a few names have been changed and we should try our best to keep up with it

I'll also update the wiki and documentation.

### Action item (high-impact)

Everyone should switch to use the `aem-cli` as the `helix-cli` is deprecated.

Run `npm install -g @adobe/aem-cli --force` to install the `aem-cli` you can then use `aem` instead of `hlx` to use the CLI.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://hlx-to-aem--milo--mokimo.hlx.page/?martech=off
