### PR TITLE
Fix(MWPW-170755): Japanese word wrap bug fix

### DIFF
--- a/libs/features/japanese-word-wrap.js
+++ b/libs/features/japanese-word-wrap.js
@@ -134,6 +134,7 @@ export async function applyJapaneseLineBreaks(config, options = {}) {
       budouxExcludeElements.has(el)
       || isWordWrapApplied(el)
       || (isFirefox() && hasFlexOrGrid(el))
+      || (el.lang && el?.lang != 'ja')
     ) return;
     parser.applyElement(el, { threshold: budouxThres });
   });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Japanese word wrap feature isolated to jp locales.

Resolves: [MWPW-170755](https://jira.corp.adobe.com/browse/MWPW-170755)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-170755--milosh--sharath-kannan.aem.page/?martech=off

https://main--cc--adobecom.hlx.page/jp/creativecloud?milolibs=mwpw-170755--milosh--sharath-kannan