### PR TITLE
Revert "MWPW-146796 Add localization to Marketo destination URLs"

### DIFF
--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -13,7 +13,7 @@
 /*
  * Marketo Form
  */
-import { parseEncodedConfig, loadScript, localizeLink, createTag, createIntersectionObserver } from '../../utils/utils.js';
+import { parseEncodedConfig, loadScript, createTag, createIntersectionObserver } from '../../utils/utils.js';
 
 const ROOT_MARGIN = 1000;
 const FORM_ID = 'form id';
@@ -48,10 +48,7 @@ export const decorateURL = (destination, baseURL = window.location) => {
       destinationUrl.pathname = `${pathname}.html`;
     }
 
-    const localized = localizeLink(destinationUrl.href, null, true);
-    destinationUrl.pathname = new URL(localized, baseURL.origin).pathname;
-
-    return destinationUrl.href;
+    return destinationUrl;
   } catch (e) {
     window.lana?.log(`Error with Marketo destination URL: ${destination} ${e.message}`);
   }
@@ -98,7 +95,7 @@ const readyForm = (form) => {
 };
 
 const setPreference = (key, value) => {
-  if (value && key?.includes('.')) {
+  if (key && key.includes('.')) {
     const keyParts = key.split('.');
     const lastKey = keyParts.pop();
     const formDataObject = keyParts.reduce((obj, part) => {
@@ -171,7 +168,7 @@ export default function init(el) {
 
     if (destinationUrl) {
       formData['form.success.type'] = 'redirect';
-      formData['form.success.content'] = destinationUrl;
+      formData['form.success.content'] = destinationUrl.href;
     }
   }
 

--- a/test/blocks/marketo/marketo.test.js
+++ b/test/blocks/marketo/marketo.test.js
@@ -1,7 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { delay } from '../../helpers/waitfor.js';
-import { setConfig } from '../../../libs/utils/utils.js';
 import init, { setPreferences, decorateURL } from '../../../libs/blocks/marketo/marketo.js';
 
 const innerHTML = await readFile({ path: './mocks/body.html' });
@@ -46,31 +45,31 @@ describe('marketo decorateURL', () => {
   it('decorates absolute URL with local base URL', () => {
     const baseURL = new URL('http://localhost:6456/marketo-block');
     const result = decorateURL('https://main--milo--adobecom.hlx.page/marketo-block/thank-you', baseURL);
-    expect(result).to.equal('http://localhost:6456/marketo-block/thank-you');
+    expect(result.href).to.equal('http://localhost:6456/marketo-block/thank-you');
   });
 
   it('decorates relative URL with absolute base URL', () => {
     const baseURL = new URL('https://main--milo--adobecom.hlx.page/marketo-block');
     const result = decorateURL('/marketo-block/thank-you', baseURL);
-    expect(result).to.equal('https://main--milo--adobecom.hlx.page/marketo-block/thank-you');
+    expect(result.href).to.equal('https://main--milo--adobecom.hlx.page/marketo-block/thank-you');
   });
 
   it('decorates absolute URL with matching base URL', () => {
     const baseURL = new URL('https://main--milo--adobecom.hlx.page/marketo-block');
     const result = decorateURL('https://main--milo--adobecom.hlx.page/marketo-block/thank-you', baseURL);
-    expect(result).to.equal('https://main--milo--adobecom.hlx.page/marketo-block/thank-you');
+    expect(result.href).to.equal('https://main--milo--adobecom.hlx.page/marketo-block/thank-you');
   });
 
   it('decorates absolute URL with .html base URL', () => {
     const baseURL = new URL('https://business.adobe.com/marketo-block.html');
     const result = decorateURL('https://main--milo--adobecom.hlx.page/marketo-block/thank-you', baseURL);
-    expect(result).to.equal('https://business.adobe.com/marketo-block/thank-you.html');
+    expect(result.href).to.equal('https://business.adobe.com/marketo-block/thank-you.html');
   });
 
   it('keeps identical absolute URL with .html base URL', () => {
     const baseURL = new URL('https://business.adobe.com/marketo-block.html');
     const result = decorateURL('https://business.adobe.com/marketo-block/thank-you.html', baseURL);
-    expect(result).to.equal('https://business.adobe.com/marketo-block/thank-you.html');
+    expect(result.href).to.equal('https://business.adobe.com/marketo-block/thank-you.html');
   });
 
   it('returns null when provided a malformed URL', () => {
@@ -82,19 +81,6 @@ describe('marketo decorateURL', () => {
   it('Does not add .html to ending slash', () => {
     const baseURL = new URL('https://business.adobe.com/marketo-block.html');
     const result = decorateURL('https://business.adobe.com/', baseURL);
-    expect(result).to.equal('https://business.adobe.com/');
-  });
-
-  it('localizes URL with .html base URL', () => {
-    setConfig({
-      pathname: '/uk/marketo-block.html',
-      locales: {
-        '': {},
-        uk: {},
-      },
-    });
-    const baseURL = new URL('https://business.adobe.com/uk/marketo-block.html');
-    const result = decorateURL('/marketo-block/thank-you', baseURL);
-    expect(result).to.equal('https://business.adobe.com/uk/marketo-block/thank-you.html');
+    expect(result.href).to.equal('https://business.adobe.com/');
   });
 });


### PR DESCRIPTION
Reverts adobecom/milo#2200 from stage.

The PR got merged with failing unit tests which are also consistently failing on stage now.

- https://revert-2200-bmarshal-marketo-localized--milo--adobecom.hlx.live/