### PR TITLE
Fix optional profile page detail in the sidekick

### DIFF
--- a/libs/utils/sidekick-decorate.js
+++ b/libs/utils/sidekick-decorate.js
@@ -178,7 +178,7 @@ export default async function stylePublish(sk) {
 
   const pageDetail = {
     webPath: window.location.pathname,
-    profile: { email: pluginActionBarSR.querySelector('#user').shadowRoot.querySelector('.user [slot="description"]')?.innerText },
+    profile: { email: pluginActionBarSR.querySelector('#user')?.shadowRoot.querySelector('.user [slot="description"]')?.innerText },
   };
   if (pageDetail && publishBtn) await checkAuthorization(pageDetail, publishBtn);
 }


### PR DESCRIPTION
### Description
Fixes an undefined error within the sidekick
<img width="988" alt="image" src="https://github.com/user-attachments/assets/b2c4098e-12b9-48e4-a644-c4f54fae010e">

**Test URLs:**
- Before: https://hlx-5--dc--adobecom.aem.live/uk/acrobat/business/industries/government
- After: https://hlx-5--dc--adobecom.aem.live/uk/acrobat/business/industries/government?milolibs=fix-sidekick-err--milo--mokimo

To get the psi check running:
- https://fix-sidekick-err--milo--mokimo.hlx.live/
