### PR TITLE
Revert "MWPW-163754 Color difference is seen in the milo pages"

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -799,10 +799,6 @@ a:hover {
   color: var(--link-hover-color);
 }
 
-.dark a:hover {
-  color: var(--link-hover-color-dark);
-}
-
 a:has(> sub:only-child) { text-decoration: unset; }
 a > sub:only-child { text-decoration: underline; }
 


### PR DESCRIPTION
Reverts adobecom/milo#3330
Reverting as home page is getting affected by the same.

**Test URLs:**
- Before: https://darkcta--milo--suhjainadobe.hlx.live/drafts/suhjain/dark-cta
- After: https://revert-3330-darkcta--milo--adobecom.hlx.live/drafts/suhjain/dark-cta