### PR TITLE
feat: expose mep experiments in global milo object

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -601,4 +601,8 @@ export async function applyPers(manifests) {
   });
   if (!config?.mep) config.mep = {};
   config.mep.martech = `|${pznVariants.join('--')}|${pznManifests.join('--')}`;
+
+  if (window.milo) {
+    window.milo.mep = { experiments };
+  }
 }


### PR DESCRIPTION
MWPW-xxxx - Expose experiments in global

As part of an instrumentation project, the selected MEP experiment (specifically the variant name and manifest) needs to be accessed by JavaScript code running outside of the MEP engine. This change stores the current experiment list inside the current `window.milo` global so that instrumentation code (e.g. running in WebSDK) can pick it up and post-process.

@chrischrischris and I discussed that although the resulting object has more data than is strictly necessary (i.e. the objects in the `experiments` array have many more properties than just the name and manifest), having milo be liberal it what it provides in this global would simplify the change on the milo end.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://<branch>--milo--adobecom.hlx.page/?martech=off
