### PR TITLE
MWPW-152759 - [LocUI] update skipped message

### DIFF
--- a/libs/blocks/locui/langs/modal.js
+++ b/libs/blocks/locui/langs/modal.js
@@ -21,11 +21,12 @@ function Modal({ lang, prefix, type }) {
 
   if (type === 'skipped') {
     const skipped = getSkippedFileWarnings(lang);
+    const regions = lang.locales.map(String).join(', ');
     return html`
       <h2 class="skipped-heading">
         <span class="skipped-icon" /> Skipped Items during rollout <i>- ${lang.Language}</i>
       </h2>
-      <p>Files that already exist in the langstore are skipped because of the project configuration.
+      <p>Files that already exist in <strong>${regions}</strong> are skipped because of the project configuration.
         If you would like file updates to be merged on rollout you will need to <i>start a new project</i> with the correct regional edit behavior (merge). <a href="https://milo.adobe.com/docs/authoring/localization#:~:text=2.Regional.edit.behavior%3A" target="_blank">Learn more</a></p>
       <ol>${skipped.map((err) => html`<li>${err}</li>`)}</ol>
     `;

--- a/libs/blocks/locui/langs/modal.js
+++ b/libs/blocks/locui/langs/modal.js
@@ -27,7 +27,7 @@ function Modal({ lang, prefix, type }) {
         <span class="skipped-icon" /> Skipped Items during rollout <i>- ${lang.Language}</i>
       </h2>
       <p>Files that already exist in <strong>${regions}</strong> are skipped because of the project configuration.
-        If you would like file updates to be merged on rollout you will need to <i>start a new project</i> with the correct regional edit behavior (merge). <a href="https://milo.adobe.com/docs/authoring/localization#:~:text=2.Regional.edit.behavior%3A" target="_blank">Learn more</a></p>
+        If you would like file updates to be merged on rollout you will need to <strong><i>start a new project</i></strong> with the correct regional edit behavior (merge). <a href="https://milo.adobe.com/docs/authoring/localization#:~:text=2.Regional.edit.behavior%3A" target="_blank">Learn more</a></p>
       <ol>${skipped.map((err) => html`<li>${err}</li>`)}</ol>
     `;
   }

--- a/libs/blocks/locui/status/view.js
+++ b/libs/blocks/locui/status/view.js
@@ -15,7 +15,7 @@ function Description({ status }) {
       message = html`<ol>${description.map((desc) => html`
         <li>${errorLinks(desc, type)}</li>`)}</ol>`;
     } else {
-      message = errorLinks(message[0], type);
+      message = errorLinks(description[0], type);
     }
   } else {
     message = errorLinks(description, type);


### PR DESCRIPTION
Update skipped messaging to list the language locales for the user.

![Screenshot 2024-06-18 at 10 01 21 AM](https://github.com/adobecom/milo/assets/10670990/1f033cb8-aff0-499d-ad04-04716596a37d)

Resolves: [MWPW-152759](https://jira.corp.adobe.com/browse/MWPW-152759)

**Test URLs:**
https://main--cc--adobecom.hlx.page/tools/loc?milolibs=sean-loc&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B400D73C9-2E1E-4E18-802F-884173827D30%257D%26file%3Dcc-prod-sanity-docx-test-2.xlsx%26action%3Ddefault%26mobileredirect%3Dtrue%26wdsle%3D0
