### PR TITLE
MWPW-138921 Fixing popup promo image size

### DIFF
--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -997,13 +997,14 @@
     flex-direction: row;
   }
 
+  .aside.promobar .foreground.container .icon-area,
+  .aside.promobar .foreground.container .icon-area img {
+    height: var(--icon-size-xxl);
+  }
+
   .aside.promobar.popup .promo-text .icon-area,
   .aside.promobar.popup .promo-text .icon-area img {
     height: var(--icon-size-m);
-  }
-
-  .aside.promobar .foreground.container .icon-area img {
-    height: var(--icon-size-xxl);
   }
 
   .aside.center:not(.notification) .foreground.container .text .icon-area img {
@@ -1063,10 +1064,6 @@
 
   .aside.notification.medium .foreground.container .text+.image {
     margin-right: 0;
-  }
-
-  .aside.promobar .foreground.container .icon-area {
-    height: var(--icon-size-xxl);
   }
 
   .aside.promobar .promo-text .content-area {


### PR DESCRIPTION
With rearrangement of CSS in https://github.com/adobecom/milo/pull/1470 the promoaside icon styles are overriding promoaside popup variant icon styles. Fixing the css to prioritize popup style for popup promo.

Resolves: [MWPW-138921](https://jira.corp.adobe.com/browse/MWPW-138921)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/mathuria/promobar/popuppromo?martech=off
- After: https://mwpw-138921--milo--aishwaryamathuria.hlx.page/drafts/mathuria/promobar/popuppromo?martech=off
