### PR TITLE
[MWPW-173863] - table inside tab expand fix

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -10,7 +10,6 @@ const MOBILE_SIZE = 768;
 const tableHighlightLoadedEvent = new Event('milo:table:highlight:loaded');
 const tabChangeEvent = 'milo:tab:changed';
 let tableIndex = 0;
-let isExpandEventsAssigned = false;
 
 const isMobileLandscape = () => (window.matchMedia('(orientation: landscape)').matches && window.innerHeight <= MOBILE_SIZE);
 function defineDeviceByScreenSize() {
@@ -243,10 +242,7 @@ function handleExpand(e) {
 }
 
 function setExpandEvents(el) {
-  if (isExpandEventsAssigned) return;
-
   el.querySelectorAll('.icon.expand').forEach((icon) => {
-    isExpandEventsAssigned = true;
     icon.parentElement.classList.add('point-cursor');
     icon.parentElement.addEventListener('click', () => handleExpand(icon));
     icon.parentElement.setAttribute('tabindex', 0);


### PR DESCRIPTION
Fixes an issue where we have tabs and in each tab we have a table, when going to the 2nd tab and trying to expand a row from the table, the row wouldn't expand.

Resolves: [MWPW-173863](https://jira.corp.adobe.com/browse/MWPW-173863)

**Ticket Use Case Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/dusan/table-in-tab-expand?martech=off
- After: https://table-inside-tab-expand--milo--adobecom.aem.page/drafts/dusan/table-in-tab-expand?martech=off

**Table kitchen sink Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off
- After: https://table-inside-tab-expand--milo--adobecom.aem.page/docs/library/kitchen-sink/table?martech=off


