### PR TITLE
"Contact Us" CTA takes user to a URL which doesnt open Jarvis chatbot as expected 

### DIFF
--- a/libs/navigation/bootstrapper.js
+++ b/libs/navigation/bootstrapper.js
@@ -1,5 +1,5 @@
 export default async function bootstrapBlock(miloLibs, blockConfig) {
-  const { name, targetEl } = blockConfig;
+  const { name, targetEl, jarvis } = blockConfig;
   const { getConfig, createTag, loadLink, loadScript } = await import(`${miloLibs}/utils/utils.js`);
   const { default: initBlock } = await import(`${miloLibs}/blocks/${name}/${name}.js`);
 
@@ -37,39 +37,41 @@ export default async function bootstrapBlock(miloLibs, blockConfig) {
   }
 
   /** Jarvis Chat */
-  const isChatInitialized = (client) => !!client?.isAdobeMessagingClientInitialized();
+  if (jarvis?.id) {
+    const isChatInitialized = (client) => !!client?.isAdobeMessagingClientInitialized();
 
-  const redirectToSupport = () => window.location.assign('https://helpx.adobe.com');
+    const redirectToSupport = () => window.location.assign('https://helpx.adobe.com');
 
-  const isChatOpen = (client) => isChatInitialized(client) && client?.getMessagingExperienceState()?.windowState !== 'hidden';
+    const isChatOpen = (client) => isChatInitialized(client) && client?.getMessagingExperienceState()?.windowState !== 'hidden';
 
-  const openChat = (event) => {
-    const client = window.AdobeMessagingExperienceClient;
+    const openChat = (event) => {
+      const client = window.AdobeMessagingExperienceClient;
 
-    if (!isChatInitialized(client)) {
-      redirectToSupport();
-      return;
-    }
+      if (!isChatInitialized(client)) {
+        redirectToSupport();
+        return;
+      }
 
-    const open = client?.openMessagingWindow;
-    if (typeof open !== 'function' || isChatOpen(client)) {
-      return;
-    }
+      const open = client?.openMessagingWindow;
+      if (typeof open !== 'function' || isChatOpen(client)) {
+        return;
+      }
 
-    const sourceType = event?.target.tagName?.toLowerCase();
-    const sourceText = sourceType === 'img' ? event.target.alt?.trim() : event.target.innerText?.trim();
+      const sourceType = event?.target.tagName?.toLowerCase();
+      const sourceText = sourceType === 'img' ? event.target.alt?.trim() : event.target.innerText?.trim();
 
-    open(event ? { sourceType, sourceText } : {});
-  };
+      open(event ? { sourceType, sourceText } : {});
+    };
 
-  const addDomEvents = () => {
-    document.addEventListener('click', (event) => {
-      if (!event.target.closest('[href*="#open-jarvis-chat"]')) return;
-      event.preventDefault();
-      openChat(event);
-    });
-  };
+    const addDomEvents = () => {
+      document.addEventListener('click', (event) => {
+        if (!event.target.closest('[href*="#open-jarvis-chat"]')) return;
+        event.preventDefault();
+        openChat(event);
+      });
+    };
 
-  // Attach DOM events
-  addDomEvents();
+    // Attach DOM events
+    addDomEvents();
+  }
 }

