### PR TITLE
MWPW-198810[MEP] Fix highlight badge text and click region for promo manifest

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -198,7 +198,11 @@ const COMMANDS_KEYS = {
 };
 
 function addIds(el, manifestId, targetManifestId) {
-  if (manifestId) el.dataset.manifestId = manifestId;
+  if (manifestId) {
+    el.dataset.manifestId = manifestId;
+    const { path } = el.dataset;
+    el.dataset.manifestDisplay = path ? `${manifestId}: ${path}` : `${manifestId}: html`;
+  }
   if (targetManifestId) el.dataset.adobeTargetTestid = targetManifestId;
 }
 
@@ -717,7 +721,12 @@ const setDataIdOnChildren = (sections, id, value) => {
 export const updateFragDataProps = (a, inline, sections, fragment) => {
   const { manifestId, adobeTargetTestid } = a.dataset;
   if (inline) {
-    if (manifestId) setDataIdOnChildren(sections, 'manifestId', manifestId);
+    if (manifestId) {
+      setDataIdOnChildren(sections, 'manifestId', manifestId);
+      const { path } = fragment.dataset;
+      const display = path ? `${manifestId}: ${path}` : `${manifestId}: html`;
+      setDataIdOnChildren(sections, 'manifestDisplay', display);
+    }
     if (adobeTargetTestid) setDataIdOnChildren(sections, 'adobeTargetTestid', adobeTargetTestid);
     if (fragment.dataset.mepLingoRoc) setDataIdOnChildren(sections, 'mepLingoRoc', fragment.dataset.mepLingoRoc);
     if (fragment.dataset.mepLingoFallback) {

--- a/libs/features/personalization/preview.css
+++ b/libs/features/personalization/preview.css
@@ -524,7 +524,8 @@
 }
 
 /* mepHighlight */
-body[data-mep-highlight='true'] [data-manifest-id]:not(section.feds-navItem):not(.feds-popup):not(.feds-popup *) {
+body[data-mep-highlight='true'] [data-manifest-id]:not(section.feds-navItem):not(.feds-popup):not(.feds-popup *),
+body[data-mep-highlight='true'] .feds-promo[data-manifest-id] {
   outline: 3px #17a2b8 dashed !important;
   box-shadow: 3px 3px 13px 0 #8f8f8f !important;
   margin: 5px 2px;
@@ -534,6 +535,12 @@ body[data-mep-highlight='true'] [data-manifest-id]:not(section.feds-navItem):not
 body[data-mep-highlight='true'] [data-manifest-id]:not(section.feds-navItem):not(.feds-popup):not(.feds-popup *):not(header.global-navigation *),
 body[data-mep-fragments='true'] [data-fragment-default] {
   position: relative !important;
+}
+
+body[data-mep-highlight='true'] .feds-promo[data-manifest-id] {
+  outline: 3px #17a2b8 dashed !important;
+  box-shadow: 3px 3px 13px 0 #8f8f8f !important;
+  margin: 5px 2px;
 }
 
 body[data-mep-highlight='true'] section.feds-navItem[data-manifest-id] > *:not(.feds-popup) {

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -1618,9 +1618,17 @@ function addHighlightData(manifests) {
       if (selector === 'gnav-source') updateManifestId('header, footer');
     });
 
-    // eslint-disable-next-line max-len
-    document.querySelectorAll(`.section[class*="merch-cards"] .fragment[data-manifest-id="${manifestName}"] merch-card`)
-      .forEach((el) => (el.dataset.manifestId = manifestName));
+    document.querySelectorAll(`.section[class*="merch-cards"] .fragment[data-manifest-id="${manifestName}"]`)
+      .forEach((parentFrag) => {
+        const parentPath = parentFrag.dataset.path;
+        parentFrag.querySelectorAll('merch-card').forEach((card) => {
+          card.dataset.manifestId = manifestName;
+          if (parentPath) {
+            card.dataset.fragmentPath = parentPath;
+            card.dataset.manifestDisplay = `${manifestName}: ${parentPath}`;
+          }
+        });
+      });
 
     document.querySelectorAll(`[data-manifest-id="${manifestName}"]`).forEach((el) => {
       if (!el.dataset.manifestDisplay) {
@@ -1700,7 +1708,6 @@ function addFragmentBadgeClickHandlers() {
     const badgeIsVisible = beforeStyles.display !== 'none' && beforeStyles.content !== 'none';
     if (!badgeIsVisible) return;
 
-    // Use max of calculated dimensions or reasonable minimums for badge text
     const badgeWidth = Math.max(parseFloat(beforeStyles.width) + 30, 200);
     const badgeHeight = parseFloat(beforeStyles.height)
       || parseFloat(beforeStyles.minHeight)
@@ -1711,7 +1718,6 @@ function addFragmentBadgeClickHandlers() {
     if (fragment.dataset.cardUrl) {
       fragmentPath = rewriteBlogPreviewHost(fragmentPath) || rewriteForPreviewHost(fragmentPath);
     }
-    const badgeTopOffset = parseFloat(fragment.style.getPropertyValue('--badge-top-offset')) || 0;
     const handleBadgeClick = () => {
       e.preventDefault();
       e.stopPropagation();
@@ -1719,6 +1725,7 @@ function addFragmentBadgeClickHandlers() {
     };
 
     if (elementStyle.display === 'contents') {
+      const badgeTopOffset = parseFloat(fragment.style.getPropertyValue('--badge-top-offset')) || 0;
       const visibleChildren = Array.from(fragment.children).filter((c) => c.offsetHeight > 0);
       if (visibleChildren.length === 0) {
         if (e.clientX >= 0 && e.clientX < badgeWidth) handleBadgeClick();
@@ -1739,11 +1746,24 @@ function addFragmentBadgeClickHandlers() {
       return;
     }
 
-    const rect = fragment.getBoundingClientRect();
-    const clickX = e.clientX - rect.left;
-    const clickY = e.clientY - rect.top;
-    const inBadgeY = clickY >= badgeTopOffset && clickY < (badgeTopOffset + badgeHeight);
-    if (inBadgeY && clickX >= 0 && clickX < badgeWidth) handleBadgeClick();
+    // ::before badges are position:absolute, anchored to the host's nearest
+    // positioned ancestor — usually the host, but not always (gnav promos
+    // resolve up to header.global-navigation). Hit area = container rect + badge top/left.
+    let containerRect;
+    if (elementStyle.position !== 'static') {
+      containerRect = fragment.getBoundingClientRect();
+    } else {
+      let ancestor = fragment.parentElement;
+      while (ancestor && window.getComputedStyle(ancestor).position === 'static') {
+        ancestor = ancestor.parentElement;
+      }
+      containerRect = (ancestor || document.documentElement).getBoundingClientRect();
+    }
+    const badgeAbsTop = containerRect.top + (parseFloat(beforeStyles.top) || 0);
+    const badgeAbsLeft = containerRect.left + (parseFloat(beforeStyles.left) || 0);
+    const inBadgeY = e.clientY >= badgeAbsTop && e.clientY < (badgeAbsTop + badgeHeight);
+    const inBadgeX = e.clientX >= badgeAbsLeft && e.clientX < (badgeAbsLeft + badgeWidth);
+    if (inBadgeY && inBadgeX) handleBadgeClick();
   });
 }
 

--- a/test/features/personalization/mocks/postPersonalization.html
+++ b/test/features/personalization/mocks/postPersonalization.html
@@ -66,7 +66,7 @@
         
         <div class="section three-merch-cards center xl-spacing special-offers">
           <div>
-            <div class="fragment" data-manifest-id="selected-example.json">
+            <div class="fragment" data-manifest-id="selected-example.json" data-path="/fragments/replaced-merch-card">
               <div class="section">
                 <merch-card class="merch-card special-offers">
                     <h5 id="students-and-teachers">Students and teachers</h5>

--- a/test/features/personalization/preview.test.js
+++ b/test/features/personalization/preview.test.js
@@ -182,7 +182,10 @@ describe('preview feature', () => {
     expect(document.querySelector('header').getAttribute('data-manifest-id')).to.equal('selected-example.json');
   });
   it('adjusts highlights for merch cards', () => {
-    expect(document.querySelector('merch-card').getAttribute('data-manifest-id')).to.equal('selected-example.json');
+    const card = document.querySelector('merch-card');
+    expect(card.getAttribute('data-manifest-id')).to.equal('selected-example.json');
+    expect(card.getAttribute('data-fragment-path')).to.equal('/fragments/replaced-merch-card');
+    expect(card.getAttribute('data-manifest-display')).to.equal('selected-example.json: /fragments/replaced-merch-card');
   });
   it('preselects form inputs', () => {
     expect(document.querySelector('option[name*="/homepage/fragments/mep/selected-example.json"][value="target-smb"]').getAttribute('selected')).to.equal('');


### PR DESCRIPTION
 ## Description
                                                                                                                                                                                                                                                                                                                        
  Fixes two MEP highlight-badge bugs that surface on promo-manifest                                                                                                                                                                                                                                                     
  replacements:                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                        
  1. **Gnav promo badge was blank (only the 🔗 icon showed).** Inline                                                                                                                                                                                                                                                   
     fragment loads set `data-manifest-id` and `data-path` on the loaded
     children but never wrote `data-manifest-display`, so the CSS rendered                                                                                                                                                                                                                                              
     the icon with empty text. Now the inline branch of                                                                                                                                                                                                                                                               
     `updateFragDataProps` writes the display string alongside the id.                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                      
  2. **Merch-card badge read "manifest.json: html" instead of the                                                                                                                                                                                                                                                       
     replacement fragment path.** The merch-card propagation in                                                                                                                                                                                                                                                       
     `addHighlightData` copied `data-manifest-id` from the parent                                                                                                                                                                                                                                                       
     `.fragment` but not its `data-path`, so the fallback defaulted to                                                                                                                                                                                                                                                  
     "html". Now the parent's path is carried onto the merch-card.
                                                                                                                                                                                                                                                                                                                        
  Also makes the badge click handler position-aware: it now reads the                                                                                                                                                                                                                                                   
  `::before` badge's computed `top`/`left` and resolves them against the                                                                                                                                                                                                                                                
  host's true containing block (walking up when the host is                                                                                                                                                                                                                                                             
  `position: static`, e.g., gnav promos which `preview.css` excludes from                                                                                                                                                                                                                                             
  `position: relative`). Without this, clicks on those badges never                                                                                                                                                                                                                                                     
  registered because the hit-test assumed the badge sat at the host's                                                                                                                                                                                                                                                   
  top-left.                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                        
  All changes are gated to MEP preview mode.   

 Use the Before and After URLs below for each step.
                                                                                                                                                                                                                                                                                                                        
  1. Open the gnav dropdown and observe the MEP badge on the promo card.                                                                                                                                                                                                                                              
  2. Scroll down to the merch-card tabs and observe the MEP badge on the
     right card.                                                                                                                                                                                                                                                                                                        
   
  **Expected (After URL):** both badges show the manifest name and the                                                                                                                                                                                                                                                  
  fragment path, and are clickable (open the replacement fragment in a                                                                                                                                                                                                                                                
  new tab).                                                                                                                                                                                                                                                                                                             
   
  **Actual (Before URL):** gnav shows an empty badge with only the 🔗                                                                                                                                                                                                                                                   
  icon; the merch-card shows a non-clickable badge with the promo                                                                                                                                                                                                                                                     
  manifest name followed by "html" instead of the fragment path.
                                                                  
Resolves: [MWPW-198810](https://jira.corp.adobe.com/browse/MWPW-198810)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/photoshop?mepHighlight=true
- After: https://main--da-cc--adobecom.aem.page/products/photoshop?mepHighlight=true&milolibs=mep-fix-promo-badges
- PSI-check: https://mep-fix-promo-badges--milo--adobecom.aem.page/?martech=off








