### PR TITLE
MWPW-151281-Fix overflow causing horizontal scroll

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -297,7 +297,7 @@ main > .section[class*='-up'] > .content {
 }
 
 @media screen and (min-width: 1200px) {
-.section.two-up {
+  .section.two-up {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -297,20 +297,20 @@ main > .section[class*='-up'] > .content {
 }
 
 @media screen and (min-width: 1200px) {
-  .section.two-up {
-    grid-template-columns: repeat(2, 1fr);
+.section.two-up {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .section.three-up {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .section.four-up {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .section.five-up {
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 
   .section.grid-template-columns-1-2 {


### PR DESCRIPTION
* Fix overflow causing horizontal scroll when using column for three-up etc with grid width in section metadata

Resolves: [MWPW-151281](https://jira.corp.adobe.com/browse/MWPW-151281)

**Test URLs:**
Milo:
- Before: https://main--milo--adobecom.hlx.page/drafts/ruchika/scroll/photoshop?martech=off
- After: https://section-metadata--milo--adobecom.hlx.page/drafts/ruchika/scroll/photoshop?martech=off

CC:
- Before: https://main--cc--adobecom.hlx.page/drafts/ruchika/scroll/temp/photoshop?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/ruchika/scroll/temp/photoshop?milolibs=section-metadata&martech=off
