### PR TITLE
Fix: blocks not searchable in sidekick library

### DIFF
--- a/libs/blocks/library-config/library-utils.js
+++ b/libs/blocks/library-config/library-utils.js
@@ -7,6 +7,8 @@ export function isMatching(container, query, type, titleText) {
 
   switch (type) {
     case 'blocks':
+    case 'c1-blocks':
+    case 'c2-blocks':
       tagsString = getSearchTags(container);
       break;
     case 'templates':


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/MWPW-198110

### Description
Blocks cannot be searched by name in the sidekick library.

`isMatching()` in `library-utils.js` only handled type `'blocks'`, but `library-config.js` passes `'c1-blocks'` or `'c2-blocks'`. The switch fell to `default`, leaving `tagsString` undefined, so every block failed the match check and search returned nothing.

Fix adds `c1-blocks` and `c2-blocks` as fall-through cases to the existing `getSearchTags` branch — a 2-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Test instructions
Tested with a local overwrite.
<img width="373" height="406" alt="image" src="https://github.com/user-attachments/assets/7a1e0f2a-5551-4681-a3ec-fdffda784915" />
