### PR TITLE
OPT-33714 APACDC0430 - New setting to allow delayed modals in mobile for test support

### DIFF
--- a/libs/mep/apacdc0430/modal/modal.css
+++ b/libs/mep/apacdc0430/modal/modal.css
@@ -1,0 +1,479 @@
+:root {
+  --modal-focus-color: #109cde;
+  --modal-max-height: calc((100vh - 6px) - 2em);
+  --modal-max-height-mobile: calc((100% - 6px) - 2em);
+  --modal-z-index: 102;
+  --modal-z-index-curtain: 101;
+  --modal-close-accent-color: #707070;
+  --jarvis-z-index-override: 100;
+  --tall-video-padding: var(--spacing-xl);
+}
+
+.branch-banner-is-active {
+  --modal-z-index: 100000;
+  --modal-z-index-curtain: 99999;
+}
+
+.dialog-modal {
+  background: #fff;
+  border-radius: 6px;
+  margin: auto;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  max-width: calc((100% - 6px) - 2em);
+  max-height: var(--modal-max-height);
+  height: fit-content;
+  width: 100%;
+  user-select: text;
+  visibility: visible;
+  overflow: auto;
+  z-index: var(--modal-z-index);
+}
+
+.dialog-modal.upgrade-flow-modal,
+.dialog-modal.three-in-one {
+  height: 100%;
+  width: 100%;
+  max-height: 100%;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.upgrade-flow-modal .dialog-close,
+.dialog-modal.hide-close-button .dialog-close {
+  display: none;
+}
+
+.upgrade-flow-modal .upgrade-flow-iframe,
+.three-in-one .milo-iframe {
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.three-in-one iframe {
+  width: 100%;
+}
+
+#locale-modal-v2 .dialog-close,
+#locale-modal-v2 .georouting-wrapper {
+  display: block;
+}
+
+.dialog-modal.commerce-frame {
+  z-index: 103;
+}
+
+.dialog-modal.delayed-modal {
+  width: 300px;
+  max-width: none;
+  border-radius: var(--l-rounded-corners);
+}
+
+@media (min-width: 430px) and (orientation: portrait) {
+  .dialog-modal.delayed-modal {
+    width: 370px;
+  }
+}
+
+@media (min-width: 430px) and (orientation: landscape) {
+  .dialog-modal.delayed-modal {
+    width: 600px;
+  }
+}
+
+@media (min-width: 576px) and (orientation: portrait) {
+  .dialog-modal.delayed-modal {
+    width: 516px;
+  }
+}
+
+@media (min-width: 768px) {
+  .dialog-modal.delayed-modal {
+    width: 600px;
+  }
+}
+
+@media (min-width: 829px) {
+  .dialog-modal.delayed-modal {
+    width: 800px;
+  }
+}
+
+@media (min-width: 1366px) {
+  .dialog-modal.delayed-modal {
+    width: 900px;
+  }
+}
+
+.modal-curtain.is-open {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgb(50 50 50 / 80%);
+  z-index: var(--modal-z-index-curtain);
+}
+
+.dialog-modal button.dialog-close {
+  border: 3px solid transparent;
+  position: absolute;
+  padding: 0;
+  cursor: pointer;
+  background: none;
+  border-radius: 50%;
+  height: 26px;
+  right: 5px;
+  top: 5px;
+  width: 26px;
+  z-index: 1;
+}
+
+.dialog-close circle {
+  fill: var(--modal-close-accent-color);
+}
+
+.dialog-close line {
+  stroke: var(--color-white);
+}
+
+.dialog-close:focus-visible {
+  outline: 2px solid var(--modal-focus-color);
+}
+
+.dialog-close:focus-visible circle {
+  fill: var(--color-white);
+}
+
+.dialog-close:focus-visible line {
+  stroke: var(--modal-close-accent-color);
+}
+
+.dialog-focus-placeholder {
+  height: 0;
+}
+
+.dialog-modal .section > .content {
+  max-width: initial;
+}
+
+.dialog-modal > .fragment > .section > .content > *:last-child {
+  margin-bottom: 0;
+}
+
+.dialog-modal > .fragment > .section > .content > *:first-child:not(h1, h2, h3, h4, h5, h6) {
+  margin-top: 0;
+}
+
+.dialog-modal > .fragment > .section > .content > h1,
+.dialog-modal > .fragment > .section > .content > h2,
+.dialog-modal > .fragment > .section > .content > h3,
+.dialog-modal > .fragment > .section > .content > h4,
+.dialog-modal > .fragment > .section > .content > h5,
+.dialog-modal > .fragment > .section > .content > h6 {
+  margin: 12px;
+}
+
+.locale-modal {
+  text-align: center;
+  padding: 48px 32px 30px;
+}
+
+.locale-modal .text-wrapper {
+  padding-top: 30px;
+}
+
+.locale-modal p {
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  margin-bottom: 1ex;
+}
+
+.locale-modal a {
+  font-size: .875rem;
+  display: block;
+  font-weight: 500;
+  padding: 8px;
+  cursor: pointer;
+}
+
+.locale-modal .world-icon {
+  width: 3.429rem;
+}
+
+.region-selector > div > p,
+.region-selector > div > ul li {
+  line-height: 1.7;
+}
+
+.region-selector > div > p {
+  font-size: 16px;
+  margin-bottom: 0;
+}
+
+.region-selector-text {
+  padding: 32px 32px 20px;
+  font-size: 16px;
+}
+
+.region-selector-text > div > p {
+  margin: 0 0 4px;
+}
+
+.region-selector-text > div > p:first-of-type {
+  font-size: 24px;
+}
+
+.dialog-modal > .fragment > .section.region-selector-text > .content > p:last-of-type {
+  margin-bottom: 0;
+}
+
+.region-selector > div > ul li > a:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.region-selector {
+  padding: 0 32px 32px;
+  font-size: 14px;
+}
+
+.region-selector ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+.region-selector .content {
+  column-count: 1;
+}
+
+.commerce-modal-open {
+  overflow: hidden;
+}
+
+.dialog-modal.tall-video {
+  line-height: 0;
+  width: fit-content;
+}
+
+.dialog-modal.tall-video .milo-video {
+  aspect-ratio: var(--aspect-ratio-tall);
+  height: auto;
+  max-height: calc(var(--modal-max-height) - 2 * var(--tall-video-padding));
+  padding-bottom: 0;
+  min-width: 90vw;
+}
+
+@media (min-width: 600px) {
+  .dialog-modal {
+    max-width: 80vw;
+    width: fit-content;
+  }
+
+  .dialog-modal.three-in-one {
+    width: 100%;
+  }
+
+  .dialog-modal .embed-vimeo {
+    min-width: 80vw;
+  }
+
+  .dialog-modal .milo-video {
+    padding-bottom: 0;
+    height: auto;
+    aspect-ratio: var(--aspect-ratio-wide);
+    max-height: var(--modal-max-height);
+  }
+
+  .dialog-modal.tall-video {
+    --modal-width-var: 50vw;
+
+    max-width: var(--modal-width-var);
+    padding: var(--tall-video-padding);
+  }
+
+  .dialog-modal.tall-video .milo-video {
+    min-width: var(--modal-width-var);
+  }
+
+  .region-selector .content {
+    column-count: 3;
+  }
+
+  .upgrade-flow-modal .upgrade-flow-iframe {
+    padding: 0 0 10px;
+  }
+}
+
+@media (min-width: 600px) and (orientation: landscape) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 19vw;
+  }
+}
+
+@media (min-width: 600px) and (min-height: 431px)  and (orientation: landscape) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 35vw;
+  }
+}
+
+@media (max-width: 1199px) {
+  .dialog-modal.commerce-frame {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  .dialog-modal.upgrade-flow-modal {
+    border-radius: 0;
+  }
+
+  .dialog-modal:not(.tall-video, .three-in-one, .commerce-frame, .upgrade-flow-modal) {
+    max-height: var(--modal-max-height-mobile);
+  }
+
+  .dialog-modal.commerce-frame > .fragment,
+  .dialog-modal.commerce-frame > .section,
+  .dialog-modal.commerce-frame > .fragment > .section {
+    height: 100vh;
+  }
+
+  .dialog-modal.xl-size,
+  .dialog-modal.xl-size > .fragment,
+  .dialog-modal.xl-size > .fragment > .section {
+    height: 100%;
+  }
+
+  .dialog-modal.xl-size .milo-iframe {
+    height: 100%;
+    padding-bottom: 0;
+  }
+}
+
+@media (min-width: 1200px) {
+  .dialog-modal.s-size {
+    max-width: 650px;
+  }
+
+  .region-selector .content {
+    column-count: 5;
+  }
+
+  .dialog-modal#langnav {
+    width: 1200px;
+    max-width: calc((100% - 6px) - 2em);
+  }
+
+  .dialog-modal.commerce-frame {
+    width: 1024px;
+    height: 850px;
+  }
+
+  .dialog-modal.commerce-frame > .fragment,
+  .dialog-modal.commerce-frame > .section,
+  .dialog-modal.commerce-frame > .fragment > .section {
+    height: 100%;
+  }
+
+  .dialog-modal.dynamic-height > .fragment,
+  .dialog-modal.dynamic-height > .section,
+  .dialog-modal.dynamic-height > .fragment > .section {
+    height: 100%;
+  }
+
+  .dialog-modal.commerce-frame .milo-iframe, .dialog-modal.dynamic-height .milo-iframe  {
+    padding-bottom: 0;
+    height: 100%;
+  }
+
+  .dialog-modal.commerce-frame.height-fit-content, .dialog-modal.dynamic-height.height-fit-content {
+    height: auto;
+    max-height: 850px;
+    min-width: 1000px;
+  }
+
+  .dialog-modal.commerce-frame.height-fit-content .milo-iframe, .dialog-modal.dynamic-height.height-fit-content .milo-iframe {
+    height: 100%;
+    max-height: 845px;
+  }
+
+  .dialog-modal.commerce-frame .milo-iframe iframe {
+    height: 0%;
+  }
+
+  .dialog-modal.upgrade-flow-modal {
+    height: 820px;
+    max-width: 1100px;
+    overflow: hidden;
+    width: 80%;
+  }
+
+  .dialog-modal.three-in-one {
+    height: 820px;
+    width: 80%;
+    max-width: 1100px;
+    overflow: hidden;
+  }
+
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 35vw;
+  }
+
+  .dialog-modal.manage-plan-cancel {
+    max-width: 100%;
+    width: 1280px;
+  }
+}
+
+@media (min-width: 1200px) and (orientation: landscape) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 25vw;
+  }
+}
+
+@media (min-width: 1400px) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 25vw;
+  }
+}
+
+@media (min-width: 1400px) and (orientation: landscape) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 20vw;
+  }
+}
+
+@media (min-width: 2000px) {
+  .dialog-modal.tall-video,
+  .dialog-modal.tall-video .milo-video {
+    --modal-width-var: 22vw;
+  }
+}
+
+@media (min-width: 1500px) {
+  .dialog-modal.dynamic-height .milo-iframe {
+    min-width: 1200px;
+  }
+}
+
+.disable-scroll {
+  overflow: hidden;
+}
+
+body:has(.dialog-modal) #adbMsgClientWrapper #adbmsgContainer > * {
+  z-index: var(--jarvis-z-index-override);
+}

