### PR TITLE
Mweb tabs, editorial cards, icon block

### DIFF
--- a/libs/mep/ace1052/editorial-card/editorial-card.css
+++ b/libs/mep/ace1052/editorial-card/editorial-card.css
@@ -32,15 +32,15 @@
   cursor: pointer;
 }
 
-.editorial-card.click.hover-scale { 
+.editorial-card.click.hover-scale {
   transition: all .2s ease-in-out;
 }
 
-.editorial-card.click.hover-scale:hover { 
+.editorial-card.click.hover-scale:hover {
   transform: scale(var(--card-scale-default));
 }
 
-.editorial-card:not(.no-bg).click.hover-scale:hover { 
+.editorial-card:not(.no-bg).click.hover-scale:hover {
   box-shadow: 0 3px 6px 0  rgba(0 0 0 / 16%);
 }
 
@@ -149,7 +149,7 @@
   line-height: 0;
 }
 
-.editorial-card.no-foreground { 
+.editorial-card.no-foreground {
   border: none;
 }
 
@@ -160,7 +160,7 @@
 .editorial-card.footer-align-left .card-footer > div { text-align: start; }
 .editorial-card.footer-align-center .card-footer > div { text-align: center; }
 
-.editorial-card.no-bg.no-border .foreground > div { 
+.editorial-card.no-bg.no-border .foreground > div {
   row-gap: var(--spacing-xs);
 }
 
@@ -170,7 +170,7 @@
   height: 100%;
 }
 
-.editorial-card .background .milo-video, 
+.editorial-card .background .milo-video,
 .editorial-card .background .milo-iframe {
   height: 100%;
   padding-bottom: 0;
@@ -194,7 +194,7 @@
   line-height: initial;
 }
 
-.editorial-card .action-area, 
+.editorial-card .action-area,
 .editorial-card .card-footer > .action-area {
   display: flex;
   align-items: center;
@@ -204,7 +204,7 @@
   flex-direction: row;
 }
 
-.editorial-card .action-area .con-button { 
+.editorial-card .action-area .con-button {
   white-space: nowrap;
 }
 
@@ -279,9 +279,9 @@
 }
 
 /* Align */
-.editorial-card.center { 
-  text-align: center; 
-  justify-items: center; 
+.editorial-card.center {
+  text-align: center;
+  justify-items: center;
 }
 
 .editorial-card.footer-align-left .action-area { justify-content: start; }
@@ -364,5 +364,33 @@
   .section .show-more-icon {
     display: inline-flex;
     align-items: center;
+  }
+}
+
+/* Mweb specific */
+@media screen and (max-width: 599px) {
+  /* General */
+  :root {
+    --type-heading-all-weight: 800;
+  }
+
+  [class^="heading-"] {
+    font-weight: var(--type-heading-all-weight);
+  }
+
+  [class^="detail-"] {
+    text-transform: unset;
+  }
+
+  [class^="detail-"] strong {
+    font-weight: 500;
+  }
+
+  /* Block specific */
+  /* Ideally this would be addressed on L22 */
+  .light .editorial-card,
+  .editorial-card.light {
+    color: var(--text-color);
+    border-color: var(--color-gray-300);
   }
 }

--- a/libs/mep/ace1052/hero-marquee/hero-marquee.css
+++ b/libs/mep/ace1052/hero-marquee/hero-marquee.css
@@ -334,10 +334,6 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
 
   .hero-marquee.media-hidden-mobile .foreground .asset,
   .hero-marquee.media-hidden-mobile .foreground-media { display: none; }
-
-  .hero-marquee .con-block.row-text:has(.action-area) + .con-block.row-text .row-wrapper {
-    text-align: center;
-  }
 }
 
 /* Tablet ONLY */
@@ -536,7 +532,8 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   }
 
   /* Block specific */
-  .hero-marquee .action-area a:not(.con-button) {
+  .hero-marquee .action-area a:not(.con-button),
+  .hero-marquee .con-block.row-text:has(.action-area) + .con-block.row-text .row-wrapper {
     align-self: center;
     font-size: 17px;
   }

--- a/libs/mep/ace1052/icon-block/icon-block.css
+++ b/libs/mep/ace1052/icon-block/icon-block.css
@@ -535,10 +535,26 @@
     height: var(--icon-size-s);
   }
 
+  .icon-block.full-width .foreground .icon-area {
+    margin-bottom: var(--spacing-xs);
+  }
+
   .section:has(.icon-block + .action-scroller) {
     width: var(--grid-container-width);
     margin: auto;
     background: #EEE;
     border-radius: var(--l-rounded-corners);
+  }
+
+  .section:has(.icon-block + .action-scroller) .action-scroller .scroller {
+    --mask-width: var(--grid-margins-width);
+
+    padding-inline: var(--grid-margins-width);
+    gap: var(--spacing-xs);
+  }
+
+  .section:has(.icon-block + .action-scroller) .action-item .main-image {
+    max-width: 60px;
+    margin-inline: auto;
   }
 }

