### PR TITLE
mwpw-145710: load ims via param from old domain

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -136,6 +136,7 @@ export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
 
 const LANGSTORE = 'langstore';
 const PAGE_URL = new URL(window.location.href);
+
 function getEnv(conf) {
   const { host } = window.location;
   const query = PAGE_URL.searchParams.get('env');

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -793,7 +793,13 @@ export async function loadIms() {
       },
       onError: reject,
     };
-    loadScript(`${base}/deps/imslib.min.js`);
+    const params = new URLSearchParams(window.location.search);
+    const useLHControlGroup = params.get('useAlternateImsDomain');
+    if (useLHControlGroup) {
+      loadScript('https://auth.services.adobe.com/imslib/imslib.min.js');
+    } else {
+      loadScript(`${base}/deps/imslib.min.js`);
+    }
   }).then(() => {
     if (!window.adobeIMS?.isSignedInUser()) {
       getConfig().entitlements([]);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -136,7 +136,6 @@ export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
 
 const LANGSTORE = 'langstore';
 const PAGE_URL = new URL(window.location.href);
-
 function getEnv(conf) {
   const { host } = window.location;
   const query = PAGE_URL.searchParams.get('env');
@@ -670,8 +669,7 @@ function decorateHeader() {
     header.remove();
     return;
   }
-  const headerQuery = new URLSearchParams(window.location.search).get('headerqa');
-  header.className = headerQuery || headerMeta || 'gnav';
+  header.className = headerMeta || 'gnav';
   const metadataConfig = getMetadata('breadcrumbs')?.toLowerCase()
   || getConfig().breadcrumbs;
   if (metadataConfig === 'off') return;
@@ -711,8 +709,7 @@ async function loadFooter() {
     footer.remove();
     return;
   }
-  const footerQuery = new URLSearchParams(window.location.search).get('footerqa');
-  footer.className = footerQuery || footerMeta || 'footer';
+  footer.className = footerMeta || 'footer';
   await loadBlock(footer);
 }
 
@@ -793,13 +790,10 @@ export async function loadIms() {
       },
       onError: reject,
     };
-    const params = new URLSearchParams(window.location.search);
-    const useLHControlGroup = params.get('useAlternateImsDomain');
-    if (useLHControlGroup) {
-      loadScript('https://auth.services.adobe.com/imslib/imslib.min.js');
-    } else {
-      loadScript(`${base}/deps/imslib.min.js`);
-    }
+    const path = PAGE_URL.searchParams.get('useAlternateImsDomain')
+      ? 'https://auth.services.adobe.com/imslib/imslib.min.js'
+      : `${base}/deps/imslib.min.js`;
+    loadScript(path);
   }).then(() => {
     if (!window.adobeIMS?.isSignedInUser()) {
       getConfig().entitlements([]);
@@ -830,8 +824,7 @@ export async function loadMartech({ persEnabled = false, persManifests = [] } = 
 }
 
 async function checkForPageMods() {
-  const search = new URLSearchParams(window.location.search);
-  const offFlag = (val) => search.get(val) === 'off';
+  const offFlag = (val) => PAGE_URL.searchParams.get(val) === 'off';
   if (offFlag('mep')) return;
   const persMd = getMetadata('personalization');
   const promoMd = getMetadata('manifestnames');


### PR DESCRIPTION
## Description
Load IMS from the old domain via query parameter `useAlternateImsDomain` to run some LH tests with both the old and new self hosted domain to measure the LH score impact.

## Related Issue
Resolves: [MWPW-145710](https://jira.corp.adobe.com/browse/MWPW-145710)

## Testing instructions
Scenario-1: Load a page, signing in should still work.
Secnario-2: Load a page with `&useAlternateImsDomain=true` and IMS should be loaded from the old domain

## Screenshots
Without query param
![Screenshot 2024-03-27 at 14 51 33](https://github.com/adobecom/milo/assets/39759830/9a4d09b0-86e8-4ae2-81e0-29423b752535)

With query param
![Screenshot 2024-03-27 at 14 51 21](https://github.com/adobecom/milo/assets/39759830/92ac0904-af00-4991-ab98-6d12c086c382)


## Test URLs
**Milo using the old ims url**
- Before: https://main--milo--adobecom.hlx.live/drafts/osahin/gnav-1?martech=off&useAlternateImsDomain=true
- After: https://mwpw-145710-ims-self-hosting--milo--mokimo.hlx.live/drafts/osahin/gnav-1?martech=off&useAlternateImsDomain=true

**Milo using the new self hosted ims url**
- Before: https://main--milo--adobecom.hlx.live/drafts/osahin/gnav-1?martech=off&useAlternateImsDomain=true
- After: https://mwpw-145710-ims-self-hosting--milo--mokimo.hlx.live/drafts/osahin/gnav-1?martech=off&georouting=off&useAlternateImsDomain=true
