### PR TITLE
MWPW-175589 and MWPW-175712: Modal does not reopen when navigation back

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -606,7 +606,7 @@ export async function updateModalState({ cta, closedByUser } = {}) {
       ctaToClick.dataset.clickDisabled = 'true';
       ctaToClick.click();
       setTimeout(() => {
-        delete cta.dataset?.clickDisabled;
+        delete ctaToClick.dataset.clickDisabled;
       }, 1000);
     }
     modalState.isOpen = true;

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -601,8 +601,15 @@ export async function updateModalState({ cta, closedByUser } = {}) {
   const modal = document.querySelector(`.dialog-modal${hash}`);
 
   if (hash && !cta && !modalState.isOpen && !modal) {
+    const ctaToClick = document.querySelector(`[is=checkout-link][data-modal-id=${hash.replace('#', '')}]`);
+    if (ctaToClick && !ctaToClick.dataset.clickDisabled) {
+      ctaToClick.dataset.clickDisabled = 'true';
+      ctaToClick.click();
+      setTimeout(() => {
+        delete cta.dataset?.clickDisabled;
+      }, 1000);
+    }
     modalState.isOpen = true;
-    document.querySelector(`[is=checkout-link][data-modal-id=${hash.replace('#', '')}]`)?.click();
     return modalState.isOpen;
   }
 

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -576,17 +576,33 @@ export async function updateModalState({ cta, closedByUser } = {}) {
   if (hash?.includes('=')) {
     const modal = document.querySelector('.dialog-modal');
     if (!modal) return modalState.isOpen;
-    const { closeModal } = await import('../modal/modal.js');
-    closeModal(modal);
     modalState.isOpen = false;
+    document.querySelectorAll(`#${modal.id}`).forEach((mod) => {
+      if (mod.classList.contains('dialog-modal')) {
+        const modalCurtain = document.querySelector(`#${modal.id}~.modal-curtain`);
+        if (modalCurtain) {
+          modalCurtain.remove();
+        }
+        mod.remove();
+      }
+      document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();
+    });
+
+    if (!document.querySelectorAll('.modal-curtain').length) {
+      document.body.classList.remove('disable-scroll');
+    }
+
+    [...document.querySelectorAll('header, main, footer')]
+      .forEach((element) => element.removeAttribute('aria-disabled'));
+
     return modalState.isOpen;
   }
 
   const modal = document.querySelector(`.dialog-modal${hash}`);
 
   if (hash && !cta && !modalState.isOpen && !modal) {
-    document.querySelector(`[is=checkout-link][data-modal-id=${hash.replace('#', '')}]`)?.click();
     modalState.isOpen = true;
+    document.querySelector(`[is=checkout-link][data-modal-id=${hash.replace('#', '')}]`)?.click();
     return modalState.isOpen;
   }
 

--- a/libs/blocks/merch/merch.md
+++ b/libs/blocks/merch/merch.md
@@ -1,0 +1,42 @@
+# Merch Modal State Handling
+
+The `updateModalState` function manages the state of merch modals across different user interactions and browser navigation scenarios. This function handles five primary use cases to ensure proper modal behavior.
+
+## Use Cases
+
+### Use Case #1: Merch Card Collection Filters
+
+When users have filters selected on merch card collections, open a modal, and then close it, the hash changes to the previous one (with filters). The modal doesn't get closed by `modal.js` because `modal.js` only closes modals when there is no hash in the URL. This function handles closing the modal in this scenario.
+
+**Example URL with filters in hash:**
+```
+https://main--cc--adobecom.aem.live/products/catalog#category=photo&types=desktop
+```
+
+**Technical Details:**
+- When hash includes '=' it is not a valid selector and throws an error in the console when trying to find the modal by hash
+- Example: `document.querySelector('.dialog-modal#category=photo&types=desktop')`
+- To avoid this error, we select the modal only by the class
+
+### Use Case #2: Browser Back-Forward Navigation
+
+Handles user clicks and browser back-forward navigation scenarios.
+
+**Scenario:** When a user opens a modal, closes it, and clicks 'Back' in the browser, the page is not reloaded. The function finds the first CTA matching the hash and clicks it to restore the modal state.
+
+### Use Case #3: Reopening Modal on Page Load
+
+Reopens the modal on page load if the URL contains the hash. The function waits for each CTA to be ready and tries to reopen the modal by clicking the first CTA with a matching `data-modal-id` attribute.
+
+### Use Case #4: Modal Closed by User
+
+Updates the modal state to reflect when a modal has been closed by the user.
+
+### Use Case #5: Hash Removed from URL
+
+If there is no hash in the URL but the modal is still open, the function closes it to maintain consistency.
+
+## Implementation Notes
+
+- The function returns the current modal state, which is used in tests
+- Modal state is tracked via the `modalState.isOpen` boolean

--- a/libs/blocks/merch/three-in-one.js
+++ b/libs/blocks/merch/three-in-one.js
@@ -113,7 +113,7 @@ export const handle3in1IFrameEvents = ({ data: msgData }) => {
   }
 };
 
-export const handleTimeoutError = () => {
+export const handleTimeoutError = async () => {
   const modal = document.querySelector('.three-in-one');
   const miloIframe = modal?.querySelector('.milo-iframe');
   const iframe = modal?.querySelector('iframe');
@@ -121,7 +121,7 @@ export const handleTimeoutError = () => {
   if (iframe?.getAttribute('data-pageloaded') || !miloIframe || !iframe || !theme) return;
   const wasReloaded = iframe.getAttribute('data-wasreloaded') === 'true';
 
-  showErrorMsg({ iframe, miloIframe, showBtn: !wasReloaded, theme, handleTimeoutError });
+  await showErrorMsg({ iframe, miloIframe, showBtn: !wasReloaded, theme, handleTimeoutError });
 
   if (wasReloaded) {
     setTimeout(() => {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -72,8 +72,9 @@ export function closeModal(modal) {
   [...document.querySelectorAll('header, main, footer')]
     .forEach((element) => element.removeAttribute('aria-disabled'));
 
-  const hashId = window.location.hash.replace('#', '');
-  if (hashId === modal.id) window.history.pushState('', document.title, `${window.location.pathname}${window.location.search}`);
+  if (window.location.hash === `#${modal.id}`) {
+    window.history.pushState(window.history.state, document.title, `${window.location.pathname}${window.location.search}`);
+  }
   isDelayedModal = false;
   if (prevHash) {
     window.location.hash = prevHash;

--- a/nala/blocks/merch/three-in-one.test.js
+++ b/nala/blocks/merch/three-in-one.test.js
@@ -27,6 +27,20 @@ test.describe('ThreeInOne Block test suite', () => {
         await expect(el).toHaveAttribute('href', href);
       }
     });
+
+    await test.step('Validate if modal reopens on back navigation', async () => {
+      const cta = await page.locator('[data-wcs-osi="ByqyQ6QmyXhzAOnjIcfHcoF1l6nfkeLgbzWz-aeM8GQ"][data-checkout-workflow-step="segmentation"]');
+      await cta.click();
+      await page.waitForSelector('.dialog-modal');
+      const modal = threeInOne.getModal();
+      expect(modal).toBeVisible();
+      await page.goto('https://www.adobe.com');
+      await page.goBack();
+      const newModal = threeInOne.getModal();
+      await expect(newModal).toBeVisible();
+      await threeInOne.closeModal();
+      expect(newModal).not.toBeVisible();
+    });
   });
 
   test(`${features[1].name}, ${features[1].tags}`, async ({ page, baseURL }) => {

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -1,5 +1,4 @@
 import { expect } from '@esm-bundle/chai';
-import sinon from 'sinon';
 import { delay } from '../../helpers/waitfor.js';
 
 import { CheckoutWorkflowStep, Defaults, Log } from '../../../libs/deps/mas/commerce.js';
@@ -23,11 +22,11 @@ import merch, {
   getOptions,
   appendDexterParameters,
   getMiloLocaleSettings,
-  reopenModal,
-  resetReopenStatus,
   setCtaHash,
   openModal,
   PRICE_TEMPLATE_LEGAL,
+  modalState,
+  updateModalState,
 } from '../../../libs/blocks/merch/merch.js';
 import { localizePreviewLinks } from '../../../libs/blocks/merch/autoblock.js';
 
@@ -481,78 +480,6 @@ describe('Merch Block', () => {
       const params = new URLSearchParams();
       expect(await buildCta(el, params)).to.be.null;
     });
-
-    describe('reopenModal', () => {
-      it('clicks the CTA if hashes match', async () => {
-        const prevHash = window.location.hash;
-        window.location.hash = '#try-photoshop';
-        const cta = document.createElement('a');
-        cta.setAttribute('data-modal-id', 'try-photoshop');
-        const clickSpy = sinon.spy(cta, 'click');
-        reopenModal(cta);
-        expect(clickSpy.called).to.be.true;
-        window.location.hash = prevHash;
-        resetReopenStatus();
-      });
-
-      it('only reopens one modal if multiples hashes match', async () => {
-        const prevHash = window.location.hash;
-        window.location.hash = '#try-photoshop';
-
-        const cta1 = document.createElement('a');
-        cta1.setAttribute('data-modal-id', 'try-photoshop');
-        const clickSpy1 = sinon.spy(cta1, 'click');
-
-        const cta2 = document.createElement('a');
-        cta1.setAttribute('data-modal-id', 'try-photoshop');
-        const clickSpy2 = sinon.spy(cta2, 'click');
-
-        reopenModal(cta1);
-        reopenModal(cta2);
-
-        expect(clickSpy1.called).to.be.true;
-        expect(clickSpy2.called).to.be.false;
-
-        window.location.hash = prevHash;
-        resetReopenStatus();
-      });
-    });
-
-    describe('openModal', () => {
-      it('sets the new hash and event listener to restore the hash on close', async () => {
-        const prevHash = window.location.hash;
-        await openModal(new CustomEvent('test'), 'https://www.adobe.com/mini-plans/creativecloud.html?mid=ft&web=1', 'TRIAL', 'try-photoshop');
-        expect(window.location.hash).to.equal('#try-photoshop');
-        const modalCloseEvent = new CustomEvent('milo:modal:closed');
-        window.dispatchEvent(modalCloseEvent);
-        expect(window.location.hash).to.equal(prevHash);
-        document.body.querySelector('.dialog-modal').remove();
-        window.location.hash = prevHash;
-      });
-
-      it('opens the 3-in-1 modal', async () => {
-        const checkoutLink = document.createElement('a');
-        checkoutLink.setAttribute('is', 'checkout-link');
-        checkoutLink.setAttribute('data-checkout-workflow', 'UCv3');
-        checkoutLink.setAttribute('data-checkout-workflow-step', 'segmentation');
-        checkoutLink.setAttribute('data-modal', 'true');
-        checkoutLink.setAttribute('data-quantity', '1');
-        checkoutLink.setAttribute('data-wcs-osi', 'L2C9cKHNNDaFtBVB6GVsyNI88RlyimSlzVfkMM2gH4A');
-        checkoutLink.setAttribute('data-extra-options', '{}');
-        checkoutLink.setAttribute('class', 'con-button placeholder-resolved');
-        checkoutLink.setAttribute('href', 'https://commerce.adobe.com/store/segmentation?ms=COM&ot=TRIAL&pa=phsp_direct_individual&cli=adobe_com&ctx=if&co=US&lang=en');
-        checkoutLink.setAttribute('daa-ll', 'Free trial-1--');
-        checkoutLink.setAttribute('data-modal-id', 'mini-plans-web-cta-photoshop-card');
-        checkoutLink.setAttribute('data-modal-type', 'twp');
-        Object.defineProperty(checkoutLink, 'isOpen3in1Modal', { get: () => true });
-        await openModal(new CustomEvent('test'), 'https://www.adobe.com/mini-plans/creativecloud.html?mid=ft&web=1', 'TRIAL', 'try-photoshop', {}, checkoutLink);
-        const threeInOneModal = document.querySelector('.dialog-modal.three-in-one');
-        expect(threeInOneModal).to.exist;
-        const iFrame = document.querySelector('.dialog-modal.three-in-one iframe');
-        expect(iFrame.src).to.equal('https://commerce.adobe.com/store/segmentation?ms=COM&ot=TRIAL&pa=phsp_direct_individual&cli=adobe_com&ctx=if&co=US&lang=en');
-        threeInOneModal.remove();
-      });
-    });
   });
 
   describe('Download flow', () => {
@@ -657,6 +584,45 @@ describe('Merch Block', () => {
       const sourceCta = await merch(document.querySelector('.merch.cta.upgrade-source'));
       await sourceCta.onceSettled();
       expect(sourceCta.textContent).to.equal('Upgrade Now');
+    });
+  });
+
+  describe('openModal', () => {
+    it('sets the new hash when it is passed as argument', async () => {
+      modalState.isOpen = false;
+      const prevHash = window.location.hash;
+      await openModal(new CustomEvent('test'), 'https://www.adobe.com/mini-plans/creativecloud.html?mid=ft&web=1', 'TRIAL', 'mini-plans-web-cta-creative-cloud-card');
+      expect(window.location.hash).to.equal('#mini-plans-web-cta-creative-cloud-card');
+      document.body.querySelector('.dialog-modal').remove();
+      window.location.hash = prevHash;
+      modalState.isOpen = false;
+    });
+
+    it('opens the 3-in-1 modal', async () => {
+      const prevHash = window.location.hash;
+      modalState.isOpen = false;
+      const checkoutLink = document.createElement('a');
+      checkoutLink.setAttribute('is', 'checkout-link');
+      checkoutLink.setAttribute('data-checkout-workflow-step', 'segmentation');
+      checkoutLink.setAttribute('data-modal', 'crm');
+      checkoutLink.setAttribute('data-quantity', '1');
+      checkoutLink.setAttribute('data-wcs-osi', 'JzW8dgW8U1SrgbHDmTE-ABsOKPgtl5jugiW8bA5PtKg');
+      checkoutLink.setAttribute('data-extra-options', '{"rf":"uc_segmentation_hide_tabs_cr"}');
+      checkoutLink.setAttribute('class', 'con-button placeholder-resolved');
+      checkoutLink.setAttribute('href', 'https://commerce.adobe.com/store/segmentation?cli=creative&ctx=if&co=US&rf=uc_segmentation_hide_tabs_cr&lang=en&ms=COM&ot=TRIAL&cs=INDIVIDUAL&pa=ccsn_direct_individual&rtc=t&lo=sl&af=uc_new_user_iframe%2Cuc_new_system_close');
+      checkoutLink.setAttribute('daa-ll', 'Free trial-5--creative-cloud');
+      checkoutLink.setAttribute('data-modal-id', 'mini-plans-web-cta-creative-cloud-card');
+      Object.defineProperty(checkoutLink, 'isOpen3in1Modal', { get: () => true });
+
+      await openModal(new CustomEvent('test'), 'https://www.adobe.com/mini-plans/creativecloud.html?mid=ft&web=1', 'TRIAL', 'mini-plans-web-cta-creative-cloud-card', { rf: 'uc_segmentation_hide_tabs_cr' }, checkoutLink);
+
+      const threeInOneModal = document.querySelector('.dialog-modal.three-in-one');
+      expect(threeInOneModal).to.exist;
+      const iFrame = document.querySelector('.dialog-modal.three-in-one iframe');
+      expect(iFrame.src).to.equal('https://commerce.adobe.com/store/segmentation?cli=creative&ctx=if&co=US&rf=uc_segmentation_hide_tabs_cr&lang=en&ms=COM&ot=TRIAL&cs=INDIVIDUAL&pa=ccsn_direct_individual&rtc=t&lo=sl&af=uc_new_user_iframe%2Cuc_new_system_close');
+      threeInOneModal.remove();
+      window.location.hash = prevHash;
+      modalState.isOpen = false;
     });
   });
 
@@ -880,6 +846,48 @@ describe('Merch Block', () => {
       const relativeUrl = '/plans-fragments/modals/individual/modals-content-rich/all-apps/master.modal.html';
       const resultUrl = appendDexterParameters(relativeUrl, JSON.stringify({ promoid: 'test' }));
       expect(resultUrl).to.include('?promoid=test');
+    });
+  });
+
+  describe('updateModalState', () => {
+    const prevHash = window.location.hash;
+
+    afterEach(() => {
+      modalState.isOpen = false;
+      document.querySelector('.dialog-modal')?.remove();
+      window.location.hash = prevHash;
+    });
+
+    it('closes the modal on back navigation on catalog page when filters were selected', async () => {
+      modalState.isOpen = false;
+      window.location.hash = '#category=photo&types=desktop';
+      modalState.isOpen = true;
+      const isModalOpen = await updateModalState();
+      expect(isModalOpen).to.be.false;
+    });
+
+    it('updates the state when modal was closed by user', async () => {
+      window.location.hash = '#miniplans-buy-all-apps';
+      const isModalOpen = await updateModalState();
+      expect(isModalOpen).to.be.true;
+    });
+
+    it('reflects the state when the modal gets closed by user click', async () => {
+      const modal = document.createElement('div');
+      modal.classList.add('dialog-modal');
+      document.body.appendChild(modal);
+      const isModalOpen = await updateModalState({ closedByUser: true });
+      expect(isModalOpen).to.be.false;
+    });
+
+    it('closes the modal when the hash was removed from the URL', async () => {
+      window.location.hash = '';
+      const modal = document.createElement('div');
+      modal.id = 'mini-plans-web-cta-creative-cloud-card';
+      modal.classList.add('dialog-modal');
+      document.body.appendChild(modal);
+      const isModalOpen = await updateModalState();
+      expect(isModalOpen).to.be.false;
     });
   });
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -860,6 +860,10 @@ describe('Merch Block', () => {
 
     it('closes the modal on back navigation on catalog page when filters were selected', async () => {
       modalState.isOpen = false;
+      const modal = document.createElement('div');
+      modal.classList.add('dialog-modal');
+      modal.id = 'mini-plans-web-cta-creative-cloud-card';
+      document.body.appendChild(modal);
       window.location.hash = '#category=photo&types=desktop';
       modalState.isOpen = true;
       const isModalOpen = await updateModalState();
@@ -875,6 +879,7 @@ describe('Merch Block', () => {
     it('reflects the state when the modal gets closed by user click', async () => {
       const modal = document.createElement('div');
       modal.classList.add('dialog-modal');
+      modal.id = 'mini-plans-web-cta-creative-cloud-card';
       document.body.appendChild(modal);
       const isModalOpen = await updateModalState({ closedByUser: true });
       expect(isModalOpen).to.be.false;


### PR DESCRIPTION
This PR fixes modal functionality for the following scenarios:
1. Browser navigation with modals: When a user opens a modal, navigates to another page, then clicks the browser's back button (or directly visits a URL with a modal hash), the modal will now properly reopen.
 
3. Filter preservation on catalog page (and any page that uses the merch-card-collection with the merch-sidebar):
When users have applied filters on the catalog page (like https://main--cc--adobecom.aem.live/products/catalog#category=graphic-design&types=desktop), opened the modal and clicked "Back" in the browser- the hash should change to the previous one (it does), and the modal should get closed (this was not working).  Also added checking to make sure the modal gets (re)opened only once, even if there are multiple CTAs with the same `data-modal-id` attribute.

5. Multiple clicks on the same CTA on a slow network cause multiple modals to open. Now it opens only one.
Note: Clicking the modal multiple times adds a grey overlay to the commerce page. This issue should be addressed by the commerce team.

Added Nala tests for the first use-case.

Resolves: [MWPW-175589](https://jira.corp.adobe.com/browse/MWPW-175589) and [MWPW-175712](https://jira.corp.adobe.com/browse/MWPW-175712)

**Test URLs:**
Before: 
- https://main--milo--adobecom.aem.page/drafts/mirafedas/3in1-test-page?martech=off&georouting=off
- https://main--cc--adobecom.aem.live/products/catalog#category=graphic-design

After: 
- https://mwpw-174745-modal-redirection--milo--mirafedas.aem.page/drafts/mirafedas/3in1-test-page?martech=off&georouting=off
- https://main--cc--adobecom.aem.live/products/catalog?milolibs=mwpw-174745-modal-redirection--milo--mirafedas&martech=off&georouting=off#category=graphic-design














































