### PR TITLE
MWPW-145921 - [Bulk Publish v2] update for deprecated api methods

### DIFF
--- a/libs/blocks/bulk-publish-v2/bulk-publish-v2.js
+++ b/libs/blocks/bulk-publish-v2/bulk-publish-v2.js
@@ -2,6 +2,7 @@ import { getConfig } from '../../utils/utils.js';
 import './components/bulk-publisher.js';
 
 export default async function init(el) {
+  console.log('use local');
   el.append(document.createElement('bulk-publish'));
   const { miloLibs, codeRoot } = getConfig();
   const base = miloLibs || codeRoot || 'libs';

--- a/libs/blocks/bulk-publish-v2/bulk-publish-v2.js
+++ b/libs/blocks/bulk-publish-v2/bulk-publish-v2.js
@@ -2,7 +2,6 @@ import { getConfig } from '../../utils/utils.js';
 import './components/bulk-publisher.js';
 
 export default async function init(el) {
-  console.log('use local');
   el.append(document.createElement('bulk-publish'));
   const { miloLibs, codeRoot } = getConfig();
   const base = miloLibs || codeRoot || 'libs';


### PR DESCRIPTION
Surprise! The delete and un-publish processes respective api methods were recently deprecated. This PR updates the services to use the new body schema for both processes.

For the delete and un-publish processes:
- uses `POST` instead of `DELETE` request method
- now passing property `delete: true` in the body
- now uses `body.paths` instead of `paths[]` url parameter for urls
- updated testing fetch mocks to use correct mock data if delete property is included in request body

Resolves: [MWPW-145921](https://jira.corp.adobe.com/browse/MWPW-145921)

Will need to test in BACOM because the remove processes are not available in milo due to missing authentication.
Please use the milolibs param with this branch and a draft of your choosing:
[https://main--bacom--adobecom.hlx.page/tools/bulk?milolibs=sarchibeque-bulk-publish-unpublish](https://main--bacom--adobecom.hlx.page/tools/bulk?milolibs=sarchibeque-bulk-publish-unpublish)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/bulk-publish-v2?martech=off
- After: https://sarchibeque-bulk-publish-unpublish--milo--adobecom.hlx.page/tools/bulk-publish-v2?martech=off
