### PR TITLE
MWPW-174943 The old gnav doesn't show up on blog.adobe.com

### DIFF
--- a/libs/blocks/gnav/gnav.js
+++ b/libs/blocks/gnav/gnav.js
@@ -671,6 +671,7 @@ export default async function init(header) {
     header.dispatchEvent(initEvent);
     header.setAttribute('daa-im', 'true');
     header.setAttribute('daa-lh', `gnav${name}`);
+    header.classList.remove('gnav-hide');
     return gnav;
   } catch (e) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* The the old gnav also relied on the `hide-gnav` class.
* The removal of the `hide-gnav` class is now done inside gnav.js

Resolves: [MWPW-174943](https://jira.corp.adobe.com/browse/MWPW-174943)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://old-gnav-fix--milo--adobecom.aem.page/?martech=off
