### PR TITLE
MWPW-173425: Allow container to expand based on line height

### DIFF
--- a/libs/blocks/card-horizontal/card-horizontal.css
+++ b/libs/blocks/card-horizontal/card-horizontal.css
@@ -72,7 +72,6 @@
   border-radius: 4px;
   gap: var(--spacing-s);
   border: 1px solid #EAEAEA;
-  max-height: 130px;
   max-width: 600px;
   margin: 0 auto;
 }
@@ -90,7 +89,6 @@
 
 .card-horizontal .foreground .card-block .card-content {
   padding-right: var(--spacing-s);
-  margin: 16px 0;
   /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
   -webkit-line-clamp: 5;


### PR DESCRIPTION
Issue: When text spacing is applied via extension, `card-horizontal` content text overflows. 

* Removed container `max-height`, to let container expand when line spacing is applied (height is determined by [.card-image](https://github.com/adobecom/milo/blob/stage/libs/blocks/card-horizontal/card-horizontal.css#L108))
* Removed `margin` from `.card-content` because it increases height of the container when there is no `max-height`
* `-webkit-line-clamp: 5` in combination with [align-items](https://github.com/adobecom/milo/blob/stage/libs/blocks/card-horizontal/card-horizontal.css#L70) will keep content height as before

Screenshots: 
<img width="692" alt="Screenshot 2025-05-19 at 10 35 19" src="https://github.com/user-attachments/assets/de7394cf-19c1-4367-8ec6-79d6a8c59956" />
<img width="646" alt="Screenshot 2025-05-19 at 10 35 27" src="https://github.com/user-attachments/assets/617acc69-b0ce-4179-993f-0d5c6ce6fa79" />

[Text spacing extension](https://chromewebstore.google.com/detail/text-spacing-editor/amnelgbfbdlfjeaobejkfmjjnmeddaoj)

Resolves: [MWPW-173425](https://jira.corp.adobe.com/browse/MWPW-173425)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/mwpw-173425-card-horizontal/card-horizontal?martech=off
- After: https://mwpw-173425-card-text-cutoff--milo--adobecom.aem.page/drafts/ratko/mwpw-173425-card-horizontal/card-horizontal?martech=off
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/card-horizontal?martech=off
- After: https://mwpw-173425-card-text-cutoff--milo--adobecom.aem.page/docs/library/kitchen-sink/card-horizontal?martech=off

**CC URLs:**: 
- Before: https://main--cc--adobecom.aem.page/fr/products/premiere/features
- After: https://main--cc--adobecom.aem.page/fr/products/premiere/features?milolibs=mwpw-173425-card-text-cutoff


