### PR TITLE
Adding creative cloud stage link to stageDomainsMap

### DIFF
--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -25,11 +25,13 @@ const stageDomainsMap = {
   'www.stage.adobe.com': {
     'www.adobe.com': 'origin',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
   },
   // Test app
   'adobecom.github.io': {
     'www.adobe.com': 'www.stage.adobe.com',
     'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
   },
 };
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added support to convert links authored with _creativecloud.adobe.com_ to _stage.creativecloud.adobe.com_ on stage environment

Resolves: [MWPW-160934](https://jira.corp.adobe.com/browse/MWPW-160934)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://cc-stage-link--milo--adobecom.hlx.page/?martech=off

**QA:**
https://adobecom.github.io/nav-consumer/navigation.html?authoringpath=/federal/dev/blaishram&customlinks=home,discover&navbranch=cc-stage-link
