### PR TITLE
MWPW-140099 - quiz-marquee center variant

### DIFF
--- a/libs/blocks/quiz-marquee/quiz-marquee.css
+++ b/libs/blocks/quiz-marquee/quiz-marquee.css
@@ -8,6 +8,15 @@
   color: var(--color-white);
 }
 
+/* Alignment */
+.quiz-marquee.center .static {
+  text-align: center;
+  align-items: center;
+}
+
+.quiz-marquee.center .static .action-area,
+.quiz-marquee.center .static .icon-area { justify-content: center; }
+
 .quiz-marquee .static p { margin: var(--spacing-xs) 0; }
 .quiz-marquee .static p:only-child { margin: 0; }
 .quiz-marquee .static p:first-child { margin-top: 0; }

--- a/libs/blocks/quiz-results/quiz-results.js
+++ b/libs/blocks/quiz-results/quiz-results.js
@@ -16,7 +16,7 @@ async function loadFragments(el, experiences) {
 
 function redirectPage(quizUrl, debug, message) {
   const url = (quizUrl) ? quizUrl.text : 'https://adobe.com';
-  window.lana.log(message);
+  window.lana?.log(message);
 
   if (debug === 'quiz-results') {
     // eslint-disable-next-line no-console
@@ -89,7 +89,7 @@ export default async function init(el, debug = null, localStoreKey = null) {
 
     loadFragments(el, basic);
   } else {
-    window.lana.log(`${LOADING_ERROR} The quiz-results block is misconfigured`);
+    window.lana?.log(`${LOADING_ERROR} The quiz-results block is misconfigured`);
     return;
   }
 

--- a/test/blocks/quiz-marquee/quiz-marquee.test.js
+++ b/test/blocks/quiz-marquee/quiz-marquee.test.js
@@ -7,13 +7,13 @@ const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 const conf = { locales };
 setConfig(conf);
 
-describe('Biz Markie got what you need', () => {
+describe('Quiz Marquee (Biz Markie) got what you need', async () => {
   before(async () => {
     document.body.innerHTML = await readFile({ path: './mocks/body.html' });
     const { default: init } = await import('../../../libs/blocks/quiz-marquee/quiz-marquee.js');
     const marquees = document.querySelectorAll('.quiz-marquee');
     marquees.forEach(async (marquee) => {
-      await init(marquee);
+      await init(marquee, 'quiz-results', 'quiz-result-test');
     });
   });
   it('it has a static copy friend', async () => {


### PR DESCRIPTION
The new quiz-marquee needs a 'center' variant to center align content

* Added styles to support a `center` variant
* Addressed an issue w/ the unit tests throwing an error. (see screenshot below)

Resolves: [MWPW-140099](https://jira.corp.adobe.com/browse/MWPW-140099)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/quiz/quiz-marquee?quizKey=cc-quiz-en-US&debug=quiz-results&martech=off
- After: https://rparrish-quiz-marquee-center--milo--adobecom.hlx.page/drafts/rparrish/quiz/quiz-marquee?quizKey=cc-quiz-en-US&debug=quiz-results&martech=off

FYI - The quiz-marquee related fragments won't load unless your local storage is set in the [app-recommender-test](https://rparrish-quiz-marquee-center--milo--adobecom.hlx.page/drafts/rparrish/quiz/rec/app-recommender-test/) on a given branch/url.

**Testing:**
- Confirm the new 'center' variant is center aligning content on the after url. The bottom 2 quiz-marquee blocks have this variant included in the document. 

**Testing the Tests ;)**
on the `main` branch try `npm run test` and look for the quiz-marquee.test.js section.
checkout the `rparrish-quiz-marquee-center` branch and try re-running the tests. These 'browser logs' should be gone. 
<img width="843" alt="Screen Shot 2023-12-07 at 3 49 56 PM" src="https://github.com/adobecom/milo/assets/2086146/d59d65b9-c248-4e7b-85a7-9760b9a01a74">

