### PR TITLE
MWPW-166997 entire content of text is not seen in megamenu in portrait mode when the text is long

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -986,12 +986,13 @@ header.new-nav .feds-nav > section.feds-navItem > .feds-popup .title .breadcrumb
   box-sizing: inherit;
 }
 header.new-nav .feds-nav > section.feds-navItem > .feds-popup .title h7 {
-  height: 25px;
+  min-height: 25px;
   font-size: 28px;
   font-weight: 700;
   line-height: 25px;
   padding: 8px 0 24px;
   box-sizing: inherit;
+  white-space: break-spaces;
 }
 
 header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tabs {
@@ -1044,6 +1045,10 @@ header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content a {
   animation: slideup 0.6s ease, fadein 0.8s ease;
   animation-fill-mode: forwards;
   font-weight: 700;
+}
+
+header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content a.feds-navLink:not(:has(div)) {
+  white-space: break-spaces;
 }
 
 header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content .feds-navLink-title {


### PR DESCRIPTION


<!-- Before submitting, please review all open PRs. -->

* Added the rule `white-space: break-spaces` to the `h7` inside the title of the mobile mega menu
  * doing so necessitated changing the `height` of the `h7` to `min-height` to allow for the increase in height caused by a line break
* added the rule `white-space: break-spaces` to anchor elements with `.feds-navLink` that do not contain children divs. This had to be done to avoid other issues with linkgroups. 

Resolves: [MWPW-166997](https://jira.corp.adobe.com/browse/MWPW-166997)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mobile-gnav-wrap-links--milo--adobecom.aem.page/?martech=off

Test: https://main--homepage--adobecom.hlx.page/ua/homepage/index-loggedout?newNav=true&milolibs=mobile-gnav-wrap-links
