### PR TITLE
[mobile gnav] view plans and pricing CTA added is not seen visible in iphone 15 in landscape and portrait mode

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1163,6 +1163,7 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
 .feds-localnav.feds-localnav--active .feds-localnav-curtain {
   width: 100%;
   height: calc(100lvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
+  min-height: -webkit-fill-available
   position: absolute;
   background: var(--feds-color-black-v2);
   opacity: 0.7;

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1163,7 +1163,7 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
 .feds-localnav.feds-localnav--active .feds-localnav-curtain {
   width: 100%;
   height: calc(100lvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
-  min-height: -webkit-fill-available;
+  padding-bottom: env(safe-area-inset-bottom);
   position: absolute;
   background: var(--feds-color-black-v2);
   opacity: 0.7;

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1162,7 +1162,7 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
 
 .feds-localnav.feds-localnav--active .feds-localnav-curtain {
   width: 100%;
-  height: calc(100lvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
+  height: calc(101lvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
   padding-bottom: env(safe-area-inset-bottom);
   position: absolute;
   background: var(--feds-color-black-v2);

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1162,7 +1162,7 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
 
 .feds-localnav.feds-localnav--active .feds-localnav-curtain {
   width: 100%;
-  height: calc(100dvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
+  height: calc(100lvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
   position: absolute;
   background: var(--feds-color-black-v2);
   opacity: 0.7;

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -61,7 +61,7 @@ header.global-navigation {
   right: 20px; /* hamburger menu gutter */
   display: none;
   flex-direction: column;
-  height: calc(100vh - 100% - 1px);
+  height: calc(100dvh - 100% - 1px);
   border-top: 1px solid var(--feds-borderColor);
   background-color: var(--feds-background-nav);
 }
@@ -584,13 +584,13 @@ header.global-navigation {
   .feds-navItem--megaMenu .feds-popup {
     right: 0;
     padding: 40px 0 0;
-    max-height: calc(100vh - 100%);
+    max-height: calc(100dvh - 100%);
     overflow: auto;
     box-sizing: border-box;
   }
 
   .global-navigation.has-promo .feds-navItem--megaMenu .feds-popup {
-    max-height: calc(100vh - 100% - var(--global-height-navPromo));
+    max-height: calc(100dvh - 100% - var(--global-height-navPromo));
   }
 
   [dir = "rtl"] .feds-navItem--megaMenu .feds-popup {
@@ -1141,11 +1141,11 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
 
 .feds-localnav.feds-localnav--active .feds-localnav-items {
   box-sizing: border-box;
-  max-height: calc(100vh - (var(--global-height-nav) + var(--feds-localnav-height)));
+  max-height: calc(100dvh - (var(--global-height-nav) + var(--feds-localnav-height)));
 }
 
 .feds-localnav.feds-localnav--active.is-sticky .feds-localnav-items {
-  max-height: calc(100vh - var(--feds-localnav-height));
+  max-height: calc(100dvh - var(--feds-localnav-height));
 }
 
 .feds-localnav .feds-localnav--active::before {
@@ -1162,14 +1162,14 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
 
 .feds-localnav.feds-localnav--active .feds-localnav-curtain {
   width: 100%;
-  height: calc(100vh - (var(--feds-height-nav) + var(--feds-localnav-height)));
+  height: calc(100dvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
   position: absolute;
   background: var(--feds-color-black-v2);
   opacity: 0.7;
 }
 
 .feds-localnav.feds-localnav--active.is-sticky .feds-localnav-curtain {
-  height: calc(100vh - var(--feds-localnav-height));
+  height: calc(100dvh - var(--feds-localnav-height));
 }
 
 .feds-localnav.feds-localnav--active .feds-localnav-exit {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1163,7 +1163,7 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
 .feds-localnav.feds-localnav--active .feds-localnav-curtain {
   width: 100%;
   height: calc(100lvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
-  min-height: -webkit-fill-available
+  min-height: -webkit-fill-available;
   position: absolute;
   background: var(--feds-color-black-v2);
   opacity: 0.7;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* We now use `dvh` to account for the iphone home bar
* We use `safe-area-inset-bottom` to fix the scroll flickering issue
* Changes were tested using an XCode Simulator

Resolves: 
* [MWPW-163856](https://jira.corp.adobe.com/browse/MWPW-163856)
* [MWPW-164378](https://jira.corp.adobe.com/browse/MWPW-164378)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://dvh-mobile-gnav--milo--adobecom.aem.page/?martech=off
