### PR TITLE
MWPW-146562 [Workflow] Add base for paths filter when dispatch DC workflow

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: changes
         with:
+          base: ${{ github.ref }}
           filters: |
             src:
               - 'libs/**'    


### PR DESCRIPTION
* Without setting `base`, the paths-filter GHA uses the default branch `stage` as the base to check for differences. When there is a release push to `main`, no difference is found and DC workflow is not triggered. 

Resolves: [MWPW-146562](https://jira.corp.adobe.com/browse/MWPW-146562)

**Test URLs:**
N/A
