### PR TITLE
MWPW-193873 [PEP] CTA Hover State Label Not Readable

### DIFF
--- a/libs/features/webapp-prompt/webapp-prompt.css
+++ b/libs/features/webapp-prompt/webapp-prompt.css
@@ -96,7 +96,7 @@
     line-height: 1.5;
   }
 
-  .appPrompt-cta {
+  .global-navigation button.appPrompt-cta {
     display: flex;
     flex-shrink: 0;
     height: 32px;
@@ -119,14 +119,14 @@
     cursor: pointer;
   }
 
-  .appPrompt-cta--close {
+  .global-navigation button.appPrompt-cta--close {
     background-color: rgb(255, 255, 255);
     border-color: rgb(75, 75, 75);
     color: rgb(75, 75, 75);
   }
 
-  .appPrompt-cta--close:hover,
-  .appPrompt-cta--close:focus {
+  .global-navigation button.appPrompt-cta--close:hover,
+  .global-navigation button.appPrompt-cta--close:focus {
     background-color: rgb(75, 75, 75);
     color: rgb(255, 255, 255);
   }


### PR DESCRIPTION


<!-- Before submitting, please review all open PRs. -->

* The problem was a more specific selector overriding the button styles on hover: https://github.com/adobecom/milo/blob/stage/libs/blocks/global-navigation/global-navigation.css#L10-L13
* The selectors for the hover state of the pep button were made more specific

Resolves: [MWPW-193873](https://jira.corp.adobe.com/browse/MWPW-193873)

https://main--cc--adobecom.aem.page/products/firefly?skipPepEntitlements=true&milolibs=pep-dismiss-button-hover


