### PR TITLE
MWPW-170822: Fix broken label

### DIFF
--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -686,6 +686,7 @@ picture:has(.picture-meta) {
   line-height: 1.2;
   z-index: 9;
   opacity: 0.7;
+  height: auto !important;
 }
 
 .picture-meta.no-picture-tag {
@@ -702,7 +703,7 @@ img:hover ~ .picture-meta {
 }
 
 .picture-meta > div {
-  padding: 5px;
+  padding: 5px !important;
   border-radius: 6px;
 }
 


### PR DESCRIPTION
* Fix broken preflight image label

Testing: Open preflight tool via sidekick and wait for image labels to load

Resolves: [MWPW-170822](https://jira.corp.adobe.com/browse/MWPW-170822)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-170822-preflight-broken-label--milo--adobecom.aem.page/?martech=off

**BACOM URL:**
- Before: https://main--bacom--adobecom.hlx.page/
- After: https://main--bacom--adobecom.hlx.page/?milolibs=MWPW-170822-preflight-broken-label

