### PR TITLE
Brand Concierge: Analytics enhancement and refactor of floating-input

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -1109,9 +1109,9 @@
   }
 
   .hero .bc-header-title {
-  font-size: 36px;
-  line-height: 45px;
-}
+    font-size: 36px;
+    line-height: 45px;
+  }
 
   .hero .bc-input-field {
     margin-bottom: 32px;

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -474,6 +474,10 @@
 }
 
 /* dark  / c2-dark */
+.brand-concierge.dark.has-bg-image {
+  background-color:#000;
+}
+
 .dark .bc-header-title,
 .dark .bc-header-subtitle,
 .c2-dark .bc-header-title,

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -454,8 +454,8 @@
 }
 
 .hero .bc-header-title {
-  font-size: 36px;
-  line-height: 45px;
+  font-size: 28px;
+  line-height: 35px;
 }
 
 .hero .bc-input-field {
@@ -1105,6 +1105,11 @@
   .hero .bc-header {
     padding: 0 50px;
   }
+
+  .hero .bc-header-title {
+  font-size: 36px;
+  line-height: 45px;
+}
 
   .hero .bc-input-field {
     margin-bottom: 32px;

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -803,9 +803,11 @@
   color: var(--bc-fi-text);
 }
 
+/* stylelint-disable */
 .floating-input-dark .bc-floating-input .input-field-button {
   color: var(--bc-fi-icon-color);
 }
+/* stylelint-enable */
 
 .floating-input-dark .bc-floating-input .input-field-button:disabled {
   color: var(--bc-fi-icon-color);

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -8,8 +8,8 @@
 .brand-concierge {
   --bc-header-font-size: 36px;
   --bc-header-line-height: 45px;
-  --bc-header-subtitle-font-size: 16px;
-  --bc-header-subtitle-line-height: 24px;
+  --bc-header-subtitle-font-size: 18px;
+  --bc-header-subtitle-line-height: 27px;
   --bc-header-margin-bottom: 32px;
   --bc-header-padding: 0 24px;
   --bc-header-color: #131313;

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -36,6 +36,14 @@
   --bc-button-color: #292929;
   --bc-button-hover-color: #131313;
   --bc-keyboard-focus-color: #5574F7;
+  --bc-dark-text-color: #fff;
+  --bc-dark-text-color-secondary: #aba8a6;
+  --bc-dark-border-color: rgba(255 255 255 / 20%);
+  --bc-dark-border-color-secondary: rgba(255 255 255 / 30%);
+  --bc-dark-input-background: #131313;
+  --bc-dark-input-border-color: linear-gradient(98deg, #9A3CF9 0%, #E743C8 35.46%, #ED457E 68.67%, #FF7918 100%);
+  --bc-dark-button-color: rgba(255 255 255 / 80%);
+  --bc-dark-button-hover-color: rgba(255 255 255 / 90%);
 
   box-sizing: border-box;
   padding: 40px 24px 12px;
@@ -352,7 +360,7 @@
   position: fixed;
   transition: opacity 0.25s ease;
   width: calc(100% - var(--bc-floating-button-spacing) * 2 - var(--bc-input-border-size) * 2);
-  z-index: 4;
+  z-index: 5;
 }
 
 .bc-floating-button::before {
@@ -465,177 +473,142 @@
   margin-top: 4px;
 }
 
-/* Modal */
-@keyframes slide-up {
-  from {
-    bottom: -100vh;
-  }
-
-  to {
-    bottom: 0;
-  }
+/* dark  / c2-dark */
+.dark .bc-header-title,
+.dark .bc-header-subtitle,
+.c2-dark .bc-header-title,
+.c2-dark .bc-header-subtitle {
+  color: var(--bc-dark-text-color);
 }
 
-@keyframes slide-down {
-  from {
-    bottom: 0;
-  }
-
-  to {
-    bottom: -100vh;
-  }
+.c2-dark .bc-header-title {
+  font-size: 32px;
+  line-height: 32px;
 }
 
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
+.c2-dark.input-first .bc-prompt-cards {
+  margin-bottom: 24px;
 }
 
-@keyframes fade-out {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
+.dark .prompt-card-button,
+.c2-dark .prompt-card-button {
+  background: rgb(255 255 255 / 10%);
+  border: 1px solid var(--bc-dark-border-color);
+  border-radius: 12px;
 }
 
-#bc-susi-modal {
-  z-index: calc( var(--modal-z-index) + 1);
-}
-
-#bc-susi-modal ~ .modal-curtain {
-  z-index: calc( var(--modal-z-index-curtain) + 1);
-}
-
-#brand-concierge-modal {
-  --modal-header-height: 57px;
-}
-
-#brand-concierge-modal.dialog-modal {
-  height: calc(100dvh - 22px);
-  width: 100vw;
-  max-width: unset;
-  max-height: unset;
-  margin-top: 22px;
-  border-radius: 24px 24px 0 0;
-  font-size: 16px;
-  top: unset;
-  bottom: 0;
-  animation: var(--bc-modal-animation-time) ease-in-out slide-up;
-}
-
-/* Fallback for browsers that don't support dvh */
-@supports not (height: 100dvh) {
-  #brand-concierge-modal.dialog-modal {
-    height: calc(100vh - 22px);
-  }
-}
-
-#brand-concierge-modal.dialog-modal.closing {
-  animation: var(--bc-modal-animation-time) ease-in-out slide-down;
-  bottom: -100vh;
-}
-
-#brand-concierge-modal ~ .modal-curtain {
-  animation: var(--bc-modal-animation-time) ease-in-out fade-in;
-  opacity: 1;
-}
-
-#brand-concierge-modal.closing ~ .modal-curtain {
-  animation: var(--bc-modal-animation-time) ease-in-out fade-out;
-  opacity: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  #brand-concierge-modal.dialog-modal,
-  #brand-concierge-modal.dialog-modal.closing,
-  #brand-concierge-modal ~ .modal-curtain,
-  #brand-concierge-modal.closing ~ .modal-curtain {
-    animation: none;
-  }
-
-  .brand-concierge.floating-input {
-    backdrop-filter: none;
-    background: #F8F8F8;
-  }
-
-  .brand-concierge.floating-input.dark {
-    background: #111;
-  }
-}
-
-#brand-concierge-modal .dialog-close {
-  z-index: 2;
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTkuNzU0ODggMTMuMjQzMkMxMC4wNDIgMTIuOTQ0NCAxMC41MTY2IDEyLjkzNDYgMTAuODE0NSAxMy4yMjI3TDE1Ljk5OCAxOC4yMDlMMjEuMTk1MyAxMy4yMUMyMS40OTMyIDEyLjkyMTkgMjEuOTY3OCAxMi45MzE3IDIyLjI1NDkgMTMuMjMwNUMyMi41NDIgMTMuNTI3NCAyMi41MzMyIDE0LjAwMyAyMi4yMzQ0IDE0LjI5MDFMMTYuNTE3NiAxOS43OTAxQzE2LjIyNzUgMjAuMDcwMyAxNS43Njg2IDIwLjA3MDMgMTUuNDc4NSAxOS43OTAxTDkuNzc1MzkgMTQuMzAyOEM5LjYyMjA3IDE0LjE1NjMgOS41NDQ5MiAxMy45NTkgOS41NDQ5MiAxMy43NjI3QzkuNTQ0OTIgMTMuNTc1MiA5LjYxNDI2IDEzLjM4NzcgOS43NTQ4OCAxMy4yNDMyWiIgZmlsbD0iIzI5MjkyOSIvPgo8L3N2Zz4=');
-  background-repeat: no-repeat;
-  background-position: center;
-  height: 32px;
-  width: 32px;
+.c2-dark .prompt-card-button {
   border: none;
-  top: 12px;
-  right: 16px;
+  border-radius: 18px;
+  position: relative;
 }
 
-#brand-concierge-modal .dialog-close:focus-visible {
-  outline: 2px solid #5574F7;
-  outline-offset: 2px;
-  border-radius: 8px;
+.c2-dark .prompt-card-button::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 18px;
+  border: 1.5px solid transparent;
+  background: linear-gradient(to right, rgba(225 29 26 / 16%), rgba(144 13 235 / 16%)) border-box;
+  mask:
+    linear-gradient(#fff 0 0) padding-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
 }
 
-#brand-concierge-modal  .dialog-close::before,
-#brand-concierge-modal  .dialog-close::after,
-#brand-concierge-modal  .dialog-close svg {
+.dark .prompt-card-button:hover {
+  border-color: var(--bc-dark-border-color-secondary);
+}
+
+.c2-dark .prompt-card-text {
+  grid-template-columns: auto;
+}
+
+.c2-dark .card-icon {
   display: none;
 }
 
