### PR TITLE
MWPW-140738 - Add foreground gap on large marquees

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -183,7 +183,6 @@
 
 .marquee.large .foreground {
   padding: var(--spacing-m) 0;
-  gap: 0;
 }
 
 .marquee.large .background img {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* At some point early on in the life of the marquee block, it must have made sense to remove the `.foreground` gap for large marquees. Now, however, the current design of all marquees requires it. This PR gives large marquees consistent spacing.

Resolves: [MWPW-140738](https://jira.corp.adobe.com/browse/MWPW-140738)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/dmosier/block-exploration-pages/marquee-text-spacing?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/dmosier/block-exploration-pages/marquee-text-spacing?milolibs=ebartholomew-lg-marquee-gap&martech=off
