### PR TITLE
[MWPW-196479] - Rich content video a11y enhancement and button spacing

### DIFF
--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -302,7 +302,7 @@
   align-items: center;
   gap: var(--s2a-spacing-3xl);
   padding-top: calc(var(--s2a-layout-sm) + var(--rc-pull-offset));
-  padding-bottom: var(--s2a-layout-sm);
+  padding-bottom: var(--s2a-layout-lg);
   overflow: clip;
 
   .media {

--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -408,6 +408,11 @@
   }
 }
 
+@keyframes rc-cta-counteract {
+  from { transform: translateY(0); }
+  to { transform: translateY(-50vh); }
+}
+
 @keyframes rc-video-enter {
   from { transform: scale(0.94) translateY(30px); }
   to { transform: scale(1) translateY(0); }
@@ -503,11 +508,22 @@
       animation: rc-section-sweep-in cubic-bezier(0.4, 0, 0.2, 1) both;
       animation-duration: auto;
       animation-timeline: --rc-video-garage;
-      animation-range: entry 50% exit 100%;
+      animation-range: entry 60% exit 100%;
     }
 
     .section.parallax-video-garage-door:has(.rich-content.video) + .section {
       margin-top: calc(var(--rc-sweep-offset) * -1);
+    }
+
+    .section.parallax-video-garage-door .rich-content.video .cta-area {
+      animation: rc-cta-counteract linear both;
+      animation-duration: auto;
+      animation-timeline: --rc-video-garage;
+      animation-range: exit 50% exit 100%;
+    }
+
+    .section.parallax-video-garage-door .rich-content.video :is(a, button) {
+      scroll-margin-top: calc(100vh - 200px);
     }
 
     @media (width >= 1440px) {
@@ -521,5 +537,6 @@
         animation-range: entry 90% exit 100%;
       }
     }
+
   }
 }


### PR DESCRIPTION
PR enhances a11y tabing for rich content video to be compliant and adds bigger padding at bottom for CTA to be available for longer before animation hits.

https://jira.corp.adobe.com/browse/MWPW-196479

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=rich-content-video-a11y




