### PR TITLE
[MWPW-175158] Adapt table addon color for a11y

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -552,9 +552,8 @@
   line-height: var(--type-body-xs-lh);
 }
 
-.table.has-addon .addon-promo,
-.table.has-addon .addon-promo a {
-  color: #2D9D78;
+.table.has-addon .addon-promo {
+  color: #05834E;
   font-size: var(--type-body-xs-size);
   line-height: var(--type-body-xs-lh);
   margin-bottom: var(--spacing-xxs);


### PR DESCRIPTION
This adapts the color of the add-on section of a table to meet minimum contrast requirements. As suggested by Consonant, the link color has also been reverted to being blue, so links follow a standard rule across our pages.

This is marked as high priority as it relates to accessibility, for which there is a tight deadline of June 28th. The JIRA story reflects its urgency as well.

Resolves: [MWPW-175158](https://jira.corp.adobe.com/browse/MWPW-175158)

**Test URLs:**
- Before (PSI): https://main--milo--overmyheadandbody.hlx.page/docs/library/kitchen-sink/table?martech=off&georouting=off
- After (PSI): https://table-green-fix--milo--overmyheadandbody.hlx.page/docs/library/kitchen-sink/table?martech=off&georouting=off
- Before (original issue): https://main--dc--adobecom.aem.live/acrobat/business/pricing-plans?martech=off&georouting=off
- After (original issue): https://main--dc--adobecom.aem.live/acrobat/business/pricing-plans?milolibs=table-green-fix--milo--overmyheadandbody&martech=off&georouting=off
