### PR TITLE
MWPW-159791 Support Next-Gen Sidekick

### DIFF
--- a/libs/blocks/bulk-publish-v2/services.js
+++ b/libs/blocks/bulk-publish-v2/services.js
@@ -63,7 +63,7 @@ const setUserData = (event) => {
 
 const isPushedDown = async () => {
   const callback = () => {
-    const sidekick = document.querySelector('helix-sidekick');
+    const sidekick = document.querySelector('aem-sidekick, helix-sidekick');
     const pushdown = sidekick?.getAttribute('pushdown');
     const bulkPub = document.querySelector('.bulk-publish-v2');
     if (pushdown && !bulkPub.classList.contains('pushdown')) {
@@ -81,13 +81,13 @@ const isPushedDown = async () => {
 const authenticate = async (tool = null) => {
   isPushedDown();
   const setUser = (event) => { tool.user = setUserData(event); };
-  const openSideKick = document.querySelector('helix-sidekick');
+  const openSideKick = document.querySelector('aem-sidekick, helix-sidekick');
   if (openSideKick) {
     openSideKick.addEventListener('statusfetched', setUser);
     /* c8 ignore next 6 */
   } else {
     document.addEventListener('sidekick-ready', () => {
-      const sidekick = document.querySelector('helix-sidekick');
+      const sidekick = document.querySelector('aem-sidekick, helix-sidekick');
       sidekick.addEventListener('statusfetched', setUser);
     }, { once: true });
   }

--- a/libs/blocks/preflight/panels/general.js
+++ b/libs/blocks/preflight/panels/general.js
@@ -77,7 +77,7 @@ async function setContent() {
   };
 
   getStatuses();
-  const sk = document.querySelector('helix-sidekick');
+  const sk = document.querySelector('aem-sidekick, helix-sidekick');
   sk?.addEventListener('statusfetched', async () => {
     getStatuses();
   });

--- a/libs/blocks/preflight/panels/seo.js
+++ b/libs/blocks/preflight/panels/seo.js
@@ -314,7 +314,7 @@ async function getResults() {
 
   const red = icons.find((icon) => icon === 'red');
   if (red) {
-    const sk = document.querySelector('helix-sidekick');
+    const sk = document.querySelector('aem-sidekick, helix-sidekick');
     if (sk) {
       const publishBtn = sk.shadowRoot.querySelector('div.publish.plugin button');
       publishBtn.addEventListener('click', () => {

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -58,7 +58,7 @@ function getRepo() {
   const [, repo] = new URL(window.location.href).hostname.split('--');
   if (repo) return repo;
   try {
-    const sidekick = document.querySelector('helix-sidekick');
+    const sidekick = document.querySelector('aem-sidekick, helix-sidekick');
     if (sidekick) {
       const [, sidekickRepo] = new URL(JSON.parse(sidekick.getAttribute('status'))?.live.url).hostname.split('--');
       return sidekickRepo;

--- a/libs/utils/sidekick.js
+++ b/libs/utils/sidekick.js
@@ -32,7 +32,7 @@ export default function init({ createTag, loadBlock, loadScript, loadStyle }) {
     sendToCaaS({ host, project, branch, repo, owner }, loadScript, loadStyle);
   });
 
-  const sk = document.querySelector('helix-sidekick');
+  const sk = document.querySelector('aem-sidekick, helix-sidekick');
 
   // Add plugin listeners here
   sk.addEventListener('custom:send-to-caas', sendToCaasListener);
@@ -40,5 +40,5 @@ export default function init({ createTag, loadBlock, loadScript, loadStyle }) {
   sk.addEventListener('custom:preflight', preflightListener);
 
   // Color code publish button
-  stylePublish(sk);
+  if (sk.nodeName === 'HELIX-SIDEKICK') stylePublish(sk);
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1142,7 +1142,7 @@ function initSidekick() {
     init({ createTag, loadBlock, loadScript, loadStyle });
   };
 
-  if (document.querySelector('helix-sidekick')) {
+  if (document.querySelector('aem-sidekick, helix-sidekick')) {
     initPlugins();
   } else {
     document.addEventListener('sidekick-ready', () => {


### PR DESCRIPTION
* Adds support for [AEM Next-Gen Sidekick](https://chromewebstore.google.com/detail/aem-sidekick-nextgen/igkmdomcgoebiipaifhmpfjhbjccggml?pli=1) (AKA `<aem-sidekick>`)
* Backwards compatible with current AEM Sidekick (AKA `<helix-sidekick>`)

Resolves: [MWPW-159791](https://jira.corp.adobe.com/browse/MWPW-159791)

Note: The next-gen sidekick doesn't appear to have an options page, so "edit" and "prod" plugins can't be tested until after release.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/send-to-caas?martech=off
- After: https://methomas-next-gen-sidekick--milo--adobecom.hlx.page/drafts/methomas/send-to-caas?martech=off
