### PR TITLE
MWPW-197953 [NPS] Some locales cause the scale label to overflow the container

### DIFF
--- a/libs/blocks/nps-csat-form/nps-csat-form.css
+++ b/libs/blocks/nps-csat-form/nps-csat-form.css
@@ -567,6 +567,7 @@ body:has(.nps-csat-form.dark.match-background) {
 
 .nps-csat-form.eleven-point-nps .nps-scale-label--low {
   text-align: start;
+  overflow-wrap: anywhere;
 }
 
 .nps-csat-form.eleven-point-nps .nps-scale-label--high {

--- a/libs/blocks/nps-csat-form/nps-csat-form.css
+++ b/libs/blocks/nps-csat-form/nps-csat-form.css
@@ -571,6 +571,7 @@ body:has(.nps-csat-form.dark.match-background) {
 
 .nps-csat-form.eleven-point-nps .nps-scale-label--high {
   text-align: end;
+  overflow-wrap: anywhere;
 }
 
 .nps-csat-form.eleven-point-nps .nps-picker {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* https://nps-scale-label-textwrap--milo--adobecom.aem.page/de/nps-csat/adobe-home/adobe-home-nps-csat

Resolves: [MWPW-197953](https://jira.corp.adobe.com/browse/MWPW-197953)



