### PR TITLE
Helix 5 support for milo blocks and features

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/gnav.md
+++ b/.github/PULL_REQUEST_TEMPLATE/gnav.md
@@ -32,5 +32,5 @@ Resolves: [MWPW-111111](https://jira.corp.adobe.com/browse/MWPW-111111)
 - After: https://main--blog--adobecom.hlx.page/?milolibs=<branch>--milo--<owner>
 
 **Milo:**
-- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
-- After: https://<branch>--milo--<owner>.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
+- Before: https://main--milo--adobecom.aem.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
+- After: https://<branch>--milo--<owner>.aem.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,5 +7,5 @@
 Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 **Test URLs:**
-- Before: https://main--milo--adobecom.hlx.page/?martech=off
-- After: https://<branch>--milo--adobecom.hlx.page/?martech=off
+- Before: https://main--milo--adobecom.aem.page/?martech=off
+- After: https://<branch>--milo--adobecom.aem.page/?martech=off

--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -44,8 +44,8 @@ let body = `
 **Acrobat:** https://www.stage.adobe.com/acrobat/online/sign-pdf.html
 
 **Milo:**
-- Before: https://main--milo--adobecom.hlx.live/?martech=off
-- After: https://stage--milo--adobecom.hlx.live/?martech=off
+- Before: https://main--milo--adobecom.aem.live/?martech=off
+- After: https://stage--milo--adobecom.aem.live/?martech=off
 `;
 
 const isHighPrio = (labels) => labels.includes(LABELS.highPriority);

--- a/.github/workflows/update-script.js
+++ b/.github/workflows/update-script.js
@@ -50,8 +50,8 @@ Resolves: NO TICKET - AUTOMATED CREATED PR.
 - After: https://main--blog--adobecom.hlx.page/?martech=off&milolibs=${branch}--milo--adobecom
 
 **Milo:**
-- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
-- After: https://${branch}--milo--adobecom.hlx.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off`;
+- Before: https://main--milo--adobecom.aem.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off
+- After: https://${branch}--milo--adobecom.aem.page/ch_de/drafts/ramuntea/gnav-refactor?martech=off`;
 
 const fetchScript = (path) =>
   new Promise((resolve, reject) => {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Ensure that your PR follows the [pull request template](.github/pull_request_tem
 
 * description contains Issue or Ticket
 * description _always_ contains at least one Milo-specific testing URL
-  * `https://<branch>--milo--<user>.hlx.page/?martech=off`
+  * `https://<branch>--milo--<user>.aem.page/?martech=off`
 
 Ensure your PR passes all checks:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Milo is a shared set of features and services to power Franklin-based websites o
 [![codecov](https://codecov.io/gh/adobecom/milo/branch/main/graph/badge.svg?token=a7ZTCbitBt)](https://codecov.io/gh/adobecom/milo)
 
 ## Environments
-[Preview](https://main--milo--adobecom.hlx.page) | [Live](https://milo.adobe.com)
+[Preview](https://main--milo--adobecom.aem.page) | [Live](https://milo.adobe.com)
 
 ## Getting started
 
@@ -51,11 +51,11 @@ You can then test any of the following:
 ```
 http://localhost:3000/?milolibs=local (local code, stage content)
 
-https://main--project--owner.hlx.page/?milolibs=local (prod code, stage content)
+https://main--project--owner.aem.page/?milolibs=local (prod code, stage content)
 
-https://main--project--owner.hlx.live/?milolibs=local (prod code, prod content)
+https://main--project--owner.aem.live/?milolibs=local (prod code, prod content)
 
-https://feat-branch--project--owner.hlx.page/?milolibs=local (feature code, stage content)
+https://feat-branch--project--owner.aem.page/?milolibs=local (feature code, stage content)
 ```
 
 ## Testing

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -2,7 +2,7 @@ coverage:
   status: 
     patch:
       default:
-        target: 100%
+        target: 90%
         threshold: 0.1%
     project:
       default:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,5 +1,5 @@
 version: 1
-# See https://www.hlx.live/docs/setup-indexing.
+# See https://www.aem.live/docs/setup-indexing.
 
 indices:
   wiki:

--- a/libs/blocks/bulk-publish-v2/utils.js
+++ b/libs/blocks/bulk-publish-v2/utils.js
@@ -6,7 +6,7 @@ const checkedIcon = `${base}/blocks/bulk-publish-v2/img/checked.svg`;
 const crossedIcon = `${base}/blocks/bulk-publish-v2/img/crossed.svg`;
 const indicatorIcon = `${base}/blocks/bulk-publish-v2/img/indicator.svg`;
 
-const getHost = (host) => (host === 'localhost' ? 'main--milo--adobecom.hlx.page' : host);
+const getHost = (host) => (host === 'localhost' ? 'main--milo--adobecom.aem.page' : host);
 
 const getStatusIcon = (status) => {
   switch (status) {

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-shadow, consistent-return, max-len, quote-props, prefer-const */
-import { createTag, getConfig, loadMartech } from '../../utils/utils.js';
+import { createTag, getConfig, loadMartech, SLD } from '../../utils/utils.js';
 
 const SEGMENTS_MAP = {
   attributes: {
@@ -195,8 +195,8 @@ function getMetadata(el) {
 
 function isProd() {
   const { host } = window.location;
-  return !(host.includes('hlx.page')
-    || host.includes('hlx.live')
+  return !(host.includes(`${SLD}.page`)
+    || host.includes(`${SLD}.live`)
     || host.includes('localhost')
     || host.includes('stage.adobe')
     || host.includes('corp.adobe'));

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -11,6 +11,7 @@ import {
   getConfig,
   getMetadata,
   parseEncodedConfig,
+  SLD,
 } from '../../utils/utils.js';
 
 const ROOT_MARGIN = 1000;
@@ -61,12 +62,12 @@ const loadCaas = async (a) => {
 
   if (host.includes('stage.adobe') || env?.name === 'local' || caasEndpoint === 'stage') {
     chimeraEndpoint = S_CAAS_AIO;
-  } else if (host.includes('.hlx.') || caasEndpoint === 'prod') {
+  } else if (host.includes(`.${SLD}.`) || caasEndpoint === 'prod') {
     // If invoking URL is not an Acom URL, then switch to AIO
     chimeraEndpoint = P_CAAS_AIO;
   }
 
-  if (host.includes('hlx.page') || env?.name === 'local' || caasContainer === 'draft') {
+  if (host.includes(`${SLD}.page`) || env?.name === 'local' || caasContainer === 'draft') {
     state.draftDb = true;
   }
 

--- a/libs/blocks/library-config/library-config.js
+++ b/libs/blocks/library-config/library-config.js
@@ -1,4 +1,4 @@
-import { createTag } from '../../utils/utils.js';
+import { createTag, SLD } from '../../utils/utils.js';
 
 const LIBRARY_PATH = '/docs/library/library.json';
 
@@ -129,7 +129,7 @@ async function getSuppliedLibrary() {
   const owner = searchParams.get('owner');
   const library = searchParams.get('library');
   if (!repo || !owner) return null;
-  return fetchLibrary(`https://main--${repo}--${owner}.hlx.live`, library);
+  return fetchLibrary(`https://main--${repo}--${owner}.${SLD}.live`, library);
 }
 
 async function fetchAssetsData(path) {

--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -20,6 +20,7 @@ import {
   localizeLink,
   createTag,
   createIntersectionObserver,
+  SLD,
 } from '../../utils/utils.js';
 
 const ROOT_MARGIN = 50;
@@ -56,7 +57,7 @@ export const decorateURL = (destination, baseURL = window.location) => {
       throw new Error('URL does not have a valid host');
     }
 
-    if (destinationUrl.hostname.includes('.hlx.')) {
+    if (destinationUrl.hostname.includes(`.${SLD}.`)) {
       destinationUrl = new URL(`${pathname}${search}${hash}`, baseURL.origin);
     }
 

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1,5 +1,5 @@
 import {
-  createTag, getConfig, loadArea, loadScript, loadStyle, localizeLink,
+  createTag, getConfig, loadArea, loadScript, loadStyle, localizeLink, SLD,
 } from '../../utils/utils.js';
 import { replaceKey } from '../../features/placeholders.js';
 
@@ -240,7 +240,7 @@ export function getMasBase(hostname, maslibs) {
       baseUrl = 'http://localhost:9001';
     } else if (maslibs) {
       const extension = /.page$/.test(hostname) ? 'page' : 'live';
-      baseUrl = `https://${maslibs}.hlx.${extension}`;
+      baseUrl = `https://${maslibs}.${SLD}.${extension}`;
     } else {
       baseUrl = 'https://www.adobe.com/mas';
     }
@@ -493,7 +493,7 @@ export async function openModal(e, url, offerType, hash, extraOptions) {
     }, { once: true });
   }
   if (isInternalModal(url)) {
-    const fragmentPath = url.split(/hlx.(page|live)/).pop();
+    const fragmentPath = url.split(/(hlx|aem).(page|live)/).pop();
     modal = await openFragmentModal(fragmentPath, getModal);
   } else {
     modal = await openExternalModal(url, getModal, extraOptions);

--- a/libs/blocks/ost/README.md
+++ b/libs/blocks/ost/README.md
@@ -22,7 +22,7 @@ perform the following:
 - navigate to adobe.com,
 - open devtools console,
 - execute `copy(adobeIMS.getAccessToken().token)`,
-- add token to OST URL querystring, e.g.: `https://mwpw-127984--milo--vladen.hlx.page/tools/ost?token=eyJhb...`
+- add token to OST URL querystring, e.g.: `https://mwpw-127984--milo--vladen.aem.page/tools/ost?token=eyJhb...`
 
 ## Settings
 

--- a/libs/blocks/pdf-viewer/README.md
+++ b/libs/blocks/pdf-viewer/README.md
@@ -1,7 +1,7 @@
 # PDF Viewer
 
 ## Feature Branch Testing
-The client ids are specific to the origin (no wildcards), so the stage **pdfViewerClientId** only works for **main--milo--adobecom.hlx.page**. If you want to test the pdf on a feature branch, you need to create a new temporary client id. Alternatively, you can name your branch **pdf-viewsdk** and use the existing client id that's set up for **pdf-viewsdk--milo--adobecom.hlx.page**. You can find it in the [developer console](https://developer.adobe.com/console/) under "Milo PDF Viewer Branch".
+The client ids are specific to the origin (no wildcards), so the stage **pdfViewerClientId** only works for **main--milo--adobecom.aem.page**. If you want to test the pdf on a feature branch, you need to create a new temporary client id. Alternatively, you can name your branch **pdf-viewsdk** and use the existing client id that's set up for **pdf-viewsdk--milo--adobecom.aem.page**. You can find it in the [developer console](https://developer.adobe.com/console/) under "Milo PDF Viewer Branch".
 
 How to create a new client id:
 1. Got to https://acrobatservices.adobe.com/dc-integration-creation-app-cdn/main.html?api=pdf-embed-api.

--- a/libs/blocks/pdf-viewer/pdf-viewer.js
+++ b/libs/blocks/pdf-viewer/pdf-viewer.js
@@ -1,6 +1,6 @@
 /* global AdobeDC */
 
-import { createTag, getConfig, loadScript } from '../../utils/utils.js';
+import { createTag, getConfig, loadScript, SLD } from '../../utils/utils.js';
 
 const API_SOURCE_URL = 'https://acrobatservices.adobe.com/view-sdk/viewer.js';
 const PDF_RENDER_DIV_ID = 'adobe-dc-view';
@@ -14,7 +14,7 @@ export const getPdfConfig = () => {
   let clientId = env.consumer?.pdfViewerClientId || env.pdfViewerClientId;
   let reportSuiteId = env.consumer?.pdfViewerReportSuite || env.pdfViewerReportSuite;
 
-  if (host.includes('hlx.live') || query === 'live') {
+  if (host.includes(`${SLD}.live`) || query === 'live') {
     /* c8 ignore next 2 */
     clientId = live?.pdfViewerClientId || CLIENT_ID_LIVE;
     reportSuiteId = live?.pdfViewerReportSuite || env.pdfViewerReportSuite;

--- a/libs/blocks/preflight/panels/seo.js
+++ b/libs/blocks/preflight/panels/seo.js
@@ -227,6 +227,7 @@ async function checkLinks() {
         && !knownBadUrls.some((url) => url === link.hostname) // Is not a known bad url
       ) {
         link.liveHref = link.href.replace('hlx.page', 'hlx.live');
+        link.liveHref = link.href.replace('aem.page', 'aem.live');
         return true;
       }
       return false;
@@ -278,7 +279,7 @@ export async function sendResults() {
   };
 
   await fetch(
-    'https://main--milo--adobecom.hlx.page/seo/preflight',
+    'https://main--milo--adobecom.aem.page/seo/preflight',
     {
       method: 'POST',
       credentials: 'same-origin',

--- a/libs/blocks/quiz-entry/quiz-entry.css
+++ b/libs/blocks/quiz-entry/quiz-entry.css
@@ -178,7 +178,7 @@
 
 .carousel-arrow {
   background-color: #fff;
-  background-image: url('https://main--milo--adobecom.aem.page/libs/blocks/carousel/img/arrow.svg');
+background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='16' viewBox='0 0 10 16'%3E%3Cdefs%3E%3Cstyle%3E.a%7Bfill%3A%23f0f%3Bopacity%3A0%3B%7D.b%7Bfill%3A%23767676%3B%7D%3C/style%3E%3C/defs%3E%3Cg transform='translate(10 16) rotate(180)'%3E%3Crect class='a' width='10' height='16'/%3E%3Cpath class='b' d='M9.115,13.853l0,0L3.051,8,9.117,2.15l0,0A1.246,1.246,0,1,0,7.386.353l0,0L7.367.366h0L.382,7.1l0,0a1.237,1.237,0,0,0,0,1.794l0,0,6.982,6.732,0,0,.015.014,0,0a1.246,1.246,0,1,0,1.73-1.794Z'/%3E%3C/g%3E%3C/svg%3E");
   background-size: 15px; 
   background-position: 50% 50%; 
   background-repeat: no-repeat;

--- a/libs/blocks/quiz-entry/quiz-entry.css
+++ b/libs/blocks/quiz-entry/quiz-entry.css
@@ -178,7 +178,7 @@
 
 .carousel-arrow {
   background-color: #fff;
-  background-image: url('https://main--milo--adobecom.hlx.page/libs/blocks/carousel/img/arrow.svg');
+  background-image: url('https://main--milo--adobecom.aem.page/libs/blocks/carousel/img/arrow.svg');
   background-size: 15px; 
   background-position: 50% 50%; 
   background-repeat: no-repeat;

--- a/libs/blocks/section-metadata/README.md
+++ b/libs/blocks/section-metadata/README.md
@@ -4,5 +4,5 @@
 The card & modal-metadata blocks use this block. If making changes, please ensure there are no breaking changes for those use cases.
 
 ## Test pages
-https://main--milo--adobecom.hlx.page/drafts/cmillar/section-container - Section Metadata
-https://main--milo--adobecom.hlx.page/drafts/methomas/card - Card
+https://main--milo--adobecom.aem.page/drafts/cmillar/section-container - Section Metadata
+https://main--milo--adobecom.aem.page/drafts/methomas/card - Card

--- a/libs/blocks/version-history/index.js
+++ b/libs/blocks/version-history/index.js
@@ -15,6 +15,7 @@ function getSiteOrigin() {
   const search = new URLSearchParams(window.location.search);
   const repo = search.get('repo');
   const owner = search.get('owner');
+  // TODO ADD HLX5 SUPPORT
   return repo && owner ? `https://main--${repo}--${owner}.hlx.live` : window.location.origin;
 }
 

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1,7 +1,9 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-console */
 
-import { createTag, getConfig, loadLink, loadScript, localizeLink } from '../../utils/utils.js';
+import {
+  createTag, getConfig, loadLink, loadScript, localizeLink, SLD,
+} from '../../utils/utils.js';
 import { getFederatedUrl } from '../../utils/federated.js';
 
 /* c8 ignore start */
@@ -75,7 +77,7 @@ export const normalizePath = (p, localize = true) => {
   }
 
   if (path.startsWith(config.codeRoot)
-    || path.includes('.hlx.')
+    || path.includes(`.${SLD}.`)
     || path.includes('.adobe.')) {
     try {
       const url = new URL(path);

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1,9 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-console */
 
-import {
-  createTag, getConfig, loadLink, loadScript, localizeLink, SLD,
-} from '../../utils/utils.js';
+import { createTag, getConfig, loadLink, loadScript, localizeLink } from '../../utils/utils.js';
 import { getFederatedUrl } from '../../utils/federated.js';
 
 /* c8 ignore start */
@@ -77,7 +75,8 @@ export const normalizePath = (p, localize = true) => {
   }
 
   if (path.startsWith(config.codeRoot)
-    || path.includes(`.${SLD}.`)
+    || path.includes('.hlx.')
+    || path.includes('.aem.')
     || path.includes('.adobe.')) {
     try {
       const url = new URL(path);

--- a/libs/features/title-append/README.md
+++ b/libs/features/title-append/README.md
@@ -1,6 +1,6 @@
 # title-append
 
-The title-append feature allows you to append an arbitrary string to an HTML document's title by populating a "title-append" column for any given row in [Franklin's bulk-metadata](https://www.hlx.live/docs/bulk-metadata).
+The title-append feature allows you to append an arbitrary string to an HTML document's title by populating a "title-append" column for any given row in [Franklin's bulk-metadata](https://www.aem.live/docs/bulk-metadata).
 
 ## Example
 

--- a/libs/mep/ace0861/section-metadata/README.md
+++ b/libs/mep/ace0861/section-metadata/README.md
@@ -4,5 +4,5 @@
 The card & modal-metadata blocks use this block. If making changes, please ensure there are no breaking changes for those use cases.
 
 ## Test pages
-https://main--milo--adobecom.hlx.page/drafts/cmillar/section-container - Section Metadata
-https://main--milo--adobecom.hlx.page/drafts/methomas/card - Card
+https://main--milo--adobecom.aem.page/drafts/cmillar/section-container - Section Metadata
+https://main--milo--adobecom.aem.page/drafts/methomas/card - Card

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -18,7 +18,7 @@ const blockConfig = [
 const envMap = {
   prod: 'https://www.adobe.com',
   stage: 'https://www.stage.adobe.com',
-  qa: 'https://gnav--milo--adobecom.hlx.page',
+  qa: 'https://gnav--milo--adobecom.aem.page',
 };
 
 const getStageDomainsMap = (stageDomainsMap) => (
@@ -62,7 +62,7 @@ export default async function loadBlock(configs, customLib) {
     stageDomainsMap = {},
   } = configs || {};
   const branch = new URLSearchParams(window.location.search).get('navbranch');
-  const miloLibs = branch ? `https://${branch}--milo--adobecom.hlx.page` : customLib || envMap[env];
+  const miloLibs = branch ? `https://${branch}--milo--adobecom.aem.page` : customLib || envMap[env];
   if (!header && !footer) {
     // eslint-disable-next-line no-console
     console.error('Global navigation Error: header and footer configurations are missing.');
@@ -78,7 +78,7 @@ export default async function loadBlock(configs, customLib) {
   const paramConfigs = getParamsConfigs(configs, miloLibs);
   const clientConfig = {
     clientEnv: env,
-    origin: `https://main--federal--adobecom.hlx.${env === 'prod' ? 'live' : 'page'}`,
+    origin: `https://main--federal--adobecom.aem.${env === 'prod' ? 'live' : 'page'}`,
     miloLibs: `${miloLibs}/libs`,
     pathname: `/${locale}`,
     locales: configs.locales || locales,

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -27,10 +27,8 @@ export const loadJarvisChat = async (getConfig, getMetadata, loadScript, loadSty
 export const loadPrivacy = async (getConfig, loadScript) => {
   const acom = '7a5eb705-95ed-4cc4-a11d-0cc5760e93db';
   const ids = {
-    'hlx.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271-test',
-    'aem.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271-test',
-    'hlx.live': '926b16ce-cc88-4c6a-af45-21749f3167f3-test',
-    'aem.live': '926b16ce-cc88-4c6a-af45-21749f3167f3-test',
+    '.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271-test',
+    '.live': '926b16ce-cc88-4c6a-af45-21749f3167f3-test',
   };
 
   const otDomainId = ids?.[Object.keys(ids)

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -28,7 +28,9 @@ export const loadPrivacy = async (getConfig, loadScript) => {
   const acom = '7a5eb705-95ed-4cc4-a11d-0cc5760e93db';
   const ids = {
     'hlx.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271-test',
+    'aem.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271-test',
     'hlx.live': '926b16ce-cc88-4c6a-af45-21749f3167f3-test',
+    'aem.live': '926b16ce-cc88-4c6a-af45-21749f3167f3-test',
   };
 
   const otDomainId = ids?.[Object.keys(ids)

--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -27,8 +27,10 @@ export const loadJarvisChat = async (getConfig, getMetadata, loadScript, loadSty
 export const loadPrivacy = async (getConfig, loadScript) => {
   const acom = '7a5eb705-95ed-4cc4-a11d-0cc5760e93db';
   const ids = {
-    '.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271-test',
-    '.live': '926b16ce-cc88-4c6a-af45-21749f3167f3-test',
+    'hlx.page': '3a6a37fe-9e07-4aa9-8640-8f358a623271-test',
+    'hlx.live': '926b16ce-cc88-4c6a-af45-21749f3167f3-test',
+    'aem.page': '01930689-3b6a-7d5f-9797-8df2c3901a05-test',
+    'aem.live': '01930691-c4e5-75ba-aa0e-721e1213c139-test',
   };
 
   const otDomainId = ids?.[Object.keys(ids)

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -41,6 +41,12 @@ const stageDomainsMap = {
     '^https://business.adobe.com/blog': 'https://main--bacom-blog--adobecom.hlx.page',
     '^https://www.adobe.com': 'origin',
   },
+  '^https://.*--milo--.*.aem.page': {
+    '^https://www.adobe.com/acrobat': 'https://main--dc--adobecom.hlx.page',
+    '^https://business.adobe.com(?!/blog)': 'https://business.stage.adobe.com',
+    '^https://business.adobe.com/blog': 'https://main--bacom-blog--adobecom.hlx.page',
+    '^https://www.adobe.com': 'origin',
+  },
 };
 
 const config = {

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -35,13 +35,7 @@ const stageDomainsMap = {
     'business.adobe.com': 'main--bacom--adobecom.hlx.page',
   },
   '.business-graybox.adobe.com': { 'business.adobe.com': 'origin' },
-  '^https://.*--milo--.*.hlx.page': {
-    '^https://www.adobe.com/acrobat': 'https://main--dc--adobecom.hlx.page',
-    '^https://business.adobe.com(?!/blog)': 'https://business.stage.adobe.com',
-    '^https://business.adobe.com/blog': 'https://main--bacom-blog--adobecom.hlx.page',
-    '^https://www.adobe.com': 'origin',
-  },
-  '^https://.*--milo--.*.aem.page': {
+  '^https://.*--milo--.*.*.page': {
     '^https://www.adobe.com/acrobat': 'https://main--dc--adobecom.hlx.page',
     '^https://business.adobe.com(?!/blog)': 'https://business.stage.adobe.com',
     '^https://business.adobe.com/blog': 'https://main--bacom-blog--adobecom.hlx.page',

--- a/libs/utils/federated.js
+++ b/libs/utils/federated.js
@@ -1,4 +1,4 @@
-import { getConfig } from './utils.js';
+import { getConfig, SLD } from './utils.js';
 
 let federatedContentRoot;
 /* eslint-disable import/prefer-default-export */
@@ -19,8 +19,8 @@ export const getFederatedContentRoot = () => {
     ? origin
     : 'https://www.adobe.com';
 
-  if (origin.includes('localhost') || origin.includes('.hlx.')) {
-    federatedContentRoot = `https://main--federal--adobecom.hlx.${origin.endsWith('.live') ? 'live' : 'page'}`;
+  if (origin.includes('localhost') || origin.includes(`.${SLD}.`)) {
+    federatedContentRoot = `https://main--federal--adobecom.aem.${origin.endsWith('.live') ? 'live' : 'page'}`;
   }
 
   return federatedContentRoot;

--- a/libs/utils/service-config.js
+++ b/libs/utils/service-config.js
@@ -2,7 +2,7 @@
  * Get author-facing config options.
  */
 
-import { getConfig } from './utils.js';
+import { getConfig, SLD } from './utils.js';
 
 const DOT_MILO = '/.milo/config.json';
 
@@ -13,7 +13,7 @@ function getSiteOrigin() {
   const search = new URLSearchParams(window.location.search);
   const repo = search.get('repo');
   const owner = search.get('owner');
-  return repo && owner ? `https://main--${repo}--${owner}.hlx.live` : window.location.origin;
+  return repo && owner ? `https://main--${repo}--${owner}.${SLD}.live` : window.location.origin;
 }
 
 /**

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -502,7 +502,7 @@ export function decorateSVG(a) {
   try {
     // Mine for URL and alt text
     const splitText = textContent.split('|');
-    const textUrl = new URL(splitText.shift().trim());
+    const authoredUrl = new URL(splitText.shift().trim());
     const altText = splitText.join('|').trim();
 
     // Relative link checking
@@ -510,12 +510,14 @@ export function decorateSVG(a) {
       ? new URL(`${window.location.origin}${a.href}`)
       : new URL(a.href);
 
-    const src = textUrl.hostname.includes(`.${SLD}.`) ? textUrl.pathname : textUrl;
+    const src = (authoredUrl.hostname.includes('.hlx.') || authoredUrl.hostname.includes('.aem.')) 
+      ? authoredUrl.pathname
+      : authoredUrl;
 
     const img = createTag('img', { loading: 'lazy', src, alt: altText || '' });
     const pic = createTag('picture', null, img);
 
-    if (textUrl.pathname === hrefUrl.pathname) {
+    if (authoredUrl.pathname === hrefUrl.pathname) {
       a.parentElement.replaceChild(pic, a);
       return pic;
     }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -144,7 +144,7 @@ export const MILO_EVENTS = { DEFERRED: 'milo:deferred' };
 const LANGSTORE = 'langstore';
 const PREVIEW = 'target-preview';
 const PAGE_URL = new URL(window.location.href);
-const SLD = PAGE_URL.hostname.includes('.aem.') ? 'aem' : 'hlx';
+export const SLD = PAGE_URL.hostname.includes('.aem.') ? 'aem' : 'hlx';
 
 const PROMO_PARAM = 'promo';
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -510,7 +510,7 @@ export function decorateSVG(a) {
       ? new URL(`${window.location.origin}${a.href}`)
       : new URL(a.href);
 
-    const src = (authoredUrl.hostname.includes('.hlx.') || authoredUrl.hostname.includes('.aem.')) 
+    const src = (authoredUrl.hostname.includes('.hlx.') || authoredUrl.hostname.includes('.aem.'))
       ? authoredUrl.pathname
       : authoredUrl;
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1159,7 +1159,7 @@ function initSidekick() {
 
 function decorateMeta() {
   const { origin } = window.location;
-  const contents = document.head.querySelectorAll(`[content*=".${SLD}."]`);
+  const contents = document.head.querySelectorAll('[content*=".hlx."], [content*=".aem."]');
   contents.forEach((meta) => {
     if (meta.getAttribute('property') === 'hlx:proxyUrl' || meta.getAttribute('name')?.endsWith('schedule')) return;
     try {

--- a/nala/blocks/video/video.spec.js
+++ b/nala/blocks/video/video.spec.js
@@ -67,7 +67,7 @@ module.exports = {
       name: '@Fragment Modal video inline',
       path: '/drafts/nala/blocks/video/fragments-modal-video-autoplay',
       data:
-      { source: 'https://main--milo--adobecom.hlx.live/libs/media_1e798d01c6ddc7e7eadc8f134d69e4f8d7193fdbb.mp4' },
+      { source: 'https://main--milo--adobecom.aem.live/libs/media_1e798d01c6ddc7e7eadc8f134d69e4f8d7193fdbb.mp4' },
       tags: '@video @smoke @regression @milo',
     },
     {

--- a/nala/utils/global.setup.js
+++ b/nala/utils/global.setup.js
@@ -3,7 +3,7 @@
 const { execSync } = require('child_process');
 const { isBranchURLValid } = require('../libs/baseurl.js');
 
-const MAIN_BRANCH_LIVE_URL = 'https://main--milo--adobecom.hlx.live';
+const MAIN_BRANCH_LIVE_URL = 'https://main--milo--adobecom.aem.live';
 const STAGE_BRANCH_URL = 'https://milo.stage.adobe.com';
 
 async function getGitHubPRBranchLiveUrl() {
@@ -29,7 +29,7 @@ async function getGitHubPRBranchLiveUrl() {
   const prFromOrg = process.env.prOrg || toRepoOrg;
   const prFromRepoName = process.env.prRepo || toRepoName;
 
-  const prBranchLiveUrl = `https://${prBranch}--${prFromRepoName}--${prFromOrg}.hlx.live`;
+  const prBranchLiveUrl = `https://${prBranch}--${prFromRepoName}--${prFromOrg}.aem.live`;
 
   try {
     if (await isBranchURLValid(prBranchLiveUrl)) {

--- a/nala/utils/nala.run.js
+++ b/nala/utils/nala.run.js
@@ -99,14 +99,14 @@ function getLocalTestLiveUrl(env, milolibs, owner = 'adobecom') {
     } if (env === 'libs') {
       return 'http://127.0.0.1:6456';
     }
-    return `https://${env}--milo--${owner}.hlx.live`;
+    return `https://${env}--milo--${owner}.aem.live`;
   }
   if (env === 'local') {
     return 'http://127.0.0.1:3000';
   } if (env === 'libs') {
     return 'http://127.0.0.1:6456';
   }
-  return `https://${env}--milo--${owner}.hlx.live`;
+  return `https://${env}--milo--${owner}.aem.live`;
 }
 
 function buildPlaywrightCommand(parsedParams, localTestLiveUrl) {

--- a/nala/utils/pr.run.sh
+++ b/nala/utils/pr.run.sh
@@ -33,6 +33,7 @@ toRepoName=${repoParts[1]}
 prRepo=${prRepo:-$toRepoName}
 prOrg=${prOrg:-$toRepoOrg}
 
+# TODO ADD HLX5 SUPPORT
 PR_BRANCH_LIVE_URL_GH="https://$FEATURE_BRANCH--$prRepo--$prOrg.hlx.live"
 
 # set pr branch url as env

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -49,7 +49,7 @@ const config = {
     baseURL:
       process.env.PR_BRANCH_LIVE_URL
       || process.env.LOCAL_TEST_LIVE_URL
-      || 'https://main--milo--adobecom.hlx.live',
+      || 'https://main--milo--adobecom.aem.live',
   },
 
   /* Configure projects for major browsers */

--- a/test/blocks/aside/mocks/body.html
+++ b/test/blocks/aside/mocks/body.html
@@ -14,7 +14,7 @@
           <h3 id="heading-xl-aside-standard-small-two-lines-1">Heading XL Aside Standard Small two lines.</h3>
           <p>Body S Regular. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
             incididunt ut labore et dolore magna.</p>
-          <p><strong><a href="https://www.hlx.live/" target="_blank">Learn More</a></strong></p>
+          <p><strong><a href="https://www.aem.live/" target="_blank">Learn More</a></strong></p>
         </div>
       </div>
     </div>

--- a/test/blocks/bulk-publish-v2/bulk-publish-v2.test.js
+++ b/test/blocks/bulk-publish-v2/bulk-publish-v2.test.js
@@ -11,7 +11,7 @@ setConfig(conf);
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 const { default: init } = await import('../../../libs/blocks/bulk-publish-v2/bulk-publish-v2.js');
-const testPage = 'https://main--milo--adobecom.hlx.page/tools/bulk-publish-v2-test';
+const testPage = 'https://main--milo--adobecom.aem.page/tools/bulk-publish-v2-test';
 
 Object.defineProperty(navigator, 'clipboard', { value: { writeText: async () => {} } });
 
@@ -114,7 +114,7 @@ describe('Bulk Publish Tool', () => {
   });
 
   it('can handle api error response', async () => {
-    await setTextArea(rootEl, 'https://error--milo--adobecom.hlx.page/not/a/valid/path');
+    await setTextArea(rootEl, 'https://error--milo--adobecom.aem.page/not/a/valid/path');
     await mouseEvent(rootEl.querySelector('#RunProcess'));
     const errors = rootEl.querySelector('.errors');
     expect(errors.querySelector('strong').innerText).to.equal('Unauthorized');
@@ -124,7 +124,7 @@ describe('Bulk Publish Tool', () => {
   it('can trigger cannot publish config', async () => {
     await clock.runAllAsync();
     await setProcess(rootEl, 'publish');
-    await setTextArea(rootEl, 'https://error--milo--adobecom.hlx.page/not/a/valid/path');
+    await setTextArea(rootEl, 'https://error--milo--adobecom.aem.page/not/a/valid/path');
     await mouseEvent(rootEl.querySelector('#RunProcess'));
     const errors = rootEl.querySelector('.errors');
     const errorText = errors?.querySelector('strong').innerText;

--- a/test/blocks/bulk-publish-v2/mocks/response/retry.json
+++ b/test/blocks/bulk-publish-v2/mocks/response/retry.json
@@ -2,7 +2,7 @@
     "webPath": "/tools/bulk-publish-v2-test",
     "resourcePath": "/tools/bulk-publish-v2-test.md",
     "preview": {
-      "url": "https://main--milo--adobecom.hlx.live/tools/bulk-publish-v2-test",
+      "url": "https://main--milo--adobecom.aem.live/tools/bulk-publish-v2-test",
       "status": 200
     },
     "links": {

--- a/test/blocks/caas/mocks/utils.js
+++ b/test/blocks/caas/mocks/utils.js
@@ -25,6 +25,9 @@ export function createIntersectionObserver({ el, callback /* , once = true, opti
   callback(el, { target: el });
 }
 
+const PAGE_URL = new URL(window.location.href);
+export const SLD = PAGE_URL.hostname.includes('.aem.') ? 'aem' : 'hlx';
+
 export const parseEncodedConfig = stub().returns({
   analyticsTrackImpression: false,
   analyticsCollectionName: '',

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -546,7 +546,7 @@ describe('global navigation', () => {
       document.body.replaceChildren(toFragment`<header class="global-navigation"></header>`);
       await initGnav(document.body.querySelector('header'));
       expect(
-        fetchStub.calledOnceWith('https://main--federal--adobecom.hlx.page/federal/path/to/gnav.plain.html'),
+        fetchStub.calledOnceWith('https://main--federal--adobecom.aem.page/federal/path/to/gnav.plain.html'),
       ).to.be.true;
     });
 
@@ -556,7 +556,7 @@ describe('global navigation', () => {
       document.body.replaceChildren(toFragment`<header class="global-navigation"></header>`);
       await initGnav(document.body.querySelector('header'));
       expect(
-        fetchStub.calledOnceWith('https://main--federal--adobecom.hlx.page/federal/path/to/gnav.plain.html'),
+        fetchStub.calledOnceWith('https://main--federal--adobecom.aem.page/federal/path/to/gnav.plain.html'),
       ).to.be.true;
     });
 

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -180,7 +180,7 @@ export const createFullGlobalNavigation = async ({
     if (url.endsWith('large-menu-cross-cloud.plain.html')) { return mockRes({ payload: largeMenuCrossCloud }); }
     if (url.endsWith('large-menu-active.plain.html')) { return mockRes({ payload: largeMenuActiveMock }); }
     if (url.endsWith('large-menu-wide-column.plain.html')) { return mockRes({ payload: largeMenuWideColumnMock }); }
-    if (url.includes('https://main--federal--adobecom.hlx.page')
+    if (url.includes('https://main--federal--adobecom.aem.page')
       && url.endsWith('feds-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
     if (url.includes('gnav')) { return mockRes({ payload: globalNavigation || globalNavigationMock }); }
     if (url.includes('correct-promo-fragment')) { return mockRes({ payload: correctPromoFragmentMock }); }

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -19,7 +19,7 @@ import { setConfig, getConfig } from '../../../../libs/utils/utils.js';
 import { createFullGlobalNavigation, config } from '../test-utilities.js';
 import mepInBlock from '../mocks/mep-config.js';
 
-const baseHost = 'https://main--federal--adobecom.hlx.page';
+const baseHost = 'https://main--federal--adobecom.aem.page';
 describe('global navigation utilities', () => {
   beforeEach(() => {
     document.body.innerHTML = '';

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -206,7 +206,7 @@ describe('global navigation utilities', () => {
     });
   });
 
-  // No tests for using the the live url and .hlx. urls
+  // No tests for using the the live url and .aem. urls
   // as mocking window.location.origin is not possible
   describe('getFedsPlaceholderConfig', () => {
     it('should return contentRoot for localhost', () => {

--- a/test/blocks/marketo/mocks/marketo-utils.js
+++ b/test/blocks/marketo/mocks/marketo-utils.js
@@ -69,3 +69,6 @@ export const loadLink = stub().returns(new Promise((resolve) => {
 }));
 
 export const customFetch = stub();
+
+const PAGE_URL = new URL(window.location.href);
+export const SLD = PAGE_URL.hostname.includes('.aem.') ? 'aem' : 'hlx';

--- a/test/blocks/merch/mocks/embed-utils.js
+++ b/test/blocks/merch/mocks/embed-utils.js
@@ -23,6 +23,9 @@ export function createTag(tag, attributes, html) {
   return el;
 }
 
+const PAGE_URL = new URL(window.location.href);
+export const SLD = PAGE_URL.hostname.includes('.aem.') ? 'aem' : 'hlx';
+
 export const getConfig = () => config;
 
 export const setConfig = (c) => { config = c; };

--- a/test/blocks/ost/mocks/ost-utils.js
+++ b/test/blocks/ost/mocks/ost-utils.js
@@ -106,7 +106,8 @@ function unmockOstDeps() {
 }
 
 const customFetch = window.fetch;
-
+const PAGE_URL = new URL(window.location.href);
+const SLD = PAGE_URL.hostname.includes('.aem.') ? 'aem' : 'hlx';
 export {
   createTag,
   getConfig,
@@ -120,4 +121,5 @@ export {
   unmockOstDeps,
   mockRes,
   customFetch,
+  SLD,
 };

--- a/test/features/personalization/actions.test.js
+++ b/test/features/personalization/actions.test.js
@@ -344,10 +344,10 @@ describe('custom actions', async () => {
             pageFilter: '',
             selectorType: 'in-block:',
           },
-          'https://main--federal--adobecom.hlx.page/federal/fragments/new-sub-menu': {
+          'https://main--federal--adobecom.aem.page/federal/fragments/new-sub-menu': {
             action: 'replace',
             pageFilter: '',
-            content: 'https://main--federal--adobecom.hlx.page/federal/fragments/even-more-new-sub-menu',
+            content: 'https://main--federal--adobecom.aem.page/federal/fragments/even-more-new-sub-menu',
             selectorType: 'in-block:',
             manifestId: false,
             targetManifestId: false,

--- a/test/navigation/mocks/gnav.html
+++ b/test/navigation/mocks/gnav.html
@@ -2,14 +2,14 @@
 <html>
   <head>
     <title>Gnav Brand (Logo)</title>
-    <link rel="canonical" href="https://main--federal--adobecom.hlx.page/federal/globalnav/drafts/blaishram/gnav">
+    <link rel="canonical" href="https://main--federal--adobecom.aem.page/federal/globalnav/drafts/blaishram/gnav">
     <meta property="og:title" content="Gnav Brand (Logo)">
-    <meta property="og:url" content="https://main--federal--adobecom.hlx.page/federal/globalnav/drafts/blaishram/gnav">
-    <meta property="og:image" content="https://main--federal--adobecom.hlx.page/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
-    <meta property="og:image:secure_url" content="https://main--federal--adobecom.hlx.page/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:url" content="https://main--federal--adobecom.aem.page/federal/globalnav/drafts/blaishram/gnav">
+    <meta property="og:image" content="https://main--federal--adobecom.aem.page/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta property="og:image:secure_url" content="https://main--federal--adobecom.aem.page/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Gnav Brand (Logo)">
-    <meta name="twitter:image" content="https://main--federal--adobecom.hlx.page/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
+    <meta name="twitter:image" content="https://main--federal--adobecom.aem.page/default-meta-image.png?width=1200&#x26;format=pjpg&#x26;optimize=medium">
     <meta name="header" content="global-navigation">
     <meta name="footer" content="global-footer">
     <meta name="gnav-source" content="/federal/globalnav/acom/acom-gnav">
@@ -27,7 +27,7 @@
       <div>
         <div class="gnav-brand logo">
           <div>
-            <div><a href="/federal/assets/svgs/adobe-logo.svg">https://main--federal--adobecom.hlx.page/federal/assets/svgs/adobe-logo.svg|Adobe, Inc.</a> <a href="https://www.adobe.com/">Adobe</a></div>
+            <div><a href="/federal/assets/svgs/adobe-logo.svg">https://main--federal--adobecom.aem.page/federal/assets/svgs/adobe-logo.svg|Adobe, Inc.</a> <a href="https://www.adobe.com/">Adobe</a></div>
           </div>
         </div>
       </div>

--- a/test/utils/federated.test.js
+++ b/test/utils/federated.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { getFederatedUrl, getFederatedContentRoot } from '../../libs/utils/federated.js';
 
-const baseHost = 'https://main--federal--adobecom.hlx.page';
+const baseHost = 'https://main--federal--adobecom.aem.page';
 
 describe('Federated navigation utilities', () => {
   describe('getFederatedContentRoot', () => {

--- a/test/utils/mocks/body-gnav.html
+++ b/test/utils/mocks/body-gnav.html
@@ -4,7 +4,7 @@
     <div class="gnav-brand logo">
       <div>
         <div><a
-            href="/federal/assets/svgs/adobe-logo.svg">https://main--federal--adobecom.hlx.page/federal/assets/svgs/adobe-logo.svg|Adobe,
+            href="/federal/assets/svgs/adobe-logo.svg">https://main--federal--adobecom.aem.page/federal/assets/svgs/adobe-logo.svg|Adobe,
             Inc.</a> <a href="https://www.adobe.com/">Adobe</a></div>
       </div>
     </div>

--- a/tools/loc/utils.js
+++ b/tools/loc/utils.js
@@ -81,7 +81,7 @@ export function getUrlInfo() {
     owner,
     repo,
     ref,
-    origin: `https://${ref}--${repo}--${owner}.hlx.page`,
+    origin: `https://${ref}--${repo}--${owner}.hlx.page`, // TODO ADD HLX5 SUPPORT
     isValid() {
       return sp && owner && repo && ref;
     },

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -117,6 +117,7 @@ const processData = async (data, accessToken) => {
   let domain = `https://${host}`;
 
   if (usePreview || publishToFloodgate !== 'default') {
+    // TODO ADD HLX5 SUPPORT
     domain = `https://main--${repo}--${owner}.hlx.live`;
   }
 

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -1,5 +1,5 @@
 import getUuid from '../../libs/utils/getUuid.js';
-import { getMetadata, SLD } from '../../libs/utils/utils.js';
+import { getMetadata } from '../../libs/utils/utils.js';
 import { LOCALES } from '../../libs/blocks/caas/utils.js';
 
 const CAAS_TAG_URL = 'https://www.adobe.com/chimera-api/tags';
@@ -196,7 +196,7 @@ export const getOrigin = (fgColor) => {
     return originLC;
   }
 
-  if (window.location.hostname.endsWith(`.${SLD}.page`)) {
+  if (window.location.hostname.endsWith('.page')) {
     const [, singlePageRepo] = window.location.hostname.split('.')[0].split('--');
     return processRepoForFloodgate(singlePageRepo, fgColor);
   }
@@ -275,7 +275,7 @@ const getBadges = (p) => {
 const isPagePublished = async () => {
   let { branch, repo, owner } = getConfig();
   if (!(branch || repo || owner)
-    && window.location.hostname.endsWith(`.${SLD}.page`)) {
+    && window.location.hostname.endsWith('.page')) {
     [branch, repo, owner] = window.location.hostname.split('.')[0].split('--');
   }
 

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -1,5 +1,5 @@
 import getUuid from '../../libs/utils/getUuid.js';
-import { getMetadata } from '../../libs/utils/utils.js';
+import { getMetadata, SLD } from '../../libs/utils/utils.js';
 import { LOCALES } from '../../libs/blocks/caas/utils.js';
 
 const CAAS_TAG_URL = 'https://www.adobe.com/chimera-api/tags';
@@ -196,7 +196,7 @@ export const getOrigin = (fgColor) => {
     return originLC;
   }
 
-  if (window.location.hostname.endsWith('.hlx.page')) {
+  if (window.location.hostname.endsWith(`.${SLD}.page`)) {
     const [, singlePageRepo] = window.location.hostname.split('.')[0].split('--');
     return processRepoForFloodgate(singlePageRepo, fgColor);
   }
@@ -275,7 +275,7 @@ const getBadges = (p) => {
 const isPagePublished = async () => {
   let { branch, repo, owner } = getConfig();
   if (!(branch || repo || owner)
-    && window.location.hostname.endsWith('.hlx.page')) {
+    && window.location.hostname.endsWith(`.${SLD}.page`)) {
     [branch, repo, owner] = window.location.hostname.split('.')[0].split('--');
   }
 

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -4,7 +4,7 @@
   "libraries": [
     {
       "text": "Blocks",
-      "paths": ["https://main--milo--adobecom.hlx.page/docs/library/blocks.json"]
+      "paths": ["https://main--milo--adobecom.aem.page/docs/library/blocks.json"]
     }
   ],
   "plugins": [
@@ -48,7 +48,7 @@
       "id": "localize-v2",
       "title": "Localize project (V2)",
       "environments": [ "edit" ],
-      "url": "https://locui--milo--adobecom.hlx.page/tools/loc",
+      "url": "https://locui--milo--adobecom.aem.page/tools/loc",
       "passReferrer": true,
       "passConfig": true,
       "excludePaths": [ "/**" ],


### PR DESCRIPTION
Re-raise of https://github.com/adobecom/milo/pull/3122 from adobecom rather than my fork

### Description
- There are a few special cases, such as loc, where I'm unsure about implications of moving certain links to aem.page, hence those simply got a "TODO" for now.
- There are other special cases, such as unit tests, where currently porting to `aem.page` does not make any sense, as our default is `hlx.page` unless detected otherwise. Some other unit tests *needed* to be adapted.
- This should *not* change any production behavior and development behavior apart of potentially pulling content from `.aem.` (federal/milo) rather than `.hlx.`

### Testing instructions
both `https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/` and `https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/` should work and have no differences.

Consuming pages should also not have any difference in experience: https://main--cc--adobecom.hlx.live/de/products/photoshop?milolibs=hlx5-upgrade--milo--adobecom

Lastly, all tools should also be checked (caas, preflight, loc) to ensure we didn't accidentally introduce any errors.

Resolves: [MWPW-157482](https://jira.corp.adobe.com/browse/MWPW-157482)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://hlx5-upgrade--milo--adobecom.aem.page/?martech=off
