### PR TITLE
MWPW-174582: retrying to fix id lookup

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -364,7 +364,6 @@ const parseCardMetadata = () => {
 function checkCtaUrl(s, options, i) {
   if ((s?.trim() === '' || s === undefined) && i > 1) return '';
   const url = (s?.trim() !== '' && s !== undefined) ? s : (options.prodUrl || window.location.origin + window.location.pathname);
-  if (url.includes('/tools/send-to-caas/bulkpublisher.html')) return '';
   return checkUrl(url, `Invalid Cta${i}Url: ${url}`);
 }
 

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -362,8 +362,8 @@ const parseCardMetadata = () => {
 };
 
 function checkCtaUrl(s, options, i) {
-  if (s?.trim() === '') return '';
-  const url = s || options.prodUrl || window.location.origin + window.location.pathname;
+  if ((s?.trim() === '' || s === undefined) && i > 1) return '';
+  const url = (s?.trim() !== '' && s !== undefined) ? s : (options.prodUrl || window.location.origin + window.location.pathname);
   if (url.includes('/tools/send-to-caas/bulkpublisher.html')) return '';
   return checkUrl(url, `Invalid Cta${i}Url: ${url}`);
 }


### PR DESCRIPTION
ID lookup tool broken when primary CTA is missing. We need to make sure that we are picking up a cta when authors do not explicitly author one to ensure the ID lookup tool will work correctly downstream.

Resolves: [MWPW-174582](https://jira.corp.adobe.com/browse/MWPW-174582)

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://mwpw-174582-2--milo--sheridansunier.aem.page/?martech=off









