### PR TITLE
MWPW-145591: Enable dom monitoring hook to verify javascript execution

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1038,7 +1038,7 @@ async function documentPostSectionLoading(config) {
     document.querySelectorAll('main > div').forEach((section, idx) => analytics.decorateSectionAnalytics(section, idx, config));
   });
 
-  document.body.appendChild(createTag('div', { id: 'page-load-ok-milo', style: 'display: none' }));
+  document.body.appendChild(createTag('div', { id: 'page-load-ok-milo', style: 'display: none;' }));
 }
 
 async function processSection(section, config, isDoc) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1037,6 +1037,8 @@ async function documentPostSectionLoading(config) {
   import('../martech/attributes.js').then((analytics) => {
     document.querySelectorAll('main > div').forEach((section, idx) => analytics.decorateSectionAnalytics(section, idx, config));
   });
+
+  document.body.appendChild(createTag('div', { id: 'page-load-ok-milo', style: 'display: none' }));
 }
 
 async function processSection(section, config, isDoc) {


### PR DESCRIPTION
Add an easy hook that's available cross consumers for the ops team to verify all the milo JS has executed and pages are visible.

Resolves: [MWPW-145591](https://jira.corp.adobe.com/browse/MWPW-145591)

### Test instructions
An invisible div `<div id="page-load-ok-milo" style="display: none"></div>` should be available on the page after pageload.
<img width="968" alt="image" src="https://github.com/adobecom/milo/assets/39759830/ab7e97f3-433d-4798-aeb0-1eb61bda4a06">


Base regression links:
**CC:**
- Before: https://main--cc--adobecom.hlx.live/?martech=off
- After: https://main--cc--adobecom.hlx.live/?martech=off&milolibs=milo-finished-loading--milo--mokimo

**Homepage:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off&milolibs=milo-finished-loading--milo--mokimo

**Blog:**
- Before: https://main--blog--adobecom.hlx.page/
- After: https://main--blog--adobecom.hlx.page/?milolibs=milo-finished-loading--milo--mokimo

**Milo:**
- Before: https://main--milo--adobecom.hlx.live
- After: https://milo-finished-loading--milo--mokimo.hlx.live