### PR TITLE
mwpw-153237: Merch @ Scale Test Content

### DIFF
--- a/libs/features/mas/web-components/test/static/merch-card/catalog.html
+++ b/libs/features/mas/web-components/test/static/merch-card/catalog.html
@@ -1,0 +1,351 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+    <body>
+        <main>
+            <div class="catalog three-merch-cards">
+                <merch-card
+                    class="merch-card catalog badge-card"
+                    data-block=""
+                    variant="catalog"
+                    size=""
+                    badge-background-color="#EDCC2D"
+                    badge-color="#000000"
+                    badge-text="Most popular"
+                    action-menu="true"
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    style="border: 1px solid rgb(237, 204, 45)"
+                    ><div slot="action-menu-content">
+                        <p><strong>Best for</strong>:</p>
+                        <ul>
+                            <li>Photo editing</li>
+                            <li>Compositing</li>
+                            <li>Drawing and painting</li>
+                            <li>Graphic design</li>
+                        </ul>
+                        <p><strong>Storage</strong>:</p>
+                        <p>100 GB of cloud storage</p>
+                        <p>
+                            <a
+                                href="https://adobe.com/"
+                                daa-ll="See system requirements-1--Creative Cloud All Apps"
+                                >See system requirements</a
+                            >
+                        </p>
+                    </div>
+                    <merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                        alt="Creative Cloud"
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="creative-cloud-all-apps"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <h4
+                        id="price---abm---creative-cloud-all-apps-with-4tb"
+                        class="card-heading"
+                        slot="heading-m"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-force-tax-exclusive="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h4>
+                    <h5 id="desktop" class="card-heading" slot="body-xxs">
+                        Desktop
+                    </h5>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p>
+                            Get 20+ creative apps including Photoshop,
+                            Illustrator, Premiere Pro, Acrobat Pro, and Adobe
+                            Express. (Substance 3D apps are not included.)
+                        </p>
+                        <p>
+                            <a
+                                href="https://adobe.com/"
+                                daa-ll="See what s included-2--Creative Cloud All Apps"
+                                >See what’s included</a
+                            >
+                            |
+                            <a
+                                href="https://adobe.com/"
+                                daa-ll="Learn more-3--Creative Cloud All Apps"
+                                >Learn more</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                href="https://business.stage.adobe.com/"
+                                class="con-button blue"
+                                daa-ll="Buy now-4--Creative Cloud All Apps"
+                                >Buy now</a
+                            >
+                            <a
+                                href="https://business.stage.adobe.com/"
+                                class="con-button outline"
+                                daa-ll="free trial-5--Creative Cloud All Apps"
+                                >free trial</a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+                <merch-card
+                    class="merch-card catalog"
+                    data-block=""
+                    variant="catalog"
+                    size=""
+                    action-menu="true"
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    ><div slot="action-menu-content">
+                        <p><strong>Best for</strong>:</p>
+                        <ul>
+                            <li>Photo editing</li>
+                            <li>Compositing</li>
+                            <li>Drawing and painting</li>
+                            <li>Graphic design</li>
+                        </ul>
+                        <p><strong>Storage</strong>:</p>
+                        <p>100 GB of cloud storage</p>
+                        <p>
+                            <a
+                                href="https://adobe.com/"
+                                daa-ll="See system requirements-1--Creative Cloud All Apps"
+                                >See system requirements</a
+                            >
+                        </p>
+                    </div>
+                    <merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                        alt="Creative Cloud"
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="creative-cloud-all-apps-1"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <h4
+                        id="price---abm---creative-cloud-all-apps-with-4tb-1"
+                        class="card-heading"
+                        slot="heading-m"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-force-tax-exclusive="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h4>
+                    <h5 id="desktop-1" class="card-heading" slot="body-xxs">
+                        Desktop
+                    </h5>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p>
+                            Get 20+ creative apps including Photoshop,
+                            Illustrator, Premiere Pro, Acrobat Pro, and Adobe
+                            Express. (Substance 3D apps are not included.)
+                        </p>
+                        <p>
+                            <a
+                                href="https://adobe.com/"
+                                daa-ll="See what s included-2--Creative Cloud All Apps"
+                                >See what’s included</a
+                            >
+                            |
+                            <a
+                                href="https://adobe.com/"
+                                daa-ll="Learn more-3--Creative Cloud All Apps"
+                                >Learn more</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                href="https://business.stage.adobe.com/"
+                                class="con-button blue"
+                                daa-ll="Buy now-4--Creative Cloud All Apps"
+                                >Buy now</a
+                            >
+                            <a
+                                href="https://business.stage.adobe.com/"
+                                class="con-button outline"
+                                daa-ll="free trial-5--Creative Cloud All Apps"
+                                >free trial</a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+                <merch-card
+                    class="merch-card catalog"
+                    data-block=""
+                    variant="catalog"
+                    size=""
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                        alt="Creative Cloud"
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="creative-cloud-all-apps-2"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <h4
+                        id="price---abm---creative-cloud-all-apps-with-4tb-2"
+                        class="card-heading"
+                        slot="heading-m"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-force-tax-exclusive="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h4>
+                    <h5 id="desktop-2" class="card-heading" slot="body-xxs">
+                        Desktop
+                    </h5>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p>
+                            Get 20+ creative apps including Photoshop,
+                            Illustrator, Premiere Pro, Acrobat Pro, and Adobe
+                            Express. (Substance 3D apps are not included.)
+                        </p>
+                        <p>
+                            <a
+                                href="https://adobe.com/"
+                                daa-ll="See what s included-1--Creative Cloud All Apps"
+                                >See what’s included</a
+                            >
+                            |
+                            <a
+                                href="https://adobe.com/"
+                                daa-ll="Learn more-2--Creative Cloud All Apps"
+                                >Learn more</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                href="https://business.stage.adobe.com/"
+                                class="con-button blue"
+                                daa-ll="Buy now-3--Creative Cloud All Apps"
+                                >Buy now</a
+                            >
+                            <a
+                                href="https://business.stage.adobe.com/"
+                                class="con-button outline"
+                                daa-ll="free trial-4--Creative Cloud All Apps"
+                                >free trial</a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+            </div>
+        </main>
+        <script src="merch-card-static.js" type="module"></script>
+    </body>
+</html>

