### PR TITLE
[MILO][Preflight] Exclude .asset-meta-entry class from preflight accessibility validation

### DIFF
--- a/libs/blocks/preflight/accessibility/accessibility-config.js
+++ b/libs/blocks/preflight/accessibility/accessibility-config.js
@@ -1,6 +1,16 @@
 export const AXE_CORE_CONFIG = {
   include: [['body']],
-  exclude: [['.preflight'], ['aem-sidekick'], ['header'], ['.global-navigation'], ['footer'], ['.global-footer'], ['.mep-preview-overlay'], ['preflight-decoration']],
+  exclude: [
+    ['.preflight'],
+    ['aem-sidekick'],
+    ['header'],
+    ['.global-navigation'],
+    ['footer'],
+    ['.global-footer'],
+    ['.mep-preview-overlay'],
+    ['.preflight-decoration'],
+    ['.asset-meta-entry'],
+  ],
   runOnly: {
     type: 'tag',
     values: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22a', 'wcag22aa'],
@@ -10,5 +20,15 @@ export const AXE_CORE_CONFIG = {
 export const CUSTOM_CHECKS_CONFIG = {
   checks: ['altText', 'color-contrast'],
   include: [['body']],
-  exclude: [['.preflight'], ['aem-sidekick'], ['header'], ['.global-navigation'], ['footer'], ['.global-footer'], ['.mep-preview-overlay'], ['preflight-decoration']],
+  exclude: [
+    ['.preflight'],
+    ['aem-sidekick'],
+    ['header'],
+    ['.global-navigation'],
+    ['footer'],
+    ['.global-footer'],
+    ['.mep-preview-overlay'],
+    ['.preflight-decoration'],
+    ['.asset-meta-entry'],
+  ],
 };


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fixes Preflight Accessibility report showing `falsy` violations
* Preflight accessibility report shows falsy violations. Items added by the Preflight are audited instead of being skipped.
* Features or fixes

Resolves: [MWPW-176564](https://jira.corp.adobe.com/browse/MWPW-176564)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://preflight-decoration--milo--adobecom.aem.page/?martech=off

Fixes following issue
- 
<img width="1347" height="437" alt="image" src="https://github.com/user-attachments/assets/a3d279da-d6f6-431e-9895-fc7025a5a6db" />