--- a/libs/navigation/bootstrapper.js
+++ b/libs/navigation/bootstrapper.js
@@ -41,18 +41,20 @@ export default async function bootstrapBlock(miloLibs, blockConfig) {
 
   const redirectToSupport = () => window.location.assign('https://helpx.adobe.com');
 
-  const isChatOpen = (client) =>
-    client?.isAdobeMessagingClientInitialized() && client?.getMessagingExperienceState()?.windowState !== 'hidden';
+  const isChatOpen = (client) => client?.isAdobeMessagingClientInitialized() && client?.getMessagingExperienceState()?.windowState !== 'hidden';
 
   const openChat = (event) => {
     const client = window.AdobeMessagingExperienceClient;
 
     if (!isChatInitialized(client)) {
-      return redirectToSupport();
+      redirectToSupport();
+      return;
     }
 
     const open = client?.openMessagingWindow;
-    if (typeof open !== 'function' || isChatOpen(client)) return;
+    if (typeof open !== 'function' || isChatOpen(client)) {
+      return;
+    }
 
     const sourceType = event?.target.tagName?.toLowerCase();
     const sourceText = sourceType === 'img' ? event.target.alt?.trim() : event.target.innerText?.trim();
@@ -61,6 +63,7 @@ export default async function bootstrapBlock(miloLibs, blockConfig) {
   };
 
   const addDomEvents = () => {
+    console.log(document);
     document.addEventListener('click', (event) => {
       if (!event.target.closest('[href*="#open-jarvis-chat"]')) return;
       event.preventDefault();

--- a/libs/navigation/bootstrapper.js
+++ b/libs/navigation/bootstrapper.js
@@ -63,7 +63,6 @@ export default async function bootstrapBlock(miloLibs, blockConfig) {
   };
 
   const addDomEvents = () => {
-    console.log(document);
     document.addEventListener('click', (event) => {
       if (!event.target.closest('[href*="#open-jarvis-chat"]')) return;
       event.preventDefault();

--- a/libs/navigation/bootstrapper.js
+++ b/libs/navigation/bootstrapper.js
@@ -35,4 +35,39 @@ export default async function bootstrapBlock(miloLibs, blockConfig) {
       loadPrivacy(getConfig, loadScript);
     }, blockConfig.delay);
   }
+
+  /** Jarvis Chat */
+  const isChatInitialized = (client) => !!client?.isAdobeMessagingClientInitialized();
+
+  const redirectToSupport = () => window.location.assign('https://helpx.adobe.com');
+
+  const isChatOpen = (client) =>
+    client?.isAdobeMessagingClientInitialized() && client?.getMessagingExperienceState()?.windowState !== 'hidden';
+
+  const openChat = (event) => {
+    const client = window.AdobeMessagingExperienceClient;
+
+    if (!isChatInitialized(client)) {
+      return redirectToSupport();
+    }
+
+    const open = client?.openMessagingWindow;
+    if (typeof open !== 'function' || isChatOpen(client)) return;
+
+    const sourceType = event?.target.tagName?.toLowerCase();
+    const sourceText = sourceType === 'img' ? event.target.alt?.trim() : event.target.innerText?.trim();
+
+    open(event ? { sourceType, sourceText } : {});
+  };
+
+  const addDomEvents = () => {
+    document.addEventListener('click', (event) => {
+      if (!event.target.closest('[href*="#open-jarvis-chat"]')) return;
+      event.preventDefault();
+      openChat(event);
+    });
+  };
+
+  // Attach DOM events
+  addDomEvents();
 }

--- a/libs/navigation/bootstrapper.js
+++ b/libs/navigation/bootstrapper.js
@@ -41,7 +41,7 @@ export default async function bootstrapBlock(miloLibs, blockConfig) {
 
   const redirectToSupport = () => window.location.assign('https://helpx.adobe.com');
 
-  const isChatOpen = (client) => client?.isAdobeMessagingClientInitialized() && client?.getMessagingExperienceState()?.windowState !== 'hidden';
+  const isChatOpen = (client) => isChatInitialized(client) && client?.getMessagingExperienceState()?.windowState !== 'hidden';
 
   const openChat = (event) => {
     const client = window.AdobeMessagingExperienceClient;

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -74,7 +74,11 @@ export default async function loadBlock(configs, customLib) {
       if (configBlock) {
         await bootstrapBlock(`${miloLibs}/libs`, {
           ...block,
-          ...(block.key === 'header' && { unavComponents: configBlock.unav?.unavComponents, redirect: configBlock.redirect }),
+          ...(block.key === 'header' && {
+            unavComponents: configBlock.unav?.unavComponents,
+            redirect: configBlock.redirect,
+            jarvis: configBlock.jarvis,
+          }),
         });
         configBlock.onReady?.();
       }

--- a/test/navigation/bootstrapper.test.js
+++ b/test/navigation/bootstrapper.test.js
@@ -26,10 +26,7 @@ const blockConfig = {
 const miloLibs = 'http://localhost:2000/libs';
 
 describe('Bootstrapper', async () => {
-  let initializeSpy;
   let openMessagingWindowSpy;
-  let isAdobeMessagingClientInitializedStub;
-  let getMessagingExperienceStateStub;
   beforeEach(async () => {
     stub(window, 'fetch').callsFake(async (url) => {
       if (url.includes('/footer')) {
@@ -47,15 +44,13 @@ describe('Bootstrapper', async () => {
     });
     window.AdobeMessagingExperienceClient = window.AdobeMessagingExperienceClient
       || {
-        initialize: () => {},
         openMessagingWindow: () => {},
         isAdobeMessagingClientInitialized: () => {},
         getMessagingExperienceState: () => {},
       };
-    initializeSpy = spy(window.AdobeMessagingExperienceClient, 'initialize');
     openMessagingWindowSpy = spy(window.AdobeMessagingExperienceClient, 'openMessagingWindow');
-    isAdobeMessagingClientInitializedStub = stub(window.AdobeMessagingExperienceClient, 'isAdobeMessagingClientInitialized').returns(true);
-    getMessagingExperienceStateStub = stub(window.AdobeMessagingExperienceClient, 'getMessagingExperienceState').returns({ windowState: 'hidden' });
+    stub(window.AdobeMessagingExperienceClient, 'isAdobeMessagingClientInitialized').returns(true);
+    stub(window.AdobeMessagingExperienceClient, 'getMessagingExperienceState').returns({ windowState: 'hidden' });
     setConfig({ miloLibs, contentRoot: '/federal/dev' });
   });
 

--- a/test/navigation/bootstrapper.test.js
+++ b/test/navigation/bootstrapper.test.js
@@ -74,6 +74,7 @@ describe('Bootstrapper', async () => {
   });
 
   it('should call openMessagingWindow when click on jarvis enabled button', async () => {
+    blockConfig.header.jarvis = { id: '1.1' };
     stub(window.AdobeMessagingExperienceClient, 'isAdobeMessagingClientInitialized').returns(true);
     stub(window.AdobeMessagingExperienceClient, 'getMessagingExperienceState').returns({ windowState: 'hidden' });
     await loadBlock(miloLibs, blockConfig.header);

--- a/test/navigation/mocks/gnav.html
+++ b/test/navigation/mocks/gnav.html
@@ -52,6 +52,9 @@
       <div>
         <p><strong><a href="http://www.google.com/">Just link</a></strong></p>
       </div>
+      <div>
+        <p><strong><a href="https://helpx.adobe.com/support.html#open-jarvis-chat">Jarvis Chat</a></strong></p>
+      </div>
       <div></div>
     </main>
     <footer></footer>


### PR DESCRIPTION
Fix for "Contact Us" CTA takes user to a URL which doesn't open Jarvis chatbot for standalone GNAV.

Resolves: [MWPW-160508](https://jira.corp.adobe.com/browse/MWPW-160508)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://mwpw-160508--milo--deva309.hlx.page/?martech=off

QA:
https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=mwpw-160508&authoringpath=/federal/home