### PR TITLE
Graybox display specificity fix

### DIFF
--- a/libs/blocks/graybox/graybox.css
+++ b/libs/blocks/graybox/graybox.css
@@ -10,7 +10,7 @@
 }
 
 .graybox {
-  display: none;
+  display: none !important;
 }
 
 .gb-graybox-body {
@@ -90,7 +90,7 @@
   position: fixed;
   right: 0;
   top: 15%;
-  z-index: calc(var(--above-all) + 2);
+  z-index: calc(var(--above-all) + 1);
 }
 
 .graybox-container .gb-toggle {
@@ -190,7 +190,7 @@
 }
 
 .dialog-modal.graybox-modal {
-  z-index: calc(var(--above-all) + 1);
+  z-index: var(--above-all);
 }
 
 .dialog-modal.graybox-modal.mobile > div {
@@ -260,7 +260,7 @@
 
 .modal-curtain.graybox-curtain.is-open {
   background: var(--gb-modal-bg);
-  z-index: var(--above-all);
+  z-index: calc(var(--above-all) - 1);
 }
 
 @media (max-height: 910px), (max-width: 420px) {

--- a/libs/blocks/graybox/graybox.css
+++ b/libs/blocks/graybox/graybox.css
@@ -90,7 +90,7 @@
   position: fixed;
   right: 0;
   top: 15%;
-  z-index: calc(var(--above-all) + 1);
+  z-index: calc(var(--above-all) + 2);
 }
 
 .graybox-container .gb-toggle {
@@ -190,7 +190,7 @@
 }
 
 .dialog-modal.graybox-modal {
-  z-index: var(--above-all);
+  z-index: calc(var(--above-all) + 1)
 }
 
 .dialog-modal.graybox-modal.mobile > div {
@@ -260,7 +260,7 @@
 
 .modal-curtain.graybox-curtain.is-open {
   background: var(--gb-modal-bg);
-  z-index: calc(var(--above-all) - 1);
+  z-index: var(--above-all);
 }
 
 @media (max-height: 910px), (max-width: 420px) {

--- a/libs/blocks/graybox/graybox.css
+++ b/libs/blocks/graybox/graybox.css
@@ -190,7 +190,7 @@
 }
 
 .dialog-modal.graybox-modal {
-  z-index: calc(var(--above-all) + 1)
+  z-index: calc(var(--above-all) + 1);
 }
 
 .dialog-modal.graybox-modal.mobile > div {


### PR DESCRIPTION
* ensure that the graybox block will never be seen, regardless of page content or setup

Resolves: [MWPW-160469](https://jira.corp.adobe.com/browse/MWPW-160469)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/colloyd/graybox/graybox-masonry?martech=off
- After: https://graybox-display-specificity-fix--milo--colloyd.hlx.page/drafts/colloyd/graybox/graybox-masonry?martech=off

Note: This small fix will ensure that the graybox block is always properly hidden. This is necessary if a graybox block is placed in such a way that the outside css overrides diplay with more specificity, such as if the block is placed inside masonry, where its display is then overridden from display: none, to display: grid.  