### PR TITLE
MWPW-155314 [MEP] Enable Entitlements + Operator

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -576,20 +576,26 @@ const checkForParamMatch = (paramStr) => {
   return false;
 };
 
+function trimNames(arr) {
+  return arr.map((v) => v.trim()).filter(Boolean);
+}
+export function buildVariantInfo(variantNames) {
+  return variantNames.reduce((acc, name) => {
+    let nameArr = [name];
+    if (!name.startsWith(TARGET_EXP_PREFIX)) nameArr = name.split(',');
+    acc[name] = trimNames(nameArr);
+    acc.allNames = [...acc.allNames, ...trimNames(name.split(/[,&]|\bnot\b/))];
+    return acc;
+  }, { allNames: [] });
+}
+
 async function getPersonalizationVariant(manifestPath, variantNames = [], variantLabel = null) {
   const config = getConfig();
   if (config.mep?.variantOverride?.[manifestPath]) {
     return config.mep.variantOverride[manifestPath];
   }
 
-  const variantInfo = variantNames.reduce((acc, name) => {
-    let nameArr = [name];
-    if (!name.startsWith(TARGET_EXP_PREFIX)) nameArr = name.split(',');
-    const vNames = nameArr.map((v) => v.trim()).filter(Boolean);
-    acc[name] = vNames;
-    acc.allNames = [...acc.allNames, ...vNames];
-    return acc;
-  }, { allNames: [] });
+  const variantInfo = buildVariantInfo(variantNames);
 
   const entitlementKeys = Object.values(await getEntitlementMap());
   const hasEntitlementTag = entitlementKeys.some((tag) => variantInfo.allNames.includes(tag));

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -850,6 +850,9 @@ export async function loadIms() {
     if (!window.adobeIMS?.isSignedInUser()) {
       getConfig().entitlements([]);
     }
+  }).catch((e) => {
+    getConfig().entitlements([]);
+    throw e;
   });
 
   return imsLoaded;

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -4,7 +4,7 @@ import { assert, stub } from 'sinon';
 import { getConfig, setConfig } from '../../../libs/utils/utils.js';
 import {
   handleFragmentCommand, applyPers,
-  init, matchGlob, createFrag, combineMepSources,
+  init, matchGlob, createFrag, combineMepSources, buildVariantInfo,
 } from '../../../libs/features/personalization/personalization.js';
 import spoofParams from './spoofParams.js';
 import mepSettings from './mepSettings.js';
