### PR TITLE
[Milo]TWP : TWP modal over Milo (Home) page is not auto re-sized

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -194,6 +194,17 @@
     padding-bottom: 0;
     height: 845px;
   }
+
+  .dialog-modal.commerce-frame.height-fit-content {
+    height: auto;
+    max-height: 850px;
+    min-width: 1000px;
+  }
+
+  .dialog-modal.commerce-frame.height-fit-content .milo-iframe {
+    height: auto;
+    max-height: 845px;
+  }
 }
 
 .disable-scroll {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -110,6 +110,29 @@ export async function sendViewportDimensionsOnRequest(messageInfo) {
   }
 }
 
+/** For the modal height adjustment to work the following conditions must be met:
+ * 1. The modal must have classes 'commerce-frame height-fit-content';
+ * 2. The iframe inside must send a postMessage with the contentHeight (a number of px or '100%);
+ */
+function adjustModalHeight(contentHeight) {
+  if (!contentHeight || !window.location.hash) return;
+  const dialog = document.querySelector(window.location.hash);
+  const iFrameWrapper = dialog?.querySelector('.milo-iframe.modal');
+  if (!iFrameWrapper) return;
+
+  if (contentHeight === '100%') {
+    iFrameWrapper.style.height = contentHeight;
+    dialog.style.height = contentHeight;
+  } else {
+    const verticalMargins = 20;
+    const clientHeight = document.documentElement.clientHeight - verticalMargins;
+    if (clientHeight <= 0) return;
+    const newHeight = contentHeight > clientHeight ? clientHeight : contentHeight;
+    iFrameWrapper.style.height = `${newHeight}px`;
+    dialog.style.height = `${newHeight}px`;
+  }
+}
+
 export async function getModal(details, custom) {
   if (!(details?.path || custom)) return null;
   const { id } = details || custom;
@@ -181,6 +204,9 @@ export async function getModal(details, custom) {
   if (dialog.classList.contains('commerce-frame')) {
     if (isInitialPageLoad) {
       window.addEventListener('message', (messageInfo) => {
+        if (dialog.classList.contains('height-fit-content')) {
+          adjustModalHeight(messageInfo?.data?.contentHeight);
+        }
         sendViewportDimensionsOnRequest(messageInfo);
       });
       isInitialPageLoad = false;

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -186,4 +186,31 @@ describe('Modals', () => {
     // Test passing, means there was no error thrown
     await hashChangeTriggered;
   });
+
+  it('adjusts the modal height upon request', async () => {
+    const contentHeightDesktop = 714;
+    const contentHeightMobile = '100%';
+    const content = new DocumentFragment();
+    const miloIFrame = document.createElement('div');
+    miloIFrame.classList.add('milo-iframe');
+    miloIFrame.classList.add('modal');
+    content.append(miloIFrame);
+    getModal(null, { class: 'commerce-frame', id: 'modal-with-iframe', content, closeEvent: 'closeModal' });
+    window.location.hash = '#modal-with-iframe';
+    const modalWithIFrame = document.querySelector('#modal-with-iframe');
+    modalWithIFrame.classList.add('height-fit-content');
+    const miloIFrameModal = document.querySelector('.milo-iframe.modal');
+
+    await setViewport({ width: 1200, height: 1000 });
+    window.postMessage({ contentHeight: contentHeightDesktop }, '*');
+    await delay(50);
+    expect(modalWithIFrame.clientHeight).to.equal(contentHeightDesktop);
+    expect(miloIFrameModal.clientHeight).to.equal(contentHeightDesktop);
+
+    await setViewport({ width: 320, height: 600 });
+    window.postMessage({ contentHeight: contentHeightMobile }, '*');
+    await delay(50);
+    expect(modalWithIFrame.style.height).to.equal(contentHeightMobile);
+    expect(miloIFrameModal.style.height).to.equal(contentHeightMobile);
+  });
 });


### PR DESCRIPTION
This change adds the automatic height adjustment for modals if the two following conditions are met:
1. The modal must have both the `commerce-frame` and `height-fit-content` classes.
2. The modal must contain an iFrame that sends a postMessage request with the content height of the page inside the iFrame.

On the desktop screen size:
If the content height is lower than the modal window height, the modal window height will be reduced to eliminate any blank space at the bottom of the page. 
Conversely, if the content height exceeds the modal window height, the modal window will expand to fill the entire available viewport height, with 20px vertical margins.

On the tablet and mobile screen sizes:
The height will stay the same, its value will be 100%.

Before:
https://github.com/adobecom/milo/assets/30750556/a59babe9-0de7-4ed8-b846-04d7d09d5335

After:
https://github.com/adobecom/milo/assets/30750556/1338f5d5-e04d-4535-9ec1-e18c7c0a2d7c

Also fixed the issue (not mentioned in the Jira) with the two cards layout on the smaller desktop screen sizes by setting a minimal modal width to 1000px for the desktop.
Before:
![Screenshot 2023-11-24 at 17 47 35](https://github.com/adobecom/milo/assets/30750556/490e66b8-e8a8-4228-8854-ff7fae879803)
After:
![Screenshot 2023-11-24 at 17 49 11](https://github.com/adobecom/milo/assets/30750556/4858f32a-d867-4d7f-8bdb-d094dcf1205b)

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?milolibs=mwpw-139177-twp-modal-height--milo--mirafedas&martech=off