### PR TITLE
[SR] - Update rich content video spacing

### DIFF
--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -364,6 +364,7 @@
       backdrop-filter: blur(var(--s2a-blur-md));
       overflow: hidden;
       transform-origin: center bottom;
+      width: 100%;
 
       video {
         display: block;


### PR DESCRIPTION
Stretches video container to max width of container in order to be centered on 1920.

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=rich-content-video-spacing&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


