### PR TITLE
fix(css): TagSelector - add position: relative to .search-item to support absolute .cb checkbox

### DIFF
--- a/libs/ui/controls/tagSelector.css
+++ b/libs/ui/controls/tagSelector.css
@@ -245,6 +245,11 @@
   background-color: lightblue;
 }
 
+/* MWPW-176102: provide positioning context for the absolutely-positioned .cb checkbox */
+.search-item {
+  position: relative;
+}
+
 .tagselect-item .cb + label::before,
 .search-item .cb + label::before {
   background-size: cover;


### PR DESCRIPTION
Provide a positioning context for the absolutely-positioned `.cb` checkbox by making its parent `.search-item` relative. This fixes overlap/placement issues with checkboxes in the search list.

<!-- Before submitting, please review all open PRs. -->

Resolves: [MWPW-176102](https://jira.corp.adobe.com/browse/MWPW-176102)

**Test URLs:**
- Before: [https://main--milo--adobecom.aem.page/?martech=off](https://main--milo--adobecom.aem.page/?martech=off)
- After: [https://mwpw-176102-stage--milo--adobecom.aem.page/?martech=off](https://mwpw-176102-stage--milo--adobecom.aem.page/?martech=off)


Before:
![caas_bug](https://github.com/user-attachments/assets/28f75523-d3cf-45b6-91a1-3ba049611ff1)

<img width="1363" alt="image" src="https://github.com/user-attachments/assets/e640b23b-134d-4266-8226-99e076cb13b2" />


After:
![caas_fix](https://github.com/user-attachments/assets/70dbd5d8-3e7e-4e93-bf0a-9bdb31b08654)










