### PR TITLE
[MWPW-159511] Create anchor (ID) elements

### DIFF
--- a/libs/blocks/marquee-anchors/marquee-anchors.js
+++ b/libs/blocks/marquee-anchors/marquee-anchors.js
@@ -16,7 +16,7 @@ const blockTypeSizes = {
 };
 
 const fetchedIcons = {};
-function decorateAnchors(anchors) {
+function decorateMarqueeAnchors(anchors) {
   const linkGroup = createTag('div', { class: 'links-group' });
   anchors[0].insertAdjacentElement('beforebegin', linkGroup);
   const { miloLibs, codeRoot } = getConfig();
@@ -79,5 +79,5 @@ export default function init(el) {
   });
 
   const anchors = el.querySelectorAll('.anchor-link');
-  if (anchors.length) decorateAnchors(anchors);
+  if (anchors.length) decorateMarqueeAnchors(anchors);
 }

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -893,6 +893,10 @@ a.static:active  {
 }
 
 /* Anchors */
+span.anchor {
+  pointer-events: none;
+}
+
 span.anchor:target::before {
   content: "";
   display: block;

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -892,6 +892,14 @@ a.static:active  {
   visibility: hidden;
 }
 
+/* Anchors */
+span.anchor:target::before {
+  content: "";
+  display: block;
+  height: 100px;
+  margin: -100px 0 0;
+}
+
 /* mobile only */
 @media (max-width: 600px) {
   .con-button.button-justified-mobile {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -833,7 +833,7 @@ async function decorateHeader() {
   }
 }
 
-async function decorateAnchors(area) {
+function decorateAnchors(area) {
   const anchors = area.querySelectorAll('span[class*="icon-anchor-"]');
   if (anchors.length === 0) return;
   anchors.forEach((anchor) => {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -835,7 +835,7 @@ async function decorateHeader() {
 
 function decorateAnchors(area) {
   const anchors = area.querySelectorAll('span[class*="icon-anchor-"]');
-  if (anchors.length === 0) return;
+  if (!anchors.length) return;
   anchors.forEach((anchor) => {
     anchor.id = anchor.classList[1].replace('icon-anchor-', '');
     anchor.classList.replace(anchor.classList[0], 'anchor');

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -833,6 +833,16 @@ async function decorateHeader() {
   }
 }
 
+async function decorateAnchors(area) {
+  const anchors = area.querySelectorAll('span[class*="icon-anchor-"]');
+  if (anchors.length === 0) return;
+  anchors.forEach((anchor) => {
+    anchor.id = anchor.classList[1].replace('icon-anchor-', '');
+    anchor.classList.replace(anchor.classList[0], 'anchor');
+    anchor.classList.replace(anchor.classList[1], `anchor-${anchor.id}`);
+  });
+}
+
 async function decorateIcons(area, config) {
   const icons = area.querySelectorAll('span.icon');
   if (icons.length === 0) return;
@@ -1380,6 +1390,7 @@ async function processSection(section, config, isDoc) {
   preloadBlockResources(section.preloadLinks);
   await Promise.all([
     decoratePlaceholders(section.el, config),
+    decorateAnchors(section.el),
     decorateIcons(section.el, config),
   ]);
   const loadBlocks = [...stylePromises];

--- a/test/utils/mocks/body.html
+++ b/test/utils/mocks/body.html
@@ -84,6 +84,11 @@
   </div>
   <!-- Default content -->
   <div>
+    <p>
+      <span class="icon icon-anchor-buy-adobe-photoshop"></span>
+    </p>
+  </div>
+  <div>
     <p>I'm not a blockhead.</p>
     <p>{{&nbsp;inkl. MwSt.}}</p>
   </div>

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -158,6 +158,16 @@ describe('Utils', () => {
       });
     });
 
+    describe('Anchors', () => {
+      it('decorates anchors with the proper id', () => {
+        const anchor = document.querySelector('span.anchor');
+        expect(anchor).to.exist;
+        expect(anchor.classList.contains('icon')).to.be.false;
+        expect(anchor.classList.contains(`anchor-${anchor.id}`)).to.be.true;
+        expect(anchor.id).to.exist;
+      });
+    });
+
     describe('PDF Viewer', () => {
       it('pdf link with different text content opens in new window', () => {
         const link = document.querySelector('a[href$="pdf"]');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
This is a new feature that allows authors to create anchor elements by using specific markup `:anchor-id-of-the-anchor:`. The element is transformed by EDS into `<span class="icon icon-anchor-id-of-the-anchor"></span>` and then transformed by custom code into `<span class="anchor anchor-id-of-the-anchor" id="id-of-the-anchor"></span>`.
The anchor can be referenced as `#id-of-the-anchor` in the URL or via href.

Resolves: [MWPW-159511](https://jira.corp.adobe.com/browse/MWPW-159511)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/narcis/anchors?martech=off
- After: https://anchor--milo--narcis-radu.aem.page/drafts/narcis/anchors?martech=off
