### PR TITLE
MWPW-160233: Adding tabindex to social share icons

### DIFF
--- a/libs/blocks/article-header/article-header.js
+++ b/libs/blocks/article-header/article-header.js
@@ -108,20 +108,24 @@ async function buildSharing() {
     twitter: {
       'data-href': `https://www.twitter.com/share?&url=${url}&text=${title}`,
       'aria-label': 'share twitter',
+      tabindex: '0',
     },
     linkedin: {
       'data-type': 'LinkedIn',
       'data-href': `https://www.linkedin.com/shareArticle?mini=true&url=${url}&title=${title}&summary=${description || ''}`,
       'aria-label': 'share linkedin',
+      tabindex: '0',
     },
     facebook: {
       'data-type': 'Facebook',
       'data-href': `https://www.facebook.com/sharer/sharer.php?u=${url}`,
       'aria-label': 'share facebook',
+      tabindex: '0',
     },
     link: {
       id: 'copy-to-clipboard',
       'aria-label': 'copy to clipboard',
+      tabindex: '0',
     },
   };
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds tabindex to the properties used to create the social share icons to ensure users can navigate via keyboard. I checked with voiceover as well to ensure the correct alt text was being represented. 

Resolves: [MWPW-160233](https://jira.corp.adobe.com/browse/MWPW-160233)

**Test URLs:**
- Before: https://main--bacom-blog--adobecom.hlx.live/blog/the-latest/samsung-proves-real-time-data-is-a-catalyst-for-better-customer-experiences?martech=off
- After: https://article-header-a11y--bacom-blog--adobecom.hlx.live/blog/the-latest/samsung-proves-real-time-data-is-a-catalyst-for-better-customer-experiences?martech=off
