### PR TITLE
MWPW-191838: Add localFirstRecencyThreshold to CaaS sort config

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -605,10 +605,14 @@ const SortPanel = () => {
     ${state.sortEnableRandomSampling && RandomSampling}
   `;
 
+  const showRecencyThreshold = state.sortDefault === 'localFirst'
+    || (state.sortEnablePopup && state.sortLocalFirst);
+
   return html`
     <${Select} label="Default Sort Order" prop="sortDefault" options=${defaultOptions.sort} />
     <${Input} label="Enable Sort Popup" prop="sortEnablePopup" type="checkbox" />
     ${state.sortEnablePopup && SortOptions}
+    ${showRecencyThreshold && html`<${Input} label="Local Region Recency Threshold (months)" prop="sortLocalFirstRecencyThreshold" type="number" />`}
   `;
 };
 

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1151,6 +1151,10 @@ export const getConfig = async (originalState, strs = {}) => {
       enabled: state.sortEnablePopup,
       defaultSort: state.sortDefault,
       options: getSortOptions(state, strs),
+      ...((state.sortDefault === 'localFirst' || state.sortLocalFirst)
+        && state.sortLocalFirstRecencyThreshold !== null
+        ? { localFirstRecencyThreshold: state.sortLocalFirstRecencyThreshold }
+        : {}),
     },
     pagination: {
       animationStyle: navigationStyle,
@@ -1326,6 +1330,9 @@ export const defaultState = {
   sortEnableRandomSampling: false,
   sortEventSort: false,
   sortFeatured: false,
+  sortLocalFirst: false,
+  sortLocalFirstRecencyThreshold: null,
+  sortLocalLast: false,
   sortModifiedAsc: false,
   sortModifiedDesc: false,
   sortRandom: false,

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -723,6 +723,50 @@ describe('getConfig', () => {
       stageDomainsMap: { localhost: { 'www.adobe.com': 'stage.adobe.com', 'business.adobe.com': 'origin' } },
     })).to.eql({});
   });
+
+  describe('localFirstRecencyThreshold', () => {
+    it('is included in sort config when sortDefault is localFirst and threshold is set', async () => {
+      const localState = {
+        ...defaultState,
+        sortDefault: 'localFirst',
+        sortLocalFirstRecencyThreshold: 6,
+      };
+      const config = await getConfig(localState, strings);
+      expect(config.sort.localFirstRecencyThreshold).to.equal(6);
+    });
+
+    it('is included in sort config when sortLocalFirst popup option is checked and threshold is set', async () => {
+      const localState = {
+        ...defaultState,
+        sortEnablePopup: true,
+        sortLocalFirst: true,
+        sortLocalFirstRecencyThreshold: 3,
+      };
+      const config = await getConfig(localState, strings);
+      expect(config.sort.localFirstRecencyThreshold).to.equal(3);
+    });
+
+    it('is omitted from sort config when threshold is null', async () => {
+      const localState = {
+        ...defaultState,
+        sortDefault: 'localFirst',
+        sortLocalFirstRecencyThreshold: null,
+      };
+      const config = await getConfig(localState, strings);
+      expect(config.sort).to.not.have.property('localFirstRecencyThreshold');
+    });
+
+    it('is omitted from sort config when localFirst is not active', async () => {
+      const localState = {
+        ...defaultState,
+        sortDefault: 'dateDesc',
+        sortLocalFirst: false,
+        sortLocalFirstRecencyThreshold: 6,
+      };
+      const config = await getConfig(localState, strings);
+      expect(config.sort).to.not.have.property('localFirstRecencyThreshold');
+    });
+  });
 });
 
 describe('getCountryAndLang', () => {


### PR DESCRIPTION
## Summary
- Adds a "Local Region Recency Threshold (months)" number input to the CaaS Config sort panel, visible when `localFirst` is the active sort (either as the default sort or selected via popup)
- Wires `localFirstRecencyThreshold` into the `getConfig` sort output, only included when localFirst is active and the threshold is non-null
- Adds `sortLocalFirst`, `sortLocalFirstRecencyThreshold`, and `sortLocalLast` to `defaultState`
- Adds unit tests covering all inclusion/omission cases

## Jira Ticket
Resolves [MWPW-191838](https://jira.corp.adobe.com/browse/MWPW-191838)

## Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://MWPW-191838--milo--sheridansunier.aem.page/?martech=off

## Test plan
Use local overrides to replace the modified files as loaded by [milo.adobe.com/tools/caas](https://milo.adobe.com/tools/caas)
- [ ] In CaaS Config UI: set Default Sort to "Local First" → threshold input appears
- [ ] In CaaS Config UI: enable Sort Popup and check "Local First" → threshold input appears
- [ ] Verify `localFirstRecencyThreshold` is present in generated config JSON when set, absent when null or localFirst is inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

