### PR TITLE
[MWPW-171113] - Automated iframe title cta

### DIFF
--- a/libs/blocks/iframe/iframe.js
+++ b/libs/blocks/iframe/iframe.js
@@ -52,7 +52,7 @@ export default function init(el) {
 
   iframe.onload = () => {
     if (new URL(iframe.src).origin !== window.location.origin) {
-      iframe.title = ariaLabel || iframe.title;
+      if (ariaLabel) iframe.title = ariaLabel;
       return;
     }
 

--- a/libs/blocks/iframe/iframe.js
+++ b/libs/blocks/iframe/iframe.js
@@ -52,7 +52,7 @@ export default function init(el) {
 
   iframe.onload = () => {
     if (new URL(iframe.src).origin !== window.location.origin) {
-      iframe.title = ariaLabel || '';
+      iframe.title = ariaLabel || iframe.title;
       return;
     }
 

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -20,7 +20,13 @@ export function findDetails(hash, el) {
   const id = hash.replace('#', '');
   const a = el || document.querySelector(`a[data-modal-hash="${hash}"]`);
   const path = a?.dataset.modalPath || localizeLink(getMetadata(`-${id}`));
-  return { id, path, isHash: hash === window.location.hash };
+  const ariaLabel = a?.getAttribute('aria-label');
+  return {
+    id,
+    path,
+    isHash: hash === window.location.hash,
+    title: ariaLabel ? `Modal: ${ariaLabel}` : null,
+  };
 }
 
 function fireAnalyticsEvent(event) {
@@ -202,6 +208,8 @@ export async function getModal(details, custom) {
 
   const iframe = dialog.querySelector('iframe');
   if (iframe) {
+    if (details?.title) iframe.setAttribute('title', details.title);
+
     if (dialog.classList.contains('commerce-frame') || dialog.classList.contains('dynamic-height')) {
       const { default: enableCommerceFrameFeatures } = await import('./modal.merch.js');
       await enableCommerceFrameFeatures({ dialog, iframe });

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -20,7 +20,7 @@ export function findDetails(hash, el) {
   const id = hash.replace('#', '');
   const a = el || document.querySelector(`a[data-modal-hash="${hash}"]`);
   const path = a?.dataset.modalPath || localizeLink(getMetadata(`-${id}`));
-  const ariaLabel = a?.getAttribute('aria-label');
+  const ariaLabel = a?.getAttribute('aria-label') || document.querySelector(`a[data-modal-id="${id}"]`)?.getAttribute('aria-label');
   return {
     id,
     path,
@@ -213,6 +213,12 @@ export async function getModal(details, custom) {
     if (dialog.classList.contains('commerce-frame') || dialog.classList.contains('dynamic-height')) {
       const { default: enableCommerceFrameFeatures } = await import('./modal.merch.js');
       await enableCommerceFrameFeatures({ dialog, iframe });
+
+      if (!details?.title) {
+        const commerceDetails = findDetails(window.location.hash, null);
+        const commerceFrameTitle = commerceDetails?.title ? commerceDetails.title : null;
+        if (commerceFrameTitle) iframe.setAttribute('title', commerceFrameTitle);
+      }
     } else {
       /* Initially iframe height is set to 0% in CSS for the height auto adjustment feature.
       The height auto adjustment feature is applicable only to dialogs

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -216,7 +216,7 @@ export async function getModal(details, custom) {
 
       if (!details?.title) {
         const commerceDetails = findDetails(window.location.hash, null);
-        const commerceFrameTitle = commerceDetails?.title ? commerceDetails.title : null;
+        const commerceFrameTitle = commerceDetails?.title || null;
         if (commerceFrameTitle) iframe.setAttribute('title', commerceFrameTitle);
       }
     } else {


### PR DESCRIPTION
This resolves the issue where iframe title was missing when opening via CTA, fixed by applying the CTA's aria-label as the iframe title.

Resolves: [MWPW-171113](https://jira.corp.adobe.com/browse/MWPW-171113)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://automated-iframe-title-cta--milo--adobecom.aem.page/?martech=off

**QA Test URLs:**
- Before: https://main--cc--adobecom.aem.page/products/catalog
- After: https://main--cc--adobecom.aem.page/products/catalog?milolibs=automated-iframe-title-cta







