### PR TITLE
Changing gnav height for standalone Gnav

### DIFF
--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -8,7 +8,8 @@
   --navigation-link-color: #035FE6;
   --navigation-link-color--hover: #136FF6;
   --feds-localnav-height: 40px;
-  --global-height-nav: 64px;
+  --global-height-nav: 56px;
+  --feds-height-nav: 55px;
 }
 
 .global-navigation, .global-footer, .dialog-modal {
@@ -43,7 +44,7 @@
 }
  
 header.global-navigation, header.global-navigation.feds--dark {
-  height: 64px;
+  height: var(--global-height-nav);
   visibility: hidden;
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* As part of Spectrum's latest guidance, the gnav height has to be reduced to 56px for adobe home
* Starting this with standalone Gnav

Resolves: [MWPW-169766](https://jira.corp.adobe.com/browse/MWPW-169766)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-compact--milo--adobecom.aem.page/?martech=off

Standalone Gnav: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&authoringpath=/federal/home&navbranch=gnav-compact&unav=appswitcher,profile,notifications,help

