### PR TITLE
MWPW-181372 Brand Concierge - In-Chat Send Button Hover

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -328,6 +328,10 @@
   transform: none !important;
 }
 
+#brand-concierge-mount .submit-button:hover:not(:disabled) {
+  transform: none !important;
+}
+
 /* Sticky */
 @keyframes sticky-in {
   from {


### PR DESCRIPTION
* Prevent send button in Brand Concierge chat from moving on hover

Resolves: [MWPW-181372](https://jira.corp.adobe.com/browse/MWPW-181372)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off
- After: https://bc-send--milo--adobecom.aem.page/drafts/methomas/brand-concierge?martech=off

Note: The !important styles are a temporary necessity to meet our deadlines. They'll be cleaned up once the product team adds support for those styles in the config.

