### PR TITLE
MWPW-158537 : Upgrade Universal Nav to version 1.4

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -406,7 +406,6 @@ header.global-navigation {
 
 .feds-utilities .unav-comp-app-switcher-popover, /* App Switcher */
 .feds-utilities .spectrum-Dialog-content, /* Notifications */
-.feds-utilities .unav-comp-external-profile, /* Profile */
 .feds-utilities .unav-comp-help-popover, /* Help */
 .feds-utilities .unc-overlay-container { /* Tooltips */
   transform: translate3d(0,0,0); /* Fix Safari issues w/ position: sticky */

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -78,9 +78,26 @@ export const CONFIG = {
         name: 'profile',
         attributes: {
           isSignUpRequired: false,
+          messageEventListener: (event) => {
+            const { name, payload, executeDefaultAction } = event.detail;
+            if (name === 'System' && payload.subType === 'AppInitiated') {
+              window.adobeProfile?.getUserProfile()
+                .then((data) => { setUserProfile(data); })
+                .catch(() => { setUserProfile({}); });
+            }
+            if (name === 'System' && payload.subType === 'SignOut') {
+              executeDefaultAction();
+            }
+            if (name === 'System' && payload.subtype === 'ProfileSwitch') {
+              executeDefaultAction.then((profile) => {
+                if (profile) window.location.reload();
+              });
+            }
+          },
           componentLoaderConfig: {
             config: {
               enableLocalSection: true,
+              enableProfileSwitcher: true,
               miniAppContext: {
                 onMessage: (name, payload) => {
                   if (name === 'System' && payload.subType === 'AppInitiated') {
@@ -129,6 +146,7 @@ export const CONFIG = {
           callbacks: getConfig().jarvis?.callbacks,
         },
       },
+      cart: { name: 'cart' },
     },
   },
 };
@@ -645,7 +663,7 @@ class Gnav {
       return 'linux';
     };
 
-    const unavVersion = new URLSearchParams(window.location.search).get('unavVersion') || '1.3';
+    const unavVersion = new URLSearchParams(window.location.search).get('unavVersion') || '1.4';
     await Promise.all([
       loadScript(`https://${environment}.adobeccstatic.com/unav/${unavVersion}/UniversalNav.js`),
       loadStyles(`https://${environment}.adobeccstatic.com/unav/${unavVersion}/UniversalNav.css`, true),

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -278,7 +278,7 @@ const closeOnClickOutside = (e, isLocalNav, navWrapper) => {
   const newMobileNav = getMetadata('mobile-gnav-v2') !== 'false';
   if (!isDesktop.matches && !newMobileNav) return;
 
-  const openElemSelector = `${selectors.globalNav} [aria-expanded = "true"], ${selectors.localNav} [aria-expanded = "true"]`;
+  const openElemSelector = `${selectors.globalNav} [aria-expanded = "true"]:not(.universal-nav-container *), ${selectors.localNav} [aria-expanded = "true"]`;
   const isClickedElemOpen = [...document.querySelectorAll(openElemSelector)]
     .find((openItem) => openItem.parentElement.contains(e.target));
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -764,7 +764,7 @@ class Gnav {
     await window.UniversalNav(CONFIG.universalNav.universalNavConfig);
     this.decorateAppPrompt({ getAnchorState: () => window.UniversalNav.getComponent?.('app-switcher') });
     isDesktop.addEventListener('change', () => {
-      window.UniversalNav.reload(CONFIG.universalNav.universalNavConfig);
+      window.UniversalNav.reload(getConfiguration());
     });
   };
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -99,13 +99,6 @@ export const CONFIG = {
               enableLocalSection: true,
               enableProfileSwitcher: true,
               miniAppContext: {
-                onMessage: (name, payload) => {
-                  if (name === 'System' && payload.subType === 'AppInitiated') {
-                    window.adobeProfile?.getUserProfile()
-                      .then((data) => { setUserProfile(data); })
-                      .catch(() => { setUserProfile({}); });
-                  }
-                },
                 logger: {
                   trace: () => {},
                   debug: () => {},
@@ -763,6 +756,7 @@ class Gnav {
       },
       children: getChildren(),
       isSectionDividerRequired: getConfig()?.unav?.showSectionDivider,
+      showTrayExperience: (!isDesktop.matches),
     });
 
     // Exposing UNAV config for consumers

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -80,7 +80,7 @@ export const CONFIG = {
           isSignUpRequired: false,
           messageEventListener: (event) => {
             const { name, payload, executeDefaultAction } = event.detail;
-            if (name !== 'System') return;
+            if (!name || name !== 'System' || !payload || typeof executeDefaultAction !== 'function') return;
             switch (payload.subType) {
               case 'AppInitiated':
                 window.adobeProfile?.getUserProfile()

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -91,7 +91,7 @@ export const CONFIG = {
                 executeDefaultAction();
                 break;
               case 'ProfileSwitch':
-                executeDefaultAction().then((profile) => {
+                Promise.resolve(executeDefaultAction()).then((profile) => {
                   if (profile) window.location.reload();
                 });
                 break;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -80,18 +80,23 @@ export const CONFIG = {
           isSignUpRequired: false,
           messageEventListener: (event) => {
             const { name, payload, executeDefaultAction } = event.detail;
-            if (name === 'System' && payload.subType === 'AppInitiated') {
-              window.adobeProfile?.getUserProfile()
-                .then((data) => { setUserProfile(data); })
-                .catch(() => { setUserProfile({}); });
-            }
-            if (name === 'System' && payload.subType === 'SignOut') {
-              executeDefaultAction();
-            }
-            if (name === 'System' && payload.subType === 'ProfileSwitch') {
-              executeDefaultAction().then((profile) => {
-                if (profile) window.location.reload();
-              });
+            if (name !== 'System') return;
+            switch (payload.subType) {
+              case 'AppInitiated':
+                window.adobeProfile?.getUserProfile()
+                  .then((data) => { setUserProfile(data); })
+                  .catch(() => { setUserProfile({}); });
+                break;
+              case 'SignOut':
+                executeDefaultAction();
+                break;
+              case 'ProfileSwitch':
+                executeDefaultAction().then((profile) => {
+                  if (profile) window.location.reload();
+                });
+                break;
+              default:
+                break;
             }
           },
           componentLoaderConfig: {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -88,8 +88,8 @@ export const CONFIG = {
             if (name === 'System' && payload.subType === 'SignOut') {
               executeDefaultAction();
             }
-            if (name === 'System' && payload.subtype === 'ProfileSwitch') {
-              executeDefaultAction.then((profile) => {
+            if (name === 'System' && payload.subType === 'ProfileSwitch') {
+              executeDefaultAction().then((profile) => {
                 if (profile) window.location.reload();
               });
             }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1023,7 +1023,7 @@ export async function loadIms() {
       return;
     }
     const [unavMeta, ahomeMeta] = [getMetadata('universal-nav')?.trim(), getMetadata('adobe-home-redirect')];
-    const defaultScope = `AdobeID,openid,gnav${unavMeta && unavMeta !== 'off' ? ',pps.read,firefly_api,additional_info.roles,read_organizations' : ''}`;
+    const defaultScope = `AdobeID,openid,gnav${unavMeta && unavMeta !== 'off' ? ',pps.read,firefly_api,additional_info.roles,read_organizations,account_cluster.read' : ''}`;
     const timeout = setTimeout(() => reject(new Error('IMS timeout')), imsTimeout || 5000);
     window.adobeid = {
       client_id: imsClientId,

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -435,10 +435,11 @@ describe('global navigation', () => {
 
       it('should handle message events correctly', async () => {
         // eslint-disable-next-line max-len
-        const mockEvent = (name, payload) => ({ detail: { name, payload, executeDefaultAction: sinon.spy(() => Promise.resolve({})) } });
+        const mockEvent = (name, payload) => ({ detail: { name, payload, executeDefaultAction: sinon.spy(() => Promise.resolve(null)) } });
         await createFullGlobalNavigation({ unavContent: 'on' });
-        const { messageEventListener } = window.UniversalNav.getCall(0).args[0].children
-          .find((c) => c.name === 'profile').attributes;
+        const messageEventListener = window.UniversalNav.getCall(0).args[0].children
+          .map((c) => c.attributes.messageEventListener)
+          .find((listener) => listener);
 
         const appInitiatedEvent = mockEvent('System', { subType: 'AppInitiated' });
         messageEventListener(appInitiatedEvent);
@@ -447,6 +448,10 @@ describe('global navigation', () => {
         const signOutEvent = mockEvent('System', { subType: 'SignOut' });
         messageEventListener(signOutEvent);
         expect(signOutEvent.detail.executeDefaultAction.called).to.be.true;
+
+        const profileSwitch = mockEvent('System', { subType: 'ProfileSwitch' });
+        messageEventListener(profileSwitch);
+        expect(profileSwitch.detail.executeDefaultAction.called).to.be.true;
       });
 
       it('should send the correct analytics events', async () => {

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -398,6 +398,7 @@ describe('global navigation', () => {
       });
       window.UniversalNav = sinon.spy(() => Promise.resolve());
       window.UniversalNav.reload = sinon.spy(() => Promise.resolve());
+      window.adobeProfile = { getUserProfile: sinon.spy(() => Promise.resolve({})) };
       // eslint-disable-next-line no-underscore-dangle
       window._satellite = { track: sinon.spy() };
       window.alloy = () => new Promise((resolve) => {
@@ -430,6 +431,22 @@ describe('global navigation', () => {
         isDesktop.dispatchEvent(new Event('change'));
         await clock.runAllAsync();
         expect(window.UniversalNav.reload.getCall(0)).to.exist;
+      });
+
+      it('should handle message events correctly', async () => {
+        // eslint-disable-next-line max-len
+        const mockEvent = (name, payload) => ({ detail: { name, payload, executeDefaultAction: sinon.spy(() => Promise.resolve({})) } });
+        await createFullGlobalNavigation({ unavContent: 'on' });
+        const { messageEventListener } = window.UniversalNav.getCall(0).args[0].children
+          .find((c) => c.name === 'profile').attributes;
+
+        const appInitiatedEvent = mockEvent('System', { subType: 'AppInitiated' });
+        messageEventListener(appInitiatedEvent);
+        expect(window.adobeProfile.getUserProfile.called).to.be.true;
+
+        const signOutEvent = mockEvent('System', { subType: 'SignOut' });
+        messageEventListener(signOutEvent);
+        expect(signOutEvent.detail.executeDefaultAction.called).to.be.true;
       });
 
       it('should send the correct analytics events', async () => {
@@ -485,6 +502,14 @@ describe('global navigation', () => {
         for (const data of unavLocalesTestData) {
           expect(getUniversalNavLocale({ prefix: data.prefix })).to.equal(data.expectedLocale);
         }
+      });
+
+      it('should pass enableProfileSwitcher to the profile component configuration', async () => {
+        await createFullGlobalNavigation({ unavContent: 'on' });
+        const profileConfig = window.UniversalNav.getCall(0).args[0].children
+          .find((c) => c.name === 'profile').attributes.componentLoaderConfig.config;
+
+        expect(profileConfig.enableProfileSwitcher).to.be.true;
       });
     });
 

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -80,7 +80,7 @@ export const analyticsTestData = {
   'unc|click|markUnread': 'Mark Notification as unread',
 };
 
-export const unavVersion = '1.3';
+export const unavVersion = '1.4';
 
 export const addMetaDataV2 = (value) => {
   const metaTag = document.createElement('meta');


### PR DESCRIPTION
Upgrade Universal Nav to version 1.4

* Add messageEventListener to avoid onMessage event listener ([Ref](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=IdentityACCM&title=Account+Menu+Mini-App#AccountMenuMiniApp-CustomeventscommunicationandonMessagedeprecationcustom_event_migration))
* Support Profile Switching in Account Menu ([Ref1](https://jira.corp.adobe.com/browse/CCH-25502), [Ref2](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=IdentityACCM&title=Profile+Switching+Integration+Guide#ProfileSwitchingIntegrationGuide-ProfileSwitchMiniApp-ProfileSwitch-IMSScopes:~:text=5.1.4.-,IMS%20Scopes%C2%A0,-The%20access%20token))
* Support new Mobile UX designs for Unav ([Ref](https://jira.corp.adobe.com/browse/CCH-25381))
* Enable shopping cart ([Ref](https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=BPS&title=Persistent+cart+integration+guide))
Note: The initial https://github.com/adobecom/milo/pull/3367 was reverted to align with the scheduled release timeline. Re-submitting the same.

Resolves: [MWPW-158537](https://jira.corp.adobe.com/browse/MWPW-158537)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/snehal/illustrator?martech=off
- After: https://gnav--milo--adobecom.hlx.page/drafts/snehal/illustrator?martech=off