### PR TITLE
Promo Preview in MEP: fix active schedule display

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -530,10 +530,11 @@ const normalizeFragPaths = ({ selector, val }) => ({
 });
 
 export async function runPersonalization(info, config) {
-  const { manifestPath } = info;
+  const { manifestPath, event, disabled } = info;
 
   const experiment = await getPersConfig(info);
-
+  experiment.event = event;
+  experiment.disabled = disabled;
   if (!experiment) return null;
 
   const { selectedVariant } = experiment;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -469,6 +469,8 @@ export async function getPersConfig(info) {
     manifestPlaceholders,
     manifestInfo,
     variantLabel,
+    disabled,
+    event,
   } = info;
   let data = manifestData;
   if (!data) {
@@ -516,6 +518,8 @@ export async function getPersConfig(info) {
   config.name = name;
   config.manifest = manifestPath;
   config.manifestUrl = manifestUrl;
+  config.disabled = disabled;
+  config.event = event;
   return config;
 }
 
@@ -530,11 +534,9 @@ const normalizeFragPaths = ({ selector, val }) => ({
 });
 
 export async function runPersonalization(info, config) {
-  const { manifestPath, event, disabled } = info;
+  const { manifestPath } = info;
 
   const experiment = await getPersConfig(info);
-  experiment.event = event;
-  experiment.disabled = disabled;
   if (!experiment) return null;
 
   const { selectedVariant } = experiment;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

The schedule is not shown in Preview when the promo is active, see screenshots.
before 
<img width="436" alt="image" src="https://github.com/adobecom/milo/assets/6617234/dda557dd-2750-4e04-bb16-c06ad69b8c36">
after 
<img width="565" alt="image" src="https://github.com/adobecom/milo/assets/6617234/b7489f47-4c0a-4ad0-9538-afe82e7e050f">


Resolves: [MWPW-140526](https://jira.corp.adobe.com/browse/MWPW-140526)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/products/special-offers?martech=off
- After: https://promofix--milo--adobecom.hlx.page/products/special-offers?martech=off
