### PR TITLE
MWPW-140273 Highlight replace fragment

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -88,6 +88,8 @@ export const preloadManifests = ({ targetManifests = [], persManifests = [] }) =
   return manifests;
 };
 
+export const getFileName = (path) => path?.split('/').pop();
+
 const createFrag = (el, url, manifestId) => {
   let href = url;
   try {
@@ -97,7 +99,7 @@ const createFrag = (el, url, manifestId) => {
     // ignore
   }
   const a = createTag('a', { href }, url);
-  if (manifestId) a.dataset.manifestId = manifestId.split('/').pop();
+  if (manifestId) a.dataset.manifestId = manifestId;
   let frag = createTag('p', undefined, a);
   const isSection = el.parentElement.nodeName === 'MAIN';
   if (isSection) {
@@ -115,8 +117,7 @@ const COMMANDS = {
   removecontent: (el, target, manifestId) => {
     if (target === 'false') return;
     if (manifestId) {
-      const div = createTag('div');
-      div.dataset.removedManifestId = manifestId.split('/').pop();
+      const div = createTag('div', { 'data-removed-manifest-id': manifestId });
       el.insertAdjacentElement('beforebegin', div);
     }
     el.classList.add(CLASS_EL_DELETE);
@@ -560,8 +561,7 @@ export async function applyPers(manifests) {
   });
   const pznManifests = pznList.map((r) => {
     const val = r.experiment?.manifestOverrideName || r.experiment?.manifest;
-    return val.split('/').pop().replace('.json', '').trim()
-      .slice(0, 15);
+    return getFileName(val).replace('.json', '').trim().slice(0, 15);
   });
   document.body.dataset.mep = `${pznVariants.join('--')}|${pznManifests.join('--')}`;
 }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -97,7 +97,7 @@ const createFrag = (el, url, manifestId) => {
     // ignore
   }
   const a = createTag('a', { href }, url);
-  if (manifestId) a.dataset.manifestId = manifestId;
+  if (manifestId) a.dataset.manifestId = manifestId.split('/').pop();
   let frag = createTag('p', undefined, a);
   const isSection = el.parentElement.nodeName === 'MAIN';
   if (isSection) {
@@ -115,7 +115,8 @@ const COMMANDS = {
   removecontent: (el, target, manifestId) => {
     if (target === 'false') return;
     if (manifestId) {
-      const div = createTag('div', { 'data-removed-manifest-id': manifestId });
+      const div = createTag('div');
+      div.dataset.removedManifestId = manifestId.split('/').pop();
       el.insertAdjacentElement('beforebegin', div);
     }
     el.classList.add(CLASS_EL_DELETE);

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -215,7 +215,7 @@ function handleCommands(commands, manifestId, rootEl = document) {
       try {
         const selectorEl = rootEl.querySelector(cmd.selector);
         if (!selectorEl) return;
-        COMMANDS[cmd.action](selectorEl, cmd.target, manifestId);
+        COMMANDS[cmd.action](selectorEl, cmd.target, getFileName(manifestId));
       } catch (e) {
         console.log('Invalid selector: ', cmd.selector);
       }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -215,7 +215,7 @@ function handleCommands(commands, manifestId, rootEl = document) {
       try {
         const selectorEl = rootEl.querySelector(cmd.selector);
         if (!selectorEl) return;
-        COMMANDS[cmd.action](selectorEl, cmd.target, getFileName(manifestId));
+        COMMANDS[cmd.action](selectorEl, cmd.target, manifestId);
       } catch (e) {
         console.log('Invalid selector: ', cmd.selector);
       }
@@ -474,7 +474,7 @@ export async function runPersonalization(info, config) {
   selectedVariant.insertscript?.map((script) => loadScript(script.val));
   selectedVariant.updatemetadata?.map((metadata) => setMetadata(metadata));
 
-  let manifestId = experiment.manifest;
+  let manifestId = getFileName(experiment.manifest);
   if (!config.mep?.preview) {
     manifestId = false;
   } else if (experiment.name) {

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -257,19 +257,33 @@ function createPreviewPill(manifests) {
   addPillEventListeners(div);
 }
 
-function addMarkerData(manifests) {
+function addHighlightData(manifests) {
   manifests.forEach((manifest) => {
-    manifest?.selectedVariant.useblockcode?.forEach((item) => {
-      if (item.selector) {
-        document.querySelectorAll(`.${item.selector}`).forEach((el) => {
-          el.dataset.codeManifestId = manifest.manifest;
+    const {
+      selectedVariant,
+      replacefragment = selectedVariant?.replacefragment,
+      useblockcode = selectedVariant?.useblockcode,
+      manifestName = manifest.manifest?.split('/').pop(),
+    } = manifest;
+    replacefragment?.forEach((item) => {
+      const { val } = item;
+      document.querySelectorAll(`[data-path*="${val}"]`).forEach((el) => {
+        el.dataset.manifestId = manifestName;
+      });
+    });
+    useblockcode?.forEach((item) => {
+      const { selector } = item;
+      if (selector) {
+        document.querySelectorAll(`.${selector}`).forEach((el) => {
+          el.dataset.codeManifestId = manifestName;
         });
       }
     });
     manifest?.selectedVariant.updatemetadata?.forEach((item) => {
-      if (item.selector === 'gnav-source') {
+      const { selector } = item;
+      if (selector === 'gnav-source') {
         document.querySelectorAll('header, footer').forEach((el) => {
-          el.dataset.manifestId = manifest.manifest;
+          el.dataset.manifestId = manifestName;
         });
       }
     });
@@ -279,8 +293,8 @@ function addMarkerData(manifests) {
 export default async function decoratePreviewMode() {
   const { miloLibs, codeRoot, experiments } = getConfig();
   loadStyle(`${miloLibs || codeRoot}/features/personalization/preview.css`);
-  if (experiments) addMarkerData(experiments);
   document.addEventListener(MILO_EVENTS.DEFERRED, () => {
     createPreviewPill(experiments);
+    if (experiments) addHighlightData(experiments);
   }, { once: true });
 }

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -1,5 +1,5 @@
 import { createTag, getConfig, getMetadata, loadStyle, MILO_EVENTS } from '../../utils/utils.js';
-import { NON_TRACKED_MANIFEST_TYPE } from './personalization.js';
+import { NON_TRACKED_MANIFEST_TYPE, getFileName } from './personalization.js';
 
 function updatePreviewButton() {
   const selectedInputs = document.querySelectorAll(
@@ -169,7 +169,7 @@ function createPreviewPill(manifests) {
       <label for="${manifestPath}--default" ${checked.class}>Default (control)</label>
     </div>`;
 
-    const manifestFileName = manifestPath.split('/').pop();
+    const manifestFileName = getFileName(manifestPath);
     const targetTitle = name ? `${name}<br><i>${manifestFileName}</i>` : manifestFileName;
     const scheduled = manifest.event
       ? `<p>Scheduled - ${manifest.disabled ? 'inactive' : 'active'}</p>
@@ -263,7 +263,7 @@ function addHighlightData(manifests) {
       selectedVariant,
       replacefragment = selectedVariant?.replacefragment,
       useblockcode = selectedVariant?.useblockcode,
-      manifestName = manifest.manifest?.split('/').pop(),
+      manifestName = getFileName(manifest.manifest),
     } = manifest;
     replacefragment?.forEach((item) => {
       const { val } = item;

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -1,6 +1,8 @@
 import { createTag, getConfig, getMetadata, loadStyle, MILO_EVENTS } from '../../utils/utils.js';
 import { NON_TRACKED_MANIFEST_TYPE, getFileName } from './personalization.js';
 
+// permissions test
+
 function updatePreviewButton() {
   const selectedInputs = document.querySelectorAll(
     '.mep-popup input[type="radio"]:checked, .mep-popup input[type="text"]',

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -258,34 +258,23 @@ function createPreviewPill(manifests) {
 }
 
 function addHighlightData(manifests) {
-  manifests.forEach((manifest) => {
-    const {
-      selectedVariant,
-      replacefragment = selectedVariant?.replacefragment,
-      useblockcode = selectedVariant?.useblockcode,
-      manifestName = getFileName(manifest.manifest),
-    } = manifest;
-    replacefragment?.forEach((item) => {
-      const { val } = item;
-      document.querySelectorAll(`[data-path*="${val}"]`).forEach((el) => {
-        el.dataset.manifestId = manifestName;
-      });
+  manifests.forEach(({ selectedVariant, manifest }) => {
+    const manifestName = getFileName(manifest);
+
+    const updateManifestId = (selector, prop = 'manifestId') => {
+      document.querySelectorAll(selector).forEach((el) => (el.dataset[prop] = manifestName));
+    };
+
+    selectedVariant?.replacefragment?.forEach(
+      ({ val }) => updateManifestId(`[data-path*="${val}"]`),
+    );
+
+    selectedVariant?.useblockcode?.forEach(({ selector }) => {
+      if (selector) updateManifestId(`.${selector}`, 'codeManifestId');
     });
-    useblockcode?.forEach((item) => {
-      const { selector } = item;
-      if (selector) {
-        document.querySelectorAll(`.${selector}`).forEach((el) => {
-          el.dataset.codeManifestId = manifestName;
-        });
-      }
-    });
-    manifest?.selectedVariant.updatemetadata?.forEach((item) => {
-      const { selector } = item;
-      if (selector === 'gnav-source') {
-        document.querySelectorAll('header, footer').forEach((el) => {
-          el.dataset.manifestId = manifestName;
-        });
-      }
+
+    selectedVariant?.updatemetadata?.forEach(({ selector }) => {
+      if (selector === 'gnav-source') updateManifestId('header, footer');
     });
   });
 }

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -1,8 +1,6 @@
 import { createTag, getConfig, getMetadata, loadStyle, MILO_EVENTS } from '../../utils/utils.js';
 import { NON_TRACKED_MANIFEST_TYPE, getFileName } from './personalization.js';
 
-// permissions test
-
 function updatePreviewButton() {
   const selectedInputs = document.querySelectorAll(
     '.mep-popup input[type="radio"]:checked, .mep-popup input[type="text"]',

--- a/test/features/personalization/mocks/postPersonalization.html
+++ b/test/features/personalization/mocks/postPersonalization.html
@@ -1,0 +1,71 @@
+<html lang="en-US" dir="ltr"><head><meta name="description" content="Milo Description">
+  <meta property="og:title" content="New Title">
+  <meta name="georouting" content="on">
+  <link rel="preload" as="fetch" crossorigin="anonymous" href="/fragments/milo-replace-content-chrome-howto-h2.plain.html"><link rel="preload" as="fetch" crossorigin="anonymous" href="/fragments/insertafter.plain.html"><link rel="preload" as="fetch" crossorigin="anonymous" href="/fragments/insertbefore.plain.html"><link rel="stylesheet" href="/test/features/personalization/mocks/newpromo/newpromo.css"><link rel="stylesheet" href="/test/features/personalization/mocks/myblock/myblock.css"><meta name="mynewmetadata" content="woot"><meta property="og:image" content="https://adobe.com/path/to/image.jpg"><link rel="preload" as="fetch" crossorigin="anonymous" href="/fragments/insertafter2.plain.html"><link rel="preload" as="fetch" crossorigin="anonymous" href="/fragments/insertafter3.plain.html"></head>
+        <body data-mep="fireflies|manifest">
+  <header></header>
+      <main>
+        <div>
+          <p><a href="/fragments/insertbefore">/fragments/insertbefore</a></p><div class="marquee">
+            <div>
+              <div data-valign="middle">
+                <picture>
+                  <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
+                </picture>
+              </div>
+            </div>
+            <div>
+              <div data-valign="middle">
+                <h2 id="milo-experimentation-platform">Milo Experimentation Platform</h2>
+                <p>Leverage the Milo Experimentation Platform (MEP) for all your personalization needs on Milo!</p>
+                <p><strong><a href="https://wiki.corp.adobe.com/display/marketingtech/Milo+Experiment+Manifests">Review Docs</a></strong></p>
+              </div>
+              <div data-valign="middle">
+                <picture>
+                  <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="811" height="207">
+                </picture>
+              </div>
+            </div>
+          </div><p><a href="/fragments/insertafter3">/fragments/insertafter3</a></p><p><a href="/fragments/insertafter2">/fragments/insertafter2</a></p><p><a href="/fragments/insertafter">/fragments/insertafter</a></p>
+        </div>
+        <div>
+          
+        </div>
+        <div>
+          <div class="how-to">
+            <div>
+              <div data-valign="middle">
+                <h2 id="how-to-leverage-milo-experimentation-platform">How to leverage Milo Experimentation Platform</h2>
+                <p>This will explain the basic steps on how to use the Milo Experimentation Platform.</p>
+                <p>
+                  <picture>
+                    <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
+                  </picture>
+                </p>
+              </div>
+            </div>
+            <div>
+              <div data-valign="middle">
+                <ul>
+                  <li>Create a webpage using Milo</li>
+                  <li>Create a page manifest</li>
+                  <li>Configure the personalization based on your requirements</li>
+                  <li>Sit back and watch visitors enjoy your personalization!</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <p><div class="fragment" data-path="/fragments/fragmentreplaced"><div class="section"><div class="content" data-block=""><h3>The fragment has been replaced</h3></div>
+      
+    </div></div></p>
+        </div>
+        <div>
+          <div class="promo"><div>New Promo!</div></div>
+          <div class="myblock"><div>My New Block!</div></div>
+        </div>
+      </main>
+      <footer></footer>
+  
+  </body></html>

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -1,7 +1,7 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 
-document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
+document.body.innerHTML = await readFile({ path: './mocks/postPersonalization.html' });
 const { default: decoratePreviewMode } = await import('../../../libs/features/personalization/preview.js');
 const { setConfig, MILO_EVENTS } = await import('../../../libs/utils/utils.js');
 
@@ -65,6 +65,12 @@ describe('preview feature', () => {
               selector: '.marquee',
               pageFilter: '',
               target: '/mep/ace0763/marquee',
+            },
+          ],
+          replacefragment: [
+            {
+              selector: '/drafts/vgoodrich/fragments/highlight-replace-fragment/original-fragment',
+              val: '/fragments/fragmentreplaced',
             },
           ],
           useblockcode: [
@@ -164,6 +170,11 @@ describe('preview feature', () => {
     document.dispatchEvent(event);
     expect(document.querySelectorAll('.mep-preview-overlay').length).to.equal(1);
     expect(document.querySelector('.mep-popup-header h4').textContent).to.equal(`${config.experiments.length} Manifest(s) served`);
+  });
+  it('adds highlights', () => {
+    expect(document.querySelector('[data-path="/fragments/fragmentreplaced"]').getAttribute('data-manifest-id')).to.equal('selected-example.json');
+    expect(document.querySelector('.marquee').getAttribute('data-code-manifest-id')).to.equal('selected-example.json');
+    expect(document.querySelector('header').getAttribute('data-manifest-id')).to.equal('selected-example.json');
   });
   it('preselects form inputs', () => {
     expect(document.querySelector('input[name="/homepage/fragments/mep/selected-example.json"][value="target-smb"]').getAttribute('checked')).to.equal('checked');


### PR DESCRIPTION
Updates made by MEP's replaceContent are highlighted if you use mepHighlight, but replaceFragment updates do not highlight in the same way.
Manifest names in highlight are the full path, making it a much longer string.  Name has been truncated to match the preview button panel format.

Resolves: [MWPW-140273](https://jira.corp.adobe.com/browse/MWPW-140273)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/highlight-replace-fragment/?mepHighlight=true&martech=off
- After: https://highlight-replace-fragment--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/highlight-replace-fragment/?mepHighlight=true&martech=off
