### PR TITLE
MWPW-157370 - [LocUI v2] Handle double clicks in sync and send requests

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -223,16 +223,24 @@ export function closeActionModal() {
   document.querySelector('.dialog-modal').dispatchEvent(new Event('closeModal'));
 }
 
+let isSyncing = false;
 export async function syncFragsLangstore() {
+  if (isSyncing) return;
+  isSyncing = true;
   closeActionModal();
   if (syncFragments.value?.length) {
     await syncToExcel(syncFragments.value);
     syncFragments.value = [];
   }
   await syncToLangstore();
+  isSyncing = false;
 }
 
+let isSending = false;
 export async function sendForLoc() {
+  if (isSending) return;
+  isSending = true;
+
   // stop polling for updates until request is made
   polling.value = false;
 
@@ -263,6 +271,7 @@ export async function sendForLoc() {
   setStatus('service');
   // Start polling for updates since this has not been kicked off.
   getServiceUpdates();
+  isSending = false;
 }
 
 export function showRollout() {


### PR DESCRIPTION
Guard sync to langstore and send for localization requests from being sent twice when a user double clicks the button.

Resolves: [MWPW-157370](https://jira.corp.adobe.com/browse/MWPW-157370)

**Test URL:**
https://sean-loc--milo--adobecom.hlx.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257Baca136c4-f6f3-479a-8169-cbda4083129c%257D%26action%3Deditnew
