### PR TITLE
MWPW-160808: fassform is seen displayed without the #id and not able to close

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -112,7 +112,7 @@ async function getPathModal(path, dialog) {
 }
 
 export async function getModal(details, custom) {
-  if (!(details?.path || custom)) return null;
+  if (!((details?.path && details?.id) || custom?.id)) return null;
   const { id } = details || custom;
 
   dialogLoadingSet.add(id);

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -112,7 +112,7 @@ async function getPathModal(path, dialog) {
 }
 
 export async function getModal(details, custom) {
-  if (!((details?.path && details?.id) || custom?.id)) return null;
+  if (!((details?.path && details?.id) || custom)) return null;
   const { id } = details || custom;
 
   dialogLoadingSet.add(id);


### PR DESCRIPTION
Fixed the issue where the modal would open even when no hash value was present in the URL

Resolves: [MWPW-160808](https://jira.corp.adobe.com/browse/MWPW-160808)

## Test URLs:
**Milo**
- Before: https://main--milo--adobecom.hlx.live/docs/authoring/create-modal
- After: https://mwpw-160808--milo--sivasadobe.hlx.live/docs/authoring/create-modal

**CC**
- Before: https://main--cc--adobecom.hlx.page/drafts/siva/160808/enterprise?martech=off
- After: https://main--cc--adobecom.hlx.page/drafts/siva/160808/enterprise?milolibs=mwpw-160808--milo--sivasadobe&martech=off
