### PR TITLE
[NALA] Add floating-anchor-delay test (tcid 13)

### DIFF
--- a/nala/blocks/brand-concierge/brand-concierge.spec.js
+++ b/nala/blocks/brand-concierge/brand-concierge.spec.js
@@ -141,5 +141,21 @@ module.exports = {
       tags: '@brand-concierge @brand-concierge-consent @regression @milo',
       data: {},
     },
+    {
+      // MWPW-194524 (PR #5940) - floating-anchor-delay<N> variant.
+      // Hides the floating button when the page scroll is within N pixels of
+      // the footer. Combined with floating-delay<M> to also hide near the top.
+      tcid: '13',
+      name: '@brand-concierge floating anchor delay',
+      path: '/drafts/nala/blocks/brand-concierge/bc-floating-anchor-delay',
+      tags: '@brand-concierge @brand-concierge-anchor-delay @regression @milo',
+      data: {
+        floatingButtonText: 'Ask a question',
+        topDelayClass: 'floating-delay-100',
+        anchorDelayClass: 'floating-anchor-delay-450',
+        topDelayPx: 100,
+        anchorDelayPx: 450,
+      },
+    },
   ],
 };

--- a/nala/blocks/brand-concierge/brand-concierge.test.js
+++ b/nala/blocks/brand-concierge/brand-concierge.test.js
@@ -535,4 +535,61 @@ test.describe('Milo Brand Concierge Block test suite', () => {
       });
     },
   );
+
+  // Test 13: floating-anchor-delay<N> variant (PR #5940 / MWPW-194524).
+  // Combined with floating-delay<M>, the floating button:
+  //   - is hidden near the top of the page (scrollY < topDelayPx)
+  //   - is visible in the middle of the page
+  //   - is hidden again when within anchorDelayPx of the page footer
+  // Tagged @bc-pending until the test fragment is authored.
+  test(
+    `[Test Id - ${features[13].tcid}] ${features[13].name},${features[13].tags}`,
+    async ({ page, baseURL }) => {
+      console.info(`[Test Page]: ${baseURL}${features[13].path}${miloLibs}`);
+      const { data } = features[13];
+
+      await test.step('step-1: Go to Brand Concierge floating-anchor-delay page', async () => {
+        await page.goto(`${baseURL}${features[13].path}${miloLibs}`);
+        await page.waitForLoadState('domcontentloaded');
+        await expect(page).toHaveURL(`${baseURL}${features[13].path}${miloLibs}`);
+      });
+
+      await test.step('step-2: Verify block carries both delay classes', async () => {
+        await expect(bc.block).toBeVisible();
+        await expect(bc.block).toHaveClass(new RegExp(data.topDelayClass));
+        await expect(bc.block).toHaveClass(new RegExp(data.anchorDelayClass));
+      });
+
+      await test.step('step-3: Floating button is hidden near top of page', async () => {
+        await expect(bc.floatingButton).toBeAttached({ timeout: 10000 });
+        // Top delay (e.g. 100px) means the button stays hidden until scroll
+        // passes that threshold.
+        await expect(bc.floatingButton).toHaveClass(/floating-hidden/);
+      });
+
+      await test.step('step-4: Floating button is visible in the middle of the page', async () => {
+        await page.evaluate(() => {
+          // Scroll well past topDelay but well before the footer.
+          window.scrollTo(0, Math.floor(document.body.scrollHeight / 2));
+          window.dispatchEvent(new Event('scroll'));
+        });
+        await page.waitForTimeout(1000);
+        await expect(bc.floatingButton).not.toHaveClass(/floating-hidden/, { timeout: 10000 });
+      });
+
+      await test.step('step-5: Floating button is hidden again near the footer', async () => {
+        await page.evaluate(() => {
+          // Scroll to within anchor-delay distance of the footer.
+          window.scrollTo(0, document.body.scrollHeight);
+          window.dispatchEvent(new Event('scroll'));
+        });
+        await page.waitForTimeout(1000);
+        await expect(bc.floatingButton).toHaveClass(/floating-hidden/, { timeout: 10000 });
+      });
+
+      await test.step('step-6: Floating button has correct text content', async () => {
+        expect(await bc.floatingButtonInput.textContent()).toBeTruthy();
+      });
+    },
+  );
 });


### PR DESCRIPTION
## Summary
Adds Nala coverage for the new `floating-anchor-delay<N>` variant introduced by PR #5940 (MWPW-194524). Combined with `floating-delay<M>`, the floating button:

- is **hidden** near the top (scrollY < topDelay)
- is **visible** in the middle of the page
- is **hidden again** when within anchorDelay pixels of the footer

Follow-up to PR #5902 (merged).

## Test page
Authored in DA at:
```
/drafts/nala/blocks/brand-concierge/bc-floating-anchor-delay
```
Block class: `brand-concierge floating-button floating-delay-100 floating-anchor-delay-450`

## New test
| Tcid | Name | Tag |
|------|------|-----|
| 13 | `@brand-concierge floating anchor delay` | `@regression` |

Steps:
1. Verify both delay classes present on the block
2. Floating button is `floating-hidden` near top
3. Scroll to middle → `floating-hidden` removed
4. Scroll to footer → `floating-hidden` re-applied
5. Floating input text content is non-empty

## Local run
- `mwpw-176456--milo--adobecom.aem.live`: 14/14 `@regression` pass (Tests 5 and 11 flaky on networkidle but recovered on retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

