### PR TITLE
[MWPW-160948] Remove blockquote default spacing

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -441,6 +441,10 @@ img {
   height: auto;
 }
 
+blockquote {
+  margin: 0 0 var(--spacing-s) 0;
+}
+
 svg.icon-milo, img.icon-milo {
   height: 1em;
   position: relative;


### PR DESCRIPTION
This ensures that styling texts as Quotes in Word does not add additional spacing in the final UI.

**Context**: accessibility standards require that quoted text be marked as such by using the `blockquote` tag. This can be easily achieved by applying a `Quote` style in Word. However, doing so will result in additional spacing due to the element's default styles. We want to make sure the layout remains consistent with what we have on production today.

**Usage notes**: this concerns simple text or text blocks. The `quote` block in Milo automatically uses the correct markup.

**GWP notes**: authors will need to edit the non-compliant pages and mark the texts surrounded by quotes (`"..."`) as `Quote` in Word. The JIRA story should link to all the non-compliant pages.

**Testing notes**: I've set up a page with the current authoring pattern and the suggested one using the `Quote` style to make sure there is parity. I've included the two most common use-cases isolated as part of the accessibility audit. I've also added an actual `quote` block to demonstrate that its markup is correct.

| Before | After |
| ------------- | ------------- |
| <img width="1113" alt="Screenshot 2024-11-07 at 15 07 47" src="https://github.com/user-attachments/assets/d18d97b1-e984-4461-9db6-52ebab607e86"> | <img width="1113" alt="Screenshot 2024-11-07 at 15 08 04" src="https://github.com/user-attachments/assets/437e88f2-eba3-4952-a4c7-6ab8f587efb8"> |

Resolves: [MWPW-160948](https://jira.corp.adobe.com/browse/MWPW-160948)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/accessibility/quote-markup?martech=off&georouting=off
- After: https://bq-spacing--milo--overmyheadandbody.hlx.page/drafts/ramuntea/accessibility/quote-markup?martech=off&georouting=off
