### PR TITLE
[SR] Pause Router-Marquee when out of view

### DIFF
--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -386,6 +386,7 @@ const startAutoplay = (slides, cards, container, block) => {
   let timer = null; // timer for the autoplay
   let paused = false; // whether the autoplay is paused
   let userPaused = false; // whether the user explicitly paused via the play/pause button
+  let offscreen = false; // whether the block is outside the viewport
   let cleanupTimer = null; // cleanup timer that resets temp inline styles
   let pendingSlide = null; // the slide that is currently transitioning in
   let leaveTimer = null; // timer for restarting autoplay on block mouse leave
@@ -500,6 +501,7 @@ const startAutoplay = (slides, cards, container, block) => {
   };
 
   const advance = () => {
+    if (paused) return;
     clearTimeout(timer);
     clearFill(active);
     activate((active + 1) % cardEls.length, 1);
@@ -508,8 +510,17 @@ const startAutoplay = (slides, cards, container, block) => {
     preloadNextVideo();
   };
 
+  const cancelLeaveTimer = () => {
+    clearTimeout(leaveTimer);
+    leaveTimer = null;
+  };
+
   const pause = () => {
     clearTimeout(timer);
+    clearTimeout(cleanupTimer);
+    cleanupTimer = null;
+    cancelLeaveTimer();
+    finishSlideTransition();
     clearFill(active);
     paused = true;
     setPlayingState(false);
@@ -517,21 +528,19 @@ const startAutoplay = (slides, cards, container, block) => {
   };
 
   const resume = () => {
+    if (offscreen) return;
     paused = false;
     userPaused = false;
     setPlayingState(true);
     startFill(active);
     timer = setTimeout(advance, AUTOPLAY_MS);
-    slides[active]?.querySelector('video')?.play().catch(() => {});
-  };
-
-  const cancelLeaveTimer = () => {
-    clearTimeout(leaveTimer);
-    leaveTimer = null;
+    const vid = slides[active]?.querySelector('video');
+    loadVideo(vid);
+    vid?.play().catch(() => {});
   };
 
   const startLeaveTimer = () => {
-    if (leaveTimer || userPaused) return;
+    if (leaveTimer || userPaused || offscreen) return;
     leaveTimer = setTimeout(() => {
       leaveTimer = null;
       resume();
@@ -642,10 +651,23 @@ const startAutoplay = (slides, cards, container, block) => {
   }, { passive: true });
 
   requestAnimationFrame(() => {
+    if (paused) return;
     startFill(active);
     timer = setTimeout(advance, AUTOPLAY_MS);
     preloadNextVideo();
   });
+
+  return {
+    setVisible: (isVisible) => {
+      if (!isVisible) {
+        offscreen = true;
+        pause();
+      } else {
+        offscreen = false;
+        if (!userPaused && paused) resume();
+      }
+    },
+  };
 };
 
 const buildViewport = (viewport, slides) => {
@@ -684,6 +706,7 @@ export default function init(el) {
   const containers = Object.entries(viewports).map(([vp, slides]) => buildViewport(vp, slides));
   el.replaceChildren(...containers);
   const initializedVps = new Set();
+  const autoplayControllers = [];
   const initViewportAutoplay = () => {
     const activeVp = getActiveViewport();
     if (initializedVps.has(activeVp)) return;
@@ -694,7 +717,7 @@ export default function init(el) {
     const cards = container.querySelector('.rm-cards');
     setSlideObserver(slides);
     setAnalytics(slides, cards, container, el);
-    startAutoplay(slides, cards, container, el);
+    autoplayControllers.push(startAutoplay(slides, cards, container, el));
   };
 
   loadViewportVideos(el);
@@ -705,4 +728,31 @@ export default function init(el) {
     loadViewportVideos(el);
     initViewportAutoplay();
   });
+
+  // Pause/resume based on scroll position.
+  // Use window.scrollY due to router-marquee being set to sticky and always in the viewport
+  let visibilityPaused = false;
+
+  const checkVisibility = () => {
+    const isVisible = window.scrollY < window.innerHeight / 2;
+    if (!isVisible && !visibilityPaused) {
+      visibilityPaused = true;
+      autoplayControllers.forEach((ctrl) => ctrl.setVisible(false));
+    } else if (isVisible && visibilityPaused) {
+      visibilityPaused = false;
+      autoplayControllers.forEach((ctrl) => ctrl.setVisible(true));
+    }
+  };
+
+  // Lenis loads after blocks, so window.lenis isn't set at init() time.
+  // On the first native scroll event, swap to lenis.on() if available so
+  // subsequent visibility checks run inside Lenis's RAF loop.
+  function onScroll() {
+    if (window.lenis) {
+      window.removeEventListener('scroll', onScroll);
+      window.lenis.on('scroll', checkVisibility);
+    }
+    checkVisibility();
+  }
+  window.addEventListener('scroll', onScroll, { passive: true });
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Added logic to pause the router marquee slide animations when it is scrolled out of view. It resumes the slide animation when scrolled back into view.

This also frees up resources for a small performance bump while scrolling through the page.

Discussed with Chip from the design team and got sign off from him.

Resolves: [MWPW-191875](https://jira.corp.adobe.com/browse/MWPW-191875)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?martech=off
- After: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=sr-rm-scroll-pause&martech=off


