### PR TITLE
Adding new mappings for events on DA

### DIFF
--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -15,6 +15,7 @@ import {
 } from '../../utils/utils.js';
 
 const ROOT_MARGIN = 1000;
+const D_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS1kZXYuYWRvYmVpb3J1bnRpbWUubmV0L2FwaS92MS93ZWIvY2hpbWVyYS0wLjAuMS9jb2xsZWN0aW9u');
 const P_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
 const S_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS1zdGFnZS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
 
@@ -65,15 +66,25 @@ const loadCaas = async (a) => {
   const caasEndpoint = queryParams.get('caasendpoint');
   const caasContainer = queryParams.get('caascontainer');
 
-  if (host.includes('stage.adobe') || env?.name === 'local' || caasEndpoint === 'stage') {
+  if (host.includes('dev.adobe') || host.startsWith('dev--') || caasEndpoint === 'dev') {
+    chimeraEndpoint = D_CAAS_AIO;
+  } else if (host.includes('stage.adobe') || env?.name === 'local' || caasEndpoint === 'stage') {
     chimeraEndpoint = S_CAAS_AIO;
   } else if (host.includes(`.${SLD}.`) || caasEndpoint === 'prod') {
-    // If invoking URL is not an Acom URL, then switch to AIO
     chimeraEndpoint = P_CAAS_AIO;
   }
 
   if (host.includes(`${SLD}.page`) || env?.name === 'local' || caasContainer === 'draft') {
     state.draftDb = true;
+  }
+
+  const pathname = window.location.pathname;
+  const isEventsPage = pathname.endsWith('/events.html');
+  if (isEventsPage && host.includes('stage.adobe')) {
+    state.draftDb = true;
+  }
+  if (isEventsPage && chimeraEndpoint === P_CAAS_AIO && state.draftDb) {
+    chimeraEndpoint = S_CAAS_AIO;
   }
 
   state.endpoint = chimeraEndpoint;

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -60,7 +60,7 @@ const loadCaas = async (a) => {
   }
 
   const { env } = getConfig();
-  const { host, search } = window.location;
+  const { host, pathname, search } = window.location;
   let chimeraEndpoint = 'www.adobe.com/chimera-api/collection';
   const queryParams = new URLSearchParams(search);
   const caasEndpoint = queryParams.get('caasendpoint');
@@ -78,7 +78,6 @@ const loadCaas = async (a) => {
     state.draftDb = true;
   }
 
-  const pathname = window.location.pathname;
   const isEventsPage = pathname.endsWith('/events.html');
   if (isEventsPage && host.includes('stage.adobe')) {
     state.draftDb = true;

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -19,6 +19,43 @@ const D_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS1kZXYuYWRvYmVpb3J1bnRpbWUubmV0L2
 const P_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
 const S_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS1zdGFnZS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
 
+const DEFAULT_CHIMERA = 'www.adobe.com/chimera-api/collection';
+
+/**
+ * Returns chimera endpoint and draftDb for given location (used by loadCaas; exported for tests).
+ * @param {string} host - window.location.host
+ * @param {string} pathname - window.location.pathname
+ * @param {string} search - window.location.search
+ * @param {string} [envName] - getConfig()?.env?.name (e.g. 'local')
+ * @returns {{ endpoint: string, draftDb: boolean }}
+ */
+export function getChimeraConfig(host, pathname, search, envName) {
+  let chimeraEndpoint = DEFAULT_CHIMERA;
+  const queryParams = new URLSearchParams(search || '');
+  const caasEndpoint = queryParams.get('caasendpoint');
+  const caasContainer = queryParams.get('caascontainer');
+
+  if (host.includes('dev.adobe') || host.startsWith('dev--') || caasEndpoint === 'dev') {
+    chimeraEndpoint = D_CAAS_AIO;
+  } else if (host.includes('stage.adobe') || envName === 'local' || caasEndpoint === 'stage') {
+    chimeraEndpoint = S_CAAS_AIO;
+  } else if (host.includes(`.${SLD}.`) || caasEndpoint === 'prod') {
+    chimeraEndpoint = P_CAAS_AIO;
+  }
+
+  let draftDb = host.includes(`${SLD}.page`) || envName === 'local' || caasContainer === 'draft';
+
+  const isEventsPage = pathname && pathname.endsWith('/events.html');
+  if (isEventsPage && host.includes('stage.adobe')) {
+    draftDb = true;
+  }
+  if (isEventsPage && chimeraEndpoint === P_CAAS_AIO && draftDb) {
+    chimeraEndpoint = S_CAAS_AIO;
+  }
+
+  return { endpoint: chimeraEndpoint, draftDb };
+}
+
 const getCaasStrings = (placeholderUrl) => new Promise((resolve) => {
   if (placeholderUrl) {
     resolve(loadStrings(placeholderUrl));
@@ -61,32 +98,9 @@ const loadCaas = async (a) => {
 
   const { env } = getConfig();
   const { host, pathname, search } = window.location;
-  let chimeraEndpoint = 'www.adobe.com/chimera-api/collection';
-  const queryParams = new URLSearchParams(search);
-  const caasEndpoint = queryParams.get('caasendpoint');
-  const caasContainer = queryParams.get('caascontainer');
-
-  if (host.includes('dev.adobe') || host.startsWith('dev--') || caasEndpoint === 'dev') {
-    chimeraEndpoint = D_CAAS_AIO;
-  } else if (host.includes('stage.adobe') || env?.name === 'local' || caasEndpoint === 'stage') {
-    chimeraEndpoint = S_CAAS_AIO;
-  } else if (host.includes(`.${SLD}.`) || caasEndpoint === 'prod') {
-    chimeraEndpoint = P_CAAS_AIO;
-  }
-
-  if (host.includes(`${SLD}.page`) || env?.name === 'local' || caasContainer === 'draft') {
-    state.draftDb = true;
-  }
-
-  const isEventsPage = pathname.endsWith('/events.html');
-  if (isEventsPage && host.includes('stage.adobe')) {
-    state.draftDb = true;
-  }
-  if (isEventsPage && chimeraEndpoint === P_CAAS_AIO && state.draftDb) {
-    chimeraEndpoint = S_CAAS_AIO;
-  }
-
-  state.endpoint = chimeraEndpoint;
+  const { endpoint, draftDb } = getChimeraConfig(host, pathname, search, env?.name);
+  state.endpoint = endpoint;
+  state.draftDb = draftDb;
 
   initCaas(state, caasStrs, block);
 };

--- a/test/blocks/caas/caas.test.html
+++ b/test/blocks/caas/caas.test.html
@@ -109,44 +109,6 @@
           expect(loadStyle.callCount).to.equal(1);
           expect(caasEl).to.equal(document.getElementById('caas'));
         });
-
-        it('Events Hub: stage.adobe.com/events.html uses stage chimera + draft (Prod Draft)', async () => {
-          const origLoc = window.location;
-          Object.defineProperty(window, 'location', {
-            value: { host: 'www.stage.adobe.com', pathname: '/events.html', search: '' },
-            writable: true,
-          });
-          const a = document.createElement('a');
-          a.href = 'https://milo.adobe.com/tools/caas#events-draft-test';
-          a.className = 'caas-link';
-          a.textContent = 'no-lazy';
-          document.querySelector('main div')?.appendChild(a);
-          await init(a);
-          await waitForElement('#caas');
-          await delay(50);
-          expect(config.endpoint).to.include('chimera-stage');
-          expect(config.draftDb).to.be.true;
-          Object.defineProperty(window, 'location', { value: origLoc, writable: true });
-        });
-
-        it('Events Hub: www.adobe.com/events.html uses prod chimera + live (Prod Live)', async () => {
-          const origLoc = window.location;
-          Object.defineProperty(window, 'location', {
-            value: { host: 'www.adobe.com', pathname: '/events.html', search: '' },
-            writable: true,
-          });
-          const a = document.createElement('a');
-          a.href = 'https://milo.adobe.com/tools/caas#events-live-test';
-          a.className = 'caas-link';
-          a.textContent = 'no-lazy';
-          document.querySelector('main div')?.appendChild(a);
-          await init(a);
-          await waitForElement('#caas');
-          await delay(50);
-          expect(config.endpoint).to.equal('www.adobe.com/chimera-api/collection');
-          expect(config.draftDb).to.be.false;
-          Object.defineProperty(window, 'location', { value: origLoc, writable: true });
-        });
       });
     });
   </script>

