### PR TITLE
left option enabled.

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -112,7 +112,7 @@
   line-height: var(--type-body-xs-lh);
 }
 
-.table:not(.merch) .section-row .col:not(.section-row-title),
+.table:not(.merch):not(.left) .section-row .col:not(.section-row-title),
 .table .row-heading .col.col-heading {
   text-align: center;
 }


### PR DESCRIPTION
Adding left text alignment option for GWP.

Resolves: https://workfront.slack.com/archives/C03B0BUA75E/p1706138939114819?thread_ts=1706129531.953969&cid=C03B0BUA75E

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/table?martech=off
- After: https://table-left--milo--adobecom.hlx.page/docs/library/blocks/table?martech=off

Left example:
https://main--bacom--adobecom.hlx.page/drafts/karchie/premier-support?milolibs=table-left
