### PR TITLE
MWPW-151932 - Section metadata style grid enhancement for tablet VP

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -245,7 +245,6 @@ main > .section[class*='-up'] > .content {
     order: 1;
   }
 
-  .section.one-up-mobile { grid-template-columns: 1fr; }
 }
 
 @media screen and (min-width: 600px) and (max-width: 1200px) {
@@ -253,10 +252,10 @@ main > .section[class*='-up'] > .content {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
   
-  .section.two-up-tablet { grid-template-columns: repeat(2, 1fr);  }
-  .section.three-up-tablet { grid-template-columns: repeat(3, 1fr);  }
-  .section.four-up-tablet { grid-template-columns: repeat(4, 1fr);  }
-  .section.five-up-tablet { grid-template-columns: repeat(5, 1fr);  }
+  .section.one-up-tablet { grid-template-columns: 1fr; }
+  .section.two-up-tablet { grid-template-columns: repeat(2, 1fr); }
+  .section.three-up-tablet { grid-template-columns: repeat(3, 1fr); }
+  .section.four-up-tablet { grid-template-columns: repeat(4, 1fr); }
 
   .section.masonry-layout {
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
@@ -264,15 +263,6 @@ main > .section[class*='-up'] > .content {
   
   .section.masonry-layout .grid-full-width:first-child {
     grid-column: 1 / -1;
-  }
-}
-
-@media screen and (max-width: 900px) {
-  .section.two-up.one-up-tablet,
-  .section.three-up.one-up-tablet,
-  .section.four-up.one-up-tablet,
-  .section.five-up.one-up-tablet {
-    grid-template-columns: 1fr;
   }
 }
 

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -244,12 +244,19 @@ main > .section[class*='-up'] > .content {
   .section.two-up.reverse-mobile > div:nth-child(2) {
     order: 1;
   }
+
+  .section.one-up-mobile { grid-template-columns: 1fr; }
 }
 
 @media screen and (min-width: 600px) and (max-width: 1200px) {
   .section.five-up {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
+  
+  .section.two-up-tablet { grid-template-columns: repeat(2, 1fr);  }
+  .section.three-up-tablet { grid-template-columns: repeat(3, 1fr);  }
+  .section.four-up-tablet { grid-template-columns: repeat(4, 1fr);  }
+  .section.five-up-tablet { grid-template-columns: repeat(5, 1fr);  }
 
   .section.masonry-layout {
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -253,7 +253,6 @@ main > .section[class*='-up'] > .content {
   }
   
   .section.one-up-tablet { grid-template-columns: 1fr; }
-  .section.two-up-tablet { grid-template-columns: repeat(2, 1fr); }
   .section.three-up-tablet { grid-template-columns: repeat(3, 1fr); }
   .section.four-up-tablet { grid-template-columns: repeat(4, 1fr); }
 


### PR DESCRIPTION
Added additional section-metadata styles to target tablet viewports with our existing `-ups` grids.
 
`style: three-up-tablet, four-up-tablet`

In addition, the existing style `one-up-tablet` should be moved into the standard tablet media query. 
(600-1200 instead of 600-900).
Live testing page -> https://main-dc-adobecom.hlx.page/acrobat/business/webinars/document-automation-made-eas[…]th-adobe-acrobat-sign?milolibs=rparrish-ups-grid-tablet  

Resolves: [MWPW-151932](https://jira.corp.adobe.com/browse/MWPW-151932)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/grids/ups-grid-responsive?martech=off
- After: https://rparrish-ups-grid-tablet--milo--adobecom.hlx.page/drafts/rparrish/grids/ups-grid-responsive?martech=off
