### PR TITLE
Update SharePoint video play button focus color

### DIFF
--- a/libs/styles/consonant-play-button.css
+++ b/libs/styles/consonant-play-button.css
@@ -15,6 +15,7 @@
   --play-triangle-height-m: 32px;
   --play-triangle-width-l: 40px;
   --play-triangle-height-l: 42px;
+  --play-focus-color: #DEDEF9;
 }
 
  .modal-img-link {
@@ -59,7 +60,7 @@
   outline: var(--play-border-width-l) solid var(--color-black);
   outline-offset: 0;
   background-color: rgb(0 0 0 / 100%);
-  border: 3px solid var(--link-color-dark);
+  border: 3px solid var(--play-focus-color);
   transition: border .2s ease-out, outline .1s ease-out;
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Updates the SharePoint video poster play button focus color to white from blue.

Resolves: [MWPW-170522](https://jira.corp.adobe.com/browse/MWPW-170522)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/drafts/rclayton/poster-play-button?martech=off
- After: https://play-icon-focus-update--milo--adobecom.hlx.page/drafts/rclayton/poster-play-button?martech=off

![image](https://github.com/user-attachments/assets/1f2856af-965b-4374-b913-bf2b24907ca6)


