### PR TITLE
MWPW-157540: fix external modals

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -374,7 +374,7 @@ export async function openModal(e, url, offerType) {
   if (/\/fragments\//.test(url)) {
     const fragmentPath = url.split(/hlx.(page|live)/).pop();
     modal = await openFragmentModal(fragmentPath, getModal);
-  } else if (/^https?:/.test(url)) {
+  } else {
     modal = await openExternalModal(url, getModal);
   }
   if (modal) {


### PR DESCRIPTION
Clone of https://github.com/adobecom/milo/pull/2806 to fast track to main directly if needed.

### How to test
Verify the Merch block, e.g. Prices and CTAs function as expected.

### Details
Go live 4th September blocker.
Fix external modals on catalog.
checkoutLinkConfig[columnName] is an external CRM modal `https://www.adobe.com/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html `
that gets localized and becomes '/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html'
that doesn't pass regex later on on openModal
`} else if (/^https?:/.test(url)) {`

Resolves: https://jira.corp.adobe.com/browse/MWPW-157540

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/mariia/pr/price-cta?martech=off
- After: https://MWPW-157540--milo--adobecom.hlx.live/drafts/mariia/pr/price-cta?martech=off
