### PR TITLE
MWPW-198305 [Mep] partial fix for c2 gnav

### DIFF
--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -1,5 +1,4 @@
 import { getEnv, getConfig, getMetadata, localizeLink } from '../../../utils/utils.js';
-import { handleCommands } from '../../../features/personalization/personalization.js';
 
 const DEFAULT_FEDERAL_URL = 'https://main--federal--adobecom.aem.page';
 
@@ -44,7 +43,10 @@ export default async function init(el) {
     (command) => command?.modifiers?.includes('include-gnav'),
   ) || [];
 
-  const personalizationHandler = (cs, root) => handleCommands(cs, root, true, true);
+  const personalizationHandler = async (cs, root) => {
+    const { handleCommands } = await import('../../../features/personalization/personalization.js');
+    return handleCommands(cs, root, true, true);
+  };
 
   const { main } = await import(federalGnavUrl);
   const gnavUrl = new URL(getMetadata('gnav-source') || `${config.locale?.contentRoot ?? window.location.origin}/gnav`);

--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -1,4 +1,5 @@
 import { getEnv, getConfig, getMetadata, localizeLink } from '../../../utils/utils.js';
+import { handleCommands } from '../../../features/personalization/personalization.js';
 
 const DEFAULT_FEDERAL_URL = 'https://main--federal--adobecom.aem.page';
 
@@ -43,10 +44,7 @@ export default async function init(el) {
     (command) => command?.modifiers?.includes('include-gnav'),
   ) || [];
 
-  const personalizationHandler = async (cs, root) => {
-    const { handleCommands } = await import('../../../features/personalization/personalization.js');
-    return handleCommands(cs, root);
-  };
+  const personalizationHandler = (cs, root) => handleCommands(cs, root, true, true);
 
   const { main } = await import(federalGnavUrl);
   const gnavUrl = new URL(getMetadata('gnav-source') || `${config.locale?.contentRoot ?? window.location.origin}/gnav`);


### PR DESCRIPTION
## Summary                                                                                                              
                                                                                                                        
  Restores `updateattribute` on parser-read attributes (`href`, `daa-ll`, `aria-label`) for `in-block:global-navigation`  
  manifests on C2 gnav.                                                                                                   
  
  **Scope:** this is a partial fix. C2 gnav is also not yet ready for Lingo link transformation, and several other in-block MEP actions aren't yet functional — full list under "What's still broken" below. Those gaps require federal-side changes and are out of scope for this PR.                                                                                                                                                                                                                                        
  
  Two changes to `libs/c2/blocks/global-navigation/global-navigation.js`:                                                 
                                                                                                                          
  - **Static-import `handleCommands`** so the synchronous `setAttribute` lands before federal reads the body. Federal calls the personalization callback without `await` (`federal/.../Utils/Utils.ts:238`), so the previous dynamic `await import('personalization.js')` yielded control too early — federal proceeded to `parseNavigation`, baked the pre-mutation hrefs into its typed data model, and the MEP change was silently discarded on rebuild.                               
  - **Pass `forceInline=true, forceRootEl=true`** to `handleCommands`. Without `forceRootEl`, `getSelectedElements` falls back to querying `document` (`personalization.js:658-659`), which doesn't yet contain the detached body federal hands us — every selector matches zero elements. This is the same pattern C1 uses at `libs/blocks/global-navigation/utilities/utilities.js:564`.                                                             
                                                                                                                        
  ## What works after this fix

  Of the in-block actions, only `updateattribute` on parser-read attrs (`href`, `daa-ll`, `aria-label`) is reliable: one selector → one match → one synchronous `setAttribute` lands in time. 

Example selector that works:
in-block:global-navigation .featured-card a[href*="/products/firefly.html"] href                                        
   
Separately, `updateMetadata` to swap `gnav-source` should also work on C2 gnav — it's a **global** command (not in-block), and the mechanism is independent of this fix: it modifies`document.head` before gnav init reads it. The fix in this PR doesn't change that path.          
   
  ## What's still broken (out of scope for this PR)                                                                       
                                                                                                                        
  The following remain broken on federal's parse-then-render pipeline and require federal-side changes to fix:            
   
  - `remove` — kills required featured-card content silently (parsers throw plain Error)                                  
  - `append` / `prepend` / `insertbefore` / `insertafter` — parser walks fixed structural positions; additions ignored on rebuild                                                                                                                 
  - `replace` with HTML — only works as `innerHTML = newContent`; structural replacements break the parser
  - Fragment substitution (`replace` with URL, M@S overrides) — federal has no top-level `inlineNestedFragments` call     
  equivalent to C1's `utilities.js:566-578`                                                                               
  - `manifestId` / target test ID attribution — federal explicitly skips this (`federal/.../Main.ts:41-50`)               
   - **Lingo link transformation** on gnav links (including `#_mep-lingo`) — federal's `LocalizeLink` callback signature is synchronous (`Utils.ts:158`: `(link: string) => string`), so milo's async `localizeLinkAsync` / `decorateLinksAsync` pipeline — where `resolveLingoPrefix` and `detectMepLingoSwap` fire — never runs on gnav links
                                                                                                                          
  Follow-up work to enable additional functionality (up to full C1 parity, depending on what's prioritized) will require federal-side changes; pending additional investigation and discussion with the federal team on the right approach. I've sketched one possible direction — a milo-supplied async decoration hook federal could call between fetch/parse and after render — that would unblock Lingo link transformation alongside the remaining in-block MEP actions, but haven't reviewed it with them yet.      
  
  
Resolves: [MWPW-198305](https://jira.corp.adobe.com/browse/MWPW-198305)

 **QA steps:**                                                                                                                                                                                     
  1. Open Before and After URL below
  2. Open the **Use Cases** dropdown in the global nav
  3. Find the **Content Creation** card and check the **Explore** CTA's `href`                                                                                                                      
                                                                                                                                                                                                    
Expected : `https://www.adobe.com/acrobat/business-professionals.html` — MEP `updateattribute` applied                                                                                                                                                                                   


Actual: `https://www.adobe.com/products/firefly.html` — the unmodified default, MEP override silently dropped                                                                      
  

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/index-loggedout?mep=%2Fupp-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-test.json--gnav-test---%2Fhomepage%2Ffragments%2Fmep%2Fhp-06-02-26-redesign-pzn.json--default---%2Fhomepage%2Ffragments%2Fmep%2Fhp-1-21-26-dc-updates-psnlz.json--default---%2Fupp-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1165v3%2Face1165v3.json--default
- After: https://main--upp--adobecom.aem.page/homepage/index-loggedout?mep=%2Fupp-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-test.json--gnav-test---%2Fhomepage%2Ffragments%2Fmep%2Fhp-06-02-26-redesign-pzn.json--default---%2Fhomepage%2Ffragments%2Fmep%2Fhp-1-21-26-dc-updates-psnlz.json--default---%2Fupp-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1165v3%2Face1165v3.json--default&milolibs=mep-partial-fix-for-c2-gnav
- psi-check: https://mep-partial-fix-for-c2-gnav--milo--adobecom.aem.page/?martech=off



 **Update:**  Switched to dynamic import for `handleCommands` now that federal [#139](https://github.com/adobecom/federal/pull/139) is merged. DNM until the live federal `dist/main.js` picks up the rebuilt bundle. #139 should also partially improve several "still broken" items —  particularly `replace` with HTML on parser-friendly content and fragment substitution inside mega-menu fragments. **Lingo link transformation and `#_mep-lingo` on gnav links remain unaffected by #139** — those still require a paired federal + milo change. Will refine the list once the live serving catches up.       

