### PR TITLE
Move the catch to the correct function

### DIFF
--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -157,8 +157,8 @@ const merge = async ({ prs, type }) => {
           number,
           title,
           prefix,
-        }).catch(console.error)
-      );
+        })
+      ).catch(console.error);
       await new Promise((resolve) => setTimeout(resolve, 5000));
     } catch (error) {
       files.forEach((file) => (SEEN[file] = false));


### PR DESCRIPTION
#milo-changelog doesn't see individual PRs being merged due to this error: `Error merging 2508: MWPW-147270 Fix the error caused by trying to load Search in Global Navigation SLACK.merge(...).catch is not a function`

Fixes small omission introduced in https://github.com/adobecom/milo/pull/2572 and moves the catch block to the correct promise.
Resolves: [MWPW-152624](https://jira.corp.adobe.com/browse/MWPW-152624)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://stage-workflow--milo--mokimo.aem.live/?martech=off
