### PR TITLE
[MWPW-178444] #_dnt within deeply nested inline fragments still gets localized

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -954,8 +954,9 @@ export function decorateLinks(el) {
   const links = [...anchors].reduce((rdx, a) => {
     appendHtmlToLink(a);
     if (a.href.includes('http:')) a.setAttribute('data-http-link', 'true');
-    if (!a.dataset?.localized) a.href = localizeLink(a.href);
-    a.dataset.localized = true;
+    const hasDnt = a.href.includes('#_dnt');
+    if (!a.dataset?.hasDnt) a.href = localizeLink(a.href);
+    if (hasDnt) a.dataset.hasDnt = true;
     decorateSVG(a);
     if (a.href.includes('#_blank')) {
       a.setAttribute('target', '_blank');

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -954,7 +954,8 @@ export function decorateLinks(el) {
   const links = [...anchors].reduce((rdx, a) => {
     appendHtmlToLink(a);
     if (a.href.includes('http:')) a.setAttribute('data-http-link', 'true');
-    a.href = localizeLink(a.href);
+    if (!a.dataset?.localized) a.href = localizeLink(a.href);
+    a.dataset.localized = true;
     decorateSVG(a);
     if (a.href.includes('#_blank')) {
       a.setAttribute('target', '_blank');

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -466,6 +466,14 @@ describe('Utils', () => {
       expect(httpLink.dataset.httpLink).to.equal('true');
     });
 
+    it('Add data-attribute "hasDnt" for links with #_dnt hash to avoid localizing when in deeply nested inline fragments', () => {
+      const container = document.createElement('div');
+      container.innerHTML = '<p><a class="dnt-link" href="https://www.adobe.com/test#_dnt">Do Not Track Link</a></p>';
+      utils.decorateLinks(container);
+      const dntLink = container.querySelector('.dnt-link');
+      expect(dntLink.dataset.hasDnt).to.equal('true');
+    });
+
     it('Sets up milo.deferredPromise', async () => {
       const { resolveDeferred } = utils.getConfig();
       expect(window.milo.deferredPromise).to.exist;


### PR DESCRIPTION
Currently, when a link with #_dnt appears within deeply-nested inline fragments (#_inline), they get passed through decorateLinks more than once. During the first pass, #_dnt is removed, so on the second pass the link is localized when it should not be. 
This PR adds an attribute and a check for it to #_dnt links within deeply-nested inline fragments so they do not get localized.

Steps to QA: 
Check the before and after test urls below.
If you hover over the LinkedIn Premium card cta, at the bottom of the page, the before link should show the localized link (inlcudes "dk") and the after link should not show "dk".

after image example:
<img width="452" height="563" alt="after" src="https://github.com/user-attachments/assets/e9738383-46ff-44ec-aee4-2f363bb75867" />

Resolves: [MWPW-178444](https://jira.corp.adobe.com/browse/MWPW-178444)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/dk/drafts/mepdev/fragments/2025/q3/dntbug/forviv/simple-frag-triple-nested-authored-inline
- After: https://main--cc--adobecom.aem.page/dk/drafts/mepdev/fragments/2025/q3/dntbug/forviv/simple-frag-triple-nested-authored-inline?milolibs=dntbug
- Psi-check: https://dntbug--milo--adobecom.aem.page/?martech=off


