### PR TITLE
[LOC UI] MWPW-166940 Hlx5 - Handling mixed URLs in Loc Urls and mismatch in project and page urls

### DIFF
--- a/libs/blocks/locui/utils/franklin.js
+++ b/libs/blocks/locui/utils/franklin.js
@@ -8,13 +8,18 @@ export const origin = `https://main--${repo}--${owner}.${SLD}.page`;
 
 // Temporary fix until https://github.com/adobe/helix-admin/issues/2831 is fixed.
 function fixPreviewDomain(json) {
-  if (SLD === 'aem') {
+  function switchPreviewDomain(from, to) {
     if (json?.preview?.url) {
-      json.preview.url = json.preview.url.replace('.hlx.', '.aem.');
+      json.preview.url = json.preview.url.replace(from, to);
     }
     if (json?.live?.url) {
-      json.live.url = json.live.url.replace('.hlx.', '.aem.');
+      json.live.url = json.live.url.replace(from, to);
     }
+  }
+  if (SLD === 'aem') {
+    switchPreviewDomain('.hlx.', '.aem.');
+  } else if (SLD === 'hlx') {
+    switchPreviewDomain('.aem.', '.hlx.');
   }
 }
 
@@ -33,4 +38,14 @@ export async function getStatus(path = '', editUrl = 'auto') {
   const json = await resp.json();
   fixPreviewDomain(json);
   return json;
+}
+
+export function validSLD(url) {
+  return url.hostname.includes(`.${SLD}.`);
+}
+
+export function switchSLD(urlStr) {
+  const url = new URL(urlStr);
+  url.hostname = SLD === 'aem' ? url.hostname.replace('.aem.', '.hlx.') : url.hostname.replace('.hlx.', '.aem.');
+  return url;
 }


### PR DESCRIPTION
Changes
1. When both aem and hlx page URLs are mixed in a project, an alert message is shown, prompting the user to enter either one of them, but not both.
2. When a mismatch is found between the project URL (e.g., Sidekick) and the page URLs in the project, the page is redirected appropriately to avoid displaying "Page Not Found" messages.
3. Helix Admin URLs are also updated to use either aem.page or hlx.page.

Resolves: [MWPW-166940](https://jira.corp.adobe.com/browse/MWPW-166940)

**Test URLs:**
- Before: https://locui--milo--adobecom.aem.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B21a05280-fe1b-4d36-84cc-e301c6416083%257D%26action%3Deditnew
- After: https://locui-debug--milo--raga-adbe-gh.aem.page/tools/loc?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&referrer=https%3A%2F%2Fadobe.sharepoint.com%2F%3Ax%3A%2Fr%2Fsites%2Fadobecom%2F_layouts%2F15%2FDoc.aspx%3Fsourcedoc%3D%257B21a05280-fe1b-4d36-84cc-e301c6416083%257D%26action%3Deditnew
