### PR TITLE
MWPW-143183: CaaS Marquee Performance Improvements

### DIFF
--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -79,7 +79,7 @@ function log(...args) {
 }
 
 const REQUEST_TIMEOUT = isProd() ? 1500 : 10000;
-const SEGMENT_API_TIMEOUT = 2500;
+const SEGMENT_API_TIMEOUT = 1000;
 
 const TEXT = {
   small: 'm',

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -1,8 +1,6 @@
 /* eslint-disable no-shadow */
 import { createTag, getConfig, loadMartech } from '../../utils/utils.js';
 
-performance.mark('caas-marquee-js');
-
 const SEGMENTS_MAP = {
   stage: {
     '5a5fd14e-f4ca-49d2-9f87-835df5477e3c': 'PHSP',
@@ -26,6 +24,8 @@ const SEGMENTS_MAP = {
     '934fdc1d-7ba6-4644-908b-53e01e550086': 'DC Paid Active entitlements',
   },
 };
+
+const ALLOY_TIMEOUT = 500;
 
 const WIDTHS = {
   split: 1199,
@@ -87,7 +87,7 @@ function parseCtas(el) {
   }
   return ctas;
 }
-function getMetadata(el){
+function getMetadata(el) {
   let metadata = {};
   for (const row of el.children) {
     const key = row.children[0].textContent.trim().toLowerCase() || '';
@@ -113,7 +113,6 @@ function isProd() {
   const { host } = window.location;
   return !(host.includes('hlx.page')
     || host.includes('localhost')
-    || host.includes('hlx.live')
     || host.includes('stage.adobe')
     || host.includes('corp.adobe'));
 }
@@ -194,6 +193,7 @@ async function segmentApiEventHandler(e) {
       renderMarquee(marquee, marquees, selectedId, metadata);
     }
   }
+  // eslint-disable-next-line no-use-before-define
   loadFallback(marquee, metadata);
 }
 
@@ -406,9 +406,9 @@ function getFgContent(metadata, size, cta, cta2) {
     <h1 class="heading-${HEADING[size]}">${metadata.title}</h1>
     <p class="body-${TEXT[size]}">${metadata.description}</p>
     <p class="action-area">
-      ${cta}
+      ${cta} 
       ${cta2}
-      </p>
+      </p> 
   </div>`;
 }
 
@@ -482,7 +482,6 @@ export function renderMarquee(marquee, marquees, id, fallback) {
   applyVariants(marquee, metadata, classList);
   addAnalytics(marquee);
   marquee.append(background, foreground);
-  console.log(performance.measure('caas-marquee-js'));
 }
 
 function loadFallback(marquee, metadata) {
@@ -524,7 +523,7 @@ export default async function init(el) {
   const marqueesPromise = getAllMarquees(promoId, origin);
   await Promise.all([martechPromise, marqueesPromise]);
   marquees = await marqueesPromise;
-  const event = await waitForEventOrTimeout('alloy_sendEvent', 500, new Event(''));
+  const event = await waitForEventOrTimeout('alloy_sendEvent', ALLOY_TIMEOUT, new Event(''));
   await segmentApiEventHandler(event);
 
   if (authorPreview()) {

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -160,7 +160,7 @@ async function responseHandler(response, fnName) {
 
 async function getAllMarquees(promoId, origin) {
   const endPoint = isProd() ? API_CONFIGS.caas.prod : API_CONFIGS.caas.stage;
-  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US`;
+  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US&perf=true`;
 
   /* eslint-disable object-curly-newline */
   const response = await fetch(`${endPoint}?${payload}`, {

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -79,7 +79,7 @@ function log(...args) {
 }
 
 const REQUEST_TIMEOUT = isProd() ? 1500 : 10000;
-const SEGMENT_API_TIMEOUT = 1000;
+const SEGMENT_API_TIMEOUT = 100;
 
 const TEXT = {
   small: 'm',

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -79,7 +79,7 @@ function log(...args) {
 }
 
 const REQUEST_TIMEOUT = isProd() ? 1500 : 10000;
-const SEGMENT_API_TIMEOUT = 100;
+const SEGMENT_API_TIMEOUT = 1000;
 
 const TEXT = {
   small: 'm',
@@ -160,7 +160,7 @@ async function responseHandler(response, fnName) {
 
 async function getAllMarquees(promoId, origin) {
   const endPoint = isProd() ? API_CONFIGS.caas.prod : API_CONFIGS.caas.stage;
-  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US&delay=5000`;
+  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US&perf=true`;
 
   /* eslint-disable object-curly-newline */
   const response = await fetch(`${endPoint}?${payload}`, {

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -465,15 +465,10 @@ export default async function init(el) {
 
   loadMartech();
 
-  marquees = await getAllMarquees(promoId, origin);
-  if (authorPreview()) {
-    renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
-  }
-
-  //   getAllMarquees(promoId, origin).then((resp) => {
-  //   marquees = resp;
-  //   if (authorPreview()) {
-  //     renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
-  //   }
-  // });
+  getAllMarquees(promoId, origin).then((resp) => {
+    marquees = resp;
+    if (authorPreview()) {
+      renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
+    }
+  });
 }

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -2,7 +2,6 @@
 import { getMetadata } from '../caas-marquee-metadata/caas-marquee-metadata.js';
 import { createTag, getConfig, loadMartech } from '../../utils/utils.js';
 
-loadMartech();
 performance.mark('caas-marquee-js');
 
 const SEGMENTS_MAP = {
@@ -463,6 +462,8 @@ export default async function init(el) {
     loadFallback(marquee, metadata);
     return;
   }
+
+  loadMartech();
 
   marquees = await getAllMarquees(promoId, origin);
   if (authorPreview()) {

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -79,7 +79,6 @@ function log(...args) {
 }
 
 const REQUEST_TIMEOUT = isProd() ? 1500 : 10000;
-// const SEGMENT_API_TIMEOUT = 1000;
 
 const TEXT = {
   small: 'm',
@@ -121,13 +120,6 @@ const waitForEventOrTimeout = (eventName, timeout, timeoutVal) => new Promise((r
   }, { once: true });
 });
 
-// eslint-disable-next-line prefer-arrow-callback, func-names
-// const timeout = setTimeout(async function () {
-//   clearTimeout(timeout);
-//   // eslint-disable-next-line no-use-before-define
-//   await loadFallback(marquee, metadata);
-// }, SEGMENT_API_TIMEOUT);
-
 // See https://experienceleague.adobe.com/docs/experience-platform/destinations/catalog/personalization/custom-personalization.html?lang=en
 // for more information on how to integrate with this API.
 async function segmentApiEventHandler(e) {
@@ -150,7 +142,6 @@ async function segmentApiEventHandler(e) {
   }
   loadFallback(marquee, metadata);
 }
-// window.addEventListener('alloy_sendEvent', (e) => segmentApiEventHandler(e));
 
 function fetchExceptionHandler(fnName, error) {
   log(`${fnName} fetch caught exception: ${error}`, LANA_OPTIONS);
@@ -480,17 +471,9 @@ export default async function init(el) {
   await Promise.all([martechPromise, marqueesPromise]);
   marquees = await marqueesPromise;
   const event = await waitForEventOrTimeout('alloy_sendEvent', 500, new Event(''));
-  // console.log(event); // will need to change param in segmentApiEventHandler
   await segmentApiEventHandler(event);
 
   if (authorPreview()) {
     renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
   }
-
-  //   getAllMarquees(promoId, origin).then((resp) => {
-  //   marquees = resp;
-  //   if (authorPreview()) {
-  //     renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
-  //   }
-  // });
 }

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -163,7 +163,7 @@ async function responseHandler(response, fnName) {
 
 async function getAllMarquees(promoId, origin) {
   const endPoint = isProd() ? API_CONFIGS.caas.prod : API_CONFIGS.caas.stage;
-  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US&perf=true`;
+  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US`;
 
   /* eslint-disable object-curly-newline */
   const response = await fetch(`${endPoint}?${payload}`, {

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -463,9 +463,11 @@ export default async function init(el) {
     return;
   }
 
-  loadMartech();
+  const martechPromise = loadMartech();
+  const marqueesPromise = getAllMarquees(promoId, origin);
+  await Promise.all([martechPromise, marqueesPromise]);
+  marquees = await marqueesPromise;
 
-  marquees = await getAllMarquees(promoId, origin);
   if (authorPreview()) {
     renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
   }

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -79,7 +79,7 @@ function log(...args) {
 }
 
 const REQUEST_TIMEOUT = isProd() ? 1500 : 10000;
-const SEGMENT_API_TIMEOUT = 1000;
+// const SEGMENT_API_TIMEOUT = 1000;
 
 const TEXT = {
   small: 'm',
@@ -122,11 +122,11 @@ const waitForEventOrTimeout = (eventName, timeout, timeoutVal) => new Promise((r
 });
 
 // eslint-disable-next-line prefer-arrow-callback, func-names
-const timeout = setTimeout(async function () {
-  clearTimeout(timeout);
-  // eslint-disable-next-line no-use-before-define
-  await loadFallback(marquee, metadata);
-}, SEGMENT_API_TIMEOUT);
+// const timeout = setTimeout(async function () {
+//   clearTimeout(timeout);
+//   // eslint-disable-next-line no-use-before-define
+//   await loadFallback(marquee, metadata);
+// }, SEGMENT_API_TIMEOUT);
 
 // See https://experienceleague.adobe.com/docs/experience-platform/destinations/catalog/personalization/custom-personalization.html?lang=en
 // for more information on how to integrate with this API.
@@ -149,7 +149,6 @@ async function segmentApiEventHandler(e) {
     } else {
       loadFallback(marquee, metadata);
     }
-    clearTimeout(timeout);
   }
 }
 // window.addEventListener('alloy_sendEvent', (e) => segmentApiEventHandler(e));

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -79,7 +79,7 @@ function log(...args) {
 }
 
 const REQUEST_TIMEOUT = isProd() ? 1500 : 10000;
-const SEGMENT_API_TIMEOUT = 2500;
+const SEGMENT_API_TIMEOUT = 1000;
 
 const TEXT = {
   small: 'm',
@@ -465,10 +465,9 @@ export default async function init(el) {
 
   loadMartech();
 
-  getAllMarquees(promoId, origin).then((resp) => {
-    marquees = resp;
-    if (authorPreview()) {
-      renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
-    }
-  });
+  marquees = await getAllMarquees(promoId, origin);
+  if (authorPreview()) {
+    renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
+  }
+
 }

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -79,7 +79,7 @@ function log(...args) {
 }
 
 const REQUEST_TIMEOUT = isProd() ? 1500 : 10000;
-const SEGMENT_API_TIMEOUT = 1000;
+const SEGMENT_API_TIMEOUT = 2500;
 
 const TEXT = {
   small: 'm',

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -160,7 +160,7 @@ async function responseHandler(response, fnName) {
 
 async function getAllMarquees(promoId, origin) {
   const endPoint = isProd() ? API_CONFIGS.caas.prod : API_CONFIGS.caas.stage;
-  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US&perf=true`;
+  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US`;
 
   /* eslint-disable object-curly-newline */
   const response = await fetch(`${endPoint}?${payload}`, {

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -160,7 +160,7 @@ async function responseHandler(response, fnName) {
 
 async function getAllMarquees(promoId, origin) {
   const endPoint = isProd() ? API_CONFIGS.caas.prod : API_CONFIGS.caas.stage;
-  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US`;
+  const payload = `originSelection=${origin}&promoId=${promoId}&language=en&country=US&delay=5000`;
 
   /* eslint-disable object-curly-newline */
   const response = await fetch(`${endPoint}?${payload}`, {

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -470,4 +470,10 @@ export default async function init(el) {
     renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
   }
 
+  //   getAllMarquees(promoId, origin).then((resp) => {
+  //   marquees = resp;
+  //   if (authorPreview()) {
+  //     renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);
+  //   }
+  // });
 }

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -132,7 +132,7 @@ const waitForEventOrTimeout = (eventName, timeout, timeoutVal) => new Promise((r
 // for more information on how to integrate with this API.
 async function segmentApiEventHandler(e) {
   const SEGMENT_MAP = isProd() ? SEGMENTS_MAP.prod : SEGMENTS_MAP.stage;
-  if (e.detail.type === 'pageView') {
+  if (e.detail?.type === 'pageView') {
     const mappedUserSegments = [];
     const userSegments = e.detail?.result?.destinations?.[0]?.segments || [];
     for (const userSegment of userSegments) {
@@ -146,10 +146,9 @@ async function segmentApiEventHandler(e) {
       selectedId = await getMarqueeId();
       // eslint-disable-next-line no-use-before-define
       renderMarquee(marquee, marquees, selectedId, metadata);
-    } else {
-      loadFallback(marquee, metadata);
     }
   }
+  loadFallback(marquee, metadata);
 }
 // window.addEventListener('alloy_sendEvent', (e) => segmentApiEventHandler(e));
 
@@ -480,7 +479,7 @@ export default async function init(el) {
   const marqueesPromise = getAllMarquees(promoId, origin);
   await Promise.all([martechPromise, marqueesPromise]);
   marquees = await marqueesPromise;
-  const event = await waitForEventOrTimeout('alloy_sendEvent', 10, new Event(''));
+  const event = await waitForEventOrTimeout('alloy_sendEvent', 500, new Event(''));
   // console.log(event); // will need to change param in segmentApiEventHandler
   await segmentApiEventHandler(event);
 

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -481,7 +481,7 @@ export default async function init(el) {
   const marqueesPromise = getAllMarquees(promoId, origin);
   await Promise.all([martechPromise, marqueesPromise]);
   marquees = await marqueesPromise;
-  const event = await waitForEventOrTimeout('alloy_sendEvent', 1000, []);
+  const event = await waitForEventOrTimeout('alloy_sendEvent', 10, new Event(''));
   // console.log(event); // will need to change param in segmentApiEventHandler
   await segmentApiEventHandler(event);
 

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -2,6 +2,7 @@
 import { getMetadata } from '../caas-marquee-metadata/caas-marquee-metadata.js';
 import { createTag, getConfig, loadMartech } from '../../utils/utils.js';
 
+loadMartech();
 performance.mark('caas-marquee-js');
 
 const SEGMENTS_MAP = {
@@ -79,7 +80,7 @@ function log(...args) {
 }
 
 const REQUEST_TIMEOUT = isProd() ? 1500 : 10000;
-const SEGMENT_API_TIMEOUT = 2500;
+const SEGMENT_API_TIMEOUT = 1000;
 
 const TEXT = {
   small: 'm',
@@ -462,8 +463,6 @@ export default async function init(el) {
     loadFallback(marquee, metadata);
     return;
   }
-
-  loadMartech();
 
   marquees = await getAllMarquees(promoId, origin);
   if (authorPreview()) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -799,7 +799,7 @@ export async function loadIms() {
   return imsLoaded;
 }
 
-async function loadMartech({ persEnabled = false, persManifests = [] } = {}) {
+export async function loadMartech({ persEnabled = false, persManifests = [] } = {}) {
   // eslint-disable-next-line no-underscore-dangle
   if (window.marketingtech?.adobe?.launch && window._satellite) {
     return true;


### PR DESCRIPTION
Increases LH score for CaaS Marquee from 62 to 93.

Before:
![image](https://github.com/adobecom/milo/assets/10876964/ef2477e1-6794-4aaf-b820-8dfc45ecc5ce)

After:
![image](https://github.com/adobecom/milo/assets/10876964/3596ca0d-3ec6-4a62-b29b-045f4fdfb257)
![image](https://github.com/adobecom/milo/assets/10876964/96ff4d2a-a0ff-44a2-bff0-ed1b84d1a18c)

We may be able to further increase this score by making some more optimizations to our backends. Will try next week and see if this bears any fruit.

Resolves: https://jira.corp.adobe.com/browse/MWPW-143183

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/sanrai/marquee-viewer/prod/recommendations
- After: https://caas-marquee-perf-2--milo--adobecom.hlx.live/drafts/sanrai/marquee-viewer/prod/recommendations