### PR TITLE
MWPW-144575: Fix for commerce-frame sections and fragments height in modals

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -26,7 +26,8 @@
 }
 
 .dialog-modal.commerce-frame > .fragment,
-.dialog-modal.commerce-frame > .section {
+.dialog-modal.commerce-frame > .section,
+.dialog-modal.commerce-frame > .fragment > .section {
   height: 100vh;
 }
 


### PR DESCRIPTION
This PR fixed the issue we see now on production, caused by the CSS selector not covering the case when the .section element is not a direct descendant of a .dialog-modal, thus the height of such .section is not set to 100vh on desktop resolution, which causes the modal content not being visible.

Resolves: [MWPW-144575](https://jira.corp.adobe.com/browse/MWPW-144575)

**Test URLs:**
- Before: https://www.adobe.com/products/illustrator/campaign/pricing.html?mboxDisable=1&adobe_authoring_enabled=true#modal-see-whats-included
- After: https://mwpw-144575-modal-styles-for-main--milo--mirafedas.hlx.live/drafts/mirafedas/all-modals
