### PR TITLE
[MWPW-198599] Preflight: make IMS token optional for log capture

### DIFF
--- a/libs/blocks/preflight/checks/captureMetrics.js
+++ b/libs/blocks/preflight/checks/captureMetrics.js
@@ -47,14 +47,15 @@ const mapChecksWithColumn = (checks) => checks?.map((check) => ({
 async function capture(results) {
   const token = window.adobeIMS?.getAccessToken()?.token;
   const { imsClientId } = getConfig();
-  if (!token || !imsClientId) return null;
+  if (!imsClientId) return null;
 
-  let profile;
-  try {
-    profile = await window.adobeIMS.getProfile();
-  } catch {
-    window.lana?.log?.('IMS profile fetch failed, continuing without profile data', { tags: 'preflight', errorType: 'i' });
-    profile = { email: '' };
+  let profile = { email: '' };
+  if (token) {
+    try {
+      profile = await window.adobeIMS.getProfile();
+    } catch {
+      window.lana?.log?.('IMS profile fetch failed, continuing without profile data', { tags: 'preflight', errorType: 'i' });
+    }
   }
 
   const [
@@ -103,12 +104,11 @@ async function sendMetrics(metricsData) {
   const endpoint = getLogsEndpoint();
 
   try {
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers.authorization = `Bearer ${token}`;
     const response = await fetch(`${endpoint}?clientId=${imsClientId}`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        authorization: `Bearer ${token}`,
-      },
+      headers,
       body: JSON.stringify({ ...results, ...contextData }),
     });
 


### PR DESCRIPTION
### Description
The preflight `captureMetrics` function currently bails out when no IMS access token is present, meaning unauthenticated users never send preflight logs.

This makes the token optional:
- Gate only on `imsClientId` being present (still required for the `clientId` query param)
- Skip `getProfile()` and leave `email: ''` when no token is available
- Omit the `Authorization` header from the fetch when unauthenticated

Resolves: [MWPW-198599](https://jira.corp.adobe.com/browse/MWPW-198599)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



