### PR TITLE
MWPW-158182 add callback of URL for google yolo 

### DIFF
--- a/libs/features/google-login.js
+++ b/libs/features/google-login.js
@@ -9,7 +9,7 @@ const onToken = async (getMetadata, data, getConfig) => {
   try {
     destination = typeof config.googleLoginURLCallback === 'function' ? new URL(await config.googleLoginURLCallback()) : new URL(getMetadata('google-login-redirect'))?.href;
   } catch {
-    // Do nothing at all
+    // Do nothing
   }
 
   await window.adobeIMS.socialHeadlessSignIn({

--- a/libs/features/google-login.js
+++ b/libs/features/google-login.js
@@ -7,7 +7,7 @@ const onToken = async (getMetadata, data, getConfig) => {
   let destination;
   const config = getConfig();
   try {
-    destination = typeof config.googleLoginURLCallback === 'function' ? new URL(config.googleLoginURLCallback()) : new URL(getMetadata('google-login-redirect'))?.href;
+    destination = typeof config.googleLoginURLCallback === 'function' ? new URL(await config.googleLoginURLCallback()) : new URL(getMetadata('google-login-redirect'))?.href;
   } catch {
     // Do nothing
   }

--- a/libs/features/google-login.js
+++ b/libs/features/google-login.js
@@ -3,10 +3,11 @@ const GOOGLE_ID = '530526366930-l874a90ipfkn26naa71r010u8epp39jt.apps.googleuser
 const PLACEHOLDER = 'feds-googleLogin';
 const WRAPPER = 'feds-profile';
 
-const onToken = async (getMetadata, data) => {
+const onToken = async (getMetadata, data, getConfig) => {
   let destination;
+  const config = getConfig();
   try {
-    destination = new URL(getMetadata('google-login-redirect'))?.href;
+    destination = typeof config.googleLoginURLCallback === 'function' ? new URL(config.googleLoginURLCallback()) : new URL(getMetadata('google-login-redirect'))?.href;
   } catch {
     // Do nothing
   }
@@ -30,7 +31,7 @@ const onToken = async (getMetadata, data) => {
   });
 };
 
-export default async function initGoogleLogin(loadIms, getMetadata, loadScript) {
+export default async function initGoogleLogin(loadIms, getMetadata, loadScript, getConfig) {
   try {
     await loadIms();
   } catch {
@@ -45,7 +46,7 @@ export default async function initGoogleLogin(loadIms, getMetadata, loadScript) 
 
   window.google?.accounts?.id?.initialize({
     client_id: GOOGLE_ID,
-    callback: (data) => onToken(getMetadata, data),
+    callback: (data) => onToken(getMetadata, data, getConfig),
     prompt_parent_id: PLACEHOLDER,
     cancel_on_tap_outside: false,
   });

--- a/libs/features/google-login.js
+++ b/libs/features/google-login.js
@@ -9,7 +9,7 @@ const onToken = async (getMetadata, data, getConfig) => {
   try {
     destination = typeof config.googleLoginURLCallback === 'function' ? new URL(await config.googleLoginURLCallback()) : new URL(getMetadata('google-login-redirect'))?.href;
   } catch {
-    // Do nothing
+    // Do nothing at all
   }
 
   await window.adobeIMS.socialHeadlessSignIn({

--- a/libs/features/google-login.js
+++ b/libs/features/google-login.js
@@ -7,7 +7,8 @@ const onToken = async (getMetadata, data, getConfig) => {
   let destination;
   const config = getConfig();
   try {
-    destination = new URL(typeof config.googleLoginURLCallback === 'function' ? await config.googleLoginURLCallback() : getMetadata('google-login-redirect'))?.href;
+    destination = new URL(typeof config.googleLoginURLCallback === 'function' ? await config.googleLoginURLCallback()
+      : getMetadata('google-login-redirect'))?.href;
   } catch {
     // Do nothing
   }

--- a/libs/features/google-login.js
+++ b/libs/features/google-login.js
@@ -7,7 +7,7 @@ const onToken = async (getMetadata, data, getConfig) => {
   let destination;
   const config = getConfig();
   try {
-    destination = typeof config.googleLoginURLCallback === 'function' ? new URL(await config.googleLoginURLCallback()) : new URL(getMetadata('google-login-redirect'))?.href;
+    destination = new URL(typeof config.googleLoginURLCallback === 'function' ? await config.googleLoginURLCallback() : getMetadata('google-login-redirect'))?.href;
   } catch {
     // Do nothing
   }

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -49,7 +49,7 @@ export const loadPrivacy = async (getConfig, loadScript) => {
   });
 };
 
-export const loadGoogleLogin = async (getMetadata, loadIms, loadScript) => {
+export const loadGoogleLogin = async (getMetadata, loadIms, loadScript, getConfig) => {
   const googleLogin = getMetadata('google-login')?.toLowerCase();
   if (window.adobeIMS?.isSignedInUser() || !['mobile', 'desktop', 'on'].includes(googleLogin)) return;
   const desktopViewport = window.matchMedia('(min-width: 900px)').matches;
@@ -57,7 +57,7 @@ export const loadGoogleLogin = async (getMetadata, loadIms, loadScript) => {
   if (googleLogin === 'desktop' && !desktopViewport) return;
 
   const { default: initGoogleLogin } = await import('../features/google-login.js');
-  initGoogleLogin(loadIms, getMetadata, loadScript);
+  initGoogleLogin(loadIms, getMetadata, loadScript, getConfig);
 };
 
 /**
@@ -69,13 +69,11 @@ const loadDelayed = ([
   loadScript,
   loadStyle,
   loadIms,
-  MILO_EVENTS,
 ], DELAY = 3000) => new Promise((resolve) => {
   setTimeout(() => {
-    document.dispatchEvent(new Event(MILO_EVENTS.DELAYED));
     loadPrivacy(getConfig, loadScript);
     loadJarvisChat(getConfig, getMetadata, loadScript, loadStyle);
-    loadGoogleLogin(getMetadata, loadIms, loadScript);
+    loadGoogleLogin(getMetadata, loadIms, loadScript, getConfig);
     if (getMetadata('interlinks') === 'on') {
       const { locale } = getConfig();
       const path = `${locale.contentRoot}/keywords.json`;

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -69,8 +69,11 @@ const loadDelayed = ([
   loadScript,
   loadStyle,
   loadIms,
+  MILO_EVENTS,
 ], DELAY = 3000) => new Promise((resolve) => {
   setTimeout(() => {
+    const event = new Event(MILO_EVENTS.DELAYED);
+    document.dispatchEvent(event);
     loadPrivacy(getConfig, loadScript);
     loadJarvisChat(getConfig, getMetadata, loadScript, loadStyle);
     loadGoogleLogin(getMetadata, loadIms, loadScript);

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -72,8 +72,7 @@ const loadDelayed = ([
   MILO_EVENTS,
 ], DELAY = 3000) => new Promise((resolve) => {
   setTimeout(() => {
-    const event = new Event(MILO_EVENTS.DELAYED);
-    document.dispatchEvent(event);
+    document.dispatchEvent(new Event(MILO_EVENTS.DELAYED));
     loadPrivacy(getConfig, loadScript);
     loadJarvisChat(getConfig, getMetadata, loadScript, loadStyle);
     loadGoogleLogin(getMetadata, loadIms, loadScript);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1026,8 +1026,7 @@ async function checkForPageMods() {
 }
 
 async function loadPostLCP(config) {
-  const event = new Event(MILO_EVENTS.POSTLCP);
-  document.dispatchEvent(event);
+  document.dispatchEvent(new Event(MILO_EVENTS.POSTLCP));
   await decoratePlaceholders(document.body.querySelector('header'), config);
   if (config.mep?.targetEnabled === 'gnav') {
     /* c8 ignore next 2 */
@@ -1076,8 +1075,7 @@ export function scrollToHashedElement(hash) {
 }
 
 export async function loadDeferred(area, blocks, config) {
-  const event = new Event(MILO_EVENTS.DEFERRED);
-  area.dispatchEvent(event);
+  area.dispatchEvent(new Event(MILO_EVENTS.DEFERRED));
 
   if (area !== document) {
     return;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -138,7 +138,7 @@ ENVS.local = {
   name: 'local',
 };
 
-export const MILO_EVENTS = { DEFERRED: 'milo:deferred', DELAYED: 'milo:delayed', POSTLCP: 'milo:postlcp' };
+export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
 
 const LANGSTORE = 'langstore';
 const PREVIEW = 'target-preview';
@@ -1026,7 +1026,6 @@ async function checkForPageMods() {
 }
 
 async function loadPostLCP(config) {
-  document.dispatchEvent(new Event(MILO_EVENTS.POSTLCP));
   await decoratePlaceholders(document.body.querySelector('header'), config);
   if (config.mep?.targetEnabled === 'gnav') {
     /* c8 ignore next 2 */
@@ -1189,7 +1188,7 @@ async function documentPostSectionLoading(config) {
   initSidekick();
 
   const { default: delayed } = await import('../scripts/delayed.js');
-  delayed([getConfig, getMetadata, loadScript, loadStyle, loadIms, MILO_EVENTS]);
+  delayed([getConfig, getMetadata, loadScript, loadStyle, loadIms]);
 
   import('../martech/attributes.js').then((analytics) => {
     document.querySelectorAll('main > div').forEach((section, idx) => analytics.decorateSectionAnalytics(section, idx, config));

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -138,7 +138,7 @@ ENVS.local = {
   name: 'local',
 };
 
-export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
+export const MILO_EVENTS = { DEFERRED: 'milo:deferred', DELAYED: 'milo:delayed', POSTLCP: 'milo:postlcp' };
 
 const LANGSTORE = 'langstore';
 const PREVIEW = 'target-preview';
@@ -1026,6 +1026,8 @@ async function checkForPageMods() {
 }
 
 async function loadPostLCP(config) {
+  const event = new Event(MILO_EVENTS.POSTLCP);
+  document.dispatchEvent(event);
   await decoratePlaceholders(document.body.querySelector('header'), config);
   if (config.mep?.targetEnabled === 'gnav') {
     /* c8 ignore next 2 */
@@ -1189,7 +1191,7 @@ async function documentPostSectionLoading(config) {
   initSidekick();
 
   const { default: delayed } = await import('../scripts/delayed.js');
-  delayed([getConfig, getMetadata, loadScript, loadStyle, loadIms]);
+  delayed([getConfig, getMetadata, loadScript, loadStyle, loadIms, MILO_EVENTS]);
 
   import('../martech/attributes.js').then((analytics) => {
     document.querySelectorAll('main > div').forEach((section, idx) => analytics.decorateSectionAnalytics(section, idx, config));

--- a/test/features/google-login/google-login.test.js
+++ b/test/features/google-login/google-login.test.js
@@ -3,6 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import { readFile, setViewport } from '@web/test-runner-commands';
 import initGoogleLogin from '../../../libs/features/google-login.js';
 import { viewports } from '../../blocks/global-navigation/test-utilities.js';
+import { getConfig } from '../../../libs/utils/utils.js';
 
 describe('Google Login', () => {
   let initializeSpy;
@@ -37,12 +38,12 @@ describe('Google Login', () => {
   });
 
   it('should create a placeholder to inject DOM markup', async () => {
-    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub());
+    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub(), getConfig);
     expect(document.getElementById('feds-googleLogin')).to.exist;
   });
 
   it('should initialize and render the login element', async () => {
-    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub());
+    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub(), getConfig);
     expect(initializeSpy.called).to.be.true;
     expect(promptSpy.called).to.be.true;
     expect(initializeSpy.getCall(0).args[0].prompt_parent_id).to.equal('feds-googleLogin');
@@ -59,14 +60,14 @@ describe('Google Login', () => {
     const socialHeadlessSignInStub = sinon.stub(window.adobeIMS, 'socialHeadlessSignIn')
       .returns(new Promise((resolve, reject) => { reject(); }));
     const signInWithSocialProviderSpy = sinon.spy(window.adobeIMS, 'signInWithSocialProvider');
-    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub());
+    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub(), getConfig);
     let onToken = initializeSpy.getCall(0).args[0].callback;
-    await onToken(sinon.stub(), sinon.stub());
+    await onToken(sinon.stub(), sinon.stub(), getConfig);
     expect(signInWithSocialProviderSpy.called).to.be.true;
 
     // Existing account
     socialHeadlessSignInStub.returns(new Promise((resolve) => { resolve(); }));
-    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub());
+    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub(), getConfig);
     onToken = initializeSpy.getCall(0).args[0].callback;
     window.DISABLE_PAGE_RELOAD = true;
     signInWithSocialProviderSpy.resetHistory();
@@ -81,9 +82,9 @@ describe('Google Login', () => {
   it('should not initialize if IMS is not ready or user is already logged-in', async () => {
     window.adobeIMS = window.adobeIMS || { isSignedInUser: () => {} };
     const loggedInStub = sinon.stub(window.adobeIMS, 'isSignedInUser').returns(() => true);
-    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub());
+    await initGoogleLogin(sinon.stub(), sinon.stub(), sinon.stub(), getConfig);
     expect(document.getElementById('feds-googleLogin')).not.to.exist;
-    await initGoogleLogin(Promise.reject, sinon.stub(), sinon.stub());
+    await initGoogleLogin(Promise.reject, sinon.stub(), sinon.stub(), getConfig);
     expect(document.getElementById('feds-googleLogin')).not.to.exist;
     loggedInStub.restore();
   });

--- a/test/scripts/delayed.test.js
+++ b/test/scripts/delayed.test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import loadDelayed, { loadPrivacy, loadJarvisChat, loadGoogleLogin } from '../../libs/scripts/delayed.js';
-import { getMetadata, getConfig, setConfig, loadIms } from '../../libs/utils/utils.js';
+import { getMetadata, getConfig, setConfig, loadIms, MILO_EVENTS } from '../../libs/utils/utils.js';
 
 describe('Delayed', () => {
   const loadScript = sinon.stub().returns(() => new Promise((resolve) => { resolve(); }));
@@ -42,10 +42,11 @@ describe('Delayed', () => {
   it('should load interlinks logic', async () => {
     const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
     document.querySelector('head')?.insertAdjacentHTML('beforeend', '<meta name="interlinks" content="on">');
-    loadDelayed([getConfig, getMetadata, loadScript, loadStyle, loadIms]).then((module) => {
-      expect(module).to.exist;
-      expect(typeof module === 'object').to.equal(true);
-    });
+    loadDelayed([getConfig, getMetadata, loadScript, loadStyle, loadIms, MILO_EVENTS])
+      .then((module) => {
+        expect(module).to.exist;
+        expect(typeof module === 'object').to.equal(true);
+      });
     await clock.runAllAsync();
     clock.restore();
   });
@@ -53,9 +54,10 @@ describe('Delayed', () => {
   it('should skip load interlinks logic when metadata is off', async () => {
     const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
     document.head.querySelector('meta[name="interlinks"]')?.remove();
-    loadDelayed([getConfig, getMetadata, loadScript, loadStyle, loadIms]).then((module) => {
-      expect(module == null).to.equal(true);
-    });
+    loadDelayed([getConfig, getMetadata, loadScript, loadStyle, loadIms, MILO_EVENTS])
+      .then((module) => {
+        expect(module == null).to.equal(true);
+      });
     await clock.runAllAsync();
     clock.restore();
   });

--- a/test/scripts/delayed.test.js
+++ b/test/scripts/delayed.test.js
@@ -44,7 +44,6 @@ describe('Delayed', () => {
     document.querySelector('head')?.insertAdjacentHTML('beforeend', '<meta name="interlinks" content="on">');
     loadDelayed([getConfig, getMetadata, loadScript, loadStyle, loadIms])
       .then((module) => {
-        expect(module).to.exist;
         expect(typeof module === 'object').to.equal(true);
       });
     await clock.runAllAsync();

--- a/test/scripts/delayed.test.js
+++ b/test/scripts/delayed.test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import loadDelayed, { loadPrivacy, loadJarvisChat, loadGoogleLogin } from '../../libs/scripts/delayed.js';
-import { getMetadata, getConfig, setConfig, loadIms, MILO_EVENTS } from '../../libs/utils/utils.js';
+import { getMetadata, getConfig, setConfig, loadIms } from '../../libs/utils/utils.js';
 
 describe('Delayed', () => {
   const loadScript = sinon.stub().returns(() => new Promise((resolve) => { resolve(); }));
@@ -42,7 +42,7 @@ describe('Delayed', () => {
   it('should load interlinks logic', async () => {
     const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
     document.querySelector('head')?.insertAdjacentHTML('beforeend', '<meta name="interlinks" content="on">');
-    loadDelayed([getConfig, getMetadata, loadScript, loadStyle, loadIms, MILO_EVENTS])
+    loadDelayed([getConfig, getMetadata, loadScript, loadStyle, loadIms])
       .then((module) => {
         expect(module).to.exist;
         expect(typeof module === 'object').to.equal(true);
@@ -54,7 +54,7 @@ describe('Delayed', () => {
   it('should skip load interlinks logic when metadata is off', async () => {
     const clock = sinon.useFakeTimers({ toFake: ['setTimeout'] });
     document.head.querySelector('meta[name="interlinks"]')?.remove();
-    loadDelayed([getConfig, getMetadata, loadScript, loadStyle, loadIms, MILO_EVENTS])
+    loadDelayed([getConfig, getMetadata, loadScript, loadStyle, loadIms])
       .then((module) => {
         expect(module == null).to.equal(true);
       });


### PR DESCRIPTION
Resolves: [MWPW-158182](https://jira.corp.adobe.com/browse/MWPW-158182)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://vhargrave-MWPW-142878-events--milo--adobecom.hlx.page/?martech=off

This branch was originally built to listen to the two events to load both additional analytics and then get the primary cta url for google yolo which we redirect to.
Now after discussion with Rareș & Okan we've decided to just add a callback which resolves the url when necessary for the google yolo login. 
- https://github.com/adobecom/express-milo/pull/56/files
- https://main--express-milo--adobecom.hlx.page/express/colors/blue?milolibs=vhargrave-MWPW-142878-events
