### PR TITLE
[MWPW-155061] Secure transaction label is not center aligned with CTA 

### DIFF
--- a/libs/deps/mas/mas.js
+++ b/libs/deps/mas/mas.js
@@ -69,7 +69,7 @@ Try polyfilling it using "@formatjs/intl-pluralrules"
         display: flex;
         justify-content: flex-end;
         box-sizing: border-box;
-        align-items: center;
+        align-items: flex-end;
         width: 100%;
         flex-flow: wrap;
         gap: var(--consonant-merch-spacing-xs);
@@ -171,6 +171,7 @@ Try polyfilling it using "@formatjs/intl-pluralrules"
         align-items: center;
         flex: 1;
         line-height: normal;
+        align-self: center;
     }
 
     .secure-transaction-label::before {

--- a/libs/deps/mas/mas.js
+++ b/libs/deps/mas/mas.js
@@ -69,7 +69,7 @@ Try polyfilling it using "@formatjs/intl-pluralrules"
         display: flex;
         justify-content: flex-end;
         box-sizing: border-box;
-        align-items: flex-end;
+        align-items: center;
         width: 100%;
         flex-flow: wrap;
         gap: var(--consonant-merch-spacing-xs);

--- a/libs/deps/mas/merch-card.js
+++ b/libs/deps/mas/merch-card.js
@@ -88,7 +88,7 @@ import{LitElement as Dt}from"../lit-all.min.js";import{LitElement as wt,html as 
         display: flex;
         justify-content: flex-end;
         box-sizing: border-box;
-        align-items: center;
+        align-items: flex-end;
         width: 100%;
         flex-flow: wrap;
         gap: var(--consonant-merch-spacing-xs);
@@ -190,6 +190,7 @@ import{LitElement as Dt}from"../lit-all.min.js";import{LitElement as wt,html as 
         align-items: center;
         flex: 1;
         line-height: normal;
+        align-self: center;
     }
 
     .secure-transaction-label::before {

--- a/libs/deps/mas/merch-card.js
+++ b/libs/deps/mas/merch-card.js
@@ -88,7 +88,7 @@ import{LitElement as Dt}from"../lit-all.min.js";import{LitElement as wt,html as 
         display: flex;
         justify-content: flex-end;
         box-sizing: border-box;
-        align-items: flex-end;
+        align-items: center;
         width: 100%;
         flex-flow: wrap;
         gap: var(--consonant-merch-spacing-xs);

--- a/libs/features/mas/web-components/src/merch-card.css.js
+++ b/libs/features/mas/web-components/src/merch-card.css.js
@@ -66,7 +66,7 @@ export const styles = css`
         display: flex;
         justify-content: flex-end;
         box-sizing: border-box;
-        align-items: center;
+        align-items: flex-end;
         width: 100%;
         flex-flow: wrap;
         gap: var(--consonant-merch-spacing-xs);
@@ -168,6 +168,7 @@ export const styles = css`
         align-items: center;
         flex: 1;
         line-height: normal;
+        align-self: center;
     }
 
     .secure-transaction-label::before {

--- a/libs/features/mas/web-components/src/merch-card.css.js
+++ b/libs/features/mas/web-components/src/merch-card.css.js
@@ -66,7 +66,7 @@ export const styles = css`
         display: flex;
         justify-content: flex-end;
         box-sizing: border-box;
-        align-items: flex-end;
+        align-items: center;
         width: 100%;
         flex-flow: wrap;
         gap: var(--consonant-merch-spacing-xs);


### PR DESCRIPTION
centre align "secure transactions" in footer

Resolves: [MWPW-155061](https://jira.corp.adobe.com/browse/MWPW-155061)

Test URLs:
Before: https://main--milo--adobecom.hlx.page/drafts/rosahu/footeralignement
After: https://mwpw-155061--milo--rohitsahu.hlx.page/drafts/rosahu/footeralignement 
