### PR TITLE
MWPW-154057 social share destination links has '#_blank' added at end of url for few locales

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -285,13 +285,15 @@ class Footer {
 
     const socialElem = toFragment`<ul class="feds-social" daa-lh="Social"></ul>`;
 
+    const sanitizeLink = (link) => link.replace('#_blank', '').replace('#_dnb', '');
+
     CONFIG.socialPlatforms.forEach((platform, index) => {
       const link = socialBlock.querySelector(`a[href*="${platform}"]`);
       if (!link) return;
 
       const iconElem = toFragment`<li class="feds-social-item">
           <a
-            href="${link.href}"
+            href="${sanitizeLink(link.href)}"
             class="feds-social-link"
             aria-label="${platform}"
             daa-ll="${getAnalyticsValue(platform, index + 1)}"


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

*  Authored social links now ignore `#_blank` and `#_dnb` if they've been added by the author
* We do this because on line 300 of /libs/blocks/global-footer/global-footer.js we have `target=_blank` regardless of whether the author has added `#_blank` or not, and we by pass the regular link decoration process for social links.
(https://github.com/sharmrj/milo/blob/5eb296b58e24f4bc5d4a201600d151e6f3a56e5a/libs/blocks/global-footer/global-footer.js#L300)

Resolves: [MWPW-154057](https://jira.corp.adobe.com/browse/MWPW-154057)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://footer-social-links--milo--sharmrj.hlx.page/?martech=off
- main--homepage--adobecom.hlx.live/kr/homepage/index-loggedout?milolibs=footer-social-links--milo--sharmrj