### PR TITLE
MWPW-171937: fix cta urls for bulk publisher

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -362,7 +362,7 @@ const parseCardMetadata = () => {
 };
 
 function checkCtaUrl(s, options, i) {
-  if (s?.trim() === '') return '';
+  if ((s?.trim() === '' || s === undefined) && i > 1) return '';
   const url = s || options.prodUrl || window.location.origin + window.location.pathname;
   return checkUrl(url, `Invalid Cta${i}Url: ${url}`);
 }

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -362,7 +362,7 @@ const parseCardMetadata = () => {
 };
 
 function checkCtaUrl(s, options, i) {
-  if ((s?.trim() === '' || s === undefined) && i > 1) return '';
+  if (s?.trim() === '' || s === undefined) return '';
   const url = s || options.prodUrl || window.location.origin + window.location.pathname;
   return checkUrl(url, `Invalid Cta${i}Url: ${url}`);
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

When using the bulk send to caas tool, a phantom secondary CTA was being added to the card data.  This PR remedies this and also fixes the behavior for the primary CTA.


Resolves: [MWPW-171937](https://jira.corp.adobe.com/browse/MWPW-171937)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/cmiqueo/test-page
- After: https://MWPW-171937--milo--sheridansunier.aem.page/drafts/cmiqueo/test-page
