### PR TITLE
MWPW-156094: clean up LTRM in URLs

### DIFF
--- a/libs/blocks/quiz/quizcontainer.js
+++ b/libs/blocks/quiz/quizcontainer.js
@@ -1,6 +1,7 @@
 import { html } from '../../deps/htm-preact.js';
+import { removeLeftToRightMark } from './utils.js';
 
-export const DecorateBlockBackgroundCmp = ({ background = '' }) => html`<img loading="eager" alt="" src=${background} height="1020" width="1920" />`;
+export const DecorateBlockBackgroundCmp = ({ background = '' }) => html`<img loading="eager" alt="" src=${removeLeftToRightMark(background)} height="1020" width="1920" />`;
 
 export const DecorateBlockForeground = ({ heading, subhead }) => html`<div class="quiz-foreground">
     <h1 id="question" class="quiz-question-title" daa-lh="${heading}">${heading}</h1>

--- a/libs/blocks/quiz/quizoption.js
+++ b/libs/blocks/quiz/quizoption.js
@@ -1,4 +1,5 @@
 import { html } from '../../deps/htm-preact.js';
+import { removeLeftToRightMark } from './utils.js';
 
 export const OptionCard = ({
   text, title, image, icon, iconTablet, iconDesktop, options, disabled, selected, background,
@@ -22,15 +23,15 @@ export const OptionCard = ({
 
   const getIconHtml = () => html`<div class="quiz-option-icon ${getIconClass()}">
     <picture>
-      ${iconDesktop && html`<source media="(min-width: 1024px)" srcset="${iconDesktop}" />`}
-      ${iconTablet && html`<source media="(min-width: 600px)" srcset="${iconTablet}" />`}
-      <img src="${icon}" alt="" loading="lazy" />
+      ${iconDesktop && html`<source media="(min-width: 1024px)" srcset="${removeLeftToRightMark(iconDesktop)}" />`}
+      ${iconTablet && html`<source media="(min-width: 600px)" srcset="${removeLeftToRightMark(iconTablet)}" />`}
+      <img src="${removeLeftToRightMark(icon)}" alt="" loading="lazy" />
     </picture>
   </div>`;
 
   const imageHtml = html`
     <div class="quiz-option-image" 
-      style="background-image: url('${image}'); background-size: cover" loading="lazy">
+      style="background-image: url('${removeLeftToRightMark(image)}'); background-size: cover" loading="lazy">
     </div>`;
 
   const titleHtml = html`

--- a/libs/blocks/quiz/utils.js
+++ b/libs/blocks/quiz/utils.js
@@ -520,8 +520,11 @@ export const isValidUrl = (url) => VALID_URL_RE.test(url);
 
 export const getNormalizedMetadata = (el) => normalizeKeys(getMetadata(el));
 
+export const removeLeftToRightMark = (url) => decodeURIComponent(url).replace(/\u200E/g, '');
+
 export const getLocalizedURL = (originalURL) => {
   const { locale } = getConfig();
   const { prefix, ietf = 'en-US' } = locale || {};
-  return ietf !== 'en-US' && !originalURL.startsWith(`${prefix}/`) ? `${prefix}${originalURL}` : originalURL;
+  const decodedURL = removeLeftToRightMark(originalURL);
+  return ietf !== 'en-US' && !decodedURL.startsWith(`${prefix}/`) ? `${prefix}${decodedURL}` : decodedURL;
 };


### PR DESCRIPTION


<!-- Before submitting, please review all open PRs. -->

* Add new function in utils to clean up LTRM unicode in URLs
* Call above function in proper places

Resolves: [MWPW-156094](https://jira.corp.adobe.com/browse/MWPW-156094)

**Test URLs:**
-Before: https://main--cc--adobecom.hlx.page/il_he/creativecloud/plan-recommender/quiz2?martech=off
-After: https://stage--milo--jackysun9.hlx.page/drafts/quiz/plan-recommender-var/quiz?martech=off

How to test?
Test IL Page
https://main--cc--adobecom.hlx.page/il_he/creativecloud/plan-recommender/quiz2?martech=off&milolibs=stage--milo--JackySun9

Test JP page
https://main--cc--adobecom.hlx.page/jp/creativecloud/plan-recommender/quiz?martech=off&milolibs=stage--milo--JackySun9

Test EN Page
https://main--cc--adobecom.hlx.page/creativecloud/plan-recommender/quiz?martech=off&milolibs=stage--milo--JackySun9

Test DE Page
https://main--cc--adobecom.hlx.page/de/creativecloud/plan-recommender/quiz?martech=off&milolibs=stage--milo--JackySun9
