### PR TITLE
fix(merch): extract button styling classes from URL hash parameters

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1134,6 +1134,16 @@ export async function buildCta(el, params) {
     cta.classList.toggle('button-l', large);
     cta.classList.toggle('blue', strong);
   }
+
+  /*
+   * MWPW-170462: Extract button styling classes from URL hash parameters
+   * This handles #_button-fill and similar decorators to customize CTA appearance
+   */
+  const customClasses = el.href.matchAll(/#_button-([a-zA-Z-]+)/g);
+  for (const match of customClasses) {
+    cta.classList.add(match[1]);
+  }
+
   if (context.entitlement !== 'false') {
     cta.classList.add(LOADING_ENTITLEMENTS);
     cta.onceSettled().finally(() => {

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1135,10 +1135,6 @@ export async function buildCta(el, params) {
     cta.classList.toggle('blue', strong);
   }
 
-  /*
-   * MWPW-170462: Extract button styling classes from URL hash parameters
-   * This handles #_button-fill and similar decorators to customize CTA appearance
-   */
   const customClasses = el.href.matchAll(/#_button-([a-zA-Z-]+)/g);
   for (const match of customClasses) {
     cta.classList.add(match[1]);

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -481,6 +481,43 @@ describe('Merch Block', () => {
       const { classList } = await el.onceSettled();
       expect(classList.contains('button-l')).to.be.true;
     });
+
+    it('extracts and applies a custom button fill class from URL hash', async () => {
+      const el = await merch(document.querySelector(
+        '.merch.cta.fill',
+      ));
+      const { classList } = await el.onceSettled();
+      expect(classList.contains('fill')).to.be.true;
+      expect(classList.contains('con-button')).to.be.true;
+    });
+
+    it('handles hyphenated custom button classes correctly', async () => {
+      const el = await merch(document.querySelector(
+        '.merch.cta.custom-hyphenated',
+      ));
+      const { classList } = await el.onceSettled();
+      expect(classList.contains('my-custom-style')).to.be.true;
+      expect(classList.contains('con-button')).to.be.true;
+    });
+
+    it('ignores invalid custom button class format', async () => {
+      const el = await merch(document.querySelector(
+        '.merch.cta.custom-invalid',
+      ));
+      const { classList } = await el.onceSettled();
+      expect(classList.contains('123invalid')).to.be.false;
+      expect(classList.contains('con-button')).to.be.true;
+    });
+
+    it('does not apply unexpected custom classes when no custom hash parameter exist', async () => {
+      const el = await merch(document.querySelector(
+        '.merch.cta.primary',
+      ));
+      const { classList } = await el.onceSettled();
+      expect(classList.contains('fill')).to.be.false;
+
+      expect(classList.contains('con-button')).to.be.true;
+    });
   });
 
   describe('function "getCheckoutContext"', () => {
@@ -496,6 +533,34 @@ describe('Merch Block', () => {
       const el = document.createElement('a');
       const params = new URLSearchParams();
       expect(await buildCta(el, params)).to.be.null;
+    });
+
+    it('returns cta node with the correct custom class name', async () => {
+      const el = document.createElement('a');
+      el.setAttribute('href', '/tools/ost?osi=29&type=checkoutUrl#_button-fill');
+      const params = new URLSearchParams({ osi: '123' });
+      const result = await buildCta(el, params);
+      expect(result).to.not.be.null;
+      expect(result.classList.contains('fill')).to.be.true;
+    });
+
+    it('returns cta node ignoring invalid hash format', async () => {
+      const el = document.createElement('a');
+      el.setAttribute('href', '/tools/ost?osi=29&type=checkoutUrl#_button-123fill');
+      const params = new URLSearchParams({ osi: '123' });
+      const result = await buildCta(el, params);
+      expect(result).to.not.be.null;
+      expect(result.classList.contains('123fill')).not.to.be.true;
+    });
+
+    it('returns cta node without unexpected custom class', async () => {
+      const el = document.createElement('a');
+      el.setAttribute('href', '/tools/ost?osi=29&type=checkoutUrl');
+      const params = new URLSearchParams({ osi: '123' });
+      const result = await buildCta(el, params);
+      expect(result).to.not.be.null;
+      expect(result.classList.contains('fill')).not.to.be.true;
+      expect(result.classList.contains('con-button')).to.be.true;
     });
   });
 

--- a/test/blocks/merch/mocks/body.html
+++ b/test/blocks/merch/mocks/body.html
@@ -162,6 +162,26 @@
   href="/tools/ost?osi=28&type=checkoutUrl">CTA Buy Now</a>
 </p>
 
+<p>
+  CTA with single custom button class: <a class="merch cta fill"
+  href="/tools/ost?osi=29&type=checkoutUrl#_button-fill">CTA Buy Now</a>
+</p>
+
+<p>
+  CTA with hyphenated custom class: <a class="merch cta custom-hyphenated"
+  href="/tools/ost?osi=33&type=checkoutUrl#_button-my-custom-style">CTA Buy Now</a>
+</p>
+
+<p>
+  CTA with invalid custom class format: <a class="merch cta custom-invalid"
+  href="/tools/ost?osi=32&type=checkoutUrl#_button-123invalid">CTA Buy Now</a>
+</p>
+
+<p>
+  CTA with invalid custom class format: <a class="merch cta primary"
+  href="/tools/ost?osi=32&type=checkoutUrl">CTA Buy Now</a>
+</p>
+
 <div class="cards">
   <merch-card class="card-one">
     <h3>Product one</h3>


### PR DESCRIPTION
This change fixes an issue where the #_button-fill link decorator was not being applied to “merch” CTAs in a hero marquee block in Milo. Previously, only the default blue button style was available for merch links, because the merch link handler did not recognize or strip the #_button-fill fragment.

Here's the slack thread for additional context:
🧵: [https://adobedotcom.slack.com/archives/C03B0BUA75E/p1742958293820199](https://adobedotcom.slack.com/archives/C03B0BUA75E/p1742958293820199)

📸: <img width="1915" height="680" alt="image" src="https://github.com/user-attachments/assets/fd6d0ab2-a691-443a-a745-19a5199c8e9d" />

🔗: https://main--cc--adobecom.aem.page/drafts/aullal/backup/mwpw-170462?milolibs=mwpw-170462-merch-cta-style-fix--milo--ajullal

Resolves: [MWPW-170462](https://jira.corp.adobe.com/browse/MWPW-170462)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/aullal/
- After: https://mwpw-170462-merch-cta-style-fix--milo--ajullal.aem.page/drafts/aullal/






































