### PR TITLE
[MWPW-177247] Adapt card if text extension is active

### DIFF
--- a/libs/blocks/card/card.css
+++ b/libs/blocks/card/card.css
@@ -9,8 +9,16 @@
 }
 
 .card [class^="consonant-"]:is([class$="-title"], [class$="-text"]),
-.card [class^="consonant-CardsGrid--"][class$="up"] .consonant-ThreeFourthCard>a>.consonant-ThreeFourthCard-title {
+.card [class^="consonant-CardsGrid--"][class$="up"] .consonant-ThreeFourthCard > a > .consonant-ThreeFourthCard-title {
   max-height: unset;
+}
+
+.card.higher-clamp [class^="consonant-"]:is([class$="-title"], [class$="-text"]) {
+  -webkit-line-clamp: 6;
+}
+
+.card .consonant-CardFooter-row {
+  height: auto;
 }
 
 .card hr {

--- a/libs/blocks/card/card.js
+++ b/libs/blocks/card/card.js
@@ -7,6 +7,12 @@ const HALF_HEIGHT = 'HalfHeightCard';
 const PRODUCT = 'ProductCard';
 const DOUBLE_WIDE = 'DoubleWideCard';
 
+const adaptForTextExtension = (el) => {
+  const { letterSpacing, wordSpacing } = getComputedStyle(el);
+  const isExtensionActive = letterSpacing !== 'normal' || wordSpacing !== '0px';
+  el.classList.toggle('higher-clamp', isExtensionActive);
+};
+
 const getCardType = (styles) => {
   const cardTypes = {
     'half-card': HALF,
@@ -22,6 +28,9 @@ const addInner = (el, cardType, card) => {
   const title = el.querySelector('h1, h2, h3, h4, h5, h6');
   const text = Array.from(el.querySelectorAll('p'))?.find((p) => !p.querySelector('picture, a'));
   let inner = el.querySelector(':scope > div:not([class])');
+
+  adaptForTextExtension(el);
+  new ResizeObserver(() => { adaptForTextExtension(el); }).observe(el);
 
   if (cardType === DOUBLE_WIDE) {
     inner = document.createElement('a');


### PR DESCRIPTION
This increases the number of lines shown before adding an ellipsis in the card content, if the default letter or word spacing have been adapted, usually via the "Text Spacing Editor" extension. This aims to keep a balance between the original UI specs (clipping the title after 2 lines and the text after 3 lines) and accessibility requirements of ensuring that the same content is visible for users requiring text spacing adaptations and those who don't.

| Before | After |
| ------------- | ------------- |
| <img width="1250" height="516" alt="Screenshot 2025-08-12 at 14 26 10" src="https://github.com/user-attachments/assets/1db6a789-a334-46e8-9d01-2538278eb0e8" /> | <img width="1250" height="610" alt="Screenshot 2025-08-12 at 14 25 03" src="https://github.com/user-attachments/assets/045e42a0-dfab-43b7-9d25-d0e28ae8a251" /> |

Resolves: [MWPW-177247](https://jira.corp.adobe.com/browse/MWPW-177247)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/cards-with-long-cta?martech=off
- After: https://card-cta-height--milo--overmyheadandbody.aem.page/drafts/ramuntea/cards-with-long-cta?martech=off
- Before (Original issue): https://main--dc--adobecom.aem.live/es/acrobat/resources/document-files/spreadsheet-files/xlsx?martech=off
- After (Original issue): https://main--dc--adobecom.aem.live/es/acrobat/resources/document-files/spreadsheet-files/xlsx?martech=off&milolibs=card-cta-height--milo--overmyheadandbody


