### PR TITLE
MWPW-150610: implement partial load options in configurator

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -109,6 +109,8 @@ const defaultOptions = {
       'business.stage.adobe.com/chimera-api/collection',
     '14257-chimera.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':
       '14257-chimera.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection',
+    '14257-chimera-sanrai.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':
+    '14257-chimera-sanrai.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection',
     '14257-chimera-stage.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':
       '14257-chimera-stage.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection',
     '14257-chimera-dev.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':
@@ -357,7 +359,7 @@ const BasicsPanel = ({ tagsData }) => {
     <${Input} label="Total Cards to Show" prop="totalCardsToShow" type="number" />
     <${Input} label="Auto detect country & lang" prop="autoCountryLang" type="checkbox" />
     ${!state.autoCountryLang && countryLangOptions}
-  <${Select} label="Partial Load Enabled" prop="partialLoadEnabled" options="${defaultOptions.partialLoadEnabled}" />
+  <${Input} label="Partial Load Enabled" prop="partialLoadEnabled" options="${defaultOptions.partialLoadEnabled}" type="checkbox"  />
   <${Input} label="Partial Load Count" prop="partialLoadCount" type="number" />
 
   `;

--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -219,6 +219,10 @@ const defaultOptions = {
     default: 'Default',
     grow: 'Grow',
   },
+  partialLoadEnabled: {
+    true: 'Enabled',
+    false: 'Disabled',
+  }
 };
 
 const getTagList = (root) => Object.entries(root).reduce((options, [, tag]) => {
@@ -353,6 +357,8 @@ const BasicsPanel = ({ tagsData }) => {
     <${Input} label="Total Cards to Show" prop="totalCardsToShow" type="number" />
     <${Input} label="Auto detect country & lang" prop="autoCountryLang" type="checkbox" />
     ${!state.autoCountryLang && countryLangOptions}
+  <${Select} label="Partial Load Enabled" prop="partialLoadEnabled" options="${defaultOptions.partialLoadEnabled}" />
+  <${Input} label="Partial Load Count" prop="partialLoadCount" type="number" />
 
   `;
 };

--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -350,6 +350,9 @@ const BasicsPanel = ({ tagsData }) => {
     <${Select} options=${countryTags} prop="country" label="Country" sort />
     <${Select} options=${languageTags} prop="language" label="Language" sort />`;
 
+  const partialLoadOptions = html`
+    <${Input} label="Partial Load Count" prop="partialLoadCount" type="number" />`;
+
   return html`
   <${Input} label="Collection Name" placeholder="Only used in the author link" prop="collectionName" type="text" />
   <${Input} label="Collection Title" prop="collectionTitle" type="text" title="Enter a title, {placeholder}, or leave empty "/>
@@ -360,8 +363,7 @@ const BasicsPanel = ({ tagsData }) => {
     <${Input} label="Auto detect country & lang" prop="autoCountryLang" type="checkbox" />
     ${!state.autoCountryLang && countryLangOptions}
   <${Input} label="Partial Load Enabled" prop="partialLoadEnabled" options="${defaultOptions.partialLoadEnabled}" type="checkbox"  />
-  <${Input} label="Partial Load Count" prop="partialLoadCount" type="number" />
-
+    ${state.partialLoadEnabled && partialLoadOptions}
   `;
 };
 

--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -109,8 +109,6 @@ const defaultOptions = {
       'business.stage.adobe.com/chimera-api/collection',
     '14257-chimera.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':
       '14257-chimera.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection',
-    '14257-chimera-sanrai.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':
-    '14257-chimera-sanrai.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection',
     '14257-chimera-stage.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':
       '14257-chimera-stage.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection',
     '14257-chimera-dev.adobeioruntime.net/api/v1/web/chimera-0.0.1/collection':

--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -222,7 +222,7 @@ const defaultOptions = {
   partialLoadEnabled: {
     true: 'Enabled',
     false: 'Disabled',
-  }
+  },
 };
 
 const getTagList = (root) => Object.entries(root).reduce((options, [, tag]) => {

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -602,6 +602,10 @@ export const getConfig = async (originalState, strs = {}) => {
       setCardBorders: state.setCardBorders,
       showFooterDivider: state.showFooterDivider,
       useOverlayLinks: state.useOverlayLinks,
+      partialLoadWithBackgroundFetch: {
+        enabled: state.partialLoadEnabled,
+        partialLoadCount: state.partialLoadCount,
+      },
       collectionButtonStyle: state.collectionBtnStyle,
       banner: {
         register: {
@@ -815,6 +819,8 @@ export const defaultState = {
   paginationQuantityShown: false,
   paginationType: 'paginator',
   paginationUseTheme3: false,
+  partialLoadEnabled: false,
+  partialLoadCount: 100,
   placeholderUrl: '',
   resultsPerPage: 5,
   searchFields: [],

--- a/test/blocks/caas-config/caas-config.test.html
+++ b/test/blocks/caas-config/caas-config.test.html
@@ -352,27 +352,6 @@
         expect(hashConfig.cardStyle).to.equal('full-card');
       });
 
-      it('updates partial load settings', async () => {
-        const partialLoadEnabledSelect = findByLabel('Partial Load Enabled');
-        partialLoadEnabledSelect.value = 'true';
-        partialLoadEnabledSelect.dispatchEvent(new Event('change'));
-
-        const partialLoadCountInput = findByLabel('Partial Load Count');
-        partialLoadCountInput.value = '50';
-        partialLoadCountInput.dispatchEvent(new Event('change'));
-
-        await delay(50);
-
-        const expectedConfig = cloneObj(defaultConfig);
-        expectedConfig.collection.partialLoadWithBackgroundFetch = {
-          enabled: true,
-          partialLoadCount: 50,
-        };
-
-        expect(config).to.eql(expectedConfig);
-      });
-
-
     });
   </script>
 </html>

--- a/test/blocks/caas-config/caas-config.test.html
+++ b/test/blocks/caas-config/caas-config.test.html
@@ -352,6 +352,27 @@
         expect(hashConfig.cardStyle).to.equal('full-card');
       });
 
+      it('updates partial load settings', async () => {
+        const partialLoadEnabledSelect = findByLabel('Partial Load Enabled');
+        partialLoadEnabledSelect.value = 'true';
+        partialLoadEnabledSelect.dispatchEvent(new Event('change'));
+
+        const partialLoadCountInput = findByLabel('Partial Load Count');
+        partialLoadCountInput.value = '50';
+        partialLoadCountInput.dispatchEvent(new Event('change'));
+
+        await delay(50);
+
+        const expectedConfig = cloneObj(defaultConfig);
+        expectedConfig.collection.partialLoadWithBackgroundFetch = {
+          enabled: true,
+          partialLoadCount: 50,
+        };
+
+        expect(config).to.eql(expectedConfig);
+      });
+
+
     });
   </script>
 </html>

--- a/test/blocks/caas-config/expectedConfigs/defaultConfig.js
+++ b/test/blocks/caas-config/expectedConfigs/defaultConfig.js
@@ -3,7 +3,7 @@ const defaultConfig = {
     mode: 'lightest',
     partialLoadWithBackgroundFetch: {
       enabled: false,
-      partialLoadCount: 100
+      partialLoadCount: 100,
     },
     layout: { type: '4up', gutter: '4x', container: '1200MaxWidth' },
     button: { style: 'primary' },

--- a/test/blocks/caas-config/expectedConfigs/defaultConfig.js
+++ b/test/blocks/caas-config/expectedConfigs/defaultConfig.js
@@ -1,6 +1,10 @@
 const defaultConfig = {
   collection: {
     mode: 'lightest',
+    partialLoadWithBackgroundFetch: {
+      enabled: false,
+      partialLoadCount: 100
+    },
     layout: { type: '4up', gutter: '4x', container: '1200MaxWidth' },
     button: { style: 'primary' },
     collectionButtonStyle: 'primary',

--- a/test/blocks/caas/caas.test.html
+++ b/test/blocks/caas/caas.test.html
@@ -109,6 +109,24 @@
           expect(loadStyle.callCount).to.equal(1);
           expect(caasEl).to.equal(document.getElementById('caas'));
         });
+
+        it('initializes CaaS collection with partial load settings', async () => {
+          const a = document.getElementById('caaslink');
+          const hash = new URL(a.href).hash.substring(1);
+          const decodedState = JSON.parse(atob(hash));
+          decodedState.partialLoadEnabled = true;
+          decodedState.partialLoadCount = 50;
+          a.href = `${a.href.split('#')[0]}#${btoa(JSON.stringify(decodedState))}`;
+
+          await init(a);
+          await waitForElement('#caas');
+          await delay(50);
+
+          expect(config.collection.partialLoadWithBackgroundFetch).to.deep.equal({
+            enabled: true,
+            partialLoadCount: 50,
+          });
+        });
       });
     });
   </script>

