### PR TITLE
Fix spacing between figures

### DIFF
--- a/libs/blocks/figure/figure.css
+++ b/libs/blocks/figure/figure.css
@@ -2,8 +2,8 @@
   padding: 40px 0;
 }
 
-.figure.no-padding-bottom {
-  padding-bottom: 0;
+.figure + .figure {
+  padding-top: 0;
 }
 
 .figure figure {
@@ -69,13 +69,16 @@
     margin-left: auto;
     margin-right: 32px;
   }
-
 }
 
 @media (min-width: 700px) {
   .figure figure {
     margin: 0 auto;
     max-width: 800px;
+  }
+
+  .figure.figure-list + .figure:not(.figure-list) {
+    padding-top: 40px;
   }
 
   .figure-list {

--- a/libs/blocks/figure/figure.js
+++ b/libs/blocks/figure/figure.js
@@ -69,8 +69,4 @@ export default function init(blockEl) {
   if (blockCount > 1) {
     blockEl.classList.add('figure-list', `figure-list-${blockCount}`);
   }
-
-  if (blockEl.nextElementSibling?.classList.contains('figure')) {
-    blockEl.classList.add('no-padding-bottom');
-  }
 }


### PR DESCRIPTION
Issue: Spacing between two figure block is incorrect

<img width="886" height="482" alt="Screenshot 2025-08-14 at 11 32 06" src="https://github.com/user-attachments/assets/e8bc4ea0-1e04-4ee4-81c6-6800062f5ce8" />
<img width="854" height="481" alt="Screenshot 2025-08-14 at 11 32 19" src="https://github.com/user-attachments/assets/42e69580-ccbb-4b40-a2a3-9b4c4a00bbab" />


* Fix spacing

Resolves: [MWPW-178159](https://jira.corp.adobe.com/browse/MWPW-178159)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/figure?martech=off
- After: https://figure-padding-fix--milo--adobecom.aem.page/docs/library/kitchen-sink/figure?martech=off

**Blog URLs:**
- Before: https://main--blog--adobecom.aem.page/en/drafts/ratko/test-blog
- After: https://main--blog--adobecom.aem.page/en/drafts/ratko/test-blog?milolibs=figure-padding-fix

**Other issues found on the page will be fixed by Blog PR [67](https://github.com/adobecom/blog/pull/67):**
- With blog fix:  https://mwpw-178159-empty-figure--blog--adobecom.aem.page/en/drafts/ratko/test-blog?milolibs=figure-padding-fix