### PR TITLE
[MWPW-193582] - Optimize global navigation sticky detection and animation layers

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -912,6 +912,7 @@ header.new-nav .feds-nav-wrapper--expanded .feds-nav > section.feds-navItem > bu
   animation: slideleft 0.4s ease, fadein 0.2s ease;
   animation-fill-mode: forwards;
   padding: 15px 20px;
+  will-change: translate, opacity;
 }
 
 [dir = "rtl"] header.new-nav .feds-nav-wrapper--expanded .feds-nav > section.feds-navItem > button.feds-navLink {
@@ -925,6 +926,7 @@ header.new-nav .feds-nav > section.feds-navItem > button.feds-navLink {
   border: none;
   animation: slideright 0.4s ease, fadeout 0.2s ease;
   animation-fill-mode: forwards;
+  will-change: translate, opacity;
 }
 
 [dir = "rtl"] header.new-nav .feds-nav > section.feds-navItem > button.feds-navLink {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -745,30 +745,24 @@ class Gnav {
     if (promo) localNav.classList.add('has-promo');
     this.elements.localNav = localNav;
     firstElem.textContent = title.trim();
-    const isAtTop = () => {
-      const rect = this.elements.localNav.getBoundingClientRect();
-      // note: ios safari changes between -0.34375, 0, and 0.328125
-      return rect.top === 0;
-    };
+    const stickyObserver = new IntersectionObserver(
+      ([entry]) => {
+        this.elements.localNav?.classList.toggle('is-sticky', entry.boundingClientRect.top <= 0);
+      },
+      { threshold: [1] },
+    );
+    stickyObserver.observe(this.elements.localNav);
     window.addEventListener('scroll', (e) => {
       const classList = this.elements.localNav?.classList;
-      if (classList.contains('feds-localnav--active')) {
-        trigger({
-          element: curtain,
-          event: e,
-          type: 'localNav-curtain',
-          animatedElement: itemWrapper,
-          animationType: 'transition',
-        });
-      }
-      if (isAtTop()) {
-        if (!classList?.contains('is-sticky')) {
-          classList?.add('is-sticky');
-        }
-      } else {
-        classList?.remove('is-sticky');
-      }
-    });
+      if (!classList?.contains('feds-localnav--active')) return;
+      trigger({
+        element: curtain,
+        event: e,
+        type: 'localNav-curtain',
+        animatedElement: itemWrapper,
+        animationType: 'transition',
+      });
+    }, { passive: true });
   };
 
   decorateTopnavWrapper = async () => {

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -810,21 +810,27 @@ describe('global navigation', () => {
     });
 
     it('should remove is-sticky class to localnav on scroll less than localnav placement', async () => {
+      let stickyCallback;
+      const OrigIO = window.IntersectionObserver;
+      window.IntersectionObserver = function IOmock(cb) { stickyCallback = cb; };
+      window.IntersectionObserver.prototype = { observe() {}, disconnect() {} };
       await createFullGlobalNavigation({ globalNavigation: gnavWithlocalNav });
+      stickyCallback([{ boundingClientRect: { top: 20 } }]);
+      window.IntersectionObserver = OrigIO;
       const localNav = document.querySelector(selectors.localNav);
-      sinon.stub(localNav, 'getBoundingClientRect').returns({ top: 20 });
-      window.dispatchEvent(new Event('scroll'));
-      const localNavAfterScroll = document.querySelector(selectors.localNav);
-      expect(localNavAfterScroll.classList.contains('is-sticky')).to.be.false;
+      expect(localNav.classList.contains('is-sticky')).to.be.false;
     });
 
     it('should add is-sticky class to localnav on scroll greater than localnav placement', async () => {
+      let stickyCallback;
+      const OrigIO = window.IntersectionObserver;
+      window.IntersectionObserver = function IOmock(cb) { stickyCallback = cb; };
+      window.IntersectionObserver.prototype = { observe() {}, disconnect() {} };
       await createFullGlobalNavigation({ globalNavigation: gnavWithlocalNav });
+      stickyCallback([{ boundingClientRect: { top: 0 } }]);
+      window.IntersectionObserver = OrigIO;
       const localNav = document.querySelector(selectors.localNav);
-      sinon.stub(localNav, 'getBoundingClientRect').returns({ top: 0 });
-      window.dispatchEvent(new Event('scroll'));
-      const localNavAfterScroll = document.querySelector(selectors.localNav);
-      expect(localNavAfterScroll.classList.contains('is-sticky')).to.be.true;
+      expect(localNav.classList.contains('is-sticky')).to.be.true;
     });
 
     it('should open both screen if localnav is present but shows only level 2 screen', async () => {


### PR DESCRIPTION
Replaces the getBoundingClientRect() check in the scroll handler for local nav sticky state with an IntersectionObserver at threshold: 1, removing the layout-triggering rect read from the scroll hot path entirely. The scroll listener is now also marked { passive: true }. Also adds will-change: translate, opacity to the nav link slide/fade animations so the browser promotes those elements to the compositor upfront.

Resolves: [MWPW-193582](https://jira.corp.adobe.com/browse/MWPW-193582)

PSI Test URLs:
Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://perf-global-navigation-optimizations--milo--adobecom.aem.page/?martech=off

Test URLs:
Before: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=site-redesign-foundation
After: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=perf-global-navigation-optimizations


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- Milo: https://perf-global-navigation-optimizations--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- Milo: https://perf-global-navigation-optimizations--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- Milo: https://perf-global-navigation-optimizations--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=perf-global-navigation-optimizations--milo--adobecom
</details>