### PR TITLE
Added performance tab to the Preflight tool (#2773)

### DIFF
--- a/libs/blocks/preflight/panels/performance.js
+++ b/libs/blocks/preflight/panels/performance.js
@@ -1,0 +1,272 @@
+import { html, signal, useEffect } from '../../../deps/htm-preact.js';
+import { getMetadata } from '../../../utils/utils.js';
+
+const icons = {
+  pass: 'green',
+  fail: 'red',
+  empty: 'empty',
+};
+// TODO MEP/Personalization
+// TODO mobile / tablet?
+// TODO create ticket for PSI API
+// TODO link to documentation directly within the sections
+const text = {
+  lcpEl: {
+    key: 'lcpEl',
+    title: 'Valid LCP',
+    passed: { description: 'Valid LCP in the first section detected.' },
+    failed: { description: 'No LCP image or video in the first section detected.' },
+  },
+  singleBlock: {
+    key: 'singleBlock',
+    title: 'Single Block',
+    passed: { description: 'First section has exactly one block.' },
+    failed: { description: 'First section has more than one block.' },
+  },
+  imageSize: {
+    key: 'imageSize',
+    title: 'Images size',
+    empty: { description: 'No image as LCP element.' },
+    passed: { description: 'LCP image is less than 100KB.' },
+    failed: { description: 'LCP image is over 100KB.' },
+  },
+  videoPoster: {
+    key: 'videoPoster',
+    title: 'Videos',
+    empty: { description: 'No video as LCP element.' },
+    passed: { description: 'LCP video has a poster attribute' },
+    failed: { description: 'LCP video has no poster attribute.' },
+  },
+  fragments: {
+    key: 'fragments',
+    title: 'Fragments',
+    passed: { description: 'No fragments used within the LCP section.' },
+    failed: { description: 'Fragments used within the LCP section.' },
+  },
+  personalization: {
+    key: 'personalization',
+    title: 'Personalization',
+    passed: { description: 'Personalization is currently not enabled.' },
+    failed: { description: 'MEP or Target enabled.' },
+  },
+  placeholders: {
+    key: 'placeholders',
+    title: 'Placeholders',
+    passed: { description: 'No placeholders found within the LCP section.' },
+    failed: { description: 'Placeholders found within the LCP section.' },
+  },
+  icons: {
+    key: 'icons',
+    title: 'Icons',
+    passed: { description: 'No icons found within the LCP section.' },
+    failed: { description: 'Icons found within the LCP section.' },
+  },
+};
+
+export const config = {
+  items: signal([
+    ...Object.values(text).map(({ key, title }) => ({
+      key,
+      title,
+      icon: icons.empty,
+      description: 'Loading...',
+    })),
+  ]),
+  lcp: null,
+  cls: 0,
+};
+
+export const findItem = (key) => config.items.value.find((item) => item.key === key);
+export const updateItem = ({ key, ...updates }) => {
+  const { items } = config;
+  items.value = items.value.map((item) => (item.key === key ? { ...item, ...updates } : item));
+};
+
+export function conditionalItemUpdate({ emptyWhen, failsWhen, key }) {
+  if (emptyWhen) {
+    updateItem({
+      key,
+      icon: icons.empty,
+      description: text[key].empty.description,
+    });
+    return;
+  }
+  if (failsWhen) {
+    updateItem({
+      key,
+      icon: icons.fail,
+      description: text[key].failed.description,
+    });
+    return;
+  }
+  updateItem({
+    key,
+    icon: icons.pass,
+    description: text[key].passed.description,
+  });
+}
+
+// TODO do we also want to check the content-length header?
+// https://www.w3.org/TR/largest-contentful-paint/#largest-contentful-paint-candidate-element
+// candidate’s element is a text node, or candidate’s request's response's content length
+// in bytes is >= candidate’s element's effective visual size * 0.004
+export async function checkImageSize() {
+  const { lcp } = config;
+  const hasValidImage = lcp?.url && !lcp.url.match('media_.*.mp4');
+  let blob;
+  let isSizeValid;
+  if (hasValidImage) {
+    blob = await fetch(lcp.url).then((res) => res.blob());
+    isSizeValid = blob.size / 1000 <= 100;
+  }
+
+  conditionalItemUpdate({
+    failsWhen: !isSizeValid,
+    emptyWhen: !hasValidImage,
+    key: text.imageSize.key,
+  });
+}
+
+export function checkLCP() {
+  const { lcp } = config;
+  const mainSection = document.querySelector('main > div.section');
+  const validLcp = lcp && lcp.element && lcp.url && mainSection?.contains(lcp.element);
+  conditionalItemUpdate({
+    failsWhen: !validLcp,
+    key: text.lcpEl.key,
+    icon: icons.pass,
+    description: text.lcpEl.passed.description,
+  });
+  return validLcp;
+}
+
+export const checkFragments = () => conditionalItemUpdate({
+  failsWhen: config.lcp.element.closest('.fragment') || config.lcp.element.closest('.section')?.querySelector('[data-path*="fragment"]'),
+  key: text.fragments.key,
+});
+
+export const checkPlaceholders = async () => conditionalItemUpdate({
+  failsWhen: config.lcp.element.closest('.section').dataset.placeholdersDecorated === 'true',
+  key: text.placeholders.key,
+});
+
+export const checkForPersonalization = async () => conditionalItemUpdate({
+  failsWhen: getMetadata('personalization') || getMetadata('target') === 'on',
+  key: text.personalization.key,
+});
+
+export const checkVideosWithoutPosterAttribute = async () => conditionalItemUpdate({
+  failsWhen: !config.lcp.element.poster,
+  emptyWhen: !config.lcp.url.match('media_.*.mp4'),
+  key: text.videoPoster.key,
+});
+
+export const checkIcons = () => conditionalItemUpdate({
+  failsWhen: config.lcp.element.closest('.section').querySelector('.icon-milo'),
+  key: text.icons.key,
+});
+
+export function PerformanceItem({ icon, title, description }) {
+  return html` <div class="seo-item">
+    <div class="result-icon ${icon}"></div>
+    <div class="seo-item-text">
+      <p class="seo-item-title">${title}</p>
+      <p class="seo-item-description">${description}</p>
+    </div>
+  </div>`;
+}
+
+export const checkForSingleBlock = () => conditionalItemUpdate({
+  failsWhen: document.querySelector('main > div.section').childElementCount > 1,
+  key: text.singleBlock.key,
+});
+
+export const createPerformanceItem = ({
+  icon,
+  title,
+  description,
+} = {}) => html`<${PerformanceItem}
+  icon=${icon}
+  title=${title}
+  description=${description}
+/>`;
+
+let clonedLcpSection;
+function highlightElement(event) {
+  const lcpSection = config.lcp.element.closest('.section');
+  const tooltip = document.querySelector('.lcp-tooltip-modal');
+  const { offsetHeight, offsetWidth } = lcpSection;
+  const scaleFactor = Math.min(500 / offsetWidth, 500 / offsetHeight);
+  if (!clonedLcpSection) {
+    clonedLcpSection = lcpSection.cloneNode(true);
+    clonedLcpSection.classList.add('lcp-clone');
+    clonedLcpSection.style.width = `${lcpSection.offsetWidth}px`;
+    clonedLcpSection.style.height = `${lcpSection.offsetHeight}px`;
+    clonedLcpSection.style.transform = `scale(${scaleFactor})`;
+    clonedLcpSection.style.transformOrigin = 'top left';
+  }
+  if (!tooltip.children.length) tooltip.appendChild(clonedLcpSection);
+  const { top, left } = event.currentTarget.getBoundingClientRect();
+  tooltip.style.width = `${offsetWidth * scaleFactor}px`;
+  tooltip.style.height = `${offsetHeight * scaleFactor}px`;
+  tooltip.style.top = `${top + window.scrollY - offsetHeight * scaleFactor - 10}px`;
+  tooltip.style.left = `${left + window.scrollX}px`;
+  document.querySelector('.lcp-tooltip-modal').classList.add('show');
+}
+
+const removeHighlight = () => { document.querySelector('.lcp-tooltip-modal').classList.remove('show'); };
+
+function observePerfMetrics() {
+  // Observe LCP
+  const lcpObserver = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    const lastEntry = entries[entries.length - 1];
+    if (lastEntry && !lastEntry.url.includes('preflight')) {
+      config.lcp = lastEntry;
+    }
+    const hasValidLcp = checkLCP();
+    if (!hasValidLcp) return;
+    checkFragments();
+    checkForPersonalization();
+    checkVideosWithoutPosterAttribute();
+    checkIcons();
+    checkForSingleBlock();
+    Promise.all([checkImageSize(), checkPlaceholders()]);
+  });
+  lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true });
+
+  // Observe CLS
+  const clsObserver = new PerformanceObserver((entryList) => {
+    const entries = entryList.getEntries();
+    entries.forEach((entry) => {
+      if (!entry.hadRecentInput) {
+        config.cls += entry.value;
+      }
+    });
+    if (config.cls > 0) {
+      // TODO - Lana log? We should not have any CLS.
+      // console.log('CLS:', cls);
+    }
+  });
+  clsObserver.observe({ type: 'layout-shift', buffered: true });
+}
+
+export function Panel() {
+  useEffect(() => observePerfMetrics(), []);
+
+  return html`
+    <div class="seo-columns">
+      <div class="seo-column">${config.items.value.slice(0, 4).map((item) => createPerformanceItem(item))}</div>
+      <div class="seo-column">${config.items.value.slice(4, 8).map((item) => createPerformanceItem(item))}</div>
+      <div>Unsure on how to get this page fully into the green? Check out the <a class="performance-guidelines" href="https://milo.adobe.com/docs/authoring/performance/" target="_blank">Milo Performance Guidelines</a>.</div>
+      <div> 
+        <span class="performance-element-preview" onMouseEnter=${highlightElement} onMouseLeave=${removeHighlight}>
+          Highlight the found LCP section
+        </span> 
+      </div>
+      <div class="lcp-tooltip-modal"></div>
+    </div>
+  `;
+}
+
+export default Panel;

