### PR TITLE
[MWPW-178491] mWeb Rollout Ps Test | Aside block

### DIFF
--- a/libs/blocks/aside/aside.css
+++ b/libs/blocks/aside/aside.css
@@ -44,6 +44,11 @@
   margin-bottom: var(--spacing-xs);
 }
 
+.aside.container-mobile [class^="detail-"] strong {
+  font-weight: 500;
+  text-transform: none;
+}
+
 .aside .title-l {
   font-size: var(--type-body-m-size);
   line-height: var(--type-body-m-lh);
@@ -1278,4 +1283,10 @@
   display: inline-block;
   height: unset;
   margin-bottom: unset;
+}
+
+@media screen and (max-width: 599px) {
+  .aside.container-mobile .supplemental-text{
+    font-weight: 700;
+  }
 }

--- a/libs/blocks/aside/aside.js
+++ b/libs/blocks/aside/aside.js
@@ -18,9 +18,9 @@ import { decorateBlockText, decorateIconStack, applyHoverPlay, decorateBlockBg, 
 import { createTag, getConfig, loadStyle } from '../../utils/utils.js';
 
 // standard/default aside uses same text sizes as the split
-const variants = ['split', 'inline', 'notification'];
+const variants = ['split', 'inline', 'notification', 'container-mobile'];
 const sizes = ['extra-small', 'small', 'medium', 'large'];
-const [split, inline, notification] = variants;
+const [split, inline, notification, containerMobile] = variants;
 const [xsmall, small, medium, large] = sizes;
 const blockConfig = {
   [split]: ['xl', 's', 'm'],
@@ -31,6 +31,7 @@ const blockConfig = {
     [medium]: ['s', 's'],
     [large]: ['l', 'm'],
   },
+  [containerMobile]: ['xl', 'l', 'l'],
 };
 const FORMAT_REGEX = /^format:/i;
 const closeSvg = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">


### PR DESCRIPTION

* Added container-mobile variant to aside block.

Resolves: [MWPW-178491](https://jira.corp.adobe.com/browse/MWPW-178491)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-178491-mweb-aside-block--milo--hkuraware.aem.page/?martech=off
