### PR TITLE
MWPW-174265 Add url mapping to graybox envs

### DIFF
--- a/libs/blocks/graybox/graybox.css
+++ b/libs/blocks/graybox/graybox.css
@@ -151,14 +151,15 @@
   background-color: var(--gb-container-bg);
   border-radius: 3px;
   border-top-right-radius: 0;
-  border: 0;
+  border: 4px solid var(--gb-outline-color);
   box-sizing: border-box;
   display: grid;
   grid-template-rows: 1fr 66px;
   overflow: hidden;
   position: absolute;
-  right: 39px;
-  width: 0;
+  right: -320px;
+  width: 320px;
+  transition: right 0.4s ease;
 }
 
 .graybox-container .graybox-menu.hide-devices {
@@ -167,9 +168,9 @@
 }
 
 .graybox-container.open .graybox-menu {
-  border: var(--gb-container-border);
   min-height: 60px;
-  min-width: 320px;
+  right: 39px;
+  width: 320px;
 }
 
 .graybox-text {

--- a/libs/blocks/graybox/graybox.css
+++ b/libs/blocks/graybox/graybox.css
@@ -135,14 +135,16 @@
   height: 8px;
   margin-left: 8px;
   scale: 85%;
-  transform: rotate(140deg) scaleX(-1);
+  transform: rotate(140deg) scaleX(-1) translate3d(0, 0, 0);
+  transform-style: preserve-3d;
   transition: transform 0.2s ease-in-out, margin-left 0.2s ease-in-out;
   width: 8px;
+  will-change: transform;
 }
 
 .graybox-container.open .gb-toggle::before {
   margin-left: 3px;
-  transform: rotate(225deg) scaleX(1);
+  transform: rotate(225deg) scaleX(1) translate3d(0, 0, 0);
 }
 
 .graybox-container .graybox-menu {

--- a/libs/blocks/graybox/graybox.js
+++ b/libs/blocks/graybox/graybox.js
@@ -5,8 +5,6 @@ import { iphoneFrame, ipadFrame } from './mobileFrames.js';
 const URL_MAP = new Map([
   ['business.adobe.com', 'business-graybox.adobe.com'],
   ['www.adobe.com', 'graybox.adobe.com'],
-  // not in use yet
-  // ['www.adobe.com/creativecloud', 'cc-graybox.adobe.com'],
 ]);
 
 const OPTION = {

--- a/libs/blocks/graybox/graybox.js
+++ b/libs/blocks/graybox/graybox.js
@@ -2,6 +2,13 @@ import { createTag, getMetadata } from '../../utils/utils.js';
 import { getModal, closeModal } from '../modal/modal.js';
 import { iphoneFrame, ipadFrame } from './mobileFrames.js';
 
+const URL_MAP = new Map([
+  ['business.adobe.com', 'business-graybox.adobe.com'],
+  ['www.adobe.com', 'graybox.adobe.com'],
+  // not in use yet
+  // ['www.adobe.com/creativecloud', 'cc-graybox.adobe.com'],
+]);
+
 const OPTION = {
   CHANGED: 'changed',
   NO_CLICK: 'no-click',
@@ -32,7 +39,7 @@ const USER_AGENT = {
   iPad: 'Mozilla/5.0 (iPad; CPU OS 13_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1',
 };
 
-const DEFAULT_TITLE = 'Review Update';
+const DEFAULT_TITLE = '';
 
 let deviceModal;
 
@@ -337,16 +344,62 @@ const setupChangedEls = (globalNoClick) => {
   }
 };
 
-const transformLinks = () => {
-  const grayboxHostname = window.location.hostname;
-  const consumerHostname = grayboxHostname.replace(/[^.]+\.(?:([^.]+)-)?graybox\./, (_, sub) => `${sub || 'www'}.`);
-  document.querySelectorAll(`a[href*="${consumerHostname}"]`).forEach((el) => {
-    el.href = el.href.replace(consumerHostname, grayboxHostname);
+export const getGrayboxEnv = (url) => {
+  try {
+    const { hostname } = new URL(url);
+    if (!hostname.endsWith('graybox.adobe.com')) return null;
+
+    const env = hostname.replace('.graybox.adobe.com', '');
+    return env || null;
+  } catch (e) {
+    // ignore
+  }
+  return null;
+};
+
+export const convertToGrayboxDomain = (url, grayboxEnv, urlMap = URL_MAP) => {
+  try {
+    const urlObj = new URL(url);
+    const hostAndPath = urlObj.hostname + urlObj.pathname;
+
+    const matchPredicate = ([fromPattern]) => hostAndPath.startsWith(fromPattern);
+    const matchedPattern = [...urlMap].find(matchPredicate);
+
+    if (!matchedPattern) return url;
+
+    const [fromPattern, toPattern] = matchedPattern;
+    const remainingPath = hostAndPath.slice(fromPattern.length);
+
+    const [toDomain, ...toPathParts] = toPattern.split('/');
+    const toPath = toPathParts.join('/');
+
+    urlObj.hostname = `${grayboxEnv}.${toDomain}`;
+
+    let newPath = '';
+    if (toPath) {
+      newPath += `/${toPath}`;
+    }
+    if (remainingPath && remainingPath !== '/') {
+      newPath += remainingPath;
+    }
+    urlObj.pathname = newPath || '/';
+
+    return urlObj.toString();
+  } catch {
+    return url;
+  }
+};
+
+const transformLinks = (target = document) => {
+  const grayboxEnv = getGrayboxEnv(window.location.href);
+  if (!grayboxEnv) return;
+
+  target.querySelectorAll('a[href*=".adobe.com"]').forEach((el) => {
+    el.href = convertToGrayboxDomain(el.href, grayboxEnv);
   });
 };
 
 const grayboxThePage = (grayboxEl, grayboxMenuOff) => {
-  transformLinks();
   document.body.classList.add(CLASS.GRAYBOX_BODY);
   const globalNoClick = grayboxEl.classList.contains(CLASS.NO_CLICK)
     || grayboxEl.classList.contains(OPTION.NO_CLICK);
@@ -372,6 +425,16 @@ const grayboxThePage = (grayboxEl, grayboxMenuOff) => {
   } else {
     createGrayboxMenu(options, { isOpen: true });
   }
+
+  transformLinks();
+
+  const pollForFeds = setInterval(() => {
+    const isLoading = document.querySelector('header .feds-popup.loading');
+    if (!isLoading) {
+      clearInterval(pollForFeds);
+      transformLinks(document.body.querySelector('header'));
+    }
+  }, 100);
 };
 
 export default function init(grayboxEl) {

--- a/test/blocks/graybox/graybox.test.js
+++ b/test/blocks/graybox/graybox.test.js
@@ -3,7 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import { loadStyle, MILO_EVENTS } from '../../../libs/utils/utils.js';
 import { waitForElement, waitForRemoval } from '../../helpers/waitfor.js';
 
-const { default: init } = await import('../../../libs/blocks/graybox/graybox.js');
+const { default: init, convertToGrayboxDomain, getGrayboxEnv } = await import('../../../libs/blocks/graybox/graybox.js');
 await loadStyle('../../../libs/blocks/graybox/graybox.css');
 
 window.milo = { deferredPromise: Promise.resolve() };
@@ -86,5 +86,164 @@ describe('Graybox', () => {
     const noClickEl = document.querySelector('.gb-no-click');
     const noClickElStyle = window.getComputedStyle(noClickEl, '::after');
     expect(noClickElStyle.pointerEvents).to.equal('none');
+  });
+});
+
+describe('convertToGrayboxDomain', () => {
+  const testUrlMap = new Map([
+    ['business.adobe.com', 'business-graybox.adobe.com'],
+    ['www.adobe.com/creativecloud', 'cc-graybox.adobe.com'],
+    ['www.adobe.com/help/pics/light', 'helpsite-graybox.adobe.com/new'],
+    ['www.adobe.com', 'graybox.adobe.com'],
+  ]);
+
+  it('converts business.adobe.com domain', () => {
+    const result = convertToGrayboxDomain('https://business.adobe.com/pros/hello', 'test', testUrlMap);
+    expect(result).to.equal('https://test.business-graybox.adobe.com/pros/hello');
+  });
+
+  it('converts www.adobe.com/creativecloud path', () => {
+    const result = convertToGrayboxDomain('https://www.adobe.com/creativecloud/products/photo', 'asdf', testUrlMap);
+    expect(result).to.equal('https://asdf.cc-graybox.adobe.com/products/photo');
+  });
+
+  it('converts www.adobe.com/help/pics/light path with replacement path', () => {
+    const result = convertToGrayboxDomain('https://www.adobe.com/help/pics/light/deep/direc', 'qwer', testUrlMap);
+    expect(result).to.equal('https://qwer.helpsite-graybox.adobe.com/new/deep/direc');
+  });
+
+  it('converts www.adobe.com fallback', () => {
+    const result = convertToGrayboxDomain('https://www.adobe.com/other/path', 'test', testUrlMap);
+    expect(result).to.equal('https://test.graybox.adobe.com/other/path');
+  });
+
+  it('preserves query parameters and hash', () => {
+    const result = convertToGrayboxDomain('https://business.adobe.com/test?param=value&other=test#section', 'env', testUrlMap);
+    expect(result).to.equal('https://env.business-graybox.adobe.com/test?param=value&other=test#section');
+  });
+
+  it('handles URLs with no path', () => {
+    const result = convertToGrayboxDomain('https://business.adobe.com/', 'test', testUrlMap);
+    expect(result).to.equal('https://test.business-graybox.adobe.com/');
+  });
+
+  it('handles URLs with no trailing slash', () => {
+    const result = convertToGrayboxDomain('https://business.adobe.com', 'test', testUrlMap);
+    expect(result).to.equal('https://test.business-graybox.adobe.com/');
+  });
+
+  it('handles exact path matches', () => {
+    const result = convertToGrayboxDomain('https://www.adobe.com/creativecloud', 'test', testUrlMap);
+    expect(result).to.equal('https://test.cc-graybox.adobe.com/');
+  });
+
+  it('handles path matches with trailing slash', () => {
+    const result = convertToGrayboxDomain('https://www.adobe.com/creativecloud/', 'test', testUrlMap);
+    expect(result).to.equal('https://test.cc-graybox.adobe.com/');
+  });
+
+  it('handles deep path matching correctly', () => {
+    const result = convertToGrayboxDomain('https://www.adobe.com/help/pics/light', 'test', testUrlMap);
+    expect(result).to.equal('https://test.helpsite-graybox.adobe.com/new');
+  });
+
+  it('returns original URL for non-matching domains', () => {
+    const originalUrl = 'https://example.com/test/path';
+    const result = convertToGrayboxDomain(originalUrl, 'test', testUrlMap);
+    expect(result).to.equal(originalUrl);
+  });
+
+  it('returns original URL for non-matching paths', () => {
+    const result = convertToGrayboxDomain('https://www.adobe.com/nomatch/path', 'test', testUrlMap);
+    expect(result).to.equal('https://test.graybox.adobe.com/nomatch/path');
+  });
+
+  it('handles invalid URLs gracefully', () => {
+    const invalidUrl = 'not-a-url';
+    const result = convertToGrayboxDomain(invalidUrl, 'test', testUrlMap);
+    expect(result).to.equal(invalidUrl);
+  });
+
+  it('handles empty grayboxEnv', () => {
+    const result = convertToGrayboxDomain('https://business.adobe.com/test', '', testUrlMap);
+    expect(result).to.equal('https://.business-graybox.adobe.com/test');
+  });
+
+  it('respects pattern matching order (more specific first)', () => {
+    // This should match the more specific creativecloud pattern, not the general www.adobe.com
+    const result = convertToGrayboxDomain('https://www.adobe.com/creativecloud/desktop', 'test', testUrlMap);
+    expect(result).to.equal('https://test.cc-graybox.adobe.com/desktop');
+  });
+
+  it('handles HTTP URLs', () => {
+    const result = convertToGrayboxDomain('http://business.adobe.com/test', 'dev', testUrlMap);
+    expect(result).to.equal('http://dev.business-graybox.adobe.com/test');
+  });
+
+  it('handles URLs with ports', () => {
+    const result = convertToGrayboxDomain('https://business.adobe.com:8080/test', 'local', testUrlMap);
+    expect(result).to.equal('https://local.business-graybox.adobe.com:8080/test');
+  });
+
+  it('works with custom URL maps', () => {
+    const customMap = new Map([
+      ['custom.example.com/app', 'app-graybox.example.com/v2'],
+      ['custom.example.com', 'general-graybox.example.com'],
+    ]);
+
+    const result1 = convertToGrayboxDomain('https://custom.example.com/app/dashboard', 'test', customMap);
+    expect(result1).to.equal('https://test.app-graybox.example.com/v2/dashboard');
+
+    const result2 = convertToGrayboxDomain('https://custom.example.com/other', 'test', customMap);
+    expect(result2).to.equal('https://test.general-graybox.example.com/other');
+  });
+
+  it('handles empty URL map', () => {
+    const emptyMap = new Map();
+    const originalUrl = 'https://www.adobe.com/test';
+    const result = convertToGrayboxDomain(originalUrl, 'test', emptyMap);
+    expect(result).to.equal(originalUrl);
+  });
+});
+
+describe('getGrayboxEnv', () => {
+  it('returns environment name for valid graybox domains', () => {
+    const result = getGrayboxEnv('https://test.graybox.adobe.com/page');
+    expect(result).to.equal('test');
+  });
+
+  it('returns null for non-graybox domains', () => {
+    const result = getGrayboxEnv('https://www.adobe.com/page');
+    expect(result).to.be.null;
+  });
+
+  it('returns null for invalid URLs', () => {
+    const result = getGrayboxEnv('not-a-url');
+    expect(result).to.be.null;
+  });
+
+  it('returns null for empty URL', () => {
+    const result = getGrayboxEnv('');
+    expect(result).to.be.null;
+  });
+
+  it('returns null for URLs without hostname', () => {
+    const result = getGrayboxEnv('https://');
+    expect(result).to.be.null;
+  });
+
+  it('handles URLs with subdomains', () => {
+    const result = getGrayboxEnv('https://dev.test.graybox.adobe.com/page');
+    expect(result).to.equal('dev.test');
+  });
+
+  it('handles URLs with query parameters', () => {
+    const result = getGrayboxEnv('https://test.graybox.adobe.com/page?param=value');
+    expect(result).to.equal('test');
+  });
+
+  it('handles URLs with hash fragments', () => {
+    const result = getGrayboxEnv('https://test.graybox.adobe.com/page#section');
+    expect(result).to.equal('test');
   });
 });


### PR DESCRIPTION
This will map any production urls to their equivalent graybox urls so that the user is kept within the graybox environment.

Resolves: [MWPW-174265](https://jira.corp.adobe.com/browse/MWPW-174265)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://170201-gb-url--milo--adobecom.aem.page/?martech=off










