### PR TITLE
MWPW-157210 STE Promo card not appearing

### DIFF
--- a/libs/blocks/merch-card-collection/merch-card-collection.js
+++ b/libs/blocks/merch-card-collection/merch-card-collection.js
@@ -1,3 +1,4 @@
+import { overrideUrlOrigin } from '../../utils/helpers.js';
 import {
   createTag, decorateLinks, getConfig, loadBlock, loadStyle, localizeLink,
 } from '../../utils/utils.js';
@@ -56,21 +57,8 @@ async function getCardsRoot(config, html) {
   return cardsRoot;
 }
 
-const overrideUrlOrigin = (action) => {
-  let target = action?.target;
-  try {
-    const url = new URL(target);
-    if (url.hostname !== window.location.hostname) {
-      target = target.replace(url.origin, window.location.origin);
-    }
-  } catch (e) {
-    // ignore
-  }
-  return target;
-};
-
 const fetchOverrideCard = (action, config) => new Promise((resolve, reject) => {
-  fetch(`${localizeLink(overrideUrlOrigin(action))}.plain.html`).then((res) => {
+  fetch(`${localizeLink(overrideUrlOrigin(action?.target))}.plain.html`).then((res) => {
     if (res.ok) {
       res.text().then((cardContent) => {
         const response = { path: action.target, cardContent: /^<div>(.*)<\/div>$/.exec(cardContent.replaceAll('\n', ''))[1] };

--- a/libs/blocks/merch-card-collection/merch-card-collection.js
+++ b/libs/blocks/merch-card-collection/merch-card-collection.js
@@ -56,8 +56,21 @@ async function getCardsRoot(config, html) {
   return cardsRoot;
 }
 
+const overrideUrlOrigin = (action) => {
+  let target = action?.target;
+  try {
+    const url = new URL(target);
+    if (url.hostname !== window.location.hostname) {
+      target = target.replace(url.origin, window.location.origin);
+    }
+  } catch (e) {
+    // ignore
+  }
+  return target;
+};
+
 const fetchOverrideCard = (action, config) => new Promise((resolve, reject) => {
-  fetch(`${localizeLink(action?.target, config)}.plain.html`).then((res) => {
+  fetch(`${localizeLink(overrideUrlOrigin(action))}.plain.html`).then((res) => {
     if (res.ok) {
       res.text().then((cardContent) => {
         const response = { path: action.target, cardContent: /^<div>(.*)<\/div>$/.exec(cardContent.replaceAll('\n', ''))[1] };

--- a/libs/utils/helpers.js
+++ b/libs/utils/helpers.js
@@ -19,3 +19,21 @@ export function updateLinkWithLangRoot(link) {
     return link;
   }
 }
+
+/**
+ * Replaces the origin of the provided link with location.origin.
+ *
+ * @param link
+ * @returns {string|*}
+ */
+export function overrideUrlOrigin(link) {
+  try {
+    const url = new URL(link);
+    if (url.hostname !== window.location.hostname) {
+      return link.replace(url.origin, window.location.origin);
+    }
+  } catch (e) {
+    // ignore
+  }
+  return link;
+}

--- a/test/utils/helpers.test.js
+++ b/test/utils/helpers.test.js
@@ -2,7 +2,6 @@ import { expect } from '@esm-bundle/chai';
 import { overrideUrlOrigin } from '../../libs/utils/helpers.js';
 
 describe('overrideUrlOrigin', () => {
-
   it('Change origin to http://localhost:2000', async () => {
     const link = overrideUrlOrigin('http://www.qa.adobe.com/some/page.html?a=b#hash');
     expect(link).to.equal('http://localhost:2000/some/page.html?a=b#hash');
@@ -12,5 +11,4 @@ describe('overrideUrlOrigin', () => {
     const link = overrideUrlOrigin('/some/page.html?a=b#hash');
     expect(link).to.equal('/some/page.html?a=b#hash');
   });
-
 });

--- a/test/utils/helpers.test.js
+++ b/test/utils/helpers.test.js
@@ -1,0 +1,16 @@
+import { expect } from '@esm-bundle/chai';
+import { overrideUrlOrigin } from '../../libs/utils/helpers.js';
+
+describe('overrideUrlOrigin', () => {
+
+  it('Change origin to http://localhost:2000', async () => {
+    const link = overrideUrlOrigin('http://www.qa.adobe.com/some/page.html?a=b#hash');
+    expect(link).to.equal('http://localhost:2000/some/page.html?a=b#hash');
+  });
+
+  it('Ignore relative URLs', async () => {
+    const link = overrideUrlOrigin('/some/page.html?a=b#hash');
+    expect(link).to.equal('/some/page.html?a=b#hash');
+  });
+
+});


### PR DESCRIPTION
On https://www.stage.adobe.com/products/catalog.html call for 
https://main--cc--adobecom.hlx.page/cc-shared/fragments/promos/2024/global/test/catalog-promo-test/fragments/catalog-ste.plain.html  
fails with error 401.
On https://main--cc--adobecom.hlx.page/products/catalog this works since the hostname is identical.
So I changed the hostname in the card URL to load it from `merch-card-collection.js`
before `localizeLink()` is called.
I started with an idea to change the code of `localizeLink()` to do the same thing but this method is used in too many places, hence too risky.
Can be tested only on https://www.stage.adobe.com/products/catalog.html

Resolves: [MWPW-157210](https://jira.corp.adobe.com/browse/MWPW-157210)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/bozo/price-cta?martech=off
- After: https://mwpw157210ste--milo--bozojovicic.hlx.page/drafts/bozo/price-cta?martech=off
