### PR TITLE
[MWPW-165792] - Remove skip a11y flags

### DIFF
--- a/nala/blocks/accordion/accordion.test.js
+++ b/nala/blocks/accordion/accordion.test.js
@@ -147,8 +147,7 @@ test.describe('Milo Accordion Block test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the Accordion seo editorial block', async () => {
-      // The accessibility test for the Accordion seo editorial is failing, so skipping it.
-      await runAccessibilityTest({ page, testScope: accordion.accordion, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: accordion.accordion });
     });
   });
 });

--- a/nala/blocks/aside/aside.page.js
+++ b/nala/blocks/aside/aside.page.js
@@ -56,7 +56,6 @@ export default class Aside {
       background: {
         black: 'rgb(17, 17, 17)',
         darkGrey: 'rgb(171, 171, 171)',
-        lightGrey1: 'rgb(238, 238, 238)',
         lightGrey2: 'rgb(245, 245, 245)',
         lightGrey3: 'rgb(249, 249, 249)',
       },

--- a/nala/blocks/aside/aside.test.js
+++ b/nala/blocks/aside/aside.test.js
@@ -38,8 +38,7 @@ test.describe('Aside Block test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Small block', async () => {
-      // The accessibility test for the Aside Small is failing, so skipping it.
-      await runAccessibilityTest({ page, testScope: Aside.asideSmall, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: Aside.asideSmall });
     });
   });
 
@@ -73,7 +72,7 @@ test.describe('Aside Block test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Medium block', async () => {
-      await runAccessibilityTest({ page, testScope: Aside.asideMedium, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: Aside.asideMedium });
     });
   });
 
@@ -107,7 +106,7 @@ test.describe('Aside Block test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Large block', async () => {
-      await runAccessibilityTest({ page, testScope: Aside.asideLarge, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: Aside.asideLarge });
     });
   });
 
@@ -416,8 +415,7 @@ test.describe('Aside Block test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Notification Extra Small Dark block', async () => {
-      // The accessibility test for the AAside Notification Extra Small is failing, so skipping it.
-      await runAccessibilityTest({ page, testScope: Aside.asideNotifExtraSmallDark, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: Aside.asideNotifExtraSmallDark });
     });
   });
 

--- a/nala/blocks/aside/aside.test.js
+++ b/nala/blocks/aside/aside.test.js
@@ -415,7 +415,7 @@ test.describe('Aside Block test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Notification Extra Small Dark block', async () => {
-      await runAccessibilityTest({ page, testScope: Aside.asideNotifExtraSmallDark });
+      await runAccessibilityTest({ page, testScope: Aside.asideNotifExtraSmallDark, skipA11yTest: true });
     });
   });
 

--- a/nala/blocks/aside/aside.test.js
+++ b/nala/blocks/aside/aside.test.js
@@ -34,7 +34,7 @@ test.describe('Aside Block test suite', () => {
       const bgdColor = await Aside.asideSmall.evaluate(
         (e) => window.getComputedStyle(e).getPropertyValue('background-color'),
       );
-      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey3]).toContain(bgdColor);
+      expect(bgdColor).toBe(Aside.props.background.lightGrey3);
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Small block', async () => {
@@ -68,7 +68,7 @@ test.describe('Aside Block test suite', () => {
       expect(await Aside.actionButtons.count()).toEqual(2);
       // Check Aside block background:
       const bgdColor = await Aside.asideMedium.evaluate((e) => window.getComputedStyle(e).getPropertyValue('background-color'));
-      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey3]).toContain(bgdColor);
+      expect(bgdColor).toBe(Aside.props.background.lightGrey3);
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Medium block', async () => {
@@ -102,7 +102,7 @@ test.describe('Aside Block test suite', () => {
       expect(await Aside.actionButtons.count()).toEqual(2);
       // Check Aside block background:
       const bgdColor = await Aside.asideLarge.evaluate((e) => window.getComputedStyle(e).getPropertyValue('background-color'));
-      expect([Aside.props.background.lightGrey1, Aside.props.background.lightGrey3]).toContain(bgdColor);
+      expect(bgdColor).toBe(Aside.props.background.lightGrey3);
     });
 
     await test.step('step-3: Verify the accessibility test on the Aside Large block', async () => {

--- a/nala/blocks/carousel/carousel.test.js
+++ b/nala/blocks/carousel/carousel.test.js
@@ -53,7 +53,7 @@ test.describe('Milo Carousel Block test suite', () => {
 
     await test.step('step-4: Verify the accessibility test on the carousel block', async () => {
       // The accessibility test for the carousel container is failing, so skipping the test step
-      await runAccessibilityTest({ page, testScope: carousel.carouselContainer, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: carousel.carouselContainer });
     });
   });
 

--- a/nala/blocks/chart/chart.test.js
+++ b/nala/blocks/chart/chart.test.js
@@ -31,7 +31,7 @@ test.describe('Milo Chart feature test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the chart block', async () => {
-      await runAccessibilityTest({ page, testScope: chart.chart, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: chart.chart });
     });
   });
 
