### PR TITLE
Revert "Adding resize observer to support viewport change"

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1179,7 +1179,6 @@ class Gnav {
     const { default: decorate } = await asideJsPromise;
     if (!decorate) return this.elements.aside;
     this.elements.aside = await decorate({ headerElem: this.block, fedsPromoWrapper, promoPath });
-    if (!(this.elements.aside instanceof HTMLElement)) return this.elements.aside;
     fedsPromoWrapper.append(this.elements.aside);
 
     const updateLayout = () => {
@@ -1198,12 +1197,12 @@ class Gnav {
 
     if (this.elements.aside.clientHeight > fedsPromoWrapper.clientHeight) {
       lanaLog({ message: 'Promo height is more than expected, potential CLS', tags: 'gnav-promo', errorType: 'i' });
-    }
+      updateLayout();
 
-    this.promoResizeObserver?.disconnect();
-    this.promoResizeObserver = new ResizeObserver(updateLayout);
-    this.promoResizeObserver.observe(this.elements.aside);
-    updateLayout();
+      this.promoResizeObserver?.disconnect();
+      this.promoResizeObserver = new ResizeObserver(updateLayout);
+      this.promoResizeObserver.observe(this.elements.aside);
+    }
     performance.mark('Gnav-Aside-End');
     logPerformance('Gnav-Aside-Time', 'Gnav-Aside-Start', 'Gnav-Aside-End');
     return this.elements.aside;


### PR DESCRIPTION
Reverts adobecom/milo#4418

This has to be reverted as some clients are still using non localnav naming in localnav variation. Will re raise this after handling this case.