### PR TITLE
Correctly decorate SVGs in central navs

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -312,7 +312,7 @@ export async function fetchAndProcessPlainHtml({ url, shouldDecorateLinks = true
   if (shouldDecorateLinks) decorateLinks(body);
 
   if (path.includes('/federal/')) federatePictureSources(body);
-  
+
   const blocks = body.querySelectorAll('.martech-metadata');
   if (blocks.length) {
     import('../../martech-metadata/martech-metadata.js')

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -309,10 +309,10 @@ export async function fetchAndProcessPlainHtml({ url, shouldDecorateLinks = true
     await Promise.all(fragPromises);
   }
 
-  if (path.includes('/federal/')) federatePictureSources(body);
-
   if (shouldDecorateLinks) decorateLinks(body);
 
+  if (path.includes('/federal/')) federatePictureSources(body);
+  
   const blocks = body.querySelectorAll('.martech-metadata');
   if (blocks.length) {
     import('../../martech-metadata/martech-metadata.js')


### PR DESCRIPTION
## Description
Decorate links decorates anchor tags and turns them into images if applicable.
After we have images, we have a method that checks if an image should come from a federal source and not a relative path. 

## Related Issue
Resolves: [MWPW-142610](https://jira.corp.adobe.com/browse/MWPW-142610)

## Testing instructions
The adobe logo on the left side of the gnav should be showing up on centralized navigations, when including as a link to a centralized image/svg


## Test URLs
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=mwpw-142610-svgs--milo--mokimo

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=mwpw-142610-svgs--milo--mokimo

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=mwpw-142610-svgs--milo--mokimo

**Homepage:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=mwpw-142610-svgs--milo--mokimo

**Blog:**
- Before: https://main--blog--adobecom.hlx.page/
- After: https://main--blog--adobecom.hlx.page/?milolibs=mwpw-142610-svgs--milo--mokimo

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/prs/mwpw-142610-svgs
- After: https://mwpw-142610-svgs--milo--mokimo.hlx.page/drafts/osahin/prs/mwpw-142610-svgs
