### PR TITLE
MWPW-181071 Brand Concierge - Remove image carousel

### DIFF
--- a/libs/blocks/brand-concierge/chat-ui-config.js
+++ b/libs/blocks/brand-concierge/chat-ui-config.js
@@ -42,7 +42,10 @@ export default {
     ],
   },
   behavior: {
-    multimodalCarousel: { cardClickAction: 'openLink' },
+    multimodalCarousel: {
+      cardClickAction: 'openLink',
+      hideCarousel: true,
+    },
     input: {
       enableVoiceInput: false,
       disableMultiline: true,


### PR DESCRIPTION
* Disable image carousel from Brand Concierge chat responses

Resolves: [MWPW-181071](https://jira.corp.adobe.com/browse/MWPW-181071)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off
- After: https://bc-carousel--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off

Click "I’d like to explore templates to see what I can create." - on main this should generate a carousel and on the feature branch it should not.

