### PR TITLE
MWPW-193754 Stage aware query-index loading

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -678,24 +678,19 @@ function processQueryIndexMap(link, domain) {
 }
 const getDomainLingo = (path) => path?.split('/*')[0];
 
-const ENV_AEM_HOST_REGEX = new RegExp(`\\.${SLD}\\.(page|live)$`);
-const ENV_STAGE_HOST_REGEX = /\.stage\.adobe\.com$/;
+const ENV_STAGE_HOST_RE = /\.stage\.adobe\.com$/;
 
 export function resolveCrossSiteIndex(
-  { queryIndexWebPath, stageHost, aemRepo },
+  { queryIndexWebPath, stageHost },
   prefix,
   suffix,
   currentHost,
 ) {
   const prodHost = getDomainLingo(queryIndexWebPath);
-  const aemMatch = currentHost.match(ENV_AEM_HOST_REGEX);
   let host = prodHost;
   let sfx = '';
 
-  if (aemMatch && aemRepo) {
-    host = `main--${aemRepo}--adobecom.${SLD}.${aemMatch[1]}`;
-    if (aemMatch[1] === 'page') sfx = suffix;
-  } else if (ENV_STAGE_HOST_REGEX.test(currentHost) && stageHost) {
+  if (ENV_STAGE_HOST_RE.test(currentHost) && stageHost) {
     host = stageHost;
     sfx = suffix;
   }
@@ -757,13 +752,13 @@ async function loadQueryIndexes(prefix, links = []) {
       siteQueryIndexMapLingo
         .filter((d) => d.uniqueSiteId !== siteId
           && config.prodDomains?.includes(getDomainLingo(d.queryIndexWebPath)))
-        .forEach(({ uniqueSiteId: uid, queryIndexWebPath, stageHost, aemRepo }) => {
+        .forEach(({ uniqueSiteId: uid, queryIndexWebPath, stageHost }) => {
           const hasRegional = localesData
             .some((s) => s.uniqueSiteId === uid && parseList(s.regionalSites).includes(prefix));
           if (!hasRegional) return;
           const prodDomain = getDomainLingo(queryIndexWebPath);
           const { url, host: envHost } = resolveCrossSiteIndex(
-            { queryIndexWebPath, stageHost, aemRepo },
+            { queryIndexWebPath, stageHost },
             prefix,
             suffix,
             window.location.hostname,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -678,6 +678,34 @@ function processQueryIndexMap(link, domain) {
 }
 const getDomainLingo = (path) => path?.split('/*')[0];
 
+const ENV_AEM_HOST_RE = new RegExp(`\\.${SLD}\\.(page|live)$`);
+const ENV_STAGE_HOST_RE = /\.stage\.adobe\.com$/;
+
+export function resolveCrossSiteIndex(
+  { queryIndexWebPath, stageHost, aemRepo },
+  prefix,
+  suffix,
+  currentHost,
+) {
+  const prodHost = getDomainLingo(queryIndexWebPath);
+  const aemMatch = currentHost.match(ENV_AEM_HOST_RE);
+  let host = prodHost;
+  let sfx = '';
+
+  if (aemMatch && aemRepo) {
+    host = `main--${aemRepo}--adobecom.${SLD}.${aemMatch[1]}`;
+    if (aemMatch[1] === 'page') sfx = suffix;
+  } else if (ENV_STAGE_HOST_RE.test(currentHost) && stageHost) {
+    host = stageHost;
+    sfx = suffix;
+  }
+
+  const path = queryIndexWebPath.slice(prodHost.length)
+    .replace('/*', prefix)
+    .replace(/\/query-index\.json$/, `/query-index${sfx}.json`);
+  return { url: `https://${host}${path}`, host };
+}
+
 async function loadQueryIndexes(prefix, links = []) {
   const config = getConfig();
   const suffix = config.env?.name === 'prod' || window.location.host.includes(`${SLD}.live`) ? '' : '-preview';
@@ -729,12 +757,19 @@ async function loadQueryIndexes(prefix, links = []) {
       siteQueryIndexMapLingo
         .filter((d) => d.uniqueSiteId !== siteId
           && config.prodDomains?.includes(getDomainLingo(d.queryIndexWebPath)))
-        .forEach(({ uniqueSiteId: uid, queryIndexWebPath }) => {
+        .forEach(({ uniqueSiteId: uid, queryIndexWebPath, stageHost, aemRepo }) => {
           const hasRegional = localesData
             .some((s) => s.uniqueSiteId === uid && parseList(s.regionalSites).includes(prefix));
           if (!hasRegional) return;
-          const domain = getDomainLingo(queryIndexWebPath);
-          queryIndexes[uid] = processQueryIndexMap(`https://${queryIndexWebPath.replace('/*', prefix)}`, domain);
+          const prodDomain = getDomainLingo(queryIndexWebPath);
+          const { url, host: envHost } = resolveCrossSiteIndex(
+            { queryIndexWebPath, stageHost, aemRepo },
+            prefix,
+            suffix,
+            window.location.hostname,
+          );
+          queryIndexes[uid] = processQueryIndexMap(url, prodDomain);
+          if (envHost !== prodDomain) queryIndexes[uid].domains.push(envHost);
         });
     } catch (e) {
       window.lana?.log(`Failed to load lingo-site-mapping.json: ${e}`, { tags: 'utils', severity: 'error' });

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -678,8 +678,8 @@ function processQueryIndexMap(link, domain) {
 }
 const getDomainLingo = (path) => path?.split('/*')[0];
 
-const ENV_AEM_HOST_RE = new RegExp(`\\.${SLD}\\.(page|live)$`);
-const ENV_STAGE_HOST_RE = /\.stage\.adobe\.com$/;
+const ENV_AEM_HOST_REGEX = new RegExp(`\\.${SLD}\\.(page|live)$`);
+const ENV_STAGE_HOST_REGEX = /\.stage\.adobe\.com$/;
 
 export function resolveCrossSiteIndex(
   { queryIndexWebPath, stageHost, aemRepo },
@@ -688,14 +688,14 @@ export function resolveCrossSiteIndex(
   currentHost,
 ) {
   const prodHost = getDomainLingo(queryIndexWebPath);
-  const aemMatch = currentHost.match(ENV_AEM_HOST_RE);
+  const aemMatch = currentHost.match(ENV_AEM_HOST_REGEX);
   let host = prodHost;
   let sfx = '';
 
   if (aemMatch && aemRepo) {
     host = `main--${aemRepo}--adobecom.${SLD}.${aemMatch[1]}`;
     if (aemMatch[1] === 'page') sfx = suffix;
-  } else if (ENV_STAGE_HOST_RE.test(currentHost) && stageHost) {
+  } else if (ENV_STAGE_HOST_REGEX.test(currentHost) && stageHost) {
     host = stageHost;
     sfx = suffix;
   }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -678,8 +678,6 @@ function processQueryIndexMap(link, domain) {
 }
 const getDomainLingo = (path) => path?.split('/*')[0];
 
-const ENV_STAGE_HOST_RE = /\.stage\.adobe\.com$/;
-
 export function resolveCrossSiteIndex(
   { queryIndexWebPath, stageHost },
   prefix,
@@ -690,7 +688,7 @@ export function resolveCrossSiteIndex(
   let host = prodHost;
   let sfx = '';
 
-  if (ENV_STAGE_HOST_RE.test(currentHost) && stageHost) {
+  if (/\.stage\.adobe\.com$/.test(currentHost) && stageHost) {
     host = stageHost;
     sfx = suffix;
   }

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2032,6 +2032,108 @@ describe('Utils', () => {
     });
   });
 
+  describe('resolveCrossSiteIndex', () => {
+    let resolveCrossSiteIndex;
+
+    before(async () => {
+      const mod = await import('../../libs/utils/utils.js');
+      ({ resolveCrossSiteIndex } = mod);
+    });
+
+    const baseEntry = { queryIndexWebPath: 'business.adobe.com/*/assets/lingo/query-index.json' };
+
+    it('uses prod host with no suffix on prod', () => {
+      const { url, host } = resolveCrossSiteIndex(
+        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
+        '/fr',
+        '',
+        'business.adobe.com',
+      );
+      expect(url).to.equal('https://business.adobe.com/fr/assets/lingo/query-index.json');
+      expect(host).to.equal('business.adobe.com');
+    });
+
+    it('uses stage host with -preview suffix on .stage.adobe.com when stageHost set', () => {
+      const { url, host } = resolveCrossSiteIndex(
+        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
+        '/fr',
+        '-preview',
+        'business.stage.adobe.com',
+      );
+      expect(url).to.equal('https://business.stage.adobe.com/fr/assets/lingo/query-index-preview.json');
+      expect(host).to.equal('business.stage.adobe.com');
+    });
+
+    it('falls back to prod host with no suffix on .stage.adobe.com when stageHost missing', () => {
+      const { url, host } = resolveCrossSiteIndex(
+        { ...baseEntry, aemRepo: 'bacom' },
+        '/fr',
+        '-preview',
+        'business.stage.adobe.com',
+      );
+      expect(url).to.equal('https://business.adobe.com/fr/assets/lingo/query-index.json');
+      expect(host).to.equal('business.adobe.com');
+    });
+
+    it('uses main--<repo>--adobecom.aem.page with -preview on .aem.page when aemRepo set', () => {
+      const { url, host } = resolveCrossSiteIndex(
+        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
+        '/fr',
+        '-preview',
+        'feature--milo--adobecom.aem.page',
+      );
+      expect(url).to.equal('https://main--bacom--adobecom.aem.page/fr/assets/lingo/query-index-preview.json');
+      expect(host).to.equal('main--bacom--adobecom.aem.page');
+    });
+
+    it('uses main--<repo>--adobecom.aem.live with no suffix on .aem.live when aemRepo set', () => {
+      const { url, host } = resolveCrossSiteIndex(
+        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
+        '/fr',
+        '',
+        'main--milo--adobecom.aem.live',
+      );
+      expect(url).to.equal('https://main--bacom--adobecom.aem.live/fr/assets/lingo/query-index.json');
+      expect(host).to.equal('main--bacom--adobecom.aem.live');
+    });
+
+    it('falls back to prod host on .aem.page when aemRepo missing', () => {
+      const { url, host } = resolveCrossSiteIndex(
+        { ...baseEntry, stageHost: 'business.stage.adobe.com' },
+        '/fr',
+        '-preview',
+        'feature--milo--adobecom.aem.page',
+      );
+      expect(url).to.equal('https://business.adobe.com/fr/assets/lingo/query-index.json');
+      expect(host).to.equal('business.adobe.com');
+    });
+
+    it('handles cc-shared path (no /lingo/ segment) correctly', () => {
+      const { url } = resolveCrossSiteIndex(
+        {
+          queryIndexWebPath: 'www.adobe.com/*/cc-shared/assets/query-index.json',
+          stageHost: 'www.stage.adobe.com',
+          aemRepo: 'cc',
+        },
+        '/fr',
+        '-preview',
+        'www.stage.adobe.com',
+      );
+      expect(url).to.equal('https://www.stage.adobe.com/fr/cc-shared/assets/query-index-preview.json');
+    });
+
+    it('aem.page with aemRepo overrides stageHost match (env precedence)', () => {
+      // .aem.page hosts should never match the stage regex, but verify aem branch wins.
+      const { host } = resolveCrossSiteIndex(
+        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
+        '/fr',
+        '-preview',
+        'feature--milo--adobecom.aem.page',
+      );
+      expect(host).to.equal('main--bacom--adobecom.aem.page');
+    });
+  });
+
   describe('Language Banner in Utils', () => {
     let fetchStub;
     const sandbox = sinon.createSandbox();

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2044,7 +2044,7 @@ describe('Utils', () => {
 
     it('uses prod host with no suffix on prod', () => {
       const { url, host } = resolveCrossSiteIndex(
-        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
+        { ...baseEntry, stageHost: 'business.stage.adobe.com' },
         '/fr',
         '',
         'business.adobe.com',
@@ -2055,7 +2055,7 @@ describe('Utils', () => {
 
     it('uses stage host with -preview suffix on .stage.adobe.com when stageHost set', () => {
       const { url, host } = resolveCrossSiteIndex(
-        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
+        { ...baseEntry, stageHost: 'business.stage.adobe.com' },
         '/fr',
         '-preview',
         'business.stage.adobe.com',
@@ -2066,7 +2066,7 @@ describe('Utils', () => {
 
     it('falls back to prod host with no suffix on .stage.adobe.com when stageHost missing', () => {
       const { url, host } = resolveCrossSiteIndex(
-        { ...baseEntry, aemRepo: 'bacom' },
+        { ...baseEntry },
         '/fr',
         '-preview',
         'business.stage.adobe.com',
@@ -2075,29 +2075,7 @@ describe('Utils', () => {
       expect(host).to.equal('business.adobe.com');
     });
 
-    it('uses main--<repo>--adobecom.aem.page with -preview on .aem.page when aemRepo set', () => {
-      const { url, host } = resolveCrossSiteIndex(
-        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
-        '/fr',
-        '-preview',
-        'feature--milo--adobecom.aem.page',
-      );
-      expect(url).to.equal('https://main--bacom--adobecom.aem.page/fr/assets/lingo/query-index-preview.json');
-      expect(host).to.equal('main--bacom--adobecom.aem.page');
-    });
-
-    it('uses main--<repo>--adobecom.aem.live with no suffix on .aem.live when aemRepo set', () => {
-      const { url, host } = resolveCrossSiteIndex(
-        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
-        '/fr',
-        '',
-        'main--milo--adobecom.aem.live',
-      );
-      expect(url).to.equal('https://main--bacom--adobecom.aem.live/fr/assets/lingo/query-index.json');
-      expect(host).to.equal('main--bacom--adobecom.aem.live');
-    });
-
-    it('falls back to prod host on .aem.page when aemRepo missing', () => {
+    it('falls back to prod host on .aem.page (cross-origin auth required)', () => {
       const { url, host } = resolveCrossSiteIndex(
         { ...baseEntry, stageHost: 'business.stage.adobe.com' },
         '/fr',
@@ -2113,24 +2091,12 @@ describe('Utils', () => {
         {
           queryIndexWebPath: 'www.adobe.com/*/cc-shared/assets/query-index.json',
           stageHost: 'www.stage.adobe.com',
-          aemRepo: 'cc',
         },
         '/fr',
         '-preview',
         'www.stage.adobe.com',
       );
       expect(url).to.equal('https://www.stage.adobe.com/fr/cc-shared/assets/query-index-preview.json');
-    });
-
-    it('aem.page with aemRepo overrides stageHost match (env precedence)', () => {
-      // .aem.page hosts should never match the stage regex, but verify aem branch wins.
-      const { host } = resolveCrossSiteIndex(
-        { ...baseEntry, stageHost: 'business.stage.adobe.com', aemRepo: 'bacom' },
-        '/fr',
-        '-preview',
-        'feature--milo--adobecom.aem.page',
-      );
-      expect(host).to.equal('main--bacom--adobecom.aem.page');
     });
   });
 


### PR DESCRIPTION
Resolves: [MWPW-193754](https://jira.corp.adobe.com/browse/MWPW-193754)

## Summary
- Cross-site lingo query-indexes (from `lingo-site-mapping.json`) now load from the matching stage host instead of always hitting prod live
- On `business.stage.adobe.com`, da-cc's query-index now loads from `www.stage.adobe.com/.../query-index-preview.json` instead of `www.adobe.com/.../query-index.json`
- There's a new config for this in `lingo-site-mapping.json` named `stageHost` — sites without it fall back to prod (no behaviour change) - https://main--federal--adobecom.aem.page/federal/assets/data/lingo-site-mapping.json

## Why not `.aem.page` / `.aem.live`?
Cross-origin fetches between `*.aem.page` domains require authentication. The auth token is in an HTTP-only cookie that JavaScript cannot access, so the fetch would 401 and `processQueryIndexMap` would silently return empty paths — worse than the current prod fallback. Stage hosts share the same auth layer so cross-origin fetches work without extra tokens.

## Mapping config needed (federal repo)
Add a `stageHost` column to the `site-query-index-map` sheet in `lingo-site-mapping.json`. I've added but only previewed so far. 

**Test URLs:**
- Before: https://business.stage.adobe.com/fr/?akamaiLocale=CA
- After: https://business.stage.adobe.com/fr/?milolibs=vhargrave-env-aware-query-index&akamaiLocale=CA

- Before: https://www.stage.adobe.com/fr/acrobat/acrobat-pro.html?akamaiLocale=ca
- After: https://www.stage.adobe.com/fr/acrobat/acrobat-pro.html?akamaiLocale=ca&milolibs=vhargrave-env-aware-query-index

## How to test
- [ ] On both test links: DevTools Network shows cross-site Query Index fetched from `*.stage.adobe.com` with `-preview` suffix, and no longer from just adobe.com
- [ ] On `*.aem.page`: cross-site QI still loads from prod (graceful fallback)


