### PR TITLE
[MWPW-170623] - iframe video control fix

### DIFF
--- a/libs/styles/iframe.css
+++ b/libs/styles/iframe.css
@@ -6,6 +6,13 @@
   padding-bottom: 56.25%;
 }
 
+@media (min-width: 1790px) {
+  .milo-video,
+  .milo-iframe {
+    padding-bottom: 47.25%;
+  }
+}
+
 .milo-video iframe,
 .milo-iframe iframe {
   border: 0;


### PR DESCRIPTION
This resolves the issue where at around 1790px and onward screen width, the iframe controls start going down behind the scene where the user can't see or interact with them.

Resolves: [MWPW-170623](https://jira.corp.adobe.com/browse/MWPW-170623)

**Test URLs:**
- Before: https://iframe-video-controls--milo--adobecom.hlx.page/drafts/dusan/iframe-video-control-overflow
- After: https://main--milo--adobecom.hlx.page/drafts/dusan/iframe-video-control-overflow
