### PR TITLE
MWPW-165881 Align Chart Heights

### DIFF
--- a/libs/blocks/chart/chart.css
+++ b/libs/blocks/chart/chart.css
@@ -7,7 +7,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    align-items: flex-start;
+    align-items: stretch;
     gap: 16px;
     margin: 0 auto;
 }


### PR DESCRIPTION
* Makes chart containers the same height when using ups

Resolves: [MWPW-165881](https://jira.corp.adobe.com/browse/MWPW-165881)

**Test URLs:**
- Before: https://main--bacom--adobecom.hlx.live/resources/digital-economy-index
- After: https://main--bacom--adobecom.hlx.live/resources/digital-economy-index?milolibs=chart-height--milo--meganthecoder&martech=off

- Before: https://main--milo--adobecom.hlx.live/drafts/methomas/chart-two-up?martech=off
- After: https://chart-height--milo--meganthecoder.hlx.page/drafts/methomas/chart-two-up?martech=off
