### PR TITLE
MWPW-146268 - [Milo - Tabs] Pill dark/light support

### DIFF
--- a/libs/blocks/tabs/tabs.css
+++ b/libs/blocks/tabs/tabs.css
@@ -182,10 +182,6 @@
   margin-inline-start: 24px;
 }
 
-.tabs[class*='pill'] {
-  background: unset;
-}
-
 .tabs[class*='pill'] .tab-content {
   border-bottom: none;
 }


### PR DESCRIPTION
Pill tab-list styles should support light and dark themes. Currently it doesn't work with dark theme.
 - Removes background : unset on `tab.pill` variant

Resolves: [MWPW-146268](https://jira.corp.adobe.com/browse/MWPW-146268)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/pill-tabs?martech=off
- After: https://sarchibeque-mwpw-146268-pill-tab-dark--milo--adobecom.hlx.page/drafts/sarchibeque/pill-tabs?martech=off
