### PR TITLE
MWPW-169943 [MEP] add ability to use placeholders in updateAttribute

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -234,6 +234,7 @@ const COMMANDS = {
     const { manifestId, targetManifestId } = cmd;
     if (!cmd.attribute || !cmd.content) return;
     const [attribute, parameter] = cmd.attribute.split('_');
+    cmd.content = replacePlaceholders(cmd.content);
 
     let value;
 

--- a/test/features/personalization/actions.test.js
+++ b/test/features/personalization/actions.test.js
@@ -81,15 +81,17 @@ describe('replace action', () => {
 });
 
 describe('updateAttribute action', async () => {
-  it('updateAttribute should add or modify a html element attribute', async () => {
+  it('updateAttribute should add or modify a html element attribute, including placeholders', async () => {
     let manifestJson = await readFile({ path: './mocks/actions/manifestUpdateAttribute.json' });
     manifestJson = JSON.parse(manifestJson);
     setFetchResponse(manifestJson);
     await init(mepSettings);
+    config.placeholders = { 'my-aria-test': 'Hello world!' };
     await handleCommands(manifestJson.data, undefined, true, true);
     expect(document.querySelector('.marquee h2').getAttribute('class')).to.equal('added-class');
     expect(document.querySelector('.marquee strong a').getAttribute('href')).to.equal('https://www.google.com/?osi=new-parameter#_inline');
     expect(document.querySelector('.marquee em a').getAttribute('new-attribute')).to.equal('added-attribute');
+    expect(document.querySelector('#placeholder-replace').getAttribute('aria-label')).to.equal('Hello world!');
   });
 });
 

--- a/test/features/personalization/mocks/actions/manifestUpdateAttribute.json
+++ b/test/features/personalization/mocks/actions/manifestUpdateAttribute.json
@@ -1,7 +1,7 @@
 {
-  "total": 5,
+  "total": 6,
   "offset": 0,
-  "limit": 5,
+  "limit": 6,
   "data": [
     {
       "action": "updateattribute",
@@ -42,6 +42,14 @@
       "param-newoffer=123": "",
       "chrome": "",
       "content": "thisshouldfail"
+    },
+    {
+      "action": "updateattribute",
+      "selector": "#placeholder-replace aria-label",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "chrome": "",
+      "content": "{{my-aria-test}}"
     }
   ],
   ":type": "sheet"

--- a/test/features/personalization/mocks/personalization.html
+++ b/test/features/personalization/mocks/personalization.html
@@ -85,6 +85,9 @@
           <p><em><a href="https://adobe.com/">Learn more</a></em> <strong><a href="https://adobe.com/">Learn
                 more</a></strong></p>
         </div>
+        <div>
+          <a id="placeholder-replace" href="https://apple.com" aria-label="to-be-replaced">Aria label should receive a placeholder value from the manifest--Hello World!</a>
+        </div>
         <div class="text center xxxl-spacing-bottom">
           <div>
             <div data-valign="middle">


### PR DESCRIPTION


Resolves: [MWPW-169943](https://jira.corp.adobe.com/browse/MWPW-169943)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://placeholders-updateAttribute4--milo--adobecom.aem.page/?martech=off

Before: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q2/mepattributeplaceholder/
After: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q2/mepattributeplaceholder/?milolibs=placeholders-updateAttribute4

Note how in the "Before URL" the aria-label value of the blue button in the marquee is the place-holder code: {{my-aria-test}}
But in the After URL, it is the placeholder value "Hello world" per the manifest value.