### PR TITLE
Fix the merge to stage process

### DIFF
--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -236,7 +236,8 @@ const main = async (params) => {
     const stageToMainPR = await getStageToMainPR();
     console.log('has Stage to Main PR:', !!stageToMainPR);
     if (stageToMainPR) body = stageToMainPR.body;
-    existingPRCount = body.match(/https:\/\/github\.com\/adobecom\/milo\/pull\/\d+/g).length;
+    console.log('Current PR body:', body);
+    existingPRCount = body.match(/https:\/\/github\.com\/adobecom\/milo\/pull\/\d+/g)?.length || 0;
     console.log(`Number of PRs already in the batch: ${existingPRCount}`);
 
     if (mergeLimitExceeded()) return console.log(`Maximum number of '${MAX_MERGES}' PRs already merged. Stopping execution`);

--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -236,7 +236,6 @@ const main = async (params) => {
     const stageToMainPR = await getStageToMainPR();
     console.log('has Stage to Main PR:', !!stageToMainPR);
     if (stageToMainPR) body = stageToMainPR.body;
-    console.log('Current PR body:', body);
     existingPRCount = body.match(/https:\/\/github\.com\/adobecom\/milo\/pull\/\d+/g)?.length || 0;
     console.log(`Number of PRs already in the batch: ${existingPRCount}`);
 


### PR DESCRIPTION
### Description
Seems like this [workflow run](https://github.com/adobecom/milo/actions/runs/11436722238/job/31814762385) errors out `TypeError: Cannot read properties of null (reading 'length')` ... we always have a string for the body, so I'm not sure how this is happening, but let's safeguard this. Related to https://github.com/adobecom/milo/pull/3062

Resolves: [MWPW-157289](https://jira.corp.adobe.com/browse/MWPW-157289)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://fix-stage-process--milo--mokimo.hlx.page/?martech=off
