### PR TITLE
[MWPW-195942]: Increased sticky notification ribbon z-index to fix overlap with play-button media

### DIFF
--- a/libs/blocks/section-metadata/section-metadata.css
+++ b/libs/blocks/section-metadata/section-metadata.css
@@ -160,7 +160,7 @@
 .section.sticky-top {
   position: sticky;
   top: 57px;
-  z-index: 4;
+  z-index: 8;
   background-color: var(--color-white);
 }
 


### PR DESCRIPTION
- Fixes sticky top notification ribbon rendering behind foreground images with play-button / video-modal triggers on scroll
- **Root cause:** `.section.sticky-top` and `.modal-img-link` both had `z-index: 4`; equal values let the later DOM element paint on top
- Increases `.section.sticky-top` z-index from 4 → 8 so the ribbon stays above page media (including modal-img-link)
- Chose 8 instead of 10 because global navigation already uses z-index: 10, avoids stacking conflicts while keeping the ribbon below nav

Resolves: [MWPW-195942](https://jira.corp.adobe.com/browse/MWPW-195942)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/drafts/himani/notification-ribbon-sticky?martech=off
- After: https://main--da-cc--adobecom.aem.page/drafts/himani/notification-ribbon-sticky?milolibs=mwpw-195942-sticky-notification--milo--hkuraware&martech=off

**Dev validation:**

- **Before:**
<img width="1484" height="830" alt="before-fix" src="https://github.com/user-attachments/assets/eda00ed0-04aa-4813-a593-416ade655f45" />

- **After:**
<img width="1484" height="830" alt="after-fix" src="https://github.com/user-attachments/assets/c4aae0dd-71e9-4d93-bf68-256bab19b05f" />

