### PR TITLE
[OPT-31058] Test block support for EMEA-1435

### DIFF
--- a/libs/mep/emea1435/susi-light/susi-light.css
+++ b/libs/mep/emea1435/susi-light/susi-light.css
@@ -1,5 +1,156 @@
 /* preserving modal space for ux */
 .dialog-modal:has(.susi-light) {
-    width: 360px;
-    min-height: 462px;
+  width: 360px;
+  min-height: 462px;
+}
+
+.dialog-modal:has(.susi-light.tabs) {
+width: 400px;
+min-height: 462px;
+}
+
+.susi-light {
+display: flex;
+align-items: center;
+justify-content: center;
+line-height: initial;
+}
+
+.susi-tabs {
+text-align: center;
+display: flex;
+flex-direction: column;
+align-items: center;
+}
+
+.susi-tabs .express-logo {
+width: unset;
+height: 24px;
+padding-top: 32px;
+}
+
+.susi-tabs .title {
+font-size: var(--heading-font-size-s);
+line-height: 28.6px;
+font-weight: 900;
+padding-top: 12px;
+text-align: center;
+}
+
+.susi-tabs [role='tablist'] {
+background-color: #e6e6e6;
+border-radius: 8px;
+display: flex;
+gap: 4px;
+padding: 4px;
+margin-top: 16px;
+}
+
+.susi-tabs [role='tablist']:has(:first-child:last-child) {
+display: none;
+}
+
+.susi-tabs [role='tab'] {
+background-color: #e6e6e6;
+color: #222222;
+border: initial;
+font-family: var(--body-font-family);
+font-size: var(--body-font-size-xs);
+font-weight: 700;
+padding: 8px 12px 10px;
+line-height: 130%;
+cursor: pointer;
+}
+
+.susi-tabs [role='tab'][aria-selected='true'] {
+background-color: var(--color-white);
+border-radius: 6px;
+}
+
+.susi-tabs [role='tabpanel'] {
+width: 400px;
+max-width: 95vw;
+}
+
+.susi-tabs [role='tabpanel'].hide {
+display: none;
+}
+
+/* reduce CLS */
+.susi-tabs [role='tabpanel'].standard .susi-wrapper {
+min-height: 457.5px;
+}
+
+.susi-tabs [role='tabpanel'].edu-express .susi-wrapper {
+min-height: 366.5px;
+}
+
+.susi-tabs .footer {
+font-size: var(--body-font-size-s);
+text-align: center;
+padding: 16px 0;
+font-weight: 700;
+color: #292929;
+line-height: 20.8px;
+}
+
+.susi-tabs .footer a {
+text-decoration: underline;
+color: initial;
+font-weight: 500;
+}
+
+.susi-tabs .footer.susi-banner {
+background-color: #f3f3f3;
+}
+
+.susi-tabs .footer.susi-bubbles {
+padding-bottom: 32px
+}
+
+.susi-tabs .footer.susi-bubbles h2 {
+font-size: var(--body-font-size-l);
+font-weight: 700;
+line-height: var(--heading-line-height);
+margin: 0;
+}
+
+.susi-tabs .footer .susi-bubble-container {
+display: flex;
+gap: 12px;
+justify-content: center;
+padding-top: 8px;
+}
+
+.susi-tabs .footer .susi-bubble {
+font-size: var(--body-font-size-s);
+background-color: #f3f3f3;
+display: flex;
+flex-direction: column;
+padding: 12px 24px;
+border-radius: 8px;
+margin: 0;
+}
+
+/* ax-login-page section metadata styles */
+.section.ax-login-page .susi-tabs {
+background-color: var(--color-white);
+border-radius: 16px;
+}
+
+.section.ax-login-page .susi-light {
+padding-bottom: 48px;
+}
+.section.ax-login-page .susi-tabs .footer {
+border-radius: 8px;
+}
+
+@media (min-width: 768px) {
+.section.ax-login-page .susi-light {
+  position: absolute;
+  padding-top: 30px;
+}
+.section.ax-login-page .susi-tabs .footer {
+  border-radius: 0 0 16px 16px;
+}
 }

