### PR TITLE
New grid definition for C2

### DIFF
--- a/.claude/skills/build-block-from-figma/references/grid-system.md
+++ b/.claude/skills/build-block-from-figma/references/grid-system.md
@@ -34,9 +34,10 @@ Never use `min-width:` / `max-width:` shorthand.
 
 | Class | Behaviour |
 |-------|-----------|
-| `.container` | Standard: max-width **1440 px** content area. |
-| `.container.wide` | HD: max-width **1920 px** content area. |
+| `.container` | max-width **1920 px** content area. Fixed side margins on mobile, percentage based above |
+| `.container.fixed` | max-width **1920 px** content area. Fixed side margins on all viewports |
 | `.container.fluid` | No max-width cap (stretches to **2560 px** max). |
+
 
 Blocks should respect whichever container they are placed inside.
 Do not hardcode max-width on a block unless explicitly required by

--- a/libs/c2/blocks/global-footer/global-footer.css
+++ b/libs/c2/blocks/global-footer/global-footer.css
@@ -28,7 +28,7 @@
   display: flex;
   flex-direction: column;
   color: var(--s2a-color-gray-25);
-  max-width: var(--grid-max-width-wide);
+  max-width: var(--grid-max-width-default);
   position: relative;
   z-index: 1;
   background-color: var(--s2a-color-gray-1000);
@@ -233,7 +233,7 @@
 
 .global-footer .feds-footer-logo {
   line-height: 0;
-  max-width: var(--grid-max-width-wide);
+  max-width: var(--grid-max-width-default);
   margin: 0 auto;
   overflow: hidden;
   display: flex;
@@ -565,7 +565,7 @@ span.feds-footer-privacyLink-divider {
   .global-footer {
     padding-top: var(--s2a-layout-xl);
   }
-  
+
   .global-footer:not(.mobile) .feds-footer-options {
     display: grid;
     grid-template-areas: "region legal social";

--- a/libs/c2/blocks/global-footer/global-footer.js
+++ b/libs/c2/blocks/global-footer/global-footer.js
@@ -670,7 +670,7 @@ class Footer {
   };
 
   decorateFooter = () => {
-    this.elements.footer = toFragment`<div class="feds-footer-wrapper container wide">
+    this.elements.footer = toFragment`<div class="feds-footer-wrapper container">
     ${this.elements.footerMenu}
     ${this.elements.featuredProducts}
     <div class="feds-footer-options caption">
@@ -679,7 +679,7 @@ class Footer {
         ${this.elements.legal}
         ${this.decorateLogo()}
       </div>
-      ${this.elements.social}   
+      ${this.elements.social}
       </div>
     </div>`;
     const footerLogo = toFragment`<div class="feds-footer-logo">

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -14,7 +14,7 @@
 @property --grid-max-width {
   syntax: '<length>';
   inherits: true;
-  initial-value: 1440px;
+  initial-value: 1920px;
 }
 
 :root {
@@ -407,11 +407,11 @@
 
   /* Grid sizes */
   --grid-columns: 6;
-  --grid-margin-width-base: 24px;
+  --grid-margin-width-base: var(--s2a-spacing-24);
+  --grid-margin-width-fixed: var(--s2a-spacing-24);
   --grid-margin-width: var(--grid-margin-width-base);
   --grid-margin-width-target: var(--grid-margin-width-base);
-  --grid-max-width-default: 1440px;
-  --grid-max-width-wide: 1920px;
+  --grid-max-width-default: 1920px;
   --grid-max-width-fluid: 2560px;
 
   /* Regional font variations */
@@ -726,14 +726,14 @@ p {
   max-width: none;
   padding-inline: var(--grid-padding);
 
-  &.wide {
-    --grid-max-width: var(--grid-max-width-wide);
-    --grid-max-width-target: var(--grid-max-width-wide);
-  }
-
   &.fluid {
     --grid-max-width: var(--grid-max-width-fluid);
     --grid-margin-width: 0px; /* Keep unit for calc */
+  }
+
+  &.fixed {
+    --grid-margin-width: var(--grid-margin-width-fixed);
+    --grid-margin-width-target: var(--grid-margin-width-fixed);
   }
 
   .container {


### PR DESCRIPTION
The grid system for C2 is being adapted to support Wave 2 use-cases for the Site Redesign initiative. The default is now the `1920px` version. The `1440px` one has been removed entirely; references to it from the Global 

Resolves: [MWPW-194970](https://jira.corp.adobe.com/browse/MWPW-194970)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.live/upp-shared/fragments/tests/2026/q2/ace1201/sr-homepage?milolibs=site-redesign-foundation
- After: https://main--upp--adobecom.aem.live/upp-shared/fragments/tests/2026/q2/ace1201/sr-homepage?milolibs=c2-new-grid


