### PR TITLE
[LOC]MWPW-162877: Fragment details are not fetching correctly if same fragment is reused in multiple pages 

### DIFF
--- a/libs/blocks/locui-create/fragments/view.js
+++ b/libs/blocks/locui-create/fragments/view.js
@@ -35,6 +35,7 @@ export default function FragmentsSection({
 
   const locFragment = (fragment) => {
     const checked = selectedFragments.find((pathname) => pathname === fragment.pathname);
+    const parentPages = fragment?.parentPages?.filter((page) => page) ?? [];
     return html`
     <li class="locui-create-fragment">
     <div class="locui-create-fragment-input-container">
@@ -42,7 +43,7 @@ export default function FragmentsSection({
      <label class='locui-create-fragment-label' for=${fragment.pathname}>${fragment.pathname}</label>
      </div>
      <ul class='locui-create-fragment-parent'>
-      ${fragment.parentPages && fragment.parentPages.length > 0 && fragment.parentPages.map((parentPage) => html`<li>${parentPage}</li>`)}
+      ${parentPages.map((parentPage) => html`<li>${parentPage}</li>`)}
      </ul>
     </div>`;
   };

--- a/libs/blocks/locui-create/input-urls/index.js
+++ b/libs/blocks/locui-create/input-urls/index.js
@@ -63,7 +63,7 @@ export async function findFragments(urls) {
     if (fragments.length > 0) {
       fragments.forEach((fragment) => {
         if (acc[fragment.pathname]) {
-          acc[fragment.pathname].parentPages.push(urls[index]);
+          acc[fragment.pathname].parentPages.push(urls[index]?.href);
           return acc;
         }
         fragment.parentPages = [urls[index]?.href];


### PR DESCRIPTION
* Multiple pages urls are shown in the list when the same fragment is used across multiple pages.

Resolves: https://jira.corp.adobe.com/browse/MWPW-162877

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/sircar/locui-create?martech=off
- After: https://mwpw-162877-fragments-multiple-pages--milo--saurabhsircar11.aem.page/drafts/sircar/locui-create?martech=off
