### PR TITLE
[MWPW-169395] - Table aria labels missing

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -697,8 +697,8 @@
     border-top-right-radius: var(--border-radius);
   }
 
-  .table .row .col.hide-mobile {
-    display: none;
+  .table .hide-mobile {
+    display: none !important;
   }
 }
 

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -697,8 +697,8 @@
     border-top-right-radius: var(--border-radius);
   }
 
-  .hide-mobile {
-    display: none !important;
+  .table .row .col.hide-mobile {
+    display: none;
   }
 }
 

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -696,6 +696,10 @@
     border-top-left-radius: 0;
     border-top-right-radius: var(--border-radius);
   }
+
+  .hide-mobile {
+    display: none !important;
+  }
 }
 
 /* Start mobile styles */

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -9,6 +9,8 @@ const DESKTOP_SIZE = 900;
 const MOBILE_SIZE = 768;
 const tableHighlightLoadedEvent = new Event('milo:table:highlight:loaded');
 let tableIndex = 0;
+let isExpandEventsAssigned = false;
+
 const isMobileLandscape = () => (window.matchMedia('(orientation: landscape)').matches && window.innerHeight <= MOBILE_SIZE);
 function defineDeviceByScreenSize() {
   const screenWidth = window.innerWidth;
@@ -264,6 +266,22 @@ function handleExpand(e) {
   }
 }
 
+function setExpandEvents(el) {
+  if (isExpandEventsAssigned) return;
+
+  el.querySelectorAll('.icon.expand').forEach((icon) => {
+    isExpandEventsAssigned = true;
+    icon.parentElement.classList.add('point-cursor');
+    icon.parentElement.addEventListener('click', () => handleExpand(icon));
+    icon.parentElement.setAttribute('tabindex', 0);
+    icon.parentElement.addEventListener('keydown', (e) => {
+      if (e.key === ' ') e.preventDefault();
+
+      if (e.key === 'Enter' || e.key === ' ') handleExpand(icon);
+    });
+  });
+}
+
 function handleTitleText(cell) {
   if (cell.querySelector('.table-title-text')) return;
   const textSpan = createTag('span', { class: 'table-title-text' });
@@ -483,21 +501,6 @@ function applyStylesBasedOnScreenSize(table, originTable) {
     }
   };
 
-  const reAssignEvents = (tableEl) => {
-    tableEl.dispatchEvent(tableHighlightLoadedEvent);
-    tableEl.querySelectorAll('.icon.expand').forEach((icon) => {
-      icon.parentElement.classList.add('point-cursor');
-      icon.parentElement.addEventListener('click', () => handleExpand(icon));
-      icon.parentElement.setAttribute('tabindex', 0);
-      icon.parentElement.addEventListener('keydown', (e) => {
-        if (e.key === ' ') e.preventDefault();
-
-        if (e.key === 'Enter' || e.key === ' ') handleExpand(icon);
-      });
-    });
-    handleHovering(tableEl);
-  };
-
   const mobileRenderer = () => {
     table.dispatchEvent(tableHighlightLoadedEvent);
     const headings = table.querySelectorAll('.row-heading .col');
@@ -627,7 +630,8 @@ function applyStylesBasedOnScreenSize(table, originTable) {
     });
   }
 
-  reAssignEvents(table);
+  table.dispatchEvent(tableHighlightLoadedEvent);
+  handleHovering(table);
   setRowStyle();
 }
 
@@ -700,6 +704,8 @@ export default function init(el) {
     });
 
     isDecorated = true;
+
+    setExpandEvents(el);
     setAriaLabelForIcons(el);
     setTooltipListeners(el);
   };

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -622,12 +622,12 @@ function applyStylesBasedOnScreenSize(table, originTable) {
         });
       });
     }
-    reAssignEvents(table);
     table.parentElement.querySelectorAll('.filters select').forEach((select, index) => {
       select.querySelectorAll('option').item(index).selected = true;
     });
   }
 
