### PR TITLE
MWPW-147127 Scrolling on the gnav in mobile portrait and landscape view is not working as expected ,navigation menu when opened is not seen rendered completely in MILO Pages

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -62,7 +62,7 @@ header.global-navigation {
   right: 20px; /* hamburger menu gutter */
   display: none;
   flex-direction: column;
-  height: 100vh;
+  height: calc(100vh - var(--feds-height-nav));
   border-top: 1px solid var(--feds-borderColor--light);
   background-color: var(--feds-background-nav--light);
 }

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -62,7 +62,7 @@ header.global-navigation {
   right: 20px; /* hamburger menu gutter */
   display: none;
   flex-direction: column;
-  height: calc(100vh - var(--feds-height-nav));
+  height: 100vh;
   border-top: 1px solid var(--feds-borderColor--light);
   background-color: var(--feds-background-nav--light);
 }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -615,7 +615,7 @@ class Gnav {
 
     return this.loadDelayed().then(() => {
       this.blocks.search.instance = new this.Search(this.blocks.search.config);
-    });
+    }).catch(() => {});
   };
 
   isToggleExpanded = () => this.elements.mobileToggle?.getAttribute('aria-expanded') === 'true';


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

The content in the gnav menu (in mobile/tablet viewports, when it's open) was being cut-off on the bottom due to an incorrect height value in the wrapper. Correcting the height value for the wrapper in non desktop viewports fixes the issue

Resolves: [MWPW-147127](https://jira.corp.adobe.com/browse/MWPW-147127)

**Test URLs:**

Before: https://main--milo--adobecom.hlx.page?martech=off
After: https://mobile-gnav--milo--sharmrj.hlx.page?martech=off
  
Before: https://main--cc--adobecom.hlx.page/creativecloud?martech=off
After: https://main--cc--adobecom.hlx.live/creativecloud?milolibs=mobile-gnav--milo--sharmrj&martech=off

