### PR TITLE
Fix(mwpw:160737): Favicon fix for safar pinned tab

### DIFF
--- a/libs/utils/favicon.js
+++ b/libs/utils/favicon.js
@@ -6,6 +6,7 @@ export default function loadFavicon(createTag, config, getMetadata) {
   const favicon = document.head.querySelector('link[rel="icon"]');
   const tags = `<link rel="apple-touch-icon" href="${favBase}-180.png">
                 <link rel="icon" href="${favBase}-180.png" sizes="any">
+                <link rel="icon" href="${codeRoot}/img/favicons/safari-pinned-tab.svg" sizes="16x16">
                 <link rel="manifest" href="${favBase}.webmanifest">`;
   favicon.insertAdjacentHTML('afterend', tags);
   favicon.href = `${favBase}.ico`;

--- a/libs/utils/favicon.js
+++ b/libs/utils/favicon.js
@@ -4,9 +4,7 @@ export default function loadFavicon(createTag, config, getMetadata) {
   const favBase = `${codeRoot}/img/favicons/${name}`;
 
   const favicon = document.head.querySelector('link[rel="icon"]');
-  const tags = `<link rel="apple-touch-icon" href="${favBase}-180.png">
-                <link rel="icon" href="${favBase}-180.png" sizes="any">
-                <link rel="icon" href="${codeRoot}/img/favicons/safari-pinned-tab.svg" sizes="16x16">
+  const tags = `<link rel="apple-touch-icon" href="${favBase}-180.png" sizes="any>
                 <link rel="manifest" href="${favBase}.webmanifest">`;
   favicon.insertAdjacentHTML('afterend', tags);
   favicon.href = `${favBase}.ico`;

--- a/libs/utils/favicon.js
+++ b/libs/utils/favicon.js
@@ -4,7 +4,7 @@ export default function loadFavicon(createTag, config, getMetadata) {
   const favBase = `${codeRoot}/img/favicons/${name}`;
 
   const favicon = document.head.querySelector('link[rel="icon"]');
-  const tags = `<link rel="apple-touch-icon" href="${favBase}-180.png" sizes="any>
+  const tags = `<link rel="apple-touch-icon" href="${favBase}-180.png" sizes="any">
                 <link rel="manifest" href="${favBase}.webmanifest">`;
   favicon.insertAdjacentHTML('afterend', tags);
   favicon.href = `${favBase}.ico`;

--- a/libs/utils/favicon.js
+++ b/libs/utils/favicon.js
@@ -5,6 +5,7 @@ export default function loadFavicon(createTag, config, getMetadata) {
 
   const favicon = document.head.querySelector('link[rel="icon"]');
   const tags = `<link rel="apple-touch-icon" href="${favBase}-180.png">
+                <link rel="icon" href="${favBase}-180.png" sizes="any">
                 <link rel="manifest" href="${favBase}.webmanifest">`;
   favicon.insertAdjacentHTML('afterend', tags);
   favicon.href = `${favBase}.ico`;


### PR DESCRIPTION
* safari fav icons will display favicon-180.png as fallback for safari version 16.

Resolves: [MWPW-160737](https://jira.corp.adobe.com/browse/MWPW-160737)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/?martech=off
- After: https://favicon--milosh--sharath-kannan.hlx.live/?martech=off
cc test url
 https://mwpw-160737--cc--sharath-kannan.hlx.live/creativecloud?milolibs=favicon--milosh--sharath-kannan
