### PR TITLE
Fix: Load gnav search files only if it is authored

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -405,13 +405,15 @@ class Gnav {
       try {
         this.block.removeEventListener('click', this.loadDelayed);
         this.block.removeEventListener('keydown', this.loadDelayed);
-        const [
-          Search,
-        ] = await Promise.all([
-          loadBlock('../features/search/gnav-search.js'),
-          loadStyles(rootPath('features/search/gnav-search.css')),
-        ]);
-        this.Search = Search;
+        if (this.searchPresent()) {
+          const [
+            Search,
+          ] = await Promise.all([
+            loadBlock('../features/search/gnav-search.js'),
+            loadStyles(rootPath('features/search/gnav-search.css')),
+          ]);
+          this.Search = Search;
+        }
 
         if (!this.useUniversalNav) {
           const [ProfileDropdown] = await Promise.all([


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Removing unnecessary loading of gnav search JS and CSS files.

Resolves: [MWPW-154608](https://jira.corp.adobe.com/browse/MWPW-154608)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/blaishram/gnav-search-page?martech=off
- After: https://gnav-search--milo--bandana147.hlx.live/drafts/blaishram/gnav-search-page?martech=off
