### PR TITLE
MWPW-172104 [Kodiak][R2]: DOMXSS in [github.com/adobecom/cc-sandbox]

### DIFF
--- a/libs/utils/sanitizeHtml.js
+++ b/libs/utils/sanitizeHtml.js
@@ -1,0 +1,38 @@
+function stringToHTML(str) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(str, 'text/html');
+  return doc.body || document.createElement('body');
+}
+
+function removeScripts(html) {
+  const scripts = html.querySelectorAll('script');
+  scripts.forEach((script) => script.remove());
+}
+
+function isPossiblyDangerous(name, value) {
+  const val = value.replace(/\s+/g, '').toLowerCase();
+  if (['src', 'href', 'xlink:href'].includes(name)) {
+    // eslint-disable-next-line no-script-url
+    if (val.includes('javascript:') || val.includes('data:text/html')) return true;
+  }
+  if (name.startsWith('on')) return true;
+  return false;
+}
+
+function removeAttributes(elem) {
+  [...elem.attributes].forEach((attr) => {
+    const { name, value } = attr;
+    if (isPossiblyDangerous(name, value)) {
+      elem.removeAttribute(name);
+    }
+  });
+}
+
+function sanitizeHtml(html) {
+  const htmlEl = stringToHTML(html);
+  removeScripts(htmlEl);
+  [htmlEl, ...htmlEl.querySelectorAll('*')].forEach(removeAttributes);
+  return htmlEl.firstChild;
+}
+
+export default sanitizeHtml;

--- a/test/utils/mocks/xss.html
+++ b/test/utils/mocks/xss.html
@@ -1,0 +1,9 @@
+<div>
+  <script>alert('A')</script>
+  <div onClick="alert('B')">text</div>
+  <div>text <a href="javascript:alert('C')">link</a></div>
+  <div onClick="alert('D')">
+    <div onClick="alert('E')">nested text A</div>
+    <div onClick="alert('F')">nested text B <a href="javascript:alert('G')">nested link</a></div>
+  </div>
+</div>

--- a/test/utils/sanitizeHtml.test.js
+++ b/test/utils/sanitizeHtml.test.js
@@ -1,0 +1,14 @@
+import { expect } from '@esm-bundle/chai';
+import { readFile } from '@web/test-runner-commands';
+import sanitizeHtml from '../../libs/utils/sanitizeHtml.js';
+
+describe('sanitizeHtml Util', () => {
+  it('could sanitize HTML', async () => {
+    const htmlXss = await readFile({ path: './mocks/xss.html' });
+    expect(htmlXss.includes('alert')).to.be.true;
+    const html = sanitizeHtml(htmlXss);
+    expect(html.innerHTML.includes('alert')).to.be.false;
+    expect(html.innerHTML.includes('nested text')).to.be.true;
+    expect(html.innerHTML.includes('nested link')).to.be.true;
+  });
+});


### PR DESCRIPTION
There is a service in CC that returns HTML which needs to be injected into the page but first it needs to be sanitized (all potentially dangerous tags and attributes removed).

Resolves: [MWPW-172104](https://jira.corp.adobe.com/browse/MWPW-172104)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://mwpw172104sanitize--milo--adobecom.aem.live/?martech=off
