### PR TITLE
MWPW-141594 Move georouting to post LCP

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -896,6 +896,11 @@ async function checkForPageMods() {
 }
 
 async function loadPostLCP(config) {
+  const georouting = getMetadata('georouting') || config.geoRouting;
+  if (georouting === 'on') {
+    const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
+    await loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);
+  }
   loadMartech();
   const header = document.querySelector('header');
   if (header) {
@@ -1005,13 +1010,6 @@ function decorateDocumentExtras() {
 }
 
 async function documentPostSectionLoading(config) {
-  const georouting = getMetadata('georouting') || config.geoRouting;
-  if (georouting === 'on') {
-    // eslint-disable-next-line import/no-cycle
-    const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
-    loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);
-  }
-
   decorateFooterPromo();
 
   const appendage = getMetadata('title-append');
@@ -1067,12 +1065,13 @@ async function processSection(section, config, isDoc) {
   // Only move on to the next section when all blocks are loaded.
   await Promise.all(loaded);
 
-  if (isDoc && section.el.dataset.idx === '0') {
-    loadPostLCP(config);
-  }
-
   // Show the section when all blocks inside are done.
   delete section.el.dataset.status;
+
+  if (isDoc && section.el.dataset.idx === '0') {
+    await loadPostLCP(config);
+  }
+
   delete section.el.dataset.idx;
 
   return section.blocks;


### PR DESCRIPTION
* Moves georouting to post-LCP event for performance improvements
* Meaningfully improves georouting pages with low lighthouse scores due to LCP
* Has little/no change on georouting pages with high lighthouse scores
* Has little/no change to pages without georouting
* May increase CLS in some cases on georouting pages but has overall positive effect on lighthouse score because of LCP improvement

Resolves: [MWPW-141594](https://jira.corp.adobe.com/browse/MWPW-141594)

**Bacom FR Homepage:**
Lighthouse score: 79 -> 94
LCP: 5.6s -> 3.0s
<img width="786" alt="Screenshot 2024-01-29 at 5 07 37 PM" src="https://github.com/adobecom/milo/assets/19690988/4208fac7-b1d5-4e81-bbe4-1bd895aabfda">
<img width="784" alt="Screenshot 2024-01-29 at 5 07 46 PM" src="https://github.com/adobecom/milo/assets/19690988/ca3daffc-4f24-4bc0-bf4e-ef9b1664d948">

**CC Business Card Design Page:**
Lighthouse score: 75 -> 98
LCP: 1.9s -> 1.7s
<img width="779" alt="Screenshot 2024-01-29 at 4 54 07 PM" src="https://github.com/adobecom/milo/assets/19690988/55cdb00c-08c9-4c36-8bf4-7e752d680a7d">
<img width="783" alt="Screenshot 2024-01-29 at 4 54 17 PM" src="https://github.com/adobecom/milo/assets/19690988/6fbd2377-bc13-49d4-9244-bc1c2078df43">

**Test URLs:**
(Copied from Bacom AEM sites product page)
- Before: https://main--milo--adobecom.hlx.page/de/drafts/methomas/aem-sites?martech=off
- After: https://geo-move--milo--adobecom.hlx.page/de/drafts/methomas/aem-sites?martech=off

Lighthouse score: 90 -> 90
LCP: 1.3s -> 1.4s 
<img width="776" alt="Screenshot 2024-01-30 at 9 58 45 AM" src="https://github.com/adobecom/milo/assets/19690988/ffcef7f1-b0fb-4263-8a49-cf571a468a45">
<img width="783" alt="Screenshot 2024-01-30 at 9 59 25 AM" src="https://github.com/adobecom/milo/assets/19690988/57ed0995-56f9-4006-8e05-5fce3308c597">