### PR TITLE
MWPW-147907: Allow for 24pt font size for price [Merch Card]

### DIFF
--- a/libs/blocks/merch-card/merch-card.css
+++ b/libs/blocks/merch-card/merch-card.css
@@ -35,11 +35,6 @@ merch-card.special-offers del span[is="inline-price"] {
   text-decoration: line-through;
 }
 
-merch-card span[is="inline-price"].l-price {
-  font-size: var(--consonant-merch-card-heading-m-font-size);
-  line-height: var(--consonant-merch-card-heading-xs-line-height);
-}
-
 .dark .merch-card .con-button.outline:hover {
   color: var(--color-white);
   background-color: var(--color-black);
@@ -57,10 +52,5 @@ merch-card a[is="checkout-link"].upgrade:not(:first-of-type) {
     min-width: 66px; /* same as merch links */
     padding: 4px 18px 5px 21px;
     font-size: var(--consonant-merch-card-mini-compare-mobile-cta-font-size);
-  }
-
-  merch-card span[is="inline-price"].l-price {
-    font-size: var(--consonant-merch-card-body-s-font-size);
-    line-height: var(--consonant-merch-card-body-s-line-height);
   }
 }

--- a/libs/blocks/merch-card/merch-card.css
+++ b/libs/blocks/merch-card/merch-card.css
@@ -35,6 +35,11 @@ merch-card.special-offers del span[is="inline-price"] {
   text-decoration: line-through;
 }
 
+merch-card span[is="inline-price"].l-price {
+  font-size: var(--consonant-merch-card-heading-m-font-size);
+  line-height: var(--consonant-merch-card-heading-xs-line-height);
+}
+
 .dark .merch-card .con-button.outline:hover {
   color: var(--color-white);
   background-color: var(--color-black);
@@ -52,6 +57,10 @@ merch-card a[is="checkout-link"].upgrade:not(:first-of-type) {
     min-width: 66px; /* same as merch links */
     padding: 4px 18px 5px 21px;
     font-size: var(--consonant-merch-card-mini-compare-mobile-cta-font-size);
+  }
 
+  merch-card span[is="inline-price"].l-price {
+    font-size: var(--consonant-merch-card-body-s-font-size);
+    line-height: var(--consonant-merch-card-body-s-line-height);
   }
 }

--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -340,6 +340,17 @@ const setMiniCompareOfferSlot = (merchCard, offers) => {
   merchCard.appendChild(miniCompareOffers);
 };
 
+const updateBigPrices = (merchCard) => {
+  const prices = merchCard.querySelectorAll('strong > em > span[is="inline-price"]');
+
+  prices.forEach((span) => {
+    const strongTag = span.parentNode.parentNode;
+    const emTag = span.parentNode;
+    strongTag.replaceChild(span, emTag);
+    span.classList.add('l-price');
+  });
+};
+
 export default async function init(el) {
   if (!el.querySelector(INNER_ELEMENTS_SELECTOR)) return el;
   const styles = [...el.classList];
@@ -504,7 +515,7 @@ export default async function init(el) {
         }
       }
     }
-
+    updateBigPrices(merchCard);
     decorateBlockHrs(merchCard);
     simplifyHrs(merchCard);
     if (merchCard.classList.contains('has-divider')) merchCard.setAttribute('custom-hr', true);

