### PR TITLE
Add stagger to quick actions

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1173,20 +1173,85 @@ span.hang-opening-quote {
 
   /* Stagger parallax declarations */
   [class*="parallax-stagger-"] {
+    view-timeline: --parallax-stagger-timeline block;
+    view-timeline-inset: 40% 10%;
+
+    > :not([class*="section-"]) {
+      --parallax-stagger-row-index: 0;
+
+      animation-timing-function: var(--parallax-easing);
+      animation-fill-mode: both;
+      animation-timeline: --parallax-stagger-timeline;
+      animation-range: var(--parallax-range-start) var(--parallax-range-end);
+      will-change: transform;
+    }
+
+    /* Column count per -up class */
+    &.two-up { --parallax-stagger-cols: 2; }
+    &.three-up { --parallax-stagger-cols: 3; }
+    &.four-up { --parallax-stagger-cols: 4; }
+    &.six-up { --parallax-stagger-cols: 6; }
+
+    /* Column stagger indices per -up class */
+    &.two-up   > :nth-child(2n+1 of :not([class*="section-"])),
+    &.three-up > :nth-child(3n+1 of :not([class*="section-"])),
+    &.four-up  > :nth-child(4n+1 of :not([class*="section-"])),
+    &.six-up   > :nth-child(6n+1 of :not([class*="section-"])) { --parallax-stagger-index: 0.5; }
+
+    &.two-up   > :nth-child(2n of :not([class*="section-"])),
+    &.three-up > :nth-child(3n+2 of :not([class*="section-"])),
+    &.four-up  > :nth-child(4n+2 of :not([class*="section-"])),
+    &.six-up   > :nth-child(6n+2 of :not([class*="section-"])) { --parallax-stagger-index: 1.5; }
+
+    &.three-up > :nth-child(3n of :not([class*="section-"])),
+    &.four-up  > :nth-child(4n+3 of :not([class*="section-"])),
+    &.six-up   > :nth-child(6n+3 of :not([class*="section-"])) { --parallax-stagger-index: 2.5; }
+
+    &.four-up  > :nth-child(4n of :not([class*="section-"])),
+    &.six-up   > :nth-child(6n+4 of :not([class*="section-"])) { --parallax-stagger-index: 3.5; }
+
+    &.six-up   > :nth-child(6n+5 of :not([class*="section-"])) { --parallax-stagger-index: 4.5; }
+
+    &.six-up   > :nth-child(6n of :not([class*="section-"])) { --parallax-stagger-index: 5.5; }
+
+    /* Row stagger indices per -up class */
+    /* Row 1 */
+    &.two-up   > :nth-child(n+3 of :not([class*="section-"])):nth-child(-n+4  of :not([class*="section-"])),
+    &.three-up > :nth-child(n+4 of :not([class*="section-"])):nth-child(-n+6  of :not([class*="section-"])),
+    &.four-up  > :nth-child(n+5 of :not([class*="section-"])):nth-child(-n+8  of :not([class*="section-"])),
+    &.six-up   > :nth-child(n+7 of :not([class*="section-"])):nth-child(-n+12 of :not([class*="section-"])) {
+      --parallax-stagger-row-index: 1;
+    }
+
+    /* Row 2 */
+    &.two-up   > :nth-child(n+5  of :not([class*="section-"])):nth-child(-n+6  of :not([class*="section-"])),
+    &.three-up > :nth-child(n+7  of :not([class*="section-"])):nth-child(-n+9  of :not([class*="section-"])),
+    &.four-up  > :nth-child(n+9  of :not([class*="section-"])):nth-child(-n+12 of :not([class*="section-"])),
+    &.six-up   > :nth-child(n+13 of :not([class*="section-"])):nth-child(-n+18 of :not([class*="section-"])) {
+      --parallax-stagger-row-index: 2;
+    }
+
+    /* Row 3 */
+    &.two-up   > :nth-child(n+7  of :not([class*="section-"])):nth-child(-n+8  of :not([class*="section-"])),
+    &.three-up > :nth-child(n+10 of :not([class*="section-"])):nth-child(-n+12 of :not([class*="section-"])),
+    &.four-up  > :nth-child(n+13 of :not([class*="section-"])):nth-child(-n+16 of :not([class*="section-"])),
+    &.six-up   > :nth-child(n+19 of :not([class*="section-"])):nth-child(-n+24 of :not([class*="section-"])) {
+      --parallax-stagger-row-index: 3;
+    }
+
+    /* Row 4 */
+    &.two-up   > :nth-child(n+9  of :not([class*="section-"])):nth-child(-n+10 of :not([class*="section-"])),
+    &.three-up > :nth-child(n+13 of :not([class*="section-"])):nth-child(-n+15 of :not([class*="section-"])),
+    &.four-up  > :nth-child(n+17 of :not([class*="section-"])):nth-child(-n+20 of :not([class*="section-"])),
+    &.six-up   > :nth-child(n+25 of :not([class*="section-"])):nth-child(-n+30 of :not([class*="section-"])) {
+      --parallax-stagger-row-index: 4;
+    }
+
     @media (width >= 768px) {
-      view-timeline: --parallax-stagger-timeline block;
-      view-timeline-inset: 40% 10%;
       animation-name: none;
 
       > :not([class*="section-"]) {
-        --parallax-stagger-row-index: 0;
-
         animation-name: enable-parallax-stagger;
-        animation-timing-function: var(--parallax-easing);
-        animation-fill-mode: both;
-        animation-timeline: --parallax-stagger-timeline;
-        animation-range: var(--parallax-range-start) var(--parallax-range-end);
-        will-change: transform;
       }
 
       /* Prolong animation for 2 rows */
@@ -1204,67 +1269,6 @@ span.hang-opening-quote {
       &.four-up:has(> :nth-child(9 of :not([class*="section-"]))),
       &.six-up:has(> :nth-child(13 of :not([class*="section-"]))) {
         --parallax-range-end-length: 80%;
-      }
-
-      /* Column count per -up class */
-      &.two-up { --parallax-stagger-cols: 2; }
-      &.three-up { --parallax-stagger-cols: 3; }
-      &.four-up { --parallax-stagger-cols: 4; }
-      &.six-up { --parallax-stagger-cols: 6; }
-
-      /* Column stagger indices per -up class */
-      &.two-up   > :nth-child(2n+1 of :not([class*="section-"])),
-      &.three-up > :nth-child(3n+1 of :not([class*="section-"])),
-      &.four-up  > :nth-child(4n+1 of :not([class*="section-"])),
-      &.six-up   > :nth-child(6n+1 of :not([class*="section-"])) { --parallax-stagger-index: 0.5; }
-
-      &.two-up   > :nth-child(2n of :not([class*="section-"])),
-      &.three-up > :nth-child(3n+2 of :not([class*="section-"])),
-      &.four-up  > :nth-child(4n+2 of :not([class*="section-"])),
-      &.six-up   > :nth-child(6n+2 of :not([class*="section-"])) { --parallax-stagger-index: 1.5; }
-
-      &.three-up > :nth-child(3n of :not([class*="section-"])),
-      &.four-up  > :nth-child(4n+3 of :not([class*="section-"])),
-      &.six-up   > :nth-child(6n+3 of :not([class*="section-"])) { --parallax-stagger-index: 2.5; }
-
-      &.four-up  > :nth-child(4n of :not([class*="section-"])),
-      &.six-up   > :nth-child(6n+4 of :not([class*="section-"])) { --parallax-stagger-index: 3.5; }
-
-      &.six-up   > :nth-child(6n+5 of :not([class*="section-"])) { --parallax-stagger-index: 4.5; }
-
-      &.six-up   > :nth-child(6n of :not([class*="section-"])) { --parallax-stagger-index: 5.5; }
-
-      /* Row stagger indices per -up class */
-      /* Row 1 */
-      &.two-up   > :nth-child(n+3 of :not([class*="section-"])):nth-child(-n+4  of :not([class*="section-"])),
-      &.three-up > :nth-child(n+4 of :not([class*="section-"])):nth-child(-n+6  of :not([class*="section-"])),
-      &.four-up  > :nth-child(n+5 of :not([class*="section-"])):nth-child(-n+8  of :not([class*="section-"])),
-      &.six-up   > :nth-child(n+7 of :not([class*="section-"])):nth-child(-n+12 of :not([class*="section-"])) {
-        --parallax-stagger-row-index: 1;
-      }
-
-      /* Row 2 */
-      &.two-up   > :nth-child(n+5  of :not([class*="section-"])):nth-child(-n+6  of :not([class*="section-"])),
-      &.three-up > :nth-child(n+7  of :not([class*="section-"])):nth-child(-n+9  of :not([class*="section-"])),
-      &.four-up  > :nth-child(n+9  of :not([class*="section-"])):nth-child(-n+12 of :not([class*="section-"])),
-      &.six-up   > :nth-child(n+13 of :not([class*="section-"])):nth-child(-n+18 of :not([class*="section-"])) {
-        --parallax-stagger-row-index: 2;
-      }
-
-      /* Row 3 */
-      &.two-up   > :nth-child(n+7  of :not([class*="section-"])):nth-child(-n+8  of :not([class*="section-"])),
-      &.three-up > :nth-child(n+10 of :not([class*="section-"])):nth-child(-n+12 of :not([class*="section-"])),
-      &.four-up  > :nth-child(n+13 of :not([class*="section-"])):nth-child(-n+16 of :not([class*="section-"])),
-      &.six-up   > :nth-child(n+19 of :not([class*="section-"])):nth-child(-n+24 of :not([class*="section-"])) {
-        --parallax-stagger-row-index: 3;
-      }
-
-      /* Row 4 */
-      &.two-up   > :nth-child(n+9  of :not([class*="section-"])):nth-child(-n+10 of :not([class*="section-"])),
-      &.three-up > :nth-child(n+13 of :not([class*="section-"])):nth-child(-n+15 of :not([class*="section-"])),
-      &.four-up  > :nth-child(n+17 of :not([class*="section-"])):nth-child(-n+20 of :not([class*="section-"])),
-      &.six-up   > :nth-child(n+25 of :not([class*="section-"])):nth-child(-n+30 of :not([class*="section-"])) {
-        --parallax-stagger-row-index: 4;
       }
     }
   }

--- a/libs/mep/ace1205/quick-actions/quick-actions.css
+++ b/libs/mep/ace1205/quick-actions/quick-actions.css
@@ -117,17 +117,18 @@ img.quick-actions-media {
 }
 
 @media (width < 768px) {
-  .quick-actions-grid.two-up,
-  .quick-actions-grid.three-up,
-  .quick-actions-grid.four-up,
-  .quick-actions-grid.six-up {
+  .quick-actions-grid[class*="up"] {
     grid-template-columns: repeat(2, 1fr);
   }
-}
 
-@media (768px <= width < 1280px) {
-  .quick-actions-grid.six-up {
-    grid-template-columns: repeat(3, 1fr);
+  @supports (animation-timeline: view()) {
+    .quick-actions-grid.parallax-stagger-ltr {
+      animation-name: none;
+
+      > :not([class*="section-"]) {
+        animation-name: enable-parallax-stagger;
+      }
+    }
   }
 }
 

--- a/libs/mep/ace1205/quick-actions/quick-actions.js
+++ b/libs/mep/ace1205/quick-actions/quick-actions.js
@@ -40,15 +40,29 @@ function buildTile(tileRow) {
   return tile;
 }
 
-const N_UP_MAP = { 2: 'two-up', 3: 'three-up', 4: 'four-up' };
+const mediaQueries = {
+  mobile: window.matchMedia('(width < 768px)'),
+  tablet: window.matchMedia('(768px <= width < 1280px)'),
+};
+
+const N_UP = { mobile: 'two-up', tablet: 'three-up', desktop: 'six-up' };
 
 function decorate(block) {
   const header = decorateSectionHeader(block);
   const tileRows = [...block.children].filter((row) => row.children.length >= 2);
-  const nUp = N_UP_MAP[tileRows.length] || 'six-up';
-  const grid = createTag('div', { class: `quick-actions-grid ${nUp}` });
+  const grid = createTag('div', { class: 'quick-actions-grid parallax-stagger-ltr' });
 
   tileRows.forEach((row) => grid.append(buildTile(row)));
+
+  const applyNUp = () => {
+    let key = 'desktop';
+    if (mediaQueries.mobile.matches) key = 'mobile';
+    else if (mediaQueries.tablet.matches) key = 'tablet';
+    grid.classList.remove(...Object.values(N_UP));
+    grid.classList.add(N_UP[key]);
+  };
+  applyNUp();
+  Object.keys(mediaQueries).forEach((k) => mediaQueries[k].addEventListener('change', applyNUp));
 
   block.replaceChildren(...[header, grid].filter(Boolean));
 }

--- a/libs/mep/ace1205/section-metadata/section-metadata.js
+++ b/libs/mep/ace1205/section-metadata/section-metadata.js
@@ -2,8 +2,8 @@ import { handleFocalpoint } from '../../../utils/decorate.js';
 import { createTag } from '../../../utils/utils.js';
 
 const mediaQueries = {
-  mobile: window.matchMedia('(max-width: 767px)'),
-  tablet: window.matchMedia('(min-width: 768px) and (max-width: 1023px)'),
+  mobile: window.matchMedia('(width < 768px)'),
+  tablet: window.matchMedia('(768px <= width < 1280px)'),
 };
 
 export function handleBackground(div, section) {


### PR DESCRIPTION
This contains a few updates to consolidate staggering animation functionality:
* move stagger declarations outside of the mobile media query, so it can be enabled more easily on any breakpoint via declaring the animation name alone;
* standardizes `.X-up` values across viewports for quick-actions block. This is still not authorable, but it gets us one step closer;
* enables the staggering animation for quick-action tiles even below `768px`;
* updates the tablet definition in section-metadata to match grid definitions and its own media queries defined in its CSS file.

Resolves: [MWPW-197870](https://jira.corp.adobe.com/browse/MWPW-197870)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=stagger-quick-actions&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


