### PR TITLE
MWPW-157888 - Hero marquee w/ `no-min-height` and no l/r padding when using a `full-width` variant

### DIFF
--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -17,6 +17,7 @@
   align-items: center;
 }
 
+.hero-marquee.no-min-height { min-height: unset; }
 .hero-marquee.s-min-height { min-height: var(--s-min-height); }
 .hero-marquee.l-min-height { min-height: var(--l-min-height); }
 

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -133,14 +133,16 @@ function loadBreakpointThemes() {
 export default async function init(el) {
   el.classList.add('con-block');
   let rows = el.querySelectorAll(':scope > div');
-  if (rows.length > 1 && rows[0].textContent !== '') {
+  if (rows.length <= 1) return;
+  const [head, ...tail] = rows;
+  rows = tail;
+  if (head.textContent.trim() === '') {
+    head.remove();
+  } else {
     el.classList.add('has-bg');
-    const [head, ...tail] = rows;
     handleObjectFit(head);
     decorateBlockBg(el, head, { useHandleFocalpoint: true });
-    rows = tail;
   }
-
   // get first row that's not a keyword key/value row
   const mainRowIndex = rows.findIndex((row) => {
     const firstColText = row.children[0].textContent.toLowerCase().trim();


### PR DESCRIPTION
As and author in a milo project using a  [hero-marquee]

1) I want to use this block with out a minimal height so the block has a natural height based on content. 
2) I want to use this block in an ups grid w/ the variant `full-width` and not have the extra left/right padding seen in this scenario. 

Example screenshot - Notice the block height is huge, the l/r padding is causing the block to go outside its bounds. 
<img width="1211" alt="Screen Shot 2024-09-10 at 12 13 11 PM" src="https://github.com/user-attachments/assets/6bbb10d6-2962-4b47-bbe1-088326ab7c63">

---

Fixed
1) Add a `no-min-height` variant to the hero-marquee. 
2) Address padding issue on hero-block. Erroneously comes from the `has-bg` class being added. 

Resolves: [MWPW-157888](https://jira.corp.adobe.com/browse/MWPW-157888)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/steenmeyer/hero-editorial-layout-pattern-examples/hero-editorial-no-min-height-masonry1?martech=off
- After: https://rparrish-hero-no-min--milo--adobecom.hlx.page/drafts/steenmeyer/hero-editorial-layout-pattern-examples/hero-editorial-no-min-height-masonry1?martech=off