### PR TITLE
MWPW-153129 - [LocUI] Index pathname conditions in find fragments

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -63,7 +63,8 @@ async function fetchDocument(hlxPath) {
 }
 
 async function findPageFragments(path) {
-  const isIndex = path.lastIndexOf('index');
+  const page = path.split('/').pop();
+  const isIndex = page === 'index' ? path.lastIndexOf('index') : 0;
   const hlxPath = isIndex > 0 ? path.substring(0, isIndex) : path;
   const doc = await fetchDocument(hlxPath);
   if (!doc) return undefined;


### PR DESCRIPTION
Some pages have the word index in their name and come back 404 because of the find fragments function automatically pulling everything before the word index when it is found in fragment path. This PR tightens up those conditions so it is always checking the last segment of the path and checking that it must always equal `index`.

Resolves: [MWPW-153129](https://jira.corp.adobe.com/browse/MWPW-153129)

**Test URLs: (Sync fragments to test)**
- Before: https://main--bacom--adobecom.hlx.page/tools/loc?milolibs=locui&ref=locui&repo=bacom&owner=adobecom&host=business.adobe.com&project=BACOM&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B68803fea-30e8-4b22-b56d-a7cd705565f6%257D%26action%3Deditnew%26wdsle%3D0
- After: https://main--bacom--adobecom.hlx.page/tools/loc?milolibs=sean-loc&ref=locui&repo=bacom&owner=adobecom&host=business.adobe.com&project=BACOM&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B68803fea-30e8-4b22-b56d-a7cd705565f6%257D%26action%3Deditnew%26wdsle%3D0
