### PR TITLE
[MWPW-192533] - bulk publish additional check

### DIFF
--- a/libs/blocks/bulk-publish-v2/utils.js
+++ b/libs/blocks/bulk-publish-v2/utils.js
@@ -77,6 +77,7 @@ const getInvalidUrlReason = (str) => {
     [!url.hostname, 'Invalid URL (missing hostname)'],
     [!url.hostname || !AEM_PAGE_HOST_REGEX.test(url.hostname), 'Invalid host (expected *.aem.page or *.aem.live)'],
     [!ref || !repo || !owner, 'Invalid host (missing ref, repo, or owner)'],
+    [/^([^-]+)(?:-.+)-\1$/.test(repo ?? ''), 'Invalid host (repo name has a duplicated segment, e.g. da-bacom-da should be da-bacom)'],
     [ref && repo && owner && !url.hostname.endsWith(`${ref}--${repo}--${owner}.${tld}`), 'Invalid host format (expected ref--repo--owner.aem.page or .aem.live)'],
     [repo === 'bacom', 'Old Bacom project is not supported, use new DA project instead'],
     [url.pathname.includes('//'), 'Invalid URL (path must not contain //)'],


### PR DESCRIPTION
PR seeks to add an aditional check so that the user is notified that the following URL is invalid:

URL to test against:
`https://main--da-bacom-da--adobecom.aem.page/blog/the-latest/adobe-and-databricks-develop-a-partnership-that-enables-brands-to-deliver-ai-driven-personalization-at-scale`

Resolves: [MWPW-192533](https://jira.corp.adobe.com/browse/MWPW-192533)

**PSI Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bulk-publish-err-handle--milo--adobecom.aem.page/?martech=off

**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.page/tools/bulk
- After: https://main--da-bacom--adobecom.aem.page/tools/bulk?milolibs=bulk-publish-err-handle

