### PR TITLE
Add news.adobe.com as known federal origin

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -15,6 +15,7 @@ const allowedOrigins = [
   'https://business.adobe.com',
   'https://blog.adobe.com',
   'https://milo.adobe.com',
+  'https://news.adobe.com',
 ];
 
 export const selectors = {


### PR DESCRIPTION
### Description
As part of the news.adobe.com migration, we want to add news.adobe.com as known federal origin as it was set up for federal from an akamai perspective

Resolves: [MWPW-151236](https://jira.corp.adobe.com/browse/MWPW-151236)

### Visuals
![Screenshot 2024-05-28 at 09 40 25](https://github.com/adobecom/milo/assets/39759830/4f42bc66-b01e-4081-8782-42fbf49c4173)

### Test instructions
Milolibs don't work on news.adobe.com as the consumer has not set this up yet. Using local overrides to test this change is the most convenient and quickest method to verify this PR works as intended on the consuming pages.
Test link from @Ruchika4 : https://news.stage.adobe.com/news/news-details/test-redirect


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/?martech=off
- After: https://mwpw-151236--milo--mokimo.hlx.live/?martech=off
