### PR TITLE
MWPW-165992 Fix Chart Font Family

### DIFF
--- a/libs/blocks/chart/chartLightTheme.js
+++ b/libs/blocks/chart/chartLightTheme.js
@@ -23,7 +23,7 @@ export default (deviceSize) => {
   const axisColor = '#767676';
   const options = {
     textStyle: {
-      fontFamily: 'Adobe Clean',
+      fontFamily: '"Adobe Clean", adobe-clean, "Trebuchet MS", sans-serif',
       fontSize: 16,
       fontWeight: 700,
     },


### PR DESCRIPTION
* Updates chart font family to match milo body font
* Fixes issue where incorrect font is sometimes seen on Safari

Resolves: [MWPW-165992](https://jira.corp.adobe.com/browse/MWPW-165992)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://chart-font--milo--meganthecoder.aem.page/drafts/methomas/chart-two-up?martech=off
