### PR TITLE
Fix tab issue with links in icon block

### DIFF
--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -2,7 +2,6 @@
   display: block;
   width: 100%;
   position: relative;
-  overflow: hidden;
 }
 
 .icon-block p {


### PR DESCRIPTION
* Fix for border not showing up properly when we press tab for links in icon block 


Resolves: [MWPW-140826](https://jira.corp.adobe.com/browse/MWPW-140826)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/icon?martech=off
- After: https://tab--milo--ruchika4.hlx.page/drafts/ruchika/icon?martech=off


CC:
- Before: https://main--cc--adobecom.hlx.page/creativecloud/tools/business-card-design-software?martech=off
- After: https://main--cc--adobecom.hlx.page/creativecloud/tools/business-card-design-software?milolibs=tab--milo--ruchika4&martech=off
