### PR TITLE
MWPW-158652 [MEP] skip rows missing an action value

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -513,6 +513,10 @@ const getVariantInfo = (line, variantNames, variants, manifestPath, fTargetId) =
   // retro support
   const action = line.action?.toLowerCase()
     .replace('content', '').replace('fragment', '').replace('tosection', '');
+  if (config.mep?.preview && !action) {
+    console.log('Invalid action found: ', line);
+    return;
+  }
   const pageFilter = line['page filter'] || line['page filter optional'];
   const { selector } = line;
 
@@ -565,9 +569,6 @@ const getVariantInfo = (line, variantNames, variants, manifestPath, fTargetId) =
       }
     } else if (action in COMMANDS || action in CREATE_CMDS) {
       variants[vn].commands.push(variantInfo);
-    } else {
-      /* c8 ignore next 2 */
-      console.log('Invalid action found: ', line);
     }
   });
 };

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -513,10 +513,8 @@ const getVariantInfo = (line, variantNames, variants, manifestPath, fTargetId) =
   // retro support
   const action = line.action?.toLowerCase()
     .replace('content', '').replace('fragment', '').replace('tosection', '');
-  if (config.mep?.preview && !action) {
-    console.log('Invalid action found: ', line);
-    return;
-  }
+  if (config.mep?.preview && !action) console.log('Invalid action found: ', line);
+  if (!action) return;
   const pageFilter = line['page filter'] || line['page filter optional'];
   const { selector } = line;
 


### PR DESCRIPTION
Currently, a MEP manifest action row with no value in the action column outputs a message in the console. Instead, the action should just be skipped.

Additionally, if there is an "invalid" action, the message should only be displayed for internal users. aka if we are going to show the MEP button.

QA steps: The "After" link should not log "Invalid action found." To test that it still logs the error message in preview mode, remove the mepButton parameter. 

Resolves: [MWPW-158652](https://jira.corp.adobe.com/browse/MWPW-158652)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/skipmissingaction/base?mepButton=off&martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/skipmissingaction/base?milolibs=fixmissingactionerror&mepButton=off&martech=off
- Psi-check: https://fixmissingactionerror--milo--adobecom.hlx.page/?martech=off
