### PR TITLE
[MWPW-161403] Remove default alt from media block

### DIFF
--- a/libs/blocks/media/media.js
+++ b/libs/blocks/media/media.js
@@ -79,9 +79,7 @@ export default async function init(el) {
       decorateBlockText(text, blockTypeSizes[size], blockType);
     }
     const image = row.querySelector(':scope > div:not([class])');
-    if (image) image.classList.add('image');
-    const img = image?.querySelector(':scope img');
-    if (header && img?.alt === '') img.alt = header.textContent;
+    image?.classList.add('image');
     const imageVideo = image?.querySelector('video');
     if (imageVideo) applyHoverPlay(imageVideo);
 


### PR DESCRIPTION
The media block was opinionated when it came to `alt` attributes, defaulting them to the block's heading. This is an accessibility anti-pattern, thus removing this behavior and relying on authors to add the relevant attribute values when needed.

Resolves: [MWPW-161403](https://jira.corp.adobe.com/browse/MWPW-161403)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ramuntea/accessibility/default-alt-in-media-block?martech=off
- After: https://rm-default-media-alt--milo--overmyheadandbody.hlx.page/drafts/ramuntea/accessibility/default-alt-in-media-block?martech=off
