### PR TITLE
[MWPW-152181] Tabbing gets "stuck" after second instance of merch-card CTAs, within a segment blade

### DIFF
--- a/libs/features/mas/web-components/src/merch-card.js
+++ b/libs/features/mas/web-components/src/merch-card.js
@@ -637,6 +637,9 @@ export class MerchCard extends LitElement {
                 !e.shiftKey &&
                 document.activeElement === lastFocusableElement
             ) {
+                const merchCards = document.querySelectorAll(MERCH_CARD_NODE_NAME);
+                const lastMerchCard = merchCards[merchCards.length - 1];
+                if (this === lastMerchCard) return;
                 e.preventDefault();
                 e.stopImmediatePropagation();
             } else if (


### PR DESCRIPTION
Allow the default tab action to proceed if the current focused element is from the last merch card.

Resolves: [MWPW-152181](https://jira.corp.adobe.com/browse/MWPW-152181)

Test URLs:
Before: https://main--milo--adobecom.hlx.page/drafts/rosahu/rosahu
After: https://mwpw-152181--milo--rohitsahu.hlx.page/drafts/rosahu/rosahu