### PR TITLE
[LOC] MWPW-166758: Support for hlx and aem urls for fragments and url validations

### DIFF
--- a/libs/blocks/locui-create/input-urls/index.js
+++ b/libs/blocks/locui-create/input-urls/index.js
@@ -1,8 +1,8 @@
 import { findDeepFragments } from '../../locui/actions/index.js';
 import { urls as locuiUrls } from '../../locui/utils/state.js';
 import { validateUrlsFormat } from '../../locui/loc/index.js';
-import { origin } from '../../locui/utils/franklin.js';
 import { PROJECT_TYPES } from '../utils/constant.js';
+import { validateOrigin } from '../utils/utils.js';
 
 export function validateProjectName(name) {
   if (name && !/^[a-zA-Z0-9-]+$/.test(name)) {
@@ -20,7 +20,7 @@ export function validateUrls(urlsStr) {
       if (!(/^(https):\/\/[^\s/$.?#].[^\s]*$/g.test(urls[0]))) {
         return errorMessage;
       }
-      if (url.origin !== origin) {
+      if (validateOrigin(url)) {
         return errorMessage;
       }
     } catch {

--- a/libs/blocks/locui-create/input-urls/index.js
+++ b/libs/blocks/locui-create/input-urls/index.js
@@ -16,11 +16,10 @@ export function validateUrls(urlsStr) {
   const errorMessage = 'Invalid URL Pattern. Please enter valid URL';
   while (urls.length > 0) {
     try {
-      const url = new URL(urls[0]);
       if (!(/^(https):\/\/[^\s/$.?#].[^\s]*$/g.test(urls[0]))) {
         return errorMessage;
       }
-      if (validateOrigin(url)) {
+      if (!validateOrigin(urls[0])) {
         return errorMessage;
       }
     } catch {

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -147,3 +147,21 @@ export function getProjectByParams(searchParams) {
 
   return Object.keys(projectInfo).length > 0 ? projectInfo : null;
 }
+
+export function validateOrigin(urlStr) {
+  try {
+    const url = new URL(urlStr);
+    const urlDomains = url.host?.split('.');
+    const originDomains = origin.host?.split('.');
+    if (urlDomains.length === originDomains.length) {
+      const [urlSD, urlSDL, urlTDL] = urlDomains;
+      const [originSD, originSDL, originTDL] = originDomains;
+      if (urlSD === originSD && urlTDL === originTDL && (urlSDL === originSDL || urlSDL === 'aem' || urlSDL === 'hlx')) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -1,4 +1,5 @@
 import getServiceConfig from '../../../utils/service-config.js';
+import { SLD } from '../../../utils/utils.js';
 import { origin } from '../../locui/utils/franklin.js';
 import { getInitialName } from '../input-urls/index.js';
 import {
@@ -154,10 +155,13 @@ export function validateOrigin(urlStr) {
     const urlDomains = url.host?.split('.');
     const originUrl = new URL(origin);
     const originDomains = originUrl.host?.split('.');
-    if (urlDomains && originDomains && urlDomains.length === originDomains.length) {
-      const [urlSD, urlSDL, urlTDL] = urlDomains;
-      const [originSD, originSDL, originTDL] = originDomains;
-      if (urlSD === originSD && urlTDL === originTDL && (urlSDL === originSDL || urlSDL === 'aem' || urlSDL === 'hlx')) {
+    if (SLD === 'hlx') {
+      return urlStr === origin;
+    }
+    if (SLD === 'aem' && urlDomains?.length === originDomains.length) {
+      const [urlSD, urlSLD] = urlDomains;
+      const [originSD] = originDomains;
+      if (urlSD === originSD && (urlSLD === 'aem' || urlSLD === 'hlx')) {
         return true;
       }
       return false;

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -152,12 +152,14 @@ export function getProjectByParams(searchParams) {
 export function validateOrigin(urlStr) {
   try {
     const url = new URL(urlStr);
+    
+    
+    if (SLD === 'hlx') {
+      return url.origin === origin;
+    }
     const urlDomains = url.host?.split('.');
     const originUrl = new URL(origin);
     const originDomains = originUrl.host?.split('.');
-    if (SLD === 'hlx') {
-      return urlStr === origin;
-    }
     if (SLD === 'aem' && urlDomains?.length === originDomains.length) {
       const [urlSD, urlSLD] = urlDomains;
       const [originSD] = originDomains;

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -163,7 +163,7 @@ export function validateOrigin(urlStr) {
       return false;
     }
     return false;
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -152,16 +152,18 @@ export function validateOrigin(urlStr) {
   try {
     const url = new URL(urlStr);
     const urlDomains = url.host?.split('.');
-    const originDomains = origin.host?.split('.');
-    if (urlDomains.length === originDomains.length) {
+    const originUrl = new URL(origin);
+    const originDomains = originUrl.host?.split('.');
+    if (urlDomains && originDomains && urlDomains.length === originDomains.length) {
       const [urlSD, urlSDL, urlTDL] = urlDomains;
       const [originSD, originSDL, originTDL] = originDomains;
       if (urlSD === originSD && urlTDL === originTDL && (urlSDL === originSDL || urlSDL === 'aem' || urlSDL === 'hlx')) {
         return true;
       }
+      return false;
     }
     return false;
-  } catch {
+  } catch (e) {
     return false;
   }
 }

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -155,16 +155,9 @@ export function validateOrigin(urlStr) {
     if (SLD === 'hlx') {
       return url.origin === origin;
     }
-    const urlDomains = url.host?.split('.');
-    const originUrl = new URL(origin);
-    const originDomains = originUrl.host?.split('.');
-    if (SLD === 'aem' && urlDomains?.length === originDomains.length) {
-      const [urlSD, urlSLD] = urlDomains;
-      const [originSD] = originDomains;
-      if (urlSD === originSD && (urlSLD === 'aem' || urlSLD === 'hlx')) {
-        return true;
-      }
-      return false;
+    if (SLD === 'aem') {
+      const origins = [url.origin.replace('.aem.', '.hlx.'), url.origin.replace('.hlx.', '.aem.')];
+      return origins.includes(origin);
     }
     return false;
   } catch {

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -152,8 +152,6 @@ export function getProjectByParams(searchParams) {
 export function validateOrigin(urlStr) {
   try {
     const url = new URL(urlStr);
-    
-    
     if (SLD === 'hlx') {
       return url.origin === origin;
     }

--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -12,11 +12,12 @@ import {
   user,
 } from '../utils/state.js';
 import { setStatus } from '../utils/status.js';
-import { getStatus, origin, preview } from '../utils/franklin.js';
+import { getStatus, preview } from '../utils/franklin.js';
 import login from '../../../tools/sharepoint/login.js';
 import { getServiceUpdates } from '../utils/miloc.js';
 import { connectSK } from '../../../utils/sidekick.js';
 import { isUrl, getUrl } from '../utils/url.js';
+import { validateOrigin } from '../../locui-create/utils/utils.js';
 
 const LANG_ACTIONS = ['Translate', 'English Copy', 'Rollout', 'Transcreate'];
 const MOCK_REFERRER = 'https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B94460FAC-CDEE-4B31-B8E0-AA5E3F45DCC5%257D%26file%3Dwesco-demo.xlsx';
@@ -48,7 +49,7 @@ export function validateUrlsFormat(projectUrls, removeMedia = false) {
   projectUrls.forEach((projectUrl, idx) => {
     const url = getUrl(projectUrl);
     const domain = isUrl(url.alt) ?? url;
-    if (domain.origin !== origin) {
+    if (!validateOrigin(url)) {
       const aemUrl = domain.hostname?.split('--').length === 3;
       url.valid = !aemUrl ? 'not AEM url' : 'not same domain';
     }


### PR DESCRIPTION
* Added support for both hlx and aem pages for urls validation and fragments search

Resolves: https://jira.corp.adobe.com/browse/MWPW-166758

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/tools/locui-create?martech=off
- After: https://hlx-updates--milo--saurabhsircar11.aem.page/tools/locui-create?martech=off

**Bacom Test URLs:**
- Before: https://main--bacom--adobecom.hlx.page/tools/locui-create?milolibs=milostudio-stage&ref=main&repo=bacom&owner=adobecom&host=business.adobe.com&project=BACOM&env=local
- After: https://main--bacom--adobecom.hlx.page/tools/locui-create?milolibs=hlx-updates--milo--saurabhsircar11&ref=main&repo=bacom&owner=adobecom&host=business.adobe.com&project=BACOM&env=local
