### PR TITLE
Support for prod non milo environment

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -489,7 +489,7 @@ const fetchUuidForCard = async (card) => {
   }
   try {
     const url = new URL(card.contentId);
-    const localizedLink = localizeLink(url, window.location.hostname, true);
+    const localizedLink = localizeLink(url, null, true);
     const substr = String(localizedLink).split('https://').pop();
     return await getUuid(substr);
   } catch (error) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

localizeLink API that doesn't correctly work, on prod bacom pages. Adjusted the call to the API to make it work.

Some more information on this issue solution can be found here: 
https://wiki.corp.adobe.com/pages/viewpage.action?pageId=2932205920

The logic is as follows:

1. Fully Qualified URL: --> Localize Link --> getUUID --> Call Chimera IO
2. UUID --> Call Chimera IO

![Screenshot 2023-11-14 at 2 40 51 PM](https://github.com/adobecom/milo/assets/131935409/72a046ce-aa0c-492e-84f2-cae53215f31f)


Resolves: [MWPW-133011](https://jira.corp.adobe.com/browse/MWPW-133011)

For the prod test URLs please enable local overrides to test
**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/shkhan/mwpw-132559?martech=off
- Before: https://business.adobe.com/mena_en/request-consultation/thankyou.html?martech=off
- After: https://shkhan-featured-mwpw-133011--milo--shkhan91.hlx.page/drafts/shkhan/mwpw-132559?martech=off
- After: https://business.adobe.com/mena_en/request-consultation/thankyou.html?martech=off
