### PR TITLE
[MWPW-148140] Adjust table strikethrough pricing

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -247,6 +247,11 @@
   padding: var(--spacing-xxs) 0;
 }
 
+.table .row-heading .col-heading .pricing .price-strikethrough {
+  display: inline-block;
+  font-size: var(--type-body-s-size);
+}
+
 /* section */
 .table .divider {
   display: none;


### PR DESCRIPTION
This tweaks the font size for strikethrough pricing inside table headers.

Resolves: [MWPW-148140](https://jira.corp.adobe.com/browse/MWPW-148140)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-kyung-overhaul?martech-off&georouting=off
- After: https://table-strikethrough-font--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-kyung-overhaul?martech-off&georouting=off