### PR TITLE
MWPW-176341 Fix self ref frag loop

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -187,7 +187,11 @@ export class Tree {
   insert(parentNodeKey, key, value = key) {
     for (const node of this.traverse()) {
       if (node.key === parentNodeKey) {
-        node.children.push(new Node(key, value, node));
+        if (parentNodeKey === key) {
+          node.isRecursive = true;
+        } else {
+          node.children.push(new Node(key, value, node));
+        }
         return true;
       }
     }

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -85,6 +85,13 @@ describe('Fragments', () => {
     expect(window.lana.log.args[2][0]).to.equal('ERROR: Fragment Circular Reference loading http://localhost:2000/test/blocks/fragment/mocks/fragments/frag-a');
   });
 
+  it('Doesnt infinitely load circular reference to itself', async () => {
+    const a = document.querySelector('a.self-ref');
+    await getFragment(a);
+    expect(document.querySelector('h5')).to.exist;
+    expect(window.lana.log.args[3][0]).to.equal('ERROR: Fragment Circular Reference loading http://localhost:2000/test/blocks/fragment/mocks/fragments/self-ref');
+  });
+
   it('Inlines fragments inside a block', async () => {
     const marquee = document.querySelector('.marquee-section');
     await loadArea(marquee);

--- a/test/blocks/fragment/mocks/body.html
+++ b/test/blocks/fragment/mocks/body.html
@@ -7,6 +7,7 @@
 <a class="frag-a" href="/test/blocks/fragment/mocks/fragments/frag-a">Fragment</a>
 <a class="frag-image" href="/test/blocks/fragment/mocks/fragments/frag-image">Fragment</a>
 <a class="frag-a" href="/test/blocks/fragment/mocks/federal/fragments/frag-a">Fragment</a>
+<a class="self-ref" href="/test/blocks/fragment/mocks/fragments/self-ref">Self Referencing Fragment</a>
 <p class="frag-p-wrapper" test="test">
   <a class="frag-p" href="/test/blocks/fragment/mocks/fragments/frag-p">Fragment</a>
 </p>

--- a/test/blocks/fragment/mocks/fragments/self-ref.plain.html
+++ b/test/blocks/fragment/mocks/fragments/self-ref.plain.html
@@ -1,0 +1,4 @@
+<div>
+  <h5>Self Referencing Fragment</h5>
+  <a href="/test/blocks/fragment/mocks/fragments/self-ref">Self Referencing Fragment</a>
+</div>


### PR DESCRIPTION
Prevents a fragment that has a link to itself from infinitely load looping

Resolves: [MWPW-176341](https://jira.corp.adobe.com/browse/MWPW-176341)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/cpeyer/loopfrag?martech=off
- After: https://176341-fragloop--milo--adobecom.aem.page/drafts/cpeyer/loopfrag?martech=off
