### PR TITLE
Fixing mega menu outline focus cutoff on firefox

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -721,6 +721,7 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
 
   .feds-navItem--section > .feds-navLink {
     padding: 0 20px;
+    outline-offset: -2px;
   }
 
   .feds-navItem--section.feds-navItem--active > .feds-navLink:before {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -720,7 +720,8 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     border-right: 1px solid var(--feds-borderColor);
   }
 
-  .feds-navItem--section > .feds-navLink {
+  .feds-navItem--section > .feds-navLink,
+  .feds-navItem > .feds-navLink {
     padding: 0 20px;
     outline-offset: -2px;
   }

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -142,6 +142,7 @@ header.global-navigation {
   outline-offset: 2px;
   padding: 0 var(--feds-gutter);
   column-gap: 10px;
+  outline-offset: -2px;
 }
 
 .feds-brand {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -428,6 +428,8 @@ header.global-navigation {
 .feds-breadcrumbs a {
   display: block;
   color: var(--feds-color-link-breadcrumbs);
+  padding: 0 4px;
+  outline-offset: -2px;
 }
 
 .feds-breadcrumbs [aria-current] {
@@ -435,7 +437,11 @@ header.global-navigation {
 }
 
 .feds-breadcrumbs li span[aria-hidden="true"] {
-  padding: 0 12px;
+  padding: 0 8px;
+}
+
+.feds-breadcrumbs li:last-child > span {
+  padding-right: 12px;
 }
 
 .feds-utilities {

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Making outline focus of mega menu links to accomodate top outline for firefox

Resolves: [MWPW-197237](https://jira.corp.adobe.com/browse/MWPW-197237)

**Test URLs:**
- Before: https://main--homepage--adobecom.aem.live/uk/homepage/index-loggedout
- After: https://main--homepage--adobecom.aem.live/uk/homepage/index-loggedout?milolibs=mega-menu-outline


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=mega-menu-outline--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=mega-menu-outline--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=mega-menu-outline--milo--adobecom
- Milo: https://mega-menu-outline--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=mega-menu-outline--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=mega-menu-outline--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=mega-menu-outline--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mega-menu-outline--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mega-menu-outline--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mega-menu-outline--milo--adobecom
- Milo: https://mega-menu-outline--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mega-menu-outline--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mega-menu-outline--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mega-menu-outline--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mega-menu-outline--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mega-menu-outline--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mega-menu-outline--milo--adobecom
- Milo: https://mega-menu-outline--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mega-menu-outline--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mega-menu-outline--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mega-menu-outline--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=mega-menu-outline--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=mega-menu-outline--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=mega-menu-outline--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=mega-menu-outline--milo--adobecom
</details>