### PR TITLE
MWPW-145574 - Dynamic Nav Gnav Implementation

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -947,14 +947,20 @@ class Gnav {
   };
 }
 
+const getSource = async () => {
+  const { locale, dynamicNavKey } = getConfig();
+  let url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
+  if (dynamicNavKey) {
+    const { default: dynamicNav } = await import('../../features/dynamic-navigation.js');
+    url = dynamicNav(url, dynamicNavKey);
+  }
+  return url;
+};
+
 export default async function init(block) {
   try {
-    const { locale, mep, dynamicNavKey } = getConfig();
-    let url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
-    if (dynamicNavKey) {
-      const { default: dynamicNav } = await import('../../features/dynamic-navigation.js');
-      url = dynamicNav(url, dynamicNavKey);
-    }
+    const { mep } = getConfig();
+    const url = await getSource();
     const content = await fetchAndProcessPlainHtml({ url })
       .catch((e) => lanaLog({
         message: `Error fetching gnav content url: ${url}`,

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -35,8 +35,6 @@ import {
 
 import { replaceKey, replaceKeyArray } from '../../features/placeholders.js';
 
-import dynamicNav from '../../features/dynamic-navigation.js';
-
 const CONFIG = {
   icons: {
     company: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.5 118.1"><defs><style>.cls-1 {fill: #eb1000;}</style></defs><g><g><polygon class="cls-1" points="84.1 0 133.5 0 133.5 118.1 84.1 0"/><polygon class="cls-1" points="49.4 0 0 0 0 118.1 49.4 0"/><polygon class="cls-1" points="66.7 43.5 98.2 118.1 77.6 118.1 68.2 94.4 45.2 94.4 66.7 43.5"/></g></g></svg>',
@@ -954,6 +952,7 @@ export default async function init(block) {
     const { locale, mep, dynamicNavKey } = getConfig();
     let url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
     if (dynamicNavKey) {
+      const { default: dynamicNav } = await import('../../features/dynamic-navigation.js');
       url = dynamicNav(url, dynamicNavKey);
     }
     const content = await fetchAndProcessPlainHtml({ url })

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -35,6 +35,8 @@ import {
 
 import { replaceKey, replaceKeyArray } from '../../features/placeholders.js';
 
+import dynamicNav from '../../features/dynamic-navigation.js';
+
 const CONFIG = {
   icons: {
     company: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.5 118.1"><defs><style>.cls-1 {fill: #eb1000;}</style></defs><g><g><polygon class="cls-1" points="84.1 0 133.5 0 133.5 118.1 84.1 0"/><polygon class="cls-1" points="49.4 0 0 0 0 118.1 49.4 0"/><polygon class="cls-1" points="66.7 43.5 98.2 118.1 77.6 118.1 68.2 94.4 45.2 94.4 66.7 43.5"/></g></g></svg>',
@@ -949,8 +951,11 @@ class Gnav {
 
 export default async function init(block) {
   try {
-    const { locale, mep } = getConfig();
-    const url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
+    const { locale, mep, dynamicNavKey } = getConfig();
+    let url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
+    if (dynamicNavKey) {
+      url = dynamicNav(url, dynamicNavKey);
+    }
     const content = await fetchAndProcessPlainHtml({ url })
       .catch((e) => lanaLog({
         message: `Error fetching gnav content url: ${url}`,

--- a/libs/features/dynamic-navigation.js
+++ b/libs/features/dynamic-navigation.js
@@ -9,13 +9,7 @@ export default function dynamicNav(url, key) {
     return url;
   }
 
-  if (metadataContent !== 'on') return url;
+  if (metadataContent !== 'on' || key !== window.sessionStorage.getItem('dynamicNavKey')) return url;
 
-  if (key !== window.sessionStorage.getItem('dynamicNavKey')) return url;
-
-  const source = window.sessionStorage.getItem('gnavSource');
-
-  if (!source) return url;
-
-  return source;
+  return window.sessionStorage.getItem('gnavSource') || url;
 }

--- a/libs/features/dynamic-navigation.js
+++ b/libs/features/dynamic-navigation.js
@@ -1,0 +1,21 @@
+import { getMetadata } from '../utils/utils.js';
+
+export default function dynamicNav(url, key) {
+  const metadataContent = getMetadata('dynamic-nav');
+
+  if (metadataContent === 'entry') {
+    window.sessionStorage.setItem('gnavSource', url);
+    window.sessionStorage.setItem('dynamicNavKey', key);
+    return url;
+  }
+
+  if (metadataContent !== 'on') return url;
+
+  if (key !== window.sessionStorage.getItem('dynamicNavKey')) return url;
+
+  const source = window.sessionStorage.getItem('gnavSource');
+
+  if (!source) return url;
+
+  return source;
+}

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -24,6 +24,7 @@ import globalNavigationMock from './mocks/global-navigation.plain.js';
 import globalNavigationActiveMock from './mocks/global-navigation-active.plain.js';
 import globalNavigationWideColumnMock from './mocks/global-navigation-wide-column.plain.js';
 import globalNavigationCrossCloud from './mocks/global-navigation-cross-cloud.plain.js';
+import { getConfig } from '../../../tools/send-to-caas/send-utils.js';
 
 const ogFetch = window.fetch;
 
@@ -1404,6 +1405,31 @@ describe('global navigation', () => {
       await initGnav(document.body.querySelector('header'));
       expect(
         fetchStub.calledOnceWith('https://www.stage.adobe.com/federal/path/to/gnav.plain.html'),
+      ).to.be.true;
+    });
+
+    it('fetches navigation saved in sessionStorage', async () => {
+      const dynamicNavOn = toFragment`<meta name="dynamic-nav" content="on">`;
+      const conf = getConfig();
+      setConfig({ dynamicNavKey: 'milo', ...conf });
+      document.head.append(dynamicNavOn);
+      window.sessionStorage.setItem('dynamicNavKey', 'milo');
+      window.sessionStorage.setItem('gnavSource', '/some-path');
+      await initGnav(document.body.querySelector('header'));
+      expect(
+        fetchStub.calledOnceWith('/some-path.plain.html'),
+      ).to.be.true;
+    });
+
+    it('does not fetch from sessionStorage url when dyanmicNavKey is not present', async () => {
+      const dynamicNavOn = toFragment`<meta name="dynamic-nav" content="on">`;
+      document.head.append(dynamicNavOn);
+      document.body.replaceChildren(toFragment`<header class="global-navigation"></header>`);
+      window.sessionStorage.setItem('dynamicNavKey', 'milo');
+      window.sessionStorage.setItem('gnavSource', '/some-path');
+      await initGnav(document.body.querySelector('header'));
+      expect(
+        fetchStub.calledOnceWith('http://localhost:2000/gnav.plain.html'),
       ).to.be.true;
     });
   });

--- a/test/features/dynamic-nav/dynamicNav.test.js
+++ b/test/features/dynamic-nav/dynamicNav.test.js
@@ -1,0 +1,48 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import { loadArea, setConfig, getConfig, getMetadata } from '../../../libs/utils/utils.js';
+import dynamicNav from '../../../libs/features/dynamic-navigation.js';
+
+describe('Dynamic nav', () => {
+  beforeEach(() => {
+    const conf = { dynamicNavKey: 'bacom' };
+    setConfig(conf);
+    window.sessionStorage.setItem('gnavSource', 'some-source-string');
+  });
+
+  it('Saves the gnavSource and dynamicNavKey to session storage', async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/entry.html' });
+    window.sessionStorage.removeItem('gnavSource');
+    dynamicNav('gnav/aem-sites', 'bacom');
+    expect(window.sessionStorage.getItem('gnavSource')).to.equal('gnav/aem-sites');
+    expect(window.sessionStorage.getItem('dynamicNavKey')).to.equal('bacom');
+  });
+
+  it('Returns the provided url when the dynamic nav metadata is not present', async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/off.html' });
+    const url = dynamicNav('gnav/aem-sites', 'nocom');
+    expect(window.sessionStorage.getItem('gnavSource')).to.equal('some-source-string');
+    expect(url).to.equal('gnav/aem-sites');
+  })
+
+  it('Returns the provided url with when the wrong dynamicNavKey is passed', async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/on.html' });
+    const url = dynamicNav('gnav/aem-sites', 'nocom');
+    expect(window.sessionStorage.getItem('gnavSource')).to.equal('some-source-string');
+    expect(url).to.equal('gnav/aem-sites');
+  });
+
+  it('Returns the sessionStorage url if the item exists, the keys match, and dynamic nav is on', async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/on.html' });
+    const url = dynamicNav('gnav/aem-sites', 'bacom');
+    expect(window.sessionStorage.getItem('gnavSource')).to.equal('some-source-string');
+    expect(url).to.equal('some-source-string');
+  })
+
+  it('Returns the pprovided url if it does not find an item in sessionStorage and dynamic nav is on', async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/on.html' });
+    window.sessionStorage.removeItem('gnavSource');
+    const url = dynamicNav('gnav/aem-sites', 'bacom');
+    expect(url).to.equal('gnav/aem-sites');
+  })
+});

--- a/test/features/dynamic-nav/dynamicNav.test.js
+++ b/test/features/dynamic-nav/dynamicNav.test.js
@@ -1,6 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import { loadArea, setConfig, getConfig, getMetadata } from '../../../libs/utils/utils.js';
+import { setConfig } from '../../../libs/utils/utils.js';
 import dynamicNav from '../../../libs/features/dynamic-navigation.js';
 
 describe('Dynamic nav', () => {
@@ -23,7 +23,7 @@ describe('Dynamic nav', () => {
     const url = dynamicNav('gnav/aem-sites', 'nocom');
     expect(window.sessionStorage.getItem('gnavSource')).to.equal('some-source-string');
     expect(url).to.equal('gnav/aem-sites');
-  })
+  });
 
   it('Returns the provided url with when the wrong dynamicNavKey is passed', async () => {
     document.head.innerHTML = await readFile({ path: './mocks/on.html' });
@@ -37,12 +37,12 @@ describe('Dynamic nav', () => {
     const url = dynamicNav('gnav/aem-sites', 'bacom');
     expect(window.sessionStorage.getItem('gnavSource')).to.equal('some-source-string');
     expect(url).to.equal('some-source-string');
-  })
+  });
 
   it('Returns the pprovided url if it does not find an item in sessionStorage and dynamic nav is on', async () => {
     document.head.innerHTML = await readFile({ path: './mocks/on.html' });
     window.sessionStorage.removeItem('gnavSource');
     const url = dynamicNav('gnav/aem-sites', 'bacom');
     expect(url).to.equal('gnav/aem-sites');
-  })
+  });
 });

--- a/test/features/dynamic-nav/mocks/entry.html
+++ b/test/features/dynamic-nav/mocks/entry.html
@@ -1,0 +1,1 @@
+<meta name="dynamic-nav" content="entry">

--- a/test/features/dynamic-nav/mocks/off.html
+++ b/test/features/dynamic-nav/mocks/off.html
@@ -1,0 +1,1 @@
+<meta name="stub" content="stub">

--- a/test/features/dynamic-nav/mocks/on.html
+++ b/test/features/dynamic-nav/mocks/on.html
@@ -1,0 +1,1 @@
+<meta name="dynamic-nav" content="on">


### PR DESCRIPTION
Adds functionality to allow consumer projects to opt in to a dynamic nav experience. If a dynamicNavKey is registered in a consumer repo's config, this code adds logic to save the gnav source to sessionStorage allowing for the same nav experience in subsequent clicks.

- `entry` pages will set gnavSource to sessionStorage is a gnav source meta tag is present
- `on` pages will check for a gnavSource in sessionStorage, and if one is found, either modify the gnav-source meta tag, or create one
- pages without the dynamic-nav metadata will do nothing or remove gnavSource from sessionStorage
- projects without the key present, or where the key mismatches with the key saved in storage will use the default gnav experience

Context:
The wiki in the ticket provides more context, but it was desired by our stakeholders that this only be a single tab experience.

Based on comments in https://github.com/adobecom/milo/pull/2092 I am adding this PR as the approach and closing 2092. 

Resolves: [MWPW-145574](https://jira.corp.adobe.com/browse/MWPW-145574)

Test URLs:

Before: https://main--milo--adobecom.hlx.page/drafts/slavin/dynamic-nav/hugo-boss-case-study-entry?martech=off
After: https://dynamic-nav-gnav-impl--milo--jasonhowellslavin.hlx.page/drafts/slavin/dynamic-nav/hugo-boss-case-study-entry?martech=off
Before: https://main--bacom--adobecom.hlx.page/drafts/slavin/dynamic-nav/aem-rtcdp-entry?martech=off
After: https://dynamic-nav-gnav-impl-config--bacom--adobecom.hlx.page/drafts/slavin/dynamic-nav/aem-rtcdp-entry?milolibs=dynamic-nav&martech=off

To test:
Go to the second after link. On the Hugo Boss page
Observe the nav (pricing and resources)
Right click "watch now" and open in a new tab
Observe the nav is the default milo nav ("Explore")
From the Hugo Boss page left click "Watch Now" to open in the same tab
Observe the pricing and resources nav loads
