### PR TITLE
MWPW-136763: Fixes cases where origin is not in mapping

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -188,7 +188,7 @@ const getOrigin = (fgColor) => {
     cc: 'hawks',
     dc: 'doccloud',
   };
-  if (mappings[origin]) {
+  if (mappings[origin] || origin) {
     return mappings[origin] || origin;
   }
 


### PR DESCRIPTION
There was an issue found during Prod Smoke testing where origins where the mapping didn't exist would not fallback to code repo name and return the empty string.

