### PR TITLE
MWPW-194822: do not add non-draft fragments in draftsOnly mode

### DIFF
--- a/test/tools/floodbox/floodgate/floodgate-workflows.test.js
+++ b/test/tools/floodbox/floodgate/floodgate-workflows.test.js
@@ -195,9 +195,7 @@ describe('findFragments (floodgate-workflows)', () => {
     });
 
     it('does not filter fragments when accessMode is undefined', async () => {
-      const cmp = makeCmp({
-        files: [`/${ORG}/${REPO}/some/page`],
-      });
+      const cmp = makeCmp({ files: [`/${ORG}/${REPO}/some/page`] });
       const html = `
         <a href="https://main--${REPO}--${ORG}.aem.page/fragments/shared">shared</a>
         <a href="https://main--${REPO}--${ORG}.aem.page/drafts/promo/fragments/hero">draft</a>`;

--- a/test/tools/floodbox/floodgate/floodgate-workflows.test.js
+++ b/test/tools/floodbox/floodgate/floodgate-workflows.test.js
@@ -8,11 +8,12 @@ import RequestHandler from '../../../../tools/floodbox/request-handler.js';
 const ORG = 'test-org';
 const REPO = 'test-repo';
 
-function makeCmp({ files, color, chronoBoxFragmentsEnabled = false }) {
+function makeCmp({ files, color, chronoBoxFragmentsEnabled = false, accessMode } = {}) {
   return {
     token: 'test-token',
     _abortController: undefined,
     _floodgateConfig: { chronoBoxFragmentsEnabled },
+    _accessMode: accessMode,
     _filesToProcess: [...files],
     _selectedColor: color,
   };
@@ -150,6 +151,64 @@ describe('findFragments (floodgate-workflows)', () => {
       await findFragments(cmp, ORG, REPO, 'promote');
 
       expect(cmp._fragmentsAssets).to.eql(new Set());
+    });
+  });
+
+  describe('draftsOnly access mode', () => {
+    it('passes accessMode through to config for copy operation', async () => {
+      const cmp = makeCmp({
+        files: [`/${ORG}/${REPO}/some/page`],
+        accessMode: 'draftsOnly',
+      });
+      const html = `
+        <a href="https://main--${REPO}--${ORG}.aem.page/fragments/shared">shared</a>
+        <a href="https://main--${REPO}--${ORG}.aem.page/drafts/promo/fragments/hero">draft</a>`;
+      daFetchStub.resolves({ ok: true, text: async () => html });
+
+      await findFragments(cmp, ORG, REPO, 'copy');
+
+      expect(cmp._fragmentsAssets).to.eql(
+        new Set([`/${ORG}/${REPO}/drafts/promo/fragments/hero`]),
+      );
+      expect(cmp._filesToProcess).to.include(`/${ORG}/${REPO}/drafts/promo/fragments/hero`);
+      expect(cmp._filesToProcess).to.not.include(`/${ORG}/${REPO}/fragments/shared`);
+    });
+
+    it('passes accessMode through to config for promote operation', async () => {
+      const color = 'pink';
+      const fgRepo = `${REPO}-fg-${color}`;
+      const cmp = makeCmp({
+        files: [`/${ORG}/${REPO}/some/page`],
+        color,
+        accessMode: 'draftsOnly',
+      });
+      const html = `
+        <a href="https://main--${fgRepo}--${ORG}.aem.page/fragments/shared">shared</a>
+        <a href="https://main--${fgRepo}--${ORG}.aem.page/drafts/promo/fragments/hero">draft</a>`;
+      daFetchStub.resolves({ ok: true, text: async () => html });
+
+      await findFragments(cmp, ORG, REPO, 'promote');
+
+      expect(cmp._fragmentsAssets).to.eql(
+        new Set([`/${ORG}/${REPO}/drafts/promo/fragments/hero`]),
+      );
+    });
+
+    it('does not filter fragments when accessMode is undefined', async () => {
+      const cmp = makeCmp({
+        files: [`/${ORG}/${REPO}/some/page`],
+      });
+      const html = `
+        <a href="https://main--${REPO}--${ORG}.aem.page/fragments/shared">shared</a>
+        <a href="https://main--${REPO}--${ORG}.aem.page/drafts/promo/fragments/hero">draft</a>`;
+      daFetchStub.resolves({ ok: true, text: async () => html });
+
+      await findFragments(cmp, ORG, REPO, 'copy');
+
+      expect(cmp._fragmentsAssets).to.eql(new Set([
+        `/${ORG}/${REPO}/fragments/shared`,
+        `/${ORG}/${REPO}/drafts/promo/fragments/hero`,
+      ]));
     });
   });
 });

