### PR TITLE
Mwpw 177477 share status

### DIFF
--- a/libs/blocks/share/share.css
+++ b/libs/blocks/share/share.css
@@ -188,7 +188,7 @@ main > .section.center .share.inline ul.icon-container {
 }
 
 @media screen and (min-width: 600px) {
-  .share .copy-to-clipboard::before ,
+  .share .copy-to-clipboard::before,
   [dir="rtl"] .share .copy-to-clipboard::before {
     left: 50%;
   }

--- a/libs/blocks/share/share.css
+++ b/libs/blocks/share/share.css
@@ -188,7 +188,8 @@ main > .section.center .share.inline ul.icon-container {
 }
 
 @media screen and (min-width: 600px) {
-  .share .copy-to-clipboard::before {
+  .share .copy-to-clipboard::before ,
+  [dir="rtl"] .share .copy-to-clipboard::before {
     left: 50%;
   }
 }

--- a/libs/blocks/share/share.js
+++ b/libs/blocks/share/share.js
@@ -182,7 +182,8 @@ export default async function decorate(block) {
         class: 'aria-live-container',
       },
     );
-    container.append(li, copyAriaLive);
+    container.append(li);
+    block.append(copyAriaLive);
     let changeText = false;
     copyButton.addEventListener('click', (e) => {
       /* c8 ignore next 6 */

--- a/libs/blocks/share/share.js
+++ b/libs/blocks/share/share.js
@@ -173,7 +173,6 @@ export default async function decorate(block) {
       clipboardSvg.svg,
     );
     const li = createTag('li');
-    li.append(copyButton);
     const copyAriaLive = createTag(
       'div',
       {
@@ -182,8 +181,8 @@ export default async function decorate(block) {
         class: 'aria-live-container',
       },
     );
+    li.append(copyButton, copyAriaLive);
     container.append(li);
-    block.append(copyAriaLive);
     let changeText = false;
     copyButton.addEventListener('click', (e) => {
       /* c8 ignore next 6 */


### PR DESCRIPTION
Issues: #4626 adds `aria-live` to share block but according to axeDevTools `aria-live` can't be direct child of the `ul`. On RTL copy tooltip container is not centered. 

* Move `aria-live` to `li`
* RTL: center container on tablet/desktop

Resolves: [MWPW-177324](https://jira.corp.adobe.com/browse/MWPW-177324), [MWPW-177477](https://jira.corp.adobe.com/browse/MWPW-177477)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/share?martech=off
- After: https://mwpw-177477-share-status--milo--adobecom.aem.page/docs/library/kitchen-sink/share?martech=off

**RTL URLs:**
- Before: https://main--cc--adobecom.aem.page/ae_ar/ai/overview/features/video-translator
- After: https://main--cc--adobecom.aem.page/ae_ar/ai/overview/features/video-translator?milolibs=mwpw-177477-share-status
