### PR TITLE
Mobile Gnav Standalone Localnav curtain was missing some styles

### DIFF
--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -7,6 +7,7 @@
 :root {
   --navigation-link-color: #035FE6;
   --navigation-link-color--hover: #136FF6;
+  --feds-localnav-height: 40px;
 }
 
 .global-navigation, .global-footer, .dialog-modal {
@@ -66,4 +67,9 @@ header.global-navigation, header.global-navigation.feds--dark {
 
 .feds-client-search {
   margin-left: auto;
+}
+
+header.global-navigation + .feds-localnav {
+  display: block;
+  height: var(--feds-localnav-height);
 }

--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -8,6 +8,7 @@
   --navigation-link-color: #035FE6;
   --navigation-link-color--hover: #136FF6;
   --feds-localnav-height: 40px;
+  --global-height-nav: 64px;
 }
 
 .global-navigation, .global-footer, .dialog-modal {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Some styles in styles.css necessary for localnav to function were missing from standalone gnav


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mobile-gnav-standalone--milo--adobecom.aem.page/?martech=off

https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=mobile-gnav-standalone&newNav=true