### PR TITLE
[MWPW-175193] Remove programmatic headings from table

### DIFF
--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -311,11 +311,6 @@ function handleSection(sectionParams) {
       handleTitleText(sectionHeadTitle);
       sectionHeadTitle.classList.add('section-head-title');
       sectionHeadTitle.setAttribute('role', 'rowheader');
-      const sectionHeadText = sectionHeadTitle.querySelector('.table-title-text');
-      if (sectionHeadText) {
-        sectionHeadText.setAttribute('role', 'heading');
-        sectionHeadText.setAttribute('aria-level', '4');
-      }
     }
 
     if (isCollapseTable) {


### PR DESCRIPTION
This is fundamentally a revert of https://github.com/adobecom/milo/pull/4276, for which a faulty fix was applied based on a wrong interpretation of a [JIRA requirement](https://jira.corp.adobe.com/browse/MWPW-174220#comment-48038978). The issue brought up in that story had been fixed in https://github.com/adobecom/milo/pull/4248 / https://jira.corp.adobe.com/browse/MWPW-171938 by @DKos95.

This is marked as high priority as it relates to accessibility, for which there is a tight deadline of June 28th. The JIRA story reflects its urgency as well.

Resolves: [MWPW-175193](https://jira.corp.adobe.com/browse/MWPW-175193)

**Test URLs:**
- Before (PSI): https://main--milo--overmyheadandbody.hlx.page/docs/library/kitchen-sink/table?martech=off&georouting=off
- After (PSI): https://faulty-table-headings--milo--overmyheadandbody.hlx.page/docs/library/kitchen-sink/table?martech=off&georouting=off
- Before (original issue): https://main--cc--adobecom.aem.live/creativecloud/business/teams/plans?georouting=off#get-business-features-with-creative-cloud-for-teams
- After (original issue): https://main--cc--adobecom.aem.live/creativecloud/business/teams/plans?milolibs=faulty-table-headings--milo--overmyheadandbody&martech=off&georouting=off#get-business-features-with-creative-cloud-for-teams




