### PR TITLE
MWPW-169423 [MEP] MEP button not reporting spoofed Target value

### DIFF
--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -249,6 +249,9 @@ function addMepPopupListeners(popup, pageId) {
 function formatManifestText(count) {
   return count > 1 ? 'Manifests' : 'Manifest';
 }
+function setTargetOnText(target) {
+  return target === 'postlcp' ? 'on post LCP' : target;
+}
 export function getMepPopup(mepConfig, isMmm = false) {
   const { page } = mepConfig;
   const pageId = page?.pageId ? `-${page.pageId}` : '';
@@ -270,7 +273,16 @@ export function getMepPopup(mepConfig, isMmm = false) {
   const mepPopupBody = createTag('div', { class: 'mep-popup-body' });
   const mepManifestList = createTag('div', { class: 'mep-manifest-list' });
 
-  const targetOnText = page.target === 'postlcp' ? 'on post LCP' : page.target;
+  const config = getConfig();
+  const targetMapping = {
+    postlcp: 'postlcp',
+    true: 'on',
+    false: 'off',
+  };
+  const targetEnabled = targetMapping[config.mep.targetEnabled];
+  const mepTarget = isMmm ? page.target : targetEnabled;
+  const targetOnText = setTargetOnText(mepTarget);
+
   mepPageInfo.innerHTML = `
     <h6 class="mep-manifest-page-info-title">Page Info</h6>
     <div class="mep-columns">

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -250,6 +250,7 @@ function formatManifestText(count) {
   return count > 1 ? 'Manifests' : 'Manifest';
 }
 function setTargetOnText(target) {
+  if (target === undefined) return 'off';
   return target === 'postlcp' ? 'on post LCP' : target;
 }
 export function getMepPopup(mepConfig, isMmm = false) {
@@ -279,7 +280,7 @@ export function getMepPopup(mepConfig, isMmm = false) {
     true: 'on',
     false: 'off',
   };
-  const targetEnabled = targetMapping[config.mep.targetEnabled];
+  const targetEnabled = targetMapping[config.mep?.targetEnabled];
   const mepTarget = isMmm ? page.target : targetEnabled;
   const targetOnText = setTargetOnText(mepTarget);
 

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -250,7 +250,6 @@ function formatManifestText(count) {
   return count > 1 ? 'Manifests' : 'Manifest';
 }
 function setTargetOnText(target) {
-  if (target === undefined) return 'off';
   return target === 'postlcp' ? 'on post LCP' : target;
 }
 export function getMepPopup(mepConfig, isMmm = false) {
@@ -279,6 +278,7 @@ export function getMepPopup(mepConfig, isMmm = false) {
     postlcp: 'postlcp',
     true: 'on',
     false: 'off',
+    undefined: 'off',
   };
   const targetEnabled = targetMapping[config.mep?.targetEnabled];
   const mepTarget = isMmm ? page.target : targetEnabled;

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -249,7 +249,8 @@ function addMepPopupListeners(popup, pageId) {
 function formatManifestText(count) {
   return count > 1 ? 'Manifests' : 'Manifest';
 }
-function setTargetOnText(target) {
+function setTargetOnText(target, page) {
+  if (target === undefined) return page.target;
   return target === 'postlcp' ? 'on post LCP' : target;
 }
 export function getMepPopup(mepConfig, isMmm = false) {
@@ -278,11 +279,10 @@ export function getMepPopup(mepConfig, isMmm = false) {
     postlcp: 'postlcp',
     true: 'on',
     false: 'off',
-    undefined: 'off',
   };
   const targetEnabled = targetMapping[config.mep?.targetEnabled];
   const mepTarget = isMmm ? page.target : targetEnabled;
-  const targetOnText = setTargetOnText(mepTarget);
+  const targetOnText = setTargetOnText(mepTarget, page);
 
   mepPageInfo.innerHTML = `
     <h6 class="mep-manifest-page-info-title">Page Info</h6>


### PR DESCRIPTION
This update enables the MEP button to display a spoofed target integration status(i.e., target was set via query parameters), if one is available, and if not, it will continue to show the actual target integration status. 

Steps to QA:
Navigate to the before and after links below and check the Target Integration status on the MEP button:
-Expected(After): 'Target Integration   Off'
-Actual(Before): 'Target Integration    On'

Note: to confirm that mmm is not impacted by this PR and is still only reporting the actual target integration status, I overwrote the preview.js file in my browser, navigated to the photoshop page with ?target=off in the URL, and then checked status listed on the MMM page to confirm that it is still set to "On":
![Screenshot 2025-03-19 at 3 58 09 PM](https://github.com/user-attachments/assets/7d416f0a-71af-4c92-9fb9-653b3181599b)


Resolves: [MWPW-169423](https://jira.corp.adobe.com/browse/MWPW-169423)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q2/meptargetspoofedvalue/targeton?target=off&mep
- After: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q2/meptargetspoofedvalue/targeton?milolibs=meptargetspoofedvalue&target=off&mep
- Psi-check: https://meptargetspoofedvalue--milo--adobecom.aem.page/?martech=off
