### PR TITLE
MWPW-147002-Fix spacing issue between button on table header left variation in RTL

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -160,11 +160,7 @@
 }
 
 .table.header-left .row-heading .col.col-heading .buttons-wrapper > * {
-  margin-left: 0;
-}
-
-[dir='rtl'] .table.header-left .row-heading .col.col-heading .buttons-wrapper > * {
-  margin-right: 0;
+  margin-inline-start: 0;
 }
 
 .table .row-heading .col-heading.top-left-rounded {


### PR DESCRIPTION
* Fix spacing issue between button on table header left variation in RTL

Resolves: [MWPW-147002](https://jira.corp.adobe.com/browse/MWPW-147002)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/fragments/consonant/tables/table-header-left?martech=off
- After: https://table-rtl--milo--adobecom.hlx.page/fragments/consonant/tables/table-header-left?martech=off

CC
- Before: https://main--cc--adobecom.hlx.live/kw_ar/products/illustrator/plans?martech=off
- After: https://main--cc--adobecom.hlx.live/kw_ar/products/illustrator/plans?milolibs=table-rtl&martech=off

Note: for testing milo url please update dir to RTL in your elements tab in developer tools
