### PR TITLE
[MWPW-171062] Allow decorative images through image links

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -745,7 +745,7 @@ export function decorateImageLinks(el) {
     try {
       const url = new URL(source.trim());
       const href = (url.hostname.includes('.aem.') || url.hostname.includes('.hlx.')) ? `${url.pathname}${url.search}${url.hash}` : url.href;
-      if (alt?.trim().length) img.alt = alt.trim();
+      img.alt = alt?.trim() || '';
       const pic = img.closest('picture');
       const picParent = pic.parentElement;
       if (href.includes('.mp4')) {


### PR DESCRIPTION
This allows defining decorative images when using the image links feature.

Resolves: [MWPW-171062](https://jira.corp.adobe.com/browse/MWPW-171062)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/decorative-image-link?martech=off
- After: https://vid-img-alt--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/decorative-image-link?martech=off


