### PR TITLE
MWPW-141780 - Clean up Accordion block attributes

### DIFF
--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -92,7 +92,7 @@ function createItem(accordion, id, heading, num, edit) {
   const dtAttrs = hTag ? {} : { role: 'heading', 'aria-level': 3 };
   const dtHtml = hTag ? createTag(hTag.tagName, { class: 'accordion-heading' }, button) : button;
   const dt = createTag('dt', dtAttrs, dtHtml);
-  const dd = createTag('dd', { role: 'region', 'aria-labelledby': triggerId, id: panelId, hidden: true }, panel);
+  const dd = createTag('dd', { 'aria-labelledby': triggerId, id: panelId, hidden: true }, panel);
   const dm = createTag('div', { class: 'media-p' });
 
   if (edit) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* This is a small PR intended to clean up the a11y attributes on the Accordion block. The body of each accordion item had a `role="region"` attribute that was redundant, as we only ever have one element used as the body of the accordion item.

Resolves: [MWPW-141780](https://jira.corp.adobe.com/browse/MWPW-141780)

**Test URLs:**

Milo:
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/accordion?martech=off
- After: https://ebartholomew-mwpw-141780-accordion-attr--milo--adobecom.hlx.page/docs/library/blocks/accordion?martech=off

CC:
- Before: https://main--cc--adobecom.hlx.page/drafts/jbrown/batch-02/products/aftereffects?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/jbrown/batch-02/products/aftereffects?martech=off&milolibs=ebartholomew-mwpw-141780-accordion-attr
