### PR TITLE
Fed nav footer event

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -117,6 +117,7 @@ class Footer {
     this.block.setAttribute('daa-lh', `gnav|${getExperienceName()}|footer${mepMartech}`);
 
     this.block.append(this.elements.footer);
+    this.block.dispatchEvent(new Event('milo:footer:loaded'));
   }, 'Failed to decorate footer content', 'errorType=error,module=global-footer');
 
   loadMenuLogic = async () => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -419,6 +419,7 @@ class Gnav {
         lanaLog({ message: 'GNAV: Error within loadDelayed', e, tags: 'errorType=warn,module=gnav' });
         resolve();
       }
+      this.block.dispatchEvent(new Event('milo:gnav:loaded'));
     });
 
     return this.ready;
@@ -973,7 +974,6 @@ export default async function init(block) {
       block,
     });
     gnav.init();
-    block.dispatchEvent(new Event('gnav:init'));
     block.setAttribute('daa-im', 'true');
     const mepMartech = mep?.martech || '';
     block.setAttribute('daa-lh', `gnav|${getExperienceName()}${mepMartech}`);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -973,6 +973,7 @@ export default async function init(block) {
       block,
     });
     gnav.init();
+    block.dispatchEvent(new Event('gnav:init'));
     block.setAttribute('daa-im', 'true');
     const mepMartech = mep?.martech || '';
     block.setAttribute('daa-lh', `gnav|${getExperienceName()}${mepMartech}`);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

- New Akamai update will remove /media_ rules and QA found out fed nav and footer's images are getting 404 since they are getting loaded after media path altering function. This PR is to detect feds' loads so we know the exact time to run the function at consumer side.

![image](https://github.com/adobecom/milo/assets/55804872/1d82d1bd-bbdc-4372-89e6-5f435aa4129d)

![image](https://github.com/adobecom/milo/assets/55804872/338e4c34-973d-4dbe-8d7b-6f8d6d29ee51)


Resolves: https://workfront.slack.com/archives/C05J8364J0J/p1713837998307309?thread_ts=1713558036.129549&cid=C05J8364J0J

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/?martech=off
- After: https://fed-nav-footer-event--milo--adobecom.hlx.page/?martech=off
