### PR TITLE
Upgrading package version for bundled Gnav to 0.0.8

### DIFF
--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",


### PR DESCRIPTION
Upgrading package version for bundled Gnav to 0.0.8

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-version--milo--adobecom.aem.page/?martech=off

Test Url - https://adobecom.github.io/nav-consumer/?authoringpath=/federal/home&theme=dark&usebundle=true


