### PR TITLE
MWPW-138449 - Mobile progress indicator until 1024px

### DIFF
--- a/libs/blocks/quiz/quiz.css
+++ b/libs/blocks/quiz/quiz.css
@@ -395,14 +395,6 @@ html[dir="rtl"] .quiz-step::after {
     margin: var(--spacing-xxxl) 0;
   }
 
-  .quiz-step-container.top {
-    display: flex;
-  }
-  
-  .quiz-step-container.bottom{
-    display: none;
-  }
-
   .quiz-footer {
     margin: 0 0 40px;
   }
@@ -416,6 +408,14 @@ html[dir="rtl"] .quiz-step::after {
 
   .quiz-option.has-icon .quiz-option-image {
     display: flex;
+  }
+
+  .quiz-step-container.top {
+    display: flex;
+  }
+  
+  .quiz-step-container.bottom{
+    display: none;
   }
 }
 


### PR DESCRIPTION
* Shows mobile progress indicator at tablet widths

Resolves: [MWPW-138449](https://jira.corp.adobe.com/browse/MWPW-138449)

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.page/drafts/colloyd/quiz/?martech=off
- After: https://mwpw-138449-mobile-progress-indicator-at-tablet--milo--colloyd.hlx.page/drafts/colloyd/quiz/?martech=off

View the "After" page at widths below 1024px and the progress indicator should be seen below the questions (mobile). Where "Before" swapped to the mobile indicator below 600px
