### PR TITLE
MWPW-137932 - Bullet-proof quiz and result metadata keys

### DIFF
--- a/libs/blocks/quiz-results/quiz-results.js
+++ b/libs/blocks/quiz-results/quiz-results.js
@@ -1,5 +1,6 @@
 import { createTag } from '../../utils/utils.js';
-import { getMetadata, handleStyle } from '../section-metadata/section-metadata.js';
+import { handleStyle } from '../section-metadata/section-metadata.js';
+import { getNormalizedMetadata } from '../quiz/utils.js';
 
 export const LOADING_ERROR = 'Could not load quiz results:';
 
@@ -44,9 +45,9 @@ function setAnalytics(hashValue, debug) {
 }
 
 export default async function init(el, debug = null, localStoreKey = null) {
-  const data = getMetadata(el);
+  const data = getNormalizedMetadata(el);
   const params = new URL(document.location).searchParams;
-  const quizUrl = data['quiz-url'];
+  const quizUrl = data.quizurl;
   const BASIC_KEY = 'basicFragments';
   const NESTED_KEY = 'nestedFragments';
   const HASH_KEY = 'pageloadHash';
@@ -71,8 +72,8 @@ export default async function init(el, debug = null, localStoreKey = null) {
     return;
   }
 
-  if (data['nested-fragments'] && el.classList.contains('nested')) {
-    const nested = results[NESTED_KEY][data['nested-fragments'].text];
+  if (data.nestedfragments && el.classList.contains('nested')) {
+    const nested = results[NESTED_KEY][data.nestedfragments.text];
     if (nested) loadFragments(el, nested);
   } else if (el.classList.contains('basic')) {
     const basic = results[BASIC_KEY];

--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -22,9 +22,9 @@ const initQuizKey = () => {
   return locale?.ietf ? `${quizKey}-${locale.ietf}` : quizKey;
 };
 
-const initAnalyticsType = () => metaData['analytics-type']?.text;
+const initAnalyticsType = () => metaData.analyticstype?.text;
 
-const initAnalyticsQuiz = () => metaData['analytics-quiz']?.text;
+const initAnalyticsQuiz = () => metaData.analyticsquiz?.text;
 
 async function fetchContentOfFile(path) {
   const response = await fetch(configPath(path));
@@ -32,8 +32,8 @@ async function fetchContentOfFile(path) {
 }
 
 export const initConfigPathGlob = (rootElement) => {
-  metaData = getMetadata(rootElement);
-  shortQuiz = metaData['short-quiz']?.text === 'true';
+  metaData = getNormalizedMetadata(rootElement);
+  shortQuiz = metaData.shortquiz?.text === 'true';
   configPath = initConfigPath(metaData);
   quizKey = initQuizKey(rootElement);
   analyticsType = initAnalyticsType();
@@ -237,6 +237,23 @@ const getNestedFragments = (resultResources, productCodes, fragKey) => {
     });
   });
   return fragArray;
+};
+
+/**
+ * Normalizes the values of the metadata keys in the metadata table, cleaning them up
+ * and removing all but alphanumeric characters in preparation for getMetadata();
+ */
+const normalizeKeys = (el) => {
+  const metadata = [...el.childNodes];
+  for (const row of metadata) {
+    if (row.children) {
+      let key = row.children[0].textContent;
+      if (key) {
+        key = key.match(/[a-zA-Z0-9]/g).join('');
+        row.children[0].innerHTML = key;
+      }
+    }
+  }
 };
 
 export const getRedirectUrl = (destinationPage) => {
@@ -465,3 +482,8 @@ export const getAnalyticsDataForLocalStorage = (config) => {
 };
 
 export const isValidUrl = (url) => VALID_URL_RE.test(url);
+
+export const getNormalizedMetadata = (el) => {
+  normalizeKeys(el);
+  return getMetadata(el);
+};

--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -240,20 +240,19 @@ const getNestedFragments = (resultResources, productCodes, fragKey) => {
 };
 
 /**
- * Normalizes the values of the metadata keys in the metadata table, cleaning them up
- * and removing all but alphanumeric characters in preparation for getMetadata();
+ * Normalizes the metadata keys in the metadata object,
+ * cleaning them up and removing all but alphanumeric characters
  */
-const normalizeKeys = (el) => {
-  const metadata = [...el.childNodes];
-  for (const row of metadata) {
-    if (row.children) {
-      let key = row.children[0].textContent;
-      if (key) {
-        key = key.match(/[a-zA-Z0-9]/g).join('');
-        row.children[0].innerHTML = key;
-      }
+const normalizeKeys = (data) => {
+  const keys = Object.keys(data);
+  for (const key of keys) {
+    const newKey = key.match(/[a-zA-Z0-9]/g).join('');
+    if (key !== newKey) {
+      data[newKey] = data[key];
+      delete data[key];
     }
   }
+  return data;
 };
 
 export const getRedirectUrl = (destinationPage) => {
@@ -483,7 +482,4 @@ export const getAnalyticsDataForLocalStorage = (config) => {
 
 export const isValidUrl = (url) => VALID_URL_RE.test(url);
 
-export const getNormalizedMetadata = (el) => {
-  normalizeKeys(el);
-  return getMetadata(el);
-};
+export const getNormalizedMetadata = (el) => normalizeKeys(getMetadata(el));

--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -245,14 +245,16 @@ const getNestedFragments = (resultResources, productCodes, fragKey) => {
  */
 const normalizeKeys = (data) => {
   const keys = Object.keys(data);
+  const cleanData = {};
   for (const key of keys) {
     const newKey = key.match(/[a-zA-Z0-9]/g).join('');
     if (key !== newKey) {
-      data[newKey] = data[key];
-      delete data[key];
+      cleanData[newKey] = data[key];
+    } else {
+      cleanData[key] = data[key];
     }
   }
-  return data;
+  return cleanData;
 };
 
 export const getRedirectUrl = (destinationPage) => {


### PR DESCRIPTION
* add a method to remove characters other than alpha-numeric
* standardized on no dashes or spaces in property names

Resolves: [MWPW-137932](https://jira.corp.adobe.com/browse/MWPW-137932)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/xiasun/quiz-2/?martech=off
- After: https://mwpw-137932-bulletproof-property-names--milo--colloyd.hlx.page/drafts/colloyd/quiz/?martech=off

Testing notes: To test, observe the following URL on milo main: https://main--milo--adobecom.hlx.page/drafts/colloyd/quiz/
Note the odd characters in the property names that are causing block load failure. This is the same page used for the "After" URL above.

The same has been done for two result pages, though you will have to submit a quiz to generate local storage data before observing them and it may be easier to observe the junk characters in the keys by editing the page with the sidekick
 * https://main--milo--adobecom.hlx.page/drafts/colloyd/quiz-results-block/quiz-results-tester?debug=quiz-results
 * https://main--milo--adobecom.hlx.page/drafts/colloyd/quiz-results-block/quiz-results-nested-tester?debug=quiz-results