### PR TITLE
[MWPW-189934]: Prevented carousel videos from auto-playing when reduce motion is enabled.

### DIFF
--- a/libs/blocks/carousel/carousel.js
+++ b/libs/blocks/carousel/carousel.js
@@ -36,6 +36,7 @@ const FOCUSABLE_SELECTOR = 'a, :not(.video-container, .pause-play-wrapper) > vid
 
 const isDesktop = window.matchMedia('(min-width: 900px)');
 const isMobileVp = window.matchMedia('(max-width: 599px)');
+const prefersReducedMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 function getPreviousAriaLabel(currentIndex, totalSlides) {
   return currentIndex === 0 && totalSlides > 0
@@ -485,7 +486,7 @@ function moveSlides(event, carouselElements) {
   activeSlide.classList.add('active');
   setAriaHiddenAndTabIndex(carouselElements, activeSlide);
 
-  if (isHintingTablet(el) || isHintingMobile) {
+  if ((isHintingTablet(el) || isHintingMobile) && !prefersReducedMotion()) {
     const video = activeSlide?.querySelector('video');
     /* c8 ignore start */
     if (video?.paused


### PR DESCRIPTION
**Summary:**
- With Reduce motion enabled, carousel videos no longer auto-play when using prev/next arrows on hinting carousels. Videos stay paused until the user clicks play.

**Changes:**
- Added local `prefersReducedMotion()` in `libs/blocks/carousel/carousel.js`
- Guarded hinting auto-play in `moveSlides()` with && `!prefersReducedMotion()`

**Expected video behaviour:**
- **Reduce motion on:** Videos do not auto-play on arrow navigation, user must click play.
- **User clicks play:** Video plays while it remains in the viewport.
- **User swipes / navigates away:** Video leaves the viewport and is paused.
- **Slide returns to view:** Video stays paused, it does not auto-resume. User must click play again.

Resolves: [MWPW-189934](https://jira.corp.adobe.com/browse/MWPW-189934)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.live/products/firefly/features/ai-video-generator?martech=off
- After: https://main--da-cc--adobecom.aem.live/products/firefly/features/ai-video-generator?milolibs=mwpw-189934-reduce-motion-carousel--milo--hkuraware&martech=off


**Dev validation:**

- Before:
<img width="1497" height="784" alt="before-fix" src="https://github.com/user-attachments/assets/53761092-089f-4c09-ac8c-e4d867dccd80" />

- After:
<img width="1497" height="784" alt="after-fix" src="https://github.com/user-attachments/assets/4610e82b-864c-439f-a50d-9d2ff4edb4a9" />