--- a/libs/features/mas/web-components/test/static/merch-card/image.html
+++ b/libs/features/mas/web-components/test/static/merch-card/image.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+    <body>
+        <main>
+            <div class="image two-merch-cards">
+                <merch-card
+                    class="merch-card image"
+                    data-block=""
+                    variant="image"
+                    size=""
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    ><div slot="bg-image">
+                        <picture>
+                            <source
+                                type="image/webp"
+                                srcset="
+                                    https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_15bce1dd56f189c7e498a2d9b7ed5ec1f2c08491f.png?width=2000&amp;format=webply&amp;optimize=medium
+                                "
+                                media="(min-width: 600px)"
+                            />
+                            <source
+                                type="image/webp"
+                                srcset="
+                                    https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_15bce1dd56f189c7e498a2d9b7ed5ec1f2c08491f.png?width=750&amp;format=webply&amp;optimize=medium
+                                "
+                            />
+                            <source
+                                type="image/png"
+                                srcset="
+                                    https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_15bce1dd56f189c7e498a2d9b7ed5ec1f2c08491f.png?width=2000&amp;format=png&amp;optimize=medium
+                                "
+                                media="(min-width: 600px)"
+                            />
+                            <img
+                                loading="lazy"
+                                alt=""
+                                src="https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_15bce1dd56f189c7e498a2d9b7ed5ec1f2c08491f.png?width=750&amp;format=png&amp;optimize=medium"
+                                width="750"
+                                height="357"
+                            />
+                        </picture>
+                    </div>
+                    <merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                        alt="Creative Cloud"
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="creative-cloud-all-apps"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <h4
+                        id="desktop--mobile"
+                        class="card-heading"
+                        slot="body-xxs"
+                    >
+                        Desktop + Mobile
+                    </h4>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p></p>
+                        <p>
+                            Get 20+ creative apps and save big when you choose a
+                            yearly plan instead of a monthly plan.
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="commitment"
+                                data-quantity="1"
+                                data-wcs-osi="r_JXAnlFI7xD6FxWKl2ODvZriLYBoSL701Kd1hRyhe8"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-1--Creative Cloud All Apps"
+                                href="https://commerce.adobe.com/store/commitment?items%5B0%5D%5Bid%5D=632B3ADD940A7FBB7864AA5AD19B8D28&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+                <merch-card
+                    class="merch-card image badge-card"
+                    data-block=""
+                    variant="image"
+                    size=""
+                    badge-background-color="#EDCC2D"
+                    badge-color="#000000"
+                    badge-text="Best value"
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    style="border: 1px solid rgb(237, 204, 45)"
+                    ><div slot="bg-image">
+                        <picture>
+                            <source
+                                type="image/webp"
+                                srcset="
+                                    https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_15bce1dd56f189c7e498a2d9b7ed5ec1f2c08491f.png?width=2000&amp;format=webply&amp;optimize=medium
+                                "
+                                media="(min-width: 600px)"
+                            />
+                            <source
+                                type="image/webp"
+                                srcset="
+                                    https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_15bce1dd56f189c7e498a2d9b7ed5ec1f2c08491f.png?width=750&amp;format=webply&amp;optimize=medium
+                                "
+                            />
+                            <source
+                                type="image/png"
+                                srcset="
+                                    https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_15bce1dd56f189c7e498a2d9b7ed5ec1f2c08491f.png?width=2000&amp;format=png&amp;optimize=medium
+                                "
+                                media="(min-width: 600px)"
+                            />
+                            <img
+                                loading="lazy"
+                                alt=""
+                                src="https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_15bce1dd56f189c7e498a2d9b7ed5ec1f2c08491f.png?width=750&amp;format=png&amp;optimize=medium"
+                                width="750"
+                                height="357"
+                            />
+                        </picture>
+                    </div>
+                    <merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                        alt="Creative Cloud"
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="creative-cloud-all-apps-1"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <h4
+                        id="desktop--mobile-1"
+                        class="card-heading"
+                        slot="body-xxs"
+                    >
+                        Desktop + Mobile
+                    </h4>
+                    <div slot="body-xs">
+                        <p>
+                            Get 20+ creative apps and save big when you choose a
+                            yearly plan instead of a monthly plan.
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="commitment"
+                                data-quantity="1"
+                                data-wcs-osi="r_JXAnlFI7xD6FxWKl2ODvZriLYBoSL701Kd1hRyhe8"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-1--Creative Cloud All Apps"
+                                href="https://commerce.adobe.com/store/commitment?items%5B0%5D%5Bid%5D=632B3ADD940A7FBB7864AA5AD19B8D28&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+            </div>
+        </main>
+        <script src="merch-card-static.js" type="module"></script>
+    </body>
+</html>

--- a/libs/features/mas/web-components/test/static/merch-card/index.html
+++ b/libs/features/mas/web-components/test/static/merch-card/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+<body>
+    <main>
+        <h1>Merch @ Scale Test Content</h1>
+        <h2>Merch Card</h2>
+        <ul>
+            <li><a href="segment.html">Segment</a></li>
+            <li><a href="special-offers.html">Special Offers</a></li>
+            <li><a href="plans.html">Plans</a></li>
+            <li><a href="catalog.html">Catalog</a></li>
+            <li><a href="image.html">Image</a></li>
+            <li><a href="product.html">Product</a></li>
+            <li><a href="inline-heading.html">Inline Heading</a></li>
+            <li><a href="mini-compare-chart.html">Mini Compare Chart</a></li>
+            <li><a href="twp.html">TwP (Trial with Payment)</a></li>
+        </ul>
+    </main>
+    <script src="merch-card-static.js" type="module"></script>
+</body>
+</html>

--- a/libs/features/mas/web-components/test/static/merch-card/inline-heading.html
+++ b/libs/features/mas/web-components/test/static/merch-card/inline-heading.html
@@ -1,0 +1,314 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+    <body>
+        <main>
+            <div class="inline-heading three-merch-cards">
+                <merch-card
+                    class="merch-card background-opacity-70 inline-heading has-divider"
+                    data-block=""
+                    variant="inline-heading"
+                    size=""
+                    filters="all"
+                    types=""
+                    custom-hr="true"
+                    tabindex="0"
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/libs/img/mnemonics/svg/creative-cloud.svg"
+                        alt=""
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="creative-cloud-all-apps"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p>
+                            <span
+                                is="inline-price"
+                                data-display-old-price="true"
+                                data-display-per-unit="false"
+                                data-display-recurrence="true"
+                                data-display-tax="false"
+                                data-quantity="1"
+                                data-template="price"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                class="placeholder-resolved"
+                                ><span
+                                    class="price"
+                                    aria-label="US$79.99 per month"
+                                    ><span class="price-currency-symbol"
+                                        >US$</span
+                                    ><span
+                                        class="price-currency-space disabled"
+                                    ></span
+                                    ><span class="price-integer">79</span
+                                    ><span class="price-decimals-delimiter"
+                                        >.</span
+                                    ><span class="price-decimals">99</span
+                                    ><span class="price-recurrence">/mo</span
+                                    ><span
+                                        class="price-unit-type disabled"
+                                    ></span
+                                    ><span
+                                        class="price-tax-inclusivity disabled"
+                                    ></span></span
+                            ></span>
+                        </p>
+                        <hr
+                            style="
+                                background: linear-gradient(
+                                    90deg,
+                                    rgba(255, 0, 0, 1) 0%,
+                                    rgba(255, 154, 0, 1) 10%,
+                                    rgba(208, 222, 33, 1) 20%,
+                                    rgba(79, 220, 74, 1) 30%,
+                                    rgba(63, 218, 216, 1) 40%,
+                                    rgba(47, 201, 226, 1) 50%,
+                                    rgba(28, 127, 238, 1) 60%,
+                                    rgba(95, 21, 242, 1) 70%,
+                                    rgba(186, 12, 248, 1) 80%,
+                                    rgba(251, 7, 217, 1) 90%,
+                                    rgba(255, 0, 0, 1) 100%
+                                );
+                            "
+                        />
+                        <p>
+                            <strong>(</strong> background opacity 70, inline
+                            heading <strong>)</strong> - This uses a gradient
+                            css value in the horizontal style.<br />This has the
+                            variants `background opacity 70` and `inline
+                            heading`.
+                        </p>
+                        <p>
+                            <a
+                                href="https://www-offers-author.qa03.corp.adobe.com/content/experience-fragments/offers-plans/us/en/plans-fragments/modals/individual/modals-content-rich/all-apps/master.html"
+                                daa-ll="See plan pricing details-1--Creative Cloud All Apps"
+                                >See plan &amp; pricing details</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-2--Creative Cloud All Apps"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+                <merch-card
+                    class="merch-card background-opacity-70 inline-heading has-divider"
+                    data-block=""
+                    variant="inline-heading"
+                    size=""
+                    filters="all"
+                    types=""
+                    custom-hr="true"
+                    tabindex="0"
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/libs/img/mnemonics/svg/photoshop.svg"
+                        alt=""
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3 id="photoshop" class="card-heading" slot="heading-xs">
+                        Photoshop
+                    </h3>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p>
+                            <span
+                                is="inline-price"
+                                data-display-old-price="true"
+                                data-display-per-unit="false"
+                                data-display-recurrence="true"
+                                data-display-tax="false"
+                                data-quantity="1"
+                                data-template="price"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                class="placeholder-resolved"
+                                ><span
+                                    class="price"
+                                    aria-label="US$79.99 per month"
+                                    ><span class="price-currency-symbol"
+                                        >US$</span
+                                    ><span
+                                        class="price-currency-space disabled"
+                                    ></span
+                                    ><span class="price-integer">79</span
+                                    ><span class="price-decimals-delimiter"
+                                        >.</span
+                                    ><span class="price-decimals">99</span
+                                    ><span class="price-recurrence">/mo</span
+                                    ><span
+                                        class="price-unit-type disabled"
+                                    ></span
+                                    ><span
+                                        class="price-tax-inclusivity disabled"
+                                    ></span></span
+                            ></span>
+                        </p>
+                        <hr
+                            style="
+                                background: linear-gradient(
+                                    90deg,
+                                    #31a8ff,
+                                    #195784
+                                );
+                            "
+                        />
+                        <p>
+                            <strong>(</strong> background opacity 70, inline
+                            heading <strong>)</strong> - This uses a gradient
+                            css value in the horizontal style.<br />This has the
+                            variants `background opacity 70` and `inline
+                            heading`.
+                        </p>
+                        <p>
+                            <a
+                                href="https://www-offers-author.qa03.corp.adobe.com/content/experience-fragments/offers-plans/us/en/plans-fragments/modals/individual/modals-content-rich/all-apps/master.html"
+                                daa-ll="See plan pricing details-1--Photoshop"
+                                >See plan &amp; pricing details</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-2--Photoshop"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+                <merch-card
+                    class="merch-card background-opacity-70 inline-heading has-divider"
+                    data-block=""
+                    variant="inline-heading"
+                    size=""
+                    filters="all"
+                    types=""
+                    custom-hr="true"
+                    tabindex="0"
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/libs/img/mnemonics/svg/illustrator.svg"
+                        alt=""
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3 id="illustrator" class="card-heading" slot="heading-xs">
+                        Illustrator
+                    </h3>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p>
+                            <span
+                                is="inline-price"
+                                data-display-old-price="true"
+                                data-display-per-unit="false"
+                                data-display-recurrence="true"
+                                data-display-tax="false"
+                                data-quantity="1"
+                                data-template="price"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                class="placeholder-resolved"
+                                ><span
+                                    class="price"
+                                    aria-label="US$79.99 per month"
+                                    ><span class="price-currency-symbol"
+                                        >US$</span
+                                    ><span
+                                        class="price-currency-space disabled"
+                                    ></span
+                                    ><span class="price-integer">79</span
+                                    ><span class="price-decimals-delimiter"
+                                        >.</span
+                                    ><span class="price-decimals">99</span
+                                    ><span class="price-recurrence">/mo</span
+                                    ><span
+                                        class="price-unit-type disabled"
+                                    ></span
+                                    ><span
+                                        class="price-tax-inclusivity disabled"
+                                    ></span></span
+                            ></span>
+                        </p>
+                        <hr style="background: #dc6920" />
+                        <p>
+                            <strong>(</strong> background opacity 70, inline
+                            heading <strong>)</strong> - This uses a hex color
+                            value in the horizontal style.<br />This has the
+                            variants `background opacity 70` and `inline
+                            heading`.
+                        </p>
+                        <p>
+                            <a
+                                href="https://www-offers-author.qa03.corp.adobe.com/content/experience-fragments/offers-plans/us/en/plans-fragments/modals/individual/modals-content-rich/all-apps/master.html"
+                                daa-ll="See plan pricing details-1--Illustrator"
+                                >See plan &amp; pricing details</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-2--Illustrator"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+            </div>
+        </main>
+        <script src="merch-card-static.js" type="module"></script>
+    </body>
+</html>

