### PR TITLE
ServiceNow CMR Fixes - [MWPW=173724]

### DIFF
--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -1,10 +1,27 @@
-import requests
-import time
 import datetime
-import random
 import json
 import os
+import random
 import sys
+import time
+import requests
+
+APPLICATION_JSON = "application/json"
+CMR_RETRIEVAL_ERROR = "CMR ID Retrieval Operation failed..."
+POST_FAILURE_MESSAGE = "POST failed with response code: "
+#IMS_URL = 'https://ims-na1.adobelogin.com/ims/token'
+IMS_URL = 'https://ims-na1-stg1.adobelogin.com/ims/token'
+#SERVICENOW_CMR_URL = 'https://ipaasapi.adobe-services.com/change_management/changes'
+SERVICENOW_CMR_URL = 'https://ipaasapi-stage.adobe-services.com/change_management/changes'
+#SERVICENOW_GET_CMR_URL = 'https://ipaasapi.adobe-services.com/change_management/transactions/'
+SERVICENOW_GET_CMR_URL = 'https://ipaasapi-stage.adobe-services.com/change_management/transactions/'
+
+def _search_value(value, target_string):
+  if isinstance(value, str):
+    return target_string in value
+  if isinstance(value, (dict, list)):
+    return find_string_in_json(value, target_string)
+  return False
 
 def find_string_in_json(json_data, target_string):
   """
@@ -14,25 +31,13 @@ def find_string_in_json(json_data, target_string):
       json_data (dict or list): The JSON data to search.
       target_string (str): The string to find.
 
-  Returns:
-      bool: True if the string is found, False otherwise.
-  """
-
+    Returns:
+        bool: True if the string is found, False otherwise.
+    """
   if isinstance(json_data, dict):
-      for key, value in json_data.items():
-          if isinstance(value, str) and target_string in value:
-              return True
-          elif isinstance(value, (dict, list)):
-              if find_string_in_json(value, target_string):
-                  return True
-  elif isinstance(json_data, list):
-      for item in json_data:
-          if isinstance(item, str) and target_string in item:
-              return True
-          elif isinstance(item, (dict, list)):
-              if find_string_in_json(item, target_string):
-                  return True
-
+    return any(_search_value(value, target_string) for value in json_data.values())
+  if isinstance(json_data, list):
+    return any(_search_value(item, target_string) for item in json_data)
   return False
 
 def backoff_with_timeout(operation, max_retries=5, base_delay=1, max_delay=60, timeout=300):
@@ -55,24 +60,28 @@ def backoff_with_timeout(operation, max_retries=5, base_delay=1, max_delay=60, t
       _type_: The return value from the sent in operation that requires a smart backoff.
   """
 
-  start_time = time.time()
+  start_time_timer = time.time()
   attempts = 0
-  while attempts <= max_retries and (time.time() - start_time) < timeout:
-      try:
-          print("Attempting ServiceNow API operation...")
-          return operation()  # Attempt the operation
-      except Exception as e:
-          attempts += 1
-          if attempts > max_retries or (time.time() - start_time) >= timeout:
-              raise  # Re-raise the exception if max retries or timeout is reached
+  while attempts <= max_retries and (time.time() - start_time_timer) < timeout:
+    try:
+      print("Attempting ServiceNow API operation...")
+      return operation()  # Attempt the operation
+    except:
+      attempts += 1
 
-          delay = min(base_delay * (2 ** (attempts - 1)), max_delay) + random.uniform(0, 0.1 * base_delay)
-          time.sleep(delay)
-  raise TimeoutError("Operation timed out after {} seconds or {} retries, whatever came first.".format(timeout, max_retries))
+      if attempts > max_retries or (time.time() - start_time_timer) >= timeout:
+          raise  # Re-raise the exception if max retries or timeout is reached
+
+      delay = min(base_delay * (2 ** (attempts - 1)), max_delay) + random.uniform(0, 0.1 * base_delay)
+      time.sleep(delay)
+  raise TimeoutError(f"Operation timed out after {timeout} seconds or {max_retries} retries, whatever came first.")
 
 def get_cmr_id_operation():
   """
   Operation to retrieve a Change Management Request ID from ServiceNow
+
+  Args:
+      url (str): The API GET Request URL to retrieve the Change Management Request ID from ServiceNow
 
   Raises:
       Exception: If the GET request returns a non 200 response.
@@ -83,47 +92,49 @@ def get_cmr_id_operation():
       _type_: The Change ID from the JSON payload
   """
   response = requests.get(servicenow_get_cmr_url, headers=headers)
