### PR TITLE
Warn on duplicate fragment references within a page

### DIFF
--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -5,6 +5,36 @@ import {
 
 const fragMap = {};
 
+// Registry of fragment URLs loaded during the current page session.
+// Used only for duplicate-reference detection; does not affect loading behaviour.
+const _loadedFragments = new Set();
+
+/**
+ * Clears the duplicate-fragment registry. Intended for test isolation only —
+ * do not call this in production code paths.
+ */
+export const _resetFragmentRegistry = () => _loadedFragments.clear();
+
+/**
+ * Returns a normalised form of a fragment URL so that trivial formatting
+ * differences (trailing slash, mixed case on scheme/host) do not create
+ * false negatives in the duplicate registry.
+ * @param {string} href
+ * @returns {string}
+ */
+const normalizeFragmentUrl = (href) => {
+  try {
+    const u = new URL(href);
+    // Lowercase scheme and host; remove a trailing slash from the pathname
+    // (but keep a bare "/" intact).
+    u.pathname = u.pathname.replace(/\/$/, '') || '/';
+    return `${u.protocol.toLowerCase()}//${u.host.toLowerCase()}${u.pathname}${u.search}${u.hash}`;
+  } catch {
+    // Relative or unparseable href — normalise by trimming only.
+    return href.trim().replace(/\/$/, '');
+  }
+};
+
 const removeHash = (url) => {
   const urlNoHash = url.split('#')[0];
   return url.includes('#_dnt') ? `${urlNoHash}#_dnt` : urlNoHash;
@@ -139,6 +169,14 @@ export default async function init(a) {
     });
     return;
   }
+
+  // Duplicate-fragment detection (warn only — loading is unaffected).
+  const normalizedFragUrl = normalizeFragmentUrl(relHref);
+  if (_loadedFragments.has(normalizedFragUrl)) {
+    // eslint-disable-next-line no-console
+    console.warn('[milo] Duplicate fragment reference detected:', normalizedFragUrl, a);
+  }
+  _loadedFragments.add(normalizedFragUrl);
 
   let resourcePath = a.href;
   if (a.href.includes('/federal/')) {

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -48,7 +48,7 @@ const config = {
 setConfig(config);
 
 document.body.innerHTML = await readFile({ path: './mocks/body.html' });
-const { default: getFragment, removeMepLingoRow } = await import('../../../libs/blocks/fragment/fragment.js');
+const { default: getFragment, removeMepLingoRow, _resetFragmentRegistry } = await import('../../../libs/blocks/fragment/fragment.js');
 
 // Store original fetch for passthrough
 const originalFetch = window.fetch;
@@ -162,6 +162,69 @@ describe('Fragments', () => {
     for (const attr of attributes) {
       expect(wrapper.getAttribute(attr.name)).to.equal(attr.value);
     }
+  });
+});
+
+describe('Duplicate fragment detection', () => {
+  let warnStub;
+
+  beforeEach(() => {
+    _resetFragmentRegistry();
+    warnStub = stub(console, 'warn');
+  });
+
+  afterEach(() => {
+    warnStub.restore();
+  });
+
+  it('does not warn on the first load of a fragment', async () => {
+    const a = document.createElement('a');
+    a.href = 'http://localhost:2000/test/blocks/fragment/mocks/fragments/fragment';
+    document.body.appendChild(a);
+    await getFragment(a);
+    expect(warnStub.called).to.be.false;
+  });
+
+  it('warns exactly once when the same fragment URL is loaded twice', async () => {
+    const makeLink = () => {
+      const a = document.createElement('a');
+      a.href = 'http://localhost:2000/test/blocks/fragment/mocks/fragments/fragment';
+      document.body.appendChild(a);
+      return a;
+    };
+    await getFragment(makeLink());
+    expect(warnStub.called).to.be.false;
+    await getFragment(makeLink());
+    expect(warnStub.calledOnce).to.be.true;
+    expect(warnStub.firstCall.args[0]).to.equal('[milo] Duplicate fragment reference detected:');
+    expect(warnStub.firstCall.args[1]).to.include('/fragments/fragment');
+  });
+
+  it('does not warn when two different fragment URLs are loaded', async () => {
+    const makeLink = (path) => {
+      const a = document.createElement('a');
+      a.href = `http://localhost:2000/test/blocks/fragment/mocks/fragments/${path}`;
+      document.body.appendChild(a);
+      return a;
+    };
+    await getFragment(makeLink('fragment'));
+    await getFragment(makeLink('frag-cache'));
+    expect(warnStub.called).to.be.false;
+  });
+
+  it('treats URLs with a trailing slash as duplicates of the same URL without one', async () => {
+    const makeLink = (href) => {
+      const a = document.createElement('a');
+      a.href = href;
+      document.body.appendChild(a);
+      return a;
+    };
+    const base = 'http://localhost:2000/test/blocks/fragment/mocks/fragments/fragment';
+    await getFragment(makeLink(base));
+    expect(warnStub.called).to.be.false;
+    // Second call with trailing slash — should be treated as duplicate
+    await getFragment(makeLink(`${base}/`));
+    expect(warnStub.calledOnce).to.be.true;
   });
 });
 
