### PR TITLE
MWPW-146036 - Rig up quiz entry button

### DIFF
--- a/libs/blocks/quiz-entry/mlField.js
+++ b/libs/blocks/quiz-entry/mlField.js
@@ -1,7 +1,7 @@
 import { html } from '../../deps/htm-preact.js';
 import { getConfig } from '../../utils/utils.js';
 
-export const getFiResults = async (endpoint, apiKey, input, numberOfItems, validFiCodes) => {
+export const getMLResults = async (endpoint, apiKey, threshold, input, count, validFiCodes) => {
   const { env } = getConfig();
   const subdomain = env === 'prod' ? 'cchome-dev' : 'cchome-dev';
   const apiUrl = `https://${subdomain}.adobe.io/int/v1/models`;
@@ -11,7 +11,7 @@ export const getFiResults = async (endpoint, apiKey, input, numberOfItems, valid
     payload: {
       data: {
         input,
-        num_items: numberOfItems || 10,
+        num_items: count || 10,
         given_prod_list: validFiCodes,
       },
     },
@@ -28,9 +28,20 @@ export const getFiResults = async (endpoint, apiKey, input, numberOfItems, valid
     .then((response) => response.json())
     .catch((error) => window.lana.log(`ERROR: Fetching fi codes ${error}`));
 
+  let highestProb = null;
+  result.filtered = result?.data?.filter((item) => {
+    let isValid = false;
+    if (!highestProb) {
+      highestProb = item.prob;
+      isValid = true;
+    } else if (item.prob / highestProb > threshold) {
+      isValid = true;
+    }
+    return isValid;
+  });
   return result;
 };
 
-export const mlField = ({ cardsUsed, onMLInput, placeholderText }) => html`<div class="ml-field-container">
-    <input id="ml-field-input" class="ml-input" type="textarea" placeholder="${placeholderText}" oninput="${onMLInput}" disabled="${cardsUsed}" />
+export const mlField = ({ cardsUsed, onMLInput, onMLEnter, placeholderText }) => html`<div class="ml-field-container">
+    <input id="ml-field-input" class="ml-input" type="textarea" placeholder="${placeholderText}" oninput="${onMLInput}" onkeypress="${onMLEnter}" disabled="${cardsUsed}" />
   </div>`;

--- a/libs/blocks/quiz-entry/quiz-entry.css
+++ b/libs/blocks/quiz-entry/quiz-entry.css
@@ -214,23 +214,40 @@ html[dir="rtl"] .quiz-option-icon {
   cursor: not-allowed;
 }
 
-.quiz-button {
-  width: 101px;
-  height: 40px;
-  background: #222;
-  border: 2px solid #FFF;
-  border-radius: 20px;
-  font-weight: 700;
-  font-size: 17px;
-  line-height: 21px;
-  text-align: center;
-  color: #FFF;
-  cursor: pointer;
+.quiz-button-container {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin: 50px 0 24px;
 }
 
-.quiz-button-container {
-  margin-top: 56px;
-  margin-bottom: 104px;
+.quiz-button {
+  background: var(--color-gray-800);
+  border: 2px solid var(--color-white);
+  border-radius: 30px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  min-height: 32px;
+  min-width: 100%;
+  padding: 11px 86px;
+}
+
+.quiz-button-label {
+  color: var(--color-white);
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 22px;
+}
+
+.quiz-button[disabled] {
+  background: var(--color-gray-400);
+  cursor: not-allowed;
+}
+
+.quiz-button[disabled] .quiz-button-label{
+  color: var(--color-white);
 }
 
 /* Tablet up */

--- a/libs/blocks/quiz-entry/utils.js
+++ b/libs/blocks/quiz-entry/utils.js
@@ -17,12 +17,94 @@ export async function getQuizJson(path) {
   return [];
 }
 
+export const handleNext = (questionsData, selectedQuestion, userInputSelections, userFlow) => {
+  const allcards = Object.keys(userInputSelections);
+  let nextFlow = [];
+  let hasResultTrigger = false;
+
+  allcards.forEach((selection) => {
+    // for each elem in current selection, find its coresponding
+    // next element and push it to the next array.
+    const nextItems = questionsData[selectedQuestion.questions].data;
+    const getAllSelectedQuestionsRelatedOptions = nextItems.filter(
+      (nextItem) => nextItem.options === selection,
+    );
+
+    getAllSelectedQuestionsRelatedOptions.forEach(({ options, next }) => {
+      if (options === selection) {
+        const flowStepsList = next.split(',');
+        // RESET the queue and add only the next question.
+        if (flowStepsList.includes('RESET')) { // Reset to intial question
+          nextFlow = []; // Resetting the nextQuizViews
+          // eslint-disable-next-line no-param-reassign
+          userFlow = []; // Resetting the userFlow as well
+        }
+
+        if (!hasResultTrigger) {
+          hasResultTrigger = flowStepsList.includes('RESULT');
+        }
+
+        const filteredNextSteps = flowStepsList.filter((val) => (val !== 'RESULT' && val !== 'RESET'));
+
+        nextFlow = [...nextFlow, ...filteredNextSteps];
+      }
+    });
+  });
+
+  // Stripping off the next steps that are negated using 'NOT()'.
+  nextFlow.forEach((nextStep) => {
+    if (nextStep?.startsWith('NOT(')) {
+      const stepsToSkip = nextStep?.substring(
+        nextStep.indexOf('(') + 1,
+        nextStep.lastIndexOf(')'),
+      );
+      const stepsToSkipArr = stepsToSkip?.split(',');
+      stepsToSkipArr?.forEach((skip) => {
+        nextFlow = nextFlow.filter((view) => (view !== skip));
+      });
+    }
+  });
+
+  // Filtering out the NOT() from the nextQuizViews.
+  nextFlow = nextFlow.filter((view) => view.startsWith('NOT(') === false);
+
+  return { nextFlow: [...new Set([...userFlow, ...nextFlow])] };
+};
+
+export const handleSelections = (prevSelections, selectedQuestion, selections) => {
+  const newSelections = { selectedQuestion, selectedCards: selections };
+  let nextSelections = [];
+  let isNewQuestion = true;
+  // de-dup any existing data if they use the ml field and cards.
+  if (prevSelections.length > 0) {
+    prevSelections.forEach((selection) => {
+      if (selection.selectedQuestion === selectedQuestion) {
+        selection.selectedCards = selections;
+        isNewQuestion = false;
+      }
+    });
+    nextSelections = prevSelections;
+  }
+
+  if (isNewQuestion) nextSelections.push(newSelections);
+
+  return { nextSelections };
+};
+
 export async function getQuizEntryData(el) {
   const blockData = getNormalizedMetadata(el);
   const dataPath = blockData.data.text;
   const quizPath = blockData.quiz.text;
+  const maxQuestions = blockData.maxquestions?.text || 10;
   const analyticsType = blockData.analyticstype?.text;
   const analyticsQuiz = blockData.analyticsquiz?.text;
   const [questionData, stringsData] = await getQuizJson(dataPath);
-  return { quizPath, analyticsQuiz, analyticsType, questionData, stringsData };
+  return {
+    quizPath,
+    maxQuestions,
+    analyticsQuiz,
+    analyticsType,
+    questionData,
+    stringsData,
+  };
 }


### PR DESCRIPTION
* Support for ml filtering
* Debug support using ?debug=quiz-entry
* Support for defining a maximum number of questions in the block before it will redirect
* Support for pressing the enter key in the ml field

Resolves: [MWPW-146036](https://jira.corp.adobe.com/browse/MWPW-146036)

**Test URLs:**
- Before: https://quiz-entry-block--milo--adobecom.hlx.page/drafts/colloyd/quiz-entry/?martech=off
- After: https://quiz-entry-continue-button--milo--colloyd.hlx.page/drafts/colloyd/quiz-entry/?martech=off

Testing notes: 
You can now specify the number of questions that it will go through before redirecting to the main quiz, though this may not be used immediately, it does provide some future proofing if they want to try adding a few more questions before redirecting
You can prevent the redirect and get some console logs for ml field entries and quizState by adding debug=quiz-entry in the query string, like this:
- https://quiz-entry-continue-button--milo--colloyd.hlx.page/drafts/colloyd/quiz-entry/?martech=off&debug=quiz-entry
