### PR TITLE
MWPW-159157: Update modal to account for new image size

### DIFF
--- a/libs/blocks/media/media.css
+++ b/libs/blocks/media/media.css
@@ -475,7 +475,7 @@ div[class*="-up"] .media .foreground > .media-row {
   }
 }
 
-.media.in-modal > .container.foreground > .media-row {
+.media.in-modal:not(.space-between) > .container.foreground > .media-row {
   display: grid;
   gap: 0;
 }
@@ -503,7 +503,7 @@ div[class*="-up"] .media .foreground > .media-row {
 }
 
 @media (orientation: landscape) {
-  .media.in-modal > .container.foreground > .media-row {
+  .media.in-modal:not(.space-between) > .container.foreground > .media-row {
     grid-template-columns: 1fr 1fr;
   }
 


### PR DESCRIPTION
We added support for a new class in the media block: 'space-between', which when added will add additional space between the right and left parts of the media block, see [Figma](https://www.figma.com/proto/Bvg6OTmb7WnzN8RcA3VrSC/Q4-24-BF%2FCM-All-Apps-Promo?page-id=0%3A1&node-id=10010-40784&viewport=3084%2C3842%2C0.07&t=emC0Wy3D2f49ELvt-1&scaling=scale-down-width&content-scaling=fixed&starting-point-node-id=1%3A2&disable-default-keyboard-nav=1).

Updated authoring documentation: https://main--milo--mirafedas.hlx.page/docs/authoring/promotions/delayed-modal

Resolves: [MWPW-159157](https://jira.corp.adobe.com/browse/MWPW-159157)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/aftereffects/free-trial-download?instant=2024-11-15T14:00:00.000Z 
- After: https://mwpw-159157-media-space-between--milo--mirafedas.hlx.page/drafts/mirafedas/delayed-modals/delayed-modal-space-between?georouting=off&martech=off
