### PR TITLE
MWPW-175124 Configurable Multi-Step

### DIFF
--- a/libs/blocks/marketo-config/context.js
+++ b/libs/blocks/marketo-config/context.js
@@ -5,6 +5,18 @@ export const saveStateToLocalStorage = (state, lsKey) => {
   localStorage.setItem(lsKey, JSON.stringify(state));
 };
 
+export const loadStateFromLocalStorage = (lsKey) => {
+  const lsState = localStorage.getItem(lsKey);
+  if (lsState) {
+    try {
+      return JSON.parse(lsState);
+      /* c8 ignore next 2 */
+      // eslint-disable-next-line no-empty
+    } catch (e) { }
+  }
+  return null;
+};
+
 function deepCopy(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
@@ -29,14 +41,8 @@ const getInitialState = (defaultState, lsKey) => {
     return mergedState;
   }
 
-  const lsState = localStorage.getItem(lsKey);
-  if (lsState) {
-    try {
-      Object.assign(mergedState, JSON.parse(lsState));
-      /* c8 ignore next 2 */
-      // eslint-disable-next-line no-empty
-    } catch (e) { }
-  }
+  const lsState = loadStateFromLocalStorage(lsKey);
+  if (lsState) Object.assign(mergedState, lsState);
 
   return mergedState;
 };

--- a/libs/blocks/marketo-config/context.js
+++ b/libs/blocks/marketo-config/context.js
@@ -52,7 +52,7 @@ const createReducer = (defaultState) => (state, action) => {
     case 'SET_VALUE':
       return { ...state, [action.prop]: action.value };
     case 'RESET_STATE':
-      return deepCopy(defaultState);
+      return { ...deepCopy(defaultState), reset: Date.now() };
     /* c8 ignore next 2 */
     default:
       return state;

--- a/libs/blocks/marketo-config/marketo-config.css
+++ b/libs/blocks/marketo-config/marketo-config.css
@@ -83,10 +83,28 @@
   border: 1px solid #d7373f;
 }
 
+.tagselect .tagselect-plus,
+.tagselect .tagselect-plus::after {
+  background: #EFEFEF;
+}
+
 .tool-content {
   display: grid;
   grid-template-columns: 380px 1fr;
   gap: 24px;
+}
+
+.marketo-config .debug-settings {
+  display: flex;
+  gap: 12px;
+}
+
+.marketo-config .debug-settings button.active {
+    background: #777;
+}
+
+.marketo-config .debug-settings button.active:hover {
+    background: #999;
 }
 
 .config-panel {
@@ -96,6 +114,13 @@
 .content-panel {
   border-top: 2px solid black;
   padding-top: 12px;
+}
+
+.content-panel iframe {
+  width: 100%;
+  height: 100%;
+  min-height: 80vh;
+  border: none;
 }
 
 .tool-header h1 {

--- a/libs/blocks/marketo-config/marketo-config.js
+++ b/libs/blocks/marketo-config/marketo-config.js
@@ -1,10 +1,18 @@
 import { html, render, useContext, useState, useEffect } from '../../deps/htm-preact.js';
 import { utf8ToB64, loadBlock, createTag } from '../../utils/utils.js';
-import { setPreferences } from '../marketo/marketo.js';
-import { ConfiguratorContext, ConfiguratorProvider, saveStateToLocalStorage } from './context.js';
+import { ConfiguratorContext, ConfiguratorProvider, saveStateToLocalStorage, loadStateFromLocalStorage } from './context.js';
 import Accordion from '../../ui/controls/Accordion.js';
 import CopyBtn from '../../ui/controls/CopyBtn.js';
 import { Input, Select } from '../../ui/controls/formControls.js';
+import StepPanel from './step-panel.js';
+
+const TEMPLATE_RULE_MAPPING = {
+  formVersion: 'form.id',
+  formSuccessType: 'form.success.type',
+  purpose: 'form.subtype',
+  field_visibility: 'field_visibility',
+  field_filters: 'field_filters',
+};
 
 async function fetchData(url) {
   const resp = await fetch(url.toLowerCase());
@@ -104,21 +112,71 @@ const validateState = (state, panelsData) => {
     });
   });
 
