### PR TITLE
Improve share block accessibility

### DIFF
--- a/libs/blocks/share/share.css
+++ b/libs/blocks/share/share.css
@@ -123,6 +123,8 @@
   visibility: visible;
   opacity: 1;
   transition-delay: 0ms;
+  pointer-events: auto;
+  cursor: default;
 }
 
 .share .copy-to-clipboard:hover::before,
@@ -168,4 +170,11 @@ main > .section.center .share.inline p.icon-container {
   .share .copy-to-clipboard::before {
     left: 50%;
   }
+}
+
+.share .aria-live-container {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
 }

--- a/libs/blocks/share/share.js
+++ b/libs/blocks/share/share.js
@@ -169,12 +169,24 @@ export default async function decorate(block) {
       },
       clipboardSvg.svg,
     );
-    container.append(copyButton);
+    const copyAriaLive = createTag(
+      'div',
+      {
+        'aria-live': 'polite',
+        role: 'status',
+        class: 'aria-live-container',
+      },
+    );
+    container.append(copyButton, copyAriaLive);
+    let changeText = false;
     copyButton.addEventListener('click', (e) => {
       /* c8 ignore next 6 */
       e.preventDefault();
+      copyAriaLive.textContent = '';
       navigator.clipboard.writeText(window.location.href).then(() => {
         copyButton.classList.add('copy-to-clipboard-copied');
+        copyAriaLive.textContent = copiedTooltip + (changeText ? '\u200b' : '');
+        changeText = !changeText;
         setTimeout(() => document.activeElement.blur(), 500);
         setTimeout(
           () => copyButton.classList.remove('copy-to-clipboard-copied'),


### PR DESCRIPTION
Issues: 
- When user clicks copy button, `Copied`  text is not announced by the screen reader.
- Hovering tooltip popup is not possible

I added [\u200b](https://unicode-explorer.com/c/200B) char because if user clicks button again, reader will ignore it because text is the same as before.

Resolves: [MWPW-176818](https://jira.corp.adobe.com/browse/MWPW-176818) , [MWPW-176923](https://jira.corp.adobe.com/browse/MWPW-176923)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/share?martech=off
- After: https://share-copy-a11y--milo--adobecom.aem.page/docs/library/kitchen-sink/share?martech=off

**CC URLs:**
- Before: https://main--cc--adobecom.aem.page/es/creativecloud/video/discover/how-to-trim-video?akamaiLocale=es
- After: https://main--cc--adobecom.aem.page/es/creativecloud/video/discover/how-to-trim-video?milolibs=share-copy-a11y&akamaiLocale=es


