### PR TITLE
MWPW-189237: add ?caas-env=dev query param support to bulk publisher

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -10,6 +10,7 @@ import {
 const CAAS_TAG_URL = 'https://www.adobe.com/chimera-api/tags';
 const HLX_ADMIN_STATUS = 'https://admin.hlx.page/status';
 const URL_POSTXDM = 'https://14257-milocaasproxy.adobeio-static.net/api/v1/web/milocaas/postXDM';
+const URL_POSTXDM_DEV = 'https://14257-milocaasproxy-dev.adobeio-static.net/api/v1/web/milocaas/postXDM';
 const VALID_URL_RE = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
 const VALID_MODAL_RE = /fragments(.*)#[a-zA-Z0-9_-]+$/;
 
@@ -615,18 +616,20 @@ const getCardMetadata = async (options) => {
 };
 
 const postDataToCaaS = async ({ accessToken, caasEnv, caasProps, draftOnly }) => {
+  const isDev = new URLSearchParams(window.location.search).get('caas-env') === 'dev';
+  const postXdmUrl = isDev ? URL_POSTXDM_DEV : URL_POSTXDM;
+  const resolvedEnv = isDev ? 'dev' : caasEnv;
   const options = {
     method: 'POST',
     body: JSON.stringify(caasProps),
     headers: {
       Authorization: `Bearer ${accessToken}`,
       draft: !!draftOnly,
-      'caas-env': caasEnv,
+      'caas-env': resolvedEnv,
     },
   };
-
   let response;
-  const res = await fetch(URL_POSTXDM, options);
+  const res = await fetch(postXdmUrl, options);
   if (res !== undefined) {
     const text = await res.text();
 


### PR DESCRIPTION
## Summary
- Adds `?caas-env=dev` query param support to the bulk publisher
- When present, `postDataToCaaS` routes to the dev proxy endpoint (`14257-milocaasproxy-dev`) instead of prod
- Also sends `caas-env: dev` in the request header
- Allows E2E automation to target the dev environment natively without JS fetch interception

## Test plan
- Visit `bulkpublisher.html?caas-env=dev` and trigger a publish — verify the request goes to `14257-milocaasproxy-dev` with `caas-env: dev` header
- Visit without the param — verify prod endpoint and existing behaviour unchanged
- Visit with `?caas-env=stage` or any other value — verify prod endpoint is used (no URL override)

This has already been tested and is automated here: 
https://github.com/adobecom/caas/pull/427



