### PR TITLE
[Loc]MWPW-164350 - Fragments are getting added multiple times in the Enter urls 

### DIFF
--- a/libs/blocks/locui-create/input-urls/index.js
+++ b/libs/blocks/locui-create/input-urls/index.js
@@ -1,4 +1,5 @@
 import { findDeepFragments } from '../../locui/actions/index.js';
+import { urls as locuiUrls } from '../../locui/utils/state.js';
 import { validateUrlsFormat } from '../../locui/loc/index.js';
 import { origin } from '../../locui/utils/franklin.js';
 import { PROJECT_TYPES } from '../utils/constant.js';
@@ -66,6 +67,8 @@ export function checkForErrors(errors) {
 }
 
 export async function findFragments(urls) {
+  // Using locui state urls as it is internally used in finding fragments and check duplicates
+  locuiUrls.value = [...urls];
   const fragmentUrls = urls.map((url) => findDeepFragments(url.pathname));
   const pageFragments = await Promise.all(fragmentUrls);
   const fragmentsByPathname = pageFragments.reduce((acc, fragments, index) => {
@@ -82,9 +85,11 @@ export async function findFragments(urls) {
     }
     return acc;
   }, {});
+  locuiUrls.value = [];
   const foundFragments = Object.values(fragmentsByPathname);
   return validateUrlsFormat(foundFragments, true);
 }
+
 export function getInitialName(type) {
   const prefix = type === PROJECT_TYPES.rollout ? 'rollout' : 'translate';
   let date = new Date().toISOString();


### PR DESCRIPTION

* Used locui state variable to prevent duplicity

Resolves: https://jira.corp.adobe.com/browse/MWPW-164350

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-164350-edit-duplicate-fragments--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off