--- a/test/tools/floodbox/references.test.js
+++ b/test/tools/floodbox/references.test.js
@@ -158,7 +158,7 @@ describe('References', () => {
         htmlPaths: dirHtmlPaths,
         org,
         repo,
-        includeChronoBoxFragments: true,
+        config: { chronoBoxFragmentsEnabled: true },
       });
       expect(result).to.eql(new Set([
         '/test-org/test-repo/fragments/from-link',
@@ -180,7 +180,7 @@ describe('References', () => {
         htmlPaths: dirHtmlPaths,
         org,
         repo,
-        includeChronoBoxFragments: true,
+        config: { chronoBoxFragmentsEnabled: true },
       });
       expect(result).to.eql(new Set([
         '/test-org/test-repo/some/dir/fragments/a',
@@ -201,7 +201,7 @@ describe('References', () => {
         htmlPaths: dirHtmlPaths,
         org,
         repo,
-        includeChronoBoxFragments: true,
+        config: { chronoBoxFragmentsEnabled: true },
       });
       expect(result).to.eql(new Set(['/test-org/test-repo/some/dir/fragments/ok']));
     });
@@ -217,7 +217,7 @@ describe('References', () => {
         htmlPaths: dirHtmlPaths,
         org,
         repo,
-        includeChronoBoxFragments: true,
+        config: { chronoBoxFragmentsEnabled: true },
       });
       expect(result).to.eql(new Set(['/test-org/test-repo/absolute/fragments/foo']));
     });
@@ -246,7 +246,7 @@ describe('References', () => {
         htmlPaths: dirHtmlPaths,
         org,
         repo,
-        includeChronoBoxFragments: true,
+        config: { chronoBoxFragmentsEnabled: true },
       });
       expect(result).to.eql(new Set([
         '/test-org/test-repo/events/events-shared/fragments/sm/blank',
@@ -280,7 +280,7 @@ describe('References', () => {
         htmlPaths: dirHtmlPaths,
         org,
         repo,
-        includeChronoBoxFragments: true,
+        config: { chronoBoxFragmentsEnabled: true },
       });
       expect(result).to.eql(new Set());
     });
@@ -304,9 +304,100 @@ describe('References', () => {
         htmlPaths: dirHtmlPaths,
         org,
         repo,
-        includeChronoBoxFragments: true,
+        config: { chronoBoxFragmentsEnabled: true },
       });
       expect(result).to.eql(new Set(['/test-org/test-repo/events/ok']));
+    });
+  });
+
+  describe('draftsOnly access mode', () => {
+    it('filters out fragments outside /drafts when accessMode is draftsOnly', async () => {
+      requestHandlerStub
+        .onFirstCall().resolves({
+          ok: true,
+          text: async () => `
+            <a href="https://main--test-repo--test-org.aem.page/fragments/shared/hero">shared</a>
+            <a href="https://main--test-repo--test-org.aem.page/drafts/campaign/fragments/hero">draft</a>
+          `,
+        })
+        .onSecondCall().resolves({ ok: true, text: async () => '' });
+
+      const result = await findFragmentsAndAssets({
+        accessToken,
+        htmlPaths,
+        org,
+        repo,
+        config: { accessMode: 'draftsOnly' },
+      });
+      expect(result).to.eql(new Set(['/test-org/test-repo/drafts/campaign/fragments/hero']));
+    });
+
+    it('keeps all fragments when accessMode is not draftsOnly', async () => {
+      requestHandlerStub
+        .onFirstCall().resolves({
+          ok: true,
+          text: async () => `
+            <a href="https://main--test-repo--test-org.aem.page/fragments/shared/hero">shared</a>
+            <a href="https://main--test-repo--test-org.aem.page/drafts/campaign/fragments/hero">draft</a>
+          `,
+        })
+        .onSecondCall().resolves({ ok: true, text: async () => '' });
+
+      const result = await findFragmentsAndAssets({
+        accessToken,
+        htmlPaths,
+        org,
+        repo,
+        config: {},
+      });
+      expect(result).to.eql(new Set([
+        '/test-org/test-repo/fragments/shared/hero',
+        '/test-org/test-repo/drafts/campaign/fragments/hero',
+      ]));
+    });
+
+    it('returns an empty set when all fragments are outside /drafts in draftsOnly mode', async () => {
+      requestHandlerStub
+        .onFirstCall().resolves({
+          ok: true,
+          text: async () => '<a href="https://main--test-repo--test-org.aem.page/fragments/shared/hero">shared</a>',
+        })
+        .onSecondCall().resolves({ ok: true, text: async () => '' });
+
+      const result = await findFragmentsAndAssets({
+        accessToken,
+        htmlPaths,
+        org,
+        repo,
+        config: { accessMode: 'draftsOnly' },
+      });
+      expect(result).to.eql(new Set());
+    });
+
+    it('draftsOnly filter applies after chrono-box extraction', async () => {
+      const dirHtmlPaths = ['/some/dir/page1', '/some/dir/page2'];
+      const cbHtml = (json) => `
+        <div class="chrono-box">
+          <div>
+            <div>schedule</div>
+            <div>${json}</div>
+          </div>
+        </div>`;
+      const html = `
+        <a href="https://main--test-repo--test-org.aem.page/fragments/shared">shared</a>
+        ${cbHtml('[{"pathToFragment":"/drafts/campaign/hero"},{"pathToFragment":"fragments/non-draft"}]')}`;
+      requestHandlerStub
+        .onFirstCall().resolves({ ok: true, text: async () => html })
+        .onSecondCall().resolves({ ok: true, text: async () => '' });
+
+      const result = await findFragmentsAndAssets({
+        accessToken,
+        htmlPaths: dirHtmlPaths,
+        org,
+        repo,
+        config: { accessMode: 'draftsOnly', chronoBoxFragmentsEnabled: true },
+      });
+      expect(result).to.eql(new Set(['/test-org/test-repo/drafts/campaign/hero']));
     });
   });
 });

