### PR TITLE
[SR] Bento variant addition and VQA 

### DIFF
--- a/libs/mep/ace1205/explore-card/explore-card.css
+++ b/libs/mep/ace1205/explore-card/explore-card.css
@@ -117,7 +117,7 @@
     margin-bottom: var(--s2a-spacing-2xl);
   }
 
-  [class*='title-'] {
+  [class*='heading-'] {
     margin-top: auto;
     margin-bottom: var(--s2a-spacing-xs);
   }

--- a/libs/mep/ace1205/explore-card/explore-card.js
+++ b/libs/mep/ace1205/explore-card/explore-card.js
@@ -15,7 +15,7 @@ function getForegroundContent(foregroundRow, contentDiv, blockName) {
   }
 }
 
-function decorate(block, root) {
+function decorate(block, root, el) {
   const blockName = root.classList[0].toLowerCase();
   const rows = block.querySelectorAll(':scope > div');
   const firstRow = rows[0];
@@ -59,11 +59,15 @@ function decorate(block, root) {
 
   if (!link) return;
   const linkContainer = createTag('a', { class: `${blockName}-link-container`, href: link.href, 'data-tracking-label': heading?.textContent });
-  link.remove();
+  if (!el.classList.contains('show-link')) link.remove();
+  if (el.classList.contains('show-link')) {
+    link.classList.add('standalone-link', 'label');
+    link.setAttribute('tabindex', '-1');
+  }
   linkContainer.append(contentDiv);
   firstRow.prepend(linkContainer);
 }
 
 export default function init(el) {
-  decorateViewportContent(el, decorate);
+  decorateViewportContent(el, (block, root) => decorate(block, root, el));
 }

--- a/libs/mep/ace1205/explore-card/explore-card.js
+++ b/libs/mep/ace1205/explore-card/explore-card.js
@@ -59,11 +59,10 @@ function decorate(block, root, el) {
 
   if (!link) return;
   const linkContainer = createTag('a', { class: `${blockName}-link-container`, href: link.href, 'data-tracking-label': heading?.textContent });
-  if (!el.classList.contains('show-link')) link.remove();
   if (el.classList.contains('show-link')) {
     link.classList.add('standalone-link', 'label');
     link.setAttribute('tabindex', '-1');
-  }
+  } else link.remove();
   linkContainer.append(contentDiv);
   firstRow.prepend(linkContainer);
 }

--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -103,6 +103,7 @@
 
     .explore-card-foreground {
       aspect-ratio: 1 / 1.2;
+      transition: filter 0.3s ease-in-out, transform 0.3s ease-out;
 
       img {
         object-fit: cover;
@@ -186,6 +187,12 @@
 
     &:hover {
       color: inherit;
+
+      &+ .explore-card-background,
+      & .explore-card-foreground {
+        filter: brightness(0.98);
+        transform: scale(1.015);
+      }
     }
   }
 
@@ -195,6 +202,7 @@
   }
 
   &.bento .explore-card-background {
+    transition: filter 0.3s ease-in-out, transform 0.3s ease-out;
     img,
     .video-container {
       opacity: 1;

--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -69,15 +69,6 @@
     color: inherit;
   }
 
-  &.bento .explore-card {
-    border-radius: var(--s2a-border-radius-md);
-    z-index: inherit;
-
-    .explore-card-container:hover [class*='body-'] {
-      opacity: initial;
-    }
-  }
-
   &.bento .explore-card-content {
     padding-inline: 0;
     padding-bottom: var(--s2a-spacing-xl);
@@ -137,6 +128,7 @@
       }
     }
   }
+  
 
   &.bento .scrim {
     .explore-card-content {
@@ -170,6 +162,24 @@
 
       .content-aux {
         aspect-ratio: 1.02 / 1;
+      }
+    }
+  }
+
+  &.bento .explore-card {
+    border-radius: var(--s2a-border-radius-md);
+    z-index: inherit;
+
+    .explore-card-container:hover [class*='body-'] {
+      opacity: initial;
+    }
+
+    &.center {
+      .explore-card-content {
+        [class*='body-'],
+        [class*='heading-'] {
+          max-width: 370px;
+        }
       }
     }
   }

--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -65,19 +65,13 @@
     grid-auto-rows: initial;
   }
 
