### PR TITLE
MWPW-145643 - Revert retry button for now

### DIFF
--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -60,11 +60,9 @@ function Language({ item, idx }) {
           `)}
         </div>
       `}
-      ${['translated', 'completed', 'error'].find((i) => i === item.status) && html`
+      ${(item.status === 'translated' || item.status === 'completed') && html`
         <div class=locui-subproject-action-area>
-          <button class=locui-urls-heading-action onClick=${() => rollout(item, idx)}>
-            ${item.status === 'error' ? 'Retry' : rolloutType}
-          </button>
+          <button class=locui-urls-heading-action onClick=${() => rollout(item, idx)}>${rolloutType}</button>
         </div>
       `}
     </li>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* A special endpoint is required for this button to have the desired effect. Reverting it for now while we wait for that endpoint, to avoid confusion amongst authors.

Resolves: [MWPW-145643](https://jira.corp.adobe.com/browse/MWPW-145643)

**Test URLs:**
- Before: https://locui--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B469f3162-9516-40ef-a7e6-a6295b3faba8%257D%26action%3Deditnew
- After: https://ebartholomew-locui-revert-retry--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B469f3162-9516-40ef-a7e6-a6295b3faba8%257D%26action%3Deditnew
