### PR TITLE
MWPW-179461 Brand Concierge - Fix duplicate analytics

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -74,11 +74,9 @@ function decorateCards(el, cards) {
 
     cardButton.addEventListener('click', () => {
       const input = el.querySelector('.bc-input-field input');
-      const button = el.querySelector('button.input-field-button');
 
       input.value = cardText.textContent.trim();
-      button.disabled = false;
-      button.click();
+      openChatModal(input.value, el);
     });
   });
 


### PR DESCRIPTION
* Fix bug where clicking on a Brand Concierge prompt card generated two clicks, one on the card and one on the submit button

Resolves: [MWPW-179461](https://jira.corp.adobe.com/browse/MWPW-179461)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off
- After: https://bc-analytics-bug--milo--meganthecoder.aem.page/drafts/methomas/brand-concierge?martech=off

(To test, remove ?martech=off and look in the console for click event logs)

