### PR TITLE
[MWPW-156760] Table caret position

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -292,7 +292,7 @@
 .table .section-head .section-head-title > :not(.icon) {
   font-size: var(--type-body-m-size);
   line-height: var(--type-heading-s-lh);
-  width: calc(100% - 20px);
+  width: calc(100% - 30px);
 }
 
 .table .section-head .section-head-title,
@@ -354,12 +354,17 @@
 .table .icon.expand {
   background-color: transparent;
   border: 0;
-  background-image: url('../../ui/img/expand2.svg');
+  background-image: url('../../ui/img/chevron-wide-black.svg');
   background-repeat: no-repeat;
   background-position: center right;
-  width: 15px;
-  height: 15px;
+  width: 17px;
+  height: 17px;
   cursor: pointer;
+  rotate: -90deg;
+}
+
+[dir="rtl"] .table .icon.expand {
+  rotate: 90deg;
 }
 
 .table .section-head-title:hover .icon.expand {
@@ -367,7 +372,7 @@
 }
 
 .table .icon.expand[aria-expanded=true] {
-  background-image: url('../../ui/img/collapse2.svg');
+  rotate: unset;
 }
 
 .table .row-highlight .col-highlight.transparent-border {

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -358,7 +358,7 @@
   background-repeat: no-repeat;
   background-position: center;
   width: 12px;
-  height: 17px;
+  aspect-ratio: 1.7;
   cursor: pointer;
   rotate: -90deg;
   background-size: contain;

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -292,7 +292,7 @@
 .table .section-head .section-head-title > :not(.icon) {
   font-size: var(--type-body-m-size);
   line-height: var(--type-heading-s-lh);
-  width: calc(100% - 30px);
+  width: calc(100% - 25px);
 }
 
 .table .section-head .section-head-title,
@@ -356,11 +356,12 @@
   border: 0;
   background-image: url('../../ui/img/chevron-wide-black.svg');
   background-repeat: no-repeat;
-  background-position: center right;
-  width: 17px;
+  background-position: center;
+  width: 12px;
   height: 17px;
   cursor: pointer;
   rotate: -90deg;
+  background-size: contain;
 }
 
 [dir="rtl"] .table .icon.expand {

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -256,7 +256,9 @@ function handleSection(sectionParams) {
 
     if (isCollapseTable) {
       const iconTag = createTag('span', { class: 'icon expand' });
-      sectionHeadTitle.prepend(iconTag);
+      if (!sectionHeadTitle.querySelector('.icon.expand')) {
+        sectionHeadTitle.prepend(iconTag);
+      }
 
       if (expandSection) {
         iconTag.setAttribute('aria-expanded', 'true');

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -256,7 +256,7 @@ function handleSection(sectionParams) {
 
     if (isCollapseTable) {
       const iconTag = createTag('span', { class: 'icon expand' });
-      sectionHeadTitle.appendChild(iconTag);
+      sectionHeadTitle.prepend(iconTag);
 
       if (expandSection) {
         iconTag.setAttribute('aria-expanded', 'true');


### PR DESCRIPTION
This changes the caret for table from "Title +/-" to ">/⌄ Title"

Resolves: [MWPW-156760](https://jira.corp.adobe.com/browse/MWPW-156760)

| Before       | After        |
|--------------|--------------|
|<img width="230" alt="Screenshot 2025-01-28 at 16 29 46" src="https://github.com/user-attachments/assets/d635dac6-842f-42c8-870b-b46f0d79ad80" />|<img width="226" alt="Screenshot 2025-01-28 at 16 29 39" src="https://github.com/user-attachments/assets/cc5b057d-6363-4131-8a7f-27464e789040" />|

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
- After: https://table-caret-position--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
