### PR TITLE
[MWPW-171328] - Icon block link image focus

### DIFF
--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -69,7 +69,6 @@
   margin: 0 auto var(--spacing-xs);
   max-height: var(--icon-size-xxl);
   max-width: 234px;
-  overflow: hidden;
 }
 
 .icon-block .foreground .icon-area picture {

--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -239,6 +239,11 @@
   grid-template-columns: repeat(auto-fit, minmax(276px, 1fr)) !important;
 }
 
+.wrapper-anchor {
+  display: flex;
+  flex-direction: column;
+}
+
 .icon-block .foreground .text-content > * {
   width: 100%;
 }

--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -239,7 +239,7 @@
   grid-template-columns: repeat(auto-fit, minmax(276px, 1fr)) !important;
 }
 
-.wrapper-anchor {
+.icon-block .wrapper-anchor {
   display: flex;
   flex-direction: column;
 }

--- a/libs/blocks/icon-block/icon-block.js
+++ b/libs/blocks/icon-block/icon-block.js
@@ -55,19 +55,18 @@ function decorateContent(el) {
     text.classList.add('text-content');
     const image = block.querySelector(':scope img');
     const lastElem = text.lastElementChild;
+    let actionLink = null;
     if (lastElem.children.length === 1
       && lastElem.lastElementChild.nodeName === 'A'
       && lastElem.lastElementChild.innerText === lastElem.innerText) {
       text.lastElementChild.classList.add('action-area');
+      actionLink = lastElem.lastElementChild;
     }
 
     if (image) {
       const iconP = image.closest('p');
       iconP.classList.add('icon-area');
       const iconLink = iconP.querySelector('a');
-      const actionLink = lastElem?.children.length === 1 && lastElem.lastElementChild.nodeName === 'A'
-        ? lastElem.lastElementChild
-        : null;
 
       if (iconLink && actionLink) {
         const wrapper = createTag('a', {
@@ -77,15 +76,11 @@ function decorateContent(el) {
 
         iconLink.replaceWith(...iconLink.childNodes);
 
-        const actionContent = actionLink.innerHTML;
-        lastElem.innerHTML = actionContent;
-        lastElem.classList.add('action-area');
+        lastElem.innerHTML = actionLink.innerHTML;
 
-        wrapper.appendChild(iconP.cloneNode(true));
-        wrapper.appendChild(lastElem.cloneNode(true));
-
-        iconP.replaceWith(wrapper);
-        lastElem.remove();
+        iconP.parentNode.insertBefore(wrapper, iconP);
+        wrapper.appendChild(iconP);
+        wrapper.appendChild(lastElem);
       }
     }
     const size = getBlockSize(el, 2);

--- a/libs/blocks/icon-block/icon-block.js
+++ b/libs/blocks/icon-block/icon-block.js
@@ -73,11 +73,8 @@ function decorateContent(el) {
           href: actionLink.href,
           class: 'wrapper-anchor',
         });
-
         iconLink.replaceWith(...iconLink.childNodes);
-
-        lastElem.innerHTML = actionLink.innerHTML;
-
+        lastElem.replaceChildren(...actionLink.childNodes);
         iconP.parentNode.insertBefore(wrapper, iconP);
         wrapper.appendChild(iconP);
         wrapper.appendChild(lastElem);

--- a/libs/blocks/icon-block/icon-block.js
+++ b/libs/blocks/icon-block/icon-block.js
@@ -54,13 +54,39 @@ function decorateContent(el) {
   if (text) {
     text.classList.add('text-content');
     const image = block.querySelector(':scope img');
-    if (image) image.closest('p').classList.add('icon-area');
-    // place standalone links inside an action-area
     const lastElem = text.lastElementChild;
     if (lastElem.children.length === 1
       && lastElem.lastElementChild.nodeName === 'A'
       && lastElem.lastElementChild.innerText === lastElem.innerText) {
       text.lastElementChild.classList.add('action-area');
+    }
+
+    if (image) {
+      const iconP = image.closest('p');
+      iconP.classList.add('icon-area');
+      const iconLink = iconP.querySelector('a');
+      const actionLink = lastElem?.children.length === 1 && lastElem.lastElementChild.nodeName === 'A'
+        ? lastElem.lastElementChild
+        : null;
+
+      if (iconLink && actionLink) {
+        const wrapper = createTag('a', {
+          href: actionLink.href,
+          class: 'wrapper-anchor',
+        });
+
+        iconLink.replaceWith(...iconLink.childNodes);
+
+        const actionContent = actionLink.innerHTML;
+        lastElem.innerHTML = actionContent;
+        lastElem.classList.add('action-area');
+
+        wrapper.appendChild(iconP.cloneNode(true));
+        wrapper.appendChild(lastElem.cloneNode(true));
+
+        iconP.replaceWith(wrapper);
+        lastElem.remove();
+      }
     }
     const size = getBlockSize(el, 2);
     const variant = [...variants].filter((v) => el.classList.contains(v))?.[0] ?? variants[0];

--- a/libs/blocks/icon-block/icon-block.js
+++ b/libs/blocks/icon-block/icon-block.js
@@ -65,8 +65,8 @@ function decorateContent(el) {
 
     if (image) {
       const iconP = image.closest('p');
-      iconP.classList.add('icon-area');
-      const iconLink = iconP.querySelector('a');
+      iconP?.classList.add('icon-area');
+      const iconLink = iconP?.querySelector('a');
 
       if (iconLink && actionLink) {
         const wrapper = createTag('a', {
@@ -76,8 +76,7 @@ function decorateContent(el) {
         iconLink.replaceWith(...iconLink.childNodes);
         lastElem.replaceChildren(...actionLink.childNodes);
         iconP.parentNode.insertBefore(wrapper, iconP);
-        wrapper.appendChild(iconP);
-        wrapper.appendChild(lastElem);
+        wrapper.append(iconP, lastElem);
       }
     }
     const size = getBlockSize(el, 2);

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -838,6 +838,13 @@ a {
   text-decoration: underline;
 }
 
+a:focus img {
+  outline: auto 2px;
+  outline-color: -webkit-focus-ring-color;
+  outline-color: -moz-focus-ring-color;
+  outline-color: -ms-focus-ring-color;
+}
+
 a:hover {
   color: var(--link-hover-color);
 }

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -838,13 +838,6 @@ a {
   text-decoration: underline;
 }
 
-a:focus img {
-  outline: auto 2px;
-  outline-color: -webkit-focus-ring-color;
-  outline-color: -moz-focus-ring-color;
-  outline-color: -ms-focus-ring-color;
-}
-
 a:hover {
   color: var(--link-hover-color);
 }


### PR DESCRIPTION
This resolves an issue in the Icon block where the focus block was missing for a link whose content is an image.

Resolves: [MWPW-171328](https://jira.corp.adobe.com/browse/MWPW-171328)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/icon-block?martech=off
- After: https://link-image-focus--milo--adobecom.aem.page/docs/library/kitchen-sink/icon-block?martech=off

**CC Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/products/substance3d/s3d-family-apps-blade-grey-links?martech=off
- After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/products/substance3d/s3d-family-apps-blade-grey-links?milolibs=link-image-focus&martech=off














