### PR TITLE
MWPW-177666: add card style to dropdown of caas config

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -77,6 +77,7 @@ const defaultOptions = {
     'text-card': 'Text Card',
     'icon-card': 'Icon Card',
     'news-card': 'News Card',
+    'horizontal-card': 'Horizontal Card',
     'custom-card': 'Custom Card',
     'blade-card': 'Blade Card',
   },


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Adds the horizontal card style to the caas card collection configurator drop down.

Resolves: [MWPW-177666](https://jira.corp.adobe.com/browse/MWPW-177666)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-177666--milo--sheridansunier.aem.page/?martech=off
