### PR TITLE
[MWPW-191882] Update tokens to 0.16 package

### DIFF
--- a/.github/workflows/update-s2a-styles.js
+++ b/.github/workflows/update-s2a-styles.js
@@ -19,8 +19,8 @@ const DEPS_DIR = './libs/c2/styles/deps';
 // flat list of `.tgz` files; the package name has no consistent naming pattern,
 // so it is pinned here and bumped manually when a new release ships.
 const DEPS_RELEASE_BASE_URL = 'https://github.com/adobecom/consonant/raw/main/releases';
-const DEPS_PACKAGE = 'adobecom-s2a-tokens-0.0.14.tgz';
-const DEPS_PACKAGE_SHA256 = '47dc99d6bdd3ebf53402ab4a1c2be3282b822a7dd77e3d6edb76cd2f3e1897c6';
+const DEPS_PACKAGE = 'adobecom-s2a-tokens-0.0.16.tgz';
+const DEPS_PACKAGE_SHA256 = '3a189fc72ff8193205c9ec120babdcec3c467077ef0ac3f74d45a74c2e04c908';
 // Path inside the extracted package that holds the CSS sources we want to
 // mirror into DEPS_DIR.
 const DEPS_PACKAGE_CSS_SUBPATH = path.join('css', 'dev');

--- a/libs/c2/blocks/carousel-c2/carousel-c2.css
+++ b/libs/c2/blocks/carousel-c2/carousel-c2.css
@@ -383,7 +383,7 @@
 }
 
 @keyframes text-enter {
-  from { line-height: 2; }
+  from { line-height: 200%; }
 }
 
 @keyframes button-enter {

--- a/libs/c2/styles/deps/tokens.primitives.css
+++ b/libs/c2/styles/deps/tokens.primitives.css
@@ -221,17 +221,12 @@
   --s2a-font-letter-spacing-neg-2_88: -2.88px;
   --s2a-font-letter-spacing-neg-1_68: -1.68px;
   --s2a-font-letter-spacing-neg-1_44: -1.44px;
-  --s2a-font-letter-spacing-neg-1_2: -1.2px;
   --s2a-font-letter-spacing-neg-1: -1px;
   --s2a-font-letter-spacing-neg-0_96: -0.96px;
   --s2a-font-letter-spacing-neg-0_48: -0.48px;
   --s2a-font-letter-spacing-neg-0_2: -0.2px;
   --s2a-font-letter-spacing-neg-0_16: -0.16px; /** Letter spacing primitive: -0.16px */
   --s2a-font-letter-spacing-0: 0;
-  --s2a-font-letter-spacing-0_12: 0.12px;
-  --s2a-font-letter-spacing-0_14: 0.14px;
-  --s2a-font-letter-spacing-0_16: 0.16px;
-  --s2a-font-letter-spacing-0_24: 0.24px;
 
   /* Font Line Height */
   --s2a-font-line-height-16: 16px;

--- a/libs/c2/styles/deps/tokens.responsive.lg.css
+++ b/libs/c2/styles/deps/tokens.responsive.lg.css
@@ -37,23 +37,23 @@
   --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-sm);
   --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-lg);
   --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-3xl);
-  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-2xl);
+  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-3xl);
   --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-9xl);
-  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-8xl);
-  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-11xl);
+  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
 
   /* Typography / Line Height */
   --s2a-typography-line-height-super: var(--s2a-font-line-height-6xl);
   --s2a-typography-line-height-title-1: var(--s2a-font-line-height-5xl);
   --s2a-typography-line-height-title-2: var(--s2a-font-line-height-3xl);
   --s2a-typography-line-height-title-3: var(--s2a-font-line-height-2xl);
-  --s2a-typography-line-height-title-4: var(--s2a-font-line-height-xl);
+  --s2a-typography-line-height-title-4: var(--s2a-font-line-height-lg);
   --s2a-typography-line-height-title-5: var(--s2a-font-line-height-md);
   --s2a-typography-line-height-title-6: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);

--- a/libs/c2/styles/deps/tokens.responsive.md.css
+++ b/libs/c2/styles/deps/tokens.responsive.md.css
@@ -36,17 +36,17 @@
   --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-md);
   --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-sm);
   --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-xl);
