### PR TITLE
MWPW-178197: SUSI Light Layouts

### DIFF
--- a/libs/blocks/susi-light-login/susi-light-login.css
+++ b/libs/blocks/susi-light-login/susi-light-login.css
@@ -10,7 +10,7 @@
   box-sizing: border-box;
   overflow-y: scroll;
   scrollbar-width: none;
-  min-height: calc(100vh - calc(var(--feds-height-nav, 63px) + 67px) );
+  width: 100%;
 }
 
 .login-container {
@@ -25,7 +25,7 @@
   justify-content: center;
   align-items: center;
   margin-bottom: 12px;
-  padding: 0 24px;
+  padding: 24px;
 }
 
 .susi-product-title {
@@ -85,6 +85,7 @@
   background-color: white;
   box-sizing: border-box;
   justify-items: center;
+  border-radius: 16px 16px 0 0;
 }
 
 susi-sentry-light {
@@ -96,11 +97,22 @@ susi-sentry-light {
   scrollbar-width: none;
 }
 
+.section.two-up:has(.susi-light-login) {
+  display: flex;
+  flex-direction: column;
+}
+
 @media (min-width: 900px) {
   .susi-light-login {
     height: calc(100vh - calc(var(--feds-height-nav, 63px) + 67px) );
     min-height: 730px;
     padding: 20px 0;
+  }
+
+
+  .section.two-up:has(.susi-light-login) {
+    display: grid;
+    flex-direction: unset;
   }
   
   .login-container {
@@ -129,6 +141,13 @@ susi-sentry-light {
   .socialonly susi-sentry-light {
     height: 295px;
   }
+}
+
+@media (min-width: 1200px) {
+  .login-product {
+    padding: 0 24px;
+  }
+
 }
 
 .dialog-modal .susi-light-login {

--- a/libs/blocks/susi-light-login/susi-light-login.css
+++ b/libs/blocks/susi-light-login/susi-light-login.css
@@ -97,7 +97,6 @@ susi-sentry-light {
 }
 
 @media (min-width: 900px) {
-
   .susi-light-login {
     height: calc(100vh - calc(var(--feds-height-nav, 63px) + 67px) );
     min-height: 730px;
@@ -119,4 +118,20 @@ susi-sentry-light {
     justify-items: unset;
     border-radius: 16px 16px 0 0;
   }
+
+
+  .emailonly .susi-light-wrapper,
+  .socialonly .susi-light-wrapper {
+    min-height: 100%;
+  }
+
+  .emailonly susi-sentry-light,
+  .socialonly susi-sentry-light {
+    height: 295px;
+  }
+}
+
+.dialog-modal .susi-light-login {
+  height: auto;
+  min-height: auto;
 }

--- a/libs/blocks/susi-light-login/susi-light-login.js
+++ b/libs/blocks/susi-light-login/susi-light-login.js
@@ -21,7 +21,7 @@ const onRedirect = (e) => window.location.assign(e.detail);
 const onError = (e) => window.lana?.log('Product Login pages: SUSI Light Error: ', e);
 
 const getText = (e) => e?.textContent?.trim();
-
+const layoutClasses = ['socialAndEmail', 'emailAndSocial', 'socialOnly', 'emailOnly'];
 export class SusiLight {
   constructor(el) {
     this.el = el;
@@ -59,6 +59,9 @@ export class SusiLight {
   createSusiElement = () => {
     const { env } = getConfig();
     const sentry = createTag('susi-sentry-light');
+    const { classList } = this.el;
+    const layoutClass = layoutClasses.filter((layout) => classList.contains(layout.toLowerCase()));
+
     if (env.name !== 'prod') sentry.stage = true;
     sentry.variant = 'standard';
     sentry.authParams = this.createAuthParams();
@@ -67,6 +70,10 @@ export class SusiLight {
     sentry.config = { consentProfile: 'free' };
     sentry.addEventListener('redirect', onRedirect);
     sentry.addEventListener('on-error', onError);
+    if (layoutClass.length > 0) {
+      const [layout] = layoutClass;
+      sentry.config.layout = layout;
+    }
     return sentry;
   };
 

--- a/libs/blocks/susi-light-login/susi-light-login.js
+++ b/libs/blocks/susi-light-login/susi-light-login.js
@@ -60,7 +60,7 @@ export class SusiLight {
     const { env } = getConfig();
     const sentry = createTag('susi-sentry-light');
     const { classList } = this.el;
-    const layoutClass = layoutClasses.filter((layout) => classList.contains(layout.toLowerCase()));
+    const layoutClass = layoutClasses.find((layout) => classList.contains(layout.toLowerCase()));
 
     if (env.name !== 'prod') sentry.stage = true;
     sentry.variant = 'standard';
@@ -70,9 +70,8 @@ export class SusiLight {
     sentry.config = { consentProfile: 'free' };
     sentry.addEventListener('redirect', onRedirect);
     sentry.addEventListener('on-error', onError);
-    if (layoutClass.length > 0) {
-      const [layout] = layoutClass;
-      sentry.config.layout = layout;
+    if (layoutClass) {
+      sentry.config.layout = layoutClass;
     }
     return sentry;
   };


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds the ability to add the layout string expected by the susi config to the block as a classname to allow Susi to use that layout. Small style considerations. 

Resolves: [MWPW-178197](https://jira.corp.adobe.com/browse/MWPW-178197)

**Test URLs:**
- Before: https://main--milo--jasonhowellslavin.aem.live/?martech=off
- After: https://susi-config-layout--milo--jasonhowellslavin.aem.live/?martech=off

To test that the it works as expected, use: 
https://ims--milo--adobecom.aem.page/drafts/slavin/scratch in incognito









