### PR TITLE
Consume 0.0.17 tokens to rename title to heading

### DIFF
--- a/.github/workflows/update-s2a-styles.js
+++ b/.github/workflows/update-s2a-styles.js
@@ -19,8 +19,8 @@ const DEPS_DIR = './libs/c2/styles/deps';
 // flat list of `.tgz` files; the package name has no consistent naming pattern,
 // so it is pinned here and bumped manually when a new release ships.
 const DEPS_RELEASE_BASE_URL = 'https://github.com/adobecom/consonant/raw/main/releases';
-const DEPS_PACKAGE = 'adobecom-s2a-tokens-0.0.16.tgz';
-const DEPS_PACKAGE_SHA256 = '3a189fc72ff8193205c9ec120babdcec3c467077ef0ac3f74d45a74c2e04c908';
+const DEPS_PACKAGE = 'adobecom-s2a-tokens-0.0.17.tgz';
+const DEPS_PACKAGE_SHA256 = 'fc1f98e52b723fd2d7c7060826c66a1c0bd3afc4b730478ae6d9609f542bf4a4';
 // Path inside the extracted package that holds the CSS sources we want to
 // mirror into DEPS_DIR.
 const DEPS_PACKAGE_CSS_SUBPATH = path.join('css', 'dev');

--- a/libs/c2/blocks/carousel-c2/carousel-c2.css
+++ b/libs/c2/blocks/carousel-c2/carousel-c2.css
@@ -81,7 +81,7 @@
               animation-fill-mode: var(--carousel-animation-fill);
               animation-range: var(--carousel-text-animation-range);
 
-              :is([class*="title-"]) {
+              :is([class*="heading-"]) {
                 margin-bottom: 8px;
               }
 

--- a/libs/c2/blocks/region-nav/region-nav.css
+++ b/libs/c2/blocks/region-nav/region-nav.css
@@ -26,9 +26,9 @@
 .region-nav > div:first-of-type > div > p:first-of-type {
   font-family: var(--heading-font-family);
   font-weight: var(--s2a-font-weight-adobe-clean-display-black);
-  font-size: var(--s2a-typography-font-size-title-5);
-  line-height: var(--s2a-typography-line-height-title-5);
-  letter-spacing: var(--s2a-typography-letter-spacing-title-5);
+  font-size: var(--s2a-typography-font-size-heading-5);
+  line-height: var(--s2a-typography-line-height-heading-5);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-5);
 }
 
 .region-nav > div:first-of-type > div > p:last-of-type {

--- a/libs/c2/blocks/rich-content/rich-content.js
+++ b/libs/c2/blocks/rich-content/rich-content.js
@@ -18,12 +18,12 @@ function decorateText(el) {
   hangOpeningQuote(firstText);
 }
 
-function promoteParagraphTitle(content, headingSize = '2') {
+function promoteParagraphHeading(content, headingSize = '2') {
   if (!content || content.querySelector('h1, h2, h3, h4, h5, h6')) return;
   const firstP = content.querySelector('p');
   if (!firstP) return;
   const bodyClass = [...firstP.classList].find((c) => c.startsWith('body-'));
-  if (bodyClass) firstP.classList.replace(bodyClass, `title-${headingSize}`);
+  if (bodyClass) firstP.classList.replace(bodyClass, `heading-${headingSize}`);
 }
 
 function decorate(block) {
@@ -32,7 +32,7 @@ function decorate(block) {
   content?.classList.add('content');
   foreground?.classList.add('foreground');
   decorateText(content);
-  promoteParagraphTitle(content);
+  promoteParagraphHeading(content);
 }
 
 export default function init(el) {

--- a/libs/c2/styles/deps/tokens.responsive.lg.css
+++ b/libs/c2/styles/deps/tokens.responsive.lg.css
@@ -18,12 +18,6 @@
 
   /* Typography / Font Size */
   --s2a-typography-font-size-super: var(--s2a-font-size-11xl);
-  --s2a-typography-font-size-title-1: var(--s2a-font-size-10xl);
-  --s2a-typography-font-size-title-2: var(--s2a-font-size-7xl);
-  --s2a-typography-font-size-title-3: var(--s2a-font-size-6xl);
-  --s2a-typography-font-size-title-4: var(--s2a-font-size-4xl);
-  --s2a-typography-font-size-title-5: var(--s2a-font-size-2xl);
-  --s2a-typography-font-size-title-6: var(--s2a-font-size-lg);
   --s2a-typography-font-size-body-lg: var(--s2a-font-size-xl);
   --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
@@ -31,15 +25,15 @@
   --s2a-typography-font-size-eyebrow: var(--s2a-font-size-md);
   --s2a-typography-font-size-label: var(--s2a-font-size-sm);
   --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
+  --s2a-typography-font-size-heading-1: var(--s2a-font-size-10xl);
+  --s2a-typography-font-size-heading-2: var(--s2a-font-size-7xl);
+  --s2a-typography-font-size-heading-3: var(--s2a-font-size-6xl);
+  --s2a-typography-font-size-heading-4: var(--s2a-font-size-4xl);
+  --s2a-typography-font-size-heading-5: var(--s2a-font-size-2xl);
+  --s2a-typography-font-size-heading-6: var(--s2a-font-size-lg);
 
   /* Typography / Letter Spacing */
   --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-xs);
-  --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-sm);
-  --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-lg);
-  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-2xl);
-  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-3xl);
-  --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
   --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
