### PR TITLE
MWPW-163916 [Mobile GNAV] | Flickering issue while scrolling when LNAV is opened

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1182,10 +1182,8 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
   width: 100%;
   height: calc(101lvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
   padding-bottom: env(safe-area-inset-bottom);
-  position: absolute;
   background: var(--feds-color-black-v2);
   opacity: 0.7;
-  top: var(--feds-localnav-height);
 }
 
 .feds-localnav.feds-localnav--active.is-sticky .feds-localnav-curtain {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1180,7 +1180,7 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
 
 .feds-localnav.feds-localnav--active .feds-localnav-curtain {
   width: 100%;
-  height: calc(101lvh - (var(--feds-height-nav) + var(--feds-localnav-height)));
+  height: 101lvh;
   padding-bottom: env(safe-area-inset-bottom);
   background: var(--feds-color-black-v2);
   opacity: 0.7;

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1252,3 +1252,10 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
     opacity: 0;
   }
 }
+
+/* */
+
+.disable-ios-scroll {
+  overflow: hidden;
+  position: fixed;
+}

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1186,10 +1186,6 @@ header.new-nav .feds-breadcrumbs li:first-child:not(:nth-last-child(-n+3)):after
   opacity: 0.7;
 }
 
-.feds-localnav.feds-localnav--active.is-sticky .feds-localnav-curtain {
-  height: calc(100dvh - var(--feds-localnav-height));
-}
-
 .feds-localnav.feds-localnav--active .feds-localnav-exit {
   display: block;
 }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -409,7 +409,7 @@ class Gnav {
       const f = (event) => {
         event.preventDefault();
       };
-      window.addEventListener('touchmove', f);
+      window.addEventListener('touchmove', f, { passive: false }); // for iOS
       return () => { window.removeEventListener('touchmove', f); };
     }
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -42,6 +42,8 @@ import {
   animateInSequence,
   transformTemplateToMobile,
   closeAllTabs,
+  enableMobileScroll,
+  disableMobileScroll,
 } from './utilities/utilities.js';
 import { getFedsPlaceholderConfig } from '../../utils/federated.js';
 
@@ -403,12 +405,6 @@ class Gnav {
 
       itemWrapper.appendChild(clonedItem);
     });
