### PR TITLE
iphone flicker

### DIFF
--- a/libs/utils/fonts.js
+++ b/libs/utils/fonts.js
@@ -14,7 +14,7 @@ function dynamicTypekit(kitId, d = document) {
  *
  * @param {Object} locale the locale details
  */
-export default function loadFonts(locale, loadStyle) {
+export default function loadFonts(locale, loadLink) {
   const tkSplit = locale.tk.split('.');
   // Add preload for Typekit resources
   const preloadLink = document.createElement('link');
@@ -23,11 +23,12 @@ export default function loadFonts(locale, loadStyle) {
   preloadLink.href = `https://use.typekit.net/${locale.tk}`;
   preloadLink.crossOrigin = 'anonymous';
   document.head.appendChild(preloadLink);
-  if (tkSplit[1] === 'css') {
-    return new Promise((resolve) => {
-      loadStyle(`https://use.typekit.net/${locale.tk}`, resolve);
-    });
-  }
-  // eslint-disable-next-line consistent-return
-  return dynamicTypekit(locale.tk);
+
+  preloadLink.onload = () => {
+    if (tkSplit[1] === 'css') {
+      loadLink(`https://use.typekit.net/${locale.tk}`, { rel: 'stylesheet' });
+    } else {
+      dynamicTypekit(locale.tk);
+    }
+  };
 }

--- a/libs/utils/fonts.js
+++ b/libs/utils/fonts.js
@@ -1,3 +1,5 @@
+import { loadLink } from "./utils";
+
 // A gently modified version of the dynamic subsetting loader from Adobe Fonts
 function dynamicTypekit(kitId, d = document) {
   const config = { kitId, scriptTimeout: 3000, async: true };
@@ -14,12 +16,12 @@ function dynamicTypekit(kitId, d = document) {
  *
  * @param {Object} locale the locale details
  */
-export default function loadFonts(locale, loadStyle) {
+export default function loadFonts(locale) {
   const tkSplit = locale.tk.split('.');
   if (tkSplit[1] === 'css') {
-    return new Promise((resolve) => {
-      loadStyle(`https://use.typekit.net/${locale.tk}`, resolve);
-    });
+    loadLink(`https://use.typekit.net/${locale.tk}`, { rel: 'stylesheet' });
+    return;
   }
+  // eslint-disable-next-line consistent-return
   return dynamicTypekit(locale.tk);
 }

--- a/libs/utils/fonts.js
+++ b/libs/utils/fonts.js
@@ -16,6 +16,13 @@ function dynamicTypekit(kitId, d = document) {
  */
 export default function loadFonts(locale, loadLink) {
   const tkSplit = locale.tk.split('.');
+  // Add preload for Typekit resources
+  const preloadLink = document.createElement('link');
+  preloadLink.rel = 'preload';
+  preloadLink.as = tkSplit[1] === 'css' ? 'style' : 'script';
+  preloadLink.href = `https://use.typekit.net/${locale.tk}`;
+  preloadLink.crossOrigin = 'anonymous';
+  document.head.appendChild(preloadLink);
   if (tkSplit[1] === 'css') {
     loadLink(`https://use.typekit.net/${locale.tk}`, { rel: 'stylesheet' });
     return;

--- a/libs/utils/fonts.js
+++ b/libs/utils/fonts.js
@@ -1,5 +1,3 @@
-import { loadLink } from "./utils";
-
 // A gently modified version of the dynamic subsetting loader from Adobe Fonts
 function dynamicTypekit(kitId, d = document) {
   const config = { kitId, scriptTimeout: 3000, async: true };
@@ -16,7 +14,7 @@ function dynamicTypekit(kitId, d = document) {
  *
  * @param {Object} locale the locale details
  */
-export default function loadFonts(locale) {
+export default function loadFonts(locale, loadLink) {
   const tkSplit = locale.tk.split('.');
   if (tkSplit[1] === 'css') {
     loadLink(`https://use.typekit.net/${locale.tk}`, { rel: 'stylesheet' });

--- a/libs/utils/fonts.js
+++ b/libs/utils/fonts.js
@@ -14,7 +14,7 @@ function dynamicTypekit(kitId, d = document) {
  *
  * @param {Object} locale the locale details
  */
-export default function loadFonts(locale, loadLink) {
+export default function loadFonts(locale, loadStyle) {
   const tkSplit = locale.tk.split('.');
   // Add preload for Typekit resources
   const preloadLink = document.createElement('link');
@@ -24,8 +24,9 @@ export default function loadFonts(locale, loadLink) {
   preloadLink.crossOrigin = 'anonymous';
   document.head.appendChild(preloadLink);
   if (tkSplit[1] === 'css') {
-    loadLink(`https://use.typekit.net/${locale.tk}`, { rel: 'stylesheet' });
-    return;
+    return new Promise((resolve) => {
+      loadStyle(`https://use.typekit.net/${locale.tk}`, resolve);
+    });
   }
   // eslint-disable-next-line consistent-return
   return dynamicTypekit(locale.tk);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1492,7 +1492,7 @@ async function loadPostLCP(config) {
   }
   loadTemplate();
   const { default: loadFonts } = await import('./fonts.js');
-  loadFonts(config.locale, loadLink);
+  loadFonts(config.locale);
 
   if (config?.mep) {
     import('../features/personalization/personalization.js')

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1492,7 +1492,7 @@ async function loadPostLCP(config) {
   }
   loadTemplate();
   const { default: loadFonts } = await import('./fonts.js');
-  loadFonts(config.locale, loadLink);
+  loadFonts(config.locale, loadStyle);
 
   if (config?.mep) {
     import('../features/personalization/personalization.js')

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1492,7 +1492,7 @@ async function loadPostLCP(config) {
   }
   loadTemplate();
   const { default: loadFonts } = await import('./fonts.js');
-  loadFonts(config.locale);
+  loadFonts(config.locale, loadLink);
 
   if (config?.mep) {
     import('../features/personalization/personalization.js')

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1492,7 +1492,7 @@ async function loadPostLCP(config) {
   }
   loadTemplate();
   const { default: loadFonts } = await import('./fonts.js');
-  loadFonts(config.locale, loadStyle);
+  loadFonts(config.locale, loadLink);
 
   if (config?.mep) {
     import('../features/personalization/personalization.js')


### PR DESCRIPTION
Milo pages flashing occurs after initial load on Mobile Safari

 I have observed that the issue is happening because of late loading of adobe-fonts on safari. Initially, the browser loads the backup fonts and then loads the adobe fonts which is flickering the screen.
In fonts.js file I have observed that we are returning a promise. In loadStyle function, the code might be waiting for the callback to complete before proceeding. Even though we are returning the promise, we are not using it in utils.js. Instead, if we replace it directly with loadLink, it's not waiting for any callback and loads the fonts directly. The flickering issue is getting resolved.

Resolves: [[MWPW-169932](https://jira.corp.adobe.com/browse/MWPW-169932)](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/suhjain/m2-folder/carousel/photoshop-page
- After: https://iphone-flicker--milo--suhjainadobe.aem.page/drafts/suhjain/m2-folder/carousel/photoshop-page
















