### PR TITLE
[ENB-7645] Add page-view send event, fix window.satellite empty issue

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1126,7 +1126,13 @@ async function updateManifestsAndPropositions({ config, targetManifests, targetP
     manifest.source = ['target'];
   });
   config.mep.targetManifests = targetManifests;
-  if (targetPropositions?.length && window._satellite) {
+  if (enablePersonalizationV2()) {
+    window.addEventListener('alloy_sendEvent', () => {
+      if (targetPropositions?.length && window._satellite) {
+        window._satellite.track('propositionDisplay', targetPropositions);
+      }
+    }, { once: true });
+  } else if (targetPropositions?.length && window._satellite) {
     window._satellite.track('propositionDisplay', targetPropositions);
   }
   if (config.mep.targetEnabled === 'postlcp') {


### PR DESCRIPTION
Add pageview send event, fix window.satellite empty issue
https://main--cc--adobecom.hlx.live/drafts/suhjain/swati-pages/photoshop-v2?target=on&milolibs=ENB-7645-wait-pageview-call--milo--swamu#

Resolves: [ENB-7645](https://jira.corp.adobe.com/browse/ENB-7645)

Test URLs:
Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://ENB-7645-wait-pageview-call--milo--swamu.aem.page/?martech=off