### PR TITLE
MWPW-130939 - [Milo Loc v2] Find Nested Fragments

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -56,18 +56,18 @@ async function findPageFragments(path) {
 }
 
 async function findDeepFragments(path) {
-  const deepFragments = await findPageFragments(path);
-  if (!deepFragments) return [];
   const searched = [];
-  while (deepFragments.length !== searched.length) {
-    const search = deepFragments.filter((frag) => !searched.includes(frag.pathname));
-    for (const fragment of search) {
-      const nested = await findPageFragments(fragment.pathname);
-      searched.push(fragment.pathname);
-      if (nested && nested.length) deepFragments.push(...nested);
+  const fragments = await findPageFragments(path);
+  if (!fragments) return [];
+  while (fragments.length !== searched.length) {
+    const needsSearch = fragments.filter((fragment) => !searched.includes(fragment.pathname));
+    for (const search of needsSearch) {
+      const nestedFragments = await findPageFragments(search.pathname);
+      if (nestedFragments?.length) fragments.push(...nestedFragments);
+      searched.push(search.pathname);
     }
   }
-  return deepFragments.length ? getUrls(deepFragments) : [];
+  return fragments.length ? getUrls(fragments) : [];
 }
 
 export async function findFragments() {


### PR DESCRIPTION
**_As a web producer, we need to allow all nested fragments to be added to LOC pages on a single click._**

**Solution:**
For each url configured in a project, when the `Find Fragments` button is clicked that event will execute a function that will search each fragment for nested fragments, levels deep, until all fragments are found.

**Testing:**
Test this functionality locally by checking out this branch and running `aem up`.
1. Create a new loc v2 project in sharepoint and add test URL (https://main--milo--adobecom.hlx.page/drafts/sarchibeque/find-fragments-test) or add your own page with nested fragments.
2. Finish configuration of loc project.
3. Open loc v2 project and copy pathname to localhost instance to run the new code locally.
4. Click `Find Fragments` after the project has loaded.
5. Should return exactly 5 fragments paths (two of them being fragments nested within fragments) and add them to the excel file. Clicking `find fragments` again should return 0 fragments.

Resolves: [MWPW-130939](https://jira.corp.adobe.com/browse/MWPW-130939)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/find-fragments-test?martech=off
- After: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/find-fragments-test?martech=off
