### PR TITLE
MWPW-137970: make MEP prelinks relative

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -50,14 +50,21 @@ const DATA_TYPE = {
 };
 
 const createFrag = (el, url, manifestId) => {
-  const a = createTag('a', { href: url }, url);
+  let href = url;
+  try {
+    const { pathname, hash } = new URL(url);
+    href = `${pathname}${hash}`;
+  } catch {
+    // ignore
+  }
+  const a = createTag('a', { href }, url);
   if (manifestId) a.dataset.manifestId = manifestId;
   let frag = createTag('p', undefined, a);
   const isSection = el.parentElement.nodeName === 'MAIN';
   if (isSection) {
     frag = createTag('div', undefined, frag);
   }
-  loadLink(`${url}.plain.html`, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
+  loadLink(`${href}.plain.html`, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
   return frag;
 };
 

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -52,8 +52,8 @@ const DATA_TYPE = {
 const createFrag = (el, url, manifestId) => {
   let href = url;
   try {
-    const { pathname, hash } = new URL(url);
-    href = `${pathname}${hash}`;
+    const { pathname, search, hash } = new URL(url);
+    href = `${pathname}${search}${hash}`;
   } catch {
     // ignore
   }


### PR DESCRIPTION
Makes the prelink href relative for personalization fragments.

Resolves: [MWPW-137970](https://jira.corp.adobe.com/browse/MWPW-137970)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?milolibs=mwpw-137970--milo--yesil&mep=%2Fhomepage%2Ffragments%2Fmep%2Fhp.json--target-dc
