### PR TITLE
Minor tweaks for mweb blocks

### DIFF
--- a/libs/mep/ace1052/aside/aside.css
+++ b/libs/mep/ace1052/aside/aside.css
@@ -1274,20 +1274,19 @@
   }
 
   /* Block specific */
-  .section:has(.aside.large:nth-child(3)) .aside.large {
+  .section:has(.aside:nth-child(3)) .aside {
     width: var(--grid-container-width);
     margin: var(--spacing-s) auto;
     border-radius: var(--l-rounded-corners);
   }
 
-  .section:has(.aside.large:nth-child(3)) .aside.large .foreground.container {
+  .section:has(.aside:nth-child(3)) .aside .foreground.container {
     width: 100%;
-    padding-bottom: 0;
+    padding-block: var(--spacing-xs) 0;
     gap: unset;
   }
 
-  .section:has(.aside.large:nth-child(3)) .aside.large .foreground.container .text {
-    width: var(--grid-container-width);
-    margin: auto;
+  .section:has(.aside:nth-child(3)) .aside .foreground.container .text {
+    padding-inline: var(--spacing-xs);
   }
 }

--- a/libs/mep/ace1052/brick/brick.css
+++ b/libs/mep/ace1052/brick/brick.css
@@ -1,0 +1,430 @@
+.brick {
+  position: relative;
+  display: flex;
+  text-size-adjust: none;
+  min-height: 300px;
+}
+
+.brick,
+.brick.click a.foreground {
+  color: inherit;
+}
+
+.brick.light,
+.brick.light.click a.foreground {
+  color: var(--text-color);
+}
+
+.brick.dark,
+.dark.brick.click a.foreground {
+  color: var(--color-white);
+}
+
+.brick.border {
+  border: 1px solid var(--color-gray-200);
+}
+
+.brick.click > a {
+  text-decoration: none;
+}
+
+.brick .background {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  overflow: hidden;
+}
+
+.brick .foreground {
+  position: relative;
+  display: flex;
+  flex-grow: 1;
+  padding: var(--spacing-m);
+}
+
+.brick .foreground .brick-media {
+  display: none;
+}
+
+.brick.rounded-corners,
+.brick.rounded-corners .background,
+.brick.rounded-corners .foreground {
+  border-radius: var(--spacing-xs);
+}
+
+.brick.horizontal-center .foreground,
+.brick.horizontal-center .foreground .action-area,
+.brick.center .foreground,
+.brick.center .foreground .action-area {
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+}
+
+.brick.horizontal-center .foreground {
+  align-items: flex-start;
+}
+
+.brick .background div,
+.brick .background p,
+.brick .background picture {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+.brick .background p,
+.brick .background picture {
+  display: block;
+}
+
+.brick .background img {
+  object-fit: contain;
+  object-position: bottom center;
+  width: 100%;
+  height: 100%;
+}
+
+.brick .mobile-only,
+.brick .tablet-only,
+.brick .desktop-only {
+  display: none;
+}
+
+.brick .foreground p {
+  padding: 0;
+  margin: 0;
+}
+
+.brick .foreground div > .video-container {
+  margin: 0;
+}
+
+.brick .foreground div > * {
+  margin-top: var(--spacing-xs);
+}
+
+.brick .foreground .brick-text *:first-child,
+.brick .foreground .brick-text p.icon-area + * {
+  margin-top: 0;
+}
+
+.brick .foreground p.icon-area {
+  display: inline-flex;
+  gap: var(--spacing-xs);
+  align-items: center;
+  margin-bottom: var(--spacing-s);
+  font-weight: 700;
+  font-size: var(--type-heading-s-size);
+  line-height: var(--type-heading-s-lh);
+}
+
+.brick .foreground p.icon-area.icon-gap-s {
+  gap: var(--spacing-s);
+}
+
+.brick .foreground p.action-area {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-s);
+  margin-top: var(--spacing-s);
+}
+
+.brick .icon-stack-area li,
+.brick .icon-stack-area li a {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  text-align: start;
+  flex-shrink: 0;
+}
+
+.brick .icon-stack-area li picture {
+  display: flex;
+  margin: 0;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.brick .foreground a:not([class]),
+.brick .foreground span.first-link {
+  font-weight: 700;
+}
+
+.brick .foreground .icon-area picture {
+  display: flex;
+}
+
+.brick .icon-stack-area li img {
+  width: var(--icon-size-s);
+  height: auto;
+}
+
+.brick .icon-stack-area li .list-text a {
+  display: inline-block;
+}
+
+.brick .foreground .icon-area img {
+  height: var(--icon-size-l);
+  width: auto;
+}
+
+.brick .icon-stack-area {
+  display: flex;
+  flex-flow: row wrap;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.brick.center .icon-stack-area {
+  display: inline-flex;
+  width: auto;
+}
+
+.brick.click a.foreground .first-link:not([class*="button"]) {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+.brick.click:hover a.foreground .first-link:not([class*="button"]) {
+  text-decoration: underline;
+  color: var(--link-hover-color);
+}
+
+.static-links .brick.click a.foreground .first-link:not([class*="button"]),
+.static-links .brick.click a.foreground a:not([class*="button"]),
+.brick.static-links.click a.foreground .first-link:not([class*="button"]),
+.brick.static-links.click a.foreground a:not([class*="button"]) {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.brick.click:hover .first-link.con-button,
+.brick.click:active .first-link.con-button,
+.dark .brick.click:hover .first-link.con-button,
+.dark .brick.click:active .first-link.con-button,
+.brick.dark.click:hover .first-link.con-button,
+.brick.dark.click:active .first-link.con-button {
+  background-color: var(--color-white);
+  color: var(--color-black);
+  text-decoration: none;
+}
+
+.brick.light.click:hover .first-link.con-button,
+.brick.light.click:active .first-link.con-button,
+.light .brick.click:hover .first-link.con-button,
+.light .brick.click:active .first-link.con-button {
+  background-color: var(--color-black);
+  border-color: var(--color-black);
+  color: var(--color-white);
+}
+
+.brick.click:hover .first-link.con-button.blue,
+.brick.click:active .first-link.con-button.blue {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+  color: var(--color-white);
+}
+
+@media screen and (max-width: 600px) {
+  .brick .mobile-only {
+    display: block;
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .brick {
+    min-height: 384px;
+  }
+
+  .brick .foreground {
+    padding: var(--spacing-l);
+  }
+}
+
+@media screen and (min-width: 600px) and (max-width: 1199px) {
+  .brick .tablet-only {
+    display: block;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .brick .desktop-only,
+  .brick .foreground .brick-media {
+    display: block;
+  }
+
+  .brick.split .foreground {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    padding: 0;
+  }
+
+  .brick .foreground p.icon-area {
+    font-size: var(--type-heading-xs-size);
+    line-height: var(--type-heading-xs-lh);
+  }
+
+  .brick.stack .foreground {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-m);
+    justify-content: space-between;
+    padding: var(--spacing-l) var(--spacing-l) 0 var(--spacing-l);
+  }
+
+  .brick.split.horizontal-center .foreground,
+  .brick.split.center .foreground {
+    padding: var(--spacing-l);
+  }
+
+  .brick.stack.media-left .foreground {
+    padding: 0 var(--spacing-l) var(--spacing-l) var(--spacing-l);
+  }
+
+  .brick.stack .foreground .brick-text,
+  .brick.stack .foreground .brick-media {
+    margin: 0;
+    padding: 0;
+  }
+
+  .brick.split.stack .foreground .brick-text {
+    width: 41.66%;
+  }
+
+  .brick.split.row .foreground,
+  .brick.split.row .foreground .brick-media,
+  .brick.split.row .foreground picture {
+    border-radius: inherit;
+  }
+
+  .brick.split.horizontal-center .foreground .brick-text,
+  .brick.split.center .foreground .brick-text {
+    margin: 0;
+    grid-column: 4 / span 6;
+  }
+
+  .brick.split .foreground .brick-text,
+  .brick.split.row.media-right .foreground .brick-text,
+  .brick.split.row.media-left .foreground .brick-media {
+    grid-column: span 6;
+  }
+
+  .brick.split.row.media-left .foreground .brick-text,
+  .brick.split.row.media-right .foreground .brick-media {
+    grid-column: 7 / span 6;
+  }
+
+  .brick.split.grid-full-width.row.media-right .foreground .brick-text {
+    grid-column: span 5;
+  }
+
+  .brick.split.grid-full-width.row.media-left .foreground .brick-text {
+    grid-column: 8 / span 5;
+  }
+
+  .brick.stack .foreground .brick-media picture,
+  .brick.stack .foreground .brick-media img,
+  .brick.stack .foreground .brick-media video {
+    width: 100%;
+    height: auto;
+  }
+
+  .brick.split.row .foreground .brick-media img,
+  .brick.split.row .foreground .brick-media video {
+    width: 50%;
+    height: 100%;
+    object-fit: cover;
+    padding: 0;
+    margin: 0;
+    position: absolute;
+  }
+
+  .brick.split.row .foreground .brick-media .video-container img,
+  .brick.split.row .foreground .brick-media .video-container video {
+    width: 100%;
+  }
+
+  .brick .foreground .brick-media video,
+  .brick.split.row .foreground .brick-media video {
+    object-fit: fill;
+    display: flex;
+    margin: 0;
+  }
+
+  .brick.stack .foreground .brick-media picture {
+    display: flex;
+    margin: 0;
+    padding: 0;
+  }
+
+  .brick.horizontal-center.media-right .foreground,
+  .brick.horizontal-center.media-left .foreground {
+    align-items: center;
+  }
+
+  .brick.split:not(.stack):not(.center) .foreground .brick-text {
+    margin: var(--spacing-l);
+  }
+
+  .brick.split.grid-full-width:not(.stack):not(.center) .foreground .brick-text,
+  [dir='rtl'] .brick.split.row.grid-full-width.media-left .foreground .brick-text {
+    margin-right: 0;
+    margin-left: var(--spacing-l);
+  }
+
+  .brick.split.row.grid-full-width.media-left .foreground .brick-text,
+  [dir='rtl'] .brick.split.grid-full-width:not(.stack):not(.center) .foreground .brick-text {
+    margin-right: var(--spacing-l);
+    margin-left: 0;
+  }
+
+  .brick.split.row.media-left .foreground .brick-media img,
+  .brick.split.row.media-left .foreground .brick-media video,
+  [dir='rtl'] .brick.split.row.media-right .foreground .brick-media img,
+  [dir='rtl'] .brick.split.row.media-right .foreground .brick-media video {
+    border-radius: 0;
+    border-top-left-radius: inherit;
+    border-bottom-left-radius: inherit;
+  }
+
+  .brick.split.row.media-right .foreground .brick-media img,
+  .brick.split.row.media-right .foreground .brick-media video,
+  [dir='rtl'] .brick.split.row.media-left .foreground .brick-media img,
+  [dir='rtl'] .brick.split.row.media-left .foreground .brick-media video {
+    border-radius: 0;
+    border-top-right-radius: inherit;
+    border-bottom-right-radius: inherit;
+  }
+}
+
+/* Mweb specific */
+@media screen and (max-width: 599px) {
+  /* General */
+  :root {
+    --type-heading-all-weight: 800;
+  }
+
+  [class^="heading-"] {
+    font-weight: var(--type-heading-all-weight);
+  }
+
+  [class^="detail-"] {
+    text-transform: unset;
+  }
+
+  [class^="detail-"] strong {
+    font-weight: 500;
+  }
+
+  /* Block specific */
+  .brick:has(.icon-stack-area) {
+    min-height: unset;
+  }
+}

--- a/libs/mep/ace1052/brick/brick.js
+++ b/libs/mep/ace1052/brick/brick.js
@@ -1,0 +1,145 @@
+import {
+  decorateBlockBg,
+  decorateBlockText,
+  decorateIconStack,
+  decorateTextOverrides,
+  decorateButtons,
+  handleObjectFit,
+} from '../../../utils/decorate.js';
+import { createTag, getConfig, loadStyle } from '../../../utils/utils.js';
+
+const blockTypeSizes = {
+  large: ['xxl', 'm', 'l'],
+  default: ['xl', 'm', 'l'],
+};
+
+function getBlockSize(el) {
+  const sizes = Object.keys(blockTypeSizes);
+  const size = sizes.find((s) => el.classList.contains(`${s}`)) || 'default';
+  return blockTypeSizes[size];
+}
+
+function handleSupplementalText(foreground) {
+  if (!foreground.querySelector('.action-area')) return;
+  const nextP = foreground.querySelector('.action-area + p');
+  const lastP = foreground.querySelector('.action-area ~ p:last-child');
+  if (nextP) nextP.className = '';
+  if (lastP) lastP.className = 'supplemental-text';
+}
+
+function handleClickableBrick(el, foreground) {
+  if (!el.classList.contains('click')) return;
+  const links = foreground.querySelectorAll('.brick-text a');
+  if (links.length !== 1) { el.classList.remove('click'); return; }
+  const a = links[0];
+  const linkDiv = createTag('span', { class: [...a.classList, 'first-link'].join(' ') }, a.innerHTML);
+  a.replaceWith(linkDiv, a);
+  a.className = 'foreground';
+  el.appendChild(a);
+  a.innerHTML = foreground.innerHTML;
+  foreground.remove();
+}
+
+function decorateSupplementalText(el) {
+  const supplementalEl = el.querySelector('.foreground p.supplemental-text');
+  if (!supplementalEl) return;
+  supplementalEl.className = 'body-xs supplemental-text';
+}
+
+function decorateForeground(el, foreground) {
+  const fgtext = foreground.querySelector('h1, h2, h3, h4, h5, h6, p')?.closest('div');
+  fgtext.closest('div').classList.add('brick-text');
+  if (foreground.querySelectorAll(':scope > div').length > 1) {
+    if (!el.classList.contains('stack')) {
+      foreground.closest('.brick').classList.add('split');
+      if (!el.classList.contains('center')) el.classList.add('row');
+    }
+    const mediaEl = foreground.querySelector('div:not([class])');
+    mediaEl.classList.add('brick-media');
+    el.classList.add((foreground.firstElementChild === mediaEl) ? 'media-left' : 'media-right');
+  }
+  const hasIconArea = fgtext.querySelector('p')?.querySelector('img');
+  if (hasIconArea) {
+    const iconArea = fgtext.querySelector('p');
+    iconArea.classList.add('icon-area');
+    if (iconArea.querySelectorAll('img').length > 1) iconArea.classList.add('icon-gap-s');
+  }
+}
+
+function decorateFillButtons(actionArea) {
+  if (!actionArea) return;
+  const btns = actionArea.querySelectorAll('a.con-button.blue');
+  btns.forEach((b) => {
+    b.classList.remove('blue');
+    b.classList.add('fill');
+  });
+}
+
+function decorateBrickIconStack(el) {
+  decorateIconStack(el);
+  const icnStk = el.querySelector('.icon-stack-area');
+  if (!icnStk) return;
+  icnStk.classList.add('body-xs');
+  const liELs = icnStk.querySelectorAll('li');
+  [...liELs].forEach((liEl) => {
+    const aTxt = liEl.querySelector('a')?.textContent?.trim();
+    const liTxt = liEl.textContent?.trim();
+    if (!liTxt || (liTxt === aTxt)) return;
+    const pic = liEl.querySelector('picture');
+    // TODO: Remove after bugfix PR adobe/helix-html2md#556 is merged
+    liEl.querySelectorAll('p').forEach((pElement) => {
+      while (pElement.firstChild) {
+        pElement.parentNode.insertBefore(pElement.firstChild, pElement);
+      }
+      pElement.remove();
+    });
+    // TODO: Remove after bugfix PR adobe/helix-html2md#556 is merged
+    let icn = pic;
+    if (pic && pic.parentElement !== liEl) {
+      icn = pic.parentElement.cloneNode(false);
+      icn.append(pic);
+    }
+    const txt = createTag('span', { class: 'list-text' }, liEl.innerHTML);
+    liEl.innerHTML = '';
+    if (icn) liEl.append(icn, txt);
+    liEl.append(txt);
+    txt.querySelector('picture')?.remove();
+    txt.querySelector('a:empty')?.remove();
+  });
+}
+
+function decorateBricks(el) {
+  if (!el.classList.contains('light')) el.classList.add('dark');
+  const elems = el.querySelectorAll(':scope > div');
+  if (elems.length > 1) {
+    handleObjectFit(elems[elems.length - 2]);
+    decorateBlockBg(el, elems[elems.length - 2], { useHandleFocalpoint: true });
+  }
+  if (elems.length > 2) {
+    el.style.background = elems[0].textContent;
+    elems[0].remove();
+  }
+  const foreground = elems[elems.length - 1];
+  foreground.classList.add('foreground');
+  decorateForeground(el, foreground);
+  const blockFormatting = getBlockSize(el);
+  decorateButtons(foreground, 'button-l');
+  decorateBlockText(foreground, blockFormatting);
+  if (el.classList.contains('button-fill')) decorateFillButtons(foreground.querySelector('.action-area'));
+  el.querySelector('.icon-area')?.classList.remove('detail-l');
+  decorateBrickIconStack(el);
+  handleSupplementalText(foreground);
+  handleClickableBrick(el, foreground);
+  return foreground;
+}
+
+export default function init(el) {
+  if (el.className.includes('rounded-corners')) {
+    const { miloLibs, codeRoot } = getConfig();
+    const base = miloLibs || codeRoot;
+    loadStyle(`${base}/styles/rounded-corners.css`);
+  }
+  decorateBricks(el);
+  decorateTextOverrides(el);
+  decorateSupplementalText(el);
+}

--- a/libs/mep/ace1052/editorial-card/editorial-card.css
+++ b/libs/mep/ace1052/editorial-card/editorial-card.css
@@ -393,4 +393,10 @@
     color: var(--text-color);
     border-color: var(--color-gray-300);
   }
+
+  .section:has(.editorial-card ~ .show-more-button),
+  .section.show-all:has(.editorial-card) {
+    margin-inline: var(--spacing-xs);
+    padding: var(--spacing-xs);
+  }
 }

--- a/libs/mep/ace1052/hero-marquee/hero-marquee.css
+++ b/libs/mep/ace1052/hero-marquee/hero-marquee.css
@@ -502,6 +502,10 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   }
 
   /* Block specific */
+  .hero-marquee .action-area:has(a:not(.con-button)) {
+    gap: var(--spacing-xs);
+  }
+
   .hero-marquee .action-area a:not(.con-button),
   .hero-marquee .con-block.row-text:has(.action-area) + .con-block.row-text .row-wrapper {
     align-self: center;
@@ -510,7 +514,6 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
 }
 
 /* Mweb changes test ACE-1052 */
-
 .hero-marquee .icon-list.has-svg-bullet {
   padding-inline-start: 0;
   display: flex;
@@ -537,8 +540,7 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   height: auto;
 }
 
- @media (max-width: 600px) {
-
+@media (max-width: 600px) {
   .hero-marquee .body-bold {
     font-weight: 700;
   }
@@ -546,4 +548,4 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   .hero-marquee .row-supplemental.center {
     text-align: center;
   }
- }
+}

--- a/libs/mep/ace1052/text/text.css
+++ b/libs/mep/ace1052/text/text.css
@@ -400,6 +400,10 @@
     text-align: start;
   }
 
+  .text.text-block.center .action-area {
+    gap: var(--spacing-xxs);
+  }
+
   .text.text-block.center .action-area:not(:has(> a:only-child)),
   .text.text-block.center .icon-area {
     justify-content: start;


### PR DESCRIPTION
This addresses the latest comments from the mweb stories:
* [MWPW-174167](https://jira.corp.adobe.com/browse/MWPW-174167) - remove `min-height` for the Brick block on mobile;
* [MWPW-171640](https://jira.corp.adobe.com/browse/MWPW-171640) - set the correct paddings for the Aside content on mobile;
* [MWPW-171432](https://jira.corp.adobe.com/browse/MWPW-171432) - reduce the gap between the CTA and regular link in the context of a Hero Marquee on mobile;
* [MWPW-174314](https://jira.corp.adobe.com/browse/MWPW-174314) - reduce the gap between CTAs from a Text block on mobile.

Additionally, based on recent conversations, a tweak has been made to adapt the layout of sections containing an expandable list of editorial cards.

**Test URLs:**
- Before (bricks): https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/simple-brick
- After (bricks): https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/simple-brick?milolibs=mweb-tweaks--milo--overmyheadandbody&mep=/drafts/ramuntea/mweb/ps-product-mweb-pzn.json
- Before (hero marquee, aside, text) - https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/ps-product-page-v2?georouting=off&mep=off
- After (hero marquee, aside, text) - https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/ps-product-page-v2?milolibs=mweb-tweaks--milo--overmyheadandbody&georouting=off
- Before (expandable editorial cards section): https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/expand-editorial-cards
- After (expandable editorial cards section): https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/expand-editorial-cards?milolibs=mweb-tweaks--milo--overmyheadandbody&mep=/drafts/ramuntea/mweb/ps-product-mweb-pzn.json






