### PR TITLE
[MWPW-177389] [Preflight] notification popup

### DIFF
--- a/.github/workflows/merge-to-stage.yaml
+++ b/.github/workflows/merge-to-stage.yaml
@@ -2,7 +2,7 @@ name: Merge to stage
 
 on:
   schedule:
-    - cron: '0 */4 * * *' # Run every 4 hours
+    - cron: '*/5 * * * *' # Run every 4 hours
   workflow_dispatch: # Allow manual trigger
   repository_dispatch:
     types: [merge-to-stage]

--- a/.github/workflows/merge-to-stage.yaml
+++ b/.github/workflows/merge-to-stage.yaml
@@ -2,7 +2,7 @@ name: Merge to stage
 
 on:
   schedule:
-    - cron: '*/5 * * * *' # Run every 4 hours
+    - cron: '0 */4 * * *' # Run every 4 hours
   workflow_dispatch: # Allow manual trigger
   repository_dispatch:
     types: [merge-to-stage]

--- a/libs/blocks/preflight/checks/assets.js
+++ b/libs/blocks/preflight/checks/assets.js
@@ -221,10 +221,7 @@ export async function checkImageDimensions(url, area, injectVisualMetadata = fal
     const isAssetAboveFold = isAboveFold(asset);
     assetData.isAboveFold = isAssetAboveFold;
 
-<<<<<<< HEAD
     // Add failure classification and populate arrays for both approaches
-=======
->>>>>>> 56670e8ad (force assets to not use the cache to fix the flaky results)
     if (assetData.hasMismatch) {
       assetData.failure = isAssetAboveFold ? 'critical' : 'warning';
       assetsWithMismatch.push(assetData);

--- a/libs/blocks/preflight/checks/assets.js
+++ b/libs/blocks/preflight/checks/assets.js
@@ -146,7 +146,10 @@ function getAssetData(asset) {
   };
 }
 
+<<<<<<< HEAD
 // Determine if an asset is above-the-fold and should be considered critical
+=======
+>>>>>>> fd2c6ba52 (fixed unadded changes from the rebasing)
 function isAboveFold(asset) {
   const main = asset.closest('main');
 
@@ -159,6 +162,10 @@ function isAboveFold(asset) {
     || secondSection?.contains(asset)
     || !!asset.closest('.hero, .marquee, .hero-marquee');
 }
+<<<<<<< HEAD
+=======
+
+>>>>>>> fd2c6ba52 (fixed unadded changes from the rebasing)
 export function isViewportTooSmall() {
   return !window.matchMedia('(min-width: 1200px)').matches;
 }
@@ -221,7 +228,10 @@ export async function checkImageDimensions(url, area, injectVisualMetadata = fal
     const isAssetAboveFold = isAboveFold(asset);
     assetData.isAboveFold = isAssetAboveFold;
 
+<<<<<<< HEAD
     // Add failure classification and populate arrays for both approaches
+=======
+>>>>>>> fd2c6ba52 (fixed unadded changes from the rebasing)
     if (assetData.hasMismatch) {
       assetData.failure = isAssetAboveFold ? 'critical' : 'warning';
       assetsWithMismatch.push(assetData);

--- a/libs/blocks/preflight/checks/assets.js
+++ b/libs/blocks/preflight/checks/assets.js
@@ -146,10 +146,7 @@ function getAssetData(asset) {
   };
 }
 
-<<<<<<< HEAD
 // Determine if an asset is above-the-fold and should be considered critical
-=======
->>>>>>> fd2c6ba52 (fixed unadded changes from the rebasing)
 function isAboveFold(asset) {
   const main = asset.closest('main');
 
@@ -162,10 +159,6 @@ function isAboveFold(asset) {
     || secondSection?.contains(asset)
     || !!asset.closest('.hero, .marquee, .hero-marquee');
 }
-<<<<<<< HEAD
-=======
-
->>>>>>> fd2c6ba52 (fixed unadded changes from the rebasing)
 export function isViewportTooSmall() {
   return !window.matchMedia('(min-width: 1200px)').matches;
 }
@@ -228,10 +221,7 @@ export async function checkImageDimensions(url, area, injectVisualMetadata = fal
     const isAssetAboveFold = isAboveFold(asset);
     assetData.isAboveFold = isAssetAboveFold;
 
-<<<<<<< HEAD
     // Add failure classification and populate arrays for both approaches
-=======
->>>>>>> fd2c6ba52 (fixed unadded changes from the rebasing)
     if (assetData.hasMismatch) {
       assetData.failure = isAssetAboveFold ? 'critical' : 'warning';
       assetsWithMismatch.push(assetData);

--- a/libs/blocks/preflight/checks/assets.js
+++ b/libs/blocks/preflight/checks/assets.js
@@ -221,7 +221,10 @@ export async function checkImageDimensions(url, area, injectVisualMetadata = fal
     const isAssetAboveFold = isAboveFold(asset);
     assetData.isAboveFold = isAssetAboveFold;
 
+<<<<<<< HEAD
     // Add failure classification and populate arrays for both approaches
+=======
+>>>>>>> 56670e8ad (force assets to not use the cache to fix the flaky results)
     if (assetData.hasMismatch) {
       assetData.failure = isAssetAboveFold ? 'critical' : 'warning';
       assetsWithMismatch.push(assetData);

--- a/libs/blocks/preflight/checks/constants.js
+++ b/libs/blocks/preflight/checks/constants.js
@@ -5,122 +5,11 @@ export const STATUS = {
   EMPTY: 'empty',
 };
 
-// Check IDs - stable identifiers for mapping (supports ASO)
-export const CHECK_IDS = {
-  // SEO Check IDs
-  H1_COUNT: 'h1-count',
-  TITLE_SIZE: 'title-size',
-  CANONICAL: 'canonical',
-  META_DESCRIPTION: 'meta-description',
-  BODY_SIZE: 'body-size',
-  LOREM_IPSUM: 'lorem-ipsum',
-  BROKEN_LINKS: 'broken-links',
-
-  // Performance Check IDs
-  LCP_ELEMENT: 'lcp-element',
-  SINGLE_BLOCK: 'single-block',
-  PERSONALIZATION: 'personalization',
-  IMAGE_SIZE: 'image-size',
-  VIDEO_POSTER: 'video-poster',
-  FRAGMENTS: 'fragments',
-  PLACEHOLDERS: 'placeholders',
-  ICONS: 'icons',
-
-  // Asset Check IDs
-  IMAGE_DIMENSIONS: 'image-dimensions',
-};
-
-// Severity levels for check categorization
 export const SEVERITY = {
   CRITICAL: 'critical',
   WARNING: 'warning',
 };
 
-// CHECKS constant for structured check definitions (supports notification popup)
-export const CHECKS = {
-  H1_COUNT: {
-    id: 'h1-count',
-    severity: SEVERITY.CRITICAL,
-    title: 'H1 count',
-  },
-  TITLE_SIZE: {
-    id: 'title-size',
-    severity: SEVERITY.CRITICAL,
-    title: 'Title size',
-  },
-  CANONICAL: {
-    id: 'canonical',
-    severity: SEVERITY.WARNING,
-    title: 'Canonical',
-  },
-  META_DESCRIPTION: {
-    id: 'meta-description',
-    severity: SEVERITY.CRITICAL,
-    title: 'Meta description',
-  },
-  BODY_SIZE: {
-    id: 'body-size',
-    severity: SEVERITY.CRITICAL,
-    title: 'Body size',
-  },
-  LOREM_IPSUM: {
-    id: 'lorem-ipsum',
-    severity: SEVERITY.CRITICAL,
-    title: 'Lorem Ipsum',
-  },
-  BROKEN_LINKS: {
-    id: 'broken-links',
-    severity: SEVERITY.CRITICAL,
-    title: 'Links',
-  },
-  LCP_ELEMENT: {
-    id: 'lcp-element',
-    severity: SEVERITY.CRITICAL,
-    title: 'LCP',
-  },
-  SINGLE_BLOCK: {
-    id: 'single-block',
-    severity: SEVERITY.CRITICAL,
-    title: 'Single Block',
-  },
-  PERSONALIZATION: {
-    id: 'personalization',
-    severity: SEVERITY.WARNING,
-    title: 'Personalization',
-  },
-  IMAGE_SIZE: {
-    id: 'image-size',
-    severity: SEVERITY.WARNING,
-    title: 'Images Size',
-  },
-  VIDEO_POSTER: {
-    id: 'video-poster',
-    severity: SEVERITY.WARNING,
-    title: 'Videos',
-  },
-  FRAGMENTS: {
-    id: 'fragments',
-    severity: SEVERITY.WARNING,
-    title: 'Fragments',
-  },
-  PLACEHOLDERS: {
-    id: 'placeholders',
-    severity: SEVERITY.WARNING,
-    title: 'Placeholders',
-  },
-  ICONS: {
-    id: 'icons',
-    severity: SEVERITY.WARNING,
-    title: 'Icons',
-  },
-  IMAGE_DIMENSIONS: {
-    id: 'image-dimensions',
-    severity: SEVERITY.CRITICAL,
-    title: 'Asset Dimensions',
-  },
-};
-
-// Title constants for performance checks (supports ASO)
 export const PERFORMANCE_TITLES = {
   LcpEl: 'LCP',
   SingleBlock: 'Single Block',
@@ -131,6 +20,28 @@ export const PERFORMANCE_TITLES = {
   Personalization: 'Personalization',
   Placeholders: 'Placeholders',
   Icons: 'Icons',
+};
+
+export const PERFORMANCE_IDS = {
+  lcpElement: 'lcp-element',
+  singleBlock: 'single-block',
+  personalization: 'personalization',
+  imageSize: 'image-size',
+  videoPoster: 'video-poster',
+  fragments: 'fragments',
+  placeholders: 'placeholders',
+  icons: 'icons',
+};
+
+export const PERFORMANCE_SEVERITIES = {
+  lcpElement: 'critical',
+  singleBlock: 'critical',
+  personalization: 'warning',
+  imageSize: 'warning',
+  videoPoster: 'warning',
+  fragments: 'warning',
+  placeholders: 'warning',
+  icons: 'warning',
 };
 
 export const SEO_TITLES = {
@@ -153,6 +64,27 @@ export const SEO_IDS = {
   links: 'links',
 };
 
+// Alternative IDs for native preflight checkId compatibility
+export const SEO_CHECK_IDS = {
+  title: 'title-size',
+  description: 'meta-description',
+  h1Count: 'h1-count',
+  canonical: 'canonical',
+  bodySize: 'body-size',
+  loremIpsum: 'lorem-ipsum',
+  links: 'broken-links',
+};
+
+export const SEO_SEVERITIES = {
+  title: 'critical',
+  description: 'critical',
+  h1Count: 'critical',
+  canonical: 'warning',
+  bodySize: 'critical',
+  loremIpsum: 'critical',
+  links: 'critical',
+};
+
 export const SEO_DESCRIPTIONS = {
   title: 'Title size is appropriate.',
   description: 'Meta description is present and within the recommended character limit.',
@@ -164,6 +96,14 @@ export const SEO_DESCRIPTIONS = {
 };
 
 export const ASSETS_TITLES = { AssetDimensions: 'Asset Dimensions' };
+
+export const ASSETS_IDS = {
+  imageDimensions: 'image-dimensions',
+};
+
+export const ASSETS_SEVERITIES = {
+  imageDimensions: 'critical',
+};
 
 export const ASO_TIMEOUT_MS = 60_000;
 export const ASO_POLL_INTERVAL_MS = 2_000;

--- a/libs/blocks/preflight/checks/constants.js
+++ b/libs/blocks/preflight/checks/constants.js
@@ -36,7 +36,40 @@ export const SEVERITY = {
   WARNING: 'warning',
 };
 
+<<<<<<< HEAD
 // CHECKS constant for structured check definitions (supports notification popup)
+=======
+export const SEO_TITLES = {
+  h1Count: 'H1 count',
+  title: 'Title size',
+  canonical: 'Canonical',
+  description: 'Meta description',
+  bodySize: 'Body size',
+  loremIpsum: 'Lorem Ipsum',
+  links: 'Links',
+};
+
+export const SEO_IDS = {
+  title: 'title',
+  description: 'description',
+  h1Count: 'h1-count',
+  canonical: 'canonical',
+  bodySize: 'body-size',
+  loremIpsum: 'lorem-ipsum',
+  links: 'links',
+};
+
+export const SEO_DESCRIPTIONS = {
+  title: 'Title size is appropriate.',
+  description: 'Meta description is present and within the recommended character limit.',
+  h1Count: 'Found exactly one H1 heading.',
+  canonical: 'Canonical reference is valid.',
+  bodySize: 'Body content has a good length.',
+  loremIpsum: 'No Lorem ipsum is used on the page.',
+  links: 'Links are valid.',
+};
+
+>>>>>>> f14f1de55 ([MWPW-177278] [Preflight] ASO Preflight conditioned by federal config (#4641))
 export const CHECKS = {
   H1_COUNT: {
     id: 'h1-count',
@@ -120,6 +153,7 @@ export const CHECKS = {
   },
 };
 
+<<<<<<< HEAD
 // Title constants for performance checks (supports ASO)
 export const PERFORMANCE_TITLES = {
   LcpEl: 'LCP',
@@ -163,6 +197,8 @@ export const SEO_DESCRIPTIONS = {
   links: 'Links are valid.',
 };
 
+=======
+>>>>>>> f14f1de55 ([MWPW-177278] [Preflight] ASO Preflight conditioned by federal config (#4641))
 export const ASSETS_TITLES = { AssetDimensions: 'Asset Dimensions' };
 
 export const ASO_TIMEOUT_MS = 60_000;

--- a/libs/blocks/preflight/checks/constants.js
+++ b/libs/blocks/preflight/checks/constants.js
@@ -73,12 +73,12 @@ export const SEO_DESCRIPTIONS = {
 export const CHECKS = {
   H1_COUNT: {
     id: 'h1-count',
-    severity: SEVERITY.CRITICAL,
+    severity: SEVERITY.WARNING,
     title: 'H1 count',
   },
   TITLE_SIZE: {
     id: 'title-size',
-    severity: SEVERITY.CRITICAL,
+    severity: SEVERITY.WARNING,
     title: 'Title size',
   },
   CANONICAL: {
@@ -88,12 +88,12 @@ export const CHECKS = {
   },
   META_DESCRIPTION: {
     id: 'meta-description',
-    severity: SEVERITY.CRITICAL,
+    severity: SEVERITY.WARNING,
     title: 'Meta description',
   },
   BODY_SIZE: {
     id: 'body-size',
-    severity: SEVERITY.CRITICAL,
+    severity: SEVERITY.WARNING,
     title: 'Body size',
   },
   LOREM_IPSUM: {

--- a/libs/blocks/preflight/checks/constants.js
+++ b/libs/blocks/preflight/checks/constants.js
@@ -36,40 +36,7 @@ export const SEVERITY = {
   WARNING: 'warning',
 };
 
-<<<<<<< HEAD
 // CHECKS constant for structured check definitions (supports notification popup)
-=======
-export const SEO_TITLES = {
-  h1Count: 'H1 count',
-  title: 'Title size',
-  canonical: 'Canonical',
-  description: 'Meta description',
-  bodySize: 'Body size',
-  loremIpsum: 'Lorem Ipsum',
-  links: 'Links',
-};
-
-export const SEO_IDS = {
-  title: 'title',
-  description: 'description',
-  h1Count: 'h1-count',
-  canonical: 'canonical',
-  bodySize: 'body-size',
-  loremIpsum: 'lorem-ipsum',
-  links: 'links',
-};
-
-export const SEO_DESCRIPTIONS = {
-  title: 'Title size is appropriate.',
-  description: 'Meta description is present and within the recommended character limit.',
-  h1Count: 'Found exactly one H1 heading.',
-  canonical: 'Canonical reference is valid.',
-  bodySize: 'Body content has a good length.',
-  loremIpsum: 'No Lorem ipsum is used on the page.',
-  links: 'Links are valid.',
-};
-
->>>>>>> f14f1de55 ([MWPW-177278] [Preflight] ASO Preflight conditioned by federal config (#4641))
 export const CHECKS = {
   H1_COUNT: {
     id: 'h1-count',
@@ -153,7 +120,6 @@ export const CHECKS = {
   },
 };
 
-<<<<<<< HEAD
 // Title constants for performance checks (supports ASO)
 export const PERFORMANCE_TITLES = {
   LcpEl: 'LCP',
@@ -197,8 +163,6 @@ export const SEO_DESCRIPTIONS = {
   links: 'Links are valid.',
 };
 
-=======
->>>>>>> f14f1de55 ([MWPW-177278] [Preflight] ASO Preflight conditioned by federal config (#4641))
 export const ASSETS_TITLES = { AssetDimensions: 'Asset Dimensions' };
 
 export const ASO_TIMEOUT_MS = 60_000;

--- a/libs/blocks/preflight/checks/constants.js
+++ b/libs/blocks/preflight/checks/constants.js
@@ -5,6 +5,134 @@ export const STATUS = {
   EMPTY: 'empty',
 };
 
+// Check IDs - stable identifiers for mapping (supports ASO)
+export const CHECK_IDS = {
+  // SEO Check IDs
+  H1_COUNT: 'h1-count',
+  TITLE_SIZE: 'title-size',
+  CANONICAL: 'canonical',
+  META_DESCRIPTION: 'meta-description',
+  BODY_SIZE: 'body-size',
+  LOREM_IPSUM: 'lorem-ipsum',
+  BROKEN_LINKS: 'broken-links',
+
+  // Performance Check IDs
+  LCP_ELEMENT: 'lcp-element',
+  SINGLE_BLOCK: 'single-block',
+  PERSONALIZATION: 'personalization',
+  IMAGE_SIZE: 'image-size',
+  VIDEO_POSTER: 'video-poster',
+  FRAGMENTS: 'fragments',
+  PLACEHOLDERS: 'placeholders',
+  ICONS: 'icons',
+
+  // Asset Check IDs
+  IMAGE_DIMENSIONS: 'image-dimensions',
+};
+
+// Severity levels for check categorization
+export const SEVERITY = {
+  CRITICAL: 'critical',
+  WARNING: 'warning',
+};
+
+// CHECKS constant for structured check definitions (supports notification popup)
+export const CHECKS = {
+  H1_COUNT: {
+    id: 'h1-count',
+    severity: SEVERITY.CRITICAL,
+    title: 'H1 count',
+  },
+  TITLE_SIZE: {
+    id: 'title-size',
+    severity: SEVERITY.CRITICAL,
+    title: 'Title size',
+  },
+  CANONICAL: {
+    id: 'canonical',
+    severity: SEVERITY.WARNING,
+    title: 'Canonical',
+  },
+  META_DESCRIPTION: {
+    id: 'meta-description',
+    severity: SEVERITY.CRITICAL,
+    title: 'Meta description',
+  },
+  BODY_SIZE: {
+    id: 'body-size',
+    severity: SEVERITY.CRITICAL,
+    title: 'Body size',
+  },
+  LOREM_IPSUM: {
+    id: 'lorem-ipsum',
+    severity: SEVERITY.CRITICAL,
+    title: 'Lorem Ipsum',
+  },
+  BROKEN_LINKS: {
+    id: 'broken-links',
+    severity: SEVERITY.CRITICAL,
+    title: 'Links',
+  },
+  LCP_ELEMENT: {
+    id: 'lcp-element',
+    severity: SEVERITY.CRITICAL,
+    title: 'LCP',
+  },
+  SINGLE_BLOCK: {
+    id: 'single-block',
+    severity: SEVERITY.CRITICAL,
+    title: 'Single Block',
+  },
+  PERSONALIZATION: {
+    id: 'personalization',
+    severity: SEVERITY.WARNING,
+    title: 'Personalization',
+  },
+  IMAGE_SIZE: {
+    id: 'image-size',
+    severity: SEVERITY.WARNING,
+    title: 'Images Size',
+  },
+  VIDEO_POSTER: {
+    id: 'video-poster',
+    severity: SEVERITY.WARNING,
+    title: 'Videos',
+  },
+  FRAGMENTS: {
+    id: 'fragments',
+    severity: SEVERITY.WARNING,
+    title: 'Fragments',
+  },
+  PLACEHOLDERS: {
+    id: 'placeholders',
+    severity: SEVERITY.WARNING,
+    title: 'Placeholders',
+  },
+  ICONS: {
+    id: 'icons',
+    severity: SEVERITY.WARNING,
+    title: 'Icons',
+  },
+  IMAGE_DIMENSIONS: {
+    id: 'image-dimensions',
+    severity: SEVERITY.CRITICAL,
+    title: 'Asset Dimensions',
+  },
+};
+
+// Title constants for performance checks (supports ASO)
+export const PERFORMANCE_TITLES = {
+  LcpEl: 'LCP',
+  SingleBlock: 'Single Block',
+  Performance: 'Performance',
+  ImageSize: 'Images Size',
+  VideoPoster: 'Videos',
+  Fragments: 'Fragments',
+  Personalization: 'Personalization',
+  Placeholders: 'Placeholders',
+  Icons: 'Icons',
+};
+
 export const SEO_TITLES = {
   h1Count: 'H1 count',
   title: 'Title size',
@@ -33,18 +161,6 @@ export const SEO_DESCRIPTIONS = {
   bodySize: 'Body content has a good length.',
   loremIpsum: 'No Lorem ipsum is used on the page.',
   links: 'Links are valid.',
-};
-
-export const PERFORMANCE_TITLES = {
-  Performance: 'Performance',
-  LcpEl: 'LCP',
-  SingleBlock: 'Single Block',
-  ImageSize: 'Images Size',
-  VideoPoster: 'Videos',
-  Fragments: 'Fragments',
-  Personalization: 'Personalization',
-  Placeholders: 'Placeholders',
-  Icons: 'Icons',
 };
 
 export const ASSETS_TITLES = { AssetDimensions: 'Asset Dimensions' };

--- a/libs/blocks/preflight/checks/constants.js
+++ b/libs/blocks/preflight/checks/constants.js
@@ -73,12 +73,12 @@ export const SEO_DESCRIPTIONS = {
 export const CHECKS = {
   H1_COUNT: {
     id: 'h1-count',
-    severity: SEVERITY.WARNING,
+    severity: SEVERITY.CRITICAL,
     title: 'H1 count',
   },
   TITLE_SIZE: {
     id: 'title-size',
-    severity: SEVERITY.WARNING,
+    severity: SEVERITY.CRITICAL,
     title: 'Title size',
   },
   CANONICAL: {
@@ -88,12 +88,12 @@ export const CHECKS = {
   },
   META_DESCRIPTION: {
     id: 'meta-description',
-    severity: SEVERITY.WARNING,
+    severity: SEVERITY.CRITICAL,
     title: 'Meta description',
   },
   BODY_SIZE: {
     id: 'body-size',
-    severity: SEVERITY.WARNING,
+    severity: SEVERITY.CRITICAL,
     title: 'Body size',
   },
   LOREM_IPSUM: {

--- a/libs/blocks/preflight/checks/performance.js
+++ b/libs/blocks/preflight/checks/performance.js
@@ -1,4 +1,4 @@
-import { STATUS, CHECKS } from './constants.js';
+import { STATUS, SEVERITY, PERFORMANCE_TITLES, PERFORMANCE_IDS, PERFORMANCE_SEVERITIES } from './constants.js';
 import { getMetadata } from '../../../utils/utils.js';
 
 const lcpCache = new Map();
@@ -31,9 +31,9 @@ export function checkSingleBlock(area) {
   const firstSection = area.querySelector('main > div.section');
   const hasMultipleBlocks = firstSection && firstSection.childElementCount > 1;
   return {
-    checkId: CHECKS.SINGLE_BLOCK.id,
-    severity: CHECKS.SINGLE_BLOCK.severity,
-    title: CHECKS.SINGLE_BLOCK.title,
+    checkId: PERFORMANCE_IDS.singleBlock,
+    severity: PERFORMANCE_SEVERITIES.singleBlock,
+    title: PERFORMANCE_TITLES.SingleBlock,
     status: hasMultipleBlocks ? STATUS.FAIL : STATUS.PASS,
     description: hasMultipleBlocks
       ? 'First section has more than one block.'
@@ -46,9 +46,9 @@ export function checkForPersonalization(area) {
   const target = getMetadata('target', area) === 'on';
   const hasPersonalization = personalization || target;
   return {
-    checkId: CHECKS.PERSONALIZATION.id,
-    severity: CHECKS.PERSONALIZATION.severity,
-    title: CHECKS.PERSONALIZATION.title,
+    checkId: PERFORMANCE_IDS.personalization,
+    severity: PERFORMANCE_SEVERITIES.personalization,
+    title: PERFORMANCE_TITLES.Personalization,
     status: hasPersonalization ? STATUS.FAIL : STATUS.PASS,
     description: hasPersonalization
       ? 'MEP or Target enabled.'
@@ -60,9 +60,9 @@ export async function checkLcpEl(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp) {
     return {
-      checkId: CHECKS.LCP_ELEMENT.id,
-      severity: CHECKS.LCP_ELEMENT.severity,
-      title: 'Performance',
+      checkId: PERFORMANCE_IDS.lcpElement,
+      severity: PERFORMANCE_SEVERITIES.lcpElement,
+      title: PERFORMANCE_TITLES.Performance,
       status: STATUS.FAIL,
       description: 'No LCP element found.',
     };
@@ -70,9 +70,9 @@ export async function checkLcpEl(url, area, observeLcp) {
   const firstSection = area.querySelector('main > div.section');
   const validLcp = lcp?.element && lcp?.url && firstSection?.contains(lcp.element);
   return {
-    checkId: CHECKS.LCP_ELEMENT.id,
-    severity: CHECKS.LCP_ELEMENT.severity,
-    title: CHECKS.LCP_ELEMENT.title,
+    checkId: PERFORMANCE_IDS.lcpElement,
+    severity: PERFORMANCE_SEVERITIES.lcpElement,
+    title: PERFORMANCE_TITLES.LcpEl,
     status: validLcp ? STATUS.PASS : STATUS.FAIL,
     description: validLcp
       ? 'Valid LCP in the first section detected.'
@@ -84,9 +84,9 @@ export async function checkImageSize(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp || !lcp.url || lcp.url.match('media_.*.mp4')) {
     return {
-      checkId: CHECKS.IMAGE_SIZE.id,
-      severity: CHECKS.IMAGE_SIZE.severity,
-      title: CHECKS.IMAGE_SIZE.title,
+      checkId: PERFORMANCE_IDS.imageSize,
+      severity: PERFORMANCE_SEVERITIES.imageSize,
+      title: PERFORMANCE_TITLES.ImageSize,
       status: STATUS.EMPTY,
       description: 'No image as LCP element.',
     };
@@ -95,9 +95,9 @@ export async function checkImageSize(url, area, observeLcp) {
     const blob = await fetch(lcp.url).then((res) => res.blob());
     const isSizeValid = blob.size / 1024 <= 100;
     return {
-      checkId: CHECKS.IMAGE_SIZE.id,
-      severity: CHECKS.IMAGE_SIZE.severity,
-      title: CHECKS.IMAGE_SIZE.title,
+      checkId: PERFORMANCE_IDS.imageSize,
+      severity: PERFORMANCE_SEVERITIES.imageSize,
+      title: PERFORMANCE_TITLES.ImageSize,
       status: isSizeValid ? STATUS.PASS : STATUS.FAIL,
       description: isSizeValid
         ? 'LCP image is less than 100KB.'
@@ -105,9 +105,9 @@ export async function checkImageSize(url, area, observeLcp) {
     };
   } catch (error) {
     return {
-      checkId: CHECKS.IMAGE_SIZE.id,
-      severity: CHECKS.IMAGE_SIZE.severity,
-      title: CHECKS.IMAGE_SIZE.title,
+      checkId: PERFORMANCE_IDS.imageSize,
+      severity: PERFORMANCE_SEVERITIES.imageSize,
+      title: PERFORMANCE_TITLES.ImageSize,
       status: STATUS.EMPTY,
       description: 'Could not fetch LCP image.',
     };
@@ -120,18 +120,18 @@ export async function checkVideoPoster(url, area, observeLcp) {
   const videoElement = lcp?.element?.closest('video') || lcp?.element?.querySelector('video');
   if (!hasVideoUrl && !videoElement) {
     return {
-      checkId: CHECKS.VIDEO_POSTER.id,
-      severity: CHECKS.VIDEO_POSTER.severity,
-      title: CHECKS.VIDEO_POSTER.title,
+      checkId: PERFORMANCE_IDS.videoPoster,
+      severity: PERFORMANCE_SEVERITIES.videoPoster,
+      title: PERFORMANCE_TITLES.VideoPoster,
       status: STATUS.EMPTY,
       description: 'No video as LCP element.',
     };
   }
   const hasPoster = !!videoElement?.poster;
   return {
-    checkId: CHECKS.VIDEO_POSTER.id,
-    severity: CHECKS.VIDEO_POSTER.severity,
-    title: CHECKS.VIDEO_POSTER.title,
+    checkId: PERFORMANCE_IDS.videoPoster,
+    severity: PERFORMANCE_SEVERITIES.videoPoster,
+    title: PERFORMANCE_TITLES.VideoPoster,
     status: hasPoster ? STATUS.PASS : STATUS.FAIL,
     description: hasPoster
       ? 'LCP video has a poster attribute.'
@@ -143,9 +143,9 @@ export async function checkFragments(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp?.element) {
     return {
-      checkId: CHECKS.FRAGMENTS.id,
-      severity: CHECKS.FRAGMENTS.severity,
-      title: 'Performance',
+      checkId: PERFORMANCE_IDS.fragments,
+      severity: PERFORMANCE_SEVERITIES.fragments,
+      title: PERFORMANCE_TITLES.Performance,
       status: STATUS.FAIL,
       description: 'No LCP element found.',
     };
@@ -154,18 +154,18 @@ export async function checkFragments(url, area, observeLcp) {
   const fragmentElements = fragmentClasses.flatMap((c) => Array.from(area.querySelectorAll(c)));
   if (fragmentElements.length === 0) {
     return {
-      checkId: CHECKS.FRAGMENTS.id,
-      severity: CHECKS.FRAGMENTS.severity,
-      title: CHECKS.FRAGMENTS.title,
+      checkId: PERFORMANCE_IDS.fragments,
+      severity: PERFORMANCE_SEVERITIES.fragments,
+      title: PERFORMANCE_TITLES.Fragments,
       status: STATUS.PASS,
       description: 'No fragments on the page.',
     };
   }
   const lcpInFragment = fragmentElements.some((f) => f.contains(lcp.element));
   return {
-    checkId: CHECKS.FRAGMENTS.id,
-    severity: CHECKS.FRAGMENTS.severity,
-    title: CHECKS.FRAGMENTS.title,
+    checkId: PERFORMANCE_IDS.fragments,
+    severity: PERFORMANCE_SEVERITIES.fragments,
+    title: PERFORMANCE_TITLES.Fragments,
     status: lcpInFragment ? STATUS.FAIL : STATUS.PASS,
     description: lcpInFragment
       ? 'LCP element is in a fragment. This can cause performance issues.'
@@ -177,9 +177,9 @@ export async function checkPlaceholders(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp?.element) {
     return {
-      checkId: CHECKS.PLACEHOLDERS.id,
-      severity: CHECKS.PLACEHOLDERS.severity,
-      title: 'Performance',
+      checkId: PERFORMANCE_IDS.placeholders,
+      severity: PERFORMANCE_SEVERITIES.placeholders,
+      title: PERFORMANCE_TITLES.Performance,
       status: STATUS.FAIL,
       description: 'No LCP element found.',
     };
@@ -187,18 +187,18 @@ export async function checkPlaceholders(url, area, observeLcp) {
   const placeholderElements = Array.from(area.querySelectorAll('[data-placeholder-content]'));
   if (placeholderElements.length === 0) {
     return {
-      checkId: CHECKS.PLACEHOLDERS.id,
-      severity: CHECKS.PLACEHOLDERS.severity,
-      title: CHECKS.PLACEHOLDERS.title,
+      checkId: PERFORMANCE_IDS.placeholders,
+      severity: PERFORMANCE_SEVERITIES.placeholders,
+      title: PERFORMANCE_TITLES.Placeholders,
       status: STATUS.PASS,
       description: 'No placeholders on the page.',
     };
   }
   const lcpInPlaceholder = placeholderElements.some((p) => p.contains(lcp.element));
   return {
-    checkId: CHECKS.PLACEHOLDERS.id,
-    severity: CHECKS.PLACEHOLDERS.severity,
-    title: CHECKS.PLACEHOLDERS.title,
+    checkId: PERFORMANCE_IDS.placeholders,
+    severity: PERFORMANCE_SEVERITIES.placeholders,
+    title: PERFORMANCE_TITLES.Placeholders,
     status: lcpInPlaceholder ? STATUS.FAIL : STATUS.PASS,
     description: lcpInPlaceholder
       ? 'LCP element contains placeholders. This can cause performance issues.'
@@ -210,9 +210,9 @@ export async function checkIcons(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp?.element) {
     return {
-      checkId: CHECKS.ICONS.id,
-      severity: CHECKS.ICONS.severity,
-      title: CHECKS.ICONS.title,
+      checkId: PERFORMANCE_IDS.icons,
+      severity: PERFORMANCE_SEVERITIES.icons,
+      title: PERFORMANCE_TITLES.Icons,
       status: STATUS.FAIL,
       description: 'No LCP element found.',
     };
@@ -220,18 +220,18 @@ export async function checkIcons(url, area, observeLcp) {
   const iconElements = Array.from(area.querySelectorAll('.icon'));
   if (iconElements.length === 0) {
     return {
-      checkId: CHECKS.ICONS.id,
-      severity: CHECKS.ICONS.severity,
-      title: CHECKS.ICONS.title,
+      checkId: PERFORMANCE_IDS.icons,
+      severity: PERFORMANCE_SEVERITIES.icons,
+      title: PERFORMANCE_TITLES.Icons,
       status: STATUS.PASS,
       description: 'No icons on the page.',
     };
   }
   const lcpContainsIcons = iconElements.some((i) => lcp.element.contains(i));
   return {
-    checkId: CHECKS.ICONS.id,
-    severity: CHECKS.ICONS.severity,
-    title: CHECKS.ICONS.title,
+    checkId: PERFORMANCE_IDS.icons,
+    severity: PERFORMANCE_SEVERITIES.icons,
+    title: PERFORMANCE_TITLES.Icons,
     status: lcpContainsIcons ? STATUS.FAIL : STATUS.PASS,
     description: lcpContainsIcons
       ? 'LCP element contains icons. This can cause performance issues.'

--- a/libs/blocks/preflight/checks/performance.js
+++ b/libs/blocks/preflight/checks/performance.js
@@ -1,4 +1,4 @@
-import { STATUS, PERFORMANCE_TITLES } from './constants.js';
+import { STATUS, CHECKS } from './constants.js';
 import { getMetadata } from '../../../utils/utils.js';
 
 const lcpCache = new Map();
@@ -31,7 +31,9 @@ export function checkSingleBlock(area) {
   const firstSection = area.querySelector('main > div.section');
   const hasMultipleBlocks = firstSection && firstSection.childElementCount > 1;
   return {
-    title: PERFORMANCE_TITLES.SingleBlock,
+    checkId: CHECKS.SINGLE_BLOCK.id,
+    severity: CHECKS.SINGLE_BLOCK.severity,
+    title: CHECKS.SINGLE_BLOCK.title,
     status: hasMultipleBlocks ? STATUS.FAIL : STATUS.PASS,
     description: hasMultipleBlocks
       ? 'First section has more than one block.'
@@ -44,7 +46,9 @@ export function checkForPersonalization(area) {
   const target = getMetadata('target', area) === 'on';
   const hasPersonalization = personalization || target;
   return {
-    title: PERFORMANCE_TITLES.Personalization,
+    checkId: CHECKS.PERSONALIZATION.id,
+    severity: CHECKS.PERSONALIZATION.severity,
+    title: CHECKS.PERSONALIZATION.title,
     status: hasPersonalization ? STATUS.FAIL : STATUS.PASS,
     description: hasPersonalization
       ? 'MEP or Target enabled.'
@@ -56,7 +60,9 @@ export async function checkLcpEl(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp) {
     return {
-      title: PERFORMANCE_TITLES.Performance,
+      checkId: CHECKS.LCP_ELEMENT.id,
+      severity: CHECKS.LCP_ELEMENT.severity,
+      title: 'Performance',
       status: STATUS.FAIL,
       description: 'No LCP element found.',
     };
@@ -64,7 +70,9 @@ export async function checkLcpEl(url, area, observeLcp) {
   const firstSection = area.querySelector('main > div.section');
   const validLcp = lcp?.element && lcp?.url && firstSection?.contains(lcp.element);
   return {
-    title: PERFORMANCE_TITLES.LcpEl,
+    checkId: CHECKS.LCP_ELEMENT.id,
+    severity: CHECKS.LCP_ELEMENT.severity,
+    title: CHECKS.LCP_ELEMENT.title,
     status: validLcp ? STATUS.PASS : STATUS.FAIL,
     description: validLcp
       ? 'Valid LCP in the first section detected.'
@@ -76,7 +84,9 @@ export async function checkImageSize(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp || !lcp.url || lcp.url.match('media_.*.mp4')) {
     return {
-      title: PERFORMANCE_TITLES.ImageSize,
+      checkId: CHECKS.IMAGE_SIZE.id,
+      severity: CHECKS.IMAGE_SIZE.severity,
+      title: CHECKS.IMAGE_SIZE.title,
       status: STATUS.EMPTY,
       description: 'No image as LCP element.',
     };
@@ -85,7 +95,9 @@ export async function checkImageSize(url, area, observeLcp) {
     const blob = await fetch(lcp.url).then((res) => res.blob());
     const isSizeValid = blob.size / 1024 <= 100;
     return {
-      title: PERFORMANCE_TITLES.ImageSize,
+      checkId: CHECKS.IMAGE_SIZE.id,
+      severity: CHECKS.IMAGE_SIZE.severity,
+      title: CHECKS.IMAGE_SIZE.title,
       status: isSizeValid ? STATUS.PASS : STATUS.FAIL,
       description: isSizeValid
         ? 'LCP image is less than 100KB.'
@@ -93,7 +105,9 @@ export async function checkImageSize(url, area, observeLcp) {
     };
   } catch (error) {
     return {
-      title: PERFORMANCE_TITLES.ImageSize,
+      checkId: CHECKS.IMAGE_SIZE.id,
+      severity: CHECKS.IMAGE_SIZE.severity,
+      title: CHECKS.IMAGE_SIZE.title,
       status: STATUS.EMPTY,
       description: 'Could not fetch LCP image.',
     };
@@ -106,14 +120,18 @@ export async function checkVideoPoster(url, area, observeLcp) {
   const videoElement = lcp?.element?.closest('video') || lcp?.element?.querySelector('video');
   if (!hasVideoUrl && !videoElement) {
     return {
-      title: PERFORMANCE_TITLES.VideoPoster,
+      checkId: CHECKS.VIDEO_POSTER.id,
+      severity: CHECKS.VIDEO_POSTER.severity,
+      title: CHECKS.VIDEO_POSTER.title,
       status: STATUS.EMPTY,
       description: 'No video as LCP element.',
     };
   }
   const hasPoster = !!videoElement?.poster;
   return {
-    title: PERFORMANCE_TITLES.VideoPoster,
+    checkId: CHECKS.VIDEO_POSTER.id,
+    severity: CHECKS.VIDEO_POSTER.severity,
+    title: CHECKS.VIDEO_POSTER.title,
     status: hasPoster ? STATUS.PASS : STATUS.FAIL,
     description: hasPoster
       ? 'LCP video has a poster attribute.'
@@ -125,18 +143,33 @@ export async function checkFragments(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp?.element) {
     return {
-      title: PERFORMANCE_TITLES.Performance,
+      checkId: CHECKS.FRAGMENTS.id,
+      severity: CHECKS.FRAGMENTS.severity,
+      title: 'Performance',
       status: STATUS.FAIL,
       description: 'No LCP element found.',
     };
   }
-  const hasFragments = lcp.element.closest('.fragment') || lcp.element.closest('.section')?.querySelector('[data-path*="fragment"]');
+  const fragmentClasses = ['.fragment'];
+  const fragmentElements = fragmentClasses.flatMap((c) => Array.from(area.querySelectorAll(c)));
+  if (fragmentElements.length === 0) {
+    return {
+      checkId: CHECKS.FRAGMENTS.id,
+      severity: CHECKS.FRAGMENTS.severity,
+      title: CHECKS.FRAGMENTS.title,
+      status: STATUS.PASS,
+      description: 'No fragments on the page.',
+    };
+  }
+  const lcpInFragment = fragmentElements.some((f) => f.contains(lcp.element));
   return {
-    title: PERFORMANCE_TITLES.Fragments,
-    status: hasFragments ? STATUS.FAIL : STATUS.PASS,
-    description: hasFragments
-      ? 'Fragments used within the LCP section.'
-      : 'No fragments used within the LCP section.',
+    checkId: CHECKS.FRAGMENTS.id,
+    severity: CHECKS.FRAGMENTS.severity,
+    title: CHECKS.FRAGMENTS.title,
+    status: lcpInFragment ? STATUS.FAIL : STATUS.PASS,
+    description: lcpInFragment
+      ? 'LCP element is in a fragment. This can cause performance issues.'
+      : 'No fragments contain the LCP element.',
   };
 }
 
@@ -144,19 +177,32 @@ export async function checkPlaceholders(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp?.element) {
     return {
-      title: PERFORMANCE_TITLES.Performance,
+      checkId: CHECKS.PLACEHOLDERS.id,
+      severity: CHECKS.PLACEHOLDERS.severity,
+      title: 'Performance',
       status: STATUS.FAIL,
       description: 'No LCP element found.',
     };
   }
-  const section = lcp.element.closest('.section');
-  const hasPlaceholders = section?.dataset.hasPlaceholders === 'true';
+  const placeholderElements = Array.from(area.querySelectorAll('[data-placeholder-content]'));
+  if (placeholderElements.length === 0) {
+    return {
+      checkId: CHECKS.PLACEHOLDERS.id,
+      severity: CHECKS.PLACEHOLDERS.severity,
+      title: CHECKS.PLACEHOLDERS.title,
+      status: STATUS.PASS,
+      description: 'No placeholders on the page.',
+    };
+  }
+  const lcpInPlaceholder = placeholderElements.some((p) => p.contains(lcp.element));
   return {
-    title: PERFORMANCE_TITLES.Placeholders,
-    status: hasPlaceholders ? STATUS.FAIL : STATUS.PASS,
-    description: hasPlaceholders
-      ? 'Placeholders found within the LCP section'
-      : 'No placeholders found within the LCP section.',
+    checkId: CHECKS.PLACEHOLDERS.id,
+    severity: CHECKS.PLACEHOLDERS.severity,
+    title: CHECKS.PLACEHOLDERS.title,
+    status: lcpInPlaceholder ? STATUS.FAIL : STATUS.PASS,
+    description: lcpInPlaceholder
+      ? 'LCP element contains placeholders. This can cause performance issues.'
+      : 'No placeholders in the LCP element.',
   };
 }
 
@@ -164,18 +210,32 @@ export async function checkIcons(url, area, observeLcp) {
   const lcp = await getLcpEntry(url, area, observeLcp);
   if (!lcp?.element) {
     return {
-      title: PERFORMANCE_TITLES.Icons,
+      checkId: CHECKS.ICONS.id,
+      severity: CHECKS.ICONS.severity,
+      title: CHECKS.ICONS.title,
       status: STATUS.FAIL,
       description: 'No LCP element found.',
     };
   }
-  const hasIcons = lcp.element.closest('.section')?.querySelector('.icon-milo');
+  const iconElements = Array.from(area.querySelectorAll('.icon'));
+  if (iconElements.length === 0) {
+    return {
+      checkId: CHECKS.ICONS.id,
+      severity: CHECKS.ICONS.severity,
+      title: CHECKS.ICONS.title,
+      status: STATUS.PASS,
+      description: 'No icons on the page.',
+    };
+  }
+  const lcpContainsIcons = iconElements.some((i) => lcp.element.contains(i));
   return {
-    title: PERFORMANCE_TITLES.Icons,
-    status: hasIcons ? STATUS.FAIL : STATUS.PASS,
-    description: hasIcons
-      ? 'Icons found within the LCP section.'
-      : 'No icons found within the LCP section.',
+    checkId: CHECKS.ICONS.id,
+    severity: CHECKS.ICONS.severity,
+    title: CHECKS.ICONS.title,
+    status: lcpContainsIcons ? STATUS.FAIL : STATUS.PASS,
+    description: lcpContainsIcons
+      ? 'LCP element contains icons. This can cause performance issues.'
+      : 'No icons in the LCP element.',
   };
 }
 

--- a/libs/blocks/preflight/checks/performance.js
+++ b/libs/blocks/preflight/checks/performance.js
@@ -1,4 +1,4 @@
-import { STATUS, SEVERITY, PERFORMANCE_TITLES, PERFORMANCE_IDS, PERFORMANCE_SEVERITIES } from './constants.js';
+import { STATUS, PERFORMANCE_TITLES, PERFORMANCE_IDS, PERFORMANCE_SEVERITIES } from './constants.js';
 import { getMetadata } from '../../../utils/utils.js';
 
 const lcpCache = new Map();

--- a/libs/blocks/preflight/checks/preflightApi.js
+++ b/libs/blocks/preflight/checks/preflightApi.js
@@ -30,6 +30,8 @@ let checks = null;
 
 let checksSuite = null;
 
+let checksSuite = null;
+
 export default {
   assets: {
     isViewportTooSmall,

--- a/libs/blocks/preflight/checks/preflightApi.js
+++ b/libs/blocks/preflight/checks/preflightApi.js
@@ -90,6 +90,20 @@ const runChecks = async (url, area, injectVisualMetadata = false) => {
   return { assets, performance, seo };
 };
 
+const processResults = (results) => {
+  const allResults = [
+    ...(results.assets || []),
+    ...(results.performance || []),
+    ...(results.seo || []),
+  ];
+
+  return {
+    isViewportTooSmall: isViewportTooSmall(),
+    runChecks: results,
+    hasFailures: allResults.some((result) => result.status === 'fail' && (result.severity === SEVERITY.CRITICAL || !result.severity)),
+  };
+};
+
 export async function getPreflightResults(options) {
   const {
     url,
@@ -97,32 +111,14 @@ export async function getPreflightResults(options) {
     useCache = true,
     injectVisualMetadata = false,
   } = options || {};
+  
   if (useCache && !injectVisualMetadata) {
     // Cache calls for without visual metadata
     if (!checks) checks = runChecks(url, area, injectVisualMetadata);
     const cachedChecks = await checks;
-    const allResults = [
-      ...(cachedChecks.assets || []),
-      ...(cachedChecks.performance || []),
-      ...(cachedChecks.seo || []),
-    ];
-    return {
-      isViewportTooSmall: isViewportTooSmall(),
-      runChecks: cachedChecks,
-      hasFailures: allResults.some((result) => result.status === 'fail' && result.severity === SEVERITY.CRITICAL),
-    };
+    return processResults(cachedChecks);
   }
 
   const res = await runChecks(url, area, injectVisualMetadata);
-  const allResults = [
-    ...(res.assets || []),
-    ...(res.performance || []),
-    ...(res.seo || []),
-  ];
-
-  return {
-    isViewportTooSmall: isViewportTooSmall(),
-    runChecks: res,
-    hasFailures: allResults.some((result) => result.status === 'fail' && result.severity === SEVERITY.CRITICAL),
-  };
+  return processResults(res);
 }

--- a/libs/blocks/preflight/checks/preflightApi.js
+++ b/libs/blocks/preflight/checks/preflightApi.js
@@ -30,8 +30,6 @@ let checks = null;
 
 let checksSuite = null;
 
-let checksSuite = null;
-
 export default {
   assets: {
     isViewportTooSmall,
@@ -90,20 +88,6 @@ const runChecks = async (url, area, injectVisualMetadata = false) => {
   return { assets, performance, seo };
 };
 
-const processResults = (results) => {
-  const allResults = [
-    ...(results.assets || []),
-    ...(results.performance || []),
-    ...(results.seo || []),
-  ];
-
-  return {
-    isViewportTooSmall: isViewportTooSmall(),
-    runChecks: results,
-    hasFailures: allResults.some((result) => result.status === 'fail' && (result.severity === SEVERITY.CRITICAL || !result.severity)),
-  };
-};
-
 export async function getPreflightResults(options) {
   const {
     url,
@@ -111,14 +95,33 @@ export async function getPreflightResults(options) {
     useCache = true,
     injectVisualMetadata = false,
   } = options || {};
-  
+
   if (useCache && !injectVisualMetadata) {
     // Cache calls for without visual metadata
     if (!checks) checks = runChecks(url, area, injectVisualMetadata);
     const cachedChecks = await checks;
-    return processResults(cachedChecks);
+    const allResults = [
+      ...(cachedChecks.assets || []),
+      ...(cachedChecks.performance || []),
+      ...(cachedChecks.seo || []),
+    ];
+    return {
+      isViewportTooSmall: isViewportTooSmall(),
+      runChecks: cachedChecks,
+      hasFailures: allResults.some((result) => result.status === 'fail' && result.severity === SEVERITY.CRITICAL),
+    };
   }
 
   const res = await runChecks(url, area, injectVisualMetadata);
-  return processResults(res);
+  const allResults = [
+    ...(res.assets || []),
+    ...(res.performance || []),
+    ...(res.seo || []),
+  ];
+
+  return {
+    isViewportTooSmall: isViewportTooSmall(),
+    runChecks: res,
+    hasFailures: allResults.some((result) => result.status === 'fail' && result.severity === SEVERITY.CRITICAL),
+  };
 }

--- a/libs/blocks/preflight/checks/preflightApi.js
+++ b/libs/blocks/preflight/checks/preflightApi.js
@@ -97,7 +97,6 @@ export async function getPreflightResults(options) {
     useCache = true,
     injectVisualMetadata = false,
   } = options || {};
-
   if (useCache && !injectVisualMetadata) {
     // Cache calls for without visual metadata
     if (!checks) checks = runChecks(url, area, injectVisualMetadata);

--- a/libs/blocks/preflight/checks/seo.js
+++ b/libs/blocks/preflight/checks/seo.js
@@ -1,6 +1,10 @@
+<<<<<<< HEAD
 import {
   STATUS, CHECKS, SEO_TITLES, SEO_IDS, SEO_DESCRIPTIONS,
 } from './constants.js';
+=======
+import { STATUS, CHECKS, SEVERITY } from './constants.js';
+>>>>>>> 95a5e934b (fix: notification not showing when Links are the only failing (critical) checks)
 import getServiceConfig from '../../../utils/service-config.js';
 import { getConfig, updateConfig } from '../../../utils/utils.js';
 

--- a/libs/blocks/preflight/checks/seo.js
+++ b/libs/blocks/preflight/checks/seo.js
@@ -1,4 +1,6 @@
-import { STATUS, CHECKS, SEO_TITLES, SEO_IDS, SEO_DESCRIPTIONS } from './constants.js';
+import {
+  STATUS, SEO_TITLES, SEO_IDS, SEO_DESCRIPTIONS, SEO_SEVERITIES, SEO_CHECK_IDS,
+} from './constants.js';
 import getServiceConfig from '../../../utils/service-config.js';
 import { getConfig, updateConfig } from '../../../utils/utils.js';
 
@@ -46,9 +48,9 @@ export function checkH1s(area) {
   }
 
   return {
-    checkId: CHECKS.H1_COUNT.id,
+    checkId: SEO_CHECK_IDS.h1Count,
     id: SEO_IDS.h1Count,
-    severity: CHECKS.H1_COUNT.severity,
+    severity: SEO_SEVERITIES.h1Count,
     title: SEO_TITLES.h1Count,
     status,
     description,
@@ -72,9 +74,9 @@ export function checkTitle(area) {
   }
 
   return {
-    checkId: CHECKS.TITLE_SIZE.id,
+    checkId: SEO_CHECK_IDS.title,
     id: SEO_IDS.title,
-    severity: CHECKS.TITLE_SIZE.severity,
+    severity: SEO_SEVERITIES.title,
     title: SEO_TITLES.title,
     status,
     description,
@@ -110,9 +112,9 @@ export async function checkCanon(area) {
   }
 
   return {
-    checkId: CHECKS.CANONICAL.id,
+    checkId: SEO_CHECK_IDS.canonical,
     id: SEO_IDS.canonical,
-    severity: CHECKS.CANONICAL.severity,
+    severity: SEO_SEVERITIES.canonical,
     title: SEO_TITLES.canonical,
     status,
     description,
@@ -142,9 +144,9 @@ export async function checkDescription(area) {
   }
 
   return {
-    checkId: CHECKS.META_DESCRIPTION.id,
+    checkId: SEO_CHECK_IDS.description,
     id: SEO_IDS.description, // ASO compatibility
-    severity: CHECKS.META_DESCRIPTION.severity,
+    severity: SEO_SEVERITIES.description,
     title: SEO_TITLES.description,
     status,
     description,
@@ -165,9 +167,9 @@ export async function checkBody(area) {
   }
 
   return {
-    checkId: CHECKS.BODY_SIZE.id,
+    checkId: SEO_CHECK_IDS.bodySize,
     id: SEO_IDS.bodySize,
-    severity: CHECKS.BODY_SIZE.severity,
+    severity: SEO_SEVERITIES.bodySize,
     title: SEO_TITLES.bodySize,
     status,
     description,
@@ -189,9 +191,9 @@ export async function checkLorem(area) {
   }
 
   return {
-    checkId: CHECKS.LOREM_IPSUM.id,
+    checkId: SEO_CHECK_IDS.loremIpsum,
     id: SEO_IDS.loremIpsum,
-    severity: CHECKS.LOREM_IPSUM.severity,
+    severity: SEO_SEVERITIES.loremIpsum,
     title: SEO_TITLES.loremIpsum,
     status,
     description,
@@ -206,9 +208,9 @@ function makeGroups(arr, n = 20) {
 
 export function connectionError() {
   return {
-    checkId: CHECKS.BROKEN_LINKS.id,
+    checkId: SEO_CHECK_IDS.links,
     id: SEO_IDS.links,
-    severity: CHECKS.BROKEN_LINKS.severity,
+    severity: SEO_SEVERITIES.links,
     title: SEO_TITLES.links,
     status: STATUS.LIMBO,
     description: 'A VPN connection is required to use the link check service. Please turn on VPN and refresh the page.',
@@ -331,9 +333,9 @@ export async function checkLinks({ area, urlHash, envName }) {
     : SEO_DESCRIPTIONS.links;
 
   const result = {
-    checkId: CHECKS.BROKEN_LINKS.id,
+    checkId: SEO_CHECK_IDS.links,
     id: SEO_IDS.links,
-    severity: CHECKS.BROKEN_LINKS.severity,
+    severity: SEO_SEVERITIES.links,
     title: SEO_TITLES.links,
     status,
     description,

--- a/libs/blocks/preflight/checks/seo.js
+++ b/libs/blocks/preflight/checks/seo.js
@@ -1,10 +1,6 @@
-<<<<<<< HEAD
 import {
   STATUS, CHECKS, SEO_TITLES, SEO_IDS, SEO_DESCRIPTIONS,
 } from './constants.js';
-=======
-import { STATUS, CHECKS, SEVERITY } from './constants.js';
->>>>>>> 95a5e934b (fix: notification not showing when Links are the only failing (critical) checks)
 import getServiceConfig from '../../../utils/service-config.js';
 import { getConfig, updateConfig } from '../../../utils/utils.js';
 

--- a/libs/blocks/preflight/checks/seo.js
+++ b/libs/blocks/preflight/checks/seo.js
@@ -328,6 +328,9 @@ export async function checkLinks({ area, urlHash, envName }) {
     linksCache.set(urlHash, result);
   }
 
+  const hasFailures = status === STATUS.FAIL;
+  const event = new CustomEvent('preflightLinksComplete', { detail: { result, hasFailures } });
+  window.dispatchEvent(event);
   return result;
 }
 

--- a/libs/blocks/preflight/checks/seo.js
+++ b/libs/blocks/preflight/checks/seo.js
@@ -1,6 +1,4 @@
-import {
-  STATUS, CHECKS, SEO_TITLES, SEO_IDS, SEO_DESCRIPTIONS,
-} from './constants.js';
+import { STATUS, CHECKS, SEO_TITLES, SEO_IDS, SEO_DESCRIPTIONS } from './constants.js';
 import getServiceConfig from '../../../utils/service-config.js';
 import { getConfig, updateConfig } from '../../../utils/utils.js';
 
@@ -347,9 +345,7 @@ export async function checkLinks({ area, urlHash, envName }) {
   }
 
   const hasFailures = status === STATUS.FAIL;
-  window.dispatchEvent(new CustomEvent('preflightLinksComplete', {
-    detail: { hasFailures }
-  }));
+  window.dispatchEvent(new CustomEvent('preflightLinksComplete', { detail: { hasFailures } }));
 
   return result;
 }

--- a/libs/blocks/preflight/checks/seo.js
+++ b/libs/blocks/preflight/checks/seo.js
@@ -1,4 +1,6 @@
-import { STATUS, SEO_TITLES, SEO_IDS, SEO_DESCRIPTIONS } from './constants.js';
+import {
+  STATUS, CHECKS, SEO_TITLES, SEO_IDS, SEO_DESCRIPTIONS,
+} from './constants.js';
 import getServiceConfig from '../../../utils/service-config.js';
 import { getConfig, updateConfig } from '../../../utils/utils.js';
 
@@ -46,7 +48,9 @@ export function checkH1s(area) {
   }
 
   return {
+    checkId: CHECKS.H1_COUNT.id,
     id: SEO_IDS.h1Count,
+    severity: CHECKS.H1_COUNT.severity,
     title: SEO_TITLES.h1Count,
     status,
     description,
@@ -70,7 +74,9 @@ export function checkTitle(area) {
   }
 
   return {
+    checkId: CHECKS.TITLE_SIZE.id,
     id: SEO_IDS.title,
+    severity: CHECKS.TITLE_SIZE.severity,
     title: SEO_TITLES.title,
     status,
     description,
@@ -106,7 +112,9 @@ export async function checkCanon(area) {
   }
 
   return {
+    checkId: CHECKS.CANONICAL.id,
     id: SEO_IDS.canonical,
+    severity: CHECKS.CANONICAL.severity,
     title: SEO_TITLES.canonical,
     status,
     description,
@@ -136,7 +144,9 @@ export async function checkDescription(area) {
   }
 
   return {
-    id: SEO_IDS.description,
+    checkId: CHECKS.META_DESCRIPTION.id,
+    id: SEO_IDS.description, // ASO compatibility
+    severity: CHECKS.META_DESCRIPTION.severity,
     title: SEO_TITLES.description,
     status,
     description,
@@ -157,7 +167,9 @@ export async function checkBody(area) {
   }
 
   return {
+    checkId: CHECKS.BODY_SIZE.id,
     id: SEO_IDS.bodySize,
+    severity: CHECKS.BODY_SIZE.severity,
     title: SEO_TITLES.bodySize,
     status,
     description,
@@ -179,7 +191,9 @@ export async function checkLorem(area) {
   }
 
   return {
+    checkId: CHECKS.LOREM_IPSUM.id,
     id: SEO_IDS.loremIpsum,
+    severity: CHECKS.LOREM_IPSUM.severity,
     title: SEO_TITLES.loremIpsum,
     status,
     description,
@@ -194,7 +208,9 @@ function makeGroups(arr, n = 20) {
 
 export function connectionError() {
   return {
+    checkId: CHECKS.BROKEN_LINKS.id,
     id: SEO_IDS.links,
+    severity: CHECKS.BROKEN_LINKS.severity,
     title: SEO_TITLES.links,
     status: STATUS.LIMBO,
     description: 'A VPN connection is required to use the link check service. Please turn on VPN and refresh the page.',
@@ -317,7 +333,9 @@ export async function checkLinks({ area, urlHash, envName }) {
     : SEO_DESCRIPTIONS.links;
 
   const result = {
+    checkId: CHECKS.BROKEN_LINKS.id,
     id: SEO_IDS.links,
+    severity: CHECKS.BROKEN_LINKS.severity,
     title: SEO_TITLES.links,
     status,
     description,
@@ -329,8 +347,10 @@ export async function checkLinks({ area, urlHash, envName }) {
   }
 
   const hasFailures = status === STATUS.FAIL;
-  const event = new CustomEvent('preflightLinksComplete', { detail: { result, hasFailures } });
-  window.dispatchEvent(event);
+  window.dispatchEvent(new CustomEvent('preflightLinksComplete', {
+    detail: { hasFailures }
+  }));
+
   return result;
 }
 

--- a/libs/blocks/preflight/panels/assets.js
+++ b/libs/blocks/preflight/panels/assets.js
@@ -1,8 +1,7 @@
 import { html, signal, useEffect } from '../../../deps/htm-preact.js';
-import preflightApi from '../checks/preflightApi.js';
 import { STATUS } from '../checks/constants.js';
-
-const { isViewportTooSmall, runChecks } = preflightApi.assets;
+import { getPreflightResults } from '../checks/preflightApi.js';
+import { isViewportTooSmall } from '../checks/assets.js';
 
 // Define signals for check results and viewport status
 const assetDimensionsResult = signal({
@@ -11,13 +10,21 @@ const assetDimensionsResult = signal({
 });
 const assetsWithMismatch = signal([]);
 const assetsWithMatch = signal([]);
+const criticalAssetFailures = signal([]);
+const warningAssetFailures = signal([]);
 const viewportTooSmall = signal(isViewportTooSmall());
 
 /**
  * Runs asset checks and updates signals with the results.
  */
 async function getResults() {
-  const checks = runChecks(window.location.pathname, document, true);
+  const results = await getPreflightResults({
+    url: window.location.pathname,
+    area: document,
+    useCache: false,
+    injectVisualMetadata: false,
+  });
+  const checks = results.runChecks.assets || [];
 
   const result = await Promise.resolve(checks[0]).catch((error) => ({
     title: 'Assets - Image Dimensions',
@@ -33,6 +40,8 @@ async function getResults() {
   if (result.details) {
     assetsWithMismatch.value = result.details.assetsWithMismatch || [];
     assetsWithMatch.value = result.details.assetsWithMatch || [];
+    criticalAssetFailures.value = result.details.criticalAssetFailures || [];
+    warningAssetFailures.value = result.details.warningAssetFailures || [];
   }
 }
 
@@ -54,6 +63,8 @@ function AssetsItem({ title, description }) {
  */
 function AssetGroup({ group }) {
   const { title, assetArray } = group;
+  const isCriticalGroup = title.includes('Critical');
+
   return html`
     <div class="grid-heading">
       <div class="grid-toggle">${title}</div>
@@ -67,8 +78,12 @@ function AssetGroup({ group }) {
 
     ${!viewportTooSmall.value && assetArray.value.length > 0 && html`
     <div class='assets-image-grid'>
-      ${assetArray.value.map((asset) => html`
-      <div class='assets-image-grid-item'>
+      ${assetArray.value.map((asset) => {
+    const isAboveFoldWithMismatch = isCriticalGroup;
+    const itemClass = isAboveFoldWithMismatch ? 'assets-image-grid-item above-fold-critical' : 'assets-image-grid-item';
+
+    return html`
+      <div class='${itemClass}' title='${isAboveFoldWithMismatch ? 'Above-the-fold asset with critical dimension issues' : ''}'>
         ${asset.type === 'image' && html`<img src='${asset.src}' />`}
         ${asset.type === 'video' && html`<video controls src='${asset.src}' />`}
         ${asset.type === 'mpc' && html`<iframe src='${asset.src}' />`}
@@ -79,11 +94,13 @@ function AssetGroup({ group }) {
           ${asset.hasMismatch && html`<span>Recommended size: ${asset.recommendedDimensions}</span>`}
           <span>Type: ${asset.typeLabel}</span>
           ${asset.notes && html`<span><strong>Notes:</strong> ${asset.notes}</span>`}
+          ${isAboveFoldWithMismatch && html`<span class="above-fold-notice"><strong>⚠️ CRITICAL:</strong></span>`}
         </div>
-      </div>`)}
+      </div>`;
+  })}
     </div>`}
 
-    ${!viewportTooSmall.value && !assetArray.value.length && html`
+    ${!viewportTooSmall.value && assetArray.value.length === 0 && html`
       <div class='assets-image-grid'>
         <div class='assets-image-grid-item full-width'>No assets found</div>
       </div>
@@ -119,7 +136,8 @@ export default function Assets() {
   }, []);
 
   const groups = [
-    { title: 'Assets with dimension mismatch', assetArray: assetsWithMismatch },
+    { title: 'Critical Asset Issues (Above-the-fold)', assetArray: criticalAssetFailures },
+    { title: 'Warning Asset Issues (Below-the-fold)', assetArray: warningAssetFailures },
     { title: 'Assets with matching dimensions', assetArray: assetsWithMatch },
   ];
 

--- a/libs/blocks/preflight/panels/seo.js
+++ b/libs/blocks/preflight/panels/seo.js
@@ -136,7 +136,10 @@ function SeoItem({ id, icon, title, description, supportsAi }) {
 }
 
 async function getResults() {
-  const results = (await getPreflightResults(window.location.href, document)).runChecks.seo || [];
+  const results = (await getPreflightResults({
+    url: window.location.href,
+    area: document,
+  })).runChecks.seo || [];
 
   // Update UI as each check resolves
   const icons = [];

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -663,6 +663,16 @@ body.preflight-assets-analysis {
   border-radius: 6px;
 }
 
+.above-fold-notice {
+  color: #dc2626;
+  font-weight: bold;
+  background: rgba(220, 38, 38, 10%);
+  padding: 4px 8px;
+  border-radius: 4px;
+  border-left: 3px solid #dc2626;
+  margin-top: 8px;
+}
+
 .assets-image-grid-item.full-width {
   grid-column: 1 / -1;
 }
@@ -714,6 +724,16 @@ picture:has(.asset-meta),
   line-height: 1.2;
   z-index: 2;
   opacity: 0.7;
+}
+
+.asset-meta .above-fold-critical {
+  background: rgba(220, 38, 38, 90%);
+  color: #fff;
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 2px solid #fff;
+  opacity: 1;
+  font-weight: bold;
 }
 
 .text.center .asset-meta {

--- a/libs/blocks/preflight/visual-metadata.js
+++ b/libs/blocks/preflight/visual-metadata.js
@@ -1,0 +1,63 @@
+import { createTag } from '../../utils/utils.js';
+
+export function addAssetMetadata(asset, assetData) {
+  let parent;
+  if (asset.tagName === 'VIDEO') {
+    parent = asset.closest('.video-holder') || asset.parentElement;
+  } else if (asset.tagName === 'IFRAME') {
+    parent = asset.closest('.milo-video') || asset.parentElement;
+  } else {
+    parent = asset.closest('picture') || asset.parentElement;
+  }
+
+  let container = parent.querySelector('.asset-meta');
+  if (!container) {
+    container = createTag('div', { class: 'asset-meta' });
+    parent.insertBefore(container, asset.nextSibling);
+  }
+
+  const sizeStatus = assetData.hasMismatch ? 'is-invalid' : 'is-valid';
+  const isAboveFoldCritical = assetData.isAboveFold && assetData.hasMismatch;
+
+  const sizeMessage = (isAboveFoldCritical && `CRITICAL: size issue! Use > ${assetData.recommendedDimensions}`)
+    || (assetData.hasMismatch && `Size: too small, use > ${assetData.recommendedDimensions}`)
+    || 'Size: correct';
+
+  const sizeEl = createTag('div', { class: `asset-meta-entry preflight-decoration ${sizeStatus} ${isAboveFoldCritical ? 'above-fold-critical' : ''}` }, sizeMessage);
+  container.appendChild(sizeEl);
+
+  if (assetData.type === 'mpc') {
+    const title = asset.title || '';
+    const titleStatus = title.length ? 'is-valid' : 'is-invalid';
+    const titleMessage = title.length ? `Title: ${title}` : 'Title: no title';
+
+    const titleEl = createTag('div', { class: `asset-meta-entry preflight-decoration ${titleStatus}` }, titleMessage);
+    container.appendChild(titleEl);
+  }
+}
+
+export function addAccessibilityMetadata(element, message, status = '') {
+  const picture = element.closest('picture');
+  let container;
+
+  if (picture) {
+    container = picture.querySelector('.asset-meta');
+    if (!container) {
+      container = createTag('div', { class: 'asset-meta' });
+      picture.insertBefore(container, element.nextSibling);
+    }
+  } else {
+    container = createTag('div', { class: 'asset-meta no-picture-tag' });
+    element.parentNode.insertBefore(container, element.nextSibling);
+  }
+
+  const statusMap = {
+    'has-alt': 'is-valid',
+    'is-decorative': 'needs-attention',
+    'is-invalid': 'is-invalid',
+  };
+
+  const statusClass = statusMap[status] || '';
+  const metadataEl = createTag('div', { class: `asset-meta-entry ${statusClass}` }, message);
+  container.appendChild(metadataEl);
+}

--- a/libs/styles/preflight-notification.css
+++ b/libs/styles/preflight-notification.css
@@ -1,0 +1,62 @@
+.milo-preflight-overlay {
+  position: fixed;
+  bottom: 120px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--modal-z-index);
+  font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
+}
+
+.preflight-notification {
+  background: rgb(34 34 34);
+  color: rgb(242 242 242);
+  padding: 12px 18px;
+  border-radius: 8px;
+  font-size: 14px;
+  line-height: 1.4;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
+  border: 1px solid rgb(57 57 57);
+  letter-spacing: 0.02em;
+}
+
+.notification-content {
+  display: flex;
+  gap: 12px;
+}
+
+.notification-close {
+  background: none;
+  border: none;
+  color: rgb(242 242 242);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  transition: opacity 0.15s ease;
+}
+
+.notification-close:hover {
+  opacity: 1;
+}
+
+.preflight-review-link {
+  background: none;
+  border: none;
+  color: rgb(59 99 251);
+  text-decoration: underline;
+  cursor: pointer;
+  font-weight: 500;
+  padding: 0;
+  transition: color 0.15s ease;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.preflight-review-link:hover {
+  color: rgb(90 127 255);
+} 

--- a/libs/styles/preflight-notification.css
+++ b/libs/styles/preflight-notification.css
@@ -3,7 +3,7 @@
   bottom: 120px;
   left: 50%;
   transform: translateX(-50%);
-  z-index: var(--modal-z-index);
+  z-index: 102;
   font-family: 'Adobe Clean', adobe-clean, 'Trebuchet MS', sans-serif;
 }
 

--- a/libs/utils/preflight-notification.js
+++ b/libs/utils/preflight-notification.js
@@ -85,7 +85,7 @@ function createObserver() {
       }
       return;
     }
-
+    // Check if sidekick is open and we should show notification
     if (sidekick.getAttribute('open') === 'true' && !wasDismissed) {
       const { hasFailures } = await getPreflightResults({
         url: window.location.href,

--- a/libs/utils/preflight-notification.js
+++ b/libs/utils/preflight-notification.js
@@ -1,0 +1,126 @@
+import { getPreflightResults } from '../blocks/preflight/checks/preflightApi.js';
+import { loadStyle, getConfig } from './utils.js';
+
+let wasDismissed = false;
+let sidekickObserver;
+let linkCheckListener;
+const sidekick = document.querySelector('aem-sidekick');
+function openPreflightPanel() {
+  if (sidekick) {
+    sidekick.dispatchEvent(new CustomEvent('custom:preflight', { bubbles: true }));
+  }
+}
+
+async function createPreflightNotification() {
+  const existingNotification = document.querySelector('.milo-preflight-overlay');
+  if (existingNotification) return;
+  const { miloLibs, codeRoot } = getConfig();
+  const base = miloLibs || codeRoot;
+  loadStyle(`${base}/styles/preflight-notification.css`);
+
+  const overlay = document.createElement('div');
+  overlay.className = 'milo-preflight-overlay';
+  overlay.innerHTML = `
+    <div class="preflight-notification">
+      <div class="notification-content">
+        <span class="notification-message">
+          Content quality checks are failing. Please <button class="preflight-review-link">review</button> before publishing.
+        </span>
+        <button class="notification-close">×</button>
+      </div>
+    </div>
+  `;
+
+  const reviewLink = overlay.querySelector('.preflight-review-link');
+  reviewLink.addEventListener('click', (e) => {
+    e.preventDefault();
+    openPreflightPanel();
+  });
+
+  const closeBtn = overlay.querySelector('.notification-close');
+  closeBtn.addEventListener('click', () => {
+    overlay.remove();
+    wasDismissed = true;
+    if (linkCheckListener) {
+      window.removeEventListener('preflightLinksComplete', linkCheckListener);
+      linkCheckListener = null;
+    }
+  });
+
+  document.body.appendChild(overlay);
+}
+
+function setupLinkCheckListener() {
+  if (linkCheckListener) return;
+
+  linkCheckListener = async (event) => {
+    const { hasFailures } = event.detail;
+
+    if (hasFailures && !wasDismissed) {
+      const existingNotification = document.querySelector('.milo-preflight-overlay');
+      const isPublishButtonDisabled = sidekick?.shadowRoot
+        ?.querySelector('plugin-action-bar')?.shadowRoot
+        ?.querySelector('sk-action-button.publish[disabled]');
+
+      if (!existingNotification && !isPublishButtonDisabled) {
+        await createPreflightNotification();
+      }
+    }
+
+    window.removeEventListener('preflightLinksComplete', linkCheckListener);
+    linkCheckListener = null;
+  };
+
+  window.addEventListener('preflightLinksComplete', linkCheckListener);
+}
+
+function createObserver() {
+  if (sidekickObserver) return;
+  sidekickObserver = new MutationObserver(async () => {
+    const notification = document.querySelector('.milo-preflight-overlay');
+
+    if (!sidekick || sidekick.getAttribute('open') !== 'true') {
+      if (notification) {
+        notification.remove();
+      }
+      return;
+    }
+
+    if (sidekick.getAttribute('open') === 'true' && !wasDismissed) {
+      const { hasFailures } = await getPreflightResults({
+        url: window.location.href,
+        area: document,
+      });
+      if (hasFailures) {
+        await createPreflightNotification();
+      }
+    }
+  });
+
+  sidekickObserver.observe(document, {
+    attributes: true,
+    childList: true,
+    subtree: true,
+    attributeFilter: ['open'],
+  });
+}
+
+export default async function show() {
+  createObserver();
+  const { hasFailures } = await getPreflightResults({
+    url: window.location.href,
+    area: document,
+  });
+  const existingNotification = document.querySelector('.milo-preflight-overlay');
+  if (existingNotification) return;
+
+  const isPublishButtonDisabled = sidekick?.shadowRoot
+    ?.querySelector('plugin-action-bar')?.shadowRoot
+    ?.querySelector('sk-action-button.publish[disabled]');
+
+  if (hasFailures && !wasDismissed && !isPublishButtonDisabled) {
+    await createPreflightNotification();
+  } else if (!wasDismissed && !isPublishButtonDisabled) {
+    setupLinkCheckListener();
+  }
+}

--- a/libs/utils/sidekick-decorate.js
+++ b/libs/utils/sidekick-decorate.js
@@ -1,4 +1,5 @@
 import userCanPublishPage from '../tools/utils/publish.js';
+import checkPreflightAndShowNotification from './preflight-notification.js';
 
 const PUBLISH_BTN = '.publish.plugin button';
 const PROFILE = '.profile-email';
@@ -121,6 +122,8 @@ async function checkAuthorization(page, btn) {
 export default async function stylePublish(sk) {
   if (stylePublishCalled) return;
   stylePublishCalled = true;
+
+  checkPreflightAndShowNotification();
 
   if (sk.nodeName === 'HELIX-SIDEKICK') {
     styleHelixPublish(sk);

--- a/libs/utils/sidekick.js
+++ b/libs/utils/sidekick.js
@@ -1,5 +1,6 @@
 import stylePublish from './sidekick-decorate.js';
 import { debounce } from './action.js';
+import { getPreflightResults } from '../blocks/preflight/checks/preflightApi.js';
 
 // loadScript and loadStyle are passed in to avoid circular dependencies
 export default function init({ createTag, loadBlock, loadScript, loadStyle }) {
@@ -20,6 +21,13 @@ export default function init({ createTag, loadBlock, loadScript, loadStyle }) {
   };
 
   const preflightListener = async () => {
+    await getPreflightResults({
+      url: window.location.href,
+      area: document,
+      useCache: true,
+      injectVisualMetadata: true,
+    });
+
     const preflight = createTag('div', { class: 'preflight' });
     const content = await loadBlock(preflight);
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1619,7 +1619,10 @@ function initSidekick() {
     const { default: init } = await import('./sidekick.js');
     const { getPreflightResults } = await import('../blocks/preflight/checks/preflightApi.js');
     init({ createTag, loadBlock, loadScript, loadStyle });
-    getPreflightResults(window.location.href, document);
+    getPreflightResults({
+      url: window.location.href,
+      area: document,
+    });
   };
 
   if (document.querySelector('aem-sidekick, helix-sidekick')) {

--- a/test/blocks/preflight/checks/assets.test.js
+++ b/test/blocks/preflight/checks/assets.test.js
@@ -12,6 +12,7 @@ describe('Preflight Asset Checks', () => {
   let mockPicture;
 
   beforeEach(() => {
+    const mockMain = { querySelectorAll: sinon.stub().returns([]) };
     mockMatchMedia = sinon.stub(window, 'matchMedia').returns({ matches: true });
 
     mockPicture = {
@@ -29,7 +30,11 @@ describe('Preflight Asset Checks', () => {
       setAttribute: sinon.stub(),
       addEventListener: sinon.stub(),
       checkVisibility: sinon.stub().returns(true),
-      closest: (selector) => (selector === '.icon-area' ? null : mockPicture),
+      closest: (selector) => {
+        if (selector === '.icon-area') return null;
+        if (selector === 'main') return mockMain;
+        return mockPicture;
+      },
       src: 'test.jpg',
       nextSibling: null,
     };

--- a/test/blocks/preflight/checks/assets.test.js
+++ b/test/blocks/preflight/checks/assets.test.js
@@ -12,11 +12,10 @@ describe('Preflight Asset Checks', () => {
   let mockPicture;
 
   beforeEach(() => {
-    const mockMain = { querySelectorAll: sinon.stub().returns([]) };
     mockMatchMedia = sinon.stub(window, 'matchMedia').returns({ matches: true });
 
     mockPicture = {
-      querySelector: sinon.stub().returns(null),
+      querySelectorAll: sinon.stub().returns([]),
       insertBefore: sinon.stub(),
     };
 
@@ -30,11 +29,7 @@ describe('Preflight Asset Checks', () => {
       setAttribute: sinon.stub(),
       addEventListener: sinon.stub(),
       checkVisibility: sinon.stub().returns(true),
-      closest: (selector) => {
-        if (selector === '.icon-area') return null;
-        if (selector === 'main') return mockMain;
-        return mockPicture;
-      },
+      closest: (selector) => (selector === '.icon-area' ? null : mockPicture),
       src: 'test.jpg',
       nextSibling: null,
     };


### PR DESCRIPTION
Now Preflight will be ran automatically when the page is loaded (once the `utils.js` is loaded).

After Preflight is done running in the background, it will cache its results and when the User clicks on `tools`>`preflight` to open up the Preflight Panel then the checks first look for already existing caches and if none were found they will then be ran manually.

Also added a notification bar to inform the Athors of any failling checks, The Athors can click on the `review` button to open up the Preflight Panel and get more details.

Resolves: [MWPW-177389](https://jira.corp.adobe.com/browse/MWPW-177389)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://preflight-notification--milo--adobecom.aem.page/?martech=off
- https://main--cc--adobecom.aem.page/drafts/narcis/creativecloud?milolibs=Preflight-CheckStatus--milo--skholkhojaev
- https://main--bacom--adobecom.aem.page/sg/products/experience-manager/sites/build-global-site?milolibs=preflight-notification--milo--adobecom
- https://main--da-bacom--adobecom.aem.page/products/adobe-analytics?milolibs=preflight-notification--milo--adobecom
