### PR TITLE
[MWPW-140401] Adapt nav gradient link styles

### DIFF
--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -97,6 +97,10 @@
   left: 18px;
 }
 
+.feds-navLink[class *= '-gradient'] {
+  display: none;
+}
+
 .feds-navLink-image,
 .feds-navLink-description {
   display: none;
@@ -216,11 +220,22 @@
 
   /* Nav Link special styles for A/B test */
   .feds-navLink[class *= '-gradient'] {
+    display: flex;
     border-radius: 4px;
+  }
+
+  .feds-menu-column--group .feds-navLink[class *= '-gradient'] {
+    padding-left: 8px;
+    padding-right: 8px;
+    column-gap: 8px;
   }
 
   .feds-navLink[class *= '-gradient']:not(:first-child) {
     margin-top: 12px;
+  }
+
+  .feds-menu-column--group .feds-navLink[class *= '-gradient'] picture {
+    max-width: 18px;
   }
 
   .feds-navLink[class *= '-gradient'] .feds-navLink-title {

--- a/libs/blocks/global-navigation/utilities/menu/menu.css
+++ b/libs/blocks/global-navigation/utilities/menu/menu.css
@@ -124,6 +124,11 @@
     margin-bottom: 12px;
   }
 
+  .feds-menu-column--group .feds-menu-headline {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
   .feds-menu-headline:after {
     content: none;
   }


### PR DESCRIPTION
## Description
To better match Studio specs and AEM implementation for the upcoming A/B test, a few styling tweaks are needed:
* hide links with gradients on mobile devices;
* lower the lateral padding of links with gradients, as well as the distance between the icon and text;
* limit the icon width of link gradients to `18px`. Looking forward to an eventual full implementation of this feature, authors will need to use the correctly-sized icons themselves;
* align the multi-column headline border and text with its inner-content.

## Related Issue
Resolves: [MWPW-140401](https://jira.corp.adobe.com/browse/MWPW-140401)

## Testing instructions
The story contains the link to the current AEM implementation in the comments section. That one and the Milo one should closely match. An outstanding question is regarding gradient elements font weights - design shows regular, AEM implements a bolded version, that is still pending some discussions.

## Screenshots:
<img width="948" alt="Screenshot 2023-12-13 at 14 38 02" src="https://github.com/adobecom/milo/assets/11267498/7e2f68c1-cc0c-4e6e-bd13-0301ad8453aa">

## Test URLs
**Acrobat** (no change):
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=adapt-nav-gradient-elems--milo--overmyheadandbody

**BACOM** (no change):
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=adapt-nav-gradient-elems--milo--overmyheadandbody

**CC:**
- Before: https://main--cc--adobecom.hlx.page/drafts/dwilbank/display-ace0687?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/dwilbank/display-ace0687?milolibs=adapt-nav-gradient-elems--milo--overmyheadandbody&martech=off

**Homepage** (no change):
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=adapt-nav-gradient-elems--milo--overmyheadandbody

**Blog** (no change):
- Before: https://main--blog--adobecom.hlx.page/
- After: https://main--blog--adobecom.hlx.page/?milolibs=adapt-nav-gradient-elems--milo--overmyheadandbody

**Milo:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor-colourful?martech=off
- After: https://adapt-nav-gradient-elems--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor-colourful?martech=off