### PR TITLE
[MWPW-178135] Text block 'unstyled-list' variant for a11y

### DIFF
--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -25,6 +25,13 @@
 
 .text-block div > *:last-child { margin-bottom: 0; }
 
+.text-block.unstyled-list :is(ul, ol) {
+  list-style: none;
+  padding-inline-start: 0;
+}
+
+.text-block.unstyled-list :is(ul, ol)[class^="body-"] > li:not(:first-child) { margin: inherit; }
+
 .grid .text-block div > *:last-child { margin-bottom: var(--spacing-s); }
 
 .text-block .foreground > div *:first-child { margin-top: 0; }
@@ -335,11 +342,11 @@
   .text-block.center .foreground > .tablet-up {
     justify-content: center;
   }
-  
+
   .text-block.right .foreground > .tablet-up {
     justify-content: end;
   }
-  
+
   .text-block .foreground > .mobile-up,
   .text-block .foreground > .desktop-up,
   .text-block.icon-inline .foreground > .mobile-up,
@@ -363,11 +370,11 @@
   .text-block.center .foreground > .desktop-up {
     justify-content: center;
   }
-  
+
   .text-block.right .foreground > .desktop-up {
     justify-content: end;
   }
-  
+
   .text-block .foreground > .mobile-up,
   .text-block .foreground > .tablet-up,
   .text-block.icon-inline .foreground > .mobile-up,


### PR DESCRIPTION
This adds a new variant for Text blocks so its list items look the same as regular links. This is an Accessibility requirement, so the links are being announced as part of a list, while still maintaining desired UI.

Resolves: [MWPW-178135](https://jira.corp.adobe.com/browse/MWPW-178135)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/text-block-bulletless-list?martech=off
- After: https://unstyled-list-variant--milo--overmyheadandbody.aem.page/drafts/ramuntea/text-block-bulletless-list?martech=off
