### PR TITLE
MWPW-137511 Loc videos do not load

### DIFF
--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -1,14 +1,25 @@
 import { applyHoverPlay, getVideoAttrs } from '../../utils/decorate.js';
+import { getConfig } from '../../utils/utils.js';
 
 export default function init(a) {
   const { pathname, hash } = a;
+  let videoPath = `.${pathname}`;
+  if (pathname.match('media_.*.mp4')) {
+    const { codeRoot } = getConfig();
+    const root = codeRoot.endsWith('/')
+      ? codeRoot
+      : `${codeRoot}/`;
+    const mediaFilename = pathname.split('/').pop();
+    videoPath = `${root}${mediaFilename}`;
+  }
+
   const attrs = getVideoAttrs(hash);
   const video = `<video ${attrs}>
-        <source src=".${pathname}" type="video/mp4" />
+        <source src="${videoPath}" type="video/mp4" />
       </video>`;
   if (!a.parentNode) return;
   a.insertAdjacentHTML('afterend', video);
-  const videoElem = document.body.querySelector(`source[src=".${pathname}"]`)?.parentElement;
+  const videoElem = document.body.querySelector(`source[src="${videoPath}"]`)?.parentElement;
   applyHoverPlay(videoElem);
   a.remove();
 }


### PR DESCRIPTION
Make all media_xxx.mp4 videos load from the coderoot so that loc changes are ignored.

Resolves: [137511-NUMBER](https://jira.corp.adobe.com/browse/MWPW-137511)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://137511-vidloc--milo--adobecom.hlx.page/?martech=off
