### PR TITLE
[MEP] - fix broken nala test: all-elements.test.js

### DIFF
--- a/nala/features/personalization/_README.txt
+++ b/nala/features/personalization/_README.txt
@@ -1,0 +1,20 @@
+How to run a single nala test for debugging (filename will end in "test.js"):
+
+  npm run nala stage mep-button.test.js mode=debug
+
+You can replace "stage" with your local branch for local testing.
+
+  npm run nala my-local-branch mep-button.test.js mode=debug
+
+You may also want to run this for help information: 
+
+  npm run nala help
+
+Note: you may need to sync your local branch with stage to get the latest nala tests in order for them to pass.
+
+To run all of our nala tests:
+  npm run nala stage tag=mep
+
+Another option -- watch the test in a browser:
+mode=headed
+

--- a/nala/features/personalization/all-elements.test.js
+++ b/nala/features/personalization/all-elements.test.js
@@ -18,8 +18,8 @@ test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {
   defaultUrl = `${baseURL}${features[0].data.defaultURL}${miloLibs}`;
   const linkToAdobe = page.locator('a[href="https://www.adobe.com/"]');
   const linkToAcrobat = page.locator('a[href="https://acrobat.adobe.com/"]');
-  const insertionBeforeRegularFragment = page.locator("[data-manifest-id='all-elements.json'] + div:has([data-path*='repeated-fragment'])");
-  const insertionAfterRegularFragment = page.locator("div div:has([data-path*='repeat-fragment']) + [data-manifest-id='all-elements.json']");
+  const insertionBeforeRegularFragment = page.locator("[data-manifest-id*='all-elements.json'] + div:has([data-path*='repeated-fragment'])");
+  const insertionAfterRegularFragment = page.locator("div div:has([data-path*='repeat-fragment']) + [data-manifest-id*='all-elements.json']");
 
   await test.step('step-1: Verify default test page', async () => {
     console.info(`[Test Page]: ${defaultUrl}`);


### PR DESCRIPTION
This fixes a broken nala test, all-elements.test.js, which I broke by publishing a change on a page.

Resolves: [MWPW-189706](https://jira.corp.adobe.com/browse/MWPW-189706)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://nala_update--milo--adobecom.aem.page/?martech=off

To see the test in a broken state, you can run this terminal command on the stage branch:
npm run nala stage @all-elements0  

To test it with my branch:

git switch nala_update (to pull down and test this branch)
npm run nala stage @all-elements0  (same command)


