### PR TITLE
Bulk Publish Performance Enhancements

### DIFF
--- a/libs/blocks/bulk-publish-v2/components/bulk-publisher.css
+++ b/libs/blocks/bulk-publish-v2/components/bulk-publisher.css
@@ -39,6 +39,10 @@
   right: 0;
 }
 
+.error-btns {
+  display: flex;
+}
+
 .prompt .load-indicator {
   display: inline-flex;
   gap: 22px;

--- a/libs/blocks/bulk-publish-v2/components/bulk-publisher.css
+++ b/libs/blocks/bulk-publish-v2/components/bulk-publisher.css
@@ -242,7 +242,8 @@ label[for='urls'] i {
   justify-content: space-between;
 }
 
-.error-bar .fix-btn {
+.error-bar .fix-btn,
+.error-bar .clear-btn {
   background-color: white;
   color: var(--error);
   padding: 3px 8px;
@@ -252,7 +253,8 @@ label[for='urls'] i {
   font-size: 0.8em;
 }
 
-.error-bar .fix-btn:hover {
+.error-bar .fix-btn:hover,
+.error-bar .clear-btn:hover {
   background-color: #f9f9f9;
 }
 
@@ -374,7 +376,7 @@ label[for='urls'] i {
   min-width: var(--meta-width);
 }
 
-.job-meta > *:last-child {
+.job-meta>*:last-child {
   text-align: right;
 }
 

--- a/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
+++ b/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
@@ -276,6 +276,8 @@ class BulkPublish2 extends LitElement {
     if (this.jobs.filter((job) => !job.status).length === 0) {
       this.processing = false;
       sticky().set('resume', []);
+      const progressCount = this.renderRoot.querySelector('#progress');
+      if (progressCount) progressCount.innerHTML = 0;
     }
   }
 
@@ -283,8 +285,8 @@ class BulkPublish2 extends LitElement {
     const { name, progress } = event.detail;
     const jobProcess = this.jobs.find(({ result }) => result.job.name === name);
     if (jobProcess) jobProcess.progress = progress;
-    const update = this.renderRoot.querySelector('#progress');
-    if (update) update.innerHTML = getProcessedCount(this.jobs);
+    const progressCount = this.renderRoot.querySelector('#progress');
+    if (progressCount) progressCount.innerHTML = getProcessedCount(this.jobs);
   }
 
   clearJobs = () => {

--- a/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
+++ b/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
@@ -166,11 +166,11 @@ class BulkPublish2 extends LitElement {
       <div class="errors">
         <span>Error: <strong>${text}</strong></span>
         <div class="error-btns">
-          ${count > 1 ? html`
+          ${count >= 1 ? html`
             <div class="fix-btn" @click=${() => startEdit(true)}>
               ${btnText}
             </div>` : ''}
-          <div class="fix-btn" @click=${() => this.reset()}>
+          <div class="clear-btn" @click=${() => this.reset()}>
             Clear
           </div>
         </div>

--- a/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
+++ b/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
@@ -165,8 +165,14 @@ class BulkPublish2 extends LitElement {
     return html`
       <div class="errors">
         <span>Error: <strong>${text}</strong></span>
-        <div class="fix-btn" @click=${() => startEdit(true)}>
-          ${count === 1 ? 'Done' : btnText}
+        <div class="error-btns">
+          ${count > 1 ? html`
+            <div class="fix-btn" @click=${() => startEdit(true)}>
+              ${btnText}
+            </div>` : ''}
+          <div class="fix-btn" @click=${() => this.reset()}>
+            Clear
+          </div>
         </div>
       </div>
     `;
@@ -421,7 +427,6 @@ class BulkPublish2 extends LitElement {
   }
 
   render() {
-    console.log('render');
     const { full, half, toggleMode } = this.getModeState();
     return html`
       ${this.renderLoginPrompt()}

--- a/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
+++ b/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
@@ -8,6 +8,7 @@ import {
   editEntry,
   FORM_MODES,
   getJobErrorText,
+  getProcessedCount,
   isValidUrl,
   processJobResult,
   PROCESS_TYPES,
@@ -276,15 +277,8 @@ class BulkPublish2 extends LitElement {
     const { name, progress } = event.detail;
     const jobProcess = this.jobs.find(({ result }) => result.job.name === name);
     if (jobProcess) jobProcess.progress = progress;
-    this.requestUpdate();
-  }
-
-  renderProgress(done) {
-    if (!done) return '';
-    return `${this.jobs.reduce((count, { progress }) => {
-      const processed = progress?.processed ?? 0;
-      return count + processed;
-    }, 0)}/${done}`;
+    const update = this.renderRoot.querySelector('#progress');
+    if (update) update.innerHTML = getProcessedCount(this.jobs);
   }
 
   clearJobs = () => {
@@ -315,7 +309,7 @@ class BulkPublish2 extends LitElement {
             <img src=${clearJobsIcon} alt="Clear List Icon" title="Clear Job List" />
           </div>
           <div class="job-progress${loading}">
-            ${this.renderProgress(count)}
+            <span id="progress">0</span>/${count}
           </div>
           <div class="loading-jobs${loading}">
             <div class="loader pink"></div>
@@ -427,6 +421,7 @@ class BulkPublish2 extends LitElement {
   }
 
   render() {
+    console.log('render');
     const { full, half, toggleMode } = this.getModeState();
     return html`
       ${this.renderLoginPrompt()}

--- a/libs/blocks/bulk-publish-v2/components/job-process.css
+++ b/libs/blocks/bulk-publish-v2/components/job-process.css
@@ -42,6 +42,10 @@
   color: black;
 }
 
+.status[has-update] {
+  display: none;
+}
+
 .result.success.link .url {
   color: var(--link-color);
 }

--- a/libs/blocks/bulk-publish-v2/components/job-process.js
+++ b/libs/blocks/bulk-publish-v2/components/job-process.js
@@ -32,6 +32,7 @@ class JobProcess extends LitElement {
       await pollJobStatus(this.job, (detail) => {
         if (detail.state === 'stopped') {
           this.jobStatus = detail;
+        /* c8 ignore next 3 */
         } else {
           updateItemProgress(detail, this);
         }

--- a/libs/blocks/bulk-publish-v2/components/job-process.js
+++ b/libs/blocks/bulk-publish-v2/components/job-process.js
@@ -128,7 +128,7 @@ class JobProcess extends LitElement {
     const { style, status, topic, url, time } = this.getJob(jobPath);
     return html`
       <div
-        job-item=${path}
+        job-item=${jobPath}
         class="result${style}"
         @click=${() => this.onClick({ url, code: status.code, topic }, pathIndex)}>
         <div class="process">

--- a/libs/blocks/bulk-publish-v2/services.js
+++ b/libs/blocks/bulk-publish-v2/services.js
@@ -181,7 +181,6 @@ const getJobStatus = async (link) => {
     return result;
   /* c8 ignore next 3 */
   } catch (error) {
-    console.log('error from status:', error);
     return error;
   }
 };

--- a/libs/blocks/bulk-publish-v2/services.js
+++ b/libs/blocks/bulk-publish-v2/services.js
@@ -159,18 +159,29 @@ const startJob = async (details) => {
       };
     }
   });
-  const results = await Promise.all(requests);
+  // batch to limit concurrency
+  const results = [];
+  while (requests.length) {
+    await delay(5000);
+    const result = await Promise.all(requests.splice(0, 4));
+    results.push(...result);
+  }
   return results;
 };
 
+// fetch one job status at a time
+const statusQueue = [];
 const getJobStatus = async (link) => {
-  await delay();
+  await delay(5000);
+  if (!statusQueue.includes(link)) statusQueue.push(link);
+  if (statusQueue.indexOf(link) !== 0) return null;
   try {
     const status = await fetch(link, { headers });
     const result = await status.json();
     return result;
   /* c8 ignore next 3 */
   } catch (error) {
+    console.log('error from status:', error);
     return error;
   }
 };
@@ -181,11 +192,12 @@ const pollJobStatus = async (job, setProgress) => {
   let stopped = false;
   while (!stopped) {
     const status = await getJobStatus(`${result.links.self}/details`);
-    if (status.stopTime) {
+    if (status?.stopTime) {
       jobStatus = status;
       stopped = true;
+      statusQueue.shift();
     }
-    setProgress(status);
+    if (status) setProgress(status);
   }
   return jobStatus;
 };

--- a/libs/blocks/bulk-publish-v2/services.js
+++ b/libs/blocks/bulk-publish-v2/services.js
@@ -162,7 +162,7 @@ const startJob = async (details) => {
   // batch to limit concurrency
   const results = [];
   while (requests.length) {
-    await delay(5000);
+    if (requests.length > 5) await delay(5000);
     const result = await Promise.all(requests.splice(0, 4));
     results.push(...result);
   }

--- a/libs/blocks/bulk-publish-v2/utils.js
+++ b/libs/blocks/bulk-publish-v2/utils.js
@@ -99,6 +99,7 @@ const getStatusText = (status, state, count) => {
   return { code, text, color };
 };
 
+/* c8 ignore next 16 */
 const updateItemProgress = (detail, tool) => {
   const resources = detail.data?.resources?.filter((res) => res.status !== 0);
   if (resources) {

--- a/libs/blocks/bulk-publish-v2/utils.js
+++ b/libs/blocks/bulk-publish-v2/utils.js
@@ -1,3 +1,5 @@
+import { createTag } from '../../utils/utils.js';
+
 const PREFS = 'bulk-pub-prefs';
 const FORM_MODES = ['full', 'half'];
 const DEFAULT_PREFS = { mode: FORM_MODES[0], resume: [] };
@@ -97,6 +99,23 @@ const getStatusText = (status, state, count) => {
   return { code, text, color };
 };
 
+const updateItemProgress = (detail, tool) => {
+  const resources = detail.data?.resources?.filter((res) => res.status !== 0);
+  if (resources) {
+    resources.forEach(({ path, status }) => {
+      const item = tool.renderRoot.querySelector(`[job-item='${path}']`);
+      if (!item?.hasAttribute('updated')) {
+        const { text, color } = getStatusText(status, null);
+        const newStatus = createTag('span', { class: `status ${color}` }, text);
+        const display = item.querySelector('.status');
+        display.insertAdjacentElement('afterend', newStatus);
+        item.setAttribute('updated', '');
+        display.setAttribute('has-update', '');
+      }
+    });
+  }
+};
+
 const displayDate = (newDate) => {
   const date = new Date(newDate);
   const today = new Date();
@@ -109,6 +128,11 @@ const processJobResult = (jobs) => jobs.reduce((result, job) => {
   return result;
 }, { complete: [], error: [] });
 
+const getProcessedCount = (jobs) => jobs.reduce((count, { progress }) => {
+  const processed = progress?.processed ?? 0;
+  return count + processed;
+}, 0);
+
 export {
   frisk,
   displayDate,
@@ -117,10 +141,12 @@ export {
   getErrorText,
   getJobErrorText,
   getAemUrl,
+  getProcessedCount,
   isDelete,
   PROCESS_TYPES,
   processJobResult,
   getStatusText,
+  updateItemProgress,
   sticky,
   isValidUrl,
   delay,

--- a/libs/blocks/bulk-publish-v2/utils.js
+++ b/libs/blocks/bulk-publish-v2/utils.js
@@ -104,13 +104,13 @@ const updateItemProgress = (detail, tool) => {
   if (resources) {
     resources.forEach(({ path, status }) => {
       const item = tool.renderRoot.querySelector(`[job-item='${path}']`);
-      if (!item?.hasAttribute('updated')) {
+      if (item && !item?.hasAttribute('updated')) {
         const { text, color } = getStatusText(status, null);
         const newStatus = createTag('span', { class: `status ${color}` }, text);
         const display = item.querySelector('.status');
         display.insertAdjacentElement('afterend', newStatus);
-        item.setAttribute('updated', '');
         display.setAttribute('has-update', '');
+        item.setAttribute('updated', '');
       }
     });
   }


### PR DESCRIPTION
- Refactored the done count and item status to be updated granularly instead of re-rendering components to improve performance when doing super large bulk processes.
- Now sending create requests in batches of 5 to limit concurrency in projects without authentication enabled (100 per request).
- Now in running jobs, creating a queue of status update requests (to do one at a time) to avoid overloading the browser when doing super large bulk processes.
- Added a clear button to the error display to make it more convenient to when managing request errors in the UI.

Resolves: [MWPW-145157](https://jira.corp.adobe.com/browse/MWPW-145157)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/bulk-publish-v2?martech=off
- After: https://sarchibeque-bulk-publish-enhancements--milo--adobecom.hlx.page/tools/bulk-publish-v2?martech=off
