### PR TITLE
[MWPW-159265] Callout text in RTL not properly aligned

### DIFF
--- a/libs/deps/mas/mas.js
+++ b/libs/deps/mas/mas.js
@@ -1624,6 +1624,10 @@ merch-card [slot='callout-content'] > div > div {
     padding: var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxs);
 }
 
+merch-card [slot='callout-content']:dir(rtl) > div > div > div {
+    text-align: right;
+}
+
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
     text-align: left;

--- a/libs/deps/mas/mas.js
+++ b/libs/deps/mas/mas.js
@@ -1624,13 +1624,9 @@ merch-card [slot='callout-content'] > div > div {
     padding: var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxs);
 }
 
-merch-card [slot='callout-content']:dir(rtl) > div > div > div {
-    text-align: right;
-}
-
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
-    text-align: left;
+    text-align: start;
     font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) var(--body-font-family, 'Adobe Clean');
     letter-spacing: var(--consonant-merch-card-callout-letter-spacing);
     color: var(--consonant-merch-card-callout-font-color);

--- a/libs/deps/mas/merch-card.js
+++ b/libs/deps/mas/merch-card.js
@@ -1643,13 +1643,9 @@ merch-card [slot='callout-content'] > div > div {
     padding: var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxs);
 }
 
-merch-card [slot='callout-content']:dir(rtl) > div > div > div {
-    text-align: right;
-}
-
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
-    text-align: left;
+    text-align: start;
     font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) var(--body-font-family, 'Adobe Clean');
     letter-spacing: var(--consonant-merch-card-callout-letter-spacing);
     color: var(--consonant-merch-card-callout-font-color);

--- a/libs/deps/mas/merch-card.js
+++ b/libs/deps/mas/merch-card.js
@@ -1643,6 +1643,10 @@ merch-card [slot='callout-content'] > div > div {
     padding: var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxs);
 }
 
+merch-card [slot='callout-content']:dir(rtl) > div > div > div {
+    text-align: right;
+}
+
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
     text-align: left;

--- a/libs/deps/mas/plans-modal.js
+++ b/libs/deps/mas/plans-modal.js
@@ -5229,6 +5229,10 @@ merch-card [slot='callout-content'] > div > div {
     padding: var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxs);
 }
 
+merch-card [slot='callout-content']:dir(rtl) > div > div > div {
+    text-align: right;
+}
+
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
     text-align: left;

--- a/libs/deps/mas/plans-modal.js
+++ b/libs/deps/mas/plans-modal.js
@@ -5229,13 +5229,9 @@ merch-card [slot='callout-content'] > div > div {
     padding: var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxs);
 }
 
-merch-card [slot='callout-content']:dir(rtl) > div > div > div {
-    text-align: right;
-}
-
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
-    text-align: left;
+    text-align: start;
     font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) var(--body-font-family, 'Adobe Clean');
     letter-spacing: var(--consonant-merch-card-callout-letter-spacing);
     color: var(--consonant-merch-card-callout-font-color);

--- a/libs/features/mas/web-components/src/global.css.js
+++ b/libs/features/mas/web-components/src/global.css.js
@@ -231,6 +231,10 @@ merch-card [slot='callout-content'] > div > div {
     padding: var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxs);
 }
 
+merch-card [slot='callout-content']:dir(rtl) > div > div > div {
+    text-align: right;
+}
+
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
     text-align: left;

--- a/libs/features/mas/web-components/src/global.css.js
+++ b/libs/features/mas/web-components/src/global.css.js
@@ -231,13 +231,9 @@ merch-card [slot='callout-content'] > div > div {
     padding: var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxxs) var(--consonant-merch-spacing-xxs);
 }
 
-merch-card [slot='callout-content']:dir(rtl) > div > div > div {
-    text-align: right;
-}
-
 merch-card [slot='callout-content'] > div > div > div {
     display: inline-block;
-    text-align: left;
+    text-align: start;
     font: normal normal normal var(--consonant-merch-card-callout-font-size)/var(--consonant-merch-card-callout-line-height) var(--body-font-family, 'Adobe Clean');
     letter-spacing: var(--consonant-merch-card-callout-letter-spacing);
     color: var(--consonant-merch-card-callout-font-color);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

For RTL, make callout texts right aligned

Resolves: [MWPW-159265](https://jira.corp.adobe.com/browse/MWPW-159265)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/ae_ar/drafts/mili/kitchen-sink/merch-card
- After: https://MWPW-159265--milo--rohitsahu.hlx.page/ae_ar/drafts/mili/kitchen-sink/merch-card
