### PR TITLE
MWPW-139939 - Support for quiz state in local storage

### DIFF
--- a/libs/blocks/quiz/quiz.js
+++ b/libs/blocks/quiz/quiz.js
@@ -202,6 +202,8 @@ const App = ({
     const nextQuizViewsLen = nextQuizViews.length;
     const [firstQuizView] = nextQuizViews;
 
+    localStorage.removeItem('stored-quiz-state');
+
     if (nextQuizViewsLen === 1 && isValidUrl(firstQuizView)) {
       window.location.href = firstQuizView;
       return;

--- a/libs/blocks/quiz/quiz.js
+++ b/libs/blocks/quiz/quiz.js
@@ -21,7 +21,7 @@ export async function loadFragments(fragmentURL) {
 const App = ({
   initialIsDataLoaded = false,
   preQuestions = {}, initialStrings = {}, shortQuiz: isShortQuiz = false,
-  preselections = [], nextQuizViewsExist: preNextQuizViewsExist = true, storedQuizState = {},
+  preselections = [], nextQuizViewsExist: preNextQuizViewsExist = true, storedQuizState = true,
 }) => {
   const [btnAnalytics, setBtnAnalytics] = useState(null);
   const [countSelectedCards, setCountOfSelectedCards] = useState(0);
@@ -339,7 +339,7 @@ export default async function init(
 ) {
   const configData = initConfigPathGlob(el);
   const updatedShortQuiz = shortQuiz || configData.shortQuiz;
-  let storedQuizState = localStorage.getItem('stored-quiz-state');
+  let storedQuizState = localStorage.getItem('stored-quiz-state') || {};
 
   try {
     storedQuizState = JSON.parse(storedQuizState);

--- a/libs/blocks/quiz/quiz.js
+++ b/libs/blocks/quiz/quiz.js
@@ -21,7 +21,7 @@ export async function loadFragments(fragmentURL) {
 const App = ({
   initialIsDataLoaded = false,
   preQuestions = {}, initialStrings = {}, shortQuiz: isShortQuiz = false,
-  preselections = [], nextQuizViewsExist: preNextQuizViewsExist = true,
+  preselections = [], nextQuizViewsExist: preNextQuizViewsExist = true, storedQuizState = {},
 }) => {
   const [btnAnalytics, setBtnAnalytics] = useState(null);
   const [countSelectedCards, setCountOfSelectedCards] = useState(0);
@@ -56,7 +56,14 @@ const App = ({
         strMap[question.q] = question;
       });
 
-      setUserFlow([questions.questions.data[0].questions]);
+      if (!!Object.keys(storedQuizState).length
+        && !!storedQuizState?.userFlow.length
+        && !!storedQuizState?.userSelection.length) {
+        setUserFlow(storedQuizState.userFlow);
+        updateUserSelection(storedQuizState.userSelection);
+      } else {
+        setUserFlow([questions.questions.data[0].questions]);
+      }
 
       setStringData(dataStrings);
       setQuestionData(questions);
@@ -332,6 +339,14 @@ export default async function init(
 ) {
   const configData = initConfigPathGlob(el);
   const updatedShortQuiz = shortQuiz || configData.shortQuiz;
+  let storedQuizState = localStorage.getItem('stored-quiz-state');
+
+  try {
+    storedQuizState = JSON.parse(storedQuizState);
+  } catch (e) {
+    storedQuizState = {};
+  }
+
   el.replaceChildren();
   render(html`<${App} 
     initialIsDataLoaded=${initialIsDataLoaded} 
@@ -340,5 +355,6 @@ export default async function init(
     shortQuiz=${updatedShortQuiz}
     preselections=${preselections}
     nextQuizViewsExist=${nextQuizViewsExist}
+    storedQuizState=${storedQuizState}
   />`, el);
 }

--- a/test/blocks/quiz/mocks/mock-states.js
+++ b/test/blocks/quiz/mocks/mock-states.js
@@ -114,3 +114,26 @@ export const resultData = {
     },
   ],
 };
+
+export const storedData = {
+  userFlow: [
+    'q-rather',
+    'q-photo',
+    'q-video',
+    'q-design',
+  ],
+  userSelection: [
+    {
+      selectedQuestion: {
+        questions: 'q-category',
+        'max-selections': '3',
+        'min-selections': '1',
+      },
+      selectedCards: {
+        photo: true,
+        video: true,
+        design: true,
+      },
+    },
+  ],
+};


### PR DESCRIPTION
* Renders the quiz at any point as captured in local storage

Resolves: [MWPW-139939](https://jira.corp.adobe.com/browse/MWPW-139939)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/colloyd/quiz/?martech=off
- After: https://mwpw-139939-load-userflow-from-local-storage--milo--colloyd.hlx.page/drafts/colloyd/quiz/?martech=off

Testing Notes: To test this code, you will need to load up the URLs above and set the following in local storage for each
- key: stored-quiz-state
- value: {"userFlow":["q-rather","q-photo","q-video","q-design"],"userSelection":[{"selectedQuestion":{"questions":"q-category","max-selections":"3","min-selections":"1"},"selectedCards":{"photo":true,"video":true,"design":true}}]}

In the before page, the quiz will load the first question as normal. In the after page, the quiz will load up on the second question with the first question already answered with Photo, Video and Design options pre-chosen You can verify this by choosing "Take the time to control every detail" on the second question. You should then see questions corresponding to each of the 3 pre-chosen options from question one.