### PR TITLE
Gnav dynamic pr updating replace regex

### DIFF
--- a/.github/workflows/dynamic-pr-template.yml
+++ b/.github/workflows/dynamic-pr-template.yml
@@ -120,7 +120,6 @@ jobs:
               // Check if Test URLs section exists
               const hasTestUrlsSection = pullRequest.body.includes('## GNav Test URLs');
               let newDescription;
-
               if (hasTestUrlsSection) {
                 // Replace existing Test URLs section
                 newDescription = pullRequest.body.replace(/## GNav Test URLs[\s\S]*?(?=(^##\s|\Z))/m, testUrlsSection);

--- a/.github/workflows/dynamic-pr-template.yml
+++ b/.github/workflows/dynamic-pr-template.yml
@@ -120,9 +120,10 @@ jobs:
               // Check if Test URLs section exists
               const hasTestUrlsSection = pullRequest.body.includes('## GNav Test URLs');
               let newDescription;
+
               if (hasTestUrlsSection) {
                 // Replace existing Test URLs section
-                newDescription = pullRequest.body.replace(/## GNav Test URLs[\s\S]*?(?=\n\n|$)/, testUrlsSection);
+                newDescription = pullRequest.body.replace(/## GNav Test URLs[\s\S]*?(?=(^##\s|\Z))/m, testUrlsSection);
               } else {
                 // Add Test URLs section at the end
                 newDescription = `${pullRequest.body}\n\n${testUrlsSection}`;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* The replace regex is not matching with the test url header and appending the test urls every time it runs
* So, updated the regex to match the header correctly

Test PR - https://github.com/bandana147/milo/pull/10 - Rerunning the dynamic template workflow in this PR will not append the test urls.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-dynamic-pr--milo--adobecom.aem.page/?martech=off


