### PR TITLE
MWPW-166838 fixed referential time

### DIFF
--- a/libs/features/mas/docs/benchmarks.html
+++ b/libs/features/mas/docs/benchmarks.html
@@ -62,7 +62,7 @@
       //if adjust is set to true, we adjust the limit based on the stored initTime and
       //reference time of 82ms it took on a quick network. This way, we should not be
       //affected by network speed when comparing benchmarks to limit.
-      const referentInitialTime = 82.0;
+      const referentInitialTime = 35.0;
       const previousLimit = limit;
       if (referentInitialTime < window.initTime) {
         limit = limit * window.initTime / referentInitialTime;


### PR DESCRIPTION
82 was network ressource measure i did, here initTime performance marker duration was 35, which will more than double adjusted limit

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-166838--milo--npeltier.aem.page/?martech=off
