### PR TITLE
MWPW-148185 [MILO][MEP] Promo modal suppression mechanism

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -251,7 +251,7 @@ export function delayedModal(el) {
 // Deep link-based
 export default function init(el) {
   const { modalHash, modalPath } = el.dataset;
-  if (getConfig().mep.gragments[modalPath].action === 'remove') return null;
+  if (getConfig().mep?.fragments?.[modalPath]?.action === 'remove') return null;
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
   if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null; // prevent duplicate modal loading
   const details = findDetails(window.location.hash, el);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -250,7 +250,8 @@ export function delayedModal(el) {
 
 // Deep link-based
 export default function init(el) {
-  const { modalHash } = el.dataset;
+  const { modalHash, modalPath } = el.dataset;
+  if (getConfig().mep.gragments[modalPath].action === 'remove') return null;
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
   if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null; // prevent duplicate modal loading
   const details = findDetails(window.location.hash, el);

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -4,6 +4,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { delay, waitForElement, waitForRemoval } from '../../helpers/waitfor.js';
 import { mockFetch } from '../../helpers/generalHelpers.js';
+import { getConfig } from '../../../libs/utils/utils.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
@@ -249,6 +250,13 @@ describe('Modals', () => {
     close.click();
     expect(window.location.hash).to.equal('#category=pdf-esignatures&search=acro&types=desktop%2Cmobile');
     window.location.hash = '';
+  });
+
+  it('never create modal when removed by MEP', async () => {
+    const config = getConfig();
+    config.mep = { fragments: { '/milo': { action: 'remove' } } };
+    const modal = init(document.getElementById('milo-modal-link'));
+    expect(modal).to.be.null;
   });
 });
 


### PR DESCRIPTION
Removing a modal fragment does not prevent the creation of the overlay. This code checks if the modal fragment is removed by mep and exist function if so.

Resolves: [MWPW-148185](https://jira.corp.adobe.com/browse/MWPW-148185)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepsuppressmodal/?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepsuppressmodal/?martech=off&milolibs=modalsuppression
- Psi Check: https://modalsuppression--milo--adobecom.hlx.page/?martech=off
