### PR TITLE
[DA Express Migration] Exclude Complex Sheets from Sync

### DIFF
--- a/.github/workflows/import/index.js
+++ b/.github/workflows/import/index.js
@@ -164,6 +164,16 @@ function safeguardMetadataImages(dom) {
 }
 
 const map = {}
+const projectExclude = {
+  'da-express-milo': [
+    'default/metadata.json',
+    'floating-cta-metadata.json',
+    'metadata-optimization.json',
+    'redirects.json',
+    'ax-promotions.json',
+  ],
+};
+
 async function importUrl(aemPath, importedMedia) {
   const extensionLessAemPath = aemPath.replace('.md', '');
   const url = new URL(importFrom + extensionLessAemPath);
@@ -173,6 +183,11 @@ async function importUrl(aemPath, importedMedia) {
   // Exclude auto publishing files from Sharepoint
   if (excludedFiles.some((excludedFile) => url.pathname === excludedFile)) {
     if (ROLLING_IMPORT_ENABLE_DEBUG_LOGS) console.log(`Stopped processing ${url.pathname}`);
+    return;
+  }
+
+  if (projectExclude[toRepo]?.some((excludedFile) => url.pathname.endsWith(excludedFile))) {
+    if (ROLLING_IMPORT_ENABLE_DEBUG_LOGS) console.log(`Stopped processing ${url.pathname} as project exclude`);
     return;
   }
 


### PR DESCRIPTION
### Description

* Skip complex files in for da-express-milo's content sync, as they will stay in Sharepoint for now

Resolves: https://jira.corp.adobe.com/browse/MWPW-179661

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.live/?martech=off
- After: https://da-express-import-exclude--milo--adobecom.aem.live/?martech=off








