### PR TITLE
MWPW-157147: Dynamic Nav Status Button

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1018,7 +1018,7 @@ const getSource = async () => {
   const { locale, dynamicNavKey } = getConfig();
   let url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
   if (dynamicNavKey) {
-    const { default: dynamicNav } = await import('../../features/dynamic-navigation.js');
+    const { default: dynamicNav } = await import('../../features/dynamic-navigation/dynamic-navigation.js');
     url = dynamicNav(url, dynamicNavKey);
   }
   return url;

--- a/libs/features/dynamic-navigation/dynamic-navigation.js
+++ b/libs/features/dynamic-navigation/dynamic-navigation.js
@@ -1,6 +1,6 @@
-import { getMetadata } from '../utils/utils.js';
+import { getMetadata } from '../../utils/utils.js';
 
-function isDynamicNavDisabled() {
+export function isDynamicNavDisabled() {
   const dynamicNavDisableValues = getMetadata('dynamic-nav-disable');
   if (!dynamicNavDisableValues) return false;
 

--- a/libs/features/dynamic-navigation/dynamic-navigation.js
+++ b/libs/features/dynamic-navigation/dynamic-navigation.js
@@ -1,19 +1,21 @@
 import { getMetadata } from '../../utils/utils.js';
 
-export function isDynamicNavDisabled() {
+export function foundDisableValues() {
   const dynamicNavDisableValues = getMetadata('dynamic-nav-disable');
   if (!dynamicNavDisableValues) return false;
 
   const metadataPairsMap = dynamicNavDisableValues.split(',').map((pair) => pair.split(';'));
-  return metadataPairsMap.some(([metadataKey, metadataContent]) => {
+  const foundValues = metadataPairsMap.filter(([metadataKey, metadataContent]) => {
     const metaTagContent = getMetadata(metadataKey.toLowerCase());
     return (metaTagContent
         && metaTagContent.toLowerCase() === metadataContent.toLowerCase());
   });
+
+  return foundValues.length ? foundValues : false;
 }
 
 export default function dynamicNav(url, key) {
-  if (isDynamicNavDisabled()) return url;
+  if (foundDisableValues()) return url;
   const metadataContent = getMetadata('dynamic-nav');
 
   if (metadataContent === 'entry') {

--- a/libs/features/dynamic-navigation/status.css
+++ b/libs/features/dynamic-navigation/status.css
@@ -171,3 +171,9 @@
   border: 1px solid rgb(160 160 160);
   padding: 8px 10px;
 }
+
+@media screen and (max-width: 600px) {
+  .dynamic-nav-status {
+    display: none;
+  }
+}

--- a/libs/features/dynamic-navigation/status.css
+++ b/libs/features/dynamic-navigation/status.css
@@ -151,7 +151,7 @@
   border-bottom: 1px solid white;
 }
 
-.dynamic-nav-status .disable-values{
+.dynamic-nav-status .disable-values {
   min-width: 100%;
 }
 

--- a/libs/features/dynamic-navigation/status.css
+++ b/libs/features/dynamic-navigation/status.css
@@ -1,4 +1,4 @@
-.dynamic-nav-status  {
+.dynamic-nav-status {
   border: 2px solid white;
   border-radius: 32px;
   color: #eee;
@@ -58,7 +58,7 @@
   transition-duration: 0.2s;
 }
 
-.dns-badge.dns-open::after{
+.dns-badge.dns-open::after {
   transform: rotate(135deg);
   transition-duration: 0.2s;
 }
@@ -135,7 +135,7 @@
   rotate: 180deg;
 }
 
-.dynamic-nav-status p{
+.dynamic-nav-status p {
   margin: 2px;
 }
 
@@ -160,7 +160,7 @@
   width: 100%;
 }
 
-.dynamic-nav-status .disable-values caption{
+.dynamic-nav-status .disable-values caption {
   min-width: 100%;
   text-align: left;
   font-weight: 600;

--- a/libs/features/dynamic-navigation/status.css
+++ b/libs/features/dynamic-navigation/status.css
@@ -1,0 +1,173 @@
+.dynamic-nav-status  {
+  border: 2px solid white;
+  border-radius: 32px;
+  color: #eee;
+  font-size: 16px;
+  padding: 12px 24px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  margin: 12px;
+  position: relative;
+}
+
+.dynamic-nav-status .title { 
+  display: flex;
+}
+
+.dynamic-nav-status.active {
+  background-color: #280;
+}
+
+.dynamic-nav-status.enabled {
+  background-color: #ec4;
+}
+
+.dynamic-nav-status.inactive {
+  background-color: #e20;  
+}
+
+.dns-badge {
+  border: 2px solid white;
+  border-radius: 32px;
+  background-color: transparent;
+  box-sizing: border-box;
+  color: #eee;
+  padding: 8px;
+  height: 12px;
+  width: 12px;
+  margin: 4px 8px 4px 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.dns-badge::after { 
+  content: '';
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-top: 2px solid;
+  border-right: 2px solid;
+  transform: rotate(45deg);
+  left: 5px;
+  bottom: 5px;
+  transition-duration: 0.2s;
+}
+
+.dns-badge.dns-open::after{
+  transform: rotate(135deg);
+  transition-duration: 0.2s;
+}
+
+.dynamic-nav-status .hidden {
+  display: none;
+}
+
+.dynamic-nav-status.enabled .title,
+.dynamic-nav-status.enabled .dns-badge {
+  color: var(--feds-color-hamburger);  
+  border-color: var(--feds-color-hamburger);
+}
+
+.dynamic-nav-status .dns-close-container {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  height: 10px;
+  padding: 2px;
+}
+
+.dynamic-nav-status .dns-close {
+  cursor: pointer;
+  display: block;
+  position: absolute;
+  border: 2px solid white;
+  border-radius: 32px;
+  background-color: transparent;
+  color: #eee;
+  height: 20px;
+  width: 20px;
+  top: 6px;
+  right: 6px;
+  box-sizing: border-box;
+}
+
+.dynamic-nav-status .dns-close::after {
+  content: 'x';
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  left: 4px;
+  top: -8px;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.dynamic-nav-status .details {
+  position: absolute;
+  top: 60px;
+  right: 0;
+  background-color: #444;
+  min-width: 300px;
+  border-radius: 16px;
+  box-shadow: 0 0 10px #000;
+  font-size: 12px;
+  padding: 20px;
+  z-index: 1;
+}
+
+.dynamic-nav-status .details::before {
+  content: '';
+  width: 0;
+  height: 0;
+  position: absolute;
+  border-left: 15px solid transparent;
+  border-right: 15px solid transparent;
+  border-top: 15px solid #444;
+  top: -15px;
+  right: 75px;
+  rotate: 180deg;
+}
+
+.dynamic-nav-status p{
+  margin: 2px;
+}
+
+.dynamic-nav-status .details p {
+  font-weight: 600;
+}
+
+.dynamic-nav-status .details span {
+  font-weight: 300;
+}
+
+.dynamic-nav-status .details .additional-info {
+  border-bottom: 1px solid white;
+}
+
+.dynamic-nav-status .disable-values{
+  min-width: 100%;
+}
+
+.dynamic-nav-status .disable-values table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.dynamic-nav-status .disable-values caption{
+  min-width: 100%;
+  text-align: left;
+  font-weight: 600;
+}
+
+.dynamic-nav-status .disable-values th,
+.dynamic-nav-status .disable-values td {
+  border: 1px solid rgb(160 160 160);
+  padding: 8px 10px;
+}

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -1,0 +1,133 @@
+import { createTag, getConfig, getMetadata, loadStyle } from '../../utils/utils.js';
+import { isDynamicNavDisabled } from './dynamic-navigation.js';
+
+export const ACTIVE = 'active';
+export const ENABLED = 'enabled';
+export const INACTIVE = 'inactive';
+export const tooltipInfo = {
+  active: 'Displayed in green, this status appears when a user is on an entry page or a page with the Dynamic Nav enabled, indicating that the nav is fully functioning.',
+  enabled: 'Displayed in yellow, this status indicates that the Dynamic Nav is set to "on," but the user has not yet visited an entry page.',
+  inactive: 'Displayed in red, this status indicates that the Dynamic Nav is either not configured or has been disabled.',
+};
+
+const getCurrentSource = (status, storageSource, authoredSource) => {
+  if (status === 'on') {
+    return storageSource || authoredSource;
+  }
+  return authoredSource;
+};
+
+const getStatus = (status, disabled, storageSource) => {
+  if (status === 'entry') return ACTIVE;
+
+  if (disabled) return INACTIVE;
+
+  if (status === 'on' && storageSource) return ACTIVE;
+
+  if (status === 'on' && !storageSource) return ENABLED;
+
+  return INACTIVE;
+};
+
+const processDisableValues = (arr, elem) => {
+  if (arr === null || arr === undefined || arr.length === 0) return;
+
+  const diableValueList = arr.split(',');
+  const table = createTag('table');
+
+  const tableDOM = `
+      <caption>Disable Values</caption>
+      <thead>
+        <tr>
+          <th>Key</th>
+          <th>Value</th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>`;
+
+  table.innerHTML = tableDOM;
+  const tBody = table.querySelector('tbody');
+
+  diableValueList.forEach((pair) => {
+    const itemRow = createTag('tr');
+    const [key, value] = pair.split(';');
+    const keyElem = createTag('td');
+    const valElem = createTag('td');
+    keyElem.innerText = key;
+    valElem.innerText = value;
+
+    itemRow.append(keyElem, valElem);
+    tBody.append(itemRow);
+  });
+
+  elem.append(table);
+};
+
+const returnPath = (url) => {
+  if (!url.includes('https://')) return '';
+  const sourceUrl = new URL(url);
+  return sourceUrl.pathname;
+};
+
+const createStatusWidget = (dynamicNavKey) => {
+  const storedSource = window.sessionStorage.getItem('gnavSource');
+  const authoredSource = getMetadata('gnav-source') || 'Metadata not found: site gnav source';
+  const dynamicNavSetting = getMetadata('dynamic-nav');
+  const currentSource = getCurrentSource(dynamicNavSetting, storedSource, authoredSource);
+  const dynamicNavDisableValues = getMetadata('dynamic-nav-disable');
+  const status = getStatus(dynamicNavSetting, isDynamicNavDisabled(), storedSource);
+  const statusWidget = createTag('div', { class: 'dynamic-nav-status' });
+
+  statusWidget.innerHTML = `
+    <span class="title"><span class="dns-badge"></span>Dynamic Nav</span>
+    <section class="details hidden">
+      <span class="dns-close"></span>
+      <div class="message additional-info">
+        <p>Additional Info:
+          <span>${tooltipInfo[status]}</span>
+        </p>
+      </div>
+      <p class="status">Status: <span>${status}</span></p> 
+      <p class="setting">Setting: <span>${dynamicNavSetting}</span></p>
+      <p class="consumer-key">Consumer key: <span>${dynamicNavKey}</span></p>
+      <div class="nav-source-info">
+        <p>Authored and stored source match: <span>${authoredSource === currentSource}</span></p>
+        <p>Authored Nav Source:
+        <span>${returnPath(authoredSource)}</span></p>
+        <p>Stored Nav Source:
+        <span>${returnPath(currentSource)}</span></p>
+      </div>
+      <div class="disable-values">
+      </div>
+    </section>
+  `;
+
+  processDisableValues(dynamicNavDisableValues, statusWidget.querySelector('.disable-values'));
+  statusWidget.classList.add(status);
+
+  statusWidget.addEventListener('click', () => {
+    statusWidget.querySelector('.details').classList.toggle('hidden');
+    statusWidget.querySelector('.dns-badge').classList.toggle('dns-open');
+  });
+
+  return statusWidget;
+};
+
+export default async function main() {
+  const { dynamicNavKey, miloLibs, codeRoot, env } = getConfig();
+  if (env?.name === 'prod') return;
+
+  loadStyle(`${miloLibs || `${codeRoot}/libs`}/features/dynamic-navigation/status.css`);
+
+  const statusWidget = createStatusWidget(dynamicNavKey);
+  const topNav = document.querySelector('.feds-topnav');
+  const fedsWrapper = document.querySelector('.feds-nav-wrapper');
+  const dnsClose = statusWidget.querySelector('.dns-close');
+
+  dnsClose.addEventListener('click', () => {
+    topNav.removeChild(statusWidget);
+  });
+
+  fedsWrapper.after(statusWidget);
+}

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -115,8 +115,7 @@ const createStatusWidget = (dynamicNavKey) => {
 };
 
 export default async function main() {
-  const { dynamicNavKey, miloLibs, codeRoot, env } = getConfig();
-  if (env?.name === 'prod') return;
+  const { dynamicNavKey, miloLibs, codeRoot } = getConfig();
 
   loadStyle(`${miloLibs || `${codeRoot}/libs`}/features/dynamic-navigation/status.css`);
 

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -29,13 +29,13 @@ const getStatus = (status, disabled, storageSource) => {
   return INACTIVE;
 };
 
-const processDisableValues = (arr, elem) => {
-  if (arr === null || arr === undefined || arr.length === 0) return;
+const processDisableValues = (valueStr, elem) => {
+  if (!valueStr || valueStr.length === 0) return;
 
-  const diableValueList = arr.split(',');
+  const disableValueList = valueStr.split(',');
   const table = createTag('table');
 
-  const tableDOM = `
+  table.innerHTML = `
       <caption>Disable Values</caption>
       <thead>
         <tr>
@@ -46,10 +46,9 @@ const processDisableValues = (arr, elem) => {
       <tbody>
       </tbody>`;
 
-  table.innerHTML = tableDOM;
   const tBody = table.querySelector('tbody');
 
-  diableValueList.forEach((pair) => {
+  disableValueList.forEach((pair) => {
     const itemRow = createTag('tr');
     const [key, value] = pair.split(';');
     const keyElem = createTag('td');
@@ -65,7 +64,7 @@ const processDisableValues = (arr, elem) => {
 };
 
 const returnPath = (url) => {
-  if (!url.includes('https://')) return '';
+  if (!url.startsWith('https://')) return '';
   const sourceUrl = new URL(url);
   return sourceUrl.pathname;
 };

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -115,10 +115,7 @@ const createStatusWidget = (dynamicNavKey) => {
 };
 
 export default async function main() {
-  const { dynamicNavKey, miloLibs, codeRoot } = getConfig();
-
-  loadStyle(`${miloLibs || `${codeRoot}/libs`}/features/dynamic-navigation/status.css`);
-
+  const { dynamicNavKey } = getConfig();
   const statusWidget = createStatusWidget(dynamicNavKey);
   const topNav = document.querySelector('.feds-topnav');
   const fedsWrapper = document.querySelector('.feds-nav-wrapper');

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -1,4 +1,4 @@
-import { createTag, getConfig, getMetadata, loadStyle } from '../../utils/utils.js';
+import { createTag, getConfig, getMetadata } from '../../utils/utils.js';
 import { isDynamicNavDisabled } from './dynamic-navigation.js';
 
 export const ACTIVE = 'active';

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1127,6 +1127,8 @@ export async function loadDeferred(area, blocks, config) {
       .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
   }
   if (config?.dynamicNavKey && config?.env?.name !== 'prod') {
+    const { miloLibs } = getConfig();
+    loadStyle(`${miloLibs}/features/dynamic-navigation/status.css`);
     const { default: loadDNStatus } = await import('../features/dynamic-navigation/status.js');
     loadDNStatus();
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1126,7 +1126,7 @@ export async function loadDeferred(area, blocks, config) {
     import('../features/personalization/preview.js')
       .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
   }
-  if (config?.dynamicNavKey) {
+  if (config?.dynamicNavKey && config?.env?.name !== 'prod') {
     const { default: loadDNStatus } = await import('../features/dynamic-navigation/status.js');
     loadDNStatus();
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1127,7 +1127,7 @@ export async function loadDeferred(area, blocks, config) {
       .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
   }
   if (config?.dynamicNavKey && config?.env?.name !== 'prod') {
-    const { miloLibs } = getConfig();
+    const { miloLibs } = config;
     loadStyle(`${miloLibs}/features/dynamic-navigation/status.css`);
     const { default: loadDNStatus } = await import('../features/dynamic-navigation/status.js');
     loadDNStatus();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1126,6 +1126,10 @@ export async function loadDeferred(area, blocks, config) {
     import('../features/personalization/preview.js')
       .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
   }
+  if (config?.dynamicNavKey) {
+    const { default: loadDNStatus } = await import('../features/dynamic-navigation/status.js');
+    loadDNStatus();
+  }
 }
 
 function initSidekick() {

--- a/test/features/dynamic-nav/dynamicNav.test.js
+++ b/test/features/dynamic-nav/dynamicNav.test.js
@@ -1,7 +1,7 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { setConfig } from '../../../libs/utils/utils.js';
-import dynamicNav from '../../../libs/features/dynamic-navigation.js';
+import dynamicNav from '../../../libs/features/dynamic-navigation/dynamic-navigation.js';
 
 describe('Dynamic nav', () => {
   beforeEach(() => {

--- a/test/features/dynamic-nav/mocks/status.html
+++ b/test/features/dynamic-nav/mocks/status.html
@@ -1,0 +1,9 @@
+<header>
+  <nav class="feds-topnav" aria-label="Main">
+    <div class="feds-brand-container">
+    </div>
+    <div class="feds-nav-wrapper" id="feds-nav-wrapper">
+      <div class="feds-nav"></div>
+    </div>
+  </nav>
+</header>

--- a/test/features/dynamic-nav/status.test.js
+++ b/test/features/dynamic-nav/status.test.js
@@ -1,6 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import { getConfig, setConfig, createTag } from '../../../libs/utils/utils.js';
+import { getConfig, setConfig, createTag, loadDeferred } from '../../../libs/utils/utils.js';
 import dynamicNav from '../../../libs/features/dynamic-navigation/dynamic-navigation.js';
 import status, { tooltipInfo, ACTIVE, INACTIVE, ENABLED } from '../../../libs/features/dynamic-navigation/status.js';
 
@@ -27,15 +27,24 @@ describe('Dynamic Nav Status', () => {
     setConfig(conf);
   });
 
-  it('does not load the widget on production', () => {
+  it('does not load the widget on production', async () => {
     const conf = getConfig();
     conf.env.name = 'prod';
 
-    dynamicNav();
-    status();
+    await loadDeferred(document, [], conf, () => {});
 
     const statusWidget = document.querySelector('.dynamic-nav-status');
     expect(statusWidget).to.be.null;
+  });
+
+  it('does load the widget on a lower env', async () => {
+    const conf = getConfig();
+    conf.env.name = 'local';
+
+    await loadDeferred(document, [], conf, () => {});
+
+    const statusWidget = document.querySelector('.dynamic-nav-status');
+    expect(statusWidget).to.exist;
   });
 
   it('loads the status widget', () => {

--- a/test/features/dynamic-nav/status.test.js
+++ b/test/features/dynamic-nav/status.test.js
@@ -1,0 +1,248 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import { getConfig, setConfig, createTag } from '../../../libs/utils/utils.js';
+import dynamicNav from '../../../libs/features/dynamic-navigation/dynamic-navigation.js';
+import status, { tooltipInfo, ACTIVE, INACTIVE, ENABLED } from '../../../libs/features/dynamic-navigation/status.js';
+
+const statusText = (parentElement) => {
+  const info = {
+    additionalInfo: parentElement.querySelector('.additional-info span').innerText,
+    status: parentElement.querySelector('.details .status span').innerText,
+    setting: parentElement.querySelector('.details .setting span').innerText,
+    consumerKey: parentElement.querySelector('.details .consumer-key span').innerText,
+    match: parentElement.querySelector('.nav-source-info p:nth-child(1) span').innerText,
+    authoredSource: parentElement.querySelector('.nav-source-info p:nth-child(2) span').innerText,
+    storedSource: parentElement.querySelector('.nav-source-info p:nth-child(3) span').innerText,
+  };
+  return info;
+};
+
+const GNAV_SOURCE = 'https://main--milo--adobecom.hlx.live/some-source-string';
+
+describe('Dynamic Nav Status', () => {
+  beforeEach(async () => {
+    const conf = { dynamicNavKey: 'bacom' };
+    document.body.innerHTML = await readFile({ path: './mocks/status.html' });
+    document.head.innerHTML = '<meta name="dynamic-nav" content=""><meta name="gnav-source" content="">';
+    setConfig(conf);
+  });
+
+  it('does not load the widget on production', () => {
+    const conf = getConfig();
+    conf.env.name = 'prod';
+
+    dynamicNav();
+    status();
+
+    const statusWidget = document.querySelector('.dynamic-nav-status');
+    expect(statusWidget).to.be.null;
+  });
+
+  it('loads the status widget', () => {
+    dynamicNav();
+    status();
+
+    const statusWidget = document.querySelector('.dynamic-nav-status');
+    expect(statusWidget).to.not.be.null;
+  });
+
+  it('loads the status widget in an active state', () => {
+    document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+    window.sessionStorage.setItem('gnavSource', 'some-source-string');
+
+    dynamicNav();
+    status();
+
+    const statusWidget = document.querySelector('.dynamic-nav-status');
+    expect(statusWidget.classList.contains(ACTIVE)).to.be.true;
+  });
+
+  it('loads the status widget in an enabled state', () => {
+    document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+
+    dynamicNav();
+    status();
+
+    const statusWidget = document.querySelector('.dynamic-nav-status');
+    expect(statusWidget.classList.contains(ENABLED)).to.be.true;
+  });
+
+  it('loads the status widget in an inactive state', () => {
+    dynamicNav();
+    status();
+
+    const statusWidget = document.querySelector('.dynamic-nav-status');
+    expect(statusWidget.classList.contains(INACTIVE)).to.be.true;
+  });
+
+  describe('content validation', () => {
+    it('displays the correct information to the user for the active state "entry"', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'entry');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', GNAV_SOURCE);
+      window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const info = statusText(statusWidget);
+      expect(info.additionalInfo).to.equal(tooltipInfo[ACTIVE]);
+      expect(info.status).to.equal(ACTIVE);
+      expect(info.setting).to.equal('entry');
+      expect(info.consumerKey).to.equal('bacom');
+      expect(info.match).to.equal('true');
+      expect(info.authoredSource).to.equal('/some-source-string');
+      expect(info.storedSource).to.equal('/some-source-string');
+    });
+
+    it('displays the correct information to the user for the active state "on"', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const info = statusText(statusWidget);
+      expect(info.additionalInfo).to.equal(tooltipInfo[ACTIVE]);
+      expect(info.status).to.equal(ACTIVE);
+      expect(info.setting).to.equal('on');
+      expect(info.consumerKey).to.equal('bacom');
+      expect(info.match).to.equal('false');
+      expect(info.authoredSource).to.equal('/test');
+      expect(info.storedSource).to.equal('/some-source-string');
+    });
+
+    it('displays the correct information to the user for the active state "off"', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', '');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const info = statusText(statusWidget);
+      expect(info.additionalInfo).to.equal(tooltipInfo[INACTIVE]);
+      expect(info.status).to.equal(INACTIVE);
+      expect(info.setting).to.equal('');
+      expect(info.consumerKey).to.equal('bacom');
+      expect(info.match).to.equal('true');
+      expect(info.authoredSource).to.equal('/test');
+      expect(info.storedSource).to.equal('/test');
+    });
+
+    it('displays the correct information to the user for the enabled state "on"', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const info = statusText(statusWidget);
+      expect(info.additionalInfo).to.equal(tooltipInfo[ENABLED]);
+      expect(info.status).to.equal(ENABLED);
+      expect(info.setting).to.equal('on');
+      expect(info.consumerKey).to.equal('bacom');
+      expect(info.match).to.equal('true');
+      expect(info.authoredSource).to.equal('/test');
+      expect(info.storedSource).to.equal('/test');
+    });
+  });
+
+  describe('disabled values', () => {
+    it('loads the status widget in an inactive state when disable values are present', () => {
+      const disableTag = createTag('meta', { name: 'dynamic-nav-disable', content: 'PrimaryProductName;Commerce Cloud' });
+      const ppn = createTag('meta', { name: 'primaryproductname', content: 'Commerce Cloud' });
+      document.querySelector('head').append(disableTag, ppn);
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const info = statusText(statusWidget);
+      expect(info.additionalInfo).to.equal(tooltipInfo[INACTIVE]);
+      expect(info.status).to.equal(INACTIVE);
+    });
+
+    it('loads the status widget in an active state when disabled values present but not correct', () => {
+      const disableTag = createTag('meta', { name: 'dynamic-nav-disable', content: 'PrimaryProductName;Digital Media' });
+      const ppn = createTag('meta', { name: 'primaryproductname', content: 'Commerce Cloud' });
+      document.querySelector('head').append(disableTag, ppn);
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const info = statusText(statusWidget);
+      expect(info.additionalInfo).to.equal(tooltipInfo[ACTIVE]);
+      expect(info.status).to.equal(ACTIVE);
+    });
+
+    it('shows the correct disable values that are active in a table', () => {
+      const disableTag = createTag('meta', { name: 'dynamic-nav-disable', content: 'PrimaryProductName;Commerce Cloud' });
+      const ppn = createTag('meta', { name: 'primaryproductname', content: 'Commerce Cloud' });
+      document.querySelector('head').append(disableTag, ppn);
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const info = statusText(statusWidget);
+      const disableValuesTable = statusWidget.querySelector('.disable-values');
+      expect(info.additionalInfo).to.equal(tooltipInfo[INACTIVE]);
+      expect(info.status).to.equal(INACTIVE);
+      expect(disableValuesTable.querySelector('caption')).to.exist;
+      expect(disableValuesTable.querySelector('tbody tr td:nth-child(1)')).to.exist;
+      expect(disableValuesTable.querySelector('tbody tr td:nth-child(1)').innerText).to.equal('PrimaryProductName');
+      expect(disableValuesTable.querySelector('tbody tr td:nth-child(2)')).to.exist;
+      expect(disableValuesTable.querySelector('tbody tr td:nth-child(2)').innerText).to.equal('Commerce Cloud');
+    });
+  });
+
+  describe('Event listeners', () => {
+    it('toggles the details', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+
+      dynamicNav();
+      status();
+
+      const dynamicNavStatus = document.querySelector('.dynamic-nav-status');
+      const details = dynamicNavStatus.querySelector('.details');
+
+      expect(details.classList.contains('hidden')).to.be.true;
+      dynamicNavStatus.click();
+      expect(details.classList.contains('hidden')).to.be.false;
+    });
+
+    it('removes the whole status when close is clicked', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+
+      dynamicNav();
+      status();
+
+      let dynamicNavStatus = document.querySelector('.dynamic-nav-status');
+      const details = dynamicNavStatus.querySelector('.details');
+      dynamicNavStatus.click();
+      const closeButton = details.querySelector('.dns-close');
+      closeButton.click();
+      dynamicNavStatus = document.querySelector('.dynamic-nav-status');
+      expect(dynamicNavStatus).to.be.null;
+    });
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+});

--- a/test/features/dynamic-nav/status.test.js
+++ b/test/features/dynamic-nav/status.test.js
@@ -217,6 +217,8 @@ describe('Dynamic Nav Status', () => {
       expect(disableValuesTable.querySelector('tbody tr td:nth-child(1)').innerText).to.equal('PrimaryProductName');
       expect(disableValuesTable.querySelector('tbody tr td:nth-child(2)')).to.exist;
       expect(disableValuesTable.querySelector('tbody tr td:nth-child(2)').innerText).to.equal('Commerce Cloud');
+      expect(disableValuesTable.querySelector('tbody tr td:nth-child(3)')).to.exist;
+      expect(disableValuesTable.querySelector('tbody tr td:nth-child(3)').innerText).to.equal('yes');
     });
   });
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds a status button to appear in the nav to inform content QA and QA whether or not the Dynamic Nav is active and to provide additional information about Dynamic Nav and it's settings. 
* The experience is set for tablet and up, since the core user is QA. 

Context: 
The milo repo does not have the dynamicNavKey in the config, so the first two links will not show the feature.

Resolves: [MWPW-157147](https://jira.corp.adobe.com/browse/MWPW-157147)

**Test URLs:**
- Before: https://main--milo--jasonhowellslavin.hlx.page/drafts/slavin/dynamic-nav/bacom-sample-on?martech=off
- After: https://dynamic-nav-status-button--milo--jasonhowellslavin.hlx.page/drafts/slavin/dynamic-nav/bacom-sample-on?martech=off

Bacom
- Before: https://main--bacom--adobecom.hlx.page/drafts/slavin/dynamic-nav/aem-rtcdp-entry?martech=off
- After: https://main--bacom--adobecom.hlx.page/drafts/slavin/dynamic-nav/aem-rtcdp-entry?milolibs=dynamic-nav-status-button&martech=off
