### PR TITLE
[MWPW-165790] accordion aria-expanded fix

### DIFF
--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -17,11 +17,9 @@ function toggleMedia(con, trig, status) {
     trig.setAttribute('hidden', '');
     trig.setAttribute('aria-expanded', 'false');
     con.setAttribute('hidden', '');
-    con.setAttribute('aria-expanded', 'false');
   } else {
     trig.setAttribute('aria-expanded', 'true');
     trig.removeAttribute('hidden');
-    con.setAttribute('aria-expanded', 'true');
     con.removeAttribute('hidden');
   }
 }
@@ -94,7 +92,6 @@ function createItem(accordion, id, heading, num, edit) {
   const dt = createTag('dt', dtAttrs, dtHtml);
   const dd = createTag('dd', { 'aria-labelledby': triggerId, id: panelId, hidden: true }, panel);
   const dm = createTag('div', { class: 'media-p' });
-
   if (edit) {
     const ogMedia = mediaCollection[id][num - 1];
     const mediaCopy = ogMedia.cloneNode(true);

--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -92,6 +92,7 @@ function createItem(accordion, id, heading, num, edit) {
   const dt = createTag('dt', dtAttrs, dtHtml);
   const dd = createTag('dd', { 'aria-labelledby': triggerId, id: panelId, hidden: true }, panel);
   const dm = createTag('div', { class: 'media-p' });
+
   if (edit) {
     const ogMedia = mediaCollection[id][num - 1];
     const mediaCopy = ogMedia.cloneNode(true);


### PR DESCRIPTION
This solves the issue where aria-expanded was applied to the <dd tag which it shouldn't because it is content, it should only be applied to the button causing the expansion.

Resolves: [MWPW-[165790](https://jira.corp.adobe.com/browse/MWPW-165790)]

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/nala/blocks/accordion/accordion-seo-editorial?martech=off
- After: https://accordion-aria-expanded--milo--adobecom.hlx.live/drafts/nala/blocks/accordion/accordion-seo-editorial?martech=off
