### PR TITLE
MWPW-153987 [MILO][MEP] looks in wrong location for MEP test block code on stage

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -169,21 +169,19 @@ const fetchData = async (url, type = DATA_TYPE.JSON) => {
   return null;
 };
 
-const getBlockProps = (fVal) => {
+const getBlockProps = (fVal, miloLibs, origin) => {
   let val = fVal;
   if (val?.includes('\\')) val = val?.split('\\').join('/');
   if (!val?.startsWith('/')) val = `/${val}`;
   const blockSelector = val?.split('/').pop();
-  const { origin } = PAGE_URL;
-  if (origin.includes('.hlx.') || origin.includes('localhost')) {
-    if (val.startsWith('/libs/')) {
-      /* c8 ignore next 2 */
-      const { miloLibs, codeRoot } = getConfig();
-      val = `${miloLibs || codeRoot}${val.replace('/libs', '')}`;
-    } else {
-      val = `${origin}${val}`;
-    }
+
+  if (val.startsWith('/libs/')) {
+    /* c8 ignore next 1 */
+    val = `${miloLibs}${val.replace('/libs', '')}`;
+  } else {
+    val = `${origin}${val}`;
   }
+
   return { blockSelector, blockTarget: val };
 };
 
@@ -457,6 +455,7 @@ const getVariantInfo = (line, variantNames, variants, manifestPath, manifestOver
   if (pageFilter && !matchGlob(pageFilter, new URL(window.location).pathname)) return;
 
   if (!config.mep?.preview) manifestId = false;
+  const { origin } = PAGE_URL;
   variantNames.forEach((vn) => {
     const targetManifestId = vn.startsWith(TARGET_EXP_PREFIX) ? targetId : false;
     if (!line[vn] || line[vn].toLowerCase() === 'false') return;
@@ -483,7 +482,7 @@ const getVariantInfo = (line, variantNames, variants, manifestPath, manifestOver
       variants[vn][action] = variants[vn][action] || [];
 
       if (action === 'useblockcode') {
-        const { blockSelector, blockTarget } = getBlockProps(line[vn]);
+        const { blockSelector, blockTarget } = getBlockProps(line[vn], config.miloLibs, origin);
         variants[vn][action].push({
           selector: blockSelector,
           val: blockTarget,


### PR DESCRIPTION
MEP allows you to designate a folder for new or existing blocks.  Because it can be a consumer or core lib block, it needs to be able to switch between the 2.  However, because it may be a new block, it cannot use the same test as utils (checking if the blocks is listed in MILO_BLOCKS.

The existing code assumed some massage work was needed for preview links, but that stage and prod could use relative links.  However, apparently stage uses https://stage--milo--adobecom.hlx.live/ for milolibs. 

* no longer restrict the calculation to use a domain to preview links
* remove logic between milolibs and coderoot.  I realized that if they are in this if clause we always want to use milolibs
* find miloLibs and origin outside of the loop so it does not need to be recalculated

Resolves: [MWPW-153987](https://jira.corp.adobe.com/browse/MWPW-153987)

QA Instructions:
1. Open the network tab
2. Filter for the word "block"
3. Go to the after link if available.  If not, go to the only link and use content override for personalization.js
4. Hover and check the source domain for the 4 files

**Test URLs:**
Preview link:
Expected sources:
2 brick block files: mepblockjs--milo--adobecom.hlx.live
2 homepage-brick files: main--homepage--adobecom.hlx.page
- Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?mep=%2Fhomepage%2Ffragments%2Floggedout%2Ftests%2F2024%2Fq2%2Face0861%2Face0861.json--target-var1-newblockdesigns
- After: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?mep=%2Fhomepage%2Ffragments%2Floggedout%2Ftests%2F2024%2Fq2%2Face0861%2Face0861.json--target-var1-newblockdesigns&milolibs=mepblockjs

Stage link:
Expected sources:
2 brick block files: stage--milo--adobecom.hlx.live
2 homepage-brick files: www.stage.adobe.com
- URL: https://www.stage.adobe.com/?mep=%2Fhomepage%2Ffragments%2Floggedout%2Ftests%2F2024%2Fq2%2Face0861%2Face0861.json--target-var1-newblockdesigns

Stage link:
Expected sources:
4 brick and homepage-brick block files: www.adobe.com
- URL: https://www.stage.adobe.com/?mep=%2Fhomepage%2Ffragments%2Floggedout%2Ftests%2F2024%2Fq2%2Face0861%2Face0861.json--target-var1-newblockdesigns

Psi-check: https://mepblockjs--milo--adobecom.hlx.page/?martech=off