### PR TITLE
MWPW-145566 remove faq from MILO_BLOCKS array

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -27,7 +27,6 @@ const MILO_BLOCKS = [
   'chart',
   'columns',
   'faas',
-  'faq',
   'featured-article',
   'figure',
   'form',


### PR DESCRIPTION
Currently express is migrating its faq block so that it works with milo code like any other milo college project.There used to be a block in milo named faq, but it was refactored to be called accordion with addtional functionality - https://github.com/adobecom/milo/pull/43. 
Our faq block in express is not working though because milo believes it still has a faq block.

The faq entry in the block array in utils.js in milo needs to have this entry removed, so that our faq block in express works correctly. For milo this is simply code cleanup - less bytes to all our clients  ;)

Resolves: [MWPW-145566](https://jira.corp.adobe.com/browse/MWPW-145566)

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/?martech=off
- After: https://vhargrave-mwpw-145566-faq-utils-cleanup--milo--adobecom.hlx.page/?martech=off
