### PR TITLE
MWPW-162847 [MEP][nala] add ul-li selector test

### DIFF
--- a/nala/features/personalization/ul-ol-li.spec.js
+++ b/nala/features/personalization/ul-ol-li.spec.js
@@ -1,0 +1,21 @@
+module.exports = {
+  name: 'Personalization Feature',
+  features: [
+    {
+      tcid: '0',
+      name: '@check ul selector',
+      desc: 'Verify that ul selectors work (skipping ol selectors)',
+      path: '/drafts/nala/features/personalization/ul-ol-li/ul-selector',
+      data: { defaultURL: '/drafts/nala/features/personalization/ul-ol-li/ul-selector?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Ful-ol-li%2Ful-selector.json--default' },
+      tags: '@ul0 @smoke @regression @milo ',
+    },
+    {
+      tcid: '1',
+      name: '@check li selectors',
+      desc: 'Verify that li selectors work',
+      path: '/drafts/nala/features/personalization/ul-ol-li/li-selectors',
+      data: { defaultURL: '/drafts/nala/features/personalization/ul-ol-li/li-selectors?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Ful-ol-li%2Fli-selectors.json--default' },
+      tags: '@ul1 @smoke @regression @milo ',
+    },
+  ],
+};

--- a/nala/features/personalization/ul-ol-li.test.js
+++ b/nala/features/personalization/ul-ol-li.test.js
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import { features } from './ul-ol-li.spec.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+
+// Test 0 : check ul selectors (skipping ol selectors)
+test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+  const pznUrl = `${baseURL}${features[0].path}${miloLibs}`;
+  const defaultUrl = `${baseURL}${features[0].data.defaultURL}${miloLibs}`;
+  const pznUpdateLocator = '[data-manifest-id="ul-selector.json"]';
+  const defaultUlLocator = 'ul.icon-list';
+
+  await test.step('step-1: verify the default test page has a regular ul list with 3 bullets', async () => {
+    console.info(`[Test Page]: ${defaultUrl}`);
+    await page.goto(defaultUrl);
+    await expect(page.locator(pznUpdateLocator)).toHaveCount(0);
+    await expect(page.locator(defaultUlLocator)).toHaveCount(1);
+    const element = page.locator(defaultUlLocator);
+    await expect(element.locator('li')).toHaveCount(3);
+  });
+
+  await test.step('step-2: Verify personalized page has a text replacement for the ul list', async () => {
+    console.info(`[Test Page]: ${pznUrl}`);
+    await page.goto(pznUrl);
+    const element = page.locator(pznUpdateLocator);
+    const innerHtml = await element.innerHTML();
+    await expect(page.locator(pznUpdateLocator)).toHaveCount(1);
+    await expect(page.locator(defaultUlLocator)).toHaveCount(0);
+    await expect(innerHtml).toEqual('replacement for the ul');
+  });
+});
+
+// Test 1 : check li selectors
+test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
+  const pznUrl = `${baseURL}${features[1].path}${miloLibs}`;
+  const defaultUrl = `${baseURL}${features[1].data.defaultURL}${miloLibs}`;
+  const pznUpdateLocator = 'li[data-manifest-id="li-selectors.json"]';
+  const defaultUlLocator = 'ul.icon-list';
+
+  await test.step('step-1: verify the default test page has a regular ul list with 3 bullets', async () => {
+    console.info(`[Test Page]: ${defaultUrl}`);
+    await page.goto(defaultUrl);
+    await expect(page.locator(pznUpdateLocator)).toHaveCount(0);
+    await expect(page.locator(defaultUlLocator)).toHaveCount(1);
+    const element = page.locator(defaultUlLocator);
+    await expect(element.locator('li')).toHaveCount(3);
+  });
+
+  await test.step('step-2: Verify that the personalized page has 3 replacements for the line items', async () => {
+    console.info(`[Test Page]: ${pznUrl}`);
+    await page.goto(pznUrl);
+    const element = page.locator(pznUpdateLocator).first();
+    const innerHtml = await element.innerHTML();
+    await expect(page.locator(pznUpdateLocator)).toHaveCount(3);
+    await expect(innerHtml).toEqual('replace all line items');
+  });
+});

--- a/nala/features/personalization/ul-ol-li.test.js
+++ b/nala/features/personalization/ul-ol-li.test.js
@@ -4,7 +4,7 @@ import { features } from './ul-ol-li.spec.js';
 const miloLibs = process.env.MILO_LIBS || '';
 
 // Test 0 : check ul selectors (skipping ol selectors)
-test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+test(`[Test Id - ${features[0].tcid}] ${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
   const pznUrl = `${baseURL}${features[0].path}${miloLibs}`;
   const defaultUrl = `${baseURL}${features[0].data.defaultURL}${miloLibs}`;
   const pznUpdateLocator = '[data-manifest-id="ul-selector.json"]';
@@ -31,7 +31,7 @@ test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
 });
 
 // Test 1 : check li selectors
-test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
+test(`[Test Id - ${features[1].tcid}] ${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
   const pznUrl = `${baseURL}${features[1].path}${miloLibs}`;
   const defaultUrl = `${baseURL}${features[1].data.defaultURL}${miloLibs}`;
   const pznUpdateLocator = 'li[data-manifest-id="li-selectors.json"]';


### PR DESCRIPTION
This tests the ul and li selectors (and skips ol because we don't have anything in the library that uses ol in the plain html)

Resolves: [MWPW-162847](https://jira.corp.adobe.com/browse/MWPW-162847)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://ul-ol-li--milo--adobecom.aem.page/?martech=off

tests li selectors: https://main--milo--adobecom.hlx.page/drafts/nala/features/personalization/ul-ol-li/li-selectors
tests ul selector: https://main--milo--adobecom.hlx.page/drafts/nala/features/personalization/ul-ol-li/ul-selector
compare with their default pages:
https://main--milo--adobecom.hlx.page/drafts/nala/features/personalization/ul-ol-li/ul-selector?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Ful-ol-li%2Ful-selector.json--default
https://main--milo--adobecom.hlx.page/drafts/nala/features/personalization/ul-ol-li/li-selectors?mep=%2Fdrafts%2Fnala%2Ffeatures%2Fpersonalization%2Ful-ol-li%2Fli-selectors.json--default