### PR TITLE
[MWPW-152278] Avoid empty CSS requests

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -92,16 +92,16 @@ const AUTO_BLOCKS = [
   { gist: 'https://gist.github.com' },
   { caas: '/tools/caas' },
   { faas: '/tools/faas' },
-  { fragment: '/fragments/' },
+  { fragment: '/fragments/', voidStyles: true },
   { instagram: 'https://www.instagram.com' },
-  { slideshare: 'https://www.slideshare.net' },
-  { tiktok: 'https://www.tiktok.com' },
+  { slideshare: 'https://www.slideshare.net', voidStyles: true },
+  { tiktok: 'https://www.tiktok.com', voidStyles: true },
   { twitter: 'https://twitter.com' },
   { vimeo: 'https://vimeo.com' },
   { vimeo: 'https://player.vimeo.com' },
   { youtube: 'https://www.youtube.com' },
   { youtube: 'https://youtu.be' },
-  { 'pdf-viewer': '.pdf' },
+  { 'pdf-viewer': '.pdf', voidStyles: true },
   { video: '.mp4' },
   { merch: '/tools/ost?' },
 ];
@@ -448,6 +448,7 @@ export async function loadBlock(block) {
   }
 
   const name = block.classList[0];
+  const voidStyles = block.classList.contains('void-styles');
   const { miloLibs, codeRoot, mep } = getConfig();
 
   const base = miloLibs && MILO_BLOCKS.includes(name) ? miloLibs : codeRoot;
@@ -457,9 +458,9 @@ export async function loadBlock(block) {
 
   const blockPath = `${path}/${name}`;
 
-  const styleLoaded = new Promise((resolve) => {
+  const styleLoaded = !voidStyles ? new Promise((resolve) => {
     loadStyle(`${blockPath}.css`, resolve);
-  });
+  }) : '';
 
   const scriptLoaded = new Promise((resolve) => {
     (async () => {
@@ -477,6 +478,7 @@ export async function loadBlock(block) {
       resolve();
     })();
   });
+
   await Promise.all([styleLoaded, scriptLoaded]);
   return block;
 }
@@ -560,8 +562,8 @@ export function decorateAutoBlock(a) {
     : a.href;
 
   return config.autoBlocks.find((candidate) => {
-    const key = Object.keys(candidate)[0];
-    const match = href.includes(candidate[key]);
+    const [[key, pattern], [, voidStyles] = []] = Object.entries(candidate);
+    const match = href.includes(pattern);
     if (!match) return false;
 
     if (key === 'pdf-viewer' && !a.textContent.includes('.pdf')) {
@@ -608,7 +610,7 @@ export function decorateAutoBlock(a) {
       return false;
     }
 
-    a.className = `${key} link-block`;
+    a.className = `${key} link-block${voidStyles ? ' void-styles' : ''}`;
     return true;
   });
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -92,16 +92,16 @@ const AUTO_BLOCKS = [
   { gist: 'https://gist.github.com' },
   { caas: '/tools/caas' },
   { faas: '/tools/faas' },
-  { fragment: '/fragments/', voidStyles: true },
+  { fragment: '/fragments/', styles: false },
   { instagram: 'https://www.instagram.com' },
-  { slideshare: 'https://www.slideshare.net', voidStyles: true },
-  { tiktok: 'https://www.tiktok.com', voidStyles: true },
+  { slideshare: 'https://www.slideshare.net', styles: false },
+  { tiktok: 'https://www.tiktok.com', styles: false },
   { twitter: 'https://twitter.com' },
   { vimeo: 'https://vimeo.com' },
   { vimeo: 'https://player.vimeo.com' },
   { youtube: 'https://www.youtube.com' },
   { youtube: 'https://youtu.be' },
-  { 'pdf-viewer': '.pdf', voidStyles: true },
+  { 'pdf-viewer': '.pdf', styles: false },
   { video: '.mp4' },
   { merch: '/tools/ost?' },
 ];
@@ -448,7 +448,7 @@ export async function loadBlock(block) {
   }
 
   const name = block.classList[0];
-  const voidStyles = block.classList.contains('void-styles');
+  const hasStyles = AUTO_BLOCKS.find((ab) => Object.keys(ab).includes(name))?.styles ?? true;
   const { miloLibs, codeRoot, mep } = getConfig();
 
   const base = miloLibs && MILO_BLOCKS.includes(name) ? miloLibs : codeRoot;
@@ -458,9 +458,9 @@ export async function loadBlock(block) {
 
   const blockPath = `${path}/${name}`;
 
-  const styleLoaded = !voidStyles ? new Promise((resolve) => {
+  const styleLoaded = hasStyles && new Promise((resolve) => {
     loadStyle(`${blockPath}.css`, resolve);
-  }) : '';
+  });
 
   const scriptLoaded = new Promise((resolve) => {
     (async () => {
@@ -562,8 +562,8 @@ export function decorateAutoBlock(a) {
     : a.href;
 
   return config.autoBlocks.find((candidate) => {
-    const [[key, pattern], [, voidStyles] = []] = Object.entries(candidate);
-    const match = href.includes(pattern);
+    const key = Object.keys(candidate)[0];
+    const match = href.includes(candidate[key]);
     if (!match) return false;
 
     if (key === 'pdf-viewer' && !a.textContent.includes('.pdf')) {
@@ -610,7 +610,7 @@ export function decorateAutoBlock(a) {
       return false;
     }
 
-    a.className = `${key} link-block${voidStyles ? ' void-styles' : ''}`;
+    a.className = `${key} link-block`;
     return true;
   });
 }


### PR DESCRIPTION
It has been noticed that requests are made for empty CSS files. For performance purposes, we want to avoid such requests, since they only add overhead and aren't contributing any advantages.

The initial scope of the story was focused on the `fragments.css` file, but a few more auto blocks follow the same pattern, so it made sense to update all of them in one go. Here are the files in question:
![Screenshot 2024-06-26 at 15 58 07](https://github.com/adobecom/milo/assets/11267498/53b42ae5-c29b-4b8f-a771-2129f88c2973)

Note that `event-rich-results` follows a different pattern and it should not be an issue at this point.

**BEFORE**
Filtering network calls by `/tiktok|slideshare|fragment|marquee/`

![Screenshot 2024-06-26 at 16 21 28](https://github.com/adobecom/milo/assets/11267498/293ceb15-0966-4c2d-a82c-08c6daaf78fc)

**AFTER**
Filtering network calls by `/tiktok|slideshare|fragment|marquee/`

![Screenshot 2024-06-26 at 16 21 58](https://github.com/adobecom/milo/assets/11267498/7255042e-5e51-4fda-86e1-70ea22bbc9b6)

Resolves: [MWPW-152278](https://jira.corp.adobe.com/browse/MWPW-152278)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ramuntea/empty-css-showcase?martech=off&georouting=off
- After: https://no-empty-css-load--milo--overmyheadandbody.hlx.page/drafts/ramuntea/empty-css-showcase?martech=off&georouting=off
