### PR TITLE
mwpw-154965: Fetch federal stage content from hlx.page instead of stage.adobe.com

### DIFF
--- a/libs/utils/federated.js
+++ b/libs/utils/federated.js
@@ -20,10 +20,7 @@ export const getFederatedContentRoot = () => {
     : 'https://www.adobe.com';
 
   if (origin.includes('localhost') || origin.includes('.hlx.')) {
-    // Akamai as proxy to avoid 401s, given AEM-EDS MS auth cross project limitations
-    federatedContentRoot = origin.includes('.hlx.live')
-      ? 'https://main--federal--adobecom.hlx.live'
-      : 'https://www.stage.adobe.com';
+    federatedContentRoot = `https://main--federal--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
   }
 
   return federatedContentRoot;

--- a/libs/utils/federated.js
+++ b/libs/utils/federated.js
@@ -20,7 +20,7 @@ export const getFederatedContentRoot = () => {
     : 'https://www.adobe.com';
 
   if (origin.includes('localhost') || origin.includes('.hlx.')) {
-    federatedContentRoot = `https://main--federal--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
+    federatedContentRoot = `https://main--federal--adobecom.hlx.${origin.endsWith('.live') ? 'live' : 'page'}`;
   }
 
   return federatedContentRoot;

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -517,7 +517,7 @@ describe('global navigation', () => {
       document.body.replaceChildren(toFragment`<header class="global-navigation"></header>`);
       await initGnav(document.body.querySelector('header'));
       expect(
-        fetchStub.calledOnceWith('https://www.stage.adobe.com/federal/path/to/gnav.plain.html'),
+        fetchStub.calledOnceWith('https://main--federal--adobecom.hlx.page/federal/path/to/gnav.plain.html'),
       ).to.be.true;
     });
 
@@ -527,7 +527,7 @@ describe('global navigation', () => {
       document.body.replaceChildren(toFragment`<header class="global-navigation"></header>`);
       await initGnav(document.body.querySelector('header'));
       expect(
-        fetchStub.calledOnceWith('https://www.stage.adobe.com/federal/path/to/gnav.plain.html'),
+        fetchStub.calledOnceWith('https://main--federal--adobecom.hlx.page/federal/path/to/gnav.plain.html'),
       ).to.be.true;
     });
 

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -176,7 +176,7 @@ export const createFullGlobalNavigation = async ({
     if (url.endsWith('large-menu-cross-cloud.plain.html')) { return mockRes({ payload: largeMenuCrossCloud }); }
     if (url.endsWith('large-menu-active.plain.html')) { return mockRes({ payload: largeMenuActiveMock }); }
     if (url.endsWith('large-menu-wide-column.plain.html')) { return mockRes({ payload: largeMenuWideColumnMock }); }
-    if (url.includes('https://www.stage.adobe.com')
+    if (url.includes('https://main--federal--adobecom.hlx.page')
       && url.endsWith('feds-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
     if (url.includes('gnav')) { return mockRes({ payload: globalNavigation || globalNavigationMock }); }
     if (url.includes('correct-promo-fragment')) { return mockRes({ payload: correctPromoFragmentMock }); }

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -19,7 +19,7 @@ import { setConfig, getConfig } from '../../../../libs/utils/utils.js';
 import { createFullGlobalNavigation, config } from '../test-utilities.js';
 import mepInBlock from '../mocks/mep-config.js';
 
-const baseHost = 'https://www.stage.adobe.com';
+const baseHost = 'https://main--federal--adobecom.hlx.page';
 describe('global navigation utilities', () => {
   beforeEach(() => {
     document.body.innerHTML = '';

--- a/test/utils/federated.test.js
+++ b/test/utils/federated.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { getFederatedUrl, getFederatedContentRoot } from '../../libs/utils/federated.js';
 
-const baseHost = 'https://www.stage.adobe.com';
+const baseHost = 'https://main--federal--adobecom.hlx.page';
 
 describe('Federated navigation utilities', () => {
   describe('getFederatedContentRoot', () => {


### PR DESCRIPTION
Undo's https://github.com/adobecom/milo/pull/1973 due to several reasons.
- Proxying federal content through stage.adobe.com adds a very visible VPN requirement to viewing a wide variety of pages
- PSI checks on hlx.page can't access stage.adobe.com
- Deviating from the norm (hlx.page fetches hlx.page) leads to a long tail of bugs within authoring tools (preflight, loc, etc.) that don't expect this pattern.

If we ever get a hard requirement to have authentication enabled on the federal project, we can revisit this. Given the negative aspects, I'd consider adding MS-authentication to the federal project a technical limitation for now.

Resolves: [MWPW-154965](https://jira.corp.adobe.com/browse/MWPW-154965)

## Testing instructions
- Be on VPN
- Log in on a consumer page that uses federal content
- See the federal nav popping up, without further authentication 

Regression links
- https://milo.stage.adobe.com/drafts/osahin/gnav-1?martech=off#
- https://milo.adobe.com/drafts/osahin/gnav-1?martech=off# 

## Test URLs
**Milo hlx.page now fetches content from hlx.page**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/gnav-1
- After: https://mwpw-154965--milo--adobecom.hlx.page/drafts/osahin/gnav-1

**Milo hlx.live should fetch content from hlx.live** 
- Before: https://main--milo--adobecom.hlx.live/drafts/osahin/gnav-1
- After: https://mwpw-154965--milo--adobecom.hlx.live/drafts/osahin/gnav-1
