### PR TITLE
[MWPW-195875] Preflight Checks should not be triggered on live pages

### DIFF
--- a/libs/scripts/delayed.js
+++ b/libs/scripts/delayed.js
@@ -109,6 +109,9 @@ export const addRUMCampaignTrackingParameters = ({ sampleRUM }) => {
 };
 
 export const loadPreflightResults = async () => {
+  const { hostname } = window.location;
+  if (!hostname.endsWith('.aem.page') && !hostname.endsWith('.aem.live')) return;
+
   const run = async () => {
     const { default: showPreflightNotification } = await import('../utils/preflight-notification.js');
     await showPreflightNotification();


### PR DESCRIPTION
If a project is added in the AEM sidekick it will load the sidkeick bar even if its a live page, and if the sidekick gets loaded it will also call Prelfight and run the checks on that page.

to fix that I've added an early return in delayed.js if the hostname does **not** end with `.aem.page` or `.aem.live` 

Resolves: [MWPW-195875](https://jira.corp.adobe.com/browse/MWPW-195875)

Testing:
- you need to first have the project added to you sidekick so go to https://main--milo--adobecom.aem.page/ page 
- click on the 3 bars on the right and look for "add this Project", if instead you are seeing "remove this project" then it means you already have the project added
<img width="632" height="338" alt="Screenshot 2026-05-21 at 10 41 05" src="https://github.com/user-attachments/assets/fcc25f1f-814c-4aed-aaec-f3f21e908b78" />

- Now you want to go to any [live milo page](https://milo.adobe.com/) and after few seconds you should see the notification pop up above sidekick which mean that prelfight ran in the background
- open your developer tools > Sources and search for `delayed.js`, and in there find the `loadPreflightResults` function and add the following two lines right after the funtion:
`const { hostname } = window.location;
  if (!hostname.endsWith('.aem.page') && !hostname.endsWith('.aem.live')) return;`
<img width="630" height="74" alt="Screenshot 2026-05-21 at 10 50 30" src="https://github.com/user-attachments/assets/f4c40eca-2c77-429f-9c7f-c45b41f2d193" />

- make sure the changes are saved and refresh the page.
- now Preflight will not be running and Preflight notification should not appear anymore.


Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://preflight-live-guard--milo--adobecom.aem.page/?martech=off

