### PR TITLE
MWPW-144510: Fix for DNT not working for nav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -269,7 +269,6 @@ class Gnav {
     };
 
     this.setupUniversalNav();
-    decorateLinks(this.content);
     this.elements = {};
   }
 


### PR DESCRIPTION
The `decorateLinks` function was being called twice on the content of fetched Gnav experience. Inside [fetchAndProcessPlainHtml](https://github.com/adobecom/milo/blob/stage/libs/blocks/global-navigation/utilities/utilities.js#L325) and one inside Gnav's [constructor](https://github.com/adobecom/milo/blob/stage/libs/blocks/global-navigation/global-navigation.js#L272). 

This was creating issue for links with `#_dnt`.
Eg. For Link to Resources i.e. `https://www.adobe.com/acrobat/resources.html#_dnt`
First execution of `decorateLink` is removing `#_dnt` and 2nd is localizing it to `lu_fr` which shouldn't happen for a DNT link. Removed 2nd call to `decorateLink`.

Resolves: [MWPW-144510](https://jira.corp.adobe.com/browse/MWPW-144510)

**Test URLs:** (Look for the link of Resources in Localnav)
- Before: [https://main--dc--adobecom.hlx.page/lu_fr/acrobat/campaign?martech=off](https://main--dc--adobecom.hlx.page/lu_fr/acrobat/campaign?martech=off)
- After: [https://main--dc--adobecom.hlx.page/lu_fr/acrobat/campaign?martech=off&milolibs=mwpw-144510--milo--nishantka](https://main--dc--adobecom.hlx.page/lu_fr/acrobat/campaign?martech=off&milolibs=mwpw-144510--milo--nishantka)

Gnav Experience: [https://main--dc--adobecom.hlx.page/lu_fr/dc-shared/gnav-acrobat](https://main--dc--adobecom.hlx.page/lu_fr/dc-shared/gnav-acrobat)