### PR TITLE
MWPW-167847 Support .ing domains for LANA

### DIFF
--- a/libs/utils/lana.js
+++ b/libs/utils/lana.js
@@ -21,12 +21,14 @@
 
   function isProd() {
     const { host } = window.location;
-    if (host.substring(host.length - 10) === '.adobe.com'
-      && host.substring(host.length - 15) !== '.corp.adobe.com'
-      && host.substring(host.length - 16) !== '.stage.adobe.com') {
+
+    if (host.endsWith('.adobe.com')
+      && !host.endsWith('.corp.adobe.com')
+      && !host.endsWith('.stage.adobe.com')) {
       return true;
     }
-    return false;
+
+    return ['sign.ing', 'edit.ing'].includes(host);
   }
 
   function mergeOptions(op1, op2) {


### PR DESCRIPTION
* Support the DC's vanity domains: `sign.ing` and `edit.ing`.
* Refactor the conditions with `endsWith()`. It's short and clear.
* Web Test Runner can't mock window.location. No unit test coverage for the change. 

Resolves: [MWPW-167847](https://jira.corp.adobe.com/browse/MWPW-167847)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-167847--milo--adobecom.aem.page/?martech=off


