### PR TITLE
[MWPW-173101][NALA] Automation test script for ReadingTime block

### DIFF
--- a/nala/blocks/reading-time/reading-time.page.js
+++ b/nala/blocks/reading-time/reading-time.page.js
@@ -1,0 +1,45 @@
+export default class ReadingTimeBlock {
+  constructor(page) {
+    this.page = page;
+
+    this.readingTime = this.page.locator('.reading-time.content');
+    this.media = this.page.locator('.media');
+    this.foregroundImage = this.page.locator('.container.foreground .media-row .image');
+    this.image = this.page.locator('.media-row .image img');
+    this.marquee = this.page.locator('.marquee.small.light');
+
+    this.detailM = this.page.locator('.detail-m');
+    this.headingXL = this.page.locator('.heading-xl');
+    this.bodyM = this.page.locator('.body-m');
+    this.outlineButtonL = this.page.locator('.con-button.outline.button-l');
+    this.blueButtonL = this.page.locator('.con-button.blue.button-l');
+    this.assetImage = this.page.locator('.asset.image img');
+
+    this.attributes = {
+      'foreground.image': {
+        foregroundImg: {
+          loading: 'eager',
+          fetchpriority: 'high',
+          width: '400',
+          height: '300',
+        },
+      },
+      'asset.image': {
+        assetImg: {
+          loading: 'eager',
+          fetchpriority: 'high',
+          width: '600',
+          height: '300',
+        },
+      },
+    };
+  }
+
+  async getReadingText() {
+    return this.readingTime.innerText();
+  }
+
+  async getContentText() {
+    return this.page.locator('body').innerText();
+  }
+}

--- a/nala/blocks/reading-time/reading-time.spec.js
+++ b/nala/blocks/reading-time/reading-time.spec.js
@@ -1,0 +1,34 @@
+module.exports = {
+  name: 'Reading-time Block',
+  features: [
+    {
+      tcid: '0',
+      name: 'Reading-time block',
+      path: '/drafts/nala/blocks/reading-time/reading-time-block',
+      data: { timeText: '0 min read' },
+      tags: 'reading-time @smoke @regression @milo',
+    },
+    {
+      tcid: '1',
+      name: 'Reading-time without text',
+      path: '/drafts/nala/blocks/reading-time/reading-time-withouttext',
+      tags: 'reading-time @smoke @regression @milo',
+    },
+    {
+      tcid: '2',
+      name: 'Reading-time with text',
+      path: '/drafts/nala/blocks/reading-time/reading-time-text',
+      data: {
+        detailText: 'Detail',
+        h2Text: 'Heading XL Marquee standard small light',
+        h3Text: 'Text (inset, large, m spacing)',
+        bodyText: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.',
+        bodyTextL: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ut nisl vitae urna volutpat tincidunt ac in mauris. In hac habitasse platea dictumst. Integer vel tempus nisi.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation. ',
+        listItemsText: 'Lorem ipsum dolor sit amet.',
+        outlineButtonText: 'Lorem ipsum',
+        blueButtonText: 'Call to action',
+      },
+      tags: 'reading-time @smoke @regression @milo',
+    },
+  ],
+};