-
-    const preventDefault = (e) => e.preventDefault();
-    const disableMobileScroll = () => {
-      window.addEventListener('touchmove', preventDefault, { passive: false }); // for iOS
-    }
-    const enableMobileScroll = () => window.removeEventListener('touchmove', preventDefault);
 
     localNav.querySelector('.feds-localnav-title').addEventListener('click', () => {
       localNav.classList.toggle('feds-localnav--active');
@@ -779,6 +775,8 @@ class Gnav {
   toggleMenuMobile = () => {
     const toggle = this.elements.mobileToggle;
     const isExpanded = this.isToggleExpanded();
+    if (isExpanded) disableMobileScroll();
+    else enableMobileScroll();
     if (!isExpanded && this.newMobileNav) {
       const sections = document.querySelectorAll('header.new-nav .feds-nav > section.feds-navItem > button.feds-navLink');
       animateInSequence(sections, 0.075);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -384,7 +384,10 @@ class Gnav {
     const [title, navTitle = ''] = this.getOriginalTitle(localNavItems);
     let localNav = document.querySelector('.feds-localnav');
     if (!localNav) {
-      lanaLog({ message: 'GNAV: Localnav does not include \'localnav\' in its name.', tags: 'errorType=info,module=gnav' });
+      lanaLog({
+        message: 'GNAV: Localnav does not include \'localnav\' in its name.',
+        tags: 'errorType=info,module=gnav',
+      });
       localNav = toFragment`<div class="feds-localnav"/>`;
       this.block.after(localNav);
     }
@@ -1128,8 +1131,11 @@ class Gnav {
             const y = Math.abs(parseInt(document.body.style.top, 10));
             // document.body.style.top should always be set
             // at this point by calling disableMobileScroll
-            if (popup) popup.style = `top: calc(${y || 0}px - var(--feds-height-nav) - 1px)`;
+            if (popup) popup.style.top = `calc(${y || 0}px - var(--feds-height-nav) - 1px)`;
             makeTabActive(popup);
+          } else if (isDesktop.matches && this.newMobileNav && isSectionMenu) {
+            const popup = dropdownTrigger.nextElementSibling;
+            if (popup) popup.style.removeProperty('top');
           }
           trigger({ element: dropdownTrigger, event: e });
           setActiveDropdown(dropdownTrigger);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -385,7 +385,7 @@ class Gnav {
     let localNav = document.querySelector('.feds-localnav');
     if (!localNav) {
       lanaLog({ message: 'GNAV: Localnav does not include \'localnav\' in its name.', tags: 'errorType=info,module=gnav' });
-      localNav = toFragment`<div class="feds-localnav"/>`;
+      localNav = toFragment`<div class="feds-localnav"/>`
       this.block.after(localNav);
     }
     localNav.setAttribute('daa-lh', `${title}_localNav`);
@@ -1125,8 +1125,9 @@ class Gnav {
         dropdownTrigger.addEventListener('click', (e) => {
           if (!isDesktop.matches && this.newMobileNav && isSectionMenu) {
             const popup = dropdownTrigger.nextElementSibling;
-            const y = Math.abs(parseInt(document.body.style.top));
-            // document.body.style.top should always be set at this point by calling disableMobileScroll
+            const y = Math.abs(parseInt(document.body.style.top, 10));
+            // document.body.style.top should always be set 
+            // at this point by calling disableMobileScroll
             if (popup) popup.style = `top: calc(${y || 0}px - var(--feds-height-nav) - 1px)`;
             makeTabActive(popup);
           }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -404,14 +404,11 @@ class Gnav {
       itemWrapper.appendChild(clonedItem);
     });
 
+    const preventDefault = (e) => e.preventDefault();
     const disableMobileScroll = () => {
-      const current = window.scrollY;
-      const f = (event) => {
-        event.preventDefault();
-      };
-      window.addEventListener('touchmove', f, { passive: false }); // for iOS
-      return () => { window.removeEventListener('touchmove', f); };
+      window.addEventListener('touchmove', preventDefault, { passive: false }); // for iOS
     }
+    const enableMobileScroll = () => window.removeEventListener('touchmove', preventDefault);
 
     localNav.querySelector('.feds-localnav-title').addEventListener('click', () => {
       localNav.classList.toggle('feds-localnav--active');
@@ -419,9 +416,8 @@ class Gnav {
       const isActive = localNav.classList.contains('feds-localnav--active');
       localNav.querySelector('.feds-localnav-title').setAttribute('aria-expanded', isActive);
       localNav.querySelector('.feds-localnav-title').setAttribute('daa-ll', `${title}_localNav|${isActive ? 'close' : 'open'}`);
-      let enableMobileScroll = () => {};
       if (isActive) {
-        enableMobileScroll = disableMobileScroll();
+        disableMobileScroll();
       } else {
         enableMobileScroll();
       }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -408,6 +408,7 @@ class Gnav {
       const current = window.scrollY;
       const f = (event) => {
         event.preventDefault();
+        window.scroll(0, current);
       };
       window.addEventListener('scroll', f);
       return () => { window.removeEventListener('scroll', f); };

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1147,7 +1147,7 @@ class Gnav {
             // at this point by calling disableMobileScroll
             if (popup && this.isLocalNav()) {
               const y = Math.abs(parseInt(document.body.style.top, 10));
-              popup.style.top = `calc(${y || 0}px - var(--feds-height-nav) - 1px)`;
+              popup.style = `top: calc(${y || 0}px - var(--feds-height-nav))`;
             }
             makeTabActive(popup);
           } else if (isDesktop.matches && this.newMobileNav && isSectionMenu) {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -43,7 +43,6 @@ import {
   transformTemplateToMobile,
   closeAllTabs,
   enableMobileScroll,
-  disableMobileScroll,
 } from './utilities/utilities.js';
 import { getFedsPlaceholderConfig } from '../../utils/federated.js';
 
@@ -412,10 +411,12 @@ class Gnav {
       const isActive = localNav.classList.contains('feds-localnav--active');
       localNav.querySelector('.feds-localnav-title').setAttribute('aria-expanded', isActive);
       localNav.querySelector('.feds-localnav-title').setAttribute('daa-ll', `${title}_localNav|${isActive ? 'close' : 'open'}`);
+      const pred = (e) => !localNav.contains(e.target);
+      let enableScroll = () => {};
       if (isActive) {
-        disableMobileScroll();
+        enableScroll = disableMobileScroll(pred);
       } else {
-        enableMobileScroll();
+        enableScroll();
       }
     });
 
@@ -775,8 +776,10 @@ class Gnav {
   toggleMenuMobile = () => {
     const toggle = this.elements.mobileToggle;
     const isExpanded = this.isToggleExpanded();
-    if (isExpanded) disableMobileScroll();
-    else enableMobileScroll();
+    const pred = (e) => !this.block.contains(e.target);
+    let enableScroll = () => {};
+    if (isExpanded) enableScroll = disableMobileScroll(pred);
+    else enablScroll();
     if (!isExpanded && this.newMobileNav) {
       const sections = document.querySelectorAll('header.new-nav .feds-nav > section.feds-navItem > button.feds-navLink');
       animateInSequence(sections, 0.075);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -784,6 +784,8 @@ class Gnav {
         const section = sections[0];
         queueMicrotask(() => section.click());
       }
+    } else if (isExpanded && this.newMobileNav) {
+      enableMobileScroll();
     }
     toggle?.setAttribute('aria-expanded', !isExpanded);
     document.body.classList.toggle('disable-scroll', !isExpanded);
@@ -1128,10 +1130,12 @@ class Gnav {
         dropdownTrigger.addEventListener('click', (e) => {
           if (!isDesktop.matches && this.newMobileNav && isSectionMenu) {
             const popup = dropdownTrigger.nextElementSibling;
-            const y = Math.abs(parseInt(document.body.style.top, 10));
             // document.body.style.top should always be set
             // at this point by calling disableMobileScroll
-            if (popup) popup.style.top = `calc(${y || 0}px - var(--feds-height-nav) - 1px)`;
+            if (popup && this.isLocalNav()) {
+              const y = Math.abs(parseInt(document.body.style.top, 10));
+              popup.style.top = `calc(${y || 0}px - var(--feds-height-nav) - 1px)`;
+            }
             makeTabActive(popup);
           } else if (isDesktop.matches && this.newMobileNav && isSectionMenu) {
             const popup = dropdownTrigger.nextElementSibling;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -385,7 +385,7 @@ class Gnav {
     let localNav = document.querySelector('.feds-localnav');
     if (!localNav) {
       lanaLog({ message: 'GNAV: Localnav does not include \'localnav\' in its name.', tags: 'errorType=info,module=gnav' });
-      localNav = toFragment`<div class="feds-localnav"/>`
+      localNav = toFragment`<div class="feds-localnav"/>`;
       this.block.after(localNav);
     }
     localNav.setAttribute('daa-lh', `${title}_localNav`);
@@ -1126,7 +1126,7 @@ class Gnav {
           if (!isDesktop.matches && this.newMobileNav && isSectionMenu) {
             const popup = dropdownTrigger.nextElementSibling;
             const y = Math.abs(parseInt(document.body.style.top, 10));
-            // document.body.style.top should always be set 
+            // document.body.style.top should always be set
             // at this point by calling disableMobileScroll
             if (popup) popup.style = `top: calc(${y || 0}px - var(--feds-height-nav) - 1px)`;
             makeTabActive(popup);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -43,6 +43,7 @@ import {
   transformTemplateToMobile,
   closeAllTabs,
   disableMobileScroll,
+  enableMobileScroll,
 } from './utilities/utilities.js';
 import { getFedsPlaceholderConfig } from '../../utils/federated.js';
 
@@ -411,18 +412,14 @@ class Gnav {
       const isActive = localNav.classList.contains('feds-localnav--active');
       localNav.querySelector('.feds-localnav-title').setAttribute('aria-expanded', isActive);
       localNav.querySelector('.feds-localnav-title').setAttribute('daa-ll', `${title}_localNav|${isActive ? 'close' : 'open'}`);
-      const pred = (e) => !localNav.contains(e.target);
-      let enableScroll = () => {};
-      if (isActive) {
-        enableScroll = disableMobileScroll(pred);
-      } else {
-        enableScroll();
-      }
+      if (isActive) disableMobileScroll();
+      else enableMobileScroll();
     });
 
     localNav.querySelector('.feds-localnav-curtain').addEventListener('click', (e) => {
       trigger({ element: e.currentTarget, event: e, type: 'localNav-curtain' });
       document.body.classList.remove('disable-scroll');
+      enableMobileScroll();
     });
     this.elements.localNav = localNav;
     localNavItems[0].querySelector('a').textContent = title.trim();
@@ -430,7 +427,7 @@ class Gnav {
       const rect = this.elements.localNav.getBoundingClientRect();
       return rect.top === 0;
     };
-    window.addEventListener('scroll', (event) => {
+    window.addEventListener('scroll', () => {
       const classList = this.elements.localNav?.classList;
       if (isAtTop()) {
         if (!classList?.contains('is-sticky')) {
@@ -776,11 +773,8 @@ class Gnav {
   toggleMenuMobile = () => {
     const toggle = this.elements.mobileToggle;
     const isExpanded = this.isToggleExpanded();
-    const pred = (e) => !this.block.contains(e.target);
-    let enableScroll = () => {};
-    if (isExpanded) enableScroll = disableMobileScroll(pred);
-    else enableScroll();
     if (!isExpanded && this.newMobileNav) {
+      disableMobileScroll();
       const sections = document.querySelectorAll('header.new-nav .feds-nav > section.feds-navItem > button.feds-navLink');
       animateInSequence(sections, 0.075);
       if (this.isLocalNav()) {
@@ -1131,7 +1125,9 @@ class Gnav {
         dropdownTrigger.addEventListener('click', (e) => {
           if (!isDesktop.matches && this.newMobileNav && isSectionMenu) {
             const popup = dropdownTrigger.nextElementSibling;
-            if (popup) popup.style = `top: calc(${window.scrollY}px - var(--feds-height-nav) - 1px)`;
+            const y = Math.abs(parseInt(document.body.style.top));
+            // document.body.style.top should always be set at this point by calling disableMobileScroll
+            if (popup) popup.style = `top: calc(${y || 0}px - var(--feds-height-nav) - 1px)`;
             makeTabActive(popup);
           }
           trigger({ element: dropdownTrigger, event: e });

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -422,7 +422,7 @@ class Gnav {
       const rect = this.elements.localNav.getBoundingClientRect();
       return rect.top === 0;
     };
-    window.addEventListener('scroll', () => {
+    window.addEventListener('scroll', (event) => {
       const classList = this.elements.localNav?.classList;
       if (isAtTop()) {
         if (!classList?.contains('is-sticky')) {
@@ -431,6 +431,7 @@ class Gnav {
       } else {
         classList?.remove('is-sticky');
       }
+      event.preventDefault();
     });
   };
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -42,7 +42,7 @@ import {
   animateInSequence,
   transformTemplateToMobile,
   closeAllTabs,
-  enableMobileScroll,
+  disableMobileScroll,
 } from './utilities/utilities.js';
 import { getFedsPlaceholderConfig } from '../../utils/federated.js';
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -404,14 +404,13 @@ class Gnav {
       itemWrapper.appendChild(clonedItem);
     });
 
-    const disableScroll = () => {
+    const disableMobileScroll = () => {
       const current = window.scrollY;
       const f = (event) => {
         event.preventDefault();
-        window.scroll(0, current);
       };
-      window.addEventListener('scroll', f);
-      return () => { window.removeEventListener('scroll', f); };
+      window.addEventListener('touchmove', f);
+      return () => { window.removeEventListener('touchmove', f); };
     }
 
     localNav.querySelector('.feds-localnav-title').addEventListener('click', () => {
@@ -420,11 +419,11 @@ class Gnav {
       const isActive = localNav.classList.contains('feds-localnav--active');
       localNav.querySelector('.feds-localnav-title').setAttribute('aria-expanded', isActive);
       localNav.querySelector('.feds-localnav-title').setAttribute('daa-ll', `${title}_localNav|${isActive ? 'close' : 'open'}`);
-      let enableScroll = () => {};
+      let enableMobileScroll = () => {};
       if (isActive) {
-        enableScroll = disableScroll();
+        enableMobileScroll = disableMobileScroll();
       } else {
-        enableScroll();
+        enableMobileScroll();
       }
     });
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -779,7 +779,7 @@ class Gnav {
     const pred = (e) => !this.block.contains(e.target);
     let enableScroll = () => {};
     if (isExpanded) enableScroll = disableMobileScroll(pred);
-    else enablScroll();
+    else enableScroll();
     if (!isExpanded && this.newMobileNav) {
       const sections = document.querySelectorAll('header.new-nav .feds-nav > section.feds-navItem > button.feds-navLink');
       animateInSequence(sections, 0.075);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -404,12 +404,27 @@ class Gnav {
       itemWrapper.appendChild(clonedItem);
     });
 
+    const disableScroll = () => {
+      const current = window.scrollY;
+      const f = (event) => {
+        event.preventDefault();
+      };
+      window.addEventListener('scroll', f);
+      return () => { window.removeEventListener('scroll', f); };
+    }
+
     localNav.querySelector('.feds-localnav-title').addEventListener('click', () => {
       localNav.classList.toggle('feds-localnav--active');
       document.body.classList.toggle('disable-scroll');
       const isActive = localNav.classList.contains('feds-localnav--active');
       localNav.querySelector('.feds-localnav-title').setAttribute('aria-expanded', isActive);
       localNav.querySelector('.feds-localnav-title').setAttribute('daa-ll', `${title}_localNav|${isActive ? 'close' : 'open'}`);
+      let enableScroll = () => {};
+      if (isActive) {
+        enableScroll = disableScroll();
+      } else {
+        enableScroll();
+      }
     });
 
     localNav.querySelector('.feds-localnav-curtain').addEventListener('click', (e) => {
@@ -431,7 +446,6 @@ class Gnav {
       } else {
         classList?.remove('is-sticky');
       }
-      event.preventDefault();
     });
   };
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -520,11 +520,12 @@ export const dropWhile = (xs, f) => {
   return xs;
 };
 
-const preventDefault = (e) => e.preventDefault();
+const preventDefault = (pred) => (e) => {
+  if (pred(e)) e.preventDefault();
+};
 
-export const disableMobileScroll = () => {
-  document.body.addEventListener('touchmove', preventDefault, { passive: false }); // for iOS
+export const disableMobileScroll = (pred) => {
+  const g = preventDefault(pred)
+  document.body.addEventListener('touchmove', g, { passive: false }); // for iOS
+  return document.body.removeEventListener('touchmove', g);
 }
-export const enableMobileScroll = () => document.body.removeEventListener('touchmove', preventDefault);
-
-

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -519,3 +519,11 @@ export const dropWhile = (xs, f) => {
   if (f(xs[0])) return dropWhile(xs.slice(1), f);
   return xs;
 };
+
+const preventDefault = (e) => e.preventDefault();
+export const disableMobileScroll = () => {
+  window.addEventListener('touchmove', preventDefault, { passive: false }); // for iOS
+}
+export const enableMobileScroll = () => window.removeEventListener('touchmove', preventDefault);
+
+

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -413,6 +413,20 @@ export const closeAllTabs = (tabs, tabpanels) => {
   tabs.forEach((t) => t.setAttribute('aria-selected', 'false'));
 };
 
+export const disableMobileScroll = () => {
+  document.body.style.top = `-${window.scrollY}px`;
+  document.body.classList.add('disable-ios-scroll');
+};
+
+export const enableMobileScroll = () => {
+  if (!document.body.style.top) return;
+  const y = Math.abs(parseInt(document.body.style.top, 10));
+  if (isNaN(y)) return;
+  document.body.classList.remove('disable-ios-scroll');
+  document.body.style.removeProperty('top');
+  window.scroll(0, y || 0);
+};
+
 export const transformTemplateToMobile = async (popup, item, localnav = false) => {
   const notMegaMenu = popup.parentElement.tagName === 'DIV';
   const originalContent = popup.innerHTML;
@@ -520,18 +534,3 @@ export const dropWhile = (xs, f) => {
   if (f(xs[0])) return dropWhile(xs.slice(1), f);
   return xs;
 };
-
-// 
-export const disableMobileScroll = () => {
-  document.body.style.top = `-${window.scrollY}px`;
-  document.body.classList.add('disable-ios-scroll');
-}
-
-export const enableMobileScroll = () => {
-  if (!document.body.style.top) return;
-  const y = Math.abs(parseInt(document.body.style.top, 10));
-  if (y === NaN) return;
-  document.body.classList.remove('disable-ios-scroll');
-  document.body.style.removeProperty('top');
-  window.scroll(0, y || 0);
-}

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -503,8 +503,8 @@ export const transformTemplateToMobile = async (popup, item, localnav = false) =
     e.target.closest(selectors.activeDropdown).querySelector('button').focus();
     closeAllDropdowns();
   });
-  const tabbuttons = popup.querySelectorAll('.global-navigation .tabs button');
-  const tabpanels = popup.querySelectorAll('.global-navigation .tab-content [role="tabpanel"]');
+  const tabbuttons = popup.querySelectorAll('.tabs button');
+  const tabpanels = popup.querySelectorAll('.tab-content [role="tabpanel"]');
 
   tabpanels.forEach((panel) => {
     animateInSequence(panel.querySelectorAll('a'), 0.02);

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -521,9 +521,10 @@ export const dropWhile = (xs, f) => {
 };
 
 const preventDefault = (e) => e.preventDefault();
+
 export const disableMobileScroll = () => {
-  window.addEventListener('touchmove', preventDefault, { passive: false }); // for iOS
+  document.body.addEventListener('touchmove', preventDefault, { passive: false }); // for iOS
 }
-export const enableMobileScroll = () => window.removeEventListener('touchmove', preventDefault);
+export const enableMobileScroll = () => document.body.removeEventListener('touchmove', preventDefault);
 
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -421,7 +421,7 @@ export const disableMobileScroll = () => {
 export const enableMobileScroll = () => {
   if (!document.body.style.top) return;
   const y = Math.abs(parseInt(document.body.style.top, 10));
-  if (isNaN(y)) return;
+  if (Number.isNaN(y)) return;
   document.body.classList.remove('disable-ios-scroll');
   document.body.style.removeProperty('top');
   window.scroll(0, y || 0);

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -5,6 +5,7 @@ import {
 import { getFederatedContentRoot, getFederatedUrl, getFedsPlaceholderConfig } from '../../../utils/federated.js';
 import { processTrackingLabels } from '../../../martech/attributes.js';
 import { replaceText } from '../../../features/placeholders.js';
+import { PERSONALIZATION_TAGS } from '../../../features/personalization/personalization.js';
 
 loadLana();
 
@@ -414,11 +415,13 @@ export const closeAllTabs = (tabs, tabpanels) => {
 };
 
 export const disableMobileScroll = () => {
+  if (!PERSONALIZATION_TAGS.safari()) return;
   document.body.style.top = `-${window.scrollY}px`;
   document.body.classList.add('disable-ios-scroll');
 };
 
 export const enableMobileScroll = () => {
+  if (!PERSONALIZATION_TAGS.safari()) return;
   if (!document.body.style.top) return;
   const y = Math.abs(parseInt(document.body.style.top, 10));
   if (Number.isNaN(y)) return;

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -483,6 +483,7 @@ export const transformTemplateToMobile = async (popup, item, localnav = false) =
   popup.querySelector('.close-icon')?.addEventListener('click', () => {
     document.querySelector(selectors.mainNavToggle).focus();
     closeAllDropdowns();
+    enableMobileScroll();
   });
   popup.querySelector('.main-menu')?.addEventListener('click', (e) => {
     e.target.closest(selectors.activeDropdown).querySelector('button').focus();
@@ -520,12 +521,17 @@ export const dropWhile = (xs, f) => {
   return xs;
 };
 
-const preventDefault = (pred) => (e) => {
-  if (pred(e)) e.preventDefault();
-};
+// 
+export const disableMobileScroll = () => {
+  document.body.style.top = `-${window.scrollY}px`;
+  document.body.classList.add('disable-ios-scroll');
+}
 
-export const disableMobileScroll = (pred) => {
-  const g = preventDefault(pred)
-  document.body.addEventListener('touchmove', g, { passive: false }); // for iOS
-  return document.body.removeEventListener('touchmove', g);
+export const enableMobileScroll = () => {
+  if (!document.body.style.top) return;
+  const y = Math.abs(parseInt(document.body.style.top, 10));
+  if (y === NaN) return;
+  document.body.classList.remove('disable-ios-scroll');
+  document.body.style.removeProperty('top');
+  window.scroll(0, y || 0);
 }

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -764,6 +764,10 @@ header.global-navigation + .feds-localnav {
   display: none !important;
 }
 
+html:has(body.disable-scroll) {
+  overflow: hidden;
+}
+
 .disable-scroll {
   overflow: hidden;
 }

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -766,7 +766,8 @@ header.global-navigation + .feds-localnav {
 
 html:has(body.disable-scroll) {
   overflow: hidden;
-  position: fixed;
+  position: relative;
+  height: 100%;
 }
 
 .disable-scroll {

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -766,6 +766,7 @@ header.global-navigation + .feds-localnav {
 
 html:has(body.disable-scroll) {
   overflow: hidden;
+  position: fixed;
 }
 
 .disable-scroll {

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -764,10 +764,6 @@ header.global-navigation + .feds-localnav {
   display: none !important;
 }
 
-html:has(> body.disable-scroll) {
-  overflow: hidden;
-}
-
 .disable-scroll {
   overflow: hidden;
   /* for iOS Safari */

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -766,8 +766,6 @@ header.global-navigation + .feds-localnav {
 
 .disable-scroll {
   overflow: hidden;
-  /* for iOS Safari */
-  position: absolute;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -766,6 +766,8 @@ header.global-navigation + .feds-localnav {
 
 .disable-scroll {
   overflow: hidden;
+  /* for iOS Safari */
+  position: absolute;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -764,6 +764,10 @@ header.global-navigation + .feds-localnav {
   display: none !important;
 }
 
+html:has(> body.disable-scroll) {
+  overflow: hidden;
+}
+
 .disable-scroll {
   overflow: hidden;
   /* for iOS Safari */

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -764,12 +764,6 @@ header.global-navigation + .feds-localnav {
   display: none !important;
 }
 
-html:has(body.disable-scroll) {
-  overflow: hidden;
-  position: relative;
-  height: 100%;
-}
-
 .disable-scroll {
   overflow: hidden;
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* on iOS Safari `overflow: hidden` does not prevent the screen from scrolling. Scrolling can still happen under the following circumstances:
  * when the bottom toolbar is collapsed
  * When the keyboard is visible
  * When focusing on an input (which centers it it)
* So we do `position:fixed` to prevetn scrolling. But this jumps the scroll to the top of the page. So we offset the old scroll height using `top`. 
* Once the background becomes scrollable again, we retrieve our original scroll value from `body`'s style and set the window scroll to that. 

Resolves: [MWPW-163916](https://jira.corp.adobe.com/browse/MWPW-163916)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mobile-gnav-ios-scroll-flicker--milo--adobecom.aem.page/?martech=off
https://main--federal--adobecom.hlx.page/federal/dev/prats/mobileredesign/page?milolibs=mobile-gnav-ios-scroll-flicker