--- a/libs/features/mas/web-components/test/static/merch-card/merch-card-static.js
+++ b/libs/features/mas/web-components/test/static/merch-card/merch-card-static.js
@@ -1,0 +1,15 @@
+import '../../../../../../deps/mas/commerce.js';
+import '../../../../../../deps/mas/merch-card-all.js';
+import '../../../../../../deps/mas/merch-offer-select.js';
+import '../../../../../../deps/mas/merch-quantity-select.js';
+
+const locale =
+    document
+        .querySelector('meta[name="mas-locale"]')
+        ?.getAttribute('content') ?? 'US_en';
+
+const config = () => ({
+    env: { name: 'prod' },
+    commerce: { 'commerce.env': 'PROD' },
+    locale: { prefix: locale },
+});

--- a/libs/features/mas/web-components/test/static/merch-card/mini-compare-chart.html
+++ b/libs/features/mas/web-components/test/static/merch-card/mini-compare-chart.html
@@ -1,0 +1,569 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+    <body>
+        <main>
+            <div
+                class="mini-compare-chart two-merch-cards"
+                style="
+                    --consonant-merch-card-mini-compare-top-section-height: 40px;
+                    --consonant-merch-card-mini-compare-heading-m-height: 30px;
+                    --consonant-merch-card-mini-compare-body-m-height: 146px;
+                    --consonant-merch-card-mini-compare-heading-m-price-height: 34px;
+                    --consonant-merch-card-mini-compare-price-commitment-height: 30px;
+                    --consonant-merch-card-mini-compare-offers-height: 16px;
+                    --consonant-merch-card-mini-compare-promo-text-height: 60px;
+                    --consonant-merch-card-mini-compare-footer-height: 80px;
+                    --consonant-merch-card-mini-compare-top-section-mobile-height: 32px;
+                    --consonant-merch-card-footer-row-1-min-height: 32px;
+                    --consonant-merch-card-footer-row-2-min-height: 48px;
+                    --consonant-merch-card-footer-row-3-min-height: 48px;
+                    --consonant-merch-card-footer-row-4-min-height: 48px;
+                    --consonant-merch-card-footer-row-5-min-height: 32px;
+                "
+            >
+                <merch-card
+                    class="merch-card mini-compare-chart badge-card"
+                    data-block=""
+                    variant="mini-compare-chart"
+                    size=""
+                    badge-background-color="#EDCC2D"
+                    badge-color="#000000"
+                    badge-text="Most popular"
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    style="border: 1px solid rgb(237, 204, 45)"
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                        alt="Creative Cloud"
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <div slot="body-m">
+                        <p></p>
+                        <p>
+                            Get Illustrator on desktop and iPad as part of
+                            Creative Cloud.
+                        </p>
+                    </div>
+                    <p slot="price-commitment" class="price-commitment">
+                        For the first year, then
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-force-tax-exclusive="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </p>
+                    <h3
+                        id="creative-cloud-all-apps"
+                        class="card-heading"
+                        slot="heading-m"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <h4
+                        id="this-is-promo-text-with-a-link"
+                        class="card-heading"
+                        slot="promo-text"
+                    >
+                        This is promo text
+                        <a
+                            href="https://adobe.com/"
+                            daa-ll="with a link-1--Creative Cloud All Apps"
+                            >with a link</a
+                        >
+                    </h4>
+                    <h5
+                        id="price---abm---creative-cloud-all-apps-with-4tb"
+                        class="card-heading"
+                        slot="heading-m-price"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-force-tax-exclusive="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h5>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                href="https://business.stage.adobe.com/"
+                                class="con-button blue button-l"
+                                daa-ll="Buy now-2--Creative Cloud All Apps"
+                                >Buy now</a
+                            >
+                            <a
+                                href="https://business.stage.adobe.com/"
+                                class="con-button outline button-l"
+                                daa-ll="free trial-3--Creative Cloud All Apps"
+                                >free trial</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="offers">
+                        <merch-quantity-select
+                            title="Select a quantity:"
+                            min="1"
+                            max="10"
+                            step="1"
+                            default-value="undefined"
+                            max-input="undefined"
+                            closed=""
+                        ></merch-quantity-select>
+                    </div>
+                    <div slot="footer-rows">
+                        <div class="footer-row-cell">
+                            <picture class="footer-row-icon"
+                                ><img
+                                    loading="lazy"
+                                    src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                                    alt="Creative Cloud"
+                            /></picture>
+                            <div class="footer-row-cell-description">
+                                Illustrator on desktop, web, and iPad
+                            </div>
+                        </div>
+                        <div class="footer-row-cell">
+                            <picture class="footer-row-icon"
+                                ><img
+                                    loading="lazy"
+                                    src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                                    alt="Creative Cloud"
+                            /></picture>
+                            <div class="footer-row-cell-description">
+                                Access to 20+ apps including Photoshop,
+                                Illustrator Premiere Pro, After Effects,
+                                InDesign, Lightroom, and more
+                            </div>
+                        </div>
+                        <div class="footer-row-cell">
+                            <picture class="footer-row-icon"
+                                ><img
+                                    loading="lazy"
+                                    src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                                    alt="Creative Cloud"
+                            /></picture>
+                            <div class="footer-row-cell-description">
+                                <p>
+                                    Business features like admin tools,
+                                    dedicated 24x7
+                                </p>
+                                <p>support, and 1TB of cloud storage</p>
+                            </div>
+                        </div>
+                        <div class="footer-row-cell">
+                            <picture class="footer-row-icon"
+                                ><img
+                                    loading="lazy"
+                                    src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                                    alt="Creative Cloud"
+                            /></picture>
+                            <div class="footer-row-cell-description">
+                                Adobe Express, Adobe Fresco, Adobe Portfolio,
+                                and Adobe Fonts
+                            </div>
+                        </div>
+                        <div class="footer-row-cell">
+                            <picture class="footer-row-icon"
+                                ><img
+                                    loading="lazy"
+                                    src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                                    alt="Creative Cloud"
+                            /></picture>
+                            <div class="footer-row-cell-description">
+                                1,000
+                                <a
+                                    href="https://adobe.com/"
+                                    daa-ll="generative credits-4--Creative Cloud All Apps"
+                                    >generative credits</a
+                                >
+                            </div>
+                        </div>
+                    </div></merch-card
+                >
+                <merch-card
+                    class="merch-card mini-compare-chart secure"
+                    data-block=""
+                    variant="mini-compare-chart"
+                    size=""
+                    secure-label="Secure transaction"
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                        alt="Creative Cloud"
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <div slot="body-m">
+                        <p slot="description"></p>
+                        <p>
+                            Get Illustrator on desktop and iPad as part of
+                            Creative Cloud.
+                        </p>
+                        <p>Cloud storage:</p>
+                        <merch-offer-select
+                            container="merch-card"
+                            variant="horizontal"
+                            plan-type="ABM"
+                            ><merch-offer
+                                text="20GB"
+                                tabindex="0"
+                                role="radio"
+                                type="radio"
+                                plan-type="ABM"
+                                aria-selected=""
+                                ><span
+                                    is="inline-price"
+                                    data-display-old-price="true"
+                                    data-display-per-unit="true"
+                                    data-display-recurrence="true"
+                                    data-display-tax="false"
+                                    data-force-tax-exclusive="true"
+                                    data-quantity="1"
+                                    data-template="price"
+                                    data-wcs-osi="jWh-iooSLW82QkvJ1ZIWqU1jF4UAlKttsWFGBPTmcmo"
+                                    slot="price"
+                                    class="placeholder-resolved"
+                                    ><span
+                                        class="price"
+                                        aria-label="US$9.99 per month per license"
+                                        ><span class="price-currency-symbol"
+                                            >US$</span
+                                        ><span
+                                            class="price-currency-space disabled"
+                                        ></span
+                                        ><span class="price-integer">9</span
+                                        ><span class="price-decimals-delimiter"
+                                            >.</span
+                                        ><span class="price-decimals">99</span
+                                        ><span class="price-recurrence"
+                                            >/mo</span
+                                        ><span class="price-unit-type"
+                                            >per license</span
+                                        ><span
+                                            class="price-tax-inclusivity disabled"
+                                        ></span></span></span
+                                ><a
+                                    is="checkout-link"
+                                    data-checkout-workflow="UCv3"
+                                    data-checkout-workflow-step="email"
+                                    data-quantity="1"
+                                    data-wcs-osi="p7FxvRXNKzvXKWL325AZSmT3PwpMvnFAPgW-eeSGvgU"
+                                    data-extra-options="{}"
+                                    class="con-button outline button-l placeholder-resolved"
+                                    slot="secondary-cta"
+                                    daa-ll="Free trial-1--Illustrator"
+                                    href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=BA5600A65682C94806428932E65B2D69&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                    ><span>Free trial</span></a
+                                ><a
+                                    is="checkout-link"
+                                    data-checkout-workflow="UCv3"
+                                    data-checkout-workflow-step="email"
+                                    data-quantity="1"
+                                    data-wcs-osi="6WK1gybjBe2EKcq0HI0WvbsoiKOri2yRAwS9t_kGHoE"
+                                    data-extra-options="{}"
+                                    class="con-button blue button-l placeholder-resolved"
+                                    slot="cta"
+                                    daa-ll="Buy now-2--Illustrator"
+                                    href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=DF7F553163565F8621D8AE91D978F354&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                    ><span>Buy now</span></a
+                                ></merch-offer
+                            ><merch-offer
+                                text="1TB"
+                                tabindex="0"
+                                role="radio"
+                                type="radio"
+                                plan-type="ABM"
+                                ><span
+                                    is="inline-price"
+                                    data-display-old-price="true"
+                                    data-display-per-unit="true"
+                                    data-display-recurrence="true"
+                                    data-display-tax="false"
+                                    data-force-tax-exclusive="false"
+                                    data-quantity="1"
+                                    data-template="price"
+                                    data-wcs-osi="MzCpF9nUi8rEzyW-9slEUwtRenS69PRW5fp84a93uK4"
+                                    slot="price"
+                                    class="placeholder-resolved"
+                                    ><span
+                                        class="price"
+                                        aria-label="US$19.99 per month per license"
+                                        ><span class="price-currency-symbol"
+                                            >US$</span
+                                        ><span
+                                            class="price-currency-space disabled"
+                                        ></span
+                                        ><span class="price-integer">19</span
+                                        ><span class="price-decimals-delimiter"
+                                            >.</span
+                                        ><span class="price-decimals">99</span
+                                        ><span class="price-recurrence"
+                                            >/mo</span
+                                        ><span class="price-unit-type"
+                                            >per license</span
+                                        ><span
+                                            class="price-tax-inclusivity disabled"
+                                        ></span></span></span
+                                ><a
+                                    is="checkout-link"
+                                    data-checkout-workflow="UCv3"
+                                    data-checkout-workflow-step="email"
+                                    data-quantity="1"
+                                    data-wcs-osi="gJhGqZpFk_o3tjCUyFOsl1X7XOlCodSQEBmjY2E6Lqo"
+                                    data-extra-options="{}"
+                                    class="con-button outline button-l placeholder-resolved"
+                                    slot="secondary-cta"
+                                    daa-ll="Free trial-3--Illustrator"
+                                    href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=BDA3989C0E537B7E7ACFCB269FDB611E&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                    ><span>Free trial</span></a
+                                ><a
+                                    is="checkout-link"
+                                    data-checkout-workflow="UCv3"
+                                    data-checkout-workflow-step="email"
+                                    data-quantity="1"
+                                    data-wcs-osi="MzCpF9nUi8rEzyW-9slEUwtRenS69PRW5fp84a93uK4"
+                                    data-extra-options="{}"
+                                    class="con-button blue button-l placeholder-resolved"
+                                    slot="cta"
+                                    daa-ll="Buy now-4--Illustrator"
+                                    href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=81DE7D1C91A201AB690BC4741B32F0C0&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                    ><span>Buy now</span></a
+                                ></merch-offer
+                            ></merch-offer-select
+                        >
+                    </div>
+                    <h3 id="illustrator" class="card-heading" slot="heading-m">
+                        Illustrator
+                    </h3>
+                    <h4
+                        id="save-19-us799mo-for-the-first-year-if-you-buy-now"
+                        class="card-heading"
+                        slot="promo-text"
+                    >
+                        Save 19% ($US7.99/mo) for the first year if you buy now.
+                    </h4>
+                    <h5 id="see-terms" class="card-heading" slot="promo-text">
+                        <a
+                            href="https://adobe.com/"
+                            daa-ll="See terms-5--Illustrator"
+                            >See terms.</a
+                        >
+                    </h5>
+                    <h6
+                        id="price---abm---creative-cloud-all-apps-with-4tb-price---abm---creative-cloud-all-apps-with-4tb"
+                        class="card-heading"
+                        slot="heading-m-price"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="true"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-force-tax-exclusive="true"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="jWh-iooSLW82QkvJ1ZIWqU1jF4UAlKttsWFGBPTmcmo"
+                            slot="price"
+                            class="placeholder-resolved"
+                            ><span
+                                class="price"
+                                aria-label="US$9.99 per month per license"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">9</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type">per license</span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-force-tax-exclusive="false"
+                            data-quantity="1"
+                            data-template="strikethrough"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span
+                                class="price price-strikethrough"
+                                aria-label="Regularly at US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h6>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="p7FxvRXNKzvXKWL325AZSmT3PwpMvnFAPgW-eeSGvgU"
+                                data-extra-options="{}"
+                                class="con-button outline button-l placeholder-resolved"
+                                slot="secondary-cta"
+                                daa-ll="Free trial-1--Illustrator"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=BA5600A65682C94806428932E65B2D69&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Free trial</span></a
+                            ><a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="6WK1gybjBe2EKcq0HI0WvbsoiKOri2yRAwS9t_kGHoE"
+                                data-extra-options="{}"
+                                class="con-button blue button-l placeholder-resolved"
+                                slot="cta"
+                                daa-ll="Buy now-2--Illustrator"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=DF7F553163565F8621D8AE91D978F354&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div>
+                    <div slot="offers"><p></p></div>
+                    <div slot="footer-rows">
+                        <div class="footer-row-cell">
+                            <picture class="footer-row-icon"
+                                ><img
+                                    loading="lazy"
+                                    src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                                    alt="Creative Cloud"
+                            /></picture>
+                            <div class="footer-row-cell-description">
+                                Illustrator on desktop, web, and iPad
+                            </div>
+                        </div>
+                        <div class="footer-row-cell">
+                            <div class="footer-row-cell-description"></div>
+                        </div>
+                        <div class="footer-row-cell">
+                            <picture class="footer-row-icon"
+                                ><img
+                                    loading="lazy"
+                                    src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                                    alt="Creative Cloud"
+                            /></picture>
+                            <div class="footer-row-cell-description">
+                                <p>
+                                    Business features like admin tools,
+                                    dedicated 24x7
+                                </p>
+                                <p>support, and 1TB of cloud storage</p>
+                            </div>
+                        </div>
+                        <div class="footer-row-cell">
+                            <picture class="footer-row-icon"
+                                ><img
+                                    loading="lazy"
+                                    src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                                    alt="Creative Cloud"
+                            /></picture>
+                            <div class="footer-row-cell-description">
+                                Adobe Express, Adobe Fresco, Adobe Portfolio,
+                                and Adobe Fonts
+                            </div>
+                        </div>
+                        <div class="footer-row-cell">
+                            <picture class="footer-row-icon"
+                                ><img
+                                    loading="lazy"
+                                    src="https://main--milo--adobecom.hlx.page/assets/img/creative-cloud.svg"
+                                    alt="Creative Cloud"
+                            /></picture>
+                            <div class="footer-row-cell-description">
+                                1,000
+                                <a
+                                    href="https://adobe.com/"
+                                    daa-ll="generative credits-8--Illustrator"
+                                    >generative credits</a
+                                >
+                            </div>
+                        </div>
+                    </div></merch-card
+                >
+            </div>
+        </main>
+        <script src="merch-card-static.js" type="module"></script>
+    </body>
+</html>

