### PR TITLE
MWPW-142072 | Making full width brick foreground image have full height

### DIFF
--- a/libs/blocks/brick/brick.css
+++ b/libs/blocks/brick/brick.css
@@ -345,12 +345,6 @@
     margin: 0;
   }
 
-  .brick.grid-full-width.split.row .foreground .brick-media img,
-  .brick.grid-full-width.split.row .foreground .brick-media video {
-    height: calc(100% - 2 * var(--spacing-l));
-    padding: var(--spacing-l) 0;
-  }
-
   .brick.stack .foreground .brick-media picture {
     display: flex;
     margin: 0;


### PR DESCRIPTION
Full width 12 column grid currently has foreground image that takes L spacing from top and bottom. As per the latest requirement updating the brick foreground image to have 100% height like other bricks without L spacing.

Resolves: [MWPW-142072](https://jira.corp.adobe.com/browse/MWPW-142072)

**Test URLs:**
- Before: https://main--milo--aishwaryamathuria.hlx.page/drafts/mathuria/masonry/poc/poc-7?martech=off
- After: https://mwpw-142072--milo--aishwaryamathuria.hlx.page/drafts/mathuria/masonry/poc/poc-7?martech=off
