### PR TITLE
ASO Preflight authentication

### DIFF
--- a/libs/blocks/preflight/checks/asoApi.js
+++ b/libs/blocks/preflight/checks/asoApi.js
@@ -1,17 +1,30 @@
 const CHECK_API = 'https://spacecat.experiencecloud.live/api/v1';
-const CHECK_KEY = (() => {
-  const storedKey = sessionStorage.getItem('preflight-key');
-  if (storedKey) return storedKey;
 
-  const params = new URLSearchParams(window.location.search);
-  const queryKey = params.get('preflight-key');
-  if (queryKey) {
-    sessionStorage.setItem('preflight-key', queryKey);
-    return queryKey;
-  }
+let asoTokenPromise = null;
 
-  return null;
-})();
+async function getASOToken() {
+  asoTokenPromise = asoTokenPromise || (async () => {
+    window.adobeImsFactory.createIMSLib({
+      client_id: 'milo-tools',
+      scope: 'AdobeID,openid,gnav,read_organizations,additional_info.projectedProductContext,additional_info.roles',
+      environment: 'prod',
+      autoValidateToken: true,
+      useLocalStorage: false,
+    }, 'asoIMS');
+    window.asoIMS.initialize(); // TODO - why does this force IMS sign in?
+    if (!window.asoIMS.getAccessToken()?.token) return null;
+
+    const res = await fetch(`${CHECK_API}/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accessToken: window.asoIMS.getAccessToken().token }),
+    });
+    const data = await res.json();
+    return data.sessionToken;
+  })();
+
+  return asoTokenPromise;
+}
 
 export const preflightCache = {
   identify: null,
@@ -22,11 +35,13 @@ export const preflightCache = {
 
 async function getJobId(step) {
   try {
-    if (!CHECK_KEY) throw new Error('No preflight key found');
+    const sessionToken = await getASOToken();
+    if (!sessionToken) return null;
+
     const res = await fetch(`${CHECK_API}/preflight/jobs`, {
       method: 'POST',
       headers: {
-        'x-api-key': CHECK_KEY,
+        Authorization: `Bearer ${sessionToken}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(
@@ -51,8 +66,10 @@ async function getJobResults(jobId, step) {
 
   while (retries < MAX_RETRIES) {
     try {
-      if (!CHECK_KEY) throw new Error('No preflight key found');
-      const res = await fetch(`${CHECK_API}/preflight/jobs/${jobId}`, { headers: { 'x-api-key': CHECK_KEY } });
+      const sessionToken = await getASOToken();
+      if (!sessionToken) return null;
+
+      const res = await fetch(`${CHECK_API}/preflight/jobs/${jobId}`, { headers: { Authorization: `Bearer ${sessionToken}` } });
       const data = await res.json();
 
       if (step === 'IDENTIFY' && data.result) {

--- a/libs/blocks/preflight/checks/asoApi.js
+++ b/libs/blocks/preflight/checks/asoApi.js
@@ -11,7 +11,9 @@ async function getASOToken() {
       autoValidateToken: true,
       useLocalStorage: false,
     }, 'asoIMS');
-    window.asoIMS.initialize(); // TODO - why does this force IMS sign in?
+    // TODO: We should only initialize (or re-initialize) AFTER
+    // we get a 'logged-in' sidekick event
+    window.asoIMS.initialize();
     if (!window.asoIMS.getAccessToken()?.token) return null;
 
     const res = await fetch(`${CHECK_API}/auth/login`, {


### PR DESCRIPTION
### Description
Adds the IMS/Spacecat implementation to obtain a session token.

### Limitations: 
- We can't always ensure an author is logged in
- We don't have a "not-logged-in" screen/scenario (TODO: Create follow up ticket)
- As far as I can see, there's no feedback at all when the fails timeout.

### Test scenarios:
I only implemented the scenario of a signed in user on da-bacom trying to get results from the ASO preflight.

### Test instructions
Upon launching the test link, this should make a request to the login and job endpoints of spacecat.
<img width="2008" height="1374" alt="image" src="https://github.com/user-attachments/assets/30aee93d-6352-460a-86f6-5e6df86894ff" />


Resolves: [MWPW-176919](https://jira.corp.adobe.com/browse/MWPW-176919)

**Test URLs:**
PSI Check:
- https://preflight-poc-auth--milo--adobecom.aem.live/

- Before: https://main--da-bacom--adobecom.aem.live/
- After: https://main--da-bacom--adobecom.aem.live/?milolibs=preflight-poc-auth


