### PR TITLE
[SR] Move modal disable-scroll from body to html

### DIFF
--- a/libs/mep/ace1205/modal/modal.js
+++ b/libs/mep/ace1205/modal/modal.js
@@ -104,7 +104,7 @@ export async function closeModal(modal, shouldFocusTriggerEl = true) {
   });
 
   if (!document.querySelectorAll('.modal-curtain').length) {
-    document.body.classList.remove('disable-scroll');
+    document.documentElement.classList.remove('disable-scroll');
     /** Restore lenis behaviour on modal close */
     window.lenis?.start();
   }
@@ -263,7 +263,7 @@ export async function getModal(details, custom) {
   window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {
-    document.body.classList.add('disable-scroll');
+    document.documentElement.classList.add('disable-scroll');
     /** Stop lenis behaviour on modal open */
     window.lenis?.stop();
     const curtain = createTag('div', {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Keep scroll containers of position:sticky elements from jumping when a modal is open

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=modal-overflow-html&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

**How to test:**

- scroll down to when pdf-space block has taken over
- click the floating brand-concierge button
- observe that background pdf-space doesn't vanish anymore

