### PR TITLE
[MWPW-176288] Preflight check vids from open modal

### DIFF
--- a/libs/blocks/preflight/checks/assets.js
+++ b/libs/blocks/preflight/checks/assets.js
@@ -212,7 +212,12 @@ export async function checkImageDimensions(url, area) {
     return JSON.parse(JSON.stringify(cachedResult));
   }
 
-  const allAssets = [...area.querySelectorAll('main picture img, main video, main .adobetv')];
+  const allAssets = [
+    ...area.querySelectorAll(
+      'main picture img, main video, :is(main, .dialog-modal:not(#preflight)) .adobetv',
+    ),
+  ];
+
   if (!allAssets.length) {
     return {
       title: ASSETS_TITLES.AssetDimensions,


### PR DESCRIPTION
This also includes MPC videos rendered in open modals in the assets checks being run on the page, as suggested in https://github.com/adobecom/milo/pull/4510#discussion_r2194555272.

Resolves: [MWPW-176288](https://jira.corp.adobe.com/browse/MWPW-176288)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/docs/authoring/tall-video-modal?martech=off
- After: https://preflight-vid-modal--milo--overmyheadandbody.aem.page/docs/authoring/tall-video-modal?martech=off


