### PR TITLE
MWPW-170824: Fix image label overflow

### DIFF
--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -667,7 +667,7 @@ body.preflight-assets-analysis {
 
 picture:has(.picture-meta) {
   position: relative;
-  display: block;
+  display: block !important;
 }
 
 .picture-meta {


### PR DESCRIPTION
* Fix image label overflow

Testing: Open preflight tool from sidekick, wait for image labels to show up

Resolves: [MWPW-170824](https://jira.corp.adobe.com/browse/MWPW-170824)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-170824-preflight-label-overflow--milo--adobecom.aem.page/?martech=off

**CC URL**:
- Before: https://main--cc--adobecom.hlx.page/products/substance3d
- After: https://main--cc--adobecom.hlx.page/products/substance3d?milolibs=MWPW-170824-preflight-label-overflow

