### PR TITLE
Loading aside styles before setting promo height

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1,6 +1,7 @@
 /* eslint import/no-relative-packages: 0 */
 /* eslint-disable no-async-promise-executor */
 import {
+  loadStyle,
   getConfig,
   getMetadata,
   loadIms,
@@ -1018,6 +1019,14 @@ class Gnav {
       return this.elements.aside;
     }
 
+    const { miloLibs, codeRoot } = getConfig();
+    const url = `${miloLibs || codeRoot}/blocks/aside/aside.css`;
+    await new Promise((resolve, reject) => {
+      loadStyle(url, (e) => {
+        if (e === 'error') return reject(url);
+        return resolve();
+      });
+    });
     const { default: decorate } = await import('./features/aside/aside.js');
     if (!decorate) return this.elements.aside;
     this.elements.aside = await decorate({ headerElem: this.block, fedsPromoWrapper, promoPath });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Gnav promo height was made dynamic as ROW promos sometimes overflows from the fixed promo height.
 Intermittently there is a race condition between aside.css(which hides other 2 variants) and gnav's code which sets the gnav container height which results in gnav promo expanding its height which is currently reproducible only on stage.
So, the fix is to load aside.css earlier so that the promo height is always set correctly.

<img width="431" alt="Screenshot 2025-04-28 at 1 37 13 PM" src="https://github.com/user-attachments/assets/9764d123-ed0b-4550-8962-c69e5616e2c7" />

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-aside--milo--adobecom.aem.page/?martech=off

QA: https://stage--cc--adobecom.aem.live/ua/creativecloud?milolibs=gnav-aside


## GNav Test URLs

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=gnav-aside--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=gnav-aside--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=gnav-aside--milo--adobecom
- Milo: https://gnav-aside--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=gnav-aside--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=gnav-aside--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=gnav-aside--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-aside--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-aside--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-aside--milo--adobecom
- Milo: https://gnav-aside--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-aside--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-aside--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-aside--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-aside--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-aside--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-aside--milo--adobecom
- Milo: https://gnav-aside--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-aside--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-aside--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-aside--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=gnav-aside--milo--adobecom
**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=gnav-aside--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=gnav-aside--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=gnav-aside--milo--adobecom