### PR TITLE
MWPW-161937: Handles images during promote

### DIFF
--- a/test/tools/floodbox/search-replace.test.js
+++ b/test/tools/floodbox/search-replace.test.js
@@ -28,8 +28,8 @@ describe('searchAndReplace', () => {
       expName: 'expName',
     });
     expect(result).to.not.include('gb-style');
-    expect(result).to.not.include('graybox');
-    expect(result).to.include('https://main--repo--org.aem.page/page');
+    expect(result).to.not.include('class="graybox"');
+    expect(result).to.include('https://main--repo-graybox--org.aem.page/page');
   });
 
   it('should handle unknown search type gracefully', () => {

--- a/tools/floodbox/search-replace.js
+++ b/tools/floodbox/search-replace.js
@@ -35,13 +35,16 @@ class SearchReplace {
   }
 
   adjustUrlDomains(content) {
-    const searchValue = `--${this.repo}--${this.org}`;
-    const replaceValue = `--${this.destRepo}--${this.org}`;
-    const updatedContent = content.replaceAll(searchValue, replaceValue);
     if (this.searchType === 'floodgate') {
-      return updatedContent;
+      const searchValue = `--${this.repo}--${this.org}`;
+      const replaceValue = `--${this.destRepo}--${this.org}`;
+      return content.replaceAll(searchValue, replaceValue);
     }
-    return updatedContent.replaceAll(`.page/${this.expName}`, '.page');
+    if (this.searchType === 'graybox') {
+      const updatedContent = content.replaceAll(`.page/${this.expName}`, '.page');
+      return updatedContent.replaceAll(`.live/${this.expName}`, '.live');
+    }
+    return content;
   }
 
   static removeGrayboxStyles(doc) {


### PR DESCRIPTION
- Retains image URL domain as-is for graybox during promote

Resolves: [MWPW-161937](https://jira.corp.adobe.com/browse/MWPW-161937)

**Test URLs:**
- Before: https://da.live/app/adobecom/milo/tools/graybox?ref=floodbox
- After: https://da.live/app/adobecom/milo/tools/graybox?ref=imagefix
