### PR TITLE
[MWPW-165978] Make codecov tests more reliable

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,3 +11,4 @@ coverage:
    ignore:
       - "!libs/"
       - "libs/deps/"
+      

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,4 +11,3 @@ coverage:
    ignore:
       - "!libs/"
       - "libs/deps/"
-      

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -3,8 +3,11 @@ coverage:
     patch:
       default:
         target: 90%
-        threshold: 0.1%
+        threshold: 0.5%
     project:
       default:
         target: auto
-        threshold: 0.1%
+        threshold: 0.5%
+   ignore:
+      - "!libs/"
+      - "libs/deps/"


### PR DESCRIPTION
## Description
This PR is:
- increasing the tolerance threshold for codecov to 0.5%.
- including only what's under the `libs/` folder for codecov.
- excluding `libs/deps` from codecov.

## Related Issue
Resolves: [MWPW-165978](https://jira.corp.adobe.com/browse/MWPW-165978)

## Testing instructions
- no QA needed

## Test URLs
**Milo:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/rbogos/page-default?martech=off
- After: https://mwpw-165978-coverage--robert-bogos--adobecom.hlx.page/drafts/rbogos/page-default?martech=off
