### PR TITLE
[MWPW-158756] Enhance stage links conversion for cross-domain localization

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -659,7 +659,7 @@ export function decorateLinks(el) {
   decorateImageLinks(el);
   const anchors = el.getElementsByTagName('a');
   const { hostname } = window.location;
-  const result = [...anchors].reduce((rdx, a) => {
+  const links = [...anchors].reduce((rdx, a) => {
     appendHtmlToLink(a);
     a.href = localizeLink(a.href);
     decorateSVG(a);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -695,7 +695,7 @@ export function decorateLinks(el) {
     return rdx;
   }, []);
   convertStageLinks({ anchors, config, hostname });
-  return result;
+  return links;
 }
 
 function decorateContent(el) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -659,8 +659,7 @@ export function decorateLinks(el) {
   decorateImageLinks(el);
   const anchors = el.getElementsByTagName('a');
   const { hostname } = window.location;
-  convertStageLinks({ anchors, config, hostname });
-  return [...anchors].reduce((rdx, a) => {
+  const result = [...anchors].reduce((rdx, a) => {
     appendHtmlToLink(a);
     a.href = localizeLink(a.href);
     decorateSVG(a);
@@ -695,6 +694,8 @@ export function decorateLinks(el) {
     }
     return rdx;
   }, []);
+  convertStageLinks({ anchors, config, hostname });
+  return result;
 }
 
 function decorateContent(el) {


### PR DESCRIPTION
## Description
This PR enhances the stage links conversion feature to handle cross-domain localization.

## Related Issue
Resolves: [MWPW-158756](https://jira.corp.adobe.com/browse/MWPW-158756)

## Testing instructions
1. open the after test URL

2. using the developer tools, overwrite scrips.js to :
- have `'business.adobe.com'` in the `prodDomains` array;
- have 
```
  '--milo--robert-bogos.hlx.page': {
    'business.adobe.com': 'main--bacom--adobecom.hlx.page'
  }
```
in the `stageDomainsMap` config.

<img width="619" alt="Screenshot 2024-09-19 at 15 38 28" src="https://github.com/user-attachments/assets/7fa12d70-279e-455c-9458-cc974d7e719b">


3. the business.adobe.com url should be converted and localized

<img width="993" alt="Screenshot 2024-09-19 at 15 43 06" src="https://github.com/user-attachments/assets/93a0d2b8-8d76-4be9-a97f-0dd9dd0f3244">

## Test URLs
**Milo:**
- Before: https://stage--milo--adobecom.hlx.page/de/drafts/rbogos/env-relative-urls?martech=off
- After: https://mwpw-158756-enhance-links-conversion--milo--robert-bogos.hlx.page/de/drafts/rbogos/env-relative-urls?martech=off
