### PR TITLE
[MWPW-170376] Preflight assets tab updates

### DIFF
--- a/libs/blocks/preflight/checks/constants.js
+++ b/libs/blocks/preflight/checks/constants.js
@@ -27,4 +27,4 @@ export const PERFORMANCE_TITLES = {
   Icons: 'Icons',
 };
 
-export const ASSETS_TITLES = { ImageDimensions: 'Image Dimensions' };
+export const ASSETS_TITLES = { AssetDimensions: 'Asset Dimensions' };

--- a/libs/blocks/preflight/checks/seo.js
+++ b/libs/blocks/preflight/checks/seo.js
@@ -117,7 +117,7 @@ export async function checkDescription(area) {
 }
 
 export async function checkBody(area) {
-  const nonContentEls = '#preflight, .picture-meta, aem-sidekick';
+  const nonContentEls = '#preflight, .asset-meta, aem-sidekick';
   const bodyClone = area.body.cloneNode(true);
   bodyClone.querySelectorAll(nonContentEls).forEach((el) => el.remove());
   const { length } = bodyClone.innerText.replace(/\n/g, '').trim();

--- a/libs/blocks/preflight/panels/accessibility.js
+++ b/libs/blocks/preflight/panels/accessibility.js
@@ -58,13 +58,13 @@ async function checkAlt() {
     const picture = img.closest('picture');
 
     if (picture) {
-      pictureMetaElem = picture.querySelector('.picture-meta');
+      pictureMetaElem = picture.querySelector('.asset-meta');
       if (!pictureMetaElem) {
-        pictureMetaElem = createTag('div', { class: 'picture-meta preflight-decoration' });
+        pictureMetaElem = createTag('div', { class: 'asset-meta preflight-decoration' });
         picture.insertBefore(pictureMetaElem, img.nextSibling);
       }
     } else {
-      pictureMetaElem = createTag('div', { class: 'picture-meta preflight-decoration no-picture-tag' });
+      pictureMetaElem = createTag('div', { class: 'asset-meta preflight-decoration no-picture-tag' });
       img.parentNode.insertBefore(pictureMetaElem, img.nextSibling);
     }
 
@@ -75,7 +75,7 @@ async function checkAlt() {
 
       a11yMessage = createTag(
         'div',
-        { class: 'picture-meta-a11y preflight-decoration is-decorative' },
+        { class: 'asset-meta-entry preflight-decoration needs-attention' },
         img.dataset.altCheck,
       );
 
@@ -89,7 +89,7 @@ async function checkAlt() {
     if (alt) {
       a11yMessage = createTag(
         'div',
-        { class: 'picture-meta-a11y preflight-decoration has-alt' },
+        { class: 'asset-meta-entry preflight-decoration is-valid' },
         `Alt: ${alt}`,
       );
 

--- a/libs/blocks/preflight/panels/general.js
+++ b/libs/blocks/preflight/panels/general.js
@@ -169,6 +169,7 @@ function prettyDate(string) {
 }
 
 function prettyPath(url) {
+  if (!url) return '';
   if (url.pathname === window.location.pathname) return url.pathname;
   return url.hash ? `${url.pathname} (${url.hash})` : url.pathname;
 }

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -673,13 +673,20 @@ body.preflight-assets-analysis {
   font-weight: bold;
 }
 
-picture:has(.picture-meta) {
+.assets-image-grid-item iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+picture:has(.asset-meta),
+.video-holder:has(.asset-meta) {
   position: relative;
   display: block;
   height: 100%;
 }
 
-.picture-meta {
+.asset-meta {
   position: absolute;
   top: 10px;
   left: 10px;
@@ -697,70 +704,74 @@ picture:has(.picture-meta) {
   opacity: 0.7;
 }
 
-.text.center .picture-meta {
+.text.center .asset-meta {
   left: 50%;
   transform: translateX(-50%);
 }
 
-.brick .background .picture-meta,
-.brick .background .picture-meta > div {
+.brick .background .asset-meta,
+.brick .background .asset-meta > div {
   height: unset;
   padding: unset;
   margin: unset;
 }
 
-.brick .foreground div > :is(.video-container, picture, [class^="picture-meta"]) {
+.brick .foreground div > :is(.video-holder, picture, [class^="asset-meta"]) {
   margin: 0;
 }
 
-.brick.split.row .foreground .brick-media picture:has(.picture-meta) img {
+.brick.split.row .foreground .brick-media picture:has(.asset-meta) img {
   width: 100%;
 }
 
-.brick:has(.background) .foreground .icon-area .picture-meta {
+.brick:has(.background) .foreground .icon-area .asset-meta {
   top: unset;
   bottom: -5px;
 }
 
-.brick .icon-stack-area .picture-meta {
+.brick .icon-stack-area .asset-meta {
   flex-direction: row;
   width: max-content;
   column-gap: 5px;
 }
 
-.hero-marquee.media-cover picture:has(.picture-meta) {
+.hero-marquee.media-cover :is(picture, .video-holder):has(.asset-meta) {
   display: block;
 }
 
-.picture-meta.no-picture-tag {
+.asset-meta.no-picture-tag {
   position: relative;
   top: unset;
   left: unset;
   right: unset;
 }
 
-picture:hover .picture-meta,
-img:hover ~ .picture-meta {
+picture:hover .asset-meta,
+img:hover ~ .asset-meta,
+.video-holder:hover .asset-meta {
   opacity: 1;
   z-index: 3;
 }
 
-.picture-meta > div,
-.brick .background .picture-meta > div {
+.asset-meta > div,
+.brick .background .asset-meta > div {
   padding: 5px;
   border-radius: 6px;
 }
 
-.picture-meta-a11y.is-decorative {
+.asset-meta-entry {
+  word-break: break-word;
+}
+
+.asset-meta-entry.needs-attention {
   background: #FFB74D;
 }
 
-.picture-meta-asset.has-mismatch {
+.asset-meta-entry.is-invalid {
   background: #EF5350;
 }
 
-.picture-meta-asset.no-mismatch,
-.picture-meta-a11y.has-alt {
+.asset-meta-entry.is-valid {
   background: #4CAF50;
 }
 

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -490,13 +490,16 @@ export function decorateAnchorVideo({ src = '', anchorTag }) {
   if (indexOfVideo === 1) {
     firstVideo = videoEl;
   }
+
   createIntersectionObserver({
     el: videoEl,
     options: { rootMargin: '1000px' },
     callback: () => {
-      videoEl?.appendChild(createTag('source', { src, type: 'video/mp4' }));
+      if (videoEl.querySelector('source')) return;
+      videoEl.appendChild(createTag('source', { src, type: 'video/mp4' }));
     },
   });
+
   if (videoEl.controls) {
     const io = new IntersectionObserver((entries) => {
       entries.forEach(({ isIntersecting, target }) => {

--- a/test/blocks/preflight/checks/assets.test.js
+++ b/test/blocks/preflight/checks/assets.test.js
@@ -78,8 +78,8 @@ describe('Preflight Asset Checks', () => {
     });
 
     it('tests basic checks for pass states', async () => {
-      mockImage.getAttribute.withArgs('width').returns('2000');
-      mockImage.getAttribute.withArgs('height').returns('1000');
+      mockImage.getAttribute.withArgs('width').returns('3000');
+      mockImage.getAttribute.withArgs('height').returns('1200');
       mockImage.getAttribute.withArgs('src').returns('test.jpg');
       window.createTag = () => ({ append: sinon.stub() });
 

--- a/test/blocks/preflight/panels/assets.test.js
+++ b/test/blocks/preflight/panels/assets.test.js
@@ -33,7 +33,7 @@ describe('Preflight Assets Panel', () => {
 
     render(html`<${Assets} />`, container);
 
-    expect(container.querySelector('.assets-item-title').textContent).to.equal('Image Dimensions');
+    expect(container.querySelector('.assets-item-title').textContent).to.equal('Asset Dimensions');
     expect(container.querySelector('.assets-item-description').textContent).to.equal('Checking...');
   });
 


### PR DESCRIPTION
This adapts the Assets checks from the Preflight suite to also check videos, not only images. To keep a god balance between performance and quality, a factor of `1` has been chosen for video assets; meaning a video's dimensions should be at least those of its container. It considers:
* videos uploaded through Sharepoint, used in regular `video` tags. These are marked as _Video (Sharepoint)_;
* MPC videos, embedded through `iframe` tags. These are marked as _Video (MPC)_;
* videos uploaded through MPC with their source used in regular `video` tags. These are marked as _Video (MPC source)_.

A couple of additional checks can populate a new Notes field, as suggested [here](https://milo.adobe.com/docs/authoring/videos), should one of these conditions be met:
* if a Sharepoint video has relevant audio data;
* if an MPC MP4 video source is used as a background video.

The Assets logic had to be refactored, as the logic got more complex with adding video checks. Another small change was made to the video decoration logic to ensure a source is only added if one doesn't already exist. This is needed, since the Preflight logic forces video load, even when outside the viewport, in order to perform the relevant size calculations. When a user eventually scrolls the page, we need to ensure we don't duplicate the video's `source` child.

Resolves: [MWPW-170376](https://jira.corp.adobe.com/browse/MWPW-170376)

**Test URLs:**
- Before (small video + MPC source): https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/asset-use-cases?martech=off&georouting=off
- After (small video + MPC source): https://preflight-assets-updates--milo--overmyheadandbody.aem.page/drafts/ramuntea/asset-use-cases?martech=off&georouting=off
- Before (live CC page, videos playing on hover): https://main--cc--adobecom.aem.page/products/photoshop?martech=off&georouting=off
- After (live CC page, videos playing on hover): https://main--cc--adobecom.aem.page/products/photoshop?milolibs=preflight-assets-updates--milo--overmyheadandbody&martech=off&georouting=off
- Before (live BACOM page, video in marquee): https://main--bacom--adobecom.aem.page/products/firefly-business?martech=off&georouting=off
- After (live BACOM page, video in marquee): https://main--bacom--adobecom.aem.page/products/firefly-business?milolibs=preflight-assets-updates--milo--overmyheadandbody&martech=off&georouting=off








