### PR TITLE
MWPW-181332: Adds support for different presets within a repo

### DIFF
--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -337,8 +337,8 @@ const getPresetsData = async () => {
     presetsData = presets;
     presets.forEach((preset) => {
       const option = document.createElement('option');
-      option.value = preset.repo;
-      option.text = `${preset.name} (${preset.repo})`;
+      option.value = preset.id;
+      option.text = `${preset.name} (${preset.id})`;
       parent.insertBefore(option, separator);
     });
   });


### PR DESCRIPTION
This PR updates CaaS Bulk Publisher tool to support different presets within the same repo. 
For example bacom and bacom-blog use the same bacom repo but needs different preset for UseHTML

Resolves: [MWPW-181332](https://jira.corp.adobe.com/browse/MWPW-181332)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/cmiqueo/test-page?martech=off
- After: https://mwpw-181332--milo--adobecom.aem.page/drafts/cmiqueo/test-page?martech=off

