### PR TITLE
MWPW-146681 - [LocUI] Language card polling check

### DIFF
--- a/libs/blocks/locui/langs/index.js
+++ b/libs/blocks/locui/langs/index.js
@@ -17,12 +17,10 @@ export function showUrls(item, prefix) {
 }
 
 export async function rollout(item, idx) {
-  console.log('start rollout');
   const reroll = item.status === 'completed';
   const retry = item.status === 'error';
 
   // stop polling until request is done
-  console.log('pause polling');
   polling.value = false;
 
   // Update the UI immediate instead of waiting on polling
@@ -34,7 +32,6 @@ export async function rollout(item, idx) {
   else await rolloutLang(item.code, reroll);
 
   // start status polling again when request finishes
-  console.log('restart polling');
   polling.value = true;
 }
 

--- a/libs/blocks/locui/langs/index.js
+++ b/libs/blocks/locui/langs/index.js
@@ -17,10 +17,12 @@ export function showUrls(item, prefix) {
 }
 
 export async function rollout(item, idx) {
+  console.log('start rollout');
   const reroll = item.status === 'completed';
   const retry = item.status === 'error';
 
   // stop polling until request is done
+  console.log('pause polling');
   polling.value = false;
 
   // Update the UI immediate instead of waiting on polling
@@ -32,6 +34,7 @@ export async function rollout(item, idx) {
   else await rolloutLang(item.code, reroll);
 
   // start status polling again when request finishes
+  console.log('restart polling');
   polling.value = true;
 }
 

--- a/libs/blocks/locui/utils/miloc.js
+++ b/libs/blocks/locui/utils/miloc.js
@@ -86,7 +86,8 @@ export async function getProjectStatus() {
       allowSendForLoc.value = false;
     }
 
-    handleProjectStatusDetail(json);
+    // addition check for polling state before updating lang cards
+    if (polling.value) handleProjectStatusDetail(json);
     return json;
   } catch (e) {
     return null;


### PR DESCRIPTION
With certain timing when hitting the rollout button on language cards, the polling Interval fires just before polling state is set to false and the subsequent status function completes a re-rendering of the language card before the rollout request is completed. This adds a polling state check before updating language cards to avoid this turn of events.

Resolves: [MWPW-146681](https://jira.corp.adobe.com/browse/MWPW-146681)
