### PR TITLE
[MWPW-155627] Merch Callout feature: Missing font cascade

### DIFF
--- a/libs/deps/mas/merch-card-all.js
+++ b/libs/deps/mas/merch-card-all.js
@@ -667,7 +667,7 @@ merch-card [slot='callout-content'] > div > div {
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
     text-align: left;
-    font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) Adobe Clean;
+    font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) var(--body-font-family, 'Adobe Clean');
     letter-spacing: var(--consonant-merch-card-callout-letter-spacing);
     color: var(--consonant-merch-card-callout-font-color);
 }

--- a/libs/deps/mas/merch-card.js
+++ b/libs/deps/mas/merch-card.js
@@ -690,7 +690,7 @@ merch-card [slot='callout-content'] > div > div {
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
     text-align: left;
-    font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) Adobe Clean;
+    font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) var(--body-font-family, 'Adobe Clean');
     letter-spacing: var(--consonant-merch-card-callout-letter-spacing);
     color: var(--consonant-merch-card-callout-font-color);
 }

--- a/libs/deps/mas/plans-modal.js
+++ b/libs/deps/mas/plans-modal.js
@@ -5277,7 +5277,7 @@ merch-card [slot='callout-content'] > div > div {
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
     text-align: left;
-    font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) Adobe Clean;
+    font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) var(--body-font-family, 'Adobe Clean');
     letter-spacing: var(--consonant-merch-card-callout-letter-spacing);
     color: var(--consonant-merch-card-callout-font-color);
 }

--- a/libs/features/mas/web-components/src/global.css.js
+++ b/libs/features/mas/web-components/src/global.css.js
@@ -277,7 +277,7 @@ merch-card [slot='callout-content'] > div > div {
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
     text-align: left;
-    font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) Adobe Clean;
+    font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) var(--body-font-family, 'Adobe Clean');
     letter-spacing: var(--consonant-merch-card-callout-letter-spacing);
     color: var(--consonant-merch-card-callout-font-color);
 }


### PR DESCRIPTION
Added fallback to "Adobe Clean" font for callout text.

Callout text font before Fix:
<img width="719" alt="Screenshot 2024-08-01 at 2 51 46 PM" src="https://github.com/user-attachments/assets/8c799c10-dc8f-4039-99c2-00fd9e422206">

Callout text font after Fix: 
<img width="585" alt="Screenshot 2024-08-01 at 2 51 20 PM" src="https://github.com/user-attachments/assets/31b8f5e9-deb8-4a0c-bdf4-4929abc324aa">

Resolves: [MWPW-155627](https://jira.corp.adobe.com/browse/MWPW-155627)

**Test URLs:**
Before: https://main--milo--adobecom.hlx.page/drafts/rosahu/rosahu
After: https://mwpw-155627--milo--rohitsahu.hlx.page/drafts/rosahu/rosahu
