### PR TITLE
[MWPW-179202] Implement solution for no result found in language selector

### DIFF
--- a/libs/blocks/language-selector/language-selector.css
+++ b/libs/blocks/language-selector/language-selector.css
@@ -124,6 +124,21 @@
   margin-bottom: 4px;
 }
 
+.language-item.no-search-result {
+  padding: 8px 16px;
+  color: #505050;
+  cursor: default;
+  pointer-events: none;
+}
+
+.no-search-result-text {
+  font-size: var(--type-body-xxs-size);
+  font-family: var(--body-font-family);
+  color: var(--color-gray-500);
+  line-height: var(--type-body-xxs-lh);
+  display: block;
+}
+
 .language-dropdown.fixed-height {
   min-height: var(--dropdown-initial-height, 0);
 }

--- a/libs/blocks/language-selector/language-selector.css
+++ b/libs/blocks/language-selector/language-selector.css
@@ -126,16 +126,15 @@
 
 .language-item.no-search-result {
   padding: 8px 16px;
-  color: #505050;
   cursor: default;
   pointer-events: none;
 }
 
 .no-search-result-text {
   font-size: var(--type-body-xxs-size);
-  font-family: var(--body-font-family);
-  color: var(--color-gray-500);
   line-height: var(--type-body-xxs-lh);
+  font-family: var(--body-font-family);
+  color: #505050;
   display: block;
 }
 

