### PR TITLE
[MWPW-173717] Safari fix for heading hyphenation

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -930,7 +930,14 @@ a.static:active  {
 }
 
 /* mobile only */
-@media (max-width: 600px) {
+@media (max-width: 599px) {
+  :root:not(:lang(ja-JP), :lang(ja)) :is(.heading-xxxl, .heading-xxl) {
+    hyphens: auto;
+    hyphenate-limit-chars: 15 5 5;
+    -webkit-hyphenate-limit-before: 7;
+    -webkit-hyphenate-limit-after: 7;
+  }
+
   .con-button.button-justified-mobile {
     display: block;
     text-align: center;


### PR DESCRIPTION
[Initial implementation](https://github.com/adobecom/milo/pull/4199) for this has been reverted due to headings being hyphenated in odd spots on iOS devices.

The rules have thus been adapted to:
* on non-Safari mobile browsers, hyphenate 2XL & 3XL headings with a character count larger than 15, ensuring both sides of the hyphen have at least 5 characters;
* on a Safari mobile browser, hyphenate 2XL & 3XL headings, ensuring both sides of the hyphen have at least 7 characters; there isn't a way to define a character count for the entire word, but having these limits means the hyphenation will occur only for words with a character count larger than 14;

Resolves: [MWPW-173717](https://jira.corp.adobe.com/browse/MWPW-173717)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/headline-hyphenation?martech=off&georouting=off
- Initial fix: https://large-heading-a11y--milo--overmyheadandbody.aem.page/drafts/ramuntea/headline-hyphenation?martech=off&georouting=off
- Current fix: https://hyphenate-headings-safari-fix--milo--overmyheadandbody.aem.page/drafts/ramuntea/headline-hyphenation?martech=off&georouting=off
- Before: https://main--cc--adobecom.aem.page/se/products/premiere/ai-video-editing?martech=off&georouting=off
- Initial fix: https://main--cc--adobecom.aem.page/se/products/premiere/ai-video-editing?milolibs=large-heading-a11y--milo--overmyheadandbody&martech=off&georouting=off
- Current fix: https://main--cc--adobecom.aem.page/se/products/premiere/ai-video-editing?milolibs=hyphenate-headings-safari-fix--milo--overmyheadandbody&martech=off&georouting=off
- Before: https://main--cc--adobecom.aem.page/hu/products/premiere/ai-video-editing?martech=off&georouting=off
- Initial fix: https://main--cc--adobecom.aem.page/hu/products/premiere/ai-video-editing?milolibs=large-heading-a11y--milo--overmyheadandbody&martech=off&georouting=off
- Current fix: https://main--cc--adobecom.aem.page/hu/products/premiere/ai-video-editing?milolibs=hyphenate-headings-safari-fix--milo--overmyheadandbody&martech=off&georouting=off
- Before: https://main--cc--adobecom.aem.page/jp/products/premiere/ai-video-editing?martech=off&georouting=off
- Initial fix: https://main--cc--adobecom.aem.page/jp/products/premiere/ai-video-editing?milolibs=large-heading-a11y--milo--overmyheadandbody&martech=off&georouting=off
- Current fix: https://main--cc--adobecom.aem.page/jp/products/premiere/ai-video-editing?milolibs=hyphenate-headings-safari-fix--milo--overmyheadandbody&martech=off&georouting=off
