### PR TITLE
MWPW-178722 supplemental text authored as center is seen centre of marquee area in desktop and ipad

### DIFF
--- a/libs/blocks/hero-marquee/hero-marquee.css
+++ b/libs/blocks/hero-marquee/hero-marquee.css
@@ -287,10 +287,6 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
   height: auto;
 }
 
-.hero-marquee .row-supplemental.center {
-  text-align: center;
-}
-
 /* mobile ONLY */
 @media (max-width: 600px) {
   .hero-marquee .con-button {
@@ -346,6 +342,10 @@ html[dir="rtl"] .hero-marquee li.icon-item span.icon {
 
   body.mweb-enabled .hero-marquee .m-lockup .lockup-area img {
     height: 24px;
+  }
+
+  .hero-marquee .row-supplemental.center {
+    text-align: center;
   }
 }
 
@@ -457,6 +457,10 @@ body.mweb-enabled .hero-marquee .action-area a:not(.con-button),
 body.mweb-enabled .hero-marquee .con-block.row-text:has(.action-area) + .con-block.row-text .row-wrapper {
   align-self: center;
   font-size: 17px;
+}
+
+.hero-marquee .body-bold {
+  font-weight: 700;
 }
 
 /* desktop up */


### PR DESCRIPTION
supplemental text authored as center is seen centre of marquee area in desktop and ipad

* Add your
* Specific
* Features or fixes

Resolves: [[MWPW-178722](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/suhjain/m2-folder/hero-marquee/document
- After: https://marquee-error--milo--suhjainadobe.aem.page/drafts/suhjain/m2-folder/hero-marquee/document


