### PR TITLE
MWPW-151885 - [LocUI] messaging for auth redirect

### DIFF
--- a/libs/blocks/locui/locui.css
+++ b/libs/blocks/locui/locui.css
@@ -1,0 +1,9 @@
+.locui.container {
+  margin: 0 auto;
+  margin-top: 10vh;
+  max-width: 700px;
+  border-radius: 10px;
+  border: 10px solid #eee;
+  padding: 10px 30px 30px;
+  text-align: center;
+}

--- a/libs/blocks/locui/locui.css
+++ b/libs/blocks/locui/locui.css
@@ -5,5 +5,4 @@
   border-radius: 10px;
   border: 10px solid #eee;
   padding: 10px 30px 30px;
-  text-align: center;
 }

--- a/libs/blocks/locui/locui.js
+++ b/libs/blocks/locui/locui.js
@@ -3,11 +3,14 @@ import { createTag } from '../../utils/utils.js';
 export default function init(el) {
   el.classList.add('container');
   const heading = createTag('h2', null, 'Missing project details');
-  const text = createTag('p', null, 'After authentication, unfortunately the project details were cleared upon redirect. To get back to your project, please return to the excel and run the project again.');
+  const paragraph = createTag('p', null, 'The project details were removed after you logged in. To resolve this:');
+  const steps = createTag('ol', null);
+  const stepList = ['Close this window or tab.', 'Open your project Excel file.', 'Click "Localize..." in Sidekick again.'];
+  stepList.forEach((step) => steps.append(createTag('li', null, step)));
   const learnmore = createTag('a', {
     class: 'con-button',
     href: 'https://milo.adobe.com/docs/authoring/localization#:~:text=at%20render%20time.-,Troubleshooting,-Error%20matrix',
     target: '_blank',
   }, 'Learn More');
-  el.append(heading, text, learnmore);
+  el.append(heading, paragraph, steps, learnmore);
 }

--- a/libs/blocks/locui/locui.js
+++ b/libs/blocks/locui/locui.js
@@ -1,0 +1,13 @@
+import { createTag } from '../../utils/utils.js';
+
+export default function init(el) {
+  el.classList.add('container');
+  const heading = createTag('h2', null, 'Missing project details');
+  const text = createTag('p', null, 'After authentication, unfortunately the project details were cleared upon redirect. To get back to your project, please return to the excel and run the project again.');
+  const learnmore = createTag('a', {
+    class: 'con-button',
+    href: 'https://milo.adobe.com/docs/authoring/localization#:~:text=at%20render%20time.-,Troubleshooting,-Error%20matrix',
+    target: '_blank',
+  }, 'Learn More');
+  el.append(heading, text, learnmore);
+}

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -41,6 +41,7 @@ const MILO_BLOCKS = [
   'icon-block',
   'iframe',
   'instagram',
+  'locui',
   'marketo',
   'marquee',
   'marquee-anchors',


### PR DESCRIPTION
When a user launches their localization project without having already authenticated, the user is redirected to login and upon return the project details passed as query parameters are then automatically cleared and the user gets the missing block message. This PR adds a pseudo locui block that simply displays a message to the user to re-run their project. (This block would be destroyed if we ever merge the locui branch to main)

<img width="1058" alt="Screenshot 2024-06-11 at 3 27 18 PM" src="https://github.com/adobecom/milo/assets/10670990/fb2a9d70-f7cc-4e05-81d6-3b8312c1154a">

Resolves: [MWPW-151885](https://jira.corp.adobe.com/browse/MWPW-151885)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/tools/loc?martech=off
- After: https://sartxi-locui-message--milo--adobecom.hlx.page/tools/loc?martech=off
