### PR TITLE
[SR]split-aside-grid: video support

### DIFF
--- a/libs/mep/ace1205/split-aside-grid/split-aside-grid.css
+++ b/libs/mep/ace1205/split-aside-grid/split-aside-grid.css
@@ -67,13 +67,24 @@
         border-radius: 20px;
       }
     }
+    .video-holder {
+      pointer-events: none;
+    }
+
+    video {
+      display: block;
+      width: 100%;
+      height: 100%;
+      -webkit-user-drag: none;
+      border-radius: 20px;
+    }
 
     &:not([data-slot="0"], .incoming) {
       background-color: #E3E2E2;
       box-shadow: 0 68.507px 54.806px 0 rgba(0, 0, 0, 0.14), 0 28.621px 22.897px 0 rgba(0, 0, 0, 0.10), 0 15.302px 12.242px 0 rgba(0, 0, 0, 0.08), 0 8.578px 6.863px 0 rgba(0, 0, 0, 0.07), 0 4.556px 3.645px 0 rgba(0, 0, 0, 0.06), 0 1.896px 1.517px 0 rgba(0, 0, 0, 0.04);
     }
 
-    &:not([data-slot="0"], .show-image) img {
+    &:not([data-slot="0"], .show-image) :is(video, img) {
       opacity: 0;
       transition: opacity 0.3s ease-out;
     }
@@ -206,14 +217,18 @@
       width: 100%;
       height: 100%;
 
-      img {
+      .video-holder {
+        pointer-events: unset;
+      }
+
+      :is(video, img) {
         opacity: 0;
         transition: opacity var(--dropdown-transition);
       }
 
       &[data-slot="0"] {
         opacity: 1;
-        img {
+        :is(video, img) {
           opacity: 1;
         }
       }
@@ -358,14 +373,27 @@
   }
 }
 
-@media (width >= 1920px) {
+@media (width >= 1600px) {
   .split-aside-grid-stack {
+    padding-inline-end: var(--grid-padding);
     inset-inline-end: unset;
   }
 }
 
-@media (width >= 2560px) {
-  .split-aside-grid {
-    padding-inline-end: var(--grid-padding);
+:root:has(meta[name="foundation"][content="c2"]) {
+  @media (width >= 768px) and (width <= 1600px) {
+    .split-aside-grid {
+      --border-padding: calc(var(--s2a-border-width-1) + var(--s2a-spacing-xs));
+      --btn-size: 32px;
+      --right-spacing: var(--s2a-spacing-lg);
+      button.play-pause-button {
+        right: calc(var(--button-right) - var(--border-padding) + var(--right-spacing));
+      }
+    }
+  }
+  @media (width >= 1280px) {
+    .split-aside-grid {
+      --right-spacing: var(--s2a-spacing-xl);
+    }
   }
 }

--- a/libs/mep/ace1205/split-aside-grid/split-aside-grid.js
+++ b/libs/mep/ace1205/split-aside-grid/split-aside-grid.js
@@ -1,4 +1,4 @@
-import { decorateBlockText, decorateViewportContent } from '../../../utils/decorate.js';
+import { decorateBlockText, decorateViewportContent, syncPausePlayIcon, USER_PAUSED_ATTR } from '../../../utils/decorate.js';
 import { createTag } from '../../../utils/utils.js';
 
 const SWIPE_THRESHOLD = 20;
@@ -11,6 +11,8 @@ const reducedMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)'
 const DESKTOP_MQ = '(width >= 768px)';
 const CHEVRON_SVG = '<svg viewBox="0 0 12 12" aria-hidden="true" focusable="false"><path d="M4 1l5 5-5 5" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>';
 const FOCUSABLE_SELECTOR = 'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"]), video';
+let videoObserver = null;
+let resizeObserver = null;
 
 function markStandaloneLinks(foreground) {
   foreground.querySelectorAll('a').forEach((a) => {
@@ -20,6 +22,41 @@ function markStandaloneLinks(foreground) {
     const linkText = a.textContent?.trim() ?? '';
     parent?.classList.replace('body-md', 'link-container');
     if (parentText === linkText) a.classList.add('standalone-link', 'label');
+  });
+}
+
+function replaceVideoIntersectionObserver(medias) {
+  medias.forEach((media) => {
+    const videoEl = media.querySelector('video');
+    if (!videoEl) return;
+    const oldObserver = window?.videoIntersectionObs;
+    if (oldObserver) oldObserver.unobserve(videoEl);
+
+    if (videoObserver) {
+      videoObserver.observe(videoEl);
+      return;
+    }
+
+    videoObserver = new window.IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        const { isIntersecting, target: video } = entry;
+        const isHaveLoopAttr = video.getAttributeNames().includes('loop');
+        const { playedOnce = false } = video.dataset;
+        const isUserPaused = video.hasAttribute(USER_PAUSED_ATTR);
+        const isPlaying = video.currentTime > 0 && !video.paused && !video.ended
+          && video.readyState > video.HAVE_CURRENT_DATA;
+        const isActive = video.closest('.media')?.getAttribute('data-slot') === '0';
+
+        if (!isIntersecting) {
+          if (isPlaying && (!playedOnce && !isUserPaused)) syncPausePlayIcon(video);
+          video.pause();
+        } else if (!isUserPaused && (isHaveLoopAttr || !playedOnce) && !isPlaying && isActive) {
+          video.play();
+          syncPausePlayIcon(video, { type: 'playing' });
+        }
+      });
+    }, { threshold: 0.4 });
+    videoObserver.observe(videoEl);
   });
 }
 
@@ -116,6 +153,18 @@ function setupBlock(el) {
       m.style.setProperty('--split-aside-grid-stack-index', slot);
       m.style.setProperty('--split-aside-grid-stack-slot', slot);
       m.dataset.slot = String(slot);
+      const isActive = slot === 0;
+      const video = m.querySelector('video');
+      if (!video) return;
+      const { playedOnce = false } = video.dataset;
+      if (playedOnce) return;
+      if (isActive) {
+        video.play();
+        syncPausePlayIcon(video, { type: 'playing' });
+        return;
+      }
+      video.pause();
+      syncPausePlayIcon(video);
     });
 
     items.forEach((item, idx) => {
@@ -385,16 +434,35 @@ function setupBlock(el) {
     el.removeEventListener('keydown', onKeyDown);
   }
 
+  function addResizeObserver() {
+    resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { scrollWidth } = el;
+      const width = document.documentElement.clientWidth;
+      stack.style.setProperty('--button-right', `${scrollWidth - width}px`);
+    });
+    resizeObserver.observe(el);
+  }
+
+  function removeResizeObserver() {
+    if (!resizeObserver) return;
+    resizeObserver.disconnect();
+    resizeObserver = null;
+  }
+
   function bindDesktop() {
     if (desktopBound) return;
     desktopBound = true;
     items.forEach((item) => item.addEventListener('click', onItemClick));
+    addResizeObserver();
   }
 
   function unbindDesktop() {
     if (!desktopBound) return;
     desktopBound = false;
     items.forEach((item) => item.removeEventListener('click', onItemClick));
+    removeResizeObserver();
   }
 
   function syncBindings() {
@@ -457,6 +525,7 @@ function decorate(block) {
     'aria-atomic': 'true',
   });
   block.append(itemsWrap, ariaLive);
+  replaceVideoIntersectionObserver(medias);
 }
 
 export default function init(el) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Add video support for `split-aside-grid`
* On desktop, when different dropdown is activated, video should pause

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=spli-aside-grid-video&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


