### PR TITLE
[DA Express Migration] Exclude All Sheets from Sync

### DIFF
--- a/.github/workflows/import/index.js
+++ b/.github/workflows/import/index.js
@@ -166,11 +166,7 @@ function safeguardMetadataImages(dom) {
 const map = {}
 const projectExclude = {
   'da-express-milo': [
-    'default/metadata.json',
-    'floating-cta-metadata.json',
-    'metadata-optimization.json',
-    'redirects.json',
-    'ax-promotions.json',
+    '.json',
   ],
 };
 


### PR DESCRIPTION
### Description

* Latest update: the team wants to skip all sheets for da-express-milo's content sync. So **D**ocs in **D**A, **S**heets in **S**P.
* Follow up to https://github.com/adobecom/milo/pull/4795

Resolves: https://jira.corp.adobe.com/browse/MWPW-179661

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.live/?martech=off
- After: https://da-express-import-exclude-all--milo--adobecom.aem.live/?martech=off