### PR TITLE
Global links underlined by default

### DIFF
--- a/libs/blocks/brick/brick.css
+++ b/libs/blocks/brick/brick.css
@@ -185,11 +185,12 @@
 
 .brick.click a.foreground .first-link:not([class*="button"]) {
   color: var(--link-color);
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .brick.click:hover a.foreground .first-link:not([class*="button"]) {
   text-decoration: underline;
+  text-decoration-style: double;
   color: var(--link-hover-color);
 }
 
@@ -198,7 +199,6 @@
 .brick.static-links.click a.foreground .first-link:not([class*="button"]),
 .brick.static-links.click a.foreground a:not([class*="button"]) {
   color: inherit;
-  text-decoration: underline;
 }
 
 .brick.click:hover .first-link.con-button,
@@ -210,6 +210,7 @@
   background-color: var(--color-white);
   color: var(--color-black);
   text-decoration: none;
+  text-decoration-style: double;
 }
 
 .brick.light.click:hover .first-link.con-button,

--- a/libs/blocks/brick/brick.css
+++ b/libs/blocks/brick/brick.css
@@ -185,7 +185,7 @@
 
 .brick.click a.foreground .first-link:not([class*="button"]) {
   color: var(--link-color);
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 .brick.click:hover a.foreground .first-link:not([class*="button"]) {
@@ -198,6 +198,7 @@
 .brick.static-links.click a.foreground .first-link:not([class*="button"]),
 .brick.static-links.click a.foreground a:not([class*="button"]) {
   color: inherit;
+  text-decoration: underline;
 }
 
 .brick.click:hover .first-link.con-button,

--- a/libs/blocks/brick/brick.css
+++ b/libs/blocks/brick/brick.css
@@ -190,7 +190,6 @@
 
 .brick.click:hover a.foreground .first-link:not([class*="button"]) {
   text-decoration: underline;
-  text-decoration-style: double;
   color: var(--link-hover-color);
 }
 
@@ -210,7 +209,6 @@
   background-color: var(--color-white);
   color: var(--color-black);
   text-decoration: none;
-  text-decoration-style: double;
 }
 
 .brick.light.click:hover .first-link.con-button,

--- a/libs/blocks/card-horizontal/card-horizontal.css
+++ b/libs/blocks/card-horizontal/card-horizontal.css
@@ -10,10 +10,15 @@
 
 .card-horizontal a {
   color: var(--text-color);
+  text-decoration: none;
 }
 
 .card-horizontal a:focus {
   outline: none;
+}
+
+.card-horizontal a:hover {
+  text-decoration: none;
 }
 
 .card-horizontal a::after {

--- a/libs/blocks/card-horizontal/card-horizontal.css
+++ b/libs/blocks/card-horizontal/card-horizontal.css
@@ -16,10 +16,6 @@
   outline: none;
 }
 
-.card-horizontal a:hover {
-  text-decoration: none;
-}
-
 .card-horizontal a::after {
   content: '';
   position: absolute;

--- a/libs/blocks/global-footer/global-footer.css
+++ b/libs/blocks/global-footer/global-footer.css
@@ -12,7 +12,6 @@
 }
 
 .global-footer a {
-  color: initial;
   text-decoration: unset;
 }
 

--- a/libs/blocks/global-footer/global-footer.css
+++ b/libs/blocks/global-footer/global-footer.css
@@ -11,6 +11,11 @@
   list-style-type: none;
 }
 
+.global-footer a {
+  color: initial;
+  text-decoration: unset;
+}
+
 .global-footer a:hover {
   text-decoration: none;
 }

