### PR TITLE
MWPW-191951: Detect unpublished M@S fragments in Preflight

### DIFF
--- a/libs/blocks/preflight/checks/merch.js
+++ b/libs/blocks/preflight/checks/merch.js
@@ -1,0 +1,88 @@
+import { getConfig } from '../../../utils/utils.js';
+import { SEVERITY } from './constants.js';
+
+const API_BASE = 'https://www.adobe.com/mas/io/fragment';
+const API_KEY = 'wcms-commerce-ims-ro-user-milo';
+const HYDRATION_DELAY_MS = 3000;
+
+export function findFragmentElements(area = document) {
+  const els = area.querySelectorAll('aem-fragment[fragment]');
+  const entries = [];
+  els.forEach((el) => {
+    const uuid = el.getAttribute('fragment');
+    if (!uuid) return;
+    const card = el.closest('merch-card, merch-card-collection, mas-field') || el;
+    entries.push({ uuid, el, card });
+  });
+  return entries;
+}
+
+export async function checkFragmentPublished(uuid, locale) {
+  const params = new URLSearchParams({ id: uuid, api_key: API_KEY, locale });
+  const url = `${API_BASE}?${params.toString()}`;
+  try {
+    const res = await fetch(url);
+    return { uuid, httpStatus: res.status, published: res.status === 200 };
+  } catch {
+    return { uuid, httpStatus: 0, published: false };
+  }
+}
+
+function resolveLocale(locale) {
+  if (locale) return locale;
+  const ietf = getConfig()?.locale?.ietf || 'en-US';
+  return ietf.replace('-', '_');
+}
+
+export async function checkUnpublishedFragments({ area = document, locale } = {}) {
+  const resolvedLocale = resolveLocale(locale);
+  const entries = findFragmentElements(area);
+  const byUuid = new Map();
+  entries.forEach((entry) => {
+    if (!byUuid.has(entry.uuid)) byUuid.set(entry.uuid, []);
+    byUuid.get(entry.uuid).push(entry);
+  });
+
+  const uuids = [...byUuid.keys()];
+  const results = await Promise.all(
+    uuids.map((uuid) => checkFragmentPublished(uuid, resolvedLocale)),
+  );
+
+  const unpublished = results
+    .filter((r) => !r.published)
+    .map((r) => {
+      const group = byUuid.get(r.uuid);
+      return {
+        uuid: r.uuid,
+        httpStatus: r.httpStatus,
+        elements: group.map((g) => g.el),
+        cards: group.map((g) => g.card),
+      };
+    });
+
+  // eslint-disable-next-line no-console
+  console.log(
+    '[preflight][mas] scanned %d fragment(s); %d unpublished: %o',
+    uuids.length,
+    unpublished.length,
+    unpublished.map((u) => u.uuid),
+  );
+
+  return { unpublished, scanned: uuids.length };
+}
+
+export function runChecks({ area = document, locale, delayMs = HYDRATION_DELAY_MS } = {}) {
+  return [(async () => {
+    if (delayMs > 0) {
+      await new Promise((resolve) => { setTimeout(resolve, delayMs); });
+    }
+    const { unpublished, scanned } = await checkUnpublishedFragments({ area, locale });
+    const failed = unpublished.length > 0;
+    return {
+      name: 'M@S Unpublished Fragments',
+      status: failed ? 'fail' : 'pass',
+      severity: SEVERITY.CRITICAL,
+      details: failed ? { unpublished, scanned } : { scanned },
+    };
+  })()];
+}

--- a/libs/blocks/preflight/checks/merch.js
+++ b/libs/blocks/preflight/checks/merch.js
@@ -60,13 +60,9 @@ export async function checkUnpublishedFragments({ area = document, locale } = {}
       };
     });
 
-  // eslint-disable-next-line no-console
-  console.log(
-    '[preflight][mas] scanned %d fragment(s); %d unpublished: %o',
-    uuids.length,
-    unpublished.length,
-    unpublished.map((u) => u.uuid),
-  );
+  if (unpublished.length > 0) {
+    window.lana?.log?.(`[preflight][mas] ${unpublished.length} unpublished fragment(s) out of ${uuids.length} scanned: ${unpublished.map((u) => u.uuid).join(', ')}`, { tags: 'preflight', errorType: 'i' });
+  }
 
   return { unpublished, scanned: uuids.length };
 }

