### PR TITLE
MWPW-180686 Brand Concierge - Remove chat privacy notice

### DIFF
--- a/libs/blocks/brand-concierge/chat-ui-config.js
+++ b/libs/blocks/brand-concierge/chat-ui-config.js
@@ -52,16 +52,6 @@ export default {
       messageAlignment: 'left',
       messageWidth: '100%',
     },
-    privacyNotice: {
-      title: 'Privacy Notice',
-      text: 'By using this automated chatbot, you consent that any personal information you provide in the chat may be collected, used, analyzed, disclosed, and retained by Adobe and its service providers, in accordance with the Adobe {Privacy Policy}. Please do not enter any personal information or sensitive information (e.g., financial or health data).',
-      links: [
-        {
-          text: 'Privacy Policy',
-          url: 'https://www.adobe.com/privacy/policy.html',
-        },
-      ],
-    },
     productCard: { actionButtonSize: 'S' },
   },
   arrays: {


### PR DESCRIPTION
* Remove in-chat privacy notice from Brand Concierge

Resolves: [MWPW-180686](https://jira.corp.adobe.com/browse/MWPW-180686)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off
- After: https://bc-legal--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off

(Remove ?martech=off for testing)