@@ -173,6 +173,109 @@ describe('Functional Test', () => {
     await loadManifestAndSetResponse('./mocks/manifestUseEntitlements.json');
     await init(mepSettings);
     expect(getConfig().mep?.martech).to.equal('|fireflies|manifest');
+  });
+
+  it('should resolve variants correctly with entitlements and tags exist', async () => {
+    expect(buildVariantInfo(['cc-all-apps-any & desktop'])).to.deep.equal({
+      allNames: [
+        'cc-all-apps-any',
+        'desktop',
+      ],
+      'cc-all-apps-any & desktop': [
+        'cc-all-apps-any & desktop',
+      ],
+    });
+    expect(buildVariantInfo(['desktop & cc-all-apps-any'])).to.deep.equal({
+      allNames: [
+        'desktop',
+        'cc-all-apps-any',
+      ],
+      'desktop & cc-all-apps-any': [
+        'desktop & cc-all-apps-any',
+      ],
+    });
+    expect(buildVariantInfo(['cc-all-apps-any'])).to.deep.equal({
+      allNames: [
+        'cc-all-apps-any',
+      ],
+      'cc-all-apps-any': [
+        'cc-all-apps-any',
+      ],
+    });
+    expect(buildVariantInfo(['phone, cc-all-apps-any'])).to.deep.equal({
+      allNames: [
+        'phone',
+        'cc-all-apps-any',
+      ],
+      'phone, cc-all-apps-any': [
+        'phone',
+        'cc-all-apps-any',
+      ],
+    });
+    expect(buildVariantInfo(['cc-all-apps-any, not desktop'])).to.deep.equal({
+      allNames: [
+        'cc-all-apps-any',
+        'desktop',
+      ],
+      'cc-all-apps-any, not desktop': [
+        'cc-all-apps-any',
+        'not desktop',
+      ],
+    });
+    expect(buildVariantInfo(['phone & not cc-all-apps-any'])).to.deep.equal({
+      allNames: [
+        'phone',
+        'cc-all-apps-any',
+      ],
+      'phone & not cc-all-apps-any': [
+        'phone & not cc-all-apps-any',
+      ],
+    });
+    expect(buildVariantInfo(['not phone & not cc-all-apps-any'])).to.deep.equal({
+      allNames: [
+        'phone',
+        'cc-all-apps-any',
+      ],
+      'not phone & not cc-all-apps-any': [
+        'not phone & not cc-all-apps-any',
+      ],
+    });
+    expect(buildVariantInfo(['not cc-free & not cc-all-apps-any'])).to.deep.equal({
+      allNames: [
+        'cc-free',
+        'cc-all-apps-any',
+      ],
+      'not cc-free & not cc-all-apps-any': [
+        'not cc-free & not cc-all-apps-any',
+      ],
+    });
+    expect(buildVariantInfo(['not cc-free, not cc-all-apps-any'])).to.deep.equal({
+      allNames: [
+        'cc-free',
+        'cc-all-apps-any',
+      ],
+      'not cc-free, not cc-all-apps-any': [
+        'not cc-free',
+        'not cc-all-apps-any',
+      ],
+    });
+    expect(buildVariantInfo(['not cc-free, not cc-all-apps-any', 'desktop & cc-paid, ios'])).to.deep.equal({
+      allNames: [
+        'cc-free',
+        'cc-all-apps-any',
+        'desktop',
+        'cc-paid',
+        'ios',
+      ],
+      'not cc-free, not cc-all-apps-any': [
+        'not cc-free',
+        'not cc-all-apps-any',
+      ],
+      'desktop & cc-paid, ios': [
+        'desktop & cc-paid',
+        'ios',
+      ],
+    });
   });
 
   it('invalid selector should output error to console', async () => {


### PR DESCRIPTION
This PR aims to address this scenario: when an experience column is authored to like `desktop & cc-all-apps-any` in MEP Manifest, right now, unless there's coincidently another column like `cc-all-apps-any`, the variant `desktop & cc-all-apps-any` will never get selected. Reason is that current logic in `getPersonalizationVariant()` for splitting variant name doesn't include `&`, so `hasEntitlementTag` will stay false, leading to no entitlement resolution. The code change tries to split by `&` when building out `variantInfo.allNames`. It is used to check if any entitlement tags are used. `variantInfo[name]` is used for variant mapping and thus unmodified.

This bug might again be trickier to reproduce, due to Milo by default doesn't do entitlements when logged out, and IMS only working on very specific branch links. ~~So on the feature branch, the page is in a deadlock situation, with MEP waiting for entitlements that will never be resolved.~~ (added a catch for IMS error so entitlements will still resolve). But you can create a MEP experience like https://gnav--milo--adobecom.hlx.page/drafts/jinglhua/desktop-entitlements and https://main--milo--adobecom.hlx.page/drafts/jinglhua/desktop-ent.json and then use logs or breakpoints around `variantInfo` and confirm that entitlements not getting resolved currently. To verify my fix, do the same, and you should see that at least it tries to resolve (will be resolved to an empty array due to IMS).

Resolves: https://jira.corp.adobe.com/browse/MWPW-155314

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/jinglhua/desktop-entitlements
- After: https://mep-entitlements-operator--milo--adobecom.hlx.page/drafts/jinglhua/desktop-entitlements
