### PR TITLE
MWPW-170175: Dynamic Nav Reset

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1435,6 +1435,5 @@ export default async function init(block) {
   block.setAttribute('daa-lh', `gnav|${getExperienceName()}${mepMartech}`);
   if (isDarkMode()) block.classList.add('feds--dark');
   block.classList.add('ready');
-  window.dispatchEvent(new CustomEvent('feds:navLoaded'));
   return gnav;
 }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1435,5 +1435,6 @@ export default async function init(block) {
   block.setAttribute('daa-lh', `gnav|${getExperienceName()}${mepMartech}`);
   if (isDarkMode()) block.classList.add('feds--dark');
   block.classList.add('ready');
+  window.dispatchEvent(new CustomEvent('feds:navLoaded'));
   return gnav;
 }

--- a/libs/features/dynamic-navigation/dynamic-navigation.js
+++ b/libs/features/dynamic-navigation/dynamic-navigation.js
@@ -23,21 +23,25 @@ function dynamicNavGroupMatches(groupMetaData) {
 }
 
 export default function dynamicNav(url, key) {
+  const storageSource = 'gnavSource';
+  const storageKey = 'dynamicNavKey';
+  const storageGroup = 'dynamicNavGroup';
+
   if (foundDisableValues()) return url;
   const metadataContent = getMetadata('dynamic-nav');
   const dynamicNavGroup = getMetadata('dynamic-nav-group');
 
   if (metadataContent === 'reset') {
-    window.sessionStorage.removeItem('gnavSource', url);
-    window.sessionStorage.removeItem('dynamicNavKey', key);
-    window.sessionStorage.removeItem('dynamicNavGroup', dynamicNavGroup);
+    window.sessionStorage.removeItem(storageSource, url);
+    window.sessionStorage.removeItem(storageKey, key);
+    window.sessionStorage.removeItem(storageGroup, dynamicNavGroup);
     return url;
   }
 
   if (metadataContent === 'entry') {
-    window.sessionStorage.setItem('gnavSource', url);
-    window.sessionStorage.setItem('dynamicNavKey', key);
-    if (dynamicNavGroup) window.sessionStorage.setItem('dynamicNavGroup', dynamicNavGroup);
+    window.sessionStorage.setItem(storageSource, url);
+    window.sessionStorage.setItem(storageKey, key);
+    if (dynamicNavGroup) window.sessionStorage.setItem(storageGroup, dynamicNavGroup);
     return url;
   }
 
@@ -45,7 +49,7 @@ export default function dynamicNav(url, key) {
     if (!dynamicNavGroupMatches(dynamicNavGroup)) return url;
   }
 
-  if (metadataContent !== 'on' || key !== window.sessionStorage.getItem('dynamicNavKey')) return url;
+  if (metadataContent !== 'on' || key !== window.sessionStorage.getItem(storageKey)) return url;
 
-  return window.sessionStorage.getItem('gnavSource') || url;
+  return window.sessionStorage.getItem(storageSource) || url;
 }

