### PR TITLE
MWPW-165573 - limit for project name

### DIFF
--- a/libs/blocks/locui-create/input-urls/view.js
+++ b/libs/blocks/locui-create/input-urls/view.js
@@ -233,6 +233,7 @@ export default function InputUrls() {
                 disabled=${projectCreated.value}
                 onInput=${handleNameChange}
                 placeholder="Enter letters, alphabet and hyphens only"
+                maxlength="50"
               />
               ${errors.name
               && html`<div class="form-field-error">${errors.name}</div>`}

--- a/libs/blocks/locui-create/locui-create.css
+++ b/libs/blocks/locui-create/locui-create.css
@@ -382,6 +382,7 @@ body {
   align-items: center;
   justify-content: center;
   gap: 10px;
+  word-break: break-all;
 }
 
 .modal-header strong {


### PR DESCRIPTION
* Added max length to restrict more than 50 chars

Resolves:https://jira.corp.adobe.com/browse/MWPW-165573

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-165573-project-name-limit--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off

**Bacom Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/tools/locui-create?milolibs=milostudio-stage&ref=main&repo=bacom&owner=adobecom&host=business.adobe.com&project=BACOM&env=stage
- After: https://main--bacom--adobecom.hlx.page/tools/locui-create?milolibs=MWPW-165573-project-name-limit--milo--saurabhsircar11&ref=main&repo=bacom&owner=adobecom&host=business.adobe.com&project=BACOM&env=stage