### PR TITLE
Correct error messages for duplicate files

### DIFF
--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -130,9 +130,10 @@ const merge = async ({ prs, type }) => {
 
   for await (const { number, files, html_url, title } of prs) {
     try {
-      if (files.some((file) => SEEN[file])) {
+      const duplicateFile = files.find((file) => SEEN[file]);
+      if (duplicateFile) {
         commentOnPR(
-          `Skipped ${number}: ${title} due to file "${file}" overlap. Merging will be attempted in the next batch`,
+          `Skipped ${number}: "${title}" due to file "${duplicateFile}" overlap. Merging will be attempted in the next batch`,
           number
         );
         continue;


### PR DESCRIPTION
Noticed an error [here](https://github.com/adobecom/milo/pull/2593#issuecomment-2247169707) for the stage to main workflow. 


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://correctly-error-on-duplicate-files--milo--adobecom.hlx.page/?martech=off
