### PR TITLE
MWPW-163228: Preflight svg issue

### DIFF
--- a/libs/blocks/preflight/panels/general.js
+++ b/libs/blocks/preflight/panels/general.js
@@ -8,6 +8,7 @@ const NOT_FOUND = {
   live: { lastModified: DEF_NOT_FOUND },
 };
 const DA_DOMAIN = 'da.live';
+const nonEDSContent = 'Non AEM EDS Content';
 
 const content = signal({});
 
@@ -21,22 +22,19 @@ function getAdminUrl(url, type) {
 
 async function getStatus(url) {
   const adminUrl = getAdminUrl(url, 'status');
-  const urlToFetch = adminUrl || url;
-  let resp;
-  try {
-    resp = await fetch(urlToFetch);
-  } catch (e) {
-    console.log('Erorr making request, cors', e);
+  if (!adminUrl) {
+    const resp = await fetch(url);
+    if (!resp.ok) return {};
     return {
       url,
       edit: null,
-      preview: 'N/A',
-      live: 'N/A',
-      publish: 'N/A',
+      preview: nonEDSContent,
+      live: nonEDSContent,
+      publish: nonEDSContent,
     };
   }
+  const resp = await fetch(adminUrl);
   if (!resp.ok) return {};
-  console.log(resp);
   const json = await resp.json();
   const preview = json.preview.lastModified || DEF_NEVER;
   const live = json.live.lastModified || DEF_NEVER;
@@ -186,7 +184,7 @@ function usePublishProps(item) {
 function Item({ name, item, idx }) {
   const { publishText, disablePublish } = usePublishProps(item);
   const isChecked = item.checked ? ' is-checked' : '';
-  const isFetching = item.edit || item.preview === 'N/A' ? '' : ' is-fetching';
+  const isFetching = item.edit || item.preview === nonEDSContent ? '' : ' is-fetching';
   const editIcon = item.edit && item.edit.includes(DA_DOMAIN) ? 'da-icon' : 'sharepoint-icon';
   if (!item.url) return undefined;
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds a check for urls picked up while using the preflight tool to see if they are part of the AEM EDS / Helix 5 content bus

Resolves: [MWPW-163228](https://jira.corp.adobe.com/browse/MWPW-163228)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://preflight-svg-issue--milo--jasonhowellslavin.aem.page/?martech=off

The SVG will not load in milo, in order to test it should be done on bacom in the following pages:
- https://main--bacom--adobecom.hlx.page/products/journey-optimizer/journey-orchestration
- https://main--bacom--adobecom.hlx.page/products/journey-optimizer/journey-orchestration?milolibs=preflight-svg-issue
