### PR TITLE
MWPW-144237 - [Loc v2] Fix find deep fragments

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -63,7 +63,8 @@ async function findDeepFragments(path) {
     const needsSearch = fragments.filter((fragment) => !searched.includes(fragment.pathname));
     for (const search of needsSearch) {
       const nestedFragments = await findPageFragments(search.pathname);
-      if (nestedFragments?.length) fragments.push(...nestedFragments);
+      const notSearched = nestedFragments.filter((nested) => !searched.includes(nested.pathname));
+      if (notSearched?.length) fragments.push(...notSearched);
       searched.push(search.pathname);
     }
   }


### PR DESCRIPTION
Finding nested fragments needs to check for duplicates during search. I have updated the function to filter searched pathnames.

Resolves: [MWPW-144237](https://jira.corp.adobe.com/browse/MWPW-144237)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/find-fragments-test?martech=off
- After: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/find-fragments-test?martech=off
