### PR TITLE
MWPW-174487 Fix FaaS environment detection on stage URLs

### DIFF
--- a/libs/blocks/faas/utils.js
+++ b/libs/blocks/faas/utils.js
@@ -17,7 +17,7 @@ export const getFaasHostSubDomain = (environment) => {
   if (env.name === 'prod' || faasEnv === 'prod') {
     return '';
   }
-  if (faasEnv === 'stage') {
+  if (env.name === 'stage' || faasEnv === 'stage') {
     return 'staging.';
   }
   if (faasEnv === 'dev') {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

- Fix FaaS environment detection on stage URLs to correctly use staging
  subdomain when running on http://www.stage.adobe.com
- Addresses issue where forms failed to load on stage environment without
  explicit faas-env parameter

Resolves: [MWPW-174487](https://jira.corp.adobe.com/browse/MWPW-174487)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/creativecloud/business/teams/request-information?martech=off
- After: https://mwpw-174487-faas-form--nkthakur48--adobecom.aem.live/creativecloud/business/teams/request-information?martech=off
