### PR TITLE
Bring the latest block changes into the mweb feature branch

### DIFF
--- a/libs/mep/ace1052/aside/aside.css
+++ b/libs/mep/ace1052/aside/aside.css
@@ -112,6 +112,7 @@
 .aside .foreground.container .image {
   position: relative;
   display: flex;
+  width: 100%;
 }
 
 .aside .foreground.container > div {
@@ -595,11 +596,36 @@
   align-items: center;
 }
 
+.aside.promobar.popup .mobile-up.promo-text:has(.milo-tooltip) {
+  position: relative;
+}
+
+.aside.promobar.popup .promo-text span[data-tooltip] .icon-milo {
+  height: 16px;
+}
+
+.aside.promobar.popup .mobile-up.promo-text .milo-tooltip {
+  position: absolute;
+  left: calc(var(--spacing-xs) - 5px);
+  bottom: var(--spacing-xs);
+  margin-inline-start: 0;
+}
+
+[dir="rtl"] .aside.promobar.popup .mobile-up.promo-text .milo-tooltip {
+  left: unset;
+  right: calc(var(--spacing-xs) - 5px);
+}
+
 .aside.promobar.popup {
   border-radius: var(--spacing-xs);
   width: var(--grid-container-width);
   margin: auto;
   box-shadow: 0 3px 6px #707070;
+  overflow: unset;
+}
+
+.aside.promobar.popup .background {
+  border-radius: inherit;
 }
 
 .aside.promobar.popup .foreground.container .promo-text {

--- a/libs/mep/ace1052/aside/aside.js
+++ b/libs/mep/ace1052/aside/aside.js
@@ -111,7 +111,41 @@ function checkViewportPromobar(foreground) {
   if (childCount < 3) addPromobar(children[childCount - 1], foreground);
 }
 
-function combineTextBocks(textBlocks, iconArea, viewPort, variant) {
+function toolTipPosition(container) {
+  const isRtl = document.documentElement.getAttribute('dir') === 'rtl';
+  const isTablet = container.classList.contains('tablet-up');
+  const isMobile = container.classList.contains('mobile-up');
+  if ((isRtl && isTablet) || (isMobile && !isRtl)) return 'right';
+
+  return 'left';
+}
+
+async function addTooltip(foreground) {
+  const desktopContentText = foreground.querySelector('.desktop-up .text-area')?.textContent.trim();
+  const toolTipIcons = [];
+  [...foreground.querySelectorAll(':scope > div:not(.desktop-up)')].forEach((viewPortEl) => {
+    const childContent = viewPortEl.querySelector('.text-area');
+    const childContentText = childContent.textContent.trim();
+    if (childContentText === desktopContentText) return;
+    const appendTarget = viewPortEl.querySelector('.text-area').lastElementChild;
+    const iconWrapper = createTag('em', {}, `${toolTipPosition(viewPortEl)}|${desktopContentText}`);
+    iconWrapper.style.display = 'none';
+    const tooltipSpan = createTag('span', { class: 'icon icon-tooltip' });
+    iconWrapper.appendChild(tooltipSpan);
+    toolTipIcons.push(tooltipSpan);
+    appendTarget.appendChild(iconWrapper);
+  });
+
+  if (!toolTipIcons.length) return;
+
+  const config = getConfig();
+  const base = config.miloLibs || config.codeRoot;
+  const { default: loadIcons } = await import('../../../features/icons/icons.js');
+  loadStyle(`${base}/features/icons/icons.css`);
+  loadIcons(toolTipIcons, config);
+}
+
+function combineTextBlocks(textBlocks, iconArea, viewPort, variant) {
   const promobarConfig = {
     default: {
       'mobile-up': ['s', 's'],
@@ -158,9 +192,12 @@ function decoratePromobar(el) {
     if (iconArea) textBlocks.shift();
     if (actionArea.length) textBlocks.pop();
     if (!(textBlocks.length || iconArea || actionArea.length)) child.classList.add('hide-block');
-    else if (textBlocks.length) combineTextBocks(textBlocks, iconArea, viewports[index], variant);
+    else if (textBlocks.length) combineTextBlocks(textBlocks, iconArea, viewports[index], variant);
   });
-  if (variant === 'popup') addCloseButton(el);
+  if (variant === 'popup') {
+    addCloseButton(el);
+    addTooltip(foreground);
+  }
   return foreground;
 }
 

--- a/libs/mep/ace1052/carousel/carousel.css
+++ b/libs/mep/ace1052/carousel/carousel.css
@@ -61,10 +61,11 @@
   min-width: 114px;
   gap: 10px;
 }
-
-.carousel.no-buttons .carousel-button-container {
+/* The no-buttons variant is temporarily disabled because slide indicators are currently hidden by default, which makes the no-buttons carousel unusable. */
+/* When the slide indicator color issue is resolved and they are enabled again, this should be re-enabled as well. */
+/* .carousel.no-buttons .carousel-button-container {
   min-width: auto;
-}
+} */
 
 .carousel .carousel-button-container button {
   position: relative;
@@ -100,9 +101,9 @@
   order: 3;
 }
 
-.carousel.no-buttons .carousel-button {
+/* .carousel.no-buttons .carousel-button {
   display: none;
-}
+} */
 
 .carousel .carousel-previous:hover,
 .carousel .carousel-next:hover {
@@ -191,7 +192,7 @@ html[dir="rtl"] .carousel-slides .section.carousel-slide {
 .carousel-slide.active,
 .carousel.fade .carousel-slide.active {
   opacity: 1;
-} 
+}
 
 .carousel-slides.is-ready,
 .carousel-slides.is-ready.is-reversing,
@@ -209,7 +210,7 @@ html[dir="rtl"] .carousel-slides .section.carousel-slide {
 }
 
 .carousel .carousel-controls {
-  display: flex;
+  display: none;
   position: relative;
   max-width: 88px;
   overflow: hidden;
@@ -217,9 +218,9 @@ html[dir="rtl"] .carousel-slides .section.carousel-slide {
   justify-content: inherit;
 }
 
-.carousel.no-buttons .carousel-controls {
-  padding: 0 var(--spacing-xxs);
-}
+  /* .carousel.no-buttons .carousel-controls {
+    padding: 0 var(--spacing-xxs);
+  } */
 
 .carousel .carousel-indicators {
   list-style: none;
@@ -523,7 +524,7 @@ html[dir="rtl"] .carousel .move-indicators {
     left: -80%;
     transform: translateX(80%);
   }
-  
+
   .carousel.hinting-mobile .carousel-slides.is-reversing {
     transform: translateX(-80%);
   }
@@ -723,6 +724,13 @@ html[dir="rtl"] .carousel .move-indicators {
   }
 }
 
+.carousel .aria-live-container {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
 @media (max-width: 600px) {
   /* ##mweb changes## */
   .carousel.disable-buttons.hinting-mobile .carousel-slides {
@@ -742,7 +750,7 @@ html[dir="rtl"] .carousel .move-indicators {
   .carousel.disable-buttons.hinting-mobile .carousel-slides.is-ready,
   .carousel.disable-buttons.hinting-mobile .carousel-slides.is-ready.is-reversing   {
     transform: translateX(calc((8.3vw - 16px)));
-  } 
+  }
 
   .carousel.disable-buttons.hinting-mobile .carousel-slides.is-reversing {
     transform: translateX(calc(-83.4vw - (100vw - 83.4vw) / 2));

--- a/libs/mep/ace1052/carousel/carousel.js
+++ b/libs/mep/ace1052/carousel/carousel.js
@@ -23,6 +23,7 @@ const KEY_CODES = {
   ARROW_LEFT: 'ArrowLeft',
   ARROW_RIGHT: 'ArrowRight',
 };
+const FOCUSABLE_SELECTOR = 'a, :not(.video-container, .pause-play-wrapper) > video';
 
 function decorateNextPreviousBtns() {
   const previousBtn = createTag(
@@ -200,6 +201,36 @@ function setIndicatorMultiplyer(carouselElements, activeSlideIndicator, event) {
   }
 }
 
+function updateAriaLive(ariaLive, slide) {
+  let text = '';
+  slide.querySelectorAll(':scope > :not(.section-metadata').forEach((el, index) => {
+    text += `${index ? ' ' : ''}${el.textContent.trim()}`;
+  });
+  if (text) {
+    ariaLive.textContent = text;
+  } else {
+    const el = slide.querySelector('img[alt], video[title], iframe[title]');
+    ariaLive.textContent = el?.getAttribute('alt') || el?.getAttribute('title') || '';
+  }
+}
+
+function setAriaHiddenAndTabIndex({ el: block, slides }, activeEl) {
+  const active = activeEl ?? block.querySelector('.carousel-slide.active');
+  const activeIdx = slides.findIndex((el) => el === active);
+  const isWide = window.matchMedia('(min-width: 900px)').matches;
+  const showClass = [...block.classList].find((cls) => cls.startsWith('show-'));
+  const visible = isWide && showClass ? showClass.split('-')[1] : 1;
+  const ordered = activeIdx > 0
+    ? [...slides.slice(activeIdx), ...slides.slice(0, activeIdx)] : slides;
+  ordered.forEach((slide, i) => {
+    const isVisible = i < visible;
+    slide.setAttribute('aria-hidden', !isVisible);
+    slide.querySelectorAll(FOCUSABLE_SELECTOR).forEach((el) => {
+      el.setAttribute('tabindex', isVisible ? 0 : -1);
+    });
+  });
+}
+
 function moveSlides(event, carouselElements, jumpToIndex) {
   const {
     slideContainer,
@@ -208,8 +239,11 @@ function moveSlides(event, carouselElements, jumpToIndex) {
     slideIndicators,
     controlsContainer,
     direction,
+    ariaLive,
     jumpTo,
   } = carouselElements;
+
+  ariaLive.textContent = '';
 
   let referenceSlide = slideContainer.querySelector('.reference-slide');
   let activeSlide = slideContainer.querySelector('.active');
@@ -229,7 +263,6 @@ function moveSlides(event, carouselElements, jumpToIndex) {
   referenceSlide.classList.remove('reference-slide');
   referenceSlide.style.order = null;
   activeSlide.classList.remove('active');
-  activeSlide.querySelectorAll('a, video').forEach((focusableElement) => focusableElement.setAttribute('tabindex', -1));
   activeSlideIndicator.classList.remove('active');
   if (jumpTo) activeSlideIndicator.setAttribute('tabindex', -1);
 
@@ -278,12 +311,11 @@ function moveSlides(event, carouselElements, jumpToIndex) {
   referenceSlide.classList.add('reference-slide');
   referenceSlide.style.order = '1';
 
+  updateAriaLive(ariaLive, activeSlide);
+
   // Update active slide and indicator dot attributes
   activeSlide.classList.add('active');
-  const indexOfActive = [...activeSlide.parentElement.children]
-    .findIndex((ele) => activeSlide.isSameNode(ele));
-  const IndexOfShowClass = [...carouselElements.el.classList].findIndex((ele) => ele.includes('show-'));
-  const tempSlides = [...slides.slice(indexOfActive), ...slides.slice(0, indexOfActive)];
+  setAriaHiddenAndTabIndex(carouselElements, activeSlide);
 
   // mweb Update heights dynamically
   if (carouselElements.el.classList.contains('disable-buttons') && window.innerWidth < 900) {
@@ -299,20 +331,6 @@ function moveSlides(event, carouselElements, jumpToIndex) {
     });
   }
 
-  if (IndexOfShowClass >= 0) {
-    const show = parseInt(carouselElements.el.classList[IndexOfShowClass].split('-')[1], 10);
-    tempSlides.forEach((slide, index) => {
-      let tabIndex = -1;
-      if (index < show) {
-        tabIndex = 0;
-      }
-      slide.querySelectorAll('a,:not(.video-container, .pause-play-wrapper) > video')
-        .forEach((focusableElement) => { focusableElement.setAttribute('tabindex', tabIndex); });
-    });
-  } else {
-    activeSlide.querySelectorAll('a,:not(.video-container, .pause-play-wrapper) > video')
-      .forEach((focusableElement) => { focusableElement.setAttribute('tabindex', 0); });
-  }
   activeSlideIndicator.classList.add('active');
   if (jumpTo) activeSlideIndicator.setAttribute('tabindex', 0);
   setIndicatorMultiplyer(carouselElements, activeSlideIndicator, event);
@@ -497,6 +515,11 @@ export default function init(el) {
   convertMpcMp4(slides);
   fragment.append(...slides);
   const slideWrapper = createTag('div', { class: 'carousel-wrapper' });
+  const ariaLive = createTag('div', {
+    class: 'aria-live-container',
+    'aria-live': 'polite',
+  });
+  slideWrapper.appendChild(ariaLive);
   const slideContainer = createTag('div', { class: 'carousel-slides' }, fragment);
   const carouselElements = {
     el,
@@ -507,6 +530,7 @@ export default function init(el) {
     controlsContainer,
     direction: undefined,
     jumpTo,
+    ariaLive,
   };
 
   if (el.classList.contains('lightbox')) {
@@ -548,12 +572,6 @@ export default function init(el) {
   parentArea.addEventListener(MILO_EVENTS.DEFERRED, handleDeferredImages, true);
 
   slides[0].classList.add('active');
-  const IndexOfShowClass = [...el.classList].findIndex((ele) => ele.includes('show-'));
-  let NoOfVisibleSlides = 1;
-  if (IndexOfShowClass >= 0) {
-    NoOfVisibleSlides = parseInt(el.classList[IndexOfShowClass].split('-')[1], 10);
-  }
-  slides.slice(NoOfVisibleSlides).forEach((slide) => slide.querySelectorAll('a').forEach((focusableElement) => { focusableElement.setAttribute('tabindex', -1); }));
   // ##mweb## Update button states after slide movement for mweb
   function handleEqualHeight() {
     setEqualHeight(slides);
@@ -565,6 +583,9 @@ export default function init(el) {
     parentArea.addEventListener(MILO_EVENTS.DEFERRED, handleEqualHeight, true);
   }
   handleChangingSlides(carouselElements);
+
+  setAriaHiddenAndTabIndex(carouselElements, slides[0]);
+  window.addEventListener('resize', () => setAriaHiddenAndTabIndex(carouselElements));
 
   function handleLateLoadingNavigation() {
     [...el.querySelectorAll('.is-delayed')].forEach((item) => item.classList.remove('is-delayed'));

--- a/libs/mep/ace1052/notification/notification.css
+++ b/libs/mep/ace1052/notification/notification.css
@@ -458,7 +458,7 @@
   display: flex;
   width: auto;
   height: var(--icon-size-xs);
-  min-width: unset;
+  min-width: var(--icon-size-xs);
   max-width: unset;
 }
 
@@ -466,7 +466,7 @@
   width: 100%;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
-  z-index: var(--modal-z-index);
+  z-index: 102;
 }
 
 .notification-curtain {
@@ -476,7 +476,7 @@
   bottom: 0;
   left: 0;
   background: rgb(50 50 50 / 80%);
-  z-index: var(--modal-z-index-curtain);
+  z-index: 101;
 }
 
 /* mweb-test: notification sticky CTA */

--- a/libs/mep/ace1052/section-metadata/section-metadata.css
+++ b/libs/mep/ace1052/section-metadata/section-metadata.css
@@ -205,7 +205,7 @@
 
 .section.sticky-bottom.promo-sticky-section {
   background: none;
-  z-index: 4; 
+  z-index: 4;
 }
 
 .section.sticky-bottom.popup,
@@ -215,6 +215,10 @@
 
 .section.sticky-bottom:has(.notification.split) {
   bottom: 5px;
+}
+
+.section.sticky-bottom:has(.notification.split.focus) {
+  bottom: 0;
 }
 
 .section[class*='grid-width-'] {
@@ -244,7 +248,6 @@ main > .section[class*='-up'] > .content {
   display: grid;
 }
 
-.fill-sticky-section > div.notification.pill,
 .fill-sticky-section > div.aside.promobar {
   width: 100%;
   border-radius: 0;
@@ -262,7 +265,16 @@ main > .section[class*='-up'] > .content {
   }
 
   .section[class*='grid-width-'] {
-    display: block;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+@media (min-width: 600px) {
+  .fill-sticky-section > div.notification.pill {
+    width: 100%;
+    border-radius: 0;
+    max-width: unset;
   }
 
 }
@@ -271,15 +283,15 @@ main > .section[class*='-up'] > .content {
   .section.five-up {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
-  
+
   .section.one-up-tablet { grid-template-columns: 1fr; }
   .section.three-up-tablet { grid-template-columns: repeat(3, 1fr); }
   .section.four-up-tablet { grid-template-columns: repeat(4, 1fr); }
 
   .section.masonry-layout {
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  }  
-  
+  }
+
   .section.masonry-layout .grid-full-width {
     grid-column: 1 / -1;
   }
@@ -344,12 +356,12 @@ main > .section[class*='-up'] > .content {
   .section.grid-template-columns-3-1 {
     grid-template-columns: 3fr 1fr;
   }
-  
+
   .section.grid-width-6-desktop {
     padding-left: var(--grid-margins-width-6);
     padding-right: var(--grid-margins-width-6);
   }
-  
+
   .section.grid-width-8-desktop {
     padding-left: var(--grid-margins-width-8);
     padding-right: var(--grid-margins-width-8);

--- a/libs/mep/ace1052/tabs/tabs.js
+++ b/libs/mep/ace1052/tabs/tabs.js
@@ -8,6 +8,7 @@ import { processTrackingLabels } from '../../../martech/attributes.js';
 const PADDLE = '<svg aria-hidden="true" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M1.50001 13.25C1.22022 13.25 0.939945 13.1431 0.726565 12.9292C0.299315 12.5019 0.299315 11.8096 0.726565 11.3823L5.10938 7L0.726565 2.61768C0.299315 2.19043 0.299315 1.49805 0.726565 1.0708C1.15333 0.643068 1.84669 0.643068 2.27345 1.0708L7.4297 6.22656C7.63478 6.43164 7.75001 6.70996 7.75001 7C7.75001 7.29004 7.63478 7.56836 7.4297 7.77344L2.27345 12.9292C2.06007 13.1431 1.7798 13.2495 1.50001 13.25Z" fill="currentColor"/></svg>';
 const tabColor = {};
 const linkedTabs = {};
+const tabChangeEvent = new Event('milo:tab:changed');
 
 const isTabInTabListView = (tab) => {
   const tabList = tab.closest('[role="tablist"], [role="radiogroup"]');
@@ -97,6 +98,7 @@ function changeTabs(e) {
     .forEach((p) => p.setAttribute('hidden', true));
   targetContent?.removeAttribute('hidden');
   if (tabsBlock.classList.contains('stacked-mobile')) scrollStackedMobile(targetContent);
+  window.dispatchEvent(tabChangeEvent);
 }
 
 function getStringKeyName(str) {

--- a/libs/mep/ace1052/text/text.css
+++ b/libs/mep/ace1052/text/text.css
@@ -289,7 +289,7 @@
   width: 100%;
 }
 
-.section[class*="-up"] .text-block:not(.legal, .link-farm) .foreground > div {
+.section[class*="-up"] .text-block:not(.legal, .link-farm) .foreground > div:not(:has(> strong)) {
   display: flex;
   flex-direction: column;
   width: 100%;


### PR DESCRIPTION
As the title says, this aims to apply all the recent stage changes to the blocks that have been edited for the purposes of the mweb test. These updates include important accessibility and layout updates.

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/ps-product-page-v2?milolibs=mweb-dev&georouting=off
- After: https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/ps-product-page-v2?milolibs=mweb-tweaks--milo--overmyheadandbody&georouting=off


