### PR TITLE
MWPW-140452 - Icon authoring in milo using the federal repo and individual SVG assets

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -351,6 +351,7 @@
   width: 15px;
   height: 15px;
   cursor: pointer;
+  margin-inline: unset;
 }
 
 .table .section-head-title:hover .icon.expand {

--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -100,7 +100,7 @@
   position: relative;
 }
 
-.text-block .icon-list-item .icon.margin-right:not(.margin-left) { /* target first node only */
+.text-block .icon-list-item .icon.node-index-first:not(.node-index-last) { /* target first node only */
   position: absolute;
   inset: 0 100% auto auto;
 }
@@ -122,7 +122,6 @@
 
 .text-block .icon-area {
   display: flex;
-  column-gap: var(--spacing-xs);
 }
 
 .text-block p.icon-area { /* NOT <a/> tags with icons in them */
@@ -216,10 +215,6 @@
 
 .section[class*='grid-width-'] .text-block .foreground {
   max-width: unset;
-}
-
-.text-block .icon-area.con-button {
-  column-gap: unset;
 }
 
 .text-block .icon-area picture {

--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -100,7 +100,7 @@
   position: relative;
 }
 
-.text-block .icon-list-item .icon.node-index-first:not(.node-index-last) { /* target first node only */
+.text-block .icon-list-item .icon.node-index-first {
   position: absolute;
   inset: 0 100% auto auto;
 }

--- a/libs/features/georoutingv2/georoutingv2.css
+++ b/libs/features/georoutingv2/georoutingv2.css
@@ -83,6 +83,7 @@
 }
 
 .dialog-modal.locale-modal-v2 span.icon {
+  display: inline;
   vertical-align: middle;
 }
 

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -194,7 +194,7 @@ function buildContent(currentPage, locale, geoData, locales) {
     { once: true },
   );
   img.src = `${config.miloLibs || config.codeRoot}/img/georouting/${flagFile}`;
-  const span = createTag('span', { class: 'icon margin-inline-end' }, img);
+  const span = createTag('span', { class: 'icon node-index-first' }, img);
   const mainAction = createTag('a', {
     class: 'con-button blue button-l', lang, role: 'button', 'aria-haspopup': !!locales, 'aria-expanded': false, href: '#',
   }, span);

--- a/libs/features/icons/icons.css
+++ b/libs/features/icons/icons.css
@@ -4,7 +4,7 @@
   border-bottom: none;
 }
 
-.milo-tooltip::before {
+.milo-tooltip::before { 
   content: attr(data-tooltip);
   position: absolute;
   top: 50%;

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -90,6 +90,7 @@ export default async function loadIcons(icons) {
           federalIcons[iconName] = svgClone;
         })
         .catch((error) => {
+          /* c8 ignore next */
           window.lana?.log(`Error fetching SVG for ${iconName}:`, error);
         }));
     }

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -52,16 +52,15 @@ function decorateToolTip(icon) {
   wrapper.parentElement.replaceChild(icon, wrapper);
 }
 
