### PR TITLE
[MWPW-152674] [Gray Box] Desktop gnav not hidden when device view is open

### DIFF
--- a/libs/blocks/graybox/graybox.css
+++ b/libs/blocks/graybox/graybox.css
@@ -90,7 +90,7 @@
   position: fixed;
   right: 0;
   top: 15%;
-  z-index: calc(var(--above-all) + 1);
+  z-index: calc(var(--above-all) + 2);
 }
 
 .graybox-container .gb-toggle {
@@ -190,7 +190,7 @@
 }
 
 .dialog-modal.graybox-modal {
-  z-index: var(--above-all);
+  z-index: calc(var(--above-all) + 1);
 }
 
 .dialog-modal.graybox-modal.mobile > div {
@@ -260,7 +260,7 @@
 
 .modal-curtain.graybox-curtain.is-open {
   background: var(--gb-modal-bg);
-  z-index: calc(var(--above-all) - 1);
+  z-index: var(--above-all);
 }
 
 @media (max-height: 910px), (max-width: 420px) {


### PR DESCRIPTION
### Description
This PR solves the issue where the desktop global navigation is not hidden on mobile & tablet view.

### Related Issue
Resolves: [MWPW-152674](https://jira.corp.adobe.com/browse/MWPW-152674)

### Screenshots

**Before:**

![image](https://github.com/user-attachments/assets/d3c652ce-5e47-415f-9353-aeb3ee66548a)

**After:**

![image](https://github.com/user-attachments/assets/63a024e3-82c7-43e1-b131-5a8e18b2dad7)

### Test URLs:
- Before: https://main--bacom-graybox--adobecom.hlx.page/pocone/customer-success-stories/graybox-changed
- After: https://main--bacom-graybox--adobecom.hlx.page/pocone/customer-success-stories/graybox-changed?milolibs=mwpw-152674-graybox-gnav--milo--robert-bogos

### URL for PSI check: (irrelevant for testing the changes)
https://mwpw-152674-graybox-gnav--milo--robert-bogos.hlx.page/drafts/rbogos/page-default?martech=off 
