### PR TITLE
[MWPW-172087] - safari input focus fix

### DIFF
--- a/libs/blocks/tabs/tabs.css
+++ b/libs/blocks/tabs/tabs.css
@@ -532,6 +532,12 @@
     gap: var(--spacing-s);
   }
 
+  @supports (-webkit-backdrop-filter: blur(1px)) {
+    .tabs.radio .tabList.tabList .tab-list-container {
+      padding-block: 5px;
+    }
+  }
+
   .tabs.radio .tab-list-container::before {
     margin-block-end: 0;
     margin-inline-end: -8px;

--- a/libs/deps/mas/merch-quantity-select.js
+++ b/libs/deps/mas/merch-quantity-select.js
@@ -47,6 +47,7 @@ import{html as c,LitElement as g,nothing as m}from"../lit-all.min.js";import{css
         padding-inline-start: 12px;
         box-sizing: border-box;
         -moz-appearance: textfield;
+        z-index: 1;
     }
 
     .text-field-input::-webkit-inner-spin-button,

--- a/libs/features/icons/icons.css
+++ b/libs/features/icons/icons.css
@@ -107,6 +107,13 @@
   display: block;
 }
 
+@supports (-webkit-backdrop-filter: blur(1px)) and (not (backdrop-filter: blur(1px))) {
+  .milo-tooltip:focus::before {
+    outline: 4px solid -webkit-focus-ring-color;
+    outline-offset: 1px;
+  }
+}
+
 .milo-tooltip.hide-tooltip::before,
 .milo-tooltip.hide-tooltip::after {
   display: none;


### PR DESCRIPTION
This PR fixes 3 focus issues on Safari 

Resolves: [MWPW-172087](https://jira.corp.adobe.com/browse/MWPW-172087)

**Tabs Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/tab-block
- After: https://safari-focus-fix--milo--adobecom.aem.page/docs/library/kitchen-sink/tab-block

**Tooltip Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/dusan/document16
- After: https://safari-focus-fix--milo--adobecom.aem.page/drafts/dusan/document16

**Input field Test URLs:**
- Before: https://main--dc--adobecom.hlx.page/acrobat/pricing/business
- After: https://main--dc--adobecom.hlx.page/acrobat/pricing/business?milolibs=safari-focus-fix