### PR TITLE
MWPW-148054: Match Banner content with production

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -386,7 +386,7 @@
   }
 
   .marquee.quiet .foreground .text {
-    max-width: 600px;
+    max-width: 66.6667%;
   }
 
   .marquee.center .foreground .text,


### PR DESCRIPTION
The div's width with class `.text` inside the marquee was set to 600px, while on production the width is set to 66.667%.
 In this PR we change the width to match the XD.

Resolves: [MWPW-148054](https://jira.corp.adobe.com/browse/MWPW-148054)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/products/catalog
- After: https://mwpw-148054-marquee-text-width--milo--mirafedas.hlx.page/drafts/mirafedas/catalog?martech=off
