### PR TITLE
MWPW-177985: In devices Iframe modal load in photoshop page is not seen in fit to screen size

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -12,7 +12,7 @@ const CLOSE_ICON = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" w
   </g>
 </svg>`;
 
-let isDelayedModal = false;
+let delayedModalId = null;
 let prevHash = '';
 let isDeepLink = false;
 const dialogLoadingSet = new Set();
@@ -167,7 +167,7 @@ export async function getModal(details, custom) {
   if (custom && !custom?.title) custom.title = findDetails(window.location.hash, null)?.title;
   if (custom) getCustomModal(custom, dialog);
   if (details) await getPathModal(details.path, dialog);
-  if (isDelayedModal) {
+  if (delayedModalId === id) {
     dialog.classList.add('delayed-modal');
     const mediaBlock = dialog.querySelector('div.media');
     if (mediaBlock) {
@@ -176,6 +176,7 @@ export async function getModal(details, custom) {
       const base = miloLibs || codeRoot;
       loadStyle(`${base}/styles/rounded-corners.css`);
     }
+    delayedModalId = null;
   }
 
   const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
@@ -315,7 +316,7 @@ export function delayedModal(el) {
   const { hash, delay } = getHashParams(el?.dataset.modalHash);
   const isDesktop = window.matchMedia('(min-width: 1200px)').matches;
   if (delay === undefined || !hash || !isDesktop) return false;
-  isDelayedModal = true;
+  delayedModalId = hash.replace('#', '');
   const modalOpenEvent = new Event(`${hash}:modalOpen`);
   const pagesModalWasShownOn = window.sessionStorage.getItem(`shown:${hash}`);
   el.dataset.modalHash = hash;


### PR DESCRIPTION
Previously, when the page loaded both a delayed modal and a regular modal (e.g., the three-in-one modal), a race condition caused the delayed-modal class to be applied incorrectly to both.

This happened because isDelayedModal was being reset to false before the correct modal finished rendering.

With this change, the delayed-modal class is now applied only to the intended modal, ensuring proper styling and behavior.

Resolves: [MWPW-177985](https://jira.corp.adobe.com/browse/MWPW-177985)

**Test URLs:**
- Before:
1. https://main--milo--adobecom.aem.page/drafts/mirafedas/delayed-modals/delayed-modal#mini-plans-web-cta-acrobat-pro-card
2. http://main--cc--adobecom.aem.live/creativecloud/products/photoshop#mini-plans-web-cta-photoshop-card

- After: 
1. https://mwpw-177985-delayed-modal-race--milo--mirafedas.aem.page/drafts/mirafedas/delayed-modals/delayed-modal#mini-plans-web-cta-acrobat-pro-card
2. http://main--cc--adobecom.aem.live/creativecloud/products/photoshop?milolibs=mwpw-177985-delayed-modal-race--milo--mirafedas#mini-plans-web-cta-photoshop-card
