### PR TITLE
Revert "MWPW-1351731 support linked text (#1749)"

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -120,19 +120,16 @@ export async function getPriceContext(el, params) {
 }
 
 export async function buildCta(el, params) {
+  const large = !!el.closest('.marquee');
+  const strong = el.firstElementChild?.tagName === 'STRONG' || el.parentElement?.tagName === 'STRONG';
   const context = await getCheckoutContext(el, params);
   if (!context) return null;
   const service = await initService();
-  const isCta = el.textContent?.startsWith('CTA');
   const text = el.textContent?.replace(/^CTA +/, '');
   const cta = service.createCheckoutLink(context, text);
-  if (isCta) {
-    const large = !!el.closest('.marquee');
-    const strong = el.firstElementChild?.tagName === 'STRONG' || el.parentElement?.tagName === 'STRONG';
-    cta.classList.add('con-button');
-    cta.classList.toggle('button-l', large);
-    cta.classList.toggle('blue', strong);
-  }
+  cta.classList.add('con-button');
+  cta.classList.toggle('button-l', large);
+  cta.classList.toggle('blue', strong);
   return cta;
 }
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -301,14 +301,6 @@ describe('Merch Block', () => {
       });
     });
 
-    it('renders linked text', async () => {
-      const el = await merch(document.querySelector(
-        '.merch.linked.text',
-      ));
-      expect(el.textContent).to.equal('Buy now and save 40%');
-      expect(el.classList.contains('con-button')).to.be.false;
-    });
-
     it('renders large CTA inside a marquee', async () => {
       const el = await merch(document.querySelector(
         '.merch.cta.inside-marquee',

--- a/test/blocks/merch/mocks/body.html
+++ b/test/blocks/merch/mocks/body.html
@@ -117,9 +117,4 @@
   href="/tools/ost?osi=28&type=checkoutUrl">CTA Buy Now</a>
 </p>
 
-  <p>
-    CTA with metadata default: <a class="merch linked text"
-    href="/tools/ost?osi=16&type=checkoutUrl">Buy now and save 40%</a>
-  </p>
-
 </div>


### PR DESCRIPTION
This reverts commit 104ff1a94b878e0b6a711e7d0d81caddeddf0b3e.
Reverts the changes during the backward compatibility. 

Original PR description: 
Title: Cta as linked text

Authors can link text strings with checkout links.

Screenshot 2024-01-17 at 12 48 37 PM

Resolves: [MWPW-135731](https://jira.corp.adobe.com/browse/MWPW-135731)

Test URLs:

Before: https://main--milo--adobecom.hlx.page/drafts/vkniaziev/document9?martech=off
After: https://mwpw-135163--milo--vkniaz.hlx.page/drafts/vkniaziev/document9?martech=off