### PR TITLE
MWPW-164462 [MEP] Add ability for MEP to select sections by section-metadata anchor value 

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -57,7 +57,7 @@ function handleDelay(time, section) {
 
 function handleAnchor(anchor, section) {
   if (!anchor || !section) return;
-  section.id = anchor.toLowerCase().trim().replaceAll(' ', '-');
+  section.id = anchor.toLowerCase().trim().replaceAll(/\s+/g, '-');
   section.classList.add('section-anchor');
 }
 

--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -57,7 +57,7 @@ function handleDelay(time, section) {
 
 function handleAnchor(anchor, section) {
   if (!anchor || !section) return;
-  section.id = anchor;
+  section.id = anchor.toLowerCase().trim().replaceAll(' ', '-');
   section.classList.add('section-anchor');
 }
 

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -37,7 +37,6 @@ export const PERSONALIZATION_TAGS = {
 const PERSONALIZATION_KEYS = Object.keys(PERSONALIZATION_TAGS);
 /* c8 ignore stop */
 
-const MEP_ID = 'mep-id';
 const CLASS_EL_DELETE = 'p13n-deleted';
 const CLASS_EL_REPLACE = 'p13n-replaced';
 const COLUMN_NOT_OPERATOR = 'not ';
@@ -433,8 +432,6 @@ function modifySelectorTerm(termParam) {
     'div', 'a', 'p', 'strong', 'em', 'picture', 'source', 'img', 'h',
     'ul', 'ol', 'li',
   ];
-  const hasMepId = term.startsWith(MEP_ID);
-  term = hasMepId ? term.replace(`${MEP_ID}-`, '') : term;
   const startTextMatch = term.match(/^[a-zA-Z/./-]*/);
   const startText = startTextMatch ? startTextMatch[0].toLowerCase() : '';
   const startTextPart1 = startText.split(/\.|:/)[0];
@@ -451,7 +448,6 @@ function modifySelectorTerm(termParam) {
     term = updateEndNumber(endNumber, term);
     return term;
   }
-  if (hasMepId) return `main > div:has([${MEP_ID}*="${term}"])`;
 
   if (!startText.startsWith('.')) term = `.${term}`;
   if (endNumber) {
@@ -501,7 +497,7 @@ export function modifyNonFragmentSelector(selector, action) {
 
 function getSelectedElements(sel, rootEl, forceRootEl, action) {
   const root = forceRootEl ? rootEl : document;
-  const selector = sel.startsWith(MEP_ID) ? sel.split(' ').join('-').trim() : sel.trim();
+  const selector = sel.trim();
   if (!selector) return {};
 
   if (getSelectorType(selector) === 'fragment') {
@@ -565,14 +561,14 @@ export const deleteMarkedEls = (rootEl = document) => {
     .forEach((el) => el.remove());
 };
 
-export function addMepIdToSectionMetadata(rootEl = document) {
+export function addSectionIds(rootEl = document) {
   const metadataBlocks = rootEl.querySelectorAll('.section-metadata');
-  metadataBlocks.forEach((metadataBlock) => {
-    [...metadataBlock.children].forEach((child) => {
-      const col1 = child.children[0]?.textContent.toLowerCase().trim();
-      const col2 = child.children[1]?.textContent.toLowerCase().trim();
-      if (!col1 || !col2 || col1 !== MEP_ID) return;
-      metadataBlock.setAttribute(MEP_ID, col2);
+  metadataBlocks.forEach((block) => {
+    [...block.children].forEach((row) => {
+      const col1 = row.children[0]?.textContent.toLowerCase().trim();
+      const col2 = row.children[1]?.textContent.toLowerCase().trim().split(' ').join('');
+      if (!col1 || !col2 || col1 !== 'anchor') return;
+      block.parentElement.setAttribute('id', col2);
     });
   });
 }
@@ -584,7 +580,7 @@ export function handleCommands(
   forceRootEl = false,
 ) {
   const section1 = document.querySelector('main > div');
-  addMepIdToSectionMetadata(rootEl);
+  addSectionIds(rootEl);
   commands.forEach((cmd) => {
     const { action, content, selector } = cmd;
     cmd.content = forceInline && getSelectorType(content) === 'fragment' ? addHash(content, INLINE_HASH) : content;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -565,7 +565,7 @@ export function addSectionAnchors(rootEl = document) {
   rootEl.querySelectorAll('.section-metadata').forEach((block) => {
     [...block.children].forEach((row) => {
       const col1 = row.children[0]?.textContent.toLowerCase().trim();
-      const col2 = row.children[1]?.textContent.toLowerCase().trim().replaceAll(' ', '-');
+      const col2 = row.children[1]?.textContent.toLowerCase().trim().replaceAll(/\s+/g, '-');
       if (!col1 || !col2 || col1 !== 'anchor') return;
       block.parentElement.setAttribute('id', col2);
     });

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -565,7 +565,7 @@ export function addSectionAnchors(rootEl = document) {
   rootEl.querySelectorAll('.section-metadata').forEach((block) => {
     [...block.children].forEach((row) => {
       const col1 = row.children[0]?.textContent.toLowerCase().trim();
-      const col2 = row.children[1]?.textContent.toLowerCase().trim().split(' ').join('');
+      const col2 = row.children[1]?.textContent.toLowerCase().trim().replaceAll(' ', '-');
       if (!col1 || !col2 || col1 !== 'anchor') return;
       block.parentElement.setAttribute('id', col2);
     });

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -561,7 +561,7 @@ export const deleteMarkedEls = (rootEl = document) => {
     .forEach((el) => el.remove());
 };
 
-export function addSectionIds(rootEl = document) {
+export function addSectionAnchors(rootEl = document) {
   const metadataBlocks = rootEl.querySelectorAll('.section-metadata');
   metadataBlocks.forEach((block) => {
     [...block.children].forEach((row) => {
@@ -580,7 +580,7 @@ export function handleCommands(
   forceRootEl = false,
 ) {
   const section1 = document.querySelector('main > div');
-  addSectionIds(rootEl);
+  addSectionAnchors(rootEl);
   commands.forEach((cmd) => {
     const { action, content, selector } = cmd;
     cmd.content = forceInline && getSelectorType(content) === 'fragment' ? addHash(content, INLINE_HASH) : content;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -562,8 +562,7 @@ export const deleteMarkedEls = (rootEl = document) => {
 };
 
 export function addSectionAnchors(rootEl = document) {
-  const metadataBlocks = rootEl.querySelectorAll('.section-metadata');
-  metadataBlocks.forEach((block) => {
+  rootEl.querySelectorAll('.section-metadata').forEach((block) => {
     [...block.children].forEach((row) => {
       const col1 = row.children[0]?.textContent.toLowerCase().trim();
       const col2 = row.children[1]?.textContent.toLowerCase().trim().split(' ').join('');

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -37,6 +37,7 @@ export const PERSONALIZATION_TAGS = {
 const PERSONALIZATION_KEYS = Object.keys(PERSONALIZATION_TAGS);
 /* c8 ignore stop */
 
+const MEP_ID = 'mep-id';
 const CLASS_EL_DELETE = 'p13n-deleted';
 const CLASS_EL_REPLACE = 'p13n-replaced';
 const COLUMN_NOT_OPERATOR = 'not ';
@@ -432,6 +433,8 @@ function modifySelectorTerm(termParam) {
     'div', 'a', 'p', 'strong', 'em', 'picture', 'source', 'img', 'h',
     'ul', 'ol', 'li',
   ];
+  const hasMepId = term.startsWith(MEP_ID);
+  term = hasMepId ? term.replace(`${MEP_ID}-`, '') : term;
   const startTextMatch = term.match(/^[a-zA-Z/./-]*/);
   const startText = startTextMatch ? startTextMatch[0].toLowerCase() : '';
   const startTextPart1 = startText.split(/\.|:/)[0];
@@ -448,6 +451,7 @@ function modifySelectorTerm(termParam) {
     term = updateEndNumber(endNumber, term);
     return term;
   }
+  if (hasMepId) return `main > div:has([${MEP_ID}*="${term}"])`;
 
   if (!startText.startsWith('.')) term = `.${term}`;
   if (endNumber) {
@@ -497,7 +501,7 @@ export function modifyNonFragmentSelector(selector, action) {
 
 function getSelectedElements(sel, rootEl, forceRootEl, action) {
   const root = forceRootEl ? rootEl : document;
-  const selector = sel.trim();
+  const selector = sel.startsWith(MEP_ID) ? sel.split(' ').join('-').trim() : sel.trim();
   if (!selector) return {};
 
   if (getSelectorType(selector) === 'fragment') {
@@ -561,6 +565,18 @@ export const deleteMarkedEls = (rootEl = document) => {
     .forEach((el) => el.remove());
 };
 
+export function addMepIdToSectionMetadata(rootEl = document) {
+  const metadataBlocks = rootEl.querySelectorAll('.section-metadata');
+  metadataBlocks.forEach((metadataBlock) => {
+    [...metadataBlock.children].forEach((child) => {
+      const col1 = child.children[0]?.textContent.toLowerCase().trim();
+      const col2 = child.children[1]?.textContent.toLowerCase().trim();
+      if (!col1 || !col2 || col1 !== MEP_ID) return;
+      metadataBlock.setAttribute(MEP_ID, col2);
+    });
+  });
+}
+
 export function handleCommands(
   commands,
   rootEl = document,
@@ -568,6 +584,7 @@ export function handleCommands(
   forceRootEl = false,
 ) {
   const section1 = document.querySelector('main > div');
+  addMepIdToSectionMetadata(rootEl);
   commands.forEach((cmd) => {
     const { action, content, selector } = cmd;
     cmd.content = forceInline && getSelectorType(content) === 'fragment' ? addHash(content, INLINE_HASH) : content;

--- a/test/features/personalization/mocks/personalization.html
+++ b/test/features/personalization/mocks/personalization.html
@@ -191,7 +191,7 @@
     </div>
     <div class="section-metadata">
       <div>
-        <div>mep-id</div>
+        <div>anchor</div>
         <div>marquee-container</div>
       </div>
     </div>

--- a/test/features/personalization/mocks/personalization.html
+++ b/test/features/personalization/mocks/personalization.html
@@ -185,5 +185,16 @@
         <p><a href="/fragments/removeme">/fragments/removeme</a></p>
         <p><a href="/fragments/insertaround">/fragments/insertaround</a></p>
       </div>
+  <div>
+    <div class="marquee-container-test">
+        <h1>Marquee container</h1>
+    </div>
+    <div class="section-metadata">
+      <div>
+        <div>mep-id</div>
+        <div>marquee-container</div>
+      </div>
+    </div>
+  </div>
 </main>
 <footer></footer>

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -164,6 +164,10 @@ const values = [
     b: '.aside03',
     a: '.aside03',
   },
+  {
+    b: 'mep-id-marquee-container',
+    a: 'main > div:has([mep-id*="marquee-container"])',
+  },
 ];
 describe('test different values', () => {
   values.forEach((value) => {

--- a/test/features/personalization/modifyNonFragmentSelector.test.js
+++ b/test/features/personalization/modifyNonFragmentSelector.test.js
@@ -164,10 +164,6 @@ const values = [
     b: '.aside03',
     a: '.aside03',
   },
-  {
-    b: 'mep-id-marquee-container',
-    a: 'main > div:has([mep-id*="marquee-container"])',
-  },
 ];
 describe('test different values', () => {
   values.forEach((value) => {

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -4,7 +4,7 @@ import { assert, stub } from 'sinon';
 import { getConfig, setConfig } from '../../../libs/utils/utils.js';
 import {
   handleFragmentCommand, applyPers, cleanAndSortManifestList, normalizePath,
-  init, matchGlob, createContent, combineMepSources, buildVariantInfo, addMepIdToSectionMetadata,
+  init, matchGlob, createContent, combineMepSources, buildVariantInfo, addSectionIds,
 } from '../../../libs/features/personalization/personalization.js';
 import mepSettings from './mepSettings.js';
 import mepSettingsPreview from './mepPreviewSettings.js';
@@ -378,10 +378,11 @@ describe('Functional Test', () => {
     expect(document.querySelector('meta[property="og:image"]').content).to.equal('https://adobe.com/path/to/image.jpg');
   });
 
-  it('will add mep-id attribute to the section metadata', async () => {
-    addMepIdToSectionMetadata(document);
-    const metadataBlock = document.querySelector('.section-metadata');
-    expect(metadataBlock.getAttribute('mep-id')).to.equal('marquee-container');
+  it('will add id to the section div', async () => {
+    addSectionIds(document);
+    const sectionWithId = document.querySelector('#marquee-container');
+    expect(sectionWithId).to.exist;
+    expect(sectionWithId.getAttribute('id')).to.equal('marquee-container');
   });
 });
 

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -4,7 +4,7 @@ import { assert, stub } from 'sinon';
 import { getConfig, setConfig } from '../../../libs/utils/utils.js';
 import {
   handleFragmentCommand, applyPers, cleanAndSortManifestList, normalizePath,
-  init, matchGlob, createContent, combineMepSources, buildVariantInfo, addSectionIds,
+  init, matchGlob, createContent, combineMepSources, buildVariantInfo, addSectionAnchors,
 } from '../../../libs/features/personalization/personalization.js';
 import mepSettings from './mepSettings.js';
 import mepSettingsPreview from './mepPreviewSettings.js';
@@ -379,7 +379,7 @@ describe('Functional Test', () => {
   });
 
   it('will add id to the section div', async () => {
-    addSectionIds(document);
+    addSectionAnchors(document);
     const sectionWithId = document.querySelector('#marquee-container');
     expect(sectionWithId).to.exist;
     expect(sectionWithId.getAttribute('id')).to.equal('marquee-container');

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -382,7 +382,6 @@ describe('Functional Test', () => {
     addSectionAnchors(document);
     const sectionWithId = document.querySelector('#marquee-container');
     expect(sectionWithId).to.exist;
-    expect(sectionWithId.getAttribute('id')).to.equal('marquee-container');
   });
 });
 

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -4,7 +4,7 @@ import { assert, stub } from 'sinon';
 import { getConfig, setConfig } from '../../../libs/utils/utils.js';
 import {
   handleFragmentCommand, applyPers, cleanAndSortManifestList, normalizePath,
-  init, matchGlob, createContent, combineMepSources, buildVariantInfo,
+  init, matchGlob, createContent, combineMepSources, buildVariantInfo, addMepIdToSectionMetadata,
 } from '../../../libs/features/personalization/personalization.js';
 import mepSettings from './mepSettings.js';
 import mepSettingsPreview from './mepPreviewSettings.js';
@@ -376,6 +376,12 @@ describe('Functional Test', () => {
     expect(document.querySelector('meta[name="mynewmetadata"]').content).to.equal('woot');
     expect(document.querySelector('meta[property="og:title"]').content).to.equal('New Title');
     expect(document.querySelector('meta[property="og:image"]').content).to.equal('https://adobe.com/path/to/image.jpg');
+  });
+
+  it('will add mep-id attribute to the section metadata', async () => {
+    addMepIdToSectionMetadata(document);
+    const metadataBlock = document.querySelector('.section-metadata');
+    expect(metadataBlock.getAttribute('mep-id')).to.equal('marquee-container');
   });
 });
 


### PR DESCRIPTION
* Expand `anchor` `section-metadata` property to MEP


`anchor` property adds `id` to the section
![Screenshot 2025-03-05 at 14 37 45](https://github.com/user-attachments/assets/48cdc82a-1ea4-4055-aad7-ebfcf37bc381)
Section is targeted with `id` selector
![Screenshot 2025-03-05 at 14 37 53](https://github.com/user-attachments/assets/c3f10d20-f1de-4d8e-a8eb-2860180b4ed3)

Resolves: [MWPW-164462](https://jira.corp.adobe.com/browse/MWPW-164462)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/marquee-container/demo/marquee-container-demo?martech=off
- After: https://mwpw-164462-marquee-container2--milo--adobecom.aem.page/drafts/ratko/marquee-container/demo/marquee-container-demo?martech=off

[Manifest](https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/doc2.aspx?sourcedoc=%7BB12B9C30-FBF1-45F9-8689-835C919160A6%7D&file=personalization.xlsx&action=default&mobileredirect=true)

**NOTE:** Manifest option `param-five=true` looks broken because heading element is target and swapped (just wanted to show off targeting element inside specific section)
