### PR TITLE
MWPW-156898 [MEP] Add setting to use XLG segments in MEP while logged out

### DIFF
--- a/libs/features/personalization/entitlements.js
+++ b/libs/features/personalization/entitlements.js
@@ -30,6 +30,10 @@ const ENTITLEMENT_MAP = {
   '5c6a4bb8-a2f3-4202-8cca-f5e918b969dc': 'firefly-signup-source',
   '20106303-e88c-4b15-93e5-f6a1c3215a12': 'firefly-web-usage',
   '3df0b0b0-d06e-4fcc-986e-cc97f54d04d8': 'acrobat-web-usage',
+
+  // Express segments
+  '2a537e84-b35f-4158-8935-170c22b8ae87': 'express-entitled',
+  'eb0dcb78-3e56-4b10-89f9-51831f2cc37f': 'express-pep',
 };
 
 export const getEntitlementMap = async () => {

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -1,4 +1,6 @@
-import { getConfig, getMetadata, loadIms, loadLink, loadScript } from '../utils/utils.js';
+import {
+  getConfig, getMetadata, loadIms, loadLink, loadScript, getMepEnablement,
+} from '../utils/utils.js';
 
 const ALLOY_SEND_EVENT = 'alloy_sendEvent';
 const ALLOY_SEND_EVENT_ERROR = 'alloy_sendEvent_error';
@@ -178,11 +180,15 @@ const loadMartechFiles = async (config) => {
   if (filesLoadedPromise) return filesLoadedPromise;
 
   filesLoadedPromise = async () => {
-    loadIms()
-      .then(() => {
-        if (window.adobeIMS.isSignedInUser()) setupEntitlementCallback();
-      })
-      .catch(() => {});
+    if (getMepEnablement('xlg') === 'loggedout') {
+      setupEntitlementCallback();
+    } else {
+      loadIms()
+        .then(() => {
+          if (window.adobeIMS.isSignedInUser()) setupEntitlementCallback();
+        })
+        .catch(() => {});
+    }
 
     setDeep(
       window,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -917,6 +917,7 @@ export async function loadIms() {
     loadScript(path);
   }).then(() => {
     if (getMepEnablement('xlg') === 'loggedout') {
+      /* c8 ignore next */
       getConfig().entitlements();
     } else if (!window.adobeIMS?.isSignedInUser()) {
       getConfig().entitlements([]);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -839,76 +839,6 @@ export async function decorateFooterPromo(doc = document) {
   await initFooterPromo(footerPromoTag, footerPromoType, doc);
 }
 
-let imsLoaded;
-export async function loadIms() {
-  imsLoaded = imsLoaded || new Promise((resolve, reject) => {
-    const {
-      locale, imsClientId, imsScope, env, base, adobeid,
-    } = getConfig();
-    if (!imsClientId) {
-      reject(new Error('Missing IMS Client ID'));
-      return;
-    }
-    const [unavMeta, ahomeMeta] = [getMetadata('universal-nav')?.trim(), getMetadata('adobe-home-redirect')];
-    const defaultScope = `AdobeID,openid,gnav${unavMeta && unavMeta !== 'off' ? ',pps.read,firefly_api,additional_info.roles,read_organizations' : ''}`;
-    const timeout = setTimeout(() => reject(new Error('IMS timeout')), 5000);
-    window.adobeid = {
-      client_id: imsClientId,
-      scope: imsScope || defaultScope,
-      locale: locale?.ietf?.replace('-', '_') || 'en_US',
-      redirect_uri: ahomeMeta === 'on'
-        ? `https://www${env.name !== 'prod' ? '.stage' : ''}.adobe.com${locale.prefix}` : undefined,
-      autoValidateToken: true,
-      environment: env.ims,
-      useLocalStorage: false,
-      onReady: () => {
-        resolve();
-        clearTimeout(timeout);
-      },
-      onError: reject,
-      ...adobeid,
-    };
-    const path = PAGE_URL.searchParams.get('useAlternateImsDomain')
-      ? 'https://auth.services.adobe.com/imslib/imslib.min.js'
-      : `${base}/deps/imslib.min.js`;
-    loadScript(path);
-  }).then(() => {
-    if (!window.adobeIMS?.isSignedInUser()) {
-      getConfig().entitlements([]);
-    }
-  }).catch((e) => {
-    getConfig().entitlements([]);
-    throw e;
-  });
-
-  return imsLoaded;
-}
-
-export async function loadMartech({
-  persEnabled = false,
-  persManifests = [],
-  postLCP = false,
-} = {}) {
-  // eslint-disable-next-line no-underscore-dangle
-  if (window.marketingtech?.adobe?.launch && window._satellite) {
-    return true;
-  }
-
-  if (PAGE_URL.searchParams.get('martech') === 'off'
-    || PAGE_URL.searchParams.get('marketingtech') === 'off'
-    || getMetadata('martech') === 'off') {
-    return false;
-  }
-
-  window.targetGlobalSettings = { bodyHidingEnabled: false };
-  loadIms().catch(() => {});
-
-  const { default: initMartech } = await import('../martech/martech.js');
-  await initMartech({ persEnabled, persManifests, postLCP });
-
-  return true;
-}
-
 const getMepValue = (val) => {
   const valMap = { on: true, off: false, gnav: 'gnav' };
   const finalVal = val?.toLowerCase().trim();
@@ -952,6 +882,78 @@ export const getMepEnablement = (mdKey, paramKey = false) => {
   return getMdValue(mdKey);
 };
 
+let imsLoaded;
+export async function loadIms() {
+  imsLoaded = imsLoaded || new Promise((resolve, reject) => {
+    const {
+      locale, imsClientId, imsScope, env, base, adobeid,
+    } = getConfig();
+    if (!imsClientId) {
+      reject(new Error('Missing IMS Client ID'));
+      return;
+    }
+    const [unavMeta, ahomeMeta] = [getMetadata('universal-nav')?.trim(), getMetadata('adobe-home-redirect')];
+    const defaultScope = `AdobeID,openid,gnav${unavMeta && unavMeta !== 'off' ? ',pps.read,firefly_api,additional_info.roles,read_organizations' : ''}`;
+    const timeout = setTimeout(() => reject(new Error('IMS timeout')), 5000);
+    window.adobeid = {
+      client_id: imsClientId,
+      scope: imsScope || defaultScope,
+      locale: locale?.ietf?.replace('-', '_') || 'en_US',
+      redirect_uri: ahomeMeta === 'on'
+        ? `https://www${env.name !== 'prod' ? '.stage' : ''}.adobe.com${locale.prefix}` : undefined,
+      autoValidateToken: true,
+      environment: env.ims,
+      useLocalStorage: false,
+      onReady: () => {
+        resolve();
+        clearTimeout(timeout);
+      },
+      onError: reject,
+      ...adobeid,
+    };
+    const path = PAGE_URL.searchParams.get('useAlternateImsDomain')
+      ? 'https://auth.services.adobe.com/imslib/imslib.min.js'
+      : `${base}/deps/imslib.min.js`;
+    loadScript(path);
+  }).then(() => {
+    if (getMepEnablement('xlg') === 'loggedout') {
+      getConfig().entitlements();
+    } else if (!window.adobeIMS?.isSignedInUser()) {
+      getConfig().entitlements([]);
+    }
+  }).catch((e) => {
+    getConfig().entitlements([]);
+    throw e;
+  });
+
+  return imsLoaded;
+}
+
+export async function loadMartech({
+  persEnabled = false,
+  persManifests = [],
+  postLCP = false,
+} = {}) {
+  // eslint-disable-next-line no-underscore-dangle
+  if (window.marketingtech?.adobe?.launch && window._satellite) {
+    return true;
+  }
+
+  if (PAGE_URL.searchParams.get('martech') === 'off'
+    || PAGE_URL.searchParams.get('marketingtech') === 'off'
+    || getMetadata('martech') === 'off') {
+    return false;
+  }
+
+  window.targetGlobalSettings = { bodyHidingEnabled: false };
+  loadIms().catch(() => {});
+
+  const { default: initMartech } = await import('../martech/martech.js');
+  await initMartech({ persEnabled, persManifests, postLCP });
+
+  return true;
+}
+
 async function checkForPageMods() {
   const {
     mep: mepParam,
@@ -963,9 +965,10 @@ async function checkForPageMods() {
   const pzn = getMepEnablement('personalization');
   const promo = getMepEnablement('manifestnames', PROMO_PARAM);
   const target = martech === 'off' ? false : getMepEnablement('target');
+  const xlg = martech === 'off' ? false : getMepEnablement('xlg');
   if (!(pzn || target || promo || mepParam
-    || mepHighlight || mepButton || mepParam === '')) return;
-  if (target) {
+    || mepHighlight || mepButton || mepParam === '' || xlg)) return;
+  if (target || xlg) {
     loadMartech();
   } else if (pzn && martech !== 'off') {
     loadIms()

--- a/test/utils/mocks/mep/head-xlg.html
+++ b/test/utils/mocks/mep/head-xlg.html
@@ -1,0 +1,6 @@
+<meta name="personalization" content="https://main--milo--adobecom.hlx.page/products/special-offers-manifest.json">
+<meta name="xlg" content="loggedout">
+
+<title>Document Title</title>
+<link rel="icon" href="data:,">
++

--- a/test/utils/utils-mep.test.js
+++ b/test/utils/utils-mep.test.js
@@ -1,6 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import { getMepEnablement } from '../../libs/utils/utils.js';
+import { getMepEnablement, loadIms } from '../../libs/utils/utils.js';
 import { combineMepSources } from '../../libs/features/personalization/personalization.js';
 
 describe('MEP Utils', () => {
@@ -60,6 +60,12 @@ describe('MEP Utils', () => {
       });
       expect(persEnabled).to.equal('https://main--milo--adobecom.hlx.page/products/special-offers-manifest.json');
       expect(targetEnabled).to.equal(false);
+    });
+    it('checks xlg metadata', async () => {
+      document.head.innerHTML = await readFile({ path: './mocks/mep/head-xlg.html' });
+      const xlgEnabled = getMepEnablement('xlg');
+      expect(xlgEnabled).to.equal('loggedout');
+      loadIms();
     });
   });
 });

--- a/test/utils/utils-mep.test.js
+++ b/test/utils/utils-mep.test.js
@@ -1,6 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import { getMepEnablement, loadIms } from '../../libs/utils/utils.js';
+import { getMepEnablement } from '../../libs/utils/utils.js';
 import { combineMepSources } from '../../libs/features/personalization/personalization.js';
 
 describe('MEP Utils', () => {
@@ -65,7 +65,6 @@ describe('MEP Utils', () => {
       document.head.innerHTML = await readFile({ path: './mocks/mep/head-xlg.html' });
       const xlgEnabled = getMepEnablement('xlg');
       expect(xlgEnabled).to.equal('loggedout');
-      loadIms();
     });
   });
 });


### PR DESCRIPTION
Although XLG segments can be sent to any user, MEP currently limits using them to logged in users.
Similar to the "target" setting for MEP, we will add an "xlg" setting that allows the use of XLG segments for logged out users.

* add if statement to loadIms to not set entitlements to empty when logged out if setting for xlg is set to loggedout
* move getMepEnablement and it's related functions higher so they are defined for use before loadIms
* call setupEntitlementCallback in martech.js if set to logged out, regardless of logged in status
* this also seems to fix a bug that causes a blank screen if: user is logged out, target enablement is off, and manifest uses xlg segments. we don't have any pages RIGHT NOW that use xlg without Target, but this will be good to fix for that future possibility.

Resolves: [MWPW-156898](https://jira.corp.adobe.com/browse/MWPW-156898)

QA instructions:
I've set the xlg metadata to loggedout for the page below.  I've also created a simple manifest that removes the header in the marquee so you can see if it's working.

How to check if/which segments are being sent:
1. Go to your network tab and filter for the string "interact?"
2. Look in your first entry at the response tab and see if you have anything that says "alias": "XLG Custom Personalization", with a list of segments.

QA steps:
1. Go to the https://www.adobe.com/products/acrobat-pro-cc.html
2. If you're logged out, check your xlg segments
3. If you're not getting any segments, you need to log in, wait 15 min, log out and check again
4. Once you confirm you're getting segments, you need to content override the 2 altered files in this PR
5. If you're not in the cc-free segment, also content override libs/features/personalization/entitlements.js and add any segment you are into the list with the name "test". This is also in the manifest.
6. Go to https://www.adobe.com/products/acrobat-pro-cc.html?mep=/cc-shared/fragments/tests/2024/q3/mepxlgloggedout/manifest.json&mepHighlight=true and see if the marquee headline is removed

Note, you can test the above on stage as well.

Psi-check: https://mepxlgloggedout--milo--adobecom.hlx.page/?martech=off
