### PR TITLE
MWPW-138222-support twitter new domain

### DIFF
--- a/libs/blocks/twitter/twitter.js
+++ b/libs/blocks/twitter/twitter.js
@@ -3,7 +3,8 @@ import { createIntersectionObserver, createTag, loadScript, isInTextNode } from 
 export default function init(a) {
   if (isInTextNode(a)) return;
   const embedTwitter = () => {
-    const anchor = createTag('a', { href: a.href });
+    const url = a.href.replace('https://x.com', 'https://twitter.com');
+    const anchor = createTag('a', { href: url });
     const blockquote = createTag('blockquote', { class: 'twitter-tweet' }, anchor);
     const wrapper = createTag('div', { class: 'embed-twitter' }, blockquote);
     a.parentElement.replaceChild(wrapper, a);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -84,6 +84,7 @@ const AUTO_BLOCKS = [
   { slideshare: 'https://www.slideshare.net' },
   { tiktok: 'https://www.tiktok.com' },
   { twitter: 'https://twitter.com' },
+  { twitter: 'https://x.com' },
   { vimeo: 'https://vimeo.com' },
   { vimeo: 'https://player.vimeo.com' },
   { youtube: 'https://www.youtube.com' },

--- a/test/blocks/twitter/twitter.test.html
+++ b/test/blocks/twitter/twitter.test.html
@@ -9,7 +9,9 @@
     </script>
   </head>
   <body>
-    <a href="https://twitter.com/AdobePrint/status/1555212165346254848?s=20&t=5y2vpznI_ZwECs0l_hc1mw">https://twitter.com/AdobePrint/status/1555212165346254848?s=20&amp;t=5y2vpznI_ZwECs0l_hc1mw</a>
+    <a href="https://twitter.com/AdobePrint/status/1555212165346254848?s=20&t=5y2vpznI_ZwECs0l_hc1mw">https://twitter.com/AdobePrint/status/1555212165346254848?s=20&t=5y2vpznI_ZwECs0l_hc1mw</a>
+    <a href="https://x.com/Adobe/status/1714718693161312496?s=20">https://x.com/Adobe/status/1714718693161312496?s=20</a>
+  </body>
   </body>
   <script type="module">
     import { runTests } from '@web/test-runner-mocha';
@@ -20,14 +22,16 @@
 
     runTests(() => {
       describe('twitter', () => {
-        it('renders embed tweet for twitter link', () => {
-          const twitter = document.querySelector('a');
-          init(twitter);
-          const blockquote = document.querySelector('.twitter-tweet');
-          const wrapper = document.querySelector('.embed-twitter');
+        it('renders embed tweet for both twitter links', async () => {
+          const twitterLink = document.querySelectorAll('a');
+          twitterLink.forEach(async (link) => { 
+          init(link)
+          const blockquote = document.querySelectorAll('.twitter-tweet');
+          const wrapper = document.querySelectorAll('.embed-twitter');
           expect(blockquote).to.not.be.null;
           expect(wrapper).to.not.be.null;
-          expect(loadScript.callCount).to.equal(1);
+          });
+          expect(loadScript.callCount).to.equal(2);
         });
       });
     });


### PR DESCRIPTION
* Support twitter.com and X.com both domains for creating auto block for tweets

Resolves: [MWPW-138222](https://jira.corp.adobe.com/browse/MWPW-138222)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/twitter?martech=off
- After: https://twitter--milo--ruchika4.hlx.page/drafts/ruchika/twitter?martech=off
