### PR TITLE
MWPW-153215 - [LocUI] Find fragments in Metadata

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -26,6 +26,7 @@ import {
 } from '../utils/miloc.js';
 import { signal } from '../../../deps/htm-preact.js';
 import Modal from './modal.js';
+import isUrl from '../utils/url.js';
 
 export const showRolloutOptions = signal(false);
 
@@ -67,7 +68,10 @@ function findMetaFragments(doc) {
   const metas = doc.getElementsByTagName('meta');
   if (metas.length) {
     fragments = [...metas]
-      .filter((meta) => meta.getAttribute('content')?.includes('/fragments/'))
+      .filter((meta) => {
+        const content = meta.getAttribute('content');
+        return content?.includes('/fragments/') && isUrl(content);
+      })
       .map((meta) => new URL(meta.getAttribute('content')));
   }
   return fragments;

--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -62,6 +62,17 @@ async function fetchDocument(hlxPath) {
   }
 }
 
+function findMetaFragments(doc) {
+  let fragments = [];
+  const metas = doc.getElementsByTagName('meta');
+  if (metas.length) {
+    fragments = [...metas]
+      .filter((meta) => meta.getAttribute('content')?.includes('/fragments/'))
+      .map((meta) => new URL(meta.getAttribute('content')));
+  }
+  return fragments;
+}
+
 async function findPageFragments(path) {
   const page = path.split('/').pop();
   const isIndex = page === 'index' ? path.lastIndexOf('index') : 0;
@@ -72,7 +83,7 @@ async function findPageFragments(path) {
   decorateSections(doc, true);
   await decorateFooterPromo(doc);
   const fragments = [...doc.querySelectorAll('.fragment, .modal.link-block')];
-  const fragmentUrls = fragments.reduce((acc, fragment) => {
+  let fragmentUrls = fragments.reduce((acc, fragment) => {
     // Normalize the fragment path to support production urls.
     const originalUrl = fragment.dataset.modalPath || fragment.dataset.path || fragment.href;
     let pathname;
@@ -82,16 +93,15 @@ async function findPageFragments(path) {
       setStatus('service', 'error', 'Invalid Fragment Path in files', originalUrl);
       return acc;
     }
-
     // Find dupes across current iterator as well as original url list
     const accDupe = acc.some((url) => url.pathname === pathname);
     const dupe = urls.value.some((url) => url.pathname === pathname);
-
     if (accDupe || dupe) return acc;
     const fragmentUrl = new URL(`${origin}${pathname}`);
     acc.push(fragmentUrl);
     return acc;
   }, []);
+  fragmentUrls = [...fragmentUrls, ...findMetaFragments(doc)];
   if (fragmentUrls.length === 0) return [];
   return fragmentUrls;
 }

--- a/libs/blocks/locui/utils/url.js
+++ b/libs/blocks/locui/utils/url.js
@@ -1,0 +1,8 @@
+export default function isUrl(str) {
+  try {
+    const url = new URL(str);
+    return url;
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
Add a function that finds fragment urls set as metadata content.

Resolves: [MWPW-153215](https://jira.corp.adobe.com/browse/MWPW-153215)

**Test URLs:**
https://main--cc--adobecom.hlx.page/tools/loc?milolibs=sean-loc&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Be29aea5e-1c23-4a76-b402-5df7db60215e%257D%26action%3Deditnew%26wdsle%3D0
