### PR TITLE
MWPW-135821 add ability to replace merch-card in mep

### DIFF
--- a/libs/blocks/merch-cards/merch-cards.js
+++ b/libs/blocks/merch-cards/merch-cards.js
@@ -66,7 +66,7 @@ export function parsePreferences(elements) {
   });
 }
 
-const localizedPath = (path, config) => `${config?.locale?.prefix ?? ''}${path}`;
+const localizedPath = (path, config) => `${config?.locale?.prefix && path.indexOf(config.locale.prefix) !== 0 ? config.locale.prefix : ''}${path}`;
 
 const fetchOverrideCard = (path, config) => new Promise((resolve, reject) => {
   try {
@@ -75,6 +75,8 @@ const fetchOverrideCard = (path, config) => new Promise((resolve, reject) => {
         res.text().then((cardContent) => {
           resolve({ path, cardContent: /^<div>(.*)<\/div>$/.exec(cardContent.replaceAll('\n', ''))[1] });
         });
+      } else {
+        reject(res.statusText || res.status);
       }
     });
   } catch (error) {

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -32,6 +32,8 @@ const CLASS_EL_REPLACE = 'p13n-replaced';
 const COLUMN_NOT_OPERATOR = 'not';
 const TARGET_EXP_PREFIX = 'target-';
 const PAGE_URL = new URL(window.location.href);
+export const OVERRIDE_PATHS = 'overrides';
+export const MERCH_CARDS_SELECTOR = '.merch-cards';
 
 export const NON_TRACKED_MANIFEST_TYPE = 'test or promo';
 
@@ -141,6 +143,13 @@ const COMMANDS = {
     if (el.classList.contains(CLASS_EL_REPLACE)) return;
     el.insertAdjacentElement('beforebegin', createFrag(el, target, manifestId));
     el.classList.add(CLASS_EL_DELETE, CLASS_EL_REPLACE);
+  },
+  replacemerchcard: (el, cardPath) => {
+    const paths = el.dataset[OVERRIDE_PATHS]?.split(',') || [];
+    if (!paths.includes(cardPath)) {
+      paths.push(cardPath);
+    }
+    el.dataset[OVERRIDE_PATHS] = paths.join(',');
   },
 };
 

--- a/test/blocks/merch-cards/mocks/express-override.html
+++ b/test/blocks/merch-cards/mocks/express-override.html
@@ -1,0 +1,11 @@
+<div>
+  <div class="merch-card catalog">
+    <div>
+      <h3>Adobe Express PROMOTION!!!</h3>
+    </div>
+    <div>
+      <h3>express</h3>
+      <p>catalog:categories/creativity-design/photo</p>
+    </div>
+  </div>
+</div>

--- a/test/blocks/merch-cards/mocks/merch-cards.html
+++ b/test/blocks/merch-cards/mocks/merch-cards.html
@@ -169,4 +169,42 @@
       </div>
     </div>
   </div>
+  <div id="override-cards">
+    <div class="merch-card catalog">
+      <div>
+        <h3>Adobe Express</h3>
+      </div>
+      <div>
+        <h3>express</h3>
+        <p>catalog:categories/creativity-design/photo</p>
+      </div>
+    </div>
+    <div class="merch-card catalog">
+      <div>
+        <h3>Photoshop</h3>
+      </div>
+      <div>
+        <h3>photoshop</h3>
+        <p>catalog:categories/creativity-design/photo</p>
+      </div>
+    </div>
+    <div class="merch-card catalog">
+      <div>
+        <h3>Creative Cloud All Apps</h3>
+      </div>
+      <div>
+        <h3>all-apps</h3>
+        <p>catalog:categories/creativity-design/photo</p>
+        <p>catalog:categories/creativity-design/video</p>
+      </div>
+    </div>
+    <div class="merch-card catalog premierepro">
+      <div>
+        <h3>Premiere Pro</h3>
+      </div>
+      <div>
+        <p>catalog:categories/creativity-design/video</p>
+      </div>
+    </div>
+  </div>
 </main>

--- a/test/blocks/merch-cards/mocks/photoshop-override.html
+++ b/test/blocks/merch-cards/mocks/photoshop-override.html
@@ -1,0 +1,11 @@
+<div>
+  <div class="merch-card catalog">
+    <div>
+      <h3>Photoshop PROMOTION!!!</h3>
+    </div>
+    <div>
+      <h3>photoshop</h3>
+      <p>catalog:categories/creativity-design/photo</p>
+    </div>
+  </div>
+</div>

--- a/test/features/personalization/mocks/manifestReplaceMerchCard.json
+++ b/test/features/personalization/mocks/manifestReplaceMerchCard.json
@@ -1,0 +1,28 @@
+{
+  "total": 2,
+  "offset": 0,
+  "limit": 5,
+  "data": [
+    {
+      "action": "replaceMerchCard",
+      "selector": "#features-of-milo-experimentation-platform",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "chrome": "/fragments/fragmentreplaced",
+      "firefox": "",
+      "android": "",
+      "ios": ""
+    },
+    {
+      "action": "replaceMerchCard",
+      "selector": "#features-of-milo-experimentation-platform",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "chrome": "/fragments/fragmentalsoreplaced",
+      "firefox": "",
+      "android": "",
+      "ios": ""
+    }
+  ],
+  ":type": "sheet"
+}

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -261,6 +261,18 @@ describe('Functional Test', () => {
     await applyPers([{ manifestPath: '/mocks/manifestRemove.json' }]);
     expect(document.querySelector('.z-pattern').dataset.removedManifestId).to.not.be.null;
   });
+
+  it('replaceMerchCard should tag an element with a fragment', async () => {
+    let manifestJson = await readFile({ path: './mocks/manifestReplaceMerchCard.json' });
+    manifestJson = JSON.parse(manifestJson);
+    setFetchResponse(manifestJson);
+    const el = document.querySelector('#features-of-milo-experimentation-platform');
+    expect(el).to.not.be.null;
+    await applyPers([{ manifestPath: '/path/to/manifest.json' }]);
+    // replaceMerchCard sole action at personalisation level is to tag element
+    // with list of fragments path the element will have to deal with later
+    expect(el.dataset.overrides).to.equal('/fragments/fragmentreplaced,/fragments/fragmentalsoreplaced');
+  });
 });
 
 describe('normalizePath function', () => {


### PR DESCRIPTION
- mep decorates whatever selected element with override path specified in manifest,
- merch-cards fetches specified override paths and replace them if matching name properties

Resolves: [MWPW-135821](https://jira.corp.adobe.com/browse/MWPW-135821)

with following manifest added to the page

| action | selector | page filter (optional) | target-challenger name |
|---|---|---|---|
| replaceMerchCard | .merch-cards |   | /drafts/npeltier/fragments/merch/products/catalog/photoshop/promo |

before & after personalisation (see photoshop card)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/npeltier/promocard-test?milolibs=mwpw-135821--milo--npeltier
- After: https://main--cc--adobecom.hlx.page/drafts/npeltier/promocard-test?milolibs=mwpw-135821--milo--npeltier&mep=%2Fdrafts%2Fnpeltier%2Fpromo-test.json--target-challenger+name

