### PR TITLE
Upgrading package version for bundled gnav to 0.0.7

### DIFF
--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Upgrading standalone gnav version to 0.0.7

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-version--milo--adobecom.aem.page/?martech=off