-  JSON_PARSE = json.loads(response.text)
+  json_parse = json.loads(response.text)
 
   if response.status_code != 200:
-    print("GET failed with response code: ", response.status_code)
+    print(f"GET failed with response code: {response.status_code}")
     print(response.text)
-    raise Exception("CMR ID Retrieval Operation failed...")
-  elif find_string_in_json(JSON_PARSE, "error"):
-    print("CMR ID retrieval failed with response code: ", response.status_code)
+    raise requests.exceptions.RequestException(CMR_RETRIEVAL_ERROR)
+  elif find_string_in_json(json_parse, "error"):
+    print(f"CMR ID retrieval failed with response code: {response.status_code}")
     print(response.text)
-    raise Exception("CMR ID Retrieval Operation failed...")
+    raise requests.exceptions.RequestException(CMR_RETRIEVAL_ERROR)
   else:
-    if find_string_in_json(JSON_PARSE, "Unknown"):
-      print("CMR ID retrieval failed with response code: ", response.status_code)
+    if find_string_in_json(json_parse, "Unknown"):
+      print(f"CMR ID retrieval failed with response code: {response.status_code}")
       print(response.text)
-      raise Exception("CMR ID Retrieval Operation failed...")
+      raise requests.exceptions.RequestException(CMR_RETRIEVAL_ERROR)
 
-    print("CMR ID retrieval was successful: ", response.status_code)
+    print(f"CMR ID retrieval was successful: {response.status_code}")
     print(response.text)
 
-  return JSON_PARSE["result"]["changeId"]
+  return json_parse["result"]["changeId"]
 
 # Execute Script logic:
 # python3 servicenow.py
 if __name__ == "__main__":
-
   print("Starting CMR Action...")
 
   print("Setting Planned Maintenance Time Windows for CMR...")
-  start_time = (datetime.datetime.now() + datetime.timedelta(seconds = 10)).timestamp()
-  end_time = (datetime.datetime.now() + datetime.timedelta(minutes = 10)).timestamp()
+  start_time = int((datetime.datetime.now() + datetime.timedelta(seconds = 10)).timestamp())
+  end_time = int((datetime.datetime.now() + datetime.timedelta(minutes = 10)).timestamp())
+
+  print(f"Set start time for CMR: {start_time}")
+  print(f"Set end time for CMR: {end_time}")
 
   print("Set Release Summary for CMR...")
   release_title = os.environ['PR_TITLE']
   release_details = os.environ['PR_BODY']
   pr_num = os.environ['PR_NUMBER']
+  pr_link = os.environ['PR_LINK']
   pr_created = os.environ['PR_CREATED_AT']
   pr_merged = os.environ['PR_MERGED_AT']
-  release_summary = f"Release_Details: {release_details} \n\nPull Request Number: {pr_num} \nPull Request Created At: {pr_created} \nPull Request Merged At: {pr_merged}"
+  release_summary = f"Release_Details: {release_details} \n\nPull Request Number: {pr_num} \nPull Request Link: {pr_link} \nPull Request Created At: {pr_created} \nPull Request Merged At: {pr_merged}"
 
   print("Getting IMS Token")
-  ims_url = 'https://ims-na1.adobelogin.com/ims/token'
   headers = {"Content-Type":"multipart/form-data"}
   data = {
     'client_id': os.environ['IMSACCESS_CLIENT_ID'],
@@ -131,34 +142,33 @@ if __name__ == "__main__":
     'grant_type': "authorization_code",
     'code': os.environ['IMSACCESS_AUTH_CODE']
   }
-  response = requests.post(ims_url, data=data)
-  jsonParse = json.loads(response.text)
+  response = requests.post(IMS_URL, data=data)
+  json_parse = json.loads(response.text)
 
   if response.status_code != 200:
-    print("POST failed with response code: ", response.status_code)
+    print(f"{POST_FAILURE_MESSAGE} {response.status_code}")
     print(response.text)
     sys.exit(1)
-  elif find_string_in_json(jsonParse, "error"):
-    print("IMS token request failed with response code: ", response.status_code)
+  elif find_string_in_json(json_parse, "error"):
+    print(f"IMS token request failed with response code: {response.status_code}")
     print(response.text)
     sys.exit(1)
   else:
