### PR TITLE
[MWPW-166755] table tab navigation stuck fix

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -427,9 +427,8 @@ function applyStylesBasedOnScreenSize(table, originTable) {
       icon.parentElement.addEventListener('click', () => handleExpand(icon));
       icon.parentElement.setAttribute('tabindex', 0);
       icon.parentElement.addEventListener('keydown', (e) => {
-        if (e.key !== 'Tab') {
-          e.preventDefault();
-        }
+        if (e.key !== 'Tab') e.preventDefault();
+
         if (e.key === 'Enter' || e.key === ' ') handleExpand(icon);
       });
     });

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -427,7 +427,9 @@ function applyStylesBasedOnScreenSize(table, originTable) {
       icon.parentElement.addEventListener('click', () => handleExpand(icon));
       icon.parentElement.setAttribute('tabindex', 0);
       icon.parentElement.addEventListener('keydown', (e) => {
-        e.preventDefault();
+        if (e.key !== 'Tab') {
+          e.preventDefault();
+        }
         if (e.key === 'Enter' || e.key === ' ') handleExpand(icon);
       });
     });

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -427,7 +427,7 @@ function applyStylesBasedOnScreenSize(table, originTable) {
       icon.parentElement.addEventListener('click', () => handleExpand(icon));
       icon.parentElement.setAttribute('tabindex', 0);
       icon.parentElement.addEventListener('keydown', (e) => {
-        if (e.key !== 'Tab') e.preventDefault();
+        if (e.key === ' ') e.preventDefault();
 
         if (e.key === 'Enter' || e.key === ' ') handleExpand(icon);
       });


### PR DESCRIPTION
This resolves the issue where navigating through the table with Tab causes the navigation to be stuck when getting to cells that have a caret for toggling rows.

Resolves: [MWPW-166755](https://jira.corp.adobe.com/browse/MWPW-166755)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
- After: https://table-keyboard-nav-stuck--milo--adobecom.hlx.page/docs/library/kitchen-sink/table?martech=off
