### PR TITLE
MWPW-159197 Invoke onReady of standalone gnav when it is rendered #2962

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1083,7 +1083,7 @@ export default async function init(block) {
     content,
     block,
   });
-  gnav.init();
+  await gnav.init();
   block.setAttribute('daa-im', 'true');
   const mepMartech = mep?.martech || '';
   block.setAttribute('daa-lh', `gnav|${getExperienceName()}${mepMartech}`);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -90,6 +90,7 @@ export const CONFIG = {
                   error: (e) => lanaLog({ message: 'Profile Menu error', e, tags: 'errorType=error,module=universalnav' }),
                 },
               },
+              ...getConfig().unav?.profile?.config,
             },
           },
           callbacks: {

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -215,9 +215,12 @@ export const createFullGlobalNavigation = async ({
     ),
   ]);
 
-  const instance = await initGnav(document.body.querySelector('header'));
-  instance.imsReady();
-  await clock.runAllAsync();
+  const instancePromise = initGnav(document.body.querySelector('header'));
+
+  await clock.runToLastAsync();
+  const instance = await instancePromise;
+  const imsPromise = instance.imsReady();
+  await clock.runToLastAsync();
   // We restore the clock here, because waitForElement uses setTimeout
   clock.restore();
 
@@ -242,6 +245,7 @@ export const createFullGlobalNavigation = async ({
     waitForElements.push(waitForElement(selectors.breadcrumbsWrapper, document.body));
   }
   await Promise.all(waitForElements);
+  await imsPromise;
 
   window.fetch = ogFetch;
   window.adobeIMS = undefined;


### PR DESCRIPTION
We now do `await gnav.init()` so that `onReady` is called only when `gnav.init` is finished executing
Resolves: [MWPW-159197](https://jira.corp.adobe.com/browse/MWPW-159197) [MWPW-159364](https://jira.corp.adobe.com/browse/MWPW-159364)

Test URLs:

Before: https://main--milo--adobecom.hlx.page/?martech=off
After: https://await-gnav-init--milo--sharmrj.hlx.page/?martech=off
QA: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=await-gnav-init

Added changes from: https://github.com/adobecom/milo/pull/2963