### PR TITLE
Don't merge PRs with running tests

### DIFF
--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -52,7 +52,7 @@ let body = `
 const isHighPrio = (labels) => labels.includes(LABELS.highPriority);
 const isZeroImpact = (labels) => labels.includes(LABELS.zeroImpact);
 
-const hasFailingChecks = (checks) => checks.some(({ conclusion, name }) => name !== 'merge-to-stage' && conclusion === 'failure');
+const hasFailingChecks = (checks) => checks.some(({ conclusion, name }) => name !== 'merge-to-stage' && conclusion !== 'success');
 
 const commentOnPR = async (comment, prNumber) => {
   console.log(comment); // Logs for debugging the action.
@@ -90,7 +90,7 @@ const getPRs = async () => {
 
   prs = prs.filter(({ checks, reviews, number, title }) => {
     if (hasFailingChecks(checks)) {
-      commentOnPR(`Skipped merging ${number}: ${title} due to failing checks`, number);
+      commentOnPR(`Skipped merging ${number}: ${title} due to failing or running checks`, number);
       return false;
     }
 

--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -52,7 +52,12 @@ let body = `
 const isHighPrio = (labels) => labels.includes(LABELS.highPriority);
 const isZeroImpact = (labels) => labels.includes(LABELS.zeroImpact);
 
-const hasFailingChecks = (checks) => checks.some(({ conclusion, name }) => name !== 'merge-to-stage' && conclusion !== 'success');
+const hasFailingChecks = (checks) =>
+  checks.some(
+    ({ conclusion, name }) =>
+      name !== 'merge-to-stage' &&
+      (conclusion === 'in_progress' || conclusion === 'failure')
+  );
 
 const commentOnPR = async (comment, prNumber) => {
   console.log(comment); // Logs for debugging the action.


### PR DESCRIPTION
@npeltier pointed out that https://github.com/adobecom/milo/pull/3460 got merged with failing tests. This is because the workflow to merge to stage, ran while I restarted the tests for #3460. We need to account for running tests as well.


**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://safeguard-pr-merges--milo--mokimo.aem.live/?martech=off
