### PR TITLE
MWPW-147867 - [marquee] support RTL for loc

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -449,10 +449,6 @@
     padding: var(--spacing-xl) 0;
   }
 
-  html[dir="rtl"] .marquee.split .foreground.container {
-    flex-direction: row-reverse;
-  }
-
   .marquee.split .foreground.container .text {
     max-width: calc(50% - var(--grid-column-width));
   }
@@ -490,6 +486,10 @@
 
   .marquee.split.row-reversed .foreground.container {
     justify-content: flex-end;
+  }
+
+  html[dir="rtl"] .marquee.split .foreground.container {
+    flex-direction: row-reverse;
   }
 
   html[dir="rtl"] .marquee.split.row-reversed .foreground.container {

--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -449,6 +449,10 @@
     padding: var(--spacing-xl) 0;
   }
 
+  html[dir="rtl"] .marquee.split .foreground.container {
+    flex-direction: row-reverse;
+  }
+
   .marquee.split .foreground.container .text {
     max-width: calc(50% - var(--grid-column-width));
   }

--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -492,6 +492,14 @@
     justify-content: flex-start;
   }
 
+  html[dir="rtl"] .marquee.support-rtl.split .foreground.container {
+    flex-direction: row;
+  }
+
+  html[dir="rtl"] .marquee.support-rtl.split.row-reversed .foreground.container {
+    flex-direction: row-reverse;
+  }
+
   .marquee.split .asset img,
   .marquee.split.small .asset img,
   .marquee.split.large .asset img,
@@ -722,14 +730,6 @@
   html[dir="rtl"] .marquee.split.one-third:not(.row-reversed) .asset.bleed {
     left: 0;
     right: auto;
-  }
-  
-  html[dir="rtl"] .marquee.support-rtl.split .foreground.container {
-    flex-direction: row;
-  }
-
-  html[dir="rtl"] .marquee.support-rtl.split.row-reversed .foreground.container {
-    flex-direction: row-reverse;
   }
 
   .marquee.split.one-third .foreground.container .text,

--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -449,10 +449,6 @@
     padding: var(--spacing-xl) 0;
   }
 
-  html[dir="rtl"] .marquee.split .foreground.container {
-    flex-direction: row-reverse;
-  }
-
   .marquee.split .foreground.container .text {
     max-width: calc(50% - var(--grid-column-width));
   }
@@ -487,7 +483,6 @@
     max-height: 56px;
     max-width: 212px;
   }
-
 
   .marquee.split.row-reversed .foreground.container {
     justify-content: flex-end;
@@ -727,6 +722,14 @@
   html[dir="rtl"] .marquee.split.one-third:not(.row-reversed) .asset.bleed {
     left: 0;
     right: auto;
+  }
+  
+  html[dir="rtl"] .marquee.support-rtl.split .foreground.container {
+    flex-direction: row;
+  }
+
+  html[dir="rtl"] .marquee.support-rtl.split.row-reversed .foreground.container {
+    flex-direction: row-reverse;
   }
 
   .marquee.split.one-third .foreground.container .text,


### PR DESCRIPTION
Added an opt in variant `support-rtl` to the [marquee] block to better support localization.

Text alignment in marquee block used on [this page ](https://main--cc--adobecom.hlx.page/mena_ar/products/illustrator/generative-recolor) are not working correctly with RTL geos rollout. 
Variation: marquee (split, dark, one-third, xl-button, static-links) 

Image and color is used as background.

expected result
![image-2024-05-07-22-53-50-950](https://github.com/user-attachments/assets/827c2c53-bec0-44a6-af91-6e42d2fc971c)

actual result
![image-2024-05-07-22-54-30-632](https://github.com/user-attachments/assets/44d8c9ce-23f7-4081-b86d-3890c0af60c2)

URL: https://main--cc--adobecom.hlx.page/mena_ar/products/illustrator/generative-recolor

Resolves: [MWPW-147867](https://jira.corp.adobe.com/browse/MWPW-147867)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/marquee/marquee-rtl?martech=off
- After: https://rparrish-marquee-rtl--milo--adobecom.hlx.page/drafts/rparrish/marquee/marquee-rtl?martech=off

**Doc URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off
- After: https://rparrish-marquee-rtl--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off



**Testing Notes:**
Inspect the DOM and update the `<html dir="ltr" />` attribute to `<html dir="rtl" />` and verify the marquee copy is aligned.
Doc urls have no `support-rtl` variants authored so they will still display bad unless added to the block classList. 
