### PR TITLE
MWPW-139782 - Marquee alignment for rtl locales

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -25,17 +25,29 @@
   color: var(--color-white);
 }
 
-.marquee.mobile-light a:not(.con-button) {
-  color: var(--link-color);
+.marquee .icon-area picture,
+.marquee .icon-area a {
+  display: contents;
 }
 
-.marquee.mobile-light a:not(.con-button):hover {
-  color: var(--link-hover-color);
+.marquee.mobile-light a:not(.con-button) {
+  color: var(--link-color);
 }
 
 .marquee.mobile-dark a:not(.con-button),
 .marquee.mobile-dark a:not(.con-button):hover {
   color: var(--link-color-dark);
+}
+
+.marquee.static-links:not(.mobile-dark) a:not(.con-button),
+.static-links .marquee:not(.mobile-dark) a:not(.con-button),
+.marquee.static-links a:not(.con-button):hover,
+.static-links .marquee a:not(.con-button):hover {
+  color: inherit;
+}
+
+.marquee.mobile-light a:not(.con-button):hover {
+  color: var(--link-hover-color);
 }
 
 .marquee.mobile-light a.con-button.outline {
@@ -92,11 +104,6 @@
 
 .marquee .icon-area {
   margin-bottom: var(--spacing-s);
-}
-
-.marquee .icon-area picture,
-.marquee .icon-area a {
-  display: contents;
 }
 
 .marquee .icon-area img {
@@ -352,6 +359,19 @@
     color: var(--color-white);
   }
 
+  .marquee.split.large .text {
+    margin: 0;
+  }
+
+  .marquee.quiet .foreground .text {
+    max-width: 600px;
+  }
+
+  .marquee.center .foreground .text,
+  .marquee.centered .foreground .text {
+    margin: 0 auto;
+  }
+
   .marquee.quiet.large .foreground .text {
     max-width: 800px;
   }
@@ -360,13 +380,13 @@
     color: var(--link-color);
   }
 
-  .marquee.tablet-light a:not(.con-button):hover {
-    color: var(--link-hover-color);
-  }
-
   .marquee.tablet-dark a:not(.con-button),
   .marquee.tablet-dark a:not(.con-button):hover {
     color: var(--link-color-dark);
+  }
+
+  .marquee.tablet-light a:not(.con-button):hover {
+    color: var(--link-hover-color);
   }
 
   .marquee.tablet-light a.con-button.outline {
@@ -392,7 +412,7 @@
     text-decoration: none;
   }
 
-.marquee .media {
+  .marquee .media {
     width: var(--grid-container-width); /* 10 grid / 83% */
   }
 
@@ -406,19 +426,6 @@
   .marquee.split .foreground.container {
     flex-direction: row;
     padding: var(--spacing-xl) 0;
-  }
-
-  .marquee.split.large .text {
-    margin: 0;
-  }
-
-  .marquee.quiet .foreground .text {
-    max-width: 600px;
-  }
-
-  .marquee.center .foreground .text,
-  .marquee.centered .foreground .text {
-    margin: 0 auto;
   }
   
   .marquee.split .foreground.container .text {
@@ -520,14 +527,14 @@
   .marquee.desktop-light a:not(.con-button) {
     color: var(--link-color);
   }
-
-  .marquee.desktop-light a:not(.con-button):hover {
-    color: var(--link-hover-color);
-  }
-
+  
   .marquee.desktop-dark a:not(.con-button),
   .marquee.desktop-dark a:not(.con-button):hover {
     color: var(--link-color-dark);
+  }
+
+  .marquee.desktop-light a:not(.con-button):hover {
+    color: var(--link-hover-color);
   }
 
   .marquee.desktop-light a.con-button.outline {
@@ -564,6 +571,21 @@
     gap: 100px; /* 1 column */
   }
 
+  .marquee.small .foreground,
+  .marquee.split .foreground.container {
+    padding: 0;
+  }
+
+  .marquee.quiet .foreground,
+  .marquee.inline .foreground,
+  .marquee.split .foreground {
+    justify-content: initial;
+  }
+
+  html[dir="rtl"] .marquee .foreground {
+    flex-direction: row-reverse;
+  }
+
   .marquee .text,
   .marquee.small .text,
   .marquee.large .text {
@@ -582,17 +604,6 @@
 
   .marquee .foreground .media {
     max-width: 600px;
-  }
-
-  .marquee.small .foreground,
-  .marquee.split .foreground.container {
-    padding: 0;
-  }
-  
-  .marquee.quiet .foreground,
-  .marquee.inline .foreground,
-  .marquee.split .foreground {
-    justify-content: initial;
   }
 
   .marquee.quiet.center .foreground,
@@ -706,12 +717,4 @@
   .marquee.large .foreground.container {
     max-width: var(--grid-container-width);
   }
-}
-
-
-.marquee.static-links a:not(.con-button),
-.marquee.static-links a:not(.con-button):hover,
-.static-links .marquee a:not(.con-button),
-.static-links .marquee a:not(.con-button):hover {
-  color: inherit;
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Locales that use a language which runs right to left (rtl) would have the placement of marquee text on the opposite site of the block, potentially covering up the media contained in the background. This PR standardizes the placement of the text content without affecting the reading direction. This only applies to the desktop breakpoint.
* Style lint errors were also fixed (the new code for rtl languages is on line 585 of this file)

Resolves: [MWPW-139782](https://jira.corp.adobe.com/browse/MWPW-139782)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/ae_ar/drafts/ebartholomew/rtl-marquee?martech=off
- After: https://ebartholomew-rtl-marquee--milo--adobecom.hlx.page/ae_ar/drafts/ebartholomew/rtl-marquee?martech=off
