### PR TITLE
[MWPW-170177] Move tooltip icon listeners

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -189,34 +189,6 @@ async function setAriaLabelForIcons(el) {
   });
 }
 
-function setTooltipListeners(el) {
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      el.querySelectorAll('.milo-tooltip').forEach((tooltip) => {
-        tooltip.classList.add('hide-tooltip');
-      });
-    }
-  });
-
-  el.querySelectorAll('.milo-tooltip').forEach((tooltip) => {
-    tooltip.addEventListener('mouseenter', () => {
-      tooltip.classList.remove('hide-tooltip');
-    });
-
-    tooltip.addEventListener('mouseleave', () => {
-      tooltip.classList.add('hide-tooltip');
-    });
-
-    tooltip.addEventListener('focus', () => {
-      tooltip.classList.remove('hide-tooltip');
-    });
-
-    tooltip.addEventListener('blur', () => {
-      tooltip.classList.add('hide-tooltip');
-    });
-  });
-}
-
 function handleHighlight(table) {
   const isHighlightTable = table.classList.contains('highlight');
   const firstRow = table.querySelector('.row-1');
@@ -551,7 +523,6 @@ function applyStylesBasedOnScreenSize(table, originTable) {
           clone.setAttribute('data-cloned', 'true');
           clone.classList.remove('rounded-left', 'rounded-right');
           row.appendChild(clone);
-          setTooltipListeners(clone);
         });
       }
 
@@ -693,7 +664,6 @@ export default function init(el) {
 
     setExpandEvents(el);
     setAriaLabelForIcons(el);
-    setTooltipListeners(el);
   };
 
   window.addEventListener(MILO_EVENTS.DEFERRED, () => {

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -34,6 +34,25 @@ export const fetchIcons = (config) => new Promise(async (resolve) => {
   resolve(fetchedIcons);
 });
 
+let tooltipListenersAdded = false;
+function addTooltipListeners() {
+  tooltipListenersAdded = true;
+
+  ['keydown', 'mouseenter', 'focus', 'mouseleave', 'blur'].forEach((eventType) => {
+    document.addEventListener(eventType, (event) => {
+      const tooltip = event.target?.closest?.('.milo-tooltip');
+      if (!tooltip) return;
+
+      if (['mouseenter', 'focus'].includes(eventType)) {
+        tooltip.classList.remove('hide-tooltip');
+      } else if (['mouseleave', 'blur'].includes(eventType)
+        || (eventType === 'keydown' && event.key === 'Escape')) {
+        tooltip.classList.add('hide-tooltip');
+      }
+    }, true);
+  });
+}
+
 function decorateToolTip(icon, iconName) {
   const hasTooltip = icon.closest('em')?.textContent.includes('|') && [...icon.classList].some((cls) => cls.includes('tooltip'));
   if (!hasTooltip) return;
@@ -53,6 +72,7 @@ function decorateToolTip(icon, iconName) {
   icon.setAttribute('aria-label', content);
   icon.setAttribute('role', 'button');
   wrapper.parentElement.replaceChild(icon, wrapper);
+  if (!tooltipListenersAdded) addTooltipListeners();
 }
 
 export default async function loadIcons(icons, config) {

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -40,14 +40,14 @@ function addTooltipListeners() {
 
   ['keydown', 'mouseenter', 'focus', 'mouseleave', 'blur'].forEach((eventType) => {
     document.addEventListener(eventType, (event) => {
-      const tooltip = event.target?.closest?.('.milo-tooltip');
-      if (!tooltip) return;
+      const isTooltip = event.target?.matches?.('.milo-tooltip');
+      if (!isTooltip) return;
 
       if (['mouseenter', 'focus'].includes(eventType)) {
-        tooltip.classList.remove('hide-tooltip');
+        event.target.classList.remove('hide-tooltip');
       } else if (['mouseleave', 'blur'].includes(eventType)
         || (eventType === 'keydown' && event.key === 'Escape')) {
-        tooltip.classList.add('hide-tooltip');
+        event.target.classList.add('hide-tooltip');
       }
     }, true);
   });

--- a/test/blocks/table/table.test.js
+++ b/test/blocks/table/table.test.js
@@ -125,25 +125,5 @@ describe('table and tablemetadata', () => {
         expect(selectElement.getAttribute('aria-label')).to.equal(ariaLabel);
       });
     });
-
-    it('should show and hide tooltip on hover, focus, and Escape key', async () => {
-      const tooltip = document.querySelector('.milo-tooltip');
-      expect(tooltip).to.exist;
-
-      tooltip.dispatchEvent(new Event('mouseenter'));
-      expect(tooltip.classList.contains('hide-tooltip')).to.be.false;
-
-      tooltip.dispatchEvent(new Event('mouseleave'));
-      expect(tooltip.classList.contains('hide-tooltip')).to.be.true;
-
-      tooltip.dispatchEvent(new Event('focus'));
-      expect(tooltip.classList.contains('hide-tooltip')).to.be.false;
-
-      tooltip.dispatchEvent(new Event('blur'));
-      expect(tooltip.classList.contains('hide-tooltip')).to.be.true;
-
-      await sendKeys({ press: 'Escape' });
-      expect(tooltip.classList.contains('hide-tooltip')).to.be.true;
-    });
   });
 });

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -163,4 +163,37 @@ describe('Tooltip', () => {
     expect(noTooltipIcon.classList.contains('milo-tooltip')).to.be.false;
     expect(noTooltipIcon.dataset.tooltip).to.be.undefined;
   });
