### PR TITLE
MWPW-152912 - [LocUI] Fix duplicate fragments in search

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -125,7 +125,7 @@ export async function findFragments() {
     if (fragments.length > 0) {
       fragments.forEach((fragment) => {
         // De-dupe across pages that share fragments
-        const dupe = acc.some((url) => url[0] === fragment.href);
+        const dupe = acc.some((url) => url[0]?.href === fragment.href);
         if (!dupe) acc.push([fragment]);
       });
     }


### PR DESCRIPTION
Now that the initial fragment search is sending back constructed URLs the de-dupe function needs to target the href property so that the duplicates can be filtered when finding fragments.

Resolves: [MWPW-152912](https://jira.corp.adobe.com/browse/MWPW-152912)

To Test: sync to langstore and see list of fragments

**Test URLs:** 
- Before: https://main--cc--adobecom.hlx.page/tools/loc?milolibs=locui&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Be5fe96dc-817e-44ec-8f48-47c94fd79ecb%257D%26action%3Deditnew%26wdsle%3D0
- After: https://main--cc--adobecom.hlx.page/tools/loc?milolibs=sean-loc&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Be5fe96dc-817e-44ec-8f48-47c94fd79ecb%257D%26action%3Deditnew%26wdsle%3D0
