### PR TITLE
[OPT-31767] MEP test: Add dark-table class for the emea1441 test

### DIFF
--- a/libs/mep/emea1441/table/README.md
+++ b/libs/mep/emea1441/table/README.md
@@ -1,0 +1,210 @@
+# Table
+
+## Block variant
+* `sticky`
+* `highlight`
+* `merch`
+* `collapse`
+
+
+### `sticky`
+* To enable sticky header.
+
+### `highlight`
+* If enabled, the first row below the table header is reserved for highlights, and the second row is reserved for table headings.
+```
+_______________________________________________________
+| Table (highlight)                                   |
+|_____________________________________________________|
+| Highlight-1     | Highlight-2     |                 |
+|_________________|_________________|_________________|
+| Heading Title-1 | Heading Title-2 | Heading Title-3 |
+| Pricing-1       | Pricing-2       | Pricing-3       |
+| Buttons-1       | Buttons-2       | Buttons-3       |
+|_________________|_________________|_________________|
+
+```
+
+* If not enabled, the first row below the table header is reserved for table headings.
+```
+_______________________________________________________
+| Table                                               |
+|_____________________________________________________|
+| Heading Title-1 | Heading Title-2 | Heading Title-3 |
+| Pricing-1       | Pricing-2       | Pricing-3       |
+| Buttons-1       | Buttons-2       | Buttons-3       |
+|_________________|_________________|_________________|
+
+```
+### `merch`
+* Each column will be displayed as a separate table.
+
+### `collapse`
+* A plus/minus icon will automatically be added next to the Section Title, allowing the sections to expand/collapse.
+* The first section is always expanded by default.
+* It is disabled for merch tables.
+
+
+## Block Configuration
+
+### Standard Table
+```
+__________________________________________________________________________
+| Table (sticky, highlight, collapse)                                    |
+|________________________________________________________________________|
+|                  | Highlight-2     |                 | Highlight-4     |
+|__________________|_________________|_________________|_________________|
+|                  | Heading Title-2 | Heading Title-3 | Heading Title-4 |
+|                  | Pricing-2       | Pricing-3       | Pricing-4       |
+|                  | Buttons-2       | Buttons-3       | Buttons-4       |
+|__________________|_________________|_________________|_________________|
+|---               |                 |                 |                 |
+|__________________|_________________|_________________|_________________|
+| Section-1, Title |                 |                 |                 |
+|__________________|_________________|_________________|_________________|
+| Row-1.1, Title   | Content         | Content         | Content         |
+|__________________|_________________|_________________|_________________|
+| Row-1.2, Title   | Content         | Content         | Content         |
+|__________________|_________________|_________________|_________________|
+|---               |                 |                 |                 |
+|__________________|_________________|_________________|_________________|
+| Section-2, Title |                 |                 |                 |
+|__________________|_________________|_________________|_________________|
+| Row-2.1, Title   | Content         | Content         | Content         |
+|__________________|_________________|_________________|_________________|
+| Row-2.2, Title   | Content         | Content         | Content         |
+|__________________|_________________|_________________|_________________|
+
+```
+
+### Merch Table
+```
+___________________________________________________________________
+| Table (merch, sticky, highlight)                                |
+|_________________________________________________________________|
+|                     | Highlight-2         |                     |
+|_____________________|_____________________|_____________________|
+| Images-1            | Images-2            | Images-3            |
+| Heading Title-1     | Heading Title-2     | Heading Title-3     |
+| Pricing-1           | Pricing-2           | Pricing-3           |
+| Additional Text-1   | Additional Text-2   | Additional Text-3   |
+| Buttons-1           | Buttons-3           | Buttons-3           |
+|_____________________|_____________________|_____________________|
+|---                  |                     |                     |
+|_____________________|_____________________|_____________________|
+| Section-1, Title    | Section-1, Title    | Section-1, Title    |
+|____________________ |_____________________|_____________________|
+| Section Content-1.1 | Section Content-1.1 | Section Content-1.1 |
+|_____________________|_____________________|_____________________|
+| Section Content-1.2 | Section Content-1.2 | Section Content-1.2 |
+|_____________________|____________________ |_____________________|
+|---                  |                     |                     |
+|_____________________|_____________________|_____________________|
+| Section-2, Title    | Section-2, Title    | Section-2, Title    |
+|_____________________|_____________________|_____________________|
+| Section Content-2.1 | Section Content-2.1 | Section Content-2.1 |
+|_____________________|_____________________|_____________________|
+| Section Content-2.2 | Section Content-2.2 | Section Content-2.2 |
+|_____________________|_____________________|_____________________|
+
+```
+## Headings in Table
+* The first text element in the heading column is always the title.
+* The only element(s) that can be added before the title are images.
+* The second element is reserved for pricing.
+* Every additional content after the pricing will be formatted regularly.
+* Buttons will always be displayed at the bottom of the column cell.
+
+
+## Sections in Table
+* Sections are separated by '---'.
+* The first row in a section is the Section Title.
+* The rest of the rows within the section will be considered as section content.
+
+
+## Table metadata
+It is an optional feature for customizing colors on the table instead of using default colors.
+
+Colors can be set in two ways:
+* For all columns in a row - by passing just the color without specifying the column number.
+* For each column separately - by passing the specific column number and color.
+
+The following two options are available for text color:
+* light/white
+* dark
+
+For the background color, it is possible to use the following ways of specifing colors:
+* Keywords
+* Hexadecimal colors
+* Hexadecimal colors with transparency
+* RGB colors
+* RGBA colors
+* HSL colors
+* HSLA colors
+* Gradients
+
+```
+Example:
+_____________________________________________________________________________________________________________
+| Table Metadata                                                                                            |
+|___________________________________________________________________________________________________________|
+| Highlight color             | light                                                                       |
+|___________________________________________________________________________________________________________|
+| Highlight background  color | #232323                                                                     |
+|___________________________________________________________________________________________________________|
+| Heading color               | 1, light                                                                    |
+|                             | 2, dark                                                                     |
+|___________________________________________________________________________________________________________|
+| Heading background color    | 1, #d16971                                                                  |
+|                             | 3, linear-gradient(256.69deg, #E3F1FE 4.12%, #A1CDF9 42.35%, #6BA6F0 98.9%) |
+|___________________________________________________________________________________________________________|
+
+```
+
+
+## Behaviors
+
+### Standard Table
+
+#### Mobile (0 - 768px)
+* Only 2 columns will be visible. By default, the first 2 columns with a filled heading column will be displayed. The user can then select, from the select box, which two columns they want to see.
+
+#### Tablet (769px - 899px) and Desktop (900px - ∞)
+* Each column will be visible.
+
+### Merch Table
+
+#### Mobile (0 - 768px) and Tablet (769px - 899px)
+* Only 2 columns will be visible. By default, the first 2 columns with a filled heading column will be displayed. The user can then select, from the select box, which two columns they want to see.
+
+#### Desktop (900px - ∞)
+* Each column will be visible.
+
+
+## User Experience
+
+### Standard Table
+* Default colors, without passing Table Metadata:
+
+<img width="425" alt="Screenshot 2023-06-12 at 12 50 28" src="https://github.com/draganatrajkovic/milo/assets/65951679/1e293b4c-b71a-4aaa-8c84-1ebd1051e916">
+
+* Customized colors by Table Matadata:
+
+<img width="425" alt="Screenshot 2023-06-12 at 13 14 20" src="https://github.com/draganatrajkovic/milo/assets/65951679/6a74cc24-4e20-42cb-9156-c2128a591650">
+
+* Mobile screen:
+
+<img width="284" alt="Screenshot 2023-06-12 at 13 21 45" src="https://github.com/draganatrajkovic/milo/assets/65951679/6d1567cd-1f57-41ea-9717-d542125b8e76">
+
+### Merch Table
+* Default colors, without passing Table Metadata:
+
+<img width="425" alt="Screenshot 2023-06-12 at 12 57 24" src="https://github.com/draganatrajkovic/milo/assets/65951679/f43e24bc-6acf-4294-9d3a-cbf04908daca">
+
+* Customized colors by Table Matadata:
+
+<img width="425" alt="Screenshot 2023-06-12 at 13 12 02" src="https://github.com/draganatrajkovic/milo/assets/65951679/ac820c7f-d2a4-44cb-b71d-482f752de95c">
+
+* Mobile screen:
+
+<img width="369" alt="Screenshot 2023-06-12 at 13 20 00" src="https://github.com/draganatrajkovic/milo/assets/65951679/fda0baa8-9781-4974-b467-09807e6aefc6">

