### PR TITLE
MWPW-144521: Jarvis enhancement

### DIFF
--- a/libs/features/jarvis-chat.js
+++ b/libs/features/jarvis-chat.js
@@ -203,7 +203,7 @@ const openChat = (event) => {
   }
 };
 
-const startInitialization = async (config, event) => {
+const startInitialization = async (config, event, onDemand) => {
   const asset = 'https://client.messaging.adobe.com/latest/AdobeMessagingClient';
   await Promise.all([
     loadStyle(`${asset}.css`),
@@ -238,8 +238,6 @@ const startInitialization = async (config, event) => {
         chatInitialized = !!data?.releaseControl?.showAdobeMessaging;
       },
       onReadyCallback: () => {
-        const onDemandMeta = getMetadata('jarvis-on-demand')?.toLowerCase();
-        const onDemand = onDemandMeta ? onDemandMeta === 'on' : config.jarvis.onDemand;
         if (onDemand) {
           openChat(event);
         }
@@ -300,7 +298,7 @@ const initJarvisChat = async (
     if (!event.target.closest('[href*="#open-jarvis-chat"]')) return;
     event.preventDefault();
     if (onDemand && !chatInitialized) {
-      await startInitialization(config, event);
+      await startInitialization(config, event, onDemand);
     } else {
       openChat(event);
     }

--- a/libs/features/jarvis-chat.js
+++ b/libs/features/jarvis-chat.js
@@ -219,7 +219,7 @@ const startInitialization = async (config, event, onDemand) => {
 
   window.AdobeMessagingExperienceClient.initialize({
     appid: getMetadata('jarvis-surface-id') || config.jarvis.id,
-    appver: getMetadata('jarvis-version') || config.jarvis.version,
+    appver: getMetadata('jarvis-surface-version') || config.jarvis.version,
     env: config.env.name !== 'prod' ? 'stage' : 'prod',
     clientId: window.adobeid?.client_id,
     accessToken: window.adobeIMS?.isSignedInUser()

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -21,7 +21,7 @@ export const loadJarvisChat = async (getConfig, getMetadata, loadScript, loadSty
   if (jarvis === 'desktop' && !desktopViewport) return;
 
   const { initJarvisChat } = await import('../features/jarvis-chat.js');
-  initJarvisChat(config, loadScript, loadStyle);
+  initJarvisChat(config, loadScript, loadStyle, getMetadata);
 };
 
 export const loadPrivacy = async (getConfig, loadScript) => {

--- a/test/features/jarvis-chat/jarvis-chat.test.js
+++ b/test/features/jarvis-chat/jarvis-chat.test.js
@@ -104,8 +104,6 @@ describe('Jarvis Chat', () => {
     const args = initializeSpy.getCall(0).args[0];
     expect(args.appid).to.equal(defaultConfig.jarvis.id);
     expect(args.appver).to.equal(testVersion);
-    console.log('args.appid: ', args.appid);
-    console.log('args.appver: ', args.appver);
     expect(args.env).to.equal(config.env.name === 'prod' ? 'prod' : 'stage');
   });
 

--- a/test/features/jarvis-chat/jarvis-chat.test.js
+++ b/test/features/jarvis-chat/jarvis-chat.test.js
@@ -99,7 +99,7 @@ describe('Jarvis Chat', () => {
     });
     const testVersion = '0.123';
     const getMetadataMock = sinon.stub();
-    getMetadataMock.withArgs('jarvis-version').returns(testVersion);
+    getMetadataMock.withArgs('jarvis-surface-version').returns(testVersion);
     await initJarvisChat(config, sinon.stub(), sinon.stub(), getMetadataMock);
     const args = initializeSpy.getCall(0).args[0];
     expect(args.appid).to.equal(defaultConfig.jarvis.id);

--- a/test/features/jarvis-chat/jarvis-chat.test.js
+++ b/test/features/jarvis-chat/jarvis-chat.test.js
@@ -41,14 +41,14 @@ describe('Jarvis Chat', () => {
   it('should not initialize when configuration is not available', async () => {
     setConfig({});
     const config = getConfig();
-    await initJarvisChat(config, sinon.stub(), sinon.stub());
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());
     expect(initializeSpy.called).to.be.false;
   });
 
   it('should initialize when configuration is available', async () => {
     setConfig(defaultConfig);
     const config = getConfig();
-    await initJarvisChat(config, sinon.stub(), sinon.stub());
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());
     expect(initializeSpy.called).to.be.true;
   });
 
@@ -60,7 +60,7 @@ describe('Jarvis Chat', () => {
         prefix: '/africa',
       },
     });
-    await initJarvisChat(config, sinon.stub(), sinon.stub());
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());
     const args = initializeSpy.getCall(0).args[0];
     expect(args.appid).to.equal(config.jarvis.id);
     expect(args.appver).to.equal(config.jarvis.version);
@@ -70,11 +70,92 @@ describe('Jarvis Chat', () => {
     expect(args.region).to.equal('africa');
   });
 
+  it('should receive the correct custom surface id configuration', async () => {
+    setConfig(defaultConfig);
+    const config = Object.assign(getConfig(), {
+      locale: {
+        ietf: 'en',
+        prefix: '/africa',
+      },
+    });
+
+    const testSurfaceId = 'test-id';
+    const getMetadataMock = sinon.stub();
+    getMetadataMock.withArgs('jarvis-surface-id').returns(testSurfaceId);
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), getMetadataMock);
+    const args = initializeSpy.getCall(0).args[0];
+    expect(args.appid).to.equal(testSurfaceId);
+    expect(args.appver).to.equal(defaultConfig.jarvis.version);
+    expect(args.env).to.equal(config.env.name === 'prod' ? 'prod' : 'stage');
+  });
+
+  it('should receive the correct custom version configuration', async () => {
+    setConfig(defaultConfig);
+    const config = Object.assign(getConfig(), {
+      locale: {
+        ietf: 'en',
+        prefix: '/africa',
+      },
+    });
+    const testVersion = '0.123';
+    const getMetadataMock = sinon.stub();
+    getMetadataMock.withArgs('jarvis-version').returns(testVersion);
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), getMetadataMock);
+    const args = initializeSpy.getCall(0).args[0];
+    expect(args.appid).to.equal(defaultConfig.jarvis.id);
+    expect(args.appver).to.equal(testVersion);
+    console.log('args.appid: ', args.appid);
+    console.log('args.appver: ', args.appver);
+    expect(args.env).to.equal(config.env.name === 'prod' ? 'prod' : 'stage');
+  });
+
+  it('should receive the correct default onDemand configuration', async () => {
+    setConfig(defaultConfig);
+    const config = Object.assign(getConfig(), {
+      locale: {
+        ietf: 'en',
+        prefix: '/africa',
+      },
+      jarvis: {
+        id: 'milo',
+        version: '1.0',
+        onDemand: true,
+      },
+    });
+
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());
+    expect(initializeSpy.called).to.be.false;
+  });
+
+  it('should receive the correct custom onDemand configuration', async () => {
+    setConfig(defaultConfig);
+    const config = Object.assign(getConfig(), {
+      locale: {
+        ietf: 'en',
+        prefix: '/africa',
+      },
+      jarvis: {
+        id: 'milo',
+        version: '1.0',
+        onDemand: true,
+      },
+    });
+
+    const getMetadataMock = sinon.stub();
+    getMetadataMock.withArgs('jarvis-on-demand').returns('off');
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), getMetadataMock);
+    expect(initializeSpy.called).to.be.true;
+    const args = initializeSpy.getCall(0).args[0];
+    expect(args.appid).to.equal(defaultConfig.jarvis.id);
+    expect(args.appver).to.equal(defaultConfig.jarvis.version);
+    expect(args.env).to.equal(config.env.name === 'prod' ? 'prod' : 'stage');
+  });
+
   it('should open a chat session upon click', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/jarvis-chat.html' });
     setConfig(defaultConfig);
     const config = getConfig();
-    await initJarvisChat(config, sinon.stub(), sinon.stub());
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());
     const args = initializeSpy.getCall(0).args[0];
     args.callbacks.initCallback({ releaseControl: { showAdobeMessaging: true } });
     openMessagingWindowSpy.resetHistory();
@@ -89,7 +170,7 @@ describe('Jarvis Chat', () => {
   it('should synchronize analytics', async () => {
     setConfig(defaultConfig);
     const config = getConfig();
-    await initJarvisChat(config, sinon.stub(), sinon.stub());
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());
     const args = initializeSpy.getCall(0).args[0];
 
     const iconRender = await readFile({ path: './mocks/sendChatIconRenderEvent.json' });
@@ -145,7 +226,7 @@ describe('Jarvis Chat', () => {
   it('should initialize on demand when configured', async () => {
     setConfig(defaultConfig);
     const config = getConfig();
-    await initJarvisChat(config, sinon.stub(), sinon.stub());
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());
     const args = initializeSpy.getCall(0).args[0];
     // Set uninitialized state
     args.callbacks.initCallback({ releaseControl: { showAdobeMessaging: false } });
@@ -153,7 +234,7 @@ describe('Jarvis Chat', () => {
 
     config.jarvis.onDemand = true;
     document.body.innerHTML = await readFile({ path: './mocks/jarvis-chat.html' });
-    await initJarvisChat(config, sinon.stub(), sinon.stub());
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());
     expect(initializeSpy.called).to.be.false;
     document.querySelector('a').click();
     await new Promise((resolve) => {


### PR DESCRIPTION
Adds the ability to control the Jarvis `surface id`, `version` and `onDemand` config at the page and directory level.

Resolves: [MWPW-144521](https://jira.corp.adobe.com/browse/MWPW-144521)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/nishantkaush/test/jarvis?martech=off
- After: https://mwpw-144521--milo--nishantka.hlx.live/drafts/nishantkaush/test/jarvis?martech=off
