### PR TITLE
MWPW-146030 and MWPW-143704 Add fresco-any and cc-paid-no-stock

### DIFF
--- a/libs/features/personalization/entitlements.js
+++ b/libs/features/personalization/entitlements.js
@@ -20,6 +20,9 @@ const ENTITLEMENT_MAP = {
   '76e408f6-ab08-49f0-adb6-f9b4efcc205d': 'cc-free',
   '08216aa4-4a0f-4136-8b27-182212764a7c': 'dc-free',
   'fc2d5b34-fa75-4e80-9f23-7d4b40bcfc9b': 'cc-paid',
+  'c6927505-97b3-4655-995a-6452630fa9cb': 'fresco-any',
+  'e82be3ab-1fbc-4410-a099-af6ac6d5dffe': 'cc-paid-no-stock',
+
   // PEP segments
   '6cb0d58c-3a65-47e2-b459-c52bb158d5b6': 'lightroom-web-usage',
   'caa3de84-6336-4fa8-8db2-240fc88106cc': 'photoshop-signup-source',

--- a/libs/features/personalization/stage-entitlements.js
+++ b/libs/features/personalization/stage-entitlements.js
@@ -10,6 +10,7 @@ const STAGE_ENTITLEMENTS = {
   '47e204a3-220a-4e53-a95e-94b6eded0d26': '3d-substance-collection',
   '4ec7b469-42c9-4367-a7da-39f11a32d880': '3d-substance-texturing',
   '2a93b6cc-90a2-4cff-a32d-03c71d4692e6': 'cc-free',
+  '6d9880f1-fac9-4c5e-8094-fafaf8115b26': 'fresco-any',
   // PEP segments
   '9202b767-77dc-4e6e-8d74-488d9ef08900': 'lightroom-web-usage',
   '3a7ffcce-11b8-4242-8cdf-8c8d059ae1cd': 'photoshop-signup-source',


### PR DESCRIPTION
* Add 2 new entiltements to MEP.  One has no stage ID

Resolves: [MWPW-146030](https://jira.corp.adobe.com/browse/MWPW-146030) and [MWPW-143704](https://jira.corp.adobe.com/browse/MWPW-143704)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mepfrescoccpaid--milo--adobecom.hlx.page/?martech=off
