### PR TITLE
[SR] Offer hero - a11y hotfix

### DIFF
--- a/libs/mep/ace1205/offer-hero/offer-hero.css
+++ b/libs/mep/ace1205/offer-hero/offer-hero.css
@@ -97,18 +97,8 @@
     display: flex;
   }
 
-  .hero-card:focus-within {
-    outline: 2px solid var(--s2a-color-blue-800);
-    border-radius: var(--s2a-border-radius-24);
-    outline-offset: 2px;
-  }
-
   a.hero-card-tile {
     text-decoration: none;
-
-    &:focus-visible {
-      outline: none;
-    }
 
     &:hover .learn-more svg {
       transform: translate3d(var(--s2a-spacing-4), 0, 0);
@@ -136,7 +126,6 @@
     transform-origin: top left;
     padding-top: calc(100% * 100 / 109);
     will-change: transform;
-    clip-path: inset(0 round var(--s2a-border-radius-24));
   }
 
   &:dir(rtl) .hero-card-tile {


### PR DESCRIPTION
## Description
This PR is allowing the offer hero cards to use the default browser focus outline instead of the css defined one.

## Testing instructions
- use tab to navigate the page and make sure the focus outline is visible for the offer hero cards
- test if the rounded corners of the offer hero cards are still there

## Test URL
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=offer-hero&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all








