### PR TITLE
MWPW-140884| Increase z index of sticky bottom section

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -163,7 +163,7 @@
 .section.sticky-bottom {
   position: sticky;
   bottom: 0;
-  z-index: 1;
+  z-index: 3;
   background-color: var(--color-white);
 }
 


### PR DESCRIPTION
Z index of sticky bottom section is lesser that carousel buttons and tabList causing an overlap of page content on sticky bottom component on scroll.
Increasing the z-index of sticky bottom to avoid the overlap.

Resolves: [MWPW-140884](https://jira.corp.adobe.com/browse/MWPW-140884)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/venkatas/testpages/aside-notification?martech=off
- After: https://mwpw-140884--milo--aishwaryamathuria.hlx.page/drafts/venkatas/testpages/aside-notification?martech=off
