### PR TITLE
High Impact Alert Workflow

### DIFF
--- a/.github/workflows/high-impact-alert.js
+++ b/.github/workflows/high-impact-alert.js
@@ -1,0 +1,28 @@
+const {
+  slackNotification,
+  getLocalConfigs,
+} = require('./helpers.js');
+
+const main = async (params) => {
+  const { context } = params;
+
+  try {
+    if (context.payload.label.name === 'high-impact') {
+      const { html_url, number, title } = context.payload.pull_request;
+      console.log('High impact label detected, sending Slack notification');
+      slackNotification(`:alert: High Impact PR has been opened: <${html_url}|#${number}: ${title}>.` +
+         ` Please prioritize testing the proposed changes.`, process.env.SLACK_HIGH_IMPACT_PR_WEBHOOK);
+    } else {
+      console.log('No high impact label detected');
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+if (process.env.LOCAL_RUN) {
+  const { context } = getLocalConfigs();
+  main({ context });
+}
+
+module.exports = main;

--- a/.github/workflows/high-impact-alert.js
+++ b/.github/workflows/high-impact-alert.js
@@ -7,14 +7,15 @@ const main = async (params) => {
   const { context } = params;
 
   try {
-    if (context.payload.label.name === 'high-impact') {
-      const { html_url, number, title } = context.payload.pull_request;
-      console.log('High impact label detected, sending Slack notification');
-      slackNotification(`:alert: High Impact PR has been opened: <${html_url}|#${number}: ${title}>.` +
-         ` Please prioritize testing the proposed changes.`, process.env.SLACK_HIGH_IMPACT_PR_WEBHOOK);
-    } else {
+    if (context.payload.label.name !== 'high-impact') {
       console.log('No high impact label detected');
+      return;
     }
+
+    const { html_url, number, title } = context.payload.pull_request;
+    console.log('High impact label detected, sending Slack notification');
+    slackNotification(`:alert: High Impact PR has been opened: <${html_url}|#${number}: ${title}>.` +
+      ` Please prioritize testing the proposed changes.`, process.env.SLACK_HIGH_IMPACT_PR_WEBHOOK);
   } catch (error) {
     console.error(error);
   }

--- a/.github/workflows/high-impact-alert.yml
+++ b/.github/workflows/high-impact-alert.yml
@@ -1,0 +1,24 @@
+name: High Impact Alert
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+env:
+  SLACK_HIGH_IMPACT_PR_WEBHOOK: ${{ secrets.SLACK_HIGH_IMPACT_PR_WEBHOOK }}
+
+jobs:
+  send_alert:
+    if: github.repository_owner == 'adobecom'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.4
+
+      - name: Send Slack message for high impact PRs
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const main = require('./.github/workflows/high-impact-alert.js')
+            main({ github, context })

--- a/.github/workflows/mark-stale-prs.yaml
+++ b/.github/workflows/mark-stale-prs.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository_owner == 'adobecom'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/merge-to-stage.yaml
+++ b/.github/workflows/merge-to-stage.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   merge-to-stage:
+    if: github.repository_owner == 'adobecom'
     runs-on: ubuntu-latest
     environment: milo_pr_merge
 

--- a/.github/workflows/pr-reminders.yaml
+++ b/.github/workflows/pr-reminders.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update:
+    if: github.repository_owner == 'adobecom'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This defines a new workflow that sends notifications to a Slack channel as soon as a PR with a `high-impact` label is opened. The previous logic from the `merge-to-stage.js` script has been removed, since we want such a notification to be sent out as soon as the PR is opened, not when it eventually reaches the `stage` branch, to ensure it gets visibility early on. Additionally, some workflows have been adapted to only run if the owner is `adobecom` to reduce workflow runs on forks.

Resolves: [MWPW-148268](https://jira.corp.adobe.com/browse/MWPW-148268)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://high-impact-workflow--milo--overmyheadandbody.hlx.page/?martech=off
