### PR TITLE
[MWPW-195790] caas configurator tags fetch error fix

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -296,9 +296,12 @@ export const loadCaasFiles = async () => {
 export const loadCaasTags = async (tagsUrl) => {
   let errorMsg = '';
   if (tagsUrl) {
-    const url = tagsUrl.startsWith('https://') || tagsUrl.startsWith('http://') ? tagsUrl : `https://${tagsUrl}`;
+    const urlObj = new URL(tagsUrl.startsWith('https://') || tagsUrl.startsWith('http://') ? tagsUrl : `https://${tagsUrl}`);
+    if (urlObj.hostname !== window.location.hostname && !urlObj.searchParams.has('s')) {
+      urlObj.searchParams.set('s', window.location.host);
+    }
     try {
-      const resp = await fetchWithTimeout(url);
+      const resp = await fetchWithTimeout(urlObj.toString());
       if (resp.ok) {
         const json = await resp.json();
         return {

--- a/test/blocks/caas-config/mockFetch.js
+++ b/test/blocks/caas-config/mockFetch.js
@@ -1,13 +1,13 @@
-import { stub } from 'sinon';
+import { stub, match } from 'sinon';
 import tagsData from './tagsData.js';
 
-const CAAS_TAG_URL = 'https://www.adobe.com/chimera-api/tags';
+const CAAS_TAGS_URL_BASE = 'https://www.adobe.com/chimera-api/tags';
 
 const ogFetch = window.fetch;
 
 export const stubFetch = () => {
   window.fetch = stub();
-  window.fetch.withArgs(CAAS_TAG_URL).returns(
+  window.fetch.withArgs(match((url) => url.startsWith(CAAS_TAGS_URL_BASE))).returns(
     new Promise((resolve) => {
       resolve({
         ok: true,


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fix for "Unable to fetch tags, loading backup tags" error on CaaS configurator

Resolves: [MWPW-195790](https://jira.corp.adobe.com/browse/MWPW-195790)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?not-applicable
- After: https://MWPW-195790--milo--adobecom.aem.page/?not-applicable








