### PR TITLE
MWPW-138221 - Add .m4v support

### DIFF
--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -6,7 +6,7 @@ const ROOT_MARGIN = 1000;
 const loadVideo = (a) => {
   const { pathname, hash } = a;
   let videoPath = `.${pathname}`;
-  if (pathname.match('media_.*.mp4')) {
+  if (pathname.match('media_.*.(?:mp4|m4v)')) {
     const { codeRoot } = getConfig();
     const root = codeRoot.endsWith('/')
       ? codeRoot

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -94,13 +94,13 @@ export function handleFocalpoint(pic, child, removeChild) {
 
 export async function decorateBlockBg(block, node, { useHandleFocalpoint = false } = {}) {
   const childCount = node.childElementCount;
-  if (node.querySelector('img, video, a[href*=".mp4"]') || childCount > 1) {
+  if (node.querySelector('img, video, a[href*=".mp4"], a[href*=".m4v"]') || childCount > 1) {
     node.classList.add('background');
     const binaryVP = [['mobile-only'], ['tablet-only', 'desktop-only']];
     const allVP = [['mobile-only'], ['tablet-only'], ['desktop-only']];
     const viewports = childCount === 2 ? binaryVP : allVP;
     [...node.children].forEach((child, i) => {
-      const videoLink = child.querySelector('a[href*=".mp4"]');
+      const videoLink = child.querySelector('a[href*=".mp4"], a[href*=".m4v"]');
       if (videoLink && !videoLink.hash) videoLink.hash = 'autoplay';
       if (childCount > 1) child.classList.add(...viewports[i]);
       const pic = child.querySelector('picture');
@@ -108,7 +108,7 @@ export async function decorateBlockBg(block, node, { useHandleFocalpoint = false
         && (child.childElementCount === 2 || child.textContent?.trim())) {
         handleFocalpoint(pic, child, true);
       }
-      if (!child.querySelector('img, video, a[href*=".mp4"]')) {
+      if (!child.querySelector('img, video, a[href*=".mp4"], a[href*=".m4v"]')) {
         child.style.background = child.textContent;
         child.textContent = '';
       }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -92,6 +92,7 @@ const AUTO_BLOCKS = [
   { youtube: 'https://youtu.be' },
   { 'pdf-viewer': '.pdf' },
   { video: '.mp4' },
+  { video: '.m4v' },
   { merch: '/tools/ost?' },
   { 'offer-preview': '/tools/commerce' },
 ];

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -553,7 +553,7 @@ export function decorateAutoBlock(a) {
       }
 
       // previewing a fragment page with mp4 video
-      if (a.textContent.match('media_.*.mp4')) {
+      if (a.textContent.match('media_.*.(?:mp4|m4v)')) {
         a.className = 'video link-block';
         return false;
       }
@@ -569,7 +569,7 @@ export function decorateAutoBlock(a) {
     }
 
     // slack uploaded mp4s
-    if (key === 'video' && !a.textContent.match('media_.*.mp4')) {
+    if (key === 'video' && !a.textContent.match('media_.*.(?:mp4|m4v)')) {
       return false;
     }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* The Franklin bot (Slack uploaded videos) now creates .m4v files instead of .mp4 files. Milo needs to support both file extensions moving forward.

Resolves: [MWPW-138221](https://jira.corp.adobe.com/browse/MWPW-138221)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ebartholomew/document2?martech=off
- After: https://ebartholomew-m4v-support--milo--adobecom.hlx.page/drafts/ebartholomew/document2?martech=off
