### PR TITLE
 MWPW-194203 / MWPW-194204 [MEP] Highlight CaaS + M@S content in MEP preview

### DIFF
--- a/libs/blocks/caas/caas.js
+++ b/libs/blocks/caas/caas.js
@@ -1,4 +1,5 @@
 import {
+  mepCaasConfigUrls,
   decodeCompressedString,
   initCaas,
   loadCaasFiles,
@@ -60,6 +61,8 @@ const loadCaas = async (a) => {
   a.insertAdjacentElement('afterend', modalDiv);
 
   a.insertAdjacentElement('afterend', block);
+  block.dataset.caasBlock = '';
+  mepCaasConfigUrls.set(block, a.href);
   a.remove();
 
   const langFirst = getMetadata('langfirst');

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -12,6 +12,9 @@ import { getLingoActive } from '../../utils/lingo-active.js';
 import { fetchWithTimeout } from '../utils/utils.js';
 import getUuid from '../../utils/getUuid.js';
 
+// CaaS deep-link URL per wrapper element, keyed off-DOM for MEP preview (URL too large for data-*).
+export const mepCaasConfigUrls = new WeakMap();
+
 export const LANGS = {
   en: 'en',
   de: 'de',
@@ -1225,11 +1228,16 @@ export const initCaas = async (state, caasStrs, el) => {
   if (!caasEl) return;
 
   const appEl = caasEl.parentElement;
+  const preservedConfigUrl = mepCaasConfigUrls.get(caasEl);
   caasEl.remove();
 
   const newEl = document.createElement('div');
   newEl.id = 'caas';
   newEl.className = 'caas-preview';
+  if (preservedConfigUrl) {
+    newEl.dataset.caasBlock = '';
+    mepCaasConfigUrls.set(newEl, preservedConfigUrl);
+  }
   appEl.append(newEl);
 
   const config = await getConfig(state, caasStrs);

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -1,6 +1,7 @@
 import { createTag, getConfig } from '../../utils/utils.js';
 import { decorateButtons, getBlockSize } from '../../utils/decorate.js';
 import { postProcessAutoblock } from '../merch/autoblock.js';
+import { mepMasStudioUrls } from '../merch/mas-mep-utils.js';
 import {
   initService,
   getOptions,
@@ -145,6 +146,11 @@ export async function createCard(el, options) {
   seenFragments.add(options.fragment);
   const aemFragment = createTag('aem-fragment', attrs);
   const merchCard = createTag('merch-card', { consonant: '' }, aemFragment);
+  // For the "Edit Card" mep preview badge.
+  if (getConfig()?.mep?.preview) {
+    mepMasStudioUrls.set(merchCard, el.href);
+    merchCard.dataset.masBlock = 'card';
+  }
   const parent = el.parentElement;
   if (parent && parent.tagName === 'P' && parent.children.length === 1) {
     parent.replaceWith(merchCard);
@@ -162,6 +168,10 @@ async function createInline(el, options) {
   seenFragments.add(options.fragment);
   const aemFragment = createTag('aem-fragment', attrs);
   const masField = createTag('mas-field', { field: options.field }, aemFragment);
+  if (getConfig()?.mep?.preview) {
+    mepMasStudioUrls.set(masField, el.href);
+    masField.dataset.masBlock = 'inline';
+  }
   el.replaceWith(masField);
   await checkReady(masField);
   normalizeBlockFieldWrappers(masField);

--- a/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
+++ b/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
@@ -1,6 +1,7 @@
 import { createTag, getConfig, localizeLinkAsync } from '../../utils/utils.js';
 import { debounce } from '../../utils/action.js';
 import { postProcessAutoblock, handleCustomAnalyticsEvent } from '../merch/autoblock.js';
+import { mepMasStudioUrls } from '../merch/mas-mep-utils.js';
 import {
   initService,
   getOptions,
@@ -320,6 +321,17 @@ export async function createCollection(el, options) {
   }
   const collection = createTag('merch-card-collection', attributes, aemFragment);
   const container = createTag('div', null, collection);
+  if (getConfig()?.mep?.preview) {
+    mepMasStudioUrls.set(container, el.href);
+    container.dataset.masBlock = 'collection';
+    // Attach BEFORE the replaceWith below — M@S removes aem-fragment
+    // immediately after dispatching aem:load. Dynamic import keeps
+    // preview-only code out of the production bundle.
+    const { attachAemLoadListener } = await import(
+      '../../features/personalization/preview-mas-subcollection.js'
+    );
+    attachAemLoadListener(aemFragment, container);
+  }
   const paragraph = el.parentElement;
   const toReplace = paragraph?.tagName === 'P' && hasOnlyTargetContent(paragraph, el)
     ? paragraph

--- a/libs/blocks/merch/mas-mep-utils.js
+++ b/libs/blocks/merch/mas-mep-utils.js
@@ -1,0 +1,4 @@
+// Only populated when MEP preview is active; WeakMap so entries
+// GC with their host element.
+// eslint-disable-next-line import/prefer-default-export
+export const mepMasStudioUrls = new WeakMap();

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -3,6 +3,7 @@ import {
   shouldAllowKrTrial, getCountry,
 } from '../../utils/utils.js';
 import { replaceKey } from '../../features/placeholders.js';
+import { mepMasStudioUrls } from './mas-mep-utils.js';
 
 // MAS Component Names
 export const COMMERCE_LIBRARY = 'commerce';
@@ -1554,6 +1555,12 @@ export default async function init(el) {
   log = service.Log.module('merch');
   if (merch) {
     log.debug('Rendering:', { options: { ...merch.dataset }, merch, el });
+    // Rebuilt merch href keeps only the OSI; stash the original for
+    // the "Edit OSI" badge.
+    if (getConfig()?.mep?.preview) {
+      mepMasStudioUrls.set(merch, el.href);
+      merch.dataset.masBlock = 'ost';
+    }
     el.replaceWith(merch);
     return merch;
   }

--- a/libs/blocks/ost/ost.js
+++ b/libs/blocks/ost/ost.js
@@ -160,10 +160,12 @@ export async function loadOstEnv() {
     }
     window.history.replaceState({}, null, `${window.location.origin}${window.location.pathname}?${searchParameters.toString()}`);
   }
+  const countryParam = searchParameters.get('country');
   const attributes = { 'allow-override': 'true' };
   if (masDefaultsEnabled) {
     attributes['data-mas-ff-defaults'] = 'on';
   }
+  if (countryParam) attributes.country = countryParam.toUpperCase();
   await initService(true, attributes);
   // Load commerce.js based on masLibs parameter
   masCommerceService = await loadMasComponent(COMMERCE_LIBRARY);
@@ -239,6 +241,7 @@ export async function loadOstEnv() {
   const repo = searchParameters.get('repo');
 
   let { country, language } = getMiloLocaleSettings();
+  if (countryParam) country = countryParam;
   const { locales } = getConfig();
   const log = Log.module('ost');
   const metadata = {};

--- a/libs/features/personalization/preview-mas-subcollection.js
+++ b/libs/features/personalization/preview-mas-subcollection.js
@@ -1,0 +1,175 @@
+// MEP "Highlight M@S Content" — sub-collection edit badges.
+//
+// A <merch-card-collection> can host sub-collections surfaced in the
+// sidenav (e.g., plans-page categories: Photo / Video / Design). When the
+// user picks one, we render an "Edit Sub-collection" badge linking into
+// M@S Studio.
+//
+// Capture is wired by the autoblock via attachAemLoadListener BEFORE
+// decoration: the M@S collection web component removes the parent
+// <aem-fragment> immediately after dispatching aem:load, so its rawData
+// can't be read after the fact.
+
+import { createTag } from '../../utils/utils.js';
+import { mepMasStudioUrls } from '../../blocks/merch/mas-mep-utils.js';
+
+export const SUB_COLLECTION_BADGE_CLASS = 'mep-mas-sub-collection-badge';
+
+// container -> Array<{ id, label, queryLabel }>
+export const mepMasSubCollections = new WeakMap();
+
+// Walks the referencesTree carried by aem:load.detail (mirrors the shape
+// in mas/web-components/src/merch-card-collection.js). Sub-collections are
+// nodes whose fieldName isn't 'cards' or 'variations'. Recurses for nested
+// catalog hierarchies.
+export function extractSubCollections(payload) {
+  if (!payload) return [];
+  const { references, referencesTree } = payload;
+  if (!Array.isArray(referencesTree) || !references) return [];
+  const out = [];
+  const seen = new Set();
+  function walk(nodes) {
+    nodes.forEach((node) => {
+      if (!node || typeof node !== 'object') return;
+      const { identifier, fieldName } = node;
+      if (!identifier || seen.has(identifier)) return;
+      if (fieldName === 'cards' || fieldName === 'variations') return;
+      const fields = references[identifier]?.value?.fields;
+      if (fields && (fields.label || fields.queryLabel)) {
+        seen.add(identifier);
+        out.push({
+          id: identifier,
+          label: fields.label || '',
+          queryLabel: fields.queryLabel || '',
+        });
+      }
+      if (Array.isArray(node.referencesTree) && node.referencesTree.length) {
+        walk(node.referencesTree);
+      }
+    });
+  }
+  walk(referencesTree);
+  return out;
+}
+
+export function getSubCollectionsFor(container) {
+  if (!container) return [];
+  return mepMasSubCollections.get(container) || [];
+}
+
+// One-shot aem:load capture — must be attached pre-decoration because M@S
+// removes the aem-fragment immediately after dispatching the event.
+export function attachAemLoadListener(aemFragment, container) {
+  if (!aemFragment || !container) return;
+  aemFragment.addEventListener('aem:load', (event) => {
+    const subCollections = extractSubCollections(event.detail);
+    if (subCollections.length) {
+      mepMasSubCollections.set(container, subCollections);
+    }
+  }, { once: true });
+}
+
+// Rewrites the parent's Studio URL to open the named sub-collection in
+// fragment-editor view. content-type stays as merch-card-collection
+// (sub-collections are themselves collections).
+export function toSubCollectionStudioUrl(parentUrl, subCollectionId) {
+  if (!parentUrl || !subCollectionId) return parentUrl;
+  try {
+    const u = new URL(parentUrl, window.location.origin);
+    const hash = (u.hash || '').replace(/^#/, '');
+    const hp = new URLSearchParams(hash);
+    if (hp.has('fragmentId')) hp.set('fragmentId', subCollectionId);
+    else if (hp.has('query')) hp.set('query', subCollectionId);
+    else if (hp.has('fragment')) hp.set('fragment', subCollectionId);
+    else hp.set('fragmentId', subCollectionId);
+    hp.set('page', 'fragment-editor');
+    if (!hp.get('content-type')) hp.set('content-type', 'merch-card-collection');
+    u.hash = `#${hp.toString()}`;
+    return u.toString();
+  } catch (e) {
+    return parentUrl;
+  }
+}
+
+// The badge lives OUTSIDE the container (see CRITICAL note in
+// injectSubCollectionBadge), so we walk back through any sibling MEP
+// edit-badges to find ours. Without the walk, restamp passes that
+// re-insert the parent badge would orphan the previous sub badge.
+function findExistingBadge(container) {
+  let prev = container.previousElementSibling;
+  while (prev) {
+    if (prev.classList?.contains(SUB_COLLECTION_BADGE_CLASS)) return prev;
+    if (!prev.classList?.contains('mep-mas-edit-badge')) return null;
+    prev = prev.previousElementSibling;
+  }
+  return null;
+}
+
+export function injectSubCollectionBadge(container, pageMarket) {
+  if (!container) return;
+  // Skip hidden tab variants (e.g., plans page wraps each tab —
+  // Individuals / Business / Students / Schools — in its own container).
+  // Without this guard we'd render one badge per tab. offsetHeight covers
+  // position:fixed where offsetParent can be null on visible elements.
+  if (!container.offsetParent && container.offsetHeight === 0) {
+    findExistingBadge(container)?.remove();
+    return;
+  }
+  const collection = container.querySelector('merch-card-collection');
+  const filter = (collection?.getAttribute('filter') || '').trim();
+  const subs = getSubCollectionsFor(container);
+  const existing = findExistingBadge(container);
+
+  if (!filter || filter === 'all' || !subs.length) {
+    existing?.remove();
+    return;
+  }
+
+  const active = subs.find((s) => s.queryLabel === filter);
+  if (!active) {
+    existing?.remove();
+    return;
+  }
+
+  const parentUrl = mepMasStudioUrls.get(container);
+  if (!parentUrl) {
+    existing?.remove();
+    return;
+  }
+  const url = toSubCollectionStudioUrl(parentUrl, active.id);
+  const marketSuffix = pageMarket ? ` \u00b7 ${pageMarket.toUpperCase()}` : '';
+  const labelText = `Edit Sub-collection: ${active.label || active.queryLabel}${marketSuffix}`;
+
+  if (existing) {
+    if (existing.dataset.mepMasSubId === active.id
+      && existing.dataset.mepMasMarket === (pageMarket || '')) {
+      return;
+    }
+    existing.href = url;
+    existing.textContent = labelText;
+    existing.dataset.mepMasSubId = active.id;
+    existing.dataset.mepMasMarket = pageMarket || '';
+    return;
+  }
+
+  const a = createTag(
+    'a',
+    {
+      class: SUB_COLLECTION_BADGE_CLASS,
+      href: url,
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    },
+    labelText,
+  );
+  a.dataset.mepMasSubId = active.id;
+  a.dataset.mepMasMarket = pageMarket || '';
+  // CRITICAL: insert OUTSIDE the container, not inside. The container is a
+  // CSS grid (.collection-container.plans uses grid-template-areas) — a
+  // 4th grid child would auto-place at the bottom, well below the cards.
+  container.insertAdjacentElement('beforebegin', a);
+}
+
+export function removeSubCollectionBadges() {
+  document.querySelectorAll(`a.${SUB_COLLECTION_BADGE_CLASS}`).forEach((el) => el.remove());
+}

--- a/libs/features/personalization/preview-mas-subcollection.js
+++ b/libs/features/personalization/preview-mas-subcollection.js
@@ -160,8 +160,8 @@ export function injectSubCollectionBadge(container, pageMarket) {
       target: '_blank',
       rel: 'noopener noreferrer',
     },
-    labelText,
   );
+  a.textContent = labelText;
   a.dataset.mepMasSubId = active.id;
   a.dataset.mepMasMarket = pageMarket || '';
   // CRITICAL: insert OUTSIDE the container, not inside. The container is a

--- a/libs/features/personalization/preview-mas-subcollection.js
+++ b/libs/features/personalization/preview-mas-subcollection.js
@@ -18,10 +18,9 @@ export const SUB_COLLECTION_BADGE_CLASS = 'mep-mas-sub-collection-badge';
 // container -> Array<{ id, label, queryLabel }>
 export const mepMasSubCollections = new WeakMap();
 
-// Walks the referencesTree carried by aem:load.detail (mirrors the shape
-// in mas/web-components/src/merch-card-collection.js). Sub-collections are
-// nodes whose fieldName isn't 'cards' or 'variations'. Recurses for nested
-// catalog hierarchies.
+// Walks referencesTree from aem:load.detail (shape: mas/web-components/
+// src/merch-card-collection.js). Sub-collections have fields.queryLabel
+// — that's what the sidenav matches against. Recurses for nested catalogs.
 export function extractSubCollections(payload) {
   if (!payload) return [];
   const { references, referencesTree } = payload;
@@ -31,17 +30,17 @@ export function extractSubCollections(payload) {
   function walk(nodes) {
     nodes.forEach((node) => {
       if (!node || typeof node !== 'object') return;
-      const { identifier, fieldName } = node;
-      if (!identifier || seen.has(identifier)) return;
-      if (fieldName === 'cards' || fieldName === 'variations') return;
-      const fields = references[identifier]?.value?.fields;
-      if (fields && (fields.label || fields.queryLabel)) {
-        seen.add(identifier);
-        out.push({
-          id: identifier,
-          label: fields.label || '',
-          queryLabel: fields.queryLabel || '',
-        });
+      const { identifier } = node;
+      if (identifier && !seen.has(identifier)) {
+        const fields = references[identifier]?.value?.fields;
+        if (fields?.queryLabel) {
+          seen.add(identifier);
+          out.push({
+            id: identifier,
+            label: fields.label || '',
+            queryLabel: fields.queryLabel,
+          });
+        }
       }
       if (Array.isArray(node.referencesTree) && node.referencesTree.length) {
         walk(node.referencesTree);

--- a/libs/features/personalization/preview.css
+++ b/libs/features/personalization/preview.css
@@ -683,16 +683,17 @@ body[data-mep-highlight='true'] .section[class*="-merch-cards"] .fragment[data-m
   display: none;
 }
 
-/* CaaS region highlights ----------------------------------------------------- */
-body[data-mep-caas-highlight='true'] [data-country]:not([data-country='xx']),
-body[data-mep-caas-highlight='true'] [data-country='xx'] {
+/* CaaS region highlights — scoped to [data-caas-block] descendants so unrelated
+   [data-country] elements (country pickers, form inputs, etc.) are unaffected. */
+body[data-mep-caas-highlight='true'] [data-caas-block] [data-country]:not([data-country='xx']),
+body[data-mep-caas-highlight='true'] [data-caas-block] [data-country='xx'] {
   outline: 2px dashed transparent;
   outline-offset: 2px;
   position: relative !important;
 }
 
-body[data-mep-caas-highlight='true'] [data-country]:not([data-country='xx'])::before,
-body[data-mep-caas-highlight='true'] [data-country='xx']::before {
+body[data-mep-caas-highlight='true'] [data-caas-block] [data-country]:not([data-country='xx'])::before,
+body[data-mep-caas-highlight='true'] [data-caas-block] [data-country='xx']::before {
   font-size: 14px !important;
   font-weight: 400 !important;
   min-height: 20px !important;
@@ -719,25 +720,31 @@ body[data-mep-caas-highlight='true'] [data-country='xx']::before {
 }
 
 /* Market-specific (any country code other than xx) - green */
-body[data-mep-caas-highlight='true'] [data-country]:not([data-country='xx']) {
+body[data-mep-caas-highlight='true'] [data-caas-block] [data-country]:not([data-country='xx']) {
   outline-color: #28a745;
 }
 
-body[data-mep-caas-highlight='true'] [data-country]:not([data-country='xx'])::before {
+body[data-mep-caas-highlight='true'] [data-caas-block] [data-country]:not([data-country='xx'])::before {
   content: '🔗 caas-market: ' attr(data-card-path);
   background-color: #d4edda !important;
   border: 1px solid #28a745;
 }
 
 /* Lang-first / global (xx) - yellow */
-body[data-mep-caas-highlight='true'] [data-country='xx'] {
+body[data-mep-caas-highlight='true'] [data-caas-block] [data-country='xx'] {
   outline-color: #ffc107;
 }
 
-body[data-mep-caas-highlight='true'] [data-country='xx']::before {
+body[data-mep-caas-highlight='true'] [data-caas-block] [data-country='xx']::before {
   content: '🔗 caas-lang: ' attr(data-card-path);
   background-color: #fff3cd !important;
   border: 1px solid #ffc107;
+}
+
+/* Cards with no resolvable source URL (no data-card-url, or unparseable) — the
+   badge would otherwise show "🔗 caas-market: " with an empty path. */
+body[data-mep-caas-highlight='true'] [data-caas-block] [data-country][data-card-path='']::before {
+  content: none;
 }
 
 /* CaaS collection wrapper (block-level "Edit in Configurator" badge) -------- */

--- a/libs/features/personalization/preview.css
+++ b/libs/features/personalization/preview.css
@@ -620,6 +620,7 @@ body[data-mep-fragments='true'] [data-fragment-default]::before {
   border-radius: 5px;
   box-shadow: 0 3px 8px 1px #808080;
   pointer-events: auto !important;
+  line-height: 1.5;
 }
 
 /* Non-fragment (HTML) badges - not clickable */
@@ -680,4 +681,97 @@ body[data-mep-highlight='true'] main[data-manifest-id]::before {
 
 body[data-mep-highlight='true'] .section[class*="-merch-cards"] .fragment[data-manifest-id]::before {
   display: none;
+}
+
+/* CaaS region highlights ----------------------------------------------------- */
+body[data-mep-caas-highlight='true'] [data-country]:not([data-country='xx']),
+body[data-mep-caas-highlight='true'] [data-country='xx'] {
+  outline: 2px dashed transparent;
+  outline-offset: 2px;
+  position: relative !important;
+}
+
+body[data-mep-caas-highlight='true'] [data-country]:not([data-country='xx'])::before,
+body[data-mep-caas-highlight='true'] [data-country='xx']::before {
+  font-size: 14px !important;
+  font-weight: 400 !important;
+  min-height: 20px !important;
+  min-width: 60px !important;
+  max-width: 400px;
+  text-align: left !important;
+  vertical-align: top;
+  position: absolute !important;
+  left: 5px;
+  top: var(--badge-top-offset, 0);
+  z-index: 3;
+  padding: 5px 10px !important;
+  margin: 2px;
+  margin-left: var(--badge-margin-left, 0);
+  color: #000 !important;
+  opacity: 0.9 !important;
+  border-radius: 5px;
+  box-shadow: 0 3px 8px 1px #808080;
+  pointer-events: auto !important;
+  cursor: pointer !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.5;
+}
+
+/* Market-specific (any country code other than xx) - green */
+body[data-mep-caas-highlight='true'] [data-country]:not([data-country='xx']) {
+  outline-color: #28a745;
+}
+
+body[data-mep-caas-highlight='true'] [data-country]:not([data-country='xx'])::before {
+  content: '🔗 caas-market: ' attr(data-card-path);
+  background-color: #d4edda !important;
+  border: 1px solid #28a745;
+}
+
+/* Lang-first / global (xx) - yellow */
+body[data-mep-caas-highlight='true'] [data-country='xx'] {
+  outline-color: #ffc107;
+}
+
+body[data-mep-caas-highlight='true'] [data-country='xx']::before {
+  content: '🔗 caas-lang: ' attr(data-card-path);
+  background-color: #fff3cd !important;
+  border: 1px solid #ffc107;
+}
+
+/* CaaS collection wrapper (block-level "Edit in Configurator" badge) -------- */
+body[data-mep-caas-highlight='true'] [data-caas-block] {
+  outline: 2px dashed #007bff;
+  outline-offset: 4px;
+}
+
+a.mep-caas-edit-badge,
+body a.mep-caas-edit-badge {
+  visibility: visible !important; /* override caas.css hiding /tools/caas# links */
+  display: inline-block;
+  margin: 0 0 12px 5px;
+  padding: 6px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  background-color: #cce5ff;
+  color: #003a75;
+  border: 1px solid #007bff;
+  border-radius: 5px;
+  box-shadow: 0 3px 8px 1px #808080;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 0.95;
+  z-index: 4;
+  position: relative;
+}
+
+a.mep-caas-edit-badge::before {
+  content: '🔗 ';
+}
+
+a.mep-caas-edit-badge:hover,
+a.mep-caas-edit-badge:focus {
+  opacity: 1;
+  text-decoration: none;
 }

--- a/libs/features/personalization/preview.css
+++ b/libs/features/personalization/preview.css
@@ -176,6 +176,12 @@
   text-transform: initial;
 }
 
+/* Sub-rows under "Surfaces Detected" — indented and de-emphasized. */
+.mep-popup .mep-section-data .mep-mas-subitem {
+  padding-left: 12px;
+  opacity: 0.7;
+}
+
 .mep-popup a.mep-edit-manifest {
   cursor: pointer;
   display: flex;
@@ -781,4 +787,352 @@ a.mep-caas-edit-badge:hover,
 a.mep-caas-edit-badge:focus {
   opacity: 1;
   text-decoration: none;
+}
+
+/* M@S surface highlights ---------------------------------------------------- */
+body[data-mep-mas-highlight='true'] [data-mas-block='collection'] {
+  outline: 2px dashed #6f42c1; /* purple */
+  outline-offset: 4px;
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='card'] {
+  outline: 2px dashed #fd7e14; /* orange */
+  outline-offset: 4px;
+  position: relative;
+
+  /* Anchors the .mep-mas-card-actions overlay; prevents host overflow
+     from clipping it. */
+  overflow: visible;
+}
+
+/* Inset the child-card outline so it sits inside the parent collection's
+   outline (avoids stacked dashed lines). */
+body[data-mep-mas-highlight='true'] [data-mas-block='collection'] [data-mas-block='card'] {
+  outline-offset: -2px;
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='inline'] {
+  outline: 2px dashed #e83e8c; /* pink */
+  outline-offset: 2px;
+  position: relative;
+  overflow: visible;
+
+  /* Override M@S's `mas-field { display: inline }`: an inline host that
+     wraps block children (e.g., a body field with multiple <p>s) splits
+     into degenerate inline boxes and the outline disappears. inline-block
+     gives a single coherent box; scoped to highlight mode only. */
+  display: inline-block;
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='ost'] {
+  outline: 2px dashed #0d6efd; /* blue — unified with the offer surface */
+  outline-offset: 2px;
+  position: relative;
+  overflow: visible;
+}
+
+a.mep-mas-edit-badge,
+body a.mep-mas-edit-badge {
+  display: inline-block;
+  margin: 0 0 8px 5px;
+  padding: 6px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 5px;
+  box-shadow: 0 3px 8px 1px #808080;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 0.95;
+  z-index: 4;
+  position: relative;
+}
+
+a.mep-mas-edit-badge-collection {
+  background-color: #e2d4f7;
+  color: #4a2d80;
+  border: 1px solid #6f42c1;
+}
+
+/* Sub-collection edit badge — sibling between the parent collection badge
+   and the collection. Lavender palette, lower-emphasis than the parent,
+   to communicate hierarchy. */
+a.mep-mas-sub-collection-badge,
+body a.mep-mas-sub-collection-badge {
+  display: inline-block;
+  margin: 0 0 8px 14px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 4px;
+  background-color: #f0e7fb;
+  color: #4a2d80;
+  border: 1px dashed #9b6dd7;
+  box-shadow: 0 2px 5px 0 rgb(0 0 0 / 15%);
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 0.92;
+  z-index: 4;
+  position: relative;
+}
+
+a.mep-mas-sub-collection-badge::before {
+  content: '↳ 🔗 ';
+}
+
+a.mep-mas-sub-collection-badge:hover,
+a.mep-mas-sub-collection-badge:focus {
+  opacity: 1;
+  text-decoration: none;
+}
+
+a.mep-mas-edit-badge-card {
+  background-color: #ffe5d0;
+  color: #80450b;
+  border: 1px solid #fd7e14;
+}
+
+a.mep-mas-edit-badge::before {
+  content: '🔗 ';
+}
+
+a.mep-mas-edit-badge:hover,
+a.mep-mas-edit-badge:focus {
+  opacity: 1;
+  text-decoration: none;
+}
+
+/* Card action stack — three stacked actions in the top-right of every
+   highlighted card: Edit Card, Edit OSI, Copy Fragment ID. Real DOM (not
+   a ::before pseudo) so the Copy button can host a clipboard handler.
+   Anchored by the card host's position:relative + overflow:visible above. */
+body[data-mep-mas-highlight='true'] .mep-mas-card-actions {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-end;
+  font-family: inherit;
+}
+
+body[data-mep-mas-highlight='true'] .mep-mas-card-action-edit,
+body[data-mep-mas-highlight='true'] .mep-mas-card-action-ost,
+body[data-mep-mas-highlight='true'] .mep-mas-card-action-copy {
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: 0 2px 4px 0 rgb(0 0 0 / 25%);
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+/* Edit Card (orange) — matches the card outline. */
+body[data-mep-mas-highlight='true'] .mep-mas-card-action-edit {
+  background-color: #ffe5d0;
+  color: #80450b;
+  border: 1px solid #fd7e14;
+}
+
+/* Edit OSI (blue) — matches the offer/ost palette. */
+body[data-mep-mas-highlight='true'] .mep-mas-card-action-ost {
+  background-color: #cfe2ff;
+  color: #0a3677;
+  border: 1px solid #0d6efd;
+}
+
+/* Copy Fragment ID (neutral grey) — visually distinct from the link
+   buttons; flips green for ~1.5s after a successful clipboard write. */
+body[data-mep-mas-highlight='true'] .mep-mas-card-action-copy {
+  background-color: #e9ecef;
+  color: #212529;
+  border: 1px solid #6c757d;
+  font-family: inherit;
+}
+
+body[data-mep-mas-highlight='true'] .mep-mas-card-action-copy-copied {
+  background-color: #d4edda;
+  color: #155724;
+  border-color: #28a745;
+}
+
+/* Market-mismatch flip: yellow palette (consistent with inline/ost/offer)
+   when the card's market differs from the page market. Copy stays neutral. */
+body[data-mep-mas-highlight='true'] .mep-mas-card-action-edit.mep-mas-card-actions-mismatch,
+body[data-mep-mas-highlight='true'] .mep-mas-card-action-ost.mep-mas-card-actions-mismatch {
+  background-color: #fff3cd;
+  color: #856404;
+  border-color: #ffc107;
+}
+
+/* Offer surface — every [data-wcs-osi] element. Stamped by annotateOffers().
+   CSS-only ::before badge; the capture-phase click handler in preview.js
+   opens the OST URL on hits inside the badge box. */
+body[data-mep-mas-highlight='true'] [data-mas-block='offer'] {
+  outline: 1px dashed #0d6efd;
+  outline-offset: 2px;
+  position: relative;
+
+  /* Prevent ancestor overflow from clipping the corner badge (some
+     <merch-card> variants hide overflow on the price slot). */
+  overflow: visible;
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='offer']::before {
+  content: '🔗 Edit OSI';
+  position: absolute;
+  top: -10px;
+  right: -2px;
+  z-index: 3;
+  padding: 3px 6px;
+  background-color: #cfe2ff;
+  color: #0a3677;
+  border: 1px solid #0d6efd;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 25%);
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='offer'][data-mas-market]::before {
+  content: '🔗 Edit OSI · ' attr(data-mas-market);
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='offer'][data-mas-market-mismatch='true']::before {
+  background-color: #fff3cd;
+  color: #856404;
+  border-color: #ffc107;
+}
+
+/* Suppress the per-offer pseudo when nested in a card — the card's action
+   stack already has a consolidated "Edit OSI" button. Outline preserved. */
+body[data-mep-mas-highlight='true'] [data-mas-block='card'] [data-mas-block='offer']::before {
+  content: none;
+}
+
+/* Inline (mas-field) surface — overhanging top-right ::before to avoid
+   disturbing document flow inside paragraphs/headings. */
+body[data-mep-mas-highlight='true'] [data-mas-block='inline']::before {
+  content: '🔗 Edit Inline Field in M@S Studio';
+  position: absolute;
+  top: -10px;
+  right: -2px;
+  z-index: 3;
+  padding: 3px 6px;
+  background-color: #fcd3e1;
+  color: #80224d;
+  border: 1px solid #e83e8c;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 25%);
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='inline'][data-mas-market]::before {
+  content: '🔗 Edit Inline Field in M@S Studio · ' attr(data-mas-market);
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='inline'][data-mas-market-mismatch='true']::before {
+  background-color: #fff3cd;
+  color: #856404;
+  border-color: #ffc107;
+}
+
+/* OST surface — standalone <a class="merch"> autoblock. Unified palette
+   with the offer surface; the difference is internal (OST captures the
+   full authoring URL, offer derives a minimal one from the OSI). */
+body[data-mep-mas-highlight='true'] [data-mas-block='ost']::before {
+  content: '🔗 Edit OSI';
+  position: absolute;
+  top: -10px;
+  right: -2px;
+  z-index: 11;
+  padding: 3px 6px;
+  background-color: #cfe2ff;
+  color: #0a3677;
+  border: 1px solid #0d6efd;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 25%);
+  min-width: 96px;
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='ost'][data-mas-market]::before {
+  content: '🔗 Edit OSI · ' attr(data-mas-market);
+}
+
+body[data-mep-mas-highlight='true'] [data-mas-block='ost'][data-mas-market-mismatch='true']::before {
+  background-color: #fff3cd;
+  color: #856404;
+  border-color: #ffc107;
+}
+
+/* Market chip suffix on the badge label (e.g. "Edit Card · FR"). Plain
+   when the card market matches the page; yellow pill on mismatch. */
+.mep-mas-edit-badge-market {
+  display: inline-block;
+  margin-left: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  vertical-align: 1px;
+}
+
+.mep-mas-edit-badge-market-mismatch {
+  padding: 1px 6px;
+  background-color: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffc107;
+  border-radius: 3px;
+}
+
+.mep-mas-no-content {
+  margin-top: 4px;
+  font-size: 12px;
+  font-style: italic;
+}
+
+/* M@S market spoofer (mode-toggle checkbox between Lingo and M@S dropdowns) */
+.mep-mas-market-toggle {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mep-mas-market-dropdown {
+  margin-top: 8px;
+  border-left: 3px solid #20c997;
+  padding-left: 8px;
+}
+
+/* Non-Lingo pages: no companion toggle, so drop the green border that
+   signaled "alternative to the Lingo dropdown". */
+.mep-mas-market-dropdown.standalone {
+  border-left: none;
+  padding-left: 0;
+}
+
+.mep-mas-market-dropdown[hidden] {
+  display: none;
+}
+
+.mep-popup select[id^='mepLingoRegionSelect']:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }

--- a/libs/features/personalization/preview.css
+++ b/libs/features/personalization/preview.css
@@ -902,7 +902,7 @@ a.mep-mas-edit-badge:focus {
 }
 
 /* Card action stack — three stacked actions in the top-right of every
-   highlighted card: Edit Card, Edit OSI, Copy Fragment ID. Real DOM (not
+   highlighted card: Edit Card, View in OST, Copy Fragment ID. Real DOM (not
    a ::before pseudo) so the Copy button can host a clipboard handler.
    Anchored by the card host's position:relative + overflow:visible above. */
 body[data-mep-mas-highlight='true'] .mep-mas-card-actions {
@@ -939,7 +939,7 @@ body[data-mep-mas-highlight='true'] .mep-mas-card-action-edit {
   border: 1px solid #fd7e14;
 }
 
-/* Edit OSI (blue) — matches the offer/ost palette. */
+/* View in OST (blue) — matches the offer/ost palette. */
 body[data-mep-mas-highlight='true'] .mep-mas-card-action-ost {
   background-color: #cfe2ff;
   color: #0a3677;
@@ -984,7 +984,7 @@ body[data-mep-mas-highlight='true'] [data-mas-block='offer'] {
 }
 
 body[data-mep-mas-highlight='true'] [data-mas-block='offer']::before {
-  content: '🔗 Edit OSI';
+  content: '🔗 View in OST';
   position: absolute;
   top: -10px;
   right: -2px;
@@ -1000,10 +1000,11 @@ body[data-mep-mas-highlight='true'] [data-mas-block='offer']::before {
   letter-spacing: 0.5px;
   cursor: pointer;
   box-shadow: 0 1px 2px 0 rgb(0 0 0 / 25%);
+  min-width: 112px;
 }
 
 body[data-mep-mas-highlight='true'] [data-mas-block='offer'][data-mas-market]::before {
-  content: '🔗 Edit OSI · ' attr(data-mas-market);
+  content: '🔗 View in OST · ' attr(data-mas-market);
 }
 
 body[data-mep-mas-highlight='true'] [data-mas-block='offer'][data-mas-market-mismatch='true']::before {
@@ -1013,7 +1014,7 @@ body[data-mep-mas-highlight='true'] [data-mas-block='offer'][data-mas-market-mis
 }
 
 /* Suppress the per-offer pseudo when nested in a card — the card's action
-   stack already has a consolidated "Edit OSI" button. Outline preserved. */
+   stack already has a consolidated "View in OST" button. Outline preserved. */
 body[data-mep-mas-highlight='true'] [data-mas-block='card'] [data-mas-block='offer']::before {
   content: none;
 }
@@ -1021,7 +1022,7 @@ body[data-mep-mas-highlight='true'] [data-mas-block='card'] [data-mas-block='off
 /* Inline (mas-field) surface — overhanging top-right ::before to avoid
    disturbing document flow inside paragraphs/headings. */
 body[data-mep-mas-highlight='true'] [data-mas-block='inline']::before {
-  content: '🔗 Edit Inline Field in M@S Studio';
+  content: '🔗 Edit Inline Field';
   position: absolute;
   top: -10px;
   right: -2px;
@@ -1037,10 +1038,11 @@ body[data-mep-mas-highlight='true'] [data-mas-block='inline']::before {
   letter-spacing: 0.5px;
   cursor: pointer;
   box-shadow: 0 1px 2px 0 rgb(0 0 0 / 25%);
+  min-width: 130px;
 }
 
 body[data-mep-mas-highlight='true'] [data-mas-block='inline'][data-mas-market]::before {
-  content: '🔗 Edit Inline Field in M@S Studio · ' attr(data-mas-market);
+  content: '🔗 Edit Inline Field · ' attr(data-mas-market);
 }
 
 body[data-mep-mas-highlight='true'] [data-mas-block='inline'][data-mas-market-mismatch='true']::before {
@@ -1049,11 +1051,17 @@ body[data-mep-mas-highlight='true'] [data-mas-block='inline'][data-mas-market-mi
   border-color: #ffc107;
 }
 
+/* When an ost/offer badge is nested inside an inline (mas-field) host, flip it
+   below its element so it doesn't overlap the inline badge above. */
+body[data-mep-mas-highlight='true'] [data-mas-block='inline'] :is([data-mas-block='ost'], [data-mas-block='offer'])::before {
+  top: calc(100% + 4px);
+}
+
 /* OST surface — standalone <a class="merch"> autoblock. Unified palette
    with the offer surface; the difference is internal (OST captures the
    full authoring URL, offer derives a minimal one from the OSI). */
 body[data-mep-mas-highlight='true'] [data-mas-block='ost']::before {
-  content: '🔗 Edit OSI';
+  content: '🔗 View in OST';
   position: absolute;
   top: -10px;
   right: -2px;
@@ -1073,7 +1081,8 @@ body[data-mep-mas-highlight='true'] [data-mas-block='ost']::before {
 }
 
 body[data-mep-mas-highlight='true'] [data-mas-block='ost'][data-mas-market]::before {
-  content: '🔗 Edit OSI · ' attr(data-mas-market);
+  content: '🔗 View in OST · ' attr(data-mas-market);
+  min-width: 112px;
 }
 
 body[data-mep-mas-highlight='true'] [data-mas-block='ost'][data-mas-market-mismatch='true']::before {

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -9,7 +9,16 @@ import {
   normCountryCode,
   resolveDetectedMarketCountry,
 } from '../../utils/utils.js';
+import { getMarketConfig, marketsLangForLocale } from '../../utils/market.js';
 import { mepCaasConfigUrls } from '../../blocks/caas/utils.js';
+import { mepMasStudioUrls } from '../../blocks/merch/mas-mep-utils.js';
+import { getMiloLocaleSettings, isMasGeoDetectionEnabled } from '../../blocks/merch/merch.js';
+import {
+  extractSubCollections,
+  injectSubCollectionBadge,
+  removeSubCollectionBadges,
+  mepMasSubCollections,
+} from './preview-mas-subcollection.js';
 import { US_GEO, getFileName, normalizePath } from './personalization.js';
 
 export function escapeHtml(str) {
@@ -125,6 +134,468 @@ function unwatchForCaasBlocks() {
   caasObserver = null;
 }
 
+const MAS_BADGE_CLASS = 'mep-mas-edit-badge';
+const MAS_LABELS = {
+  collection: 'Edit Collection in M@S Studio',
+  card: 'Edit Card in M@S Studio',
+  inline: 'Edit Inline Field in M@S Studio',
+  ost: 'Edit in OSI',
+  // 'offer' surface is CSS-only (::before pseudo) — label kept for symmetry.
+  offer: 'Edit in OSI',
+};
+
+// Mirrors SELECTOR_MAS_INLINE_PRICE et al. from ../mas/web-components/src/
+// constants.js. Inlined rather than imported to avoid a hard runtime
+// dependency on M@S's web-components package.
+const MAS_OSI_SELECTOR = [
+  'span[is="inline-price"][data-wcs-osi]',
+  'a[is="checkout-link"][data-wcs-osi]',
+  'button[is="checkout-button"][data-wcs-osi]',
+  'sp-button[data-wcs-osi]',
+].join(',');
+
+export function updateMasNoContentMessage(show) {
+  document.querySelectorAll('.mep-mas-no-content').forEach((el) => {
+    el.hidden = !show;
+  });
+}
+
+// Each selector catches a different M@S code path:
+//   - [data-mas-block]  autoblock-stamped surface (preview-only)
+//   - <merch-card>      web component (incl. collection children)
+//   - [data-wcs-osi]    any commerce-bound element (covers standalone offers)
+// Snapshot at call time — re-open the popup if M@S content hydrates after.
+export function hasMasSurfaces() {
+  return !!document.querySelector('[data-mas-block], merch-card, [data-wcs-osi]');
+}
+
+// Page-level market, most-to-least authoritative:
+//   1. <mas-commerce-service country=…>   what M@S sends to WCS
+//   2. getMiloLocaleSettings(locale).country   fallback before the service initializes
+//   3. ?akamaiLocale=   spoof param; M@S ignores it when geo-detect is OFF, so
+//      the chip will show the URL-path country (signaling the spoof didn't take)
+export function getResolvedPageMarket() {
+  try {
+    const masCountry = document.head.querySelector('mas-commerce-service')?.getAttribute('country');
+    if (masCountry) return normCountryCode(masCountry.toLowerCase());
+    const { locale } = getConfig() || {};
+    const masSettings = getMiloLocaleSettings(locale);
+    if (masSettings?.country) return normCountryCode(masSettings.country.toLowerCase());
+    const akamai = new URLSearchParams(window.location.search).get('akamaiLocale');
+    if (akamai) return normCountryCode(akamai.toLowerCase());
+    return null;
+  } catch (e) { return null; }
+}
+
+// Per-host market, most-to-least authoritative:
+//   1. data-ims-country (set post-WCS by M@S checkout-mixin)
+//   2. country= query param on a commerce href — what was REQUESTED of WCS
+//   3. pageMarket fallback — inline-price always falls here (no per-element country)
+export function getCardMarket(el, pageMarket) {
+  if (!el) return pageMarket;
+  // For offer/ost surfaces the host IS the checkout-link, so check it first.
+  const selfImsCountry = el.getAttribute?.('data-ims-country');
+  if (selfImsCountry) return normCountryCode(selfImsCountry.toLowerCase());
+  const imsCountry = el.querySelector?.('a[data-ims-country]')?.getAttribute('data-ims-country');
+  if (imsCountry) return normCountryCode(imsCountry.toLowerCase());
+  const candidates = [];
+  if (el.tagName === 'A' && el.href) candidates.push(el);
+  el.querySelectorAll?.('a[href*="country="]').forEach((a) => candidates.push(a));
+  for (const a of candidates) {
+    try {
+      const url = new URL(a.href, window.location.origin);
+      const country = url.searchParams.get('country');
+      if (country) return normCountryCode(country.toLowerCase());
+    } catch (e) { /* skip and try next candidate */ }
+  }
+  return pageMarket;
+}
+
+// 'unknown' when either side is unresolved — consumers skip the chip color for it.
+function classifyMarket(cardMarket, pageMarket) {
+  if (!cardMarket || !pageMarket) return 'unknown';
+  return cardMarket === pageMarket ? 'match' : 'mismatch';
+}
+
+// Child cards have no authoring <a href> (M@S renders them from collection
+// metadata) — clone the parent's captured Studio URL and substitute
+// content-type + identifier. Keeps us aligned with the parent's URL
+// convention rather than inventing a format. Returns null when undeducible.
+export function deriveChildCardStudioUrl(parentUrl, childFragmentId) {
+  if (!parentUrl || !childFragmentId) return null;
+  try {
+    const u = new URL(parentUrl, window.location.origin);
+    const hash = (u.hash || '').replace(/^#/, '');
+    const hashParams = new URLSearchParams(hash);
+    if (hashParams.get('content-type') === 'merch-card-collection') {
+      hashParams.set('content-type', 'merch-card');
+    }
+    if (hashParams.has('query')) hashParams.set('query', childFragmentId);
+    else if (hashParams.has('fragment')) hashParams.set('fragment', childFragmentId);
+    else hashParams.set('query', childFragmentId);
+    u.hash = `#${hashParams.toString()}`;
+    return u.toString();
+  } catch (e) { return null; }
+}
+
+// Rewrites query=/fragment= -> fragmentId= and page=content -> page=fragment-editor.
+// Scoped to content-type=merch-card; other types pass through unchanged.
+export function toFragmentEditorUrl(url) {
+  if (!url) return url;
+  try {
+    const u = new URL(url, window.location.origin);
+    const hash = (u.hash || '').replace(/^#/, '');
+    const hp = new URLSearchParams(hash);
+    if (hp.get('content-type') !== 'merch-card') return url;
+    const id = hp.get('fragmentId') || hp.get('query') || hp.get('fragment');
+    if (!id) return url;
+    hp.delete('query');
+    hp.delete('fragment');
+    hp.set('fragmentId', id);
+    hp.set('page', 'fragment-editor');
+    u.hash = `#${hp.toString()}`;
+    return u.toString();
+  } catch (e) { return url; }
+}
+
+function stampMarket(host, pageMarket) {
+  const market = getCardMarket(host, pageMarket);
+  if (!market) return;
+  host.dataset.masMarket = market.toUpperCase();
+  if (pageMarket && market !== pageMarket) {
+    host.dataset.masMarketMismatch = 'true';
+  } else {
+    delete host.dataset.masMarketMismatch;
+  }
+}
+
+function annotateCollectionChildren() {
+  const pageMarket = getResolvedPageMarket();
+  document.querySelectorAll('[data-mas-block="collection"]').forEach((container) => {
+    const parentUrl = mepMasStudioUrls.get(container);
+    if (!parentUrl) return;
+    // Re-stamp every pass — data-ims-country arrives async post-WCS.
+    container.querySelectorAll('merch-card').forEach((child) => {
+      if (child.offsetParent === null) return;
+      if (!child.dataset.masBlock) {
+        const aemFragment = child.querySelector('aem-fragment[fragment]');
+        const fragmentId = aemFragment?.getAttribute('fragment');
+        if (!fragmentId) return;
+        const childUrl = deriveChildCardStudioUrl(parentUrl, fragmentId);
+        if (!childUrl) return;
+        mepMasStudioUrls.set(child, childUrl);
+        child.dataset.masBlock = 'card';
+      }
+      stampMarket(child, pageMarket);
+    });
+  });
+}
+
+// Pinned to milo.adobe.com so derived OST links work the same everywhere
+// (DA preview, .aem.page, localhost). OSIs are environment-independent.
+const OST_BASE_URL = 'https://milo.adobe.com/tools/ost';
+
+// type=price/checkoutUrl pre-selects the correct OST tab. Idempotent.
+function annotateOffers() {
+  document.querySelectorAll(MAS_OSI_SELECTOR).forEach((el) => {
+    if (el.dataset.masBlock) return;
+    const osi = el.getAttribute('data-wcs-osi');
+    if (!osi) return;
+    const isPrice = el.matches('span[is="inline-price"]');
+    const type = isPrice ? 'price' : 'checkoutUrl';
+    const ostUrl = `${OST_BASE_URL}?osi=${encodeURIComponent(osi)}&type=${type}`;
+    mepMasStudioUrls.set(el, ostUrl);
+    el.dataset.masBlock = 'offer';
+  });
+}
+
+// Real DOM (not ::before) — three independent click targets + Copy needs a clipboard handler.
+const CARD_ACTIONS_CLASS = 'mep-mas-card-actions';
+const CARD_ACTION_EDIT_CLASS = 'mep-mas-card-action-edit';
+const CARD_ACTION_OST_CLASS = 'mep-mas-card-action-ost';
+const CARD_ACTION_COPY_CLASS = 'mep-mas-card-action-copy';
+
+function getCardFragmentId(card) {
+  return card.querySelector('aem-fragment[fragment]')?.getAttribute('fragment') || null;
+}
+
+// Edit OSI uses the first OSI — M@S confirmed all OSIs in a card are equivalent.
+function getCardFirstOsi(card) {
+  return card.querySelector('[data-wcs-osi]')?.getAttribute('data-wcs-osi') || null;
+}
+
+// Rebuild every pass — M@S can replace subtrees; diffing isn't worth it.
+function injectMasCardActionStack(card) {
+  const studioUrl = mepMasStudioUrls.get(card);
+  if (!studioUrl) return;
+  card.querySelectorAll(`:scope > .${CARD_ACTIONS_CLASS}`).forEach((el) => el.remove());
+
+  const stack = createTag('div', { class: CARD_ACTIONS_CLASS });
+  const market = card.dataset.masMarket;
+  const mismatch = card.dataset.masMarketMismatch === 'true';
+  const marketSuffix = market ? ` \u00b7 ${market}` : '';
+  const mismatchClass = mismatch ? ` ${CARD_ACTIONS_CLASS}-mismatch` : '';
+
+  stack.append(createTag(
+    'a',
+    {
+      class: `${CARD_ACTION_EDIT_CLASS}${mismatchClass}`,
+      href: toFragmentEditorUrl(studioUrl),
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    },
+    `Edit Card${marketSuffix}`,
+  ));
+
+  const osi = getCardFirstOsi(card);
+  if (osi) {
+    stack.append(createTag(
+      'a',
+      {
+        class: `${CARD_ACTION_OST_CLASS}${mismatchClass}`,
+        href: `https://milo.adobe.com/tools/ost?osi=${encodeURIComponent(osi)}`,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      },
+      `Edit OSI${marketSuffix}`,
+    ));
+  }
+
+  const fragmentId = getCardFragmentId(card);
+  if (fragmentId) {
+    const copyBtn = createTag(
+      'button',
+      {
+        type: 'button',
+        class: CARD_ACTION_COPY_CLASS,
+        'data-fragment-id': fragmentId,
+        title: `Copy fragment id: ${fragmentId}`,
+      },
+      'Copy Fragment ID',
+    );
+    copyBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const id = copyBtn.dataset.fragmentId;
+      const restore = () => { copyBtn.textContent = 'Copy Fragment ID'; copyBtn.classList.remove(`${CARD_ACTION_COPY_CLASS}-copied`); };
+      const flash = () => {
+        copyBtn.textContent = 'Copied!';
+        copyBtn.classList.add(`${CARD_ACTION_COPY_CLASS}-copied`);
+        setTimeout(restore, 1500);
+      };
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(id).then(flash).catch(() => {
+          copyBtn.textContent = 'Copy failed';
+          setTimeout(restore, 1500);
+        });
+      } else {
+        flash();
+      }
+    });
+    stack.append(copyBtn);
+  }
+
+  card.append(stack);
+}
+
+// Collection surfaces use this sibling-placed badge. Cards: real-DOM action
+// stack (injectMasCardActionStack). Inline/ost/offer: ::before pseudos.
+function buildMasBadge(url, surface, market, pageMarket) {
+  const a = createTag(
+    'a',
+    {
+      class: `${MAS_BADGE_CLASS} ${MAS_BADGE_CLASS}-${surface}`,
+      href: url,
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    },
+    MAS_LABELS[surface] || 'Edit in M@S Studio',
+  );
+  if (market) {
+    const state = classifyMarket(market, pageMarket);
+    const chip = createTag(
+      'span',
+      { class: `${MAS_BADGE_CLASS}-market ${MAS_BADGE_CLASS}-market-${state}` },
+      market.toUpperCase(),
+    );
+    a.append(' \u00b7 ', chip);
+  }
+  return a;
+}
+
+export function injectMasBadges() {
+  annotateCollectionChildren();
+  annotateOffers();
+  const pageMarket = getResolvedPageMarket();
+  // Re-stamp every pass — chips upgrade from pageMarket fallback to data-ims-country post-WCS.
+  document.querySelectorAll('[data-mas-block="card"], [data-mas-block="inline"], [data-mas-block="ost"], [data-mas-block="offer"]')
+    .forEach((host) => stampMarket(host, pageMarket));
+  let visibleCount = 0;
+  document.querySelectorAll('[data-mas-block]').forEach((el) => {
+    const surface = el.dataset.masBlock;
+    if (surface === 'card') {
+      injectMasCardActionStack(el);
+      visibleCount += 1;
+      return;
+    }
+    // offer/inline/ost use ::before pseudos — sibling <a> shifted layout in paragraphs/headings.
+    if (surface === 'offer' || surface === 'inline' || surface === 'ost') {
+      visibleCount += 1;
+      return;
+    }
+    const url = mepMasStudioUrls.get(el);
+    if (!url) return;
+    const market = getCardMarket(el, pageMarket);
+    // Hop past a sub-collection badge wedged between the parent badge and the container.
+    // Without this hop the idempotence check below misses the parent, rebuilds it every
+    // pass, and strands the previous sub badge.
+    let prev = el.previousElementSibling;
+    if (prev?.classList?.contains('mep-mas-sub-collection-badge')) {
+      prev = prev.previousElementSibling;
+    }
+    if (prev?.classList?.contains(MAS_BADGE_CLASS)) {
+      // Skip rebuild unless market changed — handles mid-hydration data-ims-country arrivals.
+      if (prev.dataset.mepMasMarket === (market || '')) {
+        visibleCount += 1;
+        return;
+      }
+      prev.remove();
+    }
+    const a = buildMasBadge(url, surface, market, pageMarket);
+    a.dataset.mepMasMarket = market || '';
+    el.insertAdjacentElement('beforebegin', a);
+    visibleCount += 1;
+  });
+  document.querySelectorAll('[data-mas-block="collection"]').forEach((container) => {
+    injectSubCollectionBadge(container, pageMarket);
+  });
+  updateMasNoContentMessage(visibleCount === 0);
+}
+
+export function removeMasBadges() {
+  document.querySelectorAll(`a.${MAS_BADGE_CLASS}`).forEach((el) => el.remove());
+  // Cards: real DOM, must strip. Pseudos (offer/inline/ost) hide via body[data-mep-mas-highlight].
+  document.querySelectorAll(`.${CARD_ACTIONS_CLASS}`).forEach((el) => el.remove());
+  removeSubCollectionBadges();
+  updateMasNoContentMessage(false);
+}
+
+// Hit boxes for the ::before badges in preview.css — keep in sync if CSS sizes change.
+// Anchored to the host's right edge: `w` extends leftward, negative `top` overhangs above.
+// Slightly larger than the visible badge for click forgiveness.
+const PSEUDO_BADGE_HIT = {
+  offer: { w: 130, h: 22, top: -14 },
+  inline: { w: 240, h: 22, top: -14 },
+  ost: { w: 130, h: 22, top: -14 },
+};
+
+// Pseudos can't carry an href — delegate clicks in the hit box to open the captured URL.
+// preventDefault + stopPropagation suppress the host's normal navigation (checkout/CTA).
+function handleChildCardBadgeClick(e) {
+  if (document.body.dataset.mepMasHighlight !== 'true') return;
+  // composedPath() crosses shadow boundaries — clicks originate inside the
+  // merch-card / commerce-element shadow roots.
+  const host = e.composedPath().find((n) => {
+    if (n?.nodeType !== 1) return false;
+    const surface = n.dataset?.masBlock;
+    return surface === 'offer' || surface === 'inline' || surface === 'ost';
+  });
+  if (!host) return;
+  const url = mepMasStudioUrls.get(host);
+  if (!url) return;
+  const hit = PSEUDO_BADGE_HIT[host.dataset.masBlock];
+  if (!hit) return;
+  const rect = host.getBoundingClientRect();
+  const yMin = rect.top + hit.top;
+  const inBadge = e.clientX >= rect.right - hit.w
+    && e.clientX <= rect.right
+    && e.clientY >= yMin
+    && e.clientY <= yMin + hit.h;
+  if (!inBadge) return;
+  e.preventDefault();
+  e.stopPropagation();
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+let masObserver;
+let masRestampTimer;
+// Named handler refs so unwatchForMasContent can remove them.
+let masChildCardClickHandler;
+let masAemLoadHandler;
+let masRestampClickHandler;
+// Exported for tests. Long enough for M@S hydration after a tab/accordion
+// switch, short enough to feel responsive.
+export const MAS_RESTAMP_DEBOUNCE_MS = 300;
+export function watchForMasContent() {
+  if (masObserver) return;
+
+  masChildCardClickHandler = handleChildCardBadgeClick;
+  document.addEventListener('click', masChildCardClickHandler, true);
+
+  // Fallback for the race where highlight is enabled AFTER parent aem-fragment loaded
+  // (autoblock listener missed it). aem:load bubbles+composed, so one document listener
+  // catches every fragment regardless of nesting.
+  masAemLoadHandler = (event) => {
+    if (document.body.dataset.mepMasHighlight !== 'true') return;
+    const fragment = event.target;
+    if (!fragment || fragment.tagName !== 'AEM-FRAGMENT') return;
+    const container = fragment.closest('[data-mas-block="collection"]');
+    if (!container) return;
+    const subs = extractSubCollections(event.detail);
+    if (subs.length) {
+      mepMasSubCollections.set(container, subs);
+      clearTimeout(masRestampTimer);
+      masRestampTimer = setTimeout(() => injectMasBadges(), MAS_RESTAMP_DEBOUNCE_MS);
+    }
+  };
+  document.addEventListener('aem:load', masAemLoadHandler, true);
+
+  // Tabs/accordions/filter chips toggle aria-selected/hidden — the childList observer
+  // doesn't fire for that. Debounced to coalesce rapid clicks and let M@S hydrate.
+  masRestampClickHandler = () => {
+    if (document.body.dataset.mepMasHighlight !== 'true') return;
+    clearTimeout(masRestampTimer);
+    masRestampTimer = setTimeout(() => injectMasBadges(), MAS_RESTAMP_DEBOUNCE_MS);
+  };
+  document.addEventListener('click', masRestampClickHandler, true);
+
+  // Re-injection triggers:
+  //   - new [data-mas-block] / <merch-card> nodes (collection children)
+  //   - aem-fragment[fragment] insertion (M@S sometimes appends post-mount; miss permanently)
+  //   - data-ims-country attribute (post-WCS market upgrade)
+  const isMasMutation = (n) => n.nodeType === 1 && (
+    n.matches?.('[data-mas-block], merch-card, aem-fragment[fragment]')
+    || n.querySelector?.('[data-mas-block], merch-card, aem-fragment[fragment]')
+  );
+  masObserver = new MutationObserver((mutations) => {
+    if (document.body.dataset.mepMasHighlight !== 'true') return;
+    const hit = mutations.some((m) => {
+      if (m.type === 'attributes') return m.attributeName === 'data-ims-country';
+      return [...m.addedNodes].some(isMasMutation);
+    });
+    if (hit) injectMasBadges();
+  });
+  masObserver.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['data-ims-country'],
+  });
+}
+
+function unwatchForMasContent() {
+  if (!masObserver) return;
+  document.removeEventListener('click', masChildCardClickHandler, true);
+  document.removeEventListener('aem:load', masAemLoadHandler, true);
+  document.removeEventListener('click', masRestampClickHandler, true);
+  masObserver.disconnect();
+  masObserver = null;
+  masChildCardClickHandler = null;
+  masAemLoadHandler = null;
+  masRestampClickHandler = null;
+  clearTimeout(masRestampTimer);
+}
+
 function updatePreviewButton(popup, pageId) {
   const selectedInputs = popup.querySelectorAll(
     'option:checked, input[type="text"]',
@@ -132,10 +603,14 @@ function updatePreviewButton(popup, pageId) {
   const manifestParameter = [];
 
   selectedInputs.forEach((selected) => {
-    const isHidden = selected.closest('select')?.disabled;
-    const isMepLingoSelect = selected.closest('select')?.id?.startsWith('mepLingoRegionSelect');
+    const parentSelect = selected.closest('select');
+    const isHidden = parentSelect?.disabled;
+    const parentSelectId = parentSelect?.id || '';
+    // Spoofer dropdowns drive ?akamaiLocale; no data-manifest = serializes as "undefined--…".
+    const isSpooferSelect = parentSelectId.startsWith('mepLingoRegionSelect')
+      || parentSelectId.startsWith('mepMasMarketSelect');
 
-    if (!selected.value || isHidden || isMepLingoSelect) return;
+    if (!selected.value || isHidden || isSpooferSelect) return;
 
     let { value } = selected;
 
@@ -197,6 +672,22 @@ function updatePreviewButton(popup, pageId) {
     }
   }
 
+  const mepMasHighlightCheckbox = popup.querySelector(
+    `input[type="checkbox"]#mepMasHighlightCheckbox${pageId}`,
+  );
+  if (mepMasHighlightCheckbox) {
+    document.body.dataset.mepMasHighlight = mepMasHighlightCheckbox.checked;
+    if (mepMasHighlightCheckbox.checked) {
+      simulateHref.searchParams.set('mepMasHighlight', true);
+      watchForMasContent();
+      injectMasBadges();
+    } else {
+      simulateHref.searchParams.delete('mepMasHighlight');
+      unwatchForMasContent();
+      removeMasBadges();
+    }
+  }
+
   const mepPreviewButtonCheckbox = popup.querySelector(
     `input[type="checkbox"]#mepPreviewButtonCheckbox${pageId}`,
   );
@@ -206,15 +697,55 @@ function updatePreviewButton(popup, pageId) {
     simulateHref.searchParams.delete('mepButton');
   }
 
+  // Three popup shapes for the region/market spoofer (see getMepPopup):
+  //   1) Lingo + M@S: checkbox toggles which dropdown writes ?akamaiLocale
+  //   2) Lingo only:  Lingo dropdown writes ?akamaiLocale unconditionally
+  //   3) Non-Lingo + M@S: standalone M@S dropdown writes ?akamaiLocale +
+  //      ?mepMasMarket=true (re-pre-selects on reload)
+  const mepMasMarketCheckbox = popup.querySelector(
+    `input[type="checkbox"]#mepMasMarketCheckbox${pageId}`,
+  );
   const mepLingoRegionSelect = popup.querySelector(
     `select#mepLingoRegionSelect${pageId}`,
   );
-  if (mepLingoRegionSelect) {
-    const selectedRegion = mepLingoRegionSelect.value;
-    if (selectedRegion) {
-      simulateHref.searchParams.set('akamaiLocale', selectedRegion);
+  const mepMasMarketSelect = popup.querySelector(
+    `select#mepMasMarketSelect${pageId}`,
+  );
+  const mepMasMarketWrapper = popup.querySelector('.mep-mas-market-dropdown');
+  const masMarketOn = !!mepMasMarketCheckbox?.checked;
+  if (mepLingoRegionSelect) mepLingoRegionSelect.disabled = masMarketOn;
+  // Only Lingo+M@S gates the dropdown on the checkbox; the standalone variant is always visible.
+  if (mepMasMarketWrapper && !mepMasMarketWrapper.classList.contains('standalone')) {
+    mepMasMarketWrapper.hidden = !masMarketOn;
+  }
+  if (masMarketOn) {
+    simulateHref.searchParams.set('mepMasMarket', 'true');
+    const masVal = mepMasMarketSelect?.value;
+    if (masVal) {
+      simulateHref.searchParams.set('akamaiLocale', masVal);
     } else {
       simulateHref.searchParams.delete('akamaiLocale');
+    }
+  } else if (!mepMasMarketCheckbox && mepMasMarketSelect) {
+    // Standalone shape (non-Lingo + M@S): dropdown is authoritative,
+    // mepMasMarket=true persists the selection across reloads.
+    const masVal = mepMasMarketSelect.value;
+    if (masVal) {
+      simulateHref.searchParams.set('mepMasMarket', 'true');
+      simulateHref.searchParams.set('akamaiLocale', masVal);
+    } else {
+      simulateHref.searchParams.delete('mepMasMarket');
+      simulateHref.searchParams.delete('akamaiLocale');
+    }
+  } else {
+    simulateHref.searchParams.delete('mepMasMarket');
+    if (mepLingoRegionSelect) {
+      const selectedRegion = mepLingoRegionSelect.value;
+      if (selectedRegion) {
+        simulateHref.searchParams.set('akamaiLocale', selectedRegion);
+      } else {
+        simulateHref.searchParams.delete('akamaiLocale');
+      }
     }
   }
 
@@ -510,6 +1041,22 @@ async function mmmToggleManifests(event, popup, pageId) {
   }
 }
 function addMepPopupListeners(popup, pageId) {
+  // One-way auto-check: flipping Highlight M@S ON also pre-toggles "Use M@S markets instead"
+  // so the dropdown unhides in the same click. Never auto-unchecks. Must run BEFORE the
+  // blanket change listener below so the first updatePreviewButton sees the auto-check.
+  const mepMasHighlightCheckbox = popup.querySelector(
+    `input[type="checkbox"]#mepMasHighlightCheckbox${pageId}`,
+  );
+  const mepMasMarketCheckbox = popup.querySelector(
+    `input[type="checkbox"]#mepMasMarketCheckbox${pageId}`,
+  );
+  if (mepMasHighlightCheckbox && mepMasMarketCheckbox) {
+    mepMasHighlightCheckbox.addEventListener('change', (event) => {
+      if (event.target.checked && !mepMasMarketCheckbox.checked) {
+        mepMasMarketCheckbox.checked = true;
+      }
+    });
+  }
   popup.querySelectorAll('select, input[type="checkbox"]').forEach((input) => {
     input.addEventListener('change', updatePreviewButton.bind(null, popup, pageId));
   });
@@ -542,6 +1089,8 @@ export async function getMepPopup(mepConfig, isMmm = false) {
   const highlightParam = urlParams.get('mepHighlight');
   const fragmentsParam = urlParams.get('mepFragments');
   const caasHighlightParam = urlParams.get('mepCaasHighlight');
+  const masHighlightParam = urlParams.get('mepMasHighlight');
+  const masMarketParam = urlParams.get('mepMasMarket');
 
   let mepHighlightChecked = '';
   if (page?.highlight || highlightParam === 'true') {
@@ -558,6 +1107,13 @@ export async function getMepPopup(mepConfig, isMmm = false) {
     mepCaasHighlightChecked = 'checked="checked"';
     document.body.dataset.mepCaasHighlight = true;
   }
+  let mepMasHighlightChecked = '';
+  if (masHighlightParam === 'true') {
+    mepMasHighlightChecked = 'checked="checked"';
+    document.body.dataset.mepMasHighlight = true;
+  }
+  const masMarketChecked = masMarketParam === 'true';
+  const mepMasMarketCheckedAttr = masMarketChecked ? 'checked="checked"' : '';
   const PREVIEW_BUTTON_ID = 'preview-button';
   const pageUrl = isMmm ? page.url : new URL(window.location.href).href;
   const mepPopup = createTag('div', {
@@ -614,19 +1170,38 @@ export async function getMepPopup(mepConfig, isMmm = false) {
   }
   BuildOptionsManifestLisMMM();
 
+  // Visibility gates for the market spoofers. Computed once per popup-build:
+  //   - lingoOk: page exposes Lingo regions, so the existing Lingo dropdown
+  //     and its companion "Use M@S markets instead" checkbox make sense.
+  //   - hasMas:  page has any M@S surface (collection / card / inline / OST
+  //     / offer); without one, neither M@S control is useful.
+  // Resulting render matrix:
+  //                          Lingo dropdown    M@S checkbox    M@S dropdown
+  //   Lingo + no M@S         shown             hidden          hidden
+  //   Lingo + M@S            shown             shown           gated by checkbox
+  //   non-Lingo + no M@S     "no Lingo" hint   hidden          hidden
+  //   non-Lingo + M@S        "no Lingo" hint   hidden          shown standalone
+  // Standalone variant drops the green left border (a visual link to the
+  // adjacent toggle) since there's no checkbox to anchor to.
+  const lingoOk = lingoActive() && regionKeys.length > 0;
+  const hasMas = hasMasSurfaces();
+
   function buildOptionsLingoSelect() {
-    if (lingoActive() && regionKeys.length > 0) {
+    if (lingoOk) {
       const regionOptions = regionKeys.map((key) => {
         const country = key.split('_')[0];
-        const currentAkamaiLocale = urlParams.get('akamaiLocale');
+        // M@S Markets mode disables the Lingo dropdown — surfacing a "selected" option would
+        // mislead since its value no longer drives akamaiLocale.
+        const currentAkamaiLocale = masMarketChecked ? null : urlParams.get('akamaiLocale');
         const selected = currentAkamaiLocale === country ? ' selected' : '';
         return `<option value="${country}"${selected}>${key}</option>`;
       }).join('');
 
+      const disabledAttr = masMarketChecked ? ' disabled' : '';
       return `
         <div class="mep-experience-dropdown">
           <label for="mepLingoRegionSelect${pageId}">Supported Lingo Geos</label>
-          <select name="mepLingoRegion${pageId}" id="mepLingoRegionSelect${pageId}" class="mep-manifest-variants">
+          <select name="mepLingoRegion${pageId}" id="mepLingoRegionSelect${pageId}" class="mep-manifest-variants"${disabledAttr}>
             <option value="">-- Select Region --</option>
             ${regionOptions}
           </select>
@@ -634,6 +1209,56 @@ export async function getMepPopup(mepConfig, isMmm = false) {
     } return '<div>(No Lingo supported geos for this page.)</div>';
   }
   const regionDropdownHTML = buildOptionsLingoSelect();
+
+  // Sync read from cache — do NOT await getMarketConfig(). Cold cache renders the placeholder;
+  // the deferred reload at the end of getMepPopup picks up live data. Returns '' on no M@S.
+  function buildOptionsMasMarketSelect() {
+    if (!hasMas) return '';
+    const cached = config?.marketsConfig;
+    const languages = cached?.languages?.data ?? cached?.data ?? [];
+    const lang = languages.length
+      ? marketsLangForLocale({ languages }, config?.locale)
+      : null;
+    const supported = lang?.supportedRegions
+      ?.split(',').map((m) => m.trim().toLowerCase())
+      .filter(Boolean) || [];
+
+    // Standalone (non-Lingo + M@S): always visible, pre-selected from
+    // akamaiLocale. Lingo + M@S: hidden until the companion checkbox flips.
+    const standalone = !lingoOk;
+    const hiddenAttr = standalone || masMarketChecked ? '' : 'hidden';
+    const currentAkamaiLocale = (standalone || masMarketChecked)
+      ? urlParams.get('akamaiLocale')
+      : null;
+    const opts = supported.map((c) => {
+      const selected = currentAkamaiLocale === c ? ' selected' : '';
+      return `<option value="${c}"${selected}>${c}</option>`;
+    }).join('');
+    // Always emit <select> (disabled when empty) — keeps shape stable; no downstream branches.
+    const disabledAttr = supported.length === 0 ? ' disabled' : '';
+    const placeholderOpt = supported.length === 0
+      ? '<option value="">-- No M@S markets for this page --</option>'
+      : '<option value="">-- Select Market --</option>';
+    const standaloneClass = standalone ? ' standalone' : '';
+    return `
+      <div class="mep-experience-dropdown mep-mas-market-dropdown${standaloneClass}" ${hiddenAttr}>
+        <label for="mepMasMarketSelect${pageId}">Supported M@S Markets</label>
+        <select name="mepMasMarket${pageId}" id="mepMasMarketSelect${pageId}" class="mep-manifest-variants"${disabledAttr}>
+          ${placeholderOpt}
+          ${opts}
+        </select>
+      </div>`;
+  }
+  // Warm the cache for next popup open. Fire-and-forget.
+  if (!config?.marketsConfig) getMarketConfig();
+  const masMarketDropdownHTML = buildOptionsMasMarketSelect();
+  // Checkbox only makes sense between two dropdowns — suppress on non-Lingo (M@S alone).
+  const masMarketToggleHTML = (hasMas && lingoOk) ? `
+    <div class="mep-mas-market-toggle">
+      <input type="checkbox" name="mepMasMarket${pageId}"
+        id="mepMasMarketCheckbox${pageId}" ${mepMasMarketCheckedAttr} value="true">
+      <label for="mepMasMarketCheckbox${pageId}">Use M@S markets</label>
+    </div>` : '';
 
   function buildOptionsToggles() {
     const mepToggleOptions = createTag('div', { class: 'mep-section' });
@@ -686,6 +1311,12 @@ export async function getMepPopup(mepConfig, isMmm = false) {
         id="mepCaasHighlightCheckbox${pageId}" ${mepCaasHighlightChecked} value="true">
         <label for="mepCaasHighlightCheckbox${pageId}">Highlight CaaS</label>
       </div>
+      <div>
+        <input type="checkbox" name="mepMasHighlight${pageId}"
+        id="mepMasHighlightCheckbox${pageId}" ${mepMasHighlightChecked} value="true">
+        <label for="mepMasHighlightCheckbox${pageId}">Highlight M@S</label>
+        <div class="mep-mas-no-content" hidden>No M@S content found on this page.</div>
+      </div>
       ${showManifestsCheckbox}
       <div>
         <input type="checkbox" name="mepPreviewButtonCheckbox${pageId}"
@@ -694,6 +1325,8 @@ export async function getMepPopup(mepConfig, isMmm = false) {
       </div>
     </div>
     ${regionDropdownHTML}
+    ${masMarketToggleHTML}
+    ${masMarketDropdownHTML}
     <div>New manifest location or path*</div>
     <input type="text" name="new-manifest${pageId}" class="new-manifest">
   `;
@@ -827,6 +1460,75 @@ export async function getMepPopup(mepConfig, isMmm = false) {
   }
   await buildSummaryLingo();
 
+  // M@S summary. Surfaces Detected = Collections + Cards + Inline Fields + Standalone Offers.
+  // Sub-collections are a sub-row (live inside the parent collection payload, not a separate
+  // DOM surface). Counts query real elements (merch-card, mas-field, MAS_OSI_SELECTOR) — the
+  // [data-mas-block] stamps only land while mep.preview is on. Standalone Offers excludes
+  // card-internal offers (those add a ~5x multiplier per card; per-card "Edit OSI" handles them).
+  function buildSummaryMas() {
+    const collectionContainers = document.querySelectorAll('[data-mas-block="collection"]');
+    let subCollectionCount = 0;
+    collectionContainers.forEach((c) => {
+      subCollectionCount += mepMasSubCollections.get(c)?.length || 0;
+    });
+    const standaloneOfferCount = [...document.querySelectorAll(MAS_OSI_SELECTOR)]
+      .filter((el) => !el.closest('merch-card')).length;
+    const masCounts = {
+      collection: collectionContainers.length,
+      subCollection: subCollectionCount,
+      card: document.querySelectorAll('merch-card').length,
+      inlineField: document.querySelectorAll('mas-field').length,
+      standaloneOffer: standaloneOfferCount,
+    };
+    const masSurfaces = masCounts.collection
+      + masCounts.card
+      + masCounts.inlineField
+      + masCounts.standaloneOffer;
+    const geoDetectionOn = isMasGeoDetectionEnabled();
+    const masGeoDetectionParam = new URLSearchParams(window.location.search).get('mas-geo-detection');
+    const masGeoDetectionMeta = getMetadata('mas-geo-detection');
+    let geoDetectionSource = 'none';
+    if (geoDetectionOn) {
+      geoDetectionSource = masGeoDetectionParam ? 'URL param' : 'Metadata';
+    } else if (masGeoDetectionParam || masGeoDetectionMeta) {
+      geoDetectionSource = masGeoDetectionParam ? 'URL param (off)' : 'Metadata (off)';
+    }
+
+    const svc = document.head.querySelector('mas-commerce-service');
+    const liveCountry = svc?.getAttribute('country');
+    const localeCountry = getMiloLocaleSettings(config.locale)?.country;
+    const pageMarket = (liveCountry || localeCountry || '').toUpperCase() || 'unknown';
+    const pageMarketSource = liveCountry ? 'mas-commerce-service' : 'page locale';
+
+    const masHTML = `
+    <h6 class="mep-section-header">M@S</h6>
+    <div class="mep-section-data">
+      <span>Surfaces Detected</span>
+      <span>${masSurfaces}</span>
+      <span class="mep-mas-subitem">Collections</span>
+      <span>${masCounts.collection}</span>
+      <span class="mep-mas-subitem">Sub-collections</span>
+      <span>${masCounts.subCollection}</span>
+      <span class="mep-mas-subitem">Cards</span>
+      <span>${masCounts.card}</span>
+      <span class="mep-mas-subitem">Inline Fields</span>
+      <span>${masCounts.inlineField}</span>
+      <span class="mep-mas-subitem">Standalone Offers</span>
+      <span>${masCounts.standaloneOffer}</span>
+      <span>Geo Detection</span>
+      <span>${geoDetectionOn ? 'on' : 'off'}</span>
+      <span>Geo Source</span>
+      <span>${escapeHtml(geoDetectionSource)}</span>
+      <span>Page Market</span>
+      <span>${escapeHtml(pageMarket)}</span>
+      <span>Market Source</span>
+      <span>${escapeHtml(pageMarketSource)}</span>
+    </div>
+  `;
+    mepPopupBody[1].append(createTag('div', { class: 'mep-section' }, masHTML));
+  }
+  buildSummaryMas();
+
   // Inject Overlay
   function compileOverlay() {
     mepPopup.append(mepPopupHeader, mepPopupTabs, ...mepPopupBody);
@@ -841,6 +1543,20 @@ export async function getMepPopup(mepConfig, isMmm = false) {
     if (previewButton) updatePreviewButton(mepPopup, pageId);
   }
   compileOverlay();
+
+  // Cold-cache defer-populate: if marketsConfig wasn't ready at build time, await the fetch
+  // and re-render the dropdown in place. Guarded so it never clobbers user selection.
+  if (!config?.marketsConfig) {
+    getMarketConfig().then(() => {
+      const wrapper = mepPopup.querySelector('.mep-mas-market-dropdown');
+      if (!wrapper) return;
+      const existingSelect = wrapper.querySelector('select');
+      if (existingSelect?.value) return;
+      wrapper.outerHTML = buildOptionsMasMarketSelect();
+      const newSelect = mepPopup.querySelector(`select#mepMasMarketSelect${pageId}`);
+      newSelect?.addEventListener('change', () => updatePreviewButton(mepPopup, pageId));
+    });
+  }
 
   return mepPopup;
 }
@@ -1063,6 +1779,10 @@ export async function saveToMmm() {
 export default async function decoratePreviewMode() {
   const { miloLibs, codeRoot, mep } = getConfig();
   loadStyle(`${miloLibs || codeRoot}/features/personalization/preview.css`);
+  // Warm the M@S supported-markets cache so the spoofer dropdown is ready by popup open.
+  // Critical on non-Lingo pages (e.g., /products/photoshop) — no other consumer fetches
+  // this config before the popup builds. Fire-and-forget; getMarketConfig swallows errors.
+  getMarketConfig();
   await createPreviewPill();
   if (mep?.experiments) addHighlightData(mep.experiments);
   markDefaultFragments();
@@ -1070,6 +1790,10 @@ export default async function decoratePreviewMode() {
   if (document.body.dataset.mepCaasHighlight === 'true') {
     watchForCaasBlocks();
     injectCaasBadges();
+  }
+  if (document.body.dataset.mepMasHighlight === 'true') {
+    watchForMasContent();
+    injectMasBadges();
   }
   // Adjust badge positions after a short delay to allow rendering
   setTimeout(() => {

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -303,7 +303,8 @@ function annotateOffers() {
     if (!osi) return;
     const isPrice = el.matches('span[is="inline-price"]');
     const type = isPrice ? 'price' : 'checkoutUrl';
-    const ostUrl = `${OST_BASE_URL}?osi=${encodeURIComponent(osi)}&type=${type}`;
+    const pageMarket = getResolvedPageMarket();
+    const ostUrl = `${OST_BASE_URL}?osi=${encodeURIComponent(osi)}&type=${type}${pageMarket ? `&country=${encodeURIComponent(pageMarket)}` : ''}`;
     mepMasStudioUrls.set(el, ostUrl);
     el.dataset.masBlock = 'offer';
   });
@@ -353,7 +354,7 @@ function injectMasCardActionStack(card) {
       'a',
       {
         class: `${CARD_ACTION_OST_CLASS}${mismatchClass}`,
-        href: `https://milo.adobe.com/tools/ost?osi=${encodeURIComponent(osi)}`,
+        href: `${OST_BASE_URL}?osi=${encodeURIComponent(osi)}${market ? `&country=${encodeURIComponent(market)}` : ''}`,
         target: '_blank',
         rel: 'noopener noreferrer',
       },

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -337,7 +337,7 @@ function injectMasCardActionStack(card) {
   const marketSuffix = market ? ` \u00b7 ${market}` : '';
   const mismatchClass = mismatch ? ` ${CARD_ACTIONS_CLASS}-mismatch` : '';
 
-  stack.append(createTag(
+  const editLink = createTag(
     'a',
     {
       class: `${CARD_ACTION_EDIT_CLASS}${mismatchClass}`,
@@ -345,12 +345,13 @@ function injectMasCardActionStack(card) {
       target: '_blank',
       rel: 'noopener noreferrer',
     },
-    `Edit Card${marketSuffix}`,
-  ));
+  );
+  editLink.textContent = `Edit Card${marketSuffix}`;
+  stack.append(editLink);
 
   const osi = getCardFirstOsi(card);
   if (osi) {
-    stack.append(createTag(
+    const ostLink = createTag(
       'a',
       {
         class: `${CARD_ACTION_OST_CLASS}${mismatchClass}`,
@@ -358,8 +359,9 @@ function injectMasCardActionStack(card) {
         target: '_blank',
         rel: 'noopener noreferrer',
       },
-      `View in OST${marketSuffix}`,
-    ));
+    );
+    ostLink.textContent = `View in OST${marketSuffix}`;
+    stack.append(ostLink);
   }
 
   const fragmentId = getCardFragmentId(card);
@@ -417,8 +419,8 @@ function buildMasBadge(url, surface, market, pageMarket) {
     const chip = createTag(
       'span',
       { class: `${MAS_BADGE_CLASS}-market ${MAS_BADGE_CLASS}-market-${state}` },
-      market.toUpperCase(),
     );
+    chip.textContent = market.toUpperCase();
     a.append(' \u00b7 ', chip);
   }
   return a;
@@ -1505,32 +1507,29 @@ export async function getMepPopup(mepConfig, isMmm = false) {
     const pageMarket = (liveCountry || localeCountry || '').toUpperCase() || 'unknown';
     const pageMarketSource = liveCountry ? 'mas-commerce-service' : 'page locale';
 
-    const masHTML = `
-    <h6 class="mep-section-header">M@S</h6>
-    <div class="mep-section-data">
-      <span>Mas Geo Detection</span>
-      <span>${geoDetectionOn ? 'on' : 'off'}</span>
-      <span>Geo Source</span>
-      <span>${escapeHtml(geoDetectionSource)}</span>
-      <span>Page Market</span>
-      <span>${escapeHtml(pageMarket)}</span>
-      <span>Market Source</span>
-      <span>${escapeHtml(pageMarketSource)}</span>
-      <span>Surfaces Detected</span>
-      <span>${masSurfaces}</span>
-      <span class="mep-mas-subitem">Collections</span>
-      <span>${masCounts.collection}</span>
-      <span class="mep-mas-subitem">Sub-collections</span>
-      <span>${masCounts.subCollection}</span>
-      <span class="mep-mas-subitem">Cards</span>
-      <span>${masCounts.card}</span>
-      <span class="mep-mas-subitem">Inline Fields</span>
-      <span>${masCounts.inlineField}</span>
-      <span class="mep-mas-subitem">Standalone Offers</span>
-      <span>${masCounts.standaloneOffer}</span>
-    </div>
-  `;
-    mepPopupBody[1].append(createTag('div', { class: 'mep-section' }, masHTML));
+    const section = createTag('div', { class: 'mep-section' });
+    section.append(createTag('h6', { class: 'mep-section-header' }, 'M@S'));
+    const data = createTag('div', { class: 'mep-section-data' });
+    const rows = [
+      ['Mas Geo Detection', geoDetectionOn ? 'on' : 'off'],
+      ['Geo Source', geoDetectionSource],
+      ['Page Market', pageMarket],
+      ['Market Source', pageMarketSource],
+      ['Surfaces Detected', masSurfaces],
+      ['Collections', masCounts.collection, true],
+      ['Sub-collections', masCounts.subCollection, true],
+      ['Cards', masCounts.card, true],
+      ['Inline Fields', masCounts.inlineField, true],
+      ['Standalone Offers', masCounts.standaloneOffer, true],
+    ];
+    rows.forEach(([label, value, sub]) => {
+      data.append(createTag('span', sub ? { class: 'mep-mas-subitem' } : null, label));
+      const valueSpan = createTag('span');
+      valueSpan.textContent = String(value);
+      data.append(valueSpan);
+    });
+    section.append(data);
+    mepPopupBody[1].append(section);
   }
   buildSummaryMas();
 

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -298,7 +298,7 @@ const OST_BASE_URL = 'https://milo.adobe.com/tools/ost';
 // type=price/checkoutUrl pre-selects the correct OST tab. Idempotent.
 function annotateOffers() {
   document.querySelectorAll(MAS_OSI_SELECTOR).forEach((el) => {
-    if (el.dataset.masBlock) return;
+    if (mepMasStudioUrls.has(el)) return;
     const osi = el.getAttribute('data-wcs-osi');
     if (!osi) return;
     const isPrice = el.matches('span[is="inline-price"]');
@@ -306,7 +306,7 @@ function annotateOffers() {
     const pageMarket = getResolvedPageMarket();
     const ostUrl = `${OST_BASE_URL}?osi=${encodeURIComponent(osi)}&type=${type}${pageMarket ? `&country=${encodeURIComponent(pageMarket)}` : ''}`;
     mepMasStudioUrls.set(el, ostUrl);
-    el.dataset.masBlock = 'offer';
+    if (!el.dataset.masBlock) el.dataset.masBlock = 'offer';
   });
 }
 

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -138,10 +138,10 @@ const MAS_BADGE_CLASS = 'mep-mas-edit-badge';
 const MAS_LABELS = {
   collection: 'Edit Collection in M@S Studio',
   card: 'Edit Card in M@S Studio',
-  inline: 'Edit Inline Field in M@S Studio',
-  ost: 'Edit in OSI',
+  inline: 'Edit Inline Field',
+  ost: 'View in OST',
   // 'offer' surface is CSS-only (::before pseudo) — label kept for symmetry.
-  offer: 'Edit in OSI',
+  offer: 'View in OST',
 };
 
 // Mirrors SELECTOR_MAS_INLINE_PRICE et al. from ../mas/web-components/src/
@@ -320,7 +320,7 @@ function getCardFragmentId(card) {
   return card.querySelector('aem-fragment[fragment]')?.getAttribute('fragment') || null;
 }
 
-// Edit OSI uses the first OSI — M@S confirmed all OSIs in a card are equivalent.
+// View in OST uses the first OSI — M@S confirmed all OSIs in a card are equivalent.
 function getCardFirstOsi(card) {
   return card.querySelector('[data-wcs-osi]')?.getAttribute('data-wcs-osi') || null;
 }
@@ -358,7 +358,7 @@ function injectMasCardActionStack(card) {
         target: '_blank',
         rel: 'noopener noreferrer',
       },
-      `Edit OSI${marketSuffix}`,
+      `View in OST${marketSuffix}`,
     ));
   }
 
@@ -492,30 +492,36 @@ const PSEUDO_BADGE_HIT = {
 
 // Pseudos can't carry an href — delegate clicks in the hit box to open the captured URL.
 // preventDefault + stopPropagation suppress the host's normal navigation (checkout/CTA).
+// Iterate all candidates: nested surfaces (e.g. offer inside inline) appear first in
+// composedPath, so we try each until one whose hit box actually contains the click.
 function handleChildCardBadgeClick(e) {
   if (document.body.dataset.mepMasHighlight !== 'true') return;
   // composedPath() crosses shadow boundaries — clicks originate inside the
   // merch-card / commerce-element shadow roots.
-  const host = e.composedPath().find((n) => {
+  const candidates = e.composedPath().filter((n) => {
     if (n?.nodeType !== 1) return false;
     const surface = n.dataset?.masBlock;
     return surface === 'offer' || surface === 'inline' || surface === 'ost';
   });
-  if (!host) return;
-  const url = mepMasStudioUrls.get(host);
-  if (!url) return;
-  const hit = PSEUDO_BADGE_HIT[host.dataset.masBlock];
-  if (!hit) return;
-  const rect = host.getBoundingClientRect();
-  const yMin = rect.top + hit.top;
-  const inBadge = e.clientX >= rect.right - hit.w
-    && e.clientX <= rect.right
-    && e.clientY >= yMin
-    && e.clientY <= yMin + hit.h;
-  if (!inBadge) return;
-  e.preventDefault();
-  e.stopPropagation();
-  window.open(url, '_blank', 'noopener,noreferrer');
+  for (const host of candidates) {
+    const url = mepMasStudioUrls.get(host);
+    if (!url) continue;
+    const hit = PSEUDO_BADGE_HIT[host.dataset.masBlock];
+    if (!hit) continue;
+    const rect = host.getBoundingClientRect();
+    const isNestedInInline = host.dataset.masBlock !== 'inline' && !!host.closest('[data-mas-block="inline"]');
+    const hitTop = isNestedInInline ? rect.height + 4 : hit.top;
+    const yMin = rect.top + hitTop;
+    const inBadge = e.clientX >= rect.right - hit.w
+      && e.clientX <= rect.right
+      && e.clientY >= yMin
+      && e.clientY <= yMin + hit.h;
+    if (!inBadge) continue;
+    e.preventDefault();
+    e.stopPropagation();
+    window.open(url, '_blank', 'noopener,noreferrer');
+    return;
+  }
 }
 
 let masObserver;
@@ -1440,7 +1446,7 @@ export async function getMepPopup(mepConfig, isMmm = false) {
         <span>Total</span>
         <span>${lingoData.total}</span>
       ` : `
-        <span>Page Updates</span>
+        <span>Mep Lingo Updates</span>
         <span>${lingoData.updates}</span>
       `}
         <span>Lang First / Lingo</span>
@@ -1465,7 +1471,7 @@ export async function getMepPopup(mepConfig, isMmm = false) {
   // Sub-collections are a sub-row (live inside the parent collection payload, not a separate
   // DOM surface). Counts query real elements (merch-card, mas-field, MAS_OSI_SELECTOR) — the
   // [data-mas-block] stamps only land while mep.preview is on. Standalone Offers excludes
-  // card-internal offers (those add a ~5x multiplier per card; per-card "Edit OSI" handles them).
+  // card-internal offers (~5x multiplier per card; per-card "View in OST" handles them).
   function buildSummaryMas() {
     const collectionContainers = document.querySelectorAll('[data-mas-block="collection"]');
     let subCollectionCount = 0;
@@ -1504,6 +1510,14 @@ export async function getMepPopup(mepConfig, isMmm = false) {
     const masHTML = `
     <h6 class="mep-section-header">M@S</h6>
     <div class="mep-section-data">
+      <span>Mas Geo Detection</span>
+      <span>${geoDetectionOn ? 'on' : 'off'}</span>
+      <span>Geo Source</span>
+      <span>${escapeHtml(geoDetectionSource)}</span>
+      <span>Page Market</span>
+      <span>${escapeHtml(pageMarket)}</span>
+      <span>Market Source</span>
+      <span>${escapeHtml(pageMarketSource)}</span>
       <span>Surfaces Detected</span>
       <span>${masSurfaces}</span>
       <span class="mep-mas-subitem">Collections</span>
@@ -1516,14 +1530,6 @@ export async function getMepPopup(mepConfig, isMmm = false) {
       <span>${masCounts.inlineField}</span>
       <span class="mep-mas-subitem">Standalone Offers</span>
       <span>${masCounts.standaloneOffer}</span>
-      <span>Geo Detection</span>
-      <span>${geoDetectionOn ? 'on' : 'off'}</span>
-      <span>Geo Source</span>
-      <span>${escapeHtml(geoDetectionSource)}</span>
-      <span>Page Market</span>
-      <span>${escapeHtml(pageMarket)}</span>
-      <span>Market Source</span>
-      <span>${escapeHtml(pageMarketSource)}</span>
     </div>
   `;
     mepPopupBody[1].append(createTag('div', { class: 'mep-section' }, masHTML));

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -9,6 +9,7 @@ import {
   normCountryCode,
   resolveDetectedMarketCountry,
 } from '../../utils/utils.js';
+import { mepCaasConfigUrls } from '../../blocks/caas/utils.js';
 import { US_GEO, getFileName, normalizePath } from './personalization.js';
 
 export function escapeHtml(str) {
@@ -27,6 +28,94 @@ export const API_URLS = {
   save: `${API_DOMAIN}/save-mep-call`,
   report: `${API_DOMAIN}/get-report`,
 };
+
+const CAAS_BADGE_CLASS = 'mep-caas-edit-badge';
+const PREVIEW_HOST_RE = /\.(aem|hlx)\.(page|live)$/;
+const BLOG_PATH_RE = /^\/(?:[^/]+\/)?blog\//i;
+const PREVIEW_REPO_HOST_RE = /^(.+?)--(.+?)--adobecom\.aem\.(page|live)$/;
+
+function rewriteForPreviewHost(url) {
+  if (!url) return url;
+  const isPreview = PREVIEW_HOST_RE.test(window.location.host)
+    || window.location.search.includes('milolibs=');
+  if (!isPreview) return url;
+  try {
+    const u = new URL(url);
+    const { prodDomains = ['business.adobe.com', 'www.adobe.com', 'news.adobe.com'] } = getConfig();
+    if (!prodDomains.includes(u.host)) return u.toString();
+    u.protocol = window.location.protocol;
+    u.host = window.location.host;
+    if (PREVIEW_HOST_RE.test(u.host)) u.pathname = u.pathname.replace(/\.html$/, '');
+    return u.toString();
+  } catch { return url; }
+}
+
+function rewriteBlogPreviewHost(url) {
+  if (!url) return null;
+  const m = window.location.host.match(PREVIEW_REPO_HOST_RE);
+  if (!m) return null;
+  const [, branch, repo, env] = m;
+  if (repo.endsWith('-blog')) return null;
+  try {
+    const u = new URL(url);
+    if (u.host !== 'business.adobe.com') return null;
+    if (!BLOG_PATH_RE.test(u.pathname)) return null;
+    u.protocol = window.location.protocol;
+    u.host = `${branch}--${repo}-blog--adobecom.aem.${env}`;
+    u.pathname = u.pathname.replace(/\.html$/, '');
+    return u.toString();
+  } catch { return null; }
+}
+
+function derivePathsForCards(root = document) {
+  root.querySelectorAll('[data-card-url]:not([data-card-path])').forEach((el) => {
+    const href = el.dataset.cardUrl;
+    if (!href) { el.dataset.cardPath = ''; return; }
+    try {
+      el.dataset.cardPath = new URL(href).pathname;
+    } catch {
+      el.dataset.cardPath = '';
+    }
+  });
+}
+
+function injectCaasBadges() {
+  document.querySelectorAll('[data-caas-block]').forEach((el) => {
+    const prev = el.previousElementSibling;
+    if (prev?.classList?.contains(CAAS_BADGE_CLASS)) return;
+    const url = mepCaasConfigUrls.get(el);
+    if (!url) return;
+    const a = createTag(
+      'a',
+      {
+        class: CAAS_BADGE_CLASS,
+        href: url,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      },
+      'Edit in CaaS Configurator',
+    );
+    el.insertAdjacentElement('beforebegin', a);
+  });
+  derivePathsForCards();
+}
+
+function removeCaasBadges() {
+  document.querySelectorAll(`a.${CAAS_BADGE_CLASS}`).forEach((el) => el.remove());
+}
+
+let caasObserver;
+function watchForCaasBlocks() {
+  if (caasObserver) return;
+  caasObserver = new MutationObserver((mutations) => {
+    if (document.body.dataset.mepCaasHighlight !== 'true') return;
+    const hasCaasMutation = mutations.some((m) => [...m.addedNodes].some((n) => (n.nodeType === 1)
+      && (n.matches?.('[data-caas-block], [data-card-url]')
+        || n.querySelector?.('[data-caas-block], [data-card-url]'))));
+    if (hasCaasMutation) injectCaasBadges();
+  });
+  caasObserver.observe(document.body, { childList: true, subtree: true });
+}
 
 function updatePreviewButton(popup, pageId) {
   const selectedInputs = popup.querySelectorAll(
@@ -81,6 +170,21 @@ function updatePreviewButton(popup, pageId) {
     simulateHref.searchParams.set('mepFragments', true);
   } else {
     simulateHref.searchParams.delete('mepFragments');
+  }
+
+  const mepCaasHighlightCheckbox = popup.querySelector(
+    `input[type="checkbox"]#mepCaasHighlightCheckbox${pageId}`,
+  );
+
+  if (mepCaasHighlightCheckbox) {
+    document.body.dataset.mepCaasHighlight = mepCaasHighlightCheckbox.checked;
+    if (mepCaasHighlightCheckbox.checked) {
+      simulateHref.searchParams.set('mepCaasHighlight', true);
+      injectCaasBadges();
+    } else {
+      simulateHref.searchParams.delete('mepCaasHighlight');
+      removeCaasBadges();
+    }
   }
 
   const mepPreviewButtonCheckbox = popup.querySelector(
@@ -427,6 +531,7 @@ export async function getMepPopup(mepConfig, isMmm = false) {
   const urlParams = new URLSearchParams(window.location.search);
   const highlightParam = urlParams.get('mepHighlight');
   const fragmentsParam = urlParams.get('mepFragments');
+  const caasHighlightParam = urlParams.get('mepCaasHighlight');
 
   let mepHighlightChecked = '';
   if (page?.highlight || highlightParam === 'true') {
@@ -437,6 +542,11 @@ export async function getMepPopup(mepConfig, isMmm = false) {
   if (page?.fragments || fragmentsParam === 'true') {
     mepFragmentsChecked = 'checked="checked"';
     document.body.dataset.mepFragments = true;
+  }
+  let mepCaasHighlightChecked = '';
+  if (caasHighlightParam === 'true') {
+    mepCaasHighlightChecked = 'checked="checked"';
+    document.body.dataset.mepCaasHighlight = true;
   }
   const PREVIEW_BUTTON_ID = 'preview-button';
   const pageUrl = isMmm ? page.url : new URL(window.location.href).href;
@@ -560,6 +670,11 @@ export async function getMepPopup(mepConfig, isMmm = false) {
         <input type="checkbox" name="mepFragments${pageId}"
         id="mepFragmentsCheckbox${pageId}" ${mepFragmentsChecked} value="true">
         <label for="mepFragmentsCheckbox${pageId}">Highlight fragments</label>
+      </div>
+      <div>
+        <input type="checkbox" name="mepCaasHighlight${pageId}"
+        id="mepCaasHighlightCheckbox${pageId}" ${mepCaasHighlightChecked} value="true">
+        <label for="mepCaasHighlightCheckbox${pageId}">Highlight CaaS</label>
       </div>
       ${showManifestsCheckbox}
       <div>
@@ -842,13 +957,14 @@ function addFragmentBadgeClickHandlers() {
   document.body.addEventListener('click', (e) => {
     const isHighlightEnabled = document.body.dataset.mepHighlight === 'true';
     const isFragmentsEnabled = document.body.dataset.mepFragments === 'true';
-    if (!isHighlightEnabled && !isFragmentsEnabled) return;
+    const isCaasHighlightEnabled = document.body.dataset.mepCaasHighlight === 'true';
+    if (!isHighlightEnabled && !isFragmentsEnabled && !isCaasHighlightEnabled) return;
 
     // Ignore clicks from within the MEP popup
     if (e.target.closest('.mep-preview-overlay')) return;
 
     // Find the badged element that was clicked (includes non-fragment badges)
-    const fragment = e.target.closest('[data-mep-lingo-roc], [data-mep-lingo-fallback], [data-manifest-id], [data-fragment-default]');
+    const fragment = e.target.closest('[data-mep-lingo-roc], [data-mep-lingo-fallback], [data-manifest-id], [data-fragment-default], [data-card-url]');
     if (!fragment) return;
 
     const elementStyle = window.getComputedStyle(fragment);
@@ -861,7 +977,12 @@ function addFragmentBadgeClickHandlers() {
     const badgeHeight = parseFloat(beforeStyles.height)
       || parseFloat(beforeStyles.minHeight)
       || 35;
-    const fragmentPath = fragment.dataset.path || fragment.dataset.fragmentPath;
+    let fragmentPath = fragment.dataset.path
+      || fragment.dataset.fragmentPath
+      || fragment.dataset.cardUrl;
+    if (fragment.dataset.cardUrl) {
+      fragmentPath = rewriteBlogPreviewHost(fragmentPath) || rewriteForPreviewHost(fragmentPath);
+    }
     const badgeTopOffset = parseFloat(fragment.style.getPropertyValue('--badge-top-offset')) || 0;
     const handleBadgeClick = () => {
       e.preventDefault();
@@ -936,6 +1057,8 @@ export default async function decoratePreviewMode() {
   if (mep?.experiments) addHighlightData(mep.experiments);
   markDefaultFragments();
   addFragmentBadgeClickHandlers();
+  watchForCaasBlocks();
+  if (document.body.dataset.mepCaasHighlight === 'true') injectCaasBadges();
   // Adjust badge positions after a short delay to allow rendering
   setTimeout(() => {
     adjustBadgesForZeroHeightSections();

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -102,6 +102,8 @@ function injectCaasBadges() {
 
 function removeCaasBadges() {
   document.querySelectorAll(`a.${CAAS_BADGE_CLASS}`).forEach((el) => el.remove());
+  // Clear derived paths so they don't sit in the DOM as invisible state.
+  document.querySelectorAll('[data-card-path]').forEach((el) => delete el.dataset.cardPath);
 }
 
 let caasObserver;
@@ -115,6 +117,12 @@ function watchForCaasBlocks() {
     if (hasCaasMutation) injectCaasBadges();
   });
   caasObserver.observe(document.body, { childList: true, subtree: true });
+}
+
+function unwatchForCaasBlocks() {
+  if (!caasObserver) return;
+  caasObserver.disconnect();
+  caasObserver = null;
 }
 
 function updatePreviewButton(popup, pageId) {
@@ -180,9 +188,11 @@ function updatePreviewButton(popup, pageId) {
     document.body.dataset.mepCaasHighlight = mepCaasHighlightCheckbox.checked;
     if (mepCaasHighlightCheckbox.checked) {
       simulateHref.searchParams.set('mepCaasHighlight', true);
+      watchForCaasBlocks();
       injectCaasBadges();
     } else {
       simulateHref.searchParams.delete('mepCaasHighlight');
+      unwatchForCaasBlocks();
       removeCaasBadges();
     }
   }
@@ -1057,8 +1067,10 @@ export default async function decoratePreviewMode() {
   if (mep?.experiments) addHighlightData(mep.experiments);
   markDefaultFragments();
   addFragmentBadgeClickHandlers();
-  watchForCaasBlocks();
-  if (document.body.dataset.mepCaasHighlight === 'true') injectCaasBadges();
+  if (document.body.dataset.mepCaasHighlight === 'true') {
+    watchForCaasBlocks();
+    injectCaasBadges();
+  }
   // Adjust badge positions after a short delay to allow rendering
   setTimeout(() => {
     adjustBadgesForZeroHeightSections();

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -503,25 +503,23 @@ function handleChildCardBadgeClick(e) {
     const surface = n.dataset?.masBlock;
     return surface === 'offer' || surface === 'inline' || surface === 'ost';
   });
-  for (const host of candidates) {
-    const url = mepMasStudioUrls.get(host);
-    if (!url) continue;
+  const match = candidates.find((host) => {
+    if (!mepMasStudioUrls.get(host)) return false;
     const hit = PSEUDO_BADGE_HIT[host.dataset.masBlock];
-    if (!hit) continue;
+    if (!hit) return false;
     const rect = host.getBoundingClientRect();
     const isNestedInInline = host.dataset.masBlock !== 'inline' && !!host.closest('[data-mas-block="inline"]');
     const hitTop = isNestedInInline ? rect.height + 4 : hit.top;
     const yMin = rect.top + hitTop;
-    const inBadge = e.clientX >= rect.right - hit.w
+    return e.clientX >= rect.right - hit.w
       && e.clientX <= rect.right
       && e.clientY >= yMin
       && e.clientY <= yMin + hit.h;
-    if (!inBadge) continue;
-    e.preventDefault();
-    e.stopPropagation();
-    window.open(url, '_blank', 'noopener,noreferrer');
-    return;
-  }
+  });
+  if (!match) return;
+  e.preventDefault();
+  e.stopPropagation();
+  window.open(mepMasStudioUrls.get(match), '_blank', 'noopener,noreferrer');
 }
 
 let masObserver;

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -135,14 +135,9 @@ function unwatchForCaasBlocks() {
 }
 
 const MAS_BADGE_CLASS = 'mep-mas-edit-badge';
-const MAS_LABELS = {
-  collection: 'Edit Collection in M@S Studio',
-  card: 'Edit Card in M@S Studio',
-  inline: 'Edit Inline Field',
-  ost: 'View in OST',
-  // 'offer' surface is CSS-only (::before pseudo) — label kept for symmetry.
-  offer: 'View in OST',
-};
+// Only 'collection' reaches buildMasBadge. Card uses an action stack;
+// inline/ost/offer render via CSS ::before pseudos.
+const MAS_LABELS = { collection: 'Edit Collection in M@S Studio' };
 
 // Mirrors SELECTOR_MAS_INLINE_PRICE et al. from ../mas/web-components/src/
 // constants.js. Inlined rather than imported to avoid a hard runtime
@@ -150,6 +145,7 @@ const MAS_LABELS = {
 const MAS_OSI_SELECTOR = [
   'span[is="inline-price"][data-wcs-osi]',
   'a[is="checkout-link"][data-wcs-osi]',
+  'a[is="upt-link"][data-wcs-osi]',
   'button[is="checkout-button"][data-wcs-osi]',
   'sp-button[data-wcs-osi]',
 ].join(',');
@@ -208,10 +204,13 @@ export function getCardMarket(el, pageMarket) {
       if (country) return normCountryCode(country.toLowerCase());
     } catch (e) { /* skip and try next candidate */ }
   }
+  // Only checkout-mixin and upt-link set data-ims-country; display-only
+  // (inline-price) cards fall back to pageMarket.
   return pageMarket;
 }
 
-// 'unknown' when either side is unresolved — consumers skip the chip color for it.
+// Returns 'unknown' when either side is unresolved — only 'mismatch' is
+// surfaced visually.
 function classifyMarket(cardMarket, pageMarket) {
   if (!cardMarket || !pageMarket) return 'unknown';
   return cardMarket === pageMarket ? 'match' : 'mismatch';
@@ -412,14 +411,13 @@ function buildMasBadge(url, surface, market, pageMarket) {
       target: '_blank',
       rel: 'noopener noreferrer',
     },
-    MAS_LABELS[surface] || 'Edit in M@S Studio',
+    MAS_LABELS[surface],
   );
   if (market) {
-    const state = classifyMarket(market, pageMarket);
-    const chip = createTag(
-      'span',
-      { class: `${MAS_BADGE_CLASS}-market ${MAS_BADGE_CLASS}-market-${state}` },
-    );
+    const chip = createTag('span', { class: `${MAS_BADGE_CLASS}-market` });
+    if (classifyMarket(market, pageMarket) === 'mismatch') {
+      chip.classList.add(`${MAS_BADGE_CLASS}-market-mismatch`);
+    }
     chip.textContent = market.toUpperCase();
     a.append(' \u00b7 ', chip);
   }

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { setConfig } from '../../../libs/utils/utils.js';
+import { mepMasStudioUrls } from '../../../libs/blocks/merch/mas-mep-utils.js';
 
 // TODO: Remove once mas-field is published to @adobecom/mas-platform.
 // All other MAS components (merch-card, merch-quantity-select, etc.) resolve via the import map
@@ -569,6 +570,82 @@ describe('merch-card-autoblock autoblock', () => {
       expect(badgeText).to.equal('EXCLUSIVE');
       expect(badge.getAttribute('background-color')).to.equal('#1976D2');
       // Badge color is disabled for simplified-pricing-express variant
+    });
+  });
+
+  describe('MEP Highlight M@S Content markers', () => {
+    // Defensive clear — prior describes can leak async-hydrated <merch-card> nodes.
+    beforeEach(() => { document.body.innerHTML = ''; });
+    afterEach(() => { document.body.innerHTML = ''; });
+
+    it('createCard stamps data-mas-block=card and captures original href in mepMasStudioUrls when mep.preview is on', async () => {
+      setConfig({ codeRoot: '/libs', autoBlocks: [{}], mep: { preview: true } });
+      const studioHref = 'https://mas.adobe.com/studio.html#content-type=merch-card&path=acom&query=a657fd3d9f67';
+      const a = document.createElement('a');
+      a.setAttribute('href', studioHref);
+      a.textContent = 'merch-card: ACOM / Catalog / Test Card';
+      const wrap = document.createElement('div');
+      wrap.classList.add('content');
+      wrap.id = 'mep-card-test-wrap';
+      wrap.append(a);
+      document.body.append(wrap);
+      await init(a);
+      const card = wrap.querySelector('merch-card');
+      expect(card, 'merch-card should be created inside the test container').to.exist;
+      expect(card.dataset.masBlock).to.equal('card');
+      expect(mepMasStudioUrls.get(card)).to.equal(studioHref);
+    });
+
+    it('createCard does NOT stamp data-mas-block or capture href when mep.preview is off', async () => {
+      setConfig({ codeRoot: '/libs', autoBlocks: [{}] });
+      const studioHref = 'https://mas.adobe.com/studio.html#content-type=merch-card&path=acom&query=a657fd3d9f67';
+      const a = document.createElement('a');
+      a.setAttribute('href', studioHref);
+      a.textContent = 'merch-card: ACOM / Catalog / Test Card';
+      const wrap = document.createElement('div');
+      wrap.classList.add('content');
+      wrap.id = 'mep-card-test-wrap-off';
+      wrap.append(a);
+      document.body.append(wrap);
+      await init(a);
+      const card = wrap.querySelector('merch-card');
+      expect(card, 'merch-card should be created inside the test container').to.exist;
+      expect(card.dataset.masBlock).to.equal(undefined);
+      expect(mepMasStudioUrls.get(card)).to.equal(undefined);
+    });
+
+    it('createInline stamps data-mas-block=inline and captures original href on the mas-field wrapper when mep.preview is on', async () => {
+      setConfig({ codeRoot: '/libs', autoBlocks: [{}], mep: { preview: true } });
+      const studioHref = 'https://mas.adobe.com/studio.html#content-type=merch-card&path=acom&query=9de46774-dafe-4f3e-badd-0cbeed37ea08&field=description';
+      const a = document.createElement('a');
+      a.href = studioHref;
+      a.textContent = '[[my-card:description]]';
+      const wrap = document.createElement('div');
+      wrap.id = 'mep-inline-test-wrap';
+      wrap.append(a);
+      document.body.append(wrap);
+      await init(a);
+      const masField = wrap.querySelector('mas-field');
+      expect(masField, 'mas-field should be created inside the test container').to.exist;
+      expect(masField.dataset.masBlock).to.equal('inline');
+      expect(mepMasStudioUrls.get(masField)).to.equal(studioHref);
+    });
+
+    it('createInline does NOT stamp data-mas-block or capture href when mep.preview is off', async () => {
+      setConfig({ codeRoot: '/libs', autoBlocks: [{}] });
+      const studioHref = 'https://mas.adobe.com/studio.html#content-type=merch-card&path=acom&query=9de46774-dafe-4f3e-badd-0cbeed37ea08&field=description';
+      const a = document.createElement('a');
+      a.href = studioHref;
+      a.textContent = '[[my-card:description]]';
+      const wrap = document.createElement('div');
+      wrap.id = 'mep-inline-test-wrap-off';
+      wrap.append(a);
+      document.body.append(wrap);
+      await init(a);
+      const masField = wrap.querySelector('mas-field');
+      expect(masField, 'mas-field should be created inside the test container').to.exist;
+      expect(masField.dataset.masBlock).to.equal(undefined);
+      expect(mepMasStudioUrls.get(masField)).to.equal(undefined);
     });
   });
 });

--- a/test/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.test.js
+++ b/test/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 import { delay } from '../../helpers/waitfor.js';
 import init from '../../../libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js';
 import { setConfig } from '../../../libs/utils/utils.js';
+import { mepMasStudioUrls } from '../../../libs/blocks/merch/mas-mep-utils.js';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 const conf = { locales, miloLibs: '/libs' };
@@ -329,6 +330,51 @@ describe('merch-card-collection autoblock', () => {
       const listIndex = sidenavChildren.indexOf(sidenavList);
       const checkboxIndex = sidenavChildren.indexOf(checkboxGroup);
       expect(checkboxIndex).to.be.greaterThan(listIndex);
+    });
+  });
+
+  describe('MEP Highlight M@S Content markers', () => {
+    beforeEach(() => { document.body.innerHTML = ''; });
+    afterEach(() => { document.body.innerHTML = ''; });
+
+    it('createCollection stamps data-mas-block=collection on the container and captures original href in mepMasStudioUrls when mep.preview is on', async () => {
+      setConfig({ ...conf, mep: { preview: true } });
+      const studioHref = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=e58f8f75-b882-409a-9ff8-8826b36a8368';
+      const wrap = document.createElement('div');
+      wrap.classList.add('content');
+      wrap.id = 'mep-collection-test-wrap';
+      const a = document.createElement('a');
+      a.setAttribute('href', studioHref);
+      a.textContent = 'merch-card-collection: SANDBOX / Individual Plans';
+      wrap.append(a);
+      document.body.append(wrap);
+      await init(a);
+      const container = wrap.querySelector('.collection-container');
+      expect(container, 'collection container should be created inside the test wrap').to.exist;
+      expect(container.dataset.masBlock).to.equal('collection');
+      expect(mepMasStudioUrls.get(container)).to.equal(studioHref);
+    });
+
+    it('createCollection does NOT stamp or capture href when mep.preview is off', async () => {
+      // The MEP block is gated atomically — both stamps absent means the
+      // dynamic import + attachAemLoadListener were skipped too. (We can't
+      // spy aem:load directly: M@S's <merch-card> attaches its own internal
+      // listener via handleAemFragmentEvents.)
+      setConfig({ ...conf, mep: { preview: false } });
+      const studioHref = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=e58f8f75-b882-409a-9ff8-8826b36a8368';
+      const wrap = document.createElement('div');
+      wrap.classList.add('content');
+      wrap.id = 'mep-collection-test-wrap-off';
+      const a = document.createElement('a');
+      a.setAttribute('href', studioHref);
+      a.textContent = 'merch-card-collection: SANDBOX / Individual Plans';
+      wrap.append(a);
+      document.body.append(wrap);
+      await init(a);
+      const container = wrap.querySelector('.collection-container');
+      expect(container, 'collection container should be created inside the test wrap').to.exist;
+      expect(container.dataset.masBlock).to.equal(undefined);
+      expect(mepMasStudioUrls.get(container)).to.equal(undefined);
     });
   });
 });

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -3,6 +3,7 @@ import { CheckoutWorkflowStep, Defaults, Log } from '@adobecom/mas-platform/web-
 import { expect } from '@esm-bundle/chai';
 import { delay } from '../../helpers/waitfor.js';
 
+import { mepMasStudioUrls } from '../../../libs/blocks/merch/mas-mep-utils.js';
 import merch, {
   PRICE_TEMPLATE_DISCOUNT,
   PRICE_TEMPLATE_OPTICAL,
@@ -360,6 +361,48 @@ describe('Merch Block', () => {
     it('renders merch link to GB price', async () => {
       const el = await validatePriceSpan('.merch.price.gb', {});
       expect(/£/.test(el.textContent)).to.be.true;
+    });
+
+    it('MEP Highlight M@S: stamps data-mas-block=ost and captures original /tools/ost href when mep.preview is on', async () => {
+      setConfig({ ...config, mep: { preview: true } });
+      // Earlier tests consume the canned mock anchors via replaceWith; build
+      // a fresh link in a scoped container.
+      const wrap = createTag('div', { id: 'mep-ost-test-wrap', class: 'merch-mep-ost-test' });
+      const link = createTag(
+        'a',
+        { class: 'merch price', href: '/tools/ost?osi=03&type=price&term=false' },
+        'Price - MEP Test',
+      );
+      wrap.append(link);
+      document.body.append(wrap);
+      const originalHref = link.href;
+      expect(originalHref).to.include('/tools/ost?');
+      const renderedEl = await merch(link);
+      await renderedEl.onceSettled();
+      expect(renderedEl.dataset.masBlock).to.equal('ost');
+      const captured = mepMasStudioUrls.get(renderedEl);
+      expect(captured).to.equal(originalHref);
+      expect(captured).to.include('osi=03');
+      expect(captured).to.include('type=price');
+      expect(captured).to.include('term=false');
+      wrap.remove();
+    });
+
+    it('MEP Highlight M@S: does NOT stamp data-mas-block or capture href when mep.preview is off', async () => {
+      // beforeEach calls setConfig(config) with no mep.preview.
+      const wrap = createTag('div', { id: 'mep-ost-test-wrap-off', class: 'merch-mep-ost-test-off' });
+      const link = createTag(
+        'a',
+        { class: 'merch price', href: '/tools/ost?osi=03&type=price&term=false' },
+        'Price - MEP Test',
+      );
+      wrap.append(link);
+      document.body.append(wrap);
+      const renderedEl = await merch(link);
+      await renderedEl.onceSettled();
+      expect(renderedEl.dataset.masBlock).to.equal(undefined);
+      expect(mepMasStudioUrls.get(renderedEl)).to.equal(undefined);
+      wrap.remove();
     });
   });
 

--- a/test/blocks/mmm/mmm.test.js
+++ b/test/blocks/mmm/mmm.test.js
@@ -115,9 +115,14 @@ describe('MMM', () => {
     const mepPopupBody = mmmPopup.querySelector('.mep-popup-body');
     expect(mepPopupBody).to.exist;
     const radios = mepPopupBody.querySelectorAll('select');
+    // 3 = Lingo region + 2 variant selects. M@S market select is gated on
+    // hasMasSurfaces() and this fixture has no M@S content.
     expect(radios.length).to.equal(3);
     const checkboxes = mepPopupBody.querySelectorAll('input[type="checkbox"]');
-    expect(checkboxes.length).to.equal(4);
+    // 5 = mepHighlight + mepFragments + mepCaasHighlight + mepMasHighlight +
+    // mepPreviewButton. mepMasMarketCheckbox is gated on (hasMas && lingoOk);
+    // showManifestsCheckbox is gated on !isMmm.
+    expect(checkboxes.length).to.equal(5);
     const inputs = mepPopupBody.querySelectorAll('input[type="text"]');
     expect(inputs.length).to.equal(1);
     const editButton = mepPopupBody.querySelector('.mep-edit-manifest');

--- a/test/blocks/mmm/mmm.test.js
+++ b/test/blocks/mmm/mmm.test.js
@@ -117,7 +117,7 @@ describe('MMM', () => {
     const radios = mepPopupBody.querySelectorAll('select');
     expect(radios.length).to.equal(3);
     const checkboxes = mepPopupBody.querySelectorAll('input[type="checkbox"]');
-    expect(checkboxes.length).to.equal(3);
+    expect(checkboxes.length).to.equal(4);
     const inputs = mepPopupBody.querySelectorAll('input[type="text"]');
     expect(inputs.length).to.equal(1);
     const editButton = mepPopupBody.querySelector('.mep-edit-manifest');

--- a/test/features/personalization/preview-mas-subcollection.test.js
+++ b/test/features/personalization/preview-mas-subcollection.test.js
@@ -1,0 +1,413 @@
+import { expect } from '@esm-bundle/chai';
+
+const {
+  extractSubCollections,
+  toSubCollectionStudioUrl,
+  attachAemLoadListener,
+  injectSubCollectionBadge,
+  removeSubCollectionBadges,
+  mepMasSubCollections,
+  SUB_COLLECTION_BADGE_CLASS,
+  getSubCollectionsFor,
+} = await import('../../../libs/features/personalization/preview-mas-subcollection.js');
+
+const { mepMasStudioUrls } = await import('../../../libs/blocks/merch/mas-mep-utils.js');
+const { setConfig } = await import('../../../libs/utils/utils.js');
+
+setConfig({
+  miloLibs: 'https://main--milo--adobecom.aem.live/libs',
+  codeRoot: 'https://main--cc--adobecom.aem.live/cc-shared',
+  locale: { ietf: 'en-US', prefix: '', region: 'us' },
+  env: { name: 'stage' },
+});
+
+// Mocks the M@S aem:load event detail / aem-fragment.rawData shape. See
+// mas/web-components/src/merch-card-collection.js for the canonical layout
+// of references + referencesTree.
+function buildPayload(entries, { extras = {} } = {}) {
+  const references = {};
+  const referencesTree = entries.map((e) => {
+    references[e.id] = { value: { fields: { label: e.label, queryLabel: e.queryLabel } } };
+    const node = {
+      identifier: e.id,
+      fieldName: e.fieldName ?? 'collection',
+    };
+    if (e.children?.length) {
+      const child = buildPayload(e.children);
+      node.referencesTree = child.referencesTree;
+      Object.assign(references, child.references);
+    }
+    return node;
+  });
+  return { references, referencesTree, ...extras };
+}
+
+function buildCollectionContainer({ filter, parentUrl = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=parent-1' } = {}) {
+  const container = document.createElement('div');
+  container.dataset.masBlock = 'collection';
+  const collection = document.createElement('merch-card-collection');
+  if (filter !== undefined) collection.setAttribute('filter', filter);
+  const aemFragment = document.createElement('aem-fragment');
+  aemFragment.setAttribute('fragment', 'parent-1');
+  collection.append(aemFragment);
+  container.append(collection);
+  document.body.append(container);
+  if (parentUrl) mepMasStudioUrls.set(container, parentUrl);
+  return { container, collection, aemFragment };
+}
+
+// Sub-collection badge lives OUTSIDE the container (as its previous sibling)
+// so it doesn't get absorbed into the .collection-container CSS grid and
+// auto-placed at the bottom. See injectSubCollectionBadge for rationale.
+function getBadge(container) {
+  const prev = container.previousElementSibling;
+  return prev?.classList?.contains(SUB_COLLECTION_BADGE_CLASS) ? prev : null;
+}
+
+afterEach(() => {
+  document.querySelectorAll('[data-mas-block]').forEach((el) => el.remove());
+  removeSubCollectionBadges();
+});
+
+describe('extractSubCollections', () => {
+  it('returns {id, label, queryLabel} entries for sibling collection refs', () => {
+    const payload = buildPayload([
+      { id: 'sub-photo', label: 'Photo', queryLabel: 'photo' },
+      { id: 'sub-video', label: 'Video', queryLabel: 'video' },
+    ]);
+    expect(extractSubCollections(payload)).to.deep.equal([
+      { id: 'sub-photo', label: 'Photo', queryLabel: 'photo' },
+      { id: 'sub-video', label: 'Video', queryLabel: 'video' },
+    ]);
+  });
+
+  it('skips fieldName === "cards" (leaf merch-card refs)', () => {
+    const payload = buildPayload([
+      { id: 'card-a', label: 'A', queryLabel: 'a', fieldName: 'cards' },
+      { id: 'sub-design', label: 'Design', queryLabel: 'design' },
+    ]);
+    expect(extractSubCollections(payload).map((e) => e.id)).to.deep.equal(['sub-design']);
+  });
+
+  it('skips fieldName === "variations"', () => {
+    const payload = buildPayload([
+      { id: 'var-x', label: 'X', queryLabel: 'x', fieldName: 'variations' },
+    ]);
+    expect(extractSubCollections(payload)).to.deep.equal([]);
+  });
+
+  it('walks recursively into nested referencesTree', () => {
+    const payload = buildPayload([
+      {
+        id: 'sub-top',
+        label: 'Top',
+        queryLabel: 'top',
+        children: [
+          { id: 'sub-deep', label: 'Deep', queryLabel: 'deep' },
+        ],
+      },
+    ]);
+    expect(extractSubCollections(payload).map((e) => e.id))
+      .to.deep.equal(['sub-top', 'sub-deep']);
+  });
+
+  it('dedupes refs that appear in multiple branches', () => {
+    const payload = buildPayload([
+      { id: 'sub-a', label: 'A', queryLabel: 'a' },
+      { id: 'sub-a', label: 'A', queryLabel: 'a' },
+    ]);
+    expect(extractSubCollections(payload)).to.have.length(1);
+  });
+
+  it('returns [] for missing / malformed payloads', () => {
+    expect(extractSubCollections(null)).to.deep.equal([]);
+    expect(extractSubCollections({})).to.deep.equal([]);
+    expect(extractSubCollections({ referencesTree: null, references: {} })).to.deep.equal([]);
+    expect(extractSubCollections({ referencesTree: [], references: null })).to.deep.equal([]);
+  });
+
+  it('skips refs whose value.fields are missing', () => {
+    const payload = {
+      references: { 'sub-x': {} },
+      referencesTree: [{ identifier: 'sub-x', fieldName: 'collection' }],
+    };
+    expect(extractSubCollections(payload)).to.deep.equal([]);
+  });
+});
+
+describe('toSubCollectionStudioUrl', () => {
+  it('replaces query= and forces page=fragment-editor', () => {
+    const url = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=parent';
+    const out = toSubCollectionStudioUrl(url, 'sub-x');
+    const u = new URL(out);
+    const hp = new URLSearchParams(u.hash.replace(/^#/, ''));
+    expect(hp.get('query')).to.equal('sub-x');
+    expect(hp.get('page')).to.equal('fragment-editor');
+    expect(hp.get('content-type')).to.equal('merch-card-collection');
+    expect(hp.has('fragment')).to.be.false;
+    expect(hp.has('fragmentId')).to.be.false;
+  });
+
+  it('replaces fragment= when that was the parent\'s id param', () => {
+    const url = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&fragment=parent';
+    const hp = new URLSearchParams(new URL(toSubCollectionStudioUrl(url, 'sub-x')).hash.replace(/^#/, ''));
+    expect(hp.get('fragment')).to.equal('sub-x');
+    expect(hp.has('query')).to.be.false;
+  });
+
+  it('replaces fragmentId= when that was the parent\'s id param', () => {
+    const url = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&fragmentId=parent';
+    const hp = new URLSearchParams(new URL(toSubCollectionStudioUrl(url, 'sub-x')).hash.replace(/^#/, ''));
+    expect(hp.get('fragmentId')).to.equal('sub-x');
+  });
+
+  it('adds fragmentId= and content-type when the parent URL had no id param at all', () => {
+    const url = 'https://mas.adobe.com/studio.html#path=acom';
+    const hp = new URLSearchParams(new URL(toSubCollectionStudioUrl(url, 'sub-x')).hash.replace(/^#/, ''));
+    expect(hp.get('fragmentId')).to.equal('sub-x');
+    expect(hp.get('content-type')).to.equal('merch-card-collection');
+    expect(hp.get('page')).to.equal('fragment-editor');
+  });
+
+  it('returns input unchanged when args are missing', () => {
+    expect(toSubCollectionStudioUrl(null, 'sub-x')).to.equal(null);
+    expect(toSubCollectionStudioUrl('foo', null)).to.equal('foo');
+  });
+});
+
+describe('attachAemLoadListener', () => {
+  it('populates the WeakMap when aem:load fires on the fragment', () => {
+    const { container, aemFragment } = buildCollectionContainer();
+    attachAemLoadListener(aemFragment, container);
+    const detail = buildPayload([
+      { id: 'sub-photo', label: 'Photo', queryLabel: 'photo' },
+    ]);
+    aemFragment.dispatchEvent(new CustomEvent('aem:load', { detail }));
+    expect(mepMasSubCollections.get(container)).to.deep.equal([
+      { id: 'sub-photo', label: 'Photo', queryLabel: 'photo' },
+    ]);
+  });
+
+  it('does NOT overwrite the WeakMap when payload yields zero sub-collections', () => {
+    const { container, aemFragment } = buildCollectionContainer();
+    mepMasSubCollections.set(container, [{ id: 'sub-existing', label: 'X', queryLabel: 'x' }]);
+    attachAemLoadListener(aemFragment, container);
+    aemFragment.dispatchEvent(new CustomEvent('aem:load', { detail: buildPayload([]) }));
+    expect(mepMasSubCollections.get(container)).to.deep.equal([
+      { id: 'sub-existing', label: 'X', queryLabel: 'x' },
+    ]);
+  });
+
+  it('is a no-op when called with falsy args', () => {
+    expect(() => attachAemLoadListener(null, null)).to.not.throw();
+  });
+});
+
+describe('getSubCollectionsFor (WeakMap read)', () => {
+  it('returns the cached list when present', () => {
+    const { container } = buildCollectionContainer();
+    mepMasSubCollections.set(container, [{ id: 'sub-cached', label: 'C', queryLabel: 'c' }]);
+    expect(getSubCollectionsFor(container)).to.deep.equal([
+      { id: 'sub-cached', label: 'C', queryLabel: 'c' },
+    ]);
+  });
+
+  it('returns [] when nothing has been captured yet', () => {
+    const { container } = buildCollectionContainer();
+    expect(getSubCollectionsFor(container)).to.deep.equal([]);
+  });
+
+  it('returns [] when container is missing', () => {
+    expect(getSubCollectionsFor(null)).to.deep.equal([]);
+  });
+
+  it('does NOT synthesize from <aem-fragment> in the live DOM (M@S removes it after aem:load)', () => {
+    // The capture path (attachAemLoadListener) is the only writer; a stale
+    // child aem-fragment must NOT be a fallback source.
+    const { container, aemFragment } = buildCollectionContainer();
+    Object.defineProperty(aemFragment, 'rawData', {
+      configurable: true,
+      get: () => buildPayload([{ id: 'sub-bogus', label: 'X', queryLabel: 'x' }]),
+    });
+    expect(getSubCollectionsFor(container)).to.deep.equal([]);
+  });
+});
+
+describe('injectSubCollectionBadge', () => {
+  it('renders a badge when filter matches a stored sub-collection', () => {
+    const { container } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [
+      { id: 'sub-photo', label: 'Photo', queryLabel: 'photo' },
+      { id: 'sub-video', label: 'Video', queryLabel: 'video' },
+    ]);
+    injectSubCollectionBadge(container, 'us');
+    const badge = getBadge(container);
+    expect(badge, 'badge missing').to.exist;
+    expect(badge.textContent).to.match(/Photo/);
+    expect(badge.textContent).to.match(/ \u00b7 US$/);
+    expect(badge.dataset.mepMasSubId).to.equal('sub-photo');
+    expect(badge.getAttribute('target')).to.equal('_blank');
+    const hp = new URLSearchParams(new URL(badge.href).hash.replace(/^#/, ''));
+    expect(hp.get('query')).to.equal('sub-photo');
+    expect(hp.get('page')).to.equal('fragment-editor');
+  });
+
+  it('inserts the badge OUTSIDE the container (as previous sibling) to avoid being trapped in the .collection-container CSS grid', () => {
+    const { container } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    injectSubCollectionBadge(container, 'us');
+    // Badge MUST sit before the container in normal flow, NOT inside it.
+    // Inside-the-container insertion auto-places at the bottom of the grid.
+    expect(container.previousElementSibling?.classList?.contains(SUB_COLLECTION_BADGE_CLASS))
+      .to.equal(true);
+    expect(container.querySelector(`a.${SUB_COLLECTION_BADGE_CLASS}`))
+      .to.equal(null, 'badge must NOT be inside the grid container');
+  });
+
+  it('renders nothing when filter is empty', () => {
+    const { container } = buildCollectionContainer({ filter: '' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    injectSubCollectionBadge(container, 'us');
+    expect(getBadge(container)).to.be.null;
+  });
+
+  it('renders nothing when filter is "all"', () => {
+    const { container } = buildCollectionContainer({ filter: 'all' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    injectSubCollectionBadge(container, 'us');
+    expect(getBadge(container)).to.be.null;
+  });
+
+  it('renders nothing when filter doesn\'t match any captured sub-collection', () => {
+    const { container } = buildCollectionContainer({ filter: 'nonexistent' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    injectSubCollectionBadge(container, 'us');
+    expect(getBadge(container)).to.be.null;
+  });
+
+  it('renders nothing when no parent Studio URL was captured', () => {
+    const { container } = buildCollectionContainer({ filter: 'photo', parentUrl: null });
+    mepMasStudioUrls.delete(container);
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    injectSubCollectionBadge(container, 'us');
+    expect(getBadge(container)).to.be.null;
+  });
+
+  it('removes a stale badge when the filter is cleared', () => {
+    const { container, collection } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    injectSubCollectionBadge(container, 'us');
+    expect(getBadge(container)).to.exist;
+    collection.removeAttribute('filter');
+    injectSubCollectionBadge(container, 'us');
+    expect(getBadge(container)).to.be.null;
+  });
+
+  it('updates an existing badge in-place when the filter changes (no DOM churn for unchanged state)', () => {
+    const { container, collection } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [
+      { id: 'sub-photo', label: 'Photo', queryLabel: 'photo' },
+      { id: 'sub-video', label: 'Video', queryLabel: 'video' },
+    ]);
+    injectSubCollectionBadge(container, 'us');
+    const first = getBadge(container);
+    expect(first.dataset.mepMasSubId).to.equal('sub-photo');
+    collection.setAttribute('filter', 'video');
+    injectSubCollectionBadge(container, 'us');
+    const second = getBadge(container);
+    expect(second).to.equal(first);
+    expect(second.dataset.mepMasSubId).to.equal('sub-video');
+    expect(second.textContent).to.match(/Video/);
+  });
+
+  it('omits the market suffix when pageMarket is missing', () => {
+    const { container } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    injectSubCollectionBadge(container);
+    const badge = getBadge(container);
+    expect(badge.textContent).to.not.match(/ \u00b7 /);
+  });
+
+  it('finds and reuses an existing sub-collection badge even when a parent collection badge sits between it and the container', () => {
+    // Regression: a re-inserted parent badge between the sub badge and the
+    // container would orphan the sub badge without findExistingBadge's
+    // walk-back. Verify only one sub badge survives.
+    const { container } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    injectSubCollectionBadge(container, 'us');
+    const original = getBadge(container);
+    expect(original).to.exist;
+    // Wedge a parent collection badge between the sub badge and the container.
+    const parentBadge = document.createElement('a');
+    parentBadge.classList.add('mep-mas-edit-badge', 'mep-mas-edit-badge-collection');
+    parentBadge.dataset.mepMasMarket = 'us';
+    container.insertAdjacentElement('beforebegin', parentBadge);
+    // Sanity: container.previousElementSibling is now the parent badge.
+    expect(container.previousElementSibling).to.equal(parentBadge);
+    injectSubCollectionBadge(container, 'us');
+    // Still only one sub-collection badge in the document.
+    expect(document.querySelectorAll(`a.${SUB_COLLECTION_BADGE_CLASS}`).length).to.equal(1);
+    expect(document.querySelector(`a.${SUB_COLLECTION_BADGE_CLASS}`)).to.equal(original);
+  });
+
+  it('is idempotent across many consecutive calls (no badge accumulation)', () => {
+    const { container } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    for (let i = 0; i < 10; i += 1) injectSubCollectionBadge(container, 'us');
+    expect(document.querySelectorAll(`a.${SUB_COLLECTION_BADGE_CLASS}`).length).to.equal(1);
+  });
+
+  it('removes any existing badge and skips when the container is hidden (offsetParent === null)', () => {
+    const { container } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    // First, render the badge while the container is laid out.
+    injectSubCollectionBadge(container, 'us');
+    expect(getBadge(container)).to.exist;
+    // Now simulate the hidden-tab case (jsdom always reports offsetParent
+    // as null, so we set offsetHeight to 0 to make the guard fire).
+    Object.defineProperty(container, 'offsetParent', { configurable: true, get: () => null });
+    Object.defineProperty(container, 'offsetHeight', { configurable: true, get: () => 0 });
+    injectSubCollectionBadge(container, 'us');
+    expect(getBadge(container)).to.be.null;
+  });
+
+  it('does NOT render a badge for a hidden container even when filter and subs are valid', () => {
+    const { container } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    Object.defineProperty(container, 'offsetParent', { configurable: true, get: () => null });
+    Object.defineProperty(container, 'offsetHeight', { configurable: true, get: () => 0 });
+    injectSubCollectionBadge(container, 'us');
+    expect(getBadge(container)).to.be.null;
+  });
+});
+
+describe('removeSubCollectionBadges', () => {
+  it('strips every sub-collection badge from the document', () => {
+    const { container } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [{ id: 'sub-photo', label: 'Photo', queryLabel: 'photo' }]);
+    injectSubCollectionBadge(container, 'us');
+    expect(document.querySelectorAll(`a.${SUB_COLLECTION_BADGE_CLASS}`).length).to.equal(1);
+    removeSubCollectionBadges();
+    expect(document.querySelectorAll(`a.${SUB_COLLECTION_BADGE_CLASS}`).length).to.equal(0);
+  });
+});
+
+describe('integration: injectMasBadges renders sub-collection badge for active filter', () => {
+  it('renders the sub-collection badge between the parent badge and the container (both outside the grid)', async () => {
+    // Import lazily so the preview module evaluates against the same DOM
+    // we've already prepped via buildCollectionContainer below.
+    const preview = await import('../../../libs/features/personalization/preview.js');
+    const { container } = buildCollectionContainer({ filter: 'photo' });
+    mepMasSubCollections.set(container, [
+      { id: 'sub-photo', label: 'Photo', queryLabel: 'photo' },
+    ]);
+    preview.injectMasBadges();
+    // Sibling order in the parent flow: parent badge, sub badge, container.
+    const subBadge = container.previousElementSibling;
+    expect(subBadge?.classList?.contains(SUB_COLLECTION_BADGE_CLASS))
+      .to.equal(true, 'sub-collection badge should be container.previousElementSibling');
+    const parentBadge = subBadge.previousElementSibling;
+    expect(parentBadge?.classList?.contains('mep-mas-edit-badge-collection'))
+      .to.equal(true, 'parent collection badge should sit just before the sub badge');
+  });
+});

--- a/test/features/personalization/preview-mas-subcollection.test.js
+++ b/test/features/personalization/preview-mas-subcollection.test.js
@@ -81,17 +81,17 @@ describe('extractSubCollections', () => {
     ]);
   });
 
-  it('skips fieldName === "cards" (leaf merch-card refs)', () => {
+  it('skips entries without "queryLabel" (cards and variations carry only "label")', () => {
     const payload = buildPayload([
-      { id: 'card-a', label: 'A', queryLabel: 'a', fieldName: 'cards' },
+      { id: 'card-a', label: 'A', fieldName: 'cards' },
       { id: 'sub-design', label: 'Design', queryLabel: 'design' },
     ]);
     expect(extractSubCollections(payload).map((e) => e.id)).to.deep.equal(['sub-design']);
   });
 
-  it('skips fieldName === "variations"', () => {
+  it('skips entries without "queryLabel" even when fieldName is set', () => {
     const payload = buildPayload([
-      { id: 'var-x', label: 'X', queryLabel: 'x', fieldName: 'variations' },
+      { id: 'var-x', label: 'X', fieldName: 'variations' },
     ]);
     expect(extractSubCollections(payload)).to.deep.equal([]);
   });

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -8,8 +8,19 @@ const {
   default: decoratePreviewMode,
   escapeHtml,
   parsePageAndUrl,
+  injectMasBadges,
+  removeMasBadges,
+  updateMasNoContentMessage,
+  getResolvedPageMarket,
+  getCardMarket,
+  deriveChildCardStudioUrl,
+  toFragmentEditorUrl,
+  watchForMasContent,
+  MAS_RESTAMP_DEBOUNCE_MS,
 } = await import('../../../libs/features/personalization/preview.js');
-const { setConfig, updateConfig, MILO_EVENTS, createTag } = await import('../../../libs/utils/utils.js');
+const { setConfig, updateConfig, MILO_EVENTS, createTag, getConfig } = await import('../../../libs/utils/utils.js');
+const { mepMasStudioUrls } = await import('../../../libs/blocks/merch/mas-mep-utils.js');
+const { mepMasSubCollections } = await import('../../../libs/features/personalization/preview-mas-subcollection.js');
 
 const config = {
   miloLibs: 'https://main--milo--adobecom.aem.live/libs',
@@ -553,5 +564,1225 @@ describe('Lingo fragment click handlers', () => {
     testFragment.dispatchEvent(clickEvent);
 
     expect(windowOpenStub.called).to.be.false;
+  });
+});
+
+describe('M@S highlight badges', () => {
+  // Each surface gets its own wrapper element + WeakMap entry. Reset between tests.
+  beforeEach(() => {
+    document.querySelectorAll('[data-mas-block], a.mep-mas-edit-badge, a.mep-mas-sub-collection-badge, .mep-mas-no-content, .mep-mas-card-actions').forEach((el) => el.remove());
+  });
+
+  function seedSurface(surface, href) {
+    const tag = {
+      collection: 'div',
+      card: 'div',
+      inline: 'span',
+      ost: 'span',
+    }[surface] || 'div';
+    const el = document.createElement(tag);
+    el.dataset.masBlock = surface;
+    document.body.append(el);
+    mepMasStudioUrls.set(el, href);
+    return el;
+  }
+
+  it('injectMasBadges adds a sibling <a> badge for the collection surface (only)', () => {
+    // Cards render an in-host action stack now (see "M@S card action stack"
+    // describe block). inline (mas-field) and ost render via CSS ::before
+    // pseudo on the host. Only collection still uses a sibling <a> badge.
+    const collection = seedSurface(
+      'collection',
+      'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-1',
+    );
+    injectMasBadges();
+    const prev = collection.previousElementSibling;
+    expect(prev, 'sibling badge missing before collection surface').to.exist;
+    expect(prev.tagName).to.equal('A');
+    expect(prev.classList.contains('mep-mas-edit-badge')).to.be.true;
+    expect(prev.classList.contains('mep-mas-edit-badge-collection')).to.be.true;
+    expect(prev.getAttribute('href')).to.equal(
+      'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-1',
+    );
+    expect(prev.getAttribute('target')).to.equal('_blank');
+  });
+
+  it('injectMasBadges does NOT inject a sibling <a> for card / inline / ost surfaces', () => {
+    const cardHost = seedSurface('card', 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1');
+    const inlineHost = seedSurface('inline', 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1&field=cardTitle');
+    const ostHost = seedSurface('ost', '/tools/ost?osi=03&type=price&term=false');
+
+    injectMasBadges();
+
+    // No sibling <a> badge for any of these — they render via overlay (card)
+    // or pseudo (inline / ost).
+    expect(cardHost.previousElementSibling?.classList?.contains('mep-mas-edit-badge')).to.not.equal(true);
+    expect(inlineHost.previousElementSibling?.classList?.contains('mep-mas-edit-badge')).to.not.equal(true);
+    expect(ostHost.previousElementSibling?.classList?.contains('mep-mas-edit-badge')).to.not.equal(true);
+    // WeakMap entries remain so handlers can open the captured URL.
+    expect(mepMasStudioUrls.get(inlineHost)).to.equal('https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1&field=cardTitle');
+    expect(mepMasStudioUrls.get(ostHost)).to.equal('/tools/ost?osi=03&type=price&term=false');
+  });
+
+  it('injectMasBadges is idempotent — re-running does not duplicate the card action stack', () => {
+    seedSurface('card', 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1');
+    injectMasBadges();
+    injectMasBadges();
+    injectMasBadges();
+    expect(document.querySelectorAll('.mep-mas-card-actions').length).to.equal(1);
+  });
+
+  it('injectMasBadges does NOT duplicate the parent collection badge when a sub-collection badge sits between it and the container', () => {
+    // Regression: when a sub-collection badge is wedged between the parent
+    // badge and the container, the idempotence check must walk past it or
+    // the parent badge gets rebuilt every pass and orphans the sub badge.
+    const collection = seedSurface(
+      'collection',
+      'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-1',
+    );
+    injectMasBadges();
+    expect(document.querySelectorAll('a.mep-mas-edit-badge-collection').length).to.equal(1);
+    // Re-insert a fake sub badge each pass — the real injector would strip
+    // it because this seeded surface has no <merch-card-collection> child.
+    const wedgeSubBadge = () => {
+      if (!collection.previousElementSibling?.classList?.contains('mep-mas-sub-collection-badge')) {
+        const sub = document.createElement('a');
+        sub.classList.add('mep-mas-sub-collection-badge');
+        collection.insertAdjacentElement('beforebegin', sub);
+      }
+    };
+    wedgeSubBadge();
+    injectMasBadges();
+    wedgeSubBadge();
+    injectMasBadges();
+    wedgeSubBadge();
+    injectMasBadges();
+    // Parent badge must still be exactly one — proves the walk-back hop
+    // in the idempotence check correctly skips past the wedge.
+    expect(document.querySelectorAll('a.mep-mas-edit-badge-collection').length).to.equal(1);
+  });
+
+  it('injectMasBadges skips card hosts with no WeakMap entry (no Studio URL to render)', () => {
+    const orphan = document.createElement('div');
+    orphan.dataset.masBlock = 'card';
+    document.body.append(orphan);
+    injectMasBadges();
+    // No overlay should attach when there's no captured Studio URL.
+    expect(orphan.querySelector('.mep-mas-card-actions')).to.be.null;
+  });
+
+  it('removeMasBadges clears sibling badges AND card action stacks from the document', () => {
+    seedSurface('collection', 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&query=col-1');
+    seedSurface('card', 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-2');
+    injectMasBadges();
+    expect(document.querySelectorAll('a.mep-mas-edit-badge').length).to.equal(1);
+    expect(document.querySelectorAll('.mep-mas-card-actions').length).to.equal(1);
+    removeMasBadges();
+    expect(document.querySelectorAll('a.mep-mas-edit-badge').length).to.equal(0);
+    expect(document.querySelectorAll('.mep-mas-card-actions').length).to.equal(0);
+  });
+
+  it('updateMasNoContentMessage toggles every .mep-mas-no-content placeholder', () => {
+    const a = createTag('div', { class: 'mep-mas-no-content', hidden: '' }, 'no content');
+    const b = createTag('div', { class: 'mep-mas-no-content', hidden: '' }, 'no content');
+    document.body.append(a, b);
+
+    updateMasNoContentMessage(true);
+    expect(a.hidden).to.be.false;
+    expect(b.hidden).to.be.false;
+
+    updateMasNoContentMessage(false);
+    expect(a.hidden).to.be.true;
+    expect(b.hidden).to.be.true;
+  });
+
+  it('injectMasBadges shows the no-content message when zero surfaces are present', () => {
+    const placeholder = createTag('div', { class: 'mep-mas-no-content', hidden: '' }, 'no content');
+    document.body.append(placeholder);
+    injectMasBadges();
+    expect(placeholder.hidden).to.be.false;
+  });
+
+  it('injectMasBadges hides the no-content message when at least one badge renders', () => {
+    const placeholder = createTag('div', { class: 'mep-mas-no-content' }, 'no content');
+    document.body.append(placeholder);
+    seedSurface('card', 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1');
+    injectMasBadges();
+    expect(placeholder.hidden).to.be.true;
+  });
+
+  it('injectMasBadges appends the page-level market (Case A) to the collection sibling badge as a chip', () => {
+    // Test config has locale.ietf = 'en-US' so getResolvedPageMarket() returns 'us'.
+    // Cards no longer use sibling <a> badges; they have an in-host action stack
+    // instead — its market suffix is covered by the card-action-stack tests.
+    const collection = seedSurface(
+      'collection',
+      'https://mas.adobe.com/studio.html#content-type=merch-card-collection&query=col-1',
+    );
+    injectMasBadges();
+    const badge = collection.previousElementSibling;
+    expect(badge?.textContent).to.match(/ \u00b7 US$/);
+    const chip = badge.querySelector('.mep-mas-edit-badge-market');
+    expect(chip, 'market chip should be a child element').to.exist;
+    expect(chip.textContent).to.equal('US');
+    expect(chip.classList.contains('mep-mas-edit-badge-market-match')).to.be.true;
+    expect(chip.classList.contains('mep-mas-edit-badge-market-mismatch')).to.be.false;
+  });
+});
+
+describe('M@S badge market resolution', () => {
+  beforeEach(() => {
+    document.querySelectorAll('[data-mas-block], a.mep-mas-edit-badge').forEach((el) => el.remove());
+  });
+
+  describe('getResolvedPageMarket (Case A — page-level)', () => {
+    // Priority chain: <mas-commerce-service country> > getMiloLocaleSettings >
+    // ?akamaiLocale=. Default test locale en-US makes getMiloLocaleSettings
+    // return us, so akamaiLocale is shadowed by design.
+    let originalSearch;
+    beforeEach(() => { originalSearch = window.location.search; });
+    afterEach(() => {
+      // Reset URL to baseline so akamaiLocale doesn't leak across tests.
+      window.history.replaceState({}, '', `${window.location.pathname}${originalSearch}${window.location.hash}`);
+      document.head.querySelectorAll('mas-commerce-service').forEach((el) => el.remove());
+    });
+
+    it('returns the locale ietf country when no higher-priority signal is present', () => {
+      // Default test config: locale.ietf = 'en-US'
+      expect(getResolvedPageMarket()).to.equal('us');
+    });
+
+    it('prefers <mas-commerce-service country> over the locale (authoritative WCS country)', () => {
+      const svc = document.createElement('mas-commerce-service');
+      svc.setAttribute('country', 'CA');
+      document.head.append(svc);
+      expect(getResolvedPageMarket()).to.equal('ca');
+    });
+
+    it('falls back to ?akamaiLocale= only when neither service nor locale resolves a country', () => {
+      window.history.replaceState({}, '', `${window.location.pathname}?akamaiLocale=fr${window.location.hash}`);
+      // Default locale 'us' shadows ?akamaiLocale=fr, by design.
+      expect(getResolvedPageMarket()).to.equal('us');
+    });
+
+    it('normalizes legacy country shapes via normCountryCode (uk -> gb) on the service signal', () => {
+      const svc = document.createElement('mas-commerce-service');
+      svc.setAttribute('country', 'uk');
+      document.head.append(svc);
+      expect(getResolvedPageMarket()).to.equal('gb');
+    });
+  });
+
+  describe('getCardMarket (Case B — per-card derivation from checkout link)', () => {
+    it('returns the country= param from a descendant checkout link when present', () => {
+      const wrap = createTag('div', { 'data-mas-block': 'ost' });
+      const link = createTag('a', {
+        is: 'checkout-link',
+        href: 'https://commerce.adobe.com/store/?country=DE&lang=de&items=03',
+      }, 'Buy');
+      wrap.append(link);
+      document.body.append(wrap);
+      expect(getCardMarket(wrap, 'us')).to.equal('de');
+      wrap.remove();
+    });
+
+    it('returns the country= param when the element itself is the link', () => {
+      const link = createTag('a', { href: 'https://commerce.adobe.com/store/?country=jp&items=03' }, 'Buy');
+      document.body.append(link);
+      expect(getCardMarket(link, 'us')).to.equal('jp');
+      link.remove();
+    });
+
+    it('falls back to the page market when no descendant has country=', () => {
+      const wrap = createTag('div', { 'data-mas-block': 'card' });
+      wrap.append(createTag('a', { href: 'https://example.com/no-country' }, 'Link'));
+      document.body.append(wrap);
+      expect(getCardMarket(wrap, 'fr')).to.equal('fr');
+      wrap.remove();
+    });
+
+    it('returns null page-market unchanged when nothing resolves', () => {
+      const wrap = createTag('div', { 'data-mas-block': 'inline' });
+      document.body.append(wrap);
+      expect(getCardMarket(wrap, null)).to.equal(null);
+      wrap.remove();
+    });
+  });
+
+  describe('injectMasBadges market suffix (integration)', () => {
+    it('upgrades a card surface from page-market to per-card-market and marks the action stack mismatch when they differ', () => {
+      // Page market is "us" (default test locale) but this card's checkout link
+      // resolves to GB — Edit Card label should end with "· GB" and the
+      // mismatch class should land on the Edit Card / Edit OSI buttons.
+      const wrap = document.createElement('div');
+      wrap.dataset.masBlock = 'card';
+      wrap.append(createTag('a', {
+        is: 'checkout-link',
+        href: 'https://commerce.adobe.com/store/?country=GB&items=03',
+      }, 'Buy'));
+      document.body.append(wrap);
+      mepMasStudioUrls.set(wrap, 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-x');
+
+      injectMasBadges();
+
+      expect(wrap.dataset.masMarket).to.equal('GB');
+      expect(wrap.dataset.masMarketMismatch).to.equal('true');
+      const editBtn = wrap.querySelector('.mep-mas-card-action-edit');
+      expect(editBtn, 'Edit Card action should exist').to.exist;
+      expect(editBtn.textContent).to.equal('Edit Card · GB');
+      expect(editBtn.classList.contains('mep-mas-card-actions-mismatch'), 'GB on a US page should set the mismatch class').to.be.true;
+      wrap.remove();
+    });
+
+    it('marks the card action stack as match (no mismatch class) when the per-card market equals the page market', () => {
+      const wrap = document.createElement('div');
+      wrap.dataset.masBlock = 'card';
+      wrap.append(createTag('a', {
+        is: 'checkout-link',
+        href: 'https://commerce.adobe.com/store/?country=US&items=03',
+      }, 'Buy'));
+      document.body.append(wrap);
+      mepMasStudioUrls.set(wrap, 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-x');
+
+      injectMasBadges();
+
+      expect(wrap.dataset.masMarket).to.equal('US');
+      expect(wrap.dataset.masMarketMismatch).to.be.undefined;
+      const editBtn = wrap.querySelector('.mep-mas-card-action-edit');
+      expect(editBtn?.textContent).to.equal('Edit Card · US');
+      expect(editBtn?.classList.contains('mep-mas-card-actions-mismatch')).to.be.false;
+      wrap.remove();
+    });
+  });
+
+  describe('injectMasBadges market stamping for pseudo-badge surfaces (inline + ost)', () => {
+    // The inline (mas-field) and ost surfaces render their badges via CSS
+    // ::before pseudo using attr(data-mas-market). preview.js stamps the
+    // data attribute on the host so the chip text can render purely in CSS.
+    it('stamps data-mas-market on the inline host using its descendant checkout link country', () => {
+      const host = document.createElement('span');
+      host.dataset.masBlock = 'inline';
+      host.append(createTag('a', {
+        is: 'checkout-link',
+        href: 'https://commerce.adobe.com/store/?country=DE&items=03',
+      }, 'Buy'));
+      document.body.append(host);
+      mepMasStudioUrls.set(host, 'https://mas.adobe.com/studio.html#content-type=merch-card&query=field-1');
+
+      injectMasBadges();
+
+      expect(host.dataset.masMarket).to.equal('DE');
+      // Page market is "us" — DE on a US page is a mismatch, expect the flip flag.
+      expect(host.dataset.masMarketMismatch).to.equal('true');
+      host.remove();
+    });
+
+    it('stamps data-mas-market on the ost host and clears the mismatch flag when markets agree', () => {
+      const host = document.createElement('span');
+      host.dataset.masBlock = 'ost';
+      host.append(createTag('a', {
+        is: 'checkout-link',
+        href: 'https://commerce.adobe.com/store/?country=US&items=03',
+      }, 'Buy'));
+      document.body.append(host);
+      mepMasStudioUrls.set(host, '/tools/ost?osi=03&type=price');
+
+      injectMasBadges();
+
+      expect(host.dataset.masMarket).to.equal('US');
+      // Page market is "us" — match, mismatch flag should be absent.
+      expect(host.dataset.masMarketMismatch).to.be.undefined;
+      host.remove();
+    });
+
+    it('stamps data-mas-market on offer hosts using the host\'s own data-ims-country', () => {
+      // Offer hosts ARE the checkout-link / inline-price element, so the
+      // ims-country attribute lives on the host itself (set by M@S
+      // checkout-mixin after WCS resolves) — verify getCardMarket reads it.
+      const host = createTag('a', {
+        is: 'checkout-link',
+        'data-wcs-osi': 'fake-osi',
+        'data-ims-country': 'JP',
+        href: 'https://commerce.adobe.com/store/?items=03',
+      }, 'Buy');
+      document.body.append(host);
+
+      injectMasBadges();
+
+      expect(host.dataset.masBlock).to.equal('offer');
+      expect(host.dataset.masMarket).to.equal('JP');
+      // Page market is "us" — JP is a mismatch, expect the flip flag.
+      expect(host.dataset.masMarketMismatch).to.equal('true');
+      host.remove();
+    });
+  });
+});
+
+describe('M@S per-child-card badges (Tier 3b — collection children)', () => {
+  beforeEach(() => {
+    document.querySelectorAll('[data-mas-block], a.mep-mas-edit-badge, .mep-mas-card-actions, merch-card, merch-card-collection').forEach((el) => el.remove());
+  });
+
+  describe('deriveChildCardStudioUrl', () => {
+    it('substitutes the query= identifier and switches content-type to merch-card', () => {
+      const parent = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-abc';
+      const out = deriveChildCardStudioUrl(parent, 'card-xyz');
+      expect(out).to.include('content-type=merch-card');
+      expect(out).to.not.include('content-type=merch-card-collection');
+      expect(out).to.include('path=acom');
+      expect(out).to.include('query=card-xyz');
+      expect(out).to.not.include('query=col-abc');
+    });
+
+    it('substitutes the fragment= identifier when the parent uses fragment= instead of query=', () => {
+      const parent = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=cc&fragment=col-1';
+      const out = deriveChildCardStudioUrl(parent, 'child-1');
+      expect(out).to.include('fragment=child-1');
+      expect(out).to.not.include('query=');
+    });
+
+    it('appends query= when the parent has neither query= nor fragment=', () => {
+      const parent = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom';
+      const out = deriveChildCardStudioUrl(parent, 'child-1');
+      expect(out).to.include('query=child-1');
+    });
+
+    it('returns null when parentUrl is missing', () => {
+      expect(deriveChildCardStudioUrl(null, 'child-1')).to.equal(null);
+      expect(deriveChildCardStudioUrl('', 'child-1')).to.equal(null);
+    });
+
+    it('returns null when childFragmentId is missing', () => {
+      expect(deriveChildCardStudioUrl('https://mas.adobe.com/studio.html#x=1', null)).to.equal(null);
+      expect(deriveChildCardStudioUrl('https://mas.adobe.com/studio.html#x=1', '')).to.equal(null);
+    });
+  });
+
+  describe('toFragmentEditorUrl', () => {
+    it('renames query=<id> to fragmentId=<id> and switches page to fragment-editor', () => {
+      const input = 'https://mas.adobe.com/studio.html#content-type=merch-card&page=content&path=acom&query=2c5cd672';
+      const out = toFragmentEditorUrl(input);
+      expect(out).to.include('fragmentId=2c5cd672');
+      expect(out).to.include('page=fragment-editor');
+      expect(out).to.not.include('query=');
+      expect(out).to.not.include('page=content');
+      expect(out).to.include('content-type=merch-card');
+      expect(out).to.include('path=acom');
+    });
+
+    it('renames fragment=<id> to fragmentId=<id> too', () => {
+      const input = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=abc-123';
+      const out = toFragmentEditorUrl(input);
+      expect(out).to.include('fragmentId=abc-123');
+      expect(out).to.not.include('fragment=abc-123');
+    });
+
+    it('adds page=fragment-editor when the input had no page param at all', () => {
+      const input = 'https://mas.adobe.com/studio.html#content-type=merch-card&query=xyz';
+      expect(toFragmentEditorUrl(input)).to.include('page=fragment-editor');
+    });
+
+    it('is idempotent — already-fragment-editor URLs pass through with the same shape', () => {
+      const input = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragmentId=xyz&page=fragment-editor&path=acom';
+      const out = toFragmentEditorUrl(input);
+      expect(out).to.include('fragmentId=xyz');
+      expect(out).to.include('page=fragment-editor');
+    });
+
+    it('leaves non-card URLs untouched (e.g., merch-card-collection stays on its current view)', () => {
+      const input = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&page=content&query=col-1';
+      expect(toFragmentEditorUrl(input)).to.equal(input);
+    });
+
+    it('returns the input unchanged when no id param is present', () => {
+      const input = 'https://mas.adobe.com/studio.html#content-type=merch-card&page=content';
+      expect(toFragmentEditorUrl(input)).to.equal(input);
+    });
+
+    it('returns the input unchanged when given falsy / unparseable input', () => {
+      expect(toFragmentEditorUrl(null)).to.equal(null);
+      expect(toFragmentEditorUrl('')).to.equal('');
+      expect(toFragmentEditorUrl(undefined)).to.equal(undefined);
+    });
+  });
+
+  describe('annotateCollectionChildren (via injectMasBadges integration)', () => {
+    function buildCollection(parentUrl, childFragmentIds) {
+      // Wrap mimics the structure produced by createCollection: a <div> with
+      // data-mas-block="collection" containing a <merch-card-collection>, which
+      // in turn contains <merch-card> children with <aem-fragment fragment="…">.
+      const container = document.createElement('div');
+      container.dataset.masBlock = 'collection';
+      mepMasStudioUrls.set(container, parentUrl);
+      const collEl = document.createElement('merch-card-collection');
+      childFragmentIds.forEach((id) => {
+        const card = document.createElement('merch-card');
+        const aemFragment = document.createElement('aem-fragment');
+        aemFragment.setAttribute('fragment', id);
+        card.append(aemFragment);
+        collEl.append(card);
+      });
+      container.append(collEl);
+      document.body.append(container);
+      return container;
+    }
+
+    it('stamps each child <merch-card> with data-mas-block="card" and a derived URL', () => {
+      const parentUrl = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-1';
+      const container = buildCollection(parentUrl, ['child-a', 'child-b', 'child-c']);
+
+      injectMasBadges();
+
+      const children = container.querySelectorAll('merch-card');
+      expect(children.length).to.equal(3);
+      children.forEach((card, i) => {
+        expect(card.dataset.masBlock, `child #${i} should be marked as a card`).to.equal('card');
+        const captured = mepMasStudioUrls.get(card);
+        expect(captured).to.include('content-type=merch-card');
+        expect(captured).to.not.include('content-type=merch-card-collection');
+      });
+      // Each child should have its own fragment id substituted into the URL.
+      expect(mepMasStudioUrls.get(children[0])).to.include('query=child-a');
+      expect(mepMasStudioUrls.get(children[1])).to.include('query=child-b');
+      expect(mepMasStudioUrls.get(children[2])).to.include('query=child-c');
+    });
+
+    it('renders the per-child badge as an in-host action stack (.mep-mas-card-actions)', () => {
+      // Per-child-card badges are now a real DOM overlay (.mep-mas-card-actions)
+      // injected into each <merch-card> host. Replaces the old ::before pseudo
+      // because we needed three stacked, individually-clickable actions
+      // including a clipboard-write button. Verify the overlay exists and the
+      // Edit Card link uses the captured Studio URL.
+      const parentUrl = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-1';
+      const container = buildCollection(parentUrl, ['child-a', 'child-b']);
+
+      injectMasBadges();
+
+      // No legacy overlay anchors from prior implementations.
+      expect(document.querySelectorAll('a.mep-mas-edit-badge-overlay').length).to.equal(0);
+      container.querySelectorAll('merch-card').forEach((card) => {
+        expect(card.dataset.masBlock).to.equal('card');
+        const stack = card.querySelector(':scope > .mep-mas-card-actions');
+        expect(stack, 'card should host an action stack overlay').to.exist;
+        const editBtn = stack.querySelector('.mep-mas-card-action-edit');
+        expect(editBtn).to.exist;
+        // Edit Card href is the captured Studio URL transformed to land on
+        // the fragment-editor view (query=<id> -> fragmentId=<id>,
+        // page=fragment-editor) so the author skips the search/content step.
+        const href = editBtn.getAttribute('href');
+        expect(href).to.include('page=fragment-editor');
+        expect(href).to.include('fragmentId=');
+        expect(href).to.not.include('query=');
+        expect(editBtn.getAttribute('target')).to.equal('_blank');
+      });
+    });
+
+    it('skips children whose <aem-fragment> has no fragment attribute', () => {
+      const parentUrl = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-1';
+      const container = document.createElement('div');
+      container.dataset.masBlock = 'collection';
+      mepMasStudioUrls.set(container, parentUrl);
+      const card = document.createElement('merch-card');
+      // No <aem-fragment> at all — this child should be skipped, not crash.
+      container.append(card);
+      document.body.append(container);
+
+      injectMasBadges();
+
+      expect(card.dataset.masBlock, 'unattributed child card stays unmarked').to.be.undefined;
+    });
+
+    it('is idempotent — re-running keeps each child stamped exactly once and the overlay rebuilds in place', () => {
+      const parentUrl = 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-1';
+      const container = buildCollection(parentUrl, ['child-a']);
+
+      injectMasBadges();
+      injectMasBadges();
+      injectMasBadges();
+
+      // No legacy overlay anchors after multiple passes.
+      expect(document.querySelectorAll('a.mep-mas-edit-badge-overlay').length).to.equal(0);
+      const child = container.querySelector('merch-card');
+      expect(child.dataset.masBlock).to.equal('card');
+      expect(mepMasStudioUrls.get(child)).to.include('query=child-a');
+      // Exactly one action stack on the child after multiple passes.
+      expect(child.querySelectorAll(':scope > .mep-mas-card-actions').length).to.equal(1);
+    });
+
+    it('does not annotate children when the collection has no captured parent URL', () => {
+      const container = document.createElement('div');
+      container.dataset.masBlock = 'collection';
+      // Note: no mepMasStudioUrls.set — no captured parent URL.
+      const card = document.createElement('merch-card');
+      const aemFragment = document.createElement('aem-fragment');
+      aemFragment.setAttribute('fragment', 'child-a');
+      card.append(aemFragment);
+      container.append(card);
+      document.body.append(container);
+
+      injectMasBadges();
+
+      expect(card.dataset.masBlock).to.be.undefined;
+    });
+  });
+});
+
+describe('M@S card action stack', () => {
+  // Real DOM overlay (Edit Card / Edit OSI / Copy Fragment ID) injected into
+  // every <merch-card data-mas-block='card'> by injectMasCardActionStack.
+  beforeEach(() => {
+    document.querySelectorAll('[data-mas-block], a.mep-mas-edit-badge, .mep-mas-card-actions').forEach((el) => el.remove());
+  });
+
+  function seedCard({ studioUrl, withFragment = 'frag-1', osiAttrs = [] } = {}) {
+    const card = document.createElement('merch-card');
+    card.dataset.masBlock = 'card';
+    if (withFragment) {
+      const aem = document.createElement('aem-fragment');
+      aem.setAttribute('fragment', withFragment);
+      card.append(aem);
+    }
+    osiAttrs.forEach((spec) => {
+      // spec: { tag, is, osi }
+      const el = document.createElement(spec.tag || 'span');
+      if (spec.is) el.setAttribute('is', spec.is);
+      el.setAttribute('data-wcs-osi', spec.osi);
+      card.append(el);
+    });
+    document.body.append(card);
+    if (studioUrl) mepMasStudioUrls.set(card, studioUrl);
+    return card;
+  }
+
+  it('builds Edit Card / Edit OSI / Copy Fragment ID actions when the card has a Studio URL, an OSI, and a fragment id', () => {
+    const card = seedCard({
+      studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1',
+      withFragment: 'frag-1',
+      osiAttrs: [{ tag: 'span', is: 'inline-price', osi: 'OSI-FIRST' }],
+    });
+    injectMasBadges();
+
+    const stack = card.querySelector(':scope > .mep-mas-card-actions');
+    expect(stack, 'action stack should be appended to the card').to.exist;
+    expect(stack.children.length).to.equal(3);
+    // Edit Card href is the captured Studio URL transformed to land on the
+    // fragment-editor view (`page=fragment-editor` + `fragmentId=` instead
+    // of `query=`).
+    const editHref = stack.querySelector('.mep-mas-card-action-edit')?.getAttribute('href');
+    expect(editHref).to.include('content-type=merch-card');
+    expect(editHref).to.include('fragmentId=card-1');
+    expect(editHref).to.include('page=fragment-editor');
+    expect(editHref).to.not.include('query=');
+    expect(stack.querySelector('.mep-mas-card-action-ost')?.getAttribute('href'))
+      .to.equal('https://milo.adobe.com/tools/ost?osi=OSI-FIRST');
+    const copyBtn = stack.querySelector('.mep-mas-card-action-copy');
+    expect(copyBtn).to.exist;
+    expect(copyBtn.getAttribute('data-fragment-id')).to.equal('frag-1');
+  });
+
+  it('uses the FIRST [data-wcs-osi] in DOM order when the card has multiple offers', () => {
+    const card = seedCard({
+      studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1',
+      osiAttrs: [
+        { tag: 'span', is: 'inline-price', osi: 'OSI-A' },
+        { tag: 'span', is: 'inline-price', osi: 'OSI-B' },
+        { tag: 'a', is: 'checkout-link', osi: 'OSI-C' },
+      ],
+    });
+    injectMasBadges();
+
+    const ost = card.querySelector('.mep-mas-card-action-ost');
+    expect(ost?.getAttribute('href')).to.equal('https://milo.adobe.com/tools/ost?osi=OSI-A');
+  });
+
+  it('omits the Edit OSI button when no [data-wcs-osi] exists on or inside the card (display-only card)', () => {
+    const card = seedCard({
+      studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1',
+      osiAttrs: [],
+    });
+    injectMasBadges();
+
+    const stack = card.querySelector(':scope > .mep-mas-card-actions');
+    expect(stack?.querySelector('.mep-mas-card-action-edit')).to.exist;
+    expect(stack?.querySelector('.mep-mas-card-action-ost')).to.be.null;
+    expect(stack?.querySelector('.mep-mas-card-action-copy')).to.exist;
+  });
+
+  it('omits the Copy Fragment ID button when the card has no <aem-fragment fragment="…">', () => {
+    const card = seedCard({
+      studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1',
+      withFragment: '',
+      osiAttrs: [{ tag: 'span', is: 'inline-price', osi: 'OSI-A' }],
+    });
+    injectMasBadges();
+
+    const stack = card.querySelector(':scope > .mep-mas-card-actions');
+    expect(stack?.querySelector('.mep-mas-card-action-edit')).to.exist;
+    expect(stack?.querySelector('.mep-mas-card-action-ost')).to.exist;
+    expect(stack?.querySelector('.mep-mas-card-action-copy')).to.be.null;
+  });
+
+  it('Copy Fragment ID button writes to clipboard and toggles label to "Copied!" then back', async () => {
+    const card = seedCard({
+      studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1',
+      withFragment: 'frag-xyz',
+    });
+    const writeStub = sinon.stub().resolves();
+    const original = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: writeStub },
+    });
+
+    try {
+      injectMasBadges();
+      const copyBtn = card.querySelector('.mep-mas-card-action-copy');
+      expect(copyBtn).to.exist;
+
+      copyBtn.click();
+      // Wait one microtask for the writeText promise to resolve.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(writeStub.calledOnceWithExactly('frag-xyz')).to.be.true;
+      expect(copyBtn.textContent).to.equal('Copied!');
+      expect(copyBtn.classList.contains('mep-mas-card-action-copy-copied')).to.be.true;
+
+      // Wait for the 1500ms restore timer.
+      await new Promise((resolve) => { setTimeout(resolve, 1600); });
+      expect(copyBtn.textContent).to.equal('Copy Fragment ID');
+      expect(copyBtn.classList.contains('mep-mas-card-action-copy-copied')).to.be.false;
+    } finally {
+      if (original === undefined) {
+        delete navigator.clipboard;
+      } else {
+        Object.defineProperty(navigator, 'clipboard', { configurable: true, value: original });
+      }
+    }
+  });
+
+  it('appends the action stack to standalone cards (not inside a collection) the same way as collection children', () => {
+    // Standalone <merch-card data-mas-block='card'> — outside any collection.
+    const card = seedCard({
+      studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=standalone-1',
+      withFragment: 'frag-standalone',
+      osiAttrs: [{ tag: 'span', is: 'inline-price', osi: 'OSI-S' }],
+    });
+    injectMasBadges();
+
+    const stack = card.querySelector(':scope > .mep-mas-card-actions');
+    expect(stack, 'standalone card should also get an action stack').to.exist;
+    expect(stack.children.length).to.equal(3);
+    // No sibling <a> badge for standalone cards anymore (replaced by the stack).
+    expect(card.previousElementSibling?.classList?.contains('mep-mas-edit-badge')).to.not.equal(true);
+  });
+});
+
+describe('M@S markets dropdown defer-populate (cold-cache race)', () => {
+  // Covers the non-Lingo-page case (e.g., /products/photoshop) where the
+  // markets cache is cold at popup-build time. The defer-populate block in
+  // getMepPopup awaits the in-flight fetch (kicked off by decoratePreviewMode's
+  // pre-warm) and re-renders the .mep-mas-market-dropdown wrapper in place.
+  let fetchStub;
+  let resolveMarketsFetch;
+
+  beforeEach(() => {
+    document.querySelectorAll('.mep-preview-overlay').forEach((el) => el.remove());
+    // Force a cold cache so the defer-populate path actually fires.
+    delete getConfig().marketsConfig;
+
+    // Hold the markets fetch open so the popup is built BEFORE the cache
+    // resolves — this is the race we're guarding against in real pages.
+    const marketsPromise = new Promise((resolve) => { resolveMarketsFetch = resolve; });
+    fetchStub = sinon.stub(window, 'fetch').callsFake((url) => {
+      const href = typeof url === 'string' ? url : url?.url || '';
+      if (href.includes('supported-markets')) return marketsPromise;
+      return Promise.resolve({ ok: true, status: 200 });
+    });
+  });
+
+  afterEach(() => {
+    fetchStub?.restore();
+    delete getConfig().marketsConfig;
+    document.querySelectorAll('.mep-preview-overlay').forEach((el) => el.remove());
+  });
+
+  it('renders the placeholder while cold, then re-renders with markets after the fetch resolves', async () => {
+    await decoratePreviewMode();
+
+    const popups = document.querySelectorAll('.mep-popup');
+    const popup = popups[popups.length - 1];
+    expect(popup, 'popup should exist').to.exist;
+
+    // Pre-resolve state: no markets known, dropdown is the disabled placeholder.
+    const initialSelect = popup.querySelector('select[id^="mepMasMarketSelect"]');
+    expect(initialSelect, 'placeholder <select> should exist').to.exist;
+    expect(initialSelect.disabled, 'cold-cache select is disabled').to.be.true;
+    expect(initialSelect.querySelectorAll('option').length).to.equal(1);
+
+    // Now resolve the markets fetch with a minimal supported-markets payload.
+    resolveMarketsFetch({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        languages: {
+          data: [
+            { prefix: '', defaultMarket: 'us', supportedRegions: 'us,gb,fr' },
+          ],
+        },
+      }),
+    });
+    // Flush microtasks so the .then in the defer-populate block fires.
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+    // Post-resolve state: dropdown re-rendered with the supported regions.
+    const updatedSelect = popup.querySelector('select[id^="mepMasMarketSelect"]');
+    expect(updatedSelect, 'updated <select> should exist').to.exist;
+    expect(updatedSelect.disabled, 'populated select is enabled').to.be.false;
+    const values = [...updatedSelect.querySelectorAll('option')].map((o) => o.value);
+    expect(values).to.include('us');
+    expect(values).to.include('gb');
+    expect(values).to.include('fr');
+  });
+});
+
+describe('M@S highlight click-driven re-stamp (tabs / accordions / filters)', () => {
+  // watchForMasContent installs a debounced document click listener that
+  // re-runs injectMasBadges() so card action stacks reappear when the user
+  // navigates UI patterns that don't mutate the DOM (tab toggles, accordion
+  // expands, filter chips). These tests use the side-effect of injectMasBadges
+  // (a previously-empty merch-card host gains its action stack) to verify the
+  // listener fires.
+
+  // Wait long enough for the debounce timer + a microtask flush. We add a
+  // generous margin so timer slop on busy CI machines doesn't cause flake.
+  const waitForRestamp = () => new Promise((resolve) => {
+    setTimeout(resolve, MAS_RESTAMP_DEBOUNCE_MS + 100);
+  });
+
+  beforeEach(() => {
+    document.querySelectorAll('[data-mas-block], a.mep-mas-edit-badge, .mep-mas-card-actions, merch-card').forEach((el) => el.remove());
+    document.body.dataset.mepMasHighlight = 'true';
+    // Idempotent: watchForMasContent guards against double-attach internally.
+    watchForMasContent();
+  });
+
+  afterEach(() => {
+    delete document.body.dataset.mepMasHighlight;
+  });
+
+  it('re-runs injectMasBadges after a click (debounced) so newly-visible cards get their action stack', async () => {
+    // Seed an unstamped card AFTER watchForMasContent — the click listener
+    // is the only path that should stamp it (we avoid calling injectMasBadges
+    // directly so we can be sure the click is what triggered the pass).
+    const card = document.createElement('merch-card');
+    card.dataset.masBlock = 'card';
+    document.body.append(card);
+    mepMasStudioUrls.set(card, 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1');
+    expect(card.querySelector(':scope > .mep-mas-card-actions'), 'no overlay before click').to.be.null;
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await waitForRestamp();
+
+    expect(card.querySelector(':scope > .mep-mas-card-actions'), 'overlay should exist after debounced re-stamp').to.exist;
+  });
+
+  it('coalesces rapid clicks into a single re-stamp pass', async () => {
+    const card = document.createElement('merch-card');
+    card.dataset.masBlock = 'card';
+    document.body.append(card);
+    mepMasStudioUrls.set(card, 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-2');
+
+    // Fire 3 clicks within the debounce window — should result in exactly
+    // one overlay after the timer fires (never two).
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await waitForRestamp();
+
+    expect(card.querySelectorAll(':scope > .mep-mas-card-actions').length).to.equal(1);
+  });
+
+  it('does NOT re-run when highlight mode is off', async () => {
+    delete document.body.dataset.mepMasHighlight;
+    const card = document.createElement('merch-card');
+    card.dataset.masBlock = 'card';
+    document.body.append(card);
+    mepMasStudioUrls.set(card, 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-3');
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await waitForRestamp();
+
+    expect(card.querySelector(':scope > .mep-mas-card-actions'), 'no overlay when highlight is off').to.be.null;
+  });
+});
+
+describe('M@S highlight MutationObserver — late <aem-fragment> injection', () => {
+  // M@S sometimes inserts <merch-card> first and the inner <aem-fragment
+  // fragment="..."> in a separate render pass shortly after. The observer's
+  // isMasMutation matcher includes aem-fragment[fragment] so this second
+  // insertion triggers a re-stamp pass; annotateCollectionChildren can then
+  // find the fragment id and stamp data-mas-block="card" on the host.
+
+  beforeEach(() => {
+    document.querySelectorAll('[data-mas-block], a.mep-mas-edit-badge, .mep-mas-card-actions, merch-card, merch-card-collection').forEach((el) => el.remove());
+    document.body.dataset.mepMasHighlight = 'true';
+    watchForMasContent();
+  });
+
+  afterEach(() => {
+    delete document.body.dataset.mepMasHighlight;
+  });
+
+  it('stamps a previously-fragmentless <merch-card> after a late <aem-fragment fragment> is injected into it', async () => {
+    // Build a collection with a single fragmentless child card. The first
+    // injectMasBadges pass should NOT stamp the card (no fragment to derive
+    // the Studio URL from).
+    const container = document.createElement('div');
+    container.dataset.masBlock = 'collection';
+    mepMasStudioUrls.set(container, 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-late');
+    const collEl = document.createElement('merch-card-collection');
+    const card = document.createElement('merch-card');
+    collEl.append(card);
+    container.append(collEl);
+    document.body.append(container);
+
+    injectMasBadges();
+    expect(card.dataset.masBlock, 'card stays unstamped while fragmentless').to.be.undefined;
+
+    // Late insertion: M@S now adds the inner <aem-fragment>. The observer
+    // should pick it up and re-run injectMasBadges → annotateCollectionChildren
+    // finds the fragment and stamps the host.
+    const aemFragment = document.createElement('aem-fragment');
+    aemFragment.setAttribute('fragment', 'child-late');
+    card.append(aemFragment);
+
+    // Wait a couple of macrotasks for the MutationObserver microtask + the
+    // re-run pass.
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+    expect(card.dataset.masBlock, 'card should now be stamped after late fragment insertion').to.equal('card');
+    // Parent url uses query= for the id, so the derived child url substitutes
+    // child-late into the same query= slot.
+    expect(mepMasStudioUrls.get(card)).to.include('query=child-late');
+  });
+});
+
+describe('M@S summary counts (highlight-independent)', () => {
+  // The M@S section in the MEP summary tab used to count [data-mas-block="card"]
+  // and [data-mas-block="offer"] — both stamps that only get applied while
+  // highlight mode is on (annotateCollectionChildren and annotateOffers run
+  // inside injectMasBadges). Authors who opened the popup before toggling
+  // highlight saw zero offers and missing collection-child cards. The summary
+  // now counts native M@S elements directly so the numbers are honest in
+  // either mode.
+
+  beforeEach(() => {
+    document.querySelectorAll('.mep-preview-overlay, [data-mas-block], merch-card, merch-card-collection, [data-wcs-osi]').forEach((el) => el.remove());
+    delete document.body.dataset.mepMasHighlight;
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('.mep-preview-overlay, [data-mas-block], merch-card, merch-card-collection, [data-wcs-osi]').forEach((el) => el.remove());
+    delete document.body.dataset.mepMasHighlight;
+  });
+
+  // Reads the {label: count} pairs out of the M@S section of the (most recent)
+  // preview popup so each test can assert by row name.
+  function getMasSummaryRows() {
+    const popups = document.querySelectorAll('.mep-popup');
+    const popup = popups[popups.length - 1];
+    const masSection = [...popup?.querySelectorAll('.mep-section') || []].find(
+      (sec) => sec.querySelector('h6.mep-section-header')?.textContent.trim() === 'M@S',
+    );
+    const spans = [...(masSection?.querySelectorAll('.mep-section-data > span') || [])];
+    const rows = {};
+    for (let i = 0; i < spans.length; i += 2) {
+      rows[spans[i].textContent.trim()] = spans[i + 1]?.textContent.trim();
+    }
+    return rows;
+  }
+
+  it('counts cards and standalone offers regardless of highlight mode', async () => {
+    // Highlight is OFF — annotateCollectionChildren and annotateOffers don't
+    // run, so the previous summary (which counted [data-mas-block="card"]
+    // and [data-mas-block="offer"]) would have missed the collection-child
+    // cards and reported 0 offers. Native-element queries fix both.
+    const collectionWrap = document.createElement('div');
+    collectionWrap.dataset.masBlock = 'collection';
+    const collEl = document.createElement('merch-card-collection');
+    const childCard1 = document.createElement('merch-card');
+    const childCard2 = document.createElement('merch-card');
+    // Card-internal offers should NOT be counted in "Standalone Offers" — the
+    // per-card "Edit OSI" action stack already exposes them, and counting
+    // them here would inflate the row by ~5x cards. Add one to each child
+    // to prove the filter excludes them.
+    const childOffer1 = document.createElement('span');
+    childOffer1.setAttribute('is', 'inline-price');
+    childOffer1.setAttribute('data-wcs-osi', 'OSI-CHILD-1');
+    childCard1.append(childOffer1);
+    const childOffer2 = document.createElement('span');
+    childOffer2.setAttribute('is', 'inline-price');
+    childOffer2.setAttribute('data-wcs-osi', 'OSI-CHILD-2');
+    childCard2.append(childOffer2);
+    collEl.append(childCard1, childCard2);
+    collectionWrap.append(collEl);
+    document.body.append(collectionWrap);
+
+    // Standalone authored card (lives outside any collection).
+    const standaloneCard = document.createElement('merch-card');
+    document.body.append(standaloneCard);
+
+    // A standalone offer — the kind of element a notifications block or a
+    // marquee CTA exposes. Lives outside any <merch-card>, so it counts.
+    const standaloneOffer = document.createElement('span');
+    standaloneOffer.setAttribute('is', 'inline-price');
+    standaloneOffer.setAttribute('data-wcs-osi', 'OSI-STANDALONE');
+    document.body.append(standaloneOffer);
+
+    setConfig(config);
+    await decoratePreviewMode();
+
+    const rows = getMasSummaryRows();
+    expect(rows.Collections).to.equal('1');
+    expect(rows.Cards, 'Cards counts both standalone and in-collection (highlight-independent)').to.equal('3');
+    expect(
+      rows['Standalone Offers'],
+      'Standalone Offers excludes card-internal offers — only the marquee/notification-style one is counted',
+    ).to.equal('1');
+    // Surfaces Detected = Collections + Cards + Inline Fields + Standalone
+    // Offers = 1 + 3 + 0 + 1 = 5. Sub-collections are NOT in the total
+    // (see comments in buildSummaryMas).
+    expect(rows['Surfaces Detected']).to.equal('5');
+  });
+
+  it('reports captured sub-collections as a sub-row outside the Surfaces Detected total', async () => {
+    // Two collection containers: one with 3 captured sub-collections, one
+    // with 0. The summary should show "Sub-collections: 3" but leave the
+    // headline Surfaces Detected unchanged (sub-collections aren't a
+    // separate DOM surface — they live inside their parent collection).
+    const colWithSubs = document.createElement('div');
+    colWithSubs.dataset.masBlock = 'collection';
+    colWithSubs.append(document.createElement('merch-card-collection'));
+    document.body.append(colWithSubs);
+
+    const colNoSubs = document.createElement('div');
+    colNoSubs.dataset.masBlock = 'collection';
+    colNoSubs.append(document.createElement('merch-card-collection'));
+    document.body.append(colNoSubs);
+
+    // Seed the WeakMap directly — same shape attachAemLoadListener stores.
+    mepMasSubCollections.set(colWithSubs, [
+      { id: 'sub-a', label: 'Photo', queryLabel: 'photo' },
+      { id: 'sub-b', label: 'Video', queryLabel: 'video' },
+      { id: 'sub-c', label: 'Design', queryLabel: 'design' },
+    ]);
+
+    setConfig(config);
+    await decoratePreviewMode();
+
+    const rows = getMasSummaryRows();
+    expect(rows.Collections, 'two collection containers seeded').to.equal('2');
+    expect(rows['Sub-collections'], 'sums every container\'s captured sub-collection list').to.equal('3');
+    // Surfaces total stays at 2 (just the two collections) — sub-collections
+    // are explicitly excluded from the headline so we don't double-count
+    // the same on-screen content area.
+    expect(rows['Surfaces Detected']).to.equal('2');
+  });
+});
+
+describe('M@S markets UI visibility', () => {
+  // The "Use M@S markets instead" checkbox and the "Supported M@S Markets"
+  // dropdown render conditionally based on whether the page exposes Lingo
+  // regions and whether any M@S surface is on the page. This block locks in
+  // the matrix from getMepPopup's buildOptionsMasMarketSelect / toggle gate.
+
+  let lingoMeta;
+  let prevMarketsConfig;
+
+  // Common helper: seed any kind of M@S surface so hasMasSurfaces() returns
+  // true. We use a bare [data-mas-block="ost"] node because it's the cheapest
+  // surface (no custom-element registration / DOM construction needed).
+  function seedMasSurface() {
+    const el = document.createElement('div');
+    el.dataset.masBlock = 'ost';
+    document.body.append(el);
+    return el;
+  }
+
+  function lingoConfig() {
+    return {
+      ...config,
+      mep: {
+        ...config.mep,
+        akamaiCode: 'de',
+        consentState: { performance: true, advertising: true },
+      },
+      locale: {
+        ...config.locale,
+        prefix: '/de',
+        base: '',
+        regions: { ch_de: { prefix: '/ch_de' }, at_de: { prefix: '/at_de' } },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    document.querySelectorAll('.mep-preview-overlay, [data-mas-block], merch-card, [data-wcs-osi]').forEach((el) => el.remove());
+    delete document.body.dataset.mepHighlight;
+    delete document.body.dataset.mepMasHighlight;
+    // Reset to baseline (non-Lingo) config first so leftover regions from
+    // earlier tests don't make lingoActive() flip true here. setConfig
+    // REPLACES the live config, which wipes marketsConfig — so we re-seed
+    // marketsConfig AFTER. Pre-seeding lets the dropdown render with real
+    // options synchronously, avoiding the cold-cache deferred-populate
+    // path covered separately by 'M@S markets dropdown defer-populate'.
+    setConfig(config);
+    prevMarketsConfig = getConfig().marketsConfig;
+    getConfig().marketsConfig = { languages: { data: [{ prefix: '', defaultMarket: 'us', supportedRegions: 'us,gb,fr' }] } };
+  });
+
+  afterEach(() => {
+    if (lingoMeta) {
+      lingoMeta.remove();
+      lingoMeta = null;
+    }
+    document.querySelectorAll('.mep-preview-overlay, [data-mas-block], merch-card, [data-wcs-osi]').forEach((el) => el.remove());
+    delete document.body.dataset.mepHighlight;
+    delete document.body.dataset.mepMasHighlight;
+    getConfig().marketsConfig = prevMarketsConfig;
+    // Restore the baseline non-Lingo config so subsequent describes start clean.
+    setConfig(config);
+  });
+
+  function activateLingo() {
+    lingoMeta = document.createElement('meta');
+    lingoMeta.setAttribute('name', 'langfirst');
+    lingoMeta.setAttribute('content', 'on');
+    document.head.appendChild(lingoMeta);
+    updateConfig(lingoConfig());
+  }
+
+  function getActivePopup() {
+    const popups = document.querySelectorAll('.mep-popup');
+    return popups[popups.length - 1];
+  }
+
+  it('Lingo + no M@S → suppresses both the checkbox and the dropdown', async () => {
+    activateLingo();
+    await decoratePreviewMode();
+
+    const popup = getActivePopup();
+    expect(popup, 'popup should exist').to.exist;
+    expect(
+      popup.querySelector('input[type="checkbox"][id^="mepMasMarketCheckbox"]'),
+      'no Lingo+M@S means no toggle to switch between',
+    ).to.be.null;
+    expect(
+      popup.querySelector('.mep-mas-market-dropdown'),
+      'no M@S surface to spoof, so no dropdown either',
+    ).to.be.null;
+  });
+
+  it('Lingo + M@S, highlight OFF → checkbox shown unchecked, dropdown hidden until checkbox flips', async () => {
+    activateLingo();
+    seedMasSurface();
+    await decoratePreviewMode();
+
+    const popup = getActivePopup();
+    const checkbox = popup.querySelector('input[type="checkbox"][id^="mepMasMarketCheckbox"]');
+    expect(checkbox, 'checkbox renders so user can opt into M@S spoofing').to.exist;
+    expect(checkbox.checked, 'unchecked by default until user flips it').to.be.false;
+    const dropdown = popup.querySelector('.mep-mas-market-dropdown');
+    expect(dropdown, 'dropdown is rendered but hidden').to.exist;
+    expect(dropdown.hasAttribute('hidden'), 'dropdown stays hidden behind the checkbox').to.be.true;
+    expect(
+      dropdown.classList.contains('standalone'),
+      'Lingo+M@S keeps the green-bordered companion variant',
+    ).to.be.false;
+  });
+
+  it('Lingo + M@S → user toggles Highlight M@S ON: M@S checkbox auto-checks, dropdown unhides, Lingo dropdown disables', async () => {
+    activateLingo();
+    seedMasSurface();
+    await decoratePreviewMode();
+
+    const popup = getActivePopup();
+    const masHighlight = popup.querySelector('input[type="checkbox"][id^="mepMasHighlightCheckbox"]');
+    const masMarketCheckbox = popup.querySelector('input[type="checkbox"][id^="mepMasMarketCheckbox"]');
+    const dropdown = popup.querySelector('.mep-mas-market-dropdown');
+    const lingoSelect = popup.querySelector('select[id^="mepLingoRegionSelect"]');
+    expect(masMarketCheckbox.checked, 'baseline: M@S markets checkbox starts unchecked').to.be.false;
+
+    masHighlight.checked = true;
+    masHighlight.dispatchEvent(new Event('change'));
+
+    expect(masMarketCheckbox.checked, 'flipping Highlight M@S auto-checks the markets checkbox').to.be.true;
+    expect(dropdown.hasAttribute('hidden'), 'dropdown unhides as a side-effect of the checkbox flip').to.be.false;
+    expect(lingoSelect.disabled, 'Lingo dropdown disables so the user knows M@S is now driving akamaiLocale').to.be.true;
+  });
+
+  it('Lingo + M@S → ?mepMasHighlight=true URL load: highlight is on but checkbox is NOT auto-checked', async () => {
+    // Simulate the URL-driven entry path: the highlight is already considered
+    // "on" at popup-build time via the URL param. The auto-check is wired to
+    // a runtime change event, so it should NOT fire here — the user's prior
+    // Lingo dropdown choice survives.
+    const original = window.history.state;
+    window.history.replaceState(null, '', `${window.location.pathname}?mepMasHighlight=true`);
+    activateLingo();
+    seedMasSurface();
+    try {
+      await decoratePreviewMode();
+      const popup = getActivePopup();
+      const masMarketCheckbox = popup.querySelector('input[type="checkbox"][id^="mepMasMarketCheckbox"]');
+      expect(masMarketCheckbox.checked, 'URL-driven highlight does not auto-check the markets checkbox').to.be.false;
+    } finally {
+      window.history.replaceState(original, '', window.location.pathname);
+    }
+  });
+
+  it('non-Lingo + M@S → no checkbox, dropdown shown standalone (no hidden, .standalone class set)', async () => {
+    seedMasSurface();
+    await decoratePreviewMode();
+
+    const popup = getActivePopup();
+    expect(
+      popup.querySelector('input[type="checkbox"][id^="mepMasMarketCheckbox"]'),
+      'non-Lingo means no toggle — dropdown is the only spoofer',
+    ).to.be.null;
+    const dropdown = popup.querySelector('.mep-mas-market-dropdown');
+    expect(dropdown, 'dropdown renders unconditionally when M@S is on a non-Lingo page').to.exist;
+    expect(dropdown.hasAttribute('hidden'), 'standalone variant is always visible').to.be.false;
+    expect(
+      dropdown.classList.contains('standalone'),
+      'standalone class lets CSS drop the green-border decoration',
+    ).to.be.true;
+  });
+
+  it('non-Lingo + M@S → selecting a market writes akamaiLocale and mepMasMarket to the preview URL', async () => {
+    seedMasSurface();
+    await decoratePreviewMode();
+
+    const popup = getActivePopup();
+    const dropdown = popup.querySelector('select[id^="mepMasMarketSelect"]');
+    expect(dropdown, 'dropdown should exist').to.exist;
+
+    dropdown.value = 'fr';
+    dropdown.dispatchEvent(new Event('change'));
+
+    const previewLink = popup.querySelector('a[title="Preview above choices"]');
+    const href = previewLink.getAttribute('href');
+    expect(href, 'akamaiLocale gets set from the standalone dropdown').to.include('akamaiLocale=fr');
+    expect(
+      href,
+      'mepMasMarket=true persists across reload so the next popup pre-selects the same value',
+    ).to.include('mepMasMarket=true');
+  });
+
+  it('non-Lingo + no M@S → no checkbox, no dropdown', async () => {
+    await decoratePreviewMode();
+
+    const popup = getActivePopup();
+    expect(popup.querySelector('input[type="checkbox"][id^="mepMasMarketCheckbox"]')).to.be.null;
+    expect(popup.querySelector('.mep-mas-market-dropdown')).to.be.null;
   });
 });

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -21,6 +21,7 @@ const {
 const { setConfig, updateConfig, MILO_EVENTS, createTag, getConfig } = await import('../../../libs/utils/utils.js');
 const { mepMasStudioUrls } = await import('../../../libs/blocks/merch/mas-mep-utils.js');
 const { mepMasSubCollections } = await import('../../../libs/features/personalization/preview-mas-subcollection.js');
+const { mepCaasConfigUrls } = await import('../../../libs/blocks/caas/utils.js');
 
 const config = {
   miloLibs: 'https://main--milo--adobecom.aem.live/libs',
@@ -771,6 +772,29 @@ describe('M@S badge market resolution', () => {
       document.head.append(svc);
       expect(getResolvedPageMarket()).to.equal('gb');
     });
+
+    it('returns the akamaiLocale param when locale maps to an empty country (root locale prefix)', () => {
+      // locale.prefix='/' → getMiloLocaleSettings returns country:'' (falsy)
+      // so the function falls through to the akamaiLocale branch.
+      const origLocale = getConfig().locale;
+      getConfig().locale = { ...origLocale, prefix: '/' };
+      window.history.replaceState({}, '', `${window.location.pathname}?akamaiLocale=fr${window.location.hash}`);
+      try {
+        expect(getResolvedPageMarket()).to.equal('fr');
+      } finally {
+        getConfig().locale = origLocale;
+      }
+    });
+
+    it('returns null when no market signal exists at all (empty locale country + no akamaiLocale)', () => {
+      const origLocale = getConfig().locale;
+      getConfig().locale = { ...origLocale, prefix: '/' };
+      try {
+        expect(getResolvedPageMarket()).to.be.null;
+      } finally {
+        getConfig().locale = origLocale;
+      }
+    });
   });
 
   describe('getCardMarket (Case B — per-card derivation from checkout link)', () => {
@@ -1294,6 +1318,43 @@ describe('M@S card action stack', () => {
     // No sibling <a> badge for standalone cards anymore (replaced by the stack).
     expect(card.previousElementSibling?.classList?.contains('mep-mas-edit-badge')).to.not.equal(true);
   });
+
+  it('Copy Fragment ID shows "Copy failed" when clipboard.writeText rejects', async () => {
+    const card = seedCard({
+      studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-fail',
+      withFragment: 'frag-fail',
+    });
+    const writeStub = sinon.stub().rejects(new Error('denied'));
+    const original = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText: writeStub } });
+    try {
+      injectMasBadges();
+      const copyBtn = card.querySelector('.mep-mas-card-action-copy');
+      copyBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(copyBtn.textContent).to.equal('Copy failed');
+    } finally {
+      Object.defineProperty(navigator, 'clipboard', { configurable: true, value: original });
+    }
+  });
+
+  it('Copy Fragment ID flashes "Copied!" immediately when clipboard API is absent', async () => {
+    const card = seedCard({
+      studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-noclip',
+      withFragment: 'frag-noclip',
+    });
+    const original = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+    try {
+      injectMasBadges();
+      const copyBtn = card.querySelector('.mep-mas-card-action-copy');
+      copyBtn.click();
+      expect(copyBtn.textContent).to.equal('Copied!');
+    } finally {
+      Object.defineProperty(navigator, 'clipboard', { configurable: true, value: original });
+    }
+  });
 });
 
 describe('M@S markets dropdown defer-populate (cold-cache race)', () => {
@@ -1803,5 +1864,400 @@ describe('M@S markets UI visibility', () => {
     const popup = getActivePopup();
     expect(popup.querySelector('input[type="checkbox"][id^="mepMasMarketCheckbox"]')).to.be.null;
     expect(popup.querySelector('.mep-mas-market-dropdown')).to.be.null;
+  });
+});
+
+describe('CaaS highlight badges', () => {
+  function getCaasPopup() {
+    const popups = document.querySelectorAll('.mep-popup');
+    return popups[popups.length - 1];
+  }
+
+  beforeEach(() => {
+    document.querySelectorAll('.mep-preview-overlay, [data-caas-block], a.mep-caas-edit-badge, [data-card-url]').forEach((el) => el.remove());
+    delete document.body.dataset.mepCaasHighlight;
+    setConfig(config);
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('.mep-preview-overlay, [data-caas-block], a.mep-caas-edit-badge, [data-card-url]').forEach((el) => el.remove());
+    delete document.body.dataset.mepCaasHighlight;
+  });
+
+  it('injects an Edit in CaaS Configurator badge when the checkbox is toggled on', async () => {
+    const block = document.createElement('div');
+    block.dataset.caasBlock = 'true';
+    mepCaasConfigUrls.set(block, 'https://caas-config.adobe.com/config-1');
+    document.body.append(block);
+
+    await decoratePreviewMode();
+    const popup = getCaasPopup();
+    const checkbox = popup.querySelector('input[type="checkbox"][id^="mepCaasHighlightCheckbox"]');
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    const badge = block.previousElementSibling;
+    expect(badge?.classList?.contains('mep-caas-edit-badge'), 'badge injected before the block').to.be.true;
+    expect(badge?.getAttribute('href')).to.equal('https://caas-config.adobe.com/config-1');
+    expect(badge?.getAttribute('target')).to.equal('_blank');
+    expect(badge?.textContent).to.equal('Edit in CaaS Configurator');
+  });
+
+  it('removes badges when the checkbox is toggled off', async () => {
+    const block = document.createElement('div');
+    block.dataset.caasBlock = 'true';
+    mepCaasConfigUrls.set(block, 'https://caas-config.adobe.com/config-2');
+    document.body.append(block);
+
+    await decoratePreviewMode();
+    const popup = getCaasPopup();
+    const checkbox = popup.querySelector('input[type="checkbox"][id^="mepCaasHighlightCheckbox"]');
+
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+    expect(block.previousElementSibling?.classList?.contains('mep-caas-edit-badge'), 'badge present after on').to.be.true;
+
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change'));
+    expect(document.querySelector('a.mep-caas-edit-badge'), 'badge gone after off').to.be.null;
+  });
+
+  it('is idempotent — toggling on twice does not duplicate the badge', async () => {
+    const block = document.createElement('div');
+    block.dataset.caasBlock = 'true';
+    mepCaasConfigUrls.set(block, 'https://caas-config.adobe.com/config-3');
+    document.body.append(block);
+
+    await decoratePreviewMode();
+    const popup = getCaasPopup();
+    const checkbox = popup.querySelector('input[type="checkbox"][id^="mepCaasHighlightCheckbox"]');
+
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(document.querySelectorAll('a.mep-caas-edit-badge').length).to.equal(1);
+  });
+
+  it('skips [data-caas-block] elements with no mepCaasConfigUrls entry', async () => {
+    const block = document.createElement('div');
+    block.dataset.caasBlock = 'true';
+    document.body.append(block);
+
+    await decoratePreviewMode();
+    const popup = getCaasPopup();
+    const checkbox = popup.querySelector('input[type="checkbox"][id^="mepCaasHighlightCheckbox"]');
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(document.querySelector('a.mep-caas-edit-badge'), 'no badge without WeakMap entry').to.be.null;
+  });
+
+  it('derives data-card-path from data-card-url after badge injection', async () => {
+    const block = document.createElement('div');
+    block.dataset.caasBlock = 'true';
+    mepCaasConfigUrls.set(block, 'https://caas-config.adobe.com/config-4');
+    document.body.append(block);
+
+    const card = document.createElement('div');
+    card.dataset.cardUrl = 'https://www.adobe.com/cards/photoshop.html';
+    document.body.append(card);
+
+    await decoratePreviewMode();
+    const popup = getCaasPopup();
+    const checkbox = popup.querySelector('input[type="checkbox"][id^="mepCaasHighlightCheckbox"]');
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(card.dataset.cardPath).to.equal('/cards/photoshop.html');
+  });
+
+  it('clears data-card-path when badges are removed', async () => {
+    const block = document.createElement('div');
+    block.dataset.caasBlock = 'true';
+    mepCaasConfigUrls.set(block, 'https://caas-config.adobe.com/config-5');
+    document.body.append(block);
+
+    const card = document.createElement('div');
+    card.dataset.cardUrl = 'https://www.adobe.com/cards/photoshop.html';
+    document.body.append(card);
+
+    await decoratePreviewMode();
+    const popup = getCaasPopup();
+    const checkbox = popup.querySelector('input[type="checkbox"][id^="mepCaasHighlightCheckbox"]');
+
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+    expect(card.dataset.cardPath, 'path set after inject').to.equal('/cards/photoshop.html');
+
+    checkbox.checked = false;
+    checkbox.dispatchEvent(new Event('change'));
+    expect(card.dataset.cardPath, 'path cleared after remove').to.be.undefined;
+  });
+
+  it('auto-injects badges on decoratePreviewMode when ?mepCaasHighlight=true is in the URL', async () => {
+    const block = document.createElement('div');
+    block.dataset.caasBlock = 'true';
+    mepCaasConfigUrls.set(block, 'https://caas-config.adobe.com/config-6');
+    document.body.append(block);
+
+    window.history.replaceState(null, '', `${window.location.pathname}?mepCaasHighlight=true`);
+    try {
+      await decoratePreviewMode();
+      expect(
+        block.previousElementSibling?.classList?.contains('mep-caas-edit-badge'),
+        'badge auto-injected from URL param on init',
+      ).to.be.true;
+    } finally {
+      window.history.replaceState(null, '', window.location.pathname);
+    }
+  });
+
+  it('sets data-card-path to empty string when data-card-url is not a parseable URL', async () => {
+    const block = document.createElement('div');
+    block.dataset.caasBlock = 'true';
+    mepCaasConfigUrls.set(block, 'https://caas-config.adobe.com/config-7');
+    document.body.append(block);
+
+    const card = document.createElement('div');
+    card.dataset.cardUrl = 'just-a-bare-word-no-scheme';
+    document.body.append(card);
+
+    await decoratePreviewMode();
+    const popup = getCaasPopup();
+    const checkbox = popup.querySelector('input[type="checkbox"][id^="mepCaasHighlightCheckbox"]');
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(card.dataset.cardPath).to.equal('');
+  });
+});
+
+describe('data-card-url click handling', () => {
+  let windowOpenStub;
+  let getComputedStyleStub;
+
+  beforeEach(async () => {
+    document.querySelectorAll('.mep-preview-overlay, [data-card-url]').forEach((el) => el.remove());
+    delete document.body.dataset.mepCaasHighlight;
+    windowOpenStub = sinon.stub(window, 'open');
+    const originalGetComputedStyle = window.getComputedStyle;
+    getComputedStyleStub = sinon.stub(window, 'getComputedStyle').callsFake((el, pseudo) => {
+      if (pseudo === '::before') return { display: 'block', content: '"badge"', width: '400px' };
+      return originalGetComputedStyle(el, pseudo);
+    });
+    setConfig(config);
+    await decoratePreviewMode();
+    document.body.dataset.mepCaasHighlight = 'true';
+  });
+
+  afterEach(() => {
+    windowOpenStub.restore();
+    getComputedStyleStub.restore();
+    delete document.body.dataset.mepCaasHighlight;
+    document.querySelectorAll('.mep-preview-overlay, [data-card-url]').forEach((el) => el.remove());
+  });
+
+  it('opens data-card-url when clicked in the badge area', () => {
+    const card = document.createElement('div');
+    card.dataset.cardUrl = 'https://business.adobe.com/foo.html';
+    document.body.append(card);
+    card.getBoundingClientRect = () => ({ top: 0, left: 0, width: 500, height: 100 });
+
+    card.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 50, clientY: 10 }));
+
+    expect(windowOpenStub.called, 'window.open called for card-url element').to.be.true;
+  });
+
+  it('rewrites a prod-domain card URL to the current host when ?milolibs= is in the URL', () => {
+    window.history.replaceState(null, '', `${window.location.pathname}?milolibs=some-branch`);
+    try {
+      const card = document.createElement('div');
+      card.dataset.cardUrl = 'https://www.adobe.com/products/photoshop.html';
+      document.body.append(card);
+      card.getBoundingClientRect = () => ({ top: 0, left: 0, width: 500, height: 100 });
+
+      card.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 50, clientY: 10 }));
+
+      expect(windowOpenStub.called).to.be.true;
+      const openedUrl = windowOpenStub.firstCall?.args[0] ?? '';
+      expect(openedUrl, 'prod domain rewritten to current host').to.include(window.location.host);
+      expect(openedUrl, 'pathname preserved').to.include('/products/photoshop.html');
+    } finally {
+      window.history.replaceState(null, '', window.location.pathname);
+    }
+  });
+
+  it('does not open when all highlight modes are off', () => {
+    delete document.body.dataset.mepCaasHighlight;
+    delete document.body.dataset.mepHighlight;
+    delete document.body.dataset.mepFragments;
+    const card = document.createElement('div');
+    card.dataset.cardUrl = 'https://business.adobe.com/foo.html';
+    document.body.append(card);
+    card.getBoundingClientRect = () => ({ top: 0, left: 0, width: 500, height: 100 });
+
+    card.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 50, clientY: 10 }));
+
+    expect(windowOpenStub.called, 'no open when all highlights off').to.be.false;
+  });
+});
+
+describe('handleChildCardBadgeClick — nested ost/offer inside inline', () => {
+  let windowOpenStub;
+
+  beforeEach(() => {
+    document.querySelectorAll('[data-mas-block="inline"], [data-mas-block="ost"]').forEach((el) => el.remove());
+    document.body.dataset.mepMasHighlight = 'true';
+    watchForMasContent();
+    windowOpenStub = sinon.stub(window, 'open');
+  });
+
+  afterEach(() => {
+    windowOpenStub.restore();
+    sinon.restore();
+    delete document.body.dataset.mepMasHighlight;
+    document.querySelectorAll('[data-mas-block="inline"], [data-mas-block="ost"]').forEach((el) => el.remove());
+  });
+
+  it('fires ost URL when clicking in the moved-below badge zone of a nested ost', () => {
+    const inline = document.createElement('div');
+    inline.dataset.masBlock = 'inline';
+    const ost = document.createElement('span');
+    ost.dataset.masBlock = 'ost';
+    inline.append(ost);
+    document.body.append(inline);
+
+    mepMasStudioUrls.set(inline, 'https://mas.adobe.com/inline-studio');
+    mepMasStudioUrls.set(ost, 'https://milo.adobe.com/tools/ost?osi=OSI-NESTED&type=price&country=US');
+
+    // rect: top=0, right=500, height=50. Moved zone: yMin=54, yMax=76
+    sinon.stub(ost, 'getBoundingClientRect').returns({ top: 0, right: 500, height: 50 });
+    sinon.stub(inline, 'getBoundingClientRect').returns({ top: 0, right: 500, height: 50 });
+
+    ost.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 490, clientY: 58 }));
+
+    expect(windowOpenStub.calledOnce, 'OST URL opened from moved badge zone').to.be.true;
+    expect(windowOpenStub.firstCall.args[0]).to.include('osi=OSI-NESTED');
+  });
+
+  it('does NOT fire for a nested ost clicked in the old top zone (badge moved below, click misses)', () => {
+    const inline = document.createElement('div');
+    inline.dataset.masBlock = 'inline';
+    const ost = document.createElement('span');
+    ost.dataset.masBlock = 'ost';
+    inline.append(ost);
+    document.body.append(inline);
+
+    mepMasStudioUrls.set(ost, 'https://milo.adobe.com/tools/ost?osi=OSI-MISS&type=price&country=US');
+
+    // rect: top=10, right=500, height=50. Moved zone: yMin=64, yMax=86
+    sinon.stub(ost, 'getBoundingClientRect').returns({ top: 10, right: 500, height: 50 });
+    sinon.stub(inline, 'getBoundingClientRect').returns({ top: 10, right: 500, height: 50 });
+
+    ost.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, clientX: 490, clientY: 5 }));
+
+    expect(windowOpenStub.called, 'click in pre-fix zone should not fire').to.be.false;
+  });
+});
+
+describe('injectMasBadges — stale badge replacement when market changes', () => {
+  beforeEach(() => {
+    document.querySelectorAll('[data-mas-block], a.mep-mas-edit-badge').forEach((el) => el.remove());
+    document.head.querySelectorAll('mas-commerce-service').forEach((el) => el.remove());
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('[data-mas-block], a.mep-mas-edit-badge').forEach((el) => el.remove());
+    document.head.querySelectorAll('mas-commerce-service').forEach((el) => el.remove());
+  });
+
+  it('removes and replaces the sibling badge when the resolved market changes between passes', () => {
+    const container = document.createElement('div');
+    container.dataset.masBlock = 'collection';
+    document.body.append(container);
+    mepMasStudioUrls.set(container, 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-stale');
+
+    injectMasBadges();
+    const firstBadge = container.previousElementSibling;
+    expect(firstBadge?.classList?.contains('mep-mas-edit-badge'), 'first badge exists after initial pass').to.be.true;
+    const firstMarket = firstBadge.dataset.mepMasMarket;
+
+    // data-ims-country on the element overrides the page market in getCardMarket.
+    const differentMarket = firstMarket === 'de' ? 'fr' : 'de';
+    container.setAttribute('data-ims-country', differentMarket);
+
+    injectMasBadges();
+
+    const newBadge = container.previousElementSibling;
+    expect(newBadge?.classList?.contains('mep-mas-edit-badge'), 'new badge present after re-stamp').to.be.true;
+    expect(newBadge.dataset.mepMasMarket, 'new badge reflects updated market').to.equal(differentMarket);
+    expect(document.querySelectorAll('a.mep-mas-edit-badge').length, 'only one badge — stale one removed').to.equal(1);
+  });
+});
+
+describe('masAemLoadHandler — aem:load event handler', () => {
+  beforeEach(() => {
+    document.querySelectorAll('[data-mas-block], merch-card').forEach((el) => el.remove());
+    document.body.dataset.mepMasHighlight = 'true';
+    watchForMasContent();
+  });
+
+  afterEach(() => {
+    delete document.body.dataset.mepMasHighlight;
+    document.querySelectorAll('[data-mas-block], merch-card').forEach((el) => el.remove());
+  });
+
+  it('ignores aem:load when mepMasHighlight is off', () => {
+    delete document.body.dataset.mepMasHighlight;
+    const container = document.createElement('div');
+    container.dataset.masBlock = 'collection';
+    const aemFragment = document.createElement('aem-fragment');
+    container.append(aemFragment);
+    document.body.append(container);
+    mepMasStudioUrls.set(container, 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-off');
+
+    aemFragment.dispatchEvent(new CustomEvent('aem:load', { bubbles: true, detail: null }));
+
+    expect(document.querySelector('a.mep-mas-edit-badge'), 'no badge injected when highlight is off').to.be.null;
+  });
+
+  it('ignores aem:load when target is not an AEM-FRAGMENT element', () => {
+    const div = document.createElement('div');
+    document.body.append(div);
+
+    div.dispatchEvent(new CustomEvent('aem:load', { bubbles: true, detail: null }));
+
+    expect(document.querySelector('a.mep-mas-edit-badge'), 'no badge for non-aem-fragment target').to.be.null;
+  });
+
+  it('ignores aem:load when the aem-fragment is not inside a [data-mas-block="collection"]', () => {
+    const aemFragment = document.createElement('aem-fragment');
+    document.body.append(aemFragment);
+
+    aemFragment.dispatchEvent(new CustomEvent('aem:load', { bubbles: true, detail: null }));
+
+    expect(document.querySelector('a.mep-mas-edit-badge'), 'no badge when fragment has no collection container').to.be.null;
+  });
+
+  it('stores sub-collections and schedules a re-stamp when aem:load fires with sub-collection detail', async () => {
+    const container = document.createElement('div');
+    container.dataset.masBlock = 'collection';
+    const aemFragment = document.createElement('aem-fragment');
+    container.append(aemFragment);
+    document.body.append(container);
+    mepMasStudioUrls.set(container, 'https://mas.adobe.com/studio.html#content-type=merch-card-collection&path=acom&query=col-subs');
+
+    const detail = {
+      referencesTree: [{ identifier: 'sub-id-1', fieldName: 'subFilter', referencesTree: [] }],
+      references: { 'sub-id-1': { value: { fields: { label: 'Sub One' } } } },
+    };
+    aemFragment.dispatchEvent(new CustomEvent('aem:load', { bubbles: true, detail }));
+
+    expect(mepMasSubCollections.get(container)?.length, 'sub-collections stored on the container').to.equal(1);
+    expect(mepMasSubCollections.get(container)[0].id).to.equal('sub-id-1');
+
+    await new Promise((resolve) => { setTimeout(resolve, MAS_RESTAMP_DEBOUNCE_MS + 100); });
+    expect(document.querySelector('a.mep-mas-edit-badge'), 'collection badge injected after debounced re-stamp').to.exist;
   });
 });

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -813,7 +813,7 @@ describe('M@S badge market resolution', () => {
     it('upgrades a card surface from page-market to per-card-market and marks the action stack mismatch when they differ', () => {
       // Page market is "us" (default test locale) but this card's checkout link
       // resolves to GB — Edit Card label should end with "· GB" and the
-      // mismatch class should land on the Edit Card / Edit OSI buttons.
+      // mismatch class should land on the Edit Card / View in OST buttons.
       const wrap = document.createElement('div');
       wrap.dataset.masBlock = 'card';
       wrap.append(createTag('a', {
@@ -1147,7 +1147,7 @@ describe('M@S per-child-card badges (Tier 3b — collection children)', () => {
 });
 
 describe('M@S card action stack', () => {
-  // Real DOM overlay (Edit Card / Edit OSI / Copy Fragment ID) injected into
+  // Real DOM overlay (Edit Card / View in OST / Copy Fragment ID) injected into
   // every <merch-card data-mas-block='card'> by injectMasCardActionStack.
   beforeEach(() => {
     document.querySelectorAll('[data-mas-block], a.mep-mas-edit-badge, .mep-mas-card-actions').forEach((el) => el.remove());
@@ -1173,7 +1173,7 @@ describe('M@S card action stack', () => {
     return card;
   }
 
-  it('builds Edit Card / Edit OSI / Copy Fragment ID actions when the card has a Studio URL, an OSI, and a fragment id', () => {
+  it('builds Edit Card / View in OST / Copy Fragment ID actions when the card has a Studio URL, an OSI, and a fragment id', () => {
     const card = seedCard({
       studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1',
       withFragment: 'frag-1',
@@ -1214,7 +1214,7 @@ describe('M@S card action stack', () => {
     expect(ost?.getAttribute('href')).to.include('/tools/ost?osi=OSI-A&country=US');
   });
 
-  it('omits the Edit OSI button when no [data-wcs-osi] exists on or inside the card (display-only card)', () => {
+  it('omits the View in OST button when no [data-wcs-osi] exists on or inside the card (display-only card)', () => {
     const card = seedCard({
       studioUrl: 'https://mas.adobe.com/studio.html#content-type=merch-card&query=card-1',
       osiAttrs: [],
@@ -1532,7 +1532,7 @@ describe('M@S summary counts (highlight-independent)', () => {
     const childCard1 = document.createElement('merch-card');
     const childCard2 = document.createElement('merch-card');
     // Card-internal offers should NOT be counted in "Standalone Offers" — the
-    // per-card "Edit OSI" action stack already exposes them, and counting
+    // per-card "View in OST" action stack already exposes them, and counting
     // them here would inflate the row by ~5x cards. Add one to each child
     // to prove the filter excludes them.
     const childOffer1 = document.createElement('span');

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -1173,8 +1173,8 @@ describe('M@S card action stack', () => {
     expect(editHref).to.include('fragmentId=card-1');
     expect(editHref).to.include('page=fragment-editor');
     expect(editHref).to.not.include('query=');
-    expect(stack.querySelector('.mep-mas-card-action-ost')?.getAttribute('href'))
-      .to.equal('https://milo.adobe.com/tools/ost?osi=OSI-FIRST');
+    const ostHref = stack.querySelector('.mep-mas-card-action-ost')?.getAttribute('href');
+    expect(ostHref).to.include('/tools/ost?osi=OSI-FIRST&country=US');
     const copyBtn = stack.querySelector('.mep-mas-card-action-copy');
     expect(copyBtn).to.exist;
     expect(copyBtn.getAttribute('data-fragment-id')).to.equal('frag-1');
@@ -1192,7 +1192,7 @@ describe('M@S card action stack', () => {
     injectMasBadges();
 
     const ost = card.querySelector('.mep-mas-card-action-ost');
-    expect(ost?.getAttribute('href')).to.equal('https://milo.adobe.com/tools/ost?osi=OSI-A');
+    expect(ost?.getAttribute('href')).to.include('/tools/ost?osi=OSI-A&country=US');
   });
 
   it('omits the Edit OSI button when no [data-wcs-osi] exists on or inside the card (display-only card)', () => {

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -726,7 +726,6 @@ describe('M@S highlight badges', () => {
     const chip = badge.querySelector('.mep-mas-edit-badge-market');
     expect(chip, 'market chip should be a child element').to.exist;
     expect(chip.textContent).to.equal('US');
-    expect(chip.classList.contains('mep-mas-edit-badge-market-match')).to.be.true;
     expect(chip.classList.contains('mep-mas-edit-badge-market-mismatch')).to.be.false;
   });
 });
@@ -2250,7 +2249,7 @@ describe('masAemLoadHandler — aem:load event handler', () => {
 
     const detail = {
       referencesTree: [{ identifier: 'sub-id-1', fieldName: 'subFilter', referencesTree: [] }],
-      references: { 'sub-id-1': { value: { fields: { label: 'Sub One' } } } },
+      references: { 'sub-id-1': { value: { fields: { label: 'Sub One', queryLabel: 'sub-one' } } } },
     };
     aemFragment.dispatchEvent(new CustomEvent('aem:load', { bubbles: true, detail }));
 

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -895,6 +895,25 @@ describe('M@S badge market resolution', () => {
       host.remove();
     });
 
+    it('annotates an inline-price that already has data-mas-block="ost" stamped by M@S', () => {
+      // M@S can pre-stamp data-mas-block="ost" on inline-price elements before
+      // MEP runs. The old guard (if el.dataset.masBlock) skipped these, leaving
+      // mepMasStudioUrls empty and the click handler unable to open OST.
+      const host = createTag('span', {
+        is: 'inline-price',
+        'data-wcs-osi': 'pre-stamped-osi',
+        'data-mas-block': 'ost',
+      });
+      document.body.append(host);
+
+      injectMasBadges();
+
+      expect(mepMasStudioUrls.has(host), 'URL should be registered for pre-stamped ost element').to.be.true;
+      expect(mepMasStudioUrls.get(host)).to.include('/tools/ost?osi=pre-stamped-osi');
+      expect(host.dataset.masBlock).to.equal('ost');
+      host.remove();
+    });
+
     it('stamps data-mas-market on offer hosts using the host\'s own data-ims-country', () => {
       // Offer hosts ARE the checkout-link / inline-price element, so the
       // ims-country attribute lives on the host itself (set by M@S


### PR DESCRIPTION
### Summary                                                                                                                                                   

  Adds two "Highlight ..." modes to the MEP preview panel:                                                                                                        
   
  1. **Highlight CaaS** (MWPW-194203) — CaaS-backed card collections get an outline, an "Edit in CaaS Configurator" badge, and per-card market/lang pills with    
  click-to-source navigation.                                                                                                                                   
  2. **Highlight M@S** (MWPW-194204) — M@S surfaces (collections, cards, inline fields, OST links, standalone offers) get outlines plus "Edit in M@S Studio"      
  badges that open the correct Studio entry for that specific content.                                                                                            
   
  Each mode is gated by its own checkbox in the popup, persists via URL param (`mepCaasHighlight=true` / `mepMasHighlight=true`), and has zero impact when off.   
                                                                                                                                                                
  Builds on caas-libs changes from [adobecom/caas#453](https://github.com/adobecom/caas/pull/453) (merged), which added `data-country` and `data-card-url` to card
   elements.                                                                                                                                                    
                                                                                                                                                                  
  Resolves: [MWPW-194203](https://jira.corp.adobe.com/browse/MWPW-194203), [MWPW-194204](https://jira.corp.adobe.com/browse/MWPW-194204)                          
   
  ---                                                                                                                                                             
                                                                                                                                                                
  ### Highlight CaaS — MWPW-194203                                                                                                                                
   
  - **Block badge** — `<a class="mep-caas-edit-badge">` injected as a sibling immediately before each `[data-caas-block]`, linking to the Configurator with the   
  full block config pre-loaded. Sibling placement prevents React from reconciling the anchor away.                                                              
  - **Per-card path badges** — cards from `caas-libs` carry `data-card-url` (Chimera reference field) and `data-country`. CSS `::before` pills show 🔗            
  `caas-market:` (green) or 🔗 `caas-lang:` (yellow) by country code.                                                                                             
  - **Click-to-navigate** — clicking a per-card badge area opens the card's source URL, rewritten to the current preview host. BACOM `/blog/` cards route to the
  `-blog` sibling repo.                                                                                                                                           
  - **Lazy-load support** — MutationObserver picks up late-rendered blocks. **Observer attaches on toggle-on, disconnects on toggle-off** (addresses review     
  feedback).                                                                                                                                                      
  - **Review feedback addressed** — selectors scoped to `[data-caas-block]`, empty-path badge suppression, `data-card-path` cleanup on toggle-off, observer     
  hygiene.                                                                                                                                                        
                                                                                                                                                                
  ### Highlight M@S — MWPW-194204                                                                                                                                 
                                                                                                                                                                
  - **Five surfaces** stamped with `data-mas-block`: `collection`, `card`, `inline`, `ost`, `offer`. Each gets its own outline color and "Edit in M@S Studio"     
  badge.
    - Collection (purple) → sibling badge                                                                                                                         
    - Card (orange) → real-DOM action stack (Edit Card / Edit OSI / Copy Fragment ID)                                                                           
    - Inline / OST / Offer (pink / blue / blue) → CSS `::before` pseudo-badges with click delegation to the captured Studio URL                                   
  - **Sub-collections** — `<merch-card-collection>` sidenav-filtered sub-collections get their own "Edit Sub-collection" badge. Sub-collection metadata is        
  captured at fragment load via `aem:load` (autoblock-side `attachAemLoadListener`; new `preview-mas-subcollection.js`).                                          
  - **Authoring URL capture** — `mepMasStudioUrls` WeakMap stores the original studio URL keyed by host element. Capture happens at autoblock time                
  (merch-card-autoblock, merch-card-collection-autoblock, merch.js); consumed by the preview overlay for badge `href`s.                                           
  - **Market awareness** — page market resolved from `<mas-commerce-service country>` → locale → `?akamaiLocale`. Per-host market checked against               
  `data-ims-country` (post-WCS) → `country=` query param → page fallback. Card chip flips to yellow on mismatch.                                                  
  - **M@S Markets spoofer dropdown** — lets authors test different markets without hand-editing the URL. Standalone on non-Lingo pages; gated by "Use M@S markets
  instead" checkbox alongside the Lingo dropdown.                                                                                                                 
  - **"No M@S content found" message** when the page has no M@S surfaces.                                                                                       
  - **Observer hygiene** — same pattern as CaaS: all listeners (capture-phase click, `aem:load`, restamp-click, MutationObserver) attach on `Highlight M@S`       
  toggle-on and detach on toggle-off via named handler refs.                                                                                                      
   
  ---                                                                                                                                                             
                                                                                                                                                                
  ### Implementation notes

  - The CaaS Configurator deep-link URL is ~2.5KB of base64 config — too large for a `data-*` attribute. Stored in a module-level `WeakMap` (`mepCaasConfigUrls`  
  in `caas/utils.js`), keyed by the wrapper element. CaaS removes and recreates the wrapper during init; the entry is copied during the handoff.
  - The M@S `mepMasStudioUrls` WeakMap is shared across `merch.js`, `merch-card-autoblock.js`, `merch-card-collection-autoblock.js`, and the preview overlay via  
  the new `libs/blocks/merch/mas-mep-utils.js` module. WeakMap so entries GC alongside their host elements.                                                       
  - Sub-collection capture has a strict ordering constraint: the `aem:load` listener must be attached BEFORE the container is mounted — M@S removes
  `<aem-fragment>` immediately after dispatching the event. The autoblock attaches at fragment-creation time; the preview overlay has a document-level fallback   
  for the "highlight enabled mid-session" race.                                                                                                                 
                                                                                                                                                                  
  ---                                                                                                                                                           

  ### Test URLs

  **CaaS:**
  - https://main--da-bacom--adobecom.aem.page/resources/main?akamaiLocale=sg&milolibs=mep-cardattribute&mepCaasHighlight=true
                                                                                                                                                                  
  **M@S:**
  - https://stage--cc--adobecom.aem.page/fr/creativecloud/plans?milolibs=mep-cardattribute&mepMasHighlight=true&mepMasMarket=true                                                                                                                                            
  - https://main--cc--adobecom.aem.page/products/photoshop?milolibs=mep-cardattribute&mepMasHighlight=true 
                                                                                                                                                                  
  PSI: https://mep-cardattribute--milo--adobecom.aem.page/?martech=off      

















