### PR TITLE
MWPW-171040: support for url formats lan/reg

### DIFF
--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -36,10 +36,9 @@ export function decorateLink(link, path, localeToLanguageMap = []) {
   }
 
   const { languageMap, languages, locales } = getConfig();
-  const localeArray = localeToLanguageMap.map((l) => l?.locale);
   const mergedLocales = { ...locales };
-
-  localeArray.forEach((locale) => {
+  localeToLanguageMap.forEach((lang) => {
+    const { locale } = lang;
     if (!mergedLocales[locale]) {
       mergedLocales[locale] = { ietf: 'none', tk: 'none' };
     }

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -1,4 +1,4 @@
-import { getConfig } from '../../utils/utils.js';
+import { getConfig, getLanguage, getLocale } from '../../utils/utils.js';
 
 const queriedPages = [];
 
@@ -35,14 +35,18 @@ export function decorateLink(link, path) {
     try { pathname = new URL(pathname).pathname; } catch (e) { /* href does not contain domain */ }
   }
   const linkParts = pathname.split('/');
-  const prefix = linkParts[1] || '';
+  const expressPrefix = linkParts[1] || '';
+  
+  const { languageMap, languages, locales } = getConfig();
+  const language = languages ? getLanguage(languages, locales, pathname) : getLocale(locales, pathname);
+  const prefix = language.prefix.replace('/', '');
+
   let { href } = link;
   if (href.endsWith('/')) href = href.slice(0, -1);
 
-  const { languageMap } = getConfig();
-  if (languageMap && !getConfig().locales[prefix]) {
-    const valueInMap = languageMap[prefix];
-    href = href.replace(`/${prefix}`, valueInMap ? `/${valueInMap}` : '');
+  if (languageMap && !getConfig().locales[expressPrefix]) {
+    const valueInMap = languageMap[expressPrefix];
+    href = href.replace(`/${expressPrefix}`, valueInMap ? `/${valueInMap}` : '');
   }
   link.href = `${href}${path}`;
 

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -50,11 +50,13 @@ export function decorateLink(link, path) {
   }
   link.href = `${href}${path}`;
 
+  const interactionPrefix = languageMap ? expressPrefix : prefix;
+
   link.addEventListener('mouseover', () => {
     setTimeout(() => {
       if (link.matches(':hover') && !hrefAdapted) {
         handleEvent({
-          prefix,
+          interactionPrefix,
           link,
           callback: (newHref) => {
             link.href = newHref;
@@ -70,7 +72,7 @@ export function decorateLink(link, path) {
     if (hrefAdapted) return;
     e.preventDefault();
     handleEvent({
-      prefix,
+      interactionPrefix,
       link,
       callback: (newHref) => {
         window.open(newHref, e.ctrlKey || e.metaKey ? '_blank' : '_self');

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -34,29 +34,32 @@ export function decorateLink(link, path) {
   if (pathname.startsWith('http')) {
     try { pathname = new URL(pathname).pathname; } catch (e) { /* href does not contain domain */ }
   }
-  const linkParts = pathname.split('/');
-  const expressPrefix = linkParts[1] || '';
+
+  let prefix = '';
   const { languageMap, languages, locales } = getConfig();
-  const language = languages
-    ? getLanguage(languages, locales, pathname) : getLocale(locales, pathname);
-  const prefix = language.prefix.replace('/', '');
+  if (languageMap) {
+    const linkParts = pathname.split('/');
+    prefix = linkParts[1] || '';
+  } else {
+    const language = languages
+      ? getLanguage(languages, locales, pathname) : getLocale(locales, pathname);
+    prefix = language.prefix.replace('/', '');
+  }
 
   let { href } = link;
   if (href.endsWith('/')) href = href.slice(0, -1);
 
-  if (languageMap && !getConfig().locales[expressPrefix]) {
-    const valueInMap = languageMap[expressPrefix];
+  if (languageMap && !getConfig().locales[prefix]) {
+    const valueInMap = languageMap[prefix];
     href = href.replace(`/${prefix}`, valueInMap ? `/${valueInMap}` : '');
   }
   link.href = `${href}${path}`;
-
-  const interactionPrefix = languageMap ? expressPrefix : prefix;
 
   link.addEventListener('mouseover', () => {
     setTimeout(() => {
       if (link.matches(':hover') && !hrefAdapted) {
         handleEvent({
-          interactionPrefix,
+          prefix,
           link,
           callback: (newHref) => {
             link.href = newHref;
@@ -72,7 +75,7 @@ export function decorateLink(link, path) {
     if (hrefAdapted) return;
     e.preventDefault();
     handleEvent({
-      interactionPrefix,
+      prefix,
       link,
       callback: (newHref) => {
         window.open(newHref, e.ctrlKey || e.metaKey ? '_blank' : '_self');

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -46,7 +46,7 @@ export function decorateLink(link, path) {
 
   if (languageMap && !getConfig().locales[expressPrefix]) {
     const valueInMap = languageMap[expressPrefix];
-    href = href.replace(`/${expressPrefix}`, valueInMap ? `/${valueInMap}` : '');
+    href = href.replace(`/${prefix}`, valueInMap ? `/${valueInMap}` : '');
   }
   link.href = `${href}${path}`;
 

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -37,7 +37,7 @@ export function decorateLink(link, path) {
   const linkParts = pathname.split('/');
   const expressPrefix = linkParts[1] || '';
   const { languageMap, languages, locales } = getConfig();
-  const language = languages 
+  const language = languages
     ? getLanguage(languages, locales, pathname) : getLocale(locales, pathname);
   const prefix = language.prefix.replace('/', '');
 

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -36,9 +36,9 @@ export function decorateLink(link, path) {
   }
   const linkParts = pathname.split('/');
   const expressPrefix = linkParts[1] || '';
-  
   const { languageMap, languages, locales } = getConfig();
-  const language = languages ? getLanguage(languages, locales, pathname) : getLocale(locales, pathname);
+  const language = languages 
+    ? getLanguage(languages, locales, pathname) : getLocale(locales, pathname);
   const prefix = language.prefix.replace('/', '');
 
   let { href } = link;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -373,6 +373,8 @@ export function hasLanguageLinks(area, paths = LANGUAGE_BASED_PATHS) {
 }
 
 export async function loadLanguageConfig() {
+  if (localeToLanguageMap && siteLanguages) return { siteLanguages, localeToLanguageMap };
+
   const parseList = (str) => str.split(/[\n,]+/).map((t) => t.trim()).filter(Boolean);
   try {
     const response = await fetch(`${getFederatedContentRoot()}/federal/assets/data/languages-config.json`);
@@ -385,9 +387,13 @@ export async function loadLanguageConfig() {
       pathMatches: parseList(site.pathMatches),
       languages: parseList(site.languages),
     }));
+
+    return { siteLanguages, localeToLanguageMap };
   } catch (e) {
     window.lana?.log('Failed to load language-config.json:', e);
   }
+
+  return {};
 }
 
 let fedsPlaceholderConfig;

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -14,9 +14,9 @@ const getCookie = (name) => document.cookie
   .find((row) => row.startsWith(`${name}=`))
   ?.split('=')[1];
 
-describe('Region Nav Block', () => {
+describe('Region Nav Block', async () => {
   const block = document.body.querySelector('.region-nav');
-  init(block);
+  await init(block);
   let clock;
 
   beforeEach(async () => {
@@ -164,14 +164,5 @@ describe('Region Nav Block', () => {
 
     // No languageMap means no transformation
     expect(link.href).to.equal('https://adobe.com/ar/some-page');
-  });
-
-  it('replaces the prefix with the mapped value from language', () => {
-    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
-
-    const link = createTag('a', { href: 'https://adobe.com/ph_en/' });
-    decorateLink(link, '/path/to/some/page');
-
-    expect(link.href).to.equal('https://adobe.com/en/apac/path/to/some/page');
   });
 });

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -165,4 +165,13 @@ describe('Region Nav Block', () => {
     // No languageMap means no transformation
     expect(link.href).to.equal('https://adobe.com/ar/some-page');
   });
+
+  it('replaces the prefix with the mapped value from language', () => {
+    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
+
+    const link = createTag('a', { href: 'https://adobe.com/ph_en/' });
+    decorateLink(link, '/path/to/some/page');
+
+    expect(link.href).to.equal('https://adobe.com/en/apac/path/to/some/page');
+  });
 });


### PR DESCRIPTION
* Update to region-nav to support url formats with /language/region/

Resolves: [MWPW-171040 ](https://jira.corp.adobe.com/browse/MWPW-171040 )

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-171040--milo--adobecom.aem.page/?martech=off


Express
Before: https://main--express-milo--adobecom.aem.page/express/feature/image/editor?milolibs=stage#langnav
After: https://main--express-milo--adobecom.aem.page/express/feature/image/editor?milolibs=MWPW-171040#langnav

News
Before: https://lang-nav--news--adobecom.hlx.page/en/gb/drafts/ruchika/document?milolibs=stage#langnav
After:https://lang-nav--news--adobecom.hlx.page/en/gb/drafts/ruchika/document?milolibs=MWPW-171040#langnav

CC
Before: https://stage--cc--adobecom.hlx.page/products/photoshop#langnav
After: https://stage--cc--adobecom.hlx.page/products/photoshop?milolibs=MWPW-171040#langnav




































