### PR TITLE
MWPW-173219: When 3-in-1 is disabled, CTA opens Dexter modal instead of redirection

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -600,6 +600,7 @@ export async function getModalAction(offers, options, el) {
   const hash = setCtaHash(el, checkoutLinkConfig, offerType);
   let url = checkoutLinkConfig[columnName];
   if (!url && !el?.isOpen3in1Modal) return undefined;
+  if (url && options.modal !== 'true') return undefined;
   url = isInternalModal(url) || isProdModal(url)
     ? localizeLink(checkoutLinkConfig[columnName]) : checkoutLinkConfig[columnName];
   return {

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -742,7 +742,7 @@ describe('Merch Block', () => {
       });
       fetchCheckoutLinkConfigs.promise = undefined;
       setCheckoutLinkConfigs(CHECKOUT_LINK_CONFIGS);
-      const action = await getModalAction([{ productArrangement: { productFamily: 'ILLUSTRATOR' } }], { modal: true });
+      const action = await getModalAction([{ productArrangement: { productFamily: 'ILLUSTRATOR' } }], { modal: 'true' });
       expect(action.url).to.equal('https://www.adobe.com/fr/plans-fragments/modals/individual/modals-content-rich/illustrator/master.modal.html');
     });
 
@@ -756,7 +756,7 @@ describe('Merch Block', () => {
       });
       fetchCheckoutLinkConfigs.promise = undefined;
       setCheckoutLinkConfigs(CHECKOUT_LINK_CONFIGS);
-      const action = await getModalAction([{ productArrangement: { productFamily: 'AUDITION' } }], { modal: true });
+      const action = await getModalAction([{ productArrangement: { productFamily: 'AUDITION' } }], { modal: 'true' });
       expect(action.url).to.equal('www.adobe.com/will/not/be/localized.html');
     });
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -716,6 +716,22 @@ describe('Merch Block', () => {
       expect(action).to.be.undefined;
     });
 
+    it('getModalAction: returns undefined if 3in1 is off and modal is not true', async () => {
+      const meta = document.createElement('meta');
+      meta.setAttribute('name', 'mas-ff-3in1');
+      meta.setAttribute('content', 'off');
+      document.getElementsByTagName('head')[0].appendChild(meta);
+      setConfig({
+        ...config,
+        prodDomains: PROD_DOMAINS,
+      });
+      fetchCheckoutLinkConfigs.promise = undefined;
+      setCheckoutLinkConfigs(CHECKOUT_LINK_CONFIGS);
+      const action = await getModalAction([{ productArrangement: { productFamily: 'PHOTOSHOP' } }], { modal: 'crm' });
+      expect(action).to.be.undefined;
+      document.getElementsByTagName('head')[0].removeChild(meta);
+    });
+
     it('getModalAction: localize buy now path if it comes from us/en production', async () => {
       setConfig({
         ...config,


### PR DESCRIPTION
This update refines the behavior of CTA links based on the modal URL parameter and the 3-in-1 experience feature flag:
If the modal parameter is set to anything other than 'true' and the 3-in-1 experience is disabled via metadata, the CTA will now redirect users to the appropriate page instead of opening a Dexter modal.
The Dexter modal will only open when the modal parameter is explicitly set to 'true' and the 3-in-1 experience is disabled.

Resolves: [MWPW-173219](https://jira.corp.adobe.com/browse/MWPW-173219)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/pl/drafts/mirafedas/3in1-test-page?martech=off
- After: https://mwpw-173219-3in1-disabled-for-dc--milo--mirafedas.aem.live/pl/drafts/mirafedas/3in1-test-page?martech=off
