### PR TITLE
MWPW-158475 [MEP] classes that end in a number are modified when they should not be

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -373,7 +373,7 @@ function modifySelectorTerm(termParam) {
   const startText = startTextMatch ? startTextMatch[0].toLowerCase() : '';
   const startTextPart1 = startText.split(/\.|:/)[0];
   const endNumberMatch = term.match(/[0-9]*$/);
-  const endNumber = endNumberMatch ? endNumberMatch[0] : '';
+  const endNumber = endNumberMatch && startText.match(/^[a-zA-Z]/) ? endNumberMatch[0] : '';
   if (!startText || htmlEls.includes(startText)) return term;
   if (otherSelectors.includes(startText)) {
     term = term.replace(startText, '> div');

--- a/test/features/personalization/mocks/manifestSectionBlock.json
+++ b/test/features/personalization/mocks/manifestSectionBlock.json
@@ -5,7 +5,7 @@
   "data": [
     {
       "action": "removeContent",
-      "selector": ".custom-block1",
+      "selector": ".custom-block-1",
       "page filter (optional)": "",
       "param-newoffer=123": "",
       "all": "on"

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -147,6 +147,10 @@ const values = [
     b: 'any-marquee-section',
     a: 'main > div:has([class*="marquee"])',
   },
+  {
+    b: '.aside03',
+    a: '.aside03',
+  },
 ];
 describe('test different values', () => {
   values.forEach((value) => {

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -117,7 +117,7 @@ const values = [
   },
   {
     b: 'section1 .random-block2',
-    a: 'main > div:nth-child(1) .random-block:nth-child(2 of .random-block)',
+    a: 'main > div:nth-child(1) .random-block2',
   },
   {
     b: 'main > section30',

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -143,6 +143,10 @@ const values = [
     b: 'any-marquee ul li:nth-child(2)',
     a: '[class*="marquee"] ul li:nth-child(2)',
   },
+  {
+    b: 'any-marquee-section',
+    a: 'main > div:has([class*="marquee"])',
+  },
 ];
 describe('test different values', () => {
   values.forEach((value) => {


### PR DESCRIPTION
Detailed Description: If a manifest uses a variant that ends in a number (example: `.aside02`) it is interpreted incorrectly.
................................
URL: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepclassendinginnumber/?mepHighlight=true
................................
Steps to Reproduce:
1. Go to the URL above

Expected Results: 2nd aside should be removed
................................
Actual Results: 2nd aside is not removed

Resolves: [MWPW-158475](https://jira.corp.adobe.com/browse/MWPW-158475)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepclassendinginnumber/?mepHighlight=true&martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepclassendinginnumber/?milolibs=mepclassendinginnumber&mepHighlight=true&martech=off
- Psi-check: https://mepclassendinginnumber--milo--adobecom.hlx.page/?martech=off
