### PR TITLE
MWPW-141600 set international cookie correctly in region nav

### DIFF
--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -2,7 +2,9 @@ import { getConfig } from '../../utils/utils.js';
 
 /* c8 ignore next 11 */
 function handleEvent(prefix, link) {
-  document.cookie = `international=${prefix};path=/`;
+  const domain = window.location.host === 'adobe.com'
+    || window.location.host.endsWith('.adobe.com') ? 'domain=adobe.com' : '';
+  document.cookie = `international=${prefix};path=/;${domain}`;
   sessionStorage.setItem('international', prefix);
   fetch(link.href, { method: 'HEAD' }).then((resp) => {
     if (!resp.ok) throw new Error('request failed');


### PR DESCRIPTION
Region nav should set international cookie to .adobe.com

Resolves: [MWPW-141600](https://jira.corp.adobe.com/browse/MWPW-141600)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off#langnav
- After: https://MWPW-141600-region-selector-cookie--milo--adobecom.hlx.page/?martech=off#langnav

The easiest way to test this though is to go to business.adobe.com for example. Override your region-nav.js code with the code in this PR and see how the international cookie gets set when you open the region-nav. 