### PR TITLE
[MWPW-177996] Use heading for share block title

### DIFF
--- a/libs/blocks/share/share.css
+++ b/libs/blocks/share/share.css
@@ -45,8 +45,8 @@
   gap: 18px;
 }
 
-.share p {
-  padding-bottom: 8px;
+.share :is([role="heading"], h1, h2, h3, h4, h5, h6) {
+  padding-block-end: 8px;
 }
 
 .share.dark p {

--- a/libs/blocks/share/share.js
+++ b/libs/blocks/share/share.js
@@ -60,39 +60,34 @@ function getPrevHeadingLevel(block) {
   return prevHeadingTag.replace('h', '');
 }
 
+function toSentenceCase(str) {
+  if (!str || typeof str !== 'string') return '';
+  /* eslint-disable-next-line no-useless-escape */
+  return str.toLowerCase().replace(/(^\s*\w|[\.\!\?]\s*\w)/g, (c) => c.toUpperCase());
+}
+
 export default async function decorate(block) {
   const config = getConfig();
   const base = config.miloLibs || config.codeRoot;
   const platforms = getPlatforms(block);
-  const rows = block.querySelectorAll(':scope > div');
-  const childDiv = rows[0]?.querySelector(':scope > div');
-  const emptyRow = rows.length && childDiv?.innerText.trim() === '';
-  const toSentenceCase = (str) => {
-    if (!str || typeof str !== 'string') return '';
-    /* eslint-disable-next-line no-useless-escape */
-    return str.toLowerCase().replace(/(^\s*\w|[\.\!\?]\s*\w)/g, (c) => c.toUpperCase());
-  };
+  let firstRow = block.querySelector(':scope > div');
+  let headingElem;
 
-  if (block.classList.contains('inline')) {
-    rows[0].innerHTML = '';
+  if (block.matches('.inline')) firstRow?.remove();
+  else if (firstRow?.textContent.trim().length) {
+    headingElem = firstRow.querySelector('p, div:not(:has(p, h1, h2, h3, h4, h5, h6))');
   } else {
-    rows[0]?.classList.add('tracking-header');
-    // add share placeholder if empty row
-    if (!rows.length || emptyRow) {
-      const heading = toSentenceCase(await replaceKey('share-this-page', config));
-      block.append(createTag('p', { role: 'heading', 'aria-level': getPrevHeadingLevel(block) }, heading));
+    headingElem = createTag('p', null, toSentenceCase(await replaceKey('share-this-page', config)));
+    if (firstRow) firstRow.replaceChildren(headingElem);
+    else {
+      firstRow = createTag('div', null, headingElem);
+      block.append(firstRow);
     }
   }
 
-  // wrap innerHTML in <p> tag if none are present
-  if (childDiv && !emptyRow) {
-    const innerPs = childDiv.querySelectorAll(':scope > p');
-    if (innerPs.length === 0) {
-      const text = childDiv.innerText;
-      childDiv.innerText = '';
-      childDiv.append(createTag('p', { role: 'heading', 'aria-level': getPrevHeadingLevel(block) }, text));
-    }
-  }
+  firstRow?.classList.add('tracking-header');
+  headingElem?.setAttribute('role', 'heading');
+  headingElem?.setAttribute('aria-level', getPrevHeadingLevel(block));
 
   const clipboardSupport = !!navigator.clipboard;
   if (clipboardSupport) platforms.push('clipboard');

--- a/libs/blocks/share/share.js
+++ b/libs/blocks/share/share.js
@@ -51,6 +51,15 @@ function getPlatforms(el) {
   return platforms;
 }
 
+function getPrevHeadingLevel(block) {
+  const prevHeading = [...document.querySelectorAll('h2, h3, h4, h5, h6')]
+    .reverse()
+    /* eslint-disable-next-line no-bitwise */
+    .find((heading) => heading.compareDocumentPosition(block) & Node.DOCUMENT_POSITION_FOLLOWING);
+  const prevHeadingTag = prevHeading?.tagName.toLowerCase() ?? 'h2';
+  return prevHeadingTag.replace('h', '');
+}
+
 export default async function decorate(block) {
   const config = getConfig();
   const base = config.miloLibs || config.codeRoot;
@@ -71,7 +80,7 @@ export default async function decorate(block) {
     // add share placeholder if empty row
     if (!rows.length || emptyRow) {
       const heading = toSentenceCase(await replaceKey('share-this-page', config));
-      block.append(createTag('p', null, heading));
+      block.append(createTag('p', { role: 'heading', 'aria-level': getPrevHeadingLevel(block) }, heading));
     }
   }
 
@@ -81,7 +90,7 @@ export default async function decorate(block) {
     if (innerPs.length === 0) {
       const text = childDiv.innerText;
       childDiv.innerText = '';
-      childDiv.append(createTag('p', null, text));
+      childDiv.append(createTag('p', { role: 'heading', 'aria-level': getPrevHeadingLevel(block) }, text));
     }
   }
 

--- a/test/blocks/share/share.test.js
+++ b/test/blocks/share/share.test.js
@@ -72,7 +72,7 @@ describe('Share', () => {
   it('Share w/ custom title exists', async () => {
     const shareEl = document.querySelector('.share.title');
     await init(shareEl);
-    const p = shareEl.querySelector('.tracking-header p');
+    const p = shareEl.querySelector('.tracking-header [role="heading"]');
     expect(p).to.exist;
   });
   it('Inline variant (with inline siblings) creates an inline-wrapper element', async () => {


### PR DESCRIPTION
This ensures that the text above the share icons from the Share block is announced as a heading. An option would be to actually use a heading element, but that leads to different styling needs, so I've chosen to address the issue via attributes on the existing element.

An interesting addition is the `getPrevHeadingLevel` method, which tries to find the heading level of the first `h` tag preceding a given element. This could prove useful in the future, since Adobe Accessibility rules state that the heading hierarchy should be clear on the page (i.e. no jumping from `h2` to `h4` or viceversa).

LE: After @zagi25's note, I noticed a few other small details to address:
* the `tracking-header` class was applied inconsistently, sometimes it didn't even include the heading text;
* the code intentionally replaced authored tags with a paragraph for headings. During the Accessibility work, it became clear that this pattern should be avoided and authors should have control over the tags they use;
* the logic was a bit convoluted, I rewrote it to include only the useful use-cases.

Resolves: [MWPW-177996](https://jira.corp.adobe.com/browse/MWPW-177996)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/share-scenarios?martech=off
- After: https://share-heading-a11y--milo--overmyheadandbody.aem.page/drafts/ramuntea/share-scenarios?martech=off
- Before (original issue): https://main--cc--adobecom.aem.page/es/creativecloud/design/discover/golden-ratio?martech=off
- After (original issue): https://main--cc--adobecom.aem.page/es/creativecloud/design/discover/golden-ratio?milolibs=share-heading-a11y--milo--overmyheadandbody&martech=off
















