### PR TITLE
Limit tabs upates; lower aside margins

### DIFF
--- a/libs/mep/ace1052/aside/aside.css
+++ b/libs/mep/ace1052/aside/aside.css
@@ -1286,6 +1286,12 @@
     gap: unset;
   }
 
+  .section:has(.aside:nth-child(3)) .aside [class^="detail-"],
+  .section:has(.aside:nth-child(3)) .aside [class^="heading-"]:only-of-type,
+  .section:has(.aside:nth-child(3)) .aside [class^="heading-"]:last-of-type {
+    margin-bottom: var(--spacing-xxs);
+  }
+
   .section:has(.aside:nth-child(3)) .aside .foreground.container .text {
     padding-inline: var(--spacing-xs);
   }

--- a/libs/mep/ace1052/tabs/tabs.css
+++ b/libs/mep/ace1052/tabs/tabs.css
@@ -649,19 +649,19 @@
   }
 
   /* Block specific */
-  .tabs .tabList {
+  .tabs:has(merch-card) .tabList {
     background: none;
     box-shadow: none;
   }
 
-  .tabs .tabList .tab-list-container {
+  .tabs:has(merch-card) .tabList .tab-list-container {
     padding: 1px;
     border-radius: var(--m-rounded-corners);
     background: #f8f8f8;
     overflow: hidden;
   }
 
-  .tabs .tabList button {
+  .tabs:has(merch-card) .tabList button {
     padding: 10px 18px;
     border-radius: var(--m-rounded-corners);
     border: none;
@@ -669,19 +669,19 @@
     color: var(--tabs-pill-bg-color);
   }
 
-  .tabs .tabList button[aria-selected="true"],
-  .tabs .tabList button[aria-checked="true"] {
+  .tabs:has(merch-card) .tabList button[aria-selected="true"],
+  .tabs:has(merch-card) .tabList button[aria-checked="true"] {
     background: var(--tabs-pill-bg-color);
     color: var(--color-white);
     box-shadow: 0 2px 8px 0 #00000029;
   }
 
-  .tabs .paddle {
+  .tabs:has(merch-card) .paddle {
     height: 38px;
     border-bottom: none;
   }
 
-  .tabs .paddle:disabled {
+  .tabs:has(merch-card) .paddle:disabled {
     background: none;
   }
 }


### PR DESCRIPTION
This addresses a few issues surfaced from mweb page testing:
* limit tabs updates to the section containing merch cards. @spadmasa noticed the updates were getting applied in the geo modal as well, this should no longer be the case;
* lower the margin bottom value of the detail and heading elements in aside blocks to match the Figma specs.

Resolves: [MWPW-171640](https://jira.corp.adobe.com/browse/MWPW-171640) (see last comment from Joel)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/ps-product-page-v2?milolibs=mweb-dev&georouting=off
- After: https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/ps-product-page-v2?milolibs=mweb-tweaks--milo--overmyheadandbody&georouting=off


