### PR TITLE
MWPW-148439 - FIX - Text wraps under icon & No space between Icon and text in RTL Locale.

### DIFF
--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -177,6 +177,11 @@
   margin-top: var(--spacing-s);
 }
 
+.icon-block .foreground .second-column .title-row {
+  display: flex;
+  align-items: center;
+}
+
 .icon-block.full-width.small .foreground .icon-area,
 .icon-block.vertical.small .foreground .icon-area {
   margin-bottom: var(--spacing-s);

--- a/libs/blocks/icon-block/icon-block.js
+++ b/libs/blocks/icon-block/icon-block.js
@@ -70,7 +70,15 @@ function decorateContent(el) {
       const textContent = el.querySelectorAll('.text-content > :not(.icon-area)');
       const secondColumn = createTag('div', { class: 'second-column' });
       textContent.forEach((content) => {
-        secondColumn.append(content);
+        let nodeToInsert = content;
+        const firstIcon = content.querySelector('.icon:first-child');
+        if (firstIcon) {
+          const titleRowSpan = createTag('span', { class: 'title-row' });
+          titleRowSpan.append(firstIcon, content);
+          nodeToInsert = titleRowSpan;
+        }
+
+        secondColumn.append(nodeToInsert);
       });
       if (secondColumn.children.length === 1) el.classList.add('items-center');
       el.querySelector('.foreground .text-content').append(secondColumn);

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -63,12 +63,12 @@ export default async function loadIcons(icons, config) {
     const parent = icon.parentElement;
     if (parent.childNodes.length > 1) {
       if (parent.lastChild === icon) {
-        icon.classList.add('margin-left');
+        icon.classList.add('margin-inline-start');
       } else if (parent.firstChild === icon) {
-        icon.classList.add('margin-right');
+        icon.classList.add('margin-inline-end');
         if (parent.parentElement.tagName === 'LI') parent.parentElement.classList.add('icon-list-item');
       } else {
-        icon.classList.add('margin-left', 'margin-right');
+        icon.classList.add('margin-inline-start', 'margin-inline-end');
       }
     }
     icon.insertAdjacentHTML('afterbegin', iconSVGs[iconName].outerHTML);

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -553,7 +553,17 @@ span.icon.margin-right { margin-right: 8px; }
 
 span.icon.margin-left { margin-left: 8px; }
 
-span.icon.margin-inline-end { margin-inline-end: 8px; }
+span.icon.margin-inline-end { 
+  -moz-margin-end: 8px;
+    -webkit-margin-end:8px;
+      margin-inline-end:8px;
+}
+
+span.icon.margin-inline-start { 
+  -webkit-margin-start:8px;
+    -moz-margin-start: 8px;
+      margin-inline-start:8px;
+}
 
 .button-l .con-button span.icon.margin-left,
 .con-button.button-l span.icon.margin-left { margin-left: 12px; }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Changed the icons margin to `inline-start|end` rather than `left|right`. When the RTL locale is enabled, it will resolve the space issue for all milo pages.
* Fixed text wrapping under the icon.

Resolves: [MWPW-148439](https://jira.corp.adobe.com/browse/MWPW-148439)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/bg/products/illustrator/free-trial-download?martech=off
- After: https://main--cc--adobecom.hlx.page/bg/products/illustrator/free-trial-download?milolibs=mwpw-148439--milo--sivasadobe&martech=off

**Milo Icon-Block**
- Before: https://main--cc--adobecom.hlx.page/bg/products/illustrator/free-trial-download?martech=off
- After: https://main--cc--adobecom.hlx.page/bg/products/illustrator/free-trial-download?milolibs=mwpw-148439--milo--sivasadobe&martech=off

### Browser Capabilities (margin-inline-<start|end>)
- https://caniuse.com/?search=margin-inline-end

**Mobile**
- Chrome (Android & iOS): All versions
- Safari: ≥ 3.2
- Firefox (Android & iOS): All versions

**Desktop**
- Chrome: ≥ 4.0
- Safari: ≥ 3.1
- Firefox: ≥ 3.0
- MS Edge: ≥ 88
