### PR TITLE
MWPW-145667 [MILO][MEP] Pzn analytic not added if default experience is chosen

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -605,29 +605,6 @@ export async function getPersConfig(info, override = false) {
     config.executionOrder = '1-1';
   }
 
-  if (infoTab) {
-    const infoObj = infoTab?.reduce((acc, item) => {
-      acc[item.key] = item.value;
-      return acc;
-    }, {});
-    config.manifestOverrideName = infoObj?.['manifest-override-name']?.toLowerCase();
-    config.manifestType = infoObj?.['manifest-type']?.toLowerCase();
-    const executionOrder = {
-      'manifest-type': 1,
-      'manifest-execution-order': 1,
-    };
-    Object.keys(infoObj).forEach((key) => {
-      if (!infoKeyMap[key]) return;
-      const index = infoKeyMap[key].indexOf(infoObj[key]);
-      executionOrder[key] = index > -1 ? index : 1;
-    });
-    config.executionOrder = `${executionOrder['manifest-execution-order']}-${executionOrder['manifest-type']}`;
-  } else {
-    // eslint-disable-next-line prefer-destructuring
-    config.manifestType = infoKeyMap[1];
-    config.executionOrder = '1-1';
-  }
-
   config.manifestPath = normalizePath(manifestPath);
   const selectedVariantName = await getPersonalizationVariant(
     config.manifestPath,
@@ -674,8 +651,7 @@ const normalizeFragPaths = ({ selector, val, action }) => ({
 export async function runPersonalization(experiment, config) {
   if (!experiment) return null;
   const { manifestPath, selectedVariant } = experiment;
-  if (!selectedVariant) return {};
-  if (selectedVariant === 'default') return { experiment };
+  if (!selectedVariant || selectedVariant === 'default') return { experiment };
 
   if (selectedVariant.replacepage) {
     // only one replacepage can be defined


### PR DESCRIPTION
When a pzn manifest is sent by Target and Personalization and chooses the default experience, it should still add personalization analytics to each block. Currently it does not.

Also removing some duplicate code from a previous merge conflict.

Steps to reproduce:
1. Go to before page like https://main--cc--adobecom.hlx.page/products/illustrator?mep=%2Fproducts%2Fillustrator.json--default
2. Inspect the marquee block. The daa-lh attribute should equal `b1|marquee|nopzn|illustrator` but instead it equals `b1|marquee`

Example of new code on a CC page:
- Before: https://main--cc--adobecom.hlx.page/products/illustrator?mep=%2Fproducts%2Fillustrator.json--default
- After: https://main--cc--adobecom.hlx.page/products/illustrator?milolibs=meppznanalytics&mep=%2Fproducts%2Fillustrator.json--default

Resolves: [MWPW-145667](https://jira.corp.adobe.com/browse/MWPW-145667)

**Test URLs:**
Does not work but now does:
- Before: https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q2/meppznanalytics/pzn-and-target
- After: https://meppznanalytics--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q2/meppznanalytics/pzn-and-target

Already worked correctly and still does:
Just from Personalization in metadata:
- Before: https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q2/meppznanalytics/pzn
- After: https://meppznanalytics--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q2/meppznanalytics/pzn

Just from Target:
Before: https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q2/meppznanalytics/target
After: https://meppznanalytics--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q2/meppznanalytics/target

Note: psi check will fail since pages are using Target