### PR TITLE
MWPW-157506: Localized Placeholder Texts on English Pages

### DIFF
--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -70,7 +70,7 @@ async function getPlaceholder(key, config, sheet) {
   let placeholders;
 
   if (geoLocDisabled === 'on') {
-    placeholders = await getDefaultPlaceholders();
+    placeholders = await getDefaultPlaceholders().catch(() => ({}));
   } else {
     placeholders = await fetchPlaceholders({ config, sheet });
   }

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -72,10 +72,7 @@ async function getPlaceholder(key, config, sheet) {
   if (geoLocDisabled === 'on') {
     placeholders = await getDefaultPlaceholders();
   } else {
-    placeholders = await fetchPlaceholders({ config, sheet }).catch(async () => {
-      const defaultPlaceholders = await getDefaultPlaceholders();
-      return defaultPlaceholders;
-    });
+    placeholders = await fetchPlaceholders({ config, sheet });
   }
 
   if (typeof placeholders?.[key] === 'string') return placeholders[key];

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -1,4 +1,4 @@
-import { customFetch, getConfig } from '../utils/utils.js';
+import { customFetch, getConfig, getMetadata } from '../utils/utils.js';
 
 const fetchedPlaceholders = {};
 window.mph = {};
@@ -35,6 +35,7 @@ function keyToStr(key) {
 async function getPlaceholder(key, config, sheet) {
   let defaultFetched = false;
   const defaultLocale = 'en-US';
+  const geoLocDisabled = getMetadata('disable-geo-placeholders') || 'off';
 
   const getDefaultContentRoot = () => {
     const defaultContentRoot = config.locale.contentRoot;
@@ -66,11 +67,16 @@ async function getPlaceholder(key, config, sheet) {
   };
 
   if (config.placeholders?.[key]) return config.placeholders[key];
+  let placeholders;
 
-  const placeholders = await fetchPlaceholders({ config, sheet }).catch(async () => {
-    const defaultPlaceholders = await getDefaultPlaceholders();
-    return defaultPlaceholders;
-  });
+  if (geoLocDisabled === 'on') {
+    placeholders = await getDefaultPlaceholders();
+  } else {
+    placeholders = await fetchPlaceholders({ config, sheet }).catch(async () => {
+      const defaultPlaceholders = await getDefaultPlaceholders();
+      return defaultPlaceholders;
+    });
+  }
 
   if (typeof placeholders?.[key] === 'string') return placeholders[key];
 

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -70,7 +70,7 @@ async function getPlaceholder(key, config, sheet) {
   let placeholders;
 
   if (geoLocDisabled === 'on') {
-    placeholders = await getDefaultPlaceholders().catch(() => ({}));
+    placeholders = await getDefaultPlaceholders();
   } else {
     placeholders = await fetchPlaceholders({ config, sheet });
   }

--- a/test/features/placeholders/bg/placeholders.json
+++ b/test/features/placeholders/bg/placeholders.json
@@ -1,0 +1,20 @@
+{
+  "total": 2,
+  "offset": 0,
+  "limit": 2,
+  "data": [
+    {
+      "key": "add-to-cart",
+      "value": "Добавяне в количката",
+      "color": "",
+      "url": ""
+    },
+    {
+      "key": "adobe-apps",
+      "value": "Приложения на Adobe",
+      "color": "",
+      "url": ""
+    }
+  ],
+  ":type": "sheet"
+}

--- a/test/features/placeholders/placeholders.json
+++ b/test/features/placeholders/placeholders.json
@@ -22,6 +22,18 @@
     {
       "key": "empty-value",
       "value": ""
+    },
+    {
+      "key": "add-to-cart",
+      "value": "Add to cart",
+      "color": "",
+      "url": ""
+    },
+    {
+      "key": "adobe-apps",
+      "value": "Adobe Apps",
+      "color": "",
+      "url": ""
     }
   ],
   ":type": "sheet"

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -72,4 +72,27 @@ describe('Placeholders', () => {
     expect(tag.getAttribute('href')).to.equal('/modal/800 12345 6789');
     expect(tag.getAttribute('data-attr')).to.equal('/modal/800 12345 6789');
   });
+
+  it('Replaces geo-specific placeholders when disable-geo-placeholders meta content is "off" or meta tag not defined', async () => {
+    config.locale.contentRoot = '/test/features/placeholders/bg';
+    const regex = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
+    let text = '{{add-to-cart}}. {{adobe-apps}}';
+    text = await replaceText(text, config, regex);
+    expect(text).to.equal('Добавяне в количката. Приложения на Adobe');
+  });
+
+  it('Replaces default placeholders when disable-geo-placeholders meta content is "on"', async () => {
+    const meta = document.createElement('meta');
+    meta.name = 'disable-geo-placeholders';
+    meta.content = 'on';
+    document.head.appendChild(meta);
+
+    config.locale.contentRoot = '/test/features/placeholders/bg';
+    config.locale.prefix = '/bg';
+    const regex = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
+    let text = '{{add-to-cart}}. {{adobe-apps}}';
+    text = await replaceText(text, config, regex);
+    document.head.removeChild(meta);
+    expect(text).to.equal('Add to cart. Adobe Apps');
+  });
 });

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -32,9 +32,8 @@ describe('Placeholders', () => {
 
   it('Replaces text & links', async () => {
     config.locale.contentRoot = '/test/features/placeholders';
-    const regex = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
     let text = 'Hello world {{recommended-for-you}} and {{no-results}}. Call tel: %7B%7Bphone-number%7D%7D';
-    text = await replaceText(text, config, regex);
+    text = await replaceText(text, config);
     expect(text).to.equal('Hello world Recommended for you and No results found. Call tel: 800 12345 6789');
   });
 
@@ -75,9 +74,8 @@ describe('Placeholders', () => {
 
   it('Replaces geo-specific placeholders when disable-geo-placeholders meta content is "off" or meta tag not defined', async () => {
     config.locale.contentRoot = '/test/features/placeholders/bg';
-    const regex = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
     let text = '{{add-to-cart}}. {{adobe-apps}}';
-    text = await replaceText(text, config, regex);
+    text = await replaceText(text, config);
     expect(text).to.equal('Добавяне в количката. Приложения на Adobe');
   });
 
@@ -89,9 +87,8 @@ describe('Placeholders', () => {
 
     config.locale.contentRoot = '/test/features/placeholders/bg';
     config.locale.prefix = '/bg';
-    const regex = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
     let text = '{{add-to-cart}}. {{adobe-apps}}';
-    text = await replaceText(text, config, regex);
+    text = await replaceText(text, config);
     document.head.removeChild(meta);
     expect(text).to.equal('Add to cart. Adobe Apps');
   });


### PR DESCRIPTION
* Adds functionality to conditionally use geo-specific placeholders based on `disable-geo-placeholders` meta tag. 
* If the tag is absent or set to `"off"`, the application receives geo-specific placeholders. If the tag is set to `"on"`, it defaults to generic placeholders.

Resolves: [MWPW-157506](https://jira.corp.adobe.com/browse/MWPW-157506)

GH: https://github.com/orgs/adobecom/discussions/2791

## Test URLs:

**Milo**
- Before: https://main--milo--adobecom.hlx.page/drafts/siva/157506/placeholder-example
- After: https://mwpw-157506--milo--sivasadobe.hlx.page/drafts/siva/157506/placeholder-example

**CC**
- Before: https://main--cc--adobecom.hlx.page/bg/drafts/siva/157506/elements-family?martech=off
- After: https://main--cc--adobecom.hlx.page/bg/drafts/siva/157506/elements-family?milolibs=mwpw-157506--milo--sivasadobe&martech=off
