### PR TITLE
Verify that target content has manifest info

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -55,7 +55,7 @@ const handleAlloyResponse = (response) => {
   return items
     .map((item) => {
       const content = item?.data?.content;
-      if (!content) return null;
+      if (!content || !(content.manifestLocation || content.manifestContent)) return null;
 
       return {
         manifestPath: content.manifestLocation || content.manifestPath,


### PR DESCRIPTION
Some of the target data is unrelated to manifests, this makes sure we don't try to use that data.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://verifytargetmanifest--milo--adobecom.hlx.page/?martech=off
