### PR TITLE
Minor editorial card adjustment

### DIFF
--- a/libs/mep/ace1052/editorial-card/editorial-card.css
+++ b/libs/mep/ace1052/editorial-card/editorial-card.css
@@ -25,13 +25,6 @@
   border-color: var(--color-gray-700);
 }
 
-  /* Block specific */
-.light .editorial-card,
-.editorial-card.light {
-  color: var(--text-color);
-  border-color: var(--color-gray-300);
-}
-
 .editorial-card.no-bg { background: none;}
 .editorial-card.no-border { border: none;}
 
@@ -373,6 +366,12 @@
 }
 
 /* Mweb specific */
+.light .editorial-card,
+.editorial-card.light {
+  color: var(--text-color);
+  border-color: var(--color-gray-300);
+}
+
 @media screen and (max-width: 599px) {
   /* General */
   :root {
@@ -391,6 +390,7 @@
     font-weight: 500;
   }
 
+  /* Block specific */
   .section:has(.editorial-card ~ .show-more-button),
   .section.show-all:has(.editorial-card) {
     margin-inline: var(--spacing-xs);


### PR DESCRIPTION
Minor text reformatting for editorial cards, functionality is not changed. Having all changes grouped together at the end of the file makes things a lot simpler when merging with the original code where the blocks have been copied from.

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/ps-product-page-v2?milolibs=mweb-dev&georouting=off
- After: https://main--cc--adobecom.aem.page/drafts/ramuntea/mweb/ps-product-page-v2?milolibs=mweb-tweaks--milo--overmyheadandbody&georouting=off

