### PR TITLE
Mwpw 139779: Nested fragments with merch cards fix. #1589

### DIFF
--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -126,7 +126,9 @@ const init = (el) => {
       const fragmentParent = fragment.parentElement;
       section.style.display = 'contents';
       fragment.style.display = 'contents';
-      fragmentParent.style.display = 'contents';
+      fragmentParent.style.display = fragmentParent.classList.contains('nested')
+        ? fragmentParent.style.display
+        : 'contents';
       section = fragmentParent.parentElement;
     }
     addMerchCardGridsIfMissing(section);


### PR DESCRIPTION
Fixes nested fragments with grids of merch cards inside.

Context: Nested fragments use `nested` value in section metadata style on the parent section.
Merch card initialization should only apply display: contents to parent sections of fragments that do not have any display attribute (set by a class), this PR checks if the parent section has a class of nested before applying `display: contents` directly to the element to avoid breaking the grid with cards inside.

Resolves: [MWPW-139779](https://jira.corp.adobe.com/browse/MWPW-139779)

Test URLs:

Before: https://main--milo--adobecom.hlx.page/drafts/delta/quiz-results-block/quiz-results?primary=design_ax_indiv,illustr_ax_indiv,pdf_indiv&quizKey=cc-quiz-en-US

After: https://mwpw-139779--milo--axelcureno.hlx.page/drafts/delta/quiz-results-block/quiz-results?primary=design_ax_indiv,illustr_ax_indiv,pdf_indiv&quizKey=cc-quiz-en-US