### PR TITLE
MWPW-147472: auto adjust commerce iframe

### DIFF
--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -59,7 +59,6 @@ a[is='checkout-link'] > span {
 }
 
 #checkout-link-modal iframe {
-  height: 100%;
   flex: 1;
 }
 

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -152,8 +152,8 @@ export async function fetchLiterals(url) {
 
 export async function fetchCheckoutLinkConfigs(base = '') {
   fetchCheckoutLinkConfigs.promise = fetchCheckoutLinkConfigs.promise
-    ?? fetch(`${base}${CHECKOUT_LINK_CONFIG_PATH}`).catch(() => {
-      log?.error('Failed to fetch checkout link configs');
+    ?? fetch(`${base}${CHECKOUT_LINK_CONFIG_PATH}`).catch((e) => {
+      log?.error('Failed to fetch checkout link configs', e);
     }).then((mappings) => {
       if (!mappings?.ok) return undefined;
       return mappings.json();

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -288,6 +288,7 @@ export async function openModal(e, url, offerType) {
   e.preventDefault();
   e.stopImmediatePropagation();
   const { getModal } = await import('../modal/modal.js');
+  await import('../modal/modal.merch.js');
   const offerTypeClass = offerType === OFFER_TYPE_TRIAL ? 'twp' : 'crm';
   let modal;
   if (/\/fragments\//.test(url)) {

--- a/libs/blocks/modal/modal.merch.js
+++ b/libs/blocks/modal/modal.merch.js
@@ -3,6 +3,13 @@ import { debounce } from '../../utils/action.js';
 export const MOBILE_MAX = 599;
 export const TABLET_MAX = 1199;
 
+window.addEventListener('pageshow', (event) => {
+  // if there is a commerce modal with an iframe open, reload the page to avoid bfcache issues.
+  if (event.persisted && document.querySelector('.dialog-modal.commerce-frame iframe')) {
+    window.location.reload();
+  }
+});
+
 export function adjustModalHeight(contentHeight) {
   if (!(window.location.hash || document.getElementById('checkout-link-modal'))) return;
   const dialog = document.querySelector(`div.dialog-modal.commerce-frame${window.location.hash}, #checkout-link-modal`);

--- a/libs/blocks/modal/modal.merch.js
+++ b/libs/blocks/modal/modal.merch.js
@@ -4,8 +4,8 @@ export const MOBILE_MAX = 599;
 export const TABLET_MAX = 1199;
 
 export function adjustModalHeight(contentHeight) {
-  if (!window.location.hash) return;
-  const dialog = document.querySelector(`div.dialog-modal.commerce-frame${window.location.hash}`);
+  if (!(window.location.hash || document.getElementById('checkout-link-modal'))) return;
+  const dialog = document.querySelector(`div.dialog-modal.commerce-frame${window.location.hash}, #checkout-link-modal`);
   const iframe = dialog?.querySelector('iframe');
   const iframeWrapper = dialog?.querySelector('.milo-iframe');
   if (!contentHeight || !iframe || !iframeWrapper) return;

--- a/libs/blocks/modal/modal.merch.js
+++ b/libs/blocks/modal/modal.merch.js
@@ -68,6 +68,13 @@ export function adjustStyles({ dialog, iframe }) {
   const isAutoHeightAdjustment = /\/mini-plans\/.*mid=ft.*web=1/.test(iframe.src); // matches e.g. https://www.adobe.com/mini-plans/photoshop.html?mid=ft&web=1
   if (isAutoHeightAdjustment) {
     dialog.classList.add('height-fit-content');
+    // fail safe.
+    setTimeout(() => {
+      const { height } = window.getComputedStyle(iframe);
+      if (height === '0px') {
+        iframe.style.height = '100%';
+      }
+    }, 2000);
   } else {
     iframe.style.height = '100%';
   }

--- a/libs/blocks/modal/modal.merch.js
+++ b/libs/blocks/modal/modal.merch.js
@@ -12,7 +12,9 @@ window.addEventListener('pageshow', (event) => {
 
 export function adjustModalHeight(contentHeight) {
   if (!(window.location.hash || document.getElementById('checkout-link-modal'))) return;
-  const dialog = document.querySelector(`div.dialog-modal.commerce-frame${window.location.hash}, #checkout-link-modal`);
+  let selector = '#checkout-link-modal';
+  if (!/=/.test(window.location.hash)) selector = `${selector},div.dialog-modal.commerce-frame${window.location.hash}`;
+  const dialog = document.querySelector(selector);
   const iframe = dialog?.querySelector('iframe');
   const iframeWrapper = dialog?.querySelector('.milo-iframe');
   if (!contentHeight || !iframe || !iframeWrapper) return;

--- a/test/blocks/modals/mocks/iframe.plain.html
+++ b/test/blocks/modals/mocks/iframe.plain.html
@@ -1,3 +1,5 @@
+<main></main>
+<template id="modal1">
 <div class="dialog-modal commerce-frame" id="first-dialog">
   <div class="fragment">
     <div class="section">
@@ -7,7 +9,9 @@
     </div>
   </div>
 </div>
+</template>
 
+<template id="modal2">
 <div class="dialog-modal commerce-frame" id="second-dialog">
   <div class="fragment">
     <div class="section">
@@ -17,3 +21,17 @@
     </div>
   </div>
 </div>
+</template>
+
+
+<template id="modal3">
+<div class="dialog-modal commerce-frame" id="checkout-link-modal">
+  <div class="fragment">
+    <div class="section">
+      <div class="milo-iframe modal">
+        <iframe src="https://www.adobe.com/mini-plans/illustrator.html?mid=ft&amp;web=1&amp;pint=Illustrator" allowfullscreen="true"></iframe>
+      </div>
+    </div>
+  </div>
+</div>
+</template>

--- a/test/blocks/modals/modal.merch.test.js
+++ b/test/blocks/modals/modal.merch.test.js
@@ -140,6 +140,7 @@ describe('Modal dialog with a `commerce-frame` class', () => {
   });
 
   it('initialises managed modals via merch block', async () => {
+    window.location.hash = '#page=2';
     const { dialog } = addModal('modal3');
     adjustModalHeight(600);
     expect(dialog.style.height).to.equal('580px');

--- a/test/blocks/modals/modal.merch.test.js
+++ b/test/blocks/modals/modal.merch.test.js
@@ -139,7 +139,7 @@ describe('Modal dialog with a `commerce-frame` class', () => {
     window.location.hash = '';
   });
 
-  it('initialies managed modals via merch block', async () => {
+  it('initialises managed modals via merch block', async () => {
     const { dialog } = addModal('modal3');
     adjustModalHeight(600);
     expect(dialog.style.height).to.equal('580px');

--- a/test/blocks/modals/modal.merch.test.js
+++ b/test/blocks/modals/modal.merch.test.js
@@ -1,19 +1,38 @@
 import { readFile, setViewport } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import enableCommerceFrameFeatures, { MOBILE_MAX, TABLET_MAX } from '../../../libs/blocks/modal/modal.merch.js';
+import enableCommerceFrameFeatures, { MOBILE_MAX, TABLET_MAX, adjustModalHeight } from '../../../libs/blocks/modal/modal.merch.js';
 import { delay } from '../../helpers/waitfor.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/iframe.plain.html' });
-const dialog = document.querySelector('#first-dialog');
-const iframeWrapper = dialog.querySelector('.milo-iframe');
-const iframe = dialog.querySelector('iframe');
-const secondDialog = document.querySelector('#second-dialog');
-const secondIframeWrapper = secondDialog.querySelector('.milo-iframe');
-const secondIframe = secondDialog.querySelector('iframe');
+
+const main = document.querySelector('main');
+
+const addModal = (selector) => {
+  main.append(document.getElementById(selector).content.cloneNode(true));
+  const dialog = document.querySelector('.dialog-modal');
+  const iframeWrapper = dialog.querySelector('.milo-iframe');
+  const iframe = dialog.querySelector('iframe');
+  const secondDialog = document.querySelector('.dialog-modal:nth-child(2)');
+  const secondIframeWrapper = secondDialog?.querySelector('.milo-iframe');
+  const secondIframe = secondDialog?.querySelector('iframe');
+  return {
+    dialog,
+    iframe,
+    iframeWrapper,
+    secondDialog,
+    secondIframe,
+    secondIframeWrapper,
+  };
+};
 
 describe('Modal dialog with a `commerce-frame` class', () => {
+  beforeEach(() => {
+    main.innerHTML = '';
+  });
+
   it('adjustStyles: sets the iframe height to 100% if height adjustment is not applicable', () => {
+    const { dialog, iframe } = addModal('modal1');
     const originalSrc = iframe.getAttribute('src');
     iframe.setAttribute('src', 'https://www.adobe.com/somepage.html');
     enableCommerceFrameFeatures({ dialog, iframe });
@@ -24,12 +43,15 @@ describe('Modal dialog with a `commerce-frame` class', () => {
   });
 
   it('adjustStyles: sets the `height-fit-content` class if height adjustment is applicable', () => {
+    const { dialog, iframe } = addModal('modal1');
     enableCommerceFrameFeatures({ dialog, iframe });
     expect(dialog.classList.contains('height-fit-content')).to.be.true;
     expect(iframe.style.height).to.equal('');
   });
 
   it('sends viewport dimensions upon request, and then on every resize', async () => {
+    await setViewport({ width: 800, height: 600 });
+    const { dialog, iframe } = addModal('modal1');
     sinon.spy(window, 'postMessage');
     enableCommerceFrameFeatures({ dialog, iframe });
     window.postMessage('viewportWidth');
@@ -52,6 +74,7 @@ describe('Modal dialog with a `commerce-frame` class', () => {
   });
 
   it('adjusts modal height if height auto adjustment is applicable', async () => {
+    const { dialog, iframe, iframeWrapper } = addModal('modal1');
     const contentHeight = {
       desktop: 714,
       mobile: '100%',
@@ -74,6 +97,10 @@ describe('Modal dialog with a `commerce-frame` class', () => {
   });
 
   it('properly adjusts the modal height when there are two modals on the page', async () => {
+    addModal('modal1');
+    const {
+      dialog, iframe, iframeWrapper, secondDialog, secondIframe, secondIframeWrapper,
+    } = addModal('modal2');
     const contentHeight = {
       desktop1: 714,
       desktop2: 600,
@@ -110,5 +137,11 @@ describe('Modal dialog with a `commerce-frame` class', () => {
     expect(iframeWrapper.style.height).to.equal('');
     expect(dialog.style.height).to.equal('');
     window.location.hash = '';
+  });
+
+  it('initialies managed modals via merch block', async () => {
+    const { dialog } = addModal('modal3');
+    adjustModalHeight(600);
+    expect(dialog.style.height).to.equal('580px');
   });
 });


### PR DESCRIPTION
of the managed checkout-link modals.

Resolves: [MWPW-147472](https://jira.corp.adobe.com/browse/MWPW-147472)

To test, click on the TWP and D2P modal CTAs at the after URL:
![image](https://github.com/adobecom/milo/assets/330057/043215f0-4be8-4312-8ccf-7c1992da43fb)


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ilyas/checkout-links?martech=off&georouting=off
- After: https://mwpw-147472-2--milo--yesil.hlx.page/drafts/ilyas/checkout-links?martech=off&georouting=off


CC Milo Catalog test page: https://main--cc--adobecom.hlx.page/products/catalog?milolibs=mwpw-147472-2--milo--yesil
In order to test the page at the after URL, use the following Modheader config:

![image](https://github.com/adobecom/milo/assets/330057/8b6d100d-5db6-4239-8181-6e408182396b)


You can import the following JSON as profile as well:

```javascript
[
  {
    "alwaysOn": false,
    "cspHeaders": [
      {
        "appendMode": false,
        "enabled": true,
        "name": "frame-ancestors",
        "value": "'self' https://*.adobe.com https://*.hlx.page https://*.hlx.live http://localhost:3000"
      }
    ],
    "respHeaders": [
      {
        "appendMode": false,
        "enabled": true,
        "name": "Access-Control-Allow-Origin",
        "value": "*"
      },
      {
        "appendMode": false,
        "enabled": true,
        "name": "Access-Control-Allow-Headers",
        "value": "x-api-key, Authorization"
      }
    ],
    "shortTitle": "1",
    "title": "WCS",
    "urlFilters": [
      {
        "enabled": true,
        "urlRegex": "https://wcs.adobe.com/*"
      },
      {
        "enabled": true,
        "urlRegex": "https://www.stage.adobe.com/aos-api/users/*"
      },
      {
        "enabled": true,
        "methods": [
          "GET"
        ],
        "urlRegex": "https://www.adobe.com/"
      }
    ],
    "version": 2
  }
]
``` 
