### PR TITLE
MWPW-191596: guardrails on bulk publisher

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -685,6 +685,7 @@ async function getLingoSiteLocale(origin, path, fqdn = 'www.adobe.com') {
       tags: 'caas',
       severity: 'error',
     });
+    lingoSiteMapping.fromFallback = true;
   }
   return lingoSiteMapping;
 }
@@ -693,6 +694,7 @@ export const getLanguageFirstCountryAndLang = async (path, origin, fqdn) => {
   const localeArr = path.split('/');
   let langStr = 'en';
   let countryStr = 'xx';
+  let fromFallback = false;
   if (origin.toLowerCase() === 'news') {
     langStr = LANGS[localeArr[1]] ?? LANGS[''] ?? 'en';
     countryStr = LOCALES[localeArr[2]] ?? 'xx';
@@ -701,6 +703,7 @@ export const getLanguageFirstCountryAndLang = async (path, origin, fqdn) => {
     }
   } else {
     const mapping = await getLingoSiteLocale(origin, path, fqdn);
+    fromFallback = mapping.fromFallback === true;
     countryStr = LOCALES[mapping.country.toLowerCase()] ?? 'xx';
     if (typeof countryStr === 'object') {
       countryStr = countryStr.ietf?.split('-')[1] ?? 'xx';
@@ -710,6 +713,7 @@ export const getLanguageFirstCountryAndLang = async (path, origin, fqdn) => {
   return {
     country: countryStr.toLowerCase(),
     lang: langStr.toLowerCase(),
+    ...(fromFallback && { fromFallback: true }),
   };
 };
 

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -551,11 +551,19 @@ const isLocaleInRegionalSites = (regionalSites, locStr, langStr) => {
   );
 };
 
+let lingoSiteMappingCache;
+async function fetchLingoSiteMapping(fqdn = 'www.adobe.com') {
+  if (!lingoSiteMappingCache) {
+    const response = await fetch(`https://www.adobe.com/federal/assets/data/lingo-site-mapping.json?${fqdn}`);
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    lingoSiteMappingCache = await response.json();
+  }
+  return lingoSiteMappingCache;
+}
+
 async function getIsLingoLocale(origin, country, language, fqdn = 'www.adobe.com') {
   if (origin === 'news') return true;
-  const response = await fetch(`https://www.adobe.com/federal/assets/data/lingo-site-mapping.json?${fqdn}`);
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  const configJson = await response.json();
+  const configJson = await fetchLingoSiteMapping(fqdn);
 
   let siteId;
   let isKnownLingoSiteLocale = false;
@@ -632,9 +640,7 @@ async function getLingoSiteLocale(origin, path, fqdn = 'www.adobe.com') {
 
   try {
     let siteId;
-    const response = await fetch(`https://www.adobe.com/federal/assets/data/lingo-site-mapping.json?${fqdn}`);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const configJson = await response.json();
+    const configJson = await fetchLingoSiteMapping(fqdn);
 
     const siteQueryIndexMap = configJson['site-query-index-map']?.data ?? [];
     const siteLocalesData = configJson['site-locales']?.data ?? [];

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -551,14 +551,16 @@ const isLocaleInRegionalSites = (regionalSites, locStr, langStr) => {
   );
 };
 
-let lingoSiteMappingCache;
-async function fetchLingoSiteMapping(fqdn = 'www.adobe.com') {
-  if (!lingoSiteMappingCache) {
-    const response = await fetch(`https://www.adobe.com/federal/assets/data/lingo-site-mapping.json?${fqdn}`);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    lingoSiteMappingCache = await response.json();
+let lingoSiteMappingPromise;
+function fetchLingoSiteMapping(fqdn = 'www.adobe.com') {
+  if (!lingoSiteMappingPromise) {
+    lingoSiteMappingPromise = fetch(`https://www.adobe.com/federal/assets/data/lingo-site-mapping.json?${fqdn}`)
+      .then((response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json();
+      });
   }
-  return lingoSiteMappingCache;
+  return lingoSiteMappingPromise;
 }
 
 async function getIsLingoLocale(origin, country, language, fqdn = 'www.adobe.com') {

--- a/test/blocks/caas/send-to-caas.test.js
+++ b/test/blocks/caas/send-to-caas.test.js
@@ -1,7 +1,14 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 
-import { checkUrl, getKeyValPairs, getOrigin, setConfig, getCaasProps } from '../../../tools/send-to-caas/send-utils.js';
+import {
+  checkUrl,
+  getKeyValPairs,
+  getOrigin,
+  runLanguageFirstRetry,
+  setConfig,
+  getCaasProps,
+} from '../../../tools/send-to-caas/send-utils.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
@@ -106,5 +113,54 @@ describe('getCaasProps function', () => {
     const result = getCaasProps(mockProps, invalidUrl);
     // Should not throw an error and should fall back to window.location behavior
     expect(result).to.have.property('entityId', 'test-entity-id');
+  });
+});
+
+describe('runLanguageFirstRetry (language-first retry)', () => {
+  const baseOptions = {
+    prodUrl: 'business.adobe.com/de/blog/some-page',
+    repo: 'bacom',
+    host: 'business.adobe.com',
+  };
+  const noDelay = { retryDelayMs: 0 };
+
+  it('returns immediately when resolver returns correct lang/country (no retry)', async () => {
+    const getLangFirst = async () => ({ country: 'xx', lang: 'de' });
+    const result = await runLanguageFirstRetry(baseOptions, getLangFirst, noDelay);
+    expect(result).to.equal('de-xx');
+  });
+
+  it('retries only when resolver returns en/xx with fromFallback (error), then de/xx', async () => {
+    let callCount = 0;
+    const getLangFirst = async () => {
+      callCount += 1;
+      if (callCount === 1) return { country: 'xx', lang: 'en', fromFallback: true };
+      return { country: 'xx', lang: 'de' };
+    };
+    const result = await runLanguageFirstRetry(baseOptions, getLangFirst, noDelay);
+    expect(result).to.equal('de-xx');
+    expect(callCount).to.equal(2);
+  });
+
+  it('returns en-xx immediately when resolver returns en/xx without fromFallback (no retry)', async () => {
+    let callCount = 0;
+    const getLangFirst = async () => {
+      callCount += 1;
+      return { country: 'xx', lang: 'en' };
+    };
+    const result = await runLanguageFirstRetry(baseOptions, getLangFirst, noDelay);
+    expect(result).to.equal('en-xx');
+    expect(callCount).to.equal(1);
+  });
+
+  it('returns en-xx after all retries when resolver always returns en/xx with fromFallback', async () => {
+    let callCount = 0;
+    const getLangFirst = async () => {
+      callCount += 1;
+      return { country: 'xx', lang: 'en', fromFallback: true };
+    };
+    const result = await runLanguageFirstRetry(baseOptions, getLangFirst, noDelay);
+    expect(result).to.equal('en-xx');
+    expect(callCount).to.be.greaterThan(1);
   });
 });

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -298,15 +298,47 @@ const isPagePublished = async () => {
   return false;
 };
 
-const getBulkPublishLangAttr = async (options) => {
-  let { getLocale } = getConfig();
-  if (options.languageFirst) {
-    const { country, lang } = await getLanguageFirstCountryAndLang(
+const MAX_LANG_FIRST_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
+
+const delay = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+/**
+ * Runs the language-first retry loop. Only retries when the resolver returns the
+ * default (en/xx) because of an error (fromFallback: true), e.g. mapping fetch failed.
+ * When the result is a real success (or default without error), returns immediately.
+ * Used by getBulkPublishLangAttr; exported for tests.
+ * @param {object} options - prodUrl, repo, host
+ * @param {Function} getLangFirst - async (prodUrl, repo, host) => { country, lang, fromFallback? }
+ * @param {{ retryDelayMs?: number }} [retryOpts] - optional; use in tests to avoid delay
+ * @returns {Promise<string>} lang-country e.g. 'de-xx'
+ */
+export async function runLanguageFirstRetry(options, getLangFirst, retryOpts = {}) {
+  const { retryDelayMs = RETRY_DELAY_MS } = retryOpts;
+
+  let lastResult;
+  for (let attempt = 0; attempt <= MAX_LANG_FIRST_RETRIES; attempt += 1) {
+    if (attempt > 0) await delay(retryDelayMs);
+
+    const result = await getLangFirst(
       options.prodUrl,
       options.repo,
       options.host,
     );
-    return `${lang}-${country}`;
+    const { country, lang, fromFallback } = result;
+    lastResult = `${lang}-${country}`;
+
+    const gotDefault = lang === 'en' && country === 'xx';
+    if (!gotDefault || !fromFallback) return lastResult;
+  }
+
+  return lastResult;
+}
+
+const getBulkPublishLangAttr = async (options) => {
+  let { getLocale } = getConfig();
+  if (options.languageFirst) {
+    return runLanguageFirstRetry(options, getLanguageFirstCountryAndLang);
   }
   if (!getLocale) {
     // This is only imported from the bulk publisher so there is no dependency cycle


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

_Detailed Description:
Some DE and FR Blog CaaS cards are being published with the wrong language (lang=en). Because of this, the cards appear in the US collection instead of their correct locale collections. Removing and republishing the cards does not fix the issue and sometimes causes a different locale version to appear._

URLs:

https://business.adobe.com/de/blog/adobe-commerce-commits-to-agentic-commerce-standards
https://business.adobe.com/fr/blog/how-adobe-brand-concierge-works
Steps to Reproduce:

Publish a DE or FR Blog card to CaaS.
Check the US blog collection: https://business.adobe.com/blog/
Observe the DE/FR card appearing in the US collection with lang=en.
Remove the card from Chimera.
Republish the card to CaaS.
Expected Results:
DE cards publish with lang=de and appear only in the DE collection.
FR cards publish with lang=fr and appear only in the FR collection.

We had a PR to address this issue a few times but they went stale and got closed.  This PR suppresses multiple calls to the lingo mapping xml file, which when made repeatedly, causes the breakdown authors described above.

Resolves: [MWPW-191596](https://jira.corp.adobe.com/browse/MWPW-191596)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-191596--milo--sheridansunier.aem.page/?martech=off






