### PR TITLE
[MWPW-158583] Update old run-nala GitHub action job

### DIFF
--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run Nala
         uses: adobecom/nala@main # Change if doing dev work
         env:
-          labels: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+          labels: ${{ join(github.event.pull_request.labels.*.name, 'run-nala-on') }}
           branch: ${{ github.event.pull_request.head.ref }}
           repoName: ${{ github.repository }}
           prUrl: ${{ github.event.pull_request.head.repo.html_url }}

--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run Nala Tests (Consuming Apps) 
         uses: adobecom/nala@main # Change if doing dev work
         env:
-          labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}
+          labels: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
           branch: ${{ github.event.pull_request.head.ref }}
           repoName: ${{ github.repository }}
           prUrl: ${{ github.event.pull_request.head.repo.html_url }}

--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -8,7 +8,7 @@ jobs:
   action:
     name: Running E2E & IT
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, ' ')
+    if: contains(join(github.event.pull_request.labels.*.name, ' '), 'run-nala-on-')
 
     steps:
       - name: Check out repository
@@ -16,7 +16,7 @@ jobs:
       - name: Run Nala Tests (Consuming Apps) 
         uses: adobecom/nala@main # Change if doing dev work
         env:
-          labels: ${{ join(github.event.pull_request.labels.*.name, 'run-nala-on') }}
+          labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}
           branch: ${{ github.event.pull_request.head.ref }}
           repoName: ${{ github.repository }}
           prUrl: ${{ github.event.pull_request.head.repo.html_url }}

--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -1,4 +1,4 @@
-name: Nala Tests
+name: Nala Tests (Consuming Apps)
 
 on:
   pull_request:
@@ -8,11 +8,12 @@ jobs:
   action:
     name: Running E2E & IT
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, ' ')
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Run Nala
+      - name: Run Nala Tests (Consuming Apps) 
         uses: adobecom/nala@main # Change if doing dev work
         env:
           labels: ${{ join(github.event.pull_request.labels.*.name, 'run-nala-on') }}


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Do not run nala tests on all PRs without the specified label, as the `run-nala-default.yaml `will handle this
* Update the configuration to support running Nala tests on consuming projects when the specified label is present
    - `run-nala-on-<consuming project>` from Nala repositories

Resolves: [MWPW-158583](https://jira.corp.adobe.com/browse/MWPW-158583)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://nala-worklflow--milo--adobecom.hlx.page/?martech=off
