### PR TITLE
MWPW-168109: do not modify absolute path to a script hosted in DAM when using insertScript action

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -64,8 +64,13 @@ export const DATA_TYPE = {
 
 const IN_BLOCK_SELECTOR_PREFIX = 'in-block:';
 
+const isDamContent = (path) => path?.includes('/content/dam/');
+
 export const normalizePath = (p, localize = true) => {
   let path = p;
+
+  // do not change(normalize) DAM content link's domain, since DAM content links are PROD only
+  if (isDamContent(path)) return path;
 
   if (!path?.includes('/')) {
     return path;
@@ -1195,7 +1200,7 @@ function sendTargetResponseAnalytics(failure, responseStart, timeoutLocal, messa
         },
       },
       data:
-       { _adobe_corpnew: { digitalData: { primaryEvent: { eventInfo: { eventName: val } } } } },
+        { _adobe_corpnew: { digitalData: { primaryEvent: { eventInfo: { eventName: val } } } } },
     });
   }, { once: true });
 }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -69,12 +69,7 @@ const isDamContent = (path) => path?.includes('/content/dam/');
 export const normalizePath = (p, localize = true) => {
   let path = p;
 
-  // do not change(normalize) DAM content link's domain, since DAM content links are PROD only
-  if (isDamContent(path)) return path;
-
-  if (!path?.includes('/')) {
-    return path;
-  }
+  if (isDamContent(path) || !path?.includes('/')) return path;
 
   const config = getConfig();
   if (path.startsWith('https://www.adobe.com/federal/')) {

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -3,7 +3,7 @@ import { readFile } from '@web/test-runner-commands';
 import { assert, stub } from 'sinon';
 import { getConfig, setConfig } from '../../../libs/utils/utils.js';
 import {
-  handleFragmentCommand, applyPers, cleanAndSortManifestList,
+  handleFragmentCommand, applyPers, cleanAndSortManifestList, normalizePath,
   init, matchGlob, createContent, combineMepSources, buildVariantInfo,
 } from '../../../libs/features/personalization/personalization.js';
 import mepSettings from './mepSettings.js';
@@ -88,6 +88,13 @@ describe('Functional Test', () => {
 
     expect(document.querySelector('.custom-block-1')).to.be.null;
     expect(document.querySelector('.custom-block-2')).to.be.null;
+  });
+
+  it('should not normalize (later) absolute path to a script file, if the file is hosted in DAM', async () => {
+    const DAMpath = 'https://www.adobe.com/content/dam/cc/optimization/mwpw-168109/test.js';
+    const nonDAMpath = 'https://www.adobe.com/foo/test.js';
+    expect(normalizePath(DAMpath)).to.include('https://www.adobe.com');
+    expect(normalizePath(nonDAMpath)).to.not.include('https://www.adobe.com');
   });
 
   it('scheduled manifest should apply changes if active (bts)', async () => {

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -90,7 +90,7 @@ describe('Functional Test', () => {
     expect(document.querySelector('.custom-block-2')).to.be.null;
   });
 
-  it('should not normalize (later) absolute path to a script file, if the file is hosted in DAM', async () => {
+  it('should not normalize absolute path to a script file, if the file is hosted in DAM', async () => {
     const DAMpath = 'https://www.adobe.com/content/dam/cc/optimization/mwpw-168109/test.js';
     const nonDAMpath = 'https://www.adobe.com/foo/test.js';
     expect(normalizePath(DAMpath)).to.include('https://www.adobe.com');


### PR DESCRIPTION
* Prevents modifying the absolute path to a script hosted in DAM when using insertScript action

Resolves: [MWPW-168109](https://jira.corp.adobe.com/browse/MWPW-168109)

**Test URLs:**
- Psi check: https://insert-script-abs-path--milo--adobecom.aem.page/?martech=off

QA links :

- Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/tests/2025/q1/insert-script-absolute-path/marquee

- After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/tests/2025/q1/insert-script-absolute-path/marquee?milolibs=insert-script-abs-path ( you should see a h1  tag at the bottom of the page saying `I am an appended header via an external script!` and the network tab should show that test.js came from acom not the preview domain)
