### PR TITLE
[MWPW-159701] [Graybox] Cannot read the milo config when behind auth

### DIFF
--- a/libs/blocks/graybox-promote/components/graybox-promote-lit.js
+++ b/libs/blocks/graybox-promote/components/graybox-promote-lit.js
@@ -119,7 +119,12 @@ const preview = async (context) => {
   context.previewUrl = new URL((await res.json()).preview.url);
 };
 
-const loginToSharepoint = async (context) => login({ scopes: ['files.readwrite', 'sites.readwrite.all'], telemetry: TELEMETRY, config: CONFIG })
+const loginToSharepoint = async (context) => login({
+  scopes: ['files.readwrite', 'sites.readwrite.all'],
+  telemetry: TELEMETRY,
+  config: CONFIG,
+  suppliedOrigin: window.location.origin,
+})
   .then(() => {
     context.setup.spToken = accessToken.value || accessTokenExtra.value;
   });

--- a/libs/tools/sharepoint/login.js
+++ b/libs/tools/sharepoint/login.js
@@ -2,8 +2,14 @@
 import { getMSALConfig } from './msal.js';
 import { accessToken, accessTokenExtra, account } from './state.js';
 
-export default async function login({ scopes, extraScopes, telemetry = {}, config }) {
-  const msalConfig = await getMSALConfig({ telemetry, config });
+export default async function login({
+  scopes,
+  extraScopes,
+  telemetry = {},
+  config = {},
+  suppliedOrigin,
+}) {
+  const msalConfig = await getMSALConfig({ telemetry, config, suppliedOrigin });
   const pca = new msal.PublicClientApplication(msalConfig);
   let tmpAccount = pca.getAllAccounts()[0];
   if (!tmpAccount) {

--- a/libs/tools/sharepoint/msal.js
+++ b/libs/tools/sharepoint/msal.js
@@ -10,12 +10,12 @@ const BASE_CONFIG = {
   },
 };
 
-export async function getMSALConfig({ telemetry, config = BASE_CONFIG }) {
+export async function getMSALConfig({ telemetry, config = BASE_CONFIG, suppliedOrigin }) {
   try {
     const { base } = getConfig();
     await loadScript(`${base}/deps/msal-browser-2.34.0.js`);
 
-    const { sharepoint } = await getServiceConfig();
+    const { sharepoint } = await getServiceConfig(suppliedOrigin);
 
     const auth = {
       clientId: sharepoint.clientId,


### PR DESCRIPTION
## Description
This PR updates the Graybox promote to fetch the Milo config from the current .hlx.page origin of the UI, instead of .hlx.live, which previously failed due to authentication issues.

## Related Issue
Resolves: [MWPW-159701](https://jira.corp.adobe.com/browse/MWPW-159701)

## Test URLs
Before: https://grayboxui--milo--adobecom.hlx.page/drafts/rbogos/page-default?martech=off
After: https://mwpw-159701-milo-config--milo--robert-bogos.hlx.page/drafts/rbogos/page-default?martech=off 