### PR TITLE
MWPW-177660: More lenient regex to support - and not

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -657,7 +657,7 @@ export const getGrayboxExperienceId = (
   pathname = window.location?.pathname || '',
 ) => {
   // Only allow trusted Adobe graybox domains
-  const isAdobeGraybox = /^[^.]+\.([a-z]+-)?graybox\.adobe\.com$/.test(hostname);
+  const isAdobeGraybox = /^[^.]+\.([a-z-]+-)?graybox\.adobe\.com$/.test(hostname);
   const isStageGraybox = (
     (hostname.endsWith('.aem.page') || hostname.endsWith('.aem.live'))
     && hostname.includes('graybox')
@@ -666,7 +666,7 @@ export const getGrayboxExperienceId = (
   // Check for graybox.adobe.com format: https://[exn].[pn]-graybox.adobe.com/[path].html
   if (isAdobeGraybox) {
     const parts = hostname.split('.');
-    if (parts.length >= 3 && parts[1].includes('-graybox')) {
+    if (parts.length >= 3 && parts[1].includes('graybox')) {
       return parts[0]; // Return the experience ID (first part)
     }
   }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Update graybox domain regex to support subdomain patterns
* Change regex from ([a-z]+-) to ([a-z-]+-) to allow hyphens in subdomain
* Now supports patterns like homepage-graybox.adobe.com while maintaining security

Resolves: [MWPW-177660](https://jira.corp.adobe.com/browse/MWPW-177660)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-177660--milo--adobecom.aem.page/?martech=off




