### PR TITLE
fix(merch): extract button styling classes from URL hash parameters and add it to the merch CTA

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1135,14 +1135,7 @@ export async function buildCta(el, params) {
     cta.classList.toggle('blue', strong);
   }
 
-  /*
-   * MWPW-170462: Extract button styling classes from URL hash parameters
-   * This handles #_button-fill and similar decorators to customize CTA appearance
-   */
-  const customClasses = el.href.matchAll(/#_button-([a-zA-Z-]+)/g);
-  for (const match of customClasses) {
-    cta.classList.add(match[1]);
-  }
+
 
   if (context.entitlement !== 'false') {
     cta.classList.add(LOADING_ENTITLEMENTS);

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1134,6 +1134,16 @@ export async function buildCta(el, params) {
     cta.classList.toggle('button-l', large);
     cta.classList.toggle('blue', strong);
   }
+
+  /*
+   * MWPW-170462: Extract button styling classes from URL hash parameters
+   * This handles #_button-fill and similar decorators to customize CTA appearance
+   */
+  const customClasses = el.href.matchAll(/#_button-([a-zA-Z-]+)/g);
+  for (const match of customClasses) {
+    cta.classList.add(match[1]);
+  }
+
   if (context.entitlement !== 'false') {
     cta.classList.add(LOADING_ENTITLEMENTS);
     cta.onceSettled().finally(() => {


### PR DESCRIPTION
This change fixes an issue where the #_button-fill link decorator was not being applied to “merch” CTAs in a hero marquee block in Milo. Previously, only the default blue button style was available for merch links, because the merch link handler did not recognize or strip the #_button-fill fragment.

Here's the slack thread for additional context:
🧵: [https://adobedotcom.slack.com/archives/C03B0BUA75E/p1742958293820199](https://adobedotcom.slack.com/archives/C03B0BUA75E/p1742958293820199)

📸: <img width="1915" height="680" alt="image" src="https://github.com/user-attachments/assets/fd6d0ab2-a691-443a-a745-19a5199c8e9d" />

🔗: https://main--cc--adobecom.aem.page/drafts/aullal/backup/mwpw-170462?milolibs=local

Resolves: [MWPW-170462](https://jira.corp.adobe.com/browse/MWPW-170462)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-170462-merch-cta-styling-fix--milo--adobecom.aem.page/?martech=off








