### PR TITLE
MWPW-170229: Show action scroller nav on resize

### DIFF
--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -99,6 +99,13 @@ function handleNavigation(el) {
   return buttons;
 }
 
+const allActionScrollers = [];
+function handleResize() {
+  allActionScrollers.forEach(({ scroller, buttons }) => {
+    handleBtnState(scroller, buttons);
+  });
+}
+
 export default function init(el) {
   const hasNav = el.classList.contains(NAV);
   const actions = el.parentElement.querySelectorAll('.action-item');
@@ -109,6 +116,8 @@ export default function init(el) {
   el.replaceChildren(items, ...buttons);
   if (hasNav) {
     items.addEventListener('scroll', () => handleBtnState(items, buttons));
+    allActionScrollers.push({ scroller: items, buttons });
+    window.addEventListener('resize', handleResize);
     handleBtnState(items, buttons);
   }
 }


### PR DESCRIPTION
This resolves an issue where navigation button in `action-scroller` doesn't show up after resize.

Resolves: [MWPW-170229](https://jira.corp.adobe.com/browse/MWPW-170229)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/mwpw-169845/tabs-scroller?martech=off
- After: https://mwpw-170229-scroller-resize--milo--adobecom.aem.page/drafts/ratko/mwpw-169845/tabs-scroller?martech=off
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/action-items?martech=off
- After: https://mwpw-170229-scroller-resize--milo--adobecom.aem.page/docs/library/kitchen-sink/action-items?martech=off