### PR TITLE
MWPW-154209 - [hero-marquee] bugs

### DIFF
--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -62,24 +62,6 @@
   justify-content: center;
 }
 
-/* Lockup Area */
-.hero-marquee .lockup-area { 
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  margin: 0 0 var(--spacing-xxs); 
-  font-size: var(--type-body-m-size);
-  line-height: var(--type-body-m-lh);
-  text-transform: initial;
-  white-space: nowrap;
-} 
-
-.hero-marquee .lockup-area picture { 
-  line-height: 0;
-  display: block;
-}
-
 .hero-marquee .lockup-area a,
 .hero-marquee .lockup-area a:hover {
   color: inherit;
@@ -102,45 +84,6 @@
   display: block;
 }
 
-/* Lockup Area sizes - default large */
-.hero-marquee .lockup-area picture img,
-.hero-marquee .l-icon .lockup-area,
-.hero-marquee.l-icon .lockup-area {
-  font-size: var(--type-body-m-size);
-  line-height: var(--type-body-m-lh);
-}
-
-.hero-marquee .lockup-area picture img,
-.hero-marquee .l-icon .lockup-area picture img,
-.hero-marquee.l-icon .lockup-area picture img {
-  min-width: var(--icon-size-l);
-  height: var(--icon-size-l);
-}
-
-.hero-marquee .m-icon .lockup-area,
-.hero-marquee.m-icon .lockup-area {
-  font-size: var(--type-body-s-size);
-  line-height: var(--type-body-s-lh);
-}
-
-.hero-marquee .m-icon .lockup-area picture img, 
-.hero-marquee.m-icon .lockup-area picture img {
-  min-width: var(--icon-size-m);
-  height: var(--icon-size-m);
-}
-
-.hero-marquee .xl-icon .lockup-area,
-.hero-marquee.xl-icon .lockup-area {
-  font-size: var(--type-body-xl-size);
-  line-height: var(--type-body-xl-lh);
-}
-
-.hero-marquee .xl-icon .lockup-area picture img,
-.hero-marquee.xl-icon .lockup-area picture img {
-  min-width: var(--icon-size-xl);
-  height: var(--icon-size-xl);
-}
-
 .hero-marquee.center {
   text-align: center;
   align-items: center;
@@ -158,7 +101,6 @@
 .hero-marquee .main-copy [class^="heading"],
 .hero-marquee .norm p:only-child { margin: 0; }
 .hero-marquee .norm :is(h1, h2, h3, h4, h5, h6) { margin: 0 0 var(--spacing-xs) 0; }
-.hero-marquee .norm .action-area { margin-top: var(--spacing-s); }
 .hero-marquee .norm div > *:last-child { margin-bottom: 0; }
 .hero-marquee .norm div *:first-child { margin-top: 0; }
 
@@ -322,8 +264,10 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   }
 
   /* con-vars support */
