### PR TITLE
MWPW-142058 Localize fragment preload

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import { createTag, getConfig, loadLink, loadScript, updateConfig } from '../../utils/utils.js';
+import { createTag, getConfig, loadLink, loadScript, localizeLink, updateConfig } from '../../utils/utils.js';
 import { ENTITLEMENT_MAP } from './entitlements.js';
 
 /* c20 ignore start */
@@ -112,7 +112,7 @@ const createFrag = (el, url, manifestId) => {
   if (isSection) {
     frag = createTag('div', undefined, frag);
   }
-  loadLink(`${href}.plain.html`, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
+  loadLink(`${localizeLink(a.href)}.plain.html`, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
   return frag;
 };
 

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
 
-import { createTag, getConfig, loadLink, loadScript, localizeLink, updateConfig } from '../../utils/utils.js';
+import {
+  createTag, getConfig, loadLink, loadScript, localizeLink, updateConfig,
+} from '../../utils/utils.js';
 import { ENTITLEMENT_MAP } from './entitlements.js';
 
 /* c20 ignore start */


### PR DESCRIPTION
The personalization fragment preload was not localizing links, therefore loading the us/en page for localized pages.

Resolves: [MWPW-142058](https://jira.corp.adobe.com/browse/MWPW-142058)

Before url will load `emea-cct-arobat-q1-promo-footnote` twice - first is the us/en fragment, 2nd is the africa fragment.
After url will only load the africa fragment.

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.page/africa/homepage/index-loggedout
- After: https://main--homepage--adobecom.hlx.page/africa/homepage/index-loggedout?milolibs=locfragmentpreload