### PR TITLE
MWPW-153657: Set the strikethrough price font size to 14px only in merch cards

### DIFF
--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -8,8 +8,6 @@ span[data-wcs-osi] {
 }
 
 span.placeholder-resolved[data-template="strikethrough"], span.price.price-strikethrough {
-  font-size: var(--type-body-xs-size);
-  font-weight: normal;
   text-decoration: line-through;
 }
 

--- a/libs/deps/merch-card.js
+++ b/libs/deps/merch-card.js
@@ -1,4 +1,4 @@
-// branch: main commit: fbbefe1b71216b73b1e41d50997927fbc7340473 Tue, 25 Jun 2024 15:33:55 GMT
+// branch: mwpw-153657-strikethrough-price commit: a4b3571cfb1b27fca625181cb343f207e60f233c Thu, 27 Jun 2024 13:37:14 GMT
 import{html as a,LitElement as j}from"/libs/deps/lit-all.min.js";import{LitElement as q,html as T,css as F}from"/libs/deps/lit-all.min.js";var s=class extends q{static properties={size:{type:String,attribute:!0},src:{type:String,attribute:!0},alt:{type:String,attribute:!0},href:{type:String,attribute:!0}};constructor(){super(),this.size="m",this.alt=""}render(){let{href:e}=this;return e?T`<a href="${e}">
                   <img src="${this.src}" alt="${this.alt}" loading="lazy" />
               </a>`:T` <img src="${this.src}" alt="${this.alt}" loading="lazy" />`}static styles=F`
@@ -25,378 +25,380 @@ import{html as a,LitElement as j}from"/libs/deps/lit-all.min.js";import{LitEleme
             height: var(--img-height);
         }
     `};customElements.define("merch-icon",s);import{css as k,unsafeCSS as u}from"/libs/deps/lit-all.min.js";var f="(max-width: 767px)",y="(max-width: 1199px)",i="(min-width: 768px)",c="(min-width: 1200px)",h="(min-width: 1600px)";var A=k`
-    :host {
-        position: relative;
-        display: flex;
-        flex-direction: column;
-        text-align: start;
-        background-color: var(--consonant-merch-card-background-color);
-        grid-template-columns: repeat(auto-fit, minmax(300px, max-content));
-        background-color: var(--consonant-merch-card-background-color);
-        font-family: var(--body-font-family, 'Adobe Clean');
-        border-radius: var(--consonant-merch-spacing-xs);
-        border: 1px solid var(--consonant-merch-card-border-color);
-        box-sizing: border-box;
-    }
+  :host {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    text-align: start;
+    background-color: var(--consonant-merch-card-background-color);
+    grid-template-columns: repeat(auto-fit, minmax(300px, max-content));
+    background-color: var(--consonant-merch-card-background-color);
+    font-family: var(--body-font-family, 'Adobe Clean');
+    border-radius: var(--consonant-merch-spacing-xs);
+    border: 1px solid var(--consonant-merch-card-border-color);
+    box-sizing: border-box;
+  }
 
-    :host(.placeholder) {
-        visibility: hidden;
-    }
+  :host(.placeholder) {
+    visibility: hidden;
+  }
 
-    :host([variant='special-offers']) {
-        min-height: 439px;
-    }
+  :host([variant='special-offers']) {
+    min-height: 439px;
+  }
 
-    :host([variant='catalog']) {
-        min-height: 330px;
-    }
+  :host([variant='catalog']) {
+    min-height: 330px;
+  }
 
-    :host([variant='plans']) {
-        min-height: 348px;
-    }
+  :host([variant='plans']) {
+    min-height: 348px;
+  }
 
-    :host([variant='segment']) {
-        min-height: 214px;
-    }
+  :host([variant='segment']) {
+    min-height: 214px;
+  }
 
-    :host([aria-selected]) {
-        outline: none;
-        box-sizing: border-box;
-        box-shadow: inset 0 0 0 2px var(--color-accent);
-    }
+  :host([aria-selected]) {
+    outline: none;
+    box-sizing: border-box;
+    box-shadow: inset 0 0 0 2px var(--color-accent);
+  }
 
-    .invisible {
-        visibility: hidden;
-    }
+  .invisible {
+    visibility: hidden;
+  }
 
-    :host(:hover) .invisible {
-        visibility: visible;
-        background-image: var(--ellipsis-icon);
-        cursor: pointer;
-    }
+  :host(:hover) .invisible {
+    visibility: visible;
+    background-image: var(--ellipsis-icon);
+    cursor: pointer;
+  }
 
-    .action-menu.always-visible {
-        visibility: visible;
-        background-image: var(--ellipsis-icon);
-    }
+  .action-menu.always-visible {
+    visibility: visible;
+    background-image: var(--ellipsis-icon);
+  }
 
-    :host([variant='mini-compare-chart']) > slot:not([name='icons']) {
-        display: block;
-    }
+  :host([variant='mini-compare-chart']) > slot:not([name='icons']) {
+    display: block;
+  }
 
-    .top-section {
-        display: flex;
-        justify-content: flex-start;
-        align-items: flex-start;
-        gap: 16px;
-    }
+  .top-section {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 16px;
+  }
 
-    .top-section.badge {
-        min-height: 32px;
-    }
+  .top-section.badge {
+    min-height: 32px;
+  }
 
-    .body {
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-start;
-        height: 100%;
-        gap: var(--consonant-merch-spacing-xxs);
-        padding: var(--consonant-merch-spacing-xs);
-    }
+  .body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    height: 100%;
+    gap: var(--consonant-merch-spacing-xxs);
+    padding: var(--consonant-merch-spacing-xs);
+  }
 
-    footer {
-        display: flex;
-        justify-content: flex-end;
-        box-sizing: border-box;
-        align-items: flex-end;
-        width: 100%;
-        flex-flow: wrap;
-        gap: var(--consonant-merch-spacing-xs);
+  footer {
+    display: flex;
+    justify-content: flex-end;
+    box-sizing: border-box;
+    align-items: flex-end;
+    width: 100%;
+    flex-flow: wrap;
+    gap: var(--consonant-merch-spacing-xs);
 
-        padding: var(--consonant-merch-spacing-xs);
-    }
+    padding: var(--consonant-merch-spacing-xs);
+  }
 
-    hr {
-        background-color: var(--color-gray-200);
-        border: none;
-        height: 1px;
-        width: auto;
-        margin-top: 0;
-        margin-bottom: 0;
-        margin-left: var(--consonant-merch-spacing-xs);
-        margin-right: var(--consonant-merch-spacing-xs);
-    }
+  hr {
+    background-color: var(--color-gray-200);
+    border: none;
+    height: 1px;
+    width: auto;
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: var(--consonant-merch-spacing-xs);
+    margin-right: var(--consonant-merch-spacing-xs);
+  }
 
-    div[class$='-badge'] {
-        position: absolute;
-        top: 16px;
-        right: 0;
-        font-size: var(--type-heading-xxs-size);
-        font-weight: 500;
-        max-width: 180px;
-        line-height: 16px;
-        text-align: center;
-        padding: 8px 11px;
-        border-radius: 5px 0 0 5px;
-    }
+  div[class$='-badge'] {
+    position: absolute;
+    top: 16px;
+    right: 0;
+    font-size: var(--type-heading-xxs-size);
+    font-weight: 500;
+    max-width: 180px;
+    line-height: 16px;
+    text-align: center;
+    padding: 8px 11px;
+    border-radius: 5px 0 0 5px;
+  }
 
-    div[class$='-badge']:dir(rtl) {
-        left: 0;
-        right: initial;
-        padding: 8px 11px;
-        border-radius: 0 5px 5px 0;
-    }
+  div[class$='-badge']:dir(rtl) {
+    left: 0;
+    right: initial;
+    padding: 8px 11px;
+    border-radius: 0 5px 5px 0;
+  }
 
-    .body .catalog-badge {
-        display: flex;
-        height: fit-content;
-        flex-direction: column;
-        width: fit-content;
-        border-radius: 5px;
-        position: relative;
-        top: 0;
-        margin-left: var(--consonant-merch-spacing-xxs);
-    }
+  .body .catalog-badge {
+    display: flex;
+    height: fit-content;
+    flex-direction: column;
+    width: fit-content;
+    border-radius: 5px;
+    position: relative;
+    top: 0;
+    margin-left: var(--consonant-merch-spacing-xxs);
+  }
 
-    .detail-bg-container {
-        right: 0;
-        padding: var(--consonant-merch-spacing-xs);
-        border-radius: 5px;
-        font-size: var(--consonant-merch-card-body-font-size);
-        margin: var(--consonant-merch-spacing-xs);
-    }
+  .detail-bg-container {
+    right: 0;
+    padding: var(--consonant-merch-spacing-xs);
+    border-radius: 5px;
+    font-size: var(--consonant-merch-card-body-font-size);
+    margin: var(--consonant-merch-spacing-xs);
+  }
 
-    .action-menu {
-        display: flex;
-        width: 32px;
-        height: 32px;
-        position: absolute;
-        top: 16px;
-        right: 16px;
-        background-color: #f6f6f6;
-        background-repeat: no-repeat;
-        background-position: center;
-        background-size: 16px 16px;
-    }
-    .hidden {
-        visibility: hidden;
-    }
+  .action-menu {
+    display: flex;
+    width: 32px;
+    height: 32px;
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    background-color: #f6f6f6;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 16px 16px;
+  }
+  .hidden {
+    visibility: hidden;
+  }
 
-    #stock-checkbox,
-    .secure-transaction-label {
-        font-size: var(--consonant-merch-card-body-xxs-font-size);
-        line-height: 1.3;
-        color: var(--color-gray-600);
-    }
+  #stock-checkbox,
+  .secure-transaction-label {
+    font-size: var(--consonant-merch-card-body-xxs-font-size);
+    line-height: 1.3;
+    color: var(--color-gray-600);
+  }
 
-    #stock-checkbox {
-        display: inline-flex;
-        align-items: center;
-        cursor: pointer;
-        gap: 10px; /*same as spectrum */
-    }
+  #stock-checkbox {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    gap: 10px; /*same as spectrum */
+  }
 
-    #stock-checkbox > input {
-        display: none;
-    }
+  #stock-checkbox > input {
+    display: none;
+  }
 
-    #stock-checkbox > span {
-        display: inline-block;
-        box-sizing: border-box;
-        border: 2px solid rgb(117, 117, 117);
-        border-radius: 2px;
-        width: 14px;
-        height: 14px;
-    }
+  #stock-checkbox > span {
+    display: inline-block;
+    box-sizing: border-box;
+    border: 2px solid rgb(117, 117, 117);
+    border-radius: 2px;
+    width: 14px;
+    height: 14px;
+  }
 
-    #stock-checkbox > input:checked + span {
-        background: var(--checkmark-icon) no-repeat var(--color-accent);
-        border-color: var(--color-accent);
-    }
+  #stock-checkbox > input:checked + span {
+    background: var(--checkmark-icon) no-repeat var(--color-accent);
+    border-color: var(--color-accent);
+  }
 
-    .secure-transaction-label {
-        white-space: nowrap;
-        display: inline-flex;
-        gap: var(--consonant-merch-spacing-xxs);
-        align-items: center;
-        flex: 1;
-        height: 100%;
-        line-height: normal;
-    }
+  .secure-transaction-label {
+    white-space: nowrap;
+    display: inline-flex;
+    gap: var(--consonant-merch-spacing-xxs);
+    align-items: center;
+    flex: 1;
+    height: 100%;
+    line-height: normal;
+  }
 
-    .secure-transaction-label::before {
-        display: inline-block;
-        content: '';
-        width: 12px;
-        height: 15px;
-        background: var(--secure-icon) no-repeat;
-        background-position: center;
-        background-size: contain;
-    }
+  .secure-transaction-label::before {
+    display: inline-block;
+    content: '';
+    width: 12px;
+    height: 15px;
+    background: var(--secure-icon) no-repeat;
+    background-position: center;
+    background-size: contain;
+  }
 
-    .checkbox-container {
-        display: flex;
-        align-items: center;
-        gap: var(--consonant-merch-spacing-xxs);
-    }
+  .checkbox-container {
+    display: flex;
+    align-items: center;
+    gap: var(--consonant-merch-spacing-xxs);
+  }
 
-    .checkbox-container input[type='checkbox']:checked + .checkmark {
-        background-color: var(--color-accent);
-        background-image: var(--checkmark-icon);
-        border-color: var(--color-accent);
-    }
+  .checkbox-container input[type='checkbox']:checked + .checkmark {
+    background-color: var(--color-accent);
+    background-image: var(--checkmark-icon);
+    border-color: var(--color-accent);
+  }
 
-    .checkbox-container input[type='checkbox'] {
-        display: none;
-    }
+  .checkbox-container input[type='checkbox'] {
+    display: none;
+  }
 
-    .checkbox-container .checkmark {
-        position: relative;
-        display: inline-block;
-        width: 12px;
-        height: 12px;
-        border: 2px solid #757575;
-        background: #fff;
-        border-radius: 2px;
-        cursor: pointer;
-        margin-top: 2px;
-    }
+  .checkbox-container .checkmark {
+    position: relative;
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border: 2px solid #757575;
+    background: #fff;
+    border-radius: 2px;
+    cursor: pointer;
+    margin-top: 2px;
+  }
 
-    .twp-badge {
-        padding: 4px 10px 5px 10px;
-    }
+  .twp-badge {
+    padding: 4px 10px 5px 10px;
+  }
 
-    :host([aria-selected]) .twp-badge {
-        margin-inline-end: 2px;
-        padding-inline-end: 9px;
-    }
+  :host([aria-selected]) .twp-badge {
+    margin-inline-end: 2px;
+    padding-inline-end: 9px;
+  }
 
-    :host([variant='twp']) {
-        padding: 4px 10px 5px 10px;
-    }
+  :host([variant='twp']) {
+    padding: 4px 10px 5px 10px;
+  }
 
-    slot[name='icons'] {
-        display: flex;
-        gap: 8px;
-    }
+  slot[name='icons'] {
+    display: flex;
+    gap: 8px;
+  }
 
-    :host([variant='twp']) ::slotted(merch-offer-select) {
-        display: none;
-    }
+  :host([variant='twp']) ::slotted(merch-offer-select) {
+    display: none;
+  }
 
-    :host([variant='twp']) .top-section {
-        flex: 0;
-        display: flex;
-        flex-direction: column;
-        justify-content: flex-start;
-        height: 100%;
-        gap: var(--consonant-merch-spacing-xxs);
-        padding: var(--consonant-merch-spacing-xs)
-            var(--consonant-merch-spacing-xs) var(--consonant-merch-spacing-xs)
-            var(--consonant-merch-spacing-xs);
-        align-items: flex-start;
-    }
+  :host([variant='twp']) .top-section {
+    flex: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    height: 100%;
+    gap: var(--consonant-merch-spacing-xxs);
+    padding: var(--consonant-merch-spacing-xs)
+        var(--consonant-merch-spacing-xs) var(--consonant-merch-spacing-xs)
+        var(--consonant-merch-spacing-xs);
+    align-items: flex-start;
+  }
 
-    :host([variant='twp']) .body {
-        padding: 0 var(--consonant-merch-spacing-xs);
-    }
+  :host([variant='twp']) .body {
+    padding: 0 var(--consonant-merch-spacing-xs);
+  }
 
-    :host([variant='twp']) footer {
-        gap: var(--consonant-merch-spacing-xxs);
-        flex-direction: column;
-        align-self: flex-start;
-    }
+  :host([variant='twp']) footer {
+    gap: var(--consonant-merch-spacing-xxs);
+    flex-direction: column;
+    align-self: flex-start;
+  }
 
-    :host([variant='special-offers'].center) {
-        text-align: center;
-    }
+  :host([variant='special-offers'].center) {
+    text-align: center;
+  }
 
-    /* plans */
-    :host([variant='plans']) {
-        min-height: 348px;
-    }
+  /* plans */
+  :host([variant='plans']) {
+    min-height: 348px;
+  }
 
-    :host([variant='mini-compare-chart']) footer {
-        min-height: var(--consonant-merch-card-mini-compare-footer-height);
-        padding: var(--consonant-merch-spacing-xs);
-    }
+  :host([variant='mini-compare-chart']) footer {
+    min-height: var(--consonant-merch-card-mini-compare-footer-height);
+    padding: var(--consonant-merch-spacing-xs);
+  }
 
-    /* mini-compare card  */
+  /* mini-compare card  */
+  :host([variant='mini-compare-chart']) .top-section {
+    padding-top: var(--consonant-merch-spacing-s);
+    padding-inline-start: var(--consonant-merch-spacing-s);
+    height: var(--consonant-merch-card-mini-compare-top-section-height);
+  }
+
+  @media screen and ${u(y)} {
+    [class*'-merch-cards'] :host([variant='mini-compare-chart']) footer {
+      flex-direction: column;
+      align-items: stretch;
+      text-align: center;
+    }
+  }
+
+  @media screen and ${u(f)} {
     :host([variant='mini-compare-chart']) .top-section {
-        padding-top: var(--consonant-merch-spacing-s);
-        padding-inline-start: var(--consonant-merch-spacing-s);
-        height: var(--consonant-merch-card-mini-compare-top-section-height);
+      padding-top: var(--consonant-merch-spacing-xs);
     }
+    :host([variant='mini-compare-chart']) .mini-compare-chart-badge {
+      font-size: var(--consonant-merch-card-detail-font-size);
+      padding: 6px 8px;
+      top: 10px;
+    }
+  }
+  @media screen and ${u(c)} {
+    :host([variant='mini-compare-chart']) footer {
+      padding: var(--consonant-merch-spacing-xs)
+        var(--consonant-merch-spacing-s)
+        var(--consonant-merch-spacing-s)
+        var(--consonant-merch-spacing-s);
+    }
+  }
 
-    @media screen and ${u(y)} {
-        [class*'-merch-cards'] :host([variant='mini-compare-chart']) footer {
-            flex-direction: column;
-            align-items: stretch;
-            text-align: center;
-        }
-    }
+  :host([variant='mini-compare-chart']) slot[name='footer-rows'] {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: end;
+  }
+  /* mini-compare card heights for the slots: heading-m, body-m, heading-m-price, price-commitment, offers, promo-text, footer */
+  :host([variant='mini-compare-chart']) slot[name='heading-m'] {
+    min-height: var(--consonant-merch-card-mini-compare-heading-m-height);
+  }
+  :host([variant='mini-compare-chart']) slot[name='body-m'] {
+    min-height: var(--consonant-merch-card-mini-compare-body-m-height);
+  }
+  :host([variant='mini-compare-chart']) slot[name='heading-m-price'] {
+      min-height: var(
+          --consonant-merch-card-mini-compare-heading-m-price-height
+      );
+  }
+  :host([variant='mini-compare-chart']) slot[name='price-commitment'] {
+    min-height: var(
+      --consonant-merch-card-mini-compare-price-commitment-height
+    );
+  }
+  :host([variant='mini-compare-chart']) slot[name='offers'] {
+    min-height: var(--consonant-merch-card-mini-compare-offers-height);
+  }
+  :host([variant='mini-compare-chart']) slot[name='promo-text'] {
+    min-height: var(--consonant-merch-card-mini-compare-promo-text-height);
+  }
 
-    @media screen and ${u(f)} {
-        :host([variant='mini-compare-chart']) .top-section {
-            padding-top: var(--consonant-merch-spacing-xs);
-        }
-        :host([variant='mini-compare-chart']) .mini-compare-chart-badge {
-            font-size: var(--consonant-merch-card-detail-font-size);
-            padding: 6px 8px;
-            top: 10px;
-        }
-    }
-    @media screen and ${u(c)} {
-        :host([variant='mini-compare-chart']) footer {
-            padding: var(--consonant-merch-spacing-xs)
-                var(--consonant-merch-spacing-s)
-                var(--consonant-merch-spacing-s)
-                var(--consonant-merch-spacing-s);
-        }
-    }
-
-    :host([variant='mini-compare-chart']) slot[name='footer-rows'] {
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-        justify-content: end;
-    }
-    /* mini-compare card heights for the slots: heading-m, body-m, heading-m-price, price-commitment, offers, promo-text, footer */
-    :host([variant='mini-compare-chart']) slot[name='heading-m'] {
-        min-height: var(--consonant-merch-card-mini-compare-heading-m-height);
-    }
-    :host([variant='mini-compare-chart']) slot[name='body-m'] {
-        min-height: var(--consonant-merch-card-mini-compare-body-m-height);
-    }
-    :host([variant='mini-compare-chart']) slot[name='heading-m-price'] {
-        min-height: var(
-            --consonant-merch-card-mini-compare-heading-m-price-height
-        );
-    }
-    :host([variant='mini-compare-chart']) slot[name='price-commitment'] {
-        min-height: var(
-            --consonant-merch-card-mini-compare-price-commitment-height
-        );
-    }
-    :host([variant='mini-compare-chart']) slot[name='offers'] {
-        min-height: var(--consonant-merch-card-mini-compare-offers-height);
-    }
-    :host([variant='mini-compare-chart']) slot[name='promo-text'] {
-        min-height: var(--consonant-merch-card-mini-compare-promo-text-height);
-    }
-
-    :host([variant='plans']) ::slotted([slot='heading-xs']),
-    :host([variant='segment']) ::slotted([slot='heading-xs']) {
-        max-width: var(--consonant-merch-card-heading-xs-max-width, 100%);
-    }
+  :host([variant='plans']) ::slotted([slot='heading-xs']),
+  :host([variant='segment']) ::slotted([slot='heading-xs']) {
+    max-width: var(--consonant-merch-card-heading-xs-max-width, 100%);
+  }
 `,R=()=>{let p=[k`
         /* Tablet */
         @media screen and ${u(i)} {
             :host([size='wide']),
             :host([size='super-wide']) {
-                grid-column: span 2;
+                grid-column: span 3;
                 width: 100%;
+                max-width: var(--consonant-merch-card-tablet-wide-width);
+                margin: 0 auto;
             }
         }
 
@@ -406,13 +408,13 @@ import{html as a,LitElement as j}from"/libs/deps/lit-all.min.js";import{LitEleme
                 grid-column: span 3;
             }
         `];return p.push(k`
-        /* Large desktop */
-        @media screen and ${u(h)} {
-            :host([size='super-wide']) {
-                grid-column: span 4;
-            }
-        }
-    `),p};var[_,M,O,L,N,te]=["ArrowLeft","ArrowRight","ArrowUp","ArrowDown","Enter","Tab"];var P=document.createElement("style");P.innerHTML=`
+    /* Large desktop */
+    @media screen and ${u(h)} {
+      :host([size='super-wide']) {
+        grid-column: span 4;
+      }
+    }
+  `),p};var[_,M,O,L,N,te]=["ArrowLeft","ArrowRight","ArrowUp","ArrowDown","Enter","Tab"];var P=document.createElement("style");P.innerHTML=`
 :root {
     --consonant-merch-card-detail-font-size: 12px;
     --consonant-merch-card-detail-font-weight: 500;
@@ -428,6 +430,7 @@ import{html as a,LitElement as j}from"/libs/deps/lit-all.min.js";import{LitEleme
 
     /* responsive width */
     --consonant-merch-card-mobile-width: 300px;
+    --consonant-merch-card-tablet-wide-width: 700px;
 
     /* spacing */
     --consonant-merch-spacing-xxxs: 4px;
@@ -798,11 +801,6 @@ merch-card[variant="mini-compare-chart"] [is="inline-price"] {
     min-width: 1px;
 }
 
-merch-card[variant="mini-compare-chart"] span.placeholder-resolved[data-template="strikethrough"] {
-    font-size: var(--consonant-merch-card-body-m-font-size);
-    font-weight: 500;
-}
-
 merch-card[variant="mini-compare-chart"] [slot="price-commitment"] {
     font-size: var(--consonant-merch-card-body-xs-font-size);
     padding: 0 var(--consonant-merch-spacing-s);
@@ -908,8 +906,8 @@ merch-card[variant="mini-compare-chart"] .footer-row-cell-description a {
         padding-bottom: 0;
     }
 
-    merch-card[variant="mini-compare-chart"] span.placeholder-resolved[data-template="strikethrough"] {
-        font-size: var(--consonant-merch-card-body-xs-font-size);
+    html[lang="he"] merch-card[variant="mini-compare-chart"] [is="inline-price"] .price-recurrence::before {
+        content: "\\200B";
     }
 
     merch-card[variant="mini-compare-chart"] [slot="price-commitment"] {
@@ -1381,6 +1379,12 @@ merch-card .footer-row-cell:nth-child(8) {
 
 span[is="inline-price"][data-template='strikethrough'] {
     text-decoration: line-through;
+}
+
+merch-card span.placeholder-resolved[data-template='strikethrough'],
+merch-card span.price.price-strikethrough {
+  font-size: var(--consonant-merch-card-body-xs-font-size);
+  font-weight: normal;
 }
 
 /* merch-offer-select */

--- a/libs/deps/merch-card.js
+++ b/libs/deps/merch-card.js
@@ -1,4 +1,4 @@
-// branch: mwpw-153657-strikethrough-price commit: a4b3571cfb1b27fca625181cb343f207e60f233c Thu, 27 Jun 2024 13:37:14 GMT
+// branch: main commit: 258ad3d851cc4945eae2aab2dcc80a8d0c14d861 Fri, 28 Jun 2024 14:19:21 GMT
 import{html as a,LitElement as j}from"/libs/deps/lit-all.min.js";import{LitElement as q,html as T,css as F}from"/libs/deps/lit-all.min.js";var s=class extends q{static properties={size:{type:String,attribute:!0},src:{type:String,attribute:!0},alt:{type:String,attribute:!0},href:{type:String,attribute:!0}};constructor(){super(),this.size="m",this.alt=""}render(){let{href:e}=this;return e?T`<a href="${e}">
                   <img src="${this.src}" alt="${this.alt}" loading="lazy" />
               </a>`:T` <img src="${this.src}" alt="${this.alt}" loading="lazy" />`}static styles=F`
