### PR TITLE
Adding a class to convert group link title to a simple header instead of a link

### DIFF
--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -273,6 +273,14 @@ header.global-navigation.ready {
     content: '';
   }
 
+  .feds-navLink.feds-navLink--header[class *= '-gradient'] .feds-navLink-title:after {
+    display: none;
+  }
+
+  .feds-navLink.feds-navLink--header {
+    pointer-events: none;
+  }
+
   [dir = "rtl"] .feds-navLink[class *= '-gradient'] .feds-navLink-title:after {
     transform: rotate(135deg);
   }


### PR DESCRIPTION

<!-- Before submitting, please review all open PRs. -->

* Adding a class to convert group link title to a simple header instead of link
* And hide the chevron icon

Resolves: [MWPW-168548](https://jira.corp.adobe.com/browse/MWPW-168548)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://link-group-header--milo--adobecom.aem.page/?martech=off

QA: https://business.stage.adobe.com/?milolibs=link-group-header
