### PR TITLE
MWPW-145857: Redirects formatter clean

### DIFF
--- a/libs/blocks/redirects-formatter/redirects-formatter.css
+++ b/libs/blocks/redirects-formatter/redirects-formatter.css
@@ -1,0 +1,210 @@
+
+:root {
+  --notch-size: 12px;
+  --text-color: #2c2c2c;
+  --color-white: #FFF;
+  --color-black: #000;
+}
+
+h1 {
+  margin: 20px;
+  width: fit-content;
+  padding-bottom: 10px;
+  border-bottom: 2px solid var(--text-color);
+}
+
+textarea {
+  white-space: pre;
+  min-height: 200px;
+  height: fit-content;
+}
+
+button {
+  background-color: transparent;
+  border-radius: 16px;
+  border: 2px solid var(--text-color);
+  color: var(--text-color);
+  display: inline-block;
+  font-size: 15px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 16px;
+  padding: 5px 14px;
+  text-decoration: none;
+  min-height: 21px;
+}
+
+button:hover {
+  background-color: var(--color-black);
+  border-color: var(--color-black);
+  color: var(--color-white);
+}
+
+button:hover svg {
+  fill: var(--color-white);
+}
+
+button.selected {
+  background-color: var(--color-black);
+  border-color: var(--color-black);
+  color: var(--color-white);
+}
+
+label {
+  margin: 4px;
+  align-self: center;
+}
+
+section .error-border {
+  border: 1px solid red;
+}
+
+.redirects-formatter,
+.redirects-container {
+  display: flex;
+  flex-direction: column;
+  margin: 0 20px 20px;
+}
+
+.instructions {
+  margin: 0 20px;
+}
+
+.checkboxes-container {
+  display: grid;
+  background: #efefef;
+  grid-column: 1/3;
+  border: 1px solid black;
+  width: 100%;
+}
+
+.checkbox-ui {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.checkboxes-container .tabs {
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  margin: 20px;
+}
+
+.output-container button {
+  margin-right: 20px;
+}
+
+.output-container textarea {
+  width: 100%;
+  padding: 0;
+}
+
+.select-all-container button {
+  min-width: 115px;
+}
+
+.redirect-tabs button {
+  margin: 0 20px;
+}
+
+.redirects-container section button {
+  grid-column-start: 2;
+  justify-self: end;
+}
+
+.checkboxes-container .tabs button {
+  margin: 0 15px 0 5px;
+}
+
+.select-all-container {
+  display: flex;
+  justify-content: flex-end;
+  margin: 20px;
+  width: 20%;
+}
+
+.checkbox-wrapper {
+  padding: 5px;
+  min-width: 130px;
+  display: flex;
+  align-items: center;
+}
+
+.checkbox-grouping {
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: left;
+  margin: 0 20px 20px;
+}
+
+.checkboxes .checkbox-grouping:not(.selected) {
+  display: none;
+}
+
+.bulk-redirects-container textarea {
+  margin-top: 20px;
+}
+
+.redirects-container section textarea {
+  grid-column: 1/3;
+}
+
+.error {
+  margin: 10px 20px;
+  min-height: 30px;
+  color: red;
+}
+
+.single-redirects-container .redirect-input-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  margin: 20px 0;
+}
+
+.single-redirects-container .redirect-input-row:nth-child(odd) {
+  background-color: #efefef;
+}
+
+.single-redirects-container .redirect-input-row label {
+  padding-right: 20px;
+  margin: 20px 0;
+}
+
+.single-redirects-container .redirect-input-row label:last-of-type {
+  margin-left: 40px;
+}
+
+.single-redirects-container input {
+  width: 340px;
+}
+
+.redirect-tabs {
+  display: flex;
+  margin: 20px 0;
+}
+
+.redirect-tabs .process-redirects {
+  margin: 0 20px 0 auto;
+}
+
+.bulk-redirects-container { 
+  display: grid;
+  margin-top: 20px;
+}
+
+.redirects-ui-area {
+  min-height: 260px;
+}
+
+.redirects-ui-area section:not(.selected) {
+  display: none;
+}
+
+.output-container > div {
+  display: flex;
+  justify-content: space-between;
+  margin: 40px 0;
+}

