### PR TITLE
MWPW-171967 Support for placeholders-stage

### DIFF
--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -11,7 +11,7 @@ const getPlaceholdersPath = (config, sheet) => {
 
 const parsePlaceholderJson = async (resp, placeholders) => {
   const json = resp.ok ? await resp.json() : { data: [] };
-  if (json.data.length === 0) return;
+  if (!json.data.length) return;
   json.data.forEach((item) => {
     window.mph[item.key] = item.value;
     placeholders[item.key] = item.value;
@@ -27,10 +27,8 @@ const fetchPlaceholder = (path, placeholderRequest) => new Promise(
     const placeholders = {};
 
     if (Array.isArray(resp)) {
-      // Process sequentially, later ones override earlier ones
-      for (const r of resp) {
-        await parsePlaceholderJson(r, placeholders);
-      }
+      // Overlay placeholders
+      for (const r of resp) await parsePlaceholderJson(r, placeholders);
     } else {
       await parsePlaceholderJson(resp, placeholders);
     }

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -9,22 +9,46 @@ const getPlaceholdersPath = (config, sheet) => {
   return `${path}${query}`;
 };
 
-const fetchPlaceholders = async ({ config, sheet, placeholderRequest, placeholderPath }) => {
-  const path = placeholderPath || getPlaceholdersPath(config, sheet);
+const parsePlaceholderJson = async (resp, placeholders) => {
+  const json = resp.ok ? await resp.json() : { data: [] };
+  if (json.data.length === 0) return;
+  json.data.forEach((item) => {
+    window.mph[item.key] = item.value;
+    placeholders[item.key] = item.value;
+  });
+};
+
+const fetchPlaceholder = (path, placeholderRequest) => new Promise(
   // eslint-disable-next-line no-async-promise-executor
-  fetchedPlaceholders[path] = fetchedPlaceholders[path] || new Promise(async (resolve) => {
+  async (resolve) => {
     const resp = await placeholderRequest || await customFetch(
       { resource: path, withCacheRules: true },
     ).catch(() => ({}));
-    const json = resp.ok ? await resp.json() : { data: [] };
-    if (json.data.length === 0) { resolve({}); return; }
     const placeholders = {};
-    json.data.forEach((item) => {
-      window.mph[item.key] = item.value;
-      placeholders[item.key] = item.value;
-    });
+
+    if (Array.isArray(resp)) {
+      // Process sequentially, later ones override earlier ones
+      for (const r of resp) {
+        await parsePlaceholderJson(r, placeholders);
+      }
+    } else {
+      await parsePlaceholderJson(resp, placeholders);
+    }
+
     resolve(placeholders);
-  });
+  },
+);
+
+const fetchPlaceholders = async ({
+  config,
+  sheet,
+  placeholderRequest,
+  placeholderPath,
+}) => {
+  const path = placeholderPath || getPlaceholdersPath(config, sheet);
+
+  fetchedPlaceholders[path] ||= fetchPlaceholder(path, placeholderRequest);
+
   return fetchedPlaceholders[path];
 };
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1068,28 +1068,26 @@ const findReplaceableNodes = (area) => {
   return nodes;
 };
 
-let placeholderRequest;
 function getPlaceholderPaths(config) {
-  const rootPath = `${config.locale?.contentRoot}/placeholders`;
-  const placeholderPaths = [`${rootPath}.json`];
-  if (config.env.name !== 'prod') {
-    placeholderPaths.push(`${rootPath}-stage.json`);
-  }
-  return placeholderPaths;
+  const root = `${config.locale?.contentRoot}/placeholders`;
+  const paths = [`${root}.json`];
+  if (config.env.name !== 'prod') paths.push(`${root}-stage.json`);
+  return paths;
 }
 
+let placeholderRequest;
 export async function decoratePlaceholders(area, config) {
   if (!area) return;
   const nodes = findReplaceableNodes(area);
   if (!nodes.length) return;
   area.dataset.hasPlaceholders = 'true';
-  const placeholderPaths = getPlaceholderPaths(config);
+  const phPaths = getPlaceholderPaths(config);
   placeholderRequest ||= Promise.all(
-    placeholderPaths.map((path) => customFetch({ resource: path, withCacheRules: true })),
+    phPaths.map((path) => customFetch({ resource: path, withCacheRules: true })),
   ).catch(() => ({}));
   const { decoratePlaceholderArea } = await import('../features/placeholders.js');
   await decoratePlaceholderArea({
-    placeholderPath: placeholderPaths[0],
+    placeholderPath: phPaths[0],
     placeholderRequest,
     nodes,
   });


### PR DESCRIPTION
When on non-prod sites, placeholder code will also look for a placeholders-stage.json and overlay those values on top of the placeholders.json values.

NOTE: This only adds support for stage placeholders for regular placeholders.  Feds and Pallet support will have to be done in another PR

**Implementation Details:**
In utils.js `decoratePlaceholders` used to fetch a single path to the placeholders file and initiate a fetch request that's passed into placeholders.js `decoratePlaceholderArea` function.  This is to start the load of the placeholders file before loading placeholders.js

Now `decoratePlaceholders` will check if on a stage env and start the fetch of both the placeholders.json and placeholders-stage.json.  Those are combined in a Promise.all  and passed to `decoratePlaceholderArea`.  Since the placeholder files get combined, only the prod placeholder path is passed in.

In placeholders.js `fetchPlaceholder` when the `placeholderRequest` is resolved we now check if the return value is an array, which means that we have 2 files that need to be combined.  Since prod is first and -stage is 2nd, when stage is processed it adds/overrides values from placeholders.json.

Resolves: [MWPW-171967](https://jira.corp.adobe.com/browse/MWPW-171967)

Pages below use the milo /placeholders.json and /placeholders-stage.json files.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/cpeyer/test?martech=off
- After: https://stage-placeh--milo--adobecom.aem.page/drafts/cpeyer/test?martech=off










