### PR TITLE
MWPW-160014 : Search container for Standalone Gnav on devices

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -354,6 +354,7 @@ class Gnav {
           ${this.decorateBrand()}
         </div>
         ${this.elements.navWrapper}
+        ${getConfig().searchEnabled === 'on' ? toFragment`<div class="feds-client-search"></div>` : ''}
         ${this.useUniversalNav ? this.blocks.universalNav : ''}
         ${(!this.useUniversalNav && this.blocks.profile.rawElem) ? this.blocks.profile.decoratedElem : ''}
         ${this.decorateLogo()}
@@ -838,7 +839,6 @@ class Gnav {
         ${isDesktop.matches ? '' : this.decorateSearch()}
         ${this.elements.mainNav}
         ${isDesktop.matches ? this.decorateSearch() : ''}
-        ${getConfig().searchEnabled === 'on' ? toFragment`<div class="feds-client-search"></div>` : ''}
       </div>
     `;
 

--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -42,3 +42,7 @@ header.global-navigation, header.global-navigation.feds--dark {
     padding: 0 15px;
   }
 }
+
+.feds-client-search {
+  margin-left: auto;
+}

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -643,7 +643,7 @@ describe('global navigation', () => {
   describe('Client search feature in global navigation', () => {
     it('should append the feds-client-search div when search is enabled', async () => {
       await createFullGlobalNavigation({ customConfig: { searchEnabled: 'on' } });
-      expect(document.querySelector(selectors.topNavWrapper).classList.contains('feds-client-search')).to.exist;
+      expect(document.querySelector(selectors.topNav).classList.contains('feds-client-search')).to.exist;
     });
   });
 

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -38,6 +38,7 @@ export const selectors = {
   promo: '.feds-promo',
   promoImage: '.feds-promo-image',
   topNavWrapper: '.feds-topnav-wrapper',
+  topNav: '.feds-topnav',
   breadcrumbsWrapper: '.feds-breadcrumbs-wrapper',
   mainNav: '.feds-nav',
   imsSignIn: '.feds-signIn',


### PR DESCRIPTION
MWPW-160014 : Search container for Standalone Gnav on devices

Resolves: [MWPW-160014](https://jira.corp.adobe.com/browse/MWPW-160014)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://ahsearch--milo--adobecom.hlx.page/?martech=off

**QA:**
- https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=ahsearch&showUnavSectionDivider=true&searchEnabled=on