### PR TITLE
Revert "MWPW-147867 - [marquee] support RTL for loc"

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -448,6 +448,10 @@
     padding: var(--spacing-xl) 0;
   }
 
+  html[dir="rtl"] .marquee.split .foreground.container {
+    flex-direction: row-reverse;
+  }
+
   .marquee.split .foreground.container .text {
     max-width: calc(50% - var(--grid-column-width));
   }
@@ -483,24 +487,13 @@
     max-width: 212px;
   }
 
+
   .marquee.split.row-reversed .foreground.container {
     justify-content: flex-end;
   }
 
-  html[dir="rtl"] .marquee.split .foreground.container {
-    flex-direction: row-reverse;
-  }
-
   html[dir="rtl"] .marquee.split.row-reversed .foreground.container {
     justify-content: flex-start;
-  }
-
-  html[dir="rtl"] .marquee.support-rtl.split .foreground.container {
-    flex-direction: row;
-  }
-
-  html[dir="rtl"] .marquee.support-rtl.split.row-reversed .foreground.container {
-    flex-direction: row-reverse;
   }
 
   .marquee.split .asset img,


### PR DESCRIPTION
Reverts adobecom/milo#2640 due to findings from @NadiiaSokolova which causes rtl to break in some currently working cases

Test URLs:

Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/marquee/marquee-rtl?martech=off
After: https://revert-2640-rparrish-marquee-rtl--milo--adobecom.hlx.page/drafts/rparrish/marquee/marquee-rtl?martech=off

Doc URLs:
Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off
After: https://revert-2640-rparrish-marquee-rtl--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off
