### PR TITLE
landscape mode the overlapping of button with menu items

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -1065,6 +1065,7 @@ header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tabs button[aria-
 }
 
 header.new-nav .feds-nav > section.feds-navItem > .feds-popup .tab-content {
+  min-height: 0;
   background-color: var(--feds-backgroundColor-tabContent-v2);
   padding: 10px 13px 25px;
   display: flex;


### PR DESCRIPTION
When branch banner is present in landscape mode the overlapping of button with menu items seen, scroll is not seen working in firefox in android

Steps to Reproduce:
1. hit the url in landscape mode and wait for banner to load
2.button is seen overlapped and not able to scroll in landscape mode

Resolves: [MWPW-175084](https://jira.corp.adobe.com/browse/MWPW-175084)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-175084--milo--patel-prince.aem.page/?martech=off

**QA URL:**
- https://www.stage.adobe.com/acrobat/store-sign-share-docs-photos-free.html?milolibs=mwpw-175084--milo--patel-prince
- https://main--cc--adobecom.hlx.page/drafts/souj/complimentary/online?milolibs=mwpw-175084--milo--patel-prince
- https://main--cc--adobecom.hlx.page/creativecloud?milolibs=mwpw-175084--milo--patel-prince
- https://main--cc--adobecom.hlx.page/products/photoshop/generative-fill?milolibs=mwpw-175084--milo--patel-prince


