### PR TITLE
Taking localnav height only when it is visible

### DIFF
--- a/libs/blocks/section-metadata/sticky-section.js
+++ b/libs/blocks/section-metadata/sticky-section.js
@@ -5,7 +5,7 @@ function handleTopHeight(section) {
   let topHeight = document.querySelector('header')?.offsetHeight ?? 0;
   const localNav = document.querySelector('.feds-localnav');
   const fedsPromo = document.querySelector('.feds-promo-wrapper');
-  if (localNav) {
+  if (localNav && localNav.offsetHeight > 0) {
     topHeight = localNav.offsetHeight;
   }
   if (fedsPromo) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Taking localnav height to set the top style only when it is visible

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mgnav-localnav-sticky--milo--adobecom.aem.page/?martech=off

QA: https://main--dc--adobecom.hlx.page/acrobat/hub/how-to-convert-heic-to-jpg-on-a-mac?milolibs=mgnav-localnav-sticky&newNav=true