### PR TITLE
MWPW-153955 [PEP ] dismiss tool tip text is seen chopped in RTL locale in ipad and iphone in landscape mode

### DIFF
--- a/libs/features/webapp-prompt/webapp-prompt.css
+++ b/libs/features/webapp-prompt/webapp-prompt.css
@@ -219,7 +219,6 @@
   left: -100%;
 }
 
-
 [data-pep-dismissal-tooltip]::before {
   content: '';
   z-index: 2;

--- a/libs/features/webapp-prompt/webapp-prompt.css
+++ b/libs/features/webapp-prompt/webapp-prompt.css
@@ -215,6 +215,11 @@
   color: white;
 }
 
+[dir="rtl"] [data-pep-dismissal-tooltip]::after {
+  left: -100%;
+}
+
+
 [data-pep-dismissal-tooltip]::before {
   content: '';
   z-index: 2;
@@ -236,7 +241,8 @@
 }
 
 @media (min-width: 1520px) {
-  [data-pep-dismissal-tooltip]::after {
+  [data-pep-dismissal-tooltip]::after,
+  [dir="rtl"] [data-pep-dismissal-tooltip]::after {
     left: calc(50% - 5rem);
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added some rtl specific styles to position the tooltip correctly when it's on the opposite end of the page

Resolves: [MWPW-153955](https://jira.corp.adobe.com/browse/MWPW-153955)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://rtl-pep-tooltip--milo--sharmrj.hlx.page/?martech=off
- QA: https://main--cc--adobecom.hlx.page/eg_ar/creativecloud/animation/testdoc/pepphsp1?skipPepEntitlements=true&milolibs=rtl-pep-tooltip--milo--sharmrj
