### PR TITLE
[MWPW-174911] - Modal phone close issue

### DIFF
--- a/libs/blocks/modal/modal.css
+++ b/libs/blocks/modal/modal.css
@@ -329,7 +329,7 @@
     max-height: 100%;
   }
 
-  .dialog-modal:not(.tall-video) {
+  .dialog-modal:not(.tall-video, .three-in-one) {
     max-height: var(--modal-max-height-mobile);
   }
 


### PR DESCRIPTION
Resolves: [MWPW-174911](https://jira.corp.adobe.com/browse/MWPW-174911)

**QA Note**
The issue here is with the search bar of the browser, so when you scroll down to click on "Check eligibility" before clicking on the link, scroll up a bit so that your search bar appears and then you can click to open the modal and then the issue happens in this situation where the modal is overflowing vertically and the "X" to close is almost not visible.

**Video Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/mwpw-170384-modal-overflow/modal-overflow
- After: https://modal-phone-close-issue--milo--adobecom.aem.page/drafts/ratko/mwpw-170384-modal-overflow/modal-overflow

**Ticket CC Test URLs:**
- Before: https://main--dc--adobecom.aem.live/acrobat/pricing/students
- After: https://main--dc--adobecom.aem.live/acrobat/pricing/students?milolibs=modal-phone-close-issue




