### PR TITLE
MWPW-175169 Fix gb-changed highlighting

### DIFF
--- a/libs/blocks/graybox/graybox.css
+++ b/libs/blocks/graybox/graybox.css
@@ -80,7 +80,7 @@
   background-color: var(--gb-overlay-color);
   content: "";
   display: block;
-  height: 100%;
+  height: 100vh;
   left: 0;
   pointer-events: none;
   position: fixed;
@@ -105,7 +105,7 @@
 /* The elements that should appear above the overlay */
 .gb-graybox-body .gb-changed {
   position: relative;
-  z-index: calc(var(--base-z-index) - 1);
+  z-index: calc(var(--base-z-index) + 1);
 }
 
 .graybox-container {

--- a/libs/blocks/graybox/graybox.js
+++ b/libs/blocks/graybox/graybox.js
@@ -322,7 +322,10 @@ const createGrayboxMenu = (options, { isOpen = false } = {}) => {
 
 const addPageOverlayDiv = () => {
   const overlayDiv = createTag('div', { class: CLASS.PAGE_OVERLAY });
-  document.body.insertBefore(overlayDiv, document.body.firstChild);
+  const main = document.querySelector('main');
+  if (main) {
+    main.insertBefore(overlayDiv, main.firstChild);
+  }
 };
 
 const setupChangedEls = (globalNoClick) => {


### PR DESCRIPTION
* Moves the page overlay to be a child of main, therefore keeping the stacking context for blocks on the page to have a higher z-index than the overlay.
* 
Resolves: [MWPW-175169](https://jira.corp.adobe.com/browse/MWPW-175169)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://175169--milo--adobecom.aem.page/?martech=off
