### PR TITLE
MWPW-176189 [MILO] Add support for fragments nested in an inline fragment

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -41,9 +41,11 @@ const updateFragMap = (fragment, a, href) => {
   }
 };
 
-const insertInlineFrag = (sections, a, relHref) => {
+const insertInlineFrag = async (sections, a, relHref) => {
   // Inline fragments only support one section, other sections are ignored
-  const fragChildren = [...sections[0].children];
+  const firstSection = sections[0];
+  await loadArea(firstSection);
+  const fragChildren = [...firstSection.children];
   if (a.parentElement.nodeName === 'DIV' && !a.parentElement.attributes.length) {
     a.parentElement.replaceWith(...fragChildren);
   } else {

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -41,10 +41,10 @@ const updateFragMap = (fragment, a, href) => {
   }
 };
 
-const insertInlineFrag = async (sections, a, relHref) => {
+const insertInlineFrag = (sections, a, relHref) => {
   // Inline fragments only support one section, other sections are ignored
   const firstSection = sections[0];
-  await loadArea(firstSection);
+  // await loadArea(firstSection);
   const fragChildren = [...firstSection.children];
   if (a.parentElement.nodeName === 'DIV' && !a.parentElement.attributes.length) {
     a.parentElement.replaceWith(...fragChildren);
@@ -143,7 +143,8 @@ export default async function init(a) {
     if (placeholders) fragment.innerHTML = replacePlaceholders(fragment.innerHTML, placeholders);
   }
   if (inline) {
-    await insertInlineFrag(sections, a, relHref, mep);
+    await loadArea(fragment);
+    insertInlineFrag(sections, a, relHref, mep);
   } else {
     a.parentElement.replaceChild(fragment, a);
     await loadArea(fragment);

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -143,7 +143,7 @@ export default async function init(a) {
     if (placeholders) fragment.innerHTML = replacePlaceholders(fragment.innerHTML, placeholders);
   }
   if (inline) {
-    insertInlineFrag(sections, a, relHref, mep);
+    await insertInlineFrag(sections, a, relHref, mep);
   } else {
     a.parentElement.replaceChild(fragment, a);
     await loadArea(fragment);

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -43,9 +43,7 @@ const updateFragMap = (fragment, a, href) => {
 
 const insertInlineFrag = (sections, a, relHref) => {
   // Inline fragments only support one section, other sections are ignored
-  const firstSection = sections[0];
-  // await loadArea(firstSection);
-  const fragChildren = [...firstSection.children];
+  const fragChildren = [...sections[0].children];
   if (a.parentElement.nodeName === 'DIV' && !a.parentElement.attributes.length) {
     a.parentElement.replaceWith(...fragChildren);
   } else {


### PR DESCRIPTION
* Pass inline fragments through loadArea

Resolves: [MWPW-176189](https://jira.corp.adobe.com/browse/MWPW-176189)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/pznfailswithinline/inline-no-mep
- After: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/pznfailswithinline/inline-no-mep?milolibs=mepreplacefraginline
- Psi-check: https://mepreplacefraginline--milo--adobecom.aem.page/?martech=off
