### PR TITLE
MWPW-139842 [Revert] Fill button style

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -3,22 +3,18 @@ import { createTag } from './utils.js';
 export function decorateButtons(el, size) {
   const buttons = el.querySelectorAll('em a, strong a, p > a strong');
   if (buttons.length === 0) return;
+  const buttonTypeMap = { STRONG: 'blue', EM: 'outline', A: 'blue' };
   buttons.forEach((button) => {
     const parent = button.parentElement;
-    let buttonType = 'outline';
-    if (parent.nodeName === 'EM' || parent.nodeName === 'STRONG') {
-      buttonType = parent.nodeName === 'EM' ? 'outline' : 'blue';
-      if ((parent.parentElement?.nodeName === 'EM')
-        || (parent.parentElement?.nodeName === 'STRONG')) {
-        buttonType = 'fill';
-      }
-    }
+    const buttonType = buttonTypeMap[parent.nodeName] || 'outline';
     if (button.nodeName === 'STRONG') {
       parent.classList.add('con-button', buttonType);
-      if (size) parent.classList.add(size);
+      if (size) parent.classList.add(size); /* button-l, button-xl */
     } else {
       button.classList.add('con-button', buttonType);
-      if (size) button.classList.add(size);
+      if (size) button.classList.add(size); /* button-l, button-xl */
+      parent.insertAdjacentElement('afterend', button);
+      parent.remove();
     }
     const actionArea = button.closest('p, div');
     if (actionArea) {
@@ -26,17 +22,6 @@ export function decorateButtons(el, size) {
       actionArea.nextElementSibling?.classList.add('supplemental-text', 'body-xl');
     }
   });
-
-  for (const btn of buttons) {
-    const parent = btn.parentElement;
-    if (parent.parentElement?.nodeName === 'EM' || parent.parentElement?.nodeName === 'STRONG') {
-      const grandParentBtns = parent.parentElement.querySelectorAll('.con-button');
-      parent.parentElement.replaceWith(...grandParentBtns);
-    } else if (parent.nodeName === 'EM' || parent.nodeName === 'STRONG') {
-      const parentBtns = parent.querySelectorAll('.con-button');
-      parent.replaceWith(...parentBtns);
-    }
-  }
 }
 
 export function decorateIconStack(el) {


### PR DESCRIPTION
There was some surprise authoring in the wild that this unintentionally impacted. 
A number of documents have unknown 'fill' styles authored because the bold+italic combo also initially resulted in .outline styles. see. https://adobe-mwp.slack.com/archives/C03S7CZU8NN/p1713822664500139

Rikio Kaneko
hi, we’re seeing buttons that used to be black outline/hollow, are now black filled buttons on BACOM.  Sample pages:
https://business.adobe.com/products/magento/magento-commerce.html - marquee
https://business.adobe.com/products/genstudio.html - buttons in the tabs
https://business.adobe.com/products/experience-manager/sites/aem-sites.html - tabs section and “better


The teams want to have a better testing plan to roll this feature out

**Reverts**
MWPW-139842 - Block button styling - Support button.fill w/ `<strong><em>` authoring #2059


Resolves: [MWPW-139842 ](https://jira.corp.adobe.com/browse/MWPW-139842)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/authoring/button-mapping?martech=off
- After: https://rparrish-revert-fill-button--milo--adobecom.hlx.page/docs/authoring/button-mapping?martech=off


Note: I left the `media.test.js` file change in tact from the original PR, as that addressed a testing error unrelated to the button decorator func().  