-    print("IMS token request was successful: ", response.status_code)
-    token = jsonParse["access_token"]
+    print(f"IMS token request was successful: {response.status_code}")
+    token = json_parse["access_token"]
 
   print("Create CMR in ServiceNow...")
 
-  servicenow_cmr_url = 'https://ipaasapi.adobe-services.com/change_management/changes'
   headers = {
-    "Accept":"application/json",
+    "Accept": APPLICATION_JSON,
     "Authorization":token,
-    "Content-Type":"application/json",
+    "Content-Type": APPLICATION_JSON,
     "api_key":os.environ['IPAAS_KEY']
   }
   data = {
     "title":release_title,
     "description":release_summary,
-    "instanceIds": [ 537445 ],
+    "instanceIds": [ os.environ['SNOW_INSTANCE_ID'] ],
     "plannedStartDate": start_time,
     "plannedEndDate": end_time,
     "coordinator": "narcis@adobe.com",
@@ -171,27 +181,27 @@ if __name__ == "__main__":
     "implementationPlan": "The change will be released as part of the continuous deployment of Milo's production branch, i.e., \"main\"",
     "backoutPlan": "Revert merge to the Milo production branch by creating a revert commit.", "testResults": "Changes are tested and validated successfully in staging environment. Please see the link of the PR in the description for the test results and/or the \"#nala-test-results\" slack channel."
   }
-  response = requests.post(servicenow_cmr_url, headers=headers, json=data)
-  jsonParse = json.loads(response.text)
+  response = requests.post(SERVICENOW_CMR_URL, headers=headers, json=data)
+  json_parse = json.loads(response.text)
 
   if response.status_code != 200:
-    print("POST failed with response code: ", response.status_code)
+    print(f"{POST_FAILURE_MESSAGE} {response.status_code}")
     print(response.text)
     sys.exit(1)
-  elif find_string_in_json(jsonParse, "error"):
-    print("CMR creation failed with response code: ", response.status_code)
+  elif find_string_in_json(json_parse, "error"):
+    print(f"CMR creation failed with response code: {response.status_code}")
     print(response.text)
     sys.exit(1)
   else:
-    print("CMR creation was successful: ", response.status_code)
+    print(f"CMR creation was successful: {response.status_code}")
     print(response.text)
-    transaction_id = jsonParse["id"]
+    transaction_id = json_parse["id"]
 
   print("Waiting for Transaction from Queue to ServiceNow then Retrieve CMR ID...")
 
-  servicenow_get_cmr_url = f'https://ipaasapi.adobe-services.com/change_management/transactions/{transaction_id}'
+  servicenow_get_cmr_url = f'{SERVICENOW_GET_CMR_URL}{transaction_id}'
   headers = {
-    "Accept":"application/json",
+    "Accept": APPLICATION_JSON,
     "Authorization":token,
     "api_key":os.environ['IPAAS_KEY']
   }
@@ -200,22 +210,22 @@ if __name__ == "__main__":
   time.sleep(10)
 
   try:
-      cmr_id = backoff_with_timeout(get_cmr_id_operation, max_retries=15, base_delay=1, max_delay=60, timeout=120)
-      print("CMR ID found and validated: ", cmr_id)
+    cmr_id = backoff_with_timeout(get_cmr_id_operation(), max_retries=300, base_delay=1, max_delay=60, timeout=3600)
+    print(f"CMR ID found and validated: {cmr_id}")
   except Exception as e:
-      print("All CMR ID retrieval attempts failed: ", e)
-      sys.exit(1)
+    print(f"All CMR ID retrieval attempts failed: {e}")
+    cmr_id = None
 
   print("Setting Actual Maintenance Time Windows for CMR...")
-  actual_start_time = (datetime.datetime.now() - datetime.timedelta(seconds = 10)).timestamp()
-  actual_end_time = datetime.datetime.now().timestamp()
+  actual_start_time = int((datetime.datetime.now() - datetime.timedelta(seconds = 10)).timestamp())
+  actual_end_time = int(datetime.datetime.now().timestamp())
 
   print("Closing CMR in ServiceNow...")
 
   headers = {
-    "Accept":"application/json",
+    "Accept": APPLICATION_JSON,
     "Authorization":token,
-    "Content-Type":"application/json",
+    "Content-Type": APPLICATION_JSON,
     "api_key":os.environ['IPAAS_KEY']
   }
   data = {
@@ -226,20 +236,24 @@ if __name__ == "__main__":
     "closeCode": "Successful",
     "notes": "The change request is closed as the change was released successfully"
   }
