### PR TITLE
[MWPW-168529] New Assets tab in Preflight

### DIFF
--- a/libs/blocks/preflight/panels/accessibility.js
+++ b/libs/blocks/preflight/panels/accessibility.js
@@ -42,12 +42,11 @@ function dropdownOptions(props) {
 async function checkAlt() {
   if (altResult.value.checked) return;
   // If images are not scoped, tracking pixel/images are picked up.
-  const images = document.querySelectorAll('header img, main img, footer img');
+  const images = document.querySelectorAll(':is(header, main, footer) img:not(.accessibility-control)');
   const result = { ...altResult.value };
   if (!images) return;
 
   images.forEach((img) => {
-    if (img.classList.contains('accessibility-control')) return;
     const alt = img.getAttribute('alt');
     let parent = '';
 

--- a/libs/blocks/preflight/panels/assets.js
+++ b/libs/blocks/preflight/panels/assets.js
@@ -5,6 +5,7 @@ function isViewportTooSmall() {
   return !window.matchMedia('(min-width: 1200px)').matches;
 }
 
+const maxFullWidth = 1920;
 const imagesWithMismatch = signal([]);
 const imagesWithMatch = signal([]);
 const checksPerformed = signal(false);
@@ -29,6 +30,7 @@ async function checkImageDimensions() {
         img.setAttribute('loading', 'eager');
         return new Promise((resolve) => {
           img.addEventListener('load', resolve);
+          img.addEventListener('error', resolve);
         });
       }
       return Promise.resolve();
@@ -38,12 +40,14 @@ async function checkImageDimensions() {
   // Filter the loaded images to ensure they are visible, not an icon, and not an SVG
   const images = allImages.filter((img) => img.checkVisibility()
     && !img.closest('.icon-area')
-    && !img.src.endsWith('.svg'));
+    && !img.src.includes('.svg'));
 
   if (!images.length) return;
 
-  const maxFullWidth = 1920;
   const viewportWidth = document.documentElement.clientWidth;
+
+  // Apply overflow class to body to prevent scrolling issues during image analysis
+  document.body.classList.add('preflight-assets-analysis');
 
   for (const img of images) {
     // Get the original dimensions of the uploaded image; fallback to the natural dimensions
@@ -104,6 +108,9 @@ async function checkImageDimensions() {
 
     pictureMetaElem.append(assetMessage);
   }
+
+  // Remove overflow class from body after analysis is complete
+  document.body.classList.remove('preflight-assets-analysis');
 }
 
 function AssetsItem({ title, description }) {

--- a/libs/blocks/preflight/panels/assets.js
+++ b/libs/blocks/preflight/panels/assets.js
@@ -1,0 +1,111 @@
+import { html, signal, useEffect } from '../../../deps/htm-preact.js';
+
+const imagesWithMismatch = signal([]);
+const imagesWithMatch = signal([]);
+const checksPerformed = signal(false);
+
+const groups = [
+  { title: 'Images with dimension mismatch', imgArray: imagesWithMismatch },
+  { title: 'Images with matching dimensions', imgArray: imagesWithMatch },
+];
+
+async function checkImageDimensions() {
+  if (checksPerformed.value) return;
+
+  const images = document.querySelectorAll('main picture img');
+  if (!images) return;
+
+  images.forEach(async (img) => {
+    // Don't consider hidden images, icons, or SVGs
+    if (!img.checkVisibility()
+      || img.closest('.icon-area')
+      || img.src.endsWith('.svg')) return;
+    // Force load images
+    if (!img.complete) {
+      img.setAttribute('loading', 'eager');
+      await new Promise((resolve) => {
+        img.addEventListener('load', resolve);
+      });
+    }
+
+    const {
+      naturalWidth,
+      naturalHeight,
+      offsetWidth: displayWidth,
+      offsetHeight: displayHeight,
+    } = img;
+
+    const factor = Math.round((naturalWidth / displayWidth) * 100) / 100;
+    const hasMismatch = factor < 2; // TODO: Lower factor for full width images
+
+    const imageData = {
+      src: img.getAttribute('src'),
+      naturalDimensions: `${naturalWidth}x${naturalHeight}`,
+      displayDimensions: `${displayWidth}x${displayHeight}`,
+      factor,
+    };
+
+    if (hasMismatch) {
+      imagesWithMismatch.value = [...imagesWithMismatch.value, imageData];
+      img.closest('picture').classList.add('has-mismatch');
+    } else {
+      imagesWithMatch.value = [...imagesWithMatch.value, imageData];
+      img.closest('picture').classList.add('no-mismatch');
+    }
+  });
+
+  checksPerformed.value = true;
+}
+
+function AssetsItem({ title, description }) {
+  return html`
+    <div class='assets-item'>
+      <div class='assets-item-text'>
+        <p class='assets-item-title'>${title}</p>
+        <p class='assets-item-description'>${description}</p>
+      </div>
+    </div>`;
+}
+
+function ImageGroup({ group }) {
+  const { imgArray } = group;
+  return html`
+    <div class='grid-heading'>
+      <div class='grid-toggle'>
+        ${group.title}
+      </div>
+    </div>
+
+    ${imgArray.value.length > 0 && html`
+    <div class='assets-image-grid'>
+      ${imgArray.value.map((img) => html`
+      <div class='assets-image-grid-item'>
+        <img src='${img.src}' />
+        <div class='assets-image-grid-item-text'>
+          <span>Factor: ${img.factor}</span>
+          <span>Natural size: ${img.naturalDimensions}</span>
+          <span>Display size: ${img.displayDimensions}</span>
+        </div>
+      </div>`)}
+    </div>`}
+
+    ${!imgArray.value.length && html`
+      <div class='assets-image-grid'>
+        <div class='assets-image-grid-item full-width'>No images found</div>
+      </div>
+    `}
+  `;
+}
+
+export default function Assets() {
+  useEffect(() => { checkImageDimensions(); }, []);
+
+  return html`
+  <div class='assets-columns'>
+    <${AssetsItem}
+      title="Image Dimensions"
+      description="Please verify that image dimensions match their display size to avoid blurriness."
+    />
+    ${groups.map((group) => html`<${ImageGroup} group=${group} />`)}
+  </div>`;
+}

--- a/libs/blocks/preflight/panels/seo.js
+++ b/libs/blocks/preflight/panels/seo.js
@@ -371,9 +371,9 @@ export default function Panel() {
         ${badLinks.value.map((link, idx) => html`
           <tr>
             <td>${idx + 1}.</td>
-            <td><a href='${link.liveHref}' target='_blank'>${link.liveHref}</a></td>
-            <td><span>${link.parent}</span></td>
-            <td><span>${link.status}</span></td>
+            <td><a href='${link?.liveHref}' target='_blank'>${link?.liveHref}</a></td>
+            <td><span>${link?.parent}</span></td>
+            <td><span>${link?.status}</span></td>
           </tr>`)}
       </table>`}
     </div>`;

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -595,6 +595,10 @@ span.preflight-time {
 }
 
 /* Assets css */
+body.preflight-assets-analysis {
+  overflow: auto;
+}
+
 .assets-columns {
   margin: 24px 48px;
   display: grid;

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -675,15 +675,26 @@ picture:has(.picture-meta) {
   flex-direction: column;
   align-items: flex-start;
   row-gap: 5px;
+  min-width: 100px;
   color: #fff;
   font-weight: bold;
   font-size: 14px;
   line-height: 1.2;
   z-index: 9;
+  opacity: 0.7;
 }
 
 .picture-meta.no-picture-tag {
-  position: static;
+  position: relative;
+  top: unset;
+  left: unset;
+  right: unset;
+}
+
+picture:hover .picture-meta,
+img:hover ~ .picture-meta {
+  opacity: 1;
+  z-index: 19;
 }
 
 .picture-meta > div {

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -572,17 +572,6 @@ span.preflight-time {
   font-size: 16px;
 }
 
-img[data-alt-check] {
-  border: 5px solid rgb(255 234 2);
-  box-sizing: border-box;
-  filter: drop-shadow(8px 8px 18px rgb(199 182 2));
-}
-
-img[data-alt-check]::after {
-  content: attr(data-alt-check);
-  color: red;
-}
-
 .access-image-grid-item span {
   font-size: 16px;
   font-weight: bold;
@@ -672,30 +661,47 @@ img[data-alt-check]::after {
   font-weight: bold;
 }
 
-picture:is(.has-mismatch, .no-mismatch) {
+picture:has(.picture-meta) {
   position: relative;
+  display: block;
 }
 
-picture:is(.has-mismatch, .no-mismatch)::after {
+.picture-meta {
   position: absolute;
   top: 10px;
   left: 10px;
-  padding: 5px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  row-gap: 5px;
   color: #fff;
   font-weight: bold;
-  font-size: 16px;
-  line-height: 1.4;
+  font-size: 14px;
+  line-height: 1.2;
+  z-index: 9;
+}
+
+.picture-meta.no-picture-tag {
+  position: static;
+}
+
+.picture-meta > div {
+  padding: 5px;
   border-radius: 6px;
 }
 
-picture.has-mismatch::after {
-  content: 'Incorrect asset size';
-  background: red;
+.picture-meta-a11y.is-decorative {
+  background: #FFB74D;
 }
 
-picture.no-mismatch::after {
-  content: 'Correct asset size';
-  background: darkolivegreen;
+.picture-meta-asset.has-mismatch {
+  background: #EF5350;
+}
+
+.picture-meta-asset.no-mismatch,
+.picture-meta-a11y.has-alt {
+  background: #4CAF50;
 }
 
 .preflight .image-filter {

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -354,11 +354,11 @@ span.preflight-time {
   background-size: 60px;
 }
 
-@keyframes spin { 
-  100% { 
-    -webkit-transform: rotate(360deg); 
-    transform:rotate(360deg); 
-  } 
+@keyframes spin {
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform:rotate(360deg);
+  }
 }
 
 .result-icon.green {
@@ -418,7 +418,7 @@ span.preflight-time {
 .dialog-modal#preflight .problem-links table td a {
   color: #fff;
   display: inline-block;
-  overflow-x: scroll; 
+  overflow-x: scroll;
   position: absolute;
   top: 50%;
   left: 0;
@@ -603,6 +603,99 @@ img[data-alt-check]::after {
 .show-footer .access-image-grid-item.in-main-content,
 .show-footer .access-image-grid-item.in-gnav {
   display: none;
+}
+
+/* Assets css */
+.assets-columns {
+  margin: 24px 48px;
+  display: grid;
+  gap: 20px;
+}
+
+.assets-columns .grid-heading {
+  margin-bottom: 20px;
+}
+
+.assets-columns .grid-toggle {
+  color: #fff;
+  font-weight: 700;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+}
+
+.assets-item-title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 32px;
+}
+
+.assets-image-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 35px;
+  width: 100%;
+}
+
+.assets-image-grid:last-child {
+  margin-bottom: 0;
+}
+
+.assets-image-grid-item {
+  background: rgb(0 0 0 / 20%);
+  display: grid;
+  justify-items: center;
+  padding: 10px;
+  border-radius: 6px;
+}
+
+.assets-image-grid-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.assets-image-grid-item-text {
+  display: flex;
+  align-self: flex-end;
+  flex-direction: column;
+  width: 100%;
+  margin-top: 10px;
+}
+
+.assets-image-grid-item span {
+  font-size: 16px;
+  line-height: 1.4;
+}
+
+.assets-image-grid-item span:first-of-type {
+  margin: 10px 0;
+  font-weight: bold;
+}
+
+picture:is(.has-mismatch, .no-mismatch) {
+  position: relative;
+}
+
+picture:is(.has-mismatch, .no-mismatch)::after {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  padding: 5px;
+  color: #fff;
+  font-weight: bold;
+  font-size: 16px;
+  line-height: 1.4;
+  border-radius: 6px;
+}
+
+picture.has-mismatch::after {
+  content: 'Incorrect asset size';
+  background: red;
+}
+
+picture.no-mismatch::after {
+  content: 'Correct asset size';
+  background: darkolivegreen;
 }
 
 .preflight .image-filter {

--- a/libs/blocks/preflight/preflight.js
+++ b/libs/blocks/preflight/preflight.js
@@ -5,6 +5,7 @@ import SEO from './panels/seo.js';
 import Accessibility from './panels/accessibility.js';
 import Martech from './panels/martech.js';
 import Performance from './panels/performance.js';
+import Assets from './panels/assets.js';
 
 const HEADING = 'Milo Preflight';
 const IMG_PATH = '/blocks/preflight/img';
@@ -15,6 +16,7 @@ const tabs = signal([
   { title: 'Martech' },
   { title: 'Accessibility' },
   { title: 'Performance' },
+  { title: 'Assets' },
 ]);
 
 function setTab(active) {
@@ -36,6 +38,8 @@ function setPanel(title) {
       return html`<${Accessibility} />`;
     case 'Performance':
       return html`<${Performance} />`;
+    case 'Assets':
+      return html`<${Assets} />`;
     default:
       return html`<p>No matching panel.</p>`;
   }


### PR DESCRIPTION
## Summary

This proposes a new Assets tab for the Preflight tool to enable authors to easily check whether the image assets on a page are meeting our [asset governance](https://milo.adobe.com/docs/authoring/asset-governance) recommendations. In short, the images need to be uploaded at 2x (or 1.5x for full width images) the size of the area they will be used in.

There are two layers to how (mis)matches are communicated, detailed below.

## In the Preflight modal

This clearly separates the images into two categories: those that match and those that don't match the asset governance rules. A multiplication factor is outlined, along with uploaded image size, the size at which it is displayed and its recommended size (in case of a mismatch).

<img width="595" alt="Screenshot 2025-03-19 at 17 04 58" src="https://github.com/user-attachments/assets/87eddade-e900-4fcb-b659-b9a01ed9f70f" />

## As an image overlay

Once the Preflight modal is closed, the image details are added over each individual image, so an author can easily isolate images that need to be updated. Note that placeholder images are used in the screenshot, the original size is already embedded in the image.

<img width="987" alt="Screenshot 2025-03-19 at 17 16 20" src="https://github.com/user-attachments/assets/20941cba-f8df-40bb-900e-3a7b2fa6e6f0" />

## Other notes

- the logic will run only if the viewport width is larger than `1200px`, since this is the current breakpoint at which we switch to a desktop view. The multiplication factor for full width images is calculated based on a `1920px` viewport width. Certain blocks allow the definition of per-device assets, a future iteration of the Assets logic would be helpful to consider those cases as well;
- the image Accessibility logic has also been updated to be in line with the new Assets approach. A status area will now be overlayed over the images with details around its `alt` text. This replaces the previous approach of having a glowing yellow border around decorative images. The update also ensures the `alt` text is clearly visible, which wasn't happening before;
- only images nested inside a `picture` element from the `main` area are considered for the Assets checks. These are typically the ones served through Sharepoint and the content pipeline, although there are exceptions to this rule;
- the details overlay is semi-transparent until the image is hovered, to allow an author to better see the original asset. This is especially useful for small images;
- the logic allows for a 5% tolerance when calculating the multiplication factor;
- as a QA note, unrelated to this PR, a user needs to wait for the page to load before being able to open the Preflight tab.

Resolves: [MWPW-168529](https://jira.corp.adobe.com/browse/MWPW-168529)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/preflight-assets-tab?martech=off
- After: https://assets-preflight-v2--milo--overmyheadandbody.aem.page/drafts/ramuntea/preflight-assets-tab?martech=off

**Other test pages:**
- All images too small: https://main--cc--adobecom.hlx.page/products/audition?martech=off&georouting=off&milolibs=assets-preflight-v2--milo--overmyheadandbody
- Correct & incorrect images, lots of `alt` text: https://main--cc--adobecom.hlx.page/products/photoshop-lightroom?martech=off&georouting=off&milolibs=assets-preflight-v2--milo--overmyheadandbody
- All images correct - https://main--bacom--adobecom.aem.page/support/adobe-partners?martech=off&georouting=off&milolibs=assets-preflight-v2--milo--overmyheadandbody
