### PR TITLE
MWPW-171611 - Block notifications

### DIFF
--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -24,6 +24,18 @@ export const loadJarvisChat = async (getConfig, getMetadata, loadScript, loadSty
   initJarvisChat(config, loadScript, loadStyle, getMetadata);
 };
 
+export const loadBlockNotifications = async (getConfig, loadStyle) => {
+  const { env, miloLibs, codeRoot } = getConfig();
+
+  if (env.name === 'local' || window.location.host.includes('.page')) {
+    const base = miloLibs || codeRoot;
+    loadStyle(`${base}/styles/block-notifications.css`);
+
+    const { default: blockNotifications } = await import('../utils/block-notifications.js');
+    blockNotifications(base);
+  }
+};
+
 export const loadPrivacy = async (getConfig, loadScript) => {
   const { privacyId, env } = getConfig();
   const acom = '7a5eb705-95ed-4cc4-a11d-0cc5760e93db';
@@ -105,6 +117,7 @@ const loadDelayed = ([
     loadAriaAutomation();
     loadJarvisChat(getConfig, getMetadata, loadScript, loadStyle);
     loadGoogleLogin(getMetadata, loadIms, loadScript, getConfig);
+    loadBlockNotifications(getConfig, loadStyle);
     if (getMetadata('interlinks') === 'on') {
       const { locale } = getConfig();
       const path = `${locale.contentRoot}/keywords.json`;

--- a/libs/styles/block-notifications.css
+++ b/libs/styles/block-notifications.css
@@ -1,0 +1,112 @@
+.notification-controls-container {
+  position: fixed;
+  right: 50%;
+  bottom: 0%;
+  transform: translate(50%, -9px);
+  z-index: 2;
+}
+
+.notification-controls-container a {
+  cursor: pointer;
+  color: #ffffffd6;
+  font-weight: 600;
+  background: #222c;
+  backdrop-filter: blur(24px);
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 10px;
+  border-color: #393939;
+  border-style: solid;
+  border-width: 1px;
+  font-size: 14px;
+  width: 135px;
+  box-sizing: border-box;
+  text-align: center;
+  text-decoration: none;
+  z-index: 3;
+  transition: all 0.2s ease;
+}
+
+.notification-controls-container a:hover {
+  background: #fffc;
+  backdrop-filter: blur(24px);
+  color: #000;
+}
+
+[data-block-notification] .notification-label,
+.con-label {
+  padding: 5px 8px;
+  text-transform: capitalize;
+  color: var(--color-white);
+  font-size: 14px;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.2;
+}
+
+.con-label {
+  background-color: #594CCC;
+  border-radius: 5px;
+  margin: 5px;
+  position: relative;
+  z-index: 3;
+}
+
+.hide-labels .asset-meta,
+.hide-labels .con-label {
+  display: none;
+}
+
+.block-notifications .con-label,
+.block-notifications .asset-meta {
+  display: flex;
+}
+
+[data-block-notification] {
+  border: 4px solid hotpink;
+  box-sizing:border-box;
+  position: relative;
+}
+
+[data-block-notification]::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  background: hotpink;
+  opacity: .4;
+  z-index: 1;
+}
+
+[data-block-notification] .notification-label {
+  background: hotpink;
+  border-radius: 0 0 0 5px;
+  z-index: 3;
+  gap: 5px;
+  padding-top: 3px;
+}
+
+[data-block-notification] .notification-label a {
+  font-size: 16px;
+  color: #fff;
+  padding: 0;
+  margin: 1px 0 0;
+}
+
+[data-block-notification] .notification-label a:hover {
+  color: #000;
+}
+
+.block-label-container {
+  display: inline-flex;
+  flex-flow: row-reverse wrap;
+  max-width: 140px;
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+

--- a/libs/utils/block-notifications.js
+++ b/libs/utils/block-notifications.js
@@ -67,16 +67,15 @@ export default async function blockNotifications(base) {
 
   const blockQueries = blocksKeyToLowercase.data.reduce((acc, row) => {
     const notConsonant = row.consonant === 'false';
-    const decision = row.decision !== '' ? row.decision?.toLowerCase() === 'obsolete' || 'delist' || 'delisted' : undefined;
+    const decision = row.decision !== '' ? row.decision?.toLowerCase() : undefined;
     if (row.block && (notConsonant || decision)) {
       const variation = row.variant && row.variant.replaceAll(',', '.').replaceAll(' ', '-').toLowerCase();
       const blockName = row.block.toLowerCase();
-      const documentation = row.documentation !== '' ? row.documentation : undefined;
       const name = variation ? `${blockName} ${variation}` : `${blockName}`;
       const queryProps = { selector: variation ? `.${blockName}.${variation}` : `.${blockName}` };
-      if (decision) queryProps.decision = row.decision?.toLowerCase();
+      if (decision) queryProps.decision = decision;
       if (notConsonant) queryProps.notConsonant = 'Not Consonant';
-      if (documentation) queryProps.documentation = row.documentation;
+      if (row.documentation) queryProps.documentation = row.documentation;
       if (name) queryProps.name = name;
       acc.push(queryProps);
     }
@@ -112,6 +111,7 @@ export default async function blockNotifications(base) {
         foundBlock.dataset.blockNotification = 'true';
         notificationLabel.classList.add('notification-label');
         notificationLabel.textContent = query.decision;
+        notificationLabel.title = `${query.name} has been marked ${query.decision}`;
         if (query.documentation) {
           const notificationLink = document.createElement('a');
 

--- a/libs/utils/block-notifications.js
+++ b/libs/utils/block-notifications.js
@@ -1,0 +1,137 @@
+import getServiceConfig from './service-config.js';
+
+const INFO_ICON = `<svg id="info" viewBox="0 0 18 18" class="icon-milo icon-milo-info">
+    <path fill="currentcolor" d="M10.075,6A1.075,1.075,0,1,1,9,4.925H9A1.075,1.075,0,0,1,10.075,6Zm.09173,6H10V8.2A.20005.20005,0,0,0,9.8,8H7.83324S7.25,8.01612,7.25,8.5c0,.48365.58325.5.58325.5H8v3H7.83325s-.58325.01612-.58325.5c0,.48365.58325.5.58325.5h2.3335s.58325-.01635.58325-.5C10.75,12.01612,10.16673,12,10.16673,12ZM9,.5A8.5,8.5,0,1,0,17.5,9,8.5,8.5,0,0,0,9,.5ZM9,15.6748A6.67481,6.67481,0,1,1,15.67484,9,6.67481,6.67481,0,0,1,9,15.6748Z"></path>
+  </svg>`;
+const CONSONANT_SHEET_FALLBACK = 'consonant.json';
+
+async function getJson(url) {
+  try {
+    const resp = await fetch(url);
+    if (!resp.ok) {
+      throw new Error(`Response status: ${resp.status}`);
+    }
+    return await resp.json();
+  } catch (error) {
+    window.lana?.log(error.message);
+    return null;
+  }
+}
+
+function transformKeysToLowercase(obj) {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => transformKeysToLowercase(item));
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    return Object.keys(obj).reduce((acc, key) => {
+      const value = obj[key];
+      acc[key.toLowerCase()] = transformKeysToLowercase(value);
+      return acc;
+    }, {});
+  }
+  return obj;
+}
+
+function decorateNotificationControls(element) {
+  const notificationControlsContainer = document.createElement('div');
+  const toggle = document.createElement('a');
+  toggle.classList.add('toggle-notifications');
+  toggle.textContent = 'Hide notifications';
+  let isVisible = true;
+  notificationControlsContainer.appendChild(toggle);
+  notificationControlsContainer.classList.add('notification-controls-container');
+  element.appendChild(notificationControlsContainer);
+
+  toggle.addEventListener('click', () => {
+    if (isVisible === false) {
+      isVisible = true;
+      toggle.textContent = 'Hide notifications';
+    } else {
+      isVisible = false;
+      toggle.textContent = 'Show notifications';
+    }
+    element.classList.toggle('block-notifications');
+    element.classList.toggle('hide-labels');
+  });
+}
+
+export default async function blockNotifications(base) {
+  const { blocknotifications } = await getServiceConfig(window.location.origin);
+  const conSheet = blocknotifications?.url || CONSONANT_SHEET_FALLBACK;
+  const json = await getJson(`${base}/${conSheet}`);
+  if (!json) return;
+
+  const { blocks: rawBlocks } = json;
+  const blocksKeyToLowercase = transformKeysToLowercase(rawBlocks);
+
+  const blockQueries = blocksKeyToLowercase.data.reduce((acc, row) => {
+    const notConsonant = row.consonant === 'false';
+    const decision = row.decision !== '' ? row.decision?.toLowerCase() === 'obsolete' || 'delist' || 'delisted' : undefined;
+    if (row.block && (notConsonant || decision)) {
+      const variation = row.variant && row.variant.replaceAll(',', '.').replaceAll(' ', '-').toLowerCase();
+      const blockName = row.block.toLowerCase();
+      const documentation = row.documentation !== '' ? row.documentation : undefined;
+      const name = variation ? `${blockName} ${variation}` : `${blockName}`;
+      const queryProps = { selector: variation ? `.${blockName}.${variation}` : `.${blockName}` };
+      if (decision) queryProps.decision = row.decision?.toLowerCase();
+      if (notConsonant) queryProps.notConsonant = 'Not Consonant';
+      if (documentation) queryProps.documentation = row.documentation;
+      if (name) queryProps.name = name;
+      acc.push(queryProps);
+    }
+    return acc;
+  }, []);
+
+  blockQueries.forEach((query) => {
+    const blocks = document.querySelectorAll(query.selector);
+    if (blocks.length === 0) return;
+
+    const { body } = document;
+    body.classList.add('block-notifications');
+
+    decorateNotificationControls(body);
+
+    blocks.forEach((foundBlock) => {
+      const labelContainer = foundBlock.querySelector('.block-label-container');
+      const delistNotificationLabel = foundBlock.querySelector('.notification-label');
+      const conNotificationLabel = foundBlock.querySelector('.con-label');
+      let blockLabelContainer;
+
+      // Stop duplicate labels
+      // Add a label container to the block
+      if (!labelContainer) {
+        blockLabelContainer = document.createElement('div');
+        blockLabelContainer.classList.add('block-label-container');
+        foundBlock.appendChild(blockLabelContainer);
+      }
+      if (query.decision && !delistNotificationLabel) {
+        const notificationLabel = document.createElement('div');
+
+        foundBlock.dataset.decision = query.decision.toLowerCase();
+        foundBlock.dataset.blockNotification = 'true';
+        notificationLabel.classList.add('notification-label');
+        notificationLabel.textContent = query.decision;
+        if (query.documentation) {
+          const notificationLink = document.createElement('a');
+
+          notificationLink.href = query.documentation;
+          notificationLink.target = '_blank';
+          notificationLink.title = `view ${query.name} ${notificationLabel.textContent} documentation`;
+          notificationLink.innerHTML = INFO_ICON;
+          notificationLabel.appendChild(notificationLink);
+        }
+        blockLabelContainer.appendChild(notificationLabel);
+      }
+      if (query.notConsonant && !conNotificationLabel) {
+        const conLabel = document.createElement('div');
+
+        foundBlock.dataset.conStatus = query.notConsonant;
+        conLabel.classList.add('con-label');
+        conLabel.textContent = 'Not consonant';
+        conLabel.title = `${query.name} is not a consonant block`;
+        blockLabelContainer?.appendChild(conLabel);
+      }
+    });
+  });
+}


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Analyzes blocks on a page and compares with what's been entered in the referenced `.json` file. If matches are found blocks get labeled with:
* Obsolete - with optional link to related documentation via info icon.
* Not consonant


Additional details:
* Code is executed after page has loaded - via `delayed.js`. 
* Only ran on `.page` urls.
* Includes "Hide notifications" button to toggle showing/hiding labels. This also works with labels applied via Preflight (blocks marked as Obsolete do not get hidden).
* If there are not any blocks found on a page referenced from the .json nothing is applied and the toggle button is not added.

Resolves:
* [MWPW-171611](https://jira.corp.adobe.com/browse/MWPW-171611)
* [MWPW-170416](https://jira.corp.adobe.com/browse/MWPW-170416)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/rclayton/test-template?martech=off
- After: https://block-notifications--milo--adobecom.aem.page/drafts/rclayton/test-template?martech=off

**Test URLs CC:**
- Before: https://main--cc--adobecom.aem.page/drafts/rclayton/marquee-media?martech=off
- After: https://main--cc--adobecom.aem.page/drafts/rclayton/marquee-media?milolibs=block-notifications&martech=off

**Test URLs DA BACOM:**
- Before: https://main--da-bacom--adobecom.aem.page/drafts/klee/delist-notification-test?martech=off
- After: https://main--da-bacom--adobecom.aem.page/drafts/klee/delist-notification-test?milolibs=block-notifications&martech=off

<img width="1484" height="699" alt="image" src="https://github.com/user-attachments/assets/d56c330e-db13-4db4-bffe-f03b6d396fb7" />











