### PR TITLE
Fix for text overflow in mobile gnav's tab content in landscape mode

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1387,3 +1387,11 @@ html:has(body.disable-ios-scroll) { /* this class is only added on iOS */
   position: relative;
   display: block;
 }
+
+/* Landscape mode for mobile */
+@media (orientation: landscape) and (max-width: 900px) {
+  header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tabs button {
+    padding: 15px 11px 15px 20px;
+    min-height: max-content;
+  }
+}


### PR DESCRIPTION
Fix for text overflow in landscape mode

<!-- Before submitting, please review all open PRs. -->

* Mobile gnav's tab content in landscape was overflowing if it is beyond 2 lines. After the fix the content will be visible and the tab area will scroll vertically.

Resolves: [MWPW-166845](https://jira.corp.adobe.com/browse/MWPW-166845)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-landscape--milo--adobecom.aem.page/?martech=off

QA: https://main--cc--adobecom.hlx.page/uk/products/elements-family?milolibs=gnav-landscape