### PR TITLE
MWPW-159651 && MWPW-160196 - [Hero marquee] bug fixes

### DIFF
--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -150,6 +150,10 @@ html[dir="rtl"] .hero-marquee .foreground {
   display: none;
 }
 
+.hero-marquee .foreground div.empty-asset:empty {
+  display: block;
+}
+
 /* Row Types */
 .hero-marquee .row-list {
   text-align: left;

--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -272,8 +272,8 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   }
 
   /* con-vars support */
-  .hero-marquee:is(.bg-top-mobile, .bg-bottom-mobile, .bg-top-tablet, .bg-bottom-tablet) .background,
-  .hero-marquee:is(.bg-top-mobile, .bg-bottom-mobile, .bg-top-tablet, .bg-bottom-tablet) .background video {
+  .hero-marquee:is(.bg-top-mobile, .bg-bottom-mobile) .background,
+  .hero-marquee:is(.bg-top-mobile, .bg-bottom-mobile) .background video {
       position: relative;
       width: 100%;
   }

--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -17,6 +17,7 @@
   align-items: center;
 }
 
+.hero-marquee.no-min-height { min-height: unset; }
 .hero-marquee.s-min-height { min-height: var(--s-min-height); }
 .hero-marquee.l-min-height { min-height: var(--l-min-height); }
 

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -80,8 +80,8 @@ async function decorateLockupRow(el, classes) {
   const usedLockupClass = iconSizeClass || lockupSizeClass;
   if (usedLockupClass) {
     el.classList.remove(usedLockupClass);
-    el.classList.add(`${usedLockupClass?.split('-')[0] || 'l'}-lockup`);
   }
+  el.classList.add(`${usedLockupClass?.split('-')[0] || 'l'}-lockup`);
 }
 
 function decorateBg(el) {

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -225,7 +225,10 @@ export default async function init(el) {
   if (assetRow) el.classList.add('asset-left');
   const lockupClass = [...el.classList].find((c) => c.endsWith('-lockup'));
   if (lockupClass) el.classList.remove(lockupClass);
-  const mainCopy = createTag('div', { class: `main-copy ${lockupClass || 'l-lockup'}` });
+  const buttonClass = [...el.classList].find((c) => c.endsWith('-button'));
+  if (buttonClass) el.classList.remove(buttonClass);
+  const classes = `main-copy ${lockupClass || 'l-lockup'} ${buttonClass || 'l-button'}`;
+  const mainCopy = createTag('div', { class: classes });
   while (copy.childNodes.length > 0) {
     mainCopy.appendChild(copy.childNodes[0]);
   }

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -76,8 +76,12 @@ async function decorateLockupRow(el, classes) {
   await loadIconography();
   child?.classList.add('lockup-area');
   const iconSizeClass = classes?.find((c) => c.endsWith('-icon'));
-  if (iconSizeClass) el.classList.remove(iconSizeClass);
-  el.classList.add(`${iconSizeClass?.split('-')[0] || 'l'}-lockup`);
+  const lockupSizeClass = classes?.find((c) => c.endsWith('-lockup'));
+  const usedLockupClass = iconSizeClass || lockupSizeClass;
+  if (usedLockupClass) {
+    el.classList.remove(usedLockupClass);
+    el.classList.add(`${usedLockupClass?.split('-')[0] || 'l'}-lockup`);
+  }
 }
 
 function decorateBg(el) {
@@ -208,8 +212,6 @@ export default async function init(el) {
   if (assetUnknown) assetUnknown.classList.add('asset-unknown');
 
   decorateBlockText(copy, textDefault, 'hasDetailHeading');
-  const blockLockupClass = [...el.classList].find((c) => c.endsWith('-lockup'));
-  if (blockLockupClass === undefined) copy.classList.add('l-lockup');
   await decorateLockupFromContent(copy);
   extendButtonsClass(copy);
 
@@ -221,7 +223,9 @@ export default async function init(el) {
 
   const assetRow = allRows[0].classList.contains('asset');
   if (assetRow) el.classList.add('asset-left');
-  const mainCopy = createTag('div', { class: 'main-copy' });
+  const lockupClass = [...el.classList].find((c) => c.endsWith('-lockup'));
+  if (lockupClass) el.classList.remove(lockupClass);
+  const mainCopy = createTag('div', { class: `main-copy ${lockupClass || 'l-lockup'}` });
   while (copy.childNodes.length > 0) {
     mainCopy.appendChild(copy.childNodes[0]);
   }
@@ -239,7 +243,6 @@ export default async function init(el) {
       copy.append(row);
     }
   });
-
   const promiseArr = [];
   [...rows].forEach(async (row) => {
     const cols = row.querySelectorAll(':scope > div');

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -208,6 +208,8 @@ export default async function init(el) {
   if (assetUnknown) assetUnknown.classList.add('asset-unknown');
 
   decorateBlockText(copy, textDefault, 'hasDetailHeading');
+  const blockLockupClass = [...el.classList].find((c) => c.endsWith('-lockup'));
+  if (blockLockupClass === undefined) copy.classList.add('l-lockup');
   await decorateLockupFromContent(copy);
   extendButtonsClass(copy);
 

--- a/libs/styles/breakpoint-theme.css
+++ b/libs/styles/breakpoint-theme.css
@@ -45,6 +45,28 @@
     color: var(--color-black);
     text-decoration: none;
   }
+
+  .con-block.light-mobile-only a.con-button.fill {
+    border-color: var(--text-color);
+    background-color: var(--text-color);
+    color: var(--color-white);
+  }
+
+  .con-block.dark-mobile-only a.con-button.fill {
+    border-color: var(--color-white);
+    background-color: var(--color-white);
+    color: var(--text-color);
+  }
+  
+  .con-block.light-mobile-only a.con-button.fill:is(:hover, :focus, :active) {
+    border-color: var(--color-black);
+    background-color: var(--color-black);
+  }
+  
+  .con-block.dark-mobile-only a.con-button.fill:is(:hover, :focus, :active) {
+    color: var(--color-black);
+  }
+  
 }
 
 /* Tablet ONLY */
@@ -80,6 +102,27 @@
     border-color: var(--color-white);
     color: var(--color-black);
     text-decoration: none;
+  }
+
+  .con-block.light-tablet-only a.con-button.fill {
+    border-color: var(--text-color);
+    background-color: var(--text-color);
+    color: var(--color-white);
+  }
+
+  .con-block.dark-tablet-only a.con-button.fill {
+    border-color: var(--color-white);
+    background-color: var(--color-white);
+    color: var(--text-color);
+  }
+  
+  .con-block.light-tablet-only a.con-button.fill:is(:hover, :focus, :active) {
+    border-color: var(--color-black);
+    background-color: var(--color-black);
+  }
+  
+  .con-block.dark-tablet-only a.con-button.fill:is(:hover, :focus, :active) {
+    color: var(--color-black);
   }
 }
 
@@ -117,6 +160,27 @@
     color: var(--color-black);
     text-decoration: none;
   }
+
+  .con-block.light-tablet a.con-button.fill {
+    border-color: var(--text-color);
+    background-color: var(--text-color);
+    color: var(--color-white);
+  }
+
+  .con-block.dark-tablet a.con-button.fill {
+    border-color: var(--color-white);
+    background-color: var(--color-white);
+    color: var(--text-color);
+  }
+  
+  .con-block.light-tablet a.con-button.fill:is(:hover, :focus, :active) {
+    border-color: var(--color-black);
+    background-color: var(--color-black);
+  }
+  
+  .con-block.dark-tablet a.con-button.fill:is(:hover, :focus, :active) {
+    color: var(--color-black);
+  }
 }
 
 /* desktop up */
