### PR TITLE
Fix the pr merge notification workflow

### DIFF
--- a/.github/workflows/pr-merge-notification.yaml
+++ b/.github/workflows/pr-merge-notification.yaml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Run Notify Merge with GitHub Script
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
-            const notifyMerge = require('./.github/workflows/notify-on-merge.js');
+            const notifyMerge = require('./.github/workflows/pr-merge-notification.js');
             await notifyMerge({ github, context });
         env:
           MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}


### PR DESCRIPTION
### Description
This [newly introduced workflow](https://github.com/adobecom/milo/pull/3838) runs well in isolation, however not on the CI as the script name changed during development.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://fix-merge-to-stage--milo--adobecom.aem.page/?martech=off
