### PR TITLE
MWPW-159032: Defaults to empty alt tag on the svg - Accessibility requirement

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -506,7 +506,7 @@ export function decorateSVG(a) {
     const src = textUrl.hostname.includes(`.${SLD}.`) ? textUrl.pathname : textUrl;
 
     const img = createTag('img', { loading: 'lazy', src });
-    if (altText) img.alt = altText;
+    img.alt = altText || '';
     const pic = createTag('picture', null, img);
 
     if (textUrl.pathname === hrefUrl.pathname) {


### PR DESCRIPTION
*This exist before, and we are getting request by accessibility to added again for unity project

* Defaults to empty alt tag on the image if no alt text is authored. Per accessibility best practices this declares the image as "decorative".

Resolves: [MWPW-159032](https://jira.corp.adobe.com/browse/MWPW-159032)
**Test URLs:**
- Before: https://main--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf-projectunity?martech=off
- After: https://main--dc--adobecom.hlx.page/acrobat/online/test/sign-pdf-projectunity?martech=off&milolibs=MWPW-159032--milo--joaquinrivero
