### PR TITLE
[MWPW-146274] Fix AH redirect

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -785,7 +785,7 @@ export async function loadIms() {
       scope: imsScope || defaultScope,
       locale: locale?.ietf?.replace('-', '_') || 'en_US',
       redirect_uri: ahomeMeta === 'on'
-        ? `https://www${env !== 'prod' ? '.stage' : ''}.adobe.com${locale.prefix}` : undefined,
+        ? `https://www${env.name !== 'prod' ? '.stage' : ''}.adobe.com${locale.prefix}` : undefined,
       autoValidateToken: true,
       environment: env.ims,
       useLocalStorage: false,


### PR DESCRIPTION
This fixes an omission when checking for the `env` value when defining the `redirect_uri` relevant for the Adobe Home redirect.

Resolves: [MWPW-146274](https://jira.corp.adobe.com/browse/MWPW-146274)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/kr/creativecloud/file-types/image/comparison?martech=off
- After: https://main--cc--adobecom.hlx.page/kr/creativecloud/file-types/image/comparison?milolibs=fix-ah-redirect--milo--overmyheadandbody&martech=off
