### PR TITLE
Revert "Global links underlined by default"

### DIFF
--- a/libs/blocks/card-horizontal/card-horizontal.css
+++ b/libs/blocks/card-horizontal/card-horizontal.css
@@ -10,7 +10,6 @@
 
 .card-horizontal a {
   color: var(--text-color);
-  text-decoration: none;
 }
 
 .card-horizontal a:focus {

--- a/libs/blocks/global-footer/global-footer.css
+++ b/libs/blocks/global-footer/global-footer.css
@@ -11,10 +11,6 @@
   list-style-type: none;
 }
 
-.global-footer a {
-  text-decoration: unset;
-}
-
 .global-footer a:hover {
   text-decoration: none;
 }

--- a/libs/blocks/marquee-anchors/marquee-anchors.css
+++ b/libs/blocks/marquee-anchors/marquee-anchors.css
@@ -74,7 +74,6 @@ html {
   cursor: pointer;
   position: relative;
   color: var(--text-color);
-  text-decoration: none;
 }
 
 .marquee-anchors .links .anchor-link .heading-xs {

--- a/libs/blocks/text/link-farms.css
+++ b/libs/blocks/text/link-farms.css
@@ -37,9 +37,8 @@
   text-decoration: underline;
 }
 
-.link-farm.text-block a:is(:hover, :focus) {
+.link-farm.text-block a:hover {
   text-decoration-style: double;
-  outline-offset: 3px;
 }
 
 

--- a/libs/styles/iconography.css
+++ b/libs/styles/iconography.css
@@ -50,12 +50,6 @@ dealing w/ groups of media and associated text
 
 .lockup-area > * { line-height: 0; }
 
-.lockup-area a { text-decoration: none; }
-
-.lockup-area a:hover,
-.lockup-area a:focus,
-.lockup-area a:active { text-decoration: underline; }
-
 .center .lockup-area { justify-content: center; }
 .right .lockup-area { justify-content: flex-end; }
 

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -720,10 +720,6 @@ header.global-navigation.has-promo {
   min-height: calc(var(--global-height-nav) + var(--global-height-navPromo));
 }
 
-header.global-navigation a {
-  text-decoration: unset;
-}
-
 @media (min-width: 900px) {
   header.global-navigation.has-breadcrumbs {
     padding-bottom: var(--global-height-breadcrumbs);
@@ -792,46 +788,25 @@ a.fragment {
 
 a {
   color: var(--link-color);
-  text-decoration: underline;
-}
-
-a:hover,
-a:focus,
-a:active {
-  color: var(--link-hover-color);
-}
-
-a:has(> sub:only-child) { text-decoration: unset; }
-a > sub:only-child { text-decoration: underline; }
-
-/* Links Quiet */
-a.quiet,
-a.quiet:hover,
-a.quiet:focus,
-a.quiet:active {
   text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+  color: var(--link-hover-color);
 }
 
 /* Links Static */
 a.static,
-a.static:hover,
-a.static:focus,
-a.static:active  {
+a.static:hover {
   color: var(--text-color);
+  text-decoration: underline;
 }
 
 .dark a.static,
-.dark a.static:hover,
-.dark a.static:focus,
-.dark a.static:active {
+.dark a.static:hover {
   color: var(--color-white);
-}
-
-:is(h1, h2, h3, h4, h5, h6) a,
-:is(h1, h2, h3, h4, h5, h6) a:hover,
-:is(h1, h2, h3, h4, h5, h6) a:focus,
-:is(h1, h2, h3, h4, h5, h6) a:active {
-  color: currentColor;
+  text-decoration: underline;
 }
 
 /* Buttons */
@@ -841,6 +816,7 @@ a.static:active  {
 
 .static-links a:not([class*="button"]) {
   color: inherit;
+  text-decoration: underline;
 }
 
 .copy-link {


### PR DESCRIPTION
This reverts [#3166](https://github.com/adobecom/milo/pull/3166)

- Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/accordion?martech=off&georouting=off
- After: https://revert-3166-global-links--milo--adobecom.hlx.page/docs/library/kitchen-sink/accordion?martech=off&georouting=off