### PR TITLE
MWPW-157292: CC and DC: Phone number links wrong

### DIFF
--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -133,12 +133,10 @@ export async function decoratePlaceholderArea({
   await fetchPlaceholders({ placeholderPath, config, placeholderRequest });
   const replaceNodes = nodes.map(async (nodeEl) => {
     if (nodeEl.nodeType === Node.TEXT_NODE) {
-      const newValue = await replaceText(nodeEl.nodeValue, config);
-      nodeEl.nodeValue = newValue;
+      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config);
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
-      const hrefValue = nodeEl.getAttribute('href');
-      const newValue = await replaceText(hrefValue, config);
-      nodeEl.setAttribute('href', newValue);
+      const hrefVal = await replaceText(nodeEl.getAttribute('href'), config);
+      nodeEl.setAttribute('href', hrefVal);
     }
   });
   await Promise.all(replaceNodes);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -760,23 +760,21 @@ export async function customFetch({ resource, withCacheRules }) {
 
 const findReplaceableNodes = (area) => {
   const regex = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
-  const walker = document.createTreeWalker(
-    area,
-    NodeFilter.SHOW_TEXT,
-    {
-      acceptNode(node) {
-        const a = regex.test(node.nodeValue)
-          ? NodeFilter.FILTER_ACCEPT
-          : NodeFilter.FILTER_REJECT;
-        regex.lastIndex = 0;
-        return a;
-      },
-    },
-  );
+  const walker = document.createTreeWalker(area, NodeFilter.SHOW_ALL);
   const nodes = [];
   let node = walker.nextNode();
   while (node !== null) {
-    nodes.push(node);
+    let matchFound = false;
+    if (node.nodeType === Node.TEXT_NODE) {
+      matchFound = regex.test(node.nodeValue);
+    } else if (node.nodeType === Node.ELEMENT_NODE && node.hasAttribute('href')) {
+      const hrefValue = node.getAttribute('href');
+      matchFound = regex.test(hrefValue);
+    }
+    if (matchFound) {
+      nodes.push(node);
+      regex.lastIndex = 0;
+    }
     node = walker.nextNode();
   }
   return nodes;

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -54,6 +54,9 @@
     <p>I'm not a blockhead.</p>
     <p>{{&nbsp;inkl. MwSt.}}</p>
   </div>
+  <div>
+    <a href="tel:%7B%7Bphone-number-substance%7D%7D" class="placeholder"><sup>{{phone-number-substance}}</sup></a>
+  </div>
   <!-- picture element with poster video -->
   <div>
     <picture>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -230,6 +230,9 @@ describe('Utils', () => {
       const paragraphs = [...document.querySelectorAll('p')];
       const lastPara = paragraphs.pop();
       expect(lastPara.textContent).to.equal(' inkl. MwSt.');
+      const plceholderhref = document.querySelector('.placeholder');
+      const hrefValue = plceholderhref.getAttribute('href');
+      expect(hrefValue).to.equal('tel:phone number substance');
     });
 
     it('Decorates meta helix url', () => {


### PR DESCRIPTION
The phone number on the following pages is appearing correctly in the text but showing random characters in the link. Previously, using the placeholder for both the display text and link text displayed the number correctly.

Resolves: [[MWPW-157292]](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:

Before: https://main--milo--adobecom.hlx.live/drafts/suhjain/performance/marquee-light
After:https://placeholderOriginNew--milo--suhjainadobe.hlx.live/drafts/suhjain/performance/marquee-light
