### PR TITLE
MWPW-156760 - [Table] Expand icon update to match Consonant

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -283,7 +283,7 @@
 .table .section-head .section-head-title > :not(.icon) {
   font-size: var(--type-body-m-size);
   line-height: var(--type-heading-s-lh);
-  width: calc(100% - 20px);
+  width: calc(100% - 30px);
 }
 
 .table .section-head .section-head-title,
@@ -345,12 +345,13 @@
 .table .icon.expand {
   background-color: transparent;
   border: 0;
-  background-image: url('../../ui/img/expand2.svg');
+  background-image: url('../../ui/img/chevron-wide-black.svg');
   background-repeat: no-repeat;
   background-position: center right;
-  width: 15px;
-  height: 15px;
+  width: 18px;
+  height: 18px;
   cursor: pointer;
+  rotate: -90deg;
 }
 
 .table .section-head-title:hover .icon.expand {
@@ -358,7 +359,7 @@
 }
 
 .table .icon.expand[aria-expanded=true] {
-  background-image: url('../../ui/img/collapse2.svg');
+  rotate: unset;
 }
 
 .table .row-highlight .col-highlight.transparent-border {

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -254,9 +254,8 @@ function handleSection(sectionParams) {
     }
 
     if (isCollapseTable) {
+      if (sectionHeadTitle.querySelector('.icon.expand')) return;
       const iconTag = createTag('span', { class: 'icon expand' });
-      sectionHeadTitle.insertBefore(iconTag, sectionHeadTitle.firstChild);
-
       if (expandSection) {
         iconTag.setAttribute('aria-expanded', 'true');
         expandSection = false;
@@ -269,6 +268,7 @@ function handleSection(sectionParams) {
           nextElement = nextElement.nextElementSibling;
         }
       }
+      sectionHeadTitle.insertBefore(iconTag, sectionHeadTitle.firstChild);
     }
   } else if (previousRow?.querySelector('hr') && nextRow) {
     nextRow.classList.add('section-row');

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -254,8 +254,10 @@ function handleSection(sectionParams) {
     }
 
     if (isCollapseTable) {
-      if (sectionHeadTitle.querySelector('.icon.expand')) return;
       const iconTag = createTag('span', { class: 'icon expand' });
+      if (!sectionHeadTitle.querySelector('.icon.expand')) {
+        sectionHeadTitle.insertBefore(iconTag, sectionHeadTitle.firstChild);
+      }
       if (expandSection) {
         iconTag.setAttribute('aria-expanded', 'true');
         expandSection = false;
@@ -268,7 +270,6 @@ function handleSection(sectionParams) {
           nextElement = nextElement.nextElementSibling;
         }
       }
-      sectionHeadTitle.insertBefore(iconTag, sectionHeadTitle.firstChild);
     }
   } else if (previousRow?.querySelector('hr') && nextRow) {
     nextRow.classList.add('section-row');

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -255,7 +255,7 @@ function handleSection(sectionParams) {
 
     if (isCollapseTable) {
       const iconTag = createTag('span', { class: 'icon expand' });
-      sectionHeadTitle.appendChild(iconTag);
+      sectionHeadTitle.insertBefore(iconTag, sectionHeadTitle.firstChild);
 
       if (expandSection) {
         iconTag.setAttribute('aria-expanded', 'true');


### PR DESCRIPTION
Updates the expand icon and icon placement to match Consonant designs. Currently there are `+/-` icons positioned to the end of title text in expandable sections, this PR will update it to use a rotated carat icon and will move the icon to the start of the title text.

![collapse-before-after](https://github.com/user-attachments/assets/eb0c969a-a63f-4fd0-8a81-43af81af613b)

Resolves: [MWPW-156760](https://jira.corp.adobe.com/browse/MWPW-156760)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sarchibeque/table-exand?martech=off
- After: https://sartxi-mwpw-156760-table--milo--adobecom.hlx.page/drafts/sarchibeque/table-exand?martech=off
