### PR TITLE
[MWPW-184676]:-  support mobile-rider embed in Marquee block for DA Events

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -149,7 +149,7 @@ const AUTO_BLOCKS = [
   { 'merch-card-autoblock': 'mas.adobe.com/studio.html', styles: false },
   { m7: '/creativecloud/business-plans', styles: false },
   { m7: '/creativecloud/education-plans', styles: false },
-  {'mobile-rider': 'mobilerider.com'},
+  { 'mobile-rider': 'mobilerider.com' },
 ];
 const DO_NOT_INLINE = [
   'accordion',

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -149,6 +149,7 @@ const AUTO_BLOCKS = [
   { 'merch-card-autoblock': 'mas.adobe.com/studio.html', styles: false },
   { m7: '/creativecloud/business-plans', styles: false },
   { m7: '/creativecloud/education-plans', styles: false },
+  {'mobile-rider': 'mobile-rider.com'},
 ];
 const DO_NOT_INLINE = [
   'accordion',

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -149,7 +149,7 @@ const AUTO_BLOCKS = [
   { 'merch-card-autoblock': 'mas.adobe.com/studio.html', styles: false },
   { m7: '/creativecloud/business-plans', styles: false },
   { m7: '/creativecloud/education-plans', styles: false },
-  {'mobile-rider': 'mobile-rider.com'},
+  {'mobile-rider': 'mobilerider.com'},
 ];
 const DO_NOT_INLINE = [
   'accordion',


### PR DESCRIPTION
Context: Adobe Events (e.g., Adobe MAX) are being migrated to Document Authoring (DA). The da-events repo already has a mobile-rider block that renders live streams powered by MobileRider.

The need: Event pages use the Marquee block as the hero area. For the live stream to appear there, the Marquee block in Milo needs to support a MobileRider embed in its asset area — so authors can simply place a MobileRider link inside the Marquee block in DA and have the live stream render correctly.

Resolves: [MWPW-184676] https://jira.corp.adobe.com/browse/MWPW-184676

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-184676-mobile-rider--milo--adobecom.aem.page/?martech=off

Event Author Page:-  https://da.live/edit#/adobecom/da-events/drafts/hnv/mobile-rider-marquee-impl
Event Preview Page:- https://main--da-events--adobecom.aem.page/drafts/hnv/mobile-rider-marquee-impl?milolibs=mwpw-184676-mobile-rider




