### PR TITLE
[MWPW-171655] - table icon missalignement fix

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -82,6 +82,10 @@
   margin-right: 8px;
 }
 
+.table .col picture {
+  display: flex;
+}
+
 .section.table-section,
 .section.table-merch-section {
   background: var(--color-white);


### PR DESCRIPTION
Fixes the issue where images in a table cell weren't in a horizontal line because of the picture tag having a different height than the image that's inside it.

Resolves: [MWPW-171655](https://jira.corp.adobe.com/browse/MWPW-171655)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
- After: https://table-icon-missalignement--milo--adobecom.hlx.page/docs/library/kitchen-sink/table?martech=off

**CC Test URLs:**
- Before: https://main--cc--adobecom.aem.page/in/cc-shared/fragments/roc/mep/products/photoshop/merch-table-146492
- After: https://main--cc--adobecom.aem.page/in/cc-shared/fragments/roc/mep/products/photoshop/merch-table-146492?milolibs=table-icon-missalignement


