### PR TITLE
[MWPW-190455] - Action item a11y

### DIFF
--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -119,6 +119,7 @@ export default function init(el) {
   el.replaceChildren(items, ...buttons);
   if (hasNav) {
     handleBtnState(items, buttons);
+    if (!items.querySelectorAll('a').length) items.setAttribute('aria-hidden', 'true');
     allActionScrollers.push({ scroller: items, buttons });
     import('../../utils/action.js').then(({ debounce }) => {
       items.addEventListener('scroll', debounce(() => handleBtnState(items, buttons), 50));
@@ -127,10 +128,9 @@ export default function init(el) {
       window.addEventListener('resize', debounce(handleResize, 50));
     });
   }
+
   if (items.querySelectorAll('a').length) {
     items.setAttribute('role', 'list');
     actions.forEach((action) => action.setAttribute('role', 'listitem'));
-  } else {
-    items.setAttribute('aria-hidden', 'true');
   }
 }

--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -127,6 +127,10 @@ export default function init(el) {
       window.addEventListener('resize', debounce(handleResize, 50));
     });
   }
-  items.setAttribute('role', 'list');
-  actions.forEach((action) => action.setAttribute('role', 'listitem'));
+  if (items.querySelectorAll('a').length) {
+    items.setAttribute('role', 'list');
+    actions.forEach((action) => action.setAttribute('role', 'listitem'));
+  } else {
+    items.setAttribute('tabindex', 0);
+  }
 }

--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -131,6 +131,6 @@ export default function init(el) {
     items.setAttribute('role', 'list');
     actions.forEach((action) => action.setAttribute('role', 'listitem'));
   } else {
-    items.setAttribute('tabindex', 0);
+    items.setAttribute('aria-hidden', 'true');
   }
 }

