### PR TITLE
Making unav configurable for consuming client

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -519,7 +519,7 @@ class Gnav {
       return 'linux';
     };
 
-    const unavVersion = new URLSearchParams(window.location.search).get('unavVersion') || '1.1';
+    const unavVersion = new URLSearchParams(window.location.search).get('unavVersion') || config.unavVersion || '1.1';
     await Promise.all([
       loadScript(`https://${environment}.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js`),
       loadStyles(`https://${environment}.adobeccstatic.com/unav/${unavVersion}/UniversalNav.css`),

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -55,6 +55,7 @@ export default async function loadBlock(configs, customLib) {
     pathname: `/${locale}`,
     locales: configs.locales || locales,
     contentRoot: authoringPath || footer.authoringPath,
+    unavVersion: header?.unavVersion,
     ...paramConfigs,
   };
   setConfig(clientConfig);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Making unav version configurable for consuming client's config

Resolves: [MWPW-156207](https://jira.corp.adobe.com/browse/MWPW-156207)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://gnav--milo--adobecom.hlx.page/?martech=off

**QA**:
- https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=gnav&unav-version=1.2