@@ -25,371 +25,371 @@ import{html as a,LitElement as j}from"/libs/deps/lit-all.min.js";import{LitEleme
             height: var(--img-height);
         }
     `};customElements.define("merch-icon",s);import{css as k,unsafeCSS as u}from"/libs/deps/lit-all.min.js";var f="(max-width: 767px)",y="(max-width: 1199px)",i="(min-width: 768px)",c="(min-width: 1200px)",h="(min-width: 1600px)";var A=k`
-  :host {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    text-align: start;
-    background-color: var(--consonant-merch-card-background-color);
-    grid-template-columns: repeat(auto-fit, minmax(300px, max-content));
-    background-color: var(--consonant-merch-card-background-color);
-    font-family: var(--body-font-family, 'Adobe Clean');
-    border-radius: var(--consonant-merch-spacing-xs);
-    border: 1px solid var(--consonant-merch-card-border-color);
-    box-sizing: border-box;
-  }
-
-  :host(.placeholder) {
-    visibility: hidden;
-  }
-
-  :host([variant='special-offers']) {
-    min-height: 439px;
-  }
-
-  :host([variant='catalog']) {
-    min-height: 330px;
-  }
-
-  :host([variant='plans']) {
-    min-height: 348px;
-  }
-
-  :host([variant='segment']) {
-    min-height: 214px;
-  }
-
-  :host([aria-selected]) {
-    outline: none;
-    box-sizing: border-box;
-    box-shadow: inset 0 0 0 2px var(--color-accent);
-  }
-
-  .invisible {
-    visibility: hidden;
-  }
-
-  :host(:hover) .invisible {
-    visibility: visible;
-    background-image: var(--ellipsis-icon);
-    cursor: pointer;
-  }
-
-  .action-menu.always-visible {
-    visibility: visible;
-    background-image: var(--ellipsis-icon);
-  }
-
-  :host([variant='mini-compare-chart']) > slot:not([name='icons']) {
-    display: block;
-  }
-
-  .top-section {
-    display: flex;
-    justify-content: flex-start;
-    align-items: flex-start;
-    gap: 16px;
-  }
-
-  .top-section.badge {
-    min-height: 32px;
-  }
-
-  .body {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    height: 100%;
-    gap: var(--consonant-merch-spacing-xxs);
-    padding: var(--consonant-merch-spacing-xs);
-  }
-
-  footer {
-    display: flex;
-    justify-content: flex-end;
-    box-sizing: border-box;
-    align-items: flex-end;
-    width: 100%;
-    flex-flow: wrap;
-    gap: var(--consonant-merch-spacing-xs);
-
-    padding: var(--consonant-merch-spacing-xs);
-  }
-
-  hr {
-    background-color: var(--color-gray-200);
-    border: none;
-    height: 1px;
-    width: auto;
-    margin-top: 0;
-    margin-bottom: 0;
-    margin-left: var(--consonant-merch-spacing-xs);
-    margin-right: var(--consonant-merch-spacing-xs);
-  }
-
-  div[class$='-badge'] {
-    position: absolute;
-    top: 16px;
-    right: 0;
-    font-size: var(--type-heading-xxs-size);
-    font-weight: 500;
-    max-width: 180px;
-    line-height: 16px;
-    text-align: center;
-    padding: 8px 11px;
-    border-radius: 5px 0 0 5px;
-  }
-
-  div[class$='-badge']:dir(rtl) {
-    left: 0;
-    right: initial;
-    padding: 8px 11px;
-    border-radius: 0 5px 5px 0;
-  }
-
-  .body .catalog-badge {
-    display: flex;
-    height: fit-content;
-    flex-direction: column;
-    width: fit-content;
-    border-radius: 5px;
-    position: relative;
-    top: 0;
-    margin-left: var(--consonant-merch-spacing-xxs);
-  }
-
-  .detail-bg-container {
-    right: 0;
-    padding: var(--consonant-merch-spacing-xs);
-    border-radius: 5px;
-    font-size: var(--consonant-merch-card-body-font-size);
-    margin: var(--consonant-merch-spacing-xs);
-  }
-
-  .action-menu {
-    display: flex;
-    width: 32px;
-    height: 32px;
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    background-color: #f6f6f6;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: 16px 16px;
-  }
-  .hidden {
-    visibility: hidden;
-  }
-
-  #stock-checkbox,
-  .secure-transaction-label {
-    font-size: var(--consonant-merch-card-body-xxs-font-size);
-    line-height: 1.3;
-    color: var(--color-gray-600);
-  }
-
-  #stock-checkbox {
-    display: inline-flex;
-    align-items: center;
-    cursor: pointer;
-    gap: 10px; /*same as spectrum */
-  }
-
-  #stock-checkbox > input {
-    display: none;
-  }
-
-  #stock-checkbox > span {
-    display: inline-block;
-    box-sizing: border-box;
-    border: 2px solid rgb(117, 117, 117);
-    border-radius: 2px;
-    width: 14px;
-    height: 14px;
-  }
-
-  #stock-checkbox > input:checked + span {
-    background: var(--checkmark-icon) no-repeat var(--color-accent);
-    border-color: var(--color-accent);
-  }
-
-  .secure-transaction-label {
-    white-space: nowrap;
-    display: inline-flex;
-    gap: var(--consonant-merch-spacing-xxs);
-    align-items: center;
-    flex: 1;
-    height: 100%;
-    line-height: normal;
-  }
-
-  .secure-transaction-label::before {
-    display: inline-block;
-    content: '';
-    width: 12px;
-    height: 15px;
-    background: var(--secure-icon) no-repeat;
-    background-position: center;
-    background-size: contain;
-  }
-
-  .checkbox-container {
-    display: flex;
-    align-items: center;
-    gap: var(--consonant-merch-spacing-xxs);
-  }
-
-  .checkbox-container input[type='checkbox']:checked + .checkmark {
-    background-color: var(--color-accent);
-    background-image: var(--checkmark-icon);
-    border-color: var(--color-accent);
-  }
-
-  .checkbox-container input[type='checkbox'] {
-    display: none;
-  }
-
-  .checkbox-container .checkmark {
-    position: relative;
-    display: inline-block;
-    width: 12px;
-    height: 12px;
-    border: 2px solid #757575;
-    background: #fff;
-    border-radius: 2px;
-    cursor: pointer;
-    margin-top: 2px;
-  }
-
-  .twp-badge {
-    padding: 4px 10px 5px 10px;
-  }
-
-  :host([aria-selected]) .twp-badge {
-    margin-inline-end: 2px;
-    padding-inline-end: 9px;
-  }
-
-  :host([variant='twp']) {
-    padding: 4px 10px 5px 10px;
-  }
-
-  slot[name='icons'] {
-    display: flex;
-    gap: 8px;
-  }
-
-  :host([variant='twp']) ::slotted(merch-offer-select) {
-    display: none;
-  }
-
-  :host([variant='twp']) .top-section {
-    flex: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    height: 100%;
-    gap: var(--consonant-merch-spacing-xxs);
-    padding: var(--consonant-merch-spacing-xs)
-        var(--consonant-merch-spacing-xs) var(--consonant-merch-spacing-xs)
-        var(--consonant-merch-spacing-xs);
-    align-items: flex-start;
-  }
-
-  :host([variant='twp']) .body {
-    padding: 0 var(--consonant-merch-spacing-xs);
-  }
-
-  :host([variant='twp']) footer {
-    gap: var(--consonant-merch-spacing-xxs);
-    flex-direction: column;
-    align-self: flex-start;
-  }
-
-  :host([variant='special-offers'].center) {
-    text-align: center;
-  }
-
-  /* plans */
-  :host([variant='plans']) {
-    min-height: 348px;
-  }
-
-  :host([variant='mini-compare-chart']) footer {
-    min-height: var(--consonant-merch-card-mini-compare-footer-height);
-    padding: var(--consonant-merch-spacing-xs);
-  }
-
-  /* mini-compare card  */
-  :host([variant='mini-compare-chart']) .top-section {
-    padding-top: var(--consonant-merch-spacing-s);
-    padding-inline-start: var(--consonant-merch-spacing-s);
-    height: var(--consonant-merch-card-mini-compare-top-section-height);
-  }
-
-  @media screen and ${u(y)} {
-    [class*'-merch-cards'] :host([variant='mini-compare-chart']) footer {
-      flex-direction: column;
-      align-items: stretch;
-      text-align: center;
+    :host {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        text-align: start;
+        background-color: var(--consonant-merch-card-background-color);
+        grid-template-columns: repeat(auto-fit, minmax(300px, max-content));
+        background-color: var(--consonant-merch-card-background-color);
+        font-family: var(--body-font-family, 'Adobe Clean');
+        border-radius: var(--consonant-merch-spacing-xs);
+        border: 1px solid var(--consonant-merch-card-border-color);
+        box-sizing: border-box;
     }
-  }
 
-  @media screen and ${u(f)} {
-    :host([variant='mini-compare-chart']) .top-section {
-      padding-top: var(--consonant-merch-spacing-xs);
+    :host(.placeholder) {
+        visibility: hidden;
     }
-    :host([variant='mini-compare-chart']) .mini-compare-chart-badge {
-      font-size: var(--consonant-merch-card-detail-font-size);
-      padding: 6px 8px;
-      top: 10px;
+
+    :host([variant='special-offers']) {
+        min-height: 439px;
     }
-  }
-  @media screen and ${u(c)} {
+
+    :host([variant='catalog']) {
+        min-height: 330px;
+    }
+
+    :host([variant='plans']) {
+        min-height: 348px;
+    }
+
+    :host([variant='segment']) {
+        min-height: 214px;
+    }
+
+    :host([aria-selected]) {
+        outline: none;
+        box-sizing: border-box;
+        box-shadow: inset 0 0 0 2px var(--color-accent);
+    }
+
+    .invisible {
+        visibility: hidden;
+    }
+
+    :host(:hover) .invisible {
+        visibility: visible;
+        background-image: var(--ellipsis-icon);
+        cursor: pointer;
+    }
+
+    .action-menu.always-visible {
+        visibility: visible;
+        background-image: var(--ellipsis-icon);
+    }
+
+    :host([variant='mini-compare-chart']) > slot:not([name='icons']) {
+        display: block;
+    }
+
+    .top-section {
+        display: flex;
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 16px;
+    }
+
+    .top-section.badge {
+        min-height: 32px;
+    }
+
+    .body {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        height: 100%;
+        gap: var(--consonant-merch-spacing-xxs);
+        padding: var(--consonant-merch-spacing-xs);
+    }
+
+    footer {
+        display: flex;
+        justify-content: flex-end;
+        box-sizing: border-box;
+        align-items: flex-end;
+        width: 100%;
+        flex-flow: wrap;
+        gap: var(--consonant-merch-spacing-xs);
+
+        padding: var(--consonant-merch-spacing-xs);
+    }
+
+    hr {
+        background-color: var(--color-gray-200);
+        border: none;
+        height: 1px;
+        width: auto;
+        margin-top: 0;
+        margin-bottom: 0;
+        margin-left: var(--consonant-merch-spacing-xs);
+        margin-right: var(--consonant-merch-spacing-xs);
+    }
+
+    div[class$='-badge'] {
+        position: absolute;
+        top: 16px;
+        right: 0;
+        font-size: var(--type-heading-xxs-size);
+        font-weight: 500;
+        max-width: 180px;
+        line-height: 16px;
+        text-align: center;
+        padding: 8px 11px;
+        border-radius: 5px 0 0 5px;
+    }
+
+    div[class$='-badge']:dir(rtl) {
+        left: 0;
+        right: initial;
+        padding: 8px 11px;
+        border-radius: 0 5px 5px 0;
+    }
+
+    .body .catalog-badge {
+        display: flex;
+        height: fit-content;
+        flex-direction: column;
+        width: fit-content;
+        border-radius: 5px;
+        position: relative;
+        top: 0;
+        margin-left: var(--consonant-merch-spacing-xxs);
+    }
+
+    .detail-bg-container {
+        right: 0;
+        padding: var(--consonant-merch-spacing-xs);
+        border-radius: 5px;
+        font-size: var(--consonant-merch-card-body-font-size);
+        margin: var(--consonant-merch-spacing-xs);
+    }
+
+    .action-menu {
+        display: flex;
+        width: 32px;
+        height: 32px;
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        background-color: #f6f6f6;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: 16px 16px;
+    }
+    .hidden {
+        visibility: hidden;
+    }
+
+    #stock-checkbox,
+    .secure-transaction-label {
+        font-size: var(--consonant-merch-card-body-xxs-font-size);
+        line-height: 1.3;
+        color: var(--color-gray-600);
+    }
+
+    #stock-checkbox {
+        display: inline-flex;
+        align-items: center;
+        cursor: pointer;
+        gap: 10px; /*same as spectrum */
+    }
+
+    #stock-checkbox > input {
+        display: none;
+    }
+
+    #stock-checkbox > span {
+        display: inline-block;
+        box-sizing: border-box;
+        border: 2px solid rgb(117, 117, 117);
+        border-radius: 2px;
+        width: 14px;
+        height: 14px;
+    }
+
+    #stock-checkbox > input:checked + span {
+        background: var(--checkmark-icon) no-repeat var(--color-accent);
+        border-color: var(--color-accent);
+    }
+
+    .secure-transaction-label {
+        white-space: nowrap;
+        display: inline-flex;
+        gap: var(--consonant-merch-spacing-xxs);
+        align-items: center;
+        flex: 1;
+        height: 100%;
+        line-height: normal;
+    }
+
+    .secure-transaction-label::before {
+        display: inline-block;
+        content: '';
+        width: 12px;
+        height: 15px;
+        background: var(--secure-icon) no-repeat;
+        background-position: center;
+        background-size: contain;
+    }
+
+    .checkbox-container {
+        display: flex;
+        align-items: center;
+        gap: var(--consonant-merch-spacing-xxs);
+    }
+
+    .checkbox-container input[type='checkbox']:checked + .checkmark {
+        background-color: var(--color-accent);
+        background-image: var(--checkmark-icon);
+        border-color: var(--color-accent);
+    }
+
+    .checkbox-container input[type='checkbox'] {
+        display: none;
+    }
+
+    .checkbox-container .checkmark {
+        position: relative;
+        display: inline-block;
+        width: 12px;
+        height: 12px;
+        border: 2px solid #757575;
+        background: #fff;
+        border-radius: 2px;
+        cursor: pointer;
+        margin-top: 2px;
+    }
+
+    .twp-badge {
+        padding: 4px 10px 5px 10px;
+    }
+
+    :host([aria-selected]) .twp-badge {
+        margin-inline-end: 2px;
+        padding-inline-end: 9px;
+    }
+
+    :host([variant='twp']) {
+        padding: 4px 10px 5px 10px;
+    }
+
+    slot[name='icons'] {
+        display: flex;
+        gap: 8px;
+    }
+
+    :host([variant='twp']) ::slotted(merch-offer-select) {
+        display: none;
+    }
+
+    :host([variant='twp']) .top-section {
+        flex: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        height: 100%;
+        gap: var(--consonant-merch-spacing-xxs);
+        padding: var(--consonant-merch-spacing-xs)
+            var(--consonant-merch-spacing-xs) var(--consonant-merch-spacing-xs)
+            var(--consonant-merch-spacing-xs);
+        align-items: flex-start;
+    }
+
+    :host([variant='twp']) .body {
+        padding: 0 var(--consonant-merch-spacing-xs);
+    }
+
+    :host([variant='twp']) footer {
+        gap: var(--consonant-merch-spacing-xxs);
+        flex-direction: column;
+        align-self: flex-start;
+    }
+
+    :host([variant='special-offers'].center) {
+        text-align: center;
+    }
+
+    /* plans */
+    :host([variant='plans']) {
+        min-height: 348px;
+    }
+
     :host([variant='mini-compare-chart']) footer {
-      padding: var(--consonant-merch-spacing-xs)
-        var(--consonant-merch-spacing-s)
-        var(--consonant-merch-spacing-s)
-        var(--consonant-merch-spacing-s);
+        min-height: var(--consonant-merch-card-mini-compare-footer-height);
+        padding: var(--consonant-merch-spacing-xs);
     }
