### PR TITLE
[SR] - Parallax floating cta z-index fix

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1064,7 +1064,7 @@ span.hang-opening-quote {
   transform: translateX(100%);
 }
 
-.section:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast):not(:has(.floating-cta)) {
+.section:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
   z-index: 1;
 }
 /* TODO: Parallax styles should be loaded separately and conditionally */

--- a/libs/mep/ace1205/floating-cta/floating-cta.css
+++ b/libs/mep/ace1205/floating-cta/floating-cta.css
@@ -1,5 +1,5 @@
 .section {
-  &:has(.floating-cta) {
+  &:has(.floating-cta .promo-cta .icon-button) {
     bottom: 0;
     position: sticky;
     z-index: 4;


### PR DESCRIPTION
Changes css specificity to fix z-index behaviour between blocks.

Fixes:
<img width="1512" height="420" alt="Screenshot 2026-05-28 at 11 24 02" src="https://github.com/user-attachments/assets/81920b12-aa23-4e08-824a-12a85353f585" />


**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=z-index-adaptation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


