### PR TITLE
MWPW-166740: Add ABM label CCD card [NALA]

### DIFF
--- a/nala/features/mas/ccd/masccd.spec.js
+++ b/nala/features/mas/ccd/masccd.spec.js
@@ -32,6 +32,7 @@ module.exports = {
         description: 'Save over 65% on Photoshop and more than 20 apps for the first year. Plus get the first month on us when purchase by Sep 2',
         price: 'US$19.99/mo',
         strikethroughPrice: 'US$59.99/mo',
+        abmLabel: 'Annual, paid monthly',
         cta: 'Buy now',
         offerid: '951DCCB08194F40B9C79951675547DF5',
         linkText: 'See terms',

--- a/nala/features/mas/ccd/masccd.test.js
+++ b/nala/features/mas/ccd/masccd.test.js
@@ -83,7 +83,7 @@ test.describe('CCD Merchcard feature test suite', () => {
     });
   });
 
-  // @MAS-CCD-suggested-strikethrough : CCD suggested card with eyebrow, legal link and strikethrough price
+  // @MAS-CCD-suggested-strikethrough : CCD suggested card with eyebrow, legal link, strikethrough price and ABM price label
   test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
     const testPage = `${baseURL}${features[1].path}${miloLibs}`;
     const { data } = features[1];
@@ -113,6 +113,7 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardPrice(data.id, 'suggested')).toBeVisible();
       await expect(await CCD.getCardPrice(data.id, 'suggested')).toContainText(data.price);
       await expect(await CCD.getCardPrice(data.id, 'suggested')).toContainText(data.strikethroughPrice);
+      await expect(await CCD.getCardPrice(data.id, 'suggested')).toContainText(data.abmLabel);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);


### PR DESCRIPTION
This PR adds ABM label to Suggested card in NALA tests.

Resolves: [MWPW-166740](https://jira.corp.adobe.com/browse/MWPW-166740)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/libs/features/mas/docs/ccd.html?martech=off
- After: https://mwpw-166740--milo--adobecom.hlx.page/libs/features/mas/docs/ccd.html?martech=off
