### PR TITLE
Sending pages to CaaS from the page creates double .html extension

### DIFF
--- a/test/blocks/caas/send-to-caas.test.js
+++ b/test/blocks/caas/send-to-caas.test.js
@@ -1,6 +1,7 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 
+import { getProdUrlWithHtmlExtension } from '../../../tools/send-to-caas/send-to-caas.js';
 import { checkUrl, getKeyValPairs, getOrigin, setConfig } from '../../../tools/send-to-caas/send-utils.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
@@ -43,5 +44,24 @@ describe('checkUrl function', () => {
     const emptyKeyVal = ': value1, key2:, :, key3: value3';
     const resultEmptyKeyVal = getKeyValPairs(emptyKeyVal);
     expect(JSON.stringify(resultEmptyKeyVal)).to.equal('[{"key3":"value3"}]');
+  });
+
+  beforeEach(() => {
+    window.location = { pathname: '/test-page.html' };
+  });
+
+  it('should return URL without .html if useHtml is not checked', () => {
+    document.body.innerHTML = '<input type="checkbox" id="usehtml" />';
+    expect(getProdUrlWithHtmlExtension('https://milo.adobe.com/test-page')).to.equal('https://milo.adobe.com/test-page');
+  });
+
+  it('should return URL with .html if useHtml is checked', () => {
+    document.body.innerHTML = '<input type="checkbox" id="usehtml" checked />';
+    expect(getProdUrlWithHtmlExtension('https://milo.adobe.com/test-page', 'test-page')).to.equal('https://milo.adobe.com/test-page.html');
+  });
+
+  it('should return URL with .html if useHtml is checked and not add double .html', () => {
+    document.body.innerHTML = '<input type="checkbox" id="usehtml" checked />';
+    expect(getProdUrlWithHtmlExtension('https://milo.adobe.com/test-page.html', 'test-page')).to.equal('https://milo.adobe.com/test-page.html');
   });
 });

--- a/test/blocks/caas/send-to-caas.test.js
+++ b/test/blocks/caas/send-to-caas.test.js
@@ -46,10 +46,6 @@ describe('checkUrl function', () => {
     expect(JSON.stringify(resultEmptyKeyVal)).to.equal('[{"key3":"value3"}]');
   });
 
-  beforeEach(() => {
-    window.location = { pathname: '/test-page.html' };
-  });
-
   it('should return URL without .html if useHtml is not checked', () => {
     document.body.innerHTML = '<input type="checkbox" id="usehtml" />';
     expect(getProdUrlWithHtmlExtension('https://milo.adobe.com/test-page')).to.equal('https://milo.adobe.com/test-page');

--- a/tools/send-to-caas/send-to-caas.js
+++ b/tools/send-to-caas/send-to-caas.js
@@ -221,19 +221,22 @@ const verifyInfoModal = async (tags, tagErrors, showAllPropertiesAlert) => {
 };
 
 const isUseHtmlChecked = () => document.getElementById('usehtml')?.checked;
+const appendHtmlExtension = (url) => (url.endsWith('.html') ? url : `${url}.html`);
+const getProdUrlWithHtmlExtension = (url) => (isUseHtmlChecked() ? appendHtmlExtension(url) : url);
 
 const sortObjByPropName = (obj) => Object.keys(obj)
   // eslint-disable-next-line no-return-assign, no-sequences
   .sort().reduce((c, d) => (c[d] = obj[d], c), {});
 
 const validateProps = async (prodHost, publishingModal) => {
+  const url = `${prodHost}${window.location.pathname}`;
   const { caasMetadata, errors, tags, tagErrors } = await getCardMetadata(
-    { prodUrl: `${prodHost}${window.location.pathname}` },
+    { prodUrl: url },
   );
 
   const showAllPropertiesAlert = async () => {
     const { caasMetadata: cMetaData } = await getCardMetadata(
-      { prodUrl: `${prodHost}${window.location.pathname}${isUseHtmlChecked() ? '.html' : ''}` },
+      { prodUrl: getProdUrlWithHtmlExtension(url) },
     );
     const mdStr = JSON.stringify(sortObjByPropName(cMetaData), undefined, 4);
     showAlert(`<h3>All CaaS Properties</h3><pre id="json" style="white-space:pre-wrap;font-size:14px;">${mdStr}</pre>`);
@@ -265,7 +268,7 @@ const validateProps = async (prodHost, publishingModal) => {
   let metaWithUseHtml;
   if (useHtml) {
     ({ caasMetadata: metaWithUseHtml } = await getCardMetadata(
-      { prodUrl: `${prodHost}${window.location.pathname}.html` },
+      { prodUrl: appendHtmlExtension(`${prodHost}${window.location.pathname}`) },
     ));
   }
 
@@ -395,4 +398,5 @@ export {
   sendToCaaS,
   showAlert,
   showConfirm,
+  getProdUrlWithHtmlExtension,
 };


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Ensure when URL contains .html an additional html is not added

Resolves: [MWPW-152602](https://jira.corp.adobe.com/browse/MWPW-152602)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-152602--milo--shkhan91.hlx.page/?martech=off

In order to test, send a page with .html extension to caas. While clicking the use html checkbox