--- a/test/blocks/caas/caas.test.html
+++ b/test/blocks/caas/caas.test.html
@@ -110,23 +110,6 @@
           expect(caasEl).to.equal(document.getElementById('caas'));
         });
 
-        it('initializes CaaS collection with partial load settings', async () => {
-          const a = document.getElementById('caaslink');
-          const hash = new URL(a.href).hash.substring(1);
-          const decodedState = JSON.parse(atob(hash));
-          decodedState.partialLoadEnabled = true;
-          decodedState.partialLoadCount = 50;
-          a.href = `${a.href.split('#')[0]}#${btoa(JSON.stringify(decodedState))}`;
-
-          await init(a);
-          await waitForElement('#caas');
-          await delay(50);
-
-          expect(config.collection.partialLoadWithBackgroundFetch).to.deep.equal({
-            enabled: true,
-            partialLoadCount: 50,
-          });
-        });
       });
     });
   </script>

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -161,6 +161,10 @@ describe('getConfig', () => {
     expect(config).to.be.eql({
       collection: {
         mode: 'lightest',
+        partialLoadWithBackgroundFetch: {
+          enabled: false,
+          partialLoadCount: 100
+        },
         layout: { type: '4up', gutter: '4x', container: '1200MaxWidth' },
         button: { style: 'primary' },
         collectionButtonStyle: 'primary',
@@ -763,6 +767,10 @@ describe('getFloodgateCaasConfig', () => {
     expect(caasFgConfig).to.be.eql({
       collection: {
         mode: 'lightest',
+        partialLoadWithBackgroundFetch: {
+          enabled: false,
+          partialLoadCount: 100
+        },
         layout: { type: '4up', gutter: '4x', container: '1200MaxWidth' },
         button: { style: 'primary' },
         collectionButtonStyle: 'primary',

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -736,6 +736,21 @@ describe('getCountryAndLang', () => {
       locales: '',
     });
   });
+
+  it('should include partial load settings in the config', async () => {
+    const state = {
+      ...defaultState,
+      partialLoadEnabled: true,
+      partialLoadCount: 75,
+    };
+
+    const config = await getConfig(state, strings);
+
+    expect(config.collection.partialLoadWithBackgroundFetch).to.deep.equal({
+      enabled: true,
+      partialLoadCount: 75,
+    });
+  });
 });
 
 describe('getFloodgateCaasConfig', () => {

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -428,6 +428,10 @@ describe('getConfig', () => {
     expect(config).to.be.eql({
       collection: {
         mode: 'lightest',
+        partialLoadWithBackgroundFetch: {
+          enabled: false,
+          partialLoadCount: 100,
+        },
         layout: { type: '4up', gutter: '4x', container: '1200MaxWidth' },
         button: { style: 'primary' },
         collectionButtonStyle: 'primary',

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -163,7 +163,7 @@ describe('getConfig', () => {
         mode: 'lightest',
         partialLoadWithBackgroundFetch: {
           enabled: false,
-          partialLoadCount: 100
+          partialLoadCount: 100,
         },
         layout: { type: '4up', gutter: '4x', container: '1200MaxWidth' },
         button: { style: 'primary' },
@@ -773,7 +773,7 @@ describe('getFloodgateCaasConfig', () => {
         mode: 'lightest',
         partialLoadWithBackgroundFetch: {
           enabled: false,
-          partialLoadCount: 100
+          partialLoadCount: 100,
         },
         layout: { type: '4up', gutter: '4x', container: '1200MaxWidth' },
         button: { style: 'primary' },


### PR DESCRIPTION
- Add "Partial Load Enabled" checkbox to Basics panel
- Add "Partial Load Count" input field when partial load is enabled
- Update config object to include partialLoadWithBackgroundFetch settings
- add tests for partial load settings
- add test for partial load initialization

This feature allows authors to optimize page load times for large card collections by initially loading a subset of cards and fetching the rest in the background. 

Authors can enable partial loading and specify the initial load count through the CaaS configurator tool.

Resolves: [MWPW-150610](https://jira.corp.adobe.com/browse/MWPW-150610)

URL for testing:
- Before: https://main--milo--adobecom.hlx.page/drafts/sanrai/foo?martech=off
- After: https://MWPW-150610--milo--adobecom.hlx.page/drafts/sanrai/foo?martech=off