### PR TITLE
MWPW-189783: adds support for new card styles

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -71,7 +71,7 @@ const defaultOptions = {
     '1:2': '1/2 Card...',
     '3:4': '3/4 Card',
     'half-height': '1/2 Height Card',
-    'blade-card': 'Blade Card',
+    'blade-card': 'Blade Card...',
     'blog-card': 'Blog Card',
     'button-card': 'Button Card',
     'custom-card': 'Custom Card',
@@ -378,13 +378,8 @@ const BasicsPanel = ({ tagsData }) => {
 
 const UiPanel = () => {
   const { state } = useContext(ConfiguratorContext);
-  const oneHalfOptions = html`
-    <div class="nested">
-      <${Input} label="Use Rounded Corners" prop="oneHalfRoundedCorners" type="checkbox" />
-    </div>
-  `;
 
-const bladeCardOptions = html`
+  const bladeCardOptions = html`
     <div class="blade-card-options">
       <${Input} label="Reverse direction" prop="bladeCardReverse" class="blade-card-option" type="checkbox" />
       <${Input} label="Light text" prop="bladeCardLightText" class="blade-card-option" type="checkbox" />
@@ -418,10 +413,10 @@ const bladeCardOptions = html`
     <${Input} label="Hide Date for On-Demand Content" prop="hideDateInterval" type="checkbox" />
     <${Input} label="Hide Card Banners" prop="disableBanners" type="checkbox" />
     <${Input} label="Use Center Video Play Button" prop="useCenterVideoPlay" type="checkbox" />
-    <${Input} label="Use Overlay Links" prop="useOverlayLinks" type="checkbox" />
     <${Input} label="Use Light Text" prop="useLightText" type="checkbox" />
+    <${Input} label="Use Overlay Links" prop="useOverlayLinks" type="checkbox" />
+    <${Input} label="Use Rounded Corners [new]" prop="useRoundedCorners" type="checkbox" />
     <${Select} label="Card Style" prop="cardStyle" options=${defaultOptions.cardStyle} />
-      ${state.cardStyle === '1:2' && oneHalfOptions}
       ${state.cardStyle === 'blade-card' && bladeCardOptions}
       ${state.cardStyle === 'editorial-card' && editorialCardOptions}
     <${Select} options=${defaultOptions.cardTitleAccessibilityLevel} prop="cardTitleAccessibilityLevel" label="Card Accessibility Title Level" />

--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -68,20 +68,21 @@ const defaultOptions = {
     6: '6',
   },
   cardStyle: {
-    '1:2': '1/2 Card',
+    '1:2': '1/2 Card...',
     '3:4': '3/4 Card',
     'half-height': '1/2 Height Card',
-    'full-card': 'Full Card',
+    'blade-card': 'Blade Card',
+    'blog-card': 'Blog Card',
+    'button-card': 'Button Card',
+    'custom-card': 'Custom Card',
     'double-wide': 'Double Width Card',
-    product: 'Product Card',
-    'text-card': 'Text Card',
+    'editorial-card': 'Editorial Card...',
+    'full-card': 'Full Card',
+    'horizontal-card': 'Horizontal Card',
     'icon-card': 'Icon Card',
     'news-card': 'News Card',
-    'horizontal-card': 'Horizontal Card',
-    'custom-card': 'Custom Card',
-    'blade-card': 'Blade Card',
-    'editorial-card': 'Editorial Card',
-    'blog-card': 'Blog Card',
+    product: 'Product Card',
+    'text-card': 'Text Card',
   },
   collectionBtnStyle: {
     primary: 'Primary',
@@ -195,7 +196,7 @@ const defaultOptions = {
     doccloud: 'DocCloud',
     events: 'Events',
     experienceleague: 'Experience League',
-    hawks: 'Hawks',
+    hawks: 'Creative Cloud (Hawks)',
     magento: 'Magento',
     marketo: 'Marketo',
     milo: 'Milo',
@@ -377,7 +378,13 @@ const BasicsPanel = ({ tagsData }) => {
 
 const UiPanel = () => {
   const { state } = useContext(ConfiguratorContext);
-  const bladeCardOptions = html`
+  const oneHalfOptions = html`
+    <div class="nested">
+      <${Input} label="Use Rounded Corners" prop="oneHalfRoundedCorners" type="checkbox" />
+    </div>
+  `;
+
+const bladeCardOptions = html`
     <div class="blade-card-options">
       <${Input} label="Reverse direction" prop="bladeCardReverse" class="blade-card-option" type="checkbox" />
       <${Input} label="Light text" prop="bladeCardLightText" class="blade-card-option" type="checkbox" />
@@ -414,6 +421,7 @@ const UiPanel = () => {
     <${Input} label="Use Overlay Links" prop="useOverlayLinks" type="checkbox" />
     <${Input} label="Use Light Text" prop="useLightText" type="checkbox" />
     <${Select} label="Card Style" prop="cardStyle" options=${defaultOptions.cardStyle} />
+      ${state.cardStyle === '1:2' && oneHalfOptions}
       ${state.cardStyle === 'blade-card' && bladeCardOptions}
       ${state.cardStyle === 'editorial-card' && editorialCardOptions}
     <${Select} options=${defaultOptions.cardTitleAccessibilityLevel} prop="cardTitleAccessibilityLevel" label="Card Accessibility Title Level" />

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1065,8 +1065,8 @@ export const getConfig = async (originalState, strs = {}) => {
       ctaAction: state.ctaAction,
       cardHoverEffect: state.cardHoverEffect || 'default',
       additionalRequestParams: arrayToObj(state.additionalRequestParams),
-      ...((state.cardStyle === '1:2' && state.oneHalfRoundedCorners) && {
-        oneHalfRoundedCorners: !!state.oneHalfRoundedCorners,
+      ...(state.useRoundedCorners && {
+        useRoundedCorners: !!state.useRoundedCorners,
       }),
       // Only include bladeCard when explicitly configured
       ...((state.bladeCardReverse || state.bladeCardLightText || state.bladeCardTransparent) && {
@@ -1199,7 +1199,6 @@ export const getConfig = async (originalState, strs = {}) => {
     linkTransformer: pageConfig.caasLinkTransformer || stageMapToCaasTransforms(pageConfig),
     headers: caasRequestHeaders,
   };
-  console.log('config', config);
   return config;
 };
 
@@ -1317,9 +1316,10 @@ export const defaultState = {
   detailsTextOption: 'default',
   titleHeadingLevel: 'h3',
   totalCardsToShow: 10,
+  useCenterVideoPlay: false,
   useLightText: false,
   useOverlayLinks: false,
-  useCenterVideoPlay: false,
+  useRoundedCorners: false,
   collectionButtonStyle: 'primary',
   userInfo: [],
 };

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1065,9 +1065,8 @@ export const getConfig = async (originalState, strs = {}) => {
       ctaAction: state.ctaAction,
       cardHoverEffect: state.cardHoverEffect || 'default',
       additionalRequestParams: arrayToObj(state.additionalRequestParams),
-      ...(state.useRoundedCorners && {
-        useRoundedCorners: !!state.useRoundedCorners,
-      }),
+      ...(state.useRoundedCorners
+          && { useRoundedCorners: !!state.useRoundedCorners }),
       // Only include bladeCard when explicitly configured
       ...((state.bladeCardReverse || state.bladeCardLightText || state.bladeCardTransparent)
       && {

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1069,7 +1069,8 @@ export const getConfig = async (originalState, strs = {}) => {
         useRoundedCorners: !!state.useRoundedCorners,
       }),
       // Only include bladeCard when explicitly configured
-      ...((state.bladeCardReverse || state.bladeCardLightText || state.bladeCardTransparent) && {
+      ...((state.bladeCardReverse || state.bladeCardLightText || state.bladeCardTransparent)
+      && {
         bladeCard: {
           reverse: !!state.bladeCardReverse,
           lightText: !!state.bladeCardLightText,
@@ -1077,9 +1078,8 @@ export const getConfig = async (originalState, strs = {}) => {
         },
       }),
       // Include editorialOpenVariant if necessary
-      ...((state.cardStyle === 'editorial-card' && state.editorialCardOpenVariant) && {
-        editorialOpenVariant: !!state.editorialCardOpenVariant
-      }),
+      ...((state.cardStyle === 'editorial-card' && state.editorialCardOpenVariant)
+        && { editorialOpenVariant: !!state.editorialCardOpenVariant}),
     },
     hideCtaIds: hideCtaIds.split(URL_ENCODED_COMMA),
     hideCtaTags,

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1077,8 +1077,9 @@ export const getConfig = async (originalState, strs = {}) => {
         },
       }),
       // Include editorialOpenVariant if necessary
-      ...((state.cardStyle === 'editorial-card' && state.editorialCardOpenVariant)
-        && { editorialOpenVariant: !!state.editorialCardOpenVariant }),
+      ...((state.cardStyle === 'editorial-card' && state.editorialCardOpenVariant) && {
+        editorialOpenVariant: !!state.editorialCardOpenVariant
+      }),
     },
     hideCtaIds: hideCtaIds.split(URL_ENCODED_COMMA),
     hideCtaTags,

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1065,6 +1065,9 @@ export const getConfig = async (originalState, strs = {}) => {
       ctaAction: state.ctaAction,
       cardHoverEffect: state.cardHoverEffect || 'default',
       additionalRequestParams: arrayToObj(state.additionalRequestParams),
+      ...((state.cardStyle === '1:2' && state.oneHalfRoundedCorners) && {
+        oneHalfRoundedCorners: !!state.oneHalfRoundedCorners,
+      }),
       // Only include bladeCard when explicitly configured
       ...((state.bladeCardReverse || state.bladeCardLightText || state.bladeCardTransparent) && {
         bladeCard: {
@@ -1196,6 +1199,7 @@ export const getConfig = async (originalState, strs = {}) => {
     linkTransformer: pageConfig.caasLinkTransformer || stageMapToCaasTransforms(pageConfig),
     headers: caasRequestHeaders,
   };
+  console.log('config', config);
   return config;
 };
 

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1079,7 +1079,7 @@ export const getConfig = async (originalState, strs = {}) => {
       }),
       // Include editorialOpenVariant if necessary
       ...((state.cardStyle === 'editorial-card' && state.editorialCardOpenVariant)
-        && { editorialOpenVariant: !!state.editorialCardOpenVariant}),
+        && { editorialOpenVariant: !!state.editorialCardOpenVariant }),
     },
     hideCtaIds: hideCtaIds.split(URL_ENCODED_COMMA),
     hideCtaTags,

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1246,6 +1246,7 @@ export const defaultState = {
   doNotLazyLoad: false,
   disableBanners: false,
   draftDb: false,
+  editorialCardOpenVariant: false,
   endpoint: 'www.adobe.com/chimera-api/collection',
   environment: '',
   excludedCards: [],

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -907,6 +907,93 @@ describe('getCountryAndLang', () => {
       partialLoadCount: 75,
     });
   });
+
+  it('should include useRoundedCorners in the config when enabled', async () => {
+    const state = { ...defaultState, useRoundedCorners: true };
+    const config = await getConfig(state, strings);
+    expect(config.collection.useRoundedCorners).to.be.true;
+  });
+
+  it('should NOT include useRoundedCorners in the config when disabled', async () => {
+    const state = { ...defaultState, useRoundedCorners: false };
+    const config = await getConfig(state, strings);
+    expect(config.collection).to.not.have.property('useRoundedCorners');
+  });
+
+  it('should include editorialOpenVariant when cardStyle is editorial-card and variant is enabled', async () => {
+    const state = {
+      ...defaultState,
+      cardStyle: 'editorial-card',
+      editorialCardOpenVariant: true,
+    };
+    const config = await getConfig(state, strings);
+    expect(config.collection.editorialOpenVariant).to.be.true;
+  });
+
+  it('should NOT include editorialOpenVariant when cardStyle is editorial-card but variant is disabled', async () => {
+    const state = {
+      ...defaultState,
+      cardStyle: 'editorial-card',
+      editorialCardOpenVariant: false,
+    };
+    const config = await getConfig(state, strings);
+    expect(config.collection).to.not.have.property('editorialOpenVariant');
+  });
+
+  it('should NOT include editorialOpenVariant when cardStyle is not editorial-card', async () => {
+    const state = {
+      ...defaultState,
+      cardStyle: 'half-height',
+      editorialCardOpenVariant: true,
+    };
+    const config = await getConfig(state, strings);
+    expect(config.collection).to.not.have.property('editorialOpenVariant');
+  });
+
+  it('should include localFirst sort option when sortLocalFirst is enabled', async () => {
+    const state = { ...defaultState, sortLocalFirst: true };
+    const config = await getConfig(state, strings);
+    const sortOptions = config.sort.options;
+    expect(sortOptions.some((o) => o.sort === 'localFirst')).to.be.true;
+  });
+
+  it('should include localLast sort option when sortLocalLast is enabled', async () => {
+    const state = { ...defaultState, sortLocalLast: true };
+    const config = await getConfig(state, strings);
+    const sortOptions = config.sort.options;
+    expect(sortOptions.some((o) => o.sort === 'localLast')).to.be.true;
+  });
+
+  it('should NOT include localFirst or localLast sort options by default', async () => {
+    const config = await getConfig(defaultState, strings);
+    const sortOptions = config.sort.options;
+    expect(sortOptions.some((o) => o.sort === 'localFirst')).to.be.false;
+    expect(sortOptions.some((o) => o.sort === 'localLast')).to.be.false;
+  });
+
+  it('should append current page UUID to excludeIds in the endpoint', async () => {
+    const config = await getConfig(defaultState, strings);
+    const { endpoint } = config.collection;
+    const excludeIds = new URLSearchParams(endpoint.replace(/.*\?/, '?')).get('excludeIds');
+    // The current page UUID must be present in excludeIds
+    expect(excludeIds).to.be.a('string');
+    expect(excludeIds.length).to.be.greaterThan(0);
+  });
+
+  it('should combine existing excludedCards with current page UUID in excludeIds', async () => {
+    const existingId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const state = {
+      ...defaultState,
+      excludedCards: [{ contentId: existingId }],
+    };
+    const config = await getConfig(state, strings);
+    const { endpoint } = config.collection;
+    const excludeIdsEncoded = endpoint.match(/excludeIds=([^&]*)/)?.[1] ?? '';
+    const excludeIds = decodeURIComponent(excludeIdsEncoded);
+    expect(excludeIds).to.include(existingId);
+    // Should also have the page UUID (a second UUID separated by comma)
+    expect(excludeIds.split(',').length).to.be.greaterThan(1);
+  });
 });
 
 describe('getFloodgateCaasConfig', () => {

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -558,7 +558,7 @@ const getCaasProps = (p, pageUrl = null) => {
               target: p.cta1target,
             },
           }),
-          ...(p.cta2url || (p.cta2style === 'button' && p.cta2text ) && {
+          ...((p.cta2url || (p.cta2style === 'button' && p.cta2text)) && {
             secondaryCta: {
               text: p.cta2text,
               url: p.cta2style === 'button' ? p.cta1url : p.cta2url,

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -558,10 +558,10 @@ const getCaasProps = (p, pageUrl = null) => {
               target: p.cta1target,
             },
           }),
-          ...(p.cta2url && {
+          ...(p.cta2url || (p.cta2style === 'button' && p.cta2text ) && {
             secondaryCta: {
               text: p.cta2text,
-              url: p.cta2url,
+              url: p.cta2style === 'button' ? p.cta1url : p.cta2url,
               style: p.cta2style,
               icon: p.cta2icon,
               target: p.cta2target,


### PR DESCRIPTION
**Description**:
Adds new card style: Button card
Adds new Rounded Borders modifier for 1/2 and 3/4 cards styles

**Dependency:**
This functionality relies on this CaasUI PR to be merged:
https://github.com/adobecom/caas/pull/444

**Button card:**
<img width="1241" height="324" alt="image" src="https://github.com/user-attachments/assets/5610f730-1068-4b54-8063-5e7f79c0c00e" />


**Rounded corners variant:**
<img width="1239" height="495" alt="image" src="https://github.com/user-attachments/assets/50679936-cca5-48ac-b1bd-5b0e298ef95f" />


**Resolves**:
https://jira.corp.adobe.com/browse/MWPW-189783

**Additional updates**:
  - Alphabetizes Card Sttle dropdown
  - Renames Surce from "Hawks" to "Creative Cloud (Hawks)"
  - Adds new checkbox under UI tab for "Use Rounded Corners"
  - Adds unit-tests for:
      - Use Rounded Corners
      - Editorial Open Variant
      - sortLocalFirst
      - sortLocalLast
      - Add current page UUID from excludeIds


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-189783--milo--adobecom.aem.page/?martech=off












