### PR TITLE
MWPW-173732 [MMM][MEP] Add contextually relevant button in Target Metadata Lookup Report

### DIFF
--- a/libs/blocks/mmm/mmm.js
+++ b/libs/blocks/mmm/mmm.js
@@ -731,7 +731,7 @@ function createMetadataLookup(el) {
   const dropdown = {
     id: 'mmm-metadata-lookup-repo-cc',
     label: 'Choose Repo',
-    selected: SEARCH_INITIAL_VALUES().selectedRepo,
+    selected: SEARCH().selectedRepo,
   };
 
   const search = createTag('div', { class: 'mmm-metadata-lookup' }, `
@@ -805,7 +805,7 @@ async function createView(el, search) {
   switch (true) {
     case isReport: url = API_URLS.report; break;
     case isMetadataLookup: {
-      url = TARGET_METADATA_OPTIONS[SEARCH_INITIAL_VALUES().selectedRepo].metadata;
+      url = TARGET_METADATA_OPTIONS[SEARCH().selectedRepo].metadata;
       method = 'GET';
       body = null;
       break;

--- a/libs/blocks/mmm/mmm.js
+++ b/libs/blocks/mmm/mmm.js
@@ -705,6 +705,13 @@ function handleMetadataFilterInput(event) {
 }
 
 function createMetadataLookup(el) {
+  const openMetadataSheetBtn = document.querySelector('h2 ~ .cta-container a');
+  const metadataSheetUrls = {
+    cc: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B818b8ad2-72db-4726-85a6-5238d6715069%7D&action=edit&activeCell=%27helix-default%27!A16&wdinitialsession=11b36a4d-a08b-0def-1294-1fcf497cfc1a&wdrldsc=4&wdrldc=1&wdrldr=AccessTokenExpiredWarningUnauthenticated%2CRefreshin',
+    dc: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B8F5A8CD0-7979-41CE-894A-CC465B293C1A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
+    express: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEC96D2B9-9F25-48AF-B88A-A6926A340D3A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true',
+    bacom: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEE70634D-C16E-45E7-B16E-718C5022413E%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
+  };
   const dropdown = {
     id: 'mmm-metadata-lookup-repo-cc',
     label: 'Choose Repo',
@@ -715,7 +722,6 @@ function createMetadataLookup(el) {
       express: 'Express',
       bacom: 'BACOM',
     },
-
   };
 
   const search = createTag('div', { class: 'mmm-metadata-lookup' }, `
@@ -737,6 +743,9 @@ function createMetadataLookup(el) {
     <button id="mmm-copy-metadata-report" class="mmm-metadata-lookup__button primary mmm-hide" style="align-self: center">Copy Report</button>
   `);
   el.append(search);
+  // Edit REP button label and URL
+  openMetadataSheetBtn.innerHTML = `Open ${dropdown.options[dropdown.selected]} Spreadsheet`;
+  openMetadataSheetBtn.href = metadataSheetUrls[dropdown.selected];
 
   // Handle REPO change
   // eslint-disable-next-line no-use-before-define

--- a/libs/blocks/mmm/mmm.js
+++ b/libs/blocks/mmm/mmm.js
@@ -57,6 +57,28 @@ const METADATA_URLS_CATEGORIES = {
   postLCP: { display: 'PostLCP', key: 'postLCP' },
 };
 
+const TARGET_METADATA_OPTIONS = {
+  cc: {
+    name: 'CC',
+    metadata: 'https://main--cc--adobecom.aem.live/metadata-optimization.json',
+    source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B818b8ad2-72db-4726-85a6-5238d6715069%7D&action=edit&activeCell=%27helix-default%27!A16&wdinitialsession=11b36a4d-a08b-0def-1294-1fcf497cfc1a&wdrldsc=4&wdrldc=1&wdrldr=AccessTokenExpiredWarningUnauthenticated%2CRefreshin',
+  },
+  dc: {
+    name: 'DC',
+    metadata: 'https://main--dc--adobecom.aem.live/metadata-optimization.json',
+    source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B8F5A8CD0-7979-41CE-894A-CC465B293C1A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
+  },
+  express: {
+    name: 'Express',
+    metadata: 'https://main--express-milo--adobecom.aem.live/metadata-optimization.json',
+    source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEC96D2B9-9F25-48AF-B88A-A6926A340D3A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true',
+  },
+  bacom: {
+    name: 'BACOM',
+    metadata: 'https://main--bacom--adobecom.aem.live/metadata-optimization.json',
+    source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEE70634D-C16E-45E7-B16E-718C5022413E%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
+  },
+};
 let isReport = false;
 let mmmPageVer = GRID_FORMAT.base;
 let isMetadataLookup = false;
@@ -710,28 +732,6 @@ function createMetadataLookup(el) {
     id: 'mmm-metadata-lookup-repo-cc',
     label: 'Choose Repo',
     selected: SEARCH_INITIAL_VALUES().selectedRepo,
-    options: {
-      cc: {
-        name: 'CC',
-        metadata: 'https://main--cc--adobecom.aem.live/metadata-optimization.json',
-        source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B818b8ad2-72db-4726-85a6-5238d6715069%7D&action=edit&activeCell=%27helix-default%27!A16&wdinitialsession=11b36a4d-a08b-0def-1294-1fcf497cfc1a&wdrldsc=4&wdrldc=1&wdrldr=AccessTokenExpiredWarningUnauthenticated%2CRefreshin',
-      },
-      dc: {
-        name: 'DC',
-        metadata: 'https://main--dc--adobecom.aem.live/metadata-optimization.json',
-        source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B8F5A8CD0-7979-41CE-894A-CC465B293C1A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
-      },
-      express: {
-        name: 'Express',
-        metadata: 'https://main--express-milo--adobecom.aem.live/metadata-optimization.json',
-        source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEC96D2B9-9F25-48AF-B88A-A6926A340D3A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true',
-      },
-      bacom: {
-        name: 'BACOM',
-        metadata: 'https://main--bacom--adobecom.aem.live/metadata-optimization.json',
-        source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEE70634D-C16E-45E7-B16E-718C5022413E%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
-      },
-    },
   };
 
   const search = createTag('div', { class: 'mmm-metadata-lookup' }, `
@@ -739,8 +739,8 @@ function createMetadataLookup(el) {
       <div>
         <label for="${dropdown.id}">${dropdown.label}:</label>
         <select id="${dropdown.id}" class="text-field-input">
-          ${Object.keys(dropdown.options).map((key) => `
-            <option value="${key}" ${dropdown.selected === key ? 'selected' : ''}>${dropdown.options[key].name}</option>
+          ${Object.keys(TARGET_METADATA_OPTIONS).map((key) => `
+            <option value="${key}" ${dropdown.selected === key ? 'selected' : ''}>${TARGET_METADATA_OPTIONS[key].name}</option>
           `).join('')}
         </select>
       </div>
@@ -754,7 +754,7 @@ function createMetadataLookup(el) {
   `);
   el.append(search);
   // Edit REP button label and URL
-  const { name, source } = dropdown.options[dropdown.selected];
+  const { name, source } = TARGET_METADATA_OPTIONS[dropdown.selected];
   openMetadataSheetBtn.innerHTML = `Open ${name} Spreadsheet`;
   openMetadataSheetBtn.href = source;
 
@@ -805,7 +805,7 @@ async function createView(el, search) {
   switch (true) {
     case isReport: url = API_URLS.report; break;
     case isMetadataLookup: {
-      url = API_URLS.metadata[SEARCH_INITIAL_VALUES().selectedRepo];
+      url = TARGET_METADATA_OPTIONS[SEARCH_INITIAL_VALUES().selectedRepo].metadata;
       method = 'GET';
       body = null;
       break;

--- a/libs/blocks/mmm/mmm.js
+++ b/libs/blocks/mmm/mmm.js
@@ -706,21 +706,31 @@ function handleMetadataFilterInput(event) {
 
 function createMetadataLookup(el) {
   const openMetadataSheetBtn = document.querySelector('.text.instructions .cta-container a');
-  const metadataSheetUrls = {
-    cc: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B818b8ad2-72db-4726-85a6-5238d6715069%7D&action=edit&activeCell=%27helix-default%27!A16&wdinitialsession=11b36a4d-a08b-0def-1294-1fcf497cfc1a&wdrldsc=4&wdrldc=1&wdrldr=AccessTokenExpiredWarningUnauthenticated%2CRefreshin',
-    dc: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B8F5A8CD0-7979-41CE-894A-CC465B293C1A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
-    express: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEC96D2B9-9F25-48AF-B88A-A6926A340D3A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true',
-    bacom: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEE70634D-C16E-45E7-B16E-718C5022413E%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
-  };
   const dropdown = {
     id: 'mmm-metadata-lookup-repo-cc',
     label: 'Choose Repo',
     selected: SEARCH_INITIAL_VALUES().selectedRepo,
     options: {
-      cc: 'CC',
-      dc: 'DC',
-      express: 'Express',
-      bacom: 'BACOM',
+      cc: {
+        name: 'CC',
+        metadata: 'https://main--cc--adobecom.aem.live/metadata-optimization.json',
+        source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B818b8ad2-72db-4726-85a6-5238d6715069%7D&action=edit&activeCell=%27helix-default%27!A16&wdinitialsession=11b36a4d-a08b-0def-1294-1fcf497cfc1a&wdrldsc=4&wdrldc=1&wdrldr=AccessTokenExpiredWarningUnauthenticated%2CRefreshin',
+      },
+      dc: {
+        name: 'DC',
+        metadata: 'https://main--dc--adobecom.aem.live/metadata-optimization.json',
+        source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B8F5A8CD0-7979-41CE-894A-CC465B293C1A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
+      },
+      express: {
+        name: 'Express',
+        metadata: 'https://main--express-milo--adobecom.aem.live/metadata-optimization.json',
+        source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEC96D2B9-9F25-48AF-B88A-A6926A340D3A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true',
+      },
+      bacom: {
+        name: 'BACOM',
+        metadata: 'https://main--bacom--adobecom.aem.live/metadata-optimization.json',
+        source: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7BEE70634D-C16E-45E7-B16E-718C5022413E%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',
+      },
     },
   };
 
@@ -730,7 +740,7 @@ function createMetadataLookup(el) {
         <label for="${dropdown.id}">${dropdown.label}:</label>
         <select id="${dropdown.id}" class="text-field-input">
           ${Object.keys(dropdown.options).map((key) => `
-            <option value="${key}" ${dropdown.selected === key ? 'selected' : ''}>${dropdown.options[key]}</option>
+            <option value="${key}" ${dropdown.selected === key ? 'selected' : ''}>${dropdown.options[key].name}</option>
           `).join('')}
         </select>
       </div>
@@ -744,8 +754,9 @@ function createMetadataLookup(el) {
   `);
   el.append(search);
   // Edit REP button label and URL
-  openMetadataSheetBtn.innerHTML = `Open ${dropdown.options[dropdown.selected]} Spreadsheet`;
-  openMetadataSheetBtn.href = metadataSheetUrls[dropdown.selected];
+  const { name, source } = dropdown.options[dropdown.selected];
+  openMetadataSheetBtn.innerHTML = `Open ${name} Spreadsheet`;
+  openMetadataSheetBtn.href = source;
 
   // Handle REPO change
   // eslint-disable-next-line no-use-before-define

--- a/libs/blocks/mmm/mmm.js
+++ b/libs/blocks/mmm/mmm.js
@@ -705,7 +705,7 @@ function handleMetadataFilterInput(event) {
 }
 
 function createMetadataLookup(el) {
-  const openMetadataSheetBtn = document.querySelector('h2 ~ .cta-container a');
+  const openMetadataSheetBtn = document.querySelector('.text.instructions .cta-container a');
   const metadataSheetUrls = {
     cc: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B818b8ad2-72db-4726-85a6-5238d6715069%7D&action=edit&activeCell=%27helix-default%27!A16&wdinitialsession=11b36a4d-a08b-0def-1294-1fcf497cfc1a&wdrldsc=4&wdrldc=1&wdrldr=AccessTokenExpiredWarningUnauthenticated%2CRefreshin',
     dc: 'https://adobe.sharepoint.com/:x:/r/sites/adobecom/_layouts/15/Doc.aspx?sourcedoc=%7B8F5A8CD0-7979-41CE-894A-CC465B293C1A%7D&file=metadata-optimization.xlsx&action=default&mobileredirect=true&wdsle=0',

--- a/libs/blocks/mmm/mmm.js
+++ b/libs/blocks/mmm/mmm.js
@@ -334,7 +334,7 @@ function createLastSeenManifestAndDomainDD() {
     'div',
     { id: 'mmm-dropdown-lastSeen', class: 'mmm-form-container' },
     `<div>
-      <label for="mmm-lastSeenManifest">Target manifests ${isReport ? 'not ' : ''}seen in the last:</label>
+      <label for="mmm-lastSeenManifest">${isReport ? 'Target manifests not' : 'Manifests'} seen in the last:</label>
       <select id="mmm-lastSeenManifest" type="text" name="mmm-lastSeenManifest" class="text-field-input">
       
       </select>

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -8,12 +8,6 @@ export const API_URLS = {
   pageDetails: `${API_DOMAIN}/get-page?id=`,
   save: `${API_DOMAIN}/save-mep-call`,
   report: `${API_DOMAIN}/get-report`,
-  metadata: {
-    cc: 'https://main--cc--adobecom.aem.live/metadata-optimization.json',
-    dc: 'https://main--dc--adobecom.aem.live/metadata-optimization.json',
-    express: 'https://main--express-milo--adobecom.aem.live/metadata-optimization.json',
-    bacom: 'https://main--bacom--adobecom.aem.live/metadata-optimization.json',
-  },
 };
 
 function updatePreviewButton(popup, pageId) {


### PR DESCRIPTION
This PR adds functionality to the single 'Open <repo> Spreadsheet' button on the MMM Metadata Lookup page. 

**The expected behavior is:** 
- User with no local storage cookie settings will default to the CC button messaging: _Open CC Spreadsheet_
- Returning users (with local storage cookie settings) should retain their previous repo selection with the appropriate messaging: _Open CC|DC|BACOM|EXPRESS_ Spreadsheet
- HREF of button will change to the matching Sharepoint metadata spreadsheet for selected repo (copied from the CC spreadsheet _readme_ tab)
- Clicking on button opens a new window, which leads to the selected reop's metadata spreadhseet

**Fixes/Features:**
- Added new button cta to open spreadsheet for selected repo (button is authored via sharepoint)
- Dependency: added class 'instructions' to the Text block on the base page 
- Dependency: button copy and hrefs are hardcoded. We can enhance later to remove dependency and generate copy and hrefs from a new milo table we create within the docx instead.

Resolves: [MWPW-173732](https://jira.corp.adobe.com/browse/MWPW-173732)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/authoring/features/mmm/target-metadata-lookup?martech=off
- After: https://mmm-metadata-addbutton--milo--adobecom.aem.page/docs/authoring/features/mmm/target-metadata-lookup?martech=off

**How to test**
1. On first page load, confirm the button copy is 'Open CC Spreadsheet' (default when no local storage values are saved)
2. Click on button, confirm the CC metadata sheet opens in a NEW window 
3. Change the selected repo, and confirm the button messaging changes to the appropriate repo messaging, AND the proper metadata sheet is opened when button is clicked 
4. Refresh the metadata lookup page and confirm that previous repo selection (dropdown),  button copy, and href persists correctly 














