### PR TITLE
Reduce gnav lana sampleRate to 0.01%

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -95,7 +95,7 @@ export const logPerformance = (
       .join(',');
     window.lana.log(measureStr, {
       clientId: LANA_CLIENT_ID,
-      sampleRate: 50,
+      sampleRate: 0.01,
     });
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
Bring https://github.com/adobecom/milo/pull/4150 to `stage` as well, as that one had to be merged directly to `main` to resolve a critical issue.

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/?martech=off
- After: https://gnav-lanaflood-sync--milo--overmyheadandbody.aem.page/?martech=off
