### PR TITLE
[MWPW-150668] Get utils ready for Helix 5

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -138,6 +138,7 @@ export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
 
 const LANGSTORE = 'langstore';
 const PAGE_URL = new URL(window.location.href);
+const SLD = PAGE_URL.hostname.includes('.aem.') ? 'aem' : 'hlx';
 
 function getEnv(conf) {
   const { host } = window.location;
@@ -146,8 +147,8 @@ function getEnv(conf) {
   if (query) return { ...ENVS[query], consumer: conf[query] };
   if (host.includes('localhost')) return { ...ENVS.local, consumer: conf.local };
   /* c8 ignore start */
-  if (host.includes('hlx.page')
-    || host.includes('hlx.live')
+  if (host.includes(`${SLD}.page`)
+    || host.includes(`${SLD}.live`)
     || host.includes('stage.adobe')
     || host.includes('corp.adobe')) {
     return { ...ENVS.stage, consumer: conf.stage };
@@ -230,7 +231,7 @@ export const [setConfig, updateConfig, getConfig] = (() => {
         console.log('Invalid or missing locale:', e);
       }
       config.locale.contentRoot = `${origin}${config.locale.prefix}${config.contentRoot ?? ''}`;
-      config.useDotHtml = !PAGE_URL.origin.includes('.hlx.')
+      config.useDotHtml = !PAGE_URL.origin.includes(`.${SLD}.`)
         && (conf.useDotHtml ?? PAGE_URL.pathname.endsWith('.html'));
       config.entitlements = handleEntitlements;
       config.consumerEntitlements = conf.entitlements || [];
@@ -489,7 +490,7 @@ export function decorateSVG(a) {
       ? new URL(`${window.location.origin}${a.href}`)
       : new URL(a.href);
 
-    const src = textUrl.hostname.includes('.hlx.') ? textUrl.pathname : textUrl;
+    const src = textUrl.hostname.includes(`.${SLD}.`) ? textUrl.pathname : textUrl;
 
     const img = createTag('img', { loading: 'lazy', src });
     if (altText) img.alt = altText;
@@ -515,7 +516,7 @@ export function decorateImageLinks(el) {
     const [source, alt, icon] = img.alt.split('|');
     try {
       const url = new URL(source.trim());
-      const href = url.hostname.includes('.hlx.') ? `${url.pathname}${url.hash}` : url.href;
+      const href = url.hostname.includes(`.${SLD}.`) ? `${url.pathname}${url.hash}` : url.href;
       if (alt?.trim().length) img.alt = alt.trim();
       const pic = img.closest('picture');
       const picParent = pic.parentElement;
@@ -1026,7 +1027,7 @@ function initSidekick() {
 
 function decorateMeta() {
   const { origin } = window.location;
-  const contents = document.head.querySelectorAll('[content*=".hlx."]');
+  const contents = document.head.querySelectorAll(`[content*=".${SLD}."]`);
   contents.forEach((meta) => {
     if (meta.getAttribute('property') === 'hlx:proxyUrl') return;
     try {


### PR DESCRIPTION
# Description
This is the first step towards Milo supporting Helix (Franklin/EDS) 5. When the time is right, there will be more exhaustive documentation and communication on everything this entails, but for now we just want to ensure Milo has basic support for its consumers when it comes to the domains it uses. A few projects that don't require authentication will be ported over to gather any learnings that might be useful for all Milo consumers.

Naming convention-wise, I went for [SLD](https://developer.mozilla.org/en-US/docs/Glossary/Second-level_Domain) for brevity purposes.

Resolves: [MWPW-150668](https://jira.corp.adobe.com/browse/MWPW-150668)

# Test URLs

### Milo hlx.page
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://helix-5-utils--milo--adobecom.hlx.page/?martech=off

### Milo hlx.live
- Before: https://main--milo--adobecom.hlx.live/?martech=off
- After: https://helix-5-utils--milo--adobecom.hlx.live/?martech=off

### Milo aem.page
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://helix-5-utils--milo--adobecom.aem.page/?martech=off

### Milo aem.live
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://helix-5-utils--milo--adobecom.aem.live/?martech=off

### CC
- Before: https://main--cc--adobecom.hlx.page/products/firefly?martech=off
- After: https://main--cc--adobecom.hlx.page/products/firefly?milolibs=helix-5-utils&martech=off

### Bacom
- Before: https://main--bacom--adobecom.hlx.page/ch_fr/products/experience-manager/sites/developer-tools?martech=off
- After: https://main--bacom--adobecom.hlx.page/ch_fr/products/experience-manager/sites/developer-tools?milolibs=helix-5-utils&martech=off

### HP
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?milolibs=helix-5-utils&martech=off

### Blog hlx.page
- Before: https://main--blog--adobecom.hlx.page/de/topics/3d-ar?martech=off
- After: https://main--blog--adobecom.hlx.page/de/topics/3d-ar?milolibs=helix-5-utils&martech=off

### Blog aem.page
- Before: https://helix-5--blog--adobecom.aem.page/de/topics/3d-ar?martech=off
- After: https://helix-5--blog--adobecom.aem.page/de/topics/3d-ar?milolibs=helix-5-utils&martech=off