@@ -47,15 +41,15 @@
   --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-sm);
+  --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-lg);
+  --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-xl);
+  --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-2xl);
+  --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-3xl);
+  --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
 
   /* Typography / Line Height */
   --s2a-typography-line-height-super: var(--s2a-font-line-height-6xl);
-  --s2a-typography-line-height-title-1: var(--s2a-font-line-height-5xl);
-  --s2a-typography-line-height-title-2: var(--s2a-font-line-height-3xl);
-  --s2a-typography-line-height-title-3: var(--s2a-font-line-height-2xl);
-  --s2a-typography-line-height-title-4: var(--s2a-font-line-height-lg);
-  --s2a-typography-line-height-title-5: var(--s2a-font-line-height-md);
-  --s2a-typography-line-height-title-6: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
   --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
@@ -63,6 +57,12 @@
   --s2a-typography-line-height-eyebrow: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-label: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-caption: var(--s2a-font-line-height-2xs);
+  --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-5xl);
+  --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-3xl);
+  --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-2xl);
+  --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-lg);
+  --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-md);
+  --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
 }
 
 }

--- a/libs/c2/styles/deps/tokens.responsive.md.css
+++ b/libs/c2/styles/deps/tokens.responsive.md.css
@@ -18,12 +18,6 @@
 
   /* Typography / Font Size */
   --s2a-typography-font-size-super: var(--s2a-font-size-9xl);
-  --s2a-typography-font-size-title-1: var(--s2a-font-size-7xl);
-  --s2a-typography-font-size-title-2: var(--s2a-font-size-6xl);
-  --s2a-typography-font-size-title-3: var(--s2a-font-size-3xl);
-  --s2a-typography-font-size-title-4: var(--s2a-font-size-2xl);
-  --s2a-typography-font-size-title-5: var(--s2a-font-size-xl);
-  --s2a-typography-font-size-title-6: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-lg: var(--s2a-font-size-lg);
   --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
@@ -31,15 +25,15 @@
   --s2a-typography-font-size-eyebrow: var(--s2a-font-size-md);
   --s2a-typography-font-size-label: var(--s2a-font-size-sm);
   --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
+  --s2a-typography-font-size-heading-1: var(--s2a-font-size-7xl);
+  --s2a-typography-font-size-heading-2: var(--s2a-font-size-6xl);
+  --s2a-typography-font-size-heading-3: var(--s2a-font-size-3xl);
+  --s2a-typography-font-size-heading-4: var(--s2a-font-size-2xl);
+  --s2a-typography-font-size-heading-5: var(--s2a-font-size-xl);
+  --s2a-typography-font-size-heading-6: var(--s2a-font-size-md);
 
   /* Typography / Letter Spacing */
   --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-md);
-  --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-sm);
-  --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-xl);
-  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
   --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
@@ -47,15 +41,15 @@
   --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-sm);
+  --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-xl);
+  --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
 
   /* Typography / Line Height */
   --s2a-typography-line-height-super: var(--s2a-font-line-height-4xl);
-  --s2a-typography-line-height-title-1: var(--s2a-font-line-height-3xl);
-  --s2a-typography-line-height-title-2: var(--s2a-font-line-height-2xl);
-  --s2a-typography-line-height-title-3: var(--s2a-font-line-height-lg);
-  --s2a-typography-line-height-title-4: var(--s2a-font-line-height-md);
-  --s2a-typography-line-height-title-5: var(--s2a-font-line-height-sm);
-  --s2a-typography-line-height-title-6: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
   --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
@@ -63,6 +57,12 @@
   --s2a-typography-line-height-eyebrow: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-label: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-caption: var(--s2a-font-line-height-2xs);
+  --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-3xl);
+  --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-2xl);
+  --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-lg);
+  --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-md);
+  --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
 }
 
 }

--- a/libs/c2/styles/deps/tokens.responsive.sm.css
+++ b/libs/c2/styles/deps/tokens.responsive.sm.css
@@ -17,12 +17,6 @@
 
   /* Typography / Font Size */
   --s2a-typography-font-size-super: var(--s2a-font-size-7xl);
