### PR TITLE
Fixing region modal fragment's max height for ios issue

### DIFF
--- a/libs/c2/blocks/region-nav/region-nav.css
+++ b/libs/c2/blocks/region-nav/region-nav.css
@@ -82,7 +82,7 @@
 }
 
 .dialog-modal:has(.region-nav) > .fragment {
-  max-height: calc((100dvh - 6px) - 2em);
+  max-height: calc((100svh - 6px) - 2em);
 }
 
 @media (min-width: 600px) {

--- a/libs/c2/blocks/region-nav/region-nav.css
+++ b/libs/c2/blocks/region-nav/region-nav.css
@@ -77,9 +77,12 @@
   color: var(--s2a-color-gray-1000);
 }
 
-
 .dialog-modal .region-nav a:hover {
   text-decoration: underline;
+}
+
+.dialog-modal:has(.region-nav) > .fragment {
+  max-height: calc((100dvh - 6px) - 2em);
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added max height of fragment for ios devices to 100vdh instead of vh

Resolves: [MWPW-197330](https://jira.corp.adobe.com/browse/MWPW-197330)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/de/homepage/index-loggedout
- After: https://main--upp--adobecom.aem.page/de/homepage/index-loggedout?milolibs=footer-fixes




