### PR TITLE
[MWPW-177653] Mobile carousel desktop ups

### DIFF
--- a/libs/blocks/carousel/carousel.css
+++ b/libs/blocks/carousel/carousel.css
@@ -531,7 +531,7 @@ html[dir="rtl"] .carousel .move-indicators {
   opacity: .3;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 899px) {
   .carousel.container.hinting-mobile,
   .carousel.container.hinting-center-mobile {
     width: 100%;
@@ -754,6 +754,25 @@ html[dir="rtl"] .carousel .move-indicators {
     --offset: calc(round(up, (((var(--slides) - 1) / var(--slides)) * var(--spacing-m)), 1px));
 
     transform: translateX(calc(round(down, (var(--offset) / (var(--slides) - 1)), 2px) * -1));
+  }
+
+  .carousel[class*='show-'].ups-desktop:has(.editorial-card) .carousel-slides.is-ready {
+    flex-wrap: wrap;
+    align-items: stretch;
+    transform: none;
+    left: initial;
+    transform-style: initial;
+    scroll-snap-type: none;
+    will-change: unset;
+  }
+
+  .carousel[class*='show-'].ups-desktop:has(.editorial-card) .carousel-slide {
+    flex-grow: unset;
+  }
+
+  .carousel[class*='show-'].ups-desktop:has(.editorial-card) .carousel-button-container,
+  .carousel[class*='show-'].ups-desktop:has(.editorial-card).lightbox .carousel-expand {
+    display: none;
   }
 }
 

--- a/libs/blocks/carousel/carousel.js
+++ b/libs/blocks/carousel/carousel.js
@@ -409,31 +409,28 @@ function convertMpcMp4(slides) {
   });
 }
 
