### PR TITLE
MWPW-171825 Improve lcp performance for favicon and breadcrumb

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1410,8 +1410,7 @@ async function checkForPageMods() {
 }
 
 async function loadPostLCP(config) {
-  const { default: loadFavIcon } = await import('./favicon.js');
-  loadFavIcon(createTag, getConfig(), getMetadata);
+  import('./favicon.js').then(({ default: loadFavIcon }) => loadFavIcon(createTag, getConfig(), getMetadata));
   await decoratePlaceholders(document.body.querySelector('header'), config);
   const sk = document.querySelector('aem-sidekick, helix-sidekick');
   if (sk) import('./sidekick-decorate.js').then((mod) => { mod.default(sk); });
@@ -1623,10 +1622,10 @@ async function resolveInlineFrags(section) {
   section.preloadLinks = newlyDecoratedSection.preloadLinks;
 }
 
-async function processSection(section, config, isDoc) {
+async function processSection(section, config, isDoc, lcpSectionId) {
   await resolveInlineFrags(section);
-  const firstSection = section.el.dataset.idx === '0';
-  const stylePromises = firstSection ? preloadBlockResources(section.blocks) : [];
+  const isLcpSection = lcpSectionId === section.idx;
+  const stylePromises = isLcpSection ? preloadBlockResources(section.blocks) : [];
   preloadBlockResources(section.preloadLinks);
   await Promise.all([
     decoratePlaceholders(section.el, config),
@@ -1645,7 +1644,7 @@ async function processSection(section, config, isDoc) {
   await Promise.all(loadBlocks);
 
   delete section.el.dataset.status;
-  if (isDoc && firstSection) await loadPostLCP(config);
+  if (isDoc && isLcpSection) await loadPostLCP(config);
   delete section.el.dataset.idx;
   return section.blocks;
 }
@@ -1670,8 +1669,14 @@ export async function loadArea(area = document) {
   const sections = decorateSections(area, isDoc);
 
   const areaBlocks = [];
+  let lcpSectionId = null;
+
   for (const section of sections) {
-    const sectionBlocks = await processSection(section, config, isDoc);
+    const isLastSection = section.idx === sections.length - 1;
+    if (lcpSectionId === null && (section.blocks.length !== 0 || isLastSection)) {
+      lcpSectionId = section.idx;
+    }
+    const sectionBlocks = await processSection(section, config, isDoc, lcpSectionId);
     areaBlocks.push(...sectionBlocks);
 
     areaBlocks.forEach((block) => {


### PR DESCRIPTION
- Follow up from #4071 with bugfix for solution partners bug (if page had no blocks on it, the gnav wasn't loading).
- Parallelize favicon.js import
- Change "first section" performance optimizations to "lcp section" to account for breadcrumbs being put in first section

Resolves: [MWPW-171825](https://jira.corp.adobe.com/browse/MWPW-171825)

**Test URLs:**

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://favicon-perf-2--milo--meganthecoder.aem.page/drafts/methomas/default?martech=off

Bacom:

Before: https://main--bacom--adobecom.aem.live/ai/adobe-genai
After: https://main--bacom--adobecom.aem.live/ai/adobe-genai?milolibs=favicon-perf-2--milo--meganthecoder

Acom:

Before: https://main--cc--adobecom.aem.live/ai/overview
After: https://main--cc--adobecom.aem.live/ai/overview?milolibs=favicon-perf-2--milo--meganthecoder

Solution Partners:

Before: https://main--dx-partners--adobecom.aem.live/solutionpartners/
After: https://main--dx-partners--adobecom.aem.live/solutionpartners/?milolibs=favicon-perf-2--milo--meganthecoder
