### PR TITLE
Implemented disabling scroll when modal with curtain is opened

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -195,3 +195,7 @@
     height: 845px;
   }
 }
+
+.disable-scroll {
+  overflow: hidden;
+}

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -42,11 +42,13 @@ function closeModal(modal) {
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
     if (mod.nextElementSibling?.classList.contains('modal-curtain')) {
-      document.body.classList.remove('disable-scroll');
       mod.nextElementSibling.remove();
     }
     if (mod.classList.contains('dialog-modal')) {
       mod.remove();
+    }
+    if(!document.querySelectorAll('.modal-curtain').length) {
+      document.body.classList.remove('disable-scroll');
     }
     document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();
   });

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -47,11 +47,12 @@ function closeModal(modal) {
     if (mod.classList.contains('dialog-modal')) {
       mod.remove();
     }
-    if (!document.querySelectorAll('.modal-curtain').length) {
-      document.body.classList.remove('disable-scroll');
-    }
     document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();
   });
+
+  if (!document.querySelectorAll('.modal-curtain').length) {
+    document.body.classList.remove('disable-scroll');
+  }
 
   [...document.querySelectorAll('header, main, footer')]
     .forEach((element) => element.removeAttribute('aria-disabled'));

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -34,7 +34,6 @@ export function sendAnalytics(event) {
 function closeModal(modal) {
   const { id } = modal;
   const closeEvent = new Event('milo:modal:closed');
-  document.body.classList.remove('commerce-modal-open');
   window.dispatchEvent(closeEvent);
   const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
   const analyticsEventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
@@ -43,6 +42,7 @@ function closeModal(modal) {
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
     if (mod.nextElementSibling?.classList.contains('modal-curtain')) {
+      document.body.classList.remove('disable-scroll');
       mod.nextElementSibling.remove();
     }
     if (mod.classList.contains('dialog-modal')) {
@@ -165,6 +165,7 @@ export async function getModal(details, custom) {
   window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {
+    document.body.classList.add('disable-scroll');
     const curtain = createTag('div', { class: 'modal-curtain is-open' });
     curtain.addEventListener('click', (e) => {
       if (e.target === curtain) closeModal(dialog);
@@ -174,7 +175,6 @@ export async function getModal(details, custom) {
       .forEach((element) => element.setAttribute('aria-disabled', 'true'));
   }
   if (dialog.classList.contains('commerce-frame')) {
-    document.body.classList.add('commerce-modal-open');
     if (isInitialPageLoad) {
       window.addEventListener('message', (messageInfo) => {
         sendViewportDimensionsOnRequest(messageInfo);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -47,7 +47,7 @@ function closeModal(modal) {
     if (mod.classList.contains('dialog-modal')) {
       mod.remove();
     }
-    if(!document.querySelectorAll('.modal-curtain').length) {
+    if (!document.querySelectorAll('.modal-curtain').length) {
       document.body.classList.remove('disable-scroll');
     }
     document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

This PR has been opened because previous 2 (https://github.com/adobecom/milo/pull/1457 &
https://github.com/adobecom/milo/pull/1419) had outdated and broken main origin branch. I am opening this PR after cloning this project from the start, with fresh and up-to-date main branch.

This PR should resolve the issue of scrollable background when modal dialog (which is authored to have a 'curtain') is opened. In other cases (with 'curtain-off') background should be scrollable per requirements.

Resolves: [MWPW-136767](https://jira.corp.adobe.com/browse/MWPW-136767)

Test URLs:

Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/video-examples?martech=off
After: https://mwpw-136767-modal-background-scroll--milo--saragajic11.hlx.page/drafts/rclayton/video-examples?martech=off

Commerce dialog (it should work the same as before this PR):

Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/discover1?martech=off
After: https://mwpw-136767-modal-background-scroll--milo--saragajic11.hlx.page/drafts/ruchika/discover1?martech=off

Example of page which had (in previous PR) _content_ issues:
https://main--cc--adobecom.hlx.page/creativecloud/animation/discover?milolibs=mwpw-136767-modal-background-scroll--milo--saragajic11

