### PR TITLE
MWPW-165701 Padding issue is seen in RTL locale compared to LTR locale

### DIFF
--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -107,7 +107,7 @@
 }
 
 [dir = "rtl"] .feds-navLink--hoverCaret {
-  padding-right: 12px;
+  padding-right: 20px;
   padding-left: 32px;
 }
 


### PR DESCRIPTION
Brief description of the issue:
Padding issue is seen in RTL locale compared to LTR locale

Resolves: [MWPW-165701](https://jira.corp.adobe.com/browse/MWPW-165701)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-163320--milo--patel-prince.aem.page/?martech=off

**QA URL:**
Before: https://main--cc--adobecom.hlx.page/ae_ar/products/indesign?martech=off
After: https://main--cc--adobecom.hlx.page/ae_ar/products/indesign?milolibs=mwpw-165701--milo--patel-prince
