### PR TITLE
MWPW-140529-140013: group block changes + handling sanitize styles

### DIFF
--- a/tools/loc/rollout.js
+++ b/tools/loc/rollout.js
@@ -138,9 +138,10 @@ function getMergedMdast(langstoreNowProcessedMdast, livecopyProcessedMdast) {
     function addTrackChangesInfoToChildren(content) {
       if (content?.children) {
         const { children } = content;
+        const typesToTrack = ['text', 'gtRow', 'image', 'html', 'paragraph', 'heading'];
         for (let i = 0; i < children.length; i += 1) {
           const child = children[i];
-          if (child.type === 'text' || child.type === 'gtRow' || child.type === 'image' || child.type === 'html') {
+          if (typesToTrack.includes(child.type)) {
             child.author = author;
             child.action = action;
           }


### PR DESCRIPTION
This makes grouping track changes style consistent with normal track changes. Also, handles the sanitized styles where track changes info is removed by library.

Resolves: [MWPW-140529](https://jira.corp.adobe.com/browse/MWPW-140529)  & [MWPW-140013](https://jira.corp.adobe.com/browse/MWPW-140013)
