### PR TITLE
[MWPW-168691] - Aside cta shrink JP

### DIFF
--- a/libs/blocks/aside/aside.js
+++ b/libs/blocks/aside/aside.js
@@ -81,25 +81,10 @@ function decorateMedia(el) {
 }
 
 function formatPromoButton(el) {
-  function observeWbrRemoval(btn) {
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        mutation.addedNodes.forEach((node) => {
-          if (node.nodeName === 'WBR') {
-            node.remove();
-          }
-        });
-      });
-    });
-
-    observer.observe(btn, { childList: true, subtree: true });
-  }
-
   if (!el.classList.contains('promobar')) return;
   el.querySelectorAll('.action-area').forEach((aa) => {
     aa.querySelectorAll('.con-button').forEach((btn) => {
       btn.classList.add('button-l');
-      observeWbrRemoval(btn);
       if (!el.classList.contains('popup')) return;
       if (!btn.classList.contains('outline')) btn.classList.add('fill');
     });

--- a/libs/blocks/aside/aside.js
+++ b/libs/blocks/aside/aside.js
@@ -85,7 +85,10 @@ function formatPromoButton(el) {
   el.querySelectorAll('.action-area').forEach((aa) => {
     aa.querySelectorAll('.con-button').forEach((btn) => {
       btn.classList.add('button-l');
-      btn.querySelectorAll('wbr').forEach((wbr) => wbr.remove());
+      setTimeout(() => {
+        btn.querySelectorAll('wbr').forEach((wbr) => wbr.remove());
+      }, 1000);
+
       if (!el.classList.contains('popup')) return;
       if (!btn.classList.contains('outline')) btn.classList.add('fill');
     });

--- a/libs/blocks/aside/aside.js
+++ b/libs/blocks/aside/aside.js
@@ -81,14 +81,25 @@ function decorateMedia(el) {
 }
 
 function formatPromoButton(el) {
+  function observeWbrRemoval(btn) {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeName === 'WBR') {
+            node.remove();
+          }
+        });
+      });
+    });
+
+    observer.observe(btn, { childList: true, subtree: true });
+  }
+
   if (!el.classList.contains('promobar')) return;
   el.querySelectorAll('.action-area').forEach((aa) => {
     aa.querySelectorAll('.con-button').forEach((btn) => {
       btn.classList.add('button-l');
-      setTimeout(() => {
-        btn.querySelectorAll('wbr').forEach((wbr) => wbr.remove());
-      }, 1000);
-
+      observeWbrRemoval(btn);
       if (!el.classList.contains('popup')) return;
       if (!btn.classList.contains('outline')) btn.classList.add('fill');
     });

--- a/libs/blocks/aside/aside.js
+++ b/libs/blocks/aside/aside.js
@@ -85,6 +85,7 @@ function formatPromoButton(el) {
   el.querySelectorAll('.action-area').forEach((aa) => {
     aa.querySelectorAll('.con-button').forEach((btn) => {
       btn.classList.add('button-l');
+      btn.querySelectorAll('wbr').forEach((wbr) => wbr.remove());
       if (!el.classList.contains('popup')) return;
       if (!btn.classList.contains('outline')) btn.classList.add('fill');
     });

--- a/libs/features/japanese-word-wrap.js
+++ b/libs/features/japanese-word-wrap.js
@@ -73,9 +73,10 @@ export function isWordWrapApplied(element) {
 
 export function ifWbrCtaRemove(element) {
   if (!element.classList.contains('con-button')) {
-    element.querySelectorAll('wbr').forEach((wbr) => wbr.remove());
+    return;
   }
-  return !element.classList.contains('con-button');
+
+  element.querySelectorAll('wbr').forEach((wbr) => wbr.remove());
 }
 
 /**

--- a/libs/features/japanese-word-wrap.js
+++ b/libs/features/japanese-word-wrap.js
@@ -68,7 +68,7 @@ function isFirefox() {
  * Check if a word wrap has been applied to an element.
  */
 export function isWordWrapApplied(element) {
-  return !!element.querySelector('wbr');
+  return !element.classList.contains('con-button') && !!element.querySelector('wbr');
 }
 
 /**

--- a/libs/features/japanese-word-wrap.js
+++ b/libs/features/japanese-word-wrap.js
@@ -72,6 +72,8 @@ export function isWordWrapApplied(element) {
 }
 
 export function ifWbrCtaRemove(element) {
+  console.log('hi');
+  
   if (!element.classList.contains('con-button')) {
     return;
   }
@@ -138,13 +140,14 @@ export async function applyJapaneseLineBreaks(config, options = {}) {
 
   // Apply budoux to target selector
   textElements.forEach((el) => {
+    ifWbrCtaRemove(el);
+
     if (
       budouxExcludeElements.has(el)
       || isWordWrapApplied(el)
       || (isFirefox() && hasFlexOrGrid(el))
     ) return;
     parser.applyElement(el, { threshold: budouxThres });
-    ifWbrCtaRemove(el);
   });
 
   if (bwEnabled) {

--- a/libs/features/japanese-word-wrap.js
+++ b/libs/features/japanese-word-wrap.js
@@ -68,9 +68,14 @@ function isFirefox() {
  * Check if a word wrap has been applied to an element.
  */
 export function isWordWrapApplied(element) {
-  console.log('element.classList', element.classList);
-  
-  return !element.classList.contains('con-button') && !!element.querySelector('wbr');
+  return !!element.querySelector('wbr');
+}
+
+export function ifWbrCtaRemove(element) {
+  if (!element.classList.contains('con-button')) {
+    element.querySelectorAll('wbr').forEach((wbr) => wbr.remove());
+  }
+  return !element.classList.contains('con-button');
 }
 
 /**
@@ -138,6 +143,7 @@ export async function applyJapaneseLineBreaks(config, options = {}) {
       || (isFirefox() && hasFlexOrGrid(el))
     ) return;
     parser.applyElement(el, { threshold: budouxThres });
+    ifWbrCtaRemove(el);
   });
 
   if (bwEnabled) {

--- a/libs/features/japanese-word-wrap.js
+++ b/libs/features/japanese-word-wrap.js
@@ -64,21 +64,15 @@ function isFirefox() {
   return navigator.userAgent.includes('Firefox');
 }
 
+function isAsideCta(element) {
+  return element.closest('.aside') && element.parentElement?.classList.contains('con-button');
+}
+
 /**
  * Check if a word wrap has been applied to an element.
  */
 export function isWordWrapApplied(element) {
   return !!element.querySelector('wbr');
-}
-
-export function ifWbrCtaRemove(element) {
-  console.log('hi');
-  
-  if (!element.classList.contains('con-button')) {
-    return;
-  }
-
-  element.querySelectorAll('wbr').forEach((wbr) => wbr.remove());
 }
 
 /**
@@ -140,11 +134,10 @@ export async function applyJapaneseLineBreaks(config, options = {}) {
 
   // Apply budoux to target selector
   textElements.forEach((el) => {
-    ifWbrCtaRemove(el);
-
     if (
       budouxExcludeElements.has(el)
       || isWordWrapApplied(el)
+      || isAsideCta(el)
       || (isFirefox() && hasFlexOrGrid(el))
     ) return;
     parser.applyElement(el, { threshold: budouxThres });

--- a/libs/features/japanese-word-wrap.js
+++ b/libs/features/japanese-word-wrap.js
@@ -68,6 +68,8 @@ function isFirefox() {
  * Check if a word wrap has been applied to an element.
  */
 export function isWordWrapApplied(element) {
+  console.log('element.classList', element.classList);
+  
   return !element.classList.contains('con-button') && !!element.querySelector('wbr');
 }
 


### PR DESCRIPTION
This resolves the issue where Aside CTA's were shrinking for the Japanese language.

Resolves: [MWPW-168691](https://jira.corp.adobe.com/browse/MWPW-168691)

| Before | After |
|--------|-------|
| <img width="1512" alt="Screenshot 2025-03-06 at 16 30 38" src="https://github.com/user-attachments/assets/28fdd454-77f4-4f32-96fd-6d79655460d9" /> | <img width="1510" alt="Screenshot 2025-03-06 at 16 30 48" src="https://github.com/user-attachments/assets/85fb0dbe-039a-4876-984d-37140230a246" /> |

**Test URLs:**
- Before: https://main--dc--adobecom.hlx.page/jp/acrobat/acrobat-pro?mep=off
- After: https://main--dc--adobecom.hlx.page/jp/acrobat/acrobat-pro?milolibs=aside-cta-shrink&mep=off
