### PR TITLE
MWPW-189335 [cc][LANA] non-critical messages reported: target respons…

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1582,7 +1582,7 @@ async function handleMartechTargetInteraction(
     const { targetInteractionData, respTime, respStartTime } = await targetInteractionPromise;
     sendTargetResponseAnalytics(false, respStartTime, calculatedTimeout);
     if (targetInteractionData.result) {
-      const roundedResponseTime = roundToQuarter(respTime);
+      const roundedResponseTime = roundToQuarter(respTime?.duration ?? respTime);
       performance.clearMarks();
       performance.clearMeasures();
       try {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

In the personalization.js code , line 1583, an object (respTime) was being passed inside the roundToQuarter() function. Because of which the roundToQuarter() function was returning NAN because it was unable to read the value or a number for respTime. 

<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/94b7324a-6e18-47c9-8485-f883e15aebd4" />

Instead of the respTime object, we should pass the value of duration(which is available inside the object) to calculate the roundedResponseTime.
Using the following line for reading the duration value if present: "respTime?.duration ?? respTime"

Resolves: [[MWPW-189335](https://jira.corp.adobe.com/browse/MWPW-189335)]

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://<branch>--milo--adobecom.aem.page/?martech=off

Preview: https://main--milo--vaibhavmathuradobe.aem.page/
Live: https://main--milo--vaibhavmathuradobe.aem.live/

URL used to debug the issue : https://www.adobe.com/products/flashplayer/end-of-life-alternative.html?lanadebug
 
Before the Fix : 
<img width="3456" height="1902" alt="image" src="https://github.com/user-attachments/assets/7f96f577-fac8-44ec-abe1-6853df10bcdd" />
<img width="3456" height="1902" alt="image" src="https://github.com/user-attachments/assets/c3aaab3f-c9f1-4ff2-a620-c1dd77ab1504" />


After the fix : 
<img width="3456" height="1902" alt="image" src="https://github.com/user-attachments/assets/180fdab4-cb47-47ca-a7f8-fa15e4f88c17" />
<img width="3456" height="1902" alt="image" src="https://github.com/user-attachments/assets/a9d03410-1964-4819-addc-f41b1dde06e5" />




