### PR TITLE
MWPW-142089 - Quiz background markup cleanup

### DIFF
--- a/libs/blocks/quiz/quiz.css
+++ b/libs/blocks/quiz/quiz.css
@@ -17,11 +17,12 @@
   flex-direction: column;
 }
 
-.quiz-background picture {
+.quiz-background {
   display: block;
   inset: 0;
   line-height: 0;
   position: absolute;
+  z-index: -1;
 }
 
 .quiz-background img {

--- a/libs/blocks/quiz/quizcontainer.js
+++ b/libs/blocks/quiz/quizcontainer.js
@@ -1,11 +1,6 @@
 import { html } from '../../deps/htm-preact.js';
 
-export const DecorateBlockBackgroundCmp = ({ background = '' }) => html`<picture>
-        <source type="image/webp" srcset=${background} media="(min-width: 400px)" />
-        <source type="image/png" srcset=${background}  media="(min-width: 400px)" />
-        <source type="image/webp" srcset=${background} />
-        <img loading="eager" alt="" type="image/png" src=${background}  width="750" height="375" />
-      </picture>`;
+export const DecorateBlockBackgroundCmp = ({ background = '' }) => html`<img loading="eager" alt="" src=${background} height="1020" width="1920" />`;
 
 export const DecorateBlockForeground = ({ heading, subhead }) => html`<div class="quiz-foreground">
     <h1 class="quiz-question-title" daa-lh="${heading}">${heading}</h1>


### PR DESCRIPTION
* simplified background image markup
* minor css adjustments to maintain the current display

Resolves: [MWPW-142089](https://jira.corp.adobe.com/browse/MWPW-142089)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/colloyd/quiz/?martech=off
- After: https://mwpw-142089-quiz-bg-markup--milo--colloyd.hlx.page/drafts/colloyd/quiz/?martech=off

Testing notes:
- inspect .quiz-background in the dev tools
- in the "before" page, notice the extraneous markup including picture with source and img
- in the "after" page, notice the simplified img tag only.