### PR TITLE
MWPW-180866: Excludes iOS Safari from inline preloading 3-in-1

### DIFF
--- a/libs/blocks/merch/three-in-one.js
+++ b/libs/blocks/merch/three-in-one.js
@@ -133,10 +133,17 @@ export const handleTimeoutError = async () => {
 
 export function createContent(iframeUrl) {
   const content = createTag('div', { class: 'milo-iframe' });
+  // Detect Mobile Safari - it doesn't properly support loading="lazy" on iframes
+  const isMobileSafari = /iPhone|iPad|iPod/.test(navigator.userAgent)
+    && /WebKit/.test(navigator.userAgent)
+    && !/CriOS|FxiOS|OPiOS|EdgiOS/.test(navigator.userAgent);
+
+  const loadingAttr = isMobileSafari ? '' : ' loading="lazy"';
+
   content.innerHTML = `<sp-theme system="light" color="light" scale="medium" dir="ltr" style="display: flex; justify-content: center; align-items: center; height: 100%;">
   <sp-progress-circle label="progress circle" indeterminate="" size="l" dir="ltr" role="progressbar" aria-label="progress circle"></sp-progress-circle>
   </sp-theme>
-  <iframe src="${iframeUrl}" frameborder="0" marginwidth="0" marginheight="0" allowfullscreen="true" loading="lazy" class="loading" style="height: 100%;"></iframe>`;
+  <iframe src="${iframeUrl}" frameborder="0" marginwidth="0" marginheight="0" allowfullscreen="true"${loadingAttr} class="loading" style="height: 100%;"></iframe>`;
   return content;
 }
 


### PR DESCRIPTION
Excludes inline preloading of 3-in-1 for iOS Safari since it's not supported.

More info: 
https://caniuse.com/?search=loading%3D%22lazy%22
https://stackoverflow.com/questions/72491824/why-lazy-loading-on-img-is-broken-on-mobile-browser-ios#:~:text=It%20says%20right%20here%20on%20the%20CanIUse%20that%20the%20loading%3D%22lazy%22%20attribute%20is%20not%20yet%20supported%20on%20any%20version%20of%20Safari%20unless%20the%20browser%20is%20manually%20put%20in%20Experimental%20Mode.%20For%20browser%20specific%20issues%20it%20is%20always%20good%20to%20check%20caniuse%20for%20compatibility.

`CC test URL (has to be tested from mobile safari): https://main--cc--adobecom.aem.live/creativecloud/photography?milolibs=MWPW-180866`

Resolves: [MWPW-180866](https://jira.corp.adobe.com/browse/MWPW-180866)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-180866--milo--adobecom.aem.page/?martech=off




