### PR TITLE
MWPW-166497 [Accordion] Improve Expand All Button Accessibility

### DIFF
--- a/libs/blocks/accordion/accordion.css
+++ b/libs/blocks/accordion/accordion.css
@@ -39,7 +39,12 @@ div.accordion:not(.descr-list) {
   font-family: var(--body-font-family);
 }
 
-.accordion-expand-all button.disabled {
+.accordion-expand-all button:focus-visible {
+  outline: 2px solid var(--color-accent-focus-ring);
+  outline-offset: 2px;
+}
+
+.accordion-expand-all button:disabled {
   color: var(--color-gray-500);
   border-color: var(--color-gray-500);
   background-color: #fff;

--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -87,7 +87,8 @@ function handleClick(el, dd, num) {
   if (expandAllBtns.length) {
     expandAllBtns.forEach((btn) => {
       btn.setAttribute('aria-pressed', 'mixed');
-      btn.classList.remove('fill', 'disabled');
+      btn.classList.remove('fill');
+      btn.disabled = false;
     });
   }
 
@@ -175,11 +176,12 @@ async function createExpandAllContainer(accordionItems, isEditorial, mediaEl) {
     if (targetBtn.getAttribute('aria-pressed') === 'true') return;
     targetBtn.setAttribute('aria-pressed', 'true');
     targetBtn.classList.remove('fill');
-    targetBtn.classList.add('disabled');
+    targetBtn.disabled = true;
     const siblingBtn = targetBtn.nextElementSibling || targetBtn.previousElementSibling;
     siblingBtn.setAttribute('aria-pressed', 'false');
-    siblingBtn.classList.remove('disabled');
+    siblingBtn.disabled = false;
     siblingBtn.classList.add('fill');
+    siblingBtn.focus();
     if (action === 'expand') {
       accordionItems.forEach(({ dt, dd }) => openPanel(dt.querySelector('button'), dd));
       if (!isEditorial) return;


### PR DESCRIPTION
Improve accessibility of expand-all-button feature in accordion block:
* Offset keyboard focus
* Move focus on button click
* Remove disabled button from tab order

Resolves: [MWPW-166497](https://jira.corp.adobe.com/browse/MWPW-166497)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/accordion-open-all
- After: https://accordion-expand-focus--milo--meganthecoder.aem.page/drafts/methomas/accordion-open-all?martech=off
