### PR TITLE
[MWPW-198720] Add pull_request_target labeled trigger to merge-to-stage

### DIFF
--- a/.github/workflows/merge-to-stage.yaml
+++ b/.github/workflows/merge-to-stage.yaml
@@ -1,6 +1,8 @@
 name: Merge to stage
 
 on:
+  pull_request_target:
+    types: [labeled]
   schedule:
     - cron: '0 */4 * * *' # Run every 4 hours
   workflow_dispatch: # Allow manual trigger
@@ -17,7 +19,7 @@ env:
 
 jobs:
   merge-to-stage:
-    if: github.repository_owner == 'adobecom'
+    if: github.repository_owner == 'adobecom' && (github.event_name != 'pull_request_target' || github.event.pull_request.base.ref == 'stage')
     runs-on: ubuntu-latest
     environment: milo_pr_merge
 


### PR DESCRIPTION
### Non-AI
Saw that https://github.com/adobecom/milo/pull/6168 was *NOT* directly merged to stage, despite being eligible. The mechanism works great for stage-to-main, so we should also to it for x-to-stage


### Description
Mirrors the mechanism already in place for merge-to-main: adds `pull_request_target: types: [labeled]` to the merge-to-stage workflow so that labeling a PR targeting `stage` fires the workflow immediately, rather than waiting for the 4-hour cron.

The job `if` condition is tightened to no-op when the event is a label on a PR whose base is not `stage`:

```yaml
if: github.repository_owner == 'adobecom' && (github.event_name != 'pull_request_target' || github.event.pull_request.base.ref == 'stage')
```

No changes to `merge-to-stage.js` — its existing filtering logic (checks, approvals, `Ready for Stage` label) handles all the gating.

Resolves: [MWPW-198720](https://jira.corp.adobe.com/browse/MWPW-198720)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

