### PR TITLE
MWPW-193211 added new map for EXTRA_MAS_LOCALES

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -176,6 +176,12 @@ const GeoMap = {
 };
 
 /**
+ * MAS WCS `locale` when it differs from `${language}_${country}` derived from {@link GeoMap}.
+ * @type {Record<string, string>}
+ */
+const EXTRA_MAS_LOCALES = { pr: 'es_PR' };
+
+/**
  * Used when 3in1 modals are configured with ms=e or cs=t extra parameter, but 3in1 is disabled.
  * Dexter modals should deeplink to plan=edu or plan=team tabs.
  * @type {Record<string, string>}
@@ -221,7 +227,7 @@ export function getMiloLocaleSettings(miloLocale) {
   return {
     language,
     country,
-    locale: `${language}_${country}`,
+    locale: EXTRA_MAS_LOCALES[geo] ?? `${language}_${country}`,
   };
 }
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -265,10 +265,18 @@ describe('Merch Block', () => {
         { prefix: '/langstore/el', expectedLocale: 'el_GR' },
         { prefix: '/langstore/uk', expectedLocale: 'uk_UA' },
         { prefix: '/langstore/es-419', expectedLocale: 'es-419_ES' },
+        { prefix: '/pr', expectedLocale: 'es_PR' },
       ].forEach(({ prefix, expectedLocale }) => {
         const computedLocale = getMiloLocaleSettings({ prefix })?.locale;
         expect(computedLocale).to.equal(expectedLocale);
       });
+    });
+
+    it('should use es_PR, es, US for Puerto Rico path', () => {
+      const s = getMiloLocaleSettings({ prefix: '/pr' });
+      expect(s.locale).to.equal('es_PR');
+      expect(s.language).to.equal('es');
+      expect(s.country).to.equal('US');
     });
 
     it('should use geo locale for lang-first sites', async () => {


### PR DESCRIPTION
Merch Locale Mapping Update for /pr
added new map for EXTRA_MAS_LOCALES
Resolves: [MWPW-193211](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://mwpw-193211--milo--adobecom.aem.page/?martech=off
https://main--cc--adobecom.aem.live/pr/products/catalog?milolibs=MWPW-193211


