### PR TITLE
MWPW-141053: Enable additional components for the MWEB

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -466,17 +466,15 @@ class Gnav {
       // reset sign up value on change
       children[0].attributes.isSignUpRequired = false;
 
-      if (isDesktop.matches) {
-        this.universalNavComponents?.forEach((component) => {
-          if (component === 'profile') return;
-          if (component === 'signup') {
-            children[0].attributes.isSignUpRequired = true;
-            return;
-          }
+      this.universalNavComponents?.forEach((component) => {
+        if (component === 'profile') return;
+        if (component === 'signup') {
+          children[0].attributes.isSignUpRequired = true;
+          return;
+        }
 
-          children.push(CONFIG.universalNav.components[component]);
-        });
-      }
+        children.push(CONFIG.universalNav.components[component]);
+      });
 
       return children;
     };

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -123,7 +123,7 @@ const config = {
   geoRouting: 'on',
   fallbackRouting: 'on',
   links: 'on',
-  imsClientId: 'milo',
+  imsClientId: 'fedsmilo',
   imsScope: 'AdobeID,openid,gnav',
   codeRoot: '/libs',
   locales,


### PR DESCRIPTION
## Description
This PR enables the universal navigation on mobile.

## Related Issue
Resolves: [MWPW-141053](https://jira.corp.adobe.com/browse/MWPW-141053)

## Screenshots:
<img width="541" alt="Screenshot 2024-01-17 at 17 53 21" src="https://github.com/adobecom/milo/assets/146744221/24d1d1e9-9d3b-45d8-8f73-0a7387e4aea0">

<img width="484" alt="Screenshot 2024-01-18 at 09 34 55" src="https://github.com/adobecom/milo/assets/146744221/e4bc7cde-4cd7-44be-b966-ccae8b5d26dd">

## Test URLs
**Milo:**
- Before:  https://gnav--milo--adobecom.hlx.page/drafts/rbogos/unav?martech=off
- After: https://mwpw-141053-mweb-additional-components--milo--robert-bogos.hlx.page/drafts/rbogos/unav?martech=off
