### PR TITLE
Adding Color white variable for standalone gnav and adding non milo locale path link transform in region nav

### DIFF
--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -94,6 +94,8 @@ export default async function init(block) {
   const links = divs[1].querySelectorAll('a');
   if (!links.length) return;
   const { prefix } = config.locale;
-  const path = window.location.href.replace(`${window.location.origin}${prefix}`, '').replace('#langnav', '');
+  const { location } = window;
+  const hasPrefix = location.pathname.startsWith(`${prefix}/`);
+  const path = location.href.replace(location.origin + (hasPrefix ? prefix : ''), '').replace('#langnav', '');
   links.forEach((link) => decorateLink(link, path, localeToLanguageMap));
 }

--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -11,6 +11,7 @@
   --global-height-nav: 56px;
   --feds-height-nav: 55px;
   --color-white: #FFF;
+  --modal-close-accent-color: #707070;
 }
 
 .global-navigation, .global-footer, .dialog-modal {

--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -10,6 +10,7 @@
   --feds-localnav-height: 40px;
   --global-height-nav: 56px;
   --feds-height-nav: 55px;
+  --color-white: #FFF;
 }
 
 .global-navigation, .global-footer, .dialog-modal {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding Color white css variable for standalone Gnav
* Adding a check for hasPrefix while decorating the region nav links to support page which doesn't have locale as its prefix in the url

Resolves: [MWPW-173662](https://jira.corp.adobe.com/browse/MWPW-173662)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://sgnav-modal-icon--milo--adobecom.aem.page/?martech=off

QA:
- Before: https://adobecom.github.io/nav-consumer/navigation.html?env=prod&theme=light&navbranch=main&authoringpath=/federal/learn&locale=jp#langnav
- After: https://adobecom.github.io/nav-consumer/navigation.html?env=prod&theme=light&navbranch=sgnav-modal-icon&authoringpath=/federal/learn&locale=jp#langnav








