### PR TITLE
MWPW-159561 Add lcpSectionOne metric to web vitals

### DIFF
--- a/libs/utils/logWebVitals.js
+++ b/libs/utils/logWebVitals.js
@@ -76,7 +76,10 @@ function isFragmentFromMep(fragPath, mep) {
   });
 }
 
+const boolStr = (val) => (val ? 'true' : 'false');
+
 function observeLCP(lanaData, delay, mep) {
+  const sectionOne = document.querySelector('main > div');
   new PerformanceObserver((list) => {
     const entries = list.getEntries();
     const lastEntry = entries[entries.length - 1]; // Use the latest LCP candidate
@@ -84,10 +87,11 @@ function observeLCP(lanaData, delay, mep) {
     const lcpEl = lastEntry.element;
     lanaData.lcpElType = lcpEl.nodeName.toLowerCase();
     lanaData.lcpEl = getElementInfo(lcpEl);
+    lanaData.lcpSectionOne = boolStr(sectionOne.contains(lcpEl));
     const closestFrag = lcpEl.closest('.fragment');
-    lanaData.isFrag = closestFrag ? 'true' : 'false';
+    lanaData.isFrag = boolStr(closestFrag);
     if (closestFrag) {
-      lanaData.isMep = isFragmentFromMep(closestFrag.dataset.path, mep) ? 'true' : 'false';
+      lanaData.isMep = boolStr(isFragmentFromMep(closestFrag.dataset.path, mep));
     } else {
       lanaData.isMep = 'false';
     }

--- a/libs/utils/logWebVitals.js
+++ b/libs/utils/logWebVitals.js
@@ -76,7 +76,7 @@ function isFragmentFromMep(fragPath, mep) {
   });
 }
 
-const boolStr = (val) => (val ? 'true' : 'false');
+const boolStr = (val) => `${!!val}`;
 
 function observeLCP(lanaData, delay, mep) {
   const sectionOne = document.querySelector('main > div');

--- a/test/utils/logWebVitalsUtils.test.js
+++ b/test/utils/logWebVitalsUtils.test.js
@@ -43,6 +43,8 @@ describe('Log Web Vitals Utils', () => {
         expect(parseInt(vitals.lcp, 10)).to.be.greaterThan(1);
         expect(vitals.lcpEl).to.be.equal('/test/utils/mocks/media_.png');
         expect(vitals.lcpElType).to.be.equal('img');
+        expect(vitals.lcpSectionOne).to.be.equal('true');
+
         expect(vitals.loggedIn).to.equal('false');
         expect(vitals.os).to.be.oneOf(['mac', 'win', 'android', 'linux', '']);
         expect(vitals.url).to.equal('localhost:2000/');


### PR DESCRIPTION
Logs if the LCP Element is in Section One of the page.

Resolves: [MWPW-159561](https://jira.corp.adobe.com/browse/MWPW-159561)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-159561--milo--adobecom.hlx.page/?martech=off
