### PR TITLE
MWPW-166762 [Loc][Create Project] Updated styles for Express tenant

### DIFF
--- a/libs/blocks/locui-create/locui-create.css
+++ b/libs/blocks/locui-create/locui-create.css
@@ -4,6 +4,10 @@ body {
   background-attachment: fixed;
 }
 
+div.locui-create {
+  line-height: var(--type-body-m-lh);
+}
+
 /* --- Shared --- */
 
 .row {
@@ -333,12 +337,15 @@ body {
 
 .main-content h3 {
   font-size: 24px;
+  font-weight: normal;
   padding: 0 0 10px 30px;
   border-bottom: 0.5px solid rgb(185, 185, 185);
+  margin-top: 20px;
   margin-bottom: 10px;
 }
 
-.locui-project-name {
+div.locui-create .locui-project-name {
+  margin: 16px 0;
   font-size: 16px;
 }
 
@@ -417,15 +424,12 @@ body {
 }
 
 /* Side Navigation */
-
+div.locui-create 
 .nav-link,
-.nav-link:hover {
+div.locui-create .nav-link:hover {
   text-decoration: none;
   color: black;
 }
-/* .nav-link:hover {
-  text-decoration: none;
-} */
 
 .nav-list {
   list-style: none;
@@ -433,7 +437,7 @@ body {
   margin: 0;
 }
 
-.nav-item {
+div.locui-create .nav-item {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -461,8 +465,10 @@ body {
   background: url('./img/analytics-icon.svg') center 14px / 20px no-repeat;
 }
 
-.nav-label {
+div.locui-create .nav-label {
+  line-height: inherit;
   text-align: center;
+  font-weight: normal;
   font-size: 12px;
   margin: 3px 0 0;
 }
@@ -610,6 +616,7 @@ body {
 }
 
 .locui-project-type {
+  margin: 20px 0;
   font-weight: 700;
   font-size: 1.25rem;
   font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;


### PR DESCRIPTION
* Updated styles for Express tenant, which has been overriding tool's style

Resolves: https://jira.corp.adobe.com/browse/MWPW-166762

Validated that now styles are correct:
<img width="1684" alt="Screenshot 2025-01-31 at 10 35 17 AM" src="https://github.com/user-attachments/assets/29fe5002-24d2-4532-8b08-3e0fa2e9b92b" />


**Test URLs:**
- Before: https://main--express-milo--adobecom.aem.page/tools/locui-create?milolibs=milostudio-stage&ref=main&repo=express-milo&owner=adobecom&host=www.adobe.com&env=local
- After: https://main--express-milo--adobecom.aem.page/tools/locui-create?milolibs=mwpw-166762-express-create-project&ref=main&repo=express-milo&owner=adobecom&host=www.adobe.com&env=local
