### PR TITLE
[Loc] MWPW-163949: Project creation success message is not wrapping properly

### DIFF
--- a/libs/blocks/locui-create/locui-create.css
+++ b/libs/blocks/locui-create/locui-create.css
@@ -682,7 +682,7 @@ body {
 
 .locui-project-created-modal {
   width: 450px;
-  padding: 30px 10px;
+  padding: 40px 30px;
   text-align: center;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Added Padding to the project success modal

Resolves: https://jira.corp.adobe.com/browse/MWPW-163949

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://mwpw-163949-view-popup-padding--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off