--- a/libs/features/dynamic-navigation/dynamic-navigation.js
+++ b/libs/features/dynamic-navigation/dynamic-navigation.js
@@ -27,6 +27,13 @@ export default function dynamicNav(url, key) {
   const metadataContent = getMetadata('dynamic-nav');
   const dynamicNavGroup = getMetadata('dynamic-nav-group');
 
+  if (metadataContent === 'reset') {
+    window.sessionStorage.removeItem('gnavSource', url);
+    window.sessionStorage.removeItem('dynamicNavKey', key);
+    window.sessionStorage.removeItem('dynamicNavGroup', dynamicNavGroup);
+    return url;
+  }
+
   if (metadataContent === 'entry') {
     window.sessionStorage.setItem('gnavSource', url);
     window.sessionStorage.setItem('dynamicNavKey', key);

--- a/libs/features/dynamic-navigation/status.css
+++ b/libs/features/dynamic-navigation/status.css
@@ -27,6 +27,11 @@
   background-color: #e20;  
 }
 
+.dynamic-nav-status.reset {
+  background-color: #707070;  
+}
+
+
 .dns-badge {
   border: 2px solid white;
   border-radius: 32px;

--- a/libs/features/dynamic-navigation/status.css
+++ b/libs/features/dynamic-navigation/status.css
@@ -31,7 +31,6 @@
   background-color: #707070;  
 }
 
-
 .dns-badge {
   border: 2px solid white;
   border-radius: 32px;

--- a/libs/features/dynamic-navigation/status.css
+++ b/libs/features/dynamic-navigation/status.css
@@ -11,7 +11,7 @@
   position: fixed;
   max-width: 115px;
   height: 32px;
-  z-index: 2;
+  z-index: 5;
   top: 40px;
   right: 32px;
   bottom: auto;

--- a/libs/features/dynamic-navigation/status.css
+++ b/libs/features/dynamic-navigation/status.css
@@ -3,12 +3,19 @@
   border-radius: 32px;
   color: #eee;
   font-size: 16px;
-  padding: 12px 24px;
+  padding: 2px 24px;
   cursor: pointer;
   display: flex;
   align-items: center;
   margin: 12px;
-  position: relative;
+  position: fixed;
+  max-width: 115px;
+  height: 32px;
+  z-index: 2;
+  top: 40px;
+  right: 32px;
+  bottom: auto;
+  left: auto;
 }
 
 .dynamic-nav-status .title { 
@@ -116,7 +123,7 @@
 .dynamic-nav-status .details {
   position: absolute;
   top: 60px;
-  right: 0;
+  right: -14px;
   background-color: #444;
   min-width: 300px;
   border-radius: 16px;

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -130,28 +130,15 @@ const createStatusWidget = (dynamicNavKey) => {
   return statusWidget;
 };
 
-const loadWidget = (navKey) => {
-  const statusWidget = createStatusWidget(navKey);
-  const topNav = document.querySelector('.feds-topnav');
-  const fedsWrapper = document.querySelector('.feds-nav-wrapper');
+export default async function main() {
+  const { dynamicNavKey } = getConfig();
+  const statusWidget = createStatusWidget(dynamicNavKey);
+  const topNav = document.querySelector('.global-navigation');
   const dnsClose = statusWidget.querySelector('.dns-close');
 
   dnsClose.addEventListener('click', () => {
     topNav.removeChild(statusWidget);
   });
 
-  if (fedsWrapper) fedsWrapper.after(statusWidget);
-};
-
-export default async function main() {
-  const { dynamicNavKey } = getConfig();
-
-  if (document.querySelector('.feds-nav-wrapper')) {
-    loadWidget(dynamicNavKey);
-    return;
-  }
-
-  window.addEventListener('feds:navLoaded', () => {
-    loadWidget(dynamicNavKey);
-  });
+  if (topNav) topNav.appendChild(statusWidget);
 }

--- a/libs/features/dynamic-navigation/status.js
+++ b/libs/features/dynamic-navigation/status.js
@@ -4,10 +4,12 @@ import { foundDisableValues } from './dynamic-navigation.js';
 export const ACTIVE = 'active';
 export const ENABLED = 'enabled';
 export const INACTIVE = 'inactive';
+export const RESET = 'reset';
 export const tooltipInfo = {
   active: 'Displayed in green, this status appears when a user is on an entry page or a page with the Dynamic Nav enabled, indicating that the nav is fully functioning.',
   enabled: 'Displayed in yellow, this status indicates that the Dynamic Nav is set to "on," but the user has not yet visited an entry page.',
   inactive: 'Displayed in red, this status indicates that the Dynamic Nav is either not configured or has been disabled.',
+  reset: 'Displayed in grey, this status indicates that this page resets the Dynamic Nav.',
 };
 
 const getCurrentSource = (status, storageSource, authoredSource) => {
@@ -19,6 +21,8 @@ const getCurrentSource = (status, storageSource, authoredSource) => {
 
 const getStatus = (status, disabled, storageSource) => {
   if (status === 'entry') return ACTIVE;
+
+  if (status === 'reset') return RESET;
 
   if (disabled) return INACTIVE;
 
@@ -126,9 +130,8 @@ const createStatusWidget = (dynamicNavKey) => {
   return statusWidget;
 };
 
-export default async function main() {
-  const { dynamicNavKey } = getConfig();
-  const statusWidget = createStatusWidget(dynamicNavKey);
+const loadWidget = (navKey) => {
+  const statusWidget = createStatusWidget(navKey);
   const topNav = document.querySelector('.feds-topnav');
   const fedsWrapper = document.querySelector('.feds-nav-wrapper');
   const dnsClose = statusWidget.querySelector('.dns-close');
@@ -138,4 +141,17 @@ export default async function main() {
   });
 
   if (fedsWrapper) fedsWrapper.after(statusWidget);
+};
+
+export default async function main() {
+  const { dynamicNavKey } = getConfig();
+
+  if (document.querySelector('.feds-nav-wrapper')) {
+    loadWidget(dynamicNavKey);
+    return;
+  }
+
+  window.addEventListener('feds:navLoaded', () => {
+    loadWidget(dynamicNavKey);
+  });
 }

--- a/test/features/dynamic-nav/dynamicNav.test.js
+++ b/test/features/dynamic-nav/dynamicNav.test.js
@@ -105,4 +105,18 @@ describe('Dynamic nav', () => {
     const url = dynamicNav('gnav/aem-sites', 'bacom');
     expect(url).to.equal('some-source-string');
   });
+
+  // Reset should be the last test in file
+  it('Clears storage and returns the provided url if dynamic nav is set to reset', async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/reset.html' });
+    window.sessionStorage.setItem('gnavSource', 'test');
+    window.sessionStorage.setItem('dynamicNavKey', 'test');
+    window.sessionStorage.setItem('dynamicNavGroup', 'test');
+
+    const url = dynamicNav('gnav/aem-sites', 'bacom');
+    expect(url).to.equal('gnav/aem-sites');
+    expect(window.sessionStorage.getItem('gnavSource')).to.be.null;
+    expect(window.sessionStorage.getItem('dynamicNavKey')).to.be.null;
+    expect(window.sessionStorage.getItem('dynamicNavGroup')).to.be.null;
+  });
 });

--- a/test/features/dynamic-nav/mocks/reset.html
+++ b/test/features/dynamic-nav/mocks/reset.html
@@ -1,0 +1,1 @@
+<meta name="dynamic-nav" content="reset">

--- a/test/features/dynamic-nav/mocks/status.html
+++ b/test/features/dynamic-nav/mocks/status.html
@@ -1,9 +1,4 @@
 <header>
-  <nav class="feds-topnav" aria-label="Main">
-    <div class="feds-brand-container">
-    </div>
-    <div class="feds-nav-wrapper" id="feds-nav-wrapper">
-      <div class="feds-nav"></div>
-    </div>
+  <nav class="global-navigation" aria-label="Main">
   </nav>
 </header>

--- a/test/features/dynamic-nav/status.test.js
+++ b/test/features/dynamic-nav/status.test.js
@@ -17,7 +17,7 @@ const statusText = (parentElement) => {
   return info;
 };
 
-const GNAV_SOURCE = 'https://main--milo--adobecom.hlx.live/some-source-string';
+const GNAV_SOURCE = 'https://main--milo--adobecom.aem.live/some-source-string';
 
 describe('Dynamic Nav Status', () => {
   beforeEach(async () => {
@@ -128,7 +128,7 @@ describe('Dynamic Nav Status', () => {
 
     it('displays the correct information to the user for the active state "on"', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
       window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
 
       dynamicNav();
@@ -147,7 +147,7 @@ describe('Dynamic Nav Status', () => {
 
     it('displays the correct information to the user for the active state "off"', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', '');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
       window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
 
       dynamicNav();
@@ -166,7 +166,7 @@ describe('Dynamic Nav Status', () => {
 
     it('displays the correct information to the user for the enabled state "on"', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
 
       dynamicNav();
       status();
@@ -184,7 +184,7 @@ describe('Dynamic Nav Status', () => {
 
     it('displays the correct information to the user for the enabled state "reset"', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'reset');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
 
       dynamicNav();
       status();
@@ -202,7 +202,7 @@ describe('Dynamic Nav Status', () => {
 
     it('displays the correct information for a group match', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
 
       dynamicNav();
       status();
@@ -218,7 +218,7 @@ describe('Dynamic Nav Status', () => {
 
     it('displays the correct information for a group mismatch', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
 
       window.sessionStorage.setItem('dynamicNavGroup', 'no-test');
 
@@ -236,7 +236,7 @@ describe('Dynamic Nav Status', () => {
 
     it('displays the correct information for no group being set', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
 
       document.querySelector('meta[name="dynamic-nav-group"]').remove();
       window.sessionStorage.setItem('dynamicNavGroup', 'no-test');
@@ -254,7 +254,7 @@ describe('Dynamic Nav Status', () => {
 
     it('remains active when there is no group match but the nav is active', () => {
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
 
       document.querySelector('meta[name="dynamic-nav-group"]').remove();
       window.sessionStorage.setItem('dynamicNavGroup', 'no-test');
@@ -274,7 +274,7 @@ describe('Dynamic Nav Status', () => {
       const ppn = createTag('meta', { name: 'primaryproductname', content: 'Commerce Cloud' });
       document.querySelector('head').append(disableTag, ppn);
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
       window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
 
       dynamicNav();
@@ -291,7 +291,7 @@ describe('Dynamic Nav Status', () => {
       const ppn = createTag('meta', { name: 'primaryproductname', content: 'Commerce Cloud' });
       document.querySelector('head').append(disableTag, ppn);
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
       window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
 
       dynamicNav();
@@ -308,7 +308,7 @@ describe('Dynamic Nav Status', () => {
       const ppn = createTag('meta', { name: 'primaryproductname', content: 'Commerce Cloud' });
       document.querySelector('head').append(disableTag, ppn);
       document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'on');
-      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.aem.live/test');
       window.sessionStorage.setItem('gnavSource', GNAV_SOURCE);
 
       dynamicNav();

--- a/test/features/dynamic-nav/status.test.js
+++ b/test/features/dynamic-nav/status.test.js
@@ -2,7 +2,7 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { getConfig, setConfig, createTag, loadDeferred } from '../../../libs/utils/utils.js';
 import dynamicNav from '../../../libs/features/dynamic-navigation/dynamic-navigation.js';
-import status, { tooltipInfo, ACTIVE, INACTIVE, ENABLED } from '../../../libs/features/dynamic-navigation/status.js';
+import status, { tooltipInfo, ACTIVE, INACTIVE, ENABLED, RESET } from '../../../libs/features/dynamic-navigation/status.js';
 
 const statusText = (parentElement) => {
   const info = {
@@ -88,6 +88,16 @@ describe('Dynamic Nav Status', () => {
     expect(statusWidget.classList.contains(ENABLED)).to.be.true;
   });
 
+  it('loads the status widget in a reset state', () => {
+    document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'reset');
+
+    dynamicNav();
+    status();
+
+    const statusWidget = document.querySelector('.dynamic-nav-status');
+    expect(statusWidget.classList.contains(RESET)).to.be.true;
+  });
+
   it('loads the status widget in an inactive state', () => {
     dynamicNav();
     status();
@@ -166,6 +176,24 @@ describe('Dynamic Nav Status', () => {
       expect(info.additionalInfo).to.equal(tooltipInfo[ENABLED]);
       expect(info.status).to.equal(ENABLED);
       expect(info.setting).to.equal('on');
+      expect(info.consumerKey).to.equal('bacom');
+      expect(info.match).to.equal('true');
+      expect(info.authoredSource).to.equal('/test');
+      expect(info.storedSource).to.equal('/test');
+    });
+
+    it('displays the correct information to the user for the enabled state "reset"', () => {
+      document.querySelector('meta[name="dynamic-nav"]').setAttribute('content', 'reset');
+      document.querySelector('meta[name="gnav-source"]').setAttribute('content', 'https://main--milo--adobecom.hlx/test');
+
+      dynamicNav();
+      status();
+
+      const statusWidget = document.querySelector('.dynamic-nav-status');
+      const info = statusText(statusWidget);
+      expect(info.additionalInfo).to.equal(tooltipInfo[RESET]);
+      expect(info.status).to.equal(RESET);
+      expect(info.setting).to.equal('reset');
       expect(info.consumerKey).to.equal('bacom');
       expect(info.match).to.equal('true');
       expect(info.authoredSource).to.equal('/test');

--- a/test/features/dynamic-nav/status.test.js
+++ b/test/features/dynamic-nav/status.test.js
@@ -48,15 +48,15 @@ describe('Dynamic Nav Status', () => {
     expect(statusWidget).to.exist;
   });
 
-  it('does not load the widget on when gnav v2 is not present', () => {
-    const feds = document.querySelector('.feds-nav-wrapper');
-    feds.classList.remove('feds-nav-wrapper');
+  it('does not load the widget when gnav v2 is not present', () => {
+    const globalNav = document.querySelector('.global-navigation');
+    globalNav.classList.remove('global-navigation');
     dynamicNav();
     status();
 
     const statusWidget = document.querySelector('.dynamic-nav-status');
     expect(statusWidget).to.be.null;
-    feds.classList.add('feds-nav-wrapper');
+    globalNav.classList.add('global-navigation');
   });
 
   it('loads the status widget', () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds a "reset" functionality to the dynamic nav, allowing pages to reset the experience entirely
* Adds the dispatching of a custom event when the global-navigation is done loading to address code execution order issue with status.js 

Resolves: [MWPW-MWPW-170175](https://jira.corp.adobe.com/browse/MWPW-MWPW-170175)

**Test URLs:**
- Before: https://main--milo--jasonhowellslavin.hlx.page/drafts/slavin/dynamic-nav/bacom-sample-on?martech=off
- After: https://dynamic-nav-reset--milo--jasonhowellslavin.hlx.page/drafts/slavin/dynamic-nav/bacom-sample-on?martech=off

Bacom
- Before: https://main--bacom--adobecom.hlx.page/drafts/slavin/dynamic-nav/aem-rtcdp-entry?martech=off
- After: https://main--bacom--adobecom.hlx.page/drafts/slavin/dynamic-nav/aem-rtcdp-entry?milolibs=dynamic-nav-reset&martech=off