--- a/tools/floodbox/floodgate/floodgate-workflows.js
+++ b/tools/floodbox/floodgate/floodgate-workflows.js
@@ -13,7 +13,11 @@ const DELETE_BATCH = 10;
 
 export async function findFragments(cmp, org, repo, operation) {
   const signal = cmp._abortController?.signal;
-  const includeChronoBoxFragments = !!cmp._floodgateConfig?.chronoBoxFragmentsEnabled;
+  const config = {
+    accessMode: cmp._accessMode,
+    chronoBoxFragmentsEnabled: cmp._floodgateConfig?.chronoBoxFragmentsEnabled,
+  };
+
   if (operation === 'copy') {
     const htmlPaths = cmp._filesToProcess
       .filter((p) => !p.endsWith('/') && !p.includes('.'));
@@ -23,7 +27,7 @@ export async function findFragments(cmp, org, repo, operation) {
       org,
       repo,
       signal,
-      includeChronoBoxFragments,
+      config,
     });
     cmp._fragmentsAssets = new Set(result);
   } else {
@@ -35,7 +39,7 @@ export async function findFragments(cmp, org, repo, operation) {
       org,
       repo: fgRepo,
       signal,
-      includeChronoBoxFragments,
+      config,
     });
     cmp._fragmentsAssets = new Set(
       [...fgFragments].map((p) => p.replace(`-fg-${cmp._selectedColor}`, '')),

--- a/tools/floodbox/references.js
+++ b/tools/floodbox/references.js
@@ -14,13 +14,14 @@ function stripHash(p) {
 }
 
 class References {
-  constructor(accessToken, htmlPaths, org, repo, signal, options = {}) {
+  constructor(accessToken, htmlPaths, org, repo, signal, config = {}) {
     this.accessToken = accessToken;
     this.org = org;
     this.repo = repo;
     this.htmlPaths = htmlPaths;
     this.signal = signal;
-    this.includeChronoBoxFragments = !!options.includeChronoBoxFragments;
+    this.includeChronoBoxFragments = config.chronoBoxFragmentsEnabled;
+    this.accessMode = config.accessMode;
 
     // eslint-disable-next-line no-useless-escape
     this.referencePattern = new RegExp(`https?:\/\/[^/]*--${repo}--${org}\\.[^/]*(?:page|live)(\/.*(?:fragments\/|\\.(?:pdf|svg|json))[^?#]*)`);
@@ -137,6 +138,15 @@ class References {
         }
       }));
     }
+
+    if (this.accessMode === 'draftsOnly') {
+      fragmentsAndAssets.forEach((p) => {
+        if (!p.startsWith(`/${this.org}/${this.repo}/drafts/`)) {
+          fragmentsAndAssets.delete(p);
+        }
+      });
+    }
+
     return fragmentsAndAssets;
   }
 }
@@ -147,7 +157,7 @@ function findFragmentsAndAssets({
   org,
   repo,
   signal,
-  includeChronoBoxFragments,
+  config,
 }) {
   const references = new References(
     accessToken,
@@ -155,7 +165,7 @@ function findFragmentsAndAssets({
     org,
     repo,
     signal,
-    { includeChronoBoxFragments },
+    config,
   );
   return references.getReferencedFragmentsAndAssets();
 }


### PR DESCRIPTION
Resolves: [MWPW-194822](https://jira.corp.adobe.com/browse/MWPW-194822)

**Test URLs:**
- Before: https://da.live/app/adobecom/milo/tools/floodgate?ref=stage
- After: https://da.live/app/adobecom/milo/tools/floodgate?ref=fg-draft




