### PR TITLE
MWPW-172886 [MEP] Support MEP AICS pzn tags recieved from API

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -877,7 +877,7 @@ export const getEntitlements = async (data) => {
 function normCountry(country) {
   return (country.toLowerCase() === 'uk' ? 'gb' : country.toLowerCase()).split('_')[0];
 }
-async function setMepCountry(config) { // return
+async function setMepCountry(config) {
   const urlParams = new URLSearchParams(window.location.search);
   const country = urlParams.get('country') || (document.cookie.split('; ').find((row) => row.startsWith('international='))?.split('=')[1]);
   const akamaiCode = urlParams.get('akamaiLocale')?.toLowerCase() || sessionStorage.getItem('akamai');

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -9,7 +9,6 @@ import {
   loadScript,
   localizeLink,
   getFederatedUrl,
-  getSpectraLOB,
 } from '../../utils/utils.js';
 
 /* c8 ignore start */
@@ -914,14 +913,6 @@ async function setMepLob(config) {
   }
 }
 
-// async function setMepLob(config) { // old version
-  // bad bc it's 2 separate calls
-  // if (config.mep.userLOBPromise) config.mep.meplob = await getSpectraLOB(document.referrer);
-  
-  // good, because we're awaiting the original promise with no delay
-  // if (config.mep.userLOBPromise) config.mep.meplob = await config.mep.userLOBPromise;
-// }
-
 async function getPersonalizationVariant(
   manifestPath,
   variantNames = [],
@@ -952,7 +943,6 @@ async function getPersonalizationVariant(
     if (name.startsWith('param-')) return checkForParamMatch(name);
     if (hasCountryMatch(name, config)) return true;
     if (userEntitlements?.includes(name)) return true;
-    console.log('Checking config.mep.meplob:', config.mep?.meplob);
     if (config.mep?.meplob === name.split('lob-')[1]?.toLowerCase()) return true;
     return PERSONALIZATION_KEYS.includes(name) && PERSONALIZATION_TAGS[name]();
   };
@@ -1455,8 +1445,6 @@ const awaitMartech = () => new Promise((resolve) => {
 });
 
 export async function init(enablements = {}) {
-  console.log('personzalization: init');
-  console.log(enablements);
   let manifests = [];
   const {
     mepParam, mepHighlight, mepButton, pzn, pznroc, promo, enablePersV2,

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -942,7 +942,8 @@ async function getPersonalizationVariant(
     if (hasCountryMatch(name, config)) return true;
     if (userEntitlements?.includes(name)) return true;
     console.log('Checking config.mep.meplob:', config.mep?.meplob);
-    if (name.startsWith('lob-') && name.split('-')[1].toLowerCase() === config.mep?.meplob?.toLowerCase()) return true;
+    // if (name.startsWith('lob-') && config.mep?.meplob && name.split('-')[1].toLowerCase() === config.mep.meplob) return true;
+    if (name.startsWith('lob-') && config.mep?.meplob === name.split('-')[1].toLowerCase()) return true;
     return PERSONALIZATION_KEYS.includes(name) && PERSONALIZATION_TAGS[name]();
   };
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1375,7 +1375,7 @@ export async function getSpectraLOB(lastVisitedPage) {
       body: null,
     });
     const content = await rawResponse.json();
-    return content.modelLineOfBusiness;
+    return content.modelLineOfBusiness.toLowerCase(); // added lowercase
   } catch (error) {
     if (error.name === 'TimeoutError') {
       // This exception is from the abort signal

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1375,14 +1375,14 @@ export async function getSpectraLOB(lastVisitedPage) {
       body: null,
     });
     const content = await rawResponse.json();
-    return content.modelLineOfBusiness.toLowerCase(); // added lowercase
-  } catch (error) {
-    if (error.name === 'TimeoutError') {
+    return content.modelLineOfBusiness?.toLowerCase();
+  } catch (e) {
+    if (e.name === 'TimeoutError') {
       // This exception is from the abort signal
-      window.lana?.log.log('Spectra Timeout');
+      window.lana?.log('Spectra Timeout');
     } else {
       // A network error, or some other problem.
-      window.lana?.log(`Error: type: ${error.name}, message: ${error.message}`);
+      window.lana?.log(e.reason || e.error || e.message, { errorType: 'i' });
     }
     return false;
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1361,7 +1361,6 @@ export async function getSpectraLOB(lastVisitedPage) {
   const getECID = getCookie('AMCV_9E1005A551ED61CA0A490D45@AdobeOrg');
   if (!getECID) return false;
   const [, ECID] = getECID.split('|');
-  console.log('ECID:', ECID); // remove this in production
   let url = `https://cchome-stage.adobe.io/int/v1/aep/events/webpage?ecid=${ECID}`;
   if (lastVisitedPage) url = `${url}&lastVisitedPage=${lastVisitedPage}`;
 
@@ -1389,7 +1388,6 @@ export async function getSpectraLOB(lastVisitedPage) {
 }
 
 async function checkForPageMods() {
-  console.log('utils: checkForPageMods'); // remove this in production
   const {
     mep: mepParam,
     mepHighlight,
@@ -1422,10 +1420,7 @@ async function checkForPageMods() {
       countryIPPromise = getAkamaiCode(true);
     }
   }
-
-  console.log(`meplob: ${meplob}`); // remove this in production
   if (meplob === true) userLOBPromise = getSpectraLOB(document.referrer);
-  console.log(`userLOBPromise: ${userLOBPromise}`); // remove this in production
 
   const enablePersV2 = enablePersonalizationV2();
   if ((target || xlg) && enablePersV2) {


### PR DESCRIPTION
This PR adds experience targeting by LOB (Line of Business) to MEP. The new keyword to use in MEP manifests is '_lob-<lob>_' (example: 'lob-b2b). 

This new feature requires an api call via _getSpectraLOB_() located in utils.js. If the api call promise is not resolved before utils.js calls _init_() in personalization.js, then the promise will be passed via the _entitlements_ object. The promise will be resolved before _hasMatch_() is called in personalization.js.

**Added features** 
- MEP Manifest can now use 'lob-<lob>' in experience name column to target user LOB. 
- utils.js has new functions: _getCookie_() to find ECID required for api call that returns user LOB, and _getSpectraLOB_() to execute api call to return user LOB. 
- MISC BUG FIX: _getSelectedElements_() now returns an empty object ({}) instead of null to prevent error when invalid selectors are listed in manifest. 

**Expected behavior/requirements to use** 
- Accepted quirk: user LOB (returned via _getSpectraLOB_()) will not be available on first page hit. 
- This feature requires the targeted page to have page metadata key 'aicslob' with value of 'on' lob- keyword works with the standard MEP experience name modifiers: ',' '&' 'not' 
- LOB values returned by getSpectraLOB can have - in the value returned, but should not have the string pattern 'lob-' as it would be a MEP keyword duplicate. Example: LOB string returned by getSpectraLOB should be 'b2b' instead of 'lob-b2b'. 
- The feature can be enabled manually via url params: ?lob=on allows getSpectraLOB to run even if the page does not have 'aicslob:on' in metadata table. Alternatively, user can set ANY lob value manually by using ?lob=<lob> (this feature will prevent getSpectraLOB api call from running as this is a direct spoof provided by the user in the url).

Resolves: [MWPW-174352](https://jira.corp.adobe.com/browse/MWPW-174352)
PSI check: https://targetbylob--milo--adobecom.aem.page/?martech=off

**How to test** 
There's a single page for testing. Depending on the lob spoofed, the marquee headline will change. Make sure to enable mobile device in chrome dev tools if the test case lists Device: Phone. 

qa manifest location: 
https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/targetbylob/manifest.json

**Case 1** 
LOB is CC 
https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/targetbylob/lobmarquee?milolibs=targetbylob&lob=cc
Headline: LOB-CC -or- LOB-STD on phone

**Case 2** 
LOB is STD AND Device: Phone
https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/targetbylob/lobmarquee?milolibs=targetbylob&lob=std
Headline: LOB-CC -or- LOB-STD on phone

**Case 3** 
LOB is B2B and NOT Device: Phone
https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/targetbylob/lobmarquee?milolibs=targetbylob&lob=b2b
Headline: 'LOB-B2B found NOT for phones 

**Case 4** 
LOB is B2B and Device: Phone
https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/targetbylob/lobmarquee?milolibs=targetbylob&lob=b2b
Headline: LOB-B2B AND Phone 

**Case 5** 
LOB is not spoofed, confirm LOB is CC after 2nd hit on page 
https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/targetbylob/lobmarquee?milolibs=targetbylob
Headline on 1st hit (all): ALL experience.
Headline on 2nd hit: LOB-CC -or- LOB-STD on phone 