### PR TITLE
MWPW-157785 [MEP] Create "any-marquee" and "header" simplified selectors

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -359,11 +359,13 @@ function modifySelectorTerm(termParam) {
     'primary-cta': 'strong a',
     'secondary-cta': 'em a',
     'action-area': '*:has(> em a, > strong a)',
+    'any-marquee': '[class*="marquee"]',
   };
   const otherSelectors = ['row', 'col'];
   const htmlEls = ['main', 'div', 'a', 'p', 'strong', 'em', 'picture', 'source', 'img', 'h'];
   const startTextMatch = term.match(/^[a-zA-Z/./-]*/);
   const startText = startTextMatch ? startTextMatch[0].toLowerCase() : '';
+  const startTextPart1 = startText.split(/\.|:/)[0];
   const endNumberMatch = term.match(/[0-9]*$/);
   const endNumber = endNumberMatch ? endNumberMatch[0] : '';
   if (!startText || htmlEls.includes(startText)) return term;
@@ -372,8 +374,8 @@ function modifySelectorTerm(termParam) {
     term = updateEndNumber(endNumber, term);
     return term;
   }
-  if (Object.keys(specificSelectors).includes(startText)) {
-    term = term.replace(startText, specificSelectors[startText]);
+  if (Object.keys(specificSelectors).includes(startTextPart1)) {
+    term = term.replace(startTextPart1, specificSelectors[startTextPart1]);
     term = updateEndNumber(endNumber, term);
     return term;
   }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -360,6 +360,7 @@ function modifySelectorTerm(termParam) {
     'secondary-cta': 'em a',
     'action-area': '*:has(> em a, > strong a)',
     'any-marquee': '[class*="marquee"]',
+    header: ':is(h1, h2, h3, h4, h5, h6)',
   };
   const otherSelectors = ['row', 'col'];
   const htmlEls = ['main', 'div', 'a', 'p', 'strong', 'em', 'picture', 'source', 'img', 'h'];

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -3,6 +3,10 @@ import { modifyNonFragmentSelector } from '../../../libs/features/personalizatio
 
 const values = [
   {
+    b: 'any-marquee action-area',
+    a: '[class*="marquee"] *:has(> em a, > strong a)',
+  },
+  {
     b: 'main section1 marquee action-area',
     a: 'main > div:nth-child(1) .marquee *:has(> em a, > strong a)',
   },
@@ -17,6 +21,14 @@ const values = [
   {
     b: 'marquee.light:nth-child(2) h2',
     a: '.marquee.light:nth-child(2) h2',
+  },
+  {
+    b: 'any-marquee.light:nth-child(2) h2',
+    a: '[class*="marquee"].light:nth-child(2) h2',
+  },
+  {
+    b: 'any-marquee:nth-child(2) h2',
+    a: '[class*="marquee"]:nth-child(2) h2',
   },
   {
     b: 'section2 text3',

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -24,7 +24,7 @@ const values = [
   },
   {
     b: 'marquee.light:nth-child(2) header',
-    a: '.marquee.light:nth-child(2) is:(h1, h2, h3, h4, h5, h6)',
+    a: '.marquee.light:nth-child(2) :is(h1, h2, h3, h4, h5, h6)',
   },
   {
     b: 'any-marquee.light:nth-child(2) h2',

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -23,6 +23,10 @@ const values = [
     a: '.marquee.light:nth-child(2) h2',
   },
   {
+    b: 'marquee.light:nth-child(2) header',
+    a: '.marquee.light:nth-child(2) is:(h1, h2, h3, h4, h5, h6)',
+  },
+  {
     b: 'any-marquee.light:nth-child(2) h2',
     a: '[class*="marquee"].light:nth-child(2) h2',
   },


### PR DESCRIPTION
It's becoming very common to switch between using the marquee block, interactive-marquee block or the hero-marquee block.

There's an easy CSS selector to get any of these, but if it was a simplified selector it would be easier to use.

Similarly, it can be hard to know which header level to use (h1, h2, h3 etc.) because they can look the same and even get changed by the decoration process. Although it can be achieved in CSS, it would be easier to have a simplified selector.

Resolves: [MWPW-157785](https://jira.corp.adobe.com/browse/MWPW-157785)

Note the examples below use the same manifest with the same selector: "any-marquee primary-cta"
**Test URLs:**
Marquee:
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepanymarquee/marquee?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepanymarquee/marquee?milolibs=mepanymarquee&martech=off

Hero Marquee:
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepanymarquee/hero-marquee?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepanymarquee/hero-marquee?milolibs=mepanymarquee&martech=off

Interactive Marquee:
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepanymarquee/interactive-marquee?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepanymarquee/interactive-marquee?milolibs=mepanymarquee&martech=off


-  Psi-check: https://mepanymarquee--milo--adobecom.hlx.page/?martech=off
