### PR TITLE
MWPW-162722: Sticky promo banner loading issue

### DIFF
--- a/libs/blocks/section-metadata/sticky-section.js
+++ b/libs/blocks/section-metadata/sticky-section.js
@@ -2,7 +2,7 @@ import { createTag } from '../../utils/utils.js';
 import { getMetadata, getDelayTime } from './section-metadata.js';
 
 function handleTopHeight(section) {
-  const headerHeight = document.querySelector('header').offsetHeight;
+  const headerHeight = document.querySelector('header')?.offsetHeight ?? 0;
   section.style.top = `${headerHeight}px`;
 }
 

--- a/libs/blocks/section-metadata/sticky-section.js
+++ b/libs/blocks/section-metadata/sticky-section.js
@@ -51,6 +51,7 @@ export default async function handleStickySection(sticky, section) {
     case 'sticky-top': {
       const { debounce } = await import('../../utils/action.js');
       window.addEventListener('resize', debounce(() => handleTopHeight(section)));
+      handleTopHeight(section);
       main.prepend(section);
       break;
     }

--- a/libs/blocks/section-metadata/sticky-section.js
+++ b/libs/blocks/section-metadata/sticky-section.js
@@ -33,6 +33,7 @@ function handleStickyPromobar(section, delay) {
   if ((section.querySelector(':is(.promobar, .notification)').classList.contains('no-delay'))
     || (delay && section.classList.contains('popup'))) {
     hasScrollControl = true;
+    section.classList.remove('hide-sticky-section');
   }
   if (!hasScrollControl && main.children[0] !== section) {
     stickySectionEl = createTag('div', { class: 'section show-sticky-section' });

--- a/test/blocks/section-metadata/mocks/body.html
+++ b/test/blocks/section-metadata/mocks/body.html
@@ -130,6 +130,30 @@
       </div>
     </div>
   </div>
+  <div class="section sticky-bottom-no-delay">
+    <div class="aside notification small center promobar no-delay">
+      <div>
+        <div data-valign="middle"></div>
+      </div>
+      <div>
+        <div data-valign="middle">
+          <p>
+            <picture>
+              <img loading="lazy" alt="" src="" width="750" height="738">
+            </picture>
+          </p>
+          <p><strong>Body M 18/27 Lorem ipsum dolor sit amet, consectetur adipiscing elit. no-delay</strong></p>
+          <p><strong><a href="">Call to action</a></strong></p>
+        </div>
+      </div>
+    </div>
+    <div class="section-metadata">
+      <div>
+        <div>style</div>
+        <div>sticky bottom, dark</div>
+      </div>
+    </div>
+  </div>
   <div>
     <div class="section-metadata">
       <div>

--- a/test/blocks/section-metadata/section-meta.test.js
+++ b/test/blocks/section-metadata/section-meta.test.js
@@ -94,6 +94,14 @@ describe('Section Metdata', () => {
     expect(sec.classList.contains('hide-sticky-section')).not.to.be.true;
   });
 
+  it('add promobar behaviour to be visible when no-delay', async () => {
+    const main = document.querySelector('main');
+    const sec = document.querySelector('.section.sticky-bottom-no-delay .promobar').closest('.section');
+    const sm = sec.querySelector('.section-metadata');
+    await init(sm);
+    expect(main.lastElementChild.classList.contains('hide-sticky-section')).to.be.false;
+  });
+
   it('should calculate the top position based on header height', async () => {
     const sec = document.querySelector('.section.sticky-top');
     const header = document.createElement('header');


### PR DESCRIPTION
- Fixed sticky top promo banner that hides under breadcrumbs while scrolling.
- Fixed sticky bottom promo banner not being visible when no-delay option is obtained.

Resolves: [MWPW-162722](https://jira.corp.adobe.com/browse/MWPW-162722)

## Test URLs:

**Milo**
- Before: https://main--milo--sivasadobe.hlx.live/drafts/siva/162722/bf-promo-pepe-banner
- After: https://mwpw-162722--milo--sivasadobe.hlx.live/drafts/siva/162722/bf-promo-pepe-banner

**CC**
Promo Sticky Top
- Before: https://main--cc--adobecom.hlx.page/drafts/siva/162722/elements-family?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/siva/162722/elements-family?milolibs=mwpw-162722--milo--sivasadobe&martech=off

Promo Sticky Bottom
- Before: https://main--cc--adobecom.hlx.page/drafts/siva/162722/black-friday-sticky-banner-example?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/siva/162722/black-friday-sticky-banner-example?milolibs=mwpw-162722--milo--sivasadobe&martech=off
