### PR TITLE
MWPW-156135 - [editorial-card] bugs

### DIFF
--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -152,6 +152,11 @@
   margin: 0;
 }
 
+.editorial-card .device {
+  font-size: var(--type-body-xxs-size);
+  line-height: var(--type-body-xxs-lh);
+}
+
 .editorial-card .lockup-area {
   row-gap: var(--spacing-xxs);
 }

--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -149,10 +149,9 @@
 
 .editorial-card .background .milo-video, 
 .editorial-card .background .milo-iframe {
-    height: 100%;
-    padding-bottom: 0;
+  height: 100%;
+  padding-bottom: 0;
 }
-
 
 .editorial-card .lockup-area,
 .editorial-card .device {
@@ -189,7 +188,6 @@
 .editorial-card.center .action-area {
   justify-content: center;
 }
-
 
 .editorial-card hr {
   background-color: currentcolor;
@@ -275,7 +273,6 @@
   }
 
   .editorial-card .vp-media .tablet-only { display: block; }
-
 }
 
 /* desktop up */

--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -92,6 +92,11 @@
   margin-top: auto;
 }
 
+.editorial-card .vp-media .tablet-only,
+.editorial-card .vp-media .desktop-only {
+  display: none;
+}
+
 .editorial-card .card-footer > div {
   display: flex;
   flex-direction: column;
@@ -248,3 +253,25 @@
 
 .editorial-card.footer-align-left .action-area { justify-content: start; }
 .editorial-card.footer-align-center .action-area { justify-content: center; }
+
+
+/* Tablet up */
+@media screen and (min-width: 600px) {
+  .editorial-card .vp-media .mobile-only,
+  .editorial-card .vp-media .desktop-only {
+    display: none;
+  }
+
+  .editorial-card .vp-media .tablet-only { display: block; }
+
+}
+
+/* desktop up */
+@media screen and (min-width: 1200px) {
+  .editorial-card .vp-media .mobile-only,
+  .editorial-card .vp-media .tablet-only {
+    display: none;
+  }
+
+  .editorial-card .vp-media .desktop-only { display: block; }
+}

--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -147,6 +147,13 @@
   height: 100%;
 }
 
