### PR TITLE
[MWPW-161562] Auto pause videos

### DIFF
--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -1,4 +1,5 @@
 import { decorateAnchorVideo } from '../../utils/decorate.js';
+import { createTag } from '../../utils/utils.js';
 
 export default function init(a) {
   a.classList.add('hide-video');
@@ -11,11 +12,36 @@ export default function init(a) {
       anchorTag: a,
     });
   } else {
-    const embed = `<div class="milo-video">
-      <iframe src="${a.href}" class="adobetv" webkitallowfullscreen mozallowfullscreen allowfullscreen scrolling="no" allow="encrypted-media" title="Adobe Video Publishing Cloud Player" loading="lazy">
-      </iframe>
-    </div>`;
-    a.insertAdjacentHTML('afterend', embed);
+    const iframe = createTag('iframe', {
+      src: a.href,
+      class: 'adobetv',
+      scrolling: 'no',
+      allow: 'encrypted-media; fullscreen',
+      title: 'Adobe Video Publishing Cloud Player',
+      loading: 'lazy',
+    });
+    const embed = createTag('div', { class: 'milo-video' }, iframe);
+    a.insertAdjacentElement('afterend', embed);
+
+    window.addEventListener('message', (event) => {
+      if (event.origin !== 'https://video.tv.adobe.com' || !event.data) return;
+      const { state, id } = event.data;
+      if (!['play', 'pause'].includes(state)
+        || !Number.isInteger(id)
+        || !iframe.src.startsWith(`${event.origin}/v/${id}`)) return;
+
+      iframe.setAttribute('data-playing', state === 'play');
+    });
+
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach(({ isIntersecting, target }) => {
+        if (!isIntersecting && target.getAttribute('data-playing') === 'true') {
+          target.contentWindow.postMessage({ type: 'mpcAction', action: 'pause' }, target.src);
+        }
+      });
+    }, { rootMargin: '0px' });
+    io.observe(iframe);
+
     a.remove();
   }
 }

--- a/libs/blocks/figure/figure.js
+++ b/libs/blocks/figure/figure.js
@@ -35,6 +35,14 @@ function decorateVideo(clone, figEl) {
       applyAccessibilityEvents(videoTag);
       decoratePausePlayWrapper(videoTag, 'autoplay');
     }
+    if (videoTag.controls) {
+      const io = new IntersectionObserver((entries) => {
+        entries.forEach(({ isIntersecting, target }) => {
+          if (!isIntersecting && !target.paused) target.pause();
+        });
+      }, { rootMargin: '0px' });
+      io.observe(videoTag);
+    }
     figEl.prepend(clone.querySelector('.video-container, .pause-play-wrapper, video'));
   }
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -271,7 +271,7 @@ export function addAccessibilityControl(videoString, videoAttrs, indexOfVideo, t
   return `
     <div class='video-container video-holder'>${videoString}
       <a class='pause-play-wrapper' role='button' tabindex=${tabIndex} aria-pressed=true video-index=${indexOfVideo}>
-        <div class='offset-filler ${videoAttrs.includes('autoplay') ? 'is-playing' : ''}'>  
+        <div class='offset-filler ${videoAttrs.includes('autoplay') ? 'is-playing' : ''}'>
           <img class='accessibility-control pause-icon' src='${fedRoot}/federal/assets/svgs/accessibility-pause.svg'/>
           <img class='accessibility-control play-icon' src='${fedRoot}/federal/assets/svgs/accessibility-play.svg'/>
         </div>
@@ -483,6 +483,15 @@ export function decorateAnchorVideo({ src = '', anchorTag }) {
       videoEl?.appendChild(createTag('source', { src, type: 'video/mp4' }));
     },
   });
+  if (videoEl.controls) {
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach(({ isIntersecting, target }) => {
+        if (!isIntersecting && !target.paused) target.pause();
+      });
+    }, { rootMargin: '0px' });
+    io.observe(videoEl);
+  }
+
   if (accessibilityEnabled) {
     applyAccessibilityEvents(videoEl);
     if (!videoEl.controls) {

--- a/nala/blocks/video/video.page.js
+++ b/nala/blocks/video/video.page.js
@@ -54,7 +54,7 @@ export default class Video {
       'iframe-mpc': {
         class: 'adobetv',
         scrolling: 'no',
-        allowfullscreen: '',
+        allow: 'encrypted-media; fullscreen',
         loading: 'lazy',
       },
       'iframe-youtube': {


### PR DESCRIPTION
This ensures that Sharepoint and MPC videos that aren't authored to be played automatically are paused when they are no longer in the viewport.

A few dev notes:

- although we already have a method to define intersection observers, it is currently set up to execute a callback only on intersection. For this requirement we need the exact opposite. I've fiddled around to augment the method from `utils.js`, but ultimately decided against it, since it created impractical overhead. We'd also have to call it twice under certain circumstances, since the `rootMargin` value is different;
- I've noticed that the `figure` block uses node cloning to decorate the content, I've created https://jira.corp.adobe.com/browse/MWPW-167455 to update this behavior

Resolves: [MWPW-161562](https://jira.corp.adobe.com/browse/MWPW-161562)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/anupama/pr/carousel/carousel-videos1?martech=off
- After: https://auto-pause-videos--milo--overmyheadandbody.hlx.page/drafts/anupama/pr/carousel/carousel-videos1?martech=off
