### PR TITLE
MWPW-148232 - [LocUI] Retry Queue Label

### DIFF
--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -1,4 +1,4 @@
-import { html } from '../../../deps/htm-preact.js';
+import { html, useState } from '../../../deps/htm-preact.js';
 import { languages } from '../utils/state.js';
 import { rollout, showLangErrors, showUrls } from './index.js';
 
@@ -11,7 +11,7 @@ function getPrettyStatus({ status, queued } = {}) {
     case 'rolling-out':
       return 'Rolling out';
     case 'error':
-      return `${queued ? 'In Retry Queue' : status}`;
+      return `${queued ? 'In Rollout Queue' : status}`;
     default:
       return status;
   }
@@ -23,18 +23,37 @@ function Badge(props) {
   return html`<div class=locui-subproject-badge>${prettyStatus}</div>`;
 }
 
+function langActionProps(lang) {
+  let showAction = ['translated', 'completed', 'error'].includes(lang.status);
+  let actionType = lang.status === 'completed' ? 'Re-rollout' : 'Rollout';
+  const hasError = lang.status === 'error';
+  if (showAction && lang.rolloutQueued) {
+    showAction = !hasError;
+  }
+  if (hasError) {
+    actionType = 'Retry';
+  }
+  return [showAction, actionType];
+}
+
 function Language({ item, idx }) {
+  const [didRetry, setDidRetry] = useState(false);
   const hasLocales = item.locales?.length > 0;
   const cssStatus = `locui-subproject-${item.status || 'not-started'}`;
+
   const onRollout = (e) => {
-    if (item.status === 'error') e.stopPropagation();
+    if (item.status === 'error') {
+      e.stopPropagation();
+      setDidRetry(true);
+    }
     rollout(item, idx);
   };
-  let rolloutType = item.status === 'completed' ? 'Re-rollout' : 'Rollout';
-  if (item.status === 'error') { rolloutType = 'Retry'; }
+
+  const [showAction, actionType] = langActionProps(item);
+
   return html`
     <li class="locui-subproject ${cssStatus}" onClick=${(e) => showLangErrors(e, item)}>
-      ${item.status && html`<${Badge} status=${item.status} queued=${item.rolloutQueued} />`}
+      ${item.status && html`<${Badge} status=${item.status} queued=${didRetry ? item.rolloutQueued : false} />`}
       <p class=locui-project-label>Language</p>
       <h3 class=locui-subproject-name>${item.Language}</h3>
       <p class=locui-project-label>Action</p>
@@ -60,15 +79,21 @@ function Language({ item, idx }) {
       ${hasLocales && html`
         <p class=locui-project-label>Locales</p>
         <div class=locui-subproject-locales>
-          <button class=locui-subproject-locale onClick=${() => showUrls(item, `langstore/${item.code}`)}>Langstore</button>
+          <button class=locui-subproject-locale onClick=${() => showUrls(item, `langstore/${item.code}`)}>
+            Langstore
+          </button>
           ${item.locales.map((locale) => html`
-            <button class=locui-subproject-locale onClick=${() => showUrls(item, locale)}>${locale}</button>
+            <button class=locui-subproject-locale onClick=${() => showUrls(item, locale)}>
+              ${locale}
+            </button>
           `)}
         </div>
       `}
-      ${['translated', 'completed', 'error'].includes(item.status) && !item.rolloutQueued && html`
+      ${showAction && html`
         <div class=locui-subproject-action-area>
-          <button class="locui-urls-heading-action ${item.status}" onClick=${(e) => onRollout(e)}>${rolloutType}</button>
+          <button class="locui-urls-heading-action ${item.status}" onClick=${(e) => onRollout(e)}>
+            ${actionType}
+          </button>
         </div>
       `}
     </li>

--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -2,7 +2,7 @@ import { html } from '../../../deps/htm-preact.js';
 import { languages } from '../utils/state.js';
 import { rollout, showLangErrors, showUrls } from './index.js';
 
-function getPrettyStatus({ status, queued }) {
+function getPrettyStatus({ status, queued } = {}) {
   switch (status) {
     case 'translated':
       return 'Rollout ready';

--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -2,7 +2,7 @@ import { html } from '../../../deps/htm-preact.js';
 import { languages } from '../utils/state.js';
 import { rollout, showLangErrors, showUrls } from './index.js';
 
-function getPrettyStatus(status) {
+function getPrettyStatus({ status, queued }) {
   switch (status) {
     case 'translated':
       return 'Rollout ready';
@@ -10,13 +10,15 @@ function getPrettyStatus(status) {
       return 'In progress';
     case 'rolling-out':
       return 'Rolling out';
+    case 'error':
+      return `${queued ? 'In Retry Queue' : status}`;
     default:
       return status;
   }
 }
 
-function Badge({ status }) {
-  const prettyStatus = getPrettyStatus(status);
+function Badge(props) {
+  const prettyStatus = getPrettyStatus(props);
   if (!prettyStatus) return null;
   return html`<div class=locui-subproject-badge>${prettyStatus}</div>`;
 }
@@ -32,7 +34,7 @@ function Language({ item, idx }) {
   if (item.status === 'error') { rolloutType = 'Retry'; }
   return html`
     <li class="locui-subproject ${cssStatus}" onClick=${(e) => showLangErrors(e, item)}>
-      ${item.status && html`<${Badge} status=${item.status} />`}
+      ${item.status && html`<${Badge} status=${item.status} queued=${item.rolloutQueued} />`}
       <p class=locui-project-label>Language</p>
       <h3 class=locui-subproject-name>${item.Language}</h3>
       <p class=locui-project-label>Action</p>
@@ -64,9 +66,9 @@ function Language({ item, idx }) {
           `)}
         </div>
       `}
-      ${['translated', 'completed', 'error'].includes(item.status) && html`
+      ${['translated', 'completed', 'error'].includes(item.status) && !item.rolloutQueued && html`
         <div class=locui-subproject-action-area>
-          <button class=locui-urls-heading-action onClick=${(e) => onRollout(e)}>${rolloutType}</button>
+          <button class="locui-urls-heading-action ${item.status}" onClick=${(e) => onRollout(e)}>${rolloutType}</button>
         </div>
       `}
     </li>

--- a/libs/blocks/locui/langs/view.js
+++ b/libs/blocks/locui/langs/view.js
@@ -1,4 +1,4 @@
-import { html, useState } from '../../../deps/htm-preact.js';
+import { html } from '../../../deps/htm-preact.js';
 import { languages } from '../utils/state.js';
 import { rollout, showLangErrors, showUrls } from './index.js';
 
@@ -37,14 +37,12 @@ function langActionProps(lang) {
 }
 
 function Language({ item, idx }) {
-  const [didRetry, setDidRetry] = useState(false);
   const hasLocales = item.locales?.length > 0;
   const cssStatus = `locui-subproject-${item.status || 'not-started'}`;
 
   const onRollout = (e) => {
     if (item.status === 'error') {
       e.stopPropagation();
-      setDidRetry(true);
     }
     rollout(item, idx);
   };
@@ -53,7 +51,7 @@ function Language({ item, idx }) {
 
   return html`
     <li class="locui-subproject ${cssStatus}" onClick=${(e) => showLangErrors(e, item)}>
-      ${item.status && html`<${Badge} status=${item.status} queued=${didRetry ? item.rolloutQueued : false} />`}
+      ${item.status && html`<${Badge} status=${item.status} queued=${item.rolloutQueued} />`}
       <p class=locui-project-label>Language</p>
       <h3 class=locui-subproject-name>${item.Language}</h3>
       <p class=locui-project-label>Action</p>

--- a/libs/blocks/locui/locui.css
+++ b/libs/blocks/locui/locui.css
@@ -308,16 +308,19 @@ li.locui-subproject.locui-subproject-in-progress .locui-subproject-badge {
   background: #80B3E7;
 }
 
+li.locui-subproject.locui-subproject-retrying,
 li.locui-subproject.locui-subproject-error {
   border-color: #e40909;
   background: rgb(249 148 148 / 20%);
   cursor: pointer;
 }
 
+li.locui-subproject.locui-subproject-retrying:hover,
 li.locui-subproject.locui-subproject-error:hover {
   background: rgb(249 148 148 / 40%);
 }
 
+li.locui-subproject.locui-subproject-retrying .locui-subproject-badge,
 li.locui-subproject.locui-subproject-error .locui-subproject-badge {
   background: #e40909;
 }
@@ -405,6 +408,14 @@ button.locui-urls-heading-action.cancel {
 
 button.locui-urls-heading-action.cancel:hover {
   background: #666;
+}
+
+button.locui-urls-heading-action.error {
+  background: red;
+}
+
+button.locui-urls-heading-action.error:hover {
+  background: #cd0505;
 }
 
 ul.locui-urls {


### PR DESCRIPTION
When you start a retry it can take some time, so the miloc service is passing a property `rolloutQueued` to let the user know. This PR adds a condition to display that status.

<img width="431" alt="Screenshot 2024-05-29 at 6 33 31 PM" src="https://github.com/adobecom/milo/assets/10670990/4afc37c3-8091-4e54-9cb2-94926f0b00dc">

Resolves: [MWPW-148232](https://jira.corp.adobe.com/browse/MWPW-148232)

**Test URLs:**
https://sean-loc--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B03A2B243-669F-43C8-8FEF-94DE3E784073%257D%26file%3DRetry%2520Queued%2520Status.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue
