### PR TITLE
MWPW-173888 + MWPW-173919: Appending extra options for relative urls & multiple cta reopen fix

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -521,7 +521,8 @@ export function appendExtraOptions(url, extraOptions) {
   const extraOptionsObj = JSON.parse(extraOptions);
   let urlWithExtraOptions;
   try {
-    urlWithExtraOptions = new URL(url);
+    const fullUrl = url.startsWith('/') ? `${window.location.origin}${url}` : url;
+    urlWithExtraOptions = new URL(fullUrl);
   } catch (err) {
     window.lana?.log(`Invalid URL ${url} : ${err}`);
     return url;
@@ -539,7 +540,7 @@ export function appendExtraOptions(url, extraOptions) {
 }
 
 async function openExternalModal(url, getModal, extraOptions) {
-  await loadStyle(`${getConfig().base}/blocks/iframe/iframe.css`);
+  loadStyle(`${getConfig().base}/blocks/iframe/iframe.css`);
   const root = createTag('div', { class: 'milo-iframe' });
   const urlWithExtraOptions = appendExtraOptions(url, extraOptions);
   const urlWithTabName = appendTabName(urlWithExtraOptions);
@@ -796,10 +797,17 @@ export async function getPriceContext(el, params) {
   };
 }
 
+let modalReopened = false;
 export function reopenModal(cta) {
+  if (modalReopened) return;
   if (cta && cta.getAttribute('data-modal-id') === window.location.hash.replace('#', '')) {
     cta.click();
+    modalReopened = true;
   }
+}
+
+export function resetReopenStatus() {
+  modalReopened = false;
 }
 
 export async function buildCta(el, params) {

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -25,6 +25,7 @@ import merch, {
   appendExtraOptions,
   getMiloLocaleSettings,
   reopenModal,
+  resetReopenStatus,
   setCtaHash,
   openModal,
   PRICE_TEMPLATE_LEGAL,
@@ -494,6 +495,29 @@ describe('Merch Block', () => {
         reopenModal(cta);
         expect(clickSpy.called).to.be.true;
         window.location.hash = prevHash;
+        resetReopenStatus();
+      });
+
+      it('only reopens one modal if multiples hashes match', async () => {
+        const prevHash = window.location.hash;
+        window.location.hash = '#try-photoshop';
+
+        const cta1 = document.createElement('a');
+        cta1.setAttribute('data-modal-id', 'try-photoshop');
+        const clickSpy1 = sinon.spy(cta1, 'click');
+
+        const cta2 = document.createElement('a');
+        cta1.setAttribute('data-modal-id', 'try-photoshop');
+        const clickSpy2 = sinon.spy(cta2, 'click');
+
+        reopenModal(cta1);
+        reopenModal(cta2);
+
+        expect(clickSpy1.called).to.be.true;
+        expect(clickSpy2.called).to.be.false;
+
+        window.location.hash = prevHash;
+        resetReopenStatus();
       });
     });
 
@@ -860,6 +884,12 @@ describe('Merch Block', () => {
       expect(resultUrl).to.equal(invalidUrl);
       const resultUrl2 = appendExtraOptions(invalidUrl);
       expect(resultUrl2).to.equal(invalidUrl);
+    });
+
+    it('appends extra options if the provided url is relative', () => {
+      const relativeUrl = '/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html';
+      const resultUrl = appendExtraOptions(relativeUrl, JSON.stringify({ promoid: 'test' }));
+      expect(resultUrl).to.include('?promoid=test');
     });
   });
 


### PR DESCRIPTION
PR was already approved to stage: https://github.com/adobecom/milo/pull/4225 & this PR to main exists to fast-track this to production without affecting the current stage batch

Resolves: [MWPW-173888](https://jira.corp.adobe.com/browse/MWPW-173888), [MWPW-173919](https://jira.corp.adobe.com/browse/MWPW-173919)

GWP staged content with 3in1 modals on Stage. Planned go live 5th June.
Warriors implemented feature flag "mas-ff-3in1", to enable GWP publish 3in1 modals before 5th June. Until metadata flag is removed/switched to "on", 3in1 modals will fallback to be shown as legacy Dexter Modals.

However we've identified 2 issues with fallback mechanism:

### Issue 1
deeplinking with ms=e and cs=t is not working on fallback legacy modals
### Issue 2
if there are multiple modals with same hash, then opening the page with hash will result in hanging modal and all of them opening at the same time.

This PR is blocking GWP from publishing content, so we will be requesting approval to merge it during RCP.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-173888--milo--adobecom.aem.page/?martech=off

Can be tested by overriding the source directly on these urls 
https://www.adobe.com/cc-shared/fragments/drafts/mariia/3in1
https://www.stage.adobe.com/cc-shared/fragments/drafts/mariia/3in1

