### PR TITLE
MWPW-170541: Add support for rtl

### DIFF
--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -90,15 +90,15 @@ function handleBtnState(
 }
 
 function handleNavigation(el) {
-  const isRtl = document.documentElement.getAttribute('dir') === 'rtl';
+  const isRtl = document.documentElement.dir === 'rtl';
   const prev = createTag('div', { class: 'nav-grad previous' }, PREVBUTTON);
   const next = createTag('div', { class: 'nav-grad next' }, NEXTBUTTON);
-  const buttons = [prev, next];
+  const buttons = isRtl ? [next, prev] : [prev, next];
   buttons.forEach((btn) => {
     const button = btn.childNodes[0];
     button.addEventListener('click', () => handleScroll(el, button.classList));
   });
-  return isRtl ? buttons.reverse() : buttons;
+  return buttons;
 }
 
 export default function init(el) {

--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -49,7 +49,8 @@ export function hideNavigation(el) {
   const elHasWidth = !!el.clientWidth;
   const scrollWidth = itemWidth * columns + gridGap * (columns - 1) + 2 * padding;
   const screenWidth = window.innerWidth < 1200 ? window.innerWidth : 1200;
-  const horizontalScroll = Math.ceil(el.scrollLeft) === Math.ceil(el.scrollWidth - el.clientWidth);
+  const scrollLeft = Math.ceil(Math.abs(el.scrollLeft));
+  const horizontalScroll = scrollLeft === Math.ceil(el.scrollWidth - el.clientWidth);
 
   return elHasWidth ? horizontalScroll : scrollWidth < screenWidth;
 }
@@ -89,6 +90,7 @@ function handleBtnState(
 }
 
 function handleNavigation(el) {
+  const isRtl = document.documentElement.getAttribute('dir') === 'rtl';
   const prev = createTag('div', { class: 'nav-grad previous' }, PREVBUTTON);
   const next = createTag('div', { class: 'nav-grad next' }, NEXTBUTTON);
   const buttons = [prev, next];
@@ -96,7 +98,7 @@ function handleNavigation(el) {
     const button = btn.childNodes[0];
     button.addEventListener('click', () => handleScroll(el, button.classList));
   });
-  return buttons;
+  return isRtl ? buttons.reverse() : buttons;
 }
 
 export default function init(el) {


### PR DESCRIPTION
Issue: Action scroller navigation doesn't work properly on rtl pages

* Add support for rtl


Resolves: [MWPW-170541](https://jira.corp.adobe.com/browse/MWPW-170541)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/ae_ar/drafts/ratko/action-scroller-tabs?martech=off
- After: https://mwpw-170541-scroller-rtl--milo--adobecom.aem.page/ae_ar/drafts/ratko/action-scroller-tabs?martech=off
- Before: https://main--milo--adobecom.aem.page/ae_ar/drafts/ratko/action-scroller?martech=off
- After: https://mwpw-170541-scroller-rtl--milo--adobecom.aem.page/ae_ar/drafts/ratko/action-scroller?martech=off
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/action-items?martech=off
- After: https://mwpw-170541-scroller-rtl--milo--adobecom.aem.page/docs/library/kitchen-sink/action-items?martech=off
- Before: https://main--milo--adobecom.aem.page/drafts/biljana/mwpw-169845/action-scroller?martech=off
- After: https://mwpw-170541-scroller-rtl--milo--adobecom.aem.page/drafts/biljana/mwpw-169845/action-scroller?martech=off




