### PR TITLE
MWPW-141134 - [Loc v2] Remove find fragments

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -7,7 +7,6 @@ import {
   allowSyncToLangstore,
   allowSendForLoc,
   allowRollout,
-  allowFindFragments,
   syncFragments,
 } from '../utils/state.js';
 import { setExcelStatus, setStatus } from '../utils/status.js';
@@ -129,9 +128,6 @@ export async function findAllFragments() {
 }
 
 export async function syncToLangstore() {
-  // Disable finding fragments
-  allowFindFragments.value = false;
-
   // Disable all langstore syncing, the project is being sent.
   allowSyncToLangstore.value = false;
 
@@ -174,9 +170,6 @@ export async function syncFragsLangstore() {
 }
 
 export async function sendForLoc() {
-  // Disable finding fragments
-  allowFindFragments.value = false;
-
   // Disable all langstore syncing, the project is being sent.
   allowSyncToLangstore.value = false;
 

--- a/libs/blocks/locui/actions/view.js
+++ b/libs/blocks/locui/actions/view.js
@@ -1,14 +1,6 @@
 import { html } from '../../../deps/htm-preact.js';
+import { urls, languages, allowSyncToLangstore, allowSendForLoc, allowRollout } from '../utils/state.js';
 import {
-  urls,
-  languages,
-  allowFindFragments,
-  allowSyncToLangstore,
-  allowSendForLoc,
-  allowRollout,
-} from '../utils/state.js';
-import {
-  findAllFragments,
   sendForLoc,
   showRolloutOptions,
   showRollout,
@@ -17,8 +9,7 @@ import {
 } from './index.js';
 
 export default function Actions() {
-  const canAct = allowFindFragments.value
-              || allowSyncToLangstore.value
+  const canAct = allowSyncToLangstore.value
               || allowSendForLoc.value
               || allowRollout.value;
   const canActStyle = canAct ? 'locui-section-label' : 'locui-section-label is-invisible';
@@ -31,12 +22,6 @@ export default function Actions() {
         <h2 class="${canActStyle}">Actions</h2>
       </div>
       <div class=locui-url-heading-actions>
-        ${allowFindFragments.value && html`
-          <button 
-            class=locui-urls-heading-action
-            onClick=${findAllFragments}>Find All Fragments
-          </button>
-        `}
         ${allowSyncToLangstore.value && html`
           <button
             onClick=${startSyncToLangstore}

--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -7,7 +7,6 @@ import {
   getSiteConfig,
   showLogin,
   telemetry,
-  allowFindFragments,
   allowSyncToLangstore,
   canRefresh,
 } from '../utils/state.js';
@@ -65,7 +64,6 @@ async function loadProjectSettings(projSettings) {
     setStatus('service');
   } else {
     canRefresh.value = true;
-    allowFindFragments.value = true;
     allowSyncToLangstore.value = true;
     allowSendForLoc.value = true;
   }

--- a/libs/blocks/locui/utils/miloc.js
+++ b/libs/blocks/locui/utils/miloc.js
@@ -1,5 +1,4 @@
 import {
-  allowFindFragments,
   allowSendForLoc,
   allowSyncToLangstore,
   heading,
@@ -122,7 +121,6 @@ export async function createProject() {
   const resp = await fetch(`${url}create-project`, opts);
   if (resp.status === 201) {
     canRefresh.value = false;
-    allowFindFragments.value = false;
     const projectId = window.md5(body);
     heading.value = { ...heading.value, projectId };
     const values = [['Project ID', projectId]];

--- a/libs/blocks/locui/utils/state.js
+++ b/libs/blocks/locui/utils/state.js
@@ -16,7 +16,6 @@ export const siteConfig = signal(null);
 export const user = signal();
 export const spAccessToken = signal();
 export const showLogin = signal(false);
-export const allowFindFragments = signal(false);
 export const allowSyncToLangstore = signal(false);
 export const allowSendForLoc = signal(false);
 export const allowRollout = signal(false);


### PR DESCRIPTION
Now that fragments are searched and users can select what fragments they want to add from the sync to langstore workflow we do not need the find fragments button any longer. Removing the button and the state signal associated with find fragments button.

Resolves: [MWPW-141134](https://jira.corp.adobe.com/browse/MWPW-141134)

**Test URL:**
https://locui--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Bcae62b28-0603-4424-937c-476ac75d25b4%257D%26action%3Deditnew
