### PR TITLE
[MWPW-156163] Send additional Slack notifications for high impact PRs

### DIFF
--- a/.github/workflows/high-impact-alert.js
+++ b/.github/workflows/high-impact-alert.js
@@ -13,9 +13,12 @@ const main = async (params) => {
     }
 
     const { html_url, number, title } = context.payload.pull_request;
-    console.log('High impact label detected, sending Slack notification');
+    console.log('High impact label detected, sending Slack notifications');
     slackNotification(`:alert: High Impact PR has been opened: <${html_url}|#${number}: ${title}>.` +
       ` Please prioritize testing the proposed changes.`, process.env.SLACK_HIGH_IMPACT_PR_WEBHOOK);
+    slackNotification(`:alert: High Impact PR has been opened: <${html_url}|#${number}: ${title}>.` +
+      ` Please review the PR details promptly and raise any concerns or questions.`,
+      process.env.SLACK_MILO_UPDATES_WEBHOOK);
   } catch (error) {
     console.error(error);
   }

--- a/.github/workflows/high-impact-alert.yml
+++ b/.github/workflows/high-impact-alert.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   SLACK_HIGH_IMPACT_PR_WEBHOOK: ${{ secrets.SLACK_HIGH_IMPACT_PR_WEBHOOK }}
+  SLACK_MILO_UPDATES_WEBHOOK: ${{ secrets.SLACK_MILO_UPDATES_WEBHOOK }}
 
 jobs:
   send_alert:


### PR DESCRIPTION
This sends an additional notification to a new Milo channel whenever PRs marked as 'high-impact' are opened. Moving forward, we might want to send just one notification, but both will be needed during this transition period to ensure everyone remains informed.

Resolves: [MWPW-156163](https://jira.corp.adobe.com/browse/MWPW-156163)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/?martech=off
- After: https://milo-updates-notif--milo--overmyheadandbody.hlx.page/?martech=off
