### PR TITLE
MWPW-161929: Central configuration support for Graybox on DA

### DIFF
--- a/test/tools/floodbox/graybox/graybox-config.test.js
+++ b/test/tools/floodbox/graybox/graybox-config.test.js
@@ -1,0 +1,139 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import GrayboxConfig from '../../../../tools/floodbox/graybox/graybox-config.js';
+import RequestHandler from '../../../../tools/floodbox/request-handler.js';
+import { DA_ORIGIN } from '../../../../tools/floodbox/constants.js';
+
+describe('GrayboxConfig', () => {
+  let grayboxConfig;
+  const org = 'testOrg';
+  const repo = 'testRepo';
+  const accessToken = 'testToken';
+  let daFetchStub;
+
+  beforeEach(() => {
+    sinon.restore();
+    daFetchStub = sinon.stub(RequestHandler.prototype, 'daFetch');
+    grayboxConfig = new GrayboxConfig(org, repo, accessToken);
+  });
+
+  it('should initialize properties correctly', () => {
+    expect(grayboxConfig.org).to.equal(org);
+    expect(grayboxConfig.repo).to.equal(repo);
+    expect(grayboxConfig.accessToken).to.equal(accessToken);
+    expect(grayboxConfig.requestHandler).to.be.instanceof(RequestHandler);
+    expect(grayboxConfig.isGlobalPromoteEnabled).to.be.null;
+    expect(grayboxConfig.isGlobalDeleteEnabled).to.be.null;
+    expect(grayboxConfig.isGlobalPromoteDraftsOnly).to.be.null;
+    expect(grayboxConfig.globalPromoteIgnorePaths).to.deep.equal([]);
+    expect(grayboxConfig.experiencePromoteConfig).to.deep.equal([]);
+    expect(grayboxConfig.experienceDeleteConfig).to.deep.equal([]);
+    expect(grayboxConfig.experienceDraftsOnlyConfig).to.deep.equal([]);
+  });
+
+  it('should fetch and process config correctly', async () => {
+    const mockResponse = {
+      ok: true,
+      json: sinon.stub().resolves({
+        'experience-config': {
+          data: [
+            { key: 'enablePromote', experienceNames: 'summit25, max25' },
+            { key: 'enableDelete', experienceNames: '' },
+            { key: 'promoteDraftsOnly', experienceNames: '' },
+          ],
+        },
+        'global-promote-ignore-paths': {
+          data: [
+            { globalPromoteIgnorePaths: '/placeholders.json' },
+            { globalPromoteIgnorePaths: '/metadata.json' },
+            { globalPromoteIgnorePaths: '/my-folder/my-file' },
+            { globalPromoteIgnorePaths: '/summit25/' },
+          ],
+        },
+        'global-config': {
+          data: [
+            { key: 'enablePromote', value: 'true' },
+            { key: 'enableDelete', value: 'false' },
+            { key: 'promoteDraftsOnly', value: 'false' },
+          ],
+        },
+      }),
+    };
+
+    daFetchStub.resolves(mockResponse);
+
+    await grayboxConfig.getConfig();
+
+    expect(daFetchStub.calledWith(`${DA_ORIGIN}/source/${org}/${repo}/.milo/graybox/config.json`)).to.be.true;
+    expect(mockResponse.json.called).to.be.true;
+
+    // Add assertions to verify that the properties are set correctly based on the mock response
+    expect(grayboxConfig.isGlobalPromoteEnabled).to.be.true;
+    expect(grayboxConfig.isGlobalDeleteEnabled).to.be.false;
+    expect(grayboxConfig.isGlobalPromoteDraftsOnly).to.be.false;
+    expect(grayboxConfig.globalPromoteIgnorePaths).to.deep.equal([
+      '/placeholders.json',
+      '/metadata.json',
+      '/my-folder/my-file',
+      '/summit25/',
+    ]);
+    expect(grayboxConfig.experiencePromoteConfig).to.deep.equal([
+      'summit25', 'max25',
+    ]);
+    expect(grayboxConfig.experienceDeleteConfig).to.deep.equal(['']);
+    expect(grayboxConfig.experienceDraftsOnlyConfig).to.deep.equal(['']);
+  });
+
+  // add test for failed fetch
+  it('should log error if fetch fails', async () => {
+    const mockResponse = { ok: false };
+    daFetchStub.resolves(mockResponse);
+    const consoleErrorStub = sinon.stub(console, 'error');
+
+    await grayboxConfig.getConfig();
+
+    expect(daFetchStub.calledWith(`${DA_ORIGIN}/source/${org}/${repo}/.milo/graybox/config.json`)).to.be.true;
+    expect(consoleErrorStub.calledWith(`Failed to fetch graybox config for ${org}/${repo}`)).to.be.true;
+  });
+
+  it('should return the correct value for isPromoteEnabled', () => {
+    grayboxConfig.isGlobalPromoteEnabled = true;
+    expect(grayboxConfig.isPromoteEnabled()).to.be.true;
+
+    grayboxConfig.isGlobalPromoteEnabled = false;
+    expect(grayboxConfig.isPromoteEnabled()).to.be.false;
+
+    grayboxConfig.isGlobalPromoteEnabled = null;
+    grayboxConfig.experiencePromoteConfig = ['test'];
+    expect(grayboxConfig.isPromoteEnabled('test')).to.be.true;
+  });
+
+  it('should return the correct value for isDeleteEnabled', () => {
+    grayboxConfig.isGlobalDeleteEnabled = true;
+    expect(grayboxConfig.isDeleteEnabled()).to.be.true;
+
+    grayboxConfig.isGlobalDeleteEnabled = false;
+    expect(grayboxConfig.isDeleteEnabled()).to.be.false;
+
+    grayboxConfig.isGlobalDeleteEnabled = null;
+    grayboxConfig.experienceDeleteConfig = ['test'];
+    expect(grayboxConfig.isDeleteEnabled('test')).to.be.true;
+  });
+
+  it('should return the correct value for isDraftsOnly', () => {
+    grayboxConfig.isGlobalPromoteDraftsOnly = true;
+    expect(grayboxConfig.isDraftsOnly()).to.be.true;
+
+    grayboxConfig.isGlobalPromoteDraftsOnly = false;
+    expect(grayboxConfig.isDraftsOnly()).to.be.false;
+
+    grayboxConfig.isGlobalPromoteDraftsOnly = null;
+    grayboxConfig.experienceDraftsOnlyConfig = ['test'];
+    expect(grayboxConfig.isDraftsOnly('test')).to.be.true;
+  });
+
+  it('should return the correct value for getGlobalPromoteIgnorePaths', () => {
+    grayboxConfig.globalPromoteIgnorePaths = ['/test1', '/test2'];
+    expect(grayboxConfig.getGlobalPromoteIgnorePaths()).to.deep.equal(['/test1', '/test2']);
+  });
+});

