### PR TITLE
[MWPW-139201] Allow CTAs in Gnav Promo boxes

### DIFF
--- a/libs/blocks/global-navigation/utilities/menu/menu.css
+++ b/libs/blocks/global-navigation/utilities/menu/menu.css
@@ -171,15 +171,25 @@
   .feds-promo div {
     display: flex;
     flex-direction: column;
-    row-gap: 8px;
+    row-gap: 12px;
   }
 
   .feds-promo .feds-promo-image {
     padding: 0;
   }
 
+  .feds-promo .feds-cta-wrapper {
+    padding: 0;
+    align-items: flex-start;
+  }
+
+  .feds-promo a.feds-cta,
+  .feds-promo a.feds-cta:hover {
+    text-decoration: none;
+  }
+
   .feds-promo--dark,
-  .feds-promo--dark a {
+  .feds-promo--dark a:not(.feds-cta) {
     color: var(--feds-background-nav--light);
   }
 

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -86,7 +86,7 @@ const decorateLinkGroup = (elem, index) => {
   return linkGroup;
 };
 
-const decorateElements = ({ elem, className = 'feds-navLink', parseCtas = true, itemIndex = { position: 0 } } = {}) => {
+const decorateElements = ({ elem, className = 'feds-navLink', itemIndex = { position: 0 } } = {}) => {
   const decorateLink = (link) => {
     // Increase analytics index every time a link is decorated
     itemIndex.position += 1;
@@ -97,8 +97,7 @@ const decorateElements = ({ elem, className = 'feds-navLink', parseCtas = true, 
     }
 
     // If the link is wrapped in a 'strong' or 'em' tag, make it a CTA
-    if (parseCtas
-      && (link.parentElement.tagName === 'STRONG' || link.parentElement.tagName === 'EM')) {
+    if (link.parentElement.tagName === 'STRONG' || link.parentElement.tagName === 'EM') {
       const type = link.parentElement.tagName === 'EM' ? 'secondaryCta' : 'primaryCta';
       // Remove its 'em' or 'strong' wrapper
       link.parentElement.replaceWith(link);
@@ -135,7 +134,7 @@ const decoratePromo = (elem, index) => {
   const isImageOnly = elem.matches('.image-only');
   const imageElem = elem.querySelector('picture');
 
-  decorateElements({ elem, className: 'feds-promo-link', parseCtas: false, index });
+  decorateElements({ elem, className: 'feds-promo-link', index });
 
   const decorateImage = () => {
     const linkElem = elem.querySelector('a');

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -438,6 +438,11 @@ describe('global navigation', () => {
 
         expect(isElementVisible(document.querySelector(selectors.promoImage))).to.equal(true);
       });
+
+      it('should allow CTAs in Promo boxes', async () => {
+        await createFullGlobalNavigation();
+        expect(document.querySelector(`${selectors.promo}${selectors.promo}--dark ${selectors.cta}`)).to.exist;
+      });
     });
 
     describe('small desktop', () => {

--- a/test/blocks/global-navigation/mocks/global-navigation.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation.plain.js
@@ -65,7 +65,7 @@ export default `<div>
           Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas
           porttitor congue massa.
         </p>
-        <p><a href="https://adobe.com/">Check it out</a></p>
+        <p><strong><a href="https://adobe.com/">Check it out</a></strong></p>
       </div>
     </div>
     <div>

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -33,6 +33,7 @@ export const selectors = {
   searchClear: '.feds-search-clear',
   navWrapper: '.feds-nav-wrapper',
   popupItems: '.feds-menu-items',
+  promo: '.feds-promo',
   promoImage: '.feds-promo-image',
   topNavWrapper: '.feds-topnav-wrapper',
   breadcrumbsWrapper: '.feds-breadcrumbs-wrapper',


### PR DESCRIPTION
Original PR at https://github.com/adobecom/milo/pull/1548 created against the `stage` branch. Due to an unstable process, having to open this again against `main` until there's clarity on final branch approach, since there's an upcoming restricted change period.

## Description
Links wrapped in `strong` or `em` tags were not decorated when used inside Gnav Promo boxes, part of the main navigation dropdown menus. This is leading to inconsistencies between the Black Friday / Cyber Monday experiences between AEM and Milo pages.

Note that the `parseCtas` argument for the `decorateElements` function has been initially added to support the potential output of a script that transformed AEM Gnav content into Milo Gnav content. Since that path has not been pursued, the extra argument can be removed.

## Related Issue
Resolves: [MWPW-139201](https://jira.corp.adobe.com/browse/MWPW-139201)

## Testing instructions
On the homepage test link, open the _Creativity & Design_ dropdown. Notice the CTA being decorated inside the Promo box. Now open the _Help & Support_ dropdown, notice that nothing changes, as that link inside the Promo box hasn't been decorated as bold or italics.

On the Milo test link, open the _Cloud Menu_ dropdown. Notice the Promo box remains unchanged, as it doesn't contain any links. Open the _w/ Promo_ dropdown and notice the CTA being decorated inside the Promo box.

## Screenshots:
<img width="1475" alt="Screenshot 2023-11-16 at 15 25 20" src="https://github.com/adobecom/milo/assets/11267498/f75afaf8-ba27-4117-80d7-76490eaea511">

## Test URLs
**Homepage:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=allow-cta-in-gnav-promo--milo--overmyheadandbody

**Milo:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off
- After: https://allow-cta-in-gnav-promo--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor?martech=off