### PR TITLE
MWPW-146878 [LocUI] - Actions polling state management

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -163,6 +163,7 @@ export async function syncToLangstore() {
     }, 3000);
   } else {
     await startSync();
+    getServiceUpdates();
   }
 }
 
@@ -228,12 +229,11 @@ export function showRollout() {
 }
 
 export async function rolloutAll(e, reroll) {
-  // stop polling for updates until request is made
   polling.value = false;
   showRolloutOptions.value = false;
   allowRollout.value = false;
   await rolloutLang('all', reroll);
-  getServiceUpdates();
+  polling.value = true;
 }
 
 export async function cancelLocProject() {

--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -9,6 +9,7 @@ import {
   allowRollout,
   syncFragments,
   allowCancelProject,
+  polling,
 } from '../utils/state.js';
 import { setExcelStatus, setStatus } from '../utils/status.js';
 import { origin, preview } from '../utils/franklin.js';
@@ -136,6 +137,9 @@ export async function findAllFragments() {
 }
 
 export async function syncToLangstore() {
+  // stop polling for updates until request is made
+  polling.value = false;
+
   // Disable all langstore syncing, the project is being sent.
   allowSyncToLangstore.value = false;
 
@@ -187,6 +191,9 @@ export async function syncFragsLangstore() {
 }
 
 export async function sendForLoc() {
+  // stop polling for updates until request is made
+  polling.value = false;
+
   // Disable all langstore syncing, the project is being sent.
   allowSyncToLangstore.value = false;
 
@@ -221,9 +228,12 @@ export function showRollout() {
 }
 
 export async function rolloutAll(e, reroll) {
+  // stop polling for updates until request is made
+  polling.value = false;
   showRolloutOptions.value = false;
   allowRollout.value = false;
   await rolloutLang('all', reroll);
+  getServiceUpdates();
 }
 
 export async function cancelLocProject() {

--- a/libs/blocks/locui/langs/index.js
+++ b/libs/blocks/locui/langs/index.js
@@ -1,4 +1,4 @@
-import { getServiceUpdates, rolloutLang } from '../utils/miloc.js';
+import { rolloutLang } from '../utils/miloc.js';
 import { languages, polling } from '../utils/state.js';
 import { getModal } from '../../modal/modal.js';
 import Modal from './modal.js';
@@ -30,7 +30,9 @@ export async function rollout(item, idx) {
 
   if (retry) await rolloutLang(item.code, reroll, 'retry', 'Retry.');
   else await rolloutLang(item.code, reroll);
-  getServiceUpdates();
+
+  // start status polling again when request finishes
+  polling.value = true;
 }
 
 export function showLangErrors(event, item) {

--- a/libs/blocks/locui/langs/index.js
+++ b/libs/blocks/locui/langs/index.js
@@ -1,5 +1,5 @@
-import { rolloutLang } from '../utils/miloc.js';
-import { languages } from '../utils/state.js';
+import { getServiceUpdates, rolloutLang } from '../utils/miloc.js';
+import { languages, polling } from '../utils/state.js';
 import { getModal } from '../../modal/modal.js';
 import Modal from './modal.js';
 import { createTag } from '../../../utils/utils.js';
@@ -17,16 +17,20 @@ export function showUrls(item, prefix) {
 }
 
 export async function rollout(item, idx) {
-  const reroll = item.status === 'completed';
-  const retry = item.status === 'error';
+  // stop polling until request is done
+  polling.value = false;
 
   // Update the UI immediate instead of waiting on polling
   languages.value[idx].status = item.status === 'error' ? 'retrying' : 'rolling-out';
   languages.value[idx].done = 0;
   languages.value = [...languages.value];
 
+  const reroll = item.status === 'completed';
+  const retry = item.status === 'error';
+
   if (retry) await rolloutLang(item.code, reroll, 'retry', 'Retry.');
   else await rolloutLang(item.code, reroll);
+  getServiceUpdates();
 }
 
 export function showLangErrors(event, item) {

--- a/libs/blocks/locui/langs/index.js
+++ b/libs/blocks/locui/langs/index.js
@@ -17,16 +17,16 @@ export function showUrls(item, prefix) {
 }
 
 export async function rollout(item, idx) {
+  const reroll = item.status === 'completed';
+  const retry = item.status === 'error';
+
   // stop polling until request is done
   polling.value = false;
 
   // Update the UI immediate instead of waiting on polling
-  languages.value[idx].status = item.status === 'error' ? 'retrying' : 'rolling-out';
+  languages.value[idx].status = retry ? 'retrying' : 'rolling-out';
   languages.value[idx].done = 0;
   languages.value = [...languages.value];
-
-  const reroll = item.status === 'completed';
-  const retry = item.status === 'error';
 
   if (retry) await rolloutLang(item.code, reroll, 'retry', 'Retry.');
   else await rolloutLang(item.code, reroll);

--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -24,8 +24,8 @@ function Badge({ status }) {
 function Language({ item, idx }) {
   const hasLocales = item.locales?.length > 0;
   const cssStatus = `locui-subproject-${item.status || 'not-started'}`;
-  const onButton = (e) => {
-    e.stopPropagation();
+  const onRollout = (e) => {
+    if (item.status === 'error') e.stopPropagation();
     rollout(item, idx);
   };
   let rolloutType = item.status === 'completed' ? 'Re-rollout' : 'Rollout';
@@ -66,7 +66,7 @@ function Language({ item, idx }) {
       `}
       ${['translated', 'completed', 'error'].includes(item.status) && html`
         <div class=locui-subproject-action-area>
-          <button class=locui-urls-heading-action onClick=${(e) => onButton(e)}>${rolloutType}</button>
+          <button class=locui-urls-heading-action onClick=${(e) => onRollout(e)}>${rolloutType}</button>
         </div>
       `}
     </li>

--- a/libs/blocks/locui/utils/miloc.js
+++ b/libs/blocks/locui/utils/miloc.js
@@ -181,8 +181,8 @@ export async function getServiceUpdates() {
       const json = await getProjectStatus(url);
       if (json) {
         projectStatus.value = json;
-        // stop polling for project status if cancelled or polling is turned off
-        if (json.projectStatus === 'cancelled' || !polling.value) {
+        // stop polling for project status if project cancelled
+        if (json.projectStatus === 'cancelled') {
           clearInterval(excelUpdated);
           polling.value = false;
         }


### PR DESCRIPTION
When polling for status updates and a user triggers an action, the status polling interval can return and re-render according to the status conditions before new updates from the action event are completed. This causes the UI to temporarily show the wrong action buttons until the request is finished and the status API returns a new status.

In this PR I am leveraging a polling state which is toggled on/off when an event is fired so we can avoid rendering updates from the status polling service until the actions event request is completed. I have also dialed in the polling functionality to avoid setting multiple polling intervals.

Resolves: [MWPW-146878](https://jira.corp.adobe.com/browse/MWPW-146878)
