### PR TITLE
quiz icon bug fix

### DIFF
--- a/libs/blocks/quiz/quiz.css
+++ b/libs/blocks/quiz/quiz.css
@@ -383,6 +383,7 @@ html[dir="rtl"] .quiz-step::after {
     padding: 6px 16px 24px;
   }
 
+  .quiz-option.has-icon .quiz-option-text-container,
   .quiz-option.has-image .quiz-option-text-container,
   .quiz-option.has-background .quiz-option-text-container {
     flex-grow: 1;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* fix padding for icon only cards

Resolves: [MWPW-172996](https://jira.corp.adobe.com/browse/MWPW-172996)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/colloyd/quiz/?martech=off
- After: https://quiz-icon-bug-fix--milo--colloyd.aem.page/drafts/colloyd/quiz/?martech=off
