### PR TITLE
[SR] - Fix video not pausing when out of viewport

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -450,23 +450,24 @@ function getVideoIntersectionObserver() {
   if (!window?.videoIntersectionObs) {
     window.videoIntersectionObs = new window.IntersectionObserver((entries) => {
       entries.forEach((entry) => {
-        const { intersectionRatio, target: video } = entry;
+        const { isIntersecting, intersectionRatio, target: video } = entry;
         const isHaveLoopAttr = video.getAttributeNames().includes('loop');
         const { playedOnce = false } = video.dataset;
         const isUserPaused = video.hasAttribute(USER_PAUSED_ATTR);
         const isPlaying = video.currentTime > 0 && !video.paused && !video.ended
           && video.readyState > video.HAVE_CURRENT_DATA;
+        const playInViewport = video.hasAttribute('data-play-viewport');
         const canPlay = !isUserPaused && (isHaveLoopAttr || !playedOnce) && !isPlaying;
 
-        if (intersectionRatio <= 0.8) {
+        if (!isIntersecting) {
           if (isPlaying && (!playedOnce && !isUserPaused)) syncPausePlayIcon(video);
           video.pause();
-        } else if (canPlay) {
+        } else if (canPlay && (!playInViewport || intersectionRatio > 0.8)) {
           video.play();
           syncPausePlayIcon(video, { type: 'playing' });
         }
       });
-    }, { threshold: [0.8] });
+    }, { threshold: [0, 0.8] });
   }
   return window.videoIntersectionObs;
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -450,24 +450,23 @@ function getVideoIntersectionObserver() {
   if (!window?.videoIntersectionObs) {
     window.videoIntersectionObs = new window.IntersectionObserver((entries) => {
       entries.forEach((entry) => {
-        const { isIntersecting, intersectionRatio, target: video } = entry;
+        const { intersectionRatio, target: video } = entry;
         const isHaveLoopAttr = video.getAttributeNames().includes('loop');
         const { playedOnce = false } = video.dataset;
         const isUserPaused = video.hasAttribute(USER_PAUSED_ATTR);
         const isPlaying = video.currentTime > 0 && !video.paused && !video.ended
           && video.readyState > video.HAVE_CURRENT_DATA;
-        const playInViewport = video.hasAttribute('data-play-viewport');
         const canPlay = !isUserPaused && (isHaveLoopAttr || !playedOnce) && !isPlaying;
 
-        if (!isIntersecting) {
+        if (intersectionRatio <= 0.8) {
           if (isPlaying && (!playedOnce && !isUserPaused)) syncPausePlayIcon(video);
           video.pause();
-        } else if (canPlay && (!playInViewport || intersectionRatio > 0.8)) {
+        } else if (canPlay) {
           video.play();
           syncPausePlayIcon(video, { type: 'playing' });
         }
       });
-    }, { threshold: [0, 0.8] });
+    }, { threshold: [0.8] });
   }
   return window.videoIntersectionObs;
 }

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -441,40 +441,45 @@ export function handleObjectFit(bgRow) {
   });
 }
 
+function shouldUseViewportObserver(video) {
+  if (!video || video.hasAttribute('data-hoverplay') || video.controls) return false;
+  return video.hasAttribute('data-play-viewport') || video.hasAttribute('autoplay');
+}
+
 function getVideoIntersectionObserver() {
   if (!window?.videoIntersectionObs) {
     window.videoIntersectionObs = new window.IntersectionObserver((entries) => {
       entries.forEach((entry) => {
-        const { intersectionRatio, target: video } = entry;
+        const { isIntersecting, intersectionRatio, target: video } = entry;
         const isHaveLoopAttr = video.getAttributeNames().includes('loop');
         const { playedOnce = false } = video.dataset;
         const isUserPaused = video.hasAttribute(USER_PAUSED_ATTR);
         const isPlaying = video.currentTime > 0 && !video.paused && !video.ended
           && video.readyState > video.HAVE_CURRENT_DATA;
+        const playInViewport = video.hasAttribute('data-play-viewport');
+        const canPlay = !isUserPaused && (isHaveLoopAttr || !playedOnce) && !isPlaying;
 
-        if (intersectionRatio <= 0.8) {
+        if (!isIntersecting) {
           if (isPlaying && (!playedOnce && !isUserPaused)) syncPausePlayIcon(video);
           video.pause();
-        } else if (!isUserPaused && (isHaveLoopAttr || !playedOnce) && !isPlaying) {
+        } else if (canPlay && (!playInViewport || intersectionRatio > 0.8)) {
           video.play();
           syncPausePlayIcon(video, { type: 'playing' });
         }
       });
-    }, { threshold: [0.8] });
+    }, { threshold: [0, 0.8] });
   }
   return window.videoIntersectionObs;
 }
 
 function applyInViewPortPlay(video) {
-  if (!video) return;
-  if (video.hasAttribute('data-play-viewport')) {
-    const observer = getVideoIntersectionObserver();
-    video.addEventListener('ended', () => {
-      video.dataset.playedOnce = true;
-      syncPausePlayIcon(video);
-    });
-    observer.observe(video);
-  }
+  if (!shouldUseViewportObserver(video)) return;
+  const observer = getVideoIntersectionObserver();
+  video.addEventListener('ended', () => {
+    video.dataset.playedOnce = true;
+    syncPausePlayIcon(video);
+  });
+  observer.observe(video);
 }
 
 export function decorateMultiViewport(el) {


### PR DESCRIPTION
Fixes bug where videos are not paused when scrolled past, this has been an issue in c1 also.

Resolves: [MWPW-196476](https://jira.corp.adobe.com/browse/MWPW-196476)

**C1 Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/media
- After: https://rich-content-video-performance--milo--adobecom.aem.page/docs/library/kitchen-sink/media

**C2 Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=rich-content-video-performance&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

**Homepage Test URLs:**
- Before: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=site-redesign-foundation
- After: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=rich-content-video-performance

