### PR TITLE
MWPW-155412: Fix video CLS netting +10 lighthouse points

### DIFF
--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -1,6 +1,7 @@
 import { turnAnchorIntoVideo } from '../../utils/decorate.js';
 
-const loadAdobeTv = (a) => {
+export default function init(a) {
+  a.classList.add('hide-video');
   const bgBlocks = ['aside', 'marquee', 'hero-marquee'];
   if (a.href.includes('.mp4') && bgBlocks.some((b) => a.closest(`.${b}`))) {
     a.classList.add('hide');
@@ -18,9 +19,4 @@ const loadAdobeTv = (a) => {
     a.insertAdjacentHTML('afterend', embed);
     a.remove();
   }
-};
-
-export default function init(a) {
-  a.classList.add('hide-video');
-  loadAdobeTv(a);
 }

--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -7,11 +7,11 @@ const loadAdobeTv = (a) => {
   const bgBlocks = ['aside', 'marquee', 'hero-marquee'];
   if (a.href.includes('.mp4') && bgBlocks.some((b) => a.closest(`.${b}`))) {
     a.classList.add('hide');
+    const parentElement = a.parentNode;
+    if (!parentElement) return;
     const { href, hash, dataset } = a;
     const attrs = getVideoAttrs(hash || 'autoplay', dataset);
     const video = `<video ${attrs}></video>`;
-    const parentElement = a.parentNode;
-    if (!parentElement) return;
     a.insertAdjacentHTML('afterend', video);
     createIntersectionObserver({
       el: parentElement,

--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -1,4 +1,4 @@
-import { createIntersectionObserver } from '../../utils/utils.js';
+import { createIntersectionObserver, createTag } from '../../utils/utils.js';
 import { applyHoverPlay, getVideoAttrs } from '../../utils/decorate.js';
 
 const ROOT_MARGIN = 1000;
@@ -9,11 +9,19 @@ const loadAdobeTv = (a) => {
     a.classList.add('hide');
     const { href, hash, dataset } = a;
     const attrs = getVideoAttrs(hash || 'autoplay', dataset);
-    const video = `<video ${attrs}>
-          <source src="${href}" type="video/mp4" />
-        </video>`;
-    if (!a.parentNode) return;
+    const video = `<video ${attrs}></video>`;
+    const parentElement = a.parentNode;
+    if (!parentElement) return;
     a.insertAdjacentHTML('afterend', video);
+    createIntersectionObserver({
+      el: parentElement,
+      options: { rootMargin: `${ROOT_MARGIN}px` },
+      callback: () => {
+        parentElement
+          .querySelector('video')
+          .appendChild(createTag('source', { src: href, type: 'video/mp4' }));
+      },
+    });
     const videoElem = document.body.querySelector(`source[src="${href}"]`)?.parentElement;
     applyHoverPlay(videoElem);
     a.remove();
@@ -29,13 +37,5 @@ const loadAdobeTv = (a) => {
 
 export default function init(a) {
   a.classList.add('hide-video');
-  if (a.textContent.includes('no-lazy')) {
-    loadAdobeTv(a);
-  } else {
-    createIntersectionObserver({
-      el: a,
-      options: { rootMargin: `${ROOT_MARGIN}px` },
-      callback: loadAdobeTv,
-    });
-  }
+  loadAdobeTv(a);
 }

--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -1,30 +1,15 @@
-import { createIntersectionObserver, createTag } from '../../utils/utils.js';
-import { applyHoverPlay, getVideoAttrs } from '../../utils/decorate.js';
-
-const ROOT_MARGIN = 1000;
+import { turnAnchorIntoVideo } from '../../utils/decorate.js';
 
 const loadAdobeTv = (a) => {
   const bgBlocks = ['aside', 'marquee', 'hero-marquee'];
   if (a.href.includes('.mp4') && bgBlocks.some((b) => a.closest(`.${b}`))) {
     a.classList.add('hide');
-    const parentElement = a.parentNode;
-    if (!parentElement) return;
-    const { href, hash, dataset } = a;
-    const attrs = getVideoAttrs(hash || 'autoplay', dataset);
-    const video = `<video ${attrs}></video>`;
-    a.insertAdjacentHTML('afterend', video);
-    createIntersectionObserver({
-      el: parentElement,
-      options: { rootMargin: `${ROOT_MARGIN}px` },
-      callback: () => {
-        parentElement
-          .querySelector('video')
-          .appendChild(createTag('source', { src: href, type: 'video/mp4' }));
-      },
+    if (!a.parentNode) return;
+    turnAnchorIntoVideo({
+      hash: a.hash || 'autoplay',
+      src: a.href,
+      anchorTag: a,
     });
-    const videoElem = document.body.querySelector(`source[src="${href}"]`)?.parentElement;
-    applyHoverPlay(videoElem);
-    a.remove();
   } else {
     const embed = `<div class="milo-video">
       <iframe src="${a.href}" class="adobetv" webkitallowfullscreen mozallowfullscreen allowfullscreen scrolling="no" allow="encrypted-media" title="Adobe Video Publishing Cloud Player" loading="lazy">

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -1,4 +1,4 @@
-import { createIntersectionObserver, getConfig } from '../../utils/utils.js';
+import { createIntersectionObserver, getConfig, createTag } from '../../utils/utils.js';
 import { applyHoverPlay, getVideoAttrs, applyInViewPortPlay } from '../../utils/decorate.js';
 
 const ROOT_MARGIN = 1000;
@@ -16,11 +16,21 @@ const loadVideo = (a) => {
   }
 
   const attrs = getVideoAttrs(hash, dataset);
-  const video = `<video ${attrs}>
-        <source src="${videoPath}" type="video/mp4" />
-      </video>`;
-  if (!a.parentNode) return;
+  const video = `<video ${attrs}></video>`;
+  const parentElement = a.parentNode;
+  if (!parentElement) return;
   a.insertAdjacentHTML('afterend', video);
+  createIntersectionObserver({
+    el: parentElement,
+    options: { rootMargin: `${ROOT_MARGIN}px` },
+    callback: () => {
+      parentElement
+        .querySelector('video')
+        .appendChild(
+          createTag('source', { src: videoPath, type: 'video/mp4' }),
+        );
+    },
+  });
   const videoElem = document.body.querySelector(`source[src="${videoPath}"]`)?.parentElement;
   applyHoverPlay(videoElem);
   applyInViewPortPlay(videoElem);
@@ -29,13 +39,5 @@ const loadVideo = (a) => {
 
 export default function init(a) {
   a.classList.add('hide-video');
-  if (a.textContent.includes('no-lazy')) {
-    loadVideo(a);
-  } else {
-    createIntersectionObserver({
-      el: a,
-      options: { rootMargin: `${ROOT_MARGIN}px` },
-      callback: loadVideo,
-    });
-  }
+  loadVideo(a);
 }

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -4,6 +4,8 @@ import { applyHoverPlay, getVideoAttrs, applyInViewPortPlay } from '../../utils/
 const ROOT_MARGIN = 1000;
 
 const loadVideo = (a) => {
+  const parentElement = a.parentNode;
+  if (!parentElement) return;
   const { pathname, hash, dataset } = a;
   let videoPath = `.${pathname}`;
   if (pathname.match('media_.*.mp4')) {
@@ -17,8 +19,6 @@ const loadVideo = (a) => {
 
   const attrs = getVideoAttrs(hash, dataset);
   const video = `<video ${attrs}></video>`;
-  const parentElement = a.parentNode;
-  if (!parentElement) return;
   a.insertAdjacentHTML('afterend', video);
   createIntersectionObserver({
     el: parentElement,

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -31,7 +31,7 @@ const loadVideo = (a) => {
         );
     },
   });
-  const videoElem = document.body.querySelector(`source[src="${videoPath}"]`)?.parentElement;
+  const videoElem = parentElement.querySelector('video');
   applyHoverPlay(videoElem);
   applyInViewPortPlay(videoElem);
   a.remove();

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -1,12 +1,9 @@
-import { createIntersectionObserver, getConfig, createTag } from '../../utils/utils.js';
-import { applyHoverPlay, getVideoAttrs, applyInViewPortPlay } from '../../utils/decorate.js';
-
-const ROOT_MARGIN = 1000;
+import { getConfig } from '../../utils/utils.js';
+import { turnAnchorIntoVideo } from '../../utils/decorate.js';
 
 const loadVideo = (a) => {
-  const parentElement = a.parentNode;
-  if (!parentElement) return;
-  const { pathname, hash, dataset } = a;
+  if (!a.parentNode) return;
+  const { pathname } = a;
   let videoPath = `.${pathname}`;
   if (pathname.match('media_.*.mp4')) {
     const { codeRoot } = getConfig();
@@ -16,25 +13,11 @@ const loadVideo = (a) => {
     const mediaFilename = pathname.split('/').pop();
     videoPath = `${root}${mediaFilename}`;
   }
-
-  const attrs = getVideoAttrs(hash, dataset);
-  const video = `<video ${attrs}></video>`;
-  a.insertAdjacentHTML('afterend', video);
-  createIntersectionObserver({
-    el: parentElement,
-    options: { rootMargin: `${ROOT_MARGIN}px` },
-    callback: () => {
-      parentElement
-        .querySelector('video')
-        .appendChild(
-          createTag('source', { src: videoPath, type: 'video/mp4' }),
-        );
-    },
+  turnAnchorIntoVideo({
+    hash: a.hash,
+    src: videoPath,
+    anchorTag: a,
   });
-  const videoElem = parentElement.querySelector('video');
-  applyHoverPlay(videoElem);
-  applyInViewPortPlay(videoElem);
-  a.remove();
 };
 
 export default function init(a) {

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -1,7 +1,8 @@
 import { getConfig } from '../../utils/utils.js';
 import { turnAnchorIntoVideo } from '../../utils/decorate.js';
 
-const loadVideo = (a) => {
+export default function init(a) {
+  a.classList.add('hide-video');
   if (!a.parentNode) return;
   const { pathname } = a;
   let videoPath = `.${pathname}`;
@@ -18,9 +19,4 @@ const loadVideo = (a) => {
     src: videoPath,
     anchorTag: a,
   });
-};
-
-export default function init(a) {
-  a.classList.add('hide-video');
-  loadVideo(a);
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -1,7 +1,5 @@
 import { createTag, createIntersectionObserver } from './utils.js';
 
-const ROOT_MARGIN = 1000;
-
 export function decorateButtons(el, size) {
   const buttons = el.querySelectorAll('em a, strong a, p > a strong');
   if (buttons.length === 0) return;
@@ -270,11 +268,11 @@ export function turnAnchorIntoVideo({ hash, src, anchorTag }) {
   anchorTag.insertAdjacentHTML('afterend', video);
   createIntersectionObserver({
     el: parentElement,
-    options: { rootMargin: `${ROOT_MARGIN}px` },
+    options: { rootMargin: '1000px' },
     callback: () => {
       parentElement
         .querySelector('video')
-        .appendChild(
+        ?.appendChild(
           createTag('source', { src, type: 'video/mp4' }),
         );
     },

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -1,4 +1,6 @@
-import { createTag } from './utils.js';
+import { createTag, createIntersectionObserver } from './utils.js';
+
+const ROOT_MARGIN = 1000;
 
 export function decorateButtons(el, size) {
   const buttons = el.querySelectorAll('em a, strong a, p > a strong');
@@ -229,7 +231,7 @@ export function handleObjectFit(bgRow) {
   });
 }
 
-export function getVideoIntersectionObserver() {
+function getVideoIntersectionObserver() {
   if (!window?.videoIntersectionObs) {
     window.videoIntersectionObs = new window.IntersectionObserver((entries) => {
       entries.forEach((entry) => {
@@ -250,7 +252,7 @@ export function getVideoIntersectionObserver() {
   return window.videoIntersectionObs;
 }
 
-export function applyInViewPortPlay(video) {
+function applyInViewPortPlay(video) {
   if (!video) return;
   if (video.hasAttribute('data-play-viewport')) {
     const observer = getVideoIntersectionObserver();
@@ -259,4 +261,26 @@ export function applyInViewPortPlay(video) {
     });
     observer.observe(video);
   }
+}
+
+export function turnAnchorIntoVideo({ hash, src, anchorTag }) {
+  const { dataset, parentElement } = anchorTag;
+  const attrs = getVideoAttrs(hash, dataset);
+  const video = `<video ${attrs}></video>`;
+  anchorTag.insertAdjacentHTML('afterend', video);
+  createIntersectionObserver({
+    el: parentElement,
+    options: { rootMargin: `${ROOT_MARGIN}px` },
+    callback: () => {
+      parentElement
+        .querySelector('video')
+        .appendChild(
+          createTag('source', { src, type: 'video/mp4' }),
+        );
+    },
+  });
+  const videoEl = parentElement.querySelector('video');
+  applyHoverPlay(videoEl);
+  applyInViewPortPlay(videoEl);
+  anchorTag.remove();
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -266,18 +266,14 @@ export function turnAnchorIntoVideo({ hash, src, anchorTag }) {
   const attrs = getVideoAttrs(hash, dataset);
   const video = `<video ${attrs}></video>`;
   anchorTag.insertAdjacentHTML('afterend', video);
+  const videoEl = parentElement.querySelector('video');
   createIntersectionObserver({
     el: parentElement,
     options: { rootMargin: '1000px' },
     callback: () => {
-      parentElement
-        .querySelector('video')
-        ?.appendChild(
-          createTag('source', { src, type: 'video/mp4' }),
-        );
+      videoEl?.appendChild(createTag('source', { src, type: 'video/mp4' }));
     },
   });
-  const videoEl = parentElement.querySelector('video');
   applyHoverPlay(videoEl);
   applyInViewPortPlay(videoEl);
   anchorTag.remove();

--- a/test/blocks/adobetv/adobetv.test.js
+++ b/test/blocks/adobetv/adobetv.test.js
@@ -6,17 +6,6 @@ document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 const { default: init } = await import('../../../libs/blocks/adobetv/adobetv.js');
 
 describe('adobetv autoblock', () => {
-  it('decorates no-lazy video', async () => {
-    const block = document.querySelector('.video.no-lazy');
-    const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
-    block.append(a);
-
-    init(a);
-    const video = await waitForElement('.video.no-lazy iframe');
-    expect(video).to.exist;
-  });
-
   it('creates video block', async () => {
     const wrapper = document.body.querySelector('.adobe-tv');
     const a = wrapper.querySelector(':scope > a');

--- a/test/blocks/adobetv/mocks/body.html
+++ b/test/blocks/adobetv/mocks/body.html
@@ -1,5 +1,5 @@
 <main>
-  <div class="video no-lazy">
+  <div class="video">
     <a href="https://video.tv.adobe.com/v/3410934t1">
       https://video.tv.adobe.com/v/3410934t1
     </a>

--- a/test/blocks/marquee/marquee.test.js
+++ b/test/blocks/marquee/marquee.test.js
@@ -1,8 +1,8 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { waitForElement } from '../../helpers/waitfor.js';
-import { setConfig } from '../../../libs/utils/utils.js';
+import { waitFor, waitForElement } from '../../helpers/waitfor.js';
+import { setConfig, loadStyle } from '../../../libs/utils/utils.js';
 import { loadMnemonicList } from '../../../libs/blocks/marquee/marquee.js';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
@@ -16,6 +16,15 @@ const video = await readFile({ path: './mocks/video.html' });
 const multipleIcons = await readFile({ path: './mocks/multiple-icons.html' });
 
 describe('marquee', () => {
+  before(async () => {
+    await new Promise((resolve) => {
+      loadStyle('../../../../libs/styles/styles.css', resolve);
+    });
+    await new Promise((resolve) => {
+      loadStyle('../../../../libs/blocks/marquee/marquee.css', resolve);
+    });
+  });
+
   const marquees = document.querySelectorAll('.marquee');
   marquees.forEach((marquee) => {
     init(marquee);
@@ -69,7 +78,9 @@ describe('marquee', () => {
       init(marquee);
       videoBLock(document.querySelector('#single-background a[href*=".mp4"]'));
       const videoEl = await waitForElement('#single-background .background video');
-      expect(videoEl).to.exist;
+      const intersectionObserverAddsSource = () => videoEl.querySelector('source');
+      await waitFor(intersectionObserverAddsSource);
+      expect(videoEl.querySelector('source')).to.exist;
       document.getElementById('single-background').remove();
     });
 
@@ -78,7 +89,9 @@ describe('marquee', () => {
       init(marquee);
       document.querySelectorAll('#multiple-background a[href*=".mp4"]').forEach((videoLink) => videoBLock(videoLink));
       await waitForElement('#multiple-background .background video');
-      expect(marquee.querySelectorAll('.background video').length).to.equal(1);
+      const intersectionObserverAddsSource = () => document.querySelector('.background video source');
+      await waitFor(intersectionObserverAddsSource);
+      expect(marquee.querySelectorAll('.background video source').length).to.equal(1);
       document.getElementById('multiple-background').remove();
     });
 

--- a/test/blocks/video/mocks/body.html
+++ b/test/blocks/video/mocks/body.html
@@ -4,7 +4,7 @@
   }
 </style>
 <main>
-  <div class="video no-lazy">
+  <div class="video">
     <a href="https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4">
       https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4
     </a>

--- a/test/blocks/video/video.test.js
+++ b/test/blocks/video/video.test.js
@@ -1,9 +1,8 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect, assert } from '@esm-bundle/chai';
-
 import sinon from 'sinon';
+import { waitFor, waitForElement } from '../../helpers/waitfor.js';
 
-import { waitForElement } from '../../helpers/waitfor.js';
 import { setConfig } from '../../../libs/utils/utils.js';
 
 setConfig({});
@@ -105,7 +104,7 @@ describe('video uploaded using franklin bot', () => {
     expect(video.hasAttribute('data-play-viewport')).to.be.true;
   });
 
-  it('play video when element reached 80% viewport', async () => {
+  it.only('play video when element reached 80% viewport', async () => {
     const block = document.querySelector('.video.autoplay.viewportplay.scrolled-80');
     const a = block.querySelector('a');
     a.textContent = 'no-lazy';
@@ -116,20 +115,26 @@ describe('video uploaded using franklin bot', () => {
 
     init(a);
     const video = block.querySelector('video');
+    console.log(video);
+    const intersectionObserverAddsSource = () => {
+      console.log({ shild: video.firstElementChild });
+      return video.querySelector('source');
+    };
+    const playSpy = sinon.spy(video, 'play');
+    const pauseSpy = sinon.spy(video, 'pause');
+    await waitFor(intersectionObserverAddsSource);
     const source = video.querySelector('source');
     source.setAttribute('src', 'https://www.adobe.com/creativecloud/media_1167374e3354ef57f126fa78a55cbc1708ac4babd.mp4');
     source.setAttribute('type', 'video/mp4');
-
-    const playSpy = sinon.spy(video, 'play');
-    const pauseSpy = sinon.spy(video, 'pause');
 
     video.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
+    console.log('grr');
     assert.isTrue(playSpy.calledOnce);
-
+    console.log('grr-1');
     document.body.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {

--- a/test/blocks/video/video.test.js
+++ b/test/blocks/video/video.test.js
@@ -17,17 +17,6 @@ describe('video uploaded using franklin bot', () => {
     document.body.innerHTML = '';
   });
 
-  it('decorates no-lazy video', async () => {
-    const block = document.querySelector('.video.no-lazy');
-    const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
-    block.append(a);
-
-    init(a);
-    const video = await waitForElement('.video.no-lazy video');
-    expect(video).to.exist;
-  });
-
   it('decorates video', async () => {
     const block = document.querySelector('.video.normal');
     const a = block.querySelector('a');
@@ -80,7 +69,6 @@ describe('video uploaded using franklin bot', () => {
   it('no hoverplay attribute added when with autoplay on loop', async () => {
     const block = document.querySelector('.video.autoplay.playonhover');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -92,7 +80,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with hoverplay when only hoverplay is added to url', async () => {
     const block = document.querySelector('.video.hoveronly');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -103,7 +90,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with viewportplay only with autoplay', async () => {
     const block = document.querySelector('.video.autoplay.viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -147,8 +133,6 @@ describe('video uploaded using franklin bot', () => {
 
   it('Don\'t play the video once it end when autoplay1 enabled', async () => {
     const block = document.querySelector('.video.autoplay1.viewportplay.ended');
-    const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
     const nextFrame = () => new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -199,7 +183,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with viewportplay only with autoplay1', async () => {
     const block = document.querySelector('.video.autoplay1.viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -210,7 +193,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay with autoplay1 hoverplay', async () => {
     const block = document.querySelector('.video.autoplay1.hoverplay.no-viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -221,7 +203,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay with hoverplay', async () => {
     const block = document.querySelector('.video.hoverplay.no-viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -232,7 +213,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay no autoplay', async () => {
     const block = document.querySelector('.video.no-autoplay.no-viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -243,7 +223,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay no autoplay1', async () => {
     const block = document.querySelector('.video.no-autoplay1.no-viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);

--- a/test/blocks/video/video.test.js
+++ b/test/blocks/video/video.test.js
@@ -7,9 +7,16 @@ import { setConfig } from '../../../libs/utils/utils.js';
 
 setConfig({});
 const { default: init } = await import('../../../libs/blocks/video/video.js');
-document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
 describe('video uploaded using franklin bot', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
   it('decorates no-lazy video', async () => {
     const block = document.querySelector('.video.no-lazy');
     const a = block.querySelector('a');
@@ -104,10 +111,9 @@ describe('video uploaded using franklin bot', () => {
     expect(video.hasAttribute('data-play-viewport')).to.be.true;
   });
 
-  it.only('play video when element reached 80% viewport', async () => {
+  it('play video when element reached 80% viewport', async () => {
     const block = document.querySelector('.video.autoplay.viewportplay.scrolled-80');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
     const nextFrame = () => new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -115,33 +121,27 @@ describe('video uploaded using franklin bot', () => {
 
     init(a);
     const video = block.querySelector('video');
-    console.log(video);
-    const intersectionObserverAddsSource = () => {
-      console.log({ shild: video.firstElementChild });
-      return video.querySelector('source');
-    };
     const playSpy = sinon.spy(video, 'play');
     const pauseSpy = sinon.spy(video, 'pause');
+    const intersectionObserverAddsSource = () => video.querySelector('source');
     await waitFor(intersectionObserverAddsSource);
-    const source = video.querySelector('source');
-    source.setAttribute('src', 'https://www.adobe.com/creativecloud/media_1167374e3354ef57f126fa78a55cbc1708ac4babd.mp4');
-    source.setAttribute('type', 'video/mp4');
-
     video.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
-    console.log('grr');
     assert.isTrue(playSpy.calledOnce);
-    console.log('grr-1');
-    document.body.scrollIntoView();
+
+    // push the video out of the viewport
+    const div = document.createElement('div');
+    div.style.height = '2000px';
+    video.parentNode.insertBefore(div, video);
+
     await nextFrame();
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
     assert.isTrue(pauseSpy.calledOnce);
-
     expect(video.hasAttribute('data-play-viewport')).to.be.true;
   });
 
@@ -156,15 +156,13 @@ describe('video uploaded using franklin bot', () => {
 
     init(a);
     const video = block.querySelector('video');
-    const source = video.querySelector('source');
-    source.setAttribute('src', 'https://www.adobe.com/creativecloud/media_1167374e3354ef57f126fa78a55cbc1708ac4babd.mp4');
-    source.setAttribute('type', 'video/mp4');
-
     const playSpy = sinon.spy(video, 'play');
     const pauseSpy = sinon.spy(video, 'pause');
     const endedSpy = sinon.spy();
-    video.addEventListener('ended', endedSpy);
+    const intersectionObserverAddsSource = () => video.querySelector('source');
+    await waitFor(intersectionObserverAddsSource);
 
+    video.addEventListener('ended', endedSpy);
     video.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {
@@ -172,13 +170,16 @@ describe('video uploaded using franklin bot', () => {
     });
     assert.isTrue(playSpy.calledOnce);
 
-    document.body.scrollIntoView();
+    // push the video out of the viewport
+    const div = document.createElement('div');
+    div.style.height = '2000px';
+    video.parentNode.insertBefore(div, video);
+
     await nextFrame();
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
     assert.isTrue(pauseSpy.calledOnce);
-
     video.dispatchEvent(new Event('ended'));
     await nextFrame();
     await new Promise((resolve) => {

--- a/test/blocks/video/video.test.js
+++ b/test/blocks/video/video.test.js
@@ -133,6 +133,7 @@ describe('video uploaded using franklin bot', () => {
 
   it('Don\'t play the video once it end when autoplay1 enabled', async () => {
     const block = document.querySelector('.video.autoplay1.viewportplay.ended');
+    const a = block.querySelector('a');
     block.append(a);
     const nextFrame = () => new Promise((resolve) => {
       requestAnimationFrame(resolve);

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -101,5 +101,5 @@ export default {
     </html>`,
   // Comment in the files for selectively running test suites
   // npm run test:file:watch allows to you to run single test file & view the result in a browser.
-  files: ['**/video.test.js'],
+  // files: ['**/utils.test.js'],
 };

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -101,5 +101,5 @@ export default {
     </html>`,
   // Comment in the files for selectively running test suites
   // npm run test:file:watch allows to you to run single test file & view the result in a browser.
-  // files: ['**/utils.test.js'],
+  files: ['**/video.test.js'],
 };


### PR DESCRIPTION
### Description
Fixes 0.2 marquee CLS (+10LH points) for videos. The CLS was caused by only adding the video element & source to the page AFTER text has already been rendered next to it, as the intersection observer can only render things in the event cycle. We now only add the source of a video within the scope of the intersection observer, to keep the benefits of not loading videos that aren't displayed, however also dont cause any CLS.


### Test instructions
Few related PRs/features that should still work afterwards...
- https://github.com/adobecom/milo/pull/1106
- https://github.com/adobecom/milo/pull/2487
- https://github.com/adobecom/milo/pull/1343
And the CLS should be gone. 

Resolves: [MWPW-155412](https://jira.corp.adobe.com/browse/MWPW-155412)

**Test URLs:**
Onhover play
- Before: https://main--milo--mokimo.hlx.page/drafts/ruchika/videoplay-onhover?martech=off
- After: https://cls-marquee--milo--mokimo.hlx.page/drafts/ruchika/videoplay-onhover?martech=off

Onviewport play
- Before: https://main--milo--mokimo.hlx.page/drafts/siva/products/videoplay-onviewport?martech=off
- After: https://cls-marquee--milo--mokimo.hlx.page/drafts/siva/products/videoplay-onviewport?martech=off

Only desktop (mobile should not load the video for perf reasons)
- Before: https://main--milo--mokimo.hlx.page/drafts/seanchoi/marquee-video?martech=off
- After: https://cls-marquee--milo--mokimo.hlx.page/drafts/seanchoi/marquee-video?martech=off

CLS
- Before: https://main--milo--adobecom.aem.page/drafts/osahin/magento-commerce-1
- After: https://cls-marquee--milo--mokimo.aem.page/drafts/osahin/magento-commerce-1