### PR TITLE
[MWPW-157924] - Added functionality to disable Active Element Detection

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -36,6 +36,8 @@ import {
   addMepHighlightAndTargetId,
   isDarkMode,
   darkIcons,
+  setDisableAEDState,
+  getDisableAEDState,
 } from './utilities/utilities.js';
 
 import { replaceKey, replaceKeyArray } from '../../features/placeholders.js';
@@ -840,8 +842,9 @@ class Gnav {
 
     if (!hasActiveLink()) {
       const sections = this.elements.mainNav.querySelectorAll('.feds-navItem--section');
+      const disableAED = getDisableAEDState();
 
-      if (sections.length === 1) {
+      if (!disableAED && sections.length === 1) {
         sections[0].classList.add(selectors.activeNavItem.slice(1));
         setActiveLink(true);
       }
@@ -1027,7 +1030,11 @@ const getSource = async () => {
 export default async function init(block) {
   try {
     const { mep } = getConfig();
-    const url = await getSource();
+    const sourceUrl = await getSource();
+    const [url, hash = ''] = sourceUrl.split('#');
+    if (hash === '_noActiveItem') {
+      setDisableAEDState();
+    }
     const content = await fetchAndProcessPlainHtml({ url });
     if (!content) return null;
     const gnav = new Gnav({

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -133,7 +133,7 @@ export function getAnalyticsValue(str, index) {
 
 export function getExperienceName() {
   const experiencePath = getMetadata('gnav-source');
-  const explicitExperience = experiencePath?.split('/').pop();
+  const explicitExperience = experiencePath?.split('#')[0]?.split('/').pop();
   if (explicitExperience?.length
     && explicitExperience !== 'gnav') return explicitExperience;
 
@@ -257,6 +257,15 @@ export function setActiveDropdown(elem) {
   });
 }
 
+// Disable AED(Active Element Detection)
+export const [setDisableAEDState, getDisableAEDState] = (() => {
+  let disableAED = false;
+  return [
+    () => { disableAED = true; },
+    () => disableAED,
+  ];
+})();
+
 export const [hasActiveLink, setActiveLink, getActiveLink] = (() => {
   let activeLinkFound;
 
@@ -264,7 +273,8 @@ export const [hasActiveLink, setActiveLink, getActiveLink] = (() => {
     () => activeLinkFound,
     (val) => { activeLinkFound = !!val; },
     (area) => {
-      if (hasActiveLink() || !(area instanceof HTMLElement)) return null;
+      const disableAED = getDisableAEDState();
+      if (disableAED || hasActiveLink() || !(area instanceof HTMLElement)) return null;
       const { origin, pathname } = window.location;
       const url = `${origin}${pathname}`;
       const activeLink = [

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -556,6 +556,15 @@ describe('global navigation', () => {
         fetchStub.calledOnceWith('http://localhost:2000/gnav.plain.html'),
       ).to.be.true;
     });
+
+    it('disable AED(Active Element Detetction) if gnav-souce used with hash "#_noActiveItem" modifier', async () => {
+      const gnavMeta = toFragment`<meta name="gnav-source" content="https://adobe.com/federal${customPath}#_noActiveItem">`;
+      document.head.append(gnavMeta);
+      document.body.replaceChildren(toFragment`<header class="global-navigation"></header>`);
+      await initGnav(document.body.querySelector('header'));
+      const isActiveElement = !!document.querySelector('.global-navigation .feds-navItem--active');
+      expect(isActiveElement).to.be.false;
+    });
   });
 
   describe('Dynamic nav', () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

This change prevents any NavItem from being marked as active by appending the hash `#_noActiveItem` to the `gnav-source`. The hash can be added either in the `metadata.xlsx` file or at the page level for the `gnav-source` metadata. If the hash is present, the Active Element Detection functionality is disabled.
For example:
<img width="702" alt="Screenshot 2024-09-17 at 1 09 23 PM" src="https://github.com/user-attachments/assets/be187095-bc25-4e56-babd-974f38c54125">

Before (creativity & design is active NavItem):
<img width="1800" alt="Screenshot 2024-09-17 at 1 10 50 PM" src="https://github.com/user-attachments/assets/683fd723-b237-4343-837b-101e913b92ca">

After (No NavItem is active):
<img width="1800" alt="Screenshot 2024-09-17 at 1 11 27 PM" src="https://github.com/user-attachments/assets/90d52500-c312-4c59-95b9-0ed5ab83faf6">

Resolves: [MWPW-157924](https://jira.corp.adobe.com/browse/MWPW-157924)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-157924--milo--deva309.hlx.page/?martech=off

QA:

https://main--cc--adobecom.hlx.page/drafts/devashish/vh?milolibs=mwpw-157924--milo--deva309