-  --s2a-typography-font-size-title-1: var(--s2a-font-size-5xl);
-  --s2a-typography-font-size-title-2: var(--s2a-font-size-3xl);
-  --s2a-typography-font-size-title-3: var(--s2a-font-size-2xl);
-  --s2a-typography-font-size-title-4: var(--s2a-font-size-xl);
-  --s2a-typography-font-size-title-5: var(--s2a-font-size-lg);
-  --s2a-typography-font-size-title-6: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-lg: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
@@ -30,15 +24,15 @@
   --s2a-typography-font-size-eyebrow: var(--s2a-font-size-md);
   --s2a-typography-font-size-label: var(--s2a-font-size-sm);
   --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
+  --s2a-typography-font-size-heading-1: var(--s2a-font-size-5xl);
+  --s2a-typography-font-size-heading-2: var(--s2a-font-size-3xl);
+  --s2a-typography-font-size-heading-3: var(--s2a-font-size-2xl);
+  --s2a-typography-font-size-heading-4: var(--s2a-font-size-xl);
+  --s2a-typography-font-size-heading-5: var(--s2a-font-size-lg);
+  --s2a-typography-font-size-heading-6: var(--s2a-font-size-md);
 
   /* Typography / Letter Spacing */
   --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-lg);
-  --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-lg);
-  --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-3xl);
-  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
   --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
@@ -46,15 +40,15 @@
   --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-lg);
+  --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-3xl);
+  --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-5xl);
+  --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
 
   /* Typography / Line Height */
   --s2a-typography-line-height-super: var(--s2a-font-line-height-3xl);
-  --s2a-typography-line-height-title-1: var(--s2a-font-line-height-xl);
-  --s2a-typography-line-height-title-2: var(--s2a-font-line-height-lg);
-  --s2a-typography-line-height-title-3: var(--s2a-font-line-height-md);
-  --s2a-typography-line-height-title-4: var(--s2a-font-line-height-sm);
-  --s2a-typography-line-height-title-5: var(--s2a-font-line-height-sm);
-  --s2a-typography-line-height-title-6: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
@@ -62,4 +56,10 @@
   --s2a-typography-line-height-eyebrow: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-label: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-caption: var(--s2a-font-line-height-2xs);
+  --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-xl);
+  --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-lg);
+  --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-md);
+  --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
 }

--- a/libs/c2/styles/deps/tokens.responsive.xl.css
+++ b/libs/c2/styles/deps/tokens.responsive.xl.css
@@ -18,12 +18,6 @@
 
   /* Typography / Font Size */
   --s2a-typography-font-size-super: var(--s2a-font-size-11xl);
-  --s2a-typography-font-size-title-1: var(--s2a-font-size-10xl);
-  --s2a-typography-font-size-title-2: var(--s2a-font-size-7xl);
-  --s2a-typography-font-size-title-3: var(--s2a-font-size-6xl);
-  --s2a-typography-font-size-title-4: var(--s2a-font-size-4xl);
-  --s2a-typography-font-size-title-5: var(--s2a-font-size-2xl);
-  --s2a-typography-font-size-title-6: var(--s2a-font-size-lg);
   --s2a-typography-font-size-body-lg: var(--s2a-font-size-xl);
   --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
@@ -31,15 +25,15 @@
   --s2a-typography-font-size-eyebrow: var(--s2a-font-size-md);
   --s2a-typography-font-size-label: var(--s2a-font-size-sm);
   --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
+  --s2a-typography-font-size-heading-1: var(--s2a-font-size-10xl);
+  --s2a-typography-font-size-heading-2: var(--s2a-font-size-7xl);
+  --s2a-typography-font-size-heading-3: var(--s2a-font-size-6xl);
+  --s2a-typography-font-size-heading-4: var(--s2a-font-size-4xl);
+  --s2a-typography-font-size-heading-5: var(--s2a-font-size-2xl);
+  --s2a-typography-font-size-heading-6: var(--s2a-font-size-lg);
 
   /* Typography / Letter Spacing */
   --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-xs);
-  --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-sm);
-  --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-lg);
-  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-2xl);
-  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
   --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
@@ -47,15 +41,15 @@
   --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-sm);
+  --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-lg);
+  --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-xl);
+  --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-2xl);
+  --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
 
   /* Typography / Line Height */
   --s2a-typography-line-height-super: var(--s2a-font-line-height-6xl);
-  --s2a-typography-line-height-title-1: var(--s2a-font-line-height-5xl);
-  --s2a-typography-line-height-title-2: var(--s2a-font-line-height-3xl);
-  --s2a-typography-line-height-title-3: var(--s2a-font-line-height-2xl);
-  --s2a-typography-line-height-title-4: var(--s2a-font-line-height-lg);
-  --s2a-typography-line-height-title-5: var(--s2a-font-line-height-md);
-  --s2a-typography-line-height-title-6: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
   --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
@@ -63,6 +57,12 @@
   --s2a-typography-line-height-eyebrow: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-label: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-caption: var(--s2a-font-line-height-2xs);
