### PR TITLE
[Stage] MWPW-174028 Invalid date is formatted as NaN (#4315)

### DIFF
--- a/libs/blocks/locui-create/input-urls/index.js
+++ b/libs/blocks/locui-create/input-urls/index.js
@@ -110,6 +110,7 @@ export function getInitialName(type) {
 }
 
 export function formatDateTime(dueDate) {
+  if (!dueDate) return '';
   const date = new Date(dueDate);
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');


### PR DESCRIPTION
Validated that now, when an invalid or empty date is added through UI, it gets converted to an empty string

**_Empty Date_**
<img width="1492" alt="Screenshot 2025-06-04 at 10 21 33 PM" src="https://github.com/user-attachments/assets/2aafee94-bd69-42a5-816e-1cce2958cbc1" />

**_Invalid Date (missing minutes)_**
<img width="1679" alt="Screenshot 2025-06-04 at 10 22 28 PM" src="https://github.com/user-attachments/assets/dfe64f73-d078-438c-877e-79d82438cd04" />

Resolves: [MWPW-174028](https://jira.corp.adobe.com/browse/MWPW-174028)

**Test URLs:**
- Before: https://milostudio-stage--milo--adobecom.aem.page/tools/locui-create?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&env=local&workflow=normal
- After: https://mwpw-174028-stage--milo--nkthakur48.aem.page/tools/locui-create?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&env=local&workflow=normal
