### PR TITLE
MWPW-155691 [MILO][MEP] Also use region in placeholders decision 

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -545,11 +545,12 @@ export function parseManifestVariants(data, manifestPath, manifestOverrideName) 
 function parsePlaceholders(placeholders, config, selectedVariantName = '') {
   if (!placeholders?.length || selectedVariantName === 'default') return config;
   const valueNames = [
-    'value',
     selectedVariantName.toLowerCase(),
     config.locale.region.toLowerCase(),
     config.locale.ietf.toLowerCase(),
     ...config.locale.ietf.toLowerCase().split('-'),
+    'value',
+    'other',
   ];
   const [val] = Object.entries(placeholders[0])
     .find(([key]) => valueNames.includes(key.toLowerCase()));

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -547,6 +547,7 @@ function parsePlaceholders(placeholders, config, selectedVariantName = '') {
   const valueNames = [
     'value',
     selectedVariantName.toLowerCase(),
+    config.locale.region.toLowerCase(),
     config.locale.ietf.toLowerCase(),
     ...config.locale.ietf.toLowerCase().split('-'),
   ];

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -228,7 +228,8 @@ function createPreviewPill(manifests) {
           <div class="mep-manifest-page-info-title">Page Info:</div>
           <div>Target integration feature is ${targetOnText}</div>
           <div>Personalization feature is ${personalizationOnText}</div>
-          <div>Page's Region/Locale is ${config.locale.region}/${config.locale.ietf}</div>
+          <div>Page's Region is ${config.locale.region}</div>
+          <div>Page's Locale is ${config.locale.ietf}</div>
         </div>
       </div>
       <div class="mep-manifest-list">

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -228,7 +228,7 @@ function createPreviewPill(manifests) {
           <div class="mep-manifest-page-info-title">Page Info:</div>
           <div>Target integration feature is ${targetOnText}</div>
           <div>Personalization feature is ${personalizationOnText}</div>
-          <div>Page's Locale is ${config.locale.ietf}</div>
+          <div>Page's Region/Locale is ${config.locale.region}/${config.locale.ietf}</div>
         </div>
       </div>
       <div class="mep-manifest-list">


### PR DESCRIPTION
* Also check the region as a value when deciding which placeholder column to use
* Add region name to MEP button so it's easy to determine
* moved "value" to the end and added "other" so they can be used as a catch-all for the remaining geos

Resolves: [MWPW-155691](https://jira.corp.adobe.com/browse/MWPW-155691)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/za/products/illustrator?mep=%2Fproducts%2Fillustrator.json--default---%2Fcc-shared%2Ffragments%2Ftests%2F2024%2Fq3%2Fintl0075%2Fintl0075.json--target-var1-challenger
- After: https://main--cc--adobecom.hlx.page/za/products/illustrator?milolibs=mepplaceholderregion&mep=%2Fproducts%2Fillustrator.json--default---%2Fcc-shared%2Ffragments%2Ftests%2F2024%2Fq3%2Fintl0075%2Fintl0075.json--target-var1-challenger

Psi check: https://mepplaceholderregion--milo--adobecom.hlx.page/?martech=off