### PR TITLE
MWPW-197933: Block merch free-trial links from decorating in gnav

### DIFF
--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -28,8 +28,8 @@ a[is='checkout-link'].con-button > span {
   min-width: 66px;
 }
 
-.hidden-osi-trial-link {
-  display: none;
+a[data-hide-kr-free-trial="true"] {
+  display: none !important;
 }
 
 .price-unit-type:not(.disabled)::before,

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1501,7 +1501,7 @@ export async function buildCta(el, params) {
     const prefix = getConfig()?.locale?.prefix;
     if (!(prefix === '/kr' && cta.value[0]?.offerType === OFFER_TYPE_TRIAL)) return;
     if (shouldAllowKrTrial(el, prefix)) {
-      cta.classList.remove('hidden-osi-trial-link');
+      cta.removeAttribute('data-hide-kr-free-trial');
       return;
     }
     cta.remove();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -568,8 +568,8 @@ export const shouldBlockFreeTrialLinks = (link) => {
   }
 
   if (link.dataset.wcsOsi) {
-    link.classList.add('hidden-osi-trial-link');
-    return true;
+    link.dataset.hideKrFreeTrial = 'true';
+    return false;
   }
 
   const parent = link.parentElement;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -569,7 +569,7 @@ export const shouldBlockFreeTrialLinks = (link) => {
 
   if (link.dataset.wcsOsi) {
     link.classList.add('hidden-osi-trial-link');
-    return false;
+    return true;
   }
 
   const parent = link.parentElement;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Issue: Merch checkout CTA is not hidden despite code detecting that it should be hidden. Reason is, `shouldBlockFreeTrialLinks` recognizes that button should be hidden, recognizes that it is a checkout CTA and adds `hidden-osi-trial-link` class that should hide CTA with `display:none` but it returns `false` and this allows [global-navigation.js](https://github.com/adobecom/milo/blob/stage/libs/blocks/global-navigation/global-navigation.js#L139) to continue to decorate CTA and in the process to remove `hidden-osi-trial-link` which hides the CTA. 

* return `true` if checkout CTA should be hidden


Resolves: [MWPW-197933](https://jira.corp.adobe.com/browse/MWPW-197933)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/kr/drafts/ratko/kr-free-trial-links
- After: https://mwpw-197933-hide-kr-ft--milo--adobecom.aem.page/kr/drafts/ratko/kr-free-trial-links

**EDU URLs:**
- Before: https://main--edu--adobecom.aem.page/kr/education/students/creativecloud
- After: https://main--edu--adobecom.aem.page/kr/education/students/creativecloud?milolibs=mwpw-197933-hide-kr-ft




