### PR TITLE
MWPW-179291: Lang First POC

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -533,7 +533,6 @@ export async function getCountryAndLang({ autoCountryLang, country, language }) 
           countryStr = geoCountry.toUpperCase();
         }
       } catch (error) {
-        // eslint-disable-next-line no-console
         countryStr = 'xx'; // fallback
       }
     }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Add GEO IP-based country detection for langFirst localization in CaaS API
* Implement automatic country fallback when country is not specified in URL path
* Enhance getCountryAndLang function to use Akamai GEO IP service for better localization
* Add graceful error handling and fallback to US when GEO IP lookup fails

Resolves: [MWPW-179291](https://jira.corp.adobe.com/browse/MWPW-179291)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https:/langfirst-poc--milo--adobecom.aem.page/?martech=off

**Testing:**
- Test langFirst URLs without country (e.g., `/es/products`) to verify GEO IP country detection
- Test langFirst URLs with country (e.g., `/es/mx/products`) to ensure existing functionality works
- Test with different IP locations to verify country detection accuracy
- Test error scenarios when GEO IP service is unavailable






