### PR TITLE
MWPW-161606 [MEP] Modify within modals with MEP

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -41,7 +41,7 @@ const updateFragMap = (fragment, a, href) => {
   }
 };
 
-const insertInlineFrag = (sections, a, relHref, mep, handleMepCommands) => {
+const insertInlineFrag = (sections, a, relHref) => {
   // Inline fragments only support one section, other sections are ignored
   const fragChildren = [...sections[0].children];
   if (a.parentElement.nodeName === 'DIV' && !a.parentElement.attributes.length) {
@@ -49,10 +49,7 @@ const insertInlineFrag = (sections, a, relHref, mep, handleMepCommands) => {
   } else {
     a.replaceWith(...fragChildren);
   }
-  fragChildren.forEach((child) => {
-    child.setAttribute('data-path', relHref);
-    if (handleMepCommands) mep.commands = handleMepCommands(mep.commands, child);
-  });
+  fragChildren.forEach((child) => child.setAttribute('data-path', relHref));
 };
 
 function replaceDotMedia(path, doc) {
@@ -132,16 +129,14 @@ export default async function init(a) {
     const { updateFragDataProps } = await import('../../features/personalization/personalization.js');
     updateFragDataProps(a, inline, sections, fragment);
   }
-  let handleMepCommands = false;
   if (mep?.commands?.length) {
     const { handleCommands } = await import('../../features/personalization/personalization.js');
-    handleMepCommands = handleCommands;
+    handleCommands(mep?.commands, fragment, false, true);
   }
   if (inline) {
-    insertInlineFrag(sections, a, relHref, mep, handleMepCommands);
+    insertInlineFrag(sections, a, relHref, mep);
   } else {
     a.parentElement.replaceChild(fragment, a);
-    if (handleMepCommands) handleMepCommands(mep?.commands, fragment);
     await loadArea(fragment);
   }
 }


### PR DESCRIPTION
When loading a modal fragment, the fragment is forced to be inline, and was running commands on each child.  But we need it to run on the entire fragment or we can't modify inside the fragment

Resolves: [MWPW-161606](https://jira.corp.adobe.com/browse/MWPW-161606)

QA instructions: click the "Hello world" button in the marquee to open the modal.  In the after link, the description paragraph read "success ... ???" but is not altered in the before link.
**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepupdatemodal/?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2024/q4/mepupdatemodal/?milolibs=mepupdatemodal&martech=off
- Psi-check: https://mepupdatemodal--milo--adobecom.hlx.page/?martech=off
