### PR TITLE
REVERT MWPW-157686 [MEP] Cannot spoof an experience that exists in manifest but not in Target #2844 

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -894,6 +894,8 @@ export function cleanAndSortManifestList(manifests) {
           freshManifest = manifestObj[manifest.manifestPath];
         }
         freshManifest.name = fullManifest.name;
+        freshManifest.selectedVariantName = fullManifest.selectedVariantName;
+        freshManifest.selectedVariant = freshManifest.variants[freshManifest.selectedVariantName];
         manifestObj[manifest.manifestPath] = freshManifest;
       } else {
         manifestObj[manifest.manifestPath] = manifest;


### PR DESCRIPTION
Reverting https://github.com/adobecom/milo/pull/2844

Resolves: [MWPW-157686](https://jira.corp.adobe.com/browse/MWPW-157686)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://revertspoofpznexperience--milo--adobecom.hlx.page/?martech=off
