### PR TITLE
Harden preflight link checking

### DIFF
--- a/libs/blocks/preflight/panels/general.js
+++ b/libs/blocks/preflight/panels/general.js
@@ -131,6 +131,7 @@ function prettyPath(url) {
 function Item({ name, item, idx }) {
   const isChecked = item.checked ? ' is-checked' : '';
   const isFetching = item.edit ? '' : ' is-fetching';
+  if (!item.url) return undefined;
 
   return html`
     <div class="preflight-group-row preflight-group-detail${isChecked}${isFetching}"

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -318,63 +318,74 @@ span.preflight-time {
   margin: 0;
 }
 
-.broken-links {
+.problem-links {
   margin: 24px 48px;
 }
 
-.broken-links .title {
+.problem-links .title {
   margin-bottom: 0;
 }
 
-.broken-links .note {
+.problem-links .note {
   margin-top: 20px;
 }
 
-.dialog-modal#preflight .broken-links table {
+.dialog-modal#preflight .problem-links table {
   width: 100%;
   border-collapse: collapse;
   border-radius: 6px;
   background-color: rgb(0 0 0 / 8%);
 }
 
-.dialog-modal#preflight .broken-links table th {
+.dialog-modal#preflight .problem-links table th {
   text-transform: uppercase;
   width: 10%;
 }
 
-.dialog-modal#preflight .broken-links table td a {
+.dialog-modal#preflight .problem-links table td a {
   color: #fff;
+  display: inline-block;
+  overflow-x: scroll;  
+  position: absolute;
+  top: 50%;
+  left: 0;
+  scrollbar-width: none;
+  transform: translateY(-50%);
+  white-space: nowrap;
+  width: 100%;
 }
 
-.dialog-modal#preflight .broken-links table th,
-.dialog-modal#preflight .broken-links table td {
+.dialog-modal#preflight .problem-links table th,
+.dialog-modal#preflight .problem-links table td {
   padding: 12px 0;
   text-align: center;
 }
 
-.dialog-modal#preflight .broken-links table th:nth-child(2),
-.dialog-modal#preflight .broken-links table td:nth-child(2) {
+.dialog-modal#preflight .problem-links table th:nth-child(2),
+.dialog-modal#preflight .problem-links table td:nth-child(2) {
   text-align: initial;
+  position: relative;
+  width: 75%;
 }
 
-.dialog-modal#preflight .broken-links table th:first-child {
+.dialog-modal#preflight .problem-links table th:first-child {
   width: 5%;
 }
 
-.dialog-modal#preflight .broken-links table th:nth-child(2) {
+.dialog-modal#preflight .problem-links table th:nth-child(2) {
   text-align: left;
   width: 75%
 }
 
-.dialog-modal#preflight .broken-links table tr:first-child th {
+.dialog-modal#preflight .problem-links table tr:first-child th {
   padding-top: 15px;
 }
 
-.dialog-modal#preflight .broken-links table tr:hover td {
+.dialog-modal#preflight .problem-links table tr:hover td {
   background-color: rgb(0 0 0 / 20%);
 }
 
-.broken-link {
+.problem-link {
   border: 3px solid #000!important;
   color: #fff!important;
   font-size: larger!important;
@@ -384,13 +395,13 @@ span.preflight-time {
   animation: pulse 1.5s ease-out infinite;
 }
 
-.broken-link:hover {
+.problem-link:hover {
   background-color: transparent!important;
   color: inherit!important;
   border-color:rgb(255 0 0)!important;
 }
 
-.broken-link::after {
+.problem-link::after {
   content: '(' attr(data-status) ')';
   margin-left: 5px;
   font-size: smaller;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Filter out empty `hrefs` before sending to spidy.
* Harden link check to be more robust against Spidy API.
* Update link check language.
* Better onboarding support.
  * Adds fallbacks if `.milo/config` has not been added. 
* Fix for missing Word doc reference, under general tab.

Resolves: [MWPW-146695](https://jira.corp.adobe.com/browse/MWPW-146695)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/test-template?martech=off
- After: https://preflight-link-check-harden--milo--adobecom.hlx.page/drafts/rclayton/test-template?martech=off

**Bacom Test URLs**
- Before: https://main--bacom--adobecom.hlx.page/lv/products/customer-journey-analytics/adobe-customer-journey-analytics?martech=off
- After:  https://main--bacom--adobecom.hlx.page/lv/products/customer-journey-analytics/adobe-customer-journey-analytics?milolibs=preflight-link-check-harden&martech=off

- Before: https://main--bacom--adobecom.hlx.page/lv/products/customer-journey-analytics/connected-datamartech=off
- After: https://main--bacom--adobecom.hlx.page/lv/products/customer-journey-analytics/connected-data?milolibs=preflight-link-check-harden&martech=off

**CC Test URLs**
- Before: https://main--cc--adobecom.hlx.page/drafts/rclayton/acrobat-pro-cc?martech=off
- After:  https://main--cc--adobecom.hlx.page/drafts/rclayton/acrobat-pro-cc?milolibs=preflight-link-check-harden&martech=off
