### PR TITLE
Adding decorateArea() into replaceInner()

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -159,6 +159,8 @@ export async function replaceInner(path, element) {
   if (!html) return false;
 
   element.innerHTML = html;
+  const { decorateArea } = getConfig();
+  if (decorateArea) decorateArea(element);
   return true;
 }
 /* c8 ignore stop */


### PR DESCRIPTION
Found an issue on personalization that the LCP image has `lazy` tag and media path doesn't get updated when it gets replaced the page.

This will run decorateArea() when personalization replace page by replacing `<main>` element, so homepage can handle those issue.


<img width="941" alt="image" src="https://github.com/adobecom/milo/assets/55804872/2c630456-8724-4ae3-86d0-eb3048201068">


**Related PRs:**
- #1520
- https://github.com/adobecom/homepage/pull/36

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://decoratearea-personalization--milo--adobecom.hlx.page/?martech=off