### PR TITLE
Enable web test runner test retries

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -34,7 +34,7 @@ export default {
       '**/special/tacocat/**',
     ],
   },
-  testFramework: { config: { retries: 2 } },
+  testFramework: { config: { retries: 1 } },
   plugins: [importMapsPlugin({})],
   reporters: [
     defaultReporter({ reportTestResults: true, reportTestProgress: true }),

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -34,6 +34,7 @@ export default {
       '**/special/tacocat/**',
     ],
   },
+  testFramework: { config: { retries: 2 } },
   plugins: [importMapsPlugin({})],
   reporters: [
     defaultReporter({ reportTestResults: true, reportTestProgress: true }),


### PR DESCRIPTION
### Description
We already added a bunch of measures to ensure we fix flaky tests. Since we still have an issue with flaky tests, we should enable test retries. 

When a unit test fails, we can now be **sure the test needs to be fixed.**

Developers should not need to re-run tests using the Github UI as it's retried automatically.

2 Retries mean the test would be run a maximum of 3 times when including the initial run. If a test fails 3 times in a row, the test has a serious flaw or it's a legit issue.

### Context
Web test runner test framework configs: https://modern-web.dev/docs/test-runner/test-frameworks/mocha/#configuring-mocha-options
Mocha test retries: https://mochajs.org/#-retries-n

Resolves: [MWPW-137972](https://jira.corp.adobe.com/browse/MWPW-137972)

### Testing instructions
To test if this config works, you can just use a counter to fail the test N times as you expect it to.
```js
  let count = 0;
  it('sporadically fails', async () => {
    if (count < 2) {
      count++;
      console.log('test failed');
      throw new Error('Test failed');
    }
    expect(true).to.be.true;
```

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://wrt-enable-test-retries--milo--mokimo.hlx.page/?martech=off
