### PR TITLE
[Loc][Prod] Lingo changes for Milo Studio

### DIFF
--- a/libs/blocks/locui-create/input-locale/index.js
+++ b/libs/blocks/locui-create/input-locale/index.js
@@ -136,7 +136,8 @@ export default function useInputLocale() {
       if (project.value.type === PROJECT_TYPES.translation) {
         const langDetails = languagesList.find((l) => l.languagecode === languageCodes[language]);
         const defaultLocales = langDetails?.defaultlocales ? langDetails.defaultlocales.split(',') : [];
-        return { language, locales: defaultLocales, langCode: languageCodes[language] };
+        const nonDefaultLocales = localeList.filter((locale) => !defaultLocales.includes(locale));
+        return { language, locales: nonDefaultLocales, langCode: languageCodes[language] };
       }
       return { language, locales: localeList, langCode: languageCodes[language] };
     });

--- a/libs/blocks/locui-create/input-locale/index.js
+++ b/libs/blocks/locui-create/input-locale/index.js
@@ -132,11 +132,14 @@ export default function useInputLocale() {
         groupedLocales[language].push(locale);
       }
     });
-    return Object.entries(groupedLocales).map(([language, localeList]) => ({
-      language,
-      locales: project.value.type === PROJECT_TYPES.translation ? [] : localeList,
-      langCode: languageCodes[language],
-    }));
+    return Object.entries(groupedLocales).map(([language, localeList]) => {
+      if (project.value.type === PROJECT_TYPES.translation) {
+        const langDetails = languagesList.find((l) => l.languagecode === languageCodes[language]);
+        const defaultLocales = langDetails?.defaultlocales ? langDetails.defaultlocales.split(',') : [];
+        return { language, locales: defaultLocales, langCode: languageCodes[language] };
+      }
+      return { language, locales: localeList, langCode: languageCodes[language] };
+    });
   };
 
   const updateActiveLocales = (localesToUpdate, isDeselecting = false, languageCode = null) => {
@@ -190,17 +193,24 @@ export default function useInputLocale() {
       }, {}),
     }));
     const newLocalesWithLangCode = [];
+    const effectiveLocales = [];
+    const isRollout = project.value.type !== PROJECT_TYPES.translation;
     regionCountryCodes.forEach((locale) => {
       const languages = findLanguageForLocale(locale);
       languages?.forEach((language) => {
         newLocalesWithLangCode.push(`${language.languagecode}|${locale}`);
+        if (isRollout && language.defaultlocales) {
+          const defaults = language.defaultlocales.split(',');
+          if (!defaults.includes(locale)) return;
+        }
+        if (!effectiveLocales.includes(locale)) effectiveLocales.push(locale);
       });
     });
     setSelectedLocale((prev) => [
       ...prev,
       ...newLocalesWithLangCode.filter((code) => !prev.includes(code)),
     ]);
