### PR TITLE
chore: Ignore tmp folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ logs/*
 test-html-results/
 test-results/
 test-a11y-results/
+tmp
 libs/navigation/dist/


### PR DESCRIPTION
Ignore tmp folders

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://chore-tmp--milo--hparra.aem.page/?martech=off
