### PR TITLE
MWPW-160292 Next gen sidekick publish button

### DIFF
--- a/libs/utils/sidekick-decorate.js
+++ b/libs/utils/sidekick-decorate.js
@@ -5,9 +5,7 @@ const PROFILE = '.profile-email';
 const CONFIRM_MESSAGE = 'Are you sure? This will publish to production.';
 let stylePublishCalled = false;
 
-export default function stylePublish(sk) {
-  if (stylePublishCalled) return;
-  stylePublishCalled = true;
+function styleHelixPublish(sk) {
   const setupPublishBtn = async (page, btn) => {
     const { canPublish, message } = await userCanPublishPage(page, false);
     if (canPublish) {
@@ -106,4 +104,81 @@ export default function stylePublish(sk) {
       setupPublishBtn(page, btn);
     }
   }, 500);
+}
+
+async function checkAuthorization(page, btn) {
+  const { canPublish, message } = await userCanPublishPage(page, false);
+  if (canPublish) {
+    btn.removeAttribute('disabled');
+    return;
+  }
+
+  btn.setAttribute('disabled', true);
+  btn.insertAdjacentHTML('beforeend', `<span>${message}</span>`);
+  setTimeout(() => btn.querySelector('span').remove(), 4000);
+}
+
+export default async function stylePublish(sk) {
+  if (stylePublishCalled) return;
+  stylePublishCalled = true;
+
+  if (sk.nodeName === 'HELIX-SIDEKICK') {
+    styleHelixPublish(sk);
+    return;
+  }
+
+  const style = new CSSStyleSheet();
+  style.replaceSync(`
+    sk-action-button.publish {
+      position: relative;
+    }
+    sk-action-button.publish > span {
+      display: none;
+      background: #777;
+      border-radius: 4px;
+      line-height: 1.2rem;
+      padding: 8px 12px;
+      position: absolute;
+      bottom: 34px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 150px;
+      white-space: pre-wrap;
+      color: black;
+    }
+    sk-action-button.publish[disabled] > span {
+      display: block;
+    }
+    sk-action-button.publish > span:before {
+      content: '';
+      border-left: 6px solid transparent;
+      border-right: 6px solid transparent;
+      border-top: 6px solid #777;
+      position: absolute;
+      text-align: center;
+      bottom: -6px;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+  `);
+
+  const pluginActionBarSR = sk.shadowRoot.querySelector('plugin-action-bar').shadowRoot;
+  pluginActionBarSR.adoptedStyleSheets ??= [];
+  pluginActionBarSR.adoptedStyleSheets.push(style);
+
+  const publishBtn = pluginActionBarSR.querySelector('sk-action-button.publish');
+  if (!publishBtn) {
+    sk.addEventListener('status-fetched', ({ target, detail }) => {
+      setTimeout(async () => {
+        const btn = target.shadowRoot.querySelector('plugin-action-bar').shadowRoot.querySelector('sk-action-button.publish');
+        if (detail && btn) await checkAuthorization(detail, btn);
+      }, 0);
+    });
+  }
+
+  const pageDetail = {
+    webPath: window.location.pathname,
+    profile: { email: pluginActionBarSR.querySelector('#user').shadowRoot.querySelector('.user [slot="description"]')?.innerText },
+  };
+  if (pageDetail && publishBtn) await checkAuthorization(pageDetail, publishBtn);
 }

--- a/libs/utils/sidekick.js
+++ b/libs/utils/sidekick.js
@@ -40,5 +40,5 @@ export default function init({ createTag, loadBlock, loadScript, loadStyle }) {
   sk.addEventListener('custom:preflight', preflightListener);
 
   // Color code publish button
-  if (sk.nodeName === 'HELIX-SIDEKICK') stylePublish(sk);
+  stylePublish(sk);
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1064,7 +1064,7 @@ async function checkForPageMods() {
 
 async function loadPostLCP(config) {
   await decoratePlaceholders(document.body.querySelector('header'), config);
-  const sk = document.querySelector('helix-sidekick');
+  const sk = document.querySelector('aem-sidekick, helix-sidekick');
   if (sk) import('./sidekick-decorate.js').then((mod) => { mod.default(sk); });
   if (config.mep?.targetEnabled === 'postlcp') {
     /* c8 ignore next 2 */

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -9,6 +9,10 @@
   ],
   "plugins": [
     {
+      "id": "publish",
+      "confirm": true
+    },
+    {
       "id": "path",
       "title": "Path",
       "environments": [ "edit" ],


### PR DESCRIPTION
* Supports publish permissions in Next-Gen Sidekick
* Enables AEM EDS Publish Confirm option in Next-Gen Sidekick (https://github.com/adobe/aem-sidekick/pull/262)

Resolves: [MWPW-160292](https://jira.corp.adobe.com/browse/MWPW-160292)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/methomas/send-to-caas
- After: https://methomas-sk-publish--milo--adobecom.hlx.page/drafts/methomas/send-to-caas?martech=off

Notes:
- Next-Gen sidekick is required to test
- Publish confirmation functionality isn't testable on lower environments at this time
- To test permissions, you need to be added to the next-gen tab in the [permissions config](https://adobe.sharepoint.com/:x:/r/sites/adobecom/Shared%20Documents/milo/.milo/publish-permissions-config.xlsx?d=w09132f8c4cd24298aeac8d6edb0da648&csf=1&web=1&e=wlTVvZ&nav=MTVfezgwQzQzQURCLTlFRjUtNDYwNi1BQ0ZELUI3MjgwMjM5RkFCQn0)