### PR TITLE
Enable staggering for masonry layouts

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1189,6 +1189,12 @@ span.hang-opening-quote {
         will-change: transform;
       }
 
+      &.masonry-layout > :not([class*="section-"]) {
+        --parallax-stagger-drift: 150px;
+
+        animation-timeline: view(block);
+      }
+
       /* Prolong animation for 2 rows */
       &.two-up:has(> :nth-child(3 of :not([class*="section-"]))),
       &.three-up:has(> :nth-child(4 of :not([class*="section-"]))),
@@ -1283,8 +1289,16 @@ span.hang-opening-quote {
     );
   }
 
+  .parallax-stagger-ltr.masonry-layout > :not([class*="section-"]) {
+    --parallax-stagger-from: calc(var(--parallax-stagger-index) * var(--parallax-stagger-drift));
+  }
+
+  .parallax-stagger-rtl.masonry-layout > :not([class*="section-"]) {
+    --parallax-stagger-from: calc((1 - var(--parallax-stagger-index)) * var(--parallax-stagger-drift));
+  }
+
   @keyframes enable-parallax-stagger {
-    from { transform: translate3d(0, var(--parallax-stagger-from, 0px), 0); }
+    from { transform: translate3d(0, var(--parallax-stagger-from, 0), 0); }
     to { transform: translate3d(0, 0, 0); }
   }
 

--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -610,6 +610,10 @@
       animation-duration: auto;
       animation-timeline: --rc-video-garage;
       animation-range: entry 50% exit 200%;
+
+      &.has-background + .section.has-background {
+        margin-top: -1px;
+      }
     }
 
     @media (width >= 768px) {

--- a/libs/mep/ace1205/section-metadata/section-metadata.js
+++ b/libs/mep/ace1205/section-metadata/section-metadata.js
@@ -107,24 +107,30 @@ export async function handleStyle(text, section) {
 }
 
 function handleMasonry(text, section) {
-  const spanSets = text.filter(Boolean).map((entry) => {
-    const spans = [];
-    entry.split('\n').forEach((line) => spans.push(...line.trim().split(',')));
-    return spans.map((s) => s.trim() || 'span 4');
-  });
+  const spanSets = text.filter(Boolean).map((entry) => (
+    entry.split('\n').map((line) => line.trim().split(',').map((s) => s.trim() || 'span 4'))
+  ));
 
   if (spanSets.length === 0) return;
 
   section.classList.add('masonry-layout');
   if (spanSets.length > 1) section.classList.add('masonry-responsive');
+  const isStagger = section.className.includes('parallax-stagger-');
   const divs = [...section.querySelectorAll(":scope > div:not([class*='metadata']):not(.section-background)")];
 
-  const applySpans = (spans) => {
+  const applySpans = (rows) => {
+    const cards = rows.flatMap((row) => row.map((span, j) => ({
+      span,
+      index: isStagger ? ((j + 0.5) / row.length).toFixed(2) : undefined,
+    })));
+
     divs.forEach((div, i) => {
-      const gridClasses = [...div.classList].filter((cls) => cls.startsWith('grid-'));
-      if (gridClasses.length) div.classList.remove(...gridClasses);
-      const spanWidth = spans[i] || 'span 4';
-      div.classList.add(`grid-${spanWidth.replace(' ', '-')}`);
+      const { span = 'span 4', index } = cards[i] ?? {};
+      div.classList.remove(...[...div.classList].filter((cls) => cls.startsWith('grid-')));
+      div.classList.add(`grid-${span.replace(' ', '-')}`);
+      if (index !== undefined) {
+        div.style.setProperty('--parallax-stagger-index', index);
+      }
     });
   };
 


### PR DESCRIPTION
This adds staggering capabilities to masonry layouts, by using a similar mechanism to the `.X-up` one, via the `.parallax-stagger-ltr` / `.parallax-stagger-rtl` classes applied to the section. It also fixes a rendering issue for sections following the `.parallax-video-garage-door` one.

Resolves: [MWPW-197534](https://jira.corp.adobe.com/browse/MWPW-197534)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=bento-staggering




