### PR TITLE
Upgrading package version for bundled gnav to 0.0.9

### DIFF
--- a/libs/navigation/build.mjs
+++ b/libs/navigation/build.mjs
@@ -3,6 +3,19 @@ import fs from 'node:fs';
 
 fs.rmSync('./dist/', { recursive: true, force: true });
 
+// Plugin to resolve absolute imports for MAS components
+const absoluteImportResolver = {
+  name: 'absolute-import-resolver',
+  setup(build) {
+    // Resolve absolute imports starting with /libs/deps/
+    build.onResolve({ filter: /^\/libs\/deps\// }, (args) => {
+      // Convert absolute path to relative path from current directory
+      const relativePath = args.path.replace(/^\/libs\/deps\//, '../');
+      return { path: relativePath, external: true };
+    });
+  },
+};
+
 await esbuild.build({
   entryPoints: ['navigation.css', 'footer.css', 'dark-nav.css', 'base.css'],
   bundle: true,
@@ -59,5 +72,5 @@ await esbuild.build({
   format: 'esm',
   sourcemap: true,
   outdir: './dist/',
-  plugins: [StyleLoader],
+  plugins: [StyleLoader, absoluteImportResolver],
 });

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Upgrading package version for bundled gnav to 0.0.9

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://ahome-mini-gnav--milo--adobecom.aem.page/?martech=off

QA:
https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=ahome-mini-gnav&authoringpath=/federal/dev/devashish/mini-gnav&showUnavSectionDivider=true&searchEnabled=on&mini-gnav=true&newNav=true&customlinks=home,apps,files,firefly,benefits,learn,discover&desktopAppsCta=true


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- Milo: https://ahome-mini-gnav--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=ahome-mini-gnav--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- Milo: https://ahome-mini-gnav--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ahome-mini-gnav--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- Milo: https://ahome-mini-gnav--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ahome-mini-gnav--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=ahome-mini-gnav--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=ahome-mini-gnav--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=ahome-mini-gnav--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=ahome-mini-gnav--milo--adobecom
</details>