### PR TITLE
MWPW-139129: Quiz errors when no matchedResults

### DIFF
--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -84,16 +84,18 @@ export const findAndStoreResultData = async (answers = []) => {
     primaryProductCodes = resultData.primary;
     secondaryProductCodes = resultData.secondary;
     umbrellaProduct = resultData.matchedResults[0]['umbrella-result'];
+    storeResultInLocalStorage(
+      answers,
+      resultData,
+      resultResources,
+      primaryProductCodes,
+      secondaryProductCodes,
+      umbrellaProduct,
+    );
+  } else {
+    window.lana?.log(`ERROR: No results found for ${answers}`);
   }
 
-  storeResultInLocalStorage(
-    answers,
-    resultData,
-    resultResources,
-    primaryProductCodes,
-    secondaryProductCodes,
-    umbrellaProduct,
-  );
   return {
     destinationPage,
     primaryProductCodes,
@@ -108,9 +110,9 @@ export const storeResultInLocalStorage = (
   secondaryProductCodes,
   umbrellaProduct,
 ) => {
-  const nestedFragsPrimary = resultData.matchedResults[0]['nested-fragments-primary'];
-  const nestedFragsSecondary = resultData.matchedResults[0]['nested-fragments-secondary'];
-  const structureFrags = resultData.matchedResults[0]['basic-fragments'];
+  const nestedFragsPrimary = resultData?.matchedResults?.[0]?.['nested-fragments-primary'] || '';
+  const nestedFragsSecondary = resultData?.matchedResults?.[0]?.['nested-fragments-secondary'] || '';
+  const structureFrags = resultData?.matchedResults?.[0]?.['basic-fragments'] || '';
 
   const structureFragsArray = structureFrags?.split(',');
   const nestedFragsPrimaryArray = nestedFragsPrimary?.split(',');

--- a/test/blocks/quiz/mocks/invalid-user-selection.json
+++ b/test/blocks/quiz/mocks/invalid-user-selection.json
@@ -1,0 +1,8 @@
+{
+  "selectedQuestion": {
+  "questions": "q-category",
+  "max-selections": "3",
+  "min-selections": "1"
+  },
+  "selectedCards": { "invalid-option": true }
+}

--- a/test/blocks/quiz/utils.test.js
+++ b/test/blocks/quiz/utils.test.js
@@ -151,6 +151,17 @@ describe('Quiz', () => {
     expect(structuredFrags).to.include('express');
   });
 
+  it('Testing result flow with invalid selections', async () => {
+    const selectionData = await readFile({ path: './mocks/invalid-user-selection.json' });
+    const selections = [];
+    selections[0] = JSON.parse(selectionData);
+    const { destinationPage, primaryProductCodes } = await findAndStoreResultData(
+      transformToFlowData(selections),
+    );
+    expect(destinationPage).to.be.an('string');
+    expect(primaryProductCodes).to.be.an('array').of.length(0);
+  });
+
   it('Testing result flow', async () => {
     const { destinationPage, primaryProductCodes } = await findAndStoreResultData(
       transformToFlowData(userSelection),
@@ -182,8 +193,31 @@ describe('Quiz', () => {
     expect(flowData).to.be.an('array').of.length(5);
   });
 
+  it('Testing storeResultInLocalStorage with empty results', async () => {
+    const resultResourcesData = await readFile({ path: './mocks/result-resources.json' });
+    const resultResources = JSON.parse(resultResourcesData);
+    const primaryProducts = [];
+    const secondaryProductCodes = [];
+    const umbrellaProduct = '';
+    const pageLoad = 'type=cc:app-reco&quiz=uarv3&selectedOptions=q-category/photo/video|q-rather/custom|q-photo/organize|q-video/social|q-customer/individual';
+    const resultToDelegate = storeResultInLocalStorage(
+      answers,
+      resultData,
+      resultResources,
+      primaryProducts,
+      secondaryProductCodes,
+      umbrellaProduct,
+    );
+    expect(resultToDelegate).to.be.an('object');
+    expect(resultToDelegate).to.haveOwnProperty('primaryProducts').to.be.an('array').of.length(0);
+    expect(resultToDelegate).to.haveOwnProperty('secondaryProducts').to.be.an('array').of.length(0);
+    expect(resultToDelegate).to.haveOwnProperty('umbrellaProduct').to.eq(umbrellaProduct);
+    expect(resultToDelegate).to.haveOwnProperty('pageloadHash').to.eq(pageLoad);
+  });
+
   it('Testing storeResultInLocalStorage', async () => {
-    const resultResources = await readFile({ path: './mocks/result-resources.json' });
+    const resultResourcesData = await readFile({ path: './mocks/result-resources.json' });
+    const resultResources = JSON.parse(resultResourcesData);
     const primaryProducts = [
       'lr-ind',
       'pr-ind',
@@ -192,10 +226,20 @@ describe('Quiz', () => {
       'ps-ind',
       'au-ind',
     ];
-    const resultToDelegate = storeResultInLocalStorage(answers, resultData, JSON.parse(resultResources), primaryProducts, secondaryProductCodes, 'cc');
+    const umbrellaProduct = 'cc';
+    const pageLoad = 'type=cc:app-reco&quiz=uarv3&selectedOptions=q-category/photo/video|q-rather/custom|q-photo/organize|q-video/social|q-customer/individual';
+    const resultToDelegate = storeResultInLocalStorage(
+      answers,
+      resultData,
+      resultResources,
+      primaryProducts,
+      secondaryProductCodes,
+      umbrellaProduct,
+    );
     expect(resultToDelegate).to.be.an('object');
-    expect(resultToDelegate).to.haveOwnProperty('umbrellaProduct').eq('cc');
     expect(resultToDelegate).to.haveOwnProperty('primaryProducts').include('lr-ind');
     expect(resultToDelegate).to.haveOwnProperty('secondaryProducts').include('ps-ind');
+    expect(resultToDelegate).to.haveOwnProperty('umbrellaProduct').to.eq(umbrellaProduct);
+    expect(resultToDelegate).to.haveOwnProperty('pageloadHash').to.eq(pageLoad);
   });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* If you follow a quiz path that doesn't match any results, you'll see an error in storeResultInLocalStorage errors when no matchedResults are found. I'm checking to see whether matchedResults[0] exists before dereferencing it to look for basic and nested fragments.

Resolves: [MWPW-139129](https://jira.corp.adobe.com/browse/MWPW-139129)

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.page/drafts/quiz/quiz-2/?martech=off
- After: https://uar-integration--milo--echampio-at-adobe.hlx.page/drafts/quiz/quiz-2/?martech=off
