### PR TITLE
[MWPW-156746] Use correct paths for lint:css script

### DIFF
--- a/.github/workflows/label-zero-impact.js
+++ b/.github/workflows/label-zero-impact.js
@@ -12,6 +12,7 @@ const zeroImpactDirs = [
   'LICENSE',
   'codecov.yaml',
   '.gitignore',
+  'package.json',
   'package-lock.json',
 ];
 const zeroImpactLabel = 'zero-impact';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "npm run lint:js && npm run lint:css",
     "lint:js": "eslint .",
     "lint:js:nibble": "eslint-nibble .",
-    "lint:css": "stylelint 'blocks/**/*.css' 'styles/*.css'",
+    "lint:css": "stylelint 'libs/blocks/**/*.css' 'libs/styles/*.css'",
     "build:htm-preact": "microbundle ./build/htm-preact.js -o ./libs/deps/htm-preact.js -f modern --no-sourcemap --target web; mv ./libs/deps/htm-preact.modern.mjs ./libs/deps/htm-preact.js",
     "build:preact-debug": "microbundle ./build/htm-preact-debug.js -o ./libs/deps/htm-preact-debug.js -f modern --no-sourcemap --target web; mv ./libs/deps/htm-preact-debug.modern.mjs ./libs/deps/htm-preact-debug.js",
     "build:gnav-profile": "microbundle ./libs/blocks/global-navigation/blocks/profile/profile-wrapper.js -o ./build/profile-wrapper-build.js -f umd --external none --no-sourcemap --target web; mv ./build/profile-wrapper-build.umd.js ./build/profile.js"


### PR DESCRIPTION
Fixes the paths in the `lint:css` script and adds `package.json` to the files that are considered for the `zero-impact` label, as discussed in a [previous PR](https://github.com/adobecom/milo/pull/2728#issuecomment-2286008339). Originally noticed by @chrischrischris.

Resolves: [MWPW-156746](https://jira.corp.adobe.com/browse/MWPW-156746)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/?martech=off
- After: https://update-css-lint-command--milo--overmyheadandbody.hlx.page/?martech=off
