### PR TITLE
MWPW-173586: Dexter modals deeplink -backwards compatibility for 3in1

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -260,7 +260,7 @@ export const CHECKOUT_ALLOWED_KEYS = [
 ];
 
 /**
- * Used when 3in1 modals are configured with ms=e or cs=t extra paramter, but 3in1 is diabled.
+ * Used when 3in1 modals are configured with ms=e or cs=t extra paramter, but 3in1 is disabled.
  * Dexter modals should deeplink to plan=edu or plan=team tabs.
  * @type {Record<string, string>}
  */

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -529,7 +529,10 @@ export function appendExtraOptions(url, extraOptions) {
   Object.keys(extraOptionsObj).forEach((key) => {
     if (CHECKOUT_ALLOWED_KEYS.includes(key)) {
       const value = extraOptionsObj[key];
-      urlWithExtraOptions.searchParams.set(TAB_DEEPLINK_MAPPING[key], TAB_DEEPLINK_MAPPING[value]);
+      urlWithExtraOptions.searchParams.set(
+        TAB_DEEPLINK_MAPPING[key] ?? key,
+        TAB_DEEPLINK_MAPPING[value] ?? value,
+      );
     }
   });
   return urlWithExtraOptions.href;

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -259,6 +259,18 @@ export const CHECKOUT_ALLOWED_KEYS = [
   'marketSegment',
 ];
 
+/**
+ * Used when 3in1 modals are configured with ms=e or cs=t extra paramter, but 3in1 is diabled.
+ * Dexter modals should deeplink to plan=edu or plan=team tabs.
+ * @type {Record<string, string>}
+ */
+const TAB_DEEPLINK_MAPPING = {
+  ms: 'plan',
+  cs: 'plan',
+  e: 'edu',
+  t: 'team',
+};
+
 export const CC_SINGLE_APPS_ALL = CC_SINGLE_APPS.flatMap((item) => item);
 
 export const CC_ALL_APPS = ['CC_ALL_APPS',
@@ -516,7 +528,8 @@ export function appendExtraOptions(url, extraOptions) {
   }
   Object.keys(extraOptionsObj).forEach((key) => {
     if (CHECKOUT_ALLOWED_KEYS.includes(key)) {
-      urlWithExtraOptions.searchParams.set(key, extraOptionsObj[key]);
+      const value = extraOptionsObj[key];
+      urlWithExtraOptions.searchParams.set(TAB_DEEPLINK_MAPPING[key], TAB_DEEPLINK_MAPPING[value]);
     }
   });
   return urlWithExtraOptions.href;
@@ -525,10 +538,10 @@ export function appendExtraOptions(url, extraOptions) {
 async function openExternalModal(url, getModal, extraOptions) {
   await loadStyle(`${getConfig().base}/blocks/iframe/iframe.css`);
   const root = createTag('div', { class: 'milo-iframe' });
-  const urlWithTabName = appendTabName(url);
-  const urlWithExtraOptions = appendExtraOptions(urlWithTabName, extraOptions);
+  const urlWithExtraOptions = appendExtraOptions(url, extraOptions);
+  const urlWithTabName = appendTabName(urlWithExtraOptions);
   createTag('iframe', {
-    src: urlWithExtraOptions,
+    src: urlWithTabName,
     frameborder: '0',
     marginwidth: '0',
     marginheight: '0',

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -672,7 +672,7 @@ describe('Merch Block', () => {
       document.querySelector('.modal-curtain').click();
     });
 
-    it('renders TWP modal with preselected plan', async () => {
+    it('renders TWP modal with preselected plan that overrides extra options', async () => {
       mockIms();
       const meta = document.createElement('meta');
       meta.setAttribute('name', 'preselect-plan');

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -836,10 +836,22 @@ describe('Merch Block', () => {
       });
     });
 
-    it('appends extra options to URL', () => {
+    it('appends extra options to legacy modal URL', () => {
       const url = 'https://www.adobe.com/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html';
       const resultUrl = appendExtraOptions(url, JSON.stringify({ promoid: 'test' }));
       expect(resultUrl).to.equal('https://www.adobe.com/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html?promoid=test');
+    });
+
+    it('appends plan=edu if extra options contains ms=e', () => {
+      const url = 'https://www.adobe.com/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html';
+      const resultUrl = appendExtraOptions(url, JSON.stringify({ ms: 'e' }));
+      expect(resultUrl).to.equal('https://www.adobe.com/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html?plan=edu');
+    });
+
+    it('appends plan=team if extra options contains cs=t', () => {
+      const url = 'https://www.adobe.com/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html';
+      const resultUrl = appendExtraOptions(url, JSON.stringify({ cs: 't' }));
+      expect(resultUrl).to.equal('https://www.adobe.com/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html?plan=team');
     });
 
     it('does not append extra options to URL if invalid URL or params not provided', () => {

--- a/test/blocks/merch/mocks/body.html
+++ b/test/blocks/merch/mocks/body.html
@@ -131,7 +131,7 @@
 </p>
 
 <p>TWP modal with preselected plan: <a class="merch cta twp preselected-plan"
-  href="/tools/ost?osi=illustrator-trial-abm-mult-cci&type=checkoutUrl&modal=true&entitlement=true">CTA Free Trial</a>
+  href="/tools/ost?osi=illustrator-trial-abm-mult-cci&type=checkoutUrl&modal=true&entitlement=true&cs=t">CTA Free Trial</a>
 </p>
 
 <div data-promotion-code="nicopromo" class="fragment">


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

If its a 3in1 Modal, but 3in1 is disabled - turn '3in1' style deeplinks into dexter deeplinks.
ms=e becomes plan=edu
cs=t becomes plan=team

To test on Milo you need modheader (cors issues on feature branches)
To test without modheader use CC test page: https://main--cc--adobecom.aem.page/drafts/mariia/3in1off?milolibs=mwpw-173586 

https://jira.corp.adobe.com/browse/MWPW-173586

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/mariia/pr/3in1off?martech=off
- After: https://mwpw-173586--milo--adobecom.aem.page/drafts/mariia/pr/3in1off?martech=off






