### PR TITLE
Add expand/collapse animations for FAQ block

### DIFF
--- a/libs/mep/ace1205/faq/faq.css
+++ b/libs/mep/ace1205/faq/faq.css
@@ -1,5 +1,6 @@
 .faq {
-  --faq-transition: 0.2s ease;
+  --faq-transition-duration: 400ms;
+  --faq-transition: var(--faq-transition-duration) var(--parallax-easing);
 
   position: relative;
 }
@@ -17,6 +18,26 @@
   .faq:hover &:not(:hover, [open]),
   .faq:focus-within &:not(:focus-within, [open]) {
     opacity: 0.6;
+  }
+
+  &::details-content {
+    content-visibility: visible;
+    display: block;
+    block-size: auto;
+  }
+
+  > .faq-panel {
+    display: grid;
+    grid-template-rows: 0fr;
+    visibility: hidden;
+    transition: grid-template-rows var(--faq-transition),
+      visibility 0s linear var(--faq-transition-duration);
+  }
+
+  &[open] > .faq-panel {
+    grid-template-rows: 1fr;
+    visibility: visible;
+    transition: grid-template-rows var(--faq-transition), visibility 0s linear 0s;
   }
 }
 
@@ -57,8 +78,13 @@
   }
 }
 
-.faq-panel {
-  padding-block-end: var(--s2a-spacing-xl);
+.faq-panel-inner {
+  min-block-size: 0;
+  overflow: hidden;
+
+  > *:last-child {
+    margin-block-end: var(--s2a-spacing-xl);
+  }
 
   :is(p, ul, ol) + :is(p, ul, ol) {
     margin-block-start: var(--s2a-spacing-xs);
@@ -68,5 +94,11 @@
 @media (width >= 768px) {
   .faq-panel {
     max-inline-size: calc(548 / 16 * 1rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .faq-item > .faq-panel {
+    transition: none;
   }
 }

--- a/libs/mep/ace1205/faq/faq.js
+++ b/libs/mep/ace1205/faq/faq.js
@@ -28,7 +28,8 @@ function buildItem(row, num, isFirst) {
     'daa-ll': `${isFirst ? 'close' : 'open'}-${num}--${processTrackingLabels(questionText)}`,
   }, [headingTag, icon]);
 
-  const panel = createTag('div', { class: 'faq-panel body-lg' }, answerNodes);
+  const panelInner = createTag('div', { class: 'faq-panel-inner' }, answerNodes);
+  const panel = createTag('div', { class: 'faq-panel body-lg' }, panelInner);
   const itemAttrs = { class: 'faq-item' };
   if (isFirst) itemAttrs.open = '';
   const details = createTag('details', itemAttrs, [summary, panel]);


### PR DESCRIPTION
Add animations to the FAQ block when items are expanded/collapsed.

Resolves: [MWPW-192891](https://jira.corp.adobe.com/browse/MWPW-192891)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=faq-block-anim&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


