### PR TITLE
MWPW-167928 Override Marketo POI

### DIFF
--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -40,6 +40,8 @@ const FORM_MAP = {
   'success-section': SUCCESS_SECTION,
   'co-partner-names': 'program.copartnernames',
   'sfdc-campaign-id': 'program.campaignids.sfdc',
+  'poi-field': 'field_filters.products',
+  'hardcoded-poi': 'program.poi',
 };
 export const FORM_PARAM = 'form';
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Allow setting Marketo POI values on the block level

Resolves: [MWPW-167928](https://jira.corp.adobe.com/browse/MWPW-167928)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/bmarshal/marketo/poi?martech=off&preview=1
- After: https://bmarshal-poi--milo--adobecom.aem.page/drafts/bmarshal/marketo/poi?martech=off&preview=1
