### PR TITLE
Making new GNAV experience default

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -696,7 +696,7 @@ function decorateHeader() {
     header.remove();
     return;
   }
-  header.className = headerMeta || 'gnav';
+  header.className = headerMeta || 'global-navigation';
   const metadataConfig = getMetadata('breadcrumbs')?.toLowerCase()
   || getConfig().breadcrumbs;
   if (metadataConfig === 'off') return;
@@ -738,7 +738,7 @@ async function loadFooter() {
     footer.remove();
     return;
   }
-  footer.className = footerMeta || 'footer';
+  footer.className = footerMeta || 'global-footer';
   await loadBlock(footer);
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
**Description:**
* Make the new GNAV (global-navigation and global-footer) the default one.
* Automatically onboard any new Milo consumer to use the new GNAV.
* This approach helps reduce redundant metadata properties, preventing the metadata.xlsx file from becoming unnecessarily to large.
* We have to add config if want to use deprecated version of GNAV (ganv and footer) like this experience is still used with blog and bacom blog.

For example:
`/drafts/devashish/default/**` based on this After URL, we can add the necessary configuration. However, ensure that we remove `/**` and `/drafts/**` entries , as they override the settings when `/drafts/devashish/default/**` is missing or the config values are empty. There’s no need to include anything in `metadata.xlsx` for the new GNAV (global-navigation and global-footer) to be used. If the deprecated version of GNAV (gnav and footer) is needed, we must add the appropriate configuration for it like below ways:
In document:
<img width="679" alt="Screenshot 2024-08-05 at 4 25 27 PM" src="https://github.com/user-attachments/assets/72399067-2819-4b95-bca8-bbc954bbfe19">
OR
In `metadata.xlsx`:
<img width="451" alt="Screenshot 2024-08-05 at 4 23 54 PM" src="https://github.com/user-attachments/assets/515d6e1f-0d4f-4870-84c4-d5639ab8f6e9">

Resolves: [MWPW-149575](https://jira.corp.adobe.com/browse/MWPW-149575)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-149575-default-gnav--milo--deva309.hlx.page/drafts/devashish/default/default-global-navigation?martech=off
