### PR TITLE
[MWPW-171537] Marketo hide section onSuccess

### DIFF
--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -110,9 +110,8 @@ const toggleSuccessSection = (formData) => {
     window.scrollTo(0, offsetPosition);
   };
 
-  const hide = async (sections) => {
+  const hide = (sections) => {
     sections.forEach((section) => section.classList.add('hide-block'));
-    await new Promise((resolve) => { setTimeout(resolve, 300); });
   };
 
   const showClass = formData[SUCCESS_SECTION]?.toLowerCase().replaceAll(' ', '-');

--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -32,13 +32,14 @@ const MUNCHKIN_ID = 'marketo munckin';
 const SUCCESS_TYPE = 'form.success.type';
 const SUCCESS_CONTENT = 'form.success.content';
 const SUCCESS_SECTION = 'form.success.section';
-const SUCCESS_HIDE_SECTION = 'form.success.hide section';
+const SUCCESS_HIDE_SECTION = 'form.success.hide.section';
 const FORM_MAP = {
   'success-type': SUCCESS_TYPE,
   'destination-type': SUCCESS_TYPE,
   'success-content': SUCCESS_CONTENT,
   'destination-url': SUCCESS_CONTENT,
   'success-section': SUCCESS_SECTION,
+  'success-hide-section': SUCCESS_HIDE_SECTION,
   'co-partner-names': 'program.copartnernames',
   'sfdc-campaign-id': 'program.campaignids.sfdc',
   'poi-field': 'field_filters.products',


### PR DESCRIPTION
This PR adds the hide section ability to Marketo form onSuccess handle. 

Resolves: [MWPW-171537](https://jira.corp.adobe.com/browse/MWPW-171537)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/marketo?martech=off
- After: https://marketo-hide-section--milo--adobecom.aem.page/docs/library/kitchen-sink/marketo?martech=off

**Events Milo URLs:**
- Before: http://qiyun--events-milo--adobecom.aem.page/drafts/qiyundai/details-page-dx?martech=off
- After: http://qiyun--events-milo--adobecom.aem.page/drafts/qiyundai/details-page-dx?milolibs=marketo-hide-section&martech=off


