### PR TITLE
[MMM] Fix 500 Internal Server Error when toggling manifest drawer

### DIFF
--- a/libs/blocks/mmm/mmm.js
+++ b/libs/blocks/mmm/mmm.js
@@ -137,6 +137,7 @@ async function toggleDrawer(target, dd, pageId) {
     const loading = dd.querySelector('.loading');
     if (dd.classList.contains('placeholder-resolved') || !loading) return;
     const pageData = await fetchData(`${API_URLS.pageDetails}?id=${pageId}&lastSeen=${SEARCH().lastSeenManifest}&manifestSrc=${SEARCH().manifestSrc}`, DATA_TYPE.JSON);
+    if (!pageData) return;
     loading.replaceWith(await getMepPopup(pageData, true));
     dd.classList.add('placeholder-resolved');
   }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -123,11 +123,13 @@ export const normalizePath = (p, localize = true) => {
     const firstFolder = pathname.split('/')[1];
     const mepHash = '#_dnt';
 
-    if (path.startsWith(config.codeRoot)
+    const isKnownOrigin = path.startsWith(config.codeRoot)
       || path.includes('.hlx.')
       || path.includes('.aem.')
       || path.includes('.adobe.')
-      || path.includes('localhost:')) {
+      || path.includes('localhost:');
+
+    if (isKnownOrigin) {
       if (!localize
         || config.locale?.ietf === 'en-US'
         || hash?.includes(mepHash)
@@ -141,7 +143,12 @@ export const normalizePath = (p, localize = true) => {
       }
     }
     path = isFederal ? getFederatedUrl(path) : path;
-    return `${path}${search}${hash.replace(mepHash, '')}`;
+    if (isKnownOrigin) {
+      return `${path}${search}${hash.replace(mepHash, '')}`;
+    }
+    const normalizedUrl = new URL(path);
+    normalizedUrl.hash = normalizedUrl.hash.replace(mepHash, '');
+    return normalizedUrl.toString();
   } catch (e) {
     path = isFederal ? getFederatedUrl(path) : path;
     return path;

--- a/test/blocks/mmm/mmm.test.js
+++ b/test/blocks/mmm/mmm.test.js
@@ -156,6 +156,19 @@ describe('MMM', () => {
     expect(previewButton.href).to.include('%2Fadded-manifest.json');
   });
 
+  it('does not crash and preserves loading state when fetchData returns null', async () => {
+    const [,, thirdButton] = document.body.querySelectorAll('dt button');
+    const thirdDd = document.body.querySelectorAll('dd')[2];
+    expect(thirdDd.querySelector('.loading')).to.exist;
+
+    window.fetch = stub().returns(Promise.resolve({ ok: false }));
+    thirdButton.click();
+    await delay(50);
+
+    expect(thirdDd.classList.contains('placeholder-resolved')).to.be.false;
+    expect(thirdDd.querySelector('.loading')).to.exist;
+  });
+
   it('Test filters', async () => {
     let filterData = getLocalStorageFilter();
     expect(filterData).to.be.null;

--- a/test/features/personalization/normalizePath.test.js
+++ b/test/features/personalization/normalizePath.test.js
@@ -78,4 +78,20 @@ describe('normalizePath function', () => {
     expect(path).to.include('/federal/globalnav/acom/fragments/promos/test-promo');
     expect(path).not.to.include('/de/');
   });
+
+  it('does not duplicate query params for external URLs', () => {
+    config.locale = { ietf: 'en-US', prefix: '' };
+    const apiUrl = 'https://example.lambda-url.us-west-2.on.aws/get-page?id=123&lastSeen=week&manifestSrc=pzn,%20promo';
+    const result = normalizePath(apiUrl);
+    expect(result).to.equal(apiUrl);
+    expect(result.match(/id=123/g)).to.have.lengthOf(1);
+  });
+
+  it('strips #_dnt from external URLs without duplicating params', () => {
+    config.locale = { ietf: 'en-US', prefix: '' };
+    const apiUrl = 'https://example.lambda-url.us-west-2.on.aws/get-page?id=123#_dnt';
+    const result = normalizePath(apiUrl);
+    expect(result).to.equal('https://example.lambda-url.us-west-2.on.aws/get-page?id=123');
+    expect(result).to.not.include('#_dnt');
+  });
 });


### PR DESCRIPTION

**Summary**

Toggling any page/manifest drawer on mmm page (i.e., clicking  ".mmm-trigger" button) triggers a 500 Internal Server Error from the lambda API, followed by an uncaught TypeError: Cannot destructure property 'page' of 'mepConfig' as it is null. This update prevents normalizePath from duplicating query params on external URLs while preserving the existing entitlements param-retention behavior for known origins.


- personalization.js: Introduce isKnownOrigin flag to distinguish AEM/HLX/adobe/localhost URLs from external ones. Known origins continue using pathname + search + hash (preserving the 97b9337 entitlements fix). External URLs reconstruct via new URL(path) to avoid duplicating query params.
- mmm.js: Add null guard on pageData in toggleDrawer to prevent the destructure-of-null crash when fetchData returns null.
- normalizePath.test.js: Two new tests covering external URLs with query params and #_dnt hash stripping.



**Root Cause**
#5450  added ${search} to the return in normalizePath to fix entitlement sheet parameters not being retained. This works correctly for AEM/HLX/adobe/localhost URLs where path is reassigned to just pathname, but for external URLs (like the lambda API), path is never reassigned and still contains the full URL with query params. Appending ${search} duplicates them. The server receives a malformed URL and returns 500. fetchData returns null, which propagates to getMepPopup(null, true) where destructuring null throws.

Steps to QA Using the Before and After Test URLS below: 
1. Scroll down to the first page with manifests found
2. Toggle the + to the right of the page name
Expected Results: Manifest content is retrieved and displayed
Actual Results: spinner loads and 500 error thrown in console.

Resolves: [MWPW-192357](https://jira.corp.adobe.com/browse/MWPW-192357)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/authoring/features/mmm/?martech=off
- After: https://mmm-fix500error--milo--adobecom.aem.page/docs/authoring/features/mmm/?martech=off




