### PR TITLE
MWPW-193609: force bulk publisher fqdn to prevent cors error

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -563,10 +563,6 @@ function fetchLingoSiteMapping(fqdn = 'www.adobe.com') {
   return lingoSiteMappingPromise;
 }
 
-export function primeFetchLingoSiteMapping(fqdn) {
-  if (!lingoSiteMappingPromise) fetchLingoSiteMapping(fqdn);
-}
-
 async function getIsLingoLocale(origin, country, language, fqdn = 'www.adobe.com') {
   if (origin === 'news') return true;
   const configJson = await fetchLingoSiteMapping(fqdn);

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -565,7 +565,7 @@ function fetchLingoSiteMapping(fqdn = 'www.adobe.com') {
 
 export function initBulkPublisherLingoMapping() {
   lingoSiteMappingPromise = fetch(
-    'https://www.adobe.com/federal/assets/data/lingo-site-mapping.json?bulkpublisher',
+    'https://www.milo.adobe.com/federal/assets/data/lingo-site-mapping.json?bulkpublisher',
   ).then((response) => {
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return response.json();

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -563,6 +563,10 @@ function fetchLingoSiteMapping(fqdn = 'www.adobe.com') {
   return lingoSiteMappingPromise;
 }
 
+export function primeFetchLingoSiteMapping(fqdn) {
+  if (!lingoSiteMappingPromise) fetchLingoSiteMapping(fqdn);
+}
+
 async function getIsLingoLocale(origin, country, language, fqdn = 'www.adobe.com') {
   if (origin === 'news') return true;
   const configJson = await fetchLingoSiteMapping(fqdn);

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -563,6 +563,15 @@ function fetchLingoSiteMapping(fqdn = 'www.adobe.com') {
   return lingoSiteMappingPromise;
 }
 
+export function initBulkPublisherLingoMapping() {
+  lingoSiteMappingPromise = fetch(
+    'https://www.adobe.com/federal/assets/data/lingo-site-mapping.json?bulkpublisher',
+  ).then((response) => {
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return response.json();
+  });
+}
+
 async function getIsLingoLocale(origin, country, language, fqdn = 'www.adobe.com') {
   if (origin === 'news') return true;
   const configJson = await fetchLingoSiteMapping(fqdn);

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -565,7 +565,7 @@ function fetchLingoSiteMapping(fqdn = 'www.adobe.com') {
 
 export function initBulkPublisherLingoMapping() {
   lingoSiteMappingPromise = fetch(
-    'https://www.milo.adobe.com/federal/assets/data/lingo-site-mapping.json?bulkpublisher',
+    'https://milo.adobe.com/federal/assets/data/lingo-site-mapping.json?bulkpublisher',
   ).then((response) => {
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return response.json();

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -1311,7 +1311,7 @@ describe('isLocaleInRegionalSites helper function tests', () => {
 
 describe('initBulkPublisherLingoMapping', () => {
   let ogFetch;
-  const LINGO_MAPPING_URL = 'https://www.adobe.com/federal/assets/data/lingo-site-mapping.json';
+  const LINGO_MAPPING_URL = 'https://milo.adobe.com/federal/assets/data/lingo-site-mapping.json';
 
   beforeEach(() => {
     ogFetch = window.fetch;

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -11,6 +11,7 @@ import {
   getCountryAndLang,
   stageMapToCaasTransforms,
   getGrayboxExperienceId,
+  initBulkPublisherLingoMapping,
 } from '../../../libs/blocks/caas/utils.js';
 
 describe('utils.js export sanity', () => {
@@ -1305,5 +1306,35 @@ describe('isLocaleInRegionalSites helper function tests', () => {
       const result = isLocaleInRegionalSites('/ca, /ie, /nz', 'sg');
       expect(result).to.be.false;
     });
+  });
+});
+
+describe('initBulkPublisherLingoMapping', () => {
+  let ogFetch;
+  const LINGO_MAPPING_URL = 'https://www.adobe.com/federal/assets/data/lingo-site-mapping.json';
+
+  beforeEach(() => {
+    ogFetch = window.fetch;
+  });
+
+  afterEach(() => {
+    window.fetch = ogFetch;
+  });
+
+  it('overwrites a previously cached fqdn with bulkpublisher', async () => {
+    const fetchedUrls = [];
+    window.fetch = stub().callsFake((url) => {
+      fetchedUrls.push(url);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+
+    // Simulate cache already warmed by a different fqdn
+    window.fetch(`${LINGO_MAPPING_URL}?www.adobe.com`);
+    fetchedUrls.length = 0;
+
+    initBulkPublisherLingoMapping();
+
+    expect(fetchedUrls).to.have.length(1);
+    expect(fetchedUrls[0]).to.equal(`${LINGO_MAPPING_URL}?bulkpublisher`);
   });
 });

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -14,7 +14,7 @@ import {
   getConfig,
   setConfig,
 } from './send-utils.js';
-import { getGrayboxExperienceId } from '../../libs/blocks/caas/utils.js';
+import { getGrayboxExperienceId, initBulkPublisherLingoMapping } from '../../libs/blocks/caas/utils.js';
 import comEnterpriseToCaasTagMap from './comEnterpriseToCaasTagMap.js';
 
 const BODY = document.body;
@@ -191,6 +191,8 @@ const processData = async (data, accessToken) => {
   } else if (publishToFloodgate !== 'default') {
     domain = `https://main--${repo}--${owner}.aem.live`;
   }
+
+  initBulkPublisherLingoMapping();
 
   for (const page of data) {
     if (!keepGoing) break;

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -192,8 +192,6 @@ const processData = async (data, accessToken) => {
     domain = `https://main--${repo}--${owner}.aem.live`;
   }
 
-  primeFetchLingoSiteMapping(host);
-
   for (const page of data) {
     if (!keepGoing) break;
 

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -14,7 +14,7 @@ import {
   getConfig,
   setConfig,
 } from './send-utils.js';
-import { getGrayboxExperienceId, primeFetchLingoSiteMapping } from '../../libs/blocks/caas/utils.js';
+import { getGrayboxExperienceId } from '../../libs/blocks/caas/utils.js';
 import comEnterpriseToCaasTagMap from './comEnterpriseToCaasTagMap.js';
 
 const BODY = document.body;

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -14,7 +14,7 @@ import {
   getConfig,
   setConfig,
 } from './send-utils.js';
-import { getGrayboxExperienceId } from '../../libs/blocks/caas/utils.js';
+import { getGrayboxExperienceId, primeFetchLingoSiteMapping } from '../../libs/blocks/caas/utils.js';
 import comEnterpriseToCaasTagMap from './comEnterpriseToCaasTagMap.js';
 
 const BODY = document.body;
@@ -191,6 +191,8 @@ const processData = async (data, accessToken) => {
   } else if (publishToFloodgate !== 'default') {
     domain = `https://main--${repo}--${owner}.aem.live`;
   }
+
+  primeFetchLingoSiteMapping(host);
 
   for (const page of data) {
     if (!keepGoing) break;

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -357,11 +357,9 @@ const getBulkPublishLangAttr = async (options) => {
 const getCountryAndLang = async (options, origin) => {
   const langFirst = lingoActive();
   if (langFirst) {
-    return getLanguageFirstCountryAndLang(
-      window.location.pathname,
-      origin,
-      window.location.hostname,
-    );
+    const isBulkPublisher = window.location.pathname.includes('/tools/send-to-caas/bulkpublisher');
+    const fqdn = isBulkPublisher ? options.host : window.location.hostname;
+    return getLanguageFirstCountryAndLang(window.location.pathname, origin, fqdn);
   }
   /* c8 ignore next */
   const langStr = window.location.pathname.includes('/tools/send-to-caas/bulkpublisher')

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -358,7 +358,7 @@ const getCountryAndLang = async (options, origin) => {
   const langFirst = lingoActive();
   if (langFirst) {
     const isBulkPublisher = window.location.pathname.includes('/tools/send-to-caas/bulkpublisher');
-    const fqdn = isBulkPublisher ? options.host : window.location.hostname;
+    const fqdn = isBulkPublisher ? 'bulkpublisher' : window.location.hostname;
     return getLanguageFirstCountryAndLang(window.location.pathname, origin, fqdn);
   }
   /* c8 ignore next */


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

CaaS Bulk Publish can run using cached authentication/org context.
If the cache reflects an incorrect org (observed: user authenticated to Skyline but not Adobe Inc), the job may proceed and write content to CaaS with incorrect language metadata (often defaulting to EN).

This results in silent data integrity issues and incorrect content surfacing

Resolves: [MWPW-193609](https://jira.corp.adobe.com/browse/MWPW-193609)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-193609--milo--sheridansunier.aem.page/?martech=off
















