### PR TITLE
[MWPW-174367] Inline fragment not behaving as expected in block

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -90,9 +90,11 @@ export default async function init(a) {
   }
 
   if (a.href.includes('#_inline')) {
-    inline = true;
-    a.href = a.href.replace('#_inline', '');
-    relHref = relHref.replace('#_inline', '');
+    inline = !a.href.includes('#_replacecell');
+    ['#_inline', '#_replacecell'].forEach((flag) => {
+      a.href = a.href.replace(flag, '');
+      relHref = relHref.replace(flag, '');
+    });
   }
 
   if (isCircularRef(relHref)) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -843,7 +843,7 @@ export function decorateAutoBlock(a) {
       }
 
       // Modals
-      if (url.hash !== '' && !isInlineFrag) {
+      if (url.hash !== '' && !isInlineFrag && !url.hash.includes('#_replacecell')) {
         a.dataset.modalPath = url.pathname;
         a.dataset.modalHash = url.hash;
         a.href = url.hash;


### PR DESCRIPTION
Adds a #_replacecell check to prevent #_inline being added which was erroneously removing the row upon content insertion.

Before:
![{042F7DFC-ADF6-4911-89CA-B06F96E5072B}](https://github.com/user-attachments/assets/4708a70e-0d1c-4578-8424-9a475c902938)

After:
![{C4FA99D7-1AD3-45DD-9428-4F7C8A1A158F}](https://github.com/user-attachments/assets/8cf27a7c-3404-41a6-a548-2d673e5cbc0a)

Resolves: https://jira.corp.adobe.com/browse/MWPW-174367

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/products/indesign?mep=%2Fproducts%2Findesign.json--default---%2Fdrafts%2Fmepdev%2Ffragments%2F2025%2Fq3%2Ffragmentsinblock%2Fmanifest.json--fragment-broke
- After: https://main--cc--adobecom.aem.page/products/indesign?milolibs=fragmentsinblock&mep=%2Fproducts%2Findesign.json--default---%2Fdrafts%2Fmepdev%2Ffragments%2F2025%2Fq3%2Ffragmentsinblock%2Fmanifest.json--fragment-fix
- Psi: https://fragmentsinblock--milo--adobecom.aem.page/?martech=off
