### PR TITLE
Mweb carousel editorial

### DIFF
--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -31,8 +31,9 @@
   border-color: var(--color-gray-300);
 }
 
-.editorial-card.no-bg { background: none;}
-.editorial-card.no-border { border: none;}
+.editorial-card.no-bg { background: none !important; }
+.editorial-card.no-bg .background { display: none; }
+.editorial-card.no-border { border: none; }
 
 .editorial-card.click {
   cursor: pointer;

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -90,17 +90,15 @@ function handleClickableCard(el) {
 }
 
 function handleOpenClasses(el, hasOpenClass) {
-  const openClasses = ['no-border', 'l-rounded-corners-image', 'static-links-copy'];
-  if (hasOpenClass) el.classList.add(...openClasses);
+  const baseOpenClasses = ['l-rounded-corners-image', 'static-links-copy'];
+  if (hasOpenClass) el.classList.add(...baseOpenClasses, 'no-border');
 
   if (!el.closest('.carousel.ups-desktop')) return;
-  openClasses.shift();
-  openClasses.push('no-bg');
 
   const isCarouselDesktop = window.matchMedia('(min-width: 900px)');
   const toggleOpenClasses = () => {
-    if (isCarouselDesktop.matches) el.classList.add(...openClasses);
-    else el.classList.remove(...openClasses);
+    if (isCarouselDesktop.matches) el.classList.add(...baseOpenClasses, 'no-bg');
+    else el.classList.remove(...baseOpenClasses, 'no-bg');
   };
 
   toggleOpenClasses();


### PR DESCRIPTION
This adapts the styling of Editorial Cards when nested inside a Carousel block using an `ups-desktop` variant, based on the latest requirements. Such Editorial Cards should not have a border on mobile devices, but should keep the authored background color; while on desktop devices, they should not use a background either.

**NOTE**: unfortunately `!important` is needed in this case, as the background color is set via JS.

Resolves: [MWPW-181170](https://jira.corp.adobe.com/browse/MWPW-181170)

**Test URLs:**
- Before: https://main--milo--overmyheadandbody.aem.page/drafts/ramuntea/mweb-editorial-carousel
- After: https://mweb-carousel-editorial--milo--overmyheadandbody.aem.page/drafts/ramuntea/mweb-editorial-carousel
- Before (no expected changes): https://main--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/editorial-card
- After (no expected changes): https://mweb-carousel-editorial--milo--overmyheadandbody.aem.page/docs/library/kitchen-sink/editorial-card


