### PR TITLE
MWPW-169084: mas-autoblock to listen ?query as well.

### DIFF
--- a/libs/blocks/mas-autoblock/mas-autoblock.js
+++ b/libs/blocks/mas-autoblock/mas-autoblock.js
@@ -10,7 +10,7 @@ export function getFragmentId(el) {
   const { hash } = new URL(el.href);
   const hashValue = hash.startsWith('#') ? hash.substring(1) : hash;
   const searchParams = new URLSearchParams(hashValue);
-  return searchParams.get('fragment');
+  return searchParams.get('query') || searchParams.get('fragment');
 }
 
 /**


### PR DESCRIPTION
Resolves: [MWPW-169084](https://jira.corp.adobe.com/browse/MWPW-169084)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/seanchoi/merch-card-comm?martech=off
- After: https://MWPW-169084--milo--adobecom.aem.page/drafts/seanchoi/merch-card-comm?martech=off
