### PR TITLE
MWPW-167998 when the different app banner height is present the primary cta will not be visible in landscape mode completely

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1303,8 +1303,8 @@ class Gnav {
     const hasPromo = this.block.classList.contains('has-promo');
     const promoHeight = this.elements.aside?.clientHeight;
 
-    if (!this.isLocalNav()) {
-      if (hasPromo) popup.style.top = `calc(0px - var(--feds-height-nav) - ${promoHeight}px)`;
+    if (!this.isLocalNav() && hasPromo) {
+      popup.style.top = `calc(0px - var(--feds-height-nav) - ${promoHeight}px)`;
       return;
     }
     const yOffset = window.scrollY || Math.abs(parseInt(document.body.style.top, 10)) || 0;


### PR DESCRIPTION
when the different app banner height is present the primary cta will not be visible in landscape mode completely

Resolves: [MWPW-167998](https://jira.corp.adobe.com/browse/MWPW-167998)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-167998--milo--patel-prince.aem.page/?martech=off
 
**QA URL:**
- https://main--milo--adobecom.aem.page/drafts/devashish/banner/branch-banner-inline



<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.hlx.live/acrobat?martech=off&milolibs=MWPW-167998--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.live/?martech=off&milolibs=MWPW-167998--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-167998--milo--adobecom
- Milo: https://MWPW-167998--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-167998--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-167998--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-167998--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-167998--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-167998--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-167998--milo--adobecom
- Milo: https://MWPW-167998--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-167998--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-167998--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-167998--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-167998--milo--adobecom
- BACOM: https://main--bacom--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-167998--milo--adobecom
- CC: https://main--cc--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-167998--milo--adobecom
- Milo: https://MWPW-167998--milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-167998--milo--adobecom
- News: https://main--news--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-167998--milo--adobecom
- Homepage: https://main--homepage--adobecom.hlx.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-167998--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-167998--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-167998--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-167998--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-167998--milo--adobecom
</details>