### PR TITLE
MWPW-168315 Auto set close captions for videos

### DIFF
--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -95,7 +95,7 @@ export default function init(a) {
   } else {
     const url = new URL(a.href);
     const { atvCaptionsKey, locale } = getConfig();
-    const geo = (locale?.prefix || '').replace('/', '');
+    const geo = (locale?.prefix || '').replace('/langstore', '').replace('/', '');
     const federalCR = atvCaptionsKey && getFederatedContentRoot();
 
     if (geo && federalCR && url.searchParams.has('captions')) {

--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -98,7 +98,7 @@ export default function init(a) {
     const geo = (locale?.prefix || '').replace('/', '');
     const federalCR = atvCaptionsKey && getFederatedContentRoot();
 
-    if (federalCR && url.searchParams.has('captions')) {
+    if (geo && federalCR && url.searchParams.has('captions')) {
       if (!captionsLangMapPromise) {
         const captionsUrl = `${federalCR}/federal/assets/data/adobetv-captions.json?sheet=${atvCaptionsKey}`;
         captionsLangMapPromise = fetch(captionsUrl).then((res) => {

--- a/libs/blocks/adobetv/adobetv.js
+++ b/libs/blocks/adobetv/adobetv.js
@@ -1,5 +1,86 @@
 import { decorateAnchorVideo } from '../../utils/decorate.js';
-import { createTag } from '../../utils/utils.js';
+import { createTag, getConfig, getFederatedContentRoot } from '../../utils/utils.js';
+
+let captionsLangMapPromise = null;
+
+const logError = (msg, error) => window.lana.log(`${msg}: ${error}`);
+
+const updateCaptionsLang = (url, geo, captionsLangMap) => {
+  if (geo && captionsLangMap) {
+    const entry = captionsLangMap.find((l) => l?.geos?.split(',')?.includes(geo));
+    if (entry) {
+      const captionParam = entry.captions === 'eng' ? entry.captions : `${entry.captions},eng`;
+      url.searchParams.set('captions', captionParam);
+    }
+  }
+  return url.toString();
+};
+
+const createIframe = (a, href) => {
+  const videoHref = href || a.href;
+
+  const iframe = createTag('iframe', {
+    src: videoHref,
+    class: 'adobetv',
+    scrolling: 'no',
+    allow: 'encrypted-media; fullscreen',
+    title: 'Adobe Video Publishing Cloud Player',
+    loading: 'lazy',
+  });
+  const embed = createTag('div', { class: 'milo-video' }, iframe);
+  a.insertAdjacentElement('afterend', embed);
+
+  const idMatch = videoHref.match(/\/v\/(\d+)/);
+  const videoId = idMatch ? idMatch[1] : null;
+
+  if (videoId) {
+    window.fetch(`https://video.tv.adobe.com/v/${videoId}?format=json-ld`)
+      .then((res) => res.json())
+      .then(async (info) => {
+        const { setDialogAndElementAttributes } = await import('../../scripts/accessibility.js');
+        setDialogAndElementAttributes({ element: iframe, title: `${info?.jsonLinkedData?.name}` });
+      });
+  }
+
+  window.addEventListener('message', (event) => {
+    if (event.origin !== 'https://video.tv.adobe.com' || !event.data) return;
+    const { state, id } = event.data;
+    if (!['play', 'pause'].includes(state)
+      || !Number.isInteger(id)
+      || !iframe.src.startsWith(`${event.origin}/v/${id}`)) return;
+
+    iframe.setAttribute('data-playing', state === 'play');
+  });
+
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach(({ isIntersecting, target }) => {
+      if (!isIntersecting && target.getAttribute('data-playing') === 'true') {
+        target.contentWindow?.postMessage({ type: 'mpcAction', action: 'pause' }, target.src);
+      }
+    });
+  }, { rootMargin: '0px' });
+  io.observe(iframe);
+
+  a.remove();
+};
+
+const createIframeWithCaptions = (a, url, geo) => {
+  if (!captionsLangMapPromise) {
+    createIframe(a);
+  } else {
+    captionsLangMapPromise?.then((resp) => {
+      if (resp?.data) {
+        const videoHref = updateCaptionsLang(url, geo, resp.data);
+        createIframe(a, videoHref);
+      } else {
+        createIframe(a);
+      }
+    }).catch((e) => {
+      logError('Could not get atv captions', e);
+      createIframe(a);
+    });
+  }
+};
 
 export default function init(a) {
   a.classList.add('hide-video');
@@ -12,48 +93,24 @@ export default function init(a) {
       anchorTag: a,
     });
   } else {
-    const iframe = createTag('iframe', {
-      src: a.href,
-      class: 'adobetv',
-      scrolling: 'no',
-      allow: 'encrypted-media; fullscreen',
-      title: 'Adobe Video Publishing Cloud Player',
-      loading: 'lazy',
-    });
-    const embed = createTag('div', { class: 'milo-video' }, iframe);
-    a.insertAdjacentElement('afterend', embed);
+    const url = new URL(a.href);
+    const { atvCaptionsKey, locale } = getConfig();
+    const geo = (locale?.prefix || '').replace('/', '');
+    const federalCR = atvCaptionsKey && getFederatedContentRoot();
 
-    const idMatch = a.href.match(/\/v\/(\d+)/);
-    const videoId = idMatch ? idMatch[1] : null;
-
-    if (videoId) {
-      window.fetch(`https://video.tv.adobe.com/v/${videoId}?format=json-ld`)
-        .then((res) => res.json())
-        .then(async (info) => {
-          const { setDialogAndElementAttributes } = await import('../../scripts/accessibility.js');
-          setDialogAndElementAttributes({ element: iframe, title: `${info?.jsonLinkedData?.name}` });
+    if (federalCR && url.searchParams.has('captions')) {
+      if (!captionsLangMapPromise) {
+        const captionsUrl = `${federalCR}/federal/assets/data/adobetv-captions.json?sheet=${atvCaptionsKey}`;
+        captionsLangMapPromise = fetch(captionsUrl).then((res) => {
+          if (!res.ok) {
+            return new Promise(() => { throw new Error(`Failed to fetch ${captionsUrl}`); });
+          }
+          return res.json();
         });
+      }
+      createIframeWithCaptions(a, url, geo);
+    } else {
+      createIframe(a);
     }
-
-    window.addEventListener('message', (event) => {
-      if (event.origin !== 'https://video.tv.adobe.com' || !event.data) return;
-      const { state, id } = event.data;
-      if (!['play', 'pause'].includes(state)
-        || !Number.isInteger(id)
-        || !iframe.src.startsWith(`${event.origin}/v/${id}`)) return;
-
-      iframe.setAttribute('data-playing', state === 'play');
-    });
-
-    const io = new IntersectionObserver((entries) => {
-      entries.forEach(({ isIntersecting, target }) => {
-        if (!isIntersecting && target.getAttribute('data-playing') === 'true') {
-          target.contentWindow?.postMessage({ type: 'mpcAction', action: 'pause' }, target.src);
-        }
-      });
-    }, { rootMargin: '0px' });
-    io.observe(iframe);
-
-    a.remove();
   }
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -309,7 +309,6 @@ export const [setConfig, updateConfig, getConfig] = (() => {
         && (conf.useDotHtml ?? PAGE_URL.pathname.endsWith('.html'));
       config.entitlements = handleEntitlements;
       config.consumerEntitlements = conf.entitlements || [];
-      config.atvCaptionsKey = conf.atvCaptionsKey;
       setupMiloObj(config);
       return config;
     },

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -309,6 +309,7 @@ export const [setConfig, updateConfig, getConfig] = (() => {
         && (conf.useDotHtml ?? PAGE_URL.pathname.endsWith('.html'));
       config.entitlements = handleEntitlements;
       config.consumerEntitlements = conf.entitlements || [];
+      config.atvCaptionsKey = conf.atvCaptionsKey;
       setupMiloObj(config);
       return config;
     },

--- a/test/blocks/adobetv/adobetv.test.js
+++ b/test/blocks/adobetv/adobetv.test.js
@@ -1,13 +1,37 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
+import { stub } from 'sinon';
 import { waitForElement } from '../../helpers/waitfor.js';
-import { setConfig } from '../../../libs/utils/utils.js';
+import { getConfig, updateConfig, setConfig } from '../../../libs/utils/utils.js';
 
-document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+const documentHTML = await readFile({ path: './mocks/body.html' });
 setConfig({});
 const { default: init } = await import('../../../libs/blocks/adobetv/adobetv.js');
 
 describe('adobetv autoblock', () => {
+  let ogFetch;
+
+  beforeEach(() => {
+    document.body.innerHTML = documentHTML;
+    ogFetch = window.fetch;
+    window.fetch = stub().returns(
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [
+            { captions: 'fre_fr', geos: 'be_fr,ch_fr,fr,lu_fr,ca_fr' },
+            { captions: 'ger', geos: 'at,ch_de,lu_de,de' },
+          ],
+        }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    window.fetch = ogFetch;
+    updateConfig({ captionsKey: undefined, locale: { prefix: 'en' } });
+  });
+
   it('creates video block', async () => {
     const wrapper = document.body.querySelector('.adobe-tv');
     const a = wrapper.querySelector(':scope > a');
@@ -26,5 +50,41 @@ describe('adobetv autoblock', () => {
     const video = await waitForElement('#adobetvAsBg video');
     expect(wrapper.querySelector(':scope a[href*=".mp4"]')).to.be.null;
     expect(video).to.be.exist;
+  });
+
+  it('creates video with captions localized', async () => {
+    const wrapper = document.body.querySelector('.adobe-tv-captions');
+    const a = wrapper.querySelector(':scope > a');
+    const config = getConfig();
+    updateConfig({ ...config, captionsKey: 'test', locale: { prefix: 'de' } });
+    await init(a);
+    const iframe = await waitForElement('.adobe-tv-captions iframe');
+    expect(wrapper.querySelector(':scope > a')).to.be.null;
+    expect(iframe).to.be.exist;
+    expect(iframe.src).to.equal('https://video.tv.adobe.com/v/3410934t1?captions=ger%2Ceng');
+  });
+
+  it('creates video with captions localized but no captions key', async () => {
+    const wrapper = document.body.querySelector('.adobe-tv-captions');
+    const a = wrapper.querySelector(':scope > a');
+    const config = getConfig();
+    updateConfig({ ...config, locale: { prefix: 'de' } });
+    await init(a);
+    const iframe = await waitForElement('.adobe-tv-captions iframe');
+    expect(wrapper.querySelector(':scope > a')).to.be.null;
+    expect(iframe).to.be.exist;
+    expect(iframe.src).to.equal('https://video.tv.adobe.com/v/3410934t1?captions=eng');
+  });
+
+  it('creates video with captions localized but no mapping', async () => {
+    const wrapper = document.body.querySelector('.adobe-tv-captions');
+    const a = wrapper.querySelector(':scope > a');
+    const config = getConfig();
+    updateConfig({ ...config, locale: { prefix: 'in' } });
+    await init(a);
+    const iframe = await waitForElement('.adobe-tv-captions iframe');
+    expect(wrapper.querySelector(':scope > a')).to.be.null;
+    expect(iframe).to.be.exist;
+    expect(iframe.src).to.equal('https://video.tv.adobe.com/v/3410934t1?captions=eng');
   });
 });

--- a/test/blocks/adobetv/adobetv.test.js
+++ b/test/blocks/adobetv/adobetv.test.js
@@ -56,7 +56,7 @@ describe('adobetv autoblock', () => {
     const wrapper = document.body.querySelector('.adobe-tv-captions');
     const a = wrapper.querySelector(':scope > a');
     const config = getConfig();
-    updateConfig({ ...config, captionsKey: 'test', locale: { prefix: 'de' } });
+    updateConfig({ ...config, atvCaptionsKey: 'test', locale: { prefix: 'de' } });
     await init(a);
     const iframe = await waitForElement('.adobe-tv-captions iframe');
     expect(wrapper.querySelector(':scope > a')).to.be.null;

--- a/test/blocks/adobetv/mocks/body.html
+++ b/test/blocks/adobetv/mocks/body.html
@@ -18,4 +18,9 @@
       </div>
     </div>
   </div>
+  <div class="adobe-tv-captions">
+    <a href="https://video.tv.adobe.com/v/3410934t1?captions=eng">
+      https//video.tv.adobe.com/v/3410934t1?captions=eng
+    </a>
+  </div>
 </main>


### PR DESCRIPTION
Adding support for rewriting the AdobeTV iframe URL to update captions (if available) based on the tenant locale mapping.

Below changes
1. Added a tenant mapping JSON in Federal at /federal/assets/data/adobetv-captions.json. This contains sheets per key to support tenant-specific mappings.
2. Added a config field atvCaptionsKey – this needs to be set by tenants.
3. In the AdobeTV block a. Rendering of the iframe is moved to a separate function. b. Load the captions mapping when captions exist in the URL and atvCaptionsKey is defined. c. Rewrite the captions based on the geo and mapping. Add an eng fallback to the mapping — i.e., if the derived caption is ger, add both ger,eng.

Resolves: [MWPW-168315](https://jira.corp.adobe.com/browse/MWPW-168315)


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/de/drafts/deeksha/locflow77?martech=off
- After: https://mwpw-168315-2--milo--raga-adbe-gh.aem.page/de/drafts/deeksha/locflow77?martech=off




