### PR TITLE
MWPW-152336 - Table tooltip fixes

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -602,7 +602,6 @@ header.global-navigation {
     right: initial;
   }
   
-
   [dir="rtl"] .section-row-title .milo-tooltip.top::after,
   [dir="rtl"] .section-row-title .milo-tooltip.bottom::after,
   [dir="rtl"] .section-row-title .milo-tooltip.left::after,

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -382,10 +382,7 @@
   transform: translateY(-50%);
 }
 
-[dir="rtl"] .section-row-title .milo-tooltip.top::after,
-[dir="rtl"] .section-row-title .milo-tooltip.bottom::after,
-[dir="rtl"] .section-row-title .milo-tooltip.left::after,
-[dir="rtl"] .section-row-title .milo-tooltip.right::after {
+[dir="rtl"] .section-row-title .milo-tooltip:is(.top, .bottom, .left, .right)::after {
   left: -8px;
   margin: 0 4px 0 -4px;
   top: 50%;
@@ -570,10 +567,7 @@ header.global-navigation {
     background-color: var(--color-gray-100);
   }
 
-  .section-row-title .milo-tooltip.top::before,
-  .section-row-title .milo-tooltip.bottom::before,
-  .section-row-title .milo-tooltip.left::before,
-  .section-row-title .milo-tooltip.right::before {
+  .section-row-title .milo-tooltip:is(.top, .bottom, .left, .right)::before {
     left: initial;
     margin: 0 12px 0 0;
     right: 100%;
@@ -581,10 +575,7 @@ header.global-navigation {
     transform: translateY(-50%);
   }
 
-  .section-row-title .milo-tooltip.top::after,
-  .section-row-title .milo-tooltip.bottom::after,
-  .section-row-title .milo-tooltip.left::after,
-  .section-row-title .milo-tooltip.right::after {
+  .section-row-title .milo-tooltip:is(.top, .bottom, .left, .right)::after {
     left: -8px;
     margin: 0 4px 0 -4px;
     top: 50%;
@@ -593,19 +584,13 @@ header.global-navigation {
     border-color: transparent transparent transparent #0469E3;
   }
 
-  [dir="rtl"] .section-row-title .milo-tooltip.top::before,
-  [dir="rtl"] .section-row-title .milo-tooltip.bottom::before,
-  [dir="rtl"] .section-row-title .milo-tooltip.left::before,
-  [dir="rtl"] .section-row-title .milo-tooltip.right::before {
+  [dir="rtl"] .section-row-title .milo-tooltip:is(.top, .bottom, .left, .right)::before {
     left: 100%;
     margin: 0 0 0 12px;
     right: initial;
   }
   
-  [dir="rtl"] .section-row-title .milo-tooltip.top::after,
-  [dir="rtl"] .section-row-title .milo-tooltip.bottom::after,
-  [dir="rtl"] .section-row-title .milo-tooltip.left::after,
-  [dir="rtl"] .section-row-title .milo-tooltip.right::after {
+  [dir="rtl"] .section-row-title .milo-tooltip:is(.top, .bottom, .left, .right)::after {
     border-color: transparent #0469E3 transparent transparent;
     left: 100%;
     margin: 0 0 0 -4px;

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -390,8 +390,8 @@
   margin: 0 4px 0 -4px;
   top: 50%;
   transform: translateY(-50%);
-  border: 8px solid #0469E3;
-  border-color: transparent transparent transparent #0469E3;
+  border: 8px solid transparent;
+  border-left-color: #0469E3;
 }
 
 /* hover */

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -374,10 +374,7 @@
   margin-left: 16px;
 }
 
-[dir="rtl"] .section-row-title .milo-tooltip.top::before,
-[dir="rtl"] .section-row-title .milo-tooltip.bottom::before,
-[dir="rtl"] .section-row-title .milo-tooltip.left::before,
-[dir="rtl"] .section-row-title .milo-tooltip.right::before {
+[dir="rtl"] .section-row-title .milo-tooltip:is(.top, .bottom, .left, .right)::before {
   left: initial;
   margin: 0 12px 0 0;
   right: 100%;

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -374,6 +374,29 @@
   margin-left: 16px;
 }
 
+[dir="rtl"] .section-row-title .milo-tooltip.top::before,
+[dir="rtl"] .section-row-title .milo-tooltip.bottom::before,
+[dir="rtl"] .section-row-title .milo-tooltip.left::before,
+[dir="rtl"] .section-row-title .milo-tooltip.right::before {
+  left: initial;
+  margin: 0 12px 0 0;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+[dir="rtl"] .section-row-title .milo-tooltip.top::after,
+[dir="rtl"] .section-row-title .milo-tooltip.bottom::after,
+[dir="rtl"] .section-row-title .milo-tooltip.left::after,
+[dir="rtl"] .section-row-title .milo-tooltip.right::after {
+  left: -8px;
+  margin: 0 4px 0 -4px;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 8px solid #0469E3;
+  border-color: transparent transparent transparent #0469E3;
+}
+
 /* hover */
 @media (min-width: 900px) {
   .table .col.hover {
@@ -548,6 +571,49 @@ header.global-navigation {
     grid-row: 1;
     grid-column: 1 / x;
     background-color: var(--color-gray-100);
+  }
+
+  .section-row-title .milo-tooltip.top::before,
+  .section-row-title .milo-tooltip.bottom::before,
+  .section-row-title .milo-tooltip.left::before,
+  .section-row-title .milo-tooltip.right::before {
+    left: initial;
+    margin: 0 12px 0 0;
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .section-row-title .milo-tooltip.top::after,
+  .section-row-title .milo-tooltip.bottom::after,
+  .section-row-title .milo-tooltip.left::after,
+  .section-row-title .milo-tooltip.right::after {
+    left: -8px;
+    margin: 0 4px 0 -4px;
+    top: 50%;
+    transform: translateY(-50%);
+    border: 8px solid #0469E3;
+    border-color: transparent transparent transparent #0469E3;
+  }
+
+  [dir="rtl"] .section-row-title .milo-tooltip.top::before,
+  [dir="rtl"] .section-row-title .milo-tooltip.bottom::before,
+  [dir="rtl"] .section-row-title .milo-tooltip.left::before,
+  [dir="rtl"] .section-row-title .milo-tooltip.right::before {
+    left: 100%;
+    margin: 0 0 0 12px;
+    right: initial;
+  }
+  
+
+  [dir="rtl"] .section-row-title .milo-tooltip.top::after,
+  [dir="rtl"] .section-row-title .milo-tooltip.bottom::after,
+  [dir="rtl"] .section-row-title .milo-tooltip.left::after,
+  [dir="rtl"] .section-row-title .milo-tooltip.right::after {
+    border-color: transparent #0469E3 transparent transparent;
+    left: 100%;
+    margin: 0 0 0 -4px;
+    right: initial;
   }
 
   .table .row-heading .col:nth-child(n+1) {


### PR DESCRIPTION
* force tooltip positioning for row-title in mobile and rtl scenarios so they are always fully visible

Resolves: [MWPW-152336](https://jira.corp.adobe.com/browse/MWPW-152336)


**Test URLs:**
- Before: https://table-review--milo--adobecom.hlx.page/drafts/colloyd/table/sample-table?martech=off
- After: https://table-tooltip-visibility--milo--colloyd.hlx.page/drafts/colloyd/table/sample-table?martech=off

Testing notes: Tooltip positioning in row titles in mobile are truncated in the before, they are forced to be visible in the after. This also applies for rtl in desktop on mobile.