### PR TITLE
Fix(Mwpw-166636): Play/Pause not functioning correctly with disable-autoplay plugin.

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -277,7 +277,7 @@ export function addAccessibilityControl(videoString, videoAttrs, indexOfVideo, t
   return `
     <div class='video-container video-holder'>${videoString}
       <a class='pause-play-wrapper' role='button' tabindex=${tabIndex} aria-pressed=true video-index=${indexOfVideo}>
-        <div class='offset-filler ${videoAttrs.includes('autoplay') ? 'is-playing' : ''}'>
+        <div class='offset-filler'>
           <img class='accessibility-control pause-icon' src='${fedRoot}/federal/assets/svgs/accessibility-pause.svg'/>
           <img class='accessibility-control play-icon' src='${fedRoot}/federal/assets/svgs/accessibility-play.svg'/>
         </div>
@@ -324,8 +324,9 @@ export function applyAccessibilityEvents(videoEl) {
     pausePlayWrapper.addEventListener('keydown', handlePause);
   }
   if (videoEl.hasAttribute('autoplay')) {
-    videoEl.addEventListener('canplay', () => { videoEl.play(); });
-    videoEl.addEventListener('ended', () => { syncPausePlayIcon(videoEl); });
+    videoEl.addEventListener('canplay', () => videoEl.play());
+    videoEl.addEventListener('loadstart', () => syncPausePlayIcon(videoEl));
+    videoEl.addEventListener('ended', () => syncPausePlayIcon(videoEl));
   }
 }
 

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -251,9 +251,12 @@ export function getVideoAttrs(hash, dataset) {
   return `${globalAttrs} controls`;
 }
 
-export function syncPausePlayIcon(video) {
+export function syncPausePlayIcon(video, event) {
   if (!video.getAttributeNames().includes('data-hoverplay')) {
     const offsetFiller = video.closest('.video-holder').querySelector('.offset-filler');
+    if (event?.type === 'loadstart' && offsetFiller?.classList.contains('is-playing')) {
+      return;
+    }
     const anchorTag = video.closest('.video-holder').querySelector('a');
     offsetFiller?.classList.toggle('is-playing');
     const isPlaying = offsetFiller?.classList.contains('is-playing');
@@ -261,6 +264,7 @@ export function syncPausePlayIcon(video) {
     const changedLabel = `${isPlaying ? videoLabels?.pauseMotion : videoLabels?.playMotion}`;
     const oldLabel = `${!isPlaying ? videoLabels?.pauseMotion : videoLabels?.playMotion}`;
     const ariaLabel = `${changedLabel} ${indexOfVideo}`.trim();
+    anchorTag?.setAttribute('title', `${ariaLabel}`);
     anchorTag?.setAttribute('aria-label', `${ariaLabel} `);
     anchorTag?.setAttribute('aria-pressed', isPlaying ? 'true' : 'false');
     const daaLL = anchorTag.getAttribute('daa-ll');
@@ -276,7 +280,7 @@ export function addAccessibilityControl(videoString, videoAttrs, indexOfVideo, t
   }
   return `
     <div class='video-container video-holder'>${videoString}
-      <a class='pause-play-wrapper' role='button' tabindex=${tabIndex} aria-pressed=true video-index=${indexOfVideo}>
+      <a class='pause-play-wrapper' title='${videoLabels.pauseMotion}' role='button' tabindex=${tabIndex} aria-pressed=true video-index=${indexOfVideo}>
         <div class='offset-filler'>
           <img class='accessibility-control pause-icon' src='${fedRoot}/federal/assets/svgs/accessibility-pause.svg'/>
           <img class='accessibility-control play-icon' src='${fedRoot}/federal/assets/svgs/accessibility-play.svg'/>
@@ -325,7 +329,7 @@ export function applyAccessibilityEvents(videoEl) {
   }
   if (videoEl.hasAttribute('autoplay')) {
     videoEl.addEventListener('canplay', () => videoEl.play());
-    videoEl.addEventListener('loadstart', () => syncPausePlayIcon(videoEl));
+    videoEl.addEventListener('loadstart', (event) => syncPausePlayIcon(videoEl, event));
     videoEl.addEventListener('ended', () => syncPausePlayIcon(videoEl));
   }
 }


### PR DESCRIPTION
Disable autoplay use case is handled in this PR.

* Added loadstart event to sync the play/pause buttons.
* Specific
* Features or fixes

Resolves: [MWPW-166636](https://jira.corp.adobe.com/browse/MWPW-166636)
Also Resolves: [MWPW-169859](https://jira.corp.adobe.com/browse/MWPW-169859)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ramuntea/accessibility/video-use-cases?martech=off
- After: https://mwpw-166636--milosh--sharath-kannan.hlx.page/drafts/ramuntea/accessibility/video-use-cases?martech=off
