### PR TITLE
[LOC] MWPW 162874: Removing duplicate urls from enter urls textarea

### DIFF
--- a/libs/blocks/locui-create/input-urls/view.js
+++ b/libs/blocks/locui-create/input-urls/view.js
@@ -119,8 +119,13 @@ export default function InputUrls() {
   }, []);
 
   const handleUrlsBlur = () => {
-    if (!errors.urlsStr && fragmentsEnabled) {
-      fetchFragments(urlsStr, true);
+    if (!errors.urlsStr) {
+      const splittedUrls = urlsStr.split(URL_SEPARATOR_PATTERN).filter((url) => url);
+      const uniqueUrls = Array.from(new Set(splittedUrls)).join('\n');
+      setUrlsStr(uniqueUrls);
+      if (fragmentsEnabled) {
+        fetchFragments(uniqueUrls, true);
+      }
     }
   };
 


### PR DESCRIPTION
* Used for removing duplicate urls from enter urls textarea.
* Duplicate urls will be removed onBlur event.

Resolves: https://jira.corp.adobe.com/browse/MWPW-162874

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://mwpw-162874-duplicate-urls--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off
