### PR TITLE
MWPW-176763 Eliminating custom merge option from regional editing.

### DIFF
--- a/libs/blocks/locui-create/input-urls/view.js
+++ b/libs/blocks/locui-create/input-urls/view.js
@@ -301,7 +301,6 @@ export default function InputUrls() {
                   <option value="skip">Skip</option>
                   <option value="merge">Merge</option>
                   <option value="overwrite">Overwrite</option>
-                  <option value="custom-merge">Custom Merge (.xlsx)</option>
                 </select>
                 ${errors.editBehavior
                 && html`<div class="form-field-error">


### PR DESCRIPTION
- Custom merge  option in the "regional edit behavior" dropdown is eliminated in milo studio.

- Resolves: [MWPW-176763](https://jira.corp.adobe.com/browse/MWPW-176763)

**Test URLs:**
- Before: https://milostudio-dev--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-176763-eliminating-custom-merge--milo--Shrey-Adobe.aem.page/?martech=off
