### PR TITLE
Adding support for federated urls in modals

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -18,9 +18,10 @@ import {
   lanaLog,
   logErrorFor,
   toFragment,
-  getFederatedUrl,
   federatePictureSources,
 } from '../global-navigation/utilities/utilities.js';
+
+import { getFederatedUrl } from '../../utils/federated.js';
 
 import { replaceKey } from '../../features/placeholders.js';
 

--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -1,5 +1,6 @@
 import { getMetadata, getConfig } from '../../../../utils/utils.js';
-import { toFragment, lanaLog, getFederatedUrl } from '../../utilities/utilities.js';
+import { toFragment, lanaLog } from '../../utilities/utilities.js';
+import { getFederatedUrl } from '../../../../utils/federated.js';
 
 const metadata = {
   seo: 'breadcrumbs-seo',

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -1,7 +1,7 @@
 import {
   getConfig, getMetadata, loadStyle, loadLana, decorateLinks, localizeLink,
 } from '../../../utils/utils.js';
-import { getFederatedContentRoot } from '../../../utils/federated.js';
+import { getFederatedContentRoot, getFederatedUrl } from '../../../utils/federated.js';
 import { processTrackingLabels } from '../../../martech/attributes.js';
 import { replaceText } from '../../../features/placeholders.js';
 
@@ -74,20 +74,6 @@ export function toFragment(htmlStrings, ...values) {
 
   return fragment;
 }
-
-// TODO we should match the akamai patterns /locale/federal/ at the start of the url
-// and make the check more strict.
-export const getFederatedUrl = (url = '') => {
-  if (typeof url !== 'string' || !url.includes('/federal/')) return url;
-  if (url.startsWith('/')) return `${getFederatedContentRoot()}${url}`;
-  try {
-    const { pathname, search, hash } = new URL(url);
-    return `${getFederatedContentRoot()}${pathname}${search}${hash}`;
-  } catch (e) {
-    lanaLog({ message: `getFederatedUrl errored parsing the URL: ${url}`, e, tags: 'errorType=warn,module=utilities' });
-  }
-  return url;
-};
 
 const getPath = (urlOrPath = '') => {
   try {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable import/no-cycle */
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
+import { getFederatedUrl } from '../../utils/federated.js';
 
 const FOCUSABLES = 'a:not(.hide-video), button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
 const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
@@ -91,7 +92,7 @@ function getCustomModal(custom, dialog) {
 }
 
 async function getPathModal(path, dialog) {
-  const block = createTag('a', { href: path });
+  const block = createTag('a', { href: getFederatedUrl(path) });
   dialog.append(block);
 
   // eslint-disable-next-line import/no-cycle

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable import/no-cycle */
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
-import { getFederatedUrl } from '../../utils/federated.js';
 
 const FOCUSABLES = 'a:not(.hide-video), button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
 const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
@@ -92,7 +91,12 @@ function getCustomModal(custom, dialog) {
 }
 
 async function getPathModal(path, dialog) {
-  const block = createTag('a', { href: getFederatedUrl(path) });
+  let href = path;
+  if (path.includes('/federal/')) {
+    const { getFederatedUrl } = await import('../../utils/federated.js');
+    href = getFederatedUrl(path);
+  }
+  const block = createTag('a', { href });
   dialog.append(block);
 
   // eslint-disable-next-line import/no-cycle

--- a/libs/utils/federated.js
+++ b/libs/utils/federated.js
@@ -14,7 +14,6 @@ export const getFederatedContentRoot = () => {
   if (federatedContentRoot) return federatedContentRoot;
 
   const { origin } = window.location;
-
   federatedContentRoot = [...allowedOrigins, ...cdnWhitelistedOrigins].some((o) => origin.replace('.stage', '') === o)
     ? origin
     : 'https://www.adobe.com';

--- a/libs/utils/federated.js
+++ b/libs/utils/federated.js
@@ -28,3 +28,17 @@ export const getFederatedContentRoot = () => {
 
   return federatedContentRoot;
 };
+
+// TODO we should match the akamai patterns /locale/federal/ at the start of the url
+// and make the check more strict.
+export const getFederatedUrl = (url = '') => {
+  if (typeof url !== 'string' || !url.includes('/federal/')) return url;
+  if (url.startsWith('/')) return `${getFederatedContentRoot()}${url}`;
+  try {
+    const { pathname, search, hash } = new URL(url);
+    return `${getFederatedContentRoot()}${pathname}${search}${hash}`;
+  } catch (e) {
+    window.lana?.log(`getFederatedUrl errored parsing the URL: ${url}: ${e.toString()}`);
+  }
+  return url;
+};

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -15,7 +15,6 @@ import {
   getExperienceName,
   logErrorFor,
 } from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
-import { getFederatedUrl } from '../../../../libs/utils/federated.js';
 import { setConfig, getConfig } from '../../../../libs/utils/utils.js';
 import { createFullGlobalNavigation, config } from '../test-utilities.js';
 import mepInBlock from '../mocks/mep-config.js';
@@ -387,57 +386,6 @@ describe('global navigation utilities', () => {
 
       // Restore the original window.lana.log method
       window.lana.log = originalLanaLog;
-    });
-  });
-
-  describe('getFederatedUrl', () => {
-    it('should return the url if its not federated', () => {
-      expect(getFederatedUrl('https://adobe.com/foo-fragment.html')).to.equal(
-        'https://adobe.com/foo-fragment.html',
-      );
-
-      expect(getFederatedUrl('/foo-fragment.html')).to.equal(
-        '/foo-fragment.html',
-      );
-
-      expect(getFederatedUrl('/lu_de/foo-fragment.html')).to.equal(
-        '/lu_de/foo-fragment.html',
-      );
-    });
-
-    it('should return the federated url', () => {
-      expect(
-        getFederatedUrl('https://adobe.com/federal/foo-fragment.html'),
-      ).to.equal(
-        `${baseHost}/federal/foo-fragment.html`,
-      );
-      expect(
-        getFederatedUrl('https://adobe.com/lu_de/federal/gnav/foofooter.html'),
-      ).to.equal(
-        `${baseHost}/lu_de/federal/gnav/foofooter.html`,
-      );
-    });
-
-    it('should return the federated url for a relative link', () => {
-      expect(
-        getFederatedUrl('/federal/foo-fragment.html'),
-      ).to.equal(
-        `${baseHost}/federal/foo-fragment.html`,
-      );
-    });
-
-    it('should return the federated url for a relative link including hashes and search params', () => {
-      expect(
-        getFederatedUrl('/federal/foo-fragment.html?foo=bar#test'),
-      ).to.equal(
-        `${baseHost}/federal/foo-fragment.html?foo=bar#test`,
-      );
-    });
-
-    it('should return the url for invalid urls', () => {
-      expect(getFederatedUrl('en-US/federal/')).to.equal('en-US/federal/');
-      expect(getFederatedUrl(null)).to.equal(null);
-      expect(getFederatedUrl(123121)).to.equal(123121);
     });
   });
 });

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -14,8 +14,8 @@ import {
   trigger,
   getExperienceName,
   logErrorFor,
-  getFederatedUrl,
 } from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
+import { getFederatedUrl } from '../../../../libs/utils/federated.js';
 import { setConfig, getConfig } from '../../../../libs/utils/utils.js';
 import { createFullGlobalNavigation, config } from '../test-utilities.js';
 import mepInBlock from '../mocks/mep-config.js';

--- a/test/utils/federated.test.js
+++ b/test/utils/federated.test.js
@@ -1,0 +1,49 @@
+import { expect } from '@esm-bundle/chai';
+import { getFederatedUrl, getFederatedContentRoot } from '../../libs/utils/federated.js';
+
+const baseHost = 'https://www.stage.adobe.com';
+
+describe('Federated navigation utilities', () => {
+  describe('getFederatedContentRoot', () => {
+    it('should return the federated content root', () => {
+      expect(getFederatedContentRoot('https://adobe.com/federel/footer')).to.equal(baseHost);
+    });
+  });
+
+  describe('getFederatedUrl', () => {
+    it('should return the url if its not federated', () => {
+      expect(getFederatedUrl('https://adobe.com/foo-fragment.html')).to.equal('https://adobe.com/foo-fragment.html');
+
+      expect(getFederatedUrl('/foo-fragment.html')).to.equal('/foo-fragment.html');
+
+      expect(getFederatedUrl('/lu_de/foo-fragment.html')).to.equal(
+        '/lu_de/foo-fragment.html',
+      );
+    });
+
+    it('should return the federated url', () => {
+      expect(getFederatedUrl('https://adobe.com/federal/foo-fragment.html')).to.equal(`${baseHost}/federal/foo-fragment.html`);
+      expect(
+        getFederatedUrl('https://adobe.com/lu_de/federal/gnav/foofooter.html'),
+      ).to.equal(`${baseHost}/lu_de/federal/gnav/foofooter.html`);
+    });
+
+    it('should return the federated url for a relative link', () => {
+      expect(getFederatedUrl('/federal/foo-fragment.html')).to.equal(
+        `${baseHost}/federal/foo-fragment.html`,
+      );
+    });
+
+    it('should return the federated url for a relative link including hashes and search params', () => {
+      expect(
+        getFederatedUrl('/federal/foo-fragment.html?foo=bar#test'),
+      ).to.equal(`${baseHost}/federal/foo-fragment.html?foo=bar#test`);
+    });
+
+    it('should return the url for invalid urls', () => {
+      expect(getFederatedUrl('en-US/federal/')).to.equal('en-US/federal/');
+      expect(getFederatedUrl(null)).to.equal(null);
+      expect(getFederatedUrl(123121)).to.equal(123121);
+    });
+  });
+});


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds support for federated URLs in modals to centralize content for the region selector.
* Moved out getFederatedUrl function from utilities file to federated.js file

Resolves: [MWPW-130787](https://jira.corp.adobe.com/browse/MWPW-130787) and [MWPW-153670](https://jira.corp.adobe.com/browse/MWPW-153670)

**Test URLs:**
- Before:  https://main--milo--adobecom.hlx.page/?martech=off
- After:  https://central-regionpicker--milo--bandana147.hlx.page/?martech=off
- Qa url: https://central-regionpicker--milo--bandana147.hlx.page/drafts/blaishram/document?martech=off
