### PR TITLE
chore: Configure Trusted Hosts for Sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,7 @@
 {
   "project": "Milo",
   "host": "milo.adobe.com",
+  "trustedHosts": ["milo.adobe.com", "*--milo--adobecom.aem.page"],
   "libraries": [
     {
       "text": "Blocks",

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,7 +1,7 @@
 {
   "project": "Milo",
   "host": "milo.adobe.com",
-  "trustedHosts": ["milo.adobe.com", "*--milo--adobecom.aem.page"],
+  "trustedHosts": ["milo.adobe.com", "*--milo--adobecom.aem.page", "*--milo--adobecom.aem.live"],
   "libraries": [
     {
       "text": "Blocks",


### PR DESCRIPTION
After: https://trusted-hosts--milo--adobecom.aem.page/?martech=off