### PR TITLE
MWPW-141387 Marquee background colors bug

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -133,6 +133,14 @@
   line-height: 0;
 }
 
+.marquee .background .expand-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
 .marquee .text p {
   margin: 0 0 var(--spacing-s);
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -110,6 +110,7 @@ export async function decorateBlockBg(block, node, { useHandleFocalpoint = false
       }
       if (!child.querySelector('img, video, a[href*=".mp4"]')) {
         child.style.background = child.textContent;
+        child.classList.add('expand-background');
         child.textContent = '';
       }
     });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Fixes issue with Marquee block breakpoint background colors not displaying.

**Context:**
When a marquee is authored to use background breakpoints and a hex color or gradient is authored for the background, the background does not display. The reason being, the color or gradient is applied via an inline style to a div element with no content. Making the breakpoint div empty and collapsing when the block renders.

This isn't a problem when using a image or video as those are nested in the breakpoint div with content and styled appropriately. 

Resolves: [MWPW-141387](https://jira.corp.adobe.com/browse/MWPW-141387)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/poc/marquee-breakpoint-bug?martech=off
- After: https://mwpw-141387-marquee-breakpoints--milo--adobecom.hlx.page/drafts/rclayton/poc/marquee-breakpoint-bug?martech=off

**Multiple Marquee variations Test URLs**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/poc/marquee-breakpoint-test?martech=off
- After: https://mwpw-141387-marquee-breakpoints--milo--adobecom.hlx.page/drafts/rclayton/poc/marquee-breakpoint-test?martech=off

**CC Test URLs**
- Before: https://main--cc--adobecom.hlx.page/drafts/moussa/tests/mobile-color-test?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/moussa/tests/mobile-color-test?milolibs=mwpw-141387-marquee-breakpoints&martech=off