### PR TITLE
feat: add hreflang sitemap caching to eliminate redundant bot fetches

### DIFF
--- a/libs/features/hreflang/hreflang.js
+++ b/libs/features/hreflang/hreflang.js
@@ -48,24 +48,32 @@ async function fetchSitemapMap(sitemapUrl) {
     }
     return buildHreflangMap(xmlDoc);
   } catch (e) {
-    window.lana?.log(`hreflang: error fetching sitemap ${sitemapUrl} - ${e.message}`, { tags: 'hreflang', severity: 'error' });
+    const msg = e.name === 'AbortError'
+      ? `hreflang: sitemap fetch timed out after ${FETCH_TIMEOUT_MS}ms: ${sitemapUrl}`
+      : `hreflang: error fetching sitemap ${sitemapUrl} - ${e.message}`;
+    window.lana?.log(msg, { tags: 'hreflang', severity: 'error' });
     return null;
   } finally {
     clearTimeout(timeoutId);
   }
 }
 
-function getSitemapPath(pathname, locales, sitemapTemplate) {
-  const localeMatch = locales.find((locale) => pathname.startsWith(`/${locale}/`));
-  return localeMatch ? sitemapTemplate.replace('{locale}', localeMatch) : sitemapTemplate.replace('/{locale}', '');
+function getSitemapPath(localeMatch, sitemapTemplate) {
+  if (!sitemapTemplate.includes('{locale}')) {
+    window.lana?.log(`hreflang: sitemapTemplate missing {locale} placeholder: ${sitemapTemplate}`, { tags: 'hreflang', severity: 'error' });
+    return sitemapTemplate;
+  }
+  return localeMatch
+    ? sitemapTemplate.replace('{locale}', localeMatch)
+    : sitemapTemplate.replace(/\/?{locale}/, '');
 }
 
 // sitemapOrigin is the prod origin used in sitemap <loc> values, which may differ
 // from location.origin (e.g. localhost in dev). The fetch uses location.origin so
 // it works locally; sitemapOrigin is only used to construct the lookup key.
-function getCurrentPageUrl(sitemapOrigin, pathname, locales) {
-  const localeMatch = locales.find((locale) => pathname.startsWith(`/${locale}/`));
-  const correctedPath = pathname.endsWith('.html') ? pathname : `${pathname}.html`;
+function getCurrentPageUrl(sitemapOrigin, pathname, localeMatch) {
+  const normalizedPath = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+  const correctedPath = normalizedPath.endsWith('.html') ? normalizedPath : `${normalizedPath}.html`;
   const isLocaleRoot = localeMatch && pathname === `/${localeMatch}/`;
   if (pathname === '/' || isLocaleRoot) {
     return isLocaleRoot ? `${sitemapOrigin}/${localeMatch}/` : `${sitemapOrigin}/`;
@@ -109,9 +117,10 @@ export async function appendHreflangLinks({
   if (!allowedAgents.some((agent) => userAgent.includes(agent.trim()))) return;
 
   const { origin, pathname } = location;
-  const sitemapPath = getSitemapPath(pathname, locales, sitemapTemplate);
+  const localeMatch = locales.find((locale) => pathname.startsWith(`/${locale}/`));
+  const sitemapPath = getSitemapPath(localeMatch, sitemapTemplate);
   const sitemapUrl = `${origin}${sitemapPath}`;
-  const currentPageUrl = getCurrentPageUrl(sitemapOrigin, pathname, locales);
+  const currentPageUrl = getCurrentPageUrl(sitemapOrigin, pathname, localeMatch);
 
   let map = getCachedMap(sitemapPath);
   if (!map) {

--- a/libs/features/hreflang/hreflang.js
+++ b/libs/features/hreflang/hreflang.js
@@ -1,0 +1,127 @@
+const CACHE_KEY_PREFIX = 'milo-hreflang-';
+const FETCH_TIMEOUT_MS = 5000;
+
+function buildHreflangMap(xmlDoc) {
+  const map = {};
+  for (const urlEl of xmlDoc.querySelectorAll('url')) {
+    const loc = urlEl.querySelector('loc')?.textContent;
+    if (!loc) continue;
+    const links = [...urlEl.querySelectorAll('link[rel="alternate"]')]
+      .map((el) => ({ hreflang: el.getAttribute('hreflang'), href: el.getAttribute('href') }))
+      .filter((l) => l.hreflang && l.href);
+    if (links.length) map[loc] = links;
+  }
+  return map;
+}
+
+function getCachedMap(cacheKey) {
+  try {
+    const cached = sessionStorage.getItem(CACHE_KEY_PREFIX + cacheKey);
+    return cached ? JSON.parse(cached) : null;
+  } catch {
+    return null;
+  }
+}
+
+function setCachedMap(cacheKey, map) {
+  try {
+    sessionStorage.setItem(CACHE_KEY_PREFIX + cacheKey, JSON.stringify(map));
+  } catch {
+    window.lana?.log(`hreflang: sessionStorage quota exceeded for ${cacheKey}`, { tags: 'hreflang', severity: 'warning' });
+  }
+}
+
+async function fetchSitemapMap(sitemapUrl) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(sitemapUrl, { signal: controller.signal });
+    if (!response.ok) {
+      window.lana?.log(`hreflang: failed to fetch sitemap ${sitemapUrl} (${response.status})`, { tags: 'hreflang', severity: 'error' });
+      return null;
+    }
+    const xmlText = await response.text();
+    const xmlDoc = new DOMParser().parseFromString(xmlText, 'text/xml');
+    if (xmlDoc.querySelector('parsererror')) {
+      window.lana?.log(`hreflang: failed to parse sitemap ${sitemapUrl}`, { tags: 'hreflang', severity: 'error' });
+      return null;
+    }
+    return buildHreflangMap(xmlDoc);
+  } catch (e) {
+    window.lana?.log(`hreflang: error fetching sitemap ${sitemapUrl} - ${e.message}`, { tags: 'hreflang', severity: 'error' });
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function getSitemapPath(pathname, locales, sitemapTemplate) {
+  const localeMatch = locales.find((locale) => pathname.startsWith(`/${locale}/`));
+  return localeMatch ? sitemapTemplate.replace('{locale}', localeMatch) : sitemapTemplate.replace('/{locale}', '');
+}
+
+// sitemapOrigin is the prod origin used in sitemap <loc> values, which may differ
+// from location.origin (e.g. localhost in dev). The fetch uses location.origin so
+// it works locally; sitemapOrigin is only used to construct the lookup key.
+function getCurrentPageUrl(sitemapOrigin, pathname, locales) {
+  const localeMatch = locales.find((locale) => pathname.startsWith(`/${locale}/`));
+  const correctedPath = pathname.endsWith('.html') ? pathname : `${pathname}.html`;
+  const isLocaleRoot = localeMatch && pathname === `/${localeMatch}/`;
+  if (pathname === '/' || isLocaleRoot) {
+    return isLocaleRoot ? `${sitemapOrigin}/${localeMatch}/` : `${sitemapOrigin}/`;
+  }
+  return `${sitemapOrigin}${correctedPath}`;
+}
+
+function injectLinks(hreflangLinks) {
+  const titleEl = document.head.querySelector('title');
+  if (!titleEl || !hreflangLinks?.length) return;
+  const linkEls = hreflangLinks.map(({ hreflang, href }) => {
+    const el = document.createElement('link');
+    el.setAttribute('rel', 'alternate');
+    el.setAttribute('hreflang', hreflang);
+    el.setAttribute('href', href);
+    return el;
+  });
+  titleEl.after(...linkEls);
+}
+
+/**
+ * @param {object} config
+ * @param {string[]} config.locales - list of locale prefixes (e.g. ['de', 'fr', 'de_de'])
+ * @param {string} config.sitemapTemplate - path template with {locale} placeholder
+ *   e.g. '/{locale}/cc-shared/assets/sitemap.xml' for CC
+ *   e.g. '/{locale}/sitemap.xml' for bacom
+ * @param {string} [config.sitemapOrigin] - prod origin used in sitemap <loc> values (default: 'https://www.adobe.com')
+ * @param {object} [config.location] - override window.location (for testing)
+ */
+export async function appendHreflangLinks({
+  locales,
+  sitemapTemplate,
+  sitemapOrigin = 'https://www.adobe.com',
+  location = window.location,
+} = {}) {
+  const userAgentMeta = document.querySelector('meta[name="hreflinksuseragents"]');
+  if (!userAgentMeta?.content) return;
+
+  const allowedAgents = userAgentMeta.content.split(',');
+  const { userAgent } = window.navigator;
+  if (!allowedAgents.some((agent) => userAgent.includes(agent.trim()))) return;
+
+  const { origin, pathname } = location;
+  const sitemapPath = getSitemapPath(pathname, locales, sitemapTemplate);
+  const sitemapUrl = `${origin}${sitemapPath}`;
+  const currentPageUrl = getCurrentPageUrl(sitemapOrigin, pathname, locales);
+
+  let map = getCachedMap(sitemapPath);
+  if (!map) {
+    map = await fetchSitemapMap(sitemapUrl);
+    if (!map) return;
+    setCachedMap(sitemapPath, map);
+  }
+
+  const hreflangLinks = map[currentPageUrl] ?? map[currentPageUrl.replace(/\/$/, '')];
+  injectLinks(hreflangLinks);
+}
+
+export default appendHreflangLinks;

--- a/libs/features/hreflang/hreflang.js
+++ b/libs/features/hreflang/hreflang.js
@@ -3,14 +3,14 @@ const FETCH_TIMEOUT_MS = 5000;
 
 function buildHreflangMap(xmlDoc) {
   const map = {};
-  for (const urlEl of xmlDoc.querySelectorAll('url')) {
+  xmlDoc.querySelectorAll('url').forEach((urlEl) => {
     const loc = urlEl.querySelector('loc')?.textContent;
-    if (!loc) continue;
+    if (!loc) return;
     const links = [...urlEl.querySelectorAll('link[rel="alternate"]')]
       .map((el) => ({ hreflang: el.getAttribute('hreflang'), href: el.getAttribute('href') }))
       .filter((l) => l.hreflang && l.href);
     if (links.length) map[loc] = links;
-  }
+  });
   return map;
 }
 

--- a/test/features/hreflang/hreflang.test.js
+++ b/test/features/hreflang/hreflang.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { stub, restore } from 'sinon';
+import sinon, { stub, restore } from 'sinon';
 import { appendHreflangLinks } from '../../../libs/features/hreflang/hreflang.js';
 
 const DE_LOCATION = { origin: 'https://www.adobe.com', pathname: '/de/products/test' };
@@ -43,10 +43,6 @@ function removeUserAgentMeta() {
   document.querySelector('meta[name="hreflinksuseragents"]')?.remove();
 }
 
-function removeHeadLoadedMeta() {
-  document.querySelector('meta[name="head-loaded"]')?.remove();
-}
-
 function removeInjectedLinks() {
   document.querySelectorAll('link[rel="alternate"]').forEach((el) => el.remove());
 }
@@ -64,7 +60,6 @@ describe('appendHreflangLinks', () => {
   beforeEach(() => {
     sessionStorage.clear();
     removeUserAgentMeta();
-    removeHeadLoadedMeta();
     removeInjectedLinks();
     fetchStub?.restore();
     if (!document.head.querySelector('title')) {
@@ -75,6 +70,15 @@ describe('appendHreflangLinks', () => {
 
   afterEach(() => {
     restore();
+  });
+
+  it('returns template as-is and logs when sitemapTemplate has no {locale} placeholder', async () => {
+    setUserAgentMeta(window.navigator.userAgent);
+    fetchStub = mockFetch(buildMockXml(MOCK_MAP));
+
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: '/sitemap.xml', sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+
+    expect(fetchStub.calledWith('https://www.adobe.com/sitemap.xml', sinon.match.any)).to.be.true;
   });
 
   it('does nothing when hreflinksuseragents meta is absent', async () => {
@@ -126,6 +130,15 @@ describe('appendHreflangLinks', () => {
   it('handles failed fetch gracefully', async () => {
     setUserAgentMeta(window.navigator.userAgent);
     fetchStub = mockFetch('', false);
+
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+
+    expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(0);
+  });
+
+  it('handles fetch timeout gracefully', async () => {
+    setUserAgentMeta(window.navigator.userAgent);
+    stub(window, 'fetch').rejects(new DOMException('The user aborted a request.', 'AbortError'));
 
     await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
 

--- a/test/features/hreflang/hreflang.test.js
+++ b/test/features/hreflang/hreflang.test.js
@@ -54,6 +54,13 @@ function mockFetch(xmlBody, ok = true) {
   });
 }
 
+const BASE_CONFIG = {
+  locales: LOCALES,
+  sitemapTemplate: SITEMAP_TEMPLATE,
+  sitemapOrigin: SITEMAP_ORIGIN,
+  location: DE_LOCATION,
+};
+
 describe('appendHreflangLinks', () => {
   let fetchStub;
 
@@ -76,21 +83,21 @@ describe('appendHreflangLinks', () => {
     setUserAgentMeta(window.navigator.userAgent);
     fetchStub = mockFetch(buildMockXml(MOCK_MAP));
 
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: '/sitemap.xml', sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    await appendHreflangLinks({ ...BASE_CONFIG, sitemapTemplate: '/sitemap.xml' });
 
     expect(fetchStub.calledWith('https://www.adobe.com/sitemap.xml', sinon.match.any)).to.be.true;
   });
 
   it('does nothing when hreflinksuseragents meta is absent', async () => {
     fetchStub = mockFetch(buildMockXml(MOCK_MAP));
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    await appendHreflangLinks(BASE_CONFIG);
     expect(fetchStub.called).to.be.false;
   });
 
   it('does nothing when user agent is not in allowed list', async () => {
     setUserAgentMeta('SomeOtherBot');
     fetchStub = mockFetch(buildMockXml(MOCK_MAP));
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    await appendHreflangLinks(BASE_CONFIG);
     expect(fetchStub.called).to.be.false;
   });
 
@@ -98,7 +105,7 @@ describe('appendHreflangLinks', () => {
     setUserAgentMeta(window.navigator.userAgent);
     fetchStub = mockFetch(buildMockXml(MOCK_MAP));
 
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    await appendHreflangLinks(BASE_CONFIG);
 
     const links = document.querySelectorAll('link[rel="alternate"]');
     expect(links).to.have.length(2);
@@ -110,9 +117,9 @@ describe('appendHreflangLinks', () => {
     setUserAgentMeta(window.navigator.userAgent);
     fetchStub = mockFetch(buildMockXml(MOCK_MAP));
 
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    await appendHreflangLinks(BASE_CONFIG);
     removeInjectedLinks();
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    await appendHreflangLinks(BASE_CONFIG);
 
     expect(fetchStub.callCount).to.equal(1);
     expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(2);
@@ -122,7 +129,7 @@ describe('appendHreflangLinks', () => {
     setUserAgentMeta(window.navigator.userAgent);
     fetchStub = mockFetch(buildMockXml(MOCK_MAP));
 
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_UNKNOWN_LOCATION });
+    await appendHreflangLinks({ ...BASE_CONFIG, location: DE_UNKNOWN_LOCATION });
 
     expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(0);
   });
@@ -131,7 +138,7 @@ describe('appendHreflangLinks', () => {
     setUserAgentMeta(window.navigator.userAgent);
     fetchStub = mockFetch('', false);
 
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    await appendHreflangLinks(BASE_CONFIG);
 
     expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(0);
   });
@@ -140,7 +147,7 @@ describe('appendHreflangLinks', () => {
     setUserAgentMeta(window.navigator.userAgent);
     stub(window, 'fetch').rejects(new DOMException('The user aborted a request.', 'AbortError'));
 
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    await appendHreflangLinks(BASE_CONFIG);
 
     expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(0);
   });
@@ -150,7 +157,7 @@ describe('appendHreflangLinks', () => {
     fetchStub = mockFetch(buildMockXml(MOCK_MAP));
     stub(sessionStorage, 'setItem').throws(new DOMException('QuotaExceededError'));
 
-    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    await appendHreflangLinks(BASE_CONFIG);
 
     expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(2);
   });

--- a/test/features/hreflang/hreflang.test.js
+++ b/test/features/hreflang/hreflang.test.js
@@ -1,0 +1,144 @@
+import { expect } from '@esm-bundle/chai';
+import { stub, restore } from 'sinon';
+import { appendHreflangLinks } from '../../../libs/features/hreflang/hreflang.js';
+
+const DE_LOCATION = { origin: 'https://www.adobe.com', pathname: '/de/products/test' };
+const DE_UNKNOWN_LOCATION = { origin: 'https://www.adobe.com', pathname: '/de/unknown/page' };
+
+const LOCALES = ['de', 'fr', 'jp'];
+const SITEMAP_TEMPLATE = '/{locale}/assets/sitemap.xml';
+const SITEMAP_ORIGIN = 'https://www.adobe.com';
+
+const MOCK_MAP = {
+  'https://www.adobe.com/de/products/test.html': [
+    { hreflang: 'en', href: 'https://www.adobe.com/products/test.html' },
+    { hreflang: 'fr', href: 'https://www.adobe.com/fr/products/test.html' },
+  ],
+  'https://www.adobe.com/de/': [
+    { hreflang: 'en', href: 'https://www.adobe.com/' },
+  ],
+};
+
+function buildMockXml(map) {
+  const urls = Object.entries(map).map(([loc, links]) => `
+    <url>
+      <loc>${loc}</loc>
+      ${links.map((l) => `<link rel="alternate" hreflang="${l.hreflang}" href="${l.href}"/>`).join('')}
+    </url>
+  `).join('');
+  return `<?xml version="1.0" encoding="UTF-8"?><urlset>${urls}</urlset>`;
+}
+
+function setUserAgentMeta(agents = 'Googlebot') {
+  let meta = document.querySelector('meta[name="hreflinksuseragents"]');
+  if (!meta) {
+    meta = document.createElement('meta');
+    meta.setAttribute('name', 'hreflinksuseragents');
+    document.head.append(meta);
+  }
+  meta.setAttribute('content', agents);
+}
+
+function removeUserAgentMeta() {
+  document.querySelector('meta[name="hreflinksuseragents"]')?.remove();
+}
+
+function removeHeadLoadedMeta() {
+  document.querySelector('meta[name="head-loaded"]')?.remove();
+}
+
+function removeInjectedLinks() {
+  document.querySelectorAll('link[rel="alternate"]').forEach((el) => el.remove());
+}
+
+function mockFetch(xmlBody, ok = true) {
+  return stub(window, 'fetch').resolves({
+    ok,
+    text: () => Promise.resolve(xmlBody),
+  });
+}
+
+describe('appendHreflangLinks', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    removeUserAgentMeta();
+    removeHeadLoadedMeta();
+    removeInjectedLinks();
+    fetchStub?.restore();
+    if (!document.head.querySelector('title')) {
+      const title = document.createElement('title');
+      document.head.append(title);
+    }
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  it('does nothing when hreflinksuseragents meta is absent', async () => {
+    fetchStub = mockFetch(buildMockXml(MOCK_MAP));
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    expect(fetchStub.called).to.be.false;
+  });
+
+  it('does nothing when user agent is not in allowed list', async () => {
+    setUserAgentMeta('SomeOtherBot');
+    fetchStub = mockFetch(buildMockXml(MOCK_MAP));
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    expect(fetchStub.called).to.be.false;
+  });
+
+  it('fetches sitemap and injects hreflang links for matching page', async () => {
+    setUserAgentMeta(window.navigator.userAgent);
+    fetchStub = mockFetch(buildMockXml(MOCK_MAP));
+
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+
+    const links = document.querySelectorAll('link[rel="alternate"]');
+    expect(links).to.have.length(2);
+    expect(links[0].getAttribute('hreflang')).to.equal('en');
+    expect(links[1].getAttribute('hreflang')).to.equal('fr');
+  });
+
+  it('uses sessionStorage cache on second call, skipping fetch', async () => {
+    setUserAgentMeta(window.navigator.userAgent);
+    fetchStub = mockFetch(buildMockXml(MOCK_MAP));
+
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+    removeInjectedLinks();
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+
+    expect(fetchStub.callCount).to.equal(1);
+    expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(2);
+  });
+
+  it('does not inject links when page not found in sitemap', async () => {
+    setUserAgentMeta(window.navigator.userAgent);
+    fetchStub = mockFetch(buildMockXml(MOCK_MAP));
+
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_UNKNOWN_LOCATION });
+
+    expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(0);
+  });
+
+  it('handles failed fetch gracefully', async () => {
+    setUserAgentMeta(window.navigator.userAgent);
+    fetchStub = mockFetch('', false);
+
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+
+    expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(0);
+  });
+
+  it('handles sessionStorage quota exceeded gracefully', async () => {
+    setUserAgentMeta(window.navigator.userAgent);
+    fetchStub = mockFetch(buildMockXml(MOCK_MAP));
+    stub(sessionStorage, 'setItem').throws(new DOMException('QuotaExceededError'));
+
+    await appendHreflangLinks({ locales: LOCALES, sitemapTemplate: SITEMAP_TEMPLATE, sitemapOrigin: SITEMAP_ORIGIN, location: DE_LOCATION });
+
+    expect(document.querySelectorAll('link[rel="alternate"]')).to.have.length(2);
+  });
+});


### PR DESCRIPTION
## Problem

Bots crawling locale pages (e.g. `/de/`) fetch the full sitemap XML on every single page load to extract hreflang alternate links. For large locale sitemaps like CC's `de`, that's **470KB compressed / 15MB uncompressed per page load**. A bot crawling 1k pages downloads 15GB of sitemap data and spends ~23 minutes just on sitemap fetches.

This was flagged in [da-cc PR #18](https://github.com/adobecom/da-cc/pull/18) (MWPW-188278) and tracked for follow-up as [MWPW-191067](https://jira.corp.adobe.com/browse/MWPW-191067).

## Solution

A new shared module `libs/features/hreflang/hreflang.js` that:

1. On the first page a bot visits, fetches and parses the full sitemap
2. Extracts only the URL-to-hreflang mapping (strips all XML markup overhead)
3. Caches the processed map in `sessionStorage`
4. On every subsequent page in that session, skips the fetch entirely and does a direct map lookup

**First page:** 1 fetch, parses once, stores lightweight map
**Every subsequent page:** 0 fetches, instant sessionStorage lookup

## Design decisions

- **Processed map, not raw XML** keeps sessionStorage footprint well within the 5MB browser limit even for large sitemaps
- **Locale-scoped cache keys** so `/de/sitemap.xml` and `/fr/sitemap.xml` get separate entries with no cross-locale collisions
- **Fully configurable** via `sitemapTemplate` and `sitemapOrigin` so this works for bacom, CC, acrobat, and any other property without hardcoding paths
- **`sitemapOrigin` vs `location.origin`** - fetch uses current origin (works in local dev), map lookup uses prod origin (matches `<loc>` values in sitemap)
- **Bot-only** and gated by `meta[name="hreflinksuseragents"]` so regular users are never affected

## Usage

```js
import(`${libs}/features/hreflang/hreflang.js`).then(({ appendHreflangLinks }) => {
  appendHreflangLinks({
    locales: LOCALES,
    sitemapTemplate: '/{locale}/cc-shared/assets/sitemap.xml', // CC
    sitemapOrigin: 'https://www.adobe.com',
  });
}).catch((e) => window.lana?.log(`hreflang: failed to load module - ${e.message}`, { tags: 'hreflang', severity: 'error' }));
```

## Test plan

- [x] 9 unit tests covering: UA gating, sitemap fetch, sessionStorage cache hit, page not found, fetch failure, timeout/abort, quota exceeded, invalid template
- [x] Validated locally on bacom: sitemap fetched once, 11 hreflang links injected after `<title>` on homepage
- [ ] CC to wire up and validate against `/de/cc-shared/assets/sitemap.xml`

