### PR TITLE
MWPW-187017: Correctly decorate double tag CTAs

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -22,16 +22,24 @@ let videoLabels = {
 const isReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 let videoCounter = 0;
 
+export function getButtonType(buttonParent) {
+  const buttonTypeMap = { STRONG: 'blue', EM: 'outline', A: 'blue' };
+  let { nodeName } = buttonParent;
+  if (nodeName === 'STRONG') {
+    nodeName = buttonParent.parentElement?.nodeName === 'EM' ? 'EM' : nodeName;
+  }
+  return buttonTypeMap[nodeName] || 'outline';
+}
+
 export function decorateButtons(el, size) {
   const buttons = el.querySelectorAll('em a, strong a, p > a strong');
   if (buttons.length === 0) return;
-  const buttonTypeMap = { STRONG: 'blue', EM: 'outline', A: 'blue' };
 
   buttons.forEach((button) => {
     const parent = button.parentElement;
     if (shouldBlockFreeTrialLinks(button)) return;
     let target = button;
-    const buttonType = buttonTypeMap[parent.nodeName] || 'outline';
+    const buttonType = getButtonType(parent);
     if (button.nodeName === 'STRONG') {
       target = parent;
     } else {

--- a/test/utils/decorate.test.js
+++ b/test/utils/decorate.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { expect } from '@esm-bundle/chai';
-import { setBackgroundFocus } from '../../libs/utils/decorate.js';
+import { setBackgroundFocus, getButtonType } from '../../libs/utils/decorate.js';
 
 describe('setBackgroundFocus', () => {
   let container;
@@ -78,5 +78,42 @@ describe('setBackgroundFocus', () => {
     expect(img.dataset.title).to.equal('data-focal:50,50');
     setBackgroundFocus(pic);
     expect(img.dataset.title).to.be.undefined;
+  });
+});
+
+describe('Decorate', () => {
+  it('Should return outline for <em><strong> CTA', async () => {
+    const ctaParent = document.createElement('em');
+    const cta = document.createElement('strong');
+    cta.innerHTML = '<a href="https://test.com">CTA</a>';
+    ctaParent.appendChild(cta);
+    const type = getButtonType(cta);
+    expect(type).to.equal('outline');
+  });
+  it('Should return outline for <strong><em> CTA', async () => {
+    const ctaParent = document.createElement('strong');
+    const cta = document.createElement('em');
+    cta.innerHTML = '<a href="https://test.com">CTA</a>';
+    ctaParent.appendChild(cta);
+    const type = getButtonType(cta);
+    expect(type).to.equal('outline');
+  });
+  it('Should return blue for <strong> CTA', async () => {
+    const cta = document.createElement('strong');
+    cta.innerHTML = '<a href="https://test.com">CTA</a>';
+    const type = getButtonType(cta);
+    expect(type).to.equal('blue');
+  });
+  it('Should return outline for <em> CTA', async () => {
+    const cta = document.createElement('em');
+    cta.innerHTML = '<a href="https://test.com">CTA</a>';
+    const type = getButtonType(cta);
+    expect(type).to.equal('outline');
+  });
+  it('Should return blue for <a> CTA', async () => {
+    const cta = document.createElement('a');
+    cta.innerHTML = '<strong>CTA</strong>';
+    const type = getButtonType(cta);
+    expect(type).to.equal('blue');
   });
 });


### PR DESCRIPTION
Issue: If CTA link is both bold and italic, tag that is returned is:
`<em><strong><a href="https://www.adobe.com/products/special-offers.html">Découvrir nos offres spéciales</a></strong></em>`
Current logic, treats this only as strong resulting in blue button

- Check if strong tag has em parent

Example: 
- Old DC page: `<strong><em><a href="">More tutorials</a></em></strong> `-> `outline` btn
- Imported DA DC page: `<em><strong><a href="">More tutorials</a></strong></em>` -> `blue` btn 


Resolves: [MWPW-187017](https://jira.corp.adobe.com/browse/MWPW-187017)

**Test URLs:**
- Before: https://main-double-tag-cta--milo--adobecom.aem.page/drafts/ratko/mwpw-186114-aside-da/aside
- After: https://mwpw-187017-double-tag-cta--milo--adobecom.aem.page/drafts/ratko/mwpw-186114-aside-da/aside

**DC URLs:**
- Old DC: https://main--dc--adobecom.aem.live/acrobat/business/acrobat-pro-14-day-trial
- DA DC: https://main--da-dc--adobecom.aem.live/acrobat/business/acrobat-pro-14-day-trial
- After: https://main--da-dc--adobecom.aem.live/acrobat/business/acrobat-pro-14-day-trial?milolibs=mwpw-187017-double-tag-cta

**BACOM URLs:**
- Old BACOM: https://main--bacom--adobecom.aem.live/customer-success-stories/lenovo-case-study
- DA BACOM: https://main--da-bacom--adobecom.aem.live/customer-success-stories/lenovo-case-study
- After: https://main--da-bacom--adobecom.aem.live/customer-success-stories/lenovo-case-study?milolibs=mwpw-187017-double-tag-cta

**CC URLs:**
- Before: https://main--cc--adobecom.aem.live/ai/overview/news
- After: https://main--cc--adobecom.aem.live/ai/overview/news?milolibs=mwpw-187017-double-tag-cta

