### PR TITLE
DOTCOM-140152 - Update helix-query for Blog usage

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -99,4 +99,4 @@ indices:
       lastModified:
         select: none
         value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT') 
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -88,6 +88,10 @@ indices:
         select: head > meta[property="article:tag"]
         values: |
           attribute(el, 'content')
+      category:
+        select: head > meta[property="category"]
+        values: |
+          attribute(el, 'content')
       robots:
         select: head > meta[name="robots"]
         value: |

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -65,9 +65,9 @@ indices:
         value: |
           attribute(el, 'content')
       title:
-        select: main h1:first-of-type
+        select: head > meta[property="og:title"]
         value: |
-          textContent(el)
+          attribute(el, 'content')
       date:
         select: head > meta[name="publication-date"]
         value: |

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -60,19 +60,43 @@ indices:
       - '/blog/drafts/**'
     target: /blog/query-index.xlsx
     properties:
-      title:
-        select: head > meta[property="og:title"]
+      author:
+        select: head > meta[name="author"]
         value: |
           attribute(el, 'content')
+      title:
+        select: main h1:first-of-type
+        value: |
+          textContent(el)
+      date:
+        select: head > meta[name="publication-date"]
+        value: |
+          dateValue(attribute(el, 'content'), 'MM-DD-YYYY')
       image:
         select: head > meta[property="og:image"]
         value: |
           match(attribute(el, 'content'), 'https:\/\/[^/]+(\/.*)')
+      imageAlt:
+        select: head > meta[property="og:image:alt"]
+        value: |
+          attribute(el, 'content')
       description:
         select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      tags:
+        select: head > meta[property="article:tag"]
+        values: |
+          attribute(el, 'content')
+      category:
+        select: head > meta[property="category"]
+        values: |
+          attribute(el, 'content')
+      robots:
+        select: head > meta[name="robots"]
         value: |
           attribute(el, 'content')
       lastModified:
         select: none
         value: |
-          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT') 

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -88,10 +88,6 @@ indices:
         select: head > meta[property="article:tag"]
         values: |
           attribute(el, 'content')
-      category:
-        select: head > meta[property="category"]
-        values: |
-          attribute(el, 'content')
       robots:
         select: head > meta[name="robots"]
         value: |


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Add your
* Specific
* Features or fixes

Resolves: https://jira.corp.adobe.com/browse/DOTCOM-140152

We want to enable blog article to share updates on milo.adobe.com
https://milo.adobe.com/blog/

The actual helix-query is missing information
date, author, category, tags
<img width="394" alt="Screenshot 2024-11-14 at 11 08 13" src="https://github.com/user-attachments/assets/0deff6e9-a0d5-44a7-887a-75e9e4139c8d">


**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.live/blog/?martech=off
- After: https://update-helix-query-blog-usage--milo--elaineskpt.hlx.live/blog/?martech=off
