### PR TITLE
Mwpw 138103:  Quantity selector in mini compare chart card

### DIFF
--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -431,12 +431,13 @@ const init = async (el) => {
   if (cardType === 'plans' || cardType === MINI_COMPARE_CHART) {
     const quantitySelect = createQuantitySelect(el);
     const offerSelection = el.querySelector('ul');
+    const bodySlotName = `body-${merchCard.variant !== MINI_COMPARE_CHART ? 'xs' : 'm'}`;
     if (offerSelection) {
       const { initOfferSelection } = await import('./merch-offer-select.js');
       initOfferSelection(merchCard, offerSelection, quantitySelect);
     }
     if (quantitySelect) {
-      const bodySlot = merchCard.querySelector('div[slot="body-xs"]');
+      const bodySlot = merchCard.querySelector(`div[slot="${bodySlotName}"]`);
       bodySlot.append(quantitySelect);
     }
   }

--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -428,7 +428,7 @@ const init = async (el) => {
   }
   merchCard.appendChild(footer);
 
-  if (cardType === 'plans') {
+  if (cardType === 'plans' || cardType === MINI_COMPARE_CHART) {
     const quantitySelect = createQuantitySelect(el);
     const offerSelection = el.querySelector('ul');
     if (offerSelection) {

--- a/test/blocks/merch-card/merch-card.test.js
+++ b/test/blocks/merch-card/merch-card.test.js
@@ -334,6 +334,16 @@ describe('Mini Compare Chart Merch Card', () => {
     expect(buttons[0].textContent).to.be.equal('Buy now');
     expect(buttons[1].textContent).to.be.equal('free trial');
   });
+  it('Supports Mini Compare Chart with quantity select', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/mini-compare-chart.html' });
+    const merchCard = await init(document.querySelector('.merch-card.mini-compare-chart'));
+    const quantitySelect = merchCard.querySelector('merch-quantity-select');
+    expect(quantitySelect).to.exist;
+    expect(quantitySelect.getAttribute('title')).to.equal('Select a quantity:');
+    expect(quantitySelect.getAttribute('min')).to.equal('1');
+    expect(quantitySelect.getAttribute('max')).to.equal('10');
+    expect(quantitySelect.getAttribute('step')).to.equal('1');
+  });
 });
 
 describe('Merch Card with Offer Selection', () => {

--- a/test/blocks/merch-card/mocks/mini-compare-chart.html
+++ b/test/blocks/merch-card/mocks/mini-compare-chart.html
@@ -14,6 +14,14 @@
         </picture>
         <h2 id="illustrator">Illustrator</h2>
         <p>Get Illustrator on desktop and iPad as part of Creative Cloud. <em>This is promo text</em></p>
+        <ul>
+          <li><strong>Quantity</strong>
+            <ul>
+              <li>Select a quantity:</li>
+              <li>1,10,1</li>
+            </ul>
+          </li>
+        </ul>
         <h2 id="price---abm---creative-cloud-all-apps-with-4tb-1"><a href="#">PRICE - ABM - Creative Cloud All Apps with 4TB</a></h2>
         <p><strong><a href="https://business.adobe.com/">Buy now</a></strong> <em><a href="https://business.adobe.com/">free trial</a></em></p>
       </div>


### PR DESCRIPTION
Adds support for quantity selector in Mini compare chart card.

![Screenshot 2024-01-29 at 9 50 45 AM](https://github.com/adobecom/milo/assets/1179549/a4144b07-4865-46c5-b293-da274bb9a620)

Resolves: [MWPW-138103](https://jira.corp.adobe.com/browse/MWPW-138103)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/axel/mini-compare-chart
- After: https://mwpw-141691--milo--adobecom.hlx.page/drafts/axel/mini-compare-chart
