### PR TITLE
MWPW-169732 Fetch resources from adobe.com/federal instead of https://main--federal--adobecom.aem.live/federal

### DIFF
--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -112,9 +112,13 @@ export default async function loadBlock(configs, customLib) {
     import('../utils/utils.js'),
   ]);
   const paramConfigs = getParamsConfigs(configs);
-  const origin = env === 'prod'
-    ? 'https://www.adobe.com/federal'
-    : 'https://main--federal--adobecom.aem.page';
+  const origin = (() => {
+    switch (env) {
+      case 'prod': return 'https://www.adobe.com';
+      case 'stage': return 'https://www.stage.adobe.com';
+      default: return 'https://main--federal--adobecom.aem.page';
+    }
+  })();
   const clientConfig = {
     theme,
     prodDomains,

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -112,6 +112,9 @@ export default async function loadBlock(configs, customLib) {
     import('../utils/utils.js'),
   ]);
   const paramConfigs = getParamsConfigs(configs);
+  const origin = env === 'prod'
+    ? 'https://www.adobe.com/federal'
+    : 'https://main--federal--adobecom.aem.page';
   const clientConfig = {
     theme,
     prodDomains,
@@ -122,8 +125,8 @@ export default async function loadBlock(configs, customLib) {
     locales: configs.locales || locales,
     contentRoot: authoringPath || footer?.authoringPath,
     stageDomainsMap: getStageDomainsMap(stageDomainsMap),
-    origin: `https://main--federal--adobecom.aem.${env === 'prod' ? 'live' : 'page'}`,
-    allowedOrigins: [...allowedOrigins, `https://main--federal--adobecom.aem.${env === 'prod' ? 'live' : 'page'}`],
+    origin,
+    allowedOrigins: [...allowedOrigins, origin],
     onFooterReady: footer?.onReady,
     onFooterError: footer?.onError,
     ...paramConfigs,


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added some logic to determine whether to use `www.adobe.com` or `www.stage.adobe.com` for the standalone gnav 
* There's some defensive logic in case the env is neither stage nor prod.

Resolves: [MWPW-169732](https://jira.corp.adobe.com/browse/MWPW-169732)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://standalone-prod-content--milo--adobecom.aem.page/?martech=off

qa url: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=standalone-prod-content