### PR TITLE
[SR] - parallax after section z index

### DIFF
--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -546,11 +546,14 @@
 
     .section.parallax-video-garage-door:has(.rich-content.video) ~ .section {
       position: relative;
-      z-index: 2;
       animation: rc-section-sweep-in cubic-bezier(0.4, 0, 0.2, 1) both;
       animation-duration: auto;
       animation-timeline: --rc-video-garage;
       animation-range: entry 60% exit 100%;
+    }
+
+    .section.parallax-video-garage-door:has(.rich-content.video) ~ .section:not([class*='rounded-corners-']) {
+      z-index: 2;
     }
 
     .section.parallax-video-garage-door:has(.rich-content.video) + .section {


### PR DESCRIPTION
Changes z-index for parallax after section only if it doesn't have rounded corners, since rounded corners require a higher z-index.

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=parallax-after-section-z-ind&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


