### PR TITLE
MWPW-166689 Add video support to Article Header

### DIFF
--- a/libs/blocks/article-header/article-header.css
+++ b/libs/blocks/article-header/article-header.css
@@ -181,7 +181,8 @@
   background: yellow;
 }
 
-.article-feature-image {
+.article-feature-image,
+.article-feature-video {
   padding: 0;
   margin: auto;
   width: 100%;
@@ -196,6 +197,11 @@
   width: 100%;
   max-height: 580px;
   object-fit: cover;
+}
+
+.article-feature-video .video-container,
+.article-feature-video video {
+  width: 100%;
 }
 
 @media (min-width: 480px) {
@@ -217,6 +223,17 @@
 
   .article-byline .article-byline-sharing span:not(:last-child) {
     margin-right: 8px;
+  }
+
+  .article-feature-video .milo-video,
+  .article-feature-video .embed-vimeo {
+    padding-bottom: 580px;
+  }
+
+  .article-feature-video lite-vimeo,
+  .article-feature-video video {
+    height: 580px;
+    width: 100%;
   }
 }
 

--- a/libs/blocks/article-header/article-header.js
+++ b/libs/blocks/article-header/article-header.js
@@ -182,6 +182,15 @@ function decorateFigure(el) {
   el.lastElementChild.remove();
 }
 
+function decorateMedia(el) {
+  if (el.querySelector('picture')) {
+    decorateFigure(el);
+    return;
+  }
+
+  el.classList.add('article-feature-video');
+}
+
 export default async function init(blockEl) {
   const childrenEls = Array.from(blockEl.children);
   const categoryContainer = childrenEls[0];
@@ -214,8 +223,8 @@ export default async function init(blockEl) {
   const shareBlock = await buildSharing();
   bylineContainer.append(shareBlock);
 
-  const featureImgContainer = childrenEls[3];
-  decorateFigure(featureImgContainer);
+  const mediaContainer = childrenEls[3];
+  decorateMedia(mediaContainer);
 
   document.addEventListener('milo:deferred', () => updateShareText(shareBlock));
 }

--- a/test/blocks/article-header/article-header.test.js
+++ b/test/blocks/article-header/article-header.test.js
@@ -157,4 +157,11 @@ describe('article header', () => {
     await init(document.body.querySelector('.article-header'));
     expect(document.body.querySelector('.article-category a')).to.be.null;
   });
+
+  it('supports a featured video', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-video.html' });
+    const el = document.body.querySelector('.article-header');
+    await init(el);
+    expect(el.querySelector('.article-feature-video video')).to.exist;
+  });
 });

--- a/test/blocks/article-header/mocks/body-video.html
+++ b/test/blocks/article-header/mocks/body-video.html
@@ -1,0 +1,21 @@
+<div class="article-header">
+  <div>
+    <div>
+      <p><a href="" data-topic-link="Adobe Life">Adobe Life</a></p>
+    </div>
+  </div>
+  <div>
+    <div>
+      <h1 id="connecting-external-data-sources-to-adobe-experience-manager-guides-is-now-a-breeze">Connecting external data sources to Adobe Experience Manager Guides is now a breeze</h1>
+    </div>
+  </div>
+  <div>
+    <div>
+      <p><a href="/test/blocks/article-header/mocks/adobe-communication-team">Adobe Communications Team</a></p>
+      <p>02-25-2025</p>
+    </div>
+  </div>
+  <div>
+    <div><video playsinline="" controls="" data-video-source=""></video></div>
+  </div>
+</div>


### PR DESCRIPTION
* Allow videos in the Article Header
* Has the same video features across milo: https://milo.adobe.com/docs/authoring/videos (with the exception that uploaded mp4s aren't supported in DA)

Resolves: [MWPW-166689](https://jira.corp.adobe.com/browse/MWPW-166689)

**Test URLs:**
MP4:
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/article-header-mp4?martech=off
- After: https://article-header-video--milo--meganthecoder.aem.page/drafts/methomas/article-header-mp4?martech=off

More examples in comment below