### PR TITLE
[SR][MWPW-196545]: Social Proof use blockquote

### DIFF
--- a/libs/mep/ace1205/social-proof/social-proof.css
+++ b/libs/mep/ace1205/social-proof/social-proof.css
@@ -66,6 +66,24 @@
         }
       }
     }
+
+    figure {
+      height: 100%;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      gap: var(--s2a-spacing-md);
+
+      figcaption {
+        display: flex;
+        flex-direction: column;
+
+        :not(:first-child) {
+          color: var(--s2a-color-content-subtle);
+        }
+      }
+    }
   }
 }
 

--- a/libs/mep/ace1205/social-proof/social-proof.js
+++ b/libs/mep/ace1205/social-proof/social-proof.js
@@ -1,15 +1,34 @@
 import { decorateBlockText, decorateViewportContent, hangOpeningQuote } from '../../../utils/decorate.js';
 import { createTag } from '../../../utils/utils.js';
 
+const HEADING = '3';
+const BODY = 'lg';
+
 function createContent(foreground) {
   const heading = foreground?.querySelector('h1, h2, h3, h4, h5, h6');
   if (!heading) return;
-
   const content = createTag('div', { class: 'content' });
   [...foreground.children].forEach((child) => {
     if (child !== heading) content.appendChild(child);
   });
   foreground.appendChild(content);
+}
+
+function decorateBlockQuote(blockQuote) {
+  const figure = createTag('figure');
+  figure.append(blockQuote);
+  const [quote, ...captions] = [...blockQuote.children];
+  hangOpeningQuote(quote);
+  quote.classList.add(`heading-${HEADING}`);
+  const caption = createTag('figcaption', { class: `body-${BODY}` }, [
+    ...captions.map((cap) => {
+      const text = cap.textContent;
+      cap.remove();
+      return createTag('span', {}, text);
+    }),
+  ]);
+  figure.appendChild(caption);
+  return figure;
 }
 
 function decorate(block) {
@@ -29,7 +48,13 @@ function decorate(block) {
   secondRow?.remove();
 
   foreground?.classList.add('foreground');
-  decorateBlockText(foreground, { heading: '3', body: 'lg' });
+  const blockQuote = foreground.querySelector('blockquote');
+  if (blockQuote) {
+    const qoute = decorateBlockQuote(blockQuote);
+    foreground.append(qoute);
+    return;
+  }
+  decorateBlockText(foreground, { heading: HEADING, body: BODY });
   hangOpeningQuote(foreground?.querySelector('h1, h2, h3, h4, h5, h6'));
   createContent(foreground);
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Decorate `blockquote` element based on ticked description. 
* Old decorating logic was not removed, can be adjusted for future use cases. 

Authoring: 
<img width="841" height="706" alt="Screenshot 2026-06-04 at 18 45 04" src="https://github.com/user-attachments/assets/ef60930c-07c3-46f6-872f-c82c2fa40115" />


Resolves: [MWPW-196545](https://jira.corp.adobe.com/browse/MWPW-196545)

**NOTE:** Block needs to be updated on Offer and Product pages after merging. 
**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/drafts/ratko/soical-proof?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/drafts/ratko/soical-proof?milolibs=mwpw-196545-social-proof-a11y&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

