### PR TITLE
Update CODEOWNERS to assign ownership for mep and martech attributes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,7 +10,8 @@
 /libs/features/georoutingv2/ @adobecom/milo-core
 /libs/features/icons/ @adobecom/milo-core
 /libs/features/mas/ @adobecom/tacocat
-/libs/features/personalization/ @vgoodric
+/libs/features/mep/ @adobecom/mep-squad
+/libs/features/personalization/ @adobecom/mep-squad
 /libs/features/seotech/ @adobecom/milo-core
 /libs/features/spectrum-web-components/ @adobecom/tacocat
 /libs/features/webapp-prompt/ @adobecom/feds
@@ -137,3 +138,4 @@
 
 # Standalone Gnav
 /libs/navigation/ @adobecom/feds
+/libs/martech/attributes.js @adobecom/mep-squad


### PR DESCRIPTION
* /libs/features/mep/
* /libs/features/personalization/
* /libs/martech/attributes.js

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mepcodeowners--milo--adobecom.aem.page/?martech=off
