### PR TITLE
[MWPW-177247] Adapt card footer height for a11y

### DIFF
--- a/libs/blocks/card/card.css
+++ b/libs/blocks/card/card.css
@@ -9,8 +9,12 @@
 }
 
 .card [class^="consonant-"]:is([class$="-title"], [class$="-text"]),
-.card [class^="consonant-CardsGrid--"][class$="up"] .consonant-ThreeFourthCard>a>.consonant-ThreeFourthCard-title {
+.card [class^="consonant-CardsGrid--"][class$="up"] .consonant-ThreeFourthCard > a > .consonant-ThreeFourthCard-title {
   max-height: unset;
+}
+
+.card .consonant-CardFooter-row {
+  height: auto;
 }
 
 .card hr {


### PR DESCRIPTION
This removes the fixed height restriction from the card block footer, to allow its content to expand to the space it needs. Thus, content is no longer hidden and is compliant with accessibility requirements.

| Before | After |
| ------------- | ------------- |
| <img width="1296" height="694" alt="Screenshot 2025-08-05 at 15 17 26" src="https://github.com/user-attachments/assets/42e08f91-99e3-4faf-8457-dec97e2a84a6" /> | <img width="1296" height="694" alt="Screenshot 2025-08-05 at 15 16 57" src="https://github.com/user-attachments/assets/65c0d496-89fb-4abe-8e11-0c49da575ced" /> |

Resolves: [MWPW-177247](https://jira.corp.adobe.com/browse/MWPW-177247)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/cards-with-long-cta?martech=off
- After: https://card-cta-height--milo--overmyheadandbody.aem.page/drafts/ramuntea/cards-with-long-cta?martech=off
- Before (Original issue): https://main--dc--adobecom.aem.live/es/acrobat/resources/document-files/spreadsheet-files/xlsx?martech=off
- After (Original issue): https://main--dc--adobecom.aem.live/es/acrobat/resources/document-files/spreadsheet-files/xlsx?martech=off&milolibs=card-cta-height--milo--overmyheadandbody


