### PR TITLE
MWPW-166758 Cross domain fragment validation in locui

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -119,7 +119,7 @@ async function findPageFragments(path) {
     const dupe = urls.value.some((url) => removeLangstorePrefix(url.pathname) === pathname);
     if (accDupe || dupe) return acc;
     const fragmentUrl = new URL(`${origin}${pathname}`);
-    fragmentUrl.alt = !isUrl(fragment.textContent) ? fragment.textContent : originalUrl;
+    fragmentUrl.alt = isUrl(fragment.textContent) ? fragment.textContent : originalUrl;
     acc.push(fragmentUrl);
     return acc;
   }, []);

--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -46,14 +46,13 @@ export function removeLangstorePrefix(path) {
 export function validateOrigin(urlStr) {
   try {
     const url = new URL(urlStr);
+    let replaceWith = '';
     if (SLD === 'hlx') {
-      return url.origin === origin;
+      replaceWith = '.aem.page';
+    } else if (SLD === 'aem') {
+      replaceWith = '.hlx.page';
     }
-    if (SLD === 'aem') {
-      const origins = [url.origin.replace('.aem.', '.hlx.'), url.origin.replace('.hlx.', '.aem.')];
-      return origins.includes(origin);
-    }
-    return false;
+    return replaceWith ? origin === url.origin.replace(`.${SLD}.page`, replaceWith) : false;
   } catch {
     return false;
   }

--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -46,13 +46,8 @@ export function removeLangstorePrefix(path) {
 export function validateOrigin(urlStr) {
   try {
     const url = new URL(urlStr);
-    let replaceWith = '';
-    if (SLD === 'hlx') {
-      replaceWith = '.aem.page';
-    } else if (SLD === 'aem') {
-      replaceWith = '.hlx.page';
-    }
-    return replaceWith ? origin === url.origin.replace(`.${SLD}.page`, replaceWith) : false;
+    const origins = [url.origin.replace('.aem.', '.hlx.'), url.origin.replace('.hlx.', '.aem.')];
+    return origins.includes(origin);
   } catch {
     return false;
   }

--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -1,4 +1,4 @@
-import { getConfig, getLocale, SLD } from '../../../utils/utils.js';
+import { getConfig, getLocale } from '../../../utils/utils.js';
 import {
   allowSendForLoc,
   heading,

--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -43,12 +43,28 @@ export function removeLangstorePrefix(path) {
   return path.replace(/^\/langstore\/[^/]+/, '');
 }
 
+export function validateOrigin(urlStr) {
+  try {
+    const url = new URL(urlStr);
+    if (SLD === 'hlx') {
+      return url.origin === origin;
+    }
+    if (SLD === 'aem') {
+      const origins = [url.origin.replace('.aem.', '.hlx.'), url.origin.replace('.hlx.', '.aem.')];
+      return origins.includes(origin);
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 export function validateUrlsFormat(projectUrls, removeMedia = false) {
   let firstUrlLang;
   projectUrls.forEach((projectUrl, idx) => {
     const url = getUrl(projectUrl);
     const domain = isUrl(url.alt) ?? url;
-    if (domain.origin !== origin) {
+    if (!validateOrigin(domain.origin)) {
       const aemUrl = domain.hostname?.split('--').length === 3;
       url.valid = !aemUrl ? 'not AEM url' : 'not same domain';
     }

--- a/libs/blocks/locui/loc/index.js
+++ b/libs/blocks/locui/loc/index.js
@@ -1,4 +1,4 @@
-import { getConfig, getLocale } from '../../../utils/utils.js';
+import { getConfig, getLocale, SLD } from '../../../utils/utils.js';
 import {
   allowSendForLoc,
   heading,


### PR DESCRIPTION
Porting cross domain fragment validation change from MiloStudio branch PRs to locui branch

Resolves: [MWPW-166758](https://jira.corp.adobe.com/browse/MWPW-166758)

**Test URLs:**
- Before: https://locui--milo--adobecom.aem.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B21a05280-fe1b-4d36-84cc-e301c6416083%257D%26action%3Deditnew
- After: https://locui-debug--milo--raga-adbe-gh.aem.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B21a05280-fe1b-4d36-84cc-e301c6416083%257D%26action%3Deditnew
