### PR TITLE
[LOC UI] MWPW-195240 - Loc projects picking config stage in prod

### DIFF
--- a/libs/blocks/locui/utils/state.js
+++ b/libs/blocks/locui/utils/state.js
@@ -1,12 +1,6 @@
 import { signal } from '../../../deps/htm-preact.js';
-import { getConfig } from '../../../utils/utils.js';
 import { setStatus } from './status.js';
 import { origin } from './franklin.js';
-
-function getLocConfigPath() {
-  const { env } = getConfig();
-  return env?.name === 'prod' ? '/.milo/config.json' : '/.milo/config-stage.json';
-}
 
 export const telemetry = { application: { appName: 'Adobe Localization' } };
 
@@ -31,6 +25,13 @@ export const canRefresh = signal(false);
 export const serviceStatus = signal('');
 export const serviceStatusDate = signal();
 export const isLOCV3RolloutFlow = signal(false);
+
+function getLocConfigPath() {
+  if (!heading.value.name) {
+    return '/.milo/config.json';
+  }
+  return heading.value.env === 'prod' ? '/.milo/config.json' : '/.milo/config-stage.json';
+}
 
 export function getSiteConfig() {
   setStatus('siteConfig', 'info', 'Getting site settings.');

--- a/libs/blocks/locui/utils/state.js
+++ b/libs/blocks/locui/utils/state.js
@@ -26,11 +26,14 @@ export const serviceStatus = signal('');
 export const serviceStatusDate = signal();
 export const isLOCV3RolloutFlow = signal(false);
 
+const LOC_CONFIG_PATH = '/.milo/config.json';
+const LOC_CONFIG_STAGE_PATH = '/.milo/config-stage.json';
+
 function getLocConfigPath() {
   if (!heading.value.name) {
-    return '/.milo/config.json';
+    return LOC_CONFIG_PATH;
   }
-  return heading.value.env === 'prod' ? '/.milo/config.json' : '/.milo/config-stage.json';
+  return heading.value.env === 'prod' ? LOC_CONFIG_PATH : LOC_CONFIG_STAGE_PATH;
 }
 
 export function getSiteConfig() {
@@ -44,8 +47,8 @@ export function getSiteConfig() {
     }
     const primaryPath = getLocConfigPath();
     let resp = await fetch(`${origin}${primaryPath}`);
-    if (!resp.ok && primaryPath !== '/.milo/config.json') {
-      resp = await fetch(`${origin}/.milo/config.json`);
+    if (!resp.ok && primaryPath !== LOC_CONFIG_PATH) {
+      resp = await fetch(`${origin}${LOC_CONFIG_PATH}`);
     }
     if (!resp.ok) {
       setStatus('siteConfig', 'error', 'Error getting site settings.');


### PR DESCRIPTION
Utilize the project-defined 'env' variable rather than a generic value; since all loc projects run within aem.page (whcih is always 'stage')

Resolves: [MWPW-195240](https://jira.corp.adobe.com/browse/MWPW-195240)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://main--milo--adobecom.aem.page/?martech=off


