### PR TITLE
Remove CORS restrictions for module imports

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,4 +1,4 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<script src="/libs/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+<script src="/libs/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/libs/styles/styles.css"/>
 <link rel="icon" href="data:," size="any"/>


### PR DESCRIPTION
Milo consumers CC/DC are already running
without CORS restriction.
This change will enable the feature in PR#2544
to be used on Milo pages as well.

For more context, see: https://github.com/adobecom/milo/pull/2544#discussion_r1669910973

Resolves: [MWPW-153962](https://jira.corp.adobe.com/browse/MWPW-153962)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-153962-2--milo--yesil.hlx.page/?martech=off
