### PR TITLE
MWPW-158776 Fix video CLS 

### DIFF
--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -1,4 +1,4 @@
-import { turnAnchorIntoVideo } from '../../utils/decorate.js';
+import { decorateAnchorVideo } from '../../utils/decorate.js';
 
 export default function init(a) {
   a.classList.add('hide-video');
@@ -6,7 +6,7 @@ export default function init(a) {
   if (a.href.includes('.mp4') && bgBlocks.some((b) => a.closest(`.${b}`))) {
     a.classList.add('hide');
     if (!a.parentNode) return;
-    turnAnchorIntoVideo({
+    decorateAnchorVideo({
       src: a.href,
       anchorTag: a,
     });

--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -1,22 +1,16 @@
-import { createIntersectionObserver } from '../../utils/utils.js';
-import { applyHoverPlay, getVideoAttrs } from '../../utils/decorate.js';
+import { turnAnchorIntoVideo } from '../../utils/decorate.js';
 
-const ROOT_MARGIN = 1000;
-
-const loadAdobeTv = (a) => {
+export default function init(a) {
+  a.classList.add('hide-video');
   const bgBlocks = ['aside', 'marquee', 'hero-marquee'];
   if (a.href.includes('.mp4') && bgBlocks.some((b) => a.closest(`.${b}`))) {
     a.classList.add('hide');
-    const { href, hash, dataset } = a;
-    const attrs = getVideoAttrs(hash || 'autoplay', dataset);
-    const video = `<video ${attrs}>
-          <source src="${href}" type="video/mp4" />
-        </video>`;
     if (!a.parentNode) return;
-    a.insertAdjacentHTML('afterend', video);
-    const videoElem = document.body.querySelector(`source[src="${href}"]`)?.parentElement;
-    applyHoverPlay(videoElem);
-    a.remove();
+    turnAnchorIntoVideo({
+      hash: a.hash || 'autoplay',
+      src: a.href,
+      anchorTag: a,
+    });
   } else {
     const embed = `<div class="milo-video">
       <iframe src="${a.href}" class="adobetv" webkitallowfullscreen mozallowfullscreen allowfullscreen scrolling="no" allow="encrypted-media" title="Adobe Video Publishing Cloud Player" loading="lazy">
@@ -24,18 +18,5 @@ const loadAdobeTv = (a) => {
     </div>`;
     a.insertAdjacentHTML('afterend', embed);
     a.remove();
-  }
-};
-
-export default function init(a) {
-  a.classList.add('hide-video');
-  if (a.textContent.includes('no-lazy')) {
-    loadAdobeTv(a);
-  } else {
-    createIntersectionObserver({
-      el: a,
-      options: { rootMargin: `${ROOT_MARGIN}px` },
-      callback: loadAdobeTv,
-    });
   }
 }

--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -7,7 +7,6 @@ export default function init(a) {
     a.classList.add('hide');
     if (!a.parentNode) return;
     turnAnchorIntoVideo({
-      hash: a.hash || 'autoplay',
       src: a.href,
       anchorTag: a,
     });

--- a/libs/blocks/figure/figure.js
+++ b/libs/blocks/figure/figure.js
@@ -1,4 +1,5 @@
-import { applyHoverPlay, getVideoAttrs } from '../../utils/decorate.js';
+import { applyHoverPlay, decorateAnchorVideo } from '../../utils/decorate.js';
+import { createTag } from '../../utils/utils.js';
 
 function buildCaption(pEl) {
   const figCaptionEl = document.createElement('figcaption');
@@ -15,23 +16,22 @@ function htmlToElement(html) {
 }
 
 function decorateVideo(clone, figEl) {
-  let video = clone.querySelector('video');
-  const videoLink = clone.querySelector('a[href*=".mp4"]');
-  if (videoLink) {
-    const { href, hash, dataset } = videoLink;
-    const attrs = getVideoAttrs(hash, dataset);
-    const videoElem = `<video ${attrs}>
-      <source src="${href}" type="video/mp4" />
-    </video>`;
-
-    videoLink.insertAdjacentHTML('afterend', videoElem);
-    videoLink.remove();
-    video = clone.querySelector('video');
-  }
-  if (video) {
-    video.removeAttribute('data-mouseevent');
-    applyHoverPlay(video);
-    figEl.prepend(video);
+  const videoTag = clone.querySelector('video');
+  const anchorTag = clone.querySelector('a[href*=".mp4"]');
+  if (anchorTag && !anchorTag.hash) anchorTag.hash = '#autoplay';
+  if (anchorTag) decorateAnchorVideo({ src: anchorTag.href, anchorTag });
+  if (videoTag) {
+    videoTag.removeAttribute('data-mouseevent');
+    if (videoTag.dataset?.videoSource) {
+      videoTag.appendChild(
+        createTag('source', {
+          src: videoTag.dataset?.videoSource,
+          type: 'video/mp4',
+        }),
+      );
+    }
+    applyHoverPlay(videoTag);
+    figEl.prepend(videoTag);
   }
 }
 

--- a/libs/blocks/marquee/marquee.js
+++ b/libs/blocks/marquee/marquee.js
@@ -88,7 +88,7 @@ function decorateSplit(el, foreground, media) {
 
   let mediaCreditInner;
   const txtContent = media?.lastChild?.textContent?.trim();
-  if (txtContent?.match(/^http.*\.mp4/)) return;
+  if (txtContent?.match(/^http.*\.mp4/) || media?.lastChild?.tagName === 'VIDEO') return;
   if (txtContent) {
     mediaCreditInner = createTag('p', { class: 'body-s' }, txtContent);
   } else if (media.lastElementChild?.tagName !== 'PICTURE') {
@@ -99,7 +99,7 @@ function decorateSplit(el, foreground, media) {
     const mediaCredit = createTag('div', { class: 'media-credit container' }, mediaCreditInner);
     el.appendChild(mediaCredit);
     el.classList.add('has-credit');
-    media?.lastChild.remove();
+    media?.lastChild?.remove();
   }
 }
 

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -1,9 +1,12 @@
 import { getConfig } from '../../utils/utils.js';
-import { turnAnchorIntoVideo } from '../../utils/decorate.js';
+import { decorateAnchorVideo } from '../../utils/decorate.js';
 
 export default function init(a) {
   a.classList.add('hide-video');
-  if (!a.parentNode) return;
+  if (!a.parentNode) {
+    a.remove();
+    return;
+  }
   const { pathname } = a;
   let videoPath = `.${pathname}`;
   if (pathname.match('media_.*.mp4')) {
@@ -14,7 +17,7 @@ export default function init(a) {
     const mediaFilename = pathname.split('/').pop();
     videoPath = `${root}${mediaFilename}`;
   }
-  turnAnchorIntoVideo({
+  decorateAnchorVideo({
     src: videoPath,
     anchorTag: a,
   });

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -15,7 +15,6 @@ export default function init(a) {
     videoPath = `${root}${mediaFilename}`;
   }
   turnAnchorIntoVideo({
-    hash: a.hash,
     src: videoPath,
     anchorTag: a,
   });

--- a/libs/blocks/video/video.js
+++ b/libs/blocks/video/video.js
@@ -1,10 +1,10 @@
-import { createIntersectionObserver, getConfig } from '../../utils/utils.js';
-import { applyHoverPlay, getVideoAttrs, applyInViewPortPlay } from '../../utils/decorate.js';
+import { getConfig } from '../../utils/utils.js';
+import { turnAnchorIntoVideo } from '../../utils/decorate.js';
 
-const ROOT_MARGIN = 1000;
-
-const loadVideo = (a) => {
-  const { pathname, hash, dataset } = a;
+export default function init(a) {
+  a.classList.add('hide-video');
+  if (!a.parentNode) return;
+  const { pathname } = a;
   let videoPath = `.${pathname}`;
   if (pathname.match('media_.*.mp4')) {
     const { codeRoot } = getConfig();
@@ -14,28 +14,9 @@ const loadVideo = (a) => {
     const mediaFilename = pathname.split('/').pop();
     videoPath = `${root}${mediaFilename}`;
   }
-
-  const attrs = getVideoAttrs(hash, dataset);
-  const video = `<video ${attrs}>
-        <source src="${videoPath}" type="video/mp4" />
-      </video>`;
-  if (!a.parentNode) return;
-  a.insertAdjacentHTML('afterend', video);
-  const videoElem = document.body.querySelector(`source[src="${videoPath}"]`)?.parentElement;
-  applyHoverPlay(videoElem);
-  applyInViewPortPlay(videoElem);
-  a.remove();
-};
-
-export default function init(a) {
-  a.classList.add('hide-video');
-  if (a.textContent.includes('no-lazy')) {
-    loadVideo(a);
-  } else {
-    createIntersectionObserver({
-      el: a,
-      options: { rootMargin: `${ROOT_MARGIN}px` },
-      callback: loadVideo,
-    });
-  }
+  turnAnchorIntoVideo({
+    hash: a.hash,
+    src: videoPath,
+    anchorTag: a,
+  });
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -1,4 +1,4 @@
-import { createTag, loadStyle, getConfig } from './utils.js';
+import { createTag, loadStyle, getConfig, createIntersectionObserver } from './utils.js';
 
 const { miloLibs, codeRoot } = getConfig();
 
@@ -115,8 +115,6 @@ export async function decorateBlockBg(block, node, { useHandleFocalpoint = false
     const allVP = [['mobile-only'], ['tablet-only'], ['desktop-only']];
     const viewports = childCount === 2 ? binaryVP : allVP;
     [...node.children].forEach((child, i) => {
-      const videoLink = child.querySelector('a[href*=".mp4"]');
-      if (videoLink && !videoLink.hash) videoLink.hash = 'autoplay';
       if (childCount > 1) child.classList.add(...viewports[i]);
       const pic = child.querySelector('picture');
       if (useHandleFocalpoint && pic
@@ -324,10 +322,11 @@ export async function loadCDT(el, classList) {
   }
 }
 
-export function turnAnchorIntoVideo({ hash, src, anchorTag }) {
+export function decorateAnchorVideo({ src, anchorTag }) {
+  if (!src.length || !(anchorTag instanceof HTMLElement)) return;
+  if (anchorTag.closest('.marquee, .aside, .hero-marquee') && !anchorTag.hash) anchorTag.hash = '#autoplay';
   const { dataset, parentElement } = anchorTag;
-  const attrs = getVideoAttrs(hash, dataset);
-  const video = `<video ${attrs}></video>`;
+  const video = `<video ${getVideoAttrs(anchorTag.hash, dataset)} data-video-source=${src}></video>`;
   anchorTag.insertAdjacentHTML('afterend', video);
   const videoEl = parentElement.querySelector('video');
   createIntersectionObserver({

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -200,7 +200,7 @@ export function getImgSrc(pic) {
   return source?.srcset ? `poster='${source.srcset}'` : '';
 }
 
-export function getVideoAttrs(hash, dataset) {
+function getVideoAttrs(hash, dataset) {
   const isAutoplay = hash?.includes('autoplay');
   const isAutoplayOnce = hash?.includes('autoplay1');
   const playOnHover = hash?.includes('hoverplay');

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -260,7 +260,7 @@ export function handleObjectFit(bgRow) {
   });
 }
 
-export function getVideoIntersectionObserver() {
+function getVideoIntersectionObserver() {
   if (!window?.videoIntersectionObs) {
     window.videoIntersectionObs = new window.IntersectionObserver((entries) => {
       entries.forEach((entry) => {
@@ -281,7 +281,7 @@ export function getVideoIntersectionObserver() {
   return window.videoIntersectionObs;
 }
 
-export function applyInViewPortPlay(video) {
+function applyInViewPortPlay(video) {
   if (!video) return;
   if (video.hasAttribute('data-play-viewport')) {
     const observer = getVideoIntersectionObserver();
@@ -322,4 +322,22 @@ export async function loadCDT(el, classList) {
   } catch (error) {
     window.lana?.log(`Failed to load countdown timer module: ${error}`, { tags: 'countdown-timer' });
   }
+}
+
+export function turnAnchorIntoVideo({ hash, src, anchorTag }) {
+  const { dataset, parentElement } = anchorTag;
+  const attrs = getVideoAttrs(hash, dataset);
+  const video = `<video ${attrs}></video>`;
+  anchorTag.insertAdjacentHTML('afterend', video);
+  const videoEl = parentElement.querySelector('video');
+  createIntersectionObserver({
+    el: parentElement,
+    options: { rootMargin: '1000px' },
+    callback: () => {
+      videoEl?.appendChild(createTag('source', { src, type: 'video/mp4' }));
+    },
+  });
+  applyHoverPlay(videoEl);
+  applyInViewPortPlay(videoEl);
+  anchorTag.remove();
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -322,7 +322,7 @@ export async function loadCDT(el, classList) {
   }
 }
 
-export function decorateAnchorVideo({ src, anchorTag }) {
+export function decorateAnchorVideo({ src = '', anchorTag }) {
   if (!src.length || !(anchorTag instanceof HTMLElement)) return;
   if (anchorTag.closest('.marquee, .aside, .hero-marquee') && !anchorTag.hash) anchorTag.hash = '#autoplay';
   const { dataset, parentElement } = anchorTag;

--- a/test/blocks/adobetv/adobetv.test.js
+++ b/test/blocks/adobetv/adobetv.test.js
@@ -6,17 +6,6 @@ document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 const { default: init } = await import('../../../libs/blocks/adobetv/adobetv.js');
 
 describe('adobetv autoblock', () => {
-  it('decorates no-lazy video', async () => {
-    const block = document.querySelector('.video.no-lazy');
-    const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
-    block.append(a);
-
-    init(a);
-    const video = await waitForElement('.video.no-lazy iframe');
-    expect(video).to.exist;
-  });
-
   it('creates video block', async () => {
     const wrapper = document.body.querySelector('.adobe-tv');
     const a = wrapper.querySelector(':scope > a');

--- a/test/blocks/adobetv/mocks/body.html
+++ b/test/blocks/adobetv/mocks/body.html
@@ -1,5 +1,5 @@
 <main>
-  <div class="video no-lazy">
+  <div class="video">
     <a href="https://video.tv.adobe.com/v/3410934t1">
       https://video.tv.adobe.com/v/3410934t1
     </a>

--- a/test/blocks/figure/figure.test.js
+++ b/test/blocks/figure/figure.test.js
@@ -42,8 +42,9 @@ describe('init', () => {
     init(blockEl);
 
     const figures = blockEl.querySelectorAll('.figure');
-    expect(figures[0].querySelector('a > picture')).to.be.exist;
-    expect(figures[1].querySelector('a > video')).to.be.exist;
+    expect(figures[0].querySelector('a > picture')).to.exist;
+    expect(figures[1].querySelector('a > video')).to.exist;
+    expect(figures[1].querySelector('a > video > source')).to.exist;
   });
 
   it('should not add any classes to the block element when no pictures are present', () => {

--- a/test/blocks/figure/mocks/body.html
+++ b/test/blocks/figure/mocks/body.html
@@ -51,17 +51,7 @@
         <div>
           <p>
             <video>
-              <source type="image/webp"
-                srcset=""
-                media="(min-width: 400px)">
-              <source type="image/webp"
-                srcset="">
-              <source type="image/jpeg"
-                srcset=""
-                media="(min-width: 400px)">
-              <img loading="lazy" alt="" type="image/jpeg"
-                src=""
-                width="2000" height="876">
+
             </video>
           </p>
           <p><em>caption</em></p>
@@ -114,9 +104,7 @@
       <div>
         <div>
           <p>
-            <video width="320" height="240" controls>
-              <source src="movie.mp4" type="video/mp4">
-              <source src="movie.ogg" type="video/ogg">
+            <video width="320" height="240" controls data-video-source="movie.mp4">
             </video>
           </p>
           <p><a href="https://blog.adobe.com/en/publish/2022/12/07/kah-milah-ledgester-breathes-life-into-award-winning-art-with-adobe-creative-cloud">https://blog.adobe.com/en/publish/2022/12/07/kah-milah-ledgester-breathes-life-into-award-winning-art-with-adobe-creative-cloud</a></p>

--- a/test/blocks/marquee/marquee.test.js
+++ b/test/blocks/marquee/marquee.test.js
@@ -1,8 +1,8 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { waitForElement } from '../../helpers/waitfor.js';
-import { setConfig } from '../../../libs/utils/utils.js';
+import { waitFor, waitForElement } from '../../helpers/waitfor.js';
+import { setConfig, loadStyle } from '../../../libs/utils/utils.js';
 import { loadMnemonicList } from '../../../libs/blocks/marquee/marquee.js';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
@@ -16,6 +16,15 @@ const video = await readFile({ path: './mocks/video.html' });
 const multipleIcons = await readFile({ path: './mocks/multiple-icons.html' });
 
 describe('marquee', () => {
+  before(async () => {
+    await new Promise((resolve) => {
+      loadStyle('../../../../libs/styles/styles.css', resolve);
+    });
+    await new Promise((resolve) => {
+      loadStyle('../../../../libs/blocks/marquee/marquee.css', resolve);
+    });
+  });
+
   const marquees = document.querySelectorAll('.marquee');
   marquees.forEach((marquee) => {
     init(marquee);
@@ -69,7 +78,9 @@ describe('marquee', () => {
       init(marquee);
       videoBLock(document.querySelector('#single-background a[href*=".mp4"]'));
       const videoEl = await waitForElement('#single-background .background video');
-      expect(videoEl).to.exist;
+      const intersectionObserverAddsSource = () => videoEl.querySelector('source');
+      await waitFor(intersectionObserverAddsSource);
+      expect(videoEl.querySelector('source')).to.exist;
       document.getElementById('single-background').remove();
     });
 
@@ -78,7 +89,9 @@ describe('marquee', () => {
       init(marquee);
       document.querySelectorAll('#multiple-background a[href*=".mp4"]').forEach((videoLink) => videoBLock(videoLink));
       await waitForElement('#multiple-background .background video');
-      expect(marquee.querySelectorAll('.background video').length).to.equal(1);
+      const intersectionObserverAddsSource = () => document.querySelector('.background video source');
+      await waitFor(intersectionObserverAddsSource);
+      expect(marquee.querySelectorAll('.background video source').length).to.equal(1);
       document.getElementById('multiple-background').remove();
     });
 

--- a/test/blocks/video/mocks/body.html
+++ b/test/blocks/video/mocks/body.html
@@ -4,7 +4,7 @@
   }
 </style>
 <main>
-  <div class="video no-lazy">
+  <div class="video">
     <a href="https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4">
       https://main--blog--adobecom.hlx.page/media_17927691d22fe4e1bd058e94762a224fdc57ebb7b.mp4
     </a>

--- a/test/blocks/video/video.test.js
+++ b/test/blocks/video/video.test.js
@@ -3,7 +3,8 @@ import { expect, assert } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { waitFor, waitForElement } from '../../helpers/waitfor.js';
 
-import { setConfig } from '../../../libs/utils/utils.js';
+import { setConfig, createTag } from '../../../libs/utils/utils.js';
+import { decorateAnchorVideo } from '../../../libs/utils/decorate.js';
 
 setConfig({});
 const { default: init } = await import('../../../libs/blocks/video/video.js');
@@ -15,6 +16,22 @@ describe('video uploaded using franklin bot', () => {
 
   afterEach(() => {
     document.body.innerHTML = '';
+  });
+
+  it('removes the element, if it does not have a parent node', (done) => {
+    const anchor = createTag('a');
+    anchor.remove = () => done();
+    init(anchor);
+  });
+
+  it('does not do anything, if the element is not a valid htmlEl', () => {
+    expect(() => {
+      decorateAnchorVideo({ anchorTag: undefined });
+    }).not.to.throw();
+
+    expect(() => {
+      decorateAnchorVideo({ src: 'some-length', anchorTag: undefined });
+    }).not.to.throw();
   });
 
   it('decorates video', async () => {

--- a/test/blocks/video/video.test.js
+++ b/test/blocks/video/video.test.js
@@ -1,25 +1,20 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect, assert } from '@esm-bundle/chai';
-
 import sinon from 'sinon';
+import { waitFor, waitForElement } from '../../helpers/waitfor.js';
 
-import { waitForElement } from '../../helpers/waitfor.js';
 import { setConfig } from '../../../libs/utils/utils.js';
 
 setConfig({});
 const { default: init } = await import('../../../libs/blocks/video/video.js');
-document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
 describe('video uploaded using franklin bot', () => {
-  it('decorates no-lazy video', async () => {
-    const block = document.querySelector('.video.no-lazy');
-    const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
-    block.append(a);
+  beforeEach(async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+  });
 
-    init(a);
-    const video = await waitForElement('.video.no-lazy video');
-    expect(video).to.exist;
+  afterEach(() => {
+    document.body.innerHTML = '';
   });
 
   it('decorates video', async () => {
@@ -74,7 +69,6 @@ describe('video uploaded using franklin bot', () => {
   it('no hoverplay attribute added when with autoplay on loop', async () => {
     const block = document.querySelector('.video.autoplay.playonhover');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -86,7 +80,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with hoverplay when only hoverplay is added to url', async () => {
     const block = document.querySelector('.video.hoveronly');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -97,7 +90,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with viewportplay only with autoplay', async () => {
     const block = document.querySelector('.video.autoplay.viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -108,7 +100,6 @@ describe('video uploaded using franklin bot', () => {
   it('play video when element reached 80% viewport', async () => {
     const block = document.querySelector('.video.autoplay.viewportplay.scrolled-80');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
     const nextFrame = () => new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -116,13 +107,10 @@ describe('video uploaded using franklin bot', () => {
 
     init(a);
     const video = block.querySelector('video');
-    const source = video.querySelector('source');
-    source.setAttribute('src', 'https://www.adobe.com/creativecloud/media_1167374e3354ef57f126fa78a55cbc1708ac4babd.mp4');
-    source.setAttribute('type', 'video/mp4');
-
     const playSpy = sinon.spy(video, 'play');
     const pauseSpy = sinon.spy(video, 'pause');
-
+    const intersectionObserverAddsSource = () => video.querySelector('source');
+    await waitFor(intersectionObserverAddsSource);
     video.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {
@@ -130,20 +118,22 @@ describe('video uploaded using franklin bot', () => {
     });
     assert.isTrue(playSpy.calledOnce);
 
-    document.body.scrollIntoView();
+    // push the video out of the viewport
+    const div = document.createElement('div');
+    div.style.height = '2000px';
+    video.parentNode.insertBefore(div, video);
+
     await nextFrame();
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
     assert.isTrue(pauseSpy.calledOnce);
-
     expect(video.hasAttribute('data-play-viewport')).to.be.true;
   });
 
   it('Don\'t play the video once it end when autoplay1 enabled', async () => {
     const block = document.querySelector('.video.autoplay1.viewportplay.ended');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
     const nextFrame = () => new Promise((resolve) => {
       requestAnimationFrame(resolve);
@@ -151,15 +141,13 @@ describe('video uploaded using franklin bot', () => {
 
     init(a);
     const video = block.querySelector('video');
-    const source = video.querySelector('source');
-    source.setAttribute('src', 'https://www.adobe.com/creativecloud/media_1167374e3354ef57f126fa78a55cbc1708ac4babd.mp4');
-    source.setAttribute('type', 'video/mp4');
-
     const playSpy = sinon.spy(video, 'play');
     const pauseSpy = sinon.spy(video, 'pause');
     const endedSpy = sinon.spy();
-    video.addEventListener('ended', endedSpy);
+    const intersectionObserverAddsSource = () => video.querySelector('source');
+    await waitFor(intersectionObserverAddsSource);
 
+    video.addEventListener('ended', endedSpy);
     video.scrollIntoView();
     await nextFrame();
     await new Promise((resolve) => {
@@ -167,13 +155,16 @@ describe('video uploaded using franklin bot', () => {
     });
     assert.isTrue(playSpy.calledOnce);
 
-    document.body.scrollIntoView();
+    // push the video out of the viewport
+    const div = document.createElement('div');
+    div.style.height = '2000px';
+    video.parentNode.insertBefore(div, video);
+
     await nextFrame();
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
     assert.isTrue(pauseSpy.calledOnce);
-
     video.dispatchEvent(new Event('ended'));
     await nextFrame();
     await new Promise((resolve) => {
@@ -193,7 +184,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with viewportplay only with autoplay1', async () => {
     const block = document.querySelector('.video.autoplay1.viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -204,7 +194,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay with autoplay1 hoverplay', async () => {
     const block = document.querySelector('.video.autoplay1.hoverplay.no-viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -215,7 +204,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay with hoverplay', async () => {
     const block = document.querySelector('.video.hoverplay.no-viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -226,7 +214,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay no autoplay', async () => {
     const block = document.querySelector('.video.no-autoplay.no-viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);
@@ -237,7 +224,6 @@ describe('video uploaded using franklin bot', () => {
   it('decorate video with no viewportplay no autoplay1', async () => {
     const block = document.querySelector('.video.no-autoplay1.no-viewportplay');
     const a = block.querySelector('a');
-    a.textContent = 'no-lazy';
     block.append(a);
 
     init(a);


### PR DESCRIPTION
Follow up for the reverted PR https://github.com/adobecom/milo/pull/2849

Resolves: [MWPW-158776](https://jira.corp.adobe.com/browse/MWPW-158776)

This should still work: https://github.com/adobecom/milo/pull/1936

**Test URLs:**

Onhover play
- Before: https://main--milo--mokimo.hlx.live/drafts/ruchika/videoplay-onhover?martech=off
- After: https://marquee-cls--milo--mokimo.hlx.live/drafts/ruchika/videoplay-onhover?martech=off

Onviewport play
- Before: https://main--milo--mokimo.hlx.live/drafts/siva/products/videoplay-onviewport?martech=off
- After: https://marquee-cls--milo--mokimo.hlx.live/drafts/siva/products/videoplay-onviewport?martech=off

Only desktop (mobile should not load the video for perf reasons)
- Before: https://main--milo--mokimo.hlx.live/drafts/seanchoi/marquee-video?martech=off
- After: https://marquee-cls--milo--mokimo.hlx.live/drafts/seanchoi/marquee-video?martech=off

Split marquee video tests
Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/marquee-split?martech=off
After: https://marquee-cls--milo--mokimo.hlx.page/docs/library/kitchen-sink/marquee-split?martech=off

Before: https://main--cc--adobecom.hlx.page/drafts/00-CC-milo-migration/bugs/document?martech=off
After: https://main--cc--adobecom.hlx.page/drafts/00-CC-milo-migration/bugs/document?martech=off&milolibs=marquee-cls--milo--mokimo

CLS
- Before: https://main--milo--adobecom.aem.live/drafts/osahin/magento-commerce-1
- After: https://marquee-cls--milo--mokimo.aem.live/drafts/osahin/magento-commerce-1

Bacom tests
- Before: https://stage--bacom--adobecom.hlx.live/products/real-time-customer-data-platform/rtcdp?milolibs=stage
- After: https://stage--bacom--adobecom.hlx.live/products/real-time-customer-data-platform/rtcdp?milolibs=marquee-cls--milo--mokimo

CC tests
- Before: https://main--cc--adobecom.hlx.live/creativecloud/buy/education
- After: https://main--cc--adobecom.hlx.live/creativecloud/buy/education?milolibs=marquee-cls--milo--mokimo

