### PR TITLE
Setup the federal stage environment

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -76,8 +76,9 @@ export const getFederatedContentRoot = () => {
     ? origin
     : 'https://www.adobe.com';
 
-  if (origin.includes('localhost') || origin.includes('.hlx.')) {
-    federatedContentRoot = `https://main--federal--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
+  if (origin.includes('localhost') || origin.includes('.hlx.page')) {
+    // Akamai as proxy to avoid 401s, given AEM-EDS MS uth multi project limitations
+    federatedContentRoot = 'https://www.stage.adobe.com';
   }
 
   return federatedContentRoot;

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -76,9 +76,11 @@ export const getFederatedContentRoot = () => {
     ? origin
     : 'https://www.adobe.com';
 
-  if (origin.includes('localhost') || origin.includes('.hlx.page')) {
+  if (origin.includes('localhost') || origin.includes('.hlx.')) {
     // Akamai as proxy to avoid 401s, given AEM-EDS MS auth multi project limitations
-    federatedContentRoot = 'https://www.stage.adobe.com';
+    federatedContentRoot = origin.includes('.hlx.live')
+      ? 'https://main--federal--adobecom.hlx.live'
+      : 'https://www.stage.adobe.com';
   }
 
   return federatedContentRoot;

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -77,7 +77,7 @@ export const getFederatedContentRoot = () => {
     : 'https://www.adobe.com';
 
   if (origin.includes('localhost') || origin.includes('.hlx.')) {
-    // Akamai as proxy to avoid 401s, given AEM-EDS MS auth multi project limitations
+    // Akamai as proxy to avoid 401s, given AEM-EDS MS auth cross project limitations
     federatedContentRoot = origin.includes('.hlx.live')
       ? 'https://main--federal--adobecom.hlx.live'
       : 'https://www.stage.adobe.com';

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -77,7 +77,7 @@ export const getFederatedContentRoot = () => {
     : 'https://www.adobe.com';
 
   if (origin.includes('localhost') || origin.includes('.hlx.page')) {
-    // Akamai as proxy to avoid 401s, given AEM-EDS MS uth multi project limitations
+    // Akamai as proxy to avoid 401s, given AEM-EDS MS auth multi project limitations
     federatedContentRoot = 'https://www.stage.adobe.com';
   }
 

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -1393,7 +1393,7 @@ describe('global navigation', () => {
       document.body.replaceChildren(toFragment`<header class="global-navigation"></header>`);
       await initGnav(document.body.querySelector('header'));
       expect(
-        fetchStub.calledOnceWith('https://main--federal--adobecom.hlx.page/federal/path/to/gnav.plain.html'),
+        fetchStub.calledOnceWith('https://www.stage.adobe.com/federal/path/to/gnav.plain.html'),
       ).to.be.true;
     });
 
@@ -1403,7 +1403,7 @@ describe('global navigation', () => {
       document.body.replaceChildren(toFragment`<header class="global-navigation"></header>`);
       await initGnav(document.body.querySelector('header'));
       expect(
-        fetchStub.calledOnceWith('https://main--federal--adobecom.hlx.page/federal/path/to/gnav.plain.html'),
+        fetchStub.calledOnceWith('https://www.stage.adobe.com/federal/path/to/gnav.plain.html'),
       ).to.be.true;
     });
   });

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -171,7 +171,7 @@ export const createFullGlobalNavigation = async ({
     if (url.endsWith('large-menu-cross-cloud.plain.html')) { return mockRes({ payload: largeMenuCrossCloud }); }
     if (url.endsWith('large-menu-active.plain.html')) { return mockRes({ payload: largeMenuActiveMock }); }
     if (url.endsWith('large-menu-wide-column.plain.html')) { return mockRes({ payload: largeMenuWideColumnMock }); }
-    if (url.includes('main--federal--adobecom.hlx.page')
+    if (url.includes('https://www.stage.adobe.com')
       && url.endsWith('feds-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
     if (url.includes('gnav')) { return mockRes({ payload: globalNavigation || globalNavigationMock }); }
     if (url.includes('correct-promo-fragment')) { return mockRes({ payload: correctPromoFragmentMock }); }

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -19,6 +19,7 @@ import {
 import { setConfig } from '../../../../libs/utils/utils.js';
 import { createFullGlobalNavigation, config } from '../test-utilities.js';
 
+const baseHost = 'https://www.stage.adobe.com';
 describe('global navigation utilities', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -39,7 +40,7 @@ describe('global navigation utilities', () => {
   describe('getFedsContentRoot', () => {
     it('should return content source for localhost', () => {
       const contentSource = getFederatedContentRoot();
-      expect(contentSource).to.equal('https://main--federal--adobecom.hlx.page');
+      expect(contentSource).to.equal(baseHost);
     });
   });
 
@@ -114,7 +115,7 @@ describe('global navigation utilities', () => {
       });
       federatePictureSources(template);
       verifyImageTemplate({
-        host: 'https://main--federal--adobecom.hlx.page',
+        host: baseHost,
         path: '/federal/media.png',
         locale: '',
         template,
@@ -129,7 +130,7 @@ describe('global navigation utilities', () => {
       });
       federatePictureSources(template);
       verifyImageTemplate({
-        host: 'https://main--federal--adobecom.hlx.page',
+        host: baseHost,
         path: '/federal/media.png',
         locale: '/ch_de',
         template,
@@ -174,7 +175,7 @@ describe('global navigation utilities', () => {
       });
       federatePictureSources(template);
       verifyImageTemplate({
-        host: 'https://main--federal--adobecom.hlx.page',
+        host: baseHost,
         path: '/federal/media.png',
         locale: '',
         template,
@@ -189,7 +190,7 @@ describe('global navigation utilities', () => {
       });
       federatePictureSources(template);
       verifyImageTemplate({
-        host: 'https://main--federal--adobecom.hlx.page',
+        host: baseHost,
         path: '/federal/media.png',
         locale: '/ch_de',
         template,
@@ -207,7 +208,7 @@ describe('global navigation utilities', () => {
       const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig(placeholderConfig);
       expect(ietf).to.equal('en-US');
       expect(prefix).to.equal('');
-      expect(contentRoot).to.equal('https://main--federal--adobecom.hlx.page/federal/globalnav');
+      expect(contentRoot).to.equal(`${baseHost}/federal/globalnav`);
     });
 
     it('should return a config object for a specific locale', () => {
@@ -223,7 +224,7 @@ describe('global navigation utilities', () => {
       const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig(placeholderConfig);
       expect(ietf).to.equal('fi-FI');
       expect(prefix).to.equal('/fi');
-      expect(contentRoot).to.equal('https://main--federal--adobecom.hlx.page/fi/federal/globalnav');
+      expect(contentRoot).to.equal(`${baseHost}/fi/federal/globalnav`);
     });
   });
 
@@ -399,12 +400,12 @@ describe('global navigation utilities', () => {
       expect(
         getFederatedUrl('https://adobe.com/federal/foo-fragment.html'),
       ).to.equal(
-        'https://main--federal--adobecom.hlx.page/federal/foo-fragment.html',
+        `${baseHost}/federal/foo-fragment.html`,
       );
       expect(
         getFederatedUrl('https://adobe.com/lu_de/federal/gnav/foofooter.html'),
       ).to.equal(
-        'https://main--federal--adobecom.hlx.page/lu_de/federal/gnav/foofooter.html',
+        `${baseHost}/lu_de/federal/gnav/foofooter.html`,
       );
     });
 
@@ -412,7 +413,7 @@ describe('global navigation utilities', () => {
       expect(
         getFederatedUrl('/federal/foo-fragment.html'),
       ).to.equal(
-        'https://main--federal--adobecom.hlx.page/federal/foo-fragment.html',
+        `${baseHost}/federal/foo-fragment.html`,
       );
     });
 
@@ -420,7 +421,7 @@ describe('global navigation utilities', () => {
       expect(
         getFederatedUrl('/federal/foo-fragment.html?foo=bar#test'),
       ).to.equal(
-        'https://main--federal--adobecom.hlx.page/federal/foo-fragment.html?foo=bar#test',
+        `${baseHost}/federal/foo-fragment.html?foo=bar#test`,
       );
     });
 


