### PR TITLE
Initial checkin. Good state.

### DIFF
--- a/libs/features/personalization/preview.css
+++ b/libs/features/personalization/preview.css
@@ -217,6 +217,15 @@
   gap: 8px;
 }
 
+.mep-popup select.mep-manifest-variants {
+  width: 100%;
+  overflow: hidden;
+  white-space: pre;
+  -moz-white-space: pre;
+  -o-white-space: pre;
+  text-overflow: ellipsis;
+}
+
 .mep-popup input.new-manifest,
 .mep-popup select.mep-manifest-variants {
   height: 36px;

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -185,7 +185,7 @@ function getManifestListDomAndParameter(mepConfig) {
       manifestParameter.push(`${editUrl}--default`);
     }
     options += `<option name="${editPath}${pageId}" value="default" 
-    id="${editPath}${pageId}--default" data-manifest="${editPath}" ${isSelected}>Default (control)</option>`;
+    id="${editPath}${pageId}--default" data-manifest="${editPath}" ${isSelected} title="Default (control)">Default (control)</option>`;
     isSelected = '';
     variantNamesArray.forEach((variant) => {
       isSelected = '';
@@ -194,7 +194,7 @@ function getManifestListDomAndParameter(mepConfig) {
         manifestParameter.push(`${manifestPath}--${variant}`);
       }
       options += `<option name="${editPath}${pageId}" value="${variant}" 
-      id="${editPath}${pageId}--${variant}" data-manifest="${editPath}" ${isSelected}>${variant}</option>`;
+      id="${editPath}${pageId}--${variant}" data-manifest="${editPath}" ${isSelected} title="${variant}">${variant}</option>`;
     });
     manifestList += `<div class="mep-section" title="Manifest location: ${editUrl}&#013;Analytics manifest name: ${analyticsTitle || 'N/A for this manifest type'}">
       <div class="mep-manifest-info">  


### PR DESCRIPTION
Fixes MEP button width with long manifests names. Adds a title hover to each option. Options will still be wider than the overlay as they can't be styled.

![image](https://github.com/user-attachments/assets/fcca59e9-6522-423e-8a21-cabfd6e91e04)

Resolves: [MWPW-170917](https://jira.corp.adobe.com/browse/MWPW-170917)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q2/mep-button-options-fix/marquee
- After: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q2/mep-button-options-fix/marquee?milolibs=mep-button-options-fix
https://mep-button-options-fix--milo--adobecom.hlx.live/&martech=off