### PR TITLE
MWPW-147527 Fix JP text issue in Review component

### DIFF
--- a/libs/blocks/review/components/review/RatingSummary.js
+++ b/libs/blocks/review/components/review/RatingSummary.js
@@ -1,4 +1,4 @@
-import { html } from '../../../../deps/htm-preact.js';
+import { html, useRef } from '../../../../deps/htm-preact.js';
 
 function RatingSummary({
   averageRating = 0,
@@ -11,17 +11,29 @@ function RatingSummary({
 
   if (!averageRating) return html`<div></div>`;
 
+  const spanAverage = useRef(html`
+    <span className="hlx-ReviewStats-average">${averageRatingRounded}</span>
+  `);
+  const spanMax = useRef(html`
+    <span className="hlx-ReviewStats-outOf">${maxRating}</span>
+  `);
+  const spanTotalReviews = useRef(html`
+    <span className="hlx-ReviewStats-total">${totalReviews}</span>
+  `);
+  const spanVote = useRef(html`
+    <span className="hlx-ReviewStats-vote">
+      ${totalReviews === 1 ? reviewString : reviewStringPlural}
+    </span>
+  `);
   // placeholder
   return html`
     <div className="hlx-ReviewStats is-Visible">
-      <span className="hlx-ReviewStats-average">${averageRatingRounded}</span>
+      ${spanAverage.current}
       <span className="hlx-ReviewStats-separator">/</span>
-      <span className="hlx-ReviewStats-outOf">${maxRating}</span>
+      ${spanMax.current}
       <span className="hlx-ReviewStats-separator">-</span>
-      <span className="hlx-ReviewStats-total">${totalReviews}</span>
-      <span className="hlx-ReviewStats-vote">
-        ${totalReviews === 1 ? reviewString : reviewStringPlural}
-      </span>
+      ${spanTotalReviews.current}
+      ${spanVote.current}
     </div>
   `;
 }

--- a/libs/blocks/review/components/review/RatingSummary.js
+++ b/libs/blocks/review/components/review/RatingSummary.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import { html, useRef } from '../../../../deps/htm-preact.js';
 
 function RatingSummary({

--- a/test/blocks/review/mocks/body_jp.html
+++ b/test/blocks/review/mocks/body_jp.html
@@ -1,0 +1,54 @@
+<main>
+  <div>
+    <div class="review">
+      <div>
+        <div>Review url</div>
+        <div>https://main--helixdemo--nkthakur48.hlx.page/data/review</div>
+      </div>
+      <div>
+        <div>Title</div>
+        <div>私たちのツールをぜひ評価してください。いただいた評価が開発チームの原動力となります。</div>
+      </div>
+      <div>
+        <div>Hide title</div>
+        <div>true</div>
+      </div>
+      <div>
+        <div>Rating verb</div>
+        <div>投票する, 件の評価</div>
+      </div>
+      <div>
+        <div>Rating noun</div>
+        <div>星, 星</div>
+      </div>
+      <div>
+        <div>Comment placeholder</div>
+        <div>フィードバックをお聞かせください</div>
+      </div>
+      <div>
+        <div>Comment field label</div>
+        <div>レビューのフィードバック</div>
+      </div>
+      <div>
+        <div>Submit text</div>
+        <div>送信</div>
+      </div>
+      <div>
+        <div>Thank you text</div>
+        <div>アンケートにご協力いただき、誠にありがとうございました。</div>
+      </div>
+      <div>
+        <div>Tooltips</div>
+        <div>悪い, 平均以下, 良い, 非常に良い, 優れている</div>
+      </div>
+      <div>
+        <div>Tooltip delay</div>
+        <div>5</div>
+      </div>
+      <div>
+        <div>Initial Value</div>
+        <div>0</div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/review/mocks/head.html
+++ b/test/blocks/review/mocks/head.html
@@ -1,0 +1,3 @@
+<script></script>
+<link rel="icon" href="data:,">
+<meta name="martech" content="off">

--- a/test/blocks/review/review_jp.test.js
+++ b/test/blocks/review/review_jp.test.js
@@ -1,0 +1,49 @@
+import sinon from 'sinon';
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import { waitForElement, delay } from '../../helpers/waitfor.js';
+import { getConfig, updateConfig, loadArea } from '../../../libs/utils/utils.js';
+
+describe('Review Component for JP', () => {
+  beforeEach(async () => {
+    const config = getConfig();
+    updateConfig({ ...config, base: '/libs', codeRoot: '/libs', locale: { ietf: 'ja-JP', tk: '', prefix: 'jp' } });
+    document.head.innerHTML = await readFile({ path: './mocks/head.html' });
+    document.body.innerHTML = await readFile({ path: './mocks/body_jp.html' });
+    window.s_adobe = { visitor: { getMarketingCloudVisitorID: () => 'abcd' } };
+    sinon.stub(window, 'fetch').resolves(
+      new Response(JSON.stringify({
+        total: 4,
+        offset: 0,
+        limit: 4,
+        data: [
+          { country: 'all', total: '17', average: '3.5' },
+          { country: 'en', total: '6', average: '3.3' },
+          { country: 'fr', total: '3', average: '3.3' },
+          { country: 'de', total: '3', average: '3.3' },
+        ],
+        ':type': 'sheet',
+      }), {
+        status: 200,
+        headers: { 'Content-type': 'application/json' },
+      }),
+    );
+    await loadArea();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should show JP text correctly', async () => {
+    const review = await waitForElement('.hlx-ReviewWrapper');
+    const ratingInputs = review.querySelectorAll('.hlx-Review-ratingFields input');
+    await delay(125);
+    await ratingInputs[2].dispatchEvent(new Event('click'));
+    await delay(125);
+    const title = review.querySelector('.hlx-reviewTitle');
+    expect(title.textContent).to.equal('私たちのツールをぜひ評価してください。いただいた評価が開発チームの原動力となります。');
+    const vote = review.querySelector('.hlx-ReviewStats');
+    expect(vote.textContent).to.equal('3.5/5-17 件の評価');
+  });
+});


### PR DESCRIPTION
* The bug only happens in JP. When the review component goes through `controlJapaneseLineBreaks()`, somehow text strings are duplicated.
* The bug is reproducible in the unit test I created. 
* The fix is to use `useRef()` for those text elements.

Resolves: [MWPW-147527](https://jira.corp.adobe.com/browse/MWPW-147527)

**Test URLs:**
- Before: https://main--dc--adobecom.hlx.live/jp/acrobat/online/compress-pdf?martech=off
- After: https://main--dc--adobecom.hlx.live/jp/acrobat/online/compress-pdf?milolibs=MWPW-147527&martech=off

- Before: https://main--milo--adobecom.aem.live/
- After: https://mwpw-147527--milo--adobecom.aem.live/
