### PR TITLE
MWPW-181093 Brand Concierge - Chat Tablet Padding

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -547,6 +547,7 @@
   height: calc(100% - var(--modal-header-height));
 }
 
+
 /* Tablet up */
 @media screen and (min-width: 768px) {
   .bc-prompt-cards {


### PR DESCRIPTION
* Fix issue in Brand Concierge chat where input extends to edges of window between 481px - 768px

Resolves: [MWPW-181093](https://jira.corp.adobe.com/browse/MWPW-181093)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off
- After: https://bc-margin--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off


