### PR TITLE
fix(caas): enable tag path search in TagSelectPicker

### DIFF
--- a/libs/ui/controls/TagSelectPicker.js
+++ b/libs/ui/controls/TagSelectPicker.js
@@ -57,7 +57,10 @@ const Picker = ({
   const getSearchResults = () => {
     const lowerSearchTerm = debouncedSearchTerm.toLowerCase();
     return Object.entries(optionMap)
-      .filter(([, { label }]) => label.toLowerCase().includes(lowerSearchTerm))
+      .filter(
+        ([, { label, path }]) => label.toLowerCase().includes(lowerSearchTerm)
+           || path.toLowerCase().includes(lowerSearchTerm),
+      )
       .map(([id, { label, path }]) => {
         const isChecked = selectedTags.includes(id);
         return html`


### PR DESCRIPTION
Currently, product managers provide web producers with specific tag paths to display in CaaS card collections. However, when web producers attempt to search for tags using these provided paths in the Tag selector interface no results are returned even though the tags exist. This creates friction in the workflow and forces users to manually navigate through the tag hierarchy to find the required tags.

Example GWP ticket: https://jira.corp.adobe.com/browse/DOTCOM-160900

<img width="1290" height="302" alt="image" src="https://github.com/user-attachments/assets/3ea3c218-ef0f-4803-b6f2-af9f47c968d6" />


Before fix:
![no_result](https://github.com/user-attachments/assets/4b34da19-c79f-4f32-979a-10959268dbe0)

<img width="1728" height="993" alt="result" src="https://github.com/user-attachments/assets/a24a864c-9aa2-4f0e-b50c-223ee7c5ad31" />

After fix:
![Screen Recording 2025-07-18 at 3 07 00 pm](https://github.com/user-attachments/assets/091efb20-9baa-4353-80f9-3c7f6b620f39)


Fixes: MWPW-176616


Resolves: [MWPW-176616](https://jira.corp.adobe.com/browse/MWPW-176616)

**Test URLs:**
- Before:  https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-176616-caas-tag-path-search--milo--adobecom.aem.page/?martech=off


