### PR TITLE
MWPW-169194: adds new detailText option for staticDate

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -214,6 +214,7 @@ const defaultOptions = {
     default: 'Default',
     createdDate: 'Created Date',
     modifiedDate: 'Modified Date',
+    staticDate: 'Static Date',
   },
   cardHoverEffect: {
     default: 'Default',


### PR DESCRIPTION
Description:

Adds a new option to the Default Text Caas Card collection options in the MIlo Configurator

![image](https://github.com/user-attachments/assets/affdf130-63c6-4bc4-b1bd-6500d6cace02)

Resolves: [MWPW-169194](https://jira.corp.adobe.com/browse/MWPW-169194)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/cmiqueo/test-page?martech=off
- After: https://MWPW-169194--milo--adobecom.aem.page/drafts/cmiqueo/test-page?martech=off
