### PR TITLE
fix: enforce origin of experiment blocks

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -421,7 +421,7 @@ export async function loadBlock(block) {
   const expBlock = checkForExpBlock(name, expBlocks);
   if (expBlock) {
     name = expBlock.blockName;
-    path = expBlock.blockPath;
+    path = `${base}${expBlock.blockPath}`;
   }
 
   const blockPath = `${path}/${name}`;

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -118,6 +118,7 @@ describe('Functional Test', () => {
     setFetchResponse(manifestJson);
 
     await applyPers([{ manifestPath: '/path/to/manifest.json' }]);
+
     expect(getConfig().expBlocks).to.deep.equal({ myblock: '/test/features/personalization/mocks/myblock' });
     const myBlock = document.querySelector('.myblock');
     expect(myBlock.textContent?.trim()).to.equal('This block does not exist');

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
 import { stub } from 'sinon';
-import { getConfig, loadBlock } from '../../../libs/utils/utils.js';
+import { getConfig, loadBlock, setConfig } from '../../../libs/utils/utils.js';
 import initFragments from '../../../libs/blocks/fragment/fragment.js';
 import { applyPers } from '../../../libs/features/personalization/personalization.js';
 
@@ -21,6 +21,10 @@ const setFetchResponse = (data, type = 'json') => {
 
 // Note that the manifestPath doesn't matter as we stub the fetch
 describe('Functional Test', () => {
+  before(() => {
+    setConfig({ codeRoot: '' });
+  });
+
   it('replaceContent should replace an element with a fragment', async () => {
     let manifestJson = await readFile({ path: './mocks/manifestReplace.json' });
     manifestJson = JSON.parse(manifestJson);
@@ -114,7 +118,6 @@ describe('Functional Test', () => {
     setFetchResponse(manifestJson);
 
     await applyPers([{ manifestPath: '/path/to/manifest.json' }]);
-
     expect(getConfig().expBlocks).to.deep.equal({ myblock: '/test/features/personalization/mocks/myblock' });
     const myBlock = document.querySelector('.myblock');
     expect(myBlock.textContent?.trim()).to.equal('This block does not exist');


### PR DESCRIPTION
When running experiments that modify blocks, the resulting path for the new block is relative to the origin the import is run on, which means that we always try to load from the milo origin even when the block is in the project, unless we specify the whole URL in the config… but that leads to possible CORS issues during dev/testing since we would try to load from different hosts.

To fix the issue, we explicitly re-use the `base` path that contains either the milo or the project origin so the import happens from the right origin.

Resolves: [MWPW-138857](https://jira.corp.adobe.com/browse/MWPW-138857)

**Test URLs:**
- Before: https://franklin-experimentation--homepage--ramboz.hlx.page/drafts/ramboz/index-loggedout?experiment=demo%2Fchallenger-1
- After: https://franklin-experimentation--homepage--ramboz.hlx.page/drafts/ramboz/index-loggedout?experiment=demo%2Fchallenger-1&milolibs=fix-expblocks (check the homepage-brick-alt block resolution)

