### PR TITLE
MWPW-140229: Sync Universal Nav analytics from Dunamis to AA

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -524,7 +524,9 @@ class Gnav {
                 data.content?.name?.split('-').map((str) => str.charAt(0).toUpperCase() + str.slice(1)).join(' ')
               }`,
               footer: {
-                // two of these will be removed in the future, when the unav team updates the data model
+                // two of these will be removed in the future,
+                // when the unav team updates the data model for consistency
+                // between logged in and logged out states
                 'all-apps': 'AppLauncher.allapps',
                 'adobe-dot-com': 'AppLauncher.adobe.com',
                 'adobe-home': 'AppLauncher.adobe.com',

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -524,8 +524,8 @@ class Gnav {
                 data.content?.name?.split('-').map((str) => str.charAt(0).toUpperCase() + str.slice(1)).join(' ')
               }`,
               footer: {
-                'adobe-home': 'AppLauncher.adobe.com',
-                'all-apps': 'AppLauncher.allapps',
+                'adobe-dot-com': 'AppLauncher.adobe.com',
+                'see-all-apps': 'AppLauncher.allapps',
               },
             },
             render: { component: 'AppLauncher.appIconToggle' },

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -538,9 +538,6 @@ class Gnav {
       const interaction = getInteraction();
 
       if (!interaction) return;
-      // __ added for testing purposes, will be removed before merging
-      console.log('interaction -->', interaction);
-      // _____________________________________________________________
       // eslint-disable-next-line no-underscore-dangle
       window._satellite?.track('event', {
         xdm: {},

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -538,6 +538,9 @@ class Gnav {
       const interaction = getInteraction();
 
       if (!interaction) return;
+      // __ added for testing purposes, will be removed before merging
+      console.log('interaction -->', interaction);
+      // _____________________________________________________________
       // eslint-disable-next-line no-underscore-dangle
       window._satellite?.track('event', {
         xdm: {},

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -236,6 +236,11 @@ const getUniversalNavLocale = (locale) => {
          || 'en_US';
 };
 
+const convertToPascalCase = (str) => str
+  ?.split('-')
+  .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+  .join(' ');
+
 class Gnav {
   constructor(body, el) {
     this.blocks = {
@@ -468,6 +473,8 @@ class Gnav {
     const locale = getUniversalNavLocale(config.locale);
     const environment = config.env.name === 'prod' ? 'prod' : 'stage';
     const visitorGuid = window.alloy ? await window.alloy('getIdentity').then((data) => data?.identity?.ECID) : undefined;
+    const experienceName = getExperienceName();
+
     const getDevice = () => {
       const agent = navigator.userAgent;
       if (agent.includes('Mac')) return 'macOS';
@@ -508,22 +515,25 @@ class Gnav {
       if (!data) return;
 
       const getInteraction = () => {
-        const { event: { type, subtype } = {}, source: { name } = {} } = data;
-        const contentName = data.content?.name;
+        const {
+          event: { type, subtype } = {},
+          source: { name } = {},
+          content: { name: contentName } = {},
+        } = data;
+
         switch (`${name}|${type}|${subtype}|${contentName || ''}`) {
           case 'profile|click|sign-in|':
-            return `Sign in|gnav|${getExperienceName()}|unav`;
+            return `Sign in|gnav|${experienceName}|unav`;
           case 'profile|render|component|':
-            return `Account|gnav|${getExperienceName()}`;
+            return `Account|gnav|${experienceName}`;
           case 'profile|click|account|':
-            return `View Account|gnav|${getExperienceName()}`;
+            return `View Account|gnav|${experienceName}`;
           case 'profile|click|sign-out|':
-            return `Sign out|gnav|${getExperienceName()}|unav`;
+            return `Sign out|gnav|${experienceName}|unav`;
           case 'app-switcher|render|component|':
             return 'AppLauncher.appIconToggle';
           case `app-switcher|click|app|${contentName}`:
-            return `AppLauncher.appClick.${contentName?.split('-')
-              .map((str) => str.charAt(0).toUpperCase() + str.slice(1)).join(' ')}`;
+            return `AppLauncher.appClick.${convertToPascalCase(contentName)}`;
           case 'app-switcher|click|footer|adobe-home':
             return 'AppLauncher.adobe.com';
           case 'app-switcher|click|footer|all-apps':

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -525,7 +525,7 @@ class Gnav {
               }`,
               footer: {
                 'adobe-home': 'AppLauncher.adobe.com',
-                'all-apps': 'AppLauncher.allaps',
+                'all-apps': 'AppLauncher.allapps',
               },
             },
             render: { component: 'AppLauncher.appIconToggle' },

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -509,36 +509,33 @@ class Gnav {
 
       const getInteraction = () => {
         const { event: { type, subtype } = {}, source: { name } = {} } = data;
-        const interactionMapping = {
-          profile: {
-            click: {
-              account: `View Account|gnav|${getExperienceName()}`,
-              'sign-in': `Sign in|gnav|${getExperienceName()}|unav`,
-              'sign-out': `Sign out|gnav|${getExperienceName()}|unav`,
-            },
-            render: { component: `Account|gnav|${getExperienceName()}` },
-          },
-          'app-switcher': {
-            click: {
-              app: `AppLauncher.appClick.${
-                data.content?.name?.split('-').map((str) => str.charAt(0).toUpperCase() + str.slice(1)).join(' ')
-              }`,
-              footer: {
-                // two of these will be removed in the future,
-                // when the unav team updates the data model for consistency
-                // between logged in and logged out states
-                'all-apps': 'AppLauncher.allapps',
-                'adobe-dot-com': 'AppLauncher.adobe.com',
-                'adobe-home': 'AppLauncher.adobe.com',
-                'see-all-apps': 'AppLauncher.allapps',
-              },
-            },
-            render: { component: 'AppLauncher.appIconToggle' },
-          },
-        };
-        const interactionResult = interactionMapping[name]?.[type]?.[subtype];
-
-        return (interactionResult && interactionResult[data.content?.name]) || interactionResult;
+        const contentName = data.content?.name;
+        switch (`${name}|${type}|${subtype}|${contentName || ''}`) {
+          case 'profile|click|sign-in|':
+            return `Sign in|gnav|${getExperienceName()}|unav`;
+          case 'profile|render|component|':
+            return `Account|gnav|${getExperienceName()}`;
+          case 'profile|click|account|':
+            return `View Account|gnav|${getExperienceName()}`;
+          case 'profile|click|sign-out|':
+            return `Sign out|gnav|${getExperienceName()}|unav`;
+          case 'app-switcher|render|component|':
+            return 'AppLauncher.appIconToggle';
+          case `app-switcher|click|app|${contentName}`:
+            return `AppLauncher.appClick.${contentName?.split('-')
+              .map((str) => str.charAt(0).toUpperCase() + str.slice(1)).join(' ')}`;
+          case 'app-switcher|click|footer|adobe-home':
+            return 'AppLauncher.adobe.com';
+          case 'app-switcher|click|footer|all-apps':
+            return 'AppLauncher.allapps';
+          case 'app-switcher|click|footer|adobe-dot-com':
+            return 'AppLauncher.adobe.com';
+          case 'app-switcher|click|footer|see-all-apps':
+            return 'AppLauncher.allapps';
+            // TODO: add support for notifications
+          default:
+            return null;
+        }
       };
       const interaction = getInteraction();
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -524,6 +524,7 @@ class Gnav {
                 data.content?.name?.split('-').map((str) => str.charAt(0).toUpperCase() + str.slice(1)).join(' ')
               }`,
               footer: {
+                // two of these will be removed in the future, when the unav team updates the data model
                 'all-apps': 'AppLauncher.allapps',
                 'adobe-dot-com': 'AppLauncher.adobe.com',
                 'adobe-home': 'AppLauncher.adobe.com',

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -526,6 +526,8 @@ class Gnav {
               footer: {
                 'adobe-dot-com': 'AppLauncher.adobe.com',
                 'see-all-apps': 'AppLauncher.allapps',
+                'adobe-home': 'AppLauncher.adobe.com',
+                'all-apps': 'AppLauncher.allapps',
               },
             },
             render: { component: 'AppLauncher.appIconToggle' },

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -512,8 +512,8 @@ class Gnav {
         const interactionMapping = {
           profile: {
             click: {
-              'sign-in': `Sign in|gnav|${getExperienceName()}|unav`,
               account: `View Account|gnav|${getExperienceName()}`,
+              'sign-in': `Sign in|gnav|${getExperienceName()}|unav`,
               'sign-out': `Sign out|gnav|${getExperienceName()}|unav`,
             },
             render: { component: `Account|gnav|${getExperienceName()}` },
@@ -524,10 +524,10 @@ class Gnav {
                 data.content?.name?.split('-').map((str) => str.charAt(0).toUpperCase() + str.slice(1)).join(' ')
               }`,
               footer: {
-                'adobe-dot-com': 'AppLauncher.adobe.com',
-                'see-all-apps': 'AppLauncher.allapps',
-                'adobe-home': 'AppLauncher.adobe.com',
                 'all-apps': 'AppLauncher.allapps',
+                'adobe-dot-com': 'AppLauncher.adobe.com',
+                'adobe-home': 'AppLauncher.adobe.com',
+                'see-all-apps': 'AppLauncher.allapps',
               },
             },
             render: { component: 'AppLauncher.appIconToggle' },

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -123,8 +123,7 @@ const config = {
   geoRouting: 'on',
   fallbackRouting: 'on',
   links: 'on',
-  // will be reverted before merging
-  imsClientId: 'fedsmilo',
+  imsClientId: 'milo',
   imsScope: 'AdobeID,openid,gnav,pps.read',
   codeRoot: '/libs',
   locales,

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -123,7 +123,8 @@ const config = {
   geoRouting: 'on',
   fallbackRouting: 'on',
   links: 'on',
-  imsClientId: 'milo',
+  // will be reverted before merging
+  imsClientId: 'fedsmilo',
   imsScope: 'AdobeID,openid,gnav,pps.read',
   codeRoot: '/libs',
   locales,


### PR DESCRIPTION
## Description
This PR syncs the analytics from Dunamis to AA

## Related Issue
Resolves: [MWPW-140229](https://jira.corp.adobe.com/browse/MWPW-140229)

## Testing instructions
1. click on any element from the universal navigation;
2. go to the network tab in dev tools;
3. search for 'collect' and you'll find the sent tag inside the payload, as you can see in the screenshot below;
<img width="1728" alt="Screenshot 2024-01-30 at 14 28 51" src="https://github.com/adobecom/milo/assets/146744221/c8c2550e-8396-45e3-a3c8-df168f4b9977">


The sent tags can be verified against https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=marketingtech&title=Universal+Nav+on+Adobe.com+-+Custom+Tracking

## Test URLs
**Milo:**
- Before: https://gnav--milo--adobecom.hlx.page/drafts/rbogos/unav?martech=off
- After: https://mwpw-140229-sync-unav-analytics--milo--robert-bogos.hlx.page/drafts/rbogos/unav?martech=off
