### PR TITLE
Adding check for localnav before setting the top for sticky top section metadata

### DIFF
--- a/libs/blocks/section-metadata/sticky-section.js
+++ b/libs/blocks/section-metadata/sticky-section.js
@@ -2,7 +2,11 @@ import { createTag } from '../../utils/utils.js';
 import { getMetadata, getDelayTime } from './section-metadata.js';
 
 function handleTopHeight(section) {
-  const headerHeight = document.querySelector('header')?.offsetHeight ?? 0;
+  let headerHeight = document.querySelector('header').offsetHeight;
+  const localNav = document.querySelector('.feds-localnav');
+  if (localNav) {
+    headerHeight = localNav.offsetHeight;
+  }
   section.style.top = `${headerHeight}px`;
 }
 

--- a/libs/mep/ace0861/section-metadata/sticky-section.js
+++ b/libs/mep/ace0861/section-metadata/sticky-section.js
@@ -2,7 +2,11 @@ import { createTag } from '../../../utils/utils.js';
 import { getMetadata, getDelayTime } from './section-metadata.js';
 
 function handleTopHeight(section) {
-  const headerHeight = document.querySelector('header').offsetHeight;
+  let headerHeight = document.querySelector('header').offsetHeight;
+  const localNav = document.querySelector('.feds-localnav');
+  if (localNav) {
+    headerHeight = localNav.offsetHeight;
+  }
   section.style.top = `${headerHeight}px`;
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding check for localnav before setting the top for sticky top metadata

Resolves: [MWPW-165638](https://jira.corp.adobe.com/browse/MWPW-165638)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mgnav-sticky-top--milo--adobecom.aem.page/?martech=off

QA: https://main--dc--adobecom.hlx.page/acrobat/hub/how-to-convert-heic-to-jpg-on-a-mac?milolibs=mgnav-sticky-top&newNav=true