### PR TITLE
codeowners adjustment for quiz related blocks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,9 +44,10 @@
 /libs/blocks/mnemonic-list/ @adobecom/tacocat
 /libs/blocks/ost/ @adobecom/tacocat
 /libs/blocks/pdf-vewer/ @meganthecoder @JasonHowellSlavin @Brandon32
-/libs/blocks/quiz/ @colloyd @sabyamon @fullcolorcoder @JackySun9 @elaineskpt @echampio-at-adobe
+/libs/blocks/quiz/ @colloyd @sabyamon @fullcolorcoder @JackySun9
+/libs/blocks/quiz-entry/ @colloyd @fullcolorcoder @JackySun9
 /libs/blocks/quiz-marquee/ @ryanmparrish
-/libs/blocks/quiz-results/ @colloyd @sabyamon @fullcolorcoder @JackySun9 @elaineskpt @echampio-at-adobe
+/libs/blocks/quiz-results/ @colloyd @sabyamon @fullcolorcoder @JackySun9
 /libs/blocks/quote/ @ryanmparrish
 /libs/blocks/recommended-articles/ @meganthecoder @JasonHowellSlavin @Brandon32 @rgclayton
 /libs/blocks/review/ @nkthakur48 @chrischrischris @auniverseaway


### PR DESCRIPTION
trivial codeowners adjustment for quiz related blocks

- removed engineers who are no longer employees or have moved to non-development roles
- add quiz-entry
