### PR TITLE
Notification pill variant needs 16px spacing below it

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -208,7 +208,8 @@
   z-index: 4; 
 }
 
-.section.sticky-bottom.popup {
+.section.sticky-bottom.popup,
+.section.sticky-bottom:has(.notification.pill) {
   bottom: var(--spacing-xs);
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Adding a 16px spacing between the pill notification and the bottom of the browser to get it the appearance of "floating.

Note: The ribbon notification variant does not get this spacing.

Resolves: [MWPW-163581](https://jira.corp.adobe.com/browse/MWPW-163581)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/notification-banner?martech=off
- After:https://pill-notification-padding--milo--adobecom.hlx.page/drafts/rclayton/notification-banner?martech=off


![image](https://github.com/user-attachments/assets/0d04f8e7-3f49-4c19-97db-3cebe1f92966)
