### PR TITLE
MWPW-142786: skip Download flow if url is empty

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -122,7 +122,7 @@ export async function getDownloadAction(options, imsSignedInPromise, offerFamily
   const entitlements = await fetchEntitlements();
   if (!entitlements?.length) return undefined;
   const checkoutLinkConfig = await getCheckoutLinkConfig(offerFamily);
-  if (!checkoutLinkConfig) return undefined;
+  if (!checkoutLinkConfig?.DOWNLOAD_URL) return undefined;
   const offer = entitlements.find((
     { offer: { product_arrangement: { family: subscriptionFamily } } },
   ) => {
@@ -165,7 +165,7 @@ export async function getUpgradeAction(options, imsSignedInPromise, productFamil
   return undefined;
 }
 
-async function openModalExternalModal(url, getModal, offerType) {
+async function openExternalModal(url, getModal, offerType) {
   const iframe = createTag('iframe', {
     src: url,
     frameborder: '0',
@@ -187,7 +187,7 @@ export async function openModal(e, url, offerType) {
   e.preventDefault();
   const { getModal } = await import('../modal/modal.js');
   if (/^https?:/.test(url)) {
-    openModalExternalModal(url, getModal, offerType);
+    openExternalModal(url, getModal, offerType);
   }
 }
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -467,8 +467,16 @@ describe('Merch Block', () => {
       expect(checkoutLinkConfig).to.be.undefined;
     });
 
-    it('getDownloadAction: returns undefined', async () => {
+    it('getDownloadAction: returns undefined if not entitled', async () => {
       const checkoutLinkConfig = await getDownloadAction({ entitlement: true }, Promise.resolve(true), 'ILLUSTRATOR');
+      expect(checkoutLinkConfig).to.be.undefined;
+    });
+
+    it('getDownloadAction: returns undefined if download URL is empty', async () => {
+      const [photoshopConfig] = CHECKOUT_LINK_CONFIGS.data;
+      photoshopConfig.DOWNLOAD_URL = '';
+      setCheckoutLinkConfigs(CHECKOUT_LINK_CONFIGS);
+      const checkoutLinkConfig = await getDownloadAction({ entitlement: true }, Promise.resolve(true), 'PHOTOSHOP');
       expect(checkoutLinkConfig).to.be.undefined;
     });
 


### PR DESCRIPTION
Resolves: [MWPW-142786](https://jira.corp.adobe.com/browse/MWPW-142786)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ilyas/checkout-links?martech=off&georouting=off
- After: https://mwpw-142786--milo--yesil.hlx.page/drafts/ilyas/checkout-links?martech=off&georouting=off

**CC Test URLs (with IMS)**:
https://main--cc--adobecom.hlx.page/drafts/ilyas/checkout-links?milolibs=mwpw-142786--milo--yesil
