### PR TITLE
MWPW-173528 Fix Safari mobile preview

### DIFF
--- a/libs/blocks/graybox/graybox.css
+++ b/libs/blocks/graybox/graybox.css
@@ -194,6 +194,11 @@
   cursor: default;
 }
 
+.graybox-devices > a.gb-selected-button {
+  background: gray;
+  pointer-events: none;
+}
+
 .graybox-devices > a:hover {
   background-color: var(--gb-container-btn-bg);
   text-decoration: none;

--- a/libs/blocks/graybox/graybox.js
+++ b/libs/blocks/graybox/graybox.js
@@ -49,27 +49,33 @@ const setMetadata = (metadata) => {
 
 const isMobileDevice = () => /Android|webOS|iPhone|iPad|iPod/i.test(navigator.userAgent);
 
-const getTableValues = (el) => [...el.childNodes].reduce((rdx, row) => {
-  if (!row.children) return rdx;
+const getTableValues = (el) => [...el.childNodes].reduce(
+  (rdx, row) => {
+    if (!row.children) return rdx;
 
-  const key = row.children[0]?.textContent?.trim().toLowerCase();
-  const content = row.children[1];
-  let text = content?.textContent.trim();
-  /* c8 ignore next 3 */
-  if (key !== 'title' && key !== 'desc' && text) {
-    text = text.toLowerCase();
-  }
-  if (key && content) {
-    rdx.keys.push(key);
-    rdx[key] = { content, text };
-  }
-  return rdx;
-}, { keys: [] });
+    const key = row.children[0]?.textContent?.trim().toLowerCase();
+    const content = row.children[1];
+    let text = content?.textContent.trim();
+    /* c8 ignore next 3 */
+    if (key !== 'title' && key !== 'desc' && text) {
+      text = text.toLowerCase();
+    }
+    if (key && content) {
+      rdx.keys.push(key);
+      rdx[key] = { content, text };
+    }
+    return rdx;
+  },
+  { keys: [] },
+);
 
 /* c8 ignore start */
 const getOptions = (text, metadata) => {
   const options = text || getMetadata(metadata);
-  return options?.toLowerCase().split(',').map((opt) => opt.trim());
+  return options
+    ?.toLowerCase()
+    .split(',')
+    .map((opt) => opt.trim());
 };
 
 const decorateFooter = (footer, options) => {
@@ -110,7 +116,7 @@ const checkGnav = (options, globalNoClick) => {
   const gnav = document.querySelector('.global-navigation');
   if (gnav) {
     const gnavOptions = getOptions(options.gnav?.text, METADATA.GNAV);
-    if (!(gnavOptions?.includes(OPTION.CHANGED))) {
+    if (!gnavOptions?.includes(OPTION.CHANGED)) {
       gnav.classList.add(CLASS.NO_CHANGE);
       if (globalNoClick) {
         gnav.classList.add(CLASS.NO_CLICK);
@@ -131,8 +137,7 @@ const checkNoClick = (grayboxEl, noClickOnGray) => {
   if (document.body.classList.contains(CLASS.NO_CHANGE)) {
     document.body.classList.add(CLASS.NO_CLICK);
   } else {
-    document.querySelectorAll(`.${CLASS.NO_CHANGE}`)
-      .forEach((el) => el.classList.add(CLASS.NO_CLICK));
+    document.querySelectorAll(`.${CLASS.NO_CHANGE}`).forEach((el) => el.classList.add(CLASS.NO_CLICK));
   }
 };
 
@@ -169,6 +174,37 @@ const injectCSSIntoIframe = (iframe, cssRules) => {
   });
 };
 
+const setIframeUA = (iFrame, isMobile, isTablet) => {
+  if (isMobile) {
+    document.body.classList.add(CLASS.PHONE_PREVIEW);
+    deviceModal.classList.add('mobile');
+    setUserAgent(iFrame.contentWindow, USER_AGENT.iPhone);
+  } else if (isTablet) {
+    document.body.classList.add(CLASS.TABLET_PREVIEW);
+    deviceModal.classList.add('tablet');
+    setUserAgent(iFrame.contentWindow, USER_AGENT.iPad);
+  }
+};
+
+const setupIframe = (iFrame, isMobile, isTablet) => {
+  const cssRules = `
+    body > .mep-preview-overlay {
+      display: none !important;
+    }
+  `;
+  injectCSSIntoIframe(iFrame, cssRules);
+
+  iFrame.style.height = '';
+
+  setIframeUA(iFrame, isMobile, isTablet);
+
+  // Spoof iFrame dimensions as screen size for MEP
+  iFrame.contentWindow.screen = {
+    width: isMobile ? 350 : 768,
+    height: isMobile ? 800 : 1024,
+  };
+};
+
 const openDeviceModal = async (e) => {
   if (deviceModal) {
     closeModal(deviceModal);
@@ -187,37 +223,27 @@ const openDeviceModal = async (e) => {
   iFrameUrl.searchParams.set('graybox', 'menu-off');
   const deviceBorder = createTag('img', { class: 'graybox-device-border', src: isMobile ? iphoneFrame : ipadFrame });
   const iFrame = createTag('iframe', { src: iFrameUrl.href, width: '100%', height: '100%' });
-  const cssRules = `
-    body > .mep-preview-overlay {
-      display: none !important;
-    }
-  `;
-
-  injectCSSIntoIframe(iFrame, cssRules);
 
   const modal = createTag('div', null, [deviceBorder, iFrame]);
   docFrag.append(modal);
 
-  deviceModal = await getModal(null, { class: 'graybox-modal', id: 'graybox-modal', content: docFrag, closeEvent: 'closeGrayboxModal' });
+  deviceModal = await getModal(
+    null,
+    { class: 'graybox-modal', id: 'graybox-modal', content: docFrag, closeEvent: 'closeGrayboxModal' },
+  );
 
-  // Disable modal.js forcing 100% height
-  iFrame.style.height = '';
-
-  if (isMobile) {
-    document.body.classList.add(CLASS.PHONE_PREVIEW);
-    deviceModal.classList.add('mobile');
-    setUserAgent(iFrame.contentWindow, USER_AGENT.iPhone);
-  } else if (isTablet) {
-    document.body.classList.add(CLASS.TABLET_PREVIEW);
-    deviceModal.classList.add('tablet');
-    setUserAgent(iFrame.contentWindow, USER_AGENT.iPad);
+  const isSafari = /Safari/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent);
+  if (isSafari) {
+    deviceModal.style.display = 'none';
+    setupIframe(iFrame, isMobile, isTablet);
+    iFrame.addEventListener('load', () => {
+      // safari needs to wait for the iframe to load before setting the user agent
+      setIframeUA(iFrame, isMobile, isTablet);
+      deviceModal.style.display = '';
+    });
+  } else {
+    setupIframe(iFrame, isMobile, isTablet);
   }
-
-  // Spoof iFrame dimensions as screen size for MEP
-  iFrame.contentWindow.screen = {
-    width: iFrame.clientWidth,
-    height: iFrame.clientHeight,
-  };
 
   const removeBodyPreviewClasses = () => document.body.classList.remove(
     CLASS.PHONE_PREVIEW,
@@ -246,12 +272,7 @@ const createGrayboxMenu = (options, { isOpen = false } = {}) => {
   const grayboxDevices = createTag('div', { class: 'graybox-devices' }, null, { parent: grayboxMenu });
 
   ['mobile', 'tablet', 'desktop'].forEach((device) => {
-    const button = createTag(
-      'a',
-      { class: `graybox-${device} con-button` },
-      capitalizeFirstLetter(device),
-      { parent: grayboxDevices },
-    );
+    const button = createTag('a', { class: `graybox-${device} con-button` }, capitalizeFirstLetter(device), { parent: grayboxDevices });
     button.addEventListener('click', openDeviceModal);
   });
 
@@ -303,7 +324,7 @@ const grayboxThePage = (grayboxEl, grayboxMenuOff) => {
   transformLinks();
   document.body.classList.add(CLASS.GRAYBOX_BODY);
   const globalNoClick = grayboxEl.classList.contains(CLASS.NO_CLICK)
-  || grayboxEl.classList.contains(OPTION.NO_CLICK);
+    || grayboxEl.classList.contains(OPTION.NO_CLICK);
 
   const hasGrayboxChangedEl = !!document.querySelector(`.${CLASS.CHANGED}`);
   if (hasGrayboxChangedEl) {
@@ -312,8 +333,7 @@ const grayboxThePage = (grayboxEl, grayboxMenuOff) => {
     addPageOverlayDiv();
     setupChangedEls(globalNoClick);
   } else if (globalNoClick) {
-    document.querySelectorAll(`.${CLASS.NO_CHANGE}`)
-      .forEach((el) => el.classList.add(CLASS.NO_CLICK));
+    document.querySelectorAll(`.${CLASS.NO_CHANGE}`).forEach((el) => el.classList.add(CLASS.NO_CLICK));
   }
 
   const options = getTableValues(grayboxEl);
@@ -335,11 +355,7 @@ export default function init(grayboxEl) {
   const grayboxParam = url.searchParams.get('graybox');
 
   /* c8 ignore next 9 */
-  const enableGraybox = grayboxParam === 'on'
-    || url.hostname.includes('graybox.adobe.com')
-    || url.hostname.includes('localhost')
-    || url.hostname.includes('-graybox--')
-    || getMetadata('project') === 'graybox';
+  const enableGraybox = grayboxParam === 'on' || url.hostname.includes('graybox.adobe.com') || url.hostname.includes('localhost') || url.hostname.includes('-graybox--') || getMetadata('project') === 'graybox';
 
   if (grayboxParam === 'off' || !enableGraybox) {
     return;

--- a/libs/blocks/graybox/graybox.js
+++ b/libs/blocks/graybox/graybox.js
@@ -16,6 +16,7 @@ const CLASS = {
   PAGE_OVERLAY: 'gb-page-overlay',
   PHONE_PREVIEW: 'gb-phone-preview',
   TABLET_PREVIEW: 'gb-tablet-preview',
+  SELECTED_BUTTON: 'gb-selected-button',
 };
 
 const METADATA = {
@@ -212,6 +213,9 @@ const openDeviceModal = async (e) => {
     deviceModal = null;
   }
 
+  e.target.parentElement.querySelector('.graybox-desktop').classList.remove(CLASS.SELECTED_BUTTON);
+  e.target.classList.add(CLASS.SELECTED_BUTTON);
+
   if (e.target.classList.contains('graybox-desktop')) {
     return;
   }
@@ -245,10 +249,17 @@ const openDeviceModal = async (e) => {
     setupIframe(iFrame, isMobile, isTablet);
   }
 
-  const removeBodyPreviewClasses = () => document.body.classList.remove(
-    CLASS.PHONE_PREVIEW,
-    CLASS.TABLET_PREVIEW,
-  );
+  const removeBodyPreviewClasses = () => {
+    e.target.parentElement.querySelectorAll(':scope > a')
+      .forEach((el) => el.classList.remove(CLASS.SELECTED_BUTTON));
+
+    e.target.parentElement.querySelector('.graybox-desktop').classList.add(CLASS.SELECTED_BUTTON);
+
+    document.body.classList.remove(
+      CLASS.PHONE_PREVIEW,
+      CLASS.TABLET_PREVIEW,
+    );
+  };
 
   window.addEventListener('milo:modal:closed', removeBodyPreviewClasses, { once: true });
 
@@ -273,6 +284,9 @@ const createGrayboxMenu = (options, { isOpen = false } = {}) => {
 
   ['mobile', 'tablet', 'desktop'].forEach((device) => {
     const button = createTag('a', { class: `graybox-${device} con-button` }, capitalizeFirstLetter(device), { parent: grayboxDevices });
+    if (device === 'desktop') {
+      button.classList.add(CLASS.SELECTED_BUTTON);
+    }
     button.addEventListener('click', openDeviceModal);
   });
 


### PR DESCRIPTION
Safari requires that the spoofed user agent be set on the load event and not before that.

Also added an indicator as to which form factor user has selected.

Resolves: [MWPW-173528](https://jira.corp.adobe.com/browse/MWPW-173528)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/cpeyer/graybox/graybox-changed
- After: https://gb-safari-preview--milo--adobecom.aem.page/drafts/cpeyer/graybox/graybox-changed
Safari requires that the spoofed user agent be set on the load event and not before that.