### PR TITLE
[MWPW-141050] Fetch profile for PEP

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -259,8 +259,6 @@ const convertToPascalCase = (str) => str
   .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
   .join(' ');
 
-// TODO: debate whether this should be here or in a separate file,
-// since it's not time-sensitive and we want to potentially bundle it
 // TODO: position the prompt relative to the App Switcher
 const loadAppPrompt = async () => {
   const state = getMetadata('app-prompt')?.toLowerCase();
@@ -273,20 +271,6 @@ const loadAppPrompt = async () => {
     || !entName?.length
     || !promptPath?.length) return;
 
-  const id = promptPath.split('/').pop();
-  const isDismissed = JSON.parse(document.cookie
-    .split(';')
-    .find((item) => item.trim().startsWith('dismissedAppPrompts='))
-    ?.split('=')[1] || '[]')
-    .includes(id);
-
-  if (isDismissed) return;
-
-  // const entitlements = await getConfig().entitlements();
-  const entitlements = ['photoshop']; // TODO: replace this line with the one above
-
-  if (!entitlements?.length || !entitlements.includes(entName)) return;
-
   const { base } = getConfig();
   const [
     webappPrompt,
@@ -295,7 +279,7 @@ const loadAppPrompt = async () => {
     loadStyle(`${base}/features/webapp-prompt/webapp-prompt.css`),
   ]);
 
-  webappPrompt.default({ promptPath, id });
+  webappPrompt.default({ promptPath, entName });
 };
 
 class Gnav {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -8,29 +8,30 @@ import {
   loadStyle,
 } from '../../utils/utils.js';
 import {
-  toFragment,
-  getFedsPlaceholderConfig,
-  getAnalyticsValue,
-  decorateCta,
-  getExperienceName,
-  loadDecorateMenu,
-  loadBlock,
-  loadStyles,
-  trigger,
-  setActiveDropdown,
   closeAllDropdowns,
-  loadBaseStyles,
-  yieldToMain,
+  decorateCta,
+  fetchAndProcessPlainHtml,
+  getActiveLink,
+  getAnalyticsValue,
+  getExperienceName,
+  getFedsPlaceholderConfig,
+  hasActiveLink,
   isDesktop,
   isTangentToViewport,
-  setCurtainState,
-  hasActiveLink,
-  setActiveLink,
-  getActiveLink,
-  selectors,
-  logErrorFor,
   lanaLog,
-  fetchAndProcessPlainHtml,
+  loadBaseStyles,
+  loadBlock,
+  loadDecorateMenu,
+  loadStyles,
+  logErrorFor,
+  selectors,
+  setActiveDropdown,
+  setActiveLink,
+  setCurtainState,
+  setUserProfile,
+  toFragment,
+  trigger,
+  yieldToMain,
 } from './utilities/utilities.js';
 
 import { replaceKey, replaceKeyArray } from '../../features/placeholders.js';
@@ -63,6 +64,13 @@ const CONFIG = {
             config: {
               enableLocalSection: true,
               miniAppContext: {
+                onMessage: (name, payload) => {
+                  if (name === 'System' && payload.subType === 'AppInitiated') {
+                    window.adobeProfile?.getUserProfile()
+                      .then((data) => { setUserProfile(data); })
+                      .catch(() => { setUserProfile({}); });
+                  }
+                },
                 logger: {
                   trace: () => {},
                   debug: () => {},
@@ -251,6 +259,45 @@ const convertToPascalCase = (str) => str
   .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
   .join(' ');
 
+// TODO: debate whether this should be here or in a separate file,
+// since it's not time-sensitive and we want to potentially bundle it
+// TODO: position the prompt relative to the App Switcher
+const loadAppPrompt = async () => {
+  const state = getMetadata('app-prompt')?.toLowerCase();
+  const entName = getMetadata('app-prompt-entitlement')?.toLowerCase();
+  const promptPath = getMetadata('app-prompt-path')?.toLowerCase();
+  const desktopViewport = window.matchMedia('(min-width: 900px)').matches;
+  if (state === 'off'
+    || !window.adobeIMS?.isSignedInUser()
+    || !desktopViewport
+    || !entName?.length
+    || !promptPath?.length) return;
+
+  const id = promptPath.split('/').pop();
+  const isDismissed = JSON.parse(document.cookie
+    .split(';')
+    .find((item) => item.trim().startsWith('dismissedAppPrompts='))
+    ?.split('=')[1] || '[]')
+    .includes(id);
+
+  if (isDismissed) return;
+
+  // const entitlements = await getConfig().entitlements();
+  const entitlements = ['photoshop']; // TODO: replace this line with the one above
+
+  if (!entitlements?.length || !entitlements.includes(entName)) return;
+
+  const { base } = getConfig();
+  const [
+    webappPrompt,
+  ] = await Promise.all([
+    import('../../features/webapp-prompt/webapp-prompt.js'),
+    loadStyle(`${base}/features/webapp-prompt/webapp-prompt.css`),
+  ]);
+
+  webappPrompt.default({ promptPath, id });
+};
+
 class Gnav {
   constructor({ content, block } = {}) {
     this.content = content;
@@ -420,7 +467,11 @@ class Gnav {
   };
 
   imsReady = async () => {
-    const tasks = [this.useUniversalNav ? this.decorateUniversalNav : this.decorateProfile];
+    if (!window.adobeIMS.isSignedInUser() || !this.useUniversalNav) setUserProfile({});
+
+    const tasks = this.useUniversalNav
+      ? [this.decorateUniversalNav, loadAppPrompt]
+      : [this.decorateProfile];
 
     try {
       for await (const task of tasks) {

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -322,3 +322,35 @@ export async function fetchAndProcessPlainHtml({ url, shouldDecorateLinks = true
   body.innerHTML = await replaceText(body.innerHTML, getFedsPlaceholderConfig());
   return body;
 }
+
+export const [setUserProfile, getUserProfile] = (() => {
+  let profileData;
+  let profileResolve;
+  let profileTimeout;
+
+  const profilePromise = new Promise((resolve) => {
+    profileResolve = resolve;
+
+    profileTimeout = setTimeout(() => {
+      profileData = {};
+      resolve(profileData);
+    }, 5000);
+  });
+
+  return [
+    (data) => {
+      // TODO: debate whether to reject on empty profile or just return empty object;
+      // it might be that:
+      // * acc mgmt event is not fired
+      // * acc mgmt method isn't defined/doesn't return data/throws
+      // * user is not signed in
+      // * previous profile logic is used
+      if (data && !profileData) {
+        profileData = data;
+        clearTimeout(profileTimeout);
+        profileResolve(profileData);
+      }
+    },
+    () => profilePromise,
+  ];
+})();

--- a/libs/features/personalization/entitlements.js
+++ b/libs/features/personalization/entitlements.js
@@ -1,9 +1,5 @@
 import { getConfig } from '../../utils/utils.js';
 
-// TODO: add PEP segment map here when we have it;
-// However, we need to decide if these are relevant to others or not;
-// if not, we should find a better place for them
-// and add a method to return raw segments
 const ENTITLEMENT_MAP = {
   '51b1f617-2e43-4e91-a98a-3b7716ecba8f': 'photoshop-any',
   '8ba78b22-90fb-4b97-a1c4-f8c03a45cbc2': 'indesign-any',
@@ -17,6 +13,11 @@ const ENTITLEMENT_MAP = {
   'ab713720-91a2-4e8e-b6d7-6f613e049566': 'any-cc-product-no-stock',
   'b0f65e1c-7737-4788-b3ae-0011c80bcbe1': 'any-cc-product-with-stock',
   '934fdc1d-7ba6-4644-908b-53e01e550086': 'any-dc-product',
+  // PEP segments
+  '6cb0d58c-3a65-47e2-b459-c52bb158d5b6': 'lightroom-web-usage',
+  'caa3de84-6336-4fa8-8db2-240fc88106cc': 'photoshop-web-usage',
+  '5c6a4bb8-a2f3-4202-8cca-f5e918b969dc': 'firefly-web-usage',
+  '3df0b0b0-d06e-4fcc-986e-cc97f54d04d8': 'acrobat-web-usage',
 };
 
 export const getEntitlementMap = async () => {

--- a/libs/features/personalization/stage-entitlements.js
+++ b/libs/features/personalization/stage-entitlements.js
@@ -7,6 +7,11 @@ const STAGE_ENTITLEMENTS = {
   '07609803-48a0-4762-be51-94051ccffb45': 'premiere-pro-any',
   '67129b31-eb1a-4c9e-b251-4561ac7c8602': 'any-cc-product-no-stock',
   '569f0f9d-83e8-45b4-adbf-07ef08a83398': 'any-cc-product-with-stock',
+  // PEP segments
+  '9202b767-77dc-4e6e-8d74-488d9ef08900': 'lightroom-web-usage',
+  '3a7ffcce-11b8-4242-8cdf-8c8d059ae1cd': 'photoshop-web-usage',
+  'cbe1d7ab-db7d-49cb-969e-a6a2bbe8c660': 'firefly-web-usage',
+  '96adf81f-97ca-4943-81ff-c41fbe8f3af7': 'acrobat-web-usage',
 };
 
 export default STAGE_ENTITLEMENTS;

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -60,46 +60,6 @@ export const loadGoogleLogin = async (getMetadata, loadIms, loadScript) => {
   initGoogleLogin(loadIms, getMetadata, loadScript);
 };
 
-// TODO: adapt logic to only start execution after App Switcher loads;
-// we then need to position the prompt relative to it
-export const loadAppPrompt = async (getConfig, getMetadata, loadStyle) => {
-  const state = getMetadata('app-prompt')?.toLowerCase();
-  const entName = getMetadata('app-prompt-entitlement')?.toLowerCase();
-  const promptPath = getMetadata('app-prompt-path')?.toLowerCase();
-  const desktopViewport = window.matchMedia('(min-width: 900px)').matches;
-  if (state === 'off'
-    || !window.adobeIMS?.isSignedInUser()
-    || !desktopViewport
-    || !entName?.length
-    || !promptPath?.length) return;
-
-  const id = promptPath.split('/').pop();
-  const isDismissed = JSON.parse(document.cookie
-    .split(';')
-    .find((item) => item.trim().startsWith('dismissedAppPrompts='))
-    ?.split('=')[1] || '[]')
-    .includes(id);
-
-  if (isDismissed) return;
-
-  // TODO: factor in multiple entitlements, one for app, one for web app usage?
-  // const entitlements = await getConfig().entitlements();
-  const entitlements = ['photoshop']; // TODO: replace this line with the one above
-
-  if (!entitlements?.length || !entitlements.includes(entName)) return;
-
-  const { base, env } = getConfig();
-  const profileApi = `https://${env.adobeIO}/profile`;
-  const [
-    webappPrompt,
-  ] = await Promise.all([
-    import('../features/webapp-prompt/webapp-prompt.js'),
-    loadStyle(`${base}/features/webapp-prompt/webapp-prompt.css`),
-  ]);
-
-  webappPrompt.default({ promptPath, id, profileApi });
-};
-
 /**
  * Executes everything that happens a lot later, without impacting the user experience.
  */
@@ -114,7 +74,6 @@ const loadDelayed = ([
     loadPrivacy(getConfig, loadScript);
     loadJarvisChat(getConfig, getMetadata, loadScript, loadStyle);
     loadGoogleLogin(getMetadata, loadIms, loadScript);
-    loadAppPrompt(getConfig, getMetadata, loadStyle);
     if (getMetadata('interlinks') === 'on') {
       const { locale } = getConfig();
       const path = `${locale.contentRoot}/keywords.json`;


### PR DESCRIPTION
## Description
This adapts the current PEP logic to use the new method of fetching profile data, rather than relying on IMS and cc-collab. Two new utility methods have been created, `setUserProfile` and `getUserProfile` so that the profile data can be used in other parts of the logic, if needed. `getUserProfile` will return a `Promise` that resolves as soon as data becomes available. I've decided to simply resolve with an empty object if errors are encountered or 5 seconds have passed; this is due to the number of edge cases where uncaught errors could be thrown to the console.

PEP-specific segments [1] have also been added and the logic slightly adapted to decide whether the prompt needs to be shown. Because we don't have a clear way of testing this on Milo pages, I've added some test functionality so that a `extraPepEnts` query parameter can be used to define segment names for which the user qualifies for. This, of course, will need to be removed before the final merge.

This PR is also a first step towards loading the prompt based on Universal Nav status.

[1] The segment names are `lightroom-web-usage`, `photoshop-web-usage`, `firefly-web-usage` and `acrobat-web-usage` and are defined for both production and stage environments.

## Related Issue
Resolves: [MWPW-141050](https://jira.corp.adobe.com/browse/MWPW-141050) & [MWPW-141050](https://jira.corp.adobe.com/browse/MWPW-141050)

## Testing instructions
* use VPN, load test page and log in;
* append a `extraPepEnts` query parameter to the URL, specifying the additional segments the user qualifies for, as defined in the PEP prompt content document (for example, `?extraPepEnts=photoshop,firefly-web-usage`);
* refresh the page;
* PEP prompt should load and show the user's profile;
* no network requests should be made for cc-collab.

## Test URLs
**Milo:**
- Before: https://project-pep--milo--adobecom.hlx.page/drafts/ramuntea/universal-nav?imsClientId=fedsmilo&martech=off&georouting=off
- After: https://project-pep--milo--overmyheadandbody.hlx.page/drafts/ramuntea/universal-nav?imsClientId=fedsmilo&martech=off&georouting=off
