### PR TITLE
Apply width of active gnav element after bolding of text is done

### DIFF
--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -353,14 +353,13 @@ const decorateMenu = (config) => logErrorFor(async () => {
         config.template.classList.remove(selectors.deferredActiveNavItem.slice(1));
       };
 
+      config.template.classList.add(selectors.activeNavItem.slice(1));
       if (isDesktop.matches) {
         config.template.style.width = `${config.template.offsetWidth}px`;
         config.template.classList.add(selectors.deferredActiveNavItem.slice(1));
         isDesktop.addEventListener('change', resetActiveState, { once: true });
         window.addEventListener('feds:navOverflow', resetActiveState, { once: true });
       }
-
-      config.template.classList.add(selectors.activeNavItem.slice(1));
     }
 
     asyncDropDownCount += 1;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Applying width of active gnav element after bolding of text is done

Resolves: [MWPW-165143](https://jira.corp.adobe.com/browse/MWPW-165143)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-165143--milo--adobecom.aem.page/?martech=off


QA: 
- Before: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&authoringpath=/federal/dev/blaishram/learn-copy
- After: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&authoringpath=/federal/dev/blaishram/learn-copy&navbranch=MWPW-165143
