### PR TITLE
MWPW-152280 MEP: Only preload fragments that are in the 1st section

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -111,6 +111,11 @@ export const preloadManifests = ({ targetManifests = [], persManifests = [] }) =
 
 export const getFileName = (path) => path?.split('/').pop();
 
+const isInLcpSection = (el) => {
+  const lcpSection = document.querySelector('body > main > div');
+  return lcpSection === el || lcpSection?.contains(el);
+};
+
 const createFrag = (el, url, manifestId) => {
   let href = url;
   try {
@@ -126,7 +131,9 @@ const createFrag = (el, url, manifestId) => {
   if (isSection) {
     frag = createTag('div', undefined, frag);
   }
-  loadLink(`${localizeLink(a.href)}.plain.html`, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
+  if (isInLcpSection(el)) {
+    loadLink(`${localizeLink(a.href)}.plain.html`, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
+  }
   return frag;
 };
 

--- a/test/features/personalization/actions.test.js
+++ b/test/features/personalization/actions.test.js
@@ -263,4 +263,26 @@ describe('custom actions', async () => {
       },
     });
   });
+
+  it('Only fragments in the first section should be preloaded', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
+
+    let manifestJson = await readFile({ path: './mocks/actions/manifestPreloadFrags.json' });
+    manifestJson = JSON.parse(manifestJson);
+    setFetchResponse(manifestJson);
+
+    // This fragment is in the 1st section and should be preloaded
+    const lcpLink = 'link[href^="/test/features/personalization/mocks/fragments/fragmentReplaced"]';
+
+    // This fragment is in the 3rd section and should not be preloaded
+    const notLcpLink = 'link[href^="/test/features/personalization/mocks/fragments/inlineFragReplaced"]';
+
+    expect(document.querySelector(lcpLink)).not.to.exist;
+    expect(document.querySelector(notLcpLink)).not.to.exist;
+
+    await applyPers([{ manifestPath: '/path/to/manifest.json' }]);
+
+    expect(document.querySelector(lcpLink)).to.exist;
+    expect(document.querySelector(notLcpLink)).not.to.exist;
+  });
 });

--- a/test/features/personalization/mocks/actions/manifestPreloadFrags.json
+++ b/test/features/personalization/mocks/actions/manifestPreloadFrags.json
@@ -1,0 +1,28 @@
+{
+  "total": 5,
+  "offset": 0,
+  "limit": 5,
+  "data": [
+    {
+      "action": "replace",
+      "selector": ".custom-block",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "chrome": "/test/features/personalization/mocks/fragments/fragmentReplaced",
+      "firefox": "",
+      "android": "",
+      "ios": ""
+    },
+    {
+      "action": "replace",
+      "selector": ".how-to",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "chrome": "/test/features/personalization/mocks/fragments/inlineFragReplaced",
+      "firefox": "",
+      "android": "",
+      "ios": ""
+    }
+  ],
+  ":type": "sheet"
+}


### PR DESCRIPTION
MEP was preloading all fragments that would be changed in the page, but only the first section fragments should be pre-loaded to improve LCP

Resolves: [MWPW-152280](https://jira.corp.adobe.com/browse/MWPW-152280)

Before:
![Screenshot 2024-06-26 at 4 02 37 PM](https://github.com/adobecom/milo/assets/9143715/273f8e67-649e-4ed2-8941-f4d8b13967b3)

![Screenshot 2024-06-26 at 4 16 05 PM](https://github.com/adobecom/milo/assets/9143715/133b264d-1feb-41cd-b85e-7a67998a952f)

After:
![Screenshot 2024-06-26 at 4 03 57 PM](https://github.com/adobecom/milo/assets/9143715/68c00983-17a2-4ab0-86c6-82c9fe1e258e)

![Screenshot 2024-06-26 at 4 15 21 PM](https://github.com/adobecom/milo/assets/9143715/f7ea83ca-2d8e-4c50-8131-75f1a2913df5)


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/pers/mwpw152280
- After: https://meps-fragments--milo--adobecom.hlx.page/drafts/cpeyer/pers/mwpw152280
