### PR TITLE
Revert "[MWPW-189253]: Fixed section metadata mobile gap issue occurs"

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -198,7 +198,6 @@
   padding-right: var(--grid-margins-width);
   display: grid;
   gap: var(--spacing-m);
-  grid-template-columns: minmax(0, 1fr);
 }
 
 .section[class*='grid-width-'] > .content,
@@ -273,6 +272,10 @@ main > .section[class*='-up'] > .content {
 
   .section.two-up.reverse-mobile > div:nth-child(2) {
     order: 1;
+  }
+
+  .section[class*='grid-width-'] {
+    display: block;
   }
 
   .section:has(> .show-more-button),


### PR DESCRIPTION
Reverts adobecom/milo#5931

It was breaking Plan page on Genuine - https://www.stage.adobe.com/genuine-shared/fragments/ic-ses-experience/all-apps/individual
<img width="1897" height="978" alt="image" src="https://github.com/user-attachments/assets/c9b88219-77ff-403b-bed8-a4b2b8b4f4fd" />

Related JIRA - https://jira.corp.adobe.com/browse/MWPW-195692
More details - https://adobe-mwp.slack.com/archives/C079KBL5WP2/p1779249061052489

