### PR TITLE
MWPW-166465 Checking language details after lowercasing

### DIFF
--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -114,7 +114,8 @@ export function setSelectedLocalesAndRegions() {
 
 export function getLanguageDetails(lang) {
   const langDetails = stLocales.value?.find(
-    ({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase()) ?? {};
+    ({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase()
+  ) ?? {};
   return [
     {
       action: 'Rollout',

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -113,8 +113,7 @@ export function setSelectedLocalesAndRegions() {
 }
 
 export function getLanguageDetails(lang) {
-  const langDetails =
-    stLocales.value?.find(
+  const langDetails = stLocales.value?.find(
       ({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase()
     ) ?? {};
   return [

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -114,8 +114,7 @@ export function setSelectedLocalesAndRegions() {
 
 export function getLanguageDetails(lang) {
   const langDetails = stLocales.value?.find(
-      ({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase()
-    ) ?? {};
+    ({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase()) ?? {};
   return [
     {
       action: 'Rollout',

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -1,7 +1,12 @@
 import getServiceConfig from '../../../utils/service-config.js';
 import { origin } from '../../locui/utils/franklin.js';
 import { getInitialName } from '../input-urls/index.js';
-import { env, locSelected, locales as stLocales, project as stProject } from '../store.js';
+import {
+  env,
+  locSelected,
+  locales as stLocales,
+  project as stProject,
+} from '../store.js';
 
 export function getTenantName() {
   try {
@@ -28,7 +33,8 @@ export function processLocaleData(localeData) {
         .split(',')
         .map((loc) => loc.trim())
         .join(','),
-    })).sort((a, b) => a.language.localeCompare(b.language));
+    }))
+    .sort((a, b) => a.language.localeCompare(b.language));
 
   const processedLocaleRegion = localeData.localegroups.data.map((item) => ({
     ...item,
@@ -107,14 +113,19 @@ export function setSelectedLocalesAndRegions() {
 }
 
 export function getLanguageDetails(lang) {
-  const langDetails = stLocales.value?.find(({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase()) ?? {};
-  return [{
-    action: 'Rollout',
-    langCode: langDetails.languagecode,
-    language: langDetails.language,
-    locales: langDetails.livecopies.split(','),
-    workflow: '',
-  }];
+  const langDetails =
+    stLocales.value?.find(
+      ({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase()
+    ) ?? {};
+  return [
+    {
+      action: 'Rollout',
+      langCode: langDetails.languagecode,
+      language: langDetails.language,
+      locales: langDetails.livecopies.split(','),
+      workflow: '',
+    },
+  ];
 }
 
 export function getProjectByParams(searchParams) {

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -107,7 +107,7 @@ export function setSelectedLocalesAndRegions() {
 }
 
 export function getLanguageDetails(lang) {
-  const langDetails = stLocales.value?.find(({ languagecode }) => languagecode === lang) ?? {};
+  const langDetails = stLocales.value?.find(({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase()) ?? {};
   return [{
     action: 'Rollout',
     langCode: langDetails.languagecode,

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -114,7 +114,7 @@ export function setSelectedLocalesAndRegions() {
 
 export function getLanguageDetails(lang) {
   const langDetails = stLocales.value?.find(
-    ({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase()
+    ({ languagecode }) => languagecode.toLowerCase() === lang.toLowerCase(),
   ) ?? {};
   return [
     {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Now we are checking language details for provided "language" query (in single rollout) by lowercasing it first. This is required for languages with pattern xy-AB (say "fr-CA"), which gets converted to lowercase as part of Preview URL by franklin 

Resolves: [MWPW-166465](https://jira.corp.adobe.com/browse/MWPW-166465)

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-166465-language-check--milo--nkthakur48.hlx.page/drafts/sircar/locui-create?martech=off
