### PR TITLE
MWPW-157423 - [LocUI] Empty spaces in locales configuration

### DIFF
--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -96,7 +96,8 @@ async function loadLocales() {
     const locales = language.Locales || found?.livecopies;
     if (locales) {
       const localesTrim = locales.replaceAll(' ', '');
-      language.locales = localesTrim.includes('\n') ? localesTrim.split('\n') : localesTrim.split(',');
+      const localesList = localesTrim.includes('\n') ? localesTrim.split('\n') : localesTrim.split(',');
+      language.locales = localesList.filter((locale) => locale !== '');
     }
     return language;
   })];


### PR DESCRIPTION
Empty space between locales in language config creates blank locale inside the language card. After formatting locales list we will now filter empty strings.

Resolves: [MWPW-157423](https://jira.corp.adobe.com/browse/MWPW-157423)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/tools/loc?milolibs=locui&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B8f453a68-7eff-4a10-954d-feb2371c1d76%257D%26action%3Deditnew
- After: https://main--cc--adobecom.hlx.page/tools/loc?milolibs=sean-loc&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B8f453a68-7eff-4a10-954d-feb2371c1d76%257D%26action%3Deditnew
