### PR TITLE
MWPW-135731 support linked text CTA with #_tcl attribute

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -185,9 +185,13 @@ export async function buildCta(el, params) {
   const service = await initService();
   const text = el.textContent?.replace(/^CTA +/, '');
   const cta = service.createCheckoutLink(context, text);
-  cta.classList.add('con-button');
-  cta.classList.toggle('button-l', large);
-  cta.classList.toggle('blue', strong);
+  if (el.href.includes('#_tcl')) {
+    el.href = el.href.replace('#_tcl', '');
+  } else {
+    cta.classList.add('con-button');
+    cta.classList.toggle('button-l', large);
+    cta.classList.toggle('blue', strong);
+  }
   if (context.entitlement !== 'false') {
     cta.classList.add(LOADING_ENTITLEMENTS);
     cta.onceSettled().finally(() => cta.classList.remove(LOADING_ENTITLEMENTS));

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -354,6 +354,20 @@ describe('Merch Block', () => {
       });
     });
 
+    it('should not add button classes to cta if href includes "#_tcl"', async () => {
+      const el = await merch(document.querySelector(
+        '.merch.text.link',
+      ));
+      const { href, textContent } = await el.onceSettled();
+      console.log('href', href);
+      expect(href.includes('#_tcl')).to.be.false;
+      expect(textContent).to.equal('40% off');
+      expect(el.getAttribute('is')).to.equal('checkout-link');
+      expect(el.classList.contains('con-button')).to.be.false;
+      expect(el.classList.contains('button-l')).to.be.false;
+      expect(el.classList.contains('blue')).to.be.false;
+    });
+
     it('renders large CTA inside a marquee', async () => {
       const el = await merch(document.querySelector(
         '.merch.cta.inside-marquee',

--- a/test/blocks/merch/mocks/body.html
+++ b/test/blocks/merch/mocks/body.html
@@ -105,6 +105,10 @@
 <p>All Apps CTA with Switch Modal (Upgrade Flow): <a class="merch cta upgrade-source"
   href="/tools/ost?osi=32&type=checkoutUrl">CTA Buy Now</a>
 </p>
+  <p>CTA with blue background: <a class="merch text  link"
+  href="/tools/ost?osi=20&type=checkoutUrl#_tcl"><strong>40% off</strong></a>
+  </p>
+
 
 <div data-promotion-code="nicopromo" class="fragment">
   <h2>Promo prices inside a fragment</h2>


### PR DESCRIPTION
This PR introduced changes to support CTA text links. 

The condition was added to check if the href of the cta element includes #_tcl. 

Resolves: [MWPW-135731](https://jira.corp.adobe.com/browse/MWPW-135731)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/vkniaziev/textlinks??martech=off
- After: https://mwpw-135731--milo--vkniaz.hlx.page/drafts/vkniaziev/textlinks?martech=off
