### PR TITLE
[MWPW-157740] Table pricing gutter

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -264,6 +264,7 @@
 
 .table .section-row .col {
   padding: 16px 24px;
+  column-gap: 0.5ch;
 }
 
 .table .section-row .col:has(> p:nth-child(2)) {


### PR DESCRIPTION
Multiple elements can be added to a table column. There is currently no separation between them; since such columns mostly contain text (wrapped in their own elements), the gap has been set to be close to a space character.

| Before | After |
| ------------- | ------------- |
| <img width="1216" alt="Screenshot 2024-09-09 at 17 14 38" src="https://github.com/user-attachments/assets/2297ad4a-24d9-4a55-b941-2d1acab69b8a"> | <img width="1216" alt="Screenshot 2024-09-09 at 17 15 52" src="https://github.com/user-attachments/assets/9b1e8acc-2755-46c8-848a-c45559e46b05"> |

Resolves: [MWPW-157740](https://jira.corp.adobe.com/browse/MWPW-157740)

**Test URLs:**
- Before: https://stage--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-mwpw-152305?martech=off&georouting=off
- After: https://table-pricing-gutter--milo--overmyheadandbody.hlx.page/drafts/ramuntea/table-tiger-team-mwpw-152305?martech=off&georouting=off

**Initial issue:**
- Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/promos/2024/americas/black-friday/products/substance3d/plans/creativecloud/table?martech=off&georouting=off
- After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/promos/2024/americas/black-friday/products/substance3d/plans/creativecloud/table?martech=off&georouting=off&milolibs=table-pricing-gutter--milo--overmyheadandbody
