### PR TITLE
[MWPW-175634] Reading time color update for a11y

### DIFF
--- a/libs/blocks/reading-time/reading-time.css
+++ b/libs/blocks/reading-time/reading-time.css
@@ -1,7 +1,7 @@
 @import '../../styles/inline.css';
 
 .reading-time > span {
-  color: #adadad;
+  color: rgb(80 80 80);
   font-style: italic;
   font-weight: 700;
   font-size: var(--type-body-s-size);
@@ -40,7 +40,7 @@ main > .section > .inline-wrapper > .inline.reading-time + .inline.share {
     border-left: none;
     padding-left: 0;
   }
-  
+
   main > .section > .inline-wrapper > .inline + .inline.reading-time {
     border-top: 1px solid #adadad;
   }

--- a/nala/blocks/reading-time/reading-time.test.js
+++ b/nala/blocks/reading-time/reading-time.test.js
@@ -34,7 +34,7 @@ test.describe('Reading-time feature test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on Reading-time block', async () => {
-      await runAccessibilityTest({ page, testScope: readingTime.readingTime, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: readingTime.readingTime });
     });
   });
 
@@ -63,7 +63,7 @@ test.describe('Reading-time feature test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on Reading-time without text block', async () => {
-      await runAccessibilityTest({ page, testScope: readingTime.readingTime, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: readingTime.readingTime });
     });
   });
 
@@ -112,7 +112,7 @@ test.describe('Reading-time feature test suite', () => {
     });
 
     await test.step('step-4: Verify the accessibility test on Reading-time with text block', async () => {
-      await runAccessibilityTest({ page, testScope: readingTime.readingTime, skipA11yTest: true });
+      await runAccessibilityTest({ page, testScope: readingTime.readingTime });
     });
   });
 });

--- a/nala/utils/nala.run.js
+++ b/nala/utils/nala.run.js
@@ -21,7 +21,7 @@ function displayHelp() {
   \x1b[33m* config=<config-file>\x1b[0m               Custom configuration file to use (default: Playwright's default)
   \x1b[33m* project=<project-name>\x1b[0m             Project configuration (default: milo-live-chromium)
   \x1b[33m* milolibs=<local|prod|code|feature>\x1b[0m Milo library environment (default: none)
-  \x1b[33m* owner=<repo-owner>\x1b[0m                 repo owner (default owner = adobecom) 
+  \x1b[33m* owner=<repo-owner>\x1b[0m                 repo owner (default owner = adobecom)
 
 \x1b[1mExamples:\x1b[0m
   | \x1b[36mCommand\x1b[0m                                                | \x1b[36mDescription\x1b[0m                                                                        |
@@ -33,7 +33,7 @@ function displayHelp() {
   | npm run nala local mode=ui                             | Runs all nala tests on local environment in UI mode on chrome browser              |
   | npm run nala local -g=@accordion                       | Runs tests annotated with tag i.e @accordion on local env on chrome browser        |
   | npm run nala local -g=@accordion browser=firefox       | Runs tests annotated with tag i.e @accordion on local env on Firefox browser       |
-  | npm run nala <featurebranch> owner='<owner>'           | Runs all nala tests on the specified feature branch for the given repo owner       |        
+  | npm run nala <featurebranch> owner='<owner>'           | Runs all nala tests on the specified feature branch for the given repo owner       |
 
 \x1b[1mDebugging:\x1b[0m
 -----------


### PR DESCRIPTION
This adapts the color of the reading time block to be a darker shade of gray in order to meet minimum contrast for accessibility purposes. It's not clear what the usage of this block is across the website, so updating the color should be very low risk. The chosen gray is Spectrum 2-compliant and is the first option that actually meets the 4.5:1 color contrast.

Resolves: [MWPW-175634](https://jira.corp.adobe.com/browse/MWPW-175634)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/nala/blocks/reading-time/reading-time-block?martech=off
- After: https://reading-time-color--milo--overmyheadandbody.aem.page/drafts/nala/blocks/reading-time/reading-time-block?martech=off


