### PR TITLE
MWPW-154998 [MEP][MILO] Manifests do not execute in the right order when there is a disabled manifest

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -615,6 +615,7 @@ const createDefaultExperiment = (manifest) => ({
   disabled: manifest.disabled,
   event: manifest.event,
   manifest: manifest.manifestPath,
+  executionOrder: '1-1',
   selectedVariant: { commands: [], fragments: [] },
   selectedVariantName: 'default',
   variantNames: ['all'],

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -631,7 +631,7 @@ describe('Utils', () => {
       document.head.innerHTML = await readFile({ path: './mocks/head-personalization.html' });
       await utils.loadArea();
       const resultConfig = utils.getConfig();
-      const resultExperiment = resultConfig.mep.experiments[2];
+      const resultExperiment = resultConfig.mep.experiments[0];
       expect(resultConfig.mep.preview).to.be.true;
       expect(resultConfig.mep.experiments.length).to.equal(3);
       expect(resultExperiment.manifest).to.equal('/products/special-offers-manifest.json');


### PR DESCRIPTION
* Adds default execution order to disabled promos.
Resolves: [MWPW-154998](https://jira.corp.adobe.com/browse/MWPW-154998)

Manifests are sorted based on their type and execution order.  When a promo is "on" but not in the current date range, there is a default JS object created so we don't have to download the manifest.  But the default object does not have an execution order, thus distorting the sort.  Promos should be listed after personalization.

QA Instructions: open the MEP button in the before and after links.  The personalization manifest should be listed first in the after link. (photoshop.js)

Test URLs:
Before: https://main--cc--adobecom.hlx.page/products/photoshop?mep&at_preview_token=uJdpE_R7koOtTuEQ9TFfnQ&at_preview_index=1_3&at_preview_listed_activities_only=true
After: https://main--cc--adobecom.hlx.page/products/photoshop?milolibs=mepaddpromoorder&mep&at_preview_token=uJdpE_R7koOtTuEQ9TFfnQ&at_preview_index=1_3&at_preview_listed_activities_only=true

Psi check:
https://mepaddpromoorder--milo--adobecom.hlx.page/?martech=off