### PR TITLE
Fixed the popup position for when there is no promo

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1166,7 +1166,10 @@ class Gnav {
             // at this point by calling disableMobileScroll
             if (popup && this.isLocalNav()) {
               const y = window.scrollY;
-              popup.style = `top: calc(${y || 0}px - var(--feds-height-nav) - var(--global-height-navPromo)`;
+              const offset = this.block.classList.contains('has-promo')
+                ? 'var(--feds-height-nav) - var(--global-height-navPromo)'
+                : 'var(--feds-height-nav)';
+              popup.style = `top: calc(${y || 0}px - ${offset}`;
             }
             makeTabActive(popup);
           } else if (isDesktop.matches && this.newMobileNav && isSectionMenu) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->


With promo: https://main--cc--adobecom.hlx.page/ae_ar/creativecloud/photography/discover/how-to-read-a-histogram?milolibs=mobile-gnav-popup&newNav=true

without promo: https://main--cc--adobecom.hlx.live/creativecloud?milolibs=mobile-gnav-popup&newNav=true