### PR TITLE
[MWPW-181099] Support to include 'play icon' on a video in a how-to block

### DIFF
--- a/libs/blocks/how-to/how-to.js
+++ b/libs/blocks/how-to/how-to.js
@@ -46,7 +46,11 @@ const setJsonLd = (heading, description, mainImage, stepsLd) => {
   document.getElementsByTagName('head')[0].appendChild(jsonLdScript);
 };
 
-const getImage = (el) => el.querySelector('.image-link') || el.querySelector('picture') || el.querySelector('a[href$=".svg"');
+const getImage = (el) => {
+  const modalImgLink = el.querySelector('.modal-img-link');
+  if (modalImgLink) return modalImgLink;
+  return el.querySelector('.image-link') || el.querySelector('picture') || el.querySelector('a[href$=".svg"');
+};
 const getVideo = (el) => el.querySelector('.video-container, .pause-play-wrapper, video, .milo-video');
 
 const getHowToInfo = (el) => {

--- a/libs/blocks/how-to/how-to.js
+++ b/libs/blocks/how-to/how-to.js
@@ -46,11 +46,7 @@ const setJsonLd = (heading, description, mainImage, stepsLd) => {
   document.getElementsByTagName('head')[0].appendChild(jsonLdScript);
 };
 
-const getImage = (el) => {
-  const modalImgLink = el.querySelector('.modal-img-link');
-  if (modalImgLink) return modalImgLink;
-  return el.querySelector('.image-link') || el.querySelector('picture') || el.querySelector('a[href$=".svg"');
-};
+const getImage = (el) => el.querySelector('.modal-img-link') || el.querySelector('.image-link') || el.querySelector('picture') || el.querySelector('a[href$=".svg"');
 const getVideo = (el) => el.querySelector('.video-container, .pause-play-wrapper, video, .milo-video');
 
 const getHowToInfo = (el) => {


### PR DESCRIPTION
* Support to include 'play icon' on a video in a how-to block. This is specifically for opening the video in a modal.

Resolves: [MWPW-181099](https://jira.corp.adobe.com/browse/MWPW-181099)

**Test URLs:**
Milo
- Before: https://stage--milo--adobecom.aem.page/drafts/ruchika/how-to?martech=off
- After: https://how-to--milo--adobecom.aem.page/drafts/ruchika/how-to?martech=off

DC
- Before: https://main--dc--adobecom.aem.page/drafts/jzummi/modal-test?milolibs=stage&martech=off
- After: https://main--dc--adobecom.aem.page/drafts/jzummi/modal-test?milolibs=how-to&martech=off
