### PR TITLE
mepUpdate

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -151,7 +151,6 @@ const getTargetPersonalization = async () => {
     targetManifests: manifests,
     targetPropositions: propositions,
   };
-
 };
 
 const getDtmLib = (env) => ({

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -148,8 +148,8 @@ const getTargetPersonalization = async () => {
   }
 
   return {
-    targetManifests : manifests,
-    targetPropositions : propositions
+    targetManifests: manifests,
+    targetPropositions: propositions,
   };
 
 };
@@ -252,8 +252,8 @@ export default async function init({
       const { preloadManifests, applyPers } = await import('../features/personalization/personalization.js');
       const manifests = preloadManifests({ targetManifests, persManifests });
       await applyPers(manifests, postLCP);
-      if(targetPropositions?.length) {
-        _satellite.track('propositionDisplay', targetPropositions);
+      if (targetPropositions?.length && window._satellite) {
+        window._satellite.track('propositionDisplay', targetPropositions);
       }
     }
   }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -252,6 +252,7 @@ export default async function init({
       const manifests = preloadManifests({ targetManifests, persManifests });
       await applyPers(manifests, postLCP);
       if (targetPropositions?.length && window._satellite) {
+        // eslint-disable-next-line no-underscore-dangle
         window._satellite.track('propositionDisplay', targetPropositions);
       }
     }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -252,7 +252,7 @@ export default async function init({
       const manifests = preloadManifests({ targetManifests, persManifests });
       await applyPers(manifests, postLCP);
       if (targetPropositions?.length && window._satellite) {
-        // eslint-disable-next-line no-underscore-dangle 
+        // eslint-disable-next-line no-underscore-dangle
         window._satellite.track('propositionDisplay', targetPropositions);
       }
     }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -252,7 +252,7 @@ export default async function init({
       const manifests = preloadManifests({ targetManifests, persManifests });
       await applyPers(manifests, postLCP);
       if (targetPropositions?.length && window._satellite) {
-        // eslint-disable-next-line no-underscore-dangle
+        // eslint-disable-next-line no-underscore-dangle 
         window._satellite.track('propositionDisplay', targetPropositions);
       }
     }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -132,6 +132,7 @@ const getTargetPersonalization = async () => {
   }, { once: true });
 
   let manifests = [];
+  let propositions = [];
   const response = await waitForEventOrTimeout(ALLOY_SEND_EVENT, timeout);
   if (response.error) {
     window.lana.log('target response time: ad blocker', { tags: 'errorType=info,module=martech' });
@@ -143,9 +144,14 @@ const getTargetPersonalization = async () => {
   } else {
     sendTargetResponseAnalytics(false, responseStart, timeout);
     manifests = handleAlloyResponse(response.result);
+    propositions = response.result && response.result.propositions;
   }
 
-  return manifests;
+  return {
+    targetManifests : manifests,
+    targetPropositions : propositions
+  };
+
 };
 
 const getDtmLib = (env) => ({
@@ -241,11 +247,14 @@ export default async function init({
       { as: 'script', rel: 'modulepreload' },
     );
 
-    const targetManifests = await getTargetPersonalization();
+    const { targetManifests, targetPropositions } = await getTargetPersonalization();
     if (targetManifests?.length || persManifests?.length) {
       const { preloadManifests, applyPers } = await import('../features/personalization/personalization.js');
       const manifests = preloadManifests({ targetManifests, persManifests });
       await applyPers(manifests, postLCP);
+      if(targetPropositions?.length) {
+        _satellite.track('propositionDisplay', targetPropositions);
+      }
     }
   }
 


### PR DESCRIPTION
Currently in Milo MEP, the Target propositionDisplay call is not happenning after the Target propositions are rendered on the page.

This change is to make the Target propositionDisplay call from the MEP Martech.js file once the Target propositions are applied.

This wiki explains the changes in detail:
https://wiki.corp.adobe.com/pages/viewpage.action?pageId=3169882054 

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://<branch>--milo--adobecom.hlx.page/?martech=off
