### PR TITLE
Mwpw 154887: Making gnav visible in base.css 

### DIFF
--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -112,13 +112,7 @@
 }
 
 header.global-navigation {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background-color: var(--feds-background-nav--light);
   visibility: visible;
-  box-sizing: content-box;
-  overflow-x: clip;
 }
 
 /* Desktop styles */

--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -111,6 +111,16 @@
   align-items: center;
 }
 
+header.global-navigation {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--feds-background-nav--light);
+  visibility: visible;
+  box-sizing: content-box;
+  overflow-x: clip;
+}
+
 /* Desktop styles */
 @media (min-width: 900px) {
   .feds-navLink,

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -28,6 +28,15 @@
 }
 
 /* General */
+header.global-navigation {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--feds-background-nav--light);
+  box-sizing: content-box;
+  overflow-x: clip;
+}
+
 .feds-topnav-wrapper {
   position: relative;
   z-index: 2;

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -28,16 +28,6 @@
 }
 
 /* General */
-header.global-navigation {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background-color: var(--feds-background-nav--light);
-  visibility: visible;
-  box-sizing: content-box;
-  overflow-x: clip;
-}
-
 .feds-topnav-wrapper {
   position: relative;
   z-index: 2;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -299,11 +299,11 @@ class Gnav {
     // Order is important, decorateTopnavWrapper will render the nav
     // Ensure any critical task is executed before it
     const tasks = [
-      loadBaseStyles,
       this.decorateMainNav,
       this.decorateTopNav,
       this.decorateAside,
       this.decorateTopnavWrapper,
+      loadBaseStyles,
       this.ims,
       this.addChangeEventListeners,
     ];


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

On a slow network, the global navigation (gnav) is visible before the complete styling is applied, as the CSS to make it visible is in global-navigation.css. 
To resolve this, the CSS is moved to base.css.

Resolves: [MWPW-154887](https://jira.corp.adobe.com/browse/MWPW-154887)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/snehal/unav11?martech=off
- After: https://mwpw-154887--milo--bandana147.hlx.page/drafts/snehal/unav11?martech=off
