### PR TITLE
MWPW-139338: mocked ims for gnav.js unit tests

### DIFF
--- a/test/blocks/gnav/gnav.test.js
+++ b/test/blocks/gnav/gnav.test.js
@@ -20,6 +20,19 @@ const config = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } }, imsClien
 setConfig(config);
 
 describe('Gnav', () => {
+  before(() => {
+    window.adobeid = {
+      client_id: 'milo',
+      scope: 'gnav',
+    };
+    window.adobeIMS = { getAccessToken: () => false };
+  });
+
+  after(() => {
+    delete window.adobeid;
+    delete window.adobeIMS;
+  });
+
   beforeEach(() => {
     sinon.spy(console, 'log');
   });
@@ -30,6 +43,7 @@ describe('Gnav', () => {
 
   it('test wrong gnav', async () => {
     gnav = await mod.default(document.querySelector('header'));
+    window.adobeid.onReady();
     expect(gnav).to.be.not.null;
   });
 

--- a/test/blocks/gnav/mocks/head.html
+++ b/test/blocks/gnav/mocks/head.html
@@ -1,2 +1,3 @@
 <meta name="gnav-source" content="/test/blocks/gnav/mocks/gnav">
 <link rel="stylesheet" href="/libs/blocks/gnav/gnav.css">
+<script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>


### PR DESCRIPTION
## Description
This helps mocking Adobe IMS script for the `gnav.js` unit tests

## Testing instructions
run `npm run test` in your terminal

## Test URLs
**Acrobat:**
- Before: https://main--dc--adobecom.hlx.page/drafts/rbogos/default?martech=off
- After: https://main--dc--adobecom.hlx.page/drafts/rbogos/default?milolibs=mwpw-138031-footer-tests--milo--rbogos&martech=off

**BACOM:**
- Before: https://main--bacom--adobecom.hlx.page/drafts/rbogos/default
- After: https://main--bacom--adobecom.hlx.page/drafts/rbogos/default?milolibs=mwpw-138031-footer-tests--milo--rbogos&martech=off

**CC:**
- Before: https://main--cc--adobecom.hlx.page/drafts/rbogos/default?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/rbogos/default?milolibs=mwpw-138031-footer-tests--milo--rbogos&martech=off

**Milo:**
- Before: https://main--milo--robert-bogos.hlx.page/drafts/rbogos/default?martech=off
- After: https://gnav-unit-tests--milo--robert-bogos.hlx.page/drafts/rbogos/default?martech=off