### PR TITLE
Adding onReady and onError callback for standalone footer

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -76,7 +76,16 @@ class Footer {
       shouldDecorateLinks: false,
     });
 
-    if (!this.body) return;
+    if (!this.body) {
+      const error = new Error('Could not create global footer. Content not found!');
+      error.tags = 'global-footer';
+      error.url = url;
+      error.errorType = 'error';
+      lanaLog({ message: error.message, ...error });
+      const { onFooterError } = getConfig();
+      onFooterError?.(error);
+      return;
+    }
 
     const [region, social] = ['.region-selector', '.social'].map((selector) => this.body.querySelector(selector));
     const [regionParent, socialParent] = [region?.parentElement, social?.parentElement];
@@ -112,8 +121,9 @@ class Footer {
 
     const mepMartech = mep?.martech || '';
     this.block.setAttribute('daa-lh', `gnav|${getExperienceName()}|footer${mepMartech}`);
-
     this.block.append(this.elements.footer);
+    const { onFooterReady } = getConfig();
+    onFooterReady?.();
   }, 'Failed to decorate footer content', 'global-footer', 'error');
 
   loadMenuLogic = async () => {

--- a/libs/navigation/bootstrapper.js
+++ b/libs/navigation/bootstrapper.js
@@ -25,6 +25,7 @@ export default async function bootstrapBlock(initBlock, blockConfig) {
       { key: 'unavComponents', name: 'universal-nav' },
       { key: 'redirect', name: 'adobe-home-redirect' },
       { key: 'mobileGnavV2', name: 'mobile-gnav-v2' },
+      { key: 'footerSource', name: 'footer-source' },
     ];
     metaTags.forEach((tag) => {
       const { key } = tag;

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -159,7 +159,8 @@ export default async function loadBlock(configs, customLib) {
             errorType: e.errorType,
           });
         }
-      } else if (block.key === 'footer') {
+      }
+      if (block.key === 'footer') {
         try {
           await import('./footer.css');
         } catch (e) {

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -131,11 +131,11 @@ export default async function loadBlock(configs, customLib) {
   setConfig(clientConfig);
   for await (const block of blockConfig) {
     const configBlock = configs[block.key];
-    const config = getConfig();
-    const gnavSource = `${config?.locale?.contentRoot}/gnav`;
-    const footerSource = `${config?.locale?.contentRoot}/footer`;
 
     if (configBlock) {
+      const config = getConfig();
+      const gnavSource = `${config?.locale?.contentRoot}/gnav`;
+      const footerSource = `${config?.locale?.contentRoot}/footer`;
       if (block.key === 'header') {
         try {
           const { default: init } = await import('../blocks/global-navigation/global-navigation.js');
@@ -161,11 +161,9 @@ export default async function loadBlock(configs, customLib) {
         }
       }
       if (block.key === 'footer') {
-        try {
-          await import('./footer.css');
-        } catch (e) {
+        import('./footer.css').catch(() => {
           loadStyle(`${miloLibs}/libs/navigation/footer.css`);
-        }
+        });
         try {
           const { default: init } = await import('../blocks/global-footer/global-footer.js');
           await bootstrapBlock(init, { ...block, footerSource });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding onError and onReady call specific to header and footer component
* Since footer's init has a setTimeout, we cannot call the onError and onReady like header in the try/catch. It has to be called from the component itself.

Resolves: [MWPW-159105](https://jira.corp.adobe.com/browse/MWPW-159105)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://footer-callback--milo--adobecom.aem.page/?martech=off

QA: https://adobecom.github.io/nav-consumer/?env=stage&authoringpath=/federal/home&navbranch=footer-callback
