### PR TITLE
MWPW-152041[MEP][MILO] Add support for using MEP placeholders in gnav

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -147,7 +147,7 @@ let fedsPlaceholderConfig;
 export const getFedsPlaceholderConfig = ({ useCache = true } = {}) => {
   if (useCache && fedsPlaceholderConfig) return fedsPlaceholderConfig;
 
-  const { locale } = getConfig();
+  const { locale, placeholders } = getConfig();
   const libOrigin = getFederatedContentRoot();
 
   fedsPlaceholderConfig = {
@@ -155,6 +155,7 @@ export const getFedsPlaceholderConfig = ({ useCache = true } = {}) => {
       ...locale,
       contentRoot: `${libOrigin}${locale.prefix}/federal/globalnav`,
     },
+    placeholders,
   };
 
   return fedsPlaceholderConfig;


### PR DESCRIPTION
Note: marked high priority because it is holding up test development and jeopardizing the launch date.

Resolves: [MWPW-152041](https://jira.corp.adobe.com/browse/MWPW-152041)

For testing purposes, observe the Buy now button in the gnav. It should be updated to "Swapped buy now!!" in After url. 

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q3/mepplaceholdersgnav/gnavplaceholders
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q3/mepplaceholdersgnav/gnavplaceholders?milolibs=mepplaceholdersgnav

**Test URLs for psi check:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mepplaceholdersgnav--milo--adobecom.hlx.page/?martech=off