### PR TITLE
MWPW-195844 Hide VAT labels from strikethrough pricing on milo cards

### DIFF
--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -135,3 +135,7 @@ a[is='checkout-link'].con-button > span {
   top: 50%; 
   transform: translate(-50%,-50%);
 }
+
+.price-strikethrough.price-labels-hidden span:is(.price-tax-inclusivity, .price-unit-type) {
+  display: none;
+}


### PR DESCRIPTION
Hide labels on ST prices when directly followed with promo price, some empty text in between is ignored.

Related MAS PR https://github.com/adobecom/mas/pull/899

Test pages https://mwpw195844--milo--bozojovicic.aem.page/drafts/bozo/st-prices?maslibs=MWPW-195844

https://main--da-cc--adobecom.aem.live/fr/cc-shared/fragments/merch/products/photoshop/mini-compare/creativecloud/individual/intro-pricing?maslibs=MWPW-195844&milolibs=mwpw195844--milo--bozojovicic

Resolves: [MWPW-195844](https://jira.corp.adobe.com/browse/MWPW-195844)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw195844--milo--bozojovicic.aem.page/?martech=off


