### PR TITLE
MWPW-144575: Fix for commerce modal height

### DIFF
--- a/libs/blocks/modal/modal.merch.js
+++ b/libs/blocks/modal/modal.merch.js
@@ -61,7 +61,7 @@ export function adjustStyles({ dialog, iframe }) {
   if (isAutoHeightAdjustment) {
     dialog.classList.add('height-fit-content');
   } else {
-    iframe.style.height = '100%';
+    iframe.style.height = '100vh';
   }
 }
 

--- a/libs/blocks/modal/modal.merch.js
+++ b/libs/blocks/modal/modal.merch.js
@@ -57,7 +57,6 @@ function reactToMessage({ data, source }) {
 
 export function adjustStyles({ dialog, iframe }) {
   const isAutoHeightAdjustment = /\/mini-plans\/.*mid=ft.*web=1/.test(iframe.src); // matches e.g. https://www.adobe.com/mini-plans/photoshop.html?mid=ft&web=1
-  console.log('isAutoHeightAdjustment', isAutoHeightAdjustment);
   if (isAutoHeightAdjustment) {
     dialog.classList.add('height-fit-content');
   } else {


### PR DESCRIPTION
Fix for commerce modal height breaking in milo.

Affected page: https://www.adobe.com/products/illustrator/campaign/pricing.html?mboxDisable=1&adobe_authoring_enabled=true#cc-all-apps-upsell-blade-swi-link

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://<branch>--milo--adobecom.hlx.page/?martech=off
