### PR TITLE
Handle gnav promo bar overflowing gracefully

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1283,7 +1283,7 @@ class Gnav {
             const popup = dropdownTrigger.nextElementSibling;
             // document.body.style.top should always be set
             // at this point by calling disableMobileScroll
-            if (popup) {
+            if (popup && this.isLocalNav()) {
               this.updatePopupPosition(popup);
             }
             makeTabActive(popup);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1024,7 +1024,6 @@ class Gnav {
     fedsPromoWrapper.append(this.elements.aside);
 
     const updateLayout = () => {
-      lanaLog({ message: 'Promo height is more than expected, potential CLS', tags: 'gnav-promo', errorType: 'info' });
       const promoHeight = `${this.elements.aside.clientHeight}px`;
       const header = document.querySelector('header');
       const localNav = document.querySelector('.feds-localnav');
@@ -1039,8 +1038,14 @@ class Gnav {
     };
 
     if (this.elements.aside.clientHeight > fedsPromoWrapper.clientHeight) {
+      lanaLog({ message: 'Promo height is more than expected, potential CLS', tags: 'gnav-promo', errorType: 'info' });
       updateLayout();
-      new ResizeObserver(updateLayout).observe(this.elements.aside);
+
+      if (this.promoResizeObserver) {
+        this.promoResizeObserver.disconnect();
+      }
+      this.promoResizeObserver = new ResizeObserver(updateLayout);
+      this.promoResizeObserver.observe(this.elements.aside);
     }
 
     return this.elements.aside;
@@ -1115,8 +1120,9 @@ class Gnav {
     const popup = activePopup || this.elements.mainNav.querySelector('.feds-navItem--section.feds-dropdown--active .feds-popup');
     if (!popup) return;
     const yOffset = window.scrollY || Math.abs(parseInt(document.body.style.top, 10)) || 0;
+    const promoHeight = this.elements.aside?.clientHeight;
     const navOffset = this.block.classList.contains('has-promo')
-      ? 'var(--feds-height-nav) - var(--global-height-navPromo)'
+      ? `var(--feds-height-nav) - ${promoHeight}px`
       : 'var(--feds-height-nav)';
     popup.removeAttribute('style');
     popup.style.top = `calc(${yOffset}px - ${navOffset} - 2px)`;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1120,8 +1120,8 @@ class Gnav {
     const hasPromo = this.block.classList.contains('has-promo');
     const promoHeight = this.elements.aside?.clientHeight;
 
-    if (!this.isLocalNav() && hasPromo) {
-      popup.style.top = `calc(0px - var(--feds-height-nav) - ${promoHeight}px)`;
+    if (!this.isLocalNav()) {
+      if (hasPromo) popup.style.top = `calc(0px - var(--feds-height-nav) - ${promoHeight}px)`;
       return;
     }
     const yOffset = window.scrollY || Math.abs(parseInt(document.body.style.top, 10)) || 0;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1022,6 +1022,26 @@ class Gnav {
     if (!decorate) return this.elements.aside;
     this.elements.aside = await decorate({ headerElem: this.block, fedsPromoWrapper, promoPath });
     fedsPromoWrapper.append(this.elements.aside);
+
+    const updateLayout = () => {
+      fedsPromoWrapper.style.height = `${this.elements.aside.clientHeight}px`;
+      if (!document.querySelector('.feds-localnav')) {
+        document.querySelector('header').style.top = `${this.elements.aside.clientHeight}px`;
+      }
+    }
+
+    if (this.elements.aside.clientHeight > fedsPromoWrapper.clientHeight) {
+      updateLayout();
+      const resizeObserver = new ResizeObserver(() => {
+        updateLayout();
+      });
+      resizeObserver.observe(this.elements.aside);
+      resizeObserver.observe(fedsPromoWrapper);
+      window.addEventListener('unload', () => {
+        resizeObserver.disconnect();
+      });
+    }
+  
     return this.elements.aside;
   };
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1032,14 +1032,7 @@ class Gnav {
 
     if (this.elements.aside.clientHeight > fedsPromoWrapper.clientHeight) {
       updateLayout();
-      const resizeObserver = new ResizeObserver(() => {
-        updateLayout();
-      });
-      resizeObserver.observe(this.elements.aside);
-      resizeObserver.observe(fedsPromoWrapper);
-      window.addEventListener('unload', () => {
-        resizeObserver.disconnect();
-      });
+      new ResizeObserver(updateLayout).observe(this.elements.aside);
     }
   
     return this.elements.aside;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1041,9 +1041,7 @@ class Gnav {
       lanaLog({ message: 'Promo height is more than expected, potential CLS', tags: 'gnav-promo', errorType: 'info' });
       updateLayout();
 
-      if (this.promoResizeObserver) {
-        this.promoResizeObserver.disconnect();
-      }
+      this.promoResizeObserver?.disconnect();
       this.promoResizeObserver = new ResizeObserver(updateLayout);
       this.promoResizeObserver.observe(this.elements.aside);
     }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1117,11 +1117,15 @@ class Gnav {
   updatePopupPosition = (activePopup) => {
     const popup = activePopup || this.elements.mainNav.querySelector('.feds-navItem--section.feds-dropdown--active .feds-popup');
     if (!popup) return;
-    const yOffset = window.scrollY || Math.abs(parseInt(document.body.style.top, 10)) || 0;
+    const hasPromo = this.block.classList.contains('has-promo');
     const promoHeight = this.elements.aside?.clientHeight;
-    const navOffset = this.block.classList.contains('has-promo')
-      ? `var(--feds-height-nav) - ${promoHeight}px`
-      : 'var(--feds-height-nav)';
+
+    if (!this.isLocalNav() && hasPromo) {
+      popup.style.top = `calc(0px - var(--feds-height-nav) - ${promoHeight}px)`;
+      return;
+    }
+    const yOffset = window.scrollY || Math.abs(parseInt(document.body.style.top, 10)) || 0;
+    const navOffset = hasPromo ? `var(--feds-height-nav) - ${promoHeight}px` : 'var(--feds-height-nav)';
     popup.removeAttribute('style');
     popup.style.top = `calc(${yOffset}px - ${navOffset} - 2px)`;
     const { isPresent, isSticky, height } = getBranchBannerInfo();
@@ -1283,7 +1287,7 @@ class Gnav {
             const popup = dropdownTrigger.nextElementSibling;
             // document.body.style.top should always be set
             // at this point by calling disableMobileScroll
-            if (popup && this.isLocalNav()) {
+            if (popup) {
               this.updatePopupPosition(popup);
             }
             makeTabActive(popup);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1283,7 +1283,7 @@ class Gnav {
             const popup = dropdownTrigger.nextElementSibling;
             // document.body.style.top should always be set
             // at this point by calling disableMobileScroll
-            if (popup && this.isLocalNav()) {
+            if (popup) {
               this.updatePopupPosition(popup);
             }
             makeTabActive(popup);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1024,10 +1024,11 @@ class Gnav {
     fedsPromoWrapper.append(this.elements.aside);
 
     const updateLayout = () => {
+      lanaLog({ message: 'Promo height is more than expected, potential CLS', tags: 'gnav-promo', errorType: 'info' });
       const promoHeight = `${this.elements.aside.clientHeight}px`;
       const header = document.querySelector('header');
       const localNav = document.querySelector('.feds-localnav');
-      
+
       fedsPromoWrapper.style.height = promoHeight;
       header.style.top = promoHeight;
 
@@ -1035,13 +1036,13 @@ class Gnav {
         header.style.top = 0;
         localNav.style.top = promoHeight;
       }
-    }
+    };
 
     if (this.elements.aside.clientHeight > fedsPromoWrapper.clientHeight) {
       updateLayout();
       new ResizeObserver(updateLayout).observe(this.elements.aside);
     }
-  
+
     return this.elements.aside;
   };
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1024,9 +1024,16 @@ class Gnav {
     fedsPromoWrapper.append(this.elements.aside);
 
     const updateLayout = () => {
-      fedsPromoWrapper.style.height = `${this.elements.aside.clientHeight}px`;
-      if (!document.querySelector('.feds-localnav')) {
-        document.querySelector('header').style.top = `${this.elements.aside.clientHeight}px`;
+      const promoHeight = `${this.elements.aside.clientHeight}px`;
+      const header = document.querySelector('header');
+      const localNav = document.querySelector('.feds-localnav');
+      
+      fedsPromoWrapper.style.height = promoHeight;
+      header.style.top = promoHeight;
+
+      if (!isDesktop.matches && localNav) {
+        header.style.top = 0;
+        localNav.style.top = promoHeight;
       }
     }
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -631,7 +631,8 @@ export const [branchBannerLoadCheck, getBranchBannerInfo] = (() => {
                 branchBannerInfo.height = node.offsetHeight; // Get the height of the element
                 if (branchBannerInfo.isSticky) {
                   // Adjust the top position of the lnav to account for the branch banner height
-                  document.querySelector('.feds-localnav').style.top = `${branchBannerInfo.height}px`;
+                  const navElem = document.querySelector(isLocalNav() ? '.feds-localnav' : 'header');
+                  navElem.style.top = `${branchBannerInfo.height}px`;
                 } else {
                   // Add a class to the body to indicate the presence of a non-sticky branch banner
                   document.body.classList.add('branch-banner-inline');
@@ -648,7 +649,9 @@ export const [branchBannerLoadCheck, getBranchBannerInfo] = (() => {
                 branchBannerInfo.isSticky = false;
                 branchBannerInfo.height = 0;
                 // Remove the top style attribute when the branch banner is removed
-                document.querySelector('.feds-localnav')?.removeAttribute('style');
+                const navElem = document.querySelector(isLocalNav() ? '.feds-localnav' : 'header');
+                navElem?.removeAttribute('style');
+
                 // Remove the class indicating the presence of a non-sticky branch banner
                 document.body.classList.remove('branch-banner-inline');
                 // Update the popup position when the branch banner is removed


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Currently the promo hides the gnav if it overflows. Now, we are pushing gnav down with a lana log that there is potential CLS.

Resolves: [MWPW-170784](https://jira.corp.adobe.com/browse/MWPW-170784)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo-overflow?martech=off
- After: https://gnav-promo--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo-overflow?martech=off


## GNav Test URLs

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=gnav-promo--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=gnav-promo--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=gnav-promo--milo--adobecom
- Milo: https://gnav-promo--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=gnav-promo--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=gnav-promo--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=gnav-promo--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-promo--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-promo--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-promo--milo--adobecom
- Milo: https://gnav-promo--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-promo--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-promo--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-promo--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-promo--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-promo--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-promo--milo--adobecom
- Milo: https://gnav-promo--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-promo--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-promo--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-promo--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=gnav-promo--milo--adobecom
**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=gnav-promo--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=gnav-promo--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=gnav-promo--milo--adobecom