### PR TITLE
[Loc][MWPW-188683] Support config-stage sheet and defaultlocales column for locale selection

### DIFF
--- a/libs/blocks/locui-create/input-locale/index.js
+++ b/libs/blocks/locui-create/input-locale/index.js
@@ -132,11 +132,14 @@ export default function useInputLocale() {
         groupedLocales[language].push(locale);
       }
     });
-    return Object.entries(groupedLocales).map(([language, localeList]) => ({
-      language,
-      locales: project.value.type === PROJECT_TYPES.translation ? [] : localeList,
-      langCode: languageCodes[language],
-    }));
+    return Object.entries(groupedLocales).map(([language, localeList]) => {
+      if (project.value.type === PROJECT_TYPES.translation) {
+        const langDetails = languagesList.find((l) => l.languagecode === languageCodes[language]);
+        const defaultLocales = langDetails?.defaultlocales ? langDetails.defaultlocales.split(',') : [];
+        return { language, locales: defaultLocales, langCode: languageCodes[language] };
+      }
+      return { language, locales: localeList, langCode: languageCodes[language] };
+    });
   };
 
   const updateActiveLocales = (localesToUpdate, isDeselecting = false, languageCode = null) => {

--- a/libs/blocks/locui-create/input-locale/index.js
+++ b/libs/blocks/locui-create/input-locale/index.js
@@ -193,17 +193,23 @@ export default function useInputLocale() {
       }, {}),
     }));
     const newLocalesWithLangCode = [];
+    const effectiveLocales = [];
     regionCountryCodes.forEach((locale) => {
       const languages = findLanguageForLocale(locale);
       languages?.forEach((language) => {
         newLocalesWithLangCode.push(`${language.languagecode}|${locale}`);
+        if (language.defaultlocales) {
+          const defaults = language.defaultlocales.split(',');
+          if (!defaults.includes(locale)) return;
+        }
+        if (!effectiveLocales.includes(locale)) effectiveLocales.push(locale);
       });
     });
     setSelectedLocale((prev) => [
       ...prev,
       ...newLocalesWithLangCode.filter((code) => !prev.includes(code)),
     ]);
-    updateActiveLocales(regionCountryCodes);
+    updateActiveLocales(effectiveLocales);
   };
 
   const deselectRegion = (regionKey, regionCountryCodes) => {

--- a/libs/blocks/locui-create/input-locale/index.js
+++ b/libs/blocks/locui-create/input-locale/index.js
@@ -194,11 +194,12 @@ export default function useInputLocale() {
     }));
     const newLocalesWithLangCode = [];
     const effectiveLocales = [];
