### PR TITLE
[MWPW-162639] youtube block a tag fix

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -264,7 +264,9 @@ export const [setConfig, updateConfig, getConfig] = (() => {
 })();
 
 export function isInTextNode(node) {
-  return (node.parentElement.children.length > 1 && node.parentElement.firstChild.tagName === 'A') || node.parentElement.firstChild.nodeType === Node.TEXT_NODE;
+  console.log('node.parentElement.children.length', node.parentElement.children.length);
+  
+  return (node.parentElement.childNodes.length > 1 && node.parentElement.firstChild.tagName === 'A') || node.parentElement.firstChild.nodeType === Node.TEXT_NODE;
 }
 
 export function createTag(tag, attributes, html, options = {}) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -264,8 +264,6 @@ export const [setConfig, updateConfig, getConfig] = (() => {
 })();
 
 export function isInTextNode(node) {
-  console.log('node.parentElement.children.length', node.parentElement.children.length);
-  
   return (node.parentElement.childNodes.length > 1 && node.parentElement.firstChild.tagName === 'A') || node.parentElement.firstChild.nodeType === Node.TEXT_NODE;
 }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -264,7 +264,7 @@ export const [setConfig, updateConfig, getConfig] = (() => {
 })();
 
 export function isInTextNode(node) {
-  return node.parentElement.firstChild.tagName === 'A' || node.parentElement.firstChild.nodeType === Node.TEXT_NODE;
+  return (node.parentElement.children.length > 1 && node.parentElement.firstChild.tagName === 'A') || node.parentElement.firstChild.nodeType === Node.TEXT_NODE;
 }
 
 export function createTag(tag, attributes, html, options = {}) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -264,7 +264,7 @@ export const [setConfig, updateConfig, getConfig] = (() => {
 })();
 
 export function isInTextNode(node) {
-  return node.parentElement.firstChild.nodeType === Node.TEXT_NODE;
+  return node.parentElement.firstChild.tagName === 'A' || node.parentElement.firstChild.nodeType === Node.TEXT_NODE;
 }
 
 export function createTag(tag, attributes, html, options = {}) {


### PR DESCRIPTION
This resolves the issue where the youtube link was being processed into a block because the link was first in the paragraph and not text.

Resolves: [MWPW-162639](https://jira.corp.adobe.com/browse/MWPW-162639)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/cpeyer/temp/og-issue?martech=off
- After: https://inline-youtube-link--milo--adobecom.aem.page/drafts/cpeyer/temp/og-issue?martech=off