### PR TITLE
Revert "MWPW-155412: Fix video CLS netting +10 lighthouse points"

### DIFF
--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -1,16 +1,22 @@
-import { turnAnchorIntoVideo } from '../../utils/decorate.js';
+import { createIntersectionObserver } from '../../utils/utils.js';
+import { applyHoverPlay, getVideoAttrs } from '../../utils/decorate.js';
 
-export default function init(a) {
-  a.classList.add('hide-video');
+const ROOT_MARGIN = 1000;
+
+const loadAdobeTv = (a) => {
   const bgBlocks = ['aside', 'marquee', 'hero-marquee'];
   if (a.href.includes('.mp4') && bgBlocks.some((b) => a.closest(`.${b}`))) {
     a.classList.add('hide');
+    const { href, hash, dataset } = a;
+    const attrs = getVideoAttrs(hash || 'autoplay', dataset);
+    const video = `<video ${attrs}>
+          <source src="${href}" type="video/mp4" />
+        </video>`;
     if (!a.parentNode) return;
-    turnAnchorIntoVideo({
-      hash: a.hash || 'autoplay',
-      src: a.href,
-      anchorTag: a,
-    });
+    a.insertAdjacentHTML('afterend', video);
+    const videoElem = document.body.querySelector(`source[src="${href}"]`)?.parentElement;
+    applyHoverPlay(videoElem);
+    a.remove();
   } else {
     const embed = `<div class="milo-video">
       <iframe src="${a.href}" class="adobetv" webkitallowfullscreen mozallowfullscreen allowfullscreen scrolling="no" allow="encrypted-media" title="Adobe Video Publishing Cloud Player" loading="lazy">
@@ -18,5 +24,18 @@ export default function init(a) {
     </div>`;
     a.insertAdjacentHTML('afterend', embed);
     a.remove();
+  }
+};
+
+export default function init(a) {
+  a.classList.add('hide-video');
+  if (a.textContent.includes('no-lazy')) {
+    loadAdobeTv(a);
+  } else {
+    createIntersectionObserver({
+      el: a,
+      options: { rootMargin: `${ROOT_MARGIN}px` },
+      callback: loadAdobeTv,
+    });
   }
 }

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -1,10 +1,10 @@
-import { getConfig } from '../../utils/utils.js';
-import { turnAnchorIntoVideo } from '../../utils/decorate.js';
+import { createIntersectionObserver, getConfig } from '../../utils/utils.js';
+import { applyHoverPlay, getVideoAttrs, applyInViewPortPlay } from '../../utils/decorate.js';
 
-export default function init(a) {
-  a.classList.add('hide-video');
-  if (!a.parentNode) return;
-  const { pathname } = a;
+const ROOT_MARGIN = 1000;
+
+const loadVideo = (a) => {
+  const { pathname, hash, dataset } = a;
   let videoPath = `.${pathname}`;
   if (pathname.match('media_.*.mp4')) {
     const { codeRoot } = getConfig();
@@ -14,9 +14,28 @@ export default function init(a) {
     const mediaFilename = pathname.split('/').pop();
     videoPath = `${root}${mediaFilename}`;
   }
-  turnAnchorIntoVideo({
-    hash: a.hash,
-    src: videoPath,
-    anchorTag: a,
-  });
+
+  const attrs = getVideoAttrs(hash, dataset);
+  const video = `<video ${attrs}>
+        <source src="${videoPath}" type="video/mp4" />
+      </video>`;
+  if (!a.parentNode) return;
+  a.insertAdjacentHTML('afterend', video);
+  const videoElem = document.body.querySelector(`source[src="${videoPath}"]`)?.parentElement;
+  applyHoverPlay(videoElem);
+  applyInViewPortPlay(videoElem);
+  a.remove();
+};
+
+export default function init(a) {
+  a.classList.add('hide-video');
+  if (a.textContent.includes('no-lazy')) {
+    loadVideo(a);
+  } else {
+    createIntersectionObserver({
+      el: a,
+      options: { rootMargin: `${ROOT_MARGIN}px` },
+      callback: loadVideo,
+    });
+  }
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -1,4 +1,4 @@
-import { createTag, createIntersectionObserver } from './utils.js';
+import { createTag } from './utils.js';
 
 export function decorateButtons(el, size) {
   const buttons = el.querySelectorAll('em a, strong a, p > a strong');
@@ -229,7 +229,7 @@ export function handleObjectFit(bgRow) {
   });
 }
 
-function getVideoIntersectionObserver() {
+export function getVideoIntersectionObserver() {
   if (!window?.videoIntersectionObs) {
     window.videoIntersectionObs = new window.IntersectionObserver((entries) => {
       entries.forEach((entry) => {
@@ -250,7 +250,7 @@ function getVideoIntersectionObserver() {
   return window.videoIntersectionObs;
 }
 
-function applyInViewPortPlay(video) {
+export function applyInViewPortPlay(video) {
   if (!video) return;
   if (video.hasAttribute('data-play-viewport')) {
     const observer = getVideoIntersectionObserver();
@@ -259,22 +259,4 @@ function applyInViewPortPlay(video) {
     });
     observer.observe(video);
   }
-}
-
-export function turnAnchorIntoVideo({ hash, src, anchorTag }) {
-  const { dataset, parentElement } = anchorTag;
-  const attrs = getVideoAttrs(hash, dataset);
-  const video = `<video ${attrs}></video>`;
-  anchorTag.insertAdjacentHTML('afterend', video);
-  const videoEl = parentElement.querySelector('video');
-  createIntersectionObserver({
-    el: parentElement,
-    options: { rootMargin: '1000px' },
-    callback: () => {
-      videoEl?.appendChild(createTag('source', { src, type: 'video/mp4' }));
-    },
-  });
-  applyHoverPlay(videoEl);
-  applyInViewPortPlay(videoEl);
-  anchorTag.remove();
 }

--- a/test/blocks/adobetv/adobetv.test.js
+++ b/test/blocks/adobetv/adobetv.test.js
@@ -6,6 +6,17 @@ document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 const { default: init } = await import('../../../libs/blocks/adobetv/adobetv.js');
 
 describe('adobetv autoblock', () => {
+  it('decorates no-lazy video', async () => {
+    const block = document.querySelector('.video.no-lazy');
+    const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
+    block.append(a);
+
+    init(a);
+    const video = await waitForElement('.video.no-lazy iframe');
+    expect(video).to.exist;
+  });
+
   it('creates video block', async () => {
     const wrapper = document.body.querySelector('.adobe-tv');
     const a = wrapper.querySelector(':scope > a');

--- a/test/blocks/adobetv/mocks/body.html
+++ b/test/blocks/adobetv/mocks/body.html
@@ -1,5 +1,5 @@
 <main>
-  <div class="video">
+  <div class="video no-lazy">
     <a href="https://video.tv.adobe.com/v/3410934t1">
       https://video.tv.adobe.com/v/3410934t1
     </a>

--- a/test/blocks/marquee/marquee.test.js
+++ b/test/blocks/marquee/marquee.test.js
@@ -1,8 +1,8 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { waitFor, waitForElement } from '../../helpers/waitfor.js';
-import { setConfig, loadStyle } from '../../../libs/utils/utils.js';
+import { waitForElement } from '../../helpers/waitfor.js';
+import { setConfig } from '../../../libs/utils/utils.js';
 import { loadMnemonicList } from '../../../libs/blocks/marquee/marquee.js';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
@@ -16,15 +16,6 @@ const video = await readFile({ path: './mocks/video.html' });
 const multipleIcons = await readFile({ path: './mocks/multiple-icons.html' });
 
 describe('marquee', () => {
-  before(async () => {
-    await new Promise((resolve) => {
-      loadStyle('../../../../libs/styles/styles.css', resolve);
-    });
-    await new Promise((resolve) => {
-      loadStyle('../../../../libs/blocks/marquee/marquee.css', resolve);
-    });
-  });
-
   const marquees = document.querySelectorAll('.marquee');
   marquees.forEach((marquee) => {
     init(marquee);
@@ -78,9 +69,7 @@ describe('marquee', () => {
       init(marquee);
       videoBLock(document.querySelector('#single-background a[href*=".mp4"]'));
       const videoEl = await waitForElement('#single-background .background video');
-      const intersectionObserverAddsSource = () => videoEl.querySelector('source');
-      await waitFor(intersectionObserverAddsSource);
-      expect(videoEl.querySelector('source')).to.exist;
+      expect(videoEl).to.exist;
       document.getElementById('single-background').remove();
     });
 
@@ -89,9 +78,7 @@ describe('marquee', () => {
       init(marquee);
       document.querySelectorAll('#multiple-background a[href*=".mp4"]').forEach((videoLink) => videoBLock(videoLink));
       await waitForElement('#multiple-background .background video');
-      const intersectionObserverAddsSource = () => document.querySelector('.background video source');
-      await waitFor(intersectionObserverAddsSource);
-      expect(marquee.querySelectorAll('.background video source').length).to.equal(1);
+      expect(marquee.querySelectorAll('.background video').length).to.equal(1);
       document.getElementById('multiple-background').remove();
     });
 

--- a/test/blocks/video/mocks/body.html
+++ b/test/blocks/video/mocks/body.html
@@ -4,7 +4,7 @@
   }
 </style>
 <main>
-  <div class="video">
+  <div class="video no-lazy">
     <a href="https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4">
       https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4
     </a>

--- a/test/blocks/video/video.test.js
+++ b/test/blocks/video/video.test.js
@@ -1,20 +1,25 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect, assert } from '@esm-bundle/chai';
-import sinon from 'sinon';
-import { waitFor, waitForElement } from '../../helpers/waitfor.js';
 
+import sinon from 'sinon';
+
+import { waitForElement } from '../../helpers/waitfor.js';
 import { setConfig } from '../../../libs/utils/utils.js';
 
 setConfig({});
 const { default: init } = await import('../../../libs/blocks/video/video.js');
+document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
 describe('video uploaded using franklin bot', () => {
-  beforeEach(async () => {
-    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
-  });
+  it('decorates no-lazy video', async () => {
+    const block = document.querySelector('.video.no-lazy');
+    const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
+    block.append(a);
 
-  afterEach(() => {
-    document.body.innerHTML = '';
+    init(a);
+    const video = await waitForElement('.video.no-lazy video');
+    expect(video).to.exist;
   });
 
   it('decorates video', async () => {
@@ -69,6 +74,7 @@ describe('video uploaded using franklin bot', () => {
   it('no hoverplay attribute added when with autoplay on loop', async () => {
     const block = document.querySelector('.video.autoplay.playonhover');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -80,6 +86,7 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with hoverplay when only hoverplay is added to url', async () => {
     const block = document.querySelector('.video.hoveronly');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -90,6 +97,7 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with viewportplay only with autoplay', async () => {
     const block = document.querySelector('.video.autoplay.viewportplay');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -100,6 +108,7 @@ describe('video uploaded using franklin bot', () => {
   it('play video when element reached 80% viewport', async () => {
     const block = document.querySelector('.video.autoplay.viewportplay.scrolled-80');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
     const nextFrame = () => new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -107,10 +116,13 @@ describe('video uploaded using franklin bot', () => {
 
     init(a);
     const video = block.querySelector('video');
+    const source = video.querySelector('source');
+    source.setAttribute('src', 'https://www.adobe.com/creativecloud/media_1167374e3354ef57f126fa78a55cbc1708ac4babd.mp4');
+    source.setAttribute('type', 'video/mp4');
+
     const playSpy = sinon.spy(video, 'play');
     const pauseSpy = sinon.spy(video, 'pause');
-    const intersectionObserverAddsSource = () => video.querySelector('source');
-    await waitFor(intersectionObserverAddsSource);
+
     video.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {
@@ -118,22 +130,20 @@ describe('video uploaded using franklin bot', () => {
     });
     assert.isTrue(playSpy.calledOnce);
 
-    // push the video out of the viewport
-    const div = document.createElement('div');
-    div.style.height = '2000px';
-    video.parentNode.insertBefore(div, video);
-
+    document.body.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
     assert.isTrue(pauseSpy.calledOnce);
+
     expect(video.hasAttribute('data-play-viewport')).to.be.true;
   });
 
   it('Don\'t play the video once it end when autoplay1 enabled', async () => {
     const block = document.querySelector('.video.autoplay1.viewportplay.ended');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
     const nextFrame = () => new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -141,13 +151,15 @@ describe('video uploaded using franklin bot', () => {
 
     init(a);
     const video = block.querySelector('video');
+    const source = video.querySelector('source');
+    source.setAttribute('src', 'https://www.adobe.com/creativecloud/media_1167374e3354ef57f126fa78a55cbc1708ac4babd.mp4');
+    source.setAttribute('type', 'video/mp4');
+
     const playSpy = sinon.spy(video, 'play');
     const pauseSpy = sinon.spy(video, 'pause');
     const endedSpy = sinon.spy();
-    const intersectionObserverAddsSource = () => video.querySelector('source');
-    await waitFor(intersectionObserverAddsSource);
-
     video.addEventListener('ended', endedSpy);
+
     video.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {
@@ -155,16 +167,13 @@ describe('video uploaded using franklin bot', () => {
     });
     assert.isTrue(playSpy.calledOnce);
 
-    // push the video out of the viewport
-    const div = document.createElement('div');
-    div.style.height = '2000px';
-    video.parentNode.insertBefore(div, video);
-
+    document.body.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
     assert.isTrue(pauseSpy.calledOnce);
+
     video.dispatchEvent(new Event('ended'));
     await nextFrame();
     await new Promise((resolve) => {
@@ -184,6 +193,7 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with viewportplay only with autoplay1', async () => {
     const block = document.querySelector('.video.autoplay1.viewportplay');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -194,6 +204,7 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay with autoplay1 hoverplay', async () => {
     const block = document.querySelector('.video.autoplay1.hoverplay.no-viewportplay');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -204,6 +215,7 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay with hoverplay', async () => {
     const block = document.querySelector('.video.hoverplay.no-viewportplay');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -214,6 +226,7 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay no autoplay', async () => {
     const block = document.querySelector('.video.no-autoplay.no-viewportplay');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -224,6 +237,7 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay no autoplay1', async () => {
     const block = document.querySelector('.video.no-autoplay1.no-viewportplay');
     const a = block.querySelector('a');
+    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);


### PR DESCRIPTION
Reverts adobecom/milo#2724 due to issues on https://business.stage.adobe.com/products/real-time-customer-data-platform/rtcdp.html?milolibs=stage

- https://revert-2724-cls-marquee--milo--adobecom.hlx.page/

Bacom tests
- Before: https://stage--bacom--adobecom.hlx.live/products/real-time-customer-data-platform/rtcdp?milolibs=stage
- After: https://stage--bacom--adobecom.hlx.live/products/real-time-customer-data-platform/rtcdp?milolibs=revert-2724-cls-marquee