### PR TITLE
[MWPW-173963] - table inside tabs sticky fix

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -8,7 +8,7 @@ import { getGnavHeight } from '../global-navigation/utilities/utilities.js';
 const DESKTOP_SIZE = 900;
 const MOBILE_SIZE = 768;
 const tableHighlightLoadedEvent = new Event('milo:table:highlight:loaded');
-const TAB_CHANGE_EVENT = 'milo:tab:changed';
+const tabChangeEvent = 'milo:tab:changed';
 let tableIndex = 0;
 let isExpandEventsAssigned = false;
 
@@ -698,7 +698,7 @@ export default function init(el) {
     }
   });
 
-  window.addEventListener(TAB_CHANGE_EVENT, () => handleStickyHeader(el));
+  window.addEventListener(tabChangeEvent, () => handleStickyHeader(el));
   observer.observe(el);
 
   tableIndex++;

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -8,7 +8,7 @@ import { processTrackingLabels } from '../../martech/attributes.js';
 const PADDLE = '<svg aria-hidden="true" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.50001 13.25C1.22022 13.25 0.939945 13.1431 0.726565 12.9292C0.299315 12.5019 0.299315 11.8096 0.726565 11.3823L5.10938 7L0.726565 2.61768C0.299315 2.19043 0.299315 1.49805 0.726565 1.0708C1.15333 0.643068 1.84669 0.643068 2.27345 1.0708L7.4297 6.22656C7.63478 6.43164 7.75001 6.70996 7.75001 7C7.75001 7.29004 7.63478 7.56836 7.4297 7.77344L2.27345 12.9292C2.06007 13.1431 1.7798 13.2495 1.50001 13.25Z" fill="currentColor"/></svg>';
 const tabColor = {};
 const linkedTabs = {};
-const TAB_CHANGE_EVENT = 'milo:tab:changed';
+const tabChangeEvent = new Event('milo:tab:changed');
 
 const isTabInTabListView = (tab) => {
   const tabList = tab.closest('[role="tablist"], [role="radiogroup"]');
@@ -98,7 +98,7 @@ function changeTabs(e) {
     .forEach((p) => p.setAttribute('hidden', true));
   targetContent?.removeAttribute('hidden');
   if (tabsBlock.classList.contains('stacked-mobile')) scrollStackedMobile(targetContent);
-  window.dispatchEvent(new Event(TAB_CHANGE_EVENT));
+  window.dispatchEvent(tabChangeEvent);
 }
 
 function getStringKeyName(str) {


### PR DESCRIPTION
This fixes an issue where for tables nested inside a tab the logic for canceling the sticky heading wasn't being initialized.

Resolves: [MWPW-173963](https://jira.corp.adobe.com/browse/MWPW-173963)

**Tables inside Tabs Test URLs:**
Before: https://main--milo--adobecom.aem.page/drafts/dusan/table-inside-tabs
After: https://tabs-table-nested-sticky-fix--milo--adobecom.aem.page/drafts/dusan/table-inside-tabs

**Test URLs:**
Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
After: https://tabs-table-nested-sticky-fix--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off

**CC Test URLs:**
Before: https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/lightroom/compare-plans/table/individual/default
After: https://main--cc--adobecom.hlx.page/cc-shared/fragments/merch/products/lightroom/compare-plans/table/individual/default?milolibs=tabs-table-nested-sticky-fix






