### PR TITLE
[MWPW-176806] Icons not loading for the sidekick library

### DIFF
--- a/libs/blocks/library-config/library-config.js
+++ b/libs/blocks/library-config/library-config.js
@@ -105,7 +105,7 @@ async function loadList(type, content, list) {
       break;
     case 'icons':
       addSearch({ content, list, type });
-      loadIcons({ content, list });
+      loadIcons({ content, list, query: '' });
       break;
     case 'assets':
       loadAssets(content, list);


### PR DESCRIPTION
## Description
This PR is fixing the issue where icons are not loading for the sidekick library.

## Related Issue
Resolves: [MWPW-176806](https://jira.corp.adobe.com/browse/MWPW-176806)

## Testing instructions
1. open test URL
2. go to icons
3. icons should load

## Screenshots:

**Before:**
<img width="1102" height="1012" alt="Screenshot 2025-07-23 at 12 01 57" src="https://github.com/user-attachments/assets/5208c5d8-adfb-4e29-95c0-7af5ea4ebbf8" />


**After:**
<img width="1102" height="1012" alt="Screenshot 2025-07-23 at 12 02 36" src="https://github.com/user-attachments/assets/ef7da4a2-90f6-4f3a-be43-5b1bf7eae076" />


## Test URLs
**For PSI check:**
- Before: https://stage--milo--adobecom.aem.page/drafts/rbogos/page-default?martech=off
- After: https://mwpw-176806-federal-icons--milo--robert-bogos.aem.page/drafts/rbogos/page-default?martech=off

**Test on the below:**
- Before: https://stage--milo--adobecom.aem.page/tools/library
- After: https://mwpw-176806-federal-icons--milo--robert-bogos.aem.page/tools/library



