### PR TITLE
MWPW-194181[MEP] Fix flash in preview

### DIFF
--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -132,9 +132,10 @@ function addDividers(node, selector) {
   });
 }
 
-function addPillEventListeners(div, onClose) {
+function addPillEventListeners(div, overlay, onClose) {
   div.querySelector('.mep-manifest.mep-badge').addEventListener('click', () => {
-    div.classList.toggle('mep-hidden');
+    const isHidden = div.classList.toggle('mep-hidden');
+    if (!isHidden) overlay?.showPopover?.();
   });
   div.querySelector('.mep-close').addEventListener('click', () => {
     const overlayEl = document.querySelector('.mep-preview-overlay');
@@ -732,7 +733,6 @@ async function createPreviewPill() {
   pill.append(await getMepPopup(mepConfig));
   overlay.append(pill);
   document.body.append(overlay);
-  overlay.showPopover?.();
   let onClose;
   if (window.lenis?.options) {
     const originalPrevent = window.lenis.options.prevent;
@@ -742,7 +742,7 @@ async function createPreviewPill() {
     };
     onClose = () => { window.lenis.options.prevent = originalPrevent; };
   }
-  addPillEventListeners(pill, onClose);
+  addPillEventListeners(pill, overlay, onClose);
 }
 function addHighlightData(manifests) {
   manifests.forEach(({ selectedVariant, manifest }) => {

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -119,6 +119,17 @@ describe('preview feature', () => {
     document.querySelector('.mep-close').click();
     expect(document.querySelectorAll('.mep-preview-overlay').length).to.equal(0);
   });
+  it('showPopover is deferred until badge click, not called on init', async () => {
+    await decoratePreviewMode();
+    const overlay = document.querySelector('.mep-preview-overlay');
+    const showPopover = sinon.stub();
+    overlay.showPopover = showPopover;
+    expect(showPopover.called).to.be.false;
+    document.querySelector('.mep-badge').click();
+    expect(showPopover.calledOnce).to.be.true;
+    document.querySelector('.mep-badge').click();
+    expect(showPopover.calledOnce).to.be.true;
+  });
   it('close button does not throw when overlay is already removed', async () => {
     await decoratePreviewMode();
     const closeBtn = document.querySelector('.mep-close');


### PR DESCRIPTION
### Summary                                                                        
                                                                                 
  Regression from [MWPW-193436](https://jira.corp.adobe.com/browse/MWPW-193436) / #5845, which fixed the MEP overlay being obscured
   by the federal gnav on C2 pages. That fix used the Popover API
  (popover="manual") to promote the overlay into the browser top layer — but     
  called showPopover() immediately on creation, making the overlay visible in the
   top layer as soon as it was appended to the DOM.                              
                                                                                 
  Previously the overlay was created with style="display:none" and stayed        
  invisible until the user opened the pill. With the Popover API change, the
  overlay is shown unconditionally on init — before the pill's mep-hidden CSS has
   a chance to hide its contents — causing a brief flash.
                                                                               
  The flash appears to happen on GNAV hover because decoratePreviewMode() runs in
   Phase D (~3s after LCP). By that point the user is naturally interacting with
  the page, so the flash coincides with cursor movement and looks                
  hover-triggered. It isn't.
                                                                               
###   Fix

  Defer showPopover() to the badge click handler, called only when the pill is   
  opening (not toggling closed). The overlay stays hidden in the popover state
  until the user first opens it, at which point it's promoted to the top layer as
   intended.      
                                                                                                   
###   Scope                                                                          
  
  Only affects internal/preview users — createPreviewPill() only runs when MEP   
  preview mode is active.
                                                                                 

###   Steps to QA                                                     
  1. Open the Before and After test urls below
  2. wait 3-5 seconds after page load and watch for a flash (described in more detail in ticket)
  **Expected Results**: No modal or overlay flashes on page load or during any
  interaction.                                 
  **Actual Results:** A modal briefly appears and disappears approximately 3 seconds 
  after page load.                                   
                         
Resolves: [MWPW-194181](https://jira.corp.adobe.com/browse/MWPW-194181)

**Test URLs:**
- Before: https://business.stage.adobe.com
- After: https://business.stage.adobe.com/?milolibs=mep-fixflash
- PSI-chech: https://mep-fixflash--milo--adobecom.aem.page/?martech=off


