### PR TITLE
MWPW-167880 - Removing check for project param for the rollout plugin

### DIFF
--- a/libs/blocks/rollout/rollout.js
+++ b/libs/blocks/rollout/rollout.js
@@ -186,8 +186,8 @@ export default async function init(el, search = window.location.search) {
     const referrer = params?.get('referrer')?.trim();
     const host = params?.get('host')?.trim();
     const project = params?.get('project')?.trim();
-    if (!referrer || !project) {
-      el.innerHTML = '<div class="modal">Missing required parameters</div>';
+    if (!referrer) {
+      el.innerHTML = '<div class="modal">Missing required parameter referrer</div>';
       return false;
     }
 

--- a/test/blocks/rollout/rollout.test.js
+++ b/test/blocks/rollout/rollout.test.js
@@ -76,7 +76,7 @@ describe('Rollout', () => {
     const searchParams = createTestParams('');
     const result = await init(el, `?${searchParams.toString()}`);
     expect(result).to.be.false;
-    expect(el.innerHTML).to.equal('<div class="modal">Missing required parameters</div>');
+    expect(el.innerHTML).to.equal('<div class="modal">Missing required parameter referrer</div>');
   });
 
   it('should handle overrideBranch parameter', async () => {


### PR DESCRIPTION
Removed check for `project` parameter as its not being used in Milo Studio.

Resolves: https://jira.corp.adobe.com/browse/MWPW-167880

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://rollout-validation--milo--sabyamon.aem.page/?martech=off