### PR TITLE
[MWPW-190397]Read fed content prefix from consuming team config

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -388,11 +388,7 @@ export const getFederatedContentRoot = () => {
     'https://news.adobe.com',
     'graybox.adobe.com',
   ];
-  const fedContFromMiloDomain = [
-    'https://acrobat.adobe.com',
-    'https://stage.acrobat.adobe.com',
-  ];
-  const { allowedOrigins = [], origin: configOrigin } = getConfig();
+  const { allowedOrigins = [], origin: configOrigin, fedContentOrigin } = getConfig();
   if (federatedContentRoot) return federatedContentRoot;
   // Non milo consumers will have its origin from config
   const origin = configOrigin || window.location.origin;
@@ -403,8 +399,7 @@ export const getFederatedContentRoot = () => {
       ? originNoStage === o
       : originNoStage.endsWith(o);
   });
-  if (fedContFromMiloDomain.includes(window.location.origin)) federatedContentRoot = 'https://milo.adobe.com';
-  else federatedContentRoot = isAllowedOrigin ? origin : 'https://www.adobe.com';
+  federatedContentRoot = fedContentOrigin ?? (isAllowedOrigin ? origin : 'https://www.adobe.com');
 
   if (origin.includes('localhost') || origin.includes(`.${SLD}.`)) {
     federatedContentRoot = `https://main--federal--adobecom.aem.${origin.endsWith('.live') ? 'live' : 'page'}`;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -388,7 +388,7 @@ export const getFederatedContentRoot = () => {
     'https://news.adobe.com',
     'graybox.adobe.com',
   ];
-  const { allowedOrigins = [], origin: configOrigin, fedContentBaseUrl } = getConfig();
+  const { allowedOrigins = [], origin: configOrigin, fedContentPrefix } = getConfig();
   if (federatedContentRoot) return federatedContentRoot;
   // Non milo consumers will have its origin from config
   const origin = configOrigin || window.location.origin;
@@ -399,10 +399,14 @@ export const getFederatedContentRoot = () => {
       ? originNoStage === o
       : originNoStage.endsWith(o);
   });
-  federatedContentRoot = fedContentBaseUrl ?? (isAllowedOrigin ? origin : 'https://www.adobe.com');
+  federatedContentRoot = isAllowedOrigin ? origin : 'https://www.adobe.com';
 
   if (origin.includes('localhost') || origin.includes(`.${SLD}.`)) {
     federatedContentRoot = `https://main--federal--adobecom.aem.${origin.endsWith('.live') ? 'live' : 'page'}`;
+  }
+
+  if (fedContentPrefix) {
+    federatedContentRoot = `${federatedContentRoot}${fedContentPrefix}`;
   }
 
   return federatedContentRoot;
@@ -412,8 +416,10 @@ export const getFederatedUrl = (url = '') => {
   if (typeof url !== 'string' || !url.includes('/federal/')) return url;
   if (url.startsWith('/')) return `${getFederatedContentRoot()}${url}`;
   try {
+    const { fedContentPrefix } = getConfig();
     const { pathname, search, hash } = new URL(url);
-    return `${getFederatedContentRoot()}${pathname}${search}${hash}`;
+    return `${getFederatedContentRoot()}${pathname.startsWith(fedContentPrefix)
+      ? pathname.replace(fedContentPrefix, '') : pathname}${search}${hash}`;
   } catch (e) {
     window.lana?.log(`getFederatedUrl errored parsing the URL: ${url}: ${e.toString()}`, {
       tags: 'utils',

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -388,7 +388,7 @@ export const getFederatedContentRoot = () => {
     'https://news.adobe.com',
     'graybox.adobe.com',
   ];
-  const { allowedOrigins = [], origin: configOrigin, fedContentOrigin } = getConfig();
+  const { allowedOrigins = [], origin: configOrigin, fedContentBaseUrl } = getConfig();
   if (federatedContentRoot) return federatedContentRoot;
   // Non milo consumers will have its origin from config
   const origin = configOrigin || window.location.origin;
@@ -399,7 +399,7 @@ export const getFederatedContentRoot = () => {
       ? originNoStage === o
       : originNoStage.endsWith(o);
   });
-  federatedContentRoot = fedContentOrigin ?? (isAllowedOrigin ? origin : 'https://www.adobe.com');
+  federatedContentRoot = fedContentBaseUrl ?? (isAllowedOrigin ? origin : 'https://www.adobe.com');
 
   if (origin.includes('localhost') || origin.includes(`.${SLD}.`)) {
     federatedContentRoot = `https://main--federal--adobecom.aem.${origin.endsWith('.live') ? 'live' : 'page'}`;


### PR DESCRIPTION
* Read fed content prefix from consuming team config

Resolves: [MWPW-190397](https://jira.corp.adobe.com/browse/MWPW-190397)

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-190397--milo--adobecom.aem.page/?martech=off

- Before: https://stage--dc-frictionless--adobecom.aem.live/heic-to-pdf?martech=off&milolibs=MWPW-190397
- After: https://MWPW-190397--milo--adobecom.aem.live/heic-to-pdf?martech=off&milolibs=MWPW-190397

Notes:
Acrobat web team is working to add mapping on acrobat.adobe.com for federal content more details here https://jira.corp.adobe.com/browse/DCXY-36990 Based on this in dc-frictionless project we are setting up a fedContentPrefix which will be used as origin for fed content for milo pages hosted on acrobat.adobe.com.
DC config here https://github.com/adobecom/dc-frictionless/blob/stage/dc-shared/scripts/scripts.js#L271







