### PR TITLE
MWPW-141691: Footer rows of merch-cards in fragments

### DIFF
--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -112,8 +112,9 @@ const MULTI_OFFER_CARDS = ['plans', 'product', MINI_COMPARE_CHART];
 const sectionObserver = new MutationObserver((mutations) => {
   mutations.forEach((mutation) => {
     if (mutation.type === 'attributes' && mutation.attributeName === 'data-status') {
-      sectionObserver.disconnect(mutation.target);
-      [...mutation.target.querySelectorAll('merch-card')].forEach((card) => card.requestUpdate());
+      const container = mutation.target.closest('main > div');
+      if (!container) return;
+      [...container.querySelectorAll('merch-card')].forEach((card) => card.requestUpdate());
     }
   });
 });

--- a/test/blocks/merch-card/mocks/mini-compare-chart.html
+++ b/test/blocks/merch-card/mocks/mini-compare-chart.html
@@ -1,3 +1,4 @@
+<main>
 <div class="section" data-status="decorated">
   <div class="merch-card mini-compare-chart">
     <div>
@@ -79,3 +80,4 @@
     </div>
   </div>
 </div>
+</main>


### PR DESCRIPTION
Resolves: [MWPW-141691](https://jira.corp.adobe.com/browse/MWPW-141691)

This PR supports merch cards in fragments.

![image](https://github.com/adobecom/milo/assets/330057/c648c55c-8b31-4cd4-885a-6fc4695f0c6c)


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/axel/mini-compare-chart?martech=off
- After: https://mwpw-141691-2--milo--yesil.hlx.page/drafts/axel/mini-compare-chart?martech=off

**CC**
https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/illustrator/mini-compare/segment-blade?milolibs=mwpw-141691-2--milo--yesil
