### PR TITLE
MWPW-140660 Fix Marketo Destination Url

### DIFF
--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -44,7 +44,7 @@ export const decorateURL = (destination, baseURL = window.location) => {
       destinationUrl = new URL(`${pathname}${search}${hash}`, baseURL.origin);
     }
 
-    if (baseURL.pathname.endsWith('.html') && !pathname.endsWith('.html')) {
+    if (baseURL.pathname.endsWith('.html') && !pathname.endsWith('.html') && !pathname.endsWith('/')) {
       destinationUrl.pathname = `${pathname}.html`;
     }
 

--- a/test/blocks/marketo/marketo.test.js
+++ b/test/blocks/marketo/marketo.test.js
@@ -77,4 +77,10 @@ describe('marketo decorateURL', () => {
     const result = decorateURL('tps://business', baseURL);
     expect(result).to.be.null;
   });
+
+  it('Does not add .html to ending slash', () => {
+    const baseURL = new URL('https://business.adobe.com/marketo-block.html');
+    const result = decorateURL('https://business.adobe.com/', baseURL);
+    expect(result.href).to.equal('https://business.adobe.com/');
+  });
 });


### PR DESCRIPTION
* Fix bug in Marketo form destination url where `.html` is added to trailing slash

Resolves: [MWPW-140660](https://jira.corp.adobe.com/browse/MWPW-140660)

**Test URLs:**
NOTE: Bug only seen on .html pages
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/aemshowcase?martech=off
- After: https://methomas-marketo-html--milo--adobecom.hlx.page/drafts/methomas/aemshowcase?martech=off

BACOM:
- Before: https://business.stage.adobe.com/resources/demo/aemshowcase.html
- After: https://business.stage.adobe.com/resources/demo/aemshowcase.html?milolibs=methomas-marketo-html
