### PR TITLE
MWPW-148129 [MILO][MEP][GNAV] Able to use select by url feature with federated link

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -452,7 +452,7 @@ function getSelectedElements(sel, rootEl, forceRootEl) {
       );
       return { els: fragments, modifiers: [FLAGS.all, FLAGS.includeFragments] };
     } catch (e) {
-      /* c8 ignore next */
+      /* c8 ignore next 2 */
       return { els: [], modifiers: [] };
     }
   }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -343,6 +343,8 @@ function registerInBlockActions(command) {
     blockSelector = blockAndSelector.slice(1).join(' ');
     command.selector = blockSelector;
     if (getSelectorType(blockSelector) === 'fragment') {
+      if (blockSelector.includes('/federal/')) blockSelector = getFederatedUrl(blockSelector);
+      if (command.content.includes('/federal/')) command.content = getFederatedUrl(command.content);
       config.mep.inBlock[blockName].fragments ??= {};
       const { fragments } = config.mep.inBlock[blockName];
       delete command.selector;

--- a/test/features/personalization/actions.test.js
+++ b/test/features/personalization/actions.test.js
@@ -3,7 +3,7 @@ import { readFile } from '@web/test-runner-commands';
 import { stub } from 'sinon';
 import { getConfig, loadBlock } from '../../../libs/utils/utils.js';
 import initFragments from '../../../libs/blocks/fragment/fragment.js';
-import { init, handleFragmentCommand } from '../../../libs/features/personalization/personalization.js';
+import { init, handleCommands } from '../../../libs/features/personalization/personalization.js';
 import mepSettings from './mepSettings.js';
 
 document.head.innerHTML = await readFile({ path: './mocks/metadata.html' });
@@ -151,7 +151,6 @@ describe('prependToSection action', async () => {
 
 describe('appendToSection action', async () => {
   it('appendToSection should add fragment to end of section', async () => {
-    config.mep = { handleFragmentCommand };
     let manifestJson = await readFile({ path: './mocks/actions/manifestAppendToSection.json' });
 
     manifestJson = JSON.parse(manifestJson);
@@ -164,6 +163,24 @@ describe('appendToSection action', async () => {
 
     const fragment = document.querySelector('main > div:nth-child(2) > div:last-child a[href="/test/features/personalization/mocks/fragments/appendToSection"]');
     expect(fragment).to.not.be.null;
+  });
+});
+
+describe('addHash', async () => {
+  it('if forceInline is true, addHash is called', async () => {
+    config.mep.commands = [{
+      action: 'replace',
+      content: '/new-fragment',
+      selector: 'h1',
+    }];
+    const rootEl = document.createElement('div');
+    handleCommands(config.mep.commands, rootEl, true, true);
+    console.log(config.mep.commands[0].content);
+    expect(config.mep.commands[0].content).to.equal('/new-fragment#_inline');
+    config.mep.commands[0].content = 'https://main--cc--adobecom.hlx.page/cc/fragments/new-fragment';
+    handleCommands(config.mep.commands, rootEl, true, true);
+    console.log(config.mep.commands[0].content);
+    expect(config.mep.commands[0].content).to.equal('https://main--cc--adobecom.hlx.page/cc/fragments/new-fragment#_inline');
   });
 });
 
@@ -219,20 +236,25 @@ describe('remove action', () => {
     let manifestJson = await readFile({ path: './mocks/actions/manifestRemove.json' });
     manifestJson = JSON.parse(manifestJson);
     setFetchResponse(manifestJson);
+    delete config.mep;
 
-    setTimeout(async () => {
-      expect(document.querySelector('.z-pattern')).to.not.be.null;
-      mepSettings.mepButton = false;
-      await init(mepSettings);
+    expect(document.querySelector('.z-pattern')).to.not.be.null;
+    await init({
+      mepParam: '',
+      mepHighlight: false,
+      mepButton: false,
+      pzn: '/path/to/manifest.json',
+      promo: false,
+      target: false,
+    });
 
-      expect(document.querySelector('.z-pattern')).to.not.be.null;
-      expect(document.querySelector('.z-pattern').dataset.removedManifestId).to.not.be.null;
+    expect(document.querySelector('.z-pattern')).to.not.be.null;
+    expect(document.querySelector('.z-pattern').dataset.removedManifestId).to.equal('manifest.json');
 
-      const removeMeFrag = document.querySelector('a[href="/fragments/removeme"]');
-      await initFragments(removeMeFrag);
-      expect(document.querySelector('a[href="/fragments/removeme"]')).to.not.be.null;
-      expect(document.querySelector('a[href="/fragments/removeme"]').dataset.removedManifestId).to.not.be.null;
-    }, 50);
+    const removeMeFrag = document.querySelector('a[href="/fragments/removeme"]');
+    await initFragments(removeMeFrag);
+    expect(document.querySelector('a[href="/fragments/removeme"]')).to.not.be.null;
+    expect(document.querySelector('a[href="/fragments/removeme"]').dataset.removedManifestId).to.not.be.null;
   });
 });
 

--- a/test/features/personalization/actions.test.js
+++ b/test/features/personalization/actions.test.js
@@ -322,6 +322,14 @@ describe('custom actions', async () => {
             pageFilter: '',
             selectorType: 'in-block:',
           },
+          'https://main--federal--adobecom.hlx.page/federal/fragments/new-sub-menu': {
+            action: 'replace',
+            pageFilter: '',
+            content: 'https://main--federal--adobecom.hlx.page/federal/fragments/even-more-new-sub-menu',
+            selectorType: 'in-block:',
+            manifestId: false,
+            targetManifestId: false,
+          },
         },
       },
     });

--- a/test/features/personalization/mocks/actions/manifestCustomAction.json
+++ b/test/features/personalization/mocks/actions/manifestCustomAction.json
@@ -35,13 +35,25 @@
       "firefox": "",
       "android": "",
       "ios": ""
-    },    {
+    },
+    {
       "action": "replace",
       "selector": "in-block:my-block /fragments/new-sub-menu",
       "page filter (optional)": "",
       "param-newoffer=123": "",
       "chrome": "/fragments/even-more-new-sub-menu",
       "target-var1": "/fragments/even-more-new-sub-menu",
+      "firefox": "",
+      "android": "",
+      "ios": ""
+    },
+    {
+      "action": "replace",
+      "selector": "in-block:my-block /federal/fragments/new-sub-menu",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "chrome": "/federal/fragments/even-more-new-sub-menu",
+      "target-var1": "/federal/fragments/even-more-new-sub-menu",
       "firefox": "",
       "android": "",
       "ios": ""


### PR DESCRIPTION
* check for and update selector and content if it's a federal link for in-block selectors

Resolves: [MWPW-148129](https://jira.corp.adobe.com/browse/MWPW-148129)

QA instructions: if you extend the gnav's first menu (Creativity & Design) it will now match the 2nd menu's content (PDF & E-signatures)
**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepgnavfedlink/
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepgnavfedlink/?milolibs=mepgnavfedlink
- Psi-check: https://mepgnavfedlink--milo--adobecom.hlx.page/?martech=off
