### PR TITLE
MWPW-167217 [MEP] preserve hash in normalizePath

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -77,18 +77,17 @@ export const normalizePath = (p, localize = true) => {
 
   if (isDamContent(path) || !path?.includes('/')) return path;
 
+  if (path.includes('/federal/')) return getFederatedUrl(path);
+
   const config = getConfig();
-  if (path.includes('/federal/')) {
-    return getFederatedUrl(path);
+  if (!path.startsWith(config.codeRoot) && !path.startsWith('http') && !path.startsWith('/')) {
+    path = `/${path}`;
   }
 
   try {
-    if (!path.startsWith(config.codeRoot) && !path.startsWith('http') && !path.startsWith('/')) {
-      path = `/${path}`;
-    }
     const url = new URL(path);
-    const firstFolder = url.pathname.split('/')[1];
-    const { hash } = url;
+    const { hash, pathname } = url;
+    const firstFolder = pathname.split('/')[1];
 
     if (path.startsWith(config.codeRoot)
       || path.includes('.hlx.')
@@ -99,12 +98,11 @@ export const normalizePath = (p, localize = true) => {
         || hash.includes('#_dnt')
         || firstFolder in config.locales
         || path.includes('.json')) {
-        path = url.pathname;
+        path = pathname;
       } else {
-        path = `${config.locale.prefix}${url.pathname}`;
+        path = `${config.locale.prefix}${pathname}`;
       }
     }
-
     return `${path}${hash}`;
   } catch (e) {
     return path;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -78,31 +78,36 @@ export const normalizePath = (p, localize = true) => {
   if (isDamContent(path) || !path?.includes('/')) return path;
 
   const config = getConfig();
-  if (path.startsWith('https://www.adobe.com/federal/')) {
+  if (path.includes('/federal/')) {
     return getFederatedUrl(path);
   }
 
-  if (path.startsWith(config.codeRoot)
-    || path.includes('.hlx.')
-    || path.includes('.aem.')
-    || path.includes('.adobe.')) {
-    try {
-      const url = new URL(path);
-      const firstFolder = url.pathname.split('/')[1];
+  try {
+    const url = new URL(path);
+    const firstFolder = url.pathname.split('/')[1];
+    const { hash } = url;
+
+    if (path.startsWith(config.codeRoot)
+      || path.includes('.hlx.')
+      || path.includes('.aem.')
+      || path.includes('.adobe.')) {
       if (!localize
         || config.locale.ietf === 'en-US'
-        || url.hash.includes('#_dnt')
+        || hash.includes('#_dnt')
         || firstFolder in config.locales
         || path.includes('.json')) {
         path = url.pathname;
       } else {
         path = `${config.locale.prefix}${url.pathname}`;
       }
-    } catch (e) { /* return path below */ }
-  } else if (!path.startsWith('http') && !path.startsWith('/')) {
-    path = `/${path}`;
+    } else if (!path.startsWith('http') && !path.startsWith('/')) {
+      path = `/${path}`;
+    }
+
+    return `${path}${hash}`;
+  } catch (e) {
+    return path;
   }
-  return path;
 };
 
 export const getFileName = (path) => path?.split('/').pop();

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -78,7 +78,7 @@ export const normalizePath = (p, localize = true) => {
   if (isDamContent(path) || !path?.includes('/')) return path;
 
   const config = getConfig();
-  if (path.includes('/federal/')) {
+  if (path.startsWith('https://www.adobe.com/federal/')) {
     return getFederatedUrl(path);
   }
 

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -78,7 +78,7 @@ export const normalizePath = (p, localize = true) => {
   if (isDamContent(path) || !path?.includes('/')) return path;
 
   const config = getConfig();
-  if (path.startsWith('https://www.adobe.com/federal/')) {
+  if (path.includes('/federal/')) {
     return getFederatedUrl(path);
   }
 

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -83,6 +83,9 @@ export const normalizePath = (p, localize = true) => {
   }
 
   try {
+    if (!path.startsWith(config.codeRoot) && !path.startsWith('http') && !path.startsWith('/')) {
+      path = `/${path}`;
+    }
     const url = new URL(path);
     const firstFolder = url.pathname.split('/')[1];
     const { hash } = url;
@@ -100,8 +103,6 @@ export const normalizePath = (p, localize = true) => {
       } else {
         path = `${config.locale.prefix}${url.pathname}`;
       }
-    } else if (!path.startsWith('http') && !path.startsWith('/')) {
-      path = `/${path}`;
     }
 
     return `${path}${hash}`;

--- a/test/features/personalization/normalizePath.test.js
+++ b/test/features/personalization/normalizePath.test.js
@@ -20,17 +20,22 @@ describe('normalizePath function', () => {
 
   it('does not localize for #_dnt', async () => {
     const path = await normalizePath('https://main--milo--adobecom.hlx.page/path/to/fragment.plain.html#_dnt');
-    expect(path).to.equal('/path/to/fragment.plain.html');
+    expect(path).to.equal('/path/to/fragment.plain.html#_dnt');
   });
 
   it('does not localize if fragment is already localized', async () => {
     const path = await normalizePath('https://main--milo--adobecom.hlx.page/de/path/to/fragment.plain.html#_dnt');
-    expect(path).to.equal('/de/path/to/fragment.plain.html');
+    expect(path).to.equal('/de/path/to/fragment.plain.html#_dnt');
   });
 
   it('does not localize json', async () => {
     const path = await normalizePath('https://main--milo--adobecom.hlx.page/path/to/manifest.json');
     expect(path).to.equal('/path/to/manifest.json');
+  });
+
+  it('retains a hash if one is passed in', async () => {
+    const path = await normalizePath('https://main--milo--adobecom.hlx.page/path/to/fragment.plain.html#noActiveItem');
+    expect(path).to.equal('/path/to/fragment.plain.html#noActiveItem');
   });
 
   it('does localize otherwise', async () => {


### PR DESCRIPTION
This PR enhances the **normalizePath** function to ensure that hash values included in full URLs are retained.
### Summary:
- Retains Hash Values: Ensures that hash values in full URLs are preserved during normalization.

- Consistency: Aligns the handling of hash values with the existing path processing logic.


Resolves: [MWPW-167217](https://jira.corp.adobe.com/browse/MWPW-167217)

### Steps to reproduce:

1. Using the before and after URLS, got to url and open dev tools.

**The expected gnav-source value(After)**: 

![Screenshot 2025-02-27 at 10 22 48 AM](https://github.com/user-attachments/assets/dd8a0131-a6dd-40ae-8bf5-255403f27bb9)

**The actual gnav-source value(Before)**:

![Screenshot 2025-02-27 at 10 43 23 AM](https://github.com/user-attachments/assets/9f139518-61b6-4341-a20a-900172c0b297)


**Test URLs:**
- Psi-check: https://meppreservehash--milo--adobecom.aem.page/?martech=off
- Before: https://main--cc--adobecom.hlx.page/products/catalog?mep=%2Fproducts%2Fcatalog.json--default---%2Fcc-shared%2Ffragments%2Fpromos%2F2025%2Famericas%2Fcci-all-apps-q1%2Fcci-all-apps-q1.json--default---%2Fcc-shared%2Ffragments%2Fpromos%2F2025%2Fglobal%2Ftry-buy%2Ftry-buy-global.json--default---%2Fdrafts%2Fmepdev%2Ffragments%2F2025%2Fq1%2Fmeppreservehash%2Face1047-viv-test.json--all
- After: https://main--cc--adobecom.hlx.page/products/catalog?mep=%2Fproducts%2Fcatalog.json--default---%2Fcc-shared%2Ffragments%2Fpromos%2F2025%2Famericas%2Fcci-all-apps-q1%2Fcci-all-apps-q1.json--default---%2Fcc-shared%2Ffragments%2Fpromos%2F2025%2Fglobal%2Ftry-buy%2Ftry-buy-global.json--default---%2Fdrafts%2Fmepdev%2Ffragments%2F2025%2Fq1%2Fmeppreservehash%2Face1047-viv-test.json--all&milolibs=meppreservehash

