### PR TITLE
MWPW-161174 fixed library query param

### DIFF
--- a/libs/blocks/library-config/library-config.js
+++ b/libs/blocks/library-config/library-config.js
@@ -112,9 +112,7 @@ async function loadList(type, content, list) {
   }
 }
 
-async function fetchLibrary(domain) {
-  const { searchParams } = new URL(window.location.href);
-  const suppliedLibrary = searchParams.get('library');
+async function fetchLibrary(domain, suppliedLibrary) {
   const library = suppliedLibrary || `${domain}${LIBRARY_PATH}`;
   try {
     const resp = await fetch(library);
@@ -129,8 +127,9 @@ async function getSuppliedLibrary() {
   const { searchParams } = new URL(window.location.href);
   const repo = searchParams.get('repo');
   const owner = searchParams.get('owner');
+  const library = searchParams.get('library');
   if (!repo || !owner) return null;
-  return fetchLibrary(`https://main--${repo}--${owner}.hlx.live`);
+  return fetchLibrary(`https://main--${repo}--${owner}.hlx.live`, library);
 }
 
 async function fetchAssetsData(path) {


### PR DESCRIPTION
Hi, our `.hlx.live` page is protected with an access.live.allow rule in .config. and because of this we are not able to add our blocks to the library in sidekick. You can find more information here: https://github.com/orgs/adobecom/discussions/3121 

We found that there is a possibility to fetch library blocks data from custom url by adding `library` query param to library URL in `config.json`, but we found the bug in `library-config.js` and because of this bug, custom library URL will be fetched two times, and milo library data will be skipped. 
We propose solution that when `library` query param is present, additional blocks data will  be fetched from custom url specified in this param and then added to existing milo blocks. 

Resolves: [MWPW-161174](https://jira.corp.adobe.com/browse/MWPW-161174)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://library-sidekick--milo--cod17828.hlx.page/?martech=off
**NOTE** my branch link doesn't work i have some issue with setting up AEM sync code 
