### PR TITLE
MWPW-147482 - ML Input Bulletproofing

### DIFF
--- a/libs/blocks/quiz-entry/mlField.js
+++ b/libs/blocks/quiz-entry/mlField.js
@@ -28,18 +28,24 @@ export const getMLResults = async (endpoint, apiKey, threshold, input, count, va
     .then((response) => response.json())
     .catch((error) => window.lana.log(`ERROR: Fetching fi codes ${error}`));
 
+  let value;
   let highestProb = null;
-  result.filtered = result?.data?.filter((item) => {
-    let isValid = false;
-    if (!highestProb) {
-      highestProb = item.prob;
-      isValid = true;
-    } else if (item.prob / highestProb > threshold) {
-      isValid = true;
-    }
-    return isValid;
-  });
-  return result;
+  if (result) {
+    result.filtered = result?.data?.filter((item) => {
+      let isValid = false;
+      if (!highestProb) {
+        highestProb = item.prob;
+        isValid = true;
+      } else if (item.prob / highestProb > threshold) {
+        isValid = true;
+      }
+      return isValid;
+    });
+    value = result;
+  } else {
+    value = { errors: [{ title: 'Unable to fetch fi codes' }] };
+  }
+  return value;
 };
 
 export const mlField = ({ cardsUsed, onMLInput, onMLEnter, placeholderText, onClearClick }) => html`<div class="ml-field-container">

--- a/libs/blocks/quiz-entry/utils.js
+++ b/libs/blocks/quiz-entry/utils.js
@@ -95,7 +95,7 @@ export async function getQuizEntryData(el) {
   const blockData = getNormalizedMetadata(el);
   const dataPath = blockData.data.text;
   const quizPath = blockData.quiz.text;
-  const maxQuestions = blockData.maxquestions?.text || 10;
+  const maxQuestions = Number(blockData.maxquestions?.text) || 10;
   const analyticsType = blockData.analyticstype?.text;
   const analyticsQuiz = blockData.analyticsquiz?.text;
   const [questionData, stringsData] = await getQuizJson(dataPath);


### PR DESCRIPTION
* add support for fallback fi codes
* add lana logging for ml field failures
* fix so the redirect checks for maxQuestions

Resolves: [MWPW-147482](https://jira.corp.adobe.com/browse/MWPW-147482)

**Test URLs:**
- Before:  https://quiz-entry-block--milo--adobecom.hlx.page/drafts/colloyd/quiz-entry/?martech=off
- After: https://quiz-entry-ml-bulletproofing--milo--colloyd.hlx.page/drafts/colloyd/quiz-entry/?martech=off

Testing notes: 
To test the fallback fi codes, I've created a page that is deliberately broken with invalid ml details (specifically the endpoint is wrong). Notice in the console on this page, when interacting with the ml field, that the messaging now confirms that it is using fallback codes. You can test this through to results by dropping the debug param. Search for something video related and you will see that the results will display the fallback products, PS, AI and PR.
- https://quiz-entry-ml-bulletproofing--milo--colloyd.hlx.page/drafts/colloyd/quiz-entry-broken/?martech=off&debug=quiz-entry