### PR TITLE
Picking first string only for localnav title

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -372,6 +372,9 @@ class Gnav {
       </div>`;
 
     this.block.append(this.elements.curtain, this.elements.aside, this.elements.topnavWrapper);
+    // TODO: Remove with mobile redesign code
+    const firstLocalNavItem = this.elements.navWrapper.querySelector('.feds-nav .feds-navItem:not(.feds-navItem--section) a');
+    if (firstLocalNavItem) firstLocalNavItem.textContent = firstLocalNavItem.textContent.split('|')[0];
   };
 
   addChangeEventListeners = () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

As part of the new mobile redesign task, the mobile localnav requires the ability to override the title. To support this, we are introducing an overriding capability by allowing an additional string to be added to the title, e.g., "Photoshop | Overview."

This is a prerequisite task for the mobile redesign work, enabling authors to prepare their content before the mobile redesign code is merged.


Resolves: [MWPW-163191](https://jira.corp.adobe.com/browse/MWPW-163191)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-localnav-title--milo--adobecom.aem.page/?martech=off

**Qa**
- Before: https://main--federal--adobecom.hlx.page/federal/dev/blaishram/page-with-localnav
- After: https://main--federal--adobecom.hlx.page/federal/dev/blaishram/page-with-localnav?milolibs=gnav-localnav-title