### PR TITLE
MWPW-190510 [Timeline] Fix timeline block DOM reading order for screen readers (WCAG 1.3.2)

### DIFF
--- a/libs/blocks/timeline/timeline.css
+++ b/libs/blocks/timeline/timeline.css
@@ -3,29 +3,44 @@
   padding: 0 var(--grid-margins-width) var(--spacing-xl) var(--grid-margins-width);
   width: 100%;
   margin: 0 auto;
+  display: grid;
+  grid-template-rows: auto auto auto;
 }
 
 .dialog-modal .timeline {
   padding: 0 var(--spacing-xl) var(--spacing-xl) var(--spacing-xl);
 }
 
-.timeline .row {
+/* Columns use subgrid so bars and periods align across left/right */
+.timeline > .left,
+.timeline > .right {
   display: grid;
+  grid-row: 1 / -1;
+  grid-template-rows: subgrid;
 }
 
-.timeline.segment-timeline-3-9 .row,
-.timeline.segment-timeline-4-8 .row,
-.timeline.segment-timeline-5-7 .row  {
+.timeline > .right {
+  grid-template-columns: 1.5fr 1fr;
+  gap: 0 8px;
+}
+
+[dir="rtl"] .timeline > .right {
+  grid-template-columns: 1fr 1fr;
+}
+
+.timeline.segment-timeline-3-9,
+.timeline.segment-timeline-4-8,
+.timeline.segment-timeline-5-7 {
   grid-template-columns: 1fr 58.3%;
 }
 
-.timeline.segment-timeline-6-6 .row {
+.timeline.segment-timeline-6-6 {
   grid-template-columns: 50% 50%;
-} 
+}
 
-.timeline.segment-timeline-7-5 .row,
-.timeline.segment-timeline-8-4 .row,
-.timeline.segment-timeline-9-3 .row { 
+.timeline.segment-timeline-7-5,
+.timeline.segment-timeline-8-4,
+.timeline.segment-timeline-9-3 {
   grid-template-columns: 1fr 41.7%;
 }
 
@@ -42,110 +57,43 @@
   line-height: var(--type-body-xs-lh);
 }
 
-.timeline .row:nth-child(2)>div {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
+/* Text entries — grid row 1 */
+.timeline > .left > [data-valign],
+.timeline > .right > [data-valign] {
+  grid-row: 1;
 }
 
-.timeline .row:nth-of-type(1)>.right>div+div {
+.timeline > .left > [data-valign]:not(.left-center) > * {
+  max-width: 100px;
+}
+
+.timeline > .right > :first-child {
+  grid-column: 1;
+  max-width: 135px;
+}
+
+.timeline > .right > .right-end {
+  grid-column: 2;
   text-align: right;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
 }
 
-.timeline .row:nth-of-type(1)>.left>div>* {
+.timeline > .right > .right-end > * {
   max-width: 100px;
 }
 
-.dark .timeline .row:nth-child(3)>div *,
-.timeline.dark .row:nth-child(3)>div * {
-  color: var(--color-black);
+/* Bar wrappers — grid row 2, decorative (aria-hidden) */
+.timeline .bar-wrapper {
+  grid-row: 2;
+  display: flex;
+  align-items: center;
 }
 
-.timeline .row:nth-of-type(1)>.right>div+div>* {
-  max-width: 100px;
-}
-
-.timeline .row:nth-of-type(1)>.right,
-.timeline .row:nth-of-type(2)>.right {
-  display: grid;
+.timeline > .right > .bar-wrapper {
+  grid-column: 1 / -1;
   justify-content: space-between;
-}
-
-.timeline .row:nth-of-type(1)>.right {
-  grid-template-columns: 1.5fr 1fr;
-  grid-gap: 8px;
-}
-
-[dir="rtl"] .timeline .row:nth-of-type(1)>.right {
-  grid-template-columns: 1fr 1fr;
-}
-
-.timeline.segment-timeline-3-9 .left-center,
-.timeline.segment-timeline-4-8 .left-center,
-.timeline.segment-timeline-5-7 .left-center,
-.timeline.segment-timeline-6-6 .left-center {
-  display: none;
-}
-@media screen and (max-width: 599.99px) {
-  .timeline.segment-timeline-7-5 .row:nth-of-type(1)>.right,
-  .timeline.segment-timeline-8-4 .row:nth-of-type(1)>.right,
-  .timeline.segment-timeline-9-3 .row:nth-of-type(1)>.right {
-    grid-template-columns: 1fr;
-  }
-
-  .timeline.segment-timeline-7-5 .row:nth-of-type(1)>.left,
-  .timeline.segment-timeline-8-4 .row:nth-of-type(1)>.left,
-  .timeline.segment-timeline-9-3 .row:nth-of-type(1)>.left {
-    grid-template-columns: 1fr 1.5fr; 
-    display: grid;
-    justify-content: space-between;
-    grid-gap: 8px; 
-  }
-
-  .timeline.segment-timeline-7-5 .right-center,
-  .timeline.segment-timeline-8-4 .right-center,
-  .timeline.segment-timeline-9-3 .right-center {
-    display: none;
-  }
-
-  .timeline.segment-timeline-7-5 .left-center,
-  .timeline.segment-timeline-8-4 .left-center,
-  .timeline.segment-timeline-9-3 .left-center {
-    text-align: right;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-  }
-  
-  [dir="rtl"] .timeline.segment-timeline-7-5 .left-center,
-  [dir="rtl"] .timeline.segment-timeline-8-4 .left-center,
-  [dir="rtl"] .timeline.segment-timeline-9-3 .left-center {
-    text-align: left;
-  }
-
-  .timeline .row:nth-of-type(1)>.left .left-center>* {
-    padding-right: 0;
-  }
-}
-
-@media screen and (min-width: 600px) {
-  .timeline.segment-timeline-7-5 .left-center,
-  .timeline.segment-timeline-8-4 .left-center,
-  .timeline.segment-timeline-9-3 .left-center {
-    display: none;
-  }
-}
-
-.timeline .row:nth-of-type(2)>.right {
-  grid-template-columns: 2px 2px;
-}
-
-.timeline .row:nth-of-type(1)>.right>div:nth-of-type(1) {
-  max-width: 135px;
-  /* padding-right: var(--spacing-xxs); */
 }
 
 .timeline .bar {
@@ -155,7 +103,9 @@
   margin: var(--spacing-xxs) 0;
 }
 
-.timeline .row:nth-of-type(3) p {
+/* Period labels — grid row 3 */
+.timeline .period {
+  grid-row: 3;
   text-align: center;
   font-weight: 700;
   padding: 4px var(--spacing-xxs);
@@ -166,81 +116,148 @@
   border-radius: 4px;
 }
 
-.timeline .row:nth-of-type(3) .left p {
-  margin-right: 1px;
-}
-
-.timeline .row:nth-of-type(3) .right p {
+.timeline > .right > .period {
+  grid-column: 1 / -1;
   margin-left: 3px;
 }
 
-.dark .timeline .row:nth-child(1)>div>div>*,
-.timeline.dark .row:nth-child(1)>div>div>* {
+.timeline > .left > .period {
+  margin-right: 1px;
+}
+
+.dark .timeline .period,
+.timeline.dark .period {
+  color: var(--color-black);
+}
+
+.dark .timeline > .left > [data-valign] > *,
+.dark .timeline > .right > [data-valign] > *,
+.timeline.dark > .left > [data-valign] > *,
+.timeline.dark > .right > [data-valign] > * {
   color: var(--color-white);
 }
 
-[dir="rtl"] .timeline .row:nth-of-type(1)>.left>div>* {
-  /* padding: 0 0 0 var(--spacing-m); */
+.timeline.segment-timeline-3-9 .left-center,
+.timeline.segment-timeline-4-8 .left-center,
+.timeline.segment-timeline-5-7 .left-center,
+.timeline.segment-timeline-6-6 .left-center {
+  display: none;
+}
+
+@media screen and (max-width: 599.99px) {
+  .timeline.segment-timeline-7-5 > .right,
+  .timeline.segment-timeline-8-4 > .right,
+  .timeline.segment-timeline-9-3 > .right {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline.segment-timeline-7-5 .right-center,
+  .timeline.segment-timeline-8-4 .right-center,
+  .timeline.segment-timeline-9-3 .right-center {
+    display: none;
+  }
+
+  .timeline.segment-timeline-7-5 > .left,
+  .timeline.segment-timeline-8-4 > .left,
+  .timeline.segment-timeline-9-3 > .left {
+    grid-template-columns: 1fr 1.5fr;
+    column-gap: 8px;
+  }
+
+  .timeline.segment-timeline-7-5 > .left > .bar-wrapper,
+  .timeline.segment-timeline-7-5 > .left > .period,
+  .timeline.segment-timeline-8-4 > .left > .bar-wrapper,
+  .timeline.segment-timeline-8-4 > .left > .period,
+  .timeline.segment-timeline-9-3 > .left > .bar-wrapper,
+  .timeline.segment-timeline-9-3 > .left > .period {
+    grid-column: 1 / -1;
+  }
+
+  .timeline.segment-timeline-7-5 .left-center,
+  .timeline.segment-timeline-8-4 .left-center,
+  .timeline.segment-timeline-9-3 .left-center {
+    grid-row: 1;
+    text-align: right;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
+  .timeline > .left > .left-center > * {
+    padding-right: 0;
+  }
+
+  .timeline.segment-timeline-7-5 > .right > .right-end,
+  .timeline.segment-timeline-8-4 > .right > .right-end,
+  .timeline.segment-timeline-9-3 > .right > .right-end {
+    grid-column: 1;
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .timeline.segment-timeline-7-5 .left-center,
+  .timeline.segment-timeline-8-4 .left-center,
+  .timeline.segment-timeline-9-3 .left-center {
+    display: none;
+  }
+}
+
+[dir="rtl"] .timeline > .left > [data-valign] > * {
   padding: 0;
   text-align: right;
 }
 
-[dir="rtl"] .timeline.timeline.segment-timeline-7-5 .row:nth-of-type(1)>.left>.left-center>*,
-[dir="rtl"] .timeline.timeline.segment-timeline-8-4 .row:nth-of-type(1)>.left>.left-center>*,
-[dir="rtl"] .timeline.timeline.segment-timeline-9-3 .row:nth-of-type(1)>.left>.left-center>* {
-  padding: 0;
-  text-align: left;
-}
-
-[dir="rtl"] .timeline .row:nth-of-type(1)>.right>div+div {
+[dir="rtl"] .timeline > .right > .right-end {
   padding: 0 0 var(--spacing-xxs) 0;
   text-align: left;
 }
 
-[dir="rtl"] .timeline .row:nth-of-type(3) .left p {
+[dir="rtl"] .timeline > .left > .period {
   margin: 0 0 0 1px;
 }
 
-[dir="rtl"] .timeline .row:nth-of-type(3) .right p {
+[dir="rtl"] .timeline > .right > .period {
   margin: 0 3px 0 0;
 }
 
-@media screen and (min-width: 600px) {
-  .dialog-modal .timeline {
-    padding: 0 var(--spacing-xl) var(--spacing-xl) var(--spacing-xl);
-  }
+[dir="rtl"] .timeline.segment-timeline-7-5 > .left > .left-center > *,
+[dir="rtl"] .timeline.segment-timeline-8-4 > .left > .left-center > *,
+[dir="rtl"] .timeline.segment-timeline-9-3 > .left > .left-center > * {
+  padding: 0;
+  text-align: left;
 }
+
 @media screen and (min-width: 1200px) {
-  .timeline.segment-timeline-3-9 .row {
-    grid-template-columns: 1fr 75%
+  .timeline.segment-timeline-3-9 {
+    grid-template-columns: 1fr 75%;
   }
 
-  .timeline.segment-timeline-4-8 .row {
+  .timeline.segment-timeline-4-8 {
     grid-template-columns: 1fr 66.69%;
   }
 
-  .timeline.segment-timeline-5-7 .row {
+  .timeline.segment-timeline-5-7 {
     grid-template-columns: 1fr 58.3%;
   }
 
-  .timeline.segment-timeline-6-6 .row {
+  .timeline.segment-timeline-6-6 {
     grid-template-columns: 1fr 50%;
   }
 
-  .timeline.segment-timeline-7-5 .row {
+  .timeline.segment-timeline-7-5 {
     grid-template-columns: 1fr 41.7%;
   }
 
-  .timeline.segment-timeline-8-4 .row {
+  .timeline.segment-timeline-8-4 {
     grid-template-columns: 1fr 33.3%;
   }
 
-  .timeline.segment-timeline-9-3 .row {
+  .timeline.segment-timeline-9-3 {
     grid-template-columns: 1fr 25%;
   }
 }
 
-@media screen and (min-width:1120px) {
+@media screen and (min-width: 1120px) {
   .timeline {
     padding-left: calc((100vw - 1000px) / 2);
     padding-right: calc((100vw - 1000px) / 2);

--- a/libs/blocks/timeline/timeline.js
+++ b/libs/blocks/timeline/timeline.js
@@ -26,38 +26,22 @@ function hasSegmentClass(el) {
   return hasValidSegmentClass;
 }
 
+// Legacy auto-sizing for timelines without segment classes.
+// Can be removed (getColWidth, colWidthsNotValid, updateColWidths, ~18 lines)
+// once all timelines are confirmed to use segment classes.
 function getColWidth(text, colWidths, hasSegment) {
   if (hasSegment || colWidths.length === 2) return;
   const numRegex = /\b\d{1,3}\b/;
   colWidths.push((text.match(numRegex) || [])[0]);
 }
-function createRow() {
-  return [createTag('div', { class: 'row' }),
-    createTag('div', { class: 'left' }),
-    createTag('div', { class: 'right' }),
-  ];
-}
-function createBars(index) {
-  return index === 0
-    ? [createTag('div', { class: 'bar' })] : [createTag('div', { class: 'bar' }), createTag('div', { class: 'bar' })];
-}
-function addBarRow() {
-  const [barRow, left, right] = createRow();
-  const sides = [left, right];
-  sides.forEach((text, index) => {
-    sides[index].append(...createBars(index));
-    barRow.append(sides[index]);
-  });
-  return barRow;
-}
-function addBottomRow(periodText) {
-  const [periodRow, left, right] = createRow();
-  const sides = [left, right];
-  periodText.forEach((text, index) => {
-    sides[index].append(createTag('p', { class: 'period body-s' }, text));
-    periodRow.append(sides[index]);
-  });
-  return periodRow;
+
+function createBarWrapper(count) {
+  const wrapper = createTag('div', { class: 'bar-wrapper' });
+  wrapper.setAttribute('aria-hidden', 'true');
+  for (let i = 0; i < count; i += 1) {
+    wrapper.append(createTag('div', { class: 'bar' }));
+  }
+  return wrapper;
 }
 
 function setBG(el, color) {
@@ -81,9 +65,10 @@ function updateForRTL(lgStr, el) {
   }
   return lgStr;
 }
-function setColors(colors, fragment, el) {
-  const barEls = fragment.querySelectorAll('.bar');
-  const periodEls = fragment.querySelectorAll('.period');
+
+function setColors(colors, container, el) {
+  const barEls = container.querySelectorAll('.bar');
+  const periodEls = container.querySelectorAll('.period');
   if (colors?.length === 2 && isColorOrGradient(colors[0]) && isColorOrGradient(colors[1])) {
     if (barEls.length === 3 || periodEls.length === 2) {
       const leftColor = colors[0];
@@ -104,7 +89,7 @@ function setColors(colors, fragment, el) {
         setBG(barEls[1], leftColor);
       }
       if (isGradient(rightColor)) {
-        leftColor.split(' ').forEach((color) => {
+        rightColor.split(' ').forEach((color) => {
           if (isColor(color) && !thirdBar) {
             thirdBar = color;
             setBG(barEls[2], thirdBar);
@@ -122,23 +107,24 @@ function setColors(colors, fragment, el) {
 function colWidthsNotValid(colWidths) {
   return (colWidths.length !== 2 || colWidths.some((value) => Number.isNaN(value)));
 }
-function updateColWidths(colWidths, fragment, hasSegment) {
+
+function updateColWidths(colWidths, el, hasSegment) {
   if (colWidthsNotValid(colWidths) || hasSegment) return;
   const total = Number(colWidths[0]) + Number(colWidths[1]);
-  const right = Math.floor((Number(colWidths[1]) / total) * 10000) / 100;
-  const colString = `1fr minmax(${String(right)}%, 150px)`;
-  fragment.querySelectorAll('.row').forEach((row) => {
-    row.style.gridTemplateColumns = colString;
-  });
+  const rightPct = Math.floor((Number(colWidths[1]) / total) * 10000) / 100;
+  el.style.gridTemplateColumns = `1fr minmax(${String(rightPct)}%, 150px)`;
 }
+
 export default function init(el) {
   const fragment = document.createDocumentFragment();
-  const [textRow, left, right] = createRow();
+  const left = createTag('div', { class: 'left' });
+  const right = createTag('div', { class: 'right' });
   const rows = el.querySelectorAll(':scope > div > div');
   const colors = []; const periodText = []; const colWidths = [];
   const hasSegment = hasSegmentClass(el);
+  let rightEndRow = null;
+
   rows.forEach((row, index) => {
-    const side = index === 0 ? left : right;
     const color = row.firstElementChild?.textContent?.trim();
     const p = row.querySelector(':scope > p:last-child');
     if (p) {
@@ -147,9 +133,7 @@ export default function init(el) {
         periodText.push(period.trim());
         getColWidth(period, colWidths, hasSegment);
       }
-      if (text) {
-        p.textContent = text.trim();
-      }
+      if (text) p.textContent = text.trim();
     }
 
     if (isColorOrGradient(color)) {
@@ -157,17 +141,35 @@ export default function init(el) {
       row.firstElementChild.remove();
     }
     row.parentElement.remove();
-    if (index === 1 && hasSegment) {
-      const mobileCenterLeft = row.cloneNode(true);
-      mobileCenterLeft.classList.add('left-center');
-      left.append(mobileCenterLeft);
-      row.classList.add('right-center');
+
+    if (index === 0) {
+      left.append(row);
+    } else if (index === 1) {
+      if (hasSegment) {
+        const mobileCenterLeft = row.cloneNode(true);
+        mobileCenterLeft.classList.add('left-center');
+        left.append(mobileCenterLeft);
+        row.classList.add('right-center');
+      }
+      right.append(row);
+    } else {
+      rightEndRow = row;
+      rightEndRow.classList.add('right-end');
     }
-    side.append(row);
   });
-  textRow.append(left, right);
-  [textRow, addBarRow(), addBottomRow(periodText)].forEach((row) => fragment.append(row));
-  updateColWidths(colWidths, fragment, hasSegment);
+
+  left.append(createBarWrapper(1));
+  right.append(createBarWrapper(2));
+
+  periodText.forEach((text, index) => {
+    const side = index === 0 ? left : right;
+    side.append(createTag('p', { class: 'period body-s' }, text));
+  });
+
+  if (rightEndRow) right.append(rightEndRow);
+
+  fragment.append(left, right);
+  updateColWidths(colWidths, el, hasSegment);
   setColors(colors, fragment, el);
   el.append(fragment);
 }

--- a/test/blocks/timeline/timeline.test.js
+++ b/test/blocks/timeline/timeline.test.js
@@ -71,15 +71,14 @@ describe('Timeline', () => {
     const rightTexts = right.querySelectorAll('[data-valign]');
     const rightPeriod = right.querySelector('.period');
 
+    const follows = (a, b) => a.compareDocumentPosition(b) === Node.DOCUMENT_POSITION_FOLLOWING;
+
     // Left column: text before period
-    expect(leftText.compareDocumentPosition(leftPeriod)
-      & Node.DOCUMENT_POSITION_FOLLOWING).to.be.ok;
+    expect(follows(leftText, leftPeriod)).to.be.true;
 
     // Right column: Day 8 before period, period before Day 21
-    expect(rightTexts[0].compareDocumentPosition(rightPeriod)
-      & Node.DOCUMENT_POSITION_FOLLOWING).to.be.ok;
-    expect(rightPeriod.compareDocumentPosition(rightTexts[1])
-      & Node.DOCUMENT_POSITION_FOLLOWING).to.be.ok;
+    expect(follows(rightTexts[0], rightPeriod)).to.be.true;
+    expect(follows(rightPeriod, rightTexts[1])).to.be.true;
   });
   it('updates background linear gradient for rtl', async () => {
     const timelineEl = document.querySelector('.timeline');

--- a/test/blocks/timeline/timeline.test.js
+++ b/test/blocks/timeline/timeline.test.js
@@ -33,17 +33,17 @@ describe('Timeline', () => {
     expect(descriptions[1].textContent).to.equal('Your subscription starts and billing begins');
     expect(descriptions[2].textContent).to.equal('Full refund period ends');
   });
-  it('has a payment period and a refund period section ', async () => {
+  it('has a payment period and a refund period section', async () => {
     const timelineEl = document.querySelector('.timeline');
     init(timelineEl);
-    const trialPeriod = timelineEl.querySelector('.row .left .period');
-    const refundPeriod = timelineEl.querySelector('.row .right .period');
+    const trialPeriod = timelineEl.querySelector('.left .period');
+    const refundPeriod = timelineEl.querySelector('.right .period');
 
     expect(trialPeriod.textContent).to.equal('7-day free trial');
     expect(refundPeriod.textContent).to.equal('14-day full refund period');
     expect(trialPeriod.style.background.includes('to right')).to.be.true;
   });
-  it('it sets bar background colors based on colors in free trial and refund period section', async () => {
+  it('sets bar background colors based on colors in free trial and refund period section', async () => {
     const timelineEl = document.querySelector('.timeline');
     init(timelineEl);
     const bars = timelineEl.querySelectorAll('.bar');
@@ -52,11 +52,40 @@ describe('Timeline', () => {
     expect(bars[1].style.backgroundColor).to.equal('rgb(233, 116, 154)');
     expect(bars[2].style.backgroundColor).to.equal('rgb(255, 206, 46)');
   });
+  it('marks bar wrappers as decorative for screen readers', async () => {
+    const timelineEl = document.querySelector('.timeline');
+    init(timelineEl);
+    const barWrappers = timelineEl.querySelectorAll('.bar-wrapper');
+    barWrappers.forEach((wrapper) => {
+      expect(wrapper.getAttribute('aria-hidden')).to.equal('true');
+    });
+  });
+  it('has correct DOM reading order for screen readers', async () => {
+    const timelineEl = document.querySelector('.timeline');
+    init(timelineEl);
+    const left = timelineEl.querySelector('.left');
+    const right = timelineEl.querySelector('.right');
+
+    const leftText = left.querySelector('[data-valign]');
+    const leftPeriod = left.querySelector('.period');
+    const rightTexts = right.querySelectorAll('[data-valign]');
+    const rightPeriod = right.querySelector('.period');
+
+    // Left column: text before period
+    expect(leftText.compareDocumentPosition(leftPeriod)
+      & Node.DOCUMENT_POSITION_FOLLOWING).to.be.ok;
+
+    // Right column: Day 8 before period, period before Day 21
+    expect(rightTexts[0].compareDocumentPosition(rightPeriod)
+      & Node.DOCUMENT_POSITION_FOLLOWING).to.be.ok;
+    expect(rightPeriod.compareDocumentPosition(rightTexts[1])
+      & Node.DOCUMENT_POSITION_FOLLOWING).to.be.ok;
+  });
   it('updates background linear gradient for rtl', async () => {
     const timelineEl = document.querySelector('.timeline');
     timelineEl.parentElement.setAttribute('dir', 'rtl');
     init(timelineEl);
-    const trialPeriod = timelineEl.querySelector('.row .left .period');
+    const trialPeriod = timelineEl.querySelector('.left .period');
     expect(trialPeriod.style.background.includes('to left')).to.be.true;
   });
   describe('rtl ', () => {
@@ -69,7 +98,7 @@ describe('Timeline', () => {
     it('updates linear-gradient for rtl', async () => {
       const timelineEl = document.querySelector('.timeline');
       init(timelineEl);
-      const refundPeriod = timelineEl.querySelector('.row .right .period');
+      const refundPeriod = timelineEl.querySelector('.right .period');
       expect(refundPeriod.textContent).to.equal('14-day full refund period');
       expect(refundPeriod.style.background.includes('to left')).to.be.true;
     });
@@ -84,8 +113,8 @@ describe('Timeline', () => {
     it('adds classes to handle center text alignment', async () => {
       const timelineEl = document.querySelector('.timeline');
       init(timelineEl);
-      const leftCenter = timelineEl.querySelector('.row .left-center');
-      const rightCenter = timelineEl.querySelector('.row .right-center');
+      const leftCenter = timelineEl.querySelector('.left-center');
+      const rightCenter = timelineEl.querySelector('.right-center');
       expect(rightCenter).to.exist;
       expect(leftCenter).to.exist;
     });


### PR DESCRIPTION
Summary

- Restructure the timeline block from row-based DOM (text row, bars row, periods row) to column-based (left/right columns each containing text, bar, and period in reading order)
- Screen readers now announce content in meaningful sequence: Day 1 → 7-day free trial → Day 8 → 14-day money back guarantee → Day 21
- Rewrite CSS using subgrid to preserve the existing visual layout while supporting the new DOM structure
- Mark decorative bar elements with aria-hidden="true" so screen readers skip them
- Fix pre-existing bug in setColors that used the wrong gradient source for the third bar
Add reading order verification test

**QA Test link for this bug:** 
Before: https://main--cc--adobecom.aem.page/products/photoshop/free-trial-download
After: https://main--cc--adobecom.aem.page/products/photoshop/free-trial-download?milolibs=timeline-accessibility
Steps to QA bug: 
1. Turn on the screen reader and open the above-mentioned URL.
2. Navigate to the following text content using down arrow key and observe the screen reader announcement
-Day 1 Start your free trial today
-Day 8 Your trial has ended and billing begins
-Day 21 Cancel within 14 days to get a full refund
-7-day free trial
-14-day money back guarantee

Expected results:
Screen reader announces the above-mentioned static content in a meaningful order-
-Day 1 Start your free trial today
-7-day free trial
-Day 8 Your trial has ended and billing begins
-14-day money back guarantee
-Day 21 Cancel within 14 days to get a full refund

Actual results:
Reading order of the above-mentioned static content is not meaningful. It is announced as follows-
-Day 1 Start your free trial today
-Day 8 Your trial has ended and billing begins
-Day 21 Cancel within 14 days to get a full refund
-7-day free trial
-14-day money back guarantee

**QA Test Links for regression testing:**
Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/timeline
After: https://timeline-accessibility--milo--adobecom.aem.page/docs/library/kitchen-sink/timeline
Steps to QA:
1. Open Before and After URLs side by side
2. Compare all timeline segment variants (3-9, 4-8, 5-7, 6-6, 7-5, 8-4, 9-3) at desktop width -- text alignment, bar 3. positions, period labels, and gradient colors should match
3. Resize browser to mobile width (<600px) and compare each variant -- for 7-5, 8-4, and 9-3 segments, Day 8 should appear in the left column alongside Day 1, with Day 21 alone in the right column
4. Verify bar colors and period background gradients are identical between Before and After

**QA for RTL regression testing:**
Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/timeline
After: https://timeline-accessibility--milo--adobecom.aem.page/docs/library/kitchen-sink/timeline
Steps to QA:
1. Same as regression testing above, but first open DevTools, select the html element, and add dir="rtl" attribute
2. Verify layouts mirror correctly (Day 1 on the right, Day 21 on the left) and period label gradients reverse direction
3. Before and After should look identical in RTL at both desktop and mobile widths


Resolves: [MWPW-190510](https://jira.corp.adobe.com/browse/MWPW-190510)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://timeline-accessibility--milo--adobecom.aem.page/?martech=off




