### PR TITLE
MWPW-159605 Allow consumer apps set IMS timeout value

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -947,7 +947,7 @@ let imsLoaded;
 export async function loadIms() {
   imsLoaded = imsLoaded || new Promise((resolve, reject) => {
     const {
-      locale, imsClientId, imsScope, env, base, adobeid,
+      locale, imsClientId, imsScope, env, base, adobeid, imsTimeout,
     } = getConfig();
     if (!imsClientId) {
       reject(new Error('Missing IMS Client ID'));
@@ -955,7 +955,7 @@ export async function loadIms() {
     }
     const [unavMeta, ahomeMeta] = [getMetadata('universal-nav')?.trim(), getMetadata('adobe-home-redirect')];
     const defaultScope = `AdobeID,openid,gnav${unavMeta && unavMeta !== 'off' ? ',pps.read,firefly_api,additional_info.roles,read_organizations' : ''}`;
-    const timeout = setTimeout(() => reject(new Error('IMS timeout')), 5000);
+    const timeout = setTimeout(() => reject(new Error('IMS timeout')), imsTimeout || 5000);
     window.adobeid = {
       client_id: imsClientId,
       scope: imsScope || defaultScope,


### PR DESCRIPTION
* After DC frictionless pages are switched to using the IMS guest token, we observed a small percentage of users may get an IMS timeout error. In the past we didn't log the error. The investigation is in [MWPW-158350](https://jira.corp.adobe.com/browse/MWPW-158350).  
* This change allows a consumer app to adjust the IMS timeout value. The DC team can fine tune the value to reduce the error rate.

Resolves: [MWPW-159605](https://jira.corp.adobe.com/browse/MWPW-159605)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-159605--milo--adobecom.hlx.page/?martech=off
