### PR TITLE
[MEP] Update mep target message to include postlcp

### DIFF
--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -108,7 +108,7 @@ export function parsePageAndUrl(config, windowLocation, prefix) {
 function parseMepConfig() {
   const config = getConfig();
   const { mep, locale } = config;
-  const { experiments, targetEnabled, prefix, highlight } = mep;
+  const { experiments, prefix, highlight } = mep;
   const activities = experiments.map((experiment) => {
     const {
       name, event, manifest, variantNames, selectedVariantName, disabled, analyticsTitle, source,

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -134,7 +134,7 @@ function parseMepConfig() {
     page: {
       url,
       page,
-      target: targetEnabled ? 'on' : 'off',
+      target: getMetadata('target') || 'off',
       personalization: (getMetadata('personalization')) ? 'on' : 'off',
       geo: prefix === US_GEO ? '' : prefix,
       locale: locale.ietf,


### PR DESCRIPTION
Currently, the MEP button indicates the Target feature is "on" when it is actually set to 'postLCP'. 

Steps to Reproduce:

Go to URL
Open MEP button
Check Target integration status in Page Info section.

Expected Results: Target integration feature is on
................................
Actual Results: Target integration feature is postLCP

Resolves: [MWPW-167481](https://jira.corp.adobe.com/browse/MWPW-167481)

**Test URLs:**
- Psi-check: https://mepfixtargetmsg--milo--adobecom.aem.page/?martech=off
- Before: https://main--bacom--adobecom.hlx.page/products/adobe-analytics/customer-journey-analytics/actionable-intelligence
- After: https://main--bacom--adobecom.hlx.page/products/adobe-analytics/customer-journey-analytics/actionable-intelligence?milolibs=mepfixtargetmsg
