### PR TITLE
MWPW-176945 [Milo] Tabs block fires multiple click events on load when nested

### DIFF
--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -164,6 +164,7 @@ function initTabs(elm, config, rootElem) {
     });
   });
   tabs.forEach((tab) => {
+    tab.removeEventListener('click', changeTabs);
     tab.addEventListener('click', changeTabs);
   });
   if (config) configTabs(config, rootElem);


### PR DESCRIPTION
When the tabs block is nested within other tabs blocks, multiple click events are fired unexpectedly on load. This appears to be because the changeTab click handler gets added to nested tabs more than once. This PR addresses the issue by removing the handler before adding it.  

URL: https://www.adobe.com/creativecloud/pro.html
Steps to Reproduce:
1. load the above url and open the network tabs in the browser
2. filter for "collect" and reload if necessary
3. you should see more than 5 events where launch is the initiator(actual)
4. override the tab.js file in your browser using the file in this pr
5. reload
6. you should only see one event where launch is the initiator(expected)


actual: 
<img width="1023" height="456" alt="Screenshot 2025-07-24 at 4 04 39 PM" src="https://github.com/user-attachments/assets/beb549c2-c3ca-495b-ba9c-df0eabe2b26d" />

expected:
<img width="1470" height="376" alt="Screenshot 2025-07-24 at 4 13 38 PM" src="https://github.com/user-attachments/assets/e432c43c-1199-42f6-b335-fc91e347e6d7" />


Resolves: [MWPW-176945](https://jira.corp.adobe.com/browse/MWPW-176945)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://fixtabsmultieventbug--milo--adobecom.aem.page/?martech=off




