### PR TITLE
[MILO][MEP] MEP parameter spoof breaks if chosen experience has a comma

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -417,7 +417,7 @@ async function getPersonalizationVariant(manifestPath, variantNames = [], varian
   if (config.mep?.override) {
     let manifest;
     /* c8 ignore start */
-    config.mep?.override?.split(',').some((item) => {
+    config.mep?.override?.split('---').some((item) => {
       const pair = item.trim().split('--');
       if (pair[0] === manifestPath && pair.length > 1) {
         [, manifest] = pair;
@@ -606,6 +606,7 @@ function compareExecutionOrder(a, b) {
 export function cleanAndSortManifestList(manifests) {
   const manifestObj = {};
   manifests.forEach((manifest) => {
+    if (!manifest) return;
     manifest.manifestPath = normalizePath(manifest.manifestUrl || manifest.manifest);
     if (manifest.manifestPath in manifestObj) {
       let fullManifest = manifestObj[manifest.manifestPath];

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -203,7 +203,7 @@ function createPreviewPill(manifests) {
   const personalizationOn = getMetadata('personalization');
   const personalizationOnText = personalizationOn && personalizationOn !== '' ? 'on' : 'off';
   const simulateHref = new URL(window.location.href);
-  simulateHref.searchParams.set('manifest', manifestParameter.join(','));
+  simulateHref.searchParams.set('manifest', manifestParameter.join('---'));
 
   const config = getConfig();
   let mepHighlightChecked = '';

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -28,7 +28,7 @@ function updatePreviewButton() {
   });
 
   const simulateHref = new URL(window.location.href);
-  simulateHref.searchParams.set('mep', manifestParameter.join(','));
+  simulateHref.searchParams.set('mep', manifestParameter.join('---'));
 
   const mepHighlightCheckbox = document.querySelector(
     '.mep-popup input[type="checkbox"]#mepHighlightCheckbox',

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -185,6 +185,7 @@ describe('preview feature', () => {
     expect(document.querySelector('input#mepHighlightCheckbox').getAttribute('checked')).to.equal('checked');
   });
   it('updates preview button', () => {
+    expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.contain('---');
     document.querySelector('#new-manifest').value = 'https://main--homepage--adobecom.hlx.live/homepage/fragments/mep/new-manifest.json';
     document.querySelector('input[name="/homepage/fragments/mep/selected-example.json"][value="default"]').click();
     expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.contain('new-manifest.json');
@@ -193,6 +194,7 @@ describe('preview feature', () => {
     expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.not.contain('mepHighlight');
     document.querySelector('input#mepPreviewButtonCheckbox').click();
     expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.contain('mepButton=off');
+    expect(document.querySelector('a[title="Preview above choices"]').getAttribute('href')).to.contain('---');
   });
   it('opens manifest', () => {
     document.querySelector('a.mep-edit-manifest').click();


### PR DESCRIPTION
Detailed Description: the MEP parameter supports multiple manifests by using a comma to separate the manifest/experience pairs. This delimiter was chosen before the MEP manifests supported commas in the column names. These 2 features collide when trying to spoof a column containing a comma.

................................
URL: https://main--cc--adobecom.hlx.page/products/premiere?mep=%2Fproducts%2Fpremiere.json--cc-all-apps-any%2C+premiere-any%2C%2Fcc-shared%2Ffragments%2Fpromos%2F2024%2Famericas%2Fcci-all-apps-q1%2Fcci-all-apps-q1.json--all
................................
Steps to Reproduce:
1. Go to the link above
2. Use the MEP button to preview an experience with a comma
3. Check the MEP button panel again.

Expected Results: The experience you previously selected will be chosen
................................
Actual Results: The experience you previously selected will not be chosen

Solution, switch from using a comma to separate manifest/experience pairs and use 3 dashes instead.

Resolves: [MWPW-143067](https://jira.corp.adobe.com/browse/MWPW-143067)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q2/meppreviewdelimiter/?martech=off
- After: https://meppreviewdelimiter--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q2/meppreviewdelimiter/?martech=off
