### PR TITLE
[MWPW-144602] Ensure DNT functionality in top nav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -949,7 +949,7 @@ export default async function init(block) {
   try {
     const { locale, mep } = getConfig();
     const url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
-    const content = await fetchAndProcessPlainHtml({ url })
+    const content = await fetchAndProcessPlainHtml({ url, shouldDecorateLinks: false })
       .catch((e) => lanaLog({
         message: `Error fetching gnav content url: ${url}`,
         e,

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -308,14 +308,12 @@ const decorateMenu = (config) => logErrorFor(async () => {
     const pathElement = config.item.querySelector('a');
     if (!(pathElement instanceof HTMLElement)) return;
 
-    const content = await fetchAndProcessPlainHtml({
-      url: pathElement.href,
-      message: 'Menu could not be fetched',
-    }).catch((e) => lanaLog({
-      message: `Menu could not be fetched ${pathElement.href}`,
-      e,
-      tags: 'errorType=error,module=menu',
-    }));
+    const content = await fetchAndProcessPlainHtml({ url: pathElement.href })
+      .catch((e) => lanaLog({
+        message: `Menu could not be fetched ${pathElement.href}`,
+        e,
+        tags: 'errorType=error,module=menu',
+      }));
     if (!content) return;
 
     const menuContent = toFragment`<div class="feds-menu-content">${content.innerHTML}</div>`;


### PR DESCRIPTION
## Description
Logic was introduced in https://github.com/adobecom/milo/pull/1714 to provide a more general approach to fetch and process content, including decorating links. The footer [logic](https://github.com/adobecom/milo/pull/1714/files#diff-2053e335fb245c2c097c0075eda050e9dbc23f402dea8b75dad5f4621cd2d12bR70-R73) calls it in a certain way, by defining a `shouldDecorateLinks` property. The global navigation [logic](https://github.com/adobecom/milo/pull/1714/files#diff-628bf5a25903978c5b36da4943ec813da171346d24bd64f80907f012a840b098R717) does not use that property. This means that the `decorateLinks` method is called two times, once with that method, once [here](https://github.com/adobecom/milo/blob/stage/libs/blocks/global-navigation/global-navigation.js#L272). For links that have the `#_dnt` style applied, this means that the first `decorateLinks` call removes the modifier and the second call localizes the link. We need to ensure `decorateLinks` is called just once.

I'd like @mokimo to vet this, as it might impact something from the content centralization logic.

Because this could impact Summit, priority might need to be raised.

## Related Issue
Resolves: [MWPW-144602](https://jira.corp.adobe.com/browse/MWPW-144602)

## Testing instructions

1. Open the Network tab of the browser's developer tools, load the BACOM test URL and search for _localnav-rtcdp.plain.html_
2. In the Response tab, look for the _Resources_ element and notice its href value has the `#_dnt` style applied
3. Inspect the _Resources_ element from the navigation. It should not be prefixed with the page locale.

## Test URLs
**BACOM:**
- Before: https://main--bacom--adobecom.hlx.page/ru/products/real-time-customer-data-platform/rtcdp?martech=off&georouting=off
- After: https://main--bacom--adobecom.hlx.page/ru/products/real-time-customer-data-platform/rtcdp?martech=off&georouting=off&milolibs=top-nav-dnt-fix--milo--overmyheadandbody

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off&georouting=off
- After: https://top-nav-dnt-fix--milo--overmyheadandbody.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off&georouting=off
