### PR TITLE
MWPW-142399-Fix for TwP modal not displaying in tablet viewports or smaller on Safari

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -27,7 +27,7 @@
 
 .dialog-modal.commerce-frame .fragment,
 .dialog-modal.commerce-frame .section {
-  height: 100%;
+  height: 100vh;
 }
 
 .modal-curtain.is-open {


### PR DESCRIPTION
Twp Modal not displaying in tablet viewports or smaller on Safari.
This is a relatively well know limitation of Safari, we should use `100vh` instead of `100%`

Resolves: [MWPW-142399](https://jira.corp.adobe.com/browse/MWPW-142399)

Test URLs:
https://mwpw-142399--milo--adobecom.hlx.page/

**Home Page**
Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off&#mini-plans-web-cta-photoshop-card
After: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off&milolibs=mwpw-142399#mini-plans-web-cta-photoshop-card
**CC**
Before: https://main--cc--adobecom.hlx.live/creativecloud/animation/discover?martech=off#animate
After: https://main--cc--adobecom.hlx.live/creativecloud/animation/discover?martech=off&milolibs=mwpw-142399#animate