### PR TITLE
Safeguard aria-label check to avoid JS errors

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -991,9 +991,9 @@ export function decorateLinks(el) {
     const pipeRegex = /\s?\|([^|]*)$/;
     if (pipeRegex.test(a.textContent) && !/\.[a-z]+/i.test(a.textContent)) {
       const node = [...a.childNodes].reverse()[0];
-      const ariaLabel = node.textContent.match(pipeRegex)[1];
+      const ariaLabel = node.textContent.match(pipeRegex)?.[1];
       node.textContent = node.textContent.replace(pipeRegex, '');
-      a.setAttribute('aria-label', ariaLabel.trim());
+      a.setAttribute('aria-label', (ariaLabel || '').trim());
     }
 
     return rdx;


### PR DESCRIPTION
An authoring pattern such as `Videó megtekintése | Lejátszás – Egyéni dizájn bármilyen felületen:play:` instead of 
`:play:Videó megtekintése | Lejátszás – Egyéni dizájn bármilyen felületen` will lead to a JS error and stop rendering.

Resolves: https://jira.corp.adobe.com/browse/MWPW-175388

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/osahin/video-megtekintese-lejatszas-egyeni-dizajn-barmilyen-felu
- After: https://safeguard-aria-labels--milo--adobecom.aem.page/drafts/osahin/video-megtekintese-lejatszas-egyeni-dizajn-barmilyen-felu?martech=off
