### PR TITLE
[SR] MWPW-194269: Quick Actions tile - Modify on hover signal for 

### DIFF
--- a/libs/mep/ace1205/quick-actions/quick-actions.css
+++ b/libs/mep/ace1205/quick-actions/quick-actions.css
@@ -35,20 +35,11 @@
   background: var(--s2a-color-background-subtle);
   border-radius: var(--s2a-border-radius-md);
   text-decoration: none;
+  transition: filter 0.3s ease-in-out;
 }
 
-.quick-actions-tile::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 1;
-  background: var(--s2a-color-transparent-black-08);
-  opacity: 0;
-  transition: opacity 0.5s var(--parallax-easing);
-}
-
-.quick-actions-tile:hover::before {
-  opacity: 1;
+.quick-actions-tile:hover {
+  filter: brightness(0.98);
 }
 
 .quick-actions-tile:focus-visible {
@@ -60,11 +51,12 @@
   position: absolute;
   inset: 0;
   display: block;
-  transition: transform 0.3s ease;
+  will-change: transform;
+  transition: transform 0.3s ease-out;
 }
 
 .quick-actions-tile:hover .quick-actions-media {
-  transform: scale(1.05);
+  transform: scale(1.015);
 }
 
 .quick-actions-media img,
@@ -151,5 +143,4 @@ img.quick-actions-media {
   .quick-actions-tile {
     border-radius: var(--s2a-border-radius-24);
   }
-
 }


### PR DESCRIPTION
Updates the overlay and img scale of quick actions tile on hover to match bento.

Resolves: [MWPW-194269](https://jira.corp.adobe.com/browse/MWPW-194269)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://quick-action-hover--milo--adobecom.aem.page/?martech=off

**QA:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=quick-action-hover&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


