### PR TITLE
MWPW-159236 Fix duplicate percent in donut chart tooltip

### DIFF
--- a/libs/blocks/chart/chart.js
+++ b/libs/blocks/chart/chart.js
@@ -163,7 +163,7 @@ export const donutTooltipFormatter = ({
   name,
   percent,
 } = {}, unit = '') => (
-  `${marker} ${name}<br />${data[value[0]]}${unit} ${percent}%<i class="tooltip-icon"></i>`
+  `${marker} ${name}<br />${data[value[0]]}${unit}${unit !== '%' ? ` ${percent}%` : ''}<i class="tooltip-icon"></i>`
 );
 
 export const pieTooltipFormatter = ({


### PR DESCRIPTION
* Fixes duplicate percent in donut chart tooltip. Now, the automatically calculated percent will only show if the unit isn't percent ("%").

Resolves: [MWPW-159236](https://jira.corp.adobe.com/browse/MWPW-159236)

**Test URLs:**
Milo:
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/chart-donut-percent
- After: https://methomas-donut-percent--milo--adobecom.hlx.page/drafts/methomas/chart-donut-percent?martech=off


Bacom:
- Before: https://main--bacom--adobecom.hlx.live/resources/holiday-shopping-report
- After: https://main--bacom--adobecom.hlx.live/resources/holiday-shopping-report?milolibs=methomas-donut-percent
