### PR TITLE
MWPW-148278: Dynamic-Nav hide breadcrumbs

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -951,9 +951,6 @@ class Gnav {
   };
 
   decorateBreadcrumbs = async () => {
-    if (getMetadata('dynamic-nav') === 'on' && window.sessionStorage.getItem('gnavSource') !== null) {
-      return null;
-    }
     if (!this.block.classList.contains('has-breadcrumbs')) return null;
     if (this.elements.breadcrumbsWrapper) return this.elements.breadcrumbsWrapper;
     const breadcrumbsElem = this.block.querySelector('.breadcrumbs');

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -951,6 +951,10 @@ class Gnav {
   };
 
   decorateBreadcrumbs = async () => {
+    if (getMetadata('dynamic-nav') === 'on' && window.sessionStorage.getItem('gnavSource') !== null) {
+      document.querySelector('header').classList.remove('has-breadcrumbs');
+      return null;
+    }
     if (!this.block.classList.contains('has-breadcrumbs')) return null;
     if (this.elements.breadcrumbsWrapper) return this.elements.breadcrumbsWrapper;
     const breadcrumbsElem = this.block.querySelector('.breadcrumbs');

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -952,7 +952,6 @@ class Gnav {
 
   decorateBreadcrumbs = async () => {
     if (getMetadata('dynamic-nav') === 'on' && window.sessionStorage.getItem('gnavSource') !== null) {
-      document.querySelector('header').classList.remove('has-breadcrumbs');
       return null;
     }
     if (!this.block.classList.contains('has-breadcrumbs')) return null;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -692,7 +692,9 @@ function decorateHeader() {
   const baseBreadcrumbs = getMetadata('breadcrumbs-base')?.length;
   const breadcrumbs = document.querySelector('.breadcrumbs');
   const autoBreadcrumbs = getMetadata('breadcrumbs-from-url') === 'on';
-  if (baseBreadcrumbs || breadcrumbs || autoBreadcrumbs) header.classList.add('has-breadcrumbs');
+  const dynamicNavActive = getMetadata('dynamic-nav') === 'on'
+    && window.sessionStorage.getItem('gnavSource') !== null;
+  if (!dynamicNavActive && (baseBreadcrumbs || breadcrumbs || autoBreadcrumbs)) header.classList.add('has-breadcrumbs');
   if (breadcrumbs) header.append(breadcrumbs);
   const promo = getMetadata('gnav-promo-source');
   if (promo?.length) header.classList.add('has-promo');

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -1437,4 +1437,19 @@ describe('global navigation', () => {
       ).to.be.true;
     });
   });
+
+  describe('Dynamic nav', () => {
+    describe('Breadcrumbs', () => {
+      it('should not decorate breadcrumbs when dynamic nav is active', async () => {
+        const dynamicNavOn = toFragment`<meta name="dynamic-nav" content="on">`;
+        document.head.append(dynamicNavOn);
+        document.body.replaceChildren(toFragment`<header class="global-navigation"></header>`);
+        window.sessionStorage.setItem('dynamicNavKey', 'milo');
+        window.sessionStorage.setItem('gnavSource', '/some-path');
+        await initGnav(document.body.querySelector('header'));
+        const breadcrumbs = document.querySelector('.feds-breadcrumbs');
+        expect(breadcrumbs).to.be.null;
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Ensures that breadcrumbs do not show up on "on" pages when the dynamic nav is active

Resolves: [MWPW-148278](https://jira.corp.adobe.com/browse/MWPW-148278)

Context: 
Our PMs and SEO teams determined that within the journey where the dynamic nav follows the user, breadcrumbs that do not reflect the path the user has taken may be confusing. However, SEO still wanted the page's breadcrumbs to be visible to Google, so we are only stopping the creation of the feds-breadcrumbs and adjusting the classes to reflect the absence of breadcrumbs. 

Note: You will need to add a gnavSource to the session storage in order to verify that this works:
`window.sessionStorage.setItem('gnavSource', 'https://dynamic-nav-config--bacom--adobecom.hlx.page/gnav/localnav-aem-sites')`
In the normal workflow, a user would have visited an "entry page" where this would have been set. 

**Test URLs:**

- Before: https://main--milo--adobecom.hlx.page/drafts/slavin/dynamic-nav/bacom-sample-on?martech=off
- After: https://dynamic-nav-hide-breadcrumbs--milo--jasonhowellslavin.hlx.page/drafts/slavin/dynamic-nav/bacom-sample-on?martech=off

