### PR TITLE
MWPW-146877 [LocUI] - Status Details & Sidekick

### DIFF
--- a/libs/blocks/locui/locui.css
+++ b/libs/blocks/locui/locui.css
@@ -17,13 +17,17 @@ body {
 }
 
 .locui-sync-badge-container {
-  position: absolute;
+  position: fixed;
   top: 0;
   width: 83.4%;
   margin: 0 auto;
   display: flex;
   justify-content: end;
   z-index: 100;
+}
+
+.locui-sync-badge-container.push-down {
+  top: 49px;
 }
 
 .locui-sync-badge {
@@ -106,8 +110,8 @@ span.locui-sync-badge-mono {
 }
 
 .locui-status-toast-section {
-  position: absolute;
-  top: 20px;
+  position: fixed;
+  top: 60px;
   left: 50%;
   transform: translateX(-50%);
 }

--- a/libs/blocks/locui/sync/view.js
+++ b/libs/blocks/locui/sync/view.js
@@ -2,13 +2,19 @@ import { html } from '../../../deps/htm-preact.js';
 import { serviceStatus, heading } from '../utils/state.js';
 import { showContents, getPrettyDate, toggleContent } from './index.js';
 
+function isSidekickOpen() {
+  const sidekick = document.querySelector('helix-sidekick');
+  return !!sidekick;
+}
+
 export default function Sync() {
   const prettyDate = getPrettyDate();
   const prettySync = serviceStatus.value.replace(/[\W_]+/g, '-');
   const connectedTo = heading.value.env ? `${serviceStatus} (${heading.value.env})` : serviceStatus;
+  const sidekickOpen = isSidekickOpen() ? ' push-down' : '';
 
   return html`
-    <div class=locui-sync-badge-container>
+    <div class="locui-sync-badge-container${sidekickOpen}">
       <div class="locui-sync-badge locui-sync-badge-status-${prettySync}">
         <button class=locui-sync-badge-header onClick=${toggleContent}>${connectedTo}</button>
         ${showContents.value && html`


### PR DESCRIPTION
When the user has the sidekick open in a localization v2 project and doesn't have "Push Down" enabled, the status toast and connected label is hidden behind the sidekick top bar. This PR updates the status toast and connected label to always be positioned so you can see them, whether the sidekick is open or not. I also gave them fixed position so they are showing even when the user has the page scrolled down a ways.

![Screenshot 2024-04-22 at 10 56 38 AM](https://github.com/adobecom/milo/assets/10670990/ff3eec85-32be-4ba4-b13e-49b305964d63)

Resolves: [MWPW-146877](https://jira.corp.adobe.com/browse/MWPW-146877)
