### PR TITLE
MWPW-179126 [MEP] Add marketing actions to manifest info

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1056,7 +1056,13 @@ export const addMepAnalytics = (config, header) => {
     }
   });
 };
-export async function getManifestConfig(
+export function getCanServe(action, source, consent) {
+  const isNonPzn = action === 'non-personalization' || source === 'promo';
+  const isNonMktg = action === 'non-marketing';
+  return isNonPzn || (consent?.nonMktg && isNonMktg) || consent?.mktg;
+}
+
+async function getManifestConfig(
   info = {},
   variantOverride = false,
   consent = { nonMktg: true, mktg: false },
@@ -1125,11 +1131,7 @@ export async function getManifestConfig(
     manifestConfig.manifestType = infoKeyMap['manifest-type'][1];
     manifestConfig.executionOrder = '1-1';
   }
-
-  const isNonPzn = manifestConfig.mktgAction === 'non-personalization' || source === 'promo';
-  const isNonMktg = manifestConfig.mktgAction === 'non-marketing';
-  const canServe = isNonPzn || (consent?.nonMktg && isNonMktg) || consent?.mktg;
-  if (!canServe) return null;
+  if (!getCanServe(manifestConfig.mktgAction, source, consent)) return null;
 
   manifestConfig.manifestPath = normalizePath(manifestPath);
   manifestConfig.selectedVariantName = await getPersonalizationVariant(

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1057,6 +1057,9 @@ export const addMepAnalytics = (config, header) => {
     }
   });
 };
+function getCountry() {
+  return getMepEnablement('akamaiLocale') || sessionStorage.getItem('akamai');
+}
 export function hasC0002() {
   const kndctrCookie = getCookie('kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent');
   if (kndctrCookie?.includes('general=out')) return false;
@@ -1071,8 +1074,7 @@ export function hasC0002() {
     'mc', 'sk', 'mf', 'sm', 'gb', 'yt', 'ie', 'gf', 'ee', 'mq', 'mt', 'gp', 'is', 'gr', 'it', 'es',
     'at', 're', 'cy', 'cz', 'ax', 'pl', 'ro', 'li', 'nl',
   ];
-  const country = getMepEnablement('akamaiLocale') || sessionStorage.getItem('akamai');
-  return !explicitConsentCountries.includes(country);
+  return !explicitConsentCountries.includes(getCountry());
 }
 export async function getManifestConfig(info = {}, variantOverride = false) {
   const {

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1056,22 +1056,6 @@ export const addMepAnalytics = (config, header) => {
     }
   });
 };
