### PR TITLE
MWPW-140706: Quiz options should use Adobe Clean

### DIFF
--- a/libs/blocks/quiz/quiz.css
+++ b/libs/blocks/quiz/quiz.css
@@ -68,6 +68,7 @@
   border-radius: 0.5rem;
   cursor: pointer;
   display: flex;
+  font-family: inherit;
   margin: 0 0 16px;
   padding: 0;
   user-select: none;
@@ -180,6 +181,7 @@ html[dir="rtl"] .quiz-option-icon {
   border: 2px solid var(--color-white);
   border-radius: 30px;
   cursor: pointer;
+  font-family: inherit;
   font-size: 14px;
   font-weight: 700;
   min-height: 32px;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Buttons seem to rest to the default user stylesheet font family, rather than inheriting from body, so, I explicitly inherit to pick up Adobe Clean as the desired font, rather than Arial. 

Resolves: [MWPW-140706](https://jira.corp.adobe.com/browse/MWPW-140706)

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.live/drafts/quiz/quiz-2/?martech=off
- After: https://mwpw-140706--milo--echampio-at-adobe.hlx.live/drafts/quiz/quiz-2/?martech=off
