### PR TITLE
[MWPW-197855] Fix sidekick library scroll — can't reach bottom of block list

### DIFF
--- a/libs/blocks/library-config/library-config.css
+++ b/libs/blocks/library-config/library-config.css
@@ -3,6 +3,8 @@ Common styles for the block library
 */
 
 .sk-library {
+  display: flex;
+  flex-direction: column;
   width: 360px;
   height: 360px;
   background: #303030;
@@ -169,7 +171,8 @@ input.sk-library-search-input:focus {
 
 .con-container {
   position: relative;
-  height: calc(100% - 36px);
+  flex: 1;
+  min-height: 0;
 }
 
 .sk-library ul.sk-library-list,
@@ -201,15 +204,6 @@ input.sk-library-search-input:focus {
   border-bottom: 1px solid #676767;
 }
 
-/*
- * Fixes block list getting cut off with search
- * Margin height equal to search bar height
-*/
-.sk-library ul.con-blocks-list.inset,
-.sk-library ul.con-templates-list.inset,
-.sk-library ul.con-icons-list.inset  {
-  margin-bottom: 39px;
-}
 
 .sk-library .block-group::after,
 .sk-library .content-type::after {


### PR DESCRIPTION
### Description
When an author opens the Library sidekick and scrolls through the available blocks, the last block(s) are cut off and unreachable.

**Root cause:** `.con-container` had `height: calc(100% - 36px)`, accounting only for the 36px title row. When the search bar is visible (blocks, templates, icons), the header grows to ~72px, so the container overflows the 360px parent by ~36px — clipped by `overflow: hidden` on `.sk-library`.

**Fix:** Make `.sk-library` a flex column and set `.con-container` to `flex: 1; min-height: 0`. The list area now naturally fills the remaining space regardless of header height. Also removed the `margin-bottom: 39px` workaround that was patching the symptom.

Resolves: [MWPW-197855](https://jira.corp.adobe.com/browse/MWPW-197855)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Before
<img width="517" height="446" alt="image" src="https://github.com/user-attachments/assets/426409fe-39e3-4718-a2eb-f924c31a5aa0" />


## After
<img width="503" height="438" alt="image" src="https://github.com/user-attachments/assets/964ecdea-d2f9-40a1-a192-4ad3b4d5c084" />


