### PR TITLE
MWPW-145783 - Show correct complete label for action type

### DIFF
--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -24,8 +24,7 @@ function Badge({ status }) {
 function Language({ item, idx }) {
   const hasLocales = item.locales?.length > 0;
   const cssStatus = `locui-subproject-${item.status || 'not-started'}`;
-  const completeType = item.status === 'translated' || item.status === 'in-progress' ? 'Translated' : 'Rolled out';
-  const total = item.total && completeType === 'Rolled out' ? item.total : null;
+  const completeLabel = item.Action === 'Translate' ? 'Translated' : 'Rolled out';
   const rolloutType = item.status === 'completed' ? 'Re-rollout' : 'Rollout';
   return html`
     <li class="locui-subproject ${cssStatus}" onClick=${(e) => showLangErrors(e, item)}>
@@ -41,12 +40,12 @@ function Language({ item, idx }) {
         </div>
         ${item.done > 0 && html`
         <div>
-          <p class=locui-project-label>${completeType}</p>
+          <p class=locui-project-label>${completeLabel}</p>
           <div class=locui-project-name-totals>
             <h3 class=locui-subproject-name>${item.done}</h3>
-            ${total > 0 && html`
+            ${item.total > 0 && html`
               <h4 class=locui-subproject-of>of</h4>
-              <h4 class=locui-subproject-name>${total}</h3>
+              <h4 class=locui-subproject-name>${item.total}</h3>
             `}
           </div>
         </div>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* The 'complete label' above the done vs total count section of each language would always show "Rolled Out", even if the language was being translated, not rolled out. This PR should fix this, and generally simplify the way we display the language's status.

Resolves: [MWPW-145783](https://jira.corp.adobe.com/browse/MWPW-145783)

**Test URLs:**
- Before: https://locui--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B08E1FC5E-2434-497D-9789-992E4190304A%257D%26file%3Delan-test.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
- After: https://ebartholomew-locui-complete-label--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B08E1FC5E-2434-497D-9789-992E4190304A%257D%26file%3Delan-test.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