-    updateActiveLocales(regionCountryCodes);
+    updateActiveLocales(effectiveLocales);
   };
 
   const deselectRegion = (regionKey, regionCountryCodes) => {
@@ -301,16 +311,21 @@ export default function useInputLocale() {
   };
 
   const selectLanguage = (lang) => {
-    const languageCodes = lang.livecopies.split(',');
-    const isDeselecting = languageCodes.every((code) => selectedLocaleSet.has(`${lang.languagecode}|${code}`));
+    const allLivecopies = lang.livecopies.split(',');
+    const defaultCodes = (lang.defaultlocales || lang.livecopies).split(',');
+    const isDeselecting = allLivecopies.some((code) => selectedLocaleSet.has(`${lang.languagecode}|${code}`));
     const updatedLocale = isDeselecting
       ? selectedLocale.filter((localeKey) => {
         const [langCode, locale] = parseLocaleKey(localeKey);
-        return langCode !== lang.languagecode || !languageCodes.includes(locale);
+        return langCode !== lang.languagecode || !allLivecopies.includes(locale);
       })
-      : [...selectedLocale, ...languageCodes.map((code) => `${lang.languagecode}|${code}`)];
+      : [...selectedLocale, ...allLivecopies.map((code) => `${lang.languagecode}|${code}`)];
     setSelectedLocale(updatedLocale);
-    updateActiveLocales(languageCodes, isDeselecting, lang.languagecode);
+    updateActiveLocales(
+      isDeselecting ? allLivecopies : defaultCodes,
+      isDeselecting,
+      lang.languagecode,
+    );
   };
 
   const toggleLocale = (localeKey) => {

--- a/libs/blocks/locui-create/locui-create.js
+++ b/libs/blocks/locui-create/locui-create.js
@@ -28,8 +28,8 @@ function Create() {
     const setup = async () => {
       try {
         await getUserToken();
-        await fetchLocaleDetails();
         env.value = getEnvQueryParam();
+        await fetchLocaleDetails();
         const searchParams = new URLSearchParams(window.location.search);
         const projectKey = searchParams.get('projectKey');
         const workflow = searchParams.get('workflow');

--- a/libs/blocks/locui-create/store.js
+++ b/libs/blocks/locui-create/store.js
@@ -83,10 +83,10 @@ export async function getUserToken() {
   return userToken;
 }
 
-async function fetchLocales(tenantBaseUrl) {
+async function fetchLocales(tenantBaseUrl, configName = 'config') {
   try {
     const response = await fetch(
-      `${tenantBaseUrl}/.milo/config.json?sheet=${LOCALES}&sheet=${LOCALE_GROUPS}`,
+      `${tenantBaseUrl}/.milo/${configName}.json?sheet=${LOCALES}&sheet=${LOCALE_GROUPS}`,
     );
     if (!response.ok) {
       throw new Error(`Server Error: ${response.status}`);
@@ -105,7 +105,13 @@ async function fetchLocales(tenantBaseUrl) {
 export async function fetchLocaleDetails() {
   try {
     loading.value = true;
-    let localeData = await fetchLocales(origin);
+    let localeData = null;
+    if (env.value === 'stage' || env.value === 'local') {
+      localeData = await fetchLocales(origin, 'config-stage');
+    }
+    if (!localeData) {
+      localeData = await fetchLocales(origin);
+    }
     if (!localeData) {
       localeData = await fetchLocales('https://main--federal--adobecom.aem.page');
     }

--- a/libs/blocks/locui-create/store.js
+++ b/libs/blocks/locui-create/store.js
@@ -76,6 +76,7 @@ export async function getUserToken() {
     userToken = accessToken.value;
     authenticated.value = true;
   } catch {
+    // eslint-disable-next-line no-console
     console.error('Sharepoint login failed. Unable to get User-Token!');
     authenticated.value = false;
   }
@@ -97,6 +98,7 @@ async function fetchLocales(tenantBaseUrl, configName = 'config') {
     }
     return null;
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error during fetchLocaleDetailsFromOrigin:', error.message);
     return null;
   }
@@ -127,6 +129,7 @@ export async function fetchLocaleDetails() {
     locales.value = processedLocales.filter((locItem) => locItem.livecopies !== '');
     localeRegion.value = processedLocaleRegion;
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.error('Error during fetchLocaleDetails:', error.message);
   }
   loading.value = false;

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -76,13 +76,17 @@ export function setSelectedLocalesAndRegions() {
   }, {});
   const selectedLocale = [];
   const activeLocales = {};
+  const isPromoteOrSingleRollout = userWorkflowType.value === USER_WORKFLOW_TYPE.promote_rollout
+    || userWorkflowType.value === USER_WORKFLOW_TYPE.single_rollout;
   languages.forEach((loc) => {
     const { language, locales } = loc;
     const { livecopies, defaultlocales, languagecode } = localeByLanguage[language] || {};
-    const effectiveLivecopies = defaultlocales || livecopies;
+    const visibleLivecopies = isPromoteOrSingleRollout
+      ? livecopies
+      : (defaultlocales || livecopies);
     const livecopiesArr = [];
-    if (effectiveLivecopies) {
-      const newLivecopies = effectiveLivecopies.split(',').map((locale) => `${languagecode}|${locale}`);
+    if (visibleLivecopies) {
+      const newLivecopies = visibleLivecopies.split(',').map((locale) => `${languagecode}|${locale}`);
       livecopiesArr.push(...newLivecopies);
     }
     if (locales.length > 0) {

--- a/libs/blocks/locui-create/utils/utils.js
+++ b/libs/blocks/locui-create/utils/utils.js
@@ -78,10 +78,11 @@ export function setSelectedLocalesAndRegions() {
   const activeLocales = {};
   languages.forEach((loc) => {
     const { language, locales } = loc;
-    const { livecopies, languagecode } = localeByLanguage[language] || {};
+    const { livecopies, defaultlocales, languagecode } = localeByLanguage[language] || {};
+    const effectiveLivecopies = defaultlocales || livecopies;
     const livecopiesArr = [];
-    if (livecopies) {
-      const newLivecopies = livecopies.split(',').map((locale) => `${languagecode}|${locale}`);
+    if (effectiveLivecopies) {
+      const newLivecopies = effectiveLivecopies.split(',').map((locale) => `${languagecode}|${locale}`);
       livecopiesArr.push(...newLivecopies);
     }
     if (locales.length > 0) {
@@ -110,7 +111,7 @@ export function getLanguageDetails(langs) {
       action: 'Rollout',
       langCode: langDetails.languagecode,
       language: langDetails.language,
-      locales: langDetails.livecopies?.split(','),
+      locales: (langDetails.defaultlocales || langDetails.livecopies)?.split(','),
       workflow: '',
     };
   });


### PR DESCRIPTION
## Summary

Resolves: [MWPW-188683](https://jira.corp.adobe.com/browse/MWPW-188683)

### Changes

**`config-stage` support (`store.js`, `locui-create.js`)**
- `fetchLocaleDetails` now first tries `.milo/config-stage.json` when running
  in `stage` or `local` env, falling back to `config.json` if unavailable
- `env.value` is now set before `fetchLocaleDetails()` is called so the env
  check is reliable

**`defaultlocales` column support (`utils.js`, `input-locale/index.js`)**
- Locale selection now reads a `defaultlocales` column from the config sheet
- For **translation** workflows: pre-selected locales exclude default locales
  (non-default locales are shown as pre-selected)
- For **rollout** workflows: only default locales are activated when a region
  or language is selected; all livecopies remain selectable
- For **promote/single-rollout** workflows: full `livecopies` list is used
  (existing behavior preserved)
- `selectLanguage` deselect logic fixed to check `some` instead of `every`,
  so a language deselects correctly when any of its locales are already chosen




