### PR TITLE
MWPW-131662: consistent global navigation padding on mobile

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -155,7 +155,7 @@ header.global-navigation {
 /* Popup */
 .feds-popup {
   display: none;
-  padding: 12px 0;
+  padding: 0;
   background-color: var(--feds-background-popup--light);
 }
 
@@ -461,6 +461,17 @@ header.global-navigation {
   right: auto;
 }
 
+/* Mobile styles */
+@media (max-width: 900px) {
+  .feds-menu-section > a:first-child {
+    margin-top: 12px;
+  }
+
+  .feds-menu-column > ul {
+    padding: 12px 0;
+  }
+}
+
 /* Desktop styles */
 @media (min-width: 900px) {
   /* General */
@@ -527,6 +538,7 @@ header.global-navigation {
     z-index: 1;
     box-shadow: 0 3px 3px 0 rgb(0 0 0 / 20%);
     transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */
+    padding: 12px 0;
   }
 
   [dir = "rtl"] .feds-popup {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -460,14 +460,6 @@ header.global-navigation {
   right: auto;
 }
 
-.feds-menu-section > a:first-child {
-  margin-top: 12px;
-}
-
-.feds-menu-column > ul {
-  padding: 12px 0;
-}
-
 /* Desktop styles */
 @media (min-width: 900px) {
   /* General */
@@ -666,14 +658,6 @@ header.global-navigation {
 
   .feds-breadcrumbs a:hover {
     text-decoration: underline;
-  }
-
-  .feds-menu-section > a:first-child {
-    margin: 0;
-  }
-
-  .feds-menu-column > ul {
-    padding: 0;
   }
 }
 

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -155,7 +155,6 @@ header.global-navigation {
 /* Popup */
 .feds-popup {
   display: none;
-  padding: 0;
   background-color: var(--feds-background-popup--light);
 }
 
@@ -461,15 +460,12 @@ header.global-navigation {
   right: auto;
 }
 
-/* Mobile styles */
-@media (max-width: 900px) {
-  .feds-menu-section > a:first-child {
-    margin-top: 12px;
-  }
+.feds-menu-section > a:first-child {
+  margin-top: 12px;
+}
 
-  .feds-menu-column > ul {
-    padding: 12px 0;
-  }
+.feds-menu-column > ul {
+  padding: 12px 0;
 }
 
 /* Desktop styles */
@@ -670,6 +666,14 @@ header.global-navigation {
 
   .feds-breadcrumbs a:hover {
     text-decoration: underline;
+  }
+
+  .feds-menu-section > a:first-child {
+    margin: 0;
+  }
+
+  .feds-menu-column > ul {
+    padding: 0;
   }
 }
 

--- a/libs/blocks/global-navigation/utilities/menu/menu.css
+++ b/libs/blocks/global-navigation/utilities/menu/menu.css
@@ -25,6 +25,14 @@
   padding: 6px 32px;
 }
 
+.feds-menu-column > ul {
+  padding: 12px 0;
+}
+
+.feds-menu-section > a:first-child {
+  margin-top: 12px;
+}
+
 .feds-menu-items {
   display: none;
   padding: 12px 0;
@@ -80,14 +88,6 @@
 
 .feds-promo {
   display: none;
-}
-
-.feds-menu-section > a:first-child {
-  margin-top: 12px;
-}
-
-.feds-menu-column > ul {
-  padding: 12px 0;
 }
 
 @media (min-width: 900px) {

--- a/libs/blocks/global-navigation/utilities/menu/menu.css
+++ b/libs/blocks/global-navigation/utilities/menu/menu.css
@@ -142,7 +142,7 @@
   }
 
   .feds-menu-section > a:first-child {
-    margin: 0;
+    margin-top: 0;
   }
 
   .feds-menu-headline:after {

--- a/libs/blocks/global-navigation/utilities/menu/menu.css
+++ b/libs/blocks/global-navigation/utilities/menu/menu.css
@@ -82,6 +82,14 @@
   display: none;
 }
 
+.feds-menu-section > a:first-child {
+  margin-top: 12px;
+}
+
+.feds-menu-column > ul {
+  padding: 12px 0;
+}
+
 @media (min-width: 900px) {
   .feds-menu-content {
     display: flex;
@@ -127,6 +135,14 @@
   .feds-menu-column--group .feds-menu-headline {
     margin-left: 0;
     margin-right: 0;
+  }
+
+  .feds-menu-column > ul {
+    padding: 0;
+  }
+
+  .feds-menu-section > a:first-child {
+    margin: 0;
   }
 
   .feds-menu-headline:after {


### PR DESCRIPTION
## Description
This helps to set consistent padding for the mobile menu sections of the global navigation.

## Related Issue
Resolves: [MWPW-131662](https://jira.corp.adobe.com/browse/MWPW-131662)

## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=mwpw-131662-mobile-menu-padding--milo--robert-bogos

**BACOM:**
- Before: https://main--bacom--adobecom.hlx.page/products/real-time-customer-data-platform/rtcdp?martech=off
- After: https://main--bacom--adobecom.hlx.page/products/real-time-customer-data-platform/rtcdp?martech=off&milolibs=mwpw-131662-mobile-menu-padding--milo--robert-bogos

**CC:**
- Before: https://main--cc--adobecom.hlx.page/?martech=off
- After: https://main--cc--adobecom.hlx.page/?martech=off&milolibs=mwpw-131662-mobile-menu-padding--milo--robert-bogos

**Milo:**
- Before: https://main--milo--robert-bogos.hlx.page/drafts/rbogos/page-default?martech=off
- After: https://mwpw-131662-mobile-menu-padding--milo--robert-bogos.hlx.page/drafts/rbogos/page-default?martech=off

**Homepage:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=mwpw-131662-mobile-menu-padding--milo--robert-bogos

**Blog:**
- Before: https://main--blog--adobecom.hlx.page/
- After: https://main--blog--adobecom.hlx.page/?milolibs=mwpw-131662-mobile-menu-padding--milo--robert-bogos