### PR TITLE
MWPW-168315 Auto set close captions for videos

### DIFF
--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -20,7 +20,7 @@ const CaptionsLangMap = {
   dut: ['nl', 'be_nl'],
   swe: ['se'],
   chi_hans: ['cn'],
-  chi_hant: ['hk', 'tw'],
+  chi_hant: ['hk_zh', 'tw'],
   hin: ['in_hi'],
   kor: ['kr'],
 };

--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -1,19 +1,60 @@
 import { decorateAnchorVideo } from '../../utils/decorate.js';
-import { createTag } from '../../utils/utils.js';
+import { getConfig, createTag } from '../../utils/utils.js';
+
+const CaptionsLangMap = {
+  eng: [
+    'ae_ar', 'ae_en', 'africa', 'au', 'be_en', 'bg', 'ca', 'cz', 'dk', 'ee', 'gr_en',
+    'hk_en', 'hu', 'id_en', 'id_id', 'ie', 'il_en', 'il_he', 'in', 'lt', 'lu_en',
+    'lv', 'mena_ar', 'mena_en', 'my_en', 'my_ms', 'no', 'nz', 'ph_en', 'ph_fil',
+    'pl', 'ro', 'ru', 'sa_ar', 'sa_en', 'sg', 'si', 'sk', 'th_en', 'tr', 'ua', 'uk',
+    'vn_en', 'vn_vi', 'fi',
+  ],
+  fre_fr: ['be_fr', 'ch_fr', 'fr', 'lu_fr', 'ca_fr'],
+  ger: ['at', 'ch_de', 'lu_de', 'de'],
+  jpn: ['jp'],
+  ita: ['it', 'ch_it'],
+  spa: ['es'],
+  por_br: ['br', 'pt'],
+  tha: ['th_th'],
+  spa_la: ['ar', 'cl', 'co', 'la', 'mx', 'pe'],
+  dut: ['nl', 'be_nl'],
+  swe: ['se'],
+  chi_hans: ['cn'],
+  chi_hant: ['hk', 'tw'],
+  hin: ['in_hi'],
+  kor: ['kr'],
+};
+
+export const updateCaptionsLang = (videoUrl, geo) => {
+  const url = new URL(videoUrl);
+
+  if (url.searchParams.has('captions')) {
+    for (const [langCode, geos] of Object.entries(CaptionsLangMap)) {
+      if (geos.includes(geo)) {
+        url.searchParams.set('captions', langCode);
+        break;
+      }
+    }
+  }
+
+  return url.toString();
+};
 
 export default function init(a) {
+  const geo = (getConfig()?.locale?.prefix || '').replace('/', '');
+  const videoHref = updateCaptionsLang(a.href, geo);
   a.classList.add('hide-video');
   const bgBlocks = ['aside', 'marquee', 'hero-marquee', 'long-form'];
   if (a.href.includes('.mp4') && bgBlocks.some((b) => a.closest(`.${b}`))) {
     a.classList.add('hide');
     if (!a.parentNode) return;
     decorateAnchorVideo({
-      src: a.href,
+      src: videoHref,
       anchorTag: a,
     });
   } else {
     const iframe = createTag('iframe', {
-      src: a.href,
+      src: videoHref,
       class: 'adobetv',
       scrolling: 'no',
       allow: 'encrypted-media; fullscreen',

--- a/test/blocks/adobetv/adobetv.test.js
+++ b/test/blocks/adobetv/adobetv.test.js
@@ -2,6 +2,7 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { waitForElement } from '../../helpers/waitfor.js';
 import { setConfig } from '../../../libs/utils/utils.js';
+import { updateCaptionsLang } from '../../../libs/blocks/adobetv/adobetv.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 setConfig({});
@@ -26,5 +27,37 @@ describe('adobetv autoblock', () => {
     const video = await waitForElement('#adobetvAsBg video');
     expect(wrapper.querySelector(':scope a[href*=".mp4"]')).to.be.null;
     expect(video).to.be.exist;
+  });
+});
+
+describe('updateCaptionsParam', () => {
+  it('should update captions parameter for known geo', () => {
+    const url = 'https://video.tv.adobe.com/v/123456?captions=eng';
+    const result = updateCaptionsLang(url, 'fr');
+    expect(result).to.equal('https://video.tv.adobe.com/v/123456?captions=fre_fr');
+  });
+
+  it('should not modify captions for unknown geo', () => {
+    const url = 'https://video.tv.adobe.com/v/123456?captions=eng';
+    const result = updateCaptionsLang(url, 'unknown_geo');
+    expect(result).to.equal(url);
+  });
+
+  it('should not add captions parameter if not present', () => {
+    const url = 'https://video.tv.adobe.com/v/123456';
+    const result = updateCaptionsLang(url, 'fr');
+    expect(result).to.equal(url);
+  });
+
+  it('should handle multiple query parameters', () => {
+    const url = 'https://video.tv.adobe.com/v/123456?autoplay=true&captions=eng';
+    const result = updateCaptionsLang(url, 'jp');
+    expect(result).to.equal('https://video.tv.adobe.com/v/123456?autoplay=true&captions=jpn');
+  });
+
+  it('should preserve other query parameters when updating captions', () => {
+    const url = 'https://video.tv.adobe.com/v/123456?captions=eng&quality=hd&autoplay=true';
+    const result = updateCaptionsLang(url, 'de');
+    expect(result).to.equal('https://video.tv.adobe.com/v/123456?captions=ger&quality=hd&autoplay=true');
   });
 });


### PR DESCRIPTION
* added a function to update close caption parameter (captions=eng) to the appropriate locale value (provided in the JIRA) when ever a user visits a non-english page (containing AdobeTv video)
Resolves: [MWPW-168315](https://jira.corp.adobe.com/browse/MWPW-168315)
Test URLs:
* Before: https://main--milo--adobecom.aem.page/de/drafts/deeksha/locflow77
* After: https://mwpw-168315--milo--g-abani.aem.page/de/drafts/deeksha/locflow77



