### PR TITLE
MWPW-146743 Improve Article Header Performance

### DIFF
--- a/test/blocks/article-header/article-header.test.js
+++ b/test/blocks/article-header/article-header.test.js
@@ -48,6 +48,13 @@ describe('article header', () => {
     stub.restore();
   });
 
+  it('updates share text after deferred event', async () => {
+    document.dispatchEvent(new Event('milo:deferred'));
+    const shareLink = document.querySelector('.article-byline-sharing a');
+    await delay(100);
+    expect(shareLink.getAttribute('aria-label')).to.equal('Click to share on twitter');
+  });
+
   it('should add copy-failure class to link if the copy fails', async () => {
     const writeTextStub = sinon.stub(navigator.clipboard, 'writeText').rejects();
     const copyLink = document.body.querySelector('.article-byline-sharing #copy-to-clipboard');
@@ -69,6 +76,17 @@ describe('article header', () => {
     const tooltip = await waitForElement('.copied-to-clipboard');
 
     expect(tooltip).to.exist;
+    writeTextStub.restore();
+  });
+
+  it('updates copy text after deferred event', async () => {
+    document.dispatchEvent(new Event('milo:deferred'));
+    const writeTextStub = sinon.stub(navigator.clipboard, 'writeText').resolves();
+    const copyLink = document.body.querySelector('.article-byline-sharing #copy-to-clipboard');
+    sinon.fake();
+    copyLink.click();
+    const tooltip = await waitForElement('.copied-to-clipboard');
+    expect(tooltip.textContent).to.equal('Link copied to clipboard');
     writeTextStub.restore();
   });
 

--- a/test/blocks/article-header/mocks/body.html
+++ b/test/blocks/article-header/mocks/body.html
@@ -32,6 +32,7 @@
                 src="/en/publish/2022/12/05/media_165ac27f7158c040400bd6666c6086a9c0b3c29cc.jpeg?width=750&amp;format=jpeg&amp;optimize=medium"
                 loading="eager" alt="Virtual background in red and blue."> -->
             </picture>
+            <em>Caption</em>
           </p>
         </div>
       </div>

--- a/test/blocks/article-header/mocks/placeholders.json
+++ b/test/blocks/article-header/mocks/placeholders.json
@@ -10,6 +10,14 @@
     {
       "key": "no-results",
       "value": "No results found"
+    },
+    {
+      "key": "share-twitter",
+      "value": "Click to share on twitter"
+    },
+    {
+      "key": "copied-to-clipboard",
+      "value": "Link copied to clipboard"
     }
   ],
   ":type": "sheet"


### PR DESCRIPTION
Made various updates to Article Header in order to reduce LCP on blogs:
* Reduced network requests by pulling code from imports into file
* Delayed placeholder code because it was non-critical
* Only loaded taxonomy if necessary (which it isn't on bacom blog)
* Removed await for build author so requests can be made concurrently

Resolves: [MWPW-146743](https://jira.corp.adobe.com/browse/MWPW-146743)

Results (hlx.live testing):
- Page Speed Index LCP: 0.7s reduction on bacom blog. No change on brand blog.
- DevTools LCP Fast 3G, No CPU throttling: Avg 2.8s reduction on both blogs.
- Incidental reduction in TBT for both blogs

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/blog-migration/article-header/connecting-external-data-sources-to-adobe-experience-manager-guides
- After: https://perf-refactor-article-header--milo--adobecom.hlx.page/drafts/methomas/blog-migration/article-header/connecting-external-data-sources-to-adobe-experience-manager-guides

Bacom Blog:
- Before: https://main--bacom-blog--adobecom.hlx.live/blog/the-latest/whats-new-at-adobe-summit-2024
- After: https://main--bacom-blog--adobecom.hlx.live/blog/the-latest/whats-new-at-adobe-summit-2024?milolibs=perf-refactor-article-header

Brand Blog:
- Before: https://main--blog--adobecom.hlx.live/en/publish/2024/05/21/lightroom-introduces-power-adobe-firefly-with-generative-remove
- After: https://main--blog--adobecom.hlx.live/en/publish/2024/05/21/lightroom-introduces-power-adobe-firefly-with-generative-remove?milolibs=perf-refactor-article-header