### PR TITLE
Update plans hero scrim values on mobile

### DIFF
--- a/libs/mep/ace1205/plans-hero/plans-hero.css
+++ b/libs/mep/ace1205/plans-hero/plans-hero.css
@@ -22,8 +22,8 @@
   }
 
   &::after {
-    --scrim-stop-start: -94.26%;
-    --scrim-stop-end: 35.77%;
+    --scrim-stop-start: 0.88%;
+    --scrim-stop-end: 99.12%;
 
     content: '';
     position: absolute;


### PR DESCRIPTION
Updates the scrim values for the Plans Hero block on mobile.

Resolves: VQA feedback

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=update-plans-hero-scrim&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