--- a/libs/mep/emea1435/susi-light/susi-light.css
+++ b/libs/mep/emea1435/susi-light/susi-light.css
@@ -1,0 +1,5 @@
+/* preserving modal space for ux */
+.dialog-modal:has(.susi-light) {
+    width: 360px;
+    min-height: 462px;
+}

--- a/libs/mep/emea1435/susi-light/susi-light.js
+++ b/libs/mep/emea1435/susi-light/susi-light.js
@@ -4,7 +4,148 @@ import { createTag, loadScript, getConfig, loadIms } from '../../../utils/utils.
 
 let isStage;
 
-const variant = 'edu-express';
+function sanitizeInput(input) {
+  if (Number.isInteger(input)) return input;
+  return input.replace(/[^a-zA-Z0-9-_]/g, ''); // Simple regex to strip out potentially dangerous characters
+}
+
+function createSVGWrapper(icon, sheetSize, alt, altSrc) {
+  const svgWrapper = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svgWrapper.classList.add('icon');
+  svgWrapper.classList.add(`icon-${icon}`);
+  svgWrapper.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns', 'http://www.w3.org/1999/xlink');
+  if (alt) {
+    svgWrapper.appendChild(createTag('title', { innerText: alt }));
+  }
+  const u = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+  if (altSrc) {
+    u.setAttribute('href', altSrc);
+  } else {
+    u.setAttribute('href', `/express/code/icons/ccx-sheet_${sanitizeInput(sheetSize)}.svg#${sanitizeInput(icon)}${sanitizeInput(sheetSize)}`);
+  }
+  svgWrapper.appendChild(u);
+  return svgWrapper;
+}
+
+export function getIconDeprecated(icons, alt, size = 44, altSrc) {
+  // eslint-disable-next-line no-param-reassign
+  icons = Array.isArray(icons) ? icons : [icons];
+  const [defaultIcon, mobileIcon] = icons;
+  const icon = mobileIcon && window.innerWidth < 600 ? mobileIcon : defaultIcon;
+  const symbols = [
+    'adobefonts',
+    'adobe-stock',
+    'android',
+    'animation',
+    'blank',
+    'brand',
+    'brand-libraries',
+    'brandswitch',
+    'calendar',
+    'certified',
+    'color-how-to-icon',
+    'changespeed',
+    'check',
+    'chevron',
+    'cloud-storage',
+    'crop-image',
+    'crop-video',
+    'convert',
+    'convert-png-jpg',
+    'cursor-browser',
+    'desktop',
+    'desktop-round',
+    'download',
+    'elements',
+    'facebook',
+    'globe',
+    'incredibly-easy',
+    'instagram',
+    'image',
+    'ios',
+    'libraries',
+    'library',
+    'linkedin',
+    'magicwand',
+    'mergevideo',
+    'mobile-round',
+    'muteaudio',
+    'palette',
+    'photos',
+    'photoeffects',
+    'pinterest',
+    'play',
+    'premium-templates',
+    'pricingfree',
+    'pricingpremium',
+    'privacy',
+    'qr-code',
+    'remove-background',
+    'resize',
+    'resize-video',
+    'reversevideo',
+    'rush',
+    'snapchat',
+    'sparkpage',
+    'sparkvideo',
+    'stickers',
+    'templates',
+    'text',
+    'tiktok',
+    'trim-video',
+    'twitter',
+    'up-download',
+    'upload',
+    'users',
+    'webmobile',
+    'youtube',
+    'star',
+    'star-half',
+    'star-empty',
+    'pricing-gen-ai',
+    'pricing-features',
+    'pricing-import',
+    'pricing-motion',
+    'pricing-stock',
+    'pricing-one-click',
+    'pricing-collaborate',
+    'pricing-premium-plan',
+    'pricing-sync',
+    'pricing-brand',
+    'pricing-calendar',
+    'pricing-fonts',
+    'pricing-libraries',
+    'pricing-cloud',
+    'pricing-support',
+    'pricing-sharing',
+    'pricing-history',
+    'pricing-corporate',
+    'pricing-admin',
+  ];
+
+  const size22Icons = ['chevron', 'pricingfree', 'pricingpremium'];
+
+  if (symbols.includes(icon) || altSrc) {
+    let sheetSize = size;
+    if (size22Icons.includes(icon)) sheetSize = 22;
+    return createSVGWrapper(icon, sheetSize, alt, altSrc);
+  }
+  return createTag('img', {
+    class: `icon icon-${icon}`,
+    src: altSrc || `/express/code/icons/${icon}.svg`,
+    alt: `${alt || icon}`,
+  });
+}
+
+export function getIconElementDeprecated(icons, size, alt, additionalClassName, altSrc) {
+  const icon = getIconDeprecated(icons, alt, size, altSrc);
+  if (additionalClassName) icon.classList.add(additionalClassName);
+  return icon;
+}
+
+const DCTX_ID_STAGE = 'v:2,s,dcp-r,bg:express2024,bf31d610-dd5f-11ee-abfd-ebac9468bc58';
+const DCTX_ID_PROD = 'v:2,s,dcp-r,bg:express2024,45faecb0-e687-11ee-a865-f545a8ca5d2c';
+
 const usp = new URLSearchParams(window.location.search);
 
 const onRedirect = (e) => {
@@ -19,7 +160,7 @@ const onError = (e) => {
   window.lana?.log('on error:', e);
 };
 
-export function loadWrapper() {
+export function loadSUSIScripts() {
   const CDN_URL = `https://auth-light.identity${isStage ? '-stage' : ''}.adobe.com/sentry/wrapper.js`;
   return loadScript(CDN_URL);
 }
@@ -38,58 +179,154 @@ function getDestURL(url) {
   return destURL.toString();
 }
 
-export default async function init(el) {
-  // ({ createTag, loadScript, getConfig, loadIms } = await import(`${getLibs()}/utils/utils.js`));
-  isStage = (usp.get('env') && usp.get('env') !== 'prod') || getConfig().env.name !== 'prod';
-  const rows = el.querySelectorAll(':scope> div > div');
-  const redirectUrl = rows[0]?.textContent?.trim().toLowerCase();
-  // eslint-disable-next-line camelcase
-  const client_id = rows[1]?.textContent?.trim() || 'AdobeExpressWeb';
-  const title = rows[2]?.textContent?.trim();
-  const authParams = {
-    dt: false,
-    locale: getConfig().locale.ietf.toLowerCase(),
-    response_type: 'code',
-    client_id,
-    scope: 'AdobeID,openid',
-  };
-  function sendEventToAnalytics(type, eventName) {
-    const sendEvent = () => {
-      window._satellite.track('event', {
-        xdm: {},
-        data: {
-          eventType: 'web.webinteraction.linkClicks',
-          web: {
-            webInteraction: {
-              name: eventName,
-              linkClicks: { value: 1 },
-              type,
+function sendEventToAnalytics(type, eventName, client_id) {
+  const sendEvent = () => {
+    window._satellite.track('event', {
+      xdm: {},
+      data: {
+        eventType: 'web.webinteraction.linkClicks',
+        web: {
+          webInteraction: {
+            name: eventName,
+            linkClicks: {
+              value: 1,
             },
+            type,
           },
-          /* eslint-disable object-curly-newline */
-          _adobe_corpnew: {
-            digitalData: {
-              primaryEvent: {
-                eventInfo: {
-                  eventName,
-                  client_id,
-                },
+        },
+        _adobe_corpnew: {
+          digitalData: {
+            primaryEvent: {
+              eventInfo: {
+                eventName,
+                client_id,
               },
             },
           },
-          /* eslint-enable object-curly-newline */
         },
-      });
-    };
-    if (window._satellite?.track) {
+      },
+    });
+  };
+  if (window._satellite?.track) {
+    sendEvent();
+  } else {
+    window.addEventListener('alloy_sendEvent', () => {
       sendEvent();
-    } else {
-      window.addEventListener('alloy_sendEvent', () => {
-        sendEvent();
-      }, { once: true });
-    }
+    }, { once: true });
   }
-  const destURL = getDestURL(redirectUrl);
+}
+
+function createSUSIComponent({ variant, config, authParams, destURL }) {
+  const susi = createTag('susi-sentry-light');
+  susi.authParams = authParams;
+  susi.authParams.redirect_uri = destURL;
+  susi.authParams.dctx_id = isStage ? DCTX_ID_STAGE : DCTX_ID_PROD;
+  susi.config = config;
+  if (isStage) susi.stage = 'true';
+  susi.variant = variant;
+  const onAnalytics = (e) => {
+    const { type, event } = e.detail;
+    sendEventToAnalytics(type, event, authParams.client_id);
+  };
+  susi.addEventListener('redirect', onRedirect);
+  susi.addEventListener('on-error', onError);
+  susi.addEventListener('on-analytics', onAnalytics);
+  return susi;
+}
+
+function buildSUSIParams({ client_id, variant, destURL, locale, title, hideIcon }) {
+  const params = {
+    variant,
+    authParams: {
+      dt: false,
+      locale,
+      response_type: 'code',
+      client_id,
+      scope: 'AdobeID,openid',
+    },
+    destURL,
+    config: {
+      consentProfile: 'free',
+      fullWidth: true,
+    },
+  };
+  if (title !== undefined) {
+    params.config.title = title;
+  }
+  if (hideIcon) {
+    params.config.hideIcon = true;
+  }
+  return params;
+}
+
+function sanitizeId(input) {
+  return input
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^\w-]/g, '');
+}
+
+let tabsId = 0;
+function buildSUSITabs(el, options) {
+  tabsId += 1;
+  const rows = [...el.children];
+  const wrapper = createTag('div', { class: 'susi-tabs' });
+  const tabList = createTag('div', { role: 'tablist' });
+  const susiScriptReady = loadSUSIScripts();
+  const panels = options.map((option, i) => {
+    const { footer, tabName, variant } = option;
+    const susiWrapper = createTag('div', { class: 'susi-wrapper' });
+    const panel = createTag('div', { role: 'tabpanel', class: variant }, susiWrapper);
+    susiScriptReady.then(() => susiWrapper.append(createSUSIComponent(option)));
+
+    if (footer) {
+      footer.classList.add('footer');
+      if (footer.querySelector('h2')) {
+        footer.classList.add('susi-bubbles');
+        const bubbleContainer = createTag('div', { class: 'susi-bubble-container' });
+        [...footer.querySelectorAll('p')].forEach((p) => {
+          p.classList.add('susi-bubble');
+          bubbleContainer.append(p);
+        });
+        footer.append(bubbleContainer);
+      } else {
+        footer.classList.add('susi-banner');
+      }
+      panel.append(footer);
+    }
+
+    const id = sanitizeId(`${tabName}-${tabsId}`);
+    panel.setAttribute('aria-labelledby', `tab-${id}`);
+    panel.id = `panel-${id}`;
+    i > 0 && panel.classList.add('hide');
+    const tab = createTag('button', {
+      role: 'tab',
+      'aria-selected': i === 0,
+      'aria-controls': `panel-${id}`,
+      id: `tab-${id}`,
+    }, tabName);
+    tab.addEventListener('click', () => {
+      tabList.querySelector('[aria-selected=true]')?.setAttribute('aria-selected', false);
+      tab.setAttribute('aria-selected', true);
+      panels.forEach((p) => {
+        p !== panel ? p.classList.add('hide') : p.classList.remove('hide');
+      });
+    });
+    tabList.append(tab);
+    return panel;
+  });
+
+  const logo = getIconElementDeprecated('adobe-express-logo');
+  logo.classList.add('express-logo');
+  logo.height = 24;
+  const title = rows[0].textContent?.trim();
+  const titleDiv = createTag('div', { class: 'title' }, title);
+  wrapper.append(logo, titleDiv, tabList, ...panels);
+  return wrapper;
+}
+
+function redirectIfLoggedIn(destURL) {
   const goDest = () => {
     sendEventToAnalytics('redirect', 'logged-in-auto-redirect');
     window.location.assign(destURL);
@@ -104,23 +341,55 @@ export default async function init(el) {
       })
       .catch((e) => { window.lana?.log(`Unable to load IMS in susi-light: ${e}`); });
   }
-  el.innerHTML = '';
-  await loadWrapper();
-  const config = { consentProfile: 'free' };
-  if (title) { config.title = title; }
-  const susi = createTag('susi-sentry-light');
-  susi.authParams = authParams;
-  susi.authParams.redirect_uri = destURL;
-  susi.config = config;
-  if (isStage) susi.stage = 'true';
-  susi.variant = variant;
+}
 
-  const onAnalytics = (e) => {
-    const { type, event } = e.detail;
-    sendEventToAnalytics(type, event);
-  };
-  susi.addEventListener('redirect', onRedirect);
-  susi.addEventListener('on-error', onError);
-  susi.addEventListener('on-analytics', onAnalytics);
-  el.append(susi);
+export default async function init(el) {
+  // ({ createTag, loadScript, getConfig, loadIms } = await import(`${getLibs()}/utils/utils.js`));
+  isStage = (usp.get('env') && usp.get('env') !== 'prod') || getConfig().env.name !== 'prod';
+  const locale = getConfig().locale.ietf.toLowerCase();
+  const { imsClientId } = getConfig();
+
+  const isTabs = el.classList.contains('tabs');
+  const noRedirect = el.classList.contains('no-redirect');
+
+  // only edu variant shows single
+  if (!isTabs) {
+    const rows = el.querySelectorAll(':scope > div > div');
+    const redirectUrl = rows[0]?.textContent?.trim().toLowerCase();
+    const client_id = rows[1]?.textContent?.trim() || (imsClientId ?? 'AdobeExpressWeb');
+    const title = rows[2]?.textContent?.trim();
+    const variant = 'edu-express';
+    const params = buildSUSIParams({
+      client_id, variant, destURL: getDestURL(redirectUrl), locale, title,
+    });
+    if (!noRedirect) {
+      redirectIfLoggedIn(params.destURL);
+    }
+    await loadSUSIScripts();
+    el.replaceChildren(createSUSIComponent(params));
+    return;
+  }
+  const rows = [...el.children];
+  const tabNames = [...rows[1].querySelectorAll('div')].map((div) => div.textContent);
+  const variants = [...rows[2].querySelectorAll('div')].map((div) => div.textContent?.trim().toLowerCase());
+  const redirectUrls = [...rows[3].querySelectorAll('div')].map((div) => div.textContent?.trim().toLowerCase());
+  const client_ids = [...rows[4].querySelectorAll('div')].map((div) => div.textContent?.trim() || (imsClientId ?? 'AdobeExpressWeb'));
+  const footers = rows[5] ? [...rows[5].querySelectorAll('div')] : [];
+  const tabParams = tabNames.map((tabName, index) => ({
+    tabName,
+    ...buildSUSIParams({
+      client_id: client_ids[index],
+      variant: variants[index],
+      destURL: getDestURL(redirectUrls[index]),
+      locale,
+      title: '', // rm titles
+      hideIcon: true,
+    }),
+    footer: footers[index] ?? null,
+  }));
+  if (!noRedirect) {
+    // redirect to first one if logged in
+    redirectIfLoggedIn(tabParams[0].destURL);
+  }
+  el.replaceChildren(buildSUSITabs(el, tabParams));
 }

--- a/libs/mep/emea1435/susi-light/susi-light.js
+++ b/libs/mep/emea1435/susi-light/susi-light.js
@@ -27,7 +27,7 @@ function createSVGWrapper(icon, sheetSize, alt, altSrc) {
   return svgWrapper;
 }
 
-export function getIconDeprecated(icons, alt, size = 44, altSrc) {
+export function getIconDeprecated(icons, alt, size = 44, altSrc = false) {
   // eslint-disable-next-line no-param-reassign
   icons = Array.isArray(icons) ? icons : [icons];
   const [defaultIcon, mobileIcon] = icons;
@@ -188,9 +188,7 @@ function sendEventToAnalytics(type, eventName, client_id) {
         web: {
           webInteraction: {
             name: eventName,
-            linkClicks: {
-              value: 1,
-            },
+            linkClicks: { value: 1 },
             type,
           },
         },
@@ -234,7 +232,11 @@ function createSUSIComponent({ variant, config, authParams, destURL }) {
   return susi;
 }
 
-function buildSUSIParams({ client_id, variant, destURL, locale, title, hideIcon }) {
+function buildSUSIParams(
+  {
+    client_id, variant, destURL, locale, title, hideIcon,
+  },
+) {
   const params = {
     variant,
     authParams: {
@@ -299,7 +301,7 @@ function buildSUSITabs(el, options) {
     const id = sanitizeId(`${tabName}-${tabsId}`);
     panel.setAttribute('aria-labelledby', `tab-${id}`);
     panel.id = `panel-${id}`;
-    i > 0 && panel.classList.add('hide');
+    if (i > 0) panel.classList.add('hide');
     const tab = createTag('button', {
       role: 'tab',
       'aria-selected': i === 0,
@@ -310,7 +312,8 @@ function buildSUSITabs(el, options) {
       tabList.querySelector('[aria-selected=true]')?.setAttribute('aria-selected', false);
       tab.setAttribute('aria-selected', true);
       panels.forEach((p) => {
-        p !== panel ? p.classList.add('hide') : p.classList.remove('hide');
+        if (p !== panel) p.classList.add('hide');
+        else p.classList.remove('hide');
       });
     });
     tabList.append(tab);
@@ -332,12 +335,12 @@ function redirectIfLoggedIn(destURL) {
     window.location.assign(destURL);
   };
   if (window.adobeIMS) {
-    window.adobeIMS.isSignedInUser() && goDest();
+    if (window.adobeIMS.isSignedInUser()) goDest();
   } else {
     loadIms()
       .then(() => {
         /* c8 ignore next */
-        window.adobeIMS?.isSignedInUser() && goDest();
+        if (window.adobeIMS?.isSignedInUser()) goDest();
       })
       .catch((e) => { window.lana?.log(`Unable to load IMS in susi-light: ${e}`); });
   }
@@ -359,9 +362,9 @@ export default async function init(el) {
     const client_id = rows[1]?.textContent?.trim() || (imsClientId ?? 'AdobeExpressWeb');
     const title = rows[2]?.textContent?.trim();
     const variant = 'edu-express';
-    const params = buildSUSIParams({
-      client_id, variant, destURL: getDestURL(redirectUrl), locale, title,
-    });
+    const params = buildSUSIParams(
+      { client_id, variant, destURL: getDestURL(redirectUrl), locale, title },
+    );
     if (!noRedirect) {
       redirectIfLoggedIn(params.destURL);
     }

--- a/libs/mep/emea1435/susi-light/susi-light.js
+++ b/libs/mep/emea1435/susi-light/susi-light.js
@@ -1,0 +1,126 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable camelcase */
+import { createTag, loadScript, getConfig, loadIms } from '../../../utils/utils.js';
+
+let isStage;
+
+const variant = 'edu-express';
+const usp = new URLSearchParams(window.location.search);
+
+const onRedirect = (e) => {
+  // eslint-disable-next-line no-console
+  console.log('redirecting to:', e.detail);
+  setTimeout(() => {
+    window.location.assign(e.detail);
+    // temporary solution: allows analytics to go thru
+  }, 100);
+};
+const onError = (e) => {
+  window.lana?.log('on error:', e);
+};
+
+export function loadWrapper() {
+  const CDN_URL = `https://auth-light.identity${isStage ? '-stage' : ''}.adobe.com/sentry/wrapper.js`;
+  return loadScript(CDN_URL);
+}
+
+function getDestURL(url) {
+  let destURL;
+  try {
+    destURL = new URL(url);
+  } catch (err) {
+    window.lana?.log(`invalid redirect uri for susi-light: ${url}`);
+    destURL = new URL('https://new.express.adobe.com');
+  }
+  if (isStage && ['new.express.adobe.com', 'express.adobe.com'].includes(destURL.hostname)) {
+    destURL.hostname = 'stage.projectx.corp.adobe.com';
+  }
+  return destURL.toString();
+}
+
+export default async function init(el) {
+  // ({ createTag, loadScript, getConfig, loadIms } = await import(`${getLibs()}/utils/utils.js`));
+  isStage = (usp.get('env') && usp.get('env') !== 'prod') || getConfig().env.name !== 'prod';
+  const rows = el.querySelectorAll(':scope> div > div');
+  const redirectUrl = rows[0]?.textContent?.trim().toLowerCase();
+  // eslint-disable-next-line camelcase
+  const client_id = rows[1]?.textContent?.trim() || 'AdobeExpressWeb';
+  const title = rows[2]?.textContent?.trim();
+  const authParams = {
+    dt: false,
+    locale: getConfig().locale.ietf.toLowerCase(),
+    response_type: 'code',
+    client_id,
+    scope: 'AdobeID,openid',
+  };
+  function sendEventToAnalytics(type, eventName) {
+    const sendEvent = () => {
+      window._satellite.track('event', {
+        xdm: {},
+        data: {
+          eventType: 'web.webinteraction.linkClicks',
+          web: {
+            webInteraction: {
+              name: eventName,
+              linkClicks: { value: 1 },
+              type,
+            },
+          },
+          /* eslint-disable object-curly-newline */
+          _adobe_corpnew: {
+            digitalData: {
+              primaryEvent: {
+                eventInfo: {
+                  eventName,
+                  client_id,
+                },
+              },
+            },
+          },
+          /* eslint-enable object-curly-newline */
+        },
+      });
+    };
+    if (window._satellite?.track) {
+      sendEvent();
+    } else {
+      window.addEventListener('alloy_sendEvent', () => {
+        sendEvent();
+      }, { once: true });
+    }
+  }
+  const destURL = getDestURL(redirectUrl);
+  const goDest = () => {
+    sendEventToAnalytics('redirect', 'logged-in-auto-redirect');
+    window.location.assign(destURL);
+  };
+  if (window.adobeIMS) {
+    window.adobeIMS.isSignedInUser() && goDest();
+  } else {
+    loadIms()
+      .then(() => {
+        /* c8 ignore next */
+        window.adobeIMS?.isSignedInUser() && goDest();
+      })
+      .catch((e) => { window.lana?.log(`Unable to load IMS in susi-light: ${e}`); });
+  }
+  el.innerHTML = '';
+  await loadWrapper();
+  const config = { consentProfile: 'free' };
+  if (title) { config.title = title; }
+  const susi = createTag('susi-sentry-light');
+  susi.authParams = authParams;
+  susi.authParams.redirect_uri = destURL;
+  susi.config = config;
+  if (isStage) susi.stage = 'true';
+  susi.variant = variant;
+
+  const onAnalytics = (e) => {
+    const { type, event } = e.detail;
+    sendEventToAnalytics(type, event);
+  };
+  susi.addEventListener('redirect', onRedirect);
+  susi.addEventListener('on-error', onError);
+  susi.addEventListener('on-analytics', onAnalytics);
+  el.append(susi);
+}


### PR DESCRIPTION
* Copying Express susi-light block into Milo MEP test folder to more easily assess the LOE on testing this on a CC page

Marked as high priority as test development is blocked until the code is merged.

Resolves: [OPT-31058](https://jira.corp.adobe.com/browse/OPT-31058)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://emea1435--milo--adobecom.aem.page/?martech=off
