### PR TITLE
MWPW-181155 mWeb icon block fragment double margin

### DIFF
--- a/libs/blocks/icon-block/icon-block.css
+++ b/libs/blocks/icon-block/icon-block.css
@@ -389,13 +389,13 @@
     margin-bottom: var(--spacing-xs);
   }
 
-  .section:has(.icon-block.container-mobile + .action-scroller) {
+  .section:has(> .icon-block.container-mobile + .action-scroller) {
     width: var(--grid-container-width);
     margin: auto;
     border-radius: 16px;
   }
 
-  .section:has(.icon-block.container-mobile + .action-scroller) picture.section-background img {
+  .section:has(> .icon-block.container-mobile + .action-scroller) picture.section-background img {
     border-radius: 16px;
   }
 


### PR DESCRIPTION
Double borders were coming when icon block was used inside the fragment for mweb

* Add your
* Specific
* Features or fixes

Resolves: [MWPW-181155](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/klee/jira-ticket/mwpw-181155-iconblock-doublemargin
- After: https://mwpw-181155--milo--suhjainadobe.aem.page/drafts/klee/jira-ticket/mwpw-181155-iconblock-doublemargin


