### PR TITLE
MWPW-194951 Add auto-detect Lingo to CaaS bulk publisher

### DIFF
--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -612,7 +612,7 @@ export async function isLingoLangFirstPath(origin, path, fqdn = 'www.adobe.com')
     for (const { uniqueSiteId: sid, baseSite, regionalSites } of siteLocalesData) {
       if (sid === uniqueSiteId) {
         const baseLocale = baseSite.split('/')[1] || '';
-        if (localeStr === baseLocale) {
+        if (localeStr !== '' && localeStr === baseLocale) {
           foundInMapping = true;
           break;
         }

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -580,8 +580,9 @@ export function initBulkPublisherLingoMapping() {
 /**
  * Returns true when the path's locale is known to require Language First Localization,
  * false when it is known NOT to (e.g. English regional sites like gb, au, in, jp, kr),
- * and null when the origin is not present in the lingo-site-mapping at all — meaning the
- * data stream has not been onboarded yet and the caller should fall back to its manual setting.
+ * null when the origin is not present in the lingo-site-mapping at all (unboarded data
+ * stream — caller should default to non-LFL), or throws when the mapping fetch fails
+ * (caller should surface the error rather than silently misclassifying the page).
  */
 export async function isLingoLangFirstPath(origin, path, fqdn = 'www.adobe.com') {
   const configJson = await fetchLingoSiteMapping(fqdn);

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -577,6 +577,44 @@ export function initBulkPublisherLingoMapping() {
   });
 }
 
+/**
+ * Returns true if the path's locale is a regional site of the English base for the given origin.
+ * Used by the bulk publisher to auto-detect whether to skip Language First Localization.
+ * English regional sites (e.g. gb, au, in, jp, kr) do NOT use LFL; all other bacom locales do.
+ */
+export async function isLingoEnglishRegionalSite(origin, path, fqdn = 'www.adobe.com') {
+  try {
+    const configJson = await fetchLingoSiteMapping(fqdn);
+    const siteQueryIndexMap = configJson['site-query-index-map']?.data ?? [];
+    const siteLocalesData = configJson['site-locales']?.data ?? [];
+
+    const matched = siteQueryIndexMap.find(
+      ({ caasOrigin }) => caasOrigin?.toLowerCase() === origin.toLowerCase(),
+    );
+    if (!matched) return false;
+
+    const { uniqueSiteId } = matched;
+
+    let pathname = path;
+    if (!path.startsWith('/')) {
+      try {
+        pathname = new URL(path.startsWith('http') ? path : `https://${path}`).pathname;
+      } catch {
+        pathname = `/${path.split('/').slice(1).join('/')}`;
+      }
+    }
+    const localeStr = pathname.split('/')[1] || '';
+
+    return siteLocalesData.some(({ uniqueSiteId: sid, baseSite, regionalSites }) => (
+      sid === uniqueSiteId
+      && baseSite === '/'
+      && isLocaleInRegionalSites(regionalSites, localeStr)
+    ));
+  } catch {
+    return false;
+  }
+}
+
 async function getIsLingoLocale(origin, country, language, fqdn = 'www.adobe.com') {
   if (origin === 'news') return true;
   const configJson = await fetchLingoSiteMapping(fqdn);

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -578,11 +578,12 @@ export function initBulkPublisherLingoMapping() {
 }
 
 /**
- * Returns true if the path's locale is a regional site of the English base for the given origin.
- * Used by the bulk publisher to auto-detect whether to skip Language First Localization.
- * English regional sites (e.g. gb, au, in, jp, kr) do NOT use LFL; all other bacom locales do.
+ * Returns true only when the path's locale is actively known to require Language First Localization
+ * for the given origin — i.e., it appears in the lingo mapping AND is NOT an English regional site.
+ * Returns false for English regional sites (gb, au, in, jp, kr) and for locales absent from the
+ * mapping entirely (e.g. a news-URL locale processed under the bacom preset).
  */
-export async function isLingoEnglishRegionalSite(origin, path, fqdn = 'www.adobe.com') {
+export async function isLingoLangFirstPath(origin, path, fqdn = 'www.adobe.com') {
   try {
     const configJson = await fetchLingoSiteMapping(fqdn);
     const siteQueryIndexMap = configJson['site-query-index-map']?.data ?? [];
@@ -605,11 +606,25 @@ export async function isLingoEnglishRegionalSite(origin, path, fqdn = 'www.adobe
     }
     const localeStr = pathname.split('/')[1] || '';
 
-    return siteLocalesData.some(({ uniqueSiteId: sid, baseSite, regionalSites }) => (
-      sid === uniqueSiteId
-      && baseSite === '/'
-      && isLocaleInRegionalSites(regionalSites, localeStr)
-    ));
+    let foundInMapping = false;
+    let isEnglishRegional = false;
+
+    for (const { uniqueSiteId: sid, baseSite, regionalSites } of siteLocalesData) {
+      if (sid === uniqueSiteId) {
+        const baseLocale = baseSite.split('/')[1] || '';
+        if (localeStr === baseLocale) {
+          foundInMapping = true;
+          break;
+        }
+        if (isLocaleInRegionalSites(regionalSites, localeStr)) {
+          foundInMapping = true;
+          if (baseSite === '/') isEnglishRegional = true;
+          break;
+        }
+      }
+    }
+
+    return foundInMapping && !isEnglishRegional;
   } catch {
     return false;
   }

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -578,10 +578,10 @@ export function initBulkPublisherLingoMapping() {
 }
 
 /**
- * Returns true only when the path's locale is actively known to require Language First Localization
- * for the given origin — i.e., it appears in the lingo mapping AND is NOT an English regional site.
- * Returns false for English regional sites (gb, au, in, jp, kr) and for locales absent from the
- * mapping entirely (e.g. a news-URL locale processed under the bacom preset).
+ * Returns true when the path's locale is known to require Language First Localization,
+ * false when it is known NOT to (e.g. English regional sites like gb, au, in, jp, kr),
+ * and null when the origin is not present in the lingo-site-mapping at all — meaning the
+ * data stream has not been onboarded yet and the caller should fall back to its manual setting.
  */
 export async function isLingoLangFirstPath(origin, path, fqdn = 'www.adobe.com') {
   try {
@@ -592,7 +592,7 @@ export async function isLingoLangFirstPath(origin, path, fqdn = 'www.adobe.com')
     const matched = siteQueryIndexMap.find(
       ({ caasOrigin }) => caasOrigin?.toLowerCase() === origin.toLowerCase(),
     );
-    if (!matched) return false;
+    if (!matched) return null;
 
     const { uniqueSiteId } = matched;
 

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -584,50 +584,46 @@ export function initBulkPublisherLingoMapping() {
  * data stream has not been onboarded yet and the caller should fall back to its manual setting.
  */
 export async function isLingoLangFirstPath(origin, path, fqdn = 'www.adobe.com') {
-  try {
-    const configJson = await fetchLingoSiteMapping(fqdn);
-    const siteQueryIndexMap = configJson['site-query-index-map']?.data ?? [];
-    const siteLocalesData = configJson['site-locales']?.data ?? [];
+  const configJson = await fetchLingoSiteMapping(fqdn);
+  const siteQueryIndexMap = configJson['site-query-index-map']?.data ?? [];
+  const siteLocalesData = configJson['site-locales']?.data ?? [];
 
-    const matched = siteQueryIndexMap.find(
-      ({ caasOrigin }) => caasOrigin?.toLowerCase() === origin.toLowerCase(),
-    );
-    if (!matched) return null;
+  const matched = siteQueryIndexMap.find(
+    ({ caasOrigin }) => caasOrigin?.toLowerCase() === origin.toLowerCase(),
+  );
+  if (!matched) return null;
 
-    const { uniqueSiteId } = matched;
+  const { uniqueSiteId } = matched;
 
-    let pathname = path;
-    if (!path.startsWith('/')) {
-      try {
-        pathname = new URL(path.startsWith('http') ? path : `https://${path}`).pathname;
-      } catch {
-        pathname = `/${path.split('/').slice(1).join('/')}`;
-      }
+  let pathname = path;
+  if (!path.startsWith('/')) {
+    try {
+      pathname = new URL(path.startsWith('http') ? path : `https://${path}`).pathname;
+    } catch {
+      pathname = `/${path.split('/').slice(1).join('/')}`;
     }
-    const localeStr = pathname.split('/')[1] || '';
-
-    let foundInMapping = false;
-    let isEnglishRegional = false;
-
-    for (const { uniqueSiteId: sid, baseSite, regionalSites } of siteLocalesData) {
-      if (sid === uniqueSiteId) {
-        const baseLocale = baseSite.split('/')[1] || '';
-        if (localeStr !== '' && localeStr === baseLocale) {
-          foundInMapping = true;
-          break;
-        }
-        if (isLocaleInRegionalSites(regionalSites, localeStr)) {
-          foundInMapping = true;
-          if (baseSite === '/') isEnglishRegional = true;
-          break;
-        }
-      }
-    }
-
-    return foundInMapping && !isEnglishRegional;
-  } catch {
-    return false;
   }
+  const localeStr = pathname.split('/')[1] || '';
+
+  let foundInMapping = false;
+  let isEnglishRegional = false;
+
+  for (const { uniqueSiteId: sid, baseSite, regionalSites } of siteLocalesData) {
+    if (sid === uniqueSiteId) {
+      const baseLocale = baseSite.split('/')[1] || '';
+      if (localeStr !== '' && localeStr === baseLocale) {
+        foundInMapping = true;
+        break;
+      }
+      if (isLocaleInRegionalSites(regionalSites, localeStr)) {
+        foundInMapping = true;
+        if (baseSite === '/') isEnglishRegional = true;
+        break;
+      }
+    }
+  }
+
+  return foundInMapping && !isEnglishRegional;
 }
 
 async function getIsLingoLocale(origin, country, language, fqdn = 'www.adobe.com') {

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -556,6 +556,28 @@ const isLocaleInRegionalSites = (regionalSites, locStr, langStr) => {
   );
 };
 
+// A page with no locale prefix (e.g. bacom's base English pages, which live
+// directly at /products/... with no /en/) still has its first path segment
+// extracted positionally by callers below — but that segment is real content,
+// not a locale. Only trust it as a locale if it's one of this site's own known
+// codes (a family's own base code, or any family's regionalSites codes);
+// otherwise the path is unprefixed and belongs to the site's root ('/') family.
+const resolveSiteLocaleStr = (siteLocalesData, uniqueSiteId, rawLocaleStr) => {
+  const knownCodes = new Set();
+  siteLocalesData
+    .filter((entry) => entry.uniqueSiteId === uniqueSiteId)
+    .forEach(({ baseSite, regionalSites }) => {
+      const baseLocale = baseSite?.split('/')[1];
+      if (baseLocale) knownCodes.add(baseLocale);
+      (regionalSites || '')
+        .split(',')
+        .map((site) => site.trim().replace(/^\//, ''))
+        .filter(Boolean)
+        .forEach((code) => knownCodes.add(code));
+    });
+  return knownCodes.has(rawLocaleStr) ? rawLocaleStr : '';
+};
+
 let lingoSiteMappingPromise;
 function fetchLingoSiteMapping(fqdn = 'www.adobe.com') {
   if (!lingoSiteMappingPromise) {
@@ -604,7 +626,8 @@ export async function isLingoLangFirstPath(origin, path, fqdn = 'www.adobe.com')
       pathname = `/${path.split('/').slice(1).join('/')}`;
     }
   }
-  const localeStr = pathname.split('/')[1] || '';
+  const rawLocaleStr = pathname.split('/')[1] || '';
+  const localeStr = resolveSiteLocaleStr(siteLocalesData, uniqueSiteId, rawLocaleStr);
 
   let foundInMapping = false;
   let isEnglishRegional = false;
@@ -612,7 +635,7 @@ export async function isLingoLangFirstPath(origin, path, fqdn = 'www.adobe.com')
   for (const { uniqueSiteId: sid, baseSite, regionalSites } of siteLocalesData) {
     if (sid === uniqueSiteId) {
       const baseLocale = baseSite.split('/')[1] || '';
-      if (localeStr !== '' && localeStr === baseLocale) {
+      if (localeStr === baseLocale) {
         foundInMapping = true;
         break;
       }
@@ -702,7 +725,7 @@ async function getLingoSiteLocale(origin, path, fqdn = 'www.adobe.com') {
       }
     }
   }
-  const localeStr = pathname.split('/')[1];
+  const rawLocaleStr = pathname.split('/')[1] || '';
 
   try {
     let siteId;
@@ -716,10 +739,15 @@ async function getLingoSiteLocale(origin, path, fqdn = 'www.adobe.com') {
     if (matchedByOrigin) {
       siteId = matchedByOrigin.uniqueSiteId;
     }
+    const localeStr = resolveSiteLocaleStr(siteLocalesData, siteId, rawLocaleStr);
     // check if the localeStr is in the baseSite or regionalSites.
     // if not, use the og country/language logic
     if (!siteLocalesData.some(({ uniqueSiteId, baseSite, regionalSites }) => uniqueSiteId === siteId && (localeStr === baseSite.split('/')[1] || isLocaleInRegionalSites(regionalSites, localeStr)))) {
-      const locale = LOCALES[localeStr]?.ietf || 'en-US';
+      // Not part of this site's Lingo mapping — fall back to the classic
+      // Milo locale lookup using the raw (unresolved) path segment, since it
+      // may still be a valid geo-locale prefix even though it isn't one of
+      // this site's own Lingo codes.
+      const locale = LOCALES[rawLocaleStr]?.ietf || 'en-US';
       /* eslint-disable-next-line prefer-const */
       let [currLang, currCountry] = locale.split('-');
       return {
@@ -731,10 +759,14 @@ async function getLingoSiteLocale(origin, path, fqdn = 'www.adobe.com') {
     siteLocalesData
       .filter(({ uniqueSiteId }) => uniqueSiteId === siteId)
       .forEach(({ baseSite, regionalSites }) => {
-        if (localeStr === baseSite.split('/')[1]) {
+        const baseLocale = baseSite.split('/')[1];
+        // baseLocale is '' for the root ('/') family, which has no code of its
+        // own — skip it here and let the pre-initialized {xx, en} default
+        // (above) stand, rather than overwriting it with a blank language.
+        if (baseLocale && localeStr === baseLocale) {
           lingoSiteMapping = {
             country: 'xx',
-            language: baseSite.split('/')[1],
+            language: baseLocale,
           };
           return;
         }
@@ -744,10 +776,11 @@ async function getLingoSiteLocale(origin, path, fqdn = 'www.adobe.com') {
               country: localeStr,
               language: 'en',
             };
+            return;
           }
           lingoSiteMapping = {
             country: localeStr,
-            language: baseSite.split('/')[1],
+            language: baseLocale,
           };
         }
       });

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -559,10 +559,18 @@ const isLocaleInRegionalSites = (regionalSites, locStr, langStr) => {
 // A page with no locale prefix (e.g. bacom's base English pages, which live
 // directly at /products/... with no /en/) still has its first path segment
 // extracted positionally by callers below — but that segment is real content,
-// not a locale. Only trust it as a locale if it's one of this site's own known
-// codes (a family's own base code, or any family's regionalSites codes);
-// otherwise the path is unprefixed and belongs to the site's root ('/') family.
+// not a locale, and must not be mistaken for one just because it occupies
+// that position in the URL. Trust it as a locale when either:
+//  - it's one of this site's own known codes (a family's own base code, or
+//    any family's regionalSites codes), or
+//  - it's a real locale code in Milo's classic locale table (LOCALES) — e.g.
+//    bacom's /uk/ pages: 'uk' isn't onboarded to bacom's Lingo mapping, but
+//    it IS a real locale prefix, so it must fall through to the classic
+//    non-LFL lookup rather than being swept into the unprefixed root family.
+// Otherwise the path is unprefixed and belongs to the site's root ('/') family.
 const resolveSiteLocaleStr = (siteLocalesData, uniqueSiteId, rawLocaleStr) => {
+  if (!rawLocaleStr) return '';
+  if (rawLocaleStr in LOCALES) return rawLocaleStr;
   const knownCodes = new Set();
   siteLocalesData
     .filter((entry) => entry.uniqueSiteId === uniqueSiteId)

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -861,8 +861,8 @@ describe('getCountryAndLang', () => {
         'site-query-index-map': { data: [{ uniqueSiteId: 'hawks-site', caasOrigin: 'hawks' }] },
         'site-locales': {
           data: [
-            { uniqueSiteId: 'hawks-site', baseSite: '/fr', regionalSites: 'be,ch' },
-            { uniqueSiteId: 'hawks-site', baseSite: '/', regionalSites: 'be,us' },
+            { uniqueSiteId: 'hawks-site', baseSite: '/fr', regionalSites: '/be, /ch' },
+            { uniqueSiteId: 'hawks-site', baseSite: '/', regionalSites: '/be, /us' },
           ],
         },
       }),

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -1455,8 +1455,8 @@ describe('isLingoLangFirstPath', () => {
     'site-query-index-map': { data: [{ uniqueSiteId: 'bacom-site', caasOrigin: 'bacom' }] },
     'site-locales': {
       data: [
-        { uniqueSiteId: 'bacom-site', baseSite: '/de', regionalSites: 'at' },
-        { uniqueSiteId: 'bacom-site', baseSite: '/', regionalSites: 'gb,au' },
+        { uniqueSiteId: 'bacom-site', baseSite: '/de', regionalSites: '/at' },
+        { uniqueSiteId: 'bacom-site', baseSite: '/', regionalSites: '/gb, /au' },
       ],
     },
   };

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -1449,7 +1449,8 @@ describe('isLocaleInRegionalSites helper function tests', () => {
 });
 
 describe('isLingoLangFirstPath', () => {
-  // bacom is in mapping; /de/ is a LFL baseSite; /at/ is regional of /de/; /gb/ and /au/ are English regionals
+  // bacom is in mapping; /de/ is a LFL baseSite; /at/ is regional of /de/
+  // /gb/ and /au/ are English regionals
   const MOCK_MAPPING = {
     'site-query-index-map': { data: [{ uniqueSiteId: 'bacom-site', caasOrigin: 'bacom' }] },
     'site-locales': {

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -1492,11 +1492,17 @@ describe('isLingoLangFirstPath', () => {
     expect(result).to.be.false;
   });
 
-  it('returns false when fetch fails', async () => {
+  it('throws when fetch fails so the caller can surface it as an error', async () => {
     window.fetch = stub().rejects(new Error('network error'));
     initBulkPublisherLingoMapping();
-    const result = await isLingoLangFirstPath('bacom', '/de/article', 'test');
-    expect(result).to.be.false;
+    let caught;
+    try {
+      await isLingoLangFirstPath('bacom', '/de/article', 'test');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).to.be.instanceOf(Error);
+    expect(caught.message).to.equal('network error');
   });
 });
 

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -12,6 +12,7 @@ import {
   stageMapToCaasTransforms,
   getGrayboxExperienceId,
   initBulkPublisherLingoMapping,
+  isLingoLangFirstPath,
 } from '../../../libs/blocks/caas/utils.js';
 
 describe('utils.js export sanity', () => {
@@ -1444,6 +1445,57 @@ describe('isLocaleInRegionalSites helper function tests', () => {
       const result = isLocaleInRegionalSites('/ca, /ie, /nz', 'sg');
       expect(result).to.be.false;
     });
+  });
+});
+
+describe('isLingoLangFirstPath', () => {
+  // bacom is in mapping; /de/ is a LFL baseSite; /at/ is regional of /de/; /gb/ and /au/ are English regionals
+  const MOCK_MAPPING = {
+    'site-query-index-map': { data: [{ uniqueSiteId: 'bacom-site', caasOrigin: 'bacom' }] },
+    'site-locales': {
+      data: [
+        { uniqueSiteId: 'bacom-site', baseSite: '/de', regionalSites: 'at' },
+        { uniqueSiteId: 'bacom-site', baseSite: '/', regionalSites: 'gb,au' },
+      ],
+    },
+  };
+  let ogFetch;
+
+  beforeEach(() => {
+    ogFetch = window.fetch;
+    window.fetch = stub().resolves({ ok: true, json: () => Promise.resolve(MOCK_MAPPING) });
+    initBulkPublisherLingoMapping();
+  });
+
+  afterEach(() => {
+    window.fetch = ogFetch;
+  });
+
+  it('returns null when origin is absent from the mapping', async () => {
+    const result = await isLingoLangFirstPath('unknown-origin', '/de/article', 'test');
+    expect(result).to.be.null;
+  });
+
+  it('returns true when locale matches the baseSite of a non-English entry', async () => {
+    const result = await isLingoLangFirstPath('bacom', '/de/article', 'test');
+    expect(result).to.be.true;
+  });
+
+  it('returns true when locale is a regional site of a non-English baseSite', async () => {
+    const result = await isLingoLangFirstPath('bacom', '/at/article', 'test');
+    expect(result).to.be.true;
+  });
+
+  it('returns false when locale is an English regional site', async () => {
+    const result = await isLingoLangFirstPath('bacom', '/gb/article', 'test');
+    expect(result).to.be.false;
+  });
+
+  it('returns false when fetch fails', async () => {
+    window.fetch = stub().rejects(new Error('network error'));
+    initBulkPublisherLingoMapping();
+    const result = await isLingoLangFirstPath('bacom', '/de/article', 'test');
+    expect(result).to.be.false;
   });
 });
 

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -1501,6 +1501,16 @@ describe('isLingoLangFirstPath', () => {
     expect(result).to.be.true;
   });
 
+  it('returns false for a real locale code that is simply not onboarded to this site\'s Lingo mapping', async () => {
+    // 'uk' is not in bacom-site's mapping (mock has no /uk anywhere) but IS a
+    // real locale prefix in Milo's classic locale table — it must fall
+    // through to the classic non-LFL lookup, not be swept into the
+    // unprefixed root family the way genuine content segments (e.g.
+    // "products") are.
+    const result = await isLingoLangFirstPath('bacom', '/uk/article', 'test');
+    expect(result).to.be.false;
+  });
+
   it('throws when fetch fails so the caller can surface it as an error', async () => {
     window.fetch = stub().rejects(new Error('network error'));
     initBulkPublisherLingoMapping();
@@ -1557,6 +1567,15 @@ describe('getLanguageFirstCountryAndLang', () => {
   it('resolves a French-regional path to its country with language fr', async () => {
     const result = await getLanguageFirstCountryAndLang('/be_fr/products/brand-concierge.html', 'bacom', 'test');
     expect(result).to.deep.equal({ country: 'be', lang: 'fr' });
+  });
+
+  it('falls through to the classic locale for a real locale code not onboarded to this site', async () => {
+    // 'uk' isn't in this mock's mapping (no /uk anywhere), but it IS a real
+    // locale in Milo's classic locale table (en-GB) — it must resolve via
+    // that classic lookup, not be misclassified as the unprefixed root
+    // family's en/xx.
+    const result = await getLanguageFirstCountryAndLang('/uk/products/brand-concierge.html', 'bacom', 'test');
+    expect(result).to.deep.equal({ country: 'gb', lang: 'en' });
   });
 });
 

--- a/test/blocks/caas/utils.test.js
+++ b/test/blocks/caas/utils.test.js
@@ -13,6 +13,7 @@ import {
   getGrayboxExperienceId,
   initBulkPublisherLingoMapping,
   isLingoLangFirstPath,
+  getLanguageFirstCountryAndLang,
 } from '../../../libs/blocks/caas/utils.js';
 
 describe('utils.js export sanity', () => {
@@ -1492,6 +1493,14 @@ describe('isLingoLangFirstPath', () => {
     expect(result).to.be.false;
   });
 
+  it('returns true for an unprefixed path (base English page, no locale segment)', async () => {
+    // e.g. business.adobe.com/products/brand-concierge.html: the first path
+    // segment ("products") is real content, not a locale, and must not be
+    // mistaken for one just because it occupies that position in the URL.
+    const result = await isLingoLangFirstPath('bacom', '/products/brand-concierge.html', 'test');
+    expect(result).to.be.true;
+  });
+
   it('throws when fetch fails so the caller can surface it as an error', async () => {
     window.fetch = stub().rejects(new Error('network error'));
     initBulkPublisherLingoMapping();
@@ -1503,6 +1512,51 @@ describe('isLingoLangFirstPath', () => {
     }
     expect(caught).to.be.instanceOf(Error);
     expect(caught.message).to.equal('network error');
+  });
+});
+
+describe('getLanguageFirstCountryAndLang', () => {
+  // Same shape as bacom's real lingo-site-mapping entry: a root ('/') English
+  // family plus a French family, each with their own regional variants.
+  const MOCK_MAPPING = {
+    'site-query-index-map': { data: [{ uniqueSiteId: 'bacom-site', caasOrigin: 'bacom' }] },
+    'site-locales': {
+      data: [
+        { uniqueSiteId: 'bacom-site', baseSite: '/', regionalSites: '/gb, /au' },
+        { uniqueSiteId: 'bacom-site', baseSite: '/fr', regionalSites: '/be_fr' },
+      ],
+    },
+  };
+  let ogFetch;
+
+  beforeEach(() => {
+    ogFetch = window.fetch;
+    window.fetch = stub().resolves({ ok: true, json: () => Promise.resolve(MOCK_MAPPING) });
+    initBulkPublisherLingoMapping();
+  });
+
+  afterEach(() => {
+    window.fetch = ogFetch;
+  });
+
+  it('resolves an unprefixed base-English path to en/xx, not the classic en-US fallback', async () => {
+    const result = await getLanguageFirstCountryAndLang('/products/brand-concierge.html', 'bacom', 'test');
+    expect(result).to.deep.equal({ country: 'xx', lang: 'en' });
+  });
+
+  it('resolves a French-prefixed path to fr/xx', async () => {
+    const result = await getLanguageFirstCountryAndLang('/fr/products/brand-concierge.html', 'bacom', 'test');
+    expect(result).to.deep.equal({ country: 'xx', lang: 'fr' });
+  });
+
+  it('resolves an English-regional path to its country with language en (not blank)', async () => {
+    const result = await getLanguageFirstCountryAndLang('/gb/products/brand-concierge.html', 'bacom', 'test');
+    expect(result).to.deep.equal({ country: 'gb', lang: 'en' });
+  });
+
+  it('resolves a French-regional path to its country with language fr', async () => {
+    const result = await getLanguageFirstCountryAndLang('/be_fr/products/brand-concierge.html', 'bacom', 'test');
+    expect(result).to.deep.equal({ country: 'be', lang: 'fr' });
   });
 });
 

--- a/test/tools/send-to-caas/bulk-publish-to-caas.test.js
+++ b/test/tools/send-to-caas/bulk-publish-to-caas.test.js
@@ -140,4 +140,19 @@ describe('getBulkPublishLangAttr — auto-detect Lingo matrix', () => {
     const result = await getBulkPublishLangAttr({ ...BASE, repo: 'other', autoDetectLingo: true, languageFirst: true });
     expect(result).to.equal('de-DE');
   });
+
+  it('auto-detect on, mapping fetch fails: throws so the row surfaces in the error report', async () => {
+    // A 404 or network error must not silently flip LFL to non-LFL; it should throw
+    // so bulk-publish-to-caas.js catches it and records the row as a failure.
+    window.fetch = stub().rejects(new Error('HTTP 404'));
+    initBulkPublisherLingoMapping();
+    let caught;
+    try {
+      await getBulkPublishLangAttr({ ...BASE, repo: 'bacom', autoDetectLingo: true, languageFirst: true });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).to.be.instanceOf(Error);
+    expect(caught.message).to.equal('HTTP 404');
+  });
 });

--- a/test/tools/send-to-caas/bulk-publish-to-caas.test.js
+++ b/test/tools/send-to-caas/bulk-publish-to-caas.test.js
@@ -83,7 +83,8 @@ describe('Bulk Publish to CaaS - Graybox Experience ID Integration', () => {
   });
 });
 
-// Shared mock mapping: bacom in index; /de/ is LFL baseSite; /at/ is regional of /de/; /gb/ /au/ are English regionals
+// Shared mock mapping: bacom in index; /de/ is LFL baseSite; /at/ is regional of /de/
+// /gb/ and /au/ are English regionals
 const LINGO_MOCK_MAPPING = {
   'site-query-index-map': { data: [{ uniqueSiteId: 'bacom-site', caasOrigin: 'bacom' }] },
   'site-locales': {
@@ -128,7 +129,8 @@ describe('getBulkPublishLangAttr — auto-detect Lingo matrix', () => {
   });
 
   it('auto-detect on, origin in mapping with LFL locale: mapping overrides languageFirst=false', async () => {
-    // bacom + /de/ is in the mapping as a LFL locale → must produce LFL output even with languageFirst=false
+    // bacom + /de/ is in the mapping as a LFL locale → must produce LFL output
+    // even with languageFirst=false
     const result = await getBulkPublishLangAttr({ ...BASE, repo: 'bacom', autoDetectLingo: true, languageFirst: false });
     expect(result).to.equal('de-xx');
   });

--- a/test/tools/send-to-caas/bulk-publish-to-caas.test.js
+++ b/test/tools/send-to-caas/bulk-publish-to-caas.test.js
@@ -1,8 +1,9 @@
 import { expect } from '@esm-bundle/chai';
+import { stub } from 'sinon';
 import { readFile } from '@web/test-runner-commands';
-import { getGrayboxExperienceId } from '../../../libs/blocks/caas/utils.js';
+import { getGrayboxExperienceId, initBulkPublisherLingoMapping } from '../../../libs/blocks/caas/utils.js';
+import { getBulkPublishLangAttr } from '../../../tools/send-to-caas/send-utils.js';
 
-// Mock the DOM environment
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
 
 describe('Bulk Publish to CaaS - Graybox Experience ID Integration', () => {
@@ -43,7 +44,6 @@ describe('Bulk Publish to CaaS - Graybox Experience ID Integration', () => {
     });
 
     it('should handle null/undefined host parameter', () => {
-      // The function expects string parameters, so we should test with empty strings instead
       const result1 = getGrayboxExperienceId('', '');
       const result2 = getGrayboxExperienceId('', '');
       expect(result1).to.be.null;
@@ -53,38 +53,18 @@ describe('Bulk Publish to CaaS - Graybox Experience ID Integration', () => {
 
   describe('Graybox Experience ID in CaaS Payload', () => {
     it('should add gbExperienceID to caasProps when graybox host is detected', () => {
-      // This test simulates the integration logic in bulk-publish-to-caas.js
       const host = 'test-exp.graybox.adobe.com';
       const grayboxExperienceId = getGrayboxExperienceId(host, '');
-
-      // Simulate the caasProps object
-      const caasProps = {
-        entityId: 'test-entity-id',
-        title: 'Test Title',
-        // ... other properties
-      };
-
-      // Simulate adding the graybox experience ID
-      if (grayboxExperienceId) {
-        caasProps.gbExperienceID = grayboxExperienceId;
-      }
-
+      const caasProps = { entityId: 'test-entity-id', title: 'Test Title' };
+      if (grayboxExperienceId) caasProps.gbExperienceID = grayboxExperienceId;
       expect(caasProps.gbExperienceID).to.equal('test-exp');
     });
 
     it('should not add gbExperienceID when no graybox pattern is found', () => {
       const host = 'business.adobe.com';
       const grayboxExperienceId = getGrayboxExperienceId(host, '');
-
-      const caasProps = {
-        entityId: 'test-entity-id',
-        title: 'Test Title',
-      };
-
-      if (grayboxExperienceId) {
-        caasProps.gbExperienceID = grayboxExperienceId;
-      }
-
+      const caasProps = { entityId: 'test-entity-id', title: 'Test Title' };
+      if (grayboxExperienceId) caasProps.gbExperienceID = grayboxExperienceId;
       expect(caasProps.gbExperienceID).to.be.undefined;
     });
 
@@ -95,11 +75,67 @@ describe('Bulk Publish to CaaS - Graybox Experience ID Integration', () => {
         { host: 'prod-demo.enterprise-prod-graybox.adobe.com', expected: 'prod-demo' },
         { host: 'qa.bacom-stage-graybox.adobe.com', expected: 'qa' },
       ];
-
       testCases.forEach(({ host, expected }) => {
         const result = getGrayboxExperienceId(host, '');
         expect(result).to.equal(expected, `Failed for host: ${host}`);
       });
     });
+  });
+});
+
+// Shared mock mapping: bacom in index; /de/ is LFL baseSite; /at/ is regional of /de/; /gb/ /au/ are English regionals
+const LINGO_MOCK_MAPPING = {
+  'site-query-index-map': { data: [{ uniqueSiteId: 'bacom-site', caasOrigin: 'bacom' }] },
+  'site-locales': {
+    data: [
+      { uniqueSiteId: 'bacom-site', baseSite: '/de', regionalSites: 'at' },
+      { uniqueSiteId: 'bacom-site', baseSite: '/', regionalSites: 'gb,au' },
+    ],
+  },
+};
+
+describe('getBulkPublishLangAttr — auto-detect Lingo matrix', () => {
+  let ogFetch;
+
+  beforeEach(() => {
+    ogFetch = window.fetch;
+    window.fetch = stub().resolves({ ok: true, json: () => Promise.resolve(LINGO_MOCK_MAPPING) });
+    initBulkPublisherLingoMapping();
+  });
+
+  afterEach(() => {
+    window.fetch = ogFetch;
+  });
+
+  const BASE = { prodUrl: '/de/article', host: 'bulkpublisher' };
+
+  it('auto-detect off: respects manual languageFirst=false → non-LFL output', async () => {
+    const result = await getBulkPublishLangAttr({ ...BASE, repo: 'bacom', autoDetectLingo: false, languageFirst: false });
+    expect(result).to.equal('de-DE');
+  });
+
+  it('auto-detect off: respects manual languageFirst=true → LFL output', async () => {
+    const result = await getBulkPublishLangAttr({ ...BASE, repo: 'bacom', autoDetectLingo: false, languageFirst: true });
+    expect(result).to.equal('de-xx');
+  });
+
+  it('auto-detect on, news: always uses manual languageFirst regardless of mapping', async () => {
+    const nonLfl = await getBulkPublishLangAttr({ ...BASE, repo: 'news', autoDetectLingo: true, languageFirst: false });
+    expect(nonLfl).to.equal('de-DE');
+
+    const lfl = await getBulkPublishLangAttr({ ...BASE, repo: 'news', autoDetectLingo: true, languageFirst: true });
+    expect(lfl).to.equal('de-xx');
+  });
+
+  it('auto-detect on, origin in mapping with LFL locale: mapping overrides languageFirst=false', async () => {
+    // bacom + /de/ is in the mapping as a LFL locale → must produce LFL output even with languageFirst=false
+    const result = await getBulkPublishLangAttr({ ...BASE, repo: 'bacom', autoDetectLingo: true, languageFirst: false });
+    expect(result).to.equal('de-xx');
+  });
+
+  it('auto-detect on, origin not in mapping: non-LFL even when languageFirst=true', async () => {
+    // 'other' is absent from the mock mapping → null → false → non-LFL
+    const result = await getBulkPublishLangAttr({ ...BASE, repo: 'other', autoDetectLingo: true, languageFirst: true });
+    expect(result).to.equal('de-DE');
   });
 });

--- a/test/tools/send-to-caas/bulk-publish-to-caas.test.js
+++ b/test/tools/send-to-caas/bulk-publish-to-caas.test.js
@@ -89,8 +89,8 @@ const LINGO_MOCK_MAPPING = {
   'site-query-index-map': { data: [{ uniqueSiteId: 'bacom-site', caasOrigin: 'bacom' }] },
   'site-locales': {
     data: [
-      { uniqueSiteId: 'bacom-site', baseSite: '/de', regionalSites: 'at' },
-      { uniqueSiteId: 'bacom-site', baseSite: '/', regionalSites: 'gb,au' },
+      { uniqueSiteId: 'bacom-site', baseSite: '/de', regionalSites: '/at' },
+      { uniqueSiteId: 'bacom-site', baseSite: '/', regionalSites: '/gb, /au' },
     ],
   },
 };

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -10,13 +10,12 @@ import {
   getCardMetadata,
   getCaasProps,
   getFloodgateColorFromHost,
-  LANG_FIRST_SOURCE_MAPPINGS,
   loadCaasTags,
   postDataToCaaS,
   getConfig,
   setConfig,
 } from './send-utils.js';
-import { getGrayboxExperienceId, initBulkPublisherLingoMapping, isLingoLangFirstPath } from '../../libs/blocks/caas/utils.js';
+import { getGrayboxExperienceId, initBulkPublisherLingoMapping } from '../../libs/blocks/caas/utils.js';
 import comEnterpriseToCaasTagMap from './comEnterpriseToCaasTagMap.js';
 
 const BODY = document.body;
@@ -283,18 +282,7 @@ const processData = async (data, accessToken) => {
       }
 
       const langValue = `${caasMetadata.lang}_${caasMetadata.country}`;
-      const repoLower = repo?.toLowerCase();
-      const originLower = LANG_FIRST_SOURCE_MAPPINGS[repoLower] || repoLower;
-      // eslint-disable-next-line no-await-in-loop
-      // news operates separately from the lingo mapping and always uses the manual checkbox.
-      // auto-detect on (non-news): mapping wins; origin not in mapping → non-LFL
-      // auto-detect off or news: use manual languageFirst checkbox
-      const lflDetected = autoDetectLingo && originLower !== 'news'
-        ? await isLingoLangFirstPath(originLower, prodUrl, 'bulkpublisher')
-        : null;
-      const actualLangFirst = !autoDetectLingo || originLower === 'news'
-        ? languageFirst
-        : (lflDetected ?? false);
+      const actualLangFirst = caasMetadata.country === 'xx';
 
       if (dryRun) {
         dryRunPayloads.set(caasMetadata.entityid, caasProps);

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -462,7 +462,7 @@ presetSelector.addEventListener('change', () => {
   loadFromLS();
   checkCaasEnv();
 
-  const langFirstEl = document.getElementById('language-first');
+  const langFirstEl = document.querySelector('.language-first-label');
   const autoDetectLingoEl = document.getElementById('autoDetectLingo');
   langFirstEl.classList.toggle('lingo-auto', autoDetectLingoEl.checked);
 });
@@ -540,7 +540,7 @@ dryRun.addEventListener('change', () => {
 });
 
 document.getElementById('autoDetectLingo').addEventListener('change', (e) => {
-  document.getElementById('language-first').classList.toggle('lingo-auto', e.target.checked);
+  document.querySelector('.language-first-label').classList.toggle('lingo-auto', e.target.checked);
 });
 
 const checkUserStatus = async () => {

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -15,7 +15,7 @@ import {
   getConfig,
   setConfig,
 } from './send-utils.js';
-import { getGrayboxExperienceId, initBulkPublisherLingoMapping } from '../../libs/blocks/caas/utils.js';
+import { getGrayboxExperienceId, initBulkPublisherLingoMapping, isLingoLangFirstPath } from '../../libs/blocks/caas/utils.js';
 import comEnterpriseToCaasTagMap from './comEnterpriseToCaasTagMap.js';
 
 const BODY = document.body;
@@ -279,10 +279,15 @@ const processData = async (data, accessToken) => {
       }
 
       const langValue = `${caasMetadata.lang}_${caasMetadata.country}`;
+      const repoLower = repo?.toLowerCase();
+      // eslint-disable-next-line no-await-in-loop
+      const actualLangFirst = repoLower === 'bacom'
+        ? await isLingoLangFirstPath(repoLower, prodUrl, 'bulkpublisher')
+        : languageFirst;
 
       if (dryRun) {
         dryRunPayloads.set(caasMetadata.entityid, caasProps);
-        successArr.push([pageUrl, caasMetadata.entityid, languageFirst, langValue]);
+        successArr.push([pageUrl, caasMetadata.entityid, actualLangFirst, langValue]);
         continue;
       }
 
@@ -294,7 +299,7 @@ const processData = async (data, accessToken) => {
       });
 
       if (response.success) {
-        successArr.push([pageUrl, caasMetadata.entityid, languageFirst, langValue]);
+        successArr.push([pageUrl, caasMetadata.entityid, actualLangFirst, langValue]);
       } else {
         errorArr.push([pageUrl, response]);
       }

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -39,7 +39,7 @@ STATUS_EL.addEventListener('click', (e) => {
 
 const LS_KEY = 'bulk-publish-caas';
 const FIELDS = ['presetSelector', 'host', 'repo', 'owner', 'caasEnv', 'urls', 'contentType', 'publishToFloodgate'];
-const FIELDS_CB = ['draftOnly', 'dryRun', 'useHtml', 'usePreview', 'languageFirst', 'autoDetectLingo'];
+const FIELDS_CB = ['draftOnly', 'dryRun', 'useHtml', 'usePreview', 'languageFirst'];
 const DEFAULT_VALUES = {
   preset: 'default',
   caasEnv: 'prod',
@@ -57,7 +57,6 @@ const DEFAULT_VALUES_CB = {
   usePreview: false,
   useHtml: false,
   languageFirst: false,
-  autoDetectLingo: false,
 };
 
 // Hold the selected preset data
@@ -541,6 +540,8 @@ dryRun.addEventListener('change', () => {
 
 document.getElementById('autoDetectLingo').addEventListener('change', (e) => {
   document.querySelector('.language-first-label').classList.toggle('lingo-auto', e.target.checked);
+  setConfig({ autoDetectLingo: e.target.checked });
+  window.localStorage.setItem(LS_KEY, JSON.stringify(getConfig()));
 });
 
 const checkUserStatus = async () => {

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -456,6 +456,11 @@ presetSelector.addEventListener('change', () => {
 
   loadFromLS();
   checkCaasEnv();
+
+  const langFirstEl = document.getElementById('language-first');
+  const isLingoAutoRepo = config.repo?.toLowerCase() === 'bacom';
+  langFirstEl.classList.toggle('lingo-auto', isLingoAutoRepo);
+  document.getElementById('languageFirst').disabled = isLingoAutoRepo;
 });
 
 const clearResultsButton = document.querySelector('.clear-results');

--- a/tools/send-to-caas/bulk-publish-to-caas.js
+++ b/tools/send-to-caas/bulk-publish-to-caas.js
@@ -10,6 +10,7 @@ import {
   getCardMetadata,
   getCaasProps,
   getFloodgateColorFromHost,
+  LANG_FIRST_SOURCE_MAPPINGS,
   loadCaasTags,
   postDataToCaaS,
   getConfig,
@@ -39,7 +40,7 @@ STATUS_EL.addEventListener('click', (e) => {
 
 const LS_KEY = 'bulk-publish-caas';
 const FIELDS = ['presetSelector', 'host', 'repo', 'owner', 'caasEnv', 'urls', 'contentType', 'publishToFloodgate'];
-const FIELDS_CB = ['draftOnly', 'dryRun', 'useHtml', 'usePreview', 'languageFirst'];
+const FIELDS_CB = ['draftOnly', 'dryRun', 'useHtml', 'usePreview', 'languageFirst', 'autoDetectLingo'];
 const DEFAULT_VALUES = {
   preset: 'default',
   caasEnv: 'prod',
@@ -57,6 +58,7 @@ const DEFAULT_VALUES_CB = {
   usePreview: false,
   useHtml: false,
   languageFirst: false,
+  autoDetectLingo: false,
 };
 
 // Hold the selected preset data
@@ -203,6 +205,7 @@ const processData = async (data, accessToken) => {
     previewHost,
     publishToFloodgate,
     languageFirst,
+    autoDetectLingo,
   } = getConfig();
 
   if (!repo) {
@@ -250,6 +253,7 @@ const processData = async (data, accessToken) => {
         repo,
         floodgatecolor: floodgateColor,
         languageFirst,
+        autoDetectLingo,
       });
 
       if (errors.length) {
@@ -280,10 +284,17 @@ const processData = async (data, accessToken) => {
 
       const langValue = `${caasMetadata.lang}_${caasMetadata.country}`;
       const repoLower = repo?.toLowerCase();
+      const originLower = LANG_FIRST_SOURCE_MAPPINGS[repoLower] || repoLower;
       // eslint-disable-next-line no-await-in-loop
-      const actualLangFirst = repoLower === 'bacom'
-        ? await isLingoLangFirstPath(repoLower, prodUrl, 'bulkpublisher')
-        : languageFirst;
+      // news operates separately from the lingo mapping and always uses the manual checkbox.
+      // auto-detect on (non-news): mapping wins; origin not in mapping → non-LFL
+      // auto-detect off or news: use manual languageFirst checkbox
+      const lflDetected = autoDetectLingo && originLower !== 'news'
+        ? await isLingoLangFirstPath(originLower, prodUrl, 'bulkpublisher')
+        : null;
+      const actualLangFirst = !autoDetectLingo || originLower === 'news'
+        ? languageFirst
+        : (lflDetected ?? false);
 
       if (dryRun) {
         dryRunPayloads.set(caasMetadata.entityid, caasProps);
@@ -404,6 +415,7 @@ const resetAdvancedOptions = () => {
   useHtml.checked = false;
   usePreview.checked = false;
   languageFirst.checked = false;
+  autoDetectLingo.checked = false;
   publishToFloodgate.value = 'default';
   /* eslint-enable no-undef */
 };
@@ -463,9 +475,8 @@ presetSelector.addEventListener('change', () => {
   checkCaasEnv();
 
   const langFirstEl = document.getElementById('language-first');
-  const isLingoAutoRepo = config.repo?.toLowerCase() === 'bacom';
-  langFirstEl.classList.toggle('lingo-auto', isLingoAutoRepo);
-  document.getElementById('languageFirst').disabled = isLingoAutoRepo;
+  const autoDetectLingoEl = document.getElementById('autoDetectLingo');
+  langFirstEl.classList.toggle('lingo-auto', autoDetectLingoEl.checked);
 });
 
 const clearResultsButton = document.querySelector('.clear-results');
@@ -538,6 +549,10 @@ draftOnly.addEventListener('change', () => {
 // eslint-disable-next-line no-undef
 dryRun.addEventListener('change', () => {
   checkCaasEnv();
+});
+
+document.getElementById('autoDetectLingo').addEventListener('change', (e) => {
+  document.getElementById('language-first').classList.toggle('lingo-auto', e.target.checked);
 });
 
 const checkUserStatus = async () => {
@@ -632,6 +647,15 @@ helpButtons.forEach((btn) => {
           </p>
           <p>This can be useful for testing before publishing content to production.</p>`);
         break;
+      case 'auto-detect-lingo':
+        showAlert(`<p><b>Auto-detect Lingo</b></p>
+          <p>When checked, the tool queries the <b>lingo-site-mapping</b> to automatically determine
+          whether each URL should use Language First Localization — no manual configuration needed.</p>
+          <p>Origins confirmed in the mapping use the mapping result. Origins <b>not</b> in the
+          mapping are treated as non-LFL.</p>
+          <p><tt>news</tt> is not affected by this setting and always uses the <b>Language First</b> checkbox.</p>
+          <p>When unchecked, the <b>Language First</b> checkbox in Advanced Options is used for all URLs.</p>`);
+        break;
       case 'language-first':
         showAlert(`<p><b>Language First</b></p>
           <p>When this option is checked, the tool will publish the content using language-first localization:</p>
@@ -698,6 +722,7 @@ const init = async () => {
       useHtml: document.getElementById('useHtml').checked,
       usePreview: document.getElementById('usePreview').checked,
       languageFirst: document.getElementById('languageFirst').checked,
+      autoDetectLingo: document.getElementById('autoDetectLingo').checked,
     });
     bulkPublish();
   });

--- a/tools/send-to-caas/bulkpublish.css
+++ b/tools/send-to-caas/bulkpublish.css
@@ -624,3 +624,15 @@ a.classic {
 .bulk-publisher.dark td.error {
   color: #d00;
 }
+
+#language-first.lingo-auto {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+#language-first.lingo-auto label::after {
+  content: ' (auto)';
+  font-style: italic;
+  font-size: 0.85em;
+  color: #666;
+}

--- a/tools/send-to-caas/bulkpublish.css
+++ b/tools/send-to-caas/bulkpublish.css
@@ -634,11 +634,6 @@ a.classic {
   color: #d00;
 }
 
-label.language-first-label.lingo-auto {
-  opacity: 0.5;
-  pointer-events: none;
-}
-
 label.language-first-label.lingo-auto::after {
   content: ' (auto)';
   font-style: italic;

--- a/tools/send-to-caas/bulkpublish.css
+++ b/tools/send-to-caas/bulkpublish.css
@@ -247,7 +247,13 @@ div#caas-draft-cb {
   margin-top: 15px;
 }
 
-label.dry-run-label {
+.button-container {
+  display: flex;
+  align-items: center;
+}
+
+label.dry-run-label,
+label.auto-detect-lingo-label {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -255,6 +261,9 @@ label.dry-run-label {
   font-size: 15px;
   font-weight: 300;
   cursor: pointer;
+}
+
+label.auto-detect-lingo-label span.help {
   vertical-align: middle;
 }
 

--- a/tools/send-to-caas/bulkpublish.css
+++ b/tools/send-to-caas/bulkpublish.css
@@ -253,7 +253,7 @@ div#caas-draft-cb {
 }
 
 label.dry-run-label,
-label.auto-detect-lingo-label {
+label.language-first-label {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -263,7 +263,7 @@ label.auto-detect-lingo-label {
   cursor: pointer;
 }
 
-label.auto-detect-lingo-label span.help {
+label.language-first-label span.help {
   vertical-align: middle;
 }
 
@@ -634,12 +634,12 @@ a.classic {
   color: #d00;
 }
 
-#language-first.lingo-auto {
+label.language-first-label.lingo-auto {
   opacity: 0.5;
   pointer-events: none;
 }
 
-#language-first.lingo-auto label::after {
+label.language-first-label.lingo-auto::after {
   content: ' (auto)';
   font-style: italic;
   font-size: 0.85em;

--- a/tools/send-to-caas/bulkpublisher.html
+++ b/tools/send-to-caas/bulkpublisher.html
@@ -177,6 +177,10 @@
                 <input type="checkbox" id="dryRun" name="dryRun" />
                 Dry Run
               </label>
+              <label class="auto-detect-lingo-label">
+                <input type="checkbox" id="autoDetectLingo" name="autoDetectLingo" />
+                Auto-detect Lingo <span class="help auto-detect-lingo" title="Help about this functionality">(?)</span>
+              </label>
               <span class="config-msg" > &nbsp; * Please Select a Preset or Custom Settings</span>
             </div>
 

--- a/tools/send-to-caas/bulkpublisher.html
+++ b/tools/send-to-caas/bulkpublisher.html
@@ -137,9 +137,9 @@
                   <label for="usePreview">Use Preview Content (*.stage.*)<span class="help use-preview" title="Help about this functionality">(?)</span></label>
                 </div>
                 <h4>Localization</h4>
-                <div id="language-first" class="field checkbox">
-                  <input type="checkbox" id="languageFirst" name="languageFirst" />
-                  <label for="languageFirst">Language First Localization<span class="help language-first" title="Help about this functionality">(?)</span></label>
+                <div id="auto-detect-lingo" class="field checkbox">
+                  <input type="checkbox" id="autoDetectLingo" name="autoDetectLingo" />
+                  <label for="autoDetectLingo">Auto-detect Lingo <span class="help auto-detect-lingo" title="Help about this functionality">(?)</span></label>
                 </div>
                 <!--
                 <div class="field">
@@ -177,9 +177,9 @@
                 <input type="checkbox" id="dryRun" name="dryRun" />
                 Dry Run
               </label>
-              <label class="auto-detect-lingo-label">
-                <input type="checkbox" id="autoDetectLingo" name="autoDetectLingo" />
-                Auto-detect Lingo <span class="help auto-detect-lingo" title="Help about this functionality">(?)</span>
+              <label class="language-first-label">
+                <input type="checkbox" id="languageFirst" name="languageFirst" />
+                Language First Localization <span class="help language-first" title="Help about this functionality">(?)</span>
               </label>
               <span class="config-msg" > &nbsp; * Please Select a Preset or Custom Settings</span>
             </div>

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -16,7 +16,7 @@ const URL_POSTXDM_DEV = 'https://14257-milocaasproxy-dev.adobeio-static.net/api/
 const VALID_URL_RE = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
 const VALID_MODAL_RE = /fragments(.*)#[a-zA-Z0-9_-]+$/;
 
-const LANG_FIRST_SOURCE_MAPPINGS = { cc: 'hawks', dc: 'doccloud' };
+export const LANG_FIRST_SOURCE_MAPPINGS = { cc: 'hawks', dc: 'doccloud' };
 
 const isKeyValPair = /(\s*\S+\s*:\s*\S+\s*)/;
 const isValidUrl = (u) => VALID_URL_RE.test(u);
@@ -350,16 +350,20 @@ export async function runLanguageFirstRetry(options, getLangFirst, retryOpts = {
   return lastResult;
 }
 
-const LINGO_AUTO_REPOS = new Set(['bacom']);
-
 const getBulkPublishLangAttr = async (options) => {
   let { getLocale } = getConfig();
   const repo = (options.repo || '').toLowerCase();
   const origin = LANG_FIRST_SOURCE_MAPPINGS[repo] || repo;
 
-  const useLanguageFirst = LINGO_AUTO_REPOS.has(origin)
+  // news operates separately from the lingo mapping and always uses the manual checkbox.
+  // auto-detect on (non-news): mapping wins; origin not in mapping → non-LFL
+  // auto-detect off or news: use manual languageFirst checkbox
+  const lflDetected = options.autoDetectLingo && origin !== 'news'
     ? await isLingoLangFirstPath(origin, options.prodUrl, 'bulkpublisher')
-    : options.languageFirst;
+    : null;
+  const useLanguageFirst = !options.autoDetectLingo || origin === 'news'
+    ? options.languageFirst
+    : (lflDetected ?? false);
 
   if (useLanguageFirst) {
     const mappedGetLangFirst = (path, r, fqdn) => getLanguageFirstCountryAndLang(

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -1,11 +1,12 @@
 import getUuid from '../../libs/utils/getUuid.js';
 import { getMetadata, lingoActive } from '../../libs/utils/utils.js';
 import {
+  LANGS,
   LOCALES,
   getPageLocale,
   getGrayboxExperienceId,
   getLanguageFirstCountryAndLang,
-  isLingoEnglishRegionalSite,
+  isLingoLangFirstPath,
 } from '../../libs/blocks/caas/utils.js';
 
 const CAAS_TAG_URL = 'https://www.adobe.com/chimera-api/tags';
@@ -357,7 +358,7 @@ const getBulkPublishLangAttr = async (options) => {
   const origin = LANG_FIRST_SOURCE_MAPPINGS[repo] || repo;
 
   const useLanguageFirst = LINGO_AUTO_REPOS.has(origin)
-    ? !(await isLingoEnglishRegionalSite(origin, options.prodUrl, 'bulkpublisher'))
+    ? await isLingoLangFirstPath(origin, options.prodUrl, 'bulkpublisher')
     : options.languageFirst;
 
   if (useLanguageFirst) {
@@ -375,31 +376,41 @@ const getBulkPublishLangAttr = async (options) => {
     getLocale = utilsGetLocale;
     setConfig({ getLocale });
   }
-  return getLocale(LOCALES, options.prodUrl).ietf;
+  const { ietf } = getLocale(LOCALES, options.prodUrl);
+  // LOCALES uses country codes (jp, kr) but some sites (e.g. news) use language codes (/ja/, /ko/)
+  // as URL locale prefixes. When getLocale falls back to the default en-US, try a reverse lookup.
+  if (ietf === 'en-US') {
+    const [, localeStr = ''] = options.prodUrl.split('/');
+    const lang = LANGS[localeStr];
+    if (lang && lang !== 'en') {
+      const entry = Object.entries(LOCALES).find(
+        ([key, val]) => !key.includes('_') && key !== '' && typeof val === 'object'
+          && val.ietf?.toLowerCase().startsWith(`${lang}-`),
+      );
+      if (entry) return `${lang}-${entry[0]}`;
+    }
+  }
+  return ietf;
 };
 
 const getCountryAndLang = async (options, origin) => {
+  /* c8 ignore next */
+  if (window.location.pathname.includes('/tools/send-to-caas/bulkpublisher')) {
+    const langStr = await getBulkPublishLangAttr(options);
+    const [lang = 'en', country = 'us'] = langStr?.toLowerCase().split('-') || [];
+    return { country, lang };
+  }
+
   const langFirst = lingoActive();
   if (langFirst) {
-    const isBulkPublisher = window.location.pathname.includes('/tools/send-to-caas/bulkpublisher');
-    const fqdn = isBulkPublisher ? 'bulkpublisher' : window.location.hostname;
     return getLanguageFirstCountryAndLang(
       window.location.pathname,
       LANG_FIRST_SOURCE_MAPPINGS[origin.toLowerCase()] || origin,
-      fqdn,
+      window.location.hostname,
     );
   }
-  /* c8 ignore next */
-  const langStr = window.location.pathname.includes('/tools/send-to-caas/bulkpublisher')
-    ? await getBulkPublishLangAttr(options)
-    : (LOCALES[window.location.pathname.split('/')[1]] || LOCALES['']).ietf;
-  const langAttr = langStr?.toLowerCase().split('-') || [];
-
-  const [lang = 'en', country = 'us'] = langAttr;
-  return {
-    country,
-    lang,
-  };
+  const [lang = 'en', country = 'us'] = (LOCALES[window.location.pathname.split('/')[1]] || LOCALES['']).ietf?.toLowerCase().split('-') || [];
+  return { country, lang };
 };
 
 const parseCardMetadata = () => {

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -5,6 +5,7 @@ import {
   getPageLocale,
   getGrayboxExperienceId,
   getLanguageFirstCountryAndLang,
+  isLingoEnglishRegionalSite,
 } from '../../libs/blocks/caas/utils.js';
 
 const CAAS_TAG_URL = 'https://www.adobe.com/chimera-api/tags';
@@ -348,12 +349,21 @@ export async function runLanguageFirstRetry(options, getLangFirst, retryOpts = {
   return lastResult;
 }
 
+const LINGO_AUTO_REPOS = new Set(['bacom']);
+
 const getBulkPublishLangAttr = async (options) => {
   let { getLocale } = getConfig();
-  if (options.languageFirst) {
-    const mappedGetLangFirst = (path, repo, fqdn) => getLanguageFirstCountryAndLang(
+  const repo = (options.repo || '').toLowerCase();
+  const origin = LANG_FIRST_SOURCE_MAPPINGS[repo] || repo;
+
+  const useLanguageFirst = LINGO_AUTO_REPOS.has(origin)
+    ? !(await isLingoEnglishRegionalSite(origin, options.prodUrl, 'bulkpublisher'))
+    : options.languageFirst;
+
+  if (useLanguageFirst) {
+    const mappedGetLangFirst = (path, r, fqdn) => getLanguageFirstCountryAndLang(
       path,
-      LANG_FIRST_SOURCE_MAPPINGS[repo.toLowerCase()] || repo,
+      LANG_FIRST_SOURCE_MAPPINGS[r.toLowerCase()] || r,
       fqdn,
     );
     return runLanguageFirstRetry(options, mappedGetLangFirst);

--- a/tools/send-to-caas/send-utils.js
+++ b/tools/send-to-caas/send-utils.js
@@ -720,6 +720,7 @@ const postDataToCaaS = async ({ accessToken, caasEnv, caasProps, draftOnly }) =>
 
 export {
   checkUrl,
+  getBulkPublishLangAttr,
   getCardMetadata,
   getCaasProps,
   getConfig,


### PR DESCRIPTION
## Summary

- Adds an **Auto-detect Lingo** checkbox to the bulk publisher UI (next to Dry Run). When checked, the tool consults `lingo-site-mapping.json` to determine Language First Localization automatically rather than relying on the manual Language First checkbox.
- Refactors `isLingoLangFirstPath` in `utils.js` to return `true` / `false` / `null` (null = origin not yet in the prod mapping), allowing safe handling of data streams that are staged but not yet onboarded to lingo.
- Removes the hard-coded `bacom`-only gate; any origin present in the prod mapping is now handled automatically.
- `news` is special-cased to always defer to the manual checkbox, since it operates outside the lingo mapping.

## Jira Ticket

[MWPW-194951](https://jira.corp.adobe.com/browse/MWPW-194951)

## Auto-detect behavior matrix

| Auto-detect | Origin | In mapping? | Result |
|---|---|---|---|
| off | any | — | `languageFirst` checkbox value |
| on | `news` | — | `languageFirst` checkbox value |
| on | other | yes | mapping result (`true` / `false`) |
| on | other | no (`null`) | `false` (non-LFL) |

Key points:
- `news` never touches `isLingoLangFirstPath` — it always defers to the manual checkbox.
- When auto-detect is on and an origin is **absent** from `lingo-site-mapping.json` (e.g. a new data stream being staged before prod onboarding), the tool defaults to **non-LFL** rather than silently misidentifying the locale.
- The manual `languageFirst` checkbox remains fully functional as the primary control when auto-detect is off.

## Test plan

- [ ] Unit tests cover all four matrix cases (`test/tools/send-to-caas/bulk-publish-to-caas.test.js`)
- [ ] Unit tests cover `isLingoLangFirstPath` return shapes: `null` (unknown origin), `true` (LFL baseSite/regional), `false` (English regional), `false` (fetch error) (`test/blocks/caas/utils.test.js`)
- [ ] Manual: open bulk publisher, check Auto-detect Lingo → publish a bacom `/de/` page → verify LFL lang/country in CaaS
- [ ] Manual: uncheck Auto-detect Lingo → publish same page with Language First unchecked → verify non-LFL output
- [ ] Manual: publish a `news` URL with auto-detect on → verify manual Language First checkbox controls the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)



















