### PR TITLE
Prevent a line break before 'ー U+2013', '〜 U+301C', and etc in Japanese

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -127,7 +127,7 @@
   --icon-size-s: 32px;
   --icon-size-xs: 24px;
   --icon-size-xxs: 16px;
-  
+
   /* z-index */
   --above-all: 9000; /* Used for page tools that overlay page content */
 }
@@ -763,6 +763,16 @@ h5 {
 h6 {
   font-size: var(--type-heading-xs-size);
   line-height: var(--type-heading-xs-lh);
+}
+
+h1:lang(ja),
+h2:lang(ja),
+h3:lang(ja),
+h4:lang(ja),
+h5:lang(ja),
+h6:lang(ja),
+p:lang(ja) {
+  line-break: strict;
 }
 
 /* Links */

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -765,13 +765,7 @@ h6 {
   line-height: var(--type-heading-xs-lh);
 }
 
-h1:lang(ja),
-h2:lang(ja),
-h3:lang(ja),
-h4:lang(ja),
-h5:lang(ja),
-h6:lang(ja),
-p:lang(ja) {
+:is(h1, h2, h3, h4, h5, h6, p):lang(ja) {
   line-break: strict;
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Prevent a line break before 'ー U+2013', '〜 U+301C', and etc in Japanese.

Refer from https://drafts.csswg.org/css-text-3/#line-break-property

**Before**

<image src="https://github.com/user-attachments/assets/c4e0cee3-5e59-4bf5-adf9-536cf33ea8d2" width="200px" />

**After**

<image src="https://github.com/user-attachments/assets/19c282a8-10ab-4bd3-90bb-beb74c7a040d" width="200px" />

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/jp/drafts/takyoshi/
- After: https://stage--milo--tamanyan.hlx.page/jp/drafts/takyoshi/
