### PR TITLE
[MEP][DOTCOM-167949]: added localization to federal links

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -97,7 +97,7 @@ export const normalizePath = (p, localize = true) => {
 
   if (isDamContent(path) || !path?.includes('/')) return path;
 
-  if (path.includes('/federal/')) return getFederatedUrl(path);
+  const isFederal = path.includes('/federal/');
 
   const config = getConfig();
   if (!path.startsWith(config.codeRoot) && !path.startsWith('http') && !path.startsWith('/')) {
@@ -125,8 +125,10 @@ export const normalizePath = (p, localize = true) => {
         path = `${config.locale.prefix}${pathname}`;
       }
     }
+    path = isFederal ? getFederatedUrl(path) : path;
     return `${path}${hash.replace(mepHash, '')}`;
   } catch (e) {
+    path = isFederal ? getFederatedUrl(path) : path;
     return path;
   }
 };


### PR DESCRIPTION
* Added localization to federal links

Resolves: [DOTCOM-167949](https://jira.corp.adobe.com/browse/DOTCOM-167949)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://federal-fix--milo--adobecom.aem.page/?martech=off


