### PR TITLE
MWPW-166684 Rollout plugin support for hlx5 

### DIFF
--- a/libs/blocks/rollout/rollout.js
+++ b/libs/blocks/rollout/rollout.js
@@ -61,6 +61,7 @@ const setUrlData = (url, allowEmptyPaths = false) => {
       urlOwner: urlParts[2].slice(0, pageIndex),
       urlPathRemainder: urlParts[2].slice(pageIndex + pageType.length),
       currentPageLang: getLanguageCode(url),
+      hostSuffix: pageType,
     });
 
     return urlData;
@@ -120,7 +121,7 @@ const buildUi = async (el, previewUrl, overrideBranch) => {
 
       const locV3ConfigUrl = new URL(
         'tools/locui-create',
-        `https://${branch}--${urlData.urlRepo}--${urlData.urlOwner}.hlx.page`,
+        `https://${branch}--${urlData.urlRepo}--${urlData.urlOwner}${urlData.hostSuffix}`,
       );
 
       const params = {
@@ -185,7 +186,7 @@ export default async function init(el, search = window.location.search) {
     const referrer = params?.get('referrer')?.trim();
     const host = params?.get('host')?.trim();
     const project = params?.get('project')?.trim();
-    if (!referrer || !host || !project) {
+    if (!referrer) {
       el.innerHTML = '<div class="modal">Missing required parameters</div>';
       return false;
     }

--- a/libs/blocks/rollout/rollout.js
+++ b/libs/blocks/rollout/rollout.js
@@ -186,7 +186,7 @@ export default async function init(el, search = window.location.search) {
     const referrer = params?.get('referrer')?.trim();
     const host = params?.get('host')?.trim();
     const project = params?.get('project')?.trim();
-    if (!referrer) {
+    if (!referrer || !project) {
       el.innerHTML = '<div class="modal">Missing required parameters</div>';
       return false;
     }

--- a/libs/blocks/rollout/rollout.js
+++ b/libs/blocks/rollout/rollout.js
@@ -48,9 +48,9 @@ const setUrlData = (url, allowEmptyPaths = false) => {
     const hlxPageIndex = urlParts[2].indexOf('.hlx.page');
     const aemPageIndex = urlParts[2].indexOf('.aem.page');
     const pageIndex = hlxPageIndex >= 0 ? hlxPageIndex : aemPageIndex;
-    const pageType = hlxPageIndex >= 0 ? '.hlx.page' : '.aem.page';
+    const sld = hlxPageIndex >= 0 ? '.hlx.page' : '.aem.page';
 
-    const pathLengthCheck = allowEmptyPaths ? pageType.length - 1 : pageType.length;
+    const pathLengthCheck = allowEmptyPaths ? sld.length - 1 : sld.length;
     if (pageIndex < 0 || pageIndex + pathLengthCheck >= urlParts[2].length) {
       return null;
     }
@@ -59,9 +59,9 @@ const setUrlData = (url, allowEmptyPaths = false) => {
       urlBranch: urlParts[0].slice(8), // remove "https://"
       urlRepo: urlParts[1],
       urlOwner: urlParts[2].slice(0, pageIndex),
-      urlPathRemainder: urlParts[2].slice(pageIndex + pageType.length),
+      urlPathRemainder: urlParts[2].slice(pageIndex + sld.length),
       currentPageLang: getLanguageCode(url),
-      hostSuffix: pageType,
+      sld,
     });
 
     return urlData;
@@ -121,7 +121,7 @@ const buildUi = async (el, previewUrl, overrideBranch) => {
 
       const locV3ConfigUrl = new URL(
         'tools/locui-create',
-        `https://${branch}--${urlData.urlRepo}--${urlData.urlOwner}${urlData.hostSuffix}`,
+        `https://${branch}--${urlData.urlRepo}--${urlData.urlOwner}${urlData.sld}`,
       );
 
       const params = {

--- a/test/blocks/rollout/rollout.test.js
+++ b/test/blocks/rollout/rollout.test.js
@@ -126,4 +126,30 @@ describe('Rollout', () => {
     // Restore original window.open
     windowOpenStub.restore();
   });
+
+  it('should handle aem.page', async () => {
+    const el = document.querySelector('div');
+    const searchParams = createTestParams('https://main--federal--adobecom.aem.page/langstore/en/drafts/test-one-page');
+    const windowOpenStub = sinon.stub(window, 'open');
+
+    const result = await init(el, `?${searchParams.toString()}`);
+    expect(result).to.be.true;
+
+    // select the radio button stage
+    const radioButtons = el.querySelectorAll('.radio-group input[type="radio"]');
+    radioButtons[0].checked = true;
+
+    // Trigger rollout button click
+    const rolloutBtn = el.querySelector('.rollout-btn');
+    rolloutBtn.click();
+
+    expect(windowOpenStub.called).to.be.true;
+
+    const lastUrl = new URL(windowOpenStub.firstCall.args[0]);
+    expect(lastUrl.hostname).to.equal('main--federal--adobecom.aem.page');
+    expect(lastUrl.searchParams.get('milolibs')).to.equal('milostudio-stage');
+
+    // Restore original window.open
+    windowOpenStub.restore();
+  });
 });


### PR DESCRIPTION
Changes for Rollout Plugin

1. Extract the domain suffix of aem.page or hlx.page from referrer url
2. Pass over same to Loc V3
3. Mandatory checks for optional parameters like host removed (Federal does not have host)

Resolves: [MWPW-166684](https://jira.corp.adobe.com/browse/MWPW-166684)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://rolloutplugin2--milo--raga-adbe-gh.hlx.page/?martech=off
