### PR TITLE
MWPW-195844 Hide VAT labels from strikethrough pricing on milo cards

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1510,10 +1510,29 @@ export async function buildCta(el, params) {
   return cta;
 }
 
+export async function shouldHideStPriceLabels(element) {
+  const nextElSibling = element.nextElementSibling?.nodeName === 'BR'
+    ? element.nextElementSibling.nextElementSibling
+    : element.nextElementSibling;
+
+  const href = nextElSibling?.getAttribute('href');
+  return !!(
+    (element.nextSibling?.nodeName !== '#text'
+      || element.nextSibling.textContent.trim().length < 2)
+    && href?.match('/tools/ost[?]osi=.*type=price')
+  );
+}
+
 async function buildPrice(el, params) {
   const context = await getPriceContext(el, params);
   if (!context) return null;
   const service = await initService();
+
+  if (context.template === 'strikethrough' && await shouldHideStPriceLabels(el)) {
+    context.displayPerUnit = 'false';
+    context.displayTax = 'false';
+  }
+
   const price = service.createInlinePrice(context);
   return price;
 }

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1510,7 +1510,7 @@ export async function buildCta(el, params) {
   return cta;
 }
 
-export async function shouldHideStPriceLabels(element) {
+export function shouldHideStPriceLabels(element) {
   const nextElSibling = element.nextElementSibling?.nodeName === 'BR'
     ? element.nextElementSibling.nextElementSibling
     : element.nextElementSibling;
@@ -1528,7 +1528,7 @@ async function buildPrice(el, params) {
   if (!context) return null;
   const service = await initService();
 
-  if (context.template === 'strikethrough' && await shouldHideStPriceLabels(el)) {
+  if (context.template === 'strikethrough' && shouldHideStPriceLabels(el)) {
     context.displayPerUnit = 'false';
     context.displayTax = 'false';
   }

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -34,6 +34,7 @@ import merch, {
   getMasComponentUrl,
   getMasLibsBaseUrl,
   getMasLibs,
+  shouldHideStPriceLabels,
 } from '../../../libs/blocks/merch/merch.js';
 import { decorateCardCtasWithA11y, localizePreviewLinks } from '../../../libs/blocks/merch/autoblock.js';
 
@@ -403,6 +404,78 @@ describe('Merch Block', () => {
       expect(renderedEl.dataset.masBlock).to.equal(undefined);
       expect(mepMasStudioUrls.get(renderedEl)).to.equal(undefined);
       wrap.remove();
+    });
+
+    it('should hide ST price labels with promo price right after', async () => {
+      const div = document.createElement('div');
+      const elementST = document.createElement('a');
+      elementST.setAttribute('href', 'https://milo.adobe.com/tools/ost?osi=xxx&type=strikethrough');
+      elementST.setAttribute('class', 'my-price');
+      div.append(elementST);
+      const element = document.createElement('a');
+      element.setAttribute('href', 'https://milo.adobe.com/tools/ost?osi=xxx&type=price');
+      div.append(element);
+      document.body.appendChild(div);
+      const hide = await shouldHideStPriceLabels(document.body.querySelector('.my-price'));
+      expect(hide).to.be.true;
+    });
+
+    it('should hide ST price labels with promo price right after and character between', async () => {
+      const div = document.createElement('div');
+      const elementST = document.createElement('a');
+      elementST.setAttribute('href', 'https://milo.adobe.com/tools/ost?osi=xxx&type=strikethrough');
+      elementST.setAttribute('class', 'my-price2');
+      div.append(elementST);
+      const text = document.createTextNode('* ');
+      div.append(text);
+      const element = document.createElement('a');
+      element.setAttribute('href', 'https://milo.adobe.com/tools/ost?osi=xxx&type=price');
+      div.append(element);
+      document.body.appendChild(div);
+      const hide = await shouldHideStPriceLabels(document.body.querySelector('.my-price2'));
+      expect(hide).to.be.true;
+    });
+
+    it('should not hide ST price labels without promo price', async () => {
+      const div = document.createElement('div');
+      const elementST = document.createElement('a');
+      elementST.setAttribute('href', 'https://milo.adobe.com/tools/ost?osi=xxx&type=strikethrough');
+      elementST.setAttribute('class', 'my-price3');
+      div.append(elementST);
+      document.body.appendChild(div);
+      const hide = await shouldHideStPriceLabels(document.body.querySelector('.my-price3'));
+      expect(hide).to.be.false;
+    });
+
+    it('should not hide ST price labels without promo price right after', async () => {
+      const div = document.createElement('div');
+      const elementST = document.createElement('a');
+      elementST.setAttribute('href', 'https://milo.adobe.com/tools/ost?osi=xxx&type=strikethrough');
+      elementST.setAttribute('class', 'my-price4');
+      div.append(elementST);
+      const elementI = document.createElement('i');
+      div.append(elementI);
+      const element = document.createElement('a');
+      element.setAttribute('href', 'https://milo.adobe.com/tools/ost?osi=xxx&type=price');
+      div.append(element);
+      document.body.appendChild(div);
+      const hide = await shouldHideStPriceLabels(document.body.querySelector('.my-price4'));
+      expect(hide).to.be.false;
+    });
+    it('should not hide ST price labels with some link right after', async () => {
+      const div = document.createElement('div');
+      const elementST = document.createElement('a');
+      elementST.setAttribute('href', 'https://milo.adobe.com/tools/ost?osi=xxx&type=strikethrough');
+      elementST.setAttribute('class', 'my-price4');
+      div.append(elementST);
+      const elementI = document.createElement('i');
+      div.append(elementI);
+      const element = document.createElement('a');
+      element.setAttribute('href', 'https://www.adobe.com/plans');
+      div.append(element);
+      document.body.appendChild(div);
+      const hide = await shouldHideStPriceLabels(document.body.querySelector('.my-price4'));
+      expect(hide).to.be.false;
     });
   });
 


### PR DESCRIPTION
Hide labels on ST prices when directly followed with promo price, some empty text in between is ignored.

Test page https://mwpw195844x--milo--bozojovicic.aem.page/fr/drafts/bozo/sticky-banner?maslibs=MWPW-195844

Resolves: [MWPW-195844](https://jira.corp.adobe.com/browse/MWPW-195844)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw195844x--milo--bozojovicic.aem.page/?martech=off