--- a/libs/blocks/preflight/checks/preflightApi.js
+++ b/libs/blocks/preflight/checks/preflightApi.js
@@ -27,6 +27,7 @@ import {
   runChecks as runChecksSeo,
 } from './seo.js';
 import { runChecks as runChecksStructure } from './structure.js';
+import { runChecks as runChecksMerch } from './merch.js';
 import { SEVERITY } from './constants.js';
 
 let checksSuite = null;
@@ -64,6 +65,7 @@ export default {
     runChecks: runChecksSeo,
   },
   structure: { runChecks: runChecksStructure },
+  merch: { runChecks: runChecksMerch },
 };
 
 export const getChecksSuite = () => {
@@ -108,12 +110,14 @@ const runChecks = async (url, area, injectVisualMetadata = false) => {
   const performance = await Promise.all(runChecksPerformance(url, area));
   const seo = isASO ? await fetchPreflightChecks() : runChecksSeo({ url, area });
   const structure = await Promise.all(runChecksStructure({ area }));
+  const merch = await Promise.all(runChecksMerch({ area }));
   return {
     accessibility,
     assets,
     performance,
     seo,
     structure,
+    merch,
   };
 };
 
@@ -150,6 +154,7 @@ export async function getPreflightResults(options = {}) {
     ...(res.performance || []),
     ...(res.seo || []),
     ...(res.structure || []),
+    ...(res.merch || []),
   ];
 
   const result = {

--- a/libs/blocks/preflight/panels/merch.js
+++ b/libs/blocks/preflight/panels/merch.js
@@ -1,8 +1,12 @@
 import { html, signal, useEffect } from '../../../deps/htm-preact.js';
+import { checkUnpublishedFragments } from '../checks/merch.js';
 
 const wcsElements = signal([]);
 const masFieldsMultipleFragmentWarnings = signal([]);
+const unpublishedFragments = signal([]);
 const loading = signal(true);
+
+const MAS_UNPUBLISHED_HIGHLIGHT = 'preflight-mas-unpublished';
 
 const ALLOWED_MAS_HOSTS = ['mas.adobe.com'];
 
@@ -92,6 +96,23 @@ function checkMasFieldsMultipleFragments() {
     }
   });
   masFieldsMultipleFragmentWarnings.value = warnings;
