### PR TITLE
[MWPW-181244] mWeb Ps Journey | Section Metdata - per breakpoint bg color

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.js
+++ b/libs/blocks/section-metadata/section-metadata.js
@@ -1,4 +1,3 @@
-import { debounce } from '../../utils/action.js';
 import { handleFocalpoint } from '../../utils/decorate.js';
 import { createTag, getFedsPlaceholderConfig } from '../../utils/utils.js';
 
@@ -20,8 +19,8 @@ const applyBackground = (colors, section) => {
     return;
   }
   if (colors.length === 2) {
-    const [mobileTabletColor, desktopColor] = colors;
-    section.style.background = mediaQueries.tablet.matches ? mobileTabletColor : desktopColor;
+    const [mobileColor, tabletDesktopColor] = colors;
+    section.style.background = mediaQueries.mobile.matches ? mobileColor : tabletDesktopColor;
     return;
   }
   if (colors.length >= 3) {
@@ -48,9 +47,8 @@ export function handleBackground(div, section) {
     if (color) {
       const colors = color.split('|').map((c) => c.trim());
       applyBackground(colors, section);
-      const debouncedApplyBackground = debounce(() => applyBackground(colors, section), 100);
       Object.keys(mediaQueries).forEach((key) => {
-        mediaQueries[key].addEventListener('change', debouncedApplyBackground);
+        mediaQueries[key].addEventListener('change', () => applyBackground(colors, section), 100);
       });
     }
   }


### PR DESCRIPTION
- Added `applyBackground` function to set background colors based on breakpoints.
- Problem with Using Comma as Color Separator:
   -  Comma-separated values worked only for hex/color names, not for rgb() or linear-gradient() due to internal commas.
- This update switches to using the pipe (|) as a separator for multiple colors.
- Authoring must update to use pipes in section-metadata for multi-color backgrounds.
- This is a generic update and is independent of the collapse-ups-mobile metatag.

Resolves: [MWPW-181244](https://jira.corp.adobe.com/browse/MWPW-181244)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-177520-section-metadata--milo--hkuraware.aem.page/?martech=off

**QA URL:**
https://mwpw-177520-section-metadata--milo--hkuraware.aem.page/drafts/himani/section-metadata-test











