### PR TITLE
[MWPW-178053] Show copy tooltip when its content is hovered

### DIFF
--- a/libs/blocks/share/share.css
+++ b/libs/blocks/share/share.css
@@ -85,8 +85,7 @@
 
 .share .copy-to-clipboard::before {
   content: attr(data-copy-to-clipboard);
-  display: block;        
-  pointer-events: none;
+  display: block;
   position : absolute;
   bottom: 100%;
   left: -45%;
@@ -119,7 +118,6 @@
 .share .copy-to-clipboard::after {
   content: '';
   display: block;
-  pointer-events: none;
   position : absolute;
   bottom: 100%;
   left: 50%;
@@ -144,7 +142,6 @@
   visibility: visible;
   opacity: 1;
   transition-delay: 0ms;
-  pointer-events: auto;
   cursor: default;
 }
 


### PR DESCRIPTION
This allows the copy button tooltip to be visible when its content is being hovered, required for accessibility purposes.

I've decided to completely remove the `pointer-events` declarations, as their only purpose was to disallow executing the copy logic when the tooltip content was clicked. This seems like an edge case that has no real implications, thus the simplest solution was to remove these. An easy alternative would be to use `layerY` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/layerY)) to figure out if the click occurred on the element itself or one of its pseudo-elements, but this is a non-standard feature and implementing it doesn't bring enough advantages to grant its use. I'm open to other opinions, though 🙂 

Resolves: [MWPW-178053](https://jira.corp.adobe.com/browse/MWPW-178053)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/it/creativecloud/file-types/image/vector?martech=off
- After: https://main--cc--adobecom.aem.page/it/creativecloud/file-types/image/vector?milolibs=share-copy-a11y--milo--overmyheadandbody&martech=off