### PR TITLE
Centralize per-viewport content decoration for C2

### DIFF
--- a/libs/c2/blocks/base-card/base-card.css
+++ b/libs/c2/blocks/base-card/base-card.css
@@ -1,16 +1,7 @@
-
 .base-card {
   position: relative;
   height: 100%;
   contain: layout;
-
-  > div[data-viewport] {
-    display: none;
-  }
-
-  > div[data-viewport="mobile"] {
-    display: flex;
-  }
 
   > div {
     display: flex;
@@ -111,14 +102,6 @@
 
 @media (width >= 768px) {
   .base-card {
-    > div[data-viewport="mobile"] {
-      display: none;
-    }
-
-    > div[data-viewport="tablet"] {
-      display: flex;
-    }
-
     &.featured {
       .foreground {
         padding: var(--s2a-spacing-24) var(--s2a-spacing-24) var(--s2a-spacing-40) var(--s2a-spacing-24);
@@ -129,14 +112,6 @@
 
 @media (width >= 1024px) {
   .base-card {
-    > div[data-viewport="tablet"] {
-      display: none;
-    }
-
-    > div[data-viewport="desktop"] {
-      display: flex;
-    }
-
     .media picture:not(.icon) img {
       aspect-ratio: 4/3;
     }

--- a/libs/c2/blocks/base-card/base-card.js
+++ b/libs/c2/blocks/base-card/base-card.js
@@ -1,16 +1,5 @@
-import { decorateBlockText, decorateTextOverrides } from '../../../utils/decorate.js';
+import { decorateBlockText, decorateViewportContent } from '../../../utils/decorate.js';
 import { getFederatedUrl } from '../../../utils/utils.js';
-
-const VIEWPORT_LABELS = ['mobile', 'tablet', 'desktop'];
-
-function getRowLabelText(row) {
-  const cell = row.querySelector(':scope > div');
-  return cell?.textContent?.trim().toLowerCase() ?? '';
-}
-
-function isViewportLabel(text) {
-  return VIEWPORT_LABELS.includes(text);
-}
 
 function markStandaloneLinks(foreground) {
   foreground.querySelectorAll('a').forEach((a) => {
@@ -24,46 +13,38 @@ function markStandaloneLinks(foreground) {
 
 const isSvgUrl = (url) => /\.svg(\?.*)?$/i.test(url || '');
 
-function decorateCard(wrapper) {
-  const [foreground, media] = [...wrapper.children];
-  if (!foreground || !media) return;
-  media.classList.add('media');
-  if (media.closest('.base-card.featured')) media.classList.add('parallax-featured-card-media');
-  media.querySelector('picture').classList.add('parallax-scale-down');
+function decorateCard(block, root) {
+  const row = block.children[0];
+  const foreground = row?.children[0];
+  const media = row?.children[1];
+  if (!foreground) return;
+
   foreground.classList.add('foreground');
   decorateBlockText(foreground, { heading: '4' });
   markStandaloneLinks(foreground);
-  const firstCell = foreground.children[0];
-  if (firstCell?.childElementCount !== 1 || firstCell?.firstElementChild?.tagName !== 'PICTURE') return;
 
-  const iconPicture = firstCell.firstElementChild;
-  const iconImg = iconPicture.querySelector('img');
-  if (iconImg?.hasAttribute('src') && isSvgUrl(iconImg?.src)) iconImg.src = getFederatedUrl(iconImg.getAttribute('src'));
-  iconPicture.classList.add('icon');
-  media.appendChild(iconPicture);
-  firstCell.remove();
-}
+  if (media) {
+    media.classList.add('media');
+    if (root.classList.contains('featured')) media.classList.add('parallax-featured-card-media');
+    const pic = media.querySelector('picture');
+    if (pic) pic.classList.add('parallax-scale-down');
 
-function decorateViewportStructure(rows) {
-  for (let i = 0; i < rows.length; i += 2) {
-    const labelRow = rows[i];
-    const contentRow = rows[i + 1];
-    contentRow.setAttribute('data-viewport', getRowLabelText(labelRow));
-    labelRow.remove();
-    decorateCard(contentRow);
+    // Move icon from foreground to media overlay
+    const firstCell = foreground.children[0];
+    if (firstCell?.childElementCount === 1 && firstCell?.firstElementChild?.tagName === 'PICTURE') {
+      const iconPicture = firstCell.firstElementChild;
+      const iconImg = iconPicture.querySelector('img');
+      if (iconImg?.hasAttribute('src') && isSvgUrl(iconImg?.src)) {
+        iconImg.src = getFederatedUrl(iconImg.getAttribute('src'));
+      }
+      iconPicture.classList.add('icon');
+      media.appendChild(iconPicture);
+      firstCell.remove();
+    }
   }
 }
 
 export default function init(el) {
   el.closest('.section').classList.add('base-card-section');
-  const rows = [...el.children];
-
-  const hasViewportStructure = rows.length >= 2
-    && rows.length % 2 === 0
-    && isViewportLabel(getRowLabelText(rows[0]));
-
-  if (hasViewportStructure) decorateViewportStructure(rows);
-  else decorateCard(rows[0]);
-
-  decorateTextOverrides(el);
+  decorateViewportContent(el, decorateCard);
 }

--- a/libs/c2/blocks/explore-card/explore-card.js
+++ b/libs/c2/blocks/explore-card/explore-card.js
@@ -1,5 +1,5 @@
 import { createTag, getFederatedUrl } from '../../../utils/utils.js';
-import { decorateBlockText, decorateTextOverrides } from '../../../utils/decorate.js';
+import { decorateBlockText, decorateViewportContent } from '../../../utils/decorate.js';
 
 function hasContent(node) {
   return node.textContent?.trim() !== '' || node.querySelector('img, picture, svg, a[href]');
@@ -15,15 +15,14 @@ function getForegroundContent(foregroundRow, contentDiv, blockName) {
   }
 }
 
-export default function init(el) {
-  const blockName = el.classList[0].toLowerCase();
-  const rows = el.querySelectorAll(':scope > div');
+function decorate(block, root) {
+  const blockName = root.classList[0].toLowerCase();
+  const rows = block.querySelectorAll(':scope > div');
   const firstRow = rows[0];
   const foregroundRow = rows[1];
 
   if (!firstRow) return;
 
-  // First row: content (first div) + background (second div)
   const contentDiv = firstRow.querySelector(':scope > div:first-child');
   const backgroundDiv = firstRow.querySelector(':scope > div:last-child');
   const isSvgUrl = (url) => /\.svg(\?.*)?$/i.test(url || '');
@@ -39,14 +38,16 @@ export default function init(el) {
   contentDiv?.classList.add(`${blockName}-content`);
   firstRow.classList.add(`${blockName}-container`);
 
-  // Second row: foreground container
   getForegroundContent(foregroundRow, contentDiv, blockName);
   decorateBlockText(contentDiv, { heading: '4' });
-  decorateTextOverrides(el, undefined, contentDiv);
 
   if (!link) return;
   const linkContainer = createTag('a', { class: `${blockName}-link-container`, href: link.href, 'data-tracking-label': heading?.textContent });
   link.remove();
   linkContainer.append(contentDiv);
   firstRow.prepend(linkContainer);
+}
+
+export default function init(el) {
+  decorateViewportContent(el, decorate);
 }

--- a/libs/c2/blocks/rich-content/rich-content.css
+++ b/libs/c2/blocks/rich-content/rich-content.css
@@ -46,6 +46,7 @@
   &:has(.rich-content.hero) {
     box-sizing: border-box;
     height: 640px;
+
     &.has-background .section-background {
       max-width: 100vw;
       margin: 0 auto;
@@ -95,9 +96,6 @@
       }
     }
   }
-}
-
-@media (width >= 1440px) {
 }
 
 @media (width >= 1920px) {

--- a/libs/c2/blocks/rich-content/rich-content.js
+++ b/libs/c2/blocks/rich-content/rich-content.js
@@ -1,4 +1,4 @@
-import { decorateBlockText, decorateTextOverrides } from '../../../utils/decorate.js';
+import { decorateBlockText, decorateViewportContent } from '../../../utils/decorate.js';
 import { createTag } from '../../../utils/utils.js';
 
 function hangOpeningQuote(header) {
@@ -35,101 +35,6 @@ function decorate(block) {
   promoteParagraphTitle(content);
 }
 
-function decorateMultiViewport(el, viewportContent) {
-  const viewportsMap = {
-    'mobile-tablet-desktop': {
-      mobile: '(width < 768px)',
-      tablet: '(width >= 768px) and (width < 1024px)',
-      desktop: '(width >= 1024px)',
-    },
-    'mobile-desktop': {
-      mobile: '(width < 1024px)',
-      desktop: '(width >= 1024px)',
-    },
-    'mobile-tablet': {
-      mobile: '(width < 768px)',
-      tablet: '(width >= 768px)',
-    },
-  };
-
-  const viewportsPoints = viewportsMap[Object.keys(viewportContent).join('-')];
-  if (!viewportsPoints) return;
-  const allClasses = Object.values(viewportContent)?.flatMap(({ classes }) => classes ?? []);
-  Object.entries(viewportContent).forEach(([viewport, value]) => {
-    if (!viewportsPoints[viewport]) return;
-    const { contentContainer, classes } = value;
-    const contentChildren = [...contentContainer.children];
-    const mq = window.matchMedia(viewportsPoints[viewport]);
-    const setContent = () => {
-      if (!mq.matches) return;
-      el.classList.remove(...allClasses);
-      el.classList.add(...classes);
-      el.replaceChildren(...contentChildren);
-    };
-    setContent();
-    mq.addEventListener('change', setContent);
-  });
-}
-
-function addMissingContent(con, previous) {
-  if (!previous) return;
-
-  const [foreground, media] = con;
-  const [content, background] = foreground.children;
-  const [prevForeground, prevMedia] = previous.contentContainer.children;
-  const [prevContent, prevBackground] = prevForeground.children;
-
-  const pairs = [
-    [media, prevMedia],
-    [content, prevContent],
-    [background, prevBackground],
-  ];
-
-  pairs.forEach(([el, prev]) => {
-    if (el?.children.length || el?.textContent) return;
-    el?.replaceChildren(...[...prev.children].map((c) => c.cloneNode(true)));
-  });
-}
-
-function getViewportConfig(el) {
-  const viewportContent = {};
-  const children = [...el.children];
-  const delimiterEls = [];
-  const delimiters = ['mobile', 'tablet', 'desktop'];
-  const suffix = '-viewport';
-  delimiters.forEach((delimiter, index) => {
-    const delimiterIndex = children
-      .findIndex((child) => child.textContent.trim().toLowerCase().startsWith(delimiter + suffix));
-    if (delimiterIndex < 0) return;
-    const nextDelimiterIndex = children
-      .findIndex((child) => child.textContent
-        .trim().toLowerCase().startsWith(delimiters[index + 1] + suffix));
-    const content = children
-      .slice(delimiterIndex + 1, nextDelimiterIndex < 0 ? children.length : nextDelimiterIndex);
-    addMissingContent(content, viewportContent[delimiters[index - 1]]);
-    const delimiterEl = children[delimiterIndex];
-    const classes = delimiterEl.textContent.toLowerCase().trim().match(/\(([^)]+)\)/)?.[1];
-    delimiterEls.push(delimiterEl);
-    const contentContainer = createTag('div');
-    contentContainer.append(...content);
-    viewportContent[delimiter] = {
-      contentContainer,
-      classes: classes?.split(',').map((c) => c.trim()) ?? [],
-    };
-  });
-  delimiterEls.forEach((delimiterEl) => delimiterEl.remove());
-  if (!Object.keys(viewportContent).length) {
-    return { default: { contentContainer: el } };
-  }
-  return viewportContent;
-}
-
 export default function init(el) {
-  const viewPortConfig = getViewportConfig(el);
-  Object.values(viewPortConfig).forEach((value) => {
-    const { contentContainer } = value;
-    decorate(contentContainer);
-  });
-  decorateMultiViewport(el, viewPortConfig);
-  decorateTextOverrides(el);
+  decorateViewportContent(el, decorate);
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -559,7 +559,7 @@ export function decorateAnchorVideo({ src = '', anchorTag }) {
 
 /* NOTE: Experimental logic to substitute authored classes
    with centralized kit classes */
-export function decorateBlockKit(el, kits = []) {
+export function decorateBlockKit(el, kits = {}) {
   const kitClass = [...el.classList].find((cls) => cls.endsWith('-kit'));
   if (!kitClass || !Object.keys(kits).includes(kitClass)) return;
 
@@ -567,4 +567,186 @@ export function decorateBlockKit(el, kits = []) {
   const kitClasses = kits[kitClass];
   el.className = blockClass;
   el.classList.add(kitClass, ...kitClasses);
+}
+
+/* Per-viewport content decoration */
+const VIEWPORT_KEYWORDS = ['mobile', 'tablet', 'desktop'];
+const VIEWPORT_SUFFIX = '-viewport';
+
+const VIEWPORT_QUERIES = {
+  'mobile-tablet-desktop': {
+    mobile: '(width < 768px)',
+    tablet: '(768px <= width < 1280px)',
+    desktop: '(width >= 1280px)',
+  },
+  'mobile-desktop': {
+    mobile: '(width < 1280px)',
+    desktop: '(width >= 1280px)',
+  },
+  'mobile-tablet': {
+    mobile: '(width < 768px)',
+    tablet: '(width >= 768px)',
+  },
+  mobile: { mobile: 'all' },
+  tablet: { tablet: 'all' },
+  desktop: { desktop: 'all' },
+};
+
+function isEmptyCell(el) {
+  if (!el) return true;
+  return !el.children.length && !el.textContent?.trim();
+}
+
+function cloneChildren(source) {
+  return [...source.children].map((child) => child.cloneNode(true));
+}
+
+function parseVariants(text) {
+  const match = text.match(/\(([^)]+)\)/);
+  return match
+    ? match[1].split(',').map((cls) => cls.trim()).filter(Boolean)
+    : [];
+}
+
+function getDelimiterKeyword(row) {
+  if (row.children.length !== 1) return null;
+  const text = row.children[0].textContent.trim().toLowerCase();
+  // TODO: remove bare-keyword fallback post-rollout (replace with the line below)
+  // return VIEWPORT_KEYWORDS.find((kw) => text.startsWith(kw + VIEWPORT_SUFFIX)) ?? null;
+  return VIEWPORT_KEYWORDS.find((kw) => (
+    text.startsWith(kw + VIEWPORT_SUFFIX) || text === kw || text.startsWith(`${kw} `) || text.startsWith(`${kw}(`)
+  )) ?? null;
+}
+
+function warnDuplicateH1s(viewportData) {
+  const h1Count = Object.values(viewportData)
+    .reduce((n, vp) => n + vp.container.querySelectorAll('h1').length, 0);
+  if (h1Count > 1) {
+    /* TODO: this should be surfaced in Preflight */
+    /* eslint-disable-next-line no-console */
+    console.warn(
+      '[parseViewportContent] Multiple <h1> elements detected across viewport sections. '
+      + 'This may cause SEO issues — consider using a single <h1> and swapping its text content.',
+    );
+  }
+}
+
+function resolveInheritance(rows, previousContent) {
+  if (!previousContent) return;
+
+  const [contentRow, ...extraRows] = rows;
+  const prevChildren = [...previousContent.children];
+  const [prevContentRow, ...prevExtraRows] = prevChildren;
+
+  if (contentRow && prevContentRow) {
+    [...contentRow.children].forEach((col, i) => {
+      const prevCol = prevContentRow.children[i];
+      if (isEmptyCell(col) && prevCol && !isEmptyCell(prevCol)) {
+        col.replaceChildren(...cloneChildren(prevCol));
+      }
+    });
+  }
+
+  extraRows.forEach((row, i) => {
+    const prevRow = prevExtraRows[i];
+    const cell = row?.children[0];
+    const prevCell = prevRow?.children[0];
+    if (cell && isEmptyCell(cell) && prevCell && !isEmptyCell(prevCell)) {
+      cell.replaceChildren(...cloneChildren(prevCell));
+    }
+  });
+}
+
+function parseViewportContent(el) {
+  const children = [...el.children];
+  const content = {};
+  const delimiterEls = [];
+
+  VIEWPORT_KEYWORDS.forEach((keyword, kwIndex) => {
+    const delimiterIdx = children.findIndex((child) => getDelimiterKeyword(child) === keyword);
+    if (delimiterIdx < 0) return;
+
+    // Find the next delimiter (if any) to bound this section
+    const nextIdx = children.findIndex((child, i) => {
+      if (i <= delimiterIdx) return false;
+      const nextKw = getDelimiterKeyword(child);
+      return nextKw && VIEWPORT_KEYWORDS.indexOf(nextKw) > kwIndex;
+    });
+
+    const rows = children.slice(
+      delimiterIdx + 1,
+      nextIdx < 0 ? children.length : nextIdx,
+    );
+
+    // Inherit from the nearest defined lower viewport
+    const prevKey = VIEWPORT_KEYWORDS.slice(0, kwIndex).reverse()
+      .find((k) => content[k]);
+    resolveInheritance(rows, content[prevKey]?.container);
+
+    const container = createTag('div');
+    container.append(...rows);
+
+    const delimiterEl = children[delimiterIdx];
+    const variants = parseVariants(delimiterEl.textContent);
+    delimiterEls.push(delimiterEl);
+
+    content[keyword] = { container, variants };
+  });
+
+  delimiterEls.forEach((d) => d.remove());
+
+  if (!Object.keys(content).length) {
+    return { hasViewportVariations: false };
+  }
+
+  warnDuplicateH1s(content);
+
+  const allVariants = Object.values(content).flatMap(({ variants }) => variants);
+
+  return { hasViewportVariations: true, content, allVariants };
+}
+
+function applyViewportContent(el, viewports) {
+  if (!viewports.hasViewportVariations) return;
+
+  const { content, allVariants } = viewports;
+  const vpKeys = Object.keys(content);
+  const queryKey = vpKeys.join('-');
+  const queries = VIEWPORT_QUERIES[queryKey];
+
+  if (!queries) return;
+
+  vpKeys.forEach((viewport) => {
+    const mq = window.matchMedia(queries[viewport]);
+    const { container, variants } = content[viewport];
+    const children = [...container.children];
+
+    const setContent = () => {
+      if (!mq.matches) return;
+      el.classList.remove(...allVariants);
+      if (variants.length) el.classList.add(...variants);
+      el.replaceChildren(...children);
+      decorateTextOverrides(el);
+    };
+
+    setContent();
+    mq.addEventListener('change', setContent);
+  });
+}
+
+/* decorateFn receives:
+ * - block — the element to decorate (viewport container or el itself)
+ * - root  — for checking base classes on detached containers */
+export function decorateViewportContent(el, decorateFn) {
+  const viewports = parseViewportContent(el);
+  if (viewports.hasViewportVariations) {
+    Object.values(viewports.content).forEach(({ container }) => {
+      decorateFn(container, el);
+    });
+    applyViewportContent(el, viewports);
+  } else {
+    decorateFn(el, el);
+    decorateTextOverrides(el);
+  }
+  return viewports;
 }


### PR DESCRIPTION
This aims to centralize a method to decorate cross-viewport content, now that we're introducing standard authoring pattern. Blocks where this has already been applied: base-card, rich-content, explore-card. Blocks that might not currently align with the authoring pattern or more investigation is needed from responsible engineers: router-marquee (where each viewport has multiple slides), news (where we're not aware of a need to have per-viewport content; additionally, in the future its content might come from an external source), elastic-carousel (which also has a different authoring pattern at the moment).

The logic currently support both `mobile` and `mobile-viewport` keywords (same for tablet/desktop), until engineers and GWP align on using the latter, which is needed for the localization process.

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=site-redesign-foundation
- After: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=vp-content-decoration


