### PR TITLE
MWPW-140160 - fixed styles for accordion rtl lang

### DIFF
--- a/libs/blocks/accordion/accordion.css
+++ b/libs/blocks/accordion/accordion.css
@@ -30,10 +30,18 @@ dl.accordion {
   font-size: var(--type-heading-xs-size);
   font-weight: 700;
   line-height: var(--type-heading-s-lh);
-  padding: var(--spacing-s) var(--spacing-m) var(--spacing-s) var(--spacing-xs);
   position: relative;
-  text-align: left;
   width: 100%;
+}
+
+html[dir="ltr"] .accordion dt button {
+  text-align: left;
+  padding: var(--spacing-s) var(--spacing-m) var(--spacing-s) var(--spacing-xs);
+}
+
+html[dir="rtl"] .accordion dt button {
+  text-align: right;
+  padding: var(--spacing-s) var(--spacing-xs) var(--spacing-s) var(--spacing-m);
 }
 
 .accordion dt button:hover {
@@ -47,12 +55,19 @@ dl.accordion {
 
 .accordion-icon {
   position: absolute;
-  right: var(--spacing-xs);
   top: 50%;
   margin-top: -6px;
   width: 12px;
   height: 12px;
   pointer-events: none;
+}
+
+html[dir="ltr"] .accordion-icon {
+  right: var(--spacing-xs);
+}
+
+html[dir="rtl"] .accordion-icon {
+  left: var(--spacing-xs);
 }
 
 .accordion-icon::before,
@@ -83,9 +98,16 @@ dl.accordion {
   position: absolute;
   width: 2px;
   height: 100%;
-  left: 0;
   top: 0;
   background-color: transparent;
+}
+
+html[dir="ltr"] .accordion dt button::before {
+  left: 0;
+}
+
+html[dir="rtl"] .accordion dt button::before {
+  right: 0;
 }
 
 .accordion dt button[aria-expanded="true"]::before {
@@ -158,17 +180,17 @@ dl.accordion {
 }
 
 
-@keyframes fade-in { 
-  0% { 
+@keyframes fade-in {
+  0% {
     opacity: 0;
   }
 
-  100% { 
-    opacity: 1; 
+  100% {
+    opacity: 1;
   }
 }
 
-.accordion-media > div.expanded, 
+.accordion-media > div.expanded,
 .accordion-media > div.expanded > img {
   display: inline;
   position: relative;
@@ -190,7 +212,7 @@ div.media-p {
     align-items: center;
     justify-content: center;
   }
-  
+
   .editorial .accordion {
     width: 50%;
     display: inline-block;

--- a/libs/blocks/accordion/accordion.css
+++ b/libs/blocks/accordion/accordion.css
@@ -32,15 +32,11 @@ dl.accordion {
   line-height: var(--type-heading-s-lh);
   position: relative;
   width: 100%;
-}
-
-html[dir="ltr"] .accordion dt button {
   text-align: left;
   padding: var(--spacing-s) var(--spacing-m) var(--spacing-s) var(--spacing-xs);
 }
 
 html[dir="rtl"] .accordion dt button {
-  text-align: right;
   padding: var(--spacing-s) var(--spacing-xs) var(--spacing-s) var(--spacing-m);
 }
 
@@ -60,13 +56,11 @@ html[dir="rtl"] .accordion dt button {
   width: 12px;
   height: 12px;
   pointer-events: none;
-}
-
-html[dir="ltr"] .accordion-icon {
   right: var(--spacing-xs);
 }
 
 html[dir="rtl"] .accordion-icon {
+  right: unset;
   left: var(--spacing-xs);
 }
 
@@ -100,9 +94,6 @@ html[dir="rtl"] .accordion-icon {
   height: 100%;
   top: 0;
   background-color: transparent;
-}
-
-html[dir="ltr"] .accordion dt button::before {
   left: 0;
 }
 

--- a/libs/blocks/accordion/accordion.css
+++ b/libs/blocks/accordion/accordion.css
@@ -30,10 +30,10 @@ dl.accordion {
   font-size: var(--type-heading-xs-size);
   font-weight: 700;
   line-height: var(--type-heading-s-lh);
-  position: relative;
-  width: 100%;
-  text-align: left;
   padding: var(--spacing-s) var(--spacing-m) var(--spacing-s) var(--spacing-xs);
+  position: relative;
+  text-align: left;
+  width: 100%;
 }
 
 html[dir="rtl"] .accordion dt button {
@@ -51,12 +51,12 @@ html[dir="rtl"] .accordion dt button {
 
 .accordion-icon {
   position: absolute;
+  right: var(--spacing-xs);
   top: 50%;
   margin-top: -6px;
   width: 12px;
   height: 12px;
   pointer-events: none;
-  right: var(--spacing-xs);
 }
 
 html[dir="rtl"] .accordion-icon {
@@ -92,9 +92,9 @@ html[dir="rtl"] .accordion-icon {
   position: absolute;
   width: 2px;
   height: 100%;
+  left: 0;
   top: 0;
   background-color: transparent;
-  left: 0;
 }
 
 html[dir="rtl"] .accordion dt button::before {


### PR DESCRIPTION
* Separated specific styles for ltr and rtl locales
* The +/- sign is on the left side for rtl locales
* Text alignment is right for rtl locales
* The blue border for an opened accordion item is on the right side for rtl locales

Resolves: [MWPW-140160](https://jira.corp.adobe.com/browse/MWPW-140160)

**Test URLs for _ltr_ locale:**
- Before: https://www.stage.adobe.com/acrobat/online/pdf-to-ppt.html
- After: https://www.stage.adobe.com/acrobat/online/pdf-to-ppt.html?milolibs=mwpw-140160-accordion-styles-for-rtl--milo--draganatrajkovic


**Test URLs for _rtl_ locales:**
- Before: 
1. https://www.stage.adobe.com/kw_ar/acrobat/online/pdf-to-ppt.html
2. https://www.stage.adobe.com/il_he/acrobat/online/pdf-to-ppt.html

- After: 
1. https://www.stage.adobe.com/kw_ar/acrobat/online/pdf-to-ppt.html?milolibs=mwpw-140160-accordion-styles-for-rtl--milo--draganatrajkovic
3. https://www.stage.adobe.com/il_he/acrobat/online/pdf-to-ppt.html?milolibs=mwpw-140160-accordion-styles-for-rtl--milo--draganatrajkovic
