### PR TITLE
[MWPW-198112] Fix NALA fork PR tests always failing due to missing authored content

### DIFF
--- a/nala/utils/global.setup.js
+++ b/nala/utils/global.setup.js
@@ -28,10 +28,17 @@ async function getGitHubPRBranchLiveUrl() {
   // Get the org and repo from the environment variables
   const prFromOrg = process.env.prOrg || toRepoOrg;
   const prFromRepoName = process.env.prRepo || toRepoName;
+  const isFork = process.env.isFork === 'true';
 
   let prBranchLiveUrl;
   if (prBranch === 'main') {
     prBranchLiveUrl = MAIN_BRANCH_LIVE_URL;
+  } else if (isFork) {
+    // Fork PRs: use the target org's base branch for authored content,
+    // and point milolibs at the fork branch so the fork's code is exercised.
+    const baseBranch = process.env.prBaseBranch || 'stage';
+    prBranchLiveUrl = `https://${baseBranch}--${toRepoName}--${toRepoOrg}.aem.live`;
+    process.env.MILO_LIBS = `?milolibs=${prBranch}--${prFromRepoName}--${prFromOrg}`;
   } else {
     prBranchLiveUrl = `https://${prBranch}--${prFromRepoName}--${prFromOrg}.aem.live`;
   }
@@ -50,6 +57,9 @@ async function getGitHubPRBranchLiveUrl() {
     console.info('PR Branch(U)  : ', prBranch);
     console.info('PR Number     : ', prNumber || 'Auto-PR');
     console.info('PR From Branch live url : ', prBranchLiveUrl);
+    if (isFork) {
+      console.info('Fork PR MILO_LIBS       : ', process.env.MILO_LIBS);
+    }
   } catch (err) {
     console.error(`Error => Error in setting PR Branch test URL : ${prBranchLiveUrl}`);
     console.info(`Note: PR branch test url  ${prBranchLiveUrl} is not valid, Exiting test execution.`);


### PR DESCRIPTION
### Description
Fork PRs run tests against the fork's AEM live URL (e.g. \`fix-my-branch--milo--mokimo.aem.live\`) which has no authored content — SharePoint docs only exist under the target org. Every block/commerce/promotions/MEP test fails with "element not found" or timeout because the test pages simply don't exist on the fork's AEM.

**Root cause:** \`global.setup.js\` always builds the test \`baseURL\` from the PR author's org, so fork PRs point to a domain with no content.

**Fix:** When \`isFork=true\`, use the target org's base branch for \`baseURL\` (so all authored content is available) and set \`MILO_LIBS\` to the fork's branch so the PR's code changes are still exercised via \`?milolibs=\`.

All test files already append \`miloLibs\` via \`\${baseURL}\${path}\${miloLibs}\` — no individual test files need touching. The \`isFork\` and \`prBaseBranch\` env vars are already passed by the workflow.

Resolves: [MWPW-198112](https://jira.corp.adobe.com/browse/MWPW-198112)

Related: fixes fork PR failures seen in #6116

🤖 Generated with [Claude Code](https://claude.com/claude-code)



