### PR TITLE
Add analytics to 404 page template

### DIFF
--- a/libs/templates/404/404.js
+++ b/libs/templates/404/404.js
@@ -12,6 +12,9 @@ async function get404(path) {
   const main = document.body.querySelector('main');
   main.append(section);
   await loadArea(main);
+  import('../../martech/analytics.js').then((analytics) => {
+    document.querySelectorAll('main > div').forEach((block, idx) => analytics.decorateSectionAnalytics(block, idx));
+  });
 }
 
 async function getLegacy404() {

--- a/libs/templates/404/404.js
+++ b/libs/templates/404/404.js
@@ -13,7 +13,7 @@ async function get404(path) {
   main.append(section);
   await loadArea(main);
   import('../../martech/analytics.js').then((analytics) => {
-    document.querySelectorAll('main > div').forEach((block, idx) => analytics.decorateSectionAnalytics(block, idx));
+    document.querySelectorAll('main > div').forEach((area, idx) => analytics.decorateSectionAnalytics(area, idx));
   });
 }
 


### PR DESCRIPTION
* Add analytics tracking attributes to 404 page template

Resolves: [MWPW-138736](https://jira.corp.adobe.com/browse/MWPW-138736)

**Test URLs:**
Milo:
- Before: https://main--milo--adobecom.hlx.page/doesnotexist
- After: https://404-analytics--milo--ruchika4.hlx.page/doesnotexist

DC
- Before: https://main--dc--adobecom.hlx.page/acrobat/resources123
- After: https://main--dc--adobecom.hlx.page/acrobat/resources123?milolibs=404-analytics--milo--ruchika4

CC
- Before: https://stage--cc--adobecom.hlx.page/fr/creativecloud/photography/hub/guides/add-vintage-frame-in-photoshops
- After: https://stage--cc--adobecom.hlx.page/fr/creativecloud/photography/hub/guides/add-vintage-frame-in-photoshops?milolibs=404-analytics--milo--ruchika4


For testing:

Open the before url and inspect any link and button you will see no tracking attributes set. In after link you should see proper daa-ll and daa-lh values set.

