### PR TITLE
[MWPW-166027] - Add empty space if the logo is undefined

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -457,7 +457,8 @@ export const transformTemplateToMobile = async (popup, item, localnav = false) =
         {{main-menu}}
       </button>
   `;
-  const brand = document.querySelector('.feds-brand')?.outerHTML;
+  // Get the outerHTML of the .feds-brand element or use a default empty <span> if it doesn't exist
+  const brand = document.querySelector('.feds-brand')?.outerHTML || '<span></span>';
   const breadCrumbs = document.querySelector('.feds-breadcrumbs')?.outerHTML;
   popup.innerHTML = `
     <div class="top-bar">


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

In some cases the logo is coming as undefined for the new mobile GNAV.
We have added a empty space instead of 'undefined' text showing in the new Mobile GNAV.
Error Screenshot:
<img src="https://github.com/user-attachments/assets/45048fff-7434-4b88-8fed-7c498494acf7" alt="IMG_3226-1" width="300" height="650">

Resolves: [MWPW-166027](https://jira.corp.adobe.com/browse/MWPW-166027)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-166027--milo--deva309.aem.page/?martech=off
