### PR TITLE
[MWPW-177991][NALA]Disable Marketo block ui tests till we fix the delay issues

### DIFF
--- a/nala/blocks/actionitem/actionitem.test.js
+++ b/nala/blocks/actionitem/actionitem.test.js
@@ -160,7 +160,8 @@ test.describe('Milo Action-Item block test suite', () => {
     });
     await test.step('step-3: Click the float button', async () => {
       await actionItem.floatButton.click();
-      expect(await page.url()).not.toBe(testPage);
+      await page.waitForLoadState('networkidle');
+      expect(page.url()).not.toBe(testPage);
     });
   });
 

--- a/nala/blocks/actionitem/actionitem.test.js
+++ b/nala/blocks/actionitem/actionitem.test.js
@@ -160,7 +160,8 @@ test.describe('Milo Action-Item block test suite', () => {
     });
     await test.step('step-3: Click the float button', async () => {
       await actionItem.floatButton.click();
-      await expect(page).not.toHaveURL(testPage, { timeout: 2000 });
+      await page.waitForLoadState('networkidle');
+      expect(page.url()).not.toBe(testPage);
     });
   });
 

--- a/nala/blocks/actionitem/actionitem.test.js
+++ b/nala/blocks/actionitem/actionitem.test.js
@@ -160,8 +160,7 @@ test.describe('Milo Action-Item block test suite', () => {
     });
     await test.step('step-3: Click the float button', async () => {
       await actionItem.floatButton.click();
-      await page.waitForLoadState('networkidle');
-      expect(page.url()).not.toBe(testPage);
+      await expect(page).not.toHaveURL(testPage, { timeout: 2000 });
     });
   });
 

--- a/nala/blocks/marketo/marketo.test.js
+++ b/nala/blocks/marketo/marketo.test.js
@@ -9,7 +9,7 @@ test.describe('Marketo block test suite', () => {
   test.beforeAll(async () => {
     console.log('Skipping Marketo block test suite in all environments');
     test.skip('Skipping in CI environment — TODO: debug why this is failing on GitHub Actions');
-    // if (process.env.CI) test.setTimeout(1000 * 60 * 3); // 3 minutes
+    // if (process.env.CI) test.setTimeout(1000 * 60 * 3);
   });
 
   test.beforeEach(async ({ page }) => {

--- a/nala/blocks/marketo/marketo.test.js
+++ b/nala/blocks/marketo/marketo.test.js
@@ -6,10 +6,10 @@ let marketoBlock;
 const miloLibs = process.env.MILO_LIBS || '';
 
 test.describe('Marketo block test suite', () => {
-  test.beforeAll(async ({ browserName }) => {
-    if (browserName === 'chromium' && process.env.CI) test.skip('TODO: debug why this is failing on github actions');
-
-    if (process.env.CI) test.setTimeout(1000 * 60 * 3); // 3 minutes
+  test.beforeAll(async () => {
+    console.log('Skipping Marketo block test suite in all environments');
+    test.skip('Skipping in CI environment — TODO: debug why this is failing on GitHub Actions');
+    // if (process.env.CI) test.setTimeout(1000 * 60 * 3); // 3 minutes
   });
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Currently `Marketo` block tests are f`reaky/failing in GitHub CI/CD` run due to `delays`.
* This PR will disable the execution of `Marketo Block` tests, till we fix the delay issue
* Features or fixes

Resolves: [MWPW-177991](https://jira.corp.adobe.com/browse/MWPW-177991)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://disable-marketo--milo--adobecom.aem.page/?martech=off










