### PR TITLE
[MWPW-163723] [NALA] Update Nala CircleCI Job to Manual Trigger

### DIFF
--- a/.github/workflows/run-nala-circleci.yml
+++ b/.github/workflows/run-nala-circleci.yml
@@ -1,9 +1,7 @@
 name: Nala Tests on CircleCI
 
 on:
-  push:
-    branches:
-      - stage
+  workflow_dispatch:
 
 jobs:
   trigger-circleci:


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
* The current CircleCI job using a self-hosted runner is experiencing issues, causing delays as the automated trigger in the pipeline frequently hangs. This impacts the merge process.
* By default, Nala tests are already running on the stage branch as part of the pipeline, making this additional CircleCI job redundant in most cases.

Updating the workflow to use a manual trigger (workflow_dispatch) temporarily. This allows the CircleCI job to be executed only on demand, avoiding pipeline hangs while maintaining the flexibility to run the job when needed. Once the self-hosted runner issues are resolved, the automated trigger can be reinstated if required


Resolves: [MWPW-163723](https://jira.corp.adobe.com/browse/MWPW-163723)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://nala-circleci--milo--adobecom.aem.page/?martech=off
