### PR TITLE
[MWPW-174755] Update carousel nav colors for a11y

### DIFF
--- a/libs/blocks/carousel/carousel.css
+++ b/libs/blocks/carousel/carousel.css
@@ -1,26 +1,22 @@
 .carousel {
-  /* Scope variables to carousel */
   --carousel-slide-button-height: 40px;
   --carousel-slide-button-width: var(--carousel-slide-button-height);
   --carousel-slide-button-height-desktop: 40px;
   --carousel-slide-button-width-desktop: var(--carousel-slide-button-height-desktop);
+  --carousel-nav-background: #242424;
+  --carousel-nav-background-dark: #e6e6e6;
+  --carousel-nav-button-background-hover: #d5d5d5;
+  --carousel-nav-button-background-active: #b1b1b1;
+  --carousel-nav-button-background-focus: #147af3;
   --carousel-focus-color: #109cde;
-  --carousel-ligthbox-active-text-color: var(--color-white);
-  --carousel-button-background-color: #e6e6e6;
-  --carousel-button-box-shadow-color: #2680eb;
-  --carousel-button-border-color: #e1e1e1;
-  --carousel-button-border-hover-color: #cacaca;
-  --carousel-button-border-focus-color: #378ef0;
-  --carousel-indicator-background-color: var(--carousel-button-border-hover-color);
-  --carousel-indicator-active-background-color: #242424;
+  --carousel-indicator-background-color: #cacaca;
   --carousel-expand-background-color: rgb(255 255 255 / 75%);
   --carousel-expand-border-color: rgb(116 116 116 / 30%);
-  --carousel-nav-arrow-color: var(--carousel-indicator-active-background-color);
   --s-rounded-corners: 4px;
   --m-rounded-corners: 8px;
   --l-rounded-corners: 16px;
   --full-rounded-corners: 50%;
-  --indicator-multiplyer: 0;
+  --indicator-multiplier: 0;
 
   position: relative;
   margin-bottom: 1.8rem;
@@ -53,7 +49,7 @@
   align-items: center;
   align-self: center;
   justify-content: space-between;
-  background: rgb(36 36 36 / 5%);
+  background: var(--carousel-nav-background);
   border-radius: 25px;
   padding: 4px;
   order: 3;
@@ -75,12 +71,12 @@
 
 .dark .carousel .carousel-button-container,
 .carousel.dark .carousel-button-container {
-  background: rgb(255 255 255 / 25%);
+  background: var(--carousel-nav-background-dark);
 }
 
 .carousel .carousel-previous,
 .carousel .carousel-next {
-  background-color: var(--carousel-button-background-color);
+  background-color: var(--carousel-nav-background-dark);
   border-radius: 100%;
   border: 2px solid transparent;
   display: flex;
@@ -90,7 +86,7 @@
   outline: 0;
   height: var(--carousel-slide-button-height);
   width:  var(--carousel-slide-button-width);
-  transition: background .3s ease, outline .3s ease, border .3s ease, box-shadow .3s ease;
+  transition: background .3s ease, outline-color .3s ease, border-color .3s ease;
   z-index: 2;
 }
 
@@ -108,30 +104,30 @@
 
 .carousel .carousel-previous:hover,
 .carousel .carousel-next:hover {
-  background-color: #d5d5d5;
+  background-color: var(--carousel-nav-button-background-hover);
 }
 
 .carousel .carousel-previous:active,
 .carousel .carousel-next:active {
-  background-color: #b1b1b1;
+  background-color: var(--carousel-nav-button-background-active);
 }
 
 .carousel .carousel-previous:focus,
 .carousel .carousel-next:focus {
   border-color: var(--color-white);
-  outline: 2px solid var(--carousel-button-border-focus-color);
+  outline: 2px solid var(--carousel-nav-button-background-focus);
 }
 
 .dark .carousel .carousel-previous,
 .dark .carousel .carousel-next,
 .carousel.dark .carousel-previous,
 .carousel.dark .carousel-next {
-  background-color: var(--carousel-nav-arrow-color);
+  background-color: var(--carousel-nav-background);
 }
 
 .carousel .carousel-previous path,
 .carousel .carousel-next path {
-  fill: var(--carousel-nav-arrow-color);
+  fill: var(--carousel-nav-background);
 }
 
 .dark .carousel .carousel-previous path,
@@ -197,7 +193,7 @@ html[dir="rtl"] .carousel-slides .section.carousel-slide {
 .carousel-slide.active,
 .carousel.fade .carousel-slide.active {
   opacity: 1;
-} 
+}
 
 .carousel-slides.is-ready,
 .carousel-slides.is-ready.is-reversing,
@@ -240,11 +236,11 @@ html[dir="rtl"] .carousel-slides .section.carousel-slide {
 }
 
 .carousel .move-indicators {
-  transform: translateX(calc((16px * var(--indicator-multiplyer)) * -1));
+  transform: translateX(calc((16px * var(--indicator-multiplier)) * -1));
 }
 
 html[dir="rtl"] .carousel .move-indicators {
-  transform: translateX(calc((16px * var(--indicator-multiplyer)) * 1));
+  transform: translateX(calc((16px * var(--indicator-multiplier)) * 1));
 }
 
 .carousel .carousel-indicator {
@@ -269,7 +265,7 @@ html[dir="rtl"] .carousel .move-indicators {
 
 .carousel .carousel-indicator.active::after {
   content: '';
-  background-color: var(--carousel-indicator-active-background-color);
+  background-color: var(--carousel-nav-background);
   height: inherit;
   width: inherit;
 }
@@ -347,13 +343,6 @@ html[dir="rtl"] .carousel .move-indicators {
 .carousel.dark .carousel-previous:active,
 .carousel.dark .carousel-next:active {
   background-color: #000;
-}
-
-.dark .carousel .carousel-previous:focus,
-.dark .carousel .carousel-next:focus,
-.carousel.dark .carousel-previous:focus,
-.carousel.dark .carousel-next:focus {
-  border-color: rgb(255 255 255 / 25%);
 }
 
 .carousel .carousel-expand,
@@ -568,7 +557,7 @@ html[dir="rtl"] .carousel .move-indicators {
     left: -80%;
     transform: translateX(80%);
   }
-  
+
   .carousel.hinting-mobile .carousel-slides.is-reversing {
     transform: translateX(-80%);
   }


### PR DESCRIPTION
This adapts the colors of the Carousel's navigation arrows for Accessibility purposes. There is an outstanding question around hover state colors when a dark theme is used; currently, a `#000` value is used for the arrow background, while the new Figma specs suggest no change is needed. I've continued using the previous value, a new PR will be needed, should the intention actually be to not have any.

Resolves: [MWPW-174755](https://jira.corp.adobe.com/browse/MWPW-174755)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/carousel-arrow-a11y?martech=off
- After: https://carousel-arrow-a11y--milo--overmyheadandbody.aem.page/drafts/ramuntea/carousel-arrow-a11y?martech=off
