### PR TITLE
[MWPW-172068] More specific link bolding for Media

### DIFF
--- a/libs/blocks/media/media.css
+++ b/libs/blocks/media/media.css
@@ -66,8 +66,7 @@
     width: 100%;
 }
 
-.media .text .action-area a:not(.con-button),
-.media .text > :nth-last-child(-n+1 of p[class^="body-"]) a:not(.con-button) {
+.media .text [class*="action-area"] a:not(.con-button) {
   font-weight: 700;
 }
 

--- a/libs/blocks/media/media.js
+++ b/libs/blocks/media/media.js
@@ -77,6 +77,10 @@ export default async function init(el) {
       text.classList.add('text');
       decorateAvatar(text);
       decorateBlockText(text, blockTypeSizes[size], blockType);
+      const plainActionArea = text.querySelector('[class*="body-"]:has(a:not(.con-button)):last-child:not(.action-area)');
+      const hasTextNode = plainActionArea
+        && [...plainActionArea.childNodes].some((n) => n.nodeType === Node.TEXT_NODE && n.textContent.trim() !== '');
+      if (!hasTextNode) plainActionArea?.classList.add('action-area-plain');
     }
     const image = row.querySelector(':scope > div:not([class])');
     image?.classList.add('image');


### PR DESCRIPTION
As part of a previous implementation from https://jira.corp.adobe.com/browse/MWPW-162043 (https://github.com/adobecom/milo/pull/3517), the last regular link from a Media block was bolded. Some newly surfaced use-cases proved this to be insuficient, thus requiring a more granular approach. The non-CTA link not adjacent to text from the last paragraph of a text wrapper element of the Media block which is not already an `action-area` will now be programatically marked as such in order to apply the correct styling.

Resolves: [MWPW-172068](https://jira.corp.adobe.com/browse/MWPW-172068)

**Test URLs:**
- Before (original use-case, no change): https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/media-heading-style?martech=off
- After (original use-case, no change): https://media-bolded-link--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/media-heading-style?martech=off
- Before (newly flagged issue, wrongly bolded in first block): https://main--milo--overmyheadandbody.aem.page/drafts/klee/jira-ticket/mwpw-172068-media-body-links?martech=off
- After (newly flagged issue, wrongly bolded in first block): https://media-bolded-link--milo--overmyheadandbody.aem.page/drafts/klee/jira-ticket/mwpw-172068-media-body-links?martech=off
- Before (Kitchen Sink, no change): https://main--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/media?martech=off
- After (Kitchen Sink, no change): https://media-bolded-link--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/media?martech=off












