### PR TITLE
MWPW-181748 [MEP] Create 4th level of marketing actions to handle bundle tests

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1102,7 +1102,7 @@ export function getManifestConsent(manifestConfig) {
   // If consent not given for advertising or performance, override to first experience
   if (!advertising || !performance) {
     const config = getConfig();
-    config.mep.variantOverride ??= {};
+    if (!config.mep.variantOverride) config.mep.variantOverride = {};
     if (!config.mep.variantOverride?.[manifestPath]) {
       [config.mep.variantOverride[manifestPath]] = variantNames;
     }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -983,8 +983,6 @@ async function getPersonalizationVariant(
   }
 
   const variantInfo = buildVariantInfo(variantNames);
-  // inside getPersonalizationVariant around line 985 after the override but before rest of logic, 
-  // override to first variant if marketing action is marketing decrease but have not consented to 2 or 4
   const entitlementKeys = Object.values(await getEntitlementMap());
   const hasEntitlementTag = entitlementKeys.some((tag) => variantInfo.allNames.includes(tag));
 
@@ -1081,7 +1079,7 @@ const getGeoRestriction = (geoRestriction) => {
   const akamaiCode = urlParams.get('akamaiLocale')?.toLowerCase() || sessionStorage.getItem('akamai');
   const geoArray = geoRestriction?.split(',').map((item) => item.trim().toLowerCase());
   return geoArray.includes(akamaiCode);
-}
+};
 
 export function getManifestMarketingAction(mktgAction, source) {
   const allowedServices = ['core services', 'non-marketing', 'marketing decrease', 'marketing increase'];
@@ -1099,7 +1097,6 @@ export function getManifestConsent(manifestConfig) {
   if (mktgAction === 'non-marketing') return performance;
   if (mktgAction === 'marketing increase') return advertising;
 
-  // If consent not given for advertising or performance, override to first experience
   if (!advertising || !performance) {
     const config = getConfig();
     if (!config.mep.variantOverride) config.mep.variantOverride = {};

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1090,7 +1090,8 @@ export function getManifestMarketingAction(mktgAction, source) {
   return 'marketing increase';
 }
 
-export function getManifestConsent(mktgAction, manifestPath, variantNames) {
+export function getManifestConsent(manifestConfig) {
+  const { mktgAction, variantNames, manifestPath } = manifestConfig;
   if (mktgAction === 'core services') return true;
 
   const { performance, advertising } = getMepConsentConfig();
@@ -1179,15 +1180,14 @@ async function getManifestConfig(info, variantOverride) {
 
   let finalDisabled = disabled;
   manifestConfig.mktgAction = getManifestMarketingAction(manifestConfig.mktgAction, source);
+  manifestConfig.manifestPath = normalizePath(manifestPath);
   const isGeoAllowed = getGeoRestriction(manifestConfig.geoRestriction);
-  const { mktgAction, variantNames } = manifestConfig;
-  const isConsentAllowed = getManifestConsent(mktgAction, manifestPath, variantNames);
+  const isConsentAllowed = getManifestConsent(manifestConfig);
   if (!isGeoAllowed || !isConsentAllowed) {
     if (!getConfig().mep?.preview) return null;
     finalDisabled = true;
   }
 
-  manifestConfig.manifestPath = normalizePath(manifestPath);
   manifestConfig.selectedVariantName = await getPersonalizationVariant(
     manifestConfig.manifestPath,
     manifestConfig.variantNames,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1439,7 +1439,7 @@ async function checkForPageMods() {
   const target = martech === 'off' ? false : getMepEnablement('target');
   const xlg = martech === 'off' ? false : getMepEnablement('xlg');
   const ajo = martech === 'off' ? false : getMepEnablement('ajo');
-  const mepgeolocation = getMepEnablement('mepgeolocation'); 
+  const mepgeolocation = getMepEnablement('mepgeolocation');
   const mepMarketingDecrease = getMepEnablement('mep-marketing-decrease');
 
   if (!(pzn || pznroc || target || promo || mepParam

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1439,12 +1439,11 @@ async function checkForPageMods() {
   const target = martech === 'off' ? false : getMepEnablement('target');
   const xlg = martech === 'off' ? false : getMepEnablement('xlg');
   const ajo = martech === 'off' ? false : getMepEnablement('ajo');
-  const mepgeolocation = getMepEnablement('mepgeolocation'); // Make these uniform?
-  const mepMarketingDecrease = getMepEnablement('mep-marketing-decrease'); // Make these uniform?
-  const mepGeoRestriction = getMepEnablement('mep-geo-restriction'); // Make these uniform?
+  const mepgeolocation = getMepEnablement('mepgeolocation'); 
+  const mepMarketingDecrease = getMepEnablement('mep-marketing-decrease');
 
   if (!(pzn || pznroc || target || promo || mepParam
-    || mepHighlight || mepButton || mepParam === '' || xlg || ajo)) return;
+    || mepHighlight || mepButton || mepParam === '' || xlg || ajo || mepMarketingDecrease)) return;
 
   loadLink(`${getConfig().base}/martech/helpers.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1439,7 +1439,9 @@ async function checkForPageMods() {
   const target = martech === 'off' ? false : getMepEnablement('target');
   const xlg = martech === 'off' ? false : getMepEnablement('xlg');
   const ajo = martech === 'off' ? false : getMepEnablement('ajo');
-  const mepgeolocation = getMepEnablement('mepgeolocation');
+  const mepgeolocation = getMepEnablement('mepgeolocation'); // Make these uniform?
+  const mepMarketingDecrease = getMepEnablement('mep-marketing-decrease'); // Make these uniform?
+  const mepGeoRestriction = getMepEnablement('mep-geo-restriction'); // Make these uniform?
 
   if (!(pzn || pznroc || target || promo || mepParam
     || mepHighlight || mepButton || mepParam === '' || xlg || ajo)) return;
@@ -1502,6 +1504,7 @@ async function checkForPageMods() {
     calculatedTimeout,
     enablePersV2,
     promises,
+    mepMarketingDecrease,
   });
 }
 


### PR DESCRIPTION
We need to handle manifests that test a pricing advantage (bundle/discount) differently by serving the discount to users who have opted out.
* Add a new metadata source for manifests
* Add a new marketing action
* Add ability to filter manifests by geo
* Serve challenger to those have opted out and have the new marketing action

Resolves: [MWPW-181748](https://jira.corp.adobe.com/browse/MWPW-181748)

QA instructions, check below conditions to see if mwpw-181748.json is served and which experience is served.
To change your cookie settings, scroll to the bottom of the footer and click edit cookies.  Be sure to confirm choices after updating checkboxes.

Start with all cookies accepted.

1. Manifest should not appear because you are outside of US: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q4/mwpw-181748/page?milolibs=mwpw-181748&MWPW-181748&at_preview_token=S2EcX_6aX9f7WxcPceu2YQ&at_preview_index=1_2&at_preview_listed_activities_only=true&akamaiLocale=fr

2. Manifest should appear and you should be in the challenger because that is what Target served: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q4/mwpw-181748/page?milolibs=mwpw-181748&MWPW-181748&at_preview_token=S2EcX_6aX9f7WxcPceu2YQ&at_preview_index=1_2&at_preview_listed_activities_only=true&akamaiLocale=us

3. Manifest should appear but you should be in the control because that is what Target served: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q4/mwpw-181748/page?milolibs=mwpw-181748&MWPW-181748&at_preview_token=S2EcX_6aX9f7WxcPceu2YQ&at_preview_index=1_1&at_preview_listed_activities_only=true&akamaiLocale=us

Go into cookie settings and opt out of last option, advertising.
4. Manifest should appear but you should be in the challenger: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q4/mwpw-181748/page?milolibs=mwpw-181748&MWPW-181748&at_preview_token=S2EcX_6aX9f7WxcPceu2YQ&at_preview_index=1_1&at_preview_listed_activities_only=true&akamaiLocale=us

Go into cookie settings and opt out of first changeable checkbox.
5. Manifest should appear but you should be in the challenger: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q4/mwpw-181748/page?milolibs=mwpw-181748&MWPW-181748&at_preview_token=S2EcX_6aX9f7WxcPceu2YQ&at_preview_index=1_1&at_preview_listed_activities_only=true&akamaiLocale=us

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q4/mwpw-181748/page?MWPW-181748&at_preview_token=S2EcX_6aX9f7WxcPceu2YQ&at_preview_index=1_2&at_preview_listed_activities_only=true
- After: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2025/q4/mwpw-181748/page?milolibs=mwpw-181748&MWPW-181748&at_preview_token=S2EcX_6aX9f7WxcPceu2YQ&at_preview_index=1_2&at_preview_listed_activities_only=true
- Psi-check: https://mwpw-181748--milo--adobecom.aem.page/?martech=off
