### PR TITLE
MWPW-140080: Merch card grid with fragments

### DIFF
--- a/libs/blocks/merch-card/merch-card.css
+++ b/libs/blocks/merch-card/merch-card.css
@@ -1,5 +1,7 @@
 main > div[class*="-merch-card"],
-main > div[class*="-merch-cards"] {
+main > div[class*="-merch-cards"],
+.fragment > div[class*="-merch-card"],
+.fragment > div[class*="-merch-cards"] {
   display: grid;
 }
 


### PR DESCRIPTION
Fixes Merch cards grids with nested fragments.

Currently merch cards are inheriting the style display: block from Milo styles, whereas we use display: grid for our grids that are children of main. This change adds the use case when the grid is a children of a fragment.

Resolves: [MWPW-140080](https://jira.corp.adobe.com/browse/MWPW-140080)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/axel/segment-page
- After: https://main--cc--adobecom.hlx.page/drafts/axel/segment-page?milolibs=MWPW-140080--milo--axelcureno
