### PR TITLE
Attaching loadblock to window to provide alternative way of loading the script

### DIFF
--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -11,7 +11,6 @@ const envMap = {
   stage: 'https://www.stage.adobe.com',
   qa: 'https://feds--milo--adobecom.hlx.page',
 };
-
 export default async function loadBlock(configs, customLib) {
   const { footer, locale, env = 'prod' } = configs || {};
   const branch = new URLSearchParams(window.location.search).get('navbranch');
@@ -32,3 +31,5 @@ export default async function loadBlock(configs, customLib) {
     bootstrapBlock({ ...clientConfig, contentRoot: authoringPath, privacyId }, blockConfig.footer);
   }
 }
+
+window.loadNavigation = loadBlock;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Some apps are facing issues with dynamically loaded external scripts while bundling. Therefore, we are adding an alternative way of calling the function from the window object.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://feds--milo--adobecom.hlx.page/?martech=off

QA: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=feds