-  }
 
-  :host([variant='mini-compare-chart']) slot[name='footer-rows'] {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: end;
-  }
-  /* mini-compare card heights for the slots: heading-m, body-m, heading-m-price, price-commitment, offers, promo-text, footer */
-  :host([variant='mini-compare-chart']) slot[name='heading-m'] {
-    min-height: var(--consonant-merch-card-mini-compare-heading-m-height);
-  }
-  :host([variant='mini-compare-chart']) slot[name='body-m'] {
-    min-height: var(--consonant-merch-card-mini-compare-body-m-height);
-  }
-  :host([variant='mini-compare-chart']) slot[name='heading-m-price'] {
-      min-height: var(
-          --consonant-merch-card-mini-compare-heading-m-price-height
-      );
-  }
-  :host([variant='mini-compare-chart']) slot[name='price-commitment'] {
-    min-height: var(
-      --consonant-merch-card-mini-compare-price-commitment-height
-    );
-  }
-  :host([variant='mini-compare-chart']) slot[name='offers'] {
-    min-height: var(--consonant-merch-card-mini-compare-offers-height);
-  }
-  :host([variant='mini-compare-chart']) slot[name='promo-text'] {
-    min-height: var(--consonant-merch-card-mini-compare-promo-text-height);
-  }
+    /* mini-compare card  */
+    :host([variant='mini-compare-chart']) .top-section {
+        padding-top: var(--consonant-merch-spacing-s);
+        padding-inline-start: var(--consonant-merch-spacing-s);
+        height: var(--consonant-merch-card-mini-compare-top-section-height);
+    }
 
