### PR TITLE
MWPW-139621 - LCP loading via fragments

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -83,7 +83,7 @@ export default async function init(a) {
   const html = await resp.text();
   const doc = new DOMParser().parseFromString(html, 'text/html');
   replaceDotMedia(a.href, doc);
-  if (decorateArea) decorateArea(doc);
+  if (decorateArea) decorateArea(doc, { fragmentLink: a });
 
   const sections = doc.querySelectorAll('body > div');
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
The recently introduced `decorateArea` function does not support loading an LCP relevant image originating from a fragment. To fully support this, @chrischrischris and I found a way to do this:
- in `fragments.js`, add the current fragment link as additional parameter to the `decorateArea` function
- use a config object in case we want to pass in more stuff in the future without breaking consumer implementations

By passing in the current fragment's link to `decorateArea`, we can do the following on the consumer side:
- check for the first `a` element with class `fragment` and compare it with the passed in fragment link
- this way we know that the current fragment is the first one since milo hasn't processed and swapped out the `a.fragment` element with its actual content from the fragment document

Resolves: [MWPW-139621](https://jira.corp.adobe.com/browse/MWPW-139621)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://<branch>--milo--adobecom.hlx.page/?martech=off
