### PR TITLE
MWPW-175850 Icon tooltips: support any icon + responsive placement; legacy-compatible

### DIFF
--- a/libs/features/icons/icons.css
+++ b/libs/features/icons/icons.css
@@ -107,6 +107,127 @@
   display: block;
 }
 
+/* Responsive placement overrides */
+@media (min-width: 600px) {
+  .milo-tooltip.dir-tablet-left::before {
+    left: initial;
+    margin: initial;
+    right: 100%;
+    margin-right: 8px;
+  }
+
+  .milo-tooltip.dir-tablet-left::after {
+    left: 0;
+    margin-right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    border: 8px solid #0469E3;
+    border-color: transparent transparent transparent #0469E3;
+  }
+
+  .milo-tooltip.dir-tablet-top::before {
+    left: calc(50% - 11px);
+    transform: translateX(-50%) translateY(-100%);
+    top: -6px;
+    margin-bottom: 15px;
+  }
+
+  .milo-tooltip.dir-tablet-top::after {
+    left: 50%;
+    top: 2px;
+    transform: translateY(-50%);
+    border: 8px solid #0469E3;
+    border-color: #0469E3 transparent transparent;
+  }
+
+  .milo-tooltip.dir-tablet-right::before {
+    left: 100%;
+    margin-left: 7px;
+    right: initial;
+    margin-right: initial;
+  }
+
+  .milo-tooltip.dir-tablet-right::after {
+    left: 100%;
+    margin-left: -8px;
+    border-color: transparent #0469E3 transparent transparent;
+  }
+
+  .milo-tooltip.dir-tablet-bottom::before {
+    left: calc(50% - 11px);
+    transform: translateX(-50%);
+    top: 100%;
+    margin-top: 9px;
+  }
+
+  .milo-tooltip.dir-tablet-bottom::after {
+    left: 50%;
+    top: calc(100% + 1px);
+    transform: translateY(-50%);
+    border-color: transparent transparent #0469E3;
+  }
+}
+
+@media (min-width: 1200px) {
+  .milo-tooltip.dir-desktop-left::before {
+    left: initial;
+    margin: initial;
+    right: 100%;
+    margin-right: 8px;
+  }
+
+  .milo-tooltip.dir-desktop-left::after {
+    left: 0;
+    margin-right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    border: 8px solid #0469E3;
+    border-color: transparent transparent transparent #0469E3;
+  }
+
+  .milo-tooltip.dir-desktop-top::before {
+    left: calc(50% - 11px);
+    transform: translateX(-50%) translateY(-100%);
+    top: -6px;
+    margin-bottom: 15px;
+  }
+
+  .milo-tooltip.dir-desktop-top::after {
+    left: 50%;
+    top: 2px;
+    transform: translateY(-50%);
+    border: 8px solid #0469E3;
+    border-color: #0469E3 transparent transparent;
+  }
+
+  .milo-tooltip.dir-desktop-right::before {
+    left: 100%;
+    margin-left: 7px;
+    right: initial;
+    margin-right: initial;
+  }
+
+  .milo-tooltip.dir-desktop-right::after {
+    left: 100%;
+    margin-left: -8px;
+    border-color: transparent #0469E3 transparent transparent;
+  }
+
+  .milo-tooltip.dir-desktop-bottom::before {
+    left: calc(50% - 11px);
+    transform: translateX(-50%);
+    top: 100%;
+    margin-top: 9px;
+  }
+
+  .milo-tooltip.dir-desktop-bottom::after {
+    left: 50%;
+    top: calc(100% + 1px);
+    transform: translateY(-50%);
+    border-color: transparent transparent #0469E3;
+  }
+}
+
 .milo-tooltip.hide-tooltip::before,
 .milo-tooltip.hide-tooltip::after {
   display: none;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1101,6 +1101,19 @@ async function decorateHeader() {
 }
 
 async function decorateIcons(area, config) {
+  // Materialize icon tokens inside emphasis wrappers for tooltip authoring
+  const emWrappers = area.querySelectorAll('em');
+  emWrappers.forEach((em) => {
+    if (!em.textContent.includes('|')) return;
+    const hasSpanIcon = em.querySelector(':scope > span.icon');
+    if (hasSpanIcon) return;
+    const match = em.textContent.match(/:(?<name>[a-z0-9-]+):/i);
+    if (!match?.groups?.name) return;
+    const iconName = match.groups.name.toLowerCase();
+    const span = createTag('span', { class: `icon icon-${iconName}` });
+    em.insertBefore(span, em.firstChild);
+  });
+
   const icons = area.querySelectorAll('span.icon');
   if (icons.length === 0) return;
   const { base, iconsExcludeBlocks } = config;

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -123,6 +123,20 @@ describe('Icon Support', () => {
     expect(tooltip).to.exist;
   });
 
+  it('Creates responsive tooltip classes (desktop, tablet, mobile)', async () => {
+    const tooltipWrapper = createTag('em', {}, 'top, left, bottom|Responsive tooltip text.');
+    const tooltipIcon = createTag('span', { class: 'icon icon-tooltip' });
+    tooltipWrapper.appendChild(tooltipIcon);
+    document.body.appendChild(tooltipWrapper);
+
+    await loadIcons([tooltipIcon], config);
+    const tooltip = document.querySelector('.milo-tooltip');
+    expect(tooltip).to.exist;
+    expect(tooltip.classList.contains('bottom')).to.be.true; // base/mobile
+    expect(tooltip.classList.contains('dir-tablet-left')).to.be.true;
+    expect(tooltip.classList.contains('dir-desktop-top')).to.be.true;
+  });
+
   it('Handles invalid SVG response', async () => {
     const icon = createTag('span', { class: 'icon icon-invalid' });
     document.body.appendChild(icon);


### PR DESCRIPTION
Implements responsive tooltip placement and support for any icon token within <em> wrappers.\n\n- Adds parsing of :icon: in <em> wrappers to materialize <span class="icon">.\n- Extends decorateToolTip to parse single or responsive placement (desktop, tablet, mobile).\n- Forces legacy :tooltip: to icon-info.\n- Adds CSS overrides for dir-tablet-* and dir-desktop-* at 600px and 1200px.\n- Adds unit test for responsive classes.\n\nTicket: MWPW-175850