--- a/libs/blocks/redirects-formatter/redirects-formatter.js
+++ b/libs/blocks/redirects-formatter/redirects-formatter.js
@@ -1,0 +1,98 @@
+import { createCheckboxArea } from './utils/checkboxes.js';
+import { createRedirectsList, getLocalesFromUi, processRedirects } from './utils/process-redirects.js';
+import { createRedirectsArea } from './utils/redirect-inputs.js';
+
+export const NO_LOCALE_ERROR = 'No locales selected from list';
+const EMPTY_INPUT_ERROR = 'Please input a URl to process';
+const CORRECT_URL_ERROR = 'Please use full urls in the inputs: https://www.adobe.com/x/y/z';
+const OUTPUT_LABEL_TEXT = 'Localized results appear here:';
+const COPY_TO_CLIPBOARD = 'Copy to clipboard';
+
+function handleError(e, eSection) {
+  const errorElem = document.querySelector('.error');
+  setTimeout(() => {
+    errorElem.innerText = '';
+    eSection.classList.remove('error-border');
+  }, 2000);
+  errorElem.innerText = e;
+  eSection.classList.add('error-border');
+}
+
+export function stringifyListForExcel(urls) {
+  return urls.reduce((rdx, url) => `${rdx}${url[0]}\t${url[1]}\n`, '');
+}
+
+export default async function init(el) {
+  const { createTag } = await import('../../utils/utils.js');
+
+  const localeConfigPath = './locale-config.json';
+  const resp = await fetch(localeConfigPath);
+  if (!resp.ok) return;
+  const { data } = await resp.json();
+
+  const redirectsContainer = createTag('section', { class: 'redirects-container' });
+  const errorSection = createTag('p', { class: 'error' });
+
+  // Checkboxes
+  const checkBoxesHeader = createTag('p', { class: 'cb-label' });
+  checkBoxesHeader.innerText = 'Select Locales';
+  const checkBoxes = await createCheckboxArea(data);
+
+  // Text input area
+  const singleInputArea = createRedirectsArea();
+
+  // Text output Area
+  const textAreaOutput = createTag('textarea', { class: 'redirects-text-area', id: 'redirects-output', name: 'redirects-output', readonly: true });
+  const taoLabel = createTag('label', { for: 'redirects-output' }, OUTPUT_LABEL_TEXT);
+  const copyButton = createTag('button', { class: 'copy' }, COPY_TO_CLIPBOARD);
+  const outputUiWrapper = createTag('div', {}, [taoLabel, copyButton]);
+  const outputAreaContainer = createTag('section', { class: 'output-container' }, [outputUiWrapper, textAreaOutput]);
+
+  // Create the DOM
+  redirectsContainer.append(checkBoxes, singleInputArea, outputAreaContainer);
+  el.append(errorSection, redirectsContainer);
+
+  // Event Listeners
+  document.querySelector('.process-redirects').addEventListener('click', () => {
+    const checkboxesList = checkBoxes.querySelectorAll('input[type="checkbox"]');
+    const locales = getLocalesFromUi(checkboxesList);
+    const activeInput = document.querySelector('.redirects-ui-area .selected');
+    const redirectsList = createRedirectsList(activeInput);
+
+    if (!locales.length) {
+      handleError(NO_LOCALE_ERROR, checkBoxes);
+      return;
+    }
+
+    if (redirectsList[0]?.source === '') {
+      handleError(EMPTY_INPUT_ERROR, activeInput);
+      return;
+    }
+
+    const processedList = processRedirects(redirectsList, locales, () => {
+      handleError(CORRECT_URL_ERROR, activeInput);
+    });
+    const outputString = stringifyListForExcel(processedList);
+
+    textAreaOutput.value = outputString;
+  });
+
+  copyButton.addEventListener('click', () => {
+    if (!navigator?.clipboard) return;
+    const redirects = textAreaOutput.value;
+    navigator.clipboard.writeText(redirects).then(
+      () => {
+        copyButton.innerText = 'Copied';
+        setTimeout(() => {
+          copyButton.innerText = COPY_TO_CLIPBOARD;
+        }, 1500);
+      },
+      () => {
+        copyButton.innerText = 'Error!';
+        setTimeout(() => {
+          copyButton.innerText = COPY_TO_CLIPBOARD;
+        }, 1500);
+      },
+    );
+  });
+}

--- a/libs/blocks/redirects-formatter/utils/checkboxes.js
+++ b/libs/blocks/redirects-formatter/utils/checkboxes.js
@@ -1,0 +1,106 @@
+import { createTag } from '../../../utils/utils.js';
+
+const selectedClassName = 'selected';
+
+export function createGroupings(sheetData) {
+  return sheetData.reduce((rdx, row) => {
+    Object.entries(row).forEach(([groupName, locale]) => {
+      if (!rdx[groupName]) {
+        rdx[groupName] = [];
+      }
+      if (locale && !rdx[groupName].includes(locale)) {
+        rdx[groupName].push(locale);
+      }
+    });
+    return rdx;
+  }, {});
+}
+
+export function createAllRegionGroup(sheetData) {
+  return [...new Set(
+    sheetData.flatMap((row) => Object.values(row))
+      .filter((locale) => locale),
+  )];
+}
+
+function createTabs(tabNames) {
+  return tabNames.map((tabKey, idx) => {
+    const tabClass = tabKey.replaceAll(' ', '-').toLocaleLowerCase().trim();
+    return createTag('button', { class: `${tabClass} checkbox-tab ${idx === 0 ? selectedClassName : ''}`, 'data-group-name': tabClass }, tabKey);
+  });
+}
+
+function createCheckboxGroupNodes(checkboxGroupings) {
+  return Object.keys(checkboxGroupings).map((groupKey, idx) => {
+    const groupClass = groupKey.replaceAll(' ', '-').toLocaleLowerCase().trim();
+    const group = createTag('div', { class: `${groupClass} checkbox-grouping ${idx === 0 ? selectedClassName : ''}` });
+
+    const checkboxes = checkboxGroupings[groupKey].map((locale) => {
+      const checkbox = createTag('input', {
+        class: 'locale-checkbox',
+        type: 'checkbox',
+        id: `${groupKey}-${locale}`,
+        name: `${groupKey}-${locale}`,
+        value: `${locale}`,
+      });
+      const label = createTag('label', { class: 'locale-label', for: `${groupKey}-${locale}` }, locale);
+
+      return createTag('div', { class: 'checkbox-wrapper' }, [checkbox, label]);
+    });
+
+    group.append(...checkboxes);
+    return group;
+  });
+}
+
+export function createCheckboxArea(data) {
+  const checkboxComponent = createTag('section', { class: 'checkboxes-container' });
+  const checkboxSelectSection = createTag('div', { class: 'checkboxes' });
+  const groupings = createGroupings(data);
+  const allGroup = createAllRegionGroup(data);
+  groupings.All = allGroup;
+  const tabKeys = Object.keys(groupings);
+
+  // Create tabs and select UI
+  const tabs = createTabs(tabKeys);
+  const tabHolder = createTag('div', { class: 'tabs' }, [...tabs]);
+  const SELECT_ALL_REGIONS = 'select all';
+  const DESELECT_ALL_REGIONS = 'remove all';
+  const selectButton = createTag('button', { class: 'select' }, SELECT_ALL_REGIONS);
+  const selectAllContainer = createTag('div', { class: 'select-all-container' }, selectButton);
+  const checkboxUi = createTag('div', { class: 'checkbox-ui' }, [tabHolder, selectAllContainer]);
+
+  // Create group nodes and populate with checkboxes
+  const groupNodes = createCheckboxGroupNodes(groupings);
+  checkboxSelectSection.append(...groupNodes);
+  checkboxComponent.append(checkboxUi, checkboxSelectSection);
+
+  // Event Listeners
+  checkboxUi.querySelectorAll('.checkbox-tab').forEach((clickedTab) => {
+    clickedTab.addEventListener('click', () => {
+      checkboxUi.querySelector(`.${selectedClassName}`).classList.remove(selectedClassName);
+      clickedTab.classList.add(selectedClassName);
+      const associatedClass = clickedTab.dataset.groupName;
+      const selectedArea = checkboxSelectSection.querySelector(`.${selectedClassName}`);
+      selectedArea.querySelectorAll('input').forEach((checkbox) => {
+        checkbox.checked = false;
+      });
+      selectButton.innerText = SELECT_ALL_REGIONS;
+      selectedArea.classList.remove(selectedClassName);
+      checkboxSelectSection.querySelector(`.${associatedClass}`).classList.add(selectedClassName);
+    });
+  });
+
+  selectButton.addEventListener('click', () => {
+    const selectedCheckboxArea = checkboxSelectSection.querySelector(`.${selectedClassName}`);
+    const currentIsSelectAll = selectButton.innerText === SELECT_ALL_REGIONS;
+
+    selectedCheckboxArea.querySelectorAll('input').forEach((checkbox) => {
+      checkbox.checked = currentIsSelectAll;
+    });
+
+    selectButton.innerText = currentIsSelectAll ? DESELECT_ALL_REGIONS : SELECT_ALL_REGIONS;
+  });
+
+  return checkboxComponent;
+}

