### PR TITLE
 [MWPW-161698] - Add two up in mobile for Editorial Card

### DIFF
--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -307,3 +307,11 @@
 
   .editorial-card .vp-media .desktop-only { display: block; }
 }
+
+/* mobile only */
+@media screen and (max-width: 700px) {
+  .section.two-up-mobile:has(.editorial-card) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-xs);
+  }
+}


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

This PR will allow to have two up layout in mobile with `two-up-mobile`. 

Resolves: [MWPW-161698](https://jira.corp.adobe.com/browse/MWPW-161698)

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/saugat/editorial-card/editorial-card-2-up?martech=off
- After: https://smalla-editorial-card-2-up--milo--adobecom.hlx.page/drafts/saugat/editorial-card/editorial-card-2-up?martech=off

Before:
<img width="462" alt="Screenshot 2024-11-08 at 3 25 06 PM" src="https://github.com/user-attachments/assets/c34c233e-4384-4c50-bb58-87ba8bd8d2bd">
After:
<img width="454" alt="Screenshot 2024-11-08 at 3 24 53 PM" src="https://github.com/user-attachments/assets/847a4101-b90c-4913-b2e4-0ef460b44bf7">
