### PR TITLE
MWPW-143825 - Block library block grouping

### DIFF
--- a/libs/blocks/library-container-end/library-container-end.css
+++ b/libs/blocks/library-container-end/library-container-end.css
@@ -1,3 +1,9 @@
+
+.library-container-end,
+.section.masonry-layout .library-container-end[class*='grid-'] {
+  display: none;
+}
+
 .library-container-end::before {
   display: block;
   content: 'Library Container End';

--- a/libs/blocks/library-container-start/library-container-start.css
+++ b/libs/blocks/library-container-start/library-container-start.css
@@ -1,3 +1,8 @@
+.library-container-start,
+.section.masonry-layout .library-container-start[class*='grid-'] {
+  display: none;
+}
+
 .library-container-start::before {
   display: block;
   content: 'Library Container Start';

--- a/libs/blocks/library-metadata/library-metadata.css
+++ b/libs/blocks/library-metadata/library-metadata.css
@@ -1,5 +1,6 @@
 .library-metadata {
   margin: 24px auto;
+  display: block;
 }
 
 .library-metadata::before {
@@ -10,18 +11,16 @@
   border-radius: 6px;
   text-transform: uppercase;
   font-weight: 700;
+  font-size: smaller;
   color: #293c51;
   padding: 6px 12px;
 }
 
 .library-meta-row {
+  background-color: #EFEFEF;
   display: grid;
   grid-template-columns: 1fr 1fr;
   margin-top: 4px;
-  border-radius: 6px;
-}
-
-.library-meta-row {
-  background-color: #EFEFEF;
   padding: 6px 12px;
+  border-radius: 6px;
 }

--- a/libs/blocks/library-metadata/library-metadata.js
+++ b/libs/blocks/library-metadata/library-metadata.js
@@ -5,4 +5,16 @@ export default function init(el) {
     row.classList.add('library-meta-row');
     row.firstElementChild.classList.add('library-meta-key');
   });
+  // Fixes layout issue for groups of blocks using a grid layout
+  const section = el.closest('.section');
+  if (section.querySelector('.library-container-end')) {
+    const content = section.querySelector('.content');
+    section.insertAdjacentElement('afterend', el);
+
+    if (!content) return;
+    const reflowSection = document.createElement('div');
+    reflowSection.classList.add('section');
+    reflowSection.append(content);
+    section.insertAdjacentElement('beforebegin', reflowSection);
+  }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
* Fixes layout issues caused by `library-container-start`, `library-container-end` `library-metadata blocks`. 
* Hides `library-container-start` and `library-container-end` blocks from preview example.

*Note: This fix is only for the previewing of blocks from the block library. This code never makes it way to published content.

---
Resolves: [MWPW-143825](https://jira.corp.adobe.com/browse/MWPW-143825)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/patterns?martech=off
- After: https://block-grouping--milo--adobecom.hlx.page/docs/library/blocks/patterns?martech=off
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/bricks?martech=off
- After: https://block-grouping--milo--adobecom.hlx.page/docs/library/blocks/bricks?martech=off
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/carousel?martech=off
- After: https://block-grouping--milo--adobecom.hlx.page/docs/library/blocks/carousel?martech=off
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/tabs?martech=off
- After: https://block-grouping--milo--adobecom.hlx.page/docs/library/blocks/tabs?martech=off

---
**Context:**
Milo's block library has the ability to group multiple blocks, name that grouping so authors can copy and paste the group in one action. This is extremely helpful for blocks like Carousel or Tabs that require the use of multiple blocks to be authored in order to display on a page. 

This also introduced the idea of block patterns to create more advanced layouts. Consonant has identified common layout patterns that require multiple blocks to be assembled on a page. Creating this patterns and serving them from the block library will help reduce time for authoring and create a more consistent layout for these patterns when added to a page.