### PR TITLE
MWPW-167292: Fix aside promobar buttons overflow

### DIFF
--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -567,7 +567,7 @@
 }
 
 .aside.promobar .action-area .con-button {
-  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .aside.promobar .promo-text.desktop-up,


### PR DESCRIPTION
## Description


## Related Issue
Resolves: [MWPW-167292](https://jira.corp.adobe.com/browse/MWPW-167292)

## Testing instructions


## Screenshots (if appropriate):
![Screenshot 2025-02-12 at 13 05 26](https://github.com/user-attachments/assets/bd337767-4635-46f0-8322-597a31c058d5)
![Screenshot 2025-02-12 at 13 04 45](https://github.com/user-attachments/assets/1b7b0b78-4046-47cd-9757-da40a75585b3)

## Test URLs
**Milo:**
- Before: https://main--milo--adobecom.hlx.page/drafts/ratko/mwpw-167292/aside-promobar?martech=off
- After: https://mwpw-167292-aside-promobar-btn--milo--adobecom.hlx.page/drafts/ratko/mwpw-167292/aside-promobar?martech=off

