### PR TITLE
Add scrim style for section metadata

### DIFF
--- a/libs/c2/blocks/section-metadata/section-metadata.css
+++ b/libs/c2/blocks/section-metadata/section-metadata.css
@@ -98,6 +98,28 @@
   }
 }
 
+.section.scrim .section-background {
+  &::after {
+    --scrim-stop: 80%;
+    --scrim-dir: right;
+
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(
+      to var(--scrim-dir),
+      rgb(0 0 0 / 60%) var(--scrim-stop),
+      rgb(0 0 0 / 40%) calc((var(--scrim-stop) + 100%) / 2),
+      transparent
+    );
+    pointer-events: none;
+  }
+
+  [dir='rtl'] &::after {
+    --scrim-dir: left;
+  }
+}
+
 /* mobile only */
 @media (width < 768px) {
   .section-background .mobile-only {
@@ -106,6 +128,10 @@
 
   .section[class*='grid-width-'] {
     display: block;
+  }
+
+  .section.scrim .section-background::after {
+    --scrim-stop: 60%;
   }
 }
 

--- a/libs/c2/blocks/section-metadata/section-metadata.js
+++ b/libs/c2/blocks/section-metadata/section-metadata.js
@@ -117,7 +117,7 @@ function handleMasonry(text, section) {
 
   section.classList.add('masonry-layout');
   if (spanSets.length > 1) section.classList.add('masonry-responsive');
-  const divs = [...section.querySelectorAll(":scope > div:not([class*='metadata'])")];
+  const divs = [...section.querySelectorAll(":scope > div:not([class*='metadata']):not(.section-background)")];
 
   const applySpans = (spans) => {
     divs.forEach((div, i) => {

--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -182,6 +182,28 @@
   }
 }
 
+.section.scrim .section-background {
+  &::after {
+    --scrim-stop: 80%;
+    --scrim-dir: right;
+
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(
+      to var(--scrim-dir),
+      rgb(0 0 0 / 60%) var(--scrim-stop),
+      rgb(0 0 0 / 40%) calc((var(--scrim-stop) + 100%) / 2),
+      transparent
+    );
+    pointer-events: none;
+  }
+
+  [dir='rtl'] &::after {
+    --scrim-dir: left;
+  }
+}
+
 /* mobile only */
 @media (width < 768px) {
   .section-background .mobile-only {
@@ -225,6 +247,10 @@
         }
       }
     }
+  }
+
+  .section.scrim .section-background::after {
+    --scrim-stop: 60%;
   }
 }
 

--- a/libs/mep/ace1205/section-metadata/section-metadata.js
+++ b/libs/mep/ace1205/section-metadata/section-metadata.js
@@ -117,7 +117,7 @@ function handleMasonry(text, section) {
 
   section.classList.add('masonry-layout');
   if (spanSets.length > 1) section.classList.add('masonry-responsive');
-  const divs = [...section.querySelectorAll(":scope > div:not([class*='metadata'], .section-background)")];
+  const divs = [...section.querySelectorAll(":scope > div:not([class*='metadata']):not(.section-background)")];
 
   const applySpans = (spans) => {
     divs.forEach((div, i) => {


### PR DESCRIPTION
Add the possibility of using a scrim over a background image set through section metadata.

Resolves: [MWPW-192888](https://jira.corp.adobe.com/browse/MWPW-192888)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=site-redesign-foundation
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=global-scrim-style






