### PR TITLE
MWPW-162811: Fixed reset button to black color

### DIFF
--- a/libs/blocks/locui-create/locui-create.css
+++ b/libs/blocks/locui-create/locui-create.css
@@ -653,6 +653,9 @@ body {
 
 .reset-button {
   margin-left: auto;
+  color: #fff;
+  background-color: #292929;
+  border-color: #292929;
 }
 
 .button:hover,
@@ -661,6 +664,10 @@ body {
 .locale-button:hover,
 .reset-button:hover {
   background-color: #e1e1e1;
+}
+
+.reset-button:hover {
+  background-color: #131313;
 }
 
 .region-button.active,


### PR DESCRIPTION
* Fixed "Reset All" button in select locales screen to black

Resolves: [MWPW-162811](https://jira.corp.adobe.com/browse/MWPW-162811)

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://mwpw-162811-screen-2-ui-fixes--milo--zweihand3r.hlx.page/drafts/sircar/locui-create?martech=off
