### PR TITLE
MWPW-141638: Fix for commerce modals event listeners

### DIFF
--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -485,7 +485,7 @@ const init = async (el) => {
       if (merchCard.variant === MINI_COMPARE_CHART) {
         setMiniCompareOfferSlot(merchCard, quantitySelect);
       } else {
-        const bodySlot = merchCard.querySelector('div[slot="xs"]');
+        const bodySlot = merchCard.querySelector('div[slot="body-xs"]');
         bodySlot.append(quantitySelect);
       }
     }

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -233,8 +233,12 @@
   }
 
   .dialog-modal.commerce-frame.height-fit-content .milo-iframe {
-    height: auto;
+    height: 100%;
     max-height: 845px;
+  }
+
+  .dialog-modal.commerce-frame.height-fit-content .milo-iframe iframe {
+    height: 0%;
   }
   
   .dialog-modal.upgrade-flow-modal {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -9,9 +9,10 @@ const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="2
     <line x1="8" y1="8" transform="translate(10506 -3397)" fill="none" stroke="#fff" stroke-width="2"/>
   </g>
 </svg>`;
-let isInitialPageLoad = true;
 const MOBILE_MAX = 599;
 const TABLET_MAX = 1199;
+let messageAbortController;
+let resizeAbortController;
 
 export function findDetails(hash, el) {
   const id = hash.replace('#', '');
@@ -31,13 +32,17 @@ export function sendAnalytics(event) {
   });
 }
 
-function closeModal(modal) {
+export function closeModal(modal) {
   const { id } = modal;
   const closeEvent = new Event('milo:modal:closed');
   window.dispatchEvent(closeEvent);
   const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
   const analyticsEventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
   const closeEventAnalytics = new Event(`${analyticsEventName}:modalClose:buttonClose`);
+  // removing the 'message' and 'resize' event listener set for commerce modals
+  messageAbortController?.abort();
+  resizeAbortController?.abort();
+
   sendAnalytics(closeEventAnalytics);
 
   document.querySelectorAll(`#${id}`).forEach((mod) => {
@@ -93,42 +98,41 @@ async function getPathModal(path, dialog) {
   const { default: getFragment } = await import('../fragment/fragment.js');
   await getFragment(block);
 }
+
 function sendViewportDimensionsToiFrame(source) {
   const viewportWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
   source.postMessage({ mobileMax: MOBILE_MAX, tabletMax: TABLET_MAX, viewportWidth }, '*');
 }
 
-let resizeListenerAdded = false;
-export async function sendViewportDimensionsOnRequest(messageInfo) {
-  if (messageInfo.data === 'viewportWidth') {
-    sendViewportDimensionsToiFrame(messageInfo.source);
-    const { debounce } = await import('../../utils/action.js');
-    if (!resizeListenerAdded) {
-      window.addEventListener('resize', debounce(() => sendViewportDimensionsToiFrame(messageInfo.source), 50));
-      resizeListenerAdded = true;
-    }
-  }
+export function sendViewportDimensionsOnRequest({ messageInfo, debounce }) {
+  const { data, source } = messageInfo || {};
+  if (data !== 'viewportWidth' || !source || !debounce) return;
+  resizeAbortController = new AbortController();
+  sendViewportDimensionsToiFrame(source);
+  window.addEventListener('resize', debounce(() => sendViewportDimensionsToiFrame(source), 10), { signal: resizeAbortController.signal });
 }
 
 /** For the modal height adjustment to work the following conditions must be met:
  * 1. The modal must have classes 'commerce-frame height-fit-content';
  * 2. The iframe inside must send a postMessage with the contentHeight (a number of px or '100%);
  */
-function adjustModalHeight({ contentHeight, dialogId }) {
-  if (!contentHeight || !dialogId) return;
-  const dialog = document.querySelector(`#${dialogId}`);
-  const iFrameWrapper = dialog?.querySelector('.milo-iframe.modal');
-  if (!iFrameWrapper) return;
-
+function adjustModalHeight({ contentHeight, dialog }) {
+  const iframe = dialog?.querySelector('iframe');
+  const iframeWrapper = dialog?.querySelector('.milo-iframe');
+  if (!contentHeight || !iframe || !iframeWrapper) return;
   if (contentHeight === '100%') {
-    iFrameWrapper.style.height = contentHeight;
+    // the initial iframe height was set to 0 in CSS for the content height to be measured properly
+    iframe.style.height = '100%';
+    iframeWrapper.style.height = contentHeight;
     dialog.style.height = contentHeight;
   } else {
     const verticalMargins = 20;
     const clientHeight = document.documentElement.clientHeight - verticalMargins;
     if (clientHeight <= 0) return;
     const newHeight = contentHeight > clientHeight ? clientHeight : contentHeight;
-    iFrameWrapper.style.height = `${newHeight}px`;
+    // the initial iframe height was set to 0 in CSS for the content height to be measured properly
+    iframe.style.height = '100%';
+    iframeWrapper.style.height = `${newHeight}px`;
     dialog.style.height = `${newHeight}px`;
   }
 }
@@ -202,15 +206,17 @@ export async function getModal(details, custom) {
       .forEach((element) => element.setAttribute('aria-disabled', 'true'));
   }
   if (dialog.classList.contains('commerce-frame')) {
-    if (isInitialPageLoad) {
-      window.addEventListener('message', (messageInfo) => {
-        if (dialog.classList.contains('height-fit-content')) {
-          adjustModalHeight({ contentHeight: messageInfo?.data?.contentHeight, dialogId: id });
-        }
-        sendViewportDimensionsOnRequest(messageInfo);
-      });
-      isInitialPageLoad = false;
-    }
+    const { debounce } = await import('../../utils/action.js');
+    messageAbortController = new AbortController();
+    window.addEventListener('message', (messageInfo) => {
+      if (dialog.classList.contains('height-fit-content')) {
+        adjustModalHeight({ contentHeight: messageInfo?.data?.contentHeight, dialog });
+      }
+      /* If the page inside iFrame comes from another domain, it won't be able to retrieve
+      the viewport dimensions, so it sends a request to receive the viewport dimensions
+      from the parent window. */
+      sendViewportDimensionsOnRequest({ debounce, messageInfo });
+    }, { signal: messageAbortController.signal });
   }
   return dialog;
 }


### PR DESCRIPTION
**How it works now:**
In the current implementation, when the commerce modal is open, we establish a message event listener to address two scenarios:
- If the page within the iFrame cannot detect its viewport width due to CORS restrictions, it may request the viewport width from the parent page.
- The page within the iFrame measures its content height and sends this information to adjust the modal height, eliminating any blank space at the bottom.

Upon closing the commerce modal, we remove the message event listener using the abortController.
Additionally, the dynamic import of the debounce function has been optimized by relocating it outside the function that is invoked within the event listener, ensuring that the import is executed only once. The debouncing time decreased from 50 to 10 to avoid the modal getting stuck when the resize is done quickly.

**How it worked before:**
Previously, the message event listener was set during page load, and the function called upon that event retained the context of the initially opened modal window. This led to an issue where, upon closing one modal and opening another, the height adjustment would fail because the event listener function attempted to adjust the height of the previously opened modal. The current enhancements address and resolve this limitation.

**Resolves:** [MWPW-141638](https://jira.corp.adobe.com/browse/MWPW-141638)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout
- After: https://mwpw-141638-modal-height-multiple--milo--mirafedas.hlx.page/drafts/mirafedas/twp

Note for testers:
To verify the modals on my test page you would need to set the frame-ancestors in ModHeaders plugin in the CSP response modifiers to asterisk (see screenshot)
![Screenshot 2024-02-06 at 18 45 05](https://github.com/adobecom/milo/assets/30750556/91d81b8c-acf0-4e5f-86a8-b19b6be3fa36)

