### PR TITLE
MWPW-157965: Upgrade Universal Nav to Version 1.3

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -521,7 +521,7 @@ class Gnav {
       return 'linux';
     };
 
-    const unavVersion = new URLSearchParams(window.location.search).get('unavVersion') || '1.1';
+    const unavVersion = new URLSearchParams(window.location.search).get('unavVersion') || '1.3';
     await Promise.all([
       loadScript(`https://${environment}.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js`),
       loadStyles(`https://${environment}.adobeccstatic.com/unav/${unavVersion}/UniversalNav.css`),
@@ -608,9 +608,6 @@ class Gnav {
       locale,
       imsClientId: window.adobeid?.client_id,
       theme: isDarkMode() ? 'dark' : 'light',
-      onReady: () => {
-        this.decorateAppPrompt({ getAnchorState: () => window.UniversalNav.getComponent?.('app-switcher') });
-      },
       analyticsContext: {
         consumer: {
           name: 'adobecom',
@@ -627,11 +624,13 @@ class Gnav {
 
     // Exposing UNAV config for consumers
     CONFIG.universalNav.universalNavConfig = getConfiguration();
-    window.UniversalNav(CONFIG.universalNav.universalNavConfig);
-
-    isDesktop.addEventListener('change', () => {
-      window.UniversalNav.reload(CONFIG.universalNav.universalNavConfig);
-    });
+    window.UniversalNav(CONFIG.universalNav.universalNavConfig)
+      .then(() => {
+        this.decorateAppPrompt({ getAnchorState: () => window.UniversalNav.getComponent?.('app-switcher') });
+        isDesktop.addEventListener('change', () => {
+          window.UniversalNav.reload(CONFIG.universalNav.universalNavConfig);
+        });
+      });
   };
 
   decorateAppPrompt = async ({ getAnchorState } = {}) => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -624,13 +624,11 @@ class Gnav {
 
     // Exposing UNAV config for consumers
     CONFIG.universalNav.universalNavConfig = getConfiguration();
-    window.UniversalNav(CONFIG.universalNav.universalNavConfig)
-      .then(() => {
-        this.decorateAppPrompt({ getAnchorState: () => window.UniversalNav.getComponent?.('app-switcher') });
-        isDesktop.addEventListener('change', () => {
-          window.UniversalNav.reload(CONFIG.universalNav.universalNavConfig);
-        });
-      });
+    await window.UniversalNav(CONFIG.universalNav.universalNavConfig);
+    this.decorateAppPrompt({ getAnchorState: () => window.UniversalNav.getComponent?.('app-switcher') });
+    isDesktop.addEventListener('change', () => {
+      window.UniversalNav.reload(CONFIG.universalNav.universalNavConfig);
+    });
   };
 
   decorateAppPrompt = async ({ getAnchorState } = {}) => {

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -10,6 +10,7 @@ import {
   viewports,
   unavLocalesTestData,
   analyticsTestData,
+  unavVersion,
 } from './test-utilities.js';
 import { setConfig, getLocale } from '../../../libs/utils/utils.js';
 import initGnav, { getUniversalNavLocale, osMap } from '../../../libs/blocks/global-navigation/global-navigation.js';
@@ -27,7 +28,7 @@ describe('global navigation', () => {
   before(() => {
     document.head.innerHTML = `<link rel="icon" href="/libs/img/favicons/favicon.ico" size="any">
     <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-    <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+    <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
     `;
   });
 
@@ -366,8 +367,8 @@ describe('global navigation', () => {
         toFake: ['setTimeout'],
         shouldAdvanceTime: true,
       });
-      window.UniversalNav = sinon.spy();
-      window.UniversalNav.reload = sinon.spy();
+      window.UniversalNav = sinon.spy(() => Promise.resolve());
+      window.UniversalNav.reload = sinon.spy(() => Promise.resolve());
       // eslint-disable-next-line no-underscore-dangle
       window._satellite = { track: sinon.spy() };
       window.alloy = () => new Promise((resolve) => {
@@ -578,7 +579,7 @@ describe('global navigation', () => {
       document.head.innerHTML = `<meta name="app-prompt" content="off" />
       <link rel="icon" href="/libs/img/favicons/favicon.ico" size="any" />
       <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-      <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+      <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
       `;
       const gnav = await createFullGlobalNavigation({});
       gnav.decorateAppPrompt();
@@ -592,7 +593,7 @@ describe('global navigation', () => {
       <meta name="app-prompt-path" content="https://dismiss-pep--milo--adobecom.hlx.page/drafts/raghavs/pep-prompt-content"/>
       <link rel="icon" href="/libs/img/favicons/favicon.ico" size="any" />
       <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-      <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+      <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
       `;
       const gnav = await createFullGlobalNavigation({});
       window.adobeIMS = { isSignedInUser: () => true };

--- a/test/blocks/global-navigation/gnav-brand.test.js
+++ b/test/blocks/global-navigation/gnav-brand.test.js
@@ -4,6 +4,7 @@ import {
   createFullGlobalNavigation,
   selectors,
   isElementVisible,
+  unavVersion,
 } from './test-utilities.js';
 import logoOnlyNav from './mocks/global-navigation-only-logo.plain.js';
 import brandOnlyNav from './mocks/global-navigation-only-brand.plain.js';
@@ -15,7 +16,7 @@ describe('brand', () => {
   before(() => {
     document.head.innerHTML = `<link rel="icon" href="/libs/img/favicons/favicon.ico" size="any">
     <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-    <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+    <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
     `;
   });
 

--- a/test/blocks/global-navigation/gnav-cross-cloud.test.js
+++ b/test/blocks/global-navigation/gnav-cross-cloud.test.js
@@ -4,6 +4,7 @@ import {
   createFullGlobalNavigation,
   selectors,
   isElementVisible,
+  unavVersion,
 } from './test-utilities.js';
 import globalNavigationCrossCloud from './mocks/global-navigation-cross-cloud.plain.js';
 
@@ -11,7 +12,7 @@ describe('Cross Cloud Menu', () => {
   before(() => {
     document.head.innerHTML = `<link rel="icon" href="/libs/img/favicons/favicon.ico" size="any">
     <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-    <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+    <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
     `;
   });
 

--- a/test/blocks/global-navigation/gnav-main-nav-popup.test.js
+++ b/test/blocks/global-navigation/gnav-main-nav-popup.test.js
@@ -5,6 +5,7 @@ import {
   createFullGlobalNavigation,
   selectors,
   isElementVisible,
+  unavVersion,
 } from './test-utilities.js';
 import { toFragment } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
@@ -14,7 +15,7 @@ describe('main nav popups', () => {
   before(() => {
     document.head.innerHTML = `<link rel="icon" href="/libs/img/favicons/favicon.ico" size="any">
     <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-    <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+    <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
     `;
   });
 

--- a/test/blocks/global-navigation/gnav-main-nav.test.js
+++ b/test/blocks/global-navigation/gnav-main-nav.test.js
@@ -7,6 +7,7 @@ import {
   selectors,
   isElementVisible,
   viewports,
+  unavVersion,
 } from './test-utilities.js';
 import { isDesktop, setActiveLink, toFragment } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
 import globalNavigationActiveMock from './mocks/global-navigation-active.plain.js';
@@ -15,7 +16,7 @@ describe('main nav', () => {
   before(() => {
     document.head.innerHTML = `<link rel="icon" href="/libs/img/favicons/favicon.ico" size="any">
     <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-    <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+    <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
     `;
   });
 

--- a/test/blocks/global-navigation/gnav-profile.test.js
+++ b/test/blocks/global-navigation/gnav-profile.test.js
@@ -5,6 +5,7 @@ import {
   createFullGlobalNavigation,
   selectors,
   isElementVisible,
+  unavVersion,
 } from './test-utilities.js';
 import globalNavigationMock from './mocks/global-navigation.plain.js';
 
@@ -12,7 +13,7 @@ describe('profile', () => {
   before(() => {
     document.head.innerHTML = `<link rel="icon" href="/libs/img/favicons/favicon.ico" size="any">
     <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-    <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+    <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
     `;
   });
 

--- a/test/blocks/global-navigation/gnav-promo.test.js
+++ b/test/blocks/global-navigation/gnav-promo.test.js
@@ -1,13 +1,13 @@
 /* eslint-disable no-restricted-syntax */
 import { expect } from '@esm-bundle/chai';
-import { createFullGlobalNavigation } from './test-utilities.js';
+import { createFullGlobalNavigation, unavVersion } from './test-utilities.js';
 import { toFragment } from '../../../libs/blocks/global-navigation/utilities/utilities.js';
 
 describe('Promo', () => {
   before(() => {
     document.head.innerHTML = `<link rel="icon" href="/libs/img/favicons/favicon.ico" size="any">
     <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-    <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+    <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
     `;
   });
 

--- a/test/blocks/global-navigation/gnav-search.test.js
+++ b/test/blocks/global-navigation/gnav-search.test.js
@@ -7,6 +7,7 @@ import {
   selectors,
   isElementVisible,
   mockRes,
+  unavVersion,
 } from './test-utilities.js';
 
 const ogFetch = window.fetch;
@@ -19,7 +20,7 @@ describe('search', () => {
   before(() => {
     document.head.innerHTML = `<link rel="icon" href="/libs/img/favicons/favicon.ico" size="any">
     <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
-    <script src="https://stage.adobeccstatic.com/unav/1.1/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
+    <script src="https://stage.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js" type="javascript/blocked" data-loaded="true"></script>
     `;
   });
 

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -77,6 +77,8 @@ export const analyticsTestData = {
   'unc|click|markUnread': 'Mark Notification as unread',
 };
 
+export const unavVersion = '1.3';
+
 export const unavLocalesTestData = Object.entries(LANGMAP).reduce((acc, curr) => {
   const result = [];
   const [locale, prefixes] = curr;


### PR DESCRIPTION
Upgrades the UNav to 1.3

Adding eventListener for reloading Unav once Unav promise resolved as with v1.3 - the window.UniversalNav() returns a promise post which we can use methods like window.UniversalNav().reload() - [ref](https://wiki.corp.adobe.com/display/CCHome/Universal+Nav+Release+Info#:~:text=window.UniversalNav(config))
Also, Unav suggested to not rely on onReady method for triggering PEP modal instead we can wait for promise returned by `window.UniversalNav()` to be resolved.

Resolves: [MWPW-157965](https://jira.corp.adobe.com/browse/MWPW-157965)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/nishantkaush/test/unav?martech=off
- After: https://feds--milo--adobecom.hlx.live/drafts/nishantkaush/test/unav?martech=off
