### PR TITLE
MWPW-166855 - Express fragment Validation

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -102,7 +102,8 @@ async function findPageFragments(path) {
     // Find dupes across current iterator as well as original url list
     const accDupe = acc.some((url) => url.pathname === pathname);
     // Used remove langstore prefix for langstore urls
-    const dupe = urls.value.some((url) => removeLangstorePrefix(url.pathname) === pathname);
+    const dupe = urls.value
+      .some((url) => removeLangstorePrefix(url.pathname) === removeLangstorePrefix(pathname));
     if (accDupe || dupe) return acc;
     const fragmentUrl = new URL(`${origin}${pathname}`);
     fragmentUrl.alt = !isUrl(fragment.textContent) ? fragment.textContent : originalUrl;


### PR DESCRIPTION
* Removed langstore prefix from url pathname of the fragment

Resolves:https://jira.corp.adobe.com/browse/MWPW-166855

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-166855-express-fragment-validation--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off
