### PR TITLE
[SR] Tabs Block (Wave 2) - enable staggered animation on mobile

### DIFF
--- a/libs/mep/ace1205/tabs/tabs.css
+++ b/libs/mep/ace1205/tabs/tabs.css
@@ -166,32 +166,31 @@
   }
 }
 
-@media (width >= 768px) {
-  /* Animation for tab content entrance */
-  @keyframes tab-content-in {
-    from {
-      opacity: 0;
-      transform: translateY(16px);
-    }
-
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
+/* Animation for tab content entrance */
+@keyframes tab-content-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
   }
 
-  .tabs.staggered-intro-merch-cards .tab-content-container [role='tabpanel'].tab-entering .section merch-card {
-    animation: tab-content-in 0.5s ease both;
-
-    &:nth-child(2) { animation-delay: 0.1s; }
-    &:nth-child(3) { animation-delay: 0.2s; }
-    &:nth-child(4) { animation-delay: 0.3s; }
-    &:nth-child(5) { animation-delay: 0.4s; }
-    &:nth-child(6) { animation-delay: 0.5s; }
-    &:nth-child(7) { animation-delay: 0.6s; }
-    &:nth-child(8) { animation-delay: 0.7s; }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
+
+.tabs.staggered-intro-merch-cards .tab-content-container [role='tabpanel'].tab-entering .section merch-card {
+  animation: tab-content-in 0.5s ease both;
+  
+  &:nth-child(2) { animation-delay: 0.1s; }
+  &:nth-child(3) { animation-delay: 0.2s; }
+  &:nth-child(4) { animation-delay: 0.3s; }
+  &:nth-child(5) { animation-delay: 0.4s; }
+  &:nth-child(6) { animation-delay: 0.5s; }
+  &:nth-child(7) { animation-delay: 0.6s; }
+  &:nth-child(8) { animation-delay: 0.7s; }
+}
+
 
 @media (prefers-reduced-motion: reduce) {
   .tabs.staggered-intro-merch-cards .tab-content-container [role='tabpanel'].tab-entering .section merch-card {

--- a/libs/mep/ace1205/tabs/tabs.js
+++ b/libs/mep/ace1205/tabs/tabs.js
@@ -68,7 +68,6 @@ const saveActiveTabInStorage = (targetId, config) => {
 };
 
 function triggerTabEnterAnimation(panel) {
-  if (!window.matchMedia('(width >= 768px)').matches) return;
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
   const cards = [...panel.querySelectorAll('.section merch-card')];
   if (!cards.length) return;


### PR DESCRIPTION
Quick PR that enables the staggered animations within the mobile tab content containers.

Context:
The tabs prototype has different animations on mobile, but PDM has confirmed that we should emulate the desktop animations for mobile as well. 

Features:
1. CSS and JS now support `.staggered-intro-merch-cards` on mobile breakpoint. 

Implementation: 
1. Removed the check for mobile breakpoint from JS. 
2. Moved CSS rules to outside of media query. 
3. `prefers-reduced-motion` is still supported. 

Resolves: [[MWPW-192897](https://jira.corp.adobe.com/browse/MWPW-192897) (universal Tab block)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=sr2-tabs-mobile-animation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all




