### PR TITLE
Centralize Geo Routing Modals

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -1,5 +1,5 @@
 import {
-  getConfig, getMetadata, loadStyle, loadLana, decorateLinks, localizeLink,
+  getConfig, getMetadata, loadStyle, loadLana, decorateLinks, localizeLink, getFederatedContentRoot,
 } from '../../../utils/utils.js';
 import { processTrackingLabels } from '../../../martech/attributes.js';
 import { replaceText } from '../../../features/placeholders.js';
@@ -7,16 +7,6 @@ import { replaceText } from '../../../features/placeholders.js';
 loadLana();
 
 const FEDERAL_PATH_KEY = 'federal';
-
-// TODO when porting this to milo core, we should define this on config level
-// and allow consumers to add their own origins
-const allowedOrigins = [
-  'https://www.adobe.com',
-  'https://business.adobe.com',
-  'https://blog.adobe.com',
-  'https://milo.adobe.com',
-  'https://news.adobe.com',
-];
 
 export const selectors = {
   globalNav: '.global-navigation',
@@ -83,27 +73,6 @@ export function toFragment(htmlStrings, ...values) {
 
   return fragment;
 }
-
-// TODO we might eventually want to move this to the milo core utilities
-let federatedContentRoot;
-export const getFederatedContentRoot = () => {
-  if (federatedContentRoot) return federatedContentRoot;
-
-  const { origin } = window.location;
-
-  federatedContentRoot = allowedOrigins.some((o) => origin.replace('.stage', '') === o)
-    ? origin
-    : 'https://www.adobe.com';
-
-  if (origin.includes('localhost') || origin.includes('.hlx.')) {
-    // Akamai as proxy to avoid 401s, given AEM-EDS MS auth cross project limitations
-    federatedContentRoot = origin.includes('.hlx.live')
-      ? 'https://main--federal--adobecom.hlx.live'
-      : 'https://www.stage.adobe.com';
-  }
-
-  return federatedContentRoot;
-};
 
 // TODO we should match the akamai patterns /locale/federal/ at the start of the url
 // and make the check more strict.

--- a/libs/features/georouting/georouting.js
+++ b/libs/features/georouting/georouting.js
@@ -129,24 +129,20 @@ async function showModal(details) {
   return getModal(null, { class: 'locale-modal', id: 'locale-modal', content: details, closeEvent: 'closeModal' });
 }
 
-export default async function loadGeoRouting(config, createTag, getMetadata) {
+export default async function loadGeoRouting(config, createTag, getMetadata, geoDetails) {
   const { locale } = config;
 
   const urlLocale = locale.prefix.replace('/', '');
   const storedInter = sessionStorage.getItem('international') || getCookie('international');
   const storedLocale = storedInter === 'us' ? '' : storedInter;
 
-  const resp = await fetch(`${config.contentRoot ?? ''}/georouting.json`);
-  if (!resp.ok) return;
-  const json = await resp.json();
-
-  const urlGeoData = json.data.find((d) => d.prefix === urlLocale);
+  const urlGeoData = geoDetails.data.find((d) => d.prefix === urlLocale);
   if (!urlGeoData) return;
 
   if (storedLocale || storedLocale === '') {
     // Show modal when url and cookie disagree
     if (urlLocale.split('_')[0] !== storedLocale.split('_')[0]) {
-      const localeMatches = json.data.filter((d) => d.prefix === storedLocale);
+      const localeMatches = geoDetails.data.filter((d) => d.prefix === storedLocale);
       const details = await getDetails(urlGeoData, localeMatches, config, createTag, getMetadata);
       if (details) { await showModal(details); }
     }
@@ -156,7 +152,7 @@ export default async function loadGeoRouting(config, createTag, getMetadata) {
   // Show modal when derived countries from url locale and akamai disagree
   const akamaiCode = await getAkamaiCode();
   if (akamaiCode && !getCodes(urlGeoData).includes(akamaiCode)) {
-    const localeMatches = getMatches(json.data, akamaiCode);
+    const localeMatches = getMatches(geoDetails.data, akamaiCode);
     const details = await getDetails(urlGeoData, localeMatches, config, createTag, getMetadata);
     if (details) { await showModal(details); }
   }

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -287,7 +287,7 @@ export default async function loadGeoRouting(
   if (!resp.ok) {
     resp = await fetch(`${config.contentRoot ?? ''}/georouting.json`);
     if (!resp.ok) {
-      resp = await fetch(`${getFederatedContentRoot()}/georouting/georoutingv2.json`);
+      resp = await fetch(`${getFederatedContentRoot()}/federal/georouting/georoutingv2.json`);
       if (!resp.ok) return;
     } else {
       const json = await resp.json();

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -1,4 +1,4 @@
-import { getFederatedContentRoot } from '../../blocks/global-navigation/utilities/utilities.js';
+import { getFederatedContentRoot } from '../../utils/utils.js';
 
 let config;
 let createTag;

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -1,3 +1,5 @@
+import { getFederatedContentRoot } from '../../blocks/global-navigation/utilities/utilities.js';
+
 let config;
 let createTag;
 let getMetadata;
@@ -281,12 +283,19 @@ export default async function loadGeoRouting(
   loadBlock = loadBlockFunc;
   loadStyle = loadStyleFunc;
 
-  const resp = await fetch(`${config.contentRoot ?? ''}/georoutingv2.json`);
+  let resp = await fetch(`${config.contentRoot ?? ''}/georoutingv2.json`);
   if (!resp.ok) {
-    // eslint-disable-next-line import/no-cycle
-    const { default: loadGeoRoutingOld } = await import('../georouting/georouting.js');
-    loadGeoRoutingOld(config, createTag, getMetadata);
-    return;
+    resp = await fetch(`${config.contentRoot ?? ''}/georouting.json`);
+    if (!resp.ok) {
+      resp = await fetch(`${getFederatedContentRoot()}/georouting/georoutingv2.json`);
+      if (!resp.ok) return;
+    } else {
+      const json = await resp.json();
+      // eslint-disable-next-line import/no-cycle
+      const { default: loadGeoRoutingOld } = await import('../georouting/georouting.js');
+      loadGeoRoutingOld(config, createTag, getMetadata, json);
+      return;
+    }
   }
   const json = await resp.json();
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1284,7 +1284,7 @@ export const getFederatedContentRoot = () => {
 
   const { origin } = window.location;
 
-  federatedContentRoot = [ ...allowedOrigins, ...defaultAllowedOrigins ].some((o) => origin.replace('.stage', '') === o)
+  federatedContentRoot = [...allowedOrigins, ...defaultAllowedOrigins].some((o) => origin.replace('.stage', '') === o)
     ? origin
     : 'https://www.adobe.com';
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1270,4 +1270,32 @@ export function loadLana(options = {}) {
   window.addEventListener('unhandledrejection', lanaError);
 }
 
+const defaultAllowedOrigins = [
+  'https://www.adobe.com',
+  'https://business.adobe.com',
+  'https://blog.adobe.com',
+  'https://milo.adobe.com',
+];
+
+let federatedContentRoot;
+export const getFederatedContentRoot = () => {
+  const { allowedOrigins } = getConfig();
+  if (federatedContentRoot) return federatedContentRoot;
+
+  const { origin } = window.location;
+
+  federatedContentRoot = { ...allowedOrigins, ...defaultAllowedOrigins }.some((o) => origin.replace('.stage', '') === o)
+    ? origin
+    : 'https://www.adobe.com';
+
+  if (origin.includes('localhost') || origin.includes('.hlx.')) {
+    // Akamai as proxy to avoid 401s, given AEM-EDS MS auth cross project limitations
+    federatedContentRoot = origin.includes('.hlx.live')
+      ? 'https://main--federal--adobecom.hlx.live'
+      : 'https://www.stage.adobe.com';
+  }
+
+  return federatedContentRoot;
+};
+
 export const reloadPage = () => window.location.reload();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1279,7 +1279,7 @@ const defaultAllowedOrigins = [
 
 let federatedContentRoot;
 export const getFederatedContentRoot = () => {
-  const { allowedOrigins } = getConfig();
+  const { allowedOrigins = [] } = getConfig();
   if (federatedContentRoot) return federatedContentRoot;
 
   const { origin } = window.location;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1284,7 +1284,7 @@ export const getFederatedContentRoot = () => {
 
   const { origin } = window.location;
 
-  federatedContentRoot = { ...allowedOrigins, ...defaultAllowedOrigins }.some((o) => origin.replace('.stage', '') === o)
+  federatedContentRoot = [ ...allowedOrigins, ...defaultAllowedOrigins ].some((o) => origin.replace('.stage', '') === o)
     ? origin
     : 'https://www.adobe.com';
 

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -5,7 +5,6 @@ import {
   toFragment,
   getFedsPlaceholderConfig,
   federatePictureSources,
-  getFederatedContentRoot,
   getAnalyticsValue,
   decorateCta,
   hasActiveLink,
@@ -47,15 +46,6 @@ describe('global navigation utilities', () => {
     const fragment2 = toFragment`<span>${fragment}</span>`;
     expect(fragment2.innerHTML).to.equal('<div>test</div>');
     expect(fragment2.tagName).to.equal('SPAN');
-  });
-
-  // No tests for using the the live url and .hlx. urls
-  // as mocking window.location.origin is not possible
-  describe('getFedsContentRoot', () => {
-    it('should return content source for localhost', () => {
-      const contentSource = getFederatedContentRoot();
-      expect(contentSource).to.equal(baseHost);
-    });
   });
 
   describe('federatePictureSources', () => {

--- a/test/features/georouting/georouting.test.js
+++ b/test/features/georouting/georouting.test.js
@@ -2,7 +2,8 @@ import { stub } from 'sinon';
 import { expect } from '@esm-bundle/chai';
 
 const { default: init, getCookie } = await import('../../../libs/features/georouting/georouting.js');
-let { createTag, getMetadata } = await import('../../../libs/utils/utils.js');
+let { getMetadata } = await import('../../../libs/utils/utils.js');
+const { createTag } = await import('../../../libs/utils/utils.js');
 
 const mockConfig = {
   locales: {
@@ -136,7 +137,7 @@ describe('GeoRouting', () => {
 
   it('Does create a modal if detected country from IP is CH and url prefix is US', async () => {
     // prepare
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.not.be.null;
@@ -146,7 +147,7 @@ describe('GeoRouting', () => {
     // prepare
     setUserCountryFromIP('US');
     sessionStorage.setItem('international', 'us');
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.be.null;
@@ -157,7 +158,7 @@ describe('GeoRouting', () => {
   it('If aiming for CH page and IP in Switzerland no modal is shown', async () => {
     // prepare
     mockConfig.locale.prefix = 'ch_de';
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.be.null;
@@ -167,7 +168,7 @@ describe('GeoRouting', () => {
 
   it('If aiming for US page but IP in Switzerland shows CH links and US continue', async () => {
     // prepare
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.not.be.null;
@@ -192,7 +193,7 @@ describe('GeoRouting', () => {
     mockConfig.locale.prefix = 'ch_fr';
     setUserCountryFromIP('US');
     sessionStorage.setItem('international', 'de');
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.not.be.null;
@@ -215,7 +216,7 @@ describe('GeoRouting', () => {
     // prepare
     mockConfig.locale.prefix = 'mena_en';
     setUserCountryFromIP('BW');
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.not.be.null;
@@ -239,7 +240,7 @@ describe('GeoRouting', () => {
     mockConfig.locale.prefix = 'mena_en';
     setUserCountryFromIP('BW');
     document.cookie = 'international=ch_de;path=/';
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.not.be.null;
@@ -262,7 +263,7 @@ describe('GeoRouting', () => {
     // prepare
     mockConfig.locale.prefix = 'ch_de';
     sessionStorage.setItem('international', 'ch_fr');
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     mockConfig.locale.prefix = '';
@@ -272,7 +273,7 @@ describe('GeoRouting', () => {
   it('If IP is from an unknown country no modal is show', async () => {
     // prepare
     setUserCountryFromIP('NOEXIST');
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.be.null;
@@ -284,7 +285,7 @@ describe('GeoRouting', () => {
     // prepare
     stubFallbackMetadata('off');
     stubHeadRequestToReturnVal('/ch_it', false);
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.not.be.null;
@@ -308,7 +309,7 @@ describe('GeoRouting', () => {
   it('Will show fallback links if fallbackrouting is on and page exist request fails', async () => {
     // prepare
     stubHeadRequestToReturnVal('/ch_it', false);
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.not.be.null;
@@ -328,7 +329,7 @@ describe('GeoRouting', () => {
     stubHeadRequestToReturnVal('/ch_de', false);
     stubHeadRequestToReturnVal('/ch_it', false);
     stubHeadRequestToReturnVal('/ch_fr', false);
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.be.null;
@@ -341,7 +342,7 @@ describe('GeoRouting', () => {
 
   it('Sets international and georouting_presented cookies on link click in modal', async () => {
     // prepare
-    await init(mockConfig, createTag, getMetadata);
+    await init(mockConfig, createTag, getMetadata, mockGeoroutingJson);
     const modal = document.querySelector('.dialog-modal');
     const cookie = getCookie('international');
     const storage = sessionStorage.getItem('international');

--- a/test/features/georoutingv2/georoutingv2.test.js
+++ b/test/features/georoutingv2/georoutingv2.test.js
@@ -632,9 +632,9 @@ describe('GeoRouting', () => {
   it('Will load georouting even if georoutingv2 and georouting file is not found', async () => {
     stubFetchForGeorouting(false);
     stubFetchForGeoroutingOld(false);
-    stubFetchForFederalGeorouting()
+    stubFetchForFederalGeorouting();
     await init(mockConfig, createTag, getMetadata, loadBlock, loadStyle);
     const modal = document.querySelector('.dialog-modal');
     expect(modal).to.not.be.null;
-  })
+  });
 });

--- a/test/features/georoutingv2/georoutingv2.test.js
+++ b/test/features/georoutingv2/georoutingv2.test.js
@@ -3,8 +3,9 @@ import { expect } from '@esm-bundle/chai';
 import { setViewport } from '@web/test-runner-commands';
 
 const { default: init, getCookie } = await import('../../../libs/features/georoutingv2/georoutingv2.js');
+
 let { getMetadata } = await import('../../../libs/utils/utils.js');
-const { createTag, loadStyle, loadBlock, setConfig } = await import('../../../libs/utils/utils.js');
+const { createTag, loadStyle, loadBlock, setConfig, getFederatedContentRoot } = await import('../../../libs/utils/utils.js');
 
 const mockConfig = {
   locales: {
@@ -212,8 +213,38 @@ function stubHeadRequestToReturnVal(prefix, val) {
   );
 }
 
-const stubFetchForGeorouting = () => {
+const stubFetchForGeorouting = (val) => {
   window.fetch.withArgs('/georoutingv2.json').returns(
+    new Promise((resolve) => {
+      resolve({
+        ok: val,
+        json: () => mockGeoroutingJson,
+      });
+    }),
+  );
+  mockGeoroutingJson.georouting.data.forEach((d) => {
+    const prefix = d.prefix ? `/${d.prefix}` : '';
+    stubHeadRequestToReturnVal(prefix, true);
+  });
+};
+
+const stubFetchForGeoroutingOld = (val) => {
+  window.fetch.withArgs('/georouting.json').returns(
+    new Promise((resolve) => {
+      resolve({
+        ok: val,
+        json: () => mockGeoroutingJson,
+      });
+    }),
+  );
+  mockGeoroutingJson.georouting.data.forEach((d) => {
+    const prefix = d.prefix ? `/${d.prefix}` : '';
+    stubHeadRequestToReturnVal(prefix, true);
+  });
+};
+
+const stubFetchForFederalGeorouting = () => {
+  window.fetch.withArgs(`${getFederatedContentRoot()}/federal/georouting/georoutingv2.json`).returns(
     new Promise((resolve) => {
       resolve({
         ok: true,
@@ -240,7 +271,7 @@ const closeModal = () => {
 describe('GeoRouting', () => {
   before(() => {
     setUserCountryFromIP();
-    stubFetchForGeorouting();
+    stubFetchForGeorouting(true);
     setGeorouting();
   });
   after(() => {
@@ -597,4 +628,13 @@ describe('GeoRouting', () => {
     // cleanup
     setGeorouting('on');
   });
+
+  it('Will load georouting even if georoutingv2 and georouting file is not found', async () => {
+    stubFetchForGeorouting(false);
+    stubFetchForGeoroutingOld(false);
+    stubFetchForFederalGeorouting()
+    await init(mockConfig, createTag, getMetadata, loadBlock, loadStyle);
+    const modal = document.querySelector('.dialog-modal');
+    expect(modal).to.not.be.null;
+  })
 });

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -3,7 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { waitFor, waitForElement } from '../helpers/waitfor.js';
 import { mockFetch } from '../helpers/generalHelpers.js';
-import { createTag } from '../../libs/utils/utils.js';
+import { createTag, getFederatedContentRoot } from '../../libs/utils/utils.js';
 
 const utils = {};
 
@@ -44,6 +44,16 @@ describe('Utils', () => {
       window.fetch = ogFetch;
       // eslint-disable-next-line no-console
       console.log.restore();
+    });
+
+    // No tests for using the the live url and .hlx. urls
+    // as mocking window.location.origin is not possible
+    describe('getFedsContentRoot', () => {
+      const baseHost = 'https://www.stage.adobe.com';
+      it('should return content source for localhost', () => {
+        const contentSource = getFederatedContentRoot();
+        expect(contentSource).to.equal(baseHost);
+      });
     });
 
     describe('Template', () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Picks georouting json from feds folder if georouting and georoutingv2 file is not found in consumers site's folder.
* Addressed 2 todos:
     - Moved _getFederatedContentRoot_ to utils.js
     - Allows consumers to add their own allowed origins

Resolves: https://jira.corp.adobe.com/browse/MWPW-151542

**Test URLs:**
- Before: https://main--genuine--adobecom.hlx.page/georouting?martech=off
- After: https://main--genuine--adobecom.hlx.page/georouting?milolibs=georouting-central--milo--bandana147&martech=off

Since the before is not reproducible in folders in which georouting already exists, so we can't reproduce the before url in milo repo. So adding below urls for psi checks to pass:
- Before: https://main--milo--adobecom.hlx.page/georouting?martech=off
- After: https://georouting-central--milo--bandana147.hlx.page/drafts/blaishram/document1&martech=off