--- a/libs/features/mas/web-components/test/static/merch-card/plans.html
+++ b/libs/features/mas/web-components/test/static/merch-card/plans.html
@@ -1,0 +1,578 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+    <body>
+        <main>
+            <div class="plans three-merch-cards">
+                <merch-card
+                    class="merch-card plans"
+                    data-block=""
+                    variant="plans"
+                    size=""
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_13fdffb82a8eadb56de60fe7ec03f7f7201379836.png?width=750&amp;format=png&amp;optimize=medium"
+                        alt=""
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="creative-cloud-all-apps"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <h4
+                        id="price---abm---creative-cloud-all-apps-with-4tb"
+                        class="card-heading"
+                        slot="heading-m"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h4>
+                    <h5 id="desktop" class="card-heading" slot="promo-text">
+                        Desktop
+                    </h5>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p>
+                            Get 20+ Creative Cloud apps including Photoshop,
+                            Illustrator, Adobe Express, Premiere Pro, and
+                            Acrobat Pro. (Substance 3D apps are not included.)
+                        </p>
+                        <p>
+                            <a
+                                href="https://www-offers-author.qa03.corp.adobe.com/content/experience-fragments/offers-plans/us/en/plans-fragments/modals/individual/modals-content-rich/all-apps/master.html"
+                                daa-ll="See plan pricing details-1--Creative Cloud All Apps"
+                                >See plan &amp; pricing details</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-2--Creative Cloud All Apps"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+                <merch-card
+                    class="merch-card plans secure add-stock"
+                    data-block=""
+                    variant="plans"
+                    size=""
+                    secure-label="Secure transaction"
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    ><h3
+                        id="acrobat-pro"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Acrobat Pro
+                    </h3>
+                    <div slot="body-xs">
+                        <p slot="description">
+                            The complete PDF solution for working anywhere
+                            (includes desktop, web, and mobile access).
+                        </p>
+                        <h5 class="merch-card-price">
+                            <span
+                                is="inline-price"
+                                data-display-old-price="true"
+                                data-display-per-unit="false"
+                                data-display-recurrence="true"
+                                data-display-tax="false"
+                                data-quantity="1"
+                                data-template="price"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                slot="price"
+                                class="placeholder-resolved"
+                                ><span
+                                    class="price"
+                                    aria-label="US$79.99 per month"
+                                    ><span class="price-currency-symbol"
+                                        >US$</span
+                                    ><span
+                                        class="price-currency-space disabled"
+                                    ></span
+                                    ><span class="price-integer">79</span
+                                    ><span class="price-decimals-delimiter"
+                                        >.</span
+                                    ><span class="price-decimals">99</span
+                                    ><span class="price-recurrence">/mo</span
+                                    ><span
+                                        class="price-unit-type disabled"
+                                    ></span
+                                    ><span
+                                        class="price-tax-inclusivity disabled"
+                                    ></span></span
+                            ></span>
+                        </h5>
+                        <merch-offer-select
+                            container="merch-card"
+                            stock=""
+                            plan-type="ABM"
+                            ><merch-offer
+                                text="Annual, monthly payment"
+                                badge-text="Recommended"
+                                tabindex="0"
+                                role="radio"
+                                type="radio"
+                                plan-type="ABM"
+                                aria-selected=""
+                                ><span
+                                    is="inline-price"
+                                    data-display-old-price="true"
+                                    data-display-per-unit="false"
+                                    data-display-recurrence="true"
+                                    data-display-tax="false"
+                                    data-quantity="1"
+                                    data-template="price"
+                                    data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                    slot="price"
+                                    class="placeholder-resolved"
+                                    ><span
+                                        class="price"
+                                        aria-label="US$79.99 per month"
+                                        ><span class="price-currency-symbol"
+                                            >US$</span
+                                        ><span
+                                            class="price-currency-space disabled"
+                                        ></span
+                                        ><span class="price-integer">79</span
+                                        ><span class="price-decimals-delimiter"
+                                            >.</span
+                                        ><span class="price-decimals">99</span
+                                        ><span class="price-recurrence"
+                                            >/mo</span
+                                        ><span
+                                            class="price-unit-type disabled"
+                                        ></span
+                                        ><span
+                                            class="price-tax-inclusivity disabled"
+                                        ></span></span></span
+                                ><a
+                                    is="checkout-link"
+                                    data-checkout-workflow="UCv3"
+                                    data-checkout-workflow-step="email"
+                                    data-quantity="1"
+                                    data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                    data-extra-options="{}"
+                                    class="con-button placeholder-resolved"
+                                    slot="cta"
+                                    daa-ll="Buy now-1--Acrobat Pro"
+                                    href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                    ><span>Buy now</span></a
+                                ></merch-offer
+                            ><merch-offer
+                                text="Annual, one-time payment"
+                                badge-text="Best Offer"
+                                tabindex="0"
+                                role="radio"
+                                type="radio"
+                                plan-type="ABM"
+                                ><span
+                                    is="inline-price"
+                                    data-display-old-price="true"
+                                    data-display-per-unit="false"
+                                    data-display-recurrence="true"
+                                    data-display-tax="false"
+                                    data-quantity="1"
+                                    data-template="price"
+                                    data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                    slot="price"
+                                    class="placeholder-resolved"
+                                    ><span
+                                        class="price"
+                                        aria-label="US$79.99 per month"
+                                        ><span class="price-currency-symbol"
+                                            >US$</span
+                                        ><span
+                                            class="price-currency-space disabled"
+                                        ></span
+                                        ><span class="price-integer">79</span
+                                        ><span class="price-decimals-delimiter"
+                                            >.</span
+                                        ><span class="price-decimals">99</span
+                                        ><span class="price-recurrence"
+                                            >/mo</span
+                                        ><span
+                                            class="price-unit-type disabled"
+                                        ></span
+                                        ><span
+                                            class="price-tax-inclusivity disabled"
+                                        ></span></span></span
+                                ><a
+                                    is="checkout-link"
+                                    data-checkout-workflow="UCv3"
+                                    data-checkout-workflow-step="email"
+                                    data-quantity="1"
+                                    data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                    data-extra-options="{}"
+                                    class="con-button placeholder-resolved"
+                                    slot="cta"
+                                    daa-ll="Buy now-2--Acrobat Pro"
+                                    href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                    ><span>Buy now</span></a
+                                ></merch-offer
+                            ><merch-offer
+                                text="Monthly, without commitment"
+                                tabindex="0"
+                                role="radio"
+                                type="radio"
+                                plan-type="ABM"
+                                ><span
+                                    is="inline-price"
+                                    data-display-old-price="true"
+                                    data-display-per-unit="false"
+                                    data-display-recurrence="true"
+                                    data-display-tax="false"
+                                    data-quantity="1"
+                                    data-template="price"
+                                    data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                    slot="price"
+                                    class="placeholder-resolved"
+                                    ><span
+                                        class="price"
+                                        aria-label="US$79.99 per month"
+                                        ><span class="price-currency-symbol"
+                                            >US$</span
+                                        ><span
+                                            class="price-currency-space disabled"
+                                        ></span
+                                        ><span class="price-integer">79</span
+                                        ><span class="price-decimals-delimiter"
+                                            >.</span
+                                        ><span class="price-decimals">99</span
+                                        ><span class="price-recurrence"
+                                            >/mo</span
+                                        ><span
+                                            class="price-unit-type disabled"
+                                        ></span
+                                        ><span
+                                            class="price-tax-inclusivity disabled"
+                                        ></span></span></span
+                                ><a
+                                    is="checkout-link"
+                                    data-checkout-workflow="UCv3"
+                                    data-checkout-workflow-step="email"
+                                    data-quantity="1"
+                                    data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                    data-extra-options="{}"
+                                    class="con-button placeholder-resolved"
+                                    slot="cta"
+                                    daa-ll="Buy now-3--Acrobat Pro"
+                                    href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                    ><span>Buy now</span></a
+                                ></merch-offer
+                            ></merch-offer-select
+                        >
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                slot="secondary-cta"
+                                is="checkout-link"
+                                daa-ll="-4--Acrobat Pro"
+                            ></a
+                            ><a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                data-extra-options="{}"
+                                class="con-button placeholder-resolved"
+                                slot="cta"
+                                daa-ll="Buy now-1--Acrobat Pro"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+                <merch-card
+                    class="merch-card plans secure add-stock badge-card"
+                    data-block=""
+                    variant="plans"
+                    size=""
+                    badge-background-color="#EDCC2D"
+                    badge-color="#000000"
+                    badge-text="Best value"
+                    secure-label="Secure transaction"
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    style="
+                        border: 1px solid rgb(237, 204, 45);
+                        --consonant-merch-card-heading-xs-max-width: 179px;
+                    "
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_13fdffb82a8eadb56de60fe7ec03f7f7201379836.png?width=750&amp;format=png&amp;optimize=medium"
+                        alt=""
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="creative-cloud-all-apps-1"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <h4
+                        id="price---abm---creative-cloud-all-apps-with-4tb-1"
+                        class="card-heading"
+                        slot="heading-m"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h4>
+                    <h5 id="desktop-1" class="card-heading" slot="promo-text">
+                        Desktop
+                    </h5>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p>
+                            Get 20+ Creative Cloud apps including Photoshop,
+                            Illustrator, Adobe Express, Premiere Pro, and
+                            Acrobat Pro. (Substance 3D apps are not included.)
+                        </p>
+                        <p>
+                            <a
+                                href="https://www-offers-author.qa03.corp.adobe.com/content/experience-fragments/offers-plans/us/en/plans-fragments/modals/individual/modals-content-rich/all-apps/master.html"
+                                daa-ll="See plan pricing details-1--Creative Cloud All Apps"
+                                >See plan &amp; pricing details</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-2--Creative Cloud All Apps"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+                <merch-card
+                    class="merch-card plans"
+                    data-block=""
+                    variant="plans"
+                    size=""
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_13fdffb82a8eadb56de60fe7ec03f7f7201379836.png?width=750&amp;format=png&amp;optimize=medium"
+                        alt=""
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="creative-cloud-all-apps-2"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Creative Cloud All Apps
+                    </h3>
+                    <h4
+                        id="price---abm---creative-cloud-all-apps-with-4tb-2"
+                        class="card-heading"
+                        slot="heading-m"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h4>
+                    <h5 id="desktop-2" class="card-heading" slot="promo-text">
+                        Desktop
+                    </h5>
+                    <div slot="body-xs">
+                        <p></p>
+                        <p>
+                            AI Assistant add-on available
+                            <a
+                                href="/assets/img/illustrator.svg"
+                                daa-ll="Icon exclamation-1--Creative Cloud All Apps"
+                                >Icon exclamation</a
+                            >
+                        </p>
+                        <p>
+                            For a limited time pay
+                            <span
+                                is="inline-price"
+                                data-display-old-price="true"
+                                data-display-per-unit="false"
+                                data-quantity="1"
+                                data-template="price"
+                                data-wcs-osi="A1xn6EL4pK93bWjM8flffQpfEL-bnvtoQKQAvkx574M"
+                                class="placeholder-resolved"
+                                ><span
+                                    class="price"
+                                    aria-label="US$22.99 per month"
+                                    ><span class="price-currency-symbol"
+                                        >US$</span
+                                    ><span
+                                        class="price-currency-space disabled"
+                                    ></span
+                                    ><span class="price-integer">22</span
+                                    ><span class="price-decimals-delimiter"
+                                        >.</span
+                                    ><span class="price-decimals">99</span
+                                    ><span class="price-recurrence">/mo</span
+                                    ><span
+                                        class="price-unit-type disabled"
+                                    ></span
+                                    ><span
+                                        class="price-tax-inclusivity disabled"
+                                    ></span></span
+                            ></span>
+                            when you add
+                            <a
+                                href="/assets/img/illustrator.svg"
+                                daa-ll="Icon exclamation-2--Creative Cloud All Apps"
+                                >Icon exclamation</a
+                            >
+                        </p>
+                        <p>
+                            Get 20+ Creative Cloud apps including Photoshop,
+                            Illustrator, Adobe Express, Premiere Pro, and
+                            Acrobat Pro. (Substance 3D apps are not included.)
+                        </p>
+                        <p>
+                            <a
+                                href="https://www-offers-author.qa03.corp.adobe.com/content/experience-fragments/offers-plans/us/en/plans-fragments/modals/individual/modals-content-rich/all-apps/master.html"
+                                daa-ll="See plan pricing details-3--Creative Cloud All Apps"
+                                >See plan &amp; pricing details</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-4--Creative Cloud All Apps"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+            </div>
+        </main>
+        <script src="merch-card-static.js" type="module"></script>
+    </body>
+</html>

