### PR TITLE
Adding prodDomains and allowed origin for standalone gnav

### DIFF
--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -41,6 +41,9 @@ const getStageDomainsMap = (stageDomainsMap) => (
   }
 );
 
+// Production Domain
+const prodDomains = ['milo.adobe.com', 'business.adobe.com', 'www.adobe.com', 'adobecom.github.io'];
+
 function getParamsConfigs(configs) {
   return blockConfig.reduce((acc, block) => {
     block.params.forEach((param) => {
@@ -107,6 +110,7 @@ export default async function loadBlock(configs, customLib) {
     contentRoot: authoringPath || footer.authoringPath,
     theme,
     ...paramConfigs,
+    prodDomains,
     standaloneGnav: true,
     stageDomainsMap: getStageDomainsMap(stageDomainsMap),
   };

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -65,6 +65,7 @@ export default async function loadBlock(configs, customLib) {
     env = 'prod',
     locale = '',
     theme,
+    allowedOrigins,
     stageDomainsMap = {},
   } = configs || {};
   if (!header && !footer) {
@@ -111,6 +112,7 @@ export default async function loadBlock(configs, customLib) {
     theme,
     ...paramConfigs,
     prodDomains,
+    allowedOrigins,
     standaloneGnav: true,
     stageDomainsMap: getStageDomainsMap(stageDomainsMap),
   };


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding prodDomains and allowed origin for standalone gnav 

Resolves: [MWPW-163701](https://jira.corp.adobe.com/browse/MWPW-163701)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-prodDomains--milo--adobecom.aem.page/?martech=off

Qa: 
- Before: https://adobecom.github.io/nav-consumer/navigation.html?authoringpath=/federal/home&locale=jp
- After: https://adobecom.github.io/nav-consumer/navigation.html?authoringpath=/federal/home&navbranch=gnav-prodDomains&locale=jp
