### PR TITLE
MWPW-173436 | Fix delay in split notification load

### DIFF
--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -412,7 +412,7 @@
   display: flex;
   width: auto;
   height: var(--icon-size-xs);
-  min-width: unset;
+  min-width: var(--icon-size-xs);
   max-width: unset;
 }
 

--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -420,7 +420,7 @@
   width: 100%;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
-  z-index: var(--modal-z-index);
+  z-index: 102;
 }
 
 .notification-curtain {
@@ -430,7 +430,7 @@
   bottom: 0;
   left: 0;
   background: rgb(50 50 50 / 80%);
-  z-index: var(--modal-z-index-curtain);
+  z-index: 101;
 }
 
 @media screen and (max-width: 600px) {


### PR DESCRIPTION
Fix delay in notification load by adding specific z-index value as var load is delayed

Resolves: [MWPW-173436](https://jira.corp.adobe.com/browse/MWPW-173436)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/mathuria/promobar/creativecloud/?martech=off
- After: https://mwpw-173436--milo--adobecom.aem.page/drafts/mathuria/promobar/creativecloud?martech=off

https://stage--cc--adobecom.aem.page/products/photoshop?milolibs=mwpw-173436--milo--adobecom
https://stage--dc--adobecom.aem.page/acrobat/pdf-reader?milolibs=mwpw-173436--milo--adobecom

This fix is critical for acrobat 6/5 release
