### PR TITLE
Adding support for secondary CTA for new mobile gnav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1035,7 +1035,13 @@ header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {
 
 header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content .feds-cta--secondary {
   margin: 12px;
-  max-width: 180px;
+  display: inline-block;
+  line-height: 2;
+  text-wrap: wrap;
+  min-width: 100px;
+  max-width: 200px;
+  align-items: center;
+  text-align: center;
 }
 
 [dir = "rtl"] header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1033,6 +1033,11 @@ header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {
   border-left: 1px solid var(--feds-borderColor-link-v2);
 }
 
+header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content .feds-cta--secondary {
+  margin: 12px;
+  max-width: 180px;
+}
+
 [dir = "rtl"] header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {
   border-left: none;
   border-right: 1px solid var(--feds-borderColor-link-v2);

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1035,13 +1035,14 @@ header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {
 
 header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content .feds-cta--secondary {
   margin: 12px;
+  height: unset;
   display: inline-block;
-  line-height: 2;
+  line-height: 1.2;
   text-wrap: wrap;
   min-width: 100px;
   max-width: 200px;
-  align-items: center;
   text-align: center;
+  padding: 6px;
 }
 
 [dir = "rtl"] header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1042,7 +1042,7 @@ header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content .feds
   min-width: 100px;
   max-width: 200px;
   text-align: center;
-  padding: 6px;
+  padding: 6px 14px;
 }
 
 [dir = "rtl"] header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1042,7 +1042,7 @@ header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content .feds
   min-width: 100px;
   max-width: 200px;
   text-align: center;
-  padding: 6px 14px;
+  padding: 5px 14px 6px;
 }
 
 [dir = "rtl"] header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1042,7 +1042,7 @@ header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content .feds
   min-width: 100px;
   max-width: 200px;
   text-align: center;
-  padding: 5px 14px 6px;
+  padding: 5px 18px 6px;
 }
 
 [dir = "rtl"] header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -455,10 +455,10 @@ export const transformTemplateToMobile = async (popup, item, localnav = false) =
       const daallTab = headline?.getAttribute('daa-ll');
       const daalhTabContent = section.querySelector('.feds-menu-items')?.getAttribute('daa-lh');
       const content = section.querySelector('.feds-menu-items') ?? section;
-      const links = [...content.querySelectorAll('a.feds-navLink')].map((x) => x.outerHTML).join('');
+      const links = [...content.querySelectorAll('a.feds-navLink, .feds-cta--secondary')].map((x) => x.outerHTML).join('');
       return { name, links, daallTab, daalhTabContent };
     });
-  const CTA = popup.querySelector('.feds-cta')?.outerHTML ?? '';
+  const CTA = popup.querySelector('.feds-cta--primary')?.outerHTML ?? '';
   const mainMenu = `
       <button class="main-menu" daa-ll="Main menu_Gnav" aria-label='Main menu'>
         <svg xmlns="http://www.w3.org/2000/svg" width="7" height="12" viewBox="0 0 7 12" fill="none"><path d="M5.55579 1L1.09618 5.45961C1.05728 5.4985 1.0571 5.56151 1.09577 5.60062L5.51027 10.0661" stroke=${isDarkMode() ? '#f2f2f2' : 'black'} stroke-width="2" stroke-linecap="round"/></svg>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding support for secondary CTA for new mobile gnav

Resolves: [MWPW-165807](https://jira.corp.adobe.com/browse/MWPW-165807)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mgnav-secondary-btn--milo--adobecom.aem.page/?martech=off

QA: https://main--homepage--adobecom.hlx.page/hu/homepage/index-loggedout?milolibs=mgnav-secondary-btn&newNav=true