### PR TITLE
[LOC] MWPW-166855 - handled when fragment url comes undefined

### DIFF
--- a/libs/blocks/locui/actions/index.js
+++ b/libs/blocks/locui/actions/index.js
@@ -94,7 +94,7 @@ async function findPageFragments(path) {
     const originalUrl = fragment.dataset.modalPath || fragment.dataset.path || fragment.href;
     let pathname;
     try {
-      pathname = new URL(originalUrl, origin).pathname.replace('.html', '');
+      pathname = new URL(originalUrl, originalUrl ? origin : '').pathname.replace('.html', '');
     } catch (error) {
       setStatus('service', 'error', 'Invalid Fragment Path in files', originalUrl);
       return acc;


### PR DESCRIPTION
* Added condition to handle undefined original url

Resolves:https://jira.corp.adobe.com/browse/MWPW-166855

**Test URLs:**
- Before: https://stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-166855-express-undefined-urls--milo--saurabhsircar11.hlx.page/drafts/sircar/locui-create?martech=off

**Express Test URLs:**
- Before: https://main--express-milo--adobecom.aem.page/tools/locui-create?milolibs=milostudio-stage&ref=main&repo=express-milo&owner=adobecom&host=www.adobe.com&env=stage&martech=off
- After: https://main--express-milo--adobecom.aem.page/tools/locui-create?milolibs=MWPW-166855-express-undefined-urls--milo--saurabhsircar11&ref=main&repo=express-milo&owner=adobecom&host=www.adobe.com&env=stage