### PR TITLE
MWPW-171040 region nav lang

### DIFF
--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -1,4 +1,4 @@
-import { getConfig } from '../../utils/utils.js';
+import { getConfig, getLanguage, getLocale } from '../../utils/utils.js';
 
 const queriedPages = [];
 
@@ -35,14 +35,18 @@ export function decorateLink(link, path) {
     try { pathname = new URL(pathname).pathname; } catch (e) { /* href does not contain domain */ }
   }
   const linkParts = pathname.split('/');
-  const prefix = linkParts[1] || '';
+  const expressPrefix = linkParts[1] || '';
+  
+  const language = languages ? getLanguage(languages, locales, pathname) : getLocale(locales, pathname);
+  const { languageMap, languages, locales } = getConfig();
+  const prefix = language.prefix.replace('/', '');
+
   let { href } = link;
   if (href.endsWith('/')) href = href.slice(0, -1);
 
-  const { languageMap } = getConfig();
-  if (languageMap && !getConfig().locales[prefix]) {
-    const valueInMap = languageMap[prefix];
-    href = href.replace(`/${prefix}`, valueInMap ? `/${valueInMap}` : '');
+  if (languageMap && !getConfig().locales[expressPrefix]) {
+    const valueInMap = languageMap[expressPrefix];
+    href = href.replace(`/${expressPrefix}`, valueInMap ? `/${valueInMap}` : '');
   }
   link.href = `${href}${path}`;
 

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -37,8 +37,8 @@ export function decorateLink(link, path) {
   const linkParts = pathname.split('/');
   const expressPrefix = linkParts[1] || '';
   
-  const language = languages ? getLanguage(languages, locales, pathname) : getLocale(locales, pathname);
   const { languageMap, languages, locales } = getConfig();
+  const language = languages ? getLanguage(languages, locales, pathname) : getLocale(locales, pathname);
   const prefix = language.prefix.replace('/', '');
 
   let { href } = link;


### PR DESCRIPTION
* Update to region-nav to support url formats with /language/region/

Resolves: [MWPW-171040 ](https://jira.corp.adobe.com/browse/MWPW-171040 )

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-171040--milo--adobecom.aem.page/?martech=off


Express
Before: https://main--express-milo--adobecom.aem.page/express/feature/image/editor?milolibs=stage#langnav
After: https://main--express-milo--adobecom.aem.page/express/feature/image/editor?milolibs=MWPW-171040#langnav

News
Before: https://main--news--adobecom.hlx.page/?milolibs=stage#langnav
After:https://main--news--adobecom.hlx.page/?milolibs=MWPW-171040#langnav
