### PR TITLE
Adding Standalone gnav's default allowed origins

### DIFF
--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -112,7 +112,7 @@ export default async function loadBlock(configs, customLib) {
     theme,
     ...paramConfigs,
     prodDomains,
-    allowedOrigins,
+    allowedOrigins: [...allowedOrigins, `https://main--federal--adobecom.aem.${env === 'prod' ? 'live' : 'page'}`],
     standaloneGnav: true,
     stageDomainsMap: getStageDomainsMap(stageDomainsMap),
   };

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -65,7 +65,7 @@ export default async function loadBlock(configs, customLib) {
     env = 'prod',
     locale = '',
     theme,
-    allowedOrigins,
+    allowedOrigins = [],
     stageDomainsMap = {},
   } = configs || {};
   if (!header && !footer) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added default alllowedOrigins for standalone gnav from which content will be picked

Resolves: - [MWPW-163797](https://jira.corp.adobe.com/browse/MWPW-163797) ,  [MWPW-162745](https://jira.corp.adobe.com/browse/MWPW-162745)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-allowedOrigins--milo--adobecom.aem.page/?martech=off

QA:
- Before: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&authoringpath=/federal/home
- After: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=gnav-allowedOrigins&authoringpath=/federal/home