### PR TITLE
MWPW-174127 | Accessibility | Set heading role for half height card

### DIFF
--- a/libs/blocks/card/card.js
+++ b/libs/blocks/card/card.js
@@ -42,6 +42,7 @@ const addInner = (el, cardType, card) => {
   }
 
   if (cardType === HALF_HEIGHT) {
+    title?.setAttribute('role', 'presentation');
     text?.remove();
   }
 


### PR DESCRIPTION
Set heading role to presentation for accessibility for half height card.

Resolves: [MWPW-174127](https://jira.corp.adobe.com/browse/MWPW-174127)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/card?martech=off
- After: https://MWPW-174127--milo--adobecom.hlx.page/docs/library/blocks/card?martech=off

https://main--cc--adobecom.aem.live/se/products/premiere/ai-video-editing?milolibs=mwpw-174127--milo--adobecom