--- a/libs/features/mas/web-components/test/static/merch-card/product.html
+++ b/libs/features/mas/web-components/test/static/merch-card/product.html
@@ -1,0 +1,206 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+    <body>
+        <main>
+            <div class="two-merch-cards product">
+                <merch-card
+                    class="merch-card product has-divider"
+                    data-block=""
+                    variant="product"
+                    size=""
+                    filters="all"
+                    types=""
+                    custom-hr="true"
+                    tabindex="0"
+                >
+                    <merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/libs/img/mnemonics/svg/illustrator.svg"
+                        alt=""
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3 id="illustrator" class="card-heading" slot="heading-xs">
+                        Illustrator
+                    </h3>
+                    <h4
+                        id="price---abm---creative-cloud-all-apps-with-4tb"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h4>
+                    <div slot="body-xs">
+                        <p></p>
+                        <hr style="background: #dc6920" />
+                        <p>
+                            <strong>(</strong> background opacity 70, inline
+                            heading <strong>)</strong> - This uses a hex color
+                            value in the horizontal style.<br />This has the
+                            variants `background opacity 70` and `inline
+                            heading`.
+                        </p>
+                        <p>
+                            <a
+                                href="https://www-offers-author.qa03.corp.adobe.com/content/experience-fragments/offers-plans/us/en/plans-fragments/modals/individual/modals-content-rich/all-apps/master.html"
+                                daa-ll="See plan pricing details-1--Illustrator"
+                                target="_blank"
+                                >See plan &amp; pricing details</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-2--Illustrator"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                target="_blank"
+                            >
+                                <span>Buy now</span>
+                            </a>
+                        </p>
+                    </div>
+                </merch-card>
+                <merch-card
+                    class="merch-card product secure has-divider"
+                    data-block=""
+                    variant="product"
+                    size=""
+                    secure-label="Secure transaction"
+                    filters="all"
+                    types=""
+                    custom-hr="true"
+                    tabindex="0"
+                    ><merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/libs/img/mnemonics/svg/illustrator.svg"
+                        alt=""
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <h3
+                        id="illustrator-1"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        Illustrator
+                    </h3>
+                    <h4
+                        id="price---abm---creative-cloud-all-apps-with-4tb-1"
+                        class="card-heading"
+                        slot="heading-xs"
+                    >
+                        <span
+                            is="inline-price"
+                            data-display-old-price="true"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-quantity="1"
+                            data-template="price"
+                            data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                            class="placeholder-resolved"
+                            ><span class="price" aria-label="US$79.99 per month"
+                                ><span class="price-currency-symbol">US$</span
+                                ><span
+                                    class="price-currency-space disabled"
+                                ></span
+                                ><span class="price-integer">79</span
+                                ><span class="price-decimals-delimiter">.</span
+                                ><span class="price-decimals">99</span
+                                ><span class="price-recurrence">/mo</span
+                                ><span class="price-unit-type disabled"></span
+                                ><span
+                                    class="price-tax-inclusivity disabled"
+                                ></span></span
+                        ></span>
+                    </h4>
+                    <div slot="body-xs">
+                        <p></p>
+                        <hr style="background: #dc6920" />
+                        <p>
+                            <strong>(</strong> background opacity 70, inline
+                            heading <strong>)</strong> - This uses a hex color
+                            value in the horizontal style.<br />This has the
+                            variants `background opacity 70` and `inline
+                            heading`.
+                        </p>
+                        <p>
+                            <a
+                                href="https://www-offers-author.qa03.corp.adobe.com/content/experience-fragments/offers-plans/us/en/plans-fragments/modals/individual/modals-content-rich/all-apps/master.html"
+                                daa-ll="See plan pricing details-1--Illustrator"
+                                target="_blank"
+                                >See plan &amp; pricing details</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p class="action-area">
+                            <a
+                                is="checkout-link"
+                                data-checkout-workflow="UCv3"
+                                data-checkout-workflow-step="email"
+                                data-quantity="1"
+                                data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                data-extra-options="{}"
+                                class="con-button blue placeholder-resolved"
+                                daa-ll="Buy now-2--Illustrator"
+                                href="https://commerce.adobe.com/store/email?items%5B0%5D%5Bid%5D=01A09572A72A7D7F848721DE4D3C73FA&amp;cli=adobe_com&amp;ctx=fp&amp;co=US&amp;lang=en"
+                                target="_blank"
+                                ><span>Buy now</span></a
+                            >
+                        </p>
+                    </div></merch-card
+                >
+            </div>
+        </main>
+        <script src="merch-card-static.js" type="module"></script>
+    </body>
+</html>

