### PR TITLE
MWPW-178853 The DA in-editor preview's Global-Navigation disappears after a split second

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -486,7 +486,7 @@ export async function fetchAndProcessPlainHtml({
     });
     return null;
   }
-  const text = await res.text();
+  const text = await (plainHTMLPromise ? res.clone().text() : res.text())
   const { body } = new DOMParser().parseFromString(text, 'text/html');
   if (mepFragment?.manifestId) body.dataset.manifestId = mepFragment.manifestId;
   if (mepFragment?.targetManifestId) body.dataset.adobeTargetTestid = mepFragment.targetManifestId;


### PR DESCRIPTION


<!-- Before submitting, please review all open PRs. -->

* [If plainHTMLPromise is non-null, clone the response stream in `fetchAndProcessPlainHTML`

Resolves: [MWPW-178853](https://jira.corp.adobe.com/browse/MWPW-178853)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://reuse-gnav-html-response--milo--adobecom.aem.page/?martech=off

https://da.live/edit#/adobecom/da-bacom/customer-success-stories/aida-case-study
