### PR TITLE
MWPW-147270 Fix the error caused by trying to load Search in Global Navigation

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -650,7 +650,9 @@ class Gnav {
   };
 
   loadSearch = () => {
-    if (this.blocks?.search?.instance) return null;
+    const instanceAlreadyExists = !!this.blocks?.search?.instance;
+    const searchNotInContent = !this.searchPresent();
+    if (instanceAlreadyExists || searchNotInContent) return null;
 
     return this.loadDelayed().then(() => {
       this.blocks.search.instance = new this.Search(this.blocks.search.config);
@@ -966,10 +968,10 @@ class Gnav {
     return this.elements.breadcrumbsWrapper;
   };
 
-  decorateSearch = () => {
-    const searchBlock = this.content.querySelector('.search');
+  searchPresent = () => !!this.content.querySelector('.search');
 
-    if (!searchBlock) return null;
+  decorateSearch = () => {
+    if (!this.searchPresent()) return null;
 
     this.blocks.search.config.trigger = toFragment`
       <button class="feds-search-trigger" aria-label="Search" aria-expanded="false" aria-controls="feds-search-bar" daa-ll="Search">

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -206,6 +206,7 @@ export function loadStyles(url) {
 // CSS imports were not used due to duplication of file include
 export async function loadBaseStyles() {
   const url = rootPath('base.css');
+
   await loadStyles(url);
 }
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -206,7 +206,6 @@ export function loadStyles(url) {
 // CSS imports were not used due to duplication of file include
 export async function loadBaseStyles() {
   const url = rootPath('base.css');
-
   await loadStyles(url);
 }
 


### PR DESCRIPTION

<!-- Before submitting, please review all open PRs. -->

This bug was filed in response to this comment: https://github.com/adobecom/milo/pull/2185#pullrequestreview-2019744236

- In mobile viewports, search is now only loaded upon clicking the trigger if the `.search` element is present in the global-navigation content

Resolves: [MWPW-147270](https://jira.corp.adobe.com/browse/MWPW-147270)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://fix-search-error--milo--sharmrj.hlx.page/?martech=off

QA: https://stage--cc--adobecom.hlx.page/products/photoshop/ai?milolibs=fix-search-error--milo--sharmrj

Note: No behavior is changed by this PR.
