### PR TITLE
MWPW-158071: Optimize LCP loading times

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -459,6 +459,9 @@ export async function loadBlock(block) {
   const base = miloLibs && MILO_BLOCKS.includes(name) ? miloLibs : codeRoot;
   let path = `${base}/blocks/${name}`;
 
+  if (name === 'marquee' || name === 'hero-marquee') {
+    loadLink(`${base}/utils/decorate.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+  }
   if (mep?.blocks?.[name]) path = mep.blocks[name];
 
   const blockPath = `${path}/${name}`;
@@ -466,7 +469,6 @@ export async function loadBlock(block) {
   const styleLoaded = hasStyles && new Promise((resolve) => {
     loadStyle(`${blockPath}.css`, resolve);
   });
-
   const scriptLoaded = new Promise((resolve) => {
     (async () => {
       try {
@@ -1238,9 +1240,6 @@ async function processSection(section, config, isDoc) {
     decoratePlaceholders(section.el, config),
     decorateIcons(section.el, config),
   ];
-  if (section.classList.contains('marquee') || section.classList.contains('hero-marquee')) {
-    loadLink('./utils/decorate.js', { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
-  }
   if (section.preloadLinks.length) {
     const [modals, nonModals] = partition(section.preloadLinks, (block) => block.classList.contains('modal'));
     nonModals.forEach((block) => tasks.push(loadBlock(block)));

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1044,7 +1044,7 @@ async function checkForPageMods() {
 
 async function loadPostLCP(config) {
   const nodes = findReplaceableNodes(document.body.querySelector('header'));
-  if (nodes.length) await fetchPlaceholders(document.body.querySelector('header'), config);
+  if (nodes.length) await fetchPlaceholders(config);
   if (nodes.length && decoratePlaceholderArea) {
     await decoratePlaceholderArea({
       placeholderRequest,
@@ -1250,7 +1250,7 @@ async function processSection(section, config, isDoc) {
   const tasks = [];
   const icons = section.el.querySelectorAll('span.icon');
   if (icons.length > 0) tasks.push(fetchIcons(config));
-  if (findReplaceableNodes(section.el).length) tasks.push(fetchPlaceholders(section.el, config));
+  if (findReplaceableNodes(section.el).length) tasks.push(fetchPlaceholders(config));
   if (section.preloadLinks.length) {
     const [modals, nonModals] = partition(section.preloadLinks, (block) => block.classList.contains('modal'));
     nonModals.forEach((block) => tasks.push(loadBlock(block)));


### PR DESCRIPTION
### Description
It's relatively hard to track performance beforehand, however we observed a +500MS (13%) gain on CC pages speeding up loading [placeholders](https://github.com/adobecom/milo/pull/2752). We've also seen good success with preloading as noted in [this discussion](https://github.com/orgs/adobecom/discussions/2719)

### Decorate.js
[This PR](https://github.com/adobecom/milo/pull/2493) initially introduced the idea of preloading `decorate.js` for a performance gain, but introduced _too much_ flexibility. The idea of preloading `decorate.js` for specifically the two common (hero-)marquees blocks is valuable and worth the added 3 lines of code, as neither is likely to change anytime soon.

### Impressions
This should provide good benefits on a wide arrange of blocks, consumers and pages by optimizing the load order and chains, however we will want to observe the CRUM/RUM/CRUX data after merging the changes in this PR
![homepage-before](https://github.com/user-attachments/assets/0118626c-1611-4477-bde7-d77706682bd8)
![homepage-after](https://github.com/user-attachments/assets/7ba47789-edbe-4028-8123-0286c7e67025)

Resolves: [MWPW-158071](https://jira.corp.adobe.com/browse/MWPW-158071)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://marquee-perf-improvements--milo--mokimo.hlx.page/?martech=off
