### PR TITLE
MWPW-171526 [MMM][MEP] MMM North America filter does not show US pages

### DIFF
--- a/libs/blocks/mmm/mmm.js
+++ b/libs/blocks/mmm/mmm.js
@@ -154,7 +154,7 @@ function filterPageList(pageNum, perPage, event) {
   const detail = {};
   Object.keys(searchValues).forEach((key) => {
     let { value } = searchValues[key];
-    if (value.replace) {
+    if (key === 'filter' && value.replace) { // allow optional commas inside filter textbox
       value = value.replace(',', '');
       value = value.replace(/\n/g, ',\n');
     }


### PR DESCRIPTION
Recently introduced code that should only affect *Filter* text area is affecting dropdowns as well, turning values like `us,ca,ca_fr` to `usca,ca_fr` by replacing first coma. 

Resolves: [MWPW-171526](https://jira.corp.adobe.com/browse/MWPW-171526)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/authoring/features/mmm
- After: https://mmm-filter-bug--milo--adobecom.hlx.page/docs/authoring/features/mmm

QA Steps:

Choose NA REGION in `Top Regions/Geos` dropdown. In the broken *BEFORE* state you won't see US pages


