### PR TITLE
MWPW-139842 - Block button styling - Support button.fill w/ <strong><em> authoring

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -8,8 +8,8 @@ export function decorateButtons(el, size) {
     let buttonType = 'outline';
     if (parent.nodeName === 'EM' || parent.nodeName === 'STRONG') {
       buttonType = parent.nodeName === 'EM' ? 'outline' : 'blue';
-      if ((parent.parentElement?.nodeName === 'EM') ||
-          (parent.parentElement?.nodeName === 'STRONG')) {
+      if ((parent.parentElement?.nodeName === 'EM')
+        || (parent.parentElement?.nodeName === 'STRONG')) {
         buttonType = 'fill';
       }
     }
@@ -19,7 +19,7 @@ export function decorateButtons(el, size) {
     } else {
       button.classList.add('con-button', buttonType);
       if (size) button.classList.add(size);
-    }    
+    }
     const actionArea = button.closest('p, div');
     if (actionArea) {
       actionArea.classList.add('action-area');
@@ -29,7 +29,7 @@ export function decorateButtons(el, size) {
 
   for (const btn of buttons) {
     const parent = btn.parentElement;
-    if (parent.parentElement?.nodeName === 'EM' || parent.parentElement?.nodeName === 'STRONG') { 
+    if (parent.parentElement?.nodeName === 'EM' || parent.parentElement?.nodeName === 'STRONG') {
       const grandParentBtns = parent.parentElement.querySelectorAll('.con-button');
       parent.parentElement.replaceWith(...grandParentBtns);
     } else if (parent.nodeName === 'EM' || parent.nodeName === 'STRONG') {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -6,7 +6,8 @@ export function decorateButtons(el, size) {
   const buttonTypeMap = { STRONG: 'blue', EM: 'outline', A: 'blue' };
   buttons.forEach((button) => {
     const parent = button.parentElement;
-    const buttonType = buttonTypeMap[parent.nodeName] || 'outline';
+    let buttonType = buttonTypeMap[parent.nodeName] || 'outline';
+    if (parent.nodeName === 'EM' && parent.parentElement.nodeName === 'STRONG') buttonType = 'fill';
     if (button.nodeName === 'STRONG') {
       parent.classList.add('con-button', buttonType);
       if (size) parent.classList.add(size); /* button-l, button-xl */

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -3,26 +3,40 @@ import { createTag } from './utils.js';
 export function decorateButtons(el, size) {
   const buttons = el.querySelectorAll('em a, strong a, p > a strong');
   if (buttons.length === 0) return;
-  const buttonTypeMap = { STRONG: 'blue', EM: 'outline', A: 'blue' };
   buttons.forEach((button) => {
     const parent = button.parentElement;
-    let buttonType = buttonTypeMap[parent.nodeName] || 'outline';
-    if (parent.nodeName === 'EM' && parent.parentElement.nodeName === 'STRONG') buttonType = 'fill';
+    let buttonType = 'outline';
+    if (parent.nodeName === 'EM' || parent.nodeName === 'STRONG') {
+      buttonType = parent.nodeName === 'EM' ? 'outline' : 'blue';
+      if ((parent.parentElement?.nodeName === 'EM') ||
+          (parent.parentElement?.nodeName === 'STRONG')) {
+        buttonType = 'fill';
+      }
+    }
     if (button.nodeName === 'STRONG') {
       parent.classList.add('con-button', buttonType);
-      if (size) parent.classList.add(size); /* button-l, button-xl */
+      if (size) parent.classList.add(size);
     } else {
       button.classList.add('con-button', buttonType);
-      if (size) button.classList.add(size); /* button-l, button-xl */
-      parent.insertAdjacentElement('afterend', button);
-      parent.remove();
-    }
+      if (size) button.classList.add(size);
+    }    
     const actionArea = button.closest('p, div');
     if (actionArea) {
       actionArea.classList.add('action-area');
       actionArea.nextElementSibling?.classList.add('supplemental-text', 'body-xl');
     }
   });
+
+  for (const btn of buttons) {
+    const parent = btn.parentElement;
+    if (parent.parentElement?.nodeName === 'EM' || parent.parentElement?.nodeName === 'STRONG') { 
+      const grandParentBtns = parent.parentElement.querySelectorAll('.con-button');
+      parent.parentElement.replaceWith(...grandParentBtns);
+    } else if (parent.nodeName === 'EM' || parent.nodeName === 'STRONG') {
+      const parentBtns = parent.querySelectorAll('.con-button');
+      parent.replaceWith(...parentBtns);
+    }
+  }
 }
 
 export function decorateIconStack(el) {

--- a/test/blocks/media/media.test.js
+++ b/test/blocks/media/media.test.js
@@ -23,7 +23,7 @@ describe('media', () => {
       expect(iconArea).to.exist;
     });
     it('has an icon area with blue button', () => {
-      const actionArea = medias[3].querySelector('.action-area');
+      const actionArea = medias[0].querySelector('.action-area');
       expect(actionArea).to.exist;
       const blueButton = actionArea.querySelector('.con-button.blue');
       expect(blueButton).to.exist;


### PR DESCRIPTION
As an author in Milo, I want the ability to add a 'fill' button to a Milo page. This should be available in the same capacity as the rest of the buttons as shown here: https://milo.adobe.com/docs/authoring/button-mapping  

<img width="155" alt="Screen Shot 2024-03-04 at 2 43 45 PM" src="https://github.com/adobecom/milo/assets/2086146/f5c79386-f794-41c5-8583-676e95f82236">



Resolves: [MWPW-139842](https://jira.corp.adobe.com/browse/MWPW-139842)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/buttons?martech=off
- After: https://rparrish-button-fill--milo--adobecom.hlx.page/drafts/rparrish/buttons?martech=off


Additional live pages can be tested w/ the url param `?miloLibs=rparrrish-button-fill`
(No`fill` buttons should be present on any live content w/ the exception of bricks)
https://main--cc--adobecom.hlx.page/products/illustrator/free-trial-download?miloLibs=rparrrish-button-fill
https://main--cc--adobecom.hlx.page/products/illustrator?miloLibs=rparrrish-button-fill
https://main--cc--adobecom.hlx.page/products/premiere?miloLibs=rparrrish-button-fill
https://main--cc--adobecom.hlx.page/products/firefly?miloLibs=rparrrish-button-fill

