### PR TITLE
MWPW: mWeb Rollout Ps Test | 800 font weight & feature flag

### DIFF
--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -939,7 +939,14 @@ a.static:active  {
     -webkit-hyphenate-limit-after: 7;
   }
 
-  :root:has(head > meta[name="mweb"][content="on"]) body [class^="heading-"] {
+  :root:has(head > meta[name="mweb"][content="on"]) body [class^="heading-"],
+  :root:has(head > meta[name="mweb"][content="on"]) body h1, 
+  :root:has(head > meta[name="mweb"][content="on"]) body h2, 
+  :root:has(head > meta[name="mweb"][content="on"]) body h3, 
+  :root:has(head > meta[name="mweb"][content="on"]) body h4,
+  :root:has(head > meta[name="mweb"][content="on"]) body h5, 
+  :root:has(head > meta[name="mweb"][content="on"]) body h6
+  {
     font-weight: var(--type-heading-all-weight-mweb);
   }
 

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -939,15 +939,10 @@ a.static:active  {
     -webkit-hyphenate-limit-after: 7;
   }
 
-  :root:has(head > meta[name="mweb"][content="on"]) body [class^="heading-"],
-  :root:has(head > meta[name="mweb"][content="on"]) body h1, 
-  :root:has(head > meta[name="mweb"][content="on"]) body h2, 
-  :root:has(head > meta[name="mweb"][content="on"]) body h3, 
-  :root:has(head > meta[name="mweb"][content="on"]) body h4,
-  :root:has(head > meta[name="mweb"][content="on"]) body h5, 
-  :root:has(head > meta[name="mweb"][content="on"]) body h6
-  {
-    font-weight: var(--type-heading-all-weight-mweb);
+  body.mweb-enabled {
+    [class^="heading-"], h1, h2, h3, h4, h5, h6 {
+      font-weight: var(--type-heading-all-weight-mweb);
+    }
   }
 
   .con-button.button-justified-mobile {

--- a/libs/styles/styles.css
+++ b/libs/styles/styles.css
@@ -61,6 +61,7 @@
 
   /* Headings (Consonant) */
   --type-heading-all-weight: 700;
+  --type-heading-all-weight-mweb: 800;
   --type-heading-xxxl-size: calc(var(--font-size-multiplier, 1) * 44px);
   --type-heading-xxxl-lh: 55px;
   --type-heading-xxl-size: calc(var(--font-size-multiplier, 1) * 36px);
@@ -936,6 +937,10 @@ a.static:active  {
     hyphenate-limit-chars: 15 5 5;
     -webkit-hyphenate-limit-before: 7;
     -webkit-hyphenate-limit-after: 7;
+  }
+
+  :root:has(head > meta[name="mweb"][content="on"]) body [class^="heading-"] {
+    font-weight: var(--type-heading-all-weight-mweb);
   }
 
   .con-button.button-justified-mobile {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -253,6 +253,13 @@ export function getMetadata(name, doc = document) {
   return meta && meta.content;
 }
 
+(() => {
+  const mweb = getMetadata('mweb');
+  if (mweb === 'on') {
+    document.body.classList.add('mweb-enabled');
+  }
+})();
+
 const handleEntitlements = (() => {
   const { martech } = Object.fromEntries(PAGE_URL.searchParams);
   if (martech === 'off') return () => { };


### PR DESCRIPTION
#### Summary of Changes:

* Applied font weight 800 to all headings for viewports up to 599px, based on the `mweb` meta tag.
* Analyzed multiple blocks that use the `.heading-` class and identified the heading variants used in each:

  * **Hero-marquee**: `h1` class:- `heading-xxl`
  * **Marquee**: `h1` class:- `heading-xl`
  * **Text**: `h2` class:- `heading-l`
  * **Text**: `h3` class:- `heading-xxxl`
  * **Notification**: `h3` class:- `heading-m`
  * **Carousel**: `h3` class:- `heading-l`
  * **Aside Block**: `h3` class:- `heading-xl`
* Found that some blocks (e.g., **Card**) use standard heading tags (`h1`, `h2`, etc.) without the `.heading-` class. In these cases, using only class="heading-" will not apply the font-weight changes. That’s why I’ve also included styles targeting standard heading tags (h1 to h6) to ensure consistent styling.
* Also identified that the **Table** block uses the `.heading-content` class on a `div`. Font-weight styling will now apply there as well.
* Currently, tested with English locale only.

**Resolves:** [MWPW-177170](https://jira.corp.adobe.com/browse/MWPW-177170)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-177170-mweb-font-weight--milo--hkuraware.aem.page/?martech=off


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- Milo: https://mwpw-177170-mweb-font-weight--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- Milo: https://mwpw-177170-mweb-font-weight--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- Milo: https://mwpw-177170-mweb-font-weight--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=mwpw-177170-mweb-font-weight--milo--adobecom
</details>


**Screenshots:**
<img width="1512" height="804" alt="Screenshot 2025-08-05 at 3 07 12 PM" src="https://github.com/user-attachments/assets/dff22eb9-eb93-4034-99a9-ac1e142e5bb9" />
<img width="1512" height="610" alt="Screenshot 2025-08-05 at 12 29 52 PM" src="https://github.com/user-attachments/assets/f5f8dfd7-55ad-42bc-b036-3b7dbaed59c4" />
<img width="1512" height="610" alt="Screenshot 2025-08-05 at 12 30 21 PM" src="https://github.com/user-attachments/assets/ba8322e7-2945-470d-a3b0-70ba86d6591e" />
<img width="1512" height="610" alt="Screenshot 2025-08-05 at 12 32 15 PM" src="https://github.com/user-attachments/assets/ccc88940-e10f-4a75-a5ca-df4a2d302c1d" />
<img width="1512" height="683" alt="Screenshot 2025-08-05 at 12 33 08 PM" src="https://github.com/user-attachments/assets/f8cc7a8c-53e0-4f3d-a4a0-bddc36480426" />
<img width="1512" height="804" alt="Screenshot 2025-08-05 at 12 34 12 PM" src="https://github.com/user-attachments/assets/dd4ee8c5-9b4f-4e11-b874-521c19bdd05b" />
<img width="1512" height="804" alt="Screenshot 2025-08-05 at 12 36 55 PM" src="https://github.com/user-attachments/assets/21d62412-1c22-48e1-8319-728704a102b0" />
<img width="1512" height="804" alt="Screenshot 2025-08-05 at 12 37 20 PM" src="https://github.com/user-attachments/assets/26eb7f52-162e-4f5f-8388-40d4d814d555" />
<img width="1512" height="804" alt="Screenshot 2025-08-05 at 12 37 58 PM" src="https://github.com/user-attachments/assets/783859fc-b6ea-426e-909c-34640c560119" />
<img width="1512" height="804" alt="Screenshot 2025-08-05 at 12 41 08 PM" src="https://github.com/user-attachments/assets/2166d00a-2626-45e1-bbac-45c1148483e3" />
