### PR TITLE
[MWPW-175533] Hero Marquee lockup text overlap fix

### DIFF
--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -72,6 +72,14 @@
   color: inherit;
 }
 
+.hero-marquee .lockup-area > p:has(picture) {
+  margin-block: 0;
+}
+
+.hero-marquee .lockup-label {
+  line-height: initial;
+}
+
 .hero-marquee .action-area a:not(.con-button) {
   font-weight: 700;
 }

--- a/libs/blocks/hero-marquee/hero-marquee.js
+++ b/libs/blocks/hero-marquee/hero-marquee.js
@@ -82,6 +82,11 @@ async function decorateLockupRow(el, classes) {
     el.classList.remove(usedLockupClass);
   }
   el.classList.add(`${usedLockupClass?.split('-')[0] || 'l'}-lockup`);
+  [...child.children].forEach((node) => {
+    if (node.childElementCount || !node.textContent.trim()) return;
+    const newSpan = createTag('span', { class: 'lockup-label' }, node.textContent.trim());
+    node.parentElement.replaceChild(newSpan, node);
+  });
 }
 
 function decorateBg(el) {


### PR DESCRIPTION
This fixes an edge case in the Hero Marquee when a return is added between the lockup image and its text inside a `con-block-row`. The lockup pattern is used in the Editorial Card, Hero Marquee, Aside and Notification Ribbon & Pill. Based on the lockup pattern used in those blocks, I tried to make the 3 possible use-cases look uniform when used inside the Hero Marquee:
* return between image(s) and text in a `con-block-row`;
* space between image(s) and text in a `con-block-row`;
* lockup as part of the main Hero Marquee content.

| Before | After |
| ------------- | ------------- |
| <img width="491" alt="Screenshot 2025-07-09 at 17 35 18" src="https://github.com/user-attachments/assets/30b959ba-9739-4dc5-a34c-be040d133299" /> | <img width="491" alt="Screenshot 2025-07-09 at 17 35 33" src="https://github.com/user-attachments/assets/0bb1d069-dbf5-410e-bdfa-782309baa3c0" /> |

Resolves: [MWPW-175533](https://jira.corp.adobe.com/browse/MWPW-175533)

**Test URLs:**
- Before (Kitchen Sink): https://main--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/hero-marquee?martech=off
- After (Kitchen Sink): https://hero-marquee-lockup--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/hero-marquee?martech=off
- Before (original issue): https://main--cc--adobecom.aem.page/products/photoshop-premiere-elements/2026-upgrade?martech=off
- After (original issue): https://main--cc--adobecom.aem.page/products/photoshop-premiere-elements/2026-upgrade?martech=off&milolibs=hero-marquee-lockup--milo--overmyheadandbody
- Before (the 3 use-cases side-by-side): https://main--cc--adobecom.aem.page/drafts/ramuntea/lockup-in-hero-marquee?martech=off
- After (the 3 use-cases side-by-side): https://main--cc--adobecom.aem.page/drafts/ramuntea/lockup-in-hero-marquee?martech=off&milolibs=hero-marquee-lockup--milo--overmyheadandbody


