### PR TITLE
Fix broken gnav test

### DIFF
--- a/test/blocks/gnav/gnav.test.js
+++ b/test/blocks/gnav/gnav.test.js
@@ -25,7 +25,7 @@ describe('Gnav', () => {
       client_id: 'milo',
       scope: 'gnav',
     };
-    window.adobeIMS = { getAccessToken: () => false };
+    window.adobeIMS = { getAccessToken: () => false, isSignedInUser: () => false };
   });
 
   after(() => {
@@ -172,6 +172,11 @@ describe('Gnav', () => {
 
 describe('Localized Gnav', () => {
   before(async () => {
+    window.adobeid = {
+      client_id: 'milo',
+      scope: 'gnav',
+    };
+    window.adobeIMS = { getAccessToken: () => false, isSignedInUser: () => false };
     // Load Localized Gnav
     await loadDefaultHtml();
     document.head.getElementsByTagName('meta')[0].setAttribute('content', '/test/blocks/gnav/mocks/simple-gnav');

--- a/test/blocks/gnav/gnav.test.js
+++ b/test/blocks/gnav/gnav.test.js
@@ -192,6 +192,8 @@ describe('Localized Gnav', () => {
     setConfig(config);
     await loadDefaultHtml();
     gnav = await mod.default(document.querySelector('header'));
+    delete window.adobeid;
+    delete window.adobeIMS;
   });
 
   it('Test Gnav Localized Links', async () => {


### PR DESCRIPTION
### Description
Fixes a broken test for the old gnav, that was failing due to some changes in the core utils where `isSignedInUser` might not be a function for _tests_. In production this should not be an issue since we specifically wait for IMS to properly load, thus this is only a mocking/test issue.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://fix-failing-gnav-test--milo--adobecom.hlx.page/?martech=off
