### PR TITLE
MWPW-169629 [MEP] DNT hash should not be preserved like other hashes

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -89,6 +89,7 @@ export const normalizePath = (p, localize = true) => {
     const url = new URL(path);
     const { hash, pathname } = url;
     const firstFolder = pathname.split('/')[1];
+    const mepHash = '#_dnt';
 
     if (path.startsWith(config.codeRoot)
       || path.includes('.hlx.')
@@ -96,7 +97,7 @@ export const normalizePath = (p, localize = true) => {
       || path.includes('.adobe.')) {
       if (!localize
         || config.locale.ietf === 'en-US'
-        || hash.includes('#_dnt')
+        || hash.includes(mepHash)
         || firstFolder in config.locales
         || path.includes('.json')) {
         path = pathname;
@@ -104,7 +105,7 @@ export const normalizePath = (p, localize = true) => {
         path = `${config.locale.prefix}${pathname}`;
       }
     }
-    return `${path}${hash}`;
+    return `${path}${hash.replace(mepHash, '')}`;
   } catch (e) {
     return path;
   }

--- a/test/features/personalization/normalizePath.test.js
+++ b/test/features/personalization/normalizePath.test.js
@@ -20,12 +20,12 @@ describe('normalizePath function', () => {
 
   it('does not localize for #_dnt', async () => {
     const path = await normalizePath('https://main--milo--adobecom.hlx.page/path/to/fragment.plain.html#_dnt');
-    expect(path).to.equal('/path/to/fragment.plain.html#_dnt');
+    expect(path).to.equal('/path/to/fragment.plain.html');
   });
 
   it('does not localize if fragment is already localized', async () => {
     const path = await normalizePath('https://main--milo--adobecom.hlx.page/de/path/to/fragment.plain.html#_dnt');
-    expect(path).to.equal('/de/path/to/fragment.plain.html#_dnt');
+    expect(path).to.equal('/de/path/to/fragment.plain.html');
   });
 
   it('does not localize json', async () => {


### PR DESCRIPTION
Marked high priority because it is causing issues in live personalization

* Remove #_dnt from hash in normalize path

Resolves: [MWPW-169629 [MEP] DNT hash should not be preserved like other hashes](https://jira.corp.adobe.com/browse/MWPW-169629)

**Test URLs:**
Example 1: sticky banner does not work in before link (scroll down to test)
- Before: https://main--cc--adobecom.aem.page/products/illustrator?audience=edu&mep=%2Fproducts%2Fillustrator.json--target-edu_pzn
- After: https://main--cc--adobecom.aem.page/products/illustrator?audience=edu&mep=%2Fproducts%2Fillustrator.json--target-edu_pzn&milolibs=mepdontpreservednt&martech=off

Example 2: page is blank and does not render in before link
- Before: https://main--cc--adobecom.aem.page/uk/products/photoshop?mep=%2Fcc-shared%2Ffragments%2Ftests%2Femea-latam%2F2024%2Fq3%2Femea1425-ax-macro%2Fmep%2Femea1425-ps.json--target-variant
- After: https://main--cc--adobecom.aem.page/uk/products/photoshop?mep=%2Fcc-shared%2Ffragments%2Ftests%2Femea-latam%2F2024%2Fq3%2Femea1425-ax-macro%2Fmep%2Femea1425-ps.json--target-variant&milolibs=mepdontpreservednt&martech=off

- Psi-check: https://mepdontpreservednt--milo--adobecom.aem.page/?martech=off