-  response = requests.post(servicenow_cmr_url, headers=headers, json=data)
-  jsonParse = json.loads(response.text)
+  response = requests.post(SERVICENOW_CMR_URL, headers=headers, json=data)
+  json_parse = json.loads(response.text)
 
   if response.status_code != 200:
-    print("POST failed with response code: ", response.status_code)
+    print(f"{POST_FAILURE_MESSAGE} {response.status_code}")
     print(response.text)
     sys.exit(1)
-  elif find_string_in_json(jsonParse, "error"):
-    print("CMR closure failed with response code: ", response.status_code)
+  elif find_string_in_json(json_parse, "error"):
+    print(f"CMR closure failed with response code: {response.status_code}")
     print(response.text)
     sys.exit(1)
   else:
-    print("CMR closure was successful: ", response.status_code)
+    print(f"CMR closure was successful: {response.status_code}")
     print(response.text)
 
-  print("Change Management Request in ServiceNow was successful.")
-  print ("You can find the change record in ServiceNow https://adobe.service-now.com/now/change-launchpad/homepage, by searching for this ID: ", cmr_id)
+  print("Change Management Request has been sent to the queue and is being processed.")
+  print(f"You can find the change record in ServiceNow https://adobe.service-now.com/now/change-launchpad/homepage, by searching for this ID: {cmr_id}")
+  print("")
+  print(f"If the CMR ID is not found, search for the change record in ServiceNow by the planned start time {datetime.datetime.fromtimestamp(start_time)} and/or planned end time {datetime.datetime.fromtimestamp(end_time)}.")
+  print("")
+  print(f"If all else fails, please check the ServiceNow queue for transaction ID '{transaction_id}' and validate that the CMR was created successfully by reaching out to the Change Management team in the #unified-change-management-support slack channel.")

--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -6,6 +6,7 @@ import sys
 import time
 import requests
 
+# Global Variables
 APPLICATION_JSON = "application/json"
 CMR_RETRIEVAL_ERROR = "CMR ID Retrieval Operation failed..."
 POST_FAILURE_MESSAGE = "POST failed with response code: "

--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -6,7 +6,6 @@ import sys
 import time
 import requests
 
-# Global Variables
 APPLICATION_JSON = "application/json"
 CMR_RETRIEVAL_ERROR = "CMR ID Retrieval Operation failed..."
 POST_FAILURE_MESSAGE = "POST failed with response code: "

--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -6,8 +6,6 @@ import sys
 import time
 import requests
 
-# Global Variables
-
 APPLICATION_JSON = "application/json"
 CMR_RETRIEVAL_ERROR = "CMR ID Retrieval Operation failed..."
 POST_FAILURE_MESSAGE = "POST failed with response code: "

--- a/.github/workflows/servicenow.py
+++ b/.github/workflows/servicenow.py
@@ -6,6 +6,8 @@ import sys
 import time
 import requests
 
+# Global Variables
+
 APPLICATION_JSON = "application/json"
 CMR_RETRIEVAL_ERROR = "CMR ID Retrieval Operation failed..."
 POST_FAILURE_MESSAGE = "POST failed with response code: "

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -4,25 +4,27 @@
 name: Create CMR in ServiceNow
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:
-      - main
+      - servicenow-cmr-test
 
 permissions:
   contents: read
 
 env:
   IMSACCESS_CLIENT_ID: ${{ secrets.IMSACCESS_CLIENT_ID }}
