### PR TITLE
MWPW-145302: Added 's-size' class for modal, and horizontal paddings for section

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -207,6 +207,10 @@
 }
 
 @media (min-width: 1200px) {
+  .dialog-modal.s-size {
+    max-width: 650px;
+  }
+
   .region-selector .content {
     column-count: 5;
   }

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -70,6 +70,38 @@
   padding: var(--spacing-xxs) 0;
 }
 
+.section.xxxl-padding {
+  padding: var(--spacing-xxxl);
+}
+
+.section.xxl-padding {
+  padding: var(--spacing-xxl);
+}
+
+.section.xl-padding {
+  padding: var(--spacing-xl);
+}
+
+.section.l-padding {
+  padding: var(--spacing-l);
+}
+
+.section.m-padding {
+  padding: var(--spacing-m);
+}
+
+.section.s-padding {
+  padding: var(--spacing-s);
+}
+
+.section.xs-padding {
+  padding: var(--spacing-xs);
+}
+
+.section.xxs-padding {
+  padding: var(--spacing-xxs);
+}
+
 .section picture.section-background {
   display: block;
   position: absolute;


### PR DESCRIPTION
To create a Terms and Conditions modal like this one: 
https://www.adobe.com/promo/streamyard.html#terms 
two things were missing in Milo: the possibility to add horizontal padding for sections, and the possibility to restrict the modal width on the desktop screen to 650px.
As a rule, modals adjust to the fragment content size, but in case of this modal we need to restrict its width, so we introduce the class 's-size' for the max-width of 650px (only on desktop, on mobile and tablet it will take the whole available screen width).
As for section, classes `xxxl/xl/l/etc-spacing` add vertical padding, but set horizontal padding to 0.
We add classes `xxxl/xl/l/etc-padding` for the section to make it possible to have even horizontal and vertical paddings.

Resolves: [MWPW-145302](https://jira.corp.adobe.com/browse/MWPW-145302)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/rakaur/samsung#see-terms-modal
- After: https://mwpw-145302-modal-s-and-section-padding--milo--mirafedas.hlx.page/drafts/mirafedas/all-modals#samsung
