### PR TITLE
MWPW-158014 - [Notification] bugs

### DIFF
--- a/libs/blocks/section-metadata/sticky-section.js
+++ b/libs/blocks/section-metadata/sticky-section.js
@@ -27,10 +27,11 @@ function promoIntersectObserve(el, stickySectionEl, options = {}) {
 function handleStickyPromobar(section, delay) {
   const main = document.querySelector('main');
   section.classList.add('promo-sticky-section', 'hide-sticky-section');
-  if (section.querySelector('.popup:is(.promobar, .notification.pill)')) section.classList.add('popup');
+  if (section.querySelector('.popup:is(.promobar, .notification)')) section.classList.add('popup');
   let stickySectionEl = null;
   let hasScrollControl;
-  if ((section.querySelector(':is(.promobar, .notification.pill)').classList.contains('no-delay')) || (delay && section.classList.contains('popup'))) {
+  if ((section.querySelector(':is(.promobar, .notification:not(.no-hide))').classList.contains('no-delay'))
+    || (delay && section.classList.contains('popup'))) {
     hasScrollControl = true;
   }
   if (!hasScrollControl && main.children[0] !== section) {
@@ -52,7 +53,7 @@ export default async function handleStickySection(sticky, section) {
       break;
     }
     case 'sticky-bottom': {
-      if (section.querySelector(':is(.promobar, .notification.pill.popup)')) {
+      if (section.querySelector(':is(.promobar, .notification:not(.no-hide))')) {
         const metadata = getMetadata(section.querySelector('.section-metadata'));
         const delay = getDelayTime(metadata.delay?.text);
         if (delay) setTimeout(() => { handleStickyPromobar(section, delay); }, delay);

--- a/libs/blocks/section-metadata/sticky-section.js
+++ b/libs/blocks/section-metadata/sticky-section.js
@@ -27,7 +27,7 @@ function promoIntersectObserve(el, stickySectionEl, options = {}) {
 function handleStickyPromobar(section, delay) {
   const main = document.querySelector('main');
   section.classList.add('promo-sticky-section', 'hide-sticky-section');
-  if (section.querySelector('.popup:is(.promobar, .notification)')) section.classList.add('popup');
+  if (section.querySelector('.popup:is(.promobar)')) section.classList.add('popup');
   let stickySectionEl = null;
   let hasScrollControl;
   if ((section.querySelector(':is(.promobar, .notification:not(.no-hide))').classList.contains('no-delay'))

--- a/libs/blocks/section-metadata/sticky-section.js
+++ b/libs/blocks/section-metadata/sticky-section.js
@@ -30,7 +30,7 @@ function handleStickyPromobar(section, delay) {
   if (section.querySelector('.popup:is(.promobar)')) section.classList.add('popup');
   let stickySectionEl = null;
   let hasScrollControl;
-  if ((section.querySelector(':is(.promobar, .notification:not(.no-hide))').classList.contains('no-delay'))
+  if ((section.querySelector(':is(.promobar, .notification)').classList.contains('no-delay'))
     || (delay && section.classList.contains('popup'))) {
     hasScrollControl = true;
   }
@@ -40,7 +40,9 @@ function handleStickyPromobar(section, delay) {
   }
   const io = promoIntersectObserve(section, stickySectionEl);
   if (stickySectionEl) io.observe(stickySectionEl);
-  io.observe(document.querySelector('footer'));
+  if (section.querySelector(':is(.promobar, .notification:not(.no-hide))')) {
+    io.observe(document.querySelector('footer'));
+  }
 }
 
 export default async function handleStickySection(sticky, section) {
@@ -53,7 +55,7 @@ export default async function handleStickySection(sticky, section) {
       break;
     }
     case 'sticky-bottom': {
-      if (section.querySelector(':is(.promobar, .notification:not(.no-hide))')) {
+      if (section.querySelector(':is(.promobar, .notification)')) {
         const metadata = getMetadata(section.querySelector('.section-metadata'));
         const delay = getDelayTime(metadata.delay?.text);
         if (delay) setTimeout(() => { handleStickyPromobar(section, delay); }, delay);

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -294,18 +294,18 @@ function applyInViewPortPlay(video) {
 }
 
 export function decorateMultiViewport(el) {
-  const viewports = [
-    '(max-width: 599px)',
-    '(min-width: 600px) and (max-width: 1199px)',
-    '(min-width: 1200px)',
-  ];
   const foreground = el.querySelector('.foreground');
-  if (foreground.childElementCount === 2 || foreground.childElementCount === 3) {
+  const cols = foreground.childElementCount;
+  if (cols === 2 || cols === 3) {
+    const viewports = [
+      '(max-width: 599px)',
+      '(min-width: 600px) and (max-width: 1199px)',
+      '(min-width: 1200px)',
+      '(min-width: 600px)',
+    ].filter((vp, id) => (cols === 2 ? [0, 3].includes(id) : id !== 3));
     [...foreground.children].forEach((child, index) => {
       const mq = window.matchMedia(viewports[index]);
-      const setContent = () => {
-        if (mq.matches) foreground.replaceChildren(child);
-      };
+      const setContent = () => mq.matches && foreground.replaceChildren(child);
       setContent();
       mq.addEventListener('change', setContent);
     });

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -302,7 +302,7 @@ export function decorateMultiViewport(el) {
       '(min-width: 600px) and (max-width: 1199px)',
       '(min-width: 1200px)',
       '(min-width: 600px)',
-    ].filter((vp, id) => (cols === 2 ? [0, 3].includes(id) : id !== 3));
+    ].filter((v, i) => (cols === 2 ? [0, 3].includes(i) : i !== 3));
     [...foreground.children].forEach((child, index) => {
       const mq = window.matchMedia(viewports[index]);
       const setContent = () => mq.matches && foreground.replaceChildren(child);


### PR DESCRIPTION
As an author, I would like to be able to have the current Aside notification functionalities to be available in the new Notification block.

**Bugs:**
**_1 & 2_** the `notification.ribbon` block (when nested in section with `.sticky-bottom` style) is not using the same default functionality as the original `aside.promobar` block that it was created to replace.
1. The notification ribbon block should hide when the user scrolls to the bottom of the page.
2. The notification ribbon block should only show up once the user scrolls to the element position in the document.
3. The multi view port decorator wasn't setup to differentiate between a two column layout and a three column layout.

**Solutions:**
1. Adjusted selector in the section for sticky functionality to query for all notifications where the class list does not contain the `no-hide` class name.
2. _Same as 1_.
3. Adjusted multi viewport decorator to consider number of columns in layout and subsequently use proper viewport logic in setting child content.

Resolves: [MWPW-158014](https://jira.corp.adobe.com/browse/MWPW-158014)

**Test URLs Bug 1 and 2:**
- Before: https://main--milo--adobecom.hlx.page/drafts/klee/test-aside-notification-sticky-bottom?martech=off
- After: https://sartxi-mwpw-158014-notifies--milo--adobecom.hlx.page/drafts/klee/test-aside-notification-sticky-bottom?martech=off

**Test URLs for the 'no-hide' variant:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/test-sticky-notification-nohide?martech=off
- After: https://sartxi-mwpw-158014-notifies--milo--adobecom.hlx.page/drafts/sarchibeque/test-sticky-notification-nohide?martech=off

**Test URLs Bug 3:**
- Before: https://main--milo--adobecom.hlx.page/drafts/klee/test-notification?martech=off
- After: https://sartxi-mwpw-158014-notifies--milo--adobecom.hlx.page/drafts/klee/test-notification?martech=off
