### PR TITLE
[MWPW-161098] Environment-aware links support for CaaS

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -539,7 +539,7 @@ const getCardsString = async (cards = []) => {
   return uuids.filter(Boolean).join('%2C');
 };
 
-const getStageMapTransformations = (config) => {
+export const stageMapToCaasTransforms = (config) => {
   if (config.env?.name === 'prod' || !config.stageDomainsMap) return {};
   const { href, hostname } = window.location;
   const matchedRules = Object.entries(config.stageDomainsMap)
@@ -758,7 +758,7 @@ export const getConfig = async (originalState, strs = {}) => {
       lastViewedSession: state.lastViewedSession || '',
     },
     customCard: ['card', `return \`${state.customCard}\``],
-    linkTransformer: pageConfig.caasLinkTransformer || getStageMapTransformations(pageConfig),
+    linkTransformer: pageConfig.caasLinkTransformer || stageMapToCaasTransforms(pageConfig),
     headers: caasRequestHeaders,
   };
 

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -8,6 +8,7 @@ import {
   arrayToObj,
   getPageLocale,
   getCountryAndLang,
+  stageMapToCaasTransforms,
 } from '../../../libs/blocks/caas/utils.js';
 
 const mockLocales = ['ar', 'br', 'ca', 'ca_fr', 'cl', 'co', 'la', 'mx', 'pe', '', 'africa', 'be_fr', 'be_en', 'be_nl',
@@ -681,6 +682,26 @@ describe('getConfig', () => {
       },
       linkTransformer: {},
     });
+  });
+
+  it('should pass stageDomainsMap as caasLinkTransformer on stage', async () => {
+    expect(stageMapToCaasTransforms({
+      env: { name: 'stage' },
+      stageDomainsMap: { localhost: { 'www.adobe.com': 'stage.adobe.com', 'business.adobe.com': 'origin' } },
+    })).to.eql({
+      enabled: true,
+      hostnameTransforms: [
+        { from: 'www.adobe.com', to: 'stage.adobe.com' },
+        { from: 'business.adobe.com', to: 'localhost' },
+      ],
+    });
+  });
+
+  it('should not pass stageDomainsMap as caasLinkTransformer on prod', async () => {
+    expect(stageMapToCaasTransforms({
+      env: { name: 'prod' },
+      stageDomainsMap: { localhost: { 'www.adobe.com': 'stage.adobe.com', 'business.adobe.com': 'origin' } },
+    })).to.eql({});
   });
 });
 


### PR DESCRIPTION
## Description
This PR introduces support for CaaS cards within the **environment-aware links** feature.
More info about the **environment-aware links** feature can be found in [this discussion](https://github.com/orgs/adobecom/discussions/2880).

## Related Issue
Resolves: [MWPW-161098](https://jira.corp.adobe.com/browse/MWPW-161098)

## Testing instructions
Using the before and after urls, compare the links to which the CaaS cards are directing to. 
Conversions will be done relative to the `stageDomainsMap` set in [the consumer config](https://github.com/adobecom/milo/blob/stage/libs/scripts/scripts.js#L24L44).

## Screenshots:

**Before**
![Screenshot 2024-11-08 at 11 09 05](https://github.com/user-attachments/assets/3dcc1ad4-1943-4ebb-9d2e-5cc771cd7db7)

**After**
![Screenshot 2024-11-08 at 11 07 30](https://github.com/user-attachments/assets/3a485f1c-de90-4a46-a832-65c16fbfc7de)

## Test URLs
**Milo:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rbogos/caas?martech=off
- After: https://mwpw-160399-caas-support--milo--robert-bogos.hlx.page/drafts/rbogos/caas?martech=off