--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -342,12 +342,16 @@ const setMiniCompareOfferSlot = (merchCard, offers) => {
 
 const updateBigPrices = (merchCard) => {
   const prices = merchCard.querySelectorAll('strong > em > span[is="inline-price"]');
-
+  const isMobile = window.matchMedia('(max-width: 1199px)').matches;
   prices.forEach((span) => {
     const strongTag = span.parentNode.parentNode;
     const emTag = span.parentNode;
     strongTag.replaceChild(span, emTag);
-    span.classList.add('l-price');
+    if (!isMobile) {
+      span.style.cssText = 'font-size: 24px; line-height: 22.5px;';
+    } else {
+      span.style.cssText = 'font-size: 16px; line-height: 24px;';
+    }
   });
 };
 

--- a/test/blocks/merch-card/merch-card.test.js
+++ b/test/blocks/merch-card/merch-card.test.js
@@ -100,6 +100,7 @@ describe('Plans Card', () => {
       elements: [
         { selector: 'h3[slot="heading-m"]' },
         { selector: 'h4[slot="heading-xs"]' },
+        { selector: 'strong span' },
         { selector: 'div[slot="body-xs"]', textContent: 'Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.MaecenasSee terms about lorem ipsum' },
         { attribute: { name: 'variant', value: 'plans' } },
         { attribute: { name: 'badge-background-color', value: '#EDCC2D' } },

--- a/test/blocks/merch-card/merch-card.test.js
+++ b/test/blocks/merch-card/merch-card.test.js
@@ -426,3 +426,45 @@ describe('Section metadata rules', async () => {
     expect(merchCard.dataset.removedManifestId).to.exist;
   });
 });
+
+describe('Viewport Responsiveness without Sinon', () => {
+  let originalMatchMedia;
+
+  beforeEach(() => {
+    // Store the original window.matchMedia
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    // Restore the original window.matchMedia after each test
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('Adjusts layout for desktop viewports', async () => {
+    window.matchMedia = (query) => ({
+      matches: query.includes('(max-width: 600px)'),
+      addListener: () => {},
+      removeListener: () => {},
+    });
+
+    document.body.innerHTML = await readMockText('/test/blocks/merch-card/mocks/plans-card.html');
+    const merchCard = await init(document.querySelector('.merch-card.plans.edu.icons.secure'));
+    const bigPrice = merchCard.querySelector('strong span[is="inline-price"]');
+    expect(bigPrice).to.exist;
+    expect(bigPrice.style.fontSize).to.equal('24px');
+  });
+
+  it('Maintains layout for mobile viewports', async () => {
+    window.matchMedia = (query) => ({
+      matches: !query.includes('(max-width: 600px)'),
+      addListener: () => {},
+      removeListener: () => {},
+    });
+
+    document.body.innerHTML = await readMockText('/test/blocks/merch-card/mocks/plans-card.html');
+    const merchCard = await init(document.querySelector('.merch-card.plans.edu.icons.secure'));
+    const bigPrice = merchCard.querySelector('strong span[is="inline-price"]');
+    expect(bigPrice).to.exist;
+    expect(bigPrice.style.fontSize).to.equal('16px');
+  });
+});

--- a/test/blocks/merch-card/mocks/plans-card.html
+++ b/test/blocks/merch-card/mocks/plans-card.html
@@ -67,7 +67,8 @@
           <img loading="lazy" alt="" src="" width="80" height="78">
         </picture>
         <h2 id="lorem-ipsum-dolor-sit-amet1"><em>Lorem ipsum dolor sit amet</em></h2>
-        <h3 id="lorem-ipsum-dolor1">Lorem ipsum dolor</h3>
+        <h3 id="lorem-ipsum-dolor1">Lorem ipsum dolo <strong><em><span is="inline-price">Lorem ipsum dolor </span></em></strong></h3>
+        <h5>Maecenas porttitor enim.</h5>
         <p>Maecenas porttitor congue massa. Fusce posuere, magna sed pulvinar ultricies, purus lectus malesuada libero, sit amet commodo magna eros quis urna. Nunc viverra imperdiet enim.</p>
         <p><strong>Maecenas</strong></p>
         <p><a href="https://adobe.com/">See terms about lorem ipsum</a></p>


### PR DESCRIPTION
Allows using 24px font size for prices inside merch card by applying the font styles bold+italic to a price link in Word.

Resolves: [MWPW-147907](https://jira.corp.adobe.com/browse/MWPW-147907)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/axel/bug-fixes/big-price?martech=off
- After: https://mwpw-147907--milo--adobecom.hlx.page/drafts/axel/bug-fixes/big-price?martech=off
