### PR TITLE
[MWPW-166151] Mobile gnav links transformations

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -668,7 +668,7 @@ export function convertStageLinks({ anchors, config, hostname, href }) {
   if (!matchedRules) return;
   const [, domainsMap] = matchedRules;
   [...anchors].forEach((a) => {
-    const hasLocalePrefix = a.pathname.startsWith(locale.prefix);
+    const hasLocalePrefix = a.pathname.startsWith(`${locale.prefix}/`);
     const noLocaleLink = hasLocalePrefix ? a.href.replace(locale.prefix, '') : a.href;
     const matchedDomain = Object.keys(domainsMap)
       .find((domain) => (new RegExp(domain)).test(noLocaleLink));


### PR DESCRIPTION
## Description
This PR fixes a bug where part of the non-localized URL pathname matches the current locale, leading to unwanted link transformations.

## Related Issue
Resolves: [MWPW-166151](https://jira.corp.adobe.com/browse/MWPW-166151)

## Testing instructions
1.Launch the after URL
2.Log in with the stage account shared in the Jira ticket description.
3.Make sure gnav is visible.
4.Change the locale from english to **Suomi**.
5.Click on files tab (_"Tiedostot"_) in side nav.
6.Should not lead to a 404 page.

## Screenshots:

**Before:** 

![Screenshot 2025-01-23 at 10 24 52](https://github.com/user-attachments/assets/c99b91b1-f16f-46fe-b4da-f8b178dc4e66)


**After:**

![Screenshot 2025-01-23 at 10 23 24](https://github.com/user-attachments/assets/0493eb84-0bb3-42c2-aea4-41813a508ee5)



## Test URLs
- Before: https://adobecom.github.io/nav-consumer/navigation.html?authoringpath=/federal/home&locale=fi&customlinks=files,apps&navbranch=stage
- After: https://adobecom.github.io/nav-consumer/navigation.html?authoringpath=/federal/home&locale=fi&customlinks=files,apps&navbranch=mwpw-166151-stage-links-conversion

PSI check URL: https://mwpw-166151-stage-links-conversion--milo--adobecom.hlx.page/drafts/rbogos/page-default?martech=off
