### PR TITLE
MWPW-140321 - how-to block - Heading area without Image has gap

### DIFF
--- a/libs/blocks/how-to/how-to.css
+++ b/libs/blocks/how-to/how-to.css
@@ -74,15 +74,22 @@ html[dir="rtl"] .how-to ol > li::before {
     column-gap: var(--spacing-m);
     grid-template-rows: 1fr;
     grid-template-areas:
+      "heading heading"
+      "list list"
+  }
+
+  .how-to .foreground.has-image {
+    grid-template-areas:
       "heading image"
       "list list"
   }
 
-  .how-to.large-image .foreground {
+  .how-to.large-image .foreground,
+  .how-to.large-image .foreground.has-image {
     grid-template-rows: 1fr;
     grid-auto-rows: min-content;
     grid-template-areas:
-      "heading image"
+      "heading heading"
       "list image"
   }
 

--- a/libs/blocks/how-to/how-to.js
+++ b/libs/blocks/how-to/how-to.js
@@ -136,6 +136,7 @@ export default function init(el) {
   decorateTextOverrides(el);
   const rows = el.querySelectorAll(':scope > div');
   const foreground = createTag('div', { class: 'foreground' });
+  if (mainImage) foreground.classList.add('has-image');
   rows.forEach((row) => { foreground.appendChild(row); });
   foreground.appendChild(orderedList);
   el.appendChild(foreground);


### PR DESCRIPTION
Fixed the how-to grid styles to support full container layouts when authored w/ out a supporting content image. 

* Included a class `.has-image` on the `.foreground` element to apply conditional grid logic. 

Resolves: [MWPW-140321](https://jira.corp.adobe.com/browse/MWPW-140321)

**Test LIVE URLs**
 - Before: https://main--cc--adobecom.hlx.page/drafts/00-CC-milo-migration/batch02/products/indesign/presentation-maker#how-to-design-a-presentation-from-scratch
 - After: https://main--cc--adobecom.hlx.page/drafts/00-CC-milo-migration/batch02/products/indesign/presentation-maker?milolibs=rparrish-howto-patch#how-to-design-a-presentation-from-scratch

**Test Draft URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/how-to?martech=off
- After: https://rparrish-howto-patch--milo--adobecom.hlx.page/drafts/rparrish/how-to?martech=off

Testing notes: Compare the before/after views and scroll down to the '[Testing overflow title](https://rparrish-howto-patch--milo--adobecom.hlx.page/drafts/rparrish/how-to#testing-overflow-title)' section. You should notice the title/desc header row goes full container width. 

The other examples in this draft show the existing authoring patterns. 
 - image in the headline. 
 - image split w/ list content w/ class `.large-image`