### PR TITLE
MWPW-138740: fix strikethrough price

### DIFF
--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -7,7 +7,7 @@ inline-price[data-wcs-osi] {
   display: inline-block;
 }
 
-inline-price.placeholder-resolved[data-template="priceStrikethrough"], inline-price.price.price-strikethrough {
+inline-price.placeholder-resolved[data-template="priceStrikethrough"], span.price.price-strikethrough {
   text-decoration: line-through;
 }
 


### PR DESCRIPTION
This PR addresses a style regression in promo prices.

actual:
![image](https://github.com/adobecom/milo/assets/330057/10da1926-c1ae-407f-a181-93e7468a5764)

expected:
![image](https://github.com/adobecom/milo/assets/330057/0b58d008-1ec4-4469-857a-7f71ceddf846)


Resolves: [MWPW-138740](https://jira.corp.adobe.com/browse/MWPW-138740)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ilyas/merch?martech=off
- After: https://mwpw-138740--milo--yesil.hlx.live/drafts/ilyas/merch?martech=off
