### PR TITLE
[MWPW-194479] Fix merge-to-main workflow to trigger on label events from stage to main

### DIFF
--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -17,7 +17,7 @@ jobs:
     environment: milo_pr_merge
     # Run this when manually triggered or on a schedule
     # Otherwise run this only on PRs that are merged from stage to main
-    if: github.repository_owner == 'adobecom' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'stage'))
+    if: github.repository_owner == 'adobecom' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request_target' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'stage'))
 
     steps:
       - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e


### PR DESCRIPTION
### Description
The `pull_request_target` labeled trigger was already defined in the workflow but the job condition checked for `pull_request` event name instead of `pull_request_target`, so label events never actually ran the job.

This fix corrects the condition to match the trigger, improving workflow stability and execution time by allowing the merge to happen immediately when a label is applied rather than waiting for the scheduled run.

Resolves: [MWPW-194479](https://jira.corp.adobe.com/browse/MWPW-194479)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

