### PR TITLE
MWPW-158148 [MEP] Can't use ul, ol or li in MEP selectorsf

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -366,6 +366,7 @@ function modifySelectorTerm(termParam) {
   const htmlEls = [
     'html', 'body', 'header', 'footer', 'main',
     'div', 'a', 'p', 'strong', 'em', 'picture', 'source', 'img', 'h',
+    'ul', 'ol', 'li',
   ];
   const startTextMatch = term.match(/^[a-zA-Z/./-]*/);
   const startText = startTextMatch ? startTextMatch[0].toLowerCase() : '';

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -135,6 +135,14 @@ const values = [
     b: 'custom-block3',
     a: '.custom-block:nth-child(3 of .custom-block)',
   },
+  {
+    b: 'any-marquee ol li:nth-child(2)',
+    a: '[class*="marquee"] ol li:nth-child(2)',
+  },
+  {
+    b: 'any-marquee ul li:nth-child(2)',
+    a: '[class*="marquee"] ul li:nth-child(2)',
+  },
 ];
 describe('test different values', () => {
   values.forEach((value) => {


### PR DESCRIPTION
* Can't use ul, ol or li in MEP selectors because it does not know they are HTML elements

Resolves: [MWPW-158148](https://jira.corp.adobe.com/browse/MWPW-158148)

QA instructions: Should see bippity boppity text in bullet list
**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/cgarrett/logged-in-training/li-training-test?mep=%2Fdrafts%2Fcgarrett%2Flogged-in-training%2Fli-training-test.json--heromarquee-bodycopy
- After: https://main--cc--adobecom.hlx.page/drafts/cgarrett/logged-in-training/li-training-test?milolibs=mepul&mep=%2Fdrafts%2Fcgarrett%2Flogged-in-training%2Fli-training-test.json--heromarquee-bodycopy
- Psi-check: https://mepul--milo--adobecom.hlx.page/?martech=off
