### PR TITLE
MWPW-174735 [Milo][Analytics] Tabs do not have a daa-lh attribute on the block

### DIFF
--- a/libs/martech/attributes.js
+++ b/libs/martech/attributes.js
@@ -86,7 +86,7 @@ export async function decorateSectionAnalytics(section, idx, config) {
   document.querySelector('main')?.setAttribute('daa-im', 'true');
   section.setAttribute('daa-lh', id);
   section.querySelectorAll('[data-block]:has([data-block])').forEach((block) => {
-    block.removeAttribute('data-block');
+    if (!block.classList.contains('tabs')) block.removeAttribute('data-block');
   });
   const mepMartech = config?.mep?.martech || '';
   section.querySelectorAll('[data-block]').forEach((block, blockIdx) => {


### PR DESCRIPTION
The decorateSectionAnalytics function is skipping over the tabs block when adding the main, block-level daa-lh value because it (and Milo generally) does not expect blocks to exist within blocks. This PR adds the daa-lh value to tabs by making an exception for the tabs block.

Resolves: [MWPW-174735](https://jira.corp.adobe.com/browse/MWPW-174735)

Steps to QA:
check before and after links below for the daa-lh value for tabs.
Expected (After): daa-lh --> 'b1|tabs|nopzn|plans-pzn'
Actual (Before): no daa-lh value

![Screenshot 2025-06-11 at 4 31 26 PM](https://github.com/user-attachments/assets/ac7678e0-1260-4de8-a408-94b125757164)


**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/creativecloud/plans
- After: https://main--cc--adobecom.aem.page/creativecloud/plans?milolibs=tabanalytics
- Psi-check: https://tabanalytics--milo--adobecom.aem.page/?martech=off

