### PR TITLE
Vhargrave/mwpw 169933 language based links

### DIFF
--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -17,6 +17,7 @@ import {
   getMetadata,
 } from '../utils/utils.js';
 import locales from '../utils/locales.js';
+import languages from '../utils/languages.js';
 
 // Production Domain
 const prodDomains = ['milo.adobe.com', 'business.adobe.com', 'www.adobe.com'];
@@ -50,6 +51,7 @@ const config = {
   imsClientId: 'milo',
   codeRoot: '/libs',
   locales,
+  languages,
   prodDomains,
   stageDomainsMap,
   jarvis: {

--- a/libs/utils/languages.js
+++ b/libs/utils/languages.js
@@ -1,0 +1,22 @@
+export default {
+  en: {
+    ietf: 'en',
+    tk: 'hah7vzn.css',
+    regions: [
+      { region: 'us', ietf: 'en-US', tk: 'hah7vzn.css' },
+      { region: 'gb', ietf: 'en-GB', tk: 'hah7vzn.css' },
+      { region: 'apac', ietf: 'en', tk: 'hah7vzn.css' },
+    ],
+  },
+  de: {
+    ietf: 'de',
+    tk: 'hah7vzn.css',
+    languageBased: false,
+    regions: [
+      // { region: 'at', ietf: 'de-AT', tk: 'hah7vzn.css' },
+      { region: 'ch', ietf: 'de-CH', tk: 'hah7vzn.css' },
+      { region: 'de', ietf: 'de-DE', tk: 'hah7vzn.css' },
+      // { region: 'lu', ietf: 'de-LU', tk: 'hah7vzn.css' }
+    ],
+  },
+};

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -210,11 +210,13 @@ export function getLanguage(languages, locales, pathname = window.location.pathn
   const baseSplit = [LANGSTORE, PREVIEW].includes(split[1]) ? 1 : 0;
   const languageString = split[baseSplit + 1];
   const region = split[baseSplit + 2];
+  let regionPath = '';
 
   const language = languages[languageString];
   if (language && region && language.regions) {
     const [matchingRegion] = language.regions.filter((r) => r.region === region);
     language.region = matchingRegion;
+    regionPath = matchingRegion ? `/${region}` : '';
   }
 
   // if no language, allow for support of locale based routing still
@@ -222,7 +224,7 @@ export function getLanguage(languages, locales, pathname = window.location.pathn
     return getLocale(locales, pathname);
   }
 
-  language.prefix = `/${languageString}${region ? `/${region}` : ''}`;
+  language.prefix = `/${languageString}${regionPath}`;
   language.languageBased = true;
   return language;
 }
@@ -341,7 +343,7 @@ export const getFederatedUrl = (url = '') => {
   return url;
 };
 
-function hasLanguageLinks(area) {
+export function hasLanguageLinks(area) {
   const targetDomains = [
     // don't add milo too. It's a special case because of tools, merch, etc.
     'news.adobe.com',
@@ -358,7 +360,7 @@ function hasLanguageLinks(area) {
   });
 }
 
-async function loadLanguageConfig() {
+export async function loadLanguageConfig() {
   try {
     const config = await fetch(`${getFederatedContentRoot()}/federal/assets/data/languages-config.json`);
     const configJson = await config.json();

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -519,7 +519,6 @@ describe('Utils', () => {
         config.pathname = path;
         utils.setConfig(config);
       }
-
       it('Same domain link is relative and localized', () => {
         expect(utils.localizeLink('https://main--milo--adobecom.hlx.page/gnav/solutions', 'main--milo--adobecom.hlx.page')).to.equal('/be_fr/gnav/solutions');
       });
@@ -1004,6 +1003,202 @@ describe('Utils', () => {
       metaTag.setAttribute('name', 'footer');
       metaTag.setAttribute('content', 'on');
       document.head.appendChild(metaTag);
+    });
+  });
+
+  describe('Localization Logic', () => {
+    // Base config with common properties
+    const baseConfig = {
+      locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } },
+      prodDomains: ['news.adobe.com'],
+      contentRoot: '/root',
+    };
+
+    // --- Tests for localizeLink ---
+    describe('localizeLink', () => {
+      it('uses locale prefix when no language-based logic applies', () => {
+        utils.setConfig({
+          ...baseConfig,
+          pathname: '/de/',
+          locales: {
+            ...baseConfig.locales,
+            de: { ietf: 'de-DE', tk: 'hah7vzn.css' },
+          },
+        });
+        const href = 'https://examplesite.com/path';
+        const result = utils.localizeLink(href, 'examplesite.com');
+        expect(utils.getConfig().locale.prefix).to.equal('/de');
+        expect(result).to.equal('/de/path');
+      });
+
+      it('adjusts prefix to locale when no site match', () => {
+        utils.setConfig({
+          ...baseConfig,
+          pathname: '/ch_de/',
+          languages: {
+            de: {
+              ietf: 'de',
+              tk: 'hah7vzn.css',
+              regions: [{ region: 'ch', ietf: 'de-CH', tk: 'hah7vzn.css' }],
+            },
+          },
+          locales: {
+            ...baseConfig.locales,
+            ch_de: { ietf: 'ch-DE', tk: 'hah7vzn.css' },
+          },
+        });
+        const href = 'https://othersite.com/path';
+        const result = utils.localizeLink(href, 'othersite.com');
+        expect(utils.getConfig().locale.prefix).to.equal('/ch_de');
+        expect(utils.getConfig().locale.languageBased).to.be.undefined;
+        expect(result).to.equal('/ch_de/path');
+      });
+
+      it('keeps language-based prefix when site matches and language is valid', async () => {
+        const mockConfig = {
+          'locale-to-language-map': { data: [] },
+          'site-languages': {
+            data: [
+              {
+                domainMatches: 'news.adobe.com\n--news--adobecom.',
+                languages: 'en\nen/gb\nde',
+              },
+            ],
+          },
+        };
+        window.fetch = async () => ({
+          ok: true,
+          json: () => Promise.resolve(mockConfig),
+        });
+        utils.setConfig({
+          ...baseConfig,
+          pathname: '/en/gb/',
+          languages: {
+            en: {
+              ietf: 'en',
+              tk: 'hah7vzn.css',
+              regions: [{ region: 'gb', ietf: 'en-GB', tk: 'hah7vzn.css' }],
+            },
+          },
+        });
+        await utils.loadLanguageConfig();
+        const href = 'https://news.adobe.com/path';
+        const result = utils.localizeLink(href, 'news.adobe.com');
+        expect(utils.getConfig().locale.prefix).to.equal('/en/gb');
+        expect(utils.getConfig().locale.languageBased).to.be.true;
+        expect(result).to.equal('/en/gb/path');
+      });
+
+      it('maps to locale prefix when site matches but language is invalid', async () => {
+        const mockConfig = {
+          'locale-to-language-map': { data: [{ locale: 'ch_de', languagePath: 'de/ch' }] },
+          'site-languages': {
+            data: [
+              {
+                domainMatches: 'news.adobe.com\n--news--adobecom.',
+                languages: 'en\nfr',
+              },
+            ],
+          },
+        };
+        window.fetch = async () => ({
+          ok: true,
+          json: () => Promise.resolve(mockConfig),
+        });
+        utils.setConfig({
+          ...baseConfig,
+          pathname: '/de/ch/',
+          languages: {
+            de: {
+              ietf: 'de',
+              tk: 'hah7vzn.css',
+              regions: [{ region: 'ch', ietf: 'de-CH', tk: 'hah7vzn.css' }],
+            },
+          },
+          locales: {
+            ...baseConfig.locales,
+            ch_de: { ietf: 'de-CH', tk: 'hah7vzn.css' },
+          },
+        });
+        await utils.loadLanguageConfig();
+        const href = 'https://news.adobe.com/path';
+        const result = utils.localizeLink(href, 'news.adobe.com');
+        expect(utils.getConfig().locale.prefix).to.equal('/de/ch');
+        expect(utils.getConfig().locale.languageBased).to.be.true;
+        expect(result).to.equal('/ch_de/path');
+      });
+
+      it('uses locale prefix for non-language-based when site matches but no language', async () => {
+        const mockConfig = {
+          'locale-to-language-map': { data: [{ locale: 'ch_de', languagePath: 'de/ch' }] },
+          'site-languages': {
+            data: [
+              {
+                domainMatches: 'news.adobe.com\n--news--adobecom.',
+                languages: 'en\nfr',
+              },
+            ],
+          },
+        };
+        window.fetch = async () => ({
+          ok: true,
+          json: () => Promise.resolve(mockConfig),
+        });
+        utils.setConfig({
+          ...baseConfig,
+          pathname: '/ch_de/',
+          locales: {
+            ...baseConfig.locales,
+            ch_de: { ietf: 'de-CH', tk: 'hah7vzn.css' },
+          },
+        });
+        await utils.loadLanguageConfig();
+        const href = 'https://news.adobe.com/path';
+        const result = utils.localizeLink(href, 'news.adobe.com');
+        expect(utils.getConfig().locale.prefix).to.equal('/ch_de');
+        expect(utils.getConfig().locale.languageBased).to.be.undefined;
+        expect(result).to.equal('/ch_de/path');
+      });
+
+      it('skips language logic on localhost', () => {
+        utils.setConfig({
+          ...baseConfig,
+          pathname: '/de/ch/',
+          languages: {
+            de: {
+              ietf: 'de',
+              tk: 'hah7vzn.css',
+              regions: [{ region: 'ch', ietf: 'de-CH', tk: 'hah7vzn.css' }],
+            },
+          },
+        });
+        const href = 'http://localhost/path';
+        const result = utils.localizeLink(href);
+        expect(utils.getConfig().locale.prefix).to.equal('/de/ch');
+        expect(utils.getConfig().locale.languageBased).to.be.true;
+        expect(result).to.equal('/de/ch/path');
+      });
+    });
+
+    // --- Tests for hasLanguageLinks ---
+    describe('hasLanguageLinks', () => {
+      it('returns true when links match target domains', () => {
+        const link = utils.createTag('a', { href: 'https://news.adobe.com/path' }, 'Link');
+        const div = utils.createTag('div', {}, link);
+        expect(utils.hasLanguageLinks(div)).to.be.true;
+      });
+
+      it('returns false when no links match target domains', () => {
+        const link = utils.createTag('a', { href: 'https://examplesite.com/path' }, 'Link');
+        const div = utils.createTag('div', {}, link);
+        expect(utils.hasLanguageLinks(div)).to.be.false;
+      });
+
+      it('handles invalid URLs gracefully', () => {
+        const link = utils.createTag('a', { href: 'invalid://url' }, 'Link');
+        const div = utils.createTag('div', {}, link);
+        expect(utils.hasLanguageLinks(div)).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
Allow for language based links in milo

Resolves: [MWPW-169933](https://jira.corp.adobe.com/browse/MWPW-169933)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://vhargrave-MWPW-169933-language-based-links--milo--adobecom.aem.page/?martech=off

- Before: http://main--milo--adobecom.aem.page/de/de/
- After: http://vhargrave-mwpw-169933-language-based-links--milo--adobecom.aem.page/de/de/

**News - will be the first consumer using this new paradigm**
- Before: https://language-site--news--adobecom.aem.page/ko/drafts/ruchika/testpage
- After: https://language-site--news--adobecom.aem.page/ko/drafts/ruchika/testpage?milolibs=vhargrave-MWPW-169933-language-based-links

- Before: https://language-site--news--adobecom.aem.page/en/gb/
- After: https://language-site--news--adobecom.aem.page/en/gb/?milolibs=vhargrave-MWPW-169933-language-based-links


** CC & other consumers should not be affected by this change **
- Before: http://main--cc--adobecom.aem.live/products/photoshop-lightroom
- After: http://main--cc--adobecom.aem.live/products/photoshop-lightroom?milolibs=vhargrave-MWPW-169933-language-based-links

- Before: http://main--bacom--adobecom.hlx.page/
- After: http://main--bacom--adobecom.hlx.page/?milolibs=vhargrave-MWPW-169933-language-based-links

- Before: http://main--bacom--adobecom.hlx.page/de/
- After: http://main--bacom--adobecom.hlx.page/de/?milolibs=vhargrave-MWPW-169933-language-based-links



