### PR TITLE
[MWPW-172403] - Text headings strong font weight

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -793,7 +793,12 @@ h1, h2, h3, h4, h5, h6 {
   scroll-margin-top: var(--feds-totalheight-nav);
 }
 
-h1, h2, h3, h4, h5, h6 strong {
+h1 strong,
+h2 strong,
+h3 strong,
+h4 strong,
+h5 strong,
+h6 strong {
   font-weight: 700;
 }
 

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -793,6 +793,10 @@ h1, h2, h3, h4, h5, h6 {
   scroll-margin-top: var(--feds-totalheight-nav);
 }
 
+h1, h2, h3, h4, h5, h6 strong {
+  font-weight: 700;
+}
+
 h1 {
   font-size: var(--type-heading-xl-size);
   line-height: var(--type-heading-xl-lh);

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -793,12 +793,7 @@ h1, h2, h3, h4, h5, h6 {
   scroll-margin-top: var(--feds-totalheight-nav);
 }
 
-h1 strong,
-h2 strong,
-h3 strong,
-h4 strong,
-h5 strong,
-h6 strong {
+:is(h1, h2, h3, h4, h5, h6) strong {
   font-weight: 700;
 }
 

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -794,7 +794,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 :is(h1, h2, h3, h4, h5, h6) strong {
-  font-weight: 700;
+  font-weight: inherit;
 }
 
 h1 {


### PR DESCRIPTION
This resolves an issue where a Chrome update caused the strong element to have a font weight of bolder(900) instead of bold(700).

Resolves: [MWPW-172403](https://jira.corp.adobe.com/browse/MWPW-172403)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/docs/library/kitchen-sink/hero-marquee
- After: https://text-headings-font-weight--milo--adobecom.aem.live/docs/library/kitchen-sink/hero-marquee




