### PR TITLE
MWPW-191588 [MEP] Fix federal URL normalization in normalizePath and decorateMeta

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -118,7 +118,9 @@ export const normalizePath = (p, localize = true) => {
         || path?.includes('.json')) {
         path = pathname;
       } else {
-        path = `${config.locale.prefix}${normalizePath(pathname)}`;
+        path = isFederal
+          ? `${config.locale.prefix}${pathname}`
+          : `${config.locale.prefix}${normalizePath(pathname)}`;
       }
     }
     path = isFederal ? getFederatedUrl(path) : path;

--- a/test/features/personalization/normalizePath.test.js
+++ b/test/features/personalization/normalizePath.test.js
@@ -54,4 +54,28 @@ describe('normalizePath function', () => {
     const path = await normalizePath('https://main--milo--adobecom.aem.page/path/to/fragment.plain.html');
     expect(path).to.equal('/de/path/to/fragment.plain.html');
   });
+
+  it('localizes federal URLs with locale prefix and preserves federal origin', async () => {
+    config.locales = {
+      de: {
+        ietf: 'de-DE',
+        prefix: '/de',
+      },
+    };
+    config.locale = config.locales.de;
+    const federalUrl = 'https://main--federal--adobecom.aem.page/federal/globalnav/acom/fragments/promos/test-promo';
+    const path = await normalizePath(federalUrl);
+    expect(path).to.include('/de/federal/globalnav/acom/fragments/promos/test-promo');
+    expect(path).to.include('federal--adobecom.aem.page');
+    expect(path).not.to.include('/de/https://');
+  });
+
+  it('does not localize federal URLs for en-US locale', async () => {
+    config.locale = { ietf: 'en-US', prefix: '' };
+    const federalUrl = 'https://main--federal--adobecom.aem.page/federal/globalnav/acom/fragments/promos/test-promo';
+    const path = await normalizePath(federalUrl);
+    expect(path).to.include('federal--adobecom.aem.page');
+    expect(path).to.include('/federal/globalnav/acom/fragments/promos/test-promo');
+    expect(path).not.to.include('/de/');
+  });
 });


### PR DESCRIPTION
**Update**: Since #5680 now has the "ready for stage" label, I've added "do not merge" to this PR. Once #5680 lands on stage, I'll rebase to pull in those updates, drop the utils.js / decorateMetadata-related changes (only the personalization.js updates will be needed at that point), and remove the "do not merge" label.

**Summary**
- Fix normalizePath to correctly handle federal URLs by applying the locale prefix directly to the pathname instead of through a recursive call that re-federalized the path into an absolute URL, producing malformed meta content
- Add gnav-promo-source to decorateMeta ignore lists in both loadPostLCP and decorateDocumentExtras to prevent localizeLinkAsync from independently mangling the federal URL through the async lingo block
- Add unit tests for federal URL normalization with and without locale prefix
**Context**
- This issue surfaced from the interaction of two earlier changes — the decorateMeta call-site split (MWPW-179494) and updateMetadata link normalization (MWPW-190350). Together they exposed two independent code paths that both produce malformed results for federal meta tags like gnav-promo-source.

**Root Cause**
Two separate code paths independently mangle the gnav-promo-source federal URL:

1. normalizePath (personalization.js): When processing a federal URL (e.g., from an updateMetadata manifest action), the recursive normalizePath(pathname) call hits a catch block that converts the relative pathname back to an absolute federal URL via getFederatedUrl. This absolute URL is then concatenated with the locale prefix, producing a malformed path like /th_enhttps://main--federal--adobecom.aem.page/federal/....

2. decorateMeta (utils.js): After the call-site split, gnav-promo-source was no longer in an ignore list. decorateMeta calls localizeLinkAsync with no anchor element, which on stage enters the async lingo block and prepends the locale prefix to the federal pathname, independently producing a mangled URL.

Both fixes are required on stage today. Note: PR #5680 (Lingo - Smart localize links) adds an aTag guard to the async lingo entry condition, which implicitly fixes path 2 by preventing decorateMeta from entering the lingo block. Once that merges, the ignoreNames changes become moot, but the normalizePath fix remains necessary.

**Steps to QA:**
1. Navigate to Before and After Test URLs below:
2. Open mep button to confirm the only active manifest is updatemetadataissue.json
3. observe promo bar area
4. observe metadata value for gnav-promo-source in the head (inspect in chrome dev tools)
Expected Promo bar: "Checkout with TrueMoney and save up to 40% on select plans including CC Pro and Photoshop. Ends April 27."
Expected metadata for gnav-promo-source:  https://main--federal--adobecom.aem.page/th_en/federal/globalnav/acom/fragments/promos/2026/apac/apac-promo-truemoney-th-2026/truemoney-gnav-promobar
Actual Promo bar: none
Actual gnav-promo-source: https://main--upp--adobecom.aem.page/th_en/th_enhttps://main--federal--adobecom.aem.page/federal/globalnav/acom/fragments/promos/2026/apac/apac-promo-truemoney-th-2026/truemoney-gnav-promobar



Resolves: [MWPW-191588](https://jira.corp.adobe.com/browse/MWPW-191588)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/th_en/homepage/index-loggedout?mep=%2Fhomepage%2Fmanifests%2F2026%2Fapac%2Fq2-promos%2Fth-truemoney-digital-wallet-promo-178412.json--default---%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fff-go-big%2Fff-go-big-180706.json--default---%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fnab-premiere-q226%2Fnab-premiere-q226-179538.json--default---%2Fdrafts%2Fmepdev%2Fupdatemetadataissue.json--all---%2Fcc-shared%2Ffragments%2Ftests%2F2025%2Fq1%2Ffix-pod-height%2Ffix-pod-height.json--default
- After: https://main--upp--adobecom.aem.page/th_en/homepage/index-loggedout?mep=%2Fhomepage%2Fmanifests%2F2026%2Fapac%2Fq2-promos%2Fth-truemoney-digital-wallet-promo-178412.json--default---%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fff-go-big%2Fff-go-big-180706.json--default---%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fnab-premiere-q226%2Fnab-premiere-q226-179538.json--default---%2Fdrafts%2Fmepdev%2Fupdatemetadataissue.json--all---%2Fcc-shared%2Ffragments%2Ftests%2F2025%2Fq1%2Ffix-pod-height%2Ffix-pod-height.json--default&milolibs=mepgnavpromosourcefix
- PSI-check: https://mepgnavpromosourcefix--milo--adobecom.aem.page/?martech=off