--- a/libs/blocks/language-selector/language-selector.js
+++ b/libs/blocks/language-selector/language-selector.js
@@ -186,6 +186,7 @@ function renderLanguages({
   currentLang,
   selectedLangItemRef,
   activeIndexRef,
+  noSearchResult,
 }) {
   return (searchTerm = '') => {
     if (!languagesList.length) return [];
@@ -200,48 +201,63 @@ function renderLanguages({
       || isIetfMatch(lang.langObj, searchLower)
       || isEnglishMappingMatch(lang.name, searchLower, searchNormalized, langMapToEnglish));
     const fragment = document.createDocumentFragment();
-    filteredLanguages.forEach((lang, idx) => {
-      const langItem = createTag('li', {
-        class: 'language-item',
-        id: `language-option-${idx}`,
-        role: 'none',
+
+    if (filteredLanguages.length === 0 && searchTerm.trim() && noSearchResult) {
+      const noResultItem = createTag('li', { 
+        class: 'language-item no-search-result', 
+        role: 'status',
+        'aria-live': 'polite',
+        'aria-label': 'No search results found'
       });
-      if (lang.name === currentLang.name) {
-        langItem.classList.add('selected');
-        selectedLangItemRef.current = langItem;
-        if (activeIndexRef.current === -1) activeIndexRef.current = idx;
-      }
-      const langLink = createTag('a', {
-        href: `${window.location.origin}${lang.prefix ? `/${lang.prefix}${window.location.pathname.replace(/^\/[a-zA-Z-]+/, '')}` : window.location.pathname.replace(/^\/[a-zA-Z-]+/, '')}`,
-        class: 'language-link',
-        role: 'option',
-        'aria-selected': lang.name === currentLang.name ? 'true' : 'false',
-        tabindex: '-1',
-      });
-      langLink.innerHTML = `
-        <span class="language-name">${lang.name}</span>
-        ${lang.name === currentLang.name ? CHECKMARK_SVG : ''}
-      `;
-      langLink.addEventListener('click', (e) => {
-        e.preventDefault();
-        const { pathname, href } = window.location;
-        const currentLangForPath = getCurrentLanguage(filteredLanguages);
-        const currentPrefix = currentLangForPath && currentLangForPath.prefix ? `/${currentLangForPath.prefix}` : '';
-        const hasPrefix = currentPrefix && pathname.startsWith(`${currentPrefix}/`);
-        const path = href.replace(window.location.origin + (hasPrefix ? currentPrefix : ''), '').replace('#langnav', '');
-        const newPath = lang.prefix ? `/${lang.prefix}${path}` : path;
-        const fullUrl = `${window.location.origin}${newPath}`;
-        handleEvent({
-          prefix: lang.prefix,
-          link: { href: fullUrl },
-          callback: (url) => {
-            window.open(url, e.ctrlKey || e.metaKey ? '_blank' : '_self');
-          },
+      const noResultText = createTag('span', { class: 'no-search-result-text', role: 'text', 'aria-label': noSearchResult.trim() });
+      noResultText.innerHTML = noSearchResult.trim().replace(/[\n|]+/g, '<br><span style="display: block; height: 8px;"></span>');
+      noResultItem.appendChild(noResultText);
+      fragment.appendChild(noResultItem);
+    } else {
+      filteredLanguages.forEach((lang, idx) => {
+        const langItem = createTag('li', {
+          class: 'language-item',
+          id: `language-option-${idx}`,
+          role: 'none',
         });
+        if (lang.name === currentLang.name) {
+          langItem.classList.add('selected');
+          selectedLangItemRef.current = langItem;
+          if (activeIndexRef.current === -1) activeIndexRef.current = idx;
+        }
+        const langLink = createTag('a', {
+          href: `${window.location.origin}${lang.prefix ? `/${lang.prefix}${window.location.pathname.replace(/^\/[a-zA-Z-]+/, '')}` : window.location.pathname.replace(/^\/[a-zA-Z-]+/, '')}`,
+          class: 'language-link',
+          role: 'option',
+          'aria-selected': lang.name === currentLang.name ? 'true' : 'false',
+          tabindex: '-1',
+        });
+        langLink.innerHTML = `
+          <span class="language-name">${lang.name}</span>
+          ${lang.name === currentLang.name ? CHECKMARK_SVG : ''}
+        `;
+        langLink.addEventListener('click', (e) => {
+          e.preventDefault();
+          const { pathname, href } = window.location;
+          const currentLangForPath = getCurrentLanguage(filteredLanguages);
+          const currentPrefix = currentLangForPath && currentLangForPath.prefix ? `/${currentLangForPath.prefix}` : '';
+          const hasPrefix = currentPrefix && pathname.startsWith(`${currentPrefix}/`);
+          const path = href.replace(window.location.origin + (hasPrefix ? currentPrefix : ''), '').replace('#langnav', '');
+          const newPath = lang.prefix ? `/${lang.prefix}${path}` : path;
+          const fullUrl = `${window.location.origin}${newPath}`;
+          handleEvent({
+            prefix: lang.prefix,
+            link: { href: fullUrl },
+            callback: (url) => {
+              window.open(url, e.ctrlKey || e.metaKey ? '_blank' : '_self');
+            },
+          });
+        });
+        langItem.appendChild(langLink);
+        fragment.appendChild(langItem);
       });
-      langItem.appendChild(langLink);
-      fragment.appendChild(langItem);
-    });
+    }
+
     languageList.appendChild(fragment);
     if (activeIndexRef.current >= 0 && filteredLanguages[activeIndexRef.current]) {
       languageList.setAttribute('aria-activedescendant', `language-option-${activeIndexRef.current}`);
@@ -272,6 +288,7 @@ function setupDropdownEvents({
   currentLang,
   selectedLangItemRef,
   activeIndexRef,
+  noSearchResult,
 }) {
   let isDraggingDropdown = false;
   let dragStartY = 0;
@@ -344,6 +361,7 @@ function setupDropdownEvents({
     currentLang,
     selectedLangItemRef,
     activeIndexRef,
+    noSearchResult,
   });
 
   async function openDropdown() {
@@ -520,6 +538,7 @@ export default async function init(block) {
   const placeholders = divs[0].querySelectorAll('p');
   const ariaLabel = placeholders[0]?.textContent.trim();
   const placeholderText = placeholders[1]?.textContent.trim();
+  const noSearchResult = placeholders[2]?.textContent.trim();
   if (!links.length) return;
 
   const languagesList = getLanguages(links, languages, locales);
@@ -558,5 +577,6 @@ export default async function init(block) {
     currentLang,
     selectedLangItemRef,
     activeIndexRef,
+    noSearchResult,
   });
 }

--- a/libs/blocks/language-selector/language-selector.js
+++ b/libs/blocks/language-selector/language-selector.js
@@ -180,6 +180,15 @@ const isEnglishMappingMatch = (name, searchLower, searchNormalized, mappingData)
     || getNormalizedText(englishMapping.Native) === nativeNameNormalized);
 };
 
+function escapeHTML(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 function renderLanguages({
   languageList,
   languagesList,
@@ -203,14 +212,16 @@ function renderLanguages({
     const fragment = document.createDocumentFragment();
 
     if (filteredLanguages.length === 0 && searchTerm.trim() && noSearchResult) {
-      const noResultItem = createTag('li', { 
-        class: 'language-item no-search-result', 
+      const noResultItem = createTag('li', {
+        class: 'language-item no-search-result',
         role: 'status',
         'aria-live': 'polite',
-        'aria-label': 'No search results found'
+        'aria-label': 'No search results found',
       });
       const noResultText = createTag('span', { class: 'no-search-result-text', role: 'text', 'aria-label': noSearchResult.trim() });
-      noResultText.innerHTML = noSearchResult.trim().replace(/[\n|]+/g, '<br><span style="display: block; height: 8px;"></span>');
+      // Escape before inserting, then format line breaks
+      const safeHtml = escapeHTML(noSearchResult.trim()).replace(/[\n|]+/g, '<br><span style="display: block; height: 8px;"></span>');
+      noResultText.innerHTML = safeHtml;
       noResultItem.appendChild(noResultText);
       fragment.appendChild(noResultItem);
     } else {

--- a/test/blocks/language-selector/language-selector.test.js
+++ b/test/blocks/language-selector/language-selector.test.js
@@ -737,6 +737,92 @@ describe('Language Selector Block - Network Event Handling', () => {
     }
     stub.restore();
   });
+
+  it('displays no search result message with proper accessibility attributes', async () => {
+    // Wait for dropdown to be fully loaded using fake timers
+    await clock.runAllAsync();
+
+    // Get the search input and type a search term that won't match any language
+    const searchInput = document.querySelector('.search-input');
+    expect(searchInput).to.exist;
+
+    // Type a search term that won't match any language
+    searchInput.value = 'xyz123';
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Wait for the search to process using fake timers
+    await clock.runAllAsync();
+
+    // Check if no search result message is displayed
+    const noSearchResultItem = document.querySelector('.language-item.no-search-result');
+    expect(noSearchResultItem).to.exist;
+
+    // Check accessibility attributes
+    expect(noSearchResultItem.getAttribute('role')).to.equal('status');
+    expect(noSearchResultItem.getAttribute('aria-live')).to.equal('polite');
+    expect(noSearchResultItem.getAttribute('aria-label')).to.equal('No search results found');
+
+    // Check the text content
+    const noSearchResultText = noSearchResultItem.querySelector('.no-search-result-text');
+    expect(noSearchResultText).to.exist;
+    expect(noSearchResultText.getAttribute('role')).to.equal('text');
+    expect(noSearchResultText.getAttribute('aria-label')).to.equal('Your search did not yield any results.\nTry a different search term.');
+
+    // Check that the text content is properly formatted with line breaks
+    expect(noSearchResultText.innerHTML).to.include('<br>');
+    expect(noSearchResultText.innerHTML).to.include('Your search did not yield any results');
+    expect(noSearchResultText.innerHTML).to.include('Try a different search term');
+    expect(noSearchResultText.innerHTML).to.include('<span style="display: block; height: 8px;"></span>');
+  });
+
+  it('does not display no search result message when search matches languages', async () => {
+    await clock.runAllAsync();
+    const searchInput = document.querySelector('.search-input');
+    expect(searchInput).to.exist;
+    searchInput.value = 'English';
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+    await clock.runAllAsync();
+    const noSearchResultItem = document.querySelector('.language-item.no-search-result');
+    expect(noSearchResultItem).to.not.exist;
+    const languageItems = document.querySelectorAll('.language-item:not(.no-search-result)');
+    expect(languageItems.length).to.be.greaterThan(0);
+  });
+
+  it('handles line breaks with both newline and pipe characters', async () => {
+    // Wait for dropdown to be fully loaded using fake timers
+    await clock.runAllAsync();
+
+    // Get the search input and type a search term that won't match any language
+    const searchInput = document.querySelector('.search-input');
+    expect(searchInput).to.exist;
+
+    // Type a search term that won't match any language
+    searchInput.value = 'xyz123';
+    searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Wait for the search to process using fake timers
+    await clock.runAllAsync();
+
+    // Check if no search result message is displayed
+    const noSearchResultItem = document.querySelector('.language-item.no-search-result');
+    expect(noSearchResultItem).to.exist;
+
+    // Check the text content
+    const noSearchResultText = noSearchResultItem.querySelector('.no-search-result-text');
+    expect(noSearchResultText).to.exist;
+
+    // Check that the text content is properly formatted with line breaks
+    expect(noSearchResultText.innerHTML).to.include('<br>');
+    expect(noSearchResultText.innerHTML).to.include('Your search did not yield any results');
+    expect(noSearchResultText.innerHTML).to.include('Try a different search term');
+    expect(noSearchResultText.innerHTML).to.include('<span style="display: block; height: 8px;"></span>');
+
+    // Verify that consecutive line break characters are treated as single breaks
+    // The regex should replace \n with <br> and not create double line breaks
+    const htmlContent = noSearchResultText.innerHTML;
+    const brCount = (htmlContent.match(/<br>/g) || []).length;
+    expect(brCount).to.equal(1); // Should only have one <br> tag
+  });
 });
 
 afterEach(() => {

--- a/test/blocks/language-selector/mocks/languages.html
+++ b/test/blocks/language-selector/mocks/languages.html
@@ -6,6 +6,9 @@
   <div class="language-selector">
     <div>
       <p>Search</p>
+      <p>Search language</p>
+      <p>Your search did not yield any results.
+Try a different search term.</p>
       <ul>
         <li><a href="/#_dnt">English(US)</a></li>
         <li><a href="/en/gb/#_dnt">English(UK)</a></li>


### PR DESCRIPTION
* Display a text when no results are found in search in language-selector


Resolves: [MWPW-179202](https://jira.corp.adobe.com/browse/MWPW-179202)

**Test URLs:**
Milo:
**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ruchika/language/document1?martech=off
- After: https://search-enhancement--milo--adobecom.aem.page/drafts/ruchika/language/document1?martech=off

News
- Before: https://main--news--adobecom.hlx.page/drafts/ruchika/lang-selector?milolibs=stage&martech=off
- After: https://main--news--adobecom.hlx.page/drafts/ruchika/lang-selector?milolibs=search-enhancement&martech=off

Testing Notes:
1. Expected behavior can be properly tested on newsroom link provided above as that has proper language object created in config.
2. Make sure search functionality works as before.
3. Localized string should be displayed is the placeholder for no search string is authored in the language-selector block. If not authored no error should be thrown and behavior should be same as it it currently on live
4. For more details on how to author the values in placeholder file for text to be shown when no result found in search refer to jira ticket.
