### PR TITLE
MWPW-152016 - Localization target preview for transcreation

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -298,8 +298,10 @@ export function localizeLink(
     const isLocalizable = relative || (prodDomains && prodDomains.includes(url.hostname))
       || overrideDomain;
     if (!isLocalizable) return processedHref;
-    const isLocalizedLink = path.startsWith(`/${LANGSTORE}`) || Object.keys(locales)
-      .some((loc) => loc !== '' && (path.startsWith(`/${loc}/`) || path.endsWith(`/${loc}`)));
+    const isLocalizedLink = path.startsWith(`/${LANGSTORE}`)
+      || path.startsWith(`/${PREVIEW}`)
+      || Object.keys(locales).some((loc) => loc !== '' && (path.startsWith(`/${loc}/`)
+      || path.endsWith(`/${loc}`)));
     if (isLocalizedLink) return processedHref;
     const urlPath = `${locale.prefix}${path}${url.search}${hash}`;
     return relative ? urlPath : `${url.origin}${urlPath}`;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -139,6 +139,7 @@ ENVS.local = {
 export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
 
 const LANGSTORE = 'langstore';
+const PREVIEW = 'target-preview';
 const PAGE_URL = new URL(window.location.href);
 const SLD = PAGE_URL.hostname.includes('.aem.') ? 'aem' : 'hlx';
 
@@ -168,13 +169,11 @@ export function getLocale(locales, pathname = window.location.pathname) {
   }
   const split = pathname.split('/');
   const localeString = split[1];
-  const locale = locales[localeString] || locales[''];
-  if (localeString === LANGSTORE) {
+  let locale = locales[localeString] || locales[''];
+  if ([LANGSTORE, PREVIEW].includes(localeString)) {
+    const ietf = Object.keys(locales).find((loc) => locales[loc]?.ietf?.startsWith(split[2]));
+    if (ietf) locale = locales[ietf];
     locale.prefix = `/${localeString}/${split[2]}`;
-    if (
-      Object.values(locales)
-        .find((loc) => loc.ietf?.startsWith(split[2]))?.dir === 'rtl'
-    ) locale.dir = 'rtl';
     return locale;
   }
   const isUS = locale.ietf === 'en-US';


### PR DESCRIPTION
This PR adds support for `rtl` localization for transcreation staging in `target-preview` directory. Also updates the function to use the proper locale for `LANGSTORE` instead of only updating the `dir` property.

Resolves: [MWPW-152016](https://jira.corp.adobe.com/browse/MWPW-152016)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/target-preview/he/drafts/sarchibeque/testingpreview?martech=off
- After: https://sartxi-mwpw-152016-locale-preview--milo--adobecom.hlx.page/target-preview/he/drafts/sarchibeque/testingpreview?martech=off
