### PR TITLE
MWPW-155723 - Adds group metadata to ensure dyanmic nav continuity 

### DIFF
--- a/libs/features/dynamic-navigation/dynamic-navigation.js
+++ b/libs/features/dynamic-navigation/dynamic-navigation.js
@@ -14,14 +14,26 @@ export function foundDisableValues() {
   return foundValues.length ? foundValues : false;
 }
 
+function dynamicNavGroupMatches(groupMetaData) {
+  const storedGroup = window.sessionStorage.getItem('dynamicNavGroup');
+  if (groupMetaData && storedGroup) return storedGroup === groupMetaData;
+  return false;
+}
+
 export default function dynamicNav(url, key) {
   if (foundDisableValues()) return url;
   const metadataContent = getMetadata('dynamic-nav');
+  const dynamicNavGroup = getMetadata('dynamic-nav-group');
 
   if (metadataContent === 'entry') {
     window.sessionStorage.setItem('gnavSource', url);
     window.sessionStorage.setItem('dynamicNavKey', key);
+    if (dynamicNavGroup) window.sessionStorage.setItem('dynamicNavGroup', dynamicNavGroup);
     return url;
+  }
+
+  if (metadataContent === 'on' && dynamicNavGroup) {
+    if (!dynamicNavGroupMatches(dynamicNavGroup)) return url;
   }
 
   if (metadataContent !== 'on' || key !== window.sessionStorage.getItem('dynamicNavKey')) return url;

--- a/libs/features/dynamic-navigation/dynamic-navigation.js
+++ b/libs/features/dynamic-navigation/dynamic-navigation.js
@@ -16,7 +16,9 @@ export function foundDisableValues() {
 
 function dynamicNavGroupMatches(groupMetaData) {
   const storedGroup = window.sessionStorage.getItem('dynamicNavGroup');
-  if (groupMetaData && storedGroup) return storedGroup === groupMetaData;
+  if (groupMetaData && storedGroup) {
+    return storedGroup.toLowerCase() === groupMetaData.toLowerCase();
+  }
   return false;
 }
 

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -81,7 +81,7 @@ const createStatusWidget = (dynamicNavKey) => {
   const dynamicNavDisableValues = getMetadata('dynamic-nav-disable');
   const foundValues = foundDisableValues();
   const groupMetaSetting = getMetadata('dynamic-nav-group') || 'Group not set';
-  const groupsMatch = groupMetaSetting === window.sessionStorage.getItem('dynamicNavGroup');
+  const groupsMatch = groupMetaSetting.toLowerCase() === window.sessionStorage.getItem('dynamicNavGroup').toLowerCase();
   const groupsMatchMessage = groupsMatch ? 'Yes' : 'No';
   const isDisabled = foundValues.length >= 1 || (!groupsMatch && groupMetaSetting !== 'Group not set');
   const status = getStatus(dynamicNavSetting, isDisabled, storedSource);

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -80,10 +80,12 @@ const createStatusWidget = (dynamicNavKey) => {
   const currentSource = getCurrentSource(dynamicNavSetting, storedSource, authoredSource);
   const dynamicNavDisableValues = getMetadata('dynamic-nav-disable');
   const foundValues = foundDisableValues();
-  const status = getStatus(dynamicNavSetting, foundValues.length >= 1, storedSource);
-  const statusWidget = createTag('div', { class: 'dynamic-nav-status' });
   const groupMetaSetting = getMetadata('dynamic-nav-group') || 'Group not set';
-  const groupsMatch = groupMetaSetting === window.sessionStorage.getItem('dynamicNavGroup') ? 'Yes' : 'No';
+  const groupsMatch = groupMetaSetting === window.sessionStorage.getItem('dynamicNavGroup');
+  const groupsMatchMessage = groupsMatch ? 'Yes' : 'No';
+  const isDisabled = foundValues.length >= 1 || (!groupsMatch && groupMetaSetting !== 'Group not set');
+  const status = getStatus(dynamicNavSetting, isDisabled, storedSource);
+  const statusWidget = createTag('div', { class: 'dynamic-nav-status' });
 
   statusWidget.innerHTML = `
     <span class="title"><span class="dns-badge"></span>Dynamic Nav</span>
@@ -97,7 +99,7 @@ const createStatusWidget = (dynamicNavKey) => {
       <p class="status">Status: <span>${status}</span></p> 
       <p class="setting">Setting: <span>${dynamicNavSetting}</span></p>
       <p class="group">Group: <span>${groupMetaSetting}</span></p>
-      <p class="group-match">Group matches stored group: <span>${groupsMatch}</span></p>
+      <p class="group-match">Group matches stored group: <span>${groupsMatchMessage}</span></p>
       <p class="consumer-key">Consumer key: <span>${dynamicNavKey}</span></p>
       <div class="nav-source-info">
         <p>Authored and stored source match: <span>${authoredSource === currentSource}</span></p>

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -82,6 +82,8 @@ const createStatusWidget = (dynamicNavKey) => {
   const foundValues = foundDisableValues();
   const status = getStatus(dynamicNavSetting, foundValues.length >= 1, storedSource);
   const statusWidget = createTag('div', { class: 'dynamic-nav-status' });
+  const groupMetaSetting = getMetadata('dynamic-nav-group') || 'Group not set';
+  const groupsMatch = groupMetaSetting === window.sessionStorage.getItem('dynamicNavGroup') ? 'Yes' : 'No';
 
   statusWidget.innerHTML = `
     <span class="title"><span class="dns-badge"></span>Dynamic Nav</span>
@@ -94,6 +96,8 @@ const createStatusWidget = (dynamicNavKey) => {
       </div>
       <p class="status">Status: <span>${status}</span></p> 
       <p class="setting">Setting: <span>${dynamicNavSetting}</span></p>
+      <p class="group">Group: <span>${groupMetaSetting}</span></p>
+      <p class="group-match">Group matches stored group: <span>${groupsMatch}</span></p>
       <p class="consumer-key">Consumer key: <span>${dynamicNavKey}</span></p>
       <div class="nav-source-info">
         <p>Authored and stored source match: <span>${authoredSource === currentSource}</span></p>

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1144,26 +1144,9 @@ export async function loadDeferred(area, blocks, config) {
     import('../features/personalization/preview.js')
       .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
   }
-<<<<<<< HEAD
-<<<<<<< HEAD
   if (config?.dynamicNavKey && config?.env?.name !== 'prod') {
-<<<<<<< HEAD
-<<<<<<< HEAD
     const { miloLibs } = config;
     loadStyle(`${miloLibs}/features/dynamic-navigation/status.css`);
-=======
-  if (config?.dynamicNavKey) {
->>>>>>> 2b4175db3 (Adding a dynamic nav status button into the global nav to aid content QA in understanding which nav is active)
-=======
-  if (config?.dynamicNavKey && config?.env?.name !== 'prod') {
->>>>>>> 2294df8a2 (Code review comments: cleaned css and added prod check in loadDeferred to disable status. Updated tests)
-=======
-    const { miloLibs } = getConfig();
-=======
-    const { miloLibs } = config;
->>>>>>> 11ba48fc3 (Change for clarity in utils)
-    loadStyle(`${miloLibs}/features/dynamic-navigation/status.css`);
->>>>>>> d04034194 (Moving styles into utils, as loading within module caused CLS)
     const { default: loadDNStatus } = await import('../features/dynamic-navigation/status.js');
     loadDNStatus();
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1144,9 +1144,26 @@ export async function loadDeferred(area, blocks, config) {
     import('../features/personalization/preview.js')
       .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
   }
+<<<<<<< HEAD
+<<<<<<< HEAD
   if (config?.dynamicNavKey && config?.env?.name !== 'prod') {
+<<<<<<< HEAD
+<<<<<<< HEAD
     const { miloLibs } = config;
     loadStyle(`${miloLibs}/features/dynamic-navigation/status.css`);
+=======
+  if (config?.dynamicNavKey) {
+>>>>>>> 2b4175db3 (Adding a dynamic nav status button into the global nav to aid content QA in understanding which nav is active)
+=======
+  if (config?.dynamicNavKey && config?.env?.name !== 'prod') {
+>>>>>>> 2294df8a2 (Code review comments: cleaned css and added prod check in loadDeferred to disable status. Updated tests)
+=======
+    const { miloLibs } = getConfig();
+=======
+    const { miloLibs } = config;
+>>>>>>> 11ba48fc3 (Change for clarity in utils)
+    loadStyle(`${miloLibs}/features/dynamic-navigation/status.css`);
+>>>>>>> d04034194 (Moving styles into utils, as loading within module caused CLS)
     const { default: loadDNStatus } = await import('../features/dynamic-navigation/status.js');
     loadDNStatus();
   }

--- a/test/features/dynamic-nav/dynamicNav.test.js
+++ b/test/features/dynamic-nav/dynamicNav.test.js
@@ -58,6 +58,24 @@ describe('Dynamic nav', () => {
     expect(url).to.equal('gnav/aem-sites');
   });
 
+  it('Returns the provided url when the group has not been set', async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/on.html' });
+    const url = dynamicNav('gnav/aem-sites', 'bacom');
+    expect(url).to.equal('some-source-string');
+  });
+
+  it('Returns the provided url when the group does not match', async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/on.html' });
+    const groupMeta = document.createElement('meta');
+    groupMeta.setAttribute('name', 'dynamic-nav-group');
+    groupMeta.setAttribute('content', 'test');
+    document.head.appendChild(groupMeta);
+
+    window.sessionStorage.setItem('dynamicNavGroup', 'no-test');
+    const url = dynamicNav('gnav/aem-sites', 'bacom');
+    expect(url).to.equal('gnav/aem-sites');
+  });
+
   it('Returns the sessionStorage url when dynamic nav ignore items are present but do not match the metadata', async () => {
     document.head.innerHTML = await readFile({ path: './mocks/on-ignore-does-not-match.html' });
     const url = dynamicNav('gnav/aem-sites', 'bacom');
@@ -72,6 +90,18 @@ describe('Dynamic nav', () => {
 
   it('Returns the sessionStorage url when dynamic nav ignore metadata content is empty', async () => {
     document.head.innerHTML = await readFile({ path: './mocks/on-ignore-no-content.html' });
+    const url = dynamicNav('gnav/aem-sites', 'bacom');
+    expect(url).to.equal('some-source-string');
+  });
+
+  it('Returns the sessionStorage url when the groups match', async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/on.html' });
+    const groupMeta = document.createElement('meta');
+    groupMeta.setAttribute('name', 'dynamic-nav-group');
+    groupMeta.setAttribute('content', 'test');
+    document.head.appendChild(groupMeta);
+
+    window.sessionStorage.setItem('dynamicNavGroup', 'test');
     const url = dynamicNav('gnav/aem-sites', 'bacom');
     expect(url).to.equal('some-source-string');
   });

--- a/test/features/dynamic-nav/status.test.js
+++ b/test/features/dynamic-nav/status.test.js
@@ -23,7 +23,8 @@ describe('Dynamic Nav Status', () => {
   beforeEach(async () => {
     const conf = { dynamicNavKey: 'bacom' };
     document.body.innerHTML = await readFile({ path: './mocks/status.html' });
-    document.head.innerHTML = '<meta name="dynamic-nav" content=""><meta name="gnav-source" content="">';
+    document.head.innerHTML = '<meta name="dynamic-nav" content=""><meta name="gnav-source" content=""><meta name="dynamic-nav-group" content="test">';
+    window.sessionStorage.setItem('dynamicNavGroup', 'test');
     setConfig(conf);
   });
 
@@ -164,13 +165,6 @@ describe('Dynamic Nav Status', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
       document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
 
-      const groupMeta = document.createElement('meta');
-      groupMeta.setAttribute('name', 'dynamic-nav-group');
-      groupMeta.setAttribute('content', 'test');
-      document.head.appendChild(groupMeta);
-
-      window.sessionStorage.setItem('dynamicNavGroup', 'test');
-
       dynamicNav();
       status();
 
@@ -180,16 +174,12 @@ describe('Dynamic Nav Status', () => {
 
       expect(group.innerText).to.equal('test');
       expect(groupMatch.innerText).to.equal('Yes');
+      expect(statusWidget.classList.contains(ENABLED)).to.be.true;
     });
 
     it('displays the correct information for a group mismatch', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
       document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
-
-      const groupMeta = document.createElement('meta');
-      groupMeta.setAttribute('name', 'dynamic-nav-group');
-      groupMeta.setAttribute('content', 'test');
-      document.head.appendChild(groupMeta);
 
       window.sessionStorage.setItem('dynamicNavGroup', 'no-test');
 
@@ -202,12 +192,14 @@ describe('Dynamic Nav Status', () => {
 
       expect(group.innerText).to.equal('test');
       expect(groupMatch.innerText).to.equal('No');
+      expect(statusWidget.classList.contains(INACTIVE)).to.be.true;
     });
 
     it('displays the correct information for no group being set', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
       document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
 
+      document.querySelector('meta[name="dynamic-nav-group"]').remove();
       window.sessionStorage.setItem('dynamicNavGroup', 'no-test');
 
       dynamicNav();
@@ -219,6 +211,21 @@ describe('Dynamic Nav Status', () => {
 
       expect(group.innerText).to.equal('Group not set');
       expect(groupMatch.innerText).to.equal('No');
+    });
+
+    it('remains active when there is no group match but the nav is active', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+
+      document.querySelector('meta[name="dynamic-nav-group"]').remove();
+      window.sessionStorage.setItem('dynamicNavGroup', 'no-test');
+      window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      expect(statusWidget.classList.contains(ACTIVE)).to.be.true;
     });
   });
 

--- a/test/features/dynamic-nav/status.test.js
+++ b/test/features/dynamic-nav/status.test.js
@@ -159,6 +159,67 @@ describe('Dynamic Nav Status', () => {
       expect(info.authoredSource).to.equal('/test');
       expect(info.storedSource).to.equal('/test');
     });
+
+    it('displays the correct information for a group match', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+
+      const groupMeta = document.createElement('meta');
+      groupMeta.setAttribute('name', 'dynamic-nav-group');
+      groupMeta.setAttribute('content', 'test');
+      document.head.appendChild(groupMeta);
+
+      window.sessionStorage.setItem('dynamicNavGroup', 'test');
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const group = statusWidget.querySelector('.group span');
+      const groupMatch = statusWidget.querySelector('.group-match span');
+
+      expect(group.innerText).to.equal('test');
+      expect(groupMatch.innerText).to.equal('Yes');
+    });
+
+    it('displays the correct information for a group mismatch', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+
+      const groupMeta = document.createElement('meta');
+      groupMeta.setAttribute('name', 'dynamic-nav-group');
+      groupMeta.setAttribute('content', 'test');
+      document.head.appendChild(groupMeta);
+
+      window.sessionStorage.setItem('dynamicNavGroup', 'no-test');
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const group = statusWidget.querySelector('.group span');
+      const groupMatch = statusWidget.querySelector('.group-match span');
+
+      expect(group.innerText).to.equal('test');
+      expect(groupMatch.innerText).to.equal('No');
+    });
+
+    it('displays the correct information for no group being set', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+
+      window.sessionStorage.setItem('dynamicNavGroup', 'no-test');
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const group = statusWidget.querySelector('.group span');
+      const groupMatch = statusWidget.querySelector('.group-match span');
+
+      expect(group.innerText).to.equal('Group not set');
+      expect(groupMatch.innerText).to.equal('No');
+    });
   });
 
   describe('disabled values', () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds the ability to add a group metadata attribute to dynamic nav 
* Groups will allow the nav to be disabled when groups do not match
* Group should not effect nav if not enabled

Resolves: [MWPW-155723](https://jira.corp.adobe.com/browse/MWPW-155723)

**Test URLs:**
- Before: https://main--milo--jasonhowellslavin.hlx.page/drafts/slavin/dynamic-nav/bacom-sample-on?martech=off
- After: https://dynamic-nav-groups--milo--jasonhowellslavin.hlx.page/drafts/slavin/dynamic-nav/bacom-sample-on?martech=off

Bacom
- Before: https://main--bacom--adobecom.hlx.page/drafts/slavin/dynamic-nav/aem-rtcdp-entry?martech=off
- After: https://main--bacom--adobecom.hlx.page/drafts/slavin/dynamic-nav/aem-rtcdp-entry?milolibs=dynamic-nav-groups&martech=off
