### PR TITLE
Moving getGnavSource back to utils

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -6,6 +6,7 @@ import {
   loadIms,
   decorateLinks,
   loadScript,
+  getGnavSource,
   getFedsPlaceholderConfig,
 } from '../../utils/utils.js';
 import {
@@ -1347,16 +1348,6 @@ class Gnav {
 
     return this.elements.search;
   };
-}
-
-async function getGnavSource() {
-  const { locale, dynamicNavKey } = getConfig();
-  let url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
-  if (dynamicNavKey) {
-    const { default: dynamicNav } = await import('../../features/dynamic-navigation/dynamic-navigation.js');
-    url = dynamicNav(url, dynamicNavKey);
-  }
-  return url;
 }
 
 export default async function init(block) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -842,6 +842,16 @@ function decorateDefaults(el) {
   });
 }
 
+export async function getGnavSource() {
+  const { locale, dynamicNavKey } = getConfig();
+  let url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
+  if (dynamicNavKey) {
+    const { default: dynamicNav } = await import('../features/dynamic-navigation/dynamic-navigation.js');
+    url = dynamicNav(url, dynamicNavKey);
+  }
+  return url;
+}
+
 export function isLocalNav() {
   const { locale = {} } = getConfig();
   const gnavSource = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Moving getGnavSource back to utils as DME team is consuming it through utils.js


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-source--milo--adobecom.aem.page/?martech=off

QA: 
- https://stage--dme-partners--adobecom.hlx.page/channelpartners/home/?milolibs=gnav-source
- https://main--cc--adobecom.hlx.page/products/catalog?milolibs=gnav-source