### PR TITLE
[MWPW-179398] mWeb Rollout Ps Test | Text block

### DIFF
--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -315,6 +315,47 @@
   height: 100%;
 }
 
+/* Mweb specific */
+@media screen and (max-width: 599px) {
+  .text.text-block.left-mobile {
+    text-align: start;
+  }
+
+  .text.text-block.center-mobile {
+    text-align: center;
+  }
+
+  .text.text-block.left-mobile .action-area,
+  .text.text-block.center-mobile .action-area {
+    gap: var(--spacing-xxs);
+  }
+
+  .text.text-block.left-mobile .action-area:not(:has(> a:only-child)),
+  .text.text-block.left-mobile .icon-area {
+    justify-content: start;
+  }
+
+  .text.text-block.center-mobile .action-area:not(:has(> a:only-child)),
+  .text.text-block.center-mobile .icon-area {
+    justify-content: center;
+  }
+
+  .text.text-block.left-mobile .icon-area,
+  .text.text-block.center-mobile .icon-area {
+    margin-block-end: var(--spacing-xxs);
+  }
+
+  .text.text-block.left-mobile [class^="heading"],
+  .text.text-block.center-mobile [class^="heading"] {
+    margin: 0 0 12px;
+  }
+
+  .text.text-block.left-mobile [class^="body-"]:not(.action-area),
+  .text.text-block.center-mobile [class^="body-"]:not(.action-area) {
+    margin: 12px 0 var(--spacing-xs) 0;
+  }
+}
+
 /* Tablet up */
 @media screen and (min-width: 600px) {
   .inset.text-block .foreground::before {

--- a/libs/blocks/text/text.css
+++ b/libs/blocks/text/text.css
@@ -330,12 +330,12 @@
     gap: var(--spacing-xxs);
   }
 
-  .text.text-block.left-mobile .action-area:not(:has(> a:only-child)),
+  .text.text-block.left-mobile .action-area,
   .text.text-block.left-mobile .icon-area {
     justify-content: start;
   }
 
-  .text.text-block.center-mobile .action-area:not(:has(> a:only-child)),
+  .text.text-block.center-mobile .action-area,
   .text.text-block.center-mobile .icon-area {
     justify-content: center;
   }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added two new mweb variants for Text block - left-mobile and center-mobile

Resolves: [MWPW-179398](https://jira.corp.adobe.com/browse/MWPW-179398)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/drafts/drashti/mweb/text/mweb-text?martech=off
- After: https://mweb-text--milo--drashti1712.aem.live/drafts/drashti/mweb/text/mweb-text?martech=off
