### PR TITLE
MWPW-ComingSoon fix for martech=off when page has manifest with enablements

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -597,7 +597,7 @@ async function getPersonalizationVariant(manifestPath, variantNames = [], varian
   const hasEntitlementTag = entitlementKeys.some((tag) => variantInfo.allNames.includes(tag));
 
   let userEntitlements = [];
-  if (hasEntitlementTag) {
+  if (hasEntitlementTag && config.mep.martech !== 'off') {
     userEntitlements = await config.entitlements();
   }
 
@@ -937,7 +937,7 @@ export const combineMepSources = async (persEnabled, promoEnabled, mepParam) => 
 export async function init(enablements = {}) {
   let manifests = [];
   const {
-    mepParam, mepHighlight, mepButton, pzn, promo, target, postLCP,
+    mepParam, mepHighlight, mepButton, pzn, promo, target, postLCP, martech
   } = enablements;
   const config = getConfig();
   if (!postLCP) {
@@ -950,6 +950,7 @@ export async function init(enablements = {}) {
       highlight: (mepHighlight !== undefined && mepHighlight !== 'false'),
       targetEnabled: target,
       experiments: [],
+      martech,
     };
     manifests = manifests.concat(await combineMepSources(pzn, promo, mepParam));
     manifests?.forEach((manifest) => {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -924,14 +924,19 @@ export const getMepEnablement = (mdKey, paramKey = false) => {
 };
 
 async function checkForPageMods() {
-  const { mep: mepParam, mepHighlight, mepButton } = Object.fromEntries(PAGE_URL.searchParams);
+  const {
+    mep: mepParam,
+    mepHighlight,
+    mepButton,
+    martech,
+  } = Object.fromEntries(PAGE_URL.searchParams);
   if (mepParam === 'off') return;
   const pzn = getMepEnablement('personalization');
   const promo = getMepEnablement('manifestnames', PROMO_PARAM);
   const target = getMepEnablement('target');
   if (!(pzn || target || promo || mepParam
     || mepHighlight || mepButton || mepParam === '')) return;
-  if (target) {
+  if (target && martech !== 'off') {
     loadMartech();
   } else if (pzn) {
     loadIms()
@@ -944,7 +949,7 @@ async function checkForPageMods() {
 
   const { init } = await import('../features/personalization/personalization.js');
   await init({
-    mepParam, mepHighlight, mepButton, pzn, promo, target,
+    mepParam, mepHighlight, mepButton, pzn, promo, target, martech,
   });
 }
 


### PR DESCRIPTION
pages with enablements cannot finish rendering when martech is disabled.

* add a check to disable the feature when martech is off

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/illustrator?martech=off
- After: https://main--cc--adobecom.hlx.page/products/illustrator?martech=off&milolibs=martechofffix
- 
Psi check: https://martechofffix--milo--adobecom.hlx.page/?martech=off
