### PR TITLE
MWPW-168547 Fix autofill on Marketo multi-step form

### DIFF
--- a/libs/blocks/marketo/marketo-multi.js
+++ b/libs/blocks/marketo/marketo-multi.js
@@ -13,6 +13,18 @@ const VALIDATION_STEP = {
   mktoFormsCompanyType: '3',
 };
 
+export function updateTabIndex(formEl, stepToAdd, stepToRemove) {
+  const fieldsToAdd = formEl.querySelectorAll(`.mktoFormRowTop[data-validate="${stepToAdd}"]:not(.mktoHidden) input, 
+    .mktoFormRowTop[data-validate="${stepToAdd}"]:not(.mktoHidden) select, 
+    .mktoFormRowTop[data-validate="${stepToAdd}"]:not(.mktoHidden) textarea`);
+  fieldsToAdd.forEach((f) => { f.tabIndex = 0; });
+
+  const fieldsToRemove = formEl.querySelectorAll(`.mktoFormRowTop[data-validate="${stepToRemove}"]:not(.mktoHidden) input, 
+    .mktoFormRowTop[data-validate="${stepToRemove}"]:not(.mktoHidden) select, 
+    .mktoFormRowTop[data-validate="${stepToRemove}"]:not(.mktoHidden) textarea`);
+  fieldsToRemove.forEach((f) => { f.tabIndex = -1; });
+}
+
 function updateStepDetails(formEl, step, totalSteps) {
   formEl.classList.add('hide-errors');
   formEl.classList.remove('show-warnings');
@@ -31,6 +43,7 @@ function showPreviousStep(formEl, totalSteps) {
   const backBtn = formEl.querySelector('.back-btn');
 
   updateStepDetails(formEl, previousStep, totalSteps);
+  updateTabIndex(formEl, previousStep, currentStep);
   if (previousStep === 1) backBtn?.remove();
 }
 
@@ -46,6 +59,7 @@ const showNextStep = (formEl, currentStep, totalSteps) => {
   }
 
   updateStepDetails(formEl, nextStep, totalSteps);
+  updateTabIndex(formEl, nextStep, currentStep);
 };
 
 export const formValidate = (formEl) => {
@@ -61,11 +75,13 @@ export const formValidate = (formEl) => {
   return currentStep === totalSteps;
 };
 
-function setValidationSteps(formEl, totalSteps) {
+function setValidationSteps(formEl, totalSteps, currentStep) {
   formEl.querySelectorAll('.mktoFormRowTop').forEach((row) => {
     const rowAttr = row.getAttribute('data-mktofield') || row.getAttribute('data-mkto_vis_src');
     const step = VALIDATION_STEP[rowAttr] ? Math.min(VALIDATION_STEP[rowAttr], totalSteps) : 1;
     row.dataset.validate = rowAttr?.startsWith('adobe-privacy') ? totalSteps : step;
+    const fields = row.querySelectorAll('input, select, textarea');
+    if (fields.length) fields.forEach((f) => { f.tabIndex = step === currentStep ? 0 : -1; });
   });
 }
 
@@ -74,7 +90,7 @@ function onRender(formEl, totalSteps) {
   const submitButton = formEl.querySelector('#mktoButton_new');
   submitButton?.classList.toggle('mktoHidden', currentStep !== totalSteps);
   formEl.querySelector('.step-details .step').textContent = `Step ${currentStep} of ${totalSteps}`;
-  setValidationSteps(formEl, totalSteps);
+  setValidationSteps(formEl, totalSteps, currentStep);
 }
 
 const readyForm = (form, totalSteps) => {
@@ -88,9 +104,12 @@ const readyForm = (form, totalSteps) => {
   const stepDetails = createTag('div', { class: 'step-details' }, stepEl);
   formEl.append(nextContainer, stepDetails);
 
-  const debouncedOnRender = debounce(() => onRender(formEl, totalSteps), 10);
+  const debouncedOnRender = debounce(() => onRender(formEl, totalSteps), 50);
   const observer = new MutationObserver(debouncedOnRender);
   observer.observe(formEl, { childList: true, subtree: true });
+  setTimeout(() => {
+    observer.disconnect();
+  }, 12000);
   debouncedOnRender();
 };
 

--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -91,21 +91,35 @@
 
 .marketo .mktoFormRowTop {
   display: contents;
+  visibility: visible;
+  position: static;
+  pointer-events: auto;
 }
 
 .marketo.multi-step .mktoFormRow.mktoFormRowTop[data-validate="2"],
 .marketo.multi-step .mktoFormRow.mktoFormRowTop[data-validate="3"] {
-  display: none;
+  display: block;
+  visibility: hidden;
+  position: absolute;
+  left: -100000px;
+  pointer-events: none;
 }
 
 .marketo.multi-step .mktoForm[data-step="2"] .mktoFormRow.mktoFormRowTop[data-validate="2"],
 .marketo.multi-step .mktoForm[data-step="3"] .mktoFormRow.mktoFormRowTop[data-validate="3"] {
   display: contents;
+  visibility: visible;
+  position: static;
+  pointer-events: auto;
 }
 
 .marketo.multi-step .mktoForm[data-step="2"] .mktoFormRow.mktoFormRowTop[data-validate="1"],
 .marketo.multi-step .mktoForm[data-step="3"] .mktoFormRow.mktoFormRowTop[data-validate="1"] {
-  display: none;
+  display: block;
+  visibility: hidden;
+  position: absolute;
+  left: -100000px;
+  pointer-events: none;
 }
 
 .marketo.multi-step .mktoForm[data-step="1"] .mktoFormRow.mktoFormRowTop.adobe-privacy,
@@ -116,6 +130,9 @@
 .marketo.multi-step .mktoForm[data-step="3"] .mktoFormRow.mktoFormRowTop.adobe-privacy,
 .marketo.multi-step.multi-2 .mktoForm[data-step="2"] .mktoFormRow.mktoFormRowTop.adobe-privacy {
   display: grid;
+  visibility: visible;
+  position: static;
+  pointer-events: auto;
 }
 
 .marketo.multi-step .step-details {

--- a/test/blocks/marketo/marketo-multi.test.js
+++ b/test/blocks/marketo/marketo-multi.test.js
@@ -1,7 +1,7 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import sinon, { stub } from 'sinon';
-import init, { formValidate } from '../../../libs/blocks/marketo/marketo-multi.js';
+import init, { formValidate, updateTabIndex } from '../../../libs/blocks/marketo/marketo-multi.js';
 
 const innerHTML = await readFile({ path: './mocks/multi-step-2.html' });
 
@@ -74,5 +74,33 @@ describe('marketo multi-step', () => {
     expect(formEl.dataset.step).to.equal('1');
     expect(formEl.querySelector('.back-btn')).to.be.null;
     expect(formEl.querySelector('.step-details .step').textContent).to.equal('Step 1 of 2');
+  });
+
+  it('sets initial tabindex for fields', () => {
+    const formEl = document.querySelector('form');
+    const step1Field = formEl.querySelector('.mktoFormRowTop[data-validate="1"] input');
+    const step2Field = formEl.querySelector('.mktoFormRowTop[data-validate="2"] input');
+    expect(step1Field.tabIndex).to.equal(0);
+    expect(step2Field.tabIndex).to.equal(-1);
+  });
+
+  it('updates tabindex when switching steps', () => {
+    const formEl = document.querySelector('form');
+    const step1Field = formEl.querySelector('.mktoFormRowTop[data-validate="1"] input');
+    const step2Field = formEl.querySelector('.mktoFormRowTop[data-validate="2"] input');
+
+    // Initial state
+    expect(step1Field.tabIndex).to.equal(0);
+    expect(step2Field.tabIndex).to.equal(-1);
+
+    // Switch to step 2
+    updateTabIndex(formEl, 2, 1);
+    expect(step1Field.tabIndex).to.equal(-1);
+    expect(step2Field.tabIndex).to.equal(0);
+
+    // Switch back to step 1
+    updateTabIndex(formEl, 1, 2);
+    expect(step1Field.tabIndex).to.equal(0);
+    expect(step2Field.tabIndex).to.equal(-1);
   });
 });


### PR DESCRIPTION
* Updates Marketo form so that browser autofill works on multi-step
* Reduces the amount of times that `onRender` runs

Resolves: [MWPW-168547](https://jira.corp.adobe.com/browse/MWPW-168547)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/bmarshal/marketo/multi-2
- After: https://marketo-autofill--milo--meganthecoder.aem.page/drafts/bmarshal/marketo/multi-2

- Before: https://main--milo--adobecom.aem.page/drafts/bmarshal/marketo/multi-3
- After: https://marketo-autofill--milo--meganthecoder.aem.page/drafts/bmarshal/marketo/multi-3
