### PR TITLE
MWPW-178759 Auto Cache Clear on Release

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -1,0 +1,56 @@
+name: Clear Akamai Cache
+
+on:
+  workflow_call:
+    inputs:
+      cpCode:
+        description: 'CP Code'
+        required: true
+        type: string
+      network:
+        description: 'Network'
+        required: true
+        type: string
+      command:
+        description: 'Command'
+        required: true
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      cpCode:
+        description: 'CP Code: Prod - 1318762 / Stage - 1318533'
+        type: string
+        required: true
+        default: '1318762'
+      network:
+        description: 'Network'
+        type: choice
+        required: true
+        default: 'staging'
+        options:
+          - 'staging'          
+          - 'production'
+      command:
+        description: 'Command'
+        type: choice
+        required: true
+        default: 'invalidate'
+        options:
+          - 'invalidate'          
+          - 'delete'
+
+jobs:
+  clear-cache:     
+    name: Clear Cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clear Cache
+        uses: jdmevo123/akamai-purge-action@1.7
+        env:
+          EDGERC: ${{ secrets.EDGERC }}
+        with:
+          command: ${{ inputs.command }}
+          type: 'cpcode'
+          ref: ${{ inputs.cpCode }}
+          network: ${{ inputs.network }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - stage
+
+jobs:
+  clear-stage-cache:
+    if: github.ref == 'refs/heads/stage'
+    uses: ./.github/workflows/clear-cache.yml
+    with:
+      cpCode: 1318533
+      network: production
+      command: delete
+    secrets: inherit
+
+  clear-prod-cache:
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/clear-cache.yml
+    with:
+      cpCode: 1318762
+      network: production
+      command: delete
+
+    secrets: inherit


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

As a Web Platform Services team member, I want to see Milo projects self-maintain their CDN caches in both Akamai stage and prod networks so that during the period of "production spoof testing" of a CDN release on [www.adobe.com](http://www.adobe.com/) on Akamai stage

- Manual option is available as well 

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-178759--milo--adobecom.aem.page/?martech=off
