### PR TITLE
MWPW-145728 Increase timeout; add metadata support

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -605,29 +605,6 @@ export async function getPersConfig(info, override = false) {
     config.executionOrder = '1-1';
   }
 
-  if (infoTab) {
-    const infoObj = infoTab?.reduce((acc, item) => {
-      acc[item.key] = item.value;
-      return acc;
-    }, {});
-    config.manifestOverrideName = infoObj?.['manifest-override-name']?.toLowerCase();
-    config.manifestType = infoObj?.['manifest-type']?.toLowerCase();
-    const executionOrder = {
-      'manifest-type': 1,
-      'manifest-execution-order': 1,
-    };
-    Object.keys(infoObj).forEach((key) => {
-      if (!infoKeyMap[key]) return;
-      const index = infoKeyMap[key].indexOf(infoObj[key]);
-      executionOrder[key] = index > -1 ? index : 1;
-    });
-    config.executionOrder = `${executionOrder['manifest-execution-order']}-${executionOrder['manifest-type']}`;
-  } else {
-    // eslint-disable-next-line prefer-destructuring
-    config.manifestType = infoKeyMap[1];
-    config.executionOrder = '1-1';
-  }
-
   config.manifestPath = normalizePath(manifestPath);
   const selectedVariantName = await getPersonalizationVariant(
     config.manifestPath,

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -103,7 +103,7 @@ const getTargetPersonalization = async () => {
   const responseStart = performance.now();
   window.addEventListener(ALLOY_SEND_EVENT, () => {
     const responseTime = performance.now() - responseStart;
-    sendAnalytics(Math.ceil(responseTime / 250) / 4);
+    sendAnalytics(`target response time ${Math.ceil(responseTime / 250) / 4}`);
   }, { once: true });
 
   try {

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -1,7 +1,7 @@
-import { getConfig, loadIms, loadLink, loadScript } from '../utils/utils.js';
+import { getConfig, getMetadata, loadIms, loadLink, loadScript } from '../utils/utils.js';
 
 const ALLOY_SEND_EVENT = 'alloy_sendEvent';
-const TARGET_TIMEOUT_MS = 2000;
+const TARGET_TIMEOUT_MS = 3500;
 const ENTITLEMENT_TIMEOUT = 3000;
 
 const setDeep = (obj, path, value) => {
@@ -77,7 +77,9 @@ const getTargetPersonalization = async () => {
   const experimentParam = params.get('experiment');
   if (experimentParam) return getExpFromParam(experimentParam);
 
-  const timeout = parseInt(params.get('target-timeout'), 10) || TARGET_TIMEOUT_MS;
+  const timeout = parseInt(params.get('target-timeout'), 10)
+    || parseInt(getMetadata('target-timeout'), 10)
+    || TARGET_TIMEOUT_MS;
 
   let response;
   try {

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -82,12 +82,21 @@ const getTargetPersonalization = async () => {
     || TARGET_TIMEOUT_MS;
 
   let response;
+
   try {
     response = await waitForEventOrTimeout(ALLOY_SEND_EVENT, timeout);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log(e);
+
+    // TODO: Timeout happened, update analytics here
   }
+
+  const responseStart = performance.now();
+  window.addEventListener(ALLOY_SEND_EVENT, () => {
+    const responseTime = performance.now() - responseStart;
+    // TODO: update analytics here
+  });
 
   let manifests = [];
   if (response) {

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -116,11 +116,11 @@ const getTargetPersonalization = async () => {
 
   try {
     response = await waitForEventOrTimeout(ALLOY_SEND_EVENT, timeout);
-    sendTargetResponseAnalytics(true, responseStart);
+    sendTargetResponseAnalytics(false, responseStart);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.log(e);
-    sendTargetResponseAnalytics(false, responseStart);
+    sendTargetResponseAnalytics(true, responseStart);
   }
 
   let manifests = [];


### PR DESCRIPTION
Increase the default timeout to 3.5s.  Also add ability to modify the timeout 

Resolves: [MWPW-145728](https://jira.corp.adobe.com/browse/MWPW-145728)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://ccc-target-timeout--milo--adobecom.hlx.page/?martech=off

As promised, here is the Jira ticket to create unit tests for martech.js https://jira.corp.adobe.com/browse/MWPW-145975