### PR TITLE
MWPW-181302: Update mas version to 0.5.5

### DIFF
--- a/libs/features/mas/package-lock.json
+++ b/libs/features/mas/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@adobecom/mas",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@adobecom/mas",
-            "version": "0.5.4",
+            "version": "0.5.5",
             "devDependencies": {
                 "@dexter/tacocat-core": "file:./internal/tacocat-core-1.13.1.tgz",
                 "@esm-bundle/chai": "4.3.4-fix.0",

--- a/libs/features/mas/package.json
+++ b/libs/features/mas/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobecom/mas",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "type": "module",
     "main": "dist/mas.js",
     "private": true,


### PR DESCRIPTION
Version bump of mas release v0.5.5

Resolves: [MWPW-181302](https://jira.corp.adobe.com/browse/MWPW-181302)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-181302--milo--adobecom.aem.page/?martech=off