+.editorial-card .background .milo-video, 
+.editorial-card .background .milo-iframe {
+    height: 100%;
+    padding-bottom: 0;
+}
+
+
 .editorial-card .lockup-area,
 .editorial-card .device {
   margin: 0;

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -80,8 +80,7 @@ function handleClickableCard(el) {
 
 const init = async (el) => {
   el.classList.add('con-block');
-  const isOpen = el.className.includes('open');
-  if (isOpen) {
+  if (el.className.includes('open')) {
     el.classList.add('no-border', 'l-rounded-corners-image', 'static-links-copy');
   }
   if (el.className.includes('rounded-corners')) {
@@ -90,31 +89,28 @@ const init = async (el) => {
   if (![...el.classList].some((c) => c.endsWith('-lockup'))) el.classList.add('m-lockup');
   let rows = el.querySelectorAll(':scope > div');
   const [head, middle, ...tail] = rows;
-  if (rows.length === 3) el.classList.add('equal-height');
+  if (rows.length === 4) el.classList.add('equal-height');
   if (rows.length >= 1) {
-    const count = rows.length >= 4 ? 'four-plus' : rows.length;
+    const count = rows.length >= 3 ? 'three-plus' : rows.length;
     switch (count) {
-      case 'four-plus':
-        // 4+ rows (0:bg, 1:media, 2:copy, ...3:static, last:card-footer)
+      case 'three-plus':
+        // 3+ rows (0:bg, 1:media, 2:copy, ...3:static, last:card-footer)
         decorateBgRow(el, head);
         rows = tail;
         await decorateForeground(el, rows);
         decorateMedia(el, middle);
         break;
       case 2:
-      case 3:
         // 2 rows (0:media, 1:copy)
-        // 3 rows (0:media, 1:copy, last:card-footer)
-        rows = [middle];
-        if (count === 3) rows = [middle, tail[0]];
-        await decorateForeground(el, rows);
+        rows = middle;
+        await decorateForeground(el, [rows]);
         decorateMedia(el, head);
         el.classList.add('no-bg');
         break;
       case 1:
         // 1 row  (0:copy)
-        rows = [head];
-        await decorateForeground(el, rows);
+        rows = head;
+        await decorateForeground(el, [rows]);
         el.classList.add('no-bg', 'no-media');
         break;
       default:

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -92,28 +92,29 @@ const init = async (el) => {
   const [head, middle, ...tail] = rows;
   if (rows.length === 4) el.classList.add('equal-height');
   if (rows.length >= 1) {
-    let count = rows.length >= 3 ? 'three-plus' : rows.length;
-    // 3 rows + .open (0:media, 1:copy, last:card-footer) = NO BG ROW
-    if (rows.length === 3 && isOpen) count = 2;
+    const count = rows.length >= 4 ? 'four-plus' : rows.length;
     switch (count) {
-      case 'three-plus':
-        // 3+ rows (0:bg, 1:media, 2:copy, ...3:static, last:card-footer)
+      case 'four-plus':
+        // 4+ rows (0:bg, 1:media, 2:copy, ...3:static, last:card-footer)
         decorateBgRow(el, head);
         rows = tail;
         await decorateForeground(el, rows);
         decorateMedia(el, middle);
         break;
       case 2:
+      case 3:
         // 2 rows (0:media, 1:copy)
-        rows = middle;
-        await decorateForeground(el, [rows]);
+        // 3 rows (0:media, 1:copy, last:card-footer)
+        rows = [middle];
+        if (count === 3) rows = [middle, tail[0]];
+        await decorateForeground(el, rows);
         decorateMedia(el, head);
         el.classList.add('no-bg');
         break;
       case 1:
         // 1 row  (0:copy)
-        rows = head;
-        await decorateForeground(el, [rows]);
+        rows = [head];
+        await decorateForeground(el, rows);
         el.classList.add('no-bg', 'no-media');
         break;
       default:

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -42,10 +42,10 @@ const decorateMedia = (el, media) => {
 };
 
 const decorateForeground = async (el, rows) => {
-  rows.forEach(async (row, i) => {
+  rows.forEach((row, i) => {
     if (i === 0) {
       row.classList.add('foreground');
-      await decorateLockupFromContent(row);
+      decorateLockupFromContent(row);
     } else if (i === (rows.length - 1)) {
       row.classList.add('card-footer');
       if (!row.textContent.trim()) row.classList.add('empty');

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -25,9 +25,10 @@ async function decorateLockupFromContent(el) {
 const extendDeviceContent = (el) => {
   const detail = el.querySelector('[class^="detail-"]');
   const prevElem = detail?.previousElementSibling;
-  if (!prevElem || ![...prevElem.classList].some((c) => c.startsWith('body-'))) return;
-  prevElem.classList.remove('body-m');
-  prevElem.classList.add('body-xxs', 'device');
+  if (!prevElem) return;
+  const elBodyClass = [...prevElem.classList].find((c) => c.startsWith('body-'));
+  prevElem.classList.remove(elBodyClass);
+  prevElem.classList.add('device');
 };
 
 const decorateMedia = (el, media) => {

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -37,7 +37,7 @@ const decorateMedia = (el, media) => {
   if (mediaVideo) {
     applyHoverPlay(mediaVideo);
   }
-  if (media.children.length > 1) decorateBlockBg(el, media);
+  if (media.children.length > 1) decorateBlockBg(el, media, { className: 'vp-media' });
 };
 
 const decorateForeground = async (el, rows) => {

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -90,7 +90,7 @@ const init = async (el) => {
   if (![...el.classList].some((c) => c.endsWith('-lockup'))) el.classList.add('m-lockup');
   let rows = el.querySelectorAll(':scope > div');
   const [head, middle, ...tail] = rows;
-  if (rows.length === 4) el.classList.add('equal-height');
+  if (rows.length === 3) el.classList.add('equal-height');
   if (rows.length >= 1) {
     const count = rows.length >= 4 ? 'four-plus' : rows.length;
     switch (count) {

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -57,12 +57,13 @@ const decorateForeground = async (el, rows) => {
 };
 
 const decorateBgRow = (el, background) => {
-  if (background.textContent.trim() === '') {
+  decorateBlockBg(el, background);
+  const rows = background.querySelectorAll(':scope > div');
+  const bgRowsEmpty = [...rows].every((row) => row.innerHTML.trim() === '');
+  if (bgRowsEmpty) {
     el.classList.add('no-bg');
     background.remove();
-    return;
   }
-  decorateBlockBg(el, background);
 };
 
 function handleClickableCard(el) {

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -80,7 +80,8 @@ function handleClickableCard(el) {
 
 const init = async (el) => {
   el.classList.add('con-block');
-  if (el.className.includes('open')) {
+  const isOpen = el.className.includes('open');
+  if (isOpen) {
     el.classList.add('no-border', 'l-rounded-corners-image', 'static-links-copy');
   }
   if (el.className.includes('rounded-corners')) {
@@ -91,7 +92,9 @@ const init = async (el) => {
   const [head, middle, ...tail] = rows;
   if (rows.length === 4) el.classList.add('equal-height');
   if (rows.length >= 1) {
-    const count = rows.length >= 3 ? 'three-plus' : rows.length;
+    let count = rows.length >= 3 ? 'three-plus' : rows.length;
+    // 3 rows + .open (0:media, 1:copy, last:card-footer) = NO BG ROW
+    if (rows.length === 3 && isOpen) count = 2;
     switch (count) {
       case 'three-plus':
         // 3+ rows (0:bg, 1:media, 2:copy, ...3:static, last:card-footer)

--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -31,7 +31,7 @@
   position: absolute;
   right: 0;
   top: 0;
-  z-index: -1;
+  z-index: 0;
   overflow: hidden;
 }
 

--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -31,7 +31,6 @@
   position: absolute;
   right: 0;
   top: 0;
-  z-index: 0;
   overflow: hidden;
 }
 

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -211,7 +211,8 @@
 .detail-xl,
 .detail-l,
 .detail-m,
-.detail-s {
+.detail-s,
+.detail-xs {
   margin: 0;
 }
 

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -93,10 +93,10 @@ export function handleFocalpoint(pic, child, removeChild) {
   image.style.objectPosition = `${x} ${y}`;
 }
 
-export async function decorateBlockBg(block, node, { useHandleFocalpoint = false } = {}) {
+export async function decorateBlockBg(block, node, { useHandleFocalpoint = false, className = 'background' } = {}) {
   const childCount = node.childElementCount;
   if (node.querySelector('img, video, a[href*=".mp4"]') || childCount > 1) {
-    node.classList.add('background');
+    node.classList.add(className);
     const binaryVP = [['mobile-only'], ['tablet-only', 'desktop-only']];
     const allVP = [['mobile-only'], ['tablet-only'], ['desktop-only']];
     const viewports = childCount === 2 ? binaryVP : allVP;


### PR DESCRIPTION
Fixed the following bugs
1) In Editorial card, when image is added per breakpoint, it uses the same decorate bg function with rounded-corder.css where the image unintentionally gets targeted with the class `.background` causing a style naming collision. I am passing this className as a parameter now. 
2) When per-viewport bg images are used, they do not display
3) Button and product lockup override work ONLY ATM
4) Custom device support text should always be body-xxs
5) A [text-block] background doesn't show when it's authored in a wrapping section that also has a background. *bonus

Resolves: [MWPW-156135](https://jira.corp.adobe.com/browse/MWPW-156135)

**Test URLs:**
Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/cards/editorial-cards-bugz?martech=off
After: https://rparrish-editorial-bugz--milo--adobecom.hlx.page/drafts/rparrish/cards/editorial-cards-bugz?martech=off
