### PR TITLE
MWPW-148282: Remove data layer names from Marketo Configurator 

### DIFF
--- a/libs/blocks/marketo-config/marketo-config.js
+++ b/libs/blocks/marketo-config/marketo-config.js
@@ -79,7 +79,6 @@ const Fields = ({ fieldsData }) => {
     } catch {
       const keyValuePairs = field.options.split(',').map((item) => {
         const [key, val] = item.trim().split(':');
-        console.log([key.trim(), `${(val || key).trim()} (${key.trim()})`]);
         return key.trim() ? [key.trim(), `${(val || key).trim()}`] : ['', 'Choose an option...'];
       });
       options = Object.fromEntries(keyValuePairs);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Removes strings only used by the data layer from the configurator UI

Resolves: [MWPW-148282](https://jira.corp.adobe.com/browse/MWPW-148282)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mkto-config-modify-template-names--milo--adobecom.hlx.live/?martech=off

** Changing url from tools to point to index. Our tools run preact, etc. and are internal facing. 
