### PR TITLE
[MWPW-167752] Loop focus in modals containing iframes

### DIFF
--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -36,7 +36,7 @@ export default function init(a) {
     const io = new IntersectionObserver((entries) => {
       entries.forEach(({ isIntersecting, target }) => {
         if (!isIntersecting && target.getAttribute('data-playing') === 'true') {
-          target.contentWindow.postMessage({ type: 'mpcAction', action: 'pause' }, target.src);
+          target.contentWindow?.postMessage({ type: 'mpcAction', action: 'pause' }, target.src);
         }
       });
     }, { rootMargin: '0px' });

--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -125,6 +125,10 @@
   outline: 2px solid var(--modal-focus-color);
 }
 
+.dialog-focus-placeholder {
+  height: 0;
+}
+
 .dialog-modal .section > .content {
   max-width: initial;
 }

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -3,7 +3,7 @@
 import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../utils/utils.js';
 import { decorateSectionAnalytics } from '../../martech/attributes.js';
 
-const FOCUSABLES = 'a:not(.hide-video), button, input, textarea, select, details, [tabindex]:not([tabindex="-1"]';
+const FOCUSABLES = 'a:not(.hide-video), button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
 const CLOSE_ICON = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
   <g transform="translate(-10500 3403)">
     <circle cx="10" cy="10" r="10" transform="translate(10500 -3403)" fill="#707070"/>
@@ -139,6 +139,7 @@ export async function getModal(details, custom) {
     'aria-label': 'Close',
     'daa-ll': `${analyticsEventName}:modalClose:buttonClose`,
   }, CLOSE_ICON);
+  const focusPlaceholder = createTag('div', { class: 'dialog-focus-placeholder', tabindex: 0 });
 
   const focusVisible = { focusVisible: true };
   const focusablesOnLoad = [...dialog.querySelectorAll(FOCUSABLES)];
@@ -154,20 +155,17 @@ export async function getModal(details, custom) {
     firstFocusable = close;
   }
 
-  dialog.addEventListener('keydown', (event) => {
-    const isShiftKey = event.shiftKey;
-    const isTab = event.key === 'Tab';
-    const isCloseActive = document.activeElement === close;
+  let shiftTabOnClose = false;
 
-    if (!isShiftKey && isTab && isCloseActive) {
-      event.preventDefault();
-      firstFocusable.focus(focusVisible);
-    }
+  close.addEventListener('keydown', (event) => {
+    if (event.key !== 'Tab' || !event.shiftKey) return;
+    shiftTabOnClose = true;
+    focusPlaceholder.focus(focusVisible);
+  });
 
-    if (isTab && isShiftKey && document.activeElement === firstFocusable) {
-      event.preventDefault();
-      close.focus(focusVisible);
-    }
+  focusPlaceholder.addEventListener('focus', () => {
+    if (!shiftTabOnClose) close.focus(focusVisible);
+    shiftTabOnClose = false;
   });
 
   close.addEventListener('click', (e) => {
@@ -181,7 +179,8 @@ export async function getModal(details, custom) {
     }
   });
   decorateSectionAnalytics(dialog, `${id}-modal`, getConfig());
-  dialog.append(close);
+  dialog.prepend(close);
+  dialog.append(focusPlaceholder);
   document.body.append(dialog);
   dialogLoadingSet.delete(id);
   firstFocusable.focus({ preventScroll: true, ...focusVisible });

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -112,7 +112,7 @@ describe('Modals', () => {
     const modal = document.getElementById('milo');
     expect(modal).to.exist;
     expect(modal.getAttribute('daa-lh')).to.equal('milo-modal');
-    const buttons = modal.querySelectorAll('button');
+    const buttons = modal.querySelectorAll('button[id]');
     expect(buttons[0].getAttribute('daa-ll')).to.equal('Milo Button 1-1--Milo');
     expect(buttons[1].getAttribute('daa-ll')).to.equal('Milo Button 2-2--Milo');
     window.location.hash = '';


### PR DESCRIPTION
This ensures all elements within a modal window are focusable and that focus seamlessly loops through them.

Additionally, it fixes an issue that is logging a console error when a modal containing an MPC video is closed.

QA note: this change adds the close button a bit earlier in the markup. I wasn't able to find proof that this has any impact, but it should be checked nevertheless.

Resolves: [MWPW-167752](https://jira.corp.adobe.com/browse/MWPW-167752)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/mpc-in-modal?martech=off
- After: https://loop-modal-focus--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/mpc-in-modal?martech=off

**Initial page where issue was reported, click "Watch the video":**
- Before: https://main--cc--adobecom.hlx.page/products/firefly?martech=off
- After: https://main--cc--adobecom.hlx.page/products/firefly?milolibs=loop-modal-focus--milo--overmyheadandbody&martech=off