### PR TITLE
MWPW-159423: Link urls are not resolved on Main Milo catalog and give 404

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -654,7 +654,7 @@ export function convertStageLinks({ anchors, config, hostname }) {
       .find((domain) => a.href.includes(domain));
     if (!matchedDomain) return;
     a.href = a.href.replace(a.hostname, domainsMap[matchedDomain] === 'origin'
-      ? hostname
+      ? a.hostname
       : domainsMap[matchedDomain]);
   });
 }

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -538,7 +538,7 @@ describe('Utils', () => {
 
         anchors.forEach((a, index) => {
           const expectedDomain = Object.values(domainsMap)[index];
-          expect(a.href).to.contain(expectedDomain === 'origin' ? hostname : expectedDomain);
+          expect(a.href).to.contain(expectedDomain === 'origin' ? a.hostname : expectedDomain);
         });
 
         externalAnchors.forEach((a) => expect(a.href).to.equal(a.href));


### PR DESCRIPTION
When converting URLs in the stage environment we need to keep the link hostname, not the window location hostname, if the stageDomainsMap rule is set to 'origin' for this link hostname. Otherwise, the links get transformed while they should remain unchanged. For example, if the link points to adobe.com, the hostname should stay as is because for this domain the rule is set to 'origin', but it gets changed to `main--cc--adobecom.hlx.live`.

For more information about the stageDomainsMap rules see this PR: https://github.com/adobecom/milo/pull/2834

Resolves: [MWPW-159423](https://jira.corp.adobe.com/browse/MWPW-159423)

**Test URLs:**
Before: 
- https://main--cc--adobecom.hlx.live/products/catalog?martech=off
- https://main--milo--adobecom.hlx.page/drafts/rbogos/env-relative-urls?martech=off
After: 
- https://main--cc--adobecom.hlx.live/products/catalog?milolibs=mwpw-159423-transformed-links--milo--mirafedas&martech=off
- https://mwpw-159423-transformed-links--milo--mirafedas.hlx.page/drafts/rbogos/env-relative-urls?martech=off