--- a/test/blocks/caas/caas.test.html
+++ b/test/blocks/caas/caas.test.html
@@ -110,6 +110,43 @@
           expect(caasEl).to.equal(document.getElementById('caas'));
         });
 
+        it('Events Hub: stage.adobe.com/events.html uses stage chimera + draft (Prod Draft)', async () => {
+          const origLoc = window.location;
+          Object.defineProperty(window, 'location', {
+            value: { host: 'www.stage.adobe.com', pathname: '/events.html', search: '' },
+            writable: true,
+          });
+          const a = document.createElement('a');
+          a.href = 'https://milo.adobe.com/tools/caas#events-draft-test';
+          a.className = 'caas-link';
+          a.textContent = 'no-lazy';
+          document.querySelector('main div')?.appendChild(a);
+          await init(a);
+          await waitForElement('#caas');
+          await delay(50);
+          expect(config.endpoint).to.include('chimera-stage');
+          expect(config.draftDb).to.be.true;
+          Object.defineProperty(window, 'location', { value: origLoc, writable: true });
+        });
+
+        it('Events Hub: www.adobe.com/events.html uses prod chimera + live (Prod Live)', async () => {
+          const origLoc = window.location;
+          Object.defineProperty(window, 'location', {
+            value: { host: 'www.adobe.com', pathname: '/events.html', search: '' },
+            writable: true,
+          });
+          const a = document.createElement('a');
+          a.href = 'https://milo.adobe.com/tools/caas#events-live-test';
+          a.className = 'caas-link';
+          a.textContent = 'no-lazy';
+          document.querySelector('main div')?.appendChild(a);
+          await init(a);
+          await waitForElement('#caas');
+          await delay(50);
+          expect(config.endpoint).to.equal('www.adobe.com/chimera-api/collection');
+          expect(config.draftDb).to.be.false;
+          Object.defineProperty(window, 'location', { value: origLoc, writable: true });
+        });
       });
     });
   </script>

