### PR TITLE
feat: Add graybox experience ID extraction for CaaS payloads

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -657,7 +657,7 @@ export const getGrayboxExperienceId = (
   pathname = window.location?.pathname || '',
 ) => {
   // Only allow trusted Adobe graybox domains
-  const isAdobeGraybox = /^[^.]+\.([a-z]+-)?graybox\.adobe\.com$/.test(hostname);
+  const isAdobeGraybox = /^[^.]+\.([a-z-]+-)?graybox\.adobe\.com$/.test(hostname);
   const isStageGraybox = (
     (hostname.endsWith('.aem.page') || hostname.endsWith('.aem.live'))
     && hostname.includes('graybox')
@@ -666,7 +666,7 @@ export const getGrayboxExperienceId = (
   // Check for graybox.adobe.com format: https://[exn].[pn]-graybox.adobe.com/[path].html
   if (isAdobeGraybox) {
     const parts = hostname.split('.');
-    if (parts.length >= 3 && parts[1].includes('-graybox')) {
+    if (parts.length >= 3 && parts[1].includes('graybox')) {
       return parts[0]; // Return the experience ID (first part)
     }
   }

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -666,8 +666,10 @@ export const getGrayboxExperienceId = (
   // Check for graybox.adobe.com format: https://[exn].[pn]-graybox.adobe.com/[path].html
   if (isAdobeGraybox) {
     const parts = hostname.split('.');
-    if (parts.length >= 3 && parts[1].includes('graybox')) {
-      return parts[0]; // Return the experience ID (first part)
+    if (parts.length >= 3) {
+      if (parts[1] === 'graybox' || parts[1].includes('-graybox')) {
+        return parts[0]; // Return the experience ID (first part)
+      }
     }
   }
 

--- a/test/tools/send-to-caas/bulk-publish-to-caas.test.js
+++ b/test/tools/send-to-caas/bulk-publish-to-caas.test.js
@@ -1,0 +1,108 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { readFile } from '@web/test-runner-commands';
+
+// Mock the DOM environment
+document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+
+// Import the function we want to test
+import { getGrayboxExperienceId } from '../../../libs/blocks/caas/utils.js';
+
+describe('Bulk Publish to CaaS - Graybox Experience ID Integration', () => {
+  describe('getGrayboxExperienceId from host parameter', () => {
+    it('should extract experience ID from .graybox domain', () => {
+      const host = 'test-exp.graybox.adobe.com';
+      const result = getGrayboxExperienceId(host, '');
+      expect(result).to.equal('test-exp');
+    });
+
+    it('should extract experience ID from .**-graybox domain', () => {
+      const host = 'test-exp.bacom-graybox.adobe.com';
+      const result = getGrayboxExperienceId(host, '');
+      expect(result).to.equal('test-exp');
+    });
+
+    it('should extract experience ID from complex graybox patterns', () => {
+      const host = 'qa-demo.enterprise-stage-graybox.adobe.com';
+      const result = getGrayboxExperienceId(host, '');
+      expect(result).to.equal('qa-demo');
+    });
+
+    it('should return null for non-graybox domains', () => {
+      const host = 'business.adobe.com';
+      const result = getGrayboxExperienceId(host, '');
+      expect(result).to.be.null;
+    });
+
+    it('should return null for malformed graybox hosts', () => {
+      const host = 'graybox.adobe.com';
+      const result = getGrayboxExperienceId(host, '');
+      expect(result).to.be.null;
+    });
+
+    it('should handle empty host parameter', () => {
+      const result = getGrayboxExperienceId('', '');
+      expect(result).to.be.null;
+    });
+
+    it('should handle null/undefined host parameter', () => {
+      // The function expects string parameters, so we should test with empty strings instead
+      const result1 = getGrayboxExperienceId('', '');
+      const result2 = getGrayboxExperienceId('', '');
+      expect(result1).to.be.null;
+      expect(result2).to.be.null;
+    });
+  });
+
+  describe('Graybox Experience ID in CaaS Payload', () => {
+    it('should add gbExperienceID to caasProps when graybox host is detected', () => {
+      // This test simulates the integration logic in bulk-publish-to-caas.js
+      const host = 'test-exp.graybox.adobe.com';
+      const grayboxExperienceId = getGrayboxExperienceId(host, '');
+      
+      // Simulate the caasProps object
+      const caasProps = {
+        entityId: 'test-entity-id',
+        title: 'Test Title',
+        // ... other properties
+      };
+
+      // Simulate adding the graybox experience ID
+      if (grayboxExperienceId) {
+        caasProps.gbExperienceID = grayboxExperienceId;
+      }
+
+      expect(caasProps.gbExperienceID).to.equal('test-exp');
+    });
+
+    it('should not add gbExperienceID when no graybox pattern is found', () => {
+      const host = 'business.adobe.com';
+      const grayboxExperienceId = getGrayboxExperienceId(host, '');
+      
+      const caasProps = {
+        entityId: 'test-entity-id',
+        title: 'Test Title',
+      };
+
+      if (grayboxExperienceId) {
+        caasProps.gbExperienceID = grayboxExperienceId;
+      }
+
+      expect(caasProps.gbExperienceID).to.be.undefined;
+    });
+
+    it('should handle various graybox host patterns correctly', () => {
+      const testCases = [
+        { host: 'demo.graybox.adobe.com', expected: 'demo' },
+        { host: 'stage-test.bacom-graybox.adobe.com', expected: 'stage-test' },
+        { host: 'prod-demo.enterprise-prod-graybox.adobe.com', expected: 'prod-demo' },
+        { host: 'qa.bacom-stage-graybox.adobe.com', expected: 'qa' },
+      ];
+
+      testCases.forEach(({ host, expected }) => {
+        const result = getGrayboxExperienceId(host, '');
+        expect(result).to.equal(expected, `Failed for host: ${host}`);
+      });
+    });
+  });
+});

--- a/test/tools/send-to-caas/mocks/body.html
+++ b/test/tools/send-to-caas/mocks/body.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Page</title>
+</head>
+<body>
+    <div id="test-container">
+        <h1>Test Page</h1>
+        <div class="card-metadata">
+            <div><a href="https://example.com">Test Link</a></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -14,6 +14,7 @@ import {
   getConfig,
   setConfig,
 } from './send-utils.js';
+import { getGrayboxExperienceId } from '../../libs/blocks/caas/utils.js';
 import comEnterpriseToCaasTagMap from './comEnterpriseToCaasTagMap.js';
 
 const BODY = document.body;
@@ -233,7 +234,15 @@ const processData = async (data, accessToken) => {
         continue;
       }
 
+      // Extract graybox experience ID from the host
+      const grayboxExperienceId = getGrayboxExperienceId(host, '');
+
       const caasProps = getCaasProps(caasMetadata, pageUrl);
+
+      // Add graybox experience ID to caasProps if found
+      if (grayboxExperienceId) {
+        caasProps.gbExperienceID = grayboxExperienceId;
+      }
 
       const response = await postDataToCaaS({
         accessToken,


### PR DESCRIPTION
- Enhance getGrayboxExperienceId function in caas/utils.js to handle both .graybox and .**-graybox patterns
- Integrate graybox experience ID extraction in bulk-publish-to-caas.js
- Add gbExperienceID field to CaaS payloads when graybox hosts are detected
- Remove duplicate function implementation and use centralized caas/utils.js function
- Add comprehensive test coverage for graybox experience ID functionality

Changes:
- libs/blocks/caas/utils.js: Enhanced graybox pattern matching
- tools/send-to-caas/bulk-publish-to-caas.js: Added graybox ID integration
- test/tools/send-to-caas/: Added comprehensive test suite

Resolves: MWPW-179291

<!-- Before submitting, please review all open PRs. -->

* Add your
* Specific
* Features or fixes

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://<branch>--milo--adobecom.aem.page/?martech=off
