### PR TITLE
Color mismatch in the Gnav in dark mode on mobile device

### DIFF
--- a/libs/blocks/global-navigation/dark-nav.css
+++ b/libs/blocks/global-navigation/dark-nav.css
@@ -156,12 +156,12 @@ header.new-nav.feds--dark .feds-nav > section.feds-navItem > .feds-popup .top-ba
   color: var(--feds-color-adobeBrand);
 }
 
+header.global-navigation.feds--dark {
+  background-color: var(--feds-background-nav--desktop);
+}
+
 /* Desktop styles */
 @media (min-width: 900px) {
-  header.global-navigation.feds--dark {
-    background-color: var(--feds-background-nav--desktop);
-  }
-  
   .feds--dark .feds-topnav-wrapper {
     background-color: var(--feds-background-nav--desktop);
   }

--- a/libs/blocks/global-navigation/dark-nav.css
+++ b/libs/blocks/global-navigation/dark-nav.css
@@ -160,12 +160,12 @@ header.global-navigation.feds--dark {
   background-color: var(--feds-background-nav--desktop);
 }
 
+.feds--dark .feds-topnav-wrapper {
+  background-color: var(--feds-background-nav--desktop);
+}
+
 /* Desktop styles */
 @media (min-width: 900px) {
-  .feds--dark .feds-topnav-wrapper {
-    background-color: var(--feds-background-nav--desktop);
-  }
-  
   /* Popup */
   .feds--dark .feds-popup {
     background-color: var(--feds-background-popup);

--- a/libs/blocks/global-navigation/dark-nav.css
+++ b/libs/blocks/global-navigation/dark-nav.css
@@ -156,10 +156,7 @@ header.new-nav.feds--dark .feds-nav > section.feds-navItem > .feds-popup .top-ba
   color: var(--feds-color-adobeBrand);
 }
 
-header.global-navigation.feds--dark {
-  background-color: var(--feds-background-nav--desktop);
-}
-
+header.global-navigation.feds--dark,
 .feds--dark .feds-topnav-wrapper {
   background-color: var(--feds-background-nav--desktop);
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Making mobile and desktop background color consistent for Gnav

Resolves: [MWPW-169322](https://jira.corp.adobe.com/browse/MWPW-169322)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mgnav-bgcolor--milo--adobecom.aem.page/?martech=off

Standalone Gnav: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&authoringpath=/federal/home&customlinks=home,apps,learn,files,discover&theme=dark&navbranch=mgnav-bgcolor&newNav=on



## GNav Test URLs

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- Milo: https://mgnav-bgcolor--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=mgnav-bgcolor--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- Milo: https://mgnav-bgcolor--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mgnav-bgcolor--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- Milo: https://mgnav-bgcolor--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mgnav-bgcolor--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=mgnav-bgcolor--milo--adobecom
**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=mgnav-bgcolor--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=mgnav-bgcolor--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=mgnav-bgcolor--milo--adobecom