### PR TITLE
MWPW-160751 - Preflight - Adjust section height limit

### DIFF
--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -193,7 +193,7 @@ a.preflight-edit.da-icon {
 }
 
 .preflight-group-items {
-  max-height: 1000px;
+  max-height: 9000px;
   transition: max-height .2s ease-in-out;
   overflow: hidden;
 }


### PR DESCRIPTION
Adjusting the `max-height `limit so Preflight doesn't truncate/cut off sections with a long list of items.

Resolves: [MWPW-160751](https://jira.corp.adobe.com/browse/MWPW-160751)


**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/?martech=off
- After: https://preflight-scrolling--milo--adobecom.hlx.page/?martech=off


**Homepage Test URLs:**
- Before: https://main--homepage--adobecom.hlx.page/kr/homepage/index-loggedout?martech=off
- After: https://main--homepage--adobecom.hlx.page/kr/homepage/index-loggedout?milolibs=preflight-scrolling&martech=off

**Testing notes:**

- Open a page that has a lot of fragments being used (10+). 
- Launch Preflight.
- Under the general tab, you should see the full list of fragments. The section shouldn't be truncated/cut off.
- The homepage test url has a big list of fragments under the general tab.