### PR TITLE
MWPW-143135: mep page filter to auto match optional .html extension

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -200,9 +200,9 @@ const consolidateObjects = (arr, prop) => arr.reduce((propMap, item) => {
   return propMap;
 }, {});
 
-const matchGlob = (searchStr, inputStr) => {
+export const matchGlob = (searchStr, inputStr) => {
   const pattern = searchStr.replace(/\*\*/g, '.*');
-  const reg = new RegExp(`^${pattern}$`, 'i'); // devtool bug needs this backtick: `
+  const reg = new RegExp(`^${pattern}(\\.html)?$`, 'i'); // devtool bug needs this backtick: `
   return reg.test(inputStr);
 };
 

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -3,7 +3,7 @@ import { readFile } from '@web/test-runner-commands';
 import { stub } from 'sinon';
 import { getConfig, setConfig, loadBlock } from '../../../libs/utils/utils.js';
 import initFragments from '../../../libs/blocks/fragment/fragment.js';
-import { applyPers, normalizePath } from '../../../libs/features/personalization/personalization.js';
+import { applyPers, normalizePath, matchGlob } from '../../../libs/features/personalization/personalization.js';
 
 document.head.innerHTML = await readFile({ path: './mocks/metadata.html' });
 document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
@@ -295,5 +295,27 @@ describe('normalizePath function', () => {
     config.locale = config.locales.de;
     const path = await normalizePath('https://main--milo--adobecom.hlx.page/path/to/fragment.plain.html');
     expect(path).to.equal('/de/path/to/fragment.plain.html');
+  });
+});
+
+describe('matchGlob function', () => {
+  it('should match page', async () => {
+    const result = matchGlob('/products/special-offers', '/products/special-offers');
+    expect(result).to.be.true;
+  });
+
+  it('should match page with HTML extension', async () => {
+    const result = matchGlob('/products/special-offers', '/products/special-offers.html');
+    expect(result).to.be.true;
+  });
+
+  it('should not match child page', async () => {
+    const result = matchGlob('/products/special-offers', '/products/special-offers/free-download');
+    expect(result).to.be.false;
+  });
+
+  it('should match child page', async () => {
+    const result = matchGlob('/products/special-offers**', '/products/special-offers/free-download');
+    expect(result).to.be.true;
   });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

In Milo, some pages have '.html' extensions on Live, but not on Production:
Live: https://www.adobe.com/products/special-offers.html 
Prod: https://main--cc--adobecom.hlx.live/products/special-offers 

When providing a page filter in the MEP manifest, Authors shouldn't be required to put in a regex to match both cases.
MEP can assume and accept the optional HTML extension.
 
Resolves: [MWPW-143135](https://jira.corp.adobe.com/browse/MWPW-143135)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/mariia/pr/promo/promo?martech=off
- After:  https://htmlextension--milo--adobecom.hlx.live/drafts/mariia/pr/promo/promo?martech=off