### PR TITLE
[MWPW-153881] Table section not initially expanding on mobile

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -11,6 +11,10 @@
   border-color: var(--border-color);
 }
 
+.table a:not([class*="button"]) {
+  display: inline-block;
+}
+
 .table > .row {
   display: grid;
   grid-template-columns: repeat(auto-fit, 50%);
@@ -132,8 +136,8 @@
 
 .table .section-row .col.section-row-title,
 .table .section-row .col.section-row-title p {
-  font-size: var(--type-body-xs-size);
-  line-height: var(--type-body-xs-lh);
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
 }
 
 .table:not(.merch):not(.left, .header-left) .section-row .col:not(.section-row-title),
@@ -161,7 +165,7 @@
 
 .table:not(.merch) .row-heading .col.col-heading .action-area {
   display: flex;
-  gap: var(--spacing-s);
+  gap: var(--spacing-xs);
   flex-wrap: wrap;
 }
 
@@ -604,11 +608,6 @@ header.global-navigation {
 @media (max-width: 768px) {
   .table .col {
     border: 1px var(--border-color) solid;
-  }
-
-  .table:not(.highlight) .col-heading {
-    border-top-left-radius: 16px;
-    border-top-right-radius: 16px;
   }
 }
 

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -431,6 +431,8 @@ function applyStylesBasedOnScreenSize(table, originTable) {
       table.parentElement.insertBefore(filters, table);
       table.parentElement.classList.add(`table-${table.classList.contains('merch') ? 'merch-' : ''}section`);
     }
+
+    filterChangeEvent();
   };
 
   // For Mobile (else: tablet / desktop)


### PR DESCRIPTION
This adapts the logic so that table sections can be expanded on mobile without having to change the filters.

It also brings in a few small changes requested in another thread:

* **Regular links that have more than 1 word should not span multiple lines**

| Before | After |
| ------------- | ------------- |
| <img width="612" alt="Screenshot 2024-07-05 at 11 56 31" src="https://github.com/adobecom/milo/assets/11267498/2d8aaefc-320f-49f8-af31-988143baae9a"> | <img width="612" alt="Screenshot 2024-07-05 at 11 56 36" src="https://github.com/adobecom/milo/assets/11267498/95263d51-d6e9-4ed8-87bb-6987a2be4e9a"> |

* **The font size and line height of the first column needs to be increased from XS to S**

| Before | After |
| ------------- | ------------- |
| <img width="514" alt="Screenshot 2024-07-05 at 11 59 05" src="https://github.com/adobecom/milo/assets/11267498/3df0e13d-d13d-4270-bea6-caca1affe87e"> | <img width="514" alt="Screenshot 2024-07-05 at 11 59 13" src="https://github.com/adobecom/milo/assets/11267498/16d95400-54c2-4964-b3a6-6306ac25c366"> |

* **The gap between CTA buttons should be reduced from S to XS**

| Before | After |
| ------------- | ------------- |
| <img width="514" alt="Screenshot 2024-07-05 at 12 08 44" src="https://github.com/adobecom/milo/assets/11267498/7f85413d-da3c-4a73-8816-49fd4171baca"> | <img width="514" alt="Screenshot 2024-07-05 at 12 08 50" src="https://github.com/adobecom/milo/assets/11267498/b6504a4b-1c4e-4d0b-b53e-c12cb70b2223"> |

* **There shouldn't be a border radius between table columns on mobile**

| Before | After |
| ------------- | ------------- |
| <img width="582" alt="Screenshot 2024-07-05 at 12 09 57" src="https://github.com/adobecom/milo/assets/11267498/a44c6516-5d82-4219-ae59-f7b4d9e48cfa"> | <img width="582" alt="Screenshot 2024-07-05 at 12 10 06" src="https://github.com/adobecom/milo/assets/11267498/c8cc3c99-3fb9-46a2-9f02-e5fbc55b1da5"> |

Resolves: [MWPW-153881](https://jira.corp.adobe.com/browse/MWPW-153881)

**Test URLs:**
- Before: https://table-review--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-mwpw-152305?martech-off&georouting=off
- After: https://mobile-table-sections--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-mwpw-152305?martech-off&georouting=off
- Before: https://table-review--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-kyung-overhaul?martech-off&georouting=off
- After: https://mobile-table-sections--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-kyung-overhaul?martech-off&georouting=off
