### PR TITLE
[MWPW-174951] Allow centered text block link for mweb

### DIFF
--- a/libs/mep/ace1052/text/text.css
+++ b/libs/mep/ace1052/text/text.css
@@ -396,7 +396,7 @@
   }
 
   /* Block specific */
-  .text.text-block.center {
+  .text.text-block.center:not(:has(a:only-child:not(.con-button))) {
     text-align: start;
   }
 


### PR DESCRIPTION
This excludes simple single non-CTA links inside centered-content text blocks from being automatically left-aligned.

Resolves: [MWPW-174951](https://jira.corp.adobe.com/browse/MWPW-174951)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/cc-shared/fragments/tests/2025/q2/ace1052/ace1052-mweb-ps-free-trial-download?milolibs=mweb-dev&mep=/drafts/ramuntea/mweb/ps-product-mweb-pzn.json&georouting=off
- After: https://main--cc--adobecom.aem.page/cc-shared/fragments/tests/2025/q2/ace1052/ace1052-mweb-ps-free-trial-download?milolibs=mweb-tweaks--milo--overmyheadandbody&mep=/drafts/ramuntea/mweb/ps-product-mweb-pzn.json&georouting=off