--- a/tools/floodbox/graybox/graybox-config.js
+++ b/tools/floodbox/graybox/graybox-config.js
@@ -1,0 +1,98 @@
+import RequestHandler from '../request-handler.js';
+import { DA_ORIGIN } from '../constants.js';
+
+const GRAYBOX_CONFIG_FILE = '/.milo/graybox/config.json';
+/**
+ * GrayboxConfig provides the configuration setup for the graybox app.
+ * If the global config is not defined, it will default to the experience config.
+ * If global config is defined (true or false), it will override the experience config.
+ */
+class GrayboxConfig {
+  constructor(org, repo, accessToken) {
+    this.org = org;
+    this.repo = repo;
+    this.accessToken = accessToken;
+    this.requestHandler = new RequestHandler(accessToken);
+
+    // global config
+    this.isGlobalPromoteEnabled = null;
+    this.isGlobalDeleteEnabled = null;
+    this.isGlobalPromoteDraftsOnly = null;
+
+    // global promote ignore paths
+    this.globalPromoteIgnorePaths = [];
+
+    // experience config
+    this.experiencePromoteConfig = [];
+    this.experienceDeleteConfig = [];
+    this.experienceDraftsOnlyConfig = [];
+  }
+
+  async getConfig() {
+    const resp = await this.requestHandler.daFetch(`${DA_ORIGIN}/source/${this.org}/${this.repo}${GRAYBOX_CONFIG_FILE}`);
+    if (resp.ok) {
+      const json = await resp.json();
+      const { 'global-config': globalConfig, 'experience-config': experienceConfig, 'global-promote-ignore-paths': globalPromoteIgnorePathsConfig } = json;
+
+      if (globalConfig) {
+        const enablePromoteConfig = globalConfig.data.find(({ key }) => key === 'enablePromote');
+        this.isGlobalPromoteEnabled = !enablePromoteConfig || enablePromoteConfig.value === '' ? null : enablePromoteConfig.value === 'true';
+        const enableDeleteConfig = globalConfig.data.find(({ key }) => key === 'enableDelete');
+        this.isGlobalDeleteEnabled = !enableDeleteConfig || enableDeleteConfig.value === '' ? null : enableDeleteConfig.value === 'true';
+        const promoteDraftsOnlyConfig = globalConfig.data.find(({ key }) => key === 'promoteDraftsOnly');
+        this.isGlobalPromoteDraftsOnly = !promoteDraftsOnlyConfig || promoteDraftsOnlyConfig.value === '' ? null : promoteDraftsOnlyConfig.value === 'true';
+      }
+
+      if (experienceConfig) {
+        const promoteConfig = experienceConfig.data.find(({ key }) => key === 'enablePromote');
+        if (promoteConfig) {
+          this.experiencePromoteConfig = promoteConfig.experienceNames.split(',').map((expName) => expName.trim());
+        }
+        const deleteConfig = experienceConfig.data.find(({ key }) => key === 'enableDelete');
+        if (deleteConfig) {
+          this.experienceDeleteConfig = deleteConfig.experienceNames.split(',').map((expName) => expName.trim());
+        }
+        const draftsOnlyConfig = experienceConfig.data.find(({ key }) => key === 'promoteDraftsOnly');
+        if (draftsOnlyConfig) {
+          this.experienceDraftsOnlyConfig = draftsOnlyConfig.experienceNames.split(',').map((expName) => expName.trim());
+        }
+      }
+
+      if (globalPromoteIgnorePathsConfig) {
+        this.globalPromoteIgnorePaths = globalPromoteIgnorePathsConfig.data.map(
+          ({ globalPromoteIgnorePaths }) => globalPromoteIgnorePaths,
+        );
+      }
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(`Failed to fetch graybox config for ${this.org}/${this.repo}`);
+    }
+  }
+
+  isPromoteEnabled(expName) {
+    if (this.isGlobalPromoteEnabled === null) {
+      return this.experiencePromoteConfig.includes(expName);
+    }
+    return this.isGlobalPromoteEnabled;
+  }
+
+  isDeleteEnabled(expName) {
+    if (this.isGlobalDeleteEnabled === null) {
+      return this.experienceDeleteConfig.includes(expName);
+    }
+    return this.isGlobalDeleteEnabled;
+  }
+
+  isDraftsOnly(expName) {
+    if (this.isGlobalPromoteDraftsOnly === null) {
+      return this.experienceDraftsOnlyConfig.includes(expName);
+    }
+    return this.isGlobalPromoteDraftsOnly;
+  }
+
+  getGlobalPromoteIgnorePaths() {
+    return this.globalPromoteIgnorePaths;
+  }
+}
+
+export default GrayboxConfig;

