### PR TITLE
MWPW-191003 M@S Errors Visible in aem.page 

### DIFF
--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -71,10 +71,10 @@ export async function checkReady(masElement, fragment) {
   if (isMasErrorEnv()) {
     const uuid = fragment ?? masElement.querySelector('aem-fragment')?.getAttribute('fragment');
     if (masElement.hasAttribute('failed')) {
-      createFragmentErrorEl(uuid, 'Frag').then((el) => masElement.insertAdjacentElement('beforebegin', el));
+      createFragmentErrorEl(uuid, 'Card').then((el) => masElement.insertAdjacentElement('beforebegin', el));
     } else {
       masElement.addEventListener('aem:error', async (e) => {
-        masElement.insertAdjacentElement('beforebegin', await createFragmentErrorEl(uuid, 'Frag', e.detail?.status));
+        masElement.insertAdjacentElement('beforebegin', await createFragmentErrorEl(uuid, 'Card', e.detail?.status));
       }, { once: true });
     }
   }

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -7,6 +7,8 @@ import {
   getOptions,
   overrideOptions,
   loadMasComponent,
+  createFragmentErrorEl,
+  isMasErrorEnv,
   COMMERCE_LIBRARY,
   MAS_MERCH_CARD,
   MAS_MERCH_QUANTITY_SELECT,
@@ -65,16 +67,29 @@ async function loadInlineDependencies() {
   await loadMasComponent(MAS_FIELD);
 }
 
-export async function checkReady(masElement) {
+export async function checkReady(masElement, fragment) {
+  if (isMasErrorEnv()) {
+    const showError = async () => {
+      const uuid = fragment ?? masElement.querySelector('aem-fragment')?.getAttribute('fragment');
+      masElement.insertAdjacentElement('beforebegin', await createFragmentErrorEl(uuid, 'Frag'));
+    };
+    if (masElement.hasAttribute('failed')) {
+      showError();
+    } else {
+      new MutationObserver(async (_, obs) => {
+        if (masElement.hasAttribute('failed')) {
+          obs.disconnect();
+          showError();
+        }
+      }).observe(masElement, { attributes: true, attributeFilter: ['failed'] });
+    }
+  }
+
   const readyPromise = masElement.checkReady();
   const success = await Promise.race([readyPromise, getTimeoutPromise()]);
   if (success === 'timeout') {
     log.error(`${masElement.tagName} did not initialize withing give timeout`);
   } else if (!success) {
-    const { env } = getConfig();
-    if (env.name !== 'prod') {
-      masElement.prepend(createTag('div', { }, 'Failed to load. Please check your VPN connection.'));
-    }
     log.error(`${masElement.tagName} failed to initialize`);
   }
 }
@@ -126,7 +141,7 @@ async function createJsonLd(el, options) {
   const aemFragment = createTag('aem-fragment', attrs);
   const merchCard = createTag('merch-card', { consonant: '', hidden: '' }, aemFragment);
   document.body.appendChild(merchCard);
-  await checkReady(merchCard);
+  await checkReady(merchCard, options.fragment);
   const fragmentEl = merchCard.querySelector('aem-fragment');
   const fields = fragmentEl?.data?.fields;
   const priceEl = merchCard.querySelector('[is="inline-price"][data-template="price"]')
@@ -157,7 +172,7 @@ export async function createCard(el, options) {
   } else {
     el.replaceWith(merchCard);
   }
-  await checkReady(merchCard);
+  await checkReady(merchCard, options.fragment);
   await postProcessAutoblock(merchCard, true);
 }
 
@@ -179,7 +194,7 @@ async function createInline(el, options) {
     masField.dataset.masBlock = 'inline';
   }
   el.replaceWith(masField);
-  await checkReady(masField);
+  await checkReady(masField, options.fragment);
   normalizeBlockFieldWrappers(masField);
 
   const content = masField.querySelector(':scope > [data-role="mas-field-content"]');

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -69,19 +69,13 @@ async function loadInlineDependencies() {
 
 export async function checkReady(masElement, fragment) {
   if (isMasErrorEnv()) {
-    const showError = async () => {
-      const uuid = fragment ?? masElement.querySelector('aem-fragment')?.getAttribute('fragment');
-      masElement.insertAdjacentElement('beforebegin', await createFragmentErrorEl(uuid, 'Frag'));
-    };
+    const uuid = fragment ?? masElement.querySelector('aem-fragment')?.getAttribute('fragment');
     if (masElement.hasAttribute('failed')) {
-      showError();
+      createFragmentErrorEl(uuid, 'Frag').then((el) => masElement.insertAdjacentElement('beforebegin', el));
     } else {
-      new MutationObserver(async (_, obs) => {
-        if (masElement.hasAttribute('failed')) {
-          obs.disconnect();
-          showError();
-        }
-      }).observe(masElement, { attributes: true, attributeFilter: ['failed'] });
+      masElement.addEventListener('aem:error', async (e) => {
+        masElement.insertAdjacentElement('beforebegin', await createFragmentErrorEl(uuid, 'Frag', e.detail?.status));
+      }, { once: true });
     }
   }
 

--- a/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
+++ b/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
@@ -9,6 +9,8 @@ import {
   overrideOptions,
   updateModalState,
   loadMasComponent,
+  createFragmentErrorEl,
+  isMasErrorEnv,
   MAS_MERCH_CARD,
   MAS_MERCH_QUANTITY_SELECT,
   MAS_MERCH_CARD_COLLECTION,
@@ -340,9 +342,8 @@ export async function createCollection(el, options) {
 
   const success = await collection.checkReady();
   if (!success) {
-    const { env } = getConfig();
-    if (env.name !== 'prod') {
-      collection.prepend(createTag('div', { }, 'Failed to load. Please check your VPN connection.'));
+    if (isMasErrorEnv()) {
+      collection.prepend(await createFragmentErrorEl(options.fragment, 'Collection'));
     }
   }
   container.classList.add('collection-container', collection.variant);

--- a/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
+++ b/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
@@ -340,11 +340,15 @@ export async function createCollection(el, options) {
     : el;
   toReplace.replaceWith(container);
 
+  if (isMasErrorEnv()) {
+    collection.addEventListener('aem:error', async (e) => {
+      collection.prepend(await createFragmentErrorEl(options.fragment, 'Collection', e.detail?.status));
+    }, { once: true });
+  }
+
   const success = await collection.checkReady();
-  if (!success) {
-    if (isMasErrorEnv()) {
-      collection.prepend(await createFragmentErrorEl(options.fragment, 'Collection'));
-    }
+  if (!success && isMasErrorEnv() && !collection.querySelector('.mas-frag-error')) {
+    collection.prepend(await createFragmentErrorEl(options.fragment, 'Collection'));
   }
   container.classList.add('collection-container', collection.variant);
 

--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -130,8 +130,52 @@ a[is='checkout-link'].con-button > span {
 .upgrade-flow-content sp-theme {
   width: max-content;
   height: max-content;
-  left: 50%; 
-  position: relative; 
-  top: 50%; 
+  left: 50%;
+  position: relative;
+  top: 50%;
   transform: translate(-50%,-50%);
+}
+
+.mas-frag-error {
+  position: relative;
+  border: 2px solid #c9444d;
+  border-radius: 8px;
+  padding: 24px 16px 16px;
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(201,68,77,.07) 0,
+    rgba(201,68,77,.07) 10px,
+    transparent 10px,
+    transparent 20px
+  );
+  text-align: center;
+  margin: 8px 0;
+  width: 300px;
+  height: 300px;
+}
+
+.mas-frag-error-badge {
+  position: absolute;
+  top: -1px;
+  right: 0;
+  background: #c9444d;
+  color: #fff;
+  font: bold 11px/1 sans-serif;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  padding: 6px 10px 5px;
+  border-radius: 0 6px;
+}
+
+.mas-frag-error-label {
+  font: bold 14px/1.4 sans-serif;
+  color: #333;
+  margin: 8px 0 4px;
+}
+
+.mas-frag-error-id {
+  font: 13px/1.4 monospace;
+  color: #777;
+  margin: 0;
+  word-break: break-all;
 }

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1594,10 +1594,12 @@ export function isMasErrorEnv(host = window.location.host) {
   return host.includes('localhost') || host.includes('.aem.page');
 }
 
-export async function createFragmentErrorEl(uuid, label = 'Frag') {
+export async function createFragmentErrorEl(uuid, label = 'Frag', status = null) {
   loadStyle(`${getConfig().base}/blocks/merch/merch.css`);
   let badge = 'Load Error';
-  if (uuid) {
+  if (status === 404) {
+    badge = 'Not Found';
+  } else if (uuid) {
     try {
       const { locale } = getMiloLocaleSettings(getConfig()?.locale);
       const source = isMasErrorEnv() ? '&source=aem' : '';

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1599,8 +1599,7 @@ export async function createFragmentErrorEl(uuid, label = 'Frag') {
   let badge = 'Load Error';
   if (uuid) {
     try {
-      const ietf = getConfig()?.locale?.ietf || 'en-US';
-      const locale = ietf.replace('-', '_');
+      const { locale } = getMiloLocaleSettings(getConfig()?.locale);
       const source = isMasErrorEnv() ? '&source=aem' : '';
       const res = await fetch(`${MAS_FRAGMENT_API}?id=${uuid}&api_key=${MAS_FRAGMENT_API_KEY}&locale=${locale}${source}`);
       if (res.status === 404) badge = 'Not Found';

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1594,7 +1594,7 @@ export function isMasErrorEnv(host = window.location.host) {
   return host.includes('localhost') || host.includes('.aem.page');
 }
 
-export async function createFragmentErrorEl(uuid, label = 'Frag', status = null) {
+export async function createFragmentErrorEl(uuid, label = 'Card', status = null) {
   loadStyle(`${getConfig().base}/blocks/merch/merch.css`);
   let badge = 'Load Error';
   if (status === 404) {

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1594,58 +1594,8 @@ export function isMasErrorEnv(host = window.location.host) {
   return host.includes('localhost') || host.includes('.aem.page');
 }
 
-let masErrorStylesInjected = false;
-function injectMasErrorStyles() {
-  if (masErrorStylesInjected) return;
-  masErrorStylesInjected = true;
-  const style = document.createElement('style');
-  style.textContent = `
-    .mas-frag-error {
-      position: relative;
-      border: 2px solid #c9444d;
-      border-radius: 8px;
-      padding: 24px 16px 16px;
-      background-image: repeating-linear-gradient(
-        45deg,
-        rgba(201,68,77,.07) 0,
-        rgba(201,68,77,.07) 10px,
-        transparent 10px,
-        transparent 20px
-      );
-      text-align: center;
-      margin: 8px 0;
-      width: 300px;
-      height: 300px;
-    }
-    .mas-frag-error-badge {
-      position: absolute;
-      top: -1px;
-      right: 0;
-      background: #c9444d;
-      color: #fff;
-      font: bold 11px/1 sans-serif;
-      letter-spacing: .06em;
-      text-transform: uppercase;
-      padding: 6px 10px 5px;
-      border-radius: 0 6px;
-    }
-    .mas-frag-error-label {
-      font: bold 14px/1.4 sans-serif;
-      color: #333;
-      margin: 8px 0 4px;
-    }
-    .mas-frag-error-id {
-      font: 13px/1.4 monospace;
-      color: #777;
-      margin: 0;
-      word-break: break-all;
-    }
-  `;
-  document.head.appendChild(style);
-}
-
 export async function createFragmentErrorEl(uuid, label = 'Frag') {
-  injectMasErrorStyles();
+  loadStyle(`${getConfig().base}/blocks/merch/merch.css`);
   let badge = 'Load Error';
   if (uuid) {
     try {

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1587,6 +1587,83 @@ export default async function init(el) {
   return null;
 }
 
+const MAS_FRAGMENT_API = 'https://www.adobe.com/mas/io/fragment';
+const MAS_FRAGMENT_API_KEY = 'wcms-commerce-ims-ro-user-milo';
+
+export function isMasErrorEnv(host = window.location.host) {
+  return host.includes('localhost') || host.includes('.aem.page');
+}
+
+let masErrorStylesInjected = false;
+function injectMasErrorStyles() {
+  if (masErrorStylesInjected) return;
+  masErrorStylesInjected = true;
+  const style = document.createElement('style');
+  style.textContent = `
+    .mas-frag-error {
+      position: relative;
+      border: 2px solid #c9444d;
+      border-radius: 8px;
+      padding: 24px 16px 16px;
+      background-image: repeating-linear-gradient(
+        45deg,
+        rgba(201,68,77,.07) 0,
+        rgba(201,68,77,.07) 10px,
+        transparent 10px,
+        transparent 20px
+      );
+      text-align: center;
+      margin: 8px 0;
+      width: 300px;
+      height: 300px;
+    }
+    .mas-frag-error-badge {
+      position: absolute;
+      top: -1px;
+      right: 0;
+      background: #c9444d;
+      color: #fff;
+      font: bold 11px/1 sans-serif;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      padding: 6px 10px 5px;
+      border-radius: 0 6px;
+    }
+    .mas-frag-error-label {
+      font: bold 14px/1.4 sans-serif;
+      color: #333;
+      margin: 8px 0 4px;
+    }
+    .mas-frag-error-id {
+      font: 13px/1.4 monospace;
+      color: #777;
+      margin: 0;
+      word-break: break-all;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export async function createFragmentErrorEl(uuid, label = 'Frag') {
+  injectMasErrorStyles();
+  let badge = 'Load Error';
+  if (uuid) {
+    try {
+      const ietf = getConfig()?.locale?.ietf || 'en-US';
+      const locale = ietf.replace('-', '_');
+      const source = isMasErrorEnv() ? '&source=aem' : '';
+      const res = await fetch(`${MAS_FRAGMENT_API}?id=${uuid}&api_key=${MAS_FRAGMENT_API_KEY}&locale=${locale}${source}`);
+      if (res.status === 404) badge = 'Not Found';
+    } catch { /* network error */ }
+  }
+  const el = createTag('div', { class: 'mas-frag-error' });
+  const badgeEl = createTag('span', { class: 'mas-frag-error-badge' }, badge);
+  const labelEl = createTag('p', { class: 'mas-frag-error-label' }, `${label}:`);
+  const idEl = createTag('p', { class: 'mas-frag-error-id' }, uuid || 'unknown');
+  el.append(badgeEl, labelEl, idEl);
+  return el;
+}
+
 window.addEventListener('hashchange', updateModalState);
 
 window.addEventListener('popstate', updateModalState);

--- a/libs/blocks/preflight/checks/merch.js
+++ b/libs/blocks/preflight/checks/merch.js
@@ -18,7 +18,7 @@ export function findFragmentElements(area = document) {
 }
 
 export async function checkFragmentPublished(uuid, locale) {
-  const params = new URLSearchParams({ id: uuid, api_key: API_KEY, locale });
+  const params = new URLSearchParams({ id: uuid, api_key: API_KEY, locale, source: 'preflight' });
   const url = `${API_BASE}?${params.toString()}`;
   try {
     const res = await fetch(url);

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -1,6 +1,7 @@
 import { CheckoutWorkflowStep, Defaults, Log } from '@adobecom/mas-platform/web-components/dist/commerce.js';
 
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 import { delay } from '../../helpers/waitfor.js';
 
 import { mepMasStudioUrls } from '../../../libs/blocks/merch/mas-mep-utils.js';
@@ -35,6 +36,8 @@ import merch, {
   getMasLibsBaseUrl,
   getMasLibs,
   shouldHideStPriceLabels,
+  isMasErrorEnv,
+  createFragmentErrorEl,
 } from '../../../libs/blocks/merch/merch.js';
 import { decorateCardCtasWithA11y, localizePreviewLinks } from '../../../libs/blocks/merch/autoblock.js';
 
@@ -1703,5 +1706,69 @@ describe('Merch Block', () => {
       window.history.pushState({}, '', '/?maslibs=feature-branch');
       expect(getMasLibs()).to.equal('https://feature-branch--mas--adobecom.aem.live/web-components/dist');
     });
+  });
+});
+
+describe('isMasErrorEnv', () => {
+  it('returns true for localhost', () => {
+    expect(isMasErrorEnv('localhost:6456')).to.be.true;
+  });
+
+  it('returns true for aem.page', () => {
+    expect(isMasErrorEnv('main--milo--adobecom.aem.page')).to.be.true;
+  });
+
+  it('returns false for aem.live', () => {
+    expect(isMasErrorEnv('main--milo--adobecom.aem.live')).to.be.false;
+  });
+
+  it('returns false for stage.adobe.com', () => {
+    expect(isMasErrorEnv('stage.adobe.com')).to.be.false;
+  });
+
+  it('returns false for www.adobe.com', () => {
+    expect(isMasErrorEnv('www.adobe.com')).to.be.false;
+  });
+});
+
+describe('createFragmentErrorEl', () => {
+  let fetchStub;
+
+  afterEach(() => {
+    fetchStub?.restore();
+  });
+
+  it('shows Not Found badge when fragment API returns 404', async () => {
+    fetchStub = sinon.stub(window, 'fetch').resolves(new Response('', { status: 404 }));
+    const el = await createFragmentErrorEl('test-uuid', 'Frag');
+    expect(el.classList.contains('mas-frag-error')).to.be.true;
+    expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Not Found');
+    expect(el.querySelector('.mas-frag-error-label').textContent).to.equal('Frag:');
+    expect(el.querySelector('.mas-frag-error-id').textContent).to.equal('test-uuid');
+  });
+
+  it('shows Load Error badge when fragment API returns non-404', async () => {
+    fetchStub = sinon.stub(window, 'fetch').resolves(new Response('', { status: 500 }));
+    const el = await createFragmentErrorEl('test-uuid', 'Frag');
+    expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Load Error');
+  });
+
+  it('shows Load Error badge when fetch throws', async () => {
+    fetchStub = sinon.stub(window, 'fetch').rejects(new Error('network error'));
+    const el = await createFragmentErrorEl('test-uuid', 'Frag');
+    expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Load Error');
+  });
+
+  it('uses Collection label for collections', async () => {
+    fetchStub = sinon.stub(window, 'fetch').resolves(new Response('', { status: 404 }));
+    const el = await createFragmentErrorEl('some-collection', 'Collection');
+    expect(el.querySelector('.mas-frag-error-label').textContent).to.equal('Collection:');
+    expect(el.querySelector('.mas-frag-error-id').textContent).to.equal('some-collection');
+  });
+
+  it('shows unknown when uuid is not provided', async () => {
+    const el = await createFragmentErrorEl(null, 'Frag');
+    expect(el.querySelector('.mas-frag-error-id').textContent).to.equal('unknown');
+    expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Load Error');
   });
 });

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -1740,22 +1740,22 @@ describe('createFragmentErrorEl', () => {
 
   it('shows Not Found badge when fragment API returns 404', async () => {
     fetchStub = sinon.stub(window, 'fetch').resolves(new Response('', { status: 404 }));
-    const el = await createFragmentErrorEl('test-uuid', 'Frag');
+    const el = await createFragmentErrorEl('test-uuid', 'Card');
     expect(el.classList.contains('mas-frag-error')).to.be.true;
     expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Not Found');
-    expect(el.querySelector('.mas-frag-error-label').textContent).to.equal('Frag:');
+    expect(el.querySelector('.mas-frag-error-label').textContent).to.equal('Card:');
     expect(el.querySelector('.mas-frag-error-id').textContent).to.equal('test-uuid');
   });
 
   it('shows Load Error badge when fragment API returns non-404', async () => {
     fetchStub = sinon.stub(window, 'fetch').resolves(new Response('', { status: 500 }));
-    const el = await createFragmentErrorEl('test-uuid', 'Frag');
+    const el = await createFragmentErrorEl('test-uuid', 'Card');
     expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Load Error');
   });
 
   it('shows Load Error badge when fetch throws', async () => {
     fetchStub = sinon.stub(window, 'fetch').rejects(new Error('network error'));
-    const el = await createFragmentErrorEl('test-uuid', 'Frag');
+    const el = await createFragmentErrorEl('test-uuid', 'Card');
     expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Load Error');
   });
 
@@ -1767,14 +1767,14 @@ describe('createFragmentErrorEl', () => {
   });
 
   it('shows unknown when uuid is not provided', async () => {
-    const el = await createFragmentErrorEl(null, 'Frag');
+    const el = await createFragmentErrorEl(null, 'Card');
     expect(el.querySelector('.mas-frag-error-id').textContent).to.equal('unknown');
     expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Load Error');
   });
 
   it('shows Not Found when status 404 is passed directly without fetching', async () => {
     fetchStub = sinon.stub(window, 'fetch');
-    const el = await createFragmentErrorEl('test-uuid', 'Frag', 404);
+    const el = await createFragmentErrorEl('test-uuid', 'Card', 404);
     expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Not Found');
     expect(fetchStub.called).to.be.false;
   });

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -1771,4 +1771,11 @@ describe('createFragmentErrorEl', () => {
     expect(el.querySelector('.mas-frag-error-id').textContent).to.equal('unknown');
     expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Load Error');
   });
+
+  it('shows Not Found when status 404 is passed directly without fetching', async () => {
+    fetchStub = sinon.stub(window, 'fetch');
+    const el = await createFragmentErrorEl('test-uuid', 'Frag', 404);
+    expect(el.querySelector('.mas-frag-error-badge').textContent).to.equal('Not Found');
+    expect(fetchStub.called).to.be.false;
+  });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

On `aem.page` users will now see more accurate errors states for m@s fragments 
Call made to `mas/io` will also have a `source` query param to help declutter logs. They values will be either `preflight` or `aem`. These will only come from `aem.page` pages where preflight can run. 

DA (aem.page) - https://main--upp--adobecom.aem.page/drafts/gunn/pre-mas-error?milolibs=MWPW-191003
SP (aem.page)  - https://mwpw-191003--milo--adobecom.aem.page/drafts/mariia/card404

Before:
Only a message for the collection; cards fail silently. 
<img width="1474" height="685" alt="image" src="https://github.com/user-attachments/assets/17f04e7e-f5a4-4ae8-a37a-f82dd94dc7fd" />

After:
<img width="910" height="1301" alt="image" src="https://github.com/user-attachments/assets/aadbb9c6-fe6c-4bf9-91ea-61d6ad7d7166" />


Resolves: [MWPW-191003](https://jira.corp.adobe.com/browse/MWPW-191003)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-191003--milo--adobecom.aem.page/?martech=off












