### PR TITLE
No need to ignore the Events root

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -139,7 +139,12 @@ const [getCaasTags, loadCaasTags] = (() => {
 const getTag = (tagName, errors) => {
   if (!tagName) return undefined;
   const caasTags = getCaasTags();
-  const tag = findTag(caasTags, tagName);
+  // Skip the Events namespace root by tagID (not by title "Events", which would also
+  // exclude unrelated tags like caas:newsroom/article/events). Falls back to a search
+  // inside the Events subtree only if no non-Events match is found, preserving the
+  // historical "prefer non-Events" resolution.
+  const tag = findTag(caasTags, tagName, ['caas:events'])
+    || findTag(caasTags.events.tags, tagName, []);
 
   if (!tag) {
     errors.push(tagName);

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -139,8 +139,7 @@ const [getCaasTags, loadCaasTags] = (() => {
 const getTag = (tagName, errors) => {
   if (!tagName) return undefined;
   const caasTags = getCaasTags();
-  // search all except Events first
-  const tag = findTag(caasTags, tagName, ['Events']) || findTag(caasTags.events.tags, tagName, []);
+  const tag = findTag(caasTags, tagName);
 
   if (!tag) {
     errors.push(tagName);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

- Fix CaaS tag lookup in send-to-Caaas: stop passing ['Events'] into findTag, which skipped every tag whose display title is "Events" (e.g. caas:newsroom/article/events), not only the Events namespace root.

- Drop the redundant second findTag(caasTags.events.tags, …) pass; a single walk of caasTags with default empty ignore already covers the Events subtree.

Resolves: [MWPW-193344](https://jira.corp.adobe.com/browse/MWPW-193344)

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://tag-fix--milo--adobecom.aem.page/?martech=off


