### PR TITLE
MWPW-140470: allow OST to overwrite landscape

### DIFF
--- a/libs/blocks/ost/ost.js
+++ b/libs/blocks/ost/ost.js
@@ -15,6 +15,7 @@ const OST_STYLE_URL = `${OST_BASE}/index.css`;
 /** @see https://git.corp.adobe.com/PandoraUI/core/blob/master/packages/react-env-provider/src/component.tsx#L49 */
 export const WCS_ENV = 'PROD';
 export const WCS_API_KEY = 'wcms-commerce-ims-ro-user-cc';
+export const WCS_LANDSCAPE = 'PUBLISHED';
 
 /**
  * Maps Franklin page metadata to OST properties.
@@ -137,6 +138,7 @@ export async function loadOstEnv() {
   window.history.replaceState({}, null, newURL);
 
   const environment = searchParameters.get('env') ?? WCS_ENV;
+  const landscape = searchParameters.get('wcsLandscape') ?? WCS_LANDSCAPE;
   const owner = searchParameters.get('owner');
   const referrer = searchParameters.get('referrer');
   const repo = searchParameters.get('repo');
@@ -210,6 +212,7 @@ export async function loadOstEnv() {
     onSelect,
     country,
     environment,
+    landscape,
     language,
     searchParameters: ostSearchParameters,
     searchOfferSelectorId,

--- a/test/blocks/ost/mocks/ost-utils.js
+++ b/test/blocks/ost/mocks/ost-utils.js
@@ -33,14 +33,14 @@ const mockRes = ({ payload, status = 200 } = {}) => new Promise((resolve) => {
   });
 });
 
-function mockOstDeps({ failStatus = false, failMetadata = false, mockToken } = {}) {
+function mockOstDeps({ failStatus = false, failMetadata = false, mockToken, overrideParams } = {}) {
   const options = {
     country: 'CH',
     language: 'de',
     workflow: 'UCv2',
   };
 
-  const params = {
+  const defaultParams = {
     ref: 'main',
     repo: 'milo',
     owner: 'adobecom',
@@ -49,6 +49,7 @@ function mockOstDeps({ failStatus = false, failMetadata = false, mockToken } = {
     referrer: 'https://adobe.sharepoint.com/:w:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B341A5A28-4B2F-4BC0-B7D4-6467E22B275C%7D&file=index.docx&action=default&mobileredirect=true',
     token: mockToken ? 'aos-access-token' : undefined,
   };
+  const params = { ...defaultParams, ...overrideParams };
 
   window.fetch = sinon.stub()
     .onFirstCall()

--- a/test/blocks/ost/ost.test.html.js
+++ b/test/blocks/ost/ost.test.html.js
@@ -150,4 +150,32 @@ describe('init', () => {
     window.adobeid.onReady();
     expect(window.adobeIMS.signIn.called).to.be.true;
   });
+
+  it('opens OST with overwritten WCS "landscape" and "env" values', async () => {
+    const {
+      options: { country, language, workflow },
+      params: { token },
+    } = mockOstDeps({ mockToken: true, overrideParams: { wcsLandscape: 'DRAFT', env: 'stage' } });
+
+    const {
+      AOS_API_KEY,
+      CHECKOUT_CLIENT_ID,
+      WCS_API_KEY,
+      default: init,
+    } = await import('../../../libs/blocks/ost/ost.js');
+    await init(document.body.firstChild);
+
+    expect(window.ost.openOfferSelectorTool.called).to.be.true;
+    expect(window.ost.openOfferSelectorTool.getCall(0).args[0]).to.include({
+      aosAccessToken: token,
+      aosApiKey: AOS_API_KEY,
+      checkoutClientId: CHECKOUT_CLIENT_ID,
+      country,
+      environment: 'stage',
+      landscape: 'DRAFT',
+      language,
+      wcsApiKey: WCS_API_KEY,
+      workflow,
+    });
+  });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Allow opening OST with landscape=DRAFT

Resolves: [MWPW-140470](https://jira.corp.adobe.com/browse/MWPW-140470)

Only affects OST Tool, so no PSI checks trigger.

**Test URLs:**
- Default OST: https://main--milo--adobecom.hlx.page/tools/ost
- Draft OST: https://ostdraft--milo--adobecom.hlx.page/tools/ost?wcsLandscape=draft
