### PR TITLE
MWPW-152627 [MILO][MARTECH] add Target propositionDisplay call

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import { getConfig, getMetadata, loadIms, loadLink, loadScript } from '../utils/utils.js';
 
 const ALLOY_SEND_EVENT = 'alloy_sendEvent';
@@ -220,7 +221,6 @@ const loadMartechFiles = async (config, url, edgeConfigId) => {
     const env = ['stage', 'local'].includes(config.env.name) ? '.qa' : '';
     const martechPath = `martech.main.standard${env}.min.js`;
     await loadScript(`${config.miloLibs || config.codeRoot}/deps/${martechPath}`);
-    // eslint-disable-next-line no-underscore-dangle
     window._satellite.track('pageload');
   };
 
@@ -252,7 +252,6 @@ export default async function init({
       const manifests = preloadManifests({ targetManifests, persManifests });
       await applyPers(manifests, postLCP);
       if (targetPropositions?.length && window._satellite) {
-        // eslint-disable-next-line no-underscore-dangle
         window._satellite.track('propositionDisplay', targetPropositions);
       }
     }

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -145,7 +145,7 @@ const getTargetPersonalization = async () => {
   } else {
     sendTargetResponseAnalytics(false, responseStart, timeout);
     manifests = handleAlloyResponse(response.result);
-    propositions = response.result && response.result.propositions;
+    propositions = response.result?.propositions || [];
   }
 
   return {


### PR DESCRIPTION
Currently in Milo MEP, the Target propositionDisplay call is not happening after the Target propositions are rendered on the page.

This update makes the Target propositionDisplay call from the MEP Martech.js file once the Target propositions are applied.

This wiki explains the changes in detail (Testing instructions are available in this wiki):
https://wiki.corp.adobe.com/pages/viewpage.action?pageId=3169882054

Resolves: [MWPW-152627](https://jira.corp.adobe.com/browse/MWPW-152627)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?milolibs=targetpropdisplay

Note: check the network tab for an interact call to sstats.  Should be listed as eventType in events property in Payload tab

Psi-check: https://targetpropdisplay--milo--adobecom.hlx.page/?martech=off