### PR TITLE
MWPW-176120: use app id/ver from section metadata if not present in config

### DIFF
--- a/libs/features/jarvis-chat.js
+++ b/libs/features/jarvis-chat.js
@@ -220,8 +220,8 @@ const startInitialization = async (config, event, onDemand) => {
   }
 
   window.AdobeMessagingExperienceClient.initialize({
-    appid: getMetadata('jarvis-surface-id') || config.jarvis.id,
-    appver: getMetadata('jarvis-surface-version') || config.jarvis.version,
+    appid: getMetadata('jarvis-surface-id') || config.jarvis.id || jarvisSecMeta?.['jarvis-surface-id'],
+    appver: getMetadata('jarvis-surface-version') || config.jarvis.version || jarvisSecMeta?.['jarvis-surface-version'],
     env: config.env.name !== 'prod' ? 'stage' : 'prod',
     clientId: window.adobeid?.client_id,
     accessToken: window.adobeIMS?.isSignedInUser()


### PR DESCRIPTION
Uses app id/ver from section metadata present in footer if not present in project config.

Resolves: [MWPW-176120](https://jira.corp.adobe.com/browse/MWPW-176120)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-176120--milo--adobecom.aem.page/?martech=off

QA:
Events: (no jarvis config)
- Before: https://main--events-milo--adobecom.aem.page/events?martech=off
- After: https://main--events-milo--adobecom.aem.page/events?martech=off&milolibs=MWPW-176120

Milo:
https://mwpw-176120--milo--adobecom.aem.page/drafts/nishantkaush/test/jarvis-footer/jarvis-on-demand?martech=off

