### PR TITLE
[MWPW-140788] Ensure correct Gnav Promo element order

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/gnav.md
+++ b/.github/PULL_REQUEST_TEMPLATE/gnav.md
@@ -27,11 +27,10 @@ Resolves: [MWPW-111111](https://jira.corp.adobe.com/browse/MWPW-111111)
 - Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
 - After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=<branch>--milo--<owner>
 
-**Milo:**
-- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
-- After: https://<branch>--milo--<owner>.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
-
 **Blog:**
 - Before: https://main--blog--adobecom.hlx.page/
 - After: https://main--blog--adobecom.hlx.page/?milolibs=<branch>--milo--<owner>
 
+**Milo:**
+- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
+- After: https://<branch>--milo--<owner>.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -133,12 +133,9 @@ const decoratePromo = (elem, index) => {
   const imageElem = elem.querySelector('picture');
 
   if (!isImageOnly) {
-    const cachedImageElem = imageElem && elem.removeChild(imageElem.closest(`${selectors.gnavPromo} > div`));
-    const innerContainer = toFragment`<div class="feds-promo-content"></div>`;
-
-    innerContainer.append(...elem.children);
-    elem.appendChild(innerContainer);
-    if (cachedImageElem) elem.appendChild(cachedImageElem);
+    const content = [...elem.querySelectorAll(':scope > div')]
+      .find((section) => !(section.querySelector('picture') instanceof HTMLElement));
+    content?.classList.add('feds-promo-content');
   }
 
   decorateElements({ elem, className: 'feds-promo-link', index });

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -518,6 +518,26 @@ describe('global navigation', () => {
         await createFullGlobalNavigation();
         expect(document.querySelector(`${selectors.promo}${selectors.promo}--dark ${selectors.cta}`)).to.exist;
       });
+
+      it('should render promo elements in initial order', async () => {
+        // Initial template order is text, then image
+        await createFullGlobalNavigation();
+
+        const imgAfterTxt = document.querySelector('.feds-promo-content + .feds-promo-image');
+        expect(imgAfterTxt).to.exist;
+
+        // Switch original order to be image, then text
+        const template = toFragment`<div></div>`;
+        template.innerHTML = globalNavigationMock;
+        const templatePromo = template.querySelector('.gnav-promo');
+        const templatePromoContent = templatePromo.firstElementChild;
+        templatePromoContent.remove();
+        templatePromo.append(templatePromoContent);
+        await createFullGlobalNavigation({ globalNavigation: template.innerHTML });
+
+        const txtAfterImg = document.querySelector('.feds-promo-image + .feds-promo-content');
+        expect(txtAfterImg).to.exist;
+      });
     });
 
     describe('small desktop', () => {


### PR DESCRIPTION
## Description
This ensures that the element order for the Gnav Promo block is maintained in the final UI. This issue has been introduced by a recent commit to add more consistent spacing for some Gnav elements ([link](https://github.com/adobecom/milo/commit/a07d6e51bef9382576e7998a9c8c2ebdfafe2b45)).

## Related Issue
Resolves: [MWPW-140788](https://jira.corp.adobe.com/browse/MWPW-140788)

## Testing instructions
The Milo test page contains all known promo use-cases, their elements should match the order in which they were added to the document.

## Screenshots:
<img width="1232" alt="Screenshot 2024-01-03 at 16 05 29" src="https://github.com/adobecom/milo/assets/11267498/d8dc6286-0780-4cb4-8edc-9f690ed32f4f">

## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=gnav-promo-order--milo--overmyheadandbody

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=gnav-promo-order--milo--overmyheadandbody

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=gnav-promo-order--milo--overmyheadandbody

**Homepage:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=gnav-promo-order--milo--overmyheadandbody

**Blog:**
- Before: https://main--blog--adobecom.hlx.page/
- After: https://main--blog--adobecom.hlx.page/?milolibs=gnav-promo-order--milo--overmyheadandbody

**Page where this was discovered:**
- Before: https://main--cc--adobecom.hlx.page/drafts/jbrown/firefly/firefly?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/jbrown/firefly/firefly?martech=off&milolibs=gnav-promo-order--milo--overmyheadandbody

**Milo:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor-multiple-promos?martech=off
- After: https://gnav-promo-order--milo--overmyheadandbody.hlx.page/drafts/ramuntea/gnav-refactor-multiple-promos?martech=off