### PR TITLE
[MWPW-173502] Remove hash from how-to schema

### DIFF
--- a/libs/blocks/how-to/how-to.js
+++ b/libs/blocks/how-to/how-to.js
@@ -3,9 +3,9 @@ import { decorateTextOverrides } from '../../utils/decorate.js';
 
 const getSrc = (image) => image.src || image.querySelector('[src]')?.src || image.href;
 
-const getStepLd = (count, divId, image, step) => ({
+const getStepLd = (count, image, step) => ({
   '@type': 'HowToStep',
-  url: `${window.location.href}#${divId}`,
+  url: `${window.location.origin}${window.location.pathname}`,
   name: `Step ${count}`,
   ...(image && { image: getSrc(image) }),
   itemListElement: [
@@ -138,7 +138,7 @@ export default function init(el) {
   }
 
   if (isSeo) {
-    const stepsLd = steps.map((step, idx) => getStepLd(idx + 1, heading.id, images[idx], step));
+    const stepsLd = steps.map((step, idx) => getStepLd(idx + 1, images[idx], step));
     setJsonLd(heading?.textContent, desc?.textContent, mainImage, stepsLd);
   }
   decorateTextOverrides(el);

--- a/test/blocks/how-to/how-to.test.js
+++ b/test/blocks/how-to/how-to.test.js
@@ -8,7 +8,7 @@ const { default: videoinit } = await import('../../../libs/blocks/video/video.js
 const { default: adobetv } = await import('../../../libs/blocks/adobetv/adobetv.js');
 const { default: init } = await import('../../../libs/blocks/how-to/how-to.js');
 
-const expectedTest1Script = '{"@context":"http://schema.org","@type":"HowTo","name":"How to compress a PDF online (with schema)","description":"Follow these easy steps to compress a large PDF file online:","publisher":{"@type":"Organization","name":"Adobe","logo":{"@type":"ImageObject","url":"https://www.adobe.com/content/dam/cc/icons/Adobe_Corporate_Horizontal_Red_HEX.svg"}},"step":[{"@type":"HowToStep","url":"http://localhost:2000/?wtr-session-id=3ttlurFnGTxR4QflqCL7t#how-to-compress-a-pdf-online-with-schema","name":"Step 1","itemListElement":[{"@type":"HowToDirection","text":"Select the PDF file you want to make smaller."}]},{"@type":"HowToStep","url":"http://localhost:2000/?wtr-session-id=3ttlurFnGTxR4QflqCL7t#how-to-compress-a-pdf-online-with-schema","name":"Step 2","image":"http://localhost:2000/mock.png","itemListElement":[{"@type":"HowToDirection","text":"After uploading, Acrobat will automatically reduce the PDF size."}]},{"@type":"HowToStep","url":"http://localhost:2000/?wtr-session-id=3ttlurFnGTxR4QflqCL7t#how-to-compress-a-pdf-online-with-schema","name":"Step 3","itemListElement":[{"@type":"HowToDirection","text":"Download your compressed PDF file or sign in to share it. Yay!"}]}],"@image":{"@type":"ImageObject","url":"http://localhost:2000/assets/img/compress-pdf-how-to-400x240.svg"}}';
+const expectedTest1Script = '{"@context":"http://schema.org","@type":"HowTo","name":"How to compress a PDF online (with schema)","description":"Follow these easy steps to compress a large PDF file online:","publisher":{"@type":"Organization","name":"Adobe","logo":{"@type":"ImageObject","url":"https://www.adobe.com/content/dam/cc/icons/Adobe_Corporate_Horizontal_Red_HEX.svg"}},"step":[{"@type":"HowToStep","url":"http://localhost:2000/","name":"Step 1","itemListElement":[{"@type":"HowToDirection","text":"Select the PDF file you want to make smaller."}]},{"@type":"HowToStep","url":"http://localhost:2000/","name":"Step 2","image":"http://localhost:2000/mock.png","itemListElement":[{"@type":"HowToDirection","text":"After uploading, Acrobat will automatically reduce the PDF size."}]},{"@type":"HowToStep","url":"http://localhost:2000/","name":"Step 3","itemListElement":[{"@type":"HowToDirection","text":"Download your compressed PDF file or sign in to share it. Yay!"}]}],"@image":{"@type":"ImageObject","url":"http://localhost:2000/assets/img/compress-pdf-how-to-400x240.svg"}}';
 
 describe('How To', () => {
   it('Renders as an ordered list', async () => {
@@ -25,8 +25,7 @@ describe('How To', () => {
     expect(howToList?.children.length).to.equal(3);
 
     script = document.querySelector('script[type="application/ld+json"]');
-    const wtrSessionRe = /wtr-session-id=.*?#/g;
-    expect(script.innerText.replace(wtrSessionRe, '')).to.equal(expectedTest1Script.replace(wtrSessionRe, ''));
+    expect(script.innerText).to.equal(expectedTest1Script);
     script.remove();
   });
 


### PR DESCRIPTION
This removes the div hash from the How To schema, as requested by the Tech SEO team.

Resolves: [MWPW-173502](https://jira.corp.adobe.com/browse/MWPW-173502)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/products/photoshop/rasterize?martech=off&georouting=off#foo
- After: https://main--cc--adobecom.aem.page/products/photoshop/rasterize?milolibs=remove-howto-hash--milo--overmyheadandbody&martech=off&georouting=off#foo
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/nala/blocks/howto/how-to-seo?martech=off&georouting=off
- After: https://remove-howto-hash--milo--overmyheadandbody.aem.page/drafts/nala/blocks/howto/how-to-seo?martech=off&georouting=off


