### PR TITLE
Upgrade to RUM V2.7.0

### DIFF
--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -342,7 +342,6 @@ async function buildFilter(type, tax, block, config) {
   applyBtn.classList.add('button', 'small', 'apply');
   applyBtn.textContent = await replacePlaceholder('apply');
   applyBtn.addEventListener('click', () => {
-    // sampleRUM('apply-topic-filter');
     delete config.selectedProducts;
     delete config.selectedIndustries;
     closeCurtain();

--- a/libs/blocks/library-config/library-config.js
+++ b/libs/blocks/library-config/library-config.js
@@ -197,7 +197,6 @@ function createList(libraries) {
       list.classList.add('inset');
       skLibrary.classList.add('allow-back');
       loadList(type, libraries[type], list);
-      window.hlx?.rum.sampleRUM('click', { source: e.target });
     });
   });
 

--- a/libs/blocks/library-config/lists/blocks.js
+++ b/libs/blocks/library-config/lists/blocks.js
@@ -285,7 +285,6 @@ export default async function loadBlocks(blocks, list, query, type) {
         setTimeout(() => { e.target.classList.remove('copied'); }, 3000);
         const blob = new Blob([`${BLOCK_SPACING}${containerHtml}${BLOCK_SPACING}`], { type: 'text/html' });
         createCopy(blob);
-        window.hlx?.rum.sampleRUM('click', { source: e.target });
       });
       item.append(name, copy);
 

--- a/libs/blocks/library-config/lists/icons.js
+++ b/libs/blocks/library-config/lists/icons.js
@@ -18,7 +18,6 @@ export default async function iconList(content, list) {
       const formatted = `:${key}:`;
       const blob = new Blob([formatted], { type: 'text/plain' });
       createCopy(blob);
-      window.hlx?.rum.sampleRUM('click', { source: e.target });
     });
     title.append(copy);
     list.append(title);

--- a/libs/blocks/library-config/lists/personalization.js
+++ b/libs/blocks/library-config/lists/personalization.js
@@ -26,7 +26,6 @@ const getCopyBtn = (tagName) => {
     setTimeout(() => { e.target.classList.remove('copied'); }, 3000);
     const blob = new Blob([tagName], { type: 'text/plain' });
     createCopy(blob);
-    window.hlx?.rum.sampleRUM('click', { source: e.target });
   });
   return copy;
 };

--- a/libs/blocks/library-config/lists/placeholders.js
+++ b/libs/blocks/library-config/lists/placeholders.js
@@ -21,7 +21,6 @@ export default async function placeholderList(content, list) {
       const formatted = `{{${placeholder.key}}}`;
       const blob = new Blob([formatted], { type: 'text/plain' });
       createCopy(blob);
-      window.hlx?.rum.sampleRUM('click', { source: e.target });
     });
     title.append(copy);
     list.append(title);

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -82,7 +82,7 @@ const loadDelayed = ([
     } else {
       resolve(null);
     }
-    import('../utils/samplerum.js').then(({ sampleRUM }) => sampleRUM('cwv'));
+    import('../utils/samplerum.js').then(({ sampleRUM }) => sampleRUM());
   }, DELAY);
 });
 