--- a/tools/floodbox/graybox/graybox-config.js
+++ b/tools/floodbox/graybox/graybox-config.js
@@ -32,30 +32,18 @@ class GrayboxConfig {
     const resp = await this.requestHandler.daFetch(`${DA_ORIGIN}/source/${this.org}/${this.repo}${GRAYBOX_CONFIG_FILE}`);
     if (resp.ok) {
       const json = await resp.json();
-      const { 'global-config': globalConfig, 'experience-config': experienceConfig, 'global-promote-ignore-paths': globalPromoteIgnorePathsConfig } = json;
+      const {
+        'global-config': globalConfig,
+        'experience-config': experienceConfig,
+        'global-promote-ignore-paths': globalPromoteIgnorePathsConfig,
+      } = json;
 
       if (globalConfig) {
-        const enablePromoteConfig = globalConfig.data.find(({ key }) => key === 'enablePromote');
-        this.isGlobalPromoteEnabled = !enablePromoteConfig || enablePromoteConfig.value === '' ? null : enablePromoteConfig.value === 'true';
-        const enableDeleteConfig = globalConfig.data.find(({ key }) => key === 'enableDelete');
-        this.isGlobalDeleteEnabled = !enableDeleteConfig || enableDeleteConfig.value === '' ? null : enableDeleteConfig.value === 'true';
-        const promoteDraftsOnlyConfig = globalConfig.data.find(({ key }) => key === 'promoteDraftsOnly');
-        this.isGlobalPromoteDraftsOnly = !promoteDraftsOnlyConfig || promoteDraftsOnlyConfig.value === '' ? null : promoteDraftsOnlyConfig.value === 'true';
+        this.#setGlobalConfig(globalConfig);
       }
 
       if (experienceConfig) {
-        const promoteConfig = experienceConfig.data.find(({ key }) => key === 'enablePromote');
-        if (promoteConfig) {
-          this.experiencePromoteConfig = promoteConfig.experienceNames.split(',').map((expName) => expName.trim());
-        }
-        const deleteConfig = experienceConfig.data.find(({ key }) => key === 'enableDelete');
-        if (deleteConfig) {
-          this.experienceDeleteConfig = deleteConfig.experienceNames.split(',').map((expName) => expName.trim());
-        }
-        const draftsOnlyConfig = experienceConfig.data.find(({ key }) => key === 'promoteDraftsOnly');
-        if (draftsOnlyConfig) {
-          this.experienceDraftsOnlyConfig = draftsOnlyConfig.experienceNames.split(',').map((expName) => expName.trim());
-        }
+        this.#setExperienceConfig(experienceConfig);
       }
 
       if (globalPromoteIgnorePathsConfig) {
@@ -92,6 +80,30 @@ class GrayboxConfig {
 
   getGlobalPromoteIgnorePaths() {
     return this.globalPromoteIgnorePaths;
+  }
+
+  #setGlobalConfig(globalConfig) {
+    const enablePromoteConfig = globalConfig.data.find(({ key }) => key === 'enablePromote');
+    this.isGlobalPromoteEnabled = !enablePromoteConfig || enablePromoteConfig.value === '' ? null : enablePromoteConfig.value === 'true';
+    const enableDeleteConfig = globalConfig.data.find(({ key }) => key === 'enableDelete');
+    this.isGlobalDeleteEnabled = !enableDeleteConfig || enableDeleteConfig.value === '' ? null : enableDeleteConfig.value === 'true';
+    const promoteDraftsOnlyConfig = globalConfig.data.find(({ key }) => key === 'promoteDraftsOnly');
+    this.isGlobalPromoteDraftsOnly = !promoteDraftsOnlyConfig || promoteDraftsOnlyConfig.value === '' ? null : promoteDraftsOnlyConfig.value === 'true';
+  }
+
+  #setExperienceConfig(experienceConfig) {
+    const promoteConfig = experienceConfig.data.find(({ key }) => key === 'enablePromote');
+    if (promoteConfig) {
+      this.experiencePromoteConfig = promoteConfig.experienceNames.split(',').map((expName) => expName.trim());
+    }
+    const deleteConfig = experienceConfig.data.find(({ key }) => key === 'enableDelete');
+    if (deleteConfig) {
+      this.experienceDeleteConfig = deleteConfig.experienceNames.split(',').map((expName) => expName.trim());
+    }
+    const draftsOnlyConfig = experienceConfig.data.find(({ key }) => key === 'promoteDraftsOnly');
+    if (draftsOnlyConfig) {
+      this.experienceDraftsOnlyConfig = draftsOnlyConfig.experienceNames.split(',').map((expName) => expName.trim());
+    }
   }
 }
 

--- a/tools/floodbox/graybox/graybox-config.js
+++ b/tools/floodbox/graybox/graybox-config.js
@@ -2,6 +2,7 @@ import RequestHandler from '../request-handler.js';
 import { DA_ORIGIN } from '../constants.js';
 
 const GRAYBOX_CONFIG_FILE = '/.milo/graybox/config.json';
+
 /**
  * GrayboxConfig provides the configuration setup for the graybox app.
  * If the global config is not defined, it will default to the experience config.

--- a/tools/floodbox/graybox/graybox.js
+++ b/tools/floodbox/graybox/graybox.js
@@ -206,7 +206,7 @@ export default class MiloGraybox extends LitElement {
   async handlePromotePaths(event) {
     event.preventDefault();
     let paths = this.shadowRoot.querySelector('textarea[name="promotePaths"]').value;
-    paths = paths.split('\n').map((path) => path.trim());
+    paths = paths.split('\n').map((path) => path.trim()).filter((path) => path.length > 0);
 
     // #1 - Validate paths
     const { valid, org, repo, expName } = validatePaths(paths);
@@ -281,7 +281,7 @@ export default class MiloGraybox extends LitElement {
 
   async validateInputPaths(event) {
     const textarea = event.target;
-    const paths = textarea.value.split('\n').map((path) => path.trim());
+    const paths = textarea.value.split('\n').map((path) => path.trim()).filter((path) => path.length > 0);
     const { valid, org, repo, expName } = validatePaths(paths);
     if (valid) {
       this._grayboxConfig = new GrayboxConfig(org, repo, this.token);

--- a/tools/floodbox/graybox/graybox.js
+++ b/tools/floodbox/graybox/graybox.js
@@ -286,7 +286,7 @@ export default class MiloGraybox extends LitElement {
   }
 
   togglePromoteIgnore(event) {
-    this.promoteIgnore = event.target.checked;
+    this._promoteIgnore = event.target.checked;
     this.requestUpdate();
   }
 
@@ -386,7 +386,7 @@ export default class MiloGraybox extends LitElement {
             <option value="promotePaths">Promote Graybox Paths</option>            
           </select>
         </div>
-        ${this.selectedOption === 'promoteExp' ? html`
+        ${this._selectedOption === 'promoteExp' ? html`
           <div class="input-row">
             <input type="text" class="path-input" name="path" placeholder="Enter Experience Path" value="/sukamat/da-bacom-graybox/summit25" @input=${this.validateInput} />
             <button class="primary" @click=${this.handleClear}>Clear</button>
@@ -397,7 +397,7 @@ export default class MiloGraybox extends LitElement {
             <input type="checkbox" id="publish" name="publish" disabled>
             <label for="publish">Publish files after promote?</label>
           </div>
-          ${this.promoteIgnore === true ? html`
+          ${this._promoteIgnore === true ? html`
             <div class="input-row promote-ignore">
               <textarea class="path-list" name="additionalInfo" rows="3" 
                 placeholder="Enter paths to ignore from promote, separated by line-break. Eg:/<org>/<site>/<exp>/<path-to-file>"></textarea>
@@ -407,7 +407,7 @@ export default class MiloGraybox extends LitElement {
               <button class="accent" .disabled=${!this._canPromote} @click=${this.handlePromoteExperience}>Promote</button>
             </div>          
           ` : nothing}
-        ${this.selectedOption === 'promotePaths' ? html`
+        ${this._selectedOption === 'promotePaths' ? html`
           <div class="input-row">
             <textarea name="promotePaths" rows="3" placeholder="Enter graybox paths to promote, separated by line-break" @input=${this.validateInputPaths}></textarea>
             <button class="primary" @click=${this.handleClear}>Clear</button>


### PR DESCRIPTION
- Adds config support to enable/disable promote at
  - per experience level 
  - global level
- Adds options to ignore specific paths during promote
- Adds options to promote drafts only for testing at 
  - per experience level
  - global level

Resolves: [MWPW-161929](https://jira.corp.adobe.com/browse/MWPW-161929)

**Test URLs:**
- Before: https://da.live/app/adobecom/milo/tools/graybox?ref=floodbox
- After: https://da.live/app/adobecom/milo/tools/graybox?ref=graybox-config 

The config has been temporarily added here for testing:
https://da.live/#/sukamat/da-bacom-graybox/.milo/graybox

This can be copied into your own org for testing. It will be moved to the `adobecom` org later.