+  --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-5xl);
+  --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-3xl);
+  --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-2xl);
+  --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-lg);
+  --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-md);
+  --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
 }
 
 }

--- a/libs/c2/styles/deps/tokens.semantic.css
+++ b/libs/c2/styles/deps/tokens.semantic.css
@@ -43,7 +43,6 @@
   --s2a-font-family-heading: var(--s2a-font-family-adobe-clean-display);
   --s2a-font-family-label: var(--s2a-font-family-adobe-clean);
   --s2a-font-family-subheading: var(--s2a-font-family-adobe-clean-display);
-  --s2a-font-family-title: var(--s2a-font-family-adobe-clean-display);
 
   /* Font Letter Spacing */
   --s2a-font-letter-spacing-xs: var(--s2a-font-letter-spacing-neg-3_84);
@@ -88,7 +87,7 @@
   --s2a-font-size-11xl: var(--s2a-font-size-96);
 
   /* Font Weight */
-  --s2a-font-weight-title: var(--s2a-font-weight-adobe-clean-display-black);
+  --s2a-font-weight-heading: var(--s2a-font-weight-adobe-clean-display-black);
   --s2a-font-weight-body: var(--s2a-font-weight-adobe-clean-regular);
   --s2a-font-weight-eyebrow: var(--s2a-font-weight-adobe-clean-bold);
   --s2a-font-weight-label: var(--s2a-font-weight-adobe-clean-bold);

--- a/libs/c2/styles/deps/tokens.semantic.dark.css
+++ b/libs/c2/styles/deps/tokens.semantic.dark.css
@@ -14,11 +14,11 @@
 
   /* Color / Border */
   --s2a-color-border-brand: var(--s2a-color-brand-adobe-red);
-  --s2a-color-border-default: var(--s2a-color-gray-800);
+  --s2a-color-border-default: var(--s2a-color-gray-300);
   --s2a-color-border-disabled: var(--s2a-color-gray-400);
-  --s2a-color-border-inverse: var(--s2a-color-gray-25);
-  --s2a-color-border-knockout: var(--s2a-color-gray-1000);
-  --s2a-color-border-strong: var(--s2a-color-gray-900);
+  --s2a-color-border-inverse: var(--s2a-color-gray-1000);
+  --s2a-color-border-knockout: var(--s2a-color-gray-25);
+  --s2a-color-border-strong: var(--s2a-color-gray-25);
   --s2a-color-border-subtle: var(--s2a-color-gray-300);
   --s2a-color-border-utility-error: var(--s2a-color-red-900);
 
@@ -30,13 +30,13 @@
   --s2a-color-content-default: var(--s2a-color-gray-25);
   --s2a-color-content-disabled: var(--s2a-color-gray-400);
   --s2a-color-content-eyebrow: var(--s2a-color-transparent-white-48);
+  --s2a-color-content-heading: var(--s2a-color-content-knockout);
   --s2a-color-content-inverse: var(--s2a-color-gray-1000);
   --s2a-color-content-knockout: var(--s2a-color-gray-25);
   --s2a-color-content-label: var(--s2a-color-content-knockout);
   --s2a-color-content-strong: var(--s2a-color-gray-600);
   --s2a-color-content-subheading: var(--s2a-color-content-knockout);
   --s2a-color-content-subtle: var(--s2a-color-transparent-white-64);
-  --s2a-color-content-title: var(--s2a-color-content-knockout);
   --s2a-color-content-utility-error: var(--s2a-color-red-900);
 
   /* Color / Focus Ring */

--- a/libs/c2/styles/deps/tokens.semantic.light.css
+++ b/libs/c2/styles/deps/tokens.semantic.light.css
@@ -30,13 +30,13 @@
   --s2a-color-content-default: var(--s2a-color-gray-1000);
   --s2a-color-content-disabled: var(--s2a-color-gray-400);
   --s2a-color-content-eyebrow: var(--s2a-color-transparent-black-64);
+  --s2a-color-content-heading: var(--s2a-color-content-default);
   --s2a-color-content-inverse: var(--s2a-color-content-knockout);
   --s2a-color-content-knockout: var(--s2a-color-gray-25);
   --s2a-color-content-label: var(--s2a-color-content-default);
   --s2a-color-content-strong: var(--s2a-color-gray-900);
   --s2a-color-content-subheading: var(--s2a-color-gray-1000);
   --s2a-color-content-subtle: var(--s2a-color-transparent-black-64);
-  --s2a-color-content-title: var(--s2a-color-content-default);
   --s2a-color-content-utility-error: var(--s2a-color-red-900);
 
   /* Color / Focus Ring */

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -325,7 +325,7 @@
   --s2a-font-size-9xl: var(--s2a-font-size-72);
   --s2a-font-size-10xl: var(--s2a-font-size-80);
   --s2a-font-size-11xl: var(--s2a-font-size-96);
