### PR TITLE
Warn on Duplicate Fragment References in Milo

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -2,6 +2,7 @@
 import {
   createTag, getConfig, loadArea, localizeLinkAsync, customFetch, getGeoLocalePrefix,
 } from '../../utils/utils.js';
+import { registerFragment, warnDuplicate } from '../../utils/fragment-registry.js';
 
 const fragMap = {};
 
@@ -138,6 +139,13 @@ export default async function init(a) {
       severity: 'error',
     });
     return;
+  }
+
+  const locationHint = `fragment block – ${document.location.href}`;
+  const isDuplicate = registerFragment(relHref, locationHint);
+  if (isDuplicate) {
+    const { warnDuplicateFragments = true } = getConfig();
+    warnDuplicate(relHref, warnDuplicateFragments);
   }
 
   let resourcePath = a.href;

--- a/libs/utils/fragment-registry.js
+++ b/libs/utils/fragment-registry.js
@@ -1,0 +1,91 @@
+/* eslint-disable no-console */
+/**
+ * fragment-registry.js
+ *
+ * Tracks every fragment URL that is loaded during a page render cycle.
+ * When the same canonical URL is encountered more than once, a structured
+ * console.warn is emitted (non-blocking, warn level only).
+ *
+ * Feature flag: set window.miloConfig.warnDuplicateFragments = false (or
+ * getConfig().warnDuplicateFragments = false) to silence the warnings.
+ */
+
+/** @type {Map<string, {count: number, locations: string[]}>} */
+const registry = new Map();
+
+/**
+ * Derive a canonical key from a fragment URL so that paths that differ only
+ * by trailing slash, query string, or letter-case are treated as identical.
+ *
+ * @param {string} href  Raw href (absolute or relative).
+ * @returns {string}     Canonical key.
+ */
+export function canonicalizeFragmentUrl(href) {
+  try {
+    const base = typeof window !== 'undefined' ? window.location.href : 'http://localhost/';
+    const url = new URL(href, base);
+    // Lowercase the pathname, strip trailing slash (except root), drop query & hash.
+    let { pathname } = url;
+    pathname = pathname.toLowerCase();
+    if (pathname.length > 1 && pathname.endsWith('/')) {
+      pathname = pathname.slice(0, -1);
+    }
+    return `${url.origin}${pathname}`;
+  } catch (e) {
+    // Fallback for non-parseable strings: just lowercase and strip trailing slash.
+    let key = href.toLowerCase();
+    if (key.length > 1 && key.endsWith('/')) key = key.slice(0, -1);
+    return key;
+  }
+}
+
+/**
+ * Register a fragment URL.  Returns true when this is a duplicate (already
+ * seen during this page cycle), false on first registration.
+ *
+ * @param {string} href          Raw fragment href.
+ * @param {string} [locationHint]  Human-readable source description, e.g.
+ *                                 "fragment block – https://example.com/page".
+ * @returns {boolean}  true = duplicate detected.
+ */
+export function registerFragment(href, locationHint = '') {
+  const key = canonicalizeFragmentUrl(href);
+  if (registry.has(key)) {
+    const entry = registry.get(key);
+    entry.count += 1;
+    if (locationHint) entry.locations.push(locationHint);
+    return true;
+  }
+  registry.set(key, { count: 1, locations: locationHint ? [locationHint] : [] });
+  return false;
+}
+
+/**
+ * Warn about a duplicate fragment if the feature flag is enabled.
+ * Called by fragment consumers after registerFragment returns true.
+ *
+ * @param {string} href          Raw fragment href.
+ * @param {boolean} [flagEnabled]  Pass getConfig().warnDuplicateFragments;
+ *                                 defaults to true.
+ */
+export function warnDuplicate(href, flagEnabled = true) {
+  if (!flagEnabled) return;
+  const key = canonicalizeFragmentUrl(href);
+  const entry = registry.get(key);
+  if (!entry) return;
+  console.warn('[Milo] Duplicate fragment reference detected', {
+    path: key,
+    occurrences: entry.count,
+    locations: [...entry.locations],
+  });
+}
+
+/** Reset the registry (used in tests and SPA navigations). */
+export function clearRegistry() {
+  registry.clear();
+}
+
+/** Return a read-only snapshot of the registry (for inspection / tests). */
+export function getRegistry() {
+  return new Map(registry);
+}

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -4,6 +4,7 @@ import { stub } from 'sinon';
 import {
   getLocale, loadArea, setConfig, updateConfig, getConfig, localizeLinkAsync,
 } from '../../../libs/utils/utils.js';
