### PR TITLE
MWPW-14127: Updates the order of the image path lookup

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -239,8 +239,8 @@ const getCardImageUrl = () => {
   const { doc } = getConfig();
   const imageUrl = getImagePathMd('cardimage')
     || getImagePathMd('cardimagepath')
-    || doc.querySelector('meta[property="og:image"]')?.content
-    || doc.querySelector('main')?.querySelector('img')?.src;
+    || doc.querySelector('main')?.querySelector('img')?.src
+    || doc.querySelector('meta[property="og:image"]')?.content;
 
   if (!imageUrl) return null;
   return addHost(imageUrl);


### PR DESCRIPTION
This PR updates the order logic of the image path lookup. Right now the script never reads the value of the image **src** attribute because it stops at the the **meta property="og:image**", which should be the last fall-back option.

Resolves: [MWPW-141271](https://jira.corp.adobe.com/browse/MWPW-141271)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://MWPW-141271--milo--adobecom.hlx.page/?martech=off
