### PR TITLE
[MWPW-194471] Update merge-to-main schedule from 9:00 to 8:48 UTC

### DIFF
--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     types: [labeled]
   schedule:
-    - cron: '0 9 * * *' # Run every day at 9am UTC
+    - cron: '48 8 * * *' # Run every day at 8:48am UTC
   workflow_dispatch: # Allow manual trigger
 
 env:


### PR DESCRIPTION
## Summary
- Changes cron from `0 9 * * *` to `48 8 * * *` in `.github/workflows/merge-to-main.yaml`
- Shifts the daily merge-to-main run 12 minutes earlier (8:48 UTC instead of 9:00 UTC)
PS: Using this weird time to hopefully run the action more consistently as per github [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule)

## Test plan
- [ ] Verify cron expression `48 8 * * *` is correct (minute 48, hour 8 = 08:48 UTC)
- [ ] Confirm no other schedule references need updating

Jira: https://jira.corp.adobe.com/browse/MWPW-194471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- Milo: https://schedule/merge-to-main-0848--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- Milo: https://schedule/merge-to-main-0848--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- Milo: https://schedule/merge-to-main-0848--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=schedule/merge-to-main-0848--milo--adobecom
</details>