### PR TITLE
MWPW-154898 No wait for modal fragment

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1150,6 +1150,16 @@ async function documentPostSectionLoading(config) {
   document.body.appendChild(createTag('div', { id: 'page-load-ok-milo', style: 'display: none;' }));
 }
 
+export function partition(arr, fn) {
+  return arr.reduce(
+    (acc, val, i, ar) => {
+      acc[fn(val, i, ar) ? 0 : 1].push(val);
+      return acc;
+    },
+    [[], []],
+  );
+}
+
 async function processSection(section, config, isDoc) {
   const inlineFrags = [...section.el.querySelectorAll('a[href*="#_inline"]')];
   if (inlineFrags.length) {
@@ -1163,8 +1173,10 @@ async function processSection(section, config, isDoc) {
   }
 
   if (section.preloadLinks.length) {
-    const preloads = section.preloadLinks.map((block) => loadBlock(block));
+    const [modals, nonModals] = partition(section.preloadLinks, (block) => block.classList.contains('modal'));
+    const preloads = nonModals.map((block) => loadBlock(block));
     await Promise.all(preloads);
+    modals.forEach((block) => loadBlock(block));
   }
 
   const loaded = section.blocks.map((block) => loadBlock(block));

--- a/test/utils/utils-partition.test.js
+++ b/test/utils/utils-partition.test.js
@@ -1,0 +1,27 @@
+import { expect } from '@esm-bundle/chai';
+import { partition } from '../../libs/utils/utils.js';
+
+describe('Utils Partition', () => {
+  it('partition array', async () => {
+    const arr = [
+      { name: 'John', age: 23 },
+      { name: 'James', age: 40 },
+      { name: 'Mary', age: 31 },
+    ];
+    const result = partition(arr, (x) => x.age > 30);
+    expect(result[0]).to.have.deep.members(
+      [
+        { name: 'Mary', age: 31 },
+        { name: 'James', age: 40 },
+      ],
+    );
+    expect(result[1]).to.have.deep.members(
+      [{ name: 'John', age: 23 }],
+    );
+  });
+  it('empty array', async () => {
+    const arr = [];
+    const result = partition(arr, (x) => x.age > 30);
+    expect(result).to.eql([[], []]);
+  });
+});


### PR DESCRIPTION
- A section doesn't need to wait for loading of modal fragments. Marquee and modal can be loaded at the same time.
- This PR is one part of #2493, which has been closed. The other part will be addressed in [MWPW-154899](https://jira.corp.adobe.com/browse/MWPW-154899)

Resolve: [MWPW-154898](https://jira.corp.adobe.com/browse/MWPW-154898)

**Test URLs:**

Before: https://main--milo--adobecom.hlx.live/docs/authoring/blocks/marquee-anchors?martech=off
After: https://mwpw-154898--milo--adobecom.hlx.live/docs/authoring/blocks/marquee-anchors?martech=off

**DC Test URLs:**

Before: https://www.stage.adobe.com/acrobat/how-to/pdf-editor-pdf-files.html
Marquee and icons are loaded after modal.

![BeforeNoWait](https://github.com/user-attachments/assets/2e396211-f7a8-4789-8113-d27a264059cf)

After: https://www.stage.adobe.com/acrobat/how-to/pdf-editor-pdf-files.html?milolibs=mwpw-154898
Marquee, icons, and modal are loaded at the same time. 

![AfterNoWait](https://github.com/user-attachments/assets/16c1b1d8-d22c-4942-b7b2-b250681f91cf)

