### PR TITLE
[MEP]add mep-order files

### DIFF
--- a/nala/features/personalization/mep-order.spec.js
+++ b/nala/features/personalization/mep-order.spec.js
@@ -1,0 +1,21 @@
+module.exports = {
+  name: 'check order of MEP executions',
+  features: [
+    {
+      tcid: '0',
+      name: '@check order of pzn vs promo vs test',
+      desc: 'pzn should be first, promo should be second, test should be last',
+      path: '/drafts/nala/features/personalization/mep-order/pzn-vs-promo-vs-test',
+      data: {},
+      tags: '@meporder0 @mep @smoke @regression @milo',
+    },
+    {
+      tcid: '1',
+      name: '@check order of first vs normal vs last',
+      desc: 'order should be first, normal, last',
+      path: '/drafts/nala/features/personalization/mep-order/first-vs-normal-vs-last',
+      data: {},
+      tags: '@meporder1 @mep @smoke @regression @milo',
+    },
+  ],
+};

--- a/nala/features/personalization/mep-order.test.js
+++ b/nala/features/personalization/mep-order.test.js
@@ -1,0 +1,32 @@
+// to run this test:
+// npm run nala stage tag=meporder mode=headed
+
+import { expect, test } from '@playwright/test';
+import { features } from './mep-order.spec.js';
+import AsideBlock from '../../blocks/aside/aside.page.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+
+test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+  const heroMarqueeH1 = page.locator('h1');
+  const aside = new AsideBlock(page);
+  const URL = `${baseURL}${features[0].path}${miloLibs}`;
+  console.info(`[Test Page]: ${URL}`);
+
+  await page.goto(URL);
+  await expect(heroMarqueeH1).toHaveText('replaced by PZN manifest');
+  await expect(aside.h2TitleXLarge.nth(0)).toHaveText('replaced by Promo manifest');
+  await expect(aside.h2TitleXLarge.nth(1)).toHaveText('replaced by Test manifest');
+});
+
+test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
+  const heroMarqueeH1 = page.locator('h1');
+  const aside = new AsideBlock(page);
+  const URL = `${baseURL}${features[1].path}${miloLibs}`;
+  console.info(`[Test Page]: ${URL}`);
+
+  await page.goto(URL);
+  await expect(heroMarqueeH1).toHaveText('replaced by FIRST manifest');
+  await expect(aside.h2TitleXLarge.nth(0)).toHaveText('replaced by NORMAL manifest');
+  await expect(aside.h2TitleXLarge.nth(1)).toHaveText('replaced by LAST manifest');
+});


### PR DESCRIPTION
This nala test checks the order of execution for nala tests.
There are 2 tests: 
1) The order of first vs normal vs last should be as expected.
2) The order of manifest types should be pzn 1st, promo 2nd, and test (last).


Resolves: [MWPW-170409](https://jira.corp.adobe.com/browse/MWPW-170409)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mep-order--milo--adobecom.aem.page/?martech=off

test pages:
https://main--milo--adobecom.aem.page/drafts/nala/features/personalization/mep-order/first-vs-normal-vs-last
https://main--milo--adobecom.aem.page/drafts/nala/features/personalization/mep-order/pzn-vs-promo-vs-test

In essence, the headings of the 3 sections are being replaced. 
All 3 headings are being replaced by the first execution.
The 2nd heading is being overwritten by the 2nd execution
The 3rd heading is being overwritten by the 1st and the 2nd execution, but also by the last execution.
The expected order therefore is as follows:
a) the first heading should be the first execution
b) the second heading should be the second execution (as it overwrites the first)
c) the third heading should be the third execution (as it overwrites the other 2)