### PR TITLE
[MWPW-168268] Correct RCP dates in Slack comms

### DIFF
--- a/.github/workflows/rcp-notifier.js
+++ b/.github/workflows/rcp-notifier.js
@@ -29,13 +29,13 @@ const main = async () => {
     const slackText = (days) =>
       `Reminder RCP starts in ${days} days: from ${start.toUTCString()} to ${end.toUTCString()}. Merges to stage will be disabled beginning ${calculateDateOffset(start, stageOffset).toUTCString()}.`;
     if (isWithin24Hours(firstNoticeOffset) && !isShort) {
-      console.log('Is within 24 hours of 10 days before RCP');
-      await slackNotification(slackText(10), process.env.MILO_DEV_HOOK);
+      console.log('Is within 24 hours of 13 days before RCP');
+      await slackNotification(slackText(13), process.env.MILO_DEV_HOOK);
     }
 
     if (isWithin24Hours(lastNoticeOffset) && !isShort) {
-      console.log('Is within 24 hours of 4 days before RCP');
-      await slackNotification(slackText(4), process.env.MILO_DEV_HOOK);
+      console.log('Is within 24 hours of 6 days before RCP');
+      await slackNotification(slackText(6), process.env.MILO_DEV_HOOK);
     }
   }
 


### PR DESCRIPTION
This updates the Slack message sent out for upcoming RCPs. Currently it sends the message on the correct days (13/6 days before) with the wrong remaining days (10/4 days).

Resolves: [MWPW-168268](https://jira.corp.adobe.com/browse/MWPW-168268)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/?martech=off
- After: https://rcp-msg-erratum--milo--overmyheadandbody.aem.page/?martech=off