-  IMSACCESS_CLIENT_SECRET: ${{ secrets.IMSACCESS_CLIENT_SECRET_PROD }}
-  IMSACCESS_AUTH_CODE: ${{ secrets.IMSACCESS_AUTH_CODE_PROD }}
-  IPAAS_KEY: ${{ secrets.IPAAS_KEY_PROD }}
+  IMSACCESS_CLIENT_SECRET: ${{ secrets.IMSACCESS_CLIENT_SECRET_STAGE }}
+  IMSACCESS_AUTH_CODE: ${{ secrets.IMSACCESS_AUTH_CODE_STAGE }}
+  IPAAS_KEY: ${{ secrets.IPAAS_KEY_STAGE }}
+  SNOW_INSTANCE_ID: ${{ secrets.SNOW_INSTANCE_ID }}
   PR_TITLE: ${{ github.event.pull_request.title }}
   PR_BODY: ${{ github.event.pull_request.body }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
   PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
   PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
+  PR_LINK: ${{ github.event.pull_request.html_url }}
 
 jobs:
   build:

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -83,7 +83,7 @@ jobs:
         script: |
           const notifySnowCr = require('./.github/workflows/snow-cr-notification.js');
           if (process.env.PR_STATE == 'open') {
-            await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: null, planned_start_time:  null, planned_end_time: null });
+            await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: null, planned_start_time:  process.env.PLANNED_START_TIME, planned_end_time: process.env.PLANNED_END_TIME });
           } else {
             await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: process.env.CHANGE_ID, planned_start_time: process.env.PLANNED_START_TIME, planned_end_time: process.env.PLANNED_END_TIME });
           }

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -6,6 +6,7 @@ name: Create CMR in ServiceNow
 on:
   pull_request_target:
     types:
+      - opened
       - closed
     branches:
       - servicenow-cmr-test
@@ -25,12 +26,19 @@ env:
   PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
   PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
   PR_LINK: ${{ github.event.pull_request.html_url }}
+  PR_STATE: ${{ github.event.pull_request.state }}
+  MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}
 
 jobs:
-  build:
-    # Only run this workflow on pull requests that have merged and not manually closed by user
-    if: github.event.pull_request.merged == true
+  create-cmr:
+    # Only run this workflow on pull requests that have been newly opened
+    if:  ${{ (github.event.pull_request.merged == true || github.event.pull_request.state == 'open') && (github.event.pull_request.base.ref == 'stage' || github.event.pull_request.base.ref == 'main') }}
     runs-on: ubuntu-latest
+    outputs:
+      TRANSACTION_ID: ${{ steps.create-cmr.outputs.transaction_id }}
+      CHANGE_ID: ${{ steps.create-cmr.outputs.change_id }}
+      PLANNED_START_TIME: ${{ steps.create-cmr.outputs.planned_start_time }}
+      PLANNED_END_TIME: ${{ steps.create-cmr.outputs.planned_end_time }}
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -41,6 +49,18 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip requests timedelta
+
     - name: Execute script for creating and closing CMR
       run: |
         python ./.github/workflows/servicenow.py
+
+    - name: Execute script for notifying of CMR state
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        script: |
+          const notifySnowCr = require('./.github/workflows/snow-cr-notification.js');
+          if (process.env.PR_STATE == 'open') {
+            await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: null, planned_start_time:  null, planned_end_time: null });
+          } else {
+            await notifySnowCr({ github, context, transaction_id: process.env.TRANSACTION_ID, change_id: process.env.CHANGE_ID, planned_start_time: process.env.PLANNED_START_TIME, planned_end_time: process.env.PLANNED_END_TIME });
+          }

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -15,11 +15,12 @@ permissions:
   contents: read
 
 env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IMSACCESS_CLIENT_ID: ${{ secrets.IMSACCESS_CLIENT_ID }}
   IMSACCESS_CLIENT_SECRET: ${{ secrets.IMSACCESS_CLIENT_SECRET_STAGE }}
   IMSACCESS_AUTH_CODE: ${{ secrets.IMSACCESS_AUTH_CODE_STAGE }}
   IPAAS_KEY: ${{ secrets.IPAAS_KEY_STAGE }}
-  SNOW_INSTANCE_ID: ${{ secrets.SNOW_INSTANCE_ID }}
+  MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}
   PR_TITLE: ${{ github.event.pull_request.title }}
   PR_BODY: ${{ github.event.pull_request.body }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -27,12 +28,12 @@ env:
   PR_MERGED_AT: ${{ github.event.pull_request.merged_at }}
   PR_LINK: ${{ github.event.pull_request.html_url }}
   PR_STATE: ${{ github.event.pull_request.state }}
-  MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}
+  SNOW_INSTANCE_ID: ${{ secrets.SNOW_INSTANCE_ID }}
 
 jobs:
   create-cmr:
     # Only run this workflow on pull requests that have been newly opened
