### PR TITLE
MWPW-146491 Fast follow to change timeout analytic and use Date instead of performance

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -18,19 +18,22 @@ const setDeep = (obj, path, value) => {
   currentObj[pathArr[pathArr.length - 1]] = value;
 };
 
-const waitForEventOrTimeout = (eventName, timeout, timeoutVal) => new Promise((resolve, reject) => {
+const waitForEventOrTimeout = (eventName, timeout, returnValIfTimeout) => new Promise((resolve, reject) => {
+  const listener = (event) => {
+    clearTimeout(timer);
+    resolve(event.detail);
+  };
+
   const timer = setTimeout(() => {
-    if (timeoutVal !== undefined) {
-      resolve(timeoutVal);
+    window.removeEventListener(eventName, listener);
+    if (returnValIfTimeout !== undefined) {
+      resolve(returnValIfTimeout);
     } else {
-      reject(new Error(`Timeout waiting for ${eventName} after ${timeout}ms`));
+      resolve({ timeout: true });
     }
   }, timeout);
 
-  window.addEventListener(eventName, (event) => {
-    clearTimeout(timer);
-    resolve(event.detail);
-  }, { once: true });
+  window.addEventListener(eventName, listener, { once: true });
 });
 
 const getExpFromParam = (expParam) => {
@@ -76,7 +79,7 @@ function roundToQuarter(num) {
 }
 
 function calculateResponseTime(responseStart) {
-  const responseTime = performance.now() - responseStart;
+  const responseTime = Date.now() - responseStart;
   return roundToQuarter(responseTime);
 }
 
@@ -112,41 +115,20 @@ const getTargetPersonalization = async () => {
     || parseInt(getMetadata('target-timeout'), 10)
     || TARGET_TIMEOUT_MS;
 
-  let response;
 
-  const responseStart = performance.now();
+  const responseStart = Date.now();
   window.addEventListener(ALLOY_SEND_EVENT, () => {
     const responseTime = calculateResponseTime(responseStart);
     window.lana.log('target response time', responseTime);
   }, { once: true });
 
-  try {
-    response = await waitForEventOrTimeout(ALLOY_SEND_EVENT, timeout);
-    sendTargetResponseAnalytics(false, responseStart, timeout);
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.log(e);
-    if (e.message.startsWith('Timeout waiting for alloy_sendEvent after')) {
-      const timer = setTimeout(() => {
-        // eslint-disable-next-line no-use-before-define
-        window.removeEventListener(ALLOY_SEND_EVENT, sendAnalytics);
-        sendTargetResponseAnalytics(true, responseStart, timeout);
-      }, 5100 - timeout);
-
-      // eslint-disable-next-line no-inner-declarations
-      function sendAnalytics() {
-        clearTimeout(timer);
-        sendTargetResponseAnalytics(true, responseStart, timeout);
-      }
-
-      window.addEventListener(ALLOY_SEND_EVENT, sendAnalytics, { once: true });
-    } else {
-      sendTargetResponseAnalytics(false, responseStart, timeout, e.message);
-    }
-  }
-
   let manifests = [];
-  if (response) {
+  const response = await waitForEventOrTimeout(ALLOY_SEND_EVENT, timeout);
+  if (response.timeout) {
+    waitForEventOrTimeout(ALLOY_SEND_EVENT, 5100 - timeout)
+      .then(() => sendTargetResponseAnalytics(true, responseStart, timeout));
+  } else {
+    sendTargetResponseAnalytics(false, responseStart, timeout);
     manifests = handleAlloyResponse(response.result);
   }
 

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -18,8 +18,10 @@ const setDeep = (obj, path, value) => {
   currentObj[pathArr[pathArr.length - 1]] = value;
 };
 
-const waitForEventOrTimeout = (eventName, timeout, returnValIfTimeout) => new Promise((resolve, reject) => {
+// eslint-disable-next-line max-len
+const waitForEventOrTimeout = (eventName, timeout, returnValIfTimeout) => new Promise((resolve) => {
   const listener = (event) => {
+    // eslint-disable-next-line no-use-before-define
     clearTimeout(timer);
     resolve(event.detail);
   };
@@ -114,7 +116,6 @@ const getTargetPersonalization = async () => {
   const timeout = parseInt(params.get('target-timeout'), 10)
     || parseInt(getMetadata('target-timeout'), 10)
     || TARGET_TIMEOUT_MS;
-
 
   const responseStart = Date.now();
   window.addEventListener(ALLOY_SEND_EVENT, () => {


### PR DESCRIPTION
I created a PR recently https://github.com/adobecom/milo/pull/2140 that increased the timeout and improved error handling. We're seeing some unexpected results and want to dig in a little further. So we're updating the analytics again.

Fast follow for: [MWPW-146491](https://jira.corp.adobe.com/browse/MWPW-146491)

Test URLs:

Before: https://main--milo--adobecom.hlx.page/?martech=off
After: https://meptimeoutagain--milo--adobecom.hlx.page/?martech=off

Page with Target on:
https://main--homepage--adobecom.hlx.page/homepage/index-loggedout
https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?milolibs=meptimeoutagain

Note: this is listed as high priority because in Dexter, if a Target response came in quite late, the page would "flicker" but they would still get the updates. In Milo, MEP can only alter the page before decoration. And we do not want to wait indefinitely before showing the user the page. So we opted to pick a timeout and move on without the updates if needed. This resulted in some users being categorized as seeing updates, but viewing an unaltered page.
Some discrepancy is fine, but currently, the discrepancy is so high, that we cannot rely on MEP test results, thus rendering testing in Milo useless. Since testing yields over 100M/year, we are anxious to resolve the issue as quickly as possible.