### PR TITLE
[DA Importer] Fix hlx vs aem domains

### DIFF
--- a/.github/workflows/import/index.js
+++ b/.github/workflows/import/index.js
@@ -54,11 +54,14 @@ async function importMedia(pageUrl, text, importedMedia) {
 
   const linkedMedia = [...results, ...matches].reduce((acc, a) => {
     let href = a.getAttribute('href') || a.getAttribute('alt');
+
+    // Normalize all links to aem
+    href = href.replace('.hlx.', '.aem.');
+
     // Don't add any off origin content.
     const isSameDomain = prefixes.some((prefix) => href.startsWith(prefix));
     if (!isSameDomain) return acc;
 
-    href = href.replace('.hlx.', '.aem.');
 
     [href] = href.match(/^[^?#| ]+/);
 


### PR DESCRIPTION
Port from https://github.com/adobe/da-nx/commit/481b8ba74bdc021c0b6ecfdf1082cecc58c3ef84

No QE required for this zero impact port.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://nx-sync--milo--adobecom.aem.page/?martech=off


