### PR TITLE
Add support for Jarvis through Unav and make appID of notifications configurable

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -101,7 +101,7 @@ export const CONFIG = {
       appswitcher: { name: 'app-switcher' },
       notifications: {
         name: 'notifications',
-        attributes: { notificationsConfig: { applicationContext: { appID: 'adobecom' } } },
+        attributes: { notificationsConfig: { applicationContext: { appID: window.adobeid?.client_id } } },
       },
       help: {
         name: 'help',

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -107,6 +107,13 @@ export const CONFIG = {
         name: 'help',
         attributes: { children: getHelpChildren() },
       },
+      jarvis: {
+        name: 'jarvis',
+        attributes: {
+          appid: getConfig().jarvis?.id,
+          callbacks: getConfig().jarvis?.callbacks,
+        },
+      },
     },
   },
 };

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -632,6 +632,7 @@ class Gnav {
         onAnalyticsEvent,
       },
       children: getChildren(),
+      isSectionDividerRequired: getConfig()?.unav?.showSectionDivider,
     });
 
     // Exposing UNAV config for consumers

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -43,8 +43,8 @@ import {
 import { replaceKey, replaceKeyArray } from '../../features/placeholders.js';
 
 function getHelpChildren() {
-  const { unavHelpChildren } = getConfig();
-  return unavHelpChildren || [
+  const { unav } = getConfig();
+  return unav?.unavHelpChildren || [
     { type: 'Support' },
     { type: 'Community' },
   ];
@@ -101,7 +101,7 @@ export const CONFIG = {
       appswitcher: { name: 'app-switcher' },
       notifications: {
         name: 'notifications',
-        attributes: { notificationsConfig: { applicationContext: { appID: window.adobeid?.client_id } } },
+        attributes: { notificationsConfig: { applicationContext: { appID: getConfig().unav?.uncAppId || 'adobecom' } } },
       },
       help: {
         name: 'help',

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -4,7 +4,7 @@ const blockConfig = [
     name: 'global-navigation',
     targetEl: 'header',
     appendType: 'prepend',
-    params: ['imsClientId', 'searchEnabled', 'unavHelpChildren', 'customLinks', 'jarvis'],
+    params: ['imsClientId', 'searchEnabled', 'unav', 'customLinks', 'jarvis'],
   },
   {
     key: 'footer',

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -72,7 +72,7 @@ export default async function loadBlock(configs, customLib) {
       if (configBlock) {
         await bootstrapBlock(`${miloLibs}/libs`, {
           ...block,
-          ...(block.key === 'header' && { unavComponents: configBlock.unavComponents, redirect: configBlock.redirect }),
+          ...(block.key === 'header' && { unavComponents: configBlock.unav?.unavComponents, redirect: configBlock.redirect }),
         });
         configBlock.onReady?.();
       }

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -45,6 +45,7 @@ export default async function loadBlock(configs, customLib) {
   const branch = new URLSearchParams(window.location.search).get('navbranch');
   const miloLibs = branch ? `https://${branch}--milo--adobecom.hlx.page` : customLib || envMap[env];
   if (!header && !footer) {
+    // eslint-disable-next-line no-console
     console.error('Global navigation Error: header and footer configurations are missing.');
     return;
   }

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -4,7 +4,7 @@ const blockConfig = [
     name: 'global-navigation',
     targetEl: 'header',
     appendType: 'prepend',
-    params: ['imsClientId', 'searchEnabled', 'unavHelpChildren', 'customLinks'],
+    params: ['imsClientId', 'searchEnabled', 'unavHelpChildren', 'customLinks', 'jarvis'],
   },
   {
     key: 'footer',

--- a/test/navigation/bootstrapper.test.js
+++ b/test/navigation/bootstrapper.test.js
@@ -19,7 +19,7 @@ const blockConfig = {
     name: 'global-navigation',
     targetEl: 'header',
     appendType: 'prepend',
-    unav: { unavComponents: 'profile' }
+    unav: { unavComponents: 'profile' },
   },
 };
 

--- a/test/navigation/bootstrapper.test.js
+++ b/test/navigation/bootstrapper.test.js
@@ -19,7 +19,13 @@ const blockConfig = {
     name: 'global-navigation',
     targetEl: 'header',
     appendType: 'prepend',
-    unavComponents: 'profile',
+    unav: {
+      unavComponents: 'profile',
+      unavHelpChildren: [
+        { type: 'Support' },
+        { type: 'Community' }
+      ],
+    }
   },
 };
 

--- a/test/navigation/bootstrapper.test.js
+++ b/test/navigation/bootstrapper.test.js
@@ -19,13 +19,7 @@ const blockConfig = {
     name: 'global-navigation',
     targetEl: 'header',
     appendType: 'prepend',
-    unav: {
-      unavComponents: 'profile',
-      unavHelpChildren: [
-        { type: 'Support' },
-        { type: 'Community' }
-      ],
-    }
+    unav: { unavComponents: 'profile' }
   },
 };
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* With recent release, Jarvis is not under help component in Unav. Added jarvis as a child component.
* Make appID of unav's notifications component configurable
* Unav has a isSectionDividerRequired feature which gnav needs to support. Global navigation component will take it in the config and pass it to unav config

Resolves: [MWPW-159217](https://jira.corp.adobe.com/browse/MWPW-159217) and [MWPW-159143](https://jira.corp.adobe.com/browse/MWPW-159143)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://unav-jarvis--milo--adobecom.hlx.page/?martech=off

**Qa**: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=unav-jarvis&showUnavSectionDivider=true
