### PR TITLE
[MWPW-192445] Router Marquee cards not visible completely

### DIFF
--- a/libs/c2/blocks/router-marquee/router-marquee.css
+++ b/libs/c2/blocks/router-marquee/router-marquee.css
@@ -348,6 +348,7 @@
   .rm-viewport[data-viewport="mobile"] {
     display: flex;
     height: 100vh;
+    height: 100svh;
   }
 
   .rm-content-wrapper {
@@ -380,6 +381,7 @@
   .rm-viewport[data-viewport="tablet"] {
     display: flex;
     height: 100vh;
+    height: 100svh;
   }
 
   .rm-content-wrapper {


### PR DESCRIPTION
This PR is fixing the Router marquee issue where the cards were not completely visible when specific operating systems where coupled with specific browser versions on mobile.

Resolves: [MWPW-192445](https://jira.corp.adobe.com/browse/MWPW-192445)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?martech=off
- After: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=mwpw-192445&martech=off

