### PR TITLE
[MWPW-153616] Update 404 links in region selector

### DIFF
--- a/test/blocks/region-nav/mocks/regions.html
+++ b/test/blocks/region-nav/mocks/regions.html
@@ -5,12 +5,14 @@
       <p><strong>Americas</strong></p>
       <ul>
         <li><a href="/ar/">Argentina</a></li>
-        <li><a href="/br/">Brasil</a></li>
+        <li><a href="/br/path/to/page">Brasil</a></li>
         <li><a href="/">United States</a></li>
       </ul>
       <p><strong>Europe, Middle East and Africa</strong></p>
       <ul>
         <li><a href="/africa/">Africa - English</a></li>
+        <li><a href="/ch_de/path/to/page">Schweiz</a></li>
+        <li><a href="/ch_fr/path/to/page">Suisse</a></li>
         <li><a href="https:adobe.com/ru/">Россия</a></li>
         <li><a href="/ua/">Україна</a></li>
         <li><a href="/il_he/">ישראל - עברית</a></li>
@@ -18,7 +20,7 @@
       </ul>
       <p><strong>Asia Pacific</strong></p>
       <ul>
-        <li><a href="/au/">Australia</a></li>
+        <li><a href="/au/path/to/page">Australia</a></li>
         <li><a href="/my_ms/">Malaysia</a></li>
         <li><a href="/kr/">한국</a></li>
       </ul>

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -1,5 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 import { setConfig, getConfig } from '../../../libs/utils/utils.js';
 
 import init from '../../../libs/blocks/region-nav/region-nav.js';
@@ -7,16 +8,100 @@ import init from '../../../libs/blocks/region-nav/region-nav.js';
 document.body.innerHTML = await readFile({ path: './mocks/regions.html' });
 
 setConfig({ });
