### PR TITLE
MWPW-143067 split mep param to ---

### DIFF
--- a/libs/features/personalization/add-preview-to-config.js
+++ b/libs/features/personalization/add-preview-to-config.js
@@ -27,7 +27,7 @@ export default async function addPreviewToConfig({
       }
     });
 
-    config.mep.override.split(',').forEach((manifestPair) => {
+    config.mep.override.split('---').forEach((manifestPair) => {
       const manifestPath = manifestPair.trim().toLowerCase().split('--')[0];
       if (!persManifestPaths.includes(manifestPath)) {
         persManifests.push({ manifestPath });


### PR DESCRIPTION
MEP parameter breaks when there are 2 manifests. In the example links, the MEP parameter lists 2 manifests.  In the before link, the MEP button only shows 1 manifest.  In the after link, it correctly shows 2.

Resolves a bug related to [MWPW-143067](https://jira.corp.adobe.com/browse/MWPW-143067)

before: https://main--cc--adobecom.hlx.page/products/premiere?milolibs=stage&target=off&mep=%2Fproducts%2Fpremiere.json--default---%2Fcc-shared%2Ffragments%2Ftests%2F2024%2Fq2%2Face0887%2Face0887.json--target-var-newsmb

after: https://main--cc--adobecom.hlx.page/products/premiere?milolibs=mepsplit&target=off&mep=%2Fproducts%2Fpremiere.json--default---%2Fcc-shared%2Ffragments%2Ftests%2F2024%2Fq2%2Face0887%2Face0887.json--target-var-newsmb

Note, psi check will fail because these are links on CC and preview feature is internal only (not good for LHS).  Looks like we never built unit tests on this file that's only used for this internal feature.  I'll add it later, but this fix needs to go ASAP.