### PR TITLE
Fix failing video tests

### DIFF
--- a/test/blocks/video/video.test.js
+++ b/test/blocks/video/video.test.js
@@ -1,10 +1,15 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
+import { setConfig } from '../../../libs/utils/utils.js';
 
 const { default: init } = await import('../../../libs/blocks/video/video.js');
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
 describe('video uploaded using franklin bot', () => {
+  beforeEach(() => {
+    setConfig({});
+  });
+
   it('decorates video', async () => {
     const block = document.querySelector('.video.normal');
     const a = block.querySelector('a');


### PR DESCRIPTION
### Description
Fix failing tests introduced in https://github.com/adobecom/milo/pull/1415/files by applying default configs for the tests.
Consumers need to set configs either way, so this purely test-setup related.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/?martech=off
- After: https://mwpw-137511-fix-failing-tests--milo--mokimo.hlx.live/?martech=off
