### PR TITLE
[MWPW-174861] - table heading content height increase fix

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -110,14 +110,17 @@ function handleEqualHeight(table, tag) {
   columns.forEach(({ children }) => {
     [...children].forEach((row, i) => {
       row.style.height = 'auto';
-      if (!height[i] || row.offsetHeight > height[i]) {
-        height[i] = row.offsetHeight;
-      }
+      const style = window.getComputedStyle(row);
+      const actualHeight = row.clientHeight
+       - parseFloat(style.paddingTop)
+       - parseFloat(style.paddingBottom);
+
+      if (!height[i] || actualHeight > height[i]) height[i] = actualHeight;
     });
   });
   columns.forEach(({ children }) => {
     [...children].forEach((row, i) => {
-      row.style.minHeight = height[i] > 0 ? `${height[i]}px` : 'unset';
+      if (row.clientHeight > 0) row.style.minHeight = height[i] > 0 ? `${height[i]}px` : 'unset';
     });
   });
 }


### PR DESCRIPTION
Resolves: [MWPW-174861](https://jira.corp.adobe.com/browse/MWPW-174861)

**QA Note**
The following PR https://github.com/adobecom/milo/pull/4042 should also be tested as this issue was introduced there and we still need to keep what that PR fixed in terms of accessibility.

**Test URLs for https://github.com/adobecom/milo/pull/4042:**
- Before: https://main--cc--adobecom.aem.page/products/photoshop-lightroom/plans
- After: https://main--cc--adobecom.aem.page/products/photoshop-lightroom/plans?milolibs=table-res-heading-fix

**1st & 2nd use case Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/dusan/table-in-tab-expand?martech=off
- After: https://table-res-heading-fix--milo--adobecom.aem.page/drafts/dusan/table-in-tab-expand?martech=off

**3d use case Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/dusan/mobile-scroll-table-height-fix
- After: https://table-res-heading-fix--milo--adobecom.aem.page/drafts/dusan/mobile-scroll-table-height-fix