-  --s2a-font-weight-title: var(--s2a-font-weight-adobe-clean-display-black);
+  --s2a-font-weight-heading: var(--s2a-font-weight-adobe-clean-display-black);
   --s2a-font-weight-body: var(--s2a-font-weight-adobe-clean-regular);
   --s2a-font-weight-eyebrow: var(--s2a-font-weight-adobe-clean-bold);
   --s2a-font-weight-label: var(--s2a-font-weight-adobe-clean-bold);
@@ -369,7 +369,7 @@
   --s2a-color-content-strong: var(--s2a-color-gray-900);
   --s2a-color-content-subheading: var(--s2a-color-gray-1000);
   --s2a-color-content-subtle: var(--s2a-color-transparent-black-64);
-  --s2a-color-content-title: var(--s2a-color-content-default);
+  --s2a-color-content-heading: var(--s2a-color-content-default);
   --s2a-color-content-utility-error: var(--s2a-color-red-900);
   --s2a-color-focus-ring-default: var(--s2a-color-blue-900);
   --s2a-color-focus-ring-knockout: var(--s2a-color-gray-25);
@@ -384,12 +384,12 @@
   --s2a-viewport-vertical-padding-xl: var(--s2a-layout-sm);
   --s2a-layout-guide-gap: var(--s2a-spacing-xs);
   --s2a-typography-font-size-super: var(--s2a-font-size-7xl);
-  --s2a-typography-font-size-title-1: var(--s2a-font-size-5xl);
-  --s2a-typography-font-size-title-2: var(--s2a-font-size-3xl);
-  --s2a-typography-font-size-title-3: var(--s2a-font-size-2xl);
-  --s2a-typography-font-size-title-4: var(--s2a-font-size-xl);
-  --s2a-typography-font-size-title-5: var(--s2a-font-size-lg);
-  --s2a-typography-font-size-title-6: var(--s2a-font-size-md);
+  --s2a-typography-font-size-heading-1: var(--s2a-font-size-5xl);
+  --s2a-typography-font-size-heading-2: var(--s2a-font-size-3xl);
+  --s2a-typography-font-size-heading-3: var(--s2a-font-size-2xl);
+  --s2a-typography-font-size-heading-4: var(--s2a-font-size-xl);
+  --s2a-typography-font-size-heading-5: var(--s2a-font-size-lg);
+  --s2a-typography-font-size-heading-6: var(--s2a-font-size-md);
   --s2a-typography-font-size-body-xs: var(--s2a-font-size-xs);
   --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
   --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
@@ -398,12 +398,12 @@
   --s2a-typography-font-size-label: var(--s2a-font-size-sm);
   --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
   --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-lg);
-  --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-lg);
-  --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-3xl);
-  --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-4xl);
-  --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-5xl);
-  --s2a-typography-letter-spacing-title-6: var(--s2a-font-letter-spacing-5xl);
+  --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-lg);
+  --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-3xl);
+  --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-5xl);
+  --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
   --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
@@ -412,12 +412,12 @@
   --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
   --s2a-typography-line-height-super: var(--s2a-font-line-height-3xl);
-  --s2a-typography-line-height-title-1: var(--s2a-font-line-height-xl);
-  --s2a-typography-line-height-title-2: var(--s2a-font-line-height-lg);
-  --s2a-typography-line-height-title-3: var(--s2a-font-line-height-md);
-  --s2a-typography-line-height-title-4: var(--s2a-font-line-height-sm);
-  --s2a-typography-line-height-title-5: var(--s2a-font-line-height-sm);
-  --s2a-typography-line-height-title-6: var(--s2a-font-line-height-xs);
+  --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-xl);
+  --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-lg);
+  --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-md);
+  --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-body-xs: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
   --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
@@ -485,6 +485,10 @@
   --s2a-color-background-default: var(--s2a-color-gray-900);
   --s2a-color-background-inverse: var(--s2a-color-gray-25);
   --s2a-color-background-subtle: var(--s2a-color-gray-700);
+  --s2a-color-border-default: var(--s2a-color-gray-300);
+  --s2a-color-border-inverse: var(--s2a-color-gray-1000);
+  --s2a-color-border-knockout: var(--s2a-color-gray-25);
+  --s2a-color-border-strong: var(--s2a-color-gray-25);
   --s2a-color-content-default: var(--s2a-color-gray-25);
   --s2a-color-content-eyebrow: var(--s2a-color-transparent-white-48);
   --s2a-color-content-inverse: var(--s2a-color-gray-1000);
@@ -492,7 +496,7 @@
   --s2a-color-content-strong: var(--s2a-color-gray-600);
   --s2a-color-content-subheading: var(--s2a-color-content-knockout);
   --s2a-color-content-subtle: var(--s2a-color-transparent-white-64);
