### PR TITLE
[MWPW-142055] Ensure UNav dropdowns are visible on Safari

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -373,6 +373,15 @@ header.global-navigation {
   display: flex;
   align-items: center;
   padding: 0 var(--feds-gutter);
+  z-index: 1; /* Useful for UNav dropdowns */
+}
+
+.feds-utilities .unav-comp-app-switcher-popover, /* App Switcher */
+.feds-utilities .spectrum-Dialog-content, /* Notifications */
+.feds-utilities .unav-comp-external-profile, /* Profile */
+.feds-utilities .unav-comp-help-popover, /* Help */
+.feds-utilities .unc-overlay-container { /* Tooltips */
+  transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */
 }
 
 /* Profile styles - to be removed after IMS takes over the profile */


### PR DESCRIPTION
## Description
This ensures that the Universal Nav dropdown menus and their tooltips are visible when browsing on a mobile viewport in Safari 16.

## Related Issue
Resolves: [MWPW-142055](https://jira.corp.adobe.com/browse/MWPW-142055)

## Testing instructions
Use Safari 16 on a mobile viewport and log in. Hover and click the Utility Navigation icons and notice that their tooltips and dropdown menus are visible.

## Test URLs
**Milo:**
- Before: https://gnav--milo--adobecom.hlx.page/drafts/narcis/default?martech=off
- After: https://gnav--milo--overmyheadandbody.hlx.page/drafts/narcis/default?martech=off
