### PR TITLE
MWPW-144813: Add 'xl-size' class for dialog-modal

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -93,7 +93,7 @@
   margin: 12px;
 }
 
-.locale-modal{
+.locale-modal {
   text-align: center;
   padding: 48px 32px 30px;
 }
@@ -203,6 +203,17 @@
   .dialog-modal.commerce-frame > .section,
   .dialog-modal.commerce-frame > .fragment > .section {
     height: 100vh;
+  }
+
+  .dialog-modal.xl-size,
+  .dialog-modal.xl-size > .fragment,
+  .dialog-modal.xl-size > .fragment > .section {
+    height: 100%;
+  }
+
+  .dialog-modal.xl-size .milo-iframe {
+    height: 100%;
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
This change adds a new `xl-size` class for the modal window, which allows the modal window to fill all available screen height on mobile and tablet, and to be wider on desktop.
We set this class to the modal window that renders an iframe with the following pages:
https://www.adobe.com/creativecloud/whats-included/mini-plans/cci-all-apps-whats-included.html
https://www.adobe.com/creativecloud/whats-included/mini-plans/edu-all-apps-whats-included.html
https://www.adobe.com/creativecloud/whats-included/mini-plans/cct-all-apps-whats-included.html
https://www.adobe.com/creativecloud/whats-included/plans/cci-all-apps-whats-included.html 
https://www.adobe.com/creativecloud/whats-included/plans/edu-all-apps-whats-included.html
https://www.adobe.com/creativecloud/whats-included/plans/cct-all-apps-whats-included.html 
We may use it later for other use cases as well.

Resolves: [MWPW-144813](https://jira.corp.adobe.com/browse/MWPW-144813)

**Test URLs:**
- Before:
https://main--milo--adobecom.hlx.live/drafts/mirafedas/all-modals#cci-all-apps-whats-included
- After:
https://mwpw-144813-whatsincluded-styles--milo--mirafedas.hlx.page/drafts/mirafedas/all-modals#see-whats-included-xl

Note:
Make sure the ModHeaders plugin has the frame-ancestors set to * in the CSP response modifiers, without this on the 'After' page the modal content will not render because of the CORS.
