### PR TITLE
MWPW-159555 Add support for lana-sample query param

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 (function () {
   const MSG_LIMIT = 2000;
 

--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -65,7 +65,8 @@
       return;
     }
 
-    const sampleRate = o.errorType === 'i' ? o.implicitSampleRate : o.sampleRate;
+    const sampleRateParam = parseInt(new URL(window.location).searchParams.get('lana-sample'), 10);
+    const sampleRate = sampleRateParam || (o.errorType === 'i' ? o.implicitSampleRate : o.sampleRate);
 
     if (!w.lana.debug && !w.lana.localhost && sampleRate <= Math.random() * 100) return;
 

--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -1,5 +1,6 @@
-/* eslint-disable */
-(function () {
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-console */
+(function iife() {
   const MSG_LIMIT = 2000;
 
   const defaultOptions = {
@@ -50,10 +51,6 @@
     }, {});
   }
 
-  function sendUnhandledError(e) {
-    log(e.reason || e.error || e.message, { errorType: 'i' });
-  }
-
   function log(msg, options) {
     msg = msg && msg.stack ? msg.stack : (msg || '');
     if (msg.length > MSG_LIMIT) {
@@ -97,8 +94,13 @@
       }
       xhr.open('GET', `${endpoint}?${queryParams.join('&')}`);
       xhr.send();
+      // eslint-disable-next-line consistent-return
       return xhr;
     }
+  }
+
+  function sendUnhandledError(e) {
+    log(e.reason || e.error || e.message, { errorType: 'i' });
   }
 
   function hasDebugParam() {

--- a/libs/utils/lana.md
+++ b/libs/utils/lana.md
@@ -37,6 +37,7 @@ Note that any errors that happen on a `*.corp.adobe.com` domain will automatical
         * same as `sampleRate`
     * `useProd` - bool: Defaults to `true`
         * Toggle between prod and stage endpoints
+
 ## Helper Functions
 
 The helper functions have been deprecated in favor of the options being passed with every lana call.
@@ -51,6 +52,8 @@ Note that the default option state is stored in `window.lana.options` and can be
 
 Debugging mode can be enabled by setting a `lanaDebug` query param.  This sends lana messages with debug enabled and will console.log the responses.
 Alternatively, the `window.lana.debug` property can be set (the query param also sets this property).
+
+The Lana logging sample rate can be overridden with the `lana-sample` query param.  It should be set as an integer between 0-100.  This will set the sample rate for all lana messages regardless of other sample rates set.
 
 ## localhost
 

--- a/test/utils/lana.test.js
+++ b/test/utils/lana.test.js
@@ -197,4 +197,28 @@ describe('LANA', () => {
 
     window.history.pushState({ path: originalUrl }, '', originalUrl);
   });
+
+  it('Invalid lana-sample query params are ignored', () => {
+    window.lana.options = {
+      clientId: 'blah',
+      sampleRate: 100,
+      implicitSampleRate: 100,
+    };
+    const originalUrl = window.location.href;
+
+    // create a new url based on the current url that adds a query param for lana-sample
+    const newUrl = new URL(window.location.href);
+    newUrl.searchParams.set('lana-sample', 'notvalid');
+
+    window.history.pushState({ path: newUrl.toString() }, '', newUrl.toString());
+
+    window.lana.log('lana-sample query param');
+    expect(xhrRequests.length).to.equal(1);
+    expect(xhrRequests[0].method).to.equal('GET');
+    expect(xhrRequests[0].url).to.equal(
+      'https://www.stage.adobe.com/lana/ll?m=lana-sample%20query%20param&c=blah&s=100&t=e',
+    );
+
+    window.history.pushState({ path: originalUrl }, '', originalUrl);
+  });
 });

--- a/test/utils/lana.test.js
+++ b/test/utils/lana.test.js
@@ -170,4 +170,28 @@ describe('LANA', () => {
       'https://www.stage.adobe.com/lana/ll?m=only%20the%20clientId%20set%20in%20window.lana.options&c=blah&s=100&t=e',
     );
   });
+
+  it('The lana-sample query param overrides existing sampleRate', () => {
+    window.lana.options = {
+      clientId: 'blah',
+      sampleRate: 100,
+      implicitSampleRate: 100,
+    };
+    const originalUrl = window.location.href;
+
+    // create a new url based on the current url that adds a query param for lana-sample
+    const newUrl = new URL(window.location.href);
+    newUrl.searchParams.set('lana-sample', '33');
+
+    window.history.pushState({ path: newUrl.toString() }, '', newUrl.toString());
+
+    window.lana.log('lana-sample query param');
+    expect(xhrRequests.length).to.equal(1);
+    expect(xhrRequests[0].method).to.equal('GET');
+    expect(xhrRequests[0].url).to.equal(
+      'https://www.stage.adobe.com/lana/ll?m=lana-sample%20query%20param&c=blah&s=33&t=e',
+    );
+
+    window.history.pushState({ path: originalUrl }, '', originalUrl);
+  });
 });

--- a/test/utils/lana.test.js
+++ b/test/utils/lana.test.js
@@ -174,14 +174,17 @@ describe('LANA', () => {
   it('The lana-sample query param overrides existing sampleRate', () => {
     window.lana.options = {
       clientId: 'blah',
-      sampleRate: 100,
-      implicitSampleRate: 100,
+      sampleRate: 0,
+      implicitSampleRate: 0,
     };
     const originalUrl = window.location.href;
 
+    window.lana.log('Sample rate is zero so should not be logged');
+    expect(xhrRequests.length).to.equal(0);
+
     // create a new url based on the current url that adds a query param for lana-sample
     const newUrl = new URL(window.location.href);
-    newUrl.searchParams.set('lana-sample', '33');
+    newUrl.searchParams.set('lana-sample', '100');
 
     window.history.pushState({ path: newUrl.toString() }, '', newUrl.toString());
 
@@ -189,7 +192,7 @@ describe('LANA', () => {
     expect(xhrRequests.length).to.equal(1);
     expect(xhrRequests[0].method).to.equal('GET');
     expect(xhrRequests[0].url).to.equal(
-      'https://www.stage.adobe.com/lana/ll?m=lana-sample%20query%20param&c=blah&s=33&t=e',
+      'https://www.stage.adobe.com/lana/ll?m=lana-sample%20query%20param&c=blah&s=100&t=e',
     );
 
     window.history.pushState({ path: originalUrl }, '', originalUrl);


### PR DESCRIPTION
The `lana-sample` query param will override any sample rate defined elsewhere.  Setting it to "100" will force lana to send everything to splunk.

Resolves: [MWPW-159555](https://jira.corp.adobe.com/browse/MWPW-159555)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-159555--milo--adobecom.hlx.page/?martech=off
