### PR TITLE
MWPW-155489 [PEP] Add device type as PEP criteria

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -637,9 +637,12 @@ class Gnav {
     const state = getMetadata('app-prompt')?.toLowerCase();
     const entName = getMetadata('app-prompt-entitlement')?.toLowerCase();
     const promptPath = getMetadata('app-prompt-path')?.toLowerCase();
+    const hasMobileUA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Touch/i.test(navigator.userAgent);
+
     if (state === 'off'
       || !window.adobeIMS?.isSignedInUser()
       || !isDesktop.matches
+      || hasMobileUA
       || !entName?.length
       || !promptPath?.length) return;
 


### PR DESCRIPTION
Due to our specific viewport breakpoints, PEP was being served to iPhone/iPad users browsing with their device held horizontally. This lead to a requirement for serving PEP only to desktop users. 

- We've used the same check MEP uses to determine if the user is on a mobile device or not
- We haven't imported the MEP check since, in pages where personalization is turned off, the browser would needlessly download and parse the personalization.js just for the User Agent check.
- Requirements for MEP and PEP won't necessarily move in lockstep, so it makes sense to maintain our own list of User Agents we'll check for in PEP.

Note: As [MDN recommends](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent#avoiding_user_agent_detection), it's preferable to not do useragent sniffing and prefer feature detection instead. In our case this would mean, if we're redirecting to a web app, do the feature detection for that particular webapp before we decide to redirect the user to that webapp. But this is a more complicated problem to solve and it'll need to be looked into (if it's even worth the effort).


Resolves: [MWPW-155489](https://jira.corp.adobe.com/browse/MWPW-155489)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://pep-ua--milo--sharmrj.hlx.page/?martech=off
- QA: https://main--cc--adobecom.hlx.page/products/photoshop-lightroom?milolibs=pep-ua--milo--sharmrj&skipPepEntitlements=true
