### PR TITLE
Standalone Gnav Link transformation support for hosts other than stage.adobe.com

### DIFF
--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -1,7 +1,6 @@
 /* Custom properties (variables) */
 :root {
   /* Top navigation - box model */
-  --feds-height-nav: 63px;
   --feds-maxWidth-nav: 1440px;
   --feds-minWidth-menu: 1200px;
   --feds-height-breadcrumbs: 33px;

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -23,23 +23,22 @@ const envMap = {
   qa: 'https://gnav--milo--adobecom.aem.page',
 };
 
-const getStageDomainsMap = (stageDomainsMap) => (
-  {
-    'www.stage.adobe.com': {
-      'www.adobe.com': 'origin',
-      'helpx.adobe.com': 'helpx.stage.adobe.com',
-      'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
-      ...stageDomainsMap,
-    },
-    // Test app
-    'adobecom.github.io': {
-      'www.adobe.com': 'www.stage.adobe.com',
-      'helpx.adobe.com': 'helpx.stage.adobe.com',
-      'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
-      ...stageDomainsMap,
-    },
+const getStageDomainsMap = (stageDomainsMap, env) => {
+  const defaultUrls = {
+    'www.adobe.com': 'origin',
+    'helpx.adobe.com': 'helpx.stage.adobe.com',
+    'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
+  };
+
+  const merged = { ...defaultUrls, ...stageDomainsMap };
+  const domainMap = { 'www.stage.adobe.com': merged };
+
+  if (env !== 'prod') {
+    domainMap[window.location.host] = merged;
   }
-);
+
+  return domainMap;
+};
 
 // Production Domain
 const prodDomains = [
@@ -128,7 +127,7 @@ export default async function loadBlock(configs, customLib) {
     miloLibs: `${miloLibs}/libs`,
     locales: configs.locales || locales,
     contentRoot: authoringPath || footer?.authoringPath,
-    stageDomainsMap: getStageDomainsMap(stageDomainsMap),
+    stageDomainsMap: getStageDomainsMap(stageDomainsMap, env),
     origin,
     allowedOrigins: [...allowedOrigins, origin],
     onFooterReady: footer?.onReady,

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -2,6 +2,7 @@
 
  :root {
   --global-height-nav: 64px;
+  --feds-height-nav: 63px;
   --global-height-breadcrumbs: 33px;
   /* stylelint-disable-next-line custom-property-pattern */
   --global-height-navPromo: 72px;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds support to add the current rendered host to stage domain map
* Moving top nav wrapper variable to styles.css as it is overriding standalone gnav's smaller height variable

Resolves: [MWPW-173409](https://jira.corp.adobe.com/browse/MWPW-173409)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav--milo--adobecom.aem.page/?martech=off
