### PR TITLE
[MWPW-154102] Accordion RTL alignment

### DIFF
--- a/libs/blocks/accordion/accordion.css
+++ b/libs/blocks/accordion/accordion.css
@@ -32,7 +32,7 @@ dl.accordion {
   line-height: var(--type-heading-s-lh);
   padding: var(--spacing-s) var(--spacing-m) var(--spacing-s) var(--spacing-xs);
   position: relative;
-  text-align: left;
+  text-align: start;
   width: 100%;
   -webkit-text-size-adjust: 100%;
 }


### PR DESCRIPTION
This adjusts an accordion style for RTL alignment.

| Before | After |
| ------------- | ------------- |
| <img width="499" alt="Screenshot 2024-08-07 at 13 31 05" src="https://github.com/user-attachments/assets/4ba7dae5-4eb0-45c9-8cee-c32a4406a031"> | <img width="499" alt="Screenshot 2024-08-07 at 13 30 35" src="https://github.com/user-attachments/assets/2374232d-e654-4e7d-bf34-1a4f9c0a9b4d"> |

Resolves: [MWPW-154102](https://jira.corp.adobe.com/browse/MWPW-154102)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/kw_ar/drafts/ramuntea/accordion?martech=off
- After: https://accordion-rtl--milo--overmyheadandbody.hlx.page/kw_ar/drafts/ramuntea/accordion?martech=off
