### PR TITLE
MWPW-173649 CWV Logging Updates

### DIFF
--- a/libs/utils/logWebVitals.js
+++ b/libs/utils/logWebVitals.js
@@ -13,9 +13,12 @@ function sendToLana(lanaData) {
     downlink: window.navigator?.connection?.downlink || '',
     loggedIn: window.adobeIMS?.isSignedInUser() || false,
     os: (ua.match(/Windows/) && 'win')
+      || (ua.match(/CriOS/) && 'iOS')
       || (ua.match(/Mac/) && 'mac')
       || (ua.match(/Android/) && 'android')
       || (ua.match(/Linux/) && 'linux')
+      || '',
+    tablet: (ua.match(/(ipad|iPad|tablet|(android(?!.*mobile))|(windows(?!.*phone).*touch))/) && 'yes')
       || '',
     windowHeight: window.innerHeight,
     windowWidth: window.innerWidth,
@@ -115,8 +118,11 @@ function logMepExperiments(lanaData, mep) {
 export default function webVitals(mep, { delay = 1000, sampleRate = 50 } = {}) {
   const isChrome = () => {
     const nav = window.navigator;
-    return nav.userAgent.includes('Chrome') && nav.vendor.includes('Google');
+    const desktopChrome = nav.userAgent.includes('Chrome') && nav.vendor.includes('Google');
+    const iOSChrome = nav.userAgent.includes('CriOS') && nav.vendor.includes('Google');
+    return desktopChrome || iOSChrome;
   };
+
   if (!isChrome() || Math.random() * 100 > sampleRate) return;
   const getConsent = () => window.adobePrivacy?.activeCookieGroups().indexOf('C0002') !== -1;
   function handleEvent() {

--- a/libs/utils/logWebVitals.js
+++ b/libs/utils/logWebVitals.js
@@ -88,7 +88,7 @@ function observeLCP(lanaData, delay, mep) {
     const lastEntry = entries[entries.length - 1]; // Use the latest LCP candidate
     lanaData.lcp = parseInt(lastEntry.startTime, 10);
     const lcpEl = lastEntry.element;
-    lanaData.lcpElType = lcpEl.nodeName.toLowerCase();
+    lanaData.lcpElType = lcpEl?.nodeName?.toLowerCase() || 'Element Was Replaced';
     lanaData.lcpEl = getElementInfo(lcpEl);
     lanaData.lcpSectionOne = boolStr(sectionOne.contains(lcpEl));
     const closestFrag = lcpEl.closest('.fragment');

--- a/test/utils/logWebVitals.test.js
+++ b/test/utils/logWebVitals.test.js
@@ -33,7 +33,8 @@ describe('Log Web Vitals', () => {
         expect(vitals.manifest3selected).to.equal('all');
         expect(vitals.manifest4path).to.equal('/cc-shared/fragments/tests/2024/q2/ace0875/ace0875.json');
         expect(vitals.manifest4selected).to.equal('target-var-marqueelink');
-        expect(vitals.os).to.be.oneOf(['mac', 'win', 'android', 'linux', '']);
+        expect(vitals.os).to.be.oneOf(['mac', 'iOS', 'win', 'android', 'linux', '']);
+        expect(vitals.tablet).to.be.oneOf(['yes', '']);
         expect(vitals.url).to.equal('localhost:2000/');
         expect(vitals.isMep).to.equal('false');
         expect(vitals.isFrag).to.equal('false');

--- a/test/utils/logWebVitalsUtils.test.js
+++ b/test/utils/logWebVitalsUtils.test.js
@@ -49,7 +49,8 @@ describe('Log Web Vitals Utils', () => {
         expect(vitals.lcpSectionOne).to.equal('true');
 
         expect(vitals.loggedIn).to.equal('false');
-        expect(vitals.os).to.be.oneOf(['mac', 'win', 'android', 'linux', '']);
+        expect(vitals.os).to.be.oneOf(['mac', 'iOS', 'win', 'android', 'linux', '']);
+        expect(vitals.tablet).to.be.oneOf(['yes', '']);
         expect(vitals.url).to.equal('localhost:2000/');
         expect(parseInt(vitals.windowHeight, 10)).to.be.greaterThan(200);
         expect(parseInt(vitals.windowWidth, 10)).to.be.greaterThan(200);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Updated the CWV logging piece. It can now run on Chrome browsers on modern iOS devices (not sure if this was intentional or not). I will also report on whether the device is a tablet and if the OS is iOS/iPadOS

Resolves: [MWPW-173649](https://jira.corp.adobe.com/browse/MWPW-173649)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-173649--milo--adobecom.aem.page/?martech=off




