### PR TITLE
MWPW-192822 Add geo-ip placeholder resolution with deferred LCP support

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import {
-  createTag, getConfig, loadArea, localizeLinkAsync, customFetch, getMepLingoPrefix,
+  createTag, getConfig, loadArea, localizeLinkAsync, customFetch, getGeoLocalePrefix,
 } from '../../utils/utils.js';
 
 const fragMap = {};
@@ -149,7 +149,7 @@ export default async function init(a) {
   const isMepLingoLink = a.dataset.mepLingo === 'true';
   const isMepLingoInsert = a.dataset.mepLingoInsert === 'true';
   const isMepLingoRemove = a.dataset.mepLingoRemove === 'true';
-  const shouldFetchMepLingo = isMepLingoLink && !!await getMepLingoPrefix();
+  const shouldFetchMepLingo = isMepLingoLink && !!await getGeoLocalePrefix();
 
   // Import mep/lingo.js once if this is a mep-lingo link
   const lingoModule = isMepLingoLink ? await import('../../features/mep/lingo.js') : null;
@@ -216,7 +216,7 @@ export default async function init(a) {
       .catch(() => ({}));
   }
 
-  const mepLingoPrefix = await getMepLingoPrefix();
+  const mepLingoPrefix = await getGeoLocalePrefix();
   const fetchedNonRegionalContent = isMepLingoLink && resp?.ok
     && !relHref.includes(mepLingoPrefix || '___NONE___');
   const redirectedRegionalFetch = (isBlockSwap || isSectionSwap) && resp?.redirected

--- a/libs/features/mep/README.md
+++ b/libs/features/mep/README.md
@@ -84,7 +84,7 @@ mepLingoCountryToRegion: {
 |----------|-------------|
 | `getCountry()` | Get user's country code from akamaiLocale param, sessionStorage, or server timing |
 | `lingoActive()` | Check if lingo is enabled via `langfirst` URL param or meta tag |
-| `getMepLingoPrefix()` | Get the regional prefix for the current user's country |
+| `getGeoLocalePrefix()` | Get the regional prefix for the current user's country |
 
 ### `getLocaleCodeFromPrefix` Details
 

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -3,7 +3,7 @@ import {
   getCookie,
   getConfig,
   getMetadata,
-  getMepLingoPrefix,
+  getGeoLocalePrefix,
   loadStyle,
   lingoActive,
   normCountryCode,
@@ -647,7 +647,7 @@ export async function getMepPopup(mepConfig, isMmm = false) {
   async function buildSummaryLingo() {
     async function getGeoUserSupport() {
       if (regionKeys?.length === 0 || !lingoActive()) return 'Not Applicable';
-      if (await getMepLingoPrefix()) return 'Supported';
+      if (await getGeoLocalePrefix()) return 'Supported';
       return 'Not Supported';
     }
 

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -1,4 +1,4 @@
-import { customFetch, getConfig, getMetadata } from '../utils/utils.js';
+import { customFetch, getConfig, getMetadata, lingoActive, getMepLingoPrefix } from '../utils/utils.js';
 
 const fetchedPlaceholders = {};
 window.mph = {};
@@ -9,11 +9,11 @@ const getPlaceholdersPath = (config, sheet) => {
   return `${path}${query}`;
 };
 
-const parsePlaceholderJson = async (resp, placeholders) => {
+const parsePlaceholderJson = async (resp, placeholders, { updateMph = true } = {}) => {
   try {
     const json = resp.ok ? await resp.json() : { data: [] };
     json.data?.forEach((item) => {
-      window.mph[item.key] = item.value;
+      if (updateMph) window.mph[item.key] = item.value;
       placeholders[item.key] = item.value;
     });
   } catch (e) {
@@ -21,7 +21,7 @@ const parsePlaceholderJson = async (resp, placeholders) => {
   }
 };
 
-const fetchPlaceholder = (path, placeholderRequest) => new Promise(
+const fetchPlaceholder = (path, placeholderRequest, { updateMph = true } = {}) => new Promise(
   // eslint-disable-next-line no-async-promise-executor
   async (resolve) => {
     const resp = await placeholderRequest || await customFetch(
@@ -31,9 +31,9 @@ const fetchPlaceholder = (path, placeholderRequest) => new Promise(
 
     if (Array.isArray(resp)) {
       // Overlay placeholders
-      for (const r of resp) await parsePlaceholderJson(r, placeholders);
+      for (const r of resp) await parsePlaceholderJson(r, placeholders, { updateMph });
     } else {
-      await parsePlaceholderJson(resp, placeholders);
+      await parsePlaceholderJson(resp, placeholders, { updateMph });
     }
 
     resolve(placeholders);
@@ -45,16 +45,52 @@ export const fetchPlaceholders = async ({
   sheet,
   placeholderRequest,
   placeholderPath,
+  updateMph = true,
 }) => {
   const path = placeholderPath || getPlaceholdersPath(config, sheet);
 
-  fetchedPlaceholders[path] ||= fetchPlaceholder(path, placeholderRequest);
+  fetchedPlaceholders[path] ||= fetchPlaceholder(path, placeholderRequest, { updateMph });
 
   return fetchedPlaceholders[path];
 };
 
 function keyToStr(key) {
   return key.replaceAll('-', ' ');
+}
+
+const isGeoKey = (key) => key.endsWith('-geo');
+const stripGeo = (key) => key.slice(0, -4);
+
+let geoPlaceholderPromise;
+export function resetGeoPlaceholderCache() { geoPlaceholderPromise = undefined; }
+
+async function getGeoPlaceholders(sheet) {
+  if (!lingoActive()) return null;
+  const geoPrefix = await getMepLingoPrefix();
+  if (!geoPrefix) return null;
+
+  const siteConfig = getConfig();
+  const { origin } = window.location;
+  const contentRoot = siteConfig.contentRoot ?? '';
+  const geoContentRoot = `${origin}${geoPrefix}${contentRoot}`;
+  const geoConfig = { locale: { contentRoot: geoContentRoot } };
+
+  const root = `${geoContentRoot}/placeholders`;
+  const paths = [`${root}.json`];
+  if (siteConfig.env?.name !== 'prod'
+    && getMetadata('placeholders-stage') === 'on') paths.push(`${root}-stage.json`);
+
+  const placeholderRequest = Promise.all(
+    paths.map((path) => customFetch({ resource: path, withCacheRules: true }).catch(() => ({}))),
+  );
+
+  return fetchPlaceholders({
+    config: geoConfig,
+    sheet,
+    placeholderRequest,
+    placeholderPath: paths[0],
+    updateMph: false,
+  }).catch(() => ({}));
 }
 
 async function getPlaceholder(key, config, sheet) {
@@ -92,6 +128,9 @@ async function getPlaceholder(key, config, sheet) {
   };
 
   if (config.placeholders?.[key]) return config.placeholders[key];
+
+  if (isGeoKey(key)) return getPlaceholder(stripGeo(key), config, sheet);
+
   let placeholders;
 
   if (geoLocDisabled === 'on') {
@@ -108,6 +147,14 @@ async function getPlaceholder(key, config, sheet) {
   }
 
   return keyToStr(key);
+}
+
+async function resolveGeoKey(key, config, sheet) {
+  const baseKey = stripGeo(key);
+  geoPlaceholderPromise ??= getGeoPlaceholders(sheet);
+  const geoPlaceholders = await geoPlaceholderPromise;
+  if (typeof geoPlaceholders?.[baseKey] === 'string') return geoPlaceholders[baseKey];
+  return getPlaceholder(baseKey, config, sheet);
 }
 
 export async function replaceKey(key, config, sheet = 'default') {
@@ -129,6 +176,11 @@ export async function replaceKeyArray(keys, config, sheet = 'default') {
   return placeholders;
 }
 
+function isTelContext(text, matchIndex) {
+  const preceding = text.slice(Math.max(0, matchIndex - 10), matchIndex);
+  return /(?:^|["'=\s])tel:/i.test(preceding);
+}
+
 export async function replaceText(
   text,
   config,
@@ -142,13 +194,26 @@ export async function replaceText(
     return text;
   }
   const keys = Array.from(matches, (match) => match[1] || match[2]);
-  const placeholders = await replaceKeyArray(keys, config, sheet);
-  // The .shift method is very slow, thus using normal iterator
+  const resolved = await Promise.all(keys.map(async (key, idx) => {
+    if (isGeoKey(key) && isTelContext(text, matches[idx].index)) {
+      return resolveGeoKey(key, config, sheet);
+    }
+    return getPlaceholder(key, config, sheet);
+  }));
+
   let i = 0;
   // eslint-disable-next-line no-plusplus
-  let finalText = text.replaceAll(regex, () => placeholders[i++]);
+  let finalText = text.replaceAll(regex, () => resolved[i++]);
   finalText = finalText.replace(/&nbsp;/g, '\u00A0');
   return finalText;
+}
+
+function findGeoKeyInTelHref(el) {
+  if (el.tagName !== 'A') return null;
+  const href = el.getAttribute('href') || '';
+  if (!/^tel:/i.test(href)) return null;
+  const geoMatch = href.match(/{{(.*?-geo)}}|%7B%7B(.*?-geo)%7D%7D/);
+  return geoMatch ? (geoMatch[1] || geoMatch[2]) : null;
 }
 
 export async function decoratePlaceholderArea({
@@ -159,10 +224,13 @@ export async function decoratePlaceholderArea({
   if (!nodes.length) return;
   const config = getConfig();
   await fetchPlaceholders({ placeholderPath, config, placeholderRequest });
+  const geoLinks = [];
   const replaceNodes = nodes.map(async (nodeEl) => {
     if (nodeEl.nodeType === Node.TEXT_NODE) {
       nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config);
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
+      const geoKey = findGeoKeyInTelHref(nodeEl);
+      if (geoKey) geoLinks.push({ el: nodeEl, geoKey });
       const attrPromises = [...nodeEl.attributes].map(async (attr) => {
         const attrVal = await replaceText(attr.value, config);
         return { name: attr.name, value: attrVal };
@@ -174,4 +242,12 @@ export async function decoratePlaceholderArea({
     }
   });
   await Promise.all(replaceNodes);
+  if (geoLinks.length) {
+    await Promise.all(geoLinks.map(async ({ el, geoKey }) => {
+      const geoValue = await resolveGeoKey(geoKey, config);
+      if (geoValue && geoValue !== keyToStr(stripGeo(geoKey))) {
+        el.textContent = geoValue;
+      }
+    }));
+  }
 }

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -58,13 +58,11 @@ function keyToStr(key) {
 }
 
 const isGeoIpKey = (key) => key.endsWith('-geo-ip');
-
-const geoPlaceholderCache = new Map();
-export function resetGeoPlaceholderCache() { geoPlaceholderCache.clear(); }
+const PH_RE = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
 
 async function getGeoPlaceholders(config, sheet) {
   // Dynamic to avoid circular dep with utils.js that hangs WTR test runner
-  const { lingoActive, getGeoLocalePrefix } = await import('../utils/utils.js');
+  const { lingoActive, getGeoLocalePrefix, getPlaceholderPaths } = await import('../utils/utils.js');
   if (!lingoActive()) return null;
   const geoPrefix = await getGeoLocalePrefix();
   if (!geoPrefix) return null;
@@ -88,12 +86,8 @@ async function getGeoPlaceholders(config, sheet) {
   }
 
   const geoContentRoot = `${geoOrigin}${geoPrefix}${pathSuffix}`;
-  const geoConfig = { locale: { contentRoot: geoContentRoot } };
-
-  const root = `${geoContentRoot}/placeholders`;
-  const paths = [`${root}.json`];
-  if (siteConfig.env?.name !== 'prod'
-    && getMetadata('placeholders-stage') === 'on') paths.push(`${root}-stage.json`);
+  const geoConfig = { locale: { contentRoot: geoContentRoot }, env: siteConfig.env || {} };
+  const paths = getPlaceholderPaths(geoConfig);
 
   const placeholderRequest = Promise.all(
     paths.map((path) => customFetch({ resource: path, withCacheRules: true }).catch(() => ({}))),
@@ -161,14 +155,6 @@ async function getPlaceholder(key, config, sheet) {
   return keyToStr(key);
 }
 
-function ensureGeoFetch(config, sheet) {
-  const cacheKey = config.locale?.contentRoot ?? '';
-  if (!geoPlaceholderCache.has(cacheKey)) {
-    geoPlaceholderCache.set(cacheKey, getGeoPlaceholders(config, sheet));
-  }
-  return geoPlaceholderCache.get(cacheKey);
-}
-
 export async function replaceKey(key, config, sheet = 'default') {
   if (typeof key !== 'string' || !key.length) return '';
 
@@ -191,7 +177,7 @@ export async function replaceKeyArray(keys, config, sheet = 'default') {
 export async function replaceText(
   text,
   config,
-  regex = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g,
+  regex = PH_RE,
   sheet = 'default',
   { defer = false } = {},
 ) {
@@ -202,15 +188,9 @@ export async function replaceText(
     return text;
   }
   const keys = Array.from(matches, (match) => match[1] || match[2]);
-  const hasGeoIp = keys.some(isGeoIpKey);
-
   let geoPlaceholders = null;
-  if (hasGeoIp) {
-    if (defer) {
-      ensureGeoFetch(config, sheet);
-    } else {
-      geoPlaceholders = await ensureGeoFetch(config, sheet);
-    }
+  if (keys.some(isGeoIpKey) && !defer) {
+    geoPlaceholders = await getGeoPlaceholders(config, sheet);
   }
 
   const resolved = await Promise.all(keys.map(async (key) => {
@@ -231,7 +211,7 @@ const geoIpPattern = /{{(.*?-geo-ip)}}|%7B%7B(.*?-geo-ip)%7D%7D/g;
 const findGeoIpKeys = (t) => (t ? [...t.matchAll(geoIpPattern)].map((m) => m[1] || m[2]) : []);
 
 async function deferGeoIpUpdate(deferredItems, config, sheet) {
-  const geo = await ensureGeoFetch(config, sheet);
+  const geo = await getGeoPlaceholders(config, sheet);
   if (!geo) return;
   await Promise.all(deferredItems.map(async ({ node, type, attrName, key }) => {
     if (config.placeholders?.[key] || typeof geo[key] !== 'string') return;
@@ -255,17 +235,17 @@ export async function decoratePlaceholderArea({
   const config = getConfig();
   await fetchPlaceholders({ placeholderPath, config, placeholderRequest });
   const deferred = [];
-  const opts = { defer: true };
+  const deferOpt = { defer: true };
   const track = (keys, item) => keys.forEach((key) => deferred.push({ ...item, key }));
 
   const replaceNodes = nodes.map(async (nodeEl) => {
     if (nodeEl.nodeType === Node.TEXT_NODE) {
       track(findGeoIpKeys(nodeEl.nodeValue), { node: nodeEl, type: 'text' });
-      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config, undefined, undefined, opts);
+      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config, PH_RE, 'default', deferOpt);
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
       const attrPromises = [...nodeEl.attributes].map(async (attr) => {
         track(findGeoIpKeys(attr.value), { node: nodeEl, type: 'attr', attrName: attr.name });
-        const val = await replaceText(attr.value, config, undefined, undefined, opts);
+        const val = await replaceText(attr.value, config, PH_RE, 'default', deferOpt);
         return { name: attr.name, value: val };
       });
       (await Promise.all(attrPromises)).forEach(({ name, value }) => {

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -1,4 +1,4 @@
-import { customFetch, getConfig, getMetadata, lingoActive, getMepLingoPrefix } from '../utils/utils.js';
+import { customFetch, getConfig, getMetadata } from '../utils/utils.js';
 
 const fetchedPlaceholders = {};
 window.mph = {};
@@ -65,6 +65,8 @@ let geoPlaceholderPromise;
 export function resetGeoPlaceholderCache() { geoPlaceholderPromise = undefined; }
 
 async function getGeoPlaceholders(sheet) {
+  // Dynamic to avoid circular dep with utils.js that hangs WTR test runner
+  const { lingoActive, getMepLingoPrefix } = await import('../utils/utils.js');
   if (!lingoActive()) return null;
   const geoPrefix = await getMepLingoPrefix();
   if (!geoPrefix) return null;

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -163,15 +163,12 @@ async function getPlaceholder(key, config, sheet) {
   return keyToStr(key);
 }
 
-async function resolveGeoIpKey(key, config, sheet) {
-  if (config.placeholders?.[key]) return config.placeholders[key];
+function ensureGeoFetch(config, sheet) {
   const cacheKey = config.locale?.contentRoot ?? '';
   if (!geoPlaceholderCache.has(cacheKey)) {
     geoPlaceholderCache.set(cacheKey, getGeoPlaceholders(config, sheet));
   }
-  const geoPlaceholders = await geoPlaceholderCache.get(cacheKey);
-  if (typeof geoPlaceholders?.[key] === 'string') return geoPlaceholders[key];
-  return getPlaceholder(key, config, sheet);
+  return geoPlaceholderCache.get(cacheKey);
 }
 
 export async function replaceKey(key, config, sheet = 'default') {
@@ -198,6 +195,7 @@ export async function replaceText(
   config,
   regex = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g,
   sheet = 'default',
+  { defer = false } = {},
 ) {
   if (typeof text !== 'string' || !text.length) return '';
 
@@ -206,10 +204,21 @@ export async function replaceText(
     return text;
   }
   const keys = Array.from(matches, (match) => match[1] || match[2]);
-  const resolved = await Promise.all(keys.map(async (key) => {
-    if (isGeoIpKey(key)) {
-      return resolveGeoIpKey(key, config, sheet);
+  const hasGeoIp = keys.some(isGeoIpKey);
+
+  let geoPlaceholders = null;
+  if (hasGeoIp) {
+    if (defer) {
+      ensureGeoFetch(config, sheet);
+    } else {
+      geoPlaceholders = await ensureGeoFetch(config, sheet);
     }
+  }
+
+  const resolved = await Promise.all(keys.map(async (key) => {
+    if (config.placeholders?.[key]) return config.placeholders[key];
+    if (geoPlaceholders && isGeoIpKey(key)
+      && typeof geoPlaceholders[key] === 'string') return geoPlaceholders[key];
     return getPlaceholder(key, config, sheet);
   }));
 
@@ -220,6 +229,25 @@ export async function replaceText(
   return finalText;
 }
 
+const geoIpPattern = /{{(.*?-geo-ip)}}|%7B%7B(.*?-geo-ip)%7D%7D/g;
+const findGeoIpKeys = (t) => (t ? [...t.matchAll(geoIpPattern)].map((m) => m[1] || m[2]) : []);
+
+async function deferGeoIpUpdate(deferredItems, config, sheet) {
+  const geo = await ensureGeoFetch(config, sheet);
+  if (!geo) return;
+  await Promise.all(deferredItems.map(async ({ node, type, attrName, key }) => {
+    if (config.placeholders?.[key] || typeof geo[key] !== 'string') return;
+    const base = await getPlaceholder(key, config, sheet);
+    if (geo[key] === base) return;
+    if (type === 'text') {
+      node.nodeValue = node.nodeValue.replace(base, geo[key]);
+    } else {
+      const cur = node.getAttribute(attrName);
+      if (cur) node.setAttribute(attrName, cur.replace(base, geo[key]));
+    }
+  }));
+}
+
 export async function decoratePlaceholderArea({
   placeholderPath,
   placeholderRequest,
@@ -228,19 +256,28 @@ export async function decoratePlaceholderArea({
   if (!nodes.length) return;
   const config = getConfig();
   await fetchPlaceholders({ placeholderPath, config, placeholderRequest });
+  const deferred = [];
+  const opts = { defer: true };
+  const track = (keys, item) => keys.forEach((key) => deferred.push({ ...item, key }));
+
   const replaceNodes = nodes.map(async (nodeEl) => {
     if (nodeEl.nodeType === Node.TEXT_NODE) {
-      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config);
+      track(findGeoIpKeys(nodeEl.nodeValue), { node: nodeEl, type: 'text' });
+      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config, undefined, undefined, opts);
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
       const attrPromises = [...nodeEl.attributes].map(async (attr) => {
-        const attrVal = await replaceText(attr.value, config);
-        return { name: attr.name, value: attrVal };
+        track(findGeoIpKeys(attr.value), { node: nodeEl, type: 'attr', attrName: attr.name });
+        const val = await replaceText(attr.value, config, undefined, undefined, opts);
+        return { name: attr.name, value: val };
       });
-      const results = await Promise.all(attrPromises);
-      results.forEach(({ name, value }) => {
+      (await Promise.all(attrPromises)).forEach(({ name, value }) => {
         nodeEl.setAttribute(name, value);
       });
     }
   });
   await Promise.all(replaceNodes);
+
+  if (deferred.length) {
+    decoratePlaceholderArea.deferredGeo = deferGeoIpUpdate(deferred, config);
+  }
 }

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -66,10 +66,8 @@ async function getGeoPlaceholders(config, sheet) {
   if (!lingoActive()) return null;
   const geoPrefix = await getGeoLocalePrefix();
   if (!geoPrefix) return null;
-
   const siteConfig = getConfig();
   let geoOrigin = window.location.origin;
-
   let pathSuffix = siteConfig.contentRoot ?? '';
   const callerContentRoot = config.locale?.contentRoot ?? '';
   const siteContentRoot = siteConfig.locale?.contentRoot ?? '';
@@ -98,7 +96,10 @@ async function getGeoPlaceholders(config, sheet) {
     sheet,
     placeholderRequest,
     placeholderPath: paths[0],
-  }).catch(() => ({}));
+  }).catch((e) => {
+    window.lana?.log(`Error fetching geo placeholders: ${e?.message}`, { tags: 'placeholders', severity: 'warn' });
+    return {};
+  });
 }
 
 async function getPlaceholder(key, config, sheet) {

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -58,8 +58,7 @@ function keyToStr(key) {
   return key.replaceAll('-', ' ');
 }
 
-const isGeoKey = (key) => key.endsWith('-geo');
-const stripGeo = (key) => key.slice(0, -4);
+const isGeoIpKey = (key) => key.endsWith('-geo-ip');
 
 const geoPlaceholderCache = new Map();
 export function resetGeoPlaceholderCache() { geoPlaceholderCache.clear(); }
@@ -146,8 +145,6 @@ async function getPlaceholder(key, config, sheet) {
 
   if (config.placeholders?.[key]) return config.placeholders[key];
 
-  if (isGeoKey(key)) return getPlaceholder(stripGeo(key), config, sheet);
-
   let placeholders;
 
   if (geoLocDisabled === 'on') {
@@ -166,15 +163,15 @@ async function getPlaceholder(key, config, sheet) {
   return keyToStr(key);
 }
 
-async function resolveGeoKey(key, config, sheet) {
-  const baseKey = stripGeo(key);
+async function resolveGeoIpKey(key, config, sheet) {
+  if (config.placeholders?.[key]) return config.placeholders[key];
   const cacheKey = config.locale?.contentRoot ?? '';
   if (!geoPlaceholderCache.has(cacheKey)) {
     geoPlaceholderCache.set(cacheKey, getGeoPlaceholders(config, sheet));
   }
   const geoPlaceholders = await geoPlaceholderCache.get(cacheKey);
-  if (typeof geoPlaceholders?.[baseKey] === 'string') return geoPlaceholders[baseKey];
-  return getPlaceholder(baseKey, config, sheet);
+  if (typeof geoPlaceholders?.[key] === 'string') return geoPlaceholders[key];
+  return getPlaceholder(key, config, sheet);
 }
 
 export async function replaceKey(key, config, sheet = 'default') {
@@ -196,11 +193,6 @@ export async function replaceKeyArray(keys, config, sheet = 'default') {
   return placeholders;
 }
 
-function isTelContext(text, matchIndex) {
-  const preceding = text.slice(Math.max(0, matchIndex - 10), matchIndex);
-  return /(?:^|["'=\s])tel:/i.test(preceding);
-}
-
 export async function replaceText(
   text,
   config,
@@ -214,9 +206,9 @@ export async function replaceText(
     return text;
   }
   const keys = Array.from(matches, (match) => match[1] || match[2]);
-  const resolved = await Promise.all(keys.map(async (key, idx) => {
-    if (isGeoKey(key) && isTelContext(text, matches[idx].index)) {
-      return resolveGeoKey(key, config, sheet);
+  const resolved = await Promise.all(keys.map(async (key) => {
+    if (isGeoIpKey(key)) {
+      return resolveGeoIpKey(key, config, sheet);
     }
     return getPlaceholder(key, config, sheet);
   }));
@@ -228,14 +220,6 @@ export async function replaceText(
   return finalText;
 }
 
-function findGeoKeyInTelHref(el) {
-  if (el.tagName !== 'A') return null;
-  const href = el.getAttribute('href') || '';
-  if (!/^tel:/i.test(href)) return null;
-  const geoMatch = href.match(/{{(.*?-geo)}}|%7B%7B(.*?-geo)%7D%7D/);
-  return geoMatch ? (geoMatch[1] || geoMatch[2]) : null;
-}
-
 export async function decoratePlaceholderArea({
   placeholderPath,
   placeholderRequest,
@@ -244,13 +228,10 @@ export async function decoratePlaceholderArea({
   if (!nodes.length) return;
   const config = getConfig();
   await fetchPlaceholders({ placeholderPath, config, placeholderRequest });
-  const geoLinks = [];
   const replaceNodes = nodes.map(async (nodeEl) => {
     if (nodeEl.nodeType === Node.TEXT_NODE) {
       nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config);
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
-      const geoKey = findGeoKeyInTelHref(nodeEl);
-      if (geoKey) geoLinks.push({ el: nodeEl, geoKey });
       const attrPromises = [...nodeEl.attributes].map(async (attr) => {
         const attrVal = await replaceText(attr.value, config);
         return { name: attr.name, value: attrVal };
@@ -262,12 +243,4 @@ export async function decoratePlaceholderArea({
     }
   });
   await Promise.all(replaceNodes);
-  if (geoLinks.length) {
-    await Promise.all(geoLinks.map(async ({ el, geoKey }) => {
-      const geoValue = await resolveGeoKey(geoKey, config);
-      if (geoValue && geoValue !== keyToStr(stripGeo(geoKey))) {
-        el.textContent = geoValue;
-      }
-    }));
-  }
 }

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -1,4 +1,11 @@
-import { customFetch, getConfig, getMetadata } from '../utils/utils.js';
+import {
+  customFetch,
+  getConfig,
+  getMetadata,
+  getGeoLocalePrefix,
+  getPlaceholderPaths,
+  lingoActive,
+} from '../utils/utils.js';
 
 const fetchedPlaceholders = {};
 window.mph = {};
@@ -61,10 +68,6 @@ const isGeoIpKey = (key) => key.endsWith('-geo-ip');
 const PLACEHOLDER_REGEX = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
 
 async function getGeoPlaceholders(config, sheet) {
-  // Dynamic, not static — moving these into the static import above slows
-  // the WTR suite ~3.7x and times out ~11 tests. utils.js is already cached
-  // by the time this runs, so no runtime cost.
-  const { lingoActive, getGeoLocalePrefix, getPlaceholderPaths } = await import('../utils/utils.js');
   if (!lingoActive()) return null;
   const geoPrefix = await getGeoLocalePrefix();
   if (!geoPrefix) return null;

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -61,10 +61,10 @@ function keyToStr(key) {
 const isGeoKey = (key) => key.endsWith('-geo');
 const stripGeo = (key) => key.slice(0, -4);
 
-let geoPlaceholderPromise;
-export function resetGeoPlaceholderCache() { geoPlaceholderPromise = undefined; }
+const geoPlaceholderCache = new Map();
+export function resetGeoPlaceholderCache() { geoPlaceholderCache.clear(); }
 
-async function getGeoPlaceholders(sheet) {
+async function getGeoPlaceholders(config, sheet) {
   // Dynamic to avoid circular dep with utils.js that hangs WTR test runner
   const { lingoActive, getGeoLocalePrefix } = await import('../utils/utils.js');
   if (!lingoActive()) return null;
@@ -72,9 +72,24 @@ async function getGeoPlaceholders(sheet) {
   if (!geoPrefix) return null;
 
   const siteConfig = getConfig();
-  const { origin } = window.location;
-  const contentRoot = siteConfig.contentRoot ?? '';
-  const geoContentRoot = `${origin}${geoPrefix}${contentRoot}`;
+  let geoOrigin = window.location.origin;
+
+  let pathSuffix = siteConfig.contentRoot ?? '';
+  const callerContentRoot = config.locale?.contentRoot ?? '';
+  const siteContentRoot = siteConfig.locale?.contentRoot ?? '';
+  if (callerContentRoot && callerContentRoot !== siteContentRoot) {
+    let path = callerContentRoot;
+    try {
+      const url = new URL(path);
+      geoOrigin = url.origin;
+      path = url.pathname;
+    } catch { /* relative path */ }
+    const prefix = config.locale?.prefix ?? '';
+    if (prefix && path.startsWith(prefix)) path = path.slice(prefix.length);
+    pathSuffix = path;
+  }
+
+  const geoContentRoot = `${geoOrigin}${geoPrefix}${pathSuffix}`;
   const geoConfig = { locale: { contentRoot: geoContentRoot } };
 
   const root = `${geoContentRoot}/placeholders`;
@@ -153,8 +168,11 @@ async function getPlaceholder(key, config, sheet) {
 
 async function resolveGeoKey(key, config, sheet) {
   const baseKey = stripGeo(key);
-  geoPlaceholderPromise ??= getGeoPlaceholders(sheet);
-  const geoPlaceholders = await geoPlaceholderPromise;
+  const cacheKey = config.locale?.contentRoot ?? '';
+  if (!geoPlaceholderCache.has(cacheKey)) {
+    geoPlaceholderCache.set(cacheKey, getGeoPlaceholders(config, sheet));
+  }
+  const geoPlaceholders = await geoPlaceholderCache.get(cacheKey);
   if (typeof geoPlaceholders?.[baseKey] === 'string') return geoPlaceholders[baseKey];
   return getPlaceholder(baseKey, config, sheet);
 }

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -66,9 +66,9 @@ export function resetGeoPlaceholderCache() { geoPlaceholderPromise = undefined; 
 
 async function getGeoPlaceholders(sheet) {
   // Dynamic to avoid circular dep with utils.js that hangs WTR test runner
-  const { lingoActive, getMepLingoPrefix } = await import('../utils/utils.js');
+  const { lingoActive, getGeoLocalePrefix } = await import('../utils/utils.js');
   if (!lingoActive()) return null;
-  const geoPrefix = await getMepLingoPrefix();
+  const geoPrefix = await getGeoLocalePrefix();
   if (!geoPrefix) return null;
 
   const siteConfig = getConfig();

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -9,11 +9,11 @@ const getPlaceholdersPath = (config, sheet) => {
   return `${path}${query}`;
 };
 
-const parsePlaceholderJson = async (resp, placeholders, { updateMph = true } = {}) => {
+const parsePlaceholderJson = async (resp, placeholders) => {
   try {
     const json = resp.ok ? await resp.json() : { data: [] };
     json.data?.forEach((item) => {
-      if (updateMph) window.mph[item.key] = item.value;
+      window.mph[item.key] = item.value;
       placeholders[item.key] = item.value;
     });
   } catch (e) {
@@ -21,7 +21,7 @@ const parsePlaceholderJson = async (resp, placeholders, { updateMph = true } = {
   }
 };
 
-const fetchPlaceholder = (path, placeholderRequest, { updateMph = true } = {}) => new Promise(
+const fetchPlaceholder = (path, placeholderRequest) => new Promise(
   // eslint-disable-next-line no-async-promise-executor
   async (resolve) => {
     const resp = await placeholderRequest || await customFetch(
@@ -31,9 +31,9 @@ const fetchPlaceholder = (path, placeholderRequest, { updateMph = true } = {}) =
 
     if (Array.isArray(resp)) {
       // Overlay placeholders
-      for (const r of resp) await parsePlaceholderJson(r, placeholders, { updateMph });
+      for (const r of resp) await parsePlaceholderJson(r, placeholders);
     } else {
-      await parsePlaceholderJson(resp, placeholders, { updateMph });
+      await parsePlaceholderJson(resp, placeholders);
     }
 
     resolve(placeholders);
@@ -45,11 +45,10 @@ export const fetchPlaceholders = async ({
   sheet,
   placeholderRequest,
   placeholderPath,
-  updateMph = true,
 }) => {
   const path = placeholderPath || getPlaceholdersPath(config, sheet);
 
-  fetchedPlaceholders[path] ||= fetchPlaceholder(path, placeholderRequest, { updateMph });
+  fetchedPlaceholders[path] ||= fetchPlaceholder(path, placeholderRequest);
 
   return fetchedPlaceholders[path];
 };
@@ -105,7 +104,6 @@ async function getGeoPlaceholders(config, sheet) {
     sheet,
     placeholderRequest,
     placeholderPath: paths[0],
-    updateMph: false,
   }).catch(() => ({}));
 }
 

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -61,7 +61,9 @@ const isGeoIpKey = (key) => key.endsWith('-geo-ip');
 const PH_RE = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
 
 async function getGeoPlaceholders(config, sheet) {
-  // Dynamic to avoid circular dep with utils.js that hangs WTR test runner
+  // Dynamic, not static — moving these into the static import above slows
+  // the WTR suite ~3.7x and times out ~11 tests. utils.js is already cached
+  // by the time this runs, so no runtime cost.
   const { lingoActive, getGeoLocalePrefix, getPlaceholderPaths } = await import('../utils/utils.js');
   if (!lingoActive()) return null;
   const geoPrefix = await getGeoLocalePrefix();

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -58,7 +58,7 @@ function keyToStr(key) {
 }
 
 const isGeoIpKey = (key) => key.endsWith('-geo-ip');
-const PH_RE = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
+const PLACEHOLDER_REGEX = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
 
 async function getGeoPlaceholders(config, sheet) {
   // Dynamic, not static — moving these into the static import above slows
@@ -180,7 +180,7 @@ export async function replaceKeyArray(keys, config, sheet = 'default') {
 export async function replaceText(
   text,
   config,
-  regex = PH_RE,
+  regex = PLACEHOLDER_REGEX,
   sheet = 'default',
   { defer = false } = {},
 ) {
@@ -244,11 +244,11 @@ export async function decoratePlaceholderArea({
   const replaceNodes = nodes.map(async (nodeEl) => {
     if (nodeEl.nodeType === Node.TEXT_NODE) {
       track(findGeoIpKeys(nodeEl.nodeValue), { node: nodeEl, type: 'text' });
-      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config, PH_RE, 'default', deferOpt);
+      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config, PLACEHOLDER_REGEX, 'default', deferOpt);
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
       const attrPromises = [...nodeEl.attributes].map(async (attr) => {
         track(findGeoIpKeys(attr.value), { node: nodeEl, type: 'attr', attrName: attr.name });
-        const val = await replaceText(attr.value, config, PH_RE, 'default', deferOpt);
+        const val = await replaceText(attr.value, config, PLACEHOLDER_REGEX, 'default', deferOpt);
         return { name: attr.name, value: val };
       });
       (await Promise.all(attrPromises)).forEach(({ name, value }) => {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -964,7 +964,7 @@ export async function resolveDetectedMarketCountry() {
   return detectedMarket;
 }
 
-export async function getLingoRegion() {
+export async function getGeoLocalePrefix() {
   if (!lingoActive()) return null;
   const config = getConfig();
   const { locale } = config || {};
@@ -1072,7 +1072,7 @@ export async function localizeLinkAsync(
     const isFragment = effectiveHref.includes('/fragments/');
     if (isBasePage) {
       const isRegularFragment = isFragment && !isMepLingoLink;
-      prefix = (aTag && !isRegularFragment) ? await getMepLingoPrefix() : (locale?.prefix ?? '');
+      prefix = (aTag && !isRegularFragment) ? await getGeoLocalePrefix() : (locale?.prefix ?? '');
       base = locale?.prefix?.replace('/', '') ?? '';
     } else {
       const basePrefix = locale?.base === '' ? '' : `/${locale?.base}`;
@@ -2653,7 +2653,7 @@ function loadLingoIndexes(area = document) {
     loadQueryIndexes(config.locale.prefix, [...area.querySelectorAll('.section a')].map((a) => a.href).filter(Boolean));
     return;
   }
-  getMepLingoPrefix().then((prefix) => {
+  getGeoLocalePrefix().then((prefix) => {
     if (prefix) {
       loadQueryIndexes(prefix, [...area.querySelectorAll('.section a')].map((a) => a.href).filter(Boolean));
     }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -964,7 +964,7 @@ export async function resolveDetectedMarketCountry() {
   return detectedMarket;
 }
 
-export async function getGeoLocalePrefix() {
+export async function getLingoRegion() {
   if (!lingoActive()) return null;
   const config = getConfig();
   const { locale } = config || {};
@@ -990,7 +990,7 @@ export async function getGeoLocalePrefix() {
   return regionKey ? regions[regionKey] : null;
 }
 
-export async function getMepLingoPrefix() {
+export async function getGeoLocalePrefix() {
   const region = await getLingoRegion();
   return region?.prefix ?? null;
 }
@@ -1787,7 +1787,7 @@ const findReplaceableNodes = (area) => {
   return nodes;
 };
 
-function getPlaceholderPaths(config) {
+export function getPlaceholderPaths(config) {
   const root = `${config.locale?.contentRoot}/placeholders`;
   const paths = [`${root}.json`];
   if (config.env.name !== 'prod'

--- a/test/blocks/merch/mocks/embed-utils.js
+++ b/test/blocks/merch/mocks/embed-utils.js
@@ -54,3 +54,7 @@ export const getCountry = stub().resolves('us');
  * @see https://jira.corp.adobe.com/browse/MWPW-174411
 */
 export const shouldAllowKrTrial = stub();
+
+export const lingoActive = () => false;
+export const getGeoLocalePrefix = () => Promise.resolve(null);
+export const getPlaceholderPaths = () => [];

--- a/test/blocks/ost/mocks/ost-utils.js
+++ b/test/blocks/ost/mocks/ost-utils.js
@@ -135,6 +135,10 @@ const shouldAllowKrTrial = (button, localePrefix) => {
   return localePrefix === '/kr' && hasAllowKrTrial;
 };
 
+const lingoActive = () => false;
+const getGeoLocalePrefix = () => Promise.resolve(null);
+const getPlaceholderPaths = () => [];
+
 export {
   createTag,
   getConfig,
@@ -152,4 +156,7 @@ export {
   customFetch,
   SLD,
   shouldAllowKrTrial,
+  lingoActive,
+  getGeoLocalePrefix,
+  getPlaceholderPaths,
 };

--- a/test/features/placeholders/lu_fr/federal/globalnav/placeholders.json
+++ b/test/features/placeholders/lu_fr/federal/globalnav/placeholders.json
@@ -1,0 +1,12 @@
+{
+  "total": 1,
+  "offset": 0,
+  "limit": 1,
+  "data": [
+    {
+      "key": "phone-number-geo-ip",
+      "value": "+352 GNAV 99999"
+    }
+  ],
+  ":type": "sheet"
+}

--- a/test/features/placeholders/lu_fr/placeholders.json
+++ b/test/features/placeholders/lu_fr/placeholders.json
@@ -1,7 +1,7 @@
 {
-  "total": 2,
+  "total": 4,
   "offset": 0,
-  "limit": 2,
+  "limit": 4,
   "data": [
     {
       "key": "phone-number",
@@ -10,6 +10,14 @@
     {
       "key": "purchase-by-phone-cci",
       "value": "+352 800 12345"
+    },
+    {
+      "key": "phone-number-geo-ip",
+      "value": "+352 800 99999"
+    },
+    {
+      "key": "buy-now-geo-ip",
+      "value": "Acheter maintenant"
     }
   ],
   ":type": "sheet"

--- a/test/features/placeholders/lu_fr/placeholders.json
+++ b/test/features/placeholders/lu_fr/placeholders.json
@@ -1,0 +1,16 @@
+{
+  "total": 2,
+  "offset": 0,
+  "limit": 2,
+  "data": [
+    {
+      "key": "phone-number",
+      "value": "+352 800 24642"
+    },
+    {
+      "key": "purchase-by-phone-cci",
+      "value": "+352 800 12345"
+    }
+  ],
+  ":type": "sheet"
+}

--- a/test/features/placeholders/placeholders.json
+++ b/test/features/placeholders/placeholders.json
@@ -20,6 +20,14 @@
       "value": "800 12345 6789"
     },
     {
+      "key": "phone-number-geo-ip",
+      "value": "800 555 1234"
+    },
+    {
+      "key": "buy-now-geo-ip",
+      "value": "Buy now"
+    },
+    {
       "key": "empty-value",
       "value": ""
     },

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -1,7 +1,13 @@
 import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
 import { setConfig, getConfig, customFetch } from '../../../libs/utils/utils.js';
-import { replaceText, replaceKey, replaceKeyArray, decoratePlaceholderArea } from '../../../libs/features/placeholders.js';
+import {
+  replaceText,
+  replaceKey,
+  replaceKeyArray,
+  decoratePlaceholderArea,
+  resetGeoPlaceholderCache,
+} from '../../../libs/features/placeholders.js';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 const conf = { locales };
@@ -91,5 +97,118 @@ describe('Placeholders', () => {
     text = await replaceText(text, config);
     document.head.removeChild(meta);
     expect(text).to.equal('Add to cart. Adobe Apps');
+  });
+});
+
+describe('Geo Placeholders (-geo suffix)', () => {
+  let paramsGetStub;
+  let langfirstMeta;
+  const geoFixturePath = '/test/features/placeholders/lu_fr';
+
+  before(() => {
+    paramsGetStub = stub(URLSearchParams.prototype, 'get');
+    paramsGetStub.withArgs('cache').returns('off');
+  });
+
+  after(() => {
+    paramsGetStub.restore();
+  });
+
+  function enableLingo() {
+    langfirstMeta = document.createElement('meta');
+    langfirstMeta.name = 'langfirst';
+    langfirstMeta.content = 'on';
+    document.head.appendChild(langfirstMeta);
+    sessionStorage.setItem('akamai', 'lu');
+    const geoLocales = {
+      '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+      '/fr': { ietf: 'fr-FR', tk: 'hah7vzn.css' },
+    };
+    const regions = { lu_fr: { prefix: geoFixturePath } };
+    setConfig({ locales: geoLocales, locale: { region: 'fr' }, contentRoot: '' });
+    const cfg = getConfig();
+    cfg.locale.prefix = '/fr';
+    cfg.locale.regions = regions;
+    return cfg;
+  }
+
+  function disableLingo() {
+    if (langfirstMeta?.parentNode) langfirstMeta.parentNode.removeChild(langfirstMeta);
+    sessionStorage.removeItem('akamai');
+    resetGeoPlaceholderCache();
+  }
+
+  afterEach(() => {
+    disableLingo();
+  });
+
+  it('resolves -geo key from geo-specific placeholder file on langfirst pages', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    const text = await replaceText('tel:%7B%7Bphone-number-geo%7D%7D', cfg);
+    expect(text).to.equal('tel:+352 800 24642');
+  });
+
+  it('does not geo-resolve -geo keys outside tel: context', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    const text = await replaceText('{{phone-number-geo}}', cfg);
+    expect(text).to.equal('800 12345 6789');
+  });
+
+  it('falls back to base key value when langfirst is off', async () => {
+    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
+    const cfg = getConfig();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    resetGeoPlaceholderCache();
+    const text = await replaceText('tel:{{phone-number-geo}}', cfg);
+    expect(text).to.equal('tel:800 12345 6789');
+  });
+
+  it('updates link display text when tel: href contains a -geo placeholder', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    const link = document.createElement('a');
+    link.setAttribute('href', 'tel:%7B%7Bphone-number-geo%7D%7D');
+    link.textContent = '800 12345 6789';
+
+    await decoratePlaceholderArea({ nodes: [link] });
+
+    expect(link.getAttribute('href')).to.equal('tel:+352 800 24642');
+    expect(link.textContent).to.equal('+352 800 24642');
+  });
+
+  it('does not update display text when href has no -geo key', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    const link = document.createElement('a');
+    link.setAttribute('href', 'tel:%7B%7Bphone-number%7D%7D');
+    link.textContent = 'Call us';
+
+    await decoratePlaceholderArea({ nodes: [link] });
+
+    expect(link.getAttribute('href')).to.equal('tel:800 12345 6789');
+    expect(link.textContent).to.equal('Call us');
+  });
+
+  it('geo-resolves -geo in tel: href within an HTML string (GNAV path)', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    const html = '<a href="tel:%7B%7Bphone-number-geo%7D%7D">Call us</a>';
+    const result = await replaceText(html, cfg);
+    expect(result).to.equal('<a href="tel:+352 800 24642">Call us</a>');
+  });
+
+  it('does not geo-resolve -geo in non-tel link href', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    const link = document.createElement('a');
+    link.setAttribute('href', '/page/%7B%7Bphone-number-geo%7D%7D');
+    link.textContent = 'Some link';
+
+    await decoratePlaceholderArea({ nodes: [link] });
+
+    expect(link.getAttribute('href')).to.equal('/page/800 12345 6789');
+    expect(link.textContent).to.equal('Some link');
   });
 });

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -221,5 +221,4 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     expect(link.textContent).to.equal('Call us');
     delete cfg.placeholders;
   });
-
 });

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -142,25 +142,18 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     disableLingo();
   });
 
-  it('resolves -geo-ip phone number from geo placeholder file', async () => {
+  it('replaceText resolves geo value for -geo-ip keys (default, non-deferred)', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';
     const text = await replaceText('tel:{{phone-number-geo-ip}}', cfg);
     expect(text).to.equal('tel:+352 800 99999');
   });
 
-  it('resolves -geo-ip non-phone placeholder from geo file', async () => {
+  it('replaceText resolves geo value for non-phone -geo-ip key', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';
     const text = await replaceText('{{buy-now-geo-ip}}', cfg);
     expect(text).to.equal('Acheter maintenant');
-  });
-
-  it('resolves -geo-ip in non-tel href context', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const text = await replaceText('<a href="/page/{{buy-now-geo-ip}}">info</a>', cfg);
-    expect(text).to.equal('<a href="/page/Acheter maintenant">info</a>');
   });
 
   it('falls back to base placeholder when langfirst is off', async () => {
@@ -172,7 +165,7 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     expect(text).to.equal('Buy now');
   });
 
-  it('preserves custom display text when href has -geo-ip placeholder', async () => {
+  it('deferred update swaps base to geo value in href, preserves custom text', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';
     const link = document.createElement('a');
@@ -180,12 +173,15 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     link.textContent = 'Call Adobe Support';
 
     await decoratePlaceholderArea({ nodes: [link] });
+    expect(link.getAttribute('href')).to.equal('tel:800 555 1234');
+    expect(link.textContent).to.equal('Call Adobe Support');
 
+    await decoratePlaceholderArea.deferredGeo;
     expect(link.getAttribute('href')).to.equal('tel:+352 800 99999');
     expect(link.textContent).to.equal('Call Adobe Support');
   });
 
-  it('resolves -geo-ip in both href and text node independently', async () => {
+  it('deferred update swaps both href and text node to geo values', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';
     const link = document.createElement('a');
@@ -194,7 +190,10 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     link.appendChild(textNode);
 
     await decoratePlaceholderArea({ nodes: [link, textNode] });
+    expect(link.getAttribute('href')).to.equal('tel:800 555 1234');
+    expect(textNode.nodeValue).to.equal('800 555 1234');
 
+    await decoratePlaceholderArea.deferredGeo;
     expect(link.getAttribute('href')).to.equal('tel:+352 800 99999');
     expect(textNode.nodeValue).to.equal('+352 800 99999');
   });
@@ -205,6 +204,21 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     cfg.placeholders = { 'phone-number-geo-ip': 'MEP override value' };
     const text = await replaceText('{{phone-number-geo-ip}}', cfg);
     expect(text).to.equal('MEP override value');
+    delete cfg.placeholders;
+  });
+
+  it('deferred update skips keys overridden by MEP', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    cfg.placeholders = { 'phone-number-geo-ip': 'MEP override value' };
+    const link = document.createElement('a');
+    link.setAttribute('href', 'tel:%7B%7Bphone-number-geo-ip%7D%7D');
+    link.textContent = 'Call us';
+
+    await decoratePlaceholderArea({ nodes: [link] });
+    await decoratePlaceholderArea.deferredGeo;
+    expect(link.getAttribute('href')).to.equal('tel:MEP override value');
+    expect(link.textContent).to.equal('Call us');
     delete cfg.placeholders;
   });
 

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -6,7 +6,6 @@ import {
   replaceKey,
   replaceKeyArray,
   decoratePlaceholderArea,
-  resetGeoPlaceholderCache,
 } from '../../../libs/features/placeholders.js';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
@@ -135,7 +134,6 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
   function disableLingo() {
     if (langfirstMeta?.parentNode) langfirstMeta.parentNode.removeChild(langfirstMeta);
     sessionStorage.removeItem('akamai');
-    resetGeoPlaceholderCache();
   }
 
   afterEach(() => {
@@ -160,7 +158,6 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
     const cfg = getConfig();
     cfg.locale.contentRoot = '/test/features/placeholders';
-    resetGeoPlaceholderCache();
     const text = await replaceText('{{buy-now-geo-ip}}', cfg);
     expect(text).to.equal('Buy now');
   });
@@ -205,6 +202,19 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     const text = await replaceText('{{phone-number-geo-ip}}', cfg);
     expect(text).to.equal('MEP override value');
     delete cfg.placeholders;
+  });
+
+  it('resolves geo value for federated content root (GNAV path)', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    const federatedConfig = {
+      locale: {
+        ...cfg.locale,
+        contentRoot: `${window.location.origin}/fr/federal/globalnav`,
+      },
+    };
+    const text = await replaceText('{{phone-number-geo-ip}}', federatedConfig);
+    expect(text).to.equal('+352 GNAV 99999');
   });
 
   it('deferred update skips keys overridden by MEP', async () => {

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -100,7 +100,7 @@ describe('Placeholders', () => {
   });
 });
 
-describe('Geo Placeholders (-geo suffix)', () => {
+describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
   let paramsGetStub;
   let langfirstMeta;
   const geoFixturePath = '/test/features/placeholders/lu_fr';
@@ -142,73 +142,70 @@ describe('Geo Placeholders (-geo suffix)', () => {
     disableLingo();
   });
 
-  it('resolves -geo key from geo-specific placeholder file on langfirst pages', async () => {
+  it('resolves -geo-ip phone number from geo placeholder file', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';
-    const text = await replaceText('tel:%7B%7Bphone-number-geo%7D%7D', cfg);
-    expect(text).to.equal('tel:+352 800 24642');
+    const text = await replaceText('tel:{{phone-number-geo-ip}}', cfg);
+    expect(text).to.equal('tel:+352 800 99999');
   });
 
-  it('does not geo-resolve -geo keys outside tel: context', async () => {
+  it('resolves -geo-ip non-phone placeholder from geo file', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';
-    const text = await replaceText('{{phone-number-geo}}', cfg);
-    expect(text).to.equal('800 12345 6789');
+    const text = await replaceText('{{buy-now-geo-ip}}', cfg);
+    expect(text).to.equal('Acheter maintenant');
   });
 
-  it('falls back to base key value when langfirst is off', async () => {
+  it('resolves -geo-ip in non-tel href context', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    const text = await replaceText('<a href="/page/{{buy-now-geo-ip}}">info</a>', cfg);
+    expect(text).to.equal('<a href="/page/Acheter maintenant">info</a>');
+  });
+
+  it('falls back to base placeholder when langfirst is off', async () => {
     setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
     const cfg = getConfig();
     cfg.locale.contentRoot = '/test/features/placeholders';
     resetGeoPlaceholderCache();
-    const text = await replaceText('tel:{{phone-number-geo}}', cfg);
-    expect(text).to.equal('tel:800 12345 6789');
+    const text = await replaceText('{{buy-now-geo-ip}}', cfg);
+    expect(text).to.equal('Buy now');
   });
 
-  it('updates link display text when tel: href contains a -geo placeholder', async () => {
+  it('preserves custom display text when href has -geo-ip placeholder', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';
     const link = document.createElement('a');
-    link.setAttribute('href', 'tel:%7B%7Bphone-number-geo%7D%7D');
-    link.textContent = '800 12345 6789';
+    link.setAttribute('href', 'tel:%7B%7Bphone-number-geo-ip%7D%7D');
+    link.textContent = 'Call Adobe Support';
 
     await decoratePlaceholderArea({ nodes: [link] });
 
-    expect(link.getAttribute('href')).to.equal('tel:+352 800 24642');
-    expect(link.textContent).to.equal('+352 800 24642');
+    expect(link.getAttribute('href')).to.equal('tel:+352 800 99999');
+    expect(link.textContent).to.equal('Call Adobe Support');
   });
 
-  it('does not update display text when href has no -geo key', async () => {
+  it('resolves -geo-ip in both href and text node independently', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';
     const link = document.createElement('a');
-    link.setAttribute('href', 'tel:%7B%7Bphone-number%7D%7D');
-    link.textContent = 'Call us';
+    link.setAttribute('href', 'tel:%7B%7Bphone-number-geo-ip%7D%7D');
+    const textNode = document.createTextNode('{{phone-number-geo-ip}}');
+    link.appendChild(textNode);
 
-    await decoratePlaceholderArea({ nodes: [link] });
+    await decoratePlaceholderArea({ nodes: [link, textNode] });
 
-    expect(link.getAttribute('href')).to.equal('tel:800 12345 6789');
-    expect(link.textContent).to.equal('Call us');
+    expect(link.getAttribute('href')).to.equal('tel:+352 800 99999');
+    expect(textNode.nodeValue).to.equal('+352 800 99999');
   });
 
-  it('geo-resolves -geo in tel: href within an HTML string (GNAV path)', async () => {
+  it('MEP placeholder overrides geo-ip value', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';
-    const html = '<a href="tel:%7B%7Bphone-number-geo%7D%7D">Call us</a>';
-    const result = await replaceText(html, cfg);
-    expect(result).to.equal('<a href="tel:+352 800 24642">Call us</a>');
+    cfg.placeholders = { 'phone-number-geo-ip': 'MEP override value' };
+    const text = await replaceText('{{phone-number-geo-ip}}', cfg);
+    expect(text).to.equal('MEP override value');
+    delete cfg.placeholders;
   });
 
-  it('does not geo-resolve -geo in non-tel link href', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const link = document.createElement('a');
-    link.setAttribute('href', '/page/%7B%7Bphone-number-geo%7D%7D');
-    link.textContent = 'Some link';
-
-    await decoratePlaceholderArea({ nodes: [link] });
-
-    expect(link.getAttribute('href')).to.equal('/page/800 12345 6789');
-    expect(link.textContent).to.equal('Some link');
-  });
 });

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2677,6 +2677,8 @@ describe('Utils', () => {
     };
 
     beforeEach(async () => {
+      document.querySelector('meta[name="langfirst"]')?.remove();
+      sessionStorage.removeItem('akamai');
       const timestamp = Date.now();
       lingoModule = await import(`../../libs/utils/utils.js?t=${timestamp}`);
     });
@@ -2748,6 +2750,8 @@ describe('Utils', () => {
     };
 
     beforeEach(async () => {
+      document.querySelector('meta[name="langfirst"]')?.remove();
+      sessionStorage.removeItem('akamai');
       originalAdobeId = window.adobeid;
       const timestamp = Date.now();
       lingoModule = await import(`../../libs/utils/utils.js?t=${timestamp}`);

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -7,7 +7,7 @@ function customReporter() {
   return {
     async reportTestFileResults({ logger, sessionsForTestFile }) {
       sessionsForTestFile.forEach((session) => {
-        session.testResults.tests.forEach((test) => {
+        session.testResults?.tests?.forEach((test) => {
           if (!test.passed && !test.skipped) {
             logger.log(test);
           }


### PR DESCRIPTION
**Summary:** 

Adds Milo-level support for geo-specific placeholders via a -geo-ip key suffix. When langfirst=on is set and a user's country is detected, placeholders ending in -geo-ip resolve from a regional placeholder sheet (e.g. lu_fr/placeholders.json). To protect LCP, resolution in page sections is deferred — base values render immediately and geo values swap in asynchronously after the fetch completes. This feature is independent of DC's existing geo phone number handling — their custom code continues to work unchanged.

**What Changed:** 

- Add -geo-ip placeholder suffix for geo-specific resolution, gated by langfirst=on metadata
- Defer geo-ip resolution in decoratePlaceholderArea (LCP path) -- base values render immediately, geo values swap in asynchronously after the geo placeholder fetch completes
- Direct replaceText callers (e.g. GNAV) use the default defer: false and await geo values before rendering -- no flash of default content
- Preserve existing MEP placeholder priority -- config.placeholders overrides are checked first in the new geo-ip resolution path
- Rename getMepLingoPrefix to getGeoLocalePrefix across utils.js, fragment.js, preview.js, and README.md

**How it works:**
The geo fetch is cached per content root via ensureGeoFetch, so multiple calls share one network request. For GNAV federated content, the origin and path are derived from the caller's contentRoot URL so the fetch targets the correct federated origin.

**Note on resetGeoPlaceholderCache:**
The geo placeholder cache is a module-private Map keyed by content root. Tests must clear it between runs to prevent stale data from a lingo-enabled test leaking into a lingo-disabled test (same cache key, different lingo state). This export is not called in production code.

**Authoring note:**
Unlike the DC -geo suffix (which strips the suffix and falls back to the base key), -geo-ip keys are looked up exactly as written. If a -geo-ip key is used on the page but no matching entry exists in the base placeholder sheet, the fallback text will be the key name (e.g. "phone number geo ip"). Authors must add entries for -geo-ip keys in both the base and regional placeholder sheets.

Steps to QA Feature:
1) Open the Before and After Urls below
2) Observe the 3 placeholders shown in the image

Expected:
1. federal-lu-fr
2. Placeholder: da-cc-lu-fr
3. nested placeholder: da-cc-lu-fr

Actual:
1. feder-fr
2. Placeholder: da-cc-fr
3. nested placeholder: [da-cc-fr](tel:da-cc-fr).


<img width="925" height="471" alt="Screenshot 2026-04-21 at 11 09 22 PM" src="https://github.com/user-attachments/assets/3c1ec170-c950-47d1-846a-57ae79aeb716" />


Resolves: [MWPW-192822](https://jira.corp.adobe.com/browse/MWPW-192822)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/fr/drafts/markp/placeholders?akamaiLocale=lu
- After: https://main--da-cc--adobecom.aem.page/fr/drafts/markp/placeholders?milolibs=phonenumber-ip&akamaiLocale=lu
- Psi: https://phonenumber-ip--milo--adobecom.aem.page/?martech=off


**Update (addressing review feedback):**
- Removed geoPlaceholderCache, ensureGeoFetch, and resetGeoPlaceholderCache — the existing fetchedPlaceholders cache already deduplicates by URL. No test-only exports remain.
- Exported getPlaceholderPaths from utils.js and reused it in getGeoPlaceholders to eliminate the duplicated placeholders-stage check.
- Replaced undefined, undefined args in replaceText calls with explicit PH_RE constant.
- Added federated GNAV test with /federal/globalnav path suffix and dedicated fixture.


**Update 2 (rebase fix + other small review updates):**

- Fixed rebase conflict with #5809: renamed getGeoLocalePrefix → getLingoRegion (returns full region object), added thin getGeoLocalePrefix wrapper for prefix-only callers.
- getPlaceholderPaths import moved to dynamic import inside getGeoPlaceholders (static import triggered circular-dep hang in WTR).
- Added lana warning log in geo placeholder fetch catch (was silent).
- Fixed test pollution in utils.test.js: defensive langfirst meta cleanup in getLingoRegion and loadIms beforeEach blocks.
- Removed extra blank lines per nit feedback.














