### PR TITLE
[LOC] MWPW-163183 - fixed cta issue when no fragments is selected

### DIFF
--- a/libs/blocks/locui-create/fragments/view.js
+++ b/libs/blocks/locui-create/fragments/view.js
@@ -60,7 +60,6 @@ export default function FragmentsSection({
     ${errorFragments?.length > 0 && html`<div class='form-field-error'>Invalid fragments <button class='locui-invalid-fragments-btn' onClick=${() => {
     showFragments(errorFragments);
   }}>view details</button></div>`}
-    ${validFragments.length > 0 && selectedFragments.length < 1 && html`<div class='form-field-error'>Select atleast one fragment to proceed further</div>`}
    </div>
   </div>`;
 }

--- a/libs/blocks/locui-create/input-urls/index.js
+++ b/libs/blocks/locui-create/input-urls/index.js
@@ -26,6 +26,13 @@ export function validateUrls(urlsStr) {
   return '';
 }
 
+export function validateFragments(isFragmentEnabled, noOfValidFrag, fragmentsSelected) {
+  if (isFragmentEnabled && noOfValidFrag > 0 && fragmentsSelected.length === 0) {
+    return 'Select atleast one fragment to proceed further';
+  }
+  return '';
+}
+
 export function validateForm({
   name,
   editBehavior,

--- a/libs/blocks/locui-create/input-urls/view.js
+++ b/libs/blocks/locui-create/input-urls/view.js
@@ -8,6 +8,7 @@ import {
   validateProjectName,
   validateUrls,
   findFragments,
+  validateFragments,
 } from './index.js';
 import { getUrls } from '../../locui/loc/index.js';
 import { URL_SEPARATOR_PATTERN } from '../utils/constant.js';
@@ -68,16 +69,21 @@ export default function InputUrls() {
 
   function handleFragmentsToggle() {
     setFragmentsEnabled(!fragmentsEnabled);
-    if (!fragmentsEnabled && !errors.urlsStr) {
-      fetchFragments(urlsStr, true);
+    if (!fragmentsEnabled) {
+      if (!errors.urlsStr) {
+        fetchFragments(urlsStr, true);
+      }
+    } else {
+      setErrors({ ...errors, fragments: '' });
     }
   }
 
   const handleFragmentsChange = useCallback((_fragments) => {
     setFragments(_fragments);
+    const error = validateFragments(fragmentsEnabled, noOfValidFrag, _fragments);
     setErrors((prev) => ({
       ...prev,
-      fragments: fragmentsEnabled && noOfValidFrag > 0 && _fragments.length === 0,
+      fragments: error,
     }));
   }, [fragmentsEnabled, noOfValidFrag]);
 
@@ -213,8 +219,10 @@ export default function InputUrls() {
               selectedFragments=${fragments}
               setSelectedFragments=${handleFragmentsChange}
               isLoading=${isFragmentsLoading}
+              formErrors=${errors.fragments}
             />
           `}
+          ${errors.fragments && html`<div class='form-field-error'>${errors.fragments}</div>`}
         </div>
       </div>
 


### PR DESCRIPTION
* Moved form errors related to fragments to parent component.
* reset form errors related to fragments when include fragments is disabled

Resolves: https://jira.corp.adobe.com/browse/MWPW-163183

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-163183-next-cta-issue--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off
