### PR TITLE
MWPW-149470 [MILO][MEP] Remove sendTargetResponseAnalytics function

### DIFF
--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -63,13 +63,12 @@ function calculateResponseTime(responseStart) {
 }
 
 export const getTargetPersonalization = async (
-  { handleAlloyResponse, sendTargetResponseAnalytics },
+  { handleAlloyResponse },
 ) => {
   const responseStart = Date.now();
   window.addEventListener(ALLOY_SEND_EVENT, () => {
-    const responseTime = calculateResponseTime(responseStart);
     try {
-      window.lana.log(`target response time: ${responseTime}`, {
+      window.lana.log(`target response time: ${calculateResponseTime(responseStart)}`, {
         tags: 'martech',
         errorType: 'e',
         sampleRate: 0.5,
@@ -99,9 +98,12 @@ export const getTargetPersonalization = async (
   }
   if (response.timeout) {
     waitForEventOrTimeout(ALLOY_SEND_EVENT, 5100 - timeout)
-      .then(() => sendTargetResponseAnalytics(true, responseStart, timeout));
+      .then(() => window.lana.log(`target response timed out: ${calculateResponseTime(responseStart)}`, {
+        tags: 'martech',
+        errorType: 'e',
+        sampleRate: 0.5,
+      }));
   } else {
-    sendTargetResponseAnalytics(false, responseStart, timeout);
     targetManifests = handleAlloyResponse(response.result);
     targetPropositions = response.result?.propositions || [];
   }


### PR DESCRIPTION
* Remove all of the AA tracking for how long Target response takes
* Add in lana log tracking for when Target took longer than the page's Target timeout setting

Resolves: [MWPW-149470](https://jira.corp.adobe.com/browse/MWPW-149470)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mepremovetracking--milo--adobecom.aem.page/?martech=off
