### PR TITLE
[MWPW-175255] Actionless action item a11y

### DIFF
--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -119,6 +119,7 @@ export default function init(el) {
   el.replaceChildren(items, ...buttons);
   if (hasNav) {
     handleBtnState(items, buttons);
+    if (!items.querySelectorAll('a').length) items.setAttribute('tabindex', 0);
     allActionScrollers.push({ scroller: items, buttons });
     import('../../utils/action.js').then(({ debounce }) => {
       items.addEventListener('scroll', debounce(() => handleBtnState(items, buttons), 50));


### PR DESCRIPTION
Although the action item was not intended to be used without actual actions (links), it seems that there are cases where it is used in that manner. The arrows that move the items left or right are accessible, but axe is suggesting that the whole area needs to be focusable as well. This is what the current PR aims to implement. Nothing changes for action scrollers that do have nested links.

axe suggestion:
<img width="528" alt="Screenshot 2025-06-24 at 18 17 59" src="https://github.com/user-attachments/assets/fe5bcc84-804e-4082-87c8-5449016101d4" />

Resolves: [MWPW-175255](https://jira.corp.adobe.com/browse/MWPW-175255)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.live/docs/library/kitchen-sink/action-items?martech=off
- After: https://actionless-action-item--milo--overmyheadandbody.aem.live/docs/library/kitchen-sink/action-items?martech=off
- Before (original issue): https://main--da-bacom--adobecom.aem.live/products/firefly-business?martech=off
- After (original issue): https://main--da-bacom--adobecom.aem.live/products/firefly-business?martech=off&milolibs=actionless-action-item--milo--overmyheadandbody


