### PR TITLE
MWPW-148640: Add Jarvis africa to ZA mapping

### DIFF
--- a/libs/features/jarvis-chat.js
+++ b/libs/features/jarvis-chat.js
@@ -215,6 +215,7 @@ const startInitialization = async (config, event, onDemand) => {
     [language, region] = config.locale.ietf.split('-');
   } else {
     [region, language] = config.locale.prefix.replace('/', '').split('_');
+    if (region === 'africa') region = 'ZA';
   }
 
   window.AdobeMessagingExperienceClient.initialize({

--- a/test/features/jarvis-chat/jarvis-chat.test.js
+++ b/test/features/jarvis-chat/jarvis-chat.test.js
@@ -57,6 +57,24 @@ describe('Jarvis Chat', () => {
     const config = Object.assign(getConfig(), {
       locale: {
         ietf: 'en',
+        prefix: '/mena',
+      },
+    });
+    await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());
+    const args = initializeSpy.getCall(0).args[0];
+    expect(args.appid).to.equal(config.jarvis.id);
+    expect(args.appver).to.equal(config.jarvis.version);
+    expect(args.env).to.equal(config.env.name === 'prod' ? 'prod' : 'stage');
+    expect(args.accessToken).to.be.undefined;
+    expect(args.language).to.equal('en');
+    expect(args.region).to.equal('mena');
+  });
+
+  it('should receive the correct africa configuration', async () => {
+    setConfig(defaultConfig);
+    const config = Object.assign(getConfig(), {
+      locale: {
+        ietf: 'en',
         prefix: '/africa',
       },
     });
@@ -67,7 +85,7 @@ describe('Jarvis Chat', () => {
     expect(args.env).to.equal(config.env.name === 'prod' ? 'prod' : 'stage');
     expect(args.accessToken).to.be.undefined;
     expect(args.language).to.equal('en');
-    expect(args.region).to.equal('africa');
+    expect(args.region).to.equal('ZA');
   });
 
   it('should receive the correct custom surface id configuration', async () => {

--- a/test/features/jarvis-chat/jarvis-chat.test.js
+++ b/test/features/jarvis-chat/jarvis-chat.test.js
@@ -57,7 +57,7 @@ describe('Jarvis Chat', () => {
     const config = Object.assign(getConfig(), {
       locale: {
         ietf: 'en',
-        prefix: '/mena',
+        prefix: '/mena_en',
       },
     });
     await initJarvisChat(config, sinon.stub(), sinon.stub(), sinon.stub());


### PR DESCRIPTION
This adds a condition to map africa region to ZA (similar to aem) because `en_AFRICA` is not a valid locale as per Jarvis and Jarvis fails to load because of this.

Resolves: [MWPW-148640](https://jira.corp.adobe.com/browse/MWPW-148640)

**Test URLs:**

Milo
- Before: https://mwpw-148640--milo--nishantka.hlx.page/africa/drafts/nishantkaush/document
- After: https://main--milo--adobecom.hlx.page/africa/drafts/nishantkaush/document?milolibs=mwpw-148640--milo--nishantka

CC:

- Before: https://main--cc--adobecom.hlx.page/africa/creativecloud
- After: https://main--cc--adobecom.hlx.page/africa/creativecloud?milolibs=mwpw-148640--milo--nishantka

