### PR TITLE
MWPW-190760: OST dual-OSI discount support

### DIFF
--- a/libs/blocks/ost/ost.js
+++ b/libs/blocks/ost/ost.js
@@ -197,7 +197,10 @@ export async function loadOstEnv() {
   searchParameters.delete('exclusive');
   defaultPlaceholderOptions.forceTaxExclusive = exclusive;
 
-  const searchOfferSelectorId = searchParameters.get('osi');
+  const osiParam = searchParameters.get('osi') ?? '';
+  const osiParts = osiParam.split(',');
+  const searchOfferSelectorId = osiParts[0] || undefined;
+  const initialReferenceOsi = osiParts[1] || undefined;
   searchParameters.delete('osi');
 
   [
@@ -311,6 +314,7 @@ export async function loadOstEnv() {
     language,
     searchParameters: ostSearchParameters,
     searchOfferSelectorId,
+    initialReferenceOsi,
     defaultPlaceholderOptions,
     wcsApiKey: WCS_API_KEY,
     ctaTextOption,


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-190760

Split the comma-separated `osi` URL parameter into `searchOfferSelectorId` and `initialReferenceOsi` so the OST correctly populates the discount reference OSI field when re-opening a dual-OSI discount.

## Changes

- `libs/blocks/ost/ost.js`: Parse `osi` param by comma, pass `initialReferenceOsi` to OST config

## Test URLs

- Before: https://main--milo--adobecom.aem.live/tools/ost
- After: https://mwpw-190760--milo--adobecom.aem.live/tools/ost

## Checklist

- [x] Code follows project conventions
- [x] Backward compatible (single OSI still works)
- [x] Tested with dual-OSI discount param

