### PR TITLE
Fix(MWPW-174997 and MWPW-175840): List with Brick - Text not wrapping

### DIFF
--- a/libs/blocks/brick/brick.css
+++ b/libs/blocks/brick/brick.css
@@ -141,6 +141,10 @@
   flex-shrink: 0;
 }
 
+.brick .icon-stack-area li a {
+  flex-shrink: initial;
+}
+
 .brick .icon-stack-area li picture {
   display: flex;
   margin: 0;


### PR DESCRIPTION
- Fixed List with Brick - Text not wrapping issue. 
- Fixed slight Gap is seen in mobile mode in pl/creativecloud page in android device issue.

Resolves: [MWPW-174997](https://jira.corp.adobe.com/browse/MWPW-174997), [MWPW-175840](https://jira.corp.adobe.com/browse/MWPW-175840)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-174997-brick-text-wrap-new--milo--hkuraware.aem.page/?martech=off


