### PR TITLE
MWPW-157761: Tab preselect in external modals [catalog]

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -364,6 +364,8 @@ async function openExternalModal(url, getModal) {
   });
 }
 
+const isInternalModal = (url) => /\/fragments\//.test(url);
+
 export async function openModal(e, url, offerType) {
   e.preventDefault();
   e.stopImmediatePropagation();
@@ -371,7 +373,7 @@ export async function openModal(e, url, offerType) {
   await import('../modal/modal.merch.js');
   const offerTypeClass = offerType === OFFER_TYPE_TRIAL ? 'twp' : 'crm';
   let modal;
-  if (/\/fragments\//.test(url)) {
+  if (isInternalModal(url)) {
     const fragmentPath = url.split(/hlx.(page|live)/).pop();
     modal = await openFragmentModal(fragmentPath, getModal);
   } else {
@@ -398,7 +400,8 @@ export async function getModalAction(offers, options) {
   const columnName = (offerType === OFFER_TYPE_TRIAL) ? FREE_TRIAL_PATH : BUY_NOW_PATH;
   let url = checkoutLinkConfig[columnName];
   if (!url) return undefined;
-  url = localizeLink(checkoutLinkConfig[columnName]);
+  url = isInternalModal(url)
+    ? localizeLink(checkoutLinkConfig[columnName]) : checkoutLinkConfig[columnName];
   return { url, handler: (e) => openModal(e, url, offerType) };
 }
 


### PR DESCRIPTION
Fixes preselected tab not working in external modals (Twp) on Catalog page.

Resolves: [MWPW-157761](https://jira.corp.adobe.com/browse/MWPW-157761)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/mariia/pr/price-cta?martech=off
- After: https://MWPW-157761--milo--adobecom.hlx.live/drafts/mariia/pr/price-cta?martech=off