### PR TITLE
MWPW-193054: Add 'edu' as a CaaS source

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -193,6 +193,7 @@ const defaultOptions = {
   source: {
     bacom: 'Bacom',
     doccloud: 'DocCloud',
+    edu: 'Edu',
     events: 'Events',
     experienceleague: 'Experience League',
     hawks: 'Hawks',

--- a/libs/blocks/caas-config/caas-tags.js
+++ b/libs/blocks/caas-config/caas-tags.js
@@ -11218,6 +11218,16 @@ const caasTags = {
               'cq:movedTo': '',
               tags: {},
             },
+            edu: {
+              path: '/content/cq:tags/caas/source/edu',
+              tagID: 'caas:source/edu',
+              name: 'edu',
+              tagImage: '',
+              title: 'Edu',
+              description: '',
+              'cq:movedTo': '',
+              tags: {},
+            },
             marketo: {
               path: '/content/cq:tags/caas/source/marketo',
               tagID: 'caas:source/marketo',


### PR DESCRIPTION
## Resolves
[MWPW-193054](https://jira.corp.adobe.com/browse/MWPW-193054): Add a Chimera source for the new Adobe Education Hub (`www.adobe.com/education`) launching ~5/21 so its content can be discovered, referenced, and surfaced in CaaS collections across adobe.com.

## Changes
Two-file diff (+11 lines) wiring `edu` into the Configurator's source dropdown and the bundled tag taxonomy fallback:

- `libs/blocks/caas-config/caas-config.js`: adds `edu: 'Edu'` to `defaultOptions.source` so authors can select it in the Configurator UI.
- `libs/blocks/caas-config/caas-tags.js`: adds the `edu` source taxonomy node (`caas:source/edu`) under `caas:source.tags` so tag validation falls back gracefully when the live taxonomy fetch fails.

## Out of scope (handled separately)
- Canonical `caas:source/edu` registration in the chimera taxonomy at `www.adobe.com/chimera-api/tags`, submitted via the standard Javelin tag-request process.
- `edu` row in `bppresets.json` (`milo.adobe.com/drafts/caas/bppresets.json`), already added.
- `lingo-site-mapping.json` registration, deferred until edu adds non-English locales (5/13 launch is English-only at `/education/`, which doesn't require langFirst registration).

## Testing

You can see it fully implemented and added here: 

<img width="917" height="757" alt="image" src="https://github.com/user-attachments/assets/cf8763f6-5f55-41c0-b92d-711e10e211a5" />

- `defaultOptions.source` map is sorted alphabetically; `edu` placed between `doccloud` and `events`, matches the existing convention.
- `caas-tags.js` source node placed adjacent to `doccloud`, mirrors the existing schema (`path`, `tagID`, `name`, `tagImage`, `title`, `description`, `cq:movedTo`, `tags`).
- No behavior change for any existing source; purely additive.