@@ -153,5 +217,26 @@
     border-color: var(--color-white);
     color: var(--color-black);
     text-decoration: none;
+  }
+
+  .con-block.light-desktop a.con-button.fill {
+    border-color: var(--text-color);
+    background-color: var(--text-color);
+    color: var(--color-white);
+  }
+
+  .con-block.dark-desktop a.con-button.fill {
+    border-color: var(--color-white);
+    background-color: var(--color-white);
+    color: var(--text-color);
+  }
+  
+  .con-block.light-desktop a.con-button.fill:is(:hover, :focus, :active) {
+    border-color: var(--color-black);
+    background-color: var(--color-black);
+  }
+  
+  .con-block.dark-desktop a.con-button.fill:is(:hover, :focus, :active) {
+    color: var(--color-black);
   }
 }

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -359,18 +359,19 @@
   padding: 10px 24px 8px;
 }
 
-.con-button.button-justified {
-  display: block;
-  text-align: center;
-  width: 100%;
-}
-
-.xxl-button .con-button {
+.xxl-button .con-button,
+.con-button.button-xxl {
   border-radius: 30px;
   font-size: 22px;
   line-height: 27px;
   min-height: 27px;
   padding: 14px 30px 15px;
+}
+
+.con-button.button-justified {
+  display: block;
+  text-align: center;
+  width: 100%;
 }
 
 .dark .con-button {

--- a/test/blocks/hero-marquee/mocks/body.html
+++ b/test/blocks/hero-marquee/mocks/body.html
@@ -21,6 +21,10 @@
     <div><picture><img loading="lazy" src="./"></picture> <strong>XL Icon Size</strong></div>
   </div>
   <div>
+    <div>con-block-row-lockup (xl-lockup)</div>
+    <div><picture><img loading="lazy" src="./"></picture> <strong>XL Icon Size</strong></div>
+  </div>
+  <div>
     <div>
       <p><picture><img loading="lazy" src="./"></picture> After Effects</p>
       <p>DETAIL TEXT</p>


### PR DESCRIPTION
**1) Hero marquee doesn't render as expected when authored with a split content row and an empty first cell.** 
The hero marquee copy area can be authored w/ a two column row (split-cell), indicating that there is a content division of either `asset | copy` or `empty(whitespace) | copy` etc. When the first cell in this row is empty, the content appears on the left when it should stay divided and appear in the authored right position. 

Solution: display `.empty-asset:empty` as block, instead of 'hidden' 

<img width="2417" alt="Screenshot 2024-10-15 at 1 24 43 PM" src="https://github.com/user-attachments/assets/b7b51d36-930a-4047-a61d-9689f72c22f5">

Resolves: [MWPW-159651](https://jira.corp.adobe.com/browse/MWPW-159651) - [Hero marquee] Main content can't be placed on right correctly

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/vmorel/hero-marquee-content-on-right?martech=off
- After: https://rparrish-hero-right-copy--milo--adobecom.hlx.page/drafts/rparrish/hero/hero-left-right?martech=off

---
**1) Inconsistent lockup sizes** 
When a hero marquee is authored with out a lockup size variant (xl-lockup), ex. `[hero-marquee]` , the default lockup size isn't rendered correctly.
The spec for l-lockup are: 
Product tile: 56px - Font size: 38px
Currently: Product name font size set to body copy size
![image](https://github.com/user-attachments/assets/99a8794d-b35e-4fca-9b69-bc8ea33cf06c)
But it should be: 38px
![image](https://github.com/user-attachments/assets/4333d8ac-9eae-438a-a42a-b054651ec228)


**2) Button Sizes on a con-row variant should take priority**
When authoring a hero with a block variant, ex.`hero-marquee (xxl-button)` and a content row with a button size variant, ex `con-block-row-text (l-button)`, the row variant should take priority.
Currently the block level variant will be used if the size is incrementally smaller in the row. 
![image](https://github.com/user-attachments/assets/fa95f324-b862-475f-9f96-a2c72651f63b)

3) media-breakpoints.css don't support the new `button-fill` style
The media breakpoint specific theme variants, such as "dark-mobile/light-mobile/dark-tablet/light-tablet/dark-desktop/light-desktop" don't support the new button variant #_button-fill
`dark = (button.fill  / text) is white, bg is dark`

<img width="1604" alt="Screenshot 2024-10-15 at 1 35 46 PM" src="https://github.com/user-attachments/assets/8a4296af-7ca2-4a3c-8316-a91e87e5c524">



Resolves: [MWPW-160196](https://jira.corp.adobe.com/browse/MWPW-160196) - [Hero marquee] - bugs


**Test URLs:**
- before: https://main--milo--adobecom.hlx.page/drafts/rparrish/hero/hero-bug-fixes-160196?martech=off
- after: https://rparrish-hero-right-copy--milo--adobecom.hlx.page/drafts/rparrish/hero/hero-bug-fixes-160196?martech=off


**Live URLs:**
Before Block: https://main--milo--adobecom.hlx.page/docs/library/blocks/hero-marquee?martech=off
After Block: https://rparrish-hero-right-copy--milo--adobecom.hlx.page/docs/library/blocks/hero-marquee?martech=off

Before Sink: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/hero-marquee?martech=off
After Sink: https://rparrish-hero-right-copy--milo--adobecom.hlx.page/docs/library/kitchen-sink/hero-marquee?martech=off
