### PR TITLE
Upgrading standalone gnav version to 0.0.5

### DIFF
--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Upgrading standalone gnav version to 0.0.5

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-version--milo--adobecom.aem.page/?martech=off
