### PR TITLE
[MWPW-194599] Fix zero-impact PRs being blocked by batch merge limit

### DIFF
--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -134,7 +134,7 @@ const merge = async ({ prs, type }) => {
 
   for await (const { number, files, html_url, title } of prs) {
     try {
-      if (mergeLimitExceeded()) return;
+      if (type !== LABELS.zeroImpact && mergeLimitExceeded()) return;
       if (!process.env.LOCAL_RUN) {
         await github.rest.pulls.merge({
           owner,


### PR DESCRIPTION
### Description
Zero-impact PRs should always be merged regardless of the MAX_MERGES limit. The `mergeLimitExceeded()` check inside the `merge()` function was returning early for all PR types — including zero-impact — preventing them from being added to a batch when it was already full.

**Fix:** Skip the limit check when the PR type is `zero-impact`:
```js
if (type !== LABELS.zeroImpact && mergeLimitExceeded()) return;
```

Resolves: [MWPW-194599](https://jira.corp.adobe.com/browse/MWPW-194599)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

