### PR TITLE
[MWPW-167137] LI alignment in Media block

### DIFF
--- a/libs/blocks/media/media.css
+++ b/libs/blocks/media/media.css
@@ -127,18 +127,31 @@ div[class*="-up"] .media .foreground > .media-row {
   margin-bottom: var(--spacing-xs);
 }
 
-.media ul > li::before {
-  content: "";
-  display: inline-block;
-  margin-left: 3px;
+[dir="rtl"] .media ul {
+  padding-left: initial;
+  padding-right: 20px;
+}
+
+.media.checklist ul {
+  padding: initial;
+  display: flex;
+  flex-direction: column;
+  row-gap: 1px;
 }
 
 .media.checklist li {
-  background: url("/libs/img/ui/checkmark-green.svg") no-repeat 5px 5px transparent;
   list-style-type: none;
-  margin-left: -25px;
-  padding: 0 0 1px 29px;
-  vertical-align: middle;
+  display: flex;
+  align-items: flex-start;
+  column-gap: 4px;
+}
+
+.media.checklist li::before {
+  content: "";
+  width: 20px;
+  height: 24px;
+  flex-shrink: 0;
+  background: url("/libs/img/ui/checkmark-green.svg") no-repeat 50% calc(50% + 2px) transparent;
 }
 
 .media .subcopy {


### PR DESCRIPTION
This updates the list styles inside the Media block to fix an alignment issue for multiline list items. It also ensures RTL is correctly supported.

The suggested changes don't match Figma specs, as all lists are currently being analyzed from a design perspective; we'll be getting a more comprehensive list of updates once that is concluded. Additional details are available in the comments section of the story. However, these suggested updates make it easier to update styles in the future.

Before | After
--- | ---
![Screenshot 2025-02-28 at 15 05 07](https://github.com/user-attachments/assets/6970b095-66cc-48d9-b912-260424edb717) | ![Screenshot 2025-02-28 at 15 05 01](https://github.com/user-attachments/assets/0ab16160-aed2-4293-b913-39c10c83678d)
![Screenshot 2025-02-28 at 15 05 36](https://github.com/user-attachments/assets/e3195d2d-9cf8-466b-ba47-e94f76f84c02) | ![Screenshot 2025-02-28 at 15 05 29](https://github.com/user-attachments/assets/9b0b4084-e13a-454b-8aa1-2c554dcc2694)

Resolves: [MWPW-167137](https://jira.corp.adobe.com/browse/MWPW-167137)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.hlx.page/drafts/ramuntea/media-list-alignment?martech=off
- After: https://li-in-media--milo--overmyheadandbody.hlx.page/drafts/ramuntea/media-list-alignment?martech=off
