### PR TITLE
[NALA][MWPW-176044] Redirect Nala test runs targeting main branch to milo.adobe.com

### DIFF
--- a/nala/utils/global.setup.js
+++ b/nala/utils/global.setup.js
@@ -3,7 +3,7 @@
 const { execSync } = require('child_process');
 const { isBranchURLValid } = require('../libs/baseurl.js');
 
-const MAIN_BRANCH_LIVE_URL = 'https://main--milo--adobecom.aem.live';
+const MAIN_BRANCH_LIVE_URL = 'https://milo.adobe.com';
 const STAGE_BRANCH_URL = 'https://milo.stage.adobe.com';
 
 async function getGitHubPRBranchLiveUrl() {
@@ -29,7 +29,12 @@ async function getGitHubPRBranchLiveUrl() {
   const prFromOrg = process.env.prOrg || toRepoOrg;
   const prFromRepoName = process.env.prRepo || toRepoName;
 
-  const prBranchLiveUrl = `https://${prBranch}--${prFromRepoName}--${prFromOrg}.aem.live`;
+  let prBranchLiveUrl;
+  if (prBranch === 'main') {
+    prBranchLiveUrl = MAIN_BRANCH_LIVE_URL;
+  } else {
+    prBranchLiveUrl = `https://${prBranch}--${prFromRepoName}--${prFromOrg}.aem.live`;
+  }
 
   try {
     if (await isBranchURLValid(prBranchLiveUrl)) {

--- a/nala/utils/nala.run.js
+++ b/nala/utils/nala.run.js
@@ -96,6 +96,9 @@ function parseArgs(args) {
 }
 
 function getLocalTestLiveUrl(env, milolibs, repo = 'milo', owner = 'adobecom') {
+  if (env === 'main') {
+    return 'https://milo.adobe.com';
+  }
   if (milolibs) {
     process.env.MILO_LIBS = `?milolibs=${milolibs}`;
     if (env === 'local') {

--- a/nala/utils/pr.run.sh
+++ b/nala/utils/pr.run.sh
@@ -33,8 +33,12 @@ toRepoName=${repoParts[1]}
 prRepo=${prRepo:-$toRepoName}
 prOrg=${prOrg:-$toRepoOrg}
 
-# TODO ADD HLX5 SUPPORT
-PR_BRANCH_LIVE_URL_GH="https://$FEATURE_BRANCH--$prRepo--$prOrg.aem.live"
+# Handle PR Branch Live URL
+if [[ "$FEATURE_BRANCH" == "main" ]]; then
+  PR_BRANCH_LIVE_URL_GH="https://milo.adobe.com"
+else
+  PR_BRANCH_LIVE_URL_GH="https://${FEATURE_BRANCH}--${prRepo}--${prOrg}.aem.live"
+fi
 
 # set pr branch url as env
 export PR_BRANCH_LIVE_URL_GH


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Redirect Nala test runs targeting `main` branch to [milo.adobe.com](http://milo.adobe.com/) instead of `main--milo--adobecom.aem.live`
* This change aims to reduce/remove unnecessary automated test traffic from `main--milo--adobecom.aem.live`
`
* Context
    * As per slack conversation, starting July 4th, Its observed that traffic spikes on` main--milo--adobecom.hlx.live` every 5 hours without `x-forwarded-host`.
    
* This PR ensures automated Nala test runs on `main` branch are routed to `milo.adobe.com `

Resolves: [MWPW-176044](https://jira.corp.adobe.com/browse/MWPW-176044)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://nala-config--milo--adobecom.aem.page/?martech=off


