### PR TITLE
DOTCOM-128841 change the wrapper from p to div

### DIFF
--- a/libs/blocks/global-footer/global-footer.css
+++ b/libs/blocks/global-footer/global-footer.css
@@ -220,26 +220,29 @@
 
 /* Privacy */
 .feds-footer-legalWrapper {
-  display: flex;
-  flex-direction: column; /* More privacy rows are allowed */
-  align-items: flex-start;
-  row-gap: 12px;
+  display: block;
+}
+
+.feds-footer-copyright {
+  display: inline-block;
 }
 
 .feds-footer-privacySection {
-  display: flex;
-  align-items: center;
-  column-gap: 5px;
-  flex-wrap: wrap;
-  margin: 0;
+  display: inline;
 }
 
 .feds-footer-privacyLink {
-  display: flex;
+  display: inline-flex;
   column-gap: 5px;
   align-items: center;
   color: var(--feds-color-link);
   fill: var(--feds-color-link);
+  vertical-align: bottom;
+}
+
+span.feds-footer-privacyLink-divider {
+    display: inline-block;
+    margin: 0 5px;
 }
 
 .feds-footer-privacyLink:hover {
@@ -310,11 +313,16 @@
   /* Privacy */
   .feds-footer-legalWrapper {
     align-items: flex-end;
+    text-align: right;
   }
 
   .feds-footer-privacySection {
     justify-content: flex-end;
     text-align: right;
+  }
+  span.feds-footer-privacyLink-divider, .feds-footer-privacyLink {
+    margin-left: 5px;
+    margin-right: 0;
   }
 }
 

--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -351,9 +351,7 @@ class Footer {
 
     // Decorate copyright element
     const currentYear = new Date().getFullYear();
-    copyrightElem.replaceWith(toFragment`<span class="feds-footer-copyright">
-        Copyright © ${currentYear} ${copyrightElem.textContent}
-      </span>`);
+    copyrightElem.remove();
 
     // Add Ad Choices icon
     const adChoicesElem = privacyContent.querySelector('a[href*="#interest-based-ads"]');
@@ -362,7 +360,10 @@ class Footer {
       </svg>`);
 
     this.elements.legal = toFragment`<div class="feds-footer-legalWrapper" daa-lh="Legal"></div>`;
-
+    this.elements.legal.append(copyrightElem);
+    copyrightElem.replaceWith(toFragment`<span class="feds-footer-copyright">
+      Copyright © ${currentYear} ${copyrightElem.textContent}
+    </span>`);
     while (privacyContent.children.length) {
       const privacySection = privacyContent.firstElementChild;
       privacySection.classList.add('feds-footer-privacySection');
@@ -371,6 +372,13 @@ class Footer {
         link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index + 1));
       });
       this.elements.legal.append(privacySection);
+
+      const privacySectionDiv = document.createElement('div');
+      [...privacySection.attributes].forEach((attr) => {
+        privacySectionDiv.setAttribute(attr.name, attr.value);
+      });
+      privacySectionDiv.innerHTML = privacySection.innerHTML.replace(/( \/ )/g, '<span class="feds-footer-privacyLink-divider">$1</span>');;
+      privacySection.parentNode.replaceChild(privacySectionDiv, privacySection);
     }
 
     return this.elements.legal;


### PR DESCRIPTION
Brief description of the issue:
The copyright information should NOT be part of the list of links because it is not a link. Add a <div> with role="list" to wrap the 5 links to create the list item.

Note: changes has been tested using macos's voice over.

Resolves: [DOTCOM-128841](https://jira.corp.adobe.com/browse/DOTCOM-128841)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-165806--milo--patel-prince.aem.page/?martech=off

**QA URL:**
Before: https://main--cc--adobecom.hlx.page/creativecloud?martech=off
After: https://main--cc--adobecom.hlx.page/creativecloud?martech=off&milolibs=dotcom-128841--milo--patel-prince