@@ -59,7 +59,7 @@ test.describe('Milo Chart feature test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the chart block', async () => {
-      await runAccessibilityTest({ page, testScope: chart.chart, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: chart.chart });
     });
   });
 
@@ -96,7 +96,7 @@ test.describe('Milo Chart feature test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the chart block', async () => {
-      await runAccessibilityTest({ page, testScope: chart.chart, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: chart.chart });
     });
   });
 
@@ -126,7 +126,7 @@ test.describe('Milo Chart feature test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the chart block', async () => {
-      await runAccessibilityTest({ page, testScope: chart.chart, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: chart.chart });
     });
   });
 
@@ -159,7 +159,7 @@ test.describe('Milo Chart feature test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the chart block', async () => {
-      await runAccessibilityTest({ page, testScope: chart.chart, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: chart.chart });
     });
   });
 
@@ -189,7 +189,7 @@ test.describe('Milo Chart feature test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the chart block', async () => {
-      await runAccessibilityTest({ page, testScope: chart.chart, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: chart.chart });
     });
   });
 
@@ -220,7 +220,7 @@ test.describe('Milo Chart feature test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the chart block', async () => {
-      await runAccessibilityTest({ page, testScope: chart.chart, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: chart.chart });
     });
   });
 });

--- a/nala/blocks/columns/columns.test.js
+++ b/nala/blocks/columns/columns.test.js
@@ -140,7 +140,7 @@ test.describe('Milo Columns Block test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the Columns(table) block', async () => {
-      await runAccessibilityTest({ page, testScope: column.column, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: column.column });
     });
   });
 

--- a/nala/blocks/figure/figure.test.js
+++ b/nala/blocks/figure/figure.test.js
@@ -53,9 +53,13 @@ test.describe('Milo Figure Block test suite', () => {
       await expect(await figureBlock.figCaption.nth(1)).toContainText(data.figCaption_2);
     });
 
-    await test.step('step-3: Verify the accessibility test on the Figure block', async () => {
-      // The accessibility test for the Figure block is failing, so skipping it.
-      await runAccessibilityTest({ page, testScope: figureBlock.figure, skipA11yTest: true });
+    await test.step('step-3: Verify the accessibility test on all Figure blocks', async () => {
+      const figureBlocks = await figureBlock.figure.all();
+
+      for (let i = 0; i < figureBlocks.length; i++) {
+        console.info(`Running accessibility test on Figure block #${i + 1}`);
+        await runAccessibilityTest({ page, testScope: figureBlocks[i] });
+      }
     });
   });
 });

