### PR TITLE
MWPW-154124: use preview index

### DIFF
--- a/libs/blocks/merch-card-collection/merch-card-collection.js
+++ b/libs/blocks/merch-card-collection/merch-card-collection.js
@@ -27,8 +27,9 @@ const LITERAL_SLOTS = [
 // allows improve TBT by returning control to the main thread.
 // eslint-disable-next-line no-promise-executor-return
 const makePause = async (timeout = 0) => new Promise((resolve) => setTimeout(resolve, timeout));
-
 const BLOCK_NAME = 'merch-card-collection';
+const PROD_INDEX = 'query-index-cards.json';
+const PREVIEW_INDEX = 'query-index-cards-preview.json';
 
 const fail = (el, err = '') => {
   window.lana?.log(`Failed to initialize merch cards: ${err}`);
@@ -131,7 +132,9 @@ export function parsePreferences(elements) {
 /** Retrieve cards from query-index  */
 async function fetchCardsData(config, type, el) {
   let cardsData;
-  const endpointElement = el.querySelector('a[href*="query-index-cards.json"]');
+  const usePreviewIndex = config.env.name === 'stage' && !window.location.host.includes('.live');
+  const endpointElement = el.querySelector(`a[href*="${usePreviewIndex ? PREVIEW_INDEX : PROD_INDEX}"]`)
+                            ?? el.querySelector(`a[href*="${PROD_INDEX}"]`);
   if (!endpointElement) {
     throw new Error('No query-index endpoint provided');
   }

--- a/libs/blocks/merch-card-collection/merch-card-collection.js
+++ b/libs/blocks/merch-card-collection/merch-card-collection.js
@@ -138,7 +138,8 @@ async function fetchCardsData(config, type, el) {
   if (!endpointElement) {
     throw new Error('No query-index endpoint provided');
   }
-  endpointElement.remove();
+  el.querySelector(`a[href*="${PROD_INDEX}"]`)?.remove();
+  el.querySelector(`a[href*="${PREVIEW_INDEX}"]`)?.remove();
   let queryIndexCardPath = localizeLink(endpointElement.getAttribute('href'), config);
   if (/\.json$/.test(queryIndexCardPath)) {
     queryIndexCardPath = `${queryIndexCardPath}?sheet=${type}`;

--- a/test/blocks/merch-card-collection/merch-card-collection.test.js
+++ b/test/blocks/merch-card-collection/merch-card-collection.test.js
@@ -29,7 +29,7 @@ describe('Merch Cards', async () => {
       let data;
       const overrideUrl = /override-(.*).plain.html/;
       const overrideMatch = overrideUrl.exec(url);
-      const queryIndexMatch = /-cards.json/.test(url);
+      const queryIndexMatch = /-cards(-preview)?.json/.test(url);
       if ((overrideMatch && overrideRespondError) || (queryIndexMatch && queryIndexRespondError)) {
         return Promise.resolve({
           status: 500,
@@ -205,6 +205,26 @@ describe('Merch Cards', async () => {
     const el = document.getElementById('localizeQueryIndex');
     await init(el);
     expect(window.fetch.calledWith('https://main--milo--adobecom.hlx.live/fr/query-index-cards.json?sheet=catalog')).to.be.true;
+  });
+
+  it('should use preview query-index url if stage env and not hlx.live', async () => {
+    setConfig({
+      ...conf,
+      env: { name: 'stage' },
+    });
+    const el = document.getElementById('previewQueryIndex');
+    await init(el);
+    expect(window.fetch.calledWith('https://main--milo--adobecom.hlx.live/query-index-cards-preview.json?sheet=catalog')).to.be.true;
+  });
+
+  it('should default to prod index if preview is missing', async () => {
+    setConfig({
+      ...conf,
+      env: { name: 'stage' },
+    });
+    const el = document.getElementById('previewQueryIndexMissing');
+    await init(el);
+    expect(window.fetch.calledWith('https://main--milo--adobecom.hlx.live/query-index-cards.json?sheet=catalog')).to.be.true;
   });
 
   describe('error handling', async () => {

--- a/test/blocks/merch-card-collection/mocks/merch-card-collection.html
+++ b/test/blocks/merch-card-collection/mocks/merch-card-collection.html
@@ -111,6 +111,21 @@
         </div>
       </div>
     </div>
+    <div id="previewQueryIndex" class="merch-card-collection catalog">
+      <div>
+        <div>
+          <a href="https://main--milo--adobecom.hlx.live/query-index-cards.json">query index</a>
+          <a href="https://main--milo--adobecom.hlx.live/query-index-cards-preview.json">preview query index</a>
+        </div>
+      </div>
+    </div>
+    <div id="previewQueryIndexMissing" class="merch-card-collection catalog">
+      <div>
+        <div>
+          <a href="https://main--milo--adobecom.hlx.live/query-index-cards.json">query index</a>
+        </div>
+      </div>
+    </div>
     <div id="noQueryIndexEndpoint" class="merch-card-collection catalog">
       <div>
         <div>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Sorry for ugly cards in Milo, for shiny cards please check catalog collection.


Use custom index for Preview in Merch Card Collections.
If no preview index is authored, default to Prod Index.

Resolves: https://jira.corp.adobe.com/browse/MWPW-154124

## How to test
alternate between hlx.page and hlx.live and observe different Photoshop Card content descriptions ('PREVIEW CARD')
![image](https://github.com/user-attachments/assets/466ddb32-7e17-41e5-a014-6dc9946d4747)


In Network tab you can see `query-index-cards.json?sheet=catalog` loading for .live and `query-index-cards-preview.json?sheet=catalog` for .hlx.page.

## PROD Catalog Pages - expect no impact
hlx.live: https://main--cc--adobecom.hlx.live/products/catalog?milolibs=MWPW-154124-pi 
hlx.page: https://main--cc--adobecom.hlx.page/products/catalog?milolibs=MWPW-154124-pi

## TEST Catalog Pages - impact
hlx.live (uses prod index): https://main--cc--adobecom.hlx.live/drafts/mariia/catalog/catalog?milolibs=MWPW-154124-pi
hlx.page (uses preview index): https://main--cc--adobecom.hlx.page/drafts/mariia/catalog/catalog?milolibs=MWPW-154124-pi

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/mariia/pr/merch-collection?martech=off
- After: https://MWPW-154124-pi--milo--adobecom.hlx.live/drafts/mariia/pr/merch-collection?martech=off
