### PR TITLE
MWPW-143145: add instant preview paramter

### DIFF
--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -177,7 +177,7 @@ function createPreviewPill(manifests) {
     const targetTitle = name ? `${name}<br><i>${manifestFileName}</i>` : manifestFileName;
     const scheduled = manifest.event
       ? `<p>Scheduled - ${manifest.disabled ? 'inactive' : 'active'}</p>
-        <p>On: ${manifest.event.start?.toLocaleString()}</p>
+         <p>On: ${manifest.event.start?.toLocaleString()} - <a target= "_blank" href="?instant=${manifest.event.start?.toISOString()}">instant</a></p>
          <p>Off: ${manifest.event.end?.toLocaleString()}</p>` : '';
     let analyticsTitle = '';
     if (manifestType === NON_TRACKED_MANIFEST_TYPE) {

--- a/libs/features/personalization/promo-utils.js
+++ b/libs/features/personalization/promo-utils.js
@@ -2,15 +2,15 @@ import { getMetadata } from '../../utils/utils.js';
 
 const GMTStringToLocalDate = (gmtString) => new Date(`${gmtString}+00:00`);
 
-export const isDisabled = (event) => {
+export const isDisabled = (event, searchParams) => {
   if (!event) return false;
-  const currentDate = new Date();
+  const currentDate = searchParams?.get('instant') ? new Date(searchParams.get('instant')) : new Date();
   if ((!event.start && event.end) || (!event.end && event.start)) return true;
   return Boolean(event.start && event.end
     && (currentDate < event.start || currentDate > event.end));
 };
 
-export default function getPromoManifests(manifestNames) {
+export default function getPromoManifests(manifestNames, searchParams) {
   const attachedManifests = manifestNames
     ? manifestNames.split(',')?.map((manifest) => manifest?.trim())
     : [];
@@ -27,7 +27,7 @@ export default function getPromoManifests(manifestNames) {
           start: GMTStringToLocalDate(start),
           end: GMTStringToLocalDate(end),
         };
-        const disabled = isDisabled(event);
+        const disabled = isDisabled(event, searchParams);
         return { manifestPath, disabled, event };
       }
       return null;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -852,7 +852,7 @@ async function checkForPageMods() {
 
   if (promoEnabled) {
     const { default: getPromoManifests } = await import('../features/personalization/promo-utils.js');
-    persManifests = persManifests.concat(getPromoManifests(promoMd));
+    persManifests = persManifests.concat(getPromoManifests(promoMd, PAGE_URL.searchParams));
   }
 
   const { env } = getConfig();

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -145,16 +145,16 @@ describe('preview feature', () => {
         disabled: false,
         event: {
           name: 'black-friday-global',
-          start: '2023-11-10T00:00:00.000Z',
-          end: '2024-11-24T00:00:00.000Z',
+          start: new Date('2023-11-10T00:00:00.000Z'),
+          end: new Date('2024-11-24T00:00:00.000Z'),
         },
       },
       {
         disabled: true,
         event: {
           name: 'cyber-monday-emea',
-          start: '2024-11-24T00:00:00.000Z',
-          end: '2024-11-24T00:00:00.000Z',
+          start: new Date('2024-11-24T00:00:00.000Z'),
+          end: new Date('2024-11-24T00:00:00.000Z'),
         },
         manifest: '/promos/2023/emea/cyber-monday/cyber-monday-emea.json',
         variantNames: [

--- a/test/features/personalization/promo-utils.test.js
+++ b/test/features/personalization/promo-utils.test.js
@@ -8,15 +8,15 @@ describe('isDisabled', () => {
       start: new Date('2000-11-01T00:00:00'),
       end: new Date('2300-11-01T00:00:00'),
     };
-    expect(isDisabled(event)).to.be.false;
+    expect(isDisabled(event, new URLSearchParams())).to.be.false;
   });
 
   it('should be enabled if no event exist', () => {
-    expect(isDisabled(null)).to.be.false;
+    expect(isDisabled(null, new URLSearchParams())).to.be.false;
   });
 
   it('should be enabled if event has no dates', () => {
-    expect(isDisabled({})).to.be.false;
+    expect(isDisabled({}, new URLSearchParams())).to.be.false;
   });
 
   it('should be disabled if current time is outside range', () => {
@@ -24,17 +24,27 @@ describe('isDisabled', () => {
       start: new Date('2300-11-01T00:00:00'),
       end: new Date('2301-11-01T00:00:00'),
     };
-    expect(isDisabled(event)).to.be.true;
+    expect(isDisabled(event, new URLSearchParams())).to.be.true;
   });
 
   it('should be disabled if no start time defined', () => {
     const event = { end: new Date('2300-11-01T00:00:00') };
-    expect(isDisabled(event)).to.be.true;
+    expect(isDisabled(event, new URLSearchParams())).to.be.true;
   });
 
   it('should be disabled if no end time defined', () => {
     const event = { start: new Date('2000-11-01T00:00:00') };
-    expect(isDisabled(event)).to.be.true;
+    expect(isDisabled(event, new URLSearchParams())).to.be.true;
+  });
+
+  it('should be enabled if current time is outside range, but instant parameter is withing the range', () => {
+    const searchParams = new URLSearchParams();
+    searchParams.append('instant', '2300-12-14T05:00:00.000Z');
+    const event = {
+      start: new Date('2300-11-01T00:00:00'),
+      end: new Date('2301-11-01T00:00:00'),
+    };
+    expect(isDisabled(event, searchParams)).to.be.false;
   });
 });
 
@@ -63,18 +73,18 @@ describe('getPromoManifests', () => {
   it('should return an array of promo manifests', async () => {
     document.head.innerHTML = await readFile({ path: './mocks/head-schedule.html' });
     const manifestNames = 'pre-black-friday-global,black-friday-global,cyber-monday';
-    expect(getPromoManifests(manifestNames)).to.deep.eq(expectedManifests);
+    expect(getPromoManifests(manifestNames, new URLSearchParams())).to.deep.eq(expectedManifests);
   });
 
   it('should return an empty array if no schedule', async () => {
     document.head.innerHTML = '';
     const manifestNames = 'pre-black-friday-global,black-friday-global,cyber-monday';
-    expect(getPromoManifests(manifestNames).length).to.be.equal(0);
+    expect(getPromoManifests(manifestNames, new URLSearchParams()).length).to.be.equal(0);
   });
 
   it('should return an empty array if no manifestnames', async () => {
     document.head.innerHTML = await readFile({ path: './mocks/head-schedule.html' });
     const manifestNames = '';
-    expect(getPromoManifests(manifestNames).length).to.be.equal(0);
+    expect(getPromoManifests(manifestNames, new URLSearchParams()).length).to.be.equal(0);
   });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Implement the 'instant' parameter for Milo Promotions.
'Instant' param overrides current browser time with provided value and impacts Promo manifests.

### Details
'instant' parameter in the format of ISO 8601 with UTC (GMT) timezone allows GWP to see the page 'in the future' and validate upcoming promotions. It compliments `?mep` parameter (allows to preview manifests on the page) with an ability to validate the configured promo schedule.
[Sample Page](https://instant--milo--3ch023.hlx.live/drafts/mariia/pr/promo/promo?instant=2024-06-14T05:00:00.000Z)

### How to use

1. Open the page with configured promo
2. In MEP Preview click on 'instant'
3. The link with an instant parameter will open in the new tab, you can share the link with anyone for a review

<img width="1162" alt="image" src="https://github.com/adobecom/milo/assets/6617234/b99bb753-0f89-42d0-a48f-e40b37859e74">
<img width="1179" alt="image" src="https://github.com/adobecom/milo/assets/6617234/dcdb8115-f2b6-4ed6-9972-1dea8d8219c7">


Resolves: [MWPW-143145](https://jira.corp.adobe.com/browse/MWPW-143145)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/mariia/pr/promo/promo?martech=off
- After: https://instant--milo--adobecom.hlx.live/drafts/mariia/pr/promo/promo?martech=off