### PR TITLE
Localize federal inline fragments before fetching them

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -1,4 +1,6 @@
-import { getConfig, getMetadata, loadStyle, loadLana, decorateLinks } from '../../../utils/utils.js';
+import {
+  getConfig, getMetadata, loadStyle, loadLana, decorateLinks, localizeLink,
+} from '../../../utils/utils.js';
 import { processTrackingLabels } from '../../../martech/attributes.js';
 import { replaceText } from '../../../features/placeholders.js';
 
@@ -314,7 +316,7 @@ export async function fetchAndProcessPlainHtml({ url, shouldDecorateLinks = true
   if (inlineFrags.length) {
     const { default: loadInlineFrags } = await import('../../fragment/fragment.js');
     const fragPromises = inlineFrags.map((link) => {
-      link.href = getFederatedUrl(link.href);
+      link.href = getFederatedUrl(localizeLink(link.href));
       return loadInlineFrags(link);
     });
     await Promise.all(fragPromises);


### PR DESCRIPTION
## Description
@overmyheadandbody has done the initial research and
> We're not localizing fragment links. The main navigation is fetched via the localized path, the same for the dropdown menus; but any fragments nested inside the dropdown menus are no longer localized. 

## Related Issue
Resolves: [MWPW-145673](https://jira.corp.adobe.com/browse/MWPW-145673)

## Testing instructions
Federal fragments should be localizeable


## Test URLs
**Initial bug report in the german variant**
- Before: https://main--federal--adobecom.hlx.page/de/federal/globalnav/drafts/ankshukl/document-preview-acom-gnav-plus-footer
- After: https://main--federal--adobecom.hlx.page/de/federal/globalnav/drafts/ankshukl/document-preview-acom-gnav-plus-footer?milolibs=mwpw-145673-federal-fragments--milo--mokimo

**English variant:**
- Before: https://main--federal--adobecom.hlx.page/federal/globalnav/drafts/ankshukl/document-preview-acom-gnav-plus-footer
- After: https://main--federal--adobecom.hlx.page/federal/globalnav/drafts/ankshukl/document-preview-acom-gnav-plus-footer?milolibs=mwpw-145673-federal-fragments--milo--mokimo

Base regression links:
**Acrobat:**
- Before: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off
- After: https://www.stage.adobe.com/acrobat/online/sign-pdf.html?martech=off&milolibs=mwpw-145673-federal-fragments--milo--mokimo

**BACOM:**
- Before: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off
- After: https://business.stage.adobe.com/fr/customer-success-stories.html?martech=off&milolibs=mwpw-145673-federal-fragments--milo--mokimo

**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=mwpw-145673-federal-fragments--milo--mokimo

**Homepage:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=mwpw-145673-federal-fragments--milo--mokimo

**Blog:**
- Before: https://main--blog--adobecom.hlx.page/
- After: https://main--blog--adobecom.hlx.page/?milolibs=mwpw-145673-federal-fragments--milo--mokimo

**Milo:**
- Before: https://main--milo--adobecom.hlx.live/ch_de/drafts/ramuntea/gnav-refactor?martech=off
- After: https://mwpw-145673-federal-fragments--milo--mokimo.hlx.live/ch_de/drafts/ramuntea/gnav-refactor?martech=off&georouting=off
