### PR TITLE
[SR] PDF-Space CTA fix

### DIFF
--- a/libs/mep/ace1205/pdf-space/pdf-space.js
+++ b/libs/mep/ace1205/pdf-space/pdf-space.js
@@ -1443,8 +1443,8 @@ function mountMotion(el) {
   });
 
   let pointerDown = false;
-  stage.addEventListener('pointerdown', () => { pointerDown = true; }, { capture: true });
-  stage.addEventListener('pointerup', () => { pointerDown = false; }, { capture: true });
+  stage.addEventListener('pointerdown', () => { pointerDown = true; });
+  stage.addEventListener('pointerup', () => { pointerDown = false; });
 
   const textBlockLink = textBlockEl.querySelector('a');
   textBlockLink?.addEventListener('focus', () => {

--- a/libs/mep/ace1205/pdf-space/pdf-space.js
+++ b/libs/mep/ace1205/pdf-space/pdf-space.js
@@ -1442,12 +1442,17 @@ function mountMotion(el) {
     if (stage.scrollLeft !== 0) stage.scrollLeft = 0;
   });
 
+  let pointerDown = false;
+  stage.addEventListener('pointerdown', () => { pointerDown = true; }, { capture: true });
+  stage.addEventListener('pointerup', () => { pointerDown = false; }, { capture: true });
+
   const textBlockLink = textBlockEl.querySelector('a');
   textBlockLink?.addEventListener('focus', () => {
-    snapToFocusTarget(ANIM_STATE.timing.slottingStart);
+    if (!pointerDown) snapToFocusTarget(ANIM_STATE.timing.slottingStart);
   });
   const ctaLink = ctaEl.querySelector('a');
   ctaLink?.addEventListener('focus', () => {
+    if (pointerDown) return;
     const { timing } = ANIM_STATE;
     snapToFocusTarget(
       timing.slottingStart + timing.slottingDuration + timing.postRevealScrollDistance,


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fix when clicking Try the demo link for the first time, the page would shift up rather than redirecting the users

Resolves: https://jira.corp.adobe.com/browse/DOTCOM-188834

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=site-redesign-foundation
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=pdf-space-cta-fix

How to test:
- Scroll down to PDF-Space block's "Try the demo" cta
- In base, clicking it might not work, and only cause the page's scroll to be updated
- In feature branch, clicking it should function as desired