--- a/nala/blocks/howto/howto.test.js
+++ b/nala/blocks/howto/howto.test.js
@@ -36,7 +36,7 @@ test.describe('Milo HowTo block test suite', () => {
 
     await test.step('step-3: Verify the accessibility test on the HowTo default block', async () => {
       // The accessibility test for the HowTo default block is failing, so skipping it.
-      await runAccessibilityTest({ page, testScope: howTo.howTo, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: howTo.howTo });
     });
   });
 

--- a/nala/blocks/marquee-anchors/marquee-anchors.test.js
+++ b/nala/blocks/marquee-anchors/marquee-anchors.test.js
@@ -77,7 +77,7 @@ test.describe('Milo Marquee Anchors test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the marquee anchors block', async () => {
-      await runAccessibilityTest({ page, testScope: marquee.marqueeAnchors, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: marquee.marqueeAnchors });
     });
   });
 
@@ -142,7 +142,7 @@ test.describe('Milo Marquee Anchors test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the marquee anchors (transparent) block', async () => {
-      await runAccessibilityTest({ page, testScope: marquee.marqueeAnchorsTransparent, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: marquee.marqueeAnchorsTransparent });
     });
   });
 });

--- a/nala/blocks/marquee/marquee.page.js
+++ b/nala/blocks/marquee/marquee.page.js
@@ -138,7 +138,7 @@ export default class Marquee {
         },
       },
       'marquee.split.one-third-large': {
-        style: /^background:\s+rgb\(245, 245, 245\)$/,
+        style: /^background:\s+rgb\(249, 249, 249\)$/,
         iconImg: {
           loading: 'eager',
           fetchpriority: 'high',

--- a/nala/blocks/marquee/marquee.test.js
+++ b/nala/blocks/marquee/marquee.test.js
@@ -404,7 +404,7 @@ test.describe('Milo Marquee Block test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the Marquee (split, large) block', async () => {
-      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitLarge });
+      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitLarge, skipA11yTest: true });
     });
   });
 
@@ -480,7 +480,7 @@ test.describe('Milo Marquee Block test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the Marquee (split, one-third) block', async () => {
-      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitOneThird });
+      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitOneThird, skipA11yTest: true });
     });
   });
 

--- a/nala/blocks/marquee/marquee.test.js
+++ b/nala/blocks/marquee/marquee.test.js
@@ -404,7 +404,7 @@ test.describe('Milo Marquee Block test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the Marquee (split, large) block', async () => {
-      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitLarge, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitLarge });
     });
   });
 
@@ -442,7 +442,7 @@ test.describe('Milo Marquee Block test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the Marquee (split, one-third, large, light) block', async () => {
-      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitOneThirdLargeLight, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitOneThirdLargeLight });
     });
   });
 
@@ -480,7 +480,7 @@ test.describe('Milo Marquee Block test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the Marquee (split, one-third) block', async () => {
-      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitOneThird, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitOneThird });
     });
   });
 
@@ -513,7 +513,7 @@ test.describe('Milo Marquee Block test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the Marquee (split,one-third,small,light) block', async () => {
-      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitOneThirdSmallLight, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: marquee.marqueeSplitOneThirdSmallLight });
     });
   });
 

--- a/nala/blocks/text/text.test.js
+++ b/nala/blocks/text/text.test.js
@@ -239,8 +239,7 @@ test.describe('Milo Text Block test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the text (legal) block', async () => {
-      // The accessibility test is failing, so skipping it.
-      await runAccessibilityTest({ page, testScope: text.textlegal, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: text.textlegal });
     });
   });
 

--- a/nala/blocks/text/text.test.js
+++ b/nala/blocks/text/text.test.js
@@ -239,7 +239,7 @@ test.describe('Milo Text Block test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on the text (legal) block', async () => {
-      await runAccessibilityTest({ page, testScope: text.textlegal });
+      await runAccessibilityTest({ page, testScope: text.textlegal, skipA11yTest: true });
     });
   });
 

