### PR TITLE
Refactor icon library to adhere to the DA standard

### DIFF
--- a/libs/blocks/library-config/lists/icons.js
+++ b/libs/blocks/library-config/lists/icons.js
@@ -9,24 +9,24 @@ export default async function iconList(content, list, query) {
   if (!fedIconList) {
     fedIconList = await fetchIconList(content[0].path);
     if (!fedIconList?.length) throw new Error('No icons returned from fetchIconList');
-    fedIconList.forEach((icon) => {
-      const svg = createTag('span', { class: `icon icon-${icon.name}` }, createTag('img', { class: `icon-${icon.name}-img icon-fed`, src: `${icon.url}`, width: '18px' }));
-      const titleText = createTag('p', { class: 'item-title' }, icon.name);
+    fedIconList.forEach(({ key, icon }) => {
+      const svg = createTag('span', { class: `icon icon-${key}` }, createTag('img', { class: `icon-${key}-img icon-fed`, src: `${icon}`, width: '18px' }));
+      const titleText = createTag('p', { class: 'item-title' }, key);
       const title = createTag('li', { class: 'icon-item' }, svg);
       title.append(titleText);
       const copy = createTag('button', { class: 'copy' });
-      copy.id = `${icon.name}-icon-copy`;
+      copy.id = `${key}-icon-copy`;
       copy.addEventListener('click', (e) => {
         e.target.classList.add('copied');
         setTimeout(() => { e.target.classList.remove('copied'); }, 3000);
-        const formatted = `:${icon.name}:`;
+        const formatted = `:${key}:`;
         const blob = new Blob([formatted], { type: 'text/plain' });
         createCopy(blob);
         window.hlx?.rum.sampleRUM('click', { source: e.target });
       });
       title.append(copy);
 
-      iconElements.set(icon.name, title);
+      iconElements.set(key, title);
     });
   }
 

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -158,7 +158,7 @@ export const fetchIcons = (config) => {
 export function fetchIconList(url) {
   return fetch(url)
     .then((resp) => resp.json())
-    .then((json) => json.content.data)
+    .then((json) => json.data || json.content.data)
     .catch(() => {
       lanaLog({ message: 'Failed to fetch iconList', tags: 'icons', errorType: 'error' });
       return [];


### PR DESCRIPTION
### Description
DA uses 'key, icon' while milo uses 'name, url' .. let's switch to what DA does so that we can re-use the federal icon sheet. For backwards compatibility, I added both versions to the sheet, so this PR shouldn't break anything and be forward-compatible.

Resolves: [MWPW-180007](https://jira.corp.adobe.com/browse/MWPW-180007)

### Visuals
Tested this on DA and Sharepoint using the new format using a local overwrite for the json // icon code.
<img width="1439" height="975" alt="image" src="https://github.com/user-attachments/assets/09779611-c05a-4177-99bf-c309892e2945" />
<img width="1290" height="1178" alt="Screenshot 2025-09-05 at 10 17 01" src="https://github.com/user-attachments/assets/86a0f257-dc41-4130-863c-c9ea6575bf73" />

### Actions needed after merge
- Remove name/url/dnt sheet from the federal sheet
- add the right federal sheet to the DA project configs.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://refactor-icon-library--milo--adobecom.aem.page/?martech=off






