### PR TITLE
[MWPW-153894] Addressing overflowing table content on mobile

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -597,7 +597,7 @@ header.global-navigation {
     margin: 0 0 0 12px;
     right: initial;
   }
-  
+
   [dir="rtl"] .section-row-title .milo-tooltip:is(.top, .bottom, .left, .right)::after {
     border-color: transparent #0469E3 transparent transparent;
     left: 100%;
@@ -672,6 +672,10 @@ header.global-navigation {
   [dir="rtl"] .table .col-heading.force-last + .col-heading {
     border-top-left-radius: 0;
     border-top-right-radius: var(--border-radius);
+  }
+
+  .table:not(.merch) .section-row-title {
+    grid-column: 1 / span 2;
   }
 }
 

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -482,7 +482,10 @@ export default function init(el) {
   handleHighlight(el);
   if (isMerch) formatMerchTable(el);
 
+  let isDecorated = false;
+
   const handleTable = () => {
+    if (isDecorated) return;
     let originTable;
     let visibleHeadingsSelector = '.col-heading:not(.hidden, .col-1)';
     if (isMerch) {
@@ -506,9 +509,20 @@ export default function init(el) {
       deviceBySize = defineDeviceByScreenSize();
       handleResize();
     });
+
+    isDecorated = true;
   };
 
   window.addEventListener(MILO_EVENTS.DEFERRED, () => {
     handleTable();
   }, true);
+
+  const observer = new window.IntersectionObserver((entries) => {
+    if (entries.some((entry) => entry.isIntersecting)) {
+      observer.disconnect();
+      handleTable();
+    }
+  });
+
+  observer.observe(el);
 }


### PR DESCRIPTION
On mobile devices, if the table is the first block on the page, it could happen that its decoration took a long time, due to the fact that it depended on another Milo event. The logic has been adapted to prioritize the load of tables that are visible in the initial viewport. Another style quirk has been addressed, where certain table rows were expanding beyond the viewport on mobile devices.

| Before | After |
| ------------- | ------------- |
| <img width="413" alt="Table overflow before" src="https://github.com/user-attachments/assets/082d0f87-2b09-4bf0-9298-001d9539090b"> | <img width="413" alt="Table overflow after" src="https://github.com/user-attachments/assets/87d8b0e1-3ed0-4126-8666-f9fcbd05385d"> |

| Before | After |
| ------------- | ------------- |
| <img width="413" alt="Screenshot 2024-07-31 at 16 39 58" src="https://github.com/user-attachments/assets/648a5ded-c39d-4879-ac67-7796f0fc3023"> | <img width="413" alt="Table overflow after" src="https://github.com/user-attachments/assets/87d8b0e1-3ed0-4126-8666-f9fcbd05385d"> |

Resolves: [MWPW-153894](https://jira.corp.adobe.com/browse/MWPW-153894)

**Test URLs:**
- Before: https://table-review--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-mwpw-152305?martech=off
- After: https://overflowing-mobile-table--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-mwpw-152305?martech=off
