### PR TITLE
[MWPW-141779] Make sure Jarvis chat gets loaded regardless of alloy response / errors

### DIFF
--- a/libs/features/jarvis-chat.js
+++ b/libs/features/jarvis-chat.js
@@ -230,7 +230,7 @@ const startInitialization = async (config, event) => {
     cookiesEnabled: window.adobePrivacy?.activeCookieGroups()?.length > 1,
     cookies: {
       mcid: window.alloy ? await window.alloy('getIdentity')
-        .then((data) => data?.identity?.ECID) : undefined,
+        .then((data) => data?.identity?.ECID).catch(() => undefined) : undefined,
     },
     callbacks: {
       initCallback: (data) => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Problem: Alloy might throw errors if an incorrect configuration is being used. This will block Jarvis chat to load, since it has a dependency on the user information.
Fix: Handle alloy errors and initialise Jarvis regardless of the response.

Resolves: [MWPW-141779](https://jira.corp.adobe.com/browse/MWPW-141779)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/narcis/default?martech=off
- After: https://jarvis-fix--milo--narcis-radu.hlx.page/drafts/narcis/default?martech=off
