### PR TITLE
MWPW-187510 Relationship NPS Survey for Adobe Home

### DIFF
--- a/libs/blocks/nps-csat-form/nps-csat-form.css
+++ b/libs/blocks/nps-csat-form/nps-csat-form.css
@@ -647,11 +647,13 @@ body:has(.nps-csat-form.dark.match-background) {
 }
 
 .nps-csat-form.eleven-point-nps .nps-popover-item {
+  position: relative;
   display: flex;
   align-items: center;
   min-height: 24px;
   border-radius: 4px;
-  padding: 4px 9px 4px 28px;
+  padding-block: 4px;
+  padding-inline: 28px 9px;
   color: #292929;
   font-size: 12px;
   font-weight: 500;
@@ -666,6 +668,25 @@ body:has(.nps-csat-form.dark.match-background) {
 
 .nps-csat-form.eleven-point-nps .nps-popover-item[aria-selected="true"] {
   background: #e1e1e1;
+}
+
+.nps-csat-form.eleven-point-nps .nps-popover-item[aria-selected="true"]::before {
+  content: '';
+  position: absolute;
+  inset-inline-start: 9px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 10px;
+  background-color: rgba(59, 99, 251, 1);
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z'/%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: 10px 10px;
+  mask-size: 10px 10px;
 }
 
 @media (min-width: 480px) {

--- a/libs/blocks/nps-csat-form/nps-csat-form.css
+++ b/libs/blocks/nps-csat-form/nps-csat-form.css
@@ -437,6 +437,7 @@ body:has(.nps-csat-form.dark.match-background) {
   font-size: 18px;
   line-height: 20px;
   font-weight: 700;
+  padding-right: 24px;
 }
 
 .nps-csat-form.eleven-point-nps legend,

--- a/libs/blocks/nps-csat-form/nps-csat-form.css
+++ b/libs/blocks/nps-csat-form/nps-csat-form.css
@@ -633,6 +633,8 @@ body:has(.nps-csat-form.dark.match-background) {
 }
 
 .nps-csat-form.eleven-point-nps .nps-popover {
+  box-sizing: border-box;
+  min-width: 0;
   border: none;
   border-radius: 10px;
   padding: 8px;
@@ -650,6 +652,7 @@ body:has(.nps-csat-form.dark.match-background) {
   position: relative;
   display: flex;
   align-items: center;
+  min-width: 0;
   min-height: 24px;
   border-radius: 4px;
   padding-block: 4px;
@@ -658,6 +661,7 @@ body:has(.nps-csat-form.dark.match-background) {
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
+  overflow-wrap: break-word;
 }
 
 .nps-csat-form.eleven-point-nps .nps-popover-item:hover,

--- a/libs/blocks/nps-csat-form/nps-csat-form.css
+++ b/libs/blocks/nps-csat-form/nps-csat-form.css
@@ -452,11 +452,11 @@ body:has(.nps-csat-form.dark.match-background) {
 }
 
 .nps-csat-form.eleven-point-nps .nps-close {
-  top: -9px;
-  right: -9px;
-  width: 24px;
-  height: 24px;
-  font-size: 20px;
+  top: -5px;
+  right: -5px;
+  width: 12px;
+  height: 12px;
+  font-size: 24px;
 }
 
 .nps-csat-form.eleven-point-nps .nps-feedback-area textarea {
@@ -672,14 +672,6 @@ body:has(.nps-csat-form.dark.match-background) {
   .nps-csat-form.eleven-point-nps {
     border-radius: 16px;
     padding: 32px;
-  }
-
-  .nps-csat-form.eleven-point-nps .nps-close {
-    top: -25px;
-    right: -25px;
-    width: 32px;
-    height: 32px;
-    font-size: 24px;
   }
 
   .nps-csat-form.eleven-point-nps #nps {

--- a/libs/blocks/nps-csat-form/nps-csat-form.css
+++ b/libs/blocks/nps-csat-form/nps-csat-form.css
@@ -479,8 +479,9 @@ body:has(.nps-csat-form.dark.match-background) {
 
 .nps-csat-form.eleven-point-nps .nps-cancel,
 .nps-csat-form.eleven-point-nps .nps-submit {
-  padding-block: 6px 8px;
-  padding-inline: 16px;
+  padding-block: 4px;
+  padding-inline: 12px;
+  font-size: 12px;
 }
 
 .nps-csat-form.eleven-point-nps .desktop-nps-radio {
@@ -742,6 +743,13 @@ body:has(.nps-csat-form.dark.match-background) {
   .nps-csat-form.eleven-point-nps .nps-feedback-area textarea {
     height: 115px;
     max-height: 115px;
+  }
+
+  .nps-csat-form.eleven-point-nps .nps-cancel,
+  .nps-csat-form.eleven-point-nps .nps-submit {
+    padding-block: 7px;
+    padding-inline: 16px;
+    font-size: 14px;
   }
 }
 

--- a/libs/blocks/nps-csat-form/nps-csat-form.css
+++ b/libs/blocks/nps-csat-form/nps-csat-form.css
@@ -24,13 +24,16 @@
 
 .nps-close {
   position: absolute;
-  top: -20px;
-  right: -20px;
+  top: -25px;
+  right: -25px;
   background: none;
   border: none;
+  padding: 0;
   font-size: 24px;
+  line-height: 1;
+  font-weight: 400;
   cursor: pointer;
-  color: #666;
+  color: #2C2C2C;
   width: 32px;
   height: 32px;
   display: flex;
@@ -390,6 +393,9 @@ body:has(.nps-csat-form.dark.match-background) {
   outline: 2px solid #0066cc;
   outline-offset: 2px;
 }
+.nps-csat-form.dark .nps-close {
+  color: #DBDBDB;
+}
 .nps-csat-form.dark .nps-submit:focus {
   outline: 2px solid #0066cc;
   outline-offset: 0px;
@@ -399,5 +405,417 @@ body:has(.nps-csat-form.dark.match-background) {
   color: #FC432E;
 }
 .nps-csat-form.dark .nps-close:hover {
-  color: #DBDBDB;
+  color: #FFFFFF;
+}
+
+/* ============================================
+   Responsive + NPS-specific overrides
+   ============================================ */
+
+.nps-csat-form.eleven-point-nps {
+  width: 100%;
+  height: 100%;
+  min-width: 288px;
+  padding: 16px;
+  margin: 0;
+  box-sizing: border-box;
+  border-radius: 8px;
+  max-width: none;
+}
+
+.nps-csat-form.eleven-point-nps:not(.remove-box-shadow) {
+  box-shadow: none;
+}
+
+.nps-csat-form.eleven-point-nps #nps {
+  height: auto;
+  gap: 0;
+}
+
+.nps-csat-form.eleven-point-nps h2 {
+  margin: 0 0 8px 0;
+  font-size: 18px;
+  line-height: 20px;
+  font-weight: 700;
+}
+
+.nps-csat-form.eleven-point-nps legend,
+.nps-csat-form.eleven-point-nps .nps-feedback-area legend,
+.nps-csat-form.eleven-point-nps .nps-checkbox-area label,
+.nps-csat-form.eleven-point-nps .error-message,
+.nps-csat-form.eleven-point-nps .nps-feedback-area textarea {
+  font-size: 12px;
+}
+
+.nps-csat-form.eleven-point-nps .error-message {
+  margin-bottom: 0;
+}
+
+.nps-csat-form.eleven-point-nps .nps-close {
+  top: -9px;
+  right: -9px;
+  width: 24px;
+  height: 24px;
+  font-size: 20px;
+}
+
+.nps-csat-form.eleven-point-nps .nps-feedback-area textarea {
+  padding-block: 6px 8px;
+  padding-inline: 12px;
+  text-align: start;
+}
+
+.nps-csat-form.eleven-point-nps .nps-submit-area {
+  margin-top: 16px;
+}
+
+.nps-csat-form.eleven-point-nps .nps-radio-group {
+  margin-bottom: 8px;
+}
+
+.nps-csat-form.eleven-point-nps .nps-feedback-area {
+  margin-bottom: 0;
+}
+
+.nps-csat-form.eleven-point-nps .nps-cancel,
+.nps-csat-form.eleven-point-nps .nps-submit {
+  padding-block: 6px 8px;
+  padding-inline: 16px;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio {
+  display: none;
+}
+
+.nps-csat-form.eleven-point-nps .mobile-nps-select {
+  display: block;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio {
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 8px;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio > .radio-options {
+  display: flex;
+  justify-content: flex-start;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio .radio-item {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio .radio-item input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  inset: 0;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio .radio-item label {
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 7px;
+  background: #e1e1e1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  max-width: none;
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 500;
+  color: #2c2c2c;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio .radio-item label span {
+  align-self: center;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio .radio-item:has(input[type="radio"]:focus) label {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio .radio-item:has(input[type="radio"]:checked) label {
+  background: #2c2c2c;
+  border-color: transparent;
+  color: #fff;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio .radio-item:hover label {
+  background: #d4d4d4;
+}
+
+.nps-csat-form.eleven-point-nps .desktop-nps-radio .radio-item:has(input[type="radio"]:checked):hover label {
+  background: #1f1f1f;
+  color: #fff;
+}
+
+.nps-csat-form.eleven-point-nps .nps-scale-label {
+  font-size: 12px;
+  line-height: 16px;
+  color: #505050;
+}
+
+.nps-csat-form.eleven-point-nps .nps-scale-label--low {
+  text-align: start;
+}
+
+.nps-csat-form.eleven-point-nps .nps-scale-label--high {
+  text-align: end;
+}
+
+.nps-csat-form.eleven-point-nps .nps-picker {
+  display: block;
+  width: 100%;
+}
+
+.nps-csat-form.eleven-point-nps .mobile-nps-select {
+  width: min(100%, 192px);
+}
+
+.nps-csat-form.eleven-point-nps .nps-picker-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  width: 100%;
+  min-height: 24px;
+  border: none;
+  border-radius: 7px;
+  padding: 4px 9px;
+  background: #e1e1e1;
+  color: #131313;
+  font-family: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  text-align: start;
+}
+
+.nps-csat-form.eleven-point-nps .nps-picker-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: start;
+}
+
+.nps-csat-form.eleven-point-nps .nps-picker-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 10px;
+  height: 10px;
+  margin-inline-start: 8px;
+  flex: 0 0 10px;
+  align-self: center;
+  line-height: 0;
+}
+
+.nps-csat-form.eleven-point-nps .nps-picker-chevron::before {
+  content: '';
+  width: 10px;
+  height: 10px;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M5.59375 7.48254L9.2168 3.85949C9.54492 3.53137 9.54492 3.00011 9.2168 2.67199C8.88868 2.34387 8.35742 2.34387 8.0293 2.67199L5 5.70129L1.9707 2.67199C1.64258 2.34387 1.11132 2.34387 0.783201 2.67199C0.619142 2.83605 0.537111 3.0509 0.537111 3.26574C0.537111 3.48058 0.619142 3.69543 0.783201 3.85949L4.40625 7.48254C4.73437 7.81066 5.26563 7.81066 5.59375 7.48254Z'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10'%3E%3Cpath d='M5.59375 7.48254L9.2168 3.85949C9.54492 3.53137 9.54492 3.00011 9.2168 2.67199C8.88868 2.34387 8.35742 2.34387 8.0293 2.67199L5 5.70129L1.9707 2.67199C1.64258 2.34387 1.11132 2.34387 0.783201 2.67199C0.619142 2.83605 0.537111 3.0509 0.537111 3.26574C0.537111 3.48058 0.619142 3.69543 0.783201 3.85949L4.40625 7.48254C4.73437 7.81066 5.26563 7.81066 5.59375 7.48254Z'/%3E%3C/svg%3E");
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-size: 10px 10px;
+  mask-size: 10px 10px;
+}
+
+.nps-csat-form.eleven-point-nps .nps-popover {
+  border: none;
+  border-radius: 10px;
+  padding: 8px;
+  margin: 0;
+  inset: unset;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  background: #fff;
+  position: absolute;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+}
+
+.nps-csat-form.eleven-point-nps .nps-popover-item {
+  display: flex;
+  align-items: center;
+  min-height: 24px;
+  border-radius: 4px;
+  padding: 4px 9px 4px 28px;
+  color: #292929;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.nps-csat-form.eleven-point-nps .nps-popover-item:hover,
+.nps-csat-form.eleven-point-nps .nps-popover-item:focus {
+  background: #e8e8e8;
+  outline: none;
+}
+
+.nps-csat-form.eleven-point-nps .nps-popover-item[aria-selected="true"] {
+  background: #e1e1e1;
+}
+
+@media (min-width: 480px) {
+  .nps-csat-form.eleven-point-nps {
+    border-radius: 16px;
+    padding: 32px;
+  }
+
+  .nps-csat-form.eleven-point-nps .nps-close {
+    top: -25px;
+    right: -25px;
+    width: 32px;
+    height: 32px;
+    font-size: 24px;
+  }
+
+  .nps-csat-form.eleven-point-nps #nps {
+    gap: 0;
+  }
+
+  .nps-csat-form.eleven-point-nps h2 {
+    font-size: 20px;
+    line-height: 24px;
+  }
+
+  .nps-csat-form.eleven-point-nps .desktop-nps-radio {
+    display: flex;
+  }
+
+  .nps-csat-form.eleven-point-nps .mobile-nps-select {
+    display: none;
+  }
+
+  .nps-csat-form.eleven-point-nps .desktop-nps-radio > .radio-options {
+    gap: 4px;
+  }
+}
+
+@media (min-width: 600px) {
+  .nps-csat-form.eleven-point-nps h2 {
+    font-size: 22px;
+    line-height: 26px;
+  }
+
+  .nps-csat-form.eleven-point-nps legend,
+  .nps-csat-form.eleven-point-nps .nps-feedback-area legend,
+  .nps-csat-form.eleven-point-nps .nps-checkbox-area label,
+  .nps-csat-form.eleven-point-nps .error-message,
+  .nps-csat-form.eleven-point-nps .nps-feedback-area textarea {
+    font-size: 14px;
+  }
+
+  .nps-csat-form.eleven-point-nps #nps {
+    gap: 0;
+  }
+
+  .nps-csat-form.eleven-point-nps .nps-radio-group {
+    margin-bottom: 16px;
+  }
+
+  .nps-csat-form.eleven-point-nps .nps-submit-area {
+    margin-top: 8px;
+  }
+
+  .nps-csat-form.eleven-point-nps .desktop-nps-radio > .radio-options {
+    gap: 8px;
+  }
+
+  .nps-csat-form.eleven-point-nps .desktop-nps-radio .radio-item label {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+  }
+
+  .nps-csat-form.eleven-point-nps .nps-feedback-area textarea {
+    height: 115px;
+    max-height: 115px;
+  }
+}
+
+.nps-csat-form.dark.eleven-point-nps .desktop-nps-radio .radio-item label {
+  color: #dbdbdb;
+  background: #111;
+  border: none;
+}
+
+.nps-csat-form.dark.eleven-point-nps .desktop-nps-radio .radio-item:hover label {
+  background: #1f1f1f;
+  border: none;
+}
+
+.nps-csat-form.dark.eleven-point-nps .desktop-nps-radio .radio-item:has(input[type="radio"]:checked) label {
+  background: #dbdbdb;
+  border: none;
+  color: #111;
+}
+
+.nps-csat-form.dark.eleven-point-nps .desktop-nps-radio .radio-item:has(input[type="radio"]:checked):hover label {
+  background: #fff;
+  border: none;
+  color: #111;
+}
+
+.nps-csat-form.dark.eleven-point-nps .nps-scale-label {
+  color: #afafaf;
+}
+
+.nps-csat-form.dark.eleven-point-nps .nps-picker-trigger {
+  background: #111;
+  color: #dbdbdb;
+  border: 1px solid #393939;
+}
+
+.nps-csat-form.dark.eleven-point-nps .nps-popover {
+  background: #222;
+  border: 1px solid #393939;
+}
+
+.nps-csat-form.dark.eleven-point-nps .nps-popover-item {
+  color: #dbdbdb;
+}
+
+.nps-csat-form.dark.eleven-point-nps .nps-popover-item:hover,
+.nps-csat-form.dark.eleven-point-nps .nps-popover-item:focus {
+  background: #2f2f2f;
+}
+
+.nps-csat-form.dark.eleven-point-nps .nps-popover-item[aria-selected="true"] {
+  background: #393939;
+}
+
+.nps-csat-form.dark.eleven-point-nps .nps-feedback-area textarea::placeholder {
+  color: #8a8a8a;
+}
+
+.nps-csat-form.eleven-point-nps[dir="rtl"] .nps-checkbox-area label {
+  flex-direction: row-reverse;
+}
+
+.nps-csat-form.eleven-point-nps[dir="rtl"] .nps-picker-trigger {
+  direction: rtl;
+}
+
+.nps-csat-form.eleven-point-nps[dir="rtl"] .nps-scale-label--low {
+  text-align: end;
+}
+
+.nps-csat-form.eleven-point-nps[dir="rtl"] .nps-scale-label--high {
+  text-align: start;
+}
+
+.nps-csat-form.eleven-point-nps[dir="rtl"] .nps-submit-area {
+  justify-content: flex-start;
 }

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -11,6 +11,14 @@
 
 import { getConfig, loadMartech } from '../../utils/utils.js';
 
+/** Escapes strings for safe insertion into HTML text or double-quoted attributes. */
+const escapeHtml = (str) => String(str ?? '')
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
 const SURVEY_VERSION = '0.0.1';
 const RTL_LANG_PREFIXES = ['ar', 'he', 'fa', 'ur'];
 const NPS_DIGIT_BUFFER_TIMEOUT = 500;
@@ -40,10 +48,10 @@ class NpsPicker extends HTMLElement {
         <div
           class="nps-popover-item"
           role="option"
-          data-value="${option.value}"
+          data-value="${escapeHtml(option.value)}"
           tabindex="${index === 0 ? '0' : '-1'}"
           aria-selected="false"
-        >${option.text}</div>
+        >${escapeHtml(option.text)}</div>
       `).join('');
 
     this.innerHTML = `
@@ -53,12 +61,12 @@ class NpsPicker extends HTMLElement {
         popovertarget="${uid}"
         aria-haspopup="listbox"
         aria-expanded="false"
-        ${labelledby ? `aria-labelledby="${labelledby}"` : ''}
+        ${labelledby ? `aria-labelledby="${escapeHtml(labelledby)}"` : ''}
       >
-        <span class="nps-picker-label">${placeholder}</span>
+        <span class="nps-picker-label">${escapeHtml(placeholder)}</span>
         <span class="nps-picker-chevron" aria-hidden="true"></span>
       </button>
-      <div id="${uid}" class="nps-popover" popover="auto" role="listbox" ${labelledby ? `aria-labelledby="${labelledby}"` : ''}>
+      <div id="${uid}" class="nps-popover" popover="auto" role="listbox" ${labelledby ? `aria-labelledby="${escapeHtml(labelledby)}"` : ''}>
         ${items}
       </div>
       <input type="hidden" name="feedback" value="" ${this.hasAttribute('required') ? 'required' : ''} />
@@ -260,24 +268,24 @@ const buildForm = ({
 }) => `
   <form id="nps" novalidate>
     ${displayCross ? '<button type="button" class="nps-close" aria-label="Close">&times;</button>' : ''}
-    <h2>${title}</h2>
+    <h2>${escapeHtml(title)}</h2>
     <fieldset class="nps-radio-group" aria-required="true" aria-describedby="feedback-error">
-      <legend id="nps-question-label">${radioGroupLabel} *</legend>
+      <legend id="nps-question-label">${escapeHtml(radioGroupLabel)} *</legend>
       <div class="radio-options">
         ${options(radioGroup, npsOptions)}
       </div>
       <div class="error-message" id="feedback-error" aria-live="polite" aria-hidden="true">
         <span class="error-icon">⚠</span>
-        <span class="error-text">${errorText}</span>
+        <span class="error-text">${escapeHtml(errorText)}</span>
       </div>
     </fieldset>
     <fieldset class="nps-feedback-area">
-      <legend>${feedbackLabel}</legend>
+      <legend>${escapeHtml(feedbackLabel)}</legend>
       <textarea
         id="explanation-input"
         name="explanation"
-        placeholder="${textboxPlaceholder}"
-        aria-label="${feedbackLabel}"
+        placeholder="${escapeHtml(textboxPlaceholder)}"
+        aria-label="${escapeHtml(feedbackLabel)}"
         rows="4"
       ></textarea>
     </fieldset>
@@ -288,12 +296,12 @@ const buildForm = ({
           id="contact-me"
           name="contact-me"
         />
-        ${contactMeString}
+        ${escapeHtml(contactMeString)}
       </label>
     </fieldset>
     <fieldset class="nps-submit-area">
-      <button type="button" aria-label="Cancel" class="nps-cancel">${cancelText}</button>
-      <button type="submit" aria-label="Submit" class="nps-submit">${submitText}</button>
+      <button type="button" aria-label="Cancel" class="nps-cancel">${escapeHtml(cancelText)}</button>
+      <button type="submit" aria-label="Submit" class="nps-submit">${escapeHtml(submitText)}</button>
     </fieldset>
   </form>
   `;
@@ -308,27 +316,27 @@ const options = (radioGroup, npsOptions) => {
     const lowestOption = scoreOptions[scoreOptions.length - 1];
     return `
       <div class="desktop-nps-radio">
-         <span class="nps-scale-label nps-scale-label--low">${lowestOption?.label ?? ''}</span>
+         <span class="nps-scale-label nps-scale-label--low">${escapeHtml(lowestOption?.label ?? '')}</span>
          <div class="radio-options">
            ${scoreOptions.slice().reverse().map((scoreOption) => `
              <div class="radio-item">
-               <label for="nps-${scoreOption.value}"><span>${scoreOption.display}</span></label>
+               <label for="nps-${escapeHtml(scoreOption.value)}"><span>${escapeHtml(scoreOption.display)}</span></label>
                <input
                  type="radio"
-                 id="nps-${scoreOption.value}"
+                 id="nps-${escapeHtml(scoreOption.value)}"
                  name="feedback"
-                 value="${scoreOption.value}"
-                 data-display="${scoreOption.display}"
+                 value="${escapeHtml(scoreOption.value)}"
+                 data-display="${escapeHtml(scoreOption.display)}"
                  required
                />
              </div>
            `).join('')}
          </div>
-         <span class="nps-scale-label nps-scale-label--high">${highestOption?.label ?? ''}</span>
+         <span class="nps-scale-label nps-scale-label--high">${escapeHtml(highestOption?.label ?? '')}</span>
       </div>
       <div class="mobile-nps-select">
-        <nps-picker class="nps-picker" placeholder="${defaultSelectOption}" aria-labelledby="nps-question-label" required>
-          ${scoreOptions.map((scoreOption) => `<nps-picker-option value="${scoreOption.value}">${scoreOption.label ? `${scoreOption.display} – ${scoreOption.label}` : scoreOption.display}</nps-picker-option>`).join('')}
+        <nps-picker class="nps-picker" placeholder="${escapeHtml(defaultSelectOption)}" aria-labelledby="nps-question-label" required>
+          ${scoreOptions.map((scoreOption) => `<nps-picker-option value="${escapeHtml(scoreOption.value)}">${escapeHtml(scoreOption.label ? `${scoreOption.display} – ${scoreOption.label}` : scoreOption.display)}</nps-picker-option>`).join('')}
         </nps-picker>
       </div>
     `;
@@ -340,12 +348,12 @@ const radio = (label) => {
   const id = createIdForLabel(label);
   return `
   <div class="radio-item">
-    <label for="${id}"><span>${label}</span></label>
+    <label for="${escapeHtml(id)}"><span>${escapeHtml(label)}</span></label>
     <input
       type="radio"
-      id="${id}"
+      id="${escapeHtml(id)}"
       name="feedback"
-      value="${id}"
+      value="${escapeHtml(id)}"
       required
     />
   </div>

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -389,9 +389,37 @@ const initKeyboardAccessibility = (form, sendMessage) => {
   const radioButtons = Array.from(form.querySelectorAll('input[type="radio"][name="feedback"]'));
   const checkbox = form.querySelector('#contact-me');
   const npsRadioButtons = Array.from(form.querySelectorAll('.desktop-nps-radio input[type="radio"][name="feedback"]'));
-  const isNPS = !!form.closest('.nps-csat-form.eleven-point-nps');
+  const isElevenPointForm = !!form.closest('.nps-csat-form.eleven-point-nps');
   let npsDigitBuffer = '';
   let npsDigitBufferTimeout;
+
+  const onElevenPointFormEnterCapture = (event) => {
+    if (event.key !== 'Enter') return;
+    const target = event.target;
+    if (target instanceof HTMLTextAreaElement) return;
+    if (target instanceof HTMLButtonElement && target.type === 'submit') return;
+    if (target instanceof HTMLButtonElement && target.type === 'button') return;
+    if (target instanceof HTMLElement && target.classList.contains('nps-popover-item')) return;
+
+    if (target instanceof HTMLInputElement && target.type === 'radio' && target.name === 'feedback') {
+      event.preventDefault();
+      if (!target.checked) {
+        target.checked = true;
+        target.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      return;
+    }
+    if (target instanceof HTMLInputElement && target.type === 'checkbox' && target.id === 'contact-me') {
+      event.preventDefault();
+      target.checked = !target.checked;
+      return;
+    }
+    if (target instanceof HTMLElement && target.classList.contains('nps-picker-trigger')) {
+      event.preventDefault();
+      target.click();
+      return;
+    }
+  };
 
   const getTargetIndex = (key, index) => {
     switch (key) {
@@ -425,9 +453,13 @@ const initKeyboardAccessibility = (form, sendMessage) => {
     });
   }
 
+  if (isElevenPointForm) {
+    form.addEventListener('keydown', onElevenPointFormEnterCapture, true);
+  }
+
   form.addEventListener('keydown', (e) => {
     if (
-      isNPS
+      isElevenPointForm
       && /^\d$/.test(e.key)
       && !(e.target instanceof HTMLTextAreaElement)
       && !(e.target instanceof HTMLInputElement && e.target.type !== 'radio')
@@ -460,6 +492,9 @@ const initKeyboardAccessibility = (form, sendMessage) => {
 
   return () => {
     clearTimeout(npsDigitBufferTimeout);
+    if (isElevenPointForm) {
+      form.removeEventListener('keydown', onElevenPointFormEnterCapture, true);
+    }
   };
 };
 

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -87,9 +87,45 @@ class NpsPicker extends HTMLElement {
       if (this.#supportsPopoverApi) return;
       event.preventDefault();
       if (this.#popover.hidden) {
-        this.#openFallbackPopover();
+        this.#openPopover();
       } else {
         this.#closePopover();
+      }
+    });
+    this.#trigger.addEventListener('keydown', (event) => {
+      if (event.key === 'Tab' && this.#isPopoverOpen()) {
+        this.#closePopover();
+        return;
+      }
+      if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+        event.preventDefault();
+        if (this.#isPopoverOpen()) {
+          this.#focusSelectedItemOrFallback(0);
+        } else {
+          this.#focusItemOnOpenIndex = 0;
+          this.#openPopover();
+        }
+        return;
+      }
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        if (this.#isPopoverOpen()) {
+          this.#focusSelectedItemOrFallback(0);
+        } else {
+          this.#focusItemOnOpenIndex = 0;
+          this.#openPopover();
+        }
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        if (this.#isPopoverOpen()) {
+          this.#focusSelectedItemOrFallback(this.#items.length - 1);
+        } else {
+          this.#focusItemOnOpenIndex = this.#items.length - 1;
+          this.#openPopover();
+        }
+        return;
       }
     });
 
@@ -101,13 +137,25 @@ class NpsPicker extends HTMLElement {
       item.addEventListener('keydown', (event) => this.#onItemKeydown(event, item));
     });
 
+    this.addEventListener('focusout', (event) => this.#onFocusOut(event));
+
     this.#popover.addEventListener('toggle', (event) => {
       const isOpen = event.newState === 'open';
       this.#trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
       if (isOpen) {
         this.#positionPopover();
         this.#attachPopoverResize();
+        if (Number.isInteger(this.#focusItemOnOpenIndex)) {
+          const focusIndex = this.#focusItemOnOpenIndex;
+          this.#focusItemOnOpenIndex = null;
+          queueMicrotask(() => {
+            if (this.#isPopoverOpen()) {
+              this.#focusSelectedItemOrFallback(focusIndex);
+            }
+          });
+        }
       } else {
+        this.#focusItemOnOpenIndex = null;
         this.#detachPopoverResize();
       }
     });
@@ -152,6 +200,56 @@ class NpsPicker extends HTMLElement {
 
   #popoverResizeHandler = null;
 
+  #focusItemOnOpenIndex = null;
+
+  #focusSelectedItemOrFallback(fallbackIndex) {
+    const selectedItem = this.#items.find((item) => item.getAttribute('aria-selected') === 'true');
+    const clampedIndex = Math.max(0, Math.min(fallbackIndex, this.#items.length - 1));
+    const fallbackItem = this.#items[clampedIndex];
+    (selectedItem ?? fallbackItem)?.focus();
+  }
+
+  #focusNextElementAfterTrigger() {
+    const focusRoot = this.closest('form') ?? document;
+    const focusableSelector = 'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+    const focusableElements = Array.from(focusRoot.querySelectorAll(focusableSelector))
+      .filter((element) => element === this.#trigger || !this.contains(element));
+    const triggerIndex = focusableElements.indexOf(this.#trigger);
+    focusableElements[triggerIndex + 1]?.focus();
+  }
+
+  #openPopover() {
+    if (this.#supportsPopoverApi && typeof this.#popover.showPopover === 'function') {
+      if (!this.#popover.matches(':popover-open')) {
+        this.#popover.showPopover();
+      }
+      return;
+    }
+    if (this.#popover.hidden) {
+      this.#openFallbackPopover();
+    }
+  }
+
+  #isPopoverOpen() {
+    if (this.#supportsPopoverApi && typeof this.#popover.matches === 'function') {
+      return this.#popover.matches(':popover-open');
+    }
+    return !this.#popover.hidden;
+  }
+
+  #onFocusOut(event) {
+    if (!this.#isPopoverOpen()) return;
+
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && this.contains(nextTarget)) return;
+
+    queueMicrotask(() => {
+      const activeElement = document.activeElement;
+      if (activeElement instanceof Node && this.contains(activeElement)) return;
+      this.#closePopover();
+    });
+  }
+
   #detachPopoverResize() {
     if (!this.#popoverResizeHandler) return;
     window.removeEventListener('resize', this.#popoverResizeHandler);
@@ -167,6 +265,17 @@ class NpsPicker extends HTMLElement {
   #onItemKeydown(event, item) {
     const index = this.#items.indexOf(item);
     if (index === -1) return;
+
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      this.#closePopover();
+      if (event.shiftKey) {
+        this.#trigger.focus();
+      } else {
+        this.#focusNextElementAfterTrigger();
+      }
+      return;
+    }
 
     if (event.key === 'ArrowDown') {
       event.preventDefault();
@@ -415,7 +524,7 @@ const initKeyboardAccessibility = (form, sendMessage) => {
 
   const onElevenPointFormEnterCapture = (event) => {
     if (event.key !== 'Enter') return;
-    const { target } = event;
+    const target = event.target;
     if (target instanceof HTMLTextAreaElement) return;
     if (target instanceof HTMLButtonElement && target.type === 'submit') return;
     if (target instanceof HTMLButtonElement && target.type === 'button') return;
@@ -434,10 +543,7 @@ const initKeyboardAccessibility = (form, sendMessage) => {
       target.checked = !target.checked;
       return;
     }
-    if (target instanceof HTMLElement && target.classList.contains('nps-picker-trigger')) {
-      event.preventDefault();
-      target.click();
-    }
+    if (target instanceof HTMLElement && target.classList.contains('nps-picker-trigger')) return;
   };
 
   const getTargetIndex = (key, index) => {

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -125,7 +125,6 @@ class NpsPicker extends HTMLElement {
           this.#focusItemOnOpenIndex = this.#items.length - 1;
           this.#openPopover();
         }
-        return;
       }
     });
 
@@ -244,7 +243,7 @@ class NpsPicker extends HTMLElement {
     if (nextTarget instanceof Node && this.contains(nextTarget)) return;
 
     queueMicrotask(() => {
-      const activeElement = document.activeElement;
+      const { activeElement } = document;
       if (activeElement instanceof Node && this.contains(activeElement)) return;
       this.#closePopover();
     });
@@ -524,7 +523,7 @@ const initKeyboardAccessibility = (form, sendMessage) => {
 
   const onElevenPointFormEnterCapture = (event) => {
     if (event.key !== 'Enter') return;
-    const target = event.target;
+    const { target } = event;
     if (target instanceof HTMLTextAreaElement) return;
     if (target instanceof HTMLButtonElement && target.type === 'submit') return;
     if (target instanceof HTMLButtonElement && target.type === 'button') return;
@@ -541,9 +540,7 @@ const initKeyboardAccessibility = (form, sendMessage) => {
     if (target instanceof HTMLInputElement && target.type === 'checkbox' && target.id === 'contact-me') {
       event.preventDefault();
       target.checked = !target.checked;
-      return;
     }
-    if (target instanceof HTMLElement && target.classList.contains('nps-picker-trigger')) return;
   };
 
   const getTargetIndex = (key, index) => {

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -415,7 +415,7 @@ const initKeyboardAccessibility = (form, sendMessage) => {
 
   const onElevenPointFormEnterCapture = (event) => {
     if (event.key !== 'Enter') return;
-    const target = event.target;
+    const { target } = event;
     if (target instanceof HTMLTextAreaElement) return;
     if (target instanceof HTMLButtonElement && target.type === 'submit') return;
     if (target instanceof HTMLButtonElement && target.type === 'button') return;
@@ -437,7 +437,6 @@ const initKeyboardAccessibility = (form, sendMessage) => {
     if (target instanceof HTMLElement && target.classList.contains('nps-picker-trigger')) {
       event.preventDefault();
       target.click();
-      return;
     }
   };
 

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -563,6 +563,10 @@ const initKeyboardAccessibility = (form, sendMessage) => {
       e.preventDefault();
       const targetRadio = radioButtons[targetIndex];
       targetRadio.focus();
+      if (!isElevenPointForm) {
+        targetRadio.checked = true;
+        targetRadio.dispatchEvent(new Event('change', { bubbles: true }));
+      }
     });
   });
 

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -106,6 +106,9 @@ class NpsPicker extends HTMLElement {
       this.#trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
       if (isOpen) {
         this.#positionPopover();
+        this.#attachPopoverResize();
+      } else {
+        this.#detachPopoverResize();
       }
     });
   }
@@ -147,6 +150,20 @@ class NpsPicker extends HTMLElement {
 
   #escapeHandler = null;
 
+  #popoverResizeHandler = null;
+
+  #detachPopoverResize() {
+    if (!this.#popoverResizeHandler) return;
+    window.removeEventListener('resize', this.#popoverResizeHandler);
+    this.#popoverResizeHandler = null;
+  }
+
+  #attachPopoverResize() {
+    this.#detachPopoverResize();
+    this.#popoverResizeHandler = () => this.#positionPopover();
+    window.addEventListener('resize', this.#popoverResizeHandler);
+  }
+
   #onItemKeydown(event, item) {
     const index = this.#items.indexOf(item);
     if (index === -1) return;
@@ -187,12 +204,14 @@ class NpsPicker extends HTMLElement {
   #closePopover() {
     if (this.#supportsPopoverApi && typeof this.#popover.hidePopover === 'function') {
       if (this.#popover.matches(':popover-open')) {
+        this.#detachPopoverResize();
         this.#popover.hidePopover();
       } else {
         this.#trigger.setAttribute('aria-expanded', 'false');
       }
       return;
     }
+    this.#detachPopoverResize();
     this.#popover.hidden = true;
     this.#trigger.setAttribute('aria-expanded', 'false');
     if (this.#outsideClickHandler) {
@@ -209,6 +228,7 @@ class NpsPicker extends HTMLElement {
     this.#popover.hidden = false;
     this.#trigger.setAttribute('aria-expanded', 'true');
     this.#positionPopover();
+    this.#attachPopoverResize();
     this.#outsideClickHandler = (event) => {
       if (!this.contains(event.target)) {
         this.#closePopover();

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -12,6 +12,234 @@
 import { getConfig, loadMartech } from '../../utils/utils.js';
 
 const SURVEY_VERSION = '0.0.1';
+const RTL_LANG_PREFIXES = ['ar', 'he', 'fa', 'ur'];
+const NPS_DIGIT_BUFFER_TIMEOUT = 500;
+
+// ############################################
+// NPS Picker Web Component
+// ############################################
+
+let npsPickerIdCounter = 0;
+
+class NpsPicker extends HTMLElement {
+  connectedCallback() {
+    if (this.dataset.initialized === 'true') return;
+    this.dataset.initialized = 'true';
+
+    const options = Array.from(this.querySelectorAll('nps-picker-option')).map((option) => ({
+      value: option.getAttribute('value') ?? '',
+      text: option.textContent?.trim() ?? '',
+    }));
+
+    const uid = `nps-popover-${npsPickerIdCounter}`;
+    npsPickerIdCounter += 1;
+    const placeholder = this.getAttribute('placeholder') ?? 'Select an option';
+    const labelledby = this.getAttribute('aria-labelledby') ?? '';
+    const items = options
+      .map((option, index) => `
+        <div
+          class="nps-popover-item"
+          role="option"
+          data-value="${option.value}"
+          tabindex="${index === 0 ? '0' : '-1'}"
+          aria-selected="false"
+        >${option.text}</div>
+      `).join('');
+
+    this.innerHTML = `
+      <button
+        type="button"
+        class="nps-picker-trigger"
+        popovertarget="${uid}"
+        aria-haspopup="listbox"
+        aria-expanded="false"
+        ${labelledby ? `aria-labelledby="${labelledby}"` : ''}
+      >
+        <span class="nps-picker-label">${placeholder}</span>
+        <span class="nps-picker-chevron" aria-hidden="true"></span>
+      </button>
+      <div id="${uid}" class="nps-popover" popover="auto" role="listbox" ${labelledby ? `aria-labelledby="${labelledby}"` : ''}>
+        ${items}
+      </div>
+      <input type="hidden" name="feedback" value="" ${this.hasAttribute('required') ? 'required' : ''} />
+    `;
+
+    this.#trigger = this.querySelector('.nps-picker-trigger');
+    this.#label = this.querySelector('.nps-picker-label');
+    this.#popover = this.querySelector('.nps-popover');
+    this.#hiddenInput = this.querySelector('input[type="hidden"][name="feedback"]');
+    this.#items = Array.from(this.querySelectorAll('.nps-popover-item'));
+    this.#placeholder = placeholder;
+    this.#supportsPopoverApi = typeof this.#popover.showPopover === 'function' && typeof this.#popover.hidePopover === 'function';
+    if (!this.#supportsPopoverApi) {
+      this.#popover.hidden = true;
+    }
+
+    this.#trigger.addEventListener('click', (event) => {
+      if (this.#supportsPopoverApi) return;
+      event.preventDefault();
+      if (this.#popover.hidden) {
+        this.#openFallbackPopover();
+      } else {
+        this.#closePopover();
+      }
+    });
+
+    this.#items.forEach((item) => {
+      item.addEventListener('click', () => {
+        this.#selectItem(item);
+        this.#closePopover();
+      });
+      item.addEventListener('keydown', (event) => this.#onItemKeydown(event, item));
+    });
+
+    this.#popover.addEventListener('toggle', (event) => {
+      const isOpen = event.newState === 'open';
+      this.#trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      if (isOpen) {
+        this.#positionPopover();
+      }
+    });
+  }
+
+  get value() {
+    return this.#hiddenInput?.value ?? '';
+  }
+
+  set value(nextValue) {
+    const value = `${nextValue ?? ''}`;
+    if (!value) {
+      this.#hiddenInput.value = '';
+      this.#label.textContent = this.#placeholder;
+      this.#items.forEach((item, index) => {
+        item.setAttribute('aria-selected', 'false');
+        item.tabIndex = index === 0 ? 0 : -1;
+      });
+      return;
+    }
+    const selectedItem = this.#items.find((item) => item.dataset.value === value);
+    if (selectedItem) this.#selectItem(selectedItem);
+  }
+
+  #trigger;
+
+  #label;
+
+  #popover;
+
+  #hiddenInput;
+
+  #items = [];
+
+  #placeholder = '';
+
+  #supportsPopoverApi = false;
+
+  #outsideClickHandler = null;
+
+  #escapeHandler = null;
+
+  #onItemKeydown(event, item) {
+    const index = this.#items.indexOf(item);
+    if (index === -1) return;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const next = this.#items[(index + 1) % this.#items.length];
+      next.focus();
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const prev = this.#items[(index - 1 + this.#items.length) % this.#items.length];
+      prev.focus();
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.#selectItem(item);
+      this.#closePopover();
+    }
+  }
+
+  #selectItem(item) {
+    const selectedValue = item.dataset.value ?? '';
+    this.#hiddenInput.value = selectedValue;
+    this.#label.textContent = item.textContent?.trim() ?? this.#placeholder;
+
+    this.#items.forEach((option) => {
+      const isSelected = option === item;
+      option.setAttribute('aria-selected', isSelected ? 'true' : 'false');
+      option.tabIndex = isSelected ? 0 : -1;
+    });
+
+    this.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  #closePopover() {
+    if (this.#supportsPopoverApi && typeof this.#popover.hidePopover === 'function') {
+      if (this.#popover.matches(':popover-open')) {
+        this.#popover.hidePopover();
+      } else {
+        this.#trigger.setAttribute('aria-expanded', 'false');
+      }
+      return;
+    }
+    this.#popover.hidden = true;
+    this.#trigger.setAttribute('aria-expanded', 'false');
+    if (this.#outsideClickHandler) {
+      document.removeEventListener('mousedown', this.#outsideClickHandler);
+      this.#outsideClickHandler = null;
+    }
+    if (this.#escapeHandler) {
+      document.removeEventListener('keydown', this.#escapeHandler);
+      this.#escapeHandler = null;
+    }
+  }
+
+  #openFallbackPopover() {
+    this.#popover.hidden = false;
+    this.#trigger.setAttribute('aria-expanded', 'true');
+    this.#positionPopover();
+    this.#outsideClickHandler = (event) => {
+      if (!this.contains(event.target)) {
+        this.#closePopover();
+      }
+    };
+    this.#escapeHandler = (event) => {
+      if (event.key === 'Escape' || event.key === 'Esc') {
+        this.#closePopover();
+      }
+    };
+    document.addEventListener('mousedown', this.#outsideClickHandler);
+    document.addEventListener('keydown', this.#escapeHandler);
+  }
+
+  #positionPopover() {
+    const triggerBox = this.#trigger.getBoundingClientRect();
+    const popoverOffset = 4;
+    const viewportPadding = 16;
+    const availableBelow = Math.floor(
+      window.innerHeight - (triggerBox.bottom + popoverOffset) - viewportPadding,
+    );
+    const constrainedHeight = Math.max(0, availableBelow);
+
+    this.#popover.style.width = `${triggerBox.width}px`;
+    this.#popover.style.top = `${triggerBox.bottom + window.scrollY + popoverOffset}px`;
+    this.#popover.style.maxHeight = `${constrainedHeight}px`;
+    this.#popover.style.overflowY = 'auto';
+    const isRtl = this.closest('[dir="rtl"]') !== null;
+    if (isRtl) {
+      this.#popover.style.left = `${triggerBox.right + window.scrollX - triggerBox.width}px`;
+    } else {
+      this.#popover.style.left = `${triggerBox.left + window.scrollX}px`;
+    }
+  }
+}
+
+if (!customElements.get('nps-picker')) {
+  customElements.define('nps-picker', NpsPicker);
+}
 
 // ############################################
 // HTML
@@ -21,6 +249,7 @@ const buildForm = ({
   title,
   radioGroupLabel,
   radioGroup,
+  npsOptions,
   feedbackLabel,
   textboxPlaceholder,
   contactMeString,
@@ -32,10 +261,10 @@ const buildForm = ({
   <form id="nps" novalidate>
     ${displayCross ? '<button type="button" class="nps-close" aria-label="Close">&times;</button>' : ''}
     <h2>${title}</h2>
-    <fieldset class="nps-radio-group" role="radiogroup" aria-label="${radioGroupLabel}" aria-required="true" aria-describedby="feedback-error">
-      <legend>${radioGroupLabel} *</legend>
+    <fieldset class="nps-radio-group" aria-required="true" aria-describedby="feedback-error">
+      <legend id="nps-question-label">${radioGroupLabel} *</legend>
       <div class="radio-options">
-        ${radioGroup.map(radio).join('')}
+        ${options(radioGroup, npsOptions)}
       </div>
       <div class="error-message" id="feedback-error" aria-live="polite" aria-hidden="true">
         <span class="error-icon">⚠</span>
@@ -69,6 +298,44 @@ const buildForm = ({
   </form>
   `;
 
+const options = (radioGroup, npsOptions) => {
+  if (npsOptions) {
+    const {
+      defaultSelectOption,
+      scoreOptions,
+    } = npsOptions;
+    const highestOption = scoreOptions[0];
+    const lowestOption = scoreOptions[scoreOptions.length - 1];
+    return `
+      <div class="desktop-nps-radio">
+         <span class="nps-scale-label nps-scale-label--low">${lowestOption?.label ?? ''}</span>
+         <div class="radio-options">
+           ${scoreOptions.slice().reverse().map((scoreOption) => `
+             <div class="radio-item">
+               <label for="nps-${scoreOption.value}"><span>${scoreOption.display}</span></label>
+               <input
+                 type="radio"
+                 id="nps-${scoreOption.value}"
+                 name="feedback"
+                 value="${scoreOption.value}"
+                 data-display="${scoreOption.display}"
+                 required
+               />
+             </div>
+           `).join('')}
+         </div>
+         <span class="nps-scale-label nps-scale-label--high">${highestOption?.label ?? ''}</span>
+      </div>
+      <div class="mobile-nps-select">
+        <nps-picker class="nps-picker" placeholder="${defaultSelectOption}" aria-labelledby="nps-question-label" required>
+          ${scoreOptions.map((scoreOption) => `<nps-picker-option value="${scoreOption.value}">${scoreOption.label ? `${scoreOption.display} – ${scoreOption.label}` : scoreOption.display}</nps-picker-option>`).join('')}
+        </nps-picker>
+      </div>
+    `;
+  }
+  return radioGroup.map(radio).join('');
+};
+
 const radio = (label) => {
   const id = createIdForLabel(label);
   return `
@@ -99,7 +366,8 @@ const cancelActions = (() => {
       feedback: null,
       contactMe: false,
     };
-    const surveyType = 'CSAT 5pt'; // Hardcoded until NPS forms are implemented
+    const isNPSForm = !!document.querySelector('form#nps nps-picker.nps-picker');
+    const surveyType = isNPSForm ? 'NPS' : 'CSAT 5pt';
     const dataObj = buildDataObject(d, surveyType, CancelSurvey);
     window._satellite?.track?.('event', dataObj) // eslint-disable-line
   };
@@ -112,6 +380,10 @@ const cancelActions = (() => {
 const initKeyboardAccessibility = (form, sendMessage) => {
   const radioButtons = Array.from(form.querySelectorAll('input[type="radio"][name="feedback"]'));
   const checkbox = form.querySelector('#contact-me');
+  const npsRadioButtons = Array.from(form.querySelectorAll('.desktop-nps-radio input[type="radio"][name="feedback"]'));
+  const isNPS = !!form.closest('.nps-csat-form.eleven-point-nps');
+  let npsDigitBuffer = '';
+  let npsDigitBufferTimeout;
 
   const getTargetIndex = (key, index) => {
     switch (key) {
@@ -134,9 +406,6 @@ const initKeyboardAccessibility = (form, sendMessage) => {
       const targetRadio = radioButtons[targetIndex];
       targetRadio.focus();
     });
-    button.addEventListener('focus', () => {
-      if (!button.checked) button.click();
-    });
   });
 
   if (checkbox) {
@@ -149,12 +418,41 @@ const initKeyboardAccessibility = (form, sendMessage) => {
   }
 
   form.addEventListener('keydown', (e) => {
+    if (
+      isNPS
+      && /^\d$/.test(e.key)
+      && !(e.target instanceof HTMLTextAreaElement)
+      && !(e.target instanceof HTMLInputElement && e.target.type !== 'radio')
+    ) {
+      clearTimeout(npsDigitBufferTimeout);
+      npsDigitBuffer = `${npsDigitBuffer}${e.key}`.slice(-2);
+
+      const candidateDisplays = npsDigitBuffer === '10' ? ['10'] : [e.key];
+      const targetRadio = npsRadioButtons
+        .find((inputEl) => candidateDisplays.includes(inputEl.dataset.display));
+      if (targetRadio) {
+        e.preventDefault();
+        targetRadio.checked = true;
+        targetRadio.focus();
+        targetRadio.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+
+      npsDigitBufferTimeout = setTimeout(() => {
+        npsDigitBuffer = '';
+      }, NPS_DIGIT_BUFFER_TIMEOUT);
+      return;
+    }
+
     if (e.key === 'Escape' || e.key === 'Esc') {
       e.preventDefault();
       cancelActions();
       sendMessage(CANCEL);
     }
   });
+
+  return () => {
+    clearTimeout(npsDigitBufferTimeout);
+  };
 };
 
 // ############################################
@@ -261,9 +559,16 @@ export const MSG_TIMEOUT = 1000;
 const STATE_BASE = 0;
 const STATE_EXPECT_ACK = 1;
 
-const initMessageClient = () => {
+const initMessageClient = (registerCleanup = () => {}) => {
   let state = STATE_BASE;
   let timeout;
+
+  const clearAckTimeout = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+  };
 
   const sendMessage = (() => {
     const parent = typeof window.uxpHost?.postMessage === 'function'
@@ -277,9 +582,11 @@ const initMessageClient = () => {
         case Cancel:
         case Ready: {
           state = STATE_EXPECT_ACK;
+          clearAckTimeout();
           timeout = setTimeout(() => {
             sendMessage(TIMEOUT_ERROR(null, 'Timed out waiting for "Acknowledged"'));
             state = STATE_BASE;
+            timeout = undefined;
           }, MSG_TIMEOUT);
           break;
         }
@@ -297,7 +604,11 @@ const initMessageClient = () => {
     };
   })();
 
-  window.addEventListener('message', (event) => {
+  const onMessage = (event) => {
+    if (typeof event.data !== 'string') {
+      return;
+    }
+
     const message = (() => {
       try {
         return JSON.parse(event.data);
@@ -317,7 +628,7 @@ const initMessageClient = () => {
       case Cancel:
         if (state === STATE_EXPECT_ACK) {
           state = STATE_BASE;
-          clearTimeout(timeout);
+          clearAckTimeout();
         }
         cancelActions();
         sendMessage(ACK);
@@ -325,7 +636,7 @@ const initMessageClient = () => {
       case Acknowledged: {
         if (state === STATE_EXPECT_ACK) {
           state = STATE_BASE;
-          clearTimeout(timeout);
+          clearAckTimeout();
         }
         break;
       }
@@ -343,8 +654,54 @@ const initMessageClient = () => {
       default:
         sendMessage(UNRECOGNIZED_TYPE_ERROR(message, `Message type ${message.type} is wrong`));
     }
+  };
+  window.addEventListener('message', onMessage);
+  registerCleanup(() => {
+    clearAckTimeout();
+    window.removeEventListener('message', onMessage);
   });
   return sendMessage;
+};
+
+// ############################################
+// Utils
+// ############################################
+
+const readScore = (form) => {
+  const isNPS = !!form.querySelector('.nps-picker');
+  if (isNPS) {
+    const desktopNpsRadio = form.querySelector('.desktop-nps-radio');
+    const mobileNpsSelect = form.querySelector('.mobile-nps-select');
+    const isDesktopVisible = !!desktopNpsRadio && window.getComputedStyle(desktopNpsRadio).display !== 'none';
+    const isMobileVisible = !!mobileNpsSelect && window.getComputedStyle(mobileNpsSelect).display !== 'none';
+
+    if (isDesktopVisible) {
+      const checkedRadio = form.querySelector('.desktop-nps-radio input[type="radio"][name="feedback"]:checked');
+      const score = parseInt(checkedRadio?.value, 10);
+      return Number.isNaN(score) ? -1 : score;
+    }
+
+    if (isMobileVisible) {
+      const selectedValue = form.querySelector('.mobile-nps-select nps-picker.nps-picker')?.value;
+      const score = parseInt(selectedValue, 10);
+      return Number.isNaN(score) ? -1 : score;
+    }
+
+    const fallbackScore = parseInt(new FormData(form).get('feedback'), 10);
+    return Number.isNaN(fallbackScore) ? -1 : fallbackScore;
+  }
+  const radioButtons = Array.from(form.querySelectorAll('input[type="radio"]'));
+  const idx = radioButtons.findIndex((r) => r.checked);
+  return idx === -1 ? -1 : idx + 1;
+};
+
+const updateNpsAriaLabel = (form) => {
+  const npsGroup = form.querySelector('.desktop-nps-radio .radio-options');
+  if (!npsGroup) return;
+  const selectedDisplay = form.querySelector('.desktop-nps-radio input[type="radio"][name="feedback"]:checked')?.dataset.display;
+  const valueText = selectedDisplay ?? 'none selected';
+  npsGroup.setAttribute('role', 'group');
+  npsGroup.setAttribute('aria-label', `Overall rating (radio group) ${valueText} out of 10`);
 };
 
 // ############################################
@@ -354,6 +711,31 @@ const initMessageClient = () => {
 export default async (block) => {
   // parsing the block
   if (!block) return;
+
+  const cleanupCallbacks = [];
+  const registerCleanup = (callback) => {
+    cleanupCallbacks.push(callback);
+  };
+  let isCleanedUp = false;
+  const runCleanup = () => {
+    if (isCleanedUp) return;
+    isCleanedUp = true;
+    while (cleanupCallbacks.length) {
+      const callback = cleanupCallbacks.pop();
+      callback?.();
+    }
+  };
+
+  const blockLifecycleObserver = new MutationObserver(() => {
+    if (!block.isConnected) {
+      runCleanup();
+    }
+  });
+  blockLifecycleObserver.observe(document.body, {
+    childList: true,
+    subtree: true,
+  });
+  registerCleanup(() => blockLifecycleObserver.disconnect());
 
   // We must not show the consent banner on the nps csat form
   const config = getConfig();
@@ -379,6 +761,7 @@ export default async (block) => {
     ?.nextElementSibling
     ?.textContent).map((x) => !!x ? x : null); // eslint-disable-line
   const searchParams = new URLSearchParams(window.location.search);
+  const sourceLocale = searchParams.get('source_locale')?.toLowerCase() ?? '';
 
   if (searchParams.get('source_color_theme')?.toLowerCase() === 'dark') {
     block.classList.add('dark');
@@ -388,6 +771,9 @@ export default async (block) => {
   }
   if (matchBackgroundColor?.toLowerCase() === 'true') {
     block.classList.add('match-background');
+  }
+  if (RTL_LANG_PREFIXES.some((prefix) => sourceLocale === prefix || sourceLocale.startsWith(`${prefix}-`))) {
+    block.setAttribute('dir', 'rtl');
   }
 
   // Set zoom on the body to handle edgecases in illustrator
@@ -401,13 +787,54 @@ export default async (block) => {
   } catch (e) {
     console.warn(e);
   }
-
-  const radioGroupList = (() => {
+  const {
+    radioGroupList,
+    npsOptions,
+  } = (() => {
     const [scale, optionList] = radioLabels?.split('::').map((x) => x.trim()) ?? [];
-    if (scale !== '5' && scale !== '7') {
-      console.warn('Invalid scale specified; defaulting to a 5 pt scale. The value of scale has to be either \'5\' or \'7\'');
+    if (scale !== '5' && scale !== '7' && scale !== '11') {
+      console.warn('Invalid scale specified; defaulting to a 5 pt scale. The value of scale has to be either \'5\', \'7\', or \'11\'.');
     }
     switch (scale) {
+      case '11': {
+        block.classList.add('eleven-point-nps');
+        const [defaultSelectValue, ...authoredScoreOptions] = optionList?.split(',').map((x) => x.trim()) ?? [];
+        const parsedScoreOptions = authoredScoreOptions
+          .map((token, index) => {
+            if (!token) return null;
+            const [rawDisplay, ...rawLabelParts] = token.split('-');
+            const display = rawDisplay?.trim();
+            if (!display) return null;
+            const label = rawLabelParts.join('-').trim();
+            return {
+              value: String(authoredScoreOptions.length - 1 - index),
+              display,
+              label,
+            };
+          })
+          .filter(Boolean);
+        const fallbackScoreOptions = [
+          { value: '10', display: '10', label: 'Extremely likely' },
+          { value: '9', display: '9', label: '' },
+          { value: '8', display: '8', label: '' },
+          { value: '7', display: '7', label: '' },
+          { value: '6', display: '6', label: '' },
+          { value: '5', display: '5', label: '' },
+          { value: '4', display: '4', label: '' },
+          { value: '3', display: '3', label: '' },
+          { value: '2', display: '2', label: '' },
+          { value: '1', display: '1', label: '' },
+          { value: '0', display: '0', label: 'Not at all likely' },
+        ];
+        return {
+          radioGroupList: (parsedScoreOptions.length ? parsedScoreOptions : fallbackScoreOptions)
+            .map((scoreOption) => scoreOption.display),
+          npsOptions: {
+            defaultSelectOption: defaultSelectValue ?? 'Select an Option',
+            scoreOptions: parsedScoreOptions.length ? parsedScoreOptions : fallbackScoreOptions,
+          },
+        };
+      }
       case '7': {
         block.classList.add('seven-point');
         const [
@@ -419,7 +846,7 @@ export default async (block) => {
           two,
           three,
         ] = optionList?.split(',').map((x) => x.trim()) ?? [];
-        return [
+        const sevenPointScale = [
           minusThree ?? 'Extremely dissatisfied',
           minusTwo   ?? 'Moderately dissatisfied',
           minusOne   ?? 'Slightly dissatisfied',
@@ -428,6 +855,10 @@ export default async (block) => {
           two        ?? 'Moderately satisfied',
           three      ?? 'Extremely satisfied',
         ];
+        return {
+          radioGroupList: sevenPointScale,
+          npsOptions: null,
+        };
       }
       case '5':
       default: {
@@ -439,20 +870,26 @@ export default async (block) => {
           two,
         ] = optionList?.split(',').map((x) => x.trim()) ?? [];
         block.classList.add('five-point');
-        return [
+        const fivePointScale = [
           minusTwo ?? 'Very dissatisfied',
           minusOne ?? 'Dissatisfied',
           zero     ?? 'Neutral',
           one      ?? 'Satisfied',
           two      ?? 'Very satisfied',
         ];
+        return {
+          radioGroupList: fivePointScale,
+          npsOptions: null,
+        };
       }
     }
   })();
+  const isNPSForm = !!npsOptions;
   const data = {
     title,
     radioGroupLabel: question,
     radioGroup: radioGroupList,
+    npsOptions,
     feedbackLabel: explanationString,
     textboxPlaceholder,
     contactMeString,
@@ -467,7 +904,7 @@ export default async (block) => {
     .createContextualFragment(buildForm(data));
   block.replaceChildren(formFragment);
 
-  const sendMessage = initMessageClient();
+  const sendMessage = initMessageClient(registerCleanup);
 
   try {
     await loadMartech();
@@ -481,7 +918,11 @@ export default async (block) => {
   }
 
   const form = block.querySelector('#nps');
-  initKeyboardAccessibility(form, sendMessage);
+  const cleanupKeyboardAccessibility = initKeyboardAccessibility(form, sendMessage);
+  registerCleanup(cleanupKeyboardAccessibility);
+  updateNpsAriaLabel(form);
+  const firstInteractiveElement = form.querySelector('.nps-close, input[type="radio"], .nps-picker-trigger, textarea, #contact-me, .nps-cancel, .nps-submit');
+  firstInteractiveElement?.focus();
 
   // The form will still be interactable in case
   // Acknowledgement fails
@@ -496,10 +937,9 @@ export default async (block) => {
     if (submitted) return;
     block.classList.add('submit-clicked');
 
-    const radioButtons = Array.from(form.querySelectorAll('input[type="radio"]'));
-    const selectedRadio = radioButtons.findIndex((r) => r.checked);
+    const score = readScore(form);
 
-    if (selectedRadio === -1) {
+    if (score === -1) {
       radioGroup.classList.add('show-error');
       radioGroup.setAttribute('aria-invalid', 'true');
       errorMessage?.setAttribute('aria-hidden', 'false');
@@ -510,7 +950,6 @@ export default async (block) => {
     errorMessage?.setAttribute('aria-hidden', 'true');
     submitted = true;
     const formData = new FormData(form);
-    const score = selectedRadio + 1;
     const feedback = formData.get('explanation');
     const contactMe = formData.get('contact-me') === 'on';
     const d = {
@@ -518,7 +957,7 @@ export default async (block) => {
       feedback,
       contactMe,
     };
-    const surveyType = 'CSAT 5pt'; // Hardcoded until NPS forms are implemented
+    const surveyType = isNPSForm ? 'NPS' : 'CSAT 5pt';
     const dataObj = buildDataObject(d, surveyType, SubmitSurvey);
     window._satellite?.track?.('event', dataObj) // eslint-disable-line
     sendMessage(SUBMIT(d));
@@ -544,11 +983,20 @@ export default async (block) => {
   const radioButtons = form.querySelectorAll('input[type="radio"]');
   radioButtons.forEach((r) => {
     r.addEventListener('change', () => {
+      updateNpsAriaLabel(form);
       if (block.classList.contains('submit-clicked')) {
         radioGroup.classList.remove('show-error');
         radioGroup.removeAttribute('aria-invalid');
         errorMessage?.setAttribute('aria-hidden', 'true');
       }
     });
+  });
+  form.querySelector('nps-picker.nps-picker')?.addEventListener('change', () => {
+    updateNpsAriaLabel(form);
+    if (block.classList.contains('submit-clicked')) {
+      radioGroup.classList.remove('show-error');
+      radioGroup.removeAttribute('aria-invalid');
+      errorMessage?.setAttribute('aria-hidden', 'true');
+    }
   });
 };

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -568,6 +568,14 @@ const initKeyboardAccessibility = (form, sendMessage) => {
         targetRadio.dispatchEvent(new Event('change', { bubbles: true }));
       }
     });
+    if (!isElevenPointForm) {
+      button.addEventListener('focus', () => {
+        if (!button.checked) {
+          button.checked = true;
+          button.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+      });
+    }
   });
 
   if (checkbox) {

--- a/test/blocks/nps-csat-form/nps-csat-form.test.html
+++ b/test/blocks/nps-csat-form/nps-csat-form.test.html
@@ -273,7 +273,6 @@
           });
 
           it('should not submit and show error if no radio button is selected', async () => {
-            // Initialize form
             await npsCsatForm(block);
             const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
@@ -282,11 +281,12 @@
             const form = block.querySelector('#nps');
             const radioGroup = block.querySelector('.nps-radio-group');
 
-            // Try to submit without selecting radio
+            // Programmatically uncheck all radios to test validation
+            form.querySelectorAll('input[type="radio"]').forEach((r) => { r.checked = false; });
+
             const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
             form.dispatchEvent(submitEvent);
 
-            // Should show error state
             expect(radioGroup.classList.contains('show-error')).to.be.true;
             expect(block.classList.contains('submit-clicked')).to.be.true;
           });
@@ -738,7 +738,6 @@
 
         describe('Radio Button Error State Management', () => {
           it('should remove error state when radio button is selected after submission attempt', async () => {
-            // Initialize form
             await npsCsatForm(block);
             const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
@@ -748,18 +747,18 @@
             const radioGroup = block.querySelector('.nps-radio-group');
             const radioButton = form.querySelector('input[type="radio"]');
 
-            // Try to submit without selecting radio (to trigger error)
+            // Programmatically uncheck all radios to test validation
+            form.querySelectorAll('input[type="radio"]').forEach((r) => { r.checked = false; });
+
             const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
             form.dispatchEvent(submitEvent);
 
             expect(radioGroup.classList.contains('show-error')).to.be.true;
 
-            // Now select a radio button
             radioButton.checked = true;
             const changeEvent = new Event('change', { bubbles: true });
             radioButton.dispatchEvent(changeEvent);
 
-            // Error should be removed after radio button selection
             expect(radioGroup.classList.contains('show-error')).to.be.false;
           });
         });

--- a/test/blocks/nps-csat-form/nps-csat-form.test.html
+++ b/test/blocks/nps-csat-form/nps-csat-form.test.html
@@ -13,17 +13,14 @@
   <script>
     // Set up mocking in a non-module script so it executes before any module loads
     window.capturedMessages = [];
-    window.mockParent = {
+    window.mockHost = {
       postMessage: (message, origin) => {
         window.capturedMessages.push({ message, origin });
       },
     };
-    
-    // Mock window.parent before any modules load
-    Object.defineProperty(window, 'parent', {
-      configurable: true,
-      get: () => window.mockParent,
-    });
+
+    // Use uxpHost to mock postMessage transport without redefining window.parent
+    window.uxpHost = window.mockHost;
   </script>
   <script type="module">
     import { runTests } from '@web/test-runner-mocha';
@@ -42,22 +39,22 @@
     const ErrorMsg = 'Error';
 
     // Helper to create a block with test data
-    const createBlock = () => {
+    const createBlock = (overrides = {}) => {
       const block = document.createElement('div');
       block.className = 'nps-csat-form';
       
       // Add child rows with test data
       const rows = [
-        ['Title', 'How satisfied are you?'],
-        ['Question', 'How satisfied are you with this product?'],
-        ['Radio Labels', '5 :: Very dissatisfied, Dissatisfied, Neutral, Satisfied, Very satisfied'],
-        ['Feedback Label', 'Please provide additional feedback'],
-        ['Textbox Placeholder', 'Enter your feedback here...'],
-        ['Contact Me', 'I would like Adobe to contact me about my feedback'],
-        ['Cancel Text', 'Cancel'],
-        ['Submit Text', 'Submit'],
-        ['Error Text', 'Please select a rating'],
-        ['Display Cross', 'false'],
+        ['Title', overrides.title ?? 'How satisfied are you?'],
+        ['Question', overrides.question ?? 'How satisfied are you with this product?'],
+        ['Radio Labels', overrides.radioLabels ?? '5 :: Very dissatisfied, Dissatisfied, Neutral, Satisfied, Very satisfied'],
+        ['Feedback Label', overrides.feedbackLabel ?? 'Please provide additional feedback'],
+        ['Textbox Placeholder', overrides.textboxPlaceholder ?? 'Enter your feedback here...'],
+        ['Contact Me', overrides.contactMeString ?? 'I would like Adobe to contact me about my feedback'],
+        ['Cancel Text', overrides.cancelText ?? 'Cancel'],
+        ['Submit Text', overrides.submitText ?? 'Submit'],
+        ['Error Text', overrides.errorText ?? 'Please select a rating'],
+        ['Display Cross', overrides.displayCross ?? 'false'],
       ];
       
       rows.forEach(([key, value]) => {
@@ -113,6 +110,20 @@
       // Start checking immediately
       setTimeout(checkForMessage, 0);
     });
+
+    const receiveMessageOfType = async (expectedType, timeoutMessage) => {
+      const startTime = Date.now();
+      const timeoutMs = MSG_TIMEOUT + 250;
+
+      while (Date.now() - startTime < timeoutMs) {
+        const message = await receiveMessage(timeoutMessage);
+        if (message.type === expectedType) {
+          return message;
+        }
+      }
+
+      throw new Error(timeoutMessage ?? `Timed out waiting for ${expectedType} message`);
+    };
 
     const sendMessage = (message) => {
       const event = new MessageEvent('message', {
@@ -171,7 +182,7 @@
           it('should send Ready message on initialization and wait for Ack', async () => {
             // Initialize the form
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -183,7 +194,7 @@
           it('should timeout and send Error message if no Ack received within timeout', async () => {
             // Initialize the form but don't send Ack
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
 
             // Don't send Ack - wait for timeout
@@ -198,7 +209,7 @@
             // Initialize form with proper Ack
             await npsCsatForm(block);
 
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -215,7 +226,7 @@
           it('should send Submit message with form data when form is submitted', async () => {
             // Initialize form
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -246,7 +257,7 @@
           it('should not submit and show error if no radio button is selected', async () => {
             // Initialize form
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -263,12 +274,214 @@
           });
         });
 
+        describe('NPS Form Handling', () => {
+          beforeEach(() => {
+            if (block && block.parentNode) {
+              block.parentNode.removeChild(block);
+            }
+            block = createBlock({
+              question: 'How likely are you to recommend Adobe to a friend or colleague?',
+              radioLabels: '11 :: Select an option, 10-Extremely likely, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0-Not at all likely',
+            });
+          });
+
+          it('should parse authored NPS options and map values to score positions', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const form = block.querySelector('#nps');
+            const desktopRadios = Array.from(form.querySelectorAll('.desktop-nps-radio input[type="radio"][name="feedback"]'));
+            const desktopLabels = Array.from(form.querySelectorAll('.desktop-nps-radio label span'));
+            const pickerOptions = Array.from(form.querySelectorAll('nps-picker .nps-popover-item'));
+
+            expect(desktopRadios.length).to.equal(11);
+            expect(desktopLabels[0].textContent.trim()).to.equal('0');
+            expect(desktopLabels[desktopLabels.length - 1].textContent.trim()).to.equal('10');
+            expect(desktopRadios[0].value).to.equal('0');
+            expect(desktopRadios[desktopRadios.length - 1].value).to.equal('10');
+
+            expect(pickerOptions.length).to.equal(11);
+            expect(pickerOptions[0].getAttribute('data-value')).to.equal('10');
+            expect(pickerOptions[0].textContent.trim()).to.equal('10 – Extremely likely');
+            expect(pickerOptions[1].getAttribute('data-value')).to.equal('9');
+            expect(pickerOptions[1].textContent.trim()).to.equal('9');
+            expect(pickerOptions[pickerOptions.length - 1].getAttribute('data-value')).to.equal('0');
+            expect(pickerOptions[pickerOptions.length - 1].textContent.trim()).to.equal('0 – Not at all likely');
+          });
+
+          it('should submit desktop NPS score using radio score value', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const form = block.querySelector('#nps');
+            const desktopContainer = form.querySelector('.desktop-nps-radio');
+            const mobileContainer = form.querySelector('.mobile-nps-select');
+            desktopContainer.style.display = 'block';
+            mobileContainer.style.display = 'none';
+
+            const radio = form.querySelector('#nps-2');
+            radio.checked = true;
+
+            const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+            form.dispatchEvent(submitEvent);
+
+            const submitMessage = await receiveMessageOfType(Submit);
+            expect(submitMessage.type).to.equal(Submit);
+            expect(submitMessage.data.score).to.equal(2);
+          });
+
+          it('should submit mobile NPS score using selected option score value', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const form = block.querySelector('#nps');
+            const desktopContainer = form.querySelector('.desktop-nps-radio');
+            const mobileContainer = form.querySelector('.mobile-nps-select');
+            const picker = form.querySelector('nps-picker.nps-picker');
+            desktopContainer.style.display = 'none';
+            mobileContainer.style.display = 'block';
+            picker.value = '4';
+
+            const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+            form.dispatchEvent(submitEvent);
+
+            const submitMessage = await receiveMessageOfType(Submit);
+            expect(submitMessage.type).to.equal(Submit);
+            expect(submitMessage.data.score).to.equal(4);
+          });
+        });
+
+        describe('NPS Popover Picker', () => {
+          beforeEach(() => {
+            if (block && block.parentNode) {
+              block.parentNode.removeChild(block);
+            }
+            block = createBlock({
+              question: 'How likely are you to recommend Adobe to a friend or colleague?',
+              radioLabels: '11 :: Select an option, 10-Extremely likely, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0-Not at all likely',
+            });
+          });
+
+          it('should render picker trigger, popover, and options', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const picker = block.querySelector('nps-picker.nps-picker');
+            const trigger = picker.querySelector('.nps-picker-trigger');
+            const popover = picker.querySelector('.nps-popover');
+            const options = picker.querySelectorAll('.nps-popover-item');
+
+            expect(picker).to.exist;
+            expect(trigger).to.exist;
+            expect(popover).to.exist;
+            expect(options.length).to.equal(11);
+          });
+
+          it('should update picker value and label when selecting an item', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const picker = block.querySelector('nps-picker.nps-picker');
+            const triggerLabel = picker.querySelector('.nps-picker-label');
+            const thirdItem = picker.querySelectorAll('.nps-popover-item')[2];
+
+            let changed = false;
+            picker.addEventListener('change', () => { changed = true; });
+            thirdItem.click();
+
+            expect(changed).to.be.true;
+            expect(picker.value).to.equal(thirdItem.getAttribute('data-value'));
+            expect(triggerLabel.textContent.trim()).to.equal(thirdItem.textContent.trim());
+            expect(thirdItem.getAttribute('aria-selected')).to.equal('true');
+          });
+
+          it('should sync aria-expanded with popover toggle events', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const picker = block.querySelector('nps-picker.nps-picker');
+            const trigger = picker.querySelector('.nps-picker-trigger');
+            const popover = picker.querySelector('.nps-popover');
+
+            const openEvent = new Event('toggle');
+            Object.defineProperty(openEvent, 'newState', { value: 'open' });
+            popover.dispatchEvent(openEvent);
+            expect(trigger.getAttribute('aria-expanded')).to.equal('true');
+
+            const closeEvent = new Event('toggle');
+            Object.defineProperty(closeEvent, 'newState', { value: 'closed' });
+            popover.dispatchEvent(closeEvent);
+            expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+          });
+
+          it('should support keyboard navigation and enter selection in popover', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const picker = block.querySelector('nps-picker.nps-picker');
+            const trigger = picker.querySelector('.nps-picker-trigger');
+            const popover = picker.querySelector('.nps-popover');
+            const items = picker.querySelectorAll('.nps-popover-item');
+            const first = items[0];
+            const second = items[1];
+
+            if (typeof popover.showPopover === 'function' && !popover.matches(':popover-open')) {
+              popover.showPopover();
+            } else {
+              trigger.click();
+            }
+
+            first.focus();
+            first.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }));
+            expect(document.activeElement).to.equal(second);
+
+            second.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+            expect(picker.value).to.equal(second.getAttribute('data-value'));
+          });
+
+          it('should show and clear submit error for picker selection flow', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const form = block.querySelector('#nps');
+            const radioGroup = block.querySelector('.nps-radio-group');
+            const desktopContainer = form.querySelector('.desktop-nps-radio');
+            const mobileContainer = form.querySelector('.mobile-nps-select');
+            const picker = form.querySelector('nps-picker.nps-picker');
+            desktopContainer.style.display = 'none';
+            mobileContainer.style.display = 'block';
+
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+            expect(radioGroup.classList.contains('show-error')).to.be.true;
+
+            const firstItem = picker.querySelectorAll('.nps-popover-item')[0];
+            firstItem.click();
+            expect(radioGroup.classList.contains('show-error')).to.be.false;
+          });
+        });
+
         describe('Cancel Button Handling', () => {
           it.skip('should send Cancel message when cancel button is clicked', async () => {
             // Skipped: cancelActions uses a closure that may have been called in previous tests
             // Initialize form
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -298,7 +511,7 @@
             // Skipped: cancelActions uses a closure that maintains state across tests
             // This test would need module reloading to work properly
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -326,7 +539,7 @@
           it('should send Error message for invalid JSON in parent messages', async () => {
             // Initialize form
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -345,7 +558,7 @@
           it('should send Error message for unrecognized message types', async () => {
             // Initialize form
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -363,7 +576,7 @@
           it('should remove error state when radio button is selected after submission attempt', async () => {
             // Initialize form
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -390,7 +603,7 @@
         describe('Keyboard Accessibility', () => {
           it('should navigate radio buttons forward with ArrowRight', async () => {
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -408,7 +621,7 @@
 
           it('should navigate radio buttons forward with ArrowUp', async () => {
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -426,7 +639,7 @@
 
           it('should navigate radio buttons backward with ArrowLeft', async () => {
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -444,7 +657,7 @@
 
           it('should wrap around when navigating with arrow keys', async () => {
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -468,7 +681,7 @@
 
           it('should toggle checkbox with spacebar', async () => {
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -498,7 +711,7 @@
           it.skip('should send cancel message when Escape key is pressed', async () => {
             // Skipped: cancelActions uses a closure that may have been called in previous tests
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -524,7 +737,7 @@
           it.skip('should send cancel message when Esc key is pressed', async () => {
             // Skipped: cancelActions uses a closure that may have been called in previous tests
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -545,11 +758,126 @@
           });
         });
 
+        describe('NPS Digit Key Navigation', () => {
+          beforeEach(() => {
+            if (block && block.parentNode) {
+              block.parentNode.removeChild(block);
+            }
+            block = createBlock({
+              question: 'How likely are you to recommend Adobe to a friend or colleague?',
+              radioLabels: '11 :: Select an option, 10-Extremely likely, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0-Not at all likely',
+            });
+          });
+
+          it('should select matching NPS value when pressing a digit key', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const form = block.querySelector('#nps');
+            const keyEvent = new KeyboardEvent('keydown', { key: '8', bubbles: true, cancelable: true });
+            form.dispatchEvent(keyEvent);
+
+            const scoreEightRadio = form.querySelector('.desktop-nps-radio input[type="radio"][data-display="8"]');
+            expect(scoreEightRadio.checked).to.be.true;
+          });
+
+          it('should select value 10 when pressing 1 then 0 quickly', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const form = block.querySelector('#nps');
+            form.dispatchEvent(new KeyboardEvent('keydown', { key: '1', bubbles: true, cancelable: true }));
+            form.dispatchEvent(new KeyboardEvent('keydown', { key: '0', bubbles: true, cancelable: true }));
+
+            const scoreTenRadio = form.querySelector('.desktop-nps-radio input[type="radio"][data-display="10"]');
+            expect(scoreTenRadio.checked).to.be.true;
+          });
+        });
+
+        describe('Focus Management', () => {
+          it('should focus close button first when close button is present', async () => {
+            if (block && block.parentNode) {
+              block.parentNode.removeChild(block);
+            }
+            block = createBlock({
+              displayCross: 'true',
+            });
+
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            expect(document.activeElement).to.equal(block.querySelector('.nps-close'));
+          });
+
+          it('should focus first radio when close button is absent', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            expect(document.activeElement).to.equal(block.querySelector('input[type="radio"]'));
+          });
+        });
+
+        describe('RTL Support', () => {
+          const originalUrl = window.location.href;
+
+          afterEach(() => {
+            window.history.replaceState({}, '', originalUrl);
+          });
+
+          it('should set dir=rtl when source_locale is an RTL locale', async () => {
+            window.history.replaceState({}, '', `${window.location.pathname}?source_locale=ar`);
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            expect(block.getAttribute('dir')).to.equal('rtl');
+          });
+
+          it('should set dir=rtl for additional RTL locales', async () => {
+            window.history.replaceState({}, '', `${window.location.pathname}?source_locale=he`);
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            expect(block.getAttribute('dir')).to.equal('rtl');
+          });
+
+          it('should not set dir=rtl for LTR locale', async () => {
+            window.history.replaceState({}, '', `${window.location.pathname}?source_locale=en`);
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            expect(block.hasAttribute('dir')).to.be.false;
+          });
+
+          it('should not set dir=rtl when source_locale is absent', async () => {
+            window.history.replaceState({}, '', `${window.location.pathname}`);
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            expect(block.hasAttribute('dir')).to.be.false;
+          });
+        });
+
 
         describe('Form Submission with Analytics', () => {
           it('should send analytics data with all form fields on successful submission', async () => {
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -594,7 +922,7 @@
 
           it('should prevent double submission', async () => {
             await npsCsatForm(block);
-            const readyMessage = await receiveMessage();
+            const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
             sendMessage(ACK);
 
@@ -628,7 +956,7 @@
             it('should start in STATE_BASE and transition to STATE_EXPECT_ACK when sending Ready message', async () => {
               // Initialize form - this sends Ready message and transitions to STATE_EXPECT_ACK
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
 
               // At this point, state should be STATE_EXPECT_ACK
@@ -643,7 +971,7 @@
             it('should transition from STATE_EXPECT_ACK to STATE_BASE when receiving Acknowledged', async () => {
               // Initialize form
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
 
               // Send ACK to transition back to STATE_BASE
@@ -662,7 +990,7 @@
             it('should transition to STATE_EXPECT_ACK when sending Cancel message', async () => {
               // Initialize and acknowledge
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
               sendMessage(ACK);
 
@@ -687,7 +1015,7 @@
             it('should handle parent Cancel message and transition states correctly', async () => {
               // Initialize and acknowledge
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
               sendMessage(ACK);
 
@@ -709,7 +1037,7 @@
             it('should transition from STATE_EXPECT_ACK to STATE_BASE on timeout', async () => {
               // Initialize form but don't send ACK
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
 
               // Wait for timeout error
@@ -728,7 +1056,7 @@
             it('should clear timeout when receiving Acknowledged in STATE_EXPECT_ACK', async () => {
               // Initialize form
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
 
               // Send ACK before timeout
@@ -744,7 +1072,7 @@
             it('should handle malformed JSON in any state', async () => {
               // Initialize and acknowledge
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
               sendMessage(ACK);
 
@@ -763,7 +1091,7 @@
             it('should handle messages with missing type property', async () => {
               // Initialize and acknowledge
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
               sendMessage(ACK);
 
@@ -778,7 +1106,7 @@
             it('should handle unrecognized message types in STATE_BASE', async () => {
               // Initialize and acknowledge
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
               sendMessage(ACK);
 
@@ -793,7 +1121,7 @@
             it('should ignore Ready and Submit messages in STATE_BASE', async () => {
               // Initialize and acknowledge
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
               sendMessage(ACK);
 
@@ -810,7 +1138,7 @@
             it('should send unexpected type error for Ready/Submit messages in STATE_EXPECT_ACK', async () => {
               // Initialize form (now in STATE_EXPECT_ACK)
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
 
               // Send Ready message while expecting ACK
@@ -826,7 +1154,7 @@
             it('should send unrecognized error for unknown message types', async () => {
               // Initialize form (now in STATE_EXPECT_ACK)
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
 
               // Send unrecognized message - should get error but stay in STATE_EXPECT_ACK
@@ -840,7 +1168,7 @@
             it('should handle Error messages without state change', async () => {
               // Initialize and acknowledge
               await npsCsatForm(block);
-              const readyMessage = await receiveMessage();
+              const readyMessage = await receiveMessageOfType(Ready);
               expect(readyMessage.type).to.equal(Ready);
               sendMessage(ACK);
 

--- a/test/blocks/nps-csat-form/nps-csat-form.test.html
+++ b/test/blocks/nps-csat-form/nps-csat-form.test.html
@@ -153,6 +153,24 @@
       }, timeoutMs);
     });
 
+    const waitForCondition = (predicate, timeoutMs = 200) => new Promise((resolve, reject) => {
+      const startTime = Date.now();
+
+      const check = () => {
+        if (predicate()) {
+          resolve();
+          return;
+        }
+        if (Date.now() - startTime >= timeoutMs) {
+          reject(new Error('Timed out waiting for condition'));
+          return;
+        }
+        setTimeout(check, 5);
+      };
+
+      check();
+    });
+
     runTests(() => {
       describe('NPS CSAT Form - Message Handling', () => {
         let block;
@@ -451,6 +469,152 @@
 
             second.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
             expect(picker.value).to.equal(second.getAttribute('data-value'));
+          });
+
+          it('should close the picker when focus tabs away from the open dropdown', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const picker = block.querySelector('nps-picker.nps-picker');
+            const form = block.querySelector('#nps');
+            const trigger = picker.querySelector('.nps-picker-trigger');
+            const popover = picker.querySelector('.nps-popover');
+            const firstItem = picker.querySelectorAll('.nps-popover-item')[0];
+            const submitButton = form.querySelector('.nps-submit');
+
+            if (typeof popover.showPopover === 'function' && !popover.matches(':popover-open')) {
+              popover.showPopover();
+            } else {
+              trigger.click();
+            }
+
+            firstItem.focus();
+            firstItem.dispatchEvent(new FocusEvent('focusout', {
+              bubbles: true,
+              cancelable: true,
+              relatedTarget: submitButton,
+            }));
+            submitButton.focus();
+            await Promise.resolve();
+
+            expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+          });
+
+          it('should close the picker on the first tab press from the trigger', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const picker = block.querySelector('nps-picker.nps-picker');
+            const trigger = picker.querySelector('.nps-picker-trigger');
+            const popover = picker.querySelector('.nps-popover');
+
+            if (typeof popover.showPopover === 'function' && !popover.matches(':popover-open')) {
+              popover.showPopover();
+            } else {
+              trigger.click();
+            }
+
+            trigger.focus();
+            trigger.dispatchEvent(new KeyboardEvent('keydown', {
+              key: 'Tab',
+              bubbles: true,
+              cancelable: true,
+            }));
+
+            expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+          });
+
+          it('should move focus into the dropdown when opened from the keyboard', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const picker = block.querySelector('nps-picker.nps-picker');
+            const trigger = picker.querySelector('.nps-picker-trigger');
+            const firstItem = picker.querySelectorAll('.nps-popover-item')[0];
+
+            trigger.focus();
+            trigger.dispatchEvent(new KeyboardEvent('keydown', {
+              key: 'ArrowDown',
+              bubbles: true,
+              cancelable: true,
+            }));
+            await waitForCondition(() => document.activeElement === firstItem);
+
+            expect(document.activeElement).to.equal(firstItem);
+          });
+
+          it('should close the picker and move focus to textarea on tab from an option', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const picker = block.querySelector('nps-picker.nps-picker');
+            const trigger = picker.querySelector('.nps-picker-trigger');
+            const firstItem = picker.querySelectorAll('.nps-popover-item')[0];
+            const textarea = block.querySelector('#explanation-input');
+
+            trigger.focus();
+            trigger.dispatchEvent(new KeyboardEvent('keydown', {
+              key: 'ArrowDown',
+              bubbles: true,
+              cancelable: true,
+            }));
+            await waitForCondition(() => document.activeElement === firstItem);
+
+            firstItem.dispatchEvent(new KeyboardEvent('keydown', {
+              key: 'Tab',
+              bubbles: true,
+              cancelable: true,
+            }));
+
+            await waitForCondition(() => (
+              trigger.getAttribute('aria-expanded') === 'false'
+              && document.activeElement === textarea
+            ));
+
+            expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+            expect(document.activeElement).to.equal(textarea);
+          });
+
+          it('should close the picker and move focus back to the trigger on shift-tab from an option', async () => {
+            await npsCsatForm(block);
+            const readyMessage = await receiveMessageOfType(Ready);
+            expect(readyMessage.type).to.equal(Ready);
+            sendMessage(ACK);
+
+            const picker = block.querySelector('nps-picker.nps-picker');
+            const trigger = picker.querySelector('.nps-picker-trigger');
+            const firstItem = picker.querySelectorAll('.nps-popover-item')[0];
+
+            trigger.focus();
+            trigger.dispatchEvent(new KeyboardEvent('keydown', {
+              key: 'ArrowDown',
+              bubbles: true,
+              cancelable: true,
+            }));
+            await waitForCondition(() => document.activeElement === firstItem);
+
+            firstItem.dispatchEvent(new KeyboardEvent('keydown', {
+              key: 'Tab',
+              shiftKey: true,
+              bubbles: true,
+              cancelable: true,
+            }));
+
+            await waitForCondition(() => (
+              trigger.getAttribute('aria-expanded') === 'false'
+              && document.activeElement === trigger
+            ));
+
+            expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+            expect(document.activeElement).to.equal(trigger);
           });
 
           it('should show and clear submit error for picker selection flow', async () => {

--- a/test/blocks/nps-csat-form/nps-csat-form.test.html
+++ b/test/blocks/nps-csat-form/nps-csat-form.test.html
@@ -765,7 +765,7 @@
         });
 
         describe('Keyboard Accessibility', () => {
-          it('should navigate radio buttons forward with ArrowRight', async () => {
+          it('should navigate radio buttons forward with ArrowRight and select on 5pt', async () => {
             await npsCsatForm(block);
             const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
@@ -774,16 +774,15 @@
             const form = block.querySelector('#nps');
             const radioButtons = Array.from(form.querySelectorAll('input[type="radio"]'));
 
-            // Focus first radio button and press ArrowRight
             radioButtons[0].focus();
             const arrowRightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true });
             radioButtons[0].dispatchEvent(arrowRightEvent);
 
-            // Should focus next radio button
             expect(document.activeElement).to.equal(radioButtons[1]);
+            expect(radioButtons[1].checked).to.be.true;
           });
 
-          it('should navigate radio buttons forward with ArrowUp', async () => {
+          it('should navigate radio buttons forward with ArrowUp and select on 5pt', async () => {
             await npsCsatForm(block);
             const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
@@ -792,16 +791,15 @@
             const form = block.querySelector('#nps');
             const radioButtons = Array.from(form.querySelectorAll('input[type="radio"]'));
 
-            // Focus first radio button and press ArrowUp
             radioButtons[0].focus();
             const arrowUpEvent = new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true });
             radioButtons[0].dispatchEvent(arrowUpEvent);
 
-            // Should focus next radio button
             expect(document.activeElement).to.equal(radioButtons[1]);
+            expect(radioButtons[1].checked).to.be.true;
           });
 
-          it('should navigate radio buttons backward with ArrowLeft', async () => {
+          it('should navigate radio buttons backward with ArrowLeft and select on 5pt', async () => {
             await npsCsatForm(block);
             const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
@@ -810,16 +808,15 @@
             const form = block.querySelector('#nps');
             const radioButtons = Array.from(form.querySelectorAll('input[type="radio"]'));
 
-            // Focus second radio button and press ArrowLeft
             radioButtons[1].focus();
             const arrowLeftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true });
             radioButtons[1].dispatchEvent(arrowLeftEvent);
 
-            // Should focus previous radio button
             expect(document.activeElement).to.equal(radioButtons[0]);
+            expect(radioButtons[0].checked).to.be.true;
           });
 
-          it('should wrap around when navigating with arrow keys', async () => {
+          it('should wrap around when navigating with arrow keys and select on 5pt', async () => {
             await npsCsatForm(block);
             const readyMessage = await receiveMessageOfType(Ready);
             expect(readyMessage.type).to.equal(Ready);
@@ -828,19 +825,19 @@
             const form = block.querySelector('#nps');
             const radioButtons = Array.from(form.querySelectorAll('input[type="radio"]'));
 
-            // Focus last radio button and press ArrowRight (should wrap to first)
             const lastIndex = radioButtons.length - 1;
             radioButtons[lastIndex].focus();
             const arrowRightEvent = new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true });
             radioButtons[lastIndex].dispatchEvent(arrowRightEvent);
 
             expect(document.activeElement).to.equal(radioButtons[0]);
+            expect(radioButtons[0].checked).to.be.true;
 
-            // Focus first radio button and press ArrowLeft (should wrap to last)
             const arrowLeftEvent = new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true });
             radioButtons[0].dispatchEvent(arrowLeftEvent);
 
             expect(document.activeElement).to.equal(radioButtons[lastIndex]);
+            expect(radioButtons[lastIndex].checked).to.be.true;
           });
 
           it('should toggle checkbox with spacebar', async () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Added an 11-point NPS experience with a custom picker UI and right-to-left (RTL) language support.

- Introduced a new nps-picker custom element (trigger + popover listbox) for mobile-friendly score selection.
- Added full 0-10 scoring with explicit low/high endpoint labels and matching desktop radio + picker option data.
- Implemented adaptive NPS input behavior: desktop uses radio controls, while mobile uses the picker, with responsive styling rules.
- Added keyboard and accessibility improvements for picker/radio interactions, including focus management and change events.
- Added locale-driven RTL handling (dir="rtl" when applicable) plus RTL-specific layout/style adjustments.
- Expanded test coverage for the new NPS scale, picker rendering/interaction, validation flow, and responsive behavior.

Resolves: [MWPW-187510](https://jira.corp.adobe.com/browse/MWPW-187510)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://nps--milo--adobecom.aem.page/?martech=off

https://nps--milo--adobecom.aem.page/drafts/raghavs/nps-csat/nps-11?source_color_theme=light





















