### PR TITLE
[LOC]MWPW-166758 - fragment validations

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -105,7 +105,7 @@ async function findPageFragments(path) {
     const dupe = urls.value.some((url) => removeLangstorePrefix(url.pathname) === pathname);
     if (accDupe || dupe) return acc;
     const fragmentUrl = new URL(`${origin}${pathname}`);
-    fragmentUrl.alt = !isUrl(fragment.textContent) ? fragment.textContent : originalUrl;
+    fragmentUrl.alt = isUrl(fragment.textContent) ? fragment.textContent : originalUrl;
     acc.push(fragmentUrl);
     return acc;
   }, []);

--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -49,7 +49,7 @@ export function validateUrlsFormat(projectUrls, removeMedia = false) {
   projectUrls.forEach((projectUrl, idx) => {
     const url = getUrl(projectUrl);
     const domain = isUrl(url.alt) ?? url;
-    if (!validateOrigin(url)) {
+    if (!validateOrigin(domain.origin)) {
       const aemUrl = domain.hostname?.split('--').length === 3;
       url.valid = !aemUrl ? 'not AEM url' : 'not same domain';
     }


### PR DESCRIPTION
* removed not condition
* passed domain origin


Resolves:https://jira.corp.adobe.com/browse/MWPW-166758
For URL - https://main--express-milo--adobecom.aem.page/drafts/fragments/page-frag, below are errors reported:
![image](https://github.com/user-attachments/assets/1c1d91cc-d3c2-444a-8b24-42194d3ab99f)


**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-166758-fragment-validations--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off