### PR TITLE
MWPW-174568: [Preflight] Metadata on hover overlaps with navigation bar

### DIFF
--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -324,7 +324,7 @@ span.preflight-time {
 .tooltip:hover::after {
   opacity: 1;
   visibility: visible;
-  z-index: 9;
+  z-index: 3;
 }
 
 /* SEO */
@@ -822,7 +822,7 @@ img:hover ~ .picture-meta {
   position: fixed;
   border: 2px solid red;
   background-color: white;
-  z-index: 103;
+  z-index: 9;
   overflow: hidden;
   pointer-events: none;
   display: block;

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -324,7 +324,7 @@ span.preflight-time {
 .tooltip:hover::after {
   opacity: 1;
   visibility: visible;
-  z-index: 9;
+  z-index: 3;
 }
 
 /* SEO */
@@ -742,7 +742,7 @@ picture:has(.picture-meta) {
 picture:hover .picture-meta,
 img:hover ~ .picture-meta {
   opacity: 1;
-  z-index: 9;
+  z-index: 3;
 }
 
 .picture-meta > div,

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -324,7 +324,7 @@ span.preflight-time {
 .tooltip:hover::after {
   opacity: 1;
   visibility: visible;
-  z-index: 3;
+  z-index: 2;
 }
 
 /* SEO */
@@ -693,7 +693,7 @@ picture:has(.picture-meta) {
   font-weight: bold;
   font-size: 14px;
   line-height: 1.2;
-  z-index: 3;
+  z-index: 2;
   opacity: 0.7;
 }
 
@@ -822,7 +822,7 @@ img:hover ~ .picture-meta {
   position: fixed;
   border: 2px solid red;
   background-color: white;
-  z-index: 9;
+  z-index: 10;
   overflow: hidden;
   pointer-events: none;
   display: block;

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -324,7 +324,7 @@ span.preflight-time {
 .tooltip:hover::after {
   opacity: 1;
   visibility: visible;
-  z-index: 3;
+  z-index: 9;
 }
 
 /* SEO */
@@ -693,7 +693,7 @@ picture:has(.picture-meta) {
   font-weight: bold;
   font-size: 14px;
   line-height: 1.2;
-  z-index: 9;
+  z-index: 3;
   opacity: 0.7;
 }
 

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -822,7 +822,7 @@ img:hover ~ .picture-meta {
   position: fixed;
   border: 2px solid red;
   background-color: white;
-  z-index: 10;
+  z-index: 4;
   overflow: hidden;
   pointer-events: none;
   display: block;

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -742,7 +742,7 @@ picture:has(.picture-meta) {
 picture:hover .picture-meta,
 img:hover ~ .picture-meta {
   opacity: 1;
-  z-index: 19;
+  z-index: 9;
 }
 
 .picture-meta > div,


### PR DESCRIPTION
Since the navigation bar had a `z-index: 10`, i lowered the `z-index:` of the Metadata on hover so that it wouldnt show on top of the navigation bar when scrolling up

Resolves: [MWPW-174568](https://jira.corp.adobe.com/browse/MWPW-174568)

**Test URLs:**
- Before: https://main--bacom--adobecom.aem.page/sg/products/genstudio-for-performance-marketing
- After: https://mwpw-174568-metadata-overlaping--milo--skholkhojaev.aem.page/ 

**TEST Link:**
-  https://main--bacom--adobecom.aem.page/sg/products/genstudio-for-performance-marketing?milolibs=MWPW-174568-Metadata-overlaping--milo--skholkhojaev












