### PR TITLE
Ace1068 Marquee and Notification variant

### DIFF
--- a/libs/mep/ace1068/hero-marquee/hero-marquee.css
+++ b/libs/mep/ace1068/hero-marquee/hero-marquee.css
@@ -275,12 +275,12 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
     text-align: center;
   }
     
-  .hero-marquee.remove-outline .con-button.outline {
-    border-color: transparent;
-    text-decoration: underline;
+  .hero-marquee.mobile-center-link a:not(.con-button) {
+    color: #000;
+    align-self: center;
   }
 
-  .hero-marquee.remove-outline .action-area {
+  .hero-marquee.mobile-center-link .action-area {
     gap: var(--spacing-xs);
   }
 

--- a/libs/mep/ace1068/hero-marquee/hero-marquee.css
+++ b/libs/mep/ace1068/hero-marquee/hero-marquee.css
@@ -51,6 +51,12 @@
   width: 100%;
 }
 
+.hero-marquee.mobile-cta-left .action-area {
+  flex-flow: row wrap;
+  gap: 8px;
+}
+
+
 .hero-marquee .background-split picture img {
   object-fit: cover;
   height: 100%;
@@ -134,6 +140,10 @@ html[dir="rtl"] .hero-marquee .foreground {
 .hero-marquee .foreground .copy {
   display: grid;
   gap: var(--spacing-xs);
+}
+
+.hero-marquee.mobile-compact-spacing .foreground .copy {
+  gap: 12px;
 }
 
 .hero-marquee hr {
@@ -263,6 +273,15 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   .hero-marquee .con-button {
     display: block;
     text-align: center;
+  }
+    
+  .hero-marquee.remove-outline .con-button.outline {
+    border-color: transparent;
+    text-decoration: underline;
+  }
+
+  .hero-marquee.remove-outline .action-area {
+    gap: var(--spacing-xs);
   }
 
   .hero-marquee.media-top-mobile {

--- a/libs/mep/ace1068/hero-marquee/hero-marquee.css
+++ b/libs/mep/ace1068/hero-marquee/hero-marquee.css
@@ -26,7 +26,7 @@
   color: var(--color-white);
 }
 
-.hero-marquee.typography-extra-bold h1 {
+.hero-marquee.header-extra-bold h1 {
   font-size: 40px;
   font-weight: 800;
   line-height: 44px;

--- a/libs/mep/ace1068/hero-marquee/hero-marquee.css
+++ b/libs/mep/ace1068/hero-marquee/hero-marquee.css
@@ -26,7 +26,7 @@
   color: var(--color-white);
 }
 
-.hero-marquee.typography-update h1 {
+.hero-marquee.typography-extra-bold h1 {
   font-size: 40px;
   font-weight: 800;
   line-height: 44px;

--- a/libs/mep/ace1068/hero-marquee/hero-marquee.css
+++ b/libs/mep/ace1068/hero-marquee/hero-marquee.css
@@ -1,0 +1,489 @@
+.hero-marquee {
+  --s-min-height: 248px; /* 360px */
+  --m-min-height: 448px; /* 560px */
+  --l-min-height: 588px; /* 700px */
+
+  /* 112 = 56px default padding */
+
+  padding: var(--spacing-xl) 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-m);
+  width: 100%;
+  overflow: hidden;
+  min-height: var(--m-min-height);
+  justify-content: center;
+  align-items: center;
+}
+
+.hero-marquee.no-min-height { min-height: unset; }
+.hero-marquee.s-min-height { min-height: var(--s-min-height); }
+.hero-marquee.l-min-height { min-height: var(--l-min-height); }
+
+.dark .hero-marquee,
+.hero-marquee.dark {
+  color: var(--color-white);
+}
+
+.hero-marquee.typography-update h1 {
+  font-size: 40px;
+  font-weight: 800;
+  line-height: 44px;
+}
+
+.hero-marquee .background picture {
+  line-height: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+}
+
+/* Alignment */
+.hero-marquee .action-area,
+.hero-marquee .lockup-area {
+  display: flex;
+}
+
+.hero-marquee .action-area {
+  flex-flow: column wrap;
+  gap: var(--spacing-s);
+  width: 100%;
+}
+
+.hero-marquee .background-split picture img {
+  object-fit: cover;
+  height: 100%;
+  width: 100%;
+}
+
+.hero-marquee.media-cover picture {
+  line-height: 0em;
+  display: block;
+}
+
+.hero-marquee .main-copy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  justify-content: center;
+}
+
+.hero-marquee .row-lockup .lockup-area {
+  margin: 0;
+}
+
+.hero-marquee .lockup-area a,
+.hero-marquee .lockup-area a:hover {
+  color: inherit;
+}
+
+.hero-marquee .action-area a:not(.con-button) {
+  font-weight: 700;
+}
+
+.hero-marquee .foreground-media {
+  z-index: 1;
+}
+
+.hero-marquee .foreground-media picture img,
+.hero-marquee .foreground-media video {
+  object-fit: cover;
+  object-position: center top;
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.hero-marquee.center {
+  text-align: center;
+  align-items: center;
+}
+
+.hero-marquee.center .action-area,
+.hero-marquee.center .lockup-area {
+  justify-content: center;
+}
+
+.hero-marquee .norm p { margin: var(--spacing-xs) 0; }
+
+.hero-marquee .main-copy p,
+.hero-marquee .main-copy p:only-child,
+.hero-marquee .main-copy [class^="heading"],
+.hero-marquee .norm p:only-child { margin: 0; }
+.hero-marquee .norm :is(h1, h2, h3, h4, h5, h6) { margin: 0 0 var(--spacing-xs) 0; }
+.hero-marquee .norm div > *:last-child { margin-bottom: 0; }
+.hero-marquee .norm div *:first-child { margin-top: 0; }
+
+.hero-marquee > .foreground {
+  max-width: var(--grid-container-width);
+  min-width: var(--grid-container-width);
+  margin: 0 auto;
+  display: grid;
+  gap: var(--spacing-m);
+}
+
+html[dir="rtl"] .hero-marquee .foreground {
+  flex-direction: row-reverse;
+}
+
+.hero-marquee > .foreground.fw {
+  width: 100%;
+}
+
+.hero-marquee .foreground .copy {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.hero-marquee hr {
+  width: 100%;
+  border: none;
+  height: 1px;
+  margin: 0;
+}
+
+.hero-marquee .has-divider {
+  margin: var(--spacing-xxs) 0;
+}
+
+/* content hidden */
+.hero-marquee .hidden {
+  visibility: hidden;
+  height: 0;
+}
+
+.hero-marquee .foreground div:empty {
+  display: none;
+}
+
+.hero-marquee .foreground div.empty-asset:empty {
+  display: block;
+}
+
+/* Row Types */
+.hero-marquee .row-list {
+  text-align: left;
+}
+
+html[dir="rtl"] .hero-marquee .row-list {
+  text-align: right;
+}
+
+.hero-marquee .row-list .row-wrapper {
+  display: table;
+}
+
+.hero-marquee .row-list li {
+  margin-bottom: var(--spacing-xxs);
+}
+
+/* row-qr */
+.hero-marquee .row-qrcode .row-wrapper {
+  display: flex;
+  gap: var(--spacing-s);
+  margin: 0;
+}
+
+.hero-marquee .row-qrcode .row-wrapper > p {
+  margin: 0;
+}
+
+.hero-marquee .row-qrcode .qr-code-img {
+  display: none;
+}
+
+.hero-marquee .row-qrcode .google-play a,
+.hero-marquee .row-qrcode .app-store a {
+  width: 135px;
+  height: 40px;
+  display: inline-flex;
+  color: transparent;
+}
+
+.hero-marquee .row-qrcode .google-play a {
+  background: url('/libs/img/ui/google-play.svg') no-repeat transparent;
+}
+
+.hero-marquee .row-qrcode .app-store a {
+  background: url('/libs/img/ui/app-store.svg') no-repeat transparent;
+}
+
+.hero-marquee.center .row-qrcode .row-wrapper {
+  justify-content: center;
+}
+
+.hero-marquee.center .row-list .row-wrapper {
+  margin: 0 auto;
+}
+
+.hero-marquee .row-list .icon-list {
+  padding-inline-start: var(--spacing-m);
+  margin: 0;
+}
+
+.hero-marquee li.icon-item {
+  position: relative;
+  list-style: none;
+}
+
+.hero-marquee li::marker {
+  padding-inline-start: 40px;
+}
+
+.hero-marquee li.icon-item::marker {
+  color: transparent;
+}
+
+.hero-marquee li.icon-item span.icon {
+  position: absolute;
+  left: -28px;
+}
+
+html[dir="rtl"] .hero-marquee li.icon-item span.icon {
+  left: unset;
+  right: -28px;
+}
+
+/* row-supplemental */
+.hero-marquee .row-supplemental.bold {
+  font-weight: 700;
+}
+
+.hero-marquee.media-cover.has-bg .asset {
+  display: none;
+}
+
+.hero-marquee.asset-left > .foreground.cols-2 > .asset {
+  order: 2;
+}
+
+/* mobile ONLY */
+@media (max-width: 600px) {
+  .hero-marquee .con-button {
+    display: block;
+    text-align: center;
+  }
+
+  .hero-marquee.media-top-mobile {
+    flex-direction: column-reverse;
+  }
+
+  .hero-marquee.media-top-mobile .foreground .copy {
+    order: 2;
+  }
+
+  .hero-marquee.media-cover:not(.bg-bottom-mobile),
+  .hero-marquee.media-cover:not(.media-hidden-mobile) {
+    padding-bottom: 0;
+  }
+
+  /* con-vars support */
+  .hero-marquee:is(.bg-top-mobile, .bg-bottom-mobile) .background,
+  .hero-marquee:is(.bg-top-mobile, .bg-bottom-mobile) .background video {
+      position: relative;
+      width: 100%;
+  }
+
+  .hero-marquee.bg-top-mobile  {
+    padding-top: unset;
+  }
+
+  .hero-marquee.bg-bottom-mobile {
+    padding-bottom: unset;
+  }
+
+  .hero-marquee.media-cover.media-top-mobile,
+  .hero-marquee.media-cover.media-hidden-mobile:not(.bg-bottom-mobile) {
+    padding-top: 0;
+    padding-bottom: var(--spacing-xl);
+  }
+
+  .hero-marquee.bg-top-mobile:not(.bg-bottom-mobile),
+  .hero-marquee.bg-top-mobile.media-top-mobile {
+    padding-top: 0;
+  }
+
+  .hero-marquee.bg-bottom-mobile .background {
+    order: 2;
+  }
+
+  .hero-marquee.media-hidden-mobile .foreground .asset,
+  .hero-marquee.media-hidden-mobile .foreground-media { display: none; }
+}
+
+/* Tablet ONLY */
+@media screen and (min-width: 600px) and (max-width: 1199px) {
+  .hero-marquee.media-cover:not(.bg-bottom-mobile) {
+    padding-bottom: 0;
+  }
+
+  .hero-marquee.media-top-tablet,
+  .hero-marquee.media-cover.media-top-tablet {
+    flex-direction: column-reverse;
+  }
+
+  .hero-marquee.media-top-tablet > .foreground .copy {
+    order: 2;
+  }
+
+  .hero-marquee.media-cover.media-top-tablet,
+  .hero-marquee.media-cover.media-hidden-tablet:not(.bg-bottom-tablet) {
+    padding-top: 0;
+    padding-bottom: var(--spacing-xl);
+  }
+
+  /* con-vars support */
+  .hero-marquee:is(.bg-top-tablet, .bg-bottom-tablet) .background,
+  .hero-marquee:is(.bg-top-tablet, .bg-bottom-tablet) .background video {
+    position: relative;
+    width: 100%;
+  }
+
+  .hero-marquee.bg-top-tablet {
+    padding-top: 0;
+  }
+
+  .hero-marquee.bg-bottom-tablet {
+    padding-bottom: 0;
+  }
+
+  .hero-marquee.bg-bottom-tablet .background {
+    order: 2;
+  }
+
+  /* helper classes */
+  .hero-marquee.media-hidden-tablet .foreground .asset,
+  .hero-marquee.media-hidden-tablet .foreground-media,
+  .hero-marquee.media-hidden-tablet-tablet .foreground-media { display: none; }
+}
+
+/* Tablet UP */
+@media screen and (min-width: 600px) {
+  .hero-marquee,
+  .hero-marquee .action-area {
+    flex-direction: row;
+  }
+
+  .hero-marquee .action-area {
+    align-items: center;
+  }
+
+  .hero-marquee.media-cover {
+    flex-direction: column;
+  }
+
+  .hero-marquee.center .action-area {
+    justify-content: center;
+  }
+
+  .hero-marquee.bg-top-tablet,
+  .hero-marquee.bg-bottom-tablet {
+    flex-direction: column;
+  }
+
+  /* min height */
+  .hero-marquee.s-min-height-tablet { min-height: var(--s-min-height);}
+  .hero-marquee.l-min-height-tablet { min-height: var(--l-min-height);}
+
+  /* helper classes */
+  .hero-marquee .order-0-tablet { order: 0; }
+  .hero-marquee .order-1-tablet { order: 1; }
+  .hero-marquee .order-2-tablet { order: 2; }
+  .hero-marquee .order-3-tablet { order: 3; }
+}
+
+@media screen and (min-width: 920px) {
+  .hero-marquee .foreground.cols-1 {
+    max-width: 800px;
+    min-width: unset;
+  }
+}
+
+/* desktop up */
+@media screen and (min-width: 1200px) {
+  .hero-marquee {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .hero-marquee.media-cover {
+    flex-direction: row;
+  }
+
+  .hero-marquee.media-cover picture {
+    display: unset;
+  }
+
+  .hero-marquee.media-cover.has-bg .asset {
+    display: initial;
+  }
+
+  .hero-marquee > .foreground.cols-2 {
+    grid-template-columns: minmax(50%, 1fr) minmax(50%, 1fr);
+    align-items: center;
+    gap: 0;
+  }
+
+  .hero-marquee > .foreground.cols-2 .copy {
+    padding-inline-end: 100px;
+  }
+
+  .hero-marquee.asset-left > .foreground.cols-2 .copy {
+    padding-inline-start: 100px;
+    padding-inline-end: unset;
+  }
+
+
+  .hero-marquee .foreground-media {
+    position: absolute;
+    width: 50vw;
+    height: 100%;
+    right: 0;
+    top: 0;
+  }
+
+  .hero-marquee.asset-left .foreground-media,
+  html[dir="rtl"] .hero-marquee .foreground-media {
+    right: unset;
+    left: 0;
+  }
+
+  html[dir="rtl"] .hero-marquee.asset-left .foreground-media {
+    right: 0;
+    left: unset;
+  }
+
+  .hero-marquee.asset-left > .foreground.cols-2 > .asset {
+    order: unset;
+  }
+
+  /* Action area order */
+  .hero-marquee .main-copy .action-area,
+  .hero-marquee .main-copy [class*='heading-'] + [class*='body-'] {
+    order: unset;
+  }
+
+  /* meta blocks */
+  .hero-marquee .row-qrcode .qr-code-img {
+    display: inline-block;
+    max-width: 140px;
+    max-height: 140px;
+    margin: 0;
+  }
+
+  .hero-marquee .row-qrcode .google-play,
+  .hero-marquee .row-qrcode .app-store {
+    display: none;
+  }
+
+  /* min height */
+  .hero-marquee.s-min-height-desktop { min-height: var(--s-min-height);}
+  .hero-marquee.l-min-height-desktop { min-height: var(--l-min-height);}
+
+  /* helper classes */
+  .hero-marquee .order-0-desktop { order: 0; }
+  .hero-marquee .order-1-desktop { order: 1; }
+  .hero-marquee .order-2-desktop { order: 2; }
+  .hero-marquee .order-3-desktop { order: 3; }
+}

--- a/libs/mep/ace1068/hero-marquee/hero-marquee.js
+++ b/libs/mep/ace1068/hero-marquee/hero-marquee.js
@@ -1,0 +1,277 @@
+import {
+  decorateBlockBg,
+  decorateBlockHrs,
+  decorateBlockText,
+  decorateTextOverrides,
+  decorateButtons,
+  handleObjectFit,
+  loadCDT,
+} from '../../../utils/decorate.js';
+import { createTag, loadStyle, getConfig } from '../../../utils/utils.js';
+
+const contentTypes = ['list', 'qrcode', 'lockup', 'text', 'bgcolor', 'supplemental'];
+const rowTypeKeyword = 'con-block-row-';
+const breakpointThemeClasses = ['dark-mobile', 'light-mobile', 'dark-tablet', 'light-tablet', 'dark-desktop', 'light-desktop'];
+const textDefault = ['xxl', 'm', 'l']; // heading, body, detail
+
+const { miloLibs, codeRoot } = getConfig();
+const base = miloLibs || codeRoot;
+
+function distillClasses(el, classes) {
+  const taps = ['-heading', '-body', '-detail', '-button'];
+  classes?.forEach((elClass) => {
+    const elTaps = taps.filter((tap) => elClass.endsWith(tap));
+    if (!elTaps.length) return;
+    const parts = elClass.split('-');
+    el.classList.add(`${parts[1]}-${parts[0]}`);
+    el.classList.remove(elClass);
+  });
+}
+
+function decorateList(el, classes) {
+  el.classList.add('body-l');
+  const listItems = el.querySelectorAll('li');
+  if (listItems.length) {
+    const firstDiv = el.querySelector(':scope > div');
+    firstDiv.classList.add('foreground');
+    [...listItems].forEach((item) => {
+      const firstElemIsIcon = item.children[0]?.classList.contains('icon');
+      if (firstElemIsIcon) item.classList.add('icon-item');
+      if (!item.parentElement.classList.contains('icon-list')) item.parentElement.classList.add('icon-list');
+    });
+  }
+  distillClasses(el, classes);
+}
+
+function decorateQr(el) {
+  const text = el.querySelector(':scope > div');
+  /* c8 ignore next */
+  if (!text) return;
+  const classes = ['qr-code-img', 'google-play', 'app-store'];
+  [...text.children].forEach((e, i) => {
+    e.classList.add(classes[i]);
+  });
+}
+
+async function loadIconography() {
+  await new Promise((resolve) => { loadStyle(`${base}/styles/iconography.css`, resolve); });
+}
+
+async function decorateLockupFromContent(el) {
+  const rows = el.querySelectorAll(':scope > p');
+  const firstRowImg = rows[0]?.querySelector('img');
+  if (!firstRowImg) return;
+  await loadIconography();
+  rows[0].classList.add('lockup-area');
+  rows[0].childNodes.forEach((node) => {
+    if (node.nodeType === 3 && node.nodeValue?.trim()) {
+      const newSpan = createTag('span', { class: 'lockup-label' }, node.nodeValue);
+      node.parentElement.replaceChild(newSpan, node);
+    }
+  });
+}
+
+async function decorateLockupRow(el, classes) {
+  const child = el.querySelector(':scope > div');
+  await loadIconography();
+  child?.classList.add('lockup-area');
+  const iconSizeClass = classes?.find((c) => c.endsWith('-icon'));
+  const lockupSizeClass = classes?.find((c) => c.endsWith('-lockup'));
+  const usedLockupClass = iconSizeClass || lockupSizeClass;
+  if (usedLockupClass) {
+    el.classList.remove(usedLockupClass);
+  }
+  el.classList.add(`${usedLockupClass?.split('-')[0] || 'l'}-lockup`);
+}
+
+function decorateBg(el) {
+  const block = el.closest('.hero-marquee');
+  block.style.background = el.textContent.trim();
+  el.remove();
+}
+
+function wrapInnerHTMLInPTag(el) {
+  const innerDiv = el.querySelector(':scope > div');
+  const containsPTag = [...innerDiv.childNodes].some((node) => node.nodeName === 'P');
+  if (!containsPTag) {
+    const pTag = createTag('p');
+    while (innerDiv.firstChild) pTag.appendChild(innerDiv.firstChild);
+    innerDiv.appendChild(pTag);
+  }
+}
+
+function decorateText(el, classes) {
+  el.classList.add('norm');
+  wrapInnerHTMLInPTag(el);
+  const btnClass = classes?.find((c) => c.endsWith('-button'));
+  if (btnClass) {
+    const [theme, size] = btnClass.split('-').reverse();
+    el.classList.remove(btnClass);
+    decorateButtons(el, `${theme}-${size}`);
+  } else {
+    decorateButtons(el, 'button-xl');
+  }
+  decorateBlockText(el, textDefault);
+  decorateTextOverrides(el, ['-heading', '-body', '-detail']);
+}
+
+function decorateSup(el, classes) {
+  el.classList.add('norm');
+  distillClasses(el, classes);
+}
+
+function extendButtonsClass(copy) {
+  const buttons = copy.querySelectorAll('.con-button');
+  if (buttons.length === 0) return;
+  buttons.forEach((button) => {
+    button.classList.add('button-xl', 'button-justified-mobile');
+  });
+}
+function parseKeyString(str) {
+  const regex = /^(\w+)\s*\((.*)\)$/;
+  const match = str.match(regex);
+  if (!match) return { key: str };
+  const key = match[1];
+  const classes = match[2].split(',').map((c) => c.trim());
+  const result = { key, classes };
+  return result;
+}
+
+async function loadContentType(el, key, classes) {
+  if (classes !== undefined && classes.length) el.classList.add(...classes);
+  switch (key) {
+    case 'bgcolor':
+      decorateBg(el);
+      break;
+    case 'lockup':
+      await decorateLockupRow(el, classes);
+      break;
+    case 'qrcode':
+      decorateQr(el);
+      break;
+    case 'list':
+      decorateList(el, classes);
+      break;
+    case 'supplemental':
+      decorateSup(el, classes);
+      break;
+    case 'text':
+      decorateText(el, classes);
+      break;
+    default:
+  }
+}
+
+function loadBreakpointThemes() {
+  loadStyle(`${base}/styles/breakpoint-theme.css`);
+}
+
+export default async function init(el) {
+  el.classList.add('con-block');
+  let rows = el.querySelectorAll(':scope > div');
+  if (rows.length > 1 && rows[0].textContent !== '') {
+    el.classList.add('has-bg');
+    const [head, ...tail] = rows;
+    handleObjectFit(head);
+    decorateBlockBg(el, head, { useHandleFocalpoint: true });
+    rows = tail;
+  }
+
+  // get first row that's not a keyword key/value row
+  const mainRowIndex = rows.findIndex((row) => {
+    const firstColText = row.children[0].textContent.toLowerCase().trim();
+    return !firstColText.includes(rowTypeKeyword);
+  });
+  const foreground = rows[mainRowIndex];
+  const fRows = foreground.querySelectorAll(':scope > div');
+  foreground.classList.add('foreground', `cols-${fRows.length}`);
+  let copy = fRows[0];
+  const anyTag = foreground.querySelector('p, h1, h2, h3, h4, h5, h6');
+  const asset = foreground.querySelector('div > picture, :is(.video-container, .pause-play-wrapper), div > video, div > a[href*=".mp4"], div > a.image-link');
+  const allRows = foreground.querySelectorAll('div > div');
+  copy = anyTag.closest('div');
+  copy.classList.add('copy');
+
+  if (asset) {
+    asset.parentElement.classList.add('asset');
+    if (el.classList.contains('media-cover')) {
+      el.appendChild(createTag('div', { class: 'foreground-media' }, asset));
+    }
+  } else {
+    [...fRows].forEach((row) => {
+      if (row.childElementCount === 0) {
+        row.classList.add('empty-asset');
+      }
+    });
+  }
+
+  const assetUnknown = (allRows.length === 2
+    && allRows[1].classList.length === 0)
+    ? allRows[1]
+    : null;
+  if (assetUnknown) assetUnknown.classList.add('asset-unknown');
+
+  decorateBlockText(copy, textDefault, 'hasDetailHeading');
+  await decorateLockupFromContent(copy);
+  extendButtonsClass(copy);
+
+  /* c8 ignore next 2 */
+  const containsClassFromArray = () => breakpointThemeClasses.some(
+    (className) => el.classList.contains(className),
+  );
+  if (containsClassFromArray) loadBreakpointThemes();
+
+  const assetRow = allRows[0].classList.contains('asset');
+  if (assetRow) el.classList.add('asset-left');
+  const lockupClass = [...el.classList].find((c) => c.endsWith('-lockup'));
+  if (lockupClass) el.classList.remove(lockupClass);
+  const buttonClass = [...el.classList].find((c) => c.endsWith('-button'));
+  if (buttonClass) el.classList.remove(buttonClass);
+  const classes = `main-copy ${lockupClass || 'l-lockup'} ${buttonClass || 'l-button'}`;
+  const mainCopy = createTag('div', { class: classes });
+  while (copy.childNodes.length > 0) {
+    mainCopy.appendChild(copy.childNodes[0]);
+  }
+  rows.splice(mainRowIndex, 1);
+  if (mainRowIndex > 0) {
+    for (let i = 0; i < mainRowIndex; i += 1) {
+      rows[i].classList.add('prepend');
+    }
+  }
+  copy.append(mainCopy);
+  [...rows].forEach((row) => {
+    if (row.classList.contains('prepend')) {
+      mainCopy.before(row);
+    } else {
+      copy.append(row);
+    }
+  });
+  const promiseArr = [];
+  [...rows].forEach(async (row) => {
+    const cols = row.querySelectorAll(':scope > div');
+    const firstCol = cols[0];
+    const firstColText = firstCol.textContent.toLowerCase().trim();
+    const isKeywordRow = firstColText.includes(rowTypeKeyword);
+    if (isKeywordRow) {
+      const keyValue = firstColText.replace(rowTypeKeyword, '').trim();
+      const parsed = parseKeyString(keyValue);
+      firstCol.parentElement.classList.add(`row-${parsed.key}`, 'con-block');
+      firstCol.remove();
+      cols[1].classList.add('row-wrapper');
+      if (contentTypes.includes(parsed.key)) {
+        promiseArr.push(loadContentType(row, parsed.key, parsed.classes));
+      }
+    } else {
+      row.classList.add('norm');
+      decorateBlockHrs(row);
+      decorateButtons(row, 'button-xl');
+    }
+  });
+  decorateTextOverrides(el, ['-heading', '-body', '-detail'], mainCopy);
+
+  if (el.classList.contains('countdown-timer')) {
+    promiseArr.push(loadCDT(copy, el.classList));
+  }
+
+  await Promise.all(promiseArr);
+}

--- a/libs/mep/ace1068/notification/notification.css
+++ b/libs/mep/ace1068/notification/notification.css
@@ -34,6 +34,7 @@
 .notification.button-full-width .con-button {
   width: 100%;
   max-width: 328px;
+  align-self: center;
 }
 
 .notification.ribbon {

--- a/libs/mep/ace1068/notification/notification.css
+++ b/libs/mep/ace1068/notification/notification.css
@@ -1,0 +1,734 @@
+.notification {
+  --min-block-size: 160px;
+  --min-block-size-ribbon: 50px;
+  --min-block-size-pill: 72px;
+  --margin-inline-pill-desktop: 80px;
+  --margin-inline-ribbon: 30px;
+  --max-inline-size-image: 75px;
+  --max-inline-size-icon: 231px;
+  --inline-size-image: auto;
+  --inline-size-pill: 85%;
+  --border-block-size: 10px;
+  --close-size: 20px;
+  --icon-size-xs: 24px;
+  --icon-size-s: 32px;
+  --icon-size-m: 40px;
+  --icon-size: 56px;
+  --icon-size-xl: 64px;
+  --pill-radius: 16px;
+  --pill-shadow: 0 3px 6px #00000029;
+  --split-shadow: 0 6px 16px 0 rgb(0 0 0 / 0.16);
+
+  display: flex;
+  inline-size: 100%;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  overflow: hidden;
+  min-block-size: var(--min-block-size);
+  background: var(--color-white);
+}
+
+.notification.button-full-width .action-area,
+.notification.button-full-width .con-button {
+  width: 100%;
+  max-width: 328px;
+}
+
+.notification.ribbon {
+  min-block-size: var(--min-block-size-ribbon);
+}
+
+.dark .notification,
+.notification.dark {
+  color: var(--color-white);
+}
+
+.notification p {
+  margin: 0;
+  inline-size: 100%;
+}
+
+
+.notification [class*="heading-"] {
+  margin-block-end: var(--spacing-xxs);
+}
+
+.notification [class*="heading-"] strong {
+  font-weight: unset;
+}
+
+.notification .text p:not(.icon-area, .action-area) {
+  margin-block-end: var(--spacing-s);
+}
+
+.notification.ribbon.space-between [class*="heading-"] + p {
+  margin-block-end: 0;
+}
+
+.notification .foreground {
+  display: flex;
+  position: relative;
+  align-items: flex-start;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin-block: var(--spacing-s);
+  box-sizing: border-box;
+  justify-content: flex-start;
+}
+
+.notification.ribbon .foreground {
+  inline-size: 100%;
+  margin-inline: var(--margin-inline-ribbon);
+  margin-block: 0;
+  padding-block: var(--spacing-s);
+}
+
+.notification .foreground [data-align=center],
+.notification.center .foreground,
+.notification.center .foreground > * {
+  text-align: center;
+  justify-content: center;
+}
+
+.notification.pill .foreground {
+  padding-inline: var(--spacing-xs) var(--spacing-xxs);
+  padding-block: var(--spacing-xs) var(--spacing-xxs);
+  margin: 0;
+  inline-size: 100%;
+}
+
+.notification.ribbon.xxs-padding .foreground {
+  padding-block: var(--spacing-xxs);
+}
+
+.notification.ribbon.xs-padding .foreground {
+  padding-block: var(--spacing-xs);
+}
+
+.notification.split .foreground {
+  padding-inline: var(--spacing-xs);
+  padding-block: var(--spacing-xs);
+}
+
+.notification:is(.ribbon, .pill) .close {
+  position: absolute;
+  inset-inline: auto var(--spacing-xxs);
+  inset-block: var(--spacing-xxs) auto;
+  block-size: var(--close-size);
+  inline-size: var(--close-size);
+  cursor: pointer;
+  margin: auto;
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0;
+}
+
+.notification .close .path {
+  fill: var(--text-color);
+}
+
+.dark .notification .close .path,
+.notification.dark .close .path {
+  fill: var(--color-white);
+}
+
+.notification .border {
+  display: block;
+  block-size: var(--border-block-size);
+  inline-size: 100%;
+}
+
+.notification .action-area {
+  gap: var(--spacing-s);
+  display: flex;
+  align-items: center;
+}
+
+.notification .background img {
+  min-block-size: unset;
+}
+
+.notification .foreground .text {
+  display: flex;
+  flex-wrap: wrap;
+  max-inline-size: none;
+  padding-block-start: 0;
+  padding-block-end: 0;
+}
+
+.notification.pill .foreground .text {
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: start;
+  inline-size: 100%;
+}
+
+.notification.ribbon [class*="heading-"]:only-child {
+  margin-block-end: var(--spacing-s);
+}
+
+.notification.ribbon.space-between [class*="heading-"]:only-child {
+  margin-block-end: 0;
+}
+
+.notification.ribbon.space-between .foreground .text {
+  flex-wrap: nowrap;
+  inline-size: 100%;
+}
+
+.notification.ribbon.space-between .foreground .copy-wrap {
+  margin-inline-end: var(--spacing-s);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex-basis: 100%;
+}
+
+.notification .foreground .image {
+  position: relative;
+  display: flex;
+  inline-size: var(--inline-size-image);
+  max-inline-size: var(--max-inline-size-image);
+  margin: 0;
+  order: -1;
+}
+
+.notification .foreground > div {
+  flex-grow: 1;
+  flex-basis: 100%;
+  min-inline-size: 0;
+}
+
+.notification .foreground .text a {
+  white-space: nowrap;
+}
+
+.notification .icon-area img {
+  display: flex;
+  align-items: center;
+  inline-size: auto;
+}
+
+.notification.ribbon .icon-area img {
+  max-block-size: var(--icon-size);
+}
+
+.notification .icon-area.lockup-area img {
+  max-block-size: unset;
+}
+
+.notification .lockup-area {
+  flex-wrap: nowrap;
+}
+
+.notification .foreground .image :is(picture, video),
+.notification .foreground .image picture img {
+  inline-size: 100%;
+  display: flex;
+}
+
+.notification:is(.ribbon.m-icon, .pill) .icon-area img {
+  max-block-size: var(--icon-size-m);
+}
+
+.notification.s-icon:is(.ribbon, .pill) .icon-area img {
+  max-block-size: var(--icon-size-s);
+}
+
+.notification.xs-icon:is(.ribbon, .pill) .icon-area img {
+  max-block-size: var(--icon-size-xs);
+}
+
+.notification.ribbon.xl-icon .icon-area img {
+  max-block-size: var(--icon-size-xl);
+}
+
+.notification .text [class*="heading-"] + .action-area {
+  margin-block-start: var(--spacing-xs);
+}
+
+.notification.center .foreground .action-area {
+  justify-content: center;
+}
+
+.notification .foreground .icon-area {
+  block-size: auto;
+  max-inline-size: none;
+  margin-block-end: var(--spacing-xs);
+  flex-shrink: 0;
+  display: flex;
+}
+
+.notification .foreground .icon-area:not(.lockup-area) {
+  gap: var(--spacing-xs);
+}
+
+.notification.center .foreground .icon-area {
+  justify-content: center;
+}
+
+.notification.pill .foreground .icon-area {
+  margin-inline-end: 0;
+  margin-block-end: var(--spacing-xs);
+  inline-size: auto;
+}
+
+.notification.ribbon.space-between .foreground .icon-area {
+  align-items: center;
+  inline-size: auto;
+  margin-inline-end: var(--spacing-xs);
+  margin-block-end: 0;
+}
+
+.notification .foreground .text a:not(.con-button) {
+  inline-size: auto;
+  font-weight: normal;
+}
+
+.notification .foreground .text .action-area > a {
+  margin-inline-end: 0;
+}
+
+.notification .foreground .text .heading-l {
+  margin-block-end: var(--spacing-xxs);
+}
+
+.notification .foreground:not(.no-image) .text .body-s.action-area,
+.notification .foreground:not(.no-image) .text .body-m.action-area {
+  margin-block-end: 0;
+}
+
+.notification.center .icon-area picture {
+  display: flex;
+  justify-content: center;
+}
+
+.notification.pill {
+  border-radius: var(--pill-radius);
+  inline-size: calc(100% - var(--spacing-m));
+  margin-inline: auto;
+  box-shadow: var(--pill-shadow);
+}
+
+.notification.split.pill {
+  box-shadow: var(--split-shadow);
+}
+
+.notification.pill .foreground .action-area {
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.notification.ribbon.space-between .foreground .action-area {
+  flex-wrap: wrap;
+  align-self: center;
+  justify-content: flex-end;
+  inline-size: auto;
+}
+
+.notification.flexible {
+  background: unset;
+}
+
+.notification .flexible-inner {
+  inline-size: 100%;
+  box-shadow: var(--pill-shadow);
+}
+
+.notification.pill.no-shadow,
+.notification.pill.no-shadow.flexible .flexible-inner {
+  box-shadow: unset;
+}
+
+.notification .foreground > :is(.tablet-up, .desktop-up) {
+  display: none;
+}
+
+.notification.pill .foreground .text > :not(.action-area) {
+  padding-inline-end: var(--spacing-xxs);
+  inline-size: calc(100% - var(--spacing-xxs));
+}
+
+.notification.pill .copy-wrap p:first-child:not(:only-child) {
+  margin-block-end: var(--spacing-xxs);
+}
+
+.notification.pill.max-width-6 { max-width: 600px; }
+.notification.pill.max-width-8 { max-width: 800px; }
+.notification.pill.max-width-10 { max-width: 1000px; }
+.notification.pill.max-width-12 { max-width: 1200px; }
+.notification.pill.max-width-auto { max-width: unset; }
+
+
+.notification.split .copy-wrap > [class^="heading-"] {
+  max-width: 92.6%;
+}
+
+.notification.split .foreground .text .copy-wrap,
+.notification.split .foreground .text .split-list-area {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  padding-inline-end: 0px;
+  inline-size: 100%;
+}
+
+.notification.split .split-list-area .split-list-item
+ {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.notification.split .split-list-area .split-list-item .text-content {
+  display: flex;
+  gap: var(--spacing-xxs);
+  align-items: center;
+  font-weight: 700;
+}
+
+
+.notification.split .split-list-area .split-list-item .text-content div {
+  max-width: 79.042%;
+}
+
+.notification.split .split-list-area .split-list-item .con-button {
+  white-space: normal;
+  text-align: center;
+  min-width: 89px;
+  max-width: 89px;
+}
+
+.notification.split .split-list-area .split-list-item picture,
+.notification.split .split-list-area .split-list-item picture img {
+  display: flex;
+  width: auto;
+  height: var(--icon-size-xs);
+  min-width: unset;
+  max-width: unset;
+}
+
+@media screen and (min-width: 600px) {
+  .notification {
+    --max-inline-size-image: 188px;
+    --max-inline-size-banner: 800px;
+    --min-inline-size-flexible: 300px;
+    --inline-size-image: 35%;
+    --full-width: 1200px;
+    --padding-inline-flexible: 80px;
+  }
+
+  .notification:not(.pill, .ribbon) .foreground {
+    max-inline-size: var(--max-inline-size-banner);
+  }
+
+  .notification .foreground {
+    align-items: center;
+    flex-direction: row;
+    margin-block: 0;
+    margin-inline: auto;
+    padding-block: var(--spacing-s);
+    padding-inline: 0;
+    gap: var(--spacing-s);
+  }
+
+  .notification .foreground > :is(.mobile-up, .desktop-up) {
+    display: none;
+  }
+
+  .notification .foreground > .tablet-up {
+    display: flex;
+  }
+
+  .notification:is(.max-width-12-desktop, .ribbon) .foreground {
+    max-inline-size: var(--full-width);
+    margin-inline: var(--grid-margins-width);
+  }
+
+  .notification .foreground .image {
+    margin: 0;
+    padding: 0;
+    order: unset;
+  }
+
+  .notification .foreground .text.image {
+    justify-content: flex-start;
+  }
+
+  .notification .background {
+    overflow: hidden;
+    position: absolute;
+    inset: 0;
+  }
+
+  .notification .foreground .text {
+    margin-block-end: 0;
+    padding-inline-end: 0;
+  }
+
+  .notification .foreground .text + .image {
+    margin-inline-end: 0;
+  }
+
+  .notification .foreground .icon-area {
+    inline-size: auto;
+    margin-inline-end: var(--spacing-xs);
+    margin-block-end: 0;
+  }
+
+  .notification.ribbon .close {
+    inset-inline: auto var(--spacing-s);
+    inset-block: 0;
+  }
+
+  .notification.ribbon .foreground .text {
+    flex-flow: row nowrap;
+    align-items: center;
+  }
+
+  .notification.ribbon .action-area {
+    inline-size: auto;
+  }
+
+  .notification.ribbon .copy-wrap {
+    margin-inline-end: var(--spacing-s);
+  }
+
+  .notification.space-between .copy-wrap {
+    flex-basis: 100%;
+  }
+
+  .notification.ribbon .copy-wrap :last-child {
+    margin-block-end: 0;
+  }
+
+  .notification.center .copy-wrap {
+    text-align: start;
+  }
+
+  .notification.pill .foreground {
+    padding: var(--spacing-s);
+  }
+
+  .notification.pill:not(.flexible) .foreground {
+    inline-size: var(--grid-width);
+  }
+
+  .notification.pill .foreground .text {
+    align-items: center;
+    text-align: center;
+  }
+
+  .notification.pill .foreground .action-area {
+    justify-content: center;
+  }
+
+  .notification.ribbon.space-between .foreground .action-area {
+    flex-wrap: unset;
+  }
+
+  .notification.pill.flexible {
+    pointer-events: none;
+    box-shadow: none;
+    padding-block-end: var(--spacing-xxs);
+  }
+
+  .notification .flexible-inner {
+    position: relative;
+    margin: auto;
+    pointer-events: auto;
+    inline-size: auto;
+    padding-inline: var(--padding-inline-flexible);
+    overflow: hidden;
+    min-inline-size: var(--min-inline-size-flexible);
+    border-radius: var(--pill-radius);
+  }
+
+  .notification.pill .foreground .text > :not(.action-area) {
+    padding-inline-end: unset;
+    inline-size: unset;
+  }
+
+  .notification.pill.max-width-6-tablet { max-width: 600px; }
+  .notification.pill.max-width-8-tablet { max-width: 800px; }
+  .notification.pill.max-width-10-tablet { max-width: 1000px; }
+  .notification.pill.max-width-12-tablet { max-width: 1200px; }
+  .notification.pill.max-width-auto-tablet { max-width: unset; }
+
+  .notification.split {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .notification {
+    --inline-size-image: 20%;
+    --inline-size-image-10: 30%;
+    --max-inline-size-image-10: 300px;
+    --inline-size-image-full: 33.333%;
+    --max-inline-size-image-full: 400px;
+    --max-inline-size-pill: 1600px;
+    --pill-radius: 100px;
+  }
+
+  .notification:not(.pill, .ribbon) .foreground {
+    inline-size: calc(var(--grid-width) * (8 / 12));
+    margin-inline: var(--grid-margins-width-8);
+    gap: var(--spacing-m);
+  }
+
+  .notification:is(.max-width-12-desktop, .max-width-10-desktop) .foreground {
+    inline-size: unset;
+  }
+
+  .notification.max-width-12-desktop .foreground {
+    gap: var(--spacing-xl);
+    margin-inline: var(--grid-margins-width);
+  }
+
+  .notification.ribbon .foreground {
+    gap: var(--spacing-s);
+  }
+
+  .notification.max-width-10-desktop .foreground {
+    margin-inline: var(--grid-margins-width-10);
+    gap: var(--spacing-l);
+    max-inline-size: calc(var(--grid-column-width) * 10);
+  }
+
+  .notification .foreground > :is(.mobile-up, .tablet-up) {
+    display: none;
+  }
+
+  .notification .foreground > .desktop-up {
+    display: flex;
+  }
+
+  .notification .foreground > div {
+    object-fit: cover;
+    padding-inline-start: 0;
+  }
+
+  .notification .foreground .icon-area {
+    max-inline-size: var(--max-inline-size-icon);
+    margin-inline-end: var(--spacing-s);
+  }
+
+  .notification .foreground .lockup-area {
+    max-inline-size: none;
+  }
+
+  .notification.ribbon .foreground .icon-area {
+    flex-shrink: 0;
+  }
+
+  .notification .foreground .image {
+    inline-size: var(--inline-size-image);
+  }
+
+  .notification.max-width-10-desktop .foreground .image {
+    inline-size: var(--inline-size-image);
+    max-inline-size: var(--max-inline-size-image-10);
+  }
+
+  .notification.max-width-12-desktop .foreground .image {
+    inline-size: var(--inline-size-image-full);
+    max-inline-size: var(--max-inline-size-image-full);
+  }
+
+  .notification .foreground .text + .image {
+    margin-inline-end: 0;
+  }
+
+  .notification.pill {
+    min-block-size: var(--min-block-size-pill);
+    inline-size: var(--inline-size-pill);
+    max-inline-size: var(--max-inline-size-pill);
+    margin-inline: auto;
+  }
+
+  .notification.pill p {
+    inline-size: auto;
+  }
+
+  .notification.pill .text [class*="heading-"],
+  .notification.pill .text p {
+    flex-shrink: 0;
+    margin-block-end: 0;
+  }
+
+  .notification.pill .foreground .text [class*="heading-"] {
+    margin-block-end: 0;
+  }
+
+  .notification.pill .close {
+    inset-inline: auto var(--spacing-s);
+    inset-block: 0;
+  }
+
+  .notification.pill .foreground {
+    padding-block: var(--spacing-xs);
+    padding-inline: var(--spacing-m);
+    margin: 0;
+  }
+
+  .notification.pill:not(.flexible) .foreground {
+    inline-size: calc(100% - var(--margin-inline-pill-desktop) * 2);
+  }
+
+  .notification.pill.flexible .foreground {
+    padding-inline: 0;
+  }
+
+  .notification.pill .foreground .icon-area {
+    margin-inline-end: var(--spacing-s);
+    margin-block-end: 0;
+  }
+
+  .notification.pill .icon-area img {
+    max-block-size: var(--icon-size-m);
+  }
+
+  .notification.pill .foreground .action-area {
+    margin-inline-start: var(--spacing-s);
+  }
+
+  .notification.pill .foreground .text {
+    flex-flow: row nowrap;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .notification.pill.flexible .flexible-inner {
+    border-radius: var(--pill-radius);
+  }
+
+  .notification.pill .copy-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    text-align: start;
+    gap: var(--spacing-xxs);
+  }
+
+  .notification.pill .copy-wrap > * {
+    max-inline-size: 100%;
+  }
+
+  .notification.ribbon.space-between .foreground .icon-area {
+    margin-inline-end: var(--spacing-s);
+  }
+
+  .notification.pill .copy-wrap p:first-child:not(:only-child) {
+    margin-block-end: 0;
+  }
+
+  .notification.pill.max-width-6-desktop { max-width: 600px; }
+  .notification.pill.max-width-8-desktop { max-width: 800px; }
+  .notification.pill.max-width-10-desktop { max-width: 1000px; }
+  .notification.pill.max-width-12-desktop { max-width: 1200px; }
+  .notification.pill.max-width-auto-desktop { max-width: unset; }
+}

--- a/libs/mep/ace1068/notification/notification.js
+++ b/libs/mep/ace1068/notification/notification.js
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+* Notification - v1.2
+*/
+
+import { decorateBlockText, decorateBlockBg, decorateTextOverrides, decorateMultiViewport, loadCDT } from '../../../utils/decorate.js';
+import { createTag, getConfig, loadStyle } from '../../../utils/utils.js';
+
+const { miloLibs, codeRoot } = getConfig();
+const base = miloLibs || codeRoot;
+const variants = ['banner', 'ribbon', 'pill'];
+const sizes = ['small', 'medium', 'large'];
+const [banner, ribbon, pill] = variants;
+const [small, medium, large] = sizes;
+const defaultSize = medium;
+const defaultVariant = banner;
+const blockConfig = {
+  [banner]: {
+    [small]: ['s', 's', 's', 'm'],
+    [medium]: ['m', 'm', 'm', 'l'],
+    [large]: ['l', 'l', 'l', 'l'],
+  },
+  [ribbon]: {
+    [small]: ['s', 's', 's', 'm'],
+    [medium]: ['m', 'm', 'm', 'l'],
+    [large]: ['l', 'l', 'l', 'l'],
+  },
+  [pill]: {
+    [small]: ['s', 's', 's', 'm'],
+    [medium]: ['m', 'm', 'm', 'l'],
+    [large]: ['l', 'm', 'm', 'l'],
+  },
+};
+
+const closeSvg = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <g clip-path="url(#clip0_699_20329)">
+    <path d="M17.071 2.9289C15.6725 1.53038 13.8907 0.577987 11.9509 0.192144C10.0111 -0.1937 8.0004 0.00433988 6.17314 0.761219C4.34589 1.5181 2.78411 2.79982 1.6853 4.44431C0.586487 6.0888 0 8.02219 0 10C0 11.9778 0.586487 13.9112 1.6853 15.5557C2.78411 17.2002 4.34589 18.4819 6.17314 19.2388C8.0004 19.9957 10.0111 20.1937 11.9509 19.8079C13.8907 19.422 15.6725 18.4696 17.071 17.0711C17.9996 16.1425 18.7362 15.0401 19.2388 13.8269C19.7413 12.6136 20 11.3132 20 10C20 8.68677 19.7413 7.3864 19.2388 6.17314C18.7362 4.95988 17.9996 3.85748 17.071 2.9289ZM13.9082 14.7616C13.814 14.8558 13.6862 14.9087 13.5529 14.9087C13.4197 14.9087 13.2919 14.8558 13.1977 14.7616L10.0002 11.5636L6.80219 14.7616C6.70795 14.8558 6.58016 14.9087 6.44691 14.9087C6.31366 14.9087 6.18587 14.8558 6.09163 14.7616L5.23736 13.9073C5.14316 13.813 5.09023 13.6853 5.09023 13.552C5.09023 13.4188 5.14316 13.291 5.23736 13.1967L8.43636 10.0003L5.23887 6.80276C5.19215 6.75609 5.15508 6.70067 5.12979 6.63967C5.10451 6.57867 5.09149 6.51328 5.09149 6.44724C5.09149 6.3812 5.10451 6.31581 5.12979 6.25481C5.15508 6.1938 5.19215 6.13838 5.23887 6.09171L6.09314 5.23744C6.18738 5.14323 6.31517 5.09031 6.44842 5.09031C6.58167 5.09031 6.70946 5.14323 6.80369 5.23744L10.0002 8.43643L13.1982 5.23895C13.2448 5.19222 13.3003 5.15516 13.3613 5.12987C13.4223 5.10458 13.4877 5.09157 13.5537 5.09157C13.6197 5.09157 13.6851 5.10458 13.7461 5.12987C13.8071 5.15516 13.8626 5.19222 13.9092 5.23895L14.761 6.09322C14.8552 6.18745 14.9081 6.31525 14.9081 6.44849C14.9081 6.58174 14.8552 6.70954 14.761 6.80377L11.564 10.0003L14.761 13.1977C14.8552 13.292 14.9081 13.4198 14.9081 13.553C14.9081 13.6863 14.8552 13.8141 14.761 13.9083L13.9082 14.7616Z" class="path"/>
+  </g>
+  <defs>
+    <clipPath id="clip0_699_20329">
+      <rect width="20" height="20" fill="white"/>
+    </clipPath>
+  </defs>
+</svg>`;
+
+let iconographyLoaded = false;
+
+function getOpts(el) {
+  const optRows = [...el.querySelectorAll(':scope > div:nth-of-type(n+3)')];
+  if (!optRows.length) return {};
+  optRows.forEach((row) => row.remove());
+  const camel = (str) => str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+  const fmt = (child) => child.textContent.toLowerCase().replace('\n', '').trim();
+  return optRows.reduce((a, c) => ({ ...a, [camel(fmt(c.children[0]))]: fmt(c.children[1]) }), {});
+}
+
+function getBlockData(el) {
+  const variant = variants.find((varClass) => el.classList.contains(varClass)) || defaultVariant;
+  const size = sizes.find((sizeClass) => el.classList.contains(sizeClass)) || defaultSize;
+  const fontSizes = [...blockConfig[variant][size]];
+  const buttonSize = el.className.match(/([xsml]+)-button/);
+  if (buttonSize) fontSizes.splice(3, 1, buttonSize[1]);
+  return { fontSizes, options: { ...getOpts(el) } };
+}
+
+function wrapCopy(foreground) {
+  const texts = foreground.querySelectorAll('.text');
+  if (!texts) return;
+  texts.forEach((text) => {
+    const heading = text?.querySelector('h1, h2, h3, h4, h5, h6, p:not(.icon-area, .action-area)');
+    const icon = heading?.previousElementSibling;
+    const body = heading?.nextElementSibling?.classList.contains('action-area') ? '' : heading?.nextElementSibling;
+    const copy = createTag('div', { class: 'copy-wrap' }, [heading, body].filter(Boolean));
+    text?.insertBefore(copy, icon?.nextSibling || text.children[0]);
+  });
+}
+
+function addCloseAction(el, btn) {
+  btn.addEventListener('click', (e) => {
+    if (btn.nodeName === 'A') e.preventDefault();
+    el.style.display = 'none';
+    el.closest('.section')?.classList.add('close-sticky-section');
+    document.dispatchEvent(new CustomEvent('milo:sticky:closed'));
+  });
+}
+
+function decorateClose(el) {
+  const btn = createTag('button', { 'aria-label': 'close', class: 'close' }, closeSvg);
+  addCloseAction(el, btn);
+  el.appendChild(btn);
+}
+
+function decorateFlexible(el) {
+  const innards = [
+    el.querySelector('.background'),
+    el.querySelector('.foreground'),
+    el.querySelector('.close'),
+  ].filter(Boolean);
+  const inner = createTag('div', { class: 'flexible-inner' }, innards);
+  if (el.style.background) {
+    inner.style.background = el.style.background;
+    el.style.removeProperty('background');
+  }
+  el.appendChild(inner);
+}
+
+async function loadIconography() {
+  await new Promise((resolve) => { loadStyle(`${base}/styles/iconography.css`, resolve); });
+  iconographyLoaded = true;
+}
+
+async function decorateLockup(lockupArea, el) {
+  if (!iconographyLoaded) await loadIconography();
+  const icon = lockupArea.querySelector('picture');
+  const content = icon.nextElementSibling || icon.nextSibling;
+  const label = createTag('span', { class: 'lockup-label' }, content.nodeValue || content);
+  if (content.nodeType === 3) {
+    lockupArea.replaceChild(label, content);
+  } else {
+    lockupArea.appendChild(label);
+  }
+  lockupArea.classList.add('lockup-area');
+  const pre = el.className.match(/([xsml]+)-(lockup|icon)/);
+  if (!pre) el.classList.add(`${el.matches('.pill') ? 'm' : 'l'}-lockup`);
+  if (pre && pre[2] === 'icon') el.classList.replace(pre[0], `${pre[1]}-lockup`);
+}
+
+function decorateSplitList(el, listContent) {
+  const closeEvent = '#_evt-close';
+  const listContainer = createTag('div', { class: 'split-list-area' });
+  listContent?.querySelectorAll('li').forEach((item) => {
+    const listItem = createTag('div', { class: 'split-list-item' });
+    const pic = item.querySelector('picture');
+    if (!pic) return;
+    const textli = ['STRONG', 'EM', 'A'].includes(item.lastElementChild.nodeName)
+      ? item
+      : item.nextElementSibling;
+    const btn = createTag('div', {}, textli.lastElementChild);
+    const btnA = btn.querySelector('a');
+    if (btnA?.href.includes(closeEvent)) {
+      btnA.href = closeEvent;
+      addCloseAction(el, btnA);
+    }
+    const textContent = createTag('div', { class: 'text-content' });
+    const text = createTag('div', {}, textli.innerText.trim());
+    textContent.append(pic, text);
+    listItem.append(textContent, btn);
+    listContainer.append(listItem);
+    pic.querySelector('img').loading = 'eager';
+  });
+  listContent.replaceWith(listContainer);
+}
+
+async function decorateForegroundText(el, container) {
+  const text = container?.querySelector('h1, h2, h3, h4, h5, h6, p')?.closest('div');
+  text?.classList.add('text');
+  if (el.classList.contains('countdown-timer') && !el.classList.contains('pill') && !el.classList.contains('ribbon')) {
+    await loadCDT(text, el.classList);
+  }
+  if (el.classList.contains('split')) {
+    decorateSplitList(el, text?.querySelector('ul'));
+    return;
+  }
+  const iconArea = text?.querySelector('p:has(picture)');
+  iconArea?.classList.add('icon-area');
+  if (iconArea?.textContent.trim()) await decorateLockup(iconArea, el);
+}
+
+async function decorateLayout(el) {
+  const [background, ...rest] = el.querySelectorAll(':scope > div');
+  const foreground = rest.pop();
+  if (background) decorateBlockBg(el, background);
+  foreground?.classList.add('foreground', 'container');
+  if (el.matches(`:is(.${pill}, .${ribbon})`)) {
+    foreground.querySelectorAll(':scope > div').forEach((div) => decorateForegroundText(el, div));
+  } else {
+    await decorateForegroundText(el, foreground);
+  }
+  const fgMedia = foreground?.querySelector(':scope > div:not(.text) :is(img, video, a[href*=".mp4"])')?.closest('div');
+  const bgMedia = el.querySelector(':scope > div:not(.foreground) :is(img, video, a[href*=".mp4"])')?.closest('div');
+  const media = fgMedia ?? bgMedia;
+  media?.classList.toggle('image', media && !media.classList.contains('text'));
+  foreground?.classList.toggle('no-image', !media && !el.querySelector('.icon-area'));
+  if (el.matches(`:is(.${pill}, .${ribbon}):not(.no-closure)`)) decorateClose(el);
+  if (el.matches(`.${pill}.flexible`)) decorateFlexible(el);
+  return foreground;
+}
+
+export default async function init(el) {
+  el.classList.add('con-block');
+  const { fontSizes, options } = getBlockData(el);
+  const blockText = await decorateLayout(el);
+  decorateBlockText(blockText, fontSizes);
+  if (options.borderBottom) {
+    el.append(createTag('div', { style: `background: ${options.borderBottom};`, class: 'border' }));
+  }
+  decorateTextOverrides(el);
+  el.querySelectorAll('a:not([class])').forEach((staticLink) => staticLink.classList.add('static'));
+  if (el.matches(`:is(.${ribbon}, .${pill})`)) {
+    wrapCopy(blockText);
+    decorateMultiViewport(el);
+  }
+}

--- a/libs/mep/ace1068/section-metadata/section-metadata.css
+++ b/libs/mep/ace1068/section-metadata/section-metadata.css
@@ -1,0 +1,380 @@
+.section-metadata {
+  display: none;
+}
+
+.section.darkest {
+  background-color: rgb(0 0 0);
+  color: rgb(255 255 255);
+}
+
+.section.dark {
+  background-color: rgb(29 29 29);
+  color: rgb(255 255 255);
+}
+
+.section.light {
+  background-color: rgb(255 255 255);
+  color: rgb(34 34 34);
+}
+
+.section.hide-sticky-section,
+.section.close-sticky-section {
+  display: none;
+}
+
+.section.has-background {
+  background-color: unset;
+}
+
+.section.xxxl-spacing-static {
+  padding: var(--spacing-xxxl-static) 0;
+}
+
+.section.xxl-spacing-static {
+  padding: var(--spacing-xxl-static) 0;
+}
+
+.section.xl-spacing-static {
+  padding: var(--spacing-xl-static) 0;
+}
+
+.section.xxxl-spacing {
+  padding: var(--spacing-xxxl) 0;
+}
+
+.section.xxl-spacing {
+  padding: var(--spacing-xxl) 0;
+}
+
+.section.xl-spacing {
+  padding: var(--spacing-xl) 0;
+}
+
+.section.l-spacing {
+  padding: var(--spacing-l) 0;
+}
+
+.section.m-spacing {
+  padding: var(--spacing-m) 0;
+}
+
+.section.s-spacing {
+  padding: var(--spacing-s) 0;
+}
+
+.section.xs-spacing {
+  padding: var(--spacing-xs) 0;
+}
+
+.section.xxs-spacing {
+  padding: var(--spacing-xxs) 0;
+}
+
+.section.xxxl-padding {
+  padding: var(--spacing-xxxl);
+}
+
+.section.xxl-padding {
+  padding: var(--spacing-xxl);
+}
+
+.section.xl-padding {
+  padding: var(--spacing-xl);
+}
+
+.section.l-padding {
+  padding: var(--spacing-l);
+}
+
+.section.m-padding {
+  padding: var(--spacing-m);
+}
+
+.section.s-padding {
+  padding: var(--spacing-s);
+}
+
+.section.xs-padding {
+  padding: var(--spacing-xs);
+}
+
+.section.xxs-padding {
+  padding: var(--spacing-xxs);
+}
+
+.section picture.section-background {
+  display: block;
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+}
+
+.section .section-background img {
+  object-fit: cover;
+  height: 100%;
+  width: 100%;
+}
+
+.section.center .content > h1,
+.section.center .content > h2,
+.section.center .content > h3,
+.section.center .content > h4,
+.section.center .content > h5,
+.section.center .content > h6,
+.section.center .content > p {
+  text-align: center;
+}
+
+.section.divider {
+  border-bottom: 1px solid #d8d8d8;
+}
+
+.section.divider-inherit {
+  border-bottom: 1px solid;
+}
+
+.section.center[class*='-up'] {
+  justify-items: center;
+}
+
+.section[class*='-up'].no-gap {
+  gap: 0;
+}
+
+.section[class*='-up'].xxs-gap {
+  gap: var(--spacing-xxs);
+}
+
+.section[class*='-up'].xs-gap {
+  gap: var(--spacing-xs);
+}
+
+.section[class*='-up'].s-gap {
+  gap: var(--spacing-s);
+}
+
+.section[class*='-up'].l-gap {
+  gap: var(--spacing-l);
+}
+
+.section[class*='-up'].xl-gap {
+  gap: var(--spacing-xl)
+}
+
+.section[class*='-up'].xxl-gap {
+  gap: var(--spacing-xxl);
+}
+
+.section[class*='-up'].xxxl-gap {
+  gap: var(--spacing-xxxl);
+}
+
+.section.two-up,
+.section.three-up,
+.section.four-up,
+.section.five-up {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(276px, 1fr));
+  gap: var(--spacing-m);
+  align-items: start;
+  padding-left: var(--grid-margins-width);
+  padding-right: var(--grid-margins-width);
+}
+
+.section.five-up {
+  grid-template-columns: repeat(auto-fit, minmax(142px, 1fr));
+}
+
+.section.sticky-top {
+  position: sticky;
+  top: 57px;
+  z-index: 1;
+  background-color: var(--color-white);
+}
+
+.section.sticky-top:has(.notification.pill) {
+  height: 0;
+}
+
+.section.sticky-bottom {
+  position: sticky;
+  bottom: 0;
+  z-index: 3;
+  background-color: var(--color-white);
+}
+
+.section.sticky-bottom.promo-sticky-section {
+  background: none;
+  z-index: 4; 
+}
+
+.section.sticky-bottom.popup,
+.section.sticky-bottom:has(.notification.pill) {
+  bottom: var(--spacing-xs);
+}
+
+.section.sticky-bottom:has(.notification.split) {
+  bottom: 5px;
+}
+
+.section[class*='grid-width-'] {
+  padding-left: var(--grid-margins-width);
+  padding-right: var(--grid-margins-width);
+  display: grid;
+  gap: var(--spacing-m);
+}
+
+.section[class*='grid-width-'] > .content,
+main > .section[class*='-up'] > .content {
+  max-width: initial;
+  margin: 0;
+}
+
+.section.masonry-layout {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: var(--spacing-s);
+  padding-left: var(--grid-margins-width);
+  padding-right: var(--grid-margins-width);
+}
+
+.section.masonry-layout > div[class*='grid-'],
+.section.masonry-layout > div[class*='grid-'] > div.fragment,
+.section.masonry-layout > div[class*='grid-'] > div.fragment > div.section {
+  display: grid;
+}
+
+.fill-sticky-section > div.notification.pill,
+.fill-sticky-section > div.aside.promobar {
+  width: 100%;
+  border-radius: 0;
+  max-width: unset;
+}
+
+/* mobile only */
+@media (max-width: 600px) {
+  .section.two-up.reverse-mobile > div:nth-child(1) {
+    order: 2;
+  }
+
+  .section.two-up.reverse-mobile > div:nth-child(2) {
+    order: 1;
+  }
+
+  .section[class*='grid-width-'] {
+    display: block;
+  }
+
+}
+
+@media screen and (min-width: 600px) and (max-width: 1200px) {
+  .section.five-up {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+  
+  .section.one-up-tablet { grid-template-columns: 1fr; }
+  .section.three-up-tablet { grid-template-columns: repeat(3, 1fr); }
+  .section.four-up-tablet { grid-template-columns: repeat(4, 1fr); }
+
+  .section.masonry-layout {
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }  
+  
+  .section.masonry-layout .grid-full-width {
+    grid-column: 1 / -1;
+  }
+}
+
+@media screen and (min-width: 720px) {
+  .section.grid-width-6 {
+    padding-left: calc((100vw - 600px) / 2);
+    padding-right: calc((100vw - 600px) / 2);
+  }
+}
+
+@media screen and (min-width: 920px) {
+  .section.grid-width-8 {
+    padding-left: calc((100vw - 800px) / 2);
+    padding-right: calc((100vw - 800px) / 2);
+  }
+}
+
+@media (min-width: 900px) {
+  .section.sticky-top {
+    top: 64px;
+  }
+}
+
+@media screen and (min-width: 1120px) {
+  .section.grid-width-10 {
+    padding-left: calc((100vw - 1000px) / 2);
+    padding-right: calc((100vw - 1000px) / 2);
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .section.two-up {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .section.three-up {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .section.four-up {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .section.five-up {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .section.grid-template-columns-1-2 {
+    grid-template-columns: 1fr 2fr;
+  }
+
+  .section.grid-template-columns-2-1 {
+    grid-template-columns: 2fr 1fr;
+  }
+
+  .section.grid-template-columns-1-3 {
+    grid-template-columns: 1fr 3fr;
+  }
+
+  .section.grid-template-columns-3-1 {
+    grid-template-columns: 3fr 1fr;
+  }
+  
+  .section.grid-width-6-desktop {
+    padding-left: var(--grid-margins-width-6);
+    padding-right: var(--grid-margins-width-6);
+  }
+  
+  .section.grid-width-8-desktop {
+    padding-left: var(--grid-margins-width-8);
+    padding-right: var(--grid-margins-width-8);
+  }
+
+  .section.grid-width-10-desktop {
+    padding-left: var(--grid-margins-width-10);
+    padding-right: var(--grid-margins-width-10);
+  }
+
+  .section.masonry-layout {
+    grid-template-columns: repeat(12, 1fr);
+  }
+
+  .section.masonry-layout .grid-full-width {grid-column: span 12; }
+  .section.masonry-layout .grid-half-width {grid-column: span 6; }
+  .section.masonry-layout .grid-span-1 {grid-column: span 1; }
+  .section.masonry-layout .grid-span-2 {grid-column: span 2; }
+  .section.masonry-layout .grid-span-3 {grid-column: span 3; }
+  .section.masonry-layout .grid-span-4 {grid-column: span 4; }
+  .section.masonry-layout .grid-span-5 {grid-column: span 5; }
+  .section.masonry-layout .grid-span-6 {grid-column: span 6; }
+  .section.masonry-layout .grid-span-7 {grid-column: span 7; }
+  .section.masonry-layout .grid-span-8 {grid-column: span 8; }
+  .section.masonry-layout .grid-span-9 {grid-column: span 9; }
+  .section.masonry-layout .grid-span-10 {grid-column: span 10; }
+  .section.masonry-layout .grid-span-11 {grid-column: span 11; }
+}

--- a/libs/mep/ace1068/section-metadata/section-metadata.js
+++ b/libs/mep/ace1068/section-metadata/section-metadata.js
@@ -1,0 +1,83 @@
+import { handleFocalpoint } from '../../../utils/decorate.js';
+
+export function handleBackground(div, section) {
+  const pic = div.background.content?.querySelector('picture');
+  if (pic) {
+    section.classList.add('has-background');
+    pic.classList.add('section-background');
+    handleFocalpoint(pic, div.background.content);
+    section.insertAdjacentElement('afterbegin', pic);
+  } else {
+    const color = div.background.content?.textContent;
+    if (color) {
+      section.style.background = color;
+    }
+  }
+}
+
+export async function handleStyle(text, section) {
+  if (!text || !section) return;
+  const styles = text.split(', ').map((style) => style.replaceAll(' ', '-'));
+  const sticky = styles.find((style) => style === 'sticky-top' || style === 'sticky-bottom');
+  if (sticky) {
+    const { default: handleStickySection } = await import('./sticky-section.js');
+    await handleStickySection(sticky, section);
+  }
+  if (styles.includes('masonry')) styles.push('masonry-up');
+  section.classList.add(...styles);
+}
+
+function handleMasonry(text, section) {
+  section.classList.add(...['masonry-layout', 'masonry-up']);
+  const divs = section.querySelectorAll(":scope > div:not([class*='metadata'])");
+  const spans = [];
+  text.split('\n').forEach((line) => spans.push(...line.trim().split(',')));
+  [...divs].forEach((div, i) => {
+    const spanWidth = spans[i] ? spans[i] : 'span 4';
+    div.classList.add(`grid-${spanWidth.trim().replace(' ', '-')}`);
+  });
+}
+
+function handleLayout(text, section) {
+  if (!(text || section)) return;
+  const layoutClass = `grid-template-columns-${text.replaceAll(' | ', '-')}`;
+  section.classList.add(layoutClass);
+}
+
+export function getDelayTime(time) {
+  if (time > 99) return time;
+  return (time * 1000);
+}
+
+function handleDelay(time, section) {
+  if (!(time || section)) return;
+  section.classList.add('hide-sticky-section');
+  setTimeout(() => { section.classList.remove('hide-sticky-section'); }, getDelayTime(time));
+}
+
+function handleAnchor(anchor, section) {
+  if (!anchor || !section) return;
+  section.id = anchor.toLowerCase().trim().replaceAll(/\s+/g, '-');
+  section.classList.add('section-anchor');
+}
+
+export const getMetadata = (el) => [...el.childNodes].reduce((rdx, row) => {
+  if (row.children) {
+    const key = row.children[0].textContent.trim().toLowerCase();
+    const content = row.children[1];
+    const text = content.textContent.trim().toLowerCase();
+    if (key && content) rdx[key] = { content, text };
+  }
+  return rdx;
+}, {});
+
+export default async function init(el) {
+  const section = el.closest('.section');
+  const metadata = getMetadata(el);
+  if (metadata.style) await handleStyle(metadata.style.text, section);
+  if (metadata.background) handleBackground(metadata, section);
+  if (metadata.layout) handleLayout(metadata.layout.text, section);
+  if (metadata.masonry) handleMasonry(metadata.masonry.text, section);
+  if (metadata.delay) handleDelay(metadata.delay.text, section);
+  if (metadata.anchor) handleAnchor(metadata.anchor.text, section);
+}

--- a/libs/mep/ace1068/section-metadata/sticky-section.js
+++ b/libs/mep/ace1068/section-metadata/sticky-section.js
@@ -16,8 +16,7 @@ function promoIntersectObserve(el, stickySectionEl, options = {}) {
         return;
       }
 
-      const { target } = entry;
-      const { isIntersecting } = entry;
+      const { target, isIntersecting } = entry;
 
       if (target === document.querySelector('footer')) {
         el.classList.toggle('fill-sticky-section', isIntersecting);

--- a/libs/mep/ace1068/section-metadata/sticky-section.js
+++ b/libs/mep/ace1068/section-metadata/sticky-section.js
@@ -45,9 +45,18 @@ function handleStickyPromobar(section, delay) {
     hasScrollControl = true;
     section.classList.remove('hide-sticky-section');
   }
+  const metadata = getMetadata(section.querySelector('.section-metadata'));
+
   if (!hasScrollControl && main.children[0] !== section) {
-    stickySectionEl = createTag('div', { class: 'section show-sticky-section' });
-    section.parentElement.insertBefore(stickySectionEl, section);
+    const isStickyAfterCTA = metadata?.style?.text.includes('sticky-after-cta');
+
+    if (isStickyAfterCTA) {
+      stickySectionEl = main.children[0].querySelector('.action-area');
+      stickySectionEl?.classList.add('show-sticky-section');
+    } else {
+      stickySectionEl = createTag('div', { class: 'section show-sticky-section' });
+      section.parentElement.insertBefore(stickySectionEl, section);
+    }
   }
   const io = promoIntersectObserve(section, stickySectionEl);
   if (stickySectionEl) io.observe(stickySectionEl);
@@ -55,7 +64,6 @@ function handleStickyPromobar(section, delay) {
     io.observe(document.querySelector('footer'));
   }
 
-  const metadata = getMetadata(section.querySelector('.section-metadata'));
   const selector = metadata?.['custom-hide']?.text;
   const targetElement = document.querySelector(selector);
   if (targetElement) {

--- a/libs/mep/ace1068/section-metadata/sticky-section.js
+++ b/libs/mep/ace1068/section-metadata/sticky-section.js
@@ -66,8 +66,9 @@ function handleStickyPromobar(section, delay) {
   const selector = metadata?.['custom-hide']?.text;
   const targetElement = document.querySelector(selector);
   if (targetElement) {
-    targetElement.classList.add('hide-at-intersection');
-    io.observe(targetElement);
+    stickySectionEl = createTag('div', { class: 'hide-at-intersection' });
+    targetElement.parentElement.insertBefore(stickySectionEl, targetElement);
+    io.observe(stickySectionEl);
   }
 }
 

--- a/libs/mep/ace1068/section-metadata/sticky-section.js
+++ b/libs/mep/ace1068/section-metadata/sticky-section.js
@@ -24,8 +24,10 @@ function promoIntersectObserve(el, stickySectionEl, options = {}) {
       } else if (target === stickySectionEl) {
         const abovePromoStart = isIntersecting || stickySectionEl?.getBoundingClientRect().y > 0;
         el.classList.toggle('hide-sticky-section', abovePromoStart);
-      } else if (target.classList.contains('hide-at-intersection')) {
-        const aboveViewport = isIntersecting || entry.boundingClientRect.top < 0;
+      } else if (target === document.querySelector('.hide-at-intersection')) {
+        const aboveViewport = isIntersecting
+        || entry.boundingClientRect.top < 0
+        || stickySectionEl?.getBoundingClientRect().y > 0;
         el.classList.toggle('hide-sticky-section', aboveViewport);
       }
     });
@@ -54,7 +56,7 @@ function handleStickyPromobar(section, delay) {
   }
 
   const metadata = getMetadata(section.querySelector('.section-metadata'));
-  const selector = metadata?.['hide-at-intersection']?.text;
+  const selector = metadata?.['custom-hide']?.text;
   const targetElement = document.querySelector(selector);
   if (targetElement) {
     targetElement.classList.add('hide-at-intersection');
@@ -66,7 +68,7 @@ export default async function handleStickySection(sticky, section) {
   const main = document.querySelector('main');
   switch (sticky) {
     case 'sticky-top': {
-      const { debounce } = await import('../../utils/action.js');
+      const { debounce } = await import('../../../utils/action.js');
       window.addEventListener('resize', debounce(() => handleTopHeight(section)));
       handleTopHeight(section);
       main.prepend(section);

--- a/libs/mep/ace1068/section-metadata/sticky-section.js
+++ b/libs/mep/ace1068/section-metadata/sticky-section.js
@@ -1,0 +1,88 @@
+import { createTag } from '../../../utils/utils.js';
+import { getMetadata, getDelayTime } from './section-metadata.js';
+import { getGnavHeight } from '../../../blocks/global-navigation/utilities/utilities.js';
+
+function handleTopHeight(section) {
+  const topHeight = getGnavHeight();
+  section.style.top = `${topHeight}px`;
+}
+
+function promoIntersectObserve(el, stickySectionEl, options = {}) {
+  return new IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => {
+      if (el.classList.contains('close-sticky-section')) {
+        window.removeEventListener('resize', handleTopHeight);
+        observer.unobserve(entry.target);
+        return;
+      }
+
+      const { target } = entry;
+      const { isIntersecting } = entry;
+
+      if (target === document.querySelector('footer')) {
+        el.classList.toggle('fill-sticky-section', isIntersecting);
+      } else if (target === stickySectionEl) {
+        const abovePromoStart = isIntersecting || stickySectionEl?.getBoundingClientRect().y > 0;
+        el.classList.toggle('hide-sticky-section', abovePromoStart);
+      } else if (target.classList.contains('hide-at-intersection')) {
+        const aboveViewport = isIntersecting || entry.boundingClientRect.top < 0;
+        el.classList.toggle('hide-sticky-section', aboveViewport);
+      }
+    });
+  }, options);
+}
+
+function handleStickyPromobar(section, delay) {
+  const main = document.querySelector('main');
+  section.classList.add('promo-sticky-section', 'hide-sticky-section');
+  if (section.querySelector('.popup:is(.promobar)')) section.classList.add('popup');
+  let stickySectionEl = null;
+  let hasScrollControl;
+  if ((section.querySelector(':is(.promobar, .notification)').classList.contains('no-delay'))
+    || (delay && section.classList.contains('popup'))) {
+    hasScrollControl = true;
+    section.classList.remove('hide-sticky-section');
+  }
+  if (!hasScrollControl && main.children[0] !== section) {
+    stickySectionEl = createTag('div', { class: 'section show-sticky-section' });
+    section.parentElement.insertBefore(stickySectionEl, section);
+  }
+  const io = promoIntersectObserve(section, stickySectionEl);
+  if (stickySectionEl) io.observe(stickySectionEl);
+  if (section.querySelector(':is(.promobar, .notification)')) {
+    io.observe(document.querySelector('footer'));
+  }
+
+  const metadata = getMetadata(section.querySelector('.section-metadata'));
+  const selector = metadata?.['hide-at-intersection']?.text;
+  const targetElement = document.querySelector(selector);
+  if (targetElement) {
+    targetElement.classList.add('hide-at-intersection');
+    io.observe(targetElement);
+  }
+}
+
+export default async function handleStickySection(sticky, section) {
+  const main = document.querySelector('main');
+  switch (sticky) {
+    case 'sticky-top': {
+      const { debounce } = await import('../../utils/action.js');
+      window.addEventListener('resize', debounce(() => handleTopHeight(section)));
+      handleTopHeight(section);
+      main.prepend(section);
+      break;
+    }
+    case 'sticky-bottom': {
+      if (section.querySelector(':is(.promobar, .notification)')) {
+        const metadata = getMetadata(section.querySelector('.section-metadata'));
+        const delay = getDelayTime(metadata.delay?.text);
+        if (delay) setTimeout(() => { handleStickyPromobar(section, delay); }, delay);
+        else handleStickyPromobar(section, delay);
+      }
+      main.append(section);
+      break;
+    }
+    default:
+      break;
+  }
+}


### PR DESCRIPTION
Designed for mobile. Works on all break points.

- Adds marquee H1 typography variant.
- Adds sticky notification 100% width button(s) variant to match Figma mock.
- Adds sticky notification hide-at-intersection metadata and intersection observer functionality. 

Update:
- Adds marquee styles to match Figma designs.
![image](https://github.com/user-attachments/assets/ebd44205-6f5e-460b-ac49-32d3caf91a23)

Using the the All experience compare to figma mock or charter:

1. Check marquee layout var1 and var2 on both pages.
2. Check sticky notification stretched sticky button.
3. Check that sticky notification hides at the selector main > div:nth-child(6) (Get Lightroom section) and below, then reappears above.
4. Verify that no other scroll/hide functionality breaks; IE should hide when marquee is in viewport.

Resolves: https://jira.corp.adobe.com/browse/OPT-32422
Figma: https://www.figma.com/design/UuRhSbHGPLy4nLJaurTR84/Mobile-SSOT---Hard-file?node-id=820-175168&p=f&t=vbPCDaeWSCyhtzJW-0

**Test URLs:**
QA Links: 

https://main--cc--adobecom.aem.page/products/photoshop-lightroom?target=on&milolibs=ace1068sticky&at_preview_token=afKNsfkAEIEOKEioBWIWYQ&at_preview_index=1_2&at_preview_listed_activities_only=true&at_preview_evaluate_as_true_audience_ids=7559079

https://main--cc--adobecom.aem.page/products/photoshop-lightroom/mobile?target=on&milolibs=ace1068sticky&at_preview_token=afKNsfkAEIEOKEioBWIWYQ&at_preview_index=1_2&at_preview_listed_activities_only=true&at_preview_evaluate_as_true_audience_ids=7559079

Psi check: https://ace1068sticky--milo--adobecom.hlx.live/&martech=off














