### PR TITLE
MWPW-141132 - [Milo Loc V2] urls preview

### DIFF
--- a/libs/blocks/locui/locui.css
+++ b/libs/blocks/locui/locui.css
@@ -505,7 +505,7 @@ button.locui-url-action {
   }
 }
 
-button.locui-url-action[disabled] {
+button.locui-url-action.disabled {
   opacity: 0.25;
 }
 

--- a/libs/blocks/locui/url/index.js
+++ b/libs/blocks/locui/url/index.js
@@ -1,4 +1,4 @@
-import { getStatus } from '../utils/franklin.js';
+import { getStatus, preview, publish } from '../utils/franklin.js';
 
 const TIME_FORMAT = { hour12: false, hour: '2-digit', minute: '2-digit', timeZoneName: 'short' };
 
@@ -8,13 +8,6 @@ function getPrettyDate(string) {
   const date = rawDate.toLocaleDateString();
   const time = rawDate.toLocaleTimeString([], TIME_FORMAT);
   return [date, time];
-}
-
-export async function handleAction(url, sync = false) {
-  if (sync) {
-    console.log('sync to franklin', url);
-  }
-  window.open(url, '_blank');
 }
 
 async function getDetails(path) {
@@ -36,6 +29,15 @@ async function getDetails(path) {
       modified: getPrettyDate(json.live.lastModified),
     },
   };
+}
+
+export async function handleAction(item, isLive = false) {
+  const url = new URL(item.value[isLive ? 'live' : 'preview'].url);
+  if (isLive) await publish(url.pathname);
+  else await preview(url.pathname);
+  const details = await getDetails(item.value.path);
+  item.value = { ...item.value, ...details };
+  window.open(url, '_blank');
 }
 
 export async function openWord(e, item) {

--- a/libs/blocks/locui/url/index.js
+++ b/libs/blocks/locui/url/index.js
@@ -1,4 +1,4 @@
-import { getStatus, preview, publish } from '../utils/franklin.js';
+import { getStatus, preview } from '../utils/franklin.js';
 import { setStatus } from '../utils/status.js';
 
 const TIME_FORMAT = { hour12: false, hour: '2-digit', minute: '2-digit', timeZoneName: 'short' };
@@ -32,27 +32,30 @@ async function getDetails(path) {
   };
 }
 
