### PR TITLE
[MWPW-185881] Use default standalone locales from federal instead of milo

### DIFF
--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -23,6 +23,33 @@ const envMap = {
   qa: 'https://gnav--milo--adobecom.aem.page',
 };
 
+/**
+ * Origin for federal content (locales, etc.) in standalone gnav.
+ * Matches adobe.com / federal, not Milo libs.
+ */
+function getStandaloneNavOrigin(env) {
+  switch (env) {
+    case 'prod': return 'https://www.adobe.com';
+    case 'stage': return 'https://www.stage.adobe.com';
+    default: return 'https://main--federal--adobecom.aem.page';
+  }
+}
+
+/**
+ * Load locale map from the federal project (same source as adobe.com consumers).
+ * Dynamic import avoids bundling federal URLs.
+ */
+async function loadFederalLocales(env) {
+  const origin = getStandaloneNavOrigin(env);
+  const url = `${origin}/federal/utils/locales.js`;
+  const mod = await import(url);
+  return mod.default;
+}
+
+async function resolveLocales(env, localesOverride) {
+  return localesOverride ?? loadFederalLocales(env);
+}
+
 const getStageDomainsMap = (stageDomainsMap, env) => {
   const defaultUrls = {
     'www.adobe.com': 'origin',
@@ -117,23 +144,17 @@ export default async function loadBlock(configs, customLib) {
     loadStyle(`${miloLibs}/libs/navigation/navigation.css`);
   }
 
-  // Relative paths work just fine since they exist in the context of this file's origin
+  const origin = getStandaloneNavOrigin(env);
   const [
     { default: bootstrapBlock },
-    { default: locales },
-    { setConfig, getConfig, createTag }] = await Promise.all([
+    locales,
+    { setConfig, getConfig, createTag },
+  ] = await Promise.all([
     import('./bootstrapper.js'),
-    import('../utils/locales.js'),
+    resolveLocales(env, configs?.locales),
     import('../utils/utils.js'),
   ]);
   const paramConfigs = getParamsConfigs(configs);
-  const origin = (() => {
-    switch (env) {
-      case 'prod': return 'https://www.adobe.com';
-      case 'stage': return 'https://www.stage.adobe.com';
-      default: return 'https://main--federal--adobecom.aem.page';
-    }
-  })();
   const clientConfig = {
     theme,
     prodDomains,
@@ -141,7 +162,7 @@ export default async function loadBlock(configs, customLib) {
     standaloneGnav: true,
     pathname: `/${locale}`,
     miloLibs: `${miloLibs}/libs`,
-    locales: configs.locales || locales,
+    locales,
     contentRoot: authoringPath || footer?.authoringPath,
     stageDomainsMap: getStageDomainsMap(stageDomainsMap, env),
     origin,

--- a/test/navigation/navigation.test.js
+++ b/test/navigation/navigation.test.js
@@ -3,11 +3,14 @@ import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { stub, restore } from 'sinon';
 import loadBlock from '../../libs/navigation/navigation.js';
+import miloLocales from '../../libs/utils/locales.js';
 import { setConfig } from '../../libs/utils/utils.js';
 import { mockRes } from '../blocks/global-navigation/test-utilities.js';
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 const miloLibs = 'http://localhost:2000/libs';
+
+const withTestLocales = (config) => ({ ...config, locales: miloLocales });
 
 describe('Navigation component', async () => {
   beforeEach(async () => {
@@ -27,20 +30,20 @@ describe('Navigation component', async () => {
   });
 
   it('Renders the footer block', async () => {
-    await loadBlock({ authoringPath: '/federal/dev', footer: { privacyId: '12343', onReady: 'dede' }, env: 'qa' }, 'http://localhost:2000');
+    await loadBlock(withTestLocales({ authoringPath: '/federal/dev', footer: { privacyId: '12343', onReady: 'dede' }, env: 'qa' }), 'http://localhost:2000');
     const el = document.getElementsByTagName('footer');
     expect(el).to.exist;
   });
 
   it('Renders the localnav if isLocalNav key is passed', async () => {
-    await loadBlock({ authoringPath: '/federal/localnav', header: { imsClientId: 'fedsmilo', mobileGnavV2: 'on', isLocalNav: true, jarvis: { id: '1.2' } }, env: 'stage', theme: 'dark' }, 'http://localhost:2000');
+    await loadBlock(withTestLocales({ authoringPath: '/federal/localnav', header: { imsClientId: 'fedsmilo', mobileGnavV2: 'on', isLocalNav: true, jarvis: { id: '1.2' } }, env: 'stage', theme: 'dark' }), 'http://localhost:2000');
     const el = document.querySelector('.feds-localnav');
     expect(el).to.exist;
   });
 
   it('Renders the header block', async () => {
     const onReady = stub();
-    await loadBlock({ authoringPath: '/federal/dev', header: { imsClientId: 'fedsmilo', onReady, layout: 'fullWidth', noBorder: 'true' }, env: 'prod', theme: 'dark' }, 'http://localhost:2000');
+    await loadBlock(withTestLocales({ authoringPath: '/federal/dev', header: { imsClientId: 'fedsmilo', onReady, layout: 'fullWidth', noBorder: 'true' }, env: 'prod', theme: 'dark' }), 'http://localhost:2000');
     const el = document.getElementsByTagName('header');
     expect(el).to.exist;
     expect(onReady.called).to.be.true;
@@ -48,7 +51,7 @@ describe('Navigation component', async () => {
 
   it('Renders the mini GNAV', async () => {
     const onReady = stub();
-    await loadBlock({
+    await loadBlock(withTestLocales({
       authoringPath: '/federal/dev',
       header: {
         imsClientId: 'fedsmilo',
@@ -60,7 +63,7 @@ describe('Navigation component', async () => {
       },
       env: 'prod',
       theme: 'dark',
-    }, 'http://localhost:2000');
+    }), 'http://localhost:2000');
     const isMiniGnav = !!document.querySelector('.mini-gnav');
     console.log(isMiniGnav);
     expect(isMiniGnav).to.be.true;
@@ -69,7 +72,7 @@ describe('Navigation component', async () => {
 
   it('Renders the mini GNAV and desktop apps cta placeholder', async () => {
     const onReady = stub();
-    await loadBlock({
+    await loadBlock(withTestLocales({
       authoringPath: '/federal/dev',
       header: {
         imsClientId: 'fedsmilo',
@@ -80,7 +83,7 @@ describe('Navigation component', async () => {
       },
       env: 'prod',
       theme: 'dark',
-    }, 'http://localhost:2000');
+    }), 'http://localhost:2000');
     const isMiniGnav = document.querySelector('.mini-gnav');
     const isDesktopAppsCta = document.querySelector('.feds-client-desktop-apps');
     expect(isMiniGnav).to.exist;
@@ -90,7 +93,7 @@ describe('Navigation component', async () => {
 
   it('Renders mini GNAV and search placeholder before (.feds-nav-wrapper)', async () => {
     const onReady = stub();
-    await loadBlock({
+    await loadBlock(withTestLocales({
       authoringPath: '/federal/dev',
       header: {
         imsClientId: 'fedsmilo',
@@ -102,7 +105,7 @@ describe('Navigation component', async () => {
       },
       env: 'prod',
       theme: 'dark',
-    }, 'http://localhost:2000');
+    }), 'http://localhost:2000');
     const isMiniGnav = document.querySelector('.mini-gnav');
     const searchPlaceholder = document.querySelector('.feds-client-search');
     expect(isMiniGnav).to.exist;
@@ -113,7 +116,7 @@ describe('Navigation component', async () => {
 
   it('Should not render the footer block when config is not passed', async () => {
     try {
-      await loadBlock({ env: 'qa', authoringPath: '/federal/dev', footer: {} }, 'http://localhost:2000');
+      await loadBlock(withTestLocales({ env: 'qa', authoringPath: '/federal/dev', footer: {} }), 'http://localhost:2000');
       const el = document.getElementsByTagName('footer');
       expect(el).to.not.exist;
     } catch (e) {
@@ -123,7 +126,7 @@ describe('Navigation component', async () => {
 
   it('Should not render the header block when config is not passed', async () => {
     try {
-      await loadBlock({ env: 'qa', footer: { privacyId: '12343' } }, 'http://localhost:2000');
+      await loadBlock(withTestLocales({ env: 'qa', footer: { privacyId: '12343' } }), 'http://localhost:2000');
       const el = document.getElementsByTagName('header');
       expect(el).to.not.exist;
     } catch (e) {
@@ -133,7 +136,7 @@ describe('Navigation component', async () => {
 
   it('Does not render either header or footer if not found in configs', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/body.html' });
-    await loadBlock({ authoringPath: '/federal/dev', env: 'qa' }, 'http://localhost:2000');
+    await loadBlock(withTestLocales({ authoringPath: '/federal/dev', env: 'qa' }), 'http://localhost:2000');
     const header = document.getElementsByTagName('header');
     const footer = document.getElementsByTagName('footer');
     expect(header).to.be.empty;
@@ -141,7 +144,7 @@ describe('Navigation component', async () => {
   });
 
   it('Renders the footer block with authoringpath passed in footer', async () => {
-    await loadBlock({ footer: { privacyId: '12343', authoringPath: '/federal/dev' }, env: 'qa' }, 'http://localhost:2000');
+    await loadBlock(withTestLocales({ footer: { privacyId: '12343', authoringPath: '/federal/dev' }, env: 'qa' }), 'http://localhost:2000');
     const el = document.getElementsByTagName('footer');
     expect(el).to.exist;
   });


### PR DESCRIPTION
Use default locales from federal instead of Milo when clients specific locales are not used

Resolves: [MWPW-185881](https://jira.corp.adobe.com/browse/MWPW-185881)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://standalone-default-locales--milo--adobecom.aem.page/?martech=off

QA:

https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=standalone-default-locales&authoringpath=/federal/learn&locale=fr

https://adobecom.github.io/nav-consumer/navigation.html?env=stage&navbranch=standalone-default-locales&authoringpath=/federal/home&locale=de

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=standalone-default-locales--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=standalone-default-locales--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=standalone-default-locales--milo--adobecom
- Milo: https://standalone-default-locales--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=standalone-default-locales--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=standalone-default-locales--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=standalone-default-locales--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=standalone-default-locales--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=standalone-default-locales--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=standalone-default-locales--milo--adobecom
- Milo: https://standalone-default-locales--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=standalone-default-locales--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=standalone-default-locales--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=standalone-default-locales--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=standalone-default-locales--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=standalone-default-locales--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=standalone-default-locales--milo--adobecom
- Milo: https://standalone-default-locales--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=standalone-default-locales--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=standalone-default-locales--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=standalone-default-locales--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=standalone-default-locales--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=standalone-default-locales--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=standalone-default-locales--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=standalone-default-locales--milo--adobecom
</details>