+
+  it('should show and hide tooltip on hover, focus, and Escape key', async () => {
+    await loadIcons([iconTooltip], config);
+    const tooltip = document.querySelector('.milo-tooltip');
+    expect(tooltip).to.exist;
+
+    // Create events with tooltip as target for document to catch
+    const mouseenterEvent = new Event('mouseenter', { bubbles: true });
+    Object.defineProperty(mouseenterEvent, 'target', { value: tooltip });
+    document.dispatchEvent(mouseenterEvent);
+    expect(tooltip.classList.contains('hide-tooltip')).to.be.false;
+
+    const mouseleaveEvent = new Event('mouseleave', { bubbles: true });
+    Object.defineProperty(mouseleaveEvent, 'target', { value: tooltip });
+    document.dispatchEvent(mouseleaveEvent);
+    expect(tooltip.classList.contains('hide-tooltip')).to.be.true;
+
+    const focusEvent = new Event('focus', { bubbles: true });
+    Object.defineProperty(focusEvent, 'target', { value: tooltip });
+    document.dispatchEvent(focusEvent);
+    expect(tooltip.classList.contains('hide-tooltip')).to.be.false;
+
+    const blurEvent = new Event('blur', { bubbles: true });
+    Object.defineProperty(blurEvent, 'target', { value: tooltip });
+    document.dispatchEvent(blurEvent);
+    expect(tooltip.classList.contains('hide-tooltip')).to.be.true;
+
+    // For Escape key, we need to simulate a keydown event on document
+    const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    Object.defineProperty(escapeEvent, 'target', { value: tooltip });
+    document.dispatchEvent(escapeEvent);
+    expect(tooltip.classList.contains('hide-tooltip')).to.be.true;
+  });
 });


### PR DESCRIPTION
This moves the tooltip event listeners to the icons file so that relevant events are attached wherever tooltips are used.

Resolves: [MWPW-170177](https://jira.corp.adobe.com/browse/MWPW-170177)

**Test URLs:**
- Before (Milo, table w/ tooltips): https://main--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/table
- After (Milo, table w/ tooltips): https://tooltip-icon-listeners--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/table
- Before (DC, pricing w/ tooltips): https://main--dc--adobecom.hlx.page/acrobat/pricing?martech=off
- After (DC, pricing w/ tooltips): https://main--dc--adobecom.hlx.page/acrobat/pricing?milolibs=tooltip-icon-listeners--milo--overmyheadandbody&martech=off