### PR TITLE
MWPW-148418 - Share default placeholder text not displaying in some cases

### DIFF
--- a/libs/blocks/share/share.js
+++ b/libs/blocks/share/share.js
@@ -56,7 +56,7 @@ export default async function decorate(block) {
   const platforms = getPlatforms(block);
   const rows = block.querySelectorAll(':scope > div');
   const childDiv = rows[0]?.querySelector(':scope > div');
-  const emptyRow = rows.lengh && childDiv?.innerText.trim() === '';
+  const emptyRow = rows.length && childDiv?.innerText.trim() === '';
   const toSentenceCase = (str) => {
     if (!str || typeof str !== 'string') return '';
     /* eslint-disable-next-line no-useless-escape */


### PR DESCRIPTION
Found a BUG w/ the Share block default placeholder

This [PR](https://github.com/adobecom/milo/pull/2240) was release last week and I was going thru it to demo this in the author meet up.... 
Then I noticed the default placeholder wasn't always showing. Derp 👎 

(I found a typo in `share.js` that was not accurately checking for a length)

*This only impacts share block instances when an empty content row is authored in the block table. 
(known live examples use only a single title block table row) - 2nd example

Doesn't work ❌ (no default placeholder)
<img width="656" alt="Screen Shot 2024-05-15 at 6 04 57 PM" src="https://github.com/adobecom/milo/assets/2086146/8235faf2-4772-4450-9f5b-07da9033ebbe">

works ✅ 
<img width="646" alt="Screen Shot 2024-05-15 at 6 05 03 PM" src="https://github.com/adobecom/milo/assets/2086146/bab6166c-0e7d-4b01-9e5e-f013751665b8">

works ✅ 
<img width="645" alt="Screen Shot 2024-05-15 at 6 05 11 PM" src="https://github.com/adobecom/milo/assets/2086146/f7991839-f1be-459f-98e4-4e98c36ce00b">



---
Previous related PR https://github.com/adobecom/milo/pull/2240

Resolves: [MWPW-148418](https://jira.corp.adobe.com/browse/MWPW-148418)

LIVE CC page: https://main--cc--adobecom.hlx.page/creativecloud/animation/discover/principles-of-animation?milolibs=rparrish-share-default-fix (no impact*)

Draft Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/share?martech=off
Draft After: https://rparrish-share-default-fix--milo--adobecom.hlx.page/drafts/rparrish/share?martech=off
[Authoring Docs](https://main--milo--adobecom.hlx.page/docs/authoring/blocks/share)

Before: https://main--milo--adobecom.hlx.page/docs/authoring/examples/share-block?martech=off
After: https://rparrish-share-default-fix--milo--adobecom.hlx.page/docs/authoring/examples/share-block?martech=off
