### PR TITLE
Improve carousel accessibility

### DIFF
--- a/libs/blocks/carousel/carousel.css
+++ b/libs/blocks/carousel/carousel.css
@@ -722,3 +722,10 @@ html[dir="rtl"] .carousel .move-indicators {
     transform: translateX(calc(round(down, (var(--offset) / (var(--slides) - 1)), 2px) * -1));
   }
 }
+
+.carousel .aria-live-container {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}

--- a/libs/blocks/carousel/carousel.css
+++ b/libs/blocks/carousel/carousel.css
@@ -193,13 +193,9 @@ html[dir="rtl"] .carousel-slides .section.carousel-slide {
   opacity: 1;
 } 
 
-.carousel-slide.visibility-hidden {
+.carousel-slide.non-visible-slide {
   visibility: hidden;
 }
-
-/* .carousel-slide:not(.active) { */
-/*   visibility: hidden; */
-/* } */
 
 .carousel-slides.is-ready,
 .carousel-slides.is-ready.is-reversing,

--- a/libs/blocks/carousel/carousel.css
+++ b/libs/blocks/carousel/carousel.css
@@ -193,6 +193,14 @@ html[dir="rtl"] .carousel-slides .section.carousel-slide {
   opacity: 1;
 } 
 
+.carousel-slide.visibility-hidden {
+  visibility: hidden;
+}
+
+/* .carousel-slide:not(.active) { */
+/*   visibility: hidden; */
+/* } */
+
 .carousel-slides.is-ready,
 .carousel-slides.is-ready.is-reversing,
 .carousel[class*='show-'] .carousel-slides.is-ready,

--- a/libs/blocks/carousel/carousel.js
+++ b/libs/blocks/carousel/carousel.js
@@ -215,7 +215,6 @@ function moveSlides(event, carouselElements, jumpToIndex) {
   referenceSlide.classList.remove('reference-slide');
   referenceSlide.style.order = null;
   activeSlide.classList.remove('active');
-  activeSlide.setAttribute('aria-hidden', true);
   activeSlide.querySelectorAll('a, video').forEach((focusableElement) => focusableElement.setAttribute('tabindex', -1));
   activeSlideIndicator.classList.remove('active');
   activeSlideIndicator.setAttribute('tabindex', -1);
@@ -269,8 +268,8 @@ function moveSlides(event, carouselElements, jumpToIndex) {
   updateAriaLive(ariaLive, activeSlide);
 
   // Update active slide and indicator dot attributes
+  activeSlide.classList.remove('visibility-hidden');
   activeSlide.classList.add('active');
-  activeSlide.removeAttribute('aria-hidden');
   const indexOfActive = [...activeSlide.parentElement.children]
     .findIndex((ele) => activeSlide.isSameNode(ele));
   const IndexOfShowClass = [...carouselElements.el.classList].findIndex((ele) => ele.includes('show-'));
@@ -308,7 +307,12 @@ function moveSlides(event, carouselElements, jumpToIndex) {
   */
   const slideDelay = 25;
   slideContainer.classList.remove('is-ready');
-  return setTimeout(() => slideContainer.classList.add('is-ready'), slideDelay);
+  setTimeout(() => {
+    slides[activeSlideIndex].classList.add('visibility-hidden');
+  }, 600);
+  return setTimeout(() => {
+    slideContainer.classList.add('is-ready');
+  }, slideDelay);
 }
 
 export function getSwipeDistance(start, end) {
@@ -427,10 +431,10 @@ export default function init(el) {
   const slides = [...candidateKeys].reduce((rdx, key) => {
     if (key.textContent === 'carousel' && key.nextElementSibling.textContent === carouselName) {
       const slide = key.closest('.section');
-      slide.classList.add('carousel-slide');
+      slide.classList.add('carousel-slide', 'visibility-hidden');
       rdx.push(slide);
       slide.setAttribute('data-index', rdx.indexOf(slide));
-      slide.setAttribute('aria-hidden', true);
+      // slide.setAttribute('aria-hidden', true);
     }
     return rdx;
   }, []);
@@ -498,6 +502,7 @@ export default function init(el) {
   }
   parentArea.addEventListener(MILO_EVENTS.DEFERRED, handleDeferredImages, true);
 
+  slides[0].classList.remove('visibility-hidden');
   slides[0].classList.add('active');
   slides[0].removeAttribute('aria-hidden');
   const IndexOfShowClass = [...el.classList].findIndex((ele) => ele.includes('show-'));

--- a/libs/blocks/carousel/carousel.js
+++ b/libs/blocks/carousel/carousel.js
@@ -184,6 +184,7 @@ function updateAriaLive(ariaLive, slide) {
   });
 }
 
+let hiddenSlideTimeout;
 function moveSlides(event, carouselElements, jumpToIndex) {
   const {
     slideContainer,
@@ -195,6 +196,7 @@ function moveSlides(event, carouselElements, jumpToIndex) {
     ariaLive,
   } = carouselElements;
 
+  clearTimeout(hiddenSlideTimeout);
   ariaLive.textContent = '';
 
   let referenceSlide = slideContainer.querySelector('.reference-slide');
@@ -268,7 +270,7 @@ function moveSlides(event, carouselElements, jumpToIndex) {
   updateAriaLive(ariaLive, activeSlide);
 
   // Update active slide and indicator dot attributes
-  activeSlide.classList.remove('visibility-hidden');
+  activeSlide.classList.remove('non-visible-slide');
   activeSlide.classList.add('active');
   const indexOfActive = [...activeSlide.parentElement.children]
     .findIndex((ele) => activeSlide.isSameNode(ele));
@@ -307,9 +309,9 @@ function moveSlides(event, carouselElements, jumpToIndex) {
   */
   const slideDelay = 25;
   slideContainer.classList.remove('is-ready');
-  setTimeout(() => {
-    slides[activeSlideIndex].classList.add('visibility-hidden');
-  }, 600);
+  hiddenSlideTimeout = setTimeout(() => {
+    slides[activeSlideIndex].classList.add('non-visible-slide');
+  }, 625);
   return setTimeout(() => {
     slideContainer.classList.add('is-ready');
   }, slideDelay);
@@ -431,10 +433,9 @@ export default function init(el) {
   const slides = [...candidateKeys].reduce((rdx, key) => {
     if (key.textContent === 'carousel' && key.nextElementSibling.textContent === carouselName) {
       const slide = key.closest('.section');
-      slide.classList.add('carousel-slide', 'visibility-hidden');
+      slide.classList.add('carousel-slide', 'non-visible-slide');
       rdx.push(slide);
       slide.setAttribute('data-index', rdx.indexOf(slide));
-      // slide.setAttribute('aria-hidden', true);
     }
     return rdx;
   }, []);
@@ -502,9 +503,8 @@ export default function init(el) {
   }
   parentArea.addEventListener(MILO_EVENTS.DEFERRED, handleDeferredImages, true);
 
-  slides[0].classList.remove('visibility-hidden');
+  slides[0].classList.remove('non-visible-slide');
   slides[0].classList.add('active');
-  slides[0].removeAttribute('aria-hidden');
   const IndexOfShowClass = [...el.classList].findIndex((ele) => ele.includes('show-'));
   let NoOfVisibleSlides = 1;
   if (IndexOfShowClass >= 0) {

--- a/nala/blocks/carousel/carousel.page.js
+++ b/nala/blocks/carousel/carousel.page.js
@@ -150,14 +150,14 @@ export default class Carousel {
  * @param {string} tagOrClass - The tag name or class name of the element containing the text.
  * @returns {Promise<string>} The text content of the specified carousel slide.
  */
-  async getSlideText(index, tagOrClass) {
+  async getSlideText(index, tagOrClass, elVisibility = 'visible') {
     let slideSelector = `.carousel-slide:nth-child(${index}) `;
     if (tagOrClass.startsWith('.')) {
       slideSelector += tagOrClass;
     } else {
       slideSelector += `${tagOrClass}`;
     }
-    await this.page.waitForSelector(slideSelector);
+    await this.page.waitForSelector(slideSelector, { state: elVisibility });
     const slide = await this.page.$(slideSelector);
     const text = await slide.textContent();
     return text;

--- a/nala/blocks/carousel/carousel.test.js
+++ b/nala/blocks/carousel/carousel.test.js
@@ -32,7 +32,7 @@ test.describe('Milo Carousel Block test suite', () => {
       // verify carousel indictor and active indicator
       expect(await carousel.areIndicatorsDisplayed()).toBeTruthy();
       expect(await carousel.getNumberOfIndicators()).toBe(4);
-      expect(await carousel.getCurrentIndicatorIndex()).toBeNull();
+      expect(await carousel.getCurrentIndicatorIndex()).toBe('0');
 
       // verify carousel next and previous buttons
       expect(await carousel.isNextButtonlVisible()).toBeTruthy();
@@ -43,12 +43,12 @@ test.describe('Milo Carousel Block test suite', () => {
       // move to next slide by clicking next button and verify h2 tag header
       await carousel.moveToNextSlide();
       expect(await carousel.getCurrentSlideIndex()).toBe('1');
-      expect(await carousel.getSlideText(1, 'h2', 'Orange Slices')).toBeTruthy();
+      expect(await carousel.getSlideText(1, 'h2', 'hidden')).toBeTruthy();
 
       // move to 3rd slide by clicking indicator and verify h2 tag header
       await carousel.moveToIndicator(3);
-      expect(await carousel.getCurrentIndicatorIndex()).toBeNull();
-      expect(await carousel.getSlideText(3, 'h2', 'Apples')).toBeTruthy();
+      expect(await carousel.getCurrentIndicatorIndex()).toBe('0');
+      expect(await carousel.getSlideText(3, 'h2', 'hidden')).toBeTruthy();
     });
 
     await test.step('step-4: Verify the accessibility test on the carousel block', async () => {
@@ -76,7 +76,7 @@ test.describe('Milo Carousel Block test suite', () => {
       // verify indicator visibility, count and index of active slide
       expect(await carousel.areIndicatorsDisplayed()).toBeTruthy();
       expect(await carousel.getNumberOfIndicators()).toBe(4);
-      expect(await carousel.getCurrentIndicatorIndex()).toBeNull();
+      expect(await carousel.getCurrentIndicatorIndex()).toBe('0');
 
       expect(await carousel.isNextButtonlVisible()).toBeTruthy();
       expect(await carousel.isPreviousButtonlVisible()).toBeTruthy();
@@ -119,7 +119,7 @@ test.describe('Milo Carousel Block test suite', () => {
     await test.step('step-3: Perform carousel slides and controls operation and verify contents', async () => {
       // move to next slide by clicking next button and verify h2 tag header
       await carousel.moveToNextSlide();
-      expect(await carousel.getSlideText(1, 'h2', 'Melon')).toBeTruthy();
+      expect(await carousel.getSlideText(1, 'h2')).toBeTruthy();
     });
 
     await test.step('step-3: Verify the accessibility test on the carousel show-2 container block', async () => {


### PR DESCRIPTION
Issues: Missing slide content announcement when navigating carousel and select slide indicator missing correct state. 
* Added `aria-live` [docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-live)
* Update `aria-live` with slide text content, so it gets announced to the user
* Set correct `aria-label` attributes to the slide indicators
* Set `aria-current` attribute to the active indicator

Resolves: [MWPW-171960](https://jira.corp.adobe.com/browse/MWPW-171960) and [MWPW-172184](https://jira.corp.adobe.com/browse/MWPW-172184)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/mwpw-171960-carousel-dots/carousel?martech=off
- After: https://accessibility-carousel--milo--adobecom.aem.page/drafts/ratko/mwpw-171960-carousel-dots/carousel?martech=off





