### PR TITLE
MWPW-154998 [MEP][MILO] Manifests do not execute in the right order when there is a disabled manifest

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -625,6 +625,7 @@ const createDefaultExperiment = (manifest) => ({
   disabled: manifest.disabled,
   event: manifest.event,
   manifest: manifest.manifestPath,
+  executionOrder: '1-1',
   selectedVariant: { commands: [], fragments: [] },
   selectedVariantName: 'default',
   variantNames: ['all'],

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -631,7 +631,7 @@ describe('Utils', () => {
       document.head.innerHTML = await readFile({ path: './mocks/head-personalization.html' });
       await utils.loadArea();
       const resultConfig = utils.getConfig();
-      const resultExperiment = resultConfig.mep.experiments[2];
+      const resultExperiment = resultConfig.mep.experiments[0];
       expect(resultConfig.mep.preview).to.be.true;
       expect(resultConfig.mep.experiments.length).to.equal(3);
       expect(resultExperiment.manifest).to.equal('https://main--milo--adobecom.hlx.page/products/special-offers-manifest.json');


### PR DESCRIPTION
* Adds default execution order to disabled promos

Resolves: [MWPW-154998](https://jira.corp.adobe.com/browse/MWPW-154998)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://manifestorder--milo--adobecom.hlx.page/?martech=off
