### PR TITLE
[MWPW-161858] Remove sticky section when footer is visible

### DIFF
--- a/libs/blocks/section-metadata/sticky-section.js
+++ b/libs/blocks/section-metadata/sticky-section.js
@@ -6,6 +6,7 @@ function handleTopHeight(section) {
   section.style.top = `${headerHeight}px`;
 }
 
+let isFooterStart = false;
 function promoIntersectObserve(el, stickySectionEl, options = {}) {
   const io = new IntersectionObserver((entries, observer) => {
     entries.forEach((entry) => {
@@ -17,7 +18,8 @@ function promoIntersectObserve(el, stickySectionEl, options = {}) {
       const isPromoStart = entry.target === stickySectionEl;
       const abovePromoStart = (isPromoStart && entry.isIntersecting)
         || stickySectionEl?.getBoundingClientRect().y > 0;
-      if (entry.isIntersecting || abovePromoStart) el.classList.add('hide-sticky-section');
+      if (entry.target === document.querySelector('footer')) isFooterStart = entry.isIntersecting;
+      if (entry.isIntersecting || abovePromoStart || isFooterStart) el.classList.add('hide-sticky-section');
       else el.classList.remove('hide-sticky-section');
     });
   }, options);


### PR DESCRIPTION
## Description
When the footer is in the view screen, sections with sticky-bottom will have the "hide-sticky-section" class added.

## Related Issue
Resolves: [MWPW-161858](https://jira.corp.adobe.com/browse/MWPW-161858)

## Testing instructions
1. Expand window height size to 1440px
2. Reload the page
3. Scroll down the page until the footer is in view
4. The sticky banner should not be visible

## Screenshots
**Before**
![Screenshot 2024-12-20 at 11 37 18](https://github.com/user-attachments/assets/5513480e-356c-4db9-9312-aea36ca20707)

**After**
![Screenshot 2024-12-20 at 11 36 45](https://github.com/user-attachments/assets/d0c8d4bb-718d-4cc0-8288-72ff51ca1e27)

## Test URLs
- Before: https://main--cc--adobecom.hlx.page/products/special-offers?martech=off
- After: https://main--cc--adobecom.hlx.page/products/special-offers?milolibs=mwpw-161858-consonant&martech=off

PSI check url: https://mwpw-161858-consonant--milo--adobecom.hlx.page/drafts/rbogos/page-default?martech=off
