### PR TITLE
[MWPW-147003] Marquee RTL adaptation

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -432,6 +432,10 @@
     padding: var(--spacing-xl) 0;
   }
 
+  html[dir="rtl"] .marquee.split .foreground.container {
+    flex-direction: row-reverse;
+  }
+
   .marquee.split .foreground.container .text {
     max-width: calc(50% - var(--grid-column-width));
   }
@@ -470,6 +474,10 @@
 
   .marquee.split.row-reversed .foreground.container {
     justify-content: flex-end;
+  }
+
+  html[dir="rtl"] .marquee.split.row-reversed .foreground.container {
+    justify-content: flex-start;
   }
 
   .marquee.split .asset img,

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -86,7 +86,7 @@ function decorateSplit(el, foreground, media) {
 
   let mediaCreditInner;
   const txtContent = media?.lastChild?.textContent?.trim();
-  if (txtContent.match(/^http.*\.mp4/)) return;
+  if (txtContent?.match(/^http.*\.mp4/)) return;
   if (txtContent) {
     mediaCreditInner = createTag('p', { class: 'body-s' }, txtContent);
   } else if (media.lastElementChild?.tagName !== 'PICTURE') {


### PR DESCRIPTION
## Description
This addresses an RTL issue for the split marquee.

I initially saw this as a "patch" and tried to consolidate `flex-direction` for all marquees starting at `600px`. Due to the large number of use-cases, I did a bunch of screenshot diffs and it seems that that approach would have affected multiple types of marquees between 600-1200px. Thus I decided to play it safe for now and address the initially reported issues, since the bug is marked as critical.

## Issue

**Resolves**: [MWPW-147003](https://jira.corp.adobe.com/browse/MWPW-147003)

## Test URLs

### Initially reported pages

- **Before**: https://main--cc--adobecom.hlx.page/mena_ar/products/illustrator
- **After**: https://main--cc--adobecom.hlx.page/mena_ar/products/illustrator?milolibs=marquee-on-rtl--milo--overmyheadandbody

- **Before**: https://main--cc--adobecom.hlx.page/eg_ar/products/illustrator/campaign/pricing
- **After**: https://main--cc--adobecom.hlx.page/eg_ar/products/illustrator/campaign/pricing?milolibs=marquee-on-rtl--milo--overmyheadandbody

- **Before**: https://main--cc--adobecom.hlx.page/eg_ar/products/acrobat-pro-cc
- **After**: https://main--cc--adobecom.hlx.page/eg_ar/products/acrobat-pro-cc?milolibs=marquee-on-rtl--milo--overmyheadandbody

### Marquee kitchen sink

- **Before**: https://main--milo--overmyheadandbody.hlx.page/docs/library/kitchen-sink/marquee?martech=off&georouting=off
- **After**: https://marquee-on-rtl--milo--overmyheadandbody.hlx.page/docs/library/kitchen-sink/marquee?martech=off&georouting=off