### PR TITLE
MWPW-189755 Hide duplicate promo image link from a11y & tab order

### DIFF
--- a/libs/blocks/global-navigation/utilities/keyboard/utils.js
+++ b/libs/blocks/global-navigation/utilities/keyboard/utils.js
@@ -21,7 +21,6 @@ const selectors = {
   breadCrumbItems: '.feds-breadcrumbs li:not(:nth-last-child(n+3):not(:first-child)) > a',
   expandedPopupTrigger: '.feds-navLink[aria-expanded = "true"]',
   promoLink: '.feds-promo-link',
-  imagePromo: 'a.feds-promo-image',
   fedsNav: '.feds-nav',
   popup: '.feds-popup',
   headline: '.feds-menu-headline',
@@ -63,7 +62,6 @@ selectors.profileDropdown = `
 selectors.popupItems = `
   ${selectors.navLink}:not(.feds-navLink--header),
   ${selectors.promoLink},
-  ${selectors.imagePromo},
   ${selectors.cta},
   ${selectors.regionPicker},
   ${selectors.socialLink},

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -246,7 +246,7 @@ const decoratePromo = async (elem, index) => {
     let promoImageElem;
 
     if (linkElem instanceof HTMLElement) {
-      promoImageElem = toFragment`<a class="feds-promo-image" href="${linkElem.href}" daa-ll="promo-image">
+      promoImageElem = toFragment`<a class="feds-promo-image" href="${linkElem.href}" daa-ll="promo-image" aria-hidden="true" tabindex="-1">
           ${imageElem}
         </a>`;
     } else {

--- a/test/blocks/global-navigation/gnav-main-nav-popup.test.js
+++ b/test/blocks/global-navigation/gnav-main-nav-popup.test.js
@@ -67,7 +67,10 @@ describe('main nav popups', () => {
       document.querySelector(selectors.mainNavToggle).click();
       document.querySelector(selectors.navLink).click();
 
-      expect(isElementVisible(document.querySelector(selectors.promoImage))).to.equal(true);
+      const promoImage = document.querySelector(selectors.promoImage);
+      expect(isElementVisible(promoImage)).to.equal(true);
+      expect(promoImage.getAttribute('aria-hidden')).to.equal('true');
+      expect(promoImage.getAttribute('tabindex')).to.equal('-1');
     });
 
     it('should allow CTAs in Promo boxes', async () => {
@@ -129,7 +132,10 @@ describe('main nav popups', () => {
       document.querySelector(selectors.mainNavToggle).click();
       document.querySelector(selectors.navLink).click();
 
-      expect(isElementVisible(document.querySelector(selectors.promoImage))).to.equal(true);
+      const promoImage = document.querySelector(selectors.promoImage);
+      expect(isElementVisible(promoImage)).to.equal(true);
+      expect(promoImage.getAttribute('aria-hidden')).to.equal('true');
+      expect(promoImage.getAttribute('tabindex')).to.equal('-1');
     });
   });
 

--- a/test/blocks/global-navigation/keyboard/keyboard-mobile.test.js
+++ b/test/blocks/global-navigation/keyboard/keyboard-mobile.test.js
@@ -9,7 +9,7 @@ const isOpen = (element) => element.getAttribute('aria-expanded') === 'true'
 const isClosed = (element) => element.getAttribute('aria-expanded') === 'false'
   && element.hasAttribute('daa-lh', 'header|Open');
 const getPopup = (element) => element.parentElement.querySelector(selectors.popup);
-const getNavLinks = (trigger) => [...getPopup(trigger).querySelectorAll(`${selectors.navLink}, ${selectors.promoLink}, ${selectors.imagePromo}`)];
+const getNavLinks = (trigger) => [...getPopup(trigger).querySelectorAll(`${selectors.navLink}, ${selectors.promoLink}`)];
 let mainNavItems;
 let keyboardNavigation;
 const loadStyles = (path) => new Promise((resolve) => {

--- a/test/blocks/global-navigation/keyboard/keyboard-mobile.test.js
+++ b/test/blocks/global-navigation/keyboard/keyboard-mobile.test.js
@@ -71,10 +71,10 @@ describe('mobile', () => {
       expect(document.activeElement).to.equal(navLinks[1]);
     });
     it('shifts focus from the last popup item, to the next trigger', async () => {
-      const section = navLinks[navLinks.length - 2].closest(selectors.section);
+      const section = navLinks[navLinks.length - 1].closest(selectors.section);
       const headline = section.querySelector(selectors.headline);
       headline.setAttribute('aria-expanded', true);
-      navLinks[navLinks.length - 2].focus();
+      navLinks[navLinks.length - 1].focus();
       await sendKeys({ press: 'Tab' });
       expect(document.activeElement).to.equal(triggerTwo);
     });
@@ -104,10 +104,10 @@ describe('mobile', () => {
       expect(document.activeElement.innerText).to.equal('second-column-first-section-first-item');
     });
     it('shifts focus from the last popup item to the next trigger', async () => {
-      const section = navLinks[navLinks.length - 2].closest(selectors.section);
+      const section = navLinks[navLinks.length - 1].closest(selectors.section);
       const headline = section.querySelector(selectors.headline);
       headline.setAttribute('aria-expanded', true);
-      navLinks[navLinks.length - 2].focus();
+      navLinks[navLinks.length - 1].focus();
       await sendKeys({ press: 'ArrowRight' });
       expect(document.activeElement).to.equal(triggerTwo);
     });
@@ -190,10 +190,10 @@ describe('mobile', () => {
       expect(document.activeElement).to.equal(navLinks[1]);
     });
     it('shifts focus from the last popup item, to the next trigger', async () => {
-      const section = navLinks[navLinks.length - 2].closest(selectors.section);
+      const section = navLinks[navLinks.length - 1].closest(selectors.section);
       const headline = section.querySelector(selectors.headline);
       headline.setAttribute('aria-expanded', true);
-      navLinks[navLinks.length - 2].focus();
+      navLinks[navLinks.length - 1].focus();
       await sendKeys({ press: 'ArrowDown' });
       expect(document.activeElement).to.equal(triggerTwo);
     });

--- a/test/blocks/global-navigation/keyboard/keyboard.test.js
+++ b/test/blocks/global-navigation/keyboard/keyboard.test.js
@@ -10,7 +10,7 @@ const isOpen = (element) => element.getAttribute('aria-expanded') === 'true'
 const isClosed = (element) => element.getAttribute('aria-expanded') === 'false'
   && element.hasAttribute('daa-lh', 'header|Open');
 const getPopup = (element) => element.parentElement.querySelector(selectors.popup);
-const getNavLinks = (trigger) => [...getPopup(trigger).querySelectorAll(`${selectors.navLink}, ${selectors.promoLink}, ${selectors.imagePromo}`)];
+const getNavLinks = (trigger) => [...getPopup(trigger).querySelectorAll(`${selectors.navLink}, ${selectors.promoLink}`)];
 let mainNavItems;
 let otherNavItems;
 let keyboardNavigation;
@@ -253,8 +253,7 @@ describe('keyboard navigation', () => {
         const navLinks = [
           ...triggerOne.parentElement.querySelectorAll(`
         ${selectors.navLink},
-        ${selectors.promoLink},
-        ${selectors.imagePromo}
+        ${selectors.promoLink}
       `),
         ];
         const lastNavLink = navLinks[navLinks.length - 1];

--- a/test/blocks/global-navigation/keyboard/mocks/global-nav-mobile.html
+++ b/test/blocks/global-navigation/keyboard/mocks/global-nav-mobile.html
@@ -426,6 +426,8 @@
                         <a
                           class="feds-promo-image"
                           href="https://www.adobe.com/"
+                          aria-hidden="true"
+                          tabindex="-1"
                         >
                           <picture>
                             <source


### PR DESCRIPTION
Resolves: [MWPW-189757](https://jira.corp.adobe.com/browse/MWPW-189757)

**Test URLs:**
https://www.stage.adobe.com/acrobat.html?milolibs=MWPW-189757-header-decorative-image-alt-text 

Problem
The mega-menu promo graphic was wrapped in a link that duplicated the “Start free trial” CTA. Screen readers announced unhelpful text (e.g. “decorative image”) for that link, and keyboard users hit an extra tab stop for the same destination.

Solution
Mark the promo image anchor (a.feds-promo-image) with aria-hidden="true" and tabindex="-1" so it is not exposed to assistive tech and is not in the tab order.
Remove the promo image link from the custom popup keyboard focus list (popupItems in utilities/keyboard/utils.js).
Update global-navigation tests and the mobile nav mock to match the new behavior.

<img width="1728" height="1117" alt="Screenshot 2026-04-09 at 11 20 28 AM" src="https://github.com/user-attachments/assets/0e5211a7-60e5-4363-9b0a-c48b5d3af69d" />



<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- Milo: https://MWPW-189757-header-decorative-image-alt-text--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- Milo: https://MWPW-189757-header-decorative-image-alt-text--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- Milo: https://MWPW-189757-header-decorative-image-alt-text--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-189757-header-decorative-image-alt-text--milo--adobecom
</details>