### PR TITLE
MWPW-174220 | Accessibility | Changing table heading roles to not have them treated as text.

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -256,7 +256,7 @@ function setExpandEvents(el) {
 
 function handleTitleText(cell) {
   if (cell.querySelector('.table-title-text')) return;
-  const textSpan = createTag('span', { class: 'table-title-text', role: 'heading', 'aria-level': '4' });
+  const textSpan = createTag('span', { class: 'table-title-text' });
   while (cell.firstChild) textSpan.append(cell.firstChild);
 
   const iconTooltip = textSpan.querySelector('.icon-info, .icon-tooltip, .milo-tooltip');
@@ -311,6 +311,11 @@ function handleSection(sectionParams) {
       handleTitleText(sectionHeadTitle);
       sectionHeadTitle.classList.add('section-head-title');
       sectionHeadTitle.setAttribute('role', 'rowheader');
+      const sectionHeadText = sectionHeadTitle.querySelector('.table-title-text');
+      if (sectionHeadText) {
+        sectionHeadText.setAttribute('role', 'heading');
+        sectionHeadText.setAttribute('aria-level', '4');
+      }
     }
 
     if (isCollapseTable) {

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -256,7 +256,7 @@ function setExpandEvents(el) {
 
 function handleTitleText(cell) {
   if (cell.querySelector('.table-title-text')) return;
-  const textSpan = createTag('span', { class: 'table-title-text' });
+  const textSpan = createTag('span', { class: 'table-title-text', role: 'heading', aria-level='1'});
   while (cell.firstChild) textSpan.append(cell.firstChild);
 
   const iconTooltip = textSpan.querySelector('.icon-info, .icon-tooltip, .milo-tooltip');

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -256,7 +256,7 @@ function setExpandEvents(el) {
 
 function handleTitleText(cell) {
   if (cell.querySelector('.table-title-text')) return;
-  const textSpan = createTag('span', { class: 'table-title-text', role: 'heading', aria-level='1'});
+  const textSpan = createTag('span', { class: 'table-title-text', role: 'heading', 'aria-level': '1'});
   while (cell.firstChild) textSpan.append(cell.firstChild);
 
   const iconTooltip = textSpan.querySelector('.icon-info, .icon-tooltip, .milo-tooltip');

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -256,7 +256,7 @@ function setExpandEvents(el) {
 
 function handleTitleText(cell) {
   if (cell.querySelector('.table-title-text')) return;
-  const textSpan = createTag('span', { class: 'table-title-text', role: 'heading', 'aria-level': '1'});
+  const textSpan = createTag('span', { class: 'table-title-text', role: 'heading', 'aria-level': '4' });
   while (cell.firstChild) textSpan.append(cell.firstChild);
 
   const iconTooltip = textSpan.querySelector('.icon-info, .icon-tooltip, .milo-tooltip');


### PR DESCRIPTION
Changing table heading roles to not have them treated as text.

Resolves: [MWPW-174220](https://jira.corp.adobe.com/browse/MWPW-174220)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/table?martech=off
- After: https://MWPW-174220--milo--adobecom.hlx.page/docs/library/blocks/table?martech=off

Test url : https://main--cc--adobecom.aem.live/products/elements-family?milolibs=MWPW-174220





