### PR TITLE
Only comment reminders on PRs against stage

### DIFF
--- a/.github/workflows/pr-reminders.js
+++ b/.github/workflows/pr-reminders.js
@@ -53,6 +53,7 @@ const main = async ({ github, context }) => {
       owner: context.repo.owner,
       repo: context.repo.repo,
       state: 'open',
+      base: 'stage',
     });
 
     for await (const pr of openPRs) {


### PR DESCRIPTION
### Description
Only add PR reminders to PRs raised against stage.

This avoids reminders on branches against [main](https://github.com/adobecom/milo/pull/2359#issuecomment-2128306397) - or simply contributions to loc, which don't need a "Ready for Stage" label for example.

**Test URLs:**
- Before: https://main--milo--mokimo.hlx.live/?martech=off
- After: https://reminders-only-for-stage--milo--mokimo.hlx.live/?martech=off
