### PR TITLE
[MWPW-163539] Update RCP workflow

### DIFF
--- a/.github/workflows/helpers.js
+++ b/.github/workflows/helpers.js
@@ -43,7 +43,11 @@ const RCPDates = [
   },
 ];
 
-const isWithinRCP = (offset = 0) => {
+const isShortRCP = (start, end) => {
+  return ((end - start) / (1000 * 60 * 60)) < 24;
+};
+
+const isWithinRCP = ({ offset = 0, excludeShortRCP = false } = {}) => {
   const now = new Date();
   if (now.getFullYear() !== CURRENT_YEAR) {
     console.log(`ADD NEW RCPs for ${CURRENT_YEAR + 1}`);
@@ -53,7 +57,9 @@ const isWithinRCP = (offset = 0) => {
   if (RCPDates.some(({ start, end }) => {
     const adjustedStart = new Date(start);
     adjustedStart.setDate(adjustedStart.getDate() - offset);
-    return start <= now && now <= end
+    const match = adjustedStart <= now && now <= end;
+    if (!match || (excludeShortRCP && isShortRCP(start, end))) return false;
+    return true;
   })) {
     console.log(
       'Current date is within a RCP (2 days earlier for stage, to keep stage clean & make CSO contributions during an RCP easier). Stopping execution.'
@@ -148,6 +154,7 @@ module.exports = {
   getLocalConfigs,
   slackNotification,
   pulls: { addLabels, addFiles, getChecks, getReviews },
+  isShortRCP,
   isWithinRCP,
   RCPDates,
 };

--- a/.github/workflows/merge-to-main.js
+++ b/.github/workflows/merge-to-main.js
@@ -9,6 +9,7 @@ const {
 const PR_TITLE = '[Release] Stage to Main';
 const STAGE = 'stage';
 const PROD = 'main';
+const MIN_SOT_APPROVALS = process.env.MIN_SOT_APPROVALS ? Number(process.env.MIN_SOT_APPROVALS) : 4;
 
 let github, owner, repo;
 
@@ -40,7 +41,7 @@ const main = async (params) => {
     const stageToMainPR = await getStageToMainPR();
     const signOffs = stageToMainPR?.labels.filter((l) => l.includes('SOT'));
     console.log(`${signOffs.length} SOT labels on PR ${stageToMainPR.number}`);
-    if (signOffs.length >= 4) {
+    if (signOffs.length >= MIN_SOT_APPROVALS) {
       console.log('Stage to Main  PR has all required labels. Merging...');
       await github.rest.pulls.merge({
         owner,

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}
+  MIN_SOT_APPROVALS: ${{ secrets.MIN_SOT_APPROVALS }}
 
 jobs:
   merge-to-main:

--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -31,8 +31,8 @@ const SLACK = {
   openedSyncPr: ({ html_url, number }) => `:fast_forward: Created <${html_url}|Stage to Main PR ${number}>`,
 };
 
-let github; 
-let owner; 
+let github;
+let owner;
 let repo;
 
 let body = `
@@ -230,7 +230,7 @@ const main = async (params) => {
   github = params.github;
   owner = params.context.repo.owner;
   repo = params.context.repo.repo;
-  if (isWithinRCP(process.env.STAGE_RCP_OFFSET_DAYS || 2)) return console.log('Stopped, within RCP period.');
+  if (isWithinRCP({ offset: process.env.STAGE_RCP_OFFSET_DAYS || 2, excludeShortRCP: true })) return console.log('Stopped, within RCP period.');
 
   try {
     const stageToMainPR = await getStageToMainPR();


### PR DESCRIPTION
This tries to address a few issues with the current RCP workflow logic:
* don't block the merge to stage pipe for RCPs shorter than 24h. The merge to main pipe will continue to be blocked;
* don't send Slack notifications for RCPs lasting less than a day to avoid confusion;
* adapt the logic that decides when to send the Slack notifications to avoid sending the same alert multiple times;
* take the offset into account for the `isWithinRCP` method;
* declare the number of minimum required SOT approvals as a secret.

Resolves: [MWPW-163539](https://jira.corp.adobe.com/browse/MWPW-163539)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/?martech=off
- After: https://upate-rcp-workflow--milo--overmyheadandbody.aem.page/?martech=off
