### PR TITLE
Revert "MWPW-148002: Adjust Strike-through price font size for: merch-card (all variations)"

### DIFF
--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -8,8 +8,6 @@ span[data-wcs-osi] {
 }
 
 span.placeholder-resolved[data-template="strikethrough"], span.price.price-strikethrough {
-  font-size: var(--type-body-xs-size);
-  font-weight: normal;
   text-decoration: line-through;
 }
 


### PR DESCRIPTION
Reverts adobecom/milo#2459 because the font size change was suppose to be applied not to all strikethrough prices, but only to ones located inside merch cards. The proper fix is coming in this ticket: https://jira.corp.adobe.com/browse/MWPW-153657


Before: https://main--milo--adobecom.hlx.page/docs/authoring/commerce/merch-card-product?martech=off
After: https://revert-2459-mwpw-148002-price-font-size-new--milo--adobecom.hlx.page/docs/authoring/commerce/merch-card-product?martech=off
https://revert-2459-mwpw-148002-price-font-size-new--milo--adobecom.hlx.page/docs/authoring/commerce/merch-card-product?martech=off
