### PR TITLE
[NALA][MWPW-170695] Add automation tests for Notification Block

### DIFF
--- a/nala/blocks/notification/notification.page.js
+++ b/nala/blocks/notification/notification.page.js
@@ -1,0 +1,27 @@
+export default class Notification {
+  constructor(page, nth = 0) {
+    this.page = page;
+    // notification  locators
+    this.notification = this.page.locator('.notification').nth(nth);
+    this.headingM = this.notification.locator('.heading-m');
+    this.detailM = this.notification.locator('.detail-m');
+    this.bodyM = this.notification.locator('.body-m').nth(nth);
+
+    // actions area
+    this.actionArea = this.notification.locator('.action-area');
+    this.outlineButton = this.notification.locator('.con-button.outline');
+    this.outlineButtonS = this.notification.locator('.con-button.outline.button-s');
+    this.blueButton = this.notification.locator('.con-button.blue');
+    this.blueButtonL = this.notification.locator('.con-button.blue.button-l');
+    this.blueButtonXL = this.notification.locator('.con-button.blue.button-xl');
+
+    // background images
+    this.background = this.notification.locator('.background');
+    this.backgroundImage = this.notification.locator('div.background img');
+
+    // foreground images
+    this.foreground = this.notification.locator('.foreground');
+    this.foregroundImage = this.notification.locator('div.foreground img');
+    this.iconImage = this.foreground.locator('.icon-area img');
+  }
+}

--- a/nala/blocks/notification/notification.spec.js
+++ b/nala/blocks/notification/notification.spec.js
@@ -1,0 +1,18 @@
+/* eslint-disable max-len */
+
+module.exports = {
+  FeatureName: 'Quote Block',
+  features: [
+    {
+      tcid: '0',
+      name: '@Notification',
+      path: '/drafts/nala/blocks/notification/notification',
+      data: {
+        h3Text: 'Notification default heading M 24/30',
+        bodyM: 'Default body M 18/27 and body linked text is styled as static links',
+        blueButtonText: 'Call to action',
+      },
+      tags: '@notification @smoke @regression @milo',
+    },
+  ],
+};

--- a/nala/blocks/notification/notification.test.js
+++ b/nala/blocks/notification/notification.test.js
@@ -9,24 +9,24 @@ let notification;
 
 const miloLibs = process.env.MILO_LIBS || '';
 
-test.describe('Milo Marquee Block test suite', () => {
+test.describe('Milo Notification Block test suite', () => {
   test.beforeEach(async ({ page }) => {
     webUtil = new WebUtil(page);
     notification = new NotificationBlock(page);
   });
 
-  // Test 0 : Marquee (light)
+  // Test 0 : Notification
   test(`[Test Id - ${features[0].tcid}] ${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
     console.info(`[Test Page]: ${baseURL}${features[0].path}${miloLibs}`);
     const { data } = features[0];
 
-    await test.step('step-1: Go to Marquee (light) block test page', async () => {
+    await test.step('step-1: Go to Notification block test page', async () => {
       await page.goto(`${baseURL}${features[0].path}${miloLibs}`);
       await page.waitForLoadState('domcontentloaded');
       await expect(page).toHaveURL(`${baseURL}${features[0].path}${miloLibs}`);
     });
 
-    await test.step('step-2: Verify marquee(light) specs', async () => {
+    await test.step('step-2: Verify Notification specs', async () => {
       await expect(await notification.notification).toBeVisible();
 
       await expect(await notification.headingM).toContainText(data.h3Text);
@@ -41,7 +41,7 @@ test.describe('Milo Marquee Block test suite', () => {
       await expect(await notification.blueButton).toHaveAttribute('daa-ll', await webUtil.getLinkDaall(data.blueButtonText, 1, data.h3Text));
     });
 
-    await test.step('step-4: Verify the accessibility test on the marquee(light) block', async () => {
+    await test.step('step-4: Verify the accessibility test on the Notification block', async () => {
       await runAccessibilityTest({ page, testScope: notification.notification });
     });
   });

--- a/nala/blocks/notification/notification.test.js
+++ b/nala/blocks/notification/notification.test.js
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+import WebUtil from '../../libs/webutil.js';
+import { features } from './notification.spec.js';
+import NotificationBlock from './notification.page.js';
+import { runAccessibilityTest } from '../../libs/accessibility.js';
+
+let webUtil;
+let notification;
+
+const miloLibs = process.env.MILO_LIBS || '';
+
+test.describe('Milo Marquee Block test suite', () => {
+  test.beforeEach(async ({ page }) => {
+    webUtil = new WebUtil(page);
+    notification = new NotificationBlock(page);
+  });
+
+  // Test 0 : Marquee (light)
+  test(`[Test Id - ${features[0].tcid}] ${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+    console.info(`[Test Page]: ${baseURL}${features[0].path}${miloLibs}`);
+    const { data } = features[0];
+
+    await test.step('step-1: Go to Marquee (light) block test page', async () => {
+      await page.goto(`${baseURL}${features[0].path}${miloLibs}`);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(`${baseURL}${features[0].path}${miloLibs}`);
+    });
+
+    await test.step('step-2: Verify marquee(light) specs', async () => {
+      await expect(await notification.notification).toBeVisible();
+
+      await expect(await notification.headingM).toContainText(data.h3Text);
+      await expect(await notification.bodyM).toContainText(data.bodyM);
+      await expect(await notification.blueButton).toContainText(data.blueButtonText);
+
+      await expect(await notification.backgroundImage).toBeVisible();
+    });
+
+    await test.step('step-3: Verify analytics attributes', async () => {
+      await expect(await notification.notification).toHaveAttribute('daa-lh', await webUtil.getBlockDaalh('notification', 1));
+      await expect(await notification.blueButton).toHaveAttribute('daa-ll', await webUtil.getLinkDaall(data.blueButtonText, 1, data.h3Text));
+    });
+
+    await test.step('step-4: Verify the accessibility test on the marquee(light) block', async () => {
+      await runAccessibilityTest({ page, testScope: notification.notification });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Nala automation test scripts for notification block
* Default notification block variant
* Features or fixes

Resolves: [MWPW-170695](https://jira.corp.adobe.com/browse/MWPW-170695)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://notification-block--milo--adobecom.aem.page/?martech=off
