### PR TITLE
[MWPW-189253]: Fixed section metadata mobile gap issue occurs

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -198,6 +198,7 @@
   padding-right: var(--grid-margins-width);
   display: grid;
   gap: var(--spacing-m);
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .section[class*='grid-width-'] > .content,
@@ -272,10 +273,6 @@ main > .section[class*='-up'] > .content {
 
   .section.two-up.reverse-mobile > div:nth-child(2) {
     order: 1;
-  }
-
-  .section[class*='grid-width-'] {
-    display: block;
   }
 
   .section:has(> .show-more-button),


### PR DESCRIPTION
- Resolved grid spacing issue in section-metadata.

Resolves: [MWPW-189253](https://jira.corp.adobe.com/browse/MWPW-189253)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/klee/jira-ticket/mwpw-189253-ups-gap-removed-10-col?martech=off
- After: https://mwpw-189253-section-metadata--milo--hkuraware.aem.page/drafts/klee/jira-ticket/mwpw-189253-ups-gap-removed-10-col?martech=off

**Dev validation:**

Before:-
<img width="1067" height="827" alt="before-fix" src="https://github.com/user-attachments/assets/dddf77d4-d233-4abd-8c9f-0320aadc46e0" />

After:- 
<img width="1067" height="827" alt="after-fix" src="https://github.com/user-attachments/assets/b85a0c77-e73e-4978-a255-4630d05f0013" />