### PR TITLE
MWPW-136152 - Added the `quiz-marquee` to the utils blocks list for consuming sites

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -55,6 +55,7 @@ const MILO_BLOCKS = [
   'preflight',
   'promo',
   'quiz',
+  'quiz-marquee',
   'quiz-results',
   'tabs',
   'table-of-contents',


### PR DESCRIPTION
Added the `quiz-marquee` to the /libs/utils.js blocks list for consuming sites

FYI: This was overlooked in the initial PR and the CC site needs access to start testing
 
Resolves: [MWPW-136152](https://jira.corp.adobe.com/browse/MWPW-136152)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/uar/marquee/animate?debug=quiz-results&martech=off
- After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/uar/marquee/animate?milolibs=rparrish-quiz-marquee-utils&debug=quiz-results&martech=off
