### PR TITLE
Fed Icons - Table icon decoration and collapse icon wrapping

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -351,6 +351,7 @@
   width: 15px;
   height: 15px;
   cursor: pointer;
+  margin-inline: unset;
 }
 
 .table .section-head-title:hover .icon.expand {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1322,8 +1322,9 @@ export async function loadArea(area = document) {
 
   if (allIcons.length) {
     const { default: loadIcons, decorateIcons } = await import('../features/icons/icons.js');
-    await decorateIcons(area, allIcons, config);
-    await loadIcons(allIcons);
+    const areaIcons = area.querySelectorAll('span.icon');
+    await decorateIcons(area, areaIcons, config);
+    await loadIcons(areaIcons);
   }
 
   const currentHash = window.location.hash;


### PR DESCRIPTION
In reference to the [new federal icons work that was reverted](https://github.com/adobecom/milo/pull/2986), icons within tables were not having their respective SVG assets injected or tooltips being decorated. This was because the table block moves the icons around. I was able to see the icons being decorated by reselecting all icons before passing to icon js to be decorated and loaded.

There is also an issue where the expand/collapse icons wrapped to the bottom because of the new node index margin that was added. Unsetting that for this individual icon in the table.css.

Resolves: [MWPW-140452](https://jira.corp.adobe.com/browse/MWPW-140452)

**Test URLs:**
- Before: https://rparrish-fed-icons--milo--adobecom.hlx.page/drafts/sarchibeque/table-icons?martech=off
- After: https://sartxi-fed-icons-tables--milo--adobecom.hlx.page/drafts/sarchibeque/table-icons?martech=off

**URLs where issue was uncovered:**
- Before: https://main--dc--adobecom.hlx.page/acrobat/pricing?milolibs=rparrish-fed-icons&martech=off
- After: https://main--dc--adobecom.hlx.page/acrobat/pricing?milolibs=sartxi-fed-icons-tables&martech=off