### PR TITLE
[MWPW-191784] Update to clear block on market config failure 

### DIFF
--- a/libs/blocks/market-selector/market-selector.js
+++ b/libs/blocks/market-selector/market-selector.js
@@ -634,10 +634,16 @@ function createDropdown(
 
 export default async function init(block) {
   const config = await getMarketConfig();
-  if (!config || !config.languages?.length) return;
+  if (!config || !config.languages?.length) {
+    block.innerHTML = '';
+    return;
+  }
 
   const markets = await loadMarketsData();
-  if (!markets?.length) return;
+  if (!markets?.length) {
+    block.innerHTML = '';
+    return;
+  }
 
   const placeholders = block.querySelectorAll('p');
   const labels = {


### PR DESCRIPTION
Updating to clear market-selector block on supported-markets or markets config failure 

Resolves: [MWPW-191784](https://jira.corp.adobe.com/browse/MWPW-191784)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://acom-market--milo--adobecom.aem.page/?martech=off


