### PR TITLE
[MWPW-193582] - Constrain explore-card icon to square bounds

### DIFF
--- a/libs/c2/blocks/explore-card/explore-card.css
+++ b/libs/c2/blocks/explore-card/explore-card.css
@@ -95,7 +95,8 @@
 
   img {
     width: 32px;
-    height: auto;
+    height: 32px;
+    object-fit: contain;
   }
 }
 


### PR DESCRIPTION
Fixes icon images in the explore card having an indeterminate height during load by setting an explicit height: 32px alongside the existing width: 32px. Previously height: auto caused the element to collapse to 0 until the image loaded, triggering a layout shift. object-fit: contain preserves the aspect ratio.

Resolves: [MWPW-193582](https://jira.corp.adobe.com/browse/MWPW-193582)

**PSI Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://perf-explore-card-icon-sizing--milo--adobecom.aem.page/?martech=off

**Test URLs:**
- Before: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=site-redesign-foundation
- After: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=perf-explore-card-icon-sizing


