### PR TITLE
Revert "MWPW-170454 : Visual list is not marked up as list"

### DIFF
--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -75,13 +75,13 @@ const decorateLinkGroup = (elem, index) => {
       <div class="feds-navLink-title">${link.textContent}</div>
       ${descriptionElem}
     </div>` : '';
-  const linkGroup = toFragment`<li><a
+  const linkGroup = toFragment`<a
     href="${link.href}"
     class="feds-navLink${modifierClasses.length ? ` ${modifierClasses.join(' ')}` : ''}"
     daa-ll="${getAnalyticsValue(link.textContent, index)}">
       ${imageElem}
       ${contentElem}
-    </a></li>`;
+    </a>`;
   if (link?.target) linkGroup.target = link.target;
 
   return linkGroup;
@@ -273,28 +273,14 @@ const decorateColumns = async ({ content, separatorTagName = 'H5' } = {}) => {
 
         itemDestination.append(imageElem);
       } else {
-        let decoratedElem = decorateElements({ elem: columnElem, itemIndex });
+        const decoratedElem = decorateElements({ elem: columnElem, itemIndex });
         columnElem.remove();
 
         // If an items template has been previously created,
         // add the current element to it;
         // otherwise append the element to the section
         const elemDestination = menuItems || itemDestination;
-        let menuList = null;
-        if (decoratedElem.tagName === 'P') {
-          const li = toFragment`<li></li>`;
-          li.innerHTML = decoratedElem.innerHTML;
-          decoratedElem = li;
-        }
-        if (decoratedElem.tagName === 'LI') {
-          if (!elemDestination.querySelector('ul')) {
-            elemDestination.append(toFragment`<ul></ul>`);
-          }
-          menuList = elemDestination.querySelector('ul');
-        } else {
-          menuList = elemDestination;
-        }
-        menuList.append(decoratedElem);
+        elemDestination.append(decoratedElem);
       }
     }
 


### PR DESCRIPTION
Reverts adobecom/milo#4084
PR causing break in the footer as css is not merged.

## GNav Test URLs

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- Milo: https://revert-4084-mwpw-170454--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- Milo: https://revert-4084-mwpw-170454--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- Milo: https://revert-4084-mwpw-170454--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom
**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=revert-4084-mwpw-170454--milo--adobecom