### PR TITLE
MWPW-169160 [MEP] MEP button - made sure that non-target manifest paths match the current domain

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1070,10 +1070,6 @@ export function cleanAndSortManifestList(manifests, conf) {
           ? fullManifest.variants
           : freshManifest.variants;
 
-        if (!targetManifestWinsOverServerManifest) {
-          freshManifest.manifestPath = normalizePath(freshManifest.manifestPath);
-        }
-
         freshManifest.selectedVariant = freshManifest.variants[freshManifest.selectedVariantName];
         manifestObj[manifest.manifestPath] = freshManifest;
       } else {

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1053,6 +1053,7 @@ export function cleanAndSortManifestList(manifests, conf) {
     try {
       if (!manifest?.manifest) return;
       if (!manifest.manifestPath) manifest.manifestPath = normalizePath(manifest.manifest);
+      if (manifest.source && !manifest.source.includes('target')) manifest.manifest = normalizePath(manifest.manifest);
       if (manifest.manifestPath in manifestObj) {
         let fullManifest = manifestObj[manifest.manifestPath];
         let freshManifest = manifest;
@@ -1068,6 +1069,10 @@ export function cleanAndSortManifestList(manifests, conf) {
         freshManifest.variants = targetManifestWinsOverServerManifest
           ? fullManifest.variants
           : freshManifest.variants;
+
+        if (!targetManifestWinsOverServerManifest) {
+          freshManifest.manifestPath = normalizePath(freshManifest.manifestPath);
+        }
 
         freshManifest.selectedVariant = freshManifest.variants[freshManifest.selectedVariantName];
         manifestObj[manifest.manifestPath] = freshManifest;

--- a/test/features/personalization/cleanAndSortManifestList.test.js
+++ b/test/features/personalization/cleanAndSortManifestList.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
 import { cleanAndSortManifestList } from '../../../libs/features/personalization/personalization.js';
+import { getConfig } from '../../../libs/utils/utils.js';
 
 // Note that the manifestPath doesn't matter as we stub the fetch
 describe('Functional test', () => {
@@ -83,5 +84,19 @@ describe('Functional test', () => {
     expect(first.manifestUrl).to.include('pzn-normal.json');
     expect(second.manifestUrl).to.include('none.json');
     expect(third.manifestUrl).to.include('test-normal.json');
+  });
+
+  it('Should normalize manifest path for non-target manifests', async () => {
+    const config = getConfig();
+    config.locales = ['en-US'];
+    config.locale = { ietf: 'en-US' };
+    let manifestJson = await readFile({ path: './mocks/manifestLists/two-manifests-one-from-target.json' });
+    manifestJson = JSON.parse(manifestJson);
+    const [targetManifest, pznManifest] = manifestJson;
+    expect(pznManifest.manifest).to.include('https');
+    expect(targetManifest.manifest).to.include('https');
+    const [cleanPznManifest, cleanTargetManifest] = cleanAndSortManifestList(manifestJson);
+    expect(cleanPznManifest.manifest).to.not.include('https');
+    expect(cleanTargetManifest.manifest).to.include('https');
   });
 });

--- a/test/features/personalization/mocks/manifestLists/two-manifests-one-from-target.json
+++ b/test/features/personalization/mocks/manifestLists/two-manifests-one-from-target.json
@@ -102,7 +102,7 @@
           "fragments": []
       },
       "source": ["pzn"],
-      "manifest": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
+      "manifest": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
       "manifestUrl": "https://main--milo--adobecom.hlx.page/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json",
       "manifestPath": "/drafts/vgoodrich/fragments/2024/q1/mepmanifestorder/manifests/pzn-normal.json"
   }

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -314,7 +314,7 @@ describe('Utils', () => {
 
     it('Does not setup nofollow links', async () => {
       window.fetch = mockFetch({ payload: { data: [] } });
-      await utils.loadDeferred(document, [], { links: 'on' }, () => {});
+      await utils.loadDeferred(document, [], { links: 'on' }, () => { });
       const gaLink = document.querySelector('a[href="https://analytics.google.com/"]');
       expect(gaLink.getAttribute('rel')).to.be.null;
     });
@@ -329,7 +329,7 @@ describe('Utils', () => {
       metaPath.content = '/test/utils/mocks/nofollow.json';
 
       document.head.append(metaOn, metaPath);
-      await utils.loadDeferred(document, [], { contentRoot: '' }, () => {});
+      await utils.loadDeferred(document, [], { contentRoot: '' }, () => { });
       const gaLink = document.querySelector('a[href^="https://analytics.google.com"]');
       expect(gaLink).to.exist;
     });
@@ -785,7 +785,7 @@ describe('Utils', () => {
       div.className = 'global-navigation';
       document.body.appendChild(div);
       window.location.hash = '#not-block';
-      window.scrollBy = () => {};
+      window.scrollBy = () => { };
     });
 
     it('should scroll to the hashed element', () => {
@@ -941,7 +941,7 @@ describe('Utils', () => {
       const resultExperiment = resultConfig.mep.experiments[0];
       expect(resultConfig.mep.preview).to.be.true;
       expect(resultConfig.mep.experiments.length).to.equal(3);
-      expect(resultExperiment.manifest).to.equal('https://main--milo--adobecom.hlx.page/products/special-offers-manifest.json');
+      expect(resultExperiment.manifest).to.equal('/products/special-offers-manifest.json');
     });
   });
 


### PR DESCRIPTION
* MEP Button manifest links: made sure that non-target manifest urls match with the the current domain

Resolves: [MWPW-169160](https://jira.corp.adobe.com/browse/MWPW-169160)

Instructions:

Toggle MEP button and hover over [manifest_name].json link. In BEFORE you will see link has .hlx. in it, which doesn't match the current url(with .aem. instead of .hlx.). In AFTER you will see matching domain.

URL for testing:
- Before: https://main--cc--adobecom.aem.page/drafts/dfedotov/marquee?target=on&mep
- After: https://main--cc--adobecom.aem.page/drafts/dfedotov/marquee?target=on&milolibs=mep-manifest-links&mep
- Psi-check: https://mep-manifest-links--milo--adobecom.aem.page/?martech=off