### PR TITLE
[MWPW-154970] allow authoring hash value delay=0 for promo modals

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -222,7 +222,7 @@ export function getHashParams(hashStr) {
       params.hash = part;
     } else {
       const [key, val] = part.split('=');
-      if (key === 'delay' && parseInt(val, 10) > 0) {
+      if (key === 'delay') {
         params.delay = parseInt(val, 10) * 1000;
       }
     }
@@ -232,7 +232,7 @@ export function getHashParams(hashStr) {
 
 export function delayedModal(el) {
   const { hash, delay } = getHashParams(el?.dataset.modalHash);
-  if (!delay || !hash) return false;
+  if (delay === undefined || !hash) return false;
   isDelayedModal = true;
   const modalOpenEvent = new Event(`${hash}:modalOpen`);
   const pagesModalWasShownOn = window.sessionStorage.getItem(`shown:${hash}`);

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -191,7 +191,10 @@ describe('Modals', () => {
 
   it('validates and returns proper hash parameters', () => {
     expect(getHashParams()).to.deep.equal({});
-    expect(getHashParams('#delayed-modal:delay=0')).to.deep.equal({ hash: '#delayed-modal' });
+    expect(getHashParams('#delayed-modal:delay=0')).to.deep.equal({
+      delay: 0,
+      hash: '#delayed-modal',
+    });
     expect(getHashParams('#delayed-modal:delay=1')).to.deep.equal({
       delay: 1000,
       hash: '#delayed-modal',


### PR DESCRIPTION
* Allow authoring hash value delay=0 for modals authored using promos.
* This is for the performance gain we see when these modals are authored with delay=0 compared to delay=1

Resolves: [MWPW-154970](https://jira.corp.adobe.com/browse/MWPW-154970)

**Test URLs:**
Milo:

- Before: https://stage--milo--adobecom.hlx.page/drafts/ruchika/document?martech=off
- After: https://MWPW-154970--milo--adobecom.hlx.page/drafts/ruchika/document?martech=off

CC
- Before: https://main--cc--adobecom.hlx.page/drafts/ruchika/tiger/promo/illustrator-no-delay?martech=off

- After: https://main--cc--adobecom.hlx.page/drafts/ruchika/tiger/promo/illustrator-no-delay?milolibs=MWPW-154970&martech=off
