### PR TITLE
MWPW-166878: Remove the empty A link element left from icon

### DIFF
--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -226,6 +226,7 @@ const parseContent = async (el, merchCard) => {
   ];
 
   innerElements.forEach((element) => {
+    if (!element.innerHTML) return;
     let { tagName } = element;
     if (isHeadingTag(tagName)) {
       let slotName = SLOT_MAP[merchCard.variant]?.[tagName] || SLOT_MAP_DEFAULT[tagName];
@@ -663,7 +664,10 @@ export default async function init(el) {
       const merchIcon = createTag('merch-icon', { slot: 'icons', src: icon.src, alt: icon.alt, href: icon.href, size: 'l' });
       merchCard.appendChild(merchIcon);
     });
-    icons.forEach((icon) => icon.remove());
+    icons.forEach((icon) => {
+      if (icon.parentElement.nodeName === 'A') icon.parentElement.remove();
+      else icon.remove();
+    });
   }
 
   addStock(merchCard, styles);

--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -226,7 +226,7 @@ const parseContent = async (el, merchCard) => {
   ];
 
   innerElements.forEach((element) => {
-    if (!element.innerHTML) return;
+    if (!element.innerHTML.trim()) return;
     let { tagName } = element;
     if (isHeadingTag(tagName)) {
       let slotName = SLOT_MAP[merchCard.variant]?.[tagName] || SLOT_MAP_DEFAULT[tagName];

--- a/nala/blocks/merchcard/merchcard.pages.js
+++ b/nala/blocks/merchcard/merchcard.pages.js
@@ -42,9 +42,9 @@ export default class Merchcard {
     this.specialOffersTitlePromoText = this.specialOffers.locator('p[slot="body-xxs"]');
     this.specialOffersTitleHeading = this.specialOffers.locator('h3[slot="heading-xs"]').nth(0);
 
-    this.specialOffersDescription1 = this.specialOffers.locator('div[slot="body-xs"] p').nth(1);
-    this.specialOffersDescription2 = this.specialOffers.locator('div[slot="body-xs"] p').nth(2);
-    this.specialOffersDescription3 = this.specialOffers.locator('div[slot="body-xs"] p').nth(3);
+    this.specialOffersDescription1 = this.specialOffers.locator('div[slot="body-xs"] p').nth(0);
+    this.specialOffersDescription2 = this.specialOffers.locator('div[slot="body-xs"] p').nth(1);
+    this.specialOffersDescription3 = this.specialOffers.locator('div[slot="body-xs"] p').nth(2);
     this.specialOffersLinkText3 = this.specialOffersDescription3.locator('a').nth(0);
 
     this.seeTermsTextLink = this.merchCard.locator('a:has-text("See terms")');
@@ -54,9 +54,9 @@ export default class Merchcard {
     this.plansRibbon = this.plans.locator('.plans-badge');
     this.plansCardTitleHeadingXS = this.plans.locator('h3[slot="heading-xs"]');
     this.plansCardTitleBodyXXS = this.plans.locator('p[slot="body-xxs"]');
-    this.plansCardDescription1 = this.plans.locator('div[slot="body-xs"] p').nth(1);
-    this.plansCardDescription2 = this.plans.locator('div[slot="body-xs"] p').nth(2);
-    this.plansCardDescription3 = this.plans.locator('div[slot="body-xs"] p').nth(3);
+    this.plansCardDescription1 = this.plans.locator('div[slot="body-xs"] p').nth(0);
+    this.plansCardDescription2 = this.plans.locator('div[slot="body-xs"] p').nth(1);
+    this.plansCardDescription3 = this.plans.locator('div[slot="body-xs"] p').nth(2);
     this.seePlansTextLink = this.merchCard.locator('a:has-text("See plan & pricing details")');
 
     // merch-card catalog
@@ -73,7 +73,7 @@ export default class Merchcard {
 
     this.catalogCardTitleHeadingXS = this.catalog.locator('h3[slot="heading-xs"]');
     this.catalogCardTitleH4 = this.catalog.locator('p[slot="body-xxs"]');
-    this.catalogCardDescription2 = this.catalog.locator('div[slot="body-xs"] p').nth(2);
+    this.catalogCardDescription2 = this.catalog.locator('div[slot="body-xs"] p').nth(1);
     this.seeWhatsIncludedTextLink = this.merchCard.locator('a:has-text("See what’s included")');
     this.learnMoreTextLink = this.merchCard.locator('a:has-text("Learn more")');
 


### PR DESCRIPTION
Resolves: [MWPW-166878](https://jira.corp.adobe.com/browse/MWPW-166878)

* This should remove not only A link with empty content but any empty elements also from Merch cards.


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://MWPW-166878--milo--adobecom.hlx.page/?martech=off

**Test for consumer site:**
- Before: https://main--cc--adobecom.hlx.page/products/catalog?martech=off
- After: https://main--cc--adobecom.hlx.page/products/catalog?martech=off&milolibs=MWPW-166878
- Before: https://main--cc--adobecom.hlx.page/products/special-offers?martech=off
- After: https://main--cc--adobecom.hlx.page/products/special-offers?martech=off&milolibs=MWPW-166878