### PR TITLE
MWPW-152952 Allow message for Marketo form success

### DIFF
--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -32,6 +32,8 @@ export const formValidate = (form) => {
 };
 
 export const decorateURL = (destination, baseURL = window.location) => {
+  if (!(destination.startsWith('http') || destination.startsWith('/'))) return null;
+
   try {
     let destinationUrl = new URL(destination, baseURL.origin);
     const { hostname, pathname, search, hash } = destinationUrl;

--- a/test/blocks/marketo/marketo.test.js
+++ b/test/blocks/marketo/marketo.test.js
@@ -97,4 +97,10 @@ describe('marketo decorateURL', () => {
     const result = decorateURL('/marketo-block/thank-you', baseURL);
     expect(result).to.equal('https://business.adobe.com/uk/marketo-block/thank-you.html');
   });
+
+  it('Does not decorate non-url text', () => {
+    const baseURL = new URL('https://business.adobe.com/marketo-block.html');
+    const result = decorateURL('Thank you for submitting the form', baseURL);
+    expect(result).to.be.null;
+  });
 });


### PR DESCRIPTION
* Fixes issue that was preventing "message" success type for Marketo forms
* FYI there's also a fix needed on the MCZ side for the message to fully work

Resolves: [MWPW-152952](https://jira.corp.adobe.com/browse/MWPW-152952)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/marketo-message?martech=off
- After: https://methomas-marketo-message--milo--adobecom.hlx.page/drafts/methomas/marketo-message?martech=off

To verify:
- Note that the form doesn't redirect
- Also, look in the console under "Form Type & Version" -> "success"
- The content should be a thank you message: "Thank you. Your request has been..."
- The type should be "message"

<img width="554" alt="Screenshot 2024-07-08 at 4 06 04 PM" src="https://github.com/adobecom/milo/assets/19690988/28ea6c61-1c36-47f4-a201-8faf8a77450a">

Regression:
(Should redirect)
- https://main--bacom--adobecom.hlx.live/?milolibs=methomas-marketo-message