### PR TITLE
Set expiry of 'international' cookie for 1 year for selection of region from region selector

### DIFF
--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -3,7 +3,8 @@ import { getConfig } from '../../utils/utils.js';
 /* c8 ignore next 11 */
 function handleEvent(prefix, link) {
   const domain = window.location.host.endsWith('.adobe.com') ? 'domain=adobe.com' : '';
-  document.cookie = `international=${prefix};path=/;${domain}`;
+  const maxAge = 365 * 24 * 60 * 60; // max-age in seconds for 365 days
+  document.cookie = `international=${prefix};max-age=${maxAge};path=/;${domain}`;
   sessionStorage.setItem('international', prefix);
   fetch(link.href, { method: 'HEAD' }).then((resp) => {
     if (!resp.ok) throw new Error('request failed');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Added expiry of 'international' cookie as 1 year for selecting a region from region selector. Similar, like we already have this for AEM dexter pages.

Before:
<img width="1800" alt="Screenshot 2024-09-09 at 2 16 54 PM" src="https://github.com/user-attachments/assets/25af1c1e-d553-4494-a7d9-d64f060be73b">

After:
<img width="1800" alt="Screenshot 2024-09-09 at 2 26 21 PM" src="https://github.com/user-attachments/assets/1284c030-2e00-475c-91ae-f78b7b06bce3">

Resolves: [MWPW-157238](https://jira.corp.adobe.com/browse/MWPW-157238)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-157238--milo--deva309.hlx.page/drafts/devashish/wam?martech=off
