### PR TITLE
MWPW-136896: Regional edit support for heading/bookmarks

### DIFF
--- a/tools/loc/rollout.js
+++ b/tools/loc/rollout.js
@@ -118,7 +118,7 @@ function getMergedMdast(langstoreNowProcessedMdast, livecopyProcessedMdast) {
         const { children } = content;
         for (let i = 0; i < children.length; i += 1) {
           const child = children[i];
-          if (child.type === 'text' || child.type === 'gtRow' || child.type === 'image') {
+          if (child.type === 'text' || child.type === 'gtRow' || child.type === 'image' || child.type === 'html') {
             child.author = author;
             child.action = action;
           }


### PR DESCRIPTION
Resolves: [MWPW-136896]( https://jira.corp.adobe.com/browse/MWPW-136896)

This PR skips adding anchors for `Heading` & `Bookmarks` in langstore version. This is done to have the link point to regional heading which is shown in preview by default.

With this change:
<div class="OutlineElement Ltr SCXW51860322 BCX0" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow: visible; cursor: text; clear: both; position: relative; direction: ltr; color: rgb(0, 0, 0); font-family: &quot;Segoe UI&quot;, &quot;Segoe UI Web&quot;, Arial, Verdana, sans-serif; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="TableContainer Ltr SCXW51860322 BCX0" style="margin: 2px 0px 2px -5px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow: visible; position: relative; display: flex; justify-content: center;">

Heading/Bookmark block changed (same Heading) | Link block changed (same Link) | Result
-- | -- | --
true | false | Link points to regional Heading/Bookmark block.
false | true | Both regional and langstore link points to Heading/Bookmark block
true | true | Both regional and langstore link points to regional Heading/Bookmark block.
false | false | Works as expected

</div></div><div class="OutlineElement Ltr SCXW51860322 BCX0" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow: visible; cursor: text; clear: both; position: relative; direction: ltr; color: rgb(0, 0, 0); font-family: &quot;Segoe UI&quot;, &quot;Segoe UI Web&quot;, Arial, Verdana, sans-serif; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><p class="Paragraph SCXW51860322 BCX0" xml:lang="EN-GB" lang="EN-GB" paraid="1325091612" paraeid="{9fa36ff3-08a6-4065-aa7c-a36d38745c4f}{210}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; overflow-wrap: break-word; white-space: pre-wrap; font-weight: normal; font-style: normal; vertical-align: baseline; font-kerning: none; background-color: transparent; color: windowtext; text-align: center; text-indent: 0px;"><span data-contrast="auto" xml:lang="EN-GB" lang="EN-GB" class="TextRun SCXW51860322 BCX0" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-variant-ligatures: none !important; font-size: 11pt; line-height: 18.3458px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"><span class="NormalTextRun SCXW51860322 BCX0" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent;"></span></span><span class="EOP SCXW51860322 BCX0" data-ccp-props="{&quot;201341983&quot;:0,&quot;335551550&quot;:2,&quot;335551620&quot;:2,&quot;335559739&quot;:160,&quot;335559740&quot;:259}" style="margin: 0px; padding: 0px; user-select: text; -webkit-user-drag: none; -webkit-tap-highlight-color: transparent; font-size: 11pt; line-height: 18.3458px; font-family: Calibri, Calibri_EmbeddedFont, Calibri_MSFontService, sans-serif;"> </span></p></div>


If heading text is modified, the in-page link is also modified. Hence, on 2nd rollout we will see both Link's & Heading's block with track changes. The langstore link points to langstore heading (if langstore version is kept).
If the track changes are accepted, we get white background link which is immutable. After 2nd rollout if the heading text is modified - the in-page link is not automatically modified. So, in-page link is broken. In such case - 3rd rollout link will also be broken.