### PR TITLE
[MWPW-170108] - Notification a11y

### DIFF
--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -340,6 +340,16 @@
   display: none;
 }
 
+.visibility-hidden {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  z-index: -1;
+}
+
 .notification.pill .foreground .text > :not(.action-area) {
   padding-inline-end: var(--spacing-xxs);
   inline-size: calc(100% - var(--spacing-xxs));

--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -341,7 +341,9 @@
 }
 
 .notification-visibility-hidden {
-  position: absolute;
+  position: fixed;
+  top: 0;
+  left: 0;
   width: 0;
   height: 0;
   overflow: hidden;

--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -340,7 +340,7 @@
   display: none;
 }
 
-.visibility-hidden {
+.notification-visibility-hidden {
   position: absolute;
   width: 0;
   height: 0;

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -101,6 +101,14 @@ function addCloseAction(el, btn) {
     liveRegion.textContent = 'Banner closed';
     document.body.appendChild(liveRegion);
     liveRegion.focus();
+    let isSticky = false;
+    let rect;
+    el.closest('.section').classList.forEach((cls) => {
+      if (cls.includes('sticky')) {
+        isSticky = true;
+        rect = el.closest('.section').getBoundingClientRect();
+      }
+    });
     el.style.display = 'none';
     el.closest('.section')?.classList.add('close-sticky-section');
     if (el.classList.contains('focus')) {
@@ -125,6 +133,12 @@ function addCloseAction(el, btn) {
           ? focusableElements[focusableElements.length - 1]
           : null;
       };
+
+      if (isSticky) {
+        const elementAtPosition = document.elementFromPoint(rect.left, rect.top);
+        const stickySection = !elementAtPosition.classList.contains('section') ? elementAtPosition.closest('.section') : elementAtPosition;
+        focusTarget = findFocusableInSection(stickySection);
+      }
 
       let currentSection = el.closest('.section').previousElementSibling;
       while (currentSection && !focusTarget) {

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -90,15 +90,13 @@ function addCloseAction(el, btn) {
   btn.addEventListener('click', (e) => {
     if (btn.nodeName === 'A') e.preventDefault();
 
-    // Create accessibility live region
     const liveRegion = createTag('div', {
       class: 'notification-visibility-hidden',
       'aria-live': 'assertive',
       'aria-atomic': 'true',
       role: 'status',
       tabindex: '-1',
-    });
-    liveRegion.textContent = 'Banner closed';
+    }, 'Banner closed');
     document.body.appendChild(liveRegion);
     liveRegion.focus();
     let isSticky = false;
@@ -141,18 +139,16 @@ function addCloseAction(el, btn) {
         focusTarget = findFocusableInSection(stickySection);
       }
 
-      let currentSection = el.closest('.section').previousElementSibling;
+      let currentSection = el.closest('.section')?.previousElementSibling;
       while (currentSection && !focusTarget) {
         focusTarget = findFocusableInSection(currentSection);
         if (!focusTarget) currentSection = currentSection.previousElementSibling;
       }
 
-      if (!focusTarget) {
-        const header = document.querySelector('header');
-        if (header) {
-          const headerFocusable = [...header.querySelectorAll(focusableSelector)];
-          focusTarget = headerFocusable[headerFocusable.length - 1];
-        }
+      const header = document.querySelector('header');
+      if (!focusTarget && header) {
+        const headerFocusable = [...header.querySelectorAll(focusableSelector)];
+        focusTarget = headerFocusable[headerFocusable.length - 1];
       }
 
       liveRegion?.remove();

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -91,7 +91,7 @@ function addCloseAction(el, btn) {
     if (btn.nodeName === 'A') e.preventDefault();
 
     const liveRegion = createTag('div', {
-      class: 'visibility-hidden',
+      class: 'notification-visibility-hidden',
       'aria-live': 'assertive',
       'aria-atomic': 'true',
       role: 'status',

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -104,14 +104,12 @@ function addCloseAction(el, btn) {
     let isSticky = false;
     let rect;
     const sectionElement = el.closest('.section');
-    if (sectionElement) {
-      sectionElement.classList.forEach((cls) => {
-        if (cls.includes('sticky')) {
-          isSticky = true;
-          rect = sectionElement.getBoundingClientRect();
-        }
-      });
+
+    if (sectionElement?.className.includes('sticky')) {
+      isSticky = true;
+      rect = sectionElement.getBoundingClientRect();
     }
+
     el.style.display = 'none';
     el.closest('.section')?.classList.add('close-sticky-section');
     if (el.classList.contains('focus')) {
@@ -139,7 +137,7 @@ function addCloseAction(el, btn) {
 
       if (isSticky) {
         const elementAtPosition = document.elementFromPoint(rect.left, rect.top);
-        const stickySection = !elementAtPosition.classList.contains('section') ? elementAtPosition.closest('.section') : elementAtPosition;
+        const stickySection = elementAtPosition.closest('.section');
         focusTarget = findFocusableInSection(stickySection);
       }
 
@@ -158,7 +156,7 @@ function addCloseAction(el, btn) {
       }
 
       liveRegion?.remove();
-      if (focusTarget) focusTarget.focus();
+      if (focusTarget) focusTarget.focus({ preventScroll: true });
     }, 2000);
   });
 }

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -103,12 +103,15 @@ function addCloseAction(el, btn) {
     liveRegion.focus();
     let isSticky = false;
     let rect;
-    el.closest('.section').classList.forEach((cls) => {
-      if (cls.includes('sticky')) {
-        isSticky = true;
-        rect = el.closest('.section').getBoundingClientRect();
-      }
-    });
+    const sectionElement = el.closest('.section');
+    if (sectionElement) {
+      sectionElement.classList.forEach((cls) => {
+        if (cls.includes('sticky')) {
+          isSticky = true;
+          rect = sectionElement.getBoundingClientRect();
+        }
+      });
+    }
     el.style.display = 'none';
     el.closest('.section')?.classList.add('close-sticky-section');
     if (el.classList.contains('focus')) {

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -86,6 +86,21 @@ function wrapCopy(foreground) {
   });
 }
 
+const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+const selectedSelector = '[aria-selected="true"], [aria-checked="true"]';
+
+export function findFocusableInSection(section, selSelector, focSelector) {
+  if (!section) return null;
+
+  const selectedElement = section.querySelector(selSelector);
+  if (selectedElement) return selectedElement;
+
+  const focusableElements = [...section.querySelectorAll(focSelector)];
+  return focusableElements.length > 0
+    ? focusableElements[focusableElements.length - 1]
+    : null;
+}
+
 function addCloseAction(el, btn) {
   btn.addEventListener('click', (e) => {
     if (btn.nodeName === 'A') e.preventDefault();
@@ -117,31 +132,17 @@ function addCloseAction(el, btn) {
     document.dispatchEvent(new CustomEvent('milo:sticky:closed'));
 
     setTimeout(() => {
-      const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
-      const selectedSelector = '[aria-selected="true"], [aria-checked="true"]';
       let focusTarget;
-
-      const findFocusableInSection = (section) => {
-        if (!section) return null;
-
-        const selectedElement = section.querySelector(selectedSelector);
-        if (selectedElement) return selectedElement;
-
-        const focusableElements = [...section.querySelectorAll(focusableSelector)];
-        return focusableElements.length > 0
-          ? focusableElements[focusableElements.length - 1]
-          : null;
-      };
 
       if (isSticky) {
         const elementAtPosition = document.elementFromPoint(rect.left, rect.top);
         const stickySection = elementAtPosition.closest('.section');
-        focusTarget = findFocusableInSection(stickySection);
+        focusTarget = findFocusableInSection(stickySection, selectedSelector, focusableSelector);
       }
 
       let currentSection = el.closest('.section')?.previousElementSibling;
       while (currentSection && !focusTarget) {
-        focusTarget = findFocusableInSection(currentSection);
+        focusTarget = findFocusableInSection(currentSection, selectedSelector, focusableSelector);
         if (!focusTarget) currentSection = currentSection.previousElementSibling;
       }
 

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -89,6 +89,17 @@ function wrapCopy(foreground) {
 function addCloseAction(el, btn) {
   btn.addEventListener('click', (e) => {
     if (btn.nodeName === 'A') e.preventDefault();
+
+    const liveRegion = createTag('div', {
+      class: 'visibility-hidden',
+      'aria-live': 'assertive',
+      'aria-atomic': 'true',
+      role: 'status',
+      tabindex: '-1',
+    });
+    liveRegion.textContent = 'Banner closed';
+    el.closest('.section')?.appendChild(liveRegion);
+    liveRegion.focus();
     el.style.display = 'none';
     el.closest('.section')?.classList.add('close-sticky-section');
     if (el.classList.contains('focus')) {
@@ -96,11 +107,15 @@ function addCloseAction(el, btn) {
       el.closest('.section').querySelector('.notification-curtain').remove();
     }
     document.dispatchEvent(new CustomEvent('milo:sticky:closed'));
+
+    setTimeout(() => {
+      if (liveRegion) liveRegion.remove();
+    }, 2500);
   });
 }
 
 function decorateClose(el) {
-  const btn = createTag('button', { 'aria-label': 'close', class: 'close' }, closeSvg);
+  const btn = createTag('button', { 'aria-label': 'Close Promo Banner', class: 'close' }, closeSvg);
   addCloseAction(el, btn);
   el.appendChild(btn);
 }
@@ -221,6 +236,8 @@ async function decorateLayout(el) {
 
 export default async function init(el) {
   el.classList.add('con-block');
+  el.setAttribute('aria-label', 'Promo Banner');
+  el.setAttribute('role', 'region');
   const { fontSizes, options } = getBlockData(el);
   const blockText = await decorateLayout(el);
   decorateBlockText(blockText, fontSizes);

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -98,7 +98,7 @@ function addCloseAction(el, btn) {
       tabindex: '-1',
     });
     liveRegion.textContent = 'Banner closed';
-    el.closest('.section')?.appendChild(liveRegion);
+    document.body.appendChild(liveRegion);
     liveRegion.focus();
     el.style.display = 'none';
     el.closest('.section')?.classList.add('close-sticky-section');
@@ -114,7 +114,7 @@ function addCloseAction(el, btn) {
       const nextFocusable = allFocusable[allFocusable.indexOf(btn) + 1];
       liveRegion?.remove();
       if (nextFocusable) nextFocusable.focus();
-    }, 2500);
+    }, 2000);
   });
 }
 

--- a/libs/blocks/notification/notification.js
+++ b/libs/blocks/notification/notification.js
@@ -109,7 +109,11 @@ function addCloseAction(el, btn) {
     document.dispatchEvent(new CustomEvent('milo:sticky:closed'));
 
     setTimeout(() => {
-      if (liveRegion) liveRegion.remove();
+      const focusableElements = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+      const allFocusable = [...document.querySelectorAll(focusableElements)];
+      const nextFocusable = allFocusable[allFocusable.indexOf(btn) + 1];
+      liveRegion?.remove();
+      if (nextFocusable) nextFocusable.focus();
     }, 2500);
   });
 }

--- a/test/blocks/notification/notification.test.js
+++ b/test/blocks/notification/notification.test.js
@@ -2,6 +2,7 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { setConfig } from '../../../libs/utils/utils.js';
 import { delay } from '../../helpers/waitfor.js';
+import { findFocusableInSection } from '../../../libs/blocks/notification/notification.js';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 const conf = { locales, miloLibs: 'http://localhost:2000/libs' };
@@ -119,6 +120,38 @@ describe('notification', async () => {
       splits[1].querySelector('a[href*="#_evt-close"]').dispatchEvent(new MouseEvent('click'));
       expect(splits[1].closest('.section').classList.contains('close-sticky-section')).to.be.true;
       expect(splits[1].closest('.section').querySelector('.notification-curtain')).to.not.exist;
+    });
+  });
+
+  describe('findFocusableInSection', () => {
+    let section;
+    let splits;
+    const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    const selectedSelector = '[aria-selected="true"], [aria-checked="true"]';
+
+    beforeEach(async () => {
+      splits = [...notifs].filter((e) => e.classList.contains('split'));
+      section = splits[0].closest('.section');
+    });
+
+    it('returns selected element when present', () => {
+      const link = section.querySelector('a');
+      link.setAttribute('aria-selected', 'true');
+      const result = findFocusableInSection(section, selectedSelector, focusableSelector);
+      expect(result).to.equal(link);
+    });
+
+    it('returns last focusable element when no selected element', () => {
+      const result = findFocusableInSection(section, selectedSelector, focusableSelector);
+      const focusableElements = [...section.querySelectorAll(focusableSelector)];
+      expect(result).to.equal(focusableElements[focusableElements.length - 1]);
+    });
+
+    it('returns null when no focusable elements', () => {
+      section.querySelectorAll(focusableSelector)
+        .forEach((el) => el.remove());
+      const result = findFocusableInSection(section, selectedSelector, focusableSelector);
+      expect(result).to.be.null;
     });
   });
 });


### PR DESCRIPTION
This resolves the issue where the notification container was missing a role and an aria-label, the aria-label was changed for the close button, added an announcement for the screen reader "Banner closed" after closing the banner and focusing on the next element after finishing the announcement.

Update:
After a meeting with Taryn, it was decided that when closing the banner the focus after the closing announcement would shift to the previous sections selected/checked element like an active tab/element if it has one and if not then the last focusable element in the previous section.

Resolves: [MWPW-170108](https://jira.corp.adobe.com/browse/MWPW-170108)

**Previous section last focusable element Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/dusan/notification-close-testing?martech=off
- After: https://notification-a11y--milo--adobecom.aem.page/drafts/dusan/notification-close-testing?martech=off

**Previous section active tab Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/dusan/notification-close-two?martech=off
- After: https://notification-a11y--milo--adobecom.aem.page/drafts/dusan/notification-close-two?martech=off

**Sticky Banner use case Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/dusan/notification-close-four
- After: https://notification-a11y--milo--adobecom.aem.page/drafts/dusan/notification-close-four

**Use case when previous section doesn't have focusable element or selected/checked element, so we go to it's previous section and do this over and over until we find something focusable in one of the previous sections and if no sections have a focusable element, as a last resort we focus the headers last focusable element - Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/dusan/notification-close-three?martech=off
- After: https://notification-a11y--milo--adobecom.aem.page/drafts/dusan/notification-close-three?martech=off

**DC Test URLs:**
- Before: https://main--dc--adobecom.hlx.page/dc-shared/fragments/generative-ai-pdf/promobar-try-demo-desktop
- After: https://main--dc--adobecom.hlx.page/dc-shared/fragments/generative-ai-pdf/promobar-try-demo-desktop?milolibs=notification-a11y



















