### PR TITLE
[MWPW-131197] Gnav active element detection

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/gnav.md
+++ b/.github/PULL_REQUEST_TEMPLATE/gnav.md
@@ -1,9 +1,11 @@
 ## Description
 
+
 ## Related Issue
 Resolves: [MWPW-111111](https://jira.corp.adobe.com/browse/MWPW-111111)
 
 ## Testing instructions
+
 
 ## Screenshots (if appropriate):
 
@@ -20,6 +22,10 @@ Resolves: [MWPW-111111](https://jira.corp.adobe.com/browse/MWPW-111111)
 **CC:**
 - Before: https://main--cc--adobecom.hlx.live/?martech=off
 - After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=<branch>--milo--<owner>
+
+**Homepage:**
+- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
+- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=<branch>--milo--<owner>
 
 **Milo:**
 - Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off

--- a/libs/blocks/fallback/fallback.js
+++ b/libs/blocks/fallback/fallback.js
@@ -6,6 +6,7 @@
 const SYNTHETIC_BLOCKS = [
   'adobe-logo',
   'breadcrumbs',
+  'column-break',
   'gnav-brand',
   'gnav-promo',
   'large-menu',

--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -115,14 +115,51 @@
     padding: 0 12px;
   }
 
+  .feds-navItem--active > .feds-navLink {
+    position: relative;
+    font-weight: 700;
+  }
+
+  .feds-navItem--active > .feds-navLink:only-child {
+    cursor: default;
+  }
+
+  .feds-navItem--active > .feds-navLink:only-child:hover,
+  .feds-navItem--active > .feds-navLink:only-child:focus {
+    color: var(--feds-color-link--light);
+  }
+
+  .feds-navItem--active > .feds-navLink:before {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border-bottom: 2px solid #2c2c2c;
+    content: "";
+  }
+
+  .feds-navItem--active > .feds-navLink:before {
+    margin: 0 12px;
+  }
+
+  .feds-navItem--activeDeferred > .feds-navLink {
+    padding: 0;
+    width: 100%;
+    justify-content: center;
+  }
+
   .feds-topnav--overflowing .feds-navLink,
   .feds-topnav--overflowing .feds-navLink--hoverCaret,
   [dir = "rtl"] .feds-topnav--overflowing .feds-navLink--hoverCaret {
     padding: 0 8px;
   }
 
-  .feds-navLink--hoverCaret {
-    position: static;
+  .feds-topnav--overflowing .feds-navItem--active > .feds-navLink:before {
+    margin: 0 8px;
+  }
+
+  .feds-topnav--overflowing .feds-navItem--activeDeferred > .feds-navLink {
+    padding: 0;
   }
 
   .feds-navLink--hoverCaret:hover,

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -575,8 +575,16 @@ header.global-navigation {
     padding: 0 20px;
   }
 
+  .feds-navItem--section.feds-navItem--active > .feds-navLink:before {
+    margin: 0 20px;
+  }
+
   .feds-topnav--overflowing .feds-navItem--section > .feds-navLink {
     padding: 0 12px;
+  }
+
+  .feds-topnav--overflowing .feds-navItem--section.feds-navItem--active > .feds-navLink:before {
+    margin: 0 12px;
   }
 
   .feds-navItem:not(:last-child) > .feds-navLink {

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -1,21 +1,18 @@
 import {
-  getAnalyticsValue,
-  toFragment,
   decorateCta,
-  yieldToMain,
+  getActiveLink,
+  getAnalyticsValue,
   getFedsPlaceholderConfig,
-  logErrorFor,
-  setActiveDropdown,
-  trigger,
   isDesktop,
+  logErrorFor,
+  selectors,
+  setActiveDropdown,
+  toFragment,
+  trigger,
+  yieldToMain,
 } from '../utilities.js';
 import { decorateLinks } from '../../../../utils/utils.js';
 import { replaceText } from '../../../../features/placeholders.js';
-
-const selectors = {
-  gnavPromo: '.gnav-promo',
-  columnBreak: '.column-break',
-};
 
 const decorateHeadline = (elem, index) => {
   if (!(elem instanceof HTMLElement)) return null;
@@ -59,7 +56,7 @@ const decorateHeadline = (elem, index) => {
 };
 
 const decorateLinkGroup = (elem, index) => {
-  if (!(elem instanceof HTMLElement) || !elem.querySelector('a')) return null;
+  if (!(elem instanceof HTMLElement) || !elem.querySelector('a')) return '';
 
   // TODO: allow links with image and no label
   const image = elem.querySelector('picture');
@@ -311,6 +308,26 @@ const decorateMenu = (config) => logErrorFor(async () => {
     // Content has been fetched dynamically, need to decorate links
     decorateLinks(menuTemplate);
     await decorateColumns({ content: menuContent });
+
+    if (getActiveLink(menuTemplate) instanceof HTMLElement) {
+      // Special handling on desktop, as content is loaded async;
+      // bolding the item text would normally push the content
+      // to the right, potentially causing CLS
+      const resetActiveState = () => {
+        config.template.style.width = '';
+        config.template.classList.remove(selectors.deferredActiveNavItem.slice(1));
+      };
+
+      if (isDesktop.matches) {
+        config.template.style.width = `${config.template.offsetWidth}px`;
+        config.template.classList.add(selectors.deferredActiveNavItem.slice(1));
+        isDesktop.addEventListener('change', resetActiveState, { once: true });
+        window.addEventListener('feds:navOverflow', resetActiveState, { once: true });
+      }
+
+      config.template.classList.add(selectors.activeNavItem.slice(1));
+    }
+
     config.template.classList.add('feds-navItem--megaMenu');
   }
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -9,9 +9,13 @@ export const selectors = {
   navLink: '.feds-navLink',
   overflowingTopNav: '.feds-topnav--overflowing',
   navItem: '.feds-navItem',
+  activeNavItem: '.feds-navItem--active',
+  deferredActiveNavItem: '.feds-navItem--activeDeferred',
   activeDropdown: '.feds-dropdown--active',
   menuSection: '.feds-menu-section',
   menuColumn: '.feds-menu-column',
+  gnavPromo: '.gnav-promo',
+  columnBreak: '.column-break',
 };
 
 export function toFragment(htmlStrings, ...values) {
@@ -161,6 +165,30 @@ export function setActiveDropdown(elem) {
     return false;
   });
 }
+
+export const [hasActiveLink, setActiveLink, getActiveLink] = (() => {
+  let activeLinkFound;
+
+  return [
+    () => activeLinkFound,
+    (val) => { activeLinkFound = !!val; },
+    (area) => {
+      if (hasActiveLink() || !(area instanceof HTMLElement)) return null;
+      const { origin, pathname } = window.location;
+      let activeLink;
+
+      [`${origin}${pathname}`, pathname].forEach((path) => {
+        if (activeLink) return;
+        activeLink = area.querySelector(`a[href = '${path}'], a[href ^= '${path}?'], a[href ^= '${path}#']`);
+      });
+
+      if (!activeLink) return null;
+
+      setActiveLink(true);
+      return activeLink;
+    },
+  ];
+})();
 
 export function closeAllDropdowns({ type } = {}) {
   const selector = type === 'headline'

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -3,7 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
 import { createFullGlobalNavigation, selectors, isElementVisible, mockRes, viewports } from './test-utilities.js';
-import { isDesktop, isTangentToViewport, toFragment } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
+import { isDesktop, isTangentToViewport, setActiveLink, toFragment } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
 import logoOnlyNav from './mocks/global-navigation-only-logo.plain.js';
 import brandOnlyNav from './mocks/global-navigation-only-brand.plain.js';
 import nonSvgBrandOnlyNav from './mocks/global-navigation-only-non-svg-brand.plain.js';
@@ -11,6 +11,7 @@ import longNav from './mocks/global-navigation-long.plain.js';
 import noLogoBrandOnlyNav from './mocks/global-navigation-only-brand-no-image.plain.js';
 import noBrandImageOnlyNav from './mocks/global-navigation-only-brand-no-explicit-image.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
+import globalNavigationActiveMock from './mocks/global-navigation-active.plain.js';
 import globalNavigationWideColumnMock from './mocks/global-navigation-wide-column.plain.js';
 
 const ogFetch = window.fetch;
@@ -392,6 +393,80 @@ describe('global navigation', () => {
         [...document.querySelectorAll(selectors.navItem)].forEach((el) => {
           expect(isElementVisible(el)).to.equal(true);
         });
+      });
+    });
+
+    describe('sets an active item', () => {
+      beforeEach(() => {
+        setActiveLink(false);
+      });
+
+      it('marks simple link as active', async () => {
+        const targetSelector = '#simple-link';
+        const template = toFragment`<div></div>`;
+        template.innerHTML = globalNavigationActiveMock;
+        const templateActiveElem = template.querySelector(targetSelector);
+        templateActiveElem.setAttribute('href', window.location.href);
+        await createFullGlobalNavigation({ globalNavigation: template.innerHTML });
+        const markupActiveElem = document.querySelector(targetSelector);
+        expect(markupActiveElem.closest(selectors.activeNavItem) instanceof HTMLElement).to.be.true;
+      });
+
+      it('marks item with sync dropdown containing active link', async () => {
+        const targetSelector = '#link-in-dropdown';
+        const template = toFragment`<div></div>`;
+        template.innerHTML = globalNavigationActiveMock;
+        const templateActiveElem = template.querySelector(targetSelector);
+        templateActiveElem.setAttribute('href', window.location.href);
+        await createFullGlobalNavigation({ globalNavigation: template.innerHTML });
+        const markupActiveElem = document.querySelector(targetSelector);
+        expect(markupActiveElem.closest(selectors.activeNavItem) instanceof HTMLElement).to.be.true;
+      });
+
+      it('marks item from a nav with a single async dropdown containing active link', async () => {
+        await createFullGlobalNavigation({ globalNavigation: globalNavigationActiveMock });
+        const sections = document.querySelectorAll('section.feds-navItem--section');
+        expect(sections.length).to.equal(1);
+        expect(sections[0].matches(selectors.activeNavItem)).to.be.true;
+      });
+
+      it('marks item from a nav with multiple async dropdowns containing active link', async () => {
+        const template = toFragment`<div></div>`;
+        template.innerHTML = globalNavigationActiveMock;
+        // Duplicate cloud menu and add it to the template
+        const toDuplicate = template.querySelector('#cloud-menu-wrapper');
+        const duplicated = toDuplicate.cloneNode(true);
+        duplicated.id = `${duplicated.id}-duplicate`;
+        const duplicatedCloudMenuElem = duplicated.querySelector('a#cloud-menu');
+        duplicatedCloudMenuElem.id = `${duplicatedCloudMenuElem.id}-duplicate`;
+        toDuplicate.after(duplicated);
+        await createFullGlobalNavigation({ globalNavigation: template.innerHTML });
+        // There should be two sections, one of which is active
+        const sections = document.querySelectorAll('.feds-navItem--section');
+        expect(sections.length).to.equal(2);
+        const activeSections = document.querySelectorAll(`.feds-navItem--section${selectors.activeNavItem}`);
+        expect(activeSections.length).to.equal(1);
+        // A special class needs to be added in this case
+        const activeSection = document.querySelector(selectors.activeNavItem);
+        expect(activeSection.matches(selectors.deferredActiveNavItem)).to.be.true;
+        // The special class should be removed is switching to mobile/tablet
+        await setViewport(viewports.mobile);
+        isDesktop.dispatchEvent(new Event('change'));
+        expect(activeSection.matches(selectors.deferredActiveNavItem)).to.be.false;
+      });
+
+      it('marks a single item as active if multiple links match URL', async () => {
+        const targetSelector1 = '#simple-link';
+        const targetSelector2 = '#link-in-dropdown';
+        const template = toFragment`<div></div>`;
+        template.innerHTML = globalNavigationActiveMock;
+        const templateActiveElem1 = template.querySelector(targetSelector1);
+        templateActiveElem1.setAttribute('href', window.location.href);
+        const templateActiveElem2 = template.querySelector(targetSelector2);
+        templateActiveElem2.setAttribute('href', window.location.href);
+        await createFullGlobalNavigation({ globalNavigation: template.innerHTML });
+        const activeSections = document.querySelectorAll('section.feds-navItem--section');
+        expect(activeSections.length).to.equal(1);
       });
     });
   });

--- a/test/blocks/global-navigation/mocks/global-navigation-active.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation-active.plain.js
@@ -1,0 +1,282 @@
+// Uses the franklin structure without any customizations
+export default `
+<div>
+  <div class="gnav-brand logo">
+    <div>
+      <div>
+        <p>
+          <a href="http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg">
+            http://localhost:2000/test/blocks/global-navigation/mocks/adobe-logo.svg
+          </a>
+        </p>
+        <p><a href="https://www.adobe.com/">Adobe</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="cloud-menu-wrapper">
+  <div class="large-menu section">
+    <div>
+      <div>
+        <h2 id="cloud-menu">
+          <a href="/large-menu-active" id="cloud-menu">Cloud Menu</a>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <h2 id="w-promo"><a href="https://business.adobe.com/">w/ Promo</a></h2>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/topics/creativity.html#_blank"
+        >Creativity</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+        >Digital Transformation</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/trends--research.html"
+        >Trends &#x26; Research</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/future-of-work.html"
+        >Future Of Work</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/leadership.html">Leadership</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/customer-stories.html"
+        >Customer Stories</a
+      >
+    </li>
+    <li><a href="https://blog.adobe.com/en/topics/events.html">Events</a></li>
+  </ul>
+  <div class="gnav-promo dark">
+    <div>
+      <div>
+        <p><strong>Business Resilience: Leading Through Change</strong></p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Maecenas
+          porttitor congue massa.
+        </p>
+        <p><strong><a href="https://adobe.com/">Check it out</a></strong></p>
+      </div>
+    </div>
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_medium_dropdown.png"
+            width="215"
+            height="121"
+          />
+        </picture>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
+  <h2 id="col">2 Col</h2>
+  <h5 id="column-1-heading">Column 1 heading</h5>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/creativity.html" id="link-in-dropdown">Creativity</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+        >Digital Transformation</a
+      >
+    </li>
+  </ul>
+  <div class="link-group blue">
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >What is Creative Cloud?</a
+          >
+        </p>
+        <p>Creative apps and services for everyone</p>
+      </div>
+    </div>
+  </div>
+  <h5 id="column-2-heading">Column 2 heading</h5>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/future-of-work.html"
+        >Future Of Work</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/leadership.html">Leadership</a>
+    </li>
+  </ul>
+  <p>
+    <em><a href="https://blog.adobe.com/en/topics/events.html">Events</a></em>
+  </p>
+</div>
+<div>
+  <h2 id="col-1"><a href="https://business.adobe.com/">1 col</a></h2>
+  <ul>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/creativity.html">Creativity</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+        >Digital Transformation</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/trends--research.html"
+        >Trends &#x26; Research</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/future-of-work.html"
+        >Future Of Work</a
+      >
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/leadership.html">Leadership</a>
+    </li>
+    <li>
+      <a href="https://blog.adobe.com/en/topics/customer-stories.html"
+        >Customer Stories</a
+      >
+    </li>
+    <li><a href="https://blog.adobe.com/en/topics/events.html">Events</a></li>
+  </ul>
+</div>
+<div>
+  <p>
+    <strong
+      ><a href="https://helpx.adobe.com/#open-jarvis-chat">Primary</a></strong
+    >
+  </p>
+</div>
+<div>
+  <p>
+    <em><a href="http://localhost:6456/drafts/ramuntea/gnav-refactor" id="cta">Secondary</a></em>
+  </p>
+</div>
+<div>
+  <h2 id="random-text">Random text</h2>
+</div>
+<div>
+  <h2 id="no-dropdown"><a href="https://www.adobe.com/" id="simple-link">No Dropdown</a></h2>
+</div>
+<div>
+  <div class="search">
+    <div>
+      <div>
+        <p>Search</p>
+        <p>Search</p>
+      </div>
+    </div>
+  </div>
+  <div class="profile">
+    <div>
+      <div>
+        <h5 id="local-menu-title">Local Menu Title</h5>
+        <p>
+          <a href="https://blog.adobe.com/en/topics/creativity.html"
+            >Creativity</a
+          >
+        </p>
+        <p>
+          <a href="https://blog.adobe.com/en/topics/digital-transformation.html"
+            >Digital Transformation</a
+          >
+        </p>
+        <p>
+          <a href="https://blog.adobe.com/en/topics/trends--research.html"
+            >Trends &#x26; Research</a
+          >
+        </p>
+      </div>
+    </div>
+    <div>
+      <div>
+        <ul>
+          <li>
+            <a href="https://experiencecloud.adobe.com/exc-content/login.html"
+              >Experience Cloud</a
+            >
+          </li>
+          <li>
+            <a href="https://account.magento.com/customer/account/login"
+              >Commerce (Magento)</a
+            >
+          </li>
+          <li><a href="https://login.marketo.com/">Marketo Engage</a></li>
+          <li>
+            <a href="https://business.adobe.com/products/workfront/login.html"
+              >Workfront</a
+            >
+          </li>
+          <li><a href="https://adobe.com?sign-in=true">Adobe Account</a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="app-launcher">
+    <div>
+      <div><a href="/gnav/app-launcher">App Launcher</a></div>
+    </div>
+  </div>
+  <div class="adobe-logo">
+    <div>
+      <div><a href="https://www.adobe.com/">Adobe</a></div>
+    </div>
+  </div>
+</div>`;

--- a/test/blocks/global-navigation/mocks/large-menu-active.plain.js
+++ b/test/blocks/global-navigation/mocks/large-menu-active.plain.js
@@ -1,0 +1,378 @@
+// Uses the franklin structure without any customizations
+export default `<div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a id="large-menu-active-link" href=${window.location.href}
+            >What is Creative Cloud?</a
+          >
+        </p>
+        <p>Creative apps and services for everyone</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Photographers</a
+          >
+        </p>
+        <p>Lightroom, Photoshop, and more</p>
+      </div>
+    </div>
+  </div>
+  <h5 id="test-heading">Test heading</h5>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Students and Teachers</a
+          >
+        </p>
+        <p>Save over 60% on Creative Cloud</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Small and medium business</a
+          >
+        </p>
+        <p>Creative apps and services for teams</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Enterprise</a
+          >
+        </p>
+        <p>Solutions for large organizations</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <picture>
+          <source
+          type="image/webp"
+          srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+          media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            width="52"
+            height="51"
+          />
+        </picture>
+      </div>
+      <div>
+        <a href="https://business.adobe.com/what-is-experience-cloud.html"
+          >No subtitle</a
+        >
+      </div>
+    </div>
+  </div>
+  <p>
+    <a href="https://www.adobe.com/creativecloud/plans.html"
+      >View plans and pricing</a
+    >
+  </p>
+  <p>
+    <a href="https://www.adobe.com/creativecloud/plans.html"
+      >And another link</a
+    >
+  </p>
+</div>
+<div>
+  <h5 id="featured-products">Featured products</h5>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Photoshop</a
+          >
+        </p>
+        <p>Image editing and design</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Lightroom</a
+          >
+        </p>
+        <p>The cloud-based photo service</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Illustrator</a
+          >
+        </p>
+        <p>Vector graphics and illustration</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Premiere Pro</a
+          >
+        </p>
+        <p>Video editing and production</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Adobe Acrobat</a
+          >
+        </p>
+        <p>The complete PDF solution</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <p>
+          <a href="https://business.adobe.com/what-is-experience-cloud.html"
+            >Adobe Stock</a
+          >
+        </p>
+        <p>High-quality licensable assets</p>
+      </div>
+    </div>
+  </div>
+  <div class="link-group">
+    <div>
+      <div>
+        <a href="https://business.adobe.com/what-is-experience-cloud.html"
+          >No subtitle</a
+        >
+      </div>
+    </div>
+  </div>
+  <p>
+    <strong
+      ><a href="https://business.adobe.com/what-is-experience-cloud.html"
+        >View all Creative Cloud products</a
+      ></strong
+    >
+  </p>
+</div>
+<div>
+  <h5 id="explore">Explore</h5>
+  <ul>
+    <li><a href="http://google.com/">Photo</a></li>
+    <li><a href="http://google.com/">Graphic design</a></li>
+    <li><a href="http://google.com/">Video</a></li>
+    <li><a href="http://google.com/">Illustration</a></li>
+    <li><a href="http://google.com/">UI and UX</a></li>
+    <li><a href="http://google.com/">Social media</a></li>
+    <li><a href="http://google.com/">3D and AR</a></li>
+  </ul>
+</div>
+<div>
+  <div class="gnav-promo image-only">
+    <div>
+      <div>
+        <picture>
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=2000&format=webply&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <source
+            type="image/webp"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=750&format=webply&optimize=medium"
+          />
+          <source
+            type="image/png"
+            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=2000&format=png&optimize=medium"
+            media="(min-width: 600px)"
+          />
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_large_dropdown.png?width=750&format=png&optimize=medium"
+            width="375"
+            height="514"
+          />
+        </picture>
+      </div>
+    </div>
+    <div>
+      <div><a href="https://www.adobe.com/">https://www.adobe.com/</a></div>
+    </div>
+  </div>
+</div>
+`;

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -7,6 +7,7 @@ import { getLocale, setConfig, loadStyle } from '../../../libs/utils/utils.js';
 import defaultPlaceholders from './mocks/placeholders.js';
 import defaultProfile from './mocks/profile.js';
 import largeMenuMock from './mocks/large-menu.plain.js';
+import largeMenuActiveMock from './mocks/large-menu-active.plain.js';
 import largeMenuWideColumnMock from './mocks/large-menu-wide-column.plain.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
 import correctPromoFragmentMock from './mocks/correctPromoFragment.plain.js';
@@ -129,6 +130,7 @@ export const createFullGlobalNavigation = async ({
     if (url.includes('profile')) { return mockRes({ payload: defaultProfile }); }
     if (url.includes('placeholders')) { return mockRes({ payload: placeholders || defaultPlaceholders }); }
     if (url.endsWith('large-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
+    if (url.endsWith('large-menu-active.plain.html')) { return mockRes({ payload: largeMenuActiveMock }); }
     if (url.endsWith('large-menu-wide-column.plain.html')) { return mockRes({ payload: largeMenuWideColumnMock }); }
     if (url.includes('gnav')) { return mockRes({ payload: globalNavigation || globalNavigationMock }); }
     if (url.includes('correct-promo-fragment')) { return mockRes({ payload: correctPromoFragmentMock }); }

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -5,6 +5,9 @@ import {
   getFedsPlaceholderConfig,
   getAnalyticsValue,
   decorateCta,
+  hasActiveLink,
+  setActiveLink,
+  getActiveLink,
   closeAllDropdowns,
   trigger,
   getExperienceName,
@@ -84,6 +87,32 @@ describe('global navigation utilities', () => {
       expect(el.children[0].getAttribute('href')).to.equal('test');
       expect(el.children[0].getAttribute('daa-ll')).to.equal('test');
       expect(el.children[0].textContent.trim()).to.equal('test');
+    });
+  });
+
+  describe('active logic', () => {
+    it('can have its state updated', () => {
+      const currentState = hasActiveLink();
+      setActiveLink(!currentState);
+      expect(hasActiveLink()).to.equal(!currentState);
+      setActiveLink(currentState);
+      expect(hasActiveLink()).to.equal(currentState);
+    });
+
+    it('finds the active link from an area', () => {
+      setActiveLink(false);
+
+      const area = toFragment`<div>
+          <a href="https://www.adobe.com/">Home</a>
+        </div>`;
+
+      expect(getActiveLink(area)).to.be.null;
+      expect(hasActiveLink()).to.be.false;
+
+      area.append(toFragment`<a href="${window.location.href}">Current</a>`);
+
+      expect(getActiveLink(area) instanceof HTMLElement).to.be.true;
+      expect(hasActiveLink()).to.be.true;
     });
   });
 


### PR DESCRIPTION
## Description
To reach better feature parity between the AEM and Milo versions of the Global Navigation, this PR implements active element detection for navigation elements. A detailed Wiki is available in the JIRA issue, describing all use-cases.

A few developer notes, in order of files:
- test URLs for the Homepage have been added to the _gnav.md_ custom PR template;
- the `column-break` synthetic block added for https://github.com/adobecom/milo/pull/1532 has been added to _fallback.js_ to avoid false alerts when previewing navigation files;
- link groups that don't contain links will be transformed into empty strings to avoid `null` elements in the final markup;
- you might notice that on top of the `.feds-navItem--active` class, another `.feds-navItem--activeDeferred` is used. The latter is used for when no items loaded synchronously contain an active element and the navigation contains multiple asynchronously-loaded section menus. Since we depend on async code to mark the active element, we want to adapt the behaviour to avoid potential CLS issues, thus we use this extra modifier. It gets removed once the viewport switches to mobile or the content of the navigation is overflowing, since CLS should no longer be impacted.

## Related Issue
Resolves: [MWPW-131197](https://jira.corp.adobe.com/browse/MWPW-131197)

## Testing instructions
Go on a page whose URL is referenced by a link from the Global Navigation. The top navigation item that contains that link should have its text bolded and receive a bottom border.

Feel free to edit some experiences and add multiple items with the potential of being active. There should obviously be just one active item in the navigation. If multiple links match the criteria, the Wiki describes which gets priority.

## Screenshots:
<img width="912" alt="Screenshot 2023-12-01 at 15 04 58" src="https://github.com/adobecom/milo/assets/11267498/a4ab1454-0730-4070-a481-71ff5756b8d1">

## Test URLs
**Acrobat** (link in dropdown):
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=gnav-active-elem--milo--overmyheadandbody

**BACOM** (simple top navigation link):
- Before: https://main--bacom--adobecom.hlx.page/products/real-time-customer-data-platform/rtcdp?martech=off
- After: https://main--bacom--adobecom.hlx.page/products/real-time-customer-data-platform/rtcdp?martech=off&milolibs=gnav-active-elem--milo--overmyheadandbody

**CC** (cloud menu):
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=gnav-active-elem--milo--overmyheadandbody

**Homepage** (no item):
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=gnav-active-elem--milo--overmyheadandbody

**Milo** (multiple cloud menus):
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor-colourful?foo=bar#baz&martech=off
- After: https://gnav-active-elem--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor-colourful?martech=off