### PR TITLE
[MWPW-159129] - Add full width GNAV css for adobe home

### DIFF
--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -36,7 +36,7 @@ header.global-navigation, header.global-navigation.feds--dark {
   .feds-promo-link:hover {
     color: #136FF6;
   }
-  .feds--full-width .feds-topnav{
+  .feds--full-width .feds-topnav {
     max-width: none;
     padding: 0 10px 0 15px;
   }

--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -36,4 +36,8 @@ header.global-navigation, header.global-navigation.feds--dark {
   .feds-promo-link:hover {
     color: #136FF6;
   }
+  .feds--full-width .feds-topnav{
+    max-width: none;
+    padding: 0 10px 0 15px;
+  }
 }

--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -38,6 +38,6 @@ header.global-navigation, header.global-navigation.feds--dark {
   }
   .feds--full-width .feds-topnav {
     max-width: none;
-    padding: 0 10px 0 15px;
+    padding: 0 15px;
   }
 }

--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -36,6 +36,7 @@ header.global-navigation, header.global-navigation.feds--dark {
   .feds-promo-link:hover {
     color: #136FF6;
   }
+  
   .feds--full-width .feds-topnav {
     max-width: none;
     padding: 0 15px;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Added a CSS class for full-width GNAV on Adobe home, applied from tablet size and above.

Resolves: [MWPW-159129](https://jira.corp.adobe.com/browse/MWPW-159129)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-159129--milo--deva309.hlx.page/?martech=off

QA:
https://adobecom.github.io/nav-consumer/navigation-full-width.html?env=stage&navbranch=mwpw-159129&authoringpath=/federal/test-website