### PR TITLE
MWPW-178109 [Plans] Category filters - accessibility issues

### DIFF
--- a/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
+++ b/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
@@ -94,6 +94,12 @@ function getSidenav(collection) {
   spSidenav.setAttribute('manageTabIndex', true);
   const sidenavList = createTag('merch-sidenav-list', { deeplink: 'filter' }, spSidenav);
 
+  sidenavList.updateComplete.then(() => {
+    sidenavList.querySelectorAll('sp-sidenav-item').forEach((item) => {
+      item?.shadowRoot?.querySelector('a')?.setAttribute('role', 'tab');
+    });
+  });
+
   let multilevel = false;
   function generateLevelItems(level, parent) {
     for (const node of level) {

--- a/libs/features/mas/src/merch-card-collection.js
+++ b/libs/features/mas/src/merch-card-collection.js
@@ -689,7 +689,7 @@ const RESULT_TEXT_SLOT_NAMES = {
           if (!customHeaderAreaGetter) return nothing;
           const customHeaderArea = customHeaderAreaGetter(this.collection);
           if (!customHeaderArea || customHeaderArea === nothing) return nothing;
-          return html`<div id="custom">${customHeaderArea}</div>`;
+          return html`<div id="custom" role="heading" aria-level="2">${customHeaderArea}</div>`;
       }
   
       // #region Handlers

--- a/libs/features/mas/src/sidenav/merch-sidenav-list.js
+++ b/libs/features/mas/src/sidenav/merch-sidenav-list.js
@@ -54,6 +54,7 @@ export class MerchSidenavList extends LitElement {
 
     selectElement(element, selected = true) {
         element.selected = selected;
+        element.shadowRoot?.querySelector('a')?.setAttribute('aria-selected', selected);
         if (element.parentNode.tagName === 'SP-SIDENAV-ITEM') {
             this.selectElement(element.parentNode, false);
         }


### PR DESCRIPTION
Plans page, sidenav items should be read as tabs by the screen reader.

Test page : `main--cc--adobecom.aem.live/creativecloud/plans?milolibs=mwpw178109a11y--milo--bozojovicic`

Resolves: [MWPW-178109](https://jira.corp.adobe.com/browse/MWPW-178109)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://mwpw178109a11y--milo--bozojovicic.aem.live/?martech=off
