### PR TITLE
MWPW-173830: Add tooltip to notification pill

### DIFF
--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -108,6 +108,30 @@
   inline-size: 100%;
 }
 
+.notification.pill {
+  overflow: unset;
+}
+
+.notification.pill .background {
+  border-radius: inherit;
+}
+
+.notification.pill .foreground .text.notification-pill-mobile .milo-tooltip {
+  position: absolute;
+  left: calc(var(--spacing-xs) - 4px);
+  bottom: var(--spacing-xs);
+  margin-inline-start: 0;
+}
+
+[dir="rtl"] .notification.pill .foreground .text.notification-pill-mobile .milo-tooltip {
+  left: unset;
+  right: calc(var(--spacing-xs) - 4px);
+}
+
+.notification.pill .foreground .text span[data-tooltip] .icon-milo {
+  height: 16px;
+}
+
 .notification.ribbon.xxs-padding .foreground {
   padding-block: var(--spacing-xxs);
 }


### PR DESCRIPTION
Issue: Content from notification pill desktop is not available on notification pill tablet/mobile.

* Add tooltip icon with notification desktop textContent to tablet and mobile if tablet/mobile textContent is different from desktop.

**NOTE:** I thought of avoiding code duplication (https://github.com/adobecom/milo/pull/4204) by maybe moving `addTooltip` to `accessibility.js`, but block structures are different and I feel it will be harder to maintain this if there is some changes to either `aside` or `notification`. 

Resolves: [MWPW-173830](https://jira.corp.adobe.com/browse/MWPW-173830)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/notification-pill?martech=off
- After: https://mwpw-173830-a11y-notification--milo--adobecom.aem.page/docs/library/kitchen-sink/notification-pill?martech=off
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/notification?martech=off
- After: https://mwpw-173830-a11y-notification--milo--adobecom.aem.page/docs/library/kitchen-sink/notification?martech=off
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/notification-ribbon?martech=off
- After: https://mwpw-173830-a11y-notification--milo--adobecom.aem.page/docs/library/kitchen-sink/notification-ribbon?martech=off
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/mwpw-173830-a11y-notification/notification?martech=off
- After: https://mwpw-173830-a11y-notification--milo--adobecom.aem.page/drafts/ratko/mwpw-173830-a11y-notification/notification?martech=off
- Before: https://main--milo--adobecom.aem.page/ae_ar/drafts/ratko/notification?martech=off
- After: https://mwpw-173830-a11y-notification--milo--adobecom.aem.page/ae_ar/drafts/ratko/notification?martech=off




