### PR TITLE
Add opt-out class to quiz blocks

### DIFF
--- a/libs/blocks/quiz-entry/quizoption.js
+++ b/libs/blocks/quiz-entry/quizoption.js
@@ -8,7 +8,7 @@ export const OptionCard = ({
   disabled, selected, background, onClick,
 }) => {
   const getOptionClass = () => {
-    let className = '';
+    let className = 'no-track ';
     if (icon || iconTablet || iconDesktop) className += 'has-icon ';
     if (image) className += 'has-image ';
     if (background) className += 'has-background ';

--- a/libs/blocks/quiz/quizoption.js
+++ b/libs/blocks/quiz/quizoption.js
@@ -5,7 +5,7 @@ export const OptionCard = ({
   text, title, image, icon, iconTablet, iconDesktop, options, disabled, selected, background,
 }) => {
   const getOptionClass = () => {
-    let className = '';
+    let className = 'no-track ';
     if (icon || iconTablet || iconDesktop) className += 'has-icon ';
     if (image) className += 'has-image ';
     if (background) className += 'has-background ';


### PR DESCRIPTION
* add .no-track to quiz cards
* add .no-track to quiz-entry cards

Resolves: [MWPW-152331](https://jira.corp.adobe.com/browse/MWPW-152331)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/colloyd/quiz/?martech=off
- After: https://quiz-block-daa-opt-out--milo--colloyd.hlx.page/drafts/colloyd/quiz/?martech=off

Note: When paired with the changes to support an opt out class from https://github.com/adobecom/milo/pull/3042 these changes will remove daa-ll attributes from the options cards in quiz and quiz-entry - daa-ll will still be present until both PR's are merged. 

To test, inspect cards from before and after and note the presence of the "no-track" class on the button element for each card on the "after" url. When the PR noted above is merged, the daa-ll attributes will also be removed. I've isolated each piece of this fix to different PR's for code history clarity.

You can test quiz-entry using these urls: 

- Before: https://main--milo--adobecom.hlx.page/drafts/colloyd/quiz-entry/?martech=off
- After: https://quiz-block-daa-opt-out--milo--colloyd.hlx.page/drafts/colloyd/quiz-entry/?martech=off
