### PR TITLE
[MWPW-194954] [Router marquee] Enhanced breakpoint naming support

### DIFF
--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -110,7 +110,8 @@ const groupByViewport = (el) => {
   let current = null;
   [...el.children].forEach((row) => {
     const firstCol = row.querySelector(':scope > div');
-    const breakpoint = BREAKPOINTS.find((b) => firstCol?.textContent.trim().toLowerCase() === b);
+    const text = firstCol?.textContent.trim().toLowerCase();
+    const breakpoint = BREAKPOINTS.find((b) => text === b || text === `${b}-viewport`);
     if (breakpoint) {
       current = breakpoint;
       viewports[current] = [];


### PR DESCRIPTION
## Description
This PR is enhancing the Router Marquee to support more variants for the breakpoint naming when authoring the block.

## Related Issue
Resolves: [MWPW-194954](https://jira.corp.adobe.com/browse/MWPW-194954)

## Testing instructions
- regression test needed


## Test URLs
**using `mobile, tablet, desktop` when authoring breakpoint specific content**

- Before: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=stage&martech=off
- After: https://main--upp--adobecom.aem.page/homepage/drafts/ramuntea/redesign-demo?milolibs=mwpw-194954&martech=off

**using `mobile, tablet, desktop, mobile-viewport, tablet-viewport, desktop-viewport` when authoring breakpoint specific content**

- Before: https://main--upp--adobecom.aem.page/homepage/drafts/rbogos/router-marquee-viewports?milolibs=stage&martech=off
- After: https://main--upp--adobecom.aem.page/homepage/drafts/rbogos/router-marquee-viewports?milolibs=mwpw-194954&martech=off
