### PR TITLE
MWPW-141810: updated custom ietf locale logic for unav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -204,27 +204,29 @@ const closeOnClickOutside = (e) => {
   }
 };
 
-const getUniversalNavLocale = () => {
-  const { locale: { prefix: configPrefix = '', ietf = '' } = {} } = getConfig() || {};
-  const prefix = configPrefix.replace('/', '');
+const getUniversalNavLocale = (locale) => {
+  const prefix = locale.prefix.replace('/', '');
+  const { ietf } = locale;
   const DEFAULTLANG = {
-    en_US: ['ae_en', 'africa', 'au', 'be_en', 'ca', 'cis_en', 'cy_en', 'eg_en', 'gr_en', 'hk_en', 'id_en', 'ie', 'il_en', 'in', 'kw_en', 'langstore', 'lu_en', 'mena_en', 'mt', 'my_en', 'ng', 'nz', 'ph_en', 'qa_en', 'sa_en', 'sg', 'th_en', 'uk', 'vn_en', 'za'],
-    fr_FR: ['be_fr', 'ca_fr', 'ch_fr', 'lu_fr'],
     de_DE: ['at', 'ch_de', 'lu_de'],
+    en_US: ['ae_en', 'africa', 'au', 'be_en', 'ca', 'cis_en', 'cy_en', 'eg_en', 'gr_en', 'hk_en', 'id_en', 'ie', 'il_en', 'in', 'kw_en', 'langstore', 'lu_en', 'mena_en', 'mt', 'my_en', 'ng', 'nz', 'ph_en', 'qa_en', 'sa_en', 'sg', 'th_en', 'uk', 'vn_en', 'za'],
     es_ES: ['ar', 'ar_es', 'cl', 'co', 'cr', 'ec', 'gt', 'la', 'mx', 'pe', 'pr'],
+    fr_FR: ['be_fr', 'ca_fr', 'ch_fr', 'lu_fr'],
   };
   const CUSTOMLANG = {
     be_nl: 'nl_NL',
     ch_it: 'it_IT',
+    cis_ru: 'ru_RU',
     hk_zh: 'zh_TW',
     no: 'nb_NO',
-    cis_ru: 'ru_RU',
   };
   const prefixParts = prefix.split('_').reverse();
 
   return Object.keys(DEFAULTLANG).find((key) => DEFAULTLANG[key].includes(prefix))
          || CUSTOMLANG[prefix]
-         || (ietf.includes('-') ? ietf.replace('-', '_') : `${prefixParts[0].toLowerCase()}_${prefixParts[1].toUpperCase()}`)
+         || (ietf.includes('-')
+           ? ietf.replace('-', '_')
+           : prefixParts.length === 2 && `${prefixParts[0].toLowerCase()}_${prefixParts[1].toUpperCase()}`)
          || 'en_US';
 };
 
@@ -457,7 +459,7 @@ class Gnav {
 
   decorateUniversalNav = async () => {
     const config = getConfig();
-    const locale = getUniversalNavLocale();
+    const locale = getUniversalNavLocale(config.locale);
     const environment = config.env.name === 'prod' ? 'prod' : 'stage';
     const visitorGuid = window.alloy ? await window.alloy('getIdentity').then((data) => data?.identity?.ECID) : undefined;
     const getDevice = () => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -209,7 +209,11 @@ const getUniversalNavLocale = (locale) => {
   const { ietf } = locale;
   const DEFAULTLANG = {
     de_DE: ['at', 'ch_de', 'lu_de'],
-    en_US: ['ae_en', 'africa', 'au', 'be_en', 'ca', 'cis_en', 'cy_en', 'eg_en', 'gr_en', 'hk_en', 'id_en', 'ie', 'il_en', 'in', 'kw_en', 'langstore', 'lu_en', 'mena_en', 'mt', 'my_en', 'ng', 'nz', 'ph_en', 'qa_en', 'sa_en', 'sg', 'th_en', 'uk', 'vn_en', 'za'],
+    en_US: [
+      'ae_en', 'africa', 'au', 'be_en', 'ca', 'cis_en', 'cy_en', 'eg_en', 'gr_en', 'hk_en',
+      'id_en', 'ie', 'il_en', 'in', 'kw_en', 'langstore', 'lu_en', 'mena_en', 'mt', 'my_en',
+      'ng', 'nz', 'ph_en', 'qa_en', 'sa_en', 'sg', 'th_en', 'uk', 'vn_en', 'za',
+    ],
     es_ES: ['ar', 'ar_es', 'cl', 'co', 'cr', 'ec', 'gt', 'la', 'mx', 'pe', 'pr'],
     fr_FR: ['be_fr', 'ca_fr', 'ch_fr', 'lu_fr'],
   };

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -205,7 +205,7 @@ const closeOnClickOutside = (e) => {
 };
 
 const getIetfLocale = (ietfLocale) => {
-  const nonStandardLocaleMap = { no_NO: 'nb_NO' };
+  const nonStandardLocaleMap = { no_NO: 'nb_NO', pt_PT: 'pt_BR' };
   return nonStandardLocaleMap[ietfLocale] || ietfLocale;
 };
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -204,9 +204,28 @@ const closeOnClickOutside = (e) => {
   }
 };
 
-const getIetfLocale = (ietfLocale) => {
-  const nonStandardLocaleMap = { no_NO: 'nb_NO', pt_PT: 'pt_BR' };
-  return nonStandardLocaleMap[ietfLocale] || ietfLocale;
+const getUniversalNavLocale = () => {
+  const { locale: { prefix: configPrefix = '', ietf = '' } = {} } = getConfig() || {};
+  const prefix = configPrefix.replace('/', '');
+  const DEFAULTLANG = {
+    en_US: ['ae_en', 'africa', 'au', 'be_en', 'ca', 'cis_en', 'cy_en', 'eg_en', 'gr_en', 'hk_en', 'id_en', 'ie', 'il_en', 'in', 'kw_en', 'langstore', 'lu_en', 'mena_en', 'mt', 'my_en', 'ng', 'nz', 'ph_en', 'qa_en', 'sa_en', 'sg', 'th_en', 'uk', 'vn_en', 'za'],
+    fr_FR: ['be_fr', 'ca_fr', 'ch_fr', 'lu_fr'],
+    de_DE: ['at', 'ch_de', 'lu_de'],
+    es_ES: ['ar', 'ar_es', 'cl', 'co', 'cr', 'ec', 'gt', 'la', 'mx', 'pe', 'pr'],
+  };
+  const CUSTOMLANG = {
+    be_nl: 'nl_NL',
+    ch_it: 'it_IT',
+    hk_zh: 'zh_TW',
+    no: 'nb_NO',
+    cis_ru: 'ru_RU',
+  };
+  const prefixParts = prefix.split('_').reverse();
+
+  return Object.keys(DEFAULTLANG).find((key) => DEFAULTLANG[key].includes(prefix))
+         || CUSTOMLANG[prefix]
+         || (ietf.includes('-') ? ietf.replace('-', '_') : `${prefixParts[0].toLowerCase()}_${prefixParts[1].toUpperCase()}`)
+         || 'en_US';
 };
 
 class Gnav {
@@ -438,14 +457,7 @@ class Gnav {
 
   decorateUniversalNav = async () => {
     const config = getConfig();
-    let language;
-    let region;
-    if (config.locale.ietf.includes('-')) {
-      [language, region] = config.locale.ietf.split('-');
-    } else {
-      [region, language] = config.locale.prefix.replace('/', '').split('_');
-    }
-    const locale = getIetfLocale(`${language.toLowerCase()}_${region.toUpperCase()}`);
+    const locale = getUniversalNavLocale();
     const environment = config.env.name === 'prod' ? 'prod' : 'stage';
     const visitorGuid = window.alloy ? await window.alloy('getIdentity').then((data) => data?.identity?.ECID) : undefined;
     const getDevice = () => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -226,7 +226,9 @@ const getUniversalNavLocale = (locale) => {
          || CUSTOMLANG[prefix]
          || (ietf.includes('-')
            ? ietf.replace('-', '_')
-           : prefixParts.length === 2 && `${prefixParts[0].toLowerCase()}_${prefixParts[1].toUpperCase()}`)
+           : prefixParts[1]
+           && prefixParts.every((i) => !!i)
+           && `${prefixParts[0].toLowerCase()}_${prefixParts[1].toUpperCase()}`)
          || 'en_US';
 };
 

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -123,7 +123,7 @@ const config = {
   geoRouting: 'on',
   fallbackRouting: 'on',
   links: 'on',
-  imsClientId: 'fedsmilo',
+  imsClientId: 'milo',
   imsScope: 'AdobeID,openid,gnav,pps.read',
   codeRoot: '/libs',
   locales,

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -123,7 +123,7 @@ const config = {
   geoRouting: 'on',
   fallbackRouting: 'on',
   links: 'on',
-  imsClientId: 'milo',
+  imsClientId: 'fedsmilo',
   imsScope: 'AdobeID,openid,gnav,pps.read',
   codeRoot: '/libs',
   locales,


### PR DESCRIPTION
## Description
This PR updates the custom ietf locale logic for the universal navigation to match the [mapping received from the Universal Navigation team.](https://git.corp.adobe.com/wcms/hawks/pull/3080/files)

## Related Issue
Resolves: [MWPW-141810](https://jira.corp.adobe.com/browse/MWPW-141810)

## Test URLs
**Milo:**
- Before:  https://gnav--milo--adobecom.hlx.page/drafts/rbogos/unav?martech=off
- After: https://mwpw-141810-update-locales-unav--milo--robert-bogos.hlx.page/drafts/rbogos/unav?martech=off