### PR TITLE
MWPW-175726 [Milo][MEP] DecorateMeta does not find localized federal preview urls on production pages

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1587,7 +1587,7 @@ function initSidekick() {
 
 function decorateMeta() {
   const { origin } = window.location;
-  const contents = document.head.querySelectorAll('[content*=".hlx."], [content*=".aem."]');
+  const contents = document.head.querySelectorAll('[content*=".hlx."], [content*=".aem."], [content*="/federal/"]');
   contents.forEach((meta) => {
     if (meta.getAttribute('property') === 'hlx:proxyUrl' || meta.getAttribute('name')?.endsWith('schedule')) return;
     try {


### PR DESCRIPTION
After replacing the gnav-promo-source with a preview link (only on production pages) using updateMetadata in MEP, the available localized promo content is not shown. However, the localized content shows as expected on preview pages.

The issue is that in production, getFederatedUrl (used in normalizePath in personalization.js) returns a production url, but decorateMeta (in utils.js) is only looking for preview links. 

This PR updates updates decorateMeta to also look for production urls. 

Resolves: [MWPW-175726](https://jira.corp.adobe.com/browse/MWPW-175726)

To see the issue, you can see this [link](https://www.adobe.com/hk_zh/products/illustrator.html?instant=2025-06-30T04%3A00%3A00.000Z&mep=%2Fproducts%2Fillustrator.json--default---%2Fcc-shared%2Ffragments%2Fpromos%2F2025%2Fapac%2Fapac-promo-cup-hk-2025%2Fapac-promo-cup-hk-2025-gnav.json--default---%2Fcc-shared%2Ffragments%2Fpromos%2F2025%2Fapac%2Fapac-promo-cup-hk-2025%2Fpreservingbug.json
 ) where you will see english promo content(all manifests except for preservingbug.json should be set to default):
 
 
![Screenshot 2025-06-27 at 3 30 16 PM](https://github.com/user-attachments/assets/f87f4ec3-689c-4bc8-a575-e4d769db536c)

Since this is in production, to see the "after" case, you will need to overwrite the utils.js file in the browser with the file content from this PR. After reloading, you should see Chinese content for the promo(all manifests except for preservingbug.json should be set to default):

![Screenshot 2025-06-27 at 3 32 27 PM](https://github.com/user-attachments/assets/776ceede-9e24-4475-b245-1298fc19c8ce)




**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mepdecoratemetafix--milo--adobecom.aem.page/?martech=off


