### PR TITLE
[MWPW-193582] - Perf parallax scroll

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -985,6 +985,7 @@ p {
          directly — avoids inheriting --parallax-stagger-progress which forces a full
          descendant style-recalc on every scroll frame. */
       view-timeline: --parallax-stagger-timeline block;
+      view-timeline-inset: 40% 10%;
       animation-name: none;
 
       > :not([class*="section-"]) {

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -17,12 +17,6 @@
   initial-value: 1440px;
 }
 
-@property --parallax-stagger-progress {
-  syntax: '<number>';
-  inherits: false;
-  initial-value: 0;
-}
-
 :root {
   /* tokens.primitives */
   --s2a-color-gray-25: #fff;
@@ -981,9 +975,6 @@ p {
   /* Stagger parallax declarations */
   [class*="parallax-stagger-"] {
     @media (width >= 768px) {
-      /* Define a named view-timeline so children can reference the section's scroll position
-         directly — avoids inheriting --parallax-stagger-progress which forces a full
-         descendant style-recalc on every scroll frame. */
       view-timeline: --parallax-stagger-timeline block;
       view-timeline-inset: 40% 10%;
       animation-name: none;

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -19,7 +19,7 @@
 
 @property --parallax-stagger-progress {
   syntax: '<number>';
-  inherits: true;
+  inherits: false;
   initial-value: 0;
 }
 
@@ -981,12 +981,20 @@ p {
   /* Stagger parallax declarations */
   [class*="parallax-stagger-"] {
     @media (width >= 768px) {
-      animation-name: enable-parallax-stagger;
+      /* Define a named view-timeline so children can reference the section's scroll position
+         directly — avoids inheriting --parallax-stagger-progress which forces a full
+         descendant style-recalc on every scroll frame. */
+      view-timeline: --parallax-stagger-timeline block;
+      animation-name: none;
 
       > :not([class*="section-"]) {
         --parallax-stagger-row-index: 0;
 
-        transform: translate3d(0, calc(var(--parallax-stagger-from, 0px) * var(--parallax-stagger-progress)), 0);
+        animation-name: enable-parallax-stagger;
+        animation-timing-function: var(--parallax-easing);
+        animation-fill-mode: both;
+        animation-timeline: --parallax-stagger-timeline;
+        animation-range: var(--parallax-range-start) var(--parallax-range-end);
         will-change: transform;
       }
 
@@ -1070,8 +1078,8 @@ p {
   }
 
   @keyframes enable-parallax-stagger {
-    from { --parallax-stagger-progress: 1; }
-    to { --parallax-stagger-progress: 0; }
+    from { transform: translate3d(0, var(--parallax-stagger-from, 0px), 0); }
+    to { transform: translate3d(0, 0, 0); }
   }
 
   /* Garage door parallax (rich content over section w/ bkg) declarations */
@@ -1143,6 +1151,7 @@ p {
   /* Section 1 to section 2 parallax declarations */
   /* TODO: decide if this is general enough to be a global class */
   .section.parallax-move-up-fast {
+    will-change: transform;
     position: sticky;
     top: 0;
     z-index: 0;


### PR DESCRIPTION
Replaces the `--parallax-stagger-progress` custom property inheritance pattern, previously animating a custom property on the parent forced a full descendant style recalculation on every scroll frame. Now each child owns its own transform keyframe animation tied to a named view-timeline on the parent section, limiting recalc scope to the compositing thread. 
Also adds `will-change: transform` to `.parallax-move-up-fast` to hint the browser to promote the sticky section to its own compositor layer upfront, so the scroll-driven transform animation runs on the compositor thread from the first frame.

Resolves: [MWPW-193582](https://jira.corp.adobe.com/browse/MWPW-193582)

**PSI Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://perf-parallax-scroll--milo--adobecom.aem.page/?martech=off

**Test URLs:**
- Before: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=site-redesign-foundation
- After: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=perf-parallax-scroll

