### PR TITLE
[SR] page performance tweaks

### DIFF
--- a/libs/c2/blocks/base-card/base-card.css
+++ b/libs/c2/blocks/base-card/base-card.css
@@ -2,6 +2,7 @@
 .base-card {
   position: relative;
   height: 100%;
+  contain: layout;
 
   > div[data-viewport] {
     display: none;

--- a/libs/c2/blocks/elastic-carousel/elastic-carousel.css
+++ b/libs/c2/blocks/elastic-carousel/elastic-carousel.css
@@ -62,6 +62,7 @@ html[dir="rtl"] {
       cursor: pointer;
       will-change: width, max-width;
       transition: max-width .3s var(--paralax-easing), width .3s var(--paralax-easing), background-color .2s ease;
+      contain: layout;
 
       .elastic-carousel-item-header {
         display: flex;

--- a/libs/c2/blocks/news/news.css
+++ b/libs/c2/blocks/news/news.css
@@ -29,6 +29,7 @@
     padding: var(--s2a-spacing-0) var(--s2a-spacing-lg);
     height: 100%;
     box-sizing: border-box;
+    contain: layout;
 
     > .foreground {
       display: flex;

--- a/libs/c2/blocks/section-metadata/section-metadata.css
+++ b/libs/c2/blocks/section-metadata/section-metadata.css
@@ -62,10 +62,6 @@
     align-items: stretch;
     grid-auto-rows: initial;
   }
-
-  &:not(.section:first-of-type) {
-    content-visibility: auto;
-  }
 }
 
 .section[class*='grid-width-'] {

--- a/libs/c2/blocks/section-metadata/section-metadata.css
+++ b/libs/c2/blocks/section-metadata/section-metadata.css
@@ -62,6 +62,10 @@
     align-items: stretch;
     grid-auto-rows: initial;
   }
+
+  &:not(.section:first-of-type) {
+    content-visibility: auto;
+  }
 }
 
 .section[class*='grid-width-'] {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2095,6 +2095,9 @@ async function loadPostLCP(config) {
       loadScript(`${config.base}/deps/lenis.min.js`),
     ]);
     const lerp = parseFloat(PAGE_URL.searchParams.get('inertialFactor')) || 0.08;
+    const fsThreshold = parseFloat(PAGE_URL.searchParams.get('fsThreshold')) || 90;
+    const fsFactor = parseFloat(PAGE_URL.searchParams.get('fsFactor')) || 0.4;
+    const fsDelay = parseFloat(PAGE_URL.searchParams.get('fsDelay')) || 300;
     const lenisPreventClasses = ['dialog-modal', 'ot-sdk-container', 'global-navigation'];
     window.lenis = new window.Lenis({
       autoRaf: true,
@@ -2104,10 +2107,10 @@ async function loadPostLCP(config) {
     // Reduce inertia during fast scrolling to avoid sustained RAF CPU usage
     let fastScrollTimer;
     window.addEventListener('wheel', (e) => {
-      if (Math.abs(e.deltaY) > 90) {
-        window.lenis.options.lerp = 0.4;
+      if (Math.abs(e.deltaY) > fsThreshold) {
+        window.lenis.options.lerp = fsFactor;
         clearTimeout(fastScrollTimer);
-        fastScrollTimer = setTimeout(() => { window.lenis.options.lerp = lerp; }, 300);
+        fastScrollTimer = setTimeout(() => { window.lenis.options.lerp = lerp; }, fsDelay);
       }
     }, { passive: true });
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2095,9 +2095,9 @@ async function loadPostLCP(config) {
       loadScript(`${config.base}/deps/lenis.min.js`),
     ]);
     const lerp = parseFloat(PAGE_URL.searchParams.get('inertialFactor')) || 0.08;
-    const fsThreshold = parseFloat(PAGE_URL.searchParams.get('fsThreshold')) || 90;
-    const fsFactor = parseFloat(PAGE_URL.searchParams.get('fsFactor')) || 0.4;
-    const fsDelay = parseFloat(PAGE_URL.searchParams.get('fsDelay')) || 300;
+    const fsThreshold = 110;
+    const fsFactor = 0.11;
+    const fsDelay = 700;
     const lenisPreventClasses = ['dialog-modal', 'ot-sdk-container', 'global-navigation'];
     window.lenis = new window.Lenis({
       autoRaf: true,
@@ -2105,12 +2105,12 @@ async function loadPostLCP(config) {
       prevent: (node) => lenisPreventClasses.some((cls) => node.classList?.contains(cls)),
     });
     // Reduce inertia during fast scrolling to avoid sustained RAF CPU usage
-    let fastScrollTimer;
+    let fsScrollTimer;
     window.addEventListener('wheel', (e) => {
       if (Math.abs(e.deltaY) > fsThreshold) {
         window.lenis.options.lerp = fsFactor;
-        clearTimeout(fastScrollTimer);
-        fastScrollTimer = setTimeout(() => { window.lenis.options.lerp = lerp; }, fsDelay);
+        clearTimeout(fsScrollTimer);
+        fsScrollTimer = setTimeout(() => { window.lenis.options.lerp = lerp; }, fsDelay);
       }
     }, { passive: true });
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2101,6 +2101,15 @@ async function loadPostLCP(config) {
       lerp,
       prevent: (node) => lenisPreventClasses.some((cls) => node.classList?.contains(cls)),
     });
+    // Reduce inertia during fast scrolling to avoid sustained RAF CPU usage
+    let fastScrollTimer;
+    window.addEventListener('wheel', (e) => {
+      if (Math.abs(e.deltaY) > 90) {
+        window.lenis.options.lerp = 0.4;
+        clearTimeout(fastScrollTimer);
+        fastScrollTimer = setTimeout(() => { window.lenis.options.lerp = lerp; }, 300);
+      }
+    }, { passive: true });
   }
   // load privacy here if quick-link is present in first section
   const quickLink = document.querySelector('div.section')?.querySelector('.quick-link');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Working through some page performance tweaks to minimize cpu spin up, layout thrashing and paint storms during scrolling.
* Reduce inertia during fast scrolling to avoid sustained RAF CPU usage
* Added `content-visibility: auto:` For sections lower on the page (like the “Explore what’s new”,  “Adobe News” or “Tools that work for you”), use content-visibility: auto. This allows the browser to skip the rendering work (layout and painting) for off-screen content until the user scrolls near it.
* Added`contain: layout`; News-cards, elastic-cards, and base-cards. This tells the browser that changes inside those boxes won’t affect the layout of the rest of the page, limiting the scope of “Reflows.”

Resolves: [MWPW-191875](https://jira.corp.adobe.com/browse/MWPW-191875)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?mep=off&martech=off
- After: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=sr-page-scroll-perf&mep=off&martech=off

**Notes**
How the inertia throttling works:

- `deltaY > 80` — threshold for “fast” scroll (a typical slow scroll is ~30–50, fast flick is 100+). Tune as needed.
- `lerp = 0.4` — during fast scroll, Lenis converges ~5x faster to the target position, so the RAF loop idles sooner instead of easing for hundreds of ms.
- After `300ms` of no fast-scroll events, lerp resets to the original smooth value.

Why this helps CPU: Lenis’s RAF loop runs on every frame until Math.abs(velocity) < threshold. With lerp = 0.08, a fast fling can keep it running for 1–2 seconds per gesture. At lerp = 0.4, it converges in a few frames.

Adjusting numbers:
- Raise `90` threshold if it kicks in too eagerly on normal scrolling
- Lower `0.4` toward `1.0` for even less inertia on fast scroll (1.0 = instant, no smoothing)
- Raise `300` debounce if the smooth feel is snapping back too soon during continuous fast scroll





