### PR TITLE
[MWPW-162258][NALA] Increase GitHub Test Execution Worker Count for Nala to Improve Execution Speed

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,7 +31,7 @@ const config = {
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 6 : 3,
+  workers: process.env.CI ? 10 : 3,
   /* Reporter to use. */
   reporter: process.env.CI
     ? [['github'], ['list'], ['./nala/utils/base-reporter.js']]

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,7 +31,7 @@ const config = {
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 8 : 3,
+  workers: process.env.CI ? 7 : 3,
   /* Reporter to use. */
   reporter: process.env.CI
     ? [['github'], ['list'], ['./nala/utils/base-reporter.js']]

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,7 +31,7 @@ const config = {
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 10 : 3,
+  workers: process.env.CI ? 8 : 3,
   /* Reporter to use. */
   reporter: process.env.CI
     ? [['github'], ['list'], ['./nala/utils/base-reporter.js']]


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Increase the GitHub worker count to `[ 7 ]` to support more parallel execution.
* Validate that execution time is significantly reduced from the current 8-minute duration.


Resolves: [MWPW-162258](https://jira.corp.adobe.com/browse/MWPW-162258)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://nala-workers--milo--adobecom.hlx.page/?martech=off
