### PR TITLE
MWPW-170921 [MEP][Localization] Create process for localizing MEP placeholders

### DIFF
--- a/libs/features/personalization/mepLocPlaceholders.js
+++ b/libs/features/personalization/mepLocPlaceholders.js
@@ -7,9 +7,8 @@ async function customFetch({ resource, withCacheRules }) {
   return fetch(resource, options);
 }
 
-export default async function getMepLocPlaceHolders(manifestPath, localizeLink) {
-  const localizedPath = localizeLink(manifestPath);
-
+export default async function getMepLocPlaceHolders(localizedPath) {
+  if (!localizedPath) return null;
   const resp = await customFetch({ resource: `${localizedPath}.plain.html`, withCacheRules: true })
     .catch(() => ({}));
 

--- a/libs/features/personalization/mepLocPlaceholders.js
+++ b/libs/features/personalization/mepLocPlaceholders.js
@@ -1,0 +1,29 @@
+async function customFetch({ resource, withCacheRules }) {
+  const options = {};
+  if (withCacheRules) {
+    const params = new URLSearchParams(window.location.search);
+    options.cache = params.get('cache') === 'off' ? 'reload' : 'default';
+  }
+  return fetch(resource, options);
+}
+export default async function getMepLocPlaceHolders(manifestPath) {
+  const resp = await customFetch({ resource: `${manifestPath}.plain.html`, withCacheRules: true })
+    .catch(() => ({}));
+
+  if (!resp?.ok) {
+    window.lana?.log(`Could not get mep placeholders: ${manifestPath}.plain.html`);
+    return null;
+  }
+  const html = await resp.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const rows = Array.from(doc.querySelectorAll('.mep-placeholders > div')).slice(1);
+  const mepPlaceHolders = rows.map((row) => {
+    const key = row.children[0]?.textContent?.trim();
+    const value = row.children[1].innerHTML;
+    if (key && value) {
+      return { key, value };
+    }
+    return null;
+  }).filter(Boolean);
+  return mepPlaceHolders;
+}

--- a/libs/features/personalization/mepLocPlaceholders.js
+++ b/libs/features/personalization/mepLocPlaceholders.js
@@ -6,6 +6,7 @@ async function customFetch({ resource, withCacheRules }) {
   }
   return fetch(resource, options);
 }
+
 export default async function getMepLocPlaceHolders(manifestPath) {
   const resp = await customFetch({ resource: `${manifestPath}.plain.html`, withCacheRules: true })
     .catch(() => ({}));

--- a/libs/features/personalization/mepLocPlaceholders.js
+++ b/libs/features/personalization/mepLocPlaceholders.js
@@ -7,12 +7,14 @@ async function customFetch({ resource, withCacheRules }) {
   return fetch(resource, options);
 }
 
-export default async function getMepLocPlaceHolders(manifestPath) {
-  const resp = await customFetch({ resource: `${manifestPath}.plain.html`, withCacheRules: true })
+export default async function getMepLocPlaceHolders(manifestPath, localizeLink) {
+  const localizedPath = localizeLink(manifestPath);
+
+  const resp = await customFetch({ resource: `${localizedPath}.plain.html`, withCacheRules: true })
     .catch(() => ({}));
 
   if (!resp?.ok) {
-    window.lana?.log(`Could not get mep placeholders: ${manifestPath}.plain.html`);
+    window.lana?.log(`Could not get mep placeholders: ${localizedPath}.plain.html`);
     return null;
   }
   const html = await resp.text();

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1286,6 +1286,7 @@ export const combineMepSources = async (
   rocPersEnabled,
   promoEnabled,
   mepParam,
+  mph,
 ) => {
   let persManifests = [];
 
@@ -1298,11 +1299,8 @@ export const combineMepSources = async (
     persManifests = persManifests.concat(rocPersManifest);
   }
 
-export const combineMepSources = async (persEnabled, promoEnabled, mepParam, mph) => {
-  let persManifests = [];
+  if (mph) persManifests = persManifests.concat(parseManifestUrlAndAddSource(mph, 'mph'));
 
-  if (persEnabled) persManifests = createPersManifests(persEnabled, 'pzn');
-  if (mph) persManifests = persManifests.concat(createPersManifests(mph, 'mph'));
   if (promoEnabled) {
     const { default: getPromoManifests } = await import('./promo-utils.js');
     persManifests = persManifests.concat(getPromoManifests(promoEnabled, PAGE_URL.searchParams));

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1281,10 +1281,7 @@ function parseManifestUrlAndAddSource(manifestString, source) {
   return manifestString.toLowerCase()
     .split(/,|(\s+)|(\\n)/g)
     .filter((path) => path?.trim())
-    .map((manifestPath) => ({
-      manifestPath: source === 'mph' ? localizeLink(manifestPath) : manifestPath,
-      source: [source],
-    }));
+    .map((manifestPath) => ({ manifestPath, source: [source] }));
 }
 
 export const combineMepSources = async (

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1285,6 +1285,11 @@ export const combineMepSources = async (
     persManifests = persManifests.concat(rocPersManifest);
   }
 
+export const combineMepSources = async (persEnabled, promoEnabled, mepParam, mepPl) => {
+  let persManifests = [];
+
+  if (persEnabled) persManifests = createPersManifests(persEnabled, 'pzn');
+  if (mepPl) persManifests = persManifests.concat(createPersManifests(mepPl, 'mepPl'));
   if (promoEnabled) {
     const { default: getPromoManifests } = await import('./promo-utils.js');
     persManifests = persManifests.concat(getPromoManifests(promoEnabled, PAGE_URL.searchParams));
@@ -1447,7 +1452,7 @@ const awaitMartech = () => new Promise((resolve) => {
 export async function init(enablements = {}) {
   let manifests = [];
   const {
-    mepParam, mepHighlight, mepButton, pzn, pznroc, promo, enablePersV2,
+    mepParam, mepHighlight, mepButton, pzn, pznroc, mepPl, promo, enablePersV2,
     target, ajo, countryIPPromise, mepgeolocation, targetInteractionPromise, calculatedTimeout,
     postLCP,
   } = enablements;
@@ -1471,7 +1476,7 @@ export async function init(enablements = {}) {
       targetInteractionPromise,
     };
 
-    manifests = manifests.concat(await combineMepSources(pzn, pznroc, promo, mepParam));
+    manifests = manifests.concat(await combineMepSources(pzn, pznroc, promo, mepParam, mepPl));
     manifests?.forEach((manifest) => {
       if (manifest.disabled) return;
       const normalizedURL = normalizePath(manifest.manifestPath);

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -9,7 +9,6 @@ import {
   loadScript,
   localizeLink,
   getFederatedUrl,
-  customFetch,
 } from '../../utils/utils.js';
 
 /* c8 ignore start */
@@ -1000,28 +999,6 @@ export const addMepAnalytics = (config, header) => {
       });
     }
   });
-};
-// I will move this to a separate file later
-export const getMepLocPlaceHolders = async (manifestPath) => {
-  const resp = await customFetch({ resource: `${manifestPath}.plain.html`, withCacheRules: true })
-    .catch(() => ({}));
-
-  if (!resp?.ok) {
-    window.lana?.log(`Could not get mep placeholders: ${manifestPath}.plain.html`);
-    return null;
-  }
-  const html = await resp.text();
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  const rows = Array.from(doc.querySelectorAll('.mep-placeholders > div')).slice(1);
-  const mepPlaceHolders = rows.map((row) => {
-    const key = row.children[0]?.textContent?.trim();
-    const value = row.children[1].innerHTML;
-    if (key && value) {
-      return { key, value };
-    }
-    return null;
-  }).filter(Boolean);
-  return mepPlaceHolders;
 };
 
 export async function getManifestConfig(info = {}, variantOverride = false) {

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -9,6 +9,7 @@ import {
   loadScript,
   localizeLink,
   getFederatedUrl,
+  customFetch,
 } from '../../utils/utils.js';
 
 /* c8 ignore start */
@@ -1017,13 +1018,34 @@ export async function getManifestConfig(info = {}, variantOverride = false) {
     return createDefaultExperiment(info);
   }
   let data = manifestData;
-  if (!data) {
+  const isMph = source?.[0] === 'mph';
+  if (!data && !isMph) {
     const fetchedData = await fetchData(manifestPath, DATA_TYPE.JSON);
     if (fetchData) data = fetchedData;
   }
+  let mepPlaceHolders = null;
+  if (!data && isMph) {
+    const resp = await customFetch({ resource: `${manifestPath}.plain.html`, withCacheRules: true })
+      .catch(() => ({}));
 
-  const persData = data?.experiences?.data || data?.data || data;
-  const isMph = source?.[0] === 'mph';
+    if (!resp?.ok) {
+      window.lana?.log(`Could not get mep placeholders: ${manifestPath}.plain.html`);
+      return null;
+    }
+    const html = await resp.text();
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const rows = Array.from(doc.querySelectorAll('.mep-placeholders > div')).slice(1);
+    mepPlaceHolders = rows.map((row) => {
+      const key = row.children[0]?.textContent?.trim();
+      const value = row.children[1].innerHTML;
+      if (key && value) {
+        return { key, value };
+      }
+      return null;
+    }).filter(Boolean);
+  }
+
+  const persData = data?.experiences?.data || data?.data || data || mepPlaceHolders;
   if (!persData || (isMph && !persData.length)) return null;
   if (isMph) {
     return createDefaultExperiment({ manifestPath, isMph, persData });
@@ -1075,8 +1097,8 @@ export async function getManifestConfig(info = {}, variantOverride = false) {
     manifestConfig.variantNames,
     variantLabel,
   );
-
-  manifestConfig.placeholderData = manifestPlaceholders || data?.placeholders?.data;
+  manifestConfig.placeholderData = manifestPlaceholders
+    || data?.placeholders?.data || mepPlaceHolders || {};
   manifestConfig.name = name;
   manifestConfig.manifest = manifestPath;
   manifestConfig.manifestUrl = manifestUrl;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1026,7 +1026,7 @@ export async function getManifestConfig(info = {}, variantOverride = false) {
   let mepPlaceHolders = null;
   if (!data && isMph) {
     const config = getConfig();
-    if (config.mep.mepPromise) mepPlaceHolders = await config.mep.mphPromise;
+    if (config.mep.mphPromise) mepPlaceHolders = await config.mep.mphPromise;
   }
 
   const persData = data?.experiences?.data || data?.data || data || mepPlaceHolders;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1026,7 +1026,7 @@ export async function getManifestConfig(info = {}, variantOverride = false) {
   let mepPlaceHolders = null;
   if (!data && isMph) {
     const config = getConfig();
-    mepPlaceHolders = await config.mep.mphPromise;
+    if (config.mep.mepPromise) mepPlaceHolders = await config.mep.mphPromise;
   }
 
   const persData = data?.experiences?.data || data?.data || data || mepPlaceHolders;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1001,6 +1001,29 @@ export const addMepAnalytics = (config, header) => {
     }
   });
 };
+// I will move this to a separate file later
+export const getMepPlaceHolders = async (manifestPath) => {
+  const resp = await customFetch({ resource: `${manifestPath}.plain.html`, withCacheRules: true })
+    .catch(() => ({}));
+
+  if (!resp?.ok) {
+    window.lana?.log(`Could not get mep placeholders: ${manifestPath}.plain.html`);
+    return null;
+  }
+  const html = await resp.text();
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const rows = Array.from(doc.querySelectorAll('.mep-placeholders > div')).slice(1);
+  const mepPlaceHolders = rows.map((row) => {
+    const key = row.children[0]?.textContent?.trim();
+    const value = row.children[1].innerHTML;
+    if (key && value) {
+      return { key, value };
+    }
+    return null;
+  }).filter(Boolean);
+  return mepPlaceHolders;
+};
+
 export async function getManifestConfig(info = {}, variantOverride = false) {
   const {
     name,
@@ -1025,24 +1048,8 @@ export async function getManifestConfig(info = {}, variantOverride = false) {
   }
   let mepPlaceHolders = null;
   if (!data && isMph) {
-    const resp = await customFetch({ resource: `${manifestPath}.plain.html`, withCacheRules: true })
-      .catch(() => ({}));
-
-    if (!resp?.ok) {
-      window.lana?.log(`Could not get mep placeholders: ${manifestPath}.plain.html`);
-      return null;
-    }
-    const html = await resp.text();
-    const doc = new DOMParser().parseFromString(html, 'text/html');
-    const rows = Array.from(doc.querySelectorAll('.mep-placeholders > div')).slice(1);
-    mepPlaceHolders = rows.map((row) => {
-      const key = row.children[0]?.textContent?.trim();
-      const value = row.children[1].innerHTML;
-      if (key && value) {
-        return { key, value };
-      }
-      return null;
-    }).filter(Boolean);
+    const config = getConfig();
+    mepPlaceHolders = await config.mep.mphPromise;
   }
 
   const persData = data?.experiences?.data || data?.data || data || mepPlaceHolders;
@@ -1485,7 +1492,7 @@ const awaitMartech = () => new Promise((resolve) => {
 export async function init(enablements = {}) {
   let manifests = [];
   const {
-    mepParam, mepHighlight, mepButton, pzn, pznroc, mph, promo, enablePersV2,
+    mepParam, mepHighlight, mepButton, pzn, pznroc, mph, mphPromise, promo, enablePersV2,
     target, ajo, countryIPPromise, mepgeolocation, targetInteractionPromise, calculatedTimeout,
     postLCP,
   } = enablements;
@@ -1506,6 +1513,7 @@ export async function init(enablements = {}) {
       enablePersV2,
       countryIPPromise,
       geoLocation: mepgeolocation,
+      mphPromise,
       targetInteractionPromise,
     };
 

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1002,7 +1002,7 @@ export const addMepAnalytics = (config, header) => {
   });
 };
 // I will move this to a separate file later
-export const getMepPlaceHolders = async (manifestPath) => {
+export const getMepLocPlaceHolders = async (manifestPath) => {
   const resp = await customFetch({ resource: `${manifestPath}.plain.html`, withCacheRules: true })
     .catch(() => ({}));
 

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -189,6 +189,7 @@ function getManifestListDomAndParameter(mepConfig) {
     const variantNamesArray = typeof variantNames === 'string' ? variantNames.split('||') : variantNames;
     let options = '';
     let isSelected = '';
+    const isMph = Array.isArray(source) ? source[0] === 'mph' : source === 'mph';
     if (!variantNames.includes(selectedVariantName) && pageId === 0) {
       isSelected = 'selected';
       manifestParameter.push(`${editUrl}--default`);
@@ -214,17 +215,20 @@ function getManifestListDomAndParameter(mepConfig) {
           ${targetActivityName ? `<div class="target-activity-name">${targetActivityName || ''}</div>` : ''}
           <div class="mep-columns">
             <div class="mep-column">
-              <div class="mep-active">Active</div>
+              ${!isMph ? '<div class="mep-active">Active</div>' : ''}
               <div>Source</div>
-              ${manifest.lastSeen ? '<div>Last seen</div>' : ''}
-              ${eventStart && eventEnd ? '<div>Scheduled</div>' : ''}
+              ${(manifest.lastSeen && !isMph) ? '<div>Last seen</div>' : ''}
+              ${(eventStart && eventEnd && !isMph) ? '<div>Scheduled</div>' : ''}
             
             </div>
             <div class="mep-column">
-              ${!variantNames.includes(selectedVariantName) ? '<div class="mep-active">default (control)</div>' : `<div class='mep-selected-variant mep-active'>${selectedVariantName}</div>`}
-              <div>${source}</div>
-              ${manifest.lastSeen ? `<div>${formatDate(new Date(manifest.lastSeen))}</div>` : ''}
-              ${eventStart && eventEnd ? `<div>${disabled ? 'inactive' : 'active'}</div>` : ''}
+              ${!isMph ? (() => {
+    if (!variantNames.includes(selectedVariantName)) return '<div class="mep-active">default (control)</div>';
+    return `<div class='mep-selected-variant mep-active'>${selectedVariantName}</div>`;
+  })() : ''}
+              <div>${isMph ? 'MEP Localized Placeholders' : source}</div>
+              ${(manifest.lastSeen && !isMph) ? `<div>${formatDate(new Date(manifest.lastSeen))}</div>` : ''}
+              ${(eventStart && eventEnd && !isMph) ? `<div>${disabled ? 'inactive' : 'active'}</div>` : ''}
             </div>
           </div>
           ${eventStart && eventEnd ? `<div class="mep-columns">
@@ -238,10 +242,10 @@ function getManifestListDomAndParameter(mepConfig) {
             </div>
           </div>
         </div>` : ''}
-        <div class="mep-experience-dropdown">
+        ${!isMph ? `<div class="mep-experience-dropdown">
           <label for="experiences">Experience</label>
           <select name="experiences" class="mep-manifest-variants">${options}</select>
-        </div>
+        </div>` : ''}
       </div>
     </div>`;
   });

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -159,9 +159,14 @@ export async function decoratePlaceholderArea({
   if (!nodes.length) return;
   const config = getConfig();
   await fetchPlaceholders({ placeholderPath, config, placeholderRequest });
+  const range = document.createRange();
   const replaceNodes = nodes.map(async (nodeEl) => {
     if (nodeEl.nodeType === Node.TEXT_NODE) {
-      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config);
+      const replaced = await replaceText(nodeEl.nodeValue, config);
+      if (replaced === nodeEl.nodeValue) return;
+      range.selectNode(nodeEl);
+      range.deleteContents();
+      range.insertNode(range.createContextualFragment(replaced));
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
       const attrPromises = [...nodeEl.attributes].map(async (attr) => {
         const attrVal = await replaceText(attr.value, config);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1405,7 +1405,7 @@ async function checkForPageMods() {
   let calculatedTimeout = null;
   if (mepParam === 'off') return;
   const pzn = getMepEnablement('personalization');
-  const mepPl = getMepEnablement('mep-placeholders');
+  const mph = getMepEnablement('mep-placeholders');
   const pznroc = getMepEnablement('personalization-roc');
   const promo = getMepEnablement('manifestnames', PROMO_PARAM);
   const target = martech === 'off' ? false : getMepEnablement('target');
@@ -1413,7 +1413,7 @@ async function checkForPageMods() {
   const ajo = martech === 'off' ? false : getMepEnablement('ajo');
   const mepgeolocation = getMepEnablement('mepgeolocation');
 
-  if (!(pzn || mepPl || pznroc || target || promo || mepParam
+  if (!(pzn || mph || pznroc || target || promo || mepParam
     || mepHighlight || mepButton || mepParam === '' || xlg || ajo)) return;
 
   if (mepgeolocation) {
@@ -1461,7 +1461,7 @@ async function checkForPageMods() {
     mepHighlight,
     mepButton,
     pzn,
-    mepPl,
+    mph,
     pznroc,
     promo,
     target,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1405,6 +1405,7 @@ async function checkForPageMods() {
   let calculatedTimeout = null;
   if (mepParam === 'off') return;
   const pzn = getMepEnablement('personalization');
+  const mepPl = getMepEnablement('mep-placeholders');
   const pznroc = getMepEnablement('personalization-roc');
   const promo = getMepEnablement('manifestnames', PROMO_PARAM);
   const target = martech === 'off' ? false : getMepEnablement('target');
@@ -1412,7 +1413,7 @@ async function checkForPageMods() {
   const ajo = martech === 'off' ? false : getMepEnablement('ajo');
   const mepgeolocation = getMepEnablement('mepgeolocation');
 
-  if (!(pzn || pznroc || target || promo || mepParam
+  if (!(pzn || mepPl || pznroc || target || promo || mepParam
     || mepHighlight || mepButton || mepParam === '' || xlg || ajo)) return;
 
   if (mepgeolocation) {
@@ -1460,6 +1461,7 @@ async function checkForPageMods() {
     mepHighlight,
     mepButton,
     pzn,
+    mepPl,
     pznroc,
     promo,
     target,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1427,7 +1427,7 @@ async function checkForPageMods() {
   }
   if (mph) {
     const { default: getMepLocPlaceHolders } = await import('../features/personalization/mepLocPlaceholders.js');
-    mphPromise = getMepLocPlaceHolders(mph);
+    mphPromise = getMepLocPlaceHolders(localizeLink(mph));
   }
   const enablePersV2 = enablePersonalizationV2();
   if ((target || xlg) && enablePersV2) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1401,6 +1401,7 @@ async function checkForPageMods() {
   } = Object.fromEntries(PAGE_URL.searchParams);
   let targetInteractionPromise = null;
   let countryIPPromise = null;
+  let mphPromise = null;
 
   let calculatedTimeout = null;
   if (mepParam === 'off') return;
@@ -1423,6 +1424,11 @@ async function checkForPageMods() {
       const { getAkamaiCode } = await import('../features/georoutingv2/georoutingv2.js');
       countryIPPromise = getAkamaiCode(true);
     }
+  }
+  if (mph) {
+    const { getMepPlaceHolders } = await import('../features/personalization/personalization.js');
+    mphPromise = getMepPlaceHolders(mph);
+    console.log('mph', mph);
   }
   const enablePersV2 = enablePersonalizationV2();
   if ((target || xlg) && enablePersV2) {
@@ -1462,6 +1468,7 @@ async function checkForPageMods() {
     mepButton,
     pzn,
     mph,
+    mphPromise,
     pznroc,
     promo,
     target,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1426,7 +1426,7 @@ async function checkForPageMods() {
     }
   }
   if (mph) {
-    const { getMepLocPlaceHolders } = await import('../features/personalization/personalization.js');
+    const { default: getMepLocPlaceHolders } = await import('../features/personalization/mepLocPlaceholders.js');
     mphPromise = getMepLocPlaceHolders(mph);
   }
   const enablePersV2 = enablePersonalizationV2();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1426,9 +1426,8 @@ async function checkForPageMods() {
     }
   }
   if (mph) {
-    const { getMepPlaceHolders } = await import('../features/personalization/personalization.js');
-    mphPromise = getMepPlaceHolders(mph);
-    console.log('mph', mph);
+    const { getMepLocPlaceHolders } = await import('../features/personalization/personalization.js');
+    mphPromise = getMepLocPlaceHolders(mph);
   }
   const enablePersV2 = enablePersonalizationV2();
   if ((target || xlg) && enablePersV2) {

--- a/test/features/placeholders/placeholders.json
+++ b/test/features/placeholders/placeholders.json
@@ -34,6 +34,12 @@
       "value": "Adobe Apps",
       "color": "",
       "url": ""
+    },
+    {
+      "key": "bold-italic-adobe-apps",
+      "value": "<strong><em>Adobe Apps</em></strong>",
+      "color": "",
+      "url": ""
     }
   ],
   ":type": "sheet"

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -72,6 +72,17 @@ describe('Placeholders', () => {
     expect(tag.getAttribute('data-attr')).to.equal('/modal/800 12345 6789');
   });
 
+  it('Replaces text that includes html e.g., bold and italics', async () => {
+    const placeholderPath = '/test/features/placeholders.json';
+    const placeholderRequest = customFetch({ resource: placeholderPath, withCacheRules: true })
+      .catch(() => ({}));
+    const p = document.createElement('p');
+    const textNode = document.createTextNode('This is {{bold-italic-adobe-apps}}');
+    p.appendChild(textNode);
+    await decoratePlaceholderArea({ placeholderPath, placeholderRequest, nodes: [textNode] });
+    expect(p.innerHTML).to.equal('This is <strong><em>Adobe Apps</em></strong>');
+  });
+
   it('Replaces geo-specific placeholders when disable-geo-placeholders meta content is "off" or meta tag not defined', async () => {
     config.locale.contentRoot = '/test/features/placeholders/bg';
     let text = '{{add-to-cart}}. {{adobe-apps}}';


### PR DESCRIPTION
This PR enables GWP to localize mep placeholders using their current localization workflow. To localize mep placeholders, a word document containing a table and the class mep-placeholders is added to the new mep-placeholders property in page metadata. Since this feature relies on word rather than excel, the placeholder content can retain formatting such as bold, italics and links. 

Note: since it's possible to overwrite placeholders that exist in the basepage, this PR also updates placeholders.js to handle html formatting (e.g., bold italics, links).

For Qa purposes, see after links: header should include the following:

1. Placeholders authored in header content in marquee:
_**UK base page and Overwrote plain acrobat on base page**_

2. Placeholders authored in fragments added via mep (centered below marquee):
**Page-name placeholder in uk frag: _UK base page -- from mep_**
Content-with-link placeholder in uk frag: This is text with a [link](https://main--cc--adobecom.aem.page/uk/) -- from mep


3. Placeholders added via mep (left aligned at the bottom):
I’m the nested page-name: **_UK base page_** -- nested placeholder added via mep
This is text with a [link](https://main--cc--adobecom.aem.page/uk/) -- content with link added via mep




Resolves: [MWPW-170921](https://jira.corp.adobe.com/browse/MWPW-170921)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/uk/drafts/mepdev/fragments/2025/q2/mepplaceholderspocword/simple
- After: https://main--cc--adobecom.aem.page/uk/drafts/mepdev/fragments/2025/q2/mepplaceholderspocword/simple?milolibs=mepplaceholderpoc
- Psi-check: https://mepplaceholderpoc--milo--adobecom.aem.page/?martech=off


