### PR TITLE
Adding dnt support for language picker

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -347,7 +347,7 @@ class Footer {
 
     // Note: the region picker currently works only with Milo modals/fragments;
     // in the future we'll need to update this for non-Milo consumers
-    if (url.hash !== '') {
+    if (url.hash !== '' && url.hash !== '#_dnt') {
       // Hash -> region selector opens a modal
       decorateAutoBlock(regionPickerElem); // add modal-specific attributes
       regionPickerElem.href = url.hash;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Previously, every URL with a hash value was assumed to be a modal. Now, instead, we are excluding the _dnt hash value to support DNT.

Resolves: [MWPW-179744](https://jira.corp.adobe.com/browse/MWPW-179744)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://regionpicker-dnt--milo--adobecom.aem.page/?martech=off