--- a/libs/blocks/marquee-anchors/marquee-anchors.css
+++ b/libs/blocks/marquee-anchors/marquee-anchors.css
@@ -100,7 +100,6 @@ html {
 .marquee-anchors .links .anchor-link:focus,
 .marquee-anchors .links .anchor-link:active {
   border-color: var(--link-color);
-  text-decoration: none;
 }
 
 .marquee-anchors .links .anchor-link > div {

--- a/libs/blocks/marquee-anchors/marquee-anchors.css
+++ b/libs/blocks/marquee-anchors/marquee-anchors.css
@@ -74,6 +74,7 @@ html {
   cursor: pointer;
   position: relative;
   color: var(--text-color);
+  text-decoration: none;
 }
 
 .marquee-anchors .links .anchor-link .heading-xs {
@@ -100,6 +101,7 @@ html {
 .marquee-anchors .links .anchor-link:focus,
 .marquee-anchors .links .anchor-link:active {
   border-color: var(--link-color);
+  text-decoration: none;
 }
 
 .marquee-anchors .links .anchor-link > div {

--- a/libs/blocks/text/link-farms.css
+++ b/libs/blocks/text/link-farms.css
@@ -37,8 +37,9 @@
   text-decoration: underline;
 }
 
-.link-farm.text-block a:hover {
+.link-farm.text-block a:is(:hover, :focus) {
   text-decoration-style: double;
+  outline-offset: 3px;
 }
 
 

--- a/libs/styles/iconography.css
+++ b/libs/styles/iconography.css
@@ -50,6 +50,12 @@ dealing w/ groups of media and associated text
 
 .lockup-area > * { line-height: 0; }
 
+.lockup-area a { text-decoration: none; }
+
+.lockup-area a:hover,
+.lockup-area a:focus,
+.lockup-area a:active { text-decoration: underline; }
+
 .center .lockup-area { justify-content: center; }
 .right .lockup-area { justify-content: flex-end; }
 

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -813,7 +813,6 @@ a:hover,
 a:focus, 
 a:active {
   color: var(--link-hover-color);
-  text-decoration-style: double;
 }
 
 /* Links Quiet */

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -734,7 +734,6 @@ header.global-navigation.has-promo {
 }
 
 header.global-navigation a {
-  color: initial;
   text-decoration: unset;
 }
 
@@ -809,8 +808,8 @@ a {
   text-decoration: underline;
 }
 
-a:hover, 
-a:focus, 
+a:hover,
+a:focus,
 a:active {
   color: var(--link-hover-color);
 }

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -733,6 +733,11 @@ header.global-navigation.has-promo {
   min-height: calc(var(--global-height-nav) + var(--global-height-navPromo));
 }
 
+header.global-navigation a {
+  color: initial;
+  text-decoration: unset;
+}
+
 @media (min-width: 900px) {
   header.global-navigation.has-breadcrumbs {
     padding-bottom: var(--global-height-breadcrumbs);
@@ -806,6 +811,7 @@ a {
 
 a:hover {
   color: var(--link-hover-color);
+  text-decoration-style: double;
 }
 
 /* Links Quiet */

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -814,6 +814,9 @@ a:active {
   color: var(--link-hover-color);
 }
 
+a:has(sub:only-child) { text-decoration: unset; }
+a sub:only-child { text-decoration: underline; }
+
 /* Links Quiet */
 a.quiet,
 a.quiet:hover,

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -801,12 +801,17 @@ a.fragment {
 
 a {
   color: var(--link-color);
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 a:hover {
-  text-decoration: underline;
   color: var(--link-hover-color);
+}
+
+/* Links Quiet */
+a.quiet,
+a.quiet:hover {
+  text-decoration: none;
 }
 
 /* Links Static */

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -814,8 +814,8 @@ a:active {
   color: var(--link-hover-color);
 }
 
-a:has(sub:only-child) { text-decoration: unset; }
-a sub:only-child { text-decoration: underline; }
+a:has(> sub:only-child) { text-decoration: unset; }
+a > sub:only-child { text-decoration: underline; }
 
 /* Links Quiet */
 a.quiet,

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -809,28 +809,41 @@ a {
   text-decoration: underline;
 }
 
-a:hover {
+a:hover, 
+a:focus, 
+a:active {
   color: var(--link-hover-color);
   text-decoration-style: double;
 }
 
 /* Links Quiet */
 a.quiet,
-a.quiet:hover {
+a.quiet:hover,
+a.quiet:focus,
+a.quiet:active {
   text-decoration: none;
 }
 
 /* Links Static */
 a.static,
-a.static:hover {
+a.static:hover,
+a.static:focus,
+a.static:active  {
   color: var(--text-color);
-  text-decoration: underline;
 }
 
 .dark a.static,
-.dark a.static:hover {
+.dark a.static:hover,
+.dark a.static:focus,
+.dark a.static:active {
   color: var(--color-white);
-  text-decoration: underline;
+}
+
+:is(h1, h2, h3, h4, h5, h6) a,
+:is(h1, h2, h3, h4, h5, h6) a:hover,
+:is(h1, h2, h3, h4, h5, h6) a:focus,
+:is(h1, h2, h3, h4, h5, h6) a:active {
+  color: currentColor;
 }
 
 /* Buttons */
@@ -840,7 +853,6 @@ a.static:hover {
 
 .static-links a:not([class*="button"]) {
   color: inherit;
-  text-decoration: underline;
 }
 
 .copy-link {


### PR DESCRIPTION
Credits: this is largely based on @ryanmparrish's work [here](https://github.com/adobecom/milo/compare/stage...rparrish/links).

To comply with accessibility standards, we need to adapt link styles to be underlined. The story contains all the details, but here are some highlights:

- any blue link becomes blue and underlined, hover/focus state remains the same;
- any gray link stays gray and underlined, hover/focus state remains the same;
- no action needed for:
    - CTAs;
    - Gnav/Footer;
    - larger elements that act as links.
- links that are part of a link farm receive double underline on hover/focus;
- for links inside headlines, underline and keep the headline's color.

This has a massive blast radius, as links are likely present on each and every adobe.com page, so please test thoroughly. To test, simply append a `milolibs=global-links` query parameter to your `.hlx.` URL.

The PR is marked as `high-impact`, as the JIRA story is marked as critical and needs to go out before the upcoming RCP.

Resolves: [MWPW-145672](https://jira.corp.adobe.com/browse/MWPW-145672)

**Test URLs:**
* Before: <a href="https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/accordion?martech=off&georouting=off">https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/accordion?martech=off&georouting=off</a>
* After: <a href="https://global-links--milo--adobecom.hlx.page/docs/library/kitchen-sink/accordion?martech=off&georouting=off">https://global-links--milo--adobecom.hlx.page/docs/library/kitchen-sink/accordion?martech=off&georouting=off</a>

Check the PR description history for all the relevant kitchen sink links.