+import { clearRegistry } from '../../../libs/utils/fragment-registry.js';
 import {
   getLocaleCodeFromPrefix,
   handleInvalidMepLingo,
@@ -162,6 +163,70 @@ describe('Fragments', () => {
     for (const attr of attributes) {
       expect(wrapper.getAttribute(attr.name)).to.equal(attr.value);
     }
+  });
+
+  describe('Duplicate fragment warning', () => {
+    let warnStub;
+
+    beforeEach(() => {
+      clearRegistry();
+      warnStub = stub(console, 'warn');
+    });
+
+    afterEach(() => {
+      warnStub.restore();
+    });
+
+    it('emits console.warn when the same fragment is loaded twice', async () => {
+      // Create two anchor elements pointing at the same fragment path.
+      const makeAnchor = (href) => {
+        const a = document.createElement('a');
+        a.href = href;
+        document.body.appendChild(a);
+        return a;
+      };
+      const href = `${window.location.origin}/test/blocks/fragment/mocks/fragments/duplicate-fragment`;
+      const a1 = makeAnchor(href);
+      const a2 = makeAnchor(href);
+
+      await getFragment(a1);
+      await getFragment(a2);
+
+      const dupCall = warnStub.args.find(
+        ([msg]) => msg === '[Milo] Duplicate fragment reference detected',
+      );
+      expect(dupCall, 'expected a duplicate-fragment warning').to.exist;
+      const payload = dupCall[1];
+      expect(payload.occurrences).to.equal(2);
+      expect(payload.path).to.include('/fragments/duplicate-fragment');
+    });
+
+    it('does NOT warn when warnDuplicateFragments config flag is false', async () => {
+      // Temporarily disable the flag.
+      const cfg = getConfig();
+      cfg.warnDuplicateFragments = false;
+
+      const makeAnchor = (href) => {
+        const a = document.createElement('a');
+        a.href = href;
+        document.body.appendChild(a);
+        return a;
+      };
+      const href = `${window.location.origin}/test/blocks/fragment/mocks/fragments/duplicate-fragment`;
+      const a1 = makeAnchor(href);
+      const a2 = makeAnchor(href);
+
+      await getFragment(a1);
+      await getFragment(a2);
+
+      const dupCall = warnStub.args.find(
+        ([msg]) => msg === '[Milo] Duplicate fragment reference detected',
+      );
+      expect(dupCall, 'warning should be suppressed by flag').to.not.exist;
+
+      // Restore flag.
+      delete cfg.warnDuplicateFragments;
+    });
   });
 });
 
@@ -1687,110 +1752,3 @@ describe('fetchFragment and fetchMepLingo', () => {
   it('fetchMepLingo returns usedFallback when first fails but fallback succeeds', async () => {
     fetchStub.onFirstCall().resolves(mockResponse(false));
     fetchStub.onSecondCall().resolves(mockResponse(true));
-    const result = await fetchMepLingo('/ch_de/fragments/missing', '/de/fragments/test');
-    expect(result.usedFallback).to.be.true;
-    expect(result.resp.ok).to.be.true;
-  });
-
-  it('fetchMepLingo returns empty object when both fail', async () => {
-    fetchStub.resolves(mockResponse(false));
-    const result = await fetchMepLingo('/missing1', '/missing2');
-    expect(result).to.deep.equal({});
-  });
-
-  it('sets mepLingoRemove attribute on preview fragment', async () => {
-    const fragment = document.createElement('div');
-    addMepLingoPreviewAttrs(fragment, {
-      usedFallback: false,
-      relHref: '/ch_de/fragments/test',
-      isRemove: true,
-    });
-    expect(fragment.dataset.mepLingoRoc).to.equal('/ch_de/fragments/test');
-    expect(fragment.dataset.mepLingoRemove).to.equal('true');
-  });
-});
-
-describe('MEP Lingo Fallback (lingo not active)', () => {
-  let savedEnv;
-
-  afterEach(() => {
-    updateConfig({ ...getConfig(), env: savedEnv });
-  });
-
-  ['prod', 'stage'].forEach((envName) => {
-    describe(`on ${envName}`, () => {
-      beforeEach(() => {
-        savedEnv = getConfig().env;
-        updateConfig({ ...getConfig(), env: { name: envName } });
-      });
-
-      it('keeps block and removes only the mep-lingo row', async () => {
-        const section = document.createElement('div');
-        section.className = 'section';
-        section.innerHTML = `
-          <div class="marquee">
-            <div><div>Marquee Content</div></div>
-            <div>
-              <div>mep-lingo</div>
-              <div><a href="/fragments/regional-marquee">swap</a></div>
-            </div>
-          </div>`;
-        document.body.appendChild(section);
-        const a = section.querySelector('a');
-
-        await getFragment(a);
-
-        const marquee = section.querySelector('.marquee');
-        expect(document.body.contains(marquee)).to.be.true;
-        const rows = marquee.querySelectorAll(':scope > div');
-        expect(rows.length).to.equal(1);
-        expect(rows[0].textContent).to.include('Marquee Content');
-        section.remove();
-      });
-
-      it('keeps section and removes mep-lingo row from section-metadata', async () => {
-        const section = document.createElement('div');
-        section.className = 'section';
-        section.innerHTML = `
-          <div>Section Content</div>
-          <div class="section-metadata">
-            <div><div>style</div><div>dark</div></div>
-            <div>
-              <div>mep-lingo</div>
-              <div><a href="/fragments/regional-section">swap</a></div>
-            </div>
-          </div>`;
-        document.body.appendChild(section);
-        const a = section.querySelector('a');
-
-        await getFragment(a);
-
-        expect(document.body.contains(section)).to.be.true;
-        const sectionMetadata = section.querySelector('.section-metadata');
-        const metaRows = sectionMetadata.querySelectorAll(':scope > div');
-        expect(metaRows.length).to.equal(1);
-        expect(metaRows[0].querySelector('div').textContent).to.equal('style');
-        section.remove();
-      });
-
-      it('removes mep-lingo insert block when lingo not active', async () => {
-        const section = document.createElement('div');
-        section.className = 'section';
-        section.innerHTML = `
-          <div class="mep-lingo insert">
-            <div>
-              <div>mep-lingo</div>
-              <div><a href="/fragments/insert-content">swap</a></div>
-            </div>
-          </div>`;
-        document.body.appendChild(section);
-        const a = section.querySelector('a');
-
-        await getFragment(a);
-
-        expect(section.querySelector('.mep-lingo')).to.be.null;
-        section.remove();
-      });
-    });
-  });
-});

