### PR TITLE
MWPW-141842 custom aem gnav (Express Migration)

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -669,7 +669,7 @@ body {
   opacity: 1 !important; /* Fix Target hiding */
 }
 
-header:not(.global-navigation) {
+header:not(.global-navigation, .custom-header) {
   height: 57px;
   position: fixed;
   top: 0;
@@ -681,11 +681,11 @@ header:not(.global-navigation) {
   box-sizing: border-box;
 }
 
-header:not(.global-navigation) nav {
+header:not(.global-navigation, .custom-header) nav {
   display: none;
 }
 
-header:not(.global-navigation) ~ main {
+header:not(.global-navigation, .custom-header) ~ main {
   margin-top: 57px;
 }
 
@@ -871,25 +871,25 @@ a.static:hover {
 
 /* tablet large up */
 @media (min-width: 900px) {
-  header:not(.global-navigation) {
+  header:not(.global-navigation, .custom-header) {
     min-height: var(--global-height-nav);
     border-bottom: 1px solid #EAEAEA;
     overflow: unset;
   }
 
-  header:not(.global-navigation) ~ main {
+  header:not(.global-navigation, .custom-header) ~ main {
     margin-top: 64px;
   }
 
-  header:not(.global-navigation).has-breadcrumbs {
+  header:not(.global-navigation, .custom-header).has-breadcrumbs {
     min-height: 97px;
   }
 
-  header:not(.global-navigation) nav {
+  header:not(.global-navigation, .custom-header) nav {
     display: unset;
   }
 
-  header:not(.global-navigation).has-breadcrumbs + main {
+  header:not(.global-navigation, .custom-header).has-breadcrumbs + main {
     margin-top: 97px;
   }
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -133,7 +133,7 @@ ENVS.local = {
   name: 'local',
 };
 
-export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
+export const MILO_EVENTS = { DEFERRED: 'milo:deferred', LCP_LOADED: 'milo:LCP:loaded' };
 
 const LANGSTORE = 'langstore';
 const PAGE_URL = new URL(window.location.href);
@@ -663,6 +663,10 @@ function decorateDefaults(el) {
 function decorateHeader() {
   const header = document.querySelector('header');
   if (!header) return;
+  if (getMetadata('custom-header') === 'on') {
+    header.classList.add('custom-header');
+    return;
+  }
   const headerMeta = getMetadata('header');
   if (headerMeta === 'off') {
     document.body.classList.add('nav-off');
@@ -705,6 +709,10 @@ async function decoratePlaceholders(area, config) {
 async function loadFooter() {
   const footer = document.querySelector('footer');
   if (!footer) return;
+  if (getMetadata('custom-footer') === 'on') {
+    footer.classList.add('custom-footer');
+    return;
+  }
   const footerMeta = getMetadata('footer');
   if (footerMeta === 'off') {
     footer.remove();
@@ -888,6 +896,7 @@ async function checkForPageMods() {
 }
 
 async function loadPostLCP(config) {
+  window.dispatchEvent(new Event(MILO_EVENTS.LCP_LOADED));
   const georouting = getMetadata('georouting') || config.geoRouting;
   if (georouting === 'on') {
     const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
@@ -895,7 +904,7 @@ async function loadPostLCP(config) {
   }
   loadMartech();
   const header = document.querySelector('header');
-  if (header) {
+  if (header && !header.classList.contains('custom-header')) {
     header.classList.add('gnav-hide');
     await loadBlock(header);
     header.classList.remove('gnav-hide');

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -133,7 +133,7 @@ ENVS.local = {
   name: 'local',
 };
 
-export const MILO_EVENTS = { DEFERRED: 'milo:deferred', LCP_LOADED: 'milo:LCP:loaded' };
+export const MILO_EVENTS = { DEFERRED: 'milo:deferred', LCP_LOADED: 'milo:LCP:loaded', POST_SECTION_LOADING: 'milo:postSection:loading' };
 
 const LANGSTORE = 'langstore';
 const PAGE_URL = new URL(window.location.href);
@@ -1011,6 +1011,7 @@ function decorateDocumentExtras() {
 }
 
 async function documentPostSectionLoading(config) {
+  window.dispatchEvent(new Event(MILO_EVENTS.POST_SECTION_LOADING));
   decorateFooterPromo();
 
   const appendage = getMetadata('title-append');


### PR DESCRIPTION
Express is migrating to milo, but will be using the current AEM gnav until at least next year. For more information see the timeline [here](https://wiki.corp.adobe.com/display/adobedotcom/Timeline). It therefore needs to be possible to have a milo college project using the old gnav, while we're transitioning. 

Resolves: [MWPW-141842](https://jira.corp.adobe.com/browse/MWPW-141842), [MWPW-142878](https://jira.corp.adobe.com/browse/MWPW-142878)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://vhargrave-MWPW-141842-aem-gnav-express--milo--adobecom.hlx.page/?martech=off

**New Express Project we're migrating blocks for**
- Before: https://main--express-milo--adobecom.hlx.page/express/create/instagram-story?martech=off
- After: https://main--express-milo--adobecom.hlx.page/express/create/instagram-story?milolibs=vhargrave-MWPW-141842-aem-gnav-express

