### PR TITLE
Updating package version for bundled standalone gnav

### DIFF
--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Updating package version for bundled standalone gnav


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-version--milo--adobecom.aem.page/?martech=off
