### PR TITLE
Plans hero block

### DIFF
--- a/libs/mep/ace1205/plans-hero/plans-hero.css
+++ b/libs/mep/ace1205/plans-hero/plans-hero.css
@@ -1,0 +1,93 @@
+.plans-hero {
+  --plans-hero-height: 400px;
+  --plans-hero-cols: 4;
+
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: var(--plans-hero-height);
+  color: var(--s2a-color-content-knockout);
+}
+
+.plans-hero-media {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+
+  picture, img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  &::after {
+    --scrim-stop-start: -84.26%;
+    --scrim-stop-end: 25.77%;
+
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(271deg,
+      var(--s2a-color-transparent-black-00) var(--scrim-stop-start),
+      var(--s2a-color-transparent-black-64) var(--scrim-stop-end));
+    pointer-events: none;
+  }
+
+  [dir='rtl'] &::after {
+    scale: -1 1;
+  }
+}
+
+.plans-hero-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--s2a-spacing-md);
+  max-width: calc(100% * var(--plans-hero-cols) / var(--grid-columns));
+  text-wrap: balance;
+
+  .eyebrow {
+    color: var(--s2a-color-content-subtle);
+  }
+}
+
+@media (width >= 768px) {
+  .plans-hero {
+    --plans-hero-height: 284px;
+    --plans-hero-cols: 6;
+  }
+
+  .plans-hero-media::after {
+    --scrim-stop-start: 0.88%;
+    --scrim-stop-end: 69.65%;
+  }
+}
+
+@media (width >= 1024px) {
+  .plans-hero {
+    --plans-hero-height: 436px;
+    --plans-hero-cols: 5;
+  }
+}
+
+@media (width >= 1280px) {
+  .plans-hero {
+    --plans-hero-height: 452px;
+  }
+}
+
+@media (width >= 1440px) {
+  .plans-hero {
+    --plans-hero-height: 800px;
+
+    align-items: flex-start;
+  }
+
+  .plans-hero-content {
+    padding-block-start: var(--s2a-layout-lg);
+  }
+}

--- a/libs/mep/ace1205/plans-hero/plans-hero.js
+++ b/libs/mep/ace1205/plans-hero/plans-hero.js
@@ -1,0 +1,25 @@
+import { decorateBlockText, decorateViewportContent } from '../../../utils/decorate.js';
+import { createTag } from '../../../utils/utils.js';
+
+function decorate(block) {
+  const row = block.children[0];
+  if (!row) return;
+
+  const [textCell, mediaCell] = row.children;
+
+  const media = createTag('div', { class: 'plans-hero-media' });
+  const picture = mediaCell?.querySelector('picture');
+  if (picture) media.append(picture);
+
+  if (textCell) {
+    decorateBlockText(textCell, { heading: '2', body: 'md' });
+    textCell.classList.add('plans-hero-content');
+  }
+
+  block.replaceChildren(media, textCell ?? createTag('div', { class: 'plans-hero-content' }));
+}
+
+export default function init(el) {
+  el.classList.add('container');
+  decorateViewportContent(el, decorate);
+}

--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -129,7 +129,6 @@
   &.bento .dark .explore-card-content [class*='body-'] {
     color: inherit;
   }
-  
 
   &.bento .scrim {
     .explore-card-content {
@@ -256,23 +255,20 @@
 
 .section.scrim .section-background {
   &::after {
-    --scrim-stop: 80%;
-    --scrim-dir: right;
+    --scrim-stop-start: -84.26%;
+    --scrim-stop-end: 25.77%;
 
     content: '';
     position: absolute;
     inset: 0;
-    background-image: linear-gradient(
-      to var(--scrim-dir),
-      rgb(0 0 0 / 60%) var(--scrim-stop),
-      rgb(0 0 0 / 40%) calc((var(--scrim-stop) + 100%) / 2),
-      transparent
-    );
+    background-image: linear-gradient(271deg,
+      var(--s2a-color-transparent-black-00) var(--scrim-stop-start),
+      var(--s2a-color-transparent-black-64) var(--scrim-stop-end));
     pointer-events: none;
   }
 
   [dir='rtl'] &::after {
-    --scrim-dir: left;
+    scale: -1 1;
   }
 }
 
@@ -322,7 +318,8 @@
   }
 
   .section.scrim .section-background::after {
-    --scrim-stop: 60%;
+    --scrim-stop-start: 0.88%;
+    --scrim-stop-end: 69.65%;
   }
 }
 


### PR DESCRIPTION
Due to multiple flagged VQA issues, the Plans Hero is now its own block that accurately matches Figma specs. This will be ported over to the Plans page as soon as it gets merged, to not disrupt VQA activities.

Resolves: [MWPW-192888](https://jira.corp.adobe.com/browse/MWPW-192888)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205-plans?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205-plans?milolibs=plans-hero-tweaks&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- Initial state using Section Metadata: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


