### PR TITLE
[MWPW-154795] Style Feds Global-footer region picker drop-up variant (without hash)

### DIFF
--- a/libs/blocks/global-footer/global-footer.css
+++ b/libs/blocks/global-footer/global-footer.css
@@ -142,12 +142,13 @@
   left: 0;
   display: none;
   padding: 20px;
-  min-width: 130px;
-  max-height: 300px;
+  min-width: 165px;
+  max-height: none;
   overflow-y: auto;
   background: var(--feds-background-nav--light);
-  border: 1px solid var(--feds-color-border--light);
+  border: 1px solid #D4D4D4;
   border-radius: 4px;
+  box-sizing: border-box;
 }
 
 [dir = "rtl"] .feds-regionPicker-wrapper > .fragment {

--- a/libs/blocks/global-footer/global-footer.css
+++ b/libs/blocks/global-footer/global-footer.css
@@ -311,3 +311,40 @@
     margin: 0;
   }
 }
+
+.footer-region-button.inline-dialog-active + .fragment p,
+.feds-regionPicker + .fragment p {
+  font-size: var(--type-detail-l-size);
+  margin-top: 20px;
+  margin-bottom: 0;
+}
+
+.footer-region-button.inline-dialog-active + .fragment p:first-child,
+.feds-regionPicker + .fragment p:first-child {
+  margin-top: 0;
+}
+
+.feds-regionPicker-wrapper > .fragment a {
+  line-height: 1;
+  padding: 0;
+  color: var(--color-gray-700);
+}
+
+.footer-region-button.inline-dialog-active + .fragment p strong > a,
+.feds-regionPicker + .fragment p strong > a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.footer-region-button.inline-dialog-active + .fragment p strong > a::after,
+.feds-regionPicker-wrapper > .fragment p strong > a::after {
+  content: ' ';
+  display: block;
+  margin: 0 2px;
+  width: 6px;
+  height: 16px;
+  border: solid var(--color-info-accent);
+  border-width: 0 1px 1px 0;
+  transform: rotate(45deg);
+}

--- a/libs/blocks/global-footer/global-footer.css
+++ b/libs/blocks/global-footer/global-footer.css
@@ -191,7 +191,8 @@
 }
 
 .feds-regionPicker-wrapper > .fragment a:hover {
-  background: var(--feds-background-link--hover--light);
+  color: var(--color-gray-500);
+  background: none;
 }
 
 /* Social */

--- a/libs/blocks/global-footer/global-footer.css
+++ b/libs/blocks/global-footer/global-footer.css
@@ -143,10 +143,10 @@
   display: none;
   padding: 20px;
   min-width: 165px;
-  max-height: none;
+  max-height: 300px;
   overflow-y: auto;
   background: var(--feds-background-nav--light);
-  border: 1px solid #D4D4D4;
+  border: 1px solid var(--color-gray-300);
   border-radius: 4px;
   box-sizing: border-box;
 }


### PR DESCRIPTION
Add styling for region picker drop-up variant (without hash)

Resolves: [MWPW-154795](https://jira.corp.adobe.com/browse/MWPW-154795)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/snehal/unav11
- After: https://dropup--milo--adobecom.hlx.page/drafts/snehal/unav11

Before styles applied : 
<img width="838" alt="image" src="https://github.com/user-attachments/assets/e9edd2f4-bf40-417d-a549-e5767599331a">

After styles applied :
<img width="746" alt="image" src="https://github.com/user-attachments/assets/ac4c86d9-443b-4751-9c31-79d0bf1f7282">

QA : [Sample Page](https://dropup--milo--adobecom.hlx.page/drafts/snehal/unav11)