### PR TITLE
MWPW-178626 Brand Concierge - add consent check

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -148,7 +148,20 @@ function decorateLegal(el, legal) {
   el.removeChild(legal);
 }
 
+function handleConsent(el) {
+  if (!window.adobePrivacy) return;
+  const cookieGrp = window.adobePrivacy.activeCookieGroups();
+  if (!cookieGrp?.includes('C0002')) {
+    el.classList.add('hide-block');
+    window.lana?.log('Block hidden because user has not consented to cookies', { tags: 'brand-concierge' });
+  }
+}
+
 export default async function init(el) {
+  handleConsent(el);
+  window.addEventListener('adobePrivacy:PrivacyReject', () => handleConsent(el));
+  window.addEventListener('adobePrivacy:PrivacyCustom', () => handleConsent(el));
+
   const rows = el.querySelectorAll(':scope > div');
   let isDefault = false;
   let fieldFirst = false;

--- a/test/blocks/brand-concierge/brand-concierge.test.js
+++ b/test/blocks/brand-concierge/brand-concierge.test.js
@@ -126,4 +126,47 @@ describe('Brand Concierge', () => {
     expect(mount).to.exist;
     expect(mount.dataset.initialMessage).to.contain('Prompt two');
   });
+
+  describe('Privacy Consent Handling', () => {
+    let block;
+    let originalAdobePrivacy;
+    let originalLana;
+
+    beforeEach(async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+      block = document.querySelector('.brand-concierge');
+      originalAdobePrivacy = window.adobePrivacy;
+      originalLana = window.lana;
+    });
+
+    afterEach(() => {
+      window.adobePrivacy = originalAdobePrivacy;
+      window.lana = originalLana;
+      sinon.restore();
+    });
+
+    it('shows the block if privacy hasnt loaded yet', async () => {
+      window.adobePrivacy = undefined;
+      await init(block);
+      expect(block.classList.contains('hide-block')).to.be.false;
+    });
+
+    it('hides the block if the user rejects all cookies', async () => {
+      window.adobePrivacy = undefined;
+      await init(block);
+      expect(block.classList.contains('hide-block')).to.be.false;
+      window.adobePrivacy = { activeCookieGroups: sinon.stub().returns(['C0001']) };
+      window.dispatchEvent(new CustomEvent('adobePrivacy:PrivacyReject'));
+      expect(block.classList.contains('hide-block')).to.be.true;
+    });
+
+    it('hides the block if the user rejects performance cookies', async () => {
+      window.adobePrivacy = undefined;
+      await init(block);
+      expect(block.classList.contains('hide-block')).to.be.false;
+      window.adobePrivacy = { activeCookieGroups: sinon.stub().returns(['C0001', 'C0003']) };
+      window.dispatchEvent(new CustomEvent('adobePrivacy:PrivacyReject'));
+      expect(block.classList.contains('hide-block')).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
* Hide the brand concierge block if the user has not consented to performance cookies

Resolves: [MWPW-178626](https://jira.corp.adobe.com/browse/MWPW-178626)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off
- After: https://bc-consent--milo--meganthecoder.aem.page/drafts/methomas/brand-concierge?martech=off

