### PR TITLE
[MWPW-148268] Adjust high impact workflow

### DIFF
--- a/.github/workflows/high-impact-alert.yml
+++ b/.github/workflows/high-impact-alert.yml
@@ -1,7 +1,7 @@
 name: High Impact Alert
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.1.4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Send Slack message for high impact PRs
         uses: actions/github-script@v7.0.1


### PR DESCRIPTION
This attempts to solve a workflow issue where the Slack Webhook secret was not accessible to forks, thus PRs open from forks would not be able to send Slack notifications.

Resolves: [MWPW-148268](https://jira.corp.adobe.com/browse/MWPW-148268)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/?martech=off
- After: https://adjust-high-impact-workflow--milo--overmyheadandbody.hlx.page/?martech=off
