### PR TITLE
Fix(MWPW-167810): Sidekick preflight - Lorem ipsum bug.

### DIFF
--- a/libs/utils/sidekick.js
+++ b/libs/utils/sidekick.js
@@ -1,4 +1,5 @@
 import stylePublish from './sidekick-decorate.js';
+import { debounce } from './action.js';
 
 // loadScript and loadStyle are passed in to avoid circular dependencies
 export default function init({ createTag, loadBlock, loadScript, loadStyle }) {
@@ -37,8 +38,7 @@ export default function init({ createTag, loadBlock, loadScript, loadStyle }) {
   // Add plugin listeners here
   sk.addEventListener('custom:send-to-caas', sendToCaasListener);
   sk.addEventListener('custom:check-schema', checkSchemaListener);
-  sk.addEventListener('custom:preflight', preflightListener);
-
+  sk.addEventListener('custom:preflight', debounce(() => preflightListener(), 500));
   // Color code publish button
   stylePublish(sk);
 }

--- a/libs/utils/sidekick.js
+++ b/libs/utils/sidekick.js
@@ -39,6 +39,7 @@ export default function init({ createTag, loadBlock, loadScript, loadStyle }) {
   sk.addEventListener('custom:send-to-caas', sendToCaasListener);
   sk.addEventListener('custom:check-schema', checkSchemaListener);
   sk.addEventListener('custom:preflight', debounce(() => preflightListener(), 500));
+
   // Color code publish button
   stylePublish(sk);
 }


### PR DESCRIPTION
* The preflight listener is now debounced as it was being called multiple times creating two dom nodes for preflight modal.

Resolves: [MWPW-167810](https://jira.corp.adobe.com/browse/MWPW-167810)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/sharathkannan/video-accessibility/fragments/hero-marquee1?martech=off
- After: https://mwpw-167810--milosh--sharath-kannan.aem.page/drafts/sharathkannan/video-accessibility/fragments/hero-marquee1?martech=off
