### PR TITLE
[LOC UI] MWPW-164043 - Changes for supporting langstore urls

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -9,12 +9,13 @@ import {
   allowRollout,
   syncFragments,
   allowCancelProject,
+  projectStatus,
   polling,
 } from '../utils/state.js';
 import { setExcelStatus, setStatus } from '../utils/status.js';
 import { origin, preview } from '../utils/franklin.js';
 import { createTag, decorateSections, decorateFooterPromo } from '../../../utils/utils.js';
-import { getUrls, validateUrlsFormat } from '../loc/index.js';
+import { getUrls, validateUrlsFormat, getLangstorePrefix, removeLangstorePrefix } from '../loc/index.js';
 import updateExcelTable from '../../../tools/sharepoint/excel.js';
 import { getItemId } from '../../../tools/sharepoint/shared.js';
 import {
@@ -100,7 +101,7 @@ async function findPageFragments(path) {
     }
     // Find dupes across current iterator as well as original url list
     const accDupe = acc.some((url) => url.pathname === pathname);
-    const dupe = urls.value.some((url) => url.pathname === pathname);
+    const dupe = urls.value.some((url) => removeLangstorePrefix(url.pathname) === pathname);
     if (accDupe || dupe) return acc;
     const fragmentUrl = new URL(`${origin}${pathname}`);
     fragmentUrl.alt = fragment.textContent;
@@ -112,14 +113,22 @@ async function findPageFragments(path) {
   return fragmentUrls;
 }
 
+function addFragmentPrefix(fragments, prefix) {
+  return fragments ? fragments.map((url) => {
+    url.pathname = url.pathname.startsWith(prefix) ? url.pathname : `${prefix}${url.pathname}`;
+    return url;
+  }) : undefined;
+}
+
 async function findDeepFragments(path) {
   const searched = [];
-  const fragments = await findPageFragments(path);
+  const prefix = getLangstorePrefix(path);
+  const fragments = addFragmentPrefix(await findPageFragments(path), prefix);
   if (!fragments) return [];
   while (fragments.length !== searched.length) {
     const needsSearch = fragments.filter((fragment) => !searched.includes(fragment.pathname));
     for (const search of needsSearch) {
-      const nestedFragments = await findPageFragments(search.pathname);
+      const nestedFragments = addFragmentPrefix(await findPageFragments(search.pathname), prefix);
       if (nestedFragments === undefined) {
         search.valid = 'not found';
       } else {
@@ -190,7 +199,7 @@ export async function syncToLangstore() {
   // Disable cancel project
   allowCancelProject.value = false;
 
-  if (!heading.value.projectId) {
+  if (!heading.value.projectId || projectStatus.value.projectStatus === 'draft') {
     const status = await createProject();
     setTimeout(async () => {
       if (status === 201) {
@@ -254,7 +263,7 @@ export async function sendForLoc() {
   allowCancelProject.value = false;
 
   // If no Project ID, create project first.
-  if (!heading.value.projectId) {
+  if (!heading.value.projectId || projectStatus.value.projectStatus === 'draft') {
     const status = await createProject();
     if (status === 201) {
       // Give the service time to digest and error check creating a project

--- a/libs/blocks/locui/langs/modal.js
+++ b/libs/blocks/locui/langs/modal.js
@@ -7,7 +7,7 @@ import errorLinks from '../status/index.js';
 
 function Modal({ lang, prefix, type }) {
   const localeUrls = urls.value.map(
-    (url) => new URL(`${origin}/${prefix}${url.pathname}`),
+    (url) => new URL(`${origin}/${prefix}${url.pagePath}`),
   );
 
   if (type === 'error') {

--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -35,8 +35,17 @@ async function validateUrl(url) {
   }
 }
 
+export function getLangstorePrefix(path) {
+  return path.replace(/^(\/langstore\/[^/]+)*(\/.*)/, '$1');
+}
+
+export function removeLangstorePrefix(path) {
+  return path.replace(/^\/langstore\/[^/]+/, '');
+}
+
 export function validateUrlsFormat(projectUrls, removeMedia = false) {
-  projectUrls.forEach((projectUrl) => {
+  let firstUrlLang;
+  projectUrls.forEach((projectUrl, idx) => {
     const url = getUrl(projectUrl);
     const domain = isUrl(url.alt) ?? url;
     if (domain.origin !== origin) {
@@ -45,6 +54,16 @@ export function validateUrlsFormat(projectUrls, removeMedia = false) {
     }
     if ((/\.(gif|jpg|jpeg|tiff|png|webp)$/i).test(domain.pathname)) {
       url.valid = 'media';
+    }
+    if (idx && !firstUrlLang && url.pathname.startsWith('/langstore/')) {
+      url.valid = 'not US url';
+    } else if (idx && firstUrlLang) {
+      const urlLang = getLangstorePrefix(url.pathname);
+      if (firstUrlLang !== urlLang) {
+        url.valid = `not same as first ${firstUrlLang}`;
+      }
+    } else {
+      firstUrlLang = getLangstorePrefix(url.pathname);
     }
   });
   if (removeMedia) {
@@ -74,13 +93,14 @@ export function getUrls(jsonUrls) {
   const { locales } = getConfig();
   // Assume all URLs will be the same locale as the first URL
   const locale = getLocale(locales, jsonUrls[0].pathname);
-  const langstorePrefix = locale.prefix ? `/langstore${locale.prefix}` : '/langstore/en';
+  const lang = (locale.prefix.replace(/^\/langstore\//, '/') ?? '/en').replace('/', '') || 'en';
   // Loop through each url to get langstore information
   return jsonUrls.map((url) => {
     url.langstore = {
-      lang: locale.prefix ? locale.prefix.replace('/', '') : 'en',
-      pathname: url.pathname.replace(locale.prefix, langstorePrefix),
+      lang,
+      pathname: url.pathname.replace(locale.prefix, `/langstore/${lang}`),
     };
+    url.pagePath = removeLangstorePrefix(url.pathname);
     return url;
   });
 }

--- a/libs/blocks/locui/url/view.js
+++ b/libs/blocks/locui/url/view.js
@@ -8,7 +8,7 @@ export default function Url({ suffix, item }) {
   let hasError;
   if (item.valid === undefined) {
     // if not validated (LANGSTORE, locale) then get validation status from urls
-    const match = urls.value.find((url) => sourcePath.endsWith(url.pathname)
+    const match = urls.value.find((url) => sourcePath.endsWith(url.pagePath)
       || url.langstore.pathname.endsWith(langstorePath));
     hasError = typeof match.valid === 'string' ? match.valid : false;
   } else {
@@ -20,7 +20,7 @@ export default function Url({ suffix, item }) {
       <p class=locui-url-path>${sourcePath}${hasError ? html`<span>${hasError}</span>` : ''}</p>
       <div class="locui-url-tab-group locui-url-tab-group-cols-${suffix.length}">
         <${Tabs} suffix=${suffix[0]} path=${sourcePath} hasError=${hasError} sync=${item.sync} />
-        ${langstorePath && html`
+        ${langstorePath && sourcePath !== langstorePath && html`
           <${Tabs} suffix=${suffix[1]} path=${langstorePath} hasError=${hasError} sync=${item.sync} />
         `}
       </div>

--- a/libs/blocks/locui/utils/miloc.js
+++ b/libs/blocks/locui/utils/miloc.js
@@ -77,6 +77,11 @@ export async function getProjectStatus() {
       setStatus('service-error', 'error', json.projectStatusText);
     }
 
+    if (json.projectStatus === 'draft') {
+      allowSyncToLangstore.value = true;
+      allowSendForLoc.value = true;
+    }
+
     if (json.projectStatus === 'sync') {
       allowSyncToLangstore.value = false;
     }
@@ -128,7 +133,7 @@ export async function getProjectStatus() {
 export async function startSync() {
   setStatus('service', 'info', 'Syncing documents to Langstore.');
   const url = await getMilocUrl();
-  setExcelStatus('Sync to langstore/en', '');
+  setExcelStatus(`Sync to langstore/${urls.value?.[0].langstore.lang || 'en'}`, '');
   const opts = { method: 'POST', headers: { 'User-Token': accessToken.value } };
   const resp = await fetch(`${url}start-sync?project=${heading.value.projectId}`, opts);
   if (resp.status === UNAUTHORIZED) showAuthError('start project');


### PR DESCRIPTION
As part of Loc V3 and single file rollout (MWPW-162683), loc service needs to support langstore/ urls.
This locui PR is for supporting those changes. Current flows would work as usual.

Resolves: MWPW-164043

Test URLs:
Before: https://locui--milo--adobecom.hlx.page/tools/loc?milolibs=locui&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B3e761436-39f0-4c33-8f17-f202b559f236%257D%26action%3Deditnew

After: https://locui-debug--milo--raga-adbe-gh.hlx.page/tools/loc?milolibs=locui&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B3e761436-39f0-4c33-8f17-f202b559f236%257D%26action%3Deditnew