### PR TITLE
[MWPW-143313] IMS scopes based on UNav enablement

### DIFF
--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -11,7 +11,6 @@
  */
 
 import {
-  getMetadata,
   loadArea,
   loadLana,
   setConfig,
@@ -120,14 +119,11 @@ const locales = {
   sea: { ietf: 'en', tk: 'hah7vzn.css' },
 };
 
-const unavMeta = getMetadata('universal-nav')?.trim();
-
 const config = {
   geoRouting: 'on',
   fallbackRouting: 'on',
   links: 'on',
   imsClientId: 'milo',
-  imsScope: `AdobeID,openid,gnav${unavMeta && unavMeta !== 'off' ? ',pps.read,firefly_api' : ''}`,
   codeRoot: '/libs',
   locales,
   prodDomains,

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -11,6 +11,7 @@
  */
 
 import {
+  getMetadata,
   loadArea,
   loadLana,
   setConfig,
@@ -119,12 +120,14 @@ const locales = {
   sea: { ietf: 'en', tk: 'hah7vzn.css' },
 };
 
+const unavMeta = getMetadata('universal-nav')?.trim();
+
 const config = {
   geoRouting: 'on',
   fallbackRouting: 'on',
   links: 'on',
   imsClientId: 'milo',
-  imsScope: 'AdobeID,openid,gnav,pps.read,firefly_api',
+  imsScope: `AdobeID,openid,gnav${unavMeta && unavMeta !== 'off' ? ',pps.read,firefly_api' : ''}`,
   codeRoot: '/libs',
   locales,
   prodDomains,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -775,10 +775,12 @@ export async function loadIms() {
       reject(new Error('Missing IMS Client ID'));
       return;
     }
+    const unavMeta = getMetadata('universal-nav')?.trim();
+    const defaultScope = `AdobeID,openid,gnav${unavMeta && unavMeta !== 'off' ? ',pps.read,firefly_api' : ''}`;
     const timeout = setTimeout(() => reject(new Error('IMS timeout')), 5000);
     window.adobeid = {
       client_id: imsClientId,
-      scope: imsScope || 'AdobeID,openid,gnav,pps.read,firefly_api',
+      scope: imsScope || defaultScope,
       locale: locale?.ietf?.replace('-', '_') || 'en_US',
       autoValidateToken: true,
       environment: env.ims,


### PR DESCRIPTION
This aims to adapt the IMS `scope` configuration property based on the Universal Navigation enablement on the page.

To make use of the Universal Navigation features, additional scopes need to be used. However, if those scopes are defined, but not configured in IMSS for the respective client ID, the IMS library will fail to load, thus users would no longer be able to sign in or see their profile.

The desire is to define those additional scopes only on pages using the Universal Navigation. This tailors to Milo consumers that have not set their own scopes and instead rely on some sensible defaults.

The change has been made in two places:
* _scripts.js_ - this is where the Milo-specific configs are defined, we want to have this change here to make sure the Universal Navigation feature works correctly on Milo pages, _main--milo--adobe.com/hlx.(page|live)_;
* _utils.js_ - since this is being used by all Milo consumers, we need to consider two cases:
    * the consumer already has scopes defined - in this case, their scopes are used;
    * no scopes have been defined by the consumer - in this case, the basic scopes would be defined, unless they're using the Universal Navigation, in which case the additional scopes get appended as well.

**NOTE**: even though all consumers call `setConfig` in their scripts, as suggested in [Milo College](https://github.com/adobecom/milo-college/blob/main/scripts/scripts.js#L61), there aren't any defaults being set for IMS, as can be seen in the `setConfig` [method](https://github.com/adobecom/milo/blob/main/libs/utils/utils.js#L209-L236). Thus, it seems reasonable to me to adapt both files where scopes are declared.

**Testing instructions**: on a test page, open the browser's developer tools and check the value for `adobeid.scope`.

Resolves: [MWPW-143313](https://jira.corp.adobe.com/browse/MWPW-143313)

**Test URLs:**
- Before (additional scopes are set regardless of the Universal Navigation enablement):  https://main--milo--adobecom.hlx.page/drafts/ramuntea/gnav-refactor?martech=off&georouting=off
- After (basic scopes are set): https://gnav--milo--adobecom.hlx.page/drafts/ramuntea/gnav-refactor?martech=off&georouting=off
- After (additional scopes are used on Universal Navigation enabled page): https://gnav--milo--adobecom.hlx.page/drafts/ramuntea/universal-nav?martech=off&georouting=off
