### PR TITLE
[MEP][MILO] MWPW-172886:Dynamic content on RFI page via referrer | MEP

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -94,7 +94,8 @@ export const normalizePath = (p, localize = true) => {
     if (path.startsWith(config.codeRoot)
       || path.includes('.hlx.')
       || path.includes('.aem.')
-      || path.includes('.adobe.')) {
+      || path.includes('.adobe.')
+      || path.includes('localhost:')) {
       if (!localize
         || config.locale.ietf === 'en-US'
         || hash.includes(mepHash)
@@ -827,13 +828,10 @@ const checkForParamMatch = (paramStr) => {
   return false;
 };
 
-const checkForPreviousPageMatch = (paramStr) => {
-  if (document.referrer === '' || !document.referrer) return false;
-  const previousPageString = paramStr.toLowerCase().split('previouspage-')[1];
-  const refValue = new URL(document.referrer);
-  if (!previousPageString.includes('**')) return (refValue.href === previousPageString || refValue.pathname === previousPageString);
-  if (previousPageString.includes('**')) return matchGlob(previousPageString, refValue.pathname);
-  return false;
+const checkForPreviousPageMatch = (previousPageStr) => {
+  if (!document.referrer) return false;
+  const previousPageString = previousPageStr.toLowerCase().split('previouspage-')[1];
+  return matchGlob(previousPageString, new URL(document.referrer).pathname);
 };
 
 function trimNames(arr) {


### PR DESCRIPTION
This PR adds the ability to use previous page (document.referrer) as a MEP experience targeting condition. 

**Features/Fixes** 
* User can target previous page as an experience targeting condition by using template: previousPage-<path of previous page here> 
* previousPage- accepts both exact path (example: previousPage-/products/photoshop), and globs (examples: **/photoshop , or **/products/photoshop\**) 
* Added localhost:3000 as an accepted domain to allow proper debugging while in local dev env

**Expected behavior** 
* Users can now use previousPage- as a targeting prefix followed by a glob or url path to pop the experience when user document.referrer meets the condition (if the object is available) 
* previousPage- targeting condition should work with the '&' ',' 'not' targeting modifiers

<table>
  <tr>
    <th>targeting condition</th>
    <th>experience activation conditions</th>
  </tr>
    <td>previousPage-/products/photoshop</td>
    <td>previous page path IS /products/photoshop</td>
  </tr>
<tr>
    <td>previousPage-**/products</td>
    <td>previous page path ENDS with /products</td>
  </tr>
 <tr>
    <td>previousPage-**/products**</td>
    <td>previous page url INCLUDES /products/</td>
  </tr>
 <tr>
    <td>phone, previousPage-**/products**</td>
    <td>user is using PHONE<br>OR<br>previous page url INCLUDES /products/</td>
  </tr>
  <tr>
    <td>phone, previousPage-**/products** & not previousPage-**/photoshop</td>
    <td>user is using PHONE<br>OR<br>previous page url INCLUDES /products/ BUT not /photoshop </td>
  </tr>
</table>


Resolves: [MWPW-172886](https://jira.corp.adobe.com/browse/MWPW-172886)
Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://mep-referrer--milo--adobecom.aem.page/?martech=off

**How to test**
For QA, I created multiple pages that act as the _referrer_. All of the pages have a marquee CTA that leads to the _test page_ with a manifest. Each referring page meets a certain manifest targeting condition when qualified as that referring page.  **Go to the listed ref page, click on the 2nd page CTA on marquee, check you're in the right experience when the test page loads (I listed the edited test page headline in each case for easier visual confirmation)**

test page with manifest for reference: 
https://mep-referrer--milo--adobecom.aem.page/drafts/mepdev/2025/q2/referrer/second-redirect

**Case 1** 
**User sees exp when using PHONE, OR if ref url IS direct match of path**
_mep exp:_ phone, previousPage-/drafts/mepdev/2025/q2/referrer/first-industry-business
_ref page:_ https://mep-referrer--milo--adobecom.aem.page/drafts/mepdev/2025/q2/referrer/first-industry-business
_headline on test page:_ Phone OR ref= path for "drafts/mepdev/2025/q2/referrer/first-industry-business"

_note: to check the OR phone is working, check the test page as first hit on new browser window. this same experience should pop without a ref page._

**Case 2** 
**User sees exp when ref url CONTAINS 'sub/' and DOES NOT CONTAIN 'sub/nogo'**
_mep exp:_ previousPage-\**sub/\** & not previousPage-**sub/nogo
_ref page:_ https://mep-referrer--milo--adobecom.aem.page/drafts/mepdev/2025/q2/referrer/sub/insubs-go
_headline on test page:_ ANY page in /sub/ except NOGO.html 

**Case 3** 
**User sees exp when ref url CONTAINS 'sub/'**
_mep exp:_ previousPage-\**sub/\**
_ref page:_ https://mep-referrer--milo--adobecom.aem.page/drafts/mepdev/2025/q2/referrer/sub/nogo
_headline on test page:_ any page from /SUB/ even NOGO

**Case 4** 
**User sees exp when ref url ENDS WITH '/basic-page' (glob at the start of targeting)**
_mep exp:_ previousPage-\**basic-page
_ref page:_ https://mep-referrer--milo--adobecom.aem.page/drafts/mepdev/2025/q2/referrer/basic-page
_headline on test page:_ Page that ENDS with /basic-page (starting glob check) 

**Case 5**
**All condition**
_mep exp:_ all
_ref page:_ https://mep-referrer--milo--adobecom.aem.page/drafts/mepdev/2025/q2/referrer/dummy-photoshop
_headline on test page:_ ALL pages experience (last) 