### PR TITLE
 MWPW-194190 EXTRA_MAS_LANGUAGES

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -182,6 +182,12 @@ const GeoMap = {
 const EXTRA_MAS_LOCALES = { pr: 'es_PR' };
 
 /**
+ * MAS commerce-service `lang` overrides for regions where BCP 47 script subtag is required.
+ * @type {Record<string, string>}
+ */
+const EXTRA_MAS_LANGUAGES = { tw: 'zh-Hant', hk_zh: 'zh-Hant' };
+
+/**
  * Used when 3in1 modals are configured with ms=e or cs=t extra parameter, but 3in1 is disabled.
  * Dexter modals should deeplink to plan=edu or plan=team tabs.
  * @type {Record<string, string>}
@@ -222,7 +228,7 @@ export function getMiloLocaleSettings(miloLocale) {
   }
 
   country = country.toUpperCase();
-  language = language.toLowerCase();
+  language = EXTRA_MAS_LANGUAGES[geo] ?? language.toLowerCase();
 
   return {
     language,


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Adding `EXTRA_MAS_LANGUAGES` to support extra lang support in Taiwan and Hong Kong

Resolves: [MWPW-194190](https://jira.corp.adobe.com/browse/MWPW-194190)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-194190--milo--adobecom.aem.page/?martech=off
- https://main--da-cc--adobecom.aem.page/hk_zh/products/photoshop?milolibs=mwpw-194190
- https://main--da-cc--adobecom.aem.page/tw/products/photoshop?milolibs=mwpw-194190
