### PR TITLE
MWPW-162833 [nala][MEP] confirm the "any-marquee-section" selector

### DIFF
--- a/nala/features/personalization/any-marquee-section.spec.js
+++ b/nala/features/personalization/any-marquee-section.spec.js
@@ -4,7 +4,7 @@ module.exports = {
     {
       tcid: '0',
       name: '@test the default page',
-      desc: 'there should be marquees present, not any "replacement text"',
+      desc: 'there should be marquees present in the default page, "replacement text" should be present in the PZN page',
       path: '/drafts/nala/features/personalization/any-marquee-section/any-marquee-section',
       data: { defaultURL: '/drafts/nala/features/personalization/any-marquee-section/any-marquee-section?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Fany-marquee-section%2Fany-marquee-section.json--default' },
       tags: '@anymarquee0 @smoke @regression @milo ',

--- a/nala/features/personalization/any-marquee-section.spec.js
+++ b/nala/features/personalization/any-marquee-section.spec.js
@@ -3,7 +3,7 @@ module.exports = {
   features: [
     {
       tcid: '0',
-      name: '@test the default page',
+      name: '@test the default and personalized pages',
       desc: 'there should be marquees present in the default page, "replacement text" should be present in the PZN page',
       path: '/drafts/nala/features/personalization/any-marquee-section/any-marquee-section',
       data: { defaultURL: '/drafts/nala/features/personalization/any-marquee-section/any-marquee-section?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Fany-marquee-section%2Fany-marquee-section.json--default' },

--- a/nala/features/personalization/any-marquee-section.spec.js
+++ b/nala/features/personalization/any-marquee-section.spec.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'test the any-marquee-section selector',
+  features: [
+    {
+      tcid: '0',
+      name: '@test the default page',
+      desc: 'there should be marquees present, not any "replacement text"',
+      path: '/drafts/nala/features/personalization/any-marquee-section/any-marquee-section',
+      data: { defaultURL: '/drafts/nala/features/personalization/any-marquee-section/any-marquee-section?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Fany-marquee-section%2Fany-marquee-section.json--default' },
+      tags: '@anymarquee0 @smoke @regression @milo ',
+    },
+  ],
+};

--- a/nala/features/personalization/any-marquee-section.test.js
+++ b/nala/features/personalization/any-marquee-section.test.js
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+import { features } from './any-marquee-section.spec.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+
+// Test 0: verify the selector "any-marquee-selector"
+test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+  const defaultURL = `${baseURL}${features[0].data.defaultURL}${miloLibs}`;
+  const pznURL = `${baseURL}${features[0].path}${miloLibs}`;
+  const PZNUpdateLocator = '[data-manifest-id="any-marquee-section.json"]';
+  const marqueeLocator = '.marquee';
+  const heroMarqueeLocator = '.hero-marquee';
+
+  await test.step('step-1: verify default test page', async () => {
+    console.info(`[Test Page]: ${defaultURL}`);
+    await page.goto(defaultURL);
+    await expect(page.locator(PZNUpdateLocator)).toHaveCount(0);
+    await expect(page.locator(marqueeLocator)).toHaveCount(18);
+    await expect(page.locator(heroMarqueeLocator)).toHaveCount(3);
+  });
+
+  await test.step('step-2: verify personalized page substitutions', async () => {
+    console.info(`[Test Page]: ${pznURL}`);
+    await page.goto(pznURL);
+    await expect(page.locator(PZNUpdateLocator)).toHaveCount(21);
+    await expect(page.locator(marqueeLocator)).toHaveCount(0);
+    await expect(page.locator(heroMarqueeLocator)).toHaveCount(0);
+  });
+});

--- a/nala/features/personalization/any-marquee-section.test.js
+++ b/nala/features/personalization/any-marquee-section.test.js
@@ -5,7 +5,7 @@ import { features } from './any-marquee-section.spec.js';
 
 const miloLibs = process.env.MILO_LIBS || '';
 
-// Test 0: verify the selector "any-marquee-selector"
+// Test 0: verify the selector "any-marquee-section"
 test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
   const defaultURL = `${baseURL}${features[0].data.defaultURL}${miloLibs}`;
   const pznURL = `${baseURL}${features[0].path}${miloLibs}`;

--- a/nala/features/personalization/any-marquee-section.test.js
+++ b/nala/features/personalization/any-marquee-section.test.js
@@ -1,3 +1,5 @@
+// to run the test: npm run nala stage any-marquee-section.test.js
+
 import { expect, test } from '@playwright/test';
 import { features } from './any-marquee-section.spec.js';
 


### PR DESCRIPTION
This nala tests checks the "any-marquee-section" selector per PR request 2884: 

Resolves: [MWPW-162833](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://any-marquee-section--milo--adobecom.aem.page/?martech=off
- PSI check: https://any-marquee-section--milo--adobecom.aem.page/?martech=off

Here is an example of the nala test:
https://main--milo--adobecom.hlx.page/drafts/nala/features/personalization/any-marquee-section/any-marquee-section
compare with the default base page: https://main--milo--adobecom.hlx.page/drafts/nala/features/personalization/any-marquee-section/any-marquee-section?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Fany-marquee-section%2Fany-marquee-section.json--default

Note how every type of marquee is listed on the base page and that all marquee types are replaced with text by using the any-marquee-section selector in the MEP manifest
