### PR TITLE
MWPW-174852 [M@S] Enable default merch settings on MAS driven pages

### DIFF
--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -1,7 +1,7 @@
 import { createTag, getConfig } from '../../utils/utils.js';
 import '../../deps/mas/merch-card.js';
 import '../../deps/mas/merch-quantity-select.js';
-import { postProcessAutoblock } from '../merch/autoblock.js';
+import { postProcessAutoblock, enableMasDefaults } from '../merch/autoblock.js';
 import {
   initService,
   getOptions,
@@ -70,6 +70,7 @@ export async function createCard(el, options) {
 }
 
 export default async function init(el) {
+  enableMasDefaults();
   let options = getOptions(el);
   const { fragment } = options;
   if (!fragment) return;

--- a/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
+++ b/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
@@ -1,5 +1,5 @@
 import { createTag, getConfig } from '../../utils/utils.js';
-import { postProcessAutoblock, handleCustomAnalyticsEvent } from '../merch/autoblock.js';
+import { postProcessAutoblock, handleCustomAnalyticsEvent, enableMasDefaults } from '../merch/autoblock.js';
 import '../../deps/mas/merch-card.js';
 import '../../deps/mas/merch-quantity-select.js';
 import {
@@ -226,6 +226,7 @@ export async function createCollection(el, options) {
 }
 
 export default async function init(el) {
+  enableMasDefaults();
   let options = { ...DEFAULT_OPTIONS, ...getOptions(el) };
   if (!options.fragment) return;
   enableModalOpeningOnPageLoad();

--- a/libs/blocks/merch/autoblock.js
+++ b/libs/blocks/merch/autoblock.js
@@ -102,3 +102,9 @@ export async function postProcessAutoblock(autoblockEl, isCard = false) {
   });
   return Promise.allSettled(processPromises);
 }
+
+export function enableMasDefaults() {
+  if (!document.head.querySelector('meta[name="mas-ff-defaults"]')) {
+    document.head.append(createTag('meta', { name: 'mas-ff-defaults', content: 'on' }));
+  }
+}


### PR DESCRIPTION
Enable `mas-ff-defaults` on every MAS driven page. For now that's only US plans page.

Resolves: [MWPW-174852](https://jira.corp.adobe.com/browse/MWPW-174852)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://mwpw174852defaults--milo--bozojovicic.aem.live/?martech=off
