### PR TITLE
MWPW-148424 Fix chart dates

### DIFF
--- a/libs/blocks/chart/utils.js
+++ b/libs/blocks/chart/utils.js
@@ -34,20 +34,12 @@ export function formatExcelDate(date) {
   let newDate;
 
   if (!Number.isNaN(+date)) {
-    const hours = Math.floor((+date % 1) * 24);
-    const minutes = Math.floor((((+date % 1) * 24) - hours) * 60);
-    const offsetUTC = 24 - (new Date().getTimezoneOffset() / 60);
-
-    newDate = new Date(Date.UTC(0, 0, +date, hours - offsetUTC, minutes));
+    newDate = +date > 99999
+      ? new Date(+date * 1000)
+      : new Date(Math.round((+date - (1 + 25567 + 1)) * 86400 * 1000));
   } else {
     newDate = new Date(date);
   }
 
-  const localDateFormat = new Date(
-    newDate.getFullYear(),
-    newDate.getMonth(),
-    newDate.getDate(),
-  );
-
-  return localDateFormat.toLocaleString([], { dateStyle: 'short' });
+  return newDate.toLocaleString([], { dateStyle: 'short', timeZone: 'GMT' });
 }

--- a/test/blocks/chart/utils.test.js
+++ b/test/blocks/chart/utils.test.js
@@ -1,7 +1,11 @@
 import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 
-const { throttle, parseValue } = await import('../../../libs/blocks/chart/utils.js');
+const {
+  throttle,
+  parseValue,
+  formatExcelDate,
+} = await import('../../../libs/blocks/chart/utils.js');
 
 describe('chart utils', () => {
   describe('throttle', () => {
@@ -44,6 +48,25 @@ describe('chart utils', () => {
     });
     it('parses a non-number', () => {
       expect(parseValue('foo')).to.equal('foo');
+    });
+  });
+
+  describe('formatExcelDate', () => {
+    const dates = [
+      { excel: 45200, expected: '10/1/23' },
+      { excel: 45231, expected: '11/1/23' },
+      { excel: 45261, expected: '12/1/23' },
+      { excel: 45292, expected: '1/1/24' },
+      { excel: 45323, expected: '2/1/24' },
+      { excel: 45352, expected: '3/1/24' },
+      { excel: 45383, expected: '4/1/24' },
+      { excel: 45413, expected: '5/1/24' },
+    ];
+
+    dates.forEach((date) => {
+      it(`formats excel date ${date.excel} to ${date.expected}`, () => {
+        expect(formatExcelDate(date.excel)).to.equal(date.expected);
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fix charts rendering incorrect dates due to timezones.
* Matching sidekick formula for excel dates:
  * https://github.com/adobe/aem-sidekick/blob/main/src/extension/views/json/json.js#L290-L292

Resolves: [MWPW-148424](https://jira.corp.adobe.com/browse/MWPW-148424)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/bmarshal/charts/chart-dates?martech=off
- After: https://bmarshal-chart-dates--milo--adobecom.hlx.page/drafts/bmarshal/charts/chart-dates?martech=off

**BACOM URLs:** (chart data was manually offset)
- Before: https://main--bacom--adobecom.hlx.page/resources/digital-economy-index?martech=off
- After: https://main--bacom--adobecom.hlx.page/resources/digital-economy-index?martech=off&milolibs=bmarshal-chart-dates