### PR TITLE
MWPW-144236 - Correct rollout total

### DIFF
--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -25,7 +25,7 @@ function Language({ item, idx }) {
   const hasLocales = item.locales?.length > 0;
   const cssStatus = `locui-subproject-${item.status || 'not-started'}`;
   const completeType = item.status === 'translated' || item.status === 'in-progress' ? 'Translated' : 'Rolled out';
-  const total = item.total && completeType === 'Rolled out' ? item.total * item.size : null;
+  const total = item.total && completeType === 'Rolled out' ? item.total : null;
   const rolloutType = item.status === 'completed' ? 'Re-rollout' : 'Rollout';
   return html`
     <li class="locui-subproject ${cssStatus}" onClick=${(e) => showLangErrors(e, item)}>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Multiplying by the languages size is no longer needed, the lang's `total` property should be sufficient by itself.

Resolves: [MWPW-144236](https://jira.corp.adobe.com/browse/MWPW-144236)

**Test URLs:**
- Before: https://locui--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B08E1FC5E-2434-497D-9789-992E4190304A%257D%26file%3Delan-test.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
- After: https://ebartholomew-locui-total--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B08E1FC5E-2434-497D-9789-992E4190304A%257D%26file%3Delan-test.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
