### PR TITLE
Profile menu complex config for standalone Gnav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -124,7 +124,7 @@ export const CONFIG = {
               ...getConfig().unav?.profile?.config,
             },
           },
-          complexConfig: getConfig().unav?.profile?.complexConfig || {},
+          complexConfig: getConfig().unav?.profile?.complexConfig || null,
           callbacks: {
             onSignIn: () => { window.adobeIMS?.signIn(SIGNIN_CONTEXT); },
             onSignUp: () => { window.adobeIMS?.signIn(SIGNIN_CONTEXT); },

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -124,6 +124,7 @@ export const CONFIG = {
               ...getConfig().unav?.profile?.config,
             },
           },
+          complexConfig: getConfig().unav?.profile?.complexConfig || {},
           callbacks: {
             onSignIn: () => { window.adobeIMS?.signIn(SIGNIN_CONTEXT); },
             onSignUp: () => { window.adobeIMS?.signIn(SIGNIN_CONTEXT); },


### PR DESCRIPTION
Profile menu complex config for standalone Gnav

* This is required by Adobe Home to enable static local section in profile menu

Resolves: [MWPW-167523](https://jira.corp.adobe.com/browse/MWPW-167523)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw167523--milo--adobecom.aem.page/?martech=off
