### PR TITLE
MWPW-173254 [MMM][MEP] Checkboxes within filter groups with no saved values should be selected by default (updated)

### DIFF
--- a/libs/blocks/mmm/mmm.js
+++ b/libs/blocks/mmm/mmm.js
@@ -354,7 +354,7 @@ function createCheckBoxFilterGroup(checkBoxId, legendLabel, optionsObj) {
   const checkBoxFieldset = createTag('fieldset', { id: `mmm-${checkBoxId}-fieldset` }, checkBoxLegend);
   // helper function only ran during filter build. consider moving to outter lex scope
   function createCheckBox(groupName, checkboxLabel, checkboxValue) {
-    const initValueCheck = SEARCH_INITIAL_VALUES()?.[groupName]?.split(', ').includes(checkboxValue);
+    const initValueCheck = !SEARCH_INITIAL_VALUES()?.[groupName] || SEARCH_INITIAL_VALUES()?.[groupName]?.split(', ').includes(checkboxValue);
     const checkDiv = createTag('div', { class: 'mmm-checkbox-option' });
     const checkLabel = createTag('label', { for: `mmm-${groupName}-${checkboxValue}` }, checkboxLabel);
     const checkBox = createTag('input', {
@@ -537,7 +537,7 @@ function createReportButton() {
     'a',
     {
       class: 'con-button outline button-l button-justified-mobile mmm-report-slack',
-      href: 'https://adobe.enterprise.slack.com/archives/C08LXEQ735W',
+      href: 'https://adobe.enterprise.slack.com/archives/C08SA7JUW3F',
     },
     'Open Slack',
   );


### PR DESCRIPTION
This PR solves an MMM issue where none of the checkboxes for Target Setting and Manifest Source filters were selected by default if user does not have targetSetting and/or manifestSrc keys in their local storage mmm_filter_settings cookie. 

**The expected behavior is:**
- New users (no local storage cookie settings) should have _all_ checkboxes within the Target Setting and Manifest Source groups selected by default 
- Returning users (with local storage cookie settings) should retain their previous filter selections from previous session 
- Returning user who may have had a previous cookie value without targetSetting and/or manifestSrc should have _all_ checkboxes within the Target Setting and Manifest Source groups selected by default 

**Fix:**
Single line edit to check if the group name for targetSetting or manifestSrc exists, before checking if individual checkbox values exist to determine if the entire checkbox group should be selected by default, or just select values. 

Additional small fix: Updated slack channel link. 

Resolves: [MWPW-173254](https://jira.corp.adobe.com/browse/MWPW-173254)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/authoring/features/mmm?martech=off
- After: https://mmm-checkboxdefaultselected--milo--adobecom.aem.page/docs/authoring/features/mmm?martech=off

**How to test:**
Repeat the steps below for the before and after links
1. Change any filter to make sure the application data is set
2. Mimic a user who used MMM before the checkboxes were created by editing the value for mmm_filter_settings.
In the Application panel in dev tools, find _Storage_ -> _Local storage_ -> find the _domain name_ in the list -> select _mmm_filter_settings_ on the panel that lists all settings available for the page to be the following:
```
{
  "geos": "",
  "pages": "",
  "lastSeenManifest": "threeMonths",
  "subdomain": "www",
  "filter": "",
  "pageNum": 1,
  "perPage": 25
}
```
3. Reload the page


Expected Results: All checkboxes start as checked
................................
Actual Results: All checkboxes start as unchecked

You can also confirm the following still works in the after link:
1. Change which checkboxes are selected
2. Refresh and validate that your selections persist correctly after reload
3. Delete mmm_filter_settings from application data to mimic a new user
4. Refresh and validate all boxes are checked