### PR TITLE
MWPW-157693 [MEP] Action area simplified selector does not work well with hero-marquee block

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -358,7 +358,7 @@ function modifySelectorTerm(termParam) {
     section: 'main > div',
     'primary-cta': 'p strong a',
     'secondary-cta': 'p em a',
-    'action-area': 'p:has(em a, strong a)',
+    'action-area': '*:has(> em a, > strong a)',
   };
   const otherSelectors = ['row', 'col'];
   const htmlEls = ['main', 'div', 'a', 'p', 'strong', 'em', 'picture', 'source', 'img', 'h'];

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -4,7 +4,7 @@ import { modifyNonFragmentSelector } from '../../../libs/features/personalizatio
 const values = [
   {
     b: 'main section1 marquee action-area',
-    a: 'main > div:nth-child(1) .marquee p:has(em a, strong a)',
+    a: 'main > div:nth-child(1) .marquee *:has(> em a, > strong a)',
   },
   {
     b: 'main > section1 .marquee h2',


### PR DESCRIPTION
The new action-area MEP simplified selector does not work on hero-marquees because there is no paragraph around the buttons

* Update CSS selector to also be able to catch divs

Resolves: [MWPW-157693](https://jira.corp.adobe.com/browse/MWPW-157693)

QA instructions: We want the action-area selector to start working in hero-marquees but continue to work in regular marquees.  To make it more obvious the content is updated, I added "(pzn)" to the marquee description and to one of the buttons
**Test URLs:**
Hero Marquee:
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepactionarea/marquee?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepactionarea/marquee?milolibs=mepactionarea&martech=off
Marquee:
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepactionarea/max-lr-hero-option?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepactionarea/max-lr-hero-option?milolibs=mepactionarea&martech=off

- Psi-check: https://mepactionarea--milo--adobecom.hlx.page/?martech=off