### PR TITLE
[MWPW-159328] handle a case where there are not placeholders availabl…

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -154,7 +154,7 @@ export function replacePlaceholders(value, placeholders) {
   if (!matches) return val;
   matches.forEach((match) => {
     const key = match.replace(/{{|}}/g, '').trim();
-    if (placeholders[key]) val = val.replace(match, placeholders[key]);
+    if (placeholders?.[key]) val = val.replace(match, placeholders[key]);
   });
   return val;
 }

--- a/test/features/personalization/parseNestedPlaceholders.test.js
+++ b/test/features/personalization/parseNestedPlaceholders.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { parseNestedPlaceholders, createContent } from '../../../libs/features/personalization/personalization.js';
+import { parseNestedPlaceholders, createContent, replacePlaceholders } from '../../../libs/features/personalization/personalization.js';
 import { getConfig } from '../../../libs/utils/utils.js';
 
 const config = getConfig();
@@ -27,5 +27,17 @@ describe('test createContent', () => {
     el.innerHTML = 'Hello World';
     const newContent = createContent(el, '{{promo-discount}}', false, false, 'replace', []);
     expect(newContent.innerHTML).to.equal('50');
+  });
+});
+describe('replacePlaceholders()', () => {
+  it('should replace placeholders', () => {
+    const str = 'Buy now and save {{promo-discount}}% off {{promo-product-name}}.';
+    const newStr = replacePlaceholders(str, config.placeholders);
+    expect(newStr).to.equal('Buy now and save 50% off CC All Apps.');
+  });
+  it('should not break when there are no placeholders available', () => {
+    const str = 'For just {{promo-price}}, get 20+...';
+    const newStr = replacePlaceholders(str, null);
+    expect(newStr).to.equal(str);
   });
 });


### PR DESCRIPTION
**Clone of https://github.com/adobecom/milo/pull/2998 which went into stage**

- Handle a case where there are not placeholders available in replacePlaceholders() function and prevent the page from throwing an error

Resolves: [MWPW-159328](https://jira.corp.adobe.com/browse/MWPW-159328)

Steps to QA: 
Check the console.logs of the Before and After links. Before will include "MEP Error: TypeError: Cannot read properties of undefined (reading 'free-trial')" and After will not.

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/suhjain/vivanchanges/photoshop?mep=%2Fdrafts%2Fsuhjain%2Fvivanchanges%2Fphotoshop.json--phone+%26+not+photoshop-any%2C+phone+%26+not+cc-all-apps-any
- After: https://main--cc--adobecom.hlx.page/drafts/suhjain/vivanchanges/photoshop?mep=%2Fdrafts%2Fsuhjain%2Fvivanchanges%2Fphotoshop.json--phone+%26+not+photoshop-any%2C+phone+%26+not+cc-all-apps-any&milolibs=MWPW-159328

Psi-check: https://mwpw-159328-main--milo--mokimo.hlx.page/?martech=off
