### PR TITLE
MWPW-164756: Fix inset text ol

### DIFF
--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -201,7 +201,6 @@
 
 .inset.text-block .foreground ul,
 .inset.text-block .foreground ol {
-  list-style: outside;
   padding-left: var(--spacing-xs);
 }
 


### PR DESCRIPTION
Resolves: [MWPW-164756](https://jira.corp.adobe.com/browse/MWPW-164756)

- [x] Axe a11y scan (with `Best Practices` enabled) was run for this fix, and no a11y issues were introduced.

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ratko/mwpw-164756/text?martech=off
- After: https://mwpw-164756-ol-inset-text--milo--adobecom.hlx.page/drafts/ratko/mwpw-164756/text?martech=off
