### PR TITLE
MWPW-189756 Fix(region-nav): WCAG 1.3.1 – add heading semantics to region-nav modal

### DIFF
--- a/libs/blocks/region-nav/region-nav.css
+++ b/libs/blocks/region-nav/region-nav.css
@@ -30,6 +30,8 @@
 .region-nav > div:first-of-type h2 {
   font-size: 24px;
   font-weight: bold;
+  line-height: 1.7;
+  display: inline;
 }
 
 .region-nav > div:first-of-type h2 + p {

--- a/libs/blocks/region-nav/region-nav.css
+++ b/libs/blocks/region-nav/region-nav.css
@@ -30,8 +30,6 @@
 .region-nav > div:first-of-type h2 {
   font-size: 24px;
   font-weight: bold;
-  line-height: 1.7;
-  display: inline;
 }
 
 .region-nav > div:first-of-type h2 + p {

--- a/libs/blocks/region-nav/region-nav.css
+++ b/libs/blocks/region-nav/region-nav.css
@@ -38,9 +38,11 @@
   font-size: 24px;
   font-weight: bold;
   margin: 0 0 4px;
+  line-height: 1.3;
+  margin-block: 0 4px;
 }
 
-.region-nav > div:first-of-type h2 + p {
+.region-nav > div:first-of-type > div > h2 + p:first-of-type {
   font-size: 16px;
   font-weight: normal;
   margin-top: 0;

--- a/libs/blocks/region-nav/region-nav.css
+++ b/libs/blocks/region-nav/region-nav.css
@@ -5,10 +5,14 @@
   line-height: 1.7;
 }
 
-.region-nav > div:nth-of-type(2) > div > p,
+.region-nav > div:nth-of-type(2) > div > p {
+  font-size: 16px;
+  margin-bottom: 0;
+}
+
 .region-nav > div:nth-of-type(2) > div > h3 {
   font-size: 16px;
-  margin: 0 0 0;
+  margin-bottom: 0;
   font-weight: bold;
 }
 
@@ -22,14 +26,18 @@
   position: relative;
 }
 
-.region-nav > div:first-of-type > div > p,
-.region-nav > div:first-of-type > div > h2 {
+.region-nav > div:first-of-type > div > p {
   margin: 0 0 4px;
 }
 
-.region-nav > div:first-of-type h2 {
+.region-nav > div:first-of-type > div > p:first-of-type {
+  font-size: 24px;
+}
+
+.region-nav > div:first-of-type > div > h2 {
   font-size: 24px;
   font-weight: bold;
+  margin: 0 0 4px;
 }
 
 .region-nav > div:first-of-type h2 + p {
@@ -42,7 +50,10 @@
   margin-bottom: 0;
 }
 
-.region-nav > div:nth-of-type(2) > div > p:first-of-type,
+.region-nav > div:nth-of-type(2) > div > p:first-of-type {
+  margin-top: 0;
+}
+
 .region-nav > div:nth-of-type(2) > div > h3:first-of-type {
   margin-top: 0;
 }

--- a/libs/blocks/region-nav/region-nav.css
+++ b/libs/blocks/region-nav/region-nav.css
@@ -1,12 +1,15 @@
 
 .region-nav > div:nth-of-type(2) > div > p,
+.region-nav > div:nth-of-type(2) > div > h3,
 .region-nav > div:nth-of-type(2) > div > ul li {
   line-height: 1.7;
 }
 
-.region-nav > div:nth-of-type(2) > div > p {
+.region-nav > div:nth-of-type(2) > div > p,
+.region-nav > div:nth-of-type(2) > div > h3 {
   font-size: 16px;
-  margin-bottom: 0;
+  margin: 0 0 0;
+  font-weight: bold;
 }
 
 .region-nav > div:first-of-type {
@@ -19,19 +22,28 @@
   position: relative;
 }
 
-.region-nav > div:first-of-type > div > p {
+.region-nav > div:first-of-type > div > p,
+.region-nav > div:first-of-type > div > h2 {
   margin: 0 0 4px;
 }
 
-.region-nav > div:first-of-type > div > p:first-of-type {
+.region-nav > div:first-of-type h2 {
   font-size: 24px;
+  font-weight: bold;
+}
+
+.region-nav > div:first-of-type h2 + p {
+  font-size: 16px;
+  font-weight: normal;
+  margin-top: 0;
 }
 
 .region-nav > div:first-of-type > p:last-of-type {
   margin-bottom: 0;
 }
 
-.region-nav > div:nth-of-type(2) > div > p:first-of-type {
+.region-nav > div:nth-of-type(2) > div > p:first-of-type,
+.region-nav > div:nth-of-type(2) > div > h3:first-of-type {
   margin-top: 0;
 }
 

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -124,12 +124,22 @@ export default async function init(block) {
       titleP.replaceWith(h2);
     }
   }
-  const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');
+  /*const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');
   regionHeaders.forEach((strong) => {
     if (strong.querySelector('a')) return;
     const p = strong.parentElement;
     if (p.nextElementSibling?.tagName !== 'UL') return;
     const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() }, strong.textContent);
+    p.replaceWith(h3);
+  });*/
+  regionHeaders.forEach((strong) => {
+    const p = strong.parentElement;
+    const parentDiv = p.parentElement;
+    // Only convert if this is the first <p><strong> in its column div
+    const firstStrong = parentDiv.querySelector(':scope > p > strong');
+    if (firstStrong !== strong) return;
+    const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() });
+    h3.innerHTML = strong.innerHTML; // preserve links
     p.replaceWith(h3);
   });
   const links = divs[1].querySelectorAll('a');

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -125,25 +125,13 @@ export default async function init(block) {
     }
   }
   const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');
-  /*regionHeaders.forEach((strong) => {
-    if (strong.querySelector('a')) return;
-    const p = strong.parentElement;
-    if (p.nextElementSibling?.tagName !== 'UL') return;
-    const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() }, strong.textContent);
-    p.replaceWith(h3);
-  });*/ /**...previous code  */
-  
-  /**below is new trial code */
   regionHeaders.forEach((strong) => {
-    const p = strong.parentElement;
-    const parentDiv = p.parentElement;
-    // Only convert if this is the first <p><strong> in its column div
-    const firstStrong = parentDiv.querySelector(':scope > p > strong');
-    if (firstStrong !== strong) return;
-    const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() });
-    h3.innerHTML = strong.innerHTML; // preserve links
-    p.replaceWith(h3);
-  });
+  if (strong.querySelector('a')) return;
+  const p = strong.parentElement;
+  if (p.nextElementSibling?.tagName !== 'UL') return;
+  const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() }, strong.textContent);
+  p.replaceWith(h3);
+});
   const links = divs[1].querySelectorAll('a');
   if (!links.length) return;
   const { prefix } = config.locale;

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -129,12 +129,12 @@ export default async function init(block) {
   }
   const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');
   regionHeaders.forEach((strong) => {
-  if (strong.querySelector('a')) return;
-  const p = strong.parentElement;
-  if (p.nextElementSibling?.tagName !== 'UL') return;
-  const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() }, strong.textContent);
-  p.replaceWith(h3);
-});
+    if (strong.querySelector('a')) return;
+    const p = strong.parentElement;
+    if (p.nextElementSibling?.tagName !== 'UL') return;
+    const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() }, strong.textContent);
+    p.replaceWith(h3);
+  });
   const links = divs[1].querySelectorAll('a');
   if (!links.length) return;
   const { prefix } = config.locale;

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -6,6 +6,7 @@ import {
   setInternational,
   getCountry,
   setMarket,
+  createTag,
 } from '../../utils/utils.js';
 import { norm } from '../../utils/market.js';
 
