### PR TITLE
MWPW-144575: fix for the modal duplication

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -179,7 +179,7 @@ export async function getModal(details, custom) {
 // Deep link-based
 export default function init(el) {
   const { modalHash } = el.dataset;
-  if (window.location.hash === modalHash) {
+  if (window.location.hash === modalHash && !document.querySelector(`div.dialog-modal${modalHash}`)) {
     const details = findDetails(window.location.hash, el);
     if (details) return getModal(details);
   }


### PR DESCRIPTION
Added check to ensure we do not create a modal when it is already created and present in DOM.

Resolves: [MWPW-144575](https://jira.corp.adobe.com/browse/MWPW-144575)

**Test URLs:**
This bug is not always reproducible, but it is possible to catch it when the page is opened for the first time in incognito mode. This problem is browser agnostic.
- Before: https://www.stage.adobe.com/#mini-plans-web-cta-creative-cloud-card
- After: here are examples of different modals, basically every modal will be 'touched' with this fix, so feel free to test on all possible modals:
[Page with modals](https://mwpw-144575-duplicated-modals--milo--mirafedas.hlx.live/drafts/mirafedas/all-modals)

