### PR TITLE
[LOC] MWPW-163209 - Removed Fragment sections when invalid or empty urls

### DIFF
--- a/libs/blocks/locui-create/input-urls/view.js
+++ b/libs/blocks/locui-create/input-urls/view.js
@@ -74,7 +74,10 @@ export default function InputUrls() {
         fetchFragments(urlsStr, true);
       }
     } else {
-      setErrors({ ...errors, fragments: '' });
+      setErrors((prev) => ({ ...prev, fragments: '' }));
+      setAllFragments([]);
+      setNoOfValidFragments(0);
+      setFragments([]);
     }
   }
 
@@ -125,13 +128,19 @@ export default function InputUrls() {
   }, []);
 
   const handleUrlsBlur = () => {
-    if (!errors.urlsStr) {
+    if (urlsStr && !errors.urlsStr) {
       const splittedUrls = urlsStr.split(URL_SEPARATOR_PATTERN).filter((url) => url);
       const uniqueUrls = Array.from(new Set(splittedUrls)).join('\n');
       setUrlsStr(uniqueUrls);
       if (fragmentsEnabled) {
         fetchFragments(uniqueUrls, true);
       }
+    } else {
+      setFragmentsEnabled(false);
+      setAllFragments([]);
+      setNoOfValidFragments(0);
+      setErrors((prev) => ({ ...prev, fragments: '' }));
+      setFragments([]);
     }
   };
 


### PR DESCRIPTION
* Set fragments to empty array and disabled the include fragments switch when there is an invalid or no url present.

Resolves: https://jira.corp.adobe.com/browse/MWPW-163209

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-163209-remove-fragment-section--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off