### PR TITLE
[MWPW-177349] - editorial card media variants expanded

### DIFF
--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -248,30 +248,22 @@
 }
 
 /* Aspect Ratio */
-.editorial-card.media-square .media-area img,
-.editorial-card.media-square .media-area video,
-.editorial-card.media-square .media-area .milo-video {
+.editorial-card.media-square .media-area :is(img, video, .milo-video) {
   aspect-ratio: var(--aspect-ratio-square);
   max-height: unset;
 }
 
-.editorial-card.media-wide .media-area img,
-.editorial-card.media-wide .media-area video,
-.editorial-card.media-wide .media-area .milo-video {
+.editorial-card.media-wide .media-area :is(img, video, .milo-video) {
   aspect-ratio: var(--aspect-ratio-wide);
   max-height: unset;
 }
 
-.editorial-card.media-standard .media-area img,
-.editorial-card.media-standard .media-area video,
-.editorial-card.media-standard .media-area .milo-video {
+.editorial-card.media-standard .media-area :is(img, video, .milo-video) {
   aspect-ratio: var(--aspect-ratio-standard);
   max-height: unset;
 }
 
-.editorial-card.media-tall .media-area img,
-.editorial-card.media-tall .media-area video,
-.editorial-card.media-tall .media-area .milo-video {
+.editorial-card.media-tall .media-area :is(img, video, .milo-video) {
   aspect-ratio: var(--aspect-ratio-tall);
   max-height: unset;
 }


### PR DESCRIPTION
This PR enables the use of videos for the following editorial card variants in addition to media-tall:
- media-square
- media-wide
- media-standard

Resolves: [MWPW-177349](https://jira.corp.adobe.com/browse/MWPW-177349)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/rclayton/editorial-cards-media-variants
- After: https://editorial-card-media-variants--milo--adobecom.aem.page/drafts/rclayton/editorial-cards-media-variants

**Editorial Card Kitchen Sink Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/editorial-card
- After: https://editorial-card-media-variants--milo--adobecom.aem.page/docs/library/kitchen-sink/editorial-card

