### PR TITLE
New modal option to support tall videos

### DIFF
--- a/libs/blocks/modal-metadata/modal-metadata.js
+++ b/libs/blocks/modal-metadata/modal-metadata.js
@@ -1,9 +1,13 @@
 import { getMetadata, handleStyle } from '../section-metadata/section-metadata.js';
 
-export default function init(el) {
+export default async function init(el) {
   const modal = el.closest('.dialog-modal');
   if (!modal) return;
   const metadata = getMetadata(el);
   if (metadata.style) handleStyle(metadata.style.text, modal);
   if (metadata.curtain?.text === 'off') modal.classList.add('curtain-off');
+  if (modal.classList.contains('tall-video')) {
+    const { handleBackground } = await import('../section-metadata/section-metadata.js');
+    if (metadata.background) handleBackground(metadata, modal);
+  }
 }

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -1,5 +1,7 @@
 :root {
   --modal-focus-color: #109cde;
+  --spacing-xl: 56px;
+  --aspect-ratio-tall: 9/16;
 }
 
 .dialog-modal {
@@ -220,10 +222,31 @@
   overflow: hidden;
 }
 
+.dialog-modal.tall-video {
+  line-height: 0;
+  width: fit-content;
+}
+
+.dialog-modal.tall-video .milo-video {
+  aspect-ratio: var(--aspect-ratio-tall);
+  height: auto;
+  padding-bottom: 0;
+}
+
 @media (min-width: 600px) {
   .dialog-modal {
     max-width: 80vw;
     width: fit-content;
+  }
+
+  .dialog-modal.tall-video {
+    max-width: 45vw;
+    padding: var(--spacing-xl);
+  }
+
+  .dialog-modal.tall-video .milo-video {
+    min-width: 45vw;
+    aspect-ratio: var(--aspect-ratio-tall);
   }
 
   .region-selector .content {
@@ -314,6 +337,37 @@
     max-width: 1100px;
     overflow: hidden;
     width: 80%;
+  }
+
+  .dialog-modal.tall-video {
+    max-width: 35vw;
+  }
+
+  .dialog-modal.tall-video .milo-video {
+    min-width: 35vw;
+  }
+}
+
+@media (min-width: 1400px) {
+  .dialog-modal.tall-video {
+    max-width: 25vw;
+    max-height: 1200px;
+  }
+
+  .dialog-modal.tall-video .milo-video {
+    min-width: 25vw;
+    max-height: 1200px;
+    height: 100%;
+  }
+}
+
+@media (min-width: 2000px) {
+  .dialog-modal.tall-video {
+    max-width: 22vw;
+  }
+
+  .dialog-modal.tall-video .milo-video {
+    min-width: 22vw;
   }
 }
 

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -1,7 +1,5 @@
 :root {
   --modal-focus-color: #109cde;
-  --spacing-xl: 56px;
-  --aspect-ratio-tall: 9/16;
 }
 
 .dialog-modal {
@@ -231,6 +229,7 @@
   aspect-ratio: var(--aspect-ratio-tall);
   height: auto;
   padding-bottom: 0;
+  min-width: 90vw;
 }
 
 @media (min-width: 600px) {
@@ -240,13 +239,16 @@
   }
 
   .dialog-modal.tall-video {
-    max-width: 45vw;
+    --modal-width-var: 50vw;
+
+    max-width: var(--modal-width-var);
     padding: var(--spacing-xl);
   }
 
   .dialog-modal.tall-video .milo-video {
-    min-width: 45vw;
-    aspect-ratio: var(--aspect-ratio-tall);
+    --modal-width-var: 50vw;
+
+    min-width: var(--modal-width-var);
   }
 
   .region-selector .content {
@@ -255,6 +257,13 @@
 
   .upgrade-flow-modal .upgrade-flow-iframe {
     padding: 0 0 10px;
+  }
+}
+
+@media (min-width: 600px) and (orientation: landscape) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 25vw;
   }
 }
 
@@ -339,35 +348,43 @@
     width: 80%;
   }
 
-  .dialog-modal.tall-video {
-    max-width: 35vw;
-  }
-
+  .dialog-modal.tall-video,
   .dialog-modal.tall-video .milo-video {
-    min-width: 35vw;
+    --modal-width-var: 35vw;
+  }
+}
+
+@media (min-width: 1200px) and (orientation: landscape) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 25vw;
   }
 }
 
 @media (min-width: 1400px) {
-  .dialog-modal.tall-video {
-    max-width: 25vw;
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 25vw;
+
     max-height: 1200px;
   }
 
   .dialog-modal.tall-video .milo-video {
-    min-width: 25vw;
-    max-height: 1200px;
     height: 100%;
   }
 }
 
-@media (min-width: 2000px) {
-  .dialog-modal.tall-video {
-    max-width: 22vw;
-  }
-
+@media (min-width: 1400px) and (orientation: landscape) {
+  .dialog-modal.tall-video,
   .dialog-modal.tall-video .milo-video {
-    min-width: 22vw;
+    --modal-width-var: 20vw;
+  }
+}
+
+@media (min-width: 2000px) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 22vw;
   }
 }
 

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -263,7 +263,7 @@
 @media (min-width: 600px) and (orientation: landscape) {
   .dialog-modal.tall-video,
   .dialog-modal.tall-video .milo-video {
-    --modal-width-var: 25vw;
+    --modal-width-var: 19vw;
   }
 }
 

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -246,8 +246,6 @@
   }
 
   .dialog-modal.tall-video .milo-video {
-    --modal-width-var: 50vw;
-
     min-width: var(--modal-width-var);
   }
 
@@ -264,6 +262,13 @@
   .dialog-modal.tall-video,
   .dialog-modal.tall-video .milo-video {
     --modal-width-var: 19vw;
+  }
+}
+
+@media (min-width: 900px) and (min-height: 431px)  and (orientation: landscape) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 25vw;
   }
 }
 

--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -1,6 +1,6 @@
 import { handleFocalpoint } from '../../utils/decorate.js';
 
-function handleBackground(div, section) {
+export function handleBackground(div, section) {
   const pic = div.background.content?.querySelector('picture');
   if (pic) {
     section.classList.add('has-background');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
**New tall video modal option**
* Adds ability to display tall/portrait style videos in modal
* Opt in feature - add `modal-metadata` block to fragment and apply new `style` "`tall-video`"

This new feature is enabled by adding a `modal-metadata` block to a fragment that will be used as a modal. Adding a new `style` value of "`tall-video`" will enable the feature. 

This use case is for the Photoshop mobile launch.
Resolves: [MWPW-162482](https://jira.corp.adobe.com/browse/MWPW-162482)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/tall-video?martech=off
- After: https://modal-tall-video--milo--adobecom.hlx.page/drafts/rclayton/tall-video?martech=off


--- 

<img width="864" alt="image" src="https://github.com/user-attachments/assets/db45eb82-5f82-4ba6-b718-22dcdacaac78">

![image](https://github.com/user-attachments/assets/8aa0d51e-827d-4d05-b72c-b3838d673025)