### PR TITLE
MWPW-151189 [MILO][MEP] Skip Martech timeout if blocked by ad blocker

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -1,6 +1,7 @@
 import { getConfig, getMetadata, loadIms, loadLink, loadScript } from '../utils/utils.js';
 
 const ALLOY_SEND_EVENT = 'alloy_sendEvent';
+const ALLOY_SEND_EVENT_ERROR = 'alloy_sendEvent_error';
 const TARGET_TIMEOUT_MS = 4000;
 const ENTITLEMENT_TIMEOUT = 3000;
 
@@ -26,6 +27,12 @@ const waitForEventOrTimeout = (eventName, timeout, returnValIfTimeout) => new Pr
     resolve(event.detail);
   };
 
+  const errorListener = () => {
+    // eslint-disable-next-line no-use-before-define
+    clearTimeout(timer);
+    resolve({ error: true });
+  };
+
   const timer = setTimeout(() => {
     window.removeEventListener(eventName, listener);
     if (returnValIfTimeout !== undefined) {
@@ -36,6 +43,7 @@ const waitForEventOrTimeout = (eventName, timeout, returnValIfTimeout) => new Pr
   }, timeout);
 
   window.addEventListener(eventName, listener, { once: true });
+  window.addEventListener(ALLOY_SEND_EVENT_ERROR, errorListener, { once: true });
 });
 
 const getExpFromParam = (expParam) => {
@@ -125,6 +133,7 @@ const getTargetPersonalization = async () => {
 
   let manifests = [];
   const response = await waitForEventOrTimeout(ALLOY_SEND_EVENT, timeout);
+  if (response.error) return [];
   if (response.timeout) {
     waitForEventOrTimeout(ALLOY_SEND_EVENT, 5100 - timeout)
       .then(() => sendTargetResponseAnalytics(true, responseStart, timeout));


### PR DESCRIPTION
Some Ad Blockers prevent the call to Target.  Martech fires an event to signal an error when this occurs.  If we add an event listener for this event as well, we can stop waiting for the "success event" that will never fire.  This should lead to improved page performance for these users, thus increasing page performance averages.

Steps to test:
1. install an ad blocker extension that blocks sstats server (I found AdBlocker Ultimate works)
2. Confirm in the network tab that calls to sstats.adobe.com are blocked
3. Observe the performance difference with the new code

Resolves: [MWPW-151189](https://jira.corp.adobe.com/browse/MWPW-151189)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q2/gnavinternal/index-target-on
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q2/gnavinternal/index-target-on?milolibs=mepadblocker

**Test URLs for psi-check:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mepadblocker--milo--adobecom.hlx.page/?martech=off
