### PR TITLE
[merge to stage automation] Remove superfluent slacks to the changelog

### DIFF
--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -20,10 +20,6 @@ const LABELS = {
 const SLACK = {
   merge: ({ html_url, number, title, highImpact }) =>
     `:merged:${highImpact} PR merged to stage: <${html_url}|${number}: ${title}>.`,
-  failingChecks: ({ html_url, number, title }) =>
-    `:x: Skipping <${html_url}|${number}: ${title}> due to failing checks`,
-  requireApprovals: ({ html_url, number, title }) =>
-    `:x: Skipping <${html_url}|${number}: ${title}> due to insufficient approvals`,
   openedSyncPr: ({ html_url, number }) =>
     `:fast_forward: Created <${html_url}|Stage to Main PR ${number}>`,
 };

--- a/.github/workflows/merge-to-stage.yaml
+++ b/.github/workflows/merge-to-stage.yaml
@@ -31,4 +31,4 @@ jobs:
           github-token: ${{ steps.milo-pr-merge-token.outputs.token }}
           script: |
             const main = require('./.github/workflows/merge-to-stage.js')
-            main({ github, context, core })
+            main({ github, context })


### PR DESCRIPTION
Follow up for https://github.com/adobecom/milo/pull/2224 - do not spam #milo-changelog with PRs that are not changing anything. Devs can be expected to check the action or reach out to #milo-stage and ping me there.

**Test URLs:**
- Before: https://main--milo--mokimo.hlx.live/?martech=off
- After: https://remove-skipped-pr-slacks--milo--mokimo.hlx.live/?martech=off
