### PR TITLE
Handle CLS issue on localnav: mobile redesign

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -997,7 +997,7 @@ header + .feds-localnav {
 
 .feds-localnav-title {
   width: 100%;
-  height: 53px;
+  height: 40px;
   font-size: 16px;
   font-weight: 700;
   border: 0;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -381,7 +381,7 @@ class Gnav {
     } else {
       let localNav = document.querySelector('.feds-localnav');
       if (!localNav) {
-        lanaLog({ message: `GNAV: Localnav does not include 'localnav' in its name.`, tags: 'errorType=info,module=gnav' });
+        lanaLog({ message: 'GNAV: Localnav does not include \'localnav\' in its name.', tags: 'errorType=info,module=gnav' });
         localNav = toFragment`<div class="feds-localnav"/>`;
         this.block.after(localNav);
       }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -5,6 +5,7 @@ import {
   loadIms,
   decorateLinks,
   loadScript,
+  getGnavSource,
 } from '../../utils/utils.js';
 import {
   closeAllDropdowns,
@@ -1174,19 +1175,9 @@ class Gnav {
   };
 }
 
-const getSource = async () => {
-  const { locale, dynamicNavKey } = getConfig();
-  let url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
-  if (dynamicNavKey) {
-    const { default: dynamicNav } = await import('../../features/dynamic-navigation/dynamic-navigation.js');
-    url = dynamicNav(url, dynamicNavKey);
-  }
-  return url;
-};
-
 export default async function init(block) {
   const { mep } = getConfig();
-  const sourceUrl = await getSource();
+  const sourceUrl = await getGnavSource();
   const newMobileNav = getMetadata('mobile-gnav-v2') !== 'false';
   const [url, hash = ''] = sourceUrl.split('#');
   if (hash === '_noActiveItem') {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -379,7 +379,12 @@ class Gnav {
     if (this.elements.localNav || !this.newMobileNav || isDesktop.matches) {
       localNavItems[0].querySelector('a').textContent = title.trim();
     } else {
-      const localNav = document.querySelector('.feds-localnav');
+      let localNav = document.querySelector('.feds-localnav');
+      if (!localNav) {
+        lanaLog({ message: `GNAV: Localnav does not include 'localnav' in its name.`, tags: 'errorType=info,module=gnav' });
+        localNav = toFragment`<div class="feds-localnav"/>`;
+        this.block.after(localNav);
+      }
       localNav.append(toFragment`<button class="feds-navLink--hoverCaret feds-localnav-title"></button>`, toFragment` <div class="feds-localnav-items"></div>`);
 
       const itemWrapper = localNav.querySelector('.feds-localnav-items');

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -725,7 +725,7 @@ header.global-navigation a {
 }
 
 .feds-localnav {
-  height: 53px;
+  height: 40px;
 }
 
 @media (min-width: 900px) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -761,7 +761,7 @@ export async function getGnavSource() {
   return url;
 };
 
-function decorateHeader() {
+async function decorateHeader() {
   const breadcrumbs = document.querySelector('.breadcrumbs');
   breadcrumbs?.remove();
   const header = document.querySelector('header');
@@ -782,7 +782,7 @@ function decorateHeader() {
   const dynamicNavActive = getMetadata('dynamic-nav') === 'on'
     && window.sessionStorage.getItem('gnavSource') !== null;
   if (!dynamicNavActive && (baseBreadcrumbs || breadcrumbs || autoBreadcrumbs)) header.classList.add('has-breadcrumbs');
-  const gnavSource = getGnavSource();
+  const gnavSource = await getGnavSource();
   const gnavName = gnavSource.split('/').pop();
   
   if (gnavName.match('localnav') && getMetadata('mobile-gnav-v2') !== 'false') {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -751,6 +751,16 @@ function decorateDefaults(el) {
   });
 }
 
+export async function getGnavSource() {
+  const { locale, dynamicNavKey } = getConfig();
+  let url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
+  if (dynamicNavKey) {
+    const { default: dynamicNav } = await import('../features/dynamic-navigation/dynamic-navigation.js');
+    url = dynamicNav(url, dynamicNavKey);
+  }
+  return url;
+};
+
 function decorateHeader() {
   const breadcrumbs = document.querySelector('.breadcrumbs');
   breadcrumbs?.remove();
@@ -772,9 +782,8 @@ function decorateHeader() {
   const dynamicNavActive = getMetadata('dynamic-nav') === 'on'
     && window.sessionStorage.getItem('gnavSource') !== null;
   if (!dynamicNavActive && (baseBreadcrumbs || breadcrumbs || autoBreadcrumbs)) header.classList.add('has-breadcrumbs');
-  const gnavSource = getMetadata('gnav-source');
-  const gnavUrl = gnavSource.split('/');
-  const gnavName = gnavUrl[gnavUrl.length - 1];
+  const gnavSource = getGnavSource();
+  const gnavName = gnavSource.split('/').pop();
   
   if (gnavName.match('localnav') && getMetadata('mobile-gnav-v2') !== 'false') {
     // Preserving space to avoid CLS issue

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -759,7 +759,7 @@ export async function getGnavSource() {
     url = dynamicNav(url, dynamicNavKey);
   }
   return url;
-};
+}
 
 async function decorateHeader() {
   const breadcrumbs = document.querySelector('.breadcrumbs');
@@ -783,9 +783,7 @@ async function decorateHeader() {
     && window.sessionStorage.getItem('gnavSource') !== null;
   if (!dynamicNavActive && (baseBreadcrumbs || breadcrumbs || autoBreadcrumbs)) header.classList.add('has-breadcrumbs');
   const gnavSource = await getGnavSource();
-  const gnavName = gnavSource.split('/').pop();
-  
-  if (gnavName.match('localnav') && getMetadata('mobile-gnav-v2') !== 'false') {
+  if (gnavSource.split('/').pop().match('localnav') && getMetadata('mobile-gnav-v2') !== 'false') {
     // Preserving space to avoid CLS issue
     const localNavWrapper = createTag('div', { class: 'feds-localnav' });
     header.after(localNavWrapper);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -772,7 +772,11 @@ function decorateHeader() {
   const dynamicNavActive = getMetadata('dynamic-nav') === 'on'
     && window.sessionStorage.getItem('gnavSource') !== null;
   if (!dynamicNavActive && (baseBreadcrumbs || breadcrumbs || autoBreadcrumbs)) header.classList.add('has-breadcrumbs');
-  if (getMetadata('is-localnav') === 'true' && getMetadata('mobile-gnav-v2') !== 'false') {
+  const gnavSource = getMetadata('gnav-source');
+  const gnavUrl = gnavSource.split('/');
+  const gnavName = gnavUrl[gnavUrl.length - 1];
+  
+  if (gnavName.match('localnav') && getMetadata('mobile-gnav-v2') !== 'false') {
     // Preserving space to avoid CLS issue
     const localNavWrapper = createTag('div', { class: 'feds-localnav' });
     header.after(localNavWrapper);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

LocalNavs must include the string 'localnav' in their name; otherwise, they will encounter CLS issues with the mobile design for localnav.

* Adding a check for localnav string on gnav source and preserving space
* Adding Lana log if content is localnav but file name doesn't include localnav

Resolves: [MWPW-161998](https://jira.corp.adobe.com/browse/MWPW-161998)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mgnav-cls--milo--adobecom.aem.page/?martech=off

QA: 
- Without localnav string -  https://main--federal--adobecom.hlx.page/federal/dev/blaishram/page-with-localnav?milolibs=mgnav-cls
- With localnav string - https://main--federal--adobecom.hlx.page/federal/dev/blaishram/express/express?milolibs=mgnav-cls

