### PR TITLE
MWPW-170254 Placeholder are not getting replaced for aria-label

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -44,6 +44,7 @@ const MILO_BLOCKS = [
   'instagram',
   'locui',
   'locui-create',
+  'm7',
   'marketo',
   'marquee',
   'marquee-anchors',
@@ -109,7 +110,9 @@ const AUTO_BLOCKS = [
   { 'pdf-viewer': '.pdf', styles: false },
   { video: '.mp4' },
   { merch: '/tools/ost?' },
-  { 'mas-autoblock': 'mas.adobe.com/studio' },
+  { 'mas-autoblock': 'mas.adobe.com/studio', styles: false },
+  { m7: '/creativecloud/business-plans.html', styles: false },
+  { m7: '/creativecloud/education-plans.html', styles: false },
 ];
 const DO_NOT_INLINE = [
   'accordion',

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -44,7 +44,6 @@ const MILO_BLOCKS = [
   'instagram',
   'locui',
   'locui-create',
-  'm7',
   'marketo',
   'marquee',
   'marquee-anchors',
@@ -110,9 +109,7 @@ const AUTO_BLOCKS = [
   { 'pdf-viewer': '.pdf', styles: false },
   { video: '.mp4' },
   { merch: '/tools/ost?' },
-  { 'mas-autoblock': 'mas.adobe.com/studio', styles: false },
-  { m7: '/creativecloud/business-plans.html', styles: false },
-  { m7: '/creativecloud/education-plans.html', styles: false },
+  { 'mas-autoblock': 'mas.adobe.com/studio' },
 ];
 const DO_NOT_INLINE = [
   'accordion',
@@ -926,9 +923,14 @@ const findReplaceableNodes = (area) => {
     let matchFound = false;
     if (node.nodeType === Node.TEXT_NODE) {
       matchFound = regex.test(node.nodeValue);
-    } else if (node.nodeType === Node.ELEMENT_NODE && node.hasAttribute('href')) {
-      const hrefValue = node.getAttribute('href');
-      matchFound = regex.test(hrefValue);
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const { attributes } = node;
+      for (let i = 0; i < attributes.length; i += 1) {
+        const { value: attrValue } = attributes[i];
+        if (regex.test(attrValue)) {
+          matchFound = true;
+        }
+      }
     }
     if (matchFound) {
       nodes.push(node);


### PR DESCRIPTION
MWPW-170254 Placeholder are not getting replaced for aria-label
Adding functionality to read all the attributes in an element node to be replaced for placeholders.

Resolves: [MWPW-170254](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
Before: https://main--cc--adobecom.aem.live/drafts/suhjain/placeholder/placeholder
After: https://placeholder--milo--suhjainadobe.aem.live?martech=off

**Test URLs for placeholders:**
Before: https://main--cc--adobecom.aem.live/drafts/suhjain/placeholder/placeholder
After: https://main--cc--adobecom.aem.live/drafts/suhjain/placeholder/placeholder?milolibs=placeholder--milo--suhjainadobe
