### PR TITLE
MWPW-142499-Fix link farm text block failing to load when no heading is added

### DIFF
--- a/libs/blocks/text/text.js
+++ b/libs/blocks/text/text.js
@@ -57,7 +57,7 @@ function decorateLinkFarms(el) {
   loadStyle(`${miloLibs || codeRoot}/blocks/text/link-farms.css`);
   const [title, foregroundDiv] = [...el.querySelectorAll('.foreground')];
   const hCount = foregroundDiv.querySelectorAll('h1, h2, h3, h4, h5, h6').length;
-  title.querySelector('h1, h2, h3, h4, h5, h6').classList.add('heading-l');
+  title.querySelector('h1, h2, h3, h4, h5, h6')?.classList.add('heading-l');
   foregroundDiv.querySelectorAll('p').forEach((p) => p.classList.add('body-s'));
   foregroundDiv.querySelectorAll('div').forEach((divElem, index) => {
     const heading = divElem.querySelector('h1, h2, h3, h4, h5, h6');


### PR DESCRIPTION
* Fix link farm text block failing to load when no heading is added


Resolves: [MWPW-142499](https://jira.corp.adobe.com/browse/MWPW-142499)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/link-farm?martech=off
- After: https://link-farm--milo--ruchika4.hlx.page/drafts/ruchika/link-farm?martech=off

CC:
- Before: https://main--cc--adobecom.hlx.page/creativecloud/file-types/image/comparison?martech=off
- After: https://main--cc--adobecom.hlx.page/creativecloud/file-types/image/comparison?milolibs=link-farm--milo--ruchika4&martech=off

Note: Issue was identified on production page