--- a/libs/features/mas/web-components/test/static/merch-card/segment.html
+++ b/libs/features/mas/web-components/test/static/merch-card/segment.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+    <body>
+        <main>
+            <div class="three-merch-cards segment">
+                <merch-card
+                    variant="segment"
+                    badge-color="#EDCC2D"
+                    badge-background-color="#000000"
+                    badge-text="Best value"
+                >
+                    <h3 slot="heading-xs">Individuals</h3>
+                    <h3 slot="heading-xs">
+                        <span
+                            is="inline-price"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-template="priceOptical"
+                            data-wcs-osi="abm-edu"
+                        >$19.99/mo</span>
+                        <span
+                            is="inline-price"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-template="priceStrikethrough"
+                            data-wcs-osi="abm"
+                        >$9.99/mo</span>
+                    </h3>
+                    <div slot="body-xs">
+                        <p>Get 20+ Creative Cloud apps and services.</p>
+                        <p>
+                            <a href="https://adobe.com">See what’s included.</a>
+                            | <a href="https://adobe.com">Learn more.</a>
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <a
+                            href="https://business.adobe.com/"
+                            class="con-button blue"
+                            >Save now</a
+                        >
+                    </div>
+                </merch-card>
+                <merch-card variant="segment">
+                    <h3 slot="heading-xs">Students and teachers</h3>
+                    <h3 slot="heading-xs">
+                        <span
+                            is="inline-price"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-template="priceOptical"
+                            data-wcs-osi="abm-edu"
+                        >$19.99/mo</span>
+                        <span
+                            is="inline-price"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-template="priceStrikethrough"
+                            data-wcs-osi="abm"
+                        >$9.99/mo</span>
+                    </h3>
+                    <div slot="body-xs">
+                        <p>Get 20+ Creative Cloud apps and services.</p>
+                        <p>Get 20+ Creative Cloud apps and services.</p>
+                        <p>Get 20+ Creative Cloud apps and services.</p>
+                        <p>Get 20+ Creative Cloud apps and services.</p>
+                        <p>
+                            <a href="https://adobe.com">See what’s included.</a>
+                            | <a href="https://adobe.com">Learn more.</a>
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <a
+                            href="https://business.adobe.com/"
+                            class="con-button blue"
+                            >Save now</a
+                        >
+                    </div>
+                </merch-card>
+                <merch-card variant="segment">
+                    <h3 slot="heading-xs">Students and teachers</h3>
+                    <h3 slot="heading-xs">
+                        <span
+                            is="inline-price"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-template="priceOptical"
+                            data-wcs-osi="abm-edu"
+                        >$19.99/mo</span>
+                        <span
+                            is="inline-price"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-template="priceStrikethrough"
+                            data-wcs-osi="abm"
+                        >$9.99/mo</span>
+                    </h3>
+                    <div slot="body-xs">
+                        <p>Get 20+ Creative Cloud apps and services.</p>
+                        <p>Get 20+ Creative Cloud apps and services.</p>
+                        <p>Get 20+ Creative Cloud apps and services.</p>
+                        <p>Get 20+ Creative Cloud apps and services.</p>
+                        <p>
+                            <a href="https://adobe.com">See what’s included.</a>
+                            | <a href="https://adobe.com">Learn more.</a>
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <a
+                            href="https://business.adobe.com/"
+                            class="con-button blue"
+                            >Save now</a
+                        >
+                    </div>
+                </merch-card>
+            </div>
+        </main>
+        <script src="merch-card-static.js" type="module"></script>
+    </body>
+</html>

