### PR TITLE
MWPW-170349 [Article Header] Support no author link

### DIFF
--- a/libs/blocks/article-header/article-header.js
+++ b/libs/blocks/article-header/article-header.js
@@ -33,8 +33,8 @@ function openPopup(e) {
 
 async function buildAuthorInfo(authorEl, bylineContainer) {
   const { textContent } = authorEl;
-  const link = authorEl.href || authorEl.dataset.authorPage;
   const config = getConfig();
+  const link = authorEl.href || authorEl.dataset.authorPage || `${config.locale.contentRoot}/authors/${textContent.replace(/[^0-9a-z]/gi, '-').toLowerCase()}`;
   const base = config.miloLibs || config.codeRoot;
   const authorImg = createTag('div', { class: 'article-author-image' });
   authorImg.style.backgroundImage = `url(${base}/blocks/article-header/adobe-logo.svg)`;
@@ -62,6 +62,12 @@ async function buildAuthorInfo(authorEl, bylineContainer) {
     } else {
       authorImg.style.backgroundImage = 'none';
     }
+  }
+
+  if (getMetadata('article-author-link') === 'off' && authorEl.nodeName === 'A') {
+    const parent = authorEl.parentElement;
+    authorEl.remove();
+    parent.textContent = textContent;
   }
 }
 
@@ -211,7 +217,7 @@ export default async function init(blockEl) {
   bylineContainer.firstElementChild.classList.add('article-byline-info');
 
   const authorContainer = bylineContainer.firstElementChild.firstElementChild;
-  const authorEl = authorContainer.firstElementChild;
+  const authorEl = authorContainer.firstElementChild || authorContainer;
   authorContainer.classList.add('article-author');
 
   buildAuthorInfo(authorEl, bylineContainer);

--- a/test/blocks/article-header/article-header.test.js
+++ b/test/blocks/article-header/article-header.test.js
@@ -127,14 +127,6 @@ describe('test the invalid article header', () => {
     document.body.innerHTML = invalidDoc;
   });
 
-  it('does not init if the element is invalid', async () => {
-    await init(document.body.querySelector('.article-header'));
-    const authorTextEl = await waitForElement('.article-author');
-    const authorLink = document.querySelector('.article-author a');
-    expect(authorTextEl).to.exist;
-    expect(authorLink).to.not.exist;
-  });
-
   it('adds invalid-date when invalid date is provided', async () => {
     await init(document.body.querySelector('.article-header'));
     const date = await waitForElement('.article-date-invalid');
@@ -163,5 +155,19 @@ describe('article header', () => {
     const el = document.body.querySelector('.article-header');
     await init(el);
     expect(el.querySelector('.article-feature-video video')).to.exist;
+  });
+
+  it('tries to get author picture from text if no link is provided', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/body-without-author-link.html' });
+    await init(document.body.querySelector('.article-header'));
+    expect(document.body.querySelector('.article-author-image')).to.exist;
+  });
+
+  it('removes author link via metadata', async () => {
+    document.head.innerHTML = '<meta name="article-author-link" content="off">';
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+    await init(document.body.querySelector('.article-header'));
+    await delay(100);
+    expect(document.querySelector('.article-author').childElementCount).to.equal(0);
   });
 });

--- a/test/blocks/article-header/mocks/body-without-author-link.html
+++ b/test/blocks/article-header/mocks/body-without-author-link.html
@@ -1,0 +1,69 @@
+<div>
+  <div class="section">
+    <div class="article-header">
+      <div>
+        <div>
+          <p>Adobe Life</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h1 id="celebrating-a-special-milestone-10-things-you-might-not-know-about-adobes-40-years-of-innovation">
+            Celebrating a special milestone: 10 things you might not know about Adobe’s 40 years of innovation</h1>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p><a href="/test/blocks/article-header/mocks/adobe-communication-team">Adobe Communications Team</a></p>
+          <p>12-05-2022</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p>
+            <picture>
+              <!-- <source media="(min-width: 400px)" type="image/webp"
+                srcset="/en/publish/2022/12/05/media_165ac27f7158c040400bd6666c6086a9c0b3c29cc.jpeg?width=2000&amp;format=webply&amp;optimize=medium">
+              <source type="image/webp"
+                srcset="/en/publish/2022/12/05/media_165ac27f7158c040400bd6666c6086a9c0b3c29cc.jpeg?width=750&amp;format=webply&amp;optimize=medium">
+              <source media="(min-width: 400px)"
+                srcset="/en/publish/2022/12/05/media_165ac27f7158c040400bd6666c6086a9c0b3c29cc.jpeg?width=2000&amp;format=jpeg&amp;optimize=medium">
+              <img
+                src="/en/publish/2022/12/05/media_165ac27f7158c040400bd6666c6086a9c0b3c29cc.jpeg?width=750&amp;format=jpeg&amp;optimize=medium"
+                loading="eager" alt="Virtual background in red and blue."> -->
+            </picture>
+            <em>Caption</em>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<div id="article-header-no-author-link" class="article-header">
+  <div>
+    <div>
+      <p><a href="" data-topic-link="Adobe Life">Adobe Life</a></p>
+    </div>
+  </div>
+  <div>
+    <div>
+      <h1 id="celebrating-a-special-milestone-10-things-you-might-not-know-about-adobes-40-years-of-innovation">
+        Celebrating a special milestone: 10 things you might not know about Adobe’s 40 years of innovation</h1>
+    </div>
+  </div>
+  <div>
+    <div>
+      <p><span data-author-page="/test/blocks/article-header/mocks/adobe-communication-team">Adobe Communications Team</span></p>
+      <p>12-05-2022</p>
+    </div>
+  </div>
+  <div>
+    <div>
+      <p>
+        <picture>
+        </picture>
+        <em>Caption</em>
+      </p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
* Add new support to turn off author link in article header block via metadata `article-author-link` set to `off`
* Change backup behavior to try to get author image from text rather than no image

Resolves: [MWPW-170349](https://jira.corp.adobe.com/browse/MWPW-170349)

**Test URLs:**
With link + metadata
--See links in comments--

Regression (link still supported):
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/blog-migration/article-header/connecting-external-data-sources-to-adobe-experience-manager-guides?martech=off
- After: https://author-link--milo--meganthecoder.aem.page/drafts/methomas/blog-migration/article-header/connecting-external-data-sources-to-adobe-experience-manager-guides?martech=off

