### PR TITLE
MWPW-165428 Fix georouting tab scroll

### DIFF
--- a/libs/blocks/tabs/tabs.css
+++ b/libs/blocks/tabs/tabs.css
@@ -554,4 +554,9 @@
   .tabs.stacked-mobile.quiet div[role="tablist"] button {
     margin-inline-start: 0;
   }
+
+  .tabs[class*='stacked-mobile'] .paddle {
+    background: unset;
+    border: none;
+  }
 }

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -67,7 +67,8 @@ function changeTabs(e) {
   const parent = target.parentNode;
   const content = parent.parentNode.parentNode.lastElementChild;
   const targetContent = content.querySelector(`#${target.getAttribute('aria-controls')}`);
-  const blockId = target.closest('.tabs').id;
+  const tabsBlock = target.closest('.tabs');
+  const blockId = tabsBlock.id;
   parent
     .querySelectorAll(`[aria-selected="true"][data-block-id="${blockId}"]`)
     .forEach((t) => t.setAttribute('aria-selected', false));
@@ -77,7 +78,7 @@ function changeTabs(e) {
     .querySelectorAll(`[role="tabpanel"][data-block-id="${blockId}"]`)
     .forEach((p) => p.setAttribute('hidden', true));
   targetContent.removeAttribute('hidden');
-  scrollStackedMobile(targetContent);
+  if (tabsBlock.classList.contains('stacked-mobile')) scrollStackedMobile(targetContent);
 }
 
 function getStringKeyName(str) {


### PR DESCRIPTION
* Fix bug where clicking on a tab in the georouting modal scrolls the page underneath on mobile
* Fix bug where paddles add line to stacked mobile tabs

Resolves: [MWPW-165428](https://jira.corp.adobe.com/browse/MWPW-165428)

**Test URLs:**
- Before: https://main--cc--adobecom.hlx.live/creativecloud?georouting=on&akamaiLocale=in
- After: https://main--cc--adobecom.hlx.live/creativecloud?georouting=on&akamaiLocale=in&milolibs=georouting-scroll--milo--meganthecoder&martech=off
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/tabs-stacked-mobile
- After: https://georouting-scroll--milo--meganthecoder.aem.page/drafts/methomas/tabs-stacked-mobile?martech=off