### PR TITLE
[MWPW-157116] - Add feature for pause animation on hover for PEP

### DIFF
--- a/libs/features/webapp-prompt/webapp-prompt.css
+++ b/libs/features/webapp-prompt/webapp-prompt.css
@@ -184,7 +184,7 @@
     transform-origin: top right;
   }
 
-  .appPrompt:hover .appPrompt-progress {
+  .appPrompt:hover .appPrompt-progressPauseOnHover {
     animation-play-state: paused;
   }
 

--- a/libs/features/webapp-prompt/webapp-prompt.css
+++ b/libs/features/webapp-prompt/webapp-prompt.css
@@ -184,6 +184,10 @@
     transform-origin: top right;
   }
 
+  .appPrompt:hover .appPrompt-progress {
+    animation-play-state: paused;
+  }
+
   @keyframes appPrompt-animate {
     100% {
       transform: scaleX(1);

--- a/libs/features/webapp-prompt/webapp-prompt.js
+++ b/libs/features/webapp-prompt/webapp-prompt.js
@@ -231,7 +231,7 @@ export class AppPrompt {
   };
 
   decorate = () => {
-    const animationPlayState = this.options['pause-on-hover'] === 'on';
+    const animationPauseOnHover = this.options['pause-on-hover'] === 'on';
     this.elements.closeIcon = toFragment`<button daa-ll="Close Modal" aria-label="${this.cancel}" class="appPrompt-close"></button>`;
     this.elements.cta = toFragment`<button daa-ll="Stay on this page" class="appPrompt-cta appPrompt-cta--close">${this.cancel}</button>`;
     this.elements.profile = this.profile
@@ -260,7 +260,7 @@ export class AppPrompt {
         ${this.elements.cta}
       </div>
       <div class="appPrompt-progressWrapper">
-        <div class="appPrompt-progress" style="background-color: ${this.options['loader-color']}; animation-duration: ${this.options['loader-duration']}ms; ${!animationPlayState && 'animation-play-state: running;'}"></div>
+        <div class="appPrompt-progress ${animationPauseOnHover && 'appPrompt-progressPauseOnHover'}" style="background-color: ${this.options['loader-color']}; animation-duration: ${this.options['loader-duration']}ms;"></div>
       </div>
     </div>`;
   };
@@ -287,7 +287,7 @@ export class AppPrompt {
     let startTime;
 
     const startTimeout = () => {
-      startTime = Date.now();
+      startTime = performance.now();
       timeoutId = setTimeout(() => {
         this.close({ saveDismissal: false, dismissalActions: false });
         AppPrompt.redirectTo(this.options['redirect-url']);
@@ -296,7 +296,7 @@ export class AppPrompt {
 
     const stopTimeout = () => {
       clearTimeout(timeoutId);
-      remainingTime -= Date.now() - startTime;
+      remainingTime -= performance.now() - startTime;
     };
 
     if (withPause) {

--- a/libs/features/webapp-prompt/webapp-prompt.js
+++ b/libs/features/webapp-prompt/webapp-prompt.js
@@ -19,6 +19,7 @@ const CONFIG = {
   selectors: { prompt: '.appPrompt' },
   delay: 7000,
   loaderColor: '#EB1000',
+  pauseOnHover: 'off',
   ...DISMISSAL_CONFIG,
 };
 
@@ -155,7 +156,7 @@ export class AppPrompt {
     this.parent.prepend(this.template);
     this.elements.closeIcon.focus();
 
-    this.redirectFn = this.initRedirect();
+    this.redirectFn = this.initRedirect(this.options['pause-on-hover'] === 'on');
   };
 
   doesEntitlementMatch = async () => {
@@ -225,10 +226,12 @@ export class AppPrompt {
     metadata['dismissal-animation-duration'] = parseInt(metadata['dismissal-animation-duration'] ?? CONFIG.animationDuration, 10);
     metadata['dismissal-tooltip-message'] ??= CONFIG.tooltipMessage;
     metadata['dismissal-tooltip-duration'] = parseInt(metadata['dismissal-tooltip-duration'] ?? CONFIG.tooltipDuration, 10);
+    metadata['pause-on-hover'] ??= CONFIG.pauseOnHover;
     this.options = metadata;
   };
 
   decorate = () => {
+    const animationPlayState = this.options['pause-on-hover'] === 'on';
     this.elements.closeIcon = toFragment`<button daa-ll="Close Modal" aria-label="${this.cancel}" class="appPrompt-close"></button>`;
     this.elements.cta = toFragment`<button daa-ll="Stay on this page" class="appPrompt-cta appPrompt-cta--close">${this.cancel}</button>`;
     this.elements.profile = this.profile
@@ -257,7 +260,7 @@ export class AppPrompt {
         ${this.elements.cta}
       </div>
       <div class="appPrompt-progressWrapper">
-        <div class="appPrompt-progress" style="background-color: ${this.options['loader-color']}; animation-duration: ${this.options['loader-duration']}ms;"></div>
+        <div class="appPrompt-progress" style="background-color: ${this.options['loader-color']}; animation-duration: ${this.options['loader-duration']}ms; ${!animationPlayState && 'animation-play-state: running;'}"></div>
       </div>
     </div>`;
   };
@@ -278,10 +281,35 @@ export class AppPrompt {
     window.location.assign(url);
   }
 
-  initRedirect = () => setTimeout(() => {
-    this.close({ saveDismissal: false, dismissalActions: false });
-    AppPrompt.redirectTo(this.options['redirect-url']);
-  }, this.options['loader-duration']);
+  initRedirect = (withPause = false) => {
+    let timeoutId;
+    let remainingTime = this.options['loader-duration'];
+    let startTime;
+
+    const startTimeout = () => {
+      startTime = Date.now();
+      timeoutId = setTimeout(() => {
+        this.close({ saveDismissal: false, dismissalActions: false });
+        AppPrompt.redirectTo(this.options['redirect-url']);
+      }, remainingTime);
+    };
+
+    const stopTimeout = () => {
+      clearTimeout(timeoutId);
+      remainingTime -= Date.now() - startTime;
+    };
+
+    if (withPause) {
+      const appPromptElem = document.querySelector(CONFIG.selectors.prompt);
+      if (appPromptElem) {
+        appPromptElem.addEventListener('mouseenter', stopTimeout);
+        appPromptElem.addEventListener('mouseleave', startTimeout);
+      }
+    }
+
+    // Start the timeout initially
+    startTimeout();
+  };
 
   isDismissedPrompt = () => AppPrompt.getDismissedPrompts().includes(this.id);
 

--- a/test/features/webapp-prompt/mocks/pep-prompt-content.js
+++ b/test/features/webapp-prompt/mocks/pep-prompt-content.js
@@ -52,5 +52,9 @@ export default ({
       <div>dismissal-tooltip-duration</div>
       <div>${tooltipDuration}</div>
     </div>`}
+    <div>
+      <div>pause-on-hover</div>
+      <div>on</div>
+    </div>
   </div>
 </div>`;

--- a/test/features/webapp-prompt/webapp-prompt.test.js
+++ b/test/features/webapp-prompt/webapp-prompt.test.js
@@ -167,6 +167,15 @@ describe('PEP', () => {
       expect(document.querySelector(allSelectors.pepWrapper)).to.not.exist;
     });
 
+    it('stops the PEP timer when PEP content is hovered', async () => {
+      const clock = sinon.useFakeTimers();
+      await initPep({});
+      document.querySelector(allSelectors.pepWrapper).dispatchEvent(new Event('mouseenter'));
+      clock.tick(10000);
+      expect(window.location.hash).to.not.equal('#soup');
+      clock.uninstall();
+    });
+
     it('redirects when the PEP timer runs out', async () => {
       const clock = sinon.useFakeTimers();
       await initPep({});


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

**Implemented the 'Pause On Hover' feature for Feds PEP content, allowing it to adopt the same functionality available for Express PEP.**

Authoring changes via section metadata in the PEP content to support the ability to author this feature:
<img width="672" alt="Screenshot 2024-09-03 at 6 02 52 PM" src="https://github.com/user-attachments/assets/053694d5-068a-4e76-a36b-87eb6dc8c910" />

Due deligence wiki: https://wiki.corp.adobe.com/display/WEBT/%5BDue+Diligence%5D+PEP+-+Federalizing+Express

Resolves: [MWPW-157116](https://jira.corp.adobe.com/browse/MWPW-157116)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-157116--milo--deva309.aem.page/?martech=off

QA:
- https://feds--milo--adobecom.hlx.page/drafts/devashish/pep/pep-prompt?skipPepEntitlements=true (without pause on hover)
- https://feds--milo--adobecom.hlx.page/drafts/devashish/pep/pause/pep-prompt-pause-animation?skipPepEntitlements=true (with pause on hover)
