### PR TITLE
[MWPW-193628]: [Accessibility] Fixed Content is lost at 200% zoom.

### DIFF
--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -224,7 +224,6 @@
   flex-direction: column;
   justify-content: center;
   flex: 1 1 0;
-  /* Prevent the title from shrinking so far it wraps per-letter at higher zoom levels */
   min-inline-size: min-content;
   max-inline-size: 100%;
 }

--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -38,6 +38,7 @@
 
 .notification.ribbon {
   min-block-size: var(--min-block-size-ribbon);
+  overflow: visible;
 }
 
 .dark .notification,
@@ -211,7 +212,9 @@
 }
 
 .notification.ribbon.space-between .foreground .text {
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
+  row-gap: var(--spacing-xs);
+  column-gap: var(--spacing-s);
   inline-size: 100%;
 }
 
@@ -220,7 +223,10 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  flex-basis: 100%;
+  flex: 1 1 0;
+  /* Prevent the title from shrinking so far it wraps per-letter at higher zoom levels */
+  min-inline-size: min-content;
+  max-inline-size: 100%;
 }
 
 .notification .foreground .image {
@@ -363,6 +369,9 @@
   align-self: center;
   justify-content: flex-end;
   inline-size: auto;
+  max-inline-size: 100%;
+  min-inline-size: 0;
+  flex: 0 1 auto;
 }
 
 .notification.flexible {
@@ -618,7 +627,7 @@
   }
 
   .notification.ribbon .foreground .text {
-    flex-flow: row nowrap;
+    flex-flow: row wrap;
     align-items: center;
   }
 
@@ -665,7 +674,7 @@
   }
 
   .notification.ribbon.space-between .foreground .action-area {
-    flex-wrap: unset;
+    flex-wrap: wrap;
   }
 
   .notification.pill.flexible {

--- a/libs/blocks/notification/notification.css
+++ b/libs/blocks/notification/notification.css
@@ -219,7 +219,7 @@
 }
 
 .notification.ribbon.space-between .foreground .copy-wrap {
-  margin-inline-end: var(--spacing-s);
+  margin-inline-end: 0;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
- Fix ribbon notification CTAs being cut off at 200% zoom (e.g. “Visit the Google Play Store”).
- Improves WCAG 1.4.4 Resize text (AA) by allowing layout to reflow/wrap instead of clipping.
- Adjusts ribbon space-between flex sizing/wrapping and prevents the title (e.g. “Lightroom”) from wrapping per-letter at higher zoom.
- Test: Chrome 1366×768 at 100% vs 200% zoom; confirm both CTAs are fully visible/clickable.

Resolves: [MWPW-193628](https://jira.corp.adobe.com/browse/MWPW-193628)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/drafts/himani/sticky-banner-notification?martech=off
- After: https://main--da-cc--adobecom.aem.page/drafts/himani/sticky-banner-notification?milolibs=mwpw-193628-a11y-lightroom--milo--hkuraware&martech=off

**Dev validation:**

Before(1366px by 768px zoom 200% ):- 
<img width="1337" height="709" alt="before-fix" src="https://github.com/user-attachments/assets/de9b02a6-b930-4cbc-8d39-3c2175f612f2" />

After(1366px by 768px zoom 200% ):- 
<img width="1337" height="709" alt="after-fix" src="https://github.com/user-attachments/assets/07ef426b-8ef4-4d83-97c2-32f1522f5c07" />
<img width="1337" height="709" alt="after-fix-dimensions" src="https://github.com/user-attachments/assets/5bae0e32-0d12-4dda-875e-d7527ecba736" />






