### PR TITLE
[MWPW-117914] Allow promobar use on top of Gnav

### DIFF
--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -481,6 +481,14 @@
   height: var(--icon-size-m);
 }
 
+.aside.promobar .promo-text[data-align="center"] {
+  justify-content: center;
+}
+
+.aside.promobar .action-area .con-button {
+  flex-shrink: 0;
+}
+
 .aside.promobar .promo-text.desktop-up,
 .aside.promobar .promo-text.tablet-up {
   display: none;
@@ -600,7 +608,7 @@
 
   .aside.split.no-media:not(.notification) .foreground.container .text {
     padding: var(--spacing-xxxl) 0;
-  }  
+  }
 
   .aside.promobar .mobile-up.hide-block ~ .promo-close {
     display: none;
@@ -611,15 +619,15 @@
   .aside.small {
     min-height: 420px;
   }
-  
+
   .aside.medium {
     min-height: 560px;
   }
-  
+
   .aside.large {
     min-height: 700px;
   }
-  
+
   .aside .foreground.container {
     align-items: center;
     flex-direction: row;
@@ -889,7 +897,7 @@
     align-items: center;
     text-align: center;
   }
-  
+
   .aside.promobar.popup .promo-text .action-area {
     justify-content: center;
     padding: 0 0 var(--spacing-xxs);
@@ -1106,7 +1114,7 @@
     right: var(--spacing-s);
     top: calc(50% - 10px);
   }
-  
+
   .aside.promobar .desktop-up.hide-block ~ .promo-close {
     display: none;
   }

--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -1,7 +1,7 @@
 /* Custom properties (variables) */
 :root {
   /* Top navigation - box model */
-  --feds-height-nav: 64px;
+  --feds-height-nav: 63px;
   --feds-maxWidth-nav: 1440px;
   --feds-height-breadcrumbs: 33px;
   --feds-gutter: 8px;

--- a/libs/blocks/global-navigation/features/aside/aside.js
+++ b/libs/blocks/global-navigation/features/aside/aside.js
@@ -1,0 +1,26 @@
+import { loadBlock, decorateAutoBlock } from '../../../../utils/utils.js';
+import { toFragment, lanaLog, getAnalyticsValue } from '../../utilities/utilities.js';
+
+export default async function decorateAside({ headerElem, promoPath } = {}) {
+  const onError = () => {
+    headerElem.classList.remove('has-promo');
+    lanaLog({ message: 'Gnav Promo fragment not replaced, potential CLS' });
+    return '';
+  };
+
+  const fragLink = toFragment`<a href="${promoPath}">${promoPath}</a>`;
+  const fragTemplate = toFragment`<div>${fragLink}</div>`;
+  decorateAutoBlock(fragLink);
+  if (!fragLink.classList.contains('fragment')) return onError();
+  await loadBlock(fragLink).catch(() => onError());
+  const aside = fragTemplate.querySelector('.aside');
+  if (fragTemplate.contains(fragLink) || !aside) return onError();
+
+  aside.removeAttribute('data-block');
+  aside.setAttribute('daa-lh', 'Promo');
+  aside.querySelectorAll('a').forEach((link, index) => {
+    link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
+  });
+
+  return aside;
+}

--- a/libs/blocks/global-navigation/features/aside/aside.js
+++ b/libs/blocks/global-navigation/features/aside/aside.js
@@ -3,7 +3,7 @@ import { toFragment, lanaLog, getAnalyticsValue } from '../../utilities/utilitie
 
 export default async function decorateAside({ headerElem, promoPath } = {}) {
   const onError = () => {
-    headerElem.classList.remove('has-promo');
+    headerElem?.classList.remove('has-promo');
     lanaLog({ message: 'Gnav Promo fragment not replaced, potential CLS' });
     return '';
   };

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -84,7 +84,7 @@ header.global-navigation {
 
 /* Promo */
 .global-navigation .aside.promobar {
-  display: none;
+  display: none; /* For when someone switches from desktop to mobile */
 }
 
 /* Hamburger toggle */

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -85,6 +85,7 @@ header.global-navigation {
 /* Promo */
 .global-navigation .aside.promobar {
   display: none; /* For when someone switches from desktop to mobile */
+  z-index: 1;
 }
 
 /* Hamburger toggle */

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -82,6 +82,11 @@ header.global-navigation {
   overflow-y: auto;
 }
 
+/* Promo */
+.global-navigation .aside.promobar {
+  display: none;
+}
+
 /* Hamburger toggle */
 .feds-toggle {
   width: 60px;
@@ -489,6 +494,12 @@ header.global-navigation {
     padding-bottom: 0 !important; /* Remove JS-set one */
   }
 
+  /* Promo */
+  .global-navigation .aside.promobar {
+    display: flex;
+    min-height: var(--global-height-navPromo);
+  }
+
   /* Brand block */
   .feds-brand-image + .feds-brand-label {
     display: flex;
@@ -604,12 +615,13 @@ header.global-navigation {
   /* Breadcrumbs */
   .feds-breadcrumbs-wrapper {
     position: absolute;
-    top: 100%;
+    top: calc(100% + 1px); /* Accounting for nav bottom border */
     left: 0;
     right: 0;
     justify-content: center;
     border-bottom: unset;
     box-shadow: 0 3px 2px rgb(142 142 142 / 30%);
+    background: var(--feds-background-nav--light);
     transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */
   }
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -483,7 +483,10 @@ class Gnav {
   decorateAside = async () => {
     this.elements.aside = '';
     const promoPath = getMetadata('gnav-promo-source');
-    if (!promoPath) return this.elements.aside;
+    if (!isDesktop.matches || !promoPath) {
+      this.el.classList.remove('has-promo');
+      return this.elements.aside;
+    }
 
     const { default: decorate } = await import('./features/aside/aside.js');
     if (!decorate) return this.elements.aside;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -4,8 +4,6 @@ import {
   getMetadata,
   loadIms,
   decorateLinks,
-  loadBlock as loadMiloBlock,
-  decorateAutoBlock,
 } from '../../utils/utils.js';
 import {
   toFragment,
@@ -487,27 +485,9 @@ class Gnav {
     const promoPath = getMetadata('gnav-promo-source');
     if (!promoPath) return this.elements.aside;
 
-    const onError = () => {
-      this.el.classList.remove('has-promo');
-      lanaLog({ message: 'Gnav Promo fragment not replaced, potential CLS' });
-      return this.elements.aside;
-    };
-
-    const fragLink = toFragment`<a href="${promoPath}">${promoPath}</a>`;
-    const fragTemplate = toFragment`<div>${fragLink}</div>`;
-    decorateAutoBlock(fragLink);
-    if (!fragLink.classList.contains('fragment')) return onError();
-    await loadMiloBlock(fragLink);
-    const aside = fragTemplate.querySelector('.aside');
-    if (fragTemplate.contains(fragLink) || !aside) return onError();
-
-    this.elements.aside = aside;
-    this.elements.aside.removeAttribute('data-block');
-    this.elements.aside.setAttribute('daa-lh', 'Promo');
-    this.elements.aside.querySelectorAll('a').forEach((link, index) => {
-      link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
-    });
-
+    const { default: decorate } = await import('./features/aside/aside.js');
+    if (!decorate) return this.elements.aside;
+    this.elements.aside = await decorate({ headerElem: this.el, promoPath });
     return this.elements.aside;
   };
 

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -1,7 +1,7 @@
 /*** Variables ***/
 
  :root {
-  --global-height-nav: 65px;
+  --global-height-nav: 64px;
   --global-height-breadcrumbs: 33px;
   --global-height-navPromo: 65px;
   --feds-totalheight-nav: calc(var(--feds-height-nav, --global-height-nav) + var(--feds-height-breadcrumbs, --global-height-breadcrumbs));

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -1,8 +1,9 @@
 /*** Variables ***/
 
  :root {
-  --global-height-nav: 64px;
+  --global-height-nav: 65px;
   --global-height-breadcrumbs: 33px;
+  --global-height-navPromo: 65px;
   --feds-totalheight-nav: calc(var(--feds-height-nav, --global-height-nav) + var(--feds-height-breadcrumbs, --global-height-breadcrumbs));
 
   /* Colors */
@@ -640,13 +641,18 @@ header:not(.global-navigation) ~ main {
   all of the ':not(.global-navigation)' rules can be entirely removed.
  */
 header.global-navigation {
-  height: var(--global-height-nav); /* TODO better approach for value? */
+  height: var(--global-height-nav);
   visibility: hidden;
 }
 
 @media (min-width: 900px) {
+  header.global-navigation.has-promo {
+    height: auto;
+    min-height: calc(var(--global-height-nav) + var(--global-height-navPromo));
+  }
+
   header.global-navigation.has-breadcrumbs {
-    padding-bottom: var(--global-height-breadcrumbs); /* TODO better approach for value? */
+    padding-bottom: var(--global-height-breadcrumbs);
   }
 }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -649,6 +649,8 @@ function decorateHeader() {
   const autoBreadcrumbs = getMetadata('breadcrumbs-from-url') === 'on';
   if (baseBreadcrumbs || breadcrumbs || autoBreadcrumbs) header.classList.add('has-breadcrumbs');
   if (breadcrumbs) header.append(breadcrumbs);
+  const promo = getMetadata('gnav-promo-source');
+  if (promo?.length) header.classList.add('has-promo');
 }
 
 async function decorateIcons(area, config) {

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -9,6 +9,7 @@ import brandOnlyNav from './mocks/global-navigation-only-brand.plain.js';
 import nonSvgBrandOnlyNav from './mocks/global-navigation-only-non-svg-brand.plain.js';
 import longNav from './mocks/global-navigation-long.plain.js';
 import noLogoBrandOnlyNav from './mocks/global-navigation-only-brand-no-image.plain.js';
+import noBrandImageOnlyNav from './mocks/global-navigation-only-brand-no-explicit-image.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
 
 const ogFetch = window.fetch;
@@ -151,6 +152,12 @@ describe('global navigation', () => {
         await createFullGlobalNavigation({ globalNavigation: noLogoBrandOnlyNav });
         const brandImage = document.querySelector(`${selectors.brandImage}`);
         expect(isElementVisible(brandImage)).to.equal(false);
+      });
+
+      it('should render a default image if the one defined is invalid', async () => {
+        await createFullGlobalNavigation({ globalNavigation: noBrandImageOnlyNav });
+        const brandImage = document.querySelector(`${selectors.brandImage}`);
+        expect(isElementVisible(brandImage)).to.equal(true);
       });
     });
 

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -67,12 +67,6 @@ describe('global navigation', () => {
       expect(nav.el.querySelector('.aside.promobar')).to.equal(null);
     });
 
-    it('attaches a special modifier class to the header', async () => {
-      // This is just to check that the setup is correct for the following few steps
-      const nav = await createFullGlobalNavigation({ hasPromo: true });
-      expect(nav.el.classList.contains('has-promo')).to.be.true;
-    });
-
     it('doesn\'t exist if metadata is not referencing a fragment', async () => {
       const wrongPromoMeta = toFragment`<meta name="gnav-promo-source" content="http://localhost:2000/path/to/promo">`;
       document.head.append(wrongPromoMeta);
@@ -103,6 +97,15 @@ describe('global navigation', () => {
         expect(linkElem.hasAttribute('daa-ll')).to.be.true;
       });
       promoMeta.remove();
+    });
+
+    it('doesn\'t exist on mobile', async () => {
+      const promoMeta = toFragment`<meta name="gnav-promo-source" content="http://localhost:2000/fragments/correct-promo-fragment">`;
+      document.head.append(promoMeta);
+      const nav = await createFullGlobalNavigation({ viewport: 'mobile', hasPromo: true });
+      expect(nav.el.classList.contains('has-promo')).to.be.false;
+      const asideElem = nav.el.querySelector('.aside.promobar');
+      expect(asideElem).to.not.exist;
     });
   });
 

--- a/test/blocks/global-navigation/mocks/correctPromoFragment.plain.js
+++ b/test/blocks/global-navigation/mocks/correctPromoFragment.plain.js
@@ -1,0 +1,10 @@
+export default `<div>
+  <div class="aside promobar dark">
+    <div>
+      <div data-align="center" data-valign="middle">
+        <p>Try this promo right now!</p>
+        <p><em><a href="https://adobe.com/">Try it!</a></em></p>
+      </div>
+    </div>
+  </div>
+</div>`;

--- a/test/blocks/global-navigation/mocks/global-navigation-only-brand-no-explicit-image.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-only-brand-no-explicit-image.js
@@ -1,0 +1,12 @@
+export default `
+<div class="gnav-brand">
+  <div>
+    <div>
+      <p>
+        <a href=".png"></a>
+      </p>
+      <p><a href="https://www.adobe.com/">Adobe</a></p>
+    </div>
+  </div>
+</div>
+`;

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -12,6 +12,7 @@ import defaultPlaceholders from './mocks/placeholders.js';
 import defaultProfile from './mocks/profile.js';
 import largeMenuMock from './mocks/large-menu.plain.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
+import correctPromoFragmentMock from './mocks/correctPromoFragment.plain.js';
 import { isElementVisible, selectors as keyboardSelectors } from '../../../libs/blocks/global-navigation/utilities/keyboard/utils.js';
 import { selectors as baseSelectors, toFragment } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
 
@@ -117,6 +118,7 @@ export const createFullGlobalNavigation = async ({
   customConfig = config,
   breadcrumbsEl = defaultBreadcrumbsEl(),
   globalNavigation,
+  hasPromo,
 } = {}) => {
   const clock = sinon.useFakeTimers({
     // Intercept setTimeout and call the function immediately
@@ -130,6 +132,8 @@ export const createFullGlobalNavigation = async ({
     if (url.includes('placeholders')) { return mockRes({ payload: placeholders || defaultPlaceholders }); }
     if (url.endsWith('large-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
     if (url.includes('gnav')) { return mockRes({ payload: globalNavigation || globalNavigationMock }); }
+    if (url.includes('correct-promo-fragment')) { return mockRes({ payload: correctPromoFragmentMock }); }
+    if (url.includes('wrong-promo-fragment')) { return mockRes({ payload: '<div>Non-promo content</div>' }); }
     return null;
   });
   window.adobeIMS = {
@@ -146,7 +150,7 @@ export const createFullGlobalNavigation = async ({
   };
 
   document.body.replaceChildren(toFragment`
-    <header class="global-navigation has-breadcrumbs" daa-im="true" daa-lh="gnav|milo">
+    <header class="global-navigation has-breadcrumbs${hasPromo ? ' has-promo' : ''}" daa-im="true" daa-lh="gnav|milo">
       ${breadcrumbsEl}
     </header>`);
 


### PR DESCRIPTION
## Description
This allows authors to include a promo bar on top of the Global Navigation by defining a new `gnav-promo-source` metadata property with its value leading to a fragment which contains an `aside` block. For design purposes, it's important that authors use the `promobar` variation of the block, although we don't currently have a restriction for this from a code perspective.

Some additional notes:
- `utils.js` has been slightly adapted to add a modifier class to the header in case a Gnav promo was authored on a page. Its use can be seen in `style.css` where we adapt the nav height;
- some minimal changes have been made to the `aside` block CSS to ensure content alignment follows Word indentation and that the CTA does not wrap on multiple rows. The latter might be something useful for all `.con-button` elements, although I'm not aware of all the use cases;

Documentation will be added soon at https://milo.adobe.com/docs/authoring/global-navigation.

## Related Issue
Resolves: [MWPW-117914](https://jira.corp.adobe.com/browse/MWPW-117914)

## Testing instructions
As an FYI, it was decided that promos will not be available on mobile devices for the moment. Rendering will only occur if the viewport width is larger than `900px`. If a user then resizes their viewport below `900px`, the promo will be hidden.

One thing to look into is any CLS impact - the promo will be added on top of the navigation, thus pushing down all other page content. We assign a minimal value to the promo to apply the same principle as breadcrumbs - assign space early on to avoid content jumping around later. Tablet devices will likely experience _some_ CLS, since we can't guesstimate the actual length of the copy, but we're trying to keep the impact to a minimum.

## Screenshots:
**Dc Gnav with Promo**
<img width="1728" alt="DC page with Gnav Promo" src="https://github.com/adobecom/milo/assets/11267498/2cd0780b-b873-4950-b9fe-50c32574de26">

## Test URLs
**Acrobat:**
- Before: https://main--dc--adobecom.hlx.page/drafts/ramuntea/page-with-gnav-promo-fragment?martech=off
- After: https://main--dc--adobecom.hlx.page/drafts/ramuntea/page-with-gnav-promo-fragment?milolibs=mwpw-117914-gnav-promo--milo--overmyheadandbody&martech=off

**BACOM:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/ramuntea/page-with-gnav-promo-fragment
- After: https://main--bacom--adobecom.hlx.page/drafts/ramuntea/page-with-gnav-promo-fragment?milolibs=mwpw-117914-gnav-promo--milo--overmyheadandbody&martech=off

**CC:**
- Before: https://main--cc--adobecom.hlx.page/drafts/ramuntea/page-with-gnav-promo-fragment?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/ramuntea/page-with-gnav-promo-fragment?milolibs=mwpw-117914-gnav-promo--milo--overmyheadandbody&martech=off

**Milo:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-with-metadata-promo?martech=off
- After: https://mwpw-117914-gnav-promo--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-with-metadata-promo?martech=off