### PR TITLE
MWPW-192012 [MEP] Fix: guard undefined els/modifiers in handleCommands

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -750,8 +750,8 @@ export async function handleCommands(
           }
         }
       }
-      if ((els.length && !cmd.modifiers.includes(FLAGS.all))
-        || !cmd.modifiers.includes(FLAGS.includeFragments)) {
+      if ((els?.length && !cmd.modifiers?.includes(FLAGS.all))
+        || !cmd.modifiers?.includes(FLAGS.includeFragments)) {
         cmd.completed = true;
       }
     }

--- a/test/features/personalization/actions.test.js
+++ b/test/features/personalization/actions.test.js
@@ -403,7 +403,12 @@ describe('handleCommands with invalid selector', () => {
       selector: '',
     }];
     const rootEl = document.createElement('div');
-    await handleCommands(commands, rootEl, false, true);
-    expect(commands[0].completed).to.not.exist;
+    let error;
+    try {
+      await handleCommands(commands, rootEl, false, true);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).to.be.undefined;
   });
 });

--- a/test/features/personalization/actions.test.js
+++ b/test/features/personalization/actions.test.js
@@ -394,3 +394,16 @@ describe('custom actions', async () => {
     expect(document.querySelector(notLcpLink)).not.to.exist;
   });
 });
+
+describe('handleCommands with invalid selector', () => {
+  it('should not throw when getSelectedElements returns empty object', async () => {
+    const commands = [{
+      action: 'replace',
+      content: '/some-fragment',
+      selector: '',
+    }];
+    const rootEl = document.createElement('div');
+    await handleCommands(commands, rootEl, false, true);
+    expect(commands[0].completed).to.not.exist;
+  });
+});


### PR DESCRIPTION
**Summary**

Fixes regression from #5164 where handleCommands crashes when
getSelectedElements returns an empty object for an empty/invalid
selector. The || [] fallback was added to the els iteration loop
but not to the els.length / cmd.modifiers.includes completion check
below it, causing a TypeError.
- Add optional chaining to els?.length and cmd.modifiers?.includes
- Add unit test for empty selector case


**Steps to QA:** 
1. Open Before and After Test URLS below.
2. Expand the gnav dropdown

**Expected Results**: gnav loads
**Actual results**: error message: 
"Something went wrong.
There was an unexpected error.
Please try again in a moment."

Resolves: [MWPW-192012](https://jira.corp.adobe.com/browse/MWPW-192012)

**Test URLs:**
- Before: https://main--cc--adobecom.aem.page/jp/products/photoshop
- After: https://main--cc--adobecom.aem.page/jp/products/photoshop?milolibs=mep-handlecommands-fix
- Psi-check: https://mep-handlecommands-fix--milo--adobecom.aem.page/?martech=off


