### PR TITLE
[MWPW-170714] - Section metadata grid

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -319,11 +319,13 @@ main > .section[class*='-up'] > .content {
   }
 }
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 1070px) {
   .section.two-up {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+}
 
+@media screen and (min-width: 1200px) {
   .section.three-up {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -269,6 +269,9 @@ main > .section[class*='-up'] > .content {
     display: block;
   }
 
+  .section[class*='grid-width-'] > *:not(:first-child) {
+    margin-top: var(--spacing-m);
+  }
 }
 
 @media screen and (min-width: 600px) and (max-width: 1200px) {

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -266,11 +266,8 @@ main > .section[class*='-up'] > .content {
   }
 
   .section[class*='grid-width-'] {
-    display: block;
-  }
-
-  .section[class*='grid-width-'] > *:not(:first-child) {
-    margin-top: var(--spacing-m);
+    display: flex;
+    flex-direction: column;
   }
 }
 
@@ -326,6 +323,10 @@ main > .section[class*='-up'] > .content {
 }
 
 @media screen and (min-width: 1200px) {
+  .section.two-up {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .section.three-up {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }

--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -316,12 +316,6 @@ main > .section[class*='-up'] > .content {
   }
 }
 
-@media screen and (min-width: 1070px) {
-  .section.two-up {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
 @media screen and (min-width: 1200px) {
   .section.two-up {
     grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
This resolves the issue where when on mobile the spaces between the cards is missing, and the section metadata two-up from the resolution 1070px to 1199px ended up making 3 items instead of 2 per row.

Resolves: [MWPW-170714](https://jira.corp.adobe.com/browse/MWPW-170714)

**PR Note:**
#Example2 looks to be intended functionality, which is explained in the ticket comment https://jira.corp.adobe.com/browse/MWPW-170714#comment-47764490, will need more discussion with Consonant and won't be addressed in this PR, while #Example1 will be addressed.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/klee/jira-ticket/mwpw-170714-section-metadata-gap-ups?martech=off
- After: https://section-metadata-grid--milo--adobecom.aem.page/drafts/klee/jira-ticket/mwpw-170714-section-metadata-gap-ups?martech=off

**Test URLs for the previous solution that caused this issue:**
- Before: https://main--milo--adobecom.aem.page/drafts/sharathkannan/rtl?martech=off
- After: https://section-metadata-grid--milo--adobecom.aem.page/drafts/sharathkannan/rtl?martech=off






