### PR TITLE
Quiz option card accessibility fixes

### DIFF
--- a/libs/blocks/quiz-entry/quizoption.js
+++ b/libs/blocks/quiz-entry/quizoption.js
@@ -18,12 +18,12 @@ export const OptionCard = ({
     <picture>
       ${iconDesktop && html`<source media="(min-width: 1024px)" srcset="${iconDesktop}" />`}
       ${iconTablet && html`<source media="(min-width: 600px)" srcset="${iconTablet}" />`}
-      <img src="${icon}" alt="${`Icon - ${title || text}`}" loading="lazy" />
+      <img src="${icon}" alt="" loading="lazy" />
     </picture>
   </div>`;
 
   const imageHtml = image ? html`<div class="quiz-option-image" style="background-image: url('${image}'); background-size: cover" loading="lazy"></div>` : null;
-  const titleHtml = title ? html`<h2 class="quiz-option-title">${title}</h2>` : null;
+  const titleHtml = title ? html`<p class="quiz-option-title">${title}</p>` : null;
   const textHtml = text ? html`<p class="quiz-option-text">${text}</p>` : null;
 
   return html`<button class="quiz-option ${getOptionClass()}" data-option-name="${options}" 

--- a/libs/blocks/quiz/quizoption.js
+++ b/libs/blocks/quiz/quizoption.js
@@ -24,7 +24,7 @@ export const OptionCard = ({
     <picture>
       ${iconDesktop && html`<source media="(min-width: 1024px)" srcset="${iconDesktop}" />`}
       ${iconTablet && html`<source media="(min-width: 600px)" srcset="${iconTablet}" />`}
-      <img src="${icon}" alt="${`Icon - ${title || text}`}" loading="lazy" />
+      <img src="${icon}" alt="" loading="lazy" />
     </picture>
   </div>`;
 
@@ -34,7 +34,7 @@ export const OptionCard = ({
     </div>`;
 
   const titleHtml = html`
-    <h2 class="quiz-option-title">${title}</h2>
+    <p class="quiz-option-title">${title}</p>
   `;
 
   const textHtml = html`


### PR DESCRIPTION
* remove heading tags in cards, which have the role of checkbox
* set alt to "" for card icons as they are decorative images
* applied both fixes to the quiz and quiz-entry blocks

Resolves: [MWPW-147763](https://jira.corp.adobe.com/browse/MWPW-147763), [MWPW-147761](https://jira.corp.adobe.com/browse/MWPW-147761)

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/colloyd/quiz/?martech=off
- After: https://quiz-option-card-accessibility--milo--colloyd.hlx.page/drafts/colloyd/quiz/?martech=off

Additional Notes: Changes have been made in both quiz and quiz-entry blocks. The h2 > p tag change applies to both blocks and can be observed in both. However, the icon alt text change can only be observed in the quiz block urls above, as the quiz-entry block is currently being tested and the test case does not use icons for the cards. You can check for the changes to h2s in cards for the quiz-entry block at the following: 

- Before: https://stage--milo--adobecom.hlx.page/drafts/colloyd/quiz-entry/?martech=off
- After: https://quiz-option-card-accessibility--milo--colloyd.hlx.page/drafts/colloyd/quiz-entry/?martech=off