### PR TITLE
Add the block name to collect rum data

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -469,6 +469,7 @@ export async function loadBlock(block) {
     return null;
   }
   const { name, blockPath, hasStyles } = getBlockData(block);
+  block.dataset.blockName = name;
   const styleLoaded = hasStyles && new Promise((resolve) => {
     loadStyle(`${blockPath}.css`, resolve);
   });

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -470,6 +470,7 @@ export async function loadBlock(block) {
   }
   const { name, blockPath, hasStyles } = getBlockData(block);
   block.dataset.blockName = name;
+  block.classList.add('block');
   const styleLoaded = hasStyles && new Promise((resolve) => {
     loadStyle(`${blockPath}.css`, resolve);
   });


### PR DESCRIPTION
### Description
Adds the block-name to the dataset to properly [track](https://github.com/adobe/helix-rum-enhancer/blob/1.x/src/index.js#L156) block usage

### Test instructions
Ensure blocks have a `data-block-name` attribute
![Screenshot 2024-10-15 at 17 03 31](https://github.com/user-attachments/assets/e819086c-6ca4-44f2-8b69-9cc7b2d19e10)


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://add-block-name--milo--mokimo.hlx.page/?martech=off