--- a/libs/blocks/redirects-formatter/utils/process-redirects.js
+++ b/libs/blocks/redirects-formatter/utils/process-redirects.js
@@ -1,0 +1,77 @@
+export function getLocalesFromUi(nodeList) {
+  return [...nodeList].reduce((rdx, cb) => {
+    if (cb.checked) {
+      rdx.push(cb.value);
+    }
+    return rdx;
+  }, []);
+}
+
+function createPairsFromTextaArea(textaAreaValue) {
+  const whitespace = /\s+/;
+  const urlValues = textaAreaValue.split(whitespace);
+  const pairs = [];
+  for (let i = 0; i < urlValues.length; i += 2) {
+    const source = urlValues[i]?.trim();
+    const destination = urlValues[i + 1]?.trim();
+
+    if (source?.length && destination) {
+      pairs.push({
+        source,
+        destination,
+      });
+    }
+  }
+  return pairs;
+}
+
+function createPairsFromNodeList(nodeList, sourceSelector, destinationSelector) {
+  return [...nodeList].reduce((rdx, container) => {
+    const source = container.querySelector(sourceSelector);
+    const destination = container.querySelector(destinationSelector);
+    rdx.push({
+      source: source?.value.trim(),
+      destination: destination?.value.trim(),
+    });
+    return rdx;
+  }, []);
+}
+
+export function createRedirectsList(inputArea) {
+  const isTextArea = inputArea.querySelector('textarea');
+  if (isTextArea) return createPairsFromTextaArea(isTextArea.value);
+  return createPairsFromNodeList(inputArea.querySelectorAll('.input-container'), '.source', '.destination');
+}
+
+function isFullyQualifiedUrl(inputValue) {
+  try {
+    const url = new URL(inputValue);
+    return url;
+  } catch (e) {
+    return false;
+  }
+}
+
+export function processRedirects(redirectList, locales, errorCallback) {
+  return redirectList.reduce((rdx, urlPair) => {
+    locales.forEach((locale) => {
+      const source = isFullyQualifiedUrl(urlPair.source);
+      const destination = isFullyQualifiedUrl(urlPair.destination);
+
+      if (!source || !destination) {
+        errorCallback();
+      }
+
+      const appendHtml = document.querySelector('#add-html').checked;
+      const sourcePath = source.pathname?.split('.html')[0] || '/';
+      const destinationPath = () => {
+        if (!appendHtml || destination.pathname === '/') {
+          return destination.pathname;
+        }
+        return `${destination.pathname}.html`;
+      };
+      rdx.push([`/${locale}${sourcePath}`, `${destination.origin}/${locale}${destinationPath()}`]);
+    });
+    return rdx;
+  }, []);
+}

