### PR TITLE
[MWPW-155103] Removed query params from the adminPageUri 

### DIFF
--- a/libs/blocks/graybox-promote/components/graybox-promote-lit.js
+++ b/libs/blocks/graybox-promote/components/graybox-promote-lit.js
@@ -220,7 +220,7 @@ class GrayboxPromote extends LitElement {
           const { root, gbRoot, driveId } = spData;
           const mainRepo = repo.replace('-graybox', '');
           const params = {
-            adminPageUri: `https://milo.adobe.com/tools/graybox?ref=${ref}&repo=${mainRepo}&owner=${owner}&host=business.adobe.com&project=${mainRepo.toUpperCase()}&referrer=MOCK_REF`,
+            adminPageUri: `https://milo.adobe.com/tools/graybox-promote?ref=${ref}&repo=${mainRepo}&owner=${owner}&host=business.adobe.com&project=${mainRepo.toUpperCase()}&referrer=MOCK_REF`,
             projectExcelPath: getProjectExcelPath(url),
             rootFolder: root,
             gbRootFolder: gbRoot,

--- a/libs/blocks/graybox-promote/components/graybox-promote-lit.js
+++ b/libs/blocks/graybox-promote/components/graybox-promote-lit.js
@@ -146,7 +146,7 @@ class GrayboxPromote extends LitElement {
         await getProjectInfo(this);
         await getSharepointData(this);
         const mainRepo = this.repo.replace('-graybox', '');
-        this.setup.adminPageUri = `https://milo.adobe.com/tools/graybox-promote?ref=${this.ref}&repo=${mainRepo}&owner=${this.owner}&host=business.adobe.com&project=${mainRepo.toUpperCase()}&referrer=MOCK_REF`;
+        this.setup.adminPageUri = `https://milo.adobe.com/tools/graybox-promote?ref=${this.ref}&repo=${mainRepo}&owner=${this.owner}&project=${mainRepo.toUpperCase()}`;
         await getGrayboxConfig(this);
         // TODO remove the line below after receiving user permissions
         this.setup.ignoreUserCheck = true;

--- a/libs/blocks/graybox-promote/components/graybox-promote-lit.js
+++ b/libs/blocks/graybox-promote/components/graybox-promote-lit.js
@@ -219,7 +219,23 @@ class GrayboxPromote extends LitElement {
         try {
           const { root, gbRoot, driveId } = spData;
           const mainRepo = repo.replace('-graybox', '');
-          const promote = await fetch(`${promoteUrl}?spToken=${this.spToken}&projectExcelPath=${getProjectExcelPath(url)}&rootFolder=${root}&gbRootFolder=${gbRoot}&experienceName=${experienceName}&adminPageUri=${`https://milo.adobe.com/tools/graybox?ref=${ref}%26repo=${mainRepo}%26owner=${owner}`}%26host=business.adobe.com%26project=${mainRepo.toUpperCase()}%26referrer=MOCK_REF&draftsOnly=${promoteDraftsOnly}&promoteIgnorePaths=${promoteIgnorePaths}&driveId=${driveId}&ignoreUserCheck=true`);
+          const params = {
+            adminPageUri: `https://milo.adobe.com/tools/graybox?ref=${ref}&repo=${mainRepo}&owner=${owner}&host=business.adobe.com&project=${mainRepo.toUpperCase()}&referrer=MOCK_REF`,
+            projectExcelPath: getProjectExcelPath(url),
+            rootFolder: root,
+            gbRootFolder: gbRoot,
+            experienceName,
+            draftsOnly: promoteDraftsOnly,
+            promoteIgnorePaths,
+            driveId,
+            ignoreUserCheck: true,
+            spToken: this.spToken,
+          };
+          const promote = await fetch(promoteUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams(params).toString(),
+          });
           const promoteRes = await promote.json();
           if (promoteRes?.code === 200) {
             return 'Successfully promoted';

--- a/libs/blocks/graybox-promote/components/graybox-promote-lit.js
+++ b/libs/blocks/graybox-promote/components/graybox-promote-lit.js
@@ -86,6 +86,8 @@ const getGrayboxConfig = async (ref, repo, owner, grayboxIoEnv) => {
 
   const grayboxData = sheet.graybox?.data;
 
+  if (!grayboxIoEnv) grayboxIoEnv = 'stage';
+
   return {
     promoteDraftsOnly:
       getSheetValue(

--- a/libs/blocks/graybox-promote/components/graybox-promote-lit.js
+++ b/libs/blocks/graybox-promote/components/graybox-promote-lit.js
@@ -35,12 +35,7 @@ const KEYS = {
 // const TELEMETRY = { application: { appName: 'Adobe Graybox Promote' } };
 
 const getJson = async (url, errMsg = `Failed to fetch ${url}`) => {
-  let res;
-  try {
-    res = await fetch(url);
-  } catch (err) {
-    throw new Error(errMsg, err.message);
-  }
+  const res = await fetch(url);
 
   if (!res.ok) {
     throw new Error(errMsg, res.status, res.statusText);
@@ -114,23 +109,15 @@ const getSharepointData = async (url) => {
 };
 
 const getFilePath = async ({ ref, repo, owner, excelRef } = {}) => {
-  try {
-    const status = await fetch(`${ADMIN}/status/${owner}/${repo}/${ref}?editUrl=${excelRef}`);
-    if (!status.ok) throw new Error('Failed to fetch file path');
-    return (new URL((await status.json())?.preview?.url)).pathname;
-  } catch (e) {
-    throw new Error(`Error getting file path: ${e.message}`);
-  }
+  const status = await fetch(`${ADMIN}/status/${owner}/${repo}/${ref}?editUrl=${excelRef}`);
+  if (!status.ok) throw new Error('Failed to fetch file path');
+  return (new URL((await status.json())?.preview?.url))?.pathname;
 };
 
 const getPreviewUrl = async ({ owner, repo, ref, filePath } = {}) => {
-  try {
-    const res = await fetch(`${ADMIN}/preview/${owner}/${repo}/${ref}${filePath}`, { method: 'POST' });
-    if (!res.ok) throw new Error('Failed to fetch preview URL');
-    return new URL((await res.json())?.preview?.url);
-  } catch (e) {
-    throw new Error(`Error getting preview URL: ${e.message}`);
-  }
+  const res = await fetch(`${ADMIN}/preview/${owner}/${repo}/${ref}${filePath}`, { method: 'POST' });
+  if (!res.ok) throw new Error('Failed to fetch preview URL');
+  return new URL((await res.json())?.preview?.url);
 };
 
 class GrayboxPromote extends LitElement {

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -4,29 +4,31 @@
   "libraries": [
     {
       "text": "Blocks",
-      "paths": ["https://main--milo--adobecom.hlx.page/docs/library/blocks.json"]
+      "paths": [
+        "https://main--milo--adobecom.hlx.page/docs/library/blocks.json"
+      ]
     }
   ],
   "plugins": [
     {
       "id": "path",
       "title": "Path",
-      "environments": [ "edit" ],
+      "environments": ["edit"],
       "url": "/tools/path-finder",
       "isPalette": true,
       "passReferrer": true,
       "passConfig": true,
       "paletteRect": "top: 50%; left: 50%; transform: translate(-50%,-50%); height: 84px; width: 900px; overflow: hidden; border-radius: 6px; box-shadow: 0 20px 35px 0px rgba(0, 0, 0, 0.5);",
-      "includePaths": [ "**.docx**", "**.xlsx**" ]
+      "includePaths": ["**.docx**", "**.xlsx**"]
     },
     {
       "id": "library",
       "title": "Library",
-      "environments": [ "edit" ],
+      "environments": ["edit"],
       "isPalette": true,
       "paletteRect": "top: auto; bottom: 25px; left: 25px; height: 388px; width: 360px;",
       "url": "/tools/library?skipConsent=true",
-      "includePaths": [ "**.docx**" ]
+      "includePaths": ["**.docx**"]
     },
     {
       "id": "tools",
@@ -37,32 +39,32 @@
       "containerId": "tools",
       "id": "localize",
       "title": "Localize",
-      "environments": [ "edit" ],
+      "environments": ["edit"],
       "url": "/tools/loc/index.html?project=milo--adobecom",
       "passReferrer": true,
-      "excludePaths": [ "/**" ],
-      "includePaths": [ "**/:x**" ]
+      "excludePaths": ["/**"],
+      "includePaths": ["**/:x**"]
     },
     {
       "containerId": "tools",
       "id": "localize-v2",
       "title": "Localize project (V2)",
-      "environments": [ "edit" ],
+      "environments": ["edit"],
       "url": "https://locui--milo--adobecom.hlx.page/tools/loc",
       "passReferrer": true,
       "passConfig": true,
-      "excludePaths": [ "/**" ],
-      "includePaths": [ "**/:x**" ]
+      "excludePaths": ["/**"],
+      "includePaths": ["**/:x**"]
     },
     {
       "containerId": "tools",
       "id": "floodgate",
       "title": "Floodgate",
-      "environments": [ "edit" ],
+      "environments": ["edit"],
       "url": "/tools/floodgate/index.html?project=milo--adobecom",
       "passReferrer": true,
-      "excludePaths": [ "/**" ],
-      "includePaths": [ "**/:x**" ]
+      "excludePaths": ["/**"],
+      "includePaths": ["**/:x**"]
     },
     {
       "containerId": "tools",
@@ -91,31 +93,31 @@
       "containerId": "tools",
       "id": "offerpreview",
       "title": "Offer preview",
-      "environments": [ "edit" ],
+      "environments": ["edit"],
       "isPalette": true,
       "paletteRect": "top: auto; bottom: 25px; left: 75px; height: 388px; width: 360px;",
       "url": "/tools/commerce",
-      "includePaths": [ "**.docx**" ]
+      "includePaths": ["**.docx**"]
     },
     {
       "containerId": "tools",
       "id": "locales",
       "title": "Locales",
-      "environments": [ "edit", "dev", "preview", "live" ],
+      "environments": ["edit", "dev", "preview", "live"],
       "isPalette": true,
       "passConfig": true,
       "passReferrer": true,
       "paletteRect": "top: auto; bottom: 25px; left: 75px; height: 388px; width: 360px;",
       "url": "/tools/locale-nav",
-      "includePaths": [ "**.docx**" ]
+      "includePaths": ["**.docx**"]
     },
     {
       "containerId": "tools",
       "id": "ost",
       "title": "Use offer",
-      "environments": [ "edit", "dev", "preview" ],
+      "environments": ["edit", "dev", "preview"],
       "url": "https://milo.adobe.com/tools/ost",
-      "includePaths": [ "**.docx**" ],
+      "includePaths": ["**.docx**"],
       "passConfig": true,
       "passReferrer": true
     },
@@ -140,43 +142,43 @@
       "containerId": "tools",
       "id": "version-history",
       "title": "Version History",
-      "environments": [ "edit" ],
+      "environments": ["edit"],
       "url": "/tools/version-history",
       "isPalette": true,
       "passReferrer": true,
       "passConfig": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 498px; width: 460px;",
-      "includePaths": [ "**.docx**", "**.xlsx**" ]
+      "includePaths": ["**.docx**", "**.xlsx**"]
     },
     {
       "containerId": "tools",
       "id": "graybox-promote",
       "title": "Graybox Promote",
-      "environments": [ "preview" ],
+      "environments": ["edit"],
       "url": "/tools/graybox-promote",
       "isPalette": true,
       "passReferrer": true,
       "passConfig": true,
       "paletteRect": "top: auto; bottom: 20px; left: 20px; height: 498px; width: 460px;",
-      "includePaths": [ "*.json" ]
+      "includePaths": ["*.json"]
     },
     {
       "containerId": "tools",
       "id": "caas-configurator",
       "title": "CaaS Configurator",
-      "environments": [ "edit", "preview", "dev" ],
+      "environments": ["edit", "preview", "dev"],
       "url": "https://milo.adobe.com/tools/caas",
       "isPalette": false,
-      "includePaths": [ "**.docx**"]
+      "includePaths": ["**.docx**"]
     },
     {
       "containerId": "tools",
       "id": "faas-configurator",
       "title": "FaaS Configurator",
-      "environments": [ "edit", "preview", "dev" ],
+      "environments": ["edit", "preview", "dev"],
       "url": "https://milo.adobe.com/tools/faas",
       "isPalette": false,
-      "includePaths": [ "**.docx**"]
+      "includePaths": ["**.docx**"]
     }
   ]
 }


### PR DESCRIPTION
## Description
This PR removes the `host` and `referrer` query params from the adminPageUri, in the Graybox promote API call payload, as they are no longer necessary.

## Related Issue
Resolves: [MWPW-155103](https://jira.corp.adobe.com/browse/MWPW-155103)

## Testing instructions
This is part of the Garybox promote feature and all testing regarding it will be done using [this ticket.](https://jira.corp.adobe.com/browse/MWPW-153227)

## Test URL
https://grayboxui--milo--adobecom.hlx.page/drafts/rbogos/page-default?martech=off
