### PR TITLE
CSO fix for preload

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -316,7 +316,7 @@ export function getMasBase(hostname, maslibs) {
 
 function getCommercePreloadUrl() {
   const { env } = getConfig();
-  if (env === 'prod') {
+  if (env.name === 'prod') {
     return 'https://commerce.adobe.com/store/iframe/preload.js';
   }
   return 'https://commerce-stg.adobe.com/store/iframe/preload.js';


### PR DESCRIPTION
Fixes CSO 202506260041


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://cso-202506260041--milo--adobecom.aem.page/?martech=off


