### PR TITLE
MWPW-156447: NVDA not announced check mark on the Product Page

### DIFF
--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -70,5 +70,7 @@ export default async function loadIcons(icons, config) {
       }
     }
     icon.insertAdjacentHTML('afterbegin', iconSVGs[iconName].outerHTML);
+    const svgTag = icon.querySelector('svg');
+    svgTag.setAttribute('aria-label', iconName.replaceAll('-', ' '));
   });
 }


### PR DESCRIPTION
* Added an `aria-label` attribute to make SVG icons more accessible

Resolves: [MWPW-156447](https://jira.corp.adobe.com/browse/MWPW-156447)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/siva/156447/icons-example?martech=off
- After: https://mwpw-156447--milo--sivasadobe.hlx.page/drafts/siva/156447/icons-example?martech=off 