--- a/libs/blocks/redirects-formatter/utils/redirect-inputs.js
+++ b/libs/blocks/redirects-formatter/utils/redirect-inputs.js
@@ -1,0 +1,86 @@
+import { createTag } from '../../../utils/utils.js';
+
+const INPUT_LABEL_TEXT = 'Paste source and destination URLs here:';
+const PROCESS_TEXT = 'Process redirects';
+const startingRowId = 0;
+const deleteIcon = `<svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 0 18 18" width="18">
+  <title>S Delete 18 N</title>
+  <path class="fill" d="M15.75,3H12V2a1,1,0,0,0-1-1H6A1,1,0,0,0,5,2V3H1.25A.25.25,0,0,0,1,3.25v.5A.25.25,0,0,0,1.25,4h1L3.4565,16.55a.5.5,0,0,0,.5.45H13.046a.5.5,0,0,0,.5-.45L14.75,4h1A.25.25,0,0,0,16,3.75v-.5A.25.25,0,0,0,15.75,3ZM5.5325,14.5a.5.5,0,0,1-.53245-.46529L5,14.034l-.5355-8a.50112.50112,0,0,1,1-.067l.5355,8a.5.5,0,0,1-.46486.53283ZM9,14a.5.5,0,0,1-1,0V6A.5.5,0,0,1,9,6ZM11,3H6V2h5Zm1,11.034a.50112.50112,0,0,1-1-.067l.5355-8a.50112.50112,0,1,1,1,.067Z" />
+</svg>`;
+const addIcon = `<svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 0 18 18" width="18">
+  <title>S Add 18 N</title>
+  <path class="fill" d="M14.5,8H10V3.5A.5.5,0,0,0,9.5,3h-1a.5.5,0,0,0-.5.5V8H3.5a.5.5,0,0,0-.5.5v1a.5.5,0,0,0,.5.5H8v4.5a.5.5,0,0,0,.5.5h1a.5.5,0,0,0,.5-.5V10h4.5a.5.5,0,0,0,.5-.5v-1A.5.5,0,0,0,14.5,8Z" />
+</svg>`;
+
+function createSingleInputRow(id) {
+  const fromLabel = createTag('label', { for: `source-${id}` }, 'Source URL');
+  const fromInput = createTag('input', { class: 'source', type: 'text', id: `source-${id}`, name: `source-${id}` });
+  const toLabel = createTag('label', { for: `destination-${id}` }, 'Destination URL');
+  const toInput = createTag('input', { class: 'destination', type: 'text', id: `destination-${id}`, name: `destination-${id}` });
+  const removeInputButton = createTag('button', { class: 'remove-input', 'data-input-id': id }, deleteIcon);
+
+  const inputContainer = createTag('div', { class: 'input-container' }, [fromLabel, fromInput, toLabel, toInput]);
+
+  removeInputButton.addEventListener('click', () => {
+    const removalId = removeInputButton.dataset.inputId;
+    const inputsParent = document.querySelector('.single-redirects-container');
+    const elementToRemove = inputsParent.querySelector(`.redirect-input-row[data-row-id="${removalId}"]`);
+    elementToRemove.remove();
+  });
+
+  return createTag('div', { class: 'redirect-input-row', 'data-row-id': id }, [inputContainer, removeInputButton]);
+}
+
+export default function createSingleRedirectArea() {
+  const singleInput = createSingleInputRow(startingRowId);
+  const addInputButton = createTag('button', { class: 'add-input' }, addIcon);
+  const addSingleInput = createTag('div', { class: 'single-input-ui' }, addInputButton);
+
+  addSingleInput.addEventListener('click', () => {
+    const inputParent = document.querySelector('.single-redirects-container');
+    const newRowId = parseInt(inputParent.dataset.nextRowId, 10);
+
+    const newRow = createSingleInputRow(newRowId);
+    document.querySelector('.single-redirects-container').insertBefore(newRow, addSingleInput);
+    inputParent.dataset.nextRowId = newRowId + 1;
+  });
+
+  const singleRedirectsContainer = createTag('section', { class: 'single-redirects-container selected' }, [singleInput, addSingleInput]);
+  singleRedirectsContainer.dataset.nextRowId = 1;
+  return singleRedirectsContainer;
+}
+
+function createBulkRedirectsArea() {
+  const textAreaInput = createTag('textarea', { class: 'redirects-text-area', id: 'redirects-input', name: 'redirects-input' });
+  const taiLabel = createTag('label', { for: 'redirects-input' }, INPUT_LABEL_TEXT);
+  return createTag('section', { class: 'bulk-area bulk-redirects-container' }, [taiLabel, textAreaInput]);
+}
+
+export function createRedirectsArea() {
+  const selectedClassName = 'selected';
+  const singleTab = createTag('button', { class: `single-tab ${selectedClassName}`, 'data-toggles-content': 'single-redirects-container' }, 'Single Redirects');
+  const bulkTab = createTag('button', { class: 'bulk-tab', 'data-toggles-content': 'bulk-redirects-container' }, 'Bulk Redirects');
+  const htmlLabel = createTag('label', { for: 'add-html' }, 'Add .html to the end of urls');
+  const htlmCheckbox = createTag('input', { type: 'checkbox', class: 'add-html', id: 'add-html', name: 'add-html', checked: true });
+  const submitButton = createTag('button', { class: 'process-redirects' }, PROCESS_TEXT);
+  const tabsHolder = createTag('div', { class: 'redirect-tabs' }, [singleTab, bulkTab, htmlLabel, htlmCheckbox, submitButton]);
+
+  const singleInputArea = createSingleRedirectArea();
+  const bulkRedirectArea = createBulkRedirectsArea();
+
+  const uiArea = createTag('div', { class: 'redirects-ui-area' }, [singleInputArea, bulkRedirectArea]);
+
+  tabsHolder.querySelectorAll('button:not(.process-redirects)').forEach((button) => {
+    button.addEventListener('click', (e) => {
+      const currentButton = e.currentTarget;
+      tabsHolder.querySelector(`.${selectedClassName}`).classList.remove(selectedClassName);
+      currentButton.classList.add(selectedClassName);
+      const areaToShowClass = currentButton.dataset.togglesContent;
+
+      uiArea.querySelector(`section.${selectedClassName}`).classList.remove(selectedClassName);
+      uiArea.querySelector(`.${areaToShowClass}`).classList.add(selectedClassName);
+    });
+  });
+
+  return createTag('section', { class: 'main-redirects-ui-wrapper' }, [tabsHolder, uiArea]);
+}

