### PR TITLE
Revert "[MWPW-173717] Hyphenate large headings on mobile"

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -930,12 +930,7 @@ a.static:active  {
 }
 
 /* mobile only */
-@media (max-width: 599px) {
-  :root:not(:lang(ja-JP), :lang(ja)) :is(.heading-xxxl, .heading-xxl) {
-    hyphens: auto;
-    hyphenate-limit-chars: 15 5 5;
-  }
-
+@media (max-width: 600px) {
   .con-button.button-justified-mobile {
     display: block;
     text-align: center;


### PR DESCRIPTION
Reverts adobecom/milo#4199

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- Milo: https://revert-4199-large-heading-a11y--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- Milo: https://revert-4199-large-heading-a11y--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- Milo: https://revert-4199-large-heading-a11y--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=revert-4199-large-heading-a11y--milo--adobecom
</details>