### PR TITLE
quiz button and indicator accessibility

### DIFF
--- a/libs/blocks/quiz/quizoption.js
+++ b/libs/blocks/quiz/quizoption.js
@@ -92,7 +92,7 @@ export const GetQuizOption = ({
       <div class="quiz-button-container">
         <button 
           disabled=${countSelectedCards < minSelections && 'disabled'}
-          aria-label="Next" 
+          aria-label="${btnText}" 
           class="quiz-button" 
           daa-ll="${btnAnalyticsData}"
           onClick=${() => { handleOnNextClick(); }}>

--- a/libs/blocks/quiz/stepIndicator.js
+++ b/libs/blocks/quiz/stepIndicator.js
@@ -7,6 +7,7 @@ function StepIndicator({
   bottom = false,
   top = false,
 }) {
+  const step = currentStep < totalSteps ? currentStep + 1 : currentStep;
   const quizSteps = html`
     <div class="quiz-step-container${totalSteps > 3 ? ' wide' : ''}${top ? ' top' : ''}${bottom ? ' bottom' : ''}">
       ${Array.from({ length: totalSteps }).map((_, index) => {
@@ -21,7 +22,9 @@ function StepIndicator({
       default:
         className = 'future';
     }
-    return html`<div class="quiz-step ${className}"></div>`;
+    return html`<div class="quiz-step ${className}"
+      aria-current="${index === currentStep || totalSteps < currentStep ? 'step' : null}"
+      aria-label="${index === currentStep ? `Step ${step} of ${totalSteps}` : null}"></div>`;
   })}
     </div>
   `;

--- a/libs/blocks/quiz/stepIndicator.js
+++ b/libs/blocks/quiz/stepIndicator.js
@@ -23,7 +23,7 @@ function StepIndicator({
         className = 'future';
     }
     return html`<div class="quiz-step ${className}"
-      aria-current="${index === currentStep || totalSteps < currentStep ? 'step' : null}"
+      aria-current="${index === currentStep ? 'step' : null}"
       aria-label="${index === currentStep ? `Step ${step} of ${totalSteps}` : null}"></div>`;
   })}
     </div>


### PR DESCRIPTION
* aria-label on button made dynamic to match the text
* accessibility additions to the progress indicator

Resolves: [MWPW-161333](https://jira.corp.adobe.com/browse/MWPW-161333)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/colloyd/quiz/?martech=off
- After: https://quiz-q4-accessibility--milo--colloyd.aem.page/drafts/colloyd/quiz/?martech=off

Testing notes: 
In the "After" page, observe the progress indicator and look for the aria-current="step" and aria-label="Step [X] of [Total] on the current indicator.

For the button, choose options and go through the quiz until the button says, "Get your results", note how the aria-label on the button is representative of the text in the button and is no longer the hard coded "Next".
