### PR TITLE
Revert "Tooltips are hidden while hovering over top four icons on Safari browser."

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -34,6 +34,7 @@ header.global-navigation {
   z-index: 10;
   background-color: var(--feds-background-nav);
   box-sizing: content-box;
+  overflow-x: clip;
 }
 
 .feds-topnav-wrapper {
@@ -520,10 +521,6 @@ header.global-navigation {
 
 /* Desktop styles */
 @media (min-width: 900px) {
-  header.global-navigation {
-    contain: layout;
-  }
-
   /* General */
   .global-navigation.has-breadcrumbs {
     padding-bottom: var(--feds-height-breadcrumbs);
@@ -799,14 +796,6 @@ header.new-nav .feds-nav-wrapper {
   transition: translate 0.4s ease-out, opacity 0.4s ease, visibility 0s linear 0.5s;
   display: flex;
   visibility: hidden;
-}
-
-header.new-nav .feds-nav-wrapper:not(:has(.feds-dropdown--active)) {
-  overflow-x: clip;
-}
-
-header.new-nav.global-navigation:has(.feds-dropdown--active) {
-  overflow-x: clip;
 }
 
 [dir = "rtl"] header.new-nav .feds-nav-wrapper {


### PR DESCRIPTION
Reverts adobecom/milo#3815

https://github.com/adobecom/milo/pull/3819#pullrequestreview-2706717736 

This functionality was not tested on firefox + phone + RTL locales. 
As a result of this PR, firefox is added to device automation. @spadmasa 

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://revert-3815-mwpw-161097-fix--milo--patel-prince.aem.page/?martech=off