### PR TITLE
MWPW-176763: Eliminating custom merge option from regional editing

### DIFF
--- a/libs/blocks/locui-create/input-urls/view.js
+++ b/libs/blocks/locui-create/input-urls/view.js
@@ -175,7 +175,7 @@ export default function InputUrls() {
     nextStep();
   }
 
-  function handleKeyDown(e, pType, handleTypeChange) {
+  function handleKeyDown(e, pType) {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       handleTypeChange(pType);
@@ -242,7 +242,7 @@ export default function InputUrls() {
                   tabindex="0"
                   role="radio"
                   aria-checked=${type === pType}
-                  onKeyDown=${(e) => handleKeyDown(e, pType, handleTypeChange)}
+                  onKeyDown=${(e) => handleKeyDown(e, pType)}
                 >
                   ${PROJECT_TYPE_LABELS[pType]}
                 </div>


### PR DESCRIPTION
- Custom merge option in the "regional edit behavior" dropdown is eliminated in milo studio.

Resolves: [MWPW-176763](https://jira.corp.adobe.com/browse/MWPW-176763)

Test URLs:

- Before: https://milostudio-stage--milo--adobecom.aem.page/tools/locui-create
- After: https://mwpw-176763-remove-custom-merge--milo--shrey-adobe.aem.page/tools/locui-create