### PR TITLE
[MWPW-175711] Optimize network calls for langauge selector on language based sites

### DIFF
--- a/libs/blocks/language-selector/language-selector.js
+++ b/libs/blocks/language-selector/language-selector.js
@@ -1,4 +1,4 @@
-import { createTag, getConfig, getLanguage, getFederatedContentRoot } from '../../utils/utils.js';
+import { createTag, getConfig, getLanguage, loadLanguageConfig } from '../../utils/utils.js';
 
 const queriedPages = [];
 const CHECKMARK_SVG = '<svg class="check-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13.3337 4L6.00033 11.3333L2.66699 8" stroke="#274DEA" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>';
@@ -19,17 +19,10 @@ document.addEventListener('mousedown', () => {
   miloLangIsKeyboard = false;
 });
 
-const langMapToEnglishPromise = ((async () => {
-  try {
-    const response = await fetch(`${getFederatedContentRoot()}/federal/assets/data/languages-mapping.json`);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const configJson = await response.json();
-    return configJson.data || [];
-  } catch (e) {
-    window.lana?.log('Failed to load language-mapping.json:', e);
-    return [];
-  }
-}))();
+const langMapToEnglishPromise = (async () => {
+  const { nativeToEnglishMapping } = await loadLanguageConfig();
+  return nativeToEnglishMapping || [];
+})();
 
 let langMapToEnglish = [];
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -502,7 +502,6 @@ function getPrefixBySite(locale, url, relative) {
   const site = langConfig?.siteLanguages?.find((s) => s.pathMatches.some((d) => isPathMatch(d, url.href)));
   const localeSiteWithLanguageTarget = !locale.language && site && langConfig?.localeToLanguageMap;
   const languageSiteWithLocaleTarget = locale.language && !relative && !site?.languages.some((l) => (l === DEFAULT_LANG ? '' : `/${l}`) === prefix);
-
   if (localeSiteWithLanguageTarget) {
     const mappedLanguageFromPrefix = langConfig?.localeToLanguageMap?.find((m) => `${m.locale === '' ? '' : '/'}${m.locale}` === prefix);
     const languageInUseBySite = site.languages.find((l) => `${l}` === mappedLanguageFromPrefix.languagePath);
@@ -522,7 +521,7 @@ function isLocalizedPath(path, locales) {
   const langstorePath = path.startsWith(`/${LANGSTORE}`);
   const isMerchLink = path === '/tools/ost';
   const previewPath = path.startsWith(`/${PREVIEW}`);
-  const anyTypeOfLocaleOrLanguagePath = langConfig
+  const anyTypeOfLocaleOrLanguagePath = langConfig?.localeToLanguageMap
     && (langConfig.localeToLanguageMap.some((l) => l.locale !== '' && (path.startsWith(`/${l.locale}/`) || path === `/${l.locale}`))
       || (langConfig.localeToLanguageMap.some((l) => path.startsWith(`/${l.languagePath}/`) || path === `/${l.languagePath}`)));
   const legacyLocalePath = locales && Object.keys(locales).some((loc) => loc !== '' && (path.startsWith(`/${loc}/`)

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -167,9 +167,7 @@ export const SLD = PAGE_URL.hostname.includes('.aem.') ? 'aem' : 'hlx';
 const PROMO_PARAM = 'promo';
 let isMartechLoaded = false;
 
-let localeToLanguageMap;
-let siteLanguages;
-let nativeToEnglishMapping;
+let langConfig;
 
 export function getEnv(conf) {
   const { host } = window.location;
@@ -384,8 +382,8 @@ export function hasLanguageLinks(area, paths = LANGUAGE_BASED_PATHS) {
 }
 
 export async function loadLanguageConfig() {
-  if (localeToLanguageMap && siteLanguages && nativeToEnglishMapping) {
-    return { siteLanguages, localeToLanguageMap, nativeToEnglishMapping };
+  if (langConfig) {
+    return langConfig;
   }
 
   const parseList = (str) => str.split(/[\n,]+/).map((t) => t.trim()).filter(Boolean);
@@ -394,15 +392,17 @@ export async function loadLanguageConfig() {
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const configJson = await response.json();
 
-    localeToLanguageMap = configJson['locale-to-language-map']?.data;
-    siteLanguages = configJson['site-languages']?.data?.map((site) => ({
-      ...site,
-      pathMatches: parseList(site.pathMatches),
-      languages: parseList(site.languages),
-    }));
-    nativeToEnglishMapping = configJson['langmap-native-to-en']?.data || [];
+    langConfig = {
+      localeToLanguageMap: configJson['locale-to-language-map']?.data,
+      siteLanguages: configJson['site-languages']?.data?.map((site) => ({
+        ...site,
+        pathMatches: parseList(site.pathMatches),
+        languages: parseList(site.languages),
+      })),
+      nativeToEnglishMapping: configJson['langmap-native-to-en']?.data || [],
+    };
 
-    return { siteLanguages, localeToLanguageMap, nativeToEnglishMapping };
+    return langConfig;
   } catch (e) {
     window.lana?.log('Failed to load language-config.json:', e);
   }
@@ -500,19 +500,19 @@ function getExtension(path) {
 
 function getPrefixBySite(locale, url, relative) {
   let { prefix } = locale;
-  const site = siteLanguages?.find((s) => s.pathMatches.some((d) => isPathMatch(d, url.href)));
-
-  const localeSiteWithLanguageTarget = !locale.language && site && localeToLanguageMap;
+  // eslint-disable-next-line max-len
+  const site = langConfig?.siteLanguages?.find((s) => s.pathMatches.some((d) => isPathMatch(d, url.href)));
+  const localeSiteWithLanguageTarget = !locale.language && site && langConfig?.localeToLanguageMap;
   const languageSiteWithLocaleTarget = locale.language && !relative && !site?.languages.some((l) => (l === DEFAULT_LANG ? '' : `/${l}`) === prefix);
   if (localeSiteWithLanguageTarget) {
-    const mappedLanguageFromPrefix = localeToLanguageMap?.find((m) => `${m.locale === '' ? '' : '/'}${m.locale}` === prefix);
+    const mappedLanguageFromPrefix = langConfig?.localeToLanguageMap?.find((m) => `${m.locale === '' ? '' : '/'}${m.locale}` === prefix);
     const languageInUseBySite = site.languages.find((l) => `${l}` === mappedLanguageFromPrefix.languagePath);
     if (languageInUseBySite) {
       prefix = languageInUseBySite === DEFAULT_LANG ? '' : `/${languageInUseBySite}`;
     }
   }
   if (languageSiteWithLocaleTarget) {
-    const mappedLocaleFromLanguage = localeToLanguageMap?.find((m) => `/${m.languagePath}` === prefix);
+    const mappedLocaleFromLanguage = langConfig?.localeToLanguageMap?.find((m) => `/${m.languagePath}` === prefix);
     prefix = mappedLocaleFromLanguage ? `${mappedLocaleFromLanguage.locale === '' ? '' : '/'}${mappedLocaleFromLanguage.locale}` : prefix;
   }
 
@@ -523,9 +523,9 @@ function isLocalizedPath(path, locales) {
   const langstorePath = path.startsWith(`/${LANGSTORE}`);
   const isMerchLink = path === '/tools/ost';
   const previewPath = path.startsWith(`/${PREVIEW}`);
-  const anyTypeOfLocaleOrLanguagePath = localeToLanguageMap
-    && (localeToLanguageMap.some((l) => l.locale !== '' && (path.startsWith(`/${l.locale}/`) || path === `/${l.locale}`))
-      || (localeToLanguageMap.some((l) => path.startsWith(`/${l.languagePath}/`) || path === `/${l.languagePath}`)));
+  const anyTypeOfLocaleOrLanguagePath = langConfig?.localeToLanguageMap
+    && (langConfig.localeToLanguageMap.some((l) => l.locale !== '' && (path.startsWith(`/${l.locale}/`) || path === `/${l.locale}`))
+      || (langConfig.localeToLanguageMap.some((l) => path.startsWith(`/${l.languagePath}/`) || path === `/${l.languagePath}`)));
   const legacyLocalePath = locales && Object.keys(locales).some((loc) => loc !== '' && (path.startsWith(`/${loc}/`)
     || path.endsWith(`/${loc}`)));
   return langstorePath
@@ -1745,7 +1745,7 @@ export async function loadArea(area = document) {
     appendSuffixToTitles();
   }
   const config = getConfig();
-  if (!localeToLanguageMap && !siteLanguages && (config.languages || hasLanguageLinks(area))) {
+  if (!langConfig && (config.languages || hasLanguageLinks(area))) {
     await loadLanguageConfig();
   }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -382,9 +382,7 @@ export function hasLanguageLinks(area, paths = LANGUAGE_BASED_PATHS) {
 }
 
 export async function loadLanguageConfig() {
-  if (langConfig) {
-    return langConfig;
-  }
+  if (langConfig) return langConfig;
 
   const parseList = (str) => str.split(/[\n,]+/).map((t) => t.trim()).filter(Boolean);
   try {
@@ -504,6 +502,7 @@ function getPrefixBySite(locale, url, relative) {
   const site = langConfig?.siteLanguages?.find((s) => s.pathMatches.some((d) => isPathMatch(d, url.href)));
   const localeSiteWithLanguageTarget = !locale.language && site && langConfig?.localeToLanguageMap;
   const languageSiteWithLocaleTarget = locale.language && !relative && !site?.languages.some((l) => (l === DEFAULT_LANG ? '' : `/${l}`) === prefix);
+
   if (localeSiteWithLanguageTarget) {
     const mappedLanguageFromPrefix = langConfig?.localeToLanguageMap?.find((m) => `${m.locale === '' ? '' : '/'}${m.locale}` === prefix);
     const languageInUseBySite = site.languages.find((l) => `${l}` === mappedLanguageFromPrefix.languagePath);
@@ -523,7 +522,7 @@ function isLocalizedPath(path, locales) {
   const langstorePath = path.startsWith(`/${LANGSTORE}`);
   const isMerchLink = path === '/tools/ost';
   const previewPath = path.startsWith(`/${PREVIEW}`);
-  const anyTypeOfLocaleOrLanguagePath = langConfig?.localeToLanguageMap
+  const anyTypeOfLocaleOrLanguagePath = langConfig
     && (langConfig.localeToLanguageMap.some((l) => l.locale !== '' && (path.startsWith(`/${l.locale}/`) || path === `/${l.locale}`))
       || (langConfig.localeToLanguageMap.some((l) => path.startsWith(`/${l.languagePath}/`) || path === `/${l.languagePath}`)));
   const legacyLocalePath = locales && Object.keys(locales).some((loc) => loc !== '' && (path.startsWith(`/${loc}/`)

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1476,11 +1476,28 @@ async function checkForPageMods() {
   });
 }
 
+function setCountry() {
+  const country = window.performance?.getEntriesByType('navigation')?.[0]?.serverTiming
+    ?.find((timing) => timing?.name === 'geo')?.description?.toLowerCase();
+  if (!country) return;
+  sessionStorage.setItem('akamai', country);
+  sessionStorage.setItem('feds_location', JSON.stringify({ country: country.toUpperCase() }));
+}
+
+async function setCountryPrerequisites() {
+  const country = (new URLSearchParams(window.location.search).get('akamaiLocale')?.toLowerCase())
+    || sessionStorage.getItem('akamai');
+  if (country !== 'gb' || window.adobePrivacy) return;
+  const { loadPrivacy } = await import('../scripts/delayed.js');
+  loadPrivacy(getConfig, loadScript);
+}
+
 async function loadPostLCP(config) {
   import('./favicon.js').then(({ default: loadFavIcon }) => loadFavIcon(createTag, getConfig(), getMetadata));
   await decoratePlaceholders(document.body.querySelector('header'), config);
   const sk = document.querySelector('aem-sidekick, helix-sidekick');
   if (sk) import('./sidekick-decorate.js').then((mod) => { mod.default(sk); });
+  setCountryPrerequisites();
   if (config.mep?.targetEnabled === 'postlcp') {
     /* c8 ignore next 2 */
     const { init } = await import('../features/personalization/personalization.js');
@@ -1515,7 +1532,7 @@ async function loadPostLCP(config) {
   }
   // load privacy here if quick-link is present in first section
   const quickLink = document.querySelector('div.section')?.querySelector('.quick-link');
-  if (!quickLink) return;
+  if (!quickLink || window.adobePrivacy) return;
   import('../scripts/delayed.js').then(({ loadPrivacy }) => {
     loadPrivacy(getConfig, loadScript);
   });
@@ -1722,6 +1739,7 @@ export async function loadArea(area = document) {
   const isDoc = area === document;
   if (isDoc) {
     if (document.getElementById('page-load-ok-milo')) return;
+    setCountry();
     await checkForPageMods();
     appendHtmlToCanonicalUrl();
     appendSuffixToTitles();


### PR DESCRIPTION
* Move languages-mapping.json data to languages-config.json This will reduce one extra network call.

Resolves: [MWPW-175711](https://jira.corp.adobe.com/browse/MWPW-175711)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ruchika/language/document1?martech=off
- After: https://lang-selector--milo--adobecom.aem.page/drafts/ruchika/language/document1?martech=off

News:
- Before: https://main--news--adobecom.hlx.page/news?milolibs=stage&martech=off
- After: https://main--news--adobecom.hlx.page/news?milolibs=lang-selector&martech=off

Testing Notes:
1. Expected behavior can be properly tested on newsroom link provided above as that has proper language object created in config.
2. Make sure search functionality works as before and user is able to search by exact string match and also by typing in english for native languages like Japanese. 
3. Ensure only 1 network call to languages-config.json in network tab
4. Ensure no extra json is loaded for language selector block. Previously we separate json langauges-mapping.json for search functionality. It should not load in feature branch now
5. No new functionality has been added as part of this PR so scope of testing is regression testing only.








