### PR TITLE
MWPW-155984 - Brick list showing null value in link label

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -47,8 +47,11 @@ export function decorateIconStack(el) {
     const picIndex = links[0].querySelector('a picture') ? 0 : 1;
     const linkImg = links[picIndex];
     const linkText = links[1 - picIndex];
-    linkText.prepend(linkImg.querySelector('picture'));
-    linkImg.remove();
+    const linkPic = linkImg.querySelector('picture');
+    if (linkPic) {
+      linkText.prepend(linkPic);
+      linkImg.remove();
+    }
   });
 }
 


### PR DESCRIPTION
Added a conditional check in a shared function `decorateIconStack()` that was causing this. 

(This brick list authoring was triggering some shared link checking logic that wasn't properly verifying for null values) 


Resolves: [MWPW-155984](https://jira.corp.adobe.com/browse/MWPW-155984)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/masonry/brick-list?martech=off
- After: https://rparrish-brick-lists--milo--adobecom.hlx.page/drafts/rparrish/masonry/brick-list?martech=off


**Live URLs:**
- Before: https://main--dc--adobecom.hlx.page/drafts/ntran/brick-null-bug?martech=off
- After: https://main--dc--adobecom.hlx.page/drafts/ntran/brick-null-bug?milolibs=rparrish-brick-lists&martech=off


**Regression:** blocks that use this function (aside, brick)
- aside Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/aside?martech=off
- aside After: https://rparrish-brick-lists--milo--adobecom.hlx.page/docs/library/kitchen-sink/aside?martech=off
- brick Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/brick?martech=off
- brick After: https://rparrish-brick-lists--milo--adobecom.hlx.page/docs/library/kitchen-sink/brick?martech=off
