### PR TITLE
Explicit aria-expanded for faq summary

### DIFF
--- a/libs/mep/ace1205/faq/faq.js
+++ b/libs/mep/ace1205/faq/faq.js
@@ -5,6 +5,7 @@ const SEO_SCHEMA = { '@context': 'https://schema.org', '@type': 'FAQPage', mainE
 
 function handleToggle(details) {
   const summary = details.querySelector('summary');
+  summary?.setAttribute('aria-expanded', details.open);
   const daaLl = summary?.getAttribute('daa-ll');
   if (!daaLl) return;
   summary.setAttribute(
@@ -25,6 +26,7 @@ function buildItem(row, num, isFirst) {
   const icon = createTag('span', { class: 'faq-icon', 'aria-hidden': 'true' });
   const summary = createTag('summary', {
     class: 'faq-trigger',
+    'aria-expanded': isFirst,
     'daa-ll': `${isFirst ? 'close' : 'open'}-${num}--${processTrackingLabels(questionText)}`,
   }, [headingTag, icon]);
 


### PR DESCRIPTION
Adds and updates the `aria-expanded` attribute for FAQ items, since native markup isn't being handled uniformly across platforms. This is still pending approval from an accessibility expert.

LE: confirmation has been received that this implements the expected accessibility behavior.

Resolves: [MWPW-196441](https://jira.corp.adobe.com/browse/MWPW-196441)

**Test URLs:**
- Before (Plans): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=site-redesign-foundation
- After (Plans): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=faq-a11y
- Before (Product): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation
- After (Product): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=faq-a11y


