### PR TITLE
[MWPW-197487][NALA] Fix NALA Test Failures on Chromium in GitHub CI Runs

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -43,7 +43,7 @@ const config = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 10000,
+    timeout: 12000,
   },
   testMatch: '**/*.test.js',
   /* Run tests in files in parallel */

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -43,7 +43,7 @@ const config = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000,
+    timeout: 10000,
   },
   testMatch: '**/*.test.js',
   /* Run tests in files in parallel */


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Increased Playwright global assertion timeout from **5s** to **12s** (`expect: { timeout: 12000 }`) to improve NALA test stability in GitHub CI runs.

* This increases the maximum time Playwright `expect()` assertions wait for a condition to be satisfied before failing, providing additional headroom for page hydration, asynchronous content rendering, block initialization, and DOM element availability prior to assertion evaluation.
* **Example:** `await expect(locator).toBeVisible();`
             * Element appears in 200ms  → Pass in 200ms
             * Element appears in 2s     → Pass in 2s
             * Element appears in 8s     → Pass in 8s
             * Element never appears     → Fail after 12s

Resolves: [MWPW-197487](https://jira.corp.adobe.com/browse/MWPW-197487)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-197487--milo--adobecom.aem.page/?martech=off




