### PR TITLE
[MEP] Update Cookie retrieval to use constant

### DIFF
--- a/libs/features/mep/addons/lob.js
+++ b/libs/features/mep/addons/lob.js
@@ -1,9 +1,8 @@
 import { getConfig } from '../../../utils/utils.js';
-import { getCookie } from '../../../martech/helpers.js';
+import { getCookie, AMCV_COOKIE } from '../../../martech/helpers.js';
 
 export async function getSpectraLOB(lastVisitedPage) {
-  const getECID = getCookie('AMCV_9E1005A551ED61CA0A490D45@AdobeOrg')
-    || getCookie('AMCV_9E1005A551ED61CA0A490D45%40AdobeOrg');
+  const getECID = getCookie(AMCV_COOKIE) || getCookie(encodeURIComponent(AMCV_COOKIE));
   if (!getECID) return false;
   const [, ECID] = getECID.split('|');
   const domainSuffix = getConfig()?.env?.name === 'prod' ? '' : '-stage';

--- a/libs/martech/helpers.js
+++ b/libs/martech/helpers.js
@@ -1,7 +1,7 @@
 import { getMepEnablement } from '../utils/utils.js';
 
 /* eslint-disable no-underscore-dangle */
-const AMCV_COOKIE = 'AMCV_9E1005A551ED61CA0A490D45@AdobeOrg';
+export const AMCV_COOKIE = 'AMCV_9E1005A551ED61CA0A490D45@AdobeOrg';
 const KNDCTR_COOKIE_KEYS = [
   'kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_identity',
   'kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_cluster',


### PR DESCRIPTION
* export cookie name from helpers
* import cookie name into lob
* use constant and encodeURI component

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mepcookiefix--milo--adobecom.aem.page/?martech=off


