### PR TITLE
improve redirect message for edit manifest button in sidekick

### DIFF
--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -113,7 +113,11 @@ function addPillEventListeners(div) {
     a.addEventListener('click', () => {
       if (a.getAttribute('href')) return false;
       const w = window.open('', '_blank');
-      w.document.write('<html><head></head><body>Please wait while we redirect you</body></html>');
+      w.document.write(`<html><head></head><body>
+        Please wait while we redirect you. 
+        If you are not redirected, please check that you are signed into the AEM sidekick
+        and try again.
+        </body></html>`);
       w.document.close();
       w.focus();
       getEditManifestUrl(a, w);


### PR DESCRIPTION
Using the edit manifest button only works when you are signed into the sidekick.  Updating message for better feedback.

To test, go to the test urls while signed out of the sidekick, open the MEP preview button panel, then click the pencil icon next to the test name.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/autoselectorubc/?martech=off
- After: https://autoselectorubc--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/autoselectorubc/?martech=off
