### PR TITLE
Adding support for federated urls in modals

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-cycle */
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
+import { getFederatedUrl } from '../global-navigation/utilities/utilities.js';
 
 const FOCUSABLES = 'a:not(.hide-video), button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
 const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
@@ -82,7 +83,7 @@ function getCustomModal(custom, dialog) {
 }
 
 async function getPathModal(path, dialog) {
-  const block = createTag('a', { href: path });
+  const block = createTag('a', { href: getFederatedUrl(path) });
   dialog.append(block);
 
   // eslint-disable-next-line import/no-cycle


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds support for federated URLs in modals to centralize content for the region selector.

Resolves: https://jira.corp.adobe.com/browse/MWPW-130787

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/blaishram/document?martech=off#langnav
- After: https://MWPW-130787--milo--bandana147.hlx.page/drafts/blaishram/document?martech=off#langnav
