### PR TITLE
Fixing tab visibility with animation issue

### DIFF
--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -362,9 +362,14 @@ export function setActiveDropdown(elem, type) {
   });
 }
 
-export const animateInSequence = (xs, gap) => {
+export const animateInSequence = (xs, gap, { restart = false } = {}) => {
   for (let i = 0; i < xs.length; i += 1) {
-    xs[i].style = `animation-delay: ${(i + 1) * gap}s`;
+    if (restart) {
+      xs[i].style.setProperty('animation', 'none');
+      xs[i].getBoundingClientRect();
+      xs[i].style.removeProperty('animation');
+    }
+    xs[i].style.setProperty('animation-delay', `${(i + 1) * gap}s`);
   }
 };
 
@@ -775,8 +780,11 @@ export const transformTemplateToMobile = async ({
   const tabbuttons = popup.querySelectorAll('.tabs button');
   const tabpanels = popup.querySelectorAll('.tab-content [role="tabpanel"]');
   const tabbuttonClickCallbacks = [...tabbuttons].map((tab, i) => () => {
+    const activePanel = tabpanels[i];
+    const activePanelChildren = activePanel ? [...activePanel.children] : [];
     closeAllTabs(tabbuttons, tabpanels);
-    tabpanels?.[i]?.removeAttribute('hidden');
+    activePanel?.removeAttribute('hidden');
+    animateInSequence(activePanelChildren, 0.02, { restart: true });
     tab.setAttribute('aria-selected', 'true');
   });
 

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -15,6 +15,7 @@ import {
   dropWhile,
   getGnavHeight,
   getBranchBannerInfo,
+  animateInSequence,
 } from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
 import { getAnalyticsValue, decorateCta } from '../../../../libs/blocks/global-navigation/global-navigation.js';
 import { setConfig, getConfig, getFedsPlaceholderConfig } from '../../../../libs/utils/utils.js';
@@ -349,6 +350,16 @@ describe('global navigation utilities', () => {
     // Calling 'trigger' again should close the element
     expect(trigger({ element })).to.equal(false);
     expect(element.getAttribute('aria-expanded')).to.equal('false');
+  });
+
+  it('animateInSequence can restart animations without clobbering inline styles', () => {
+    const link = toFragment`<a class="feds-navLink" style="color: red">One</a>`;
+
+    animateInSequence([link], 0.02, { restart: true });
+
+    expect(link.style.animationDelay).to.equal('0.02s');
+    expect(link.style.animation).to.equal('');
+    expect(link.style.color).to.equal('red');
   });
 
   it('getExperienceName defaults to imsClientId', () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Resetting the animation for tabs's link when tab is clicked

Resolves: [MWPW-192748](https://jira.corp.adobe.com/browse/MWPW-192748)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-active-tab--milo--adobecom.aem.page/?martech=off

QA: https://main--da-cc--adobecom.aem.live/uk/creativecloud?milolibs=gnav-active-tab

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=gnav-active-tab--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=gnav-active-tab--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=gnav-active-tab--milo--adobecom
- Milo: https://gnav-active-tab--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=gnav-active-tab--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=gnav-active-tab--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=gnav-active-tab--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-active-tab--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-active-tab--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-active-tab--milo--adobecom
- Milo: https://gnav-active-tab--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-active-tab--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-active-tab--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-active-tab--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-active-tab--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-active-tab--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-active-tab--milo--adobecom
- Milo: https://gnav-active-tab--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-active-tab--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-active-tab--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-active-tab--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=gnav-active-tab--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=gnav-active-tab--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=gnav-active-tab--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=gnav-active-tab--milo--adobecom
</details>