### PR TITLE
MWPW-175209: Get placeholders from other consumer sites.

### DIFF
--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -3,8 +3,24 @@ import { customFetch, getConfig, getMetadata } from '../utils/utils.js';
 const fetchedPlaceholders = {};
 window.mph = {};
 
+export const getPlaceholderRoot = (config) => {
+  const placeholderConstentRoot = getMetadata('placeholders-content-root');
+  if (!placeholderConstentRoot) return config.locale?.contentRoot;
+
+  let origin = 'https://www.adobe.com';
+  const placeholderOrigin = getMetadata('placeholders-origin');
+  if (config.env.name !== 'prod' && placeholderOrigin) {
+    const originParts = window.location.origin.split('--');
+    if (originParts.length === 3) {
+      origin = `${originParts[0]}--${placeholderOrigin}--${originParts[2]}`;
+    }
+  }
+  return `${origin}${config.locale?.prefix || ''}/${placeholderConstentRoot}`;
+};
+
 const getPlaceholdersPath = (config, sheet) => {
-  const path = `${config.locale.contentRoot}/placeholders.json`;
+  const placeholderRoot = getPlaceholderRoot(config);
+  const path = `${placeholderRoot}/placeholders.json`;
   const query = sheet !== 'default' && typeof sheet === 'string' && sheet.length ? `?sheet=${sheet}` : '';
   return `${path}${query}`;
 };

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1153,11 +1153,12 @@ const findReplaceableNodes = (area) => {
   return nodes;
 };
 
-function getPlaceholderPaths(config) {
-  const root = `${config.locale?.contentRoot}/placeholders`;
-  const paths = [`${root}.json`];
-  if (config.env.name !== 'prod'
-    && getMetadata('placeholders-stage') === 'on') paths.push(`${root}-stage.json`);
+function getPlaceholderPaths(config, placeholderRoot) {
+  const paths = [`${placeholderRoot}/placeholders.json`];
+  // Add stage-specific placeholder if placeholders-stage is on
+  if (config.env.name !== 'prod' && getMetadata('placeholders-stage') === 'on') {
+    paths.push(`${placeholderRoot}/placeholders-stage.json`);
+  }
   return paths;
 }
 
@@ -1167,11 +1168,11 @@ export async function decoratePlaceholders(area, config) {
   const nodes = findReplaceableNodes(area);
   if (!nodes.length) return;
   area.dataset.hasPlaceholders = 'true';
-  const phPaths = getPlaceholderPaths(config);
+  const { decoratePlaceholderArea, getPlaceholderRoot } = await import('../features/placeholders.js');
+  const phPaths = await getPlaceholderPaths(config, getPlaceholderRoot(config));
   placeholderRequest ||= Promise.all(
     phPaths.map((path) => customFetch({ resource: path, withCacheRules: true })),
   ).catch(() => ({}));
-  const { decoratePlaceholderArea } = await import('../features/placeholders.js');
   await decoratePlaceholderArea({
     placeholderPath: phPaths[0],
     placeholderRequest,


### PR DESCRIPTION
- New getPlaceholderRoot function in libs/features/placeholders.js that provides flexible placeholder root URL resolution
- Comprehensive unit test coverage with 6 test cases covering all scenarios

Resolves: [MWPW-175209](https://jira.corp.adobe.com/browse/MWPW-175209)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-175209--milo--adobecom.aem.page/?martech=off

**Other Test URLs:**
- Before: https://main--homepage--adobecom.aem.page/kr/homepage/drafts/seanchoi/index-loggedout?martech=off
- After: https://main--homepage--adobecom.aem.page/kr/homepage/drafts/seanchoi/index-loggedout?martech=off&milolibs=mwpw-175209