--- a/libs/features/mas/web-components/test/static/merch-card/special-offers.html
+++ b/libs/features/mas/web-components/test/static/merch-card/special-offers.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+    <body>
+        <main>
+            <div class="three-merch-cards special-offers">
+                <merch-card
+                    types="web,mobile"
+                    variant="special-offers"
+                    badge-color="#EDCC2D"
+                    badge-background-color="#000000"
+                    badge-text="Best value"
+                >
+                    <h4 slot="detail-m" id="individuals">INDIVIDUALS</h4>
+                    <h3 slot="heading-xs">
+                        Save over 30% on Creative Cloud All Apps.
+                    </h3>
+                    <h3 slot="heading-xs">
+                        <span
+                            is="inline-price"
+                            data-display-per-unit="false"
+                            data-display-recurrence="true"
+                            data-display-tax="false"
+                            data-wcs-osi="puf"
+                        ></span>
+                    </h3>
+                    <div slot="body-xs">
+                        <p>
+                            Get 20+ creative apps and save big when you choose a
+                            yearly plan instead of a monthly plan.
+                        </p>
+                        <p><a href="https://adobe.com/">See terms.</a></p>
+                    </div>
+                    <div slot="footer">
+                        <a
+                            href="https://business.adobe.com/"
+                            class="con-button blue"
+                            >Save now</a
+                        >
+                    </div>
+                    <div slot="bg-image" class="bgimage">
+                        <picture>
+                            <source
+                                type="image/webp"
+                                srcset="../test/img/special-offers-img.webp"
+                                media="(min-width: 600px)"
+                            />
+                            <source
+                                type="image/webp"
+                                srcset="../test/img/special-offers-img.webp"
+                            />
+                            <source
+                                type="image/png"
+                                srcset="../test/img/special-offers-img.png"
+                                media="(min-width: 600px)"
+                            />
+                            <img
+                                loading="lazy"
+                                alt=""
+                                src="../test/img/special-offers-img.png"
+                                width="750"
+                                height="357"
+                            />
+                        </picture>
+                    </div>
+                </merch-card>
+                <merch-card
+                    name="illustrator"
+                    types="tablet,desktop"
+                    variant="special-offers"
+                >
+                    <h4 slot="detail-m" id="individuals1">
+                        STUDENTS AND TEACHERS
+                    </h4>
+                    <h3 slot="heading-xs">
+                        Save over 60% on Creative Cloud All Apps.
+                    </h3>
+                    <div slot="body-xs">
+                        <p>
+                            Get 20+ apps — including Photoshop, Premiere Pro,
+                            and Illustrator — and save big for the first year.
+                        </p>
+                        <p>
+                            Get 20+ apps — including Photoshop, Premiere Pro,
+                            and Illustrator — and save big for the first year.
+                        </p>
+                        <p>
+                            Get 20+ apps — including Photoshop, Premiere Pro,
+                            and Illustrator — and save big for the first year.
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <a
+                            href="https://business.adobe.com/"
+                            class="con-button blue"
+                            >Save now</a
+                        >
+                    </div>
+                    <div slot="bg-image">
+                        <picture>
+                            <source
+                                type="image/webp"
+                                srcset="../test/img/special-offers-img2.webp"
+                                media="(min-width: 600px)"
+                            />
+                            <source
+                                type="image/webp"
+                                srcset="../test/img/special-offers-img2.webp"
+                            />
+                            <source
+                                type="image/png"
+                                srcset="../test/img/special-offers-img2.png"
+                                media="(min-width: 600px)"
+                            />
+                            <img
+                                loading="lazy"
+                                alt=""
+                                src="../test/img/special-offers-img2.png"
+                                width="750"
+                                height="357"
+                            />
+                        </picture>
+                    </div>
+                </merch-card>
+                <merch-card types="web,desktop" variant="special-offers">
+                    <h4 slot="detail-m" id="individuals1">INDIVIDUALS</h4>
+                    <h3 slot="heading-xs">
+                        <p>Get 10% off Photoshop.</p>
+                    </h3>
+                    <h3 slot="heading-xs">
+                        <p>US$19.99/mo US$54.99/mo</p>
+                    </h3>
+                    <div slot="body-xs">
+                        <p>
+                            Create gorgeous images, rich graphics, and
+                            incredible art. Save 10% for the first year. Ends
+                            Mar 20.
+                        </p>
+                        <p><a href="https://adobe.com/">See terms.</a></p>
+                    </div>
+                    <div slot="footer">
+                        <a
+                            href="https://business.adobe.com/"
+                            class="con-button blue"
+                            >Save now</a
+                        >
+                    </div>
+                    <div slot="bg-image">
+                        <picture>
+                            <source
+                                type="image/webp"
+                                srcset="../test/img/special-offers-img.webp"
+                                media="(min-width: 600px)"
+                            />
+                            <source
+                                type="image/webp"
+                                srcset="../test/img/special-offers-img.webp"
+                            />
+                            <source
+                                type="image/png"
+                                srcset="../test/img/special-offers-img.png"
+                                media="(min-width: 600px)"
+                            />
+                            <img
+                                loading="lazy"
+                                alt=""
+                                src="../test/img/special-offers-img.png"
+                                width="750"
+                                height="357"
+                            />
+                        </picture>
+                    </div>
+                </merch-card>
+            </div>
+        </main>
+        <script src="merch-card-static.js" type="module"></script>
+    </body>
+</html>

