### PR TITLE
[Lingo] MWPW-194572 Discard preview path that are configiured for redirection

### DIFF
--- a/.github/workflows/preview-indexer/internal/helix-client.js
+++ b/.github/workflows/preview-indexer/internal/helix-client.js
@@ -152,7 +152,6 @@ async function getPreviewPathsForRegion(siteOrg, siteRepo, regionPath) {
   const body = {
     select: ['preview'],
     paths: [`${path}*`],
-    pathsOnly: true,
     forceAsync: true,
   };
   const initialUrl = `https://admin.hlx.page/status/${siteOrg}/${siteRepo}/main/*`;
@@ -178,7 +177,12 @@ async function getPreviewPathsForRegion(siteOrg, siteRepo, regionPath) {
     });
     const detailsJson = detailsResponse.data;
     const isCompleted = detailsJson?.data?.phase === 'completed';
-    return isCompleted ? detailsJson?.data?.resources?.preview || [] : [];
+    if (isCompleted && detailsJson?.data?.resources?.length) {
+      return detailsJson?.data?.resources
+        .filter((data) => !data.previewConfigRedirectLocation)
+        .map((data) => data.path) || [];
+    }
+    return [];
   }
   console.error(`Job not stopped: ${job.links.self}`);
   throw new Error(`Job not stopped: ${job.links.self}`);


### PR DESCRIPTION
Paths that have redirections setup are not added into query-index. Apply the same for query-index preview

Resolves: [MWPW-194572](https://jira.corp.adobe.com/browse/MWPW-194572)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://main--milo--adobecom.aem.page/?martech=off


