### PR TITLE
[MWPW-173717] Hyphenate large headings on mobile

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -926,7 +926,12 @@ a.static:active  {
 }
 
 /* mobile only */
-@media (max-width: 600px) {
+@media (max-width: 599px) {
+  :root:not(:lang(ja-JP), :lang(ja)) :is(.heading-xxxl, .heading-xxl) {
+    hyphens: auto;
+    hyphenate-limit-chars: 15 5 5;
+  }
+
   .con-button.button-justified-mobile {
     display: block;
     text-align: center;


### PR DESCRIPTION
This allows hyphenation when long words are present in headings with a large font size on mobile devices. A few notes:
* I've updated the previous media query, which was wrong; if tablet devices are considered to start from `600px`, then it means mobile screens go up to `599px`;
* I've excluded Japanese pages from having hyphenation rules, as it already has rigorous word break rules set in place;
* From my design knowledge, ideally the two parts of a hyphenated word aren't too imbalanced, that's why the rule I've set is: break words longer than 15 characters, but never have one part of the word be less than 5 characters. This should provide a good visual balance, also from the perspective of how many lines of text a heading has;

Resolves: [MWPW-173717](https://jira.corp.adobe.com/browse/MWPW-173717)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/headline-hyphenation?martech=off&georouting=off
- After: https://large-heading-a11y--milo--overmyheadandbody.aem.page/drafts/ramuntea/headline-hyphenation?martech=off&georouting=off
- Before: https://main--cc--adobecom.aem.page/se/products/premiere/ai-video-editing?martech=off&georouting=off
- After: https://main--cc--adobecom.aem.page/se/products/premiere/ai-video-editing?milolibs=large-heading-a11y--milo--overmyheadandbody&martech=off&georouting=off
- Before: https://main--cc--adobecom.aem.page/hu/products/premiere/ai-video-editing?martech=off&georouting=off
- After: https://main--cc--adobecom.aem.page/hu/products/premiere/ai-video-editing?milolibs=large-heading-a11y--milo--overmyheadandbody&martech=off&georouting=off
- Before: https://main--cc--adobecom.aem.page/jp/products/premiere/ai-video-editing?martech=off&georouting=off
- After: https://main--cc--adobecom.aem.page/jp/products/premiere/ai-video-editing?milolibs=large-heading-a11y--milo--overmyheadandbody&martech=off&georouting=off