### PR TITLE
MWPW-146459 - [LocUI v2] Additional filtering in deep fragment search

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -82,8 +82,9 @@ async function findDeepFragments(path) {
     const needsSearch = fragments.filter((fragment) => !searched.includes(fragment.pathname));
     for (const search of needsSearch) {
       const nestedFragments = await findPageFragments(search.pathname);
-      const notSearched = nestedFragments.filter((nested) => !searched.includes(nested.pathname));
-      if (notSearched?.length) fragments.push(...notSearched);
+      const newFragments = nestedFragments.filter((nested) => !searched.includes(nested.pathname)
+        && !fragments.find((fragment) => fragment.pathname === nested.pathname));
+      if (newFragments?.length) fragments.push(...newFragments);
       searched.push(search.pathname);
     }
   }


### PR DESCRIPTION
Expanding on filtering of duplicate fragments within find deep fragments function for specific scenarios where a nested fragment is also being nested within other nested fragments on an individual page. Initially the search function was filtering already searched fragments but allowing nested fragments to be added when they were duplicates which is causing a mismatch. This PR adds an additional check for a fragments in found fragments before adding to the list.

Resolves: [MWPW-146459](https://jira.corp.adobe.com/browse/MWPW-146459)

Test URLs:
Will need to pull down branch and serve locally, then try to sync to langstore in [localization project](https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B85A38345-56CE-4C93-8213-30A9CF3FD7D9%7D&file=Book.xlsx&action=default&mobileredirect=true) to test this work.