-  :host([variant='plans']) ::slotted([slot='heading-xs']),
-  :host([variant='segment']) ::slotted([slot='heading-xs']) {
-    max-width: var(--consonant-merch-card-heading-xs-max-width, 100%);
-  }
+    @media screen and ${u(y)} {
+        [class*'-merch-cards'] :host([variant='mini-compare-chart']) footer {
+            flex-direction: column;
+            align-items: stretch;
+            text-align: center;
+        }
+    }
+
+    @media screen and ${u(f)} {
+        :host([variant='mini-compare-chart']) .top-section {
+            padding-top: var(--consonant-merch-spacing-xs);
+        }
+        :host([variant='mini-compare-chart']) .mini-compare-chart-badge {
+            font-size: var(--consonant-merch-card-detail-font-size);
+            padding: 6px 8px;
+            top: 10px;
+        }
+    }
+    @media screen and ${u(c)} {
+        :host([variant='mini-compare-chart']) footer {
+            padding: var(--consonant-merch-spacing-xs)
+                var(--consonant-merch-spacing-s)
+                var(--consonant-merch-spacing-s)
+                var(--consonant-merch-spacing-s);
+        }
+    }
+
+    :host([variant='mini-compare-chart']) slot[name='footer-rows'] {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        justify-content: end;
+    }
+    /* mini-compare card heights for the slots: heading-m, body-m, heading-m-price, price-commitment, offers, promo-text, footer */
+    :host([variant='mini-compare-chart']) slot[name='heading-m'] {
+        min-height: var(--consonant-merch-card-mini-compare-heading-m-height);
+    }
+    :host([variant='mini-compare-chart']) slot[name='body-m'] {
+        min-height: var(--consonant-merch-card-mini-compare-body-m-height);
+    }
+    :host([variant='mini-compare-chart']) slot[name='heading-m-price'] {
+        min-height: var(
+            --consonant-merch-card-mini-compare-heading-m-price-height
+        );
+    }
+    :host([variant='mini-compare-chart']) slot[name='price-commitment'] {
+        min-height: var(
+            --consonant-merch-card-mini-compare-price-commitment-height
+        );
+    }
+    :host([variant='mini-compare-chart']) slot[name='offers'] {
+        min-height: var(--consonant-merch-card-mini-compare-offers-height);
+    }
+    :host([variant='mini-compare-chart']) slot[name='promo-text'] {
+        min-height: var(--consonant-merch-card-mini-compare-promo-text-height);
+    }
+
+    :host([variant='plans']) ::slotted([slot='heading-xs']),
+    :host([variant='segment']) ::slotted([slot='heading-xs']) {
+        max-width: var(--consonant-merch-card-heading-xs-max-width, 100%);
+    }
 `,R=()=>{let p=[k`
         /* Tablet */
         @media screen and ${u(i)} {
@@ -408,13 +408,13 @@ import{html as a,LitElement as j}from"/libs/deps/lit-all.min.js";import{LitEleme
                 grid-column: span 3;
             }
         `];return p.push(k`
-    /* Large desktop */
-    @media screen and ${u(h)} {
-      :host([size='super-wide']) {
-        grid-column: span 4;
-      }
-    }
-  `),p};var[_,M,O,L,N,te]=["ArrowLeft","ArrowRight","ArrowUp","ArrowDown","Enter","Tab"];var P=document.createElement("style");P.innerHTML=`
+        /* Large desktop */
+        @media screen and ${u(h)} {
+            :host([size='super-wide']) {
+                grid-column: span 4;
+            }
+        }
+    `),p};var[_,M,O,L,N,te]=["ArrowLeft","ArrowRight","ArrowUp","ArrowDown","Enter","Tab"];var P=document.createElement("style");P.innerHTML=`
 :root {
     --consonant-merch-card-detail-font-size: 12px;
     --consonant-merch-card-detail-font-weight: 500;


### PR DESCRIPTION
In this PR we change the CSS rule to set the strikethrough price font size to 14px only in merch cards.
Corresponding mas PR should be merged first: https://github.com/adobecom/mas/pull/18 

Resolves: [MWPW-153657](https://jira.corp.adobe.com/browse/MWPW-153657)

**Test URLs:**

Before:
- DC: https://main--dc--adobecom.hlx.page/drafts/steenmeyer/acrobat-pricing-samples/acrobat-business-merch-card-product
- Milo: https://main--milo--adobecom.hlx.page/docs/authoring/commerce/merch-card-product
- Mini-compare variation: https://main--milo--adobecom.hlx.live/drafts/axel/mini-compare-chart

After: 
- DC: https://main--dc--adobecom.hlx.page/drafts/steenmeyer/acrobat-pricing-samples/acrobat-business-merch-card-product?milolibs=mwpw-153657-strikethrough-price--milo--mirafedas&mep=off&georouting=off
- Milo: https://mwpw-153657-strikethrough-price--milo--mirafedas.hlx.live/docs/authoring/commerce/merch-card-product?mep=off&georouting=off
- Mini-compare variation: https://mwpw-153657-strikethrough-price--milo--mirafedas.hlx.live/drafts/axel/mini-compare-chart?mep=off&georouting=off