### PR TITLE
Fix: Excluding modals from Active link check

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -241,7 +241,7 @@ export const [hasActiveLink, setActiveLink, getActiveLink] = (() => {
     () => activeLinkFound,
     (val) => { activeLinkFound = !!val; },
     (area) => {
-      if (hasActiveLink() || !(area instanceof HTMLElement)) return null;
+      if (hasActiveLink() || !(area instanceof HTMLElement) || area.querySelector('a').dataset.modalHash) return null;
       const { origin, pathname } = window.location;
       let activeLink;
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Excluding the active link check from modal element which was removing the modal element href attribute

Resolves: [[MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)](https://jira.corp.adobe.com/browse/MWPW-143213)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/aftereffects/ae-test-page-localnav-twp
- After: https://main--cc--adobecom.hlx.page/products/aftereffects/ae-test-page-localnav-twp?milolibs=MWPW-143213--milo--bandana147&martech=off
