### PR TITLE
[SR] Tabs Block (Wave 2) - remove scrollbar on mobile breakpoints (desktop)

### DIFF
--- a/libs/mep/ace1205/tabs/tabs.css
+++ b/libs/mep/ace1205/tabs/tabs.css
@@ -106,6 +106,8 @@
   }
 
   @media (width < 768px) {
+    overflow-x: clip;
+    
     .tabs-wrapper {
       width: 100vw;
       position: relative;


### PR DESCRIPTION
Quick PR that removes the horizontal scrollbar on DESKTOP for widths <768. 

Context:
- When resizing a desktop browser window to mobile breakpoints, a horizontal scrollbar would appear. 
- Scrollbar is introduced by tabs block, and is only seen on desktop browsers (without emulating a device).

Features:
1. Removes the scrollbar on introduced by tabs on desktop when viewing mobile breakpoints. 

Implementation: 
1. A single line of CSS added to the .tabs container itself for mobile breakpoints.

Resolves: [[MWPW-192897](https://jira.corp.adobe.com/browse/MWPW-192897) (universal Tab block)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=sr2-tabs-overflow-mobile&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all






