### PR TITLE
MWPW-169204: create QS from the link

### DIFF
--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -111,7 +111,7 @@ function extractQuantitySelect(el, merchCard) {
     quantitySelectConfig.remove();
     [attributes.min, attributes.max, attributes.step, attributes['default-value'], attributes['max-input']] = values;
   }
-  if (!attributes.min || !attributes.max) {
+  if (!attributes.min || !attributes.max || !attributes.step) {
     return null;
   }
   import('../../deps/mas/merch-quantity-select.js');

--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -89,8 +89,9 @@ export async function loadMnemonicList(foreground) {
 }
 
 function extractQuantitySelect(el) {
+  // if unsorted list has only one child & it's an ul, it's the quantity select config
   const quantitySelectConfig = [...el.querySelectorAll('ul')]
-    .find((ul) => ul.querySelector('li')?.innerText?.includes('Quantity'));
+    .find((ul) => ul.children.length === 1);
   const configMarkup = quantitySelectConfig?.querySelector('ul');
   if (!configMarkup) return null;
   const config = configMarkup.children;

--- a/test/blocks/merch-card/merch-offer-select.test.js
+++ b/test/blocks/merch-card/merch-offer-select.test.js
@@ -155,6 +155,27 @@ describe('Merch quantity select', () => {
   });
 });
 
+describe('Merch quantity select: link approach', () => {
+  before(async () => {
+    mockIms();
+    await mockFetch();
+    await initService(true);
+    document.body.innerHTML = await readMockText('/test/blocks/merch-card/mocks/selection-cards.html');
+  });
+
+  after(() => {
+    unmockIms();
+    unmockFetch();
+  });
+
+  it('Should render quantity select with link approach', async () => {
+    const merchCard = await initCard(document.querySelector('.quantity-select-link-approach'));
+    await delay(200);
+    const quantitySelect = merchCard.querySelector('merch-quantity-select');
+    expect(quantitySelect).to.exist;
+  });
+});
+
 describe('Merch quantity select: twp', () => {
   before(async () => {
     mockIms();

--- a/test/blocks/merch-card/mocks/selection-cards.html
+++ b/test/blocks/merch-card/mocks/selection-cards.html
@@ -264,6 +264,21 @@
         </div>
       </div>
     </div>
+    <div class="merch-card product secure quantity-select-link-approach">
+      <div>
+        <div data-valign="middle">
+          <h3 id="acrobat-standard-para-equipos">Acrobat Standard para equipos</h3>
+          <p><strong><em><a href="https://milo.adobe.com/tools/ost?osi=BxVNm_BrkQZj1pMUM8SeYeUGPyYLt5CU6OhVakqwS68&#x26;type=price&#x26;seat=true">PRICE - PUF - Acrobat Standard DC</a></em></strong></p>
+          <h4 id="small-tax-excl-label"><strong>{{small-tax-excl-label}}</strong></h4>
+          <h4 id="suscripción-anual-de-prepago-puedes-cancelar-en-un-plazo-de-14días-para-obtener-un-reembolso-íntegro-se-aplicará-un-cargo-si-cancelas-pasados-14-días-tooltip-si-cancela-pasados-14-días-el-pago-no-será-reembolsable-y-el-servicio-continuará-hasta-que-termine-el-periodo-contratado"><em>Suscripción anual de prepago. Puedes cancelar en un plazo de 14 días para obtener un reembolso íntegro. Se aplicará un cargo si cancelas pasados 14 días.</em> <em><span class="icon icon-tooltip"></span>| Si cancela pasados 14 días, el pago no será reembolsable y el servicio continuará hasta que termine el periodo contratado.</em></h4>
+          <p>Aplicación de PDF sencilla con funciones para editar, convertir y firmar electrónicamente.</p>
+          <h6 id="el-complemento-del-asistente-de-ia-de-acrobat-ya-está-disponible-al-realizar-el-pago-price---puf---ai-assistant-for-acrobat-small-tax-incl-label-por-el-plan-anual-de-prepago"><em>El complemento del Asistente de IA de Acrobat ya está disponible al realizar el pago. <strong><a href="https://milo.adobe.com/tools/ost?osi=NXO_Px0F8tnb9mW-uPtUfTqm7UjTNBp74LGlqaZ63n0&#x26;type=price&#x26;seat=false">PRICE - PUF - AI Assistant for Acrobat</a></strong> {{small-tax-incl-label}} por el plan anual de prepago.</em></h6>
+          <p><a href="#qs&#x26;min=1&#x26;max=10&#x26;step=1&#x26;default=2&#x26;max-input=180">Numero de licencias</a></p>
+          <p>--- #E8E8E8</p>
+          <p><strong><a href="https://milo.adobe.com/tools/ost?osi=BxVNm_BrkQZj1pMUM8SeYeUGPyYLt5CU6OhVakqwS68&#x26;type=checkoutUrl&#x26;text=buy-now&#x26;workflowStep=recommendation">CTA {{buy-now}} | Comprar ahora Acrobat Standard para equipos</a></strong></p>
+        </div>
+      </div>
+    </div>
     <div class="after"></div>
   </div>
 </div>


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Add a LOC-robust Quantity Selector approach:
Instead of adding QS as unsorted list it can be added as a Link:
HREF:
#qs&min=1&max=10&step=1&default=2&max-input=180
Link TITLE: QS title (translatable)
<img width="477" alt="image" src="https://github.com/user-attachments/assets/0cbc6445-2260-474e-b71c-aac96f38213d" />

For backwards compatibility old approach will keep working for some time & will be removed once GWP does content updates. Check https://mwpw-169204--milo--adobecom.aem.live/drafts/mariia/pr/qs1?martech=off to see 'old' approach still working

Resolves: https://jira.corp.adobe.com/browse/MWPW-169204

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/drafts/mariia/pr/qs?martech=off
- After: https://mwpw-169204--milo--adobecom.aem.live/drafts/mariia/pr/qs?martech=off




