### PR TITLE
[MWPW-189253]: Fixed section metadata mobile gap.

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -274,10 +274,6 @@ main > .section[class*='-up'] > .content {
     order: 1;
   }
 
-  .section[class*='grid-width-'] {
-    display: block;
-  }
-
   .section:has(> .show-more-button),
   .section.show-all {
     margin-inline: 30px;

--- a/libs/blocks/tabs/tabs.css
+++ b/libs/blocks/tabs/tabs.css
@@ -640,6 +640,11 @@
 }
 
 @media screen and (max-width: 599px) {
+  /* grid-width display:grid breaks tablist on mobile */
+  .section[class*='grid-width-'][class*='tablist-'] {
+    display: block;
+  }
+
   .tabs.stacked-mobile .tabList {
     margin: 0;
   }


### PR DESCRIPTION
- This PR moves the mobile `grid-width-*` layout fix from `section-metadata.css` to `tabs.css` and scopes it specifically to tabs-related layouts.
- Previously, as part of [MWPW-165662](https://jira.corp.adobe.com/browse/MWPW-165662), a global mobile rule was added in section-metadata.css that forced all .grid-width-* sections to `display: block` below 600px. This helped fix the tabs + text layout issue on mobile, but it also impacted other layouts like editorial cards by breaking their grid structure.

**Changes:**
- Removed the global mobile override from: `milo/libs/blocks/section-metadata/section-metadata.css`
- Added tabs-specific mobile overrides in: `milo/libs/blocks/tabs/tabs.css`

**The new styles now apply only to:**
- tab host sections (tablist-*)
- grid-width-* sections inside tab panels

**Result:**
- Tabs + text layouts continue to work correctly on mobile
- Merch/plans and other grid-based layouts are no longer affected

Resolves: [MWPW-189253](https://jira.corp.adobe.com/browse/MWPW-189253)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/klee/jira-ticket/mwpw-189253-ups-gap-removed-10-col?martech=off
- After: https://mwpw-189253-section-gap--milo--hkuraware.aem.page/drafts/klee/jira-ticket/mwpw-189253-ups-gap-removed-10-col?martech=off

**Dev validation:**

**Before:-**
- <img width="811" height="718" alt="before-fix-quick-facts" src="https://github.com/user-attachments/assets/541e55f0-5551-446d-bb88-504968fc689c" />
- <img width="811" height="718" alt="before-fix-editorial-card" src="https://github.com/user-attachments/assets/86fa3cd0-f170-4fe0-a3c9-9faeea658166" />
- <img width="896" height="721" alt="before-fix-rtl" src="https://github.com/user-attachments/assets/94a48303-bca7-42f9-bf44-be115bcf2682" />
- <img width="1488" height="816" alt="before-fix-merch-card" src="https://github.com/user-attachments/assets/abe011d1-06b4-4a15-b457-1c6331c7e310" />

**After:-**
- <img width="811" height="718" alt="after-fix-quick-facts" src="https://github.com/user-attachments/assets/a2bee9c1-f92d-459d-ab11-8e26f93530c5" />
- <img width="811" height="718" alt="after-fix-editorial-card" src="https://github.com/user-attachments/assets/08ed6eff-07d8-40e7-ae3f-27f1373c4a88" />
- <img width="896" height="821" alt="after-fix-rtl" src="https://github.com/user-attachments/assets/e5332d5b-3a89-42a8-ac1c-9a606c5ba268" />
- <img width="1488" height="816" alt="after-fix-merch-card" src="https://github.com/user-attachments/assets/71bd4784-21fe-47c1-af13-24a069925069" />