-export async function setNodeIndexClass(icons) {
-  icons.forEach(async (icon) => {
-    const parent = icon.parentNode;
-    const children = parent.childNodes;
-    const nodeIndex = Array.prototype.indexOf.call(children, icon);
-    let indexClass = (nodeIndex === children.length - 1) ? 'last' : 'middle';
-    if (nodeIndex === 0) indexClass = 'first';
-    if (children.length === 1) indexClass = 'only';
-    icon.classList.add(`node-index-${indexClass}`);
-  });
+export function setNodeIndexClass(icon) {
+  const parent = icon.parentNode;
+  const children = parent.childNodes;
+  console.log('parent', parent, 'children', children);
+  const nodeIndex = Array.prototype.indexOf.call(children, icon);
+  let indexClass = (nodeIndex === children.length - 1) ? 'last' : 'middle';
+  if (nodeIndex === 0) indexClass = 'first';
+  if (children.length === 1) indexClass = 'only';
+  icon.classList.add(`node-index-${indexClass}`);
 }
 
 export default async function loadIcons(icons) {
@@ -71,6 +70,7 @@ export default async function loadIcons(icons) {
 
   icons.forEach((icon) => {
     icon.classList.add('milo-icon');
+    setNodeIndexClass(icon);
     const iconName = [...icon.classList].find((c) => c.startsWith('icon-'))?.substring(5);
     if (icon.dataset.svgInjected || !iconName) return;
     if (iconName === 'tooltip') {

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -68,9 +68,11 @@ export default async function loadIcons(icons) {
   const iconsToFetch = new Map();
 
   icons.forEach((icon) => {
+    setNodeIndexClass(icon);
     if (icon.classList.contains('icon-tooltip')) decorateToolTip(icon);
     const iconName = [...icon.classList].find((c) => c.startsWith('icon-'))?.substring(5);
     if (icon.dataset.svgInjected || !iconName) return;
+    icon.setAttribute('data-name', iconName);
     if (!federalIcons[iconName] && !iconsToFetch.has(iconName)) {
       const url = `${fedRoot}/federal/assets/icons/svgs/${iconName}.svg`;
       iconsToFetch.set(iconName, fetch(url)
@@ -101,7 +103,7 @@ export default async function loadIcons(icons) {
   await Promise.all(iconRequests);
 
   icons.forEach((icon) => {
-    const iconName = [...icon.classList].find((c) => c.startsWith('icon-'))?.substring(5);
+    const iconName = icon.getAttribute('data-name');
     if (iconName && federalIcons[iconName] && !icon.dataset.svgInjected) {
       const svgClone = federalIcons[iconName].cloneNode(true);
       icon.appendChild(svgClone);

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -89,8 +89,8 @@ export default async function loadIcons(icons) {
           svgClone.classList.add('icon-milo', `icon-milo-${iconName}`);
           federalIcons[iconName] = svgClone;
         })
+        /* c8 ignore next 3 */
         .catch((error) => {
-          /* c8 ignore next */
           window.lana?.log(`Error fetching SVG for ${iconName}:`, error);
         }));
     }

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -66,7 +66,6 @@ export function getIconData(icon) {
 function preloadInViewIconResources(config) {
   const { base } = config;
   loadStyle(`${base}/features/icons/icons.css`);
-  loadLink(`${base}/utils/federated.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
 }
 
 const preloadInViewIcons = async (icons = []) => icons.forEach((icon) => {

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -39,7 +39,7 @@ export const fetchIcons = (config) => new Promise(async (resolve) => {
   resolve(fetchedIcons);
 });
 
-function decorateToolTip(icon) {
+async function decorateToolTip(icon) {
   const wrapper = icon.closest('em');
   if (!wrapper) return;
   wrapper.className = 'tooltip-wrapper';
@@ -99,7 +99,7 @@ function filterDuplicatedIcons(icons) {
   return uniqueIcons;
 }
 
-export function decorateIcons(area, icons, config) {
+export async function decorateIcons(area, icons, config) {
   if (!icons.length) return;
   const iconsATF = [...icons].filter((icon) => isElementInView(icon));
   const uniqueIcons = filterDuplicatedIcons(iconsATF);
@@ -130,8 +130,9 @@ export default async function loadIcons(icons) {
   const iconRequests = [];
   const iconsToFetch = new Map();
 
-  icons.forEach((icon) => {
-    if (icon.classList.contains('icon-tooltip')) decorateToolTip(icon);
+  icons.forEach(async (icon) => {
+    const isToolTip = icon.classList.contains('icon-tooltip');
+    if (isToolTip) decorateToolTip(icon);
     const iconName = icon.dataset.name;
     if (icon.dataset.svgInjected || !iconName) return;
     if (!federalIcons[iconName] && !iconsToFetch.has(iconName)) {

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -82,7 +82,7 @@ export default async function loadIcons(icons) {
           const svgDoc = parser.parseFromString(text, 'image/svg+xml');
           const svgElement = svgDoc.querySelector('svg');
           if (!svgElement) {
-            console.error(`No SVG element found in fetched content for ${iconName}`);
+            window.lana?.log(`No SVG element found in fetched content for ${iconName}`);
             return;
           }
           const svgClone = svgElement.cloneNode(true);

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -55,7 +55,7 @@ function decorateToolTip(icon) {
 export function setNodeIndexClass(icon) {
   const parent = icon.parentNode;
   const children = parent.childNodes;
-  const nodeIndex = Array.prototype.indexOf.call(children, icon);
+  const nodeIndex = [...children].indexOf.call(children, icon);
   let indexClass = (nodeIndex === children.length - 1) ? 'last' : 'middle';
   if (nodeIndex === 0) indexClass = 'first';
   if (children.length === 1) indexClass = 'only';

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -67,7 +67,6 @@ function preloadInViewIconResources(config) {
   const { base } = config;
   loadStyle(`${base}/features/icons/icons.css`);
   loadLink(`${base}/utils/federated.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
-  loadLink(`${base}/features/icons/icons.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
 }
 
 const preloadInViewIcons = async (icons = []) => icons.forEach((icon) => {

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -68,7 +68,6 @@ export default async function loadIcons(icons) {
   const iconsToFetch = new Map();
 
   icons.forEach((icon) => {
-    setNodeIndexClass(icon);
     if (icon.classList.contains('icon-tooltip')) decorateToolTip(icon);
     const iconName = [...icon.classList].find((c) => c.startsWith('icon-'))?.substring(5);
     if (icon.dataset.svgInjected || !iconName) return;

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -75,16 +75,6 @@ const preloadInViewIcons = async (icons = []) => icons.forEach((icon) => {
   loadLink(path, { rel: 'preload', as: 'fetch', crossorigin: 'anonymous' });
 });
 
-function isElementInView(e) {
-  const rect = e.getBoundingClientRect();
-  return (
-    rect.top >= 0
-    && rect.left >= 0
-    && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
-    && rect.right <= (window.innerWidth || document.documentElement.clientWidth)
-  );
-}
-
 function filterDuplicatedIcons(icons) {
   if (!icons.length) return [];
   const uniqueIconKeys = new Set();
@@ -101,8 +91,7 @@ function filterDuplicatedIcons(icons) {
 
 export async function decorateIcons(area, icons, config) {
   if (!icons.length) return;
-  const iconsATF = [...icons].filter((icon) => isElementInView(icon));
-  const uniqueIcons = filterDuplicatedIcons(iconsATF);
+  const uniqueIcons = filterDuplicatedIcons(icons);
   if (!uniqueIcons.length) return;
   preloadInViewIcons(uniqueIcons);
   preloadInViewIconResources(config);

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -113,18 +113,6 @@ export async function decorateIcons(area, icons, config) {
   });
 }
 
-export function setIconsIndexClass(icons) {
-  [...icons].forEach((icon) => {
-    const parent = icon.parentNode;
-    const children = parent.childNodes;
-    const nodeIndex = [...children].indexOf.call(children, icon);
-    let indexClass = (nodeIndex === children.length - 1) ? 'last' : 'middle';
-    if (nodeIndex === 0) indexClass = 'first';
-    if (children.length === 1) indexClass = 'only';
-    icon.classList.add(`node-index-${indexClass}`);
-  });
-}
-
 export default async function loadIcons(icons) {
   const fedRoot = getFederatedContentRoot();
   const iconRequests = [];

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -55,7 +55,6 @@ function decorateToolTip(icon) {
 export function setNodeIndexClass(icon) {
   const parent = icon.parentNode;
   const children = parent.childNodes;
-  console.log('parent', parent, 'children', children);
   const nodeIndex = Array.prototype.indexOf.call(children, icon);
   let indexClass = (nodeIndex === children.length - 1) ? 'last' : 'middle';
   if (nodeIndex === 0) indexClass = 'first';

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -570,9 +570,9 @@ span.icon {
 }
 
 span.icon.node-index-first { margin-inline-start: unset; }
-span.icon.node-index-middle {  margin-inline: var(--icon-spacing); }
-span.icon.node-index-last {  margin-inline-end: unset; }
-span.icon.node-index-only {  margin-inline: unset; }
+span.icon.node-index-middle { margin-inline: var(--icon-spacing); }
+span.icon.node-index-last { margin-inline-end: unset; }
+span.icon.node-index-only { margin-inline: unset; }
 
 span.icon svg {
   height: 1em;

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -564,7 +564,6 @@ div[data-failed="true"]::before {
 }
 
 span.icon {
-  height: 100%;
   width: 1em;
   display: inline-block;
   margin-inline: var(--icon-spacing);

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -559,19 +559,30 @@ div[data-failed="true"]::before {
   color: var(--color-gray-300);
 }
 
-span.icon.margin-right { margin-right: 8px; }
+span.icon {
+  height: 100%;
+  width: 1em;
+  display: inline-block;
+  margin-inline: var(--spacing-xxs);
+}
 
-span.icon.margin-left { margin-left: 8px; }
+span.icon.node-index-first { margin-inline-start: unset; }
+span.icon.node-index-middle {  margin-inline: var(--spacing-xxs); }
+span.icon.node-index-last {  margin-inline-end: unset; }
+span.icon.node-index-only {  margin-inline: unset; }
 
-span.icon.margin-inline-end { margin-inline-end: 8px; }
+span.icon svg {
+  height: 1em;
+  position: relative;
+  top: .1em;
+  width: auto;
+}
 
-span.icon.margin-inline-start { margin-inline-start: 8px; }
+.button-l .con-button span.icon,
+.con-button.button-l span.icon { margin-inline: 12px; }
 
-.button-l .con-button span.icon.margin-left,
-.con-button.button-l span.icon.margin-left { margin-left: 12px; }
-
-.button-xl .con-button span.icon.margin-left,
-.con-button.button-xl span.icon.margin-left { margin-left: 14px; }
+.button-xl .con-button span.icon,
+.con-button.button-xl span.icon { margin-inline: 14px; }
 
 /* Con Block Utils */
 .con-block.xs-spacing { padding: var(--spacing-xs) 0; }

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -128,6 +128,7 @@
   --icon-size-s: 32px;
   --icon-size-xs: 24px;
   --icon-size-xxs: 16px;
+  --icon-spacing: 8px;
 
   /* z-index */
   --above-all: 9000; /* Used for page tools that overlay page content */
@@ -349,6 +350,7 @@
   line-height: 20px;
   min-height: 21px;
   padding: 7px 18px 8px;
+  --icon-spacing: 12px;
 }
 
 .xl-button .con-button,
@@ -358,6 +360,7 @@
   line-height: 24px;
   min-height: 28px;
   padding: 10px 24px 8px;
+  --icon-spacing: 14px;
 }
 
 .xxl-button .con-button,
@@ -367,6 +370,7 @@
   line-height: 27px;
   min-height: 27px;
   padding: 14px 30px 15px;
+  --icon-spacing: 14px;
 }
 
 .con-button.button-justified {
@@ -563,11 +567,11 @@ span.icon {
   height: 100%;
   width: 1em;
   display: inline-block;
-  margin-inline: var(--spacing-xxs);
+  margin-inline: var(--icon-spacing);
 }
 
 span.icon.node-index-first { margin-inline-start: unset; }
-span.icon.node-index-middle {  margin-inline: var(--spacing-xxs); }
+span.icon.node-index-middle {  margin-inline: var(--icon-spacing); }
 span.icon.node-index-last {  margin-inline-end: unset; }
 span.icon.node-index-only {  margin-inline: unset; }
 
@@ -577,12 +581,6 @@ span.icon svg {
   top: .1em;
   width: auto;
 }
-
-.button-l .con-button span.icon,
-.con-button.button-l span.icon { margin-inline: 12px; }
-
-.button-xl .con-button span.icon,
-.con-button.button-xl span.icon { margin-inline: 14px; }
 
 /* Con Block Utils */
 .con-block.xs-spacing { padding: var(--spacing-xs) 0; }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1252,7 +1252,7 @@ async function resolveInlineFrags(section) {
   section.preloadLinks = newlyDecoratedSection.preloadLinks;
 }
 
-function setIconsIndexClass(icons) {
+export function setIconsIndexClass(icons) {
   [...icons].forEach((icon) => {
     const parent = icon.parentNode;
     const children = parent.childNodes;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -782,7 +782,7 @@ async function decorateIcons(area, config) {
   if (icons.length === 0) return;
   const { base } = config;
   loadStyle(`${base}/features/icons/icons.css`);
-  loadLink(`${base}/utils/federated.js`, { rel: 'preload', as: 'fetch', crossorigin: 'anonymous' });
+  loadLink(`${base}/utils/federated.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
   const { default: loadIcons, setNodeIndexClass } = await import('../features/icons/icons.js');
   setNodeIndexClass(icons);
   await loadIcons(icons);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -465,6 +465,13 @@ function getBlockData(block) {
   return { blockPath, name, hasStyles };
 }
 
+function getIconData(icon) {
+  const fedRoot = 'https://main--federal--adobecom.hlx.page'; // getFederatedContentRoot()
+  const name = [...icon.classList].find((c) => c.startsWith('icon-'))?.substring(5);
+  const path = `${fedRoot}/federal/assets/icons/svgs/${name}.svg`;
+  return { path, name };
+}
+
 export async function loadBlock(block) {
   if (block.classList.contains('hide-block')) {
     block.remove();
@@ -862,10 +869,25 @@ export function filterDuplicatedLinkBlocks(blocks) {
   return uniqueBlocks;
 }
 
+function filterDuplicatedIcons(icons) {
+  if (!icons.length) return [];
+  const uniqueIconKeys = new Set();
+  const uniqueIcons = [];
+  for (const icon of icons) {
+    const key = [...icon.classList].find((c) => c.startsWith('icon-'))?.substring(5);
+    if (!uniqueIconKeys.has(key)) {
+      uniqueIconKeys.add(key);
+      uniqueIcons.push(icon);
+    }
+  }
+  return uniqueIcons;
+}
+
 function decorateSection(section, idx) {
   let links = decorateLinks(section);
   decorateDefaults(section);
   const blocks = section.querySelectorAll(':scope > div[class]:not(.content)');
+  const sectionIcons = section.querySelectorAll('span.icon');
 
   const { doNotInline } = getConfig();
   const blockLinks = [...blocks].reduce((blkLinks, block) => {
@@ -898,6 +920,7 @@ function decorateSection(section, idx) {
     el: section,
     idx,
     preloadLinks: filterDuplicatedLinkBlocks(blockLinks.autoBlocks),
+    preloadIcons: filterDuplicatedIcons(sectionIcons),
   };
 }
 
@@ -1252,6 +1275,11 @@ const preloadBlockResources = (blocks = []) => blocks.map((block) => {
   return hasStyles && new Promise((resolve) => { loadStyle(`${blockPath}.css`, resolve); });
 }).filter(Boolean);
 
+const preloadSectionResources = async (section, icons = []) => icons.forEach((icon) => {
+  const { path } = getIconData(icon);
+  loadLink(path, { rel: 'preload', as: 'fetch', crossorigin: 'anonymous' });
+});
+
 async function resolveInlineFrags(section) {
   const inlineFrags = [...section.el.querySelectorAll('a[href*="#_inline"]')];
   if (!inlineFrags.length) return;
@@ -1268,6 +1296,7 @@ async function processSection(section, config, isDoc) {
   const firstSection = section.el.dataset.idx === '0';
   const stylePromises = firstSection ? preloadBlockResources(section.blocks) : [];
   preloadBlockResources(section.preloadLinks);
+  if (firstSection) preloadSectionResources(section, section.preloadIcons);
   await Promise.all([
     decoratePlaceholders(section.el, config),
     decorateIcons(section.el, config),
@@ -1283,6 +1312,14 @@ async function processSection(section, config, isDoc) {
 
   // Only move on to the next section when all blocks are loaded.
   await Promise.all(loadBlocks);
+
+  console.log('section', section);
+  // const sections = document.body.querySelectorAll('div.section');
+  // if (sections.length) {
+  //   sections.forEach((section) => {
+  //     decorateIcons(section, config);
+  //   });
+  // }
 
   delete section.el.dataset.status;
   if (isDoc && firstSection) await loadPostLCP(config);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1292,11 +1292,9 @@ export async function loadArea(area = document) {
   }
 
   const allIcons = area.querySelectorAll('span.icon');
-  const iconUtils = [];
   if (allIcons.length) {
-    const { setIconsIndexClass, decorateIcons } = await import('../features/icons/icons.js');
+    const { setIconsIndexClass } = await import('../features/icons/icons.js');
     setIconsIndexClass(allIcons);
-    iconUtils.decorateIcons = decorateIcons;
   }
 
   const sections = decorateSections(area, isDoc);
@@ -1311,7 +1309,11 @@ export async function loadArea(area = document) {
     });
   }
 
-  if (allIcons.length && isDoc) await iconUtils.decorateIcons(area, allIcons, config);
+  if (allIcons.length) {
+    const { default: loadIcons, decorateIcons } = await import('../features/icons/icons.js');
+    await decorateIcons(area, allIcons, config);
+    await loadIcons(allIcons);
+  }
 
   const currentHash = window.location.hash;
   if (currentHash) {
@@ -1319,8 +1321,6 @@ export async function loadArea(area = document) {
   }
 
   if (isDoc) {
-    const { default: loadIcons } = await import('../features/icons/icons.js');
-    loadIcons(allIcons);
     await documentPostSectionLoading(area, config);
   }
   await loadDeferred(area, areaBlocks, config);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1322,8 +1322,9 @@ export async function loadArea(area = document) {
 
   if (allIcons.length) {
     const { default: loadIcons, decorateIcons } = await import('../features/icons/icons.js');
-    await decorateIcons(area, allIcons, config);
-    await loadIcons(allIcons);
+    const areaIcons = area.querySelectorAll('span.icon');
+    await decorateIcons(area, areaIcons, config);
+    await loadIcons(areaIcons);
   }
 
   const currentHash = window.location.hash;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -783,8 +783,9 @@ async function decorateIcons(area, config) {
   const { base } = config;
   loadStyle(`${base}/features/icons/icons.css`);
   loadLink(`${base}/img/icons/icons.svg`, { rel: 'preload', as: 'fetch', crossorigin: 'anonymous' });
-  const { default: loadIcons } = await import('../features/icons/icons.js');
-  await loadIcons(icons, config);
+  const { default: loadIcons, setNodeIndexClass } = await import('../features/icons/icons.js');
+  setNodeIndexClass(icons);
+  await loadIcons(icons);
 }
 
 export async function customFetch({ resource, withCacheRules }) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -311,7 +311,7 @@ export function localizeLink(
     const isLocalizedLink = path.startsWith(`/${LANGSTORE}`)
       || path.startsWith(`/${PREVIEW}`)
       || Object.keys(locales).some((loc) => loc !== '' && (path.startsWith(`/${loc}/`)
-      || path.endsWith(`/${loc}`)));
+        || path.endsWith(`/${loc}`)));
     if (isLocalizedLink) return processedHref;
     const urlPath = `${locale.prefix}${path}${url.search}${hash}`;
     return relative ? urlPath : `${url.origin}${urlPath}`;
@@ -764,7 +764,7 @@ function decorateHeader() {
   }
   header.className = headerMeta || 'global-navigation';
   const metadataConfig = getMetadata('breadcrumbs')?.toLowerCase()
-  || getConfig().breadcrumbs;
+    || getConfig().breadcrumbs;
   if (metadataConfig === 'off') return;
   const baseBreadcrumbs = getMetadata('breadcrumbs-base')?.length;
 
@@ -816,8 +816,8 @@ async function decoratePlaceholders(area, config) {
   area.dataset.hasPlaceholders = 'true';
   const placeholderPath = `${config.locale?.contentRoot}/placeholders.json`;
   placeholderRequest = placeholderRequest
-  || customFetch({ resource: placeholderPath, withCacheRules: true })
-    .catch(() => ({}));
+    || customFetch({ resource: placeholderPath, withCacheRules: true })
+      .catch(() => ({}));
   const { decoratePlaceholderArea } = await import('../features/placeholders.js');
   await decoratePlaceholderArea({ placeholderPath, placeholderRequest, nodes });
 }
@@ -1252,6 +1252,18 @@ async function resolveInlineFrags(section) {
   section.preloadLinks = newlyDecoratedSection.preloadLinks;
 }
 
+function setIconsIndexClass(icons) {
+  [...icons].forEach((icon) => {
+    const parent = icon.parentNode;
+    const children = parent.childNodes;
+    const nodeIndex = [...children].indexOf.call(children, icon);
+    let indexClass = (nodeIndex === children.length - 1) ? 'last' : 'middle';
+    if (nodeIndex === 0) indexClass = 'first';
+    if (children.length === 1) indexClass = 'only';
+    icon.classList.add(`node-index-${indexClass}`);
+  });
+}
+
 async function processSection(section, config, isDoc) {
   await resolveInlineFrags(section);
   const firstSection = section.el.dataset.idx === '0';
@@ -1293,7 +1305,6 @@ export async function loadArea(area = document) {
 
   const allIcons = area.querySelectorAll('span.icon');
   if (allIcons.length) {
-    const { setIconsIndexClass } = await import('../features/icons/icons.js');
     setIconsIndexClass(allIcons);
   }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1313,14 +1313,6 @@ async function processSection(section, config, isDoc) {
   // Only move on to the next section when all blocks are loaded.
   await Promise.all(loadBlocks);
 
-  console.log('section', section);
-  // const sections = document.body.querySelectorAll('div.section');
-  // if (sections.length) {
-  //   sections.forEach((section) => {
-  //     decorateIcons(section, config);
-  //   });
-  // }
-
   delete section.el.dataset.status;
   if (isDoc && firstSection) await loadPostLCP(config);
   delete section.el.dataset.idx;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -782,7 +782,7 @@ async function decorateIcons(area, config) {
   if (icons.length === 0) return;
   const { base } = config;
   loadStyle(`${base}/features/icons/icons.css`);
-  loadLink(`${base}/img/icons/icons.svg`, { rel: 'preload', as: 'fetch', crossorigin: 'anonymous' });
+  loadLink(`${base}/utils/federated.js`, { rel: 'preload', as: 'fetch', crossorigin: 'anonymous' });
   const { default: loadIcons, setNodeIndexClass } = await import('../features/icons/icons.js');
   setNodeIndexClass(icons);
   await loadIcons(icons);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -783,8 +783,7 @@ async function decorateIcons(area, config) {
   const { base } = config;
   loadStyle(`${base}/features/icons/icons.css`);
   loadLink(`${base}/utils/federated.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
-  const { default: loadIcons, setNodeIndexClass } = await import('../features/icons/icons.js');
-  setNodeIndexClass(icons);
+  const { default: loadIcons } = await import('../features/icons/icons.js');
   await loadIcons(icons);
 }
 

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -3,7 +3,8 @@ import { expect } from '@esm-bundle/chai';
 import sinon, { stub } from 'sinon';
 import { waitForElement } from '../../helpers/waitfor.js';
 
-const { default: loadIcons, getIconData, setIconsIndexClass } = await import('../../../libs/features/icons/icons.js');
+const { default: loadIcons, getIconData } = await import('../../../libs/features/icons/icons.js');
+const { setIconsIndexClass } = await import('../../../libs/utils/utils.js');
 const mockRes = ({ payload, status = 200, ok = true } = {}) => new Promise((resolve) => {
   resolve({
     status,

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -2,20 +2,44 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
 import { setConfig, getConfig, createTag } from '../../../libs/utils/utils.js';
+import { waitForElement } from '../../helpers/waitfor.js';
 
-const { default: loadIcons } = await import('../../../libs/features/icons/icons.js');
+const { default: loadIcons, setNodeIndexClass } = await import('../../../libs/features/icons/icons.js');
 
 const codeRoot = '/libs';
 const conf = { codeRoot };
 setConfig(conf);
 const config = getConfig();
 
+const mockRes = ({ payload, status = 200, ok = true } = {}) => new Promise((resolve) => {
+  resolve({
+    status,
+    ok,
+    json: () => payload,
+    text: () => payload,
+  });
+});
+
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
+const originalFetch = window.fetch;
 let icons;
+const svgEx = `<?xml version="1.0" encoding="UTF-8"?>
+<svg id="arrow-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+  <path fill="currentcolor" d="M12,10V1.5a.5.5,0,0,0-.5-.5h-5a.5.5,0,0,0-.5.5V10H2.5035a.25.25,0,0,0-.177.427L9,17.1l6.673-6.673A.25.25,0,0,0,15.4965,10Z"></path>
+</svg>`;
 
 describe('Icon Suppprt', () => {
   let paramsGetStub;
+
+  beforeEach(() => {
+    window.fetch = stub().callsFake(() => mockRes({}));
+  });
+
+  afterEach(() => {
+    // Do not build up any test state - reset window.fetch to it's original state
+    window.fetch = originalFetch;
+  });
 
   before(() => {
     paramsGetStub = stub(URLSearchParams.prototype, 'get');
@@ -26,20 +50,27 @@ describe('Icon Suppprt', () => {
     paramsGetStub.restore();
   });
 
-  before(async () => {
-    icons = document.querySelectorAll('span.icon');
-    await loadIcons(icons, config);
-    await loadIcons(icons, config); // Test duplicate icon not created if run twice
-  });
-
   it('Fetches successfully with cache control enabled', async () => {
     const otherIcons = [createTag('span', { class: 'icon icon-play' })];
     await loadIcons(otherIcons, config);
   });
 
   it('Replaces span.icon', async () => {
-    const selector = icons[0].querySelector(':scope svg');
+    const payload = svgEx;
+    window.fetch.returns(mockRes({ payload }));
+
+    icons = document.querySelectorAll('span.icon');
+    await loadIcons(icons, config);
+
+    const selector = await waitForElement('span.icon svg');
     expect(selector).to.exist;
+  });
+
+  it('Sets node index class', async () => {
+    icons = document.querySelectorAll('span.icon');
+    setNodeIndexClass(icons);
+    const secondIconHasIndexClass = icons[2].classList.contains('node-index-last');
+    expect(secondIconHasIndexClass).to.be.true;
   });
 
   it('No duplicate icon', async () => {

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -1,16 +1,9 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
-import { setConfig, getConfig, createTag } from '../../../libs/utils/utils.js';
 import { waitForElement } from '../../helpers/waitfor.js';
 
 const { default: loadIcons, setNodeIndexClass } = await import('../../../libs/features/icons/icons.js');
-
-const codeRoot = '/libs';
-const conf = { codeRoot };
-setConfig(conf);
-const config = getConfig();
-
 const mockRes = ({ payload, status = 200, ok = true } = {}) => new Promise((resolve) => {
   resolve({
     status,
@@ -22,7 +15,6 @@ const mockRes = ({ payload, status = 200, ok = true } = {}) => new Promise((reso
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
-const originalFetch = window.fetch;
 let icons;
 const svgEx = `<?xml version="1.0" encoding="UTF-8"?>
 <svg id="arrow-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
@@ -30,29 +22,12 @@ const svgEx = `<?xml version="1.0" encoding="UTF-8"?>
 </svg>`;
 
 describe('Icon Suppprt', () => {
-  let paramsGetStub;
-
   beforeEach(() => {
-    window.fetch = stub().callsFake(() => mockRes({}));
+    stub(window, 'fetch').callsFake(() => mockRes({}));
   });
 
   afterEach(() => {
-    // Do not build up any test state - reset window.fetch to it's original state
-    window.fetch = originalFetch;
-  });
-
-  before(() => {
-    paramsGetStub = stub(URLSearchParams.prototype, 'get');
-    paramsGetStub.withArgs('cache').returns('off');
-  });
-
-  after(() => {
-    paramsGetStub.restore();
-  });
-
-  it('Fetches successfully with cache control enabled', async () => {
-    const otherIcons = [createTag('span', { class: 'icon icon-play' })];
-    await loadIcons(otherIcons, config);
+    window.fetch.restore();
   });
 
   it('Replaces span.icon', async () => {
@@ -60,7 +35,7 @@ describe('Icon Suppprt', () => {
     window.fetch.returns(mockRes({ payload }));
 
     icons = document.querySelectorAll('span.icon');
-    await loadIcons(icons, config);
+    await loadIcons(icons);
 
     const selector = await waitForElement('span.icon svg');
     expect(selector).to.exist;
@@ -68,7 +43,7 @@ describe('Icon Suppprt', () => {
 
   it('Sets node index class', async () => {
     icons = document.querySelectorAll('span.icon');
-    setNodeIndexClass(icons);
+    setNodeIndexClass(icons[2]);
     const secondIconHasIndexClass = icons[2].classList.contains('node-index-last');
     expect(secondIconHasIndexClass).to.be.true;
   });

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -1,6 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import { stub } from 'sinon';
+import sinon, { stub } from 'sinon';
 import { waitForElement } from '../../helpers/waitfor.js';
 
 const { default: loadIcons, setNodeIndexClass } = await import('../../../libs/features/icons/icons.js');
@@ -27,7 +27,7 @@ describe('Icon Suppprt', () => {
   });
 
   afterEach(() => {
-    window.fetch.restore();
+    sinon.restore();
   });
 
   it('Replaces span.icon', async () => {

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -3,7 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon, { stub } from 'sinon';
 import { waitForElement } from '../../helpers/waitfor.js';
 
-const { default: loadIcons, setNodeIndexClass } = await import('../../../libs/features/icons/icons.js');
+const { default: loadIcons, getIconData, setIconsIndexClass } = await import('../../../libs/features/icons/icons.js');
 const mockRes = ({ payload, status = 200, ok = true } = {}) => new Promise((resolve) => {
   resolve({
     status,
@@ -35,15 +35,19 @@ describe('Icon Suppprt', () => {
     window.fetch.returns(mockRes({ payload }));
 
     icons = document.querySelectorAll('span.icon');
+    icons.forEach((icon) => {
+      const { name } = getIconData(icon);
+      icon.dataset.name = name;
+    });
     await loadIcons(icons);
 
     const selector = await waitForElement('span.icon svg');
     expect(selector).to.exist;
   });
 
-  it('Sets node index class', async () => {
+  it('Sets icon index class', async () => {
     icons = document.querySelectorAll('span.icon');
-    setNodeIndexClass(icons[2]);
+    setIconsIndexClass(icons);
     const secondIconHasIndexClass = icons[2].classList.contains('node-index-last');
     expect(secondIconHasIndexClass).to.be.true;
   });

--- a/test/features/icons/mocks/body.html
+++ b/test/features/icons/mocks/body.html
@@ -1,4 +1,6 @@
-<header></header>
+<header>
+  <style> span.icon svg { height: 1em; width: auto; }</style>
+</header>
 <main>
   <!-- Default content -->
   <div>

--- a/test/features/icons/mocks/body.html
+++ b/test/features/icons/mocks/body.html
@@ -1,5 +1,5 @@
 <header>
-  <style> span.icon svg { height: 1em; width: auto; }</style>
+  <style>span.icon svg { height: 1em; width: auto; }</style>
 </header>
 <main>
   <!-- Default content -->


### PR DESCRIPTION
This initial [PR](https://github.com/adobecom/milo/pull/2986) was reverted due to some issues found w/ tooltips in the table block. re-submitting as this has been resolved. 

---

To streamline icon management across Milo and other consuming sites, a centralized repository, federal, along with a directory named `icons/svgs`, will be established. This will provide shared access to a unified set of icons. The transition will maintain the current authoring experience, while also introducing new opportunities for contributors to expand the icon set. The key points of this change are outlined below:

Key Points:

**Centralized Icon Repository:** A new [/assets/icons/svgs](https://adobe.sharepoint.com/sites/adobecom/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fadobecom%2FShared%20Documents%2Ffederal%2Ffederal%2Fassets%2Ficons%2Fsvgs&viewid=d776cf70%2D9b7e%2D4ab7%2Db9da%2D9e0f8e03a7d2) directory was added to the [/federal/](https://adobe.sharepoint.com/sites/adobecom/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fadobecom%2FShared%20Documents%2Ffederal&viewid=d776cf70%2D9b7e%2D4ab7%2Db9da%2D9e0f8e03a7d2) repo, allowing multiple sites (Milo and others) to use the same set of icons. All icons currently available are listed here [/icons/icons.json](https://main--federal--adobecom.hlx.page/federal/assets/icons/icons.json)

**Consistent Authoring Notation:** Authors will continue to use the current notation, such as `:icon-play:`, to insert icons into content. This ensures a seamless transition with no change in authoring experience.

**Source Change:** Icons will no longer be served from the Milo code-bus. Instead, they will be fetched from the federal repository via the content-bus.

**Author Contributions:** This new system enables authors to contribute and expand the icon set by adding new icons to the centralized repository, a feature that was previously unavailable.

**Subsequent Ticket:** The Sidekick plugin library will be updated in a subsequent ticket to improve authoring accessibility for that component - see [MWPW-159581](https://jira.corp.adobe.com/browse/MWPW-159581)

Resolves: [MWPW-140452](https://jira.corp.adobe.com/browse/MWPW-140452)

**Draft URLs:**

Before: https://main--milo--adobecom.hlx.page/drafts/rparrish/icon/icons-federal?martech=off
After: https://rparrish-fed-icons--milo--adobecom.hlx.page/drafts/rparrish/icon/icons-federal?martech=off

**Doc URLs:**

Before: https://main--milo--adobecom.hlx.page/docs/library/kitchen-sink/?martech=off
After: https://rparrish-fed-icons--milo--adobecom.hlx.page/docs/library/kitchen-sink/?martech=off

URLs where the `tooltip / table` issue was found:
https://main--dc--adobecom.hlx.page/acrobat/pricing?milolibs=rparrish-fed-icons&martech=off

⚠️ All consuming sites should be tested for this change. ?milolibs=rparrish-fed-icons
https://main--bacom--adobecom.hlx.page/?milolibs=rparrish-fed-icons