+
+const getCookie = (name) => document.cookie
+  .split('; ')
+  .find((row) => row.startsWith(`${name}=`))
+  ?.split('=')[1];
+
 describe('Region Nav Block', () => {
-  it('sets links correctly', async () => {
-    const block = document.body.querySelector('.region-nav');
-    init(block);
-    const links = document.body.querySelectorAll('a');
+  const block = document.body.querySelector('.region-nav');
+  init(block);
+  let clock;
+
+  beforeEach(async () => {
+    clock = sinon.useFakeTimers({
+      toFake: ['setTimeout'],
+      shouldAdvanceTime: true,
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('sets links correctly', () => {
     const { contentRoot } = getConfig().locale;
     window.location.hash = 'langnav';
     const path = window.location.href.replace(`${contentRoot}`, '').replace('#langnav', '');
+    const links = document.body.querySelectorAll('a');
     expect(links[0].href).to.be.equal(`${origin}/ar${path}`);
     expect(links[links.length - 1].href).to.be.equal(`${origin}/kr${path}`);
-    window.location.hash = '';
+  });
+
+  it('handles mouseover event for 200 pages', async () => {
+    sinon.stub(window, 'fetch').callsFake(() => new Promise((resolve) => {
+      resolve({
+        status: 200,
+        ok: true,
+      });
+    }));
+    sinon.stub(Element.prototype, 'matches').callsFake(() => true);
+    const mouseoverEvent = new Event('mouseover');
+
+    const auLink = document.querySelector('a[href*="/au/"]');
+    const auLinkHref = auLink.href;
+    auLink.dispatchEvent(mouseoverEvent);
+    await clock.runAllAsync();
+    expect(auLink.href).to.equal(auLinkHref);
+  });
+
+  it('handles mouseover event for 404 pages', async () => {
+    sinon.stub(window, 'fetch').callsFake(() => new Promise((resolve) => {
+      resolve({
+        status: 404,
+        ok: false,
+      });
+    }));
+    sinon.stub(Element.prototype, 'matches').callsFake(() => true);
+    const mouseoverEvent = new Event('mouseover');
+
+    const brLink = document.querySelector('a[href*="/br/"]');
+    brLink.dispatchEvent(mouseoverEvent);
+    await clock.runAllAsync();
+    expect(brLink.href).to.equal(`${origin}/br/`);
+  });
+
+  it('handles click event for 200 pages', async () => {
+    sinon.stub(window, 'fetch').callsFake(() => new Promise((resolve) => {
+      resolve({
+        status: 200,
+        ok: true,
+      });
+    }));
+    sinon.stub(window, 'open').callsFake(() => {});
+
+    const chdePrefix = 'ch_de';
+    const chdeLink = document.querySelector(`a[href*="/${chdePrefix}/"]`);
+    chdeLink.click();
+    await clock.runAllAsync();
+    expect(window.open.calledWith(chdeLink.href)).to.be.true;
+    expect(getCookie('international')).to.equal(chdePrefix);
+  });
+
+  it('handles click event for 404 pages', async () => {
+    sinon.stub(window, 'fetch').callsFake(() => new Promise((resolve) => {
+      resolve({
+        status: 404,
+        ok: false,
+      });
+    }));
+    sinon.stub(window, 'open').callsFake(() => {});
+
+    const chfrPrefix = '/ch_fr/';
+    const chfrLink = document.querySelector(`a[href*="${chfrPrefix}"]`);
+    chfrLink.click();
+    await clock.runAllAsync();
+    expect(window.open.calledWith(chfrPrefix)).to.be.true;
   });
 });


### PR DESCRIPTION
This makes a few adjustments to the link interaction logic inside the region nav modal. Currently, there are a few scenarios where we might confuse users. Clicking on a link makes a HEAD fetch request to check whether the analog page exists on the newly chosen locale. If so, the user gets redirected to that page. Otherwise, they are being redirected to the root of the newly chosen locale. Most other interactions with region nav links can lead to unexpected outcomes, which this PR tries to minimize.

| **Scenario** | Current behavior | Updated behavior |
| ------------- | ------------- | ------------- |
| **User clicks the link** | gets redirected to the equivalent page or locale root, international cookie set | gets redirected to the equivalent page or locale root, international cookie set |
| **User CMD+clicks the link** | gets redirected to the equivalent page or locale root in the same tab, international cookie set | slow action (>>100ms) - new tab is opened with equivalent page or locale root, international cookie set; <br /><br />fast action (<100ms) - new tab is opened and FOCUSED with equivalent page or locale root, international cookie set |
| **User tabs+enters link** | gets redirected to the equivalent page or locale root, international cookie set | gets redirected to the equivalent page or locale root, international cookie set |
| **User right clicks to copy the link** | link to potentially 404 equivalent page is copied, NO international cookie set | slow action (>>100ms) - link for equivalent page or locale root is copied, NO international cookie set; <br /><br />fast action (<100ms) - link to potentially 404 equivalent page is copied, NO international cookie set |
| **User right clicks to open link in new tab** | new tab is opened with potentially 404 equivalent page, NO international cookie set | slow action (>>100ms) - new tab is opened with equivalent page or locale root, NO international cookie set; <br /><br />fast action (<100ms) - new tab is opened with potentially 404 equivalent page, NO international cookie set |

QA notes:
* please make sure the international cookie is appropriately set according to the table above.

Developer notes:
* I initially tried to make use of the `contextmenu` event, but the `href` does not get reflected when the user eventually clicks to open the link in a new tab or copy its URL;
* the `100ms` timeout is based on trial and error. We want the value to be low, so that the fetch requests are made before the user manages to right click on the link, but we also don't want to make too many such requests for links the user might not actually be interested in. I found `100ms` to be a sweet spot;
* this sort of approach using `mouseover` will not play well with tools checking for 404 links, so authors might still bring up this issue;
* I did consider setting the international cookie after a `contextmenu` interaction coupled with a `visibilitychange` one, but there's no clear indication of whether the interaction was intentional or not. The user may have moved to a completely different tab, may come back to the initial one realizing they clicked the wrong locale, refresh the page after opening the context menu, etc. There's no sure way to check these scenarios, so I preferred to not complicate things for now, as this should be a rare occurrence in the first place.

Resolves: [MWPW-153616](https://jira.corp.adobe.com/browse/MWPW-153616)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/brick?martech=off#langnav
- After: https://langnav-context--milo--overmyheadandbody.hlx.page/drafts/ramuntea/brick?martech=off#langnav
