### PR TITLE
[MWPW-169500] SEO- Links check failing breaks Preflight

### DIFF
--- a/libs/blocks/preflight/panels/seo.js
+++ b/libs/blocks/preflight/panels/seo.js
@@ -256,7 +256,8 @@ async function checkLinks() {
     badResults.push(...spidyResults);
   }
 
-  badLinks.value = badResults.map((result) => links.find((link) => compareResults(result, link)));
+  badLinks.value = badResults.map((result) => links.find((link) => compareResults(result, link)))
+    .filter(Boolean);
 
   // Format the results for display
   const count = badLinks.value.length;


### PR DESCRIPTION
## Description
This PR is fixing the SEO links check from Preflight

## Related Issue
Resolves: [MWPW-169500](https://jira.corp.adobe.com/browse/MWPW-169500)

## Testing instructions
1. Open preflight
2. Open the SEO tab
3. Wait for the links check to finish

## Screenshots:
**Before:**
![Screenshot 2025-03-12 at 10 38 00](https://github.com/user-attachments/assets/5f048d8c-2904-4d54-b8d2-279b2201976f)

**After:**
![Screenshot 2025-03-12 at 10 42 44](https://github.com/user-attachments/assets/e017368e-3602-40f0-8f8d-cf1f793fc0d2)

## Test URLs
**Milo:**
- Before: https://main--milo--adobecom.aem.page/drafts/rbogos/page-default?martech=off
- After: https://mwpw-169500-preflight--milo--adobecom.aem.page/drafts/rbogos/page-default?martech=off
