### PR TITLE
Fix for jarvis A11Y issue with tooltip

### DIFF
--- a/libs/features/jarvis-chat.js
+++ b/libs/features/jarvis-chat.js
@@ -280,6 +280,20 @@ const startInitialization = async (config, event, onDemand) => {
   });
 };
 
+let eventListenerAdded = false;
+const addEventListeners = () => {
+  if (eventListenerAdded) return;
+  document.addEventListener("keydown", function(event) {
+    if (event.key === 'Escape') {
+      const tooltipMessage = document.querySelector('.adbmsg-tooltip');
+      if (tooltipMessage && tooltipMessage.style.display !== 'none') {
+          tooltipMessage.style.display = 'none';
+      }
+    }
+  });
+  eventListenerAdded = true;
+};
+
 const initJarvisChat = async (
   config,
   loadScriptFunction,
@@ -300,12 +314,14 @@ const initJarvisChat = async (
     event.preventDefault();
     if (onDemand && !chatInitialized) {
       await startInitialization(config, event, onDemand);
+      addEventListeners();
     } else {
       openChat(event);
     }
   });
   if (!onDemand) {
     await startInitialization(config);
+    addEventListeners();
   }
 };
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Implemented a fix for the `Chat with us` tooltip dismissal issue related to accessibility issue with jarvis.
Now, if the tooltip is open on hover or focus, it can be closed using the `Escape` key.

Resolves: [MWPW-168998](https://jira.corp.adobe.com/browse/MWPW-168998)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-168998--milo--deva309.aem.page/?martech=off

QA:
https://main--dc--adobecom.aem.page/acrobat/business?milolibs=mwpw-168998--milo--deva309
