### PR TITLE
[MWPW-160862] [Milo OST] Add 'Save now' to dropdown of CTA text options

### DIFF
--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -17,6 +17,7 @@
 import { decorateBlockText, decorateBlockBg, decorateTextOverrides, decorateMultiViewport, loadCDT } from '../../utils/decorate.js';
 import { createTag, getConfig, loadStyle } from '../../utils/utils.js';
 
+
 const { miloLibs, codeRoot } = getConfig();
 const base = miloLibs || codeRoot;
 const variants = ['banner', 'ribbon', 'pill'];

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -17,7 +17,6 @@
 import { decorateBlockText, decorateBlockBg, decorateTextOverrides, decorateMultiViewport, loadCDT } from '../../utils/decorate.js';
 import { createTag, getConfig, loadStyle } from '../../utils/utils.js';
 
-
 const { miloLibs, codeRoot } = getConfig();
 const base = miloLibs || codeRoot;
 const variants = ['banner', 'ribbon', 'pill'];

--- a/libs/blocks/ost/ctaTextOption.js
+++ b/libs/blocks/ost/ctaTextOption.js
@@ -3,6 +3,7 @@ const ctaTextOption = {
     { id: 'buy-now', name: 'Buy now' },
     { id: 'free-trial', name: 'Free trial' },
     { id: 'start-free-trial', name: 'Start free trial' },
+    { id: 'save-now', name: 'Save now' },
     { id: 'get-started', name: 'Get started' },
     { id: 'choose-a-plan', name: 'Choose a plan' },
     { id: 'learn-more', name: 'Learn more' },
@@ -12,7 +13,6 @@ const ctaTextOption = {
     { id: 'take-the-quiz', name: 'Take the quiz' },
     { id: 'see-more', name: 'See more' },
     { id: 'upgrade-now', name: 'Upgrade now' },
-    { id: 'save-now', name: 'Save now' },
   ],
 
   getDefaultText() {

--- a/libs/blocks/ost/ctaTextOption.js
+++ b/libs/blocks/ost/ctaTextOption.js
@@ -12,6 +12,7 @@ const ctaTextOption = {
     { id: 'take-the-quiz', name: 'Take the quiz' },
     { id: 'see-more', name: 'See more' },
     { id: 'upgrade-now', name: 'Upgrade now' },
+    { id: 'save-now', name: 'Save now' },
   ],
 
   getDefaultText() {

--- a/test/blocks/ost/textOption.test.js
+++ b/test/blocks/ost/textOption.test.js
@@ -20,7 +20,8 @@ describe('test ctaTextOption', () => {
       { id: 'change-plan-team-payment', name: 'Change Plan Team Payment' },
       { id: 'take-the-quiz', name: 'Take the quiz' },
       { id: 'see-more', name: 'See more' },
-      { id: 'upgrade-now', name: 'Upgrade now' }];
+      { id: 'upgrade-now', name: 'Upgrade now' },
+      { id: 'save-now', name: 'Save now' }];
     const texts = ctaTextOption.getTexts();
     expect(EXPECTED_TEXTS).to.deep.equal(texts);
   });

--- a/test/blocks/ost/textOption.test.js
+++ b/test/blocks/ost/textOption.test.js
@@ -12,6 +12,7 @@ describe('test ctaTextOption', () => {
     const EXPECTED_TEXTS = [{ id: 'buy-now', name: 'Buy now' },
       { id: 'free-trial', name: 'Free trial' },
       { id: 'start-free-trial', name: 'Start free trial' },
+      { id: 'save-now', name: 'Save now' },
       { id: 'get-started', name: 'Get started' },
       { id: 'choose-a-plan', name: 'Choose a plan' },
       { id: 'learn-more', name: 'Learn more' },
@@ -20,8 +21,7 @@ describe('test ctaTextOption', () => {
       { id: 'change-plan-team-payment', name: 'Change Plan Team Payment' },
       { id: 'take-the-quiz', name: 'Take the quiz' },
       { id: 'see-more', name: 'See more' },
-      { id: 'upgrade-now', name: 'Upgrade now' },
-      { id: 'save-now', name: 'Save now' }];
+      { id: 'upgrade-now', name: 'Upgrade now' }];
     const texts = ctaTextOption.getTexts();
     expect(EXPECTED_TEXTS).to.deep.equal(texts);
   });

--- a/test/blocks/ost/textOption.test.js
+++ b/test/blocks/ost/textOption.test.js
@@ -22,6 +22,7 @@ describe('test ctaTextOption', () => {
       { id: 'take-the-quiz', name: 'Take the quiz' },
       { id: 'see-more', name: 'See more' },
       { id: 'upgrade-now', name: 'Upgrade now' }];
+      
     const texts = ctaTextOption.getTexts();
     expect(EXPECTED_TEXTS).to.deep.equal(texts);
   });

--- a/test/blocks/ost/textOption.test.js
+++ b/test/blocks/ost/textOption.test.js
@@ -22,7 +22,6 @@ describe('test ctaTextOption', () => {
       { id: 'take-the-quiz', name: 'Take the quiz' },
       { id: 'see-more', name: 'See more' },
       { id: 'upgrade-now', name: 'Upgrade now' }];
-      
     const texts = ctaTextOption.getTexts();
     expect(EXPECTED_TEXTS).to.deep.equal(texts);
   });


### PR DESCRIPTION
Add "Save now" to the OST CTAs options
Ignore the below urls for testing. Provide adobe.com token to test the functionality in OST.

Before:
<img width="229" alt="Screenshot 2024-10-24 at 12 52 56 PM" src="https://github.com/user-attachments/assets/3147232b-7b7d-462e-b51e-72e1f4f3e903">

After:
<img width="260" alt="Screenshot 2024-10-24 at 2 30 31 PM" src="https://github.com/user-attachments/assets/f7f8a143-2555-4565-842f-b50b72878a78">

Resolves: [MWPW-160862](https://jira.corp.adobe.com/browse/MWPW-160862)

Test URLs:
- Before: https://main--milo--adobecom.hlx.page/drafts/rosahu/innovatex/badgealign
- After: https://mwpw-160862--milo--rohitsahu.hlx.page/drafts/rosahu/innovatex/badgealign