### PR TITLE
MWPW-164457 Add injectblock metadata support

### DIFF
--- a/libs/blocks/graybox/graybox.css
+++ b/libs/blocks/graybox/graybox.css
@@ -24,11 +24,16 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: calc(100% - 16px);
+  width: calc(100% - 15px);
   height: calc(100vh - 16px);
   border: var(--gb-page-outline-border);
   z-index: calc(var(--base-z-index) + 1);
   pointer-events: none;
+}
+
+.graybox-container:not(.open) .gb-toggle {
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
 }
 
 .gb-graybox-body.gb-tablet-preview:not(.gb-no-border)::before,

--- a/libs/blocks/graybox/graybox.js
+++ b/libs/blocks/graybox/graybox.js
@@ -30,6 +30,8 @@ const USER_AGENT = {
   iPad: 'Mozilla/5.0 (iPad; CPU OS 13_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1',
 };
 
+const DEFAULT_TITLE = 'Review Update';
+
 let deviceModal;
 
 const setMetadata = (metadata) => {
@@ -237,7 +239,7 @@ const createGrayboxMenu = (options, { isOpen = false } = {}) => {
   }
 
   const grayboxText = createTag('div', { class: 'graybox-text' }, null, { parent: grayboxMenu });
-  const title = options.title?.text || getMetadata(METADATA.TITLE) || 'Review Update';
+  const title = options.title?.text || getMetadata(METADATA.TITLE) || DEFAULT_TITLE;
   const desc = options.desc?.text || getMetadata(METADATA.DESC) || '';
   grayboxText.innerHTML = `<p>${title}</p>${desc && `<p>${desc}</p>`}`;
 
@@ -262,7 +264,7 @@ const createGrayboxMenu = (options, { isOpen = false } = {}) => {
   grayboxContainer.appendChild(toggleBtn);
   document.body.appendChild(grayboxContainer);
 
-  if (isOpen) {
+  if (isOpen && (title !== DEFAULT_TITLE || desc)) {
     grayboxContainer.classList.add('open');
   }
 };
@@ -297,7 +299,7 @@ const transformLinks = () => {
   });
 };
 
-const grayboxThePage = (grayboxEl, grayboxMenuOff) => () => {
+const grayboxThePage = (grayboxEl, grayboxMenuOff) => {
   transformLinks();
   document.body.classList.add(CLASS.GRAYBOX_BODY);
   const globalNoClick = grayboxEl.classList.contains(CLASS.NO_CLICK)
@@ -346,9 +348,5 @@ export default function init(grayboxEl) {
   setMetadata({ selector: 'georouting', val: 'off' });
   const grayboxMenuOff = url.searchParams.get('graybox') === 'menu-off';
 
-  document.addEventListener(
-    MILO_EVENTS.DEFERRED,
-    grayboxThePage(grayboxEl, grayboxMenuOff),
-    { once: true },
-  );
+  window.milo.deferredPromise.then(() => grayboxThePage(grayboxEl, grayboxMenuOff));
 }

--- a/libs/blocks/graybox/graybox.js
+++ b/libs/blocks/graybox/graybox.js
@@ -1,4 +1,4 @@
-import { createTag, getMetadata, MILO_EVENTS } from '../../utils/utils.js';
+import { createTag, getMetadata } from '../../utils/utils.js';
 import { getModal, closeModal } from '../modal/modal.js';
 import { iphoneFrame, ipadFrame } from './mobileFrames.js';
 

--- a/libs/utils/injectblock.js
+++ b/libs/utils/injectblock.js
@@ -1,0 +1,17 @@
+import { createTag, loadBlock } from './utils.js';
+
+// blockNamesStr is a comma delimited list of blocks to inject
+export default async function injectBlock(blockNamesStr) {
+  if (!blockNamesStr) return;
+
+  const mainEl = document.querySelector('main');
+  if (!mainEl) return;
+
+  const blockNames = blockNamesStr.split(',').map(name => name.trim()).filter(Boolean);
+
+  await Promise.all(blockNames.map(blockName => {
+    const blockEl = createTag('div', { class: blockName });
+    mainEl.appendChild(blockEl);
+    return loadBlock(blockEl);
+  }));
+}

--- a/libs/utils/injectblock.js
+++ b/libs/utils/injectblock.js
@@ -7,9 +7,9 @@ export default async function injectBlock(blockNamesStr) {
   const mainEl = document.querySelector('main');
   if (!mainEl) return;
 
-  const blockNames = blockNamesStr.split(',').map(name => name.trim()).filter(Boolean);
+  const blockNames = blockNamesStr.split(',').map((name) => name.trim()).filter(Boolean);
 
-  await Promise.all(blockNames.map(blockName => {
+  await Promise.all(blockNames.map((blockName) => {
     const blockEl = createTag('div', { class: blockName });
     mainEl.appendChild(blockEl);
     return loadBlock(blockEl);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1552,6 +1552,11 @@ function decorateDocumentExtras() {
 }
 
 async function documentPostSectionLoading(config) {
+  const injectBlock = getMetadata('injectblock');
+  if (injectBlock) {
+    import('./injectblock.js').then((module) => module.default(injectBlock));
+  }
+
   decorateFooterPromo();
   if (getMetadata('seotech-structured-data') === 'on' || getMetadata('seotech-video-url')) {
     import('../features/seotech/seotech.js').then((module) => module.default(

--- a/test/blocks/graybox/globalnoclick.test.js
+++ b/test/blocks/graybox/globalnoclick.test.js
@@ -10,6 +10,8 @@ const CLASS = {
   NO_CHANGE: 'gb-no-change',
 };
 
+window.milo = { deferredPromise: Promise.resolve() };
+
 describe('Graybox Global No Click With Changed Els', () => {
   before(async () => {
     document.body.innerHTML = await readFile({ path: './mocks/noclick-changed-els.html' });

--- a/test/blocks/graybox/graybox.test.js
+++ b/test/blocks/graybox/graybox.test.js
@@ -6,6 +6,8 @@ import { waitForElement, waitForRemoval } from '../../helpers/waitfor.js';
 const { default: init } = await import('../../../libs/blocks/graybox/graybox.js');
 await loadStyle('../../../libs/blocks/graybox/graybox.css');
 
+window.milo = { deferredPromise: Promise.resolve() };
+
 describe('Graybox', () => {
   before(async () => {
     document.body.innerHTML = await readFile({ path: './mocks/graybox.html' });


### PR DESCRIPTION
Adds support for `injectblock` metadata property, which when specified takes a comma delimited list of blocks to add to the page.  The blocks are added after initial page render to not affect performance, and a generic block with no variation is added to the bottom of the page.

PR also has:
* a few slight ui tweaks to graybox
* Graybox flyout is only open if there is a custom title or description

Resolves: [MWPW-164457](https://jira.corp.adobe.com/browse/MWPW-164457)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/cpeyer/temp/insertblock?martech=off
- After: https://injectblock--milo--adobecom.aem.page/drafts/cpeyer/temp/insertblock?martech=off




