### PR TITLE
MWPW-191178 Lingo FR: Dexter modals doesn't render regional pricing/checkout

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1039,7 +1039,7 @@ export async function getModalAction(offers, options, el, isMiloPreview = isPrev
   if (!url && !el?.isOpen3in1Modal) return undefined;
   const prodModalUrl = isProdModal(url);
   if (isInternalModal(url) || prodModalUrl) {
-    const localized = await localizeLinkAsync(url);
+    const localized = await localizeLinkAsync(url, window.location.hostname, false, el);
     url = prodModalUrl && !localized.startsWith('http')
       ? `${new URL(url).origin}${localized}`
       : localized;


### PR DESCRIPTION
Lingo localization doesn't work on 3in1 fallback modals (TWP/D2P/CRM) (OST checkout links)

Test page : https://stage--upp--adobecom.aem.page/fr/homepage/test/lingo?langfirst=on&akamaiLocale=ca&milolibs=mwpw191178x--milo--bozojovicic

Resolves: [MWPW-191178](https://jira.corp.adobe.com/browse/MWPW-191178)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://mwpw191178x--milo--bozojovicic.aem.live/?martech=off


