### PR TITLE
Make unav's profile config configurable to support local menu links

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -90,6 +90,7 @@ export const CONFIG = {
                   error: (e) => lanaLog({ message: 'Profile Menu error', e, tags: 'errorType=error,module=universalnav' }),
                 },
               },
+              ...getConfig().profile?.config,
             },
           },
           callbacks: {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -90,7 +90,7 @@ export const CONFIG = {
                   error: (e) => lanaLog({ message: 'Profile Menu error', e, tags: 'errorType=error,module=universalnav' }),
                 },
               },
-              ...getConfig().profile?.config,
+              ...getConfig().unav?.profile?.config,
             },
           },
           callbacks: {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* To support local menu sections in unav profile section, the onClicks are to be handled by the consuming client which means, they need to pass the onMessage of miniAppContext and it also uses the getProfile feature of account menu. 
So, adding an option to pass the profile's config from consuming client

Resolves: [MWPW-159364](https://jira.corp.adobe.com/browse/MWPW-159364)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://unav-profile--milo--adobecom.hlx.page/?martech=off
