### PR TITLE
Mobile global footer arrow keyboard navigation fixed

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -633,9 +633,7 @@ class Gnav {
       localNav.querySelector('.feds-localnav-title').setAttribute('daa-ll', `${title}_localNav|${isActive ? 'close' : 'open'}`);
     });
 
-    localNav.querySelector('.feds-navItem--active')?.addEventListener('click', () => {
-      closeAllDropdowns();
-    });
+    localNav.querySelector('.feds-navItem--active')?.addEventListener('click', closeAllDropdowns);
 
     const curtain = localNav.querySelector('.feds-localnav-curtain');
     curtain.addEventListener('click', (e) => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -632,6 +632,10 @@ class Gnav {
       localNav.querySelector('.feds-localnav-title').setAttribute('aria-expanded', isActive);
       localNav.querySelector('.feds-localnav-title').setAttribute('daa-ll', `${title}_localNav|${isActive ? 'close' : 'open'}`);
     });
+    
+    localNav.querySelector('.feds-navItem--active')?.addEventListener('click', () => {
+      closeAllDropdowns();
+    });
 
     const curtain = localNav.querySelector('.feds-localnav-curtain');
     curtain.addEventListener('click', (e) => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -632,7 +632,7 @@ class Gnav {
       localNav.querySelector('.feds-localnav-title').setAttribute('aria-expanded', isActive);
       localNav.querySelector('.feds-localnav-title').setAttribute('daa-ll', `${title}_localNav|${isActive ? 'close' : 'open'}`);
     });
-    
+
     localNav.querySelector('.feds-navItem--active')?.addEventListener('click', () => {
       closeAllDropdowns();
     });

--- a/libs/blocks/global-navigation/utilities/keyboard/mobilePopup.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/mobilePopup.js
@@ -244,7 +244,7 @@ class Popup {
         break;
       }
       case 'ArrowUp': {
-        if (newNav) break;
+        if (newNav && !isFooter) break;
         this.mobileArrowUp({ prev, curr, element, isFooter });
         break;
       }
@@ -265,7 +265,7 @@ class Popup {
         break;
       }
       case 'ArrowDown': {
-        if (newNav) break;
+        if (newNav && !isFooter) break;
         this.mobileArrowDown({ next, element, isFooter });
         break;
       }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Mobile global footer arrow keyboard navigation fixed
* Added the functionality of closing lnav if clicked on active item

Resolves: [MWPW-177039](https://jira.corp.adobe.com/browse/MWPW-177039), [MWPW-167705](https://jira.corp.adobe.com/browse/MWPW-167705)


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://footer-keyboard--milo--adobecom.aem.page/?martech=off


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=footer-keyboard--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=footer-keyboard--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=footer-keyboard--milo--adobecom
- Milo: https://footer-keyboard--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=footer-keyboard--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=footer-keyboard--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=footer-keyboard--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=footer-keyboard--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=footer-keyboard--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=footer-keyboard--milo--adobecom
- Milo: https://footer-keyboard--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=footer-keyboard--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=footer-keyboard--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=footer-keyboard--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=footer-keyboard--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=footer-keyboard--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=footer-keyboard--milo--adobecom
- Milo: https://footer-keyboard--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=footer-keyboard--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=footer-keyboard--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=footer-keyboard--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=footer-keyboard--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=footer-keyboard--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=footer-keyboard--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=footer-keyboard--milo--adobecom
</details>