--- a/test/blocks/caas/caas.test.html
+++ b/test/blocks/caas/caas.test.html
@@ -35,7 +35,7 @@
     import { runTests } from '@web/test-runner-mocha';
     import { expect } from '@esm-bundle/chai';
     import { stub } from 'sinon';
-    import init from '../../../libs/blocks/caas/caas.js';
+    import init, { getChimeraConfig } from '../../../libs/blocks/caas/caas.js';
     import { loadScript, loadStyle } from '../../../libs/utils/utils.js';
     import { delay, waitForElement } from '../../helpers/waitfor.js';
 
@@ -108,6 +108,27 @@
           expect(loadScript.callCount).to.equal(3);
           expect(loadStyle.callCount).to.equal(1);
           expect(caasEl).to.equal(document.getElementById('caas'));
+        });
+
+        describe('Events Hub chimera mapping (getChimeraConfig)', () => {
+          it('stage.adobe.com/events.html uses stage chimera and draft', () => {
+            const { endpoint, draftDb } = getChimeraConfig('www.stage.adobe.com', '/events.html', '');
+            expect(endpoint).to.include('chimera-stage');
+            expect(draftDb).to.equal(true);
+          });
+
+          it('prod events.html with draft uses stage chimera and draft', () => {
+            const { endpoint, draftDb } = getChimeraConfig('www.adobe.com', '/events.html', '?caasendpoint=prod&caascontainer=draft');
+            expect(endpoint).to.include('chimera-stage');
+            expect(draftDb).to.equal(true);
+          });
+
+          it('prod events.html live uses prod chimera and no draft', () => {
+            const { endpoint, draftDb } = getChimeraConfig('www.adobe.com', '/events.html', '?caasendpoint=prod');
+            expect(endpoint).to.include('chimera.adobeioruntime');
+            expect(endpoint).to.not.include('chimera-stage');
+            expect(draftDb).to.equal(false);
+          });
         });
       });
     });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Events Hub (CAAS collection): point chimera to dev|stage|prod and draft|live per Milo DA logic
