### PR TITLE
MWPW-163901: Fixed check when setting htmlFlow in UI

### DIFF
--- a/libs/blocks/locui-create/input-urls/view.js
+++ b/libs/blocks/locui-create/input-urls/view.js
@@ -167,7 +167,7 @@ export default function InputUrls() {
     if (project.value) {
       setType(project.value?.type);
       setName(project.value?.name);
-      setHtmlFlow(project.value?.htmlFlow || true);
+      setHtmlFlow(project.value?.htmlFlow ?? true);
       setEditBehavior(project.value?.editBehavior || '');
       setUrlsStr(project.value?.urls?.join('\n'));
       setFragmentsEnabled(project.value?.fragments?.length > 0);


### PR DESCRIPTION
* HTML Localization Flow checkbox does no longer gets checked when clicking next

Resolves: [MWPW-163901](https://jira.corp.adobe.com/browse/MWPW-163901)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-163901-html-flow-fix--milo--zweihand3r.hlx.page/drafts/arnab/locui-create?martech=off&projectKey=5657983f53c3869b2e81f17e5297a39c
