### PR TITLE
MWPW-148257 - [LocUI] Retry Language status badge style

### DIFF
--- a/libs/blocks/locui/locui.css
+++ b/libs/blocks/locui/locui.css
@@ -293,7 +293,8 @@ li.locui-subproject.locui-subproject-translated .locui-subproject-badge {
 }
 
 li.locui-subproject.locui-subproject-rolling-out .locui-subproject-badge,
-li.locui-subproject.locui-subproject-completed .locui-subproject-badge {
+li.locui-subproject.locui-subproject-completed .locui-subproject-badge,
+li.locui-subproject.locui-subproject-retrying .locui-subproject-badge {
   background: rgb(246 97 182);
 }
 


### PR DESCRIPTION
The status label when Retry is triggered changes to black. Adding the correct styling so the badge background color matches the current working status.

![before-after-retry](https://github.com/adobecom/milo/assets/10670990/0e8a706f-1b86-41ba-87ae-d9fe26bb8af0)

Resolves: [MWPW-148257](https://jira.corp.adobe.com/browse/MWPW-148257)

