### PR TITLE
[MWPW-193582] - Optimize global footer scroll and resize handling

### DIFF
--- a/libs/c2/blocks/global-footer/global-footer.js
+++ b/libs/c2/blocks/global-footer/global-footer.js
@@ -177,13 +177,12 @@ class Footer {
     if (this.logoResizeHandler) {
       window.removeEventListener('resize', this.logoResizeHandler);
     }
-    let cachedLogoHeight = logo.offsetHeight;
     let scrollPending = false;
     const updateLogoProgress = () => {
       const prevElement = logo?.previousElementSibling;
       if (!prevElement) return;
       const bottom = prevElement.getBoundingClientRect().bottom ?? 0;
-      let progress = ((window.innerHeight - bottom) / cachedLogoHeight) * 100;
+      let progress = ((window.innerHeight - bottom) / logo.offsetHeight) * 100;
       progress = Math.max(0, Math.min(100, progress));
       logo.style.setProperty('--footer-logo-entry-progress', progress);
     };
@@ -199,7 +198,6 @@ class Footer {
       if (this.logoResizeRaf) return;
       this.logoResizeRaf = requestAnimationFrame(() => {
         this.logoResizeRaf = null;
-        cachedLogoHeight = logo.offsetHeight;
         updateLogoProgress();
       });
     };

--- a/libs/c2/blocks/global-footer/global-footer.js
+++ b/libs/c2/blocks/global-footer/global-footer.js
@@ -177,20 +177,29 @@ class Footer {
     if (this.logoResizeHandler) {
       window.removeEventListener('resize', this.logoResizeHandler);
     }
+    let cachedLogoHeight = logo.offsetHeight;
+    let scrollPending = false;
     const updateLogoProgress = () => {
       const prevElement = logo?.previousElementSibling;
       if (!prevElement) return;
-      const rect = prevElement.getBoundingClientRect();
-      const bottom = rect?.bottom ?? 0;
-      let progress = ((window.innerHeight - bottom) / logo.offsetHeight) * 100;
+      const bottom = prevElement.getBoundingClientRect().bottom ?? 0;
+      let progress = ((window.innerHeight - bottom) / cachedLogoHeight) * 100;
       progress = Math.max(0, Math.min(100, progress));
       logo.style.setProperty('--footer-logo-entry-progress', progress);
     };
-    this.logoScrollHandler = updateLogoProgress;
+    this.logoScrollHandler = () => {
+      if (scrollPending) return;
+      scrollPending = true;
+      requestAnimationFrame(() => {
+        updateLogoProgress();
+        scrollPending = false;
+      });
+    };
     this.logoResizeHandler = () => {
       if (this.logoResizeRaf) return;
       this.logoResizeRaf = requestAnimationFrame(() => {
         this.logoResizeRaf = null;
+        cachedLogoHeight = logo.offsetHeight;
         updateLogoProgress();
       });
     };
@@ -266,27 +275,40 @@ class Footer {
       return;
     }
 
-    const menuContents = this.elements.footer?.querySelectorAll('.feds-menu-content');
-    if (!menuContents?.length) return;
+    const menuContents = [...(this.elements.footer?.querySelectorAll('.feds-menu-content') ?? [])];
+    if (!menuContents.length) return;
 
-    menuContents.forEach((menuContent) => {
+    const candidates = menuContents.filter((menuContent) => {
       const columnCount = menuContent.querySelectorAll(':scope > .feds-menu-column').length;
       if (columnCount <= 3) {
         menuContent.classList.remove(FOOTER_MENU_STACKED_CLASS);
-        return;
+        return false;
       }
-
-      menuContent.classList.remove(FOOTER_MENU_STACKED_CLASS);
-      const hasOverflow = menuContent.scrollWidth > menuContent.clientWidth;
-      menuContent.classList.toggle(FOOTER_MENU_STACKED_CLASS, hasOverflow);
+      return true;
     });
+
+    // Batch write: remove stacked class so natural widths are measurable
+    candidates.forEach((menuContent) => menuContent.classList.remove(FOOTER_MENU_STACKED_CLASS));
+
+    // Batch read: one layout flush for all items
+    const overflows = candidates.map(
+      (menuContent) => menuContent.scrollWidth > menuContent.clientWidth,
+    );
+
+    // Batch write: apply stacked class based on measurements
+    candidates.forEach(
+      (menuContent, i) => menuContent.classList.toggle(FOOTER_MENU_STACKED_CLASS, overflows[i]),
+    );
   };
 
   initFooterMenuLayoutSync = () => {
     this.syncFooterMenuLayout();
 
     if (this.footerMenuResizeObserver) return;
-    this.footerMenuResizeObserver = new ResizeObserver(() => {
+    this.footerMenuResizeObserver = new ResizeObserver((entries) => {
+      const width = entries[entries.length - 1]?.contentBoxSize?.[0]?.inlineSize;
+      if (width === this.cachedFooterWidth) return;
+      this.cachedFooterWidth = width;
       if (this.footerMenuResizeRaf) return;
       this.footerMenuResizeRaf = window.requestAnimationFrame(() => {
         this.footerMenuResizeRaf = null;


### PR DESCRIPTION
Three improvements to the footer scroll handler: 

1. Throttles the logo scroll handler with requestAnimationFrame and a scrollPending guard to avoid redundant per-frame work;
2. Caches logo.offsetHeight and only re-reads it on resize instead of every scroll event;
3. Batches the footer menu layout sync — separating DOM reads from writes to avoid interleaved forced reflows, and skips the ResizeObserver callback entirely when the container width hasn't changed.

Resolves: [MWPW-193582](https://jira.corp.adobe.com/browse/MWPW-193582)

**PSI Test URLs:**
Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://perf-global-footer-scroll-optimization--milo--adobecom.aem.page/?martech=off

**Test URLs:**
Before: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=site-redesign-foundation
After: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=perf-global-footer-scroll-optimization






