### PR TITLE
MWPW-148094 - LocUI Error Status style

### DIFF
--- a/libs/blocks/locui/locui.css
+++ b/libs/blocks/locui/locui.css
@@ -123,6 +123,10 @@ span.locui-sync-badge-mono {
   width: 420px;
 }
 
+.locui-status-toast.has-description {
+  cursor: pointer;
+}
+
 .locui-status-toast-type-info {
   background: linear-gradient(0deg, rgb(0 154 206 / 100%) 0%, rgb(0 139 186 / 100%) 100%);
   color: #003d52;
@@ -151,6 +155,18 @@ p.locui-status-toast-description {
   margin: 0;
   padding: 12px 16px;
   background: rgba(255 255 255 / 10%);
+  cursor: default;
+  overflow: auto;
+  max-height: 85vh;
+}
+
+p.locui-status-toast-description ol {
+  padding-left: 25px;
+  margin: 0 0 8px;
+}
+
+p.locui-status-toast-description ol li:not(:last-child) {
+  margin-bottom: 10px;
 }
 
 div.locui-status-toast-expand {

--- a/libs/blocks/locui/status/view.js
+++ b/libs/blocks/locui/status/view.js
@@ -5,18 +5,25 @@ function toggleDesc(e) {
   e.target.closest('.locui-status-toast').classList.toggle('open');
 }
 
+function renderMessage(description) {
+  let message = description;
+  if (Array.isArray(description) && description.length > 1) {
+    message = html`<ol>${description.map((desc) => html`<li>${desc}</li>`)}</ol>`;
+  }
+  return message;
+}
+
 function Toast({ status }) {
   return html`
-    <div onClick=${toggleDesc}
-      class="locui-status-toast locui-status-toast-type-${status.type}
+    <div class="locui-status-toast locui-status-toast-type-${status.type}
       ${status.description && 'has-description'}">
-      <div class=locui-status-toast-content>
+      <div class=locui-status-toast-content onClick=${toggleDesc}>
         <span class=locui-status-toast-content-type>${status.type}</span>
         <span class=locui-status-toast-text>${status.text}</span>
+        <div class=locui-status-toast-expand>Expand</div>
       </div>
       ${status.description && html`
-        <p class=locui-status-toast-description>${status.description}</p>
-        <div class=locui-status-toast-expand>Expand</div>`}
+        <p class=locui-status-toast-description>${renderMessage(status.description)}</p>`}
     </div>
   `;
 }


### PR DESCRIPTION
Errors displayed in the status popup aren't formatted to be easily readable. This updates the status component to look for a list of errors to render in a list and style properly. I also fixed the problem of clicking in the status description area toggling the expanding of the popup.

![before after](https://github.com/adobecom/milo/assets/10670990/3db15226-aeb9-4cf9-919f-ac9c6b8efb43)

Resolves: [MWPW-148094](https://jira.corp.adobe.com/browse/MWPW-148094)
