### PR TITLE
[MWPW-158022] - Text block bold break

### DIFF
--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -295,6 +295,10 @@
   width: 100%;
 }
 
+.section[class*="-up"] .text-block:not(.legal, .link-farm) .foreground >div:has(> strong) {
+  display: block;
+}
+
 .section[class*="-up"] .text-block:not(.legal, .link-farm) [class^="heading"],
 .section[class*="-up"] .text-block:not(.legal, .link-farm) p:not([class^="detail-"]),
 .section[class*="-up"] .text-block:not(.legal, .link-farm) [class^="body-"] {

--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -289,14 +289,10 @@
   width: 100%;
 }
 
-.section[class*="-up"] .text-block:not(.legal, .link-farm) .foreground > div {
+.section[class*="-up"] .text-block:not(.legal, .link-farm) .foreground > div:not(:has(> strong)) {
   display: flex;
   flex-direction: column;
   width: 100%;
-}
-
-.section[class*="-up"] .text-block:not(.legal, .link-farm) .foreground >div:has(> strong) {
-  display: block;
 }
 
 .section[class*="-up"] .text-block:not(.legal, .link-farm) [class^="heading"],

--- a/libs/blocks/text/text.js
+++ b/libs/blocks/text/text.js
@@ -111,7 +111,12 @@ export default async function init(el) {
       [...row.children].forEach((c) => decorateBlockText(c, blockTypeSizes[blockType][size]));
       decorateMultiViewport(row);
     }
-    [...row.children].forEach((c) => decorateBlockIconArea(c, el));
+    [...row.children].forEach((c) => {
+      decorateBlockIconArea(c, el);
+      const strong = c.querySelector('strong');
+      const parentDiv = strong?.parentNode;
+      if (strong && parentDiv?.tagName === 'DIV') parentDiv.replaceChildren(createTag('p', null, [...parentDiv.childNodes]));
+    });
   });
   if (el.classList.contains('full-width')) helperClasses.push('max-width-8-desktop', 'center', 'xxl-spacing');
   if (el.classList.contains('intro')) helperClasses.push('max-width-8-desktop', 'xxl-spacing-top', 'xl-spacing-bottom');

--- a/libs/blocks/text/text.js
+++ b/libs/blocks/text/text.js
@@ -111,12 +111,7 @@ export default async function init(el) {
       [...row.children].forEach((c) => decorateBlockText(c, blockTypeSizes[blockType][size]));
       decorateMultiViewport(row);
     }
-    [...row.children].forEach((c) => {
-      decorateBlockIconArea(c, el);
-      const strong = c.querySelector('strong');
-      const parentDiv = strong?.parentNode;
-      if (strong && parentDiv?.tagName === 'DIV') parentDiv.replaceChildren(createTag('p', null, [...parentDiv.childNodes]));
-    });
+    [...row.children].forEach((c) => decorateBlockIconArea(c, el));
   });
   if (el.classList.contains('full-width')) helperClasses.push('max-width-8-desktop', 'center', 'xxl-spacing');
   if (el.classList.contains('intro')) helperClasses.push('max-width-8-desktop', 'xxl-spacing-top', 'xl-spacing-bottom');


### PR DESCRIPTION
This resolves the issue where bold text was breaking into a new line in the text block in curtain situations.

Resolves: [MWPW-158022](https://jira.corp.adobe.com/browse/MWPW-158022)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/text?martech=off
- After: https://text-block-bold-break--milo--adobecom.aem.page/docs/library/kitchen-sink/text?martech=off

**1st CC Test URLs:**
- Before: https://main--dc--adobecom.hlx.page/au/drafts/dholmes/text-block-bolded-text
- After: https://main--dc--adobecom.hlx.page/au/drafts/dholmes/text-block-bolded-text?milolibs=text-block-bold-break

**2nd CC Test URLs:**
- Before: https://main--dc--adobecom.aem.page/de/acrobat/resources/academic-writing/test-files-geert/bold-text-testing
- After: https://main--dc--adobecom.aem.page/de/acrobat/resources/academic-writing/test-files-geert/bold-text-testing?milolibs=text-block-bold-break

**3d CC Test URLs:**
- Before: https://main--dc--adobecom.aem.page/de/acrobat/resources/academic-writing/paraphrase
- After: https://main--dc--adobecom.aem.page/de/acrobat/resources/academic-writing/paraphrase?milolibs=text-block-bold-break





