### PR TITLE
MWPW-179632 [NALA]: enable maslibs usage in commerce tests

### DIFF
--- a/nala/blocks/merch/default-flags.test.js
+++ b/nala/blocks/merch/default-flags.test.js
@@ -1,19 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { features } from './default-flags.spec.js';
 import DefaultFlags from './default-flags.page.js';
-import { constructUrlWithParams } from '../../libs/commerce.js';
-
-const miloLibs = process.env.MILO_LIBS || '';
-const masLibs = process.env.MAS_LIBS || '';
-
-// Helper function to construct URLs with proper query parameter handling
-function constructTestUrl(baseURL, path, browserParams = '') {
-  let fullUrl = `${baseURL}${path}`;
-  fullUrl = constructUrlWithParams(fullUrl, browserParams);
-  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
-  fullUrl = constructUrlWithParams(fullUrl, masLibs);
-  return fullUrl;
-}
+import { constructTestUrl } from '../../libs/commerce.js';
 
 test.describe('DefaultFlags Block test suite', () => {
   test.beforeEach(async ({ page, browserName }) => {

--- a/nala/blocks/merch/default-flags.test.js
+++ b/nala/blocks/merch/default-flags.test.js
@@ -1,8 +1,19 @@
 import { expect, test } from '@playwright/test';
 import { features } from './default-flags.spec.js';
 import DefaultFlags from './default-flags.page.js';
+import { constructUrlWithParams } from '../../libs/commerce.js';
 
 const miloLibs = process.env.MILO_LIBS || '';
+const masLibs = process.env.MAS_LIBS || '';
+
+// Helper function to construct URLs with proper query parameter handling
+function constructTestUrl(baseURL, path, browserParams = '') {
+  let fullUrl = `${baseURL}${path}`;
+  fullUrl = constructUrlWithParams(fullUrl, browserParams);
+  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
+  fullUrl = constructUrlWithParams(fullUrl, masLibs);
+  return fullUrl;
+}
 
 test.describe('DefaultFlags Block test suite', () => {
   test.beforeEach(async ({ page, browserName }) => {
@@ -15,12 +26,13 @@ test.describe('DefaultFlags Block test suite', () => {
 
   test(`${features[0].name}, ${features[0].tags}`, async ({ page, baseURL }) => {
     const defaultFlags = new DefaultFlags(page);
-    console.info(`[Test Page]: ${baseURL}${features[0].path}${miloLibs}`);
+    const testUrl = constructTestUrl(baseURL, features[0].path, features[0].browserParams);
+    console.info(`[Test Page]: ${testUrl}`);
 
     await test.step('Navigate to page with DefaultFlags prices', async () => {
-      await page.goto(`${baseURL}${features[0].path}${features[0].browserParams}&${miloLibs}`);
+      await page.goto(testUrl);
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[0].path}${features[0].browserParams}&${miloLibs}`);
+      await expect(page).toHaveURL(testUrl);
     });
 
     await test.step('Validate if each price is visible and has proper text for EN', async () => {
@@ -36,12 +48,13 @@ test.describe('DefaultFlags Block test suite', () => {
 
   test(`${features[1].name}, ${features[1].tags}`, async ({ page, baseURL }) => {
     const defaultFlags = new DefaultFlags(page);
-    console.info(`[Test Page]: ${baseURL}${features[1].path}${miloLibs}`);
+    const testUrl = constructTestUrl(baseURL, features[1].path, features[1].browserParams);
+    console.info(`[Test Page]: ${testUrl}`);
 
     await test.step('Navigate to page with DefaultFlags prices', async () => {
-      await page.goto(`${baseURL}${features[1].path}${features[1].browserParams}&${miloLibs}`);
+      await page.goto(testUrl);
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[1].path}${features[1].browserParams}&${miloLibs}`);
+      await expect(page).toHaveURL(testUrl);
     });
 
     await test.step('Validate if each price is visible and has proper text for FR', async () => {
@@ -57,12 +70,13 @@ test.describe('DefaultFlags Block test suite', () => {
 
   test(`${features[2].name}, ${features[2].tags}`, async ({ page, baseURL }) => {
     const defaultFlags = new DefaultFlags(page);
-    console.info(`[Test Page]: ${baseURL}${features[2].path}${miloLibs}`);
+    const testUrl = constructTestUrl(baseURL, features[2].path, features[2].browserParams);
+    console.info(`[Test Page]: ${testUrl}`);
 
     await test.step('Navigate to page with DefaultFlags prices', async () => {
-      await page.goto(`${baseURL}${features[2].path}${features[2].browserParams}&${miloLibs}`);
+      await page.goto(testUrl);
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[2].path}${features[2].browserParams}&${miloLibs}`);
+      await expect(page).toHaveURL(testUrl);
     });
 
     await test.step('Validate if each price is visible and has proper text for NG', async () => {

--- a/nala/blocks/merch/three-in-one.test.js
+++ b/nala/blocks/merch/three-in-one.test.js
@@ -1,19 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { features } from './three-in-one.spec.js';
 import ThreeInOne from './three-in-one.page.js';
-import { constructUrlWithParams } from '../../libs/commerce.js';
-
-const miloLibs = process.env.MILO_LIBS || '';
-const masLibs = process.env.MAS_LIBS || '';
-
-// Helper function to construct URLs with proper query parameter handling
-function constructTestUrl(baseURL, path, browserParams = '') {
-  let fullUrl = `${baseURL}${path}`;
-  fullUrl = constructUrlWithParams(fullUrl, browserParams);
-  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
-  fullUrl = constructUrlWithParams(fullUrl, masLibs);
-  return fullUrl;
-}
+import { constructTestUrl } from '../../libs/commerce.js';
 
 async function openModal(cta) {
   await expect(cta).not.toHaveClass(/loading-entitlements|placeholder-pending|placeholder-failed/);

--- a/nala/blocks/merch/three-in-one.test.js
+++ b/nala/blocks/merch/three-in-one.test.js
@@ -1,8 +1,19 @@
 import { expect, test } from '@playwright/test';
 import { features } from './three-in-one.spec.js';
 import ThreeInOne from './three-in-one.page.js';
+import { constructUrlWithParams } from '../../libs/commerce.js';
 
 const miloLibs = process.env.MILO_LIBS || '';
+const masLibs = process.env.MAS_LIBS || '';
+
+// Helper function to construct URLs with proper query parameter handling
+function constructTestUrl(baseURL, path, browserParams = '') {
+  let fullUrl = `${baseURL}${path}`;
+  fullUrl = constructUrlWithParams(fullUrl, browserParams);
+  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
+  fullUrl = constructUrlWithParams(fullUrl, masLibs);
+  return fullUrl;
+}
 
 async function openModal(cta) {
   await expect(cta).not.toHaveClass(/loading-entitlements|placeholder-pending|placeholder-failed/);
@@ -19,12 +30,13 @@ test.describe('ThreeInOne Block test suite', () => {
 
   test(`${features[0].name}, ${features[0].tags}`, async ({ page, baseURL }) => {
     const threeInOne = new ThreeInOne(page);
-    console.info(`[Test Page]: ${baseURL}${features[0].path}${miloLibs}`);
+    const testUrl = constructTestUrl(baseURL, features[0].path, features[0].browserParams);
+    console.info(`[Test Page]: ${testUrl}`);
 
     await test.step('Navigate to page with ThreeInOne CTAs', async () => {
-      await page.goto(`${baseURL}${features[0].path}${features[0].browserParams}&${miloLibs}`);
+      await page.goto(testUrl);
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[0].path}${features[0].browserParams}&${miloLibs}`);
+      await expect(page).toHaveURL(testUrl);
     });
 
     await test.step('Validate if each CTA is visible and has proper href', async () => {
@@ -51,11 +63,12 @@ test.describe('ThreeInOne Block test suite', () => {
 
   test(`${features[1].name}, ${features[1].tags}`, async ({ page, baseURL }) => {
     const threeInOne = new ThreeInOne(page);
-    console.info(`[Test Page]: ${baseURL}${features[1].path}${miloLibs}`);
+    const testUrl = constructTestUrl(baseURL, features[1].path, features[1].browserParams);
+    console.info(`[Test Page]: ${testUrl}`);
 
     for (const { sectionId, attributes, iframeSrc } of features[1].useCases) {
       await test.step(`Validate ${sectionId} CTA is visible and has proper attributes`, async () => {
-        await page.goto(`${baseURL}${features[1].path}${features[0].browserParams}&${miloLibs}`);
+        await page.goto(testUrl);
         await page.waitForLoadState('domcontentloaded');
         const cta = threeInOne.getFallbackCta(sectionId);
         for (const [key, value] of Object.entries(attributes)) {
@@ -72,11 +85,12 @@ test.describe('ThreeInOne Block test suite', () => {
 
   test(`${features[2].name}, ${features[2].tags}`, async ({ page, baseURL }) => {
     const threeInOne = new ThreeInOne(page);
-    console.info(`[Test Page]: ${baseURL}${features[2].path}${miloLibs}`);
+    const testUrl = constructTestUrl(baseURL, features[2].path, features[2].browserParams);
+    console.info(`[Test Page]: ${testUrl}`);
 
     await test.step('Navigate to page with ThreeInOne CTAs', async () => {
       const { sectionId, iframeSrc, attributes } = features[2];
-      await page.goto(`${baseURL}${features[2].path}${features[2].browserParams}&${miloLibs}`);
+      await page.goto(testUrl);
       await page.waitForLoadState('domcontentloaded');
       const cta = threeInOne.getFallbackCta(sectionId);
       for (const [key, value] of Object.entries(attributes)) {
@@ -91,11 +105,12 @@ test.describe('ThreeInOne Block test suite', () => {
 
   test(`${features[3].name}, ${features[3].tags}`, async ({ page, baseURL }) => {
     const threeInOne = new ThreeInOne(page);
-    console.info(`[Test Page]: ${baseURL}${features[3].path}${miloLibs}`);
+    const testUrl = constructTestUrl(baseURL, features[3].path, features[3].browserParams);
+    console.info(`[Test Page]: ${testUrl}`);
 
     await test.step('Navigate to page with ThreeInOne CTAs', async () => {
       const { sectionId, iframeSrc, attributes } = features[3];
-      await page.goto(`${baseURL}${features[3].path}${features[3].browserParams}&${miloLibs}`);
+      await page.goto(testUrl);
       await page.waitForLoadState('domcontentloaded');
       const cta = threeInOne.getFallbackCta(sectionId);
       for (const [key, value] of Object.entries(attributes)) {
@@ -110,12 +125,13 @@ test.describe('ThreeInOne Block test suite', () => {
 
   test(`${features[4].name}, ${features[4].tags}`, async ({ page, baseURL }) => {
     const threeInOne = new ThreeInOne(page);
-    console.info(`[Test Page]: ${baseURL}${features[4].path}${miloLibs}`);
+    const testUrl = constructTestUrl(baseURL, features[4].path, features[4].browserParams);
+    console.info(`[Test Page]: ${testUrl}`);
 
     await test.step('Navigate to page with ThreeInOne CTAs', async () => {
-      await page.goto(`${baseURL}${features[4].path}${features[4].browserParams}&${miloLibs}`);
+      await page.goto(testUrl);
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[4].path}${features[4].browserParams}&${miloLibs}`);
+      await expect(page).toHaveURL(testUrl);
     });
 
     await test.step('Validate ThreeInOne modal without DC AddOn', async () => {
@@ -156,11 +172,12 @@ test.describe('ThreeInOne Block test suite', () => {
 
   test(`${features[5].name}, ${features[5].tags}`, async ({ page, baseURL }) => {
     const threeInOne = new ThreeInOne(page);
-    console.info(`[Test Page]: ${baseURL}${features[5].path}${miloLibs}`);
+    const testUrl = constructTestUrl(baseURL, features[5].path, features[5].browserParams);
+    console.info(`[Test Page]: ${testUrl}`);
 
     await test.step('Validate fallback step CTA is visible and has proper attributes', async () => {
       const { sectionId, attributes } = features[5];
-      await page.goto(`${baseURL}${features[5].path}${features[5].browserParams}&${miloLibs}`);
+      await page.goto(testUrl);
       await page.waitForLoadState('domcontentloaded');
       const cta = threeInOne.getFallbackCta(sectionId);
       for (const [key, value] of Object.entries(attributes)) {

--- a/nala/blocks/merchcard/merchcard.test.js
+++ b/nala/blocks/merchcard/merchcard.test.js
@@ -2,21 +2,9 @@ import { expect, test } from '@playwright/test';
 import { features } from './merchcard.spec.js';
 import MerchCard from './merchcard.pages.js';
 import { runAccessibilityTest } from '../../libs/accessibility.js';
-import { constructUrlWithParams } from '../../libs/commerce.js';
+import { constructTestUrl } from '../../libs/commerce.js';
 
 let merchCard;
-
-const miloLibs = process.env.MILO_LIBS || '';
-const masLibs = process.env.MAS_LIBS || '';
-
-// Helper function to construct URLs with proper query parameter handling
-function constructTestUrl(baseURL, path, browserParams = '') {
-  let fullUrl = `${baseURL}${path}`;
-  fullUrl = constructUrlWithParams(fullUrl, browserParams);
-  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
-  fullUrl = constructUrlWithParams(fullUrl, masLibs);
-  return fullUrl;
-}
 
 test.describe('Milo Merchcard block test suite', () => {
   test.beforeEach(async ({ page, browserName }) => {

--- a/nala/blocks/merchcard/merchcard.test.js
+++ b/nala/blocks/merchcard/merchcard.test.js
@@ -2,10 +2,21 @@ import { expect, test } from '@playwright/test';
 import { features } from './merchcard.spec.js';
 import MerchCard from './merchcard.pages.js';
 import { runAccessibilityTest } from '../../libs/accessibility.js';
+import { constructUrlWithParams } from '../../libs/commerce.js';
 
 let merchCard;
 
 const miloLibs = process.env.MILO_LIBS || '';
+const masLibs = process.env.MAS_LIBS || '';
+
+// Helper function to construct URLs with proper query parameter handling
+function constructTestUrl(baseURL, path, browserParams = '') {
+  let fullUrl = `${baseURL}${path}`;
+  fullUrl = constructUrlWithParams(fullUrl, browserParams);
+  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
+  fullUrl = constructUrlWithParams(fullUrl, masLibs);
+  return fullUrl;
+}
 
 test.describe('Milo Merchcard block test suite', () => {
   test.beforeEach(async ({ page, browserName }) => {
@@ -17,13 +28,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 0 : Merch Card (Segment)
   test(`[Test Id - ${features[0].tcid}] ${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[0].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[0].path)}`);
     const { data } = features[0];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[0].path}`);
+      await page.goto(constructTestUrl(baseURL, features[0].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[0].path}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[0].path));
     });
 
     await test.step('step-2: Verify Merch Card content/specs', async () => {
@@ -49,13 +60,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 1 : Merch Card (Segment) with Badge
   test(`[Test Id - ${features[1].tcid}] ${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[1].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[1].path)}`);
     const { data } = features[1];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[1].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[1].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[1].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[1].path));
     });
 
     await test.step('step-2: Verify Merch Card with Badge content/specs', async () => {
@@ -91,13 +102,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 2 : Merch Card (Special Offers)
   test(`[Test Id - ${features[2].tcid}] ${features[2].name},${features[2].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[2].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[2].path)}`);
     const { data } = features[2];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[2].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[2].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[2].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[2].path));
     });
 
     await test.step('step-2: Verify Merch Card special offers content/specs', async () => {
@@ -123,13 +134,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 3 : Merch Card (Special Offers) with badge
   test(`[Test Id - ${features[3].tcid}] ${features[3].name},${features[3].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[3].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[3].path)}`);
     const { data } = features[3];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[3].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[3].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[3].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[3].path));
     });
 
     await test.step('step-2: Verify Merch Card special offers content/specs', async () => {
@@ -163,13 +174,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 4 : Merch Card (plans)
   test(`[Test Id - ${features[4].tcid}] ${features[4].name},${features[4].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[4].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[4].path)}`);
     const { data } = features[4];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[4].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[4].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[4].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[4].path));
     });
 
     await test.step('step-2: Verify Merch Card special offers content/specs', async () => {
@@ -192,13 +203,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 5 : Merch Card (plans) with badge
   test(`[Test Id - ${features[5].tcid}] ${features[5].name},${features[5].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[5].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[5].path)}`);
     const { data } = features[5];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[5].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[5].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[5].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[5].path));
     });
 
     await test.step('step-2: Verify Merch Card special offers content/specs', async () => {
@@ -228,13 +239,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 6 : Merch Card (plans) with secure
   test(`[Test Id - ${features[6].tcid}] ${features[6].name},${features[6].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[6].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[6].path)}`);
     const { data } = features[6];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[6].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[6].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[6].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[6].path));
     });
 
     await test.step('step-2: Verify Merch Card special offers content/specs', async () => {
@@ -259,13 +270,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 7 : Merch Card (plans, secure) with badge
   test(`[Test Id - ${features[7].tcid}] ${features[7].name},${features[7].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[7].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[7].path)}`);
     const { data } = features[7];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[7].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[7].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[7].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[7].path));
     });
 
     await test.step('step-2: Verify Merch Card special offers content/specs', async () => {
@@ -292,13 +303,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 8 : Merch Card (catalog)
   test(`[Test Id - ${features[8].tcid}] ${features[8].name},${features[8].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[8].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[8].path)}`);
     const { data } = features[8];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[8].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[8].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[8].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[8].path));
     });
 
     await test.step('step-2: Verify Merch Card catalog content/specs', async () => {
@@ -324,13 +335,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 9 : Merch Card (catalog) with badge
   test(`[Test Id - ${features[9].tcid}] ${features[9].name},${features[9].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[9].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[9].path)}`);
     const { data } = features[9];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[9].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[9].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[9].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[9].path));
     });
 
     await test.step('step-2: Verify Merch Card catalog with badge content/specs', async () => {
@@ -365,13 +376,13 @@ test.describe('Milo Merchcard block test suite', () => {
 
   // Test 10 : Merch Card (catalog) with more info and badge
   test(`[Test Id - ${features[10].tcid}] ${features[10].name},${features[10].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[10].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[10].path)}`);
     const { data } = features[10];
 
     await test.step('step-1: Go to Merch Card feature test page', async () => {
-      await page.goto(`${baseURL}${features[10].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[10].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[10].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[10].path));
     });
 
     await test.step('step-2: Verify Merch Card catalog with badge content/specs', async () => {

--- a/nala/blocks/tabs/tabs.test.js
+++ b/nala/blocks/tabs/tabs.test.js
@@ -2,21 +2,9 @@ import { expect, test } from '@playwright/test';
 import { features } from './tabs.spec.js';
 import TabBlock from './tabs.page.js';
 import { runAccessibilityTest } from '../../libs/accessibility.js';
-import { constructUrlWithParams } from '../../libs/commerce.js';
+import { constructTestUrl } from '../../libs/commerce.js';
 
 let tab;
-
-const miloLibs = process.env.MILO_LIBS || '';
-const masLibs = process.env.MAS_LIBS || '';
-
-// Helper function to construct URLs with proper query parameter handling
-function constructTestUrl(baseURL, path, browserParams = '') {
-  let fullUrl = `${baseURL}${path}`;
-  fullUrl = constructUrlWithParams(fullUrl, browserParams);
-  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
-  fullUrl = constructUrlWithParams(fullUrl, masLibs);
-  return fullUrl;
-}
 
 const INTERVALS = Array(5).fill(1000);
 

--- a/nala/blocks/tabs/tabs.test.js
+++ b/nala/blocks/tabs/tabs.test.js
@@ -2,10 +2,22 @@ import { expect, test } from '@playwright/test';
 import { features } from './tabs.spec.js';
 import TabBlock from './tabs.page.js';
 import { runAccessibilityTest } from '../../libs/accessibility.js';
+import { constructUrlWithParams } from '../../libs/commerce.js';
 
 let tab;
 
 const miloLibs = process.env.MILO_LIBS || '';
+const masLibs = process.env.MAS_LIBS || '';
+
+// Helper function to construct URLs with proper query parameter handling
+function constructTestUrl(baseURL, path, browserParams = '') {
+  let fullUrl = `${baseURL}${path}`;
+  fullUrl = constructUrlWithParams(fullUrl, browserParams);
+  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
+  fullUrl = constructUrlWithParams(fullUrl, masLibs);
+  return fullUrl;
+}
+
 const INTERVALS = Array(5).fill(1000);
 
 test.describe('Milo Tab block feature test suite', () => {
@@ -15,13 +27,13 @@ test.describe('Milo Tab block feature test suite', () => {
 
   // Test 0 : Tabs (xl-spacing)
   test(`[Test Id - ${features[0].tcid}] ${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[0].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[0].path)}`);
     const { data } = features[0];
 
     await test.step('step-1: Go to Tabs block feature test page', async () => {
-      await page.goto(`${baseURL}${features[0].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[0].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[0].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[0].path));
     });
 
     await test.step('step-2: Verify tabs content/specs', async () => {
@@ -51,13 +63,13 @@ test.describe('Milo Tab block feature test suite', () => {
 
   // Test 1 : Tabs (Quiet, Dark, Center)
   test(`[Test Id - ${features[1].tcid}] ${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[1].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[1].path)}`);
     const { data } = features[1];
 
     await test.step('step-1: Go to Tabs block feature test page', async () => {
-      await page.goto(`${baseURL}${features[1].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[1].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[1].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[1].path));
     });
 
     await test.step('step-2: Verify tabs content/specs', async () => {
@@ -87,8 +99,8 @@ test.describe('Milo Tab block feature test suite', () => {
 
   // Test 2 : Tabs (Tabs scrolling)
   test(`[Test Id - ${features[0].tcid}] ${features[2].tags}`, async ({ page, baseURL, isMobile }) => {
-    console.log(`[Test Page]: ${baseURL}${features[2].path}${miloLibs}`);
-    await page.goto(`${baseURL}${features[2].path}${miloLibs}`);
+    console.log(`[Test Page]: ${constructTestUrl(baseURL, features[2].path)}`);
+    await page.goto(constructTestUrl(baseURL, features[2].path));
     await page.waitForLoadState('networkidle');
 
     await test.step('checking the setup', async () => {
@@ -151,8 +163,8 @@ test.describe('Milo Tab block feature test suite', () => {
   test(`[Test Id - ${features[3].tcid}] ${features[3].tags}`, async ({ page, baseURL, browserName }) => {
     test.skip(browserName === 'webkit', 'Skipping test on WebKit');
 
-    console.log(`[Test Page]: ${baseURL}${features[3].path}${miloLibs}`);
-    await page.goto(`${baseURL}${features[3].path}${miloLibs}`);
+    console.log(`[Test Page]: ${constructTestUrl(baseURL, features[3].path)}`);
+    await page.goto(constructTestUrl(baseURL, features[3].path));
     await page.waitForLoadState('networkidle');
 
     await test.step('checking the setup', async () => {
@@ -180,13 +192,13 @@ test.describe('Milo Tab block feature test suite', () => {
 
   // Test 4 : Tabs with custom deeplink
   test(`[Test Id - ${features[4].tcid}] ${features[4].name},${features[4].tags}`, async ({ page, baseURL }) => {
-    console.info(`[Test Page]: ${baseURL}${features[4].path}${miloLibs}`);
+    console.info(`[Test Page]: ${constructTestUrl(baseURL, features[4].path)}`);
     const { data } = features[4];
 
     await test.step('step-1: Go to Tabs Deeplink test page', async () => {
-      await page.goto(`${baseURL}${features[4].path}${miloLibs}`);
+      await page.goto(constructTestUrl(baseURL, features[4].path));
       await page.waitForLoadState('domcontentloaded');
-      await expect(page).toHaveURL(`${baseURL}${features[4].path}${miloLibs}`);
+      await expect(page).toHaveURL(constructTestUrl(baseURL, features[4].path));
       // verify default tab contents
       await expect(await tab.tab2).toHaveAttribute('aria-selected', 'true');
       await expect(await tab.tab2Panel).toBeVisible();

--- a/nala/features/commerce/commerce.test.js
+++ b/nala/features/commerce/commerce.test.js
@@ -4,19 +4,7 @@ import { features } from './commerce.spec.js';
 import CommercePage from './commerce.page.js';
 import FedsLogin from '../feds/login/login.page.js';
 import FedsHeader from '../feds/header/header.page.js';
-import { PRICE_PATTERN, constructUrlWithParams } from '../../libs/commerce.js';
-
-const miloLibs = process.env.MILO_LIBS || '';
-const masLibs = process.env.MAS_LIBS || '';
-
-// Helper function to construct URLs with proper query parameter handling
-function constructTestUrl(baseURL, path, browserParams = '') {
-  let fullUrl = `${baseURL}${path}`;
-  fullUrl = constructUrlWithParams(fullUrl, browserParams);
-  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
-  fullUrl = constructUrlWithParams(fullUrl, masLibs);
-  return fullUrl;
-}
+import { PRICE_PATTERN, constructTestUrl } from '../../libs/commerce.js';
 
 let COMM;
 test.beforeEach(async ({ page, baseURL, browserName }) => {

--- a/nala/features/commerce/commerce.test.js
+++ b/nala/features/commerce/commerce.test.js
@@ -4,9 +4,19 @@ import { features } from './commerce.spec.js';
 import CommercePage from './commerce.page.js';
 import FedsLogin from '../feds/login/login.page.js';
 import FedsHeader from '../feds/header/header.page.js';
-import { PRICE_PATTERN } from '../../libs/commerce.js';
+import { PRICE_PATTERN, constructUrlWithParams } from '../../libs/commerce.js';
 
 const miloLibs = process.env.MILO_LIBS || '';
+const masLibs = process.env.MAS_LIBS || '';
+
+// Helper function to construct URLs with proper query parameter handling
+function constructTestUrl(baseURL, path, browserParams = '') {
+  let fullUrl = `${baseURL}${path}`;
+  fullUrl = constructUrlWithParams(fullUrl, browserParams);
+  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
+  fullUrl = constructUrlWithParams(fullUrl, masLibs);
+  return fullUrl;
+}
 
 let COMM;
 test.beforeEach(async ({ page, baseURL, browserName }) => {
@@ -27,7 +37,7 @@ test.beforeEach(async ({ page, baseURL, browserName }) => {
 test.describe('Commerce feature test suite', () => {
   // @Commerce-Price-Term - Validate price with term display
   test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[0].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[0].path);
     console.info('[Test Page]: ', testPage);
 
     await test.step('Go to the test page', async () => {
@@ -66,7 +76,7 @@ test.describe('Commerce feature test suite', () => {
 
   // @Commerce-Price-Unit-Term - Validate price with term and unit display
   test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[1].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[1].path);
     console.info('[Test Page]: ', testPage);
 
     await test.step('Go to the test page', async () => {
@@ -105,7 +115,7 @@ test.describe('Commerce feature test suite', () => {
 
   // @Commerce-Price-Taxlabel-Unit-Term - Validate price with term, unit and tax label display
   test(`${features[2].name},${features[2].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[2].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[2].path);
     console.info('[Test Page]: ', testPage);
 
     await test.step('Go to the test page', async () => {
@@ -144,7 +154,7 @@ test.describe('Commerce feature test suite', () => {
 
   // @Commerce-Promo - Validate price and CTAs have promo code applied
   test(`${features[3].name},${features[3].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[3].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[3].path);
     const { data } = features[3];
 
     console.info('[Test Page]: ', testPage);
@@ -190,7 +200,7 @@ test.describe('Commerce feature test suite', () => {
   test(`${features[4].name}, ${features[4].tags}`, async ({ page, baseURL }) => {
     test.skip(); // Skipping due to missing login
 
-    const testPage = `${baseURL}${features[4].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[4].path);
     console.info('[Test Page]: ', testPage);
 
     const { data } = features[4];
@@ -231,7 +241,7 @@ test.describe('Commerce feature test suite', () => {
   test(`${features[5].name}, ${features[5].tags}`, async ({ page, baseURL }) => {
     test.skip(); // Skipping due to missing login
 
-    const testPage = `${baseURL}${features[5].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[5].path);
     console.info('[Test Page]: ', testPage);
     const { data } = features[5];
     const Login = new FedsLogin(page);
@@ -270,7 +280,7 @@ test.describe('Commerce feature test suite', () => {
 
   // @Commerce-KitchenSink-Smoke - Validate commerce CTA and checkout placeholders
   test(`${features[6].name}, ${features[6].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[6].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[6].path);
     const webUtil = new WebUtil(page);
 
     console.info('[Test Page]: ', testPage);
@@ -306,7 +316,7 @@ test.describe('Commerce feature test suite', () => {
 
   // @Commerce-DE - Validate commerce CTA and checkout placeholders in DE locale
   test(`${features[7].name}, ${features[7].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[7].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[7].path);
     const { data } = features[7];
 
     console.info('[Test Page]: ', testPage);
@@ -377,7 +387,7 @@ test.describe('Commerce feature test suite', () => {
 
   // @Commerce-Old-Promo - Validate promo price WITHOUT old price
   test(`${features[8].name},${features[8].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[8].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[8].path);
     const { data } = features[8];
 
     console.info('[Test Page]: ', testPage);
@@ -400,7 +410,7 @@ test.describe('Commerce feature test suite', () => {
 
   // @Commerce-GB - Validate commerce CTA and checkout placeholders in UK locale
   test(`${features[9].name}, ${features[9].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[9].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[9].path);
     const { data } = features[9];
 
     console.info('[Test Page]: ', testPage);

--- a/nala/features/mas/acom/plans/plans.test.js
+++ b/nala/features/mas/acom/plans/plans.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { features } from './plans.spec.js';
 import MasPlans from './plans.page.js';
-import { createWorkerPageSetup, PLANS_NALA_PATH } from '../../../../libs/commerce.js';
+import { createWorkerPageSetup, constructUrlWithParams, PLANS_NALA_PATH } from '../../../../libs/commerce.js';
 
 test.skip(({ browserName }) => browserName !== 'chromium', 'Not supported to run on multiple browsers.');
 
@@ -190,9 +190,11 @@ test.describe('MAS Plans Page test suite', () => {
       const masPlans = new MasPlans(page);
 
       await test.step(`step-${stepNumber}: Verify ${tabName} tab deeplink and content`, async () => {
-        await page.goto(`${PLANS_NALA_PATH.US}${tabData.urlParam}`);
+        const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, tabData.urlParam);
+        await page.goto(targetUrl);
         await page.waitForLoadState('domcontentloaded');
-        await workerSetup.verifyPageURL('US', PLANS_NALA_PATH.US + tabData.urlParam, expect);
+        const expectedUrl = constructUrlWithParams(PLANS_NALA_PATH.US, tabData.urlParam);
+        await workerSetup.verifyPageURL('US', expectedUrl, expect);
 
         const tab = masPlans.getTabs(tabData.tabId);
         await expect(tab).toHaveAttribute('aria-selected', 'true');
@@ -206,7 +208,8 @@ test.describe('MAS Plans Page test suite', () => {
   // @MAS-Plans-Modal-Deeplink
   test(`${features[3].name},${features[3].tags}`, async ({ page }) => {
     await test.step('step-1: Go to Plans page', async () => {
-      await page.goto(`${PLANS_NALA_PATH.US}${features[3].browserParams}`);
+      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[3].browserParams);
+      await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
       await expect(page.locator(`.dialog-modal.three-in-one${features[3].browserParams}`)).toBeVisible({ timeout: 10000 });
     });
@@ -218,7 +221,8 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page with edu deeplink', async () => {
-      await page.goto(`${PLANS_NALA_PATH.US}${features[4].browserParams.landing}`);
+      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[4].browserParams.landing);
+      await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('merch-card-collection');
     });
@@ -244,7 +248,8 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page with edu deeplink', async () => {
-      await page.goto(`${PLANS_NALA_PATH.US}${features[5].browserParams.landing}`);
+      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[5].browserParams.landing);
+      await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('merch-card-collection');
     });
@@ -265,7 +270,8 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page', async () => {
-      await page.goto(`${PLANS_NALA_PATH.US}${features[6].browserParams}`);
+      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[6].browserParams);
+      await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
     });
 
@@ -355,7 +361,8 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page', async () => {
-      await page.goto(`${PLANS_NALA_PATH.US}${features[8].browserParams}`);
+      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[8].browserParams);
+      await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
     });
 
@@ -385,7 +392,8 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page', async () => {
-      await page.goto(`${PLANS_NALA_PATH.US}${features[9].browserParams}`);
+      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[9].browserParams);
+      await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
     });
 

--- a/nala/features/mas/acom/plans/plans.test.js
+++ b/nala/features/mas/acom/plans/plans.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { features } from './plans.spec.js';
 import MasPlans from './plans.page.js';
-import { createWorkerPageSetup, constructUrlWithParams, PLANS_NALA_PATH } from '../../../../libs/commerce.js';
+import { createWorkerPageSetup, addUrlQueryParams, PLANS_NALA_PATH } from '../../../../libs/commerce.js';
 
 test.skip(({ browserName }) => browserName !== 'chromium', 'Not supported to run on multiple browsers.');
 
@@ -190,10 +190,10 @@ test.describe('MAS Plans Page test suite', () => {
       const masPlans = new MasPlans(page);
 
       await test.step(`step-${stepNumber}: Verify ${tabName} tab deeplink and content`, async () => {
-        const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, tabData.urlParam);
+        const targetUrl = addUrlQueryParams(PLANS_NALA_PATH.US, tabData.urlParam);
         await page.goto(targetUrl);
         await page.waitForLoadState('domcontentloaded');
-        const expectedUrl = constructUrlWithParams(PLANS_NALA_PATH.US, tabData.urlParam);
+        const expectedUrl = addUrlQueryParams(PLANS_NALA_PATH.US, tabData.urlParam);
         await workerSetup.verifyPageURL('US', expectedUrl, expect);
 
         const tab = masPlans.getTabs(tabData.tabId);
@@ -208,7 +208,7 @@ test.describe('MAS Plans Page test suite', () => {
   // @MAS-Plans-Modal-Deeplink
   test(`${features[3].name},${features[3].tags}`, async ({ page }) => {
     await test.step('step-1: Go to Plans page', async () => {
-      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[3].browserParams);
+      const targetUrl = addUrlQueryParams(PLANS_NALA_PATH.US, features[3].browserParams);
       await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
       await expect(page.locator(`.dialog-modal.three-in-one${features[3].browserParams}`)).toBeVisible({ timeout: 10000 });
@@ -221,7 +221,7 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page with edu deeplink', async () => {
-      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[4].browserParams.landing);
+      const targetUrl = addUrlQueryParams(PLANS_NALA_PATH.US, features[4].browserParams.landing);
       await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('merch-card-collection');
@@ -248,7 +248,7 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page with edu deeplink', async () => {
-      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[5].browserParams.landing);
+      const targetUrl = addUrlQueryParams(PLANS_NALA_PATH.US, features[5].browserParams.landing);
       await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('merch-card-collection');
@@ -270,7 +270,7 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page', async () => {
-      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[6].browserParams);
+      const targetUrl = addUrlQueryParams(PLANS_NALA_PATH.US, features[6].browserParams);
       await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
     });
@@ -361,7 +361,7 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page', async () => {
-      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[8].browserParams);
+      const targetUrl = addUrlQueryParams(PLANS_NALA_PATH.US, features[8].browserParams);
       await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
     });
@@ -392,7 +392,7 @@ test.describe('MAS Plans Page test suite', () => {
     const masPlans = new MasPlans(page);
 
     await test.step('step-1: Go to Plans page', async () => {
-      const targetUrl = constructUrlWithParams(PLANS_NALA_PATH.US, features[9].browserParams);
+      const targetUrl = addUrlQueryParams(PLANS_NALA_PATH.US, features[9].browserParams);
       await page.goto(targetUrl);
       await page.waitForLoadState('domcontentloaded');
     });

--- a/nala/features/mas/acom/plans/plansdocs.test.js
+++ b/nala/features/mas/acom/plans/plansdocs.test.js
@@ -2,11 +2,10 @@ import { expect, test } from '@playwright/test';
 import { features } from './plansdocs.spec.js';
 import MasPlans from './plans.page.js';
 import WebUtil from '../../../../libs/webutil.js';
-import { createWorkerPageSetup, DOCS_GALLERY_PATH } from '../../../../libs/commerce.js';
+import { createWorkerPageSetup, validateCommerceUrl, DOCS_GALLERY_PATH } from '../../../../libs/commerce.js';
 
 let acomPage;
 let webUtil;
-const COMMERCE_LINK_REGEX = /https:\/\/commerce\.adobe\.com\/store\/email\?items%5B0%5D%5Bid%5D=([A-F0-9]{32}&apc=FY25PLES256MROW&cli=adobe_com&ctx=fp&co=US&lang=en)/i;
 
 test.skip(({ browserName }) => browserName !== 'chromium', 'Not supported to run on multiple browsers.');
 
@@ -63,7 +62,8 @@ test.describe('ACOM MAS cards feature test suite', () => {
       await expect(await acomPage.getCardCTA(data.id)).toHaveAttribute('class', /con-button blue/);
       await expect(await acomPage.getCardCTA(data.id)).toHaveAttribute('data-wcs-osi', data.ctaOsi);
       await expect(await acomPage.getCardCTA(data.id)).toContainText(data.cta);
-      await expect((await acomPage.getCardCTA(data.id)).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX);
+      const ctaHref = await (await acomPage.getCardCTA(data.id)).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref, { requiredParams: ['apc'] })).toBe(true);
       await expect(await acomPage.getCardCTA(data.id)).toHaveAttribute('data-analytics-id', /.*/);
     });
   });

--- a/nala/features/mas/benchmark/benchmark.test.js
+++ b/nala/features/mas/benchmark/benchmark.test.js
@@ -1,8 +1,19 @@
 import { expect, test } from '@playwright/test';
 import { features } from './benchmark.spec.js';
 import BenchmarkPage from './benchmark.page.js';
+import { constructUrlWithParams } from '../../../libs/commerce.js';
 
 const miloLibs = process.env.MILO_LIBS || '';
+const masLibs = process.env.MAS_LIBS || '';
+
+// Helper function to construct URLs with proper query parameter handling
+function constructTestUrl(baseURL, path, browserParams = '') {
+  let fullUrl = `${baseURL}${path}`;
+  fullUrl = constructUrlWithParams(fullUrl, browserParams);
+  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
+  fullUrl = constructUrlWithParams(fullUrl, masLibs);
+  return fullUrl;
+}
 
 test.beforeEach(async ({ page, browserName }) => {
   test.skip(browserName !== 'chromium', 'Not supported to run on multiple browsers.');
@@ -15,7 +26,7 @@ test.beforeEach(async ({ page, browserName }) => {
 
 test.describe('Benchmark feature test suite', () => {
   test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[0].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[0].path);
     console.info('[Test Page]: ', testPage);
 
     await test.step('step-1: Go to Merch Card Benchmark feature test page', async () => {

--- a/nala/features/mas/benchmark/benchmark.test.js
+++ b/nala/features/mas/benchmark/benchmark.test.js
@@ -1,19 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { features } from './benchmark.spec.js';
 import BenchmarkPage from './benchmark.page.js';
-import { constructUrlWithParams } from '../../../libs/commerce.js';
-
-const miloLibs = process.env.MILO_LIBS || '';
-const masLibs = process.env.MAS_LIBS || '';
-
-// Helper function to construct URLs with proper query parameter handling
-function constructTestUrl(baseURL, path, browserParams = '') {
-  let fullUrl = `${baseURL}${path}`;
-  fullUrl = constructUrlWithParams(fullUrl, browserParams);
-  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
-  fullUrl = constructUrlWithParams(fullUrl, masLibs);
-  return fullUrl;
-}
+import { constructTestUrl } from '../../../libs/commerce.js';
 
 test.beforeEach(async ({ page, browserName }) => {
   test.skip(browserName !== 'chromium', 'Not supported to run on multiple browsers.');

--- a/nala/features/mas/ccd/masccd.test.js
+++ b/nala/features/mas/ccd/masccd.test.js
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import { features } from './masccd.spec.js';
 import MerchCCD from './masccd.page.js';
 import WebUtil from '../../../libs/webutil.js';
-import { createWorkerPageSetup, DOCS_GALLERY_PATH } from '../../../libs/commerce.js';
+import { createWorkerPageSetup, constructUrlWithParams, DOCS_GALLERY_PATH } from '../../../libs/commerce.js';
 
 const COMMERCE_LINK_REGEX = (country = 'US', language = 'en') => new RegExp(`https://commerce.adobe.com/store/email\\?items%5B0%5D%5Bid%5D=([A-F0-9]{32}&cli=adobe_com&ctx=fp&co=${country}&lang=${language})`, 'i');
 
@@ -14,9 +14,9 @@ test.skip(({ browserName }) => browserName !== 'chromium', 'Not supported to run
 const workerSetup = createWorkerPageSetup({
   pages: [
     { name: 'US_LIGHT', url: DOCS_GALLERY_PATH.CCD.US },
-    { name: 'US_DARK', url: `${DOCS_GALLERY_PATH.CCD.US}?theme=darkest` },
+    { name: 'US_DARK', url: constructUrlWithParams(DOCS_GALLERY_PATH.CCD.US, '?theme=darkest') },
     { name: 'FR_LIGHT', url: DOCS_GALLERY_PATH.CCD.FR },
-    { name: 'FR_DARK', url: `${DOCS_GALLERY_PATH.CCD.FR}&theme=darkest` },
+    { name: 'FR_DARK', url: constructUrlWithParams(DOCS_GALLERY_PATH.CCD.FR, '&theme=darkest') },
   ],
 });
 

--- a/nala/features/mas/ccd/masccd.test.js
+++ b/nala/features/mas/ccd/masccd.test.js
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import { features } from './masccd.spec.js';
 import MerchCCD from './masccd.page.js';
 import WebUtil from '../../../libs/webutil.js';
-import { createWorkerPageSetup, constructUrlWithParams, DOCS_GALLERY_PATH } from '../../../libs/commerce.js';
+import { createWorkerPageSetup, addUrlQueryParams, DOCS_GALLERY_PATH } from '../../../libs/commerce.js';
 
 const COMMERCE_LINK_REGEX = (country = 'US', language = 'en') => new RegExp(`https://commerce.adobe.com/store/email\\?items%5B0%5D%5Bid%5D=([A-F0-9]{32}&cli=adobe_com&ctx=fp&co=${country}&lang=${language})`, 'i');
 
@@ -14,9 +14,9 @@ test.skip(({ browserName }) => browserName !== 'chromium', 'Not supported to run
 const workerSetup = createWorkerPageSetup({
   pages: [
     { name: 'US_LIGHT', url: DOCS_GALLERY_PATH.CCD.US },
-    { name: 'US_DARK', url: constructUrlWithParams(DOCS_GALLERY_PATH.CCD.US, '?theme=darkest') },
+    { name: 'US_DARK', url: addUrlQueryParams(DOCS_GALLERY_PATH.CCD.US, '?theme=darkest') },
     { name: 'FR_LIGHT', url: DOCS_GALLERY_PATH.CCD.FR },
-    { name: 'FR_DARK', url: constructUrlWithParams(DOCS_GALLERY_PATH.CCD.FR, '&theme=darkest') },
+    { name: 'FR_DARK', url: addUrlQueryParams(DOCS_GALLERY_PATH.CCD.FR, '&theme=darkest') },
   ],
 });
 

--- a/nala/features/mas/ccd/masccd.test.js
+++ b/nala/features/mas/ccd/masccd.test.js
@@ -2,9 +2,7 @@ import { expect, test } from '@playwright/test';
 import { features } from './masccd.spec.js';
 import MerchCCD from './masccd.page.js';
 import WebUtil from '../../../libs/webutil.js';
-import { createWorkerPageSetup, addUrlQueryParams, DOCS_GALLERY_PATH } from '../../../libs/commerce.js';
-
-const COMMERCE_LINK_REGEX = (country = 'US', language = 'en') => new RegExp(`https://commerce.adobe.com/store/email\\?items%5B0%5D%5Bid%5D=([A-F0-9]{32}&cli=adobe_com&ctx=fp&co=${country}&lang=${language})`, 'i');
+import { createWorkerPageSetup, addUrlQueryParams, validateCommerceUrl, DOCS_GALLERY_PATH } from '../../../libs/commerce.js';
 
 let CCD;
 let webUtil;
@@ -65,7 +63,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('data-wcs-osi', data.osi);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -131,7 +130,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('data-wcs-osi', data.osi);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', data.ctaAnalyticsId);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('daa-ll', data.ctaDaaLL);
     });
@@ -196,7 +196,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -255,7 +256,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', /.*/);
       await expect(await CCD.getCard(data.id, 'suggested')).toHaveAttribute('background-image', new RegExp(data.background));
     });
@@ -319,7 +321,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', /.*/);
       await expect(await CCD.getCard(data.id, 'suggested')).toHaveAttribute('background-image', new RegExp(data.background));
     });
@@ -382,7 +385,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', /.*/);
       await expect(await CCD.getCard(data.id, 'suggested')).toHaveAttribute('background-image', new RegExp(data.background));
     });
@@ -443,7 +447,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', /.*/);
       await expect(await CCD.getCard(data.id, 'suggested')).toHaveAttribute('background-image', new RegExp(data.background));
     });
@@ -507,7 +512,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', /.*/);
       await expect(await CCD.getCard(data.id, 'suggested')).toHaveAttribute('background-image', new RegExp(data.background));
     });
@@ -629,7 +635,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice')).toContainText(data.cta);
-      await expect(((await CCD.getCardCTALink(data.id, 'slice'))).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -692,7 +699,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -753,7 +761,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -810,7 +819,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -866,7 +876,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -990,7 +1001,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toHaveAttribute('data-wcs-osi', data.osi);
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice-wide')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -1051,7 +1063,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice-wide')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -1114,7 +1127,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice-wide')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -1176,7 +1190,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX());
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref)).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice-wide')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -1256,7 +1271,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('data-wcs-osi', data.osi);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX('FR', 'fr'));
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref, { country: 'FR', language: 'fr' })).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', /.*/);
     });
   });
@@ -1311,7 +1327,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice')).toContainText(data.cta);
-      await expect(((await CCD.getCardCTALink(data.id, 'slice'))).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX('FR', 'fr'));
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref, { country: 'FR', language: 'fr' })).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -1376,7 +1393,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toHaveAttribute('class', /accent/);
       await expect(await CCD.getCardCTA(data.id, 'slice-wide')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX('FR', 'fr'));
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'slice-wide')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref, { country: 'FR', language: 'fr' })).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'slice-wide')).toHaveAttribute('data-analytics-id', /.*/);
     });
 
@@ -1438,7 +1456,8 @@ test.describe('CCD Merchcard feature test suite', () => {
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toBeVisible();
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toHaveAttribute('class', /primary/);
       await expect(await CCD.getCardCTA(data.id, 'suggested')).toContainText(data.cta);
-      await expect((await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href)).resolves.toMatch(COMMERCE_LINK_REGEX('FR', 'fr'));
+      const ctaHref = await (await CCD.getCardCTALink(data.id, 'suggested')).evaluate((el) => el.href);
+      expect(validateCommerceUrl(ctaHref, { country: 'FR', language: 'fr' })).toBe(true);
       await expect(await CCD.getCardCTALink(data.id, 'suggested')).toHaveAttribute('data-analytics-id', /.*/);
       await expect(await CCD.getCard(data.id, 'suggested')).toHaveAttribute('background-image', new RegExp(data.background));
     });

--- a/nala/features/mas/docs/masdocs.test.js
+++ b/nala/features/mas/docs/masdocs.test.js
@@ -1,18 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { features } from './masdocs.spec.js';
-import { constructUrlWithParams } from '../../../libs/commerce.js';
-
-const miloLibs = process.env.MILO_LIBS || '';
-const masLibs = process.env.MAS_LIBS || '';
-
-// Helper function to construct URLs with proper query parameter handling
-function constructTestUrl(baseURL, path, browserParams = '') {
-  let fullUrl = `${baseURL}${path}`;
-  fullUrl = constructUrlWithParams(fullUrl, browserParams);
-  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
-  fullUrl = constructUrlWithParams(fullUrl, masLibs);
-  return fullUrl;
-}
+import { constructTestUrl } from '../../../libs/commerce.js';
 
 test.describe('MAS Docs feature test suite', () => {
   test.beforeEach(async ({ page, browserName }) => {

--- a/nala/features/mas/docs/masdocs.test.js
+++ b/nala/features/mas/docs/masdocs.test.js
@@ -1,7 +1,18 @@
 import { expect, test } from '@playwright/test';
 import { features } from './masdocs.spec.js';
+import { constructUrlWithParams } from '../../../libs/commerce.js';
 
 const miloLibs = process.env.MILO_LIBS || '';
+const masLibs = process.env.MAS_LIBS || '';
+
+// Helper function to construct URLs with proper query parameter handling
+function constructTestUrl(baseURL, path, browserParams = '') {
+  let fullUrl = `${baseURL}${path}`;
+  fullUrl = constructUrlWithParams(fullUrl, browserParams);
+  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
+  fullUrl = constructUrlWithParams(fullUrl, masLibs);
+  return fullUrl;
+}
 
 test.describe('MAS Docs feature test suite', () => {
   test.beforeEach(async ({ page, browserName }) => {
@@ -16,7 +27,7 @@ test.describe('MAS Docs feature test suite', () => {
 
   // @MAS-DOCS-checkout-link
   test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[0].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[0].path);
     console.info('[Test Page]: ', testPage);
 
     await test.step('step-1: Go to MAS Checkout Link Docs page', async () => {
@@ -40,7 +51,7 @@ test.describe('MAS Docs feature test suite', () => {
 
   // @MAS-DOCS-merch-card
   test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[1].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[1].path);
     console.info('[Test Page]: ', testPage);
 
     await test.step('step-1: Go to MAS Merch Card Docs page', async () => {

--- a/nala/features/mas/express/express.spec.js
+++ b/nala/features/mas/express/express.spec.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+const { DOCS_GALLERY_PATH, PRICE_PATTERN } = require('../../../libs/commerce.js');
 
 module.exports = {
   FeatureName: 'MAS Express Cards',
@@ -6,13 +7,13 @@ module.exports = {
     {
       tcid: '0',
       name: '@MAS-Express-Card-Free',
-      path: '/libs/features/mas/docs/express.html',
+      path: DOCS_GALLERY_PATH.EXPRESS,
       data: {
         id: '67c78f03-7d88-44c9-9a06-05443ec9265d',
         title: 'Free',
         badge: '', // No badge for free card
         description: 'Basic content creation tools, limited generative AI credits and assets.',
-        price: 'US$0.00',
+        price: /US\$0\.00/,
         priceNote: 'Free to use. No credit card required.',
         cta: 'Get Adobe Express Free',
         variant: 'simplified-pricing-express',
@@ -22,13 +23,13 @@ module.exports = {
     {
       tcid: '1',
       name: '@MAS-Express-Card-Premium',
-      path: '/libs/features/mas/docs/express.html',
+      path: DOCS_GALLERY_PATH.EXPRESS,
       data: {
         id: 'b28957b9-2341-40f9-9004-24446f68e5e5',
         title: 'Premium',
         badge: '', // No badge for premium card
         description: 'Access millions of assets, more AI credits, and premium tools.',
-        price: 'US$9.99',
+        price: PRICE_PATTERN.US.mo,
         priceNote: 'No annual commitment, billed monthly.',
         cta: 'Start 30-day free trial',
         variant: 'simplified-pricing-express',
@@ -39,13 +40,13 @@ module.exports = {
     {
       tcid: '2',
       name: '@MAS-Express-Card-Firefly-Pro',
-      path: '/libs/features/mas/docs/express.html',
+      path: DOCS_GALLERY_PATH.EXPRESS,
       data: {
         id: 'aaa728dc-2b44-495c-b9f0-bb82044db18a',
         title: 'Firefly Pro',
         badge: 'Best value', // Updated based on actual content
         description: 'Get Adobe Express Premium plus 4,000 credits for creative AI and Adobe Photoshop on web and mobile for advanced image editing.',
-        price: 'US$9.99/mo',
+        price: PRICE_PATTERN.US.mo,
         priceNote: 'No annual commitment, billed monthly.',
         priceAdditionalNote: '',
         cta: 'Start 14-day free trial',

--- a/nala/features/mas/express/express.test.js
+++ b/nala/features/mas/express/express.test.js
@@ -2,26 +2,37 @@ import { expect, test } from '@playwright/test';
 import { features } from './express.spec.js';
 import ExpressCard from './express.page.js';
 import { runAccessibilityTest } from '../../../libs/accessibility.js';
+import { createWorkerPageSetup, DOCS_GALLERY_PATH } from '../../../libs/commerce.js';
 
-const miloLibs = process.env.MILO_LIBS || '';
+test.skip(({ browserName }) => browserName !== 'chromium', 'Not supported to run on multiple browsers.');
+
+const workerSetup = createWorkerPageSetup({
+  pages: [
+    { name: 'EXPRESS', url: DOCS_GALLERY_PATH.EXPRESS },
+  ],
+});
 
 test.describe('MAS Express Cards test suite', () => {
-  test.beforeEach(async ({ page, browserName }) => {
-    test.skip(browserName !== 'chromium', 'Not supported to run on multiple browsers.');
-
-    if (browserName === 'chromium') {
-      await page.setExtraHTTPHeaders({ 'sec-ch-ua': '"Chromium";v="123", "Not:A-Brand";v="8"' });
-    }
+  test.beforeAll(async ({ browser, baseURL }) => {
+    await workerSetup.setupWorkerPages({ browser, baseURL });
   });
 
-  test(`[Test Id - ${features[0].tcid}] ${features[0].name}, ${features[0].tags}`, async ({ page, baseURL }) => {
-    const { data } = features[0];
-    console.info(`[Test Page]: ${baseURL}${features[0].path}${miloLibs}`);
+  test.afterAll(async () => {
+    await workerSetup.cleanupWorkerPages();
+  });
 
-    await test.step('step-1: Go to Express page', async () => {
-      await page.goto(`${baseURL}${features[0].path}${miloLibs}`);
-      await page.waitForLoadState('networkidle');
-      await expect(page).toHaveURL(`${baseURL}${features[0].path}${miloLibs}`);
+  test.afterEach(async ({}, testInfo) => { // eslint-disable-line no-empty-pattern
+    workerSetup.attachWorkerErrorsToFailure(testInfo);
+  });
+
+  test(`[Test Id - ${features[0].tcid}] ${features[0].name}, ${features[0].tags}`, async () => {
+    const { data } = features[0];
+    const page = workerSetup.getPage('EXPRESS');
+
+    console.info(`[Test Page]: ${await page.url()}`);
+
+    await test.step('step-1: Wait for Express page elements', async () => {
+      await workerSetup.verifyPageURL('EXPRESS', DOCS_GALLERY_PATH.EXPRESS, expect);
 
       await page.waitForSelector('merch-card-collection', { timeout: 30000 });
       await page.waitForSelector('merch-card[variant="simplified-pricing-express"]', { timeout: 30000 });
@@ -39,7 +50,7 @@ test.describe('MAS Express Cards test suite', () => {
         await expect(card.badge).toContainText(data.badge);
       }
       await expect(card.description).toContainText(data.description);
-      await expect(card.price).toContainText(data.price);
+      await expect(card.price).toContainText(new RegExp(data.price));
       await expect(card.priceNote).toContainText(data.priceNote);
       await expect(card.ctaButton).toContainText(data.cta);
     });
@@ -50,14 +61,14 @@ test.describe('MAS Express Cards test suite', () => {
     });
   });
 
-  test(`[Test Id - ${features[1].tcid}] ${features[1].name}, ${features[1].tags}`, async ({ page, baseURL }) => {
+  test(`[Test Id - ${features[1].tcid}] ${features[1].name}, ${features[1].tags}`, async () => {
     const { data } = features[1];
-    console.info(`[Test Page]: ${baseURL}${features[1].path}${miloLibs}`);
+    const page = workerSetup.getPage('EXPRESS');
 
-    await test.step('step-1: Go to Express page', async () => {
-      await page.goto(`${baseURL}${features[1].path}${miloLibs}`);
-      await page.waitForLoadState('networkidle');
-      await expect(page).toHaveURL(`${baseURL}${features[1].path}${miloLibs}`);
+    console.info(`[Test Page]: ${await page.url()}`);
+
+    await test.step('step-1: Wait for Express page elements', async () => {
+      await workerSetup.verifyPageURL('EXPRESS', DOCS_GALLERY_PATH.EXPRESS, expect);
 
       await page.waitForSelector('merch-card-collection', { timeout: 30000 });
       await page.waitForSelector('merch-card[variant="simplified-pricing-express"]', { timeout: 30000 });
@@ -80,7 +91,7 @@ test.describe('MAS Express Cards test suite', () => {
       if (viewportWidth >= 1200 && data.priceStrikethrough) {
         await expect(card.priceStrikethrough).toBeVisible();
       }
-      await expect(card.price).toContainText(data.price);
+      await expect(card.price).toContainText(new RegExp(data.price));
       await expect(card.priceNote).toContainText(data.priceNote);
 
       await expect(card.ctaButton).toContainText(data.cta);
@@ -114,14 +125,14 @@ test.describe('MAS Express Cards test suite', () => {
     });
   });
 
-  test(`[Test Id - ${features[2].tcid}] ${features[2].name}, ${features[2].tags}`, async ({ page, baseURL }) => {
+  test(`[Test Id - ${features[2].tcid}] ${features[2].name}, ${features[2].tags}`, async () => {
     const { data } = features[2];
-    console.info(`[Test Page]: ${baseURL}${features[2].path}${miloLibs}`);
+    const page = workerSetup.getPage('EXPRESS');
 
-    await test.step('step-1: Go to Express page', async () => {
-      await page.goto(`${baseURL}${features[2].path}${miloLibs}`);
-      await page.waitForLoadState('networkidle');
-      await expect(page).toHaveURL(`${baseURL}${features[2].path}${miloLibs}`);
+    console.info(`[Test Page]: ${await page.url()}`);
+
+    await test.step('step-1: Wait for Express page elements', async () => {
+      await workerSetup.verifyPageURL('EXPRESS', DOCS_GALLERY_PATH.EXPRESS, expect);
 
       await page.waitForSelector('merch-card-collection', { timeout: 30000 });
       await page.waitForSelector('merch-card[variant="simplified-pricing-express"]', { timeout: 30000 });
@@ -139,7 +150,7 @@ test.describe('MAS Express Cards test suite', () => {
         await expect(card.badge).toContainText(data.badge);
       }
       await expect(card.description).toContainText(data.description);
-      await expect(card.price).toContainText(data.price);
+      await expect(card.price).toContainText(new RegExp(data.price));
       await expect(card.priceNote).toContainText(data.priceNote);
       if (data.priceAdditionalNote) {
         await expect(card.priceAdditionalNote).toContainText(data.priceAdditionalNote);

--- a/nala/features/promotions/promotions.test.js
+++ b/nala/features/promotions/promotions.test.js
@@ -1,19 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { features } from './promotions.spec.js';
 import PromoPage from './promotions.page.js';
-import { constructUrlWithParams } from '../../libs/commerce.js';
-
-const miloLibs = process.env.MILO_LIBS || '';
-const masLibs = process.env.MAS_LIBS || '';
-
-// Helper function to construct URLs with proper query parameter handling
-function constructTestUrl(baseURL, path, browserParams = '') {
-  let fullUrl = `${baseURL}${path}`;
-  fullUrl = constructUrlWithParams(fullUrl, browserParams);
-  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
-  fullUrl = constructUrlWithParams(fullUrl, masLibs);
-  return fullUrl;
-}
+import { constructTestUrl } from '../../libs/commerce.js';
 
 let PROMO;
 test.beforeEach(async ({ page, baseURL }) => {
@@ -168,7 +156,7 @@ test.describe('Promotions feature test suite', () => {
   test(`${features[5].name},${features[5].tags}`, async ({ page, baseURL }) => {
     const testPage = constructTestUrl(baseURL, features[5].path);
     const { data } = features[5];
-    const previewPage = `${baseURL}${features[5].path}${'?mep='}${data.mepPath}&${miloLibs}${masLibs}`;
+    const previewPage = constructTestUrl(baseURL, features[5].path, `?mep=${data.mepPath}`);
     console.info('[Test Page]: ', testPage);
 
     await test.step('Go to the test page', async () => {
@@ -471,7 +459,7 @@ test.describe('Promotions feature test suite', () => {
     });
 
     await test.step('Go to the test page in DE locale', async () => {
-      testPage = `${baseURL}${data.CO_DE}${features[11].path}${miloLibs}${masLibs}`;
+      testPage = constructTestUrl(baseURL, `${data.CO_DE}${features[11].path}`);
       console.info('[Test Page][DE]: ', testPage);
       await page.goto(testPage);
       await page.waitForLoadState('domcontentloaded');
@@ -487,7 +475,7 @@ test.describe('Promotions feature test suite', () => {
     });
 
     await test.step('Go to the test page in FR locale', async () => {
-      testPage = `${baseURL}${data.CO_FR}${features[11].path}${miloLibs}${masLibs}`;
+      testPage = constructTestUrl(baseURL, `${data.CO_FR}${features[11].path}`);
       console.info('[Test Page][FR]: ', testPage);
       await page.goto(testPage);
       await page.waitForLoadState('domcontentloaded');

--- a/nala/features/promotions/promotions.test.js
+++ b/nala/features/promotions/promotions.test.js
@@ -1,8 +1,19 @@
 import { expect, test } from '@playwright/test';
 import { features } from './promotions.spec.js';
 import PromoPage from './promotions.page.js';
+import { constructUrlWithParams } from '../../libs/commerce.js';
 
 const miloLibs = process.env.MILO_LIBS || '';
+const masLibs = process.env.MAS_LIBS || '';
+
+// Helper function to construct URLs with proper query parameter handling
+function constructTestUrl(baseURL, path, browserParams = '') {
+  let fullUrl = `${baseURL}${path}`;
+  fullUrl = constructUrlWithParams(fullUrl, browserParams);
+  fullUrl = constructUrlWithParams(fullUrl, miloLibs);
+  fullUrl = constructUrlWithParams(fullUrl, masLibs);
+  return fullUrl;
+}
 
 let PROMO;
 test.beforeEach(async ({ page, baseURL }) => {
@@ -18,7 +29,7 @@ test.beforeEach(async ({ page, baseURL }) => {
 test.describe('Promotions feature test suite', () => {
   // @Promo-insert - Validate promo insert text after marquee and before text component
   test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[0].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[0].path);
     const { data } = features[0];
     console.info('[Test Page]: ', testPage);
 
@@ -48,7 +59,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-replace - Validate promo replaces marquee and text component
   test(`${features[1].name},${features[1].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[1].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[1].path);
     const { data } = features[1];
     console.info('[Test Page]: ', testPage);
 
@@ -75,7 +86,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-remove - Validate promo removes text component
   test(`${features[2].name},${features[2].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[2].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[2].path);
     const { data } = features[2];
     console.info('[Test Page]: ', testPage);
 
@@ -97,7 +108,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-two-manifests - Validate 2 active manifests on the page
   test(`${features[3].name},${features[3].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[3].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[3].path);
     const { data } = features[3];
     console.info('[Test Page]: ', testPage);
 
@@ -134,7 +145,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-replace-fragment - Validate fragment marquee replace
   test(`${features[4].name},${features[4].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[4].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[4].path);
     const { data } = features[4];
     console.info('[Test Page]: ', testPage);
 
@@ -155,9 +166,9 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-future - Validate active promo scheduled in the future
   test(`${features[5].name},${features[5].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[5].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[5].path);
     const { data } = features[5];
-    const previewPage = `${baseURL}${features[5].path}${'?mep='}${data.mepPath}&${miloLibs}`;
+    const previewPage = `${baseURL}${features[5].path}${'?mep='}${data.mepPath}&${miloLibs}${masLibs}`;
     console.info('[Test Page]: ', testPage);
 
     await test.step('Go to the test page', async () => {
@@ -204,7 +215,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-with-personalization - Validate promo together with personalization and target OFF
   test(`${features[6].name},${features[6].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[6].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[6].path);
     const { data } = features[6];
     console.info('[Test Page]: ', testPage);
 
@@ -234,7 +245,7 @@ test.describe('Promotions feature test suite', () => {
   test(`${features[7].name},${features[7].tags}`, async ({ page, baseURL, browserName }) => {
     test.skip(browserName === 'chromium' || browserName === 'webkit', 'Skipping test for Chromium and webkit browsers');
 
-    const testPage = `${baseURL}${features[7].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[7].path);
     const { data } = features[7];
     console.info('[Test Page]: ', testPage);
 
@@ -262,7 +273,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-preview - Validate preview functionality
   test(`${features[8].name},${features[8].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[8].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[8].path);
     const { data } = features[8];
     let previewPage;
     console.info('[Test Page]: ', testPage);
@@ -373,7 +384,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-page-filter-insert - Validate promo page filter with insert action
   test(`${features[9].name},${features[9].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[9].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[9].path);
     const { data } = features[9];
     console.info('[Test Page]: ', testPage);
 
@@ -403,7 +414,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-page-filter-replace - Validate promo page filter with replace action
   test(`${features[10].name},${features[10].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[10].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[10].path);
     const { data } = features[10];
     console.info('[Test Page]: ', testPage);
 
@@ -432,7 +443,7 @@ test.describe('Promotions feature test suite', () => {
   // @Promo-page-filter-geo - Validate promo page filter in default, de and fr locales
   test(`${features[11].name},${features[11].tags}`, async ({ page, baseURL, browserName }) => {
     test.skip(browserName === 'webkit', 'Skipping test for webkit browser');
-    let testPage = `${baseURL}${features[11].path}${miloLibs}`;
+    let testPage = constructTestUrl(baseURL, features[11].path);
     const { data } = features[11];
     console.info('[Test Page]: ', testPage);
 
@@ -460,7 +471,7 @@ test.describe('Promotions feature test suite', () => {
     });
 
     await test.step('Go to the test page in DE locale', async () => {
-      testPage = `${baseURL}${data.CO_DE}${features[11].path}${miloLibs}`;
+      testPage = `${baseURL}${data.CO_DE}${features[11].path}${miloLibs}${masLibs}`;
       console.info('[Test Page][DE]: ', testPage);
       await page.goto(testPage);
       await page.waitForLoadState('domcontentloaded');
@@ -476,7 +487,7 @@ test.describe('Promotions feature test suite', () => {
     });
 
     await test.step('Go to the test page in FR locale', async () => {
-      testPage = `${baseURL}${data.CO_FR}${features[11].path}${miloLibs}`;
+      testPage = `${baseURL}${data.CO_FR}${features[11].path}${miloLibs}${masLibs}`;
       console.info('[Test Page][FR]: ', testPage);
       await page.goto(testPage);
       await page.waitForLoadState('domcontentloaded');
@@ -494,7 +505,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-remove-fragment - Validate fragment marquee remove
   test(`${features[12].name},${features[12].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[12].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[12].path);
     console.info('[Test Page]: ', testPage);
 
     await test.step('Go to the test page', async () => {
@@ -509,7 +520,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-fragment-insert - Validate promo insert text after and before fragment
   test(`${features[13].name},${features[13].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[13].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[13].path);
     const { data } = features[13];
     console.info('[Test Page]: ', testPage);
 
@@ -536,7 +547,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-mas-replace-card-in-collection - Validate promo replace card in collection
   test(`${features[14].name},${features[14].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[14].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[14].path);
     const { data } = features[14];
     console.info('[Test Page]: ', testPage);
 
@@ -562,7 +573,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-mas-replace-collection-with-collection - Validate promo replace collection with collection
   test(`${features[15].name},${features[15].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[15].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[15].path);
     const { data } = features[15];
     console.info('[Test Page]: ', testPage);
 
@@ -582,7 +593,7 @@ test.describe('Promotions feature test suite', () => {
 
   // @Promo-mas-replace-collection-with-fragment - Validate promo replace collection with fragment
   test(`${features[16].name},${features[16].tags}`, async ({ page, baseURL }) => {
-    const testPage = `${baseURL}${features[16].path}${miloLibs}`;
+    const testPage = constructTestUrl(baseURL, features[16].path);
     const { data } = features[16];
     console.info('[Test Page]: ', testPage);
 

--- a/nala/libs/commerce.js
+++ b/nala/libs/commerce.js
@@ -23,6 +23,7 @@ const DOCS_GALLERY_PATH = {
   PLANS: '/libs/features/mas/docs/plans.html',
   CHECKOUT_LINK: '/libs/features/mas/docs/checkout-link.html',
   MERCH_CARD: '/libs/features/mas/docs/merch-card.html',
+  EXPRESS: '/libs/features/mas/docs/express.html',
 };
 
 async function setupMasConsoleListener(consoleErrors) {

--- a/nala/libs/commerce.js
+++ b/nala/libs/commerce.js
@@ -154,8 +154,8 @@ function validateCommerceUrl(url, options = {}) {
   try {
     const urlObj = new URL(url);
 
-    if (!urlObj.origin.includes('commerce.adobe.com')) return false;
-    if (!urlObj.pathname.includes('/store/email')) return false;
+    if (urlObj.hostname !== 'commerce.adobe.com') return false;
+    if (!urlObj.pathname.startsWith('/store/email')) return false;
 
     const params = new URLSearchParams(urlObj.search);
 


### PR DESCRIPTION
- As part of integrating milo tests in MAS PR workflow, we need to enable `?maslibs` parameter in the test urls
- Refactors helper functions used in commerce tests

Resolves: [MWPW-179632](https://jira.corp.adobe.com/browse/MWPW-179632)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://MWPW-179632--milo--afmicka.aem.live/?martech=off




