### PR TITLE
MWPW-178108: Tab panel - accessibility sev2

### DIFF
--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -115,11 +115,13 @@ function changeTabs(e, config) {
     .querySelectorAll(`[${attributeName}="true"][data-block-id="${blockId}"]`)
     .forEach((t) => {
       t.setAttribute(attributeName, false);
+      t.setAttribute('tabindex', '-1');
       if (Object.keys(tabColor).length) {
         t.removeAttribute('style', 'backgroundColor');
       }
     });
   target.setAttribute(attributeName, true);
+  target.setAttribute('tabindex', '0');
   if (tabColor[targetId]) {
     target.style.backgroundColor = tabColor[targetId];
   }
@@ -195,7 +197,8 @@ function initTabs(elm, config, rootElem) {
           /* c8 ignore next */
           if (tabFocus < 0) tabFocus = tabs.length - 1;
         }
-        tabs[tabFocus].setAttribute('tabindex', 0);
+        tabs.forEach((t) => t.setAttribute('tabindex', '-1'));
+        tabs[tabFocus].setAttribute('tabindex', '0');
         tabs[tabFocus].focus();
       }
     });
@@ -365,7 +368,7 @@ const init = (block) => {
         role: isRadio ? 'radio' : 'tab',
         class: btnClass,
         id: `tab-${tabId}-${tabName}`,
-        tabindex: '0',
+        tabindex: (i === 0) ? '0' : '-1',
         [isRadio ? 'aria-checked' : 'aria-selected']: (i === 0) ? 'true' : 'false',
         'data-block-id': `tabs-${tabId}`,
         'daa-state': 'true',


### PR DESCRIPTION
Tab panel does not behave like other tab panels on Adobe.com. A user should tab to the first tab, and then use arrow keys to toggle through the remainder tabs. Users should not tab to other tabs once in the tab panel.

Resolves: [MWPW-178108](https://jira.corp.adobe.com/browse/MWPW-178108)

`https://main--cc--adobecom.aem.page/creativecloud/plans?milolibs=mwpw-178108`

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-178108--milo--adobecom.aem.page/?martech=off
