### PR TITLE
MWPW-141639 If Target is enabled on a page, using martech=off turns off personalization and promos

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -834,9 +834,10 @@ async function checkForPageMods() {
   const targetMd = getMetadata('target');
   let persManifests = [];
   const search = new URLSearchParams(window.location.search);
-  const persEnabled = persMd && persMd !== 'off' && search.get('personalization') !== 'off';
-  const targetEnabled = targetMd && targetMd !== 'off' && search.get('target') !== 'off' && search.get('martech') !== 'off';
-  const promoEnabled = promoMd && promoMd !== 'off' && search.get('promo') !== 'off';
+  const offFlag = (val) => search.get(val) === 'off' || search.get('mep') === 'off';
+  const persEnabled = persMd && persMd !== 'off' && !offFlag('personalization');
+  const targetEnabled = targetMd && targetMd !== 'off' && !offFlag('target') && !offFlag('martech');
+  const promoEnabled = promoMd && promoMd !== 'off' && !offFlag('promo');
   const mepEnabled = persEnabled || targetEnabled || promoEnabled;
 
   if (mepEnabled) {


### PR DESCRIPTION
If the martech=off flag is used when a page does not have Target enabled, personalization and promos are able to still run.

However, if Target is enabled, the decistion tree results in the personalization and promo manifests never being executed.

It will be less confusing if the flag has the same outcome for pages with and without Target enabled.

Resolves: [MWPW-141639](https://jira.corp.adobe.com/browse/MWPW-141639)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/mepmartechoff/?martech=off
- After: https://mepmartechoff--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/mepmartechoff/?martech=off

promo=off flag
https://main--cc--adobecom.hlx.page/products/special-offers?mep&milolibs=mepmartechoff&martech=off
https://main--cc--adobecom.hlx.page/products/special-offers?mep&milolibs=mepmartechoff&martech=off&promo=off
https://main--cc--adobecom.hlx.page/products/special-offers?mep&milolibs=mepmartechoff&martech=off&mep=off