### PR TITLE
[MWPW-173125] Preflight SEO 404 / General tab fixes

### DIFF
--- a/libs/blocks/preflight/panels/general.js
+++ b/libs/blocks/preflight/panels/general.js
@@ -61,7 +61,8 @@ function getUrl(el) {
   try {
     return new URL(dataPath);
   } catch {
-    const elPath = el.href || (el.src && el.nodeName === 'IFRAME' ? el?.parentElement.dataset.pdfSrc : el.src);
+    const isPdfIframe = el.src && el.nodeName === 'IFRAME' && el.parentElement?.dataset.pdfSrc;
+    const elPath = el.href || (isPdfIframe ? el.parentElement.dataset.pdfSrc : el.src);
     const path = dataPath ? `${window.location.origin}${dataPath}` : elPath;
     return new URL(path);
   }

--- a/libs/blocks/preflight/panels/seo.js
+++ b/libs/blocks/preflight/panels/seo.js
@@ -259,8 +259,13 @@ async function checkLinks() {
     badResults.push(...spidyResults);
   }
 
-  badLinks.value = badResults.map((result) => links.find((link) => compareResults(result, link)))
-    .filter(Boolean);
+  const uniqueBadResults = badResults.reduce((acc, result) => {
+    if (!acc.some((item) => item.url === result.url)) acc.push(result);
+    return acc;
+  }, []);
+
+  badLinks.value = links.filter((link) => uniqueBadResults
+    .some((result) => compareResults(result, link)));
 
   // Format the results for display
   const count = badLinks.value.length;


### PR DESCRIPTION
This fixes a couple Preflight issues:
* General tab was not loading on a page due to faulty logic related to PDF link matching;
* 404 links logic was adapted so that all links on a page get marked as such, not just the first occurrence of a failing link.

Resolves:
* [MWPW-173303](https://jira.corp.adobe.com/browse/MWPW-173303)
* [MWPW-173125](https://jira.corp.adobe.com/browse/MWPW-173125)

**Test URLs:**
- Before (PSI): https://main--milo--overmyheadandbody.aem.page?martech=off
- After (PSI): https://preflight-404-pdf-fix--milo--overmyheadandbody.aem.page?martech=off
- Before (404 issue): https://main--cc--adobecom.hlx.page/hu/legal/subscription-terms
- After (404 issue): https://main--cc--adobecom.hlx.page/hu/legal/subscription-terms?milolibs=preflight-404-pdf-fix--milo--overmyheadandbody
- Before (General tab issue): https://main--cc--adobecom.hlx.page/my_en/legal/terms
- After (General tab issue): https://main--cc--adobecom.hlx.page/my_en/legal/terms?milolibs=preflight-404-pdf-fix--milo--overmyheadandbody
