### PR TITLE
MWPW-171326: Fix text overflow in table heading

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -190,7 +190,7 @@
   justify-content: space-between;
 }
 
-.table .row-heading .col.col-heading * {
+.table .col-heading * {
   max-width: 100%;
 }
 

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -190,6 +190,10 @@
   justify-content: space-between;
 }
 
+.table .row-heading .col.col-heading * {
+  max-width: 100%;
+}
+
 .table .row-heading .col.col-heading .buttons-wrapper {
   display: flex;
   justify-content: center;

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -116,7 +116,7 @@ function handleEqualHeight(table, tag) {
   });
   columns.forEach(({ children }) => {
     [...children].forEach((row, i) => {
-      row.style.height = height[i] > 0 ? `${height[i]}px` : 'auto';
+      row.style.minHeight = height[i] > 0 ? `${height[i]}px` : 'unset';
     });
   });
 }


### PR DESCRIPTION
Issue: If text spacing is applied, text overflows table heading container that have add on content (e.g. price). In tables that don't have add on content, you can reproduce this issue by resizing the window and then applying text spacing. 
* Replace `height` with `min-height`
* Set `max-width: 100%` to all descendants.

**Screenshots:**
<img width="1728" alt="Screenshot 2025-04-25 at 10 39 45" src="https://github.com/user-attachments/assets/71edaac9-cc03-4d02-88b6-a55969a5625b" />
<img width="1728" alt="Screenshot 2025-04-25 at 10 39 56" src="https://github.com/user-attachments/assets/afa985ec-6bf3-40b9-85de-7ecdb392378e" />


Resolves: [MWPW-171326](https://jira.corp.adobe.com/browse/MWPW-171326)

To test use this [extension](https://chromewebstore.google.com/detail/text-spacing-editor/amnelgbfbdlfjeaobejkfmjjnmeddaoj)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/mwpw-171326-table-text-spacing/table?martech=off
- After: https://mwpw-171326-table-text-spacing--milo--adobecom.aem.page/drafts/ratko/mwpw-171326-table-text-spacing/table?martech=off
- Before: https://main--milo--adobecom.hlx.page/drafts/klee/kitchen-sink/table?martech=off
- After: https://mwpw-171326-table-text-spacing--milo--adobecom.hlx.page/drafts/klee/kitchen-sink/table?martech=off
**CC URLs:**
- Before: https://main--cc--adobecom.aem.page/products/photoshop-lightroom/plans?milolibs=mwpw-171326-table-text-spacing
- After: https://main--cc--adobecom.aem.page/products/photoshop-lightroom/plans?milolibs=mwpw-171326-table-text-spacing

**NOTE:** When text spacing is applied this will expand table heading content, if the table is sticky variant, table content will not be visible due to table heading container occupying most of the screen. This will be resolved in [MWPW-171327](https://jira.corp.adobe.com/browse/MWPW-171327)



