### PR TITLE
MWPW-152275 Move manifest.json request up while waiting on sstats / etc.

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -950,6 +950,13 @@ export async function init(enablements = {}) {
     };
     manifests = manifests.concat(await combineMepSources(pzn, promo, mepParam));
   }
+  if (target === true && manifests.length) {
+    manifests.forEach((manifest) => {
+      if (manifest.disabled) return;
+      const localizedURL = localizeLink(manifest.manifestPath);
+      loadLink(localizedURL, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
+    });
+  }
   if (target === true || (target === 'gnav' && postLCP)) {
     const { getTargetPersonalization } = await import('../../martech/martech.js');
     const { targetManifests, targetPropositions } = await getTargetPersonalization();

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -950,8 +950,8 @@ export async function init(enablements = {}) {
     };
     manifests = manifests.concat(await combineMepSources(pzn, promo, mepParam));
   }
-  if (target === true && manifests.length) {
-    manifests.forEach((manifest) => {
+  if (target === true) {
+    manifests?.forEach((manifest) => {
       if (manifest.disabled) return;
       const localizedURL = localizeLink(manifest.manifestPath);
       loadLink(localizedURL, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -949,14 +949,13 @@ export async function init(enablements = {}) {
       experiments: [],
     };
     manifests = manifests.concat(await combineMepSources(pzn, promo, mepParam));
-  }
-  if (target === true) {
     manifests?.forEach((manifest) => {
       if (manifest.disabled) return;
       const localizedURL = localizeLink(manifest.manifestPath);
       loadLink(localizedURL, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
     });
   }
+
   if (target === true || (target === 'gnav' && postLCP)) {
     const { getTargetPersonalization } = await import('../../martech/martech.js');
     const { targetManifests, targetPropositions } = await getTargetPersonalization();


### PR DESCRIPTION
* asynchronous preload of the manifests (excluding disabled promos)

Resolves: [MWPW-152275](https://jira.corp.adobe.com/browse/MWPW-152275)

QA Instructions: Look at the performance tab in dev tools for when the 3 manifests are loaded.
**Test URLs:**
- Currently on prod (manifests load simultaneously but after interact call): https://main--cc--adobecom.hlx.page/products/illustrator
- Before (manifests load sequentially after interact call): https://main--cc--adobecom.hlx.page/products/illustrator?milolibs=mepmovefromutils
- After (manifests load simultaneously during ims and interact call): https://main--cc--adobecom.hlx.page/products/illustrator?milolibs=preloadmanifests

**Psi Check URL:**
https://preloadmanifests--milo--adobecom.hlx.page/?martech=off