### PR TITLE
[MWPW-136943] Colorful Gnav headings for A/B test

### DIFF
--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -64,22 +64,26 @@
   color: var(--feds-color-link--light);
 }
 
-.feds-navLink--hoverCaret:after {
-  position: absolute;
-  right: 18px;
-  top: 50%;
+.feds-navLink--hoverCaret:after,
+.feds-navLink[class *= '-gradient'] .feds-navLink-title:after {
   display: flex;
-  width: 6px;
-  height: 6px;
-  margin-top: -3px;
   border-width: 0 1px 1px 0;
   border-style: solid;
   border-color: var(--feds-color-link--light);
   transform-origin: 75% 75%;
-  transform: rotateZ(45deg);
   transition: transform 0.1s ease;
-  content: "";
   box-sizing: content-box;
+}
+
+.feds-navLink--hoverCaret:after {
+  position: absolute;
+  right: 18px;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  margin-top: -3px;
+  transform: rotateZ(45deg);
+  content: "";
 }
 
 [dir = "rtl"] .feds-navLink--hoverCaret {
@@ -95,6 +99,11 @@
 .feds-navLink-image,
 .feds-navLink-description {
   display: none;
+}
+
+.feds-navLink-title {
+  display: flex;
+  align-items: center;
 }
 
 /* Desktop styles */
@@ -176,8 +185,24 @@
     margin-top: 12px;
   }
 
+  .feds-navLink[class *= '-gradient'] .feds-navLink-title {
+    column-gap: 4px;
+  }
+
   .feds-navLink[class *= '-gradient'] .feds-navLink-title:after {
-    content: ' ›';
+    width: 4px;
+    height: 4px;
+    transform: rotate(-45deg);
+    content: '';
+  }
+
+  [dir = "rtl"] .feds-navLink[class *= '-gradient'] .feds-navLink-title:after {
+    transform: rotate(135deg);
+  }
+
+  .feds-navLink[class *= '-gradient']:hover .feds-navLink-title:after,
+  .feds-navLink[class *= '-gradient']:focus .feds-navLink-title:after {
+    border-color: var(--feds-color-link--hover--light);
   }
 
   .feds-navLink--photo-gradient {

--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -152,7 +152,8 @@
   }
 
   .feds-navLink-image picture {
-    width: 25px;
+    width: max-content;
+    max-width: 25px;
   }
 
   .feds-navLink-description {
@@ -164,5 +165,42 @@
   .feds-navLink:hover .feds-navLink-description,
   .feds-navLink:focus .feds-navLink-description {
     color: var(--feds-color-navLink-description--light);
+  }
+
+  /* Nav Link special styles for A/B test */
+  .feds-navLink[class *= '-gradient'] {
+    border-radius: 4px;
+  }
+
+  .feds-navLink[class *= '-gradient']:not(:first-child) {
+    margin-top: 12px;
+  }
+
+  .feds-navLink[class *= '-gradient'] .feds-navLink-title:after {
+    content: ' ›';
+  }
+
+  .feds-navLink--photo-gradient {
+    background: linear-gradient(90deg, #d0e8fa, #cef4f4);
+  }
+
+  .feds-navLink--design-gradient {
+    background: linear-gradient(90deg, #fccbfc, #ffe9d0);
+  }
+
+  .feds-navLink--3d-gradient {
+    background: linear-gradient(90deg, #e1f5cb, #edefb5);
+  }
+
+  .feds-navLink--pdf-gradient {
+    background: linear-gradient(90deg, #ffbfbf, #fde6d3);
+  }
+
+  .feds-navLink--video-gradient {
+    background: linear-gradient(90deg, #dcd9ff, #d5f1fd);
+  }
+
+  .feds-navLink--ai-gradient {
+    background: linear-gradient(90deg, #bce3ff, #ffe9d3, #f8d5e4);
   }
 }

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -520,7 +520,6 @@ header.global-navigation {
     position: absolute;
     top: 100%;
     left: 0;
-    padding: 0;
     z-index: 1;
     box-shadow: 0 3px 3px 0 rgb(0 0 0 / 20%);
     transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */
@@ -543,7 +542,7 @@ header.global-navigation {
   .feds-navItem--megaMenu .feds-popup {
     right: 0;
     justify-content: center;
-    padding: 20px 0;
+    padding: 32px 0;
   }
 
   [dir = "rtl"] .feds-navItem--megaMenu .feds-popup {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -542,7 +542,7 @@ header.global-navigation {
   .feds-navItem--megaMenu .feds-popup {
     right: 0;
     justify-content: center;
-    padding: 32px 0;
+    padding: 32px 12px;
   }
 
   [dir = "rtl"] .feds-navItem--megaMenu .feds-popup {

--- a/libs/blocks/global-navigation/utilities/keyboard/utils.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/utils.js
@@ -4,7 +4,7 @@ const selectors = {
   ...baseSelectors,
   globalFooter: '.global-footer',
   mainNavItems:
-    '.feds-navItem > a, .feds-navItem > .feds-cta-wrapper > .feds-cta',
+    '.feds-navItem > a, .feds-navItem > button, .feds-navItem > .feds-cta-wrapper > .feds-cta',
   brand: '.feds-brand',
   mainNavToggle: '.feds-toggle',
   searchTrigger: '.feds-search-trigger',
@@ -23,7 +23,7 @@ const selectors = {
   popup: '.feds-popup',
   headline: '.feds-menu-headline',
   section: '.feds-menu-section',
-  column: '.feds-menu-column',
+  column: '.feds-menu-column:not(.feds-menu-column--group)',
   cta: '.feds-cta',
   openSearch: '.feds-search-trigger[aria-expanded = "true"]',
   regionPicker: '.feds-regionPicker',

--- a/libs/blocks/global-navigation/utilities/menu/menu.css
+++ b/libs/blocks/global-navigation/utilities/menu/menu.css
@@ -30,10 +30,16 @@
   padding: 12px 0;
 }
 
+.feds-menu-column--group .feds-menu-column:not(:last-child) {
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--feds-borderColor-menu--light);
+}
+
 .feds-menu-headline {
   position: relative;
   padding: 12px 44px 12px 32px;
-  border-bottom: solid 1px var(--feds-borderColor-menu--light);
+  border-bottom: 1px solid var(--feds-borderColor-menu--light);
   color: var(--feds-color-headline--light);
   font-weight: 600;
   white-space: nowrap;
@@ -84,8 +90,19 @@
     max-width: var(--feds-maxWidth-nav);
   }
 
-  .feds-menu-column {
-    padding: 12px 0;
+  .feds-navItem--section .feds-menu-content {
+    column-gap: 12px;
+  }
+
+  .feds-menu-column--wide {
+    flex-grow: 1;
+    max-width: 75%;
+  }
+
+  .feds-menu-column--group .feds-menu-column:not(:last-child) {
+    margin-bottom: 0;
+    padding-bottom: 0;
+    border-bottom: none;
   }
 
   .feds-menu-section + .feds-menu-section {
@@ -101,6 +118,10 @@
   .feds-menu-headline,
   [dir = "rtl"] .feds-menu-headline {
     padding: 12px 0;
+  }
+
+  .global-navigation .feds-menu-headline {
+    margin-bottom: 12px;
   }
 
   .feds-menu-headline:after {

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -11,6 +11,7 @@ import longNav from './mocks/global-navigation-long.plain.js';
 import noLogoBrandOnlyNav from './mocks/global-navigation-only-brand-no-image.plain.js';
 import noBrandImageOnlyNav from './mocks/global-navigation-only-brand-no-explicit-image.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
+import globalNavigationWideColumnMock from './mocks/global-navigation-wide-column.plain.js';
 
 const ogFetch = window.fetch;
 
@@ -421,6 +422,12 @@ describe('global navigation', () => {
 
         const hasLinkgroupModifier = document.querySelector(`${selectors.navLink}--blue`) instanceof HTMLElement;
         expect(hasLinkgroupModifier).to.equal(true);
+      });
+
+      it('should render popups with wide columns', async () => {
+        await createFullGlobalNavigation({ globalNavigation: globalNavigationWideColumnMock });
+        expect(document.querySelector('.feds-navItem--section .feds-menu-column--group .feds-menu-column + .feds-menu-column')).to.exist;
+        expect(document.querySelector('.column-break')).to.not.exist;
       });
 
       it('should render the promo', async () => {

--- a/test/blocks/global-navigation/mocks/global-navigation-wide-column.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-wide-column.plain.js
@@ -1,0 +1,285 @@
+// Uses the franklin structure without any customizations
+export default `<div>
+  <div class="gnav-brand logo">
+    <div>
+      <div>
+        <p>
+          <a href="http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg">
+            http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg
+          </a>
+        </p>
+        <p><a href="https://www.adobe.com/">Adobe</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <div class="large-menu section">
+    <div>
+      <div>
+        <h2 id="cloud-menu">
+          <a href="/large-menu-wide-column">Cloud Menu</a>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <h2 id="w-promo"><a href="https://business.adobe.com/">w/ Promo</a></h2>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/topics/creativity.html#_blank"
+        >Creativity</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+        >Digital Transformation</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/trends--research.html"
+        >Trends &#x26; Research</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/future-of-work.html"
+        >Future Of Work</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/leadership.html">Leadership</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/customer-stories.html"
+        >Customer Stories</a
+      >
+    </li>
+    <li><a href="https://blog.adobe.com/en/topics/events.html">Events</a></li>
+  </ul>
+  <div class="gnav-promo dark">
+    <div>
+      <div>
+        <p><strong>Business Resilience: Leading Through Change</strong></p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas
+          porttitor congue massa.
+        </p>
+        <p><a href="https://adobe.com/">Check it out</a></p>
+      </div>
+    </div>
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+            width="215"
+            height="121"
+          />
+        </picture>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <h2 id="col">2 Col</h2>
+  <h5 id="column-1-heading">Column 1 heading</h5>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/creativity.html">Creativity</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+        >Digital Transformation</a
+      >
+    </li>
+  </ul>
+  <div class="link-group blue">
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >What is Creative Cloud?</a
+          >
+        </p>
+        <p>Creative apps and services for everyone</p>
+      </div>
+    </div>
+  </div>
+  <h5 id="column-2-heading">Column 2 heading</h5>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/future-of-work.html"
+        >Future Of Work</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/leadership.html">Leadership</a>
+    </li>
+  </ul>
+  <p>
+    <em><a href="https://blog.adobe.com/en/topics/events.html">Events</a></em>
+  </p>
+</div>
+<div>
+  <h2 id="col-1"><a href="https://business.adobe.com/">1 col</a></h2>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/creativity.html">Creativity</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+        >Digital Transformation</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/trends--research.html"
+        >Trends &#x26; Research</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/future-of-work.html"
+        >Future Of Work</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/leadership.html">Leadership</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/customer-stories.html"
+        >Customer Stories</a
+      >
+    </li>
+    <li><a href="https://blog.adobe.com/en/topics/events.html">Events</a></li>
+  </ul>
+</div>
+<div>
+  <p>
+    <strong
+      ><a href="https://helpx.adobe.com/#open-jarvis-chat">Primary</a></strong
+    >
+  </p>
+</div>
+<div>
+  <p>
+    <em
+      ><a href="http://localhost:6456/drafts/ramuntea/gnav-refactor"
+        >Secondary</a
+      ></em
+    >
+  </p>
+</div>
+<div>
+  <h2 id="random-text">Random text</h2>
+</div>
+<div>
+  <h2 id="no-dropdown"><a href="https://www.adobe.com/">No Dropdown</a></h2>
+</div>
+<div>
+  <div class="search">
+    <div>
+      <div>
+        <p>Search</p>
+        <p>Search</p>
+      </div>
+    </div>
+  </div>
+  <div class="profile">
+    <div>
+      <div>
+        <h5 id="local-menu-title">Local Menu Title</h5>
+        <p>
+          <a href="https://blog.adobe.com/en/topics/creativity.html"
+            >Creativity</a
+          >
+        </p>
+        <p>
+          <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+            >Digital Transformation</a
+          >
+        </p>
+        <p>
+          <a href="https://blog.adobe.com/en/topics/trends--research.html"
+            >Trends &#x26; Research</a
+          >
+        </p>
+      </div>
+    </div>
+    <div>
+      <div>
+        <ul>
+          <li>
+            <a href="https://experiencecloud.adobe.com/exc-content/login.html"
+              >Experience Cloud</a
+            >
+          </li>
+          <li>
+            <a href="https://account.magento.com/customer/account/login"
+              >Commerce (Magento)</a
+            >
+          </li>
+          <li><a href="https://login.marketo.com/">Marketo Engage</a></li>
+          <li>
+            <a href="https://business.adobe.com/products/workfront/login.html"
+              >Workfront</a
+            >
+          </li>
+          <li><a href="https://adobe.com?sign-in=true">Adobe Account</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="app-launcher">
+    <div>
+      <div><a href="/gnav/app-launcher">App Launcher</a></div>
+    </div>
+  </div>
+  <div class="adobe-logo">
+    <div>
+      <div><a href="https://www.adobe.com/">Adobe</a></div>
+    </div>
+  </div>
+</div>`;

--- a/test/blocks/global-navigation/mocks/large-menu-wide-column.plain.js
+++ b/test/blocks/global-navigation/mocks/large-menu-wide-column.plain.js
@@ -1,0 +1,377 @@
+// Uses the franklin structure without any customizations
+export default `
+<div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >What is Creative Cloud?</a
+          >
+        </p>
+        <p>Creative apps and services for everyone</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Photographers</a
+          >
+        </p>
+        <p>Lightroom, Photoshop, and more</p>
+      </div>
+    </div>
+  </div>
+  <h5 id="test-heading">Test heading</h5>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Students and Teachers</a
+          >
+        </p>
+        <p>Save over 60% on Creative Cloud</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Small and medium business</a
+          >
+        </p>
+        <p>Creative apps and services for teams</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Enterprise</a
+          >
+        </p>
+        <p>Solutions for large organizations</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <a href="https://business.adobe.com/what-is-experience-cloud.html"
+          >No subtitle</a
+        >
+      </div>
+    </div>
+  </div>
+  <p>
+    <a href="https://www.adobe.com/creativecloud/plans.html"
+      >View plans and pricing</a
+    >
+  </p>
+  <p>
+    <a href="https://www.adobe.com/creativecloud/plans.html"
+      >And another link</a
+    >
+  </p>
+</div>
+<div>
+  <h5 id="featured-products">Featured products</h5>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Photoshop</a
+          >
+        </p>
+        <p>Image editing and design</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Lightroom</a
+          >
+        </p>
+        <p>The cloud-based photo service</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Illustrator</a
+          >
+        </p>
+        <p>Vector graphics and illustration</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Premiere Pro</a
+          >
+        </p>
+        <p>Video editing and production</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Adobe Acrobat</a
+          >
+        </p>
+        <p>The complete PDF solution</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Adobe Stock</a
+          >
+        </p>
+        <p>High-quality licensable assets</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <a href="https://business.adobe.com/what-is-experience-cloud.html"
+          >No subtitle</a
+        >
+      </div>
+    </div>
+  </div>
+  <p>
+    <strong
+      ><a href="https://business.adobe.com/what-is-experience-cloud.html"
+        >View all Creative Cloud products</a
+      ></strong
+    >
+  </p>
+  <div class="column-break"></div>
+  <ul>
+    <li><a href="http://google.com/">Photo</a></li>
+    <li><a href="http://google.com/">Graphic design</a></li>
+    <li><a href="http://google.com/">Video</a></li>
+    <li><a href="http://google.com/">Illustration</a></li>
+    <li><a href="http://google.com/">UI and UX</a></li>
+    <li><a href="http://google.com/">Social media</a></li>
+    <li><a href="http://google.com/">3D and AR</a></li>
+  </ul>
+</div>
+<div>
+  <div class="gnav-promo image-only">
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=2000&format=webply&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=750&format=png&optimize=medium"
+            width="375"
+            height="514"
+          />
+        </picture>
+      </div>
+    </div>
+    <div>
+      <div><a href="https://www.adobe.com/">https://www.adobe.com/</a></div>
+    </div>
+  </div>
+</div>
+`;

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -3,14 +3,11 @@
 import sinon, { stub } from 'sinon';
 import { setViewport } from '@web/test-runner-commands';
 import initGnav from '../../../libs/blocks/global-navigation/global-navigation.js';
-import {
-  getLocale,
-  setConfig,
-  loadStyle,
-} from '../../../libs/utils/utils.js';
+import { getLocale, setConfig, loadStyle } from '../../../libs/utils/utils.js';
 import defaultPlaceholders from './mocks/placeholders.js';
 import defaultProfile from './mocks/profile.js';
 import largeMenuMock from './mocks/large-menu.plain.js';
+import largeMenuWideColumnMock from './mocks/large-menu-wide-column.plain.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
 import correctPromoFragmentMock from './mocks/correctPromoFragment.plain.js';
 import { isElementVisible, selectors as keyboardSelectors } from '../../../libs/blocks/global-navigation/utilities/keyboard/utils.js';
@@ -131,6 +128,7 @@ export const createFullGlobalNavigation = async ({
     if (url.includes('profile')) { return mockRes({ payload: defaultProfile }); }
     if (url.includes('placeholders')) { return mockRes({ payload: placeholders || defaultPlaceholders }); }
     if (url.endsWith('large-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
+    if (url.endsWith('large-menu-wide-column.plain.html')) { return mockRes({ payload: largeMenuWideColumnMock }); }
     if (url.includes('gnav')) { return mockRes({ payload: globalNavigation || globalNavigationMock }); }
     if (url.includes('correct-promo-fragment')) { return mockRes({ payload: correctPromoFragmentMock }); }
     if (url.includes('wrong-promo-fragment')) { return mockRes({ payload: '<div>Non-promo content</div>' }); }


### PR DESCRIPTION
## Description
This enables authors to add gradient backgrounds to _Link Group_ blocks in Gnav navigation documents. This is needed to support an upcoming UI A/B test for the Creativity & Design dropdown menu content. Considering this, we've implemented a minimal set of changes; the features will be expanded or completely removed depending on the test outcome. A few notes, in order of files:

- gradient backgrounds can be added by using some special class names. Since we don't know whether this feature has a future, we didn't yet want to enable authors to define any background possibility on their own. The class names are defined based on the proposed design and which elements require the gradient backgrounds: `photo-gradient, design-gradient, 3d-gradient, pdf-gradient, video-gradient, ai-gradient`. I've added the design specs below;
- the selectors for the Keyboard Navigation have been slightly updated. Some anchor elements were switched to buttons in a previous PR, but the change wasn't reflected in the Keyboard Navigation logic as well. This was affecting production behaviour;
- some padding and margin values have been updated to ensure a more consistent layout across all of the dropdown content use cases;
- the `75%` for wide columns has been chosen with the following logic: only if the section contains 3 columns does it get the `--wide` modifier. In the mega menu dropdown we usually have 4 columns, so 75% has been chosen to reflect this. We should not have all 4 columns nested under a single headline, since it would be redundant, given that we have the dropdown trigger above. If this feature is a winner, we'll likely need to get back to it and refine it to fit all of the possible use-cases. Without this 75% limitation, the design looks too stretched and strays away from the suggested specs;
- a new _Column Break_ block has been created to separate the content of a column in multiple sections. This is needed to be able to group multiple columns under a single headline. In the design spec below, 3 columns are nested under a single _Featured Products_ headline. We wanted to avoid nesting tables and over-fragmentising content, so this is the best compromise in the context of an A/B test;

<img width="1121" alt="Screenshot 2023-09-29 at 12 35 13 PM" src="https://github.com/adobecom/milo/assets/11267498/61f7d8bf-f87a-4a9c-839e-f6a22c39a33d">

## Related Issue
Resolves: [MWPW-136943](https://jira.corp.adobe.com/browse/MWPW-136943)

## Testing instructions
Just open the **first** dropdown and notice the colourful headings on desktop devices.

## Screenshots:
<img width="1482" alt="Screenshot 2023-11-14 at 14 46 24" src="https://github.com/adobecom/milo/assets/11267498/200644d7-a73d-47b4-89c5-3616550557b8">

## Test URLs
**Homepage:**
- Before: https://main--homepage--adobecom.hlx.page/drafts/ramuntea/index-regular?martech=off
- After: https://main--homepage--adobecom.hlx.page/drafts/ramuntea/index-colorful?milolibs=gnav-colorful-headings--milo--overmyheadandbody&martech=off

**CC:**
- Before: https://main--cc--adobecom.hlx.page/drafts/ramuntea/discover?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/ramuntea/discover-colourful?milolibs=gnav-colorful-headings--milo--overmyheadandbody&martech=off

**Milo:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?maretch=off
- After: https://gnav-colorful-headings--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor-colourful?martech=off