### PR TITLE
Automatically mark stale PRs & close them after 7 days

### DIFF
--- a/.github/workflows/mark-stale-prs.yaml
+++ b/.github/workflows/mark-stale-prs.yaml
@@ -1,0 +1,19 @@
+name: "Close stale pull requests"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-pr-message: 'This PR has not been updated recently and will be closed in 7 days if no action is taken. Please ensure all checks are passing, https://github.com/orgs/adobecom/discussions/997 provides instructions. If the PR is ready to be merged, please mark it with the "Ready for Stage" label.'
+          close-pr-message: 'Closing this PR due to inactivity.'
+          days-before-stale: 7
+          days-before-close: 7
+          exempt-pr-labels: 'Ready for Stage'
+          operations-per-run: 100


### PR DESCRIPTION
### Description
Warn and then close issues and PRs that have had no activity for a specified amount of time using the [stale](https://github.com/actions/stale) workflow.

- PRs that have not seen any activity for 7 days are marked as stale
- stale PRs are closed after 7 days
- PRs that are "Ready for Stage" are exempt.

Example: https://github.com/adobecom/milo/pulls?q=is%3Aopen+is%3Apr+label%3AStale
Example message on the PR: https://github.com/adobecom/milo/pull/1881#issuecomment-2020125661

Resolves: [MWPW-143674](https://jira.corp.adobe.com/browse/MWPW-143674)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mark-stale-prs--milo--adobecom.hlx.page/?martech=off
