### PR TITLE
MWPW-175170 Update all links for graybox

### DIFF
--- a/libs/blocks/graybox/graybox.js
+++ b/libs/blocks/graybox/graybox.js
@@ -426,13 +426,20 @@ const grayboxThePage = (grayboxEl, grayboxMenuOff) => {
 
   transformLinks();
 
-  const pollForFeds = setInterval(() => {
-    const isLoading = document.querySelector('header .feds-popup.loading');
-    if (!isLoading) {
-      clearInterval(pollForFeds);
-      transformLinks(document.body.querySelector('header'));
-    }
-  }, 100);
+  const observer = new MutationObserver((mutations) => {
+    mutations.forEach((mutation) => {
+      mutation.addedNodes.forEach((node) => {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          transformLinks(node);
+        }
+      });
+    });
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
 };
 
 export default function init(grayboxEl) {


### PR DESCRIPTION
Switch to using a MutationObserver so that any late loaded content will be scrubbed for possible graybox urls.

Resolves: [MWPW-175170](https://jira.corp.adobe.com/browse/MWPW-175170)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://175170--milo--adobecom.aem.page/?martech=off
