### PR TITLE
MWPW-164737: add daa-ll for new gnav-image element

### DIFF
--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -129,7 +129,7 @@ const decorateGnavImage = (elem) => {
   const linkElem = elem.querySelector('a');
   const imageElem = elem.querySelector('picture');
   const promoImageElem = linkElem instanceof HTMLElement
-    ? toFragment`<a class="feds-image" href="${linkElem.href}">${imageElem}</a>`
+    ? toFragment`<a class="feds-image" href="${linkElem.href}" daa-ll="gnav-image">${imageElem}</a>`
     : toFragment`<div class="feds-image">${imageElem}</div>`;
 
   elem.replaceChildren(promoImageElem);


### PR DESCRIPTION
Adds daa-ll value for new gnav-image element in GNav

Resolves: [MWPW-164737](https://jira.corp.adobe.com/browse/MWPW-164737)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-164737a--milo--adobecom.aem.page/?martech=off

QA: https://main--federal--adobecom.hlx.page/federal/dev/prats/mobileredesign/image/nav-test?milolibs=mwpw-164737a&newNav=true