### PR TITLE
intermittently seen the issue of multiple slash (/) in gnav links in news US page

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -202,11 +202,13 @@ export function getLocale(locales, pathname = window.location.pathname) {
   if ([LANGSTORE, PREVIEW].includes(localeString)) {
     const ietf = Object.keys(locales).find((loc) => locales[loc]?.ietf?.startsWith(split[2]));
     if (ietf) locale = locales[ietf];
-    locale.prefix = `/${localeString}/${split[2]}`;
+    const pathSegment = split[2] ? `/${split[2]}` : '';
+    locale.prefix = `/${localeString}${pathSegment}`;
     return locale;
   }
   const isUS = locale.ietf === 'en-US';
-  locale.prefix = isUS ? '' : `/${localeString}`;
+  const localePathPrefix = localeString ? `/${localeString}` : '';
+  locale.prefix = isUS ? '' : localePathPrefix;
   locale.region = isUS ? 'us' : localeString.split('_')[0];
   return locale;
 }


### PR DESCRIPTION
intermittently seen the issue of multiple slash (/) in gnav links in news US page

Solution:
Added a fix to handle cases where localeString or split[2] are empty.
Earlier, the logic intermittently prefixed values with /, which resulted in incorrect paths like / or //xyz. With the new change, we only add the / when a value actually exists, ensuring clean and valid path generation for both locale and path segments.

Resolves: [MWPW-178137](https://jira.corp.adobe.com/browse/MWPW-178137)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-178137--milo--patel-prince.aem.page/?martech=off
 
**QA URL:**
- https://main--news--adobecom.aem.page/news?milolibs=mwpw-178137--milo--patel-prince
- https://main--cc--adobecom.aem.page/creativecloud?milolibs=mwpw-178137--milo--patel-prince



