### PR TITLE
MWPW-147265 - [LocUI] Preview and Live Links

### DIFF
--- a/libs/blocks/locui/url/index.js
+++ b/libs/blocks/locui/url/index.js
@@ -51,7 +51,7 @@ async function previewAction(url, item) {
 
 export async function handleAction(e, item, isPrev = false) {
   e.target.classList.add('locui-action-loading');
-  const action = item.value[preview ? 'preview' : 'live'];
+  const action = item.value[isPrev ? 'preview' : 'live'];
   const url = new URL(action.url);
   if (isPrev) await previewAction(url, item);
   else window.open(url, '_blank');


### PR DESCRIPTION
Both preview and live buttons currently open a preview url, this PR will update them to look at the proper is preview flag and fetch the correct url to set on each link.

Resolves: [MWPW-147265](https://jira.corp.adobe.com/browse/MWPW-147265)
