### PR TITLE
MWPW-145672 - Update global link styles

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -764,13 +764,18 @@ a.fragment {
   display: none;
 }
 
-a {
+a:not(.dns) {
   color: var(--link-color);
-  text-decoration: none;
+  text-decoration: underline;
+}
+
+a:hover,
+a:focus,
+a:active {
+  text-decoration-style: double;
 }
 
 a:hover {
-  text-decoration: underline;
   color: var(--link-hover-color);
 }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -619,6 +619,10 @@ export function decorateLinks(el) {
     if (a.href.includes('#_dnb')) {
       a.href = a.href.replace('#_dnb', '');
     } else {
+      [...a.href.matchAll(/#_([^#_]+)/g)].forEach(([, s]) => {
+        a.classList.add(s);
+        a.href = a.href.replace(`#_${s}`, '');
+      });
       const autoBlock = decorateAutoBlock(a);
       if (autoBlock) {
         rdx.push(a);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* In order to be in alignment with a11y standards, all links must be blue _and_ underlined by default. This PR updates the default, and adds a system for adding custom classes to links using the `#_xyz` format. This allows for a `.dns` class that provides an escape hatch for the default styles.

Resolves: [MWPW-145672](https://jira.corp.adobe.com/browse/MWPW-145672)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/links?martech=off
- After: https://ebartholomew-global-link-styles--milo--adobecom.hlx.page/drafts/rparrish/links?martech=off
