### PR TITLE
MWPW-193615 makes usage of pzn & mask in autoblocks

### DIFF
--- a/libs/blocks/mas-compare-chart-autoblock/mas-compare-chart-autoblock.js
+++ b/libs/blocks/mas-compare-chart-autoblock/mas-compare-chart-autoblock.js
@@ -2,6 +2,7 @@ import { createTag, getConfig, loadStyle } from '../../utils/utils.js';
 import {
   getOptions,
   initService,
+  createAemFragment,
   loadMasComponent,
   MAS_MERCH_CARD,
   overrideOptions,
@@ -56,11 +57,7 @@ function loadCompareChartStyles() {
 }
 
 export async function createCompareChart(el, options) {
-  const attrs = { fragment: options.fragment };
-  if (seenFragments.has(options.fragment)) attrs.loading = 'cache';
-  seenFragments.add(options.fragment);
-
-  const aemFragment = createTag('aem-fragment', attrs);
+  const aemFragment = createAemFragment(options, seenFragments);
   const compareChart = createTag(MAS_COMPARE_CHART, { consonant: '' }, aemFragment);
   const paragraph = el.parentElement;
   paragraph.parentElement.className = 'mas-compare-chart-container';

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -4,6 +4,7 @@ import { postProcessAutoblock } from '../merch/autoblock.js';
 import { mepMasStudioUrls } from '../merch/mas-mep-utils.js';
 import {
   initService,
+  createAemFragment,
   getOptions,
   overrideOptions,
   loadMasComponent,
@@ -129,10 +130,7 @@ function normalizeBlockFieldWrappers(masField) {
 }
 
 async function createJsonLd(el, options) {
-  const attrs = { fragment: options.fragment };
-  if (seenFragments.has(options.fragment)) attrs.loading = 'cache';
-  seenFragments.add(options.fragment);
-  const aemFragment = createTag('aem-fragment', attrs);
+  const aemFragment = createAemFragment(options, seenFragments);
   const merchCard = createTag('merch-card', { consonant: '', hidden: '' }, aemFragment);
   document.body.appendChild(merchCard);
   await checkReady(merchCard, options.fragment);
@@ -150,10 +148,7 @@ async function createJsonLd(el, options) {
 }
 
 export async function createCard(el, options) {
-  const attrs = { fragment: options.fragment };
-  if (seenFragments.has(options.fragment)) attrs.loading = 'cache';
-  seenFragments.add(options.fragment);
-  const aemFragment = createTag('aem-fragment', attrs);
+  const aemFragment = createAemFragment(options, seenFragments);
   const merchCard = createTag('merch-card', { consonant: '' }, aemFragment);
   // For the "Edit Card" mep preview badge.
   if (getConfig()?.mep?.preview) {
@@ -178,10 +173,7 @@ function copyMasFieldIdToParent(masField, name) {
 
 /** Replaces an inline fragment link with a mas-field wrapping an aem-fragment. */
 async function createInline(el, options) {
-  const attrs = { fragment: options.fragment };
-  if (seenFragments.has(options.fragment)) attrs.loading = 'cache';
-  seenFragments.add(options.fragment);
-  const aemFragment = createTag('aem-fragment', attrs);
+  const aemFragment = createAemFragment(options, seenFragments);
   const masField = createTag('mas-field', { field: options.field }, aemFragment);
   if (getConfig()?.mep?.preview) {
     mepMasStudioUrls.set(masField, el.href);

--- a/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
+++ b/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
@@ -4,6 +4,7 @@ import { postProcessAutoblock, handleCustomAnalyticsEvent } from '../merch/autob
 import { mepMasStudioUrls } from '../merch/mas-mep-utils.js';
 import {
   initService,
+  createAemFragment,
   getOptions,
   MEP_SELECTOR,
   overrideOptions,
@@ -309,7 +310,7 @@ function paintStPriceRed(collection, locale) {
 }
 
 export async function createCollection(el, options) {
-  const aemFragment = createTag('aem-fragment', { fragment: options.fragment });
+  const aemFragment = createAemFragment(options);
   // Get MEP overrides if available
   const { mep, locale } = getConfig();
   const mepFragments = mep?.inBlock?.[MEP_SELECTOR]?.fragments || {};

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1551,16 +1551,45 @@ export function overrideOptions(fragment, options) {
   return options;
 }
 
+export function createAemFragment(options, seenFragments = null) {
+  const { fragment, pzn, mask } = options;
+  const cacheKey = `${fragment}|${pzn || ''}|${mask || ''}`;
+  const attrs = Object.fromEntries(
+    Object.entries({ fragment, pzn, mask }).filter(([, v]) => v != null),
+  );
+  if (seenFragments?.has(cacheKey)) attrs.loading = 'cache';
+  seenFragments?.add(cacheKey);
+  return createTag('aem-fragment', attrs);
+}
+
 export function getOptions(el) {
   const { hash } = new URL(el.href);
   const hashValue = hash.startsWith('#') ? hash.substring(1) : hash;
   const searchParams = new URLSearchParams(hashValue);
   const options = {};
   for (const [key, value] of searchParams.entries()) {
-    if (key === 'sidenav') options.sidenav = value === 'true';
-    else if (key === 'fragment' || key === 'query') options.fragment = value;
-    else if (key === 'field') options.field = value;
-    else if (key === 'jsonld') options.jsonld = value === 'on';
+    switch (key) {
+      case 'sidenav':
+        options.sidenav = value === 'true';
+        break;
+
+      case 'fragment':
+      case 'query':
+        options.fragment = value;
+        break;
+
+      case 'mask':
+      case 'pzn':
+      case 'field':
+        options[key] = value;
+        break;
+
+      case 'jsonld':
+        options.jsonld = value === 'on';
+        break;
+      default:
+        break;
+    }
   }
   return options;
 }

--- a/test/blocks/mas-compare-chart-autoblock/mas-compare-chart-autoblock.test.js
+++ b/test/blocks/mas-compare-chart-autoblock/mas-compare-chart-autoblock.test.js
@@ -158,6 +158,28 @@ describe('mas-compare-chart-autoblock', () => {
     expect(aemFragment.getAttribute('fragment')).to.equal('compare-chart-promo');
   });
 
+  it('passes pzn attribute to aem-fragment', async () => {
+    const a = createLink('https://mas.adobe.com/studio.html#content-type=mas-compare-chart&fragment=pzn-chart-1&pzn=abc');
+    document.body.append(a);
+    await init(a);
+    const frag = document.querySelector('mas-compare-chart aem-fragment');
+    expect(frag.getAttribute('pzn')).to.equal('abc');
+  });
+
+  it('treats same fragment with different pzn as distinct cache entries', async () => {
+    const a1 = createLink('https://mas.adobe.com/studio.html#content-type=mas-compare-chart&fragment=cache-pzn-chart-1&pzn=v1');
+    document.body.append(a1);
+    await init(a1);
+
+    const a2 = createLink('https://mas.adobe.com/studio.html#content-type=mas-compare-chart&fragment=cache-pzn-chart-1&pzn=v2');
+    document.body.append(a2);
+    await init(a2);
+
+    const frags = document.querySelectorAll('mas-compare-chart aem-fragment');
+    expect(frags[0].getAttribute('loading')).to.not.exist;
+    expect(frags[1].getAttribute('loading')).to.not.exist;
+  });
+
   it('uses cached loading for repeated fragments', async () => {
     const a1 = createLink('https://mas.adobe.com/studio.html#content-type=mas-compare-chart&fragment=compare-chart-cache');
     const a2 = createLink('https://mas.adobe.com/studio.html#content-type=mas-compare-chart&fragment=compare-chart-cache');

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -354,6 +354,56 @@ describe('merch-card-autoblock autoblock', () => {
       expect(blue.classList.contains('button-l')).to.be.true;
     });
 
+    it('passes mask and pzn to aem-fragment in createCard', async () => {
+      setConfig({ codeRoot: '/libs' });
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=mask-pzn-card-1&mask=foo&pzn=bar';
+      document.body.append(a);
+      await init(a);
+      const frag = document.querySelector('merch-card aem-fragment');
+      expect(frag.getAttribute('mask')).to.equal('foo');
+      expect(frag.getAttribute('pzn')).to.equal('bar');
+    });
+
+    it('passes mask and pzn to aem-fragment in createInline', async () => {
+      setConfig({ codeRoot: '/libs' });
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=mask-pzn-inline-1&mask=baz&pzn=qux&field=prices';
+      document.body.append(a);
+      await init(a);
+      const frag = document.querySelector('mas-field aem-fragment');
+      expect(frag.getAttribute('mask')).to.equal('baz');
+      expect(frag.getAttribute('pzn')).to.equal('qux');
+    });
+
+    it('does not set mask or pzn when absent from URL', async () => {
+      setConfig({ codeRoot: '/libs' });
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=no-mask-pzn-1';
+      document.body.append(a);
+      await init(a);
+      const frag = document.querySelector('merch-card aem-fragment');
+      expect(frag.getAttribute('mask')).to.not.exist;
+      expect(frag.getAttribute('pzn')).to.not.exist;
+    });
+
+    it('treats same fragment with different mask as distinct cache entries', async () => {
+      setConfig({ codeRoot: '/libs' });
+      const a1 = document.createElement('a');
+      a1.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=cache-mask-1&mask=v1';
+      document.body.append(a1);
+      await init(a1);
+
+      const a2 = document.createElement('a');
+      a2.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=cache-mask-1&mask=v2';
+      document.body.append(a2);
+      await init(a2);
+
+      const frags = document.querySelectorAll('merch-card aem-fragment');
+      expect(frags[0].getAttribute('loading')).to.not.exist;
+      expect(frags[1].getAttribute('loading')).to.not.exist;
+    });
+
     it('preserves Milo typography classes on parent heading when inline fragment stays inline', async () => {
       const heading = document.createElement('h1');
       heading.id = 'heading-milo-class-test';


### PR DESCRIPTION
Resolves: consuming part of  [MWPW-193615](https://jira.corp.adobe.com/browse/MWPW-193615) where mas autoblocks can now have pzn & mask attributes that will be forwarded to mas/io (depends on https://github.com/adobecom/mas/pull/958 to be working, but will not break anything if put before).

a later enhancement for fancier authoring integration should be planned. For the moment, attributes will have to be added by hand.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/drafts/nala/features/commerce/plans?martech=off
- After: https://MWPW-193615--milo--npeltier.aem.live/drafts/nala/features/commerce/plans?martech=off




