### PR TITLE
GNAV & Footer content centralisation

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -74,7 +74,7 @@ class Footer {
       .catch((e) => lanaLog({
         message: `Error fetching footer content ${url}`,
         e,
-        tags: 'errorType=error,module=gnav',
+        tags: 'errorType=error,module=global-footer',
       }));
 
     if (!this.body) return;

--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -9,11 +9,10 @@ import {
 
 import {
   getFedsPlaceholderConfig,
-  federatePictureSources,
   getExperienceName,
   getAnalyticsValue,
   loadDecorateMenu,
-  fetchAndProcess,
+  fetchAndProcessPlainHtml,
   loadBaseStyles,
   yieldToMain,
   lanaLog,
@@ -68,12 +67,15 @@ class Footer {
   decorateContent = () => logErrorFor(async () => {
     // Fetch footer content
     const url = getMetadata('footer-source') || `${locale.contentRoot}/footer`;
-    this.useFederatedContent = url.includes('/federal/');
-    this.body = await fetchAndProcess({
+    this.body = await fetchAndProcessPlainHtml({
       url,
-      message: 'Error fetching footer content',
       shouldDecorateLinks: false,
-    });
+    })
+      .catch((e) => lanaLog({
+        message: `Error fetching footer content ${url}`,
+        e,
+        tags: 'errorType=error,module=gnav',
+      }));
 
     if (!this.body) return;
 
@@ -337,7 +339,6 @@ class Footer {
         </div>
       </div>`;
 
-    if (this.useFederatedContent) federatePictureSources(this.elements.footer);
     return this.elements.footer;
   };
 }

--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -1,5 +1,5 @@
 import { getMetadata, getConfig } from '../../../../utils/utils.js';
-import { toFragment, lanaLog } from '../../utilities/utilities.js';
+import { toFragment, lanaLog, getFederatedUrl } from '../../utilities/utilities.js';
 
 const metadata = {
   seo: 'breadcrumbs-seo',
@@ -67,7 +67,7 @@ const createBreadcrumbs = (element) => {
 
 const createWithBase = async (el) => {
   const element = el || toFragment`<div><ul></ul></div>`;
-  const url = getMetadata(metadata.base);
+  const url = getFederatedUrl(getMetadata(metadata.base));
   if (!url) return null;
   try {
     const resp = await fetch(`${url}.plain.html`);

--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -83,7 +83,6 @@ class ProfileDropdown {
       replaceKeyArray(
         ['profile-button', 'sign-out', 'view-account', 'manage-teams', 'manage-enterprise', 'profile-avatar'],
         getFedsPlaceholderConfig(),
-        'feds',
       ),
       window.adobeIMS.getProfile(),
     ]);

--- a/libs/blocks/global-navigation/features/search/gnav-search.js
+++ b/libs/blocks/global-navigation/features/search/gnav-search.js
@@ -46,7 +46,7 @@ class Search {
 
   async getLabels() {
     this.labels = {};
-    [this.labels.search, this.labels.clearResults, this.labels.tryAdvancedSearch] = await replaceKeyArray(['search', 'clear-results', 'try-advanced-search'], getFedsPlaceholderConfig(), 'feds');
+    [this.labels.search, this.labels.clearResults, this.labels.tryAdvancedSearch] = await replaceKeyArray(['search', 'clear-results', 'try-advanced-search'], getFedsPlaceholderConfig());
   }
 
   decorate() {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -580,11 +580,7 @@ class Gnav {
     const activeModifier = itemHasActiveLink ? ` ${selectors.activeNavItem.slice(1)}` : '';
 
     // All dropdown decoration is delayed
-    const delayDropdownDecoration = ({
-      template,
-      isFederatedGnav,
-      isFederatedMenu,
-    } = {}) => {
+    const delayDropdownDecoration = ({ template } = {}) => {
       let decorationTimeout;
 
       const decorateDropdown = () => logErrorFor(async () => {
@@ -597,8 +593,7 @@ class Gnav {
           item,
           template,
           type: itemType,
-          isFederatedGnav,
-          isFederatedMenu,
+          isFederatedGnav: this.useFederatedContent,
         });
       }, 'Decorate dropdown failed', 'errorType=info,module=gnav');
 
@@ -641,11 +636,7 @@ class Gnav {
         });
         observer.observe(dropdownTrigger, { attributeFilter: ['aria-expanded'] });
 
-        delayDropdownDecoration({
-          template: triggerTemplate,
-          isFederatedGnav: this.useFederatedContent,
-          isFederatedMenu: item.closest('.feds') instanceof HTMLElement,
-        });
+        delayDropdownDecoration({ template: triggerTemplate });
         return triggerTemplate;
       }
       case 'primaryCta':

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -2,7 +2,6 @@ import {
   decorateCta,
   getActiveLink,
   getAnalyticsValue,
-  federatePictureSources,
   logErrorFor,
   setActiveDropdown,
   trigger,
@@ -10,7 +9,8 @@ import {
   selectors,
   toFragment,
   yieldToMain,
-  fetchAndProcess,
+  fetchAndProcessPlainHtml,
+  lanaLog,
 } from '../utilities.js';
 
 const homeIcon = '<svg xmlns="http://www.w3.org/2000/svg" height="25" viewBox="0 0 18 18" width="25"><path fill="#6E6E6E" d="M17.666,10.125,9.375,1.834a.53151.53151,0,0,0-.75,0L.334,10.125a.53051.53051,0,0,0,0,.75l.979.9785A.5.5,0,0,0,1.6665,12H2v4.5a.5.5,0,0,0,.5.5h4a.5.5,0,0,0,.5-.5v-5a.5.5,0,0,1,.5-.5h3a.5.5,0,0,1,.5.5v5a.5.5,0,0,0,.5.5h4a.5.5,0,0,0,.5-.5V12h.3335a.5.5,0,0,0,.3535-.1465l.979-.9785A.53051.53051,0,0,0,17.666,10.125Z"/></svg>';
@@ -301,8 +301,6 @@ const decorateMenu = (config) => logErrorFor(async () => {
         ${itemTopParent}
       </div>`;
 
-    if (config.isFederatedGnav) federatePictureSources(menuTemplate);
-
     await decorateColumns({ content: menuTemplate });
   }
 
@@ -310,10 +308,14 @@ const decorateMenu = (config) => logErrorFor(async () => {
     const pathElement = config.item.querySelector('a');
     if (!(pathElement instanceof HTMLElement)) return;
 
-    const content = await fetchAndProcess({
+    const content = await fetchAndProcessPlainHtml({
       url: pathElement.href,
       message: 'Menu could not be fetched',
-    });
+    }).catch((e) => lanaLog({
+      message: `Menu could not be fetched ${pathElement.href}`,
+      e,
+      tags: 'errorType=error,module=menu',
+    }));
     if (!content) return;
 
     const menuContent = toFragment`<div class="feds-menu-content">${content.innerHTML}</div>`;

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -313,6 +313,7 @@ const decorateMenu = (config) => logErrorFor(async () => {
 
   if (config.type === 'asyncDropdownTrigger') {
     const pathElement = config.item.querySelector('a');
+    const isFederatedMenu = pathElement?.href.includes('/federal/');
     if (!(pathElement instanceof HTMLElement)) return;
     let content;
 
@@ -336,7 +337,7 @@ const decorateMenu = (config) => logErrorFor(async () => {
       </div>`;
     decorateCrossCloudMenu(menuTemplate);
 
-    if (config.isFederatedMenu || config.isFederatedGnav) federatePictureSources(menuTemplate);
+    if (isFederatedMenu || config.isFederatedGnav) federatePictureSources(menuTemplate);
 
     // Content has been fetched dynamically, need to decorate links
     decorateLinks(menuTemplate);

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -3,6 +3,12 @@ import { processTrackingLabels } from '../../../martech/attributes.js';
 import { replaceText } from '../../../features/placeholders.js';
 
 loadLana();
+const allowedOrigins = [
+  'https://www.adobe.com',
+  'https://business.adobe.com',
+  'https://blog.adobe.com',
+  'https://milo.adobe.com',
+];
 
 export const selectors = {
   globalNav: '.global-navigation',
@@ -54,19 +60,14 @@ export function toFragment(htmlStrings, ...values) {
   return fragment;
 }
 
+// TODO we might eventually want to move this to the milo core utilities
 let federatedContentRoot;
 export const getFederatedContentRoot = () => {
   if (federatedContentRoot) return federatedContentRoot;
 
   const { origin } = window.location;
-  const allowedOrigins = [
-    'https://www.adobe.com',
-    'https://business.adobe.com',
-    'https://blog.adobe.com',
-    'https://milo.adobe.com',
-  ];
 
-  federatedContentRoot = allowedOrigins.some((o) => origin === o)
+  federatedContentRoot = allowedOrigins.some((o) => origin.replace('.stage', '') === o)
     ? origin
     : 'https://www.adobe.com';
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -3,6 +3,9 @@ import { processTrackingLabels } from '../../../martech/attributes.js';
 import { replaceText } from '../../../features/placeholders.js';
 
 loadLana();
+
+// TODO when porting this to milo core, we should define this on config level
+// and allow consumers to add their own origins
 const allowedOrigins = [
   'https://www.adobe.com',
   'https://business.adobe.com',
@@ -78,6 +81,8 @@ export const getFederatedContentRoot = () => {
   return federatedContentRoot;
 };
 
+// TODO we should match the akamai patterns /locale/federal/ at the start of the url
+// and make the check more strict.
 export const getFederatedUrl = (url = '') => {
   if (typeof url !== 'string' || !url.includes('/federal/')) return url;
   if (url.startsWith('/')) return `${getFederatedContentRoot()}${url}`;
@@ -85,7 +90,7 @@ export const getFederatedUrl = (url = '') => {
     const { pathname, search, hash } = new URL(url);
     return `${getFederatedContentRoot()}${pathname}${search}${hash}`;
   } catch (e) {
-    lanaLog({ message: `getFederatedUrl errored parsing the URL: ${url}`, e, tags: 'errorType=warn,module=global-footer' });
+    lanaLog({ message: `getFederatedUrl errored parsing the URL: ${url}`, e, tags: 'errorType=warn,module=utilities' });
   }
   return url;
 };

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -52,18 +52,27 @@ export function toFragment(htmlStrings, ...values) {
   return fragment;
 }
 
-let fedsContentRoot;
+let federatedContentRoot;
 export const getFederatedContentRoot = () => {
-  if (fedsContentRoot) return fedsContentRoot;
+  if (federatedContentRoot) return federatedContentRoot;
 
   const { origin } = window.location;
-  fedsContentRoot = origin;
+  const allowedOrigins = [
+    'https://www.adobe.com',
+    'https://business.adobe.com',
+    'https://blog.adobe.com',
+    'https://milo.adobe.com',
+  ];
+
+  federatedContentRoot = allowedOrigins.some((o) => origin === o)
+    ? origin
+    : 'https://www.adobe.com';
 
   if (origin.includes('localhost') || origin.includes('.hlx.')) {
-    fedsContentRoot = `https://main--federal--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
+    federatedContentRoot = `https://main--federal--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
   }
 
-  return fedsContentRoot;
+  return federatedContentRoot;
 };
 
 export const getFederatedUrl = (url = '') => {

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -279,55 +279,40 @@ export function trigger({ element, event, type } = {}) {
 
 export const yieldToMain = () => new Promise((resolve) => { setTimeout(resolve, 0); });
 
-export function processMartechAttributeMetadata(html) {
-  const dom = new DOMParser().parseFromString(html, 'text/html').body;
-  const blocks = dom.querySelectorAll('.martech-metadata');
-  blocks.forEach((block) => {
-    import('../../martech-metadata/martech-metadata.js')
-      .then(({ default: decorate }) => decorate(block));
-  });
-  return null;
-}
+export async function fetchAndProcessPlainHtml({ url, shouldDecorateLinks = true } = {}) {
+  const path = getFederatedUrl(url);
+  const res = await fetch(path.replace(/(\.html$|$)/, '.plain.html'));
+  const text = await res.text();
+  const { body } = new DOMParser().parseFromString(text, 'text/html');
 
-export async function fetchAndProcess({ url, message, shouldDecorateLinks = true } = {}) {
-  try {
-    const path = getFederatedUrl(url);
-    const res = await fetch(path.replace(/(\.html$|$)/, '.plain.html'));
-    const text = await res.text();
-    const { body } = new DOMParser().parseFromString(text, 'text/html');
+  const inlineFrags = [...body.querySelectorAll('a[href*="#_inline"]')];
+  if (inlineFrags.length) {
+    const { default: loadInlineFrags } = await import('../../fragment/fragment.js');
 
-    const inlineFrags = [...body.querySelectorAll('a[href*="#_inline"]')];
-    if (inlineFrags.length) {
-      const { default: loadInlineFrags } = await import('../../fragment/fragment.js');
-
-      const fragPromises = inlineFrags.map((link) => {
-        // Replacing paragraphs should happen in the fragment module
-        // https://jira.corp.adobe.com/browse/MWPW-141039
-        if (link.parentElement && link.parentElement.nodeName === 'P') {
-          const div = document.createElement('div');
-          link.parentElement.replaceWith(div);
-          div.appendChild(link);
-        }
-        link.href = getFederatedUrl(link.href);
-        return loadInlineFrags(link);
-      });
-      await Promise.all(fragPromises);
-    }
-
-    if (path.includes('/federal/')) federatePictureSources(body);
-
-    if (shouldDecorateLinks) decorateLinks(body);
-
-    const blocks = body.querySelectorAll('.martech-metadata');
-    blocks.forEach((block) => {
-      import('../../martech-metadata/martech-metadata.js')
-        .then(({ default: decorate }) => decorate(block));
+    const fragPromises = inlineFrags.map((link) => {
+      // Replacing paragraphs should happen in the fragment module
+      // https://jira.corp.adobe.com/browse/MWPW-141039
+      if (link.parentElement && link.parentElement.nodeName === 'P') {
+        const div = document.createElement('div');
+        link.parentElement.replaceWith(div);
+        div.appendChild(link);
+      }
+      link.href = getFederatedUrl(link.href);
+      return loadInlineFrags(link);
     });
-
-    body.innerHTML = await replaceText(body.innerHTML, getFedsPlaceholderConfig());
-    return body;
-  } catch (e) {
-    lanaLog({ message: `${message} url: ${url}`, e, tags: 'errorType=error,module=utilities' });
-    return null;
+    await Promise.all(fragPromises);
   }
+
+  if (path.includes('/federal/')) federatePictureSources(body);
+
+  if (shouldDecorateLinks) decorateLinks(body);
+
+  const blocks = body.querySelectorAll('.martech-metadata');
+  if (blocks.length) {
+    import('../../martech-metadata/martech-metadata.js')
+      .then(({ default: decorate }) => blocks.forEach((block) => decorate(block)));
+  }
+
+  body.innerHTML = await replaceText(body.innerHTML, getFedsPlaceholderConfig());
+  return body;
 }

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -39,8 +39,7 @@ describe('global navigation', () => {
 
     afterEach(() => {
       fetchStub = null;
-      window.fetch.restore();
-      window.lana.log.restore();
+      sinon.restore();
       document.head.replaceChildren();
       document.body.replaceChildren();
       document.head.innerHTML = '<script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>';

--- a/test/blocks/global-navigation/mocks/global-navigation.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation.plain.js
@@ -25,6 +25,17 @@ export default `<div>
   </div>
 </div>
 <div>
+  <div class="large-menu section feds">
+    <div>
+      <div>
+        <h2 id="feds-menu">
+          <a href="/federal/feds-menu">FEDS Menu</a>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
   <h2 id="w-promo"><a href="https://business.adobe.com/">w/ Promo</a></h2>
   <ul>
     <li>
@@ -117,23 +128,23 @@ export default `<div>
         <picture>
           <source
             type="image/webp"
-            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+            srcset="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
             media="(min-width: 600px)"
           />
           <source
             type="image/webp"
-            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+            srcset="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
           />
           <source
             type="image/png"
-            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            srcset="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
             media="(min-width: 600px)"
           />
           <img
             loading="lazy"
             alt=""
             type="image/png"
-            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            src="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
             width="52"
             height="51"
           />

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -3,7 +3,7 @@
 import sinon, { stub } from 'sinon';
 import { setViewport } from '@web/test-runner-commands';
 import initGnav from '../../../libs/blocks/global-navigation/global-navigation.js';
-import { getLocale, setConfig, loadStyle } from '../../../libs/utils/utils.js';
+import { setConfig, loadStyle } from '../../../libs/utils/utils.js';
 import defaultPlaceholders from './mocks/placeholders.js';
 import defaultProfile from './mocks/profile.js';
 import largeMenuMock from './mocks/large-menu.plain.js';
@@ -83,7 +83,6 @@ const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 export const config = {
   imsClientId: 'milo',
   codeRoot: '/libs',
-  contentRoot: `${window.location.origin}${getLocale(locales).prefix}`,
   locales,
 };
 
@@ -125,7 +124,7 @@ export const createFullGlobalNavigation = async ({
     // Intercept setTimeout and call the function immediately
     toFake: ['setTimeout'],
   });
-  setConfig(customConfig);
+  setConfig({ ...config, ...customConfig });
   await setViewport(viewports[viewport]);
   window.lana = { log: stub() };
   window.fetch = stub().callsFake((url) => {
@@ -135,6 +134,8 @@ export const createFullGlobalNavigation = async ({
     if (url.endsWith('large-menu-cross-cloud.plain.html')) { return mockRes({ payload: largeMenuCrossCloud }); }
     if (url.endsWith('large-menu-active.plain.html')) { return mockRes({ payload: largeMenuActiveMock }); }
     if (url.endsWith('large-menu-wide-column.plain.html')) { return mockRes({ payload: largeMenuWideColumnMock }); }
+    if (url.includes('main--federal--adobecom.hlx.page')
+      && url.endsWith('feds-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
     if (url.includes('gnav')) { return mockRes({ payload: globalNavigation || globalNavigationMock }); }
     if (url.includes('correct-promo-fragment')) { return mockRes({ payload: correctPromoFragmentMock }); }
     if (url.includes('wrong-promo-fragment')) { return mockRes({ payload: '<div>Non-promo content</div>' }); }

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -34,7 +34,7 @@ describe('global navigation utilities', () => {
     expect(fragment2.tagName).to.equal('SPAN');
   });
 
-  // Nno tests for using the the live url and .hlx. urls
+  // No tests for using the the live url and .hlx. urls
   // as mocking window.location.origin is not possible
   describe('getFedsContentRoot', () => {
     it('should return content source for localhost', () => {

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -3,6 +3,8 @@ import sinon from 'sinon';
 import {
   toFragment,
   getFedsPlaceholderConfig,
+  federatePictureSources,
+  getFederatedContentRoot,
   getAnalyticsValue,
   decorateCta,
   hasActiveLink,
@@ -12,6 +14,7 @@ import {
   trigger,
   getExperienceName,
   logErrorFor,
+  getFederatedUrl,
 } from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
 import { setConfig } from '../../../../libs/utils/utils.js';
 import { createFullGlobalNavigation, config } from '../test-utilities.js';
@@ -31,30 +34,72 @@ describe('global navigation utilities', () => {
     expect(fragment2.tagName).to.equal('SPAN');
   });
 
-  // TODO - no tests for using the the live url and .hlx. urls
+  // Nno tests for using the the live url and .hlx. urls
+  // as mocking window.location.origin is not possible
+  describe('getFedsContentRoot', () => {
+    it('should return content source for localhost', () => {
+      const contentSource = getFederatedContentRoot();
+      expect(contentSource).to.equal('https://main--federal--adobecom.hlx.page');
+    });
+  });
+
+  describe('federatePictureSources', () => {
+    it('should use federated content root for image sources', async () => {
+      const imgPath = 'test/blocks/global-navigation/mocks/media_medium_dropdown.png';
+      const template = toFragment`<picture>
+          <source
+            type="image/webp"
+            srcset="./${imgPath}"
+            media="(min-width: 600px)"/>
+          <source
+            type="image/webp"
+            srcset="./${imgPath}"/>
+          <source
+            type="image/png"
+            srcset="/${imgPath}"
+            media="(min-width: 600px)"/>
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="/${imgPath}"/>
+        </picture>`;
+
+      federatePictureSources(template);
+      template.querySelectorAll('source, img').forEach((source) => {
+        const attr = source.hasAttribute('src') ? 'src' : 'srcset';
+        expect(source.getAttribute(attr)).to.equal(`https://main--federal--adobecom.hlx.page/${imgPath}`);
+      });
+    });
+  });
+
+  // No tests for using the the live url and .hlx. urls
   // as mocking window.location.origin is not possible
   describe('getFedsPlaceholderConfig', () => {
     it('should return contentRoot for localhost', () => {
-      const locale = { ietf: 'en-US', prefix: '' };
-      setConfig(locale);
-      const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig();
+      const locale = { locale: { ietf: 'en-US', prefix: '' } };
+      setConfig({ ...config, ...locale });
+      const placeholderConfig = { useCache: false };
+      const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig(placeholderConfig);
       expect(ietf).to.equal('en-US');
       expect(prefix).to.equal('');
-      expect(contentRoot).to.equal('https://main--milo--adobecom.hlx.page');
+      expect(contentRoot).to.equal('https://main--federal--adobecom.hlx.page/federal/globalnav');
     });
 
     it('should return a config object for a specific locale', () => {
-      setConfig({
+      const customConfig = {
         locales: {
           '': { ietf: 'en-US' },
           fi: { ietf: 'fi-FI' },
         },
         pathname: '/fi/',
-      });
-      const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig();
+      };
+      setConfig({ ...config, ...customConfig });
+      const placeholderConfig = { useCache: false };
+      const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig(placeholderConfig);
       expect(ietf).to.equal('fi-FI');
       expect(prefix).to.equal('/fi');
-      expect(contentRoot).to.equal('https://main--milo--adobecom.hlx.page/fi');
+      expect(contentRoot).to.equal('https://main--federal--adobecom.hlx.page/fi/federal/globalnav');
     });
   });
 
@@ -208,6 +253,49 @@ describe('global navigation utilities', () => {
 
       // Restore the original window.lana.log method
       window.lana.log = originalLanaLog;
+    });
+  });
+
+  describe('getFederatedUrl', () => {
+    it('should return the url if its not federated', () => {
+      expect(getFederatedUrl('https://adobe.com/foo-fragment.html')).to.equal(
+        'https://adobe.com/foo-fragment.html',
+      );
+
+      expect(getFederatedUrl('/foo-fragment.html')).to.equal(
+        '/foo-fragment.html',
+      );
+
+      expect(getFederatedUrl('/lu_de/foo-fragment.html')).to.equal(
+        '/lu_de/foo-fragment.html',
+      );
+    });
+
+    it('should return the federated url', () => {
+      expect(
+        getFederatedUrl('https://adobe.com/federal/foo-fragment.html'),
+      ).to.equal(
+        'https://main--federal--adobecom.hlx.page/federal/foo-fragment.html',
+      );
+      expect(
+        getFederatedUrl('https://adobe.com/lu_de/federal/gnav/foofooter.html'),
+      ).to.equal(
+        'https://main--federal--adobecom.hlx.page/lu_de/federal/gnav/foofooter.html',
+      );
+    });
+
+    it('should return the federated url for a relative link', () => {
+      expect(
+        getFederatedUrl('/federal/foo-fragment.html'),
+      ).to.equal(
+        'https://main--federal--adobecom.hlx.page/federal/foo-fragment.html',
+      );
+    });
+
+    it('should return the url for invalid urls', () => {
+      expect(getFederatedUrl('en-US/federal/')).to.equal('en-US/federal/');
+      expect(getFederatedUrl(null)).to.equal(null);
+      expect(getFederatedUrl(123121)).to.equal(123121);
     });
   });
 });

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -292,6 +292,14 @@ describe('global navigation utilities', () => {
       );
     });
 
+    it('should return the federated url for a relative link including hashes and search params', () => {
+      expect(
+        getFederatedUrl('/federal/foo-fragment.html?foo=bar#test'),
+      ).to.equal(
+        'https://main--federal--adobecom.hlx.page/federal/foo-fragment.html?foo=bar#test',
+      );
+    });
+
     it('should return the url for invalid urls', () => {
       expect(getFederatedUrl('en-US/federal/')).to.equal('en-US/federal/');
       expect(getFederatedUrl(null)).to.equal(null);


### PR DESCRIPTION
### Description
Adds the possibility to centralize globalnav content such as large menu's by supplying a link from the project for centralized milo content such as https://main--federal--adobecom.hlx.live/federal/globalnav/drafts/osahin/gnav - which can be reused across any milo consumer.

On (www.|business.|blog.|milo.)adobe.com this would simply be mapped to `/federal/globalnav/drafts/osahin/gnav` and does not require any extra TLS handshake.

**There is no extra setup needed for any milo consumer** - subdomains or domains without any extra setup will simply default fetching central content from `www.adobe.com/federal/...` 

### Solution design
The overarching idea of this is that `https://main--federal--adobecom.hlx.live` serves as a content hub for anything that is shared across consumers. In the (near) future 404s can be moved there, commerce related content might make sense in there and I'm sure a bunch of use cases will pop up.

### Features added
While we added support for a bunch of (globalnav) use cases, for now only strictly _shared_ global navigation content should live in the new content repository. The normal case will still be that each consumer can maintain their own global navigation or footer.

- Ability to fetch the global footer&navigation, menu's & base-breadcrumbs from a central location
- Fetches globalnav/footer placeholders from `/federal/globalnav/placeholders` instead of `milo.adobe.com/placeholders?sheet=feds` which leads to an unnecessary TLS handshake
- Ability to fragmentize large globalnav menus or footer sections


Resolves: [MWPW-138979](https://jira.corp.adobe.com/browse/MWPW-138979)
[MWPW-136659](https://jira.corp.adobe.com/browse/MWPW-136659)
Based on [this discussion](https://github.com/orgs/adobecom/discussions/1388)

**Test URLs:**
Further use-cases can be found in `SP>milo>ch_de>drafts>osahin>federalisation` & `SP>milo>drafts>osahin>federalisation`

Ensure to be on VPN when viewing those links. The `hlx.page` content is guarded
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/osahin/federalisation/nav-and-footer
- After: https://mwpw-138979--milo--adobecom.hlx.page/ch_de/drafts/osahin/federalisation/nav-and-footer

- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/federalisation/nav-and-footer
- After: https://mwpw-138979--milo--adobecom.hlx.page/drafts/osahin/federalisation/nav-and-footer


**Regression URLs**

**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=mwpw-138979--milo--adobecom

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=mwpw-138979--milo--adobecom

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=mwpw-138979--milo--adobecom

**Homepage:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=mwpw-138979--milo--adobecom

**Blog:**
- Before: https://main--blog--adobecom.hlx.page/
- After: https://main--blog--adobecom.hlx.page/?milolibs=mwpw-138979--milo--adobecom

**CC**
- Before: https://main--cc--adobecom.hlx.page/drafts/jbrown/firefly/firefly?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/jbrown/firefly/firefly?martech=off&milolibs=mwpw-138979--milo--adobecom