### PR TITLE
MWPW-140877 - Quiz Marquee style updates

### DIFF
--- a/libs/blocks/quiz-marquee/quiz-marquee.css
+++ b/libs/blocks/quiz-marquee/quiz-marquee.css
@@ -131,7 +131,7 @@
   display: grid;
   gap: var(--spacing-m);
   width: 100%;
-  grid-template-columns: repeat(auto-fit,300px);
+  grid-template-columns: repeat(auto-fit, 378px);
 }
 
 .quiz-marquee.center .commerce-card {

--- a/libs/blocks/quiz-marquee/quiz-marquee.css
+++ b/libs/blocks/quiz-marquee/quiz-marquee.css
@@ -113,6 +113,10 @@
   margin-right: var(--spacing-xxs);
 }
 
+.quiz-marquee .aside.notification.small .foreground.container .text .body-m {
+  margin: 0;
+}
+
 .quiz-marquee .nested.icon-bullet {
   display: grid;
   gap: var(--spacing-xxs);

--- a/libs/blocks/quiz-marquee/quiz-marquee.css
+++ b/libs/blocks/quiz-marquee/quiz-marquee.css
@@ -104,6 +104,7 @@
 
 .quiz-marquee .aside.notification.small .foreground.container .text {
   align-items: flex-start;
+  flex-flow: row nowrap;
 }
 
 .quiz-marquee .aside.notification.small .foreground.container .text .icon-area {
@@ -126,7 +127,11 @@
   display: grid;
   gap: var(--spacing-m);
   width: 100%;
-  grid-template-columns: repeat(auto-fit, minmax(275px, max-content));
+  grid-template-columns: repeat(auto-fit,300px);
+}
+
+.quiz-marquee.center .commerce-card {
+  justify-content: center;
 }
 
 /* CLS */

--- a/libs/blocks/quiz-results/quiz-results.css
+++ b/libs/blocks/quiz-results/quiz-results.css
@@ -20,7 +20,7 @@
   justify-content: center;
   width: 100%;
   max-width: 100%;
-  grid-template-columns: repeat(auto-fit,minmax(300px,max-content));
+  grid-template-columns: repeat(auto-fit, 378px);
   gap: 32px;
   padding-bottom: 32px;
 }


### PR DESCRIPTION
There was some design review feedback on the quiz marquee with a few nested components. 
(aside, commerce cards)

---

1) When a .aside.notification fragment is used in the marquee content, it should display inline on mobile view. App Icon | headline/copy. 

Resolves: [MWPW-140877](https://jira.corp.adobe.com/browse/MWPW-140877)

**Test URLs:**

Before: https://main--cc--adobecom.hlx.live/cc-shared/uar/plan-recommender/quiz-results?primary=lr_indiv,ai_indiv,ps_indiv&quizKey=cc-quiz-en-US&martech=off

After: https://main--cc--adobecom.hlx.live/cc-shared/uar/plan-recommender/quiz-results?primary=lr_indiv,ai_indiv,ps_indiv&quizKey=cc-quiz-en-US&milolibs=rparrish-quiz-marquee-style&martech=off

---

2) When a commerce card fragment is used and only 2 cards are shown they should be evenly spaced and the same size from the XD -> 387px. Also when a .center variant is used these commerce cards should justify-center in the container. 

Resolves: [MWPW-140880](https://jira.corp.adobe.com/browse/MWPW-140880)

**Test URLs:**

Before: https://main--cc--adobecom.hlx.live/cc-shared/uar/plan-recommender/quiz-results?primary=ps_indiv,md_indiv&quizKey=cc-quiz-en-US&martech=off

After: https://main--cc--adobecom.hlx.live/cc-shared/uar/plan-recommender/quiz-results?primary=ps_indiv,md_indiv&quizKey=cc-quiz-en-US&milolibs=rparrish-quiz-marquee-style&martech=off

---

**Testing notes:**
https://main--cc--adobecom.hlx.live/cc-shared/uar/plan-recommender/
and select any two or three options on the first question with on of them being substance 3d
example: video + 3d/ar > any option for the next three questions

You will need to add the `&milolibs=rparrish-quiz-marquee-style` part to the result url after the quiz give you results. 
