### PR TITLE
Revert "MWPW-160061: Clickable App and Playstore links"

### DIFF
--- a/libs/blocks/media/media.js
+++ b/libs/blocks/media/media.js
@@ -30,15 +30,14 @@ function decorateAvatar(el) {
 function decorateQr(el) {
   const text = el.querySelector('.text');
   if (!text) return;
-  const appStore = text.children[(text.children.length - 1)]?.querySelector('a');
-  const googlePlay = text.children[(text.children.length - 2)]?.querySelector('a');
+  const appStore = text.children[(text.children.length - 1)];
+  const googlePlay = text.children[(text.children.length - 2)];
   const qrImage = text.children[(text.children.length - 3)];
-  if (!qrImage || !appStore || !googlePlay) return;
-  qrImage.classList.add('qr-code-img');
   appStore.classList.add('app-store');
   appStore.textContent = '';
   googlePlay.classList.add('google-play');
   googlePlay.textContent = '';
+  qrImage.classList.add('qr-code-img');
 }
 
 export default async function init(el) {


### PR DESCRIPTION
Reverts adobecom/milo#3021

Buttons are under each other rather than side by side.
**Before**
![Screenshot 2024-10-22 at 11 17 21](https://github.com/user-attachments/assets/ac50112e-d9fd-4d64-8a15-f08df336b880)

**After**
![Screenshot 2024-10-22 at 11 17 18](https://github.com/user-attachments/assets/db3ad70f-e6c5-493c-bdc6-fcf100ceefa4)

Before: https://main--cc--adobecom.hlx.page/in/creativecloud/roc/mobile-apps?milolibs=stage
After: https://main--cc--adobecom.hlx.page/in/creativecloud/roc/mobile-apps
