### PR TITLE
[SR] Updating heading and body max-width in bentos

### DIFF
--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -65,21 +65,17 @@
     grid-auto-rows: initial;
   }
 
-  &.bento .dark .explore-card-content [class*='body-'] {
-    color: inherit;
-  }
-
   &.bento .explore-card-content {
     padding-inline: 0;
     padding-bottom: var(--s2a-spacing-xl);
     padding-top: 0;
 
-    & [class*='heading-'] {
+    [class*='heading-'] {
       z-index: 1;
       margin-bottom: var(--s2a-spacing-2xs);
     }
 
-    & [class*='body-'] {
+    [class*='body-'] {
       margin-top: initial;
       margin-bottom: 0;
       opacity: 1;
@@ -90,6 +86,7 @@
     [class*='heading-'],
     [class*='body-'] {
       padding-inline: var(--s2a-spacing-xl);
+      max-width: 450px;
     }
 
     .explore-card-foreground {
@@ -127,6 +124,10 @@
         inset: 0;
       }
     }
+  }
+
+  &.bento .dark .explore-card-content [class*='body-'] {
+    color: inherit;
   }
   
 
@@ -227,9 +228,7 @@
 }
 
 .section-background {
-  & {
-    z-index: 0;
-  }
+  z-index: 0;
 
   &,
   & > * {
@@ -317,11 +316,6 @@
       .explore-card-content {
         .content-aux {
           aspect-ratio: 4 / 1.65;
-        }
-
-        [class*='heading-'],
-        [class*='body-'] {
-          max-width: 450px;
         }
       }
     }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
VQA feedback to:
* set `max-width: 450px `to body and heading elements inside bento. All breakpoints.

Resolves:
* [MWPW-192884](https://jira.corp.adobe.com/browse/MWPW-192884)
* [MWPW-192886](https://jira.corp.adobe.com/browse/MWPW-192886)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=sr-bentos-copy-mwidth&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


