### PR TITLE
MWPW-156410: add daa-lh/ll values for gnav promo

### DIFF
--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -145,7 +145,7 @@ const decoratePromo = (elem, index) => {
     let promoImageElem;
 
     if (linkElem instanceof HTMLElement) {
-      promoImageElem = toFragment`<a class="feds-promo-image" href="${linkElem.href}">
+      promoImageElem = toFragment`<a class="feds-promo-image" href="${linkElem.href}" daa-ll="promo-image">
           ${imageElem}
         </a>`;
     } else {
@@ -176,7 +176,7 @@ const decoratePromo = (elem, index) => {
     elem.classList.add('feds-promo--dark');
   }
 
-  return toFragment`<div class="feds-promo-wrapper">
+  return toFragment`<div class="feds-promo-wrapper" daa-lh="promo-card">
       ${elem}
     </div>`;
 };


### PR DESCRIPTION
Adds daa-lh value for promo column and daa-ll value for promo link in GNav. The 1st requirement for daa-lh value for mega menu dropdowns will be added as part of mobile-gnav changes.

Resolves: [MWPW-156410](https://jira.corp.adobe.com/browse/MWPW-156410)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-156410-gnav-analytics--milo--nishantka.aem.page/?martech=off

QA:
https://main--cc--adobecom.hlx.page/creativecloud/design?milolibs=mwpw-156410-gnav-analytics--milo--nishantka