### PR TITLE
Rendering gnav promo behind unav components

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -536,6 +536,10 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
   padding: 24px 32px;
 }
 
+.unav-no-scroll {
+  touch-action: none;
+}
+
 @media (max-width: 900px) {
   .feds-product-entry-cta {
     display: none;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -969,6 +969,21 @@ class Gnav {
     // Exposing UNAV config for consumers
     CONFIG.universalNav.universalNavConfig = getConfiguration();
     await window.UniversalNav(CONFIG.universalNav.universalNavConfig);
+    const fedsPromo = document.querySelector('.feds-promo-aside-wrapper');
+    const updatePromoZIndex = () => {
+      const isOpen = document.body.classList.contains('unav-no-scroll');
+      fedsPromo.style.zIndex = isOpen ? 0 : 11;
+    };
+    // Ensure promo appears behind unav if unav is active
+    if (fedsPromo && !isDesktop.matches) {
+      new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+            updatePromoZIndex();
+          }
+        });
+      }).observe(document.body, { attributes: true, attributeFilter: ['class'] });
+    }
     // In case we get it wrong
     if (!signedOut) this.blocks.universalNav?.style.removeProperty('min-width');
     performance.mark('Unav-End');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Changing the z index of promo when unav element is active so that it renders behind it

Resolves: [MWPW-177034](https://jira.corp.adobe.com/browse/MWPW-177034)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://promo-unav--milo--adobecom.aem.page/?martech=off

QA: https://main--cc--adobecom.aem.live/fr/creativecloud?martech=off&milolibs=promo-unav