--- a/test/blocks/redirects-formatter/checkboxes.test.js
+++ b/test/blocks/redirects-formatter/checkboxes.test.js
@@ -1,0 +1,235 @@
+import { expect } from '@esm-bundle/chai';
+import { createGroupings, createAllRegionGroup, createCheckboxArea } from '../../../libs/blocks/redirects-formatter/utils/checkboxes.js';
+
+describe('Checkbox Formatting', () => {
+  it('should format sheet data correctly', () => {
+    const sheetData = [
+      { Key1: 'Value1', Key2: 'Value2' },
+      { Key1: 'Value3', Key2: 'Value4' },
+      { Key1: 'Value1', Key2: 'Value2' },
+    ];
+
+    const formattedData = createGroupings(sheetData);
+
+    expect(formattedData).to.deep.equal({
+      Key1: ['Value1', 'Value3'],
+      Key2: ['Value2', 'Value4'],
+    });
+  });
+
+  it('should create all region group correctly', () => {
+    const sheetData = [
+      { Key1: 'Value1', Key2: 'Value2' },
+      { Key1: 'Value3', Key2: 'Value4' },
+      { Key1: 'Value1', Key2: 'Value2' },
+    ];
+
+    const allRegionGroup = createAllRegionGroup(sheetData);
+
+    expect(allRegionGroup).to.deep.equal(['Value1', 'Value2', 'Value3', 'Value4']);
+  });
+});
+
+const testData = [
+  {
+    English: 'ae_en',
+    Translated: 'ae_ar',
+    'Tier 1': 'jp',
+    'Tier 2': 'es',
+    'Tier 3': 'au',
+    'Tier 4': 'ae_ar',
+  },
+  {
+    English: 'africa_en',
+    Translated: 'ar_es',
+    'Tier 1': 'de',
+    'Tier 2': 'fi',
+    'Tier 3': 'br',
+    'Tier 4': 'ae_en',
+  },
+  {
+    English: 'au_en',
+    Translated: 'at_de',
+    'Tier 1': 'fr',
+    'Tier 2': 'dk',
+    'Tier 3': 'cn',
+    'Tier 4': 'africa_en',
+  },
+  {
+    English: 'be_en',
+    Translated: 'be_fr',
+    'Tier 1': 'uk',
+    'Tier 2': 'it',
+    'Tier 3': 'kr',
+    'Tier 4': 'ar_es',
+  },
+  {
+    English: 'ca_en',
+    Translated: 'be_nl',
+    'Tier 1': '',
+    'Tier 2': 'nl',
+    'Tier 3': 'la',
+    'Tier 4': 'at_de',
+  },
+  {
+    English: 'cis_en',
+    Translated: 'bg_bg',
+    'Tier 1': '',
+    'Tier 2': 'se',
+    'Tier 3': 'mx',
+    'Tier 4': 'be_en',
+  },
+];
+
+describe('Checkbox Area Component', () => {
+  let checkboxComponent;
+
+  beforeEach(() => {
+    checkboxComponent = createCheckboxArea(testData);
+    document.body.appendChild(checkboxComponent);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('creates the correct DOM structure', async () => {
+    // Main container checks
+    expect(checkboxComponent.tagName.toLowerCase()).to.equal('section');
+    expect(checkboxComponent.classList.contains('checkboxes-container')).to.be.true;
+
+    // UI section checks
+    const checkboxUi = checkboxComponent.querySelector('.checkbox-ui');
+    expect(checkboxUi).to.exist;
+
+    // Tab checks
+    const tabs = [...checkboxUi.querySelectorAll('.checkbox-tab')];
+    const expectedTabs = ['English', 'Translated', 'Tier 1', 'Tier 2', 'Tier 3', 'Tier 4', 'All'];
+    expect(tabs).to.have.length(expectedTabs.length);
+
+    tabs.forEach((tab, index) => {
+      expect(tab.textContent).to.equal(expectedTabs[index]);
+      if (index === 0) {
+        expect(tab.classList.contains('selected')).to.be.true;
+      }
+    });
+
+    // Select all button checks
+    const selectButton = checkboxUi.querySelector('.select');
+    expect(selectButton).to.exist;
+    expect(selectButton.textContent).to.equal('select all');
+
+    // Checkbox groups checks
+    const checkboxGroups = checkboxComponent.querySelectorAll('.checkbox-grouping');
+    expect(checkboxGroups).to.have.length(expectedTabs.length);
+
+    // English group content checks
+    const englishGroup = checkboxGroups[0];
+    expect(englishGroup.classList.contains('selected')).to.be.true;
+
+    const englishCheckboxes = englishGroup.querySelectorAll('.locale-checkbox');
+    const expectedEnglishValues = ['English-ae_en', 'English-africa_en', 'English-au_en', 'English-be_en', 'English-ca_en', 'English-cis_en'];
+    expect(englishCheckboxes).to.have.length(expectedEnglishValues.length);
+
+    englishCheckboxes.forEach((checkbox, index) => {
+      expect(checkbox.id).to.equal(expectedEnglishValues[index]);
+    });
+  });
+
+  it('handles tab switching correctly', async () => {
+    const tabs = checkboxComponent.querySelectorAll('.checkbox-tab');
+    const secondTab = tabs[1]; // Translated tab
+
+    // Click second tab
+    secondTab.click();
+
+    // Check tab selection
+    expect(secondTab.classList.contains('selected')).to.be.true;
+    expect(tabs[0].classList.contains('selected')).to.be.false;
+
+    // Check group visibility
+    const groups = checkboxComponent.querySelectorAll('.checkbox-grouping');
+    expect(groups[1].classList.contains('selected')).to.be.true;
+    expect(groups[0].classList.contains('selected')).to.be.false;
+  });
+
+  it('handles tab switching correctly', async () => {
+    const tabs = checkboxComponent.querySelectorAll('.checkbox-tab');
+    const secondTab = tabs[1]; // Translated tab
+
+    // Click second tab
+    secondTab.click();
+
+    // Check tab selection
+    expect(secondTab.classList.contains('selected')).to.be.true;
+    expect(tabs[0].classList.contains('selected')).to.be.false;
+
+    // Check group visibility
+    const groups = checkboxComponent.querySelectorAll('.checkbox-grouping');
+    expect(groups[1].classList.contains('selected')).to.be.true;
+    expect(groups[0].classList.contains('selected')).to.be.false;
+  });
+
+  it('handles select all functionality correctly', async () => {
+    const selectButton = checkboxComponent.querySelector('.select');
+    const firstGroup = checkboxComponent.querySelector('.checkbox-grouping.selected');
+    const checkboxes = firstGroup.querySelectorAll('input[type="checkbox"]');
+
+    // Test select all
+    selectButton.click();
+
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox.checked).to.be.true;
+    });
+    expect(selectButton.textContent).to.equal('remove all');
+
+    // Test deselect all
+    selectButton.click();
+
+    checkboxes.forEach((checkbox) => {
+      expect(checkbox.checked).to.be.false;
+    });
+    expect(selectButton.textContent).to.equal('select all');
+  });
+
+  it('unchecks all checkboxes when switching tabs', async () => {
+    const selectButton = checkboxComponent.querySelector('.select');
+    const tabs = checkboxComponent.querySelectorAll('.checkbox-tab');
+    const firstTab = tabs[0]; // English tab
+    const secondTab = tabs[1]; // Translated tab
+
+    // Select all checkboxes in first tab
+    selectButton.click();
+    const firstGroupCheckboxes = checkboxComponent.querySelector('.checkbox-grouping.selected')
+      .querySelectorAll('input[type="checkbox"]');
+    firstGroupCheckboxes.forEach((checkbox) => {
+      expect(checkbox.checked).to.be.true;
+    });
+
+    // Switch to second tab
+    secondTab.click();
+
+    // Verify tab selection
+    expect(secondTab.classList.contains('selected')).to.be.true;
+    expect(firstTab.classList.contains('selected')).to.be.false;
+
+    // Verify group visibility
+    const groups = checkboxComponent.querySelectorAll('.checkbox-grouping');
+    expect(groups[1].classList.contains('selected')).to.be.true;
+    expect(groups[0].classList.contains('selected')).to.be.false;
+
+    // Verify all checkboxes in first tab are now unchecked
+    firstGroupCheckboxes.forEach((checkbox) => {
+      expect(checkbox.checked).to.be.false;
+    });
+
+    // Verify all checkboxes in second tab are unchecked
+    const secondGroupCheckboxes = groups[1].querySelectorAll('input[type="checkbox"]');
+    secondGroupCheckboxes.forEach((checkbox) => {
+      expect(checkbox.checked).to.be.false;
+    });
+
+    // Verify select button text is reset
+    expect(selectButton.textContent).to.equal('select all');
+  });
+});

