### PR TITLE
MWPW-167066 [MEP] Add capabilty for merch-card-collection block to run MEP commands

### DIFF
--- a/libs/blocks/merch-card-collection/merch-card-collection.js
+++ b/libs/blocks/merch-card-collection/merch-card-collection.js
@@ -43,7 +43,15 @@ const fail = (el, err = '') => {
 
 /** Parse and prepare cards */
 async function getCardsRoot(config, html) {
-  const cards = `<div>${html}</div>`;
+  let cards = `<div>${html}</div>`;
+  const { mep, placeholders } = config;
+  if (mep?.commands?.length) {
+    const mepRoot = createTag('div', {}, cards);
+    const { handleCommands, replacePlaceholders } = await import('../../features/personalization/personalization.js');
+    handleCommands(mep?.commands, mepRoot, false, true);
+    if (placeholders) mepRoot.innerHTML = replacePlaceholders(mepRoot.innerHTML, placeholders);
+    cards = mepRoot.innerHTML;
+  }
   const fragment = document.createRange().createContextualFragment(
     await replaceText(cards, config),
   );

--- a/test/blocks/merch-card-collection/merch-card-collection.test.js
+++ b/test/blocks/merch-card-collection/merch-card-collection.test.js
@@ -171,7 +171,7 @@ describe('Merch Cards', async () => {
     expect(merchCards.outerHTML).to.equal(merchCards.nextElementSibling.outerHTML);
   });
 
-  it('should override cards when asked to', async () => {
+  it('MEP: should override cards when asked to', async () => {
     const el = document.getElementById('multipleFilters');
     setConfig({
       ...conf,
@@ -205,6 +205,37 @@ describe('Merch Cards', async () => {
     expect(photoshop.title.indexOf('PROMOTION') > 0).to.be.true;
     expect(express.title.indexOf('PROMOTION') > 0).to.be.true;
     expect(merchCards.dataset.overrides).to.equal('promo1.json:/override-photoshop,promo2.json:/override-express');
+  });
+
+  it('MEP: should modify cards when asked to', async () => {
+    const el = document.getElementById('multipleFilters');
+    setConfig({
+      ...conf,
+      mep: {
+        preview: true,
+        commands: [
+          {
+            action: 'remove',
+            selector: 'merch-card h3 #_include-fragments #_all',
+            pageFilter: '',
+            content: 'true',
+            selectorType: 'other',
+            manifestId: 'merchcardupdates.json',
+            targetManifestId: false,
+            modifiers: [
+              'include-fragments',
+              'all',
+            ],
+          },
+        ],
+      },
+    });
+    cards = [...document.querySelectorAll('#cards .merch-card')]
+      .map((merchCardEl) => ({ cardContent: merchCardEl.outerHTML })); // mock cards
+    const merchCards = await init(el);
+    expect(merchCards.filter).to.equal('all');
+    await delay(500);
+    expect(merchCards.querySelectorAll('h3[data-removed-manifest-id]').length).to.equal(4);
   });
 
   it('should localize the query-index url', async () => {


### PR DESCRIPTION
Currently, the merch-card-collection block creates the HTML for its merch-cards dynamically during decoration. Therefore, MEP never has a chance to execute commands against the cards being created, and is limited to only _swapping_ out cards for a brand new one (a new fragment). 

This PR introduces a feature that treats cards within a collection like fragments: if a MEP action is specified to run on fragments, merch-card-collection can access those commands. Hence, we will be able to directly edit the cards in the collection, instead of needing to make completely new replacement cards to make the edits. 

Features/Notes
- Remove elements within the merch-card-collection block
- Insert/append text and HTML
- Cannot insert fragments 
- Cannot replace elements _with_ a fragment 

Resolves: [MWPW-167066](https://jira.corp.adobe.com/browse/MWPW-167066)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- PSI check: https://mep-cardcollection-update--milo--adobecom.aem.page/?martech=off


**QA Links:** 
We have 5 examples for testing. Use the MEP button 'Highlight changes' toggle for easier visual confirmation.

**all: Hides all merch card hollow buttons**
https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/merchcardupdates/catalog?milolibs=mep-cardcollection-update&mep=%2Fdrafts%2Fmepdev%2Ffragments%2F2025%2Fq1%2Fmerchcardupdates%2Fmerchcardupdates.json--all

**freetrialbuttons: Hides cart links that say free trial and we also target the CC All Apps button based on the modal destination of the button (this is likely the example you would use)**
https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/merchcardupdates/catalog?milolibs=mep-cardcollection-update&mep=%2Fdrafts%2Fmepdev%2Ffragments%2F2025%2Fq1%2Fmerchcardupdates%2Fmerchcardupdates.json--freetrialbuttons

**acrobatpro: We hide just the hollow button on the Acrobat Pro card based on the product name**
https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/merchcardupdates/catalog?milolibs=mep-cardcollection-update&mep=%2Fdrafts%2Fmepdev%2Ffragments%2F2025%2Fq1%2Fmerchcardupdates%2Fmerchcardupdates.json--acrobatpro

**updatereplacecard: We replace the Photoshop card and still hide all trial buttons.**
https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/merchcardupdates/catalog?milolibs=mep-cardcollection-update&mep=%2Fdrafts%2Fmepdev%2Ffragments%2F2025%2Fq1%2Fmerchcardupdates%2Fmerchcardupdates.json--updatereplacecard

**removecard: We remove the Acrobat Pro card completely**
https://main--cc--adobecom.hlx.page/drafts/mepdev/fragments/2025/q1/merchcardupdates/catalog?milolibs=mep-cardcollection-update&mep=%2Fdrafts%2Fmepdev%2Ffragments%2F2025%2Fq1%2Fmerchcardupdates%2Fmerchcardupdates.json--removecard