+  &.bento .dark .explore-card-content [class*='body-'] {
+    color: inherit;
+  }
+
   &.bento .explore-card {
     border-radius: var(--s2a-border-radius-md);
     z-index: inherit;
-
-    &.dark {
-      .explore-card-content::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background: linear-gradient(180deg, rgba(0 0 0 / 0%) 60.93%, rgba(0 0 0 / 59%) 90%);
-        z-index: 1;
-      }
-    }
 
     .explore-card-container:hover [class*='body-'] {
       opacity: initial;
@@ -89,16 +83,9 @@
     padding-bottom: var(--s2a-spacing-xl);
     padding-top: 0;
 
-    &::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(180deg, rgba(255 255 255 / 0%) 60.93%, rgba(255 255 255 / 59%) 90%);
-      z-index: 1;
-    }
-
     & [class*='heading-'] {
       z-index: 1;
+      margin-bottom: var(--s2a-spacing-2xs);
     }
 
     & [class*='body-'] {
@@ -106,15 +93,12 @@
       margin-bottom: 0;
       opacity: 1;
       z-index: 1;
+      color: var(--s2a-color-content-body-subtle);
     }
 
     [class*='heading-'],
     [class*='body-'] {
       padding-inline: var(--s2a-spacing-xl);
-    }
-
-    > :nth-child(1):not(img):not(video) {
-      margin-bottom: var(--s2a-spacing-xs);
     }
 
     .explore-card-foreground {
@@ -137,6 +121,28 @@
       height: auto;
       order: -1;
       width: 100%;
+    }
+  }
+
+  &.bento .scrim {
+    .explore-card-content {
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(180deg, rgba(255 255 255 / 0%) 60.93%, rgba(255 255 255 / 59%) 90%);
+        z-index: 1;
+      }
+    }
+
+    &.dark {
+      .explore-card-content::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(180deg, rgba(0 0 0 / 0%) 60.93%, rgba(0 0 0 / 59%) 90%);
+        z-index: 1;
+      }
     }
   }
 
@@ -236,7 +242,7 @@
       }
 
       .content-aux {
-        aspect-ratio: 1 / 0.8;
+        aspect-ratio: 1 / 0.88;
       }
     }
 
@@ -248,7 +254,7 @@
 
         [class*='heading-'],
         [class*='body-'] {
-          width: 50vw;
+          max-width: 450px;
         }
       }
     }

--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -69,6 +69,16 @@
     border-radius: var(--s2a-border-radius-md);
     z-index: inherit;
 
+    &.dark {
+      .explore-card-content::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(180deg, rgba(0 0 0 / 0%) 60.93%, rgba(0 0 0 / 59%) 90%);
+        z-index: 1;
+      }
+    }
+
     .explore-card-container:hover [class*='body-'] {
       opacity: initial;
     }
@@ -78,6 +88,14 @@
     padding-inline: 0;
     padding-bottom: var(--s2a-spacing-xl);
     padding-top: 0;
+
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(180deg, rgba(255 255 255 / 0%) 60.93%, rgba(255 255 255 / 59%) 90%);
+      z-index: 1;
+    }
 
     & [class*='heading-'] {
       z-index: 1;
@@ -102,9 +120,13 @@
     .explore-card-foreground {
       aspect-ratio: 1 / 1.2;
 
-      img,
-      video {
+      img {
         object-fit: cover;
+        object-position: top;
+      }
+
+      video {
+        object-fit: contain;
         object-position: top;
       }
     }
@@ -222,6 +244,11 @@
       .explore-card-content {
         .content-aux {
           aspect-ratio: 4 / 1.65;
+        }
+
+        [class*='heading-'],
+        [class*='body-'] {
+          width: 50vw;
         }
       }
     }

--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -122,6 +122,19 @@
       order: -1;
       width: 100%;
     }
+
+    .standalone-link {
+      display: inline-block;
+      text-decoration: none;
+      color: var(--s2a-color-content-label);
+      margin-top: var(--s2a-spacing-md);
+
+      &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+      }
+    }
   }
 
   &.bento .scrim {
@@ -160,7 +173,21 @@
     }
   }
 
-  &.bento .explore-card-link-container:hover { color: inherit; }
+  &.bento .explore-card-link-container {
+    box-sizing: border-box;
+
+    &:focus-visible {
+      border: 2px solid var(--color-accent-focus-ring);
+      outline-offset: none;
+      border-radius: var(--s2a-border-radius-16);
+      box-sizing: border-box;
+      overflow: clip;
+    }
+
+    &:hover {
+      color: inherit;
+    }
+  }
 
   &.bento .explore-card-link-container::before,
   &:has(.bento .explore-card-link-container:focus-visible) .explore-card-link-container::before {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added scrim variant to enable per bento block - fine tuned for bento block (`scrim`). 
* Set `max-width` for tablet up on body copy in bentos using `full-width grid` setting.
* Set `max-width` for body and heading copy in bentos using `center` variant.
* Added new variant to show link text as an option for bentos with links (`show-link`).
* Added new hover for `show-link` variant (tint, image scale).
* Fixed tabbing focus-ring issue noted by QA.
* Addressing VQA feedback (spacing, body color, adjust aspect ratio)

Resolves:
* [MWPW-192884](https://jira.corp.adobe.com/browse/MWPW-192884)
* [MWPW-192886](https://jira.corp.adobe.com/browse/MWPW-192886)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=sr-bento-overlay&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all




