### PR TITLE
MWPW-152659 [MILO][MODAL][ANALYTICS] Analytic on modal load is missing

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /* eslint-disable import/no-cycle */
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
 
@@ -20,18 +21,15 @@ export function findDetails(hash, el) {
 }
 
 function fireAnalyticsEvent(event) {
-  // eslint-disable-next-line no-underscore-dangle
-  window._satellite?.track('event', {
+  const data = {
     xdm: {},
-    data: {
-      web: { webInteraction: { name: event?.type } },
-      _adobe_corpnew: { digitalData: event?.data },
-    },
-  });
+    data: { web: { webInteraction: { name: event?.type } } },
+  };
+  if (event?.data) data.data._adobe_corpnew.digitalData = event.data;
+  window._satellite?.track('event', data);
 }
 
 export function sendAnalytics(event) {
-  // eslint-disable-next-line no-underscore-dangle
   if (window._satellite?.track) {
     fireAnalyticsEvent(event);
   } else {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -25,7 +25,7 @@ function fireAnalyticsEvent(event) {
     xdm: {},
     data: { web: { webInteraction: { name: event?.type } } },
   };
-  if (event?.data) data.data._adobe_corpnew.digitalData = event.data;
+  if (event?.data) data.data._adobe_corpnew = { digitalData: event.data };
   window._satellite?.track('event', data);
 }
 


### PR DESCRIPTION
Note: this PR is flagged as high priority because we're getting pushed from above to resolve this ASAP.

Detailed Description: when using _satellite.track, most of the data that will be sent is already known.  You only need to update specific data.  Attempting to override data with undefined will destroy needed data.   So we need to check if the value is defined before adding it to the object we send to the function.
................................
URL: https://business.adobe.com/uk/ or any geo you are not in
................................
Steps to Reproduce:
1. Open network tab and filter for the sstats
2. Check collect entry for info on modal load

Expected Results: Call sends _adobe_corpnew info
................................
Actual Results: Call does not send _adobe_corpnew info

Cause, event.data is undefined, and destroys the object.  By first checking if event.data is defined, we can not overwrite the data that will automatically be sent.

Resolves: [MWPW-152659](https://jira.corp.adobe.com/browse/MWPW-152659)

**Test URLs:**
https://business.adobe.com/uk/

Unfortunately, this cannot be tested with preview URLs.  You must override content for the modal.js file.

psi check: https://loadmodaleventfix--milo--adobecom.hlx.page/?martech=off
