### PR TITLE
MWPW-187791 - removed global :target css from marquee-anchors

### DIFF
--- a/libs/blocks/marquee-anchors/marquee-anchors.css
+++ b/libs/blocks/marquee-anchors/marquee-anchors.css
@@ -2,13 +2,6 @@ html {
   scroll-behavior: smooth;
 }
 
-:target::before {
-  content: "";
-  display: block;
-  height: 100px;
-  margin: -100px 0 0;
-}
-
 .marquee-anchors {
   position: relative;
   padding: var(--spacing-s) 0;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2804,4 +2804,3 @@ export function loadLana(options = {}) {
 }
 
 export const reloadPage = () => window.location.reload();
-

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2804,3 +2804,4 @@ export function loadLana(options = {}) {
 }
 
 export const reloadPage = () => window.location.reload();
+


### PR DESCRIPTION
We noticed that the global `:target::before` rule from `marquee-anchors.css` seems to affect all section anchors on the page.
Because of the negative margin offset, it can block interactions with elements located in that area (for example buttons).
Since this already exists (done in this pr: https://github.com/adobecom/milo/pull/3714):
```
.section-anchor {
    scroll-margin-top: var(--global-height-nav);
}
```
the `:target::before` workaround looks potentially outdated.

Resolves: https://jira.corp.adobe.com/browse/MWPW-187791

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://marquee-anchors-scroll--milo--draganatrajkovic.aem.page/?martech=off

**Test URLs:**
- Before: https://main--da-dx-partners--adobecom.aem.page/digitalexperience/products/firefly?milolibs=main
- After: https://main--da-dx-partners--adobecom.aem.page/digitalexperience/products/firefly?milolibs=marquee-anchors-scroll--milo--draganatrajkovic

**Note:** Confirmed with Pat Vane that the Acrobat pages do not use `marquee-anchors`, so this PR should not affect or break any existing Acrobat page functionality.
