### PR TITLE
[MWPW-171958] - video pause/play a11y

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -278,7 +278,7 @@ export function addAccessibilityControl(videoString, videoAttrs, indexOfVideo, t
   }
   return `
     <div class='video-container video-holder'>${videoString}
-      <a class='pause-play-wrapper' title='${videoLabels.pauseMotion}' role='button' tabindex=${tabIndex} aria-pressed=true video-index=${indexOfVideo}>
+      <a class='pause-play-wrapper' title='${videoLabels.pauseMotion}' aria-label='${videoLabels.pauseMotion}' role='button' tabindex=${tabIndex} aria-pressed=true video-index=${indexOfVideo}>
         <div class='offset-filler'>
           <img class='accessibility-control pause-icon' alt='${videoLabels.pauseIcon}' src='${fedRoot}/federal/assets/svgs/accessibility-pause.svg'/>
           <img class='accessibility-control play-icon' alt='${videoLabels.playIcon}' src='${fedRoot}/federal/assets/svgs/accessibility-play.svg'/>


### PR DESCRIPTION
This resolves the issue where an aria-label was missing from the pause/play button.

Resolves: [MWPW-171958](https://jira.corp.adobe.com/browse/MWPW-171958)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://video-element-name-missing--milo--adobecom.aem.page/?martech=off

**CC Test URLs:**
- Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/products/substance3d/painter/aside-non-destructive
- After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/products/substance3d/painter/aside-non-destructive?milolibs=video-element-name-missing

