### PR TITLE
MWPW-166002 | [MEP] Use Target served version of manifest in prod when Target experience is chosen

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -988,9 +988,12 @@ export function cleanAndSortManifestList(manifests, conf) {
         freshManifest.name = fullManifest.name;
         freshManifest.selectedVariantName = fullManifest.selectedVariantName;
         targetManifestWinsOverServerManifest = config?.env?.name === 'prod' && fullManifest.selectedVariantName.startsWith('target-');
-        freshManifest.selectedVariant = targetManifestWinsOverServerManifest
-          ? fullManifest.variants[fullManifest.selectedVariantName]
-          : freshManifest.variants[freshManifest.selectedVariantName];
+
+        freshManifest.variants = targetManifestWinsOverServerManifest
+          ? fullManifest.variants
+          : freshManifest.variants;
+
+        freshManifest.selectedVariant = freshManifest.variants[freshManifest.selectedVariantName];
         manifestObj[manifest.manifestPath] = freshManifest;
       } else {
         manifestObj[manifest.manifestPath] = manifest;
@@ -999,15 +1002,12 @@ export function cleanAndSortManifestList(manifests, conf) {
       const manifestConfig = manifestObj[manifest.manifestPath];
       const { selectedVariantName, variantNames, placeholderData } = manifestConfig;
 
-      if (!targetManifestWinsOverServerManifest) {
-        if (selectedVariantName && variantNames.includes(selectedVariantName)) {
-          manifestConfig.run = true;
-          manifestConfig.selectedVariant = manifestConfig.variants[selectedVariantName];
-        } else {
-          /* c8 ignore next 2 */
-          manifestConfig.selectedVariantName = 'default';
-          manifestConfig.selectedVariant = 'default';
-        }
+      if (selectedVariantName && variantNames.includes(selectedVariantName)) {
+        manifestConfig.selectedVariant = manifestConfig.variants[selectedVariantName];
+      } else {
+        /* c8 ignore next 2 */
+        manifestConfig.selectedVariantName = 'default';
+        manifestConfig.selectedVariant = 'default';
       }
 
       parsePlaceholders(placeholderData, getConfig(), manifestConfig.selectedVariantName);

--- a/test/features/personalization/mocks/manifestLists/two-manifests-one-from-target.json
+++ b/test/features/personalization/mocks/manifestLists/two-manifests-one-from-target.json
@@ -12,20 +12,33 @@
                   }
               ],
               "fragments": []
+          },
+          "target-test": {
+              "commands": [
+                  {
+                      "action": "target-manifest-action",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test1",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
           }
       },
       "variantNames": [
-          "all"
+          "all",
+          "target-test"
       ],
       "manifestOverrideName": "",
       "manifestType": "test",
       "executionOrder": "1-2",
       "run": true,
-      "selectedVariantName": "all",
+      "selectedVariantName": "target-test",
       "selectedVariant": {
           "commands": [
               {
-                  "action": "appendtosection",
+                  "action": "target-manifest-action",
                   "selector": "section1",
                   "pageFilter": "",
                   "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
@@ -34,6 +47,7 @@
           ],
           "fragments": []
       },
+      "source": ["target"],
       "name": "MILO0013 - manifest order",
       "manifest": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json",
       "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/test-normal.json",
@@ -52,10 +66,23 @@
                   }
               ],
               "fragments": []
+          },
+          "target-test": {
+              "commands": [
+                  {
+                      "action": "server-manifest-action",
+                      "selector": "section1",
+                      "pageFilter": "",
+                      "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test1",
+                      "selectorType": "css"
+                  }
+              ],
+              "fragments": []
           }
       },
       "variantNames": [
-          "all"
+          "all",
+          "target-test"
       ],
       "manifestOverrideName": "",
       "manifestType": "personalization",
