### PR TITLE
[Project PEP] Update Firefly xLG Segment Mapping

### DIFF
--- a/libs/features/personalization/entitlements.js
+++ b/libs/features/personalization/entitlements.js
@@ -19,8 +19,10 @@ const ENTITLEMENT_MAP = {
   'eda8c774-420b-44c2-9006-f9a8d0fb5168': '3d-substance-texturing',
   // PEP segments
   '6cb0d58c-3a65-47e2-b459-c52bb158d5b6': 'lightroom-web-usage',
-  'caa3de84-6336-4fa8-8db2-240fc88106cc': 'photoshop-web-usage',
-  '5c6a4bb8-a2f3-4202-8cca-f5e918b969dc': 'firefly-web-usage',
+  'caa3de84-6336-4fa8-8db2-240fc88106cc': 'photoshop-signup-source',
+  'ef82408e-1bab-4518-b655-a88981515d6b': 'photoshop-web-usage',
+  '5c6a4bb8-a2f3-4202-8cca-f5e918b969dc': 'firefly-signup-source',
+  '20106303-e88c-4b15-93e5-f6a1c3215a12': 'firefly-web-usage',
   '3df0b0b0-d06e-4fcc-986e-cc97f54d04d8': 'acrobat-web-usage',
 };
 

--- a/libs/features/personalization/stage-entitlements.js
+++ b/libs/features/personalization/stage-entitlements.js
@@ -11,8 +11,10 @@ const STAGE_ENTITLEMENTS = {
   '4ec7b469-42c9-4367-a7da-39f11a32d880': '3d-substance-texturing',
   // PEP segments
   '9202b767-77dc-4e6e-8d74-488d9ef08900': 'lightroom-web-usage',
-  '3a7ffcce-11b8-4242-8cdf-8c8d059ae1cd': 'photoshop-web-usage',
-  'cbe1d7ab-db7d-49cb-969e-a6a2bbe8c660': 'firefly-web-usage',
+  '3a7ffcce-11b8-4242-8cdf-8c8d059ae1cd': 'photoshop-signup-source',
+  '81541746-1564-46d5-8787-02c3cd4bf548': 'photoshop-web-usage',
+  'cbe1d7ab-db7d-49cb-969e-a6a2bbe8c660': 'firefly-signup-source',
+  '49033b54-1c02-4640-840d-3c5fd6174992': 'firefly-web-usage',
   '96adf81f-97ca-4943-81ff-c41fbe8f3af7': 'acrobat-web-usage',
 };
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Updated the prod and stage entitlements for project PEP:
  - The PEP entitlement option named "photoshop-web-usage" is mapped to the fllowing segment IDs
    - stage: 81541746-1564-46d5-8787-02c3cd4bf548
    - prod: ef82408e-1bab-4518-b655-a88981515d6b
  - The segments that were previously mapped to "photoshop-web-usage" are mapped to a new option named "photoshop-signup-source" Thus the segment "photoshop-signup-source" is mapped to the following IDs.
    - stage: 3a7ffcce-11b8-4242-8cdf-8c8d059ae1cd   
    - prod: caa3de84-6336-4fa8-8db2-240fc88106cc
* Update PEP xlG mapping such that
  - The PEP entitlement option "firefly-web-usage" is mapped to the fllowing segment IDs
    - stage: 49033b54-1c02-4640-840d-3c5fd6174992
    - prod: 20106303-e88c-4b15-93e5-f6a1c3215a12
  - the segments that were previously mapped to "firefly-web-usage" are mapped to a new option named "firefly-signup-source"
    - stage: cbe1d7ab-db7d-49cb-969e-a6a2bbe8c660    
    - prod: 5c6a4bb8-a2f3-4202-8cca-f5e918b969dc

Resolves: [MWPW-147625](https://jira.corp.adobe.com/browse/MWPW-147625)
Resolves: [MWPW-147775](https://jira.corp.adobe.com/browse/MWPW-147775)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://main--milo--adobecom.hlx.page/?martech=off&milolibs=ent--milo--sharmrj
