### PR TITLE
MWPW-165992 Chart inherit font

### DIFF
--- a/libs/blocks/chart/chartLightTheme.js
+++ b/libs/blocks/chart/chartLightTheme.js
@@ -23,7 +23,7 @@ export default (deviceSize) => {
   const axisColor = '#767676';
   const options = {
     textStyle: {
-      fontFamily: '"Adobe Clean", adobe-clean, "Trebuchet MS", sans-serif',
+      fontFamily: 'inherit',
       fontSize: 16,
       fontWeight: 700,
     },


### PR DESCRIPTION
* Have Chart inherit the font family rather than it being explicitly set
* Follow-up from https://github.com/adobecom/milo/pull/3685#discussion_r1963743810

Resolves: [MWPW-165992](https://jira.corp.adobe.com/browse/MWPW-165992)

**Test URLs:**
- Before: https://stage--milo--meganthecoder.aem.page/drafts/methomas/chart-two-up?martech=off
- After: https://chart-font-inherit--milo--meganthecoder.aem.page/drafts/methomas/chart-two-up?martech=off
