### PR TITLE
Update gnav top if gnav promo is overflowing

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -584,7 +584,7 @@ class Gnav {
       this.block.after(localNav);
     }
     localNav.setAttribute('daa-lh', `${title}_localNav`);
-    this.updateGnavTop();
+    document.querySelector('.feds-promo-aside-wrapper') && this.updateGnavTop();
     const localNavBtn = toFragment`<button class="feds-navLink--hoverCaret feds-localnav-title" aria-haspopup="true" aria-expanded="false" daa-ll="${title}_localNav|open"></button>`;
     const localNavCurtain = toFragment` <div class="feds-localnav-curtain"></div>`;
     // Skip keyboard navigation on localnav items if it is closed
@@ -1170,7 +1170,7 @@ class Gnav {
     const header = document.querySelector('header');
     const localNav = document.querySelector('.feds-localnav');
     
-    document.querySelector('.feds-promo-aside-wrapper')?.style.height = promoHeight;
+    document.querySelector('.feds-promo-aside-wrapper').style.height = promoHeight;
     header.style.top = promoHeight;
     if (!isDesktop.matches && localNav) {
       header.style.top = 0;
@@ -1194,6 +1194,7 @@ class Gnav {
     const { default: decorate } = await asideJsPromise;
     if (!decorate) return this.elements.aside;
     this.elements.aside = await decorate({ headerElem: this.block, fedsPromoWrapper, promoPath });
+    if (!(this.elements.aside instanceof HTMLElement)) return;
     fedsPromoWrapper.append(this.elements.aside);
 
     if (this.elements.aside.clientHeight > fedsPromoWrapper.clientHeight) {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -584,7 +584,9 @@ class Gnav {
       this.block.after(localNav);
     }
     localNav.setAttribute('daa-lh', `${title}_localNav`);
-    document.querySelector('.feds-promo-aside-wrapper') && this.updateGnavTop();
+    if (document.querySelector('.feds-promo-aside-wrapper')) {
+      this.updateGnavTop();
+    }
     const localNavBtn = toFragment`<button class="feds-navLink--hoverCaret feds-localnav-title" aria-haspopup="true" aria-expanded="false" daa-ll="${title}_localNav|open"></button>`;
     const localNavCurtain = toFragment` <div class="feds-localnav-curtain"></div>`;
     // Skip keyboard navigation on localnav items if it is closed
@@ -1169,7 +1171,7 @@ class Gnav {
     const promoHeight = `${this.elements.aside.clientHeight}px`;
     const header = document.querySelector('header');
     const localNav = document.querySelector('.feds-localnav');
-    
+
     document.querySelector('.feds-promo-aside-wrapper').style.height = promoHeight;
     header.style.top = promoHeight;
     if (!isDesktop.matches && localNav) {
@@ -1194,7 +1196,7 @@ class Gnav {
     const { default: decorate } = await asideJsPromise;
     if (!decorate) return this.elements.aside;
     this.elements.aside = await decorate({ headerElem: this.block, fedsPromoWrapper, promoPath });
-    if (!(this.elements.aside instanceof HTMLElement)) return;
+    if (!(this.elements.aside instanceof HTMLElement)) return this.elements.aside;
     fedsPromoWrapper.append(this.elements.aside);
 
     if (this.elements.aside.clientHeight > fedsPromoWrapper.clientHeight) {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -584,6 +584,7 @@ class Gnav {
       this.block.after(localNav);
     }
     localNav.setAttribute('daa-lh', `${title}_localNav`);
+    this.updateGnavTop();
     const localNavBtn = toFragment`<button class="feds-navLink--hoverCaret feds-localnav-title" aria-haspopup="true" aria-expanded="false" daa-ll="${title}_localNav|open"></button>`;
     const localNavCurtain = toFragment` <div class="feds-localnav-curtain"></div>`;
     // Skip keyboard navigation on localnav items if it is closed
@@ -1164,6 +1165,20 @@ class Gnav {
     return decoratedElem;
   };
 
+  updateGnavTop = () => {
+    const promoHeight = `${this.elements.aside.clientHeight}px`;
+    const header = document.querySelector('header');
+    const localNav = document.querySelector('.feds-localnav');
+    
+    document.querySelector('.feds-promo-aside-wrapper')?.style.height = promoHeight;
+    header.style.top = promoHeight;
+    if (!isDesktop.matches && localNav) {
+      header.style.top = 0;
+      localNav.style.top = promoHeight;
+    }
+    if (!isDesktop.matches) this.updatePopupPosition();
+  };
+
   decorateAside = async () => {
     performance.mark('Gnav-Aside-Start');
     this.elements.aside = '';
@@ -1181,28 +1196,13 @@ class Gnav {
     this.elements.aside = await decorate({ headerElem: this.block, fedsPromoWrapper, promoPath });
     fedsPromoWrapper.append(this.elements.aside);
 
-    const updateLayout = () => {
-      const promoHeight = `${this.elements.aside.clientHeight}px`;
-      const header = document.querySelector('header');
-      const localNav = document.querySelector('.feds-localnav');
-
-      fedsPromoWrapper.style.height = promoHeight;
-      header.style.top = promoHeight;
-      if (!isDesktop.matches && localNav) {
-        header.style.top = 0;
-        localNav.style.top = promoHeight;
-      }
-      if (!isDesktop.matches) this.updatePopupPosition();
-    };
-
     if (this.elements.aside.clientHeight > fedsPromoWrapper.clientHeight) {
       lanaLog({ message: 'Promo height is more than expected, potential CLS', tags: 'gnav-promo', errorType: 'i' });
-      updateLayout();
-
-      this.promoResizeObserver?.disconnect();
-      this.promoResizeObserver = new ResizeObserver(updateLayout);
-      this.promoResizeObserver.observe(this.elements.aside);
     }
+    this.updateGnavTop();
+    this.promoResizeObserver?.disconnect();
+    this.promoResizeObserver = new ResizeObserver(this.updateGnavTop);
+    this.promoResizeObserver.observe(this.elements.aside);
     performance.mark('Gnav-Aside-End');
     logPerformance('Gnav-Aside-Time', 'Gnav-Aside-Start', 'Gnav-Aside-End');
     return this.elements.aside;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Update Gnav top if gnav promo's height is greater than its assigned height in responsive mode
* Call the updateGnavPos while localnav decoration to handle an edge case scenario when localnav doesn't meet its naming convention

Resolves: [MWPW-174961](https://jira.corp.adobe.com/browse/MWPW-174961)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-promo-pos--milo--adobecom.aem.page/?martech=off

**QA:**: https://main--cc--adobecom.aem.page/drafts/blaishram/document2
