### PR TITLE
MWPW-167263 [MEP] Error if a page with undefined promo uses mep param

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1121,7 +1121,7 @@ export const combineMepSources = async (persEnabled, promoEnabled, mepParam) => 
   if (mepParam && mepParam !== 'off') {
     const persManifestPaths = persManifests.map((manifest) => {
       const { manifestPath } = manifest;
-      if (manifestPath.startsWith('/')) return manifestPath;
+      if (manifestPath?.startsWith('/')) return manifestPath;
       try {
         const url = new URL(manifestPath);
         return url.pathname;


### PR DESCRIPTION
Detailed Description: 
................................
URL: https://main--cc--adobecom.hlx.page/de/products/aftereffects?mep=/cc-shared/fragments/promos/2025/global/try-buy/try-buy-global-q1-viv-test.json
................................
Steps to Reproduce:
1. Go to URL

Expected Results: Page renders
................................
Actual Results: Page errors and stays blank

Resolves: [MWPW-167263](https://jira.corp.adobe.com/browse/MWPW-167263)

**Test URLs:**
- Psi-check: https://mepnopath--milo--adobecom.aem.page/?martech=off
- Before: URL: https://main--cc--adobecom.hlx.page/de/products/aftereffects?mep=/cc-shared/fragments/promos/2025/global/try-buy/try-buy-global-q1-viv-test.json
- After: https://main--cc--adobecom.hlx.page/de/products/aftereffects?mep=/cc-shared/fragments/promos/2025/global/try-buy/try-buy-global-q1-viv-test.json&milolibs=mepnopath
