### PR TITLE
MWPW-136763: Fixes wrong origins being used by consumers #1325

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -125,6 +125,8 @@ ENVS.local = {
 
 export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
 
+console.log('hello');
+
 const LANGSTORE = 'langstore';
 const PAGE_URL = new URL(window.location.href);
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -125,8 +125,6 @@ ENVS.local = {
 
 export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
 
-console.log('hello');
-
 const LANGSTORE = 'langstore';
 const PAGE_URL = new URL(window.location.href);
 


### PR DESCRIPTION
When sending content to CaaS, milo was using the adobecom github repository name as the origin for the content source in CaaS. 

CaaS has it's own source values (legacy from dexter) that should be used, otherwise each site will have separate buckets where their content exists.

This PR creates a hard coded map for where to pull the content from which will update as new consumers onboard onto CaaS and milo.

Resolves: https://jira.corp.adobe.com/browse/MWPW-136763

**Test URLs:**
- Before: https://milo.adobe.com/tools/send-to-caas/bulkpublisher.html?martech=off
- After: https://mwpw-136763--milo--adobecom.hlx.page/tools/send-to-caas/bulkpublisher.html?martech=off