### PR TITLE
MWPW-169277: Adding capability to pass releaseName for standalone Gnav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -123,6 +123,7 @@ export const CONFIG = {
                   error: (e) => lanaLog({ message: 'Profile Menu error', e, tags: 'universalnav', errorType: 'error' }),
                 },
               },
+              releaseName: getConfig().unav?.profile?.releaseName || null,
               ...getConfig().unav?.profile?.config,
             },
           },


### PR DESCRIPTION
Adding capability to pass releaseName for standalone Gnav

Resolves: [MWPW-169277](https://jira.corp.adobe.com/browse/MWPW-169277)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav--milo--adobecom.aem.page/?martech=off
