### PR TITLE
MWPW-141870: Update seotech-video-url API endpoint

### DIFF
--- a/libs/features/seotech/README.md
+++ b/libs/features/seotech/README.md
@@ -1,10 +1,12 @@
-# SEOTECH
+# seotech
 
-Collection of SEO-related features that use the SEOTECH service.
+Collection of SEO-related features that use the `seotech` service.
 See [structured-data](https://milo.adobe.com/docs/authoring/structured-data) for authoring documentation including examples.
-See [SEOTECH Wiki](https://wiki.corp.adobe.com/display/seoteam/SEOTECH) for documentation regarding the service.
+See [seotech](https://git.corp.adobe.com/pages/wcms/seotech/) for documentation regarding the service.
 
-## Video
+## Usage
+
+### Video
 
 This feature selects a video url from the page then queries the SEOTECH service for structured data.
 If a valid VideoObject is returned then it is appended to the head of the document as JSON-LD.
@@ -21,7 +23,7 @@ Video Platforms:
 
 See [video-metadata](../../blocks/video-metadata/) if you need to define a specific VideoObject on your page.
 
-## Structured Data
+### Structured Data
 
 This feature queries the SEOTECH service for adhoc structured data that should be added to the page.
 
@@ -30,3 +32,65 @@ Metadata Properties:
 - `seotech-structured-data`: `on` to enable SEOTECH lookup
 
 See [Structured Data for Milo](https://wiki.corp.adobe.com/x/YpPwwg) (Corp Only) for complete documentation.
+
+<!-- MARK: dev -->
+## Development
+
+### Proxy
+
+adobe.com proxies the `/seotech` (Milo) endpoints of the seotech API:
+
+- Production: https://www.adobe.com/seotech/api/
+- Stage: https://www.stage.adobe.com/seotech/api/
+
+We always use production seotech regardless of Milo environment.
+
+### Unit Tests
+
+Test seotech only:
+
+    npm run test:file -- test/features/seotech/seotech.test.js
+
+### JSON-LD
+
+You can confirm expected JSON-LD is on you page using console:
+
+    Array.from(document.querySelectorAll('script[type="application/ld+json"]')).map((el) => JSON.parse(el.innerText))
+
+### seotech-video-url
+
+Proxy Examples:
+
+- Adobe: https://www.adobe.com/seotech/api/json-ld/types/video-object/providers/adobe/26535
+- YouTube: https://www.adobe.com/seotech/api/json-ld/types/video-object/providers/youtube/dQw4w9WgXcQ
+- Error (400 Bad Provider): https://www.adobe.com/seotech/api/json-ld/types/video-object/providers/foo/bar
+- Error (404 Not Found): https://www.adobe.com/seotech/api/json-ld/types/video-object/providers/youtube/lolz
+
+#### Test Pages
+
+Create/edit test pages as necessary: [milo/drafts/seotech/features/seotech-video](https://adobe.sharepoint.com/:f:/r/sites/adobecom/Shared%20Documents/milo/drafts/seotech/milo/features/seotech-video?csf=1&web=1&e=OWVZmT)
+
+Develop with `aem up` using local urls:
+
+- http://localhost:3000/drafts/seotech/milo/features/seotech-video/adobe
+- http://localhost:3000/drafts/seotech/milo/features/seotech-video/youtube
+- http://localhost:3000/drafts/seotech/milo/features/seotech-video/error
+
+Test your development branch once you push.
+Remember to change _stage_ and _adobecom_ to your own branch and user as needed:
+
+- https://stage--milo--adobecom.aem.page/drafts/seotech/milo/features/seotech-video/adobe
+- https://stage--milo--adobecom.aem.page/drafts/seotech/milo/features/seotech-video/youtube
+- https://stage--milo--adobecom.aem.page/drafts/seotech/milo/features/seotech-video/error
+
+Test stage urls once your PR is merged into stage:
+
+- https://milo.stage.adobe.com/drafts/seotech/milo/features/seotech-video/adobe
+- https://milo.stage.adobe.com/drafts/seotech/milo/features/seotech-video/youtube
+- https://milo.stage.adobe.com/drafts/seotech/milo/features/seotech-video/error
+
+Test production urls once stage is merged into main:
+
+- https://milo.adobe.com/drafts/seotech/milo/features/seotech-video/adobe
+- https://milo.adobe.com/drafts/seotech/milo/features/seotech-video/youtube
+- https://milo.adobe.com/drafts/seotech/milo/features/seotech-video/error

--- a/libs/features/seotech/seotech.js
+++ b/libs/features/seotech/seotech.js
@@ -1,6 +1,9 @@
 export const SEOTECH_API_URL_PROD = 'https://14257-seotech.adobeioruntime.net';
 export const SEOTECH_API_URL_STAGE = 'https://14257-seotech-stage.adobeioruntime.net';
 
+export const REGEX_ADOBETV = /(?:https?:\/\/)?(?:stage-)?video.tv.adobe.com\/v\/([\d]+)/;
+export const REGEX_YOUTUBE = /(?:https?:\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be)\/(?:watch\?v=)?([a-zA-Z0-9_-]+)/;
+
 export function logError(msg) {
   window.lana?.log(`SEOTECH: ${msg}`, {
     debug: false,

--- a/test/features/seotech/seotech.test.js
+++ b/test/features/seotech/seotech.test.js
@@ -80,7 +80,6 @@ describe('sha256', () => {
   });
 });
 
-
 describe('seotech', () => {
   describe('appendScriptTag + seotech-structured-data', () => {
     beforeEach(async () => {
@@ -153,13 +152,13 @@ describe('seotech', () => {
       await appendScriptTag(
         { locationUrl: window.location.href, getMetadata, getConfig, createTag },
       );
-      expect(lanaStub.calledOnceWith('SEOTECH: Failed to construct \'URL\': Invalid URL')).to.be.true;
+      expect(lanaStub.calledOnceWith('SEOTECH: Invalid video url: fake')).to.be.true;
     });
 
     it('should not append JSON-LD if url not found', async () => {
       const lanaStub = stub(window.lana, 'log');
       const getMetadata = stub().returns(null);
-      getMetadata.withArgs('seotech-video-url').returns('http://fake');
+      getMetadata.withArgs('seotech-video-url').returns('https://youtu.be/fake');
       const fetchStub = stub(window, 'fetch');
       fetchStub.returns(Promise.resolve(Response.json(
         { error: 'ERROR!' },
@@ -169,7 +168,7 @@ describe('seotech', () => {
         { locationUrl: window.location.href, getMetadata, getConfig, createTag },
       );
       expect(fetchStub.calledOnceWith(
-        'https://14257-seotech-stage.adobeioruntime.net/api/v1/web/seotech/getVideoObject?url=http://fake/',
+        'https://www.adobe.com/seotech/api/json-ld/types/video-object/providers/youtube/fake',
       )).to.be.true;
       expect(lanaStub.calledOnceWith('SEOTECH: Failed to fetch video: ERROR!')).to.be.true;
     });
@@ -178,7 +177,7 @@ describe('seotech', () => {
       const lanaStub = stub(window.lana, 'log');
       const fetchStub = stub(window, 'fetch');
       const getMetadata = stub().returns(null);
-      getMetadata.withArgs('seotech-video-url').returns('http://fake');
+      getMetadata.withArgs('seotech-video-url').returns('https://youtu.be/dQw4w9WgXcQ');
       const expectedVideoObject = {
         '@context': 'http://schema.org',
         '@type': 'VideoObject',
@@ -192,7 +191,7 @@ describe('seotech', () => {
         { locationUrl: window.location.href, getMetadata, getConfig, createTag },
       );
       expect(fetchStub.calledOnceWith(
-        'https://14257-seotech-stage.adobeioruntime.net/api/v1/web/seotech/getVideoObject?url=http://fake/',
+        'https://www.adobe.com/seotech/api/json-ld/types/video-object/providers/youtube/dQw4w9WgXcQ',
       )).to.be.true;
       const el = await waitForElement('script[type="application/ld+json"]');
       const obj = JSON.parse(el.text);

--- a/test/features/seotech/seotech.test.js
+++ b/test/features/seotech/seotech.test.js
@@ -6,7 +6,71 @@ import { getConfig, createTag } from '../../../libs/utils/utils.js';
 import {
   appendScriptTag,
   sha256,
+  REGEX_ADOBETV,
+  REGEX_YOUTUBE,
 } from '../../../libs/features/seotech/seotech.js';
+
+describe('REGEX_ADOBETV', () => {
+  const testCases = [
+    {
+      url: 'https://video.tv.adobe.com/v/26535',
+      expected: '26535',
+    },
+    {
+      url: 'https://video.tv.adobe.com/v/26535/',
+      expected: '26535',
+    },
+    {
+      url: 'https://stage-video.tv.adobe.com/v/26535',
+      expected: '26535',
+    },
+    {
+      url: 'https://blah.com/26535',
+      expected: null,
+    },
+  ];
+  testCases.forEach(({ url, expected }) => {
+    it(`should ${expected ? 'parse' : 'not parse'} adobetv url: ${url}`, () => {
+      const match = url.match(REGEX_ADOBETV);
+      if (expected) {
+        expect(match[1]).to.equal(expected);
+      } else {
+        expect(match).to.be.null;
+      }
+    });
+  });
+});
+
+describe('REGEX_YOUTUBE', () => {
+  const testCases = [
+    {
+      url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      expected: 'dQw4w9WgXcQ',
+    },
+    {
+      url: 'https://youtube.com/watch?v=dQw4w9WgXcQ',
+      expected: 'dQw4w9WgXcQ',
+    },
+    {
+      url: 'https://youtu.be/dQw4w9WgXcQ',
+      expected: 'dQw4w9WgXcQ',
+    },
+    {
+      url: 'https://www.example.com/watch?v=dQw4w9WgXcQ',
+      expected: null,
+    },
+  ];
+  testCases.forEach(({ url, expected }) => {
+    it(`should ${expected ? 'parse' : 'not parse'} youtube url: ${url}`, () => {
+      const match = url.match(REGEX_YOUTUBE);
+      if (expected) {
+        expect(match[1]).to.equal(expected);
+      } else {
+        expect(match).to.be.null;
+      }
+    });
+  });
+});
 
 describe('sha256', () => {
   it('should return a hash', async () => {
@@ -15,6 +79,7 @@ describe('sha256', () => {
     expect(hash).to.equal('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
   });
 });
+
 
 describe('seotech', () => {
   describe('appendScriptTag + seotech-structured-data', () => {

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -673,7 +673,7 @@ describe('Utils', () => {
     it('should append to title using string from metadata', async () => {
       const expected = 'Document Title NOODLE';
       await utils.loadArea();
-      await waitFor(() => document.title === expected);
+      await waitFor(() => document.title === expected, 2000);
       expect(document.title).to.equal(expected);
     });
   });
@@ -687,10 +687,10 @@ describe('Utils', () => {
       window.lana.release?.();
     });
     it('should import feature when metadata is defined and error if invalid', async () => {
-      const expectedError = 'SEOTECH: Failed to construct \'URL\': Invalid URL';
+      const expectedError = 'SEOTECH: Invalid video url: FAKE';
       await utils.loadArea();
       const lanaStub = sinon.stub(window.lana, 'log');
-      await waitFor(() => lanaStub.calledOnceWith(expectedError));
+      await waitFor(() => lanaStub.calledOnceWith(expectedError), 2000);
       expect(lanaStub.calledOnceWith(expectedError)).to.be.true;
     });
   });


### PR DESCRIPTION
Update `seotech-video-url` feature to use new version of API endpoint behind adobe.com.

Resolves: [MWPW-141870](https://jira.corp.adobe.com/browse/MWPW-141870)

## Context

I update the implementation of the [seotech-video-url](https://milo.adobe.com/docs/authoring/features/seotech-video-url) feature to use a new version of seotech API endpoint which allows for proper caching and sits behind adobe.com. We now parse video urls locally first and call the endpoint if url is supported. There are no visible changes to the user.

I also update the seotech README for future developers.

## Testing

### Unit

I updated all unit tests and added extensive tests for regex.

### E2E

Use the following snippet in dev console to confirm added VideoObject JSON-LD on each non-error page:

```js
Array.from(document.querySelectorAll('script[type="application/ld+json"]')).map((el) => JSON.parse(el.innerText))
```

Before URLs:

- tv.adobe: https://main--milo--adobecom.hlx.page/drafts/seotech/milo/features/seotech-video/adobe?martech=off
- youtube: https://main--milo--adobecom.hlx.page/drafts/seotech/milo/features/seotech-video/youtube?martech=off
- error: https://main--milo--adobecom.hlx.page/drafts/seotech/milo/features/seotech-video/error?martech=off

After URLs:

- tv.adobe: (Omitted because Adobe TV embed itself scores poorly on mobile)/drafts/seotech/milo/features/seotech-video/adobe?martech=off
-  youtube: https://MWPW-141870-1--milo--hparra.hlx.page/drafts/seotech/milo/features/seotech-video/youtube?martech=off
- error: https://MWPW-141870-1--milo--hparra.hlx.page/drafts/seotech/milo/features/seotech-video/error?martech=off
