### PR TITLE
MWPW-171825 Improve lcp performance for favicon and breadcrumb

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1398,9 +1398,7 @@ async function checkForPageMods() {
 }
 
 async function loadPostLCP(config) {
-  import('./favicon.js').then(({ default: loadFavIcon }) => {
-    loadFavIcon(createTag, getConfig(), getMetadata);
-  });
+  import('./favicon.js').then(({ default: loadFavIcon }) => loadFavIcon(createTag, getConfig(), getMetadata));
   await decoratePlaceholders(document.body.querySelector('header'), config);
   const sk = document.querySelector('aem-sidekick, helix-sidekick');
   if (sk) import('./sidekick-decorate.js').then((mod) => { mod.default(sk); });


### PR DESCRIPTION
* Parallelize favicon.js import
* Change "first section" performance optimizations to "lcp section" to account for breadcrumbs being put in first section

Resolves: [MWPW-171825](https://jira.corp.adobe.com/browse/MWPW-171825)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://favicon-perf--milo--meganthecoder.aem.page/drafts/methomas/default?martech=off

Bacom:
- Before: https://main--bacom--adobecom.aem.live/ai/adobe-genai
- After: https://main--bacom--adobecom.aem.live/ai/adobe-genai?milolibs=favicon-perf--milo--meganthecoder

Acom:
- Before: https://main--cc--adobecom.aem.live/ai/overview
- After: https://main--cc--adobecom.aem.live/ai/overview?milolibs=favicon-perf--milo--meganthecoder