### PR TITLE
Fix line height animations on HP

### DIFF
--- a/libs/c2/blocks/carousel-c2/carousel-c2.css
+++ b/libs/c2/blocks/carousel-c2/carousel-c2.css
@@ -376,7 +376,7 @@
 }
 
 @keyframes title-enter {
-  from { line-height: 2; }
+  from { line-height: 200%; }
 }
 
 @keyframes text-enter {

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -605,7 +605,7 @@ h1, h2, h3, h4, h5, h6, [class*="title-"] {
   margin: 0;
   font-family: var(--heading-font-family);
   font-weight: var(--s2a-font-weight-adobe-clean-black);
-  line-height: 1;
+  line-height: 100%;
   scroll-margin-top: var(--feds-totalheight-nav); /* TODO: Replace with the eventual Gnav variable */
 
   strong {
@@ -1138,7 +1138,7 @@ p {
   }
 
   @keyframes garage-door-line-height {
-    from { line-height: 0.6; }
+    from { line-height: 60%; }
   }
 
   /* Section 1 to section 2 parallax declarations */
@@ -1187,7 +1187,7 @@ p {
   }
 
   @keyframes text-reveal-up {
-    from { line-height: 3; }
+    from { line-height: 300%; }
   }
 }
 


### PR DESCRIPTION
This fixes the line-height animation issues on the homepage, that couldn't animate values with and without units.

Resolves: [MWPW-197422](https://jira.corp.adobe.com/browse/MWPW-197422)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.live/upp-shared/fragments/tests/2026/q2/ace1201/sr-homepage
- After: https://main--upp--adobecom.aem.live/upp-shared/fragments/tests/2026/q2/ace1201/sr-homepage?milolibs=line-height-percentages



