### PR TITLE
Add isSectionDividerRequired feature support to gnav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -625,6 +625,7 @@ class Gnav {
         onAnalyticsEvent,
       },
       children: getChildren(),
+      isSectionDividerRequired: getConfig()?.showUnavSectionDivider,
     });
 
     // Exposing UNAV config for consumers

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -4,7 +4,7 @@ const blockConfig = [
     name: 'global-navigation',
     targetEl: 'header',
     appendType: 'prepend',
-    params: ['imsClientId', 'searchEnabled', 'unavHelpChildren', 'customLinks'],
+    params: ['imsClientId', 'searchEnabled', 'unavHelpChildren', 'customLinks', 'showUnavSectionDivider'],
   },
   {
     key: 'footer',

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -45,7 +45,6 @@ export default async function loadBlock(configs, customLib) {
   const branch = new URLSearchParams(window.location.search).get('navbranch');
   const miloLibs = branch ? `https://${branch}--milo--adobecom.hlx.page` : customLib || envMap[env];
   if (!header && !footer) {
-    // eslint-disable-next-line no-console
     console.error('Global navigation Error: header and footer configurations are missing.');
     return;
   }

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -45,6 +45,7 @@ export default async function loadBlock(configs, customLib) {
   const branch = new URLSearchParams(window.location.search).get('navbranch');
   const miloLibs = branch ? `https://${branch}--milo--adobecom.hlx.page` : customLib || envMap[env];
   if (!header && !footer) {
+    // eslint-disable-next-line no-console
     console.error('Global navigation Error: header and footer configurations are missing.');
     return;
   }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Unav has a isSectionDividerRequired feature which gnav needs to support.
* Global navigation component will take it in the config and pass it to unav config

Resolves: [MWPW-159143](https://jira.corp.adobe.com/browse/MWPW-159143)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://unav-divider--milo--adobecom.hlx.page/?martech=off

Qa: https://adobecom.github.io/nav-consumer/navigation.html?navbranch=unav-divider&env=stage&showUnavSectionDivider=true
