### PR TITLE
Harden Github Action security by pinning to commit SHAs (versions)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,3 @@
+### Description
+Based on the [Github security guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) we pinned actions to a full length commit SHA's rather than tags, which are more common.
+In order to upgrade an action, simply go to the Github repo such as: https://github.com/actions/checkout/releases - find the latest release and the commit-SHA that is connected to it. When you run the action on your own fork, you can simply validate it's still running as expected and manages to download the 3rd party package within the scope of the action.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,5 @@
 ### Description
 Based on the [Github security guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) we pinned actions to a full length commit SHA's rather than tags, which are more common.
-In order to upgrade an action, simply go to the Github repo such as: https://github.com/actions/checkout/releases - find the latest release and the commit-SHA that is connected to it and replace it for all actions that use the 3rd party package you want to upgrade.
+In order to upgrade an action, simply go to the Github repo such as: https://github.com/actions/checkout/releases - find the latest release and the commit-SHA that is connected to it and replace it for all actions that use the 3rd party package you want to upgrade. This [PR](https://github.com/adobecom/milo/pull/3830) serves as an example where we upgraded multiple 3rd party packages across all actions.
 
 To QA the change, when you run the action on your own fork, you can simply validate it's still running as expected and manages to download the 3rd party package within the scope of the action.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,3 +1,5 @@
 ### Description
 Based on the [Github security guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) we pinned actions to a full length commit SHA's rather than tags, which are more common.
-In order to upgrade an action, simply go to the Github repo such as: https://github.com/actions/checkout/releases - find the latest release and the commit-SHA that is connected to it. When you run the action on your own fork, you can simply validate it's still running as expected and manages to download the 3rd party package within the scope of the action.
+In order to upgrade an action, simply go to the Github repo such as: https://github.com/actions/checkout/releases - find the latest release and the commit-SHA that is connected to it and replace it for all actions that use the 3rd party package you want to upgrade.
+
+To QA the change, when you run the action on your own fork, you can simply validate it's still running as expected and manages to download the 3rd party package within the scope of the action.

--- a/.github/workflows/code-compatibility.yaml
+++ b/.github/workflows/code-compatibility.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Check for unsupported functions
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,11 +34,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@6bb031afdd8eb862ea3fc1848194185e076637e5
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/codeql/codeql-config.yml
@@ -46,7 +46,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@6bb031afdd8eb862ea3fc1848194185e076637e5
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -59,6 +59,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@6bb031afdd8eb862ea3fc1848194185e076637e5
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4    
-      - uses: dorny/paths-filter@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683    
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: changes
         with:
           base: ${{ github.ref }}
@@ -23,7 +23,7 @@ jobs:
               - 'libs/**'    
       - if: steps.changes.outputs.src == 'true'
         name: Trigger DC Workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           github-token: ${{ secrets.DC_PAT }}
           script: |

--- a/.github/workflows/fg-sync-repos.yml
+++ b/.github/workflows/fg-sync-repos.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e
         with:
           app-id: ${{ secrets.FG_SYNC_APP_ID }}
           private-key: ${{ secrets.FG_SYNC_APP_PRIVATE_KEY }}
@@ -30,7 +30,7 @@ jobs:
           repositories: "milo-pink"
 
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           persist-credentials: false
           ref: ${{ inputs.syncBranch || github.ref_name }}

--- a/.github/workflows/high-impact-alert.yml
+++ b/.github/workflows/high-impact-alert.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Send Slack message for high impact PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const main = require('./.github/workflows/high-impact-alert.js')

--- a/.github/workflows/label-zero-impact.yaml
+++ b/.github/workflows/label-zero-impact.yaml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Add the zero impact label
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const main = require('./.github/workflows/label-zero-impact.js')

