### PR TITLE
MWPW-191696 (Direct to main) [MEP] Move metadata update before callback so that it is not asynchronous

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -430,13 +430,12 @@ function updateFramework(updateFrameworkList) {
   const existing = document.head.querySelector(
     `link[href^="${libsPath}"][href$="/styles/styles.css"]`,
   );
+  setMetadata({ selector: 'foundation', val: fwVal });
   const stylesPrefix = fwVal === 'c1' ? '' : `/${fwVal}`;
   loadLink(`${libsPath}${stylesPrefix}/styles/styles.css`, {
     rel: 'stylesheet',
     callback: (status) => {
-      if (status !== 'load') return;
-      existing?.remove();
-      setMetadata({ selector: 'foundation', val: fwVal });
+      if (status === 'load') existing?.remove();
     },
   });
 }


### PR DESCRIPTION
direct to main version

move call of updateMetadata in updateFramework to be outside of the callback so that it's synchronous
Resolves: [MWPW-191696](https://jira.corp.adobe.com/browse/MWPW-191696)

Test URLs:

Before: https://main--upp--adobecom.aem.page/homepage/index-loggedout?mep=%2Fhomepage%2Ffragments%2Fmep%2Fhp-03-19-26-hp-ff-unlimited-updates-psnlz.json--default---%2Fhomepage%2Ffragments%2Fmep%2Fhp-alt-ace1201-pzns.json--target-apro-twp-abdn---%2Fupp-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1165.json--default---%2Fhomepage%2Ffragments%2Floggedout%2Ftests%2F2026%2Fq2%2Fsite-redesign%2Fsite-redesign.json--target-var1
After: https://main--upp--adobecom.aem.page/homepage/index-loggedout?milolibs=setmetadatasync&mep=%2Fhomepage%2Ffragments%2Fmep%2Fhp-03-19-26-hp-ff-unlimited-updates-psnlz.json--default---%2Fhomepage%2Ffragments%2Fmep%2Fhp-alt-ace1201-pzns.json--target-apro-twp-abdn---%2Fupp-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1165.json--default---%2Fhomepage%2Ffragments%2Floggedout%2Ftests%2F2026%2Fq2%2Fsite-redesign%2Fsite-redesign.json--target-var1
Psi-check: https://setmetadatasync--milo--adobecom.aem.page/?martech=off


