### PR TITLE
MWPW-146930 - Rollout Tool Plugin - environment specific miloLibs

### DIFF
--- a/test/blocks/rollout/rollout.test.js
+++ b/test/blocks/rollout/rollout.test.js
@@ -42,7 +42,6 @@ describe('Rollout', () => {
   it('should detect language code correctly', async () => {
     const el = document.querySelector('div');
     const searchParams = createTestParams();
-    console.log(searchParams);
     const windowOpenStub = sinon.stub(window, 'open');
 
     const result = await init(el, `?${searchParams.toString()}`);

--- a/test/blocks/rollout/rollout.test.js
+++ b/test/blocks/rollout/rollout.test.js
@@ -10,11 +10,13 @@ const createTestParams = (
   referrer = 'https://main--bacom--adobecom.hlx.page/langstore/de/customer-success',
   host = 'milo.adobe.com',
   project = 'Milo',
+  overrideBranch = null,
 ) => {
   const searchParams = new URLSearchParams();
   searchParams.append('referrer', referrer);
   searchParams.append('host', host);
   searchParams.append('project', project);
+  if (overrideBranch) searchParams.append('overrideBranch', overrideBranch);
   return searchParams;
 };
 
@@ -40,10 +42,15 @@ describe('Rollout', () => {
   it('should detect language code correctly', async () => {
     const el = document.querySelector('div');
     const searchParams = createTestParams();
+    console.log(searchParams);
     const windowOpenStub = sinon.stub(window, 'open');
 
     const result = await init(el, `?${searchParams.toString()}`);
     expect(result).to.be.true;
+
+    // select the radio button stage
+    const radioButtons = el.querySelectorAll('.radio-group input[type="radio"]');
+    radioButtons[0].checked = true;
 
     // Trigger rollout button click
     const rolloutBtn = el.querySelector('.rollout-btn');
@@ -52,8 +59,9 @@ describe('Rollout', () => {
     expect(windowOpenStub.called).to.be.true;
 
     const lastUrl = new URL(windowOpenStub.firstCall.args[0]);
-    expect(lastUrl.searchParams.get('language')).to.equal('de'); // Changed to 'de' since test URL has /de/
-
+    expect(lastUrl.hostname).to.equal('main--bacom--adobecom.hlx.page');
+    expect(lastUrl.searchParams.get('language')).to.equal('de');
+    expect(lastUrl.searchParams.get('milolibs')).to.equal('milostudio-stage');
     // Restore original window.open
     windowOpenStub.restore();
   });
@@ -70,5 +78,53 @@ describe('Rollout', () => {
     const result = await init(el, `?${searchParams.toString()}`);
     expect(result).to.be.false;
     expect(el.innerHTML).to.equal('<div class="modal">Missing required parameters</div>');
+  });
+
+  it('should handle overrideBranch parameter', async () => {
+    const el = document.querySelector('div');
+    const searchParams = createTestParams('https://main--milo--adobecom.hlx.page/langstore/de/customer-success', 'milo.adobe.com', 'Milo', 'milostudio');
+    const windowOpenStub = sinon.stub(window, 'open');
+
+    const result = await init(el, `?${searchParams.toString()}`);
+    expect(result).to.be.true;
+
+    // Trigger rollout button click
+    const rolloutBtn = el.querySelector('.rollout-btn');
+    rolloutBtn.click();
+
+    expect(windowOpenStub.called).to.be.true;
+
+    const lastUrl = new URL(windowOpenStub.firstCall.args[0]);
+    expect(lastUrl.hostname).to.equal('milostudio--milo--adobecom.hlx.page');
+    expect(lastUrl.searchParams.get('milolibs')).to.equal('milostudio');
+
+    // Restore original window.open
+    windowOpenStub.restore();
+  });
+
+  it('should handle overrideBranch parameter for stage', async () => {
+    const el = document.querySelector('div');
+    const searchParams = createTestParams('https://main--milo--adobecom.hlx.page/langstore/de/customer-success', 'milo.adobe.com', 'Milo', 'milostudio');
+    const windowOpenStub = sinon.stub(window, 'open');
+
+    const result = await init(el, `?${searchParams.toString()}`);
+    expect(result).to.be.true;
+
+    // select the radio button stage
+    const radioButtons = el.querySelectorAll('.radio-group input[type="radio"]');
+    radioButtons[0].checked = true;
+
+    // Trigger rollout button click
+    const rolloutBtn = el.querySelector('.rollout-btn');
+    rolloutBtn.click();
+
+    expect(windowOpenStub.called).to.be.true;
+
+    const lastUrl = new URL(windowOpenStub.firstCall.args[0]);
+    expect(lastUrl.hostname).to.equal('milostudio-stage--milo--adobecom.hlx.page');
+    expect(lastUrl.searchParams.get('milolibs')).to.equal('milostudio-stage');
+
+    // Restore original window.open
+    windowOpenStub.restore();
   });
 });

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -178,7 +178,7 @@
       "isPalette": true,
       "passReferrer": true,
       "passConfig": true,
-      "url": "/tools/rollout",
+      "url": "/tools/rollout?overrideBranch=milostudio",
       "includePaths": [ "**.docx**", "**.xlsx**" ],
       "paletteRect": "top: 40%; left: 50%; transform: translate(-50%,-50%); height: 350px; width: 500px; overflow: hidden; border-radius: 15px; box-shadow: 0 20px 35px 0px rgba(0, 0, 0, 0.5);"
     }


### PR DESCRIPTION
This is a followup of https://github.com/adobecom/milo/pull/3463.
Updating `miloLibs` based on environment selected. Special case for Milo where the branch needs to be overridden.

Resolves: https://jira.corp.adobe.com/browse/MWPW-146930

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://rollout-tool-update--milo--sabyamon.hlx.page/?martech=off

This feature can be tested in Milo and in BACOM by selecting the Test project configuration locally and providing the URL ```https://rollout-tool-update--milo--sabyamon.hlx.page```