+    const isRollout = project.value.type !== PROJECT_TYPES.translation;
     regionCountryCodes.forEach((locale) => {
       const languages = findLanguageForLocale(locale);
       languages?.forEach((language) => {
         newLocalesWithLangCode.push(`${language.languagecode}|${locale}`);
-        if (language.defaultlocales) {
+        if (isRollout && language.defaultlocales) {
           const defaults = language.defaultlocales.split(',');
           if (!defaults.includes(locale)) return;
         }

--- a/libs/blocks/locui-create/input-locale/index.js
+++ b/libs/blocks/locui-create/input-locale/index.js
@@ -302,16 +302,21 @@ export default function useInputLocale() {
   };
 
   const selectLanguage = (lang) => {
-    const languageCodes = lang.livecopies.split(',');
-    const isDeselecting = languageCodes.every((code) => selectedLocaleSet.has(`${lang.languagecode}|${code}`));
+    const allLivecopies = lang.livecopies.split(',');
+    const defaultCodes = (lang.defaultlocales || lang.livecopies).split(',');
+    const isDeselecting = allLivecopies.some((code) => selectedLocaleSet.has(`${lang.languagecode}|${code}`));
     const updatedLocale = isDeselecting
       ? selectedLocale.filter((localeKey) => {
         const [langCode, locale] = parseLocaleKey(localeKey);
-        return langCode !== lang.languagecode || !languageCodes.includes(locale);
+        return langCode !== lang.languagecode || !allLivecopies.includes(locale);
       })
-      : [...selectedLocale, ...languageCodes.map((code) => `${lang.languagecode}|${code}`)];
+      : [...selectedLocale, ...allLivecopies.map((code) => `${lang.languagecode}|${code}`)];
     setSelectedLocale(updatedLocale);
-    updateActiveLocales(languageCodes, isDeselecting, lang.languagecode);
+    updateActiveLocales(
+      isDeselecting ? allLivecopies : defaultCodes,
+      isDeselecting,
+      lang.languagecode,
+    );
   };
 
   const toggleLocale = (localeKey) => {

--- a/libs/blocks/locui-create/locui-create.js
+++ b/libs/blocks/locui-create/locui-create.js
@@ -28,8 +28,8 @@ function Create() {
     const setup = async () => {
       try {
         await getUserToken();
-        await fetchLocaleDetails();
         env.value = getEnvQueryParam();
+        await fetchLocaleDetails();
         const searchParams = new URLSearchParams(window.location.search);
         const projectKey = searchParams.get('projectKey');
         const workflow = searchParams.get('workflow');

--- a/libs/blocks/locui-create/store.js
+++ b/libs/blocks/locui-create/store.js
@@ -83,10 +83,10 @@ export async function getUserToken() {
   return userToken;
 }
 
-async function fetchLocales(tenantBaseUrl) {
+async function fetchLocales(tenantBaseUrl, configName = 'config') {
   try {
     const response = await fetch(
-      `${tenantBaseUrl}/.milo/config.json?sheet=${LOCALES}&sheet=${LOCALE_GROUPS}`,
+      `${tenantBaseUrl}/.milo/${configName}.json?sheet=${LOCALES}&sheet=${LOCALE_GROUPS}`,
     );
     if (!response.ok) {
       throw new Error(`Server Error: ${response.status}`);
@@ -105,7 +105,13 @@ async function fetchLocales(tenantBaseUrl) {
 export async function fetchLocaleDetails() {
   try {
     loading.value = true;
-    let localeData = await fetchLocales(origin);
+    let localeData = null;
+    if (env.value === 'stage' || env.value === 'local') {
+      localeData = await fetchLocales(origin, 'config-stage');
+    }
+    if (!localeData) {
+      localeData = await fetchLocales(origin);
+    }
     if (!localeData) {
       localeData = await fetchLocales('https://main--federal--adobecom.aem.page');
     }

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -78,10 +78,11 @@ export function setSelectedLocalesAndRegions() {
   const activeLocales = {};
   languages.forEach((loc) => {
     const { language, locales } = loc;
-    const { livecopies, languagecode } = localeByLanguage[language] || {};
+    const { livecopies, defaultlocales, languagecode } = localeByLanguage[language] || {};
+    const effectiveLivecopies = defaultlocales || livecopies;
     const livecopiesArr = [];
-    if (livecopies) {
-      const newLivecopies = livecopies.split(',').map((locale) => `${languagecode}|${locale}`);
+    if (effectiveLivecopies) {
+      const newLivecopies = effectiveLivecopies.split(',').map((locale) => `${languagecode}|${locale}`);
       livecopiesArr.push(...newLivecopies);
     }
     if (locales.length > 0) {
@@ -110,7 +111,7 @@ export function getLanguageDetails(langs) {
       action: 'Rollout',
       langCode: langDetails.languagecode,
       language: langDetails.language,
-      locales: langDetails.livecopies?.split(','),
+      locales: (langDetails.defaultlocales || langDetails.livecopies)?.split(','),
       workflow: '',
     };
   });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
These are the changes made to support Lingo in the Milo Studio Localization workflow:

### `config-stage` sheet support
- `fetchLocales` now accepts an optional `configName` parameter (defaults to `'config'`)
- When the env is `stage` or `local`, the tool first attempts to fetch from `config-stage.json`, which allows tenants to maintain stage-specific locale configurations
- Falls back gracefully to `config.json` if `config-stage` is not present for a given tenant, so existing tenants are unaffected
- `env` is now resolved before `fetchLocaleDetails()` is called in `locui-create.js` to ensure the correct config sheet is fetched on initialization

### `defaultlocales` column support
- Locale sheets can now include an optional `defaultlocales` column per language, allowing tenants to define a subset of livecopies that should be pre-selected when a language is chosen
- When `defaultlocales` is present, only those locales are activated on language select (instead of all livecopies)
- Deselecting a language still removes all livecopies as before
- `setSelectedLocalesAndRegions` and `getLanguageDetails` in `utils.js` also respect `defaultlocales` when computing active/selected locales

### `defaultlocales` in translation workflow
- For translation projects, only the `defaultlocales` for each language are passed in the locales payload (instead of an empty list)
- No frontend behavior change — this is a data-only update to ensure the correct locales are sent downstream

### `defaultlocales` in region selection
- When a region is selected (e.g. Americas), all locales from the region still appear in the Selected Locales panel, but only locales that match a language's `defaultlocales` are activated
- For example, selecting Americas adds `ca` (English) and `ca_fr` (French) to the panel, but since French has `defaultlocales = fr`, only `ca` is active — `ca_fr` appears but is not pre-selected
- Deselecting a region still removes all its locales as before

Resolves: [MWPW-188683](https://jira.corp.adobe.com/browse/MWPW-188683)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-188683--milo--maagrawal16.aem.page/?martech=off