* stage.adobe.com/events.html → Prod Draft (stage chimera + draft)
* www.adobe.com/events.html → Prod Live (prod chimera + live)
* Prod draft events → stage chimera + draft (override when path is /events.html)
* Non–events pages unchanged (no regression)

Resolves: [MWPW-188376](https://jira.corp.adobe.com/browse/MWPW-188376)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-188376--milo--adobecom.aem.page/?martech=off

---

## Events Hub URL mapping (for testing)

Use these to verify chimera endpoint and draft/live for events pages.

### URL mapping table

| Environment | URL | Points to |
|-------------|-----|-----------|
| **DEV** | `dev--<domain>.page/.snapshots/dev/events.html` | DEV Draft Bucket (CAAS Draft – preview events) |
| **DEV** | `dev--<domain>.live/.snapshots/dev/events.html` | DEV Live Bucket (CAAS Live – published events) |
| **STAGE** | `stage--<domain>.page/.snapshots/stage/events.html` | Stage Draft Bucket (CAAS Draft – preview events) |
| **STAGE** | `stage--<domain>.live/.snapshots/stage/events.html` | Stage Live Bucket (CAAS Live – published events) |
| **PROD** | `stage--<domain>.page/events.html` | Prod Draft Bucket (preview content in production preview) |
| **PROD** | `main--<domain>.live/events.html` | Prod Live Bucket (production published events) |

### Example using bacom

| Environment | Example URL | Points to |
|-------------|------------|-----------|
| DEV | `dev--bacom--adobecom.aem.page/.snapshots/dev/events.html` | DEV Draft events |
| DEV | `dev--bacom--adobecom.aem.live/.snapshots/dev/events.html` | DEV Live events |
| STAGE | `stage--bacom--adobecom.aem.page/.snapshots/stage/events.html` | Stage Draft events |
| STAGE | `stage--bacom--adobecom.aem.live/.snapshots/stage/events.html` | Stage Live events |
| PROD | `stage--bacom--adobecom.aem.page/events.html` | Prod Draft preview events |
| PROD | `main--bacom--adobecom.aem.live/events.html` | Production events |

### Public URLs (what this PR affects)

| URL | Expected behavior |
|-----|-------------------|
| **stage.adobe.com/events.html** | Prod Draft → stage chimera + draft |
| **www.adobe.com/events.html** | Prod Live → prod chimera + live |

### How to test

1. **stage.adobe.com/events.html**  
   Open a page that has a CAAS block and path `/events.html` on `stage.adobe.com` (or mock `location` to that).  
   - Expect: CAAS uses **stage** chimera endpoint and **draft** (draftDb true).

2. **www.adobe.com/events.html**  
   Same with host `www.adobe.com`.  
   - Expect: CAAS uses **prod** chimera endpoint and **live** (draftDb false).

3. **Non–events pages**  
   Any path that does not end with `/events.html`.  
   - Expect: Same behavior as before (no change to endpoint or draft/live logic).

4. **Prod draft on .page (events only)**  
   e.g. `main--bacom--adobecom.aem.page/events.html` with draft.  
   - Expect: Override to **stage** chimera + draft (not prod chimera + draft).






