### PR TITLE
MWPW-156872 - Add `no borders` variant to Accordion block

### DIFF
--- a/libs/blocks/accordion/accordion.css
+++ b/libs/blocks/accordion/accordion.css
@@ -12,6 +12,10 @@ dl.accordion {
   border-bottom: 1px solid var(--color-gray-500);
 }
 
+.accordion-container.no-borders dl.accordion {
+  border: none;
+}
+
 .accordion dd {
   margin: 0;
   padding: var(--spacing-xs);
@@ -40,6 +44,10 @@ dl.accordion {
 .accordion dt button:hover {
   cursor: pointer;
   color: var(--color-black);
+}
+
+.accordion-container.no-borders .accordion dt button {
+  border: none;
 }
 
 .accordion dt .accordion-heading {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* A request has been made to add a `no borders` option to the Accordion block. Like the variant name implies, this removes the gray separators in between accordion items.
* Note that this has been marked as a critical update in Jira.

Resolves: [MWPW-156872](https://jira.corp.adobe.com/browse/MWPW-156872)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ebartholomew/accordion-no-borders?martech=off
- After: https://ebartholomew-mwpw-156872-no-borders-accordion--milo--adobecom.hlx.page/drafts/ebartholomew/accordion-no-borders?martech=off
