### PR TITLE
MWPW-162093 [MEP][NALA] add 2 more legacy tests

### DIFF
--- a/nala/features/personalization/personalization.spec.js
+++ b/nala/features/personalization/personalization.spec.js
@@ -40,5 +40,21 @@ module.exports = {
       },
       tags: '@pzn @smoke @regression @milo ',
     },
+    {
+      tcid: '3',
+      name: '@Replace Fragment',
+      desc: 'Personalization with action=replaceFragment',
+      path: '/drafts/nala/features/personalization/legacy/replace-fragment',
+      data: { defaultURLpath: '/drafts/nala/features/personalization/legacy/replace-fragment?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Flegacy%2Freplace-fragment.json--default' },
+      tags: '@pzn @pzn3 @smoke @regression @milo ',
+    },
+    {
+      tcid: '4',
+      name: '@Remove Content',
+      desc: 'Personalization with action=removeContent',
+      path: '/drafts/nala/features/personalization/legacy/remove-content',
+      data: { defaultURLpath: '/drafts/nala/features/personalization/legacy/remove-content?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Flegacy%2Fremove-content.json--default' },
+      tags: '@pzn @pzn4 @smoke @regression @milo ',
+    },
   ],
 };

--- a/nala/features/personalization/personalization.test.js
+++ b/nala/features/personalization/personalization.test.js
@@ -134,4 +134,47 @@ test.describe('Milo Personalization feature test suite', () => {
       await expect(await text.text).toHaveAttribute('daa-lh', textBlockDll);
     });
   });
+  // Test 3 : Personalization (replaceFragment)
+  test(`${features[3].name},${features[3].tags}`, async ({ page, baseURL }) => {
+    text = new TextBlock(page);
+    marquee = new MarqueeBlock(page);
+    const { data } = features[3];
+    const pznURL = `${baseURL}${features[3].path}${miloLibs}`;
+    const defaultURL = `${baseURL}${data.defaultURLpath}&${miloLibs}`;
+
+    await test.step('step-1: Navigate to default page and verify content/specs', async () => {
+      console.info(`[Test Page]: ${defaultURL}`);
+      await page.goto(defaultURL);
+      await expect(text.introHeadlineAlt).toContainText('This text block will be replaced');
+      await expect(marquee.marquee).toHaveCount(0);
+    });
+
+    await test.step('step-2: Navigate to personalized page and verify content/specs', async () => {
+      console.info(`[Test Page]: ${pznURL}`);
+      await page.goto(pznURL);
+      await expect(text.introHeadlineAlt).toHaveCount(0);
+      await expect(marquee.marquee).toContainText('This is a new marquee, replacing the text block');
+    });
+  });
+
+  // Test 4 : Personalization (remove content)
+  test(`${features[4].name},${features[4].tags}`, async ({ page, baseURL }) => {
+    howto = new Howto(page);
+    const { data } = features[4];
+    const pznURL = `${baseURL}${features[4].path}${miloLibs}`;
+    const defaultURL = `${baseURL}${data.defaultURLpath}&${miloLibs}`;
+
+    await test.step('step-1: Navigate to default page and verify content/specs', async () => {
+      console.info(`[Test Page]: ${defaultURL}`);
+      await page.goto(defaultURL);
+      await expect(howto.heading).toContainText('THIS HEADING WILL BE REMOVED');
+      await expect(howto.heading).toBeVisible();
+    });
+
+    await test.step('step-2: Navigate to personalized page and verify content/specs', async () => {
+      console.info(`[Test Page]: ${pznURL}`);
+      await page.goto(pznURL);
+      await expect(howto.heading).not.toBeVisible();
+    });
+  });
 });

--- a/nala/features/personalization/personalization.test.js
+++ b/nala/features/personalization/personalization.test.js
@@ -159,7 +159,7 @@ test.describe('Milo Personalization feature test suite', () => {
 
   // Test 4 : Personalization (remove content)
   test(`${features[4].name},${features[4].tags}`, async ({ page, baseURL }) => {
-    howto = new Howto(page);
+    text = new TextBlock(page);
     const { data } = features[4];
     const pznURL = `${baseURL}${features[4].path}${miloLibs}`;
     const defaultURL = `${baseURL}${data.defaultURLpath}&${miloLibs}`;
@@ -167,14 +167,14 @@ test.describe('Milo Personalization feature test suite', () => {
     await test.step('step-1: Navigate to default page and verify content/specs', async () => {
       console.info(`[Test Page]: ${defaultURL}`);
       await page.goto(defaultURL);
-      await expect(howto.heading).toContainText('THIS HEADING WILL BE REMOVED');
-      await expect(howto.heading).toBeVisible();
+      await expect(text.introHeadlineAlt).toContainText('This heading will be removed in the personalization');
+      await expect(text.introHeadlineAlt).toBeVisible();
     });
 
     await test.step('step-2: Navigate to personalized page and verify content/specs', async () => {
       console.info(`[Test Page]: ${pznURL}`);
       await page.goto(pznURL);
-      await expect(howto.heading).not.toBeVisible();
+      await expect(text.introHeadlineAlt).not.toBeVisible();
     });
   });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

This PR adds 2 legacy tests to the personalization.test.js file using an old version of a MEP manifest: removeContent and replaceFragment

Resolves: [MWPW-162093](https://jira.corp.adobe.com/browse/MWPW-162093)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://legacy2--milo--adobecom.hlx.page/?martech=off

Test pages:
https://main--milo--adobecom.hlx.live/drafts/nala/features/personalization/legacy/remove-content
and the default version: https://main--milo--adobecom.hlx.live/drafts/nala/features/personalization/legacy/remove-content?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Flegacy%2Fremove-content.json--default
https://main--milo--adobecom.hlx.page/drafts/nala/features/personalization/legacy/replace-fragment
and the default version of the above: https://main--milo--adobecom.hlx.page/drafts/nala/features/personalization/legacy/replace-fragment?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Flegacy%2Freplace-fragment.json--default