-function readySlides(slides, slideContainer) {
+function readySlides(slides, slideContainer, isUpsDesktop) {
   slideContainer.classList.add('is-ready');
 
-  const isDesktop = window.matchMedia('(min-width: 900px)');
-
   const setOrder = () => {
-    if (!isDesktop.matches) {
-      slides.forEach((slide, idx) => {
-        // Set last slide to be first in order and make reference.
-        if (slides.length - 1 === idx) {
-          slide.style.order = 1;
-          slide.classList.add('reference-slide');
-        } else {
-          slide.style.order = idx + 2;
-        }
-      });
-    } else {
-      slides.forEach((slide) => {
-        slide.style.order = '';
-      });
-    }
+    slides.forEach((slide, idx) => {
+      const isLastSlide = slides.length - 1 === idx;
+      slide.style.order = isLastSlide ? 1 : idx + 2;
+      slide.classList.toggle('reference-slide', isLastSlide);
+    });
   };
 
-  setOrder();
-  isDesktop.addEventListener('change', setOrder);
+  const isDesktop = window.matchMedia('(min-width: 900px)');
+  const setUpsOrder = () => {
+    if (!isDesktop.matches) setOrder();
+    else slides.forEach((slide) => { slide.style.order = ''; });
+  };
+
+  if (!isUpsDesktop) setOrder();
+  else {
+    setUpsOrder();
+    isDesktop.addEventListener('change', setUpsOrder);
+  }
 }
 
 export default function init(el) {
@@ -494,7 +491,8 @@ export default function init(el) {
    * before moveSlides is called for centering to work.
   */
   if (el.classList.contains('hinting-center-mobile')) {
-    readySlides(slides, slideContainer);
+    const isUpsDesktop = el.classList.contains('ups-desktop');
+    readySlides(slides, slideContainer, isUpsDesktop);
   }
 
   el.textContent = '';

--- a/libs/blocks/carousel/carousel.js
+++ b/libs/blocks/carousel/carousel.js
@@ -411,15 +411,29 @@ function convertMpcMp4(slides) {
 
 function readySlides(slides, slideContainer) {
   slideContainer.classList.add('is-ready');
-  slides.forEach((slide, idx) => {
-    // Set last slide to be first in order and make reference.
-    if (slides.length - 1 === idx) {
-      slide.style.order = 1;
-      slide.classList.add('reference-slide');
+
+  const isDesktop = window.matchMedia('(min-width: 900px)');
+
+  const setOrder = () => {
+    if (!isDesktop.matches) {
+      slides.forEach((slide, idx) => {
+        // Set last slide to be first in order and make reference.
+        if (slides.length - 1 === idx) {
+          slide.style.order = 1;
+          slide.classList.add('reference-slide');
+        } else {
+          slide.style.order = idx + 2;
+        }
+      });
     } else {
-      slide.style.order = idx + 2;
+      slides.forEach((slide) => {
+        slide.style.order = '';
+      });
     }
-  });
+  };
+
+  setOrder();
+  isDesktop.addEventListener('change', setOrder);
 }
 
 export default function init(el) {

--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -32,15 +32,15 @@
   cursor: pointer;
 }
 
-.editorial-card.click.hover-scale { 
+.editorial-card.click.hover-scale {
   transition: all .2s ease-in-out;
 }
 
-.editorial-card.click.hover-scale:hover { 
+.editorial-card.click.hover-scale:hover {
   transform: scale(var(--card-scale-default));
 }
 
-.editorial-card:not(.no-bg).click.hover-scale:hover { 
+.editorial-card:not(.no-bg).click.hover-scale:hover {
   box-shadow: 0 3px 6px 0  rgba(0 0 0 / 16%);
 }
 
@@ -130,8 +130,7 @@
   padding-top: 0;
 }
 
-.editorial-card.no-bg.no-border .static,
-.editorial-card.no-bg.no-border .card-footer {
+.editorial-card.no-bg.no-border :is(.static, .card-footer) {
   padding-inline: 0;
 }
 
@@ -149,7 +148,7 @@
   line-height: 0;
 }
 
-.editorial-card.no-foreground { 
+.editorial-card.no-foreground {
   border: none;
 }
 
@@ -160,7 +159,7 @@
 .editorial-card.footer-align-left .card-footer > div { text-align: start; }
 .editorial-card.footer-align-center .card-footer > div { text-align: center; }
 
-.editorial-card.no-bg.no-border .foreground > div { 
+.editorial-card.no-bg.no-border .foreground > div {
   row-gap: var(--spacing-xs);
 }
 
@@ -170,7 +169,7 @@
   height: 100%;
 }
 
-.editorial-card .background .milo-video, 
+.editorial-card .background .milo-video,
 .editorial-card .background .milo-iframe {
   height: 100%;
   padding-bottom: 0;
@@ -194,7 +193,7 @@
   line-height: initial;
 }
 
-.editorial-card .action-area, 
+.editorial-card .action-area,
 .editorial-card .card-footer > .action-area {
   display: flex;
   align-items: center;
@@ -275,9 +274,9 @@
 }
 
 /* Align */
-.editorial-card.center { 
-  text-align: center; 
-  justify-items: center; 
+.editorial-card.center {
+  text-align: center;
+  justify-items: center;
 }
 
 .editorial-card.footer-align-left .action-area { justify-content: start; }
@@ -296,7 +295,6 @@
   .editorial-card .action-area .con-button {
     white-space: nowrap;
   }
-
 }
 
 /* desktop up */

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -89,10 +89,28 @@ function handleClickableCard(el) {
   }
 }
 
+function handleOpenClasses(el, hasOpenClass) {
+  const openClasses = ['no-border', 'l-rounded-corners-image', 'static-links-copy'];
+  if (hasOpenClass) el.classList.add(...openClasses);
+  const isNestedInUpsCarousel = el.closest('.carousel.ups-desktop');
+
+  if (!isNestedInUpsCarousel) return;
+
+  const isCarouselDesktop = window.matchMedia('(min-width: 900px)');
+  const toggleOpenClasses = () => {
+    if (isCarouselDesktop.matches) el.classList.add(...openClasses);
+    else el.classList.remove(...openClasses);
+  };
+
+  toggleOpenClasses();
+  isCarouselDesktop.addEventListener('change', toggleOpenClasses);
+}
+
 const init = async (el) => {
   el.classList.add('con-block');
   const hasOpenClass = el.className.includes('open');
-  if (hasOpenClass) el.classList.add('no-border', 'l-rounded-corners-image', 'static-links-copy');
+  handleOpenClasses(el, hasOpenClass);
+
   if (el.className.includes('rounded-corners')) loadStyle(`${base}/styles/rounded-corners.css`);
   if (![...el.classList].some((c) => c.endsWith('-lockup'))) el.classList.add('m-lockup');
   let rows = el.querySelectorAll(':scope > div');

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -92,9 +92,8 @@ function handleClickableCard(el) {
 function handleOpenClasses(el, hasOpenClass) {
   const openClasses = ['no-border', 'l-rounded-corners-image', 'static-links-copy'];
   if (hasOpenClass) el.classList.add(...openClasses);
-  const isNestedInUpsCarousel = el.closest('.carousel.ups-desktop');
 
-  if (!isNestedInUpsCarousel) return;
+  if (!el.closest('.carousel.ups-desktop')) return;
 
   const isCarouselDesktop = window.matchMedia('(min-width: 900px)');
   const toggleOpenClasses = () => {


### PR DESCRIPTION
This adapts the behavior of when Editorial Card blocks are used inside the Carousel; the requirement in the context of the Mweb project was to allow authors to use a new variant on the carousel block (`ups-desktop`) that transitions from the regular slides on mobile devices (below `900px`) to a grid (similar to the `n-up` pattern) on desktop (starting from `900px`). Additionally, Editorial Card blocks used under these circumstances should automatically switch from the "closed" design on mobile (~content has some padding and border around it) to the "open" one on desktop.

Resolves: [MWPW-177653](https://jira.corp.adobe.com/browse/MWPW-177653)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/carousel-x-editorial?martech=off
- After: https://carousel-x-editorial--milo--overmyheadandbody.aem.page/drafts/ramuntea/carousel-x-editorial?martech=off






