### PR TITLE
MWPW-139127 - Relative Fragment Media

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -47,6 +47,16 @@ const insertInlineFrag = (sections, a) => {
   }
 };
 
+function replaceDotMedia(path, doc) {
+  const resetAttributeBase = (tag, attr) => {
+    doc.querySelectorAll(`${tag}[${attr}^="./media_"]`).forEach((el) => {
+      el[attr] = new URL(el.getAttribute(attr), new URL(path, window.location)).href;
+    });
+  };
+  resetAttributeBase('img', 'src');
+  resetAttributeBase('source', 'srcset');
+}
+
 export default async function init(a) {
   const { expFragments } = getConfig();
   let relHref = localizeLink(a.href);
@@ -72,6 +82,8 @@ export default async function init(a) {
 
   const html = await resp.text();
   const doc = new DOMParser().parseFromString(html, 'text/html');
+  replaceDotMedia(a.href, doc);
+
   const sections = doc.querySelectorAll('body > div');
 
   if (!sections.length) {

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -58,4 +58,11 @@ describe('Fragments', () => {
     expect(cols.querySelector('.aside').style.background).to.equal('rgb(238, 238, 238)');
     expect(cols.innerHTML.includes('Hello World!!!')).to.be.true;
   });
+
+  it('Makes media relative to fragment', async () => {
+    const section = document.querySelector('.default-section');
+    await loadArea(section);
+    expect(section.querySelector('source[srcset^="http://localhost:2000/test/blocks/fragment/mocks/fragments/media_15"]')).to.exist;
+    expect(section.querySelector('img[src^="http://localhost:2000/test/blocks/fragment/mocks/fragments/media_15"]')).to.exist;
+  });
 });

--- a/test/blocks/fragment/mocks/body.html
+++ b/test/blocks/fragment/mocks/body.html
@@ -30,4 +30,9 @@
     </div>
   </div>
 </div>
+<div class="default-section">
+  <div>
+    <p><a href="/test/blocks/fragment/mocks/fragments/media">./fragments/media</a></p>
+  </div>
+</div>
 </div>

--- a/test/blocks/fragment/mocks/fragments/media.plain.html
+++ b/test/blocks/fragment/mocks/fragments/media.plain.html
@@ -1,0 +1,8 @@
+<div>
+  <picture>
+    <source type="image/webp" srcset="./media_15.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+    <source type="image/webp" srcset="./media_15.png?width=750&#x26;format=webply&#x26;optimize=medium">
+    <source type="image/png" srcset="./media_15.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+    <img loading="lazy" alt="" src="./media_15.png?width=750&#x26;format=png&#x26;optimize=medium" width="1011" height="1098">
+  </picture>
+</div>


### PR DESCRIPTION
* Make media URLs relative to fragment path

Resolves: [MWPW-139127](https://jira.corp.adobe.com/browse/MWPW-139127)

## Test URLs

**Milo Test URLs:**
- [Before](https://main--milo--adobecom.hlx.page/drafts/cmillar/fragment-media?martech=off)
- [After](https://fragment-media--milo--adobecom.hlx.page/drafts/cmillar/fragment-media?martech=off)

**College Test URLs:**
- [Before](https://main--milo-college--adobecom.hlx.page/lcp-fragment-test?martech=off)
- [After](https://main--milo-college--adobecom.hlx.page/lcp-fragment-test?milolibs=fragment-media&martech=off)

**Bacom Test URLs:**
- [Before](https://main--bacom--adobecom.hlx.live/?martech=off)
- [After](https://main--bacom--adobecom.hlx.live/?milolibs=fragment-media&martech=off)

**DC / 404 Page Test URLs:**
- [Before](https://main--dc--adobecom.hlx.live/acrobat?martech=off)
- [After](https://main--dc--adobecom.hlx.live/acrobat?milolibs=fragment-media&martech=off)

**Homepage Test URLs:**
- [Before](https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off)
- [After](https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?milolibs=fragment-media&martech=off)

## How to test

### Before
1. Open network tab and search / filter for "fragments"
2. Observe there **are no** media_ requests to images.

<img width="1039" alt="Screenshot 2023-11-10 at 3 28 26 PM" src="https://github.com/adobecom/milo/assets/1972095/2fb00bd1-17ae-4a36-adca-6c7dbd286f5d">

### After
1. Open network tab and search / filter for "fragments"
2. Observe there **are** media_ requests to images.
3. Observe media_ requests are relative to the fragment

<img width="1223" alt="Screenshot 2023-11-10 at 3 28 14 PM" src="https://github.com/adobecom/milo/assets/1972095/0ac165f6-d515-4d1e-b959-a8eee5502902">


