### PR TITLE
[MWPW-145189] Adobe Home post-login redirect

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -777,13 +777,15 @@ export async function loadIms() {
       reject(new Error('Missing IMS Client ID'));
       return;
     }
-    const unavMeta = getMetadata('universal-nav')?.trim();
+    const [unavMeta, ahomeMeta] = [getMetadata('universal-nav')?.trim(), getMetadata('adobe-home-redirect')];
     const defaultScope = `AdobeID,openid,gnav${unavMeta && unavMeta !== 'off' ? ',pps.read,firefly_api' : ''}`;
     const timeout = setTimeout(() => reject(new Error('IMS timeout')), 5000);
     window.adobeid = {
       client_id: imsClientId,
       scope: imsScope || defaultScope,
       locale: locale?.ietf?.replace('-', '_') || 'en_US',
+      redirect_uri: ahomeMeta === 'on'
+        ? `https://www${env !== 'prod' ? '.stage' : ''}.adobe.com${locale.prefix}` : undefined,
       autoValidateToken: true,
       environment: env.ims,
       useLocalStorage: false,


### PR DESCRIPTION
By defining a metadata property, `adobe-home-redirect`, and setting it to `on`, a user will be redirected to the homepage after logging in. Redirect rules will then reroute them to the appropriate localized Adobe Home page.

Resolves: [MWPW-145189](https://jira.corp.adobe.com/browse/MWPW-145189)

---
### ❗NOTE❗ 
This has been deemed critical by leadership and thus was marked as such. The AEM and Milo sides of this implementation need to come together with the redirect rules and Adobe Home implementation on ROW for true E2E testing. The committed date for stage is **April 2nd**. Details surrounding the plan are also available in the comments section of the story.

---

**Testing instructions:**
- visit the URL, log out if needed
- check that `window.adobeid` has a `redirect_uri` defined leading to the stage homepage
-  log in
- you should be redirected to the Adobe Home page on stage with the appropriate locale set through the `acomLocale` query parameter

**Test URLs:**
- Before (US): https://main--cc--adobecom.hlx.page/drafts/ramuntea/photoshop?martech=off&georouting=off
- After (US): https://main--cc--adobecom.hlx.page/drafts/ramuntea/photoshop?milolibs=ims--milo--adobecom&martech=off&georouting=off
- Before (CH_DE): https://main--cc--adobecom.hlx.page/ch_de/drafts/ramuntea/premiere?martech=off&georouting=off
- After (CH_DE): https://main--cc--adobecom.hlx.page/ch_de/drafts/ramuntea/premiere?milolibs=ims--milo--adobecom&martech=off&georouting=off