-  --s2a-color-content-title: var(--s2a-color-content-knockout);
+  --s2a-color-content-heading: var(--s2a-color-content-knockout);
   --s2a-color-focus-ring-default: var(--s2a-color-blue-500);
 
   /* Milo-specific declarations */
@@ -626,10 +630,10 @@ a {
   }
 }
 
-h1, h2, h3, h4, h5, h6, [class*="title-"] {
+h1, h2, h3, h4, h5, h6, [class*="heading-"] {
   margin: 0;
   font-family: var(--heading-font-family);
-  font-weight: var(--s2a-font-weight-title);
+  font-weight: var(--s2a-font-weight-heading);
   line-height: 1;
   scroll-margin-top: var(--feds-totalheight-nav); /* TODO: Replace with the eventual Gnav variable */
 
@@ -643,46 +647,46 @@ h1, h2, h3, h4, h5, h6, [class*="title-"] {
   }
 }
 
-.title-super {
+.heading-super {
   font-size: var(--s2a-typography-font-size-super);
   line-height: var(--s2a-typography-line-height-super);
   letter-spacing: var(--s2a-typography-letter-spacing-super);
 }
 
-h1, .title-1 {
-  font-size: var(--s2a-typography-font-size-title-1);
-  line-height: var(--s2a-typography-line-height-title-1);
-  letter-spacing: var(--s2a-typography-letter-spacing-title-1);
+h1, .heading-1 {
+  font-size: var(--s2a-typography-font-size-heading-1);
+  line-height: var(--s2a-typography-line-height-heading-1);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-1);
 }
 
-h2, .title-2 {
-  font-size: var(--s2a-typography-font-size-title-2);
-  line-height: var(--s2a-typography-line-height-title-2);
-  letter-spacing: var(--s2a-typography-letter-spacing-title-2);
+h2, .heading-2 {
+  font-size: var(--s2a-typography-font-size-heading-2);
+  line-height: var(--s2a-typography-line-height-heading-2);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-2);
 }
 
-h3, .title-3 {
-  font-size: var(--s2a-typography-font-size-title-3);
-  line-height: var(--s2a-typography-line-height-title-3);
-  letter-spacing: var(--s2a-typography-letter-spacing-title-3);
+h3, .heading-3 {
+  font-size: var(--s2a-typography-font-size-heading-3);
+  line-height: var(--s2a-typography-line-height-heading-3);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-3);
 }
 
-h4, .title-4 {
-  font-size: var(--s2a-typography-font-size-title-4);
-  line-height: var(--s2a-typography-line-height-title-4);
-  letter-spacing: var(--s2a-typography-letter-spacing-title-4);
+h4, .heading-4 {
+  font-size: var(--s2a-typography-font-size-heading-4);
+  line-height: var(--s2a-typography-line-height-heading-4);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-4);
 }
 
-h5, .title-5 {
-  font-size: var(--s2a-typography-font-size-title-5);
-  line-height: var(--s2a-typography-line-height-title-5);
-  letter-spacing: var(--s2a-typography-letter-spacing-title-5);
+h5, .heading-5 {
+  font-size: var(--s2a-typography-font-size-heading-5);
+  line-height: var(--s2a-typography-line-height-heading-5);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-5);
 }
 
-h6, .title-6 {
-  font-size: var(--s2a-typography-font-size-title-6);
-  line-height: var(--s2a-typography-line-height-title-6);
-  letter-spacing: var(--s2a-typography-letter-spacing-title-6);
+h6, .heading-6 {
+  font-size: var(--s2a-typography-font-size-heading-6);
+  line-height: var(--s2a-typography-line-height-heading-6);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-6);
 }
 
 p {
@@ -1294,22 +1298,22 @@ p {
     --s2a-viewport-vertical-padding-lg: var(--s2a-layout-lg);
     --s2a-viewport-vertical-padding-xl: var(--s2a-layout-xl);
     --s2a-typography-font-size-super: var(--s2a-font-size-9xl);
-    --s2a-typography-font-size-title-1: var(--s2a-font-size-7xl);
-    --s2a-typography-font-size-title-2: var(--s2a-font-size-6xl);
-    --s2a-typography-font-size-title-3: var(--s2a-font-size-3xl);
-    --s2a-typography-font-size-title-4: var(--s2a-font-size-2xl);
-    --s2a-typography-font-size-title-5: var(--s2a-font-size-xl);
+    --s2a-typography-font-size-heading-1: var(--s2a-font-size-7xl);
+    --s2a-typography-font-size-heading-2: var(--s2a-font-size-6xl);
+    --s2a-typography-font-size-heading-3: var(--s2a-font-size-3xl);
+    --s2a-typography-font-size-heading-4: var(--s2a-font-size-2xl);
+    --s2a-typography-font-size-heading-5: var(--s2a-font-size-xl);
     --s2a-typography-font-size-body-xs: var(--s2a-font-size-sm);
     --s2a-typography-font-size-body-lg: var(--s2a-font-size-lg);
     --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-md);
-    --s2a-typography-letter-spacing-title-1: var(--s2a-font-letter-spacing-sm);
-    --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-xl);
-    --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
+    --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-sm);
+    --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-xl);
+    --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-4xl);
     --s2a-typography-line-height-super: var(--s2a-font-line-height-4xl);