-    if:  ${{ (github.event.pull_request.merged == true || github.event.pull_request.state == 'open') && (github.event.pull_request.base.ref == 'stage' || github.event.pull_request.base.ref == 'main') }}
+    if:  ${{ (github.event.pull_request.merged == true || github.event.pull_request.state == 'open') }}
     runs-on: ubuntu-latest
     outputs:
       TRANSACTION_ID: ${{ steps.create-cmr.outputs.transaction_id }}
@@ -50,9 +51,31 @@ jobs:
       run: |
         python -m pip install --upgrade pip requests timedelta
 
+    - name: Retrieve transaction ID from PR Comments
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        script: |
+          const main = require('./.github/workflows/snow-pr-comment.js')
+          if (process.env.PR_STATE == 'closed') {
+            main({ github, context })
+          } else {
+            console.log('PR is not in an closed state. Skipping...');
+          }
+
     - name: Execute script for creating and closing CMR
       run: |
         python ./.github/workflows/servicenow.py
+
+    - name: Save transaction ID in PR Comments
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        script: |
+          const main = require('./.github/workflows/snow-pr-comment.js')
+          if (process.env.PR_STATE == 'open') {
+            main({ github, context })
+          } else {
+            console.log('PR is not in an opened state. Skipping...');
+          }
 
     - name: Execute script for notifying of CMR state
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea

