### PR TITLE
Use pull_request_target to properly access secrets

### DIFF
--- a/.github/workflows/pr-merge-notification.yaml
+++ b/.github/workflows/pr-merge-notification.yaml
@@ -1,7 +1,7 @@
 name: Slack notification on Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
### Description
To properly access secrets from forks, we'll need to run the action on the _target_ branch (stage) since forks are not passed any secrets. Thanks @overmyheadandbody to initially find this little gem within his high-impact label workflow.


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://use-pull-request-target--milo--adobecom.aem.page/?martech=off
