### PR TITLE
[MWPW-159955] removed video skipa11y

### DIFF
--- a/nala/blocks/video/video.test.js
+++ b/nala/blocks/video/video.test.js
@@ -122,7 +122,7 @@ test.describe('Milo Video Block test suite', () => {
     });
 
     await test.step('step-3: Verify the accessibility test on the MPC Video block', async () => {
-      await runAccessibilityTest({ page, testScope: video.miloVideo, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: video.miloVideo });
     });
   });
 


### PR DESCRIPTION
UPDATE:
It seems that when testing locally the nala tests for Video is going through but on github it is still indeed failing, will be closing the PR, maybe this is also worth a separate ticket to investigate.

Removes skip flag for Video block accessibility test because it is passing it now.

Resolves: [MWPW-159955](https://jira.corp.adobe.com/browse/MWPW-159955)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://milo-a11y-issues--milo--adobecom.aem.page/?martech=off