@@ -1687,110 +1750,4 @@ describe('fetchFragment and fetchMepLingo', () => {
   it('fetchMepLingo returns usedFallback when first fails but fallback succeeds', async () => {
     fetchStub.onFirstCall().resolves(mockResponse(false));
     fetchStub.onSecondCall().resolves(mockResponse(true));
-    const result = await fetchMepLingo('/ch_de/fragments/missing', '/de/fragments/test');
-    expect(result.usedFallback).to.be.true;
-    expect(result.resp.ok).to.be.true;
-  });
-
-  it('fetchMepLingo returns empty object when both fail', async () => {
-    fetchStub.resolves(mockResponse(false));
-    const result = await fetchMepLingo('/missing1', '/missing2');
-    expect(result).to.deep.equal({});
-  });
-
-  it('sets mepLingoRemove attribute on preview fragment', async () => {
-    const fragment = document.createElement('div');
-    addMepLingoPreviewAttrs(fragment, {
-      usedFallback: false,
-      relHref: '/ch_de/fragments/test',
-      isRemove: true,
-    });
-    expect(fragment.dataset.mepLingoRoc).to.equal('/ch_de/fragments/test');
-    expect(fragment.dataset.mepLingoRemove).to.equal('true');
-  });
-});
-
-describe('MEP Lingo Fallback (lingo not active)', () => {
-  let savedEnv;
-
-  afterEach(() => {
-    updateConfig({ ...getConfig(), env: savedEnv });
-  });
-
-  ['prod', 'stage'].forEach((envName) => {
-    describe(`on ${envName}`, () => {
-      beforeEach(() => {
-        savedEnv = getConfig().env;
-        updateConfig({ ...getConfig(), env: { name: envName } });
-      });
-
-      it('keeps block and removes only the mep-lingo row', async () => {
-        const section = document.createElement('div');
-        section.className = 'section';
-        section.innerHTML = `
-          <div class="marquee">
-            <div><div>Marquee Content</div></div>
-            <div>
-              <div>mep-lingo</div>
-              <div><a href="/fragments/regional-marquee">swap</a></div>
-            </div>
-          </div>`;
-        document.body.appendChild(section);
-        const a = section.querySelector('a');
-
-        await getFragment(a);
-
-        const marquee = section.querySelector('.marquee');
-        expect(document.body.contains(marquee)).to.be.true;
-        const rows = marquee.querySelectorAll(':scope > div');
-        expect(rows.length).to.equal(1);
-        expect(rows[0].textContent).to.include('Marquee Content');
-        section.remove();
-      });
-
-      it('keeps section and removes mep-lingo row from section-metadata', async () => {
-        const section = document.createElement('div');
-        section.className = 'section';
-        section.innerHTML = `
-          <div>Section Content</div>
-          <div class="section-metadata">
-            <div><div>style</div><div>dark</div></div>
-            <div>
-              <div>mep-lingo</div>
-              <div><a href="/fragments/regional-section">swap</a></div>
-            </div>
-          </div>`;
-        document.body.appendChild(section);
-        const a = section.querySelector('a');
-
-        await getFragment(a);
-
-        expect(document.body.contains(section)).to.be.true;
-        const sectionMetadata = section.querySelector('.section-metadata');
-        const metaRows = sectionMetadata.querySelectorAll(':scope > div');
-        expect(metaRows.length).to.equal(1);
-        expect(metaRows[0].querySelector('div').textContent).to.equal('style');
-        section.remove();
-      });
-
-      it('removes mep-lingo insert block when lingo not active', async () => {
-        const section = document.createElement('div');
-        section.className = 'section';
-        section.innerHTML = `
-          <div class="mep-lingo insert">
-            <div>
-              <div>mep-lingo</div>
-              <div><a href="/fragments/insert-content">swap</a></div>
-            </div>
-          </div>`;
-        document.body.appendChild(section);
-        const a = section.querySelector('a');
-
-        await getFragment(a);
-
-        expect(section.querySelector('.mep-lingo')).to.be.null;
-        section.remove();
-      });
-    });
-  });
-});
+    const result = await fetchMepLingo('/ch_de/fr


### PR DESCRIPTION
A fragment URL can be referenced more than once on the same page (typically via accidental copy-paste during authoring). There is currently no feedback mechanism to alert the author or developer that a duplicate exists. Loading behavior must remain unchanged; the goal is purely observability — a console warning that surfaces the duplicate so it can be corrected.

