### PR TITLE
MWPW-157783 [MEP] Primary and Secondary CTA simplified selectors do not work well with hero-marquee block

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -356,8 +356,8 @@ function modifySelectorTerm(termParam) {
   let term = termParam;
   const specificSelectors = {
     section: 'main > div',
-    'primary-cta': 'p strong a',
-    'secondary-cta': 'p em a',
+    'primary-cta': '* > strong a',
+    'secondary-cta': '* > em a',
     'action-area': '*:has(> em a, > strong a)',
   };
   const otherSelectors = ['row', 'col'];

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -358,7 +358,7 @@ function modifySelectorTerm(termParam) {
     section: 'main > div',
     'primary-cta': 'p strong a',
     'secondary-cta': 'p em a',
-    'action-area': 'p:has(em a, strong a)',
+    'action-area': '*:has(> em a, > strong a)',
   };
   const otherSelectors = ['row', 'col'];
   const htmlEls = ['main', 'div', 'a', 'p', 'strong', 'em', 'picture', 'source', 'img', 'h'];

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -4,7 +4,7 @@ import { modifyNonFragmentSelector } from '../../../libs/features/personalizatio
 const values = [
   {
     b: 'main section1 marquee action-area',
-    a: 'main > div:nth-child(1) .marquee p:has(em a, strong a)',
+    a: 'main > div:nth-child(1) .marquee *:has(> em a, > strong a)',
   },
   {
     b: 'main > section1 .marquee h2',

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -28,35 +28,35 @@ const values = [
   },
   {
     b: 'section3 table row2 col2 primary-cta',
-    a: 'main > div:nth-child(3) .table > div:nth-child(2) > div:nth-child(2) p strong a',
+    a: 'main > div:nth-child(3) .table > div:nth-child(2) > div:nth-child(2) * > strong a',
   },
   {
     b: 'marquee primary-cta #_href',
-    a: '.marquee p strong a',
+    a: '.marquee * > strong a',
     m: ['href'],
   },
   {
     b: 'marquee primary-cta #_HREF',
-    a: '.marquee p strong a',
+    a: '.marquee * > strong a',
     m: ['href'],
   },
   {
     b: 'marquee primary-cta#_href',
-    a: '.marquee p strong a#_href',
+    a: '.marquee * > strong a#_href',
   },
   {
     b: 'marquee primary-cta #_href_all',
-    a: '.marquee p strong a',
+    a: '.marquee * > strong a',
     m: ['href', 'all'],
   },
   {
     b: 'marquee primary-cta #_href#_all',
-    a: '.marquee p strong a',
+    a: '.marquee * > strong a',
     m: ['href', 'all'],
   },
   {
     b: 'marquee primary-cta #_href #_all',
-    a: '.marquee p strong a',
+    a: '.marquee * > strong a',
     m: ['href', 'all'],
   },
   {
@@ -65,7 +65,7 @@ const values = [
   },
   {
     b: 'section3 table row2 col4 secondary-cta',
-    a: 'main > div:nth-child(3) .table > div:nth-child(2) > div:nth-child(4) p em a',
+    a: 'main > div:nth-child(3) .table > div:nth-child(2) > div:nth-child(4) * > em a',
   },
   {
     b: 'section4 merch-card',
@@ -85,7 +85,7 @@ const values = [
   },
   {
     b: '.text:has(#im-a-unique-text-block) secondary-cta',
-    a: '.text:has(#im-a-unique-text-block) p em a',
+    a: '.text:has(#im-a-unique-text-block) * > em a',
   },
   {
     b: 'section1 .random-block2',


### PR DESCRIPTION
The new primary-cta and secondary-cta MEP simplified selectors do not work on hero-marquees because there is no paragraph around the buttons

Update CSS selector to also be able to catch divs
Resolves: [MWPW-157783](https://jira.corp.adobe.com/browse/MWPW-157783)

QA instructions: We want the action-area selector to start working in hero-marquees but continue to work in regular marquees. To make it more obvious the content is updated, I added "(pzn)" to the marquee description and to one of the buttons
Test URLs:
Hero Marquee:

Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepactionarea/marquee?martech=off

After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepactionarea/marquee?milolibs=mepactionarea&martech=off
Marquee:

Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepactionarea/max-lr-hero-option?martech=off

After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepactionarea/max-lr-hero-option?milolibs=mepactionarea&martech=off

Psi-check: https://mepactionarea--milo--adobecom.hlx.page/?martech=off