### PR TITLE
[SR] Authoring + Product Marquee + Hover List VQA fixes

### DIFF
--- a/libs/mep/ace1205/hover-list/hover-list.css
+++ b/libs/mep/ace1205/hover-list/hover-list.css
@@ -22,7 +22,7 @@
   display: flex;
   gap: var(--s2a-spacing-md);
   padding-block: var(--s2a-spacing-xl);
-  transition: background 0.2s ease;
+  transition: background 0.3s ease;
 
   &:first-child {
     border-block-start: none;
@@ -38,12 +38,14 @@
   align-items: flex-start;
   display: flex;
   flex: 1;
-  gap: var(--s2a-spacing-md);
 }
 
 .hover-list-number {
+  align-items: center;
   color: var(--s2a-color-content-knockout);
+  display: flex;
   flex-shrink: 0;
+  inline-size: var(--s2a-spacing-24);
 }
 
 .hover-list-text {
@@ -89,10 +91,6 @@
     flex: 1;
   }
 
-  .hover-list-copy {
-    gap: var(--s2a-spacing-xs);
-  }
-
   .hover-list-item {
     gap: var(--s2a-spacing-lg);
     padding-block: var(--s2a-spacing-lg);
@@ -107,8 +105,8 @@
   }
 
   .hover-list-number {
-    min-inline-size: var(--s2a-spacing-24);
-    text-align: center;
+    block-size: var(--s2a-spacing-20);
+    padding-inline-start: var(--s2a-spacing-xs);
   }
 
   .hover-list-media {
@@ -148,7 +146,6 @@
     cursor: pointer;
     gap: var(--s2a-spacing-md);
     padding-block: 0;
-    padding-inline: var(--s2a-spacing-xs) var(--s2a-spacing-md);
 
     @media (hover: hover) {
       &:hover {
@@ -157,12 +154,11 @@
     }
   }
 
-  .hover-list-copy {
-    gap: var(--s2a-spacing-md);
-  }
-
   .hover-list-number {
-    min-inline-size: var(--s2a-spacing-40);
+    block-size: var(--s2a-spacing-24);
+    inline-size: var(--s2a-spacing-64);
+    justify-content: center;
+    padding-inline-start: 0;
   }
 
   .hover-list-media {

--- a/libs/mep/ace1205/product-marquee-grid/product-marquee-grid.css
+++ b/libs/mep/ace1205/product-marquee-grid/product-marquee-grid.css
@@ -24,7 +24,7 @@
   .pm-chiclet-row {
     align-items: center;
     display: flex;
-    gap: var(--s2a-spacing-lg);
+    gap: var(--s2a-spacing-md);
 
     img.icon {
       block-size: 50px;
@@ -114,6 +114,10 @@
       --grid-margin-width: var(--s2a-spacing-3xl);
       flex-direction: row;
       padding-block: var(--s2a-layout-lg) var(--s2a-spacing-3xl);
+    }
+
+    .pm-chiclet-row {
+      gap: var(--s2a-spacing-lg);
     }
 
     .pm-chiclet-row img.icon {

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -650,7 +650,7 @@ function isEmptyCell(el) {
 }
 
 function cloneChildren(source) {
-  return [...source.children].map((child) => child.cloneNode(true));
+  return [...source.childNodes].map((child) => child.cloneNode(true));
 }
 
 function parseVariants(text) {


### PR DESCRIPTION
Addressed the following VQA fixes
- Update logic to clone content from smaller viewports - currently if only text content is present in mobile, its not being cloned into tablet and desktop
- Update spacing between product marquee icon and heading
- Update spacing for hover list numbering
- Hover list item animation time update

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://<branch>--milo--adobecom.aem.page/?martech=off

QA:

Before:
https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

After:
https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=hover-pmg-vqa&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

QA: Testing clone content from smaller viewport

Before:
https://main--da-playground--adobecom.aem.page/drafts/nishantkaush/hoverlist/testhoverlist?milolibs=site-redesign-foundation&&mep=%2Fdrafts%2Fnishantkaush%2Ftest-pzn-quick.json--+all

After:
https://main--da-playground--adobecom.aem.page/drafts/nishantkaush/hoverlist/testhoverlist?milolibs=hover-pmg-vqa&&mep=%2Fdrafts%2Fnishantkaush%2Ftest-pzn-quick.json--+all

