### PR TITLE
MWPW-136727 MEP: Support for simplified selectors

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -270,8 +270,11 @@ function getSection(rootEl, idx) {
 function getSelectedEl(rootEl, selector) {
   if (!selector) return null;
 
-  let selectedEl = querySelector(rootEl, selector);
-  if (selectedEl) return selectedEl;
+  let selectedEl;
+  if (selector.includes('.') || !['section', 'block', 'row'].some((s) => selector.includes(s))) {
+    selectedEl = querySelector(rootEl, selector);
+    if (selectedEl) return selectedEl;
+  }
 
   const terms = selector.split(/\s+/);
 

--- a/test/features/personalization/mocks/manifestBlockNumber.json
+++ b/test/features/personalization/mocks/manifestBlockNumber.json
@@ -12,7 +12,7 @@
     },
     {
       "action": "replaceContent",
-      "selector": "marquee2 row2 col2",
+      "selector": "section5 marquee row2 col2",
       "page filter (optional)": "",
       "param-newoffer=123": "",
       "all": "/fragments/replace/marquee-2/r2c2"

--- a/test/features/personalization/mocks/manifestBlockNumber.json
+++ b/test/features/personalization/mocks/manifestBlockNumber.json
@@ -1,0 +1,22 @@
+{
+  "total": 5,
+  "offset": 0,
+  "limit": 5,
+  "data": [
+    {
+      "action": "replaceContent",
+      "selector": "marquee row2 col1",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "all": "/fragments/replace/marquee/r2c1"
+    },
+    {
+      "action": "replaceContent",
+      "selector": "marquee2 row2 col2",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "all": "/fragments/replace/marquee-2/r2c2"
+    }
+  ],
+  ":type": "sheet"
+}

--- a/test/features/personalization/mocks/manifestInvalidSelector.json
+++ b/test/features/personalization/mocks/manifestInvalidSelector.json
@@ -1,0 +1,15 @@
+{
+  "total": 5,
+  "offset": 0,
+  "limit": 5,
+  "data": [
+    {
+      "action": "replaceContent",
+      "selector": ".bad...selector",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "all": "on"
+    }
+  ],
+  ":type": "sheet"
+}

--- a/test/features/personalization/mocks/manifestReplace.json
+++ b/test/features/personalization/mocks/manifestReplace.json
@@ -22,6 +22,16 @@
       "firefox": "",
       "android": "",
       "ios": ""
+    },
+    {
+      "action": "replaceContent",
+      "selector": ".z-pattern.small row3 col2",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "chrome": "/fragments/milo-replace-r3c2",
+      "firefox": "",
+      "android": "",
+      "ios": ""
     }
   ],
   ":type": "sheet"

--- a/test/features/personalization/mocks/manifestSectionBlock.json
+++ b/test/features/personalization/mocks/manifestSectionBlock.json
@@ -1,0 +1,29 @@
+{
+  "total": 5,
+  "offset": 0,
+  "limit": 5,
+  "data": [
+    {
+      "action": "removeContent",
+      "selector": "section2 block2",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "all": "on"
+    },
+    {
+      "action": "removeContent",
+      "selector": "custom-block2",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "all": "on"
+    },
+    {
+      "action": "removeContent",
+      "selector": "section5 custom-block",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "all": "on"
+    }
+  ],
+  ":type": "sheet"
+}

--- a/test/features/personalization/mocks/personalization.html
+++ b/test/features/personalization/mocks/personalization.html
@@ -1,111 +1,78 @@
 <body>
 <header></header>
-    <main>
+<main>
+  <div>
+    <div class="marquee">
       <div>