-.bc-modal-header {
-  height: var(--modal-header-height);
-  padding: 12px 16px;
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  border-bottom: 1px solid rgb(0 0 0 / 9%);
+.dark .prompt-card-text p,
+.c2-dark .prompt-card-text p {
+  color: var(--bc-dark-text-color-secondary);
+  margin: 0;
 }
 
-.modal-header-icon {
-  display: flex;
-  height: 16px;
-  width: 16px;
+.dark .bc-input-field::before {
+  background: var(--bc-dark-input-border-color) border-box;
+  border: 2px solid var(--bc-input-border-color);
 }
 
-.bc-modal-title {
-  font-size: 16px;
-  letter-spacing: -0.9px;
-  line-height: 32px;
-  font-weight: 900;
+.c2-dark .bc-input-field::before {
+  background: var(--bc-dark-input-border-color) border-box;
+  border: 1px solid var(--bc-input-border-color);
+}
+
+
+.dark .bc-input-field:has(textarea:focus-visible)::before {
+  border-color: var(--bc-dark-border-color-secondary);
+}
+
+.c2-dark.input-first .bc-input-field {
+  margin-bottom: 24px;
+}
+
+.dark .bc-input-field-container,
+.c2-dark .bc-input-field-container {
+  background: var(--bc-dark-input-background);
+}
+
+.c2-dark .bc-input-field-container {
+  border-radius: 28px;
+  background: var(--bc-dark-input-background);
+}
+
+.dark .bc-input-field-container:hover,
+.dark .bc-input-field-container:has(textarea:focus-visible),
+.c2-dark .bc-input-field-container:hover,
+.c2-dark .bc-input-field-container:has(textarea:focus-visible) {
+  background: var(--bc-dark-input-background);
+}
+
+.dark .bc-input-field-container textarea,
+.c2-dark .bc-input-field-container textarea {
+  color: var(--bc-dark-text-color);
+}
+
+.dark .bc-input-field-container textarea::placeholder,
+.c2-dark .bc-input-field-container textarea::placeholder {
+  color: var(--bc-dark-text-color-secondary);
+}
+
+.dark .input-field-button,
+.c2-dark .input-field-button {
+  background: var(--bc-dark-button-color);
   color: #000;
 }
 
-.bc-beta-label {
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 14px;
-  text-transform: uppercase;
-  color: #A358B1;
-  background: #EAEAED;
-  border-radius: 4px;
-  height: 14px;
-  width: 30px;
-  text-align: center;
+.dark .input-field-button:hover,
+.c2-dark .input-field-button:hover {
+  background: var(--bc-dark-button-hover-color);
 }
 
-#brand-concierge-modal #brand-concierge-mount {
-  height: calc(100% - var(--modal-header-height));
+.dark .input-field-button:disabled,
+.c2-dark .input-field-button:disabled {
+  background: transparent;
+  color: #C6C6C6;
 }
 
+.dark .bc-legal,
+.dark .bc-legal a,
+.c2-dark .bc-legal,
+.c2-dark .bc-legal a {
+  color: var(--bc-dark-text-color-secondary);
+  font-size: 12px;
+}
+
+/* floating-input */
 .brand-concierge.floating-input {
   --bc-fi-bar-bg: rgba(248 248 248 / 65%);
   --bc-fi-bar-border: rgba(0 0 0 / 12%);
@@ -854,6 +827,177 @@
 .brand-concierge.floating-input.dark .prompt-card-button:hover {
   border: 1px solid var(--bc-fi-icon-color);
   background-color: var(--bc-fi-pill-hover-bg);
+}
+
+/* Modal */
+@keyframes slide-up {
+  from {
+    bottom: -100vh;
+  }
+
+  to {
+    bottom: 0;
+  }
+}
+
+@keyframes slide-down {
+  from {
+    bottom: 0;
+  }
+
+  to {
+    bottom: -100vh;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+#bc-susi-modal {
+  z-index: calc( var(--modal-z-index) + 1);
+}
+
+#bc-susi-modal ~ .modal-curtain {
+  z-index: calc( var(--modal-z-index-curtain) + 1);
+}
+
+#brand-concierge-modal {
+  --modal-header-height: 57px;
+}
+
+#brand-concierge-modal.dialog-modal {
+  height: calc(100dvh - 22px);
+  width: 100vw;
+  max-width: unset;
+  max-height: unset;
+  margin-top: 22px;
+  border-radius: 24px 24px 0 0;
+  font-size: 16px;
+  top: unset;
+  bottom: 0;
+  animation: var(--bc-modal-animation-time) ease-in-out slide-up;
+}
+
+/* Fallback for browsers that don't support dvh */
+@supports not (height: 100dvh) {
+  #brand-concierge-modal.dialog-modal {
+    height: calc(100vh - 22px);
+  }
+}
+
+#brand-concierge-modal.dialog-modal.closing {
+  animation: var(--bc-modal-animation-time) ease-in-out slide-down;
+  bottom: -100vh;
+}
+
+#brand-concierge-modal ~ .modal-curtain {
+  animation: var(--bc-modal-animation-time) ease-in-out fade-in;
+  opacity: 1;
+}
+
+#brand-concierge-modal.closing ~ .modal-curtain {
+  animation: var(--bc-modal-animation-time) ease-in-out fade-out;
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #brand-concierge-modal.dialog-modal,
+  #brand-concierge-modal.dialog-modal.closing,
+  #brand-concierge-modal ~ .modal-curtain,
+  #brand-concierge-modal.closing ~ .modal-curtain {
+    animation: none;
+  }
+
+  .brand-concierge.floating-input {
+    backdrop-filter: none;
+    background: #F8F8F8;
+  }
+
+  .brand-concierge.floating-input.dark {
+    background: #111;
+  }
+}
+
+#brand-concierge-modal .dialog-close {
+  z-index: 2;
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTkuNzU0ODggMTMuMjQzMkMxMC4wNDIgMTIuOTQ0NCAxMC41MTY2IDEyLjkzNDYgMTAuODE0NSAxMy4yMjI3TDE1Ljk5OCAxOC4yMDlMMjEuMTk1MyAxMy4yMUMyMS40OTMyIDEyLjkyMTkgMjEuOTY3OCAxMi45MzE3IDIyLjI1NDkgMTMuMjMwNUMyMi41NDIgMTMuNTI3NCAyMi41MzMyIDE0LjAwMyAyMi4yMzQ0IDE0LjI5MDFMMTYuNTE3NiAxOS43OTAxQzE2LjIyNzUgMjAuMDcwMyAxNS43Njg2IDIwLjA3MDMgMTUuNDc4NSAxOS43OTAxTDkuNzc1MzkgMTQuMzAyOEM5LjYyMjA3IDE0LjE1NjMgOS41NDQ5MiAxMy45NTkgOS41NDQ5MiAxMy43NjI3QzkuNTQ0OTIgMTMuNTc1MiA5LjYxNDI2IDEzLjM4NzcgOS43NTQ4OCAxMy4yNDMyWiIgZmlsbD0iIzI5MjkyOSIvPgo8L3N2Zz4=');
+  background-repeat: no-repeat;
+  background-position: center;
+  height: 32px;
+  width: 32px;
+  border: none;
+  top: 12px;
+  right: 16px;
+}
+
+#brand-concierge-modal .dialog-close:focus-visible {
+  outline: 2px solid #5574F7;
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+#brand-concierge-modal  .dialog-close::before,
+#brand-concierge-modal  .dialog-close::after,
+#brand-concierge-modal  .dialog-close svg {
+  display: none;
+}
+
+.bc-modal-header {
+  height: var(--modal-header-height);
+  padding: 12px 16px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-bottom: 1px solid rgb(0 0 0 / 9%);
+}
+
+.modal-header-icon {
+  display: flex;
+  height: 16px;
+  width: 16px;
+}
+
+.bc-modal-title {
+  font-size: 16px;
+  letter-spacing: -0.9px;
+  line-height: 32px;
+  font-weight: 900;
+  color: #000;
+}
+
+.bc-beta-label {
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 14px;
+  text-transform: uppercase;
+  color: #A358B1;
+  background: #EAEAED;
+  border-radius: 4px;
+  height: 14px;
+  width: 30px;
+  text-align: center;
+}
+
+#brand-concierge-modal #brand-concierge-mount {
+  height: calc(100% - var(--modal-header-height));
 }
 
   /* large mobile up */

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -448,7 +448,7 @@
   padding: 40px 24px 12px;
 }
 
