### PR TITLE
MWPW-165391 [Mobile-GNav] when the page is opened and navigated till center and clicked on tabs the screen is taken up

### DIFF
--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -37,7 +37,8 @@ const removeAttributes = (el, attrsKeys) => {
 const scrollStackedMobile = (content) => {
   if (!window.matchMedia('(max-width: 600px)').matches) return;
   const rects = content.getBoundingClientRect();
-  const navHeight = document.querySelector('.global-navigation, .gnav')?.scrollHeight || 0;
+  const stickyTop = document.querySelector('.feds-localnav') ?? document.querySelector('.global-navigation, .gnav');
+  const navHeight = stickyTop?.scrollHeight || 0;
   const topOffset = rects.top + window.scrollY - navHeight - 1;
   window.scrollTo({ top: topOffset, behavior: 'smooth' });
 };


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* With Mobile Gnav the global navigation is no longer sticky on mobile if there is a local nav.
* This breaks `scrollStackedMobile` in tabs.js since `navHeight` is no longer correct.
* The solution is to first check for a localnav, since that is always guaranteed to be sticky instead of the global nav, and if that does not exist, look for the global nav.

Resolves: [MWPW-165391](https://jira.corp.adobe.com/browse/MWPW-165391)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mobile-gnav-tabs--milo--adobecom.aem.page/?martech=off

Test URL: https://main--cc--adobecom.hlx.live/creativecloud?milolibs=mobile-gnav-tabs&newNav=true
