### PR TITLE
MWPW-189755- Change in language is not marked - Footer

### DIFF
--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -61,7 +61,7 @@ export function decorateLink(link, path, localeToLanguageMap = []) {
     href = href.replace(`/${prefix}`, valueInMap ? `/${valueInMap}` : '');
   }
   link.href = `${href}${path}`;
-
+  if (currentLocaleObj.ietf && currentLocaleObj.ietf !== 'none') link.setAttribute('lang', currentLocaleObj.ietf);
   link.addEventListener('mouseover', () => {
     setTimeout(() => {
       if (link.matches(':hover') && !hrefAdapted) {

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -201,13 +201,7 @@ describe('Region Nav Block', async () => {
   });
 
   it('sets lang attribute on links with valid ietf values', () => {
-    setConfig({
-      locales: {
-        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
-        ar: { ietf: 'es-AR', tk: 'hah7vzn.css' },
-        br: { ietf: 'pt-BR', tk: 'hah7vzn.css' },
-      },
-    });
+    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' }, ar: { ietf: 'es-AR', tk: 'hah7vzn.css' }, br: { ietf: 'pt-BR', tk: 'hah7vzn.css' } } });
 
     const arLink = createTag('a', { href: 'https://adobe.com/ar/' });
     decorateLink(arLink, '/some-page');
@@ -219,9 +213,7 @@ describe('Region Nav Block', async () => {
   });
 
   it('does not set lang attribute when ietf is none (localeToLanguageMap)', () => {
-    setConfig({
-      locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } },
-    });
+    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
 
     const link = createTag('a', { href: 'https://adobe.com/xx/' });
     decorateLink(link, '/some-page', [{ locale: 'xx' }]);
@@ -230,13 +222,7 @@ describe('Region Nav Block', async () => {
   });
 
   it('does not set lang attribute when locale omits ietf', () => {
-    setConfig({
-      locales: {
-        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
-        zz: { tk: 'hah7vzn.css' },
-      },
-    });
-
+    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' }, zz: { tk: 'hah7vzn.css' } } });
     const link = createTag('a', { href: 'https://adobe.com/zz/' });
     decorateLink(link, '');
 

--- a/test/blocks/region-nav/region-nav.test.js
+++ b/test/blocks/region-nav/region-nav.test.js
@@ -199,4 +199,47 @@ describe('Region Nav Block', async () => {
     // No languageMap means no transformation
     expect(link.href).to.equal('https://adobe.com/ar/some-page');
   });
+
+  it('sets lang attribute on links with valid ietf values', () => {
+    setConfig({
+      locales: {
+        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+        ar: { ietf: 'es-AR', tk: 'hah7vzn.css' },
+        br: { ietf: 'pt-BR', tk: 'hah7vzn.css' },
+      },
+    });
+
+    const arLink = createTag('a', { href: 'https://adobe.com/ar/' });
+    decorateLink(arLink, '/some-page');
+    expect(arLink.getAttribute('lang')).to.equal('es-AR');
+
+    const brLink = createTag('a', { href: 'https://adobe.com/br/' });
+    decorateLink(brLink, '/path');
+    expect(brLink.getAttribute('lang')).to.equal('pt-BR');
+  });
+
+  it('does not set lang attribute when ietf is none (localeToLanguageMap)', () => {
+    setConfig({
+      locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } },
+    });
+
+    const link = createTag('a', { href: 'https://adobe.com/xx/' });
+    decorateLink(link, '/some-page', [{ locale: 'xx' }]);
+
+    expect(link.hasAttribute('lang')).to.be.false;
+  });
+
+  it('does not set lang attribute when locale omits ietf', () => {
+    setConfig({
+      locales: {
+        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+        zz: { tk: 'hah7vzn.css' },
+      },
+    });
+
+    const link = createTag('a', { href: 'https://adobe.com/zz/' });
+    decorateLink(link, '');
+
+    expect(link.hasAttribute('lang')).to.be.false;
+  });
 });


### PR DESCRIPTION
Resolves: [MWPW-189755](https://jira.corp.adobe.com/browse/MWPW-189755)

**Test URLs:**
https://main--upp--adobecom.aem.live/homepage/index-loggedout?milolibs=region-nav-voiceover--milo--KetakiD-Deshwandikar#langnav

Adds a lang attribute to each region link in the footer “Change region” modal (region-nav), using the locale’s IETF tag from config (currentLocaleObj.ietf), so screen readers use the right language for native country/region names (e.g. Deutschland, 한국).

https://github.com/user-attachments/assets/7da26804-6e6a-4c90-b1f1-22e868009039



<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- Milo: https://region-nav-voiceover--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=region-nav-voiceover--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- Milo: https://region-nav-voiceover--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=region-nav-voiceover--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- Milo: https://region-nav-voiceover--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-voiceover--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=region-nav-voiceover--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=region-nav-voiceover--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=region-nav-voiceover--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=region-nav-voiceover--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=region-nav-voiceover--milo--adobecom
</details>