### PR TITLE
Reverts MWPW-157555: Causing prices and CTAs to fail in Safari

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -2,7 +2,6 @@ import {
   createTag, getConfig, loadArea, loadScript, loadStyle, localizeLink,
 } from '../../utils/utils.js';
 import { replaceKey } from '../../features/placeholders.js';
-import * as commerceLib from '../../deps/mas/commerce.js';
 
 export const CHECKOUT_LINK_CONFIG_PATH = '/commerce/checkout-link.json'; // relative to libs.
 
@@ -423,6 +422,15 @@ export async function initService(force = false) {
   }
   const { env, commerce = {}, locale } = getConfig();
   initService.promise = initService.promise ?? polyfills().then(async () => {
+    const { hostname, searchParams } = new URL(window.location.href);
+    let commerceLibPath = '../../deps/mas/commerce.js';
+    if (/hlx\.(page|live)$|localhost$|www\.stage\.adobe\.com$/.test(hostname)) {
+      const maslibs = searchParams.get('maslibs');
+      if (maslibs) {
+        commerceLibPath = `${getMasBase(hostname, maslibs)}/libs/commerce.js`;
+      }
+    }
+    const commerceLib = await import(commerceLibPath);
     const service = await commerceLib.init(() => ({
       env,
       commerce,

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -426,7 +426,6 @@ export async function initService(force = false) {
     let commerceLibPath = '../../deps/mas/commerce.js';
     if (/hlx\.(page|live)$|localhost$|www\.stage\.adobe\.com$/.test(hostname)) {
       const maslibs = searchParams.get('maslibs');
-      /* istanbul ignore next */
       if (maslibs) {
         commerceLibPath = `${getMasBase(hostname, maslibs)}/libs/commerce.js`;
       }

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -426,6 +426,7 @@ export async function initService(force = false) {
     let commerceLibPath = '../../deps/mas/commerce.js';
     if (/hlx\.(page|live)$|localhost$|www\.stage\.adobe\.com$/.test(hostname)) {
       const maslibs = searchParams.get('maslibs');
+      /* istanbul ignore next */
       if (maslibs) {
         commerceLibPath = `${getMasBase(hostname, maslibs)}/libs/commerce.js`;
       }

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -798,6 +798,16 @@ describe('Merch Block', () => {
         updateSearch({});
       });
 
+      it('should load commerce.js via maslibs', async () => {
+        initService.promise = undefined;
+        getMasBase.baseUrl = 'http://localhost:2000/test/blocks/merch/mas';
+        updateSearch({ maslibs: 'test' });
+        setConfig(config);
+        await mockIms();
+        const commerce = await initService(true);
+        expect(commerce.mock).to.be.true;
+      });
+
       it('should return the default Adobe URL if no maslibs parameter is present', () => {
         expect(getMasBase()).to.equal('https://www.adobe.com/mas');
       });


### PR DESCRIPTION
Reverts https://github.com/adobecom/milo/pull/2906 which is causing prices and CTAs to not resolve in Safari browsers.

Resolves: [MWPW-159404](https://jira.corp.adobe.com/browse/MWPW-159404)

**Test URLs:**
- Before:https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/merch-card
- After: https://MWPW-157555-revert--milo--adobecom.hlx.page/docs/library/kitchen-sink/merch-card?martech=off