@@ -114,6 +115,24 @@ export default async function init(block) {
   config = getConfig();
   const divs = block.querySelectorAll(':scope > div');
   if (divs.length < 2) return;
+  const titleStrong = divs[0].querySelector('strong');
+  const titleP = titleStrong?.closest('p');
+  if (titleStrong && !divs[0].querySelector('h2')) {
+    const h2 = createTag('h2', { class: `tracking-header ${titleStrong.className}`.trim() }, titleStrong.textContent);
+    if (titleP) {
+      titleP.replaceWith(h2);
+    } else {
+      titleStrong.replaceWith(h2);
+    }
+  }
+  const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');
+  regionHeaders.forEach((strong) => {
+    if (strong.querySelector('a')) return;
+    const p = strong.parentElement;
+    if (p.nextElementSibling?.tagName !== 'UL') return;
+    const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() }, strong.textContent);
+    p.replaceWith(h3);
+  });
   const links = divs[1].querySelectorAll('a');
   if (!links.length) return;
   const { prefix } = config.locale;

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -131,7 +131,9 @@ export default async function init(block) {
     if (p.nextElementSibling?.tagName !== 'UL') return;
     const h3 = createTag('h3', { class: `tracking-header ${strong.className}`.trim() }, strong.textContent);
     p.replaceWith(h3);
-  });*/
+  });*/ /**...previous code  */
+  
+  /**below is new trial code */
   regionHeaders.forEach((strong) => {
     const p = strong.parentElement;
     const parentDiv = p.parentElement;

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -119,9 +119,12 @@ export default async function init(block) {
   if (!titleDiv.querySelector('h2')) {
     const titleStrong = titleDiv.querySelector('strong');
     const titleP = titleStrong ? titleStrong.closest('p') : titleDiv.querySelector('p');
-    if (titleP) {
+    if (titleStrong && titleP) {
       const h2 = createTag('h2', { class: 'tracking-header' }, titleP.textContent.trim());
       titleP.replaceWith(h2);
+    } else if (titleP) {
+      titleP.setAttribute('role', 'heading');
+      titleP.setAttribute('aria-level', '2');
     }
   }
   const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -115,14 +115,13 @@ export default async function init(block) {
   config = getConfig();
   const divs = block.querySelectorAll(':scope > div');
   if (divs.length < 2) return;
-  const titleStrong = divs[0].querySelector('strong');
-  const titleP = titleStrong?.closest('p');
-  if (titleStrong && !divs[0].querySelector('h2')) {
-    const h2 = createTag('h2', { class: `tracking-header ${titleStrong.className}`.trim() }, titleStrong.textContent);
+  const titleDiv = divs[0];
+  if (!titleDiv.querySelector('h2')) {
+    const titleStrong = titleDiv.querySelector('strong');
+    const titleP = titleStrong ? titleStrong.closest('p') : titleDiv.querySelector('p');
     if (titleP) {
+      const h2 = createTag('h2', { class: 'tracking-header' }, titleP.textContent.trim());
       titleP.replaceWith(h2);
-    } else {
-      titleStrong.replaceWith(h2);
     }
   }
   const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -119,12 +119,9 @@ export default async function init(block) {
   if (!titleDiv.querySelector('h2')) {
     const titleStrong = titleDiv.querySelector('strong');
     const titleP = titleStrong ? titleStrong.closest('p') : titleDiv.querySelector('p');
-    if (titleStrong && titleP) {
+    if (titleP) {
       const h2 = createTag('h2', { class: 'tracking-header' }, titleP.textContent.trim());
       titleP.replaceWith(h2);
-    } else if (titleP) {
-      titleP.setAttribute('role', 'heading');
-      titleP.setAttribute('aria-level', '2');
     }
   }
   const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');

--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -124,8 +124,8 @@ export default async function init(block) {
       titleP.replaceWith(h2);
     }
   }
-  /*const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');
-  regionHeaders.forEach((strong) => {
+  const regionHeaders = divs[1].querySelectorAll(':scope > div > p > strong');
+  /*regionHeaders.forEach((strong) => {
     if (strong.querySelector('a')) return;
     const p = strong.parentElement;
     if (p.nextElementSibling?.tagName !== 'UL') return;

--- a/test/blocks/region-nav/mocks/regions.html
+++ b/test/blocks/region-nav/mocks/regions.html
@@ -1,30 +1,36 @@
 <div>
   <div class="region-nav">
-    <div><h3>title</h3></div>
     <div>
-      <p><strong>Americas</strong></p>
-      <ul>
-        <li><a href="/ar/">Argentina</a></li>
-        <li><a href="/br/path/to/page">Brasil</a></li>
-        <li><a href="/">United States</a></li>
-      </ul>
-      <p><strong>Europe, Middle East and Africa</strong></p>
-      <ul>
-        <li><a href="/africa/">Africa - English</a></li>
-        <li><a href="/ch_de/path/to/page">Schweiz</a></li>
-        <li><a href="/ch_fr/path/to/page">Suisse</a></li>
-        <li><a href="https:adobe.com/ru/">Россия</a></li>
-        <li><a href="/ua/">Україна</a></li>
-        <li><a href="/il_he/">ישראל - עברית</a></li>
-        <li><a href="/sa_ar/">المملكة العربية السعودية</a></li>
-      </ul>
-      <p><strong>Asia Pacific</strong></p>
-      <ul>
-        <li><a href="/au/path/to/page">Australia</a></li>
-        <li><a href="/my_ms/">Malaysia</a></li>
-        <li><a href="/kr/">한국</a></li>
-      </ul>
+      <div>
+        <p><strong>Choose your region</strong></p>
+        <p>Selecting a region changes the language and/or content on Adobe.com.</p>
+      </div>
+    </div>
+    <div>
+      <div>
+        <p><strong>Americas</strong></p>
+        <ul>
+          <li><a href="/ar/">Argentina</a></li>
+          <li><a href="/br/path/to/page">Brasil</a></li>
+          <li><a href="/">United States</a></li>
+        </ul>
+        <p><strong>Europe, Middle East and Africa</strong></p>
+        <ul>
+          <li><a href="/africa/">Africa - English</a></li>
+          <li><a href="/ch_de/path/to/page">Schweiz</a></li>
+          <li><a href="/ch_fr/path/to/page">Suisse</a></li>
+          <li><a href="https:adobe.com/ru/">Россия</a></li>
+          <li><a href="/ua/">Україна</a></li>
+          <li><a href="/il_he/">ישראל - עברית</a></li>
+          <li><a href="/sa_ar/">المملكة العربية السعودية</a></li>
+        </ul>
+        <p><strong>Asia Pacific</strong></p>
+        <ul>
+          <li><a href="/au/path/to/page">Australia</a></li>
+          <li><a href="/my_ms/">Malaysia</a></li>
+          <li><a href="/kr/">한국</a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
-

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -30,6 +30,25 @@ describe('Region Nav Block', async () => {
     sinon.restore();
   });
 
+  it('converts modal title <strong> to <h2> for accessibility', () => {
+    const h2 = block.querySelector(':scope > div:first-of-type h2');
+    expect(h2).to.exist;
+    expect(h2.textContent.trim()).to.equal('Choose your region');
+  });
+
+  it('converts region group <p><strong> headers to <h3> for accessibility', () => {
+    const h3s = [...block.querySelectorAll(':scope > div:nth-of-type(2) h3')];
+    expect(h3s).to.have.length(3);
+    expect(h3s[0].textContent.trim()).to.equal('Americas');
+    expect(h3s[1].textContent.trim()).to.equal('Europe, Middle East and Africa');
+    expect(h3s[2].textContent.trim()).to.equal('Asia Pacific');
+  });
+
+  it('does not leave any <p><strong> region headers after init', () => {
+    const remainingStrongHeaders = block.querySelectorAll(':scope > div:nth-of-type(2) p > strong');
+    expect(remainingStrongHeaders).to.have.length(0);
+  });
+
   it('sets links correctly', () => {
     const { contentRoot } = getConfig().locale;
     window.location.hash = 'langnav';
@@ -129,14 +148,12 @@ describe('Region Nav Block', async () => {
       locales: {
         '': { ietf: 'en-US', tk: 'hah7vzn.css' },
         africa: { ietf: 'en', tk: 'hah7vzn.css' },
-        // Notice we do NOT include 'ar' or 'at' here so that prefix is considered "not in locales".
       },
     });
 
     const link = createTag('a', { href: 'https://adobe.com/ar/' });
     decorateLink(link, '/path/to/some/page');
 
-    // Assert that the href has been transformed from '/ar/' to '/es/' due to languageMap
     expect(link.href).to.equal('https://adobe.com/es/path/to/some/page');
   });
 
@@ -154,20 +171,18 @@ describe('Region Nav Block', async () => {
     const link = createTag('a', { href: 'https://adobe.com/ar/' });
     decorateLink(link, '/some-page');
 
-    // Because `ar` is mapped to an empty string, the code replaces `"/ar"` with `""`
     expect(link.href).to.equal('https://adobe.com/some-page');
   });
 
   it('does NOT modify href if prefix is in locales (even if present in languageMap)', () => {
     setConfig({
       languageMap: { ar: 'es' },
-      locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' }, ar: { ietf: 'ar', tk: 'lpk1hwn.css', dir: 'rtl' } }, // Now "ar" is a valid locale
+      locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' }, ar: { ietf: 'ar', tk: 'lpk1hwn.css', dir: 'rtl' } },
     });
 
     const link = createTag('a', { href: 'https://adobe.com/ar/some-page' });
     decorateLink(link, '');
 
-    // Since 'ar' is in locales, we should NOT transform
     expect(link.href).to.equal('https://adobe.com/ar/some-page');
   });
 
@@ -177,7 +192,6 @@ describe('Region Nav Block', async () => {
     const link = createTag('a', { href: 'https://adobe.com/ar/some-page' });
     decorateLink(link, '');
 
-    // No languageMap means no transformation
     expect(link.href).to.equal('https://adobe.com/ar/some-page');
   });
 });

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -148,12 +148,14 @@ describe('Region Nav Block', async () => {
       locales: {
         '': { ietf: 'en-US', tk: 'hah7vzn.css' },
         africa: { ietf: 'en', tk: 'hah7vzn.css' },
+        // Notice we do NOT include 'ar' or 'at' here so that prefix is considered "not in locales".
       },
     });
 
     const link = createTag('a', { href: 'https://adobe.com/ar/' });
     decorateLink(link, '/path/to/some/page');
-
+    
+    // Assert that the href has been transformed from '/ar/' to '/es/' due to languageMap
     expect(link.href).to.equal('https://adobe.com/es/path/to/some/page');
   });
 
@@ -170,7 +172,8 @@ describe('Region Nav Block', async () => {
 
     const link = createTag('a', { href: 'https://adobe.com/ar/' });
     decorateLink(link, '/some-page');
-
+    
+    // Because `ar` is mapped to an empty string, the code replaces `"/ar"` with `""`
     expect(link.href).to.equal('https://adobe.com/some-page');
   });
 
@@ -182,7 +185,8 @@ describe('Region Nav Block', async () => {
 
     const link = createTag('a', { href: 'https://adobe.com/ar/some-page' });
     decorateLink(link, '');
-
+    
+    // Since 'ar' is in locales, we should NOT transform
     expect(link.href).to.equal('https://adobe.com/ar/some-page');
   });
 
@@ -192,6 +196,7 @@ describe('Region Nav Block', async () => {
     const link = createTag('a', { href: 'https://adobe.com/ar/some-page' });
     decorateLink(link, '');
 
+    // No languageMap means no transformation
     expect(link.href).to.equal('https://adobe.com/ar/some-page');
   });
 });

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -154,7 +154,7 @@ describe('Region Nav Block', async () => {
 
     const link = createTag('a', { href: 'https://adobe.com/ar/' });
     decorateLink(link, '/path/to/some/page');
-    
+
     // Assert that the href has been transformed from '/ar/' to '/es/' due to languageMap
     expect(link.href).to.equal('https://adobe.com/es/path/to/some/page');
   });
@@ -172,7 +172,7 @@ describe('Region Nav Block', async () => {
 
     const link = createTag('a', { href: 'https://adobe.com/ar/' });
     decorateLink(link, '/some-page');
-    
+
     // Because `ar` is mapped to an empty string, the code replaces `"/ar"` with `""`
     expect(link.href).to.equal('https://adobe.com/some-page');
   });
@@ -185,7 +185,7 @@ describe('Region Nav Block', async () => {
 
     const link = createTag('a', { href: 'https://adobe.com/ar/some-page' });
     decorateLink(link, '');
-    
+
     // Since 'ar' is in locales, we should NOT transform
     expect(link.href).to.equal('https://adobe.com/ar/some-page');
   });

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -180,7 +180,7 @@ describe('Region Nav Block', async () => {
   it('does NOT modify href if prefix is in locales (even if present in languageMap)', () => {
     setConfig({
       languageMap: { ar: 'es' },
-      locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' }, ar: { ietf: 'ar', tk: 'lpk1hwn.css', dir: 'rtl' } },
+      locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' }, ar: { ietf: 'ar', tk: 'lpk1hwn.css', dir: 'rtl' } }, // Now "ar" is a valid locale
     });
 
     const link = createTag('a', { href: 'https://adobe.com/ar/some-page' });


### PR DESCRIPTION
Resolves: [MWPW-189756](https://jira.corp.adobe.com/browse/MWPW-189756)
**Test URLs:**
https://main--dme-partners--adobecom.aem.page/drafts/soujanya/test-dnt?milolibs=mwpw-189756-region-nav--milo--KetakiD-Deshwandikar#langnav
https://main--homepage--adobecom.aem.live/homepage/index-loggedout?milolibs=mwpw-189756-region-nav--milo--KetakiD-Deshwandikar#langnav
Fix:
Dynamically converts the modal title (`p > strong`) to `<h2>` via JS
Converts region group labels (`p > strong` followed by a `ul`) to `<h3>` via JS
Guards skip bold links (e.g. partner portal items where `strong` contains `a`) to avoid breaking navigation
CSS updated to style `h2`/`h3` elements consistently with original visual design
No visual change (alignment preserved)

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- Milo: https://mwpw-189756-region-nav--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- Milo: https://mwpw-189756-region-nav--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- Milo: https://mwpw-189756-region-nav--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=mwpw-189756-region-nav--milo--adobecom
</details>