### PR TITLE
[SR] - Add not support query for js animation z index

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1005,8 +1005,10 @@ span.hang-opening-quote {
 }
 
 /* Needed for garage door JS animation in browsers without animation-timeline support */
-.section:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
-  z-index: 1;
+@supports not (animation-timeline: view()) {
+  .section:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
+    z-index: 1;
+  }
 }
 
 /* TODO: Parallax styles should be loaded separately and conditionally */


### PR DESCRIPTION
Fixes situation where block before Jump links goes over it but not visually.

https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=local&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

<img width="1512" height="420" alt="Screenshot 2026-05-28 at 11 24 02" src="https://github.com/user-attachments/assets/9d3f2ff2-458b-4c73-bce0-bb7e16ea1c58" />



