### PR TITLE
MWPW-174737 Skip validation for "dueDate" during rollout workflow

### DIFF
--- a/libs/blocks/locui-create/input-urls/index.js
+++ b/libs/blocks/locui-create/input-urls/index.js
@@ -54,7 +54,7 @@ export function validateForm({
   if (name.length > 50) {
     errors.name = 'Project name is too long. Please ensure it is no more than 50 characters.';
   }
-  if (type === 'rollout' && editBehavior === '') {
+  if (type === PROJECT_TYPES.rollout && editBehavior === '') {
     errors.editBehavior = 'Edit behavior is required';
   }
   if (urlsStr === '') {
@@ -63,7 +63,7 @@ export function validateForm({
   if (fragmentsEnabled && noOfValidFrag > 0 && fragments.length === 0) {
     errors.fragments = 'Select atleast one fragment to proceed further';
   }
-  if (new Date(`${dueDate}Z`) < new Date()) {
+  if (type === PROJECT_TYPES.translation && new Date(`${dueDate}Z`) < new Date()) {
     errors.dueDate = 'Please select a future date and time';
   }
   return errors;


### PR DESCRIPTION
Validated that now, "dueDate" is correctly getting skipped during rollout workflow

**_Rollout Workflow_** (check for due-date is getting skipped)
![fix_rollout_check](https://github.com/user-attachments/assets/8b12ca29-ca69-46f4-9bf7-c396fc720d65)


**_Translation Workflow_** (check for due-date is performed)
![val_translation_check](https://github.com/user-attachments/assets/b8ad54be-95a1-47ec-9405-248d3bbc028a)


Resolves: [MWPW-174737](https://jira.corp.adobe.com/browse/MWPW-174737)

**Test URLs:**
- Before: https://milostudio-dev--milo--adobecom.aem.page/tools/locui-create?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&env=local&workflow=normal
- After: https://mwpw-174737-validation-form-field--milo--nkthakur48.aem.page/tools/locui-create?ref=main&repo=milo&owner=adobecom&host=milo.adobe.com&project=Milo&env=local&workflow=normal