-    --s2a-typography-line-height-title-1: var(--s2a-font-line-height-3xl);
-    --s2a-typography-line-height-title-2: var(--s2a-font-line-height-2xl);
-    --s2a-typography-line-height-title-3: var(--s2a-font-line-height-lg);
-    --s2a-typography-line-height-title-4: var(--s2a-font-line-height-md);
+    --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-3xl);
+    --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-2xl);
+    --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-lg);
+    --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-md);
     --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
   }
 }
@@ -1323,30 +1327,30 @@ p {
     --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl);
     --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl);
     --s2a-typography-font-size-super: var(--s2a-font-size-11xl);
-    --s2a-typography-font-size-title-1: var(--s2a-font-size-10xl);
-    --s2a-typography-font-size-title-2: var(--s2a-font-size-7xl);
-    --s2a-typography-font-size-title-3: var(--s2a-font-size-6xl);
-    --s2a-typography-font-size-title-4: var(--s2a-font-size-4xl);
-    --s2a-typography-font-size-title-5: var(--s2a-font-size-2xl);
-    --s2a-typography-font-size-title-6: var(--s2a-font-size-lg);
+    --s2a-typography-font-size-heading-1: var(--s2a-font-size-10xl);
+    --s2a-typography-font-size-heading-2: var(--s2a-font-size-7xl);
+    --s2a-typography-font-size-heading-3: var(--s2a-font-size-6xl);
+    --s2a-typography-font-size-heading-4: var(--s2a-font-size-4xl);
+    --s2a-typography-font-size-heading-5: var(--s2a-font-size-2xl);
+    --s2a-typography-font-size-heading-6: var(--s2a-font-size-lg);
     --s2a-typography-font-size-body-lg: var(--s2a-font-size-xl);
     --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-xs);
-    --s2a-typography-letter-spacing-title-2: var(--s2a-font-letter-spacing-lg);
-    --s2a-typography-letter-spacing-title-3: var(--s2a-font-letter-spacing-xl);
-    --s2a-typography-letter-spacing-title-4: var(--s2a-font-letter-spacing-2xl);
-    --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-3xl);
+    --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-lg);
+    --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-xl);
+    --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-2xl);
+    --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-3xl);
     --s2a-typography-line-height-super: var(--s2a-font-line-height-6xl);
-    --s2a-typography-line-height-title-1: var(--s2a-font-line-height-5xl);
-    --s2a-typography-line-height-title-2: var(--s2a-font-line-height-3xl);
-    --s2a-typography-line-height-title-3: var(--s2a-font-line-height-2xl);
-    --s2a-typography-line-height-title-4: var(--s2a-font-line-height-lg);
-    --s2a-typography-line-height-title-5: var(--s2a-font-line-height-md);
+    --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-5xl);
+    --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-3xl);
+    --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-2xl);
+    --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-lg);
+    --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-md);
   }
 }
 
 @media (width >= 1440px) {
   :root {
     /* tokens.responsive.xl */
-    --s2a-typography-letter-spacing-title-5: var(--s2a-font-letter-spacing-4xl);
+    --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-4xl);
   }
 }

--- a/libs/features/georoutingv2/georoutingv2.css
+++ b/libs/features/georoutingv2/georoutingv2.css
@@ -175,9 +175,9 @@ html:has(meta[name="foundation"][content="c2"]) {
       }
 
       h3 {
-        font-size: var(--s2a-typography-font-size-title-5);
-        line-height: var(--s2a-typography-line-height-title-5);
-        letter-spacing: var(--s2a-typography-letter-spacing-title-5);
+        font-size: var(--s2a-typography-font-size-heading-5);
+        line-height: var(--s2a-typography-line-height-heading-5);
+        letter-spacing: var(--s2a-typography-letter-spacing-heading-5);
         margin: 0;
       }
     }

--- a/libs/mep/ace1201/carousel-c2/carousel-c2.css
+++ b/libs/mep/ace1201/carousel-c2/carousel-c2.css
@@ -81,7 +81,7 @@
               animation-fill-mode: var(--carousel-animation-fill);
               animation-range: var(--carousel-text-animation-range);
 
