### PR TITLE
Added events

### DIFF
--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -66,6 +66,7 @@ class ProfileDropdown {
     if (this.openOnInit) trigger({ element: this.buttonElem });
 
     this.decoratedElem.append(this.dropdown);
+    window.dispatchEvent(new CustomEvent('feds:profileDropdown:decorated'));
   }
 
   async getData() {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -354,6 +354,7 @@ class Gnav {
       </div>`;
 
     this.block.append(this.elements.curtain, this.elements.aside, this.elements.topnavWrapper);
+    window.dispatchEvent(new CustomEvent('feds:navWrapper:decorated'));
   };
 
   addChangeEventListeners = () => {

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -350,6 +350,7 @@ const decorateMenu = (config) => logErrorFor(async () => {
   }
 
   config.template?.append(menuTemplate);
+  window.dispatchEvent(new CustomEvent('feds:menu:decorated'));
 }, 'Decorate menu failed', 'errorType=info,module=gnav-menu');
 
 export default { decorateMenu, decorateLinkGroup };


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Feature:
* Added events to track navigation rendering

Hi Milo Team, on Partner Portals we want to implement feature that will allow us to show some user data in navigation, or to remove some elements from navigation based on the user data. User data is stored in the cookie that we set when user logs in.

Because navigation is rendered asynchronously, currently we don't have a way of knowing when elements will appear in the DOM. So we would like to introduce 3 events that will give us this information: 

- `feds:navWrapper:decorated` for when main navigation elements are added to the DOM
- `feds:menu:decorated` for when main navigation dropdowns are added to the DOM
- `feds:profileDropdown:decorated` for when profile dropdown is added to the DOM

Resolves: [MWPW-152981](https://jira.corp.adobe.com/browse/MWPW-152981)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://gnav-events--milo--zagi25.hlx.page/?martech=off