--- a/nala/blocks/reading-time/reading-time.test.js
+++ b/nala/blocks/reading-time/reading-time.test.js
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/test';
+import WebUtil from '../../libs/webutil.js';
+import { features } from './reading-time.spec.js';
+import ReadingTimeBlock from './reading-time.page.js';
+import { runAccessibilityTest } from '../../libs/accessibility.js';
+
+let readingTime;
+let webUtil;
+
+const miloLibs = process.env.MILO_LIBS || '';
+
+test.describe('Reading-time feature test suite', () => {
+  test.beforeEach(async ({ page }) => {
+    readingTime = new ReadingTimeBlock(page);
+    webUtil = new WebUtil(page);
+  });
+
+  test(`[Test Id - ${features[0].tcid}] ${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+    console.info(`[Test Page]: ${baseURL}${features[0].path}${miloLibs}`);
+    const { data } = features[0];
+    await test.step('step-1: Go to Reading-time feature test page', async () => {
+      await page.goto(`${baseURL}${features[0].path}${miloLibs}`);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(`${baseURL}${features[0].path}${miloLibs}`);
+    });
+
+    await test.step('step-2: Verify Reading-time specs', async () => {
+      await expect(await readingTime.readingTime).toBeVisible();
+      await expect(await readingTime.readingTime).toContainText(data.timeText);
+    });
+
+    await test.step('step-3: Verify analytics attributes', async () => {
+      await expect(readingTime.readingTime).toHaveAttribute('daa-lh', 'b1|reading-time');
+    });
+
+    await test.step('step-4: Verify the accessibility test on Reading-time block', async () => {
+      await runAccessibilityTest({ page, testScope: readingTime.readingTime, skipA11yTest: true });
+    });
+  });
+
+  test(`[Test Id - ${features[1].tcid}] ${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
+    console.info(`[Test Page]: ${baseURL}${features[1].path}${miloLibs}`);
+    await test.step('step-1: Go to Reading-time without text test page', async () => {
+      await page.goto(`${baseURL}${features[1].path}${miloLibs}`);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(`${baseURL}${features[1].path}${miloLibs}`);
+    });
+
+    await test.step('step-2: Verify Reading-time without text specs', async () => {
+      await expect(await readingTime.readingTime).toBeVisible();
+      const actual = parseInt((await readingTime.getReadingText()).split(' ')[0], 10);
+      const contentText = await readingTime.getContentText();
+      const wordCount = contentText.trim().split(/\s+/).length;
+      const expected = Math.ceil(wordCount / 200);
+      expect(Math.abs(actual - expected)).toBeLessThanOrEqual(1);
+      await expect(await readingTime.media).toBeVisible();
+      await expect(await readingTime.foregroundImage).toBeVisible();
+    });
+
+    await test.step('step-3: Verify analytics attributes', async () => {
+      await expect(readingTime.readingTime).toHaveAttribute('daa-lh', 'b1|reading-time');
+      expect(await webUtil.verifyAttributes(readingTime.image, readingTime.attributes['foreground.image'].foregroundImg)).toBeTruthy();
+    });
+
+    await test.step('step-4: Verify the accessibility test on Reading-time without text block', async () => {
+      await runAccessibilityTest({ page, testScope: readingTime.readingTime, skipA11yTest: true });
+    });
+  });
+
+  test(`[Test Id - ${features[2].tcid}] ${features[2].name},${features[2].tags}`, async ({ page, baseURL }) => {
+    console.info(`[Test Page]: ${baseURL}${features[2].path}${miloLibs}`);
+    const { data } = features[2];
+
+    await test.step('step-1: Go to Reading-time with text test page', async () => {
+      await page.goto(`${baseURL}${features[2].path}${miloLibs}`);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(`${baseURL}${features[2].path}${miloLibs}`);
+    });
+
+    await test.step('step-2: Verify Reading-time with text specs', async () => {
+      await expect(await readingTime.readingTime).toBeVisible();
+      await expect(await readingTime.detailM).toContainText(data.detailText);
+      await expect(await readingTime.headingXL).toContainText(data.h2Text);
+      await expect(await readingTime.bodyM).toContainText(data.bodyText);
+      await expect(await readingTime.outlineButtonL).toContainText(data.outlineButtonText);
+      await expect(await readingTime.blueButtonL).toContainText(data.blueButtonText);
+
+      const actual = parseInt((await readingTime.getReadingText()).split(' ')[0], 10);
+      const contentText = await readingTime.getContentText();
+      const wordCount = contentText.trim().split(/\s+/).length;
+      const expected = Math.ceil(wordCount / 200);
+      expect(Math.abs(actual - expected)).toBeLessThanOrEqual(1);
+
+      for (const sectionId of ['s2', 's3', 's4', 's5']) {
+        const section = readingTime.page.locator(`.section[daa-lh="${sectionId}"]`);
+        const heading = section.locator('h3.heading-l');
+        await expect(heading).toContainText(data.h3Text);
+        const paragraphs = section.locator('p.body-l');
+        await expect(paragraphs.nth(0)).toContainText(data.bodyTextL);
+        await expect(paragraphs.nth(1)).toContainText(data.bodyTextL);
+        const listItems = section.locator('ul.body-l > li');
+        await expect(listItems).toHaveCount(3);
+        for (let i = 0; i < 3; i++) {
+          await expect(listItems.nth(i)).toContainText(data.listItemsText);
+        }
+      }
+    });
+
+    await test.step('step-3: Verify analytics attributes', async () => {
+      await expect(readingTime.readingTime).toHaveAttribute('daa-lh', 'b1|reading-time');
+      expect(await webUtil.verifyAttributes(readingTime.assetImage, readingTime.attributes['asset.image'].assetImg)).toBeTruthy();
+    });
+
+    await test.step('step-4: Verify the accessibility test on Reading-time with text block', async () => {
+      await runAccessibilityTest({ page, testScope: readingTime.readingTime, skipA11yTest: true });
+    });
+  });
+});


### PR DESCRIPTION
This PR include automation scripts for different variants of the ReadingTime block
Test pages for ReadingTime block variants [ReadingTime block](https://adobe.sharepoint.com/sites/adobecom/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fadobecom%2FShared%20Documents%2Fmilo%2Fdrafts%2Fnala%2Fblocks%2Freading%2Dtime&viewid=d776cf70%2D9b7e%2D4ab7%2Db9da%2D9e0f8e03a7d2&newTargetListUrl=%2Fsites%2Fadobecom%2FShared%20Documents&viewpath=%2Fsites%2Fadobecom%2FShared%20Documents%2FForms%2FAllItems%2Easpx)
Tests are successfully running as part of the Nala CI/CD pipeline
Test scripts validate ReadingTime block across Chrome, Firefox, and Webkit browsers

Resolves: [MWPW-173101](https://jira.corp.adobe.com/browse/MWPW-173101)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-173101-nala-reading-time-block--milo--adobecom.aem.page/?martech=off
