### PR TITLE
[MWPW-156638] Table row header items wrap

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -35,6 +35,10 @@
   background-color: var(--color-white);
 }
 
+.table .col.section-row-title {
+  flex-wrap: nowrap;
+}
+
 .table .section-row .col {
   align-items: center;
 }


### PR DESCRIPTION
This ensures the row heading content wraps correctly when there is a long label along with a tooltip.

| Before | After |
| ------------- | ------------- |
| <img width="619" alt="Screenshot 2024-08-14 at 17 42 15" src="https://github.com/user-attachments/assets/e7df026a-97b0-4f0a-b1d6-bce4c02db29f"> | <img width="619" alt="Screenshot 2024-08-14 at 17 41 49" src="https://github.com/user-attachments/assets/cdf90990-76cd-494a-b1b8-1134fac9659f"> |

Resolves: [MWPW-156638](https://jira.corp.adobe.com/browse/MWPW-156638)

**Test URLs:**
- Before: https://table-review--milo--overmyheadandbody.hlx.page/docs/library/kitchen-sink/table?martech=off
- After: https://table-section-row-wrap--milo--overmyheadandbody.hlx.page/docs/library/kitchen-sink/table?martech=off