-
-export function getConsentLevels() {
-  const kndctr = getCookie('kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent');
-  if (kndctr?.includes('general=out')) return { nonMarketing: false, marketing: false };
-  if (kndctr?.includes('general=in')) return { nonMarketing: true, marketing: true };
-
-  const optanon = getCookie('OptanonConsent');
-  if (optanon) {
-    return {
-      nonMarketing: optanon.includes('C0002:1') || optanon.includes('C0003:1'),
-      marketing: optanon.includes('C0004:1'),
-    };
-  }
-
-  return { nonMarketing: true, marketing: false };
-}
 export async function getManifestConfig(info = {}, variantOverride = false) {
   const {
     name,
@@ -1114,7 +1098,6 @@ export async function getManifestConfig(info = {}, variantOverride = false) {
     'manifest-type': ['Personalization', 'Promo', 'Test'],
     'manifest-execution-order': ['First', 'Normal', 'Last'],
   };
-
   if (infoTab) {
     manifestConfig.manifestType = infoObj?.['manifest-type']?.toLowerCase();
     if (manifestConfig.manifestType === TRACKED_MANIFEST_TYPE) {
@@ -1524,6 +1507,22 @@ const awaitMartech = () => new Promise((resolve) => {
   const listener = (event) => resolve(event.detail);
   window.addEventListener(MARTECH_RETURNED_EVENT, listener, { once: true });
 });
+
+export function getConsentLevels() {
+  const kndctr = getCookie('kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent');
+  if (kndctr?.includes('general=out')) return { nonMarketing: false, marketing: false };
+  if (kndctr?.includes('general=in')) return { nonMarketing: true, marketing: true };
+
+  const optanon = getCookie('OptanonConsent');
+  if (optanon) {
+    return {
+      nonMarketing: optanon.includes('C0002:1') || optanon.includes('C0003:1'),
+      marketing: optanon.includes('C0004:1'),
+    };
+  }
+
+  return { nonMarketing: true, marketing: false };
+}
 
 export async function init(enablements = {}) {
   let manifests = [];

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1072,7 +1072,7 @@ export function getConsentLevels() {
   return { nonMktg: true, mktg: false };
 }
 export function canServeManifest(action, source, consent) {
-  const isNotPzn = action === 'none' || source === 'promo';
+  const isNotPzn = action === 'core services' || source === 'promo';
   const isNonMktg = ['non-marketing', 'data science', 'analytics'].includes(action);
   return isNotPzn || (consent?.nonMktg && isNonMktg) || consent?.mktg;
 }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1080,7 +1080,7 @@ export function getConsentLevels() {
   const isExplicitConsentCountry = explicitConsentCountries.includes(country);
   if (isExplicitConsentCountry) return { nonMktg: false, mktg: false };
 
-  return { nonMktg: true, mktg: false };
+  return { nonMktg: true, mktg: true };
 }
 export function canServeManifest(action, sources, consent) {
   const isNotPzn = action === 'core services' || sources?.includes('promo');

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1056,7 +1056,7 @@ export const addMepAnalytics = (config, header) => {
     }
   });
 };
-export function getCanServe(action, source, consent) {
+export function canServe(action, source, consent) {
   const isNonPzn = action === 'non-personalization' || source === 'promo';
   const isNonMktg = action === 'non-marketing';
   return isNonPzn || (consent?.nonMktg && isNonMktg) || consent?.mktg;
@@ -1131,7 +1131,7 @@ async function getManifestConfig(
     manifestConfig.manifestType = infoKeyMap['manifest-type'][1];
     manifestConfig.executionOrder = '1-1';
   }
-  if (!getCanServe(manifestConfig.mktgAction, source, consent)) return null;
+  if (!canServe(manifestConfig.mktgAction, source, consent)) return null;
 
   manifestConfig.manifestPath = normalizePath(manifestPath);
   manifestConfig.selectedVariantName = await getPersonalizationVariant(

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1123,9 +1123,9 @@ export async function getManifestConfig(info = {}, variantOverride = false) {
   }
 
   const isNonPzn = manifestConfig.marketingAction === 'non-personalization';
-  const isNonMarketing = manifestConfig.marketingAction === 'non-marketing';
+  const isNonMktg = manifestConfig.marketingAction === 'non-marketing';
   const consent = getConfig()?.mep?.consent;
-  const canServe = isNonPzn || (consent?.nonMarketing && isNonMarketing) || consent?.marketing;
+  const canServe = isNonPzn || (consent?.nonMktg && isNonMktg) || consent?.mktg;
   if (!canServe) return null;
 
   manifestConfig.manifestPath = normalizePath(manifestPath);
@@ -1510,18 +1510,18 @@ const awaitMartech = () => new Promise((resolve) => {
 
 export function getConsentLevels() {
   const kndctr = getCookie('kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent');
-  if (kndctr?.includes('general=out')) return { nonMarketing: false, marketing: false };
-  if (kndctr?.includes('general=in')) return { nonMarketing: true, marketing: true };
+  if (kndctr?.includes('general=out')) return { nonMktg: false, mktg: false };
+  if (kndctr?.includes('general=in')) return { nonMktg: true, mktg: true };
 
   const optanon = getCookie('OptanonConsent');
   if (optanon) {
     return {
-      nonMarketing: optanon.includes('C0002:1') || optanon.includes('C0003:1'),
-      marketing: optanon.includes('C0004:1'),
+      nonMktg: optanon.includes('C0002:1') || optanon.includes('C0003:1'),
+      mktg: optanon.includes('C0004:1'),
     };
   }
 
-  return { nonMarketing: true, marketing: false };
+  return { nonMktg: true, mktg: false };
 }
 
 export async function init(enablements = {}) {

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -10,7 +10,6 @@ import {
   localizeLink,
   getFederatedUrl,
   isSignedOut,
-  getMepEnablement,
 } from '../../utils/utils.js';
 
 /* c8 ignore start */

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1084,7 +1084,7 @@ export function getConsentLevels() {
 export function canServeManifest(action, sources, consent) {
   const isNotPzn = action === 'core services' || sources?.includes('promo');
   const isNonMktg = ['non-marketing', 'data science', 'analytics'].includes(action);
-  return isNotPzn || (consent?.nonMktg && isNonMktg) || consent?.mktg;
+  return isNotPzn || (consent?.nonMktg && isNonMktg) || (consent?.mktg && !isNonMktg);
 }
 
 async function getManifestConfig(

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1061,7 +1061,7 @@ export function getConsentLevels() {
   const optanon = getCookie('OptanonConsent');
   if (optanon) {
     return {
-      nonMktg: !optanon.includes('C0002:0') && !optanon.includes('C0003:0'),
+      nonMktg: !optanon.includes('C0002:0') || !optanon.includes('C0003:0'),
       mktg: optanon.includes('C0004:1'),
     };
   }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -10,6 +10,7 @@ import {
   localizeLink,
   getFederatedUrl,
   isSignedOut,
+  getMepEnablement,
 } from '../../utils/utils.js';
 
 /* c8 ignore start */
@@ -1068,6 +1069,16 @@ export function getConsentLevels() {
       mktg: optanon.includes('C0004:1'),
     };
   }
+
+  const explicitConsentCountries = [
+    'ca', 'de', 'no', 'fi', 'be', 'pt', 'bg', 'dk', 'lt', 'lu',
+    'lv', 'hr', 'fr', 'hu', 'se', 'si', 'mc', 'sk', 'mf', 'sm',
+    'gb', 'yt', 'ie', 'gf', 'ee', 'mq', 'mt', 'gp', 'is', 'gr',
+    'it', 'es', 'at', 're', 'cy', 'cz', 'ax', 'pl', 'ro', 'li', 'nl',
+  ];
+  const country = getMepEnablement('akamaiLocale') || sessionStorage.getItem('akamai');
+  const isExplicitConsentCountry = explicitConsentCountries.includes(country);
+  if (isExplicitConsentCountry) return { nonMktg: false, mktg: false };
 
   return { nonMktg: true, mktg: false };
 }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1058,10 +1058,6 @@ export const addMepAnalytics = (config, header) => {
   });
 };
 export function getConsentLevels() {
-  const kndctr = getCookie('kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent');
-  if (kndctr?.includes('general=out')) return { nonMktg: false, mktg: false };
-  if (kndctr?.includes('general=in')) return { nonMktg: true, mktg: true };
-
   const optanon = getCookie('OptanonConsent');
   if (optanon) {
     return {
@@ -1069,6 +1065,9 @@ export function getConsentLevels() {
       mktg: optanon.includes('C0004:1'),
     };
   }
+
+  const kndctr = getCookie('kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent');
+  if (kndctr?.includes('general=in')) return { nonMktg: true, mktg: false };
 
   const explicitConsentCountries = [
     'ca', 'de', 'no', 'fi', 'be', 'pt', 'bg', 'dk', 'lt', 'lu',

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1071,8 +1071,8 @@ export function getConsentLevels() {
 
   return { nonMktg: true, mktg: false };
 }
-export function canServeManifest(action, source, consent) {
-  const isNotPzn = action === 'core services' || source === 'promo';
+export function canServeManifest(action, sources, consent) {
+  const isNotPzn = action === 'core services' || sources?.includes('promo');
   const isNonMktg = ['non-marketing', 'data science', 'analytics'].includes(action);
   return isNotPzn || (consent?.nonMktg && isNonMktg) || consent?.mktg;
 }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1503,17 +1503,29 @@ const awaitMartech = () => new Promise((resolve) => {
   window.addEventListener(MARTECH_RETURNED_EVENT, listener, { once: true });
 });
 
-export function hasC0002() {
-  const akamaiLocale = getMepEnablement('akamaiLocale') || sessionStorage.getItem('akamai');
-  const explicitConsentCountries = [
-    'ca', 'de', 'no', 'fi', 'be', 'pt', 'bg', 'dk', 'lt', 'lu',
-    'lv', 'hr', 'fr', 'hu', 'se', 'si', 'mc', 'sk', 'mf', 'sm',
-    'gb', 'yt', 'ie', 'gf', 'ee', 'mq', 'mt', 'gp', 'is', 'gr',
-    'it', 'es', 'at', 're', 'cy', 'cz', 'ax', 'pl', 'ro', 'li', 'nl',
-  ];
-  return explicitConsentCountries.includes(akamaiLocale) ? 1 : 2;
+export function getCookie(key) {
+  const cookie = document.cookie.split(';')
+    .map((x) => decodeURIComponent(x.trim()).split(/=(.*)/s))
+    .find(([k]) => k === key);
+  return cookie ? cookie[1] : null;
 }
+export async function hasC0002() {
+  const kndctrCookie = getCookie('kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent');
+  if (kndctrCookie?.includes('general=out')) return false;
+  if (kndctrCookie?.includes('general=in')) return true;
 
+  const optanonCookie = getCookie('OptanonConsent');
+  if (optanonCookie?.includes('C0002:0')) return false;
+  if (optanonCookie?.includes('C0002:1')) return true;
+
+  const explicitConsentCountries = [
+    'ca', 'de', 'no', 'fi', 'be', 'pt', 'bg', 'dk', 'lt', 'lu', 'lv', 'hr', 'fr', 'hu', 'se', 'si',
+    'mc', 'sk', 'mf', 'sm', 'gb', 'yt', 'ie', 'gf', 'ee', 'mq', 'mt', 'gp', 'is', 'gr', 'it', 'es',
+    'at', 're', 'cy', 'cz', 'ax', 'pl', 'ro', 'li', 'nl',
+  ];
+  const country = getMepEnablement('akamaiLocale') || sessionStorage.getItem('akamai');
+  return !explicitConsentCountries.includes(country);
+}
 export async function init(enablements = {}) {
   let manifests = [];
   const {

--- a/test/features/personalization/consent.test.js
+++ b/test/features/personalization/consent.test.js
@@ -47,7 +47,7 @@ describe('canServeManifest', () => {
     expect(result).to.be.true;
   });
   it('should return true if the source is promo', () => {
-    const result = canServeManifest(null, 'promo', { nonMktg: false, mktg: false });
+    const result = canServeManifest(null, ['promo'], { nonMktg: false, mktg: false });
     expect(result).to.be.true;
   });
   it('should return true if the action is non-marketing and nonMktg is true', () => {

--- a/test/features/personalization/consent.test.js
+++ b/test/features/personalization/consent.test.js
@@ -9,10 +9,16 @@ describe('getConsentLevels', () => {
   beforeEach(() => {
     setCookie('kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent', '');
     setCookie('OptanonConsent', '');
+    sessionStorage.setItem('akamai', 'us');
   });
-  it('should return the default consent levels', () => {
+  it('should return the default consent levels for non-explicit consent countries', () => {
     const consent = getConsentLevels();
     expect(consent).to.deep.equal({ nonMktg: true, mktg: false });
+  });
+  it('should return everything true if the country is an explicit consent country', () => {
+    sessionStorage.setItem('akamai', 'ca');
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: false, mktg: false });
   });
   it('should return everything true if kndctr is in', () => {
     document.cookie = 'kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent=general=in';

--- a/test/features/personalization/consent.test.js
+++ b/test/features/personalization/consent.test.js
@@ -1,0 +1,77 @@
+import { expect } from '@esm-bundle/chai';
+import { getConsentLevels, canServeManifest } from '../../../libs/features/personalization/personalization.js';
+
+function setCookie(name, value) {
+  document.cookie = `${name}=${value}; path=/`;
+}
+
+describe('getConsentLevels', () => {
+  beforeEach(() => {
+    setCookie('kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent', '');
+    setCookie('OptanonConsent', '');
+  });
+  it('should return the default consent levels', () => {
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: true, mktg: false });
+  });
+  it('should return everything true if kndctr is in', () => {
+    document.cookie = 'kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent=general=in';
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: true, mktg: true });
+  });
+  it('should return everything false if kndctr is out', () => {
+    document.cookie = 'kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent=general=out';
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: false, mktg: false });
+  });
+  it('should return everything true if optanon is all on', () => {
+    document.cookie = 'OptanonConsent=C0001%3A1%2CC0002%3A1%2CC0003%3A1%2CC0004%3A1';
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: true, mktg: true });
+  });
+  it('should return everything false if optanon is all out', () => {
+    document.cookie = 'OptanonConsent=C0001%3A1%2CC0002%3A0%2CC0003%3A0%2CC0004%3A0';
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: false, mktg: false });
+  });
+  it('should return mixed if optanon is mixed', () => {
+    document.cookie = 'OptanonConsent=C0001%3A1%2CC0002%3A0%2CC0003%3A0%2CC0004%3A1';
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: false, mktg: true });
+  });
+});
+
+describe('canServeManifest', () => {
+  it('should return true if the action is non-personalization', () => {
+    const result = canServeManifest('none', null, { nonMktg: true, mktg: false });
+    expect(result).to.be.true;
+  });
+  it('should return true if the source is promo', () => {
+    const result = canServeManifest(null, 'promo', { nonMktg: true, mktg: false });
+    expect(result).to.be.true;
+  });
+  it('should return true if the action is non-marketing and nonMktg is true', () => {
+    const result = canServeManifest('non-marketing', null, { nonMktg: true, mktg: false });
+    expect(result).to.be.true;
+  });
+  it('should return false if the action is non-marketing and nonMktg is false', () => {
+    const result = canServeManifest('non-marketing', null, { nonMktg: false, mktg: false });
+    expect(result).to.be.false;
+  });
+  it('should return true if the action is null and mktg is true', () => {
+    const result = canServeManifest(null, null, { nonMktg: false, mktg: true });
+    expect(result).to.be.true;
+  });
+  it('should return false if the action is null and mktg is false', () => {
+    const result = canServeManifest(null, null, { nonMktg: true, mktg: false });
+    expect(result).to.be.false;
+  });
+  it('should return true if the action is marketing and mktg is true', () => {
+    const result = canServeManifest('marketing', null, { nonMktg: false, mktg: true });
+    expect(result).to.be.true;
+  });
+  it('should return false if the action is marketing and mktg is false', () => {
+    const result = canServeManifest('marketing', null, { nonMktg: true, mktg: false });
+    expect(result).to.be.false;
+  });
+});

--- a/test/features/personalization/consent.test.js
+++ b/test/features/personalization/consent.test.js
@@ -11,25 +11,6 @@ describe('getConsentLevels', () => {
     setCookie('OptanonConsent', '');
     sessionStorage.setItem('akamai', 'us');
   });
-  it('should return the default consent levels for non-explicit consent countries', () => {
-    const consent = getConsentLevels();
-    expect(consent).to.deep.equal({ nonMktg: true, mktg: true });
-  });
-  it('should return everything true if the country is an explicit consent country', () => {
-    sessionStorage.setItem('akamai', 'ca');
-    const consent = getConsentLevels();
-    expect(consent).to.deep.equal({ nonMktg: false, mktg: false });
-  });
-  it('should return everything true if kndctr is in', () => {
-    document.cookie = 'kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent=general=in';
-    const consent = getConsentLevels();
-    expect(consent).to.deep.equal({ nonMktg: true, mktg: true });
-  });
-  it('should return everything false if kndctr is out', () => {
-    document.cookie = 'kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent=general=out';
-    const consent = getConsentLevels();
-    expect(consent).to.deep.equal({ nonMktg: false, mktg: false });
-  });
   it('should return everything true if optanon is all on', () => {
     document.cookie = 'OptanonConsent=C0001%3A1%2CC0002%3A1%2CC0003%3A1%2CC0004%3A1';
     const consent = getConsentLevels();
@@ -44,6 +25,20 @@ describe('getConsentLevels', () => {
     document.cookie = 'OptanonConsent=C0001%3A1%2CC0002%3A0%2CC0003%3A0%2CC0004%3A1';
     const consent = getConsentLevels();
     expect(consent).to.deep.equal({ nonMktg: false, mktg: true });
+  });
+  it('should return mktg true if kndctr is in', () => {
+    document.cookie = 'kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_consent=general=in';
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: true, mktg: false });
+  });
+  it('should return everything true if the country is an explicit consent country', () => {
+    sessionStorage.setItem('akamai', 'ca');
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: false, mktg: false });
+  });
+  it('should return the default consent levels for non-explicit consent countries', () => {
+    const consent = getConsentLevels();
+    expect(consent).to.deep.equal({ nonMktg: true, mktg: true });
   });
 });
 

--- a/test/features/personalization/consent.test.js
+++ b/test/features/personalization/consent.test.js
@@ -13,7 +13,7 @@ describe('getConsentLevels', () => {
   });
   it('should return the default consent levels for non-explicit consent countries', () => {
     const consent = getConsentLevels();
-    expect(consent).to.deep.equal({ nonMktg: true, mktg: false });
+    expect(consent).to.deep.equal({ nonMktg: true, mktg: true });
   });
   it('should return everything true if the country is an explicit consent country', () => {
     sessionStorage.setItem('akamai', 'ca');

--- a/test/features/personalization/consent.test.js
+++ b/test/features/personalization/consent.test.js
@@ -56,7 +56,7 @@ describe('canServeManifest', () => {
     expect(result).to.be.true;
   });
   it('should return false if the action is non-marketing and nonMktg is false', () => {
-    const result = canServeManifest('non-marketing', null, { nonMktg: false, mktg: false });
+    const result = canServeManifest('non-marketing', null, { nonMktg: false, mktg: true });
     expect(result).to.be.false;
   });
   it('should return true if the action is null and mktg is true', () => {

--- a/test/features/personalization/consent.test.js
+++ b/test/features/personalization/consent.test.js
@@ -42,12 +42,12 @@ describe('getConsentLevels', () => {
 });
 
 describe('canServeManifest', () => {
-  it('should return true if the action is non-personalization', () => {
-    const result = canServeManifest('none', null, { nonMktg: true, mktg: false });
+  it('should return true if the action is core services', () => {
+    const result = canServeManifest('core services', null, { nonMktg: false, mktg: false });
     expect(result).to.be.true;
   });
   it('should return true if the source is promo', () => {
-    const result = canServeManifest(null, 'promo', { nonMktg: true, mktg: false });
+    const result = canServeManifest(null, 'promo', { nonMktg: false, mktg: false });
     expect(result).to.be.true;
   });
   it('should return true if the action is non-marketing and nonMktg is true', () => {

--- a/test/features/personalization/mocks/manifestWithNicknames.json
+++ b/test/features/personalization/mocks/manifestWithNicknames.json
@@ -15,6 +15,10 @@
       {
         "key": "manifest-execution-order",
         "value": "Normal"
+      },
+      {
+        "key": "manifest-marketing-action",
+        "value": "Non-marketing"
       }
     ]
   },


### PR DESCRIPTION
* getCookie function to parse cookies
* getConsentLevels to ascertain user consent to non-marketing and marketing activities
* canServeManifest to ascertain if a specific manifest can be served. manifests from the promo source are assumed to be core functionality.  All others are sources are assumed marketing unless otherwise specified.

Resolves: [MWPW-179126](https://jira.corp.adobe.com/browse/MWPW-179126)

Note: on preview links, the country is not set like it is on production.  Using the akamailLocale parameter is recommended to ensure consistent behavior.

**Test URLs:**
VPN into or be in a non-banner country (start with assumed consent):
- Before in non banner: https://main--cc--adobecom.aem.live/drafts/mepdev/fragments/2025/q3/ctest/consent-test?akamaiLocale=us
- After in non banner: https://main--cc--adobecom.aem.live/drafts/mepdev/fragments/2025/q3/ctest/consent-test?akamaiLocale=us&milolibs=mepmarketingactions

VPN into or be in a banner country (start assumed opt out):
- Before in banner: https://main--cc--adobecom.aem.live/drafts/mepdev/fragments/2025/q3/ctest/consent-test?akamaiLocale=gb
- After in banner: https://main--cc--adobecom.aem.live/drafts/mepdev/fragments/2025/q3/ctest/consent-test?akamaiLocale=gb&milolibs=mepmarketingactions

- Psi check: https://Mepmarketingactions--milo--adobecom.aem.page/?martech=off

Above each section, it explains the expected behavior based on your cookie settings. Start fresh or clear cookies and session storage to start in a new country.