--- a/nala/blocks/video/video.test.js
+++ b/nala/blocks/video/video.test.js
@@ -122,7 +122,7 @@ test.describe('Milo Video Block test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the MPC Video block', async () => {
-      await runAccessibilityTest({ page, testScope: video.miloVideo });
+      await runAccessibilityTest({ page, testScope: video.miloVideo, skipA11yTest: true });
     });
   });
 

--- a/nala/blocks/video/video.test.js
+++ b/nala/blocks/video/video.test.js
@@ -122,7 +122,7 @@ test.describe('Milo Video Block test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the MPC Video block', async () => {
-      await runAccessibilityTest({ page, testScope: video.miloVideo, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: video.miloVideo });
     });
   });
 

--- a/nala/blocks/zpattern/zpattern.test.js
+++ b/nala/blocks/zpattern/zpattern.test.js
@@ -52,9 +52,13 @@ test.describe('Milo Z Pattern Block test suite', () => {
       }
     });
 
-    await test.step('step-3: Verify the accessibility test on the ZPattern default block', async () => {
-      // The accessibility test is failing, so skipping it.
-      await runAccessibilityTest({ page, testScope: zpattern.mediaBlocks, skipA11yTest: true });
+    await test.step('step-3: Verify the accessibility test on all ZPattern media blocks', async () => {
+      const mediaBlocks = await zpattern.mediaBlocks.all();
+
+      for (const [index, mediaBlock] of mediaBlocks.entries()) {
+        console.info(`Running accessibility test on media block #${index + 1}`);
+        await runAccessibilityTest({ page, testScope: mediaBlock });
+      }
     });
   });
 
@@ -171,9 +175,13 @@ test.describe('Milo Z Pattern Block test suite', () => {
       }
     });
 
-    await test.step('step-3: Verify the accessibility test on the ZPattern dark block', async () => {
-      // The accessibility test is failing, so skipping it.
-      await runAccessibilityTest({ page, testScope: zpattern.mediaBlocks, skipA11yTest: true });
+    await test.step('step-3: Verify the accessibility test on all ZPattern dark blocks', async () => {
+      const mediaBlocks = await zpattern.mediaBlocks.all();
+
+      for (const [index, mediaBlock] of mediaBlocks.entries()) {
+        console.info(`Running accessibility test on media block #${index + 1}`);
+        await runAccessibilityTest({ page, testScope: mediaBlock });
+      }
     });
   });
 });

--- a/test/blocks/aside/aside.test.js
+++ b/test/blocks/aside/aside.test.js
@@ -20,7 +20,7 @@ describe('aside', () => {
 
     it('allows a background color', async () => {
       const el = await waitForElement('#test-default');
-      expect(window.getComputedStyle(el)?.backgroundColor).to.be.oneOf(['rgb(249, 249, 249)', 'rgb(238, 238, 238)']);
+      expect(window.getComputedStyle(el)?.backgroundColor).to.equal('rgb(249, 249, 249)');
     });
 
     it('allows a background image', async () => {

--- a/test/blocks/aside/mocks/standard.html
+++ b/test/blocks/aside/mocks/standard.html
@@ -1,6 +1,6 @@
 <div class="aside" id="test-default">
   <div>
-    <div data-valign="middle">#eeeeee</div>
+    <div data-valign="middle">#f9f9f9</div>
   </div>
   <div>
     <div data-valign="middle">


### PR DESCRIPTION
This PR removes skipA11yTest flag from tests where we can fix the a11y issue.

**Tests where skipA11yTest will be left on because of dark background class contrast issue with blue link:**
  
1. Aside - [Test Id - 11]
2. Marquee - [Test Id - 11], [Test id - 13]
3. Text - [Test Id - 6]

**Test where skipA11yTest will be left on because of Violation: Ensure all ARIA attributes have valid values**

1. Video - [Test Id - 4]

Resolves: [MWPW-165792](https://jira.corp.adobe.com/browse/MWPW-165792)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://remove-skip-a11y-flags--milo--adobecom.aem.page/?martech=off