-export async function handleAction(e, item, isLive = false) {
-  e.target.classList.add('locui-action-loading');
-  const action = item.value[isLive ? 'live' : 'preview'];
-  const url = new URL(action.url);
+async function previewAction(url, item) {
   try {
-    if (isLive) await publish(url.pathname);
-    else await preview(url.pathname);
+    await preview(url.pathname);
     const details = await getDetails(item.value.path);
     item.value = { ...item.value, ...details };
-    e.target.classList.remove('locui-action-loading');
     window.open(url, '_blank');
   } catch (error) {
-    e.target.classList.remove('locui-action-loading');
     setStatus(
       'details',
       'error',
-      `${isLive ? 'Publishing' : 'Previewing'} document`,
+      'Previewing document',
       'Sync to Langstore to perform this action',
       9000,
     );
   }
+}
+
+export async function handleAction(e, item, isPrev = false) {
+  e.target.classList.add('locui-action-loading');
+  const action = item.value[preview ? 'preview' : 'live'];
+  const url = new URL(action.url);
+  if (isPrev) await previewAction(url, item);
+  else window.open(url, '_blank');
+  e.target.classList.remove('locui-action-loading');
 }
 
 export async function openWord(e, item) {

--- a/libs/blocks/locui/url/index.js
+++ b/libs/blocks/locui/url/index.js
@@ -10,7 +10,10 @@ function getPrettyDate(string) {
   return [date, time];
 }
 
-export function handleAction(url) {
+export async function handleAction(url, sync = false) {
+  if (sync) {
+    console.log('sync to franklin', url);
+  }
   window.open(url, '_blank');
 }
 

--- a/libs/blocks/locui/url/tabs.js
+++ b/libs/blocks/locui/url/tabs.js
@@ -16,10 +16,10 @@ function Actions({ item }) {
         onClick=${(e) => { openWord(e, item); }}>Edit</button>
       <button
         class="locui-url-action locui-url-action-view${isDisabled(item.value.preview?.status)}"
-        onClick=${(e) => { handleAction(e, item); }}>Preview</button>
+        onClick=${(e) => { handleAction(e, item, true); }}>Preview</button>
       <button
         class="locui-url-action locui-url-action-view${isDisabled(item.value.live?.status)}"
-        onClick=${(e) => { handleAction(e, item, true); }}>Live</button>
+        onClick=${(e) => { handleAction(e, item); }}>Live</button>
     </div>
   `;
 }

--- a/libs/blocks/locui/url/tabs.js
+++ b/libs/blocks/locui/url/tabs.js
@@ -16,10 +16,10 @@ function Actions({ item }) {
         onClick=${(e) => { openWord(e, item); }}>Edit</button>
       <button
         class="locui-url-action locui-url-action-view${isDisabled(item.value.preview?.status)}"
-        onClick=${() => { handleAction(item); }}>Preview</button>
+        onClick=${(e) => { handleAction(e, item); }}>Preview</button>
       <button
         class="locui-url-action locui-url-action-view${isDisabled(item.value.live?.status)}"
-        onClick=${() => { handleAction(item, true); }}>Live</button>
+        onClick=${(e) => { handleAction(e, item, true); }}>Live</button>
     </div>
   `;
 }

--- a/libs/blocks/locui/url/tabs.js
+++ b/libs/blocks/locui/url/tabs.js
@@ -16,11 +16,11 @@ function Actions({ item }) {
       <button
         disabled=${item.value.preview?.status !== 200}
         class="locui-url-action locui-url-action-view"
-        onClick=${() => { handleAction(item.value.preview.url); }}>Preview</button>
+        onClick=${() => { handleAction(item.value.preview.url, true); }}>Preview</button>
       <button
         disabled=${item.value.live?.status !== 200}
         class="locui-url-action locui-url-action-view"
-        onClick=${() => { handleAction(item.value.live.url); }}>Live</button>
+        onClick=${() => { handleAction(item.value.live.url, true); }}>Live</button>
     </div>
   `;
 }

--- a/libs/blocks/locui/url/tabs.js
+++ b/libs/blocks/locui/url/tabs.js
@@ -7,6 +7,7 @@ function useSignal(value) {
 
 function Actions({ item }) {
   const isExcel = item.value.path.endsWith('.json') ? ' locui-url-action-edit-excel' : ' locui-url-action-edit-word';
+  const isDisabled = (status) => (!status || status !== 200 ? ' disabled' : '');
   return html`
     <div class=locui-url-source-actions>
       <button
@@ -14,13 +15,11 @@ function Actions({ item }) {
         class="locui-url-action locui-url-action-edit${isExcel}"
         onClick=${(e) => { openWord(e, item); }}>Edit</button>
       <button
-        disabled=${item.value.preview?.status !== 200}
-        class="locui-url-action locui-url-action-view"
-        onClick=${() => { handleAction(item.value.preview.url, true); }}>Preview</button>
+        class="locui-url-action locui-url-action-view${isDisabled(item.value.preview?.status)}"
+        onClick=${() => { handleAction(item); }}>Preview</button>
       <button
-        disabled=${item.value.live?.status !== 200}
-        class="locui-url-action locui-url-action-view"
-        onClick=${() => { handleAction(item.value.live.url, true); }}>Live</button>
+        class="locui-url-action locui-url-action-view${isDisabled(item.value.live?.status)}"
+        onClick=${() => { handleAction(item, true); }}>Live</button>
     </div>
   `;
 }

--- a/libs/blocks/locui/utils/franklin.js
+++ b/libs/blocks/locui/utils/franklin.js
@@ -13,7 +13,7 @@ export async function preview(path) {
 }
 
 export async function publish(path) {
-  const url = `${ADMIN}/preview/${owner}/${repo}/main${path}`;
+  const url = `${ADMIN}/live/${owner}/${repo}/main${path}`;
   const resp = await fetch(url, { method: 'POST' });
   const json = await resp.json();
   return json;

--- a/libs/blocks/locui/utils/franklin.js
+++ b/libs/blocks/locui/utils/franklin.js
@@ -12,13 +12,6 @@ export async function preview(path) {
   return json;
 }
 
-export async function publish(path) {
-  const url = `${ADMIN}/live/${owner}/${repo}/main${path}`;
-  const resp = await fetch(url, { method: 'POST' });
-  const json = await resp.json();
-  return json;
-}
-
 export async function getStatus(path = '', editUrl = 'auto') {
   let url = `${ADMIN}/status/${owner}/${repo}/main${path}`;
   url = editUrl ? `${url}?editUrl=${editUrl}` : url;

--- a/libs/blocks/locui/utils/franklin.js
+++ b/libs/blocks/locui/utils/franklin.js
@@ -12,6 +12,13 @@ export async function preview(path) {
   return json;
 }
 
+export async function publish(path) {
+  const url = `${ADMIN}/preview/${owner}/${repo}/main${path}`;
+  const resp = await fetch(url, { method: 'POST' });
+  const json = await resp.json();
+  return json;
+}
+
 export async function getStatus(path = '', editUrl = 'auto') {
   let url = `${ADMIN}/status/${owner}/${repo}/main${path}`;
   url = editUrl ? `${url}?editUrl=${editUrl}` : url;


### PR DESCRIPTION
When users sync to `langstore/en` the documents aren't automatically synced to preview. In current implementation when an action is clicked the user is simply navigated to the url in question without actually deploying the preview.
![Screenshot 2024-03-01 at 4 00 55 PM](https://github.com/adobecom/milo/assets/10670990/47fc76f5-e2b1-4d36-8a5a-d3edd274dde2)

This PR updates UI urls action preview button to pre-request preview process before navigating to the page, also includes error handling for when documents do not exist in the langstore:
![Screenshot 2024-03-01 at 4 00 20 PM](https://github.com/adobecom/milo/assets/10670990/73039ee5-7e1e-4333-bb48-c99a40689aee)

Resolves: [MWPW-141132](https://jira.corp.adobe.com/browse/MWPW-141132)

**Test URLs:**
- Before: https://locui--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B7c5698f5-0ae1-4219-b0b1-38bea4c22b84%257D%26action%3Deditnew
- After: https://loc-actions--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B7c5698f5-0ae1-4219-b0b1-38bea4c22b84%257D%26action%3Deditnew