### PR TITLE
Adding active column logic in a large menu

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -969,7 +969,16 @@ class Gnav {
 
     const makeTabActive = (popup) => {
       if (!popup?.querySelector('.tabs [aria-selected="true"]')) {
-        setTimeout(() => popup?.querySelector('.tab')?.click(), 100);
+        const { origin, pathname } = window.location;
+        const url = `${origin}${pathname}`;
+        setTimeout(() => {
+          const activeLink = [
+            ...popup.querySelectorAll('a:not([data-modal-hash])'),
+          ].find((el)=> (el.href === url || el.href.startsWith(`${url}?`) || el.href.startsWith(`${url}#`)));
+          
+          const tabIndex = activeLink ? +activeLink.parentNode.id : 0;
+          popup.querySelectorAll('.tab')[tabIndex]?.click();
+        }, 100);
       }
     };
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -974,8 +974,7 @@ class Gnav {
         setTimeout(() => {
           const activeLink = [
             ...popup.querySelectorAll('a:not([data-modal-hash])'),
-          ].find((el)=> (el.href === url || el.href.startsWith(`${url}?`) || el.href.startsWith(`${url}#`)));
-          
+          ].find((el) => (el.href === url || el.href.startsWith(`${url}?`) || el.href.startsWith(`${url}#`)));
           const tabIndex = activeLink ? +activeLink.parentNode.id : 0;
           popup.querySelectorAll('.tab')[tabIndex]?.click();
         }, 100);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Drill down the matching column in second screen and if no match is found then drill down the first column

Resolves: [MWPW-163266](https://jira.corp.adobe.com/browse/MWPW-163266)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mgnav-activelink--milo--adobecom.aem.page/?martech=off

**Qa**:
- Default - https://main--federal--adobecom.hlx.page/federal/dev/blaishram/express/express-2?milolibs=mgnav-activelink
- Link in second column - https://main--federal--adobecom.hlx.page/federal/dev/blaishram/express/express?milolibs=mgnav-activelink

