### PR TITLE
MWPW-180349 Brand Concierge - Remove Modal close focus ring

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -39,7 +39,7 @@ function updateModalHeight() {
 
 async function openChatModal(initialMessage, el) {
   const innerModal = new DocumentFragment();
-  const title = createTag('span', { class: 'bc-modal-title' }, 'AI Assistant');
+  const title = createTag('h1', { class: 'bc-modal-title' }, 'AI Assistant');
   const header = createTag('div', { class: 'bc-modal-header' }, [title, getBetaLabel()]);
   const mountEl = createTag('div', { id: mountId });
   if (initialMessage) mountEl.dataset.initialMessage = initialMessage;


### PR DESCRIPTION
* Remove visible focus ring around close button in Brand Concierge modal

Resolves: [MWPW-180349](https://jira.corp.adobe.com/browse/MWPW-180349)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off
- After: https://bc-close--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off
