### PR TITLE
MWPW-145643 - Stop propagation of lang button, fix retry reqest

### DIFF
--- a/libs/blocks/locui/langs/index.js
+++ b/libs/blocks/locui/langs/index.js
@@ -18,13 +18,14 @@ export function showUrls(item, prefix) {
 
 export async function rollout(item, idx) {
   const reroll = item.status === 'completed';
+  const retry = item.status === 'error';
 
   // Update the UI immediate instead of waiting on polling
   languages.value[idx].status = item.status === 'error' ? 'retrying' : 'rolling-out';
   languages.value[idx].done = 0;
   languages.value = [...languages.value];
 
-  if (item.status === 'error') await rolloutLang(item.code, reroll, 'retry', 'Retry.');
+  if (retry) await rolloutLang(item.code, reroll, 'retry', 'Retry.');
   else await rolloutLang(item.code, reroll);
 }
 

--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -24,6 +24,10 @@ function Badge({ status }) {
 function Language({ item, idx }) {
   const hasLocales = item.locales?.length > 0;
   const cssStatus = `locui-subproject-${item.status || 'not-started'}`;
+  const onButton = (e) => {
+    e.stopPropagation();
+    rollout(item, idx);
+  };
   let rolloutType = item.status === 'completed' ? 'Re-rollout' : 'Rollout';
   if (item.status === 'error') { rolloutType = 'Retry'; }
   return html`
@@ -62,7 +66,7 @@ function Language({ item, idx }) {
       `}
       ${['translated', 'completed', 'error'].includes(item.status) && html`
         <div class=locui-subproject-action-area>
-          <button class=locui-urls-heading-action onClick=${() => rollout(item, idx)}>${rolloutType}</button>
+          <button class=locui-urls-heading-action onClick=${(e) => onButton(e)}>${rolloutType}</button>
         </div>
       `}
     </li>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Because the click handler to show the error modal is applied to the entire lang container, propagation control was needed for the Retry button to be effective.
* There was a logic error in how the Retry button constructed its request.

Resolves: [MWPW-145643](https://jira.corp.adobe.com/browse/MWPW-145643)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B52E189B7-129A-4E48-A985-BCDB99F22DB8%257D%26file%3D150urls.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
- After: https://ebartholomew-locui-retry-fix--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B52E189B7-129A-4E48-A985-BCDB99F22DB8%257D%26file%3D150urls.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
