### PR TITLE
Fix: Adding gray bg and making header bold for group link on gnav

### DIFF
--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -222,6 +222,7 @@
   .feds-navLink[class *= '-gradient'] {
     display: flex;
     border-radius: 4px;
+    font-weight: 600;
   }
 
   .feds-menu-column--group .feds-navLink[class *= '-gradient'] {
@@ -280,5 +281,9 @@
 
   .feds-navLink--ai-gradient {
     background: linear-gradient(90deg, #bce3ff, #ffe9d3, #f8d5e4);
+  }
+
+  .feds-navLink--gray-gradient {
+    background: #eaeaea;
   }
 }


### PR DESCRIPTION
- Adds a gray background option for link header
- Makes gradient link group header bold 

Resolves: [MWPW-146166](https://jira.corp.adobe.com/browse/MWPW-146166)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/blaishram/index-loggedout-ace0687v4?martech=off
- After: https://mwpw-146166--milo--bandana147.hlx.live/drafts/blaishram/index-loggedout-ace0687v4?martech=off