### PR DESCRIPTION
## Description
EDS [doesn't support](https://discord.com/channels/1131492224371277874/1144495462255185971/1214164790822567936) fetching cross consumer content. We proxy content through the CDN to maintain a good authoring and developers experience.
- **localhost, .hlx.page, .hlx.live:** fetch from www.(stage.)adobe.com (might require VPN)
- **stage/prod:** fetch from (bacom|milo|blog|www).(stage.)adobe.com

## Related Issue
Resolves: [MWPW-143811](https://jira.corp.adobe.com/browse/MWPW-143811)

## Testing instructions
- Be on VPN
- Log in on a consumer page that uses federal content
- See the federal nav popping up, without further authentication 

Regression links
- https://milo.stage.adobe.com/drafts/osahin/gnav-1?martech=off#
- https://milo.adobe.com/drafts/osahin/gnav-1?martech=off# 

## Test URLs
**Milo hlx.page now fetches content from stage.adobe.com**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/gnav-1
- After: https://mwpw-143811--milo--mokimo.hlx.page/drafts/osahin/gnav-1

**Milo hlx.live should fetch content from hlx.live** 
- Before: https://main--milo--adobecom.hlx.live/drafts/osahin/gnav-1
- After: https://mwpw-143811--milo--mokimo.hlx.live/drafts/osahin/gnav-1

