### PR TITLE
[MWPW-164097] Allow special chars in aria-label definition

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -715,13 +715,11 @@ export function decorateLinks(el) {
       decorateCopyLink(a, copyEvent);
     }
     // Append aria-label
-    const pipeRegex = /\s?\|\s?/;
+    const pipeRegex = /\s?\|([^|]*)$/;
     if (pipeRegex.test(a.textContent) && !/\.[a-z]+/i.test(a.textContent)) {
-      const node = [...a.childNodes].reverse()
-        .find((child) => pipeRegex.test(child.textContent));
-      const ariaLabel = node.textContent.split(pipeRegex).pop();
-      node.textContent = node.textContent
-        .replace(new RegExp(`${pipeRegex.source}${ariaLabel}`), '');
+      const node = [...a.childNodes].reverse()[0];
+      const ariaLabel = node.textContent.match(pipeRegex)[1];
+      node.textContent = node.textContent.replace(pipeRegex, '');
       a.setAttribute('aria-label', ariaLabel.trim());
     }
 

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -52,6 +52,9 @@
     <p>
       <a href="https://www.adobe.com/" class="aria-label-piped--no-space">Text|Other text|Aria label</a>
     </p>
+    <p></p>
+      <a href="https://www.adobe.com/" class="aria-label--special-char">Text | Aria label ~!@#$%^&*()-_=+[{/;:'",.?}] special characters</a>
+    </p>
     <p>
       <a href="https://www.adobe.com/" class="aria-label-icon-none">
         <span class="icon icon-checkmark"></span>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -229,6 +229,10 @@ describe('Utils', () => {
         expect(pipedAriaLabelElem.getAttribute('aria-label')).to.equal(theAriaLabel);
         expect(pipedAriaLabelElem.innerText).to.equal(`${theText} | Other text`);
 
+        const specialCharAriaLabelElem = document.querySelector('.aria-label--special-char');
+        expect(specialCharAriaLabelElem.getAttribute('aria-label')).to.equal(`${theAriaLabel} ~!@#$%^&*()-_=+[{/;:'",.?}] special characters`);
+        expect(specialCharAriaLabelElem.innerText).to.equal(theText);
+
         const noSpacePipedAriaLabelElem = document.querySelector('.aria-label-piped--no-space');
         expect(noSpacePipedAriaLabelElem.getAttribute('aria-label')).to.equal(theAriaLabel);
         expect(noSpacePipedAriaLabelElem.innerText).to.equal(`${theText}|Other text`);


### PR DESCRIPTION
This adapts the logic that allows authors to define `aria-label` attribute values for links, in order to allow the use of special characters. We're now using capturing groups to identify the pattern match at the end of the link's text content, which simplifies the logic and also addresses the bug.

Resolves: [MWPW-164097](https://jira.corp.adobe.com/browse/MWPW-164097)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/aria-label-with-icon?martech=off
- After: https://aria-label-special-chars--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/aria-label-with-icon?martech=off
