### PR TITLE
emea1443- Implement QA feedback

### DIFF
--- a/libs/mep/emea1443/content-toggle/content-toggle.js
+++ b/libs/mep/emea1443/content-toggle/content-toggle.js
@@ -105,10 +105,21 @@ function waitForMarqueeHeight() {
   });
 }
 
+function getHoverCaretHeight() {
+  if (document.querySelector('.feds-navLink--hoverCaret')) {
+    const navLinkHeight = document.querySelector('.feds-navLink--hoverCaret').getBoundingClientRect().height;
+    return navLinkHeight;
+  }
+  return 0;
+}
+
 function getElementsHeightBeforeMain() {
   const main = document.querySelector('main');
   if (!main) return 0;
-  const beforeMain = main.getBoundingClientRect().top - document.body.getBoundingClientRect().top;
+  let beforeMain = main.getBoundingClientRect().top - document.body.getBoundingClientRect().top;
+  if (document.querySelector('.feds-navLink--hoverCaret')) {
+    beforeMain -= document.querySelector('.global-navigation').getBoundingClientRect().height;
+  }
   return beforeMain;
 }
 
@@ -118,7 +129,7 @@ function setupStickyBehaviour() {
 
   let initialOffset;
   waitForMarqueeHeight().then((marqueeHeight) => {
-    toggleWrapper.closest('.section').style.top = `${marqueeHeight}px`;
+    toggleWrapper.closest('.section').style.top = `${marqueeHeight + getHoverCaretHeight()}px`;
     initialOffset = toggleWrapper.getBoundingClientRect().top + window.scrollY;
   });
 
@@ -129,7 +140,8 @@ function setupStickyBehaviour() {
         marqueeHeight = marquee.getBoundingClientRect().height;
       }
     });
-    toggleWrapper.closest('.section').setAttribute('style', `top: ${marqueeHeight}px`);
+
+    toggleWrapper.closest('.section').setAttribute('style', `top: ${marqueeHeight + getHoverCaretHeight()}px`);
 
     const { scrollY } = window;
 
@@ -168,7 +180,8 @@ export default async function decorate(block) {
         }
       });
     }
-
-    setupStickyBehaviour();
+    if (block.classList.contains('sticky')) {
+      setupStickyBehaviour();
+    }
   }
 }


### PR DESCRIPTION
* Fixed the sticky toggle behaviour
* Added in a class to enable/disable sticky to the content toggle

Resolves: [OPT-32781](https://jira.corp.adobe.com/browse/OPT-32781)

**Test URLs:**
- Before: https://www.adobe.com/uk/creativecloud/buy/students.html
- After: https://main--cc--adobecom.aem.page/uk/creativecloud/buy/students?mep=%2Fcc-shared%2Ffragments%2Ftests%2Femea-latam%2F2025%2Fq2%2Femea1443%2Fmep%2F1443-ste-mweb.json--target-organic&milolibs=emea1443-qa-fixes

PSI Check: https://emea1443-qa-fixes--milo--adobecom.aem.page/?martech=off