@@ -65,7 +92,7 @@
       "selectedVariant": {
           "commands": [
               {
-                  "action": "appendtosection",
+                  "action": "server-manifest-action",
                   "selector": "section1",
                   "pageFilter": "",
                   "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",
@@ -74,6 +101,7 @@
           ],
           "fragments": []
       },
+      "source": ["pzn"],
       "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
       "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
       "manifestPath": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json"

--- a/test/features/personalization/mocks/manifestLists/two-manifests-one-from-target.json
+++ b/test/features/personalization/mocks/manifestLists/two-manifests-one-from-target.json
@@ -16,7 +16,7 @@
           "target-test": {
               "commands": [
                   {
-                      "action": "target-manifest-action",
+                      "action": "append",
                       "selector": "section1",
                       "pageFilter": "",
                       "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test1",
@@ -38,7 +38,7 @@
       "selectedVariant": {
           "commands": [
               {
-                  "action": "target-manifest-action",
+                  "action": "append",
                   "selector": "section1",
                   "pageFilter": "",
                   "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test",
@@ -70,7 +70,7 @@
           "target-test": {
               "commands": [
                   {
-                      "action": "server-manifest-action",
+                      "action": "appendtosection",
                       "selector": "section1",
                       "pageFilter": "",
                       "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/test1",
@@ -92,7 +92,7 @@
       "selectedVariant": {
           "commands": [
               {
-                  "action": "server-manifest-action",
+                  "action": "appendtosection",
                   "selector": "section1",
                   "pageFilter": "",
                   "target": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/fragments/pzn",

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -406,7 +406,7 @@ describe('MEP Utils', () => {
       const response = cleanAndSortManifestList(manifests, config);
       const result = response.find((manifest) => manifest.source.length > 1);
       expect(result).to.be.not.null;
-      expect(result.selectedVariant.commands[0].action).to.equal('server-manifest-action');
+      expect(result.selectedVariant.commands[0].action).to.equal('appendtosection');
     });
     it('chooses target manifest over server manifest if same manifest path and in production and selected audience is "target-*"', async () => {
       const config = { env: { name: 'prod' } };
@@ -417,7 +417,7 @@ describe('MEP Utils', () => {
       const response = cleanAndSortManifestList(manifests, config);
       const result = response.find((manifest) => manifest.source.length > 1);
       expect(result).to.be.not.null;
-      expect(result.selectedVariant.commands[0].action).to.equal('target-manifest-action');
+      expect(result.selectedVariant.commands[0].action).to.equal('append');
     });
   });
 });

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -3,7 +3,7 @@ import { readFile } from '@web/test-runner-commands';
 import { assert, stub } from 'sinon';
 import { getConfig, setConfig } from '../../../libs/utils/utils.js';
 import {
-  handleFragmentCommand, applyPers,
+  handleFragmentCommand, applyPers, cleanAndSortManifestList,
   init, matchGlob, createContent, combineMepSources, buildVariantInfo,
 } from '../../../libs/features/personalization/personalization.js';
 import mepSettings from './mepSettings.js';
@@ -394,6 +394,30 @@ describe('MEP Utils', () => {
       expect(manifests[2].manifestPath).to.equal('/black-friday.json');
       expect(manifests[3].manifestPath).to.equal('/mep-param/manifest1.json');
       expect(manifests[4].manifestPath).to.equal('/mep-param/manifest2.json');
+    });
+  });
+  describe('cleanAndSortManifestList', async () => {
+    it('chooses server manifest over target manifest if same manifest path', async () => {
+      const config = { env: { name: 'stage' } };
+      let manifests = await readFile({ path: './mocks/manifestLists/two-manifests-one-from-target.json' });
+      manifests = JSON.parse(manifests);
+      manifests[0].manifestPath = 'same path';
+      manifests[1].manifestPath = 'same path';
+      const response = cleanAndSortManifestList(manifests, config);
+      const result = response.find((manifest) => manifest.source.length > 1);
+      expect(result).to.be.not.null;
+      expect(result.selectedVariant.commands[0].action).to.equal('server-manifest-action');
+    });
+    it('chooses target manifest over server manifest if same manifest path and in production and selected audience is "target-*"', async () => {
+      const config = { env: { name: 'prod' } };
+      let manifests = await readFile({ path: './mocks/manifestLists/two-manifests-one-from-target.json' });
+      manifests = JSON.parse(manifests);
+      manifests[0].manifestPath = 'same path';
+      manifests[1].manifestPath = 'same path';
+      const response = cleanAndSortManifestList(manifests, config);
+      const result = response.find((manifest) => manifest.source.length > 1);
+      expect(result).to.be.not.null;
+      expect(result.selectedVariant.commands[0].action).to.equal('target-manifest-action');
     });
   });
 });


### PR DESCRIPTION

* For the prod env when Target experience is chosen, the manifest served by Target will be used.

Resolves: [MWPW-166002](https://jira.corp.adobe.com/browse/MWPW-166002)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- Psi-check: https://manifest-server-vs-target--milo--adobecom.aem.page/?martech=off

QA Links:

For all After links the expected text header has been provided.

- Before: 
https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/manifest-server-vs-target/page?audience=edu&env=prod

https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/manifest-server-vs-target/page?audience=edu

https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/manifest-server-vs-target/page?env=prod

https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/manifest-server-vs-target/page

- After: 
https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/manifest-server-vs-target/page?audience=edu&env=prod&milolibs=manifest-server-vs-target - Title Saved in Target

https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/manifest-server-vs-target/page?audience=edu&milolibs=manifest-server-vs-target - Preview Target Title

https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/manifest-server-vs-target/page?env=prod&milolibs=manifest-server-vs-target - Updated GWP Title

https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/manifest-server-vs-target/page?milolibs=manifest-server-vs-target - Updated GWP Title