+}
+
+async function checkUnpublishedFragmentsForPanel() {
+  const main = document.querySelector('main');
+  main?.querySelectorAll(`.${MAS_UNPUBLISHED_HIGHLIGHT}`).forEach((el) => {
+    el.classList.remove(MAS_UNPUBLISHED_HIGHLIGHT);
+  });
+  const { unpublished } = await checkUnpublishedFragments({ area: document });
+  unpublishedFragments.value = unpublished.map((u) => {
+    u.cards?.forEach((c) => c.classList.add(MAS_UNPUBLISHED_HIGHLIGHT));
+    const firstCard = u.cards?.[0];
+    return {
+      uuid: u.uuid,
+      httpStatus: u.httpStatus,
+      location: firstCard ? getBlockLocation(firstCard) : 0,
+    };
+  });
 }
 
 function getService() {
@@ -442,6 +463,42 @@ function MasFieldsMultipleFragmentSection() {
   `;
 }
 
+function UnpublishedFragmentItem({ entry }) {
+  return html`
+    <div class="preflight-item merch-item merch-error">
+      <div class="preflight-item-text">
+        <p class="preflight-item-title">
+          <span class="result-icon red"></span>
+          Unpublished M@S fragment
+        </p>
+        <p class="preflight-item-description">
+          <strong>Fragment ID:</strong> <code class="wcs-osi-code">${entry.uuid}</code>
+          <br/><strong>HTTP status:</strong> ${entry.httpStatus}
+        </p>
+        <button
+          class="preflight-action merch-scroll-btn"
+          onclick=${() => scrollToElement(entry.location)}>
+          Scroll to card
+        </button>
+      </div>
+    </div>
+  `;
+}
+
+function UnpublishedFragmentsSection() {
+  const entries = unpublishedFragments.value;
+  if (entries.length === 0) return null;
+  return html`
+    <div class="merch-section">
+      <h3 class="merch-section-title">M@S Unpublished Fragments</h3>
+      <p class="merch-section-description">These fragments are referenced on this page but are not published. Publishing now will break the live page.</p>
+      <div class="merch-blocks-list">
+        ${entries.map((entry) => html`<${UnpublishedFragmentItem} entry=${entry} />`)}
+      </div>
+    </div>
+  `;
+}
+
 function MerchSummary() {
   const totalElements = wcsElements.value.length;
   const passedCount = wcsElements.value.filter((elem) => (elem.urlStatus === 'success' || !elem.href)
@@ -451,8 +508,9 @@ function MerchSummary() {
     || elem.promoCodeStatus === 'not-found').length;
   const undeterminedCount = wcsElements.value.filter((elem) => elem.urlStatus === 'undetermined').length;
   const masWarningsCount = masFieldsMultipleFragmentWarnings.value.length;
+  const unpublishedCount = unpublishedFragments.value.length;
 
-  if (totalElements === 0 && masWarningsCount === 0) {
+  if (totalElements === 0 && masWarningsCount === 0 && unpublishedCount === 0) {
     return html`
       <div class="merch-summary no-blocks">
         <h3>No Merch Elements Found</h3>
@@ -487,6 +545,12 @@ function MerchSummary() {
           <span class="merch-stat-label">Blocks w/ multiple fragment IDs</span>
         </div>
       `}
+      ${unpublishedCount > 0 && html`
+        <div class="merch-summary-stat has-errors">
+          <span class="merch-stat-number">${unpublishedCount}</span>
+          <span class="merch-stat-label">Unpublished M@S fragments</span>
+        </div>
+      `}
     </div>
   `;
 }
@@ -496,6 +560,7 @@ export default function Merch() {
     checkMasFieldsMultipleFragments();
     setTimeout(() => {
       checkWcsElements();
+      checkUnpublishedFragmentsForPanel();
     }, 3000);
   }, []);
 
@@ -512,6 +577,7 @@ export default function Merch() {
       <div class="merch-panel">
         <${MerchSummary} />
         <${MasFieldsMultipleFragmentSection} />
+        <${UnpublishedFragmentsSection} />
       </div>
     `;
   }
@@ -520,6 +586,7 @@ export default function Merch() {
     <div class="merch-panel">
       <${MerchSummary} />
       <${MasFieldsMultipleFragmentSection} />
+      <${UnpublishedFragmentsSection} />
       <div class="merch-section">
         <h3 class="merch-section-title">Elements</h3>
         <div class="merch-blocks-list">

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -279,7 +279,7 @@ span.preflight-time {
   transition: outline 300ms;
   border: none;
   height: 36px;
-  font-family: 'Adobe Clean', adobe-clean, sans-serif;
+  font-family: var(--body-font-family);
   font-size: 16px;
   padding: 0 18px;
   clip-path: polygon(0% 0%, var(--notch-size) 0%, calc(100% - var(--notch-size)) 0%, 100% var(--notch-size), 100% calc(100% - var(--notch-size)), 100% 100%, 0% 100%, 0% 100%);
@@ -1302,7 +1302,7 @@ img:hover ~ .asset-meta,
   padding: 4px 10px;
   background: #f44;
   color: #fff;
-  font-family: 'Adobe Clean', adobe-clean, sans-serif;
+  font-family: var(--body-font-family);
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.04em;

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -1280,4 +1280,38 @@ img:hover ~ .asset-meta,
   border: 3px solid #e68600 !important;
 }
 
+/* Highlight cards whose M@S fragment is unpublished */
+.preflight-mas-unpublished {
+  position: relative !important;
+  outline: 4px solid #f44 !important;
+  background-image: repeating-linear-gradient(
+    135deg,
+    rgb(255 68 68 / 8%) 0,
+    rgb(255 68 68 / 8%) 8px,
+    transparent 8px,
+    transparent 16px
+  ) !important;
+}
+
+.preflight-mas-unpublished::before {
+  content: 'Not published';
+  position: absolute;
+  top: -1px;
+  right: -1px;
+  z-index: 2;
+  padding: 4px 10px;
+  background: #f44;
+  color: #fff;
+  font-family: 'Adobe Clean', adobe-clean, sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-top-right-radius: 8px;
+  border-bottom-left-radius: 8px;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 20%);
+  pointer-events: none;
+  line-height: 2.5;
+}
+
 

--- a/libs/utils/preflight-notification.js
+++ b/libs/utils/preflight-notification.js
@@ -10,12 +10,24 @@ function openPreflightPanel() {
   sidekick.dispatchEvent(new CustomEvent('custom:preflight', { bubbles: true }));
 }
 
-async function createPreflightNotification() {
+function getMasUnpublishedCount(results) {
+  const merchResults = results?.runChecks?.merch || [];
+  return merchResults.reduce((sum, check) => {
+    if (check?.status !== 'fail') return sum;
+    return sum + (check.details?.unpublished?.length || 0);
+  }, 0);
+}
+
+async function createPreflightNotification(masUnpublishedCount = 0) {
   const existingNotification = document.querySelector('.milo-preflight-overlay');
   if (existingNotification) return;
   const { miloLibs, codeRoot } = getConfig();
   const base = miloLibs || codeRoot;
   loadStyle(`${base}/styles/preflight-notification.css`);
+
+  const masLine = masUnpublishedCount > 0
+    ? `<br/><span class="notification-mas-line">M@S: ${masUnpublishedCount} unpublished fragment${masUnpublishedCount === 1 ? '' : 's'} on this page.</span>`
+    : '';
 
   const overlay = document.createElement('div');
   overlay.className = 'milo-preflight-overlay';
@@ -23,7 +35,7 @@ async function createPreflightNotification() {
     <div class="preflight-notification">
       <div class="notification-content">
         <span class="notification-message">
-          Content quality checks are failing. Please <button class="preflight-review-link">review</button> before publishing.
+          Content quality checks are failing. Please <button class="preflight-review-link">review</button> before publishing.${masLine}
         </span>
         <button class="notification-close">×</button>
       </div>
@@ -82,7 +94,7 @@ function createObserver() {
       url: window.location.href,
       area: document,
     }).catch(() => null);
-    if (results?.hasFailures) await createPreflightNotification();
+    if (results?.hasFailures) await createPreflightNotification(getMasUnpublishedCount(results));
   });
 
   sidekickObserver.observe(sidekick, {
@@ -113,7 +125,7 @@ export default async function show() {
   if (!results) return;
 
   if (results.hasFailures) {
-    await createPreflightNotification();
+    await createPreflightNotification(getMasUnpublishedCount(results));
   } else {
     setupLinkCheckListener();
   }

--- a/test/blocks/preflight/checks/merch.test.js
+++ b/test/blocks/preflight/checks/merch.test.js
@@ -1,0 +1,104 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import {
+  findFragmentElements,
+  checkFragmentPublished,
+  checkUnpublishedFragments,
+  runChecks,
+} from '../../../../libs/blocks/preflight/checks/merch.js';
+import { SEVERITY } from '../../../../libs/blocks/preflight/checks/constants.js';
+
+const UUID_PUBLISHED = '11111111-1111-1111-1111-111111111111';
+const UUID_UNPUBLISHED = '22222222-2222-2222-2222-222222222222';
+
+function buildArea() {
+  const area = document.createElement('div');
+  area.innerHTML = `
+    <merch-card>
+      <aem-fragment fragment="${UUID_PUBLISHED}"></aem-fragment>
+    </merch-card>
+    <merch-card>
+      <aem-fragment fragment="${UUID_UNPUBLISHED}"></aem-fragment>
+    </merch-card>
+  `;
+  return area;
+}
+
+function stubFetch() {
+  return sinon.stub(window, 'fetch').callsFake((url) => {
+    const id = new URL(url).searchParams.get('id');
+    if (id === UUID_PUBLISHED) return Promise.resolve({ status: 200 });
+    if (id === UUID_UNPUBLISHED) return Promise.resolve({ status: 404 });
+    return Promise.resolve({ status: 500 });
+  });
+}
+
+describe('Preflight M@S Unpublished Fragments check', () => {
+  let area;
+  let fetchStub;
+
+  beforeEach(() => {
+    area = buildArea();
+    fetchStub = stubFetch();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('findFragmentElements returns one entry per aem-fragment with closest merch-card', () => {
+    const entries = findFragmentElements(area);
+    expect(entries).to.have.length(2);
+    expect(entries[0].uuid).to.equal(UUID_PUBLISHED);
+    expect(entries[0].card.tagName).to.equal('MERCH-CARD');
+    expect(entries[1].uuid).to.equal(UUID_UNPUBLISHED);
+    expect(entries[1].card.tagName).to.equal('MERCH-CARD');
+  });
+
+  it('checkFragmentPublished returns published=true on 200', async () => {
+    const result = await checkFragmentPublished(UUID_PUBLISHED, 'en_US');
+    expect(result).to.deep.equal({ uuid: UUID_PUBLISHED, httpStatus: 200, published: true });
+  });
+
+  it('checkFragmentPublished returns published=false on 404', async () => {
+    const result = await checkFragmentPublished(UUID_UNPUBLISHED, 'en_US');
+    expect(result).to.deep.equal({ uuid: UUID_UNPUBLISHED, httpStatus: 404, published: false });
+  });
+
+  it('checkUnpublishedFragments reports 1 unpublished out of 2 scanned', async () => {
+    const result = await checkUnpublishedFragments({ area, locale: 'en_US' });
+    expect(result.scanned).to.equal(2);
+    expect(result.unpublished).to.have.length(1);
+    expect(result.unpublished[0].uuid).to.equal(UUID_UNPUBLISHED);
+    expect(result.unpublished[0].httpStatus).to.equal(404);
+  });
+
+  it('runChecks resolves to fail with CRITICAL severity when there are unpublished fragments', async () => {
+    const [promise] = runChecks({ area, locale: 'en_US', delayMs: 0 });
+    const result = await promise;
+    expect(result.status).to.equal('fail');
+    expect(result.severity).to.equal(SEVERITY.CRITICAL);
+    expect(result.details.unpublished).to.have.length(1);
+  });
+
+  it('runChecks resolves to pass when all fragments are published', async () => {
+    const cleanArea = document.createElement('div');
+    cleanArea.innerHTML = `
+      <merch-card>
+        <aem-fragment fragment="${UUID_PUBLISHED}"></aem-fragment>
+      </merch-card>
+    `;
+    const [promise] = runChecks({ area: cleanArea, locale: 'en_US', delayMs: 0 });
+    const result = await promise;
+    expect(result.status).to.equal('pass');
+    expect(result.severity).to.equal(SEVERITY.CRITICAL);
+  });
+
+  it('builds the API URL with api_key and underscore locale', async () => {
+    await checkFragmentPublished(UUID_PUBLISHED, 'en_US');
+    const url = fetchStub.firstCall.args[0];
+    expect(url).to.include('api_key=wcms-commerce-ims-ro-user-milo');
+    expect(url).to.include('locale=en_US');
+    expect(url).to.include(`id=${UUID_PUBLISHED}`);
+  });
+});


### PR DESCRIPTION
* Detects every M@S `<aem-fragment>` referenced on the rendered page and flags any that return non-200 from the Adobe MAS fragment API as CRITICAL failures in the Preflight aggregator.
* Adds an "Unpublished Fragments" section to the Preflight M@S panel listing each unpublished fragment ID, HTTP status, and a "Scroll to card" button.
* Decorates affected cards with a red outline, diagonal hatch background, and a "Not published" corner badge.
* Appends an additive `M@S: N unpublished fragment(s) on this page.` line to the failure toast — does not hard-block publishing.

Resolves: [MWPW-191951](https://jira.corp.adobe.com/browse/MWPW-191951)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/rivero/mas-preflight/my-document-with-unpublish-fragments
- After: https://mwpw-191951--milo--adobecom.aem.page/drafts/rivero/mas-preflight/my-document-with-unpublish-fragments

<img width="1035" height="668" alt="Screenshot 2026-04-30 at 3 08 53 PM" src="https://github.com/user-attachments/assets/a135c152-2044-45f3-8380-024389c02b35" />
<img width="1112" height="645" alt="Screenshot 2026-04-30 at 3 09 58 PM" src="https://github.com/user-attachments/assets/927528fb-8830-4c94-bd89-1e822d19ec5c" />







