### PR TITLE
Treat aem.reviews as stage environment

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -185,7 +185,8 @@ export function getEnv(conf) {
     || host.includes(`${SLD}.live`)
     || host.includes('stage.adobe')
     || host.includes('corp.adobe')
-    || host.includes('graybox.adobe')) {
+    || host.includes('graybox.adobe')
+    || host.includes('aem.reviews')) {
     return { ...ENVS.stage, consumer: conf.stage };
   }
   return { ...ENVS.prod, consumer: conf.prod };


### PR DESCRIPTION
### Description
Treat `aem.reviews` as stage env, similar to `.page, .live, .graybox` etc. 
This PR is also required for https://github.com/adobecom/milo/pull/4812 to work

Resolves: [MWPW-179804](https://jira.corp.adobe.com/browse/MWPW-179804)

Test link on aem reviews: https://osahin--osahin-mwpw-179804--milo--adobecom.aem.reviews/docs/library/kitchen-sink/accordion/40

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://osahin-mwpw-179804--milo--adobecom.aem.page/?martech=off


