### PR TITLE
MWPW-157887 [MEP] HTML elements like body need to be recognized and header simplified selector rename

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -360,10 +360,13 @@ function modifySelectorTerm(termParam) {
     'secondary-cta': 'em a',
     'action-area': '*:has(> em a, > strong a)',
     'any-marquee': '[class*="marquee"]',
-    header: ':is(h1, h2, h3, h4, h5, h6)',
+    'any-header': ':is(h1, h2, h3, h4, h5, h6)',
   };
   const otherSelectors = ['row', 'col'];
-  const htmlEls = ['main', 'div', 'a', 'p', 'strong', 'em', 'picture', 'source', 'img', 'h'];
+  const htmlEls = [
+    'html', 'body', 'header', 'footer', 'main',
+    'div', 'a', 'p', 'strong', 'em', 'picture', 'source', 'img', 'h',
+  ];
   const startTextMatch = term.match(/^[a-zA-Z/./-]*/);
   const startText = startTextMatch ? startTextMatch[0].toLowerCase() : '';
   const startTextPart1 = startText.split(/\.|:/)[0];

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -893,8 +893,6 @@ export function cleanAndSortManifestList(manifests) {
           freshManifest = manifestObj[manifest.manifestPath];
         }
         freshManifest.name = fullManifest.name;
-        freshManifest.selectedVariantName = fullManifest.selectedVariantName;
-        freshManifest.selectedVariant = freshManifest.variants[freshManifest.selectedVariantName];
         manifestObj[manifest.manifestPath] = freshManifest;
       } else {
         manifestObj[manifest.manifestPath] = manifest;

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -3,6 +3,18 @@ import { modifyNonFragmentSelector } from '../../../libs/features/personalizatio
 
 const values = [
   {
+    b: 'body > main > div',
+    a: 'body > main > div',
+  },
+  {
+    b: 'main header',
+    a: 'main header',
+  },
+  {
+    b: 'main footer',
+    a: 'main footer',
+  },
+  {
     b: 'any-marquee action-area',
     a: '[class*="marquee"] *:has(> em a, > strong a)',
   },
@@ -23,7 +35,7 @@ const values = [
     a: '.marquee.light:nth-child(2) h2',
   },
   {
-    b: 'marquee.light:nth-child(2) header',
+    b: 'marquee.light:nth-child(2) any-header',
     a: '.marquee.light:nth-child(2) :is(h1, h2, h3, h4, h5, h6)',
   },
   {


### PR DESCRIPTION
Detailed Description: selectors involving html elements like body break because MEP is not aware of them.
Changing "header" simplified selector to "any-header" since pages always have a header tag.
................................
URL: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepmorehtmlels/?mepHighlight=true
................................
Steps to Reproduce:
1. Go to URL above

Expected Results: should be 2 items highlighted, the new marquee header and a div below the marquee
................................
Actual Results: no highlighted items because nothing is added

Resolves: [MWPW-157887](https://jira.corp.adobe.com/browse/MWPW-157887)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepmorehtmlels/?mepHighlight=true&martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepmorehtmlels/?milolibs=mepmorehtmlels&mepHighlight=true&martech=off

- Psi-check: https://mepmorehtmlels--milo--adobecom.hlx.page/?martech=off

Also includes this approved PR to avoid conflicts: https://github.com/adobecom/milo/pull/2844