### PR TITLE
Increase 404 rum tracking to 10%

### DIFF
--- a/libs/utils/samplerum.js
+++ b/libs/utils/samplerum.js
@@ -47,8 +47,11 @@ export function sampleRUM(checkpoint, data = {}) {
       window.hlx.rum = { weight, id, random, isSelected, firstReadTime, sampleRUM, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'path'], rumSessionStorage };
     }
 
-    const { weight, id, firstReadTime } = window.hlx.rum;
-    if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {
+    const { id, firstReadTime } = window.hlx.rum;
+    const weight404 = 10;
+    const isSelected404 = checkpoint === '404' && (Math.random() * weight404 < 1);
+    const weight = isSelected404 ? weight404 : window.hlx.rum;
+    if (window.hlx && window.hlx.rum && (window.hlx.rum.isSelected || isSelected404)) {
       const knownProperties = ['weight', 'id', 'referer', 'checkpoint', 't', 'source', 'target', 'cwv', 'CLS', 'FID', 'LCP', 'INP', 'TTFB'];
       const sendPing = (pdata = data) => {
         // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define


### PR DESCRIPTION
### Description
To get a more accurate signal for 404 pages in the RUM data, we want to increase tracking to 10% rather than 1% for 404s.

Resolves: [MWPW-152132](https://jira.corp.adobe.com/browse/MWPW-152132)

**Test URLs:**
- Before: https://main--milo--mokimo.hlx.page/?martech=off
- After: https://mwpw-152132--milo--mokimo.hlx.page/?martech=off
