### PR TITLE
MWPW-158059 [MEP] PHONE_SIZE limit is too large to exclude smaller tablets

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -7,7 +7,7 @@ import {
 import { getEntitlementMap } from './entitlements.js';
 
 /* c8 ignore start */
-const PHONE_SIZE = window.screen.width < 600 || window.screen.height < 600;
+const PHONE_SIZE = window.screen.width < 550 || window.screen.height < 550;
 export const PERSONALIZATION_TAGS = {
   all: () => true,
   chrome: () => navigator.userAgent.includes('Chrome') && !navigator.userAgent.includes('Edg'),

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -7,7 +7,7 @@ import {
 import { getEntitlementMap } from './entitlements.js';
 
 /* c8 ignore start */
-const PHONE_SIZE = window.screen.width < 768 || window.screen.height < 768;
+const PHONE_SIZE = window.screen.width < 600 || window.screen.height < 600;
 export const PERSONALIZATION_TAGS = {
   all: () => true,
   chrome: () => navigator.userAgent.includes('Chrome') && !navigator.userAgent.includes('Edg'),


### PR DESCRIPTION
Note: this is listed a high priority because it is needed for MAX.

Detailed Description: experience columns using tablet are not catching smaller tablets
................................
URL: https://main--cc--adobecom.hlx.page/products/photoshop-lightroom/features?target=off&mep=
................................
Steps to Reproduce:
1. Simulate a device that is android and tablet
2. Go to the link above (choosing any samsung tab) should work

Expected Results: MEP button indicates Android & Tablet is chosen
................................
Actual Results: MEP button indicates mobile-device is chosen

Resolves: [MWPW-158059](https://jira.corp.adobe.com/browse/MWPW-158059)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/photoshop-lightroom/features?target=off&martech=off
- After: https://main--cc--adobecom.hlx.page/products/photoshop-lightroom/features?milolibs=meptablet&target=off&martech=off
- Psi-check: https://meptablet--milo--adobecom.hlx.page/?martech=off
