### PR TITLE
MWPW-170630 Fix table link line break

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -363,6 +363,12 @@ function handleSection(sectionParams) {
     }
   } else if (!row.classList.contains('row-1') && (!isHighlightTable || !row.classList.contains('row-2'))) {
     row.classList.add('section-row');
+    rowCols.forEach((col) => {
+      if (col.querySelector('a') && !col.querySelector('span')) {
+        const textSpan = createTag('span', { class: 'col-text' }, [...col.childNodes]);
+        col.appendChild(textSpan);
+      }
+    });
     if (isMerch && !row.classList.contains('divider')) {
       rowCols.forEach((merchCol) => {
         merchCol.classList.add('col-merch');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fix line break issues with long content with links in tables

Resolves: [MWPW-170630](https://jira.corp.adobe.com/browse/MWPW-170630)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/docs/library/kitchen-sink/table?martech=off
- After: https://bmarshal-table-links--milo--adobecom.aem.live/docs/library/kitchen-sink/table?martech=off

**BACOM URLs:**
- Before: https://main--da-bacom-blog--adobecom.aem.page/drafts/bmarshal/scope-creep?martech=off
- After: https://main--da-bacom-blog--adobecom.aem.page/drafts/bmarshal/scope-creep?martech=off&milolibs=bmarshal-table-links
- Before: https://main--da-bacom-blog--adobecom.aem.live/drafts/bmarshal/table?martech=off
- After: https://main--da-bacom-blog--adobecom.aem.live/drafts/bmarshal/table?martech=off&milolibs=bmarshal-table-links



