### PR TITLE
MWPW-161191:  Checkout cli parameter does not get rendered correctly

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -560,6 +560,23 @@ export async function initService(force = false, attributes = {}) {
     fetchCheckoutLinkConfigs.promise = undefined;
   }
   const { commerce, env: miloEnv, locale: miloLocale } = getConfig();
+
+  const extraAttrs = [
+    'checkout-workflow-step',
+    'force-tax-exclusive',
+    'checkout-client-id',
+    'allow-override',
+  ];
+
+  extraAttrs.forEach((attr) => {
+    const camelCaseAttr = attr.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+    // eslint-disable-next-line no-prototype-builtins
+    if (commerce.hasOwnProperty(camelCaseAttr)) {
+      const value = commerce[camelCaseAttr];
+      delete commerce[camelCaseAttr];
+      commerce[attr] = value;
+    }
+  });
   initService.promise = initService.promise ?? polyfills().then(async () => {
     await import('../../deps/mas/commerce.js');
     const { language, locale } = getMiloLocaleSettings(miloLocale);
@@ -629,7 +646,7 @@ export async function getCheckoutContext(el, params) {
 
   return {
     ...context,
-    checkoutClientId,
+    'checkout-client-id': checkoutClientId,
     checkoutWorkflow,
     checkoutWorkflowStep,
     checkoutMarketSegment,

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -571,7 +571,7 @@ export async function initService(force = false, attributes = {}) {
   extraAttrs.forEach((attr) => {
     const camelCaseAttr = attr.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
     // eslint-disable-next-line no-prototype-builtins
-    if (commerce.hasOwnProperty(camelCaseAttr)) {
+    if (commerce?.hasOwnProperty(camelCaseAttr)) {
       const value = commerce[camelCaseAttr];
       delete commerce[camelCaseAttr];
       commerce[attr] = value;

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -646,7 +646,7 @@ export async function getCheckoutContext(el, params) {
 
   return {
     ...context,
-    'checkout-client-id': checkoutClientId,
+    checkoutClientId,
     checkoutWorkflow,
     checkoutWorkflowStep,
     checkoutMarketSegment,

--- a/libs/features/mas/commerce/test/settings.test.js
+++ b/libs/features/mas/commerce/test/settings.test.js
@@ -32,7 +32,7 @@ describe('getSettings', () => {
     });
 
     it('overrides with search parameters', () => {
-      const checkoutClientId = 'adobecom';
+      const checkoutClientId = 'adobe_com';
       const checkoutWorkflowStep = 'segmentation';
       const promotionCode = 'nicopromo';
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -311,10 +311,10 @@ describe('Merch Block', () => {
     it('renders merch link to CTA, config values', async () => {
       setConfig({
         ...config,
-        commerce: { ...config.commerce },
+        commerce: { ...config.commerce, checkoutClientId: 'dc' },
       });
       mockIms();
-      await initService(true, { 'checkout-client-id': 'dc' });
+      await initService(true);
       const el = await merch(document.querySelector('.merch.cta.config'));
       const { dataset, href, nodeName, textContent } = await el.onceSettled();
       const url = new URL(href);


### PR DESCRIPTION
Fixes CLI parameter in checkout links in milo consumer projects like DC, CC.

Resolves: [MWPW-161191](https://jira.corp.adobe.com/browse/MWPW-161191)

Actual test URL (needs to be tested from milo consumer project): https://main--dc--adobecom.hlx.live/acrobat/features?milolibs=MWPW-161191--milo--adobecom

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/merch-card?martech=off
- After: https://MWPW-161191--milo--adobecom.hlx.page/docs/library/kitchen-sink/merch-card?martech=off
