### PR TITLE
mwpw-151992: allow to always merge zero impact PRs

### DIFF
--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -15,6 +15,7 @@ const LABELS = {
   highPriority: 'high priority',
   readyForStage: 'Ready for Stage',
   SOTPrefix: 'SOT',
+  zeroImpact: 'zero-impact',
 };
 const TEAM_MENTIONS = [
   '@adobecom/miq-sot',
@@ -46,6 +47,7 @@ let body = `
 `;
 
 const isHighPrio = (labels) => labels.includes(LABELS.highPriority);
+const isZeroImpact = (labels) => labels.includes(LABELS.zeroImpact);
 
 const hasFailingChecks = (checks) =>
   checks.some(
@@ -80,11 +82,23 @@ const getPRs = async () => {
     return true;
   });
 
-  return prs.reverse(); // OLD PRs first
+  return prs.reverse().reduce(
+    (categorizedPRs, pr) => {
+      if (isZeroImpact(pr.labels)) {
+        categorizedPRs.zeroImpactPRs.push(pr);
+      } else if (isHighPrio(pr.labels)) {
+        categorizedPRs.highImpactPRs.push(pr);
+      } else {
+        categorizedPRs.normalPRs.push(pr);
+      }
+      return categorizedPRs;
+    },
+    { zeroImpactPRs: [], highImpactPRs: [], normalPRs: [] }
+  );
 };
 
-const merge = async ({ prs }) => {
-  console.log(`Merging ${prs.length || 0} PRs that are ready... `);
+const merge = async ({ prs, type }) => {
+  console.log(`Merging ${prs.length || 0} ${type} PRs that are ready... `);
 
   for await (const { number, files, html_url, title } of prs) {
     try {
@@ -92,7 +106,10 @@ const merge = async ({ prs }) => {
         console.log(`Skipping ${number}: ${title} due to overlap in files.`);
         continue;
       }
-      files.forEach((file) => (SEEN[file] = true));
+      if (type !== LABELS.zeroImpact) {
+        files.forEach((file) => (SEEN[file] = true));
+      }
+
       if (!process.env.LOCAL_RUN) {
         await github.rest.pulls.merge({
           owner,
@@ -185,11 +202,12 @@ const main = async (params) => {
     const stageToMainPR = await getStageToMainPR();
     console.log('has Stage to Main PR:', !!stageToMainPR);
     if (stageToMainPR) body = stageToMainPR.body;
+    const { zeroImpactPRs, highImpactPRs, normalPRs } = await getPRs();
+    await merge({ prs: zeroImpactPRs, type: LABELS.zeroImpact });
     if (stageToMainPR?.labels.some((label) => label.includes(LABELS.SOTPrefix)))
       return console.log('PR exists & testing started. Stopping execution.');
-    const prs = await getPRs();
-    await merge({ prs: prs.filter(({ labels }) => isHighPrio(labels)) });
-    await merge({ prs: prs.filter(({ labels }) => !isHighPrio(labels)) });
+    await merge({ prs: highImpactPRs, type: LABELS.highPriority });
+    await merge({ prs: normalPRs, type: 'normal' });
     if (!stageToMainPR) await openStageToMainPR();
     if (stageToMainPR && body !== stageToMainPR.body) {
       console.log("Updating PR's body...");


### PR DESCRIPTION
### Description
With this change, when tests pass + reviews are there - [zero impact PRs](https://github.com/adobecom/milo/blob/stage/.github/workflows/label-zero-impact.js#L2-L14) can be included to a batch at ANY point and don't care about file overlaps. 

Since zero impact PRs are not touching any production facing code, we shouldn't need to worry about revertability/file overlaps either.

Resolves: [MWPW-151992](https://jira.corp.adobe.com/browse/MWPW-151992)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://<branch>--milo--adobecom.hlx.page/?martech=off
