### PR TITLE
[MWPW-188683] Support config-stage in locui for lingo

### DIFF
--- a/libs/blocks/locui/utils/state.js
+++ b/libs/blocks/locui/utils/state.js
@@ -1,8 +1,12 @@
 import { signal } from '../../../deps/htm-preact.js';
+import { getConfig } from '../../../utils/utils.js';
 import { setStatus } from './status.js';
 import { origin } from './franklin.js';
 
-const LOC_CONFIG = '/.milo/config.json';
+function getLocConfigPath() {
+  const { env } = getConfig();
+  return env?.name === 'prod' ? '/.milo/config.json' : '/.milo/config-stage.json';
+}
 
 export const telemetry = { application: { appName: 'Adobe Localization' } };
 
@@ -37,7 +41,11 @@ export function getSiteConfig() {
       resolve(siteConfig.value);
       return;
     }
-    const resp = await fetch(`${origin}${LOC_CONFIG}`);
+    const primaryPath = getLocConfigPath();
+    let resp = await fetch(`${origin}${primaryPath}`);
+    if (!resp.ok && primaryPath !== '/.milo/config.json') {
+      resp = await fetch(`${origin}/.milo/config.json`);
+    }
     if (!resp.ok) {
       setStatus('siteConfig', 'error', 'Error getting site settings.');
       return;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

## Dynamic LOC config resolution based on environment for Milo Studio Lingo changes stage testing

`LOC_CONFIG` was a hardcoded constant pointing to `/.milo/config-stage.json`.

### Changes
- Replaced the constant with a `getLocConfigPath()` function that resolves the config path at fetch time using `getConfig().env.name`
  - `prod` → `/.milo/config.json`
  - `local` / `stage` → `/.milo/config-stage.json`
- Added a fallback in `getSiteConfig()`: if `config-stage.json` returns a non-OK response, retries with `/.milo/config.json`

config-stage.xlsx: https://main--da-cc--adobecom.aem.page/.milo/config-stage.json


Resolves: [MWPW-188683](https://jira.corp.adobe.com/browse/MWPW-188683)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://locui-lingo--milo--maagrawal16.aem.page/?martech=off


