### PR TITLE
MWPW-157034 [MEP] move call for preview from loadPostLCP to loadDeferred

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -147,7 +147,7 @@ const COMMANDS = {
   },
 };
 
-function getSelectorType(selector) {
+function checkSelectorType(selector) {
   return selector?.startsWith('/') || selector?.startsWith('http') ? 'fragment' : 'css';
 }
 
@@ -302,7 +302,7 @@ function registerInBlockActions(cmd, manifestId, targetManifestId) {
   if (blockAndSelector.length > 1) {
     blockSelector = blockAndSelector.slice(1).join(' ');
     command.selector = blockSelector;
-    if (getSelectorType(blockSelector) === 'fragment') {
+    if (checkSelectorType(blockSelector) === 'fragment') {
       config.mep.inBlock[blockName].fragments ??= {};
       const { fragments } = config.mep.inBlock[blockName];
       delete command.selector;
@@ -334,7 +334,7 @@ function getSelectedElement(selector, action, rootEl) {
     const section = selector.trim().replace('section', '');
     if (section !== '' && Number.isNaN(section)) return null;
   }
-  if (getSelectorType(selector) === 'fragment') {
+  if (checkSelectorType(selector) === 'fragment') {
     try {
       const fragment = document.querySelector(`a[href*="${normalizePath(selector, false)}"], a[href*="${normalizePath(selector, true)}"]`);
       if (fragment) return fragment.parentNode;
@@ -465,7 +465,7 @@ const getVariantInfo = (line, variantNames, variants, manifestPath, fTargetId) =
       selector,
       pageFilter,
       target: line[vn],
-      selectorType: getSelectorType(selector),
+      selectorType: checkSelectorType(selector),
       manifestId,
       targetManifestId,
     };

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -147,7 +147,7 @@ const COMMANDS = {
   },
 };
 
-function checkSelectorType(selector) {
+function getSelectorType(selector) {
   return selector?.startsWith('/') || selector?.startsWith('http') ? 'fragment' : 'css';
 }
 
@@ -302,7 +302,7 @@ function registerInBlockActions(cmd, manifestId, targetManifestId) {
   if (blockAndSelector.length > 1) {
     blockSelector = blockAndSelector.slice(1).join(' ');
     command.selector = blockSelector;
-    if (checkSelectorType(blockSelector) === 'fragment') {
+    if (getSelectorType(blockSelector) === 'fragment') {
       config.mep.inBlock[blockName].fragments ??= {};
       const { fragments } = config.mep.inBlock[blockName];
       delete command.selector;
@@ -334,7 +334,7 @@ function getSelectedElement(selector, action, rootEl) {
     const section = selector.trim().replace('section', '');
     if (section !== '' && Number.isNaN(section)) return null;
   }
-  if (checkSelectorType(selector) === 'fragment') {
+  if (getSelectorType(selector) === 'fragment') {
     try {
       const fragment = document.querySelector(`a[href*="${normalizePath(selector, false)}"], a[href*="${normalizePath(selector, true)}"]`);
       if (fragment) return fragment.parentNode;
@@ -465,7 +465,7 @@ const getVariantInfo = (line, variantNames, variants, manifestPath, fTargetId) =
       selector,
       pageFilter,
       target: line[vn],
-      selectorType: checkSelectorType(selector),
+      selectorType: getSelectorType(selector),
       manifestId,
       targetManifestId,
     };

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1009,10 +1009,6 @@ async function loadPostLCP(config) {
     import('../features/personalization/personalization.js')
       .then(({ addMepAnalytics }) => addMepAnalytics(config, header));
   }
-  if (config.mep?.preview) {
-    import('../features/personalization/preview.js')
-      .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
-  }
 }
 
 export function scrollToHashedElement(hash) {
@@ -1067,6 +1063,10 @@ export async function loadDeferred(area, blocks, config) {
         delay: getMetadata('pageperf-delay'),
         sampleRate: parseInt(getMetadata('pageperf-rate'), 10),
       }));
+  }
+  if (config.mep?.preview) {
+    import('../features/personalization/preview.js')
+      .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
   }
 }
 


### PR DESCRIPTION
* If a merch-card is added by MEP too late on the page, the function to add highlights is too late. Moving the call to preview.js from loadPostLCP to loadDeferred will ensure the page is fully decorated.

Resolves: [MWPW-157034](https://jira.corp.adobe.com/browse/MWPW-157034)

Note, the change is near the bottom of the page, and the before link sometimes highlights the cards.  But the after link always does
**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q3/mepmovepreviewcall/test?mepHighlight=true
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q3/mepmovepreviewcall/test?mepHighlight=true&milolibs=mepmovepreviewcall
- Psi-check: https://mepmovepreviewcall--milo--adobecom.hlx.page/?martech=off
