### PR TITLE
MWPW-159291 Fix fragment recursive check algo

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -2,7 +2,6 @@
 import { createTag, getConfig, loadArea, localizeLink, customFetch } from '../../utils/utils.js';
 
 const fragMap = {};
-window.fm = fragMap;
 
 const removeHash = (url) => {
   const urlNoHash = url.split('#')[0];
@@ -31,9 +30,9 @@ const updateFragMap = (fragment, a, href) => {
 
       fragLinks.forEach((link) => {
         const localizedHref = localizeLink(removeHash(link.href));
-        const hasHrefAsParent = hrefNode.findParent(localizedHref);
-        if (hasHrefAsParent) {
-          hrefNode.isRecursive = true;
+        const parentNodeSameHref = hrefNode.findParent(localizedHref);
+        if (parentNodeSameHref) {
+          parentNodeSameHref.isRecursive = true;
         } else {
           hrefNode.addChild(localizedHref);
         }

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -2,6 +2,7 @@
 import { createTag, getConfig, loadArea, localizeLink, customFetch } from '../../utils/utils.js';
 
 const fragMap = {};
+window.fm = fragMap;
 
 const removeHash = (url) => {
   const urlNoHash = url.split('#')[0];
@@ -11,7 +12,7 @@ const removeHash = (url) => {
 const isCircularRef = (href) => [...Object.values(fragMap)]
   .some((tree) => {
     const node = tree.find(href);
-    return node ? !(node.isLeaf) : false;
+    return node?.isRecursive;
   });
 
 const updateFragMap = (fragment, a, href) => {
@@ -19,15 +20,24 @@ const updateFragMap = (fragment, a, href) => {
     .filter((link) => localizeLink(link.href).includes('/fragments/'));
   if (!fragLinks.length) return;
 
-  if (document.body.contains(a)) { // is fragment on page (not nested)
+  if (document.body.contains(a) && !a.parentElement?.closest('.fragment')) {
     // eslint-disable-next-line no-use-before-define
     fragMap[href] = new Tree(href);
     fragLinks.forEach((link) => fragMap[href].insert(href, localizeLink(removeHash(link.href))));
   } else {
     Object.values(fragMap).forEach((tree) => {
-      if (tree.find(href)) {
-        fragLinks.forEach((link) => tree.insert(href, localizeLink(removeHash(link.href))));
-      }
+      const hrefNode = tree.find(href);
+      if (!hrefNode) return;
+
+      fragLinks.forEach((link) => {
+        const localizedHref = localizeLink(removeHash(link.href));
+        const hasHrefAsParent = hrefNode.findParent(localizedHref);
+        if (hasHrefAsParent) {
+          hrefNode.isRecursive = true;
+        } else {
+          hrefNode.addChild(localizedHref);
+        }
+      });
     });
   }
 };
@@ -133,10 +143,19 @@ class Node {
     this.value = value;
     this.parent = parent;
     this.children = [];
+    this.isRecursive = false;
   }
 
-  get isLeaf() {
-    return this.children.length === 0;
+  addChild(key, value = key) {
+    const alreadyHasChild = this.children.some((n) => n.key === key);
+    if (!alreadyHasChild) {
+      this.children.push(new Node(key, value, this));
+    }
+  }
+
+  findParent(key) {
+    if (this.parent?.key === key) return this.parent;
+    return this.parent?.findParent(key);
   }
 }
 

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -64,7 +64,7 @@ describe('Fragments', () => {
     const a = document.querySelector('a.frag-a');
     await getFragment(a);
     expect(document.querySelector('h4')).to.exist;
-    expect(window.lana.log.args[2][0]).to.equal('ERROR: Fragment Circular Reference loading http://localhost:2000/test/blocks/fragment/mocks/fragments/frag-a');
+    expect(window.lana.log.args[2][0]).to.equal('ERROR: Fragment Circular Reference loading http://localhost:2000/test/blocks/fragment/mocks/fragments/frag-b');
   });
 
   it('Inlines fragments inside a block', async () => {

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -64,7 +64,7 @@ describe('Fragments', () => {
     const a = document.querySelector('a.frag-a');
     await getFragment(a);
     expect(document.querySelector('h4')).to.exist;
-    expect(window.lana.log.args[2][0]).to.equal('ERROR: Fragment Circular Reference loading http://localhost:2000/test/blocks/fragment/mocks/fragments/frag-b');
+    expect(window.lana.log.args[2][0]).to.equal('ERROR: Fragment Circular Reference loading http://localhost:2000/test/blocks/fragment/mocks/fragments/frag-a');
   });
 
   it('Inlines fragments inside a block', async () => {

--- a/test/blocks/fragment/mocks/fragments/frag-b.plain.html
+++ b/test/blocks/fragment/mocks/fragments/frag-b.plain.html
@@ -1,4 +1,4 @@
 <div>
     <h5>Frag B, Loads Frag A</h5>
-    <a href="/test/blocks/fragment/mocks/fragments/frag-a">Frag A link</a>
+    <a href="/test/blocks/fragment/mocks/fragments/frag-c">Frag C link</a>
 </div>

--- a/test/blocks/fragment/mocks/fragments/frag-c.plain.html
+++ b/test/blocks/fragment/mocks/fragments/frag-c.plain.html
@@ -1,0 +1,4 @@
+<div>
+    <h5>Frag B, Loads Frag A</h5>
+    <a href="/test/blocks/fragment/mocks/fragments/frag-a">Frag A link</a>
+</div>

--- a/test/blocks/fragment/tree.test.js
+++ b/test/blocks/fragment/tree.test.js
@@ -21,8 +21,30 @@ describe('Tree Data Struct', () => {
     t.remove('first');
     expect(t.find('first')).to.be.undefined;
     expect(t.find('second')).to.be.equal(t.root.children[0]);
+  });
 
-    expect(t.find('second').isLeaf).to.be.true;
-    expect(t.root.isLeaf).to.be.false;
+  it('Will return false if it cant insert or remove a node', () => {
+    const t = new Tree('root');
+    t.insert('root', 'first');
+    t.insert('root', 'second');
+    const isInserted = t.insert('doesnt-exist', 'third');
+    expect(isInserted).to.be.false;
+
+    const isRemoved = t.remove('doesnt-exist');
+    expect(isRemoved).to.be.false;
+  });
+
+  it('Can add child directly from a Node', () => {
+    const t = new Tree('root');
+    t.insert('root', 'first');
+    t.insert('root', 'second');
+    const firstNode = t.find('first');
+    firstNode.addChild('third');
+    expect(firstNode.children.length).to.be.equal(1);
+    expect(firstNode.children[0].key).to.be.equal('third');
+
+    // adding a duplicate key should not add a new child
+    firstNode.addChild('third');
+    expect(firstNode.children.length).to.be.equal(1);
   });
 });


### PR DESCRIPTION
Detecting recursive fragments had a very simplistic check, but would incorrectly mark a fragment as recursive and therefore not load it.  This updates the algo to explicitly look up the fragment loading tree and see if the fragment about to load will end up loading the current fragment - aka start an infinite fragment loading loop.

This was happening when a fragment that has a nested fragment is used in different sections of a page.  In this case  the photoshop card fragment was being used multiple times in different sections (each tab is in its own section).

Resolves: [MWPW-159291](https://jira.corp.adobe.com/browse/MWPW-159291)

---

Circular Fragment Verification:

- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/load-circ-frag?martech=off
- After: https://159291-frag--milo--adobecom.hlx.page/drafts/cpeyer/load-circ-frag?martech=off

---

For the test urls below the hello world banner and picture of weather radar should be displayed twice.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/cpeyer/nested-frag-test?martech=off
- After: https://159291-frag--milo--adobecom.hlx.page/drafts/cpeyer/nested-frag-test?martech=off

