### PR TITLE
MWPW-198218 Expose getGnavHeight function which will give the gnav height

### DIFF
--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -51,7 +51,7 @@ export default async function init(el) {
   const { main } = await import(federalGnavUrl);
   const gnavUrl = new URL(getMetadata('gnav-source') || `${config.locale?.contentRoot ?? window.location.origin}/gnav`);
 
-  main({
+  const gnavPromise = main({
     localizeLink,
     gnavSource: gnavUrl,
     asideSource: null,
@@ -65,10 +65,14 @@ export default async function init(el) {
       handleCommands: personalizationHandler,
     },
   }).catch((error) => {
+    console.log(error);
     window.lana?.log?.('Failed to initialize federal global navigation', {
       error,
       tags: 'global-navigation',
       errorType: 'e',
     });
+    return {};
   });
+  config.federal = { fedsGlobalNavigaton: gnavPromise };
+  console.log(config);
 }

--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -73,6 +73,6 @@ export default async function init(el) {
     });
     return {};
   });
-  config.federal = { fedsGlobalNavigaton: gnavPromise };
+  config.federal = { fedsGlobalNavigation: gnavPromise };
   console.log(config);
 }

--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -65,7 +65,6 @@ export default async function init(el) {
       handleCommands: personalizationHandler,
     },
   }).catch((error) => {
-    console.log(error);
     window.lana?.log?.('Failed to initialize federal global navigation', {
       error,
       tags: 'global-navigation',

--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -74,5 +74,4 @@ export default async function init(el) {
     return {};
   });
   config.federal = { fedsGlobalNavigation: gnavPromise };
-  console.log(config);
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

The call to `main` in `global-navigation.js` returns an object of type `Promise<GlobalNavigation>` where `GlobalNavigation` has the following type:
```typescript
type GlobalNavigation = {
  closeEverything: () => void; // Unimplemented
  reloadUnav: () => void;
  getGnavTopPosition: () => number; // Unimplemented
  setGnavTopPosition: (_: number) => void; // Unimplemented
  getGnavHeight: () => number;
  errors: Set<RecoverableError>;
}
```
The promise of this object is placed into config: `config.federal.fedsGlobalNavigation`

Usage:

```javascript

// ...
const config = getConfig()
// Use optional chaining to be safe in all scenarios
const globalNavigation = await config.federal?.fedsGlobalNavigation;
const globalNavigationHeight = globalNavigation.getGnavHeight?.();
// ...
```

The object is a promise because the gnav is rendered as an asynchronous process and we do not want to block the main thread by awaiting it until we absolutely have to. We also want to avoid race conditions where a procedure may reach for the `fedsGlobalNavigation` object but not find it because the gnav has not rendered yet. The promise solves both these issues.


Resolves: [MWPW-198218](https://jira.corp.adobe.com/browse/MWPW-198218)

Context on Slack: https://adobe-mwp.slack.com/archives/C0B5BMRG0H1/p1781109476949599?thread_ts=1781022586.986819&cid=C0B5BMRG0H1




