### PR TITLE
Fix the gradient feds navLink on dark mode

### DIFF
--- a/libs/blocks/global-navigation/dark-nav.css
+++ b/libs/blocks/global-navigation/dark-nav.css
@@ -224,6 +224,15 @@ header.new-nav.feds--dark .feds-nav > section.feds-navItem > .feds-popup .top-ba
   .feds--dark .feds-promo-link:hover {
     color: var(--feds-color-link--hover);
   }
+  /* This is to fix the Dark theme on Adobe Home
+   * Currently bacom doesn't have a dark theme
+   * so we have no designs for the gradient on
+   * dark theme.So for now we're making the
+   * background transparent
+   */
+  .feds-navLink--gray-gradient {
+    background: transparent;
+  }
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* This commit went in feds-standalone 0.0.6 as a hotfix but is missing in 0.0.7. We need to merge it to stage to get it into 0.0.7


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://dark-gnav-gradient--milo--adobecom.aem.page/?martech=off