-              :is([class*="title-"]) {
+              :is([class*="heading-"]) {
                 margin-bottom: 8px;
               }
 

--- a/libs/mep/ace1201/region-nav/region-nav.css
+++ b/libs/mep/ace1201/region-nav/region-nav.css
@@ -26,9 +26,9 @@
 .region-nav > div:first-of-type > div > p:first-of-type {
   font-family: var(--heading-font-family);
   font-weight: var(--s2a-font-weight-adobe-clean-display-black);
-  font-size: var(--s2a-typography-font-size-title-4);
-  line-height: var(--s2a-typography-line-height-title-4);
-  letter-spacing: var(--s2a-typography-letter-spacing-title-4);
+  font-size: var(--s2a-typography-font-size-heading-4);
+  line-height: var(--s2a-typography-line-height-heading-4);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-4);
 }
 
 .region-nav > div:first-of-type > div > p:last-of-type {

--- a/libs/mep/ace1201/rich-content/rich-content.js
+++ b/libs/mep/ace1201/rich-content/rich-content.js
@@ -18,12 +18,12 @@ function decorateText(el) {
   hangOpeningQuote(firstText);
 }
 
-function promoteParagraphTitle(content, headingSize = '2') {
+function promoteParagraphHeading(content, headingSize = '2') {
   if (!content || content.querySelector('h1, h2, h3, h4, h5, h6')) return;
   const firstP = content.querySelector('p');
   if (!firstP) return;
   const bodyClass = [...firstP.classList].find((c) => c.startsWith('body-'));
-  if (bodyClass) firstP.classList.replace(bodyClass, `title-${headingSize}`);
+  if (bodyClass) firstP.classList.replace(bodyClass, `heading-${headingSize}`);
 }
 
 function decorate(block) {
@@ -32,7 +32,7 @@ function decorate(block) {
   content?.classList.add('content');
   foreground?.classList.add('foreground');
   decorateText(content);
-  promoteParagraphTitle(content);
+  promoteParagraphHeading(content);
 }
 
 function decorateMultiViewport(el, viewportContent) {

--- a/libs/mep/ace1205/rich-content/rich-content.js
+++ b/libs/mep/ace1205/rich-content/rich-content.js
@@ -18,12 +18,12 @@ function decorateText(el) {
   hangOpeningQuote(firstText);
 }
 
-function promoteParagraphTitle(content, headingSize = '2') {
+function promoteParagraphHeading(content, headingSize = '2') {
   if (!content || content.querySelector('h1, h2, h3, h4, h5, h6')) return;
   const firstP = content.querySelector('p');
   if (!firstP) return;
   const bodyClass = [...firstP.classList].find((c) => c.startsWith('body-'));
-  if (bodyClass) firstP.classList.replace(bodyClass, `title-${headingSize}`);
+  if (bodyClass) firstP.classList.replace(bodyClass, `heading-${headingSize}`);
 }
 
 function decorate(block) {
@@ -32,7 +32,7 @@ function decorate(block) {
   content?.classList.add('content');
   foreground?.classList.add('foreground');
   decorateText(content);
-  promoteParagraphTitle(content);
+  promoteParagraphHeading(content);
 }
 
 export default function init(el) {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -111,7 +111,7 @@ export function decorateBlockText(el, config = blockTextConfig, type = null) {
     let headings = el?.querySelectorAll('h1, h2, h3, h4, h5, h6');
     if (headings) {
       if (type === 'hasDetailHeading' && headings.length > 1) headings = [...headings].splice(1);
-      headings.forEach((h) => h.classList.add(`${isC2 ? 'title' : 'heading'}-${sizeMap.heading}`));
+      headings.forEach((h) => h.classList.add(`heading-${sizeMap.heading}`));
       if (sizeMap.detail || isC2) {
         const prevSib = headings[0]?.previousElementSibling;
         prevSib?.classList.toggle(isC2 ? 'eyebrow' : `detail-${sizeMap.detail}`, !prevSib.querySelector('picture'));
@@ -233,7 +233,7 @@ function applyTextOverrides(el, override, targetEl) {
   });
 }
 
-const textOverridesConfig = isC2 ? ['title-', 'body-', 'button-'] : ['-heading', '-body', '-detail'];
+const textOverridesConfig = isC2 ? ['heading-', 'body-', 'button-'] : ['-heading', '-body', '-detail'];
 
 export function decorateTextOverrides(el, options = textOverridesConfig, target = false) {
   const overrides = [...el.classList]


### PR DESCRIPTION
This implements the 0.0.17 version of the token package for Site Redesign. The main change is the renaming from `title` to `heading` to limit potential of confusion throughout the system.

Resolves: [MWPW-195625](https://jira.corp.adobe.com/browse/MWPW-195625)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.live/upp-shared/fragments/tests/2026/q2/ace1201/sr-homepage?milolibs=site-redesign-foundation
- After: https://main--upp--adobecom.aem.live/upp-shared/fragments/tests/2026/q2/ace1201/sr-homepage?milolibs=c2-v17-tokens




