### PR TITLE
Mwpw 142003: Mini compare chart edge case scenario

### DIFF
--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -111,12 +111,10 @@ const MULTI_OFFER_CARDS = ['plans', 'product', MINI_COMPARE_CHART];
 // Force cards to refresh once they become visible so that the footer rows are properly aligned.
 const intersectionObserver = new IntersectionObserver((entries) => {
   entries.forEach((entry) => {
-    if (entry.isIntersecting) {
-      const container = entry.target.closest('main > div');
-      if (!container) return;
-      [...container.querySelectorAll('merch-card')].forEach((card) => card.requestUpdate());
-      intersectionObserver.unobserve(entry.target);
-    }
+    const container = entry.target.closest('main > div');
+    if (!container) return;
+    [...container.querySelectorAll('merch-card')].forEach((card) => card.requestUpdate());
+    intersectionObserver.unobserve(entry.target);
   });
 });
 


### PR DESCRIPTION
Fixes scenario where mini compare chart cards are inside individual fragments and container inside tabs. This causes the intersection observer to not trigger at all since the cards are not yet loaded in the DOM. This fixes forces the intersection observer to resize even thought the cards are not intersecting yet.

Resolves: [MWPW-142003](https://jira.corp.adobe.com/browse/MWPW-142003)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/illustrator/mini-compare/segment-blade?martech=off
- After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/illustrator/mini-compare/segment-blade?milolibs=MWPW-142003--milo--axelcureno?martech=off
