### PR TITLE
quiz entry block - fix for content disappearing before redirect

### DIFF
--- a/libs/blocks/quiz-entry/quiz-entry.js
+++ b/libs/blocks/quiz-entry/quiz-entry.js
@@ -258,7 +258,6 @@ const App = ({
       if (debug) console.log(currentQuizState);
       if (questionCount.current === maxQuestions || currentQuizState.userFlow.length === 1) {
         if (!debug) {
-          setSelectedQuestion(null);
           locationWrapper.redirect(quizPath);
         }
       } else {

--- a/libs/blocks/quiz-entry/utils.js
+++ b/libs/blocks/quiz-entry/utils.js
@@ -78,10 +78,7 @@ export const handleSelections = (prevSelections, selectedQuestion, selections) =
   // de-dup any existing data if they use the ml field and cards.
   if (prevSelections.length > 0) {
     prevSelections.forEach((selection) => {
-      const jsonSelectionSelectedQustion = JSON.stringify(selection.selectedQuestion);
-      const jsonSelectedQuesion = JSON.stringify(selectedQuestion[0].selectedQuestion);
-      const isSameQuestion = jsonSelectionSelectedQustion === jsonSelectedQuesion;
-      if (isSameQuestion) {
+      if (JSON.stringify(selection.selectedQuestion) === JSON.stringify(selectedQuestion)) {
         selection.selectedCards = selections;
         isNewQuestion = false;
       }


### PR DESCRIPTION
* bug fix for content flicker before redirect
* bug fix for debug mode where you cannot continue more than once

Resolves: [MWPW-149356](https://jira.corp.adobe.com/browse/MWPW-149356)

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/colloyd/quiz-entry/?martech=off
- After: https://quiz-entry-flicker-fix--milo--colloyd.hlx.page/drafts/colloyd/quiz-entry/?martech=off

Testing notes: To test the flicker and the fix, turn bandwidth throttling down in dev tools. Make a selection and press continue. Before, the content would disappear just before the page redirects to the quiz page. After, the content persists until the redirect happens.

To test the debug mode fix, add the debug=quiz-entry query param and make a selection and press continue. Alter your selection and press continue again. Before, it would throw a script error. After the script error is no longer present and your new selection logging works as expected.
