### PR TITLE
Skip bulk publish v1 tests as authors now use v2

### DIFF
--- a/test/blocks/bulk-publish/bulk-publish-utils.test.js
+++ b/test/blocks/bulk-publish/bulk-publish-utils.test.js
@@ -218,7 +218,7 @@ const getArrayWithDeletedProperty = (array, prop) => array.map((item) => {
   return item;
 });
 
-describe('Bulk preview and publish', () => {
+describe.skip('Bulk preview and publish', () => {
   before(() => {
     window.fetch = stub();
     stubBulkConfig();
@@ -652,7 +652,7 @@ describe('Bulk preview and publish', () => {
   });
 });
 
-describe('Bulk index', () => {
+describe.skip('Bulk index', () => {
   before(() => {
     window.fetch = stub();
     stubBulkConfig();


### PR DESCRIPTION
Skip the bulk publish v1 tests as users should be using v2 and there will be no further code changes to v1.  I did not want to delete the files yet just in case it's still being used somewhere.

Resolves: No jira filed

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://skip-bp-v1--milo--adobecom.hlx.page/?martech=off