--- a/libs/mep/ace1052/icon-block/icon-block.js
+++ b/libs/mep/ace1052/icon-block/icon-block.js
@@ -26,7 +26,7 @@ const iconBlocks = {
     [variants[3]]: ['s', 's'],
   },
   medium: {
-    [variants[0]]: ['l', 's'], /* Mweb specific */
+    [variants[0]]: ['l', 's'], /* Mweb specific, s was m */
     [variants[1]]: ['m', 'm'],
     [variants[2]]: ['s', 's'],
     [variants[3]]: ['s', 's'],

--- a/libs/mep/ace1052/tabs/tabs.css
+++ b/libs/mep/ace1052/tabs/tabs.css
@@ -1,0 +1,687 @@
+:root {
+  /* Tab Colors */
+  --tabs-active-color: #1473e6;
+  --tabs-border-color: #909090;
+  --tabs-border-hover-color: #acacac;
+  --tabs-text-color: #686868;
+  --tabs-active-text-color: #2c2c2c;
+  --tabs-bg-color: #f1f1f1;
+  --tabs-active-bg-color: #fff;
+  --tabs-list-bg-gradient: linear-gradient(
+    to bottom,
+    rgba(136, 136, 136, 0) 0%,
+    rgba(136, 136, 136, 0) 60%,
+    rgba(136, 136, 136, 0.03) 80%,
+    rgba(136, 136, 136, 0.08) 100%
+  );
+  --tabs-mobile-stacked-bg-color: #242424;
+  --tabs-mobile-stacked-text-color: #ffffff;
+  --tabs-pill-bg-color: #292929;
+  --tabs-pill-bg-color-hover: #e1e1e1;
+  --tabs-pill-bg-focus: #505050;
+  --tabs-pill-bg-color-active: #505050;
+  --tabs-pill-text-focus-color: #ffffff;
+  --tabs-pill-text-color: #505050;
+  --tabs-pill-text-selected-color: #ffffff;
+  --tabs-paddle-bs-color: #0000001a;
+  --tabs-radio-gray: #6d6d6d;
+  --tabs-radio-blue: #0265dc;
+  --tabs-radio-bg: #fff;
+  --tabs-radio-button-bg: #fdfdfd;
+}
+
+:root .dark {
+  --tabs-border-color: #909090;
+  --tabs-text-color: #b6b6b6;
+  --tabs-active-text-color: #fff;
+  --tabs-bg-color: #1a1a1a;
+  --tabs-active-bg-color: #1e1e1e;
+  --tabs-list-bg-gradient: linear-gradient(
+    rgba(0, 0, 0, 0%) 0%,
+    rgba(0, 0, 0, 0%) 60%,
+    rgba(0, 0, 0, 20%) 80%,
+    rgba(0, 0, 0, 40%) 100%
+  );
+  --tabs-pill-bg-color: #ffffff;
+  --tabs-pill-bg-focus: #6d6d6d;
+  --tabs-pill-bg-color-hover: #6d6d6d;
+  --tabs-pill-bg-color-active: #393939;
+  --tabs-pill-text-color: #fff;
+  --tabs-pill-text-selected-color: #000000;
+  --tabs-pill-text-focus-color: #ffffff;
+  --tabs-mobile-stacked-bg-color: #ffffff;
+  --tabs-mobile-stacked-text-color: #131313;
+  --tabs-paddle-bs-color: #ffffff1a;
+  --tabs-radio-gray: #d4d4d4;
+  --tabs-radio-blue: #5eaaf7;
+  --tabs-radio-bg: #1e1e1e;
+  --tabs-radio-button-bg: #000;
+}
+
+.tabs {
+  position: relative;
+  margin: 0;
+  color: var(--tabs-active-text-color);
+  background-color: var(--tabs-active-bg-color);
+  z-index: 1;
+}
+
+.tabs.xxl-spacing {
+  padding: var(--spacing-xxl) 0;
+}
+
+.tabs.xxl-spacing .paddle {
+  top: var(--spacing-xxl);
+}
+
+.tabs.xl-spacing {
+  padding: var(--spacing-xl) 0;
+}
+
+.tabs.xl-spacing .paddle {
+  top: var(--spacing-xl);
+}
+
+.tabs.l-spacing {
+  padding: var(--spacing-l) 0;
+}
+
+.tabs.l-spacing .paddle {
+  top: var(--spacing-l);
+}
+
+.tabs.s-spacing {
+  padding: var(--spacing-s) 0;
+}
+
+.tabs.s-spacing .paddle {
+  top: var(--spacing-s);
+}
+
+.tabs.xs-spacing {
+  padding: var(--spacing-xs) 0;
+}
+
+.tabs.xs-spacing .paddle {
+  top: var(--spacing-xs);
+}
+
+.tabs .tabList {
+  position: relative;
+  box-shadow: 0 -1px 0 inset var(--tabs-border-color);
+  display: flex;
+  z-index: 2;
+  margin: 0 var(--spacing-m);
+  /* ScrollProps - If content exceeds height of container, overflow! */
+  overflow: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  -ms-overflow-style: none; /* Internet Explorer 10+ */
+  scrollbar-width: none; /* Firefox 64 */
+
+  /* default bg */
+  background: var(--tabs-list-bg-gradient);
+  background-size: 100% 16px;
+  background-position: bottom;
+  background-repeat: no-repeat;
+}
+
+.tabs .tabList::-webkit-scrollbar {
+  display: none; /* Safari and Chrome */
+}
+
+.tabs .tab-headline {
+  margin-top: var(--spacing-xxl);
+  margin-bottom: var(--spacing-xl);
+}
+
+.tabs.center .tab-headline {
+  text-align: center;
+}
+
+.tabs .tabList .tab-list-container {
+  display: flex;
+  width: var(--grid-container-width);
+  margin: 0 auto;
+  box-sizing: content-box;
+}
+
+/* center tabs */
+.tabs.center > .tabList::after,
+.tabs.center > .tabList::before {
+  content: "";
+  margin: auto;
+}
+
+.tabs.center:not(.same-width) .tabList .tab-list-container {
+  width: auto;
+}
+
+.tabs .tab-content {
+  border-bottom: 1px solid var(--tabs-border-color);
+}
+
+/* contained tabs content */
+[role='tabpanel'] > .section > .content,
+.tabs.contained .tab-content .tab-content-container {
+  width: var(--grid-container-width);
+  margin: 0 auto;
+}
+
+.tab-content [role='tabpanel'] .section {
+  position: relative;
+}
+
+.tab-content [role='tabpanel'] .section picture.section-background {
+  z-index: 0;
+}
+
+.tab-content [role='tabpanel'] .section > .content {
+  z-index: 1;
+  position: relative;
+}
+
+.tab-content [role='tabpanel'] .section[class*='-up'] > .content {
+  width: 100%;
+}
+
+.tabs .tabList button {
+  background: transparent;
+  border-radius: 4px 4px 0 0;
+  border: 1px solid transparent;
+  color: var(--tabs-text-color);
+  cursor: pointer;
+  float: left;
+  font-family: var(--body-font-family);
+  font-weight: 600;
+  margin-left: -1px;
+  margin-top: 0;
+  padding: 14px 16px 12px;
+  text-decoration: none;
+  transition: color 0.1s ease-in-out;
+  white-space: nowrap;
+  width: auto;
+  z-index: 1;
+}
+
+.tabs.same-width .tabList button {
+  flex: 1;
+}
+
+.tabs .paddle {
+  position: absolute;
+  cursor: pointer;
+  width: 32px;
+  height: 48px;
+  top: 0;
+  background: var(--tabs-active-bg-color);
+  border: 0;
+  border-bottom: 1px solid var(--tabs-border-color);
+  padding: 14px 0 12px;
+  display: flex;
+  align-items: center;
+}
+
+.tabs.quiet .paddle {
+  margin-top: 1px;
+}
+
+.tabs.radio .tabList,
+.tabs.radio .tabList button,
+.tabs.radio .paddle {
+  box-shadow: none;
+  background: none;
+  border: none;
+}
+
+.tabs .tabList button:first-of-type {
+  margin-left: 0;
+  margin-top: 0;
+}
+
+.tabs .tabList button:hover {
+  color: var(--tabs-active-text-color);
+}
+
+.tabs .tabList button:active {
+  color: var(--tabs-active-color);
+}
+
+.tabs .tabList button[aria-selected="true"],
+.tabs .tabList button[aria-checked="true"] {
+  background: var(--tabs-active-bg-color);
+  border-color: var(--tabs-border-color) var(--tabs-border-color) transparent;
+  color: var(--tabs-active-text-color);
+}
+
+/* Tabs: .quiet, .pill */
+.tabs.quiet .tabList button {
+  border-width: 0 0 2px;
+  border-color: transparent;
+  background: transparent;
+  padding-right: 0;
+  padding-left: 0;
+  margin-inline-start: 24px;
+}
+
+.tabs.quiet:is(.no-top-border, .no-border) .tabList,
+.tabs.quiet:is(.no-top-border, .no-border) .paddle,
+.tabs.quiet:is(.no-bottom-border, .no-border) .tab-content {
+  border-bottom: none;
+  box-shadow: none;
+  background: none;
+}
+
+.tabs.quiet .tabList {
+  padding-bottom: 1px;
+}
+
+.tabs[class*='pill'] .tab-content {
+  border-bottom: none;
+}
+
+.tabs[class*='pill'] .tabList {
+  box-shadow: unset;
+  background: unset;
+}
+
+.tabs[class*='pill'] .tabList .tab-list-container {
+  margin-top: var(--spacing-xxs);
+  margin-bottom: var(--spacing-xxs);
+}
+
+.tabs[class*='pill'] .tabList button {
+  color: var(--tabs-pill-text-color);
+  margin: 0;
+  margin-inline-start: 16px;
+  border-radius: 75px;
+  font-weight: 400;
+  padding: 0.2em 1em;
+  border: none;
+}
+
+.tabs.radio .tabList button {
+  background: transparent;
+  padding-block: 0 var(--spacing-s);
+  padding-inline: 0;
+  font-size: var(--type-body-s-size);
+  font-weight: normal;
+  color: var(--tabs-active-text-color);
+  display: flex;
+  align-items: center;
+}
+
+.tabs.quiet .tabList button:first-of-type,
+.tabs[class*='pill'] .tabList button:first-of-type {
+  margin-inline-start: 0;
+}
+
+.tabs.quiet .tabList button:hover {
+  border-bottom-color: var(--tabs-border-hover-color);
+}
+
+.tabs.quiet .tabList button[aria-selected="true"],
+.tabs.quiet .tabList button[aria-checked="true"] {
+  border-bottom-color: var(--tabs-active-color);
+}
+
+.tabs[class*='pill'] .tabList button:focus {
+  color: var(--tabs-pill-text-focus-color);
+  background: var(--tabs-pill-bg-focus);
+}
+
+.tabs[class*='pill'] .tabList button:focus-visible {
+  outline: 2px solid #4145ca;
+}
+
+.tabs[class*='pill'] .tabList button[aria-selected="true"],
+.tabs[class*='pill'] .tabList button[aria-checked="true"] {
+  color: var(--tabs-pill-text-selected-color);
+  background: var(--tabs-pill-bg-color);
+  text-shadow: 0.4px 0 0 var(--tabs-pill-text-color);
+}
+
+.tabs[class*='pill'] .tabList button:hover {
+  color: var(--tabs-pill-text-color);
+  background: var(--tabs-pill-bg-color-hover);
+}
+
+.tabs[class*='pill'] .tabList button:active {
+  color: var(--tabs-pill-text-focus-color);
+  background: var(--tabs-pill-bg-color-active);
+}
+
+.tabs[class*='pill'] .tabList button.l-pill {
+  font-size: 16px;
+  line-height: 20.8px;
+  height: 40px;
+}
+
+.tabs[class*='pill'] .tabList button.m-pill {
+  font-size: 14px;
+  line-height: 18.2px;
+  height: 32px;
+}
+
+.tabs[class*='pill'] .tabList button.s-pill {
+  font-size: 12px;
+  line-height: 15.6px;
+  height: 24px;
+}
+
+.tabs .paddle {
+  z-index: 3;
+}
+
+.tabs .paddle:disabled {
+  cursor: default;
+  box-shadow: none;
+  background: var(--tabs-list-bg-gradient);
+  background-size: 100% 16px;
+  background-position: bottom;
+  background-repeat: no-repeat;
+}
+
+.tabs .paddle-left {
+  box-shadow: 4px 0 4px -2px var(--tabs-paddle-bs-color);
+  left: 0;
+}
+
+.tabs .paddle-right {
+  box-shadow: -4px 0 4px -2px var(--tabs-paddle-bs-color);
+  right: 0;
+}
+
+.tabs .paddle svg {
+  opacity: 1;
+  width: 8px;
+  height: 14px;
+  margin: 0 auto;
+  transition: opacity 150ms ease;
+  color: var(--tabs-text-color);
+}
+
+.tabs .paddle-left svg {
+  transform: rotate(180deg);
+}
+
+.tabs .paddle:hover svg {
+  color: var(--tabs-active-text-color);
+}
+
+.tabs .paddle:disabled svg {
+  opacity: 0;
+}
+
+.tabs[class*='pill'] .paddle {
+  background: unset;
+  border: none;
+}
+
+.tabs.radio:not(.dark) {
+  background: none;
+}
+
+.tabs.radio .tab-content {
+  border: none;
+}
+
+.tabs.radio .paddle {
+  display: none;
+}
+
+.tabs.radio .tabList {
+  margin-block: 0;
+  margin-inline: auto;
+  inline-size: var(--grid-container-width);
+}
+
+.tabs.radio .tabList.tabList .tab-list-container {
+  background: var(--tabs-radio-bg);
+  border: 1px solid var(--tabs-border-color);
+  border-radius: 24px;
+  padding-block: var(--spacing-xs) var(--spacing-s);
+  padding-inline: var(--spacing-s);
+  font-size: var(--type-body-s-size);
+  color: var(--tabs-active-text-color);
+  flex-direction: column;
+  align-items: start;
+  inline-size: 100%;
+}
+
+.tabs.radio .tabList button:last-of-type {
+  padding-inline-end: 0;
+  padding-block-end: 0;
+}
+
+.tabs.radio .tabList button::before {
+  content: '';
+  border: 2px solid var(--tabs-radio-gray);
+  border-radius: 100%;
+  block-size: 14px;
+  min-inline-size: 14px;
+  margin-inline-end: 12px;
+  background: var(--tabs-radio-button-bg);
+  transition: border 150ms;
+  box-sizing: border-box;
+}
+
+.tabs.radio .tabList button:hover::before {
+  border-color: var(--tabs-radio-blue);
+}
+
+.tabs.radio .tabList button[aria-selected="true"]::before,
+.tabs.radio .tabList button[aria-checked="true"]::before {
+  border: 5px solid var(--tabs-radio-blue);
+}
+
+.tabs.radio .tab-list-container::before {
+  content: attr(data-pretext);
+  font-weight: var(--type-detail-all-weight);
+  line-height: var(--type-body-xs-lh);
+  margin-block-end: var(--spacing-xs);
+}
+
+.tabs.radio .tabList :is(button, button:hover, button:focus-visible, button[aria-selected="true"], button[aria-checked="true"]) {
+  background: unset;
+  border-radius: unset;
+  outline: revert;
+  outline-offset: revert;
+  margin-inline-start: revert;
+  color: inherit;
+  text-shadow: revert;
+}
+
+/* Section Metadata */
+.tabs-background-transparent .tabs,
+.tabs-background-transparent .tabs .tabList,
+.tabs-background-transparent .tabs .tabList button[aria-selected="true"],
+.tabs-background-transparent .tabs .tabList button[aria-checked="true"],
+.tabs-background-transparent .tabs .tabList .paddle {
+  background: transparent;
+}
+
+.tabs.radio.center .tabList {
+  justify-content: center;
+}
+
+.tabs.radio.right .tabList {
+  justify-content: end;
+}
+
+.dark .tabs.radio .tab-list-container::before,
+.dark .tabs.radio .tabList button {
+  color: var(--color-white);
+}
+
+.tabs-background-transparent .tabs .tabList button[aria-selected="true"],
+.tabs-background-transparent .tabs .tabList button[aria-checked="true"] {
+  border-bottom-color: var(--tabs-active-bg-color);
+}
+
+@media screen and (min-width: 600px) {
+  .tabs.radio .tabList.tabList .tab-list-container {
+    flex-direction: row;
+    align-items: center;
+    border-radius: 40px;
+    padding-block: 0;
+    padding-inline: var(--spacing-s);
+    inline-size: auto;
+    max-inline-size: var(--grid-container-width);
+    margin: 0;
+    gap: var(--spacing-s);
+  }
+
+  .tabs.radio .tab-list-container::before {
+    margin-block-end: 0;
+    margin-inline-end: -8px;
+  }
+
+  .tabs.radio .tabList button {
+    white-space: normal;
+    text-align: start;
+  }
+
+  .tabs.radio .tabList button,
+  .tabs.radio .tabList button:last-of-type {
+    padding-block: var(--spacing-xs);
+    padding-inline: 0;
+    min-block-size: 56px;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  [role='tabpanel'] > .section[class*='-up'] > .content,
+  [role='tabpanel'] > .section[class*='grid-width-'] > .content {
+    width: auto;
+  }
+
+  .tabs .tabList {
+    min-height: 62px;
+  }
+
+  .tabs .tabList button {
+    padding: 24px 32px 18px;
+    line-height: 18px;
+  }
+
+  .tabs.quiet .tabList button {
+    padding-top: 18px;
+    padding-bottom: 18px;
+  }
+
+  .tabs .paddle {
+    height: 62px;
+  }
+
+  .tabs .paddle svg {
+    top: 24px;
+  }
+}
+
+@media screen and (max-width: 599px) {
+  .tabs.stacked-mobile .tabList {
+    margin: 0;
+  }
+
+  .tabs.stacked-mobile .paddle {
+    display: none;
+  }
+
+  .tabs.stacked-mobile .tabList .tab-list-container {
+    flex-direction: column;
+    margin: 30px auto;
+  }
+
+  .tabs.stacked-mobile .tabList button {
+    font-size: 20px;
+    white-space: unset;
+    word-wrap: break-word;
+    line-height: 25px;
+    padding: 8px;
+    border-radius: 0;
+    border: 0;
+    margin-bottom: 8px;
+  }
+
+  .tabs.stacked-mobile .tabList button:last-of-type {
+    margin-bottom: 0;
+  }
+
+  .tabs.stacked-mobile .tabList button[aria-selected="true"],
+  .tabs.stacked-mobile .tabList button[aria-checked="true"] {
+    background-color: var(--tabs-mobile-stacked-bg-color);
+    color: var(--tabs-mobile-stacked-text-color);
+  }
+
+  .tabs.stacked-mobile.center .tabList .tab-list-container {
+    width: 100%;
+    margin: 0 30px 30px;
+  }
+
+  .tabs.stacked-mobile.quiet .tabList button {
+    margin-inline-start: 0;
+  }
+
+  .tabs[class*='stacked-mobile'] .paddle {
+    background: unset;
+    border: none;
+  }
+}
+
+/* Mweb specific */
+@media screen and (max-width: 599px) {
+  /* General */
+  :root {
+    --type-heading-all-weight: 800;
+  }
+
+  [class^="heading-"] {
+    font-weight: var(--type-heading-all-weight);
+  }
+
+  [class^="detail-"] {
+    text-transform: unset;
+  }
+
+  [class^="detail-"] strong {
+    font-weight: 500;
+  }
+
+  /* Block specific */
+  .tabs .tabList {
+    background: none;
+    box-shadow: none;
+  }
+
+  .tabs .tabList .tab-list-container {
+    padding: 1px;
+    border-radius: var(--m-rounded-corners);
+    background: #f8f8f8;
+    overflow: hidden;
+  }
+
+  .tabs .tabList button {
+    padding: 10px 18px;
+    border-radius: var(--m-rounded-corners);
+    border: none;
+    font-weight: 700;
+    color: var(--tabs-pill-bg-color);
+  }
+
+  .tabs .tabList button[aria-selected="true"],
+  .tabs .tabList button[aria-checked="true"] {
+    background: var(--tabs-pill-bg-color);
+    color: var(--color-white);
+    box-shadow: 0 2px 8px 0 #00000029;
+  }
+
+  .tabs .paddle {
+    height: 38px;
+    border-bottom: none;
+  }
+
+  .tabs .paddle:disabled {
+    background: none;
+  }
+}

--- a/libs/mep/ace1052/tabs/tabs.js
+++ b/libs/mep/ace1052/tabs/tabs.js
@@ -1,0 +1,388 @@
+/*
+ * tabs - consonant v6
+ * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role
+ */
+import { createTag, MILO_EVENTS, getConfig } from '../../../utils/utils.js';
+import { processTrackingLabels } from '../../../martech/attributes.js';
+
+const PADDLE = '<svg aria-hidden="true" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.50001 13.25C1.22022 13.25 0.939945 13.1431 0.726565 12.9292C0.299315 12.5019 0.299315 11.8096 0.726565 11.3823L5.10938 7L0.726565 2.61768C0.299315 2.19043 0.299315 1.49805 0.726565 1.0708C1.15333 0.643068 1.84669 0.643068 2.27345 1.0708L7.4297 6.22656C7.63478 6.43164 7.75001 6.70996 7.75001 7C7.75001 7.29004 7.63478 7.56836 7.4297 7.77344L2.27345 12.9292C2.06007 13.1431 1.7798 13.2495 1.50001 13.25Z" fill="currentColor"/></svg>';
+const tabColor = {};
+const linkedTabs = {};
+
+const isTabInTabListView = (tab) => {
+  const tabList = tab.closest('[role="tablist"], [role="radiogroup"]');
+  const tabRect = tab.getBoundingClientRect();
+  const tabListRect = tabList.getBoundingClientRect();
+
+  const tabLeft = Math.round(tabRect.left);
+  const tabRight = Math.round(tabRect.right);
+  const tabListLeft = Math.round(tabListRect.left);
+  const tabListRight = Math.round(tabListRect.right);
+
+  return (tabLeft >= tabListLeft && tabRight <= tabListRight);
+};
+
+const scrollTabIntoView = (e, inline = 'center') => {
+  const isElInView = isTabInTabListView(e);
+  if (!isElInView) e.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline });
+};
+
+const setAttributes = (el, attrs) => {
+  Object.keys(attrs).forEach((key) => el.setAttribute(key, attrs[key]));
+};
+
+const removeAttributes = (el, attrsKeys) => {
+  attrsKeys.forEach((key) => el.removeAttribute(key));
+};
+
+const scrollStackedMobile = (content) => {
+  if (!window.matchMedia('(max-width: 600px)').matches) return;
+  const rects = content.getBoundingClientRect();
+  const stickyTop = document.querySelector('.feds-localnav') ?? document.querySelector('.global-navigation, .gnav');
+  const navHeight = stickyTop?.scrollHeight || 0;
+  const topOffset = rects.top + window.scrollY - navHeight - 1;
+  window.scrollTo({ top: topOffset, behavior: 'smooth' });
+};
+
+export function getRedirectionUrl(linkedTabsList, targetId) {
+  if (!targetId || !linkedTabsList[targetId] || window.location.pathname === linkedTabsList[targetId]) return '';
+  const currentUrl = new URL(window.location.href);
+  /* c8 ignore next 4 */
+  const tabParam = currentUrl.searchParams.get('tab');
+  if (tabParam) {
+    currentUrl.searchParams.set('tab', `${tabParam.split('-')[0]}-${targetId.split('-')[2]}`);
+  }
+  currentUrl.pathname = linkedTabsList[targetId];
+  return currentUrl;
+}
+
+function changeTabs(e) {
+  const { target } = e;
+  const targetId = target.getAttribute('id');
+  const redirectionUrl = getRedirectionUrl(linkedTabs, targetId);
+  /* c8 ignore next 4 */
+  if (redirectionUrl) {
+    window.location.assign(redirectionUrl);
+    return;
+  }
+  const parent = target.parentNode;
+  const content = parent.parentNode.parentNode.lastElementChild;
+  const tabsBlock = target.closest('.tabs');
+  const blockId = tabsBlock.id;
+  const isRadio = target.getAttribute('role') === 'radio';
+  const attributeName = isRadio ? 'aria-checked' : 'aria-selected';
+
+  let targetContent;
+  if (isRadio) {
+    targetContent = content.querySelector(`#${target.getAttribute('data-control-id')}`);
+  } else {
+    targetContent = content.querySelector(`#${target.getAttribute('aria-controls')}`);
+  }
+
+  parent
+    .querySelectorAll(`[${attributeName}="true"][data-block-id="${blockId}"]`)
+    .forEach((t) => {
+      t.setAttribute(attributeName, false);
+      if (Object.keys(tabColor).length) {
+        t.removeAttribute('style', 'backgroundColor');
+      }
+    });
+  target.setAttribute(attributeName, true);
+  if (tabColor[targetId]) {
+    target.style.backgroundColor = tabColor[targetId];
+  }
+  scrollTabIntoView(target);
+  content
+    .querySelectorAll(`.tabpanel[data-block-id="${blockId}"]`)
+    .forEach((p) => p.setAttribute('hidden', true));
+  targetContent?.removeAttribute('hidden');
+  if (tabsBlock.classList.contains('stacked-mobile')) scrollStackedMobile(targetContent);
+}
+
+function getStringKeyName(str) {
+  // The \p{L} and \p{N} Unicode props are used to match any letter or digit character in any lang.
+  const regex = /[^\p{L}\p{N}_-]/gu;
+  return str.trim().toLowerCase().replace(/\s+/g, '-').replace(regex, '');
+}
+
+function getUniqueId(el, rootElem) {
+  const tabs = rootElem.querySelectorAll('.tabs');
+  return [...tabs].indexOf(el) + 1;
+}
+
+function configTabs(config, rootElem) {
+  if (config['active-tab']) {
+    const id = `#tab-${CSS.escape(config['tab-id'])}-${CSS.escape(getStringKeyName(config['active-tab']))}`;
+    const sel = rootElem.querySelector(id);
+    if (sel) {
+      sel.addEventListener('click', (e) => e.stopPropagation(), { once: true });
+      sel.click();
+    }
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  // Deeplink with a custom id parameter, e.g. ?plans=edu
+  const deeplinkParam = params.get(config.id);
+  if (deeplinkParam) {
+    const tabBtn = rootElem.querySelector(`[data-deeplink="${deeplinkParam}"]`);
+    if (tabBtn) {
+      tabBtn.click();
+      return;
+    }
+  }
+  // Deeplink with tab parameter, e.g. ?tab=plans-2
+  const tabParam = params.get('tab');
+  if (!tabParam) return;
+  const dashIndex = tabParam.lastIndexOf('-');
+  const [tabsId, tabIndex] = [tabParam.substring(0, dashIndex), tabParam.substring(dashIndex + 1)];
+  if (tabsId === config.id) rootElem.querySelector(`#tab-${config.id}-${tabIndex}`)?.click();
+}
+
+function initTabs(elm, config, rootElem) {
+  const tabs = elm.querySelectorAll('[role="tab"], [role="radio"]');
+  const tabLists = elm.querySelectorAll('[role="tablist"], [role="radiogroup"]');
+  let tabFocus = 0;
+
+  tabLists.forEach((tabList) => {
+    tabList.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+        if (e.key === 'ArrowRight') {
+          tabFocus += 1;
+          /* c8 ignore next */
+          if (tabFocus >= tabs.length) tabFocus = 0;
+        } else if (e.key === 'ArrowLeft') {
+          tabFocus -= 1;
+          /* c8 ignore next */
+          if (tabFocus < 0) tabFocus = tabs.length - 1;
+        }
+        tabs[tabFocus].setAttribute('tabindex', 0);
+        tabs[tabFocus].focus();
+      }
+    });
+  });
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', changeTabs);
+  });
+  if (config) configTabs(config, rootElem);
+}
+
+function previousTab(current, i, arr) {
+  const next = arr[i + 1];
+  // The tab before the first visible tab
+  return (next && !isTabInTabListView(current) && isTabInTabListView(next));
+}
+
+function nextTab(current, i, arr) {
+  const previous = arr[i - 1];
+  // The tab after the last visible tab
+  return (previous && isTabInTabListView(previous) && !isTabInTabListView(current));
+}
+
+function initPaddles(tabList, left, right, isRadio) {
+  const tabListItems = tabList.querySelectorAll(isRadio ? '[role="radio"]' : '[role="tab"]');
+  const tabListItemsArray = [...tabListItems];
+  const firstTab = tabListItemsArray[0];
+  const lastTab = tabListItemsArray[tabListItemsArray.length - 1];
+
+  left.addEventListener('click', () => {
+    const previous = tabListItemsArray.find(previousTab);
+    if (previous) {
+      scrollTabIntoView(previous, 'end');
+    } else {
+      /* c8 ignore next 3 */
+      const { width } = tabList.getBoundingClientRect();
+      tabList.scrollBy({ left: -(width / 2), behavior: 'smooth' });
+    }
+  });
+  right.addEventListener('click', () => {
+    const next = tabListItemsArray.find(nextTab);
+    if (next) {
+      scrollTabIntoView(next, 'start');
+    } else {
+      /* c8 ignore next 3 */
+      const { width } = tabList.getBoundingClientRect();
+      tabList.scrollBy({ left: width / 2, behavior: 'smooth' });
+    }
+  });
+
+  const options = {
+    root: tabList,
+    rootMargin: '0px',
+    threshold: 0.9,
+  };
+
+  const callback = (entries) => {
+    entries.forEach((entry) => {
+      if (entry.target === firstTab) {
+        if (entry.isIntersecting) {
+          setAttributes(left, { disabled: '', 'aria-hidden': true });
+        } else {
+          removeAttributes(left, ['disabled', 'aria-hidden']);
+        }
+      } else if (entry.target === lastTab) {
+        if (entry.isIntersecting) {
+          setAttributes(right, { disabled: '', 'aria-hidden': true });
+        } else {
+          removeAttributes(right, ['disabled', 'aria-hidden']);
+        }
+      }
+    });
+  };
+
+  const observer = new IntersectionObserver(callback, options);
+
+  observer.observe(firstTab);
+  observer.observe(lastTab);
+}
+
+const handleDeferredImages = (block) => {
+  /* c8 ignore next 6 */
+  const loadLazyImages = () => {
+    const images = block.querySelectorAll('img[loading="lazy"]');
+    images.forEach((img) => {
+      img.removeAttribute('loading');
+    });
+  };
+  document.addEventListener(MILO_EVENTS.DEFERRED, loadLazyImages, { once: true, capture: true });
+};
+
+const handlePillSize = (pill) => {
+  const sizes = ['s', 'm', 'l'];
+  const variant = pill.substring(0, pill.indexOf('-pill'));
+  const size = sizes.findIndex((tshirt) => variant.startsWith(tshirt));
+  return `${sizes[size]?.[0] ?? sizes[1]}-pill`;
+};
+
+export function assignLinkedTabs(linkedTabsList, metaSettings, id, val) {
+  if (!metaSettings.link || !id || !val || !linkedTabsList) return;
+  const relativeLinkRegex = /^\/(?:[a-zA-Z0-9-_]+(?:\/[a-zA-Z0-9-_]+)*)?$/;
+  if (relativeLinkRegex.test(metaSettings.link)) {
+    linkedTabsList[`tab-${id}-${val}`] = metaSettings.link;
+  }
+}
+
+const init = (block) => {
+  const rootElem = block.closest('.fragment') || document;
+  const rows = block.querySelectorAll(':scope > div');
+  const parentSection = block.closest('.section');
+  /* c8 ignore next */
+  if (!rows.length) return;
+
+  // Tab Config
+  const config = {};
+  const configRows = [...rows];
+  configRows.splice(0, 1);
+  configRows.forEach((row) => {
+    const rowKey = getStringKeyName(row.children[0].textContent);
+    const rowVal = row.children[1].textContent.trim();
+    config[rowKey] = rowVal;
+    row.remove();
+  });
+  const tabId = config.id || getUniqueId(block, rootElem);
+  config['tab-id'] = tabId;
+  block.id = `tabs-${tabId}`;
+  parentSection?.classList.add(`tablist-${tabId}-section`);
+
+  // Tab Content
+  const tabContentContainer = createTag('div', { class: 'tab-content-container' });
+  const tabContent = createTag('div', { class: 'tab-content' }, tabContentContainer);
+  block.append(tabContent);
+
+  const isRadio = block.classList.contains('radio');
+  // Tab List
+  const tabList = rows[0];
+  tabList.classList.add('tabList');
+  tabList.setAttribute('role', isRadio ? 'radiogroup' : 'tablist');
+  const tabListContainer = tabList.querySelector(':scope > div');
+  tabListContainer.classList.add('tab-list-container');
+  const tabListLabel = config.pretext;
+  if (tabListLabel) tabList.setAttribute('aria-label', tabListLabel);
+
+  const tabListItems = rows[0].querySelectorAll(':scope li');
+  if (tabListItems) {
+    const pillVariant = [...block.classList].find((variant) => variant.includes('pill'));
+    const btnClass = pillVariant ? handlePillSize(pillVariant) : 'heading-xxs'; /* Mweb specific; xxs was xs */
+    tabListItems.forEach((item, i) => {
+      const tabName = config.id ? i + 1 : getStringKeyName(item.textContent);
+      const controlId = `tab-panel-${tabId}-${tabName}`;
+      const tabBtnAttributes = {
+        role: isRadio ? 'radio' : 'tab',
+        class: btnClass,
+        id: `tab-${tabId}-${tabName}`,
+        tabindex: '0',
+        [isRadio ? 'aria-checked' : 'aria-selected']: (i === 0) ? 'true' : 'false',
+        'data-block-id': `tabs-${tabId}`,
+        'daa-state': 'true',
+        'daa-ll': `tab-${tabId}-${tabName}`,
+        ...(isRadio ? { 'data-control-id': controlId } : { 'aria-controls': controlId }),
+      };
+      const tabBtn = createTag('button', tabBtnAttributes);
+      tabBtn.innerText = item.textContent;
+      tabListContainer.append(tabBtn);
+
+      const tabContentAttributes = {
+        id: `tab-panel-${tabId}-${tabName}`,
+        ...(isRadio ? { } : { role: 'tabpanel' }),
+        class: 'tabpanel',
+        'aria-labelledby': `tab-${tabId}-${tabName}`,
+        'data-block-id': `tabs-${tabId}`,
+      };
+      const tabListContent = createTag('div', tabContentAttributes);
+      tabListContent.setAttribute('aria-labelledby', `tab-${tabId}-${tabName}`);
+      if (i > 0) tabListContent.setAttribute('hidden', '');
+      tabContentContainer.append(tabListContent);
+    });
+    tabListItems[0].parentElement.remove();
+    tabListContainer.dataset.pretext = config.pretext;
+  }
+
+  // Tab Paddles
+  const paddleLeft = createTag('button', { class: 'paddle paddle-left', disabled: '', 'aria-hidden': true, 'aria-label': 'Scroll tabs to left' }, PADDLE);
+  const paddleRight = createTag('button', { class: 'paddle paddle-right', disabled: '', 'aria-hidden': true, 'aria-label': 'Scroll tabs to right' }, PADDLE);
+  tabList.insertAdjacentElement('afterend', paddleRight);
+  block.prepend(paddleLeft);
+  initPaddles(tabList, paddleLeft, paddleRight, isRadio);
+
+  // Tab Sections
+  const allSections = Array.from(rootElem.querySelectorAll('div.section'));
+  allSections.forEach((e) => {
+    const sectionMetadata = e.querySelector(':scope > .section-metadata');
+    if (!sectionMetadata) return;
+    const metaSettings = {};
+    sectionMetadata.querySelectorAll(':scope > div').forEach((row) => {
+      const key = getStringKeyName(row.children[0].textContent);
+      if (!['tab', 'tab-background', 'link', 'deeplink'].includes(key)) return;
+      const val = row.children[1].textContent;
+      if (!val) return;
+      metaSettings[key] = val;
+    });
+    if (!metaSettings.tab) return;
+    let id = tabId;
+    let val = getStringKeyName(metaSettings.tab);
+    const assotiatedTabButton = rootElem.querySelector(`#tab-${val}`);
+    assotiatedTabButton?.setAttribute('data-deeplink', metaSettings.deeplink);
+    let assocTabItem = rootElem.querySelector(`#tab-panel-${id}-${val}`);
+    if (config.id) {
+      const values = metaSettings.tab.split(',');
+      [id] = values;
+      val = getStringKeyName(String(values[1]));
+      assocTabItem = rootElem.querySelector(`#tab-panel-${id}-${val}`);
+    }
+    if (assocTabItem) {
+      if (metaSettings['tab-background']) {
+        tabColor[`tab-${id}-${val}`] = metaSettings['tab-background'];
+      }
+      assignLinkedTabs(linkedTabs, metaSettings, id, val);
+      const tabLabel = tabListItems[val - 1]?.innerText;
+      if (tabLabel) {
+        assocTabItem.setAttribute('data-nested-lh', `t${val}${processTrackingLabels(tabLabel, getConfig(), 3)}`);
+      }
+      const section = sectionMetadata.closest('.section');
+      assocTabItem.append(section);
+    }
+  });
+  handleDeferredImages(block);
+  initTabs(block, config, rootElem);
+};
+
+export default init;


### PR DESCRIPTION
This updates styles for tabs, editorial cards and the icon block for the purposes of the mweb test.

Resolves:
* [MWPW-171558](https://jira.corp.adobe.com/browse/MWPW-171558)
* [MWPW-171541](https://jira.corp.adobe.com/browse/MWPW-171541)
* [MWPW-173606](https://jira.corp.adobe.com/browse/MWPW-173606)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/products/photoshop?&georouting=off&mep=off
- After: https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/ps-product-page-v2?milolibs=mweb-styles--milo--overmyheadandbody&georouting=off
