### PR TITLE
MWPW-138962:  Bacom-blog Article Feed Issue

### DIFF
--- a/libs/blocks/article-feed/article-helpers.js
+++ b/libs/blocks/article-feed/article-helpers.js
@@ -90,7 +90,11 @@ function loadArticleTaxonomy(article) {
 
     const articleTax = computeTaxonomyFromTopics(topics, path);
 
-    clonedArticle.category = articleTax.category;
+    const { productionDomain, contentRoot } = getConfig();
+
+    if (productionDomain !== 'business.adobe.com' && contentRoot !== '/blog') {
+      clonedArticle.category = articleTax.category;
+    }
 
     // topics = tags as an array
     clonedArticle.topics = topics;

--- a/libs/blocks/article-feed/article-helpers.js
+++ b/libs/blocks/article-feed/article-helpers.js
@@ -90,11 +90,7 @@ function loadArticleTaxonomy(article) {
 
     const articleTax = computeTaxonomyFromTopics(topics, path);
 
-    const { productionDomain, contentRoot } = getConfig();
-
-    if (productionDomain !== 'business.adobe.com' && contentRoot !== '/blog') {
-      clonedArticle.category = articleTax.category;
-    }
+    clonedArticle.category ??= articleTax.category;
 
     // topics = tags as an array
     clonedArticle.topics = topics;


### PR DESCRIPTION
* Adds logic looking into the config to determine if the site is bacom blog before reassigning the category prop

Resolves: [MWPW-138962](https://jira.corp.adobe.com/browse/MWPW-138962)

**Test URLs:**
_bacom-blog_
- Before: https://main--bacom-blog--adobecom.hlx.page/drafts/staged-content/blog/tags/adobe-analytics?martech=off
- After: https://main--bacom-blog--adobecom.hlx.page/drafts/staged-content/blog/tags/adobe-analytics?martech=off&milolibs=article-feed-category

_brand blog_
- Before: https://main--blog--adobecom.hlx.page/en/topics/customer-stories?martech=off
- After: https://main--blog--adobecom.hlx.page/en/topics/customer-stories?martech=off&milolibs=article-feed-category
