### PR TITLE
MWPW-173816: remove stock checks temporarily

### DIFF
--- a/nala/features/mas/acom/masacom.test.js
+++ b/nala/features/mas/acom/masacom.test.js
@@ -45,7 +45,7 @@ test.describe('ACOM MAS cards feature test suite', () => {
       await expect(description).toContainText(data.description);
       await expect(description).toContainText(data.description);
       await expect(await acomPage.getSeeAllPlansLink(data.id)).toHaveText(data.seeAllPlansText);
-      await expect(await acomPage.getStockCheckbox(data.id)).toContainText(data.stockCheckboxLabel);
+      // await expect(await acomPage.getStockCheckbox(data.id)).toContainText(data.stockCheckboxLabel);
       await expect(await acomPage.getCardPrice(data.id)).toBeVisible();
       await expect(await acomPage.getCardPrice(data.id)).toContainText(data.price);
       await expect(await acomPage.getCardPromoText(data.id)).toBeVisible();
@@ -83,8 +83,8 @@ test.describe('ACOM MAS cards feature test suite', () => {
       expect(await webUtil.verifyCSS(await acomPage.getCardDescription(data.id).first(), acomPage.cssProp.description)).toBeTruthy();
       expect(await webUtil.verifyCSS(await acomPage.getSeeAllPlansLink(data.id), acomPage.cssProp.legalLink)).toBeTruthy();
       expect(await webUtil.verifyCSS(await acomPage.getCardCallout(data.id), acomPage.cssProp.callout)).toBeTruthy();
-      expect(await webUtil.verifyCSS(await acomPage.getStockCheckbox(data.id), acomPage.cssProp.stockCheckbox.text)).toBeTruthy();
-      expect(await webUtil.verifyCSS(await acomPage.getStockCheckboxIcon(data.id), acomPage.cssProp.stockCheckbox.checkbox)).toBeTruthy();
+      // expect(await webUtil.verifyCSS(await acomPage.getStockCheckbox(data.id), acomPage.cssProp.stockCheckbox.text)).toBeTruthy();
+      // expect(await webUtil.verifyCSS(await acomPage.getStockCheckboxIcon(data.id), acomPage.cssProp.stockCheckbox.checkbox)).toBeTruthy();
       expect(await webUtil.verifyCSS(await acomPage.getCardSecureTransaction(data.id), acomPage.cssProp.secureTransaction)).toBeTruthy();
       expect(await webUtil.verifyCSS(await acomPage.getCardCTA(data.id), acomPage.cssProp.cta)).toBeTruthy();
     });


### PR DESCRIPTION
Removes checks for stock checkbox until switched to the full functionality. This is needed to prevent Nala exutions failures during transition period

Resolves: [MWPW-173816](https://jira.corp.adobe.com/browse/MWPW-173816)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-173816--milo--adobecom.aem.page/?martech=off


