### PR TITLE
feat(article-feed): sort articles newest-first on da-blog

### DIFF
--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -4,7 +4,7 @@ import {
   loadTaxonomy,
   getArticleTaxonomy,
   buildArticleCard,
-  getArticleDate,
+  calculateExcelDate,
 } from './article-helpers.js';
 
 import { createTag, getConfig, createIntersectionObserver } from '../../utils/utils.js';
@@ -596,14 +596,12 @@ async function decorateArticleFeed(
   articleCards.append(container);
 
   const pageEnd = offset + limit;
-  const { hostname } = window.location;
-  const isDaBlog = hostname === 'blog.adobe.com' || hostname.includes('da-blog') || hostname === 'localhost';
-  if (offset === 0 && isDaBlog) {
+  if (offset === 0) {
     while (!blogIndex.complete) {
       // eslint-disable-next-line no-await-in-loop
       await fetchBlogArticleIndex();
     }
-    blogIndex.data.sort((a, b) => getArticleDate(b) - getArticleDate(a));
+    blogIndex.data.sort((a, b) => calculateExcelDate(Number(b.date)).getTime() - calculateExcelDate(Number(a.date)).getTime());
   }
   await filterArticles(feed, limit, offset);
   const articles = feed.data;

--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -596,8 +596,14 @@ async function decorateArticleFeed(
   articleCards.append(container);
 
   const pageEnd = offset + limit;
+  if (offset === 0) {
+    while (!blogIndex.complete) {
+      // eslint-disable-next-line no-await-in-loop
+      await fetchBlogArticleIndex();
+    }
+    blogIndex.data.sort((a, b) => getArticleDate(b) - getArticleDate(a));
+  }
   await filterArticles(feed, limit, offset);
-  if (offset === 0) feed.data.sort((a, b) => getArticleDate(b) - getArticleDate(a));
   const articles = feed.data;
 
   if (articles.length) {

--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -4,6 +4,7 @@ import {
   loadTaxonomy,
   getArticleTaxonomy,
   buildArticleCard,
+  getArticleDate,
 } from './article-helpers.js';
 
 import { createTag, getConfig, createIntersectionObserver } from '../../utils/utils.js';
@@ -596,6 +597,7 @@ async function decorateArticleFeed(
 
   const pageEnd = offset + limit;
   await filterArticles(feed, limit, offset);
+  if (offset === 0) feed.data.sort((a, b) => getArticleDate(b) - getArticleDate(a));
   const articles = feed.data;
 
   if (articles.length) {

--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -4,7 +4,6 @@ import {
   loadTaxonomy,
   getArticleTaxonomy,
   buildArticleCard,
-  getArticleDate,
   calculateExcelDate,
 } from './article-helpers.js';
 

--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -596,7 +596,9 @@ async function decorateArticleFeed(
   articleCards.append(container);
 
   const pageEnd = offset + limit;
-  if (offset === 0) {
+  const { hostname } = window.location;
+  const isDaBlog = hostname === 'blog.adobe.com' || hostname.includes('da-blog') || hostname === 'localhost';
+  if (offset === 0 && isDaBlog) {
     while (!blogIndex.complete) {
       // eslint-disable-next-line no-await-in-loop
       await fetchBlogArticleIndex();

--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -600,7 +600,9 @@ async function decorateArticleFeed(
     // eslint-disable-next-line no-await-in-loop
     await fetchBlogArticleIndex();
   }
-  blogIndex.data.sort((a, b) => calculateExcelDate(Number(b.date)).getTime() - calculateExcelDate(Number(a.date)).getTime());
+  blogIndex.data.sort((a, b) => (
+    calculateExcelDate(Number(b.date)).getTime() - calculateExcelDate(Number(a.date)).getTime()
+  ));
   await filterArticles(feed, limit, offset);
   const articles = feed.data;
 

--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -4,6 +4,7 @@ import {
   loadTaxonomy,
   getArticleTaxonomy,
   buildArticleCard,
+  getArticleDate,
   calculateExcelDate,
 } from './article-helpers.js';
 
@@ -596,13 +597,11 @@ async function decorateArticleFeed(
   articleCards.append(container);
 
   const pageEnd = offset + limit;
-  if (offset === 0) {
-    while (!blogIndex.complete) {
-      // eslint-disable-next-line no-await-in-loop
-      await fetchBlogArticleIndex();
-    }
-    blogIndex.data.sort((a, b) => calculateExcelDate(Number(b.date)).getTime() - calculateExcelDate(Number(a.date)).getTime());
+  while (!blogIndex.complete) {
+    // eslint-disable-next-line no-await-in-loop
+    await fetchBlogArticleIndex();
   }
+  blogIndex.data.sort((a, b) => calculateExcelDate(Number(b.date)).getTime() - calculateExcelDate(Number(a.date)).getTime());
   await filterArticles(feed, limit, offset);
   const articles = feed.data;
 

--- a/libs/blocks/article-feed/article-helpers.js
+++ b/libs/blocks/article-feed/article-helpers.js
@@ -20,7 +20,7 @@ let taxonomyModule;
  * @param {number} date The date to format
  * @returns {string} The formatted date
  */
-function calculateExcelDate(date) {
+export function calculateExcelDate(date) {
   return new Date(Math.round((date - (1 + 25567 + 1)) * 86400 * 1000));
 }
 

--- a/libs/blocks/article-feed/article-helpers.js
+++ b/libs/blocks/article-feed/article-helpers.js
@@ -177,19 +177,6 @@ export async function loadTaxonomy() {
 }
 
 /**
- * Returns a comparable timestamp for an article's date field.
- * Handles Excel serial numbers, ISO strings, and missing values.
- * @param {Object} article
- * @returns {number}
- */
-export function getArticleDate(article) {
-  const { date } = article;
-  if (!date || date === '0') return 0;
-  if (!date.toString().includes('-')) return calculateExcelDate(Number(date)).getTime();
-  return new Date(date.replace(/-/g, '/')).getTime();
-}
-
-/**
  * Format date to locale.
  *
  * @param {number} date The date to format

--- a/libs/blocks/article-feed/article-helpers.js
+++ b/libs/blocks/article-feed/article-helpers.js
@@ -177,6 +177,19 @@ export async function loadTaxonomy() {
 }
 
 /**
+ * Returns a comparable timestamp for an article's date field.
+ * Handles Excel serial numbers, ISO strings, and missing values.
+ * @param {Object} article
+ * @returns {number}
+ */
+export function getArticleDate(article) {
+  const { date } = article;
+  if (!date || date === '0') return 0;
+  if (!date.toString().includes('-')) return calculateExcelDate(Number(date)).getTime();
+  return new Date(date.replace(/-/g, '/')).getTime();
+}
+
+/**
  * Format date to locale.
  *
  * @param {number} date The date to format


### PR DESCRIPTION
## Summary
- Fetch full query-index before rendering article cards
- Sort `blogIndex.data` newest-first using `calculateExcelDate`
- Export `calculateExcelDate` from `article-helpers.js` for use in sort
- Remove unused `getArticleDate`
Jira : https://jira.corp.adobe.com/browse/MWPW-195245 

## Test plan
- [ ] Visit `https://silviulcf--da-blog--adobecom.aem.live/de/topics/creativity?milolibs=blog-sort-newest` and verify articles are newest-first
- [ ] Verify "load more" continues in correct order
- [ ] Verify no regression on `https://main--bacom-blog--adobecom.aem.live/` (uses CaaS, not article-feed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



