### PR TITLE
MWPW-170548: Apply flex to metch action area

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -205,7 +205,7 @@
   padding: var(--spacing-s);
 }
 
-.table:not(.merch) .row-heading .col.col-heading .action-area {
+.table .row-heading .col.col-heading .action-area {
   display: flex;
   gap: var(--spacing-xs);
   flex-wrap: wrap;
@@ -790,9 +790,5 @@
 
   .table :is(.heading-button,.action-area) {
     max-width: 100%;
-  }
-
-  .table .action-area .con-button.button-l {
-    overflow: hidden;
   }
 }


### PR DESCRIPTION
Issue: In `table merch` there is no space between vertically aligned buttons on tablet screen size if they are authored next to each other.

![Screenshot 2025-05-22 at 14 18 09](https://github.com/user-attachments/assets/ae1b8291-5d61-4160-a3b4-1bdc437fd13c)


* Apply flex to `table merch` `action-area`
* On mobile `overflow: hidden` was used to make space between vertically aligned buttons, while this adds space between buttons when they are authored in the same line, it also adds more space between vertically aligned buttons that already have space between them (second table column on the test page). 

![Screenshot 2025-05-22 at 13 59 03](https://github.com/user-attachments/assets/7576e941-40e9-4aa8-a38b-5e2e52824b20)
![Screenshot 2025-05-22 at 13 58 59](https://github.com/user-attachments/assets/bf19246d-ee6b-4d14-a1ed-03e7e82e55da)

Resolves: [MWPW-170548](https://jira.corp.adobe.com/browse/MWPW-170548)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/mwpw-170548-table-cta/document?martech=off
- After: https://mwpw-170548-table-cta--milo--adobecom.aem.page/drafts/ratko/mwpw-170548-table-cta/document?martech=off
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
- After: https://mwpw-170548-table-cta--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off

**DC URLs:**
- Before: https://main--dc--adobecom.hlx.page/dc-shared/fragments/modals/free-trial/sign-free-trial
- After: https://main--dc--adobecom.hlx.page/dc-shared/fragments/modals/free-trial/sign-free-trial?milolibs=mwpw-170548-table-cta


