### PR TITLE
added quiz-entry to utils.js

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -64,6 +64,7 @@ const MILO_BLOCKS = [
   'preflight',
   'promo',
   'quiz',
+  'quiz-entry',
   'quiz-marquee',
   'quiz-results',
   'tabs',


### PR DESCRIPTION
Block name needs to be added to `utils` or it cannot be used on a consumer repo. 
This is the recommended fix to merge into your branch.

**Test URLs:**

**before**: https://main--cc--adobecom.hlx.page/cc-shared/fragments/tests/2024/q2/ace0862/quiz?milolibs=quiz-entry-block

**after**: https://main--cc--adobecom.hlx.page/cc-shared/fragments/tests/2024/q2/ace0862/quiz?milolibs=quiz-entry-block-fix
