### PR TITLE
[MWPW-168637] paramaters appended to ecid value - bug fix

### DIFF
--- a/libs/features/branch-quick-links/branch-quick-links.js
+++ b/libs/features/branch-quick-links/branch-quick-links.js
@@ -22,7 +22,6 @@ function addLoader(a) {
 }
 
 async function decorateQuickLink(a, hasConsent) {
-  if (!window.alloy) return;
   let ecid = null;
   try {
     const data = await window.alloy_getIdentity;

--- a/libs/features/branch-quick-links/branch-quick-links.js
+++ b/libs/features/branch-quick-links/branch-quick-links.js
@@ -31,7 +31,9 @@ async function decorateQuickLink(a, hasConsent) {
     window.lana.log(`Error fetching ECID: ${e}`, { tags: 'branch-quick-links' });
   }
   if (ecid && hasConsent && !a.href.includes('ecid')) {
-    a.href = a.href.concat(`?ecid=${ecid}`);
+    const urlObj = new URL(a.href, window.location.origin);
+    urlObj.searchParams.set('ecid', ecid);
+    a.href = urlObj.toString();
   }
   window.location.href = a.href;
 }

--- a/libs/features/branch-quick-links/branch-quick-links.js
+++ b/libs/features/branch-quick-links/branch-quick-links.js
@@ -33,7 +33,7 @@ async function decorateQuickLink(a, hasConsent) {
   if (ecid && hasConsent && !a.href.includes('ecid')) {
     const urlObj = new URL(a.href, window.location.origin);
     urlObj.searchParams.set('ecid', ecid);
-    a.href = urlObj.toString();
+    a.href = urlObj.href;
   }
   window.location.href = a.href;
 }


### PR DESCRIPTION
* Fixed the ecid value getting concatenated with other params in branch quick links

Resolves: [MWPW-168637](https://jira.corp.adobe.com/browse/MWPW-168637)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/drafts/drashti/milo-banner/ql-noloader
- After: https://ecid-query--milo--drashti1712.aem.live/drafts/drashti/milo-banner/ql-noloader
