### PR TITLE
MWPW-137282 - Action item block layout options

### DIFF
--- a/libs/blocks/action-item/action-item.css
+++ b/libs/blocks/action-item/action-item.css
@@ -1,5 +1,6 @@
 .action-item {
   display: flex;
+  width: 160px;
 }
 
 .action-item img {
@@ -87,6 +88,10 @@
 
 .action-item.image-size-large img {
   max-height: var(--spacing-xxxl);
+}
+
+.action-item.float-icon {
+  margin: 0 var(--spacing-xs);
 }
 
 .action-item.float-icon .floated-icon img {

--- a/libs/blocks/action-scroller/action-scroller.css
+++ b/libs/blocks/action-scroller/action-scroller.css
@@ -12,16 +12,18 @@
 
 .action-scroller .scroller {
   display: grid;
-  grid-template-columns: repeat(var(--action-scroller-columns), 1fr);
-  grid-auto-columns: minmax(var(--action-scroller-column-width), 1fr);
+  grid-template-columns: repeat(var(--action-scroller-columns), var(--action-scroller-item-width));
+  grid-auto-columns: minmax(var(--action-scroller-column-width), var(--action-scroller-item-width));
   grid-auto-flow: column;
-  gap: var(--spacing-m);
+  gap: var(--spacing-xs);
   padding: 0 var(--action-scroller-mobile-padding);
   overflow-x: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;
   scroll-behavior: smooth;
+}
 
+.action-scroller .scroller[hide-mask='false'] {
   --mask-width: 60px;
   --mask-image-content: linear-gradient(to right,
       transparent,
@@ -44,7 +46,6 @@
   mask-position: 0 0, 100% 0;
   mask-repeat: no-repeat, no-repeat;
 }
-
 
 .action-scroller .scroller::-webkit-scrollbar {
   display: none;
@@ -138,5 +139,9 @@
   .action-scroller {
     width: var(--grid-container-width);
     margin: 0 auto;
+  }
+
+  .action-scroller .justify-center {
+    justify-content: center;
   }
 }

--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -4,8 +4,6 @@ const { miloLibs, codeRoot } = getConfig();
 const base = miloLibs || codeRoot;
 
 const defaultItemWidth = (cols) => (cols === 3 ? 160 : 147);
-const defaultGridGap = 16;
-
 const PREVBUTTON = `<button class="nav-button previous-button"><img class="previous-icon" alt="Previous icon" src="${base}/blocks/carousel/img/arrow.svg"></button>`;
 const NEXTBUTTON = `<button class="nav-button next-button"><img class="next-icon" alt="Next icon" src="${base}/blocks/carousel/img/arrow.svg"></button>`;
 
@@ -36,15 +34,11 @@ function setBlockProps(el, columns) {
 }
 
 function handleScroll(el, btn) {
-  const itemWidth = el.parentElement?.style?.getPropertyValue('--action-scroller-item-width')
-    ?? defaultItemWidth;
+  const itemWidth = el.parentElement?.style?.getPropertyValue('--action-scroller-item-width');
   const gapStyle = window
     .getComputedStyle(el, null)
     .getPropertyValue('column-gap');
-  const gridGap = gapStyle
-    ? parseInt(gapStyle.replace('px', ''), 10)
-    : defaultGridGap;
-  const scrollDistance = parseInt(itemWidth, 10) + gridGap;
+  const scrollDistance = parseInt(itemWidth, 10) + parseInt(gapStyle.replace('px', ''), 10);
   el.scrollLeft = btn[1].includes('next-button')
     ? el.scrollLeft + scrollDistance
     : el.scrollLeft - scrollDistance;

--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -3,9 +3,8 @@ import { createTag, getConfig } from '../../utils/utils.js';
 const { miloLibs, codeRoot } = getConfig();
 const base = miloLibs || codeRoot;
 
-const [NAV, ALIGN] = ['navigation', 'grid-align'];
-const defaultItemWidth = 106;
-const defaultGridGap = 32;
+const defaultItemWidth = (cols) => (cols === 3 ? 160 : 147);
+const defaultGridGap = 16;
 
 const PREVBUTTON = `<button class="nav-button previous-button"><img class="previous-icon" alt="Previous icon" src="${base}/blocks/carousel/img/arrow.svg"></button>`;
 const NEXTBUTTON = `<button class="nav-button next-button"><img class="next-icon" alt="Next icon" src="${base}/blocks/carousel/img/arrow.svg"></button>`;
@@ -24,18 +23,16 @@ const getBlockProps = (el) => [...el.childNodes].reduce((attr, row) => {
 
 function setBlockProps(el, columns) {
   const attrs = getBlockProps(el);
-  const itemWidth = attrs['item width'] ?? defaultItemWidth;
+  const itemWidth = attrs['item width'] ?? defaultItemWidth(columns);
   const overrides = attrs.style
     ? attrs.style
       .split(', ')
       .map((style) => style.replaceAll(' ', '-'))
       .join(' ')
     : '';
-  const gridAlign = [...el.classList].filter((cls) => cls.toLowerCase().includes(ALIGN))
-    ?? 'grid-align-start';
   el.style.setProperty('--action-scroller-columns', columns);
   el.style.setProperty('--action-scroller-item-width', itemWidth);
-  return `scroller ${gridAlign} ${overrides}`;
+  return `scroller ${columns <= 5 ? 'justify-center' : ''} ${overrides}`;
 }
 
 function handleScroll(el, btn) {
@@ -53,15 +50,13 @@ function handleScroll(el, btn) {
     : el.scrollLeft - scrollDistance;
 }
 
-function handleBtnState(
-  { scrollLeft, scrollWidth, clientWidth },
-  [prev, next],
-) {
-  prev.setAttribute('hide-btn', scrollLeft === 0);
-  next.setAttribute(
-    'hide-btn',
-    Math.ceil(scrollLeft) === Math.ceil(scrollWidth - clientWidth),
-  );
+function handleBtnState(el, [prev, next]) {
+  const { scrollLeft, scrollWidth, clientWidth } = el;
+  const hidePrev = scrollLeft === 0;
+  const hideNext = Math.ceil(scrollLeft) === Math.ceil(scrollWidth - clientWidth);
+  prev.setAttribute('hide-btn', hidePrev);
+  next.setAttribute('hide-btn', hideNext);
+  el.setAttribute('hide-mask', hidePrev && hideNext);
 }
 
 function handleNavigation(el) {
@@ -76,7 +71,7 @@ function handleNavigation(el) {
 }
 
 export default function init(el) {
-  const hasNav = el.classList.contains(NAV);
+  const hasNav = el.classList.contains('navigation');
   const actions = el.parentElement.querySelectorAll('.action-item');
   const style = setBlockProps(el, actions.length);
   const items = createTag('div', { class: style }, null);

--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -204,10 +204,6 @@
   max-width: var(--icon-size-l);
 }
 
-.section.five-up  {
-  grid-template-columns: repeat(auto-fit, minmax(276px, 1fr)) !important;
-}
-
 .icon-block .foreground .text-content > * {
   width: 100%;
 }
@@ -431,9 +427,5 @@
 
   .three-up .icon-block.bio .foreground {
     max-width: 300px;
-  }
-
-  .section.five-up {
-    grid-template-columns: repeat(5, 1fr) !important;
   }
 }

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -101,10 +101,6 @@
   border-bottom: 1px solid;
 }
 
-.section.center[class*='-up'] {
-  justify-items: center;
-}
-
 .section[class*='-up'].no-gap {
   gap: 0;
 }
@@ -137,10 +133,7 @@
   gap: var(--spacing-xxxl);
 }
 
-.section.two-up,
-.section.three-up,
-.section.four-up,
-.section.five-up {
+.section[class*='-up'] {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(276px, 1fr));
   gap: var(--spacing-m);
@@ -150,7 +143,7 @@
 }
 
 .section.five-up {
-  grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(125px, 1fr));
 }
 
 .section.sticky-top {
@@ -165,11 +158,6 @@
   bottom: 0;
   z-index: 1;
   background-color: var(--color-white);
-}
-
-.section.sticky-bottom.promo-sticky-section {
-  background: none;
-  z-index: 4;
 }
 
 .section[class*='grid-width-'] {
@@ -235,6 +223,12 @@ main > .section[class*='-up'] > .content {
     grid-template-columns: repeat(5, 1fr);
   }
 
+  .section.center-desktop[class*='-up'] {
+    grid-template-columns: auto;
+    grid-auto-flow: column;
+    justify-content: center;
+  }
+
   .section.grid-template-columns-1-2 {
     grid-template-columns: 1fr 2fr;
   }
@@ -250,12 +244,12 @@ main > .section[class*='-up'] > .content {
   .section.grid-template-columns-3-1 {
     grid-template-columns: 3fr 1fr;
   }
-  
+
   .section.grid-width-6-desktop {
     padding-left: var(--grid-margins-width-6);
     padding-right: var(--grid-margins-width-6);
   }
-  
+
   .section.grid-width-8-desktop {
     padding-left: var(--grid-margins-width-8);
     padding-right: var(--grid-margins-width-8);

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -101,6 +101,10 @@
   border-bottom: 1px solid;
 }
 
+.section.center[class*='-up'] {
+  justify-items: center;
+}
+
 .section[class*='-up'].no-gap {
   gap: 0;
 }
@@ -167,6 +171,11 @@
   gap: var(--spacing-m);
 }
 
+.section.sticky-bottom.promo-sticky-section {
+  background: none;
+  z-index: 4;
+}
+
 .section[class*='grid-width-'] > .content,
 main > .section[class*='-up'] > .content {
   max-width: initial;
@@ -223,7 +232,7 @@ main > .section[class*='-up'] > .content {
     grid-template-columns: repeat(5, 1fr);
   }
 
-  .section.center-desktop[class*='-up'] {
+  .section.center[class*='-up'] {
     grid-template-columns: auto;
     grid-auto-flow: column;
     justify-content: center;

--- a/test/blocks/action-scroller/action-scroller.test.js
+++ b/test/blocks/action-scroller/action-scroller.test.js
@@ -51,6 +51,7 @@ describe('action scrollers', () => {
           const scrolled = scrollArea.scrollLeft > 0;
           expect(scrolled).to.be.true;
         });
+
         it('can scroll previous', async () => {
           const scrollArea = scroller.querySelector('.scroller');
           const prevBtn = scroller.querySelector('.previous-button');

--- a/test/blocks/action-scroller/mocks/body.html
+++ b/test/blocks/action-scroller/mocks/body.html
@@ -195,7 +195,7 @@
     </div>
   </div>
   <div>
-    <div class="action-scroller navigation"></div>
+    <div class="action-scroller"></div>
     <div class="action-item">
       <div>
         <picture>

--- a/test/blocks/action-scroller/mocks/body.html
+++ b/test/blocks/action-scroller/mocks/body.html
@@ -93,14 +93,14 @@
     </div>
   </div>
   <div>
-    <div class="action-scroller navigation grid-align-end">
+    <div class="action-scroller navigation">
       <div>
         <div>Item width</div>
         <div>110</div>
       </div>
       <div>
         <div>style</div>
-        <div>Grid align end</div>
+        <div>dark</div>
       </div>
     </div>
     <div class="action-item">
@@ -163,6 +163,39 @@
         <div><a href="https://www.adobe.com/">https://www.adobe.com/</a></div>
       </div>
     </div>
+    <div class="action-item">
+      <div>
+        <picture>
+          <img loading="lazy" alt="" src="" width="178" height="180">
+        </picture>
+      </div>
+      <div>
+        <div><a href="https://www.adobe.com/">https://www.adobe.com/</a></div>
+      </div>
+    </div>
+    <div class="action-item">
+      <div>
+        <picture>
+          <img loading="lazy" alt="" src="" width="178" height="180">
+        </picture>
+      </div>
+      <div>
+        <div><a href="https://www.adobe.com/">https://www.adobe.com/</a></div>
+      </div>
+    </div>
+    <div class="action-item">
+      <div>
+        <picture>
+          <img loading="lazy" alt="" src="" width="178" height="180">
+        </picture>
+      </div>
+      <div>
+        <div><a href="https://www.adobe.com/">https://www.adobe.com/</a></div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="action-scroller navigation"></div>
     <div class="action-item">
       <div>
         <picture>


### PR DESCRIPTION
The spacing and width of action items nested within the scroller and section grid are not currently correct for the `action-icons` 3-5 up design examples. This is due to the way the grid template items are styled in both places. So we are adding functionality to make the action icons design layouts possible.

- Added `.center` style on section grid in desktop that will justify grid content center
- Added default width on the action item to match designs and provide a function that applies item width conditional logic
- Added center content style in action scroller for 5 or less items (also considers the established action item width logic)
- Added Action scroller `hide mask` attribute to handle edge case I noticed, where mask was obscuring content when justified center in the action scroller
- Removed unneeded grid style overrides in icon-block.css

Resolves: [MWPW-137282](https://jira.corp.adobe.com/browse/MWPW-137282)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/justify-action-item?martech=off
- After: https://sarchibeque-mwpw-137282-center-actions--milo--adobecom.hlx.page/drafts/sarchibeque/justify-action-item?martech=off
