### PR TITLE
Opt-out class to prevent automatic addition of daa-ll

### DIFF
--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -40,7 +40,7 @@ export function decorateDefaultLinkAnalytics(block, config) {
     let analyticsSelector = `${headerSelector}, .tracking-header`;
     const headers = block.querySelectorAll(analyticsSelector);
     if (!headers.length) analyticsSelector = `${analyticsSelector}, b, strong`;
-    block.querySelectorAll(`${analyticsSelector}, a:not(.video.link-block), button`).forEach((item) => {
+    block.querySelectorAll(`${analyticsSelector}, a:not(.video.link-block, .no-track), button:not(.no-track)`).forEach((item) => {
       if (item.nodeName === 'A' || item.nodeName === 'BUTTON') {
         if (item.classList.contains('tracking-header')) {
           header = processTrackingLabels(item.textContent, config, headerCharLimit);

--- a/libs/martech/attributes.md
+++ b/libs/martech/attributes.md
@@ -25,7 +25,8 @@ Input a string and outputs the clean string. Optional 2nd parameter of character
 > Used in decorateSectionAnalytics, so every block will be passed through this function.
 Can be used inside a block to add daa-ll attributes. Does not overwrite existing daa-ll attributes.
 You only need to call this function in the block if you need the daa-ll attributes added during block decoration.
-Input the block element no return value.
+Input the block element no return value. You can opt out of daa-ll attributes by adding the .no-track class to 
+specific links or buttons in your block.
 
 ### decorateSectionAnalytics
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* support for .no-track to skip addition of daa-ll
* information on how to opt out added to .md

Resolves: [MWPW-160447](https://jira.corp.adobe.com/browse/MWPW-160447)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/colloyd/quiz/?martech=off
- After: https://daa-ll-opt-out--milo--colloyd.hlx.page/drafts/colloyd/quiz/?martech=off

Note: This addition has no effect until the .no-track is added to a link or button inside a block. This change is strictly to support that opt-out class, and can't be tested using the supplied urls. For clarity, I've opted to keep the changes to martech/attributes separate from changes to quiz blocks. A subsequent PR will be forthcoming to add .no-track to quiz blocks that need the opt out.

For reference, the ticket associated with quiz blocks is: https://jira.corp.adobe.com/browse/MWPW-152331
