### PR TITLE
[MWPW-144516] Handle cross cloud menu block error

### DIFF
--- a/libs/blocks/fallback/fallback.js
+++ b/libs/blocks/fallback/fallback.js
@@ -7,6 +7,7 @@ const SYNTHETIC_BLOCKS = [
   'adobe-logo',
   'breadcrumbs',
   'column-break',
+  'cross-cloud-menu',
   'gnav-brand',
   'gnav-promo',
   'large-menu',


### PR DESCRIPTION
## Description
This ensures that the Cross Cloud Menu block, used as part of Global Navigation dropdown menus is not marked as having errors when previewing navigation documents.

## Related Issue
Resolves: [MWPW-144516](https://jira.corp.adobe.com/browse/MWPW-144516)

## Testing instructions
Scroll to the bottom of the page. Before, the block was surrounded by the pink error box, after it is not.

## Test URLs
**Milo:**
- Before: https://main--federal--adobecom.hlx.page/federal/globalnav/acom/sections/section-menu-cc-localnav
- After: https://main--federal--adobecom.hlx.page/federal/globalnav/acom/sections/section-menu-cc-localnav?milolibs=cross-cloud-menu-error--milo--overmyheadandbody
