### PR TITLE
MWPW-141020: [Project PEP] Implement Analytics Enablement

### DIFF
--- a/libs/features/webapp-prompt/webapp-prompt.js
+++ b/libs/features/webapp-prompt/webapp-prompt.js
@@ -11,8 +11,6 @@ const CONFIG = {
   icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.5 118.1" title="Adobe, Inc."><defs><style>.cls-1 {fill: #eb1000;}</style></defs><g><g><polygon class="cls-1" points="84.1 0 133.5 0 133.5 118.1 84.1 0"/><polygon class="cls-1" points="49.4 0 0 0 0 118.1 49.4 0"/><polygon class="cls-1" points="66.7 43.5 98.2 118.1 77.6 118.1 68.2 94.4 45.2 94.4 66.7 43.5"/></g></g></svg>',
 };
 
-const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
-
 const getElemText = (elem) => elem?.textContent?.trim().toLowerCase();
 
 // Note: this might be used outside of Milo,
@@ -124,7 +122,7 @@ class AppPrompt {
       </div>`
       : '';
 
-    return toFragment`<div daa-state="true" daa-im="true" daa-lh="PEP Modal_${capitalize(this.options['product-name'])}" class="appPrompt">
+    return toFragment`<div daa-state="true" daa-im="true" daa-lh="PEP Modal_${this.options['product-name']}" class="appPrompt">
       ${this.elements.closeIcon}
       <div class="appPrompt-icon">
         ${this.image}

--- a/libs/features/webapp-prompt/webapp-prompt.js
+++ b/libs/features/webapp-prompt/webapp-prompt.js
@@ -45,7 +45,7 @@ class AppPrompt {
     await this.getData(content);
     // TODO: we might need to set this at the page level through metadata
     // so that the same prompt can lead to different apps
-    if (!this.options['redirect-url']) return;
+    if (!this.options['redirect-url'] || !this.options['product-name']) return;
 
     this.template = this.decorate();
 

--- a/libs/features/webapp-prompt/webapp-prompt.js
+++ b/libs/features/webapp-prompt/webapp-prompt.js
@@ -11,7 +11,7 @@ const CONFIG = {
   icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.5 118.1" title="Adobe, Inc."><defs><style>.cls-1 {fill: #eb1000;}</style></defs><g><g><polygon class="cls-1" points="84.1 0 133.5 0 133.5 118.1 84.1 0"/><polygon class="cls-1" points="49.4 0 0 0 0 118.1 49.4 0"/><polygon class="cls-1" points="66.7 43.5 98.2 118.1 77.6 118.1 68.2 94.4 45.2 94.4 66.7 43.5"/></g></g></svg>',
 };
 
-const capitalize = (str) => str && (str.charAt(0).toUpperCase() + str.slice(1));
+const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
 
 const getElemText = (elem) => elem?.textContent?.trim().toLowerCase();
 

--- a/libs/features/webapp-prompt/webapp-prompt.js
+++ b/libs/features/webapp-prompt/webapp-prompt.js
@@ -11,7 +11,7 @@ const CONFIG = {
   icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.5 118.1" title="Adobe, Inc."><defs><style>.cls-1 {fill: #eb1000;}</style></defs><g><g><polygon class="cls-1" points="84.1 0 133.5 0 133.5 118.1 84.1 0"/><polygon class="cls-1" points="49.4 0 0 0 0 118.1 49.4 0"/><polygon class="cls-1" points="66.7 43.5 98.2 118.1 77.6 118.1 68.2 94.4 45.2 94.4 66.7 43.5"/></g></g></svg>',
 };
 
-const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
+const capitalize = (str) => str && (str.charAt(0).toUpperCase() + str.slice(1));
 
 const getElemText = (elem) => elem?.textContent?.trim().toLowerCase();
 
@@ -27,13 +27,12 @@ const getMetadata = (el) => [...el.childNodes].reduce((acc, row) => {
 }, {});
 
 class AppPrompt {
-  constructor({ promptPath, id, profileApi, entName } = {}) {
+  constructor({ promptPath, id, profileApi } = {}) {
     this.promptPath = promptPath;
     this.id = id;
     this.profileApi = profileApi;
     this.elements = {};
-    // TODO - make sure this is still valid after we have the entitlements mapping
-    this.productName = capitalize(entName);
+
     if (this.isDismissedPrompt()) return;
 
     this.init();
@@ -112,7 +111,7 @@ class AppPrompt {
   // TODO: should we allow for app icon to be set as SVG?
   decorate = () => {
     this.elements.closeIcon = toFragment`<button daa-ll="Close Modal" class="appPrompt-close"></button>`;
-    this.elements.cta = toFragment`<button daa-ll="${this.cancelText}" class="appPrompt-cta appPrompt-cta--close">${this.cancelText}</button>`;
+    this.elements.cta = toFragment`<button daa-ll="Stay on this page" class="appPrompt-cta appPrompt-cta--close">${this.cancelText}</button>`;
     this.elements.profile = Object.keys(this.profile).length
       ? toFragment`<div class="appPrompt-profile">
         <div class="appPrompt-avatar">
@@ -125,7 +124,7 @@ class AppPrompt {
       </div>`
       : '';
 
-    return toFragment`<div daa-state="true" daa-im="true" daa-lh="PEP Modal_${this.productName}" class="appPrompt">
+    return toFragment`<div daa-state="true" daa-im="true" daa-lh="PEP Modal_${capitalize(this.options['product-name'])}" class="appPrompt">
       ${this.elements.closeIcon}
       <div class="appPrompt-icon">
         ${this.image}

--- a/libs/features/webapp-prompt/webapp-prompt.js
+++ b/libs/features/webapp-prompt/webapp-prompt.js
@@ -11,6 +11,8 @@ const CONFIG = {
   icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.5 118.1" title="Adobe, Inc."><defs><style>.cls-1 {fill: #eb1000;}</style></defs><g><g><polygon class="cls-1" points="84.1 0 133.5 0 133.5 118.1 84.1 0"/><polygon class="cls-1" points="49.4 0 0 0 0 118.1 49.4 0"/><polygon class="cls-1" points="66.7 43.5 98.2 118.1 77.6 118.1 68.2 94.4 45.2 94.4 66.7 43.5"/></g></g></svg>',
 };
 
+const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
+
 const getElemText = (elem) => elem?.textContent?.trim().toLowerCase();
 
 // Note: this might be used outside of Milo,
@@ -25,12 +27,13 @@ const getMetadata = (el) => [...el.childNodes].reduce((acc, row) => {
 }, {});
 
 class AppPrompt {
-  constructor({ promptPath, id, profileApi } = {}) {
+  constructor({ promptPath, id, profileApi, entName } = {}) {
     this.promptPath = promptPath;
     this.id = id;
     this.profileApi = profileApi;
     this.elements = {};
-
+    // TODO - make sure this is still valid after we have the entitlements mapping
+    this.productName = capitalize(entName);
     if (this.isDismissedPrompt()) return;
 
     this.init();
@@ -108,8 +111,8 @@ class AppPrompt {
 
   // TODO: should we allow for app icon to be set as SVG?
   decorate = () => {
-    this.elements.closeIcon = toFragment`<button class="appPrompt-close"></button>`;
-    this.elements.cta = toFragment`<button class="appPrompt-cta appPrompt-cta--close">${this.cancelText}</button>`;
+    this.elements.closeIcon = toFragment`<button daa-ll="Close Modal" class="appPrompt-close"></button>`;
+    this.elements.cta = toFragment`<button daa-ll="${this.cancelText}" class="appPrompt-cta appPrompt-cta--close">${this.cancelText}</button>`;
     this.elements.profile = Object.keys(this.profile).length
       ? toFragment`<div class="appPrompt-profile">
         <div class="appPrompt-avatar">
@@ -122,7 +125,7 @@ class AppPrompt {
       </div>`
       : '';
 
-    return toFragment`<div class="appPrompt">
+    return toFragment`<div daa-state="true" daa-im="true" daa-lh="PEP Modal_${this.productName}" class="appPrompt">
       ${this.elements.closeIcon}
       <div class="appPrompt-icon">
         ${this.image}

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -97,7 +97,7 @@ export const loadAppPrompt = async (getConfig, getMetadata, loadStyle) => {
     loadStyle(`${base}/features/webapp-prompt/webapp-prompt.css`),
   ]);
 
-  webappPrompt.default({ promptPath, id, profileApi });
+  webappPrompt.default({ promptPath, id, profileApi, entName });
 };
 
 /**

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -97,7 +97,7 @@ export const loadAppPrompt = async (getConfig, getMetadata, loadStyle) => {
     loadStyle(`${base}/features/webapp-prompt/webapp-prompt.css`),
   ]);
 
-  webappPrompt.default({ promptPath, id, profileApi, entName });
+  webappPrompt.default({ promptPath, id, profileApi });
 };
 
 /**


### PR DESCRIPTION
## Description
This PR enables analytics for PEP

## Related Issue
Resolves: [MWPW-141020](https://jira.corp.adobe.com/browse/MWPW-141020)

## Testing instructions
1. open the `after test URL` and wait for the PEP modal to show up
2. open dev tools and watch the network tab, searching for calls to `https://sstats.adobe.com/ee/irl1/v1/interact`
3. click on the X button
4. the request payload for searched api call should have `events[0].xdm.web.webInteraction.name` equal to `"Close Modal|PEP Modal_Photoshop"` ( see screenshots )
5. delete the `dismissedAppPrompts` cookie so that the modal will show up again on refresh
6. click the "Stay on this page" button
7. the request payload for searched api call should have `events[0].xdm.web.webInteraction.name` equal to `"Stay on this page|PEP Modal_Photoshop"` ( see screenshots )

## Screenshots
<img width="1540" alt="Screenshot 2024-03-04 at 11 06 14" src="https://github.com/adobecom/milo/assets/146744221/214c2025-b7e8-4261-bb18-509acb50dc8a">
<img width="1540" alt="Screenshot 2024-03-04 at 11 04 07" src="https://github.com/adobecom/milo/assets/146744221/a5e5282b-39de-44b7-a9c5-c00c17988481">

## Test URLs
**Milo:**
- Before: https://project-pep--milo--adobecom.hlx.page/drafts/rbogos/pep-prompt?imsClientId=fedsmilo
- After: https://mwpw-141020-pep-analytics--milo--robert-bogos.hlx.page/drafts/rbogos/pep-prompt?imsClientId=fedsmilo
