### PR TITLE
MWPW-130601-Add typekit for adobe clean thai

### DIFF
--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -106,7 +106,7 @@ const locales = {
   si: { ietf: 'sl-SI', tk: 'qxw8hzm.css' },
   sk: { ietf: 'sk-SK', tk: 'qxw8hzm.css' },
   th_en: { ietf: 'en', tk: 'hah7vzn.css' },
-  th_th: { ietf: 'th', tk: 'dln3iyr.css' },
+  th_th: { ietf: 'th', tk: 'lqo2bst.css' },
   tr: { ietf: 'tr-TR', tk: 'qxw8hzm.css' },
   tw: { ietf: 'zh-TW', tk: 'jay0ecd' },
   ua: { ietf: 'uk-UA', tk: 'qxw8hzm.css' },

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -106,7 +106,7 @@ const locales = {
   si: { ietf: 'sl-SI', tk: 'qxw8hzm.css' },
   sk: { ietf: 'sk-SK', tk: 'qxw8hzm.css' },
   th_en: { ietf: 'en', tk: 'hah7vzn.css' },
-  th_th: { ietf: 'th', tk: 'qxw8hzm.css' },
+  th_th: { ietf: 'th', tk: 'dln3iyr.css' },
   tr: { ietf: 'tr-TR', tk: 'qxw8hzm.css' },
   tw: { ietf: 'zh-TW', tk: 'jay0ecd' },
   ua: { ietf: 'uk-UA', tk: 'qxw8hzm.css' },

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -160,6 +160,10 @@
   --body-font-family: adobe-clean-han-traditional, 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
 }
 
+:root:lang(th-TH) {
+  --body-font-family: adobe-clean-thai, 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+}
+
 @media (min-width: 1200px) {
   :root {
     --spacing-xl: 56px;

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -160,7 +160,7 @@
   --body-font-family: adobe-clean-han-traditional, 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
 }
 
-:root:lang(th-TH) {
+:root:lang(th) {
   --body-font-family: adobe-clean-thai, 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
 }
 


### PR DESCRIPTION
* Update thai pages to load Adobe Clean Thai

Resolves: [MWPW-130601](https://jira.corp.adobe.com/browse/MWPW-130601)

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/th_th/drafts/ruchika/thai-page?martech=off&georouting=off
- After: https://adobe-clean-thai--milo--adobecom.hlx.page/th_th/drafts/ruchika/thai-page?martech=off&georouting=off

Note: Added georouting=off query param to pass the psi check