--- a/libs/mep/apacdc0430/modal/modal.js
+++ b/libs/mep/apacdc0430/modal/modal.js
@@ -314,6 +314,8 @@ export function getHashParams(hashStr) {
       const [key, val] = part.split('=');
       if (key === 'delay') {
         params.delay = parseInt(val, 10) * 1000;
+      } else if (key === 'mobile') {
+        params.mobile = val === 'true';
       }
     }
     return params;
@@ -321,9 +323,9 @@ export function getHashParams(hashStr) {
 }
 
 export function delayedModal(el) {
-  const { hash, delay } = getHashParams(el?.dataset.modalHash);
-  // const isDesktop = window.matchMedia('(min-width: 1200px)').matches;
-  if (delay === undefined || !hash) return false;
+  const { hash, delay, mobile } = getHashParams(el?.dataset.modalHash);
+  const isDesktop = window.matchMedia('(min-width: 1200px)').matches;
+  if (delay === undefined || !hash || (!mobile && !isDesktop)) return false;
   delayedModalId = hash.replace('#', '');
   const modalOpenEvent = new Event(`${hash}:modalOpen`);
   const pagesModalWasShownOn = window.sessionStorage.getItem(`shown:${hash}`);

--- a/libs/mep/apacdc0430/modal/modal.js
+++ b/libs/mep/apacdc0430/modal/modal.js
@@ -1,0 +1,373 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable import/no-cycle */
+import { createTag, getMetadata, localizeLink, loadStyle, getConfig } from '../../../utils/utils.js';
+import { decorateSectionAnalytics } from '../../../martech/attributes.js';
+
+const LOCALE_MODAL_ID = 'locale-modal-v2';
+const FOCUSABLES = 'a:not(.hide-video, .faas), button:not([disabled], .locale-modal-v2 .paddle), input, textarea, select, details, [tabindex]:not([tabindex="-1"])';
+const CLOSE_ICON = `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <g transform="translate(-10500 3403)">
+    <circle cx="10" cy="10" r="10" transform="translate(10500 -3403)"/>
+    <line y1="8" x2="8" transform="translate(10506 -3397)" fill="none" stroke-width="2"/>
+    <line x1="8" y1="8" transform="translate(10506 -3397)" fill="none" stroke-width="2"/>
+  </g>
+</svg>`;
+
+let delayedModalId = null;
+let prevHash = '';
+let isDeepLink = false;
+const dialogLoadingSet = new Set();
+
+export function findDetails(hash, el) {
+  const id = hash.replace('#', '');
+  const a = el || document.querySelector(`a[data-modal-hash="${hash}"]`);
+  const path = a?.dataset.modalPath || localizeLink(getMetadata(`-${id}`));
+  const ariaLabel = a?.getAttribute('aria-label') || document.querySelector(`a[data-modal-id="${id}"]`)?.getAttribute('aria-label');
+  return {
+    id,
+    path,
+    isHash: hash === window.location.hash,
+    title: ariaLabel ? `Modal: ${ariaLabel}` : null,
+  };
+}
+
+function fireAnalyticsEvent(event) {
+  const data = {
+    xdm: {},
+    data: { web: { webInteraction: { name: event?.type } } },
+  };
+  if (event?.data) data.data._adobe_corpnew = { digitalData: event.data };
+  window._satellite?.track('event', data);
+}
+
+export function sendAnalytics(event) {
+  if (window._satellite?.track) {
+    fireAnalyticsEvent(event);
+  } else {
+    window.addEventListener('alloy_sendEvent', () => {
+      fireAnalyticsEvent(event);
+    }, { once: true });
+  }
+}
+
+function focusAfterModalClose(modal) {
+  const isGeoPopup = modal?.id === LOCALE_MODAL_ID;
+  const onetrustBanner = (isDeepLink || isGeoPopup) && document.querySelector('#onetrust-banner-sdk');
+  const geoPopupFocus = !isGeoPopup && document.querySelector(`.dialog-modal#${LOCALE_MODAL_ID} a.con-button`);
+  const toFocus = geoPopupFocus || onetrustBanner || null;
+  toFocus?.focus();
+  isDeepLink = false;
+
+  return toFocus;
+}
+
+export function closeModal(modal) {
+  const { id } = modal;
+  const closeEvent = new Event('milo:modal:closed');
+  window.dispatchEvent(closeEvent);
+
+  const iframe = modal.querySelector('iframe');
+  if (iframe?._iframeKeydownListener) {
+    try {
+      const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+      iframeDoc.removeEventListener('keydown', iframe._iframeKeydownListener);
+    } catch (e) {
+      // Cross-origin iframe, can't access content
+    }
+    delete iframe._iframeKeydownListener;
+  }
+
+  if (modal._documentKeydownListener) {
+    modal.removeEventListener('keydown', modal._documentKeydownListener);
+    delete modal._documentKeydownListener;
+  }
+
+  document.querySelectorAll(`#${id}`).forEach((mod) => {
+    if (mod.classList.contains('dialog-modal')) {
+      const modalCurtain = !mod.matches('.dialog-modal.curtain-off') && document.querySelector(`#${id}~.modal-curtain`);
+      if (modalCurtain) {
+        modalCurtain.remove();
+      }
+      mod.remove();
+    }
+    document.querySelector(`[data-modal-hash="#${mod.id}"]`)?.focus();
+  });
+
+  if (!document.querySelectorAll('.modal-curtain').length) {
+    document.body.classList.remove('disable-scroll');
+  }
+
+  [...document.querySelectorAll('header, main, footer')]
+    .forEach((element) => element.removeAttribute('aria-disabled'));
+
+  const hashId = window.location.hash.replace('#', '');
+  if (hashId === modal.id || modal.id === 'checkout-link-modal') {
+    window.history.pushState(window.history.state, document.title, `${window.location.pathname}${window.location.search}${prevHash ? `${prevHash}` : ''}`);
+  }
+  if (prevHash) prevHash = '';
+
+  if (focusAfterModalClose(modal)) return;
+
+  if (document.querySelector('.notification-curtain')) {
+    window.dispatchEvent(new Event('milo:modal:closed:notification'));
+    return;
+  }
+
+  document.querySelector(`a[data-modal-id="${id}"].con-button`)?.focus();
+}
+
+function isElementInView(element) {
+  const rect = element.getBoundingClientRect();
+  return (
+    rect.top >= 0
+    && rect.left >= 0
+    && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)
+    && rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+  );
+}
+
+function getCustomModal(custom, dialog) {
+  const { miloLibs, codeRoot } = getConfig();
+  loadStyle(`${miloLibs || codeRoot}/blocks/modal/modal.css`);
+  if (custom.id) dialog.id = custom.id;
+  if (custom.title) dialog.setAttribute('aria-label', custom.title);
+  if (custom.class) dialog.classList.add(custom.class);
+  if (custom.closeEvent) dialog.addEventListener(custom.closeEvent, () => closeModal(dialog));
+  dialog.append(custom.content);
+}
+
+async function getPathModal(path, dialog) {
+  let href = path;
+  if (path.includes('/federal/')) {
+    const { getFederatedUrl } = await import('../../../utils/utils.js');
+    href = getFederatedUrl(path);
+  }
+  const block = createTag('a', { href });
+  dialog.append(block);
+
+  // eslint-disable-next-line import/no-cycle
+  const { default: getFragment } = await import('../../../blocks/fragment/fragment.js');
+  await getFragment(block);
+}
+
+const isSameOrigin = (iframe) => new URL(iframe.src).origin === window.location.origin;
+
+function addIframeKeydownListener(iframe, dialog) {
+  try {
+    const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+    const iframeKeydownListener = (event) => (event.key === 'Escape') && closeModal(dialog);
+    iframeDoc.addEventListener('keydown', iframeKeydownListener);
+    iframe._iframeKeydownListener = iframeKeydownListener;
+  } catch (e) {
+    // Cross-origin iframe, can't access content
+  }
+}
+
+export async function getModal(details, custom) {
+  if (!((details?.path && details?.id) || custom)) return null;
+  const { id, deepLink } = details || custom;
+  if (id !== LOCALE_MODAL_ID) isDeepLink = deepLink;
+
+  dialogLoadingSet.add(id);
+  const dialog = createTag('div', { class: 'dialog-modal', id, role: 'dialog', 'aria-modal': true });
+  const loadedEvent = new Event('milo:modal:loaded');
+
+  if (custom && !custom?.title) custom.title = findDetails(window.location.hash, null)?.title;
+  if (custom) getCustomModal(custom, dialog);
+  if (details) await getPathModal(details.path, dialog);
+  if (delayedModalId === id) {
+    dialog.classList.add('delayed-modal');
+    const mediaBlock = dialog.querySelector('div.media');
+    if (mediaBlock) {
+      mediaBlock.classList.add('in-modal');
+      const { miloLibs, codeRoot } = getConfig();
+      const base = miloLibs || codeRoot;
+      loadStyle(`${base}/styles/rounded-corners.css`);
+    }
+    delayedModalId = null;
+  }
+
+  const localeModal = id?.includes('locale-modal') ? 'localeModal' : 'milo';
+  const analyticsEventName = window.location.hash ? window.location.hash.replace('#', '') : localeModal;
+  const close = createTag('button', {
+    class: 'dialog-close',
+    'aria-label': 'Close',
+    'daa-ll': `${analyticsEventName}:modalClose:buttonClose`,
+  }, CLOSE_ICON);
+  const focusPlaceholder = createTag('div', { class: 'dialog-focus-placeholder', tabindex: 0 });
+
+  const focusVisible = { focusVisible: true };
+  const focusablesOnLoad = [...dialog.querySelectorAll(FOCUSABLES)];
+  const titleOnLoad = dialog.querySelector('h1, h2, h3, h4, h5');
+  let firstFocusable;
+
+  if (focusablesOnLoad.length && isElementInView(focusablesOnLoad[0])) {
+    firstFocusable = focusablesOnLoad[0]; // eslint-disable-line prefer-destructuring
+  } else if (titleOnLoad) {
+    titleOnLoad.setAttribute('tabIndex', 0);
+    firstFocusable = titleOnLoad;
+  } else {
+    firstFocusable = close;
+  }
+
+  let shiftTabOnClose = false;
+
+  close.addEventListener('keydown', (event) => {
+    if (event.key !== 'Tab' || !event.shiftKey) return;
+    shiftTabOnClose = true;
+    focusPlaceholder.focus(focusVisible);
+  });
+
+  focusPlaceholder.addEventListener('focus', () => {
+    if (!shiftTabOnClose) close.focus(focusVisible);
+    shiftTabOnClose = false;
+  });
+
+  close.addEventListener('click', (e) => {
+    closeModal(dialog);
+    e.preventDefault();
+  });
+
+  const documentKeydownListener = (event) => (event.key === 'Escape') && closeModal(dialog);
+  dialog.addEventListener('keydown', documentKeydownListener);
+  dialog._documentKeydownListener = documentKeydownListener;
+
+  decorateSectionAnalytics(dialog, `${id}-modal`, getConfig());
+  dialog.prepend(close);
+  dialog.append(focusPlaceholder);
+  document.body.append(dialog);
+  dialogLoadingSet.delete(id);
+  firstFocusable?.focus({ preventScroll: true, ...focusVisible });
+  window.dispatchEvent(loadedEvent);
+
+  if (!dialog.classList.contains('curtain-off')) {
+    document.body.classList.add('disable-scroll');
+    const curtain = createTag('div', {
+      class: 'modal-curtain is-open',
+      'daa-ll': `${analyticsEventName}:modalClose:curtainClose`,
+    });
+    curtain.addEventListener('click', (e) => {
+      if (e.target === curtain) closeModal(dialog);
+    });
+    dialog.insertAdjacentElement('afterend', curtain);
+    [...document.querySelectorAll('header, main, footer')]
+      .forEach((element) => element.setAttribute('aria-disabled', 'true'));
+  }
+
+  const iframe = dialog.querySelector('iframe');
+  if (iframe) {
+    const title = custom?.title || details?.title;
+    if (title) {
+      iframe.setAttribute('title', title);
+      dialog.setAttribute('aria-label', title);
+    }
+
+    if (iframe.title) {
+      dialog.setAttribute('aria-label', iframe.title);
+    } else {
+      iframe.onload = () => {
+        try {
+          if (!isSameOrigin(iframe) && iframe.title) {
+            dialog.setAttribute('aria-label', iframe.title);
+            return;
+          }
+
+          const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+          const iframeHeading = iframeDoc.querySelector('h1, h2, h3, h4, h5, h6')?.textContent.trim();
+          if (iframeHeading) dialog.setAttribute('aria-label', iframeHeading);
+          if (!iframe.title && iframeHeading) iframe.title = iframeHeading;
+        } catch (e) {
+          // Cross-origin iframe, can't access content
+        }
+      };
+    }
+
+    iframe.addEventListener('load', () => {
+      if (!isSameOrigin(iframe)) return;
+      addIframeKeydownListener(iframe, dialog);
+    });
+
+    if (dialog.classList.contains('commerce-frame') || dialog.classList.contains('dynamic-height')) {
+      const { default: enableCommerceFrameFeatures } = await import('./modal.merch.js');
+      await enableCommerceFrameFeatures({ dialog, iframe });
+    } else {
+      /* Initially iframe height is set to 0% in CSS for the height auto adjustment feature.
+      The height auto adjustment feature is applicable only to dialogs
+      with the `commerce-frame` or `dynamic-height` classes */
+      iframe.style.height = '100%';
+    }
+    if (!custom?.closeEvent) dialog.addEventListener('iframe:modal:closed', () => closeModal(dialog));
+  } else {
+    const firstHeading = dialog.querySelector('h1, h2, h3, h4, h5, h6');
+    if (firstHeading) dialog.setAttribute('aria-label', firstHeading.textContent.trim());
+  }
+
+  return dialog;
+}
+
+export function getHashParams(hashStr) {
+  if (!hashStr) return {};
+  return hashStr.split(':').reduce((params, part) => {
+    if (part.startsWith('#')) {
+      params.hash = part;
+    } else {
+      const [key, val] = part.split('=');
+      if (key === 'delay') {
+        params.delay = parseInt(val, 10) * 1000;
+      }
+    }
+    return params;
+  }, {});
+}
+
+export function delayedModal(el) {
+  const { hash, delay } = getHashParams(el?.dataset.modalHash);
+  // const isDesktop = window.matchMedia('(min-width: 1200px)').matches;
+  if (delay === undefined || !hash) return false;
+  delayedModalId = hash.replace('#', '');
+  const modalOpenEvent = new Event(`${hash}:modalOpen`);
+  const pagesModalWasShownOn = window.sessionStorage.getItem(`shown:${hash}`);
+  el.dataset.modalHash = hash;
+  el.href = hash;
+  if (!pagesModalWasShownOn?.includes(window.location.pathname)) {
+    setTimeout(() => {
+      window.location.replace(hash);
+      sendAnalytics(modalOpenEvent);
+      window.sessionStorage.setItem(`shown:${hash}`, `${pagesModalWasShownOn || ''} ${window.location.pathname}`);
+    }, delay);
+  }
+  return true;
+}
+
+// Deep link-based
+export default function init(el) {
+  const { modalHash, modalPath } = el.dataset;
+  if (getConfig().mep?.fragments?.[modalPath]?.action === 'remove') return null;
+  if (delayedModal(el) || window.location.hash !== modalHash || document.querySelector(`div.dialog-modal${modalHash}`)) return null;
+  if (dialogLoadingSet.has(modalHash?.replace('#', ''))) return null; // prevent duplicate modal loading
+  const details = findDetails(window.location.hash, el);
+  details.deepLink = true;
+  return details ? getModal(details) : null;
+}
+
+// Click-based modal
+window.addEventListener('hashchange', (e) => {
+  if (!window.location.hash) {
+    try {
+      const url = new URL(e.oldURL);
+      const dialog = document.querySelector(`.dialog-modal${url.hash}`);
+      if (dialog) closeModal(dialog);
+    } catch (error) {
+      /* do nothing */
+    }
+  } else {
+    const details = findDetails(window.location.hash, null);
+    if (details) getModal(details);
+    if (e.oldURL?.includes('#')) {
+      const { hash } = new URL(e.oldURL);
+      if (hash.includes('=') || !document.querySelector(`${hash}:not(.dialog-modal)`)) {
+        prevHash = hash;
+      }
+    }
+  }
+});

