### PR TITLE
[MWPW-170383] Modal close button focus a11y

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -3,6 +3,7 @@
   --modal-max-height: calc((100vh - 6px) - 2em);
   --modal-z-index: 102;
   --modal-z-index-curtain: 101;
+  --modal-close-accent-color: #707070;
   --jarvis-z-index-override: 100;
   --tall-video-padding: var(--spacing-xl);
 }
@@ -127,8 +128,24 @@
   z-index: 1;
 }
 
+.dialog-close circle {
+  fill: var(--modal-close-accent-color);
+}
+
+.dialog-close line {
+  stroke: var(--color-white);
+}
+
 .dialog-close:focus-visible {
   outline: 2px solid var(--modal-focus-color);
+}
+
+.dialog-close:focus-visible circle {
+  fill: var(--color-white);
+}
+
+.dialog-close:focus-visible line {
+  stroke: var(--modal-close-accent-color);
 }
 
 .dialog-focus-placeholder {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -6,9 +6,9 @@ import { decorateSectionAnalytics } from '../../martech/attributes.js';
 const FOCUSABLES = 'a:not(.hide-video), button:not([disabled], .locale-modal-v2 .paddle), input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
 const CLOSE_ICON = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
   <g transform="translate(-10500 3403)">
-    <circle cx="10" cy="10" r="10" transform="translate(10500 -3403)" fill="#707070"/>
-    <line y1="8" x2="8" transform="translate(10506 -3397)" fill="none" stroke="#fff" stroke-width="2"/>
-    <line x1="8" y1="8" transform="translate(10506 -3397)" fill="none" stroke="#fff" stroke-width="2"/>
+    <circle cx="10" cy="10" r="10" transform="translate(10500 -3403)"/>
+    <line y1="8" x2="8" transform="translate(10506 -3397)" fill="none" stroke-width="2"/>
+    <line x1="8" y1="8" transform="translate(10506 -3397)" fill="none" stroke-width="2"/>
   </g>
 </svg>`;
 


### PR DESCRIPTION
This adapts the focus state of the Modal's close button for accessibility purposes, by inverting the icon's colors.

Resolves: [MWPW-170383](https://jira.corp.adobe.com/browse/MWPW-170383)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/docs/authoring/create-modal
- After: https://modal-close-a11y--milo--overmyheadandbody.aem.page/docs/authoring/create-modal
- Before: https://main--dc--adobecom.aem.page/acrobat/generative-ai-pdf?martech=off
- After: https://main--dc--adobecom.aem.page/acrobat/generative-ai-pdf?milolibs=modal-close-a11y--milo--overmyheadandbody&martech=off
