### PR TITLE
[MWPW-192608] Fix race condition in bulk publish v2 authentication

### DIFF
--- a/libs/blocks/bulk-publish-v2/services.js
+++ b/libs/blocks/bulk-publish-v2/services.js
@@ -79,16 +79,25 @@ const authenticate = async (tool = null) => {
   isPushedDown();
   const setUserV6 = (event) => { tool.user = setUserData(event?.detail?.data); };
   const setUserV7 = (event) => { tool.user = setUserData(event?.detail); };
+
+  const addListeners = (sidekick) => {
+    sidekick.addEventListener('statusfetched', setUserV6); // sidekick v6
+    sidekick.addEventListener('status-fetched', setUserV7); // sidekick v7
+    // Handle race condition where status-fetched fired before listeners were registered
+    const existingStatus = sidekick.appStore?.status;
+    if (existingStatus && Object.keys(existingStatus).length > 0) {
+      tool.user = setUserData(existingStatus);
+    }
+  };
+
   const openSideKick = document.querySelector('aem-sidekick, helix-sidekick');
   if (openSideKick) {
-    openSideKick.addEventListener('statusfetched', setUserV6); // sidekick v6
-    openSideKick.addEventListener('status-fetched', setUserV7); // sidekick v7
-    /* c8 ignore next 6 */
+    addListeners(openSideKick);
+  /* c8 ignore next 5 */
   } else {
     document.addEventListener('sidekick-ready', () => {
       const sidekick = document.querySelector('aem-sidekick, helix-sidekick');
-      sidekick.addEventListener('statusfetched', setUserV6); // sidekick v6
-      sidekick.addEventListener('status-fetched', setUserV7); // sidekick v7
+      addListeners(sidekick);
     }, { once: true });
   }
 };

--- a/test/blocks/bulk-publish-v2/bulk-publish-v2.test.js
+++ b/test/blocks/bulk-publish-v2/bulk-publish-v2.test.js
@@ -266,4 +266,18 @@ describe('Bulk Publish Tool', () => {
     await mouseEvent(rootEl.querySelector('.clear-jobs'));
     expect(rootEl.querySelectorAll('job-process')).to.have.lengthOf(0);
   });
+
+  it('can authenticate when sidekick already has status fetched', async () => {
+    const { authenticate } = await import('../../../libs/blocks/bulk-publish-v2/services.js');
+    const sidekick = document.querySelector('helix-sidekick');
+    sidekick.appStore.status = {
+      profile: { name: 'Unit Test', email: 'tester@adobe.com' },
+      preview: { permissions: ['delete', 'read', 'write', 'list'] },
+      live: { permissions: ['delete', 'read', 'write', 'list'] },
+    };
+    const tool = { user: null };
+    await authenticate(tool);
+    expect(tool.user).to.exist;
+    expect(tool.user.profile.email).to.equal('tester@adobe.com');
+  });
 });

--- a/test/blocks/bulk-publish-v2/mocks/authentication.js
+++ b/test/blocks/bulk-publish-v2/mocks/authentication.js
@@ -1,4 +1,9 @@
 class MockAuth extends HTMLElement {
+  constructor() {
+    super();
+    this.appStore = { status: {} };
+  }
+
   opened() {
     this.dispatchEvent(new CustomEvent('sidekick-ready', { bubbles: true }));
     this.isopen = true;


### PR DESCRIPTION
### Description
Fix race condition in bulk publish v2 where the sidekick `status-fetched` event fires before listeners are registered, causing users to see "open sidekick and sign in" even when the sidekick is already open and logged in.

The fix extracts listener registration into an `addListeners` helper and immediately checks `sidekick.appStore?.status` after attaching listeners to handle the case where the event already fired.

Resolves: [MWPW-192608](https://jira.corp.adobe.com/browse/MWPW-192608)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/tools/bulk-publish
- After: https://mwpw-192608--milo--mokimo.aem.live/tools/bulk-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)







