### PR TITLE
MWPW-147867 - [marquee] support RTL for loc - RePost

### DIFF
--- a/libs/blocks/marquee/marquee.css
+++ b/libs/blocks/marquee/marquee.css
@@ -487,13 +487,20 @@
     max-width: 212px;
   }
 
-
   .marquee.split.row-reversed .foreground.container {
     justify-content: flex-end;
   }
 
   html[dir="rtl"] .marquee.split.row-reversed .foreground.container {
     justify-content: flex-start;
+  }
+
+  html[dir="rtl"] .marquee.support-rtl.split .foreground.container {
+    flex-direction: row;
+  }
+
+  html[dir="rtl"] .marquee.support-rtl.split.row-reversed .foreground.container {
+    flex-direction: row-reverse;
   }
 
   .marquee.split .asset img,


### PR DESCRIPTION
FYI - I am reposting this PR. The previous one was reverted due to some issues found on stage. I believe this happened due to a selector position I moved for linting purposes that had some default layouts shift. 
Only new selectors are added in this pass, no linting changes, so no regression. 

---

Added an opt in variant `support-rtl` to the [marquee] block to better support localization.

Text alignment in marquee block used on [this page ](https://main--cc--adobecom.hlx.page/mena_ar/products/illustrator/generative-recolor)are not working correctly with RTL geos rollout.

Variation: marquee (split, dark, one-third, xl-button, static-links)

Image and color is used as background.

expected result
![image](https://github.com/user-attachments/assets/22e70b6d-ebc8-4a38-8ab5-8680b9da4eec)

actual result
![image](https://github.com/user-attachments/assets/46a595a2-877d-4f3b-bbd4-e54af73ef892)

URL: https://main--cc--adobecom.hlx.page/mena_ar/products/illustrator/generative-recolor

Resolves: [MWPW-147867](https://jira.corp.adobe.com/browse/MWPW-147867)

**Test URLs:**
Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/marquee/marquee-rtl?martech=off
After: https://rparrish-marquee-rtl-2--milo--adobecom.hlx.page/drafts/rparrish/marquee/marquee-rtl?martech=off

**Doc URLs:**
Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off
After: https://rparrish-marquee-rtl-2--milo--adobecom.hlx.page/docs/library/blocks/marquee?martech=off

**CC Draft (rtl already set)**
before: https://main--cc--adobecom.hlx.page/mena_ar/drafts/rparrish/marquee-rtl
after: https://main--cc--adobecom.hlx.page/mena_ar/drafts/rparrish/marquee-rtl?milolibs=rparrish-marquee-rtl-2

**CC Live**
https://main--cc--adobecom.hlx.page/mena_ar/products/illustrator/generative-recolor?milolibs=rparrish-marquee-rtl-2

Testing Notes:
Inspect the DOM and update the <html dir="ltr" /> attribute to <html dir="rtl" /> and verify the marquee copy is aligned.
Doc urls have no support-rtl variants authored so they will still display bad unless added to the block classList.