### PR TITLE
MWPW-153600 [PEP] loader bar on PEP prompt is seen loaded Left to right in RTL locale

### DIFF
--- a/libs/features/webapp-prompt/webapp-prompt.css
+++ b/libs/features/webapp-prompt/webapp-prompt.css
@@ -182,6 +182,10 @@
     transform: scaleX(0) translateZ(0);
   }
 
+  [dir = "rtl"] .appPrompt-progress {
+    transform-origin: top right;
+  }
+
   @keyframes appPrompt-animate {
     100% {
       transform: scaleX(1);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Changed the transform origin of `.appPrompt-progress` to start on the right instead of at the origin (top left)

Resolves: [MWPW-153600](https://jira.corp.adobe.com/browse/MWPW-153600)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://pep-rtl--milo--adobecom.hlx.page/?martech=off
- qa url: https://main--cc--adobecom.hlx.page/il_he/creativecloud/animation/testdoc/pepphsp1?milolibs=pep-rtl&skipPepEntitlements=true