--- a/.github/workflows/mark-stale-prs.yaml
+++ b/.github/workflows/mark-stale-prs.yaml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository_owner == 'adobecom'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: 'This PR has not been updated recently and will be closed in 7 days if no action is taken. Please ensure all checks are passing, https://github.com/orgs/adobecom/discussions/997 provides instructions. If the PR is ready to be merged, please mark it with the "Ready for Stage" label.'

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -20,17 +20,17 @@ jobs:
     if: github.repository_owner == 'adobecom' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'stage'))
 
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e
         id: milo-pr-merge-token
         with:
           app-id: ${{ secrets.MILO_PR_MERGE_APP_ID }}
           private-key: ${{ secrets.MILO_PR_MERGE_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Merge to main
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           github-token: ${{ steps.milo-pr-merge-token.outputs.token }}
           script: |

--- a/.github/workflows/merge-to-stage.yaml
+++ b/.github/workflows/merge-to-stage.yaml
@@ -22,17 +22,17 @@ jobs:
     environment: milo_pr_merge
 
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e
         id: milo-pr-merge-token
         with:
           app-id: ${{ secrets.MILO_PR_MERGE_APP_ID }}
           private-key: ${{ secrets.MILO_PR_MERGE_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Merge to stage or queue to merge
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           github-token: ${{ steps.milo-pr-merge-token.outputs.token }}
           script: |

--- a/.github/workflows/pr-reminders.yaml
+++ b/.github/workflows/pr-reminders.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     - name: Remind PR initiators
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:
         script: |
           const main = require('./.github/workflows/pr-reminders.js')

--- a/.github/workflows/rcp-notifier.yml
+++ b/.github/workflows/rcp-notifier.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Create RCP Notification
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const main = require('./.github/workflows/rcp-notifier.js')

--- a/.github/workflows/release-standalone-feds.yml
+++ b/.github/workflows/release-standalone-feds.yml
@@ -22,12 +22,12 @@ jobs:
         working-directory: ./libs/navigation
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 2
 
     - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/run-lint.yaml
+++ b/.github/workflows/run-lint.yaml
@@ -10,9 +10,9 @@ jobs:
     name: Running eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 20
 
@@ -20,7 +20,7 @@ jobs:
         run: npm ci
 
       - name: Run eslint on changed files
-        uses: tj-actions/eslint-changed-files@v25
+        uses: tj-actions/eslint-changed-files@74f98653675512158746d3136cd2d9326fbfb6e1
         with:
           config_path: ".eslintrc.js"
           # ignore_path: "/path/to/.eslintignore"

--- a/.github/workflows/run-mas-tests.yaml
+++ b/.github/workflows/run-mas-tests.yaml
@@ -14,12 +14,12 @@ jobs:
         node-version: [20.x]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 2
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -32,7 +32,7 @@ jobs:
         working-directory: libs/features/mas
 
       - name: Upload commerce coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
         with:
           name: mas
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run-nala-default.yml
+++ b/.github/workflows/run-nala-default.yml
@@ -22,12 +22,12 @@ jobs:
         node-version: [20.x]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 2
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/run-nala-milolibs.yaml
+++ b/.github/workflows/run-nala-milolibs.yaml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set environment variables
         run: |
@@ -46,7 +46,7 @@ jobs:
           HLX_TKN: ${{ secrets.HLX_TKN }}
           SLACK_WH: ${{ secrets.SLACK_WH }}          
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/run-nala.yml
+++ b/.github/workflows/run-nala.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run Nala Tests (Consuming Apps) 
         uses: adobecom/nala@main # Change if doing dev work
         env:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,12 +14,12 @@ jobs:
         node-version: [20.x]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 2
 
     - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -31,7 +31,7 @@ jobs:
       run: npm test
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage/lcov.info

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Set up Python 3.x, latest minor release
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
       with:
         python-version: "3.x"
     - name: Install dependencies

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
     - name: Update ims lib and create PR if needed
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:
         script: |
           const updateDependency = require('./.github/workflows/update-script.js')
@@ -27,7 +27,7 @@ jobs:
             scriptPath: './libs/deps/imslib.min.js'
           })
     - name: Update forms2 and create PR if needed
-      uses: actions/github-script@v7
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:
         script: |
           const updateDependency = require('./.github/workflows/update-script.js')


### PR DESCRIPTION
Following this [incident](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066) we want to harden the security for our Github actions by [pinning actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) to full length commit SHAs. Its the recommended approach in terms of security from Github and while we won't get any minor versions OOTB, security and stability is more important than the latest and greatest features in this case.

Resolves: [MWPW-169958](https://jira.corp.adobe.com/browse/MWPW-169958)

### Actions
Checkout https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683
CodeQL https://github.com/github/codeql-action/commit/6bb031afdd8eb862ea3fc1848194185e076637e5
Github script https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea
Dorny paths https://github.com/dorny/paths-filter/commit/de90cc6fb38fc0963ad72b210f1f284cd68cea36
Create-github-app-token https://github.com/actions/create-github-app-token/commit/21cfef2b496dd8ef5b904c159339626a10ad380e
Stale https://github.com/actions/stale/commit/5bef64f19d7facfb25b37b414482c7164d639639
Setup-node https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e
eslint-changed-files https://github.com/tj-actions/eslint-changed-files/commit/74f98653675512158746d3136cd2d9326fbfb6e1
Upload-artifact https://github.com/actions/upload-artifact/commit/4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
Setup-python https://github.com/actions/setup-python/commit/42375524e23c412d93fb67b49958b491fce71c38
Codecov action https://github.com/codecov/codecov-action/commit/0565863a31f2c772f9f0395002a31e3f06189574

### Further details
What I've done is getting the SHA for the latest release of each action https://github.com/actions/checkout/releases ... if we ever need to update, we should always try to look for the latest SHA of a release (*that is NOT coming from a fork)


**Test URLs:**
- Before: https://stage--milo--adobecom.aem.live/?martech=off
- After: https://stage--milo--mokimo.aem.live/?martech=off