-.brand-concierge.hero.has-bg-image {
+.brand-concierge.hero.has-bg-image:not(.dark):not(.c2-dark) {
   background: linear-gradient(180deg, #fff0 0%, #fff0 38%, #fff 100%), var(--brand-concierge-bg) 50% / cover no-repeat;
 }
 

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -449,7 +449,7 @@
   padding: 40px 24px 12px;
 }
 
-.brand-concierge.hero.has-bg-image:not(.dark):not(.c2-dark) {
+.brand-concierge.hero.has-bg-image:not(.c2-dark) {
   background: linear-gradient(180deg, #fff0 0%, #fff0 38%, #fff 100%), var(--brand-concierge-bg) 50% / cover no-repeat;
 }
 
@@ -474,13 +474,7 @@
   margin-top: 4px;
 }
 
-/* dark  / c2-dark */
-.brand-concierge.dark.has-bg-image {
-  background-color:#000;
-}
-
-.dark .bc-header-title,
-.dark .bc-header-subtitle,
+/* c2-dark */
 .c2-dark .bc-header-title,
 .c2-dark .bc-header-subtitle {
   color: var(--bc-dark-text-color);
@@ -495,14 +489,12 @@
   margin-bottom: 24px;
 }
 
-.dark .prompt-card-button,
 .c2-dark .prompt-card-button {
   background: rgb(255 255 255 / 10%);
   border-radius: 24px;
   position: relative;
 }
 
-.dark .prompt-card-button::before,
 .c2-dark .prompt-card-button::before {
   content: '';
   position: absolute;
@@ -519,26 +511,21 @@
   mask-composite: exclude;
 }
 
-.dark .prompt-card-text,
 .c2-dark .prompt-card-text,
-.dark.hero .prompt-card-text,
 .c2-dark.hero .prompt-card-text {
   grid-template-columns: auto;
 }
 
-.dark .card-icon,
 .c2-dark .card-icon {
   display: none;
 }
 
-.dark .prompt-card-text p,
 .c2-dark .prompt-card-text p {
   color: var(--bc-dark-text-color-secondary);
   margin: 0;
 }
 
 
-.dark .bc-input-field::before,
 .c2-dark .bc-input-field::before {
   background: var(--bc-dark-input-border-color) border-box;
   border: 1px solid var(--bc-input-border-color);
@@ -548,7 +535,6 @@
   margin-bottom: 24px;
 }
 
-.dark .bc-input-field-container,
 .c2-dark .bc-input-field-container {
   border-radius: calc(var(--bc-input-radius) - (var(--bc-input-border-size) / 2));
   background: var(--bc-dark-input-background);
@@ -559,42 +545,33 @@
   background: var(--bc-dark-input-background);
 }
 
-.dark .bc-input-field-container:hover,
-.dark .bc-input-field-container:has(textarea:focus-visible),
 .c2-dark .bc-input-field-container:hover,
 .c2-dark .bc-input-field-container:has(textarea:focus-visible) {
   background: var(--bc-dark-input-background);
 }
 
-.dark .bc-input-field-container textarea,
 .c2-dark .bc-input-field-container textarea {
   color: var(--bc-dark-text-color);
 }
 
-.dark .bc-input-field-container textarea::placeholder,
 .c2-dark .bc-input-field-container textarea::placeholder {
   color: var(--bc-dark-text-color-secondary);
 }
 
-.dark .input-field-button,
 .c2-dark .input-field-button {
   background: var(--bc-dark-button-color);
   color: #000;
 }
 
-.dark .input-field-button:hover,
 .c2-dark .input-field-button:hover {
   background: var(--bc-dark-button-hover-color);
 }
 
-.dark .input-field-button:disabled,
 .c2-dark .input-field-button:disabled {
   background: transparent;
   color: #C6C6C6;
 }
 
-.dark .bc-legal,
-.dark .bc-legal a,
 .c2-dark .bc-legal,
 .c2-dark .bc-legal a {
   color: var(--bc-dark-text-color-secondary);
@@ -924,12 +901,12 @@
     animation: none;
   }
 
-  .brand-concierge.floating-input {
+  .bc-floating-input {
     backdrop-filter: none;
     background: #F8F8F8;
   }
 
-  .brand-concierge.floating-input.dark {
+  .floating-input-dark .bc-floating-input {
     background: #111;
   }
 }
@@ -1138,9 +1115,7 @@
     margin-top: 4px;
   }
 
-  .dark .prompt-card-text,
   .c2-dark .prompt-card-text,
-  .dark.hero .prompt-card-text,
   .c2-dark.hero .prompt-card-text {
     grid-template-columns: auto;
   }

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -38,8 +38,6 @@
   --bc-keyboard-focus-color: #5574F7;
   --bc-dark-text-color: #fff;
   --bc-dark-text-color-secondary: #aba8a6;
-  --bc-dark-border-color: rgba(255 255 255 / 20%);
-  --bc-dark-border-color-secondary: rgba(255 255 255 / 30%);
   --bc-dark-input-background: #131313;
   --bc-dark-input-border-color: linear-gradient(98deg, #9A3CF9 0%, #E743C8 35.46%, #ED457E 68.67%, #FF7918 100%);
   --bc-dark-button-color: rgba(255 255 255 / 80%);
@@ -350,6 +348,20 @@
   color: #4B4B4B;
 }
 
+.floating-element {
+  position: fixed;
+  transition: opacity 0.2s ease;
+}
+
+.floating-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.floating-show {
+  opacity: 1;
+}
+
 /* floating-button */
 .bc-floating-button {
   bottom: 0;
@@ -357,23 +369,12 @@
   right: 0;
   margin: var(--bc-floating-button-spacing) auto;
   max-height: var(--bc-floating-button-height);
-  position: fixed;
-  transition: opacity 0.25s ease;
   width: calc(100% - var(--bc-floating-button-spacing) * 2 - var(--bc-input-border-size) * 2);
   z-index: 5;
 }
 
 .bc-floating-button::before {
   border-color: var(--bc-floating-button-border-color);
-}
-
-.bc-floating-button.floating-hidden {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.bc-floating-button.floating-show {
-  opacity: 1;
 }
 
 .bc-floating-button-container {
@@ -497,16 +498,11 @@
 .dark .prompt-card-button,
 .c2-dark .prompt-card-button {
   background: rgb(255 255 255 / 10%);
-  border: 1px solid var(--bc-dark-border-color);
-  border-radius: 12px;
-}
-
-.c2-dark .prompt-card-button {
-  border: none;
-  border-radius: 18px;
+  border-radius: 24px;
   position: relative;
 }
 
+.dark .prompt-card-button::before,
 .c2-dark .prompt-card-button::before {
   content: '';
   position: absolute;
@@ -514,17 +510,13 @@
   right: 0;
   top: 0;
   bottom: 0;
-  border-radius: 18px;
+  border-radius: 24px;
   border: 1.5px solid transparent;
   background: linear-gradient(to right, rgba(225 29 26 / 16%), rgba(144 13 235 / 16%)) border-box;
   mask:
     linear-gradient(#fff 0 0) padding-box,
     linear-gradient(#fff 0 0);
   mask-composite: exclude;
-}
-
-.dark .prompt-card-button:hover {
-  border-color: var(--bc-dark-border-color-secondary);
 }
 
 .c2-dark .prompt-card-text {
@@ -541,19 +533,15 @@
   margin: 0;
 }
 
-.dark .bc-input-field::before {
-  background: var(--bc-dark-input-border-color) border-box;
-  border: 2px solid var(--bc-input-border-color);
+.dark .bc-input-field-container,
+.c2-dark .bc-input-field-container {
+  border-radius: calc(var(--bc-input-radius) - (var(--bc-input-border-size) / 2));
 }
 
+.dark .bc-input-field::before,
 .c2-dark .bc-input-field::before {
   background: var(--bc-dark-input-border-color) border-box;
   border: 1px solid var(--bc-input-border-color);
-}
-
-
-.dark .bc-input-field:has(textarea:focus-visible)::before {
-  border-color: var(--bc-dark-border-color-secondary);
 }
 
 .c2-dark.input-first .bc-input-field {
@@ -613,7 +601,11 @@
 }
 
 /* floating-input */
-.brand-concierge.floating-input {
+.brand-concierge.floating-input-only {
+  padding: 0;
+}
+
+.floating-input .bc-floating-input {
   --bc-fi-bar-bg: rgba(248 248 248 / 65%);
   --bc-fi-bar-border: rgba(0 0 0 / 12%);
   --bc-fi-input-bg: rgba(255 255 255 / 85%);
@@ -626,7 +618,8 @@
   background: var(--bc-fi-bar-bg);
   border: 1px solid var(--bc-fi-bar-border);
   border-radius: 16px;
-  bottom: 16px;
+  bottom: 0;
+  margin: 16px 0;
   box-shadow: 0 8px 32px rgba(0 0 0 / 12%);
   box-sizing: border-box;
   display: flex;
@@ -634,42 +627,41 @@
   gap: 24px;
   left: 50%;
   padding: 16px;
-  position: fixed;
   transform: translateX(-50%);
   width: calc(100% - 32px);
-  z-index: 100;
+  z-index: 5;
 }
 
-.brand-concierge.floating-input .bc-input-field,
-.brand-concierge.floating-input .bc-prompt-cards {
+.floating-input .bc-floating-input .bc-input-field,
+.floating-input .bc-floating-input .bc-prompt-cards {
   margin: 0;
 }
 
-.brand-concierge.floating-input .bc-input-field {
+.floating-input .bc-floating-input .bc-input-field {
   flex: 1;
   min-width: 0;
 }
 
-.brand-concierge.floating-input .bc-input-field-container {
+.floating-input .bc-floating-input .bc-input-field-container {
   background: var(--bc-fi-input-bg);
   margin-bottom: 0;
   min-height: 48px;
 }
 
-.brand-concierge.floating-input .bc-input-field-container:hover,
-.brand-concierge.floating-input .bc-input-field-container:has(textarea:focus-visible) {
+.floating-input .bc-floating-input .bc-input-field-container:hover,
+.floating-input .bc-floating-input .bc-input-field-container:has(textarea:focus-visible) {
   background: var(--bc-fi-input-bg);
 }
 
-.brand-concierge.floating-input .bc-input-tooltip {
+.floating-input .bc-floating-input .bc-input-tooltip {
   color: #000;
 }
 
-.brand-concierge.floating-input.light .bc-input-tooltip {
+.floating-input .bc-floating-input.light .bc-input-tooltip {
   color: #fff;
 }
 
-.brand-concierge.floating-input .bc-input-field::before {
+.floating-input .bc-floating-input .bc-input-field::before {
   backdrop-filter: none;
   background:
     linear-gradient(var(--bc-fi-input-bg), var(--bc-fi-input-bg)) padding-box,
@@ -677,7 +669,7 @@
   border: 2px solid transparent;
 }
 
-.brand-concierge.floating-input .bc-input-field::after {
+.floating-input .bc-floating-input .bc-input-field::after {
   content: '';
   position: absolute;
   inset: -4px;
@@ -689,17 +681,17 @@
   z-index: 0;
 }
 
-.brand-concierge.floating-input .bc-input-field:hover::after,
-.brand-concierge.floating-input .bc-input-field:has(textarea:focus-visible)::after {
+.floating-input .bc-floating-input .bc-input-field:hover::after,
+.floating-input .bc-floating-input .bc-input-field:has(textarea:focus-visible)::after {
   opacity: 0.4;
 }
 
-.brand-concierge.floating-input .bc-textarea-grow-wrap {
+.floating-input .bc-floating-input .bc-textarea-grow-wrap {
   overflow: hidden;
 }
 
-.brand-concierge.floating-input .bc-input-field-container textarea,
-.brand-concierge.floating-input .bc-textarea-grow-wrap::after {
+.floating-input .bc-floating-input .bc-input-field-container textarea,
+.floating-input .bc-floating-input .bc-textarea-grow-wrap::after {
   max-height: 48px;
   min-height: 48px;
   overflow: hidden;
@@ -708,32 +700,32 @@
   white-space: nowrap;
 }
 
-.brand-concierge.floating-input .bc-input-field-label {
+.floating-input .bc-floating-input .bc-input-field-label {
   align-self: center;
   margin-top: 0;
 }
 
-.brand-concierge.floating-input .input-field-button {
+.floating-input .bc-floating-input .input-field-button {
   align-self: center;
   margin-bottom: 0;
 }
 
-.brand-concierge.floating-input .input-field-button,
-.brand-concierge.floating-input .input-field-button:hover {
+.floating-input .bc-floating-input .input-field-button,
+.floating-input .bc-floating-input .input-field-button:hover {
   background: transparent;
   color: #0004;
 }
 
-.brand-concierge.floating-input .input-field-button:disabled {
+.floating-input .bc-floating-input .input-field-button:disabled {
   color: #0004;
 }
 
-.brand-concierge.floating-input .input-field-button:not(:disabled) {
+.floating-input .bc-floating-input .input-field-button:not(:disabled) {
   background: var(--bc-button-color);
   color: #fff;
 }
 
-.brand-concierge.floating-input .bc-prompt-cards {
+.floating-input .bc-floating-input .bc-prompt-cards {
   display: none;
   flex: 0 1 auto;
   flex-wrap: nowrap;
@@ -741,7 +733,7 @@
   overflow: hidden;
 }
 
-.brand-concierge.floating-input .prompt-card-button {
+.floating-input .bc-floating-input .prompt-card-button {
   background: var(--bc-fi-pill-bg);
   border-color: var(--bc-fi-pill-border);
   border-radius: 26px;
@@ -752,16 +744,16 @@
   width: auto;
 }
 
-.brand-concierge.floating-input .prompt-card-button:hover {
+.floating-input .bc-floating-input .prompt-card-button:hover {
   background: #F8F8F8;
   border-color: rgba(0 0 0 / 22%);
 }
 
-.brand-concierge.floating-input .prompt-card-button:focus-visible {
+.floating-input .bc-floating-input .prompt-card-button:focus-visible {
   outline-offset: -2px;
 }
 
-.brand-concierge.floating-input .prompt-card-text {
+.floating-input .bc-floating-input .prompt-card-text {
   align-items: center;
   color: var(--bc-fi-pill-text);
   display: flex;
@@ -772,17 +764,17 @@
   white-space: nowrap;
 }
 
-.brand-concierge.floating-input .prompt-card-text .card-icon {
+.floating-input .bc-floating-input .prompt-card-text .card-icon {
   display: none;
 }
 
-.brand-concierge.floating-input .prompt-card-text p {
+.floating-input .bc-floating-input .prompt-card-text p {
   color: var(--bc-fi-pill-text);
   margin: 0;
   white-space: nowrap;
 }
 
-.brand-concierge.floating-input.dark {
+.floating-input-dark .bc-floating-input {
   --bc-fi-bar-bg: rgba(0 0 0 / 65%);
   --bc-fi-bar-border: rgba(255 255 255 / 21%);
   --bc-fi-input-bg: #131313;
@@ -796,39 +788,39 @@
   --bc-fi-pill-hover-bg: #222;
 }
 
-.brand-concierge.floating-input.dark .bc-input-field::before {
+.floating-input-dark .bc-floating-input .bc-input-field::before {
   background:
     linear-gradient(#111, #111) padding-box,
     linear-gradient(135deg, #D73220, #F98F06, #7155FA) border-box;
 }
 
-.brand-concierge.floating-input.dark .bc-input-field-container textarea::placeholder {
+.floating-input-dark .bc-floating-input .bc-input-field-container textarea::placeholder {
   color: rgba(219 219 219 / 70%);
 }
 
-.brand-concierge.floating-input.dark .bc-textarea-grow-wrap textarea {
+.floating-input-dark .bc-floating-input .bc-textarea-grow-wrap textarea {
   color: var(--bc-fi-text);
 }
 
-.brand-concierge.floating-input.dark .input-field-button {
+.floating-input-dark .bc-floating-input .input-field-button {
   color: var(--bc-fi-icon-color);
 }
 
-.brand-concierge.floating-input.dark .input-field-button:disabled {
+.floating-input-dark .bc-floating-input .input-field-button:disabled {
   color: var(--bc-fi-icon-color);
   pointer-events: none;
 }
 
-.brand-concierge.floating-input.dark .input-field-button:not(:disabled) {
+.floating-input-dark .bc-floating-input .input-field-button:not(:disabled) {
   color: var(--bc-fi-input-bg);
 }
 
-.brand-concierge.floating-input.dark .bc-input-field-container:hover,
-.brand-concierge.floating-input.dark .bc-input-field-container:has(textarea:focus-visible) {
+.floating-input-dark .bc-floating-input .bc-input-field-container:hover,
+.floating-input-dark .bc-floating-input .bc-input-field-container:has(textarea:focus-visible) {
   background: var(--bc-fi-input-hover-bg);
 }
 
-.brand-concierge.floating-input.dark .prompt-card-button:hover {
+.floating-input-dark .bc-floating-input .prompt-card-button:hover {
   border: 1px solid var(--bc-fi-icon-color);
   background-color: var(--bc-fi-pill-hover-bg);
 }
@@ -1031,8 +1023,8 @@
     padding: 80px 32px 24px;
   }
 
-  .brand-concierge.floating-input {
-    bottom: 24px;
+  .floating-input .bc-floating-input {
+    margin: 24px 0;
     max-width: 1412px;
     padding: 20px;
     width: calc(100% - 48px);
@@ -1156,11 +1148,11 @@
     }
   }
 
-  .brand-concierge.floating-input .bc-prompt-cards {
+  .floating-input .bc-floating-input .bc-prompt-cards {
     display: flex;
   }
 
-  .brand-concierge.floating-input .bc-input-field {
+  .floating-input .bc-floating-input .bc-input-field {
     min-width: 340px;
   }
 }

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -1206,8 +1206,8 @@
   }
 
   .hero .bc-header-title {
-    font-size: 44px;
-    line-height: 55px;
+    font-size: 80px;
+    line-height: 88px;
   }
 
   .bc-susi-modal button.dialog-close {

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -1143,6 +1143,13 @@
     margin-top: 4px;
   }
 
+  .dark .prompt-card-text,
+  .c2-dark .prompt-card-text,
+  .dark.hero .prompt-card-text,
+  .c2-dark.hero .prompt-card-text {
+    grid-template-columns: auto;
+  }
+
   #brand-concierge-modal.dialog-modal {
     height: calc(100dvh - 32px);
     margin-top: 32px;

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -348,17 +348,17 @@
   color: #4B4B4B;
 }
 
-.floating-element {
+.bc-floating-element {
   position: fixed;
   transition: opacity 0.2s ease;
 }
 
-.floating-hidden {
+.bc-floating-hidden {
   opacity: 0;
   pointer-events: none;
 }
 
-.floating-show {
+.bc-floating-show {
   opacity: 1;
 }
 

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -519,10 +519,14 @@
   mask-composite: exclude;
 }
 
-.c2-dark .prompt-card-text {
+.dark .prompt-card-text,
+.c2-dark .prompt-card-text,
+.dark.hero .prompt-card-text,
+.c2-dark.hero .prompt-card-text {
   grid-template-columns: auto;
 }
 
+.dark .card-icon,
 .c2-dark .card-icon {
   display: none;
 }
@@ -533,10 +537,6 @@
   margin: 0;
 }
 
-.dark .bc-input-field-container,
-.c2-dark .bc-input-field-container {
-  border-radius: calc(var(--bc-input-radius) - (var(--bc-input-border-size) / 2));
-}
 
 .dark .bc-input-field::before,
 .c2-dark .bc-input-field::before {
@@ -550,6 +550,7 @@
 
 .dark .bc-input-field-container,
 .c2-dark .bc-input-field-container {
+  border-radius: calc(var(--bc-input-radius) - (var(--bc-input-border-size) / 2));
   background: var(--bc-dark-input-background);
 }
 

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -540,11 +540,6 @@
   background: var(--bc-dark-input-background);
 }
 
-.c2-dark .bc-input-field-container {
-  border-radius: 28px;
-  background: var(--bc-dark-input-background);
-}
-
 .c2-dark .bc-input-field-container:hover,
 .c2-dark .bc-input-field-container:has(textarea:focus-visible) {
   background: var(--bc-dark-input-background);

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -454,8 +454,8 @@
 }
 
 .hero .bc-header-title {
-  font-size: 28px;
-  line-height: 35px;
+  font-size: 36px;
+  line-height: 45px;
 }
 
 .hero .bc-input-field {
@@ -1108,11 +1108,6 @@
     padding: 0 50px;
   }
 
-  .hero .bc-header-title {
-    font-size: 36px;
-    line-height: 45px;
-  }
-
   .hero .bc-input-field {
     margin-bottom: 32px;
     max-width: calc(768px - 4px);
@@ -1221,8 +1216,8 @@
   }
 
   .hero .bc-header-title {
-    font-size: 80px;
-    line-height: 88px;
+    font-size: 44px;
+    line-height: 55px;
   }
 
   .bc-susi-modal button.dialog-close {

--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -525,7 +525,7 @@ function decorateCards(el, cards) {
     const cardText = createTag('div', { class: 'prompt-card-text' }, `${aiIcon(`card-icon-${index + 1}`, 'card-icon', null, 16)} <p>${card.textContent.trim()}</p>`);
     const cardButton = createTag('button', {
       class: 'prompt-card-button no-track',
-      'daa-ll': getAnalyticsLabel('1'),
+      'daa-ll': getAnalyticsLabel(`1|BC-suggested_prompt_clicked|inline|${cardText.textContent.trim()}`),
       'aria-label': cardText.textContent.trim(),
     });
     if (cardImage) {

--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -34,12 +34,12 @@ const webClientVersion = params.get('webclientversion');
 let floatingButtonClicked = false;
 let bcToken;
 
-function floatingElement(targetEl, el, focusableEl = null) {
-  const getTargetHeight = (target) => {
-    const { marginBottom } = window.getComputedStyle(target);
-    return target.scrollHeight + (parseFloat(marginBottom) * 2);
-  };
+const getTargetHeight = (target) => {
+  const { marginBottom } = window.getComputedStyle(target);
+  return target.scrollHeight + (parseFloat(marginBottom) * 2);
+};
 
+function floatingElement(targetEl, el, focusableEl = null) {
   const hideFloating = () => {
     if (focusableEl) {
       focusableEl.setAttribute('aria-hidden', 'true');
@@ -71,6 +71,8 @@ function floatingElement(targetEl, el, focusableEl = null) {
   floatingSpacer.style.cssText = 'height:0; pointer-events:none;';
   mainElement.append(floatingSpacer);
 
+  targetEl.classList.add('floating-element');
+
   const ro = new ResizeObserver((entries) => {
     for (const entry of entries) {
       const size = Math.floor(entry.borderBoxSize?.[0]?.blockSize);
@@ -94,9 +96,10 @@ function floatingElement(targetEl, el, focusableEl = null) {
     // only values that need to be calculated on scroll are here, to optimize performance
     const threshold = window.scrollY + window.innerHeight - mainTop;
     const topDelay = variants.floatingDelay ? variants.floatingDelayAmount : elHeight;
+    const bottomValue = threshold - mainHeight;
 
     if (threshold > mainHeight) {
-      target.style.bottom = `${threshold - mainHeight}px`;
+      target.style.bottom = `${bottomValue}px`;
       if (variants.isFloatingAnchorHide || variants.floatingAnchorDelay) {
         hideFloating();
       } else {
@@ -493,7 +496,7 @@ function decorateBackground(el, background) {
       el.style.setProperty('--brand-concierge-bg', `url(${rawImage})`);
     }
   }
-  el.removeChild(background);
+  if (el.contains(background)) el.removeChild(background);
 }
 
 function decorateHeader(el, header) {
@@ -514,7 +517,7 @@ function decorateHeader(el, header) {
   }
 
   el.append(headerSection);
-  el.removeChild(header);
+  if (el.contains(header)) el.removeChild(header);
 }
 
 function decorateCards(el, cards) {
@@ -544,7 +547,7 @@ function decorateCards(el, cards) {
   });
 
   el.append(cardSection);
-  el.removeChild(cards);
+  if (el.contains(cards)) el.removeChild(cards);
 }
 
 function decorateInput(el, input) {
@@ -575,7 +578,7 @@ function decorateInput(el, input) {
 
   fieldSection.append(fieldContainer);
   el.append(fieldSection);
-  el.removeChild(input);
+  if (el.contains(input)) el.removeChild(input);
   updateReplicatedValue(textareaWrapper, fieldInput);
 
   fieldInput.addEventListener('input', () => {
@@ -605,7 +608,7 @@ function decorateLegal(el, legal) {
   const legalContent = createTag('p', {}, legal.querySelector('div').innerHTML);
   legalSection.append(legalContent);
   el.append(legalSection);
-  el.removeChild(legal);
+  if (el.contains(legal)) el.removeChild(legal);
 }
 
 function decorateFloatingButton(el) {
@@ -627,24 +630,42 @@ function decorateFloatingButton(el) {
   floatingElement(floatingButton, el, floatingContainer);
 }
 
-function updatePillVisibility(el) {
-  const cards = el.querySelector('.bc-prompt-cards');
-  if (!cards) return;
+function decorateFloatingInput(el, cards, input) {
+  if (variants.isFloatingInputOnly) {
+    el.classList.add('floating-input');
+  }
+  function updatePillVisibility(target) {
+    const prompts = target.querySelector('.bc-prompt-cards');
+    if (!prompts) return;
 
-  const buttons = [...cards.querySelectorAll('.prompt-card-button')];
-  buttons.forEach((btn) => { btn.style.display = ''; });
+    const buttons = [...prompts.querySelectorAll('.prompt-card-button')];
+    buttons.forEach((btn) => { btn.style.display = ''; });
 
-  requestAnimationFrame(() => {
-    const { left: containerLeft, right: containerRight } = cards.getBoundingClientRect();
+    requestAnimationFrame(() => {
+      const { left: containerLeft, right: containerRight } = prompts.getBoundingClientRect();
 
-    buttons.forEach((btn) => {
-      const { left, right } = btn.getBoundingClientRect();
+      buttons.forEach((btn) => {
+        const { left, right } = btn.getBoundingClientRect();
 
-      if (right > containerRight || left < containerLeft) {
-        btn.style.display = 'none';
-      }
+        if (right > containerRight || left < containerLeft) {
+          btn.style.display = 'none';
+        }
+      });
     });
-  });
+  }
+
+  const floatingInput = createTag('section', { class: 'bc-floating-input' });
+  decorateInput(floatingInput, input);
+  decorateCards(floatingInput, cards);
+  el.append(floatingInput);
+
+  const updateLayout = () => {
+    updatePillVisibility(floatingInput);
+  };
+
+  window.addEventListener('resize', updateLayout);
+  requestAnimationFrame(updateLayout);
+  floatingElement(floatingInput, el, el.querySelector('.bc-input-field'));
 }
 
 function handleConsent(el) {
@@ -671,8 +692,8 @@ export default async function init(el) {
 
   // set variant
   if (!el.classList.contains('hero')
-  && !el.classList.contains('floating-button-only')
-  && !el.classList.contains('floating-input')) {
+    && !el.classList.contains('floating-button-only')
+    && !el.classList.contains('floating-input-only')) {
     el.classList.add('inline');
     variants.isDefault = true;
   } else if (el.classList.contains('hero')) {
@@ -705,6 +726,8 @@ export default async function init(el) {
 
   if (el.classList.contains('floating-input')) {
     variants.isFloatingInput = true;
+  } else if (el.classList.contains('floating-input-only')) {
+    variants.isFloatingInputOnly = true;
   }
 
   if (variants.isFloatingButton) {
@@ -741,41 +764,15 @@ export default async function init(el) {
   }
 
   if (variants.isFloatingInput) {
-    const [background, header, cards, input, legal] = rows;
-    el.removeChild(background);
-    el.removeChild(header);
-    el.removeChild(legal);
-    decorateInput(el, input);
-    decorateCards(el, cards);
-
-    const mainEl = document.querySelector('main');
-    const updateLayout = () => {
-      if (mainEl) mainEl.style.paddingBottom = `${el.offsetHeight + 16}px`;
-      updatePillVisibility(el);
-    };
-
-    // Need to move handleScroll outside of floating element, and add this functionality
-    const main = document.querySelector('main');
-    let scrollPendingFloatingInput = false;
-
-    window.addEventListener('scroll', () => {
-      if (scrollPendingFloatingInput) return;
-      scrollPendingFloatingInput = true;
-      requestAnimationFrame(() => {
-        if (main) {
-          const threshold = window.scrollY + window.innerHeight - main.offsetTop;
-          const paddingMiddle = (parseFloat(mainEl.style.paddingBottom) - el.offsetHeight) / 2;
-
-          el.style.bottom = threshold > main.scrollHeight
-            ? `${threshold - main.scrollHeight + paddingMiddle}px`
-            : '';
-        }
-        scrollPendingFloatingInput = false;
-      });
-    }, { passive: true });
-
-    window.addEventListener('resize', updateLayout);
-    requestAnimationFrame(updateLayout);
+    const [, , cards, input] = rows;
+    decorateFloatingInput(el, cards, input);
+  }
+  if (variants.isFloatingInputOnly) {
+    const [, , cards, input] = rows;
+    decorateFloatingInput(el, cards, input);
+    rows.forEach((row) => {
+      el.removeChild(row);
+    });
   }
 
   const loginTestButton = params.get('susi-test-btn');

--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -46,8 +46,8 @@ function floatingElement(targetEl, el, focusableEl = null) {
       focusableEl.setAttribute('tabindex', '-1');
       focusableEl.blur();
     }
-    targetEl.classList.add('floating-hidden');
-    targetEl.classList.remove('floating-show');
+    targetEl.classList.add('bc-floating-hidden');
+    targetEl.classList.remove('bc-floating-show');
   };
 
   const showFloating = () => {
@@ -55,8 +55,8 @@ function floatingElement(targetEl, el, focusableEl = null) {
       focusableEl.removeAttribute('aria-hidden');
       focusableEl.removeAttribute('tabindex');
     }
-    targetEl.classList.remove('floating-hidden');
-    targetEl.classList.add('floating-show');
+    targetEl.classList.remove('bc-floating-hidden');
+    targetEl.classList.add('bc-floating-show');
   };
 
   const mainElement = document.querySelector('main');
@@ -71,7 +71,7 @@ function floatingElement(targetEl, el, focusableEl = null) {
   floatingSpacer.style.cssText = 'height:0; pointer-events:none;';
   mainElement.append(floatingSpacer);
 
-  targetEl.classList.add('floating-element');
+  targetEl.classList.add('bc-floating-element');
 
   const ro = new ResizeObserver((entries) => {
     for (const entry of entries) {

--- a/libs/c2/blocks/brand-concierge/brand-concierge.css
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.css
@@ -8,8 +8,8 @@
 .brand-concierge {
   --bc-header-font-size: 36px;
   --bc-header-line-height: 45px;
-  --bc-header-subtitle-font-size: 16px;
-  --bc-header-subtitle-line-height: 24px;
+  --bc-header-subtitle-font-size: 18px;
+  --bc-header-subtitle-line-height: 27px;
   --bc-header-margin-bottom: 32px;
   --bc-header-padding: 0 24px;
   --bc-header-color: #131313;
@@ -36,6 +36,12 @@
   --bc-button-color: #292929;
   --bc-button-hover-color: #131313;
   --bc-keyboard-focus-color: #5574F7;
+  --bc-dark-text-color: #fff;
+  --bc-dark-text-color-secondary: #aba8a6;
+  --bc-dark-input-background: #131313;
+  --bc-dark-input-border-color: linear-gradient(98deg, #9A3CF9 0%, #E743C8 35.46%, #ED457E 68.67%, #FF7918 100%);
+  --bc-dark-button-color: rgba(255 255 255 / 80%);
+  --bc-dark-button-hover-color: rgba(255 255 255 / 90%);
 
   box-sizing: border-box;
   padding: 40px 24px 12px;
@@ -342,6 +348,20 @@
   color: #4B4B4B;
 }
 
+.floating-element {
+  position: fixed;
+  transition: opacity 0.2s ease;
+}
+
+.floating-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.floating-show {
+  opacity: 1;
+}
+
 /* floating-button */
 .bc-floating-button {
   bottom: 0;
@@ -349,23 +369,12 @@
   right: 0;
   margin: var(--bc-floating-button-spacing) auto;
   max-height: var(--bc-floating-button-height);
-  position: fixed;
-  transition: opacity 0.25s ease;
   width: calc(100% - var(--bc-floating-button-spacing) * 2 - var(--bc-input-border-size) * 2);
-  z-index: 4;
+  z-index: 5;
 }
 
 .bc-floating-button::before {
   border-color: var(--bc-floating-button-border-color);
-}
-
-.bc-floating-button.floating-hidden {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.bc-floating-button.floating-show {
-  opacity: 1;
 }
 
 .bc-floating-button-container {
@@ -440,13 +449,13 @@
   padding: 40px 24px 12px;
 }
 
-.brand-concierge.hero.has-bg-image {
+.brand-concierge.hero.has-bg-image:not(.dark):not(.c2-dark) {
   background: linear-gradient(180deg, #fff0 0%, #fff0 38%, #fff 100%), var(--brand-concierge-bg) 50% / cover no-repeat;
 }
 
 .hero .bc-header-title {
-  font-size: 36px;
-  line-height: 45px;
+  font-size: 28px;
+  line-height: 35px;
 }
 
 .hero .bc-input-field {
@@ -463,6 +472,360 @@
 .pill-cards .card-icon {
   align-self: flex-start;
   margin-top: 4px;
+}
+
+/* dark  / c2-dark */
+.brand-concierge.dark.has-bg-image {
+  background-color:#000;
+}
+
+.dark .bc-header-title,
+.dark .bc-header-subtitle,
+.c2-dark .bc-header-title,
+.c2-dark .bc-header-subtitle {
+  color: var(--bc-dark-text-color);
+}
+
+.c2-dark .bc-header-title {
+  font-size: 32px;
+  line-height: 32px;
+}
+
+.c2-dark.input-first .bc-prompt-cards {
+  margin-bottom: 24px;
+}
+
+.dark .prompt-card-button,
+.c2-dark .prompt-card-button {
+  background: rgb(255 255 255 / 10%);
+  border-radius: 24px;
+  position: relative;
+}
+
+.dark .prompt-card-button::before,
+.c2-dark .prompt-card-button::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 24px;
+  border: 1.5px solid transparent;
+  background: linear-gradient(to right, rgba(225 29 26 / 16%), rgba(144 13 235 / 16%)) border-box;
+  mask:
+    linear-gradient(#fff 0 0) padding-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+}
+
+.dark .prompt-card-text,
+.c2-dark .prompt-card-text,
+.dark.hero .prompt-card-text,
+.c2-dark.hero .prompt-card-text {
+  grid-template-columns: auto;
+}
+
+.dark .card-icon,
+.c2-dark .card-icon {
+  display: none;
+}
+
+.dark .prompt-card-text p,
+.c2-dark .prompt-card-text p {
+  color: var(--bc-dark-text-color-secondary);
+  margin: 0;
+}
+
+
+.dark .bc-input-field::before,
+.c2-dark .bc-input-field::before {
+  background: var(--bc-dark-input-border-color) border-box;
+  border: 1px solid var(--bc-input-border-color);
+}
+
+.c2-dark.input-first .bc-input-field {
+  margin-bottom: 24px;
+}
+
+.dark .bc-input-field-container,
+.c2-dark .bc-input-field-container {
+  border-radius: calc(var(--bc-input-radius) - (var(--bc-input-border-size) / 2));
+  background: var(--bc-dark-input-background);
+}
+
+.c2-dark .bc-input-field-container {
+  border-radius: 28px;
+  background: var(--bc-dark-input-background);
+}
+
+.dark .bc-input-field-container:hover,
+.dark .bc-input-field-container:has(textarea:focus-visible),
+.c2-dark .bc-input-field-container:hover,
+.c2-dark .bc-input-field-container:has(textarea:focus-visible) {
+  background: var(--bc-dark-input-background);
+}
+
+.dark .bc-input-field-container textarea,
+.c2-dark .bc-input-field-container textarea {
+  color: var(--bc-dark-text-color);
+}
+
+.dark .bc-input-field-container textarea::placeholder,
+.c2-dark .bc-input-field-container textarea::placeholder {
+  color: var(--bc-dark-text-color-secondary);
+}
+
+.dark .input-field-button,
+.c2-dark .input-field-button {
+  background: var(--bc-dark-button-color);
+  color: #000;
+}
+
+.dark .input-field-button:hover,
+.c2-dark .input-field-button:hover {
+  background: var(--bc-dark-button-hover-color);
+}
+
+.dark .input-field-button:disabled,
+.c2-dark .input-field-button:disabled {
+  background: transparent;
+  color: #C6C6C6;
+}
+
+.dark .bc-legal,
+.dark .bc-legal a,
+.c2-dark .bc-legal,
+.c2-dark .bc-legal a {
+  color: var(--bc-dark-text-color-secondary);
+  font-size: 12px;
+}
+
+/* floating-input */
+.brand-concierge.floating-input-only {
+  padding: 0;
+}
+
+.floating-input .bc-floating-input {
+  --bc-fi-bar-bg: rgba(248 248 248 / 65%);
+  --bc-fi-bar-border: rgba(0 0 0 / 12%);
+  --bc-fi-input-bg: rgba(255 255 255 / 85%);
+  --bc-fi-pill-bg: rgba(255 255 255 / 94%);
+  --bc-fi-pill-border: rgba(0 0 0 / 12%);
+  --bc-fi-text: #292929;
+  --bc-fi-pill-text: #292929;
+
+  backdrop-filter: blur(20px);
+  background: var(--bc-fi-bar-bg);
+  border: 1px solid var(--bc-fi-bar-border);
+  border-radius: 16px;
+  bottom: 0;
+  margin: 16px 0;
+  box-shadow: 0 8px 32px rgba(0 0 0 / 12%);
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  left: 50%;
+  padding: 16px;
+  transform: translateX(-50%);
+  width: calc(100% - 32px);
+  z-index: 5;
+}
+
+.floating-input .bc-floating-input .bc-input-field,
+.floating-input .bc-floating-input .bc-prompt-cards {
+  margin: 0;
+}
+
+.floating-input .bc-floating-input .bc-input-field {
+  flex: 1;
+  min-width: 0;
+}
+
+.floating-input .bc-floating-input .bc-input-field-container {
+  background: var(--bc-fi-input-bg);
+  margin-bottom: 0;
+  min-height: 48px;
+}
+
+.floating-input .bc-floating-input .bc-input-field-container:hover,
+.floating-input .bc-floating-input .bc-input-field-container:has(textarea:focus-visible) {
+  background: var(--bc-fi-input-bg);
+}
+
+.floating-input .bc-floating-input .bc-input-tooltip {
+  color: #000;
+}
+
+.floating-input .bc-floating-input.light .bc-input-tooltip {
+  color: #fff;
+}
+
+.floating-input .bc-floating-input .bc-input-field::before {
+  backdrop-filter: none;
+  background:
+    linear-gradient(var(--bc-fi-input-bg), var(--bc-fi-input-bg)) padding-box,
+    linear-gradient(135deg, #7155FA, #D92361, #D73220) border-box;
+  border: 2px solid transparent;
+}
+
+.floating-input .bc-floating-input .bc-input-field::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 30px;
+  background: linear-gradient(135deg, #7155FA, #D92361, #D73220);
+  filter: blur(15px);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 0;
+}
+
+.floating-input .bc-floating-input .bc-input-field:hover::after,
+.floating-input .bc-floating-input .bc-input-field:has(textarea:focus-visible)::after {
+  opacity: 0.4;
+}
+
+.floating-input .bc-floating-input .bc-textarea-grow-wrap {
+  overflow: hidden;
+}
+
+.floating-input .bc-floating-input .bc-input-field-container textarea,
+.floating-input .bc-floating-input .bc-textarea-grow-wrap::after {
+  max-height: 48px;
+  min-height: 48px;
+  overflow: hidden;
+  overflow-wrap: normal;
+  padding: 12px 0;
+  white-space: nowrap;
+}
+
+.floating-input .bc-floating-input .bc-input-field-label {
+  align-self: center;
+  margin-top: 0;
+}
+
+.floating-input .bc-floating-input .input-field-button {
+  align-self: center;
+  margin-bottom: 0;
+}
+
+.floating-input .bc-floating-input .input-field-button,
+.floating-input .bc-floating-input .input-field-button:hover {
+  background: transparent;
+  color: #0004;
+}
+
+.floating-input .bc-floating-input .input-field-button:disabled {
+  color: #0004;
+}
+
+.floating-input .bc-floating-input .input-field-button:not(:disabled) {
+  background: var(--bc-button-color);
+  color: #fff;
+}
+
+.floating-input .bc-floating-input .bc-prompt-cards {
+  display: none;
+  flex: 0 1 auto;
+  flex-wrap: nowrap;
+  gap: 10px;
+  overflow: hidden;
+}
+
+.floating-input .bc-floating-input .prompt-card-button {
+  background: var(--bc-fi-pill-bg);
+  border-color: var(--bc-fi-pill-border);
+  border-radius: 26px;
+  flex: 0 0 auto;
+  height: 36px;
+  padding: 0;
+  white-space: nowrap;
+  width: auto;
+}
+
+.floating-input .bc-floating-input .prompt-card-button:hover {
+  background: #F8F8F8;
+  border-color: rgba(0 0 0 / 22%);
+}
+
+.floating-input .bc-floating-input .prompt-card-button:focus-visible {
+  outline-offset: -2px;
+}
+
+.floating-input .bc-floating-input .prompt-card-text {
+  align-items: center;
+  color: var(--bc-fi-pill-text);
+  display: flex;
+  font-size: 14px;
+  gap: 6px;
+  line-height: 1.4;
+  padding: 4px 16px;
+  white-space: nowrap;
+}
+
+.floating-input .bc-floating-input .prompt-card-text .card-icon {
+  display: none;
+}
+
+.floating-input .bc-floating-input .prompt-card-text p {
+  color: var(--bc-fi-pill-text);
+  margin: 0;
+  white-space: nowrap;
+}
+
+.floating-input-dark .bc-floating-input {
+  --bc-fi-bar-bg: rgba(0 0 0 / 65%);
+  --bc-fi-bar-border: rgba(255 255 255 / 21%);
+  --bc-fi-input-bg: #131313;
+  --bc-fi-pill-bg: rgba(0 0 0 / 93%);
+  --bc-fi-pill-border: #8F8F8F;
+  --bc-fi-text: #DBDBDB;
+  --bc-fi-pill-text: var(--bc-fi-text);
+  --bc-button-color: var(--bc-fi-text);
+  --bc-fi-icon-color: #C6C6C6;
+  --bc-fi-input-hover-bg: #292929;
+  --bc-fi-pill-hover-bg: #222;
+}
+
+.floating-input-dark .bc-floating-input .bc-input-field::before {
+  background:
+    linear-gradient(#111, #111) padding-box,
+    linear-gradient(135deg, #D73220, #F98F06, #7155FA) border-box;
+}
+
+.floating-input-dark .bc-floating-input .bc-input-field-container textarea::placeholder {
+  color: rgba(219 219 219 / 70%);
+}
+
+.floating-input-dark .bc-floating-input .bc-textarea-grow-wrap textarea {
+  color: var(--bc-fi-text);
+}
+
+/* stylelint-disable */
+.floating-input-dark .bc-floating-input .input-field-button {
+  color: var(--bc-fi-icon-color);
+}
+/* stylelint-enable */
+
+.floating-input-dark .bc-floating-input .input-field-button:disabled {
+  color: var(--bc-fi-icon-color);
+  pointer-events: none;
+}
+
+.floating-input-dark .bc-floating-input .input-field-button:not(:disabled) {
+  color: var(--bc-fi-input-bg);
+}
+
+.floating-input-dark .bc-floating-input .bc-input-field-container:hover,
+.floating-input-dark .bc-floating-input .bc-input-field-container:has(textarea:focus-visible) {
+  background: var(--bc-fi-input-hover-bg);
+}
+
+.floating-input-dark .bc-floating-input .prompt-card-button:hover {
+  border: 1px solid var(--bc-fi-icon-color);
+  background-color: var(--bc-fi-pill-hover-bg);
 }
 
 /* Modal */
@@ -560,6 +923,15 @@
   #brand-concierge-modal.closing ~ .modal-curtain {
     animation: none;
   }
+
+  .brand-concierge.floating-input {
+    backdrop-filter: none;
+    background: #F8F8F8;
+  }
+
+  .brand-concierge.floating-input.dark {
+    background: #111;
+  }
 }
 
 #brand-concierge-modal .dialog-close {
@@ -653,6 +1025,13 @@
   .brand-concierge.hero {
     padding: 80px 32px 24px;
   }
+
+  .floating-input .bc-floating-input {
+    margin: 24px 0;
+    max-width: 1412px;
+    padding: 20px;
+    width: calc(100% - 48px);
+  }
 }
 
 /* Tablet up */
@@ -729,6 +1108,11 @@
     padding: 0 50px;
   }
 
+  .hero .bc-header-title {
+  font-size: 36px;
+  line-height: 45px;
+}
+
   .hero .bc-input-field {
     margin-bottom: 32px;
     max-width: calc(768px - 4px);
@@ -771,6 +1155,14 @@
       height: calc(100vh - 32px);
     }
   }
+
+  .floating-input .bc-floating-input .bc-prompt-cards {
+    display: flex;
+  }
+
+  .floating-input .bc-floating-input .bc-input-field {
+    min-width: 340px;
+  }
 }
 
 /* tablet wide up */
@@ -786,6 +1178,11 @@
 
   #brand-concierge-modal.dialog-modal {
     max-width: 960px;
+  }
+
+  body:has(.brand-concierge.floating-input) #brand-concierge-modal.dialog-modal {
+    max-width: 1412px;
+    width: calc(100% - 48px);
   }
 }
 
@@ -817,8 +1214,8 @@
   }
 
   .hero .bc-header-title {
-    font-size: 44px;
-    line-height: 55px;
+    font-size: 80px;
+    line-height: 88px;
   }
 
   .bc-susi-modal button.dialog-close {

--- a/libs/c2/blocks/brand-concierge/brand-concierge.css
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.css
@@ -449,7 +449,7 @@
   padding: 40px 24px 12px;
 }
 
-.brand-concierge.hero.has-bg-image:not(.dark):not(.c2-dark) {
+.brand-concierge.hero.has-bg-image:not(.c2-dark) {
   background: linear-gradient(180deg, #fff0 0%, #fff0 38%, #fff 100%), var(--brand-concierge-bg) 50% / cover no-repeat;
 }
 
@@ -474,13 +474,7 @@
   margin-top: 4px;
 }
 
-/* dark  / c2-dark */
-.brand-concierge.dark.has-bg-image {
-  background-color:#000;
-}
-
-.dark .bc-header-title,
-.dark .bc-header-subtitle,
+/* c2-dark */
 .c2-dark .bc-header-title,
 .c2-dark .bc-header-subtitle {
   color: var(--bc-dark-text-color);
@@ -495,14 +489,12 @@
   margin-bottom: 24px;
 }
 
-.dark .prompt-card-button,
 .c2-dark .prompt-card-button {
   background: rgb(255 255 255 / 10%);
   border-radius: 24px;
   position: relative;
 }
 
-.dark .prompt-card-button::before,
 .c2-dark .prompt-card-button::before {
   content: '';
   position: absolute;
@@ -519,26 +511,21 @@
   mask-composite: exclude;
 }
 
-.dark .prompt-card-text,
 .c2-dark .prompt-card-text,
-.dark.hero .prompt-card-text,
 .c2-dark.hero .prompt-card-text {
   grid-template-columns: auto;
 }
 
-.dark .card-icon,
 .c2-dark .card-icon {
   display: none;
 }
 
-.dark .prompt-card-text p,
 .c2-dark .prompt-card-text p {
   color: var(--bc-dark-text-color-secondary);
   margin: 0;
 }
 
 
-.dark .bc-input-field::before,
 .c2-dark .bc-input-field::before {
   background: var(--bc-dark-input-border-color) border-box;
   border: 1px solid var(--bc-input-border-color);
@@ -548,7 +535,6 @@
   margin-bottom: 24px;
 }
 
-.dark .bc-input-field-container,
 .c2-dark .bc-input-field-container {
   border-radius: calc(var(--bc-input-radius) - (var(--bc-input-border-size) / 2));
   background: var(--bc-dark-input-background);
@@ -559,42 +545,33 @@
   background: var(--bc-dark-input-background);
 }
 
-.dark .bc-input-field-container:hover,
-.dark .bc-input-field-container:has(textarea:focus-visible),
 .c2-dark .bc-input-field-container:hover,
 .c2-dark .bc-input-field-container:has(textarea:focus-visible) {
   background: var(--bc-dark-input-background);
 }
 
-.dark .bc-input-field-container textarea,
 .c2-dark .bc-input-field-container textarea {
   color: var(--bc-dark-text-color);
 }
 
-.dark .bc-input-field-container textarea::placeholder,
 .c2-dark .bc-input-field-container textarea::placeholder {
   color: var(--bc-dark-text-color-secondary);
 }
 
-.dark .input-field-button,
 .c2-dark .input-field-button {
   background: var(--bc-dark-button-color);
   color: #000;
 }
 
-.dark .input-field-button:hover,
 .c2-dark .input-field-button:hover {
   background: var(--bc-dark-button-hover-color);
 }
 
-.dark .input-field-button:disabled,
 .c2-dark .input-field-button:disabled {
   background: transparent;
   color: #C6C6C6;
 }
 
-.dark .bc-legal,
-.dark .bc-legal a,
 .c2-dark .bc-legal,
 .c2-dark .bc-legal a {
   color: var(--bc-dark-text-color-secondary);
@@ -924,12 +901,12 @@
     animation: none;
   }
 
-  .brand-concierge.floating-input {
+  .bc-floating-input {
     backdrop-filter: none;
     background: #F8F8F8;
   }
 
-  .brand-concierge.floating-input.dark {
+  .floating-input-dark .bc-floating-input {
     background: #111;
   }
 }
@@ -1138,9 +1115,7 @@
     margin-top: 4px;
   }
 
-  .dark .prompt-card-text,
   .c2-dark .prompt-card-text,
-  .dark.hero .prompt-card-text,
   .c2-dark.hero .prompt-card-text {
     grid-template-columns: auto;
   }

--- a/libs/c2/blocks/brand-concierge/brand-concierge.css
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.css
@@ -348,17 +348,17 @@
   color: #4B4B4B;
 }
 
-.floating-element {
+.bc-floating-element {
   position: fixed;
   transition: opacity 0.2s ease;
 }
 
-.floating-hidden {
+.bc-floating-hidden {
   opacity: 0;
   pointer-events: none;
 }
 
-.floating-show {
+.bc-floating-show {
   opacity: 1;
 }
 

--- a/libs/c2/blocks/brand-concierge/brand-concierge.css
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.css
@@ -454,8 +454,8 @@
 }
 
 .hero .bc-header-title {
-  font-size: 28px;
-  line-height: 35px;
+  font-size: 36px;
+  line-height: 45px;
 }
 
 .hero .bc-input-field {
@@ -1108,11 +1108,6 @@
     padding: 0 50px;
   }
 
-  .hero .bc-header-title {
-  font-size: 36px;
-  line-height: 45px;
-}
-
   .hero .bc-input-field {
     margin-bottom: 32px;
     max-width: calc(768px - 4px);
@@ -1141,6 +1136,13 @@
   .hero .prompt-card-text .card-icon,
   .pill-cards .prompt-card-text .card-icon {
     margin-top: 4px;
+  }
+
+  .dark .prompt-card-text,
+  .c2-dark .prompt-card-text,
+  .dark.hero .prompt-card-text,
+  .c2-dark.hero .prompt-card-text {
+    grid-template-columns: auto;
   }
 
   #brand-concierge-modal.dialog-modal {
@@ -1214,8 +1216,8 @@
   }
 
   .hero .bc-header-title {
-    font-size: 80px;
-    line-height: 88px;
+    font-size: 44px;
+    line-height: 55px;
   }
 
   .bc-susi-modal button.dialog-close {

--- a/libs/c2/blocks/brand-concierge/brand-concierge.css
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.css
@@ -540,11 +540,6 @@
   background: var(--bc-dark-input-background);
 }
 
-.c2-dark .bc-input-field-container {
-  border-radius: 28px;
-  background: var(--bc-dark-input-background);
-}
-
 .c2-dark .bc-input-field-container:hover,
 .c2-dark .bc-input-field-container:has(textarea:focus-visible) {
   background: var(--bc-dark-input-background);

--- a/libs/c2/blocks/brand-concierge/brand-concierge.js
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.js
@@ -34,12 +34,12 @@ const webClientVersion = params.get('webclientversion');
 let floatingButtonClicked = false;
 let bcToken;
 
-function floatingElement(targetEl, el, focusableEl = null) {
-  const getTargetHeight = (target) => {
-    const { marginBottom } = window.getComputedStyle(target);
-    return target.scrollHeight + (parseFloat(marginBottom) * 2);
-  };
+const getTargetHeight = (target) => {
+  const { marginBottom } = window.getComputedStyle(target);
+  return target.scrollHeight + (parseFloat(marginBottom) * 2);
+};
 
+function floatingElement(targetEl, el, focusableEl = null) {
   const hideFloating = () => {
     if (focusableEl) {
       focusableEl.setAttribute('aria-hidden', 'true');
@@ -71,6 +71,8 @@ function floatingElement(targetEl, el, focusableEl = null) {
   floatingSpacer.style.cssText = 'height:0; pointer-events:none;';
   mainElement.append(floatingSpacer);
 
+  targetEl.classList.add('floating-element');
+
   const ro = new ResizeObserver((entries) => {
     for (const entry of entries) {
       const size = Math.floor(entry.borderBoxSize?.[0]?.blockSize);
@@ -94,9 +96,10 @@ function floatingElement(targetEl, el, focusableEl = null) {
     // only values that need to be calculated on scroll are here, to optimize performance
     const threshold = window.scrollY + window.innerHeight - mainTop;
     const topDelay = variants.floatingDelay ? variants.floatingDelayAmount : elHeight;
+    const bottomValue = threshold - mainHeight;
 
     if (threshold > mainHeight) {
-      target.style.bottom = `${threshold - mainHeight}px`;
+      target.style.bottom = `${bottomValue}px`;
       if (variants.isFloatingAnchorHide || variants.floatingAnchorDelay) {
         hideFloating();
       } else {
@@ -493,7 +496,7 @@ function decorateBackground(el, background) {
       el.style.setProperty('--brand-concierge-bg', `url(${rawImage})`);
     }
   }
-  el.removeChild(background);
+  if (el.contains(background)) el.removeChild(background);
 }
 
 function decorateHeader(el, header) {
@@ -514,7 +517,7 @@ function decorateHeader(el, header) {
   }
 
   el.append(headerSection);
-  el.removeChild(header);
+  if (el.contains(header)) el.removeChild(header);
 }
 
 function decorateCards(el, cards) {
@@ -525,7 +528,7 @@ function decorateCards(el, cards) {
     const cardText = createTag('div', { class: 'prompt-card-text' }, `${aiIcon(`card-icon-${index + 1}`, 'card-icon', null, 16)} <p>${card.textContent.trim()}</p>`);
     const cardButton = createTag('button', {
       class: 'prompt-card-button no-track',
-      'daa-ll': getAnalyticsLabel('1'),
+      'daa-ll': getAnalyticsLabel(`1|BC-suggested_prompt_clicked|inline|${cardText.textContent.trim()}`),
       'aria-label': cardText.textContent.trim(),
     });
     if (cardImage) {
@@ -544,7 +547,7 @@ function decorateCards(el, cards) {
   });
 
   el.append(cardSection);
-  el.removeChild(cards);
+  if (el.contains(cards)) el.removeChild(cards);
 }
 
 function decorateInput(el, input) {
@@ -575,7 +578,7 @@ function decorateInput(el, input) {
 
   fieldSection.append(fieldContainer);
   el.append(fieldSection);
-  el.removeChild(input);
+  if (el.contains(input)) el.removeChild(input);
   updateReplicatedValue(textareaWrapper, fieldInput);
 
   fieldInput.addEventListener('input', () => {
@@ -605,7 +608,7 @@ function decorateLegal(el, legal) {
   const legalContent = createTag('p', {}, legal.querySelector('div').innerHTML);
   legalSection.append(legalContent);
   el.append(legalSection);
-  el.removeChild(legal);
+  if (el.contains(legal)) el.removeChild(legal);
 }
 
 function decorateFloatingButton(el) {
@@ -625,6 +628,44 @@ function decorateFloatingButton(el) {
   });
 
   floatingElement(floatingButton, el, floatingContainer);
+}
+
+function decorateFloatingInput(el, cards, input) {
+  if (variants.isFloatingInputOnly) {
+    el.classList.add('floating-input');
+  }
+  function updatePillVisibility(target) {
+    const prompts = target.querySelector('.bc-prompt-cards');
+    if (!prompts) return;
+
+    const buttons = [...prompts.querySelectorAll('.prompt-card-button')];
+    buttons.forEach((btn) => { btn.style.display = ''; });
+
+    requestAnimationFrame(() => {
+      const { left: containerLeft, right: containerRight } = prompts.getBoundingClientRect();
+
+      buttons.forEach((btn) => {
+        const { left, right } = btn.getBoundingClientRect();
+
+        if (right > containerRight || left < containerLeft) {
+          btn.style.display = 'none';
+        }
+      });
+    });
+  }
+
+  const floatingInput = createTag('section', { class: 'bc-floating-input' });
+  decorateInput(floatingInput, input);
+  decorateCards(floatingInput, cards);
+  el.append(floatingInput);
+
+  const updateLayout = () => {
+    updatePillVisibility(floatingInput);
+  };
+
+  window.addEventListener('resize', updateLayout);
+  requestAnimationFrame(updateLayout);
+  floatingElement(floatingInput, el, el.querySelector('.bc-input-field'));
 }
 
 function handleConsent(el) {
@@ -651,7 +692,8 @@ export default async function init(el) {
 
   // set variant
   if (!el.classList.contains('hero')
-  && !el.classList.contains('floating-button-only')) {
+    && !el.classList.contains('floating-button-only')
+    && !el.classList.contains('floating-input-only')) {
     el.classList.add('inline');
     variants.isDefault = true;
   } else if (el.classList.contains('hero')) {
@@ -681,6 +723,12 @@ export default async function init(el) {
       variants.floatingAnchorDelayAmount = parseFloat(classItem.match(/\w+/g)[3]);
     }
   });
+
+  if (el.classList.contains('floating-input')) {
+    variants.isFloatingInput = true;
+  } else if (el.classList.contains('floating-input-only')) {
+    variants.isFloatingInputOnly = true;
+  }
 
   if (variants.isFloatingButton) {
     decorateFloatingButton(el);
@@ -713,6 +761,18 @@ export default async function init(el) {
     decorateInput(el, input);
     decorateCards(el, cards);
     decorateLegal(el, legal);
+  }
+
+  if (variants.isFloatingInput) {
+    const [, , cards, input] = rows;
+    decorateFloatingInput(el, cards, input);
+  }
+  if (variants.isFloatingInputOnly) {
+    const [, , cards, input] = rows;
+    decorateFloatingInput(el, cards, input);
+    rows.forEach((row) => {
+      el.removeChild(row);
+    });
   }
 
   const loginTestButton = params.get('susi-test-btn');

--- a/libs/c2/blocks/brand-concierge/brand-concierge.js
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.js
@@ -46,8 +46,8 @@ function floatingElement(targetEl, el, focusableEl = null) {
       focusableEl.setAttribute('tabindex', '-1');
       focusableEl.blur();
     }
-    targetEl.classList.add('floating-hidden');
-    targetEl.classList.remove('floating-show');
+    targetEl.classList.add('bc-floating-hidden');
+    targetEl.classList.remove('bc-floating-show');
   };
 
   const showFloating = () => {
@@ -55,8 +55,8 @@ function floatingElement(targetEl, el, focusableEl = null) {
       focusableEl.removeAttribute('aria-hidden');
       focusableEl.removeAttribute('tabindex');
     }
-    targetEl.classList.remove('floating-hidden');
-    targetEl.classList.add('floating-show');
+    targetEl.classList.remove('bc-floating-hidden');
+    targetEl.classList.add('bc-floating-show');
   };
 
   const mainElement = document.querySelector('main');
@@ -71,7 +71,7 @@ function floatingElement(targetEl, el, focusableEl = null) {
   floatingSpacer.style.cssText = 'height:0; pointer-events:none;';
   mainElement.append(floatingSpacer);
 
-  targetEl.classList.add('floating-element');
+  targetEl.classList.add('bc-floating-element');
 
   const ro = new ResizeObserver((entries) => {
     for (const entry of entries) {

--- a/nala/blocks/brand-concierge/brand-concierge.page.js
+++ b/nala/blocks/brand-concierge/brand-concierge.page.js
@@ -12,8 +12,8 @@ export default class BrandConciergeBlock {
     this.floatingButton = this.page.locator('.bc-floating-button').first();
     this.floatingButtonContainer = this.page.locator('.bc-floating-button-container').first();
     this.floatingButtonInput = this.page.locator('.bc-floating-input').first();
-    this.floatingButtonHidden = this.page.locator('.bc-floating-button.floating-hidden');
-    this.floatingButtonVisible = this.page.locator('.bc-floating-button.floating-show');
+    this.floatingButtonHidden = this.page.locator('.bc-floating-button.bc-floating-hidden');
+    this.floatingButtonVisible = this.page.locator('.bc-floating-button.bc-floating-show');
 
     // Modal elements
     this.modal = this.page.locator('#brand-concierge-modal');

--- a/nala/blocks/brand-concierge/brand-concierge.test.js
+++ b/nala/blocks/brand-concierge/brand-concierge.test.js
@@ -274,12 +274,12 @@ test.describe('Milo Brand Concierge Block test suite', () => {
           window.scrollTo(0, el.scrollHeight + 100);
           // Webkit doesn't always fire a `scroll` event for programmatic
           // scrollTo in headless mode, so the BC scroll handler never runs.
-          // Dispatch one manually so the handler updates the floating-hidden
+          // Dispatch one manually so the handler updates the bc-floating-hidden
           // class regardless of browser quirk.
           window.dispatchEvent(new Event('scroll'));
         });
         await page.waitForTimeout(1000);
-        await expect(bc.floatingButton).not.toHaveClass(/floating-hidden/, { timeout: 10000 });
+        await expect(bc.floatingButton).not.toHaveClass(/bc-floating-hidden/, { timeout: 10000 });
         expect(await bc.floatingButtonInput.textContent()).toBeTruthy();
       });
 
@@ -502,7 +502,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         });
         await page.waitForTimeout(1000);
 
-        await expect(bc.floatingButton).not.toHaveClass(/floating-hidden/, { timeout: 10000 });
+        await expect(bc.floatingButton).not.toHaveClass(/bc-floating-hidden/, { timeout: 10000 });
         const ariaHidden = await bc.floatingButtonContainer.getAttribute('aria-hidden');
         expect(ariaHidden).toBeNull();
       });
@@ -564,7 +564,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         await expect(bc.floatingButton).toBeAttached({ timeout: 10000 });
         // Top delay (e.g. 100px) means the button stays hidden until scroll
         // passes that threshold.
-        await expect(bc.floatingButton).toHaveClass(/floating-hidden/);
+        await expect(bc.floatingButton).toHaveClass(/bc-floating-hidden/);
       });
 
       await test.step('step-4: Floating button is visible in the middle of the page', async () => {
@@ -574,7 +574,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
           window.dispatchEvent(new Event('scroll'));
         });
         await page.waitForTimeout(1000);
-        await expect(bc.floatingButton).not.toHaveClass(/floating-hidden/, { timeout: 10000 });
+        await expect(bc.floatingButton).not.toHaveClass(/bc-floating-hidden/, { timeout: 10000 });
       });
 
       await test.step('step-5: Floating button is hidden again near the footer', async () => {
@@ -584,7 +584,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
           window.dispatchEvent(new Event('scroll'));
         });
         await page.waitForTimeout(1000);
-        await expect(bc.floatingButton).toHaveClass(/floating-hidden/, { timeout: 10000 });
+        await expect(bc.floatingButton).toHaveClass(/bc-floating-hidden/, { timeout: 10000 });
       });
 
       await test.step('step-6: Floating button has correct text content', async () => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adjust daa-ll attribute on brand-concierge block suggested prompts to offer more detail for analytics. [MWPW-197467](https://jira.corp.adobe.com/browse/MWPW-197467)
* Add a c2-dark variant for use with darker background settings on c2 [MWPW-198145](https://jira.corp.adobe.com/browse/MWPW-198145)
* Refactor floating-inline to allow it to make use of the delay / hiding functionality of the floating-button and to allow it to show along side an inline blade. Supports dark floating-input and light inline and vice versa. [MWPW-198145](https://jira.corp.adobe.com/browse/MWPW-198145)

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/drafts/colloyd/brand-concierge/bc-floating-input-only
- After: https://bc-sync-up--milo--adobecom.aem.page/drafts/colloyd/brand-concierge/bc-floating-input-only

Additional testing details:

* floating-input with floating-input-dark and delay / hiding at top and bottom with an inline blade: 
https://bc-sync-up--milo--adobecom.aem.page/drafts/colloyd/brand-concierge/bc-floating-input-delay
* floating-input-only: 
https://bc-sync-up--milo--adobecom.aem.page/drafts/colloyd/brand-concierge/bc-floating-input-only