--- a/.github/workflows/snow-cr-notification.js
+++ b/.github/workflows/snow-cr-notification.js
@@ -21,8 +21,8 @@ async function main({ github, context, transaction_id, change_id, planned_start_
     const { number, title, html_url } = pull_request;
     const isOpen = process.env.PR_STATE === 'open';
     const prefix = isOpen
-        ? ':exclamation: ServiceNow Change Request Created and in progress: Transaction ID: ' + transaction_id + '\n:'
-        : ':exclamation: ServiceNow Change Request Closed: Search for Change Record by Change ID: ' + change_id + '\n or Planned Start Time: ' + planned_start_time + '\n and/or Planned End Time: ' + planned_end_time + '\n:';
+        ? ':exclamation: TESTING ServiceNow Change Request Created and in progress: Transaction ID: ' + transaction_id + '\n:'
+        : ':exclamation: TESTING ServiceNow Change Request Closed: Search for Change Record by Change ID: ' + change_id + '\n or Planned Start Time: ' + planned_start_time + '\n and/or Planned End Time: ' + planned_end_time + '\n:';
 
     console.log(`Sending SNOW CR notification for PR #${number}: ${title}`);
 

--- a/.github/workflows/snow-cr-notification.js
+++ b/.github/workflows/snow-cr-notification.js
@@ -1,0 +1,40 @@
+const { slackNotification, getLocalConfigs } = require('./helpers.js');
+
+async function main({ github, context, transaction_id, change_id, planned_start_time, planned_end_time } = {}) {
+    if (!github || !context) {
+        throw new Error("GitHub context is missing. Ensure you are running in the correct environment.");
+    }
+
+    if (process.env.LOCAL_RUN) {
+        console.log("Local run detected. Loading local configurations...");
+        const localConfigs = getLocalConfigs();
+        github = localConfigs.github;
+        context = localConfigs.context;
+    }
+
+    const { pull_request } = context.payload;
+    if (!pull_request) {
+        console.log("No pull_request found in context payload. Skipping notification.");
+        return;
+    }
+
+    const { number, title, html_url } = pull_request;
+    const isOpen = process.env.PR_STATE === 'open';
+    const prefix = isOpen
+        ? ':exclamation: ServiceNow Change Request Created: Transaction ID: ' + transaction_id + '\n:'
+        : ':exclamation: ServiceNow Change Request Closed: Search for Change Record by Change ID: ' + change_id + '\n or Planned Start Time: ' + planned_start_time + '\n and/or Planned End Time: ' + planned_end_time + '\n:';
+
+    console.log(`Sending SNOW CR notification for PR #${number}: ${title}`);
+
+    await slackNotification(
+        `${prefix} <${html_url}|#${number}: ${title}>.`,
+        process.env.MILO_RELEASE_SLACK_WH
+    );
+}
+
+if (process.env.LOCAL_RUN) {
+    const { github, context } = getLocalConfigs();
+    main({ github, context });
+}
+
+module.exports = main;

--- a/.github/workflows/snow-cr-notification.js
+++ b/.github/workflows/snow-cr-notification.js
@@ -21,7 +21,7 @@ async function main({ github, context, transaction_id, change_id, planned_start_
     const { number, title, html_url } = pull_request;
     const isOpen = process.env.PR_STATE === 'open';
     const prefix = isOpen
-        ? ':exclamation: ServiceNow Change Request Created: Transaction ID: ' + transaction_id + '\n:'
+        ? ':exclamation: ServiceNow Change Request Created and in progress: Transaction ID: ' + transaction_id + '\n:'
         : ':exclamation: ServiceNow Change Request Closed: Search for Change Record by Change ID: ' + change_id + '\n or Planned Start Time: ' + planned_start_time + '\n and/or Planned End Time: ' + planned_end_time + '\n:';
 
     console.log(`Sending SNOW CR notification for PR #${number}: ${title}`);

--- a/.github/workflows/snow-pr-comment.js
+++ b/.github/workflows/snow-pr-comment.js
@@ -1,0 +1,77 @@
+// Run from the root of the project for local testing: node --env-file=.env .github/workflows/pr-reminders.js
+const { getLocalConfigs } = require('./helpers.js');
+const { fs } = require('fs');
+
+const main = async ({ github, context }) => {
+  const comment = async ({ pr_number, message, comments, transaction_id }) => {
+    if (comments.some((c) => c.body.includes(message))) {
+      console.log(
+        `SNOW Transaction Comment exists. Commenting skipped... ${message}`
+      );
+      return;
+    }
+    process.env.LOCAL_RUN
+      ? console.log(
+          `PR #${pr_number} Local execution commenting SKIPPED message for SNOW Transaction ID ${transaction_id}: ${message}`
+        )
+      : await github.rest.issues
+          .createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr_number,
+            body: message,
+          })
+          .then(() => console.log(`PR #${pr_number} Commented for SNOW Transaction ID ${transaction_id}: ${message}`))
+          .catch(console.error);
+  };
+
+  try {
+    const { data: comments } = await github.rest.issues.listComments({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: process.env.PR_NUMBER,
+    });
+
+    if (process.env.PR_STATE !== 'open') {
+      let foundTransactionId = false;
+      for await (const singleComment of comments) {
+        if (singleComment.body.includes("SNOW Change Request Transaction ID: ")) {
+          console.log(`Found SNOW Transaction ID Comment. Assigning transaction ID for closing SNOW Change Request...`);
+          foundTransactionId = true;
+          const transaction_id = singleComment.body.split("SNOW Change Request Transaction ID: ")[1].trim();
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `TRANSACTION_ID=${transaction_id}\n`);
+          break;
+        }
+      }
+      if (!foundTransactionId) {
+        console.log(`No SNOW Transaction ID Comment found. Skipping...`);
+        return;
+      }
+    }
+    else if (process.env.TRANSACTION_ID) {
+      comment({
+        pr_number: process.env.PR_NUMBER,
+        comments,
+        transaction_id: process.env.TRANSACTION_ID,
+        message:
+          'SNOW Change Request Transaction ID: ' + process.env.TRANSACTION_ID,
+      });
+    }
+    else {
+      console.log(`No SNOW Transaction ID found. Can't make PR comment. Skipping...`);
+      return;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+if (process.env.LOCAL_RUN) {
+  const { github, context } = getLocalConfigs();
+  main({
+    github,
+    context,
+  });
+}
+
+module.exports = main;


### PR DESCRIPTION
Fixes these issues:

- ServiceNow Registry InstanceID that was retired has now been changed to correct ID
- Back-off timer has been updated to have an hour timeout since in high peak times the Kafka queue for the SNOW Change Request API may take a long time to complete requests.
- GitHub action only runs when merges are closed against the production branch. This now includes branches from forks being directly merged into the production branch for hot-fixes.
- Fixed API payload values for planned start and end time to be whole integers rather than timestamp floats.

Enhancements:

- Leveraging Python F-strings where needed
- Cleaned up functions to follow linting rules
- Updated release summary information for Change Requests to include PR URLs.
- Updated print statements to provide clarity for instructions for finding Change Requests (CRs) and/or debugging when a CR isn't found.
- Slack notification with CR information

Resolves: MWPW-173724

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://servicenow-cmr-MWPW-173724--milo--adobecom.aem.page/?martech=off