### PR TITLE
[MWPW-152968] mWeb - Passing ECID to Branch.io banner - Implementation

### DIFF
--- a/libs/blocks/mobile-app-banner/mobile-app-banner.js
+++ b/libs/blocks/mobile-app-banner/mobile-app-banner.js
@@ -24,8 +24,9 @@ async function getECID() {
 }
 
 /* eslint-disable */
-function branchInit(key, ecidVal) {
+async function branchInit(key) {
   let initValue = false;
+  const ecid = await getECID();
   function initBranch() {
     if (initValue) {
       return;
@@ -64,7 +65,7 @@ function branchInit(key, ecidVal) {
     const performanceCookieConsent = cookieGrp.includes('C0002');
     const advertisingCookieConsent = cookieGrp.includes('C0004');
 
-    if (performanceCookieConsent && advertisingCookieConsent && isAndroid) branch.setBranchViewData({ data: { ecid: ecidVal }});
+    if (performanceCookieConsent && advertisingCookieConsent && isAndroid) branch.setBranchViewData({ data: { ecid: ecid }});
     branch.init(key, { tracking_disabled: !privacyConsent });
   }
 
@@ -81,7 +82,5 @@ export default async function init(el) {
   const classListArray = Array.from(el.classList);
   const product = classListArray.find((token) => token.startsWith('product-')).split('-')[1];
   const key = await getKey(product);
-  if (!key) return;
-  const ecid = await getECID();
-  branchInit(key, ecid);
+  if (key) branchInit(key);
 }

--- a/libs/blocks/mobile-app-banner/mobile-app-banner.js
+++ b/libs/blocks/mobile-app-banner/mobile-app-banner.js
@@ -65,7 +65,7 @@ async function branchInit(key) {
     const performanceCookieConsent = cookieGrp.includes('C0002');
     const advertisingCookieConsent = cookieGrp.includes('C0004');
 
-    if (performanceCookieConsent && advertisingCookieConsent && isAndroid) branch.setBranchViewData({ data: { ecid: ecid }});
+    if (performanceCookieConsent && advertisingCookieConsent && isAndroid) branch.setBranchViewData({ data: { ecid }});
     branch.init(key, { tracking_disabled: !privacyConsent });
   }
 

--- a/libs/blocks/mobile-app-banner/mobile-app-banner.js
+++ b/libs/blocks/mobile-app-banner/mobile-app-banner.js
@@ -13,8 +13,18 @@ async function getKey(product) {
   return keyMatch[0]?.key;
 }
 
+async function getECID() {
+  let ecid = null;
+  if (window.alloy) {
+    await window.alloy('getIdentity').then((data) => {
+      ecid = data?.identity?.ECID;
+    }).catch((err) => window.lana.log(`Error fetching ECID: ${err}`, { tags: 'errorType=error,module=mobile-app-banner' }));
+  }
+  return ecid;
+}
+
 /* eslint-disable */
-function branchInit(key) {
+function branchInit(key, ecidVal) {
   let initValue = false;
   function initBranch() {
     if (initValue) {
@@ -48,8 +58,16 @@ function branchInit(key) {
       0
     );
     const privacyConsent = window.adobePrivacy?.hasUserProvidedConsent();
+    const isAndroid = navigator.userAgent.includes('Android');
+    
+    const cookieGrp = window.adobePrivacy?.activeCookieGroups();
+    const performanceCookieConsent = cookieGrp.includes('C0002');
+    const advertisingCookieConsent = cookieGrp.includes('C0004');
+
+    if (performanceCookieConsent && advertisingCookieConsent && isAndroid) branch.setBranchViewData({ data: { ecid: ecidVal }});
     branch.init(key, { tracking_disabled: !privacyConsent });
   }
+
   ['adobePrivacy:PrivacyConsent', 'adobePrivacy:PrivacyReject', 'adobePrivacy:PrivacyCustom']
     .forEach((event) => {
       window.addEventListener(event, initBranch);
@@ -63,5 +81,7 @@ export default async function init(el) {
   const classListArray = Array.from(el.classList);
   const product = classListArray.find((token) => token.startsWith('product-')).split('-')[1];
   const key = await getKey(product);
-  if (key) branchInit(key);
+  if (!key) return;
+  const ecid = await getECID();
+  branchInit(key, ecid);
 }

--- a/test/blocks/mobile-app-banner/mobile-app-banner.test.js
+++ b/test/blocks/mobile-app-banner/mobile-app-banner.test.js
@@ -51,7 +51,11 @@ describe('mobile-app-banner', () => {
   });
 
   it('should init by adding branchio script', async () => {
-    window.adobePrivacy = { hasUserProvidedConsent: () => true };
+    window.adobePrivacy = {
+      hasUserProvidedConsent: () => true,
+      activeCookieGroups: () => ['C0002', 'C0004'],
+    };
+    const userAgentStub = sinon.stub(navigator, 'userAgent').get(() => 'Android');
     const module = await import('../../../libs/blocks/mobile-app-banner/mobile-app-banner.js');
     const banner = document.body.querySelector('.mobile-app-banner.product-test');
     await module.default(banner);
@@ -63,5 +67,33 @@ describe('mobile-app-banner', () => {
       if (scriptTag.getAttribute('src') !== null) scriptSrcs.push(scriptTag.getAttribute('src'));
     });
     expect(scriptSrcs).to.include('https://cdn.branch.io/branch-latest.min.js');
+    userAgentStub.restore();
+  });
+
+  it('should fetch ecid from alloy and return if event is dispatched twice', async () => {
+    window.adobePrivacy = {
+      hasUserProvidedConsent: () => true,
+      activeCookieGroups: () => ['C0002', 'C0004'],
+    };
+    window.alloy = () => {};
+    const alloyStub = sinon.stub(window, 'alloy').callsFake((command) => {
+      if (command === 'getIdentity') {
+        return Promise.resolve({ identity: { ECID: 'test-ecid' } });
+      }
+      return 'test-ecid';
+    });
+    const module = await import('../../../libs/blocks/mobile-app-banner/mobile-app-banner.js');
+    const banner = document.body.querySelector('.mobile-app-banner.product-test');
+    await module.default(banner);
+    window.dispatchEvent(new CustomEvent('adobePrivacy:PrivacyConsent'));
+    await delay(0);
+    const scriptTags = document.querySelectorAll('head > script');
+    const scriptSrcs = [];
+    scriptTags.forEach((scriptTag) => {
+      if (scriptTag.getAttribute('src') !== null) scriptSrcs.push(scriptTag.getAttribute('src'));
+    });
+    window.dispatchEvent(new CustomEvent('adobePrivacy:PrivacyConsent'));
+    expect(scriptSrcs).to.include('https://cdn.branch.io/branch-latest.min.js');
+    alloyStub.restore();
   });
 });


### PR DESCRIPTION
* When a user who has opted into both analytics and advertising cookies and is using Android device, their unique ECID is passed to Branch.
* These changes were approved and merged last month ( PR: [2567](https://github.com/adobecom/milo/pull/2567)) but were later reverted as we needed to wait for PIA approval. We are now re-opening this PR as we have received the PIA approval for this.

Resolves: [MWPW-152968](https://jira.corp.adobe.com/browse/MWPW-152968)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/drashti/milo-banner/branch-banner?martech=off
- After: https://branch-ecid--milo--drashti1712.hlx.live/drafts/drashti/milo-banner/branch-banner