### PR TITLE
MWPW-147741 [Geo-Routing] Need to load modal after bootstrap in order to ensure Analytics fires

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -19,7 +19,7 @@ export function findDetails(hash, el) {
   return { id, path, isHash: hash === window.location.hash };
 }
 
-export function sendAnalytics(event) {
+function fireAnalyticsEvent(event) {
   // eslint-disable-next-line no-underscore-dangle
   window._satellite?.track('event', {
     xdm: {},
@@ -28,6 +28,17 @@ export function sendAnalytics(event) {
       _adobe_corpnew: { digitalData: event?.data },
     },
   });
+}
+
+export function sendAnalytics(event) {
+  // eslint-disable-next-line no-underscore-dangle
+  if (window._satellite?.track) {
+    fireAnalyticsEvent(event);
+  } else {
+    window.addEventListener('alloy_sendEvent', () => {
+      fireAnalyticsEvent(event);
+    }, { once: true });
+  }
 }
 
 export function closeModal(modal) {

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -103,19 +103,18 @@ function getGeoroutingOverride() {
 }
 
 function decorateForOnLinkClick(link, urlPrefix, localePrefix) {
+  let eventType = 'Switch';
+  if (localePrefix !== undefined) eventType = 'Stay';
+  const modCurrPrefix = localePrefix || 'us';
+  const modPrefix = urlPrefix || 'us';
+  const eventName = `${eventType}:${modPrefix.split('_')[0]}-${modCurrPrefix.split('_')[0]}|Geo_Routing_Modal`;
+  link.setAttribute('daa-ll', eventName);
   link.addEventListener('click', () => {
-    const modPrefix = urlPrefix || 'us';
     // set cookie so legacy code on adobecom still works properly.
     const domain = window.location.host === 'adobe.com'
       || window.location.host.endsWith('.adobe.com') ? 'domain=adobe.com' : '';
     document.cookie = `international=${modPrefix};path=/;${domain}`;
     link.closest('.dialog-modal').dispatchEvent(new Event('closeModal'));
-    let eventName = 'Switch';
-    const modCurrPrefix = localePrefix || 'us';
-    if (localePrefix !== undefined) {
-      eventName = 'Stay';
-    }
-    sendAnalyticsFunc(new Event(`${eventName}:${modPrefix.split('_')[0]}-${modCurrPrefix.split('_')[0]}|Geo_Routing_Modal`));
   });
 }
 

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -102,9 +102,7 @@ function getGeoroutingOverride() {
   return georouting === 'off';
 }
 
-function decorateForOnLinkClick(link, urlPrefix, localePrefix) {
-  let eventType = 'Switch';
-  if (localePrefix !== undefined) eventType = 'Stay';
+function decorateForOnLinkClick(link, urlPrefix, localePrefix, eventType = 'Switch') {
   const modCurrPrefix = localePrefix || 'us';
   const modPrefix = urlPrefix || 'us';
   const eventName = `${eventType}:${modPrefix.split('_')[0]}-${modCurrPrefix.split('_')[0]}|Geo_Routing_Modal`;
@@ -150,7 +148,7 @@ function removeOnClickOutsideElement(element, event, button) {
   document.addEventListener('click', func);
 }
 
-function openPicker(button, locales, country, event, dir) {
+function openPicker(button, locales, country, event, dir, currentPage) {
   if (document.querySelector('.locale-modal-v2 .picker')) {
     return;
   }
@@ -158,7 +156,7 @@ function openPicker(button, locales, country, event, dir) {
   locales.forEach((l) => {
     const lang = config.locales[l.prefix]?.ietf ?? '';
     const a = createTag('a', { lang, href: l.url }, `${country} - ${l.language}`);
-    decorateForOnLinkClick(a, l.prefix);
+    decorateForOnLinkClick(a, l.prefix, currentPage.prefix);
     const li = createTag('li', {}, a);
     list.appendChild(li);
   });
@@ -209,15 +207,15 @@ function buildContent(currentPage, locale, geoData, locales) {
     span.appendChild(downArrow);
     mainAction.addEventListener('click', (e) => {
       e.preventDefault();
-      openPicker(mainAction, locales, locale.button, e, dir);
+      openPicker(mainAction, locales, locale.button, e, dir, currentPage);
     });
   } else {
     mainAction.href = locale.url;
-    decorateForOnLinkClick(mainAction, locale.prefix);
+    decorateForOnLinkClick(mainAction, locale.prefix, currentPage.prefix);
   }
 
   const altAction = createTag('a', { lang, href: currentPage.url }, currentPage.button);
-  decorateForOnLinkClick(altAction, currentPage.prefix, locale.prefix);
+  decorateForOnLinkClick(altAction, currentPage.prefix, locale.prefix, 'Stay');
   const linkWrapper = createTag('div', { class: 'link-wrapper' }, mainAction);
   linkWrapper.appendChild(altAction);
   fragment.append(title, text, linkWrapper);

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -110,10 +110,12 @@ function decorateForOnLinkClick(link, urlPrefix, localePrefix) {
       || window.location.host.endsWith('.adobe.com') ? 'domain=adobe.com' : '';
     document.cookie = `international=${modPrefix};path=/;${domain}`;
     link.closest('.dialog-modal').dispatchEvent(new Event('closeModal'));
+    let eventName = 'Switch';
+    const modCurrPrefix = localePrefix || 'us';
     if (localePrefix !== undefined) {
-      const modCurrPrefix = localePrefix || 'us';
-      sendAnalyticsFunc(new Event(`Stay:${modPrefix.split('_')[0]}-${modCurrPrefix.split('_')[0]}|Geo_Routing_Modal`));
+      eventName = 'Stay';
     }
+    sendAnalyticsFunc(new Event(`${eventName}:${modPrefix.split('_')[0]}-${modCurrPrefix.split('_')[0]}|Geo_Routing_Modal`));
   });
 }
 
@@ -320,12 +322,13 @@ export default async function loadGeoRouting(
 
   // Show modal when derived countries from url locale and akamai disagree
   try {
-    const akamaiCode = await getAkamaiCode();
+    let akamaiCode = await getAkamaiCode();
     if (akamaiCode && !getCodes(urlGeoData).includes(akamaiCode)) {
       const localeMatches = getMatches(json.georouting.data, akamaiCode);
       const details = await getDetails(urlGeoData, localeMatches, json.geos.data);
       if (details) {
         await showModal(details);
+        if (akamaiCode === 'gb') akamaiCode = 'uk';
         sendAnalyticsFunc(
           new Event(`Load:${urlLocale || 'us'}-${akamaiCode || 'us'}|Geo_Routing_Modal`),
         );

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -941,15 +941,15 @@ async function checkForMep() {
 }
 
 async function loadPostLCP(config) {
-  const georouting = getMetadata('georouting') || config.geoRouting;
-  if (georouting === 'on') {
-    const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
-    await loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);
-  }
   if (config.mep?.targetEnabled === 'gnav') {
     await loadMartech({ persEnabled: true, postLCP: true });
   } else {
     loadMartech();
+  }
+  const georouting = getMetadata('georouting') || config.geoRouting;
+  if (georouting === 'on') {
+    const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
+    await loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);
   }
   const header = document.querySelector('header');
   if (header) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -905,7 +905,7 @@ export const combineMepSources = async (persEnabled, promoEnabled, mepParam) => 
   return persManifests;
 };
 
-async function checkForMep() {
+async function checkForPageMods() {
   const { mep: mepParam } = Object.fromEntries(PAGE_URL.searchParams);
   if (mepParam === 'off') return;
   const persEnabled = getMepEnablement('personalization');
@@ -1137,7 +1137,7 @@ export async function loadArea(area = document) {
   const isDoc = area === document;
 
   if (isDoc) {
-    await checkForMep();
+    await checkForPageMods();
     appendHtmlToCanonicalUrl();
   }
   const config = getConfig();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -938,14 +938,16 @@ async function checkForPageMods() {
 
 async function loadPostLCP(config) {
   const georouting = getMetadata('georouting') || config.geoRouting;
+  if (config.mep?.targetEnabled === 'gnav') {
+    await loadMartech({ persEnabled: true, postLCP: true });
+  } else if (georouting === 'on') {
+    await loadMartech();
+  } else {
+    loadMartech();
+  }
   if (georouting === 'on') {
     const { default: loadGeoRouting } = await import('../features/georoutingv2/georoutingv2.js');
     await loadGeoRouting(config, createTag, getMetadata, loadBlock, loadStyle);
-  }
-  if (config.mep?.targetEnabled === 'gnav') {
-    await loadMartech({ persEnabled: true, postLCP: true });
-  } else {
-    loadMartech();
   }
   const header = document.querySelector('header');
   if (header) {

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -9,7 +9,13 @@ const {
   getModal,
   getHashParams,
   delayedModal,
+  sendAnalytics,
 } = await import('../../../libs/blocks/modal/modal.js');
+
+const trackingEvent = {
+  isTrusted: false,
+  __WTR_CONSTRUCTOR_NAME__: 'Event',
+};
 
 describe('Modals', () => {
   beforeEach(() => {
@@ -227,5 +233,27 @@ describe('Modals', () => {
     expect(modal).to.not.exist;
     window.sessionStorage.removeItem('shown:#dm');
     el.remove();
+  });
+});
+
+describe('sendAnalytics', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('satellite event not set, so must use event listener', async () => {
+    // eslint-disable-next-line no-underscore-dangle
+    window._satellite = {};
+    sendAnalytics(trackingEvent);
+    // eslint-disable-next-line no-underscore-dangle
+    window._satellite = { track: sinon.spy() };
+    const martechEvent = new Event('alloy_sendEvent');
+    dispatchEvent(martechEvent);
+  });
+
+  it('satellite event set, so can fire load event immediately', async () => {
+    // eslint-disable-next-line no-underscore-dangle
+    window._satellite = { track: sinon.spy() };
+    sendAnalytics(trackingEvent);
   });
 });

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import { readFile, sendKeys } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
@@ -11,16 +12,12 @@ const {
   delayedModal,
   sendAnalytics,
 } = await import('../../../libs/blocks/modal/modal.js');
-
-const trackingEvent = {
-  isTrusted: false,
-  __WTR_CONSTRUCTOR_NAME__: 'Event',
-};
+const satellite = { track: sinon.spy() };
 
 describe('Modals', () => {
   beforeEach(() => {
-    // eslint-disable-next-line no-underscore-dangle
-    window._satellite = { track: sinon.spy() };
+    window._satellite = satellite;
+    window._satellite.track.called = false;
   });
 
   afterEach(() => {
@@ -214,7 +211,6 @@ describe('Modals', () => {
     expect(modal).to.be.not.null;
     expect(document.querySelector('#delayed-modal').classList.contains('delayed-modal'));
     expect(window.sessionStorage.getItem('shown:#delayed-modal').includes(window.location.pathname)).to.be.true;
-    // eslint-disable-next-line no-underscore-dangle
     expect(window._satellite.track.called).to.be.true;
     window.sessionStorage.removeItem('shown:#delayed-modal');
     modal.remove();
@@ -227,7 +223,6 @@ describe('Modals', () => {
     window.sessionStorage.setItem('shown:#dm', window.location.pathname);
     expect(delayedModal(el)).to.be.true;
     await delay(1000);
-    // eslint-disable-next-line no-underscore-dangle
     expect(window._satellite.track.called).to.be.false;
     const modal = document.querySelector('#dm');
     expect(modal).to.not.exist;
@@ -242,18 +237,19 @@ describe('sendAnalytics', () => {
   });
 
   it('satellite event not set, so must use event listener', async () => {
-    // eslint-disable-next-line no-underscore-dangle
-    window._satellite = {};
-    sendAnalytics(trackingEvent);
-    // eslint-disable-next-line no-underscore-dangle
-    window._satellite = { track: sinon.spy() };
+    window._satellite = false;
+    sendAnalytics({});
+    window._satellite = satellite;
+    window._satellite.track.called = false;
     const martechEvent = new Event('alloy_sendEvent');
     dispatchEvent(martechEvent);
+    expect(window._satellite.track.called).to.be.true;
   });
 
   it('satellite event set, so can fire load event immediately', async () => {
-    // eslint-disable-next-line no-underscore-dangle
-    window._satellite = { track: sinon.spy() };
-    sendAnalytics(trackingEvent);
+    window._satellite = satellite;
+    window._satellite.track.called = false;
+    sendAnalytics({});
+    expect(window._satellite.track.called).to.be.true;
   });
 });


### PR DESCRIPTION
I've been asked by my boss' boss to drop all work to get this out Monday.  Marking high priority.

Geo modal analytics are being sent when the user closes the modal or chooses to stay on the current page.  Analytics are NOT being sent when the modal loads or they choose to change countries.

![image](https://github.com/adobecom/milo/assets/101133187/f7cf10c4-7939-4770-bdf3-8334f4d7c8d2)

Issues solved:
1. Load events were being fired but it wasn't working because it relied on something done by martech.js.  So if the geomodal is needed, we await martech before creating the modal (note this is postLCP).
2. It sometimes said gb and sometimes said uk. This is a common issue with just this geo, so added a small fix to force it to always be uk.
3. daa-ll is preferable for capturing user events.  The close button was already using daa-ll.  So daa-ll was added to switch and stay, and the event to send analytics was removed from stay's click event. 

Resolves: [MWPW-147741](https://jira.corp.adobe.com/browse/MWPW-147741)

**Test URLs for psi-check:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://geomodalanalytics--milo--adobecom.hlx.page/?martech=off

This is a tricky one to test.  This is the least painful way:
1. Be sure all incognito windows are closed.
2. Open a fresh incognito window
3. Open your network tab in dev tools to capture traffic
4. In the network tab, filter for the word `collect`
5. Go to https://main--bacom--adobecom.hlx.live/?akamaiLocale=GB&countryCode=GB&mboxOverride.browserIp=5.10.159.255&milolibs=geomodalanalytics
6. click on the first collect in the list. Click payload and expand the Request Payload.  You should see an entry called `Load:us-uk|Geo_Routing_Modal`  This is event 1 of 4 we need to capture
7. In your console, type `_satellite.setDebug(true);`
8. Click the close button
9. You'll see something saying `[Core] Rules using the direct call event type with identifier "event" have been triggered with additional detail` with an object.  Expand the object and look for `localeModal:modalClose:buttonClose`.  This is event 2 of 4 we need to capture.
10. Reload the page
11. Clear your console because it will have been spammed
12. Click the United States link.  Once again you'll see a message about the event with the object. Expand and you'll see 
`Stay:us-uk|Geo_Routing_Modal`. This is event 3 of 4 we need to capture.
13. Delete your "international" cookie and reload.  If you don't know how to clear cookies, you can close the window, open the URL in a new incognito window, and re-enter `_satellite.setDebug(true);` in your console.
14. If your console is spammed, you can clear it.
15. Hold down your command key (control key for Windows) and click the `United Kingdom` button. Once again you'll see a message about the event with the object. Expand and you'll see 
`Switch:us-uk|Geo_Routing_Modal`. This is event 4 of 4 we need to capture.