--- a/test/blocks/redirects-formatter/mocks/locale-config.json
+++ b/test/blocks/redirects-formatter/mocks/locale-config.json
@@ -1,0 +1,1 @@
+{"total":6,"offset":0,"limit":6,"data":[{"prefix":"ar"},{"prefix":"gt"},{"prefix":"ru"},{"prefix":"ck"},{"prefix":"cn"},{"prefix":"si"}],":type":"sheet"}

--- a/test/blocks/redirects-formatter/mocks/redirects-formatter.html
+++ b/test/blocks/redirects-formatter/mocks/redirects-formatter.html
@@ -1,0 +1,3 @@
+<div>
+  <div class="redirects-formatter"></div>
+</div>

--- a/test/blocks/redirects-formatter/process-redirects.test.js
+++ b/test/blocks/redirects-formatter/process-redirects.test.js
@@ -1,0 +1,145 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  getLocalesFromUi,
+  createRedirectsList,
+  processRedirects,
+} from '../../../libs/blocks/redirects-formatter/utils/process-redirects.js';
+
+describe('Process Redirects', () => {
+  describe('getLocalesFromUi', () => {
+    it('should return an array of checked locale IDs', () => {
+      const nodeList = [
+        { value: 'en', checked: true },
+        { value: 'fr', checked: false },
+        { value: 'de', checked: true },
+      ];
+      const result = getLocalesFromUi(nodeList);
+      expect(result).to.deep.equal(['en', 'de']);
+    });
+
+    it('should return empty array when no locales checked', () => {
+      const nodeList = [
+        { id: 'en', checked: false },
+        { id: 'fr', checked: false },
+      ];
+      expect(getLocalesFromUi(nodeList)).to.deep.equal([]);
+    });
+  });
+
+  describe('createRedirectsList', () => {
+    let originalBody;
+
+    beforeEach(() => {
+      originalBody = document.body.innerHTML;
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = originalBody;
+    });
+
+    it('should create pairs from textarea input', () => {
+      document.body.innerHTML = `
+        <div class="redirect-input">
+          <textarea class="redirect-pairs">/path1  /path2
+/path3   /path4</textarea>
+        </div>
+      `;
+      const inputArea = document.querySelector('.redirect-input');
+      const result = createRedirectsList(inputArea);
+      expect(result).to.deep.equal([
+        { source: '/path1', destination: '/path2' },
+        { source: '/path3', destination: '/path4' },
+      ]);
+    });
+
+    it('should create pairs from input containers', () => {
+      document.body.innerHTML = `
+        <div class="redirect-input">
+          <div class="input-container">
+            <input type="text" class="source" value="/source1">
+            <input type="text" class="destination" value="/dest1">
+          </div>
+          <div class="input-container">
+            <input type="text" class="source" value="/source2">
+            <input type="text" class="destination" value="/dest2">
+          </div>
+        </div>
+      `;
+      const inputArea = document.querySelector('.redirect-input');
+      const result = createRedirectsList(inputArea);
+      expect(result).to.deep.equal([
+        { source: '/source1', destination: '/dest1' },
+        { source: '/source2', destination: '/dest2' },
+      ]);
+    });
+  });
+
+  describe('processRedirects', () => {
+    beforeEach(() => {
+      // Add checkbox to DOM for testing
+      document.body.innerHTML = '<input type="checkbox" id="add-html" checked >';
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('should append .html when checkbox is checked', () => {
+      const redirectList = [{
+        source: 'https://www.example.com/path1',
+        destination: 'https://www.adobe.com/path2',
+      }];
+      const locales = ['en', 'fr'];
+      const errorCallback = () => {};
+
+      const result = processRedirects(redirectList, locales, errorCallback);
+      expect(result).to.deep.equal([
+        ['/en/path1', 'https://www.adobe.com/en/path2.html'],
+        ['/fr/path1', 'https://www.adobe.com/fr/path2.html'],
+      ]);
+    });
+
+    it('should not append .html when checkbox is unchecked', () => {
+      document.querySelector('#add-html').checked = false;
+      const redirectList = [{
+        source: 'https://example.com/path1',
+        destination: 'https://adobe.com/path2',
+      }];
+      const locales = ['en'];
+      const errorCallback = () => {};
+
+      const result = processRedirects(redirectList, locales, errorCallback);
+      expect(result).to.deep.equal([
+        ['/en/path1', 'https://adobe.com/en/path2'],
+      ]);
+    });
+
+    it('should call error callback for invalid URLs', () => {
+      let errorCalled = false;
+      const redirectList = [{
+        source: 'invalid-url',
+        destination: 'https://www.adobe.com/path',
+      }];
+      const locales = ['en'];
+      const errorCallback = () => { errorCalled = true; };
+
+      processRedirects(redirectList, locales, errorCallback);
+      expect(errorCalled).to.be.true;
+    });
+
+    it('should not append .html to root path even when checkbox is checked', () => {
+      document.querySelector('#add-html').checked = true;
+      const redirectList = [{
+        source: 'https://example.com/path1',
+        destination: 'https://external.com/',
+      }];
+      const locales = ['en'];
+      const errorCallback = () => {};
+
+      const result = processRedirects(redirectList, locales, errorCallback);
+      expect(result).to.deep.equal([
+        ['/en/path1', 'https://external.com/en/'],
+      ]);
+    });
+  });
+});

--- a/test/blocks/redirects-formatter/redirect-inputs.test.js
+++ b/test/blocks/redirects-formatter/redirect-inputs.test.js
@@ -1,0 +1,150 @@
+import { expect } from '@esm-bundle/chai';
+import { createRedirectsArea } from '../../../libs/blocks/redirects-formatter/utils/redirect-inputs.js';
+
+describe('Redirects Formatter Tests', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('creates main redirects UI structure', () => {
+    const redirectsArea = createRedirectsArea();
+    container.appendChild(redirectsArea);
+
+    // Check main wrapper
+    expect(redirectsArea.classList.contains('main-redirects-ui-wrapper')).to.be.true;
+
+    // Check tabs
+    const tabs = redirectsArea.querySelector('.redirect-tabs');
+    expect(tabs).to.exist;
+    expect(tabs.querySelectorAll('button').length).to.equal(3);
+
+    // Check UI areas
+    const uiArea = redirectsArea.querySelector('.redirects-ui-area');
+    expect(uiArea).to.exist;
+    expect(uiArea.querySelectorAll('section').length).to.equal(2);
+  });
+
+  it('switches between single and bulk views when tabs are clicked', () => {
+    const redirectsArea = createRedirectsArea();
+    container.appendChild(redirectsArea);
+
+    const bulkTab = redirectsArea.querySelector('.bulk-tab');
+    const singleTab = redirectsArea.querySelector('.single-tab');
+
+    // Initially single view should be selected
+    expect(redirectsArea.querySelector('.single-redirects-container').classList.contains('selected')).to.be.true;
+    expect(redirectsArea.querySelector('.bulk-redirects-container').classList.contains('selected')).to.be.false;
+
+    // Click bulk tab
+    bulkTab.click();
+    expect(redirectsArea.querySelector('.single-redirects-container').classList.contains('selected')).to.be.false;
+    expect(redirectsArea.querySelector('.bulk-redirects-container').classList.contains('selected')).to.be.true;
+
+    // Click single tab
+    singleTab.click();
+    expect(redirectsArea.querySelector('.single-redirects-container').classList.contains('selected')).to.be.true;
+    expect(redirectsArea.querySelector('.bulk-redirects-container').classList.contains('selected')).to.be.false;
+  });
+
+  it('sets correct UI area as selected when single/bulk tabs are clicked', () => {
+    const redirectsArea = createRedirectsArea();
+    container.appendChild(redirectsArea);
+
+    const bulkTab = redirectsArea.querySelector('.bulk-tab');
+    const singleTab = redirectsArea.querySelector('.single-tab');
+    const uiArea = redirectsArea.querySelector('.redirects-ui-area');
+
+    // Initially single tab and single UI area should be selected
+    expect(singleTab.classList.contains('selected')).to.be.true;
+    expect(bulkTab.classList.contains('selected')).to.be.false;
+    expect(uiArea.querySelector('.single-redirects-container').classList.contains('selected')).to.be.true;
+    expect(uiArea.querySelector('.bulk-redirects-container').classList.contains('selected')).to.be.false;
+
+    // Click bulk tab
+    bulkTab.click();
+    expect(singleTab.classList.contains('selected')).to.be.false;
+    expect(bulkTab.classList.contains('selected')).to.be.true;
+    expect(uiArea.querySelector('.single-redirects-container').classList.contains('selected')).to.be.false;
+    expect(uiArea.querySelector('.bulk-redirects-container').classList.contains('selected')).to.be.true;
+
+    // Click single tab
+    singleTab.click();
+    expect(singleTab.classList.contains('selected')).to.be.true;
+    expect(bulkTab.classList.contains('selected')).to.be.false;
+    expect(uiArea.querySelector('.single-redirects-container').classList.contains('selected')).to.be.true;
+    expect(uiArea.querySelector('.bulk-redirects-container').classList.contains('selected')).to.be.false;
+  });
+
+  it('adds new input row when + button is clicked', () => {
+    const redirectsArea = createRedirectsArea();
+    container.appendChild(redirectsArea);
+
+    const addButton = redirectsArea.querySelector('.add-input');
+
+    // Initially there should be one input row
+    expect(redirectsArea.querySelectorAll('.redirect-input-row').length).to.equal(1);
+
+    // Click add button
+    addButton.click();
+    expect(redirectsArea.querySelectorAll('.redirect-input-row').length).to.equal(2);
+
+    // Check if the new row has correct ID
+    const rows = redirectsArea.querySelectorAll('.redirect-input-row');
+    expect(rows[0].getAttribute('data-row-id')).to.equal('0');
+    expect(rows[1].getAttribute('data-row-id')).to.equal('1');
+  });
+
+  it('removes input row when - button is clicked', () => {
+    const redirectsArea = createRedirectsArea();
+    container.appendChild(redirectsArea);
+
+    // Add a new row first
+    const addButton = redirectsArea.querySelector('.add-input');
+    addButton.click();
+
+    expect(redirectsArea.querySelectorAll('.redirect-input-row').length).to.equal(2);
+
+    // Click remove button on second row
+    const removeButton = redirectsArea.querySelectorAll('.remove-input')[1];
+    removeButton.click();
+
+    expect(redirectsArea.querySelectorAll('.redirect-input-row').length).to.equal(1);
+    expect(redirectsArea.querySelector('.redirect-input-row').getAttribute('data-row-id')).to.equal('0');
+  });
+
+  it('maintains correct row IDs when all rows are deleted and new ones are added', () => {
+    const redirectsArea = createRedirectsArea();
+    container.appendChild(redirectsArea);
+
+    // Add two additional rows (total 3 rows)
+    const addButton = redirectsArea.querySelector('.add-input');
+    addButton.click();
+    addButton.click();
+    expect(redirectsArea.querySelectorAll('.redirect-input-row').length).to.equal(3);
+
+    // Remove all rows
+    const removeButtons = redirectsArea.querySelectorAll('.remove-input');
+    removeButtons[2].click();
+    removeButtons[1].click();
+    removeButtons[0].click();
+    expect(redirectsArea.querySelectorAll('.redirect-input-row').length).to.equal(0);
+
+    // Add a new row
+    addButton.click();
+    const newRow = redirectsArea.querySelector('.redirect-input-row');
+    expect(newRow).to.exist;
+    expect(newRow.getAttribute('data-row-id')).to.equal('3');
+
+    // Add another row and verify it gets the next sequential ID
+    addButton.click();
+    const rows = redirectsArea.querySelectorAll('.redirect-input-row');
+    expect(rows[1].getAttribute('data-row-id')).to.equal('4');
+  });
+});

--- a/test/blocks/redirects-formatter/redirects-formatter.test.js
+++ b/test/blocks/redirects-formatter/redirects-formatter.test.js
@@ -1,0 +1,102 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+
+const {
+  default: init,
+  NO_LOCALE_ERROR,
+} = await import('../../../libs/blocks/redirects-formatter/redirects-formatter.js');
+const COPY_TO_CLIPBOARD = 'Copied';
+
+describe('Redirects Formatter', () => {
+  const ogFetch = window.fetch;
+  let clipboardWriteText;
+  let originalClipboard;
+
+  beforeEach(async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/redirects-formatter.html' });
+
+    // Store original clipboard
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+
+    // Mock clipboard using Object.defineProperty and return a Promise
+    clipboardWriteText = sinon.stub().returns(Promise.resolve());
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: clipboardWriteText },
+      configurable: true,
+    });
+
+    const block = document.querySelector('.redirects-formatter');
+
+    sinon.stub(window, 'fetch');
+    const fetchText = await readFile({ path: './mocks/locale-config.json' });
+    const res = new window.Response(fetchText, { status: 200 });
+    window.fetch.returns(Promise.resolve(res));
+
+    await init(block);
+  });
+
+  afterEach(async () => {
+    window.fetch = ogFetch;
+    // Restore original clipboard
+    if (originalClipboard) {
+      Object.defineProperty(navigator, 'clipboard', originalClipboard);
+    } else {
+      delete navigator.clipboard;
+    }
+  });
+
+  it('informs the user of an error if no locales are selected', async () => {
+    const checkBoxes = document.querySelectorAll('.checkboxes .locale-checkbox');
+    expect([...checkBoxes].every((cb) => !cb.checked)).to.be.true;
+
+    const processButton = document.querySelector('.process-redirects');
+    const errorMessage = document.querySelector('.error');
+    const checkBoxContainer = document.querySelector('.checkboxes-container');
+    processButton.click();
+    expect(errorMessage.innerHTML).to.equal(NO_LOCALE_ERROR);
+    expect(checkBoxContainer.classList.contains('error-border')).to.be.true;
+  });
+
+  it('informs the user of an error if an incorrect url is passed in to the input', async () => {
+    const bulkTab = document.querySelector('.bulk-redirects-container');
+    const bulkTextArea = bulkTab.querySelector('textarea');
+    const bulkTabButton = document.querySelector('.bulk-tab');
+    const processButton = document.querySelector('.process-redirects');
+    const errorMessage = document.querySelector('.error');
+    const selectAllCB = document.querySelector('.select-all-container .select');
+    const correct = 'https://www.adobe.com/resource\thttps://www.adobe.com';
+    const incorrect = '/resource\thttps://www.adobe.com';
+
+    bulkTabButton.click();
+    selectAllCB.click();
+    bulkTextArea.value = correct;
+    processButton.click();
+    expect(bulkTab.classList.contains('selected')).to.be.true;
+    expect(bulkTab.classList.contains('error-border')).to.be.false;
+
+    bulkTextArea.value = incorrect;
+    processButton.click();
+    expect(errorMessage.innerHTML.length > 0).to.be.true;
+    expect(document.querySelector('.redirects-ui-area .selected.error-border')).to.exist;
+  });
+
+  it('copies formatted redirects to clipboard when copy button is clicked', async () => {
+    const bulkTab = document.querySelector('.bulk-redirects-container');
+    const bulkTextArea = bulkTab.querySelector('textarea');
+    const bulkTabButton = document.querySelector('.bulk-tab');
+    const processButton = document.querySelector('.process-redirects');
+    const selectAllCB = document.querySelector('.select-all-container .select');
+    const copyButton = document.querySelector('.copy');
+    const testInput = 'https://www.adobe.com/resource\thttps://www.adobe.com';
+
+    bulkTabButton.click();
+    selectAllCB.click();
+    bulkTextArea.value = testInput;
+    processButton.click();
+    await copyButton.click();
+
+    expect(clipboardWriteText.called).to.be.true;
+    expect(copyButton.innerHTML).to.equal(COPY_TO_CLIPBOARD);
+  });
+});


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds a Redirects Formatter tool that is currently used in Bacom to Milo.
* Adds additional functionality to the formatter currently on Bacom:
** Ability to create checkbox groupings for locals
** Ability to add single redirects as well as bulk redirects 
** Instructions can be authored 
** Styling changes

Resolves: [MWPW-145857](https://jira.corp.adobe.com/browse/MWPW-145857)

**Test URLs:**
- Before: https://main--milo--jasonhowellslavin.hlx.live/drafts/slavin/tools/redirects-formatter?martech=off
- After: https://redirects-formatter-milo--milo--jasonhowellslavin.hlx.live/drafts/slavin/tools/redirects-formatter?martech=off
