### PR TITLE
[SR] Rich content video overlay update

### DIFF
--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -504,16 +504,18 @@
     .section-background {
       overflow: hidden;
 
-      img {
-        filter: blur(var(--s2a-blur-md));
-        transform: scale(1.08);
-      }
+      &:not(:has(~ .rich-content.video.no-overlay)) {
+        img {
+          filter: blur(var(--s2a-blur-md));
+          transform: scale(1.08);
+        }
 
-      &::after {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background: var(--s2a-color-transparent-black-48);
+        &::after {
+          content: '';
+          position: absolute;
+          inset: 0;
+          background: var(--s2a-color-transparent-black-48);
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
VQA request
* Add a new variant (`no-overlay`) to remove the overlay that is applied on top of a background video .



**Test URLs:**
- Before:https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=sr-rc-video-overlay&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


