### PR TITLE
MWPW-154054 + MWPW-154192: Blank space caused by delayed modal anchor

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -228,7 +228,6 @@ export function delayedModal(el) {
   const { hash, delay } = getHashParams(el?.dataset.modalHash);
   if (!delay || !hash) return false;
   isDelayedModal = true;
-  el.classList.add('hide-block');
   const modalOpenEvent = new Event(`${hash}:modalOpen`);
   const pagesModalWasShownOn = window.sessionStorage.getItem(`shown:${hash}`);
   el.dataset.modalHash = hash;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -127,6 +127,10 @@ const createFrag = (el, url, manifestId) => {
   const a = createTag('a', { href }, url);
   if (manifestId) a.dataset.manifestId = manifestId;
   let frag = createTag('p', undefined, a);
+  const isDelayedModalAnchor = /#.*delay=/.test(href);
+  if (isDelayedModalAnchor) {
+    frag.classList.add('hide-block');
+  }
   const isSection = el.parentElement.nodeName === 'MAIN';
   if (isSection) {
     frag = createTag('div', undefined, frag);

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -128,9 +128,7 @@ export const createFrag = (el, url, manifestId) => {
   if (manifestId) a.dataset.manifestId = manifestId;
   let frag = createTag('p', undefined, a);
   const isDelayedModalAnchor = /#.*delay=/.test(href);
-  if (isDelayedModalAnchor) {
-    frag.classList.add('hide-block');
-  }
+  if (isDelayedModalAnchor) frag.classList.add('hide-block');
   const isSection = el.parentElement.nodeName === 'MAIN';
   if (isSection) {
     frag = createTag('div', undefined, frag);

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -116,7 +116,7 @@ const isInLcpSection = (el) => {
   return lcpSection === el || lcpSection?.contains(el);
 };
 
-const createFrag = (el, url, manifestId) => {
+export const createFrag = (el, url, manifestId) => {
   let href = url;
   try {
     const { pathname, search, hash } = new URL(url);

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -206,7 +206,6 @@ describe('Modals', () => {
     document.body.appendChild(anchor);
     expect(delayedModal(anchor)).to.be.true;
     await delay(1000);
-    expect(anchor.classList.contains('hide-block')).to.be.true;
     const modal = await waitForElement('#delayed-modal');
     expect(modal).to.be.not.null;
     expect(document.querySelector('#delayed-modal').classList.contains('delayed-modal'));

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
 import { assert, stub } from 'sinon';
 import { getConfig, setConfig } from '../../../libs/utils/utils.js';
-import { applyPers, matchGlob } from '../../../libs/features/personalization/personalization.js';
+import { applyPers, matchGlob, createFrag } from '../../../libs/features/personalization/personalization.js';
 import spoofParams from './spoofParams.js';
 
 document.head.innerHTML = await readFile({ path: './mocks/metadata.html' });
@@ -224,5 +224,14 @@ describe('matchGlob function', () => {
   it('should match child page', async () => {
     const result = matchGlob('/products/special-offers**', '/products/special-offers/free-download');
     expect(result).to.be.true;
+  });
+
+  it('should hide the wrapping <p> for the delayed modal anchor', async () => {
+    const parent = document.createElement('div');
+    const el = document.createElement('div');
+    parent.appendChild(el);
+    const wrapper = createFrag(el, '/fragments/promos/path-to-promo/#modal-hash:delay=1');
+    expect(wrapper.tagName).to.equal('P');
+    expect(wrapper.classList.contains('hide-block')).to.be.true;
   });
 });


### PR DESCRIPTION
When inserting an anchor link for the delayed modal we need to hide not only the link itself but the wrapping `<p>` element, otherwise it brings unwanted blank space.

Resolves: 
[MWPW-154054](https://jira.corp.adobe.com/browse/MWPW-154054)
[MWPW-154192](https://jira.corp.adobe.com/browse/MWPW-154192)

**Test URLs:**

Before: 
- https://main--cc--adobecom.hlx.page/products/aftereffects/free-trial-download?instant=2024-08-19T14:00:00.000Z
- https://main--cc--adobecom.hlx.page/creativecloud/buy/students?instant=2024-08-19T14:00:00.000Z
- https://main--milo--mirafedas.hlx.page/drafts/mirafedas/delayed-modals/delayed-modal

After: 
- https://main--cc--adobecom.hlx.page/products/aftereffects/free-trial-download?instant=2024-08-19T14:00:00.000Z&milolibs=MWPW-154054-blank-space--milo--mirafedas
- https://main--cc--adobecom.hlx.page/creativecloud/buy/students?instant=2024-08-19T14:00:00.000Z&milolibs=MWPW-154054-blank-space--milo--mirafedas
- https://mwpw-154054-blank-space--milo--mirafedas.hlx.page/drafts/mirafedas/delayed-modals/delayed-modal
