### PR TITLE
MWPW-195727 [M@S] mas-field should decorate content with fragment-id …

### DIFF
--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -161,6 +161,12 @@ export async function createCard(el, options) {
   await postProcessAutoblock(merchCard, true);
 }
 
+function copyMasFieldIdToParent(masField, name) {
+  if (masField.getAttribute(name)) {
+    masField.parentElement.setAttribute(`data-mas-field-${name}`, masField.getAttribute(name));
+  }
+}
+
 /** Replaces an inline fragment link with a mas-field wrapping an aem-fragment. */
 async function createInline(el, options) {
   const attrs = { fragment: options.fragment };
@@ -227,6 +233,8 @@ async function createInline(el, options) {
         size = (blockSize === 'large' || blockSize === 'xlarge') ? 'button-xl' : 'button-l';
       }
     }
+    copyMasFieldIdToParent(masField, 'fragment-id');
+    copyMasFieldIdToParent(masField, 'variation-id');
     masField.replaceWith(...[...content.childNodes]);
 
     // Defer decorateButtons until the last CTA mas-field in this container has been


### PR DESCRIPTION
…and variation-id

Copies fragment IDs from `mas-field` to it's parent before `mas-field` is removed from DOM
PR that adds fragment IDs to `mas-field` -> https://github.com/adobecom/mas/pull/885 

Test page https://mwpw195727--milo--bozojovicic.aem.page/fr/drafts/bozo/mas-field?maslibs=MWPW-195727

Resolves: [MWPW-195727](https://jira.corp.adobe.com/browse/MWPW-195727)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw195727--milo--bozojovicic.aem.page/?martech=off


