### PR TITLE
MWPW-169163 Re-enable broken psnlz tab preselecting function on US …

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -426,15 +426,16 @@ async function openFragmentModal(path, getModal) {
 export function appendTabName(url) {
   const metaPreselectPlan = document.querySelector('meta[name="preselect-plan"]');
   if (!metaPreselectPlan?.content) return url;
+  const isRelativePath = url.startsWith('/');
   let urlWithPlan;
   try {
-    urlWithPlan = new URL(url);
+    urlWithPlan = isRelativePath ? new URL(`${location.origin}${url}`) : new URL(url);
   } catch (err) {
     window.lana?.log(`Invalid URL ${url} : ${err}`);
     return url;
   }
   urlWithPlan.searchParams.set('plan', metaPreselectPlan.content);
-  return urlWithPlan.href;
+  return isRelativePath ? urlWithPlan.href.replace(location.origin, '') : urlWithPlan.href;
 }
 
 export function appendExtraOptions(url, extraOptions) {

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -429,13 +429,13 @@ export function appendTabName(url) {
   const isRelativePath = url.startsWith('/');
   let urlWithPlan;
   try {
-    urlWithPlan = isRelativePath ? new URL(`${location.origin}${url}`) : new URL(url);
+    urlWithPlan = isRelativePath ? new URL(`${window.location.origin}${url}`) : new URL(url);
   } catch (err) {
     window.lana?.log(`Invalid URL ${url} : ${err}`);
     return url;
   }
   urlWithPlan.searchParams.set('plan', metaPreselectPlan.content);
-  return isRelativePath ? urlWithPlan.href.replace(location.origin, '') : urlWithPlan.href;
+  return isRelativePath ? urlWithPlan.href.replace(window.location.origin, '') : urlWithPlan.href;
 }
 
 export function appendExtraOptions(url, extraOptions) {

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -790,6 +790,11 @@ describe('Merch Block', () => {
         urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator4.html?plan=edu',
       },
       {
+        url: '/mini-plans/illustrator4.html',
+        plan: 'edu',
+        urlWithPlan: '/mini-plans/illustrator4.html?plan=edu',
+      },
+      {
         url: 'https://www.adobe.com/mini-plans/illustrator5.html#thisishash',
         plan: 'edu',
         urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator5.html?plan=edu#thisishash',
@@ -808,6 +813,11 @@ describe('Merch Block', () => {
         url: 'https://www.adobe.com/mini-plans/illustrator8.selector.html/resource?mid=ft&web=1#thisishash',
         plan: 'team',
         urlWithPlan: 'https://www.adobe.com/mini-plans/illustrator8.selector.html/resource?mid=ft&web=1&plan=team#thisishash',
+      },
+      {
+        url: '/mini-plans/illustrator8.selector.html/resource?mid=ft&web=1#thisishash',
+        plan: 'team',
+        urlWithPlan: '/mini-plans/illustrator8.selector.html/resource?mid=ft&web=1&plan=team#thisishash',
       },
       {
         url: 'https://www.adobe.com/mini-plans/illustrator9.sel1.sel2.html/resource#thisishash',


### PR DESCRIPTION
… mini-plans pages

`appendTabName()` needs to add query parameter `plan` to relative paths as well, not just to URLs.

This is problematic only on adobe.com pages where TWP URLs are made relative e.g.
`www.adobe.com/products/catalog.html?audience=edu&promo=off&mep=%2Fproducts%2Fcatalog.json--target-edu_pzn#mini-plans-web-cta-acrobat-pro-card`
and only there this can be tested. The outcome should be the STE tab preselected in TWP modal. 

Resolves: [MWPW-169163](https://jira.corp.adobe.com/browse/MWPW-169163)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live?martech=off
- After: https://mwpw169163edu--milo--bozojovicic.aem.live?martech=off
