### PR TITLE
MWPW-162305: [Black Friday] CTA not visible on CRM due to sticky banner

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -27,7 +27,7 @@
 }
 
 .dialog-modal.commerce-frame {
-  z-index: 103;
+  z-index: 40002;
 }
 
 .dialog-modal.delayed-modal {
@@ -98,7 +98,7 @@
   bottom: 0;
   left: 0;
   background: rgb(50 50 50 / 80%);
-  z-index: 101;
+  z-index: 40001;
 }
 
 .dialog-modal button.dialog-close {


### PR DESCRIPTION
Increasing z-index for `.commerce-frame` modals and modal curtains to overlap the promo banner.
The issue with modal URLs is fixed in this related CC PR: https://github.com/adobecom/cc/pull/450 .

Resolves: [MWPW-162305](https://jira.corp.adobe.com/browse/MWPW-162305)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/ca/products/aftereffects?instant=2024-11-15T14:00:00.000Z
- After: https://mwpw-162305-modal-sticky-banner  --cc--adobecom.hlx.page/ca/products/aftereffects?milolibs=mwpw-162305-modal-sticky-banner--milo--mirafedas&instant=2024-11-15T14:00:00.000Z
(Added spaces after branch name to make links invisible for PSI check, this change does not influence performance)
For PSI check:
https://mwpw-162305-modal-sticky-banner--milo--mirafedas.hlx.live?martech=off&georouting=off
