### PR TITLE
Fixing region modal fragment's max height for ios issue and footer headline overlap issue

### DIFF
--- a/libs/c2/blocks/global-footer/global-footer.css
+++ b/libs/c2/blocks/global-footer/global-footer.css
@@ -54,7 +54,7 @@
   border-color: var(--s2a-color-transparent-white-12);
 }
 
-.feds-footer-wrapper .feds-menu-headline::after {
+.feds-footer-wrapper .feds-menu-headline-caret {
   border-color: var(--s2a-color-gray-25);
 }
 

--- a/libs/c2/blocks/global-footer/menu/menu.css
+++ b/libs/c2/blocks/global-footer/menu/menu.css
@@ -13,7 +13,7 @@
   transform: rotateZ(-135deg);
 }
 
-.feds-menu-headline[aria-expanded = "true"]:after {
+.feds-menu-headline[aria-expanded = "true"] .feds-menu-headline-caret {
   transform: rotateZ(225deg);
 }
 
@@ -42,46 +42,33 @@
 }
 
 .feds-menu-headline {
-  position: relative;
-  padding: 12px 44px 12px 32px;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--s2a-spacing-xs);
+  padding: var(--s2a-spacing-lg) var(--s2a-spacing-xs);
   border-bottom: 1px solid var(--feds-borderColor-menu);
   color: var(--feds-color-headline);
-  font-weight: 600;
-  white-space: nowrap;
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
   cursor: pointer;
 }
 
-.global-footer:not(.mobile) .feds-menu-headline {
-  white-space: normal;
+.feds-menu-headline-text {
+  flex: 1;
+}
+
+.feds-menu-headline-caret {
+  flex-shrink: 0;
   display: block;
-}
-
-[dir = "rtl"] .feds-menu-headline {
-  padding-right: 32px;
-  padding-left: 44px;
-}
-
-.feds-menu-headline:after {
-  position: absolute;
-  right: 30px;
-  top: 50%;
-  display: flex;
   width: 6px;
   height: 6px;
-  margin-top: -3px;
+  margin-top: 7px;
   border-width: 0 1px 1px 0;
   border-style: solid;
   border-color: var(--feds-color-link);
   transform-origin: 75% 75%;
   transform: rotateZ(45deg);
   transition: transform 0.1s ease;
-  content: "";
   box-sizing: content-box;
-}
-
-[dir = "rtl"] .feds-menu-headline:after {
-  right: unset;
-  left: 30px;
 }
 
 .feds-menu-items {
@@ -114,7 +101,6 @@
   }
 
   .global-footer:not(.mobile) .feds-menu-headline {
-    position: static;
     margin: 0 32px;
     cursor: default;
   }
@@ -137,8 +123,8 @@
     margin-top: 0;
   }
 
-  .global-footer:not(.mobile) .feds-menu-headline:after {
-    content: none;
+  .global-footer:not(.mobile) .feds-menu-headline-caret {
+    display: none;
   }
 
   .global-footer:not(.mobile) .feds-menu-headline + .feds-menu-items {

--- a/libs/c2/blocks/global-footer/menu/menu.js
+++ b/libs/c2/blocks/global-footer/menu/menu.js
@@ -64,7 +64,8 @@ const decorateHeadline = (elem, index, context = 'viewport') => {
   if (!(elem instanceof HTMLElement)) return null;
 
   const headline = toFragment`<div class="feds-menu-headline">
-      ${elem.textContent.trim()}
+      <span class="feds-menu-headline-text">${elem.textContent.trim()}</span>
+      <span class="feds-menu-headline-caret" aria-hidden="true"></span>
     </div>`;
 
   const headlineClickHandler = (e) => {

--- a/libs/c2/blocks/region-nav/region-nav.css
+++ b/libs/c2/blocks/region-nav/region-nav.css
@@ -82,6 +82,10 @@
   text-decoration: underline;
 }
 
+.dialog-modal:has(.region-nav) > .fragment {
+  max-height: calc((100svh - 6px) - 2em);
+}
+
 @media (min-width: 600px) {
   .region-nav > div:nth-of-type(2) {
     column-count: 3;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added max height of fragment for ios devices to 100vdh instead of vh
* Changed the after element to a sibling element to avoid the overlapping

Resolves: [MWPW-197330](https://jira.corp.adobe.com/browse/MWPW-197330), [MWPW-197329](https://jira.corp.adobe.com/browse/MWPW-197329)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/de/homepage/index-loggedout
- After: https://main--upp--adobecom.aem.page/de/homepage/index-loggedout?milolibs=region-modal





