### PR TITLE
mwpw-137857: increase global navigation loadDelayed delay

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -36,7 +36,7 @@ const CONFIG = {
   },
   delays: {
     mainNavDropdowns: 800,
-    loadDelayed: 2000,
+    loadDelayed: 3000,
     keyboardNav: 8000,
   },
   features: [


### PR DESCRIPTION
## Description
The homepage has seen some lighthouse score improvements with enabled Martech by aligning the global navigation internal delay of 2000ms with the milo standard of 3000ms.

## Related Issue
Resolves: [MWPW-137857](https://jira.corp.adobe.com/browse/MWPW-137857)

## Testing instructions
Dropdowns, search, profile should still work


## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=mwpw-137857--milo--mokimo

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=mwpw-137857--milo--mokimo

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=mwpw-137857--milo--mokimo

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://mwpw-137857--milo--mokimo.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off