### PR TITLE
MWPW-155676 - [LocUI] Find duplicate fragments by pathname

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -140,7 +140,7 @@ export async function findFragments() {
     if (fragments.length > 0) {
       fragments.forEach((fragment) => {
         // De-dupe across pages that share fragments
-        const dupe = acc.some((url) => url[0]?.href === fragment.href);
+        const dupe = acc.some((url) => url[0]?.pathname === fragment.pathname);
         if (!dupe) acc.push([fragment]);
       });
     }


### PR DESCRIPTION
Due to the video fragments having URL params the de-dupe function was seeing them as different because it was checking the URL href property instead of the pathname. Updating the duplicate function to look at only the pathname to avoid this.

Resolves: [MWPW-155676](https://jira.corp.adobe.com/browse/MWPW-155676)

**Test URLs:**
https://main--cc--adobecom.hlx.page/tools/loc?milolibs=sean-loc&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B170d251e-8672-4185-b0b7-440ed60908f9%257D%26action%3Deditnew
