### PR TITLE
MWPW-180376 Brand Concierge prompt button spacing

### DIFF
--- a/libs/blocks/brand-concierge/chat-ui-config.js
+++ b/libs/blocks/brand-concierge/chat-ui-config.js
@@ -118,6 +118,7 @@ export default {
     '--citations-panel-padding': '0 9px',
     '--citations-text-font-weight': '700',
     '--chat-container-background': '#FFFFFF',
+    '--chat-container-bottom-background': '#FFFFFF',
     '--chat-history-bottom-padding': '0',
     '--chat-history-padding': '12px',
     '--chat-history-padding-top-expanded': '0',


### PR DESCRIPTION
* Add spacing under prompt suggestion in bc chat
* Fix chat background issue introduced by web client

Resolves: [MWPW-180376](https://jira.corp.adobe.com/browse/MWPW-180376)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off
- After: https://bc-bugs-prompt--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off




