### PR TITLE
MWPW-173197 Allow loading of gnav on all graybox domains

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -316,7 +316,6 @@ export const [setConfig, updateConfig, getConfig] = (() => {
 })();
 
 let federatedContentRoot;
-/* eslint-disable import/prefer-default-export */
 export const getFederatedContentRoot = () => {
   const cdnWhitelistedOrigins = [
     'https://www.adobe.com',
@@ -324,15 +323,21 @@ export const getFederatedContentRoot = () => {
     'https://blog.adobe.com',
     'https://milo.adobe.com',
     'https://news.adobe.com',
+    'graybox.adobe.com',
   ];
   const { allowedOrigins = [], origin: configOrigin } = getConfig();
   if (federatedContentRoot) return federatedContentRoot;
   // Non milo consumers will have its origin from config
   const origin = configOrigin || window.location.origin;
 
-  federatedContentRoot = [...allowedOrigins, ...cdnWhitelistedOrigins].some((o) => origin.replace('.stage', '') === o)
-    ? origin
-    : 'https://www.adobe.com';
+  const isAllowedOrigin = [...allowedOrigins, ...cdnWhitelistedOrigins].some((o) => {
+    const originNoStage = origin.replace('.stage', '');
+    return o.startsWith('https://')
+      ? originNoStage === o
+      : originNoStage.endsWith(o);
+  });
+
+  federatedContentRoot = isAllowedOrigin ? origin : 'https://www.adobe.com';
 
   if (origin.includes('localhost') || origin.includes(`.${SLD}.`)) {
     federatedContentRoot = `https://main--federal--adobecom.aem.${origin.endsWith('.live') ? 'live' : 'page'}`;

--- a/test/utils/federated.test.js
+++ b/test/utils/federated.test.js
@@ -8,6 +8,12 @@ describe('Federated navigation utilities', () => {
     it('should return the federated content root', () => {
       expect(getFederatedContentRoot('https://adobe.com/federel/footer')).to.equal(baseHost);
     });
+
+    it('should allow for all graybox.adobe.com subdomains', () => {
+      expect(getFederatedContentRoot('https://graybox.adobe.com/federel/footer')).to.equal(baseHost);
+      expect(getFederatedContentRoot('https://mysubdomain.graybox.adobe.com/federel/footer')).to.equal(baseHost);
+      expect(getFederatedContentRoot('https://04-02-25-nab-gen-studio-mweb.graybox.adobe.com/federel/footer')).to.equal(baseHost);
+    });
   });
 
   describe('getFederatedUrl', () => {


### PR DESCRIPTION
With graybox, there will be many different domains used - e.g: https://04-02-25-nab-gen-studio-mweb.graybox.adobe.com

When domains without https:// are added to `cdnWhitelistedOrigins`, then an `endsWith` check is done to see if the domain is allowed.

Resolves: [MWPW-173197](https://jira.corp.adobe.com/browse/MWPW-173197)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://173197-gray-gnav--milo--adobecom.aem.page/?martech=off
