### PR TITLE
MWPW-173875 direct to main

### DIFF
--- a/libs/utils/logWebVitals.js
+++ b/libs/utils/logWebVitals.js
@@ -8,7 +8,7 @@ function sendToLana(lanaData) {
 
   Object.assign(lanaData, {
     chromeVer: ua.match(/Chrome\/(\d+\.\d+\.\d+\.\d+)/)?.[1] || '',
-    country: sessionStorage.getItem('akamai') || '',
+    country: sessionStorage.getItem('akamai') || sessionStorage.getItem('feds_location') || '',
     // eslint-disable-next-line compat/compat
     downlink: window.navigator?.connection?.downlink || '',
     loggedIn: window.adobeIMS?.isSignedInUser() || false,
@@ -19,7 +19,7 @@ function sendToLana(lanaData) {
       || (ua.match(/Linux/) && 'linux')
       || '',
     tablet: (ua.match(/(ipad|iPad|tablet|(android(?!.*mobile))|(windows(?!.*phone).*touch))/) && 'yes')
-      || '',
+      || 'no',
     windowHeight: window.innerHeight,
     windowWidth: window.innerWidth,
     url: `${window.location.host}${window.location.pathname}`,
@@ -88,15 +88,19 @@ function observeLCP(lanaData, delay, mep) {
     const lastEntry = entries[entries.length - 1]; // Use the latest LCP candidate
     lanaData.lcp = parseInt(lastEntry.startTime, 10);
     const lcpEl = lastEntry.element;
-    lanaData.lcpElType = lcpEl?.nodeName?.toLowerCase() || 'Element Was Replaced';
-    lanaData.lcpEl = getElementInfo(lcpEl);
-    lanaData.lcpSectionOne = boolStr(sectionOne.contains(lcpEl));
-    const closestFrag = lcpEl.closest('.fragment');
-    lanaData.isFrag = boolStr(closestFrag);
-    if (closestFrag) {
-      lanaData.isMep = boolStr(isFragmentFromMep(closestFrag.dataset.path, mep));
+    lanaData.lcpElType = lcpEl?.nodeName?.toLowerCase();
+    if (lanaData.lcpElType) {
+      lanaData.lcpEl = getElementInfo(lcpEl);
+      lanaData.lcpSectionOne = boolStr(sectionOne.contains(lcpEl));
+      const closestFrag = lcpEl.closest('.fragment');
+      lanaData.isFrag = boolStr(closestFrag);
+      if (closestFrag) {
+        lanaData.isMep = boolStr(isFragmentFromMep(closestFrag.dataset.path, mep));
+      } else {
+        lanaData.isMep = 'false';
+      }
     } else {
-      lanaData.isMep = 'false';
+      lanaData.lcpElType = 'Element Was Replaced';
     }
 
     setTimeout(() => {

--- a/test/utils/logWebVitals.test.js
+++ b/test/utils/logWebVitals.test.js
@@ -34,7 +34,7 @@ describe('Log Web Vitals', () => {
         expect(vitals.manifest4path).to.equal('/cc-shared/fragments/tests/2024/q2/ace0875/ace0875.json');
         expect(vitals.manifest4selected).to.equal('target-var-marqueelink');
         expect(vitals.os).to.be.oneOf(['mac', 'iOS', 'win', 'android', 'linux', '']);
-        expect(vitals.tablet).to.be.oneOf(['yes', '']);
+        expect(vitals.tablet).to.be.oneOf(['yes', 'no']);
         expect(vitals.url).to.equal('localhost:2000/');
         expect(vitals.isMep).to.equal('false');
         expect(vitals.isFrag).to.equal('false');

--- a/test/utils/logWebVitalsUtils.test.js
+++ b/test/utils/logWebVitalsUtils.test.js
@@ -50,7 +50,7 @@ describe('Log Web Vitals Utils', () => {
 
         expect(vitals.loggedIn).to.equal('false');
         expect(vitals.os).to.be.oneOf(['mac', 'iOS', 'win', 'android', 'linux', '']);
-        expect(vitals.tablet).to.be.oneOf(['yes', '']);
+        expect(vitals.tablet).to.be.oneOf(['yes', 'no']);
         expect(vitals.url).to.equal('localhost:2000/');
         expect(parseInt(vitals.windowHeight, 10)).to.be.greaterThan(200);
         expect(parseInt(vitals.windowWidth, 10)).to.be.greaterThan(200);


### PR DESCRIPTION
Update to performance logs

Returns whether it's a tablet or not
doesn't break on hydrated elements
get country fromfeds_location as a backup when akamai fails
Resolves: [MWPW-173875](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://mwpw-173875--milo--adobecom.aem.page/?martech=off

