### PR TITLE
MWPW-148084 - [LocUI] No languages messaging

### DIFF
--- a/libs/blocks/locui/actions/view.js
+++ b/libs/blocks/locui/actions/view.js
@@ -40,7 +40,7 @@ export default function Actions() {
     `;
   }
 
-  if (!languages.value || languages.value.length === 0) {
+  if (!languages?.value?.length) {
     return html`
       <div class=locui-section>
         <div class=locui-section-heading>

--- a/libs/blocks/locui/actions/view.js
+++ b/libs/blocks/locui/actions/view.js
@@ -7,6 +7,7 @@ import {
   allowRollout,
   allowCancelProject,
   projectCancelled,
+  heading,
 } from '../utils/state.js';
 import {
   sendForLoc,
@@ -33,6 +34,20 @@ export default function Actions() {
             <div>
               <h2 class="locui-section-label cancelled">Project Cancelled</h2>
               <i>Note: All processes have been stopped but documents were not deleted from SharePoint.</i>
+            </div>
+        </div>
+      </div>
+    `;
+  }
+
+  if (!languages.value || languages.value.length === 0) {
+    return html`
+      <div class=locui-section>
+        <div class=locui-section-heading>
+            <div>
+              <h2 class="locui-section-label">No Languages Configured</h2>
+              <i>To start a localization project languages need to be configured. Please select language preferences in the ${heading.value.editUrl ? html`
+                  <a href="${heading.value.editUrl}" target="_blank">excel file</a>` : 'excel file'} to proceed.</i>
             </div>
         </div>
       </div>


### PR DESCRIPTION
As a localization user, I want to be able to see that there are no languages configured so that actions aren't available and loc UI lets me know about it.

<img width="1047" alt="Screenshot 2024-05-13 at 10 21 55 AM" src="https://github.com/adobecom/milo/assets/10670990/78f1383b-4cef-4f58-bbcd-c00bccd0c8f9">

Resolves: [MWPW-148084](https://jira.corp.adobe.com/browse/MWPW-148084)

**Test URL:**
https://sean-loc--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B9d18baeb-24a4-4524-8c44-4c074b265c6b%257D%26action%3Deditnew
