### PR TITLE
[MWPW-172157] - revert tabs stacked mobile

### DIFF
--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -96,7 +96,7 @@ function changeTabs(e) {
     .querySelectorAll(`.tabpanel[data-block-id="${blockId}"]`)
     .forEach((p) => p.setAttribute('hidden', true));
   targetContent?.removeAttribute('hidden');
-  if (tabsBlock.classList.contains('stacked-mobile')) scrollStackedMobile(parent);
+  if (tabsBlock.classList.contains('stacked-mobile')) scrollStackedMobile(targetContent);
 }
 
 function getStringKeyName(str) {


### PR DESCRIPTION
This PR reverts https://github.com/adobecom/milo/pull/4068 and https://github.com/adobecom/milo/pull/4104.

Resolves: [MWPW-172157](https://jira.corp.adobe.com/browse/MWPW-172157)

**Test URLs:**
Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/tab-block?martech=off
After: https://revert-tab-stacked-scroll--milo--adobecom.aem.page/docs/library/kitchen-sink/tab-block?martech=off

**DC Test URLs:**
Before: https://main--dc--adobecom.aem.live/acrobat/features?milolibs=stage
After: https://main--dc--adobecom.aem.live/acrobat/features?milolibs=revert-tab-stacked-scroll


