### PR TITLE
Making new nav true by default for standalone Gnav and giving font family to localnav

### DIFF
--- a/libs/navigation/navigation.css
+++ b/libs/navigation/navigation.css
@@ -12,6 +12,8 @@
   --feds-height-nav: 55px;
   --color-white: #FFF;
   --modal-close-accent-color: #707070;
+  --text-color: #2c2c2c;
+  --body-font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
 }
 
 .global-navigation, .global-footer, .dialog-modal {
@@ -53,6 +55,7 @@ header.global-navigation, header.global-navigation.feds--dark {
 header.global-navigation + .feds-localnav {
   display: block;
   height: var(--feds-localnav-height);
+  font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
 }
 
 .feds-promo-aside-wrapper {

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -154,7 +154,7 @@ export default async function loadBlock(configs, customLib) {
             noBorder: configBlock.noBorder,
             jarvis: configBlock.jarvis,
             isLocalNav: configBlock.isLocalNav,
-            mobileGnavV2: configBlock.mobileGnavV2 || 'off',
+            mobileGnavV2: configBlock.mobileGnavV2 || 'on',
           });
           configBlock.onReady?.();
         } catch (e) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Making new nav true by default for standalone Gnav which is done through config
* Giving font family for localnav as adobe clean as some clients aren't passing the font-family in the body

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav--milo--adobecom.aem.page/?martech=off