--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -119,7 +119,6 @@ export default function init(el) {
   el.replaceChildren(items, ...buttons);
   if (hasNav) {
     handleBtnState(items, buttons);
-    if (!items.querySelectorAll('a').length) items.setAttribute('tabindex', 0);
     allActionScrollers.push({ scroller: items, buttons });
     import('../../utils/action.js').then(({ debounce }) => {
       items.addEventListener('scroll', debounce(() => handleBtnState(items, buttons), 50));

--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -119,7 +119,7 @@ export default function init(el) {
   el.replaceChildren(items, ...buttons);
   if (hasNav) {
     handleBtnState(items, buttons);
-    if (!items.querySelectorAll('a').length) items.setAttribute('aria-hidden', 'true');
+    if (!items.querySelectorAll('a').length) items.setAttribute('tabindex', 0);
     allActionScrollers.push({ scroller: items, buttons });
     import('../../utils/action.js').then(({ debounce }) => {
       items.addEventListener('scroll', debounce(() => handleBtnState(items, buttons), 50));

--- a/libs/blocks/action-scroller/action-scroller.js
+++ b/libs/blocks/action-scroller/action-scroller.js
@@ -119,7 +119,7 @@ export default function init(el) {
   el.replaceChildren(items, ...buttons);
   if (hasNav) {
     handleBtnState(items, buttons);
-    if (!items.querySelectorAll('a').length) items.setAttribute('tabindex', 0);
+    if (!items.querySelectorAll('a').length) items.setAttribute('aria-hidden', 'true');
     allActionScrollers.push({ scroller: items, buttons });
     import('../../utils/action.js').then(({ debounce }) => {
       items.addEventListener('scroll', debounce(() => handleBtnState(items, buttons), 50));

--- a/test/blocks/action-scroller/action-scroller.test.js
+++ b/test/blocks/action-scroller/action-scroller.test.js
@@ -70,7 +70,7 @@ describe('action scrollers', () => {
       init(el);
       const scroller = el.querySelector('.scroller');
       expect(scroller.getAttribute('aria-hidden')).to.equal('true');
-      expect(scroller.getAttribute('tabindex')).to.be.null;
+      expect(scroller.getAttribute('tabindex')).to.equal('-1');
     });
   });
 

--- a/test/blocks/action-scroller/action-scroller.test.js
+++ b/test/blocks/action-scroller/action-scroller.test.js
@@ -70,7 +70,7 @@ describe('action scrollers', () => {
       init(el);
       const scroller = el.querySelector('.scroller');
       expect(scroller.getAttribute('aria-hidden')).to.equal('true');
-      expect(scroller.getAttribute('tabindex')).to.equal('-1');
+      expect(scroller.getAttribute('tabindex')).to.be.null;
     });
   });
 

--- a/test/blocks/action-scroller/action-scroller.test.js
+++ b/test/blocks/action-scroller/action-scroller.test.js
@@ -64,6 +64,15 @@ describe('action scrollers', () => {
     });
   });
 
+  describe('action scroller no-links', () => {
+    it('does not set tabindex on scroller when there are no links', () => {
+      const el = document.querySelector('.action-scroller.no-links');
+      init(el);
+      const scroller = el.querySelector('.scroller');
+      expect(scroller.getAttribute('tabindex')).to.be.null;
+    });
+  });
+
   describe('Helper functions', () => {
     it('Should return element style properties', () => {
       const el = document.querySelector('.action-scroller.utility');

--- a/test/blocks/action-scroller/action-scroller.test.js
+++ b/test/blocks/action-scroller/action-scroller.test.js
@@ -65,11 +65,15 @@ describe('action scrollers', () => {
   });
 
   describe('action scroller no-links', () => {
-    it('does not set tabindex on scroller when there are no links', () => {
+    it('sets tabindex but no list role when there are no links', () => {
       const el = document.querySelector('.action-scroller.no-links');
       init(el);
       const scroller = el.querySelector('.scroller');
-      expect(scroller.getAttribute('tabindex')).to.be.null;
+      expect(scroller.getAttribute('tabindex')).to.equal('0');
+      expect(scroller.getAttribute('role')).to.be.null;
+      scroller.querySelectorAll('.action-item').forEach((item) => {
+        expect(item.getAttribute('role')).to.be.null;
+      });
     });
   });
 

--- a/test/blocks/action-scroller/action-scroller.test.js
+++ b/test/blocks/action-scroller/action-scroller.test.js
@@ -65,15 +65,12 @@ describe('action scrollers', () => {
   });
 
   describe('action scroller no-links', () => {
-    it('sets tabindex but no list role when there are no links', () => {
+    it('hides scroller from accessibility tree when there are no links', () => {
       const el = document.querySelector('.action-scroller.no-links');
       init(el);
       const scroller = el.querySelector('.scroller');
-      expect(scroller.getAttribute('tabindex')).to.equal('0');
-      expect(scroller.getAttribute('role')).to.be.null;
-      scroller.querySelectorAll('.action-item').forEach((item) => {
-        expect(item.getAttribute('role')).to.be.null;
-      });
+      expect(scroller.getAttribute('aria-hidden')).to.equal('true');
+      expect(scroller.getAttribute('tabindex')).to.be.null;
     });
   });
 

--- a/test/blocks/action-scroller/action-scroller.test.js
+++ b/test/blocks/action-scroller/action-scroller.test.js
@@ -20,7 +20,7 @@ describe('action scrollers', () => {
     ]);
   });
 
-  const actionScroller = document.querySelectorAll('.action-scroller:not(.utility)');
+  const actionScroller = document.querySelectorAll('.action-scroller:not(.utility):not(.no-links)');
   actionScroller.forEach((scroller) => {
     init(scroller);
 

--- a/test/blocks/action-scroller/mocks/body.html
+++ b/test/blocks/action-scroller/mocks/body.html
@@ -195,6 +195,28 @@
     </div>
   </div>
   <div>
+    <div class="action-scroller navigation no-links">
+      <div>
+        <div>Item width</div>
+        <div>110</div>
+      </div>
+    </div>
+    <div class="action-item">
+      <div>
+        <picture>
+          <img loading="lazy" alt="Image one" src="" width="178" height="180">
+        </picture>
+      </div>
+    </div>
+    <div class="action-item">
+      <div>
+        <picture>
+          <img loading="lazy" alt="Image two" src="" width="178" height="180">
+        </picture>
+      </div>
+    </div>
+  </div>
+  <div>
     <div class="action-scroller navigation utility">
       <div>
         <div>Item width</div>


### PR DESCRIPTION
This PR addresses an issue for action-scroller where just list is read out and sometimes some list items are randomly announced.

After consultation with our a11y consultant it has been confirmed that if items aren't interactable they shouldn't be in a list.
One thing that required a change after we removed `role=list` is changing from `tabIndex=0` to `aria-hidden=true` in order to preserve the fix from this PR https://github.com/adobecom/milo/pull/4461 and for the screenreader to read out all of the alt names from images when tabbed to in this use case.
The action-scroller element is tabable by default because it has overflow which browsers automatically add to the list of tabable elements.

Resolves: [MWPW-190455](https://jira.corp.adobe.com/browse/MWPW-190455)

**PSI Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://action-item-a11y--milo--adobecom.aem.page/?martech=off

**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/products/express-business
- After: https://main--da-bacom--adobecom.aem.live/products/express-business?milolibs=action-item-a11y







