### PR TITLE
MWPW-153810 media image is seen loaded twice in product page urls in desktop

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -728,7 +728,9 @@ async function decoratePlaceholders(area, config) {
     NodeFilter.SHOW_TEXT,
     {
       acceptNode: (node) => {
-        return regex.test(node.nodeValue) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+        const a = regex.test(node.nodeValue) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+        regex.lastIndex = 0;
+        return a;
     },
   });
   const nodes = [];

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -733,7 +733,7 @@ async function decoratePlaceholders(area, config) {
         regex.lastIndex = 0;
         return a;
       },
-    },
+      },
   );
   const nodes = [];
   let node = walker.nextNode();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -724,26 +724,29 @@ async function decorateIcons(area, config) {
 async function decoratePlaceholders(area, config) {
   const el = area.querySelector('main') || area;
   const regex = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
-  const walker = document.createTreeWalker(el,
+  const walker = document.createTreeWalker(
+    el,
     NodeFilter.SHOW_TEXT,
     {
-      acceptNode: (node) => {
+      acceptNode(node) {
         const a = regex.test(node.nodeValue) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
         regex.lastIndex = 0;
         return a;
+      },
     },
-  });
+  );
   const nodes = [];
-  let node;
-  while (node = walker.nextNode()) {
+  let node = walker.nextNode();
+  while (node !== null) {
     nodes.push(node);
+    node = walker.nextNode();
   }
   if (!nodes.length) return;
   const { replaceText } = await import('../features/placeholders.js');
-  for (const textNode of nodes) {
+  const replaceNodes = nodes.map(async (textNode) => {
     textNode.nodeValue = await replaceText(textNode.nodeValue, config, regex);
-    textNode.nodeValue = textNode.nodeValue.replace(/&nbsp;/g, '\u00A0');
-  }
+  });
+  await Promise.all(replaceNodes);
 }
 
 async function loadFooter() {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -733,7 +733,7 @@ async function decoratePlaceholders(area, config) {
         regex.lastIndex = 0;
         return a;
       },
-      },
+    },
   );
   const nodes = [];
   let node = walker.nextNode();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -745,6 +745,7 @@ async function decoratePlaceholders(area, config) {
   const { replaceText } = await import('../features/placeholders.js');
   const replaceNodes = nodes.map(async (textNode) => {
     textNode.nodeValue = await replaceText(textNode.nodeValue, config, regex);
+    textNode.nodeValue = textNode.nodeValue.replace(/&nbsp;/g, '\u00A0');
   });
   await Promise.all(replaceNodes);
 }

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -45,6 +45,6 @@
   <!-- Default content -->
   <div>
     <p>I'm not a blockhead.</p>
-    <p>{{nothing-to-see-here}}</p>
+    <p>{{&nbsp;inkl. MwSt.}}</p>
   </div>
 </main>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -191,7 +191,7 @@ describe('Utils', () => {
     it('Decorates placeholder', () => {
       const paragraphs = [...document.querySelectorAll('p')];
       const lastPara = paragraphs.pop();
-      expect(lastPara.textContent).to.equal('nothing to see here');
+      expect(lastPara.textContent).to.equal(' inkl. MwSt.');
     });
 
     it('Decorates meta helix url', () => {


### PR DESCRIPTION
Media image is seen loaded twice in product page urls in desktop
This fixes the replacing of whole innerHTML if there is any placeholder on the page. It only the specific placeholder text.

Resolves: [MWPW-153810](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:

Before: https://main--milo--adobecom.hlx.page/drafts/suhjain/performance/marquee-light
After: https://placeholderReplace--milo--adobecom.hlx.live/drafts/suhjain/performance/marquee-light
