### PR TITLE
[MWPW-178729] Media bolded last link fix

### DIFF
--- a/libs/blocks/media/media.js
+++ b/libs/blocks/media/media.js
@@ -77,7 +77,7 @@ export default async function init(el) {
       text.classList.add('text');
       decorateAvatar(text);
       decorateBlockText(text, blockTypeSizes[size], blockType);
-      const plainActionArea = text.querySelector('[class*="body-"]:has(a:not(.con-button)):last-child:not(.action-area)');
+      const plainActionArea = text.querySelector('[class*="body-"]:has(> a:not(.con-button)):last-child:not(.action-area)');
       const hasTextNode = plainActionArea
         && [...plainActionArea.childNodes].some((n) => n.nodeType === Node.TEXT_NODE && n.textContent.trim() !== '');
       if (!hasTextNode) plainActionArea?.classList.add('action-area-plain');


### PR DESCRIPTION
This further refines the selector needed to bold the last lone link of a Media block, to ensure the logic is not applied if the link is nested inside a list (or other wrapper).

Resolves: [MWPW-178729](https://jira.corp.adobe.com/browse/MWPW-178729)

**Test URLs:**
- Before (original use-case, no change): https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/media-heading-style?martech=off
- After (original use-case, no change): https://media-last-link-fix--milo--overmyheadandbody.aem.page/drafts/ramuntea/accessibility/media-heading-style?martech=off
- Before (previously flagged issue, no change): https://main--milo--overmyheadandbody.aem.page/drafts/klee/jira-ticket/mwpw-172068-media-body-links?martech=off
- After (previously flagged issue, no change): https://media-last-link-fix--milo--overmyheadandbody.aem.page/drafts/klee/jira-ticket/mwpw-172068-media-body-links?martech=off
- Before (Kitchen Sink, no change): https://main--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/media?martech=off
- After (Kitchen Sink, no change): https://media-last-link-fix--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/media?martech=off
- Before (new BACOM use-case): https://main--da-bacom--adobecom.aem.page/solutions/content-supply-chain/asset-management?martech=off
- After (new BACOM use-case): https://main--da-bacom--adobecom.aem.page/solutions/content-supply-chain/asset-management?milolibs=media-last-link-fix--milo--overmyheadandbody&martech=off
- Before (new BACOM use-case): https://main--da-bacom--adobecom.aem.page/products/marketo/omnichannel-engagement?martech=off
- After (new BACOM use-case): https://main--da-bacom--adobecom.aem.page/products/marketo/omnichannel-engagement?milolibs=media-last-link-fix--milo--overmyheadandbody&martech=off
