### PR TITLE
MWPW-160518: CCD Slice/Suggested card style fixes

### DIFF
--- a/libs/deps/mas/merch-card.js
+++ b/libs/deps/mas/merch-card.js
@@ -35,6 +35,11 @@ var MerchIcon = class extends LitElement {
             --img-height: 24px;
         }
 
+        :host([size='m']) {
+            --img-width: 30px;
+            --img-height: 30px;
+        }
+
         :host([size='l']) {
             --img-width: 40px;
             --img-height: 40px;
@@ -1928,6 +1933,8 @@ merch-card[variant="ccd-suggested"] [slot="heading-xs"] {
 }
 
 merch-card[variant="ccd-suggested"] [slot="cta"] a {
+  font-size: var(--consonant-merch-card-body-xs-font-size);
+  line-height: normal;
   text-decoration: none;
   color: var(--spectrum-gray-800);
   font-weight: 700;
@@ -1987,19 +1994,26 @@ var CCDSuggested = class extends VariantLayout {
       display: flex;
       flex-flow: wrap;
       place-self: flex-start;
+      flex-wrap: nowrap;
     }
 
     :host([variant='ccd-suggested']) .headings {
       padding-inline-start: var(--consonant-merch-spacing-xxs);
+      display: flex;
+      flex-direction: column;
     }
 
     :host([variant='ccd-suggested']) ::slotted([slot='icons']) {
-      place-self: flex-start;
+      place-self: center;
     }
 
     :host([variant='ccd-suggested']) ::slotted([slot='heading-xs']) {
       font-size: var(--merch-card-heading-xxs-font-size);
       line-height: var(--merch-card-heading-xxs-line-height);
+    }
+    
+    :host([variant='ccd-suggested']) ::slotted([slot='detail-m']) {
+      line-height: var(--consonant-merch-card-detail-m-line-height);
     }
     
     :host([variant='ccd-suggested'][strip-size='wide']) ::slotted([slot='body-xs']) {
@@ -2014,6 +2028,8 @@ var CCDSuggested = class extends VariantLayout {
       display: flex;
       align-items: center;
       color: var(--spectrum-gray-800, #F8F8F8);
+      font-size: var(--consonant-merch-card-body-xs-font-size);
+      line-height: var(--consonant-merch-card-body-xs-line-height);
     }
 
     :host([variant='ccd-suggested']) ::slotted([slot='cta']) {
@@ -2051,7 +2067,7 @@ merch-card[variant="ccd-slice"] [slot='body-s'] a:not(.con-button) {
     font-weight: 400;
     line-height: var(--consonant-merch-card-body-xxs-line-height);
     text-decoration-line: underline;
-    color: var(--spectrum-blue-800, #147AF3);
+    color: var(--spectrum-gray-800, var(--merch-color-grey-80;
   }
 
   merch-card[variant="ccd-slice"] [slot='image'] img {

--- a/libs/deps/mas/merch-icon.js
+++ b/libs/deps/mas/merch-icon.js
@@ -32,6 +32,11 @@ var MerchIcon = class extends LitElement {
             --img-height: 24px;
         }
 
+        :host([size='m']) {
+            --img-width: 30px;
+            --img-height: 30px;
+        }
+
         :host([size='l']) {
             --img-width: 40px;
             --img-height: 40px;

--- a/libs/features/mas/web-components/src/merch-icon.js
+++ b/libs/features/mas/web-components/src/merch-icon.js
@@ -37,6 +37,11 @@ export default class MerchIcon extends LitElement {
             --img-height: 24px;
         }
 
+        :host([size='m']) {
+            --img-width: 30px;
+            --img-height: 30px;
+        }
+
         :host([size='l']) {
             --img-width: 40px;
             --img-height: 40px;

--- a/libs/features/mas/web-components/src/variants/ccd-slice.css.js
+++ b/libs/features/mas/web-components/src/variants/ccd-slice.css.js
@@ -13,7 +13,7 @@ merch-card[variant="ccd-slice"] [slot='body-s'] a:not(.con-button) {
     font-weight: 400;
     line-height: var(--consonant-merch-card-body-xxs-line-height);
     text-decoration-line: underline;
-    color: var(--spectrum-blue-800, #147AF3);
+    color: var(--spectrum-gray-800, var(--merch-color-grey-80;
   }
 
   merch-card[variant="ccd-slice"] [slot='image'] img {

--- a/libs/features/mas/web-components/src/variants/ccd-suggested.css.js
+++ b/libs/features/mas/web-components/src/variants/ccd-suggested.css.js
@@ -17,6 +17,8 @@ merch-card[variant="ccd-suggested"] [slot="heading-xs"] {
 }
 
 merch-card[variant="ccd-suggested"] [slot="cta"] a {
+  font-size: var(--consonant-merch-card-body-xs-font-size);
+  line-height: normal;
   text-decoration: none;
   color: var(--spectrum-gray-800);
   font-weight: 700;

--- a/libs/features/mas/web-components/src/variants/ccd-suggested.js
+++ b/libs/features/mas/web-components/src/variants/ccd-suggested.js
@@ -59,19 +59,26 @@ export class CCDSuggested extends VariantLayout {
       display: flex;
       flex-flow: wrap;
       place-self: flex-start;
+      flex-wrap: nowrap;
     }
 
     :host([variant='ccd-suggested']) .headings {
       padding-inline-start: var(--consonant-merch-spacing-xxs);
+      display: flex;
+      flex-direction: column;
     }
 
     :host([variant='ccd-suggested']) ::slotted([slot='icons']) {
-      place-self: flex-start;
+      place-self: center;
     }
 
     :host([variant='ccd-suggested']) ::slotted([slot='heading-xs']) {
       font-size: var(--merch-card-heading-xxs-font-size);
       line-height: var(--merch-card-heading-xxs-line-height);
+    }
+    
+    :host([variant='ccd-suggested']) ::slotted([slot='detail-m']) {
+      line-height: var(--consonant-merch-card-detail-m-line-height);
     }
     
     :host([variant='ccd-suggested'][strip-size='wide']) ::slotted([slot='body-xs']) {
@@ -86,6 +93,8 @@ export class CCDSuggested extends VariantLayout {
       display: flex;
       align-items: center;
       color: var(--spectrum-gray-800, #F8F8F8);
+      font-size: var(--consonant-merch-card-body-xs-font-size);
+      line-height: var(--consonant-merch-card-body-xs-line-height);
     }
 
     :host([variant='ccd-suggested']) ::slotted([slot='cta']) {


### PR DESCRIPTION
This PR introduces multiple fixes to CCD Slice and Suggested cards to achieve pixel-perfect alignment with Figma specs. Specifically, the following changes are made:

**CCD Slice:**
- Change of link colors to gray.
- Added "Medium" merch-icon that matches Figma specs (30px of width, height).

**CCD Suggested**
- Font size, line height in price slot.
- Font size, line height in CTA "Buy now" links.
- Alignment of headings

Before:
![Screenshot 2024-10-16 at 1 24 19 PM](https://github.com/user-attachments/assets/acfab05b-fdf9-43a6-aaf7-7f9fd15a4e53)

After:
![Screenshot 2024-10-16 at 1 12 37 PM](https://github.com/user-attachments/assets/599b3a95-a7af-4f42-9fe9-55e49d6b4197)

Before:
![Screenshot 2024-10-16 at 1 24 34 PM](https://github.com/user-attachments/assets/fca79de8-7b28-4a04-ae82-ff0dfa814691)

After:
![Screenshot 2024-10-16 at 1 12 44 PM](https://github.com/user-attachments/assets/7e314830-41a4-40e3-a2a3-79f8b42c21fe)

Resolves: [MWPW-160518](https://jira.corp.adobe.com/browse/MWPW-160518)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/libs/features/mas/docs/ccd.html?martech=off
- After: https://mwpw-160518--milo--adobecom.hlx.page/libs/features/mas/docs/ccd.html?martech=off
