### PR TITLE
MWPW-195679 Pre-Flight Updates

### DIFF
--- a/libs/blocks/preflight/checks/merch.js
+++ b/libs/blocks/preflight/checks/merch.js
@@ -12,6 +12,11 @@ export function findFragmentElements(area = document) {
   els.forEach((el) => {
     const uuid = el.getAttribute('fragment');
     if (!uuid) return;
+    // Skip if inside a merch-card that is itself inside a merch-card-collection —
+    // collection hydration loads those cards; only the collection's own fragment matters.
+    const closestCard = el.closest('merch-card');
+    const closestCollection = el.closest('merch-card-collection');
+    if (closestCard && closestCollection && closestCollection.contains(closestCard)) return;
     const card = el.closest('merch-card, merch-card-collection, mas-field') || el;
     entries.push({ uuid, el, card });
   });

--- a/libs/blocks/preflight/checks/merch.js
+++ b/libs/blocks/preflight/checks/merch.js
@@ -19,10 +19,10 @@ export function findFragmentElements(area = document) {
 }
 
 export async function checkFragmentPublished(uuid, locale) {
-  const params = new URLSearchParams({ id: uuid, api_key: API_KEY, locale });
+  const params = new URLSearchParams({ id: uuid, api_key: API_KEY, locale, source: 'milo-preflight' });
   const url = `${API_BASE}?${params.toString()}`;
   try {
-    const res = await fetch(url, { headers: { 'X-Request-Source': 'milo-preflight' } });
+    const res = await fetch(url);
     return { uuid, httpStatus: res.status, published: res.status === 200 };
   } catch {
     return { uuid, httpStatus: 0, published: false };

--- a/libs/blocks/preflight/checks/merch.js
+++ b/libs/blocks/preflight/checks/merch.js
@@ -1,4 +1,5 @@
 import { getConfig } from '../../../utils/utils.js';
+import { getMiloLocaleSettings } from '../../merch/merch.js';
 import { SEVERITY } from './constants.js';
 
 const API_BASE = 'https://www.adobe.com/mas/io/fragment';
@@ -21,7 +22,7 @@ export async function checkFragmentPublished(uuid, locale) {
   const params = new URLSearchParams({ id: uuid, api_key: API_KEY, locale });
   const url = `${API_BASE}?${params.toString()}`;
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, { headers: { 'X-Request-Source': 'milo-preflight' } });
     return { uuid, httpStatus: res.status, published: res.status === 200 };
   } catch {
     return { uuid, httpStatus: 0, published: false };
@@ -30,8 +31,7 @@ export async function checkFragmentPublished(uuid, locale) {
 
 function resolveLocale(locale) {
   if (locale) return locale;
-  const ietf = getConfig()?.locale?.ietf || 'en-US';
-  return ietf.replace('-', '_');
+  return getMiloLocaleSettings(getConfig()?.locale).locale;
 }
 
 export async function checkUnpublishedFragments({ area = document, locale } = {}) {

--- a/test/blocks/preflight/checks/merch.test.js
+++ b/test/blocks/preflight/checks/merch.test.js
@@ -75,16 +75,16 @@ describe('Preflight M@S Unpublished Fragments check', () => {
   });
 
   it('findFragmentElements keeps fragment whose direct parent is merch-card-collection inside a merch-card', () => {
-    const area = document.createElement('div');
+    const nestedArea = document.createElement('div');
     const UUID_INNER = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
-    area.innerHTML = `
+    nestedArea.innerHTML = `
       <merch-card>
         <merch-card-collection>
           <aem-fragment fragment="${UUID_INNER}"></aem-fragment>
         </merch-card-collection>
       </merch-card>
     `;
-    const entries = findFragmentElements(area);
+    const entries = findFragmentElements(nestedArea);
     expect(entries).to.have.length(1);
     expect(entries[0].uuid).to.equal(UUID_INNER);
   });

--- a/test/blocks/preflight/checks/merch.test.js
+++ b/test/blocks/preflight/checks/merch.test.js
@@ -1,5 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
+import { getConfig, updateConfig } from '../../../../libs/utils/utils.js';
 import {
   findFragmentElements,
   checkFragmentPublished,
@@ -31,6 +32,10 @@ function stubFetch() {
     if (id === UUID_UNPUBLISHED) return Promise.resolve({ status: 404 });
     return Promise.resolve({ status: 500 });
   });
+}
+
+function getCalledHeaders(fetchStub, callIndex = 0) {
+  return fetchStub.getCall(callIndex)?.args[1]?.headers ?? {};
 }
 
 describe('Preflight M@S Unpublished Fragments check', () => {
@@ -100,5 +105,25 @@ describe('Preflight M@S Unpublished Fragments check', () => {
     expect(url).to.include('api_key=wcms-commerce-ims-ro-user-milo');
     expect(url).to.include('locale=en_US');
     expect(url).to.include(`id=${UUID_PUBLISHED}`);
+  });
+
+  it('sends X-Request-Source: milo-preflight header', async () => {
+    await checkFragmentPublished(UUID_PUBLISHED, 'en_US');
+    const headers = getCalledHeaders(fetchStub);
+    expect(headers['X-Request-Source']).to.equal('milo-preflight');
+  });
+
+  it('resolves locale from getMiloLocaleSettings when no locale provided', async () => {
+    updateConfig({ ...getConfig(), locale: { prefix: '/de' } });
+    await checkUnpublishedFragments({ area });
+    const url = fetchStub.firstCall.args[0];
+    expect(url).to.include('locale=de_DE');
+  });
+
+  it('resolves es_PR for Puerto Rico prefix via getMiloLocaleSettings', async () => {
+    updateConfig({ ...getConfig(), locale: { prefix: '/pr' } });
+    await checkUnpublishedFragments({ area });
+    const url = fetchStub.firstCall.args[0];
+    expect(url).to.include('locale=es_PR');
   });
 });

--- a/test/blocks/preflight/checks/merch.test.js
+++ b/test/blocks/preflight/checks/merch.test.js
@@ -34,7 +34,6 @@ function stubFetch() {
   });
 }
 
-
 describe('Preflight M@S Unpublished Fragments check', () => {
   let area;
   let fetchStub;
@@ -55,6 +54,39 @@ describe('Preflight M@S Unpublished Fragments check', () => {
     expect(entries[0].card.tagName).to.equal('MERCH-CARD');
     expect(entries[1].uuid).to.equal(UUID_UNPUBLISHED);
     expect(entries[1].card.tagName).to.equal('MERCH-CARD');
+  });
+
+  it('findFragmentElements skips merch-card fragments inside a merch-card-collection', () => {
+    const collectionArea = document.createElement('div');
+    const UUID_COLLECTION = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const UUID_CARD_IN_COLLECTION = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+    collectionArea.innerHTML = `
+      <merch-card-collection>
+        <aem-fragment fragment="${UUID_COLLECTION}"></aem-fragment>
+        <merch-card>
+          <aem-fragment fragment="${UUID_CARD_IN_COLLECTION}"></aem-fragment>
+        </merch-card>
+      </merch-card-collection>
+    `;
+    const entries = findFragmentElements(collectionArea);
+    expect(entries).to.have.length(1);
+    expect(entries[0].uuid).to.equal(UUID_COLLECTION);
+    expect(entries[0].card.tagName).to.equal('MERCH-CARD-COLLECTION');
+  });
+
+  it('findFragmentElements keeps fragment whose direct parent is merch-card-collection inside a merch-card', () => {
+    const area = document.createElement('div');
+    const UUID_INNER = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+    area.innerHTML = `
+      <merch-card>
+        <merch-card-collection>
+          <aem-fragment fragment="${UUID_INNER}"></aem-fragment>
+        </merch-card-collection>
+      </merch-card>
+    `;
+    const entries = findFragmentElements(area);
+    expect(entries).to.have.length(1);
+    expect(entries[0].uuid).to.equal(UUID_INNER);
   });
 
   it('checkFragmentPublished returns published=true on 200', async () => {

--- a/test/blocks/preflight/checks/merch.test.js
+++ b/test/blocks/preflight/checks/merch.test.js
@@ -34,9 +34,6 @@ function stubFetch() {
   });
 }
 
-function getCalledHeaders(fetchStub, callIndex = 0) {
-  return fetchStub.getCall(callIndex)?.args[1]?.headers ?? {};
-}
 
 describe('Preflight M@S Unpublished Fragments check', () => {
   let area;
@@ -107,10 +104,10 @@ describe('Preflight M@S Unpublished Fragments check', () => {
     expect(url).to.include(`id=${UUID_PUBLISHED}`);
   });
 
-  it('sends X-Request-Source: milo-preflight header', async () => {
+  it('appends source=milo-preflight query param', async () => {
     await checkFragmentPublished(UUID_PUBLISHED, 'en_US');
-    const headers = getCalledHeaders(fetchStub);
-    expect(headers['X-Request-Source']).to.equal('milo-preflight');
+    const url = fetchStub.firstCall.args[0];
+    expect(url).to.include('source=milo-preflight');
   });
 
   it('resolves locale from getMiloLocaleSettings when no locale provided', async () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

 1. Skip card fragments inside collections — `findFragmentElements` now skips any `aem-fragment`      
  that's inside a `merch-card` which is itself inside a `merch-card-collection`. Collection hydration
  loads those cards; only the collection's own fragment needs to be checked, reducing unnecessary  
  `/mas/io` calls and 404 spikes.       
                                                           
  2. Fix `resolveLocale` — replaced `ietf.replace('-', '_')` with
  `getMiloLocaleSettings(getConfig().locale).locale` to match the locale resolution logic in `merch.js`
   (handles GeoMap lookups, langstore paths, and special cases like es_PR for /pr).

  3. Identify preflight requests — appends `source=milo-preflight` to all `/mas/io` requests so        
  preflight 404s can be filtered separately in Splunk. 

Resolves: [MWPW-195679](https://jira.corp.adobe.com/browse/MWPW-195679)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-195679--milo--adobecom.aem.page/?martech=off
- https://mwpw-195679--milo--adobecom.aem.page/drafts/mariia/document1

**Catalog Test URLs:**
- Before: https://main--cc--adobecom.aem.live/products/catalog
- After: https://main--cc--adobecom.aem.live/products/catalog?milolibs=mwpw-195679







