### PR TITLE
[MWPW-159511] Create anchor (ID) elements

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -55,6 +55,12 @@ function handleDelay(time, section) {
   setTimeout(() => { section.classList.remove('hide-sticky-section'); }, getDelayTime(time));
 }
 
+function handleAnchor(anchor, section) {
+  if (!(anchor || section)) return;
+  section.id = anchor;
+  section.classList.add('section-anchor');
+}
+
 export const getMetadata = (el) => [...el.childNodes].reduce((rdx, row) => {
   if (row.children) {
     const key = row.children[0].textContent.trim().toLowerCase();
@@ -73,4 +79,5 @@ export default async function init(el) {
   if (metadata.layout) handleLayout(metadata.layout.text, section);
   if (metadata.masonry) handleMasonry(metadata.masonry.text, section);
   if (metadata.delay) handleDelay(metadata.delay.text, section);
+  if (metadata.anchor) handleAnchor(metadata.anchor.text, section);
 }

--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -56,7 +56,7 @@ function handleDelay(time, section) {
 }
 
 function handleAnchor(anchor, section) {
-  if (!(anchor || section)) return;
+  if (!anchor || !section) return;
   section.id = anchor;
   section.classList.add('section-anchor');
 }

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -892,6 +892,17 @@ a.static:active  {
   visibility: hidden;
 }
 
+/* Anchors */
+.section-anchor {
+  scroll-margin-top: 64px;
+}
+
+@media screen and (min-width: 600px) {
+  .global-navigation.has-breadcrumbs + main .section-anchor {
+    scroll-margin-top: 97px;
+  }
+}
+
 /* mobile only */
 @media (max-width: 600px) {
   .con-button.button-justified-mobile {

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -894,12 +894,12 @@ a.static:active  {
 
 /* Anchors */
 .section-anchor {
-  scroll-margin-top: 64px;
+  scroll-margin-top: var(--global-height-nav);
 }
 
 @media screen and (min-width: 600px) {
   .global-navigation.has-breadcrumbs + main .section-anchor {
-    scroll-margin-top: 97px;
+    scroll-margin-top: var(--feds-totalheight-nav);
   }
 }
 

--- a/test/blocks/section-metadata/mocks/body.html
+++ b/test/blocks/section-metadata/mocks/body.html
@@ -190,5 +190,13 @@
       </div>
     </div>
   </div>
+  <div class="section anchor">
+    <div class="section-metadata">
+      <div>
+        <div>anchor</div>
+        <div>anchor-test</div>
+      </div>
+    </div>
+  </div>
 </main>
 <footer></footer>

--- a/test/blocks/section-metadata/section-meta.test.js
+++ b/test/blocks/section-metadata/section-meta.test.js
@@ -118,4 +118,12 @@ describe('Section Metdata', () => {
     await delay(700);
     expect(sec.style.top).to.be.eql('77px');
   });
+
+  it('adds an anchor', async () => {
+    const sec = document.querySelector('.section.anchor');
+    const sm = sec.querySelector('.section-metadata');
+    await init(sm);
+    expect(sec.id).to.be.eql('anchor-test');
+    expect(sec.classList.contains('section-anchor')).to.be.true;
+  });
 });


### PR DESCRIPTION
New feature that allows authors to set anchors using section metadata. The [previous PR](https://github.com/adobecom/milo/pull/3694) has been closed in favour of this approach.

Resolves: [MWPW-159511](https://jira.corp.adobe.com/browse/MWPW-159511)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://anchor2--milo--narcis-radu.aem.page/?martech=off

Test URL - https://anchor2--milo--narcis-radu.aem.page/drafts/narcis/anchors/default
