### PR TITLE
MWPW-138430 - Set origin to default repo when FG send to caas

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -181,14 +181,14 @@ const processRepoForFloodgate = (repo, fgColor) => {
 };
 
 const getOrigin = (fgColor) => {
-  const bulkPublisherRepo = processRepoForFloodgate(getConfig().repo, fgColor);
-  const origin = getConfig().project || bulkPublisherRepo;
+  const { project, repo } = getConfig();
+  const origin = project || processRepoForFloodgate(repo, fgColor);
 
   if (origin) return origin;
 
   if (window.location.hostname.endsWith('.hlx.page')) {
-    const [, repo] = window.location.hostname.split('.')[0].split('--');
-    return processRepoForFloodgate(repo, fgColor);
+    const [, singlePageRepo] = window.location.hostname.split('.')[0].split('--');
+    return processRepoForFloodgate(singlePageRepo, fgColor);
   }
 
   throw new Error('No Project or Repo defined in config');


### PR DESCRIPTION
- Change the "origin" value while send to caas to use default tree as origin, instead of floodgate tree as origin

Test URLs:

Before: https://main--milo--adobecom.hlx.page/tools/send-to-caas/bulkpublisher.html?martech=off
After: https://main--milo--arshadparwaiz.hlx.page/tools/send-to-caas/bulkpublisher.html?martech=off

Test Data:

Host: milo.adobe.com
Repo: milo-pink
Repo owner: adobecom
Publish to Floodgate: pink
URLs: https://milo.adobe.com/drafts/arshad/caas-fg-card-3

Resolves: [MWPW-138430](https://jira.corp.adobe.com/browse/MWPW-138430)