### PR TITLE
MWPW-170928[MEP] Add MEP pzn tags for a user's country

### DIFF
--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -39,9 +39,12 @@ export const getCookie = (name) => document.cookie
   .find((row) => row.startsWith(`${name}=`))
   ?.split('=')[1];
 
-const getAkamaiCode = () => new Promise((resolve, reject) => {
-  const urlParams = new URLSearchParams(window.location.search);
-  const akamaiLocale = urlParams.get('akamaiLocale') || sessionStorage.getItem('akamai');
+export const getAkamaiCode = (checkedParams = false) => new Promise((resolve, reject) => {
+  let akamaiLocale = null;
+  if (!checkedParams) {
+    const urlParams = new URLSearchParams(window.location.search);
+    akamaiLocale = urlParams.get('akamaiLocale') || sessionStorage.getItem('akamai');
+  }
   if (akamaiLocale !== null) {
     resolve(akamaiLocale.toLowerCase());
   } else {

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -755,6 +755,13 @@ const matchesCountryChoiceOrIP = (name, config) => {
   return countryList.includes(testCountry);
 };
 
+function hasCountryMatch(str, config) {
+  if (str.includes('countrychoice') || str.includes('countryip')) {
+    const modifiedStr = str.replace('uk', 'gb');
+    return matchesCountryChoiceOrIP(modifiedStr, config);
+  }
+  return false;
+}
 /* c8 ignore start */
 export function parsePlaceholders(placeholders, config, selectedVariantName = '') {
   if (!placeholders?.length || selectedVariantName === 'default') return config;
@@ -772,13 +779,8 @@ export function parsePlaceholders(placeholders, config, selectedVariantName = ''
   ];
   const keys = placeholders?.length ? Object.entries(placeholders[0]) : [];
   const keyVal = keys.find(([key]) => {
-    let modifiedStr = key.toLowerCase();
-    if (valueNames.includes(modifiedStr)) return true;
-    if (modifiedStr.includes('countrychoice') || modifiedStr.includes('countryip')) {
-      modifiedStr = modifiedStr.replace('uk', 'gb');
-      return matchesCountryChoiceOrIP(modifiedStr, config);
-    }
-    return false;
+    const modifiedStr = key.toLowerCase();
+    return valueNames.includes(modifiedStr) || hasCountryMatch(modifiedStr, config);
   });
   const key = keyVal?.[0];
 
@@ -901,10 +903,7 @@ async function getPersonalizationVariant(
     if (!name) return true;
     if (name === variantLabel?.toLowerCase()) return true;
     if (name.startsWith('param-')) return checkForParamMatch(name);
-    if (name.includes('countrychoice') || name.includes('countryip')) {
-      const modifiedName = name.replace('uk', 'gb');
-      return matchesCountryChoiceOrIP(modifiedName, config);
-    }
+    if (hasCountryMatch(name, config)) return true;
     if (userEntitlements?.includes(name)) return true;
     return PERSONALIZATION_KEYS.includes(name) && PERSONALIZATION_TAGS[name]();
   };

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1293,7 +1293,7 @@ export function enablePersonalizationV2() {
 function normCountry(country) {
   return (country.toLowerCase() === 'uk' ? 'gb' : country.toLowerCase()).split('_')[0];
 }
-async function determineUserCountry(config) {
+export async function determineUserCountry(config) {
   const urlParams = new URLSearchParams(window.location.search);
   const country = urlParams.get('country') || (document.cookie.split('; ').find((row) => row.startsWith('international='))?.split('=')[1]);
   config.mep = config.mep || {};

--- a/test/features/personalization/mepGeolocation.test.js
+++ b/test/features/personalization/mepGeolocation.test.js
@@ -1,0 +1,75 @@
+import { expect } from '@esm-bundle/chai';
+import { readFile } from '@web/test-runner-commands';
+import { stub } from 'sinon';
+import { getConfig } from '../../../libs/utils/utils.js';
+import { init } from '../../../libs/features/personalization/personalization.js';
+import mepSettings from './mepGeolocationSettings.js';
+
+const config = getConfig();
+config.env = { name: 'prod' };
+config.mep = { geoLocation: true };
+
+const getFetchPromise = (data, type = 'json') => Promise.resolve({
+  ok: true,
+  [type]: () => data,
+});
+
+const setFetchResponse = (data, type = 'json') => {
+  window.fetch = stub().returns(getFetchPromise(data, type));
+};
+
+const setupTest = async (countryKey, countryValue, manifestPath) => {
+  config.mep[countryKey] = countryValue;
+  document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
+  const manifestJson = JSON.parse(await readFile({ path: manifestPath }));
+  setFetchResponse(manifestJson);
+};
+
+describe('mepGeolocation', () => {
+  beforeEach(async () => {
+    document.head.innerHTML = await readFile({ path: './mocks/metadata.html' });
+    document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
+  });
+
+  it('matches userIP(de) when countryIP is set to de', async () => {
+    await setupTest('countryIP', 'de', './mocks/manifestMEPCountryIP.json');
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init(mepSettings);
+    expect(document.querySelector('.how-to')).to.be.null;
+  });
+
+  it('does not match userIP(de) when countryIP is not set to de', async () => {
+    await setupTest('countryIP', 'fr', './mocks/manifestMEPCountryIP.json');
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init(mepSettings);
+    expect(document.querySelector('.how-to')).to.not.be.null;
+  });
+
+  it('matches userIP(jp, sg) when countryIP is set to sg or jp', async () => {
+    await setupTest('countryIP', 'sg', './mocks/manifestMEPCountryIP.json');
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init(mepSettings);
+    expect(document.querySelector('.how-to')).to.be.null;
+  });
+
+  it('matches userChoice(de) when countryChoice is set to de', async () => {
+    await setupTest('countryChoice', 'de', './mocks/manifestMEPCountryChoice.json');
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init(mepSettings);
+    expect(document.querySelector('.how-to')).to.be.null;
+  });
+
+  it('does not match userChoice(de) when countryChoice is not set to de', async () => {
+    await setupTest('countryChoice', 'fr', './mocks/manifestMEPCountryChoice.json');
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init(mepSettings);
+    expect(document.querySelector('.how-to')).to.not.be.null;
+  });
+
+  it('matches userChoice(jp, sg) when countryChoice is set to sg or jp', async () => {
+    await setupTest('countryChoice', 'sg', './mocks/manifestMEPCountryChoice.json');
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init(mepSettings);
+    expect(document.querySelector('.how-to')).to.be.null;
+  });
+});

--- a/test/features/personalization/mepGeolocation.test.js
+++ b/test/features/personalization/mepGeolocation.test.js
@@ -5,69 +5,75 @@ import { getConfig } from '../../../libs/utils/utils.js';
 import { init } from '../../../libs/features/personalization/personalization.js';
 import mepSettings from './mepGeolocationSettings.js';
 
-const config = getConfig();
-config.env = { name: 'prod' };
-config.mep = { geoLocation: true };
-
-const getFetchPromise = (data, type = 'json') => Promise.resolve({
-  ok: true,
-  [type]: () => data,
+const getFetchPromise = (data, type = 'json') => new Promise((resolve) => {
+  resolve({
+    ok: true,
+    [type]: () => data,
+  });
 });
 
 const setFetchResponse = (data, type = 'json') => {
   window.fetch = stub().returns(getFetchPromise(data, type));
 };
 
-const setupTest = async (countryKey, countryValue, manifestPath) => {
-  config.mep[countryKey] = countryValue;
-  document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
-  const manifestJson = JSON.parse(await readFile({ path: manifestPath }));
-  setFetchResponse(manifestJson);
-};
-
 describe('mepGeolocation', () => {
   beforeEach(async () => {
-    document.head.innerHTML = await readFile({ path: './mocks/metadata.html' });
+    const config = getConfig();
+    config.locale = { ietf: 'en-US', prefix: '' };
+    document.head.innerHTML = await readFile({ path: './mocks/metadata-mepgeolocation.html' });
     document.body.innerHTML = await readFile({ path: './mocks/personalization.html' });
   });
 
   it('matches userIP(de) when countryIP is set to de', async () => {
-    await setupTest('countryIP', 'de', './mocks/manifestMEPCountryIP.json');
+    sessionStorage.setItem('akamai', 'de');
+    const manifestJson = JSON.parse(await readFile({ path: './mocks/manifestMEPCountryIP.json' }));
+    setFetchResponse(manifestJson);
     expect(document.querySelector('.how-to')).to.not.be.null;
     await init(mepSettings);
     expect(document.querySelector('.how-to')).to.be.null;
+    sessionStorage.removeItem('akamai');
   });
 
   it('does not match userIP(de) when countryIP is not set to de', async () => {
-    await setupTest('countryIP', 'fr', './mocks/manifestMEPCountryIP.json');
+    const manifestJson = JSON.parse(await readFile({ path: './mocks/manifestMEPCountryIP.json' }));
+    setFetchResponse(manifestJson);
     expect(document.querySelector('.how-to')).to.not.be.null;
     await init(mepSettings);
     expect(document.querySelector('.how-to')).to.not.be.null;
   });
 
   it('matches userIP(jp, sg) when countryIP is set to sg or jp', async () => {
-    await setupTest('countryIP', 'sg', './mocks/manifestMEPCountryIP.json');
+    sessionStorage.setItem('akamai', 'sg');
+    const manifestJson = JSON.parse(await readFile({ path: './mocks/manifestMEPCountryIP.json' }));
+    setFetchResponse(manifestJson);
     expect(document.querySelector('.how-to')).to.not.be.null;
     await init(mepSettings);
     expect(document.querySelector('.how-to')).to.be.null;
+    sessionStorage.removeItem('akamai');
   });
 
   it('matches userChoice(de) when countryChoice is set to de', async () => {
-    await setupTest('countryChoice', 'de', './mocks/manifestMEPCountryChoice.json');
+    document.cookie = 'international=DE';
+    const manifestJson = JSON.parse(await readFile({ path: './mocks/manifestMEPCountryChoice.json' }));
+    setFetchResponse(manifestJson);
     expect(document.querySelector('.how-to')).to.not.be.null;
     await init(mepSettings);
     expect(document.querySelector('.how-to')).to.be.null;
   });
 
   it('does not match userChoice(de) when countryChoice is not set to de', async () => {
-    await setupTest('countryChoice', 'fr', './mocks/manifestMEPCountryChoice.json');
+    document.cookie = 'international=FR';
+    const manifestJson = JSON.parse(await readFile({ path: './mocks/manifestMEPCountryChoice.json' }));
+    setFetchResponse(manifestJson);
     expect(document.querySelector('.how-to')).to.not.be.null;
     await init(mepSettings);
-    expect(document.querySelector('.how-to')).to.not.be.null;
+    expect(document.querySelector('.how-to')).to.be.not.be.null;
   });
 
   it('matches userChoice(jp, sg) when countryChoice is set to sg or jp', async () => {
-    await setupTest('countryChoice', 'sg', './mocks/manifestMEPCountryChoice.json');
+    document.cookie = 'international=JP';
+    const manifestJson = JSON.parse(await readFile({ path: './mocks/manifestMEPCountryChoice.json' }));
+    setFetchResponse(manifestJson);
     expect(document.querySelector('.how-to')).to.not.be.null;
     await init(mepSettings);
     expect(document.querySelector('.how-to')).to.be.null;

--- a/test/features/personalization/mepGeolocationSettings.js
+++ b/test/features/personalization/mepGeolocationSettings.js
@@ -1,0 +1,10 @@
+const mepSettings = {
+  mepParam: false,
+  mepHighlight: false,
+  mepButton: false,
+  pzn: '/path/to/manifest.json',
+  promo: false,
+  target: false,
+};
+
+export default mepSettings;

--- a/test/features/personalization/mepGeolocationSettings.js
+++ b/test/features/personalization/mepGeolocationSettings.js
@@ -5,6 +5,7 @@ const mepSettings = {
   pzn: '/path/to/manifest.json',
   promo: false,
   target: false,
+  mepgeolocation: true,
 };
 
 export default mepSettings;

--- a/test/features/personalization/mocks/manifestMEPCountryChoice.json
+++ b/test/features/personalization/mocks/manifestMEPCountryChoice.json
@@ -1,0 +1,18 @@
+{
+  "total": 5,
+  "offset": 0,
+  "limit": 5,
+  "data": [
+    {
+      "action": "replace",
+      "selector": ".how-to",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "countryChoice(de)": "/test/features/personalization/mocks/fragments/milo-replace-content-firefox-accordion",
+      "countryChoice(jp,sg)": "/test/features/personalization/mocks/fragments/milo-replace-content-firefox-accordion",
+      "android": "",
+      "ios": ""
+    }
+  ],
+  ":type": "sheet"
+}

--- a/test/features/personalization/mocks/manifestMEPCountryIP.json
+++ b/test/features/personalization/mocks/manifestMEPCountryIP.json
@@ -1,0 +1,18 @@
+{
+  "total": 5,
+  "offset": 0,
+  "limit": 5,
+  "data": [
+    {
+      "action": "replace",
+      "selector": ".how-to",
+      "page filter (optional)": "",
+      "param-newoffer=123": "",
+      "countryIP(de)": "/test/features/personalization/mocks/fragments/milo-replace-content-firefox-accordion",
+      "countryIP(jp,sg)": "/test/features/personalization/mocks/fragments/milo-replace-content-firefox-accordion",
+      "android": "",
+      "ios": ""
+    }
+  ],
+  ":type": "sheet"
+}

--- a/test/features/personalization/mocks/metadata-mepgeolocation.html
+++ b/test/features/personalization/mocks/metadata-mepgeolocation.html
@@ -1,0 +1,4 @@
+<meta name="description" content="Milo Description">
+<meta property="og:title" content="milo">
+<meta name="georouting" content="off">
+<meta name="mepgeolocation" content="on">

--- a/test/utils/mocks/head-personalization.html
+++ b/test/utils/mocks/head-personalization.html
@@ -1,5 +1,6 @@
 <meta name="personalization" content="https://main--milo--adobecom.hlx.page/products/special-offers-manifest.json">
 <meta name="manifestnames" content="pre-black-friday-global,black-friday-global,cyber-monday">
 <meta name="schedule" content="pre-black-friday-global | 2023-11-01T00:00:00 | 2023-12-15T00:00:00 | https://main--milo--adobecom.hlx.page/promos/2023/black-friday/pre-black-friday/manifest-global.json, black-friday-global | 2023-12-15T00:00:00 | 2023-12-31T00:00:00 | https://main--milo--adobecom.hlx.page/promos/2023/black-friday/black-friday/manifest-global.json,  max | 2023-11-01T00:00:00 | 2023-11-30T00:00:00 | https://main--milo--adobecom.hlx.page/promos/2023/black-friday/cyber-monday/manifest-global.json">
+<meta name="mepgeolocation" content="on">
 <title>Document Title</title>
 <link rel="icon" href="data:,">

--- a/test/utils/mocks/mep/head-mepgeolocation-off.html
+++ b/test/utils/mocks/mep/head-mepgeolocation-off.html
@@ -1,0 +1,4 @@
+<meta name="mepgeolocation" content="off">
+<title>Document Title</title>
+<link rel="icon" href="data:,">
+

--- a/test/utils/mocks/mep/head-mepgeolocation-on.html
+++ b/test/utils/mocks/mep/head-mepgeolocation-on.html
@@ -1,0 +1,4 @@
+<meta name="mepgeolocation" content="on">
+<title>Document Title</title>
+<link rel="icon" href="data:,">
+

--- a/test/utils/utils-mep-with-params.test.js
+++ b/test/utils/utils-mep-with-params.test.js
@@ -7,16 +7,18 @@ describe('MEP Utils', () => {
   describe('getMepEnablement', async () => {
     it('checks param overwrites', async () => {
       document.head.innerHTML = await readFile({ path: './mocks/mep/head-promo.html' });
-      spoofParams({ target: 'postlcp', promo: 'off', personalization: 'off' });
+      spoofParams({ target: 'postlcp', promo: 'off', personalization: 'off', ajo: 'off', geoLocation: 'off' });
       setTimeout(() => {
         const persEnabled = getMepEnablement('personalization');
         const promoEnabled = getMepEnablement('manifestnames', 'promo');
         const ajoEnabled = getMepEnablement('ajo');
         const targetEnabled = getMepEnablement('target');
+        const geoLocation = getMepEnablement('geoLocation');
         expect(promoEnabled).to.equal(false);
         expect(persEnabled).to.equal(false);
         expect(ajoEnabled).to.equal(false);
         expect(targetEnabled).to.equal('postlcp');
+        expect(geoLocation).to.equal(false);
       }, 1000);
     });
   });

--- a/test/utils/utils-mep.test.js
+++ b/test/utils/utils-mep.test.js
@@ -63,6 +63,16 @@ describe('MEP Utils', () => {
       const ajoEnabled = getMepEnablement('ajo');
       expect(ajoEnabled).to.equal('postlcp');
     });
+    it('checks mepgeolocation metadata set to off', async () => {
+      document.head.innerHTML = await readFile({ path: './mocks/mep/head-mepgeolocation-off.html' });
+      const mepGelocationEnabled = getMepEnablement('mepgeolocation');
+      expect(mepGelocationEnabled).to.equal(false);
+    });
+    it('checks mepgeolocation metadata set to off', async () => {
+      document.head.innerHTML = await readFile({ path: './mocks/mep/head-mepgeolocation-on.html' });
+      const mepGelocationEnabled = getMepEnablement('mepgeolocation');
+      expect(mepGelocationEnabled).to.equal(true);
+    });
     it('checks from just metadata with no target metadata', async () => {
       document.head.innerHTML = await readFile({ path: './mocks/mep/head-promo.html' });
       const persEnabled = getMepEnablement('personalization');

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -943,50 +943,6 @@ describe('Utils', () => {
       expect(resultExperiment.manifest).to.equal('/products/special-offers-manifest.json');
     });
   });
-  describe('mepgeolocation', () => {
-    beforeEach(() => {
-      document.cookie = 'international=UK';
-    });
-    afterEach(() => {
-      document.cookie = 'international=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-    });
-    it('should enable mepgeolocation via metadata', async () => {
-      const oldHead = document.head.innerHTML;
-      const oldBody = document.body.innerHTML;
-      config.mep = { geolocation: false };
-      document.head.innerHTML = await readFile({ path: './mocks/head-personalization.html' });
-      document.body.innerHTML = await readFile({ path: './mocks/body.html' });
-      await utils.loadArea();
-      document.head.innerHTML = oldHead;
-      document.body.innerHTML = oldBody;
-    });
-    it('should set countryIP from session storage ', async () => {
-      sinon.stub(sessionStorage, 'getItem').withArgs('akamai').returns('ca');
-      await utils.determineUserCountry(config);
-      expect(config.mep.countryIP).to.equal('ca');
-      sessionStorage.getItem.restore();
-    });
-    it('should set countryChoice from international cookie', async () => {
-      await utils.determineUserCountry(config);
-      expect(config.mep.countryChoice).to.equal('gb');
-    });
-    it('should should overwrite countryIP with akamaiLocale parameter', async () => {
-      const mockUrlParams = new URLSearchParams('?akamaiLocale=FR');
-      sinon.stub(window, 'URLSearchParams').returns(mockUrlParams);
-      sinon.stub(sessionStorage, 'getItem').withArgs('akamai').returns('ca');
-      await utils.determineUserCountry(config);
-      expect(config.mep.countryIP).to.equal('fr');
-      sessionStorage.getItem.restore();
-      window.URLSearchParams.restore();
-    });
-    it('should overwrite countryChoice with country parameter ', async () => {
-      const mockUrlParams = new URLSearchParams('?country=sg');
-      sinon.stub(window, 'URLSearchParams').returns(mockUrlParams);
-      await utils.determineUserCountry(config);
-      expect(config.mep.countryChoice).to.equal('sg');
-      window.URLSearchParams.restore();
-    });
-  });
 
   describe('filterDuplicatedLinkBlocks', () => {
     it('returns empty array if receives invalid params', () => {


### PR DESCRIPTION
This feature provides two new options for delivering location-based content with MEP which can be used in experience names and placeholders:
**countryIP** and **countryChoice**
Both are enabled by setting mepgeolocation to "on" in the metadata or via query parameter.
![Screenshot 2025-04-04 at 4 02 01 PM](https://github.com/user-attachments/assets/58d2983c-f4e3-4d0e-909c-779881f80cdc)
![Screenshot 2025-04-04 at 4 06 21 PM](https://github.com/user-attachments/assets/9a5bf032-e4ca-4b4a-9144-cb5db0f5656d)

CountyIP leverages the existing getAkamaiCode function from georoutingv2.js, relying on query parameter (akamaiLocale), session storage(akamai) and lastly the geo2 api to set the config.mep.countryIP value the manifest will match against.

CountryChoice relies on the country query parameter, the international cookie and will fallback to mep.countryIP if it's available. 


Steps to test:
Using your vpn, select Singpore. Check the value of akamai in session storage, you will need to delete it and reload.
![Screenshot 2025-04-04 at 4 27 17 PM](https://github.com/user-attachments/assets/300cd2f3-6e17-4867-bafb-1462a35f8324)


You should see this in the top of the marquee:
![Screenshot 2025-04-04 at 4 26 20 PM](https://github.com/user-attachments/assets/7aa5b481-4b88-4b4e-ab93-a5090d8993dc)

now using the region picker at the buttom of the page, select australia. 
![Screenshot 2025-04-04 at 4 30 03 PM](https://github.com/user-attachments/assets/02a9d5b9-9569-4d0c-9607-5f7b505a07bb)


You will need to back page and then choose to stay in australia. But, assuming your international cookie was set properly to au: 
![Screenshot 2025-04-04 at 4 31 31 PM](https://github.com/user-attachments/assets/395685b6-c765-4906-83ea-d2ca4237693c)

You will see this in the bottom half of the marquee: 
![Screenshot 2025-04-04 at 4 32 20 PM](https://github.com/user-attachments/assets/0c518623-ab74-4707-8754-ac93a5495841)



Resolves: [MWPW-169356](https://jira.corp.adobe.com/browse/MWPW-169356)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q2/meppznusercountry/telephonenumbe
- After: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q2/meppznusercountry/telephonenumber?milolibs=meppznusercountry&mepgeolocation=on
- Psi-check: https://meppznusercountry--milo--adobecom.aem.page/?martech=off












