### PR TITLE
Appending link group classes instead of replacing

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1542,7 +1542,7 @@ class Gnav {
               return !this.customLinks.includes(linkHash);
             };
             [...customLinksSection.classList].splice(1).forEach((className) => {
-              customLinkModifier = ` feds-navItem--${className}`;
+              customLinkModifier += ` feds-navItem--${className}`;
             });
             removeCustomLink = removeLink();
           } else if (itemHasActiveLink) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* mobile-only class was getting removed since we were picking only the last class item
* Fixed by appending all authored classes

Resolves: [MWPW-175933](https://jira.corp.adobe.com/browse/MWPW-175933)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-175933--milo--adobecom.aem.page/?martech=off

**QA**
- Before: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&authoringpath=/federal/dev/blaishram/home&customlinks=home,apps,learn,files,discover
- After: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&authoringpath=/federal/dev/blaishram/home&customlinks=home,apps,learn,files,discover&navbranch=MWPW-175933
