### PR TITLE
MWPW-177651: create redirects

### DIFF
--- a/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
+++ b/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
@@ -18,6 +18,18 @@ import {
 const DEPS_TIMEOUT = 10000;
 const DEFAULT_OPTIONS = { sidenav: true };
 
+// Map of single_app values to their corresponding filter values
+const SINGLE_APP_FILTER_MAP = {
+  illustrator: 'illustration',
+  indesign: 'design',
+  animate: 'video-audio',
+  premiere: 'video-audio',
+  aftereffects: 'video-audio',
+  audition: 'video-audio',
+  incopy: 'design',
+  lightroom_1tb: 'photography',
+};
+
 function getTimeoutPromise(timeout) {
   return new Promise((resolve) => {
     setTimeout(() => resolve(false), timeout);
@@ -163,6 +175,14 @@ export async function createCollection(el, options) {
 
   /* Sidenav */
   if (options.sidenav) {
+    // Set filter based on single_app parameter if filter doesn't exist
+    const urlParams = new URLSearchParams(window.location.search);
+    const singleApp = urlParams.get('single_app');
+    if (singleApp && !urlParams.get('filter') && SINGLE_APP_FILTER_MAP[singleApp]) {
+      urlParams.set('filter', SINGLE_APP_FILTER_MAP[singleApp]);
+      const newUrl = `${window.location.pathname}?${urlParams.toString()}${window.location.hash}`;
+      window.history.pushState({}, '', newUrl);
+    }
     const sidenav = getSidenav(collection);
     if (sidenav) {
       collection.attachSidenav(sidenav);

--- a/test/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.test.js
+++ b/test/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.test.js
@@ -177,5 +177,61 @@ describe('merch-card-collection autoblock', () => {
       expect(collection).to.exist;
       expect(collection.getAttribute('overrides')).to.equal('should-be-replaced:promo-1,should-also-be-replaced:promo-2');
     });
+
+    it('sets filter parameter for illustrator single_app', async () => {
+      const originalUrl = window.location.href;
+      const url = new URL(originalUrl);
+      url.searchParams.append('single_app', 'illustrator');
+      url.searchParams.append('existing_param', 'value');
+      window.history.pushState({}, '', `${url.toString()}`);
+      const originalPushState = window.history.pushState;
+      const pushStateSpy = sinon.spy();
+      window.history.pushState = pushStateSpy;
+
+      const content = document.createElement('div');
+      content.classList.add('content');
+      const a = document.createElement('a');
+      a.setAttribute('href', 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=e58f8f75-b882-409a-9ff8-8826b36a8368');
+      a.textContent = 'merch-card-collection: SANDBOX / Individual Plans';
+      content.append(a);
+      document.body.append(content);
+      await init(a);
+
+      expect(pushStateSpy.called).to.be.true;
+      const callArgs = pushStateSpy.firstCall.args;
+      expect(callArgs[2]).to.include('filter=illustration');
+      expect(callArgs[2]).to.include('single_app=illustrator');
+      expect(callArgs[2]).to.include('existing_param=value');
+
+      window.history.pushState = originalPushState;
+      window.history.pushState({}, '', `${originalUrl}`);
+    });
+
+    it('does not set filter parameter when filter already exists', async () => {
+      const originalUrl = window.location.href;
+      const url = new URL(originalUrl);
+      url.searchParams.append('single_app', 'illustrator');
+      url.searchParams.append('filter', 'photography');
+      window.history.pushState({}, '', `${url.toString()}`);
+      const originalPushState = window.history.pushState;
+      const pushStateSpy = sinon.spy();
+      window.history.pushState = pushStateSpy;
+
+      const content = document.createElement('div');
+      content.classList.add('content');
+      const a = document.createElement('a');
+      a.setAttribute('href', 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=e58f8f75-b882-409a-9ff8-8826b36a8368');
+      a.textContent = 'merch-card-collection: SANDBOX / Individual Plans';
+      content.append(a);
+      document.body.append(content);
+      await init(a);
+
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get('filter')).to.equal('photography');
+      expect(params.get('single_app')).to.equal('illustrator');
+
+      window.history.pushState = originalPushState;
+      window.history.pushState({}, '', `${originalUrl}`);
+    });
   });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Support legacy redirects from ?single_app parameter to ?single_app=x&filter=y parameter.
Existing redirects can be checked on prod, e.g.: 
https://www.adobe.com/creativecloud/plans.html?single_app=animate

Redirection to ?plan=individual is redundant, since this tab is opened by default.
Redirection to ?filter=all is redundant, since this filter(category) is opened by default.
Change from request parameter to hash for filter and single_app is expected.

?single_app=illustrator to ?single_app=illustrator&filter=illustration
?single_app=indesign to ?single_app=indesign&filter=design
?single_app=animate to ?single_app=animate&filter=video-audio
?single_app=premiere to ?single_app=premiere&filter=video-audio
?single_app=aftereffects to ?single_app=aftereffects&filter=video-audio
?single_app=audition to ?single_app=audition&filter=video-audio
?single_app=incopy to ?single_app=incopy&filter=design
?single_app=lightroom_1tb to ?single_app=lightroom_1tb&filter=photography

Resolves: [MWPW-177651](https://jira.corp.adobe.com/browse/MWPW-177651)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/drafts/nala/features/commerce/plans2?martech=off&mep=off&georouting=off
- After: https://mwpw-177651--milo--adobecom.aem.live/drafts/nala/features/commerce/plans2?martech=off&mep=off&georouting=off