-        <div class="marquee">
-          <div>
-            <div data-valign="middle">
-              <picture>
-                <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
-              </picture>
-            </div>
-          </div>
-          <div>
-            <div data-valign="middle">
-              <h2 id="milo-experimentation-platform">Milo Experimentation Platform</h2>
-              <p>Leverage the Milo Experimentation Platform (MEP) for all your personalization needs on Milo!</p>
-              <p><strong><a href="https://wiki.corp.adobe.com/display/marketingtech/Milo+Experiment+Manifests">Review Docs</a></strong></p>
-            </div>
-            <div data-valign="middle">
-              <picture>
-                <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="811" height="207">
-              </picture>
-            </div>
-          </div>
+        <div data-valign="middle">
+          <picture>
+            <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
+          </picture>
         </div>
       </div>
       <div>
-        <div class="z-pattern small">
-          <div>
-            <div data-valign="middle">
-              <h2 id="features-of-milo-experimentation-platform">Features of Milo Experimentation Platform</h2>
-              <p>Learn more about the features of the Milo Experimentation Platform and what it can do</p>
-            </div>
-          </div>
-          <div>
-            <div data-valign="middle">
-              <picture>
-                <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
-              </picture>
-            </div>
-            <div data-valign="middle">
-              <p><strong>Who will win?</strong></p>
-              <h3 id="abn-testing">A/B/N Testing</h3>
-              <p>Milo Experimentation Platform is integrated with Adobe Target and can help you test new experiences.</p>
-              <p><strong><a href="https://adobe.com/">Learn more</a></strong></p>
-            </div>
-          </div>
-          <div>
-            <div data-valign="middle">
-              <picture>
-                <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
-              </picture>
-            </div>
-            <div data-valign="middle">
-              <p><strong>Speak directly to your audience</strong></p>
-              <h3 id="audience-experience-targeting">Audience Experience Targeting</h3>
-              <p>Leveraging Adobe Target and Adobe Audience Manager, Milo Experimentation Platform can help serve specific experiences to specific visitors.</p>
-              <p><strong><a href="https://adobe.com/">Learn more</a></strong></p>
-            </div>
-          </div>
-          <div>
-            <div data-valign="middle">
-              <picture>
-                <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
-              </picture>
-            </div>
-            <div data-valign="middle">
-              <p><strong>Personalize based on visitor attributes</strong></p>
-              <h3 id="attribute-experience-targeting">Attribute Experience Targeting</h3>
-              <p>For simple use cases, the Milo Experimentation Platform can hide/show/add content to a page based on the attributes of a visitor.</p>
-              <p><em><a href="https://adobe.com/">Learn more</a></em> <strong><a href="https://adobe.com/">Learn more</a></strong></p>
-            </div>
-          </div>
+        <div data-valign="middle">
+          <h2 id="milo-experimentation-platform">Milo Experimentation Platform</h2>
+          <p>Leverage the Milo Experimentation Platform (MEP) for all your personalization needs on Milo!</p>
+          <p><strong><a href="https://wiki.corp.adobe.com/display/marketingtech/Milo+Experiment+Manifests">Review
+                Docs</a></strong></p>
+        </div>
+        <div data-valign="middle">
+          <picture>
+            <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="811" height="207">
+          </picture>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="z-pattern small">
+      <div>
+        <div data-valign="middle">
+          <h2 id="features-of-milo-experimentation-platform">Features of Milo Experimentation Platform</h2>
+          <p>Learn more about the features of the Milo Experimentation Platform and what it can do</p>
         </div>
       </div>
       <div>
-        <div class="how-to">
-          <div>
-            <div data-valign="middle">
-              <h2 id="how-to-leverage-milo-experimentation-platform">How to leverage Milo Experimentation Platform</h2>
-              <p>This will explain the basic steps on how to use the Milo Experimentation Platform.</p>
-              <p>
-                <picture>
-                  <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
-                </picture>
-              </p>
-            </div>
-          </div>
-          <div>
-            <div data-valign="middle">
-              <ul>
-                <li>Create a webpage using Milo</li>
-                <li>Create a page manifest</li>
-                <li>Configure the personalization based on your requirements</li>
-                <li>Sit back and watch visitors enjoy your personalization!</li>
-              </ul>
-            </div>
-          </div>
+        <div data-valign="middle">
+          <picture>
+            <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
+          </picture>
+        </div>
+        <div data-valign="middle">
+          <p><strong>Who will win?</strong></p>
+          <h3 id="abn-testing">A/B/N Testing</h3>
+          <p>Milo Experimentation Platform is integrated with Adobe Target and can help you test new experiences.</p>
+          <p><strong><a href="https://adobe.com/">Learn more</a></strong></p>
         </div>
       </div>
       <div>
