### PR TITLE
[MWPW-170178] Table highlight a11y

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -131,6 +131,12 @@
   visibility: hidden;
 }
 
+.table .highlight-text {
+  overflow: hidden;
+  width: 0;
+  height: 0;
+}
+
 /* heading */
 .table .col-heading.hidden {
   border-top: none !important;

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -39,8 +39,8 @@ function handleHeading(table, headingCols) {
     if (!elements.length) {
       col.innerHTML = `<p class="tracking-header">${col.innerHTML}</p>`;
     } else {
-      let textStartIndex = 0;
-      const iconTile = elements[0]?.querySelector('img');
+      let textStartIndex = col.querySelector('.highlight-text') ? 1 : 0;
+      const iconTile = elements[textStartIndex]?.querySelector('img');
       if (iconTile) {
         textStartIndex += 1;
         if (!(table.classList.contains('merch'))) iconTile.closest('p').classList.add('header-product-tile');
@@ -199,6 +199,7 @@ function handleHighlight(table) {
 
   if (isHighlightTable) {
     firstRow.classList.add('row-highlight');
+    firstRow.setAttribute('aria-hidden', 'true');
     secondRow.classList.add('row-heading');
     secondRowCols.forEach((col) => col.classList.add('col-heading'));
     headingCols = secondRowCols;
@@ -207,6 +208,8 @@ function handleHighlight(table) {
       col.classList.add('col-highlight');
       if (col.innerText) {
         headingCols[i]?.classList.add('no-rounded');
+        const highlightText = createTag('div', { class: 'highlight-text' }, col.innerText);
+        headingCols[i]?.insertBefore(highlightText, headingCols[i].firstChild);
       } else {
         col.classList.add('hidden');
       }


### PR DESCRIPTION
This is an attempt to address the accessibility issues related to tables that make use of highlights. What it tries to address:
* stop announcing highlight content as the first row; these are visually tied to a column heading, thus highlights should not be announced individually;
* announce highlight text along with heading content when navigating through table cells, as that is what the visual representation suggests;
* make sure the highlight row isn't counted, so that the heading row is announced as the first one;
* reduce possibilities of new layout regressions being introduced.

This is likely a suboptimal fix, as the table structure would need to be completely rebuilt to account for all accessibility requirements; that redesign is currently being discussed, but in the interim, this should bring the table closer to being EAA-compliant.

### Screenshots
Notice that the VoiceOver announcement from the 'After' capture contains the highlight text as well.

Before | After
--- | ---
<img width="1515" alt="Screenshot 2025-05-27 at 15 59 16" src="https://github.com/user-attachments/assets/1371b2a7-f009-4cbf-94a5-18c52a314bff" /> | <img width="1572" alt="Screenshot 2025-05-27 at 15 57 54" src="https://github.com/user-attachments/assets/757b5485-dfb2-481b-9a67-43b9ffb358cf" />


Resolves: [MWPW-170178](https://jira.corp.adobe.com/browse/MWPW-170178)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/table?martech=off
- After: https://table-highlight--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/table?martech=off

