### PR TITLE
MWPW-141399 MEP Highlight does not work well on update merch card blocks

### DIFF
--- a/libs/features/personalization/preview.css
+++ b/libs/features/personalization/preview.css
@@ -326,6 +326,10 @@ body[data-mep-highlight='true'] [data-removed-manifest-id]::before {
   border: 1px solid #ef3726;
 }
 
+body[data-mep-highlight='true'] main[data-manifest-id]::before {
+  content: 'page replaced by: ' attr(data-manifest-id);
+}
+
 body[data-mep-highlight='true'] .section[class*="-merch-cards"] .fragment[data-manifest-id]::before {
   display: none;
 }

--- a/libs/features/personalization/preview.css
+++ b/libs/features/personalization/preview.css
@@ -326,6 +326,6 @@ body[data-mep-highlight='true'] [data-removed-manifest-id]::before {
   border: 1px solid #ef3726;
 }
 
-body[data-mep-highlight='true'] main[data-manifest-id]::before {
-  content: 'page replaced by: ' attr(data-manifest-id);
+body[data-mep-highlight='true'] .section[class*="-merch-cards"] .fragment[data-manifest-id]::before {
+  display: none;
 }

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -276,7 +276,7 @@ function addHighlightData(manifests) {
     selectedVariant?.updatemetadata?.forEach(({ selector }) => {
       if (selector === 'gnav-source') updateManifestId('header, footer');
     });
-    document.querySelectorAll('.section[class*="merch-cards"] .fragment[data-manifest-id] merch-card').forEach((el) => (el.dataset.manifestId = manifestName));
+    document.querySelectorAll(`.section[class*="merch-cards"] .fragment[data-manifest-id="${manifestName}"] merch-card`).forEach((el) => (el.dataset.manifestId = manifestName));
   });
 }
 

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -276,6 +276,7 @@ function addHighlightData(manifests) {
     selectedVariant?.updatemetadata?.forEach(({ selector }) => {
       if (selector === 'gnav-source') updateManifestId('header, footer');
     });
+    document.querySelectorAll('.section[class*="merch-cards"] .fragment[data-manifest-id] merch-card').forEach((el) => (el.dataset.manifestId = manifestName));
   });
 }
 

--- a/test/features/personalization/mocks/postPersonalization.html
+++ b/test/features/personalization/mocks/postPersonalization.html
@@ -57,13 +57,27 @@
           </div>
         </div>
         <div>
-          <p><div class="fragment" data-path="/fragments/fragmentreplaced"><div class="section"><div class="content" data-block=""><h3>The fragment has been replaced</h3></div>
-      
-    </div></div></p>
+          <p><div class="fragment" data-path="/fragments/fragmentreplaced"><div class="section"><div class="content" data-block=""><h3>The fragment has been replaced</h3></div></div></div></p>
         </div>
         <div>
           <div class="promo"><div>New Promo!</div></div>
           <div class="myblock"><div>My New Block!</div></div>
+        </div>
+        
+        <div class="section three-merch-cards center xl-spacing special-offers">
+          <div>
+            <div class="fragment" data-manifest-id="selected-example.json">
+              <div class="section">
+                <merch-card class="merch-card special-offers">
+                    <h5 id="students-and-teachers">Students and teachers</h5>
+                    <h3 id="new-block-by-mep-save-over-60-on-cc-all-apps">New Block by MEP. Save over 60% on CC All Apps.</h3>
+                    <div slot="body-xs">
+                      <p>Get 20+ CC apps, including Photoshop, Acrobat Pro, and more.</p>
+                    </div>
+                </merch-card>
+              </div>
+            </div>
+          </div>
         </div>
       </main>
       <footer></footer>

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -176,6 +176,9 @@ describe('preview feature', () => {
     expect(document.querySelector('.marquee').getAttribute('data-code-manifest-id')).to.equal('selected-example.json');
     expect(document.querySelector('header').getAttribute('data-manifest-id')).to.equal('selected-example.json');
   });
+  it('adjusts highlights for merch cards', () => {
+    expect(document.querySelector('merch-card').getAttribute('data-manifest-id')).to.equal('selected-example.json');
+  });
   it('preselects form inputs', () => {
     expect(document.querySelector('input[name="/homepage/fragments/mep/selected-example.json"][value="target-smb"]').getAttribute('checked')).to.equal('checked');
     expect(document.querySelector('input[name="/homepage/fragments/mep/default-selected.json"][value="default"]').getAttribute('checked')).to.equal('checked');


### PR DESCRIPTION
The goal of the MEP Highlight feature is to make it clear which parts of the page have been updated. In most situtations, including in an "up" layout, the highlight is visually tied to the specific block being updated.

However, on merch-cards the information is vaguely placed at the top left corner of the section.

Resolves: [MWPW-141399](https://jira.corp.adobe.com/browse/MWPW-141399)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/mep-highlight-grid/?mepHighlight=true&martech=off
- After: https://mep-highlight-grid--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/mep-highlight-grid/?mepHighlight=true&martech=off