### PR TITLE
MWPW-180338 [Plans] Issues with deep-linked tabs and modals

### DIFF
--- a/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
+++ b/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
@@ -168,7 +168,7 @@ function enableSidenavAnalytics(el) {
 export const enableModalOpeningOnPageLoad = () => {
   window.addEventListener('mas:ready', ({ target }) => {
     target.querySelectorAll('[is="checkout-link"][data-modal-id]').forEach((cta) => {
-      updateModalState({ cta });
+      if (!cta.closest('.tabpanel[hidden]')) updateModalState({ cta });
     });
   });
 };


### PR DESCRIPTION
On plans page we can have multiple modals with the same modal ID but on different tabs. 
When we open that modal, go to commerce page and then go back, the modal from the active tab needs to be opened.

Resolves: [MWPW-180338](https://jira.corp.adobe.com/browse/MWPW-180338)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://mwpw180338modal--milo--bozojovicic.aem.live/?martech=off
