### PR TITLE
[MWPW-180618] - action item alignement fix

### DIFF
--- a/libs/blocks/action-item/action-item.css
+++ b/libs/blocks/action-item/action-item.css
@@ -2,6 +2,10 @@
   display: flex;
 }
 
+.action-item .static {
+  width: -webkit-fill-available;
+}
+
 .action-item img {
   display: block;
   max-height: 240px;


### PR DESCRIPTION
This fixes alignment issues for the action item. On some pages like https://www.adobe.com/nl/nonprofits.html the class `center` is missing and would need to be applied for this fix to work as it is applied on the test pages supplied in the ticket and here bellow in the Test URLs section.

Resolves: [MWPW-180618](https://jira.corp.adobe.com/browse/MWPW-180618)

**PSI Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://action-item-align-fix--milo--adobecom.aem.page/?martech=off

**Test URLs:**
- Before: https://main--cc--adobecom.aem.live/drafts/klee/test-action-items
- After: https://main--cc--adobecom.aem.live/drafts/klee/test-action-items?milolibs=action-item-misalignment