### PR TITLE
Section metadata style: `grid width` breaking consumer layouts & Charts grid update

### DIFF
--- a/libs/blocks/chart/chart.css
+++ b/libs/blocks/chart/chart.css
@@ -3,31 +3,8 @@
   to { transform: scale(1); }
 }
 
-.section.chart-section {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: flex-start;
-    gap: 16px;
-    margin: 0 auto;
-}
-
 .chart-section > * {
-  flex: 1 1 100%;
-}
-
-@media (min-width: 1200px) {
-  .up-2 > div:not(.section-metadata) {
-    width: calc(50% - 8px);
-    max-width: calc(50% - 8px);
-    flex: 1 1 auto;
-  }
-
-  .up-3 > div:not(.section-metadata) {
-    width: calc(33% - 8px);
-    max-width: calc(33% - 8px);
-    flex: 1 1 auto;
-  }
+  width: 100%
 }
 
 .chart {

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -175,9 +175,17 @@
 }
 
 .section[class*='grid-width-'] > .content,
-main > .section[class*='-up'] > .content {
+main > .section[class*='-up'] > .content,
+.section[class*='grid-width-'] > .contained {
   max-width: initial;
   margin: 0;
+}
+
+.section[class*='grid-width-'].milo-card-section {
+  padding-left: unset;
+  padding-right: unset;
+  display: initial;
+  gap: initial;
 }
 
 @media screen and (min-width: 600px) and (max-width: 1200px) {

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -174,6 +174,11 @@
   gap: var(--spacing-m);
 }
 
+.section.container[class*='-up'] {
+  width: auto;
+  margin: 0;
+}
+
 .section[class*='grid-width-'] > .content,
 main > .section[class*='-up'] > .content,
 .section[class*='grid-width-'] > .contained {


### PR DESCRIPTION
There are a few pages on Bacom that reported some display issues after [recent updates](https://github.com/adobecom/milo/commit/55afc5c6ab3e8f19b2fb8c2bfc9858341e0e6104#diff-7d6d5811a084df948c503699455ce384eb2f73adec6f11a4ad201c74c4ecf16dR175-R180%23diff-7d6d5811a084df948c503699455ce384eb2f73adec6f11a4ad201c74c4ecf16dR175) to the section metadata styles: `grid-width-*`

* Addressed the grid-width styles from milo, so consuming sites don't have any content layout regression. 
* Adjusted the logic in the `charts` block to use our existing 'ups' grid logic and support section-metadata styles: two-up, three-up for author-ability. 

The `bacom` repo has a temporary [fix](https://github.com/adobecom/bacom/pull/151) in place and this can be removed once this is merged. 
_See [rparrish/grid-width](https://rparrish-grid-width--bacom--adobecom.hlx.page) feature branch._ 

Resolves: [MWPW-137076](https://jira.corp.adobe.com/browse/MWPW-137076)

## Test URLs:
Before
https://main--milo--adobecom.hlx.page/drafts/rparrish/bacom/digital-commerce
After
https://rparrish-grid-width--milo--adobecom.hlx.page/drafts/rparrish/bacom/digital-commerce

### LIVE Grid Width testing
**Current** - bacom fix in place - Should display as expected
https://main--bacom--adobecom.hlx.page/products/experience-manager/digital-commerce

**Before** - bacom fix reverted - Should break grid
https://rparrish-grid-width--bacom--adobecom.hlx.page/products/experience-manager/digital-commerce

**After** - bacom fix reverted && milo feature branch used - Should display as current/expected 
https://rparrish-grid-width--bacom--adobecom.hlx.page/products/experience-manager/digital-commerce?milolibs=rparrish-grid-width

 

### LIVE Charts
**Current**
https://main--bacom--adobecom.hlx.page/resources/digital-price-index
**Before Fix**
https://rparrish-grid-width--bacom--adobecom.hlx.page/resources/digital-price-index
**After**
https://rparrish-grid-width--bacom--adobecom.hlx.page/resources/digital-price-index?milolibs=rparrish-grid-width

 

### Draft Charts
**Current**
https://main--bacom--adobecom.hlx.page/drafts/parrish/resources/digital-price-index
**Before Fix**
https://rparrish-grid-width--bacom--adobecom.hlx.page/drafts/parrish/resources/digital-price-index
**After**
https://rparrish-grid-width--bacom--adobecom.hlx.page/drafts/parrish/resources/digital-price-index?milolibs=rparrish-grid-width


