### PR TITLE
MWPW-172950: Replace blockquote with p

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -523,7 +523,7 @@
   padding-bottom: 0;
 }
 
-.table.has-addon .table-title-text blockquote,
+.table.has-addon .table-title-text .blockquote,
 .table.has-addon .table-title-text code {
   font-family: var(--body-font-family);
   background-color: var(--color-gray-300);
@@ -537,7 +537,7 @@
   color: black;
 }
 
-.table.has-addon .col.section-row-title blockquote p {
+.table.has-addon .col.section-row-title .blockquote p {
   font-size: var(--type-body-xs-size);
   line-height: var(--type-body-xs-lh);
 }

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -271,6 +271,13 @@ function handleTitleText(cell) {
     nodeToInsert = titleRowSpan;
   }
 
+  const blockquote = nodeToInsert.querySelector('blockquote');
+  if (blockquote) {
+    const quoteReplacement = createTag('p', { class: 'blockquote' });
+    quoteReplacement.innerHTML = blockquote.innerHTML;
+    blockquote.replaceWith(quoteReplacement);
+  }
+
   cell.insertBefore(nodeToInsert, cell.firstChild);
 }
 


### PR DESCRIPTION
Issue: When authoring a table block, authors have an option to use `blockquote` but this leads to inappropriately semantic markup.

* Replace `blockquote` with `p`

<img width="681" alt="Screenshot 2025-05-14 at 16 19 42" src="https://github.com/user-attachments/assets/3b34430f-e33f-4c3f-8aca-a88dc0131dba" />
<img width="587" alt="Screenshot 2025-05-14 at 16 19 55" src="https://github.com/user-attachments/assets/392b6d81-a823-4d30-80d7-86e1ff6a8a03" />


Resolves: [MWPW-172950](https://jira.corp.adobe.com/browse/MWPW-172950)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
- After: https://mwpw-172950-quoteblock-table--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off

**DC URLs:**
- Before: https://main--dc--adobecom.aem.live/acrobat/pricing/compare-versions
- After: https://main--dc--adobecom.aem.live/acrobat/pricing/compare-versions?milolibs=mwpw-172950-quoteblock-table