### PR TITLE
[LOC] MWPW-165856 - When video fragment is embedded in the alt text showing two page entries in the Include fragment text area

### DIFF
--- a/libs/blocks/locui-create/fragments/view.js
+++ b/libs/blocks/locui-create/fragments/view.js
@@ -35,7 +35,7 @@ export default function FragmentsSection({
 
   const locFragment = (fragment) => {
     const checked = selectedFragments.find((pathname) => pathname === fragment.pathname);
-    const parentPages = fragment?.parentPages?.filter((page) => page) ?? [];
+    const parentPages = Array.from(fragment?.parentPages ?? []).filter((page) => page);
     return html`
     <li class="locui-create-fragment">
     <div class="locui-create-fragment-input-container">

--- a/libs/blocks/locui-create/input-urls/index.js
+++ b/libs/blocks/locui-create/input-urls/index.js
@@ -75,10 +75,10 @@ export async function findFragments(urls) {
     if (fragments.length > 0) {
       fragments.forEach((fragment) => {
         if (acc[fragment.pathname]) {
-          acc[fragment.pathname].parentPages.push(urls[index]?.href);
+          acc[fragment.pathname].parentPages.add(urls[index]?.href);
           return acc;
         }
-        fragment.parentPages = [urls[index]?.href];
+        fragment.parentPages = new Set([urls[index]?.href]);
         acc[fragment.pathname] = fragment;
         return acc;
       });


### PR DESCRIPTION
* Used set to handle duplicate parent pages

Resolves:https://jira.corp.adobe.com/browse/MWPW-165856

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-165856-dulpicate-page-entry--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off

**CC Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/tools/locui-create?milolibs=milostudio-stage&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&env=local
- After: https://main--cc--adobecom.hlx.page/tools/locui-create?milolibs=MWPW-165856-dulpicate-page-entry--milo--saurabhsircar11&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&env=local
