### PR TITLE
Adding resize observer to support viewport change

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1160,6 +1160,7 @@ class Gnav {
     const { default: decorate } = await asideJsPromise;
     if (!decorate) return this.elements.aside;
     this.elements.aside = await decorate({ headerElem: this.block, fedsPromoWrapper, promoPath });
+    if (!(this.elements.aside instanceof HTMLElement)) return this.elements.aside;
     fedsPromoWrapper.append(this.elements.aside);
 
     const updateLayout = () => {
@@ -1178,12 +1179,12 @@ class Gnav {
 
     if (this.elements.aside.clientHeight > fedsPromoWrapper.clientHeight) {
       lanaLog({ message: 'Promo height is more than expected, potential CLS', tags: 'gnav-promo', errorType: 'i' });
-      updateLayout();
-
-      this.promoResizeObserver?.disconnect();
-      this.promoResizeObserver = new ResizeObserver(updateLayout);
-      this.promoResizeObserver.observe(this.elements.aside);
     }
+
+    this.promoResizeObserver?.disconnect();
+    this.promoResizeObserver = new ResizeObserver(updateLayout);
+    this.promoResizeObserver.observe(this.elements.aside);
+    updateLayout();
     performance.mark('Gnav-Aside-End');
     logPerformance('Gnav-Aside-Time', 'Gnav-Aside-Start', 'Gnav-Aside-End');
     return this.elements.aside;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding the resize observer of promo height change to support responsive view port changes.
* Note: This was reverted as it was failing when the promopath is present but is not a valid promo url. To handle this we are adding a check if the promo element is instance of HTMLElement and then only we will be adding the resize observer.
Reverted PR - https://github.com/adobecom/milo/pull/4388

Resolves: [MWPW-174961](https://jira.corp.adobe.com/browse/MWPW-174961)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-promo-height--milo--adobecom.aem.page/?martech=off
