### PR TITLE
[Site Redesign] - Fix some VQA issues for tour block

### DIFF
--- a/libs/mep/ace1205/tour/tour.css
+++ b/libs/mep/ace1205/tour/tour.css
@@ -176,6 +176,14 @@
   will-change: transform;
   & > .fragment {
     max-height: 100%;
+    /* Firefox */
+    scrollbar-width: none;
+    /* IE and old Edge */
+    -ms-overflow-style: none;
+    /* Chrome, Safari, Edge (Chromium), Opera */
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 
   &.is-dragging {
@@ -190,13 +198,23 @@
     width: 48px;
     height: 48px;
     border-radius: 6px;
-    background-color: rgba(242, 242, 242, 1);
-    border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-black-12);
+    background-color: var(--s2a-color-gray-75);
+    border: var(--s2a-border-width-sm) solid var(--s2a-color-gray-200);
     top: var(--s2a-spacing-md);
     right: var(--s2a-spacing-md);
-    &::before,
-    &::after {
-      width: calc(10px * 1.33);
+
+    &:hover {
+      background-color: var(--s2a-color-gray-300);
+      border-color: var(--s2a-color-gray-400);
+    }
+
+    &:active {
+      background-color: var(--s2a-color-background-knockout);
+      border-color: var(--s2a-color-gray-700);
+      &::before,
+      &::after {
+        background-color: var(--s2a-color-content-knockout);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Fix below VQA issues:

- Added default, hover and active state for close button as per Figma [comment](https://www.figma.com/design/lOFnBFhsYyFWPbSdiPa9us?node-id=16483-36665#1794078135).
- Hide scroll bar for all modern browsers for Tour modal.


Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URL:**
https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=tour-vqa&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all#marketing-tour


