### PR TITLE
Mwpw 141873

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -131,6 +131,16 @@
   flex-wrap: wrap;
 }
 
+.table.header-left .row-heading .col.col-heading {
+  text-align: start;
+  padding: var(--spacing-s);
+}
+
+
+.table.header-left .row-heading .col.col-heading .buttons-wrapper {
+  justify-content: flex-start;
+}
+
 .table.button-right.merch .row-heading .col.col-heading .buttons-wrapper {
   justify-content: flex-end;
 }
@@ -143,6 +153,14 @@
   margin: 12px 6px;
 }
 
+.table.header-left .row-heading .col.col-heading .buttons-wrapper > * {
+  margin-left: 0;
+}
+
+[dir='rtl'] .table.header-left .row-heading .col.col-heading .buttons-wrapper > * {
+  margin-right: 0;
+}
+
 .table .row-heading .col-heading.top-left-rounded {
   border-top-left-radius: 16px;
 }
@@ -153,6 +171,16 @@
 
 .table .row-heading .col-1.col-heading:not(.no-rounded) {
   border-top-left-radius: 16px;
+}
+
+.table .row-heading .col-heading .header-product-tile {
+  display: inline-flex;
+  gap: var(--spacing-xxs);
+}
+
+.table .row-heading .col-heading .header-product-tile picture {
+  display: flex;
+  margin: 0;
 }
 
 .table .row-heading .col-heading .tracking-header {

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -146,10 +146,11 @@ function handleTitleText(cell) {
   const textSpan = createTag('span', { class: 'table-title-text' });
   while (cell.firstChild) textSpan.append(cell.firstChild);
   cell.append(textSpan);
-  const iconTag = textSpan.querySelector('.icon');
-  if (iconTag) {
-    cell.append(iconTag);
-  }
+  const iconTooltip = textSpan.querySelector('.icon-tooltip, .milo-tooltip');
+  if (!iconTooltip) return;
+  const tooltipEm = iconTooltip.closest('em');
+  if (tooltipEm) cell.append(tooltipEm);
+  else cell.append(iconTooltip);
 }
 
 function handleSection(sectionParams) {

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -143,10 +143,11 @@ function handleExpand(e) {
  */
 
 function handleTitleText(cell) {
+  if (cell.querySelector('.table-title-text')) return;
   const textSpan = createTag('span', { class: 'table-title-text' });
   while (cell.firstChild) textSpan.append(cell.firstChild);
   cell.append(textSpan);
-  const iconTooltip = textSpan.querySelector('.icon-tooltip, .milo-tooltip');
+  const iconTooltip = textSpan.querySelector('.icon-info, .icon-tooltip, .milo-tooltip');
   if (!iconTooltip) return;
   cell.append(iconTooltip.closest('em') || iconTooltip);
 }

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -17,7 +17,7 @@ function defineDeviceByScreenSize() {
   return 'TABLET';
 }
 
-function handleHeading(headingCols, isPriceBottom) {
+function handleHeading(headingCols, isPriceBottom, isMerch) {
   headingCols.forEach((col, i) => {
     col.classList.add('col-heading');
     if (!col.innerHTML) {
@@ -34,8 +34,10 @@ function handleHeading(headingCols, isPriceBottom) {
       col.innerHTML = `<p class="tracking-header">${col.innerHTML}</p>`;
     } else {
       let textStartIndex = 0;
-      if (elements[0]?.querySelector('img')) {
+      const iconTile = elements[0]?.querySelector('img');
+      if (iconTile) {
         textStartIndex += 1;
+        if (!isMerch) iconTile.closest('p').classList.add('header-product-tile');
       }
       elements[textStartIndex]?.classList.add('tracking-header');
       const pricingElem = elements[textStartIndex + 1];
@@ -85,6 +87,7 @@ function handleHighlight(table) {
   const secondRow = table.querySelector('.row-2');
   const secondRowCols = secondRow.querySelectorAll('.col');
   const isPriceBottom = table.classList.contains('pricing-bottom');
+  const isMerch = table.classList.contains('merch');
   let headingCols = null;
 
   if (isHighlightTable) {
@@ -113,7 +116,7 @@ function handleHighlight(table) {
     firstRow.classList.add('row-heading');
   }
 
-  handleHeading(headingCols, isPriceBottom);
+  handleHeading(headingCols, isPriceBottom, isMerch);
   table.dispatchEvent(tableHighlightLoadedEvent);
 }
 
@@ -138,6 +141,17 @@ function handleExpand(e) {
  * @param {*} sectionParams that is from init()
  * @returns {boolean expandSection} that is the only variable get updated from sectionParams
  */
+
+function handleTitleText(cell) {
+  const textSpan = createTag('span', { class: 'table-title-text' });
+  while (cell.firstChild) textSpan.append(cell.firstChild);
+  cell.append(textSpan);
+  const iconTag = textSpan.querySelector('.icon');
+  if (iconTag) {
+    cell.append(iconTag);
+  }
+}
+
 function handleSection(sectionParams) {
   const {
     row, index, allRows, rowCols, isMerch, isCollapseTable, isHighlightTable,
@@ -160,6 +174,7 @@ function handleSection(sectionParams) {
         merchCol.setAttribute('role', 'rowheader');
       });
     } else {
+      handleTitleText(sectionHeadTitle);
       sectionHeadTitle.classList.add('section-head-title');
       sectionHeadTitle.setAttribute('role', 'rowheader');
     }
@@ -210,6 +225,7 @@ function handleSection(sectionParams) {
       });
     } else {
       const sectionRowTitle = rowCols[0];
+      handleTitleText(sectionRowTitle);
       sectionRowTitle.classList.add('section-row-title');
     }
   }

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -148,9 +148,7 @@ function handleTitleText(cell) {
   cell.append(textSpan);
   const iconTooltip = textSpan.querySelector('.icon-tooltip, .milo-tooltip');
   if (!iconTooltip) return;
-  const tooltipEm = iconTooltip.closest('em');
-  if (tooltipEm) cell.append(tooltipEm);
-  else cell.append(iconTooltip);
+  cell.append(iconTooltip.closest('em') || iconTooltip);
 }
 
 function handleSection(sectionParams) {

--- a/test/blocks/table/mocks/body.html
+++ b/test/blocks/table/mocks/body.html
@@ -47,14 +47,14 @@
       <div data-align="center"></div>
     </div>
     <div>
-      <div>Right<span class="icon icon-info"></span></div>
+      <div class="tooltip-heading">Right <strong>bold</strong> and <a href="#">Link</a><span class="icon icon-tooltip"></span></div>
       <div data-align="center"><span class="icon icon-checkmark"></span></div>
       <div></div>
       <div data-align="center"><span class="icon icon-checkmark"></span></div>
       <div data-align="center"></div>
     </div>
     <div>
-      <div>Sign agreements</div>
+      <div class="multi-content-heading">Sign agreements <strong>bold</strong> and <a href="#">Link</a></div>
       <div data-align="center"></div>
       <div data-align="center"><span class="icon icon-checkmark"></span></div>
       <div></div>

--- a/test/blocks/table/table.test.js
+++ b/test/blocks/table/table.test.js
@@ -96,5 +96,16 @@ describe('table and tablemetadata', () => {
       const col5 = await waitForElement('.table .col-5');
       expect(col5).to.be.exist;
     });
+
+    it('supports multi content section headings', () => {
+      const multiContentHeading = document.querySelector('.multi-content-heading');
+      expect(multiContentHeading.childNodes.length).to.equal(1);
+    });
+
+    it('supports tooltip', () => {
+      const tooltipHeading = document.querySelector('.tooltip-heading');
+      expect(tooltipHeading.childNodes.length).to.equal(2);
+      expect(tooltipHeading.querySelector('.milo-tooltip, .icon-tooltip')).to.exist;
+    });
   });
 });


### PR DESCRIPTION
Adding following new updates to the Milo table (table, highlight, collapse, sticky) block -
- Add the option to allow bold text and a static text link within in the same line of copy.
- Icon area with Max 2 product tiles 
- Add a tool tip feature to each section row. 
- Add option to have header content aligned left
Added the details around the implemented solution in the [WIKI](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=WEBT&title=MWPW-141873+-+Table+block+Updates)

Resolves: [MWPW-141873](https://jira.corp.adobe.com/browse/MWPW-141873)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/mathuria/table/table-sample?martech=off
- After: https://mwpw-141873--milo--aishwaryamathuria.hlx.page/drafts/mathuria/table/table-sample?martech=off
