### PR TITLE
Remove @adobecom/admins from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,14 +3,9 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Milo Core (alphabetical order)
-/fstab.yaml @adobecom/admins
-/libs/features/ @adobecom/admins
 /libs/features/seotech/ @hparra
 /libs/features/title-append/ @hparra
-/libs/martech/ @adobecom/admins
-/libs/scripts/ @adobecom/admins
 /libs/scripts/taxonomy.js @meganthecoder @JasonHowellSlavin @Brandon32 @rgclayton
-/libs/utils/ @adobecom/admins
 
 # Milo Blocks (alphabetical order)
 /libs/blocks/accordion/ @fullcolorcoder @ryanmparrish


### PR DESCRIPTION
### Description
Currently we have looping in a group of [20 people](https://github.com/orgs/adobecom/teams/admins) within basically *every* milo PR, which creates a lot of spam and stops us from seeing messages we are _actually_ looped in on.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://remove-admins-from-code-owners--milo--mokimo.hlx.page/?martech=off
