### PR TITLE
MWPW-160510 - Expand icon tooltip functionality

### DIFF
--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -71,9 +71,9 @@ function filterDuplicatedIcons(icons) {
 }
 
 function handleLegacyToolTip(icons) {
-  const legacies = [...icons].filter((icon) => icon.classList.contains('icon-tooltip'));
-  if (!legacies.length) return;
-  icons.forEach((icon) => icon.classList.replace('icon-tooltip', 'icon-info-outline'));
+  const tooltips = [...icons].filter((icon) => icon.classList.contains('icon-tooltip'));
+  if (!tooltips.length) return;
+  tooltips.forEach((icon) => icon.classList.replace('icon-tooltip', 'icon-info-outline'));
 }
 
 export async function decorateIcons(icons, config) {

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -70,10 +70,10 @@ function filterDuplicatedIcons(icons) {
   return uniqueIcons;
 }
 
-function handleLegacyToolTip(icons) {
+export function handleLegacyToolTip(icons, iconClass = 'icon-info-outline') {
   const tooltips = [...icons].filter((icon) => icon.classList.contains('icon-tooltip'));
   if (!tooltips.length) return;
-  tooltips.forEach((icon) => icon.classList.replace('icon-tooltip', 'icon-info-outline'));
+  tooltips.forEach((icon) => icon.classList.replace('icon-tooltip', iconClass));
 }
 
 export async function decorateIcons(icons, config) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -793,9 +793,11 @@ const findReplaceableNodes = (area) => {
     let matchFound = false;
     if (node.nodeType === Node.TEXT_NODE) {
       matchFound = regex.test(node.nodeValue);
-    } else if (node.nodeType === Node.ELEMENT_NODE && node.hasAttribute('href')) {
-      const hrefValue = node.getAttribute('href');
-      matchFound = regex.test(hrefValue);
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const attr = node.getAttribute('href') || node.getAttribute('data-tooltip');
+      if (attr) {
+        matchFound = regex.test(attr);
+      }
     }
     if (matchFound) {
       nodes.push(node);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1250,8 +1250,15 @@ async function resolveInlineFrags(section) {
   section.preloadLinks = newlyDecoratedSection.preloadLinks;
 }
 
-export function setIconsIndexClass(icons) {
+export function setIconAttrs(icons) {
   [...icons].forEach((icon) => {
+    const em = icon.closest('em');
+    const conf = em?.textContent.split('|');
+    if (em && conf.length) {
+      icon.dataset.tooltip = conf?.pop()?.trim();
+      icon.dataset.tooltipdir = conf?.pop()?.trim().toLowerCase() || 'right';
+      em.parentElement.replaceChild(icon, em);
+    }
     const parent = icon.parentNode;
     const children = parent.childNodes;
     const nodeIndex = [...children].indexOf.call(children, icon);
@@ -1303,7 +1310,7 @@ export async function loadArea(area = document) {
 
   const allIcons = area.querySelectorAll('span.icon');
   if (allIcons.length) {
-    setIconsIndexClass(allIcons);
+    setIconAttrs(allIcons);
   }
 
   const sections = decorateSections(area, isDoc);
@@ -1320,7 +1327,7 @@ export async function loadArea(area = document) {
 
   if (allIcons.length) {
     const { default: loadIcons, decorateIcons } = await import('../features/icons/icons.js');
-    await decorateIcons(area, allIcons, config);
+    await decorateIcons(allIcons, config);
     await loadIcons(allIcons);
   }
 

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -4,7 +4,7 @@ import sinon, { stub } from 'sinon';
 import { waitForElement } from '../../helpers/waitfor.js';
 
 const { default: loadIcons, getIconData } = await import('../../../libs/features/icons/icons.js');
-const { setIconsIndexClass } = await import('../../../libs/utils/utils.js');
+const { setIconAttrs } = await import('../../../libs/utils/utils.js');
 const mockRes = ({ payload, status = 200, ok = true } = {}) => new Promise((resolve) => {
   resolve({
     status,
@@ -48,7 +48,7 @@ describe('Icon Suppprt', () => {
 
   it('Sets icon index class', async () => {
     icons = document.querySelectorAll('span.icon');
-    setIconsIndexClass(icons);
+    setIconAttrs(icons);
     const secondIconHasIndexClass = icons[2].classList.contains('node-index-last');
     expect(secondIconHasIndexClass).to.be.true;
   });

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -1,9 +1,9 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import sinon, { stub } from 'sinon';
+import { stub } from 'sinon';
 import { waitForElement } from '../../helpers/waitfor.js';
 
-const { default: loadIcons, getIconData } = await import('../../../libs/features/icons/icons.js');
+const { default: loadIcons, getIconData, handleLegacyToolTip } = await import('../../../libs/features/icons/icons.js');
 const { setIconAttrs } = await import('../../../libs/utils/utils.js');
 const mockRes = ({ payload, status = 200, ok = true } = {}) => new Promise((resolve) => {
   resolve({
@@ -22,33 +22,32 @@ const svgEx = `<?xml version="1.0" encoding="UTF-8"?>
   <path fill="currentcolor" d="M12,10V1.5a.5.5,0,0,0-.5-.5h-5a.5.5,0,0,0-.5.5V10H2.5035a.25.25,0,0,0-.177.427L9,17.1l6.673-6.673A.25.25,0,0,0,15.4965,10Z"></path>
 </svg>`;
 
-describe('Icon Suppprt', () => {
-  beforeEach(() => {
-    stub(window, 'fetch').callsFake(() => mockRes({}));
-  });
-
-  afterEach(() => {
-    sinon.restore();
-  });
-
-  it('Replaces span.icon', async () => {
+describe('Icon Support', () => {
+  let fetchStub;
+  before(async () => {
     const payload = svgEx;
-    window.fetch.returns(mockRes({ payload }));
-
+    fetchStub = stub(window, 'fetch').callsFake(() => mockRes({ payload }));
     icons = document.querySelectorAll('span.icon');
+    setIconAttrs(icons);
+    handleLegacyToolTip(icons, 'icon-play');
     icons.forEach((icon) => {
       const { name } = getIconData(icon);
       icon.dataset.name = name;
     });
     await loadIcons(icons);
+  });
 
+  after(() => {
+    fetchStub.restore();
+  });
+
+  it('Replaces span.icon', async () => {
     const selector = await waitForElement('span.icon svg');
     expect(selector).to.exist;
   });
 
   it('Sets icon index class', async () => {
     icons = document.querySelectorAll('span.icon');
-    setIconAttrs(icons);
     const secondIconHasIndexClass = icons[2].classList.contains('node-index-last');
     expect(secondIconHasIndexClass).to.be.true;
   });

--- a/test/features/icons/mocks/body.html
+++ b/test/features/icons/mocks/body.html
@@ -12,7 +12,7 @@
     <p>This is text w/ an <span class="icon icon-play"></span> in the middle  of the paragraph.</p>
     <p><em><span class="icon icon-tooltip"></span> | This is my tooltip text.</em></p>
     <p><em><span class="icon icon-tooltip"></span> | top | This is my tooltip text.</em></p>
-    <p><em><span class="icon icon-call-center"></span>| Tooltip on icon</em></p>
+    <p><em><span class="icon icon-play"></span>| left | This is my tooltip text.</em></p>
   </div>
 </main>
 <footer></footer>

--- a/test/features/icons/mocks/body.html
+++ b/test/features/icons/mocks/body.html
@@ -12,6 +12,7 @@
     <p>This is text w/ an <span class="icon icon-play"></span> in the middle  of the paragraph.</p>
     <p><em><span class="icon icon-tooltip"></span> | This is my tooltip text.</em></p>
     <p><em><span class="icon icon-tooltip"></span> | top | This is my tooltip text.</em></p>
+    <p><em><span class="icon icon-call-center"></span>| Tooltip on icon</em></p>
   </div>
 </main>
 <footer></footer>


### PR DESCRIPTION
Extends the current milo tooltip functionality to be able to use it on other icons besides the information icon. Tooltips will now also be considered in placeholder decoration, so you can use placeholders as tooltip content.

**Authoring**
To author icon tooltips the icon should append the desired position/text separated by `|` and then be _italicized_.
**_example_**: _`:lock: | top | Desired tooltip text`_

**Backwards compatibility**
This is supporting legacy tooltip authoring by updating all `:tooltip:` icons to use the `:info-outline:` icon. (Legacy implementation uses same position/text authoring)

Resolves: [MWPW-160510](https://jira.corp.adobe.com/browse/MWPW-160510)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/milo-tooltips?martech=off
- After: https://sartxi-mwpw-160510-tooltip--milo--adobecom.hlx.page/drafts/sarchibeque/milo-tooltips?martech=off
