### PR TITLE
Page Animator: show block names in section headers

### DIFF
--- a/libs/c2/tools/page-animator/page-animator.css
+++ b/libs/c2/tools/page-animator/page-animator.css
@@ -159,6 +159,14 @@
   content: '▸ ';
 }
 
+.pa-section-blocks {
+  color: #a0a0a0;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  margin-left: 2px;
+}
+
 .pa-item {
   padding: 6px 16px 6px 28px;
   cursor: pointer;

--- a/libs/c2/tools/page-animator/panel.js
+++ b/libs/c2/tools/page-animator/panel.js
@@ -74,7 +74,7 @@ export function buildPanel(
 
   let selectedId = null;
   let selectedEl = null;
-  const collapsedSections = new Set();
+  const collapsedSections = new Set(tree.map((s) => s.id));
 
   function buildCopyHtml(item) {
     const sectionNode = tree.find(
@@ -263,7 +263,11 @@ export function buildPanel(
 
       const sLabel = document.createElement('div');
       sLabel.className = `pa-section-label${isCollapsed ? ' pa-collapsed' : ''}`;
-      sLabel.textContent = section.label;
+      const names = section.blocks.map((b) => b.label);
+      const suffix = names.length
+        ? ` · ${names[0]}${names.length > 1 ? ` +${names.length - 1}` : ''}`
+        : '';
+      sLabel.innerHTML = `${section.label}<span class="pa-section-blocks">${suffix}</span>`;
       sLabel.addEventListener('click', () => {
         if (collapsedSections.has(section.id)) collapsedSections.delete(section.id);
         else collapsedSections.add(section.id);


### PR DESCRIPTION
Section header labels in the Page Animator now append their child block names (e.g. `Section · Hero +2`), so each section is identifiable at a glance. All sections also start **collapsed**, making the labelled headers the primary scannable view.

### Changes
- **`libs/c2/tools/page-animator/panel.js`** — append child block names to each section label; collapse all sections by default.
- **`libs/c2/tools/page-animator/page-animator.css`** — add `.pa-section-blocks` style for the appended names.

### How to test
1. Open a Milo page that loads the Page Animator with this branch's libs: append `?milolibs=page-animator-section-labels`.
2. Confirm each section header reads `<Section label> · <first block> +N` and that sections start collapsed; click a header to expand.

### Notes for reviewers
- Base branch is **`forge-a-panel`** (not `stage`).
- `.pa-section-blocks` uses a fixed `#a0a0a0`. The recent panel restyle (#5994) added light/dark theming — consider a themed token instead of the hard-coded gray as a follow-up.

