### PR TITLE
[MWPW-166427] Increase limit for publishing configuration object

### DIFF
--- a/libs/tools/utils/publish.js
+++ b/libs/tools/utils/publish.js
@@ -5,7 +5,7 @@ const userCanPublishPage = async (detail, isBulk = true) => {
   const { live, profile, webPath } = detail;
   let canPublish = isBulk ? live?.permissions?.includes('write') : true;
   let message = 'Publishing is currently disabled for this page';
-  const config = await getCustomConfig('/.milo/publish-permissions-config.json');
+  const config = await getCustomConfig('/.milo/publish-permissions-config.json?limit=50000');
   const item = config?.urls?.data?.find(({ url }) => (
     url.endsWith('**') ? webPath.includes(url.slice(0, -2)) : url === webPath
   ));

--- a/test/blocks/bulk-publish-v2/mocks/fetch.js
+++ b/test/blocks/bulk-publish-v2/mocks/fetch.js
@@ -12,7 +12,7 @@ const requests = {
   delstatus: 'https://admin.hlx.page/job/adobecom/milo/main/preview-remove/job-2024-01-24t23-16-20-377z/details',
   retry: 'https://admin.hlx.page/preview/adobecom/milo/main/tools/bulk-publish-v2-test',
   index: 'https://admin.hlx.page/index/adobecom/milo/main/tools/bulk-publish-v2-test',
-  permissions: '/.milo/publish-permissions-config.json',
+  permissions: '/.milo/publish-permissions-config.json?limit=50000',
   sharestatus: 'https://admin.hlx.page/job/adobecom/milo/main/preview/testshare/details',
 };
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Fixes a blocking issue where the publishing restrictions were not enforced because the configuration object was not properly read. This is a critical issue because publishing restrictions need to be enforced now.

Resolves: [MWPW-166427](https://jira.corp.adobe.com/browse/MWPW-166427)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/narcis/default?martech=off
- After: https://permissions-config--milo--narcis-radu.hlx.page/drafts/narcis/default?martech=off

URL to test functionality change: https://main--cc--adobecom.hlx.page/hu/products/photoshop?milolibs=permissions-config--milo--narcis-radu
