### PR TITLE
Add gist block as milo core block

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -32,6 +32,7 @@ const MILO_BLOCKS = [
   'form',
   'fragment',
   'featured-article',
+  'gist',
   'global-footer',
   'global-navigation',
   'graybox',


### PR DESCRIPTION
### Description
Adds gist block to the core milo blocks. otherwise consumers try to load it from their project

Resolves: [MWPW-175918](https://jira.corp.adobe.com/browse/MWPW-175918)

**Test URLs:**
- Before: https://main--milo-college--atsx-api.aem.page/?martech=off
- After: https://main--milo-college--atsx-api.aem.page/fragments/sn-product/code?milolibs=add-gist-as-milo-core-block--milo--mokimo
- https://add-gist-as-milo-core-block--milo--mokimo.aem.live/