### PR TITLE
Adding support for environment aware link feature to standalone Gnav

### DIFF
--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -21,6 +21,18 @@ const envMap = {
   qa: 'https://gnav--milo--adobecom.hlx.page',
 };
 
+const stageDomainsMap = {
+  'www.stage.adobe.com': {
+    'www.adobe.com': 'origin',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+  },
+  // Test app
+  'adobecom.github.io/nav-consumer': {
+    'www.adobe.com': 'stage.adobe.com',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+  },
+};
+
 function getParamsConfigs(configs) {
   return blockConfig.reduce((acc, block) => {
     block.params.forEach((param) => {
@@ -66,6 +78,7 @@ export default async function loadBlock(configs, customLib) {
     contentRoot: authoringPath || footer.authoringPath,
     theme,
     ...paramConfigs,
+    stageDomainsMap,
   };
   setConfig(clientConfig);
   for await (const block of blockConfig) {

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -28,7 +28,7 @@ const stageDomainsMap = {
   },
   // Test app
   'adobecom.github.io': {
-    'www.adobe.com': 'stage.adobe.com',
+    'www.adobe.com': 'www.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
   },
 };

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -27,7 +27,7 @@ const stageDomainsMap = {
     'helpx.adobe.com': 'helpx.stage.adobe.com',
   },
   // Test app
-  'adobecom.github.io/nav-consumer': {
+  'adobecom.github.io': {
     'www.adobe.com': 'stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
   },


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Add `stageDomainsMap` to the standalone gnav configuration to ensure the `convertStageLinks` function works properly for standalone nav consumers

Resolves: [MWPW-160204](https://jira.corp.adobe.com/browse/MWPW-160204)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://MWPW-160204--milo--adobecom.hlx.page/?martech=off

**QA:**
- https://adobecom.github.io/nav-consumer/navigation.html?authoringpath=/federal/home&navbranch=MWPW-160204