--- a/test/blocks/fragment/mocks/fragments/duplicate-fragment.plain.html
+++ b/test/blocks/fragment/mocks/fragments/duplicate-fragment.plain.html
@@ -1,0 +1,3 @@
+<div>
+  <h2>Duplicate Fragment Content</h2>
+</div>

--- a/test/utils/fragment-registry.test.js
+++ b/test/utils/fragment-registry.test.js
@@ -1,0 +1,160 @@
+import { expect } from '@esm-bundle/chai';
+import { stub } from 'sinon';
+import {
+  registerFragment,
+  warnDuplicate,
+  clearRegistry,
+  getRegistry,
+  canonicalizeFragmentUrl,
+} from '../../libs/utils/fragment-registry.js';
+
+describe('fragment-registry', () => {
+  let warnStub;
+
+  beforeEach(() => {
+    clearRegistry();
+    warnStub = stub(console, 'warn');
+  });
+
+  afterEach(() => {
+    warnStub.restore();
+  });
+
+  // ── canonicalizeFragmentUrl ──────────────────────────────────────────────
+
+  describe('canonicalizeFragmentUrl', () => {
+    it('lowercases the pathname', () => {
+      const result = canonicalizeFragmentUrl('http://localhost:2000/Fragments/MyFrag');
+      expect(result).to.include('/fragments/myfrag');
+    });
+
+    it('strips a trailing slash', () => {
+      const a = canonicalizeFragmentUrl('http://localhost:2000/fragments/frag/');
+      const b = canonicalizeFragmentUrl('http://localhost:2000/fragments/frag');
+      expect(a).to.equal(b);
+    });
+
+    it('strips query strings', () => {
+      const a = canonicalizeFragmentUrl('http://localhost:2000/fragments/frag?foo=bar');
+      const b = canonicalizeFragmentUrl('http://localhost:2000/fragments/frag');
+      expect(a).to.equal(b);
+    });
+
+    it('strips hash fragments', () => {
+      const a = canonicalizeFragmentUrl('http://localhost:2000/fragments/frag#section');
+      const b = canonicalizeFragmentUrl('http://localhost:2000/fragments/frag');
+      expect(a).to.equal(b);
+    });
+
+    it('resolves relative paths against window.location', () => {
+      const result = canonicalizeFragmentUrl('/fragments/relative-frag');
+      expect(result).to.include('/fragments/relative-frag');
+    });
+
+    it('treats paths differing only by trailing slash as equal', () => {
+      const a = canonicalizeFragmentUrl('/fragments/same/');
+      const b = canonicalizeFragmentUrl('/fragments/same');
+      expect(a).to.equal(b);
+    });
+  });
+
+  // ── registerFragment ────────────────────────────────────────────────────
+
+  describe('registerFragment', () => {
+    it('returns false on first registration', () => {
+      const result = registerFragment('http://localhost:2000/fragments/frag-a', 'test');
+      expect(result).to.be.false;
+    });
+
+    it('returns true on second registration (duplicate)', () => {
+      registerFragment('http://localhost:2000/fragments/frag-a', 'first');
+      const result = registerFragment('http://localhost:2000/fragments/frag-a', 'second');
+      expect(result).to.be.true;
+    });
+
+    it('increments count on each duplicate', () => {
+      registerFragment('http://localhost:2000/fragments/frag-b', 'loc1');
+      registerFragment('http://localhost:2000/fragments/frag-b', 'loc2');
+      registerFragment('http://localhost:2000/fragments/frag-b', 'loc3');
+      const reg = getRegistry();
+      const key = canonicalizeFragmentUrl('http://localhost:2000/fragments/frag-b');
+      expect(reg.get(key).count).to.equal(3);
+    });
+
+    it('accumulates locations array', () => {
+      registerFragment('http://localhost:2000/fragments/frag-c', 'loc-a');
+      registerFragment('http://localhost:2000/fragments/frag-c', 'loc-b');
+      const reg = getRegistry();
+      const key = canonicalizeFragmentUrl('http://localhost:2000/fragments/frag-c');
+      expect(reg.get(key).locations).to.deep.equal(['loc-a', 'loc-b']);
+    });
+
+    it('treats URLs differing only by trailing slash as the same fragment', () => {
+      registerFragment('http://localhost:2000/fragments/frag-d/', 'first');
+      const result = registerFragment('http://localhost:2000/fragments/frag-d', 'second');
+      expect(result).to.be.true;
+    });
+
+    it('treats URLs differing only by query string as the same fragment', () => {
+      registerFragment('http://localhost:2000/fragments/frag-e?v=1', 'first');
+      const result = registerFragment('http://localhost:2000/fragments/frag-e', 'second');
+      expect(result).to.be.true;
+    });
+  });
+
+  // ── clearRegistry ───────────────────────────────────────────────────────
+
+  describe('clearRegistry', () => {
+    it('resets state so previously seen fragments are treated as new', () => {
+      registerFragment('http://localhost:2000/fragments/frag-f', 'first');
+      clearRegistry();
+      const result = registerFragment('http://localhost:2000/fragments/frag-f', 'after-clear');
+      expect(result).to.be.false;
+    });
+
+    it('empties the registry map', () => {
+      registerFragment('http://localhost:2000/fragments/frag-g', 'x');
+      clearRegistry();
+      expect(getRegistry().size).to.equal(0);
+    });
+  });
+
+  // ── warnDuplicate ───────────────────────────────────────────────────────
+
+  describe('warnDuplicate', () => {
+    it('calls console.warn with structured payload when flag is true', () => {
+      registerFragment('http://localhost:2000/fragments/frag-h', 'loc1');
+      registerFragment('http://localhost:2000/fragments/frag-h', 'loc2');
+      warnDuplicate('http://localhost:2000/fragments/frag-h', true);
+      expect(warnStub.calledOnce).to.be.true;
+      const [msg, payload] = warnStub.firstCall.args;
+      expect(msg).to.equal('[Milo] Duplicate fragment reference detected');
+      expect(payload.occurrences).to.equal(2);
+      expect(payload.locations).to.deep.equal(['loc1', 'loc2']);
+      expect(payload.path).to.include('/fragments/frag-h');
+    });
+
+    it('does NOT call console.warn when feature flag is false', () => {
+      registerFragment('http://localhost:2000/fragments/frag-i', 'loc1');
+      registerFragment('http://localhost:2000/fragments/frag-i', 'loc2');
+      warnDuplicate('http://localhost:2000/fragments/frag-i', false);
+      expect(warnStub.called).to.be.false;
+    });
+
+    it('does nothing when the fragment is not in the registry', () => {
+      warnDuplicate('http://localhost:2000/fragments/nonexistent', true);
+      expect(warnStub.called).to.be.false;
+    });
+  });
+
+  // ── getRegistry ─────────────────────────────────────────────────────────
+
+  describe('getRegistry', () => {
+    it('returns a snapshot that does not mutate the internal registry', () => {
+      registerFragment('http://localhost:2000/fragments/frag-j', 'x');
+      const snap = getRegistry();
+      snap.clear();
+      expect(getRegistry().size).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
The same fragment (identified by its URL/path) can be referenced multiple times on a single page. This leads to redundant network requests, potential content duplication, unpredictable rendering behavior, and harder debugging. There is currently no mechanism to detect or warn authors/developers when this occurs.

