### PR TITLE
MWPW-141124: match widths used by standard merch cards

### DIFF
--- a/libs/blocks/quiz-results/quiz-results.css
+++ b/libs/blocks/quiz-results/quiz-results.css
@@ -20,7 +20,7 @@
   justify-content: center;
   width: 100%;
   max-width: 100%;
-  grid-template-columns: repeat(auto-fit, 378px);
+  grid-template-columns: repeat(auto-fit, 300px);
   gap: 32px;
   padding-bottom: 32px;
 }
@@ -47,6 +47,10 @@
   .quiz-results .desktop-up,
   .quiz-results .big-desktop-up {
     display: none;
+  }
+
+  .quiz-results .quiz-card-list {
+    grid-template-columns: repeat(auto-fit, 378px);
   }
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* set the widths of merch cards as 300px if screen less than 900 
* set the widths of merch cards as 378px if screen up to 900 

Resolves: [MWPW-141124](https://jira.corp.adobe.com/browse/MWPW-141124)

**Test URLs:**
- Before: https://uar-integration--milo--adobecom.hlx.live/drafts/quiz/quiz-2/?martech=off
- After: https://mwpw-141124--milo--jackysun9.hlx.live/drafts/quiz/quiz-2/?martech=off

You can view merch cards from https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/merch-card