### PR TITLE
[MWPW-156246][Milo Catalog Accessibility] Sort function is not accessible on Catalog

### DIFF
--- a/libs/deps/mas/merch-card-collection.js
+++ b/libs/deps/mas/merch-card-collection.js
@@ -134,7 +134,8 @@ import{html as l,LitElement as N}from"../lit-all.min.js";var m=class{constructor
                 size="m"
                 @change="${this.sortChanged}"
                 selects="single"
-                value="${i?n.alphabetical:n.authored}"
+                value="${i?n.alphabetical:n.authored}
+                aria-activedescendant="${i?"sp-menu-item-alphabetical":"sp-menu-item-authored"}"
             >
                 <span slot="label-only"
                     >${e}:

--- a/libs/features/mas/web-components/src/merch-card-collection.js
+++ b/libs/features/mas/web-components/src/merch-card-collection.js
@@ -289,7 +289,10 @@ export class MerchCardCollection extends LitElement {
                 selects="single"
                 value="${alphabetical
                     ? SORT_ORDER.alphabetical
-                    : SORT_ORDER.authored}"
+                    : SORT_ORDER.authored}
+                aria-activedescendant="${alphabetical 
+                    ? 'sp-menu-item-alphabetical' 
+                    : 'sp-menu-item-authored'}"
             >
                 <span slot="label-only"
                     >${sortText}:


### PR DESCRIPTION
added "aria-activedescendant" for catalog sort menu

Resolves: [MWPW-156246](https://jira.corp.adobe.com/browse/MWPW-156246)
 
**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/products/catalog
- After: https://main--cc--adobecom.hlx.page/products/catalog?milolibs=MWPW-156246--milo--rohitsahu&martech=off
