### PR TITLE
Correctly pass on the dataset

### DIFF
--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -7,8 +7,8 @@ const loadAdobeTv = (a) => {
   const bgBlocks = ['aside', 'marquee', 'hero-marquee'];
   if (a.href.includes('.mp4') && bgBlocks.some((b) => a.closest(`.${b}`))) {
     a.classList.add('hide');
-    const { href, hash } = a;
-    const attrs = getVideoAttrs(hash || 'autoplay');
+    const { href, hash, dataset } = a;
+    const attrs = getVideoAttrs(hash || 'autoplay', dataset);
     const video = `<video ${attrs}>
           <source src="${href}" type="video/mp4" />
         </video>`;


### PR DESCRIPTION
Pass on the dataset like the [video block](https://github.com/adobecom/milo/blob/stage/libs/blocks/video/video.js#L18) to correctly generate posters for videos.

Resolves: [MWPW-155515](https://jira.corp.adobe.com/browse/MWPW-155515)

### Test Instructions
Ensure the poster attribute is added to the video in the html
**Before**
![Screenshot 2024-07-30 at 13 13 30](https://github.com/user-attachments/assets/806d7d56-88ec-4d26-8457-4c8cb3504c93)

**After**
![Screenshot 2024-07-30 at 13 13 41](https://github.com/user-attachments/assets/82a19467-1ba2-4f23-b755-e83206f8a903)

### LH Score improvements
Adding and authoring a poster for a video, will lead to a faster LCP in cases where the Geo routing would otherwise be picked.
![Screenshot 2024-07-30 at 13 20 15](https://github.com/user-attachments/assets/dd4fe141-fad9-4763-a69d-634d49fa75dd)

![Screenshot 2024-07-30 at 13 20 27](https://github.com/user-attachments/assets/0c3fafd6-6446-4fb2-b2f1-19021151cf68)


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live?martech=off
- After: https://mwpw-155515--milo--adobecom.hlx.live?martech=off

- Before: https://main--bacom--adobecom.hlx.page/drafts/osahin/magento-commerce
- After: https://main--bacom--adobecom.hlx.page/drafts/osahin/magento-commerce?milolibs=mwpw-155515