### PR TITLE
MWPW-140538 - Icon Block inline margin

### DIFF
--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -277,6 +277,10 @@
   text-align: center;
 }
 
+[class*='-up'] .icon-block.inline .foreground { 
+  margin: unset; 
+}
+
 [class*="-up"] .icon-block.bio.inline .foreground {
   max-width: unset;
   width: unset;


### PR DESCRIPTION
When inside of a section grid the icon block shouldn't have auto margin. This PR unsets that rule for inline icon blocks when they are found within a section grid.

Resolves: [MWPW-140538](https://jira.corp.adobe.com/browse/MWPW-140538)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/icon-inline-inups?martech=off
- After: https://sarchibeque-mwpw-140538-iconinline--milo--adobecom.hlx.page/drafts/sarchibeque/icon-inline-inups?martech=off
