### PR TITLE
[MWPW-190397]Handle federated prefix for localized pages

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -448,9 +448,11 @@ export const getFederatedUrl = (url = '') => {
   if (typeof url !== 'string' || !url.includes('/federal/')) return url;
   if (url.startsWith('/')) return `${getFederatedContentRoot()}${url}`;
   try {
-    const { fedContentPrefix } = getConfig();
+    const { fedContentPrefix, locale } = getConfig();
     const { pathname, search, hash } = new URL(url);
-    return `${getFederatedContentRoot()}${pathname.startsWith(fedContentPrefix)
+    const hasPrefix = fedContentPrefix && (pathname.startsWith(fedContentPrefix)
+      || pathname.startsWith(`${locale.prefix}${fedContentPrefix}`));
+    return `${getFederatedContentRoot()}${hasPrefix
       ? pathname.replace(fedContentPrefix, '') : pathname}${search}${hash}`;
   } catch (e) {
     window.lana?.log(`getFederatedUrl errored parsing the URL: ${url}: ${e.toString()}`, {


### PR DESCRIPTION
Resolves: [MWPW-190397](https://jira.corp.adobe.com/browse/MWPW-190397)

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/?martech=off
- After: https://fed-prefix--milo--adobecom.aem.page/?martech=off

- Before: https://main--dc-frictionless--adobecom.aem.live/heic-to-pdf?martech=off&milolibs=fed-prefix
- After: https://main--dc-frictionless--adobecom.aem.live/heic-to-pdf?martech=off&milolibs=fed-prefix


