### PR TITLE
[Modal] Dedup Ongoing Dialogs for Same Fragment

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -249,7 +249,7 @@ export function delayedModal(el) {
 export default function init(el) {
   const { modalHash } = el.dataset;
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
-  if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null;
+  if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null; // prevent duplicate modal loading
   const details = findDetails(window.location.hash, el);
   return details ? getModal(details) : null;
 }

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -13,6 +13,7 @@ const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="2
 
 let isDelayedModal = false;
 let prevHash = '';
+const dialogLoadingSet = new Set();
 
 export function findDetails(hash, el) {
   const id = hash.replace('#', '');
@@ -113,6 +114,7 @@ export async function getModal(details, custom) {
   if (!(details?.path || custom)) return null;
   const { id } = details || custom;
 
+  dialogLoadingSet.add(id);
   const dialog = createTag('div', { class: 'dialog-modal', id });
   const loadedEvent = new Event('milo:modal:loaded');
 
@@ -180,6 +182,7 @@ export async function getModal(details, custom) {
 
   dialog.append(close);
   document.body.append(dialog);
+  dialogLoadingSet.delete(id);
   firstFocusable.focus({ preventScroll: true, ...focusVisible });
   window.dispatchEvent(loadedEvent);
 
@@ -246,6 +249,7 @@ export function delayedModal(el) {
 export default function init(el) {
   const { modalHash } = el.dataset;
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
+  if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null;
   const details = findDetails(window.location.hash, el);
   return details ? getModal(details) : null;
 }


### PR DESCRIPTION
There exists a race condition that when the same modal hashes appear multiple times on the page, the same fragment could be loaded more than once. More specifically, after the hash change, there is a period when getModal() needs to fetch its content but the dialog-modal hasn't been appended to document yet. If another modal on the page gets its init() called (via section preloadLinks) during this period, all the early-exit safeguard in init() we currently have will fail. This PR aims to cover this condition by keeping track of what dialogs are being loaded but not yet appended.

How to reproduce:
Locally or using overrides, in modal.js, you can fake a longer getPathModal() call by making it into something like `await Promise.all([getPathModal(details.path, dialog), new Promise((r) => setTimeout(r, 4000))]);`. Then to delay the second modal, either throw in more content, or just manually make it slower by making init() async and adding `if (document.querySelector('a.modal') !== el) { await new Promise((r) => setTimeout(r, 2000))}` to the beginning. Then clicking the primary CTA should make the FaaS fragment start overwriting itself and acting weird.

Resolves: https://jira.corp.adobe.com/browse/MWPW-147304

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/jinglhua/modal?martech=off
- After: https://modal-dedup--milo--adobecom.hlx.page/drafts/jinglhua/modal?martech=off
