### PR TITLE
MWPW-190908 [MEP] Refactor marketing action tracking in canServeManifest

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1139,32 +1139,31 @@ export const getGeoRestriction = (manifestConfig) => {
 };
 
 export function getManifestMarketingAction(mktgAction, source) {
-  const allowedServices = ['core services', 'non-marketing', 'marketing decrease', 'marketing increase'];
-  if (allowedServices.includes(mktgAction)) return mktgAction;
-  if (source?.includes('promo')) return 'core services';
+  const coreServicesNonMarketing = 'core services/non-marketing';
+  const allowedServices = [coreServicesNonMarketing, 'non-marketing', 'marketing decrease', 'marketing increase'];
+  const normalizedMktgAction = mktgAction === 'core services' ? coreServicesNonMarketing : mktgAction;
+  if (allowedServices.includes(normalizedMktgAction)) return normalizedMktgAction;
+  if (source?.includes('promo')) return coreServicesNonMarketing;
   return 'marketing increase';
 }
 
 export function canServeManifest(manifestConfig) {
   if (!getGeoRestriction(manifestConfig)) return false;
   const { mktgAction, variantNames, manifestPath } = manifestConfig;
-  if (mktgAction === 'core services') return true;
+  if (mktgAction?.includes('core services')) return true;
 
   const { performance, advertising } = getConfig().mep.consentState;
+
+  if (mktgAction?.startsWith('marketing') && performance && advertising) {
+    const fileName = getFileName(manifestPath)?.replace('.json', '');
+    sendAnalytics(`${fileName} was served`);
+  }
+
   if (mktgAction === 'non-marketing') return performance;
   if (mktgAction === 'marketing increase') return advertising;
 
   if (!advertising || !performance) overrideVariant(manifestPath, variantNames[0]);
   return true;
-}
-
-export function sendMktgTracking(fileName, mktgAction) {
-  if (!mktgAction?.startsWith('marketing')) return false;
-  const { advertising } = getConfig().mep.consentState;
-  if (!advertising) return false;
-  const eventName = `${fileName} was served`;
-  sendAnalytics(eventName);
-  return eventName;
 }
 
 async function getManifestConfig(info, variantOverride) {
@@ -1243,8 +1242,6 @@ async function getManifestConfig(info, variantOverride) {
     overrideVariant(normalizePath(manifestPath), 'Default');
     if (!getConfig().mep?.preview) return null;
     finalDisabled = true;
-  } else {
-    sendMktgTracking(fileName, manifestConfig.mktgAction);
   }
 
   manifestConfig.selectedVariantName = await getPersonalizationVariant(

--- a/test/features/personalization/canServeManifest.test.js
+++ b/test/features/personalization/canServeManifest.test.js
@@ -1,4 +1,6 @@
+/* eslint-disable no-underscore-dangle */
 import { expect } from '@esm-bundle/chai';
+import { stub } from 'sinon';
 import {
   overrideVariant,
   getGeoRestriction,
@@ -43,8 +45,11 @@ describe('getManifestMarketingAction', () => {
   it('should return the same action if it is in the allowed list', () => {
     expect(getManifestMarketingAction('marketing increase', 'promo')).to.be.equal('marketing increase');
   });
-  it('should return core services if the action is promo and the action is undefined', () => {
-    expect(getManifestMarketingAction(undefined, 'promo')).to.be.equal('core services');
+  it('should normalize core services to core services/non-marketing', () => {
+    expect(getManifestMarketingAction('core services', 'pzn')).to.be.equal('core services/non-marketing');
+  });
+  it('should return core services/non-marketing if the action is promo and the action is undefined', () => {
+    expect(getManifestMarketingAction(undefined, 'promo')).to.be.equal('core services/non-marketing');
   });
   it('should return marketing increase if the action is not in the allowed list and the source is not promo', () => {
     expect(getManifestMarketingAction('marketing', 'pzn')).to.be.equal('marketing increase');
@@ -60,10 +65,16 @@ describe('canServeManifest', () => {
     getConfig().mep.consentState = { performance: true, advertising: true };
     getConfig().mep.variantOverride = {};
   });
+  afterEach(() => {
+    delete window._satellite;
+  });
   it('should return false if the geo restriction is false', () => {
     expect(canServeManifest({ geoRestriction: 'fr, ca', manifestPath: '/test/test.json' })).to.be.false;
   });
-  it('should return true if mktgAction is core services', () => {
+  it('should return true if mktgAction is core services/non-marketing', () => {
+    expect(canServeManifest({ mktgAction: 'core services/non-marketing', manifestPath: '/test/test.json' })).to.be.true;
+  });
+  it('should return true if mktgAction is core services (legacy name)', () => {
     expect(canServeManifest({ mktgAction: 'core services', manifestPath: '/test/test.json' })).to.be.true;
   });
   it('should return true if mktgAction is non-marketing and performance is true', () => {
@@ -87,5 +98,70 @@ describe('canServeManifest', () => {
     getConfig().mep.consentState = { performance: false, advertising: true };
     expect(canServeManifest({ mktgAction: 'marketing decrease', manifestPath: '/test/test.json', variantNames: ['test'] })).to.be.true;
     expect(getConfig().mep.variantOverride['/test/test.json']).to.be.equal('test');
+  });
+
+  // "was served" analytics: MEP gates _satellite.track on both performance (C0002)
+  // and advertising (C0004) consent. Launch independently checks C0002 and suppresses
+  // events when it's off, so the effect is not observable at the network payload level.
+  // These tests verify the MEP-side gating so we don't rely on Launch's internal
+  // consent logic as the only safeguard.
+  it('should fire analytics for marketing increase when both consent flags are true', () => {
+    const trackStub = stub();
+    window._satellite = { track: trackStub };
+    canServeManifest({ mktgAction: 'marketing increase', manifestPath: '/test/test.json' });
+    expect(trackStub.calledOnce).to.be.true;
+    const [, payload] = trackStub.firstCall.args;
+    expect(payload.xdm.web.webInteraction.name).to.equal('test was served');
+  });
+
+  it('should fire analytics for marketing decrease when both consent flags are true', () => {
+    const trackStub = stub();
+    window._satellite = { track: trackStub };
+    canServeManifest({ mktgAction: 'marketing decrease', manifestPath: '/test/test.json', variantNames: ['test'] });
+    expect(trackStub.calledOnce).to.be.true;
+    const [, payload] = trackStub.firstCall.args;
+    expect(payload.xdm.web.webInteraction.name).to.equal('test was served');
+  });
+
+  it('should not fire analytics for marketing decrease when advertising consent is false', () => {
+    getConfig().mep.consentState = { performance: true, advertising: false };
+    const trackStub = stub();
+    window._satellite = { track: trackStub };
+    canServeManifest({ mktgAction: 'marketing decrease', manifestPath: '/test/test.json', variantNames: ['test'] });
+    expect(trackStub.called).to.be.false;
+  });
+
+  it('should not fire analytics for marketing decrease when performance consent is false', () => {
+    getConfig().mep.consentState = { performance: false, advertising: true };
+    const trackStub = stub();
+    window._satellite = { track: trackStub };
+    canServeManifest({ mktgAction: 'marketing decrease', manifestPath: '/test/test.json', variantNames: ['test'] });
+    expect(trackStub.called).to.be.false;
+  });
+
+  it('should not fire analytics for marketing increase when advertising consent is false', () => {
+    getConfig().mep.consentState = { performance: true, advertising: false };
+    const trackStub = stub();
+    window._satellite = { track: trackStub };
+    canServeManifest({ mktgAction: 'marketing increase', manifestPath: '/test/test.json' });
+    expect(trackStub.called).to.be.false;
+  });
+
+  it('should not fire analytics for marketing increase when performance consent is false', () => {
+    getConfig().mep.consentState = { performance: false, advertising: true };
+    const trackStub = stub();
+    window._satellite = { track: trackStub };
+    canServeManifest({ mktgAction: 'marketing increase', manifestPath: '/test/test.json' });
+    expect(trackStub.called).to.be.false;
+  });
+
+  it('should serve marketing decrease manifest with default variant but suppress analytics when consent is missing', () => {
+    getConfig().mep.consentState = { performance: false, advertising: true };
+    const trackStub = stub();
+    window._satellite = { track: trackStub };
+    const result = canServeManifest({ mktgAction: 'marketing decrease', manifestPath: '/test/test.json', variantNames: ['default'] });
+    expect(result).to.be.true;
+    expect(getConfig().mep.variantOverride['/test/test.json']).to.equal('default');
+    expect(trackStub.called).to.be.false;
   });
 });

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -6,7 +6,6 @@ import { getConfig, setConfig } from '../../../libs/utils/utils.js';
 import {
   handleFragmentCommand, applyPers, cleanAndSortManifestList, normalizePath,
   init, matchGlob, createContent, combineMepSources, buildVariantInfo, addSectionAnchors,
-  sendMktgTracking,
 } from '../../../libs/features/personalization/personalization.js';
 import mepSettings from './mepSettings.js';
 import mepSettingsPreview from './mepPreviewSettings.js';
@@ -672,28 +671,6 @@ describe('MEP Utils', () => {
     });
   });
 });
-describe('sendMktgTracking', () => {
-  it('should return false if advertising is false and mktgAction is marketing increase', async () => {
-    const config = getConfig();
-    config.mep.consentState = { advertising: false };
-    expect(sendMktgTracking('my-manifest', 'marketing increase')).to.be.false;
-  });
-  it('should return false if advertising is true and mktgAction is non-marketing', async () => {
-    const config = getConfig();
-    config.mep.consentState = { advertising: true };
-    expect(sendMktgTracking(true, 'my-manifest', 'non-marketing')).to.be.false;
-  });
-  it('should send return event name if advertising is true and mktgAction is marketing increase', async () => {
-    const config = getConfig();
-    config.mep.consentState = { advertising: true };
-    expect(sendMktgTracking('my-manifest', 'marketing increase')).to.equal('my-manifest was served');
-  });
-  it('should send return event name if advertising is true and mktgAction is marketing decrease', async () => {
-    const config = getConfig();
-    config.mep.consentState = { advertising: true };
-    expect(sendMktgTracking('my-manifest', 'marketing decrease')).to.equal('my-manifest was served');
-  });
-});
 
 describe('analyticifseen', () => {
   let observerCallback;
@@ -746,7 +723,6 @@ describe('analyticifseen', () => {
   });
 
   it('should defer analytics to alloy_sendEvent when _satellite is unavailable', () => {
-    // Flush lingering alloy_sendEvent listeners left by earlier sendMktgTracking tests
     window.dispatchEvent(new Event('alloy_sendEvent'));
 
     observerCallback([{ isIntersecting: true }]);


### PR DESCRIPTION
Summary

- Primary goal: fire analytics equally for control and challenger to show if the user has accepted all levels of consent and is "fully in the test."
- Removed sendMktgTracking and moved the "was served" analytics call directly into canServeManifest
- Now requires both performance (C0002) and advertising (C0004) consent before firing, instead of only advertising
- Renamed core services to core services/non-marketing for clarity while preserving backwards compatibility

QA URL: https://main--cc--adobecom.aem.page/drafts/mepdev/fragments/2026/q1/mep-sendanalytics-update/base?milolibs=mep-sendanalytics-update-main

steps to QA:

1. All cookies accepted
-Open the QA URL in an incognito browser, accept all cookies
-Open DevTools > Network, filter by collect, reload
-Expand a collect request > Request Payload
-Confirm "mepmarketingincrease was served", "mepmarketingdecrease was served" and "mepmarketingnonspecified was served" appear in the payloads (see image below)
-All manifests should add a sentence to the page
-MEP button should reflect the correct marketing action (including the new name for core services)
2. Advertising disabled
-Open cookie banner, uncheck "Personalize advertising", save and reload
-Both marketing increase and unspecified (which defaults to marketing increase) should stop altering the page and serve the control experience
-collect payloads should no longer contain any "was served" events
-MEP button should show the same marketing actions but the 2 manifests that are no longer firing should show default as the chosen experience
3. Performance disabled (advertising on)
-Re-accept all cookies, then uncheck only "Measure performance", save and reload
-Both increase, decrease and nonspecified content are inserted on the page (neither is gated on performance alone for serving)
-collect payloads for "was served" disappear (Launch independently suppresses on C0002)
4. Core services
-Confirm core services content is always visible regardless of consent settings
-No "was served" analytics fire for the core services manifest
<img width="1777" height="1079" alt="Screenshot 2026-04-06 at 10 29 58 AM" src="https://github.com/user-attachments/assets/1f5bfdb5-923d-4ac5-adc3-0a432f97c84f" />


Resolves: [MWPW-190908](https://jira.corp.adobe.com/browse/MWPW-190908)
Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://mep-sendanalytics-update-main--milo--adobecom.aem.page/?martech=off


