### PR TITLE
Revert "Mwpw 142278: Thumbnail icons are not aligned vertically on iPad- fix"

### DIFF
--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -187,7 +187,8 @@
 }
 
 .icon-block.inline .foreground .text-content .icon-area {
-  width: min-content;
+  width: fit-content;
+  display: contents;
 }
 
 .five-up .icon-block:not(.full-width) .foreground .icon-area img {


### PR DESCRIPTION
Reverts adobecom/milo#1854

from @ryanmparrish:

Hi all. There was a [bug](https://jira.corp.adobe.com/browse/MWPW-142278) w/ tablet/ipad alignment that 
[@dmodasara](https://adobe-mwp.slack.com/team/U03FFSK2MV4)
 worked on yesterday however this recently merged [PR](https://github.com/adobecom/milo/pull/1854) broke the alignment on icon-block.inline.
https://main--milo--adobecom.hlx.page/drafts/rparrish/icon/icon-block-inline-milo
https://main--cc--adobecom.hlx.page/products/illustrator/free-trial-download (edited)