### PR TITLE
[MWPW-145672] Change link color only on hover

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -795,9 +795,7 @@ a {
   text-decoration: underline;
 }
 
-a:hover,
-a:focus,
-a:active {
+a:hover {
   color: var(--link-hover-color);
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

https://github.com/adobecom/milo/pull/3166 introduced an issue where the blue color is applied to links on focus and active. This change will remove the states and will only keep hover.

Resolves: [MWPW-145672](https://jira.corp.adobe.com/browse/MWPW-145672)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/accordion?martech=off&georouting=off
- After: https://mwpw-145672-fix--milo--narcis-radu.hlx.page/docs/library/kitchen-sink/accordion?martech=off&georouting=off

Additional test URLs
- https://main--bacom--adobecom.hlx.page/products/real-time-customer-data-platform/rtcdp?milolibs=mwpw-145672-fix--milo--narcis-radu
- see previous PR for testing
