### PR TITLE
Caas-Marquee: Fixes integration with martech.js issues

### DIFF
--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -807,7 +807,17 @@ export default async function init(el) {
   const marqueesPromise = getAllMarquees(promoId, origin);
   await Promise.all([martechPromise, marqueesPromise]);
   marquees = await marqueesPromise;
-  const event = await waitForEventOrTimeout('alloy_sendEvent', ALLOY_TIMEOUT, new Event(''));
+
+  let event;
+  if (window.alloy_pageView) {
+    // eslint-disable-next-line camelcase, no-undef
+    const sent = await alloy_pageView.sent;
+    if (sent.destinations[0].segments) {
+      event = { detail: { type: 'pageView', result: { destinations: sent.destinations } } };
+    }
+  } else {
+    event = await waitForEventOrTimeout('alloy_sendEvent', ALLOY_TIMEOUT, new Event(''));
+  }
 
   if (authorPreview()) {
     return renderMarquee(marquee, marquees, urlParams.get('marqueeId'), metadata);


### PR DESCRIPTION
Problem:
AEP Audiences unavailable for CaaS Marquees when Target is enabled on a page

This PR fixes some issues that surfaced while integration the caas-marquee code with target for the A-B testing

After this code was merged to main (prod) ant testing began it was noticed that there was problem when martech.js was injected in the page, and as a result the caas-marquee code was never able to catch a windowEvent needed for proper functioning.  

The following fix was provided by @chrischrischris

Resolves: [MWPW-144461](https://jira.corp.adobe.com/browse/MWPW-144461)

Before:  https://www.adobe.com/
After:  https://www.adobe.com/?test=target&mep=

URL for testing:

 - https://www.adobe.com/?test=target&mep=

URL for testing:

- https://caas-marquee--milo--adobecom.hlx.page/
