### PR TITLE
Start the RCP for stage earlier

### DIFF
--- a/.github/workflows/helpers.js
+++ b/.github/workflows/helpers.js
@@ -43,15 +43,21 @@ const RCPDates = [
   },
 ];
 
-const isWithinRCP = () => {
+const isWithinRCP = (offset = 0) => {
   const now = new Date();
   if (now.getFullYear() !== CURRENT_YEAR) {
     console.log(`ADD NEW RCPs for ${CURRENT_YEAR + 1}`);
     return true;
   }
 
-  if (RCPDates.some(({ start, end }) => start <= now && now <= end)) {
-    console.log('Current date is within a RCP. Stopping execution.');
+  if (RCPDates.some(({ start, end }) => {
+    const adjustedStart = new Date(start);
+    adjustedStart.setDate(adjustedStart.getDate() - offset);
+    return start <= now && now <= end
+  })) {
+    console.log(
+      'Current date is within a RCP (2 days earlier for stage, to keep stage clean & make CSO contributions during an RCP easier). Stopping execution.'
+    );
     return true;
   }
 

--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -179,7 +179,7 @@ const main = async (params) => {
   github = params.github;
   owner = params.context.repo.owner;
   repo = params.context.repo.repo;
-  if (isWithinRCP()) return console.log('Stopped, within RCP period.');
+  if (isWithinRCP(2)) return console.log('Stopped, within RCP period.');
 
   try {
     const stageToMainPR = await getStageToMainPR();


### PR DESCRIPTION
### Description
We want to keep `stage` clean in case of CSOs during RCPs to make it easier to contribute changes without pushing unwanted changes to production.

For this reason, we'd want to stop opening PRs to stage **before** the RCP so that nothing is open **during** the RCP.

**Test URLs:**
- Before: https://main--milo--mokimo.hlx.page/?martech=off
- After: https://keep-stage-clean--milo--mokimo.hlx.page/?martech=off
