### PR TITLE
mwpw-150087: bump action dependencies

### DIFF
--- a/.github/workflows/code-compatibility.yaml
+++ b/.github/workflows/code-compatibility.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check for unsupported functions
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -46,7 +46,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -59,6 +59,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3    
+        uses: actions/checkout@v4    
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4    
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           base: ${{ github.ref }}
@@ -23,7 +23,7 @@ jobs:
               - 'libs/**'    
       - if: steps.changes.outputs.src == 'true'
         name: Trigger DC Workflow
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.DC_PAT }}
           script: |

--- a/.github/workflows/fg-sync-repos.yml
+++ b/.github/workflows/fg-sync-repos.yml
@@ -26,7 +26,7 @@ jobs:
           repositories: "milo-pink"
 
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{ inputs.syncBranch }}

--- a/.github/workflows/high-impact-alert.yml
+++ b/.github/workflows/high-impact-alert.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Send Slack message for high impact PRs
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v7
         with:
           script: |
             const main = require('./.github/workflows/high-impact-alert.js')

--- a/.github/workflows/label-zero-impact.yaml
+++ b/.github/workflows/label-zero-impact.yaml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
 
       - name: Add the zero impact label
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v7
         with:
           script: |
             const main = require('./.github/workflows/label-zero-impact.js')

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -19,17 +19,17 @@ jobs:
     if: github.repository_owner == 'adobecom' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'stage'))
 
     steps:
-      - uses: actions/create-github-app-token@v1.10.0
+      - uses: actions/create-github-app-token@v1
         id: milo-pr-merge-token
         with:
           app-id: ${{ secrets.MILO_PR_MERGE_APP_ID }}
           private-key: ${{ secrets.MILO_PR_MERGE_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
 
       - name: Merge to main
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v7
         with:
           github-token: ${{ steps.milo-pr-merge-token.outputs.token }}
           script: |

--- a/.github/workflows/merge-to-stage.yaml
+++ b/.github/workflows/merge-to-stage.yaml
@@ -19,17 +19,17 @@ jobs:
     environment: milo_pr_merge
 
     steps:
-      - uses: actions/create-github-app-token@v1.10.0
+      - uses: actions/create-github-app-token@v1
         id: milo-pr-merge-token
         with:
           app-id: ${{ secrets.MILO_PR_MERGE_APP_ID }}
           private-key: ${{ secrets.MILO_PR_MERGE_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4.1.4
+        uses: actions/checkout@v4
 
       - name: Merge to stage or queue to merge
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v7
         with:
           github-token: ${{ steps.milo-pr-merge-token.outputs.token }}
           script: |

--- a/.github/workflows/pr-reminders.yaml
+++ b/.github/workflows/pr-reminders.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4
 
     - name: Remind PR initiators
-      uses: actions/github-script@v7.0.1
+      uses: actions/github-script@v7
       with:
         script: |
           const main = require('./.github/workflows/pr-reminders.js')

--- a/.github/workflows/run-lint.yaml
+++ b/.github/workflows/run-lint.yaml
@@ -10,11 +10,11 @@ jobs:
     name: Running eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/run-nala-milolibs.yaml
+++ b/.github/workflows/run-nala-milolibs.yaml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set environment variables
         run: |

--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Nala
         uses: adobecom/nala@main # Change if doing dev work
         env:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -33,7 +33,7 @@ jobs:
       run: xvfb-run -a npm test
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage/lcov.info

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 2
 
     - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/skms.yaml
+++ b/.github/workflows/skms.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Runs a single command using the runners shell for shell validation
       - name: Validate Shell

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4
 
     - name: Update file and create PR if needed
-      uses: actions/github-script@v7.0.1
+      uses: actions/github-script@v7
       with:
         script: |
           const updateDependency = require('./.github/workflows/update-script.js')


### PR DESCRIPTION
### Description
Bump actions dependencies (mostly checkout) and remove fixed dependency versions to always pull the latest version of an action. 
This gets rid of the deprecation annotations of actions using node v16 or deprecated codeql versions (which are stopping to work in december 24)

Resolves: [MWPW-150087](https://jira.corp.adobe.com/browse/MWPW-150087)

**Test URLs:**
- Before: https://main--milo--mokimo.hlx.live/?martech=off
- After: https://bump-all-action-dependencies--milo--mokimo.hlx.live/?martech=off
