### PR TITLE
[LOC]MWPW-166822 - Disabled next button on validation error

### DIFF
--- a/libs/blocks/locui-create/components/stepControls.js
+++ b/libs/blocks/locui-create/components/stepControls.js
@@ -14,6 +14,7 @@ export default function StepControls({
       && html`<button
         class=${`s2-btn secondary ${backDisabled && 'disabled'}`}
         onclick=${onBack}
+        disabled=${backDisabled}
       >
         ${backLabel}
       </button>`}
@@ -22,6 +23,7 @@ export default function StepControls({
       && html`<button
         class=${`s2-btn accent ${nextDisabled && 'disabled'}`}
         onclick=${onNext}
+        disabled=${nextDisabled}
       >
         <strong>${nextLabel}</strong>
       </button>`}


### PR DESCRIPTION
* disabled next button

Resolves:https://jira.corp.adobe.com/browse/MWPW-166822

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-166822-disabled-next-button--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off