### PR TITLE
MWPW-159197 Invoke onReady of standalone gnav when it is rendered

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1045,7 +1045,7 @@ export default async function init(block) {
     content,
     block,
   });
-  gnav.init();
+  await gnav.init();
   block.setAttribute('daa-im', 'true');
   const mepMartech = mep?.martech || '';
   block.setAttribute('daa-lh', `gnav|${getExperienceName()}${mepMartech}`);

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -214,9 +214,12 @@ export const createFullGlobalNavigation = async ({
     ),
   ]);
 
-  const instance = await initGnav(document.body.querySelector('header'));
-  instance.imsReady();
-  await clock.runAllAsync();
+  const instancePromise = initGnav(document.body.querySelector('header'));
+
+  await clock.runToLastAsync();
+  const instance = await instancePromise;
+  const imsPromise = instance.imsReady();
+  await clock.runToLastAsync();
   // We restore the clock here, because waitForElement uses setTimeout
   clock.restore();
 
@@ -241,6 +244,7 @@ export const createFullGlobalNavigation = async ({
     waitForElements.push(waitForElement(selectors.breadcrumbsWrapper, document.body));
   }
   await Promise.all(waitForElements);
+  await imsPromise;
 
   window.fetch = ogFetch;
   window.adobeIMS = undefined;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* We now do `await gnav.init()` so that `onReady` is called only when `gnav.init` is finished executing

Resolves: [MWPW-159197](https://jira.corp.adobe.com/browse/MWPW-159197)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://await-gnav-init--milo--sharmrj.hlx.page/?martech=off
