### PR TITLE
MWPW-161920: Fix fragment reference check

### DIFF
--- a/tools/floodbox/references.js
+++ b/tools/floodbox/references.js
@@ -9,7 +9,7 @@ class References {
     this.htmlPaths = htmlPaths;
 
     // eslint-disable-next-line no-useless-escape
-    this.referencePattern = new RegExp(`https?:\/\/[^/]*--${repo}--${org}\\.[^/]*(?:page|live)(\/(?:fragments\/.*|.*\\.(?:pdf|svg|json)))`);
+    this.referencePattern = new RegExp(`https?:\/\/[^/]*--${repo}--${org}\\.[^/]*(?:page|live)(\/.*(?:fragments\/|\\.(?:pdf|svg|json))[^?]*)`);
     this.requestHandler = new RequestHandler(accessToken);
   }
 


### PR DESCRIPTION
* Update to the regex to find fragments during copy

Resolves: [MWPW-161920](https://jira.corp.adobe.com/browse/MWPW-161920)

**Test URLs:**
- Before: https://da.live/app/adobecom/milo/tools/floodgate?ref=stage
- After: https://da.live/app/adobecom/milo/tools/floodgate?ref=frag-fix

https://main--da-bacom--sukamat.aem.page/test