### PR TITLE
Remove libraries flag

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -2,12 +2,6 @@
   "project": "Milo",
   "host": "milo.adobe.com",
   "trustedHosts": ["milo.adobe.com", "*--milo--adobecom.aem.page", "*--milo--adobecom.aem.live"],
-  "libraries": [
-    {
-      "text": "Blocks",
-      "paths": ["https://main--milo--adobecom.aem.page/docs/library/blocks.json"]
-    }
-  ],
   "plugins": [
     {
       "id": "publish",


### PR DESCRIPTION
The libraries flag does not match the [sidekick schema](https://tools.aem.live/sidekick/config.schema.json) and is not used within the config service anymore. Thus we should remove it from Github as well. [MWPW-Ticket](https://jira.corp.adobe.com/browse/MWPW-173458)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://remove-unused-flag--milo--adobecom.aem.page/?martech=off