--- a/libs/features/mas/web-components/test/static/merch-card/twp.html
+++ b/libs/features/mas/web-components/test/static/merch-card/twp.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta property="og:title" content="Merch at Scale Studio" />
+        <meta name="robots" content="noindex, nofollow" />
+        <meta name="nofollow-links" content="on" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/styles/styles.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch-card.css">
+        <link rel="stylesheet" href="https://main--milo--adobecom.hlx.page/libs/blocks/merch/merch.css">
+        <title>Merch @ Scale Test Content</title>
+        <script>
+            window.process = {
+                env: {},
+            };
+        </script>
+    </head>
+
+    <body>
+        <main>
+            <div class="two-merch-cards twp">
+                <merch-card
+                    class="merch-card twp"
+                    variant="twp"
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                >
+                    <merch-icon
+                        slot="icons"
+                        src="https://mwpw-142267--milo--adobecom.hlx.page/assets/img/illustrator.svg"
+                        alt="Illustrator"
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <p slot="heading-xs" class="heading-xs">
+                        <strong>Photography</strong>
+                    </p>
+                    <p slot="body-xs-top" class="body-xs-top">
+                        Edit, organize and transform your photos.
+                    </p>
+                    <div slot="body-xs">
+                        <p>
+                            <strong>What you get:</strong>
+                        </p>
+                        <ul>
+                            <li>Lightroom on desktop, mobile and web</li>
+                            <li>Photoshop on desktop and iPad</li>
+                            <li>Lightroom Classic on desktop</li>
+                            <li>Tutorials, fonts, templates, and more</li>
+                            <li>
+                                X,XXX monthly
+                                <a href="https://firefly.adobe.com/"
+                                    >generative credits</a
+                                >
+                            </li>
+                        </ul>
+                    </div>
+                    <div slot="footer">
+                        <p>
+                            <strong>7-day free trial, then 
+                                <span
+                                    is="inline-price"
+                                    data-display-old-price="true"
+                                    data-display-per-unit="false"
+                                    data-display-recurrence="true"
+                                    data-display-tax="false"
+                                    data-quantity="1"
+                                    data-template="price"
+                                    data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                    class="placeholder-resolved"
+                                    ><span
+                                        class="price"
+                                        aria-label="US$79.99 per month"
+                                        ><span class="price-currency-symbol"
+                                            >US$</span
+                                        ><span
+                                            class="price-currency-space disabled"
+                                        ></span
+                                        ><span class="price-integer">79</span
+                                        ><span class="price-decimals-delimiter"
+                                            >.</span
+                                        ><span class="price-decimals">99</span
+                                        ><span class="price-recurrence"
+                                            >/mo</span
+                                        ><span
+                                            class="price-unit-type disabled"
+                                        ></span
+                                        ><span
+                                            class="price-tax-inclusivity disabled"
+                                        ></span></span
+                                ></span>
+                            </strong>
+                        </p>
+                    </div>
+                </merch-card>
+                <merch-card
+                    class="merch-card twp"
+                    variant="twp"
+                    badge-background-color="#2D9D78"
+                    badge-color="#FFFFFF"
+                    badge-text="Best value"
+                    filters="all"
+                    types=""
+                    tabindex="0"
+                >
+                    <merch-icon
+                        slot="icons"
+                        src="https://main--milo--adobecom.hlx.page/docs/authoring/commerce/fragments/block-samples/media_13fdffb82a8eadb56de60fe7ec03f7f7201379836.png?width=750&amp;format=png&amp;optimize=medium"
+                        alt=""
+                        href=""
+                        size="l"
+                    ></merch-icon>
+                    <p slot="heading-xs" class="heading-xs">
+                        <strong>Creative Cloud All Apps</strong>
+                    </p>
+                    <p slot="body-xs-top" class="body-xs-top">
+                        The ultimate toolkit for unlimited creativity.
+                    </p>
+                    <div slot="body-xs">
+                        <p><strong>What you get:</strong></p>
+                        <ul>
+                            <li>
+                                20+ apps – Photoshop, Illustrator, Adobe
+                                Express, Firefly, Acrobat Pro, and more
+                            </li>
+                            <li>Tutorials, fonts , templates, and more</li>
+                            <li>100GB of cloud storage</li>
+                            <li>
+                                X,XXX monthly
+                                <a href="https://firefly.adobe.com/"
+                                    >generative credits</a
+                                >
+                            </li>
+                        </ul>
+                        <p>
+                            <a href="https://adobe.com/"
+                                >See all included apps.</a
+                            >
+                        </p>
+                    </div>
+                    <div slot="footer">
+                        <p>
+                            <strong>7-day free trial, then 
+                                <span
+                                    is="inline-price"
+                                    data-display-old-price="true"
+                                    data-display-per-unit="false"
+                                    data-display-recurrence="true"
+                                    data-display-tax="false"
+                                    data-quantity="1"
+                                    data-template="price"
+                                    data-wcs-osi="Mutn1LYoGojkrcMdCLO7LQlx1FyTHw27ETsfLv0h8DQ"
+                                    class="placeholder-resolved"
+                                    ><span
+                                        class="price"
+                                        aria-label="US$79.99 per month"
+                                        ><span class="price-currency-symbol"
+                                            >US$</span
+                                        ><span
+                                            class="price-currency-space disabled"
+                                        ></span
+                                        ><span class="price-integer">79</span
+                                        ><span class="price-decimals-delimiter"
+                                            >.</span
+                                        ><span class="price-decimals">99</span
+                                        ><span class="price-recurrence"
+                                            >/mo</span
+                                        ><span
+                                            class="price-unit-type disabled"
+                                        ></span
+                                        ><span
+                                            class="price-tax-inclusivity disabled"
+                                        ></span></span></span
+                            ></strong>
+                        </p>
+                    </div>
+                </merch-card>
+            </div>
+        </main>
+        <script src="merch-card-static.js" type="module"></script>
+    </body>
+</html>


### PR DESCRIPTION
Merch at Scale static content to be used for performance checks, etc.
For now only including A.com merch cards. Adobe Home and CCD cards coming soon.
Supports milolibs configuration as URL param.

Jira ticket: https://jira.corp.adobe.com/browse/MWPW-153237

Test URLs:

Before: https://main--milo--adobecom.hlx.live/web-components/test/static/merch-card/index.html
After: https://mwpw-153237--milo--adobecom.hlx.live/web-components/test/static/merch-card/index.html