### PR TITLE
[MWPW-195208]: [Accessibility] Fixed modal initial focus without breaking focus trap

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -239,14 +239,10 @@ export async function getModal(details, custom) {
 
   const focusVisible = { focusVisible: true };
   const focusablesOnLoad = [...dialog.querySelectorAll(FOCUSABLES)];
-  const titleOnLoad = dialog.querySelector('h1, h2, h3, h4, h5');
   let firstFocusable;
 
   if (focusablesOnLoad.length && isElementInView(focusablesOnLoad[0])) {
     firstFocusable = focusablesOnLoad[0]; // eslint-disable-line prefer-destructuring
-  } else if (titleOnLoad) {
-    titleOnLoad.setAttribute('tabIndex', 0);
-    firstFocusable = titleOnLoad;
   } else {
     firstFocusable = close;
   }
@@ -283,7 +279,10 @@ export async function getModal(details, custom) {
   dialog.append(focusPlaceholder);
   document.body.append(dialog);
   dialogLoadingSet.delete(id);
-  firstFocusable?.focus({ preventScroll: true, ...focusVisible });
+  firstFocusable?.focus({
+    preventScroll: true,
+    focusVisible: document.activeElement?.matches?.(':focus-visible'),
+  });
   window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -279,10 +279,7 @@ export async function getModal(details, custom) {
   dialog.append(focusPlaceholder);
   document.body.append(dialog);
   dialogLoadingSet.delete(id);
-  firstFocusable?.focus({
-    preventScroll: true,
-    focusVisible: document.activeElement?.matches?.(':focus-visible'),
-  });
+  firstFocusable?.focus({ preventScroll: true, ...focusVisible });
   window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -182,7 +182,7 @@ describe('Modals', () => {
     await waitForRemoval('#paragraph');
   });
 
-  it('Focuses on a header when there are no other focusables', async () => {
+  it('Focuses on close instead of heading when there are no focusables', async () => {
     const meta = document.createElement('meta');
     meta.name = '-title';
     meta.content = 'http://localhost:2000/test/blocks/modals/mocks/title';
@@ -191,7 +191,8 @@ describe('Modals', () => {
     await delay(200);
     await waitForElement('#title');
     expect(document.getElementById('title')).to.exist;
-    expect(document.activeElement.getAttribute('id')).to.equal('test-title');
+    expect(document.querySelector('#test-title')?.hasAttribute('tabindex')).to.be.false;
+    expect(document.activeElement.classList.contains('dialog-close')).to.be.true;
     window.location.hash = '';
     await waitForRemoval('#title');
   });


### PR DESCRIPTION
## Summary
- Fixes modal focus management regressions introduced by an earlier focus-trap change, while keeping tab focus trapped inside open modals.
- An earlier change kept focus inside open modals by focusing the first heading and adding `tabindex="0"` to it. That addressed the focus-trap issue but introduced new problems: a visible focus ring on non-interactive heading text, screen readers skipping content above the headline.
- This PR corrects initial focus handling while preserving the existing tab trap.

**Related tickets:**
- **[Previous Focus trap ticket](https://jira.corp.adobe.com/browse/MWPW-120941)** — Modals don't have a focus trap (tab could leave the modal while open)
- **[Current ticket](https://jira.corp.adobe.com/browse/MWPW-195208)** — Modal initial focus lands on static heading and screen reader users miss content above the headline.

## Problem
A prior fix for the focus-trap issue set `tabindex="0"` on the first heading and moved focus to it when no in-view focusables were present. That kept focus inside the modal, but caused new accessibility issues:
- Keyboard focus appeared on non-interactive heading text (visible blue outline)
- Screen reader focus jumped to the headline and skipped content above it (e.g. product name), impacting meaningful sequence (WCAG 1.3.2)

## Changes
- **`milo/libs/blocks/modal/modal.js`**
  - Removed the heading `tabindex="0"` fallback when no in-view focusables are present.
  - Initial focus now moves to the **Close** button in that scenario.
  - Existing focus-trap logic (`dialog-focus-placeholder`, Shift+Tab handling) is unchanged.
  - Modals with in-view focusables still receive initial focus on the first focusable element, as before.
- **`milo/test/blocks/modals/modals.test.js`**
  - Updated test to expect Close as the initial focus target when no focusables are present.
  - Added assertion that the heading does not receive a `tabindex`.
  
**Resolves:**  [MWPW-195208](https://jira.corp.adobe.com/browse/MWPW-195208)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.live/creativecloud/you-asked-we-answered?martech=off
- After: https://main--da-cc--adobecom.aem.live/creativecloud/you-asked-we-answered?milolibs=mwpw-195208-modal-a11y--milo--hkuraware&martech=off

**Dev validation:**

**Before:**
<img width="1484" height="830" alt="before-heading-focus" src="https://github.com/user-attachments/assets/f17d7e49-f0db-4ee6-980e-5dbee16522af" />
<img width="1059" height="548" alt="before-screen-reader-focus" src="https://github.com/user-attachments/assets/3cd090ab-f5e9-4b53-9349-9d673772a4e8" />

**After:**
<img width="1484" height="830" alt="after-keyboard-button-focus" src="https://github.com/user-attachments/assets/00a3d7d5-388a-4362-b0e2-2722457801ae" />
<img width="1484" height="830" alt="after-screen-reader" src="https://github.com/user-attachments/assets/d81ca2d6-e6b0-464b-ab34-a9461c78060b" />



