### PR TITLE
MWPW-178629 Global Navigation CSS needs to be awaited to eliminate the possibility of FOUC

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -17,19 +17,12 @@ import {
 const cssPromise = (async () => {
   const { miloLibs, codeRoot, theme } = getConfig();
   const url = `${miloLibs || codeRoot}/blocks/global-navigation/`;
-  // const loadStylePromise = (u) => new Promise((resolve, reject) => {
-  //   loadStyle(u, (e) => {
-  //     if (e === 'error') return reject(u);
-  //     return resolve();
-  //   });
-  // });
-  const loadStylePromise = async (u) => {
-    const response = await fetch(u);
-    const css = await response.text();
-    const sheet = new CSSStyleSheet();
-    sheet.replaceSync(`${css}`);
-    document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
-  };
+  const loadStylePromise = (u) => new Promise((resolve, reject) => {
+    loadStyle(u, (e) => {
+      if (e === 'error') return reject(u);
+      return resolve();
+    });
+  });
   try {
     await loadStylePromise(`${url}base.css`);
     if (theme === 'dark') await loadStylePromise(`${url}dark-nav.css`);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* The IIFE that loads gnav css is now assigned to a variable
* The css promise is awaited before we make the gnav visible.

Resolves: [MWPW-178629](https://jira.corp.adobe.com/browse/MWPW-178629)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-wait-for-css--milo--adobecom.aem.page/?martech=off

Note for QA: This should be a low to no impact PR. The probability of FOUC on normal milo based pages was already vanishingly low. Though you may be able to see that FOUC is far less common on the standalone gnav: https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=gnav-wait-for-css&theme=light&authoringpath=/federal/dev/tat28144


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- Milo: https://gnav-wait-for-css--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=gnav-wait-for-css--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- Milo: https://gnav-wait-for-css--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-wait-for-css--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- Milo: https://gnav-wait-for-css--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-wait-for-css--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=gnav-wait-for-css--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=gnav-wait-for-css--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=gnav-wait-for-css--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=gnav-wait-for-css--milo--adobecom
</details>