### PR TITLE
[Preflight] MPC videos support

### DIFF
--- a/libs/blocks/preflight/checks/performance.js
+++ b/libs/blocks/preflight/checks/performance.js
@@ -102,14 +102,17 @@ export async function checkImageSize(url, area, observeLcp) {
 
 export async function checkVideoPoster(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
-  if (!lcp?.url?.match('media_.*.mp4')) {
+  const hasVideoUrl = lcp?.url?.match(/\.mp4/);
+  const videoElement = lcp?.element?.closest('video') || lcp?.element?.querySelector('video');
+  
+  if (!hasVideoUrl && !videoElement) {
     return {
       title: PERFORMANCE_TITLES.VideoPoster,
       status: STATUS.EMPTY,
       description: 'No video as LCP element.',
     };
   }
-  const hasPoster = !!lcp.element.poster;
+  const hasPoster = !!videoElement?.poster;
   return {
     title: PERFORMANCE_TITLES.VideoPoster,
     status: hasPoster ? STATUS.PASS : STATUS.FAIL,


### PR DESCRIPTION
The Performance > Videos check only detected SharePoint videos (`media_.*.mp4`) and didnt recognize MPC videos from `images-tv.adobe.com`, incorrectly showing "No videos as LCP Element" when MCP videos were there.

Resolves: [MWPW-174197](https://jira.corp.adobe.com/browse/MWPW-174197)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mpc-video-support--milo--skholkhojaev.aem.page/?martech=off


Test Page 1: https://main--cc--adobecom.aem.page/products/illustrator?milolibs=MPC-video-Support--milo--skholkhojaev
Test Page 2: https://main--cc--adobecom.aem.page/products/premiere?milolibs=MPC-video-Support--milo--skholkhojaev





