### PR TITLE
[MWPW-142625] PEP relative to App Switcher

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -370,6 +370,7 @@ header.global-navigation {
 }
 
 .feds-utilities {
+  position: relative;
   display: flex;
   align-items: center;
   padding: 0 var(--feds-gutter);

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -1,19 +1,18 @@
 import {
   decorateCta,
+  fetchAndProcessPlainHtml,
   getActiveLink,
   getAnalyticsValue,
-  logErrorFor,
-  setActiveDropdown,
-  trigger,
+  icons,
   isDesktop,
-  selectors,
-  toFragment,
-  yieldToMain,
-  fetchAndProcessPlainHtml,
   lanaLog,
+  logErrorFor,
+  selectors,
+  setActiveDropdown,
+  toFragment,
+  trigger,
+  yieldToMain,
 } from '../utilities.js';
-
-const homeIcon = '<svg xmlns="http://www.w3.org/2000/svg" height="25" viewBox="0 0 18 18" width="25"><path fill="#6E6E6E" d="M17.666,10.125,9.375,1.834a.53151.53151,0,0,0-.75,0L.334,10.125a.53051.53051,0,0,0,0,.75l.979.9785A.5.5,0,0,0,1.6665,12H2v4.5a.5.5,0,0,0,.5.5h4a.5.5,0,0,0,.5-.5v-5a.5.5,0,0,1,.5-.5h3a.5.5,0,0,1,.5.5v5a.5.5,0,0,0,.5.5h4a.5.5,0,0,0,.5-.5V12h.3335a.5.5,0,0,0,.3535-.1465l.979-.9785A.53051.53051,0,0,0,17.666,10.125Z"/></svg>';
 
 const decorateHeadline = (elem, index) => {
   if (!(elem instanceof HTMLElement)) return null;
@@ -279,7 +278,7 @@ const decorateCrossCloudMenu = (content) => {
   crossCloudMenuEl.className = 'feds-crossCloudMenu-wrapper';
   crossCloudMenuEl.querySelector('div').className = 'feds-crossCloudMenu';
   crossCloudMenuEl.querySelectorAll('ul li').forEach((el, index) => {
-    if (index === 0) el.querySelector('a')?.prepend(toFragment`${homeIcon}`);
+    if (index === 0) el.querySelector('a')?.prepend(toFragment`${icons.home}`);
     el.className = 'feds-crossCloudMenu-item';
   });
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -30,6 +30,12 @@ export const selectors = {
   columnBreak: '.column-break',
 };
 
+export const icons = {
+  company: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.5 118.1"><defs><style>.cls-1 {fill: #eb1000;}</style></defs><g><g><polygon class="cls-1" points="84.1 0 133.5 0 133.5 118.1 84.1 0"/><polygon class="cls-1" points="49.4 0 0 0 0 118.1 49.4 0"/><polygon class="cls-1" points="66.7 43.5 98.2 118.1 77.6 118.1 68.2 94.4 45.2 94.4 66.7 43.5"/></g></g></svg>',
+  search: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" focusable="false"><path d="M14 2A8 8 0 0 0 7.4 14.5L2.4 19.4a1.5 1.5 0 0 0 2.1 2.1L9.5 16.6A8 8 0 1 0 14 2Zm0 14.1A6.1 6.1 0 1 1 20.1 10 6.1 6.1 0 0 1 14 16.1Z"></path></svg>',
+  home: '<svg xmlns="http://www.w3.org/2000/svg" height="25" viewBox="0 0 18 18" width="25"><path fill="#6E6E6E" d="M17.666,10.125,9.375,1.834a.53151.53151,0,0,0-.75,0L.334,10.125a.53051.53051,0,0,0,0,.75l.979.9785A.5.5,0,0,0,1.6665,12H2v4.5a.5.5,0,0,0,.5.5h4a.5.5,0,0,0,.5-.5v-5a.5.5,0,0,1,.5-.5h3a.5.5,0,0,1,.5.5v5a.5.5,0,0,0,.5.5h4a.5.5,0,0,0,.5-.5V12h.3335a.5.5,0,0,0,.3535-.1465l.979-.9785A.53051.53051,0,0,0,17.666,10.125Z"/></svg>',
+};
+
 export const lanaLog = ({ message, e = '', tags = 'errorType=default' }) => {
   const url = getMetadata('gnav-source');
   window.lana.log(`${message} | gnav-source: ${url} | href: ${window.location.href} | ${e.reason || e.error || e.message || e}`, {
@@ -352,12 +358,6 @@ export const [setUserProfile, getUserProfile] = (() => {
 
   return [
     (data) => {
-      // TODO: debate whether to reject on empty profile or just return empty object;
-      // it might be that:
-      // * acc mgmt event is not fired
-      // * acc mgmt method isn't defined/doesn't return data/throws
-      // * user is not signed in
-      // * previous profile logic is used
       if (data && !profileData) {
         profileData = data;
         clearTimeout(profileTimeout);

--- a/libs/features/webapp-prompt/webapp-prompt.css
+++ b/libs/features/webapp-prompt/webapp-prompt.css
@@ -7,9 +7,9 @@
 
 @media (min-width: 900px) {
   .appPrompt {
-    position: fixed; /* TODO: position this relative to the App Switcher */
-    top: 150px;
-    right: 30px;
+    position: absolute;
+    top: 90%;
+    right: 0;
     width: 400px;
     padding: 24px 24px 28px;
     display: flex;
@@ -18,6 +18,13 @@
     border-radius: 16px;
     background: var(--pep-background-prompt);
     overflow: hidden;
+    box-sizing: border-box;
+    box-shadow: 0 0 3px 0 rgb(0 0 0 / 20%);
+  }
+
+  [dir = "rtl"] .appPrompt {
+    right: unset;
+    left: 0;
   }
 
   .appPrompt-icon img,
@@ -76,6 +83,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    column-gap: 12px;
   }
 
   .appPrompt-text {


### PR DESCRIPTION
This makes the necessary changes to:
* position the PEP prompt relative to the App Switcher;
* focus the App Switcher if the PEP prompt is dismissed;
* cancel displaying the PEP prompt if the App Switcher is open.

This is safe to be merged in the feature branch, but we'll need to have a few things on our radar:
* we need to get confirmation from the UNav team on the 1.1 version release that contains the updates to interact with the App Switcher, currently this is available just on production; we do have safety mechanisms is place in case their methods aren't available;
* currently the Profile menu `adobeProfile.getUserProfile()` public method is throwing errors, thus we can't retrieve profile data, I've reported the issue on the appropriate Slack channel.

This PR also addresses a bunch of leftover TODOs from the code.

Resolves: [MWPW-142625](https://jira.corp.adobe.com/browse/MWPW-142625)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/ramuntea/firefly?milolibs=project-pep--milo--adobecom
- After: https://main--cc--adobecom.hlx.page/drafts/ramuntea/firefly?milolibs=project-pep--milo--overmyheadandbody
