### PR TITLE
[LOC] MWPW-166032: fix for project name on locale selection screen

### DIFF
--- a/libs/blocks/locui-create/input-locale/view.js
+++ b/libs/blocks/locui-create/input-locale/view.js
@@ -129,7 +129,7 @@ export default function InputLocales() {
     <div class="locui-form-body">
         <div>
           <h2 class="locui-project-type">${project.value.type === PROJECT_TYPES.translation ? 'Translate' : 'Rollout'}</h2>
-          <p class="locui-project-name"><strong>Project Name:</strong> ${project.value.name || 'n/a'}</p>
+          <p class="locui-project-name">Project Name: <strong>${project.value.name || 'n/a'}</strong></p>
         </div>
         <${RenderRegion} />
         <div class="language-locale-container">


### PR DESCRIPTION
* Added strong tag in locale selection

Resolves:https://jira.corp.adobe.com/browse/MWPW-166032

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-166032-project-name-bold--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off
