### PR TITLE
[MWPW-140624] Footer layout with few columns

### DIFF
--- a/libs/blocks/global-footer/global-footer.css
+++ b/libs/blocks/global-footer/global-footer.css
@@ -253,7 +253,7 @@
   .feds-footer-wrapper .feds-menu-content {
     flex-wrap: wrap;
     width: auto;
-    max-width: auto;
+    column-gap: 12px;
   }
 
   .feds-footer-wrapper .feds-menu-headline {
@@ -262,6 +262,21 @@
 
   .feds-footer-wrapper .feds-menu-column {
     row-gap: 15px;
+  }
+
+  .feds-footer-wrapper .feds-menu-column:nth-child(-n+3):last-child {
+    flex-grow: 1;
+  }
+
+  .feds-footer-wrapper .feds-menu-column:nth-last-child(-n+3):first-child .feds-menu-section,
+  .feds-footer-wrapper .feds-menu-column:nth-child(-n+3):last-child .feds-menu-section,
+  .feds-footer-wrapper .feds-menu-column:nth-child(2):nth-last-child(2) .feds-menu-section {
+    width: fit-content;
+  }
+
+  .feds-footer-wrapper .feds-menu-column:nth-last-child(-n+3):first-child,
+  .feds-footer-wrapper .feds-menu-column:nth-child(2):nth-last-child(2) {
+    min-width: 20%;
   }
 
   /* Featured products */


### PR DESCRIPTION
## Description
This handles the use-case where 3 or fewer columns are authored for the Footer. Right now the columns span to the full width of the footer, regardless of their number or width, leading to suboptimal UI on desktop devices.

Additionally, a `max-width` property has been removed, as its value, `auto`, is invalid - https://developer.mozilla.org/en-US/docs/Web/CSS/max-width

## Related Issue
Resolves: [MWPW-140624](https://jira.corp.adobe.com/browse/MWPW-140624)

## Testing instructions
On a test page, add/remove footer columns to check out the resulting layout.

## Screenshots (if appropriate):
| Before | After |
| ------------- | ------------- |
| <img width="1486" alt="Screenshot 2024-01-11 at 15 22 35" src="https://github.com/adobecom/milo/assets/11267498/341bbbe3-d9f5-45ab-b5be-3f60fa0fe448"> | <img width="1486" alt="Screenshot 2024-01-11 at 15 22 04" src="https://github.com/adobecom/milo/assets/11267498/6ab1f4da-c8c2-49b7-bee8-b3b5402e3284"> |

## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=few-footer-columns--milo--overmyheadandbody

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=few-footer-columns--milo--overmyheadandbody

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=few-footer-columns--milo--overmyheadandbody

**Homepage** (requestor of this enhancement):
- Before: https://main--homepage--adobecom.hlx.page/cn/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/cn/homepage/index-loggedout?martech=off&milolibs=few-footer-columns--milo--overmyheadandbody

**Blog:**
- Before: https://main--blog--adobecom.hlx.page/?martech=off
- After: https://main--blog--adobecom.hlx.page/?martech=off&milolibs=few-footer-columns--milo--overmyheadandbody

**Milo:**
- Before: https://main--milo--overmyheadandbody.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://few-footer-columns--milo--overmyheadandbody.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
