### PR TITLE
MWPW-195071: adjusted cc and dc mapping to be accounted for in lingo

### DIFF
--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -198,11 +198,7 @@ export const getOrigin = (fgColor) => {
   const { project, repo } = getConfig();
   const origin = project || processRepoForFloodgate(repo, fgColor);
 
-  const mappings = {
-    cc: 'hawks',
-    dc: 'doccloud',
-  };
-  const originLC = mappings[origin.toLowerCase()] || origin;
+  const originLC = LANG_FIRST_SOURCE_MAPPINGS[origin.toLowerCase()] || origin;
   if (originLC) {
     return originLC;
   }
@@ -346,7 +342,7 @@ const getBulkPublishLangAttr = async (options) => {
   if (options.languageFirst) {
     const mappedGetLangFirst = (path, repo, fqdn) => getLanguageFirstCountryAndLang(
       path,
-      LANG_FIRST_SOURCE_MAPPINGS[repo] || repo,
+      LANG_FIRST_SOURCE_MAPPINGS[repo.toLowerCase()] || repo,
       fqdn,
     );
     return runLanguageFirstRetry(options, mappedGetLangFirst);
@@ -368,7 +364,7 @@ const getCountryAndLang = async (options, origin) => {
     const fqdn = isBulkPublisher ? 'bulkpublisher' : window.location.hostname;
     return getLanguageFirstCountryAndLang(
       window.location.pathname,
-      LANG_FIRST_SOURCE_MAPPINGS[origin] || origin,
+      LANG_FIRST_SOURCE_MAPPINGS[origin.toLowercase()] || origin,
       fqdn,
     );
   }

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -13,6 +13,8 @@ const URL_POSTXDM = 'https://14257-milocaasproxy.adobeio-static.net/api/v1/web/m
 const VALID_URL_RE = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
 const VALID_MODAL_RE = /fragments(.*)#[a-zA-Z0-9_-]+$/;
 
+const LANG_FIRST_SOURCE_MAPPINGS = { cc: 'hawks', dc: 'doccloud' };
+
 const isKeyValPair = /(\s*\S+\s*:\s*\S+\s*)/;
 const isValidUrl = (u) => VALID_URL_RE.test(u);
 const isValidModal = (u) => VALID_MODAL_RE.test(u);
@@ -342,7 +344,12 @@ export async function runLanguageFirstRetry(options, getLangFirst, retryOpts = {
 const getBulkPublishLangAttr = async (options) => {
   let { getLocale } = getConfig();
   if (options.languageFirst) {
-    return runLanguageFirstRetry(options, getLanguageFirstCountryAndLang);
+    const mappedGetLangFirst = (path, repo, fqdn) => getLanguageFirstCountryAndLang(
+      path,
+      LANG_FIRST_SOURCE_MAPPINGS[repo] || repo,
+      fqdn,
+    );
+    return runLanguageFirstRetry(options, mappedGetLangFirst);
   }
   if (!getLocale) {
     // This is only imported from the bulk publisher so there is no dependency cycle
@@ -359,7 +366,11 @@ const getCountryAndLang = async (options, origin) => {
   if (langFirst) {
     const isBulkPublisher = window.location.pathname.includes('/tools/send-to-caas/bulkpublisher');
     const fqdn = isBulkPublisher ? 'bulkpublisher' : window.location.hostname;
-    return getLanguageFirstCountryAndLang(window.location.pathname, origin, fqdn);
+    return getLanguageFirstCountryAndLang(
+      window.location.pathname,
+      LANG_FIRST_SOURCE_MAPPINGS[origin] || origin,
+      fqdn,
+    );
   }
   /* c8 ignore next */
   const langStr = window.location.pathname.includes('/tools/send-to-caas/bulkpublisher')

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -364,7 +364,7 @@ const getCountryAndLang = async (options, origin) => {
     const fqdn = isBulkPublisher ? 'bulkpublisher' : window.location.hostname;
     return getLanguageFirstCountryAndLang(
       window.location.pathname,
-      LANG_FIRST_SOURCE_MAPPINGS[origin.toLowercase()] || origin,
+      LANG_FIRST_SOURCE_MAPPINGS[origin.toLowerCase()] || origin,
       fqdn,
     );
   }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
When you send dc or cc through the bulkpublisher, it converts the origin to "doccloud" or "hawks" respectively.  This mapping needs to be done ahead of Lingo Lookups generally to avoid potential content issues in bulk published lingo content to these two origins.

Resolves: [MWPW-195071](https://jira.corp.adobe.com/browse/MWPW-195071)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-195071--milo--sheridansunier.aem.page/?martech=off
 

Testing:

- using source overrides, send a sample page to stage through the bulkpublisher
 <img width="337" height="864" alt="Screenshot 2026-05-13 at 4 20 54 PM" src="https://github.com/user-attachments/assets/f0270c30-056c-4ac7-9cee-53a294b832e5" />

- verify that if you send [this page](https://www.adobe.com/fr/acrobat/roc/business/reports/unlock-value-genai-document-mgmt-functional-leader) without the language first tag, you get "fr" and "fr" for country/language respectively
- verify that we receive "xx" and "fr" for a page like this being sent to stage w language first.

Please leave that page sent w language first on stage to keep it in the state it was before you started doing your testing.




