### PR TITLE
MWPW-140627 use placeholder keys in analytics to keep them in English

### DIFF
--- a/libs/blocks/martech-metadata/martech-metadata.js
+++ b/libs/blocks/martech-metadata/martech-metadata.js
@@ -1,10 +1,9 @@
 import { getConfig } from '../../utils/utils.js';
-import { processTrackingLabels } from '../../martech/attributes.js';
 
-export const getMetadata = (el, config) => [...el.childNodes].reduce((rdx, row) => {
+export const getMetadata = (el) => [...el.childNodes].reduce((rdx, row) => {
   if (row.children?.length > 1) {
-    const key = processTrackingLabels(row.children[0].textContent, config);
-    const value = processTrackingLabels(row.children[1].textContent, config);
+    const key = row.children[0].textContent.trim();
+    const value = row.children[1].textContent.trim();
     if (key && value) rdx[key] = value;
   }
   return rdx;
@@ -16,7 +15,7 @@ export default function init(el) {
   if (ietf !== 'en-US') {
     config.analyticLocalization = {
       ...analyticLocalization,
-      ...getMetadata(el, config),
+      ...getMetadata(el),
     };
   }
   el.remove();

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -285,7 +285,7 @@ export function parseConfig(data) {
 }
 
 /* c8 ignore start */
-function parsePlaceholders(placeholders, config, selectedVariantName = '') {
+async function parsePlaceholders(placeholders, config, selectedVariantName = '') {
   if (!placeholders?.length || selectedVariantName === 'default') return config;
   const valueNames = [
     'value',
@@ -296,8 +296,10 @@ function parsePlaceholders(placeholders, config, selectedVariantName = '') {
   const [val] = Object.entries(placeholders[0])
     .find(([key]) => valueNames.includes(key.toLowerCase()));
   if (val) {
+    if (!config.analyticLocalization) config.analyticLocalization = {};
     const results = placeholders.reduce((res, item) => {
       res[item.key] = item[val];
+      config.analyticLocalization[item.value] = item.key;
       return res;
     }, {});
     config.placeholders = { ...(config.placeholders || {}), ...results };
@@ -429,7 +431,7 @@ export async function getPersConfig(info) {
   const placeholders = manifestPlaceholders || data?.placeholders?.data;
   if (placeholders) {
     updateConfig(
-      parsePlaceholders(placeholders, getConfig(), config.selectedVariantName),
+      await parsePlaceholders(placeholders, getConfig(), config.selectedVariantName),
     );
   }
 

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -16,8 +16,10 @@ const fetchPlaceholders = (config, sheet) => {
       const json = resp.ok ? await resp.json() : { data: [] };
       if (json.data.length === 0) { resolve({}); return; }
       const placeholders = {};
+      if (!config.analyticLocalization) config.analyticLocalization = {};
       json.data.forEach((item) => {
         placeholders[item.key] = item.value;
+        config.analyticLocalization[item.value.trim()] = item.key;
       });
       resolve(placeholders);
     });

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -2,13 +2,14 @@ const INVALID_CHARACTERS = /[^\u00C0-\u1FFF\u2C00-\uD7FF\w]+/g;
 const LEAD_UNDERSCORES = /^_+|_+$/g;
 
 export function processTrackingLabels(text, config, charLimit) {
-  let analyticsValue = text?.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '').trim();
+  let analyticsValue = text?.trim();
   if (config) {
     const { analyticLocalization, loc = analyticLocalization?.[analyticsValue] } = config;
     if (loc) analyticsValue = loc;
   }
-  if (charLimit) return analyticsValue.slice(0, charLimit);
-  return analyticsValue;
+  analyticsValue = analyticsValue.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '');
+  if (charLimit) return analyticsValue.slice(0, charLimit).trim();
+  return analyticsValue.trim();
 }
 
 export function decorateDefaultLinkAnalytics(block, config) {

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -8,7 +8,7 @@ export function processTrackingLabels(text, config, charLimit) {
     if (loc) analyticsValue = loc;
   }
   analyticsValue = analyticsValue.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '');
-  if (charLimit) return analyticsValue.slice(0, charLimit).trim();
+  if (charLimit) return analyticsValue.slice(0, charLimit);
   return analyticsValue.trim();
 }
 

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -8,7 +8,7 @@ export function processTrackingLabels(text, config, charLimit) {
     if (loc) analyticsValue = loc;
   }
   analyticsValue = analyticsValue?.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '').trim();
-  if (charLimit) return analyticsValue.slice(0, charLimit).trim();
+  if (charLimit) return analyticsValue.slice(0, charLimit);
   return analyticsValue;
 }
 

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -9,7 +9,7 @@ export function processTrackingLabels(text, config, charLimit) {
   }
   analyticsValue = analyticsValue.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '');
   if (charLimit) return analyticsValue.slice(0, charLimit);
-  return analyticsValue.trim();
+  return analyticsValue;
 }
 
 export function decorateDefaultLinkAnalytics(block, config) {

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -2,13 +2,13 @@ const INVALID_CHARACTERS = /[^\u00C0-\u1FFF\u2C00-\uD7FF\w]+/g;
 const LEAD_UNDERSCORES = /^_+|_+$/g;
 
 export function processTrackingLabels(text, config, charLimit) {
-  let analyticsValue = text?.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '').trim();
+  let analyticsValue = text;
   if (config) {
-    const { analyticLocalization, loc = analyticLocalization?.[analyticsValue] } = config;
+    const { analyticLocalization, loc = analyticLocalization?.[analyticsValue.trim()] } = config;
     if (loc) analyticsValue = loc;
   }
-  //analyticsValue = analyticsValue.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '');
-  if (charLimit) return analyticsValue.slice(0, charLimit);
+  analyticsValue = analyticsValue?.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '').trim();
+  if (charLimit) return analyticsValue.slice(0, charLimit).trim();
   return analyticsValue;
 }
 

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -2,12 +2,12 @@ const INVALID_CHARACTERS = /[^\u00C0-\u1FFF\u2C00-\uD7FF\w]+/g;
 const LEAD_UNDERSCORES = /^_+|_+$/g;
 
 export function processTrackingLabels(text, config, charLimit) {
-  let analyticsValue = text?.trim();
+  let analyticsValue = text?.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '').trim();
   if (config) {
     const { analyticLocalization, loc = analyticLocalization?.[analyticsValue] } = config;
     if (loc) analyticsValue = loc;
   }
-  analyticsValue = analyticsValue.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '');
+  //analyticsValue = analyticsValue.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '');
   if (charLimit) return analyticsValue.slice(0, charLimit);
   return analyticsValue;
 }

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -2,9 +2,9 @@ const INVALID_CHARACTERS = /[^\u00C0-\u1FFF\u2C00-\uD7FF\w]+/g;
 const LEAD_UNDERSCORES = /^_+|_+$/g;
 
 export function processTrackingLabels(text, config, charLimit) {
-  let analyticsValue = text;
+  let analyticsValue = text.trim();
   if (config) {
-    const { analyticLocalization, loc = analyticLocalization?.[analyticsValue.trim()] } = config;
+    const { analyticLocalization, loc = analyticLocalization?.[analyticsValue] } = config;
     if (loc) analyticsValue = loc;
   }
   analyticsValue = analyticsValue?.replace(INVALID_CHARACTERS, ' ').replace(LEAD_UNDERSCORES, '').trim();


### PR DESCRIPTION
The recent addition of the martech metadata block allows analytics to stay in English when the page is localized into other languages.

The placeholder feature can be used to translate common phrases.  Currently, the only way to keep the analytics in English is to add every placeholder used to the martech attributes table.  This is unnecessary because the placeholder keys are always in English and prone to error.

This PR automates using the placeholder key in analytics instead of its translated text.

I also realized I could centralize the logic a little more and not import martech/attributes.js in as many places.

The example page has 3 strings being used in the analytics:
1. the header (from a manifest's placeholder tab)
2. hollow button (from the geo folder's placeholder spreadsheet)
3. solid button (just German text but there is martech metadata table with the translation)

If you inspect the buttons and look at the daa-ll attributes, you'll notice only item 3 is English.  The other 2 strings are in German.  In the after version, all 3 strings are in English.

Resolves: [MWPW-140627](https://jira.corp.adobe.com/browse/MWPW-140627)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/de/drafts/vgoodrich/fragments/placeholder-analytics/?martech=off
- After: https://placeholder-analytics--milo--adobecom.hlx.page/de/drafts/vgoodrich/fragments/placeholder-analytics/?martech=off
