### PR TITLE
[MWPW-190910] Support DA floodgate fg-{color} repo naming for CaaS

### DIFF
--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -1,6 +1,5 @@
 import {
   decodeCompressedString,
-  fgHeaderName,
   initCaas,
   loadCaasFiles,
   loadStrings,
@@ -28,15 +27,17 @@ const getFloodgateColor = async (host) => {
     const repo = parts.length >= 3 ? parts.slice(1, -1).join('--') : '';
     const fgMatch = repo.match(/-fg-(\w+)$/);
     if (fgMatch) return fgMatch[1];
-    return '';
   }
 
   try {
     const resp = await fetch(window.location.href, { method: 'HEAD', credentials: 'same-origin' });
-    return resp.headers.get(fgHeaderName) || '';
+    const fgHeader = resp.headers.get('x-adobe-floodgate');
+    if (fgHeader) return fgHeader;
   } catch {
-    return '';
+    // ignore fetch errors
   }
+
+  return '';
 };
 
 const getCaasStrings = (placeholderUrl) => new Promise((resolve) => {

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -18,7 +18,7 @@ const ROOT_MARGIN = 1000;
 const P_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
 const S_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS1zdGFnZS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
 
-const getFloodgateColor = async (host) => {
+const getFloodgateColor = (host) => {
   const metaColor = getMetadata('floodgatecolor');
   if (metaColor) return metaColor;
 
@@ -27,14 +27,6 @@ const getFloodgateColor = async (host) => {
     const repo = parts.length >= 3 ? parts.slice(1, -1).join('--') : '';
     const fgMatch = repo.match(/-fg-(\w+)$/);
     if (fgMatch) return fgMatch[1];
-  }
-
-  try {
-    const resp = await fetch(window.location.href, { method: 'HEAD', credentials: 'same-origin' });
-    const fgHeader = resp.headers.get('x-adobe-floodgate');
-    if (fgHeader) return fgHeader;
-  } catch {
-    // ignore fetch errors
   }
 
   return '';
@@ -78,7 +70,7 @@ const loadCaas = async (a) => {
   const { env } = getConfig();
   const { host, search } = window.location;
 
-  const floodGateColor = await getFloodgateColor(host);
+  const floodGateColor = getFloodgateColor(host);
   if (floodGateColor && floodGateColor !== 'default') {
     state.fetchCardsFromFloodgateTree = true;
     state.floodgateColor = floodGateColor;

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -88,7 +88,9 @@ const loadCaas = async (a) => {
   const caasEndpoint = queryParams.get('caasendpoint');
   const caasContainer = queryParams.get('caascontainer');
 
-  if (host.includes('stage.adobe') || env?.name === 'local' || caasEndpoint === 'stage') {
+  if (host.includes('stage.adobe.com')) {
+    chimeraEndpoint = 'www.stage.adobe.com/chimera-api/collection';
+  } else if (env?.name === 'local' || caasEndpoint === 'stage') {
     chimeraEndpoint = S_CAAS_AIO;
   } else if (host.includes(`.${SLD}.`) || caasEndpoint === 'prod') {
     // If invoking URL is not an Acom URL, then switch to AIO

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -1,6 +1,5 @@
 import {
   decodeCompressedString,
-  fgHeaderName,
   initCaas,
   loadCaasFiles,
   loadStrings,
@@ -54,15 +53,7 @@ const loadCaas = async (a) => {
     state.langFirst = true;
   }
 
-  let floodGateColor = getMetadata('floodgatecolor') || '';
-  if (!floodGateColor) {
-    try {
-      const resp = await fetch(window.location.href, { method: 'HEAD' });
-      floodGateColor = resp.headers.get(fgHeaderName) || '';
-    } catch {
-      // ignore fetch errors
-    }
-  }
+  const floodGateColor = getMetadata('floodgatecolor') || '';
   if (floodGateColor && floodGateColor !== 'default') {
     state.fetchCardsFromFloodgateTree = true;
     state.floodgateColor = floodGateColor;

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -1,6 +1,5 @@
 import {
   decodeCompressedString,
-  fgHeaderValue,
   initCaas,
   loadCaasFiles,
   loadStrings,
@@ -55,8 +54,9 @@ const loadCaas = async (a) => {
   }
 
   const floodGateColor = getMetadata('floodgatecolor') || '';
-  if (floodGateColor === fgHeaderValue) {
+  if (floodGateColor && floodGateColor !== 'default') {
     state.fetchCardsFromFloodgateTree = true;
+    state.floodgateColor = floodGateColor;
   }
 
   const { env } = getConfig();

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -1,5 +1,6 @@
 import {
   decodeCompressedString,
+  fgHeaderName,
   initCaas,
   loadCaasFiles,
   loadStrings,
@@ -17,6 +18,26 @@ import {
 const ROOT_MARGIN = 1000;
 const P_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
 const S_CAAS_AIO = b64ToUtf8('MTQyNTctY2hpbWVyYS1zdGFnZS5hZG9iZWlvcnVudGltZS5uZXQvYXBpL3YxL3dlYi9jaGltZXJhLTAuMC4xL2NvbGxlY3Rpb24=');
+
+const getFloodgateColor = async (host) => {
+  const metaColor = getMetadata('floodgatecolor');
+  if (metaColor) return metaColor;
+
+  if (host.endsWith('.aem.page') || host.endsWith('.aem.live')) {
+    const parts = host.split('.')[0].split('--');
+    const repo = parts.length >= 3 ? parts.slice(1, -1).join('--') : '';
+    const fgMatch = repo.match(/-fg-(\w+)$/);
+    if (fgMatch) return fgMatch[1];
+    return '';
+  }
+
+  try {
+    const resp = await fetch(window.location.href, { method: 'HEAD', credentials: 'same-origin' });
+    return resp.headers.get(fgHeaderName) || '';
+  } catch {
+    return '';
+  }
+};
 
 const getCaasStrings = (placeholderUrl) => new Promise((resolve) => {
   if (placeholderUrl) {
@@ -53,14 +74,14 @@ const loadCaas = async (a) => {
     state.langFirst = true;
   }
 
-  const floodGateColor = getMetadata('floodgatecolor') || '';
+  const { env } = getConfig();
+  const { host, search } = window.location;
+
+  const floodGateColor = await getFloodgateColor(host);
   if (floodGateColor && floodGateColor !== 'default') {
     state.fetchCardsFromFloodgateTree = true;
     state.floodgateColor = floodGateColor;
   }
-
-  const { env } = getConfig();
-  const { host, search } = window.location;
   let chimeraEndpoint = 'www.adobe.com/chimera-api/collection';
   const queryParams = new URLSearchParams(search);
   const caasEndpoint = queryParams.get('caasendpoint');

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -80,7 +80,7 @@ const loadCaas = async (a) => {
   const caasEndpoint = queryParams.get('caasendpoint');
   const caasContainer = queryParams.get('caascontainer');
 
-  if (host.includes('stage.adobe.com')) {
+  if (host === 'stage.adobe.com' || host.endsWith('.stage.adobe.com')) {
     chimeraEndpoint = 'www.stage.adobe.com/chimera-api/collection';
   } else if (env?.name === 'local' || caasEndpoint === 'stage') {
     chimeraEndpoint = S_CAAS_AIO;

--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -1,5 +1,6 @@
 import {
   decodeCompressedString,
+  fgHeaderName,
   initCaas,
   loadCaasFiles,
   loadStrings,
@@ -53,7 +54,15 @@ const loadCaas = async (a) => {
     state.langFirst = true;
   }
 
-  const floodGateColor = getMetadata('floodgatecolor') || '';
+  let floodGateColor = getMetadata('floodgatecolor') || '';
+  if (!floodGateColor) {
+    try {
+      const resp = await fetch(window.location.href, { method: 'HEAD' });
+      floodGateColor = resp.headers.get(fgHeaderName) || '';
+    } catch {
+      // ignore fetch errors
+    }
+  }
   if (floodGateColor && floodGateColor !== 'default') {
     state.fetchCardsFromFloodgateTree = true;
     state.floodgateColor = floodGateColor;

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -177,7 +177,6 @@ export const LOCALES = {
 
 const URL_ENCODED_COMMA = '%2C';
 export const fgHeaderName = 'X-Adobe-Floodgate';
-export const fgHeaderValue = 'pink';
 
 const pageConfig = pageConfigHelper();
 const pageLocales = Object.keys(pageConfig.locales || {});
@@ -831,10 +830,9 @@ const findTupleIndex = (fgHeader) => {
  * @returns requestHeaders
  */
 const addFloodgateHeader = (state) => {
-  // Delete FG header if already exists, before adding pink to avoid duplicates in requestHeaders
   requestHeaders.splice(findTupleIndex(fgHeaderName, 1));
   if (state.fetchCardsFromFloodgateTree) {
-    requestHeaders.push([fgHeaderName, fgHeaderValue]);
+    requestHeaders.push([fgHeaderName, state.floodgateColor]);
   }
   return requestHeaders;
 };
@@ -1248,6 +1246,7 @@ export const defaultState = {
   andLogicTags: [],
   autoCountryLang: false,
   fetchCardsFromFloodgateTree: false,
+  floodgateColor: '',
   bookmarkIconSelect: '',
   bookmarkIconUnselect: '',
   cardStyle: 'half-height',

--- a/test/blocks/caas/send-to-caas.test.js
+++ b/test/blocks/caas/send-to-caas.test.js
@@ -3,6 +3,7 @@ import { expect } from '@esm-bundle/chai';
 
 import {
   checkUrl,
+  getFloodgateColorFromRepo,
   getKeyValPairs,
   getOrigin,
   runLanguageFirstRetry,
@@ -162,5 +163,48 @@ describe('runLanguageFirstRetry (language-first retry)', () => {
     const result = await runLanguageFirstRetry(baseOptions, getLangFirst, noDelay);
     expect(result).to.equal('en-xx');
     expect(callCount).to.be.greaterThan(1);
+  });
+});
+
+describe('getFloodgateColorFromRepo', () => {
+  it('should extract color from DA fg repo name', () => {
+    expect(getFloodgateColorFromRepo('da-events-fg-pink')).to.equal('pink');
+  });
+
+  it('should extract color for blue', () => {
+    expect(getFloodgateColorFromRepo('da-events-fg-blue')).to.equal('blue');
+  });
+
+  it('should return empty string for legacy repo name without fg infix', () => {
+    expect(getFloodgateColorFromRepo('bacom-pink')).to.equal('');
+  });
+
+  it('should return empty string for repos with no floodgate suffix', () => {
+    expect(getFloodgateColorFromRepo('da-events')).to.equal('');
+  });
+
+  it('should return empty string for null/undefined', () => {
+    expect(getFloodgateColorFromRepo(null)).to.equal('');
+    expect(getFloodgateColorFromRepo(undefined)).to.equal('');
+  });
+});
+
+describe('getOrigin with DA floodgate repos', () => {
+  it('should strip -fg-{color} from DA repo to get correct origin', () => {
+    setConfig({ project: '', repo: 'da-events-fg-pink' });
+    const result = getOrigin('pink');
+    expect(result).to.equal('da-events');
+  });
+
+  it('should strip legacy -{color} from repo to get correct origin', () => {
+    setConfig({ project: '', repo: 'bacom-pink' });
+    const result = getOrigin('pink');
+    expect(result).to.equal('bacom');
+  });
+
+  it('should return repo as-is when floodgate color is default', () => {
+    setConfig({ project: '', repo: 'da-events' });
+    const result = getOrigin('default');
+    expect(result).to.equal('da-events');
   });
 });

--- a/test/blocks/caas/send-to-caas.test.js
+++ b/test/blocks/caas/send-to-caas.test.js
@@ -3,7 +3,7 @@ import { expect } from '@esm-bundle/chai';
 
 import {
   checkUrl,
-  getFloodgateColorFromRepo,
+  getFloodgateColorFromHost,
   getKeyValPairs,
   getOrigin,
   runLanguageFirstRetry,
@@ -166,26 +166,21 @@ describe('runLanguageFirstRetry (language-first retry)', () => {
   });
 });
 
-describe('getFloodgateColorFromRepo', () => {
-  it('should extract color from DA fg repo name', () => {
-    expect(getFloodgateColorFromRepo('da-events-fg-pink')).to.equal('pink');
+describe('getFloodgateColorFromHost', () => {
+  it('should extract color from aem.live fg host', () => {
+    expect(getFloodgateColorFromHost('main--da-events-fg-pink--adobecom.aem.live')).to.equal('pink');
   });
 
-  it('should extract color for blue', () => {
-    expect(getFloodgateColorFromRepo('da-events-fg-blue')).to.equal('blue');
+  it('should extract color from aem.page fg host', () => {
+    expect(getFloodgateColorFromHost('main--da-events-fg-blue--adobecom.aem.page')).to.equal('blue');
   });
 
-  it('should return empty string for legacy repo name without fg infix', () => {
-    expect(getFloodgateColorFromRepo('bacom-pink')).to.equal('');
+  it('should return empty string for non-fg aem host', () => {
+    expect(getFloodgateColorFromHost('main--da-events--adobecom.aem.live')).to.equal('');
   });
 
-  it('should return empty string for repos with no floodgate suffix', () => {
-    expect(getFloodgateColorFromRepo('da-events')).to.equal('');
-  });
-
-  it('should return empty string for null/undefined', () => {
-    expect(getFloodgateColorFromRepo(null)).to.equal('');
-    expect(getFloodgateColorFromRepo(undefined)).to.equal('');
+  it('should return empty string for production host', () => {
+    expect(getFloodgateColorFromHost('business.adobe.com')).to.equal('');
   });
 });
 
@@ -196,8 +191,8 @@ describe('getOrigin with DA floodgate repos', () => {
     expect(result).to.equal('da-events');
   });
 
-  it('should strip legacy -{color} from repo to get correct origin', () => {
-    setConfig({ project: '', repo: 'bacom-pink' });
+  it('should return repo as-is when it does not contain -fg-{color}', () => {
+    setConfig({ project: '', repo: 'bacom' });
     const result = getOrigin('pink');
     expect(result).to.equal('bacom');
   });

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -913,6 +913,7 @@ describe('getCountryAndLang', () => {
 describe('getFloodgateCaasConfig', () => {
   const caasFgState = defaultState;
   caasFgState.fetchCardsFromFloodgateTree = true;
+  caasFgState.floodgateColor = 'pink';
   caasFgState.draftDb = true;
 
   it('should return a floodgate enabled caas config object', async () => {

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -192,7 +192,7 @@ const processData = async (data, accessToken) => {
 
   if (usePreview) {
     domain = `https://${previewHost}`;
-  } else if (floodgateColor !== 'default') {
+  } else if (floodgateColor !== 'default' && !hostFgColor) {
     domain = `https://main--${repo}--${owner}.aem.live`;
   }
 

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -9,7 +9,7 @@ import {
 import {
   getCardMetadata,
   getCaasProps,
-  getFloodgateColorFromRepo,
+  getFloodgateColorFromHost,
   loadCaasTags,
   postDataToCaaS,
   getConfig,
@@ -185,8 +185,8 @@ const processData = async (data, accessToken) => {
     return;
   }
 
-  const repoFgColor = getFloodgateColorFromRepo(repo);
-  const floodgateColor = repoFgColor || publishToFloodgate;
+  const hostFgColor = getFloodgateColorFromHost(host);
+  const floodgateColor = hostFgColor || publishToFloodgate;
 
   let domain = `https://${host}`;
 

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -9,6 +9,7 @@ import {
 import {
   getCardMetadata,
   getCaasProps,
+  getFloodgateColorFromRepo,
   loadCaasTags,
   postDataToCaaS,
   getConfig,
@@ -184,11 +185,14 @@ const processData = async (data, accessToken) => {
     return;
   }
 
+  const repoFgColor = getFloodgateColorFromRepo(repo);
+  const floodgateColor = repoFgColor || publishToFloodgate;
+
   let domain = `https://${host}`;
 
   if (usePreview) {
     domain = `https://${previewHost}`;
-  } else if (publishToFloodgate !== 'default') {
+  } else if (floodgateColor !== 'default') {
     domain = `https://main--${repo}--${owner}.aem.live`;
   }
 
@@ -218,7 +222,7 @@ const processData = async (data, accessToken) => {
         prodUrl,
         host,
         repo,
-        floodgatecolor: publishToFloodgate,
+        floodgatecolor: floodgateColor,
         languageFirst,
       });
 

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -191,13 +191,14 @@ const processRepoForFloodgate = (repo, fgColor) => {
     if (repo.endsWith(fgInfix)) {
       return repo.slice(0, repo.lastIndexOf(fgInfix));
     }
-    return repo.slice(0, repo.lastIndexOf(`-${fgColor}`));
   }
   return repo;
 };
 
-export const getFloodgateColorFromRepo = (repo) => {
-  const match = repo?.match(/-fg-(\w+)$/);
+export const getFloodgateColorFromHost = (host) => {
+  const parts = host?.split('.')[0].split('--') || [];
+  const repo = parts.length >= 3 ? parts.slice(1, -1).join('--') : '';
+  const match = repo.match(/-fg-(\w+)$/);
   return match ? match[1] : '';
 };
 

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -187,9 +187,18 @@ const getDateProp = (dateStr, errorMsg) => {
 
 const processRepoForFloodgate = (repo, fgColor) => {
   if (repo && fgColor && fgColor !== 'default') {
+    const fgInfix = `-fg-${fgColor}`;
+    if (repo.endsWith(fgInfix)) {
+      return repo.slice(0, repo.lastIndexOf(fgInfix));
+    }
     return repo.slice(0, repo.lastIndexOf(`-${fgColor}`));
   }
   return repo;
+};
+
+export const getFloodgateColorFromRepo = (repo) => {
+  const match = repo?.match(/-fg-(\w+)$/);
+  return match ? match[1] : '';
 };
 
 export const getOrigin = (fgColor) => {


### PR DESCRIPTION
* Fix `processRepoForFloodgate` to correctly strip DA `-fg-{color}` suffix (e.g. `da-events-fg-pink` → `da-events`) so the `origin` field is computed correctly for Chimera content grouping
* Add `getFloodgateColorFromRepo` to auto-detect floodgate color from DA repo names in the bulk publisher
* Make CaaS floodgate header dynamic — replace hardcoded `pink` with the actual `floodgatecolor` metadata value, enabling support for any floodgate color
* Update bulk publisher to use detected color for both domain construction and card metadata

Resolves: [MWPW-190910](https://jira.corp.adobe.com/browse/MWPW-190910)
Related: [MWPW-189895](https://jira.corp.adobe.com/browse/MWPW-189895), [MWPW-190914](https://jira.corp.adobe.com/browse/MWPW-190914), [MWPW-190916](https://jira.corp.adobe.com/browse/MWPW-190916)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://caas-floodgate--milo--shkhan91.aem.page/?martech=off


## Test Plan

### 1. Origin field correctness (Critical — `processRepoForFloodgate`)

| Scenario | Repo | fgColor | Expected Origin | Pass? |
|----------|------|---------|-----------------|-------|
| DA floodgate pink | `da-events-fg-pink` | `pink` | `da-events` | |
| DA floodgate blue | `da-events-fg-blue` | `blue` | `da-events` | |
| Legacy floodgate pink | `bacom-pink` | `pink` | `bacom` | |
| Legacy floodgate blue | `bacom-blue` | `blue` | `bacom` | |
| No floodgate | `da-events` | `default` | `da-events` | |
| No floodgate (empty) | `da-events` | `` | `da-events` | |
| Repo with `-fg-` in name but no color match | `my-fg-repo` | `default` | `my-fg-repo` | |

### 2. Auto-detection of floodgate color from DA repo name (`getFloodgateColorFromRepo`)

| Scenario | Repo Input | Expected Color | Pass? |
|----------|-----------|----------------|-------|
| DA pink repo | `da-events-fg-pink` | `pink` | |
| DA blue repo | `da-events-fg-blue` | `blue` | |
| Legacy repo (no fg infix) | `bacom-pink` | `` (empty) | |
| Normal repo | `da-events` | `` (empty) | |
| Null input | `null` | `` (empty) | |

### 3. Bulk publisher integration (end-to-end)

- [x] **DA floodgate publish**: Configure bulk publisher with `repo=da-events-fg-pink`, `owner=adobecom`. Verify:
  - Domain resolves to `https://main--da-events-fg-pink--adobecom.aem.live`
  - `floodgatecolor` in payload is `pink` (auto-detected from repo name)
  - `entityId` is salted with `pink` (different from default entityId)
  - `contentId` is NOT salted (same as default contentId)
  - `origin` is `da-events` (not `da-events-fg`)
- [x] **Legacy floodgate publish**: Configure with `repo=bacom`, `publishToFloodgate=pink`. Verify:
  - Domain resolves to `https://main--bacom--adobecom.aem.live`
  - Payload `floodgatecolor` is `pink`
  - `origin` is `bacom`
- [x] **Non-floodgate publish**: Configure with `repo=da-events`, no floodgate. Verify:
  - Domain uses host directly (e.g. `https://business.adobe.com`)
  - `floodgatecolor` is `default`
  - `entityId` equals `contentId` (no salt)

### 4. CaaS consumer side — dynamic floodgate header

- [x] **Pink floodgate page**: Set `floodgatecolor=pink` in page metadata. Verify:
  - `X-Adobe-Floodgate: pink` header is sent to Chimera
  - Floodgated cards are returned
- [x] **Blue floodgate page**: Set `floodgatecolor=blue` in page metadata. Verify:
  - `X-Adobe-Floodgate: blue` header is sent (not hardcoded `pink`)
- [x] **Default page (no floodgate)**: No `floodgatecolor` metadata. Verify:
  - No `X-Adobe-Floodgate` header is sent
  - Default cards are returned
- [x] **Explicit `default` value**: Set `floodgatecolor=default` in metadata. Verify:
  - No `X-Adobe-Floodgate` header is sent

### 5. Featured cards compatibility

- [x] Featured cards specified by **URL path** continue to work (contentId-based lookup, unaffected by floodgate salt)
- [x] Featured cards specified by **UUID (entityId)** from the default version will NOT match floodgated content — this is expected behavior. Verify that floodgated entityIds must be used for floodgate featured cards.
- [x] Chimera `entityId:${id} OR contentId:${id}` fallback query works for both ID types

### 6. Regression — existing non-floodgate publishing

- [x] Bulk publish to CaaS prod with a standard repo (e.g. `bacom`) works identically to before
- [x] CaaS cards render correctly on pages without floodgate metadata
- [x] CaaS config UI (`caas-config` block) continues to generate correct collection endpoints

### 7. Unit tests

- [ ] `getFloodgateColorFromRepo` tests pass (DA patterns, legacy patterns, edge cases)
- [ ] `getOrigin` tests pass with DA fg repos
- [ ] CaaS utils floodgate config test passes with `floodgateColor` state property
- [ ] All existing CaaS test suites pass with no regressions


















