### PR TITLE
[SR] - Parallax z-index change

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -640,9 +640,7 @@ h1, h2, h3, h4, h5, h6, [class*="heading-"] {
     color: currentColor;
   }
 }
-.section:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
-  z-index: 1;
-}
+
 .heading-super {
   font-size: var(--s2a-typography-font-size-super);
   line-height: var(--s2a-typography-line-height-super);
@@ -1006,13 +1004,9 @@ span.hang-opening-quote {
   transform: translateX(100%);
 }
 
-/* Needed for garage door JS animation in browsers without animation-timeline support */
-@supports not (animation-timeline: view()) {
-  .section:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
-    z-index: 1;
-  }
+.section:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
+  z-index: 1;
 }
-
 /* TODO: Parallax styles should be loaded separately and conditionally */
 @supports (animation-timeline: view()) {
   /* General parallax declarations */

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -640,7 +640,9 @@ h1, h2, h3, h4, h5, h6, [class*="heading-"] {
     color: currentColor;
   }
 }
-
+.section:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
+  z-index: 1;
+}
 .heading-super {
   font-size: var(--s2a-typography-font-size-super);
   line-height: var(--s2a-typography-line-height-super);


### PR DESCRIPTION
Changes seem to have happened on some blocks regarding z-index making this neccessary, the issue why this was scoped to fix is no longer happening which means that something changed in the surrounding blocks, **we should all keep a closer eye on all z-index changes in all blocks to prevent issues like this from happening, if you do change a z-index it's a good idea to look at other pages where the block is used**.

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=sr-rich-content-z-index&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


