### PR TITLE
Adding background back for promo secondary cta

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -311,7 +311,14 @@ header.global-navigation {
   white-space: nowrap;
 }
 
-.feds-cta--secondary:hover {
+.global-navigation:not(.feds--dark) .feds-promo .feds-cta--secondary {
+  background-color: rgb(255, 255, 255);
+  border-color: rgb(75, 75, 75);
+  color: rgb(75, 75, 75);
+}
+
+.feds-cta--secondary:hover,
+.global-navigation:not(.feds--dark) .feds-promo .feds-cta--secondary:hover {
   border-color: #C6C6C6;
   background: #E9E9E9;
   color: #292929;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Secondary CTA background was updated recently to transparent - [PR](https://github.com/adobecom/milo/pull/4302)
* We need to keep the background for secondary CTA inside gnav promo

Resolves: [MWPW-178670](https://jira.corp.adobe.com/browse/MWPW-178670)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://promo-cta--milo--adobecom.aem.page/?martech=off


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=promo-cta--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=promo-cta--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=promo-cta--milo--adobecom
- Milo: https://promo-cta--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=promo-cta--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=promo-cta--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=promo-cta--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=promo-cta--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=promo-cta--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=promo-cta--milo--adobecom
- Milo: https://promo-cta--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=promo-cta--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=promo-cta--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=promo-cta--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=promo-cta--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=promo-cta--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=promo-cta--milo--adobecom
- Milo: https://promo-cta--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=promo-cta--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=promo-cta--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=promo-cta--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=promo-cta--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=promo-cta--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=promo-cta--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=promo-cta--milo--adobecom
</details>