### PR TITLE
[MWPW-197253] Rich Content Split variant

### DIFF
--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -53,6 +53,10 @@
     gap: var(--content-gap);
   }
 
+  &.left-split .action-area {
+    align-items: center;
+  }
+
   &.jump-link {
     color: var(--s2a-color-content-knockout);
     z-index: 1;

--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -260,6 +260,27 @@
       }
     }
 
+    &.left-split .foreground .content {
+      display: table;
+      width: 100%;
+
+      > :not(.action-area):not(:first-child) {
+        margin-block-start: var(--content-gap);
+      }
+
+      .action-area {
+        display: table-cell;
+        vertical-align: middle;
+        width: 1%;
+        white-space: nowrap;
+        padding-inline-start: var(--s2a-layout-sm);
+
+        > :not(:first-child) {
+          margin-inline-start: var(--content-gap);
+        }
+      }
+    }
+
     &.jump-link {
       padding-block-start: var(--s2a-layout-lg);
       padding-block-end: var(--s2a-layout-sm);


### PR DESCRIPTION
Adds a new `left split` variant to the Rich Content block, that moves the `.action-area` element on the same line as the text, center-aligned vertically. `table` and `table-cell` have been used, since we can't be sure of the number of paragraphs/eyebrow text/etc. the block could have.

Resolves: [MWPW-197253](https://jira.corp.adobe.com/browse/MWPW-197253)

**Test URLs:**
- Before (Plans): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=site-redesign-foundation
- After (Plans): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=rich-content-split
- Before (Product): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation
- After (Product): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=rich-content-split



