### PR TITLE
MWPW-152455 added handling of "no placeholders" case for parsePlaceholders()

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -644,7 +644,7 @@ export async function createMartechMetadata(placeholders, config, column) {
 }
 
 /* c8 ignore start */
-function parsePlaceholders(placeholders, config, selectedVariantName = '') {
+export function parsePlaceholders(placeholders, config, selectedVariantName = '') {
   if (!placeholders?.length || selectedVariantName === 'default') return config;
   const valueNames = [
     selectedVariantName.toLowerCase(),
@@ -655,8 +655,9 @@ function parsePlaceholders(placeholders, config, selectedVariantName = '') {
     'value',
     'other',
   ];
-  const [val] = Object.entries(placeholders[0])
-    .find(([key]) => valueNames.includes(key.toLowerCase()));
+  const keys = placeholders && placeholders.length ? Object.entries(placeholders[0]) : [];
+  const [val] = keys.find(([key]) => valueNames.includes(key.toLowerCase()));
+
   if (val) {
     const results = placeholders.reduce((res, item) => {
       res[item.key] = item[val];

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -655,7 +655,7 @@ export function parsePlaceholders(placeholders, config, selectedVariantName = ''
     'value',
     'other',
   ];
-  const keys = placeholders && placeholders.length ? Object.entries(placeholders[0]) : [];
+  const keys = placeholders?.length ? Object.entries(placeholders[0]) : [];
   const keyVal = keys.find(([key]) => valueNames.includes(key.toLowerCase()));
   const key = keyVal?.[0];
 

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -656,17 +656,18 @@ export function parsePlaceholders(placeholders, config, selectedVariantName = ''
     'other',
   ];
   const keys = placeholders && placeholders.length ? Object.entries(placeholders[0]) : [];
-  const [val] = keys.find(([key]) => valueNames.includes(key.toLowerCase()));
+  const keyVal = keys.find(([key]) => valueNames.includes(key.toLowerCase()));
+  const key = keyVal?.[0];
 
-  if (val) {
+  if (key) {
     const results = placeholders.reduce((res, item) => {
-      res[item.key] = item[val];
+      res[item.key] = item[key];
       return res;
     }, {});
     config.placeholders = { ...(config.placeholders || {}), ...results };
   }
 
-  createMartechMetadata(placeholders, config, val);
+  createMartechMetadata(placeholders, config, key);
 
   return config;
 }

--- a/test/features/personalization/parseNestedPlaceholders.test.js
+++ b/test/features/personalization/parseNestedPlaceholders.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { parseNestedPlaceholders, createContent, replacePlaceholders } from '../../../libs/features/personalization/personalization.js';
+import { parseNestedPlaceholders, createContent, replacePlaceholders, parsePlaceholders } from '../../../libs/features/personalization/personalization.js';
 import { getConfig } from '../../../libs/utils/utils.js';
 
 const config = getConfig();
@@ -10,6 +10,7 @@ config.placeholders = {
   'promo-description': 'For just {{promo-price}}, get 20+...',
   'promo-price': 'US$49.99',
 };
+config.locale = { region: 'US', ietf: 'en-US' };
 describe('test different values for parseNestedPlaceholders', () => {
   it('should update placeholders', () => {
     parseNestedPlaceholders(config);
@@ -51,5 +52,21 @@ describe('replacePlaceholders()', () => {
     const str = 'For just {{promo-price}}, get 20+...';
     const newStr = replacePlaceholders(str, null);
     expect(newStr).to.equal(str);
+  });
+});
+
+describe('parsePlaceholders()', () => {
+  it('should parse placeholders', () => {
+    const response = parsePlaceholders([
+      {
+        'en-US': 'bar',
+        key: 'foo',
+      },
+    ], config);
+    expect(response.placeholders.foo).to.equal('bar');
+  });
+  it('should not break when there are no placeholders available', () => {
+    const response = parsePlaceholders(null, config);
+    expect(response.placeholders).to.exist;
   });
 });

--- a/test/features/personalization/parseNestedPlaceholders.test.js
+++ b/test/features/personalization/parseNestedPlaceholders.test.js
@@ -66,7 +66,12 @@ describe('parsePlaceholders()', () => {
     expect(response.placeholders.foo).to.equal('bar');
   });
   it('should not break when there are no placeholders available', () => {
-    const response = parsePlaceholders(null, config);
+    const response = parsePlaceholders([
+      {
+        fr: 'bar',
+        key: 'foo',
+      },
+    ], config);
     expect(response.placeholders).to.exist;
   });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* added handling of "no placeholders" case for parsePlaceholders()

Resolves: [MWPW-152455](https://jira.corp.adobe.com/browse/MWPW-152455)

QA Instructions: The before link has an error message the after link does not:
MEP Error parsing manifests: TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/placeholders/placeholders
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/placeholders/placeholders?milolibs=MWPW-152455

Psi-check: https://mwpw-152455--milo--adobecom.hlx.page/?martech=off