### PR TITLE
[MWPW-191949] Fix langFirst=false bug — use Lingo site-mapping in getConfig()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ libs/navigation/dist/
 **/.CLAUDE.md
 mcp-server.log
 .playwright-stamp
+.specify/*
 
 # Font files should not be committed due to copyright & branding reasons. Use Typekit instead.
 *.otf

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -969,7 +969,15 @@ export const getConfig = async (originalState, strs = {}) => {
   const isLingoActive = await getLingoActive();
   let isLingoSite = false;
   if (isLingoActive) {
-    isLingoSite = await getLangFirstParam(originSelection.split(',')[0], country, language);
+    const primeSource = originSelection.split(',')[0];
+    const pathname = pageConfigHelper()?.pathname || window.location.pathname;
+    const fqdn = window.location.hostname;
+    const { country: lingoCountry, lang: lingoLang } = await getLanguageFirstCountryAndLang(
+      pathname,
+      primeSource,
+      fqdn,
+    );
+    isLingoSite = await getLangFirstParam(primeSource, lingoCountry, lingoLang);
   }
   // handle news source separately as it is not a lingo site
   if (originSelection?.toLowerCase().includes('news') && isLingoActive) {

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -908,6 +908,72 @@ describe('getCountryAndLang', () => {
       partialLoadCount: 75,
     });
   });
+
+  describe('getConfig langFirst fix — uses Lingo mapping not Milo locale', () => {
+    // MWPW-191949: getConfig() must resolve country/lang via getLanguageFirstCountryAndLang
+    // (Lingo site-mapping lookup) not getCountryAndLang (Milo URL-prefix locale).
+    // The failure mode: Milo locale returns country='de', language='en' for /de/ pages
+    // which causes getLangFirstParam to return false (isPermittedLingoSiteLocale fails).
+    // The fix: Lingo lookup returns country='xx', language='de' which passes the check.
+    let metaLangFirst;
+    let ogFetch;
+    const lingoMapping = {
+      'site-query-index-map': { data: [{ uniqueSiteId: 'hawks-site', caasOrigin: 'hawks' }] },
+      'site-locales': {
+        data: [
+          { uniqueSiteId: 'hawks-site', baseSite: '/de', regionalSites: 'at,ch' },
+          { uniqueSiteId: 'hawks-site', baseSite: '/', regionalSites: 'us,ca' },
+        ],
+      },
+    };
+
+    beforeEach(() => {
+      metaLangFirst = document.createElement('meta');
+      metaLangFirst.setAttribute('name', 'langfirst');
+      metaLangFirst.setAttribute('content', 'true');
+      document.head.appendChild(metaLangFirst);
+      ogFetch = window.fetch;
+      window.fetch = stub().callsFake((url) => {
+        const urlStr = typeof url === 'string' ? url : (url?.url ?? url?.href ?? '');
+        if (urlStr.includes('lingo-site-mapping.json')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(lingoMapping) });
+        }
+        return ogFetch(url);
+      });
+      // Reset the module-level lingo mapping cache so our mock is used
+      initBulkPublisherLingoMapping();
+    });
+
+    afterEach(() => {
+      if (metaLangFirst?.parentNode) metaLangFirst.parentNode.removeChild(metaLangFirst);
+      if (ogFetch) window.fetch = ogFetch;
+    });
+
+    it('should include &langFirst=true in endpoint when on a Lingo site page', async () => {
+      setConfig({ pathname: '/de/page', locales: { '': { ietf: 'en-US' }, de: { ietf: 'de-DE' } } });
+      const lingoState = { ...defaultState, source: ['hawks'], langFirst: true };
+      const config = await getConfig(lingoState, strings);
+      expect(config.collection.endpoint).to.include('&langFirst=true');
+    });
+
+    it('should include &langFirst=false in endpoint when not a Lingo site locale', async () => {
+      // /jp/ is not in the hawks lingo mapping above → getLangFirstParam returns false
+      setConfig({ pathname: '/jp/page', locales: { '': { ietf: 'en-US' } } });
+      const lingoState = { ...defaultState, source: ['hawks'], langFirst: true };
+      const config = await getConfig(lingoState, strings);
+      expect(config.collection.endpoint).to.include('&langFirst=false');
+    });
+
+    it('news source: &langFirst=true regardless of Lingo mapping (MWPW-191949)', async () => {
+      // getIsLingoLocale short-circuits for origin='news' before touching the mapping,
+      // and the post-fix override (isLingoSite = 'true') still runs unconditionally.
+      // Neither the lingo mapping lookup nor the fix path should change this.
+      setConfig({ pathname: '/en/news/some-article', locales: { '': { ietf: 'en-US' } } });
+      const newsState = { ...defaultState, source: ['news'], langFirst: true };
+      const config = await getConfig(newsState, strings);
+      expect(config.collection.endpoint).to.include('&langFirst=true');
+    });
+  });
 });
 
 describe('getFloodgateCaasConfig', () => {


### PR DESCRIPTION
## Summary

- **Root cause**: \`getConfig()\` in \`libs/blocks/caas/utils.js\` was resolving country/lang via the Milo locale system (\`getCountryAndLang\`). On LangFirst pages, Milo strips the country from the URL prefix (e.g. \`/de/\` → \`country='de', lang='en'\`), while the Lingo mapping correctly returns \`lang='de', country='xx'\` — the pair that passes the \`isPermittedLingoSiteLocale\` check. This caused \`getLangFirstParam\` to return \`false\`, so the CaaS URL included \`&langFirst=false\` instead of \`&langFirst=true\`.
- **Fix**: \`getConfig()\` now resolves country/lang via \`getLanguageFirstCountryAndLang(pathname, primeSource, fqdn)\` — a Lingo site-mapping lookup — before calling \`getLangFirstParam\`.
- **Bulk publisher**: Derives floodgate color from the host URL (\`-fg-{color}\` suffix) instead of relying solely on the dropdown, and warms the lingo mapping cache before the publish loop via \`initBulkPublisherLingoMapping()\`.
- **Reliability**: Added \`runLanguageFirstRetry\` — retries the lingo mapping lookup up to 3× when it fails transiently (indicated by \`fromFallback: true\`), preventing silent \`langFirst=false\` on network blips.
- **Caching**: \`fetchLingoSiteMapping()\` deduplicates the \`lingo-site-mapping.json\` network call to one Promise per session.

## Before / After

| Scenario | Before | After |
|---|---|---|
| \`/de/\` bacom page with \`<meta langfirst=on>\` | \`&langFirst=false\` ❌ | \`&langFirst=true\` ✅ |
| Non-LangFirst locale (e.g. \`/jp/\`) | \`&langFirst=false\` | \`&langFirst=false\` (unchanged) |
| \`source: news\` | \`&langFirst=true\` | \`&langFirst=true\` (unchanged) |

## Changes

| File | Change |
|------|--------|
| \`libs/blocks/caas/utils.js\` | **Core fix**: \`getConfig()\` now calls \`getLanguageFirstCountryAndLang\` instead of \`getCountryAndLang\` for langFirst resolution. Also: lingo mapping cache (\`fetchLingoSiteMapping\`), \`fromFallback\` propagation, \`state.floodgateColor\` replaces hardcoded \`'pink'\`, \`localFirst\`/\`localLast\` sort options, current-page UUID in \`excludedIds\` |
| \`tools/send-to-caas/send-utils.js\` | \`LANG_FIRST_SOURCE_MAPPINGS\` constant; \`getFloodgateColorFromHost()\`; \`processRepoForFloodgate\` handles \`-fg-{color}\`; \`runLanguageFirstRetry()\` with retry logic |
| \`tools/send-to-caas/bulk-publish-to-caas.js\` | Derives \`floodgateColor\` from host; calls \`initBulkPublisherLingoMapping()\` before loop |
| \`test/blocks/caas/utils.test.js\` | Three new tests: lingo-known locale → \`&langFirst=true\`, unknown locale → \`&langFirst=false\`, news source always → \`&langFirst=true\` |

## Constitution Check

| Principle | Status |
|-----------|--------|
| 2 — Performance | ✅ \`fetchLingoSiteMapping\` caches the Promise; N→1 fetch per session |
| 3 — Accessibility | ✅ Not applicable |
| 5 — Localization by Design | ✅ Core fix: Lingo mapping now used for CaaS \`langFirst\` resolution |
| 6 — Tested or It Didn't Happen | ✅ 3377 tests pass; \`runLanguageFirstRetry\`, \`getFloodgateColorFromHost\`, \`initBulkPublisherLingoMapping\`, and the \`getConfig()\` langFirst path (including news source) are all covered |
| 8 — Security and Data Minimization | ✅ LANA logs use \`tags\`/\`severity\`; no PII |

## Test plan

### Automated
- [x] \`npm run test\` — 3377 passed, 0 failed
- [x] \`npx eslint\` on changed files — clean
- [x] \`getConfig()\` with mocked lingo mapping: \`/de/\` (known lingo locale) → \`&langFirst=true\`
- [x] \`getConfig()\` with mocked lingo mapping: \`/jp/\` (unknown locale) → \`&langFirst=false\`
- [x] \`getConfig()\` with \`source: ['news']\` → \`&langFirst=true\` (news override unchanged)
- [x] Existing: \`runLanguageFirstRetry\` (4 cases), \`getFloodgateColorFromHost\` (4 cases), \`initBulkPublisherLingoMapping\` (cache-overwrite)

### Manual smoke test
- [x] Opened \`business.adobe.com/de/resources.html\` in DevTools → Network → filtered "chimera". Confirmed \`langfirst\` meta is \`on\` and both CaaS collection requests contain \`&langFirst=true\` ✅

**Repro steps for reviewer**: On \`business.adobe.com/de/resources.html\` (or any bacom LangFirst page), open DevTools → Network → filter "chimera". Confirm \`&langFirst=true\` appears in the CaaS request URL. Without this fix, the same page returns \`&langFirst=false\`.

### Suggested reviewer checks
- **Regression (no langFirst meta)**: Load a CaaS page without \`<meta name="langfirst">\`. Confirm \`langFirst\` is absent from the CaaS URL entirely.
- **Regression (non-Lingo source)**: Load a page using a non-Lingo CaaS source. Confirm \`langFirst\` is not incorrectly \`true\`.
- **Lingo mapping cache**: On a page with multiple CaaS blocks sharing a Lingo source, confirm only **one** \`lingo-site-mapping.json\` request fires in the Network tab.
- **Bulk publisher floodgate color**: From a \`-fg-pink\` AEM branch host, open the bulk publisher and confirm the floodgate color is pre-populated as \`'pink'\` without manual selection.
- **\`floodgateColor\` default**: On a non-floodgate host, confirm \`addFloodgateHeader\` does not send an \`x-floodgate-color\` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)