### PR TITLE
feat: integrate GenStudio tracking

### DIFF
--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -77,6 +77,19 @@ export const loadAriaAutomation = async () => {
   addAriaLabels();
 };
 
+export const addRUMCampaignTrackingParameters = ({ sampleRUM }) => {
+  const usp = new URLSearchParams(window.location.search);
+  [
+    { key: 'sdid', utmKey: 'utm_campaign' },
+    { key: 'mv', utmKey: 'utm_source' },
+    { key: 'mv2', utmKey: 'utm_medium' },
+  ].forEach(({ key, utmKey }) => {
+    const val = usp.get(key);
+    if (!val || (key === 'sdid' && val.length > 8)) return;
+    sampleRUM('utm', { source: utmKey, target: val });
+  });
+};
+
 /**
  * Executes everything that happens a lot later, without impacting the user experience.
  */
@@ -100,7 +113,10 @@ const loadDelayed = ([
     } else {
       resolve(null);
     }
-    import('../utils/samplerum.js').then(({ sampleRUM }) => sampleRUM());
+    import('../utils/samplerum.js').then(({ sampleRUM }) => {
+      sampleRUM();
+      addRUMCampaignTrackingParameters({ sampleRUM });
+    });
   }, DELAY);
 });
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Add support to track GenStudio campaign tags via RUM

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://integrate-genstudio-tracking--milo--cwjwisse.aem.live/?martech=off




