### PR TITLE
Revert "MWPW-157888 - Hero marquee w/ `no-min-height` and no l/r padding when using a `full-width` variant"

### DIFF
--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -17,7 +17,6 @@
   align-items: center;
 }
 
-.hero-marquee.no-min-height { min-height: unset; }
 .hero-marquee.s-min-height { min-height: var(--s-min-height); }
 .hero-marquee.l-min-height { min-height: var(--l-min-height); }
 

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -164,16 +164,14 @@ function loadBreakpointThemes() {
 export default async function init(el) {
   el.classList.add('con-block');
   let rows = el.querySelectorAll(':scope > div');
-  if (rows.length <= 1) return;
-  const [head, ...tail] = rows;
-  rows = tail;
-  if (head.textContent.trim() === '') {
-    head.remove();
-  } else {
+  if (rows.length > 1 && rows[0].textContent !== '') {
     el.classList.add('has-bg');
+    const [head, ...tail] = rows;
     handleObjectFit(head);
     decorateBlockBg(el, head, { useHandleFocalpoint: true });
+    rows = tail;
   }
+
   // get first row that's not a keyword key/value row
   const mainRowIndex = rows.findIndex((row) => {
     const firstColText = row.children[0].textContent.toLowerCase().trim();


### PR DESCRIPTION
Reverts adobecom/milo#2861

Issue found with missing background images.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/steenmeyer/hero-editorial-layout-pattern-examples/hero-editorial-no-min-height-masonry1?martech=off
- After: https://revert-2861-rparrish/hero-no-min--milo--adobecom.hlx.page/drafts/steenmeyer/hero-editorial-layout-pattern-examples/hero-editorial-no-min-height-masonry1?martech=off

https://revert-2861-rparrish-hero-no-min--milo--adobecom.hlx.page/