### PR TITLE
[MWPW-159265] AI callout icon alignment fix in rtl and mobile

### DIFF
--- a/libs/deps/mas/mas.js
+++ b/libs/deps/mas/mas.js
@@ -1635,7 +1635,8 @@ merch-card [slot='callout-content'] > div > div > div {
 merch-card [slot='callout-content'] img {
     width: var(--consonant-merch-card-callout-icon-size);
     height: var(--consonant-merch-card-callout-icon-size);
-    margin: 2.5px 0px 0px 9px;
+    margin-inline-end: 2.5px;
+    margin-inline-start: 9px;
 }
 
 merch-card [slot='detail-m'] {

--- a/libs/deps/mas/merch-card.js
+++ b/libs/deps/mas/merch-card.js
@@ -1654,7 +1654,8 @@ merch-card [slot='callout-content'] > div > div > div {
 merch-card [slot='callout-content'] img {
     width: var(--consonant-merch-card-callout-icon-size);
     height: var(--consonant-merch-card-callout-icon-size);
-    margin: 2.5px 0px 0px 9px;
+    margin-inline-end: 2.5px;
+    margin-inline-start: 9px;
 }
 
 merch-card [slot='detail-m'] {

--- a/libs/deps/mas/plans-modal.js
+++ b/libs/deps/mas/plans-modal.js
@@ -5240,7 +5240,8 @@ merch-card [slot='callout-content'] > div > div > div {
 merch-card [slot='callout-content'] img {
     width: var(--consonant-merch-card-callout-icon-size);
     height: var(--consonant-merch-card-callout-icon-size);
-    margin: 2.5px 0px 0px 9px;
+    margin-inline-end: 2.5px;
+    margin-inline-start: 9px;
 }
 
 merch-card [slot='detail-m'] {

--- a/libs/features/mas/web-components/src/global.css.js
+++ b/libs/features/mas/web-components/src/global.css.js
@@ -242,7 +242,8 @@ merch-card [slot='callout-content'] > div > div > div {
 merch-card [slot='callout-content'] img {
     width: var(--consonant-merch-card-callout-icon-size);
     height: var(--consonant-merch-card-callout-icon-size);
-    margin: 2.5px 0px 0px 9px;
+    margin-inline-end: 2.5px;
+    margin-inline-start: 9px;
 }
 
 merch-card [slot='detail-m'] {


### PR DESCRIPTION
AI callout icon margin from the text in rtl and on mobile was not proper. Fixed by using inline-start and inline-end instead of margin left and right.

Resolves: [MWPW-159265](https://jira.corp.adobe.com/browse/MWPW-159265)

**Test URLs:**
Before: https://main--milo--adobecom.hlx.page/ae_ar/drafts/mili/kitchen-sink/merch-card
After: https://mwpw-159265_2--milo--rohitsahu.hlx.page/ae_ar/drafts/mili/kitchen-sink/merch-card