### PR TITLE
MWPW-140456 - [Aside] fix notification static links color

### DIFF
--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -72,6 +72,7 @@
 
 .aside .foreground.container .image {
   position: relative;
+  display: flex;
 }
 
 .aside .foreground.container > div {
@@ -82,10 +83,6 @@
 
 .aside.notification .foreground.container > div {
   flex-basis: 100%;
-}
-
-.aside .foreground.container .image {
-  display: flex;
 }
 
 .aside.inline .foreground.container .image,
@@ -330,6 +327,10 @@
 .aside.notification.extra-small .foreground.container a:not(.con-button):last-of-type {
   margin-left: var(--spacing-xs);
   color: var(--link-color);
+}
+
+.static-links .aside.notification.extra-small .foreground.container a:not(.con-button):last-of-type {
+  color: inherit;
 }
 
 .aside.notification.small .foreground.container .text a.con-button {


### PR DESCRIPTION
When an author uses the `section.static-links` style with an `aside.notification.extra-small`, the link color is not applied because of a style that targets trailing links that aren't styled as buttons. I am adding an additional style that sets color to `inherit` when aside is nested in a section with static links style.

Note: I also removed a duplicate selector that was creating a styleLint error

Resolves: [MWPW-140456](https://jira.corp.adobe.com/browse/MWPW-140456)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/aside-links?martech=off
- After: https://sarchibeque-mwpw-140456-aside-links--milo--adobecom.hlx.page/drafts/sarchibeque/aside-links?martech=off