+  reAssignEvents(table);
   setRowStyle();
 }
 

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -543,9 +543,7 @@ function applyStylesBasedOnScreenSize(table, originTable) {
         const selectedCol = filters[0] + 1;
         rows.forEach((row) => {
           const selectedColumn = row.querySelector(`.col-${selectedCol}`);
-          if (!selectedColumn) {
-            return;
-          }
+          if (!selectedColumn) return;
 
           selectedColumn.classList.remove('force-last');
           selectedColumn.classList.remove('rounded-left', 'rounded-right');
@@ -595,14 +593,9 @@ function applyStylesBasedOnScreenSize(table, originTable) {
     }
   };
 
-  const removeClones = () => {
-    const rows = table.querySelectorAll('.row');
-
-    rows.forEach((row) => {
-      const clonedCols = row.querySelectorAll('.col[data-cloned]');
-      clonedCols.forEach((col) => col.remove());
-    });
-  };
+  const removeClones = () => table
+    .querySelectorAll('.row .col[data-cloned]')
+    .forEach((clonedCol) => clonedCol.remove());
 
   // For Mobile (else: tablet / desktop)
   if (!isMerch && !table.querySelector('.row-heading .col-2')) {
@@ -610,22 +603,13 @@ function applyStylesBasedOnScreenSize(table, originTable) {
     table.querySelector('.row-heading .col-1').style.display = 'flex';
   }
 
+  removeClones();
   if (deviceBySize === 'MOBILE' || (isMerch && deviceBySize === 'TABLET')) {
-    removeClones();
     mobileRenderer();
   } else {
-    removeClones();
     table.querySelectorAll('.hide-mobile').forEach((col) => { col.classList.remove('hide-mobile'); });
-    const element = table.querySelector('.row-heading');
-
-    if (element) {
-      const columns = [...element.children];
-      columns.forEach(({ children }) => {
-        [...children].forEach((row) => {
-          row.style.removeProperty('height');
-        });
-      });
-    }
+    [...(table.querySelector('.row-heading')?.children || [])]
+      .forEach((column) => [...column.children].forEach((row) => row.style.removeProperty('height')));
     table.parentElement.querySelectorAll('.filters select').forEach((select, index) => {
       select.querySelectorAll('option').item(index).selected = true;
     });

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -553,6 +553,7 @@ function applyStylesBasedOnScreenSize(table, originTable) {
           clone.setAttribute('data-cloned', 'true');
           clone.classList.remove('rounded-left', 'rounded-right');
           row.appendChild(clone);
+          setTooltipListeners(clone);
         });
       }
 

--- a/test/blocks/table/table.test.js
+++ b/test/blocks/table/table.test.js
@@ -62,9 +62,7 @@ describe('table and tablemetadata', () => {
       window.innerWidth = 760;
       window.dispatchEvent(new Event('resize'));
       const filters = await waitForElement('.filters');
-      const col5 = table.querySelector('.col-5');
       expect(filters).to.be.exist;
-      expect(col5).to.be.null;
     });
 
     it('filter test: for case of both filter poiting same options', async () => {


### PR DESCRIPTION
This resolves the issue where aria-labels were missing from Table CTA's, the main problem here was that Table.js and Merch.js are being executed in parallel and in the Table.js we were earlier using innerHtml to change the Table when the user resized or filtered the the tables in mobile mode, this caused the aria-labels that were being set in Merch.js to be set on the old table which was being replaced with a new table in Table.js, also columns were being removed from the DOM in curtain situations which was an additional problem causing the removal of aria-labels.

**Dev Notes**
Leaving this part in`.table .hide-mobile {
    display: none !important;
  }`. We would need to list at least 5 classes with high css specificity to override the display properties of some elements that need to be hidden, seems to be a safer option here and less lines.

**QA Notes**
It would be a good idea to test all the functionalities of the table since with this PR we are no longer using innerHtml which was at the core of the tables functionalities, especially filtering on mobile and the resizing of the screen.
[List of Pages where Tables are present](https://github.com/user-attachments/files/19504755/Some.pages.with.tables.md)

Resolves: [MWPW-169395](https://jira.corp.adobe.com/browse/MWPW-169395)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
- After: https://table-aria-labels--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off

**CC Merch Test URLs**
- Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/photoshop/compare-plans/table/individual/default?martech=off
- After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/photoshop/compare-plans/table/individual/default?milolibs=table-aria-labels&martech=off

- Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/photoshop/compare-plans/table/edu/default?martech=off
- After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/photoshop/compare-plans/table/edu/default?milolibs=table-aria-labels&martech=off