### PR TITLE
List accessibility for quiz-marquee

### DIFF
--- a/libs/blocks/quiz-marquee/quiz-marquee.js
+++ b/libs/blocks/quiz-marquee/quiz-marquee.js
@@ -68,9 +68,17 @@ export default async function init(el) {
   [...rows].forEach(async (row) => {
     const cols = row.querySelectorAll(':scope > div');
     const isFragRow = cols[0].textContent.trim() === 'nested-fragments';
+    let isList = false;
+
+    if (cols[2]) {
+      if (cols[2].textContent.trim() === 'list') isList = true;
+    }
 
     if (isFragRow) {
-      cols[0].parentElement.classList.add('nested', cols[1].textContent.trim());
+      const fragParent = cols[0].parentElement;
+      fragParent.classList.add('nested', cols[1].textContent.trim());
+      if (isList) fragParent.setAttribute('role', 'list');
+
       const wrapper = createTag('div', { class: 'copy-wrapper' });
       row.append(wrapper);
       wrapper.append(...cols);

--- a/libs/blocks/quiz-results/quiz-results.js
+++ b/libs/blocks/quiz-results/quiz-results.js
@@ -16,6 +16,7 @@ async function loadFragments(el, experiences) {
   }
   document.querySelectorAll('main > div, .quiz-results').forEach((quiz) => quiz.removeAttribute('daa-lh'));
   document.querySelectorAll('.quiz-results.basic > .fragment > .section').forEach((section, idx) => decorateSectionAnalytics(section, idx, getConfig()));
+  if (el.getAttribute('role') === 'list') document.querySelectorAll('.nested[role=list] > .fragment').forEach((fragment) => fragment.setAttribute('role', 'listitem'));
 }
 
 function redirectPage(quizUrl, debug, message) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Update quiz-marquee authoring to denote nested lists
* roles for list and listitem in quiz-marquee and quiz-results

Resolves: [MWPW-165027](https://jira.corp.adobe.com/browse/165027-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/colloyd/quiz-marquee/quiz-marquee-pr?quizkey=quiz-test&debug=quiz-results&martech=off
- After: https://quiz-marquee-list-support--milo--colloyd.aem.page/drafts/colloyd/quiz-marquee/quiz-marquee-pr?quizkey=quiz-test&debug=quiz-results&martech=off

Testing Notes: 

In order to test this change properly, an entry in local storage will need to be created after initially viewing the before and after pages. Set a local storage entry using the following:

Key: quiz-test-en-US
Value: {"primaryProducts":["stager-ind"],"secondaryProducts":["ps-ind","ai-ind","ae-ind"],"umbrellaProduct":"","basicFragments":["https://uar-integration--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/single-product/single-product-master","https://uar-integration--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/card/card-list"],"nestedFragments":{"marquee-product-single":[""],"check-bullet":["https://milo.adobe.com/fragments/xiasun/sample-uar-fragments/check-bullet/stager-bullet3","https://milo.adobe.com/fragments/xiasun/sample-uar-fragments/check-bullet/stager-bullet2","https://milo.adobe.com/fragments/xiasun/sample-uar-fragments/check-bullet/stager-bullet3"],"marquee-plan":["https://milo.adobe.com/fragments/xiasun/sample-uar-fragments/master-plan/substance-3d-stager-ind"],"value-prop":["https://milo.adobe.com/fragments/xiasun/sample-uar-fragments/value-prop/value-prop-stager"],"learn":["https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/learn/learn"],"commerce-card":["https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/card/ps","https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/card/ai","https://main--milo--adobecom.hlx.live/fragments/xiasun/sample-uar-fragments/card/ae"]},"pageloadHash":"type=cc:app-reco&quiz=uarv3&result=stager-ind&selectedOptions=q-category/3d|q-3d/stage|q-customer/individual"}

Note that in the before page, the list of checked bullets (classed as "nested check-bullet show") do not have role="list" and the contained fragments do not have role="listitem". Both roles are present on the after page.
