### PR TITLE
MWPW-164470: Console error dynamic nav

### DIFF
--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -137,5 +137,5 @@ export default async function main() {
     topNav.removeChild(statusWidget);
   });
 
-  fedsWrapper.after(statusWidget);
+  if (fedsWrapper) fedsWrapper.after(statusWidget);
 }

--- a/test/features/dynamic-nav/status.test.js
+++ b/test/features/dynamic-nav/status.test.js
@@ -48,6 +48,17 @@ describe('Dynamic Nav Status', () => {
     expect(statusWidget).to.exist;
   });
 
+  it('does not load the widget on when gnav v2 is not present', () => {
+    const feds = document.querySelector('.feds-nav-wrapper');
+    feds.classList.remove('feds-nav-wrapper');
+    dynamicNav();
+    status();
+
+    const statusWidget = document.querySelector('.dynamic-nav-status');
+    expect(statusWidget).to.be.null;
+    feds.classList.add('feds-nav-wrapper');
+  });
+
   it('loads the status widget', () => {
     dynamicNav();
     status();


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds a check for the feds nav wrapper element before appending. Error only occured on gnav v1 uses. 

Resolves: [MWPW-164470](https://jira.corp.adobe.com/browse/MWPW-164470)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://console-error-dynamic-nav--milo--jasonhowellslavin.aem.page/?martech=off

To see that error is gone: 
https://main--bacom-blog--adobecom.hlx.live/fr/blog/the-latest/deliver-winning-campaigns-at-speed-and-scale-with-adobe-genstudio-for-performance-marketing?milolibs=console-error-dynamic-nav
