### PR TITLE
MWPW-174664: updates mapping file URL: hlx > aem, page > live

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -204,6 +204,12 @@ export const loadStrings = async (
   try {
     const locale = getPageLocale(pathname, locales);
     const localizedURL = new URL(url);
+    if (localizedURL.hostname.includes('.hlx.')) {
+      localizedURL.hostname = localizedURL.hostname.replace('.hlx.', '.aem.');
+    }
+    if (localizedURL.hostname.endsWith('.page')) {
+      localizedURL.hostname = localizedURL.hostname.replace(/.page$/, '.live');
+    }
     if (locale) {
       localizedURL.pathname = `${locale}${localizedURL.pathname}`;
     }


### PR DESCRIPTION
Description:

This PR fixes an issued caused by many of the mapping files being loaded via .hlx.live or .hlx.page. 
This will need to load from .aem.live as the hlx domain is being decommissioned.  

Additionally, some of the mapping files are attempting to load via .page which throws a permission denied error.

Resolves: [MWPW-174664](https://jira.corp.adobe.com/browse/MWPW-174664)

Test URL:
 - https://mwpw-174664--milo--adobecom.aem.page/drafts/cmiqueo/test-page


