### PR TITLE
fast follow for MWPW-146214 [MILO][MEP] Option to have gnav but not main wait for Target (preserve targetEnabled in config under more circumstances)

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -827,7 +827,6 @@ export async function applyPers(manifests, postLCP = false) {
         mep: mepParam,
         mepHighlight,
         mepButton,
-        target,
       } = Object.fromEntries(PAGE_URL.searchParams);
       config.mep = {
         handleFragmentCommand,
@@ -835,7 +834,7 @@ export async function applyPers(manifests, postLCP = false) {
         override: mepParam ? decodeURIComponent(mepParam) : '',
         highlight: (mepHighlight !== undefined && mepHighlight !== 'false'),
         mepParam,
-        targetEnabled: target,
+        targetEnabled: config.mep?.targetEnabled,
       };
     }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -908,6 +908,7 @@ async function checkForPageMods() {
   if (!mepEnabled) return;
 
   const config = getConfig();
+  config.mep = { targetEnabled };
   loadLink(
     `${config.base}/features/personalization/personalization.js`,
     { as: 'script', rel: 'modulepreload' },
@@ -918,10 +919,8 @@ async function checkForPageMods() {
     await loadMartech({ persEnabled: true, persManifests, targetEnabled });
     return;
   }
-  if (!persManifests.length) {
-    config.mep = { targetEnabled };
-    return;
-  }
+  if (!persManifests.length) return;
+
   loadIms()
     .then(() => {
       if (window.adobeIMS.isSignedInUser()) loadMartech();


### PR DESCRIPTION
Tweak for an issue found in some circumstances when testing on stage.

Resolves: [MWPW-146214](https://jira.corp.adobe.com/browse/MWPW-146214)

Test URLs for psi-check:

Before: https://main--milo--adobecom.hlx.page/?martech=off
After: https://meptargetgnavonly2--milo--adobecom.hlx.page/?martech=off
Note: I ran the URLs below in PageSpeed Insights, but there is statistical noise.

Test URLS:
Target manifest changing gnav to say "Large menu swap". There should be no visual between these links:
Page with Target fully "on". There is no significant LHS difference between these links:
Before (LHS 88): https://main--cc--adobecom.hlx.live/drafts/mepdev/fragments/2024/q2/gnavinternal/index-target-on?gnav=block
After (LHS 90): https://main--cc--adobecom.hlx.live/drafts/mepdev/fragments/2024/q2/gnavinternal/index-target-on?milolibs=meptargetgnavonly2&gnav=block

Same page and manifest but with Target for gnav only. LHS shows large improvement with new code:
Before (LHS 84): https://main--cc--adobecom.hlx.live/drafts/mepdev/fragments/2024/q2/gnavinternal/index-target-gnav?gnav=block
After (LHS 99): https://main--cc--adobecom.hlx.live/drafts/mepdev/fragments/2024/q2/gnavinternal/index-target-gnav?milolibs=meptargetgnavonly2&gnav=block

2 Target manifests. One through Target updates the menu to say "Complete Menu Swap" and inserts a blade saying "I’m a section inserted by the gnav manifest". 2nd manifest through pzn metadata that inserts a blade saying "I’m a section inserted by the pzn manifest"
Page with Target fully "on". Both before and after will execute all 3 actions. There is no significant LHS difference between these links:
Before (LHS 86): https://main--cc--adobecom.hlx.live/drafts/mepdev/fragments/2024/q2/gnavinternal/index-pzn-target-on?gnav=withinsert
After (LHS 78): https://main--cc--adobecom.hlx.live/drafts/mepdev/fragments/2024/q2/gnavinternal/index-pzn-target-on?milolibs=meptargetgnavonly2&gnav=withinsert

Same page and manifest but with Target for gnav only. Before will execute all 3 actions, but after will not execute the new blade action in the gnav manifest. LHS shows large improvement with new code:
Before (LHS 82): https://main--cc--adobecom.hlx.live/drafts/mepdev/fragments/2024/q2/gnavinternal/index-pzn-target-gnav?gnav=withinsert
After (LHS 99): https://main--cc--adobecom.hlx.live/drafts/mepdev/fragments/2024/q2/gnavinternal/index-pzn-target-gnav?milolibs=meptargetgnavonly2&gnav=withinsert