### PR TITLE
MWPW-155654 Open TWP modal with preselected tab

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -313,8 +313,9 @@ function focusOnTab(url) {
 async function openExternalModal(url, getModal) {
   await loadStyle(`${getConfig().base}/blocks/iframe/iframe.css`);
   const root = createTag('div', { class: 'milo-iframe' });
+  const urlWithPlan = focusOnTab(url);
   createTag('iframe', {
-    src: focusOnTab(url),
+    src: urlWithPlan,
     frameborder: '0',
     marginwidth: '0',
     marginheight: '0',

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -302,11 +302,19 @@ async function openFragmentModal(path, getModal) {
   return modal;
 }
 
+function focusOnTab(url) {
+  const metaPreselectPlan = document.querySelector('meta[name="preselect-plan"]');
+  if (!metaPreselectPlan) return url;
+  const urlWithPlan = new URL(url);
+  urlWithPlan.searchParams.set('plan', metaPreselectPlan.content);
+  return urlWithPlan.href;
+}
+
 async function openExternalModal(url, getModal) {
   await loadStyle(`${getConfig().base}/blocks/iframe/iframe.css`);
   const root = createTag('div', { class: 'milo-iframe' });
   createTag('iframe', {
-    src: url,
+    src: focusOnTab(url),
     frameborder: '0',
     marginwidth: '0',
     marginheight: '0',

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -304,7 +304,7 @@ async function openFragmentModal(path, getModal) {
 
 export function appendTabName(url) {
   const metaPreselectPlan = document.querySelector('meta[name="preselect-plan"]');
-  if (!metaPreselectPlan || !metaPreselectPlan.content) return url;
+  if (!metaPreselectPlan?.content) return url;
   let urlWithPlan;
   try {
     urlWithPlan = new URL(url);

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -302,10 +302,16 @@ async function openFragmentModal(path, getModal) {
   return modal;
 }
 
-function focusOnTab(url) {
+export function appendTabName(url) {
   const metaPreselectPlan = document.querySelector('meta[name="preselect-plan"]');
-  if (!metaPreselectPlan) return url;
-  const urlWithPlan = new URL(url);
+  if (!metaPreselectPlan || !metaPreselectPlan.content) return url;
+  let urlWithPlan;
+  try {
+    urlWithPlan = new URL(url);
+  } catch (err) {
+    window.lana?.log(`Invalid URL ${url} : ${err}`);
+    return url;
+  }
   urlWithPlan.searchParams.set('plan', metaPreselectPlan.content);
   return urlWithPlan.href;
 }
@@ -313,9 +319,9 @@ function focusOnTab(url) {
 async function openExternalModal(url, getModal) {
   await loadStyle(`${getConfig().base}/blocks/iframe/iframe.css`);
   const root = createTag('div', { class: 'milo-iframe' });
-  const urlWithPlan = focusOnTab(url);
+  const urlWithTabName = appendTabName(url);
   createTag('iframe', {
-    src: urlWithPlan,
+    src: urlWithTabName,
     frameborder: '0',
     marginwidth: '0',
     marginheight: '0',

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -589,7 +589,6 @@ describe('Merch Block', () => {
       expect(modal).to.exist;
       document.querySelector('.modal-curtain').click();
     });
-
     it('renders Milo TWP modal', async () => {
       mockIms();
       const el = document.querySelector('.merch.cta.milo.twp');
@@ -631,6 +630,21 @@ describe('Merch Block', () => {
       const modal = document.getElementById('checkout-link-modal');
       expect(modal).to.exist;
       document.querySelector('.modal-curtain').click();
+    });
+    it('renders TWP modal with preselected plan', async () => {
+      mockIms();
+      const meta = document.createElement('meta');
+      meta.setAttribute('name', 'preselect-plan');
+      meta.setAttribute('content', 'edu');
+      document.getElementsByTagName('head')[0].appendChild(meta);
+      const el = document.querySelector('.merch.cta.twp.preselected-plan');
+      const cta = await merch(el);
+      const { nodeName, textContent } = await cta.onceSettled();
+      expect(nodeName).to.equal('A');
+      cta.click();
+      await delay(100);
+      expect(document.querySelector('iframe').src).to.equal('https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu');
+      document.querySelector('meta[name="preselect-plan"]').remove();
     });
   });
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -701,7 +701,7 @@ describe('Merch Block', () => {
       },
     ];
     MODAL_URLS.forEach((modalUrl) => {
-      it('appends preselected plan to modal URL', async () => {
+      it(`appends preselected plan ${modalUrl.plan} to modal URL ${modalUrl.url}`, async () => {
         const meta = document.createElement('meta');
         meta.setAttribute('name', 'preselect-plan');
         meta.setAttribute('content', modalUrl.plan);

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -22,6 +22,7 @@ import merch, {
   PRICE_LITERALS_URL,
   PRICE_TEMPLATE_REGULAR,
   getMasBase,
+  appendTabName,
 } from '../../../libs/blocks/merch/merch.js';
 
 import { mockFetch, unmockFetch, readMockText } from './mocks/fetch.js';
@@ -645,6 +646,61 @@ describe('Merch Block', () => {
       await delay(100);
       expect(document.querySelector('iframe').src).to.equal('https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu');
       document.querySelector('meta[name="preselect-plan"]').remove();
+    });
+
+    const MODAL_URLS = [
+      {
+        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
+        plan: 'edu',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu'
+      },
+      {
+        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=abc',
+        plan: 'edu',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu'
+      },
+      {
+        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1#thisishash',
+        plan: 'edu',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu#thisishash'
+      },
+      {
+        url: 'https://www.adobe.com/mini-plans/illustrator.html',
+        plan: 'edu',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?plan=edu'
+      },
+      {
+        url: 'https://www.adobe.com/mini-plans/illustrator.html#thisishash',
+        plan: 'edu',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?plan=edu#thisishash'
+      },
+      {
+        url: 'www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1', // invalid URL, protocol is missing
+        plan: 'edu',
+        urlWithPlan: 'www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1'
+      },
+      {
+        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
+        plan: 'team',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=team'
+      },
+      {
+        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
+        plan: '',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1'
+      },
+    ];
+    MODAL_URLS.forEach((modalUrl) => {
+      it('appends preselected plan to modal URL', async () => {
+        const meta = document.createElement('meta');
+        meta.setAttribute('name', 'preselect-plan');
+        meta.setAttribute('content', modalUrl.plan);
+        document.getElementsByTagName('head')[0].appendChild(meta);
+
+        const resultUrl = appendTabName(modalUrl.url);
+        expect(resultUrl).to.equal(modalUrl.urlWithPlan);
+        document.querySelector('meta[name="preselect-plan"]').remove();
+      });
     });
   });
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -639,7 +639,7 @@ describe('Merch Block', () => {
       document.getElementsByTagName('head')[0].appendChild(meta);
       const el = document.querySelector('.merch.cta.twp.preselected-plan');
       const cta = await merch(el);
-      const { nodeName, textContent } = await cta.onceSettled();
+      const { nodeName } = await cta.onceSettled();
       expect(nodeName).to.equal('A');
       cta.click();
       await delay(100);

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -650,44 +650,54 @@ describe('Merch Block', () => {
 
     const MODAL_URLS = [
       {
-        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
+        url: 'https://www.adobe.com/mini-plans/illustrator1.html?mid=ft&web=1',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator1.html?mid=ft&web=1&plan=edu',
       },
       {
-        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=abc',
+        url: 'https://www.adobe.com/mini-plans/illustrator2.html?mid=ft&web=1&plan=abc',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator2.html?mid=ft&web=1&plan=edu',
       },
       {
-        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1#thisishash',
+        url: 'https://www.adobe.com/mini-plans/illustrator3.html?mid=ft&web=1#thisishash',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu#thisishash',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator3.html?mid=ft&web=1&plan=edu#thisishash',
       },
       {
-        url: 'https://www.adobe.com/mini-plans/illustrator.html',
+        url: 'https://www.adobe.com/mini-plans/illustrator4.html',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?plan=edu',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator4.html?plan=edu',
       },
       {
-        url: 'https://www.adobe.com/mini-plans/illustrator.html#thisishash',
+        url: 'https://www.adobe.com/mini-plans/illustrator5.html#thisishash',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?plan=edu#thisishash',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator5.html?plan=edu#thisishash',
       },
       {
-        url: 'www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1', // invalid URL, protocol is missing
-        plan: 'edu',
-        urlWithPlan: 'www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
-      },
-      {
-        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
+        url: 'https://www.adobe.com/mini-plans/illustrator6.html?mid=ft&web=1',
         plan: 'team',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=team',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator6.html?mid=ft&web=1&plan=team',
       },
       {
-        url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
+        url: 'https://www.adobe.com/mini-plans/illustrator7.html?mid=ft&web=1',
         plan: '',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator7.html?mid=ft&web=1',
+      },
+      {
+        url: 'https://www.adobe.com/mini-plans/illustrator8.selector.html/resource?mid=ft&web=1#thisishash',
+        plan: 'team',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator8.selector.html/resource?mid=ft&web=1&plan=team#thisishash',
+      },
+      {
+        url: 'https://www.adobe.com/mini-plans/illustrator9.sel1.sel2.html/resource#thisishash',
+        plan: 'team',
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator9.sel1.sel2.html/resource?plan=team#thisishash',
+      },
+      {
+        url: 'www.adobe.com/mini-plans/illustrator10.html?mid=ft&web=1', // invalid URL, protocol is missing
+        plan: 'edu',
+        urlWithPlan: 'www.adobe.com/mini-plans/illustrator10.html?mid=ft&web=1',
       },
     ];
     MODAL_URLS.forEach((modalUrl) => {

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -652,42 +652,42 @@ describe('Merch Block', () => {
       {
         url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu'
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu',
       },
       {
         url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=abc',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu'
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu',
       },
       {
         url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1#thisishash',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu#thisishash'
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=edu#thisishash',
       },
       {
         url: 'https://www.adobe.com/mini-plans/illustrator.html',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?plan=edu'
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?plan=edu',
       },
       {
         url: 'https://www.adobe.com/mini-plans/illustrator.html#thisishash',
         plan: 'edu',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?plan=edu#thisishash'
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?plan=edu#thisishash',
       },
       {
         url: 'www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1', // invalid URL, protocol is missing
         plan: 'edu',
-        urlWithPlan: 'www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1'
+        urlWithPlan: 'www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
       },
       {
         url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
         plan: 'team',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=team'
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1&plan=team',
       },
       {
         url: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
         plan: '',
-        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1'
+        urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator.html?mid=ft&web=1',
       },
     ];
     MODAL_URLS.forEach((modalUrl) => {

--- a/test/blocks/merch/mocks/body.html
+++ b/test/blocks/merch/mocks/body.html
@@ -128,6 +128,10 @@
   href="/tools/ost?osi=illustrator-base-abm-mult-cci&type=checkoutUrl&modal=true&entitlement=true">CTA Buy Now</a>
 </p>
 
+<p>TWP modal with preselected plan: <a class="merch cta twp preselected-plan"
+  href="/tools/ost?osi=illustrator-trial-abm-mult-cci&type=checkoutUrl&modal=true&entitlement=true">CTA Free Trial</a>
+</p>
+
 <div data-promotion-code="nicopromo" class="fragment">
   <h2>Promo prices inside a fragment</h2>
   <p>Price without discount: <a class="merch price oldprice"


### PR DESCRIPTION
On catalog page we open TWP/D2P page in iframe/modal upon click on "Free trial" CTA. For some users the tab Education or Business need to be preselected. Personalization code will add the meta tag `<meta name="preselect-plan" content="edu">` (or with value `team`) to the page for such users and value of this tag will be read on CTA click and the query parameter `&plan=edu` (or `&plan=team`) will be added to modal page URL.

Test URL: [url](https://main--cc--adobecom.hlx.page/products/catalog?milolibs=mwpw155654--milo--bozojovicic&mep=%2Fproducts%2Fcatalog-devicetype.json--default---%2Fproducts%2Fcatalog.json--default---%2Fdrafts%2Frakaur%2Fdotcom-126722-catalog-test.json--default---%2Fdrafts%2Frakaur%2Fdotcom-126722-catalog-test-ste.json--default---%2Fdrafts%2Frakaur%2Fdotcom-126722-catalog-test-cct.json--default---%2Fdrafts%2Fbozo%2Fpersonalization%2Ftest-edu-user.json) can be used for testing. 

Resolves: [MWPW-155654](https://jira.corp.adobe.com/browse/MWPW-155654)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/bozo/price-cta?martech=off&georouting=off
- After: https://mwpw155654--milo--bozojovicic.hlx.page/drafts/bozo/price-cta?martech=off&georouting=off
