### PR TITLE
[MWPW-190563][MEP Lingo] Fallback for regional EN sites fails when MEP‑Lingo row is used in marquee block

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -91,6 +91,12 @@ export const removeMepLingoRow = (container) => {
   mepLingoRow?.remove();
 };
 
+const preserveAuthored = (a, isBlockSwap, originalBlock, originalSection) => {
+  if (isBlockSwap) removeMepLingoRow(originalBlock);
+  else removeMepLingoRow(originalSection?.querySelector('.section-metadata'));
+  a.parentElement?.remove();
+};
+
 export default async function init(a) {
   const { decorateArea, mep, placeholders, locale } = getConfig();
   let relHref = await localizeLinkAsync(a.href, window.location.hostname, false, a);
@@ -223,13 +229,7 @@ export default async function init(a) {
 
   if (usedFallback && !isMepLingoBlock
     && ((isBlockSwap && originalBlock) || (isSectionSwap && originalSection))) {
-    if (isBlockSwap) {
-      removeMepLingoRow(originalBlock);
-      a.parentElement?.remove();
-    } else {
-      removeMepLingoRow(originalSection?.querySelector('.section-metadata'));
-      a.parentElement?.remove();
-    }
+    preserveAuthored(a, isBlockSwap, originalBlock, originalSection);
     return;
   }
 
@@ -285,14 +285,12 @@ export default async function init(a) {
         originalBlock?.remove();
         a.parentElement?.remove();
       } else {
-        removeMepLingoRow(originalBlock);
-        a.parentElement?.remove();
+        preserveAuthored(a, isBlockSwap, originalBlock, originalSection);
       }
       return;
     }
     if (isSectionSwap && originalSection) {
-      removeMepLingoRow(originalSection?.querySelector('.section-metadata'));
-      a.parentElement?.remove();
+      preserveAuthored(a, false, originalBlock, originalSection);
       return;
     }
     if (isMepLingoFragment) {

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -217,7 +217,12 @@ export default async function init(a) {
   }
 
   const mepLingoPrefix = await getMepLingoPrefix();
-  if (isMepLingoLink && resp?.ok && !relHref.includes(mepLingoPrefix || '___NONE___')) {
+  const fetchedNonRegionalContent = isMepLingoLink && resp?.ok
+    && !relHref.includes(mepLingoPrefix || '___NONE___');
+  const redirectedRegionalFetch = (isBlockSwap || isSectionSwap) && resp?.redirected
+    && mepLingoPrefix && relHref.includes(mepLingoPrefix);
+
+  if (fetchedNonRegionalContent || redirectedRegionalFetch) {
     usedFallback = true;
   }
 

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -221,6 +221,18 @@ export default async function init(a) {
     return;
   }
 
+  if (usedFallback && !isMepLingoBlock
+    && ((isBlockSwap && originalBlock) || (isSectionSwap && originalSection))) {
+    if (isBlockSwap) {
+      removeMepLingoRow(originalBlock);
+      a.parentElement?.remove();
+    } else {
+      removeMepLingoRow(originalSection?.querySelector('.section-metadata'));
+      a.parentElement?.remove();
+    }
+    return;
+  }
+
   const attemptedRegionalFetch = relHref.includes(mepLingoPrefix);
   const canTryFallback = needsFallback && mepLingoPrefix
     && a.dataset.originalHref && !isMepLingoInsert && !isMepLingoRemove;

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -782,7 +782,6 @@ describe('MEP Lingo Fragments', () => {
     document.body.appendChild(section);
 
     const a = marquee.querySelector('a');
-    await simulateDecorateLinks(a);
     await getFragment(a);
 
     expect(marquee.textContent).to.include('Authored marquee content');
@@ -837,13 +836,55 @@ describe('MEP Lingo Fragments', () => {
     document.body.appendChild(section);
 
     const a = sectionMetadata.querySelector('a');
-    await simulateDecorateLinks(a);
     await getFragment(a);
 
     expect(section.textContent).to.include('Authored section content');
     const metaRows = sectionMetadata.querySelectorAll(':scope > div');
     const hasMepLingoRow = [...metaRows].some((r) => r.children[0]?.textContent?.trim() === 'mep-lingo');
     expect(hasMepLingoRow).to.be.false;
+    section.remove();
+  });
+
+  it('uses dual fetch fallback when skipQI is set and regional content 404s', async () => {
+    window.sessionStorage.setItem('akamai', 'ch');
+    const currentConfig = getConfig();
+    updateConfig({ ...currentConfig, locale: mepLingoLocale });
+
+    fetchStub.restore();
+    fetchStub = stub(window, 'fetch').callsFake((resource) => {
+      const mockPath = resource?.resource || resource;
+      if (mockPath?.includes('query-index')) {
+        return Promise.resolve(createQueryIndexResponse([]));
+      }
+      if (mockPath?.includes('lingo-site-mapping.json')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          'site-query-index-map': { data: [] },
+          'site-locales': { data: [] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      if (mockPath?.includes('/ch_de/') && mockPath?.includes('.plain.html')) {
+        return Promise.resolve(new Response(null, { status: 404, statusText: 'Not Found' }));
+      }
+      return originalFetch(resource);
+    });
+
+    const section = document.createElement('div');
+    section.className = 'section';
+    const p = document.createElement('p');
+    const a = document.createElement('a');
+    a.href = '/test/blocks/fragment/mocks/ch_de/fragments/mep-lingo-test';
+    a.dataset.mepLingo = 'true';
+    a.dataset.mepLingoSkippedQI = 'true';
+    a.dataset.originalHref = '/test/blocks/fragment/mocks/de/fragments/mep-lingo-test';
+    p.appendChild(a);
+    section.appendChild(p);
+    document.body.appendChild(section);
+
+    await getFragment(a);
+
+    const frag = section.querySelector('.fragment');
+    expect(frag).to.exist;
+    expect(frag.dataset.mepLingoFallback).to.exist;
     section.remove();
   });
 

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -740,6 +740,113 @@ describe('MEP Lingo Fragments', () => {
     expect(textBlock.textContent).to.not.include('mep-lingo');
   });
 
+  it('keeps authored block when fallback is used for block swap', async () => {
+    window.sessionStorage.setItem('akamai', 'ch');
+    const currentConfig = getConfig();
+    updateConfig({ ...currentConfig, locale: mepLingoLocale });
+
+    fetchStub.restore();
+    fetchStub = stub(window, 'fetch').callsFake((resource) => {
+      const mockPath = resource?.resource || resource;
+      if (mockPath?.includes('query-index')) {
+        return Promise.resolve(createQueryIndexResponse([]));
+      }
+      if (mockPath?.includes('lingo-site-mapping.json')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          'site-query-index-map': { data: [] },
+          'site-locales': { data: [] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      if (mockPath?.includes('/ch_de/')) {
+        return Promise.resolve(new Response(null, { status: 404, statusText: 'Not Found' }));
+      }
+      return originalFetch(resource);
+    });
+
+    const section = document.createElement('div');
+    section.className = 'section';
+    const marquee = document.createElement('div');
+    marquee.className = 'marquee';
+    const contentRow = document.createElement('div');
+    contentRow.innerHTML = '<div><p>Authored marquee content</p></div>';
+    marquee.appendChild(contentRow);
+    const mepLingoRow = document.createElement('div');
+    const cell1 = document.createElement('div');
+    cell1.textContent = 'mep-lingo';
+    const cell2 = document.createElement('div');
+    cell2.innerHTML = '<a href="/test/blocks/fragment/mocks/de/fragments/mep-lingo-test#_mep-lingo">swap</a>';
+    mepLingoRow.appendChild(cell1);
+    mepLingoRow.appendChild(cell2);
+    marquee.appendChild(mepLingoRow);
+    section.appendChild(marquee);
+    document.body.appendChild(section);
+
+    const a = marquee.querySelector('a');
+    await simulateDecorateLinks(a);
+    await getFragment(a);
+
+    expect(marquee.textContent).to.include('Authored marquee content');
+    const rows = marquee.querySelectorAll(':scope > div');
+    const hasMepLingoRow = [...rows].some((r) => r.children[0]?.textContent?.trim() === 'mep-lingo');
+    expect(hasMepLingoRow).to.be.false;
+    section.remove();
+  });
+
+  it('keeps authored section when fallback is used for section swap', async () => {
+    window.sessionStorage.setItem('akamai', 'ch');
+    const currentConfig = getConfig();
+    updateConfig({ ...currentConfig, locale: mepLingoLocale });
+
+    fetchStub.restore();
+    fetchStub = stub(window, 'fetch').callsFake((resource) => {
+      const mockPath = resource?.resource || resource;
+      if (mockPath?.includes('query-index')) {
+        return Promise.resolve(createQueryIndexResponse([]));
+      }
+      if (mockPath?.includes('lingo-site-mapping.json')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          'site-query-index-map': { data: [] },
+          'site-locales': { data: [] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      if (mockPath?.includes('/ch_de/')) {
+        return Promise.resolve(new Response(null, { status: 404, statusText: 'Not Found' }));
+      }
+      return originalFetch(resource);
+    });
+
+    const section = document.createElement('div');
+    section.className = 'section';
+    const content = document.createElement('div');
+    content.innerHTML = '<p>Authored section content</p>';
+    section.appendChild(content);
+    const sectionMetadata = document.createElement('div');
+    sectionMetadata.className = 'section-metadata';
+    const styleRow = document.createElement('div');
+    styleRow.innerHTML = '<div>style</div><div>dark</div>';
+    sectionMetadata.appendChild(styleRow);
+    const mepLingoRow = document.createElement('div');
+    const cell1 = document.createElement('div');
+    cell1.textContent = 'mep-lingo';
+    const cell2 = document.createElement('div');
+    cell2.innerHTML = '<a href="/test/blocks/fragment/mocks/de/fragments/mep-lingo-test#_mep-lingo">swap</a>';
+    mepLingoRow.appendChild(cell1);
+    mepLingoRow.appendChild(cell2);
+    sectionMetadata.appendChild(mepLingoRow);
+    section.appendChild(sectionMetadata);
+    document.body.appendChild(section);
+
+    const a = sectionMetadata.querySelector('a');
+    await simulateDecorateLinks(a);
+    await getFragment(a);
+
+    expect(section.textContent).to.include('Authored section content');
+    const metaRows = sectionMetadata.querySelectorAll(':scope > div');
+    const hasMepLingoRow = [...metaRows].some((r) => r.children[0]?.textContent?.trim() === 'mep-lingo');
+    expect(hasMepLingoRow).to.be.false;
+    section.remove();
+  });
+
   it('removes element when regional content is empty (remove variant)', async () => {
     window.sessionStorage.setItem('akamai', 'ch');
     const currentConfig = getConfig();

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -791,6 +791,61 @@ describe('MEP Lingo Fragments', () => {
     section.remove();
   });
 
+  it('keeps authored block when regional fetch is redirected (soft 404)', async () => {
+    window.sessionStorage.setItem('akamai', 'ch');
+    const currentConfig = getConfig();
+    updateConfig({ ...currentConfig, locale: mepLingoLocale });
+
+    fetchStub.restore();
+    fetchStub = stub(window, 'fetch').callsFake((resource) => {
+      const mockPath = resource?.resource || resource;
+      if (mockPath?.includes('query-index')) {
+        return Promise.resolve(createQueryIndexResponse([]));
+      }
+      if (mockPath?.includes('lingo-site-mapping.json')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          'site-query-index-map': { data: [] },
+          'site-locales': { data: [] },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      if (mockPath?.includes('/ch_de/')) {
+        return Promise.resolve({
+          ok: true,
+          redirected: true,
+          text: () => Promise.resolve('<div>redirect junk</div>'),
+        });
+      }
+      return originalFetch(resource);
+    });
+
+    const section = document.createElement('div');
+    section.className = 'section';
+    const marquee = document.createElement('div');
+    marquee.className = 'marquee';
+    const contentRow = document.createElement('div');
+    contentRow.innerHTML = '<div><p>Authored marquee content</p></div>';
+    marquee.appendChild(contentRow);
+    const mepLingoRow = document.createElement('div');
+    const cell1 = document.createElement('div');
+    cell1.textContent = 'mep-lingo';
+    const cell2 = document.createElement('div');
+    cell2.innerHTML = '<a href="/test/blocks/fragment/mocks/de/fragments/mep-lingo-test#_mep-lingo">swap</a>';
+    mepLingoRow.appendChild(cell1);
+    mepLingoRow.appendChild(cell2);
+    marquee.appendChild(mepLingoRow);
+    section.appendChild(marquee);
+    document.body.appendChild(section);
+
+    const a = marquee.querySelector('a');
+    await getFragment(a);
+
+    expect(marquee.textContent).to.include('Authored marquee content');
+    const rows = marquee.querySelectorAll(':scope > div');
+    const hasMepLingoRow = [...rows].some((r) => r.children[0]?.textContent?.trim() === 'mep-lingo');
+    expect(hasMepLingoRow).to.be.false;
+    section.remove();
+  });
+
   it('keeps authored section when fallback is used for section swap', async () => {
     window.sessionStorage.setItem('akamai', 'ch');
     const currentConfig = getConfig();


### PR DESCRIPTION
- Fixes a bug where authored content in block/section swaps (e.g., hero-marquee) was replaced by the base fragment when the regional fragment wasn't found in the query-index
- Root cause: when the query-index finds no regional version, the link falls back to the base locale path. If that base fragment exists (which it typically does -- mep-lingo fragments are authored at the US root path, and localized copies often exist too), the fetch returns 200 OK. Because the response is successful, the existing 404 handler is bypassed and the base fragment content overwrites the authored block. This gap has existed since block/section swaps were first introduced in PR #5219.
- Adds a guard after FallbackDetected that detects when fallback (non-regional) content is being used for a block/section swap and preserves the authored content instead. Standalone mep-lingo blocks are not affected.
- **Update**: Redirect detection for production CDN
Adds a second fallback detection for block/section swaps when the production CDN (business.adobe.com) returns a 301 redirect instead of a 404 for non-existent regional fragments. The fetch API follows the redirect automatically, so resp.ok is true and the existing 404 fallback logic is bypassed — causing authored blocks to be replaced with the redirect's meaningless content.
Detects this via resp.redirected and treats it as a fallback scenario, preserving the authored block. This only affects regionalized block/section swaps and is a no-op if the CDN is later fixed to return proper 404s.
Refactored both fallback conditions (fetchedNonRegionalContent and redirectedRegionalFetch) into named variables for clarity.

Steps to QA: 
Open the Before and After links below and scroll to the bottom of the page where I've authored a second hero-maquee.
Expected(After): Hero Marquee with Title: "ES Version - Define el futuro del marketing impulsado por IA"
Actual(Before): Fallback Fragment showing marquee with title: "ES Marquee Fragment - doens't exist in LA"

Steps to QA for production: 
prod url: https://business.adobe.com/solutions/unified-customer-experience.html?akamaiLocale=ru
Override the fragment.js file. 
Expected: marquee appears on page
Actual: marquee does not not appear


Resolves: [MWPW-190563](https://jira.corp.adobe.com/browse/MWPW-190563)

**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.page/es/drafts/mepdev/fragments/base-insert-remove?mep=&mepHighlight=true&akamaiLocale=la
- After: https://main--da-bacom--adobecom.aem.page/es/drafts/mepdev/fragments/base-insert-remove?milolibs=mep-lingo-fix-us-block-swap&mep=&mepHighlight=true&akamaiLocale=la
- Psi-check: https://mep-lingo-fix-us-block-swap--milo--adobecom.aem.page/?martech=off








