### PR TITLE
[MWPW-172157] - tab stacked mobile scroll fix

### DIFF
--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -67,7 +67,6 @@ function changeTabs(e) {
   }
   const parent = target.parentNode;
   const content = parent.parentNode.parentNode.lastElementChild;
-  const targetContent = content.querySelector(`#${target.getAttribute('aria-controls')}`);
   const tabsBlock = target.closest('.tabs');
   const blockId = tabsBlock.id;
   parent
@@ -86,8 +85,9 @@ function changeTabs(e) {
   content
     .querySelectorAll(`[role="tabpanel"][data-block-id="${blockId}"]`)
     .forEach((p) => p.setAttribute('hidden', true));
-  targetContent.removeAttribute('hidden');
-  if (tabsBlock.classList.contains('stacked-mobile')) scrollStackedMobile(targetContent);
+
+  content.querySelector(`#${target.getAttribute('aria-controls')}`).removeAttribute('hidden');
+  if (tabsBlock.classList.contains('stacked-mobile')) scrollStackedMobile(parent);
 }
 
 function getStringKeyName(str) {


### PR DESCRIPTION
This resolves the issue where when on mobile and clicking on stacked tabs, the action scrolls you to the content and the tab buttons go out of view.

Resolves: [MWPW-172157](https://jira.corp.adobe.com/browse/MWPW-172157)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/tab-block?martech=off
- After: https://tab-mobile-scroll--milo--adobecom.aem.page/docs/library/kitchen-sink/tab-block?martech=off


