### PR TITLE
[MWPW-129964] Fix accessibility issues for georouting language selector

### DIFF
--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -201,6 +201,7 @@ function buildContent(currentPage, locale, geoData, locales) {
     const downArrow = createTag('img', {
       class: 'icon-milo down-arrow',
       src: `${config.miloLibs || config.codeRoot}/ui/img/chevron.svg`,
+      role: 'presentation',
       width: 15,
       height: 15,
     });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Fixes a small accessibility issue where the georouting language selector image does not have a description text.

Resolves: [MWPW-129964](https://jira.corp.adobe.com/browse/MWPW-129964)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/narcis/default?martech=off
- After: https://mwpw-129964--milo--narcis-radu.hlx.page/drafts/narcis/default?martech=off

Test URL: https://main--cc--adobecom.hlx.page/products/acrobat-pro-cc?milolibs=mwpw-129964--milo--narcis-radu
Test using IN or CH VPN