### PR TITLE
MWPW-142630 - [Marquee] media CLS

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -8,7 +8,10 @@
   min-height: 560px;
 }
 
-.marquee.small, .marquee.quiet, .marquee.inline, .marquee.large.compact {
+.marquee.small,
+.marquee.quiet,
+.marquee.inline,
+.marquee.large.compact {
   min-height: 360px;
 }
 
@@ -17,7 +20,10 @@
   margin-bottom: 0;
 }
 
-.marquee.light, .marquee.mobile-light, .marquee.quiet:not(.dark), .marquee.inline {
+.marquee.light,
+.marquee.mobile-light,
+.marquee.quiet:not(.dark),
+.marquee.inline {
   color: var(--text-color);
 }
 
@@ -82,14 +88,14 @@
   align-items: stretch;
 }
 
-.marquee .media {
+.marquee .asset {
   order: 1;
   width: 100%;
   margin: 0 auto;
 }
 
-.marquee .media img,
-.marquee .media video {
+.marquee .asset img,
+.marquee .asset video {
   display: block;
   width: 100%;
   height: auto;
@@ -166,7 +172,7 @@
   order: 1;
 }
 
-.marquee.small .media {
+.marquee.small .asset {
   order: 2;
 }
 
@@ -226,19 +232,18 @@
   justify-content: center;
 }
 
-/* Split */
 .marquee.split {
   flex-direction: column;
 }
 
-.marquee.split .media {
+.marquee.split .asset {
   order: 0;
   width: 100%;
   margin: 0;
 }
 
-.marquee.split .media img,
-.marquee.split .media video {
+.marquee.split .asset img,
+.marquee.split .asset video {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -254,7 +259,7 @@
   order: 1;
 }
 
-.marquee.split.small .media {
+.marquee.split.small .asset {
   order: 2;
 }
 
@@ -375,7 +380,7 @@
   .marquee.quiet.large .foreground .text {
     max-width: 800px;
   }
-  
+
   .marquee.tablet-light a:not(.con-button) {
     color: var(--link-color);
   }
@@ -412,11 +417,10 @@
     text-decoration: none;
   }
 
-  .marquee .media {
-    width: var(--grid-container-width); /* 10 grid / 83% */
+  .marquee .asset {
+    width: var(--grid-container-width);
   }
 
-  /* Split */
   .marquee.split {
     display: flex;
     justify-content: center;
@@ -427,29 +431,29 @@
     flex-direction: row;
     padding: var(--spacing-xl) 0;
   }
-  
+
   .marquee.split .foreground.container .text {
     max-width: calc(50% - var(--grid-column-width));
   }
 
-  .marquee.split .media.bleed {
+  .marquee.split .asset.bleed {
     position: absolute;
     width: 50vw;
     right: 0;
     height: 100%;
   }
-  
-  .marquee.split.row-reversed .media.bleed {
+
+  .marquee.split.row-reversed .asset.bleed {
     right: auto;
     left: 0;
   }
 
-  html[dir="rtl"] .marquee.split .media.bleed {
+  html[dir="rtl"] .marquee.split .asset.bleed {
     left: 0;
     right: auto;
   }
 
-  html[dir="rtl"] .marquee.split.row-reversed .media.bleed {
+  html[dir="rtl"] .marquee.split.row-reversed .asset.bleed {
     right: 0;
     left: auto;
   }
@@ -468,17 +472,17 @@
     justify-content: flex-end;
   }
 
-  .marquee.split .media img,
-  .marquee.split.small .media img,
-  .marquee.split.large .media img,
-  .marquee.split .media video,
-  .marquee.split.small .media video,
-  .marquee.split.large .media video{
+  .marquee.split .asset img,
+  .marquee.split.small .asset img,
+  .marquee.split.large .asset img,
+  .marquee.split .asset video,
+  .marquee.split.small .asset video,
+  .marquee.split.large .asset video {
     max-height: initial;
   }
-  
-  .marquee.split .media.bleed picture,
-  .marquee.split .media.bleed video {
+
+  .marquee.split .asset.bleed picture,
+  .marquee.split .asset.bleed video {
     height: 100%;
     object-fit: fill;
   }
@@ -527,7 +531,7 @@
   .marquee.desktop-light a:not(.con-button) {
     color: var(--link-color);
   }
-  
+
   .marquee.desktop-dark a:not(.con-button),
   .marquee.desktop-dark a:not(.con-button):hover {
     color: var(--link-color-dark);
@@ -563,7 +567,7 @@
   .marquee.desktop-dark {
     color: var(--color-white);
   }
-  
+
   .marquee .foreground {
     flex-direction: row;
     align-items: center;
@@ -592,9 +596,9 @@
     order: unset;
   }
 
-  .marquee .media,
-  .marquee.small .media,
-  .marquee.large .media {
+  .marquee .asset,
+  .marquee.small .asset,
+  .marquee.large .asset {
     order: unset;
   }
 
@@ -602,7 +606,7 @@
     max-width: 500px;
   }
 
-  .marquee .foreground .media {
+  .marquee .foreground .asset {
     max-width: 600px;
   }
 
@@ -613,8 +617,8 @@
     justify-content: center;
   }
 
-  .marquee .media img,
-  .marquee .media video {
+  .marquee .asset img,
+  .marquee .asset video {
     width: 100%;
     max-width: initial;
     min-height: 150px;
@@ -641,7 +645,6 @@
     min-height: 700px;
     display: flex;
   }
-
 
   .marquee.large .background img {
     max-height: unset;
@@ -682,14 +685,14 @@
     justify-content: flex-end;
   }
 
-  .marquee.split.one-third .media.bleed {
+  .marquee.split.one-third .asset.bleed {
     position: absolute;
     width: calc(var(--grid-container-width) * 0.6667 + (100vw - var(--grid-container-width)) / 2);
     right: 0;
     height: 100%;
   }
 
-  html[dir="rtl"] .marquee.split.one-third:not(.row-reversed) .media.bleed {
+  html[dir="rtl"] .marquee.split.one-third:not(.row-reversed) .asset.bleed {
     left: 0;
     right: auto;
   }
@@ -725,4 +728,3 @@
 .static-links .marquee a:not(.con-button):hover {
   color: inherit;
 }
-

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -94,12 +94,12 @@ export default async function init(el) {
   const media = foreground.querySelector(':scope > div:not([class])');
 
   if (media) {
-    media.classList.add('media');
+    media.classList.add('asset');
     if (!media.querySelector('video, a[href*=".mp4"]')) decorateImage(media);
   }
 
   const firstDivInForeground = foreground.querySelector(':scope > div');
-  if (firstDivInForeground?.classList.contains('media')) el.classList.add('row-reversed');
+  if (firstDivInForeground?.classList.contains('asset')) el.classList.add('row-reversed');
 
   const size = getBlockSize(el);
   decorateButtons(text, size === 'large' ? 'button-xl' : 'button-l');


### PR DESCRIPTION
Pages with both Marquee and Media blocks now have cls scores due to the media.css .media padding style being applied to .marquee .media. This PR updates the Marquee's .media classname to instead be .asset to avoid future collisions.

Re-issuing CLS fix sans the style lint error updates that were reverted in this [PR](https://github.com/adobecom/milo/pull/1867)

Resolves: [MWPW-142630](https://jira.corp.adobe.com/browse/MWPW-142630)

**MILO**
Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/marquee-cls?martech=off
After: https://sarchibeque-mwpw-142630-marquee-cls--milo--adobecom.hlx.page/drafts/sarchibeque/marquee-cls?martech=off

**BACOM**
Before: https://main--bacom--adobecom.hlx.page/products/experience-manager/adobe-experience-manager?martech=off
After: https://main--bacom--adobecom.hlx.page/products/experience-manager/adobe-experience-manager?milolibs=sarchibeque-MWPW-142630-marquee-cls&martech=off

![before-after](https://github.com/adobecom/milo/assets/10670990/231d4308-9cba-4dd1-8761-d9f679b157d3)