--- a/libs/templates/404/404.js
+++ b/libs/templates/404/404.js
@@ -68,7 +68,7 @@ export default async function init() {
   if (style === 'feds') await get404();
   if (style === 'local') await get404(`${root}/fragments/404`);
   if (!style) await getLegacy404();
-  sampleRUM('404', { source: document.referrer, target: window.location.href });
+  sampleRUM('404', { source: document.referrer });
 }
 
 (async () => {

--- a/libs/utils/samplerum.js
+++ b/libs/utils/samplerum.js
@@ -1,101 +1,83 @@
 // code from https://github.com/adobe/helix-rum-js/blob/main/src/index.js
-export function sampleRUM(checkpoint, data = {}) {
-  const SESSION_STORAGE_KEY = 'aem-rum';
-  sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE == null ? 'https://rum.hlx.page' : window.RUM_BASE, window.location);
-  sampleRUM.defer = sampleRUM.defer || [];
-  const defer = (fnname) => {
-    sampleRUM[fnname] = sampleRUM[fnname]
-      || ((...args) => sampleRUM.defer.push({ fnname, args }));
-  };
-  /* c8 ignore start */
-  sampleRUM.drain = sampleRUM.drain
-    || ((dfnname, fn) => {
-      sampleRUM[dfnname] = fn;
-      sampleRUM.defer
-        .filter(({ fnname }) => dfnname === fnname)
-        .forEach(({ fnname, args }) => sampleRUM[fnname](...args));
-    });
-  sampleRUM.always = sampleRUM.always || [];
-  sampleRUM.always.on = (chkpnt, fn) => {
-    sampleRUM.always[chkpnt] = fn;
-  };
-  sampleRUM.on = (chkpnt, fn) => {
-    sampleRUM.cases[chkpnt] = fn;
-  };
-  /* c8 ignore stop */
-  defer('observe');
-  defer('cwv');
+// eslint-disable-next-line import/prefer-default-export
+export function sampleRUM(checkpoint, data) {
+  // eslint-disable-next-line max-len
+  const timeShift = () => (window.performance ? window.performance.now() : Date.now() - window.hlx.rum.firstReadTime);
   try {
     window.hlx = window.hlx || {};
+    sampleRUM.enhance = () => {};
     if (!window.hlx.rum) {
+      const param = new URLSearchParams(window.location.search).get('rum');
       const weight = (window.SAMPLE_PAGEVIEWS_AT_RATE === 'high' && 10)
-      || (window.SAMPLE_PAGEVIEWS_AT_RATE === 'low' && 1000)
-      || (new URLSearchParams(window.location.search).get('rum') === 'on' && 1)
-      || 100;
+        || (window.SAMPLE_PAGEVIEWS_AT_RATE === 'low' && 1000)
+        || (param === 'on' && 1)
+        || 100;
       const id = Math.random().toString(36).slice(-4);
-      const isSelected = (Math.random() * weight < 1);
-      const firstReadTime = Date.now();
-      const urlSanitizers = {
-        full: () => window.location.href,
-        origin: () => window.location.origin,
-        path: () => window.location.href.replace(/\?.*$/, ''),
-      };
-      // eslint-disable-next-line max-len
-      const rumSessionStorage = sessionStorage.getItem(SESSION_STORAGE_KEY) ? JSON.parse(sessionStorage.getItem(SESSION_STORAGE_KEY)) : {};
-      rumSessionStorage.pages = rumSessionStorage.pages ? rumSessionStorage.pages + 1 : 1;
-      sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(rumSessionStorage));
+      const isSelected = (param !== 'off') && (Math.random() * weight < 1);
       // eslint-disable-next-line object-curly-newline, max-len
-      window.hlx.rum = { weight, id, isSelected, firstReadTime, sampleRUM, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'path'], rumSessionStorage };
-    }
+      window.hlx.rum = { weight, id, isSelected, firstReadTime: window.performance ? window.performance.timeOrigin : Date.now(), sampleRUM, queue: [], collector: (...args) => window.hlx.rum.queue.push(args) };
+      if (isSelected) {
+        const dataFromErrorObj = (error) => {
+          const errData = { source: 'undefined error' };
+          try {
+            errData.target = error.toString();
+            errData.source = error.stack.split('\n')
+              .filter((line) => line.match(/https?:\/\//)).shift()
+              .replace(/at ([^ ]+) \((.+)\)/, '$1@$2')
+              .replace(/ at /, '@')
+              .trim();
+          } catch (err) { /* error structure was not as expected */ }
+          return errData;
+        };
 
-    const { weight, id, firstReadTime } = window.hlx.rum;
-    if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {
-      const knownProperties = ['weight', 'id', 'referer', 'checkpoint', 't', 'source', 'target', 'cwv', 'CLS', 'FID', 'LCP', 'INP', 'TTFB'];
-      const sendPing = (pdata = data) => {
-        // eslint-disable-next-line object-curly-newline, max-len, no-use-before-define
-        const body = JSON.stringify({ weight, id, referer: window.hlx.rum.sanitizeURL(), checkpoint, t: (Date.now() - firstReadTime), ...data }, knownProperties);
-        const url = new URL(`.rum/${weight}`, sampleRUM.baseURL).href;
-        navigator.sendBeacon(url, body);
-        // eslint-disable-next-line no-console
-        console.debug(`ping:${checkpoint}`, pdata);
-      };
-      sampleRUM.cases = sampleRUM.cases || {
-        load: () => sampleRUM('pagesviewed', { source: window.hlx.rum.rumSessionStorage.pages }) || true,
-        cwv: () => sampleRUM.cwv(data) || true,
-        /* c8 ignore next 7 */
-        lazy: () => {
-          // use classic script to avoid CORS issues
+        window.addEventListener('error', ({ error }) => {
+          const errData = dataFromErrorObj(error);
+          sampleRUM('error', errData);
+        });
+
+        window.addEventListener('unhandledrejection', ({ reason }) => {
+          let errData = {
+            source: 'Unhandled Rejection',
+            target: reason || 'Unknown',
+          };
+          if (reason instanceof Error) {
+            errData = dataFromErrorObj(reason);
+          }
+          sampleRUM('error', errData);
+        });
+
+        sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://rum.hlx.page'));
+        sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || sampleRUM.baseURL;
+        sampleRUM.sendPing = (ck, time, pingData = {}) => {
+          // eslint-disable-next-line max-len, object-curly-newline
+          const rumData = JSON.stringify({ weight, id, referer: window.location.href, checkpoint: ck, t: time, ...pingData });
+          const urlParams = window.RUM_PARAMS ? `?${new URLSearchParams(window.RUM_PARAMS).toString()}` : '';
+          const { href: url, origin } = new URL(`.rum/${weight}${urlParams}`, sampleRUM.collectBaseURL);
+          const body = origin === window.location.origin ? new Blob([rumData], { type: 'application/json' }) : rumData;
+          navigator.sendBeacon(url, body);
+          // eslint-disable-next-line no-console
+          console.debug(`ping:${ck}`, pingData);
+        };
+        sampleRUM.sendPing('top', timeShift());
+
+        sampleRUM.enhance = () => {
+          // only enhance once
+          if (document.querySelector('script[src*="rum-enhancer"]')) return;
+
           const script = document.createElement('script');
-          script.src = new URL('.rum/@adobe/helix-rum-enhancer@^1/src/index.js', sampleRUM.baseURL).href;
+          script.src = new URL('.rum/@adobe/helix-rum-enhancer@^2/src/index.js', sampleRUM.baseURL).href;
           document.head.appendChild(script);
-          return true;
-        },
-      };
-      sendPing(data);
-      if (sampleRUM.cases[checkpoint]) {
-        sampleRUM.cases[checkpoint]();
+        };
+        if (!window.hlx.RUM_MANUAL_ENHANCE) {
+          sampleRUM.enhance();
+        }
       }
     }
-    if (sampleRUM.always[checkpoint]) {
-      sampleRUM.always[checkpoint](data);
+    if (window.hlx.rum && window.hlx.rum.isSelected && checkpoint) {
+      window.hlx.rum.collector(checkpoint, data, timeShift());
     }
+    document.dispatchEvent(new CustomEvent('rum', { detail: { checkpoint, data } }));
   } catch (error) {
-    // something went wrong
+    // something went awry
   }
 }
-
-/* c8 ignore start */
-export function addRumListeners() {
-  window.addEventListener('load', () => sampleRUM('load'));
-
-  window.addEventListener('unhandledrejection', (event) => {
-    sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line });
-  });
-
-  window.addEventListener('error', (event) => {
-    sampleRUM('error', { source: event.filename, target: event.lineno });
-  });
-}
-/* c8 ignore stop */
-
-sampleRUM('top');

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1119,10 +1119,6 @@ export async function loadDeferred(area, blocks, config) {
     });
   }
 
