### PR TITLE
MWPW-175128 - Edit locales issue on 3rd step

### DIFF
--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -91,8 +91,7 @@ export function setSelectedLocalesAndRegions() {
       });
     } else {
       livecopiesArr.forEach((liveCopy) => {
-        const localeKey = `${languagecode}|${liveCopy}`;
-        activeLocales[localeKey] = language;
+        activeLocales[liveCopy] = language;
       });
     }
     selectedLocale.push(...livecopiesArr);


### PR DESCRIPTION
*  remove concatenation of ${languagecode}|${liveCopy} as livecopiesArr has concatenated values.

Resolves: https://jira.corp.adobe.com/browse/MWPW-177461

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/tools/locui-create?martech=off
- After: https://MWPW-177461-edit-locales-issue--milo--saurabhsircar11.aem.page/tools/locui-create?martech=off

 **CC URLs: **
- Before: https://main--cc--adobecom.aem.page/tools/locui-create?milolibs=milostudio-dev&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&env=local&workflow=normal
- After: https://main--cc--adobecom.aem.page/tools/locui-create?milolibs=MWPW-177461-edit-locales-issue--milo--saurabhsircar11&ref=main&repo=cc&owner=adobecom&host=www.adobe.com&project=Creative+Cloud&env=local&workflow=normal
