### PR TITLE
[MWPW-147145] Allow SVG in PEP Prompt; change redirect method

### DIFF
--- a/libs/features/webapp-prompt/webapp-prompt.css
+++ b/libs/features/webapp-prompt/webapp-prompt.css
@@ -27,6 +27,10 @@
     left: 0;
   }
 
+  .appPrompt-icon {
+    min-height: 32px;
+  }
+
   .appPrompt-icon img,
   .appPrompt-icon svg {
     width: 32px;


### PR DESCRIPTION
This allows the use of SVG icons inside the PEP Prompt document and updates the method used for redirection.

Resolves: [MWPW-147145](https://jira.corp.adobe.com/browse/MWPW-147145)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/firefly?milolibs=project-pep
- After: https://main--cc--adobecom.hlx.page/products/firefly?milolibs=project-pep--milo--overmyheadandbody
