### PR TITLE
[OPT-32740] ACE1081 Homepage Product Showcase Variants

### DIFF
--- a/libs/mep/ace1081/aside/aside.css
+++ b/libs/mep/ace1081/aside/aside.css
@@ -1,0 +1,1290 @@
+.aside {
+  --min-height: 160px;
+
+  display: flex;
+  width: 100%;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.dark .aside,
+.aside.dark {
+  color: var(--color-white);
+}
+
+.aside p {
+  margin: 0;
+}
+
+.aside [class^="heading-"]:only-of-type,
+.aside [class^="heading-"]:last-of-type {
+  margin-bottom: var(--spacing-xs);
+}
+
+.aside:is(.promobar, .notification.extra-small, .notification.small) [class^="heading-"]:is(:only-of-type, :last-of-type) {
+  margin-bottom: 0;
+}
+
+.aside [class^="body-"] {
+  margin-bottom: var(--spacing-s);
+}
+
+.aside:not(.notification, .promobar) {
+  min-height: var(--min-height);
+}
+
+.aside.promobar [class^="body-"],
+.aside.notification.extra-small [class^="body-"] {
+  margin-bottom: 0;
+}
+
+.aside [class^="detail-"] {
+  margin-bottom: var(--spacing-xs);
+}
+
+.aside .title-l {
+  font-size: var(--type-body-m-size);
+  line-height: var(--type-body-m-lh);
+  font-weight: bold;
+  text-transform: none;
+  margin-bottom: var(--spacing-xs);
+}
+
+.aside.split picture {
+  display: flex;
+}
+
+.aside .split-image img,
+.aside .split-image video {
+  object-fit: cover;
+  min-height: 700px;
+  width: 100%;
+  height: 100%;
+}
+
+.aside .video-icon-container img.video-icon {
+  pointer-events: none;
+  position:absolute;
+  bottom: -15px;
+  right: 15px;
+  height: 50px;
+  width: auto;
+}
+
+.aside.notification .background img {
+  min-height: unset;
+}
+
+.aside .foreground.container {
+  display: flex;
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: var(--spacing-m);
+  padding: var(--spacing-xl) 0;
+  box-sizing: border-box;
+}
+
+.aside .foreground.container .text {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.aside.split .foreground.container .text {
+  margin: 0;
+  max-width: var(--grid-container-width);
+}
+
+.aside.media-top-mobile .foreground .image,
+.aside.media-top-mobile .split-image {
+  order: -1;
+}
+
+.aside.media-bottom-mobile .foreground .image,
+.aside.media-bottom-mobile .split-image {
+  order: 1;
+}
+
+.aside.simple .foreground.container .text {
+  margin-bottom: 80px;
+}
+
+.aside.notification .foreground.container .text {
+  max-width: none;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.aside .foreground.container .image {
+  position: relative;
+  display: flex;
+  width: 100%;
+}
+
+.aside .foreground.container > div {
+  flex-grow: 1;
+  flex-basis: 0;
+  min-width: 0;
+}
+
+.aside.notification .foreground.container > div {
+  flex-basis: 100%;
+}
+
+.aside.split .icon-stack-area li {
+  width: fit-content;
+  min-width: calc(50% - 6px);
+}
+
+.aside.split .icon-stack-area li,
+.aside.split .icon-stack-area li a {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: bold;
+}
+
+.aside.notification .foreground.container .text a {
+  white-space: nowrap;
+}
+
+.aside:not(.notification) .foreground.container .text > * {
+  width: 100%;
+}
+
+.aside .foreground.container .text .supplemental-text {
+  margin-top: var(--spacing-s);
+  margin-bottom: 0;
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+}
+
+.aside.promobar .promo-text .action-area {
+  flex-wrap: nowrap;
+  gap: var(--spacing-xs);
+}
+
+.aside.promobar .promo-text .action-area,
+.aside .foreground.container .text .action-area {
+  margin-bottom: 0;
+  display: flex;
+  gap: var(--spacing-s);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.aside.notification .icon-area {
+  display: flex;
+  align-items: center;
+}
+
+.aside:not(.notification, .promobar) .foreground.container .icon-area:not(.con-button) {
+  max-height: 80px;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  line-height: 0;
+  margin-bottom: var(--spacing-s);
+  font-weight: bold;
+}
+
+.aside .foreground.container a.icon-area {
+  height: auto;
+  margin-bottom: 0;
+}
+
+.aside.center .foreground.container .icon-area {
+  justify-content: center;
+}
+
+.aside .avatar-area,
+.aside .lockup-area {
+  margin-bottom: var(--spacing-s);
+}
+
+.aside.split .split-image img,
+.aside.split .split-image video {
+  position: relative;
+  min-height: 270px;
+}
+
+.aside.split .split-image video {
+  display: block;
+}
+
+.aside.split .mobile-square img,
+.aside.split .mobile-square video {
+  aspect-ratio: var(--aspect-ratio-square);
+}
+
+.aside.split .mobile-wide img,
+.aside.split .mobile-wide video {
+  aspect-ratio: var(--aspect-ratio-wide);
+}
+
+.aside.split .mobile-standard img,
+.aside.split .mobile-standard video {
+  aspect-ratio: var(--aspect-ratio-standard);
+}
+
+.aside.split .format img,
+.aside.split .format video {
+  height: auto;
+}
+
+.aside.split .icon-stack-area li img {
+  width: var(--icon-size-m);
+  height: auto;
+}
+
+.aside.split .format picture,
+.aside.split .format video {
+  display: flex;
+  height: 100%;
+  align-items: center;
+}
+
+.aside.split .icon-stack-area li picture {
+  flex-shrink: 0;
+}
+
+.aside:not(.notification) .foreground.container .icon-area picture {
+  height: 100%;
+}
+
+.aside .foreground.container .icon-area img {
+  max-height: 100%;
+  width: auto;
+  object-fit: cover;
+  object-position: left top;
+}
+
+.aside.simple .foreground.container .image {
+  display: none;
+}
+
+.aside.split {
+  flex-direction: column;
+}
+
+.aside.split.large {
+  flex-direction: column-reverse;
+}
+
+.aside.split.large.aside.media-top-mobile,
+.aside.split.large.aside.media-bottom-mobile {
+  flex-direction: column;
+}
+
+.aside.split .foreground.container {
+  width: 100%;
+  max-width: 100%;
+  flex-direction: column;
+  z-index: 1;
+}
+
+.aside.split .background {
+  position: relative;
+}
+
+.aside.split.large .background {
+  background-color: transparent;
+}
+
+.aside.split .foreground.container .image {
+  margin: 0;
+  display: none;
+}
+
+.aside.notification .text [class^="heading-"] + .action-area {
+  margin-top: var(--spacing-xs);
+}
+
+.aside.notification .foreground.container img {
+  display: block;
+}
+
+.aside.rounded-corners .foreground .image img,
+.aside.rounded-corners .foreground .image:not(:has(.video-container)) .pause-play-wrapper,
+.aside.rounded-corners .foreground .image video {
+  border-radius: 16px;
+}
+
+.aside .foreground.container .image video,
+.aside .foreground.container .image picture,
+.aside .foreground.container .image picture img {
+  width: 100%;
+  display: flex;
+}
+
+.aside.split .foreground.container .split-image img,
+.aside.split .foreground.container .split-image video {
+  object-fit: cover;
+  height: 270px;
+}
+
+.aside.inline {
+  border-radius: 10px;
+}
+
+.aside.inline .foreground.container {
+  width: 100%;
+  min-height: 0;
+  margin: var(--spacing-m);
+  padding: 0;
+  gap: var(--spacing-m);
+}
+
+.aside.inline .foreground.container .image {
+  margin-top: 0;
+}
+
+.aside.inline .heading-s {
+  margin-bottom: var(--spacing-s);
+}
+
+.aside.notification {
+  min-height: 0;
+}
+
+.aside.notification .foreground.container {
+  padding-top: var(--spacing-s);
+  padding-bottom: var(--spacing-s);
+  box-sizing: border-box;
+  justify-content: flex-start;
+}
+
+.aside.notification .foreground.container .image {
+  max-width: 75px;
+  margin: 0;
+  order: -1;
+}
+
+.aside.notification .foreground.container .text a:not(.con-button) {
+  width: auto;
+  font-weight: normal;
+}
+
+.aside.notification .foreground.container .text .action-area > a {
+  margin-right: 0;
+}
+
+.aside.promobar .foreground.container {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  margin: 0;
+}
+
+.aside.promobar .foreground.container .icon-area {
+  margin-bottom: 0;
+  height: var(--icon-size-m);
+}
+
+.aside.promobar .foreground.container .icon-area img {
+  height: var(--icon-size-m);
+  max-width: 234px;
+}
+
+.aside.notification.extra-small .foreground.container a:last-child {
+  font-weight: bold;
+}
+
+.aside.notification.extra-small .foreground.container a:not(.con-button):last-of-type {
+  margin-left: var(--spacing-xs);
+  color: var(--link-color);
+}
+
+.static-links .aside.notification.extra-small .foreground.container a:not(.con-button):last-of-type {
+  color: inherit;
+}
+
+.aside.notification.small .foreground.container .text a.con-button {
+  display: table;
+  margin-left: 0;
+}
+
+.aside.notification .foreground.container .text .heading-l {
+  margin-bottom: var(--spacing-xxs);
+}
+
+.aside.notification .foreground.container:not(.no-image) .text .body-s.action-area,
+.aside.notification .foreground.container:not(.no-image) .text .body-m.action-area {
+  margin-bottom: 0;
+}
+
+.aside.notification .foreground.container .icon-area {
+  height: auto;
+  max-width: none;
+  margin-bottom: var(--spacing-xs);
+}
+
+.aside.notification .foreground.container .icon-area img {
+  max-height: 40px;
+  max-width: 234px;
+  height: auto;
+}
+
+.aside.notification.extra-small .foreground.container {
+  min-height: 50px;
+  padding-top: var(--spacing-xs);
+  padding-bottom: var(--spacing-xs);
+}
+
+.aside.notification.extra-small .foreground.container .text {
+  display: block;
+}
+
+.aside.notification.medium .foreground.container .text,
+.aside.notification.large .foreground.container .text {
+  flex-direction: column;
+}
+
+.aside.notification.small .foreground.container .text {
+  flex-direction: column;
+  max-width: 1000px;
+}
+
+.aside.center:not(.notification) .foreground.container .text {
+  margin: 80px 0;
+  text-align: center;
+  padding: 0;
+}
+
+.aside.notification.center.small .foreground.container .text {
+  text-align: left;
+}
+
+.aside.notification.center.small .foreground.container .text,
+.aside.notification.center.extra-small .foreground.container .text {
+  margin: 0 auto;
+}
+
+.aside.notification.small {
+  min-height: 88px;
+}
+
+.aside.notification.medium {
+  min-height: 160px;
+}
+
+.aside.notification.large {
+  min-height: 250px;
+}
+
+.aside.notification.medium .foreground.container {
+  max-width: 800px;
+  gap: var(--spacing-xs);
+}
+
+.aside.notification.medium .foreground.container .text .heading-s {
+  margin-bottom: var(--spacing-xxs);
+}
+
+.aside.notification.center.small .foreground.container .text p {
+  text-align: initial;
+}
+
+.aside.notification.large .foreground.container {
+  max-width: 1000px;
+  gap: var(--spacing-xs);
+}
+
+.aside.notification .foreground.container [data-align=center],
+.aside.notification.center .foreground.container,
+.aside.notification.center .foreground.container > * {
+  text-align: center;
+  justify-content: center;
+}
+
+.aside.promobar.popup .foreground.container {
+  width: 100%;
+  padding: 0;
+}
+
+.aside.center:not(.notification) .foreground.container {
+  padding: 0;
+}
+
+.aside.no-media:not(.notification) .foreground.container {
+  gap: 0;
+}
+
+.aside.notification.large.center .foreground.container,
+.aside.notification.large .foreground.container.no-image {
+  max-width: 800px;
+}
+
+.aside.promobar.popup .promo-text .action-area {
+  justify-content: flex-end;
+  padding: 0 var(--spacing-xxs) var(--spacing-xxs) 0;
+  gap: var(--spacing-xxs);
+}
+
+.aside.notification.center .foreground.container .action-area {
+  justify-content: center;
+}
+
+.aside.notification.center.small .foreground.container .text,
+.aside.notification.center.small .foreground.container .text > * {
+  justify-content: flex-start;
+}
+
+.aside.split .icon-stack-area {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 12px;
+  margin: -8px 0 var(--spacing-s);
+  width: 100%;
+  padding: 0;
+  list-style-type: none;
+}
+
+.aside.promobar.popup .promo-text .icon-area,
+.aside.promobar.popup .promo-text .icon-area img {
+  display: flex;
+  gap: var(--spacing-xxs);
+  align-items: center;
+  height: var(--icon-size-xs);
+}
+
+.aside.center:not(.notification) .foreground.container .icon-area {
+  max-width: 100%;
+}
+
+.aside.center:not(.notification) .foreground.container .text .action-area {
+  justify-content: center;
+}
+
+.aside.split .image.format {
+  display: flex;
+}
+
+.aside.split.bio .foreground.container .text .icon-area:not(.con-button) {
+  display: none;
+}
+
+.aside.promobar .foreground.container > :first-child {
+  padding: var(--spacing-xs) 0;
+}
+
+.aside.promobar .promo-text[data-align="center"] {
+  justify-content: center;
+}
+
+.aside.promobar .action-area .con-button {
+  white-space: nowrap;
+}
+
+.aside.promobar .promo-text.desktop-up,
+.aside.promobar .promo-text.tablet-up {
+  display: none;
+}
+
+.aside.promobar .promo-text.mobile-up {
+  display: flex;
+}
+
+.aside.promobar .promo-text {
+  display: flex;
+  flex-flow: row nowrap;
+  gap: var(--spacing-xs);
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--spacing-xs) 0;
+}
+
+.aside.promobar .promo-text .content-area {
+  display: flex;
+  flex-flow: row nowrap;
+  gap: var(--spacing-xs);
+  align-items: center;
+}
+
+.aside.promobar.popup .mobile-up.promo-text:has(.milo-tooltip) {
+  position: relative;
+}
+
+.aside.promobar.popup .promo-text span[data-tooltip] .icon-milo {
+  height: 16px;
+}
+
+.aside.promobar.popup .mobile-up.promo-text .milo-tooltip {
+  position: absolute;
+  left: calc(var(--spacing-xs) - 5px);
+  bottom: var(--spacing-xs);
+  margin-inline-start: 0;
+}
+
+[dir="rtl"] .aside.promobar.popup .mobile-up.promo-text .milo-tooltip {
+  left: unset;
+  right: calc(var(--spacing-xs) - 5px);
+}
+
+.aside.promobar.popup {
+  border-radius: var(--spacing-xs);
+  width: var(--grid-container-width);
+  margin: auto;
+  box-shadow: 0 3px 6px #707070;
+  overflow: unset;
+}
+
+.aside.promobar.popup .background {
+  border-radius: inherit;
+}
+
+.aside.promobar.popup .foreground.container .promo-text {
+  flex-direction: column;
+  padding: 0;
+}
+
+.aside.promobar.popup .promo-text .content-area {
+  padding: var(--spacing-xs) var(--spacing-xs) 0 var(--spacing-xs);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-xxs);
+}
+
+.aside.promobar.popup .promo-text .text-area {
+  margin-top: var(--spacing-m);
+}
+
+.aside.promobar.popup .promo-text .icon-area+.text-area {
+  margin-top: 0;
+}
+
+.aside.promobar.popup .promo-text .content-area .text-area {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xxs);
+}
+
+.aside.promobar.popup .mobile-up.promo-text .detail-xs+.text-area {
+  gap: var(--spacing-xs);
+}
+
+.aside.promobar.popup .promo-close {
+  position: absolute;
+  right: var(--spacing-xxs);
+  top: var(--spacing-xxs);
+  height: 20px;
+  width: 20px;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.aside.promobar.popup .promo-close svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.aside.promobar.popup .promo-close circle {
+  fill: var(--color-black);
+}
+
+.aside.promobar.popup .promo-close line {
+  stroke: var(--color-white);
+}
+
+.aside.promobar.popup .mobile-up.hide-block ~ .promo-close {
+  display: none;
+}
+
+@media screen and (min-width: 600px) {
+  .aside {
+    --min-height-small: 420px;
+    --min-height-medium: 560px;
+    --min-height-large: 700px;
+  }
+
+  .aside.small:not(.notification, .promobar) {
+    min-height: var(--min-height-small);
+  }
+
+  .aside.medium:not(.notification, .promobar) {
+    min-height: var(--min-height-medium);
+  }
+
+  .aside.large:not(.notification, .promobar) {
+    min-height: var(--min-height-large);
+  }
+
+  .aside.media-top-mobile .foreground .image,
+  .aside.media-top-mobile .split-image {
+    order: unset;
+  }
+
+  .aside.media-bottom-mobile .foreground .image,
+  .aside.media-bottom-mobile .split-image {
+    order: unset;
+  }
+
+  .aside.promobar.popup .mobile-up.hide-block ~ .promo-close {
+    display: unset;
+  }
+
+  .aside .foreground.container {
+    align-items: center;
+    flex-direction: row;
+    margin: 0 auto;
+  }
+
+  .aside .foreground.container .image {
+    margin: 0;
+  }
+
+  .aside .foreground.container .text.image {
+    justify-content: flex-start;
+  }
+
+  .aside .background,
+  .aside.split .split-image {
+    overflow: hidden;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+  }
+
+  .aside .foreground.container .text {
+    margin-bottom: 0;
+  }
+
+  .aside.split-right .foreground.container .text {
+    padding-left: var(--spacing-s);
+  }
+
+  .aside.simple .foreground.container .text {
+    margin-bottom: 0;
+    max-width: 318px;
+    padding-right: 0;
+  }
+
+  .aside.split .tablet-wide img,
+  .aside.split .tablet-wide video {
+    aspect-ratio: var(--aspect-ratio-wide);
+  }
+
+  .aside.split .tablet-standard img,
+  .aside.split .tablet-standard video {
+    aspect-ratio: var(--aspect-ratio-standard);
+  }
+
+  .aside.split-right .split-image img,
+  .aside.split-right .split-image video {
+    left: 0;
+  }
+
+  .aside.split.large {
+    flex-direction: column;
+  }
+
+  .aside .split-image .modal-img-link,
+  .aside.split .split-image img,
+  .aside.split .split-image video {
+    width: 50vw;
+    position: absolute;
+    right: 0;
+    object-fit: cover;
+    object-position: center top;
+  }
+
+  .aside.split .split-image img.accessibility-control {
+    position: relative;
+  }
+
+  .aside .split-image .modal-img-link,
+  .aside.split.half .split-image img,
+  .aside.split.half .split-image video {
+    width: 50vw;
+    max-width: 1396px;
+    object-position: left top;
+  }
+
+  .aside.split.split-left .split-image img,
+  .aside.split.split-left .split-image video {
+    right: 0;
+    left: auto;
+  }
+
+  .aside.split.split-right .split-image img,
+  .aside.split.split-right .split-image video {
+    left: 0;
+    right: auto;
+  }
+
+  [dir="rtl"] .aside.split.split-right .split-image img,
+  [dir="rtl"] .aside.split.split-right .split-image video {
+    right: 0;
+    left: auto;
+  }
+
+  [dir="rtl"] .aside.split.split-left .split-image img,
+  [dir="rtl"] .aside.split.split-left .split-image video {
+    left: 0;
+    right: auto;
+  }
+
+  .aside.split .foreground.container {
+    flex-direction: row;
+    justify-content: stretch;
+    max-width: var(--grid-container-width);
+    margin: 0 auto;
+    background-color: transparent;
+  }
+
+  .aside.split .foreground.container .text {
+    flex: 0 0 41.67%;
+    max-width: 100%;
+    margin: 0;
+  }
+
+  .aside.split .foreground.container .image {
+    object-fit: cover;
+    flex: 0 0 61%;
+    display: block;
+    padding: 0;
+  }
+
+  .aside.inline .foreground.container .text {
+    flex: 0 0 calc(60% - var(--spacing-s));
+    max-width: none;
+  }
+
+  .aside.notification .foreground.container .text {
+    padding-right: 0;
+  }
+
+  .aside.notification.small .foreground.container .text {
+    flex-flow: row nowrap;
+    align-items: center;
+    flex-grow: 1;
+  }
+
+  .aside.notification.small [class^="body-"] {
+    margin: 0;
+  }
+
+  .aside.notification.small .foreground.container .text .body-m.action-area {
+    margin-left: 24px;
+  }
+
+  [dir = "rtl"] .aside.notification.small .foreground.container .text .body-m.action-area {
+    margin-left: 0;
+    margin-right: 24px;
+  }
+
+  .aside.split.half .foreground.container .text {
+    flex: 0 0 41.72%;
+  }
+
+  .aside.split-right .foreground.container {
+    flex-direction: row-reverse;
+  }
+
+  .aside.inline .foreground.container .image {
+    flex: 0 0 calc(40% - var(--spacing-s));
+    margin-bottom: 0;
+  }
+
+  .aside.notification .foreground.container {
+    flex-direction: row;
+  }
+
+  .aside.notification.medium .foreground.container,
+  .aside.notification.large .foreground.container {
+    gap: var(--spacing-s);
+  }
+
+  .aside.notification .foreground.container .image {
+    width: 30%;
+    max-width: 188px;
+    margin: 0;
+    padding: 0;
+    order: unset;
+  }
+
+  .aside.notification .foreground.container .text+.image {
+    margin-right: 0;
+  }
+
+  .aside.notification .foreground.container .icon-area {
+    width: auto;
+    margin-right: var(--spacing-xs);
+    margin-bottom: 0;
+  }
+
+  [dir = "rtl"] .aside.notification .foreground.container .icon-area {
+    margin-left: var(--spacing-xs);
+    margin-right: 0;
+  }
+
+  .aside.notification.extra-small .foreground.container.no-image .text {
+    display: flex;
+  }
+
+  .aside.notification.extra-small .foreground.container.no-image .text a {
+    margin-left: 5px;
+  }
+
+  .aside.promobar.popup .promo-text .action-area {
+    justify-content: center;
+    padding: 0 0 var(--spacing-xxs);
+  }
+
+  .aside.notification.small .foreground.container .text .action-area {
+    width: auto;
+    margin-top: 0;
+  }
+
+  .aside.split.bio .foreground.container .text .icon-area:not(.con-button) {
+    display: block;
+  }
+
+  .aside.notification.small .foreground.container .text .icon-area {
+    height: 40px;
+  }
+
+  .aside.medium.split.bio .foreground.container .text .icon-area,
+  .aside.large.split.bio .foreground.container .text .icon-area {
+    height: var(--icon-size-xxl);
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .aside.medium.split.bio .foreground.container .text .icon-area img,
+  .aside.large.split.bio .foreground.container .text .icon-area img {
+    width: var(--icon-size-xxl);
+    height: var(--icon-size-xxl);
+    border-radius: 50%;
+  }
+
+  .aside.promobar .promo-text .content-area .text-area {
+    display: flex;
+    flex-flow: column nowrap;
+    gap: var(--spacing-xxs);
+  }
+
+  .aside.promobar .promo-text.mobile-up,
+  .aside.promobar .promo-text.desktop-up {
+    display: none;
+  }
+
+  .aside.promobar .promo-text.tablet-up {
+    display: flex;
+  }
+
+  .aside.promobar.popup .promo-text {
+    gap: var(--spacing-s);
+  }
+
+  .aside.promobar.popup .promo-text .content-area {
+    padding: var(--spacing-xxs) 0 0;
+    align-items: center;
+    text-align: center;
+  }
+
+  .aside.promobar p .con-button wbr,
+  .aside.notification p .con-button wbr {
+    display: none;
+  }
+}
+
+@media (min-width: 600px) and (max-width: 1199px) {
+  .aside.promobar.popup .tablet-up.hide-block ~ .promo-close {
+    display: none;
+  }
+
+  .aside.media-top-tablet .foreground.container,
+  .aside.media-bottom-tablet .foreground.container {
+    justify-content: center;
+    flex-direction: column;
+    gap: var(--spacing-l);
+    padding: var(--spacing-xl) 0;
+  }
+
+  .aside.media-top-tablet .foreground.container .text,
+  .aside.media-bottom-tablet .foreground.container .text {
+    padding-right: 0;
+  }
+
+  .aside.media-top-tablet .foreground .image,
+  .aside.split.media-top-tablet .split-image {
+    order: -1;
+  }
+
+  .aside.media-bottom-tablet .foreground .image,
+  .aside.split.media-bottom-tablet .split-image {
+    order: 100;
+  }
+
+  .aside.large.media-top-tablet,
+  .aside.large.media-bottom-tablet {
+    min-height: auto;
+  }
+
+  .aside.split.large.media-top-tablet .foreground.container .text,
+  .aside.split.large.media-bottom-tablet .foreground.container .text {
+    padding: 0;
+    flex: 0 0 100%;
+  }
+
+  .aside.split.media-top-tablet .split-image,
+  .aside.split.media-bottom-tablet .split-image {
+    position: relative;
+  }
+
+  .aside.split.media-top-tablet .split-image img,
+  .aside.split.media-bottom-tablet .split-image img,
+  .aside.split:is(.media-top-tablet, .media-bottom-tablet) .split-image video {
+    position: relative;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .aside.split.media-top-tablet .text .icon-stack-area,
+  .aside.split.media-bottom-tablet .text .icon-stack-area {
+    width: 83.33%;
+  }
+
+  .aside.split.media-top-tablet .icon-stack-area li,
+  .aside.split.media-bottom-tablet .icon-stack-area li {
+    width: calc(50% - 6px);
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .aside.small {
+    min-height: 420px;
+  }
+
+  .aside.medium {
+    min-height: 560px;
+  }
+
+  .aside.large {
+    min-height: 700px;
+  }
+
+  .aside .foreground.container {
+    width: var(--grid-container-width);
+    gap: var(--grid-column-width);
+  }
+
+  .aside .foreground.container > div {
+    object-fit: cover;
+    padding-left: 0;
+  }
+
+  .aside:not(.notification) .foreground.container .text {
+    flex: 1 0 calc(var(--grid-column-width) * 6);
+  }
+
+  .aside:not(.notification) .foreground.container .image {
+    flex: 1 0 calc(var(--grid-column-width) * 5);
+  }
+
+  .aside.inline .foreground.container .text {
+    flex: 0 0 calc(64% - var(--spacing-s));
+  }
+
+  .aside.simple .foreground.container .text {
+    margin-bottom: 0;
+    max-width: 500px;
+  }
+
+  .aside.split .foreground.container .text {
+    flex: 0 0 29%;
+  }
+
+  .aside.split .foreground.container .image {
+    flex: 0 0 70%;
+    max-width: none;
+    object-fit: cover;
+  }
+
+  .aside .split-image .modal-img-link,
+  .aside.split .split-image img,
+  .aside.split .split-image video {
+    width: 60.5vw;
+  }
+
+  .aside.split .split-image img,
+  .aside.split .split-image video {
+    max-width: 1396px;
+  }
+
+  .aside.split .desktop-wide img,
+  .aside.split .desktop-wide video {
+    aspect-ratio: var(--aspect-ratio-wide);
+  }
+
+  .aside.split .desktop-standard img,
+  .aside.split .desktop-standard video {
+    aspect-ratio: var(--aspect-ratio-standard);
+  }
+
+  .aside.split.half .foreground.container .text {
+    max-width: 500px;
+  }
+
+  .aside.inline {
+    max-width: 800px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  .aside.inline .foreground.container .image {
+    flex: 0 0 calc(36% - var(--spacing-s));
+  }
+
+  .aside.split .icon-stack-area li {
+    width: calc(50% - 6px);
+  }
+
+  .aside.split .icon-stack-area {
+    flex-direction: row;
+  }
+
+  .aside.promobar .foreground.container .icon-area,
+  .aside.promobar .foreground.container .icon-area img {
+    height: var(--icon-size-xxl);
+  }
+
+  .aside.promobar.popup .promo-text .icon-area,
+  .aside.promobar.popup .promo-text .icon-area img {
+    height: var(--icon-size-m);
+  }
+
+  .aside.center:not(.notification) .foreground.container .text {
+    max-width: 50%;
+  }
+
+  .aside.notification .foreground.container {
+    min-height: 0;
+  }
+
+  .aside.notification.extra-small .foreground.container {
+    padding-top: var(--spacing-xxs);
+    padding-bottom: var(--spacing-xxs);
+  }
+
+  .aside.notification.medium .foreground.container {
+    gap: var(--spacing-m);
+  }
+
+  .aside.notification.large .foreground.container {
+    gap: var(--spacing-l);
+  }
+
+  .aside.notification .foreground.container .image {
+    width: 20%;
+  }
+
+  .aside.notification .foreground.container .text+.image {
+    margin-right: 0;
+  }
+
+  .aside.notification.small .foreground.container .text {
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  .aside.notification.center.small .foreground.container .text,
+  .aside.notification.center.small .foreground.container .text > * {
+    justify-content: center;
+  }
+
+  .aside.notification.center.small .foreground.container .text p {
+    text-align: center;
+  }
+
+  .aside.notification.medium .foreground.container .image {
+    max-width: 168px;
+  }
+
+  .aside.notification.large .foreground.container .image {
+    max-width: 304px;
+  }
+
+  .aside.notification.medium .foreground.container .text+.image {
+    margin-right: 0;
+  }
+
+  .aside.promobar .promo-text .content-area {
+    gap: var(--spacing-m);
+  }
+
+  .aside.promobar .promo-text .content-area .text-area {
+    gap: var(--spacing-xs);
+  }
+
+  .aside.promobar .promo-text .action-area {
+    gap: var(--spacing-s);
+    flex-wrap: nowrap;
+  }
+
+  .aside.promobar .promo-text.mobile-up,
+  .aside.promobar .promo-text.tablet-up {
+    display: none;
+  }
+
+  .aside.promobar .promo-text.desktop-up {
+    display: flex;
+    gap: var(--spacing-m);
+  }
+
+  .aside.promobar.popup {
+    border-radius: var(--spacing-xl);
+    width: 85%;
+    max-width: 1600px;
+  }
+
+  .aside.promobar.popup .foreground.container .promo-text {
+    padding: var(--spacing-xs) 0;
+    flex-direction: row;
+    gap: var(--spacing-l);
+    justify-content: center;
+    max-width: 83.4%;
+  }
+
+  .aside.promobar.popup .promo-text .content-area,
+  .aside.promobar.popup .promo-text .action-area {
+    flex-direction: row;
+    padding: 0;
+    gap: var(--spacing-xs);
+    min-height: 40px;
+  }
+
+  .aside.promobar.popup .promo-close {
+    right: var(--spacing-s);
+    top: calc(50% - 10px);
+  }
+
+  .aside.promobar.popup .desktop-up.hide-block ~ .promo-close {
+    display: none;
+  }
+
+  .aside.promobar.popup .promo-text .text-area {
+    margin-top: 0;
+  }
+}
+
+@media screen and (min-width: 1440px) {
+  .aside.split .foreground.container .text {
+    flex: 0 0 calc(500px - 10.5vw);
+  }
+}
+
+.aside .foreground.container .action-area a.icon-area.con-button,
+.aside.split.bio .foreground.container .text .action-area a.icon-area.con-button {
+  display: inline-block;
+  height: unset;
+  margin-bottom: unset;
+}

--- a/libs/mep/ace1081/aside/aside.css
+++ b/libs/mep/ace1081/aside/aside.css
@@ -1288,3 +1288,8 @@
   height: unset;
   margin-bottom: unset;
 }
+
+/* This is for this test ace1081 and will likely be rolled into site CSS on RTP. */
+[class^="heading-"] {
+  font-weight: 900;
+}

--- a/libs/mep/ace1081/aside/aside.js
+++ b/libs/mep/ace1081/aside/aside.js
@@ -1,0 +1,337 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/*
+* Aside - v5.1
+*/
+
+import { decorateBlockText, decorateIconStack, applyHoverPlay, decorateBlockBg, decorateTextOverrides } from '../../../utils/decorate.js';
+import { createTag, getConfig, loadStyle } from '../../../utils/utils.js';
+
+// standard/default aside uses same text sizes as the split
+const variants = ['split', 'inline', 'notification'];
+const sizes = ['extra-small', 'small', 'medium', 'large'];
+const [split, inline, notification] = variants;
+const [xsmall, small, medium, large] = sizes;
+const blockConfig = {
+  [split]: ['xl', 's', 'm'],
+  [inline]: ['s', 'm'],
+  [notification]: {
+    [xsmall]: ['m', 'm'],
+    [small]: ['m', 'm'],
+    [medium]: ['s', 's'],
+    [large]: ['l', 'm'],
+  },
+};
+const FORMAT_REGEX = /^format:/i;
+const closeSvg = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+                    <g transform="translate(-10500 3403)">
+                      <circle cx="10" cy="10" r="10" transform="translate(10500 -3403)" fill="#707070"></circle>
+                      <line y1="8" x2="8" transform="translate(10506 -3397)" fill="none" stroke="#fff" stroke-width="2"></line>
+                      <line x1="8" y1="8" transform="translate(10506 -3397)" fill="none" stroke="#fff" stroke-width="2"></line>
+                    </g>
+                  </svg>`;
+
+function getBlockData(el) {
+  const variant = variants.find((variantClass) => el.classList.contains(variantClass));
+  const size = sizes.find((sizeClass) => el.classList.contains(sizeClass));
+  const blockData = variant ? blockConfig[variant] : blockConfig[Object.keys(blockConfig)[0]];
+  return variant && size && !Array.isArray(blockData) ? blockData[size] : blockData;
+}
+
+function decorateStaticLinks(el) {
+  if (!el.classList.contains('notification')) return;
+  const textLinks = el.querySelectorAll('a:not([class])');
+  textLinks.forEach((link) => { link.classList.add('static'); });
+}
+
+function decorateMedia(el) {
+  if (!(el.classList.contains('medium') || el.classList.contains('large'))) return;
+  const allMedia = el.querySelectorAll('div > p video, div > p picture');
+  [...allMedia].some((media) => {
+    const parentP = media.closest('p');
+    const siblingP = parentP?.nextElementSibling;
+    if (!siblingP || siblingP.nodeName !== 'P') return false;
+    const siblingText = siblingP.textContent;
+    const hasFormats = FORMAT_REGEX.test(siblingText);
+    if (!hasFormats) return false;
+    const formats = siblingText.split(': ')[1]?.split(/\s+/);
+    if (formats) {
+      const formatClasses = [];
+      formatClasses.push('format');
+      if (formats.length === 3) formatClasses.push(`desktop-${formats[2]}`);
+      if (formats.length >= 2) formatClasses.push(`tablet-${formats[1]}`);
+      formatClasses.push(`mobile-${formats[0]}`);
+      media.closest('div').classList.add(...formatClasses);
+    }
+    siblingP.remove();
+    media.closest('div').insertBefore(media, parentP);
+    parentP.remove();
+    return true;
+  });
+}
+
+function formatPromoButton(el) {
+  if (!el.classList.contains('promobar')) return;
+  el.querySelectorAll('.action-area').forEach((aa) => {
+    aa.querySelectorAll('.con-button').forEach((btn) => {
+      btn.classList.add('button-l');
+      if (!el.classList.contains('popup')) return;
+      if (!btn.classList.contains('outline')) btn.classList.add('fill');
+    });
+  });
+}
+
+function addCloseButton(el) {
+  const closeBtn = createTag('button', { class: 'promo-close', 'aria-label': 'Close' }, closeSvg);
+  el.querySelector('.foreground').appendChild(closeBtn);
+  closeBtn.addEventListener('click', (e) => {
+    e.target.closest('.section').classList.add('close-sticky-section');
+    document.dispatchEvent(new CustomEvent('milo:sticky:closed'));
+  });
+}
+
+function addPromobar(sourceEl, parent) {
+  const newPromo = sourceEl.cloneNode(true);
+  parent.appendChild(newPromo);
+}
+
+function checkViewportPromobar(foreground) {
+  const { children, childElementCount: childCount } = foreground;
+  if (childCount < 2) addPromobar(children[childCount - 1], foreground);
+  if (childCount < 3) addPromobar(children[childCount - 1], foreground);
+}
+
+function toolTipPosition(container) {
+  const isRtl = document.documentElement.getAttribute('dir') === 'rtl';
+  const isTablet = container.classList.contains('tablet-up');
+  const isMobile = container.classList.contains('mobile-up');
+  if ((isRtl && isTablet) || (isMobile && !isRtl)) return 'right';
+
+  return 'left';
+}
+
+async function addTooltip(foreground) {
+  const desktopContentText = foreground.querySelector('.desktop-up .text-area')?.textContent.trim();
+  const toolTipIcons = [];
+  [...foreground.querySelectorAll(':scope > div:not(.desktop-up)')].forEach((viewPortEl) => {
+    const childContent = viewPortEl.querySelector('.text-area');
+    const childContentText = childContent.textContent.trim();
+    if (childContentText === desktopContentText) return;
+    const appendTarget = viewPortEl.querySelector('.text-area').lastElementChild;
+    const iconWrapper = createTag('em', {}, `${toolTipPosition(viewPortEl)}|${desktopContentText}`);
+    iconWrapper.style.display = 'none';
+    const tooltipSpan = createTag('span', { class: 'icon icon-tooltip' });
+    iconWrapper.appendChild(tooltipSpan);
+    toolTipIcons.push(tooltipSpan);
+    appendTarget.appendChild(iconWrapper);
+  });
+
+  if (!toolTipIcons.length) return;
+
+  const config = getConfig();
+  const base = config.miloLibs || config.codeRoot;
+  const { default: loadIcons } = await import('../../../features/icons/icons.js');
+  loadStyle(`${base}/features/icons/icons.css`);
+  loadIcons(toolTipIcons, config);
+}
+
+function combineTextBlocks(textBlocks, iconArea, viewPort, variant) {
+  const promobarConfig = {
+    default: {
+      'mobile-up': ['s', 's'],
+      'tablet-up': ['s', 's'],
+      'desktop-up': ['m', 'l'],
+    },
+    popup: {
+      'mobile-up': ['s', 's'],
+      'tablet-up': ['l', 'm'],
+      'desktop-up': ['xxl', 'xl'],
+    },
+  };
+  const textStyle = promobarConfig[variant][viewPort];
+  const contentArea = createTag('p', { class: 'content-area' });
+  const textArea = createTag('p', { class: 'text-area' });
+  textBlocks[0].parentElement.prepend(contentArea);
+  textBlocks.forEach((textBlock) => {
+    textArea.appendChild(textBlock);
+    if (textBlock.nodeName === 'P') {
+      textBlock.classList.add(`body-${textStyle[1]}`);
+    } else {
+      textBlock.classList.add(`heading-${textStyle[0]}`);
+    }
+  });
+  if (iconArea) {
+    if (iconArea.innerText?.trim()) iconArea.classList.add('detail-xs');
+    iconArea.classList.add('icon-area');
+    contentArea.appendChild(iconArea);
+  }
+  contentArea.appendChild(textArea);
+}
+
+function decoratePromobar(el) {
+  const viewports = ['mobile-up', 'tablet-up', 'desktop-up'];
+  const foreground = el.querySelector('.foreground');
+  const variant = el.classList.contains('popup') ? 'popup' : 'default';
+  if (foreground.childElementCount !== 3) checkViewportPromobar(foreground);
+  [...foreground.children].forEach((child, index) => {
+    child.className = viewports[index];
+    child.classList.add('promo-text');
+    const textBlocks = [...child.children];
+    const iconArea = child.querySelector('picture')?.closest('p');
+    const actionArea = child.querySelectorAll('em a, strong a, p > a strong');
+    if (iconArea) textBlocks.shift();
+    if (actionArea.length) textBlocks.pop();
+    if (!(textBlocks.length || iconArea || actionArea.length)) child.classList.add('hide-block');
+    else if (textBlocks.length) combineTextBlocks(textBlocks, iconArea, viewports[index], variant);
+  });
+  if (variant === 'popup') {
+    addCloseButton(el);
+    addTooltip(foreground);
+  }
+  return foreground;
+}
+
+function loadIconography() {
+  const { miloLibs, codeRoot } = getConfig();
+  const base = miloLibs || codeRoot;
+  return new Promise((resolve) => { loadStyle(`${base}/styles/iconography.css`, resolve); });
+}
+
+export function handleImageLoad(el, image) {
+  if (image && !image.complete) {
+    el.style.visibility = 'hidden';
+    image.addEventListener('load', () => {
+      el.style.visibility = 'visible';
+    });
+    image.addEventListener('error', () => {
+      image.style.visibility = 'hidden';
+      el.style.visibility = 'visible';
+    });
+  }
+}
+function parseRowMetaData(elems) {
+  const metaDataKeys = ['video-icon'];
+  const metaData = [];
+
+  const rowArray = Array.from(elems);
+  rowArray.forEach((row) => {
+    const cols = row.querySelectorAll('div');
+    if (cols.length >= 2) {
+      const key = cols[0].textContent.trim();
+      const child = cols[1].querySelector('a, img');
+      const value = child?.href || child?.src || '';
+      if (metaDataKeys.includes(key)) {
+        metaData.push({ key, value });
+        row.remove();
+      }
+    }
+  });
+
+  const filteredRows = rowArray.filter((row) => row.isConnected);
+  return { elems: filteredRows, metaData };
+}
+
+const addVideoIcons = (el, metaData) => {
+  if (!metaData || !Array.isArray(metaData)) return;
+  metaData.forEach((item) => {
+    if (item.key === 'video-icon' || item.value !== '') {
+      const container = createTag('div', { class: 'video-icon-container' });
+      const img = createTag('img', { src: item.value, class: 'video-icon' });
+      container.append(img);
+      el.insertAdjacentElement('beforeEnd', container);
+    }
+  });
+};
+
+function decorateLayout(el) {
+  let elems = el.querySelectorAll(':scope > div');
+  let metaData = [];
+  ({ elems, metaData } = parseRowMetaData(elems));
+
+  if (elems.length > 1) {
+    decorateBlockBg(el, elems[0]);
+  }
+  const foreground = elems[elems.length - 1];
+  foreground.classList.add('foreground', 'container');
+  if (el.classList.contains('promobar')) return decoratePromobar(el);
+  if (el.classList.contains('split')) decorateMedia(el);
+  const text = foreground.querySelector('h1, h2, h3, h4, h5, h6, p')?.closest('div');
+  text?.classList.add('text');
+  const media = foreground.querySelector(':scope > div:not([class])');
+  if (media && !el.classList.contains('notification')) {
+    media.classList.add('image');
+    const video = media.querySelector('video');
+    if (video) applyHoverPlay(video);
+  }
+  const picture = text?.querySelector('p picture');
+  const iconArea = picture ? (picture.closest('p') || createTag('p', null, picture)) : null;
+  if (iconArea) {
+    const iconVariant = el.className.match(/-(avatar|lockup)/);
+    const iconClass = iconVariant ? `${iconVariant[1]}-area` : 'icon-area';
+    if (iconVariant) loadIconography();
+    iconArea.classList.add(iconClass);
+    const image = iconArea.querySelector('img');
+    handleImageLoad(el, image);
+  }
+  const foregroundImage = foreground.querySelector(':scope > div:not(.text) img')?.closest('div');
+  const bgImage = el.querySelector(':scope > div:not(.text):not(.foreground) img')?.closest('div');
+  const foregroundMedia = foreground.querySelector(':scope > div:not(.text) :is(.video-container, video, a[href*=".mp4"], a[href*="tv.adobe.com"]), :scope > div:not(.text) iframe[src*="tv.adobe.com"]')
+    ?.closest('div:not(.video-container)');
+  const bgMedia = el.querySelector(':scope > div:not(.text):not(.foreground) video, :scope > div:not(.text):not(.foreground) a:is([href*=".mp4"], [href*="tv.adobe.com"])')?.closest('div');
+  const image = foregroundImage ?? bgImage;
+  const asideMedia = foregroundMedia ?? bgMedia ?? image;
+  const isSplit = el.classList.contains('split');
+  const hasMedia = foregroundImage ?? foregroundMedia ?? (isSplit && asideMedia);
+  if (!hasMedia) el.classList.add('no-media');
+  if (asideMedia && !asideMedia.classList.contains('text')) {
+    asideMedia.classList.add(`${isSplit ? 'split-' : ''}image`);
+    if (isSplit) {
+      const position = [...asideMedia.parentNode.children].indexOf(asideMedia);
+      el.classList.add(`split${!position ? '-right' : '-left'}`);
+      foreground.parentElement.appendChild(asideMedia);
+    }
+  } else if (!iconArea) {
+    foreground?.classList.add('no-image');
+  }
+  if (el.classList.contains('split')) {
+    decorateIconStack(el);
+    // TODO: Remove after bugfix PR adobe/helix-html2md#556 is merged
+    const icnStk = el.querySelector('.icon-stack-area');
+    if (icnStk) {
+      const liELs = icnStk.querySelectorAll('li');
+      [...liELs].forEach((liEl) => {
+        liEl.querySelectorAll('p').forEach((pElement) => {
+          while (pElement.firstChild) {
+            pElement.parentNode.insertBefore(pElement.firstChild, pElement);
+          }
+          pElement.remove();
+        });
+      });
+    }
+    // TODO: Remove after bugfix PR adobe/helix-html2md#556 is merged
+  }
+  addVideoIcons(media, metaData);
+  return foreground;
+}
+
+export default function init(el) {
+  el.classList.add('con-block');
+  const blockData = getBlockData(el);
+  const blockText = decorateLayout(el);
+  decorateBlockText(blockText, blockData);
+  decorateStaticLinks(el);
+  formatPromoButton(el);
+  decorateTextOverrides(el);
+  // Override Detail with Title L style if class exists - Temporary solution until Spectrum 2
+  if (el.classList.contains('l-title')) el.querySelector('[class*="detail-"]')?.classList.add('title-l');
+}

--- a/libs/mep/ace1081/editorial-card/editorial-card.css
+++ b/libs/mep/ace1081/editorial-card/editorial-card.css
@@ -1,0 +1,331 @@
+.editorial-card {
+  --card-height-default: 213px;
+  --card-scale-default: 1.03;
+
+  border: 1px solid var(--color-gray-300);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transform: translateZ(0);
+}
+
+.editorial-card,
+.editorial-card::after,
+.editorial-card::before {
+    box-sizing: border-box;
+}
+
+.section.masonry-layout > .editorial-card[class*='grid-span-'] {
+  display: flex;
+}
+
+.dark .editorial-card,
+.editorial-card.dark {
+  color: #fff;
+  border-color: var(--color-gray-700);
+}
+
+.editorial-card.no-bg { background: none;}
+.editorial-card.no-border { border: none;}
+
+.editorial-card.click {
+  cursor: pointer;
+}
+
+.editorial-card.click.hover-scale { 
+  transition: all .2s ease-in-out;
+}
+
+.editorial-card.click.hover-scale:hover { 
+  transform: scale(var(--card-scale-default));
+}
+
+.editorial-card:not(.no-bg).click.hover-scale:hover { 
+  box-shadow: 0 3px 6px 0  rgba(0 0 0 / 16%);
+}
+
+.editorial-card .action-area a:not([class*="button"]) {
+  font-size: var(--type-body-s-size);
+}
+
+.editorial-card.static-links-copy .foreground a:not([class*="button"]) {
+  color: inherit;
+  text-decoration: underline;
+}
+
+[class*=-up] .editorial-card {
+  max-width: none;
+  width: 100%;
+  min-width: initial;
+}
+
+.editorial-card.equal-height {
+  height: 100%;
+}
+
+.editorial-card .media-area picture,
+.editorial-card .foreground picture {
+  line-height: 0;
+  display: block;
+  height: 100%;
+}
+
+.editorial-card .media-area img,
+.editorial-card .media-area video {
+  object-fit: cover;
+  object-position: center;
+  width: 100%;
+  height: 100%;
+  max-height: var(--card-height-default);
+}
+
+.editorial-card .video-icon-container {
+  position:relative;
+}
+
+.editorial-card .video-icon-container img.video-icon {
+  pointer-events: none;
+  position:absolute;
+  bottom: -15px;
+  right: 15px;
+  height: 50px;
+  width: auto;
+}
+
+.editorial-card.no-foreground,
+.editorial-card.no-foreground .media-area {
+  height: 100%;
+}
+
+.editorial-card.no-foreground .media-area img,
+.editorial-card.no-foreground .media-area video {
+  max-height: unset;
+}
+
+.editorial-card .media-area .modal-img-link {
+  display: block;
+}
+
+.editorial-card .foreground,
+.editorial-card .card-footer {
+  padding: var(--spacing-xs);
+}
+
+.editorial-card .extra-row {
+  padding: 0 var(--spacing-xs);
+}
+
+.editorial-card .card-footer {
+  padding-top: 0;
+  margin-top: auto;
+}
+
+.editorial-card .vp-media .tablet-only,
+.editorial-card .vp-media .desktop-only {
+  display: none;
+}
+
+.editorial-card .card-footer > div {
+  display: flex;
+  flex-direction: column;
+  text-align: end;
+  justify-content: end;
+  row-gap: var(--spacing-xxs);
+}
+
+.editorial-card .card-footer.empty { padding: 0; }
+
+.editorial-card.no-bg.no-border .foreground {
+  padding: var(--spacing-s) 0;
+}
+
+.editorial-card.no-bg.no-media > .foreground {
+  padding-top: 0;
+}
+
+.editorial-card.no-bg.no-border .static,
+.editorial-card.no-bg.no-border .card-footer {
+  padding-inline: 0;
+}
+
+.editorial-card .foreground > div {
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--spacing-xxs);
+}
+
+.editorial-card .background > div {
+  height: 100%;
+}
+
+.editorial-card .media-area > div {
+  line-height: 0;
+}
+
+.editorial-card.no-foreground { 
+  border: none;
+}
+
+.editorial-card.no-foreground .media-area > div {
+  height: 100%;
+}
+
+.editorial-card.footer-align-left .card-footer > div { text-align: start; }
+.editorial-card.footer-align-center .card-footer > div { text-align: center; }
+
+.editorial-card.no-bg.no-border .foreground > div { 
+  row-gap: var(--spacing-xs);
+}
+
+.editorial-card .background img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+.editorial-card .background .milo-video, 
+.editorial-card .background .milo-iframe {
+  height: 100%;
+  padding-bottom: 0;
+}
+
+.editorial-card .lockup-area,
+.editorial-card .device {
+  margin: 0;
+}
+
+.editorial-card .device {
+  font-size: var(--type-body-xxs-size);
+  line-height: var(--type-body-xxs-lh);
+}
+
+.editorial-card .lockup-area {
+  row-gap: var(--spacing-xxs);
+}
+
+.editorial-card .lockup-label {
+  line-height: initial;
+}
+
+.editorial-card .action-area, 
+.editorial-card .card-footer > .action-area {
+  display: flex;
+  align-items: center;
+  justify-content: right;
+  gap: var(--spacing-xs) var(--spacing-s);
+  flex-flow: wrap;
+  flex-direction: row;
+}
+
+.editorial-card .action-area .con-button { 
+  white-space: nowrap;
+}
+
+.editorial-card.center .action-area {
+  justify-content: center;
+}
+
+.editorial-card hr {
+  background-color: currentcolor;
+  border: none;
+  height: 1px;
+  width: 100%;
+  margin: var(--spacing-xxs) 0;
+}
+
+.editorial-card .background {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  overflow: hidden;
+}
+
+.editorial-card .media-area {
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+
+.editorial-card .media-area.background {
+  position: relative;
+  z-index: initial;
+}
+
+.editorial-card .media-area.background video {
+  position: relative;
+}
+
+.editorial-card:is(.media-square, .media-wide, .media-standard, .media-tall) .media-area .milo-video {
+  height: auto;
+  padding: 0;
+}
+
+/* Aspect Ratio */
+.editorial-card.media-square .media-area img,
+.editorial-card.media-square .media-area video {
+  aspect-ratio: var(--aspect-ratio-square);
+  max-height: unset;
+}
+
+.editorial-card.media-wide .media-area img,
+.editorial-card.media-wide .media-area video {
+  aspect-ratio: var(--aspect-ratio-wide);
+  max-height: unset;
+}
+
+.editorial-card.media-standard .media-area img,
+.editorial-card.media-standard .media-area video {
+  aspect-ratio: var(--aspect-ratio-standard);
+  max-height: unset;
+}
+
+.editorial-card.media-tall .media-area img,
+.editorial-card.media-tall .media-area video,
+.editorial-card.media-tall .media-area .milo-video {
+  aspect-ratio: var(--aspect-ratio-tall);
+  max-height: unset;
+}
+
+/* Media Height */
+.editorial-card.media-height-auto .media-area img,
+.editorial-card.media-height-auto .media-area video {
+  max-height: unset;
+}
+
+/* Align */
+.editorial-card.center { 
+  text-align: center; 
+  justify-items: center; 
+}
+
+.editorial-card.footer-align-left .action-area { justify-content: start; }
+.editorial-card.footer-align-center .action-area { justify-content: center; }
+
+
+/* Tablet up */
+@media screen and (min-width: 600px) {
+  .editorial-card .vp-media .mobile-only,
+  .editorial-card .vp-media .desktop-only {
+    display: none;
+  }
+
+  .editorial-card .vp-media .tablet-only { display: block; }
+}
+
+/* desktop up */
+@media screen and (min-width: 1200px) {
+  .editorial-card .vp-media .mobile-only,
+  .editorial-card .vp-media .tablet-only {
+    display: none;
+  }
+
+  .editorial-card .vp-media .desktop-only { display: block; }
+}
+
+/* mobile only */
+@media screen and (max-width: 700px) {
+  .section.two-up-mobile:has(.editorial-card) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-xs);
+  }
+}

--- a/libs/mep/ace1081/editorial-card/editorial-card.js
+++ b/libs/mep/ace1081/editorial-card/editorial-card.js
@@ -1,0 +1,185 @@
+import { createTag, loadStyle, getConfig } from '../../../utils/utils.js';
+import { decorateBlockBg, decorateBlockText, decorateBlockHrs, decorateTextOverrides, applyHoverPlay } from '../../../utils/decorate.js';
+
+const { miloLibs, codeRoot } = getConfig();
+const base = miloLibs || codeRoot;
+
+async function loadIconography() {
+  await new Promise((resolve) => { loadStyle(`${base}/styles/iconography.css`, resolve); });
+}
+
+async function decorateLockupFromContent(el) {
+  const rows = el.querySelectorAll(':scope > div > p');
+  const firstRowImg = rows[0]?.querySelector('img');
+  if (!firstRowImg) return;
+  await loadIconography();
+  rows[0].classList.add('lockup-area');
+  rows[0].childNodes.forEach((node) => {
+    if (node.nodeType === 3 && node.nodeValue !== ' ') {
+      const newSpan = createTag('span', { class: 'lockup-label' }, node.nodeValue);
+      node.parentElement.replaceChild(newSpan, node);
+    }
+  });
+}
+
+const extendDeviceContent = (el) => {
+  const detail = el.querySelector('[class^="detail-"]');
+  const prevElem = detail?.previousElementSibling;
+  if (!prevElem) return;
+  const elBodyClass = [...prevElem.classList].find((c) => c.startsWith('body-'));
+  prevElem.classList.remove(elBodyClass);
+  prevElem.classList.add('device');
+};
+
+const decorateMedia = (el, media) => {
+  if (!media) return;
+  media.classList.add('media-area');
+  const mediaVideo = media.querySelector('video');
+  if (mediaVideo) {
+    applyHoverPlay(mediaVideo);
+  }
+  if (media.children.length > 1) decorateBlockBg(el, media, { className: 'vp-media' });
+};
+
+const decorateForeground = async (el, rows) => {
+  let isForegroundEmpty = true;
+
+  rows.forEach((row, i) => {
+    if (!row.textContent.trim()) {
+      row.remove();
+      return;
+    }
+
+    isForegroundEmpty = false;
+    if (i === 0) {
+      row.classList.add('foreground');
+      decorateLockupFromContent(row);
+    } else if (i === (rows.length - 1)) {
+      row.classList.add('card-footer');
+      if (!row.textContent.trim()) row.classList.add('empty');
+    } else {
+      row.classList.add('extra-row');
+    }
+    decorateBlockText(row, ['m', 'm', 'm']); // heading, body, detail
+    decorateBlockHrs(row);
+  });
+
+  if (isForegroundEmpty) el.classList.add('no-foreground');
+};
+
+const decorateBgRow = (el, background, remove = false) => {
+  const rows = background.querySelectorAll(':scope > div');
+  const bgRowsEmpty = [...rows].every((row) => row.innerHTML.trim() === '');
+  if (bgRowsEmpty || remove) {
+    el.classList.add('no-bg');
+    background.remove();
+    return;
+  }
+  decorateBlockBg(el, background);
+};
+
+function handleClickableCard(el) {
+  const links = el.querySelectorAll('a');
+  if (el.classList.contains('click') && links) {
+    el.addEventListener('click', (e) => {
+      /* c8 ignore next 2 */
+      if (e.target.tagName === 'A') return;
+      (() => (links[0].target === '_blank' ? window.open(links[0].href) : window.location.assign(links[0].href)))();
+    });
+  }
+}
+
+function parseRowMetaData(rows) {
+  const metaDataKeys = ['video-icon'];
+  const metaData = [];
+
+  const rowArray = Array.from(rows);
+  rowArray.forEach((row) => {
+    const cols = row.querySelectorAll('div');
+    if (cols.length >= 2) {
+      const key = cols[0].textContent.trim();
+      const child = cols[1].querySelector('a, img');
+      const value = child?.href || child?.src || '';
+      if (metaDataKeys.includes(key)) {
+        metaData.push({ key, value });
+        row.remove();
+      }
+    }
+  });
+
+  const filteredRows = rowArray.filter((row) => row.isConnected);
+  return { rows: filteredRows, metaData };
+}
+
+const addVideoIcons = (el, metaData) => {
+  if (!metaData || !Array.isArray(metaData)) return;
+  metaData.forEach((item) => {
+    if (item.key === 'video-icon' || item.value !== '') {
+      const container = createTag('div', { class: 'video-icon-container' });
+      const img = createTag('img', { src: item.value, class: 'video-icon' });
+      container.append(img);
+      el.insertAdjacentElement('afterEnd', container);
+    }
+  });
+};
+
+const init = async (el) => {
+  el.classList.add('con-block');
+  const hasOpenClass = el.className.includes('open');
+  if (hasOpenClass) el.classList.add('no-border', 'l-rounded-corners-image', 'static-links-copy');
+  if (el.className.includes('rounded-corners')) loadStyle(`${base}/styles/rounded-corners.css`);
+  if (![...el.classList].some((c) => c.endsWith('-lockup'))) el.classList.add('m-lockup');
+  let rows = el.querySelectorAll(':scope > div');
+  let metaData = [];
+  ({ rows, metaData } = parseRowMetaData(rows));
+
+  const [head, middle, ...tail] = rows;
+  if (rows.length === 4) el.classList.add('equal-height');
+  if (rows.length >= 1) {
+    const count = rows.length >= 4 ? 'four-plus' : rows.length;
+    switch (count) {
+      case 'four-plus':
+        // 4+ rows (0:bg, 1:media, 2:copy, ...3:static, last:card-footer)
+        // 4+ rows.open (0:bg[removed], 1:media, 2:copy, ...3:static, last:card-footer)
+        decorateBgRow(el, head, hasOpenClass);
+        rows = tail;
+        decorateMedia(el, middle);
+        await decorateForeground(el, rows);
+        break;
+      case 3:
+        // 3 rows (0:bg, 1:media, last:copy)
+        // 3 rows.open (0:media, 1:copy, last:card-footer)
+        if (hasOpenClass) {
+          el.classList.add('no-bg');
+          rows = [middle, tail[0]];
+          decorateMedia(el, head);
+        } else {
+          rows = tail;
+          decorateBgRow(el, head);
+          decorateMedia(el, middle);
+        }
+        await decorateForeground(el, rows);
+        break;
+      case 2:
+        // 2 rows (0:media, 1:copy)
+        rows = [middle];
+        decorateMedia(el, head);
+        el.classList.add('no-bg');
+        await decorateForeground(el, rows);
+        break;
+      case 1:
+        // 1 row  (0:copy)
+        rows = [head];
+        el.classList.add('no-bg', 'no-media');
+        await decorateForeground(el, rows);
+        break;
+      default:
+    }
+  }
+  addVideoIcons(middle, metaData);
+  extendDeviceContent(el);
+  decorateTextOverrides(el);
+  handleClickableCard(el);
+};
+
+export default init;


### PR DESCRIPTION
Expected Changes:

- Adds 900 font weight to headers. 
![image](https://github.com/user-attachments/assets/da0c6f27-1d34-48ae-8e80-6a1c87289d30)

- Aside to parse and add mnemonics to videos. 
![image](https://github.com/user-attachments/assets/f69155da-b994-4c9b-a7b9-2ba80f7218b9)

- Editorial Cards to parse and add mnemonics to videos. 
![image](https://github.com/user-attachments/assets/3a0042ec-64fa-4b99-8c8c-614a6793e36f)

(Control will look broken because it doesn't know how to parse the row data.)
![image](https://github.com/user-attachments/assets/8dc23a0a-e963-4d61-908f-750004084b7f)
![image](https://github.com/user-attachments/assets/385c3eb9-2eed-48a6-a3a6-035de5aefb82)

Resolves: https://jira.corp.adobe.com/browse/OPT-32740

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/cc-shared/fragments/tests/2025/q3/ace1081/test-page?milolibs=ace1081&mep=
- After: https://main--cc--adobecom.aem.page/cc-shared/fragments/tests/2025/q3/ace1081/test-page?milolibs=ace1081&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2025%2Fq3%2Face1081%2Face1081.json--target-var1
- Psi: https://ace1081--milo--adobecom.aem.page/?martech=off
