### PR TITLE
MWPW-152286 Optimize marquee loading

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1150,7 +1150,7 @@ async function documentPostSectionLoading(config) {
   document.body.appendChild(createTag('div', { id: 'page-load-ok-milo', style: 'display: none;' }));
 }
 
-function partition(arr, fn) {
+export function partition(arr, fn) {
   return arr.reduce(
     (acc, val, i, ar) => {
       acc[fn(val, i, ar) ? 0 : 1].push(val);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -87,6 +87,9 @@ const MILO_BLOCKS = [
   'share',
   'reading-time',
 ];
+
+const MILO_BLOCKS_PRELOADS = { marquee: ['/utils/decorate.js'] };
+
 const AUTO_BLOCKS = [
   { adobetv: 'tv.adobe.com' },
   { gist: 'https://gist.github.com' },
@@ -451,6 +454,8 @@ export async function loadBlock(block) {
 
   const base = miloLibs && MILO_BLOCKS.includes(name) ? miloLibs : codeRoot;
   let path = `${base}/blocks/${name}`;
+
+  MILO_BLOCKS_PRELOADS[name]?.forEach((preload) => loadLink(`${base}${preload}`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' }));
 
   if (mep?.blocks?.[name]) path = mep.blocks[name];
 
@@ -1145,6 +1150,16 @@ async function documentPostSectionLoading(config) {
   document.body.appendChild(createTag('div', { id: 'page-load-ok-milo', style: 'display: none;' }));
 }
 
+function partition(arr, fn) {
+  return arr.reduce(
+    (acc, val, i, ar) => {
+      acc[fn(val, i, ar) ? 0 : 1].push(val);
+      return acc;
+    },
+    [[], []],
+  );
+}
+
 async function processSection(section, config, isDoc) {
   const inlineFrags = [...section.el.querySelectorAll('a[href*="#_inline"]')];
   if (inlineFrags.length) {
@@ -1158,8 +1173,10 @@ async function processSection(section, config, isDoc) {
   }
 
   if (section.preloadLinks.length) {
-    const preloads = section.preloadLinks.map((block) => loadBlock(block));
+    const [modals, nonModals] = partition(section.preloadLinks, (block) => block.classList.contains('modal'));
+    const preloads = nonModals.map((block) => loadBlock(block));
     await Promise.all(preloads);
+    modals.map((block) => loadBlock(block));
   }
 
   const loaded = section.blocks.map((block) => loadBlock(block));

--- a/test/utils/utils-partition.test.js
+++ b/test/utils/utils-partition.test.js
@@ -1,0 +1,27 @@
+import { expect } from '@esm-bundle/chai';
+import { partition } from '../../libs/utils/utils.js';
+
+describe('Utils Partition', () => {
+  it('partition array', async () => {
+    const arr = [
+      { name: 'John', age: 23 },
+      { name: 'James', age: 40 },
+      { name: 'Mary', age: 31 },
+    ];
+    const result = partition(arr, (x) => x.age > 30);
+    expect(result[0]).to.have.deep.members(
+      [
+        { name: 'Mary', age: 31 },
+        { name: 'James', age: 40 },
+      ],
+    );
+    expect(result[1]).to.have.deep.members(
+      [{ name: 'John', age: 23 }],
+    );
+  });
+  it('empty array', async () => {
+    const arr = [];
+    const result = partition(arr, (x) => x.age > 30);
+    expect(result).to.eql([[], []]);
+  });
+});


### PR DESCRIPTION
* Use a block preload map for known imports in a block
* A section doesn't need to wait for loading of modal links. Marquee and modal are loaded at the same time.
* More performance gain on top of #2391 

Resolves: [MWPW-152286](https://jira.corp.adobe.com/browse/mwpw-152286)

**Test URLs:**

- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-152286--milo--adobecom.hlx.page/?martech=off

**DC Test URLs:**

- Before: https://www.stage.adobe.com/acrobat/how-to/pdf-editor-pdf-files.html
- After: https://www.stage.adobe.com/acrobat/how-to/pdf-editor-pdf-files.html?milolibs=mwpw-152286

Before:
![before1](https://github.com/adobecom/milo/assets/65299136/bf1b7670-eb28-4fa8-9b17-991eeb004453)

After:
![after1](https://github.com/adobecom/milo/assets/65299136/d1736f46-4b7f-481f-9c34-2c30669aad75)
