### PR TITLE
MWPW-139968: Catalog Marquee

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -718,3 +718,37 @@
     max-width: var(--grid-container-width);
   }
 }
+
+/* catalog marquee */
+
+@media screen and (min-width: 800px) {
+  .marquee.catalog .foreground .text {
+    max-width: 800px;
+  }
+}
+
+.marquee.catalog .foreground .catalog-product-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  justify-content: center;
+  width: 100%;
+  text-align: center;
+  position: relative;
+  margin: 0 0 var(--spacing-s);
+}
+
+.marquee.catalog .foreground .catalog-product {
+  display: flex;
+  flex: none;
+  gap: var(--spacing-xxs);
+}
+
+.marquee.catalog .foreground .catalog-product-list .catalog-product strong {
+  font-size: var(--type-heading-xxs-size);
+  line-height: var(--type-heading-xs-lh);
+}
+
+.marquee.catalog .foreground .catalog-product-list .catalog-product picture img {
+  width: var(--icon-size-xs);
+}

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -64,12 +64,12 @@ const decorateImage = (media) => {
   }
 };
 
-const decorateCatalogProductList = (el, foreground) => {
-  if (!el.classList.contains('catalog') && !foreground) return;
+const decorateCatalogProductList = (classList, foreground) => {
+  if (!classList.contains('catalog') && !foreground) return;
   const paragraphs = foreground.querySelectorAll(':scope p:not([class])');
   if (paragraphs.length < 1) return;
   const productList = createTag('div', { class: 'catalog-product-list' });
-  paragraphs.forEach((paragraph) => {
+  [...paragraphs].forEach((paragraph) => {
     const title = paragraph.querySelector('strong');
     const picture = paragraph.querySelector('picture');
     const product = createTag('div', { class: 'catalog-product' });
@@ -134,5 +134,5 @@ export default function init(el) {
       media?.lastChild.remove();
     }
   }
-  decorateCatalogProductList(el, foreground);
+  decorateCatalogProductList(el.classList, foreground);
 }

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -64,6 +64,26 @@ const decorateImage = (media) => {
   }
 };
 
+const decorateCatalogProductList = (el, foreground) => {
+  if (!el.classList.contains('catalog') && !foreground) return;
+  const paragraphs = foreground.querySelectorAll(':scope p:not([class])');
+  if (paragraphs.length < 1) return;
+  const productList = createTag('div', { class: 'catalog-product-list' });
+  paragraphs.forEach((paragraph) => {
+    const title = paragraph.querySelector('strong');
+    const picture = paragraph.querySelector('picture');
+    const product = createTag('div', { class: 'catalog-product' });
+    if (title.innerText === 'Includes:') {
+      product.appendChild(title);
+    } else if (picture) {
+      product.appendChild(picture);
+      product.appendChild(title);
+    }
+    productList.appendChild(product);
+    paragraph.replaceWith(productList);
+  });
+};
+
 export default function init(el) {
   const isLight = el.classList.contains('light');
   if (!isLight) el.classList.add('dark');
@@ -114,4 +134,5 @@ export default function init(el) {
       media?.lastChild.remove();
     }
   }
+  decorateCatalogProductList(el, foreground);
 }

--- a/test/blocks/marquee/marquee.test.js
+++ b/test/blocks/marquee/marquee.test.js
@@ -105,4 +105,32 @@ describe('marquee', () => {
       expect(marquee.querySelector('.icon-area-multiple')).to.exist;
     });
   });
+
+  describe('catalog marquee', () => {
+    const marquee = document.getElementById('catalog-marquee');
+    const productList = marquee.querySelector('.catalog-product-list');
+    it('has a catalog-product-list', () => {
+      init(marquee);
+      expect(productList).to.exist;
+    });
+    it('has a catalog product', () => {
+      init(marquee);
+      const product = marquee.querySelector('.catalog-product');
+      expect(product).to.exist;
+    });
+    it('has a catalog product with a title', () => {
+      init(marquee);
+      const product = productList.querySelectorAll('.catalog-product')[0];
+      const title = product.querySelector('strong');
+      expect(title).to.exist;
+    });
+    it('has a catalog product with an image and title', () => {
+      init(marquee);
+      const product = productList.querySelectorAll('.catalog-product')[1];
+      const title = product.querySelector('strong');
+      const mnemonic = product.querySelector('picture');
+      expect(title).to.exist;
+      expect(mnemonic).to.exist;
+    });
+  });
 });

--- a/test/blocks/marquee/mocks/body.html
+++ b/test/blocks/marquee/mocks/body.html
@@ -367,3 +367,17 @@
       </div>
     </div>
   </div>
+<h2>Catalog Marquee</h2>
+<div class="marquee quiet light center catalog" id="catalog-marquee">
+  <div>
+    <div data-valign="middle">linear-gradient(90deg, rgba(226,106,96,1) 0%, rgba(228,170,166,1) 51%, rgba(163,243,120,1) 100%)</div>
+  </div>
+  <div>
+    <div data-valign="middle">
+      <h2>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</h2>
+      <p>Body M Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.</p>
+      <p><br><strong>Includes:</strong></p>
+      <p><picture><img loading="lazy" src="/assets/img/product-icons/svg/acrobat-pro-40.svg" alt="Acrobat Pro"></picture> <strong>Acrobat</strong></p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Introduces a Catalog Marquee variant which includes a list of product mnemonics and titles for catalog page.

Resolves: [MWPW-139968](https://jira.corp.adobe.com/browse/MWPW-139968)
Xd: https://xd.adobe.com/view/432e3b75-3e56-4ea2-bc4b-b5e13c9ee2cd-167d/screen/83d63683-6649-47d4-951d-444ef03bff12/specs/
<img width="1566" alt="Screenshot 2023-12-11 at 3 13 26 PM" src="https://github.com/adobecom/milo/assets/1179549/a919b31d-3be1-4f4c-a125-c0f8466f7d40">

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/catalog?martech=off
- After: https://main--cc--adobecom.hlx.page/products/catalog?milolibs=MWPW-139968--milo--axelcureno&martech=off

URL for testing:

- https://main--cc--adobecom.hlx.page/products/catalog?milolibs=MWPW-139968--milo--axelcureno&martech=off