### PR TITLE
MWPW-176866 v2 Placeholders within fragments are not resolved anymore

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -52,7 +52,7 @@ const insertInlineFrag = async (sections, a, relHref) => {
   const promises = [];
   fragChildren.forEach((child) => {
     child.setAttribute('data-path', relHref);
-    promises.push(loadArea(child));
+    if (child.querySelector('a[href*="/fragments/"]')) promises.push(loadArea(child));
   });
   await Promise.all(promises);
 };


### PR DESCRIPTION
In a previous PR, we started passing inline fragments through loadArea like non-inline fragments. However, this function normally also processes placeholders found in the fragment. This causes fed placeholders in gnav to break.  We need a solution that keeps the processing of nested fragments while not processing placeholders like before.

Resolves: [MWPW-176866](https://jira.corp.adobe.com/browse/MWPW-176866)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://inlinefragconditionalloadarea--milo--adobecom.aem.page/?martech=off

QA links:
Needs to still have a blue button
Before: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/pznfailswithinline/inline-no-mep
After: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q3/pznfailswithinline/inline-no-mep?milolibs=inlinefragconditionalloadarea
<img width="406" height="425" alt="image" src="https://github.com/user-attachments/assets/9057e771-a479-492d-b72d-a019d588d898" />



Needs to start resolving placeholder again
Before: https://main--homepage--adobecom.aem.page/homepage/index-loggedout
After: https://main--homepage--adobecom.aem.page/homepage/index-loggedout?milolibs=inlinefragconditionalloadarea
<img width="509" height="573" alt="image" src="https://github.com/user-attachments/assets/15463859-29a8-48f0-a578-26673a4657fa" />


Needs to still have placeholders resolved
Before: https://main--dc--adobecom.aem.live/acrobat/features
After: https://main--dc--adobecom.aem.live/acrobat/features?milolibs=inlinefragconditionalloadarea
Needs to avoid the below result:
<img width="830" height="367" alt="image" src="https://github.com/user-attachments/assets/b4537f09-b8a8-4467-815a-80972c35d504" />

