### PR TITLE
[MWPW-160864] Adapt action item focus state

### DIFF
--- a/libs/blocks/action-item/action-item.css
+++ b/libs/blocks/action-item/action-item.css
@@ -114,18 +114,11 @@
   transition: transform .2s ease;
 }
 
-.action-item:not(.zoom) a:focus-visible picture:not(.floated-icon) img,
-.action-item.zoom a:focus-visible picture:not(.floated-icon) {
-  outline-color: -webkit-focus-ring-color;
-  outline-style: auto;
-}
-
 .action-item:not(.float-button) a {
   width: 100%;
 }
 
 .action-item a:not(.con-button):focus-visible {
-  outline: none;
   text-decoration: underline;
 }
 

--- a/libs/blocks/action-scroller/action-scroller.css
+++ b/libs/blocks/action-scroller/action-scroller.css
@@ -16,7 +16,7 @@
   grid-auto-columns: minmax(var(--action-scroller-column-width), 1fr);
   grid-auto-flow: column;
   gap: var(--spacing-m);
-  padding: 0 var(--action-scroller-mobile-padding);
+  padding: 3px var(--action-scroller-mobile-padding);
   overflow-x: auto;
   -ms-overflow-style: none;
   scrollbar-width: none;


### PR DESCRIPTION
This adapts the focus state for action items to ensure that the whole clickable area is focused when a user is tabbing through these elements. This is needed for accessibility purposes.

Resolves: [MWPW-160864](https://jira.corp.adobe.com/browse/MWPW-160864)

Screenshots:
| Before | After |
| ------------- | ------------- |
| <img width="508" alt="Screenshot 2024-12-19 at 15 55 13" src="https://github.com/user-attachments/assets/bf40389f-5eeb-428a-8edc-c9de0798e619" /> | <img width="508" alt="Screenshot 2024-12-19 at 15 55 39" src="https://github.com/user-attachments/assets/f4f1eb82-c48b-4ac0-bf54-5bbb40e2490e" /> |

Note that items with floating icons will have an irregular outline when focused. I've confirmed with our accessibility experts that this is not a concern:

<img width="178" alt="Screenshot 2024-12-19 at 15 56 07" src="https://github.com/user-attachments/assets/b11d8796-acc5-4e3e-8f26-edec78a570d5" />

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/accessibility/action-item-focus?martech=off
- After: https://action-item-focus--milo--overmyheadandbody.hlx.page/drafts/ramuntea/accessibility/action-item-focus?martech=off
