### PR TITLE
MWPW-154980 - Milo advanced page publishing

### DIFF
--- a/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
+++ b/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
@@ -96,10 +96,7 @@ class BulkPublish2 extends LitElement {
   }
 
   setJobErrors(jobErrors, authErrors) {
-    const errors = [
-      ...jobErrors,
-      ...authErrors.map((href) => ({ href, message: 'Not able to publish' })),
-    ];
+    const errors = [...jobErrors, ...authErrors];
     const urls = [];
     errors.forEach((error) => {
       const matched = this.urls.filter((url) => {

--- a/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
+++ b/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
@@ -1,7 +1,7 @@
 import './job-process.js';
 import { LitElement, html } from '../../../deps/lit-all.min.js';
 import { getSheet } from '../../../../tools/utils/utils.js';
-import { authenticate, startJob } from '../services.js';
+import { authenticate, getPublishable, startJob } from '../services.js';
 import { getConfig } from '../../../utils/utils.js';
 import {
   delay,
@@ -95,7 +95,11 @@ class BulkPublish2 extends LitElement {
     this.validateUrls();
   }
 
-  setJobErrors(errors) {
+  setJobErrors(jobErrors, authErrors) {
+    const errors = [
+      ...jobErrors,
+      ...authErrors.map((href) => ({ href, message: 'Not able to publish' })),
+    ];
     const urls = [];
     errors.forEach((error) => {
       const matched = this.urls.filter((url) => {
@@ -323,7 +327,8 @@ class BulkPublish2 extends LitElement {
         class="panel-title"
         @click=${handleToggle}>
         <span class="title">
-          Job Results
+          ${this.jobs.length ? html`<strong>${this.jobs.length}</strong>` : ''}
+          Job Result${this.jobs.length > 1 ? 's' : ''}
         </span>
         <div class="jobs-tools${showList}">
           <div 
@@ -380,16 +385,17 @@ class BulkPublish2 extends LitElement {
   async submit() {
     if (!this.isDisabled()) {
       this.processing = 'started';
+      const { authorized, unauthorized } = await getPublishable(this);
       const job = await startJob({
-        urls: this.urls,
+        urls: authorized,
         process: this.process.toLowerCase(),
         useBulk: this.user.permissions[this.process]?.useBulk ?? false,
       });
       const { complete, error } = processJobResult(job);
       this.jobs = [...this.jobs, ...complete];
       this.processing = complete.length ? 'job' : false;
-      if (error.length) {
-        this.setJobErrors(error);
+      if (error.length || unauthorized.length) {
+        this.setJobErrors(error, unauthorized);
       } else {
         if (this.mode === 'full') this.openJobs = true;
         this.reset();

--- a/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
+++ b/libs/blocks/bulk-publish-v2/components/bulk-publisher.js
@@ -410,6 +410,7 @@ class BulkPublish2 extends LitElement {
 
   renderPromptLoader() {
     setTimeout(() => {
+      /* c8 ignore next 4 */
       const loader = this.renderRoot.querySelector('.load-indicator');
       const message = this.renderRoot.querySelector('.message');
       loader?.classList.add('hide');
@@ -430,6 +431,7 @@ class BulkPublish2 extends LitElement {
         const canUse = Object.values(this.user.permissions).filter((perms) => perms.canUse);
         if (canUse.length) return html``;
         message = 'Current user is not authorized to use Bulk Publishing Tool';
+      /* c8 ignore next 3 */
       } else {
         message = 'Please sign in to AEM sidekick to continue';
       }

--- a/libs/blocks/bulk-publish-v2/services.js
+++ b/libs/blocks/bulk-publish-v2/services.js
@@ -1,4 +1,4 @@
-import { userCanPublishPage } from '../../utils/utils.js';
+import userCanPublishPage from '../../tools/utils/publish.js';
 import {
   PROCESS_TYPES,
   getErrorText,

--- a/libs/blocks/bulk-publish-v2/services.js
+++ b/libs/blocks/bulk-publish-v2/services.js
@@ -247,7 +247,7 @@ const updateRetry = async ({ queue, urls, process }) => {
   return newQueue;
 };
 
-// publish authentication services
+// publish authentication service
 const getPublishable = async ({ urls, process, user }) => {
   let publishable = { authorized: [], unauthorized: [] };
   if (!isLive(process)) {
@@ -261,8 +261,9 @@ const getPublishable = async ({ urls, process, user }) => {
     publishable = await urls.reduce(async (init, url) => {
       const result = await init;
       const detail = { webPath: new URL(url).pathname, live, profile };
-      const auth = await userCanPublishPage(detail);
-      result[`${auth ? '' : 'un'}authorized`].push(url);
+      const { canPublish, message } = await userCanPublishPage(detail);
+      if (canPublish) result.authorized.push(url);
+      else result.unauthorized.push({ href: url, message });
       return result;
     }, Promise.resolve(publishable));
   }

--- a/libs/tools/utils/publish.js
+++ b/libs/tools/utils/publish.js
@@ -1,0 +1,32 @@
+import { getCustomConfig } from '../../../tools/utils/utils.js';
+
+const userCanPublishPage = async (detail, isBulk = true) => {
+  if (!detail) return false;
+  const { live, profile, webPath } = detail;
+  let canPublish = isBulk ? live?.permissions?.includes('write') : true;
+  let message = 'Publishing is currently disabled for this page';
+  const config = await getCustomConfig('/.milo/publish-permissions-config.json');
+  const item = config?.urls?.data?.find(({ url }) => (
+    url.endsWith('**') ? webPath.includes(url.slice(0, -2)) : url === webPath
+  ));
+  if (item) {
+    canPublish = false;
+    if (item.message) message = item.message;
+    const group = config[item.group];
+    if (group && profile?.email) {
+      let isDeny;
+      const user = group.data?.find(({ allow, deny }) => {
+        if (deny) {
+          /* c8 ignore next 3 */
+          isDeny = true;
+          return deny === profile.email;
+        }
+        return allow === profile.email;
+      });
+      canPublish = isDeny ? !user : !!user;
+    }
+  }
+  return { canPublish, message };
+};
+
+export default userCanPublishPage;

--- a/libs/utils/sidekick-decorate.js
+++ b/libs/utils/sidekick-decorate.js
@@ -2,18 +2,17 @@ import { userCanPublishPage } from './utils.js';
 
 const PUBLISH_BTN = '.publish.plugin button';
 const CONFIRM_MESSAGE = 'Are you sure? This will publish to production.';
-const NO_AUTH_MESSAGE = 'This page currently cannot be published';
 
 export default function stylePublish(sk) {
   sk.addEventListener('statusfetched', async (event) => {
-    const thisPage = event?.detail?.data;
-    const enablePublish = await userCanPublishPage(thisPage);
-    const publishBtn = event?.target?.shadowRoot?.querySelector(PUBLISH_BTN);
-    if (publishBtn) {
-      publishBtn.setAttribute('disabled', !enablePublish);
-      const message = publishBtn.querySelector('span');
-      if (message) {
-        message.innerText = enablePublish ? CONFIRM_MESSAGE : NO_AUTH_MESSAGE;
+    const page = event?.detail?.data;
+    const { canPublish, message } = await userCanPublishPage(page);
+    const btn = event?.target?.shadowRoot?.querySelector(PUBLISH_BTN);
+    if (btn) {
+      btn.setAttribute('disabled', !canPublish);
+      const messageText = btn.querySelector('span');
+      if (messageText) {
+        messageText.innerText = canPublish ? CONFIRM_MESSAGE : message;
       }
     }
   });
@@ -73,6 +72,7 @@ export default function stylePublish(sk) {
   sk.shadowRoot.adoptedStyleSheets = [style];
   setTimeout(() => {
     const btn = sk.shadowRoot.querySelector(PUBLISH_BTN);
+    btn?.setAttribute('disabled', true);
     btn?.insertAdjacentHTML('beforeend', `<span>${CONFIRM_MESSAGE}</span>`);
   }, 800);
 }

--- a/libs/utils/sidekick-decorate.js
+++ b/libs/utils/sidekick-decorate.js
@@ -74,5 +74,5 @@ export default function stylePublish(sk) {
     const btn = sk.shadowRoot.querySelector(PUBLISH_BTN);
     btn?.setAttribute('disabled', true);
     btn?.insertAdjacentHTML('beforeend', `<span>${CONFIRM_MESSAGE}</span>`);
-  }, 800);
+  }, 500);
 }

--- a/libs/utils/sidekick-decorate.js
+++ b/libs/utils/sidekick-decorate.js
@@ -1,4 +1,4 @@
-import { userCanPublishPage } from './utils.js';
+import userCanPublishPage from '../tools/utils/publish.js';
 
 const PUBLISH_BTN = '.publish.plugin button';
 const BACKUP_PROFILE = '.profile-email';

--- a/libs/utils/sidekick-decorate.js
+++ b/libs/utils/sidekick-decorate.js
@@ -1,4 +1,4 @@
-import { miloUserCanPublish } from './utils.js';
+import { userCanPublishPage } from './utils.js';
 
 const PUBLISH_BTN = '.publish.plugin button';
 const CONFIRM_MESSAGE = 'Are you sure? This will publish to production.';
@@ -7,7 +7,7 @@ const NO_AUTH_MESSAGE = 'This page currently cannot be published';
 export default function stylePublish(sk) {
   sk.addEventListener('statusfetched', async (event) => {
     const thisPage = event?.detail?.data;
-    const enablePublish = await miloUserCanPublish(thisPage);
+    const enablePublish = await userCanPublishPage(thisPage);
     const publishBtn = event?.target?.shadowRoot?.querySelector(PUBLISH_BTN);
     if (publishBtn) {
       publishBtn.setAttribute('disabled', !enablePublish);

--- a/libs/utils/sidekick-decorate.js
+++ b/libs/utils/sidekick-decorate.js
@@ -1,21 +1,21 @@
 import { userCanPublishPage } from './utils.js';
 
 const PUBLISH_BTN = '.publish.plugin button';
+const BACKUP_PROFILE = '.profile-email';
 const CONFIRM_MESSAGE = 'Are you sure? This will publish to production.';
 
 export default function stylePublish(sk) {
-  sk.addEventListener('statusfetched', async (event) => {
-    const page = event?.detail?.data;
-    const { canPublish, message } = await userCanPublishPage(page);
-    const btn = event?.target?.shadowRoot?.querySelector(PUBLISH_BTN);
-    if (btn) {
-      btn.setAttribute('disabled', !canPublish);
-      const messageText = btn.querySelector('span');
-      if (messageText) {
-        messageText.innerText = canPublish ? CONFIRM_MESSAGE : message;
-      }
+  const setupPublishBtn = async (page, btn) => {
+    const { canPublish, message } = await userCanPublishPage(page, false);
+    btn.setAttribute('disabled', !canPublish);
+    const messageText = btn.querySelector('span');
+    const text = canPublish ? CONFIRM_MESSAGE : message;
+    if (messageText) {
+      messageText.innerText = text;
+    } else {
+      btn.insertAdjacentHTML('beforeend', `<span>${text}</span>`);
     }
-  });
+  };
 
   const style = new CSSStyleSheet();
   style.replaceSync(`
@@ -42,7 +42,7 @@ export default function stylePublish(sk) {
     }
     .publish.plugin button > span {
       display: none;
-      background: var(--bg-color);
+      background: #666;
       border-radius: 4px;
       line-height: 1.2rem;
       padding: 8px 12px;
@@ -53,6 +53,9 @@ export default function stylePublish(sk) {
       width: 150px;
       white-space: pre-wrap;
     }
+    .publish.plugin button:not([disabled=true]) > span {
+      background: var(--bg-color);
+    }
     .publish.plugin button:hover > span {
       display: block;
       color: var(--text-color);
@@ -61,18 +64,39 @@ export default function stylePublish(sk) {
       content: '';
       border-left: 6px solid transparent;
       border-right: 6px solid transparent;
-      border-bottom: 6px solid var(--bg-color);
+      border-bottom: 6px solid #666;
       position: absolute;
       text-align: center;
       top: -6px;
       left: 50%;
       transform: translateX(-50%);
     }
+    .publish.plugin button:not([disabled=true]) > span:before {
+      border-bottom: 6px solid var(--bg-color);
+    }
   `);
+
   sk.shadowRoot.adoptedStyleSheets = [style];
-  setTimeout(() => {
+
+  sk.addEventListener('statusfetched', async (event) => {
+    const page = event?.detail?.data;
+    const btn = event?.target?.shadowRoot?.querySelector(PUBLISH_BTN);
+    if (page && btn) {
+      setupPublishBtn(page, btn);
+    }
+  });
+
+  setTimeout(async () => {
     const btn = sk.shadowRoot.querySelector(PUBLISH_BTN);
     btn?.setAttribute('disabled', true);
-    btn?.insertAdjacentHTML('beforeend', `<span>${CONFIRM_MESSAGE}</span>`);
+    const message = btn?.querySelector('span');
+    if (btn && !message) {
+      const page = {
+        webPath: window.location.pathname,
+        // added for edge case where the statusfetched event isnt fired on refresh
+        profile: { email: sk.shadowRoot.querySelector(BACKUP_PROFILE)?.innerText },
+      };
+      setupPublishBtn(page, btn);
+    }
   }, 500);
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1298,35 +1298,31 @@ export function loadLana(options = {}) {
 
 export const reloadPage = () => window.location.reload();
 
-export const userCanPublishPage = async (detail) => {
+export const userCanPublishPage = async (detail, isBulk = true) => {
   if (!detail) return false;
   const { live, profile, webPath } = detail;
-  let canPublish = live?.permissions?.includes('write');
-  let message = canPublish === undefined
-    ? 'Please sign into sidekick to publish this page'
-    : 'Publishing is currently disabled for this page';
-  if (canPublish) {
-    const config = await getCustomConfig('/.milo/publish-permissions-config.json');
-    if (config) {
-      const item = config.urls?.data?.find(({ url }) => (
-        url.endsWith('**') ? webPath.includes(url.slice(0, -2)) : url === webPath
-      ));
-      if (item) {
-        canPublish = false;
-        if (item.message) message = item.message;
-        const group = config[item.group];
-        if (group && profile?.email) {
-          let isDeny;
-          const user = group.data?.find(({ allow, deny }) => {
-            if (deny) {
-              /* c8 ignore next 3 */
-              isDeny = true;
-              return deny === profile.email;
-            }
-            return allow === profile.email;
-          });
-          canPublish = isDeny ? !user : !!user;
-        }
+  let canPublish = isBulk ? live?.permissions?.includes('write') : true;
+  let message = 'Publishing is currently disabled for this page';
+  const config = await getCustomConfig('/.milo/publish-permissions-config.json');
+  if (config) {
+    const item = config.urls?.data?.find(({ url }) => (
+      url.endsWith('**') ? webPath.includes(url.slice(0, -2)) : url === webPath
+    ));
+    if (item) {
+      canPublish = false;
+      if (item.message) message = item.message;
+      const group = config[item.group];
+      if (group && profile?.email) {
+        let isDeny;
+        const user = group.data?.find(({ allow, deny }) => {
+          if (deny) {
+            /* c8 ignore next 3 */
+            isDeny = true;
+            return deny === profile.email;
+          }
+          return allow === profile.email;
+        });
+        canPublish = isDeny ? !user : !!user;
       }
     }
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1317,6 +1317,7 @@ export const userCanPublishPage = async (detail) => {
           let isDeny;
           const user = group.data?.find(({ allow, deny }) => {
             if (deny) {
+              /* c8 ignore next 3 */
               isDeny = true;
               return deny === profile.email;
             }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1298,15 +1298,15 @@ export function loadLana(options = {}) {
 
 export const reloadPage = () => window.location.reload();
 
-export const miloUserCanPublish = async (page) => {
-  if (!page) return false;
+export const userCanPublishPage = async (detail) => {
+  if (!detail) return false;
   // sidekick status detail
-  const { live, profile, webPath } = page;
+  const { live, profile, webPath } = detail;
   let canPublish = live?.permissions?.includes('write');
   // check custom publish permissions config
   const config = await getCustomConfig('/.milo/publish-permissions-config.json');
   if (canPublish && config) {
-    // supporting only one wildcard(**)
+    // supporting one wildcard (**)
     const item = config.urls?.data?.find(({ url }) => (
       url.endsWith('**') ? webPath.includes(url.slice(0, -2)) : url === webPath
     ));

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1302,7 +1302,9 @@ export const userCanPublishPage = async (detail) => {
   if (!detail) return false;
   const { live, profile, webPath } = detail;
   let canPublish = live?.permissions?.includes('write');
-  let message = 'Publishing is currently disabled for this page';
+  let message = canPublish === undefined
+    ? 'Please sign into sidekick to publish this page'
+    : 'Publishing is currently disabled for this page';
   if (canPublish) {
     const config = await getCustomConfig('/.milo/publish-permissions-config.json');
     if (config) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1304,26 +1304,24 @@ export const userCanPublishPage = async (detail, isBulk = true) => {
   let canPublish = isBulk ? live?.permissions?.includes('write') : true;
   let message = 'Publishing is currently disabled for this page';
   const config = await getCustomConfig('/.milo/publish-permissions-config.json');
-  if (config) {
-    const item = config.urls?.data?.find(({ url }) => (
-      url.endsWith('**') ? webPath.includes(url.slice(0, -2)) : url === webPath
-    ));
-    if (item) {
-      canPublish = false;
-      if (item.message) message = item.message;
-      const group = config[item.group];
-      if (group && profile?.email) {
-        let isDeny;
-        const user = group.data?.find(({ allow, deny }) => {
-          if (deny) {
-            /* c8 ignore next 3 */
-            isDeny = true;
-            return deny === profile.email;
-          }
-          return allow === profile.email;
-        });
-        canPublish = isDeny ? !user : !!user;
-      }
+  const item = config?.urls?.data?.find(({ url }) => (
+    url.endsWith('**') ? webPath.includes(url.slice(0, -2)) : url === webPath
+  ));
+  if (item) {
+    canPublish = false;
+    if (item.message) message = item.message;
+    const group = config[item.group];
+    if (group && profile?.email) {
+      let isDeny;
+      const user = group.data?.find(({ allow, deny }) => {
+        if (deny) {
+          /* c8 ignore next 3 */
+          isDeny = true;
+          return deny === profile.email;
+        }
+        return allow === profile.email;
+      });
+      canPublish = isDeny ? !user : !!user;
     }
   }
   return { canPublish, message };

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
 
-import { getCustomConfig } from '../../tools/utils/utils.js';
-
 const MILO_TEMPLATES = [
   '404',
   'featured-story',
@@ -1297,32 +1295,3 @@ export function loadLana(options = {}) {
 }
 
 export const reloadPage = () => window.location.reload();
-
-export const userCanPublishPage = async (detail, isBulk = true) => {
-  if (!detail) return false;
-  const { live, profile, webPath } = detail;
-  let canPublish = isBulk ? live?.permissions?.includes('write') : true;
-  let message = 'Publishing is currently disabled for this page';
-  const config = await getCustomConfig('/.milo/publish-permissions-config.json');
-  const item = config?.urls?.data?.find(({ url }) => (
-    url.endsWith('**') ? webPath.includes(url.slice(0, -2)) : url === webPath
-  ));
-  if (item) {
-    canPublish = false;
-    if (item.message) message = item.message;
-    const group = config[item.group];
-    if (group && profile?.email) {
-      let isDeny;
-      const user = group.data?.find(({ allow, deny }) => {
-        if (deny) {
-          /* c8 ignore next 3 */
-          isDeny = true;
-          return deny === profile.email;
-        }
-        return allow === profile.email;
-      });
-      canPublish = isDeny ? !user : !!user;
-    }
-  }
-  return { canPublish, message };
-};

--- a/test/blocks/bulk-publish-v2/bulk-publish-v2.test.js
+++ b/test/blocks/bulk-publish-v2/bulk-publish-v2.test.js
@@ -114,14 +114,6 @@ describe('Bulk Publish Tool', () => {
     await mouseEvent(rootEl.querySelector('.fix-btn'));
   });
 
-  it('can validate milo urls and enable form', async () => {
-    await clock.runAllAsync();
-    await setProcess(rootEl, 'publish');
-    await setTextArea(rootEl, testPage);
-    expect(rootEl.querySelector('#RunProcess').getAttribute('disable')).to.equal('false');
-    bulkPub.clearJobs();
-  });
-
   it('can trigger cannot publish config', async () => {
     await clock.runAllAsync();
     await setProcess(rootEl, 'publish');
@@ -132,6 +124,14 @@ describe('Bulk Publish Tool', () => {
     await mouseEvent(rootEl.querySelector('.fix-btn'));
   });
 
+  it('can validate milo urls and enable form', async () => {
+    await clock.runAllAsync();
+    await setProcess(rootEl, 'publish');
+    await setTextArea(rootEl, testPage);
+    expect(rootEl.querySelector('#RunProcess').getAttribute('disable')).to.equal('false');
+    bulkPub.clearJobs();
+  });
+
   it('can submit valid bulk publish job', async () => {
     await clock.runAllAsync();
     await mouseEvent(rootEl.querySelector('.switch.full'));
@@ -140,6 +140,17 @@ describe('Bulk Publish Tool', () => {
     await mouseEvent(rootEl.querySelector('#RunProcess'));
     expect(rootEl.querySelectorAll('job-process')).to.have.lengthOf(1);
     await mouseEvent(rootEl.querySelector('.switch.half'));
+  });
+
+  it('can toggle job timing flyout', async () => {
+    await clock.runAllAsync();
+    const doneJobProcess = rootEl.querySelector('job-process');
+    const jobInfo = doneJobProcess?.shadowRoot.querySelector('job-info');
+    const timerDetail = jobInfo?.shadowRoot.querySelector('.timer');
+    await mouseEvent(timerDetail);
+    await clock.runAllAsync();
+    await mouseEvent(timerDetail);
+    expect(timerDetail.classList.contains('show-times')).to.be.false;
   });
 
   it('can submit valid bulk preview job', async () => {
@@ -184,17 +195,6 @@ describe('Bulk Publish Tool', () => {
     expect(rootEl.querySelectorAll('job-process')).to.have.lengthOf(4);
   });
 
-  it('can toggle job timing flyout', async () => {
-    await clock.runAllAsync();
-    const doneJobProcess = rootEl.querySelector('job-process');
-    const jobInfo = doneJobProcess?.shadowRoot.querySelector('job-info');
-    const timerDetail = jobInfo?.shadowRoot.querySelector('.timer');
-    await mouseEvent(timerDetail);
-    await clock.runAllAsync();
-    await mouseEvent(timerDetail);
-    expect(timerDetail.classList.contains('show-times')).to.be.false;
-  });
-
   it('can toggle view mode', async () => {
     await mouseEvent(rootEl.querySelector('.switch.full'));
     await clock.runAllAsync();
@@ -228,7 +228,6 @@ describe('Bulk Publish Tool', () => {
   it('can clear bulk jobs', async () => {
     await clock.runAllAsync();
     await mouseEvent(rootEl.querySelector('.clear-jobs'));
-    await clock.runAllAsync();
     expect(rootEl.querySelectorAll('job-process')).to.have.lengthOf(0);
   });
 });

--- a/test/blocks/bulk-publish-v2/bulk-publish-v2.test.js
+++ b/test/blocks/bulk-publish-v2/bulk-publish-v2.test.js
@@ -122,6 +122,16 @@ describe('Bulk Publish Tool', () => {
     bulkPub.clearJobs();
   });
 
+  it('can trigger cannot publish config', async () => {
+    await clock.runAllAsync();
+    await setProcess(rootEl, 'publish');
+    await setTextArea(rootEl, 'https://error--milo--adobecom.hlx.page/not/a/valid/path');
+    await mouseEvent(rootEl.querySelector('#RunProcess'));
+    const errors = rootEl.querySelector('.errors');
+    expect(errors.querySelector('strong').innerText).to.equal('Publishing disabled until the test is over');
+    await mouseEvent(rootEl.querySelector('.fix-btn'));
+  });
+
   it('can submit valid bulk publish job', async () => {
     await clock.runAllAsync();
     await mouseEvent(rootEl.querySelector('.switch.full'));

--- a/test/blocks/bulk-publish-v2/mocks/authentication.js
+++ b/test/blocks/bulk-publish-v2/mocks/authentication.js
@@ -23,7 +23,7 @@ class MockAuth extends HTMLElement {
       bubbles: true,
       detail: {
         data: {
-          profile: { name: 'Unit Test' },
+          profile: { name: 'Unit Test', email: 'tester@adobe.com' },
           preview: { permissions },
           live: { permissions },
         },

--- a/test/blocks/bulk-publish-v2/mocks/fetch.js
+++ b/test/blocks/bulk-publish-v2/mocks/fetch.js
@@ -11,6 +11,7 @@ const requests = {
   delstatus: 'https://admin.hlx.page/job/adobecom/milo/main/preview-remove/job-2024-01-24t23-16-20-377z/details',
   retry: 'https://admin.hlx.page/preview/adobecom/milo/main/tools/bulk-publish-v2-test',
   index: 'https://admin.hlx.page/index/adobecom/milo/main/tools/bulk-publish-v2-test',
+  permissions: '/.milo/publish-permissions-config.json',
 };
 
 const getMocks = async () => {
@@ -25,7 +26,7 @@ const getMocks = async () => {
 export async function mockFetch() {
   const mocks = await getMocks();
   stub(window, 'fetch').callsFake((...args) => {
-    const headers = args[1].body ?? null;
+    const headers = args[1]?.body ?? null;
     const body = headers ? JSON.parse(headers) : false;
     const [resource] = args;
     const response = mocks.find((mock) => (body.delete ? mock.request === 'delete' : mock.url === resource));

--- a/test/blocks/bulk-publish-v2/mocks/response/permissions.json
+++ b/test/blocks/bulk-publish-v2/mocks/response/permissions.json
@@ -5,28 +5,13 @@
     "limit": 4,
     "data": [
       {
-        "url": "/drafts/sarchibeque/video-test",
-        "group": "gwp-US",
-        "message": "Publishing disabled until September 10th"
-      },
-      {
-        "url": "/drafts/sarchibeque/aside-variations",
-        "group": "gwp-FR",
-        "message": ""
-      },
-      {
-        "url": "/drafts/sarchibeque/fragments/**",
-        "group": "gwp-US",
-        "message": ""
-      },
-      {
-        "url": "/drafts/sarchibeque/aside-links",
-        "group": "no-publish",
-        "message": ""
+        "url": "/not/a/valid/path",
+        "group": "gwp-test",
+        "message": "Publishing disabled until the test is over"
       }
     ]
   },
-  "gwp-US": {
+  "gwp-test": {
     "total": 2,
     "offset": 0,
     "limit": 2,
@@ -34,18 +19,6 @@
       { "allow": "testuser@adobe.com" },
       { "allow": "testuser1@adobe.com" }
     ]
-  },
-  "no-publish": {
-    "total": 2,
-    "offset": 0,
-    "limit": 2,
-    "data": [{ "deny": "user@adobe.com" }, { "deny": "thi62185@adobe.com" }]
-  },
-  "gwp-FR": {
-    "total": 1,
-    "offset": 0,
-    "limit": 1,
-    "data": [{ "allow": "thi62185@adobe.com" }]
   },
   ":version": 3,
   ":names": ["urls", "gwp-US", "no-publish", "gwp-FR"],

--- a/test/blocks/bulk-publish-v2/mocks/response/permissions.json
+++ b/test/blocks/bulk-publish-v2/mocks/response/permissions.json
@@ -1,0 +1,53 @@
+{
+  "urls": {
+    "total": 4,
+    "offset": 0,
+    "limit": 4,
+    "data": [
+      {
+        "url": "/drafts/sarchibeque/video-test",
+        "group": "gwp-US",
+        "message": "Publishing disabled until September 10th"
+      },
+      {
+        "url": "/drafts/sarchibeque/aside-variations",
+        "group": "gwp-FR",
+        "message": ""
+      },
+      {
+        "url": "/drafts/sarchibeque/fragments/**",
+        "group": "gwp-US",
+        "message": ""
+      },
+      {
+        "url": "/drafts/sarchibeque/aside-links",
+        "group": "no-publish",
+        "message": ""
+      }
+    ]
+  },
+  "gwp-US": {
+    "total": 2,
+    "offset": 0,
+    "limit": 2,
+    "data": [
+      { "allow": "testuser@adobe.com" },
+      { "allow": "testuser1@adobe.com" }
+    ]
+  },
+  "no-publish": {
+    "total": 2,
+    "offset": 0,
+    "limit": 2,
+    "data": [{ "deny": "user@adobe.com" }, { "deny": "thi62185@adobe.com" }]
+  },
+  "gwp-FR": {
+    "total": 1,
+    "offset": 0,
+    "limit": 1,
+    "data": [{ "allow": "thi62185@adobe.com" }]
+  },
+  ":version": 3,
+  ":names": ["urls", "gwp-US", "no-publish", "gwp-FR"],
+  ":type": "multi-sheet"
+}

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -34,7 +34,8 @@ const getCustomConfig = async (path) => {
   let config = null;
   const resp = await fetch(path);
   if (resp.ok) {
-    config = await resp.json();
+    const json = await resp.json();
+    config = json;
   }
   CONFIGS[path] = config;
   return CONFIGS[path];

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -34,8 +34,7 @@ const getCustomConfig = async (path) => {
   let config = null;
   const resp = await fetch(path);
   if (resp.ok) {
-    const json = await resp.json();
-    config = json;
+    config = await resp.json();
   }
   CONFIGS[path] = config;
   return CONFIGS[path];

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -31,13 +31,10 @@ const getCustomConfig = async (path) => {
   if (CONFIGS[path] !== undefined) {
     return CONFIGS[path];
   }
-  let config = null;
   const resp = await fetch(path);
-  if (resp.ok) {
-    config = await resp.json();
-  }
+  const config = resp.ok ? await resp.json() : null;
   CONFIGS[path] = config;
-  return CONFIGS[path];
+  return config;
 };
 
 export { getImsToken, getSheet, getCustomConfig };

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -27,6 +27,7 @@ const getSheet = async (url) => {
 };
 
 const getCustomConfig = async (path) => {
+  /* c8 ignore next 3 */
   if (CONFIGS[path] !== undefined) {
     return CONFIGS[path];
   }

--- a/tools/utils/utils.js
+++ b/tools/utils/utils.js
@@ -1,6 +1,7 @@
 const IMS_CLIENT_ID = 'milo_ims';
 const IMS_PROD_URL = 'https://auth.services.adobe.com/imslib/imslib.min.js';
 const STYLE_SHEETS = {};
+const CONFIGS = {};
 
 const getImsToken = async (loadScript) => {
   window.adobeid = {
@@ -25,4 +26,18 @@ const getSheet = async (url) => {
   return sheet;
 };
 
-export { getImsToken, getSheet };
+const getCustomConfig = async (path) => {
+  if (CONFIGS[path] !== undefined) {
+    return CONFIGS[path];
+  }
+  let config = null;
+  const resp = await fetch(path);
+  if (resp.ok) {
+    const json = await resp.json();
+    config = json;
+  }
+  CONFIGS[path] = config;
+  return CONFIGS[path];
+};
+
+export { getImsToken, getSheet, getCustomConfig };


### PR DESCRIPTION
As a web producer, I want to limit who can publish certain files so that files are not published prematurely before planned launches.

New Feature Includes:
- Ability to fetch an optional custom configuration file from path `.milo/publish-permissions-config` to apply advanced publishing rules on a per page basis.
- New functionality will disable the publish button in AEM sidekick if path matches an item (url pathname) in the configuration file and can also reference a group with optional `allow/deny` user list which then compares the list to the email of profile that is currently logged into sidekick.
- Bulk Publish v2 tool will also check paths in the job list for item configuration and refuse to publish urls that have been configured unless of course the currently logged in user has permissions.

Resolves: [MWPW-154980](https://jira.corp.adobe.com/browse/MWPW-154980)

**Testing Details:**
1. _Sidekick Publishing:_ Go to the test url page -> open sidekick -> verify publish button is disabled.
2. _Bulk Tool Publishing:_ Go to [BP Tool](https://sartxi-mwpw-154980-publishing--milo--adobecom.hlx.page/tools/bulk-publish) -> Publish test page URL -> see error thrown with message.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/video-test?martech=off
- After: https://sartxi-mwpw-154980-publishing--milo--adobecom.hlx.page/drafts/sarchibeque/video-test?martech=off
