### PR TITLE
[MWPW-151992] Resolve permission issues for the zero impact workflow

### DIFF
--- a/.github/workflows/label-zero-impact.yaml
+++ b/.github/workflows/label-zero-impact.yaml
@@ -1,7 +1,7 @@
 name: Add or remove zero impact label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:


### PR DESCRIPTION
### Description
Use a different workflow trigger to avoid permission issues running a workflow from a fork which can't alter PRs (add/remove) labels.

Resolves: [MWPW-151992](https://jira.corp.adobe.com/browse/MWPW-151992)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://alter-zero-impact-workflow--milo--mokimo.hlx.page/?martech=off
