### PR TITLE
MWPW-140272 Move MEP button to the left side

### DIFF
--- a/libs/features/personalization/preview.css
+++ b/libs/features/personalization/preview.css
@@ -2,7 +2,7 @@
   z-index: 101;
   position: fixed;
   bottom: 32px;
-  right: 40px;
+  left: 40px;
   color: #eee;
   font-weight: 600;
   font-size: 24px;
@@ -32,7 +32,7 @@
   height: 22px;
   border: 2px solid;
   border-radius: 100px;
-  margin-left: 16px;
+  margin-right: 16px;
 }
 
 .mep-popup-header > div > div:not(.mep-manifest-page-info-title) {
@@ -41,7 +41,7 @@
 
 @media screen and (max-width: 599px) {
   .mep-hidden .mep-badge .mep-open {
-    margin-left: 0;
+    margin-right: 0;
   }
 
   .mep-hidden .mep-badge .mep-manifest-count {
@@ -74,8 +74,8 @@
 }
 
 .mep-hidden .mep-badge .mep-open::after {
-  transform: rotate(-135deg);
-  left: 7px;
+  transform: rotate(45deg);
+  left: 5px;
   bottom: 6px;
 }
 
@@ -100,7 +100,7 @@
 
 .mep-popup-header .mep-close {
   position: absolute;
-  right: 15px;
+  right: 5px;
   cursor: pointer;
   top: 15px;
 }
@@ -120,7 +120,7 @@
 .mep-popup {
   position: absolute;
   bottom: 64px;
-  right: -8px;
+  left: -8px;
   background-color: #444;
   min-width: 300px;
   border-radius: 16px;
@@ -180,7 +180,7 @@
   border-right: 15px solid transparent;
   border-top: 15px solid #444;
   bottom: -15px;
-  right: 30px;
+  left: 30px;
 }
 
 .mep-hidden .mep-popup {

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -210,8 +210,8 @@ function createPreviewPill(manifests) {
 
   div.innerHTML = `
     <div class="mep-manifest mep-badge">
-      <div class="mep-manifest-count">${manifests?.length || 0} Manifest(s) served</div>
       <span class="mep-open"></span>
+      <div class="mep-manifest-count">${manifests?.length || 0} Manifest(s) served</div>
     </div>
     <div class="mep-popup">
     <div class="mep-popup-header">


### PR DESCRIPTION
Because the chat feature is located in the same location as the MEP button, they interfere with each other on pages using both.
Solution, move the MEP button to the bottom left corner (both in mobile and desktop view)

Example: https://business.adobe.com/?mep

![image](https://github.com/adobecom/milo/assets/101133187/f36c392d-2ff8-4531-911d-b12932f8c639)
![image](https://github.com/adobecom/milo/assets/101133187/0a20a9a5-0c6c-4ef5-8db0-2d5617190c30)

Resolves: [MWPW-140272](https://jira.corp.adobe.com/browse/MWPW-140272)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?mep&martech=off
- After: https://move-mep-btn--milo--adobecom.hlx.page/?mep&martech=off
