### PR TITLE
MWPW-177535: Fixed font fallback for ABM & addon labels

### DIFF
--- a/libs/deps/mas/merch-card-collection.js
+++ b/libs/deps/mas/merch-card-collection.js
@@ -931,7 +931,6 @@ merch-card-collection.plans merch-card[variant="plans"] aem-fragment + [slot^="h
 merch-card[variant^='plans'] span[data-template="legal"] {
     display: block;
     color: var(----merch-color-grey-80);
-    font-family: var(--Font-adobe-clean, "Adobe Clean");
     font-size: 14px;
     font-style: italic;
     font-weight: 400;

--- a/libs/deps/mas/merch-card.js
+++ b/libs/deps/mas/merch-card.js
@@ -348,7 +348,6 @@ var qr=Object.defineProperty;var Oe=o=>{throw TypeError(o)};var jr=(o,e,t)=>e in
             color: var(--merch-addon-label-color);
             font-size: var(--merch-addon-label-size);
             line-height: var(--merch-addon-label-line-height);
-            font-family: "Adobe Clean";
             font-style: normal;
             font-weight: 400;
             cursor: pointer;
@@ -1302,7 +1301,6 @@ merch-card-collection.plans merch-card[variant="plans"] aem-fragment + [slot^="h
 merch-card[variant^='plans'] span[data-template="legal"] {
     display: block;
     color: var(----merch-color-grey-80);
-    font-family: var(--Font-adobe-clean, "Adobe Clean");
     font-size: 14px;
     font-style: italic;
     font-weight: 400;

--- a/libs/features/mas/dist/mas.js
+++ b/libs/features/mas/dist/mas.js
@@ -358,7 +358,6 @@ Try polyfilling it using "@formatjs/intl-pluralrules"
             color: var(--merch-addon-label-color);
             font-size: var(--merch-addon-label-size);
             line-height: var(--merch-addon-label-line-height);
-            font-family: "Adobe Clean";
             font-style: normal;
             font-weight: 400;
             cursor: pointer;
@@ -1312,7 +1311,6 @@ merch-card-collection.plans merch-card[variant="plans"] aem-fragment + [slot^="h
 merch-card[variant^='plans'] span[data-template="legal"] {
     display: block;
     color: var(----merch-color-grey-80);
-    font-family: var(--Font-adobe-clean, "Adobe Clean");
     font-size: 14px;
     font-style: italic;
     font-weight: 400;

--- a/libs/features/mas/src/merch-addon.js
+++ b/libs/features/mas/src/merch-addon.js
@@ -142,7 +142,6 @@ export default class MerchAddon extends LitElement {
             color: var(--merch-addon-label-color);
             font-size: var(--merch-addon-label-size);
             line-height: var(--merch-addon-label-line-height);
-            font-family: "Adobe Clean";
             font-style: normal;
             font-weight: 400;
             cursor: pointer;

--- a/libs/features/mas/src/variants/plans.css.js
+++ b/libs/features/mas/src/variants/plans.css.js
@@ -87,7 +87,6 @@ merch-card-collection.plans merch-card[variant="plans"] aem-fragment + [slot^="h
 merch-card[variant^='plans'] span[data-template="legal"] {
     display: block;
     color: var(----merch-color-grey-80);
-    font-family: var(--Font-adobe-clean, "Adobe Clean");
     font-size: 14px;
     font-style: italic;
     font-weight: 400;


### PR DESCRIPTION
Resolves: [MWPW-177535](https://jira.corp.adobe.com/browse/MWPW-177535)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/nala/features/commerce/plans2?martech=off
- After: https://mwpw-177535--milo--adobecom.aem.page/drafts/nala/features/commerce/plans2?martech=off