-  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-5xl);
+  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
   --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-9xl);
-  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-11xl);
+  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
 
   /* Typography / Line Height */
   --s2a-typography-line-height-super: var(--s2a-font-line-height-4xl);

--- a/libs/c2/styles/deps/tokens.responsive.sm.css
+++ b/libs/c2/styles/deps/tokens.responsive.sm.css
@@ -21,7 +21,7 @@
   --s2a-typography-font-size-title-2: var(--s2a-font-size-3xl);
   --s2a-typography-font-size-title-3: var(--s2a-font-size-2xl);
   --s2a-typography-font-size-title-4: var(--s2a-font-size-xl);
-  --s2a-typography-font-size-title-5: var(--s2a-font-size-xl);
+  --s2a-typography-font-size-title-5: var(--s2a-font-size-lg);
   --s2a-typography-font-size-title-6: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-lg: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
@@ -34,18 +34,18 @@
   /* Typography / Letter Spacing */
   --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-lg);
   --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-lg);
-  --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-3xl);
+  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-5xl);
   --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-9xl);
-  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-11xl);
+  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
 
   /* Typography / Line Height */
   --s2a-typography-line-height-super: var(--s2a-font-line-height-3xl);

--- a/libs/c2/styles/deps/tokens.responsive.xl.css
+++ b/libs/c2/styles/deps/tokens.responsive.xl.css
@@ -37,23 +37,23 @@
   --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-sm);
   --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-lg);
   --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-3xl);
+  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-2xl);
   --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
   --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-9xl);
-  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-8xl);
-  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-11xl);
+  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
 
   /* Typography / Line Height */
   --s2a-typography-line-height-super: var(--s2a-font-line-height-6xl);
   --s2a-typography-line-height-title-1: var(--s2a-font-line-height-5xl);
   --s2a-typography-line-height-title-2: var(--s2a-font-line-height-3xl);
   --s2a-typography-line-height-title-3: var(--s2a-font-line-height-2xl);
-  --s2a-typography-line-height-title-4: var(--s2a-font-line-height-xl);
+  --s2a-typography-line-height-title-4: var(--s2a-font-line-height-lg);
   --s2a-typography-line-height-title-5: var(--s2a-font-line-height-md);
   --s2a-typography-line-height-title-6: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);

--- a/libs/c2/styles/deps/tokens.semantic.css
+++ b/libs/c2/styles/deps/tokens.semantic.css
@@ -51,16 +51,11 @@
   --s2a-font-letter-spacing-md: var(--s2a-font-letter-spacing-neg-2_88);
   --s2a-font-letter-spacing-lg: var(--s2a-font-letter-spacing-neg-1_68);
   --s2a-font-letter-spacing-xl: var(--s2a-font-letter-spacing-neg-1_44);
-  --s2a-font-letter-spacing-2xl: var(--s2a-font-letter-spacing-neg-1_2);
-  --s2a-font-letter-spacing-3xl: var(--s2a-font-letter-spacing-neg-1);
-  --s2a-font-letter-spacing-4xl: var(--s2a-font-letter-spacing-neg-0_96);
-  --s2a-font-letter-spacing-5xl: var(--s2a-font-letter-spacing-neg-0_48);
-  --s2a-font-letter-spacing-6xl: var(--s2a-font-letter-spacing-neg-0_2);
-  --s2a-font-letter-spacing-7xl: var(--s2a-font-letter-spacing-0);
-  --s2a-font-letter-spacing-8xl: var(--s2a-font-letter-spacing-0_12);
-  --s2a-font-letter-spacing-9xl: var(--s2a-font-letter-spacing-0_14);
-  --s2a-font-letter-spacing-10xl: var(--s2a-font-letter-spacing-0_16);
-  --s2a-font-letter-spacing-11xl: var(--s2a-font-letter-spacing-0_24);
+  --s2a-font-letter-spacing-2xl: var(--s2a-font-letter-spacing-neg-1);
+  --s2a-font-letter-spacing-3xl: var(--s2a-font-letter-spacing-neg-0_96);
+  --s2a-font-letter-spacing-4xl: var(--s2a-font-letter-spacing-neg-0_48);
+  --s2a-font-letter-spacing-5xl: var(--s2a-font-letter-spacing-neg-0_2);
+  --s2a-font-letter-spacing-6xl: var(--s2a-font-letter-spacing-0);
 
   /* Font Line Height */
   --s2a-font-line-height-2xs: var(--s2a-font-line-height-16);

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1174,7 +1174,7 @@ p {
   }
 
   @keyframes garage-door-line-height {
-    from { line-height: 0.6; }
+    from { line-height: 60%; }
   }
 
   /* Section 1 to section 2 parallax declarations */

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -215,16 +215,11 @@
   --s2a-font-letter-spacing-neg-2_88: -2.88px;
   --s2a-font-letter-spacing-neg-1_68: -1.68px;
   --s2a-font-letter-spacing-neg-1_44: -1.44px;
