### PR TITLE
[MWPW-148000] [ANALYTICS] Add analytics to Modals

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -260,9 +260,6 @@ export default function init(el) {
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
   if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null; // prevent duplicate modal loading
   const details = findDetails(window.location.hash, el);
-  const config = getConfig();
-
-  el.forEach((section, idx) => decorateSectionAnalytics(section, idx, config));
 
   return details ? getModal(details) : null;
 }

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -260,7 +260,6 @@ export default function init(el) {
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
   if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null; // prevent duplicate modal loading
   const details = findDetails(window.location.hash, el);
-
   return details ? getModal(details) : null;
 }
 

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -180,11 +180,7 @@ export async function getModal(details, custom) {
       closeModal(dialog);
     }
   });
-
-  const config = getConfig();
-
-  decorateSectionAnalytics(dialog, `${id}-modal`, config);
-
+  decorateSectionAnalytics(dialog, `${id}-modal`, getConfig());
   dialog.append(close);
   document.body.append(dialog);
   dialogLoadingSet.delete(id);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -216,7 +216,7 @@ export async function getModal(details, custom) {
       iframe.style.height = '100%';
     }
   }
-  
+
   return dialog;
 }
 

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -262,9 +262,7 @@ export default function init(el) {
   const details = findDetails(window.location.hash, el);
   const config = getConfig();
 
-  import('../../martech/attributes.js').then((analytics) => {
-    el.forEach((section, idx) => analytics.decorateSectionAnalytics(section, idx, config));
-  });
+  el.forEach((section, idx) => decorateSectionAnalytics(section, idx, config));
 
   return details ? getModal(details) : null;
 }

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable import/no-cycle */
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
+import { decorateSectionAnalytics } from '../../martech/attributes.js';
 
 const FOCUSABLES = 'a:not(.hide-video), button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
 const CLOSE_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
@@ -180,6 +181,10 @@ export async function getModal(details, custom) {
     }
   });
 
+  const config = getConfig();
+
+  decorateSectionAnalytics(dialog, `${id}-modal`, config);
+
   dialog.append(close);
   document.body.append(dialog);
   dialogLoadingSet.delete(id);
@@ -211,7 +216,7 @@ export async function getModal(details, custom) {
       iframe.style.height = '100%';
     }
   }
-
+  
   return dialog;
 }
 
@@ -255,6 +260,12 @@ export default function init(el) {
   if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
   if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null; // prevent duplicate modal loading
   const details = findDetails(window.location.hash, el);
+  const config = getConfig();
+
+  import('../../martech/attributes.js').then((analytics) => {
+    el.forEach((section, idx) => analytics.decorateSectionAnalytics(section, idx, config));
+  });
+
   return details ? getModal(details) : null;
 }
 

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -82,8 +82,9 @@ export function decorateDefaultLinkAnalytics(block, config) {
 }
 
 export async function decorateSectionAnalytics(section, idx, config) {
+  const id = Number.isNaN(idx) ? `s${idx + 1}` : idx;
   document.querySelector('main')?.setAttribute('daa-im', 'true');
-  section.setAttribute('daa-lh', `s${idx + 1}`);
+  section.setAttribute('daa-lh', id);
   section.querySelectorAll('[data-block] [data-block]').forEach((block) => {
     block.removeAttribute('data-block');
   });

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -82,7 +82,7 @@ export function decorateDefaultLinkAnalytics(block, config) {
 }
 
 export async function decorateSectionAnalytics(section, idx, config) {
-  const id = Number.isNaN(idx) ? `s${idx + 1}` : idx;
+  const id = !Number.isNaN(idx) ? `s${idx + 1}` : idx;
   document.querySelector('main')?.setAttribute('daa-im', 'true');
   section.setAttribute('daa-lh', id);
   section.querySelectorAll('[data-block] [data-block]').forEach((block) => {

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -82,7 +82,7 @@ export function decorateDefaultLinkAnalytics(block, config) {
 }
 
 export async function decorateSectionAnalytics(section, idx, config) {
-  const id = !Number.isNaN(idx) ? `s${idx + 1}` : idx;
+  const id = Number.isNaN(idx) ? `s${idx + 1}` : idx;
   document.querySelector('main')?.setAttribute('daa-im', 'true');
   section.setAttribute('daa-lh', id);
   section.querySelectorAll('[data-block] [data-block]').forEach((block) => {

--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -82,7 +82,7 @@ export function decorateDefaultLinkAnalytics(block, config) {
 }
 
 export async function decorateSectionAnalytics(section, idx, config) {
-  const id = Number.isNaN(idx) ? `s${idx + 1}` : idx;
+  const id = Number.isInteger(idx) ? `s${idx + 1}` : idx;
   document.querySelector('main')?.setAttribute('daa-im', 'true');
   section.setAttribute('daa-lh', id);
   section.querySelectorAll('[data-block] [data-block]').forEach((block) => {

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -109,7 +109,12 @@ describe('Modals', () => {
     window.location.hash = '#milo';
     await waitForElement('#milo');
     init(document.getElementById('milo-modal-link'));
-    expect(document.getElementById('milo')).to.exist;
+    const modal = document.getElementById('milo');
+    expect(modal).to.exist;
+    expect(modal.getAttribute('daa-lh')).to.equal('milo-modal');
+    const buttons = modal.querySelectorAll('button');
+    expect(buttons[0].getAttribute('daa-ll')).to.equal('Milo Button 1-1--Milo');
+    expect(buttons[1].getAttribute('daa-ll')).to.equal('Milo Button 2-2--Milo');
     window.location.hash = '';
     await waitForRemoval('#milo');
     expect(document.getElementById('milo')).not.to.exist;


### PR DESCRIPTION
Analytics are automatically added to main, but are modals outside of main? Modals should have analytics automatically added as well.

- Updated modal creation function to add analytics upon modal creation.
- Update martech function to accept a string or index as the analytic value.

Resolves: [MWPW-148000](https://jira.corp.adobe.com/browse/MWPW-148000)

QA instructions
Check Test modal for daa-lh values and links for daa-ll values. 

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/modalanalytics/marquee
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/modalanalytics/marquee?milolibs=modalanalytics
- Psi: https://modalanalytics--milo--adobecom.hlx.page/?martech=off
