### PR TITLE
GNav - Remove Header Display none

### DIFF
--- a/libs/blocks/home/home.css
+++ b/libs/blocks/home/home.css
@@ -1,7 +1,3 @@
-header {
-  display: none;
-}
-
 .home {
   display: grid;
   position: relative;


### PR DESCRIPTION
Allowing the Gnav to appear on the Milo Start Page

Resolves: [MWPW-154047](https://jira.corp.adobe.com/browse/MWPW-154047)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-154047--milo--akanshaa-18.hlx.page/?martech=off
