### PR TITLE
Account for no play buttons within accordions

### DIFF
--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -20,6 +20,7 @@ function playVideo(video) {
   if (!video) return;
   if (video.getAttribute('autoplay') === null) return;
   const playBtn = video.nextElementSibling;
+  if (!playBtn) return;
   const isPlaying = playBtn.getAttribute('aria-pressed') === 'true';
   if (isPlaying || video.readyState === 0) return;
   playBtn.click();


### PR DESCRIPTION
### Description
Accordions that have been authored without play buttons might lead to JS errors

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/au/cc-shared/fragments/tests/2025/q2/apac0419/riverflow-premiere#
- After: https://main--cc--adobecom.aem.live/au/cc-shared/fragments/tests/2025/q2/apac0419/riverflow-premiere?milolibs=fix-video-accordions--milo--mokimo
