### PR TITLE
MAS: fix deeplink Nala test

### DIFF
--- a/nala/features/mas/acom/plans/plans.test.js
+++ b/nala/features/mas/acom/plans/plans.test.js
@@ -193,7 +193,7 @@ test.describe('MAS Plans Page test suite', () => {
         const targetUrl = addUrlQueryParams(PLANS_NALA_PATH.US, tabData.urlParam);
         await page.goto(targetUrl);
         await page.waitForLoadState('domcontentloaded');
-        const expectedUrl = addUrlQueryParams(PLANS_NALA_PATH.US, tabData.urlParam);
+        const expectedUrl = addUrlQueryParams(PLANS_NALA_PATH.US);
         await workerSetup.verifyPageURL('US', expectedUrl, expect);
 
         const tab = masPlans.getTabs(tabData.tabId);


### PR DESCRIPTION
fix failing deeplink test on stage. 

Test was failing all along on the PR introducing the change but somehow with the last commit it became green without updating Nala test


Resolves: nojira

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://nojira-1--milo--afmicka.aem.page/?martech=off