-        <p><a href="/fragments/replaceme">/fragments/replaceme</a></p>
+        <div data-valign="middle">
+          <picture>
+            <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
+          </picture>
+        </div>
+        <div data-valign="middle">
+          <p><strong>Speak directly to your audience</strong></p>
+          <h3 id="audience-experience-targeting">Audience Experience Targeting</h3>
+          <p>Leveraging Adobe Target and Adobe Audience Manager, Milo Experimentation Platform can help serve specific
+            experiences to specific visitors.</p>
+          <p><strong><a href="https://adobe.com/">Learn more</a></strong></p>
+        </div>
       </div>
       <div>
-        <div class="promo">
-          <div>
-            <div>Old Promo Block</div>
-          </div>
+        <div data-valign="middle">
+          <picture>
+            <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
+          </picture>
+        </div>
+        <div data-valign="middle">
+          <p><strong>Personalize based on visitor attributes</strong></p>
+          <h3 id="attribute-experience-targeting">Attribute Experience Targeting</h3>
+          <p>For simple use cases, the Milo Experimentation Platform can hide/show/add content to a page based on the
+            attributes of a visitor.</p>
+          <p><em><a href="https://adobe.com/">Learn more</a></em> <strong><a href="https://adobe.com/">Learn
+                more</a></strong></p>
         </div>
         <div class="text center xxxl-spacing-bottom">
           <div>
@@ -117,6 +84,67 @@
         </div>
         <div class="myblock">This block does not exist</div>
       </div>
-    </main>
-    <footer></footer>
-</body>
+    </div>
+  </div>
+  <div>
+    <div class="how-to">
+      <div>
+        <div data-valign="middle">
+          <h2 id="how-to-leverage-milo-experimentation-platform">How to leverage Milo Experimentation Platform</h2>
+          <p>This will explain the basic steps on how to use the Milo Experimentation Platform.</p>
+          <p>
+            <picture>
+              <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
+            </picture>
+          </p>
+        </div>
+      </div>
+      <div>
+        <div data-valign="middle">
+          <ul>
+            <li>Create a webpage using Milo</li>
+            <li>Create a page manifest</li>
+            <li>Configure the personalization based on your requirements</li>
+            <li>Sit back and watch visitors enjoy your personalization!</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <p><a href="/fragments/replaceme">/fragments/replaceme</a></p>
+  </div>
+  <div>
+    <div class="marquee">
+      <div>
+        <div data-valign="middle">
+          <picture>
+            <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="1600" height="914">
+          </picture>
+        </div>
+      </div>
+      <div>
+        <div data-valign="middle">
+          <h2 id="second-marquee-title">The second marquee</h2>
+          <p>Blah blah blah</p>
+          <p><strong><a href="https://wiki.corp.adobe.com/display/marketingtech/Milo+Experiment+Manifests">Docs
+                Here</a></strong></p>
+        </div>
+        <div data-valign="middle">
+          <picture>
+            <img loading="lazy" alt="" src="/test/mocks/media_1.jpg" width="811" height="207">
+          </picture>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <div class="promo">
+      <div>
+        <div>Old Promo Block</div>
+      </div>
+    </div>
+    <div class="myblock">This block does not exist</div>
+  </div>
+</main>
+<footer></footer>

--- a/test/features/personalization/mocks/personalization.html
+++ b/test/features/personalization/mocks/personalization.html
@@ -24,6 +24,11 @@
         </div>
       </div>
     </div>
