### PR TITLE
MWPW-176105: Geo pop is seen automatically closed in stage

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -567,6 +567,27 @@ async function openExternalModal(url, getModal, extraOptions, el) {
 
 const isInternalModal = (url) => /\/fragments\//.test(url);
 
+const closeModalWithoutEvent = (modalId) => {
+  if (!modalId) return;
+  document.querySelectorAll(`#${modalId}`).forEach((mod) => {
+    if (mod.classList.contains('dialog-modal')) {
+      const modalCurtain = document.querySelector(`#${modalId}~.modal-curtain`);
+      if (modalCurtain) {
+        modalCurtain.remove();
+      }
+      mod.remove();
+    }
+    document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();
+  });
+
+  if (!document.querySelectorAll('.modal-curtain').length) {
+    document.body.classList.remove('disable-scroll');
+  }
+
+  [...document.querySelectorAll('header, main, footer')]
+    .forEach((element) => element.removeAttribute('aria-disabled'));
+};
+
 // Modal state handling: see merch.md
 export const modalState = { isOpen: false };
 
@@ -577,24 +598,7 @@ export async function updateModalState({ cta, closedByUser } = {}) {
     const modal = document.querySelector('.dialog-modal');
     if (!modal) return modalState.isOpen;
     modalState.isOpen = false;
-    document.querySelectorAll(`#${modal.id}`).forEach((mod) => {
-      if (mod.classList.contains('dialog-modal')) {
-        const modalCurtain = document.querySelector(`#${modal.id}~.modal-curtain`);
-        if (modalCurtain) {
-          modalCurtain.remove();
-        }
-        mod.remove();
-      }
-      document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();
-    });
-
-    if (!document.querySelectorAll('.modal-curtain').length) {
-      document.body.classList.remove('disable-scroll');
-    }
-
-    [...document.querySelectorAll('header, main, footer')]
-      .forEach((element) => element.removeAttribute('aria-disabled'));
-
+    closeModalWithoutEvent(modal.id);
     return modalState.isOpen;
   }
 
@@ -602,16 +606,24 @@ export async function updateModalState({ cta, closedByUser } = {}) {
   const isLocaleModal = openedDialog?.id?.includes('locale-modal');
   const modal = isLocaleModal ? null : openedDialog;
 
+  if (hash && !cta && modalState.isOpen && !modal) {
+    const dialog = document.querySelector('.dialog-modal');
+    if (!dialog) return modalState.isOpen;
+    closeModalWithoutEvent(dialog.id);
+    modalState.isOpen = false;
+    return modalState.isOpen;
+  }
+
   if (hash && !cta && !modalState.isOpen && !modal) {
     const ctaToClick = document.querySelector(`[is=checkout-link][data-modal-id=${hash.replace('#', '')}]`);
     if (ctaToClick && !ctaToClick.dataset.clickDisabled) {
       ctaToClick.dataset.clickDisabled = 'true';
       ctaToClick.click();
+      modalState.isOpen = true;
       setTimeout(() => {
         delete ctaToClick.dataset.clickDisabled;
       }, 1000);
     }
-    modalState.isOpen = true;
     return modalState.isOpen;
   }
 

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -598,7 +598,9 @@ export async function updateModalState({ cta, closedByUser } = {}) {
     return modalState.isOpen;
   }
 
-  const modal = document.querySelector(`.dialog-modal${hash}`);
+  const openedDialog = document.querySelector(`.dialog-modal${hash}`);
+  const isLocaleModal = openedDialog?.id?.includes('locale-modal');
+  const modal = isLocaleModal ? null : openedDialog;
 
   if (hash && !cta && !modalState.isOpen && !modal) {
     const ctaToClick = document.querySelector(`[is=checkout-link][data-modal-id=${hash.replace('#', '')}]`);


### PR DESCRIPTION
Made the updateModalState function ignore the locale modal as it should not control the state of this modal.

Resolves: [MWPW-176105](https://jira.corp.adobe.com/browse/MWPW-176105)

**Test URLs:**
Before: 
- https://stage--cc--adobecom.aem.page/creativecloud?martech=off
-  https://main--milo--mirafedas.aem.live/drafts/mirafedas/3in1-test-page?martech=off
After: 
- https://stage--cc--adobecom.aem.live/creativecloud?milolibs=mwpw-176105-geo-modal--milo--mirafedas?martech=off
- https://mwpw-176105-geo-modal--milo--mirafedas.aem.live/drafts/mirafedas/3in1-test-page?martech=off




