### PR TITLE
MWPW-145643 - Add retry button to langs with errors

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -21,7 +21,7 @@ import {
   startSync,
   startProject,
   getServiceUpdates,
-  postReqLang,
+  rolloutLang,
 } from '../utils/miloc.js';
 import { signal } from '../../../deps/htm-preact.js';
 import Modal from './modal.js';
@@ -222,7 +222,7 @@ export function showRollout() {
 export async function rolloutAll(e, reroll) {
   showRolloutOptions.value = false;
   allowRollout.value = false;
-  await postReqLang('all', reroll);
+  await rolloutLang('all', reroll);
 }
 
 export async function cancelLocProject() {

--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -21,7 +21,7 @@ import {
   startSync,
   startProject,
   getServiceUpdates,
-  rolloutLang,
+  postReqLang,
 } from '../utils/miloc.js';
 import { signal } from '../../../deps/htm-preact.js';
 import Modal from './modal.js';
@@ -222,7 +222,7 @@ export function showRollout() {
 export async function rolloutAll(e, reroll) {
   showRolloutOptions.value = false;
   allowRollout.value = false;
-  await rolloutLang('all', reroll);
+  await postReqLang('all', reroll);
 }
 
 export async function cancelLocProject() {

--- a/libs/blocks/locui/langs/index.js
+++ b/libs/blocks/locui/langs/index.js
@@ -20,7 +20,7 @@ export async function rollout(item, idx) {
   const reroll = item.status === 'completed';
 
   // Update the UI immediate instead of waiting on polling
-  languages.value[idx].status = 'rolling-out';
+  languages.value[idx].status = item.status === 'error' ? 'retrying' : 'rolling-out';
   languages.value[idx].done = 0;
   languages.value = [...languages.value];
 

--- a/libs/blocks/locui/langs/index.js
+++ b/libs/blocks/locui/langs/index.js
@@ -1,4 +1,4 @@
-import { postReqLang } from '../utils/miloc.js';
+import { rolloutLang } from '../utils/miloc.js';
 import { languages } from '../utils/state.js';
 import { getModal } from '../../modal/modal.js';
 import Modal from './modal.js';
@@ -24,8 +24,8 @@ export async function rollout(item, idx) {
   languages.value[idx].done = 0;
   languages.value = [...languages.value];
 
-  if (item.status === 'error') await postReqLang(item.code, reroll, 'retry', 'Retry.');
-  else await postReqLang(item.code, reroll);
+  if (item.status === 'error') await rolloutLang(item.code, reroll, 'retry', 'Retry.');
+  else await rolloutLang(item.code, reroll);
 }
 
 export function showLangErrors(event, item) {

--- a/libs/blocks/locui/langs/index.js
+++ b/libs/blocks/locui/langs/index.js
@@ -1,4 +1,4 @@
-import { rolloutLang } from '../utils/miloc.js';
+import { postReqLang } from '../utils/miloc.js';
 import { languages } from '../utils/state.js';
 import { getModal } from '../../modal/modal.js';
 import Modal from './modal.js';
@@ -24,7 +24,8 @@ export async function rollout(item, idx) {
   languages.value[idx].done = 0;
   languages.value = [...languages.value];
 
-  await rolloutLang(item.code, reroll);
+  if (item.status === 'error') await postReqLang(item.code, reroll, 'retry', 'Retry.');
+  else await postReqLang(item.code, reroll);
 }
 
 export function showLangErrors(event, item) {

--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -24,7 +24,8 @@ function Badge({ status }) {
 function Language({ item, idx }) {
   const hasLocales = item.locales?.length > 0;
   const cssStatus = `locui-subproject-${item.status || 'not-started'}`;
-  const rolloutType = item.status === 'completed' ? 'Re-rollout' : 'Rollout';
+  let rolloutType = item.status === 'completed' ? 'Re-rollout' : 'Rollout';
+  if (item.status === 'error') { rolloutType = 'Retry'; }
   return html`
     <li class="locui-subproject ${cssStatus}" onClick=${(e) => showLangErrors(e, item)}>
       ${item.status && html`<${Badge} status=${item.status} />`}
@@ -59,7 +60,7 @@ function Language({ item, idx }) {
           `)}
         </div>
       `}
-      ${(item.status === 'translated' || item.status === 'completed') && html`
+      ${['translated', 'completed', 'error'].includes(item.status) && html`
         <div class=locui-subproject-action-area>
           <button class=locui-urls-heading-action onClick=${() => rollout(item, idx)}>${rolloutType}</button>
         </div>

--- a/libs/blocks/locui/utils/miloc.js
+++ b/libs/blocks/locui/utils/miloc.js
@@ -136,7 +136,7 @@ export async function cancelProject() {
   return resp.status;
 }
 
-export async function postReqLang(
+export async function rolloutLang(
   languageCode,
   reroll = false,
   ep = 'start-rollout',

--- a/libs/blocks/locui/utils/miloc.js
+++ b/libs/blocks/locui/utils/miloc.js
@@ -136,11 +136,18 @@ export async function cancelProject() {
   return resp.status;
 }
 
-export async function rolloutLang(languageCode, reroll = false) {
-  setExcelStatus('Rolling out.', `Lang: ${languageCode} - Reroll: ${reroll ? 'yes' : 'no'}`);
+export async function postReqLang(
+  languageCode,
+  reroll = false,
+  ep = 'start-rollout',
+  statAction = 'Rolling out.',
+) {
+  let statNotes = `Lang: ${languageCode}`;
+  if (ep === 'start-rollout') { statNotes = `${statNotes} - Reroll: ${reroll ? 'yes' : 'no'}`; }
+  setExcelStatus(statAction, statNotes);
   const url = await getMilocUrl();
   const opts = { method: 'POST' };
-  const resp = await fetch(`${url}start-rollout?project=${heading.value.projectId}&languageCode=${languageCode}&reroll=${reroll}`, opts);
+  const resp = await fetch(`${url}${ep}?project=${heading.value.projectId}&languageCode=${languageCode}&reroll=${reroll}`, opts);
   return resp.json();
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* With the introduction of the `/retry` endpoint, users of this UI should be able to retry a language that has an error. This PR extends the pre-existing `rolloutLang` function to handle requests to this new endpoint as well.

Resolves: [MWPW-145643](https://jira.corp.adobe.com/browse/MWPW-145643)

**Test URLs:**
- Before: https://locui--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B52E189B7-129A-4E48-A985-BCDB99F22DB8%257D%26file%3D150urls.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
- After: https://ebartholomew-locui-retry-lang2--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B52E189B7-129A-4E48-A985-BCDB99F22DB8%257D%26file%3D150urls.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
