### PR TITLE
MWPW-161920: Authenticated site support for preview

### DIFF
--- a/tools/floodbox/bulk-action.js
+++ b/tools/floodbox/bulk-action.js
@@ -5,11 +5,12 @@ const BATCH_SIZE = 25;
 const BATCH_DELAY = 2000;
 
 export class BulkAction {
-  constructor({ org, repo, callback }) {
+  constructor({ org, repo, accessToken, callback }) {
     this.org = org;
     this.repo = repo;
     this.callback = callback;
-    this.requestHandler = new RequestHandler();
+    this.accessToken = accessToken;
+    this.requestHandler = new RequestHandler(accessToken);
     this.batchCount = 0;
   }
 
@@ -52,9 +53,9 @@ export class BulkAction {
 }
 
 async function previewOrPublishPaths({
-  org, repo, paths, action, callback, isDelete = false,
+  org, repo, paths, action, accessToken, callback, isDelete = false,
 }) {
-  const bulkAction = new BulkAction({ org, repo, callback });
+  const bulkAction = new BulkAction({ org, repo, accessToken, callback });
   // eslint-disable-next-line no-console
   console.log(`Action: ${action} :: isDelete: ${isDelete}`);
   await bulkAction.previewOrPublishPaths({ paths, action, isDelete });

--- a/tools/floodbox/floodgate/floodgate.js
+++ b/tools/floodbox/floodgate/floodgate.js
@@ -171,6 +171,7 @@ export default class MiloFloodgate extends LitElement {
       repo: repoToPrevPub,
       paths,
       action: 'preview',
+      accessToken: this.token,
       callback: (status) => {
         // eslint-disable-next-line no-console
         console.log(`${status.statusCode} :: ${status.aemUrl}`);
@@ -197,6 +198,7 @@ export default class MiloFloodgate extends LitElement {
       repo: repoToPrevPub,
       paths,
       action: 'live',
+      accessToken: this.token,
       callback: (status) => {
         // eslint-disable-next-line no-console
         console.log(`${status.statusCode} :: ${status.aemUrl}`);
@@ -424,6 +426,7 @@ export default class MiloFloodgate extends LitElement {
       repo,
       paths,
       action: 'live',
+      accessToken: this.token,
       isDelete: true,
       callback: (status) => {
         // eslint-disable-next-line no-console

--- a/tools/floodbox/graybox/graybox.js
+++ b/tools/floodbox/graybox/graybox.js
@@ -150,6 +150,7 @@ export default class MiloGraybox extends LitElement {
       repo: repoToPrevPub,
       paths,
       action: 'preview',
+      accessToken: this.token,
       callback: (status) => {
         // eslint-disable-next-line no-console
         console.log(`${status.statusCode} :: ${status.aemUrl}`);

--- a/tools/floodbox/references.js
+++ b/tools/floodbox/references.js
@@ -9,7 +9,7 @@ class References {
     this.htmlPaths = htmlPaths;
 
     // eslint-disable-next-line no-useless-escape
-    this.referencePattern = new RegExp(`https?:\/\/[^/]*--${repo}--${org}\\.[^/]*(?:page|live)(\/(?:fragments\/.*|.*\\.(?:pdf|svg|json)))`);
+    this.referencePattern = new RegExp(`https?:\/\/[^/]*--${repo}--${org}\\.[^/]*(?:page|live)(\/(?:fragments\/.*|.*\\.(?:pdf|svg|json|mp4)))`);
     this.requestHandler = new RequestHandler(accessToken);
   }
 

--- a/tools/floodbox/references.js
+++ b/tools/floodbox/references.js
@@ -9,7 +9,7 @@ class References {
     this.htmlPaths = htmlPaths;
 
     // eslint-disable-next-line no-useless-escape
-    this.referencePattern = new RegExp(`https?:\/\/[^/]*--${repo}--${org}\\.[^/]*(?:page|live)(\/(?:fragments\/.*|.*\\.(?:pdf|svg|json|mp4)))`);
+    this.referencePattern = new RegExp(`https?:\/\/[^/]*--${repo}--${org}\\.[^/]*(?:page|live)(\/(?:fragments\/.*|.*\\.(?:pdf|svg|json)))`);
     this.requestHandler = new RequestHandler(accessToken);
   }
 


### PR DESCRIPTION
- For preview/publish Helix API call, the auth token is passed in as the site is behind auth


Resolves: [MWPW-161920](https://jira.corp.adobe.com/browse/MWPW-161920)

**Test URLs:**
- Before: https://da.live/app/adobecom/milo/tools/floodgate?ref=floodbox
- After: https://da.live/app/adobecom/milo/tools/floodgate?ref=authsupport

- Before: https://da.live/app/adobecom/milo/tools/graybox?ref=floodbox
- After: https://da.live/app/adobecom/milo/tools/graybox?ref=authsupport
