### PR TITLE
Disable failing MAS test for now

### DIFF
--- a/libs/features/mas/web-components/test/merch-card.mini-compare.test.html.js
+++ b/libs/features/mas/web-components/test/merch-card.mini-compare.test.html.js
@@ -20,7 +20,7 @@ runTests(async () => {
     await mockFetch(withWcs);
     await mas();
     describe('merch-card web component with mini-compare variant', () => {
-        it('mini-compare-chart should have same body slot heights', async () => {
+        it.skip('mini-compare-chart should have same body slot heights', async () => {
             const miniCompareCharts = document.querySelectorAll(
                 'merch-card[variant="mini-compare-chart"]',
             );


### PR DESCRIPTION
### Description
Disable the failing MAS test so that the team can fix this async and we don't clog the pipeline by having all tests failing on every PR.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://disable-mas-unit-test--milo--mokimo.hlx.page/?martech=off
