### PR TITLE
MWPW-148298 - [LocUI] Validation status toast

### DIFF
--- a/libs/blocks/locui/status/view.js
+++ b/libs/blocks/locui/status/view.js
@@ -20,7 +20,7 @@ function Toast({ status }) {
       <div class=locui-status-toast-content onClick=${toggleDesc}>
         <span class=locui-status-toast-content-type>${status.type}</span>
         <span class=locui-status-toast-text>${status.text}</span>
-        <div class=locui-status-toast-expand>Expand</div>
+        ${status.description && html`<div class=locui-status-toast-expand>Expand</div>`}
       </div>
       ${status.description && html`
         <p class=locui-status-toast-description>${renderMessage(status.description)}</p>`}

--- a/libs/blocks/locui/utils/miloc.js
+++ b/libs/blocks/locui/utils/miloc.js
@@ -46,6 +46,7 @@ export async function getProjectStatus() {
     const json = await resp.json();
 
     if (json.errors) {
+      setStatus('service');
       setStatus('service-error', 'error', `${json['error-phase']}`, json.errors);
     } else {
       setStatus('service-error');
@@ -58,7 +59,8 @@ export async function getProjectStatus() {
     if (json.projectStatus === 'sync'
     || json.projectStatus === 'created'
     || json.projectStatus === 'download'
-    || json.projectStatus === 'start-glaas') {
+    || json.projectStatus === 'start-glaas'
+    || json.projectStatus === 'validation') {
       allowSyncToLangstore.value = false;
       allowSendForLoc.value = false;
       allowCancelProject.value = false;


### PR DESCRIPTION
- Let the user know when the project is in the validation status
- Hide the expand arrow when there is no description
- Hide the service status when an error status is displayed

<img width="530" alt="Screenshot 2024-05-16 at 12 54 16 PM" src="https://github.com/adobecom/milo/assets/10670990/3dbed869-5b0a-4892-8c22-4fd281751d92">

Resolves: [MWPW-148298](https://jira.corp.adobe.com/browse/MWPW-148298)
