### PR TITLE
[MWPW-159903] Fix quiz video marquees (#3009)

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -327,7 +327,7 @@ export async function loadCDT(el, classList) {
 
 export function decorateAnchorVideo({ src = '', anchorTag }) {
   if (!src.length || !(anchorTag instanceof HTMLElement)) return;
-  if (anchorTag.closest('.marquee, .aside, .hero-marquee') && !anchorTag.hash) anchorTag.hash = '#autoplay';
+  if (anchorTag.closest('.marquee, .aside, .hero-marquee, .quiz-marquee') && !anchorTag.hash) anchorTag.hash = '#autoplay';
   const { dataset, parentElement } = anchorTag;
   const video = `<video ${getVideoAttrs(anchorTag.hash, dataset)} data-video-source=${src}></video>`;
   anchorTag.insertAdjacentHTML('afterend', video);


### PR DESCRIPTION
**Clone of https://github.com/adobecom/milo/pull/3009 which went into stage**

### Description
Fixes quiz video marquees

Resolves: https://jira.corp.adobe.com/browse/MWPW-159903

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://main-fix-quiz-marquee--milo--mokimo.hlx.page/?martech=off

Quiz Marquees
Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/uar/marquee/illustrator?debug=quiz-results
After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/uar/marquee/illustrator?debug=quiz-results&milolibs=main-fix-quiz-marquees--milo--mokimo