--- a/libs/blocks/preflight/panels/performance.js
+++ b/libs/blocks/preflight/panels/performance.js
@@ -187,30 +187,32 @@ function highlightElement(event) {
   if (!clonedLcpSection) {
     clonedLcpSection = lcpSection.cloneNode(true);
     clonedLcpSection.classList.add('lcp-clone');
-    clonedLcpSection.style.width = `${lcpSection.offsetWidth}px`;
-    clonedLcpSection.style.height = `${lcpSection.offsetHeight}px`;
-    clonedLcpSection.style.transform = `scale(${scaleFactor})`;
-    clonedLcpSection.style.transformOrigin = 'top left';
   }
+  Object.assign(clonedLcpSection.style, {
+    width: `${lcpSection.offsetWidth}px`,
+    height: `${lcpSection.offsetHeight}px`,
+    transform: `scale(${scaleFactor})`,
+    transformOrigin: 'top left',
+  });
   if (!tooltip.children.length) tooltip.appendChild(clonedLcpSection);
   const { top, left } = event.currentTarget.getBoundingClientRect();
-  tooltip.style.width = `${offsetWidth * scaleFactor}px`;
-  tooltip.style.height = `${offsetHeight * scaleFactor}px`;
-  tooltip.style.top = `${top + window.scrollY - offsetHeight * scaleFactor - 10}px`;
-  tooltip.style.left = `${left + window.scrollX}px`;
+  Object.assign(tooltip.style, {
+    width: `${offsetWidth * scaleFactor}px`,
+    height: `${offsetHeight * scaleFactor}px`,
+    top: `${top + window.scrollY - offsetHeight * scaleFactor - 10}px`,
+    left: `${left + window.scrollX}px`,
+  });
   document.querySelector('.lcp-tooltip-modal').classList.add('show');
 }
 
 const removeHighlight = () => { document.querySelector('.lcp-tooltip-modal').classList.remove('show'); };
 
 function observePerfMetrics() {
-  // Observe LCP
-  const lcpObserver = new PerformanceObserver((entryList) => {
+  new PerformanceObserver((entryList) => {
     const entries = entryList.getEntries();
     const lastEntry = entries[entries.length - 1];
     if (lastEntry) config.lcp = lastEntry;
-    const hasValidLcp = checkLCP();
-    if (!hasValidLcp) {
+    if (!checkLCP()) {
       Object.values(text).forEach(({ key }) => {
         if (key === 'lcpEl') return;
         updateItem({ key, description: 'No LCP element found.' });
@@ -224,11 +226,9 @@ function observePerfMetrics() {
     checkForSingleBlock();
     checkPlaceholders();
     Promise.all([checkImageSize()]);
-  });
-  lcpObserver.observe({ type: 'largest-contentful-paint', buffered: true });
+  }).observe({ type: 'largest-contentful-paint', buffered: true });
 
-  // Observe CLS
-  const clsObserver = new PerformanceObserver((entryList) => {
+  new PerformanceObserver((entryList) => {
     const entries = entryList.getEntries();
     entries.forEach((entry) => {
       if (!entry.hadRecentInput) {
@@ -238,8 +238,7 @@ function observePerfMetrics() {
     if (config.cls > 0) {
       // TODO - Lana log? We should not have any CLS.
     }
-  });
-  clsObserver.observe({ type: 'layout-shift', buffered: true });
+  }).observe({ type: 'layout-shift', buffered: true });
 }
 
 export function Panel() {

--- a/libs/blocks/preflight/panels/performance.js
+++ b/libs/blocks/preflight/panels/performance.js
@@ -98,12 +98,16 @@ export function conditionalItemUpdate({ emptyWhen, failsWhen, key }) {
 // in bytes is >= candidate’s element's effective visual size * 0.004
 export async function checkImageSize() {
   const { lcp } = config;
-  const hasValidImage = lcp?.url && !lcp.url.match('media_.*.mp4');
+  let hasValidImage = lcp?.url && !lcp.url.match('media_.*.mp4');
   let blob;
   let isSizeValid;
   if (hasValidImage) {
-    blob = await fetch(lcp.url).then((res) => res.blob());
-    isSizeValid = blob.size / 1024 <= 100;
+    try {
+      blob = await fetch(lcp.url).then((res) => res.blob());
+      isSizeValid = blob.size / 1024 <= 100;
+    } catch (error) {
+      hasValidImage = false;
+    }
   }
 
   conditionalItemUpdate({
@@ -120,7 +124,6 @@ export function checkLCP() {
   conditionalItemUpdate({
     failsWhen: !validLcp,
     key: text.lcpEl.key,
-    icon: icons.pass,
     description: text.lcpEl.passed.description,
   });
   return validLcp;

--- a/libs/blocks/preflight/panels/performance.js
+++ b/libs/blocks/preflight/panels/performance.js
@@ -193,7 +193,8 @@ export const createPerformanceItem = ({
 
 let clonedLcpSection;
 function highlightElement(event) {
-  const lcpSection = config.lcp.element.closest('.section');
+  if (!config.lcp) return;
+  const lcpSection = config.lcp?.element.closest('.section');
   const tooltip = document.querySelector('.lcp-tooltip-modal');
   const { offsetHeight, offsetWidth } = lcpSection;
   const scaleFactor = Math.min(500 / offsetWidth, 500 / offsetHeight);
@@ -221,11 +222,15 @@ function observePerfMetrics() {
   const lcpObserver = new PerformanceObserver((entryList) => {
     const entries = entryList.getEntries();
     const lastEntry = entries[entries.length - 1];
-    if (lastEntry && !lastEntry.url.includes('preflight')) {
-      config.lcp = lastEntry;
-    }
+    if (lastEntry) config.lcp = lastEntry;
     const hasValidLcp = checkLCP();
-    if (!hasValidLcp) return;
+    if (!hasValidLcp) {
+      Object.values(text).forEach(({ key }) => {
+        if (key === 'lcpEl') return;
+        updateItem({ key, description: 'No LCP element found.' });
+      });
+      return;
+    }
     checkFragments();
     checkForPersonalization();
     checkVideosWithoutPosterAttribute();

--- a/libs/blocks/preflight/panels/seo.js
+++ b/libs/blocks/preflight/panels/seo.js
@@ -292,11 +292,11 @@ export async function sendResults() {
 
 function SeoItem({ icon, title, description }) {
   return html`
-    <div class=seo-item>
+    <div class=preflight-item>
       <div class="result-icon ${icon}"></div>
-      <div class=seo-item-text>
-        <p class=seo-item-title>${title}</p>
-        <p class=seo-item-description>${description}</p>
+      <div class=preflight-item-text>
+        <p class=preflight-item-title>${title}</p>
+        <p class=preflight-item-description>${description}</p>
       </div>
     </div>`;
 }
@@ -327,14 +327,14 @@ async function getResults() {
 export default function Panel() {
   useEffect(() => { getResults(); }, []);
   return html`
-    <div class=seo-columns>
-      <div class=seo-column>
+    <div class=preflight-columns>
+      <div class=preflight-column>
         <${SeoItem} icon=${titleResult.value.icon} title=${titleResult.value.title} description=${titleResult.value.description} />
         <${SeoItem} icon=${h1Result.value.icon} title=${h1Result.value.title} description=${h1Result.value.description} />
         <${SeoItem} icon=${canonResult.value.icon} title=${canonResult.value.title} description=${canonResult.value.description} />
         <${SeoItem} icon=${linksResult.value.icon} title=${linksResult.value.title} description=${linksResult.value.description} />
       </div>
-      <div class=seo-column>
+      <div class=preflight-column>
         <${SeoItem} icon=${bodyResult.value.icon} title=${bodyResult.value.title} description=${bodyResult.value.description} />
         <${SeoItem} icon=${loremResult.value.icon} title=${loremResult.value.title} description=${loremResult.value.description} />
         <${SeoItem} icon=${descResult.value.icon} title=${descResult.value.title} description=${descResult.value.description} />

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -341,6 +341,11 @@ span.preflight-time {
   animation: spin 2s linear infinite;
 }
 
+.result-icon.empty {
+  background: url('./img/empty.svg');
+  background-size: 60px;
+}
+
 @keyframes spin { 
   100% { 
     -webkit-transform: rotate(360deg); 
@@ -625,4 +630,38 @@ img[data-alt-check]::after {
 
 .dialog-modal#preflight table td h3 {
   font-size: 16px;
+}
+
+.performance-guidelines {
+  color: #fff;
+  text-decoration: underline;
+}
+
+.performance-element-preview {
+  position: relative;
+  display: inline-block;
+  color: #fff;
+  text-decoration: underline;
+}
+
+.performance-element-preview:hover {
+  text-decoration: none;
+}
+
+/* styles.css */
+.lcp-tooltip-modal {
+  width: 0;
+  height: 0;
+  position: fixed;
+  border: 2px solid red;
+  background-color: white;
+  z-index: 103;
+  overflow: hidden;
+  pointer-events: none;
+  display: block;
+  visibility: hidden;
+}
+
+.lcp-tooltip-modal.show {
+  visibility: visible;
 }

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -312,21 +312,21 @@ span.preflight-time {
 }
 
 /* SEO */
-.seo-columns {
+.preflight-columns {
   margin: 24px 48px 0;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 48px;
 }
 
-.seo-item {
+.preflight-item {
   margin-bottom: 48px;
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 12px;
 }
 
-.seo-item:last-child {
+.preflight-item:last-child {
   margin-bottom: 0;
 }
 
@@ -372,14 +372,14 @@ span.preflight-time {
   background-size: 60px;
 }
 
-.seo-item-title {
+.preflight-item-title {
   margin: 0;
   font-weight: 700;
   font-size: 32px;
   line-height: 1;
 }
 
-.seo-item-description {
+.preflight-item-description {
   margin: 0;
 }
 

--- a/libs/blocks/preflight/preflight.js
+++ b/libs/blocks/preflight/preflight.js
@@ -4,6 +4,7 @@ import General from './panels/general.js';
 import SEO from './panels/seo.js';
 import Accessibility from './panels/accessibility.js';
 import Martech from './panels/martech.js';
+import Performance from './panels/performance.js';
 
 const HEADING = 'Milo Preflight';
 const IMG_PATH = '/blocks/preflight/img';
@@ -13,6 +14,7 @@ const tabs = signal([
   { title: 'SEO' },
   { title: 'Martech' },
   { title: 'Accessibility' },
+  { title: 'Performance' },
 ]);
 
 function setTab(active) {
@@ -32,6 +34,8 @@ function setPanel(title) {
       return html`<${Martech} />`;
     case 'Accessibility':
       return html`<${Accessibility} />`;
+    case 'Performance':
+      return html`<${Performance} />`;
     default:
       return html`<p>No matching panel.</p>`;
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -809,6 +809,7 @@ async function decoratePlaceholders(area, config) {
   if (!area) return;
   const nodes = findReplaceableNodes(area);
   if (!nodes.length) return;
+  area.dataset.placeholdersDecorated = 'true';
   const placeholderPath = `${config.locale?.contentRoot}/placeholders.json`;
   placeholderRequest = placeholderRequest
   || customFetch({ resource: placeholderPath, withCacheRules: true })

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -809,7 +809,7 @@ async function decoratePlaceholders(area, config) {
   if (!area) return;
   const nodes = findReplaceableNodes(area);
   if (!nodes.length) return;
-  area.dataset.placeholdersDecorated = 'true';
+  area.dataset.hasPlaceholders = 'true';
   const placeholderPath = `${config.locale?.contentRoot}/placeholders.json`;
   placeholderRequest = placeholderRequest
   || customFetch({ resource: placeholderPath, withCacheRules: true })

--- a/test/blocks/preflight/panels/performance/mocks/marquee.html
+++ b/test/blocks/preflight/panels/performance/mocks/marquee.html
@@ -1,0 +1,30 @@
+<main>
+  <div>
+      <div class="marquee dark">
+          <div>
+              <div>
+                  <br>
+                  <picture>
+                      <source type="image/webp" srcset="./media_1e3592d2ec5d63ce4a4d8a920d87da94b5b2cee5c.png?width=2000&#x26;format=webply&#x26;optimize=medium" media="(min-width: 600px)">
+                      <source type="image/webp" srcset="./media_1e3592d2ec5d63ce4a4d8a920d87da94b5b2cee5c.png?width=750&#x26;format=webply&#x26;optimize=medium">
+                      <source type="image/png" srcset="./media_1e3592d2ec5d63ce4a4d8a920d87da94b5b2cee5c.png?width=2000&#x26;format=png&#x26;optimize=medium" media="(min-width: 600px)">
+                      <img loading="lazy" alt="" src="./media_1e3592d2ec5d63ce4a4d8a920d87da94b5b2cee5c.png?width=750&#x26;format=png&#x26;optimize=medium" width="1024" height="1024">
+                  </picture>
+              </div>
+          </div>
+          <div>
+              <div>
+                  <h1 id="using-data-to-transform-attitudes-and-evolve-experiences">Using data to transform attitudes and evolve experiences.</h1>
+                  <p>How BMW Group transformed the online automotive experience for customers, dealers, and employees</p>
+                  <p>
+                      <strong>
+                          <em>
+                              <a href="/fragments/customer-success-stories/modals/bmw#watch-now">Watch Now</a>
+                          </em>
+                      </strong>
+                  </p>
+              </div>
+          </div>
+      </div>
+  </div>
+</main> 

--- a/test/blocks/preflight/panels/performance/performance.test.js
+++ b/test/blocks/preflight/panels/performance/performance.test.js
@@ -173,7 +173,7 @@ describe('Preflight performance', () => {
     });
 
     it('fails if there are placeholders', async () => {
-      document.body.innerHTML = '<main><div class="section" data-placeholders-decorated="true"></div></main>';
+      document.body.innerHTML = '<main><div class="section" data-has-placeholders="true"></div></main>';
       config.lcp = { element: document.querySelector('.section') };
       checkPlaceholders();
       expect(findItem('placeholders').icon).to.equal(icons.fail);
@@ -250,11 +250,11 @@ describe('Preflight performance', () => {
     it('renders an item', () => {
       const item = html`<${PerformanceItem} icon="foo-icon" title="foo-title" description="foo-desc" />`;
       render(item, document.body);
-      const itemElement = document.querySelector('.seo-item');
+      const itemElement = document.querySelector('.preflight-item');
       expect(itemElement).to.exist;
       expect(itemElement.querySelector('.result-icon').classList.contains('foo-icon')).to.be.true;
-      expect(itemElement.querySelector('.seo-item-title').textContent).to.equal('foo-title');
-      expect(itemElement.querySelector('.seo-item-description').textContent).to.equal('foo-desc');
+      expect(itemElement.querySelector('.preflight-item-title').textContent).to.equal('foo-title');
+      expect(itemElement.querySelector('.preflight-item-description').textContent).to.equal('foo-desc');
     });
   });
 
@@ -262,11 +262,11 @@ describe('Preflight performance', () => {
     it('creates an item', () => {
       const item = createPerformanceItem({ icon: 'foo-icon', title: 'foo-title', description: 'foo-desc' });
       render(item, document.body);
-      const itemElement = document.querySelector('.seo-item');
+      const itemElement = document.querySelector('.preflight-item');
       expect(itemElement).to.exist;
       expect(itemElement.querySelector('.result-icon').classList.contains('foo-icon')).to.be.true;
-      expect(itemElement.querySelector('.seo-item-title').textContent).to.equal('foo-title');
-      expect(itemElement.querySelector('.seo-item-description').textContent).to.equal('foo-desc');
+      expect(itemElement.querySelector('.preflight-item-title').textContent).to.equal('foo-title');
+      expect(itemElement.querySelector('.preflight-item-description').textContent).to.equal('foo-desc');
     });
   });
 
@@ -274,7 +274,7 @@ describe('Preflight performance', () => {
     it('renders a panel with all the items', () => {
       const panel = html`<${Panel} />`;
       render(panel, document.body);
-      const panelItems = document.querySelectorAll('.seo-item');
+      const panelItems = document.querySelectorAll('.preflight-item');
       expect(panelItems.length).to.equal(config.items.value.length);
     });
   });

--- a/test/blocks/preflight/panels/performance/performance.test.js
+++ b/test/blocks/preflight/panels/performance/performance.test.js
@@ -1,0 +1,281 @@
+/* eslint-disable import/no-named-as-default-member */
+import { expect } from 'chai';
+import { html, render } from '../../../../../libs/deps/htm-preact.js';
+import { mockFetch } from '../../../../helpers/generalHelpers.js';
+import {
+  config,
+  updateItem,
+  checkImageSize,
+  findItem,
+  checkLCP,
+  checkFragments,
+  checkPlaceholders,
+  checkForPersonalization,
+  conditionalItemUpdate,
+  checkVideosWithoutPosterAttribute,
+  checkForSingleBlock,
+  PerformanceItem,
+  createPerformanceItem,
+  Panel,
+} from '../../../../../libs/blocks/preflight/panels/performance.js';
+
+const icons = {
+  pass: 'green',
+  fail: 'red',
+  empty: 'empty',
+};
+const defaultItems = [...config.items.value];
+describe('Preflight performance', () => {
+  const { fetch } = window;
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    window.fetch = fetch;
+    config.lcp = null;
+    config.cls = 0;
+    config.items.value = defaultItems;
+  });
+
+  describe('updateItem', () => {
+    it('updates an item', () => {
+      const item = { key: 'lcpEl', description: 'foo-desc', icon: 'foo-icon', title: 'foo-title' };
+      updateItem(item);
+      Object.keys(item).forEach((key) => expect(findItem('lcpEl')[key]).to.equal(item[key]));
+      const updatedItem = { key: 'lcpEl', description: 'foo-desc-update', icon: 'foo-icon-update', title: 'foo-title-update' };
+      updateItem(updatedItem);
+      Object.keys(updatedItem).forEach((key) => expect(findItem('lcpEl')[key]).to.equal(updatedItem[key]));
+    });
+
+    it('updating keeps unrelated items unchanged', () => {
+      const unchangedItem = { key: 'unchangedItem', description: 'foo-desc', icon: 'foo-icon', title: 'foo-title' };
+      const baseItem = { key: 'lcpEl', description: 'foo-desc' };
+      config.items.value = [
+        unchangedItem,
+        baseItem,
+      ];
+      updateItem({ ...baseItem, description: 'foo-desc-update' });
+      Object.keys(unchangedItem).forEach((key) => expect(findItem('unchangedItem')[key]).to.equal(unchangedItem[key]));
+    });
+
+    it('does not update non-existant items', () => {
+      config.items.value = [{ key: 'lcpEl' }];
+      updateItem({ key: 'new-item', description: 'new-desc' });
+      expect(config.items.value.length).to.equal(1);
+      expect(config.items.value[0].key).to.equal('lcpEl');
+    });
+  });
+
+  describe('findItem', () => {
+    it('finds an item', () => {
+      const item = { key: 'lcpEl', description: 'foo-desc', icon: 'foo-icon', title: 'foo-title' };
+      config.items.value = [item];
+      Object.keys(item).forEach((key) => expect(findItem('lcpEl')[key]).to.equal(item[key]));
+    });
+
+    it('returns undefined if the item does not exist', () => {
+      config.items.value = [];
+      expect(findItem('lcpEl')).to.be.undefined;
+    });
+  });
+
+  describe('conditionalItemUpdate', () => {
+    it('updates an item, if the condition isnt met', () => {
+      updateItem({ key: 'lcpEl', icon: icons.empty });
+      conditionalItemUpdate({ failsWhen: false, key: 'lcpEl' });
+      expect(findItem('lcpEl').icon).to.equal(icons.pass);
+    });
+
+    it('does not update an item if the condition is met', () => {
+      updateItem({ key: 'lcpEl', icon: icons.empty });
+      conditionalItemUpdate({ failsWhen: true, key: 'lcpEl' });
+      expect(findItem('lcpEl').icon).to.equal(icons.fail);
+    });
+  });
+
+  describe('Check image sizes', () => {
+    it('shows an empty field if there is no LCP image', async () => {
+      await checkImageSize();
+      expect(findItem('imageSize').icon).to.equal(icons.empty);
+    });
+
+    it('Checks if an image is below 100 kb', async () => {
+      config.lcp = { url: 'https://adobe.com/foo.jpg' };
+      window.fetch = mockFetch({ payload: { size: 200 } });
+      await checkImageSize();
+      expect(findItem('imageSize').icon).to.equal(icons.pass);
+    });
+
+    it('Checks if an image is >100 kb', async () => {
+      config.lcp = { url: 'https://example.com/foo.jpg' };
+      window.fetch = mockFetch({ payload: { size: 200000 } });
+      await checkImageSize();
+      expect(findItem('imageSize').icon).to.equal(icons.fail);
+    });
+  });
+
+  describe('Check if there is an LCP element', () => {
+    it('fails if there is no LCP element', async () => {
+      await checkLCP();
+      expect(findItem('lcpEl').icon).to.equal(icons.fail);
+    });
+
+    it('fails if the LCP element is in the second section', async () => {
+      document.body.innerHTML = '<main><div class="section"></div><div class="section"><img src=""></img></div></main>';
+      config.lcp = {
+        element: document.querySelector('img'),
+        url: 'https://adobe.com/foo.jpg',
+      };
+      await checkLCP();
+      expect(findItem('lcpEl').icon).to.equal(icons.fail);
+    });
+
+    it('succeeds if the LCP element is in the first section', async () => {
+      document.body.innerHTML = '<main><div class="section"><img src=""></img></div></main>';
+      config.lcp = {
+        element: document.querySelector('img'),
+        url: 'https://adobe.com/foo.jpg',
+      };
+      await checkLCP();
+      expect(findItem('lcpEl').icon).to.equal(icons.pass);
+    });
+  });
+
+  describe('Checking for fragments', () => {
+    it('fails if there are fragments', async () => {
+      document.body.innerHTML = '<main><div class="section"><div class="fragment"><img src="#fragment"></img></div></div></main>';
+      config.lcp = { element: document.querySelector('img') };
+      checkFragments();
+      expect(findItem('fragments').icon).to.equal(icons.fail);
+    });
+
+    it('fails if there (inline) are fragments', async () => {
+      document.body.innerHTML = '<main><div class="section"><div data-path="/fragments/marquee"><img src="#fragment"></img></div></div></main>';
+      config.lcp = { element: document.querySelector('img') };
+      checkFragments();
+      expect(findItem('fragments').icon).to.equal(icons.fail);
+    });
+
+    it('succeeds if there are no fragments', async () => {
+      document.body.innerHTML = '<main><div class="section"><div><img src="#fragment"></img></div></div></main>';
+      config.lcp = { element: document.querySelector('img') };
+      checkFragments();
+      expect(findItem('fragments').icon).to.equal(icons.pass);
+    });
+  });
+
+  describe('Checking for placeholders', () => {
+    it('succeeds if there are no placeholders', async () => {
+      document.body.innerHTML = '<main><div class="section"></div></main>';
+      config.lcp = { element: document.querySelector('.section') };
+      checkPlaceholders();
+      expect(findItem('placeholders').icon).to.equal(icons.pass);
+    });
+
+    it('fails if there are placeholders', async () => {
+      document.body.innerHTML = '<main><div class="section" data-placeholders-decorated="true"></div></main>';
+      config.lcp = { element: document.querySelector('.section') };
+      checkPlaceholders();
+      expect(findItem('placeholders').icon).to.equal(icons.fail);
+    });
+  });
+
+  describe('Checking for personalization', () => {
+    it('fails if there is personalization', async () => {
+      document.head.innerHTML = '<meta name="personalization" content="mep-fragment">';
+      checkForPersonalization();
+      expect(findItem('personalization').icon).to.equal(icons.fail);
+    });
+
+    it('fails if there is target', async () => {
+      document.head.innerHTML = '<meta name="target" content="on">';
+      checkForPersonalization();
+      expect(findItem('personalization').icon).to.equal(icons.fail);
+    });
+
+    it('succeeds if there is no personalization', async () => {
+      document.head.innerHTML = '<meta name="target" content="off">';
+      checkForPersonalization();
+      expect(findItem('personalization').icon).to.equal(icons.pass);
+    });
+  });
+
+  describe('Check for video without poster attribute', () => {
+    it('stays empty if there are no videos', async () => {
+      document.body.innerHTML = '<main><div class="marquee"><img></img></div></main>';
+      config.lcp = {
+        element: document.querySelector('img'),
+        url: 'https://adobe.com/media_.png',
+      };
+      checkVideosWithoutPosterAttribute();
+      expect(findItem('videoPoster').icon).to.equal(icons.empty);
+    });
+
+    it('fails if there are videos without poster attribute', async () => {
+      document.body.innerHTML = '<main><div class="marquee"><video></video></div></main>';
+      config.lcp = {
+        element: document.querySelector('video'),
+        url: 'https://adobe.com/media_.mp4',
+      };
+      checkVideosWithoutPosterAttribute();
+      expect(findItem('videoPoster').icon).to.equal(icons.fail);
+    });
+
+    it('succeeds if there are videos with poster attribute', async () => {
+      document.body.innerHTML = '<main><div class="marquee"><video poster="/test/utils/mocks/media_.png"></video></div></main>';
+      config.lcp = {
+        element: document.querySelector('video'),
+        url: 'https://adobe.com/media_.mp4',
+      };
+      checkVideosWithoutPosterAttribute();
+      expect(findItem('videoPoster').icon).to.equal(icons.pass);
+    });
+  });
+
+  describe('Check for multiple elements in the first section', () => {
+    it('fails if there are multiple elements', async () => {
+      document.body.innerHTML = '<main><div class="section"><div></div><div></div></div></main>';
+      checkForSingleBlock();
+      expect(findItem('singleBlock').icon).to.equal(icons.fail);
+    });
+
+    it('succeeds if there is only one element', async () => {
+      document.body.innerHTML = '<main><div class="section"><div></div></div></main>';
+      checkForSingleBlock();
+      expect(findItem('singleBlock').icon).to.equal(icons.pass);
+    });
+  });
+
+  describe('PerformanceItem', () => {
+    it('renders an item', () => {
+      const item = html`<${PerformanceItem} icon="foo-icon" title="foo-title" description="foo-desc" />`;
+      render(item, document.body);
+      const itemElement = document.querySelector('.seo-item');
+      expect(itemElement).to.exist;
+      expect(itemElement.querySelector('.result-icon').classList.contains('foo-icon')).to.be.true;
+      expect(itemElement.querySelector('.seo-item-title').textContent).to.equal('foo-title');
+      expect(itemElement.querySelector('.seo-item-description').textContent).to.equal('foo-desc');
+    });
+  });
+
+  describe('createPerformanceItem', () => {
+    it('creates an item', () => {
+      const item = createPerformanceItem({ icon: 'foo-icon', title: 'foo-title', description: 'foo-desc' });
+      render(item, document.body);
+      const itemElement = document.querySelector('.seo-item');
+      expect(itemElement).to.exist;
+      expect(itemElement.querySelector('.result-icon').classList.contains('foo-icon')).to.be.true;
+      expect(itemElement.querySelector('.seo-item-title').textContent).to.equal('foo-title');
+      expect(itemElement.querySelector('.seo-item-description').textContent).to.equal('foo-desc');
+    });
+  });
+
+  describe('Panel', () => {
+    it('renders a panel with all the items', () => {
+      const panel = html`<${Panel} />`;
+      render(panel, document.body);
+      const panelItems = document.querySelectorAll('.seo-item');
+      expect(panelItems.length).to.equal(config.items.value.length);
+    });
+  });
+});

--- a/test/helpers/generalHelpers.js
+++ b/test/helpers/generalHelpers.js
@@ -6,6 +6,7 @@ export const mockRes = ({ payload, status = 200, ok = true } = {}) => new Promis
     ok,
     json: () => payload,
     text: () => payload,
+    blob: () => payload,
   });
 });
 

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -99,7 +99,7 @@ export default {
         <script type='module' src='${testFramework}'></script>
       </body>
     </html>`,
-  // Comment in the files for selectively running test suites
-  // npm run test:file:watch allows to you to run single test file & view the result in a browser.
+  // npm run test:file:watch
+  // allows to you to run single test file & view the result in a browser.
   // files: ['**/utils.test.js'],
 };


### PR DESCRIPTION
### Description
A few todo's here and there but the features and flow should work and this should be ready for feedback and a first batch of testing.

- Adds a new performance preflight tab
- adds new&polished performance docs: https://main--milo--adobecom.aem.page/docs/authoring/performance/ (Needs a bit more polishing and hands-on-advice)

### Look & Feel 
![Screenshot 2024-10-17 at 01 08 39](https://github.com/user-attachments/assets/e5588946-b48f-45c9-990b-b6f86d08565d)

Resolves: [MWPW-157715](https://jira.corp.adobe.com/browse/MWPW-157715)

### Test instructions
Use the provided sample URLs, try to destroy the thing, close it, open it, open it on incognito, have pages with LCP, without, use production pages from bacom etc. to test this. I've encountered a lot of issues during development and I'm sure theres still many issues out there.


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/preflight-performance/marquee-fragment?martech=off
- After: https://preflight-performance-tab--milo--mokimo.hlx.page/drafts/osahin/preflight-performance/marquee-fragment?martech=off
