### PR TITLE
MWPW-141639 Quick follow to do an early return if mep=off

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -829,12 +829,16 @@ async function loadMartech({ persEnabled = false, persManifests = [] } = {}) {
 }
 
 async function checkForPageMods() {
+  const search = new URLSearchParams(window.location.search);
+  const offFlag = (val) => search.get(val) === 'off';
+  if (offFlag('mep')) {
+    document.body.dataset.mep = 'nopzn|nopzn';
+    return;
+  }
   const persMd = getMetadata('personalization');
   const promoMd = getMetadata('manifestnames');
   const targetMd = getMetadata('target');
   let persManifests = [];
-  const search = new URLSearchParams(window.location.search);
-  const offFlag = (val) => search.get(val) === 'off' || search.get('mep') === 'off';
   const persEnabled = persMd && persMd !== 'off' && !offFlag('personalization');
   const targetEnabled = targetMd && targetMd !== 'off' && !offFlag('target') && !offFlag('martech');
   const promoEnabled = promoMd && promoMd !== 'off' && !offFlag('promo');


### PR DESCRIPTION
Got a suggestion I liked right after merging. Switching to doing an early return if mep is disabled with mep=off flag

Resolves: [MWPW-141639](https://jira.corp.adobe.com/browse/MWPW-141639)

Test URLs:
Before: https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/mepmartechoff/?mep=off
After: https://mepoffearlyreturn--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/mepmartechoff/?mep=off