### PR TITLE
Fix failing caas test

### DIFF
--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -617,7 +617,7 @@ describe('getFloodgateCaasConfig', () => {
         fallbackEndpoint: '',
         totalCardsToShow: 10,
         cardStyle: 'half-height',
-        ctaAction: '_blank',
+        ctaAction: '_self',
         detailsTextOption: 'default',
         showTotalResults: false,
         i18n: {


### PR DESCRIPTION
CaaS test failing due to change in ctaAction default value

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://fixcaastests--milo--adobecom.hlx.page/?martech=off
