### PR TITLE
MWPW-157476 - [LocUI] Ignore OG property in find meta fragments

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -70,7 +70,8 @@ function findMetaFragments(doc) {
     fragments = [...metas]
       .filter((meta) => {
         const content = meta.getAttribute('content');
-        return content?.includes('/fragments/') && isUrl(content);
+        const isOGUrl = meta.getAttribute('property') === 'og:url';
+        return content?.includes('/fragments/') && isUrl(content) && !isOGUrl;
       })
       .map((meta) => new URL(meta.getAttribute('content')));
   }


### PR DESCRIPTION
In federal when finding fragments on a configured fragment URL finding fragments returns a URL found in the page META property `og:url`. Adding a condition in the find meta fragments functionality that will Ignore meta fragment URLs with that property.

Resolves: [MWPW-157476](https://jira.corp.adobe.com/browse/MWPW-157476)

**Test URLs:**
- Before: https://main--federal--adobecom.hlx.page/tools/loc?milolibs=locui&ref=main&repo=federal&owner=adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Bddfa50c7-1f5c-46f0-8132-6fb507ab6d89%257D%26action%3Deditnew
- After: https://main--federal--adobecom.hlx.page/tools/loc?milolibs=sean-loc&ref=main&repo=federal&owner=adobecom&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Bddfa50c7-1f5c-46f0-8132-6fb507ab6d89%257D%26action%3Deditnew
