### PR TITLE
[MWPW-168422] Fix for broken single rollout functionality

### DIFF
--- a/libs/blocks/locui-create/locui-create.js
+++ b/libs/blocks/locui-create/locui-create.js
@@ -50,6 +50,7 @@ function Create() {
           }
         }
         if (projectInitByUrl && !projectKey) {
+          setUserWorkflowType('singleRollout');
           setProject(projectInitByUrl);
           setInitByParams(projectInitByUrl);
           setSelectedLocalesAndRegions();


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fix blocker for singe rollout functionality.
* For single rollout, list of urls are non editable and pre populated, locale are pre populated.

Resolves: [MWPW-168422](https://jira.corp.adobe.com/browse/MWPW-168422)

**Test URLs:**
- Before: https://milostudio-stage--milo--adobecom.hlx.page/drafts/sircar/locui-create?martech=off
- After: https://MWPW-168422-single-rollout-bug--milo--maagrawal16.hlx.page/drafts/sircar/locui-create?martech=off