+    <div class="custom-block custom-block-1">
+      <div>
+        <div>Custom block 1</div>
+      </div>
+    </div>
   </div>
   <div>
     <div class="z-pattern small">
@@ -85,6 +90,16 @@
         <div class="myblock">This block does not exist</div>
       </div>
     </div>
+    <div class="special-block">
+      <div>
+        <div>Special block that is second in the section</div>
+      </div>
+    </div>
+    <div class="custom-block custom-block-2">
+      <div>
+        <div>Custom block 2</div>
+      </div>
+    </div>
   </div>
   <div>
     <div class="how-to">
@@ -137,6 +152,11 @@
         </div>
       </div>
     </div>
+    <div class="custom-block custom-block-3">
+      <div>
+        <div>Custom block 3</div>
+      </div>
+    </div>
   </div>
   <div>
     <div class="promo">
@@ -145,6 +165,11 @@
       </div>
     </div>
     <div class="myblock">This block does not exist</div>
+    <div class="custom-block custom-block-4">
+      <div>
+        <div>Custom block 4</div>
+      </div>
+    </div>
   </div>
 </main>
 <footer></footer>

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -177,6 +177,29 @@ describe('Functional Test', () => {
     const fragment = document.querySelector('a[href="/fragments/insertafter2"]');
     expect(fragment).to.not.be.null;
     expect(fragment.parentElement.previousElementSibling.className).to.equal('marquee');
+    // TODO: add check for after3
+  });
+
+  it('Can select elements using block-#', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestBlockNumber.json' });
+    manifestJson = JSON.parse(manifestJson);
+    setFetchResponse(manifestJson);
+
+    expect(document.querySelector('.marquee')).to.not.be.null;
+    expect(document.querySelector('a[href="/fragments/replace/marquee/r2c1"]')).to.be.null;
+    expect(document.querySelector('a[href="/fragments/replace/marquee-2/r3c2"]')).to.be.null;
+    const secondMarquee = document.getElementsByClassName('marquee')[1];
+    expect(secondMarquee).to.not.be.null;
+
+    await applyPers([{ manifestPath: '/path/to/manifest.json' }]);
+
+    const fragment = document.querySelector('a[href="/fragments/replace/marquee/r2c1"]');
+    expect(fragment).to.not.be.null;
+    const replacedCell = document.querySelector('.marquee > div:nth-child(2) > div:nth-child(1)');
+    expect(replacedCell.firstChild.firstChild).to.equal(fragment);
+    const secondFrag = document.querySelector('a[href="/fragments/replace/marquee-2/r2c2"]');
+    expect(secondMarquee.lastElementChild.lastElementChild.firstChild.firstChild)
+      .to.equal(secondFrag);
   });
 
   it('scheduled manifest should apply changes if active (bts)', async () => {


### PR DESCRIPTION
Adds support for simplified selectors:
* Can now use `blockNameX` where `X` is the index of which block to select if there are multiple blocks of the same kind on the page.  E.g: `merchcard3` would select the 3rd merchcard on the page.
* Can now target specific table cells within a block, using `rowX colX` notation (row X, col X).  Note that for row, the header row is not counted.
  * E.g: `marquee1 row2 col2` would target the first marquees' table cell in the 2nd row, 2nd column.

Resolves: [MWPW-136727](https://jira.corp.adobe.com/browse/MWPW-136727)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/mep-cell/surfing-marquee?martech=off
- After: 
    https://mep-cell--milo--adobecom.hlx.page/drafts/cpeyer/mep-cell/surfing-marquee?martech=off
    https://mep-cell--milo--adobecom.hlx.page/drafts/cpeyer/mep-cell/surfing-marquee?martech=off&m-pic=shuttle
    https://mep-cell--milo--adobecom.hlx.page/drafts/cpeyer/mep-cell/surfing-marquee?martech=off&m-pic=octopus
