### PR TITLE
Exposing the UNav Config for consumers to modify and reload the UNav if needed

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -621,6 +621,7 @@ class Gnav {
       children: getChildren(),
     });
 
+    CONFIG.universalNav.universalNavConfig = getConfiguration();
     window.UniversalNav(getConfiguration());
 
     isDesktop.addEventListener('change', () => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -621,7 +621,7 @@ class Gnav {
       children: getChildren(),
     });
 
-    // exposing unav config for consumers to modify certain values/functions and reload UNAV if they need to
+    // Exposing UNAV config for consumers to modify certain values/functions and reload UNAV if needed
     CONFIG.universalNav.universalNavConfig = getConfiguration();
     window.UniversalNav(getConfiguration());
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -621,6 +621,7 @@ class Gnav {
       children: getChildren(),
     });
 
+    // exposing unav config for consumers to modify certain values/functions and reload UNAV if they need to
     CONFIG.universalNav.universalNavConfig = getConfiguration();
     window.UniversalNav(getConfiguration());
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -621,12 +621,12 @@ class Gnav {
       children: getChildren(),
     });
 
-    // Exposing UNAV config for consumers to modify certain values/functions and reload UNAV if needed
+    // Exposing UNAV config for consumers
     CONFIG.universalNav.universalNavConfig = getConfiguration();
-    window.UniversalNav(getConfiguration());
+    window.UniversalNav(CONFIG.universalNav.universalNavConfig);
 
     isDesktop.addEventListener('change', () => {
-      window.UniversalNav.reload(getConfiguration());
+      window.UniversalNav.reload(CONFIG.universalNav.universalNavConfig);
     });
   };
 


### PR DESCRIPTION
Exposing the UNav config to be consumed and updated by any consumer like below:

If a Milo Global Navigation consumer wants to change the signInClick callback or listen to messages from the Profile Menu sub-navigation (which is the case for us in Firefly), then we can get the `CONFIG.universalNav.universalNavConfig` object, update anything we need to update, and then call `window.UniversalNav.reload(updatedConfig)`

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/?martech=off
- After: https://stage--milo--amol-anand.hlx.page/?martech=off