--- a/libs/mep/emea1441/table/table.css
+++ b/libs/mep/emea1441/table/table.css
@@ -1,0 +1,834 @@
+.table,
+.table.merch {
+  --border-color: #DADADA;
+  --highlight-background: #F3D949;
+  --hover-border-color: #357BEB;
+  --checkmark-color: #2C2C2C;
+  --border-radius: 16px;
+
+  max-width: 1200px;
+  margin: auto;
+  padding: 20px 0;
+  border-color: var(--border-color);
+}
+
+.table.dark-table,
+.table.merch.dark-table {
+  --border-color: #393939;
+}
+
+.section[class *= "grid-width-"] .table {
+  width: 100%;
+}
+
+.table a:not([class*="button"]) {
+  display: inline-block;
+}
+
+.table > .row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(50%, 1fr));
+}
+
+.table .col {
+  display: flex;
+  flex-wrap: wrap;
+  min-height: 27px;
+  border-left: 1px var(--border-color) solid;
+  border-right: 1px solid transparent;
+  border-top: 1px var(--border-color) solid;
+  background-color: var(--color-white);
+}
+
+.table.dark-table .col {
+  background-color: #1E1E1E;
+  color: var(--color-white);
+}
+
+.table .col.section-row-title {
+  flex-wrap: nowrap;
+}
+
+.table .section-row .col {
+  align-items: center;
+}
+
+.table:not(.left, .header-left) .col{
+  justify-content: center;
+}
+
+.table.top .section-row .col {
+  flex-direction: column;
+  justify-content: start;
+}
+
+.table.top.left .section-row .col {
+  align-items: start;
+}
+
+.table:not(.merch) .col-1:not(:only-child) {
+  background-color: var(--color-gray-100);
+}
+
+.table.dark-table:not(.merch) .col-1:not(:only-child) {
+  background-color: #080808;
+}
+
+.table .col:last-child {
+  border-right: 1px var(--border-color) solid;
+}
+
+.table .row:last-child .col {
+  border-bottom: 1px var(--border-color) solid;
+}
+
+.table .col,
+.table .col p {
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+}
+
+.table .col p {
+  margin: 0;
+}
+
+.table .col p picture {
+  margin-right: 8px;
+}
+
+.section.table-section,
+.section.table-merch-section {
+  background: var(--color-white);
+}
+
+.table.sticky,
+.table.sticky .row-1,
+.table.sticky .row-heading {
+  background: inherit;
+}
+
+.table.merch .col {
+  border-top: 1px var(--border-color) solid;
+  border-left: 1px var(--border-color) solid;
+  border-right: 1px var(--border-color) solid;
+}
+
+.table.merch .col.border-bottom {
+  border-bottom: 1px var(--border-color) solid;
+}
+
+.table .row-highlight .col.col-highlight {
+  border-color: transparent;
+}
+
+.table.collapse .section-head-collaped .col {
+  border-bottom: 1px var(--border-color) solid;
+}
+
+/* highlight */
+.table .row-highlight .col-highlight {
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+  background-color: var(--highlight-background);
+  border: 1px solid var(--highlight-background);
+  padding: 10px 30px;
+  text-transform: capitalize;
+  border-top-right-radius: var(--border-radius);
+  border-top-left-radius: var(--border-radius);
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.table.dark-table .row-highlight .col-highlight {
+  background-color: #f7ce46;
+  color: #000;
+}
+
+.table .row-highlight .col-highlight.hidden {
+  visibility: hidden;
+}
+
+/* heading */
+.table .col-heading.hidden {
+  border-top: none !important;
+  border-left: none !important;
+  border-right: none !important;
+  border-radius: 0 !important;
+}
+
+.table .col-heading:first-child {
+  border-top-left-radius: var(--border-radius);
+}
+
+[dir="rtl"] .table .col-heading:first-child {
+  border-top-left-radius: 0;
+  border-top-right-radius: var(--border-radius);
+}
+
+.table .col-heading:last-child {
+  border-top-right-radius: var(--border-radius);
+}
+
+[dir="rtl"] .table .col-heading:last-child {
+  border-top-right-radius: 0;
+  border-top-left-radius: var(--border-radius);
+}
+
+.table .row-heading .col-heading.col.no-rounded,
+[dir="rtl"] .table .row-heading .col-heading.col.no-rounded {
+  border-radius: 0;
+}
+
+.table.merch .col-heading:not(.no-rounded),
+[dir="rtl"] .table.merch .col-heading:not(.no-rounded) {
+  border-radius: var(--border-radius) var(--border-radius) 0 0;
+}
+
+.table.m-heading-icon .row-heading .col-heading img {
+  height: var(--icon-size-m);
+  width: auto;
+}
+
+.table .section-row .col.section-row-title,
+.table .section-row .col.section-row-title p {
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+}
+
+.table:not(.merch):not(.left, .header-left) .section-row .col:not(.section-row-title),
+.table .row-heading .col.col-heading {
+  text-align: center;
+}
+
+.table .row-heading .col.col-heading {
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.table .row-heading .col.col-heading .buttons-wrapper {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.table.header-left .row-heading .col.col-heading {
+  text-align: start;
+  padding: var(--spacing-s);
+}
+
+.table:not(.merch) .row-heading .col.col-heading .action-area {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+}
+
+.table.header-left .row-heading .col.col-heading .buttons-wrapper {
+  justify-content: flex-start;
+}
+
+.table.button-right.merch .row-heading .col.col-heading .buttons-wrapper {
+  justify-content: flex-end;
+}
+
+.table.merch.button-right .row-heading .col.col-heading .buttons-wrapper > * {
+  margin: 12px 0 12px 12px;
+}
+
+.table .row-heading .col.col-heading .buttons-wrapper > * {
+  margin: 10px 6px;
+}
+
+.table.header-left .row-heading .col.col-heading .buttons-wrapper > * {
+  margin-inline-start: 0;
+}
+
+.table.dark-table .con-button.outline {
+  border-color: #fff;
+  color: #fff;
+}
+
+.table.dark-table .con-button.outline:hover {
+  background-color: #fff;
+  color: #000;
+}
+
+.table .row-heading .col-heading .header-product-tile {
+  display: inline-flex;
+  gap: var(--spacing-xxs);
+  justify-content: center;
+}
+
+.table.header-left .row-heading .col-heading .header-product-tile {
+  justify-content: flex-start;
+}
+
+.table .row-heading .col-heading .header-product-tile picture {
+  display: flex;
+  margin: 0;
+}
+
+.table .row-heading .col-heading .tracking-header {
+  font-size: var(--type-heading-s-size);
+  line-height: var(--type-heading-s-lh);
+  font-weight: bold;
+  padding: var(--spacing-xxs) 0;
+}
+
+.table .row-heading .col-heading .pricing {
+  font-size: var(--type-heading-m-size);
+  line-height: var(--type-heading-m-lh);
+  font-weight: bold;
+  padding: var(--spacing-xxs) 0;
+}
+
+.table .row-heading .col-heading .pricing .price-strikethrough {
+  display: inline-block;
+  font-size: var(--type-body-s-size);
+}
+
+/* section */
+.table .divider {
+  display: none;
+}
+
+.table .section-head .col {
+  background-color: var(--color-gray-100);
+  padding: 24px;
+}
+
+.table.dark-table .section-head .col {
+  background-color: #080808;
+}
+
+.table .section-row .col {
+  padding: 16px 24px;
+  column-gap: 0.5ch;
+}
+
+.table .section-row .col:has(> p:nth-child(2)) {
+  flex-direction: column;
+}
+
+.table.left .section-row .col:has(> p:nth-child(2)),
+.table.header-left .section-row .col:has(> p:nth-child(2)) {
+  align-items: flex-start;
+}
+
+.table .section-head-title.point-cursor {
+  cursor: pointer;
+}
+
+.table .section-head .section-head-title > :not(.icon) {
+  font-size: var(--type-body-m-size);
+  line-height: var(--type-heading-s-lh);
+  width: calc(100% - 25px);
+}
+
+.table .section-head .section-head-title,
+.table .section-row .section-row-title,
+.table .section-row .section-row-title .table-title-row,
+.table.merch .section-head .col-merch,
+.table.merch .section-row .col-merch {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.table.collapse .section-row.hidden {
+  display: none;
+}
+
+.table:not(.merch) .section-head > :not(:first-child) {
+  border-left-color: transparent;
+}
+
+.table:not(.merch) .section-head > :not(:last-child) {
+  border-right-color: transparent;
+}
+
+.table .light {
+  color: var(--color-white);
+}
+
+/* icons */
+.table:not(.merch) .row .col span.milo-tooltip {
+  margin-right: -4px;
+}
+
+[dir='rtl'] .table:not(.merch) .row .col span.milo-tooltip {
+  margin-right: 0;
+  margin-left: -4px;
+}
+
+.table span[data-tooltip] .icon-milo {
+  height: 16px;
+}
+
+.table span[data-tooltip] .icon-milo:hover {
+  cursor: pointer;
+}
+
+.table span[data-tooltip] .icon-milo:hover path,
+.table span[data-tooltip] .active .icon-milo path {
+  color: var(--hover-border-color);
+}
+
+.table .icon-milo-checkmark {
+  color: var(--checkmark-color);
+  width: 21px;
+  height: 100%;
+}
+
+.table.dark-table .icon-milo-checkmark {
+  color: var(--color-white);
+}
+
+.table .icon.expand {
+  background-color: transparent;
+  border: 0;
+  background-image: url('../../ui/img/chevron-wide-black.svg');
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 12px;
+  aspect-ratio: 1.7;
+  cursor: pointer;
+  rotate: -90deg;
+  background-size: contain;
+}
+
+[dir="rtl"] .table .icon.expand {
+  rotate: 90deg;
+}
+
+.table .section-head-title:hover .icon.expand {
+  filter: invert(41%) sepia(22%) saturate(100) hue-rotate(203deg) brightness(96%) contrast(93%);
+}
+
+.table .icon.expand[aria-expanded=true] {
+  rotate: unset;
+}
+
+.table .row-highlight .col-highlight.transparent-border {
+  border-color: transparent;
+}
+
+.table.dark-table .col a:not(.con-button) {
+  color: var(--color-white);
+}
+
+/* rtl */
+[dir="rtl"] .table .col {
+  border-right: 1px var(--border-color) solid;
+  border-left: 1px solid transparent;
+}
+
+[dir="rtl"] .table.merch .col {
+  border-left: 1px var(--border-color) solid;
+}
+
+[dir="rtl"] .table .col:first-child {
+  border-right: 1px var(--border-color) solid;
+}
+
+[dir="rtl"] .table .col:last-child:not(.hover) {
+  border-left: 1px var(--border-color) solid;
+}
+
+[dir="rtl"] .table.merch .col-merch .col-merch-content picture {
+  margin-right: 0;
+  margin-left: 16px;
+}
+
+/* hover */
+@media (min-width: 900px) {
+  .table .col.hover {
+    border-left: 1px solid var(--hover-border-color);
+    border-right: 1px solid var(--hover-border-color);
+  }
+
+  .table .row-highlight .col-highlight {
+    border-top-color: transparent;
+    border-left-color: transparent;
+    border-right-color: transparent;
+  }
+
+  .table .row-highlight .col-highlight.hover {
+    border-top: 1px solid var(--hover-border-color);
+    border-left: 1px solid var(--hover-border-color);
+    border-right: 1px solid var(--hover-border-color);
+  }
+
+  .table .row-heading .col-heading.hover {
+    border-top: 1px solid var(--hover-border-color);
+  }
+
+  .table .row:last-child .col.hover,
+  .table .col.hover.hover-border-bottom {
+    border-bottom: 1px solid var(--hover-border-color);
+  }
+
+  .table .col.no-top-border.hover {
+    border-top-color: var(--border-color);
+  }
+
+  .table .section-head .col.hover {
+    border-right: 1px solid var(--hover-border-color);
+    border-left: 1px solid var(--hover-border-color);
+  }
+
+  .table .row:not(.section-head) .col:not(.col-highlight):not(.hidden).hover {
+    background-color: var(--color-gray-100);
+  }
+
+  .table.dark-table .row:not(.section-head) .col:not(.col-highlight):not(.hidden).hover {
+    background-color: #080808;
+  }
+
+  .table.merch .col.hover {
+    border-left: 1px solid var(--hover-border-color);
+    border-right: 1px solid var(--hover-border-color);
+  }
+
+  .table.merch .col.border-bottom.hover {
+    border-bottom: 1px solid var(--hover-border-color);
+  }
+}
+
+.table.has-addon .row-heading .col.col-heading:not(.col-1) {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--spacing-xxs);
+  padding: var(--spacing-xs);
+}
+
+.table.has-addon .row-heading .col.col-heading:not(.col-1) .buttons-wrapper {
+  align-items: flex-end;
+}
+
+.table.has-addon p.body {
+  font-size: var(--type-body-xxs-size);
+  line-height: var(--type-body-xxs-lh);
+  margin-bottom: var(--spacing-xxs);
+}
+
+.table.has-addon .addon-label {
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  border-radius: 4px;
+  display: flex;
+  align-items: start;
+  flex-direction: row;
+  text-align: start;
+  font-style: normal;
+  font-weight: 400;
+  color: black;
+  padding: 5px 10px;
+  box-sizing: border-box;
+}
+
+.table.has-addon .addon-label:not(:empty) {
+  background-color: var(--color-gray-300);
+}
+
+.table.has-addon .addon-label .icon {
+  display: flex;
+  align-self: center;
+}
+
+.table.has-addon .addon-label .icon,
+.table.has-addon span[data-tooltip] .active .icon-milo path {
+  color: black;
+}
+
+.table.has-addon .pricing-before,
+.table.has-addon .pricing-after {
+  min-height: 21px;
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+}
+
+.table.has-addon .pricing-after {
+  margin-bottom: var(--spacing-xxs);
+}
+
+.table.has-addon .pricing.has-pricing-before {
+  padding-top: 0;
+}
+
+.table.has-addon .pricing.has-pricing-after {
+  padding-bottom: 0;
+}
+
+.table.has-addon .table-title-text blockquote,
+.table.has-addon .table-title-text code {
+  font-family: var(--body-font-family);
+  background-color: var(--color-gray-300);
+  padding: 2px 10px;
+  border-radius: 4px;
+  margin: 0;
+  margin-bottom: var(--spacing-xxs);
+  display: inline-block;
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  color: black;
+}
+
+.table.has-addon .col.section-row-title blockquote p {
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+}
+
+.table.has-addon .addon-promo,
+.table.has-addon .addon-promo a {
+  color: #2D9D78;
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  margin-bottom: var(--spacing-xxs);
+}
+
+.table.has-addon .addon-promo a {
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.table .row-highlight,
+.table .row-heading {
+  position: sticky;
+  z-index: 1;
+  transition: box-shadow 200ms cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.table:not(.merch) .row-heading.active,
+.table.merch .row-heading.active .col-heading {
+  transition-duration: 400ms;
+  box-shadow: 0 6px 3px -3px rgb(0 0 0 / 15%);
+}
+
+.top-border-transparent {
+  border-top: 1px solid transparent;
+}
+
+@media (min-width: 769px) {
+  .table-section .filters {
+    display: none;
+  }
+
+  .table.merch .filters {
+    display: grid;
+  }
+
+  .table > .row {
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  }
+
+  .table.merch > .row {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--spacing-m);
+  }
+}
+
+/* table merch */
+@media (min-width: 900px) {
+  .table-merch-section .filters {
+    display: none;
+  }
+}
+
+.table.merch > .row {
+  grid-template-columns: repeat(auto-fit, minmax(100px, 2fr));
+  gap: var(--spacing-xs);
+}
+
+.table.merch .section-head .col.section-head-title ,
+.table.merch .row-heading .col.col-heading {
+  text-align: left;
+}
+
+.table.merch .col,
+.table.merch .row-heading .col.col-heading {
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.table.merch .row-heading .col.col-heading .buttons-wrapper {
+  justify-content: flex-start;
+}
+
+.table.merch .row-heading .col.col-heading .buttons-wrapper > * {
+  margin: 12px 12px 12px 0;
+}
+
+.table.merch .col.no-borders {
+  visibility: hidden;
+}
+
+.table.merch .section-head .col {
+  padding: 24px;
+}
+
+.table.merch .col-merch .col-merch-content {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  border: none;
+}
+
+.table.merch .col-merch .col-merch-content picture {
+  display: flex;
+  width: 30px;
+  margin-right: 16px;
+}
+
+/* Start tablet styles */
+@media (max-width: 899px) {
+  .table,
+  .table.merch {
+    margin: 0 30px;
+  }
+
+  .section[class *= "grid-width-"] .table {
+    margin: 0;
+  }
+
+  .table:not(.merch) .row .section-head-title,
+  .table:not(.merch) .row .section-row-title {
+    border-right: 1px solid var(--border-color);
+  }
+
+  .table:not(.merch) .section-head {
+    display: block;
+  }
+
+  .table .section-head .col:not(.section-head-title),
+  .table:not(.merch) .col-heading.col-1,
+  .table:not(.merch) .row-highlight .col-highlight.col-1:not(:only-child) {
+    display: none;
+  }
+
+  .table:not(.merch) .row-highlight:has(> :only-child) {
+    grid-template-columns: repeat(auto-fit, 100%);
+  }
+
+  .table:not(.merch) .section-row-title {
+    grid-row: 1;
+    grid-column: 1 / x;
+    background-color: var(--color-gray-100);
+  }
+
+  .table.dark-table:not(.merch) .section-row-title {
+    background-color: #080808;
+  }
+
+  .table .row-heading .col-heading .pricing {
+    overflow-wrap: anywhere;
+  }
+
+  .table .row-heading .col-heading span[is='inline-price'] {
+    display: inline;
+  }
+
+  .table .row-heading .col:nth-child(n+1) {
+    padding: 20px;
+  }
+
+  .table .col-heading:nth-child(2),
+  [dir="rtl"] .table .col-heading:nth-child(2):last-child {
+    border-top-left-radius: var(--border-radius);
+  }
+
+  [dir="rtl"] .table .col-heading:nth-child(2) {
+    border-top-left-radius: 0;
+    border-top-right-radius: var(--border-radius);
+  }
+}
+
+/* Start mobile styles */
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  padding: 20px 30px 0;
+  gap: 30px;
+}
+
+.filter-wrapper {
+  text-align: center;
+}
+
+.filter {
+  border: none;
+  font-size: 1rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 146px;
+  appearance: none;
+  position: relative;
+  padding-right: 30px;
+  background: url("../../ui/img/chevron-wide-black.svg") no-repeat 100%;
+}
+
+@media (max-width: 768px) {
+  .table .col {
+    border: 1px var(--border-color) solid;
+  }
+
+  .table .col.force-last {
+    order: 1;
+  }
+
+  .table .col-heading.force-last {
+    border-top-right-radius: var(--border-radius);
+    border-top-left-radius: 0;
+  }
+
+  [dir="rtl"] .table .col-heading.force-last {
+    border-top-left-radius: var(--border-radius);
+    border-top-right-radius: 0;
+  }
+
+  .table .col-heading.force-last + .col-heading {
+    border-top-right-radius: 0;
+    border-top-left-radius: var(--border-radius);
+  }
+
+  [dir="rtl"] .table .col-heading.force-last + .col-heading {
+    border-top-left-radius: 0;
+    border-top-right-radius: var(--border-radius);
+  }
+
+  .table:not(.merch) .section-row-title {
+    grid-column: 1 / span 2;
+  }
+}
+
+@media (max-width: 600px) {
+  .table.header-left .row-heading .col.col-heading {
+    padding: var(--spacing-xs);
+  }
+}
+
+@media (max-width: 480px) {
+  .table,
+  .table.merch {
+    min-width: 100%;
+    margin: 0;
+  }
+
+  .table.merch .col-merch .col-merch-content {
+    flex-direction: column;
+    align-items: initial;
+  }
+
+  .table :is(.heading-button,.action-area) {
+    max-width: 100%;
+  }
+
+  .table .action-area .con-button.button-l {
+    overflow: hidden;
+  }
+}

--- a/libs/mep/emea1441/table/table.css
+++ b/libs/mep/emea1441/table/table.css
@@ -290,6 +290,11 @@
   font-size: var(--type-body-s-size);
 }
 
+.table.price-strikethrough-small .row-heading .col-heading .pricing del {
+  display: inline-block;
+  font-size: var(--type-body-s-size);
+}
+
 /* section */
 .table .divider {
   display: none;

--- a/libs/mep/emea1441/table/table.js
+++ b/libs/mep/emea1441/table/table.js
@@ -1,0 +1,687 @@
+/* eslint-disable no-plusplus */
+import { createTag, getConfig, MILO_EVENTS } from '../../../utils/utils.js';
+import { decorateButtons } from '../../../utils/decorate.js';
+import { debounce } from '../../../utils/action.js';
+import { replaceKeyArray } from '../../../features/placeholders.js';
+import { getGnavHeight } from '../../../blocks/global-navigation/utilities/utilities.js';
+
+const DESKTOP_SIZE = 900;
+const MOBILE_SIZE = 768;
+const tableHighlightLoadedEvent = new Event('milo:table:highlight:loaded');
+let tableIndex = 0;
+const isMobileLandscape = () => (window.matchMedia('(orientation: landscape)').matches && window.innerHeight <= MOBILE_SIZE);
+function defineDeviceByScreenSize() {
+  const screenWidth = window.innerWidth;
+  if (screenWidth >= DESKTOP_SIZE) {
+    return 'DESKTOP';
+  }
+  if (screenWidth <= MOBILE_SIZE) {
+    return 'MOBILE';
+  }
+  return 'TABLET';
+}
+
+export function isStickyHeader(el) {
+  return el.classList.contains('sticky')
+    || (el.classList.contains('sticky-desktop-up') && defineDeviceByScreenSize() === 'DESKTOP')
+    || (el.classList.contains('sticky-tablet-up') && defineDeviceByScreenSize() !== 'MOBILE' && !isMobileLandscape());
+}
+
+function handleHeading(table, headingCols) {
+  const isPriceBottom = table.classList.contains('pricing-bottom');
+  headingCols.forEach((col, i) => {
+    col.classList.add('col-heading');
+    if (!col.innerHTML) return;
+
+    const elements = col.children;
+    if (!elements.length) {
+      col.innerHTML = `<p class="tracking-header">${col.innerHTML}</p>`;
+    } else {
+      let textStartIndex = 0;
+      const iconTile = elements[0]?.querySelector('img');
+      if (iconTile) {
+        textStartIndex += 1;
+        if (!(table.classList.contains('merch'))) iconTile.closest('p').classList.add('header-product-tile');
+      }
+      elements[textStartIndex]?.classList.add('tracking-header');
+      const pricingElem = elements[textStartIndex + 1];
+      const bodyElem = elements[textStartIndex + 2];
+
+      if (pricingElem) {
+        pricingElem.classList.add('pricing');
+      }
+      if (bodyElem) {
+        bodyElem.classList.add('body');
+      }
+
+      decorateButtons(col, 'button-l');
+      const buttonsWrapper = createTag('div', { class: 'buttons-wrapper' });
+      col.append(buttonsWrapper);
+      const buttons = col.querySelectorAll('.con-button');
+
+      buttons.forEach((btn) => {
+        const btnWrapper = btn.closest('P');
+        buttonsWrapper.append(btnWrapper);
+      });
+
+      const headingContent = createTag('div', { class: 'heading-content' });
+      const headingButton = createTag('div', { class: 'heading-button' });
+
+      [...elements].forEach((e) => {
+        if (e.classList.contains('pricing') && isPriceBottom) headingButton.appendChild(e);
+        else headingContent.appendChild(e);
+      });
+
+      headingButton.appendChild(buttonsWrapper);
+      col.append(headingContent, headingButton);
+    }
+
+    const trackingHeader = col.querySelector('.tracking-header');
+
+    if (trackingHeader) {
+      const trackingHeaderID = `t${tableIndex + 1}-c${i + 1}-header`;
+      trackingHeader.setAttribute('id', trackingHeaderID);
+
+      const headerBody = col.querySelector('.body:not(.action-area)');
+      headerBody?.setAttribute('id', `${trackingHeaderID}-body`);
+
+      const headerPricing = col.querySelector('.pricing');
+      headerPricing?.setAttribute('id', `${trackingHeaderID}-pricing`);
+
+      const describedBy = `${headerBody?.id ?? ''} ${headerPricing?.id ?? ''}`.trim();
+      trackingHeader.setAttribute('aria-describedby', describedBy);
+
+      col.setAttribute('role', 'columnheader');
+    }
+
+    col.querySelectorAll('h1, h2, h3, h4, h5, h6').forEach((heading) => {
+      heading.setAttribute('role', 'paragraph');
+    });
+  });
+}
+
+function handleEqualHeight(table, tag) {
+  const height = [];
+  const element = table.querySelector(tag);
+  const columns = [...element.children];
+  columns.forEach(({ children }) => {
+    [...children].forEach((row, i) => {
+      row.style.height = 'auto';
+      if (!height[i] || row.offsetHeight > height[i]) {
+        height[i] = row.offsetHeight;
+      }
+    });
+  });
+  columns.forEach(({ children }) => {
+    [...children].forEach((row, i) => {
+      row.style.height = height[i] > 0 ? `${height[i]}px` : 'auto';
+    });
+  });
+}
+
+function handleAddOnContent(table) {
+  const addOnKey = 'ADDON';
+  const addOns = [...table.querySelectorAll('.section-row-title')]
+    .filter((row) => row.innerText.toUpperCase().includes(addOnKey));
+  if (!addOns.length) return;
+  table.classList.add('has-addon');
+  addOns.forEach((addOn) => {
+    const addOnRow = addOn.parentElement;
+    addOnRow.remove();
+    const [position, order, style] = addOn.innerText.split('-')
+      .filter((key) => key.toUpperCase() !== addOnKey).map((key) => key.toLowerCase());
+    if (!position || !order) return;
+    const dataIndex = 'data-col-index';
+    [...table.querySelector('.row-heading').children].forEach((headCol) => {
+      headCol.querySelector('.heading-content')?.classList.add('content');
+      const colIndex = headCol.getAttribute(dataIndex);
+      if (colIndex <= 1) return; // skip the key column
+      const tagName = `${position}-${order}`;
+      const column = [...addOnRow.children].find((el) => el.getAttribute(dataIndex) === colIndex);
+      let content = column.childNodes;
+      const icon = column.querySelector('.icon');
+      if (style === 'label' && icon) {
+        const text = [...content].filter((node) => !node.classList?.contains('icon'));
+        content = [createTag('span', null, text), icon];
+      }
+      const tag = createTag('div', { class: tagName }, [...content].map((node) => node));
+      if (style) tag.classList.add(`addon-${style}`);
+      const el = headCol.querySelector(`.${position}`);
+      el?.classList.add(`has-${tagName}`);
+      el?.insertAdjacentElement(order === 'before' ? 'beforebegin' : 'afterend', tag);
+    });
+  });
+  setTimeout(() => handleEqualHeight(table, '.row-heading'), 0);
+  table.addEventListener('mas:resolved', debounce(() => { handleEqualHeight(table, '.row-heading'); }));
+}
+
+function setTooltipPosition(el) {
+  if (!['TABLET', 'MOBILE'].includes(defineDeviceByScreenSize())) return;
+
+  const isRtl = document.documentElement.dir === 'rtl';
+  const classesToCheck = isRtl ? ['top', 'bottom', 'left'] : ['top', 'bottom', 'right'];
+  const selector = classesToCheck.map((cls) => `.milo-tooltip.${cls}`).join(',');
+  const tooltips = el.querySelectorAll(selector);
+
+  tooltips.forEach((tooltip) => {
+    tooltip.classList.remove(...classesToCheck);
+    tooltip.classList.add(isRtl ? 'right' : 'left');
+  });
+}
+
+async function setAriaLabelForIcons(el) {
+  const config = getConfig();
+  const expendableIcons = el.querySelectorAll('.icon.expand[role="button"]');
+  const selectFilters = el.parentElement.querySelectorAll('.filters .filter');
+  const ariaLabelElements = [...selectFilters, ...expendableIcons];
+
+  if (!ariaLabelElements.length) {
+    return;
+  }
+
+  const ariaLabels = await replaceKeyArray(['toggle-row', 'choose-table-column'], config);
+
+  ariaLabelElements.forEach((element) => {
+    const labelIndex = element.classList.contains('filter') ? 1 : 0;
+    element.setAttribute('aria-label', ariaLabels[labelIndex]);
+  });
+}
+
+function setTooltipListeners(el) {
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      el.querySelectorAll('.milo-tooltip').forEach((tooltip) => {
+        tooltip.classList.add('hide-tooltip');
+      });
+    }
+  });
+
+  el.querySelectorAll('.milo-tooltip').forEach((tooltip) => {
+    tooltip.addEventListener('mouseenter', () => {
+      tooltip.classList.remove('hide-tooltip');
+    });
+
+    tooltip.addEventListener('mouseleave', () => {
+      tooltip.classList.add('hide-tooltip');
+    });
+
+    tooltip.addEventListener('focus', () => {
+      tooltip.classList.remove('hide-tooltip');
+    });
+
+    tooltip.addEventListener('blur', () => {
+      tooltip.classList.add('hide-tooltip');
+    });
+  });
+}
+
+function handleHighlight(table) {
+  const isHighlightTable = table.classList.contains('highlight');
+  const firstRow = table.querySelector('.row-1');
+  const firstRowCols = firstRow.querySelectorAll('.col');
+  const secondRow = table.querySelector('.row-2');
+  const secondRowCols = secondRow.querySelectorAll('.col');
+  let headingCols = null;
+
+  if (isHighlightTable) {
+    firstRow.classList.add('row-highlight');
+    secondRow.classList.add('row-heading');
+    secondRowCols.forEach((col) => col.classList.add('col-heading'));
+    headingCols = secondRowCols;
+
+    firstRowCols.forEach((col, i) => {
+      col.classList.add('col-highlight');
+      if (col.innerText) {
+        headingCols[i]?.classList.add('no-rounded');
+      } else {
+        col.classList.add('hidden');
+      }
+    });
+  } else {
+    headingCols = firstRowCols;
+    firstRow.classList.add('row-heading');
+  }
+
+  handleHeading(table, headingCols);
+  handleAddOnContent(table);
+  table.dispatchEvent(tableHighlightLoadedEvent);
+}
+
+function handleExpand(e) {
+  const sectionHead = e.closest('.row');
+  let nextElement = sectionHead.nextElementSibling;
+  const expanded = e.getAttribute('aria-expanded') === 'false';
+  e.setAttribute('aria-expanded', expanded.toString());
+  while (nextElement && !nextElement.classList.contains('divider')) {
+    if (expanded) {
+      sectionHead.classList.remove('section-head-collaped');
+      nextElement.classList.remove('hidden');
+    } else {
+      sectionHead.classList.add('section-head-collaped');
+      nextElement.classList.add('hidden');
+    }
+    nextElement = nextElement.nextElementSibling;
+  }
+}
+
+function handleTitleText(cell) {
+  if (cell.querySelector('.table-title-text')) return;
+  const textSpan = createTag('span', { class: 'table-title-text' });
+  while (cell.firstChild) textSpan.append(cell.firstChild);
+
+  const iconTooltip = textSpan.querySelector('.icon-info, .icon-tooltip, .milo-tooltip');
+  if (iconTooltip) cell.append(iconTooltip.closest('em') || iconTooltip);
+
+  const firstIcon = textSpan.querySelector('.icon:first-child');
+  let nodeToInsert = textSpan;
+
+  if (firstIcon) {
+    const titleRowSpan = createTag('span', { class: 'table-title-row' });
+    titleRowSpan.append(firstIcon, textSpan);
+    nodeToInsert = titleRowSpan;
+  }
+
+  cell.insertBefore(nodeToInsert, cell.firstChild);
+}
+
+/**
+ * @param {*} sectionParams that is from init()
+ * @returns {boolean expandSection} that is the only variable get updated from sectionParams
+ */
+
+function handleSection(sectionParams) {
+  const {
+    row, index, allRows, rowCols, isMerch, isCollapseTable, isHighlightTable,
+  } = sectionParams;
+  let { expandSection } = sectionParams;
+
+  const previousRow = allRows[index - 1];
+  const nextRow = allRows[index + 1];
+  const nextRowCols = Array.from(nextRow?.children || []);
+
+  if (row.querySelector('hr') && nextRow) {
+    row.classList.add('divider');
+    row.removeAttribute('role');
+    nextRow.classList.add('section-head');
+    const sectionHeadTitle = nextRowCols?.[0];
+
+    if (isMerch && nextRowCols.length) {
+      nextRowCols.forEach((merchCol) => {
+        merchCol.classList.add('section-head-title');
+        merchCol.setAttribute('role', 'rowheader');
+      });
+    } else {
+      handleTitleText(sectionHeadTitle);
+      sectionHeadTitle.classList.add('section-head-title');
+      sectionHeadTitle.setAttribute('role', 'rowheader');
+    }
+
+    if (isCollapseTable) {
+      const iconTag = createTag('span', { class: 'icon expand', role: 'button' });
+      if (!sectionHeadTitle.querySelector('.icon.expand')) {
+        sectionHeadTitle.prepend(iconTag);
+      }
+
+      if (expandSection) {
+        iconTag.setAttribute('aria-expanded', 'true');
+        expandSection = false;
+      } else {
+        iconTag.setAttribute('aria-expanded', 'false');
+        nextRow.classList.add('section-head-collaped');
+        let nextElement = row.nextElementSibling;
+        while (nextElement && !nextElement.classList.contains('divider')) {
+          nextElement.classList.add('hidden');
+          nextElement = nextElement.nextElementSibling;
+        }
+      }
+    }
+  } else if (previousRow?.querySelector('hr') && nextRow) {
+    nextRow.classList.add('section-row');
+    if (!isMerch) {
+      const sectionRowTitle = nextRowCols?.[0];
+      sectionRowTitle.classList.add('section-row-title');
+      sectionRowTitle.setAttribute('role', 'rowheader');
+      sectionRowTitle.setAttribute('scope', 'row');
+    }
+  } else if (!row.classList.contains('row-1') && (!isHighlightTable || !row.classList.contains('row-2'))) {
+    row.classList.add('section-row');
+    if (isMerch && !row.classList.contains('divider')) {
+      rowCols.forEach((merchCol) => {
+        merchCol.classList.add('col-merch');
+        const children = Array.from(merchCol.children);
+        const merchContent = createTag('div', { class: 'col-merch-content' });
+        if (children.length) {
+          children.forEach((child) => {
+            if (!child.querySelector('.icon')) {
+              merchContent.append(child);
+            }
+          });
+          merchCol.insertBefore(merchContent, merchCol.firstChild);
+        } else if (merchCol.innerText) {
+          const pTag = createTag('p', { class: 'merch-col-text' }, merchCol.innerText);
+          merchCol.innerText = '';
+          merchContent.append(pTag);
+          merchCol.append(merchContent);
+        }
+      });
+    } else {
+      const sectionRowTitle = rowCols[0];
+      handleTitleText(sectionRowTitle);
+      sectionRowTitle.classList.add('section-row-title');
+      sectionRowTitle.setAttribute('role', 'rowheader');
+      sectionRowTitle.setAttribute('scope', 'row');
+    }
+  }
+  return expandSection;
+}
+
+function formatMerchTable(table) {
+  const rows = table.querySelectorAll('.row');
+  const rowsNum = rows.length;
+  const firstRow = rows[0];
+  const colsInRow = firstRow.querySelectorAll('.col');
+  const colsInRowNum = colsInRow.length;
+
+  for (let i = colsInRowNum; i > 0; i--) {
+    const cols = table.querySelectorAll(`.col-${i}`);
+    for (let j = rowsNum - 1; j >= 0; j--) {
+      const currentCol = cols[j];
+      if (!currentCol?.innerText && currentCol?.children.length === 0) {
+        currentCol.classList.add('no-borders');
+      } else {
+        currentCol?.classList.add('border-bottom');
+        break;
+      }
+    }
+  }
+}
+
+function removeHover(cols) {
+  cols.forEach((col) => col.classList.remove('hover', 'no-top-border', 'hover-border-bottom'));
+}
+
+function handleHovering(table) {
+  const row1 = table.querySelector('.row-1');
+  const colsInRowNum = row1.childElementCount;
+  const isMerch = table.classList.contains('merch');
+  const startValue = isMerch ? 1 : 2;
+  const isCollapseTable = table.classList.contains('collapse');
+  const sectionHeads = table.querySelectorAll('.section-head');
+  const lastSectionHead = sectionHeads[sectionHeads.length - 1];
+  const lastExpandIcon = lastSectionHead?.querySelector('.icon.expand');
+
+  for (let i = startValue; i <= colsInRowNum; i++) {
+    const cols = table.querySelectorAll(`.col-${i}`);
+    cols.forEach((e) => {
+      e.addEventListener('mouseover', () => {
+        removeHover(cols);
+        const headingRow = table.querySelector('.row-heading');
+        const colClass = `col-${i}`;
+        const isLastRowCollapsed = lastExpandIcon?.getAttribute('aria-expanded') === 'false';
+        cols.forEach((col) => {
+          if (col.classList.contains('col-highlight') && col.innerText) {
+            const matchingColsClass = Array.from(col.classList).find(
+              (className) => className.startsWith(colClass),
+            );
+            const noTopBorderCol = headingRow.querySelector(`.${matchingColsClass}`);
+            noTopBorderCol?.classList.add('no-top-border');
+          }
+          if (isCollapseTable && isLastRowCollapsed) {
+            const lastSectionHeadCol = lastSectionHead.querySelector(`.col-${i}`);
+            lastSectionHeadCol.classList.add('hover-border-bottom');
+          }
+          col.classList.add('hover');
+        });
+      });
+      e.addEventListener('mouseout', () => removeHover(cols));
+    });
+  }
+}
+
+async function handleScrollEffect(table) {
+  const gnavHeight = getGnavHeight();
+  const highlightRow = table.querySelector('.row-highlight');
+  const headingRow = table.querySelector('.row-heading');
+
+  if (highlightRow) {
+    highlightRow.style.top = `${gnavHeight}px`;
+    highlightRow.classList.add('top-border-transparent');
+  } else {
+    headingRow.classList.add('top-border-transparent');
+  }
+  const topOffset = gnavHeight + (highlightRow ? highlightRow.offsetHeight : 0);
+  headingRow.style.top = `${topOffset}px`;
+
+  const intercept = table.querySelector('.intercept') || createTag('div', { class: 'intercept' });
+  intercept.setAttribute('data-observer-intercept', '');
+  headingRow.insertAdjacentElement('beforebegin', intercept);
+
+  const observer = new IntersectionObserver(([entry]) => {
+    headingRow.classList.toggle('active', !entry.isIntersecting);
+  }, { rootMargin: `-${topOffset}px` });
+  observer.observe(intercept);
+}
+
+function applyStylesBasedOnScreenSize(table, originTable) {
+  const isMerch = table.classList.contains('merch');
+  const deviceBySize = defineDeviceByScreenSize();
+
+  const setRowStyle = () => {
+    if (isMerch) return;
+    const sectionRow = Array.from(table.getElementsByClassName('section-row'));
+    if (sectionRow.length) {
+      const colsForTablet = sectionRow[0].children.length - 1;
+      const percentage = 100 / colsForTablet;
+      const templateColumnsValue = `repeat(auto-fit, ${percentage}%)`;
+      sectionRow.forEach((row) => {
+        if (deviceBySize === 'TABLET' || (deviceBySize === 'MOBILE' && !row.querySelector('.col-3'))) {
+          row.style.gridTemplateColumns = templateColumnsValue;
+        } else {
+          row.style.gridTemplateColumns = '';
+        }
+      });
+    }
+  };
+
+  const reAssignEvents = (tableEl) => {
+    tableEl.dispatchEvent(tableHighlightLoadedEvent);
+    tableEl.querySelectorAll('.icon.expand').forEach((icon) => {
+      icon.parentElement.classList.add('point-cursor');
+      icon.parentElement.addEventListener('click', () => handleExpand(icon));
+      icon.parentElement.setAttribute('tabindex', 0);
+      icon.parentElement.addEventListener('keydown', (e) => {
+        if (e.key === ' ') e.preventDefault();
+
+        if (e.key === 'Enter' || e.key === ' ') handleExpand(icon);
+      });
+    });
+    handleHovering(tableEl);
+  };
+
+  const mobileRenderer = () => {
+    table.dispatchEvent(tableHighlightLoadedEvent);
+    const headings = table.querySelectorAll('.row-heading .col');
+    const headingsLength = headings.length;
+
+    if (isMerch && headingsLength > 2) {
+      table.querySelectorAll('.col:not(.col-1, .col-2)').forEach((col) => col.remove());
+    } else if (headingsLength > 3) {
+      table.querySelectorAll('.col:not(.col-1, .col-2, .col-3), .col.no-borders').forEach((col) => col.remove());
+    }
+
+    if ((!isMerch && !table.querySelector('.col-3'))
+      || (isMerch && !table.querySelector('.col-2'))) return;
+
+    const filterChangeEvent = () => {
+      table.innerHTML = originTable.innerHTML;
+      reAssignEvents(table);
+      const filters = Array.from(table.parentElement.querySelectorAll('.filter')).map((f) => parseInt(f.value, 10));
+      const rows = table.querySelectorAll('.row');
+
+      if (isMerch) {
+        table.querySelectorAll(`.col:not(.col-${filters[0] + 1}, .col-${filters[1] + 1})`).forEach((col) => col.remove());
+      } else {
+        table.querySelectorAll(`.col:not(.col-1, .col-${filters[0] + 1}, .col-${filters[1] + 1}), .col.no-borders`).forEach((col) => col.remove());
+      }
+
+      if (filters[0] > filters[1]) {
+        if (isMerch) {
+          rows.forEach((row) => row.querySelector('.col:not(.section-row-title)')
+            .classList.add('force-last'));
+        } else {
+          rows.forEach((row) => row.querySelector('.col:not(.section-row-title, .col-1)')
+            .classList.add('force-last'));
+        }
+      } else if (filters[0] === filters[1]) {
+        rows.forEach((row) => {
+          row.append(row.querySelector('.col:last-child').cloneNode(true));
+        });
+      }
+
+      setRowStyle();
+
+      if (table.matches('.sticky')) handleScrollEffect(table);
+    };
+
+    // Remove filter if table there are only 2 columns
+    const filter = isMerch ? headingsLength > 2 : headingsLength > 2;
+    if (!table.parentElement.querySelector('.filters') && filter) {
+      const filters = createTag('div', { class: 'filters' });
+      const filter1 = createTag('div', { class: 'filter-wrapper' });
+      const filter2 = createTag('div', { class: 'filter-wrapper' });
+      const colSelect0 = createTag('select', { class: 'filter' });
+      const headingsFromOrigin = originTable.querySelectorAll('.col-heading');
+      headingsFromOrigin.forEach((heading, index) => {
+        const title = heading.querySelector('.tracking-header');
+        if (!title || (!isMerch && title.closest('.col-1'))) return;
+
+        const option = createTag('option', { value: index }, title.innerText);
+        colSelect0.append(option);
+      });
+      const colSelect1 = colSelect0.cloneNode(true);
+      colSelect0.dataset.filterIndex = 0;
+      colSelect1.dataset.filterIndex = 1;
+      const visibleCols = table.querySelectorAll(`.col-heading:not([style*="display: none"], .hidden${isMerch ? '' : ', .col-1'})`);
+      colSelect0.querySelectorAll('option').item(visibleCols.item(0).dataset.colIndex - (isMerch ? 1 : 2)).selected = true;
+      colSelect1.querySelectorAll('option').item(visibleCols.item(1).dataset.colIndex - (isMerch ? 1 : 2)).selected = true;
+      filter1.append(colSelect0);
+      filter2.append(colSelect1);
+      filters.append(filter1, filter2);
+      filter1.addEventListener('change', filterChangeEvent);
+      filter2.addEventListener('change', filterChangeEvent);
+      table.parentElement.insertBefore(filters, table);
+      table.parentElement.classList.add(`table-${table.classList.contains('merch') ? 'merch-' : ''}section`);
+      if (!isMerch && headingsLength < 4) { filters.style.display = 'none'; }
+      filterChangeEvent();
+    }
+  };
+
+  // For Mobile (else: tablet / desktop)
+  if (!isMerch && !table.querySelector('.row-heading .col-2')) {
+    table.querySelector('.row-heading').style.display = 'block';
+    table.querySelector('.row-heading .col-1').style.display = 'flex';
+  }
+
+  if (deviceBySize === 'MOBILE' || (isMerch && deviceBySize === 'TABLET')) {
+    mobileRenderer();
+  } else {
+    table.innerHTML = originTable.innerHTML;
+    reAssignEvents(table);
+    table.parentElement.querySelectorAll('.filters select').forEach((select, index) => {
+      select.querySelectorAll('option').item(index).selected = true;
+    });
+  }
+
+  setRowStyle();
+}
+
+export default function init(el) {
+  el.setAttribute('role', 'table');
+  if (el.parentElement.classList.contains('section')) {
+    el.parentElement.classList.add(`table-${el.classList.contains('merch') ? 'merch-' : ''}section`);
+  }
+  const rows = Array.from(el.children);
+  const isMerch = el.classList.contains('merch');
+  const isCollapseTable = el.classList.contains('collapse') && !isMerch;
+  const isHighlightTable = el.classList.contains('highlight');
+  let expandSection = true;
+
+  rows.forEach((row, rdx) => {
+    row.classList.add('row', `row-${rdx + 1}`);
+    row.setAttribute('role', 'row');
+    const cols = Array.from(row.children);
+    const sectionParams = {
+      row,
+      index: rdx,
+      allRows: rows,
+      rowCols: cols,
+      isMerch,
+      isCollapseTable,
+      expandSection,
+      isHighlightTable,
+    };
+
+    cols.forEach((col, cdx) => {
+      col.dataset.colIndex = cdx + 1;
+      col.classList.add('col', `col-${cdx + 1}`);
+      col.setAttribute('role', 'cell');
+    });
+
+    expandSection = handleSection(sectionParams);
+  });
+
+  handleHighlight(el);
+  if (isMerch) formatMerchTable(el);
+
+  let isDecorated = false;
+
+  const handleTable = () => {
+    if (isDecorated) return;
+    let originTable;
+    let visibleHeadingsSelector = '.col-heading:not(.hidden, .col-1)';
+    if (isMerch) {
+      visibleHeadingsSelector = '.col-heading:not(.hidden)';
+    }
+    if (el.querySelectorAll(visibleHeadingsSelector).length > 2) {
+      originTable = el.cloneNode(true);
+    } else {
+      originTable = el;
+    }
+
+    const handleResize = () => {
+      applyStylesBasedOnScreenSize(el, originTable);
+      if (isStickyHeader(el)) handleScrollEffect(el);
+      setTooltipPosition(el);
+    };
+    handleResize();
+
+    let deviceBySize = defineDeviceByScreenSize();
+    window.addEventListener('resize', () => {
+      if (el.classList.contains('has-addon')) {
+        debounce(handleEqualHeight(el, '.row-heading'), 300);
+      }
+      if (deviceBySize === defineDeviceByScreenSize()) return;
+      deviceBySize = defineDeviceByScreenSize();
+      handleResize();
+    });
+
+    isDecorated = true;
+    setAriaLabelForIcons(el);
+    setTooltipListeners(el);
+  };
+
+  window.addEventListener(MILO_EVENTS.DEFERRED, () => {
+    handleTable();
+  }, true);
+
+  const observer = new window.IntersectionObserver((entries) => {
+    if (entries.some((entry) => entry.isIntersecting)) {
+      observer.disconnect();
+      handleTable();
+    }
+  });
+
+  observer.observe(el);
+
+  tableIndex++;
+}


### PR DESCRIPTION
* Creates MEP test version of table block
* adds classes for the dark table required for EMEA1441

Figma that shows the dark table layout: 
https://www.figma.com/proto/IZD9qy0ir6GMB7SfHj0OJg/0719---OPT-31672---AX-Go-Big-UK-Macro-v4-Test?page-id=4001%3A42&node-id=4001-25557&p=f&viewport=121%2C282%2C0.02&t=2GedUvWgi0Zo2hgh-1&scaling=scale-down-width&content-scaling=fixed

Resolves: [OPT-31767](https://jira.corp.adobe.com/browse/OPT-31767)

**Test URLs:**
- Psi-check: https://emea1441-dark-table--milo--adobecom.aem.page/?martech=off
- Before: https://main--cc--adobecom.aem.page/uk/products/photoshop
- After: https://main--cc--adobecom.aem.page/uk/products/photoshop?mep=%2Fproducts%2Fphotoshop.json--default---%2Fcc-shared%2Ffragments%2Ftests%2Femea-latam%2F2025%2Fq2%2Femea1441%2Fmep%2Fphotoshop%2Fphotoshop.json&milolibs=emea1441-dark-table

