### PR TITLE
MWPW-135875 Add milo property to window.marketingtech

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -124,6 +124,7 @@ export default async function init({ persEnabled = false, persManifests }) {
       alloy: { edgeConfigId },
       target: false,
     },
+    milo: true,
   };
   window.edgeConfigId = edgeConfigId;
 


### PR DESCRIPTION
Martech folks would like to be able to easily id milo sites.

Resolves: [MWPW-135875](https://jira.corp.adobe.com/browse/MWPW-135875)

To test: Open after url and check the `window.marketingtech` object for `milo:true`

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page
- After: https://135875-martech--milo--adobecom.hlx.page