+  if ('form.fldStepPref' in state && state['form.fldStepPref']?.[2]?.length > 0) {
+    validatedState['form.fldStepPref'] = state['form.fldStepPref'];
+  }
+
   return validatedState;
 };
 
-const AdvancedPanel = (lsKey) => {
-  const { dispatch } = useContext(ConfiguratorContext);
+const AdvancedPanel = ({ lsKey }) => {
+  const { state, dispatch } = useContext(ConfiguratorContext);
+  const [supportedLanguages, setSupportedLanguages] = useState([]);
+  const windowUrl = new URL(window.location.href);
+  const isPreview = windowUrl.searchParams.get('preview') === '1';
+  const currentLocale = windowUrl.searchParams.get('lang');
+  const localeIndex = supportedLanguages.findIndex((lang) => lang === currentLocale);
+
+  useEffect(() => {
+    const handleMessage = (event) => {
+      if (event.origin !== window.location.origin) return;
+      if (event.data.type === 'supportedLanguages' && event.data.data) {
+        setSupportedLanguages(event.data.data);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
   const onClick = () => {
     const firstPanel = document.querySelector('.accordion-item button[aria-label=Expand]');
 
     localStorage.removeItem(lsKey);
     dispatch({ type: 'RESET_STATE' });
+    saveStateToLocalStorage(state, lsKey);
     firstPanel.click();
+  };
+
+  const debugState = () => {
+    // eslint-disable-next-line no-console
+    console.log('Configuration:', JSON.stringify(state, null, 2));
+  };
+
+  const togglePreview = () => {
+    if (isPreview) {
+      windowUrl.searchParams.delete('preview');
+    } else {
+      windowUrl.searchParams.set('preview', '1');
+    }
+    window.location.href = windowUrl.toString();
+  };
+
+  const changeLocale = (locale) => {
+    if (supportedLanguages[locale] === 'en_us') {
+      windowUrl.searchParams.delete('lang');
+    } else {
+      windowUrl.searchParams.set('lang', supportedLanguages[locale]);
+    }
+    window.location.href = windowUrl.toString();
   };
 
   return html`
     <button class="resetToDefaultState" onClick=${onClick}>Reset to default state</button>
+    <div class="debug-settings">
+      <button class="debug" onClick=${debugState}>Debug State</button>
+      <button role="switch" aria-checked=${isPreview} class="preview ${isPreview ? ' active' : ''}" onClick=${togglePreview}>Toggle Console Preview</button>
+    </div>
+    <${Select} label="Test Language" name="lang" options=${supportedLanguages} value=${localeIndex > -1 ? localeIndex : 0} onChange=${changeLocale} />
   `;
 };
 
@@ -129,21 +187,26 @@ const getPanels = (panelsData, lsKey) => {
   }));
 
   panels.push({
+    title: 'Multi-Step',
+    content: html`<${StepPanel} />`,
+  });
+  panels.push({
     title: 'Advanced',
-    content: html`<${AdvancedPanel} lskey=${lsKey}/>`,
+    content: html`<${AdvancedPanel} lsKey=${lsKey}/>`,
   });
 
   return panels;
 };
 
-const Configurator = ({ title, blockClass, panelsData, lsKey }) => {
-  const { state } = useContext(ConfiguratorContext);
-  const panels = getPanels(panelsData);
+const getDataUrl = (state) => {
+  const url = window.location.href.split('#')[0];
+  return `${url}#${utf8ToB64(JSON.stringify(state))}`;
+};
 
-  const getUrl = () => {
-    const url = window.location.href.split('#')[0];
-    return `${url}#${utf8ToB64(JSON.stringify(state))}`;
-  };
+const Configurator = ({ title, panelsData, lsKey }) => {
+  const { dispatch, state } = useContext(ConfiguratorContext);
+  const panels = getPanels(panelsData, lsKey);
+  const [templateRules, setTemplateRules] = useState([]);
 
   const configFormValidation = () => {
     const invalidInputs = document.querySelectorAll('.input-invalid');
@@ -163,7 +226,8 @@ const Configurator = ({ title, blockClass, panelsData, lsKey }) => {
   };
 
   const getContent = () => {
-    const url = getUrl();
+    const validatedState = validateState(state, panelsData);
+    const url = getDataUrl(validatedState);
     const dateStr = new Date().toLocaleString('us-EN', {
       weekday: 'long',
       year: 'numeric',
@@ -181,20 +245,48 @@ const Configurator = ({ title, blockClass, panelsData, lsKey }) => {
   };
 
   useEffect(() => {
+    const contentEl = document.querySelector('.content-panel');
     const validatedState = validateState(state, panelsData);
-    setPreferences(validatedState);
+    const iframe = createTag('iframe', { src: window.location.href.split(/#|\?/)[0] });
+
     saveStateToLocalStorage(validatedState, lsKey);
+    contentEl.replaceChildren(iframe);
   }, [state]);
 
   useEffect(() => {
-    const url = getUrl();
-    const blockLink = createTag('a', { href: url }, url);
-    const blockContent = createTag('div', {}, blockLink);
-    const newBlockEl = createTag('div', { class: blockClass }, blockContent);
-    const contentEl = document.querySelector('.content-panel');
-    contentEl.append(newBlockEl);
-    loadBlock(newBlockEl);
+    const handleMessage = (event) => {
+      if (event.origin !== window.location.origin) return;
+      if (event.data.type === 'templateRules' && event.data.data) {
+        setTemplateRules(event.data.data);
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
   }, []);
+
+  useEffect(() => {
+    const extractRuleValue = (rule) => rule?.[0]?.split(':')?.[0] || '';
+    const applyRulesToState = (rules) => {
+      Object.entries(TEMPLATE_RULE_MAPPING).forEach(([key, prop]) => {
+        const value = rules[key];
+        if (typeof value === 'object') {
+          Object.entries(value).forEach(([subKey, subValue]) => {
+            dispatch({ type: 'SET_VALUE', prop: `${prop}.${subKey}`, value: extractRuleValue(subValue) });
+          });
+          return;
+        }
+        dispatch({ type: 'SET_VALUE', prop, value: extractRuleValue(value) });
+      });
+    };
+
+    const formTemplate = state['form.template'];
+    if (!formTemplate || !templateRules || templateRules.length === 0) return;
+
+    const selectedRules = templateRules.find((t) => t[formTemplate])?.[formTemplate];
+    if (!selectedRules || Object.keys(selectedRules).length === 0) return;
+
+    applyRulesToState(selectedRules);
+  }, [state['form.template']]);
 
   return html`
     <div class="tool-header">
@@ -214,7 +306,6 @@ const Configurator = ({ title, blockClass, panelsData, lsKey }) => {
 };
 
 const ConfiguratorWrapper = ({ title, link }) => {
-  const blockClass = 'marketo';
   const lsKey = `${title.toLowerCase().replace(' ', '-')}-ConfiguratorState`;
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -267,16 +358,48 @@ const ConfiguratorWrapper = ({ title, link }) => {
 
   return html`
   <${ConfiguratorProvider} defaultState=${defaults} lsKey=${lsKey}>
-    <${Configurator} title=${title} blockClass=${blockClass} panelsData=${data} lsKey=${lsKey} />
+    <${Configurator} title=${title} panelsData=${data} lsKey=${lsKey} />
   </${ConfiguratorProvider}>
   `;
 };
+
+function createDataBlock(blockClass, data) {
+  const url = getDataUrl(data);
+  const link = createTag('a', { href: url }, url);
+  const row = createTag('div', null, link);
+  const block = createTag('div', { class: blockClass }, row);
+
+  return block;
+}
 
 export default async function init(el) {
   const children = Array.from(el.querySelectorAll(':scope > div'));
   const title = children[0].textContent.trim();
   const linkElement = children[1].querySelector('a[href$="json"]');
   const link = linkElement?.href;
+  // If the block is loaded in an iframe, replace it with the block itself
+  if (window.self !== window.top) {
+    const lsKey = `${title.toLowerCase().replace(' ', '-')}-ConfiguratorState`;
+    const state = loadStateFromLocalStorage(lsKey);
+    const marketoBlock = createDataBlock('marketo', state);
+
+    el.replaceWith(marketoBlock);
+    await loadBlock(marketoBlock);
+
+    const postMarketoRules = () => {
+      if (window?.MktoForms2) {
+        window.MktoForms2.whenReady(() => {
+          window.parent.postMessage({ type: 'templateRules', data: window.templateRules }, '*');
+          window.parent.postMessage({ type: 'supportedLanguages', data: window.SUPPORTED_LANGUAGES }, '*');
+        });
+      } else {
+        setTimeout(postMarketoRules, 100);
+      }
+    };
+    postMarketoRules();
+    return;
+  }
+  el.innerHTML = '';
 
   const app = html`
     <${ConfiguratorWrapper} title=${title} link=${link} />

--- a/libs/blocks/marketo-config/marketo-config.js
+++ b/libs/blocks/marketo-config/marketo-config.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { html, render, useContext, useState, useEffect } from '../../deps/htm-preact.js';
 import { utf8ToB64, loadBlock, createTag } from '../../utils/utils.js';
 import { ConfiguratorContext, ConfiguratorProvider, saveStateToLocalStorage, loadStateFromLocalStorage } from './context.js';
@@ -112,8 +113,11 @@ const validateState = (state, panelsData) => {
     });
   });
 
-  if ('form.fldStepPref' in state && state['form.fldStepPref']?.[2]?.length > 0) {
-    validatedState['form.fldStepPref'] = state['form.fldStepPref'];
+  const stepPreferences = state['form.fldStepPref'] || {};
+  const count = Object.values(stepPreferences).findLastIndex((fields) => fields?.length) + 1 || 1;
+
+  if (count > 1) {
+    validatedState['form.fldStepPref'] = stepPreferences;
   }
 
   return validatedState;
@@ -199,7 +203,7 @@ const getPanels = (panelsData, lsKey) => {
 };
 
 const getDataUrl = (state) => {
-  const url = window.location.href.split('#')[0];
+  const url = window.location.href.split(/#|\?/)[0];
   return `${url}#${utf8ToB64(JSON.stringify(state))}`;
 };
 
@@ -247,7 +251,9 @@ const Configurator = ({ title, panelsData, lsKey }) => {
   useEffect(() => {
     const contentEl = document.querySelector('.content-panel');
     const validatedState = validateState(state, panelsData);
-    const iframe = createTag('iframe', { src: window.location.href.split(/#|\?/)[0] });
+    const url = window.location.href.split(/#|\?/)[0];
+    const isPreview = window.location.href.includes('preview=1');
+    const iframe = createTag('iframe', { src: url + (isPreview ? '?preview=1' : '') });
 
     saveStateToLocalStorage(validatedState, lsKey);
     contentEl.replaceChildren(iframe);
@@ -286,7 +292,7 @@ const Configurator = ({ title, panelsData, lsKey }) => {
     if (!selectedRules || Object.keys(selectedRules).length === 0) return;
 
     applyRulesToState(selectedRules);
-  }, [state['form.template']]);
+  }, [state['form.template'], state.reset]);
 
   return html`
     <div class="tool-header">

--- a/libs/blocks/marketo-config/marketo-config.js
+++ b/libs/blocks/marketo-config/marketo-config.js
@@ -7,6 +7,8 @@ import CopyBtn from '../../ui/controls/CopyBtn.js';
 import { Input, Select } from '../../ui/controls/formControls.js';
 import StepPanel from './step-panel.js';
 
+const CONFIG_URL = 'https://milo.adobe.com/tools/marketo';
+
 const TEMPLATE_RULE_MAPPING = {
   formVersion: 'form.id',
   formSuccessType: 'form.success.type',
@@ -202,10 +204,7 @@ const getPanels = (panelsData, lsKey) => {
   return panels;
 };
 
-const getDataUrl = (state) => {
-  const url = window.location.href.split(/#|\?/)[0];
-  return `${url}#${utf8ToB64(JSON.stringify(state))}`;
-};
+const getDataUrl = (state) => `${CONFIG_URL}#${utf8ToB64(JSON.stringify(state))}`;
 
 const Configurator = ({ title, panelsData, lsKey }) => {
   const { dispatch, state } = useContext(ConfiguratorContext);

--- a/libs/blocks/marketo-config/step-panel.js
+++ b/libs/blocks/marketo-config/step-panel.js
@@ -1,0 +1,142 @@
+import { html, useContext, useState, useEffect } from '../../deps/htm-preact.js';
+import { ConfiguratorContext } from './context.js';
+import { Select } from '../../ui/controls/formControls.js';
+import TagSelect from '../../ui/controls/TagSelector.js';
+
+const STEP_OPTIONS = { 1: 'one', 2: 'multi-2', 3: 'multi-3' };
+const FORM_FIELDS = [
+  { name: 'name', label: 'First and Last Name', step: 1 },
+  { name: 'email', label: 'Email', step: 1 },
+  { name: 'phone', label: 'Phone', step: 1 },
+  { name: 'company', label: 'Company', step: 1 },
+  { name: 'country', label: 'Country', step: 1 },
+  { name: 'state', label: 'State', step: 1 },
+  { name: 'postalCode', label: 'Postal Code', step: 1 },
+  { name: 'mktoFormsJobTitle', label: 'Job Title', step: 2 },
+  { name: 'mktoFormsCompanyType', label: 'Company Type', step: 2 },
+  { name: 'mktoFormsFunctionalArea', label: 'Functional Area', step: 2 },
+  { name: 'mktoFormsRevenue', label: 'Annual Revenue', step: 2 },
+  { name: 'mktoFormsEmployeeRange', label: 'Employee Range', step: 2 },
+  { name: 'mktoFormsPrimaryProductInterest', label: 'Primary Product Interest', step: 3 },
+  { name: 'mktoFormsComments', label: 'Comments', step: 3 },
+  { name: 'mktoRequestProductDemo', label: 'Request Product Demo', step: 3 },
+];
+
+const createFieldMaps = (fields) => ({
+  allOptions: fields.reduce((acc, field) => ({ ...acc, [field.name]: field.label }), {}),
+  defaultFields: fields.reduce((acc, field) => {
+    if (!acc[field.step]) acc[field.step] = [];
+    acc[field.step].push(field.name);
+    return acc;
+  }, {}),
+});
+
+const getUnselectedOptions = (allOptions, stepPreferences) => Object.fromEntries(
+  Object.entries(allOptions).filter(([key]) => !Object.keys(STEP_OPTIONS)
+    .slice(1).some((step) => stepPreferences?.[step]?.includes(key))),
+);
+
+const ReadonlyTagSelect = ({ options, value, label }) => html`
+  <div class="tagselect">
+    <label>${label}</label>
+    <div class="tagselect-input">
+      <div class="tagselect-values">
+        ${value.map((val) => html`
+          <div class="tagselect-tag">
+            <span class="tagselect-tag-text">${options[val]}</span>
+          </div>`)}
+      </div>
+    </div>
+  </div>
+`;
+
+const StepPanel = () => {
+  const { state, dispatch } = useContext(ConfiguratorContext);
+  const [stepCount, setStepCount] = useState(1);
+  const [unselected, setUnselected] = useState({});
+  const { allOptions, defaultFields } = createFieldMaps(FORM_FIELDS);
+
+  useEffect(() => {
+    const stepPreferences = state['form.fldStepPref'] || {};
+    const filteredSteps = Object.keys(STEP_OPTIONS)
+      .filter((key) => stepPreferences?.[key]?.length > 0);
+
+    setStepCount(Math.max(1, ...filteredSteps.map(Number)));
+    setUnselected(getUnselectedOptions(allOptions, stepPreferences));
+  }, []);
+
+  const setFieldStepPreferences = (fieldStepPreferences) => {
+    dispatch({
+      type: 'SET_VALUE',
+      prop: 'form.fldStepPref',
+      value: fieldStepPreferences,
+    });
+  };
+
+  const getDefaultFieldSteps = (count) => {
+    switch (count) {
+      case 1:
+        return { 1: defaultFields[1].concat(defaultFields[2], defaultFields[3]), 2: [], 3: [] };
+      case 2:
+        return { 1: defaultFields[1], 2: defaultFields[2].concat(defaultFields[3]), 3: [] };
+      default:
+        return { 1: defaultFields[1], 2: defaultFields[2], 3: defaultFields[3] };
+    }
+  };
+
+  const setDefaultFieldSteps = (count) => {
+    const defaultFieldSteps = getDefaultFieldSteps(count);
+    setFieldStepPreferences(defaultFieldSteps);
+    setUnselected(getUnselectedOptions(allOptions, defaultFieldSteps));
+  };
+
+  const stepPreferences = state['form.fldStepPref'];
+
+  const getStepOptions = (index) => {
+    const currentStep = index + 1;
+    const stepValues = stepPreferences?.[currentStep] || [];
+    const currentStepOptions = Object.entries(allOptions).reduce((acc, [key, label]) => {
+      if (stepValues.includes(key)) {
+        acc[key] = label;
+      }
+      return acc;
+    }, getUnselectedOptions(allOptions, stepPreferences));
+
+    const onChange = (newValue) => {
+      const newFldStepPref = { ...stepPreferences, [currentStep]: newValue };
+      // Step 1 should always have all unselected options
+      const newUnselected = getUnselectedOptions(allOptions, newFldStepPref);
+      newFldStepPref[1] = Object.keys(newUnselected);
+      setFieldStepPreferences(newFldStepPref);
+      setUnselected(newUnselected);
+    };
+
+    return html`
+      <div class="step-field" key=${`step-${currentStep}-${stepValues.length}-${currentStepOptions.length}`}>
+        <${TagSelect} options=${currentStepOptions} label="Fields for step ${currentStep}" value=${stepValues} onChange=${onChange} />
+      </div>
+    `;
+  };
+
+  const handleStepCountChange = (value) => {
+    const count = parseInt(value, 10);
+    if (Number.isNaN(count)) return;
+
+    setStepCount(count);
+    setDefaultFieldSteps(count);
+  };
+
+  return html`
+    <div class="step-panel">
+      <div class="steps-config">
+        <${Select} label="Number of Steps" name="fldStepCount" options=${STEP_OPTIONS} value=${stepCount} onChange=${handleStepCountChange} />
+        <div class="step-field" key=${`step-1-${unselected.length}`}>
+          <${ReadonlyTagSelect} options=${unselected} label="Fields for step 1 (default)" value=${Object.keys(unselected)} />
+        </div>
+        ${[...Array(stepCount - 1)].map((_, i) => getStepOptions(i + 1))}
+        <button class="resetToDefaultState" onClick=${() => setDefaultFieldSteps(stepCount)}>Reset steps</button>
+      </div>
+    </div>`;
+};
+
+export default StepPanel;

--- a/libs/blocks/marketo-config/step-panel.js
+++ b/libs/blocks/marketo-config/step-panel.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { html, useContext, useState, useEffect } from '../../deps/htm-preact.js';
 import { ConfiguratorContext } from './context.js';
 import { Select } from '../../ui/controls/formControls.js';
@@ -5,19 +6,19 @@ import TagSelect from '../../ui/controls/TagSelector.js';
 
 const STEP_OPTIONS = { 1: 'one', 2: 'multi-2', 3: 'multi-3' };
 const FORM_FIELDS = [
-  { name: 'name', label: 'First and Last Name', step: 1 },
   { name: 'email', label: 'Email', step: 1 },
-  { name: 'phone', label: 'Phone', step: 1 },
-  { name: 'company', label: 'Company', step: 1 },
   { name: 'country', label: 'Country', step: 1 },
-  { name: 'state', label: 'State', step: 1 },
-  { name: 'postalCode', label: 'Postal Code', step: 1 },
+  { name: 'name', label: 'First and Last Name', step: 2 },
+  { name: 'phone', label: 'Phone', step: 2 },
   { name: 'mktoFormsJobTitle', label: 'Job Title', step: 2 },
-  { name: 'mktoFormsCompanyType', label: 'Company Type', step: 2 },
   { name: 'mktoFormsFunctionalArea', label: 'Functional Area', step: 2 },
   { name: 'mktoFormsRevenue', label: 'Annual Revenue', step: 2 },
   { name: 'mktoFormsEmployeeRange', label: 'Employee Range', step: 2 },
+  { name: 'company', label: 'Company', step: 3 },
+  { name: 'state', label: 'State', step: 3 },
+  { name: 'postcode', label: 'Postal Code', step: 3 },
   { name: 'mktoFormsPrimaryProductInterest', label: 'Primary Product Interest', step: 3 },
+  { name: 'mktoFormsCompanyType', label: 'Company Type', step: 3 },
   { name: 'mktoFormsComments', label: 'Comments', step: 3 },
   { name: 'mktoRequestProductDemo', label: 'Request Product Demo', step: 3 },
 ];
@@ -58,12 +59,11 @@ const StepPanel = () => {
 
   useEffect(() => {
     const stepPreferences = state['form.fldStepPref'] || {};
-    const filteredSteps = Object.keys(STEP_OPTIONS)
-      .filter((key) => stepPreferences?.[key]?.length > 0);
+    const count = Object.values(stepPreferences).findLastIndex((fields) => fields?.length) + 1 || 1;
 
-    setStepCount(Math.max(1, ...filteredSteps.map(Number)));
+    setStepCount(Math.max(1, count));
     setUnselected(getUnselectedOptions(allOptions, stepPreferences));
-  }, []);
+  }, [state.reset]);
 
   const setFieldStepPreferences = (fieldStepPreferences) => {
     dispatch({

--- a/libs/blocks/marketo/marketo-multi.js
+++ b/libs/blocks/marketo/marketo-multi.js
@@ -3,15 +3,19 @@ import { debounce } from '../../utils/action.js';
 import { replaceKey } from '../../features/placeholders.js';
 
 const VALIDATION_STEP = {
-  name: '2',
-  phone: '2',
-  mktoFormsJobTitle: '2',
-  mktoFormsFunctionalArea: '2',
-  company: '3',
-  state: '3',
-  postcode: '3',
-  mktoFormsPrimaryProductInterest: '3',
-  mktoFormsCompanyType: '3',
+  2: [
+    'name',
+    'phone',
+    'mktoFormsJobTitle',
+    'mktoFormsFunctionalArea',
+  ],
+  3: [
+    'company',
+    'state',
+    'postcode',
+    'mktoFormsPrimaryProductInterest',
+    'mktoFormsCompanyType',
+  ],
 };
 
 export function updateTabIndex(formEl, stepToAdd, stepToRemove) {
@@ -78,9 +82,12 @@ export const formValidate = async (formEl) => {
 };
 
 function setValidationSteps(formEl, totalSteps, currentStep) {
+  const formData = window.mcz_marketoForm_pref || {};
+  const validationMap = formData.form?.fldStepPref || VALIDATION_STEP;
   formEl.querySelectorAll('.mktoFormRowTop').forEach((row) => {
     const rowAttr = row.getAttribute('data-mktofield') || row.getAttribute('data-mkto_vis_src');
-    const step = VALIDATION_STEP[rowAttr] ? Math.min(VALIDATION_STEP[rowAttr], totalSteps) : 1;
+    const mapStep = Object.keys(validationMap).find((stepNum) => validationMap[stepNum].some((field) => field.toLowerCase() === rowAttr?.toLowerCase())) || '1';
+    const step = Math.min(parseInt(mapStep, 10), totalSteps);
     row.dataset.validate = rowAttr?.startsWith('adobe-privacy') ? totalSteps : step;
     const fields = row.querySelectorAll('input, select, textarea');
     if (fields.length) fields.forEach((f) => { f.tabIndex = step === currentStep ? 0 : -1; });

--- a/libs/blocks/marketo/marketo-multi.js
+++ b/libs/blocks/marketo/marketo-multi.js
@@ -84,6 +84,11 @@ export const formValidate = async (formEl) => {
 function setValidationSteps(formEl, totalSteps, currentStep) {
   const formData = window.mcz_marketoForm_pref || {};
   const validationMap = formData.form?.fldStepPref || VALIDATION_STEP;
+  Object.keys(validationMap).forEach((step) => {
+    validationMap[step] = validationMap[step].join(',').split(',');
+  });
+  formData.form.fldStepPref = validationMap;
+
   formEl.querySelectorAll('.mktoFormRowTop').forEach((row) => {
     const rowAttr = row.getAttribute('data-mktofield') || row.getAttribute('data-mkto_vis_src');
     const mapStep = Object.keys(validationMap).find((stepNum) => validationMap[stepNum].some((field) => field?.toLowerCase() === rowAttr?.toLowerCase())) || '1';

--- a/libs/blocks/marketo/marketo-multi.js
+++ b/libs/blocks/marketo/marketo-multi.js
@@ -87,6 +87,7 @@ function setValidationSteps(formEl, totalSteps, currentStep) {
   Object.keys(validationMap).forEach((step) => {
     validationMap[step] = validationMap[step].join(',').split(',');
   });
+  formData.form ??= {};
   formData.form.fldStepPref = validationMap;
 
   formEl.querySelectorAll('.mktoFormRowTop').forEach((row) => {

--- a/libs/blocks/marketo/marketo-multi.js
+++ b/libs/blocks/marketo/marketo-multi.js
@@ -86,7 +86,7 @@ function setValidationSteps(formEl, totalSteps, currentStep) {
   const validationMap = formData.form?.fldStepPref || VALIDATION_STEP;
   formEl.querySelectorAll('.mktoFormRowTop').forEach((row) => {
     const rowAttr = row.getAttribute('data-mktofield') || row.getAttribute('data-mkto_vis_src');
-    const mapStep = Object.keys(validationMap).find((stepNum) => validationMap[stepNum].some((field) => field.toLowerCase() === rowAttr?.toLowerCase())) || '1';
+    const mapStep = Object.keys(validationMap).find((stepNum) => validationMap[stepNum].some((field) => field?.toLowerCase() === rowAttr?.toLowerCase())) || '1';
     const step = Math.min(parseInt(mapStep, 10), totalSteps);
     row.dataset.validate = rowAttr?.startsWith('adobe-privacy') ? totalSteps : step;
     const fields = row.querySelectorAll('input, select, textarea');

--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -306,7 +306,10 @@ export default function init(el) {
   fragment.append(formWrapper);
   el.replaceChildren(fragment);
   el.classList.add('loading');
-  /* c8 ignore next 3 */
+  /* c8 ignore next 6 */
+  if (formData['form.fldStepPref']?.[2]?.length > 0) {
+    el.classList.add(formData['form.fldStepPref'][3]?.length > 0 ? 'multi-3' : 'multi-2');
+  }
   if (el.classList.contains('multi-2') || el.classList.contains('multi-3')) {
     el.classList.add('multi-step');
   }

--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -306,9 +306,13 @@ export default function init(el) {
   fragment.append(formWrapper);
   el.replaceChildren(fragment);
   el.classList.add('loading');
+
+  const stepPreferences = formData['form.fldStepPref'] || {};
+  const count = Object.values(stepPreferences).findLastIndex((fields) => fields?.length) + 1 || 1;
+
   /* c8 ignore next 6 */
-  if (formData['form.fldStepPref']?.[2]?.length > 0) {
-    el.classList.add(formData['form.fldStepPref'][3]?.length > 0 ? 'multi-3' : 'multi-2');
+  if (count > 1) {
+    el.classList.add(`multi-${count}`);
   }
   if (el.classList.contains('multi-2') || el.classList.contains('multi-3')) {
     el.classList.add('multi-step');

--- a/test/blocks/marketo-config/marketo-config.test.js
+++ b/test/blocks/marketo-config/marketo-config.test.js
@@ -76,7 +76,7 @@ describe('marketo-config', () => {
     const accordion = await waitForElement('.accordion');
     expect(accordion).to.exist;
 
-    const marketo = await waitForElement('.marketo');
+    const marketo = await waitForElement('iframe');
     expect(marketo).to.exist;
   });
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Configure Marketo multi-step form with 2 & 3 step variations via step panel.
  * Fields can be added to any step.
* Configurator now loads from iframe to allow for form reinitialization.
  * Copied template code out of MCZ and passed template config via messages.


Resolves: [MWPW-175124](https://jira.corp.adobe.com/browse/MWPW-175124)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/bmarshal/marketo/step-2?martech=off
- After: https://bmarshal-step-config--milo--adobecom.aem.page/drafts/bmarshal/marketo/step-2?martech=off
- Before: https://main--milo--adobecom.aem.page/drafts/bmarshal/marketo/step-3?martech=off
- After: https://bmarshal-step-config--milo--adobecom.aem.page/drafts/bmarshal/marketo/step-3?martech=off

**BACOM URLs:**
- Before: https://main--bacom--adobecom.hlx.live/request-consultation/experience-cloud?martech=off
- After: https://main--bacom--adobecom.hlx.live/request-consultation/experience-cloud?martech=off&milolibs=bmarshal-step-config



















