### PR TITLE
MWPW-173467: add support for dcp in susi light login

### DIFF
--- a/libs/blocks/susi-light-login/susi-light-login.js
+++ b/libs/blocks/susi-light-login/susi-light-login.js
@@ -1,5 +1,5 @@
 /* eslint-disable consistent-return */
-import { loadScript, createTag, getConfig, loadIms } from '../../utils/utils.js';
+import { loadScript, createTag, getConfig, loadIms, getMetadata } from '../../utils/utils.js';
 
 const loadSusiLight = async (env) => {
   const lib = `https://auth-light.identity${env.name === 'prod' ? '' : '-stage'}.adobe.com/sentry/wrapper.js`;
@@ -62,6 +62,8 @@ export class SusiLight {
     if (env.name !== 'prod') sentry.stage = true;
     sentry.variant = 'standard';
     sentry.authParams = this.createAuthParams();
+    const dctxId = getMetadata('susi-light-dctx-id');
+    if (dctxId) sentry.authParams.dctx_id = dctxId;
     sentry.config = { consentProfile: 'free' };
     sentry.addEventListener('redirect', onRedirect);
     sentry.addEventListener('on-error', onError);

--- a/test/blocks/susi-light-login/susi-light-login.test.js
+++ b/test/blocks/susi-light-login/susi-light-login.test.js
@@ -27,6 +27,7 @@ describe('susi light', () => {
       window.adobeIMS = { isSignedInUser: () => false };
       susiHtml = await readFile({ path: './mocks/susi-light-login.html' });
       document.head.innerHTML = `<link rel="icon" href="/libs/img/favicons/favicon.ico" size="any">
+      <meta name="susi-light-dctx-id" content="v:2,test-id">
       <script src="https://auth.services.adobe.com/imslib/imslib.min.js" type="javascript/blocked" data-loaded="true"></script>
       <script src="https://auth-light.identity-stage.adobe.com/sentry/wrapper.js" type="javascript/blocked" data-loaded="true"></script>
       `;
@@ -77,6 +78,11 @@ describe('susi light', () => {
     });
     it('should not add background for mobile', async () => {
       expect(document.querySelector('.susi-light-login').style.backgroundImage).equals('');
+    });
+    it('should have the dctx id if defined in metadata', async () => {
+      susiElement = document.querySelector('susi-sentry-light');
+      console.log(susiElement.authParams);
+      expect(susiElement.authParams.dctx_id).equals('v:2,test-id');
     });
   });
 });


### PR DESCRIPTION
Adds support for passing DCP ID in SUSI Light Login.

Resolves: [MWPW-173467](https://jira.corp.adobe.com/browse/MWPW-173467)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://susi-dcp--milo--adobecom.aem.page/?martech=off

**QA:**
- Before: https://main--cc--adobecom.aem.page/drafts/nishantkaush/products/photoshop/test?martech=off
- After: https://main--cc--adobecom.aem.page/drafts/nishantkaush/products/photoshop/test?milolibs=susi-dcp?martech=off



