### PR TITLE
MWPW-160239 [MEP] Support searching for placeholders in URLs

### DIFF
--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -135,8 +135,10 @@ export async function decoratePlaceholderArea({
     if (nodeEl.nodeType === Node.TEXT_NODE) {
       nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config);
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
-      const hrefVal = await replaceText(nodeEl.getAttribute('href'), config);
-      nodeEl.setAttribute('href', hrefVal);
+      for (const attr of nodeEl.attributes) {
+        const attrVal = await replaceText(attr.value, config);
+        nodeEl.setAttribute(attr.name, attrVal);
+      }
     }
   });
   await Promise.all(replaceNodes);

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -135,10 +135,14 @@ export async function decoratePlaceholderArea({
     if (nodeEl.nodeType === Node.TEXT_NODE) {
       nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config);
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
-      for (const attr of nodeEl.attributes) {
+      const attrPromises = [...nodeEl.attributes].map(async (attr) => {
         const attrVal = await replaceText(attr.value, config);
-        nodeEl.setAttribute(attr.name, attrVal);
-      }
+        return { name: attr.name, value: attrVal };
+      });
+      const results = await Promise.all(attrPromises);
+      results.forEach(({ name, value }) => {
+        nodeEl.setAttribute(name, value);
+      });
     }
   });
   await Promise.all(replaceNodes);

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
-import { setConfig, getConfig } from '../../../libs/utils/utils.js';
-import { replaceText, replaceKey, replaceKeyArray } from '../../../libs/features/placeholders.js';
+import { setConfig, getConfig, customFetch } from '../../../libs/utils/utils.js';
+import { replaceText, replaceKey, replaceKeyArray, decoratePlaceholderArea } from '../../../libs/features/placeholders.js';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 const conf = { locales };
@@ -56,5 +56,20 @@ describe('Placeholders', () => {
   it('Does show an empty value', async () => {
     const text = await replaceKey('empty-value', config);
     expect(text).to.equal('');
+  });
+
+  it('Replaces attributes with placeholders', async () => {
+    const placeholderPath = 'https://main--cc--adobecom.hlx.page/cc-shared/placeholders.json';
+    const placeholderRequest = customFetch({ resource: placeholderPath, withCacheRules: true })
+      .catch(() => ({}));
+
+    const tag = document.createElement('a');
+    tag.setAttribute('href', '/modal/%7B%7Bphone-number%7D%7D');
+    tag.setAttribute('data-attr', '/modal/%7B%7Bphone-number%7D%7D');
+
+    await decoratePlaceholderArea({ placeholderPath, placeholderRequest, nodes: [tag] });
+
+    expect(tag.getAttribute('href')).to.equal('/modal/800 12345 6789');
+    expect(tag.getAttribute('data-attr')).to.equal('/modal/800 12345 6789');
   });
 });


### PR DESCRIPTION
When we search for placeholders, we are looking for a pattern of text within double curly brackets.  However, when a placeholder is used inside a URL, the double curly brackets are URL encoded.

Example URL: https://main--cc--adobecom.hlx.page/cc-shared/fragments/trial-modals/product-labeledu#mini-plans-web-ctaproduct-label-card-sb

Becomes: /cc-shared/fragments/trial-modals/%7B%7Bproduct-label%7D%7D-edu#mini-plans-web-cta-%7B%7Bproduct-label%7D%7D-card-sb

I want to add support for these encoded brackets.

**QA instructions**
Check the first link for data-modal-path or data-modal-hash on the Free trial anchor. Placeholders will be unresolved. This should be fixed on the second link.

Resolves:  [MWPW-160239](https://jira.corp.adobe.com/browse/MWPW-160239)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/urlplaceholders/aside
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/urlplaceholders/aside?milolibs=urlplaceholders
- Psi-check: https://urlplaceholders--milo--adobecom.hlx.page/?martech=off
