### PR TITLE
MWPW-189756 Add semantic headings to region-nav modal (WCAG 1.3.1)

### DIFF
--- a/libs/blocks/region-nav/region-nav.css
+++ b/libs/blocks/region-nav/region-nav.css
@@ -1,12 +1,15 @@
 
 .region-nav > div:nth-of-type(2) > div > p,
+.region-nav > div:nth-of-type(2) > div > h3,
 .region-nav > div:nth-of-type(2) > div > ul li {
   line-height: 1.7;
 }
 
-.region-nav > div:nth-of-type(2) > div > p {
+.region-nav > div:nth-of-type(2) > div > p,
+.region-nav > div:nth-of-type(2) > div > h3 {
   font-size: 16px;
-  margin-bottom: 0;
+  margin: 0 0 0;
+  font-weight: bold;
 }
 
 .region-nav > div:first-of-type {
@@ -19,19 +22,26 @@
   position: relative;
 }
 
-.region-nav > div:first-of-type > div > p {
+.region-nav > div:first-of-type > div > p,
+.region-nav > div:first-of-type > div > h2 {
   margin: 0 0 4px;
 }
-
-.region-nav > div:first-of-type > div > p:first-of-type {
+.region-nav > div:first-of-type h2 {
   font-size: 24px;
+  font-weight: bold;
+}
+
+.region-nav > div:first-of-type h2 + p {
+  font-size: 16px;
+  font-weight: normal;
 }
 
 .region-nav > div:first-of-type > p:last-of-type {
   margin-bottom: 0;
 }
 
-.region-nav > div:nth-of-type(2) > div > p:first-of-type {
+.region-nav > div:nth-of-type(2) > div > p:first-of-type,
+.region-nav > div:nth-of-type(2) > div > h3:first-of-type {
   margin-top: 0;
 }
 

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -104,6 +104,36 @@ export default async function init(block) {
   config = getConfig();
   const divs = block.querySelectorAll(':scope > div');
   if (divs.length < 2) return;
+  // Ensure the modal title is a proper h2 heading
+  /*const titleDiv = divs[0];
+  const titleStrong = titleDiv.querySelector('strong');
+  if (titleStrong && !titleDiv.querySelector('h2')) {
+    const h2 = document.createElement('h2');
+    h2.textContent = titleStrong.textContent;
+    h2.className = titleStrong.className;
+    titleStrong.replaceWith(h2);
+  }*/
+    const titleStrong = divs[0].querySelector('strong');
+    const titleP = titleStrong?.closest('p');
+    if (titleStrong && !divs[0].querySelector('h2')) {
+    const h2 = document.createElement('h2');
+    h2.textContent = titleStrong.textContent;
+    h2.className = titleStrong.className;
+    if (titleP) {
+    titleP.replaceWith(h2);
+    } else {
+    titleStrong.replaceWith(h2);
+  }
+}
+  // Convert region group headers from <p><strong> to <h3>
+  const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');
+  regionHeaders.forEach((strong) => {
+    const p = strong.parentElement;
+    const h3 = document.createElement('h3');
+    h3.textContent = strong.textContent;
+    h3.className = strong.className;
+    p.replaceWith(h3);
+  });
   const links = divs[1].querySelectorAll('a');
   if (!links.length) return;
   const { prefix } = config.locale;

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -1,5 +1,5 @@
 import {
-  getConfig, getLanguage, getLocale, loadLanguageConfig, setInternational, getCountry,
+  getConfig, getLanguage, getLocale, loadLanguageConfig, setInternational, getCountry, createTag
 } from '../../utils/utils.js';
 
 let config;
@@ -104,34 +104,21 @@ export default async function init(block) {
   config = getConfig();
   const divs = block.querySelectorAll(':scope > div');
   if (divs.length < 2) return;
-  // Ensure the modal title is a proper h2 heading
-  /*const titleDiv = divs[0];
-  const titleStrong = titleDiv.querySelector('strong');
-  if (titleStrong && !titleDiv.querySelector('h2')) {
-    const h2 = document.createElement('h2');
-    h2.textContent = titleStrong.textContent;
-    h2.className = titleStrong.className;
-    titleStrong.replaceWith(h2);
-  }*/
-    const titleStrong = divs[0].querySelector('strong');
-    const titleP = titleStrong?.closest('p');
-    if (titleStrong && !divs[0].querySelector('h2')) {
-    const h2 = document.createElement('h2');
-    h2.textContent = titleStrong.textContent;
-    h2.className = titleStrong.className;
+  const titleStrong = divs[0].querySelector('strong');
+  const titleP = titleStrong?.closest('p');
+  if (titleStrong && !divs[0].querySelector('h2')) {
+    const h2 = createTag('h2', { class: titleStrong.className }, titleStrong.textContent);
     if (titleP) {
-    titleP.replaceWith(h2);
+      titleP.replaceWith(h2);
     } else {
-    titleStrong.replaceWith(h2);
+      titleStrong.replaceWith(h2);
+    }
   }
-}
   // Convert region group headers from <p><strong> to <h3>
   const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');
   regionHeaders.forEach((strong) => {
     const p = strong.parentElement;
-    const h3 = document.createElement('h3');
-    h3.textContent = strong.textContent;
-    h3.className = strong.className;
+    const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() }, strong.textContent);
     p.replaceWith(h3);
   });
   const links = divs[1].querySelectorAll('a');

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -1,5 +1,5 @@
 import {
-  getConfig, getLanguage, getLocale, loadLanguageConfig, setInternational, getCountry, createTag
+  getConfig, getLanguage, getLocale, loadLanguageConfig, setInternational, getCountry, createTag,
 } from '../../utils/utils.js';
 
 let config;

--- a/test/blocks/region-nav/mocks/regions.html
+++ b/test/blocks/region-nav/mocks/regions.html
@@ -1,29 +1,36 @@
 <div>
   <div class="region-nav">
-    <div><h3>title</h3></div>
     <div>
-      <p><strong>Americas</strong></p>
-      <ul>
-        <li><a href="/ar/">Argentina</a></li>
-        <li><a href="/br/path/to/page">Brasil</a></li>
-        <li><a href="/">United States</a></li>
-      </ul>
-      <p><strong>Europe, Middle East and Africa</strong></p>
-      <ul>
-        <li><a href="/africa/">Africa - English</a></li>
-        <li><a href="/ch_de/path/to/page">Schweiz</a></li>
-        <li><a href="/ch_fr/path/to/page">Suisse</a></li>
-        <li><a href="https:adobe.com/ru/">Россия</a></li>
-        <li><a href="/ua/">Україна</a></li>
-        <li><a href="/il_he/">ישראל - עברית</a></li>
-        <li><a href="/sa_ar/">المملكة العربية السعودية</a></li>
-      </ul>
-      <p><strong>Asia Pacific</strong></p>
-      <ul>
-        <li><a href="/au/path/to/page">Australia</a></li>
-        <li><a href="/my_ms/">Malaysia</a></li>
-        <li><a href="/kr/">한국</a></li>
-      </ul>
+      <div>
+        <p><strong>Choose your region</strong></p>
+        <p>Selecting a region changes the language and/or content on Adobe.com.</p>
+      </div>
+    </div>
+    <div>
+      <div>
+        <p><strong>Americas</strong></p>
+        <ul>
+          <li><a href="/ar/">Argentina</a></li>
+          <li><a href="/br/path/to/page">Brasil</a></li>
+          <li><a href="/">United States</a></li>
+        </ul>
+        <p><strong>Europe, Middle East and Africa</strong></p>
+        <ul>
+          <li><a href="/africa/">Africa - English</a></li>
+          <li><a href="/ch_de/path/to/page">Schweiz</a></li>
+          <li><a href="/ch_fr/path/to/page">Suisse</a></li>
+          <li><a href="https:adobe.com/ru/">Россия</a></li>
+          <li><a href="/ua/">Україна</a></li>
+          <li><a href="/il_he/">ישראל - עברית</a></li>
+          <li><a href="/sa_ar/">المملكة العربية السعودية</a></li>
+        </ul>
+        <p><strong>Asia Pacific</strong></p>
+        <ul>
+          <li><a href="/au/path/to/page">Australia</a></li>
+          <li><a href="/my_ms/">Malaysia</a></li>
+          <li><a href="/kr/">한국</a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -30,6 +30,25 @@ describe('Region Nav Block', async () => {
     sinon.restore();
   });
 
+  it('converts modal title <strong> to <h2> for accessibility', () => {
+    const h2 = block.querySelector(':scope > div:first-of-type h2');
+    expect(h2).to.exist;
+    expect(h2.textContent.trim()).to.equal('Choose your region');
+  });
+
+  it('converts region group <p><strong> headers to <h3> for accessibility', () => {
+    const h3s = [...block.querySelectorAll(':scope > div:nth-of-type(2) h3')];
+    expect(h3s).to.have.length(3);
+    expect(h3s[0].textContent.trim()).to.equal('Americas');
+    expect(h3s[1].textContent.trim()).to.equal('Europe, Middle East and Africa');
+    expect(h3s[2].textContent.trim()).to.equal('Asia Pacific');
+  });
+
+  it('does not leave any <p><strong> region headers after init', () => {
+    const remainingStrongHeaders = block.querySelectorAll(':scope > div:nth-of-type(2) p > strong');
+    expect(remainingStrongHeaders).to.have.length(0);
+  });
+
   it('sets links correctly', () => {
     const { contentRoot } = getConfig().locale;
     window.location.hash = 'langnav';


### PR DESCRIPTION
Fixes an accessibility issue where the “Choose your region” modal and other titles (Americas, EMEA,Asia Pacific) used visual headings (`<strong>` / `<p><strong>`) without proper heading semantics. 
Screen readers can now identify the title and regional sections as headings with an appropriate hierarchy.

Resolves: [MWPW-189756](https://jira.corp.adobe.com/browse/MWPW-189756)

**Test URL:**
https://main--homepage--adobecom.aem.live/homepage/index-loggedout?milolibs=region-nav-heading-semantics--milo--KetakiD-Deshwandikar#langnav

<img width="1728" height="1117" alt="Screenshot 2026-03-30 at 11 29 40 AM" src="https://github.com/user-attachments/assets/1fd5c3f0-5a91-4a24-b0b5-0d76690e32f7" />
<img width="1902" height="973" alt="image" src="https://github.com/user-attachments/assets/65d2e2e8-8dd2-4f13-8fdf-0febf6d4c66b" />




<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- Milo: https://region-nav-heading-semantics--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- Milo: https://region-nav-heading-semantics--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- Milo: https://region-nav-heading-semantics--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=region-nav-heading-semantics--milo--adobecom
</details>