### PR TITLE
MWPW-195670 on the page load the bread crumb is seen loaded which is not handled gracefully

### DIFF
--- a/libs/blocks/fallback/fallback.js
+++ b/libs/blocks/fallback/fallback.js
@@ -23,6 +23,7 @@ const SYNTHETIC_BLOCKS = [
   'featured-card',
   'product-card',
   'links-card',
+  'promo-card-small',
 ];
 
 // eslint-disable-next-line import/prefer-default-export

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -729,6 +729,10 @@ p {
   letter-spacing: var(--s2a-typography-letter-spacing-caption);
 }
 
+.breadcrumbs {
+  display: none;
+}
+
 .spacing-none { padding-block: var(--s2a-viewport-vertical-padding-none); }
 .spacing-2xs  { padding-block: var(--s2a-viewport-vertical-padding-2xs); }
 .spacing-xs   { padding-block: var(--s2a-viewport-vertical-padding-xs); }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* breadcrumbs is authored per page
* We need a `display: none` on breadcrumbs to prevent FOUC before the gnav picks them up.
* Adding promo-card-small block to fallback

Resolves: [MWPW-195670](https://jira.corp.adobe.com/browse/MWPW-195670), [MWPW-195425](https://jira.corp.adobe.com/browse/MWPW-195425)

https://main--upp--adobecom.aem.page/homepage/drafts/blaishram/redesign-demo-copy?fedsbranch=localnav-new&milolibs=hide-breadcrumbs

promo-card: https://main--federal--adobecom.aem.page/federal/dev/blaishram/redesign-gnav/solutions/large-menu-acrobat?milolibs=hide-breadcrumbs



