### PR TITLE
MWPW-175712v2: prevent openThreeInOneModal to execute twice

### DIFF
--- a/libs/blocks/merch/three-in-one.js
+++ b/libs/blocks/merch/three-in-one.js
@@ -20,6 +20,8 @@ export const LANA_OPTIONS = {
   tags: 'three-in-one',
 };
 
+let isModalOpened = false;
+
 export const reloadIframe = ({ iframe, theme, msgWrapper, handleTimeoutError }) => {
   if (!msgWrapper || !iframe || !theme || !handleTimeoutError) return;
   msgWrapper.remove();
@@ -141,6 +143,8 @@ export function createContent(iframeUrl) {
 }
 
 export default async function openThreeInOneModal(el) {
+  if (isModalOpened) return undefined;
+  isModalOpened = true;
   const iframeUrl = el?.href;
   const modalType = el?.getAttribute('data-modal');
   const id = el?.getAttribute('data-modal-id');
@@ -150,6 +154,7 @@ export default async function openThreeInOneModal(el) {
   const timeoutId = setTimeout(handleTimeoutError, 15000);
   const clearTimeoutOnClose = () => {
     clearTimeout(timeoutId);
+    isModalOpened = false;
     window.removeEventListener('milo:modal:closed', clearTimeoutOnClose);
   };
   window.addEventListener('milo:modal:closed', clearTimeoutOnClose);


### PR DESCRIPTION
this is a hotfix, we still need to analyze whe openThreeInOneModal is being called twice

Resolves: [MWPW-175712](https://jira.corp.adobe.com/browse/MWPW-175712)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-175712--milo--adobecom.aem.page/?martech=off


