### PR TITLE
MWPW-145643 - Add retry button to lang module on error

### DIFF
--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -60,9 +60,11 @@ function Language({ item, idx }) {
           `)}
         </div>
       `}
-      ${(item.status === 'translated' || item.status === 'completed') && html`
+      ${['translated', 'completed', 'error'].find((i) => i === item.status) && html`
         <div class=locui-subproject-action-area>
-          <button class=locui-urls-heading-action onClick=${() => rollout(item, idx)}>${rolloutType}</button>
+          <button class=locui-urls-heading-action onClick=${() => rollout(item, idx)}>
+            ${item.status === 'error' ? 'Retry' : rolloutType}
+          </button>
         </div>
       `}
     </li>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* As an author, I would like the option to individually retry the rollout/translation process on specific languages after they show an error status, as displayed below. In the test URLs I've provided, take a look at German; the Before link will just show the language card, the After link should have a "Retry" button.

Resolves: [MWPW-145643](https://jira.corp.adobe.com/browse/MWPW-145643)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/tools/loc?milolibs=locui&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B03be638a-488f-484d-b91f-0593318bc33e%257D%26action%3Deditnew
- After: https://main--cc--adobecom.hlx.page/tools/loc?milolibs=ebartholomew-locui-retry-lang&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B03be638a-488f-484d-b91f-0593318bc33e%257D%26action%3Deditnew
