### PR TITLE
Add option to configure children for unav's help component

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -48,7 +48,7 @@ function getHelpChildren() {
     { type: 'Support' },
     { type: 'Community' },
   ];
-};
+}
 
 export const CONFIG = {
   icons: isDarkMode() ? darkIcons : icons,

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -42,6 +42,14 @@ import {
 
 import { replaceKey, replaceKeyArray } from '../../features/placeholders.js';
 
+function getHelpChildren() {
+  const { unavHelpChildren } = getConfig();
+  return unavHelpChildren || [
+    { type: 'Support' },
+    { type: 'Community' },
+  ];
+};
+
 export const CONFIG = {
   icons: isDarkMode() ? darkIcons : icons,
   delays: {
@@ -97,13 +105,7 @@ export const CONFIG = {
       },
       help: {
         name: 'help',
-        attributes: {
-          children: [
-            { type: 'Support' },
-            { type: 'Community' },
-            // { type: 'Jarvis', appid: window.adobeid?.client_id },
-          ],
-        },
+        attributes: { children: getHelpChildren() },
       },
     },
   },

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -4,7 +4,7 @@ const blockConfig = [
     name: 'global-navigation',
     targetEl: 'header',
     appendType: 'prepend',
-    params: ['imsClientId', 'searchEnabled'],
+    params: ['imsClientId', 'searchEnabled', 'unavHelpChildren'],
   },
   {
     key: 'footer',


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Add option to configure children for unav's help component
* Universal nav has option to add custom children - [link](https://wiki.corp.adobe.com/display/CCHome/Universal+Nav+Integration+Guidelines#UniversalNavIntegrationGuidelines-HelpConfiguration)
* Need to add support for that from milo gnav.

Resolves: [MWPW-158737](https://jira.corp.adobe.com/browse/MWPW-158737)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://unav-configurable--milo--adobecom.hlx.page/?martech=off

Qa: https://adobecom.github.io/nav-consumer/navigation.html?authoringpath=/federal/dev&env=stage&navbranch=unav-configurable
