### PR TITLE
fix for georouting popup link is seen rendered out of the popup in mobile portrait view in arabic locale

### DIFF
--- a/libs/features/georoutingv2/georoutingv2.css
+++ b/libs/features/georoutingv2/georoutingv2.css
@@ -49,7 +49,7 @@
 }
 
 .dialog-modal.locale-modal-v2 a:last-child {
-  display: inline-block;
+  white-space: no-wrap;
 }
 
 .dialog-modal.locale-modal-v2 .picker li {

--- a/libs/features/georoutingv2/georoutingv2.css
+++ b/libs/features/georoutingv2/georoutingv2.css
@@ -49,7 +49,7 @@
 }
 
 .dialog-modal.locale-modal-v2 a:last-child {
-  white-space: nowrap;
+  display: inline-block;
 }
 
 .dialog-modal.locale-modal-v2 .picker li {


### PR DESCRIPTION
georouting popup link is seen rendered out of the popup in mobile portrait view in arabic locale

Resolves: [MWPW-164340](https://jira.corp.adobe.com/browse/MWPW-164340)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/mena_ar/products/photoshop?martech=off
- After: https://main--cc--adobecom.hlx.page/mena_ar/products/photoshop?milolibs=mwpw-164340-georouting--milo--patel-prince&martech=off
