### PR TITLE
MWPW-174864 | Center on mobile for center variant of notification

### DIFF
--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -85,6 +85,7 @@
 .notification.center .foreground > * {
   text-align: center;
   justify-content: center;
+  align-items: center;
 }
 
 .notification.pill .foreground {


### PR DESCRIPTION
Notification(ribbon, center) updated to center on mobile

Resolves: [MWPW-174864](https://jira.corp.adobe.com/browse/MWPW-174864)

**Test URLs:**
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/notification?martech=off
- After: https://mwpw-174864--milo--adobecom.hlx.page/docs/library/blocks/notification?martech=off

Test url - https://main--dc--adobecom.aem.page/drafts/vmorel/notification-ribbon?milolibs=mwpw-174864