### PR TITLE
MWPW-196410 fix marketo html pdf redirect

### DIFF
--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -74,7 +74,8 @@ export const decorateURL = async (destination, baseURL = window.location) => {
       destinationUrl = new URL(`${pathname}${search}${hash}`, baseURL.origin);
     }
 
-    if (baseURL.pathname.endsWith('.html') && !pathname.endsWith('.html') && !pathname.endsWith('/') && !exclude) {
+    const hasFileExtension = /\.[^/.]+$/.test(pathname);
+    if (baseURL.pathname.endsWith('.html') && !hasFileExtension && !pathname.endsWith('/') && !exclude) {
       destinationUrl.pathname = `${pathname}.html`;
     }
 

--- a/test/blocks/marketo/marketo.test.js
+++ b/test/blocks/marketo/marketo.test.js
@@ -106,6 +106,12 @@ describe('marketo decorateURL', () => {
     expect(result).to.equal('https://business.adobe.com/');
   });
 
+  it('Does not add .html to non-html file extension (e.g. PDF)', async () => {
+    const baseURL = new URL('https://business.adobe.com/marketo-block.html');
+    const result = await decorateURL('https://business.adobe.com/assets/document.pdf', baseURL);
+    expect(result).to.equal('https://business.adobe.com/assets/document.pdf');
+  });
+
   it('Does not add .html to ending slash when htmlExclude is set', async () => {
     const { htmlExclude: savedHtmlExclude } = getConfig();
     try {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fix `decorateURL` incorrectly appending `.html` to redirect destinations that already have a file extension (e.g. `.pdf`)

Resolves: [MWPW-196410](https://jira.corp.adobe.com/browse/MWPW-196410)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bmarshal-marketo-pdf-redirect--milo--adobecom.aem.page/?martech=off

**CC URLs:**
- Before: https://www.stage.adobe.com/products/adobeconnect/idc-report.html?martech=off
- After: https://www.stage.adobe.com/products/adobeconnect/idc-report.html?martech=off&milolibs=bmarshal-marketo-pdf-redirect



