### PR TITLE
better check for duplicates when from Target

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -715,9 +715,7 @@ export function cleanAndSortManifestList(manifests) {
   const manifestObj = {};
   manifests.forEach((manifest) => {
     if (!manifest?.manifest) return;
-    if (!manifest.manifestPath || !manifest.manifestPath.startsWith('/')) {
-      manifest.manifestPath = normalizePath(manifest.manifest);
-    }
+    if (!manifest.manifestPath) manifest.manifestPath = normalizePath(manifest.manifest);
     if (manifest.manifestPath in manifestObj) {
       let fullManifest = manifestObj[manifest.manifestPath];
       let freshManifest = manifest;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -64,6 +64,7 @@ export const normalizePath = (p) => {
 
   if (path.startsWith(config.codeRoot)
     || path.includes('.hlx.')
+    || path.includes('adobe.com/')
     || path.startsWith(`https://${config.productionDomain}`)) {
     try {
       const url = new URL(path);
@@ -714,7 +715,9 @@ export function cleanAndSortManifestList(manifests) {
   const manifestObj = {};
   manifests.forEach((manifest) => {
     if (!manifest?.manifest) return;
-    if (!manifest.manifestPath) manifest.manifestPath = normalizePath(manifest.manifest);
+    if (!manifest.manifestPath || !manifest.manifestPath.startsWith('/')) {
+      manifest.manifestPath = normalizePath(manifest.manifest);
+    }
     if (manifest.manifestPath in manifestObj) {
       let fullManifest = manifestObj[manifest.manifestPath];
       let freshManifest = manifest;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -86,14 +86,13 @@ export const preloadManifests = ({ targetManifests = [], persManifests = [] }) =
   manifests = manifests.concat(
     persManifests.map((manifest) => ({
       ...manifest,
-      manifestPath: appendJsonExt(manifest.manifestPath),
+      manifestPath: normalizePath(appendJsonExt(manifest.manifestPath)),
       manifestUrl: manifest.manifestPath,
     })),
   );
 
   for (const manifest of manifests) {
     if (!manifest.manifestData && manifest.manifestPath && !manifest.disabled) {
-      manifest.manifestPath = normalizePath(manifest.manifestPath);
       loadLink(
         manifest.manifestPath,
         { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' },

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -64,8 +64,7 @@ export const normalizePath = (p) => {
 
   if (path.startsWith(config.codeRoot)
     || path.includes('.hlx.')
-    || path.includes('adobe.com/')
-    || path.startsWith(`https://${config.productionDomain}`)) {
+    || path.includes('.adobe.')) {
     try {
       const url = new URL(path);
       const firstFolder = url.pathname.split('/')[1];


### PR DESCRIPTION
* when a pzn manifest is also sent from Target, and the manifest info is using a production URL: duplicates are not merged.

Resolves: [MWPW-145165](https://jira.corp.adobe.com/browse/MWPW-145165)
Also resolves: [Promo manifests not rendered in stage preview](https://jira.corp.adobe.com/browse/MWPW-145203)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/illustrator?mep
- After: https://main--cc--adobecom.hlx.page/products/illustrator?mep&milolibs=mepduplicates

Note that the before link shows 2 manifests and the after link shows only 1.

This feature can only be tested with Target enabled pages, so psi-check will fail.
