### PR TITLE
[MWPW-165793] aside temporary double background check added

### DIFF
--- a/nala/blocks/aside/aside.page.js
+++ b/nala/blocks/aside/aside.page.js
@@ -59,6 +59,7 @@ export default class Aside {
         lightGrey1: 'rgb(238, 238, 238)',
         lightGrey2: 'rgb(245, 245, 245)',
         lightGrey3: 'rgb(249, 249, 249)',
+        lightGrey4: 'rgb(248, 248, 248)',
       },
     };
   }

--- a/nala/blocks/aside/aside.page.js
+++ b/nala/blocks/aside/aside.page.js
@@ -59,7 +59,6 @@ export default class Aside {
         lightGrey1: 'rgb(238, 238, 238)',
         lightGrey2: 'rgb(245, 245, 245)',
         lightGrey3: 'rgb(249, 249, 249)',
-        lightGrey4: 'rgb(248, 248, 248)',
       },
     };
   }

--- a/nala/blocks/aside/aside.test.js
+++ b/nala/blocks/aside/aside.test.js
@@ -34,7 +34,8 @@ test.describe('Aside Block test suite', () => {
       const bgdColor = await Aside.asideSmall.evaluate(
         (e) => window.getComputedStyle(e).getPropertyValue('background-color'),
       );
-      expect(bgdColor).toBe(Aside.props.background.lightGrey1);
+      // expect(bgdColor).toBe(Aside.props.background.lightGrey1);
+      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey4]).toContain(bgdColor);
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Small block', async () => {
@@ -69,7 +70,8 @@ test.describe('Aside Block test suite', () => {
       expect(await Aside.actionButtons.count()).toEqual(2);
       // Check Aside block background:
       const bgdColor = await Aside.asideMedium.evaluate((e) => window.getComputedStyle(e).getPropertyValue('background-color'));
-      expect(bgdColor).toBe(Aside.props.background.lightGrey1);
+      // expect(bgdColor).toBe(Aside.props.background.lightGrey1);
+      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey4]).toContain(bgdColor);
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Medium block', async () => {
@@ -103,7 +105,8 @@ test.describe('Aside Block test suite', () => {
       expect(await Aside.actionButtons.count()).toEqual(2);
       // Check Aside block background:
       const bgdColor = await Aside.asideLarge.evaluate((e) => window.getComputedStyle(e).getPropertyValue('background-color'));
-      expect(bgdColor).toBe(Aside.props.background.lightGrey1);
+      // expect(bgdColor).toBe(Aside.props.background.lightGrey1);
+      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey4]).toContain(bgdColor);
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Large block', async () => {

--- a/nala/blocks/aside/aside.test.js
+++ b/nala/blocks/aside/aside.test.js
@@ -34,8 +34,7 @@ test.describe('Aside Block test suite', () => {
       const bgdColor = await Aside.asideSmall.evaluate(
         (e) => window.getComputedStyle(e).getPropertyValue('background-color'),
       );
-      // expect(bgdColor).toBe(Aside.props.background.lightGrey1);
-      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey4]).toContain(bgdColor);
+      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey3]).toContain(bgdColor);
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Small block', async () => {
@@ -70,8 +69,7 @@ test.describe('Aside Block test suite', () => {
       expect(await Aside.actionButtons.count()).toEqual(2);
       // Check Aside block background:
       const bgdColor = await Aside.asideMedium.evaluate((e) => window.getComputedStyle(e).getPropertyValue('background-color'));
-      // expect(bgdColor).toBe(Aside.props.background.lightGrey1);
-      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey4]).toContain(bgdColor);
+      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey3]).toContain(bgdColor);
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Medium block', async () => {
@@ -105,8 +103,7 @@ test.describe('Aside Block test suite', () => {
       expect(await Aside.actionButtons.count()).toEqual(2);
       // Check Aside block background:
       const bgdColor = await Aside.asideLarge.evaluate((e) => window.getComputedStyle(e).getPropertyValue('background-color'));
-      // expect(bgdColor).toBe(Aside.props.background.lightGrey1);
-      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey4]).toContain(bgdColor);
+      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey3]).toContain(bgdColor);
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Large block', async () => {

--- a/test/blocks/aside/aside.test.js
+++ b/test/blocks/aside/aside.test.js
@@ -20,8 +20,7 @@ describe('aside', () => {
 
     it('allows a background color', async () => {
       const el = await waitForElement('#test-default');
-      expect(window.getComputedStyle(el)?.backgroundColor).to.be.oneOf(['rgb(248, 248, 248)', 'rgb(238, 238, 238)']);
-      // expect(window.getComputedStyle(el)?.backgroundColor).to.equal('rgb(238, 238, 238)');
+      expect(window.getComputedStyle(el)?.backgroundColor).to.be.oneOf(['rgb(249, 249, 249)', 'rgb(238, 238, 238)']);
     });
 
     it('allows a background image', async () => {

--- a/test/blocks/aside/aside.test.js
+++ b/test/blocks/aside/aside.test.js
@@ -20,7 +20,8 @@ describe('aside', () => {
 
     it('allows a background color', async () => {
       const el = await waitForElement('#test-default');
-      expect(window.getComputedStyle(el)?.backgroundColor).to.equal('rgb(238, 238, 238)');
+      expect(window.getComputedStyle(el)?.backgroundColor).to.be.oneOf(['rgb(248, 248, 248)', 'rgb(238, 238, 238)']);
+      // expect(window.getComputedStyle(el)?.backgroundColor).to.equal('rgb(238, 238, 238)');
     });
 
     it('allows a background image', async () => {


### PR DESCRIPTION
This adds a double check for the background color allowing us to change color via authoring after merge without bringing down tests for everyone else and fixing the accessibility color contrast issue. After merging and authoring the background color, a new PR will be made to revert back to checking only the single new background color.

Resolves: [MWPW-165793](https://jira.corp.adobe.com/browse/MWPW-165793)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.live/drafts/nala/blocks/aside/aside-small?martech=off
- After: https://aside-small-background-fix--milo--adobecom.aem.page/drafts/nala/blocks/aside/aside-small?martech=off