--- a/libs/mep/apacdc0430/modal/modal.js
+++ b/libs/mep/apacdc0430/modal/modal.js
@@ -315,7 +315,7 @@ export function getHashParams(hashStr) {
       if (key === 'delay') {
         params.delay = parseInt(val, 10) * 1000;
       } else if (key === 'mobile') {
-        params.mobile = val === 'true';
+        params.mobile = val === 'allowed';
       }
     }
     return params;

--- a/libs/mep/apacdc0430/modal/modal.merch.js
+++ b/libs/mep/apacdc0430/modal/modal.merch.js
@@ -1,0 +1,88 @@
+import { debounce } from '../../../utils/action.js';
+
+export const MOBILE_MAX = 599;
+export const TABLET_MAX = 1199;
+
+window.addEventListener('pageshow', (event) => {
+  // if there is a commerce modal with an iframe open, reload the page to avoid bfcache issues.
+  if (event.persisted && document.querySelector('.dialog-modal.commerce-frame iframe')) {
+    window.location.reload();
+  }
+});
+
+export function adjustModalHeight(contentHeight) {
+  if (!(window.location.hash || document.getElementById('checkout-link-modal'))) return;
+  let selector = '#checkout-link-modal';
+  if (!/=/.test(window.location.hash)) selector = `${selector},div.dialog-modal.commerce-frame${window.location.hash},div.dialog-modal.dynamic-height${window.location.hash}`;
+  const dialog = document.querySelector(selector);
+  const iframe = dialog?.querySelector('iframe');
+  const iframeWrapper = dialog?.querySelector('.milo-iframe');
+  if (!contentHeight || !iframe || !iframeWrapper) return;
+  if (contentHeight === '100%') {
+    iframe.style.height = '100%';
+    iframeWrapper.style.removeProperty('height');
+    dialog.style.removeProperty('height');
+  } else {
+    const verticalMargins = 20;
+    const clientHeight = document.documentElement.clientHeight - verticalMargins;
+    if (clientHeight <= 0) return;
+    const newHeight = contentHeight > clientHeight ? clientHeight : contentHeight;
+    iframe.style.height = '100%';
+    iframeWrapper.style.height = `${newHeight}px`;
+    dialog.style.height = `${newHeight}px`;
+  }
+}
+
+export function sendViewportDimensionsToIframe(source) {
+  const viewportWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
+  source.postMessage({ mobileMax: MOBILE_MAX, tabletMax: TABLET_MAX, viewportWidth }, '*');
+}
+
+export function sendViewportDimensionsOnRequest(source) {
+  sendViewportDimensionsToIframe(source);
+  window.addEventListener('resize', debounce(() => sendViewportDimensionsToIframe(source), 10));
+}
+
+function reactToMessage({ data, source }) {
+  if (data === 'viewportWidth' && source) {
+    /* If the page inside iframe comes from another domain, it won't be able to retrieve
+    the viewport dimensions, so it sends a request to receive the viewport dimensions
+    from the parent window. */
+    sendViewportDimensionsOnRequest(source);
+  }
+
+  if (data?.contentHeight) {
+    /* If the page inside iframe sends the postMessage with its content height,
+    we activate the height auto adjustment to eliminate the blank space at the bottom of the modal.
+    For this we set the iframe height to 0% in CSS to let the page inside iframe
+    to measure its content height properly.
+    Then we set the modal height to be the same as the content height we received.
+    For the modal height adjustment to work the following conditions must be met:
+    1. The modal must have the class 'commerce-frame';
+    2. The page inside iframe must send a postMessage with the contentHeight (in px, or '100%); */
+    adjustModalHeight(data?.contentHeight);
+  }
+}
+
+export function adjustStyles({ dialog, iframe }) {
+  // matches e.g. https://www.adobe.com/mini-plans/photoshop.html?mid=ft&web=1 or https://www.adobe.com/creativecloud/whats-included/plans/*
+  const isAutoHeightAdjustment = /\/mini-plans\/.*mid=ft.*web=1/.test(iframe.src) || /\/creativecloud\/whats-included\/plans\//.test(iframe.src);
+  if (isAutoHeightAdjustment) {
+    dialog.classList.add('height-fit-content');
+    // fail safe.
+    setTimeout(() => {
+      const { height } = window.getComputedStyle(iframe);
+      if (height === '0px') {
+        iframe.style.height = '100%';
+      }
+    }, 2000);
+  } else {
+    iframe.style.height = '100%';
+  }
+}
+
+export default async function enableCommerceFrameFeatures({ dialog, iframe }) {
+  if (!dialog || !iframe) return;
+  adjustStyles({ dialog, iframe });
+  window.addEventListener('message', reactToMessage);
+}


### PR DESCRIPTION
* Copy of modal block in mep folder
* No CSS changes
* update to getHashParams to look for mobile=allowed
* update to delayedModal to check if mobile is allowed

Resolves: [OPT-33714](https://jira.corp.adobe.com/browse/OPT-33714)

QA instructions:
1. Spoof mobile first
2. Open the before link.  No modal will appear
3. Go to the after link. Modal willl appear

If you have already seen this modal, clear your session storage.  Modal will only appear once.

**Test URLs:**
- Before: https://main--dc--adobecom.aem.page/in/acrobat/campaign/acrobats-got-it?mep=%2Fin%2Fdc-shared%2Ffragments%2Ftest%2F2025%2Fq3%2Fapacdc0430%2Fapacdc0430.json--viv+test
- After: https://main--dc--adobecom.aem.page/in/acrobat/campaign/acrobats-got-it?mep=%2Fin%2Fdc-shared%2Ffragments%2Ftest%2F2025%2Fq3%2Fapacdc0430%2Fapacdc0430.json--viv+test&milolibs=apacdc0430
- Psi-check: https://apacdc0430--milo--adobecom.aem.page/?martech=off

