### PR TITLE
MWPW-146582: PEP fixes

### DIFF
--- a/libs/deps/imslib.min.js
+++ b/libs/deps/imslib.min.js
@@ -1,4 +1,4 @@
-var roll=function(){
+var roll=function(){ 
   /*! *****************************************************************************
       Copyright (c) Microsoft Corporation. All rights reserved.
       Licensed under the Apache License, Version 2.0 (the "License"); you may not use

--- a/libs/deps/imslib.min.js
+++ b/libs/deps/imslib.min.js
@@ -1,4 +1,4 @@
-var roll=function(){ 
+var roll=function(){
   /*! *****************************************************************************
       Copyright (c) Microsoft Corporation. All rights reserved.
       Licensed under the Apache License, Version 2.0 (the "License"); you may not use

--- a/libs/features/webapp-prompt/webapp-prompt.js
+++ b/libs/features/webapp-prompt/webapp-prompt.js
@@ -121,7 +121,7 @@ class AppPrompt {
   };
 
   decorate = () => {
-    this.elements.closeIcon = toFragment`<button daa-ll="Close Modal" class="appPrompt-close"></button>`;
+    this.elements.closeIcon = toFragment`<button daa-ll="Close Modal" aria-label="Close" class="appPrompt-close"></button>`;
     this.elements.cta = toFragment`<button daa-ll="Stay on this page" class="appPrompt-cta appPrompt-cta--close">${this.cancel}</button>`;
     this.elements.profile = this.profile
       ? toFragment`<div class="appPrompt-profile">

--- a/libs/features/webapp-prompt/webapp-prompt.js
+++ b/libs/features/webapp-prompt/webapp-prompt.js
@@ -121,7 +121,7 @@ class AppPrompt {
   };
 
   decorate = () => {
-    this.elements.closeIcon = toFragment`<button daa-ll="Close Modal" aria-label="Close" class="appPrompt-close"></button>`;
+    this.elements.closeIcon = toFragment`<button daa-ll="Close Modal" aria-label="${this.cancel}" class="appPrompt-close"></button>`;
     this.elements.cta = toFragment`<button daa-ll="Stay on this page" class="appPrompt-cta appPrompt-cta--close">${this.cancel}</button>`;
     this.elements.profile = this.profile
       ? toFragment`<div class="appPrompt-profile">


### PR DESCRIPTION
## Description
This PR fixes the close button a11y issue found on project PEP E2E testing.

## Related Issue
Resolves: [MWPW-146582](https://jira.corp.adobe.com/browse/MWPW-146582)

## Testing instructions
1. go to the test url
2. log in with any account
3. activate voice over
4. when the PEP prompt shows up, select the `X` close button
5. listen to the voice over description

## Test URLs
**Milo:**
- Before: https://project-pep--milo--adobecom.hlx.page/drafts/rbogos/pep-prompt?imsClientId=fedsmilo&extraPepEnts=firefly-web-usage#
- After: https://mwpw-146582-pep-fixes--milo--robert-bogos.hlx.page/drafts/rbogos/pep-prompt?imsClientId=fedsmilo&extraPepEnts=firefly-web-usage#