### PR TITLE
MWPW-147735 - [LocUI] Catch fetch errors in fragment search

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -47,14 +47,25 @@ async function updateExcelJson() {
   });
 }
 
+async function fetchDocument(hlxPath) {
+  try {
+    const resp = await fetch(`${origin}${hlxPath}`);
+    if (!resp.ok) return null;
+    const html = await resp.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    return doc;
+  } catch (error) {
+    setStatus('service', 'error', error.message);
+    return null;
+  }
+}
+
 async function findPageFragments(path) {
   const isIndex = path.lastIndexOf('index');
   const hlxPath = isIndex > 0 ? path.substring(0, isIndex) : path;
-  const resp = await fetch(`${origin}${hlxPath}`);
-  if (!resp.ok) return [];
-  const html = await resp.text();
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, 'text/html');
+  const doc = await fetchDocument(hlxPath);
+  if (!doc) return [];
   // Decorate the doc, but don't load any blocks (i.e. do not use loadArea)
   decorateSections(doc, true);
   await decorateFooterPromo(doc);

--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -57,7 +57,7 @@ async function fetchDocument(hlxPath) {
     const doc = parser.parseFromString(html, 'text/html');
     return doc;
   } catch (error) {
-    setStatus('service', 'error', `${error.message} - ${path}`);
+    setStatus('service', 'error', `${error.message} Fragment`, `There was an issue fetching ${path}`, 10000);
     return null;
   }
 }

--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -48,15 +48,16 @@ async function updateExcelJson() {
 }
 
 async function fetchDocument(hlxPath) {
+  const path = `${origin}${hlxPath}`;
   try {
-    const resp = await fetch(`${origin}${hlxPath}`);
+    const resp = await fetch(path);
     if (!resp.ok) return null;
     const html = await resp.text();
     const parser = new DOMParser();
     const doc = parser.parseFromString(html, 'text/html');
     return doc;
   } catch (error) {
-    setStatus('service', 'error', error.message);
+    setStatus('service', 'error', `${error.message} - ${path}`);
     return null;
   }
 }


### PR DESCRIPTION
**Problem:**
In fragment search function we weren't catching fetch errors and this was causing the UI to freeze up when a file had a redirect and caused a CORS error. 

**Solution:**
Moved the fetch into its own function with a try/catch to catch the errors and display them for the user, while also enabling the find fragments to continue searching for fragments.

Resolves: [MWPW-147735](https://jira.corp.adobe.com/browse/MWPW-147735)
