### PR TITLE
[SR] Router marquee performance tweaks

### DIFF
--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -314,6 +314,7 @@ const startAutoplay = (slides, cards, container, block) => {
   let timer = null; // timer for the autoplay
   let paused = false; // whether the autoplay is paused
   let userPaused = false; // whether the user explicitly paused via the play/pause button
+  let offscreen = false; // whether the block is outside the viewport
   let cleanupTimer = null; // cleanup timer that resets temp inline styles
   let pendingSlide = null; // the slide that is currently transitioning in
   let leaveTimer = null; // timer for restarting autoplay on block mouse leave
@@ -428,6 +429,7 @@ const startAutoplay = (slides, cards, container, block) => {
   };
 
   const advance = () => {
+    if (paused) return;
     clearTimeout(timer);
     clearFill(active);
     activate((active + 1) % cardEls.length, 1);
@@ -436,8 +438,17 @@ const startAutoplay = (slides, cards, container, block) => {
     preloadNextVideo();
   };
 
+  const cancelLeaveTimer = () => {
+    clearTimeout(leaveTimer);
+    leaveTimer = null;
+  };
+
   const pause = () => {
     clearTimeout(timer);
+    clearTimeout(cleanupTimer);
+    cleanupTimer = null;
+    cancelLeaveTimer();
+    finishSlideTransition();
     clearFill(active);
     paused = true;
     setPlayingState(false);
@@ -445,21 +456,19 @@ const startAutoplay = (slides, cards, container, block) => {
   };
 
   const resume = () => {
+    if (offscreen) return;
     paused = false;
     userPaused = false;
     setPlayingState(true);
     startFill(active);
     timer = setTimeout(advance, AUTOPLAY_MS);
-    slides[active]?.querySelector('video')?.play().catch(() => {});
-  };
-
-  const cancelLeaveTimer = () => {
-    clearTimeout(leaveTimer);
-    leaveTimer = null;
+    const vid = slides[active]?.querySelector('video');
+    loadVideo(vid);
+    vid?.play().catch(() => {});
   };
 
   const startLeaveTimer = () => {
-    if (leaveTimer || userPaused) return;
+    if (leaveTimer || userPaused || offscreen) return;
     leaveTimer = setTimeout(() => {
       leaveTimer = null;
       resume();
@@ -568,10 +577,23 @@ const startAutoplay = (slides, cards, container, block) => {
   }, { passive: true });
 
   requestAnimationFrame(() => {
+    if (paused) return;
     startFill(active);
     timer = setTimeout(advance, AUTOPLAY_MS);
     preloadNextVideo();
   });
+
+  return {
+    setVisible: (isVisible) => {
+      if (!isVisible) {
+        offscreen = true;
+        pause();
+      } else {
+        offscreen = false;
+        if (!userPaused && paused) resume();
+      }
+    },
+  };
 };
 
 const buildViewport = (viewport, slides) => {
@@ -610,6 +632,7 @@ export default function init(el) {
   const containers = Object.entries(viewports).map(([vp, slides]) => buildViewport(vp, slides));
   el.replaceChildren(...containers);
   const initializedVps = new Set();
+  const autoplayControllers = [];
   const initViewportAutoplay = () => {
     const activeVp = getActiveViewport();
     if (initializedVps.has(activeVp)) return;
@@ -618,7 +641,7 @@ export default function init(el) {
     if (!container) return;
     const slides = container.querySelectorAll('.rm-slide');
     const cards = container.querySelector('.rm-cards');
-    startAutoplay(slides, cards, container, el);
+    autoplayControllers.push(startAutoplay(slides, cards, container, el));
   };
 
   loadViewportVideos(el);
@@ -629,4 +652,33 @@ export default function init(el) {
     loadViewportVideos(el);
     initViewportAutoplay();
   });
+
+  // Pause/resume based on scroll position. The router-marquee fills the viewport at
+  // the top of the page. Once the user has scrolled past half the viewport height,
+  // the block is considered offscreen. window.scrollY is reliable regardless of
+  // whether Lenis or native scroll is driving the animation.
+  let visibilityPaused = false;
+
+  const checkVisibility = () => {
+    const isVisible = window.scrollY < window.innerHeight / 2;
+    if (!isVisible && !visibilityPaused) {
+      visibilityPaused = true;
+      autoplayControllers.forEach((ctrl) => ctrl.setVisible(false));
+    } else if (isVisible && visibilityPaused) {
+      visibilityPaused = false;
+      autoplayControllers.forEach((ctrl) => ctrl.setVisible(true));
+    }
+  };
+
+  // Lenis loads after blocks, so window.lenis isn't set at init() time.
+  // On the first native scroll event, swap to lenis.on() if available so
+  // subsequent visibility checks run inside Lenis's RAF loop.
+  function onScroll() {
+    if (window.lenis) {
+      window.removeEventListener('scroll', onScroll);
+      window.lenis.on('scroll', checkVisibility);
+    }
+    checkVisibility();
+  }
+  window.addEventListener('scroll', onScroll, { passive: true });
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2080,6 +2080,15 @@ async function loadPostLCP(config) {
       lerp,
       prevent: (node) => lenisPreventClasses.some((cls) => node.classList?.contains(cls)),
     });
+    // Reduce inertia during fast scrolling to avoid sustained RAF CPU usage
+    let fastScrollTimer;
+    window.addEventListener('wheel', (e) => {
+      if (Math.abs(e.deltaY) > 70) {
+        window.lenis.options.lerp = 0.6;
+        clearTimeout(fastScrollTimer);
+        fastScrollTimer = setTimeout(() => { window.lenis.options.lerp = lerp; }, 300);
+      }
+    }, { passive: true });
   }
   // load privacy here if quick-link is present in first section
   const quickLink = document.querySelector('div.section')?.querySelector('.quick-link');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Reduce inertia during fast scrolling to avoid sustained RAF CPU usage
* Pause auto rotation and video playing when scrolling the router marquee out of view. This also stop the background loading that continues to happen even when viewing content lower on the page.

For the 2nd bullet point open up dev tools network tab and watch the media.mp4's stop loading when the router marquee scrolls out of view. This was using extra cpu resources while scrolling down the page. The cpu seems to spin up less. Give it a look. 

Details around the first bullet point:
How it works:

- `deltaY > 80` — threshold for “fast” scroll (a typical slow scroll is ~30–50, fast flick is 100+). Tune as needed.
- `lerp = 0.4` — during fast scroll, Lenis converges ~5x faster to the target position, so the RAF loop idles sooner instead of easing for hundreds of ms.
- After 300ms of no fast-scroll events, lerp resets to the original smooth value.
- Why this helps CPU: Lenis’s RAF loop runs on every frame until Math.abs(velocity) < threshold. With lerp = 0.08, a fast fling can keep it running for 1–2 seconds per gesture. At lerp = 0.4, it converges in a few frames.

**Tuning knobs if needed:**
Raise 80 threshold if it kicks in too eagerly on normal scrolling
Lower 0.4 toward 1.0 for even less inertia on fast scroll (1.0 = instant, no smoothing)

Raise 300 debounce if the smooth feel is snapping back too soon during continuous fast scroll


**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=site-redesign-foundation&martech=off
- After: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=rm-performance-tweaks&martech=off


