### PR TITLE
MWPW-138197 Fix Adobe Logo on Safari

### DIFF
--- a/libs/blocks/gnav/gnav.css
+++ b/libs/blocks/gnav/gnav.css
@@ -1183,6 +1183,10 @@ header .app-launcher {
     box-sizing: border-box;
   }
 
+  .gnav .gnav-logo svg {
+    width: 25px;
+  }
+
   /* Search Bar */
   .gnav-search.is-open .gnav-search-bar {
     position: fixed;

--- a/libs/blocks/gnav/gnav.css
+++ b/libs/blocks/gnav/gnav.css
@@ -1184,7 +1184,7 @@ header .app-launcher {
   }
 
   .gnav .gnav-logo svg {
-    width: 25px;
+    width: 100%;
   }
 
   /* Search Bar */


### PR DESCRIPTION
* Fix issue: Adobe icon on right in gnav (old version) wasn't displaying on Safari v15-17.

Resolves: [MWPW-138197](https://jira.corp.adobe.com/browse/MWPW-138197)

**Test URLs:**
Milo:
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/text-center?headerqa=gnav&footerqa=gnav&martech=off
- After: https://methomas-adobe-logo--milo--adobecom.hlx.page/drafts/methomas/text-center?headerqa=gnav&footerqa=gnav&martech=off

Bacom blog:
- Before: https://main--bacom-blog--adobecom.hlx.page/blog/tags/the-latest
- After: https://main--bacom-blog--adobecom.hlx.page/blog/tags/the-latest?milolibs=methomas-adobe-logo

*Reminder, this is only reproducible on Safari v15-17
