### PR TITLE
Sticky label icon fix

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -309,6 +309,11 @@
   padding: 0;
 }
 
+.sticky .bc-input-field-label {
+  align-self: center;
+  margin: 0;
+}
+
 .sticky .bc-input-field-label,
 .sticky input,
 .sticky .input-field-button {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* fix for the label icon position and margin for sticky only

Resolves: no ticket, found while testing my page.

**Test URLs:**
- Before: https://bc-bugs--milo--adobecom.aem.page/drafts/colloyd/brand-concierge/brand-concierge-sticky?martech=off
- After: https://sticky-label-fix--milo--colloyd.aem.page/drafts/colloyd/brand-concierge/brand-concierge-sticky?martech=off


