### PR TITLE
Handles promote on drafts path only

### DIFF
--- a/tools/floodbox/floodgate/floodgate.js
+++ b/tools/floodbox/floodgate/floodgate.js
@@ -60,6 +60,7 @@ export default class MiloFloodgate extends LitElement {
       path: this._pinkSitePath,
       accessToken: this.token,
       crawlType: 'floodgate',
+      isDraftsOnly: this._floodgateConfig.isPromoteDraftsOnly,
       callback: () => {
         this.requestUpdate();
       },

--- a/tools/floodbox/graybox/graybox.js
+++ b/tools/floodbox/graybox/graybox.js
@@ -74,7 +74,7 @@ export default class MiloGraybox extends LitElement {
     };
   }
 
-  async startCrawl(experiencePath) {
+  async startCrawl(experiencePath, expName) {
     const { results, getDuration } = crawl({
       path: experiencePath,
       callback: () => {
@@ -83,6 +83,7 @@ export default class MiloGraybox extends LitElement {
       throttle: 10,
       accessToken: this.token,
       crawlType: 'graybox',
+      isDraftsOnly: this._grayboxConfig.isDraftsOnly(expName),
     });
     this._crawledFiles = await results;
     this.cleanUpIgnoreFilesFromPromote(this._crawledFiles);
@@ -100,6 +101,7 @@ export default class MiloGraybox extends LitElement {
         repo,
         expName: exp,
         promoteType: 'graybox',
+        isDraftOnly: this._grayboxConfig.isDraftsOnly(exp),
         files: this._filesToPromote,
         callback: (status) => {
           // eslint-disable-next-line no-console
@@ -190,11 +192,11 @@ export default class MiloGraybox extends LitElement {
     this.readPromoteIgnorePaths();
 
     // #1 - Start crawling
+    const { org, repo, exp } = this.getOrgRepoExp();
     this._startCrawlExp = true;
-    await this.startCrawl(this._gbExpPath);
+    await this.startCrawl(this._gbExpPath, exp);
 
     // #2 - Start promoting
-    const { org, repo, exp } = this.getOrgRepoExp();
     this._startPromote = true;
     await this.startPromote(org, repo, exp);
 


### PR DESCRIPTION
- Caters to "drafts only" global flag when performing promote
- Updates both FG and GB apps on DA

Resolves: [MWPW-161916](https://jira.corp.adobe.com/browse/MWPW-161916), [MWPW-161936](https://jira.corp.adobe.com/browse/MWPW-161936)

**Test URLs:**
- Before: https://da.live/app/adobecom/milo/tools/graybox?ref=floodbox
- Before: https://da.live/app/adobecom/milo/tools/floodgate?ref=floodbox
- After: https://da.live/app/adobecom/milo/tools/graybox?ref=draftsonly
- After: https://da.live/app/adobecom/milo/tools/floodgate?ref=draftsonly
