### PR TITLE
[MWPW-160719] - Support media only in Editorial-Card

### DIFF
--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -63,6 +63,7 @@
 .editorial-card .foreground picture {
   line-height: 0;
   display: block;
+  height: 100%;
 }
 
 .editorial-card .media-area img,
@@ -72,6 +73,16 @@
   width: 100%;
   height: 100%;
   max-height: var(--card-height-default);
+}
+
+.editorial-card.no-foreground,
+.editorial-card.no-foreground .media-area {
+  height: 100%;
+}
+
+.editorial-card.no-foreground .media-area img,
+.editorial-card.no-foreground .media-area video {
+  max-height: unset;
 }
 
 .editorial-card .media-area .modal-img-link {
@@ -132,6 +143,10 @@
 
 .editorial-card .media-area > div {
   line-height: 0;
+}
+
+.editorial-card.no-foreground .media-area > div {
+  height: 100%;
 }
 
 .editorial-card.footer-align-left .card-footer > div { text-align: start; }

--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -145,6 +145,10 @@
   line-height: 0;
 }
 
+.editorial-card.no-foreground { 
+  border: none;
+}
+
 .editorial-card.no-foreground .media-area > div {
   height: 100%;
 }

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -42,7 +42,15 @@ const decorateMedia = (el, media) => {
 };
 
 const decorateForeground = async (el, rows) => {
+  let isForegroundEmpty = true;
+
   rows.forEach((row, i) => {
+    if (!row.textContent.trim()) {
+      row.remove();
+      return;
+    }
+
+    isForegroundEmpty = false;
     if (i === 0) {
       row.classList.add('foreground');
       decorateLockupFromContent(row);
@@ -55,6 +63,8 @@ const decorateForeground = async (el, rows) => {
     decorateBlockText(row, ['m', 'm', 'm']); // heading, body, detail
     decorateBlockHrs(row);
   });
+
+  if (isForegroundEmpty) el.classList.add('no-foreground');
 };
 
 const decorateBgRow = (el, background, remove = false) => {

--- a/test/blocks/editorial-card/editorial-card.test.js
+++ b/test/blocks/editorial-card/editorial-card.test.js
@@ -42,4 +42,10 @@ describe('editorial-card', () => {
     const lockup = editorialCards[4].classList.contains('m-lockup');
     expect(lockup).to.exist;
   });
+
+  it('media takes full height if no foreground', () => {
+    const editorialCardWithMediaOnly = editorialCards[8];
+    // expect that editorialCardWithMediaOnly has 'no-foreground' class
+    expect(editorialCardWithMediaOnly.classList.contains('no-foreground')).to.be.true;
+  });
 });

--- a/test/blocks/editorial-card/editorial-card.test.js
+++ b/test/blocks/editorial-card/editorial-card.test.js
@@ -45,7 +45,6 @@ describe('editorial-card', () => {
 
   it('media takes full height if no foreground', () => {
     const editorialCardWithMediaOnly = editorialCards[8];
-    // expect that editorialCardWithMediaOnly has 'no-foreground' class
     expect(editorialCardWithMediaOnly.classList.contains('no-foreground')).to.be.true;
   });
 });

--- a/test/blocks/editorial-card/mocks/body.html
+++ b/test/blocks/editorial-card/mocks/body.html
@@ -186,7 +186,11 @@
     </div>
     <div class="editorial-card no-border l-rounded-corners-image">
       <div>
-        <div><a href="./media_13a2002b9279a0df970ee999ad8dd54c4b2a7244d.mp4#_hoverplay">https://main--milo--adobecom.hlx.page/media_13a2002b9279a0df970ee999ad8dd54c4b2a7244d.mp4#_hoverplay</a></div>
+        <div>
+          <picture>
+            <img loading="lazy" alt="" src="./" width="480" height="296">
+          </picture>
+        </div>
       </div>
     </div>
     <div class="editorial-card l-rounded-corners">

--- a/test/blocks/editorial-card/mocks/body.html
+++ b/test/blocks/editorial-card/mocks/body.html
@@ -173,4 +173,58 @@
       </div>
     </div>
   </div>
+
+  <h2>Media Card/ No Foreground</h2>
+  <div class="section">
+    <div class="editorial-card click">
+      <div>
+        <div>
+          <h3 id="row---copy">1 Row - [copy]</h3>
+          <p>no-foreground</p>
+        </div>
+      </div>
+    </div>
+    <div class="editorial-card no-border l-rounded-corners-image">
+      <div>
+        <div><a href="./media_13a2002b9279a0df970ee999ad8dd54c4b2a7244d.mp4#_hoverplay">https://main--milo--adobecom.hlx.page/media_13a2002b9279a0df970ee999ad8dd54c4b2a7244d.mp4#_hoverplay</a></div>
+      </div>
+    </div>
+    <div class="editorial-card l-rounded-corners">
+      <div>
+        <div>transparent</div>
+      </div>
+      <div>
+        <div>
+          <video playsinline="" poster="./" muted="" data-hoverplay="" data-mouseevent="true">
+            <source src="./" type="video/mp4">
+          </video>
+        </div>
+      </div>
+     
+    </div>
+
+    <div class="editorial-card l-rounded-corners">
+      <div>
+        <div>#fafafa</div>
+      </div>
+      <div>
+        <div>
+          <picture>
+            <img loading="lazy" alt="" src="./" width="480" height="296">
+          </picture>
+        </div>
+      </div>
+      
+    </div>
+    <div class="section-metadata">
+      <div>
+        <div>style</div>
+        <div>Four up, m spacing</div>
+      </div>
+      <div>
+        <div>background</div>
+        <div>#f7f7f7</div>
+      </div>
+    </div>
+  </div>
 </main>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->


This PR will add support to have only media in Editorial card. When there is no copy content in the editorial-card, the media will fill the container. 

Resolves: [MWPW-160719](https://jira.corp.adobe.com/browse/MWPW-160719)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/saugat/editorial-card/media-card?martech=off
- After: https://smalla-editorial-card-media-card--milo--adobecom.hlx.page/drafts/saugat/editorial-card/media-card?martech=off