-  --s2a-font-letter-spacing-neg-1_2: -1.2px;
   --s2a-font-letter-spacing-neg-1: -1px;
   --s2a-font-letter-spacing-neg-0_96: -0.96px;
   --s2a-font-letter-spacing-neg-0_48: -0.48px;
   --s2a-font-letter-spacing-neg-0_2: -0.2px;
   --s2a-font-letter-spacing-neg-0_16: -0.16px;
-  --s2a-font-letter-spacing-0_12: 0.12px;
-  --s2a-font-letter-spacing-0_14: 0.14px;
-  --s2a-font-letter-spacing-0_16: 0.16px;
-  --s2a-font-letter-spacing-0_24: 0.24px;
   --s2a-font-line-height-16: 16px;
   --s2a-font-line-height-18: 18px;
   --s2a-font-line-height-20: 20px;
@@ -299,16 +294,11 @@
   --s2a-font-letter-spacing-md: var(--s2a-font-letter-spacing-neg-2_88);
   --s2a-font-letter-spacing-lg: var(--s2a-font-letter-spacing-neg-1_68);
   --s2a-font-letter-spacing-xl: var(--s2a-font-letter-spacing-neg-1_44);
-  --s2a-font-letter-spacing-2xl: var(--s2a-font-letter-spacing-neg-1_2);
-  --s2a-font-letter-spacing-3xl: var(--s2a-font-letter-spacing-neg-1);
-  --s2a-font-letter-spacing-4xl: var(--s2a-font-letter-spacing-neg-0_96);
-  --s2a-font-letter-spacing-5xl: var(--s2a-font-letter-spacing-neg-0_48);
-  --s2a-font-letter-spacing-6xl: var(--s2a-font-letter-spacing-neg-0_2);
-  --s2a-font-letter-spacing-7xl: var(--s2a-font-letter-spacing-0);
-  --s2a-font-letter-spacing-8xl: var(--s2a-font-letter-spacing-0_12);
-  --s2a-font-letter-spacing-9xl: var(--s2a-font-letter-spacing-0_14);
-  --s2a-font-letter-spacing-10xl: var(--s2a-font-letter-spacing-0_16);
-  --s2a-font-letter-spacing-11xl: var(--s2a-font-letter-spacing-0_24);
+  --s2a-font-letter-spacing-2xl: var(--s2a-font-letter-spacing-neg-1);
+  --s2a-font-letter-spacing-3xl: var(--s2a-font-letter-spacing-neg-0_96);
+  --s2a-font-letter-spacing-4xl: var(--s2a-font-letter-spacing-neg-0_48);
+  --s2a-font-letter-spacing-5xl: var(--s2a-font-letter-spacing-neg-0_2);
+  --s2a-font-letter-spacing-6xl: var(--s2a-font-letter-spacing-0);
   --s2a-font-line-height-2xs: var(--s2a-font-line-height-16);
   --s2a-font-line-height-xs: var(--s2a-font-line-height-18);
   --s2a-font-line-height-sm: var(--s2a-font-line-height-20);
@@ -398,7 +388,7 @@
   --s2a-typography-font-size-title-2: var(--s2a-font-size-3xl);
   --s2a-typography-font-size-title-3: var(--s2a-font-size-2xl);
   --s2a-typography-font-size-title-4: var(--s2a-font-size-xl);