-  .hero-marquee:is(.bg-top-mobile, .bg-top-mobile, .bg-bottom-mobile) .background {
+  .hero-marquee:is(.bg-top-mobile, .bg-bottom-mobile, .bg-top-tablet, .bg-bottom-tablet) .background,
+  .hero-marquee:is(.bg-top-mobile, .bg-bottom-mobile, .bg-top-tablet, .bg-bottom-tablet) .background video {
       position: relative;
+      width: 100%;
   }
 
   .hero-marquee.bg-top-mobile  {
@@ -375,9 +319,10 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   }
 
   /* con-vars support */
-  .hero-marquee.bg-top-tablet .background,
-  .hero-marquee.bg-bottom-tablet .background {
+  .hero-marquee:is(.bg-top-tablet, .bg-bottom-tablet) .background,
+  .hero-marquee:is(.bg-top-tablet, .bg-bottom-tablet) .background video {
     position: relative;
+    width: 100%;
   }
 
   .hero-marquee.bg-top-tablet {

--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -358,7 +358,8 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
     justify-content: center;
   }
 
-  .hero-marquee.bg-top-tablet {
+  .hero-marquee.bg-top-tablet,
+  .hero-marquee.bg-bottom-tablet {
     flex-direction: column;
   }
 

--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -328,6 +328,10 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   .hero-marquee.bg-top-tablet {
     padding-top: 0;
   }
+  
+  .hero-marquee.bg-bottom-tablet {
+    padding-bottom: 0;
+  }
 
   .hero-marquee.bg-bottom-tablet .background {
     order: 2;

--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -62,6 +62,10 @@
   justify-content: center;
 }
 
+.hero-marquee .row-lockup .lockup-area {
+  margin: 0;
+}
+
 .hero-marquee .lockup-area a,
 .hero-marquee .lockup-area a:hover {
   color: inherit;

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -63,7 +63,7 @@ async function decorateLockupFromContent(el) {
   await loadIconography();
   rows[0].classList.add('lockup-area');
   rows[0].childNodes.forEach((node) => {
-    if (node.nodeType === 3 && node.nodeValue !== ' ') {
+    if (node.nodeType === 3 && node.nodeValue?.trim()) {
       const newSpan = createTag('span', { class: 'lockup-label' }, node.nodeValue);
       node.parentElement.replaceChild(newSpan, node);
     }

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -72,6 +72,7 @@ async function decorateLockupFromContent(el) {
 
 function decorateLockupRow(el, classes) {
   const child = el.querySelector(':scope > div');
+  loadIconography();
   child?.classList.add('lockup-area');
   const iconSizeClass = classes?.find((c) => c.endsWith('-icon'));
   if (iconSizeClass) el.classList.remove(iconSizeClass);

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -85,6 +85,12 @@ function decorateBg(el) {
   el.remove();
 }
 
+function wrapInnerHTMLInPTag(el) {
+  const innerDiv = el.querySelector(':scope > div');
+  const containsPTag = [...innerDiv.childNodes].some((node) => node.nodeName === 'P');
+  if (!containsPTag) innerDiv.innerHTML = `<p>${innerDiv.innerHTML}</p>`;
+}
+
 function decorateText(el, classes) {
   el.classList.add('norm');
   const btnClass = classes?.find((c) => c.endsWith('-button'));
@@ -95,6 +101,7 @@ function decorateText(el, classes) {
   } else {
     decorateButtons(el, 'button-xl');
   }
+  wrapInnerHTMLInPTag(el);
   decorateBlockText(el, textDefault);
   decorateTextOverrides(el, ['-heading', '-body', '-detail']);
 }

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -70,9 +70,9 @@ async function decorateLockupFromContent(el) {
   });
 }
 
-function decorateLockupRow(el, classes) {
+async function decorateLockupRow(el, classes) {
   const child = el.querySelector(':scope > div');
-  loadIconography();
+  await loadIconography();
   child?.classList.add('lockup-area');
   const iconSizeClass = classes?.find((c) => c.endsWith('-icon'));
   if (iconSizeClass) el.classList.remove(iconSizeClass);

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -93,6 +93,7 @@ function wrapInnerHTMLInPTag(el) {
 
 function decorateText(el, classes) {
   el.classList.add('norm');
+  wrapInnerHTMLInPTag(el);
   const btnClass = classes?.find((c) => c.endsWith('-button'));
   if (btnClass) {
     const [theme, size] = btnClass.split('-').reverse();
@@ -101,7 +102,6 @@ function decorateText(el, classes) {
   } else {
     decorateButtons(el, 'button-xl');
   }
-  wrapInnerHTMLInPTag(el);
   decorateBlockText(el, textDefault);
   decorateTextOverrides(el, ['-heading', '-body', '-detail']);
 }

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -72,7 +72,7 @@ async function decorateLockupFromContent(el) {
 
 function decorateLockupRow(el, classes) {
   const child = el.querySelector(':scope > div');
-  if (child) child.classList.add('lockup-area');
+  child?.classList.add('lockup-area');
   const iconSizeClass = classes?.find((c) => c.endsWith('-icon'));
   if (iconSizeClass) el.classList.remove(iconSizeClass);
   const lockupSize = iconSizeClass ? `${iconSizeClass.split('-')[0]}-lockup` : 'l-lockup';
@@ -88,7 +88,11 @@ function decorateBg(el) {
 function wrapInnerHTMLInPTag(el) {
   const innerDiv = el.querySelector(':scope > div');
   const containsPTag = [...innerDiv.childNodes].some((node) => node.nodeName === 'P');
-  if (!containsPTag) innerDiv.innerHTML = `<p>${innerDiv.innerHTML}</p>`;
+  if (!containsPTag) {
+    const pTag = createTag('p');
+    while (innerDiv.firstChild) pTag.appendChild(innerDiv.firstChild);
+    innerDiv.appendChild(pTag);
+  }
 }
 
 function decorateText(el, classes) {

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -76,8 +76,7 @@ function decorateLockupRow(el, classes) {
   child?.classList.add('lockup-area');
   const iconSizeClass = classes?.find((c) => c.endsWith('-icon'));
   if (iconSizeClass) el.classList.remove(iconSizeClass);
-  const lockupSize = iconSizeClass ? `${iconSizeClass.split('-')[0]}-lockup` : 'l-lockup';
-  el.classList.add(lockupSize);
+  el.classList.add(`${iconSizeClass?.split('-')[0] || 'l'}-lockup`);
 }
 
 function decorateBg(el) {


### PR DESCRIPTION
Fixed some bugs in the `hero-marquee` that were found in GPW user testing. These changes address the following. 

1) Row type and button variants on con-block rows should style the elements. They are not. ex `con-block-row-text (s-body, xl-button, xxxl-heading)`
2) `:icons:` in the main content area not rendering.
3) Update lockup styles from incoming globals.
4) When background image is smaller than 1199px, the image should be forced to display at 100% in tablet view.
5) When CTA is the ONLY element placed in "con block row text," margin top should be removed.
6) Video elements not displaying for mobile or tablet when authored w/ bg-bottom-mobile, bg-top-tablet variants. 


Resolves: [MWPW-154209](https://jira.corp.adobe.com/browse/MWPW-154209)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/hero/hero-bugs?martech=off
- After: https://rparrish-hero-bugz--milo--adobecom.hlx.page/drafts/rparrish/hero/hero-bugs?martech=off

**Prod URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/hero-marquee?martech=off
- After: https://rparrish-hero-bugz--milo--adobecom.hlx.page/docs/library/blocks/hero-marquee?martech=off
- Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/hero-marquee?martech=off
- After: https://rparrish-hero-bugz--milo--adobecom.hlx.page/docs/library/kitchen-sink/hero-marquee?martech=off