-  import('./samplerum.js').then(({ sampleRUM }) => {
-    sampleRUM('lazy');
-  });
-
   if (getMetadata('pageperf') === 'on') {
     import('./logWebVitals.js')
       .then((mod) => mod.default(getConfig().mep, {
@@ -1179,10 +1175,6 @@ function decorateMeta() {
 function decorateDocumentExtras() {
   decorateMeta();
   decorateHeader();
-
-  import('./samplerum.js').then(({ sampleRUM }) => {
-    sampleRUM();
-  });
 }
 
 async function documentPostSectionLoading(config) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -470,6 +470,7 @@ export async function loadBlock(block) {
     return null;
   }
   const { name, blockPath, hasStyles } = getBlockData(block);
+  block.dataset.blockName = name;
   const styleLoaded = hasStyles && new Promise((resolve) => {
     loadStyle(`${blockPath}.css`, resolve);
   });
@@ -1120,8 +1121,6 @@ export async function loadDeferred(area, blocks, config) {
 
   import('./samplerum.js').then(({ sampleRUM }) => {
     sampleRUM('lazy');
-    sampleRUM.observe(blocks);
-    sampleRUM.observe(area.querySelectorAll('picture > img'));
   });
 
   if (getMetadata('pageperf') === 'on') {
@@ -1181,8 +1180,8 @@ function decorateDocumentExtras() {
   decorateMeta();
   decorateHeader();
 
-  import('./samplerum.js').then(({ addRumListeners }) => {
-    addRumListeners();
+  import('./samplerum.js').then(({ sampleRUM }) => {
+    sampleRUM();
   });
 }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -470,7 +470,6 @@ export async function loadBlock(block) {
     return null;
   }
   const { name, blockPath, hasStyles } = getBlockData(block);
-  block.dataset.blockName = name;
   const styleLoaded = hasStyles && new Promise((resolve) => {
     loadStyle(`${blockPath}.css`, resolve);
   });
@@ -479,6 +478,7 @@ export async function loadBlock(block) {
       try {
         const { default: init } = await import(`${blockPath}.js`);
         await init(block);
+        block.dataset.blockStatus = 'loaded';
       } catch (err) {
         console.log(`Failed loading ${name}`, err);
         const config = getConfig();

--- a/test/utils/samplerum.test.js
+++ b/test/utils/samplerum.test.js
@@ -3,28 +3,31 @@
 
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import { sampleRUM } from '../../libs/utils/samplerum.js';
 
 describe('SampleRUM', () => {
-  it('Collects RUM data', () => {
+  it('Collects RUM data', async () => {
     const sendBeacon = sinon.stub(navigator, 'sendBeacon');
     // turn on RUM
     window.history.pushState({}, '', `${window.location.href}&rum=on`);
-    delete window.hlx;
 
-    // sends checkpoint beacon
-    sampleRUM('test', { foo: 'bar' });
+    const { sampleRUM } = await import('../../libs/utils/samplerum.js');
+
+    // auto collects the top checkpoint
+    sampleRUM();
     expect(sendBeacon.called).to.be.true;
     sendBeacon.resetHistory();
 
     // sends cwv beacon
+    window.hlx.rum.collector = sinon.stub();
     sampleRUM('cwv', { foo: 'bar' });
-    expect(sendBeacon.called).to.be.true;
+    expect(window.hlx.rum.collector.called).to.be.true;
 
-    // test error handling
-    sendBeacon.throws();
+    // // test error handling
+    window.hlx.rum.collector.resetHistory();
     sampleRUM('error', { foo: 'bar' });
+    expect(window.hlx.rum.collector.called).to.be.true;
 
+    delete window.hlx;
     sendBeacon.restore();
   });
 });

--- a/test/utils/samplerum.test.js
+++ b/test/utils/samplerum.test.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-unused-expressions */
-/* global describe it */
 
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';


### PR DESCRIPTION
### Description
- Upgrade to the latest RUM and RUM Enhancer. As far as I can tell, no [production project](https://github.com/search?q=org%3Aadobecom+samplerum.observe&type=code) uses `rum.observe` which does not exist anymore after this upgrade. 

- Adds the block loading status to properly track blocks

### Test instructions
- Ensure RUM data is properly captured to `https://rum.hlx.page/.rum`
![Screenshot 2024-10-24 at 15 08 03](https://github.com/user-attachments/assets/89556062-03ac-4b38-a0e0-9f2fed4f66ef)

Resolves: [MWPW-160590](https://jira.corp.adobe.com/browse/MWPW-160590)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://upgrade-rum--milo--mokimo.hlx.page/?martech=off&rum=on

CC:
- Before:https://main--cc--adobecom.hlx.live/de/products/photoshop?mep=off&rum=on
- After: https://main--cc--adobecom.hlx.live/de/products/photoshop?milolibs=upgrade-rum--milo--mokimo&mep=off&rum=on
