### PR TITLE
[MWPW-175987] - Mweb section2 lcp fix

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1777,21 +1777,21 @@ export async function loadArea(area = document) {
 
   const areaBlocks = [];
   let lcpSectionId = null;
-  let isMarqueeAndNoMedia = null;
+  let isLcpDeferred = null;
 
   for (const section of sections) {
-    if (!section.idx && window.matchMedia('(max-width: 768px)').matches) {
-      isMarqueeAndNoMedia = section.el.querySelector('.hero-marquee.no-media, .marquee.no-media, .quiz-marquee.no-media');
+    if (!section.idx && window.matchMedia('(max-width: 600px)').matches) {
+      isLcpDeferred = section.el.querySelector('.lcp-deferred');
     }
 
-    if (isMarqueeAndNoMedia && section.idx === 1) {
-      section.el.querySelectorAll('img')?.forEach((img) => img.setAttribute('loading', 'eager'));
+    if (isLcpDeferred && section.idx === 1) {
+      section.el.querySelectorAll('picture img')[0]?.setAttribute('loading', 'eager');
     }
 
     const isLastSection = section.idx === sections.length - 1;
 
     if (lcpSectionId === null && (section.blocks.length !== 0 || isLastSection)) {
-      lcpSectionId = !isMarqueeAndNoMedia ? section.idx : section.idx + 1;
+      lcpSectionId = !isLcpDeferred ? section.idx : section.idx + 1;
     }
 
     const sectionBlocks = await processSection(section, config, isDoc, lcpSectionId);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1777,12 +1777,23 @@ export async function loadArea(area = document) {
 
   const areaBlocks = [];
   let lcpSectionId = null;
+  let isMarqueeAndNoMedia = null;
 
   for (const section of sections) {
-    const isLastSection = section.idx === sections.length - 1;
-    if (lcpSectionId === null && (section.blocks.length !== 0 || isLastSection)) {
-      lcpSectionId = section.idx;
+    if (!section.idx && window.matchMedia('(max-width: 768px)').matches) {
+      isMarqueeAndNoMedia = section.el.querySelector('.hero-marquee.no-media, .marquee.no-media, .quiz-marquee.no-media');
     }
+
+    if (isMarqueeAndNoMedia && section.idx === 1) {
+      section.el.querySelectorAll('img')?.forEach((img) => img.setAttribute('loading', 'eager'));
+    }
+
+    const isLastSection = section.idx === sections.length - 1;
+
+    if (lcpSectionId === null && (section.blocks.length !== 0 || isLastSection)) {
+      lcpSectionId = !isMarqueeAndNoMedia ? section.idx : section.idx + 1;
+    }
+
     const sectionBlocks = await processSection(section, config, isDoc, lcpSectionId);
     areaBlocks.push(...sectionBlocks);
 


### PR DESCRIPTION
This PR aims to give authors the ability to improve LCP performance on mobile devices where the first section doesn't have an image that is considered to be an LCP candidate while the second section does. By applying the class `lcp-deferred` to the first section that doesn't have and LCP image we know not to treat it as the LCP section but the next section after it. The more ideal situation would be for us to automate this but unfortunately this is not possible considering that at the moment where we need to choose which section is LCP there is no structure on the page since sections haven't been rendered yet, and we can't write a query to check if the first section has a background or asset image without extracting render logic for each Marquee block which would add a considerable level of complexity and dependency in the utils file which we don't want.

**Performance analysis page**
https://main--milo--adobecom.aem.page/drafts/dusan/lcp-section2-analysis

Resolves: [MWPW-175987](https://jira.corp.adobe.com/browse/MWPW-175987)

**PSI Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mweb-section2-lcp-fix--milo--adobecom.aem.page/?martech=off

**CC Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/dusan/lcp-section2-normal-text
- After: https://main--cc--adobecom.aem.page/drafts/dusan/lcp-section2-normal-text?milolibs=mweb-section2-lcp-fix



