### PR TITLE
MWPW-144125 and MWPW-144536 [MILO][MEP] Request for New Personalization Tags

### DIFF
--- a/libs/features/personalization/entitlements.js
+++ b/libs/features/personalization/entitlements.js
@@ -13,6 +13,10 @@ const ENTITLEMENT_MAP = {
   'ab713720-91a2-4e8e-b6d7-6f613e049566': 'any-cc-product-no-stock',
   'b0f65e1c-7737-4788-b3ae-0011c80bcbe1': 'any-cc-product-with-stock',
   '934fdc1d-7ba6-4644-908b-53e01e550086': 'any-dc-product',
+  '6dfcb769-324f-42e0-9e12-1fc4dc0ee85b': 'always-on-promo',
+  '015c52cb-30b0-4ac9-b02e-f8716b39bfb6': 'not-q-always-on-promo',
+  '42e06851-64cd-4684-a54a-13777403487a': '3d-substance-collection',
+  'eda8c774-420b-44c2-9006-f9a8d0fb5168': '3d-substance-texturing',
 };
 
 export const getEntitlementMap = async () => {

--- a/libs/features/personalization/stage-entitlements.js
+++ b/libs/features/personalization/stage-entitlements.js
@@ -7,6 +7,8 @@ const STAGE_ENTITLEMENTS = {
   '07609803-48a0-4762-be51-94051ccffb45': 'premiere-pro-any',
   '67129b31-eb1a-4c9e-b251-4561ac7c8602': 'any-cc-product-no-stock',
   '569f0f9d-83e8-45b4-adbf-07ef08a83398': 'any-cc-product-with-stock',
+  '47e204a3-220a-4e53-a95e-94b6eded0d26': '3d-substance-collection',
+  '4ec7b469-42c9-4367-a7da-39f11a32d880': '3d-substance-texturing',
 };
 
 export default STAGE_ENTITLEMENTS;


### PR DESCRIPTION
Adding a few pzn tags to the prod and stage objects.

Resolves: [MWPW-144125](https://jira.corp.adobe.com/browse/MWPW-144125) and [MWPW-144536](https://jira.corp.adobe.com/browse/MWPW-144536)

**Test URLs:**
N/A but for PR check:
- Before: https://main--milo--adobecom.hlx.page?martech=off
- After: https://addmeppzntags--milo--adobecom.hlx.page?martech=off

Note: Psi check will fail since there are no test URL's.

This PR is considered a blocker, but the other team that needs this data is also in a code freeze.  So as long as we can deploy to prod by 4/1 we're fine.