### PR TITLE
Ensuring feds promo renders behind app switcher component if on mobile and it overlaps

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -884,25 +884,25 @@ class Gnav {
     // Exposing UNAV config for consumers
     CONFIG.universalNav.universalNavConfig = getConfiguration();
     await window.UniversalNav(CONFIG.universalNav.universalNavConfig);
-    const target = document.querySelector('.feds-promo-aside-wrapper');
+    const fedsPromo = document.querySelector('.feds-promo-aside-wrapper');
     const container = document.querySelector('.feds-utilities');
-    
-    if (target) {
-      const updateZIndex = () => {
-        const isOpen = container.querySelector('.unav-comp-app-switcher-open');
-        target.style.zIndex = isOpen ? 0 : 11;
-      };
-    
-      new MutationObserver(updateZIndex)
+    const hasAppSwitcher = this.universalNavComponents.includes('appswitcher');
+    const updatePromoZIndex = () => {
+      const isOpen = container.querySelector('.unav-comp-app-switcher-open');
+      fedsPromo.style.zIndex = isOpen ? 0 : 11;
+    };
+    // Ensure promo appears behind appswitcher on mobile
+    if (fedsPromo && hasAppSwitcher && !isDesktop.matches) {
+      new MutationObserver(updatePromoZIndex)
         .observe(container, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
-    
-      updateZIndex(); // initial run in case it's already open
+      updatePromoZIndex();
     }
     performance.mark('Unav-End');
     logPerformance('Unav-Time', 'Unav-Start', 'Unav-End');
     this.decorateAppPrompt({ getAnchorState: () => window.UniversalNav.getComponent?.('app-switcher') });
     isDesktop.addEventListener('change', () => {
       window.UniversalNav.reload(getConfiguration());
+      updatePromoZIndex();
     });
   };
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -884,6 +884,20 @@ class Gnav {
     // Exposing UNAV config for consumers
     CONFIG.universalNav.universalNavConfig = getConfiguration();
     await window.UniversalNav(CONFIG.universalNav.universalNavConfig);
+    const target = document.querySelector('.feds-promo-aside-wrapper');
+    const container = document.querySelector('.feds-utilities');
+    
+    if (target) {
+      const updateZIndex = () => {
+        const isOpen = container.querySelector('.unav-comp-app-switcher-open');
+        target.style.zIndex = isOpen ? 0 : 11;
+      };
+    
+      new MutationObserver(updateZIndex)
+        .observe(container, { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] });
+    
+      updateZIndex(); // initial run in case it's already open
+    }
     performance.mark('Unav-End');
     logPerformance('Unav-Time', 'Unav-Start', 'Unav-End');
     this.decorateAppPrompt({ getAnchorState: () => window.UniversalNav.getComponent?.('app-switcher') });
@@ -1123,7 +1137,6 @@ class Gnav {
     }
     performance.mark('Gnav-Aside-End');
     logPerformance('Gnav-Aside-Time', 'Gnav-Aside-Start', 'Gnav-Aside-End');
-
     return this.elements.aside;
   };
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Making z index of feds promo to 0 on mobile if app switcher is present and open

Resolves: [MWPW-171077](https://jira.corp.adobe.com/browse/MWPW-171077)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-promo-zindex--milo--adobecom.aem.page/?martech=off
