### PR TITLE
[MWPW-157556] Eagerly import lit from merch-card block

### DIFF
--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -3,6 +3,7 @@ import { getConfig, createTag, loadStyle } from '../../utils/utils.js';
 import { getMetadata } from '../section-metadata/section-metadata.js';
 import { processTrackingLabels } from '../../martech/attributes.js';
 import '../../deps/mas/merch-card.js';
+import '../../deps/lit-all.min.js';
 
 const TAG_PATTERN = /^[a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-].*$/;
 


### PR DESCRIPTION
Resolves: [MWPW-157556](https://jira.corp.adobe.com/browse/MWPW-157556)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://MWPW-157556--milo--adobecom.hlx.page/?martech=off

- Before: https://main--cc--adobecom.hlx.live/products/photoshop?martech=off&georouting=off&skipBanner=true
- After: https://main--cc--adobecom.hlx.live/products/photoshop?martech=off&georouting=off&skipBanner=true&milolibs=MWPW-157556

Before lit-all.min.js
<img width="321" alt="image" src="https://github.com/user-attachments/assets/a6a3c993-7ed3-4a9f-bedb-39f1bf7d7f5e">

After lit-all.min.js
<img width="277" alt="image" src="https://github.com/user-attachments/assets/b44ef6d9-2ce1-4557-8805-261969d7b972">

