### PR TITLE
[MWPW-194099] ACOM FR georoutingv2 changes 

### DIFF
--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -487,11 +487,15 @@ export default async function loadGeoRouting(
   if (storedLocale || storedLocale === '') {
     const urlLocaleGeo = urlLocale.split('_')[0];
     const storedLocaleGeo = storedLocale.split('_')[0];
-    // Show modal when url and cookie disagree
+    // Show modal when url and cookie disagree (skip deprecated cookie rows)
     if (urlLocaleGeo !== storedLocaleGeo) {
       const localeMatches = json.georouting.data.filter(
         (d) => d.prefix === storedLocale,
       );
+      const storedLocaleData = localeMatches[0];
+      const isDeprecatedLocale = storedLocaleData?.akamaiCodes?.trim() === ''
+        && getCodes(urlGeoData).includes(storedLocaleGeo);
+      if (isDeprecatedLocale) return;
       const details = await getDetails(urlGeoData, localeMatches, json.geos.data);
       if (details) {
         handleOverflow(await showModal(details));

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -487,15 +487,15 @@ export default async function loadGeoRouting(
   if (storedLocale || storedLocale === '') {
     const urlLocaleGeo = urlLocale.split('_')[0];
     const storedLocaleGeo = storedLocale.split('_')[0];
-    // Show modal when url and cookie disagree (skip deprecated cookie rows)
+    // Show modal when url and cookie disagree. Skip if base matches and cookie geo is in locale row
     if (urlLocaleGeo !== storedLocaleGeo) {
       const localeMatches = json.georouting.data.filter(
         (d) => d.prefix === storedLocale,
       );
-      const storedLocaleData = localeMatches[0];
-      const isDeprecatedLocale = storedLocaleData?.akamaiCodes?.trim() === ''
+      const storedLocaleBase = config.locales?.[storedLocale]?.base;
+      const isSameBase = storedLocaleBase === urlLocale
         && getCodes(urlGeoData).includes(storedLocaleGeo);
-      if (isDeprecatedLocale) return;
+      if (isSameBase) return;
       const details = await getDetails(urlGeoData, localeMatches, json.geos.data);
       if (details) {
         handleOverflow(await showModal(details));


### PR DESCRIPTION
Updating to treat the baby geo french sites' international cookie on /fr/ as the same site to supress georoutingV2 modal.
Georouting modal would be skipped when base is same and the cookie geo entry(akamaiCoddes) is available on the current locale row in georoutingv2 config.

Resolves: [MWPW-194099](https://jira.corp.adobe.com/browse/MWPW-194099)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw194099--milo--adobecom.aem.page/?martech=off

**QA:**
- https://www.stage.adobe.com/fr/creativecloud.html?akamaiLocale=lu&milolibs=mwpw194099 
with InternationalCookie = lu_fr

