### PR TITLE
Fix button-justified mobile widths

### DIFF
--- a/libs/blocks/quiz-marquee/quiz-marquee.css
+++ b/libs/blocks/quiz-marquee/quiz-marquee.css
@@ -139,7 +139,6 @@
   .quiz-marquee .con-button {
     display: block;
     text-align: center;
-    width: 100%;
   }
 }
 

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -558,7 +558,6 @@ div[class*='-up'] .con-block.has-bg.no-spacing { padding: 0; }
   .con-button.button-justified-mobile {
     display: block;
     text-align: center;
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
There is some style conflicts w/ our justified mobile buttons styles causing them to overflow past the page margins. 

* View the before/after pages in mobile viewport

Resolves: N/A - https://adobedotcom.slack.com/archives/C03B0BUA75E/p1701750915991579

**Test URLs Libs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off
- After: https://rparrish-buttons-justified--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off

**Test URLs CC:**
- Before: https://main--cc--adobecom.hlx.page/drafts/Shrinidhi/marquee?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/Shrinidhi/marquee?milolibs=rparrish-buttons-justified&martech=off
