### PR TITLE
Adobe logo not showing up as expected when retrieved from the federal project

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -18,6 +18,8 @@ import {
   lanaLog,
   logErrorFor,
   toFragment,
+  getFederatedUrl,
+  federatePictureSources,
 } from '../global-navigation/utilities/utilities.js';
 
 import { replaceKey } from '../../features/placeholders.js';
@@ -89,6 +91,9 @@ class Footer {
 
     regionParent?.appendChild(region);
     socialParent?.appendChild(social);
+
+    const path = getFederatedUrl(url);
+    federatePictureSources({ section: this.body, forceFederate: path.includes('/federal/') });
 
     // Order is important, decorateFooter makes use of elements
     // which have already been created in previous steps

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -269,7 +269,6 @@ class Gnav {
     };
 
     this.setupUniversalNav();
-    decorateLinks(this.content);
     this.elements = {};
   }
 
@@ -949,7 +948,7 @@ export default async function init(block) {
   try {
     const { locale, mep } = getConfig();
     const url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
-    const content = await fetchAndProcessPlainHtml({ url, shouldDecorateLinks: false })
+    const content = await fetchAndProcessPlainHtml({ url })
       .catch((e) => lanaLog({
         message: `Error fetching gnav content url: ${url}`,
         e,

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -320,9 +320,11 @@ export async function fetchAndProcessPlainHtml({ url, shouldDecorateLinks = true
     await Promise.all(fragPromises);
   }
 
-  if (shouldDecorateLinks) decorateLinks(body);
-
-  federatePictureSources({ section: body, forceFederate: path.includes('/federal/') });
+  // federatePictureSources should only be called after decorating the links.
+  if (shouldDecorateLinks) {
+    decorateLinks(body);
+    federatePictureSources({ section: body, forceFederate: path.includes('/federal/') });
+  }
 
   const blocks = body.querySelectorAll('.martech-metadata');
   if (blocks.length) {


### PR DESCRIPTION
## Description
Ensure centralized images always show up - also on non-centralized navigations. Authors should be able to freely link to centralized assets, such as the adobe logo which is used across a lot of consumers.

Initially fixed in https://github.com/adobecom/milo/pull/1929
Regression in https://github.com/adobecom/milo/pull/2020

Writing a unit test would be complex, hence I'm skipping on this. A nala/e2e test would make sense though.

## Related Issue
Resolves: [MWPW-145137](https://jira.corp.adobe.com/browse/MWPW-145137)

## Testing instructions
Images should always show up, in all of those scenarios.
1. Consumer based navigation + consumer based SVGs used
2. Consumer based navigation + centralized SVG
3. Centralised navigation + centralized SVG

a SVG/image can be a promo element within a menu, a logo in the brand block or in the logo block of the navigation.

## Screenshots (if appropriate):
![Screenshot 2024-02-26 at 19 59 40](https://github.com/adobecom/milo/assets/39759830/80d2873b-f179-47f4-b8e6-1c9a6a5187c0)
![Screenshot 2024-02-26 at 19 59 37](https://github.com/adobecom/milo/assets/39759830/88d721e8-52f2-4965-ae89-2bf6e947c532)


## Test URLs
**Homepage where the issue was raised initially:**
- Before: https://main--cc--adobecom.hlx.page/drafts/ankshukl/document-preview-cc-localnav?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/ankshukl/document-preview-cc-localnav?martech=off&milolibs=mwpw-145137--milo--mokimo

**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=mwpw-145137--milo--mokimo

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=mwpw-145137--milo--mokimo

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=mwpw-145137--milo--mokimo

**Blog:**
- Before: https://main--blog--adobecom.hlx.page/
- After: https://main--blog--adobecom.hlx.page/?milolibs=mwpw-145137--milo--mokimo

**Milo:**
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://mwpw-145137--milo--mokimo.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
