### PR TITLE
MWPW-158480 Exclude defaults from caas links

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -827,10 +827,21 @@ const CopyBtn = () => {
     }, 2000);
   };
 
+  const removeDefaultsFromState = (fullState) => {
+    const reducedState = {};
+    Object.keys(fullState).forEach((key) => {
+      if (JSON.stringify(fullState[key]) !== JSON.stringify(defaultState[key])) {
+        reducedState[key] = fullState[key];
+      }
+    });
+    return reducedState;
+  };
+
   const getUrl = async () => {
     const url = new URL(window.location.href);
     url.search = '';
-    const hashStr = await getEncodedObject(state, fgKeyReplacer);
+    const reducedState = removeDefaultsFromState(state);
+    const hashStr = await getEncodedObject(reducedState, fgKeyReplacer);
     // starts with ~~ to differentiate from old hash format
     url.hash = `~~${hashStr}`;
     return url.href;

--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -867,7 +867,7 @@ const CopyBtn = () => {
       hour12: false,
     });
     const collectionName = state.collectionName ? `- ${state.collectionName} ` : '';
-    link.textContent = `Content as a Service v2 ${collectionName}- ${dateStr}${state.doNotLazyLoad ? ' (no-lazy)' : ''}`;
+    link.textContent = `Content as a Service v3 ${collectionName}- ${dateStr}${state.doNotLazyLoad ? ' (no-lazy)' : ''}`;
 
     const blob = new Blob([link.outerHTML], { type: 'text/html' });
     const data = [new ClipboardItem({ [blob.type]: blob })];

--- a/test/blocks/caas-config/caas-config.test.html
+++ b/test/blocks/caas-config/caas-config.test.html
@@ -312,7 +312,7 @@
         // The header is the part before the first / in the hash
         // Due to this we only compare the characters after the header value
 
-        const hashWithoutHeader = 'bNhD9Lzw7Wafb9qCb7V0jBrxZN/aihyIoxuRIIkxxVHJor1L0vxek9ek4N+kNOR9v3gz/FaCUZk0WzFf8J6DnHTiovMj++jYTqrFQabk6LNbktvqMz2e07EWWg/E4E2DBNKylX5ExKKOfL1ChyIQYGQ8O5GlT1Q6912RHt9WWCi0PULTxIDCtKFh2zRZs0Z88Ep0qcKeNJLvHGOkaYoy/WT+ySHBqz42JuZRg8g8l6qLk1nLQbHAhZUzoqI3mZotnNCL7fSZkX8qSbeeidroC14ixeah0wJLjW3Cvv/eYZdAWncjEp1/m8xd4/1MrLlsTWj40NQ58yCsXIhMSwGft70Pw8ULwTNUKnGp9MyxSOJGJvz2aXMyEoi/EW/jebAlUz6bSHo4Gl2AtuqGZykHOT8f+H62qSdtI6OVy+QiKjvhRUvUgS12hgw9Q64ehShFvnLUjW6Ftu4Dv0gSFKmbZltRCQ405GHMEeXoewomZyBE4uMnNXBtGlxTYnknAMmijdmBj+5KAKmAte/OWJLSsGMx5hBdaikyQ66FJHL9K/E6gfUmX56rmpueoCMypm7++i5koEVTvptQKVwwbNf0fCo/AEzBuLKM7g+mdantDkQFbBCiw00H3/4CRdQMNhSScmEeoI0SgXsjhXQVb4puxI2uaWNuyHaee9jYhcjcXaii0TbQurK7SRx8HClRifOTZRrUN8hssfwSwrDnFtnfsbU0tkDo1GN88Hkqs8HG4aEBiSUahe3PmqhGHPhj2O3S7ROBvM+ERnCzXGk3XGo+SrALXDBX20J6Ck9iBHIlZklPjwfElXRIOqsApvCZidE/6rFWUycjSce3XSVv3ba922ojkstPqCNvcnNmnEifQgTiu+MTGYCDHUYILL3/AnvAO+EJK53rUzGTAHIKJQ6m6e1fDtfM7qkM9uXDFv4JVVO2hqo0e7fp0IA75nhxP0HW7EyZgl9FtCR3+QxnXsFMIPbozabcjMiL7NJ/PbwwpSxTZ4xW/vh83jhN4E67VjijhcvLi20wwFP4qzp/v1HhGxKOuQI47/azjyhE9djtRHOcgLrj4xKGPS04hgzb+gO/8Wrf7T7V9mgmOqX5GUNoW7csnysdoiCpJmjtQnMpIxkwEj9voOnrrgwaPr2d0BpqttqdBU6P3MzDTnQUUPLqNzSkO1X//AxGj3OyCCAAA';
+        const hashWithoutHeader = 'Dv6ajAgAAAA==';
 
         const hash = copyTextArea.value.split('#')[1].trim();
 


### PR DESCRIPTION
* Removes defaults from state before creating caas config link
* Reduces caas link length by 25-30% for the longest links

Related to discussion: https://github.com/orgs/adobecom/discussions/2876

Resolves: [MWPW-158480](https://jira.corp.adobe.com/browse/MWPW-158480)

**Test URLs:**
Page with old/new links
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/caas-link-v2?martech=off
- After: https://methomas-caas-link-len--milo--adobecom.hlx.page/drafts/methomas/caas-link-v3?martech=off