### PR TITLE
ENB-6995 Query Params update & sendTargetResponse function update Resubmit for #2664

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -89,20 +89,21 @@ function sendTargetResponseAnalytics(failure, responseStart, timeout, message) {
   const timeoutTime = roundToQuarter(timeout);
   let val = `target response time ${responseTime}:timed out ${failure}:timeout ${timeoutTime}`;
   if (message) val += `:${message}`;
-    window._satellite?.track?.('event', {
-      documentUnloading: true,
-      xdm: {
-        eventType: 'web.webinteraction.linkClicks',
-        web: {
-          webInteraction: {
-            linkClicks: { value: 1 },
-            type: 'other',
-            name: val,
-          },
+  // eslint-disable-next-line no-underscore-dangle
+  window._satellite?.track?.('event', {
+    documentUnloading: true,
+    xdm: {
+      eventType: 'web.webinteraction.linkClicks',
+      web: {
+        webInteraction: {
+          linkClicks: { value: 1 },
+          type: 'other',
+          name: val,
         },
       },
-      data: { _adobe_corpnew: { digitalData: { primaryEvent: { eventInfo: { eventName: val } } } } },
-    });
+    },
+    data: { _adobe_corpnew: { digitalData: { primaryEvent: { eventInfo: { eventName: val } } } } },
+  });
 }
 
 export const getTargetPersonalization = async () => {

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -89,20 +89,20 @@ function sendTargetResponseAnalytics(failure, responseStart, timeout, message) {
   const timeoutTime = roundToQuarter(timeout);
   let val = `target response time ${responseTime}:timed out ${failure}:timeout ${timeoutTime}`;
   if (message) val += `:${message}`;
-  window.alloy('sendEvent', {
-    documentUnloading: true,
-    xdm: {
-      eventType: 'web.webinteraction.linkClicks',
-      web: {
-        webInteraction: {
-          linkClicks: { value: 1 },
-          type: 'other',
-          name: val,
+    window._satellite?.track?.('event', {
+      documentUnloading: true,
+      xdm: {
+        eventType: 'web.webinteraction.linkClicks',
+        web: {
+          webInteraction: {
+            linkClicks: { value: 1 },
+            type: 'other',
+            name: val,
+          },
         },
       },
-    },
-    data: { _adobe_corpnew: { digitalData: { primaryEvent: { eventInfo: { eventName: val } } } } },
-  });
+      data: { _adobe_corpnew: { digitalData: { primaryEvent: { eventInfo: { eventName: val } } } } },
+    });
 }
 
 export const getTargetPersonalization = async () => {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -865,8 +865,9 @@ export async function loadMartech({
     return true;
   }
 
-  const query = PAGE_URL.searchParams.get('martech');
-  if (query === 'off' || getMetadata('martech') === 'off') {
+  const martechQuery = PAGE_URL.searchParams.get('martech');
+  const marketingQuery = PAGE_URL.searchParams.get('marketingtech');
+  if (martechQuery === 'off' || marketingQuery === 'off' || getMetadata('martech') === 'off') {
     return false;
   }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -865,9 +865,9 @@ export async function loadMartech({
     return true;
   }
 
-  const martechQuery = PAGE_URL.searchParams.get('martech');
-  const marketingQuery = PAGE_URL.searchParams.get('marketingtech');
-  if (martechQuery === 'off' || marketingQuery === 'off' || getMetadata('martech') === 'off') {
+  if (PAGE_URL.searchParams.get('martech') === 'off'
+    || PAGE_URL.searchParams.get('marketingtech') === 'off'
+    || getMetadata('martech') === 'off') {
     return false;
   }
 


### PR DESCRIPTION
- sendTargetResponse: Added Check for window._satellite and changed direct alloy call to _satellite call
- Added additional parameter as marketingtech to disable martech.  The martech=off also impacts launch.  So they have requested a new parameter that does the same thing in Milo as martech=off but does not impact their code.

Resolves: [ENB-6995](https://jira.corp.adobe.com/browse/ENB-6995)

Test URLs: https://www.adobe.com/products/photoshop.html?marketingtech=off

Psi-check: [https://martechteamupdates--milo--adobecom.hlx.page?marketingtech=off](https://martechteamupdates--milo--adobecom.hlx.page?marketingtech=off)

Note
Currently when passing marketingtech=off page is not loading, Expected behavior is martech bootstrap should not load and page should load as it is

More Information
There are 2 changes

In Martech.js which currently resides in [milo/libs/martech/](https://github.com/adobecom/milo/blob/main/libs/martech/martech.js) folder, we noticed there is a function named by sendTargetResponseAnalytics which has sendEvent call using window.alloy now for the requirement to disable analytics tracking we have added certain conditions in launch due to which we are able to control data collection for most of the calls, but for this function as it is directly calling window.alloy data is being sent, we would like to modify this function.

In Utils.js which resides in [milo/libs/utils/](https://github.com/adobecom/milo/blob/main/libs/utils/utils.js) folder, there is another function named by loadMartech where there are certain condition to check if "martech=off" exists in query params or not if it exists we do not load martech.js library, we would like to add another optional parameter as "marketingtech=off" , as our main bootstrap script has this as query prams to disable analytics library completely, currently when we pass "marketingtech=off" in any adotcom pages, page seems to crash / fail to load.