### PR TITLE
[MWPW-174878] Fix intermittent issue of incorrect link transformation shown on hover in language selector

### DIFF
--- a/libs/blocks/language-selector/language-selector.js
+++ b/libs/blocks/language-selector/language-selector.js
@@ -376,12 +376,13 @@ function setupDropdownEvents({
       const path = href.replace(window.location.origin + (hasPrefix ? currentPrefix : ''), '').replace('#langnav', '');
       const newPath = lang.prefix ? `/${lang.prefix}${path}` : path;
       const fullUrl = `${window.location.origin}${newPath}`;
+      const langLink = li.querySelector('a.language-link');
+      if (langLink) langLink.href = fullUrl;
       handleEvent({
         prefix: lang.prefix,
         link: { href: fullUrl },
         callback: (url) => {
-          const langLink = li.querySelector('a.language-link');
-          if (langLink) langLink.href = url;
+          if (langLink && langLink.href !== url) langLink.href = url;
         },
       });
     }


### PR DESCRIPTION
* Fix intermittent issue of incorrect link transformation shown only on hover in language selector

Resolves: [MWPW-174878](https://jira.corp.adobe.com/browse/MWPW-174878)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ruchika/language/document1?martech=off
- After: https://mwpw-169805--milo--adobecom.aem.page/drafts/ruchika/language/document1?martech=off


News
- Before: https://main--news--adobecom.hlx.page/drafts/ruchika/lang-selector?milolibs=stage&martech=off
- After: https://main--news--adobecom.hlx.page/drafts/ruchika/lang-selector?milolibs=MWPW-169805&martech=off
