### PR TITLE
MWPW-177169

### DIFF
--- a/libs/blocks/how-to/how-to.js
+++ b/libs/blocks/how-to/how-to.js
@@ -46,7 +46,7 @@ const setJsonLd = (heading, description, mainImage, stepsLd) => {
   document.getElementsByTagName('head')[0].appendChild(jsonLdScript);
 };
 
-const getImage = (el) => el.querySelector('picture') || el.querySelector('a[href$=".svg"');
+const getImage = (el) => el.querySelector('.image-link') || el.querySelector('picture') || el.querySelector('a[href$=".svg"');
 const getVideo = (el) => el.querySelector('.video-container, .pause-play-wrapper, video, .milo-video');
 
 const getHowToInfo = (el) => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Modification to the How-to block to allow images with alt tags to be used specifically for modals 

Resolves: [MWPW-177169](https://jira.corp.adobe.com/browse/MWPW-177169)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-177169-milo--adobecom.aem.page/?martech=off
- https://main--milo--adobecom.aem.page/drafts/gunn/jump?martech=off
- https://mwpw-177169--milo--adobecom.aem.page/drafts/gunn/jump?martech=off


