### PR TITLE
[Loc][MWPW-188683] Fix locale selection for promote and translation workflows

### DIFF
--- a/libs/blocks/locui-create/input-locale/index.js
+++ b/libs/blocks/locui-create/input-locale/index.js
@@ -136,7 +136,8 @@ export default function useInputLocale() {
       if (project.value.type === PROJECT_TYPES.translation) {
         const langDetails = languagesList.find((l) => l.languagecode === languageCodes[language]);
         const defaultLocales = langDetails?.defaultlocales ? langDetails.defaultlocales.split(',') : [];
-        return { language, locales: defaultLocales, langCode: languageCodes[language] };
+        const nonDefaultLocales = localeList.filter((locale) => !defaultLocales.includes(locale));
+        return { language, locales: nonDefaultLocales, langCode: languageCodes[language] };
       }
       return { language, locales: localeList, langCode: languageCodes[language] };
     });

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -76,13 +76,17 @@ export function setSelectedLocalesAndRegions() {
   }, {});
   const selectedLocale = [];
   const activeLocales = {};
+  const isPromoteOrSingleRollout = userWorkflowType.value === USER_WORKFLOW_TYPE.promote_rollout
+    || userWorkflowType.value === USER_WORKFLOW_TYPE.single_rollout;
   languages.forEach((loc) => {
     const { language, locales } = loc;
     const { livecopies, defaultlocales, languagecode } = localeByLanguage[language] || {};
-    const effectiveLivecopies = defaultlocales || livecopies;
+    const visibleLivecopies = isPromoteOrSingleRollout
+      ? livecopies
+      : (defaultlocales || livecopies);
     const livecopiesArr = [];
-    if (effectiveLivecopies) {
-      const newLivecopies = effectiveLivecopies.split(',').map((locale) => `${languagecode}|${locale}`);
+    if (visibleLivecopies) {
+      const newLivecopies = visibleLivecopies.split(',').map((locale) => `${languagecode}|${locale}`);
       livecopiesArr.push(...newLivecopies);
     }
     if (locales.length > 0) {


### PR DESCRIPTION
## Summary

- **Promote & single-rollout workflows**: When creating a promote or single-rollout project 
  for a language that has `defaultlocales` defined, all livecopies for that language are now 
  shown as selectable (visible) in the locale picker, while only the default locale is 
  pre-selected (active). Previously, only the default locale was shown at all.

- **Translation workflow**: The `locales` array sent to the service on save no longer includes 
  the default locale(s) — only non-default (regional) locales are sent. This avoids 
  re-translating the primary locale when the intent is to translate regional variants.

## Changes

- `libs/blocks/locui-create/utils/utils.js` — `setSelectedLocalesAndRegions`: for 
  `promoteRollout` and `singleRollout`, use the language's full `livecopies` as the visible 
  locale set instead of restricting to `defaultlocales`.

- `libs/blocks/locui-create/input-locale/index.js` — `transformActiveLocales`: for translation 
  projects, filter `defaultlocales` out of the saved `locales` array so only non-default 
  locales are submitted.

## Test plan

- [ ] Create a promote project from a French translation project — confirm all French livecopies 
  (`fr`, `be_fr`, `ch_fr`, `lu_fr`) appear, with only `fr` pre-selected
- [ ] Same for single-rollout launched via `?type=rollout&language=fr`
- [ ] Submit a translation project with regional locales selected — confirm the default locale 
  is not included in the saved `locales` payload
- [ ] Verify other workflows (edit, normal) are unaffected

Resolves: [MWPW-188683](https://jira.corp.adobe.com/browse/MWPW-188683)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-188683-fixes--milo--maagrawal16.aem.page/?martech=off
