### PR TITLE
MWPW-151456: Demo page accordion & hover state bug fixes

### DIFF
--- a/libs/blocks/accordion/accordion.css
+++ b/libs/blocks/accordion/accordion.css
@@ -30,7 +30,7 @@ dl.accordion {
   font-size: var(--type-detail-l-size);
   font-weight: 700;
   line-height: var(--type-title-lh);
-  padding: var(--spacing-l) var(--spacing-xxxl) var(--spacing-l) var(--spacing-l);
+  padding: var(--s2-spacing-600) var(--spacing-xxxl) var(--s2-spacing-600) var(--s2-spacing-600);
   position: relative;
   text-align: start;
   width: 100%;
@@ -103,7 +103,6 @@ html[dir="rtl"] .accordion-icon {
   background: var(--color-white);
 }
 
-.accordion dt button:focus,
 .accordion dt button:hover,
 .accordion dt button[aria-expanded="true"] {
   background: var(--color-black);

--- a/libs/blocks/region-nav/region-nav.css
+++ b/libs/blocks/region-nav/region-nav.css
@@ -9,6 +9,10 @@
   font-weight: var(--s2-regular-font-weight);
 }
 
+.region-nav a:hover {
+  text-decoration: underline;
+}
+
 .region-nav > div:nth-of-type(2) > div > p {
   font-size: 16px;
   margin-bottom: 0;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

This PR fixes accordion and hover state bugs found in an initial round of QA of the demo page

- Fixes accordion active state issue
> RE: When I click on the accordion btn, it expands then I click again, it contracts and remains black. I have to click somewhere else to have the btn gray again. Clicking on another accordion btn doesn’t make previous btn gray.

- Fixes accordion height to align with padding in mockup
- Fixes region links hover state


Accordion before:

https://github.com/user-attachments/assets/c0b0155c-ab3b-4903-9a10-36e038b369de



Accordion after:


https://github.com/user-attachments/assets/4e5c9f64-9246-4a97-ab14-fdccf9e426f2




Resolves: [MWPW-151456](https://jira.corp.adobe.com/browse/MWPW-151456)

**Test URLs:**
- Before: https://spectrum-narrative--milo--adobecom.hlx.page/drafts/ramuntea/spectrum-showcase
- After: https://saasha-bug-fixes-accordion--milo--adobecom.hlx.page/drafts/ramuntea/spectrum-showcase

**Prod URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ramuntea/spectrum-showcase

