### PR TITLE
navigate to get started in cta in bacom page via tab or arrow keys in…

### DIFF
--- a/libs/blocks/global-navigation/utilities/keyboard/mobileGnav.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/mobileGnav.js
@@ -4,7 +4,7 @@ const MobileGnav = {
   init() {
     this.isMobile = !isDesktop.matches;
     this.toggleButton = document.querySelector('.feds-toggle');
-    this.menuItemLinks = document.querySelectorAll('.feds-nav-wrapper section.feds-navItem > .feds-navLink');
+    this.menuItemLinks = document.querySelectorAll('.feds-nav-wrapper section.feds-navItem > .feds-navLink, .feds-navItem > .feds-cta-wrapper > .feds-cta');
     this.eventInitialized = false;
     this.addEventListeners();
   },

--- a/libs/blocks/global-navigation/utilities/keyboard/utils.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/utils.js
@@ -37,7 +37,7 @@ const selectors = {
   menuContent: '.feds-menu-content',
   /* mobile redesign popup selectors */
   mainMenuItems: 'header.new-nav section.feds-navItem > button',
-  mainMenuLinks: 'header.new-nav .feds-navItem > a[href]',
+  mainMenuLinks: 'header.new-nav .feds-navItem > a[href], header.new-nav .feds-navItem > .feds-cta-wrapper > .feds-cta',
   activePopup: 'header.new-nav section.feds-dropdown--active > .feds-popup',
   tab: 'button[role="tab"]',
   activeTabpanel: '.tab-content [role="tabpanel"]',


### PR DESCRIPTION
User is not able to navigate to get started in cta in bacom page via tab or arrow keys in mobile mode when the hamburger is open

Resolves: [MWPW-175508](https://jira.corp.adobe.com/browse/MWPW-175508)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-176041--milo--patel-prince.aem.page/?martech=off
 
**QA URL:**
- https://business.stage.adobe.com?milolibs=mwpw-176041--milo--patel-prince

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=MWPW-176041--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=MWPW-176041--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-176041--milo--adobecom
- Milo: https://MWPW-176041--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-176041--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-176041--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-176041--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-176041--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-176041--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-176041--milo--adobecom
- Milo: https://MWPW-176041--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-176041--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-176041--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-176041--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-176041--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-176041--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-176041--milo--adobecom
- Milo: https://MWPW-176041--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-176041--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-176041--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-176041--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-176041--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-176041--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-176041--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-176041--milo--adobecom
</details>