### PR TITLE
MWPW-169814 | Change box shadow and button to close for split notification

### DIFF
--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -17,7 +17,7 @@
   --icon-size-xl: 64px;
   --pill-radius: 16px;
   --pill-shadow: 0 3px 6px #00000029;
-  --split-shadow: 0px 0px 16px 0px rgba(0, 0, 0, 0.16);
+  --split-shadow: 0px 6px 16px 0px rgba(0, 0, 0, 0.16);
 
   display: flex;
   inline-size: 100%;

--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -17,6 +17,7 @@
   --icon-size-xl: 64px;
   --pill-radius: 16px;
   --pill-shadow: 0 3px 6px #00000029;
+  --split-shadow: 0px 0px 16px 0px rgba(0, 0, 0, 0.16);
 
   display: flex;
   inline-size: 100%;
@@ -303,6 +304,10 @@
   inline-size: calc(100% - var(--spacing-m));
   margin-inline: auto;
   box-shadow: var(--pill-shadow);
+}
+
+.notification.split.pill {
+  box-shadow: var(--split-shadow);
 }
 
 .notification.pill .foreground .action-area {

--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -17,7 +17,7 @@
   --icon-size-xl: 64px;
   --pill-radius: 16px;
   --pill-shadow: 0 3px 6px #00000029;
-  --split-shadow: 0px 6px 16px 0px rgba(0, 0, 0, 0.16);
+  --split-shadow: 0 6px 16px 0 rgb(0 0 0 / 0.16);
 
   display: flex;
   inline-size: 100%;

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -137,7 +137,7 @@ async function decorateLockup(lockupArea, el) {
 }
 
 function decorateSplitList(el, listContent) {
-  const closeEvent = "#_evt-close";
+  const closeEvent = '#_evt-close';
   const listContainer = createTag('div', { class: 'split-list-area' });
   listContent?.querySelectorAll('li').forEach((item) => {
     const listItem = createTag('div', { class: 'split-list-item' });

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -86,14 +86,18 @@ function wrapCopy(foreground) {
   });
 }
 
-function decorateClose(el) {
-  const btn = createTag('button', { 'aria-label': 'close', class: 'close' }, closeSvg);
-  btn.addEventListener('click', () => {
+function addCloseAction(el, btn) {
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
     el.style.display = 'none';
     el.closest('.section')?.classList.add('close-sticky-section');
     document.dispatchEvent(new CustomEvent('milo:sticky:closed'));
   });
+}
 
+function decorateClose(el) {
+  const btn = createTag('button', { 'aria-label': 'close', class: 'close' }, closeSvg);
+  addCloseAction(el, btn);
   el.appendChild(btn);
 }
 
@@ -132,7 +136,7 @@ async function decorateLockup(lockupArea, el) {
   if (pre && pre[2] === 'icon') el.classList.replace(pre[0], `${pre[1]}-lockup`);
 }
 
-function decorateSplitList(listContent) {
+function decorateSplitList(el, listContent) {
   const listContainer = createTag('div', { class: 'split-list-area' });
   listContent?.querySelectorAll('li').forEach((item) => {
     const listItem = createTag('div', { class: 'split-list-item' });
@@ -142,6 +146,8 @@ function decorateSplitList(listContent) {
       ? item
       : item.nextElementSibling;
     const btn = createTag('div', {}, textli.lastElementChild);
+    const hasCloseHash = btn.querySelector('a').href.includes('#_close');
+    if (hasCloseHash) addCloseAction(el, btn);
     const textContent = createTag('div', { class: 'text-content' });
     const text = createTag('div', {}, textli.innerText.trim());
     textContent.append(pic, text);
@@ -159,7 +165,7 @@ async function decorateForegroundText(el, container) {
     await loadCDT(text, el.classList);
   }
   if (el.classList.contains('split')) {
-    decorateSplitList(text?.querySelector('ul'));
+    decorateSplitList(el, text?.querySelector('ul'));
     return;
   }
   const iconArea = text?.querySelector('p:has(picture)');

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -137,6 +137,7 @@ async function decorateLockup(lockupArea, el) {
 }
 
 function decorateSplitList(el, listContent) {
+  const closeEvent = "#_evt-close";
   const listContainer = createTag('div', { class: 'split-list-area' });
   listContent?.querySelectorAll('li').forEach((item) => {
     const listItem = createTag('div', { class: 'split-list-item' });
@@ -147,8 +148,8 @@ function decorateSplitList(el, listContent) {
       : item.nextElementSibling;
     const btn = createTag('div', {}, textli.lastElementChild);
     const btnA = btn.querySelector('a');
-    if (btnA.href.includes('#_evt-close')) {
-      btnA.href = '#_evt-close';
+    if (btnA?.href.includes(closeEvent)) {
+      btnA.href = closeEvent;
       addCloseAction(el, btnA);
     }
     const textContent = createTag('div', { class: 'text-content' });

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -147,8 +147,8 @@ function decorateSplitList(el, listContent) {
       : item.nextElementSibling;
     const btn = createTag('div', {}, textli.lastElementChild);
     const btnA = btn.querySelector('a');
-    if (btnA.href.includes('#_close')) {
-      btnA.href = '#_close';
+    if (btnA.href.includes('#_evt-close')) {
+      btnA.href = '#_evt-close';
       addCloseAction(el, btnA);
     }
     const textContent = createTag('div', { class: 'text-content' });

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -88,7 +88,7 @@ function wrapCopy(foreground) {
 
 function addCloseAction(el, btn) {
   btn.addEventListener('click', (e) => {
-    if (btn.nodeName == 'A') e.preventDefault();
+    if (btn.nodeName === 'A') e.preventDefault();
     el.style.display = 'none';
     el.closest('.section')?.classList.add('close-sticky-section');
     document.dispatchEvent(new CustomEvent('milo:sticky:closed'));

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -148,7 +148,7 @@ function decorateSplitList(el, listContent) {
     const btn = createTag('div', {}, textli.lastElementChild);
     const btnA = btn.querySelector('a');
     if (btnA.href.includes('#_close')) {
-      btnA.href = "#_close"
+      btnA.href = '#_close';
       addCloseAction(el, btnA);
     }
     const textContent = createTag('div', { class: 'text-content' });

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -88,7 +88,7 @@ function wrapCopy(foreground) {
 
 function addCloseAction(el, btn) {
   btn.addEventListener('click', (e) => {
-    e.preventDefault();
+    if (btn.nodeName == 'A') e.preventDefault();
     el.style.display = 'none';
     el.closest('.section')?.classList.add('close-sticky-section');
     document.dispatchEvent(new CustomEvent('milo:sticky:closed'));
@@ -146,8 +146,11 @@ function decorateSplitList(el, listContent) {
       ? item
       : item.nextElementSibling;
     const btn = createTag('div', {}, textli.lastElementChild);
-    const hasCloseHash = btn.querySelector('a').href.includes('#_close');
-    if (hasCloseHash) addCloseAction(el, btn);
+    const btnA = btn.querySelector('a');
+    if (btnA.href.includes('#_close')) {
+      btnA.href = "#_close"
+      addCloseAction(el, btnA);
+    }
     const textContent = createTag('div', { class: 'text-content' });
     const text = createTag('div', {}, textli.innerText.trim());
     textContent.append(pic, text);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Website foundation technology.",
   "scripts": {
-    "test": "npx playwright install && wtr --config ./web-test-runner.config.mjs \"./test/**/*.test.(js|html)\" --node-resolve --port=2000 --coverage --concurrent-browsers 4 --debug",
+    "test": "npx playwright install && wtr --config ./web-test-runner.config.mjs \"./test/**/notification.test.(js|html)\" --node-resolve --port=2000 --coverage --concurrent-browsers 4 --debug",
     "test:watch": "npx playwright install && npm test -- --watch",
     "test:file": "npx playwright install && wtr --config ./web-test-runner.config.mjs --node-resolve --port=2000 --coverage",
     "test:file:watch": "npx playwright install && wtr --config ./web-test-runner.config.mjs --node-resolve --port=2000 --coverage --watch",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Website foundation technology.",
   "scripts": {
-    "test": "npx playwright install && wtr --config ./web-test-runner.config.mjs \"./test/**/notification.test.(js|html)\" --node-resolve --port=2000 --coverage --concurrent-browsers 4 --debug",
+    "test": "npx playwright install && wtr --config ./web-test-runner.config.mjs \"./test/**/*.test.(js|html)\" --node-resolve --port=2000 --coverage --concurrent-browsers 4 --debug",
     "test:watch": "npx playwright install && npm test -- --watch",
     "test:file": "npx playwright install && wtr --config ./web-test-runner.config.mjs --node-resolve --port=2000 --coverage",
     "test:file:watch": "npx playwright install && wtr --config ./web-test-runner.config.mjs --node-resolve --port=2000 --coverage --watch",

--- a/test/blocks/notification/mocks/body.html
+++ b/test/blocks/notification/mocks/body.html
@@ -540,8 +540,8 @@
     </div>
   </div>
 </div>
-<div>
-  <div class="notification pill split no-closure no-delay">
+<div class="section">
+  <div class="notification pill split no-delay">
     <div>
       <div data-valign="middle">#fff</div>
     </div>
@@ -566,7 +566,7 @@
             </picture>
           </li>
           <li>
-            Web Browser <em><a href="https://adobe.com/">Continue</a></em>
+            Web Browser <em><a href="https://adobe.com/#_evt-close">Continue</a></em>
           </li>
         </ul>
       </div>

--- a/test/blocks/notification/notification.test.js
+++ b/test/blocks/notification/notification.test.js
@@ -102,9 +102,8 @@ describe('notification', async () => {
       const stacks = splits[0].querySelectorAll('.split-list-item').length;
       expect(stacks).to.equal(2);
     });
-    it('closes the notiification', () => {
-      const event = new CustomEvent('click', { bubbles: true });
-      splits[0].querySelector('a[href*="#_evt-close"]').dispatchEvent(event);
+    it('closes the notification', () => {
+      splits[0].querySelector('a[href*="#_evt-close"]').dispatchEvent(new MouseEvent('click'));
       expect(splits[0].closest('.section').classList.contains('close-sticky-section')).to.be.true;
     });
   });

--- a/test/blocks/notification/notification.test.js
+++ b/test/blocks/notification/notification.test.js
@@ -102,5 +102,10 @@ describe('notification', async () => {
       const stacks = splits[0].querySelectorAll('.split-list-item').length;
       expect(stacks).to.equal(2);
     });
+    it('closes the notiification', () => {
+      const event = new CustomEvent('click', { bubbles: true });
+      splits[0].querySelector('a[href*="#_evt-close"]').dispatchEvent(event);
+      expect(splits[0].closest('.section').classList.contains('close-sticky-section')).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
Change box shadow for new split notification variant created for https://jira.corp.adobe.com/browse/MWPW-169814
Clicking a button in notification authored with #_close will close the notification block.

Resolves: [MWPW-169814](https://jira.corp.adobe.com/browse/MWPW-169814) | [MWPW-170780](https://jira.corp.adobe.com/browse/MWPW-170780)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/mathuria/promobar/creativecloud?martech=off
- After: https://mwpw-170780--milo--adobecom.aem.page/drafts/mathuria/promobar/creativecloud?martech=off
