### PR TITLE
[MILO][MEP] Update Manifest Type and Manifest Ordering v2

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -217,7 +217,7 @@ const consolidateObjects = (arr, prop) => arr.reduce((propMap, item) => {
   return propMap;
 }, {});
 
-const matchGlob = (searchStr, inputStr) => {
+export const matchGlob = (searchStr, inputStr) => {
   const pattern = searchStr.replace(/\*\*/g, '.*');
   const reg = new RegExp(`^${pattern}$`, 'i'); // devtool bug needs this backtick: `
   return reg.test(inputStr);

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -56,7 +56,7 @@ export const appendJsonExt = (path) => (path.endsWith('.json') ? path : `${path}
 export const normalizePath = (p) => {
   let path = p;
 
-  if (!path.includes('/')) {
+  if (!path?.includes('/')) {
     return path;
   }
 
@@ -480,6 +480,7 @@ export async function getPersConfig(info) {
     disabled,
     event,
   } = info;
+  if (disabled) return false;
   let data = manifestData;
   if (!data) {
     const fetchedData = await fetchData(manifestPath, DATA_TYPE.JSON);
@@ -606,6 +607,7 @@ function compareExecutionOrder(a, b) {
 export function cleanAndSortManifestList(manifests) {
   const manifestObj = {};
   manifests.forEach((manifest) => {
+    if (!manifest) return;
     manifest.manifestPath = normalizePath(manifest.manifestUrl || manifest.manifest);
     if (manifest.manifestPath in manifestObj) {
       let fullManifest = manifestObj[manifest.manifestPath];

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -33,7 +33,7 @@ const COLUMN_NOT_OPERATOR = 'not';
 const TARGET_EXP_PREFIX = 'target-';
 const PAGE_URL = new URL(window.location.href);
 
-export const NON_TRACKED_MANIFEST_TYPE = 'test or promo';
+export const TRACKED_MANIFEST_TYPE = 'personalization';
 
 // Replace any non-alpha chars except comma, space, ampersand and hyphen
 const RE_KEY_REPLACE = /[^a-z0-9\- _,&=]/g;
@@ -650,7 +650,7 @@ export async function applyPers(manifests) {
 
   for (const experiment of experiments) {
     if (experiment.disabled && !override) {
-      experiments.push(createDefaultExperiment(experiment));
+      results.push(createDefaultExperiment(experiment));
     } else {
       const result = await runPersonalization(experiment, config);
       if (result) {
@@ -665,7 +665,7 @@ export async function applyPers(manifests) {
   config.expBlocks = consolidateObjects(results, 'blocks');
   config.expFragments = consolidateObjects(results, 'fragments');
 
-  const pznList = results.filter((r) => (r.experiment.manifestType !== NON_TRACKED_MANIFEST_TYPE));
+  const pznList = results.filter((r) => (r.experiment?.manifestType === TRACKED_MANIFEST_TYPE));
   if (!pznList.length) return;
 
   const pznVariants = pznList.map((r) => {

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -219,7 +219,7 @@ const consolidateObjects = (arr, prop) => arr.reduce((propMap, item) => {
 
 export const matchGlob = (searchStr, inputStr) => {
   const pattern = searchStr.replace(/\*\*/g, '.*');
-  const reg = new RegExp(`^${pattern}$`, 'i'); // devtool bug needs this backtick: `
+  const reg = new RegExp(`^${pattern}(\\.html)?$`, 'i'); // devtool bug needs this backtick: `
   return reg.test(inputStr);
 };
 

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -417,7 +417,7 @@ async function getPersonalizationVariant(manifestPath, variantNames = [], varian
   if (config.mep?.override) {
     let manifest;
     /* c8 ignore start */
-    config.mep?.override?.split(',').some((item) => {
+    config.mep?.override?.split('---').some((item) => {
       const pair = item.trim().split('--');
       if (pair[0] === manifestPath && pair.length > 1) {
         [, manifest] = pair;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -634,6 +634,24 @@ const createDefaultExperiment = (manifest) => ({
   selectedVariant: { commands: [], fragments: [] },
 });
 
+export function handleFragmentCommand(command, a) {
+  const config = getConfig();
+  const { action, fragment, manifestPath } = command;
+  if (action === 'replace') {
+    a.href = fragment;
+    if (config.mep.preview) a.dataset.manifestId = manifestPath;
+    return fragment;
+  }
+  if (action === 'remove') {
+    if (config.mep.preview) {
+      a.parentElement.dataset.removedManifestId = manifestPath;
+    } else {
+      a.parentElement.remove();
+    }
+  }
+  return false;
+}
+
 export async function applyPers(manifests) {
   const config = getConfig();
 
@@ -678,20 +696,5 @@ export async function applyPers(manifests) {
   });
   if (!config?.mep) config.mep = {};
   config.mep.martech = `|${pznVariants.join('--')}|${pznManifests.join('--')}`;
-  config.mep.handleFragmentCommand = (command, a) => {
-    const { action, fragment, manifestPath } = command;
-    if (action === 'replace') {
-      a.href = fragment;
-      if (config.mep.preview) a.dataset.manifestId = manifestPath;
-      return fragment;
-    }
-    if (action === 'remove') {
-      if (config.mep.preview) {
-        a.parentElement.dataset.removedManifestId = manifestPath;
-      } else {
-        a.parentElement.remove();
-      }
-    }
-    return false;
-  };
+  config.mep.handleFragmentCommand = handleFragmentCommand;
 }

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -1,5 +1,5 @@
 import { createTag, getConfig, getMetadata, loadStyle, MILO_EVENTS } from '../../utils/utils.js';
-import { NON_TRACKED_MANIFEST_TYPE, getFileName } from './personalization.js';
+import { TRACKED_MANIFEST_TYPE, getFileName } from './personalization.js';
 
 function updatePreviewButton() {
   const selectedInputs = document.querySelectorAll(
@@ -180,7 +180,7 @@ function createPreviewPill(manifests) {
         <p>On: ${manifest.event.start?.toLocaleString()}</p>
          <p>Off: ${manifest.event.end?.toLocaleString()}</p>` : '';
     let analyticsTitle = '';
-    if (manifestType === NON_TRACKED_MANIFEST_TYPE) {
+    if (manifestType === TRACKED_MANIFEST_TYPE) {
       analyticsTitle = 'N/A for this manifest type';
     } else if (manifestOverrideName) {
       analyticsTitle = manifestOverrideName;

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -28,7 +28,7 @@ function updatePreviewButton() {
   });
 
   const simulateHref = new URL(window.location.href);
-  simulateHref.searchParams.set('mep', manifestParameter.join(','));
+  simulateHref.searchParams.set('mep', manifestParameter.join('---'));
 
   const mepHighlightCheckbox = document.querySelector(
     '.mep-popup input[type="checkbox"]#mepHighlightCheckbox',
@@ -203,7 +203,7 @@ function createPreviewPill(manifests) {
   const personalizationOn = getMetadata('personalization');
   const personalizationOnText = personalizationOn && personalizationOn !== '' ? 'on' : 'off';
   const simulateHref = new URL(window.location.href);
-  simulateHref.searchParams.set('manifest', manifestParameter.join(','));
+  simulateHref.searchParams.set('manifest', manifestParameter.join('---'));
 
   const config = getConfig();
   let mepHighlightChecked = '';

--- a/test/features/personalization/actions.test.js
+++ b/test/features/personalization/actions.test.js
@@ -3,7 +3,7 @@ import { readFile } from '@web/test-runner-commands';
 import { stub } from 'sinon';
 import { getConfig, loadBlock } from '../../../libs/utils/utils.js';
 import initFragments from '../../../libs/blocks/fragment/fragment.js';
-import { applyPers } from '../../../libs/features/personalization/personalization.js';
+import { applyPers, handleFragmentCommand } from '../../../libs/features/personalization/personalization.js';
 
 document.head.innerHTML = await readFile({ path: './mocks/metadata.html' });
 document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
@@ -11,6 +11,7 @@ document.body.innerHTML = await readFile({ path: './mocks/personalization.html' 
 // Add custom keys so tests doesn't rely on real data
 const config = getConfig();
 config.env = { name: 'prod' };
+config.mep = { handleFragmentCommand };
 
 const getFetchPromise = (data, type = 'json') => new Promise((resolve) => {
   resolve({
@@ -174,6 +175,7 @@ describe('remove action', () => {
     config.mep = {
       override: '',
       preview: true,
+      handleFragmentCommand,
     };
 
     expect(document.querySelector('.z-pattern')).to.not.be.null;

--- a/test/features/personalization/cleanAndSortManifestList.test.js
+++ b/test/features/personalization/cleanAndSortManifestList.test.js
@@ -24,6 +24,17 @@ describe('Functional test', () => {
     expect(selectedVariant.commands[0].target).to.include('fresh-from-json-version');
   });
 
+  it('Duplicate manifests in reverse order, Target version is updated', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestLists/two-duplicate-manifests-other-one-from-target.json' });
+    manifestJson = JSON.parse(manifestJson);
+    const manifestList = cleanAndSortManifestList(manifestJson);
+    const [first] = manifestList;
+    const { name, selectedVariantName, selectedVariant } = first;
+    expect(name).to.equal('MILO0013b - use fresh manifest over saved');
+    expect(selectedVariantName).to.equal('all');
+    expect(selectedVariant.commands[0].target).to.include('fresh-from-json-version');
+  });
+
   it('One of each, all normal', async () => {
     let manifestJson = await readFile({ path: './mocks/manifestLists/three-manifest-types-all-normal.json' });
     manifestJson = JSON.parse(manifestJson);

--- a/test/features/personalization/cleanAndSortManifestList.test.js
+++ b/test/features/personalization/cleanAndSortManifestList.test.js
@@ -1,0 +1,76 @@
+import { expect } from '@esm-bundle/chai';
+import { readFile } from '@web/test-runner-commands';
+import { cleanAndSortManifestList } from '../../../libs/features/personalization/personalization.js';
+
+// Note that the manifestPath doesn't matter as we stub the fetch
+describe('Functional test', () => {
+  it('Pzn before test, even when test is from Target', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestLists/two-manifests-one-from-target.json' });
+    manifestJson = JSON.parse(manifestJson);
+    const manifestList = cleanAndSortManifestList(manifestJson);
+    const [first, second] = manifestList;
+    expect(first.manifestUrl).to.include('pzn-normal.json');
+    expect(second.manifestUrl).to.include('test-normal.json');
+  });
+
+  it('Duplicate manifests, Target version is updated', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestLists/two-duplicate-manifests-one-from-target.json' });
+    manifestJson = JSON.parse(manifestJson);
+    const manifestList = cleanAndSortManifestList(manifestJson);
+    const [first] = manifestList;
+    const { name, selectedVariantName, selectedVariant } = first;
+    expect(name).to.equal('MILO0013b - use fresh manifest over saved');
+    expect(selectedVariantName).to.equal('all');
+    expect(selectedVariant.commands[0].target).to.include('fresh-from-json-version');
+  });
+
+  it('One of each, all normal', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestLists/three-manifest-types-all-normal.json' });
+    manifestJson = JSON.parse(manifestJson);
+    const manifestList = cleanAndSortManifestList(manifestJson);
+    const [first, second, third] = manifestList;
+    expect(first.manifestUrl).to.include('pzn-normal.json');
+    expect(second.manifestUrl).to.include('promo-normal.json');
+    expect(third.manifestUrl).to.include('test-normal.json');
+  });
+
+  it('One of each, promo is first and rest are normal', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestLists/three-manifest-types-one-first.json' });
+    manifestJson = JSON.parse(manifestJson);
+    const manifestList = cleanAndSortManifestList(manifestJson);
+    const [first, second, third] = manifestList;
+    expect(first.manifestUrl).to.include('promo-first.json');
+    expect(second.manifestUrl).to.include('pzn-normal.json');
+    expect(third.manifestUrl).to.include('test-normal.json');
+  });
+
+  it('One of each, promo is last and rest are normal', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestLists/three-manifest-types-one-last.json' });
+    manifestJson = JSON.parse(manifestJson);
+    const manifestList = cleanAndSortManifestList(manifestJson);
+    const [first, second, third] = manifestList;
+    expect(first.manifestUrl).to.include('pzn-normal.json');
+    expect(second.manifestUrl).to.include('test-normal.json');
+    expect(third.manifestUrl).to.include('promo-last.json');
+  });
+
+  it('One of each, promo is deprecated "Test or Promo" and rest are normal', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestLists/three-manifest-types-one-test-or-promo.json' });
+    manifestJson = JSON.parse(manifestJson);
+    const manifestList = cleanAndSortManifestList(manifestJson);
+    const [first, second, third] = manifestList;
+    expect(first.manifestUrl).to.include('pzn-normal.json');
+    expect(second.manifestUrl).to.include('test-or-promo.json');
+    expect(third.manifestUrl).to.include('test-normal.json');
+  });
+
+  it('One of each, promo has no type and rest are normal', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestLists/three-manifest-types-one-no-type.json' });
+    manifestJson = JSON.parse(manifestJson);
+    const manifestList = cleanAndSortManifestList(manifestJson);
+    const [first, second, third] = manifestList;
+    expect(first.manifestUrl).to.include('pzn-normal.json');
+    expect(second.manifestUrl).to.include('none.json');
+    expect(third.manifestUrl).to.include('test-normal.json');
+  });
+});

--- a/test/features/personalization/deprecatedActions.test.js
+++ b/test/features/personalization/deprecatedActions.test.js
@@ -3,7 +3,7 @@ import { readFile } from '@web/test-runner-commands';
 import { stub } from 'sinon';
 import { getConfig } from '../../../libs/utils/utils.js';
 import initFragments from '../../../libs/blocks/fragment/fragment.js';
-import { applyPers } from '../../../libs/features/personalization/personalization.js';
+import { applyPers, handleFragmentCommand } from '../../../libs/features/personalization/personalization.js';
 
 document.head.innerHTML = await readFile({ path: './mocks/metadata.html' });
 document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
@@ -25,6 +25,7 @@ describe('Functional Test', () => {
     // Add custom keys so tests doesn't rely on real data
     const config = getConfig();
     config.env = { name: 'prod' };
+    config.mep = { handleFragmentCommand };
   });
 
   it('replaceContent should replace an element with a fragment', async () => {

--- a/test/features/personalization/mocks/manifestLists/three-manifest-types-all-normal.json
+++ b/test/features/personalization/mocks/manifestLists/three-manifest-types-all-normal.json
@@ -1,0 +1,116 @@
+[
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/promo",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "promo",
+      "executionOrder": "1-1",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/promo",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/promo-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/promo-normal.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "test",
+      "executionOrder": "1-2",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "personalization",
+      "executionOrder": "1-0",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json"
+  }
+]

--- a/test/features/personalization/mocks/manifestLists/three-manifest-types-one-first.json
+++ b/test/features/personalization/mocks/manifestLists/three-manifest-types-one-first.json
@@ -1,0 +1,116 @@
+[
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "test",
+      "executionOrder": "1-2",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/promo",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "promo",
+      "executionOrder": "0-1",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/promo",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/promo-first.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/promo-first.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "personalization",
+      "executionOrder": "1-0",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json"
+  }
+]

--- a/test/features/personalization/mocks/manifestLists/three-manifest-types-one-last.json
+++ b/test/features/personalization/mocks/manifestLists/three-manifest-types-one-last.json
@@ -1,0 +1,116 @@
+[
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "test",
+      "executionOrder": "1-2",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/promo",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "promo",
+      "executionOrder": "2-1",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/promo",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/promo-last.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/promo-last.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "personalization",
+      "executionOrder": "1-0",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json"
+  }
+]

--- a/test/features/personalization/mocks/manifestLists/three-manifest-types-one-no-type.json
+++ b/test/features/personalization/mocks/manifestLists/three-manifest-types-one-no-type.json
@@ -1,0 +1,114 @@
+[
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/none",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "executionOrder": "1-1",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/none",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/none.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/none.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "test",
+      "executionOrder": "1-2",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "personalization",
+      "executionOrder": "1-0",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json"
+  }
+]

--- a/test/features/personalization/mocks/manifestLists/three-manifest-types-one-test-or-promo.json
+++ b/test/features/personalization/mocks/manifestLists/three-manifest-types-one-test-or-promo.json
@@ -1,0 +1,116 @@
+[
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test-or-promo",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "test or promo",
+      "executionOrder": "1-1",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test-or-promo",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-or-promo.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-or-promo.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "test",
+      "executionOrder": "1-2",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "personalization",
+      "executionOrder": "1-0",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json"
+  }
+]

--- a/test/features/personalization/mocks/manifestLists/two-duplicate-manifests-one-from-target.json
+++ b/test/features/personalization/mocks/manifestLists/two-duplicate-manifests-one-from-target.json
@@ -1,0 +1,79 @@
+[
+    {
+        "variants": {
+            "all": {
+                "commands": [
+                    {
+                        "action": "appendtosection",
+                        "selector": "section1",
+                        "pageFilter": "",
+                        "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/in-target-version",
+                        "selectorType": "css"
+                    }
+                ],
+                "fragments": []
+            }
+        },
+        "variantNames": [
+            "all"
+        ],
+        "manifestOverrideName": "",
+        "manifestType": "personalization",
+        "executionOrder": "1-0",
+        "run": true,
+        "selectedVariantName": "all",
+        "selectedVariant": {
+            "commands": [
+                {
+                    "action": "appendtosection",
+                    "selector": "section1",
+                    "pageFilter": "",
+                    "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/in-target-version",
+                    "selectorType": "css"
+                }
+            ],
+            "fragments": []
+        },
+        "name": "MILO0013b - use fresh manifest over saved",
+        "manifest": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/outdated-manifest.json",
+        "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/outdated-manifest.json"
+    },
+    {
+        "variants": {
+            "all": {
+                "commands": [
+                    {
+                        "action": "appendtosection",
+                        "selector": "section1",
+                        "pageFilter": "",
+                        "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/fresh-from-json-version",
+                        "selectorType": "css"
+                    }
+                ],
+                "fragments": []
+            }
+        },
+        "variantNames": [
+            "all"
+        ],
+        "manifestOverrideName": "",
+        "manifestType": "personalization",
+        "executionOrder": "1-0",
+        "run": true,
+        "selectedVariantName": "all",
+        "selectedVariant": {
+            "commands": [
+                {
+                    "action": "appendtosection",
+                    "selector": "section1",
+                    "pageFilter": "",
+                    "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/fresh-from-json-version",
+                    "selectorType": "css"
+                }
+            ],
+            "fragments": []
+        },
+        "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/outdated-manifest.json",
+        "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/outdated-manifest.json"
+    }
+]

--- a/test/features/personalization/mocks/manifestLists/two-duplicate-manifests-other-one-from-target.json
+++ b/test/features/personalization/mocks/manifestLists/two-duplicate-manifests-other-one-from-target.json
@@ -1,0 +1,79 @@
+[
+    {
+        "variants": {
+            "all": {
+                "commands": [
+                    {
+                        "action": "appendtosection",
+                        "selector": "section1",
+                        "pageFilter": "",
+                        "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/fresh-from-json-version",
+                        "selectorType": "css"
+                    }
+                ],
+                "fragments": []
+            }
+        },
+        "variantNames": [
+            "all"
+        ],
+        "manifestOverrideName": "",
+        "manifestType": "personalization",
+        "executionOrder": "1-0",
+        "run": true,
+        "selectedVariantName": "all",
+        "selectedVariant": {
+            "commands": [
+                {
+                    "action": "appendtosection",
+                    "selector": "section1",
+                    "pageFilter": "",
+                    "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/fresh-from-json-version",
+                    "selectorType": "css"
+                }
+            ],
+            "fragments": []
+        },
+        "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/outdated-manifest.json",
+        "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/outdated-manifest.json"
+    },
+    {
+        "variants": {
+            "all": {
+                "commands": [
+                    {
+                        "action": "appendtosection",
+                        "selector": "section1",
+                        "pageFilter": "",
+                        "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/in-target-version",
+                        "selectorType": "css"
+                    }
+                ],
+                "fragments": []
+            }
+        },
+        "variantNames": [
+            "all"
+        ],
+        "manifestOverrideName": "",
+        "manifestType": "personalization",
+        "executionOrder": "1-0",
+        "run": true,
+        "selectedVariantName": "all",
+        "selectedVariant": {
+            "commands": [
+                {
+                    "action": "appendtosection",
+                    "selector": "section1",
+                    "pageFilter": "",
+                    "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/in-target-version",
+                    "selectorType": "css"
+                }
+            ],
+            "fragments": []
+        },
+        "name": "MILO0013b - use fresh manifest over saved",
+        "manifest": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/outdated-manifest.json",
+        "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/outdated-manifest.json"
+    }
+]

--- a/test/features/personalization/mocks/manifestLists/two-manifests-one-from-target.json
+++ b/test/features/personalization/mocks/manifestLists/two-manifests-one-from-target.json
@@ -1,0 +1,79 @@
+[
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "test",
+      "executionOrder": "1-2",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "name": "MILO0013 - manifest order",
+      "manifest": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json"
+  },
+  {
+      "variants": {
+          "all": {
+              "commands": [
+                  {
+                      "action": "appendtosection",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
+          }
+      },
+      "variantNames": [
+          "all"
+      ],
+      "manifestOverrideName": "",
+      "manifestType": "personalization",
+      "executionOrder": "1-0",
+      "run": true,
+      "selectedVariantName": "all",
+      "selectedVariant": {
+          "commands": [
+              {
+                  "action": "appendtosection",
+                  "selector": "section1",
+                  "pageFilter": "",
+                  "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
+                  "selectorType": "css"
+              }
+          ],
+          "fragments": []
+      },
+      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
+      "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json"
+  }
+]

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -2,7 +2,8 @@ import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
 import { stub } from 'sinon';
 import { getConfig, setConfig } from '../../../libs/utils/utils.js';
-import { applyPers, matchGlob } from '../../../libs/features/personalization/personalization.js';
+// import { applyPers, matchGlob } from '../../../libs/features/personalization/personalization.js';
+import { applyPers } from '../../../libs/features/personalization/personalization.js';
 
 document.head.innerHTML = await readFile({ path: './mocks/metadata.html' });
 document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
@@ -112,24 +113,24 @@ describe('Functional Test', () => {
   });
 });
 
-describe('matchGlob function', () => {
-  it('should match page', async () => {
-    const result = matchGlob('/products/special-offers', '/products/special-offers');
-    expect(result).to.be.true;
-  });
+// describe('matchGlob function', () => {
+//   it('should match page', async () => {
+//     const result = matchGlob('/products/special-offers', '/products/special-offers');
+//     expect(result).to.be.true;
+//   });
 
-  it('should match page with HTML extension', async () => {
-    const result = matchGlob('/products/special-offers', '/products/special-offers.html');
-    expect(result).to.be.true;
-  });
+//   it('should match page with HTML extension', async () => {
+//     const result = matchGlob('/products/special-offers', '/products/special-offers.html');
+//     expect(result).to.be.true;
+//   });
 
-  it('should not match child page', async () => {
-    const result = matchGlob('/products/special-offers', '/products/special-offers/free-download');
-    expect(result).to.be.false;
-  });
+//   it('should not match child page', async () => {
+//     const result = matchGlob('/products/special-offers', '/products/special-offers/free-download');
+//     expect(result).to.be.false;
+//   });
 
-  it('should match child page', async () => {
-    const result = matchGlob('/products/special-offers**', '/products/special-offers/free-download');
-    expect(result).to.be.true;
-  });
-});
+//   it('should match child page', async () => {
+//     const result = matchGlob('/products/special-offers**', '/products/special-offers/free-download');
+//     expect(result).to.be.true;
+//   });
+// });

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -2,8 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
 import { stub } from 'sinon';
 import { getConfig, setConfig } from '../../../libs/utils/utils.js';
-// import { applyPers, matchGlob } from '../../../libs/features/personalization/personalization.js';
-import { applyPers } from '../../../libs/features/personalization/personalization.js';
+import { applyPers, matchGlob } from '../../../libs/features/personalization/personalization.js';
 
 document.head.innerHTML = await readFile({ path: './mocks/metadata.html' });
 document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
@@ -113,24 +112,24 @@ describe('Functional Test', () => {
   });
 });
 
-// describe('matchGlob function', () => {
-//   it('should match page', async () => {
-//     const result = matchGlob('/products/special-offers', '/products/special-offers');
-//     expect(result).to.be.true;
-//   });
+describe('matchGlob function', () => {
+  it('should match page', async () => {
+    const result = matchGlob('/products/special-offers', '/products/special-offers');
+    expect(result).to.be.true;
+  });
 
-//   it('should match page with HTML extension', async () => {
-//     const result = matchGlob('/products/special-offers', '/products/special-offers.html');
-//     expect(result).to.be.true;
-//   });
+  it('should match page with HTML extension', async () => {
+    const result = matchGlob('/products/special-offers', '/products/special-offers.html');
+    expect(result).to.be.false;
+  });
 
-//   it('should not match child page', async () => {
-//     const result = matchGlob('/products/special-offers', '/products/special-offers/free-download');
-//     expect(result).to.be.false;
-//   });
+  it('should not match child page', async () => {
+    const result = matchGlob('/products/special-offers', '/products/special-offers/free-download');
+    expect(result).to.be.false;
+  });
 
-//   it('should match child page', async () => {
-//     const result = matchGlob('/products/special-offers**', '/products/special-offers/free-download');
-//     expect(result).to.be.true;
-//   });
-// });
+  it('should match child page', async () => {
+    const result = matchGlob('/products/special-offers**', '/products/special-offers/free-download');
+    expect(result).to.be.true;
+  });
+});

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -120,7 +120,7 @@ describe('matchGlob function', () => {
 
   it('should match page with HTML extension', async () => {
     const result = matchGlob('/products/special-offers', '/products/special-offers.html');
-    expect(result).to.be.false;
+    expect(result).to.be.true;
   });
 
   it('should not match child page', async () => {

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -185,6 +185,7 @@ describe('preview feature', () => {
     expect(document.querySelector('input#mepHighlightCheckbox').getAttribute('checked')).to.equal('checked');
   });
   it('updates preview button', () => {
+    expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.contain('---');
     document.querySelector('#new-manifest').value = 'https://main--homepage--adobecom.hlx.live/homepage/fragments/mep/new-manifest.json';
     document.querySelector('input[name="/homepage/fragments/mep/selected-example.json"][value="default"]').click();
     expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.contain('new-manifest.json');
@@ -193,6 +194,7 @@ describe('preview feature', () => {
     expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.not.contain('mepHighlight');
     document.querySelector('input#mepPreviewButtonCheckbox').click();
     expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.contain('mepButton=off');
+    expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.contain('---');
   });
   it('opens manifest', () => {
     document.querySelector('a.mep-edit-manifest').click();

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -607,7 +607,7 @@ describe('Utils', () => {
       const resultConfig = utils.getConfig();
       const resultExperiment = resultConfig.experiments[0];
       expect(resultConfig.mep.preview).to.be.true;
-      expect(resultConfig.experiments.length).to.equal(3);
+      expect(resultConfig.experiments.length).to.equal(1);
       expect(resultExperiment.manifest).to.equal('/products/special-offers-manifest.json');
     });
   });

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -605,9 +605,9 @@ describe('Utils', () => {
       document.head.innerHTML = await readFile({ path: './mocks/head-personalization.html' });
       await utils.loadArea();
       const resultConfig = utils.getConfig();
-      const resultExperiment = resultConfig.experiments[0];
+      const resultExperiment = resultConfig.experiments[2];
       expect(resultConfig.mep.preview).to.be.true;
-      expect(resultConfig.experiments.length).to.equal(1);
+      expect(resultConfig.experiments.length).to.equal(3);
       expect(resultExperiment.manifest).to.equal('/products/special-offers-manifest.json');
     });
   });


### PR DESCRIPTION
Redoing the PR.  At some point file changes that weren't mine were being counted as my file updates.

Problem statement: The current order that MEP executes manifests is based on the source of the manifest. Instead, we need to use the manifest type to be sure that the manifests execute in a logical order. 

Requirements:
- Separate Manifest Type "Test or Promo" into 2 separate items in the dropdown.
- Add a Manifest Execution Order, default value "normal", other values "first" and "last"
- Manifest order will first be determined the the manifest execution order field: first, normal then last.
- If there is more than one manifest of the same "execution order", the manifest type will break the tie. First Personalization, Promo then Test.

Note: previously, we would:
1. run `cleanManifestList` to remove duplicates
2. loop through the manifests
3. fire `runPersonalization` for each manifest
4. within `runPersonalization` we would fire `getPersConfig` to get manifest contents

Because we now need to know the contents to determine the order, we now:
1. loop through the manifests
2. fire `getPersConfig` on each manifest to get contents
3. fire `cleanAndSortManifestList` to merge duplicate manifest data and sort manifests
4. loop through the manifests in their new sorted order
5. fire `runPersonalization` for each manifest

Resolves: [MWPW-142965](https://jira.corp.adobe.com/browse/MWPW-142965)

**Test URLs:**
2 manifests (1 pzn and 1 test from Target):
Before: https://mepmoreactions--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/two-manifests-one-from-target
After: https://mepmanifestorder2--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/two-manifests-one-from-target

**A bunch of additional Test URL's to test different use cases (these are all captured by unit tests as well):**
3 manifests with one of each manifest type in the "wrong" execution order:
Before: https://mepmoreactions--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-all-normal
After: https://mepmanifestorder2--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-all-normal

Same as above but one manifest using first:
Before: https://mepmoreactions--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-one-first
After: https://mepmanifestorder2--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-one-first

Same as above but one manifest using last:
Before: https://mepmoreactions--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-one-last
After: https://mepmanifestorder2--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-one-last

Same as above but old "Test or Promo" type being used:
Before: https://mepmoreactions--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-one-test-or-promo
After: https://mepmanifestorder2--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-one-test-or-promo

Same as above but one has no info tab:
Before: https://mepmoreactions--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-one-no-type
After: https://mepmanifestorder2--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/three-manifest-types-one-no-type

Improved merge also solves: https://jira.corp.adobe.com/browse/MWPW-143068
Before: https://mepmoreactions--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/outdated-manifest
After: https://mepmanifestorder2--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/outdated-manifest