### PR TITLE
[MWPW-163381] : Removed lorem ipsum text check from preflight modal

### DIFF
--- a/libs/blocks/preflight/panels/seo.js
+++ b/libs/blocks/preflight/panels/seo.js
@@ -127,7 +127,8 @@ async function checkBody() {
 async function checkLorem() {
   const result = { ...loremResult.value };
   const { innerHTML } = document.documentElement;
-  if (innerHTML.includes('Lorem ipsum')) {
+  const htmlWithoutPreflight = innerHTML.replace(document.getElementById('preflight')?.outerHTML, '');
+  if (htmlWithoutPreflight.includes('Lorem ipsum')) {
     result.icon = fail;
     result.description = 'Reason: Lorem ipsum is used on the page.';
   } else {


### PR DESCRIPTION
The preflight dialog is added to the body of the actual page. And currently the lorem ipsum text is checked inside the entire innerHTML (thus including the preflight dialog). So once the preflight dialog opens for the first time it introduces the "Lorem Ipsum" text in the body and hence for all consecutive checks, it incorrectly fails even if the page does not have the "Lorem Ipsum" text.
Handled it by eliminating the preflight dialog content and checking in the actual body of the page instead.

Resolves: [MWPW-163381](https://jira.corp.adobe.com/browse/MWPW-163381)

**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.page/drafts/ancy/content-analytics?martech=off
- After: https://main--da-bacom--adobecom.aem.page/drafts/ancy/content-analytics?milolibs=mwpw-163381--milo--sharmeeatadobe?martech=off
- After: https://mwpw-163381--milo--sharmeeatadobe.aem.page/drafts/sharmeeb/content-analytics?martech=off
