### PR TITLE
MWPW-155781 [MILO] Geo Modal Tracking on BACOM - Missing custom link

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -188,7 +188,10 @@ export async function getModal(details, custom) {
 
   if (!dialog.classList.contains('curtain-off')) {
     document.body.classList.add('disable-scroll');
-    const curtain = createTag('div', { class: 'modal-curtain is-open' });
+    const curtain = createTag('div', {
+      class: 'modal-curtain is-open',
+      'daa-ll': `${analyticsEventName}:modalClose:curtainClose`,
+    });
     curtain.addEventListener('click', (e) => {
       if (e.target === curtain) closeModal(dialog);
     });


### PR DESCRIPTION
* Add daa-ll property to modal curtain

Resolves: [MWPW-155781](https://jira.corp.adobe.com/browse/MWPW-155781)

QA instructions:
1. filter for "collect" in network tab (easier if you clear history after page load)
2. click on the curtain (overlay behind modal) to close the modal
3. check payload tab for first collect after you clicked and expand events.  Should see an event called "localeModal:modalClose:curtainClose"

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/uk/
- After: https://main--bacom--adobecom.hlx.page/uk/?milolibs=modalcurtainanalytic

Psi-check: https://modalcurtainanalytic--milo--adobecom.hlx.page/?martech=off
