### PR TITLE
MWPW-148002: Adjust Strike-through price font size for: merch-card (all variations)

### DIFF
--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -8,7 +8,7 @@ span[data-wcs-osi] {
 }
 
 span.placeholder-resolved[data-template="strikethrough"], span.price.price-strikethrough {
-  font-size: 14px;
+  font-size: var(--type-body-xs-size);
   font-weight: normal;
   text-decoration: line-through;
 }

--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -8,6 +8,8 @@ span[data-wcs-osi] {
 }
 
 span.placeholder-resolved[data-template="strikethrough"], span.price.price-strikethrough {
+  font-size: 14px;
+  font-weight: normal;
   text-decoration: line-through;
 }
 


### PR DESCRIPTION
This change sets the strikethrough price font size to 14px and font weight to normal in the merch-card block.
See XD: https://xd.adobe.com/view/fdec345a-503e-436f-af76-f15d375609b6-a8bf/screen/09ce5290-f27e-4b42-8654-8da85bea840a/specs/

Resolves: [MWPW-148002](https://jira.corp.adobe.com/browse/MWPW-148002)

Test URLs:

Before: https://main--milo--adobecom.hlx.page/docs/authoring/commerce/merch-card-product?martech=off
After: https://mwpw-148002-price-font-size-new--milo--mirafedas.hlx.page/docs/authoring/commerce/merch-card-product?martech=off
https://mwpw-148002-price-font-size-new--milo--mirafedas.hlx.live/docs/authoring/commerce/merch-card-product?martech=off
