### PR TITLE
[MWPW-153267] Expand table to parent grid size

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -12,6 +12,10 @@
   border-color: var(--border-color);
 }
 
+.section[class *= "grid-width-"] .table {
+  width: 100%;
+}
+
 .table a:not([class*="button"]) {
   display: inline-block;
 }
@@ -540,6 +544,10 @@ header.global-navigation {
   .table,
   .table.merch {
     margin: 0 30px;
+  }
+
+  .section[class *= "grid-width-"] .table {
+    margin: 0;
   }
 
   .table:not(.merch) .row .section-head-title,


### PR DESCRIPTION
This adapts the table's width when it is nested inside a section that has a set grid width via section metadata.

Resolves: [MWPW-153267](https://jira.corp.adobe.com/browse/MWPW-153267)

| Before | After |
| ------------- | ------------- |
| <img width="375" alt="Screenshot 2024-07-26 at 15 24 08" src="https://github.com/user-attachments/assets/5adc8235-daa8-4a6d-bb41-d9cfacfe2cc8"> | <img width="769" alt="Screenshot 2024-07-26 at 15 25 01" src="https://github.com/user-attachments/assets/05faa260-ba01-4042-9f6a-8837ef277b80"> |

**Test URLs:**
- Before: https://table-review--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-kyung-overhaul?martech=off
- After: https://table-in-grid--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-kyung-overhaul?martech=off
