### PR TITLE
[MWPW-167915] - faas autocomplete preserve

### DIFF
--- a/libs/blocks/faas/faas.js
+++ b/libs/blocks/faas/faas.js
@@ -75,14 +75,11 @@ const createValidationObserver = () => new MutationObserver((mutations) => {
 const createAutocompleteObserver = () => (
   new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
-      if (mutation.type !== 'attributes') return;
-
       const inputElement = mutation.target;
-
-      if (inputElement.getAttribute('autocomplete') !== 'off') return;
+      if (mutation.type !== 'attributes' || inputElement.getAttribute('autocomplete') !== 'off') return;
 
       const originalValue = inputElement.dataset.originalAutocomplete;
-      if (originalValue === undefined) return;
+      if (originalValue === '') return;
       inputElement.setAttribute('autocomplete', originalValue);
     });
   })


### PR DESCRIPTION
On PROD (Firefox) https://www.adobe.com/creativecloud/business/teams/request-information.html there is this dependency file https://tag.demandbase.com/shared/forms_45169bf05c.min.js that changes autocomplete to off on faas forms, since we can't change that file we have to create a mechanism to preserve these attributes if they are changed.

**QA Note**
Since this dependency file is only available on PROD we can't directly test this issue with that file changing the autocomplete to off, but we can emulate this behavior by applying a script in the browser console and trying to change the autocomplete ourselves to off and seeing if they are preserved, the following script can be used to test this:

`document.querySelectorAll('.faas-form input:not([type="hidden"]), .faas-form textarea').forEach(el => el.setAttribute('autocomplete', 'off'));`

Resolves: [MWPW-167915](https://jira.corp.adobe.com/browse/MWPW-167915)

**PSI Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://faas-autocomplete-demandbase--milo--adobecom.aem.page/?martech=off

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/creativecloud/business/teams/request-information?georouting=off
- After: https://main--cc--adobecom.aem.live/creativecloud/business/teams/request-information?georouting=off&milolibs=faas-autocomplete-demandbase





