### PR TITLE
Fix(MWPW-176932): Notification rounded-corner fix

### DIFF
--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -105,7 +105,8 @@
   overflow: unset;
 }
 
-.notification.pill .background {
+.notification.pill .background,
+.notification.pill > :first-child {
   border-radius: inherit;
 }
 


### PR DESCRIPTION
* Border radius is inherited for all first child of notification pill variant.

Resolves: [MWPW-176932](https://jira.corp.adobe.com/browse/MWPW-176932)

**Test URLs:**
- Before: https://main--milosh--sharath-kannan.aem.page/docs/library/kitchen-sink/notification#notification-show-3-variations?martech=off
- After: https://mwpw-176932--milosh--sharath-kannan.aem.page/docs/library/kitchen-sink/notification#notification-show-3-variations?martech=off
