### PR TITLE
MWPW-171546 fix issue with localized links being localized again. 

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -231,9 +231,9 @@ export function getLanguage(languages, locales, pathname = window.location.pathn
     const englishLang = languages.en;
     if (locale.prefix === '' && englishLang) {
       locale.language = DEFAULT_LANG;
-      locale.region = englishLang.region;
-      locale.ietf = englishLang.ietf;
-      locale.tk = englishLang.tk;
+      if (englishLang.region) locale.region = englishLang.region;
+      if (englishLang.ietf) locale.ietf = englishLang.ietf;
+      if (englishLang.tk) locale.tk = englishLang.tk;
     }
     return locale;
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -228,7 +228,13 @@ export function getLanguage(languages, locales, pathname = window.location.pathn
       || (language.languageBased === false && !language.region);
   if (isLegacyLocaleRoutingMode) {
     const locale = getLocale(locales, pathname);
-    if (locale.prefix === '') locale.language = DEFAULT_LANG;
+    const englishLang = languages.en;
+    if (locale.prefix === '' && englishLang) {
+      locale.language = DEFAULT_LANG;
+      locale.region = englishLang.region;
+      locale.ietf = englishLang.ietf;
+      locale.tk = englishLang.tk;
+    }
     return locale;
   }
 
@@ -453,6 +459,20 @@ function getPrefixBySite(locale, url, relative) {
   return prefix;
 }
 
+function isLocalizedPath(path, locales) {
+  const langstorePath = path.startsWith(`/${LANGSTORE}`);
+  const previewPath = path.startsWith(`/${PREVIEW}`);
+  const anyTypeOfLocaleOrLanguagePath = localeToLanguageMap
+    && (localeToLanguageMap.some((l) => l.locale !== '' && (path.startsWith(`/${l.locale}/`) || path === `/${l.locale}`))
+      || (localeToLanguageMap.some((l) => path.startsWith(`/${l.langaugePath}/`) || path === `/${l.langaugePath}`)));
+  const legacyLocalePath = locales && Object.keys(locales).some((loc) => loc !== '' && (path.startsWith(`/${loc}/`)
+    || path.endsWith(`/${loc}`)));
+  return langstorePath
+    || previewPath
+    || anyTypeOfLocaleOrLanguagePath
+    || legacyLocalePath;
+}
+
 export function localizeLink(
   href,
   originHostName = window.location.hostname,
@@ -473,11 +493,7 @@ export function localizeLink(
     const isLocalizable = relative || (prodDomains && prodDomains.includes(url.hostname))
       || overrideDomain;
     if (!isLocalizable) return processedHref;
-    const isLocalizedLink = path.startsWith(`/${LANGSTORE}`)
-      || path.startsWith(`/${PREVIEW}`)
-      || (languages && Object.keys(languages).some((lang) => lang !== '' && (path.startsWith(`/${lang}/`))))
-      || (locales && Object.keys(locales).some((loc) => loc !== '' && (path.startsWith(`/${loc}/`)
-        || path.endsWith(`/${loc}`))));
+    const isLocalizedLink = isLocalizedPath(path, locales);
     if (isLocalizedLink) return processedHref;
 
     const prefix = getPrefixBySite(locale, url, relative);


### PR DESCRIPTION
Resolves: [MWPW-171546](https://jira.corp.adobe.com/browse/MWPW-171546)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://vhargrave-MWPW-171546-locales-added-twice--milo--adobecom.aem.page/?martech=off

You have to override the utils.js code, but you can see it fixed here for example.  
https://news.stage.adobe.com/ja/

**News**
- Before: https://stage--news--adobecom.aem.page/ko/drafts/ruchika/testpage
- After: https://stage--news--adobecom.aem.page/ko/drafts/ruchika/testpage?milolibs=vhargrave-MWPW-171546-locales-added-twice

- Before: https://stage-site--news--adobecom.aem.page/en/gb/
- After: https://stage--news--adobecom.aem.page/en/gb/?milolibs=vhargrave-MWPW-171546-locales-added-twice


**CC & other consumers should not be affected by this**
- Before: http://main--cc--adobecom.aem.live/products/photoshop-lightroom
- After: http://main--cc--adobecom.aem.live/products/photoshop-lightroom?milolibs=vhargrave-MWPW-171546-locales-added-twice

- Before: http://main--bacom--adobecom.hlx.page/
- After: http://main--bacom--adobecom.hlx.page/?milolibs=vhargrave-MWPW-171546-locales-added-twice

- Before: http://main--bacom--adobecom.hlx.page/de/
- After: http://main--bacom--adobecom.hlx.page/de/?milolibs=vhargrave-MWPW-169933-language-based-links

**BACOM added news.adobe.com as a prod domain so urls get localized** 
- Before: https://test-lang-link--bacom--adobecom.aem.page/uk/drafts/vhargrave/links?milolibs=vhargrave-MWPW-171546-locales-added-twice
- After: https://test-lang-link--bacom--adobecom.aem.page/uk/drafts/vhargrave/links?milolibs=vhargrave-MWPW-171546-locales-added-twice


