### PR TITLE
MWPW-175097: Enable preview for stage.adobe.com

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -671,7 +671,7 @@ export async function getCheckoutAction(offers, options, imsSignedInPromise, el)
 
 export function setPreview(attributes) {
   const { host } = window.location;
-  if (host.includes(`${SLD}.page`) || host.origin === 'https://www.stage.adobe.com') {
+  if (host.includes(`${SLD}.page`) || host === 'www.stage.adobe.com') {
     attributes.preview = 'on';
   }
 }

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -671,7 +671,7 @@ export async function getCheckoutAction(offers, options, imsSignedInPromise, el)
 
 export function setPreview(attributes) {
   const { host } = window.location;
-  if (host.includes(`${SLD}.page`) || host.includes('stage.adobe.com')) {
+  if (host.includes(`${SLD}.page`) || host === 'www.stage.adobe.com') {
     attributes.preview = 'on';
   }
 }

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -671,7 +671,7 @@ export async function getCheckoutAction(offers, options, imsSignedInPromise, el)
 
 export function setPreview(attributes) {
   const { host } = window.location;
-  if (host.includes(`${SLD}.page`) || host === 'www.stage.adobe.com') {
+  if (host.includes(`${SLD}.page`) || host.includes('stage.adobe.com')) {
     attributes.preview = 'on';
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* enable preview on stage.adobe.com

can only be verified via browser overrides, since its only reproducible on www.stage
(https://www.stage.adobe.com/cc-shared/fragments/drafts/mariia/document)

Resolves: [MWPW-175097](https://jira.corp.adobe.com/browse/MWPW-175097)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/drafts/nala/features/commerce/plans?martech=off&georouting=off
- After: https://MWPW-175097--milo--markovicpredrag1209.aem.live/drafts/nala/features/commerce/plans?martech=off&georouting=off






