### PR TITLE
[MWPW-156723] Add option for brick stroke

### DIFF
--- a/libs/blocks/brick/brick.css
+++ b/libs/blocks/brick/brick.css
@@ -20,6 +20,14 @@
   color: var(--color-white);
 }
 
+.brick.border {
+  border: 1px solid var(--color-gray-200);
+}
+
+.brick.click > a {
+  text-decoration: none;
+}
+
 .brick .background {
   position: absolute;
   bottom: 0;
@@ -30,7 +38,7 @@
 }
 
 .brick .foreground {
-  position: relative; 
+  position: relative;
   display: flex;
   flex-grow: 1;
   padding: var(--spacing-m);
@@ -116,8 +124,17 @@
 .brick .foreground p.action-area {
   display: flex;
   flex-wrap: wrap;
-  gap: 24px;
+  gap: var(--spacing-s);
   margin-top: var(--spacing-s);
+}
+
+.brick .icon-stack-area li,
+.brick .icon-stack-area li a {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  text-align: start;
+  flex-shrink: 0;
 }
 
 .brick .icon-stack-area li picture {
@@ -125,6 +142,11 @@
   margin: 0;
   padding: 0;
   flex-shrink: 0;
+}
+
+.brick .foreground a:not([class]),
+.brick .foreground span.first-link {
+  font-weight: 700;
 }
 
 .brick .foreground .icon-area picture {
@@ -145,10 +167,6 @@
   width: auto;
 }
 
-.brick.click > a {
-  text-decoration: none;
-}
-
 .brick .icon-stack-area {
   display: flex;
   flex-flow: row wrap;
@@ -163,25 +181,6 @@
 .brick.center .icon-stack-area {
   display: inline-flex;
   width: auto;
-}
-
-.brick .icon-stack-area li,
-.brick .icon-stack-area li a {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  text-align: left;
-  flex-shrink: 0;
-}
-
-.brick .foreground a:not([class]),
-.brick .foreground span.first-link {
-  font-weight: 700;
-}
-
-[dir="rtl"] .brick .icon-stack-area li,
-[dir="rtl"] .brick .icon-stack-area li a {
-  text-align: right;
 }
 
 .brick.click a.foreground .first-link:not([class*="button"]) {
@@ -295,6 +294,12 @@
     width: 41.66%;
   }
 
+  .brick.split.row .foreground,
+  .brick.split.row .foreground .brick-media,
+  .brick.split.row .foreground picture {
+    border-radius: inherit;
+  }
+
   .brick.split.horizontal-center .foreground .brick-text,
   .brick.split.center .foreground .brick-text {
     margin: 0;
@@ -320,12 +325,6 @@
     grid-column: 8 / span 5;
   }
 
-  .brick.split.row .foreground,
-  .brick.split.row .foreground .brick-media,
-  .brick.split.row .foreground picture {
-    border-radius: inherit;
-  }
-
   .brick.stack .foreground .brick-media picture,
   .brick.stack .foreground .brick-media img,
   .brick.stack .foreground .brick-media video {
@@ -342,7 +341,7 @@
     margin: 0;
     position: absolute;
   }
-  
+
   .brick .foreground .brick-media video,
   .brick.split.row .foreground .brick-media video {
     object-fit: fill;


### PR DESCRIPTION
This adds a new variant to the Brick block, when the `border` variant is used. The width and color of the border can't be authored for the moment, this has been confirmed with Consonant. Figma specs can be found [here](https://www.figma.com/design/70nDFHkj7QNBx0CicnPdHs/Untitled?node-id=9-3627&node-type=instance&t=thEFcediqYJL2cz7-0). The [Kitchen Sink](https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/brick) is in the process of being updated (look for the List with Brick tab).

Most of the changes in this PR were made to address some CSSLint issues, but nothing essential has been updated. A quick regression would, however, be beneficial.

Resolves: [MWPW-156723](https://jira.corp.adobe.com/browse/MWPW-156723)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/brick?martech=off
- After: https://brick-stroke--milo--overmyheadandbody.hlx.page/drafts/ramuntea/brick?martech=off
