### PR TITLE
Feat(MWPW:151162):nofollow a individual link.

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -633,6 +633,10 @@ export function decorateLinks(el) {
       a.setAttribute('target', '_blank');
       a.href = a.href.replace('#_blank', '');
     }
+    if (a.href.includes('#_nofollow')) {
+      a.setAttribute('rel', 'nofollow');
+      a.href = a.href.replace('#_nofollow', '');
+    }
     if (a.href.includes('#_dnb')) {
       a.href = a.href.replace('#_dnb', '');
     } else {

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -24,6 +24,8 @@
     <p><a href="http://localhost:2000">http://localhost:2000/img/favicon.svg</a></p>
     <!-- #_blank -->
     <p><a class="new-tab" href="https://www.adobe.com/test#_blank">New Tab</a></p>
+    <!-- Nofollow individual link-->
+    <p><a class="no-follow" href="https://www.adobe.com/test#_nofollow">No Follow</a></p>
     <!-- Nofollow -->
     <p><a href="https://analytics.google.com">Google analytics</a></p>
     <!-- Disable Auto Block-->

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -246,7 +246,7 @@ describe('Utils', () => {
 
     it('Add rel=nofollow to a link', () => {
       const noFollowContainer = document.querySelector('main div');
-      utils.decorateLinks(noFollowContainer)
+      utils.decorateLinks(noFollowContainer);
       const noFollowLink = noFollowContainer.querySelector('.no-follow');
       expect(noFollowLink.rel).to.contain('nofollow');
       expect(noFollowLink.href).to.equal('https://www.adobe.com/test');

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -244,6 +244,14 @@ describe('Utils', () => {
       expect(newTabLink.href).to.equal('https://www.adobe.com/test');
     });
 
+    it('Add rel=nofollow to a link', () => {
+      const noFollowContainer = document.querySelector('main div');
+      utils.decorateLinks(noFollowContainer)
+      const noFollowLink = noFollowContainer.querySelector('.no-follow');
+      expect(noFollowLink.rel).to.contain('nofollow');
+      expect(noFollowLink.href).to.equal('https://www.adobe.com/test');
+    });
+
     it('Sets up milo.deferredPromise', async () => {
       const { resolveDeferred } = utils.getConfig();
       expect(window.milo.deferredPromise).to.exist;


### PR DESCRIPTION
This feature allows you to set the `rel='nofollow'` on a individual link in milo.

* similar to` #_blank` we can append `#_nofollow ` on a link to set the 'rel' attribute of an anchor tag to nofollow.
* eg: https://www.adobe.com/in/creativecloud.html#_nofollow
* updated milo docs https://mwpw-151162--milosh--sharath-kannan.hlx.page/docs/authoring/links

Resolves: [MWPW-151162](https://jira.corp.adobe.com/browse/MWPW-151162)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/sharathkannan/media-container?martech=off
- After: https://mwpw-151162--milosh--sharath-kannan.hlx.page/drafts/sharathkannan/media-container?martech=off
