### PR TITLE
VQA for left-split and plans-hero

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -987,7 +987,7 @@ p {
 
   .icon-button {
     margin-inline-start: var(--s2a-spacing-sm);
-  } 
+  }
 
   &:hover,
   &:focus {

--- a/libs/mep/ace1205/plans-hero/plans-hero.css
+++ b/libs/mep/ace1205/plans-hero/plans-hero.css
@@ -1,11 +1,10 @@
 .plans-hero {
-  --plans-hero-height: 400px;
   --plans-hero-cols: 4;
 
   position: relative;
   display: flex;
   align-items: center;
-  min-height: var(--plans-hero-height);
+  min-height: 400px;
   color: var(--s2a-color-content-knockout);
 }
 
@@ -23,8 +22,8 @@
   }
 
   &::after {
-    --scrim-stop-start: -84.26%;
-    --scrim-stop-end: 25.77%;
+    --scrim-stop-start: -94.26%;
+    --scrim-stop-end: 35.77%;
 
     content: '';
     position: absolute;
@@ -57,33 +56,27 @@
 
 @media (width >= 768px) {
   .plans-hero {
-    --plans-hero-height: 284px;
     --plans-hero-cols: 6;
+
+    min-height: min-content;
+    height: 35vw;
+    max-height: 600px;
   }
 
   .plans-hero-media::after {
-    --scrim-stop-start: 0.88%;
-    --scrim-stop-end: 69.65%;
+    --scrim-stop-start: 50.27%;
+    --scrim-stop-end: 99.12%;
   }
 }
 
 @media (width >= 1024px) {
   .plans-hero {
-    --plans-hero-height: 436px;
     --plans-hero-cols: 5;
-  }
-}
-
-@media (width >= 1280px) {
-  .plans-hero {
-    --plans-hero-height: 452px;
   }
 }
 
 @media (width >= 1440px) {
   .plans-hero {
-    --plans-hero-height: 800px;
-
     align-items: flex-start;
   }
 

--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -56,6 +56,10 @@
 
   &.left-split .action-area {
     align-items: center;
+
+    .con-button.transparent {
+      text-decoration: underline;
+    }
   }
 
   &.jump-link {
@@ -226,7 +230,7 @@
     padding-block-start: var(--s2a-layout-md);
     padding-block-end: var(--s2a-spacing-4xl);
 
-    &.hero { 
+    &.hero {
       height: 580px;
       padding-block-start: var(--s2a-layout-sm);
     }


### PR DESCRIPTION
This addresses the following VQA items:
* the plans hero should be set at `35vw` above mobile viewports; on mobile it should remain at `400px`; its `max-height` should be `600px`;
* the scrim should be updated to allow for more transparency of the image underneath, while still meeting color contrast requirements; mobile value is not yet final, it could get further updates;
* the `left-split` variant of the Rich Content should have its phone number be turned into a transparent button (authoring) and its text should be underlined.


Resolves: VQA feedback

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=plans-hero-left-split-vqa&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