-  --s2a-typography-font-size-title-5: var(--s2a-font-size-xl);
+  --s2a-typography-font-size-title-5: var(--s2a-font-size-lg);
   --s2a-typography-font-size-title-6: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-xs: var(--s2a-font-size-xs);
   --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
@@ -409,18 +399,18 @@
   --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
   --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-lg);
   --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-lg);
-  --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-3xl);
+  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-5xl);
   --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-9xl);
-  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-10xl);
-  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-7xl);
-  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-11xl);
+  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-line-height-super: var(--s2a-font-line-height-3xl);
   --s2a-typography-line-height-title-1: var(--s2a-font-line-height-xl);
   --s2a-typography-line-height-title-2: var(--s2a-font-line-height-lg);
@@ -1232,7 +1222,7 @@ p {
   }
 
   @keyframes text-reveal-up {
-    from { line-height: 3; }
+    from { line-height: 300%; }
   }
 }
 
@@ -1291,12 +1281,13 @@ p {
     --s2a-typography-font-size-title-2: var(--s2a-font-size-6xl);
     --s2a-typography-font-size-title-3: var(--s2a-font-size-3xl);
     --s2a-typography-font-size-title-4: var(--s2a-font-size-2xl);
+    --s2a-typography-font-size-title-5: var(--s2a-font-size-xl);
     --s2a-typography-font-size-body-xs: var(--s2a-font-size-sm);
     --s2a-typography-font-size-body-lg: var(--s2a-font-size-lg);
     --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-md);
     --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-sm);
     --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-xl);
-    --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-5xl);
+    --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
     --s2a-typography-line-height-super: var(--s2a-font-line-height-4xl);
     --s2a-typography-line-height-title-1: var(--s2a-font-line-height-3xl);
     --s2a-typography-line-height-title-2: var(--s2a-font-line-height-2xl);
@@ -1314,7 +1305,6 @@ p {
     --s2a-viewport-vertical-padding-md: var(--s2a-layout-lg);
     --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl);
     --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl);
-    --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-8xl);
     --s2a-typography-font-size-super: var(--s2a-font-size-11xl);
     --s2a-typography-font-size-title-1: var(--s2a-font-size-10xl);
     --s2a-typography-font-size-title-2: var(--s2a-font-size-7xl);
@@ -1326,13 +1316,13 @@ p {
     --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-xs);
     --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-lg);
     --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-xl);
-    --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-3xl);
-    --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
+    --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-2xl);
+    --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-3xl);
     --s2a-typography-line-height-super: var(--s2a-font-line-height-6xl);
     --s2a-typography-line-height-title-1: var(--s2a-font-line-height-5xl);
     --s2a-typography-line-height-title-2: var(--s2a-font-line-height-3xl);
     --s2a-typography-line-height-title-3: var(--s2a-font-line-height-2xl);
-    --s2a-typography-line-height-title-4: var(--s2a-font-line-height-xl);
+    --s2a-typography-line-height-title-4: var(--s2a-font-line-height-lg);
     --s2a-typography-line-height-title-5: var(--s2a-font-line-height-md);
   }
 }
@@ -1340,5 +1330,6 @@ p {
 @media (width >= 1440px) {
   :root {
     /* tokens.responsive.xl */
+    --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
   }
 }

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1154,7 +1154,7 @@ p {
       * {
         animation: garage-door-line-height ease-out both;
         animation-timeline: view();
-        animation-range: entry 10% cover 40%;
+        animation-range: entry 30% cover 60%;
       }
     }
   }


### PR DESCRIPTION
This updates our tokens to 0.0.16, the latest package from Consonant. Removed tokens are not referenced directly by CSS. The line-height animation had to be adapted to use a unit, now that our regular line-heights have units.

This is an iteration of https://github.com/adobecom/milo/pull/5873.

Resolves: [MWPW-191882](https://jira.corp.adobe.com/browse/MWPW-191882)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=site-redesign-foundation&georouting=off
- After: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=token-pipeline-update-0-16&georouting=off






