### PR TITLE
MWPW-171292 - Add automation test script for Block Group Block

### DIFF
--- a/nala/blocks/block-group/block-group.page.js
+++ b/nala/blocks/block-group/block-group.page.js
@@ -1,0 +1,9 @@
+export default class BlockGroup {
+  constructor (page) {
+    this.page = page;
+    
+    // block group types locators
+    this.start = this.page.locator('.block-group-start');
+    this.end = this.page.locator('.block-group-end');
+  }
+}

--- a/nala/blocks/block-group/block-group.spec.js
+++ b/nala/blocks/block-group/block-group.spec.js
@@ -1,0 +1,17 @@
+module.exports = {
+  FeatureName: 'Block Group Block',
+  features: [
+    {
+      tcid: '0',
+      name: 'Block Group (carousel)',
+      path: '/drafts/nala/blocks/block-group/carousel.plain.html',
+      tags: '@group @group-carousel @smoke @regression @milo',
+    },
+    {
+      tcid: '1',
+      name: 'Block Group (tabs)',
+      path: '/drafts/nala/blocks/block-group/tabs.plain.html',
+      tags: '@group @group-tabs @smoke @regression @milo',
+    },
+  ]
+}

--- a/nala/blocks/block-group/block-group.test.js
+++ b/nala/blocks/block-group/block-group.test.js
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { features } from './block-group.spec.js';
+import BlockGroupBlock from './block-group.page.js';
+
+let group;
+
+const miloLibs = process.env.MILO_LIBS || '';
+
+test.describe('Milo Block Group Block test suite', () => {
+  test.beforeEach(async ({ page }) => {
+    group = new BlockGroupBlock(page);
+  });
+
+  // Test 0 : Block Group Carousel
+  test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
+    console.info(`[Test Page]: ${baseURL}${features[0].path}${miloLibs}`);
+
+    await test.step('step-1: Go to Block Group carousel test page', async () => {
+      await page.goto(`${baseURL}${features[0].path}${miloLibs}`);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(`${baseURL}${features[0].path}${miloLibs}`);
+    });
+
+    await test.step('step-2: Verify block-group-start elements are present on the page', async () => {
+      expect(await group.start.count()).toBeGreaterThan(0);
+    });
+
+    await test.step('step-3: Verify block-group-end elements are present on the page', async () => {
+      expect(await group.end.count()).toBeGreaterThan(0);
+    });
+  });
+
+  // Test 1 : Block Group Tabs
+  test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
+    console.info(`[Test Page]: ${baseURL}${features[1].path}${miloLibs}`);
+
+    await test.step('step-1: Go to Block Group tabs test page', async () => {
+      await page.goto(`${baseURL}${features[1].path}${miloLibs}`);
+      await page.waitForLoadState('domcontentloaded');
+      await expect(page).toHaveURL(`${baseURL}${features[1].path}${miloLibs}`);
+    });
+
+    await test.step('step-2: Verify block-group-start elements are present on the page', async () => {
+      expect(await group.start.count()).toBeGreaterThan(0);
+    });
+
+    await test.step('step-3: Verify block-group-end elements are present on the page', async () => {
+      expect(await group.end.count()).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
Added an automation test script for Block Group Block

Resolves: [MWPW-171292](https://jira.corp.adobe.com/browse/MWPW-171292)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/nala/blocks/block-group/carousel.plain.html?martech=off
- After: https://mwpw-171292-block-group-test--milo--nadiiasokolova.aem.page/drafts/nala/blocks/block-group/carousel.plain.html?martech=off

- Before: https://main--milo--adobecom.aem.page/drafts/nala/blocks/block-group/tabs.plain.html?martech=off
- After: https://mwpw-171292-block-group-test--milo--nadiiasokolova.aem.page/drafts/nala/blocks/block-group/tabs.plain.html?martech=off

