### PR TITLE
MWPW-175427: mini-compare-chart bullet-list collapse icon fix

### DIFF
--- a/libs/blocks/merch-card/merch-card.js
+++ b/libs/blocks/merch-card/merch-card.js
@@ -458,7 +458,7 @@ const createFirstRow = async (firstRow, isMobile, checkmarkCopyContainer, defaul
       'aria-expanded': defaultChevronState === 'open',
       'aria-controls': checkmarkCopyContainer.id,
       'daa-lh': `${checkmarkCopyContainer.id}-toggle-button`,
-    }, addIcon);
+    }, defaultChevronState === 'open' ? removeIcon : addIcon);
     firstRowTextParagraph = createTag('div', { class: 'footer-rows-title' }, firstRowText);
     firstRowTextParagraph.appendChild(toggleIcon);
 


### PR DESCRIPTION
Previously, the collapsible footer rows always displayed the plus icon by default, regardless of whether their initial state was set to open or close.
With this PR, the icon now reflects the actual default state:
- If the row is initially closed, the plus icon is shown.
- If the row is initially open, the minus icon is shown.

Before:
![Screenshot 2025-06-23 at 20 35 20](https://github.com/user-attachments/assets/d3f8fd4e-a11d-4b9d-97cd-f2830fc12a04)

After:
![Screenshot 2025-06-23 at 20 35 48](https://github.com/user-attachments/assets/1d158281-271c-4a73-9795-b9f8e68b3267)


Resolves: [MWPW-175427](https://jira.corp.adobe.com/browse/MWPW-175427)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/mirafedas/mini-compare-charts/mini-compare-bullet-list?martech=off
- After: https://mwpw-175427-collapsible--milo--mirafedas.aem.page/drafts/mirafedas/mini-compare-charts/mini-compare-bullet-list?martech=off


