### PR TITLE
MWPW-138106: b.a.com Blog category titles fix

### DIFF
--- a/libs/blocks/recommended-articles/recommended-articles.js
+++ b/libs/blocks/recommended-articles/recommended-articles.js
@@ -20,8 +20,7 @@ async function getArticleDetails(article) {
   const ending = trimEndings.find((el) => title.endsWith(el));
   [title] = title.split(ending);
 
-  const metaCategory = getMetadata('category', doc);
-  const category = metaCategory || getMetadata('article:tag', doc);
+  const category = getMetadata('category', doc) || getMetadata('article:tag', doc);
 
   return {
     title,

--- a/libs/blocks/recommended-articles/recommended-articles.js
+++ b/libs/blocks/recommended-articles/recommended-articles.js
@@ -20,10 +20,13 @@ async function getArticleDetails(article) {
   const ending = trimEndings.find((el) => title.endsWith(el));
   [title] = title.split(ending);
 
+  const metaCategory = getMetadata('category', doc);
+  const category = metaCategory || getMetadata('article:tag', doc);
+
   return {
     title,
     path,
-    category: getMetadata('article:tag', doc),
+    category,
     description: getMetadata('description', doc),
     imageEl: doc.querySelector('picture'),
     date: getMetadata('publication-date', doc),

--- a/libs/scripts/taxonomy.js
+++ b/libs/scripts/taxonomy.js
@@ -68,6 +68,7 @@ async function fetchTaxonomy(target) {
 }
 
 function parseTaxonomyJson(data, root, route) {
+  console.log(data, route, root)
   let level1; let level2;
   return data?.reduce((taxonomy, row) => {
     const level3 = removeLineBreaks(row[TAXONOMY_FIELDS.level3]);
@@ -83,7 +84,7 @@ function parseTaxonomyJson(data, root, route) {
       : (level2 ? LEVEL_INDEX.level2
         : LEVEL_INDEX.level1);
 
-    const name = level3 || level2 || level1;
+    const name = level3?.toLowerCase() || level2?.toLowerCase() || level1?.toLowerCase();
     const category = row[TAXONOMY_FIELDS.type]?.trim().toLowerCase() || INTERNALS;
 
     // skip duplicates
@@ -181,7 +182,7 @@ export default async (config, route, target) => {
 
         get(topic, cat) {
           // take first one of the list
-          const item = findItem(topic, cat, taxonomy);
+          const item = findItem(topic?.toLowerCase(), cat?.toLowerCase(), taxonomy);
 
           if (!item) { return null; }
 

--- a/libs/scripts/taxonomy.js
+++ b/libs/scripts/taxonomy.js
@@ -68,7 +68,6 @@ async function fetchTaxonomy(target) {
 }
 
 function parseTaxonomyJson(data, root, route) {
-  console.log(data, route, root)
   let level1; let level2;
   return data?.reduce((taxonomy, row) => {
     const level3 = removeLineBreaks(row[TAXONOMY_FIELDS.level3]);

--- a/libs/scripts/taxonomy.js
+++ b/libs/scripts/taxonomy.js
@@ -83,7 +83,7 @@ function parseTaxonomyJson(data, root, route) {
       : (level2 ? LEVEL_INDEX.level2
         : LEVEL_INDEX.level1);
 
-    const name = level3?.toLowerCase() || level2?.toLowerCase() || level1?.toLowerCase();
+    const name = (level3 || level2 || level1)?.toLowerCase();
     const category = row[TAXONOMY_FIELDS.type]?.trim().toLowerCase() || INTERNALS;
 
     // skip duplicates


### PR DESCRIPTION
* Checks for the meta property of category for card titles in the article feed
* Sanitizes taxonomy properties and params passed into get method to avoid case sensitivity issues. 

Additional context: 
We may want to revisit this code since there are now two business logics being used by it, not to mention the new taxonomy pattern introduced with the tag selector. 

There should be no impact on brand blog's recommended articles or cards 

Resolves: [MWPW-138106](https://jira.corp.adobe.com/browse/MWPW-138106)

**Test URLs:**

*Dx Blog*
- Before: https://main--bacom-blog--adobecom.hlx.page/uk/drafts/methomas/?martech=off
- Before: https://main--bacom-blog--adobecom.hlx.page/blog/?martech=off
- After: https://main--bacom-blog--adobecom.hlx.page/uk/drafts/methomas/?milolibs=blog-category-fix&martech=off
- After: https://main--bacom-blog--adobecom.hlx.page/blog/?milolibs=blog-category-fix&martech=off

*Brand Blog*
- Before: https://main--blog--adobecom.hlx.page/en/publish/2023/10/26/celebrating-those-setting-trend-in-digital-inclusivity?martech=off
- Before: https://main--blog--adobecom.hlx.page/en?martech=off
- After: https://main--blog--adobecom.hlx.page/en/publish/2023/10/26/celebrating-those-setting-trend-in-digital-inclusivity?milolibs=blog-category-fix&martech=off
- After: https://main--blog--adobecom.hlx.page/en?milolibs=blog-category-fix&martech=off

