### PR TITLE
MWPW-177288: Move nowrap to only tablet and desktop

### DIFF
--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -204,10 +204,6 @@
   flex-direction: row;
 }
 
-.editorial-card .action-area .con-button { 
-  white-space: nowrap;
-}
-
 .editorial-card.center .action-area {
   justify-content: center;
 }
@@ -296,6 +292,11 @@
   }
 
   .editorial-card .vp-media .tablet-only { display: block; }
+
+  .editorial-card .action-area .con-button {
+    white-space: nowrap;
+  }
+
 }
 
 /* desktop up */


### PR DESCRIPTION
Issue: On mobile, button in editorial-card block overflows if there is a lot of text. 

<img width="288" height="469" alt="Screenshot 2025-08-05 at 11 07 03" src="https://github.com/user-attachments/assets/c5a2e4d1-516b-4cab-b8ef-7d5b5dea2b6b" />
<img width="282" height="488" alt="Screenshot 2025-08-05 at 11 06 52" src="https://github.com/user-attachments/assets/da29b04f-f50e-4112-9711-fd91e6777048" />

Resolves: [MWPW-177288](https://jira.corp.adobe.com/browse/MWPW-177288)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/editorial-card?martech=off
- After: https://mwpw-177288-editorial-info-lost--milo--adobecom.aem.page/docs/library/kitchen-sink/editorial-card?martech=off

**CC URLs:**
- Before: https://main--cc--adobecom.aem.page/trust?akamaiLocale=us
- After: https://main--cc--adobecom.aem.page/trust?milolibs=mwpw-177288-editorial-info-lost&akamaiLocale=us
