### PR TITLE
[MWPW-171938] - table header cell markup fix

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -639,7 +639,11 @@ export default function init(el) {
     cols.forEach((col, cdx) => {
       col.dataset.colIndex = cdx + 1;
       col.classList.add('col', `col-${cdx + 1}`);
-      col.setAttribute('role', 'cell');
+      if (col.classList.contains('section-head-title')) {
+        col.setAttribute('role', 'columnheader');
+      } else {
+        col.setAttribute('role', 'cell');
+      }
     });
 
     expandSection = handleSection(sectionParams);


### PR DESCRIPTION
This resolves an issue where curtain cells in a table had a wrong role of cell and not columnheader which was causing a11y issues with NVDA speech reader and not associating the column header with it's data.

Resolves: [MWPW-171938](https://jira.corp.adobe.com/browse/MWPW-171938)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/dusan/table-header-cell-markup?martech=off
- After: https://table-header-cell-markup--milo--adobecom.hlx.page/drafts/dusan/table-header-cell-markup?martech=off

**Table block Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
- After: https://table-header-cell-markup--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off