### PR TITLE
[MWPW-153727] Remove extra border radius from table highlight

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -84,16 +84,10 @@ function handleHighlight(table) {
 
     firstRowCols.forEach((col, i) => {
       col.classList.add('col-highlight');
-      const hasText = col.innerText;
-      if (hasText) {
+      if (col.innerText) {
         headingCols[i]?.classList.add('no-rounded');
-      } else if (!headingCols[i]?.innerText) {
-        col.classList.add('hidden');
       } else {
         col.classList.add('hidden');
-        if (!headingCols[i - 1]?.innerText) {
-          headingCols[i]?.classList.add('top-left-rounded');
-        }
       }
     });
   } else {


### PR DESCRIPTION
Removes an unnecessary border radius from the first content column of a highlight table when it lacks highlight text.

| Before | After |
| ------------- | ------------- |
| <img width="766" alt="Screenshot 2024-07-03 at 13 53 50" src="https://github.com/adobecom/milo/assets/11267498/574694fc-2d77-441b-b620-618ebc25a531"> | <img width="766" alt="Screenshot 2024-07-03 at 13 54 14" src="https://github.com/adobecom/milo/assets/11267498/d313de46-c28e-47b3-941e-0dd23b67bdb4"> |

Resolves: [MWPW-153727](https://jira.corp.adobe.com/browse/MWPW-153727)

**Test URLs:**
- Before: https://table-review--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-mwpw-152305?martech-off&georouting=off
- After: https://table-extra-radius--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-mwpw-152305?martech-off&georouting=off
