### PR TITLE
[MWPW-176491] Re-add alt labels from Preflight

### DIFF
--- a/libs/blocks/preflight/accessibility/audit-image-alt-text.js
+++ b/libs/blocks/preflight/accessibility/audit-image-alt-text.js
@@ -58,13 +58,13 @@ async function checkAlt() {
     const picture = img.closest('picture');
 
     if (picture) {
-      pictureMetaElem = picture.querySelector('.picture-meta');
+      pictureMetaElem = picture.querySelector('.asset-meta');
       if (!pictureMetaElem) {
-        pictureMetaElem = createTag('div', { class: 'picture-meta preflight-decoration' });
+        pictureMetaElem = createTag('div', { class: 'asset-meta preflight-decoration' });
         picture.insertBefore(pictureMetaElem, img.nextSibling);
       }
     } else {
-      pictureMetaElem = createTag('div', { class: 'picture-meta preflight-decoration no-picture-tag' });
+      pictureMetaElem = createTag('div', { class: 'asset-meta preflight-decoration no-picture-tag' });
       img.parentNode.insertBefore(pictureMetaElem, img.nextSibling);
     }
 
@@ -75,7 +75,7 @@ async function checkAlt() {
 
       a11yMessage = createTag(
         'div',
-        { class: 'picture-meta-a11y preflight-decoration is-decorative' },
+        { class: 'asset-meta-entry preflight-decoration needs-attention' },
         img.dataset.altCheck,
       );
 
@@ -89,7 +89,7 @@ async function checkAlt() {
     if (alt) {
       a11yMessage = createTag(
         'div',
-        { class: 'picture-meta-a11y preflight-decoration has-alt' },
+        { class: 'asset-meta-entry preflight-decoration is-valid' },
         `Alt: ${alt}`,
       );
 


### PR DESCRIPTION
This brings back the `alt` attribute values over images once Preflight is enabled on a page.

| Before | After |
| ------------- | ------------- |
| <img width="1035" height="591" alt="Screenshot 2025-07-16 at 17 23 52" src="https://github.com/user-attachments/assets/a87178c1-8a7a-4f76-86ec-456d059d97a2" /> | <img width="1035" height="591" alt="Screenshot 2025-07-16 at 17 24 07" src="https://github.com/user-attachments/assets/b59c933e-f9d2-4637-9fdc-0b0b67fc4755" /> |

Resolves: [MWPW-176491](https://jira.corp.adobe.com/browse/MWPW-176491)

**Test URLs:**
- Before (PSI): https://main--milo--overmyheadandbody.aem.page/?martech=off
- After (PSI): https://preflight-alt-labels--milo--overmyheadandbody.aem.page/?martech=off
- Before (PS page): https://main--cc--adobecom.aem.live/products/photoshop?martech=off
- After (PS page): https://main--cc--adobecom.aem.live/products/photoshop?martech=off&milolibs=preflight-alt-labels--milo--overmyheadandbody


