### PR TITLE
[SR] - double garage door prolong

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1419,7 +1419,7 @@ span.hang-opening-quote {
   }
 
   @keyframes dg-top-door {
-    from { transform: translateY(-20vh); }
+    from { transform: translateY(-30vh); }
     to { transform: translateY(0); }
   }
 


### PR DESCRIPTION
Make top animation of double-garage-door more noticable.

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=rich-content-jump-top-anim&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


