### PR TITLE
[MWPW-198875] Preflight modal redesign — light theme on c2 tokens

### DIFF
--- a/libs/blocks/preflight/checks/localization.js
+++ b/libs/blocks/preflight/checks/localization.js
@@ -27,7 +27,7 @@ function normalizePath(path) {
   return path.replace(/\/+$/, '');
 }
 
-export async function runChecks({ area = document } = {}) {
+async function computeChecks(area) {
   const { locales } = getConfig();
   const locale = getLocale(locales, window.location.pathname);
   const links = Array.from(area.querySelectorAll('a[href]'));
@@ -73,6 +73,14 @@ export async function runChecks({ area = document } = {}) {
       : `${violationsCount} link${violationsCount > 1 ? 's' : ''} potentially not localized or invalid.`,
     details: { violations },
   }];
+}
+
+// Memoized for the modal session: both the General badge and the General panel
+// call this, and each run HEAD-fetches every link on the page.
+let cachedRun;
+export function runChecks({ area = document } = {}) {
+  if (!cachedRun) cachedRun = computeChecks(area);
+  return cachedRun;
 }
 
 export default { runChecks };

--- a/libs/blocks/preflight/panels/assets.js
+++ b/libs/blocks/preflight/panels/assets.js
@@ -70,9 +70,9 @@ function clearAssetHighlight() {
     .forEach((n) => n.classList.remove('preflight-asset-highlight'));
 }
 
-// Floating popover anchored to the asset's top-left, so the user can hop
-// straight back to preflight (which reopens on the same tab) or dismiss it.
-function showReturnPopover(el) {
+// Fixed popover at the top-left of the screen, so the user can hop straight
+// back to preflight (which reopens on the same tab) or dismiss it.
+function showReturnPopover() {
   document.querySelector('.preflight-return-popover')?.remove();
 
   const label = createTag('span', { class: 'preflight-return-label' }, 'Reviewing asset on page');
@@ -89,13 +89,6 @@ function showReturnPopover(el) {
   });
 
   document.body.append(popover);
-
-  // Anchor to the asset's top-left, clamped within the viewport.
-  const rect = el.getBoundingClientRect();
-  const maxLeft = window.scrollX + document.documentElement.clientWidth - popover.offsetWidth - 8;
-  const left = Math.max(window.scrollX + 8, Math.min(rect.left + window.scrollX + 8, maxLeft));
-  popover.style.top = `${rect.top + window.scrollY + 8}px`;
-  popover.style.left = `${left}px`;
 }
 
 // Close the preflight modal and jump to the asset on the page.
@@ -106,7 +99,7 @@ function goToAsset(el) {
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
     clearAssetHighlight();
     el.classList.add('preflight-asset-highlight');
-    showReturnPopover(el);
+    showReturnPopover();
   });
 }
 

--- a/libs/blocks/preflight/panels/assets.js
+++ b/libs/blocks/preflight/panels/assets.js
@@ -122,13 +122,7 @@ function AssetGroup({ group }) {
       <div class="grid-toggle">${title}</div>
     </div>
 
-    ${viewportTooSmall.value && html`
-      <div class='assets-image-grid'>
-        <div class='assets-image-grid-item full-width'>Please resize your browser to at least 1200px width to run image checks</div>
-      </div>
-    `}
-
-    ${!viewportTooSmall.value && assetArray.value.length > 0 && html`
+    ${assetArray.value.length > 0 && html`
     <div class='assets-image-grid'>
       ${assetArray.value.map((asset) => {
     const itemClass = isCriticalGroup ? 'assets-image-grid-item above-fold-critical' : 'assets-image-grid-item';
@@ -157,7 +151,7 @@ function AssetGroup({ group }) {
   })}
     </div>`}
 
-    ${!viewportTooSmall.value && assetArray.value.length === 0 && html`
+    ${assetArray.value.length === 0 && html`
       <div class='assets-image-grid'>
         <div class='assets-image-grid-item full-width'>${empty || 'No assets found'}</div>
       </div>
@@ -197,6 +191,17 @@ export default function Assets() {
     { title: 'Warning Asset Issues (Below-the-fold)', assetArray: warningAssetFailures, empty: 'No warnings.' },
     { title: 'Assets with matching dimensions', assetArray: assetsWithMatch, empty: 'No matching assets found.' },
   ];
+
+  if (viewportTooSmall.value) {
+    return html`
+      <div class="assets-columns">
+        <${AssetsItem} ...${assetDimensionsResult.value} />
+        <div class='assets-image-grid'>
+          <div class='assets-image-grid-item full-width'>Please resize your browser to at least 1200px width to run image checks</div>
+        </div>
+      </div>
+    `;
+  }
 
   return html`
     <div class="assets-columns">

--- a/libs/blocks/preflight/panels/assets.js
+++ b/libs/blocks/preflight/panels/assets.js
@@ -70,9 +70,9 @@ function clearAssetHighlight() {
     .forEach((n) => n.classList.remove('preflight-asset-highlight'));
 }
 
-// Floating popover shown on the page after jumping to an asset, so the user can
-// hop straight back to preflight (which reopens on the same tab) or dismiss it.
-function showReturnPopover() {
+// Floating popover anchored to the asset's top-left, so the user can hop
+// straight back to preflight (which reopens on the same tab) or dismiss it.
+function showReturnPopover(el) {
   document.querySelector('.preflight-return-popover')?.remove();
 
   const label = createTag('span', { class: 'preflight-return-label' }, 'Reviewing asset on page');
@@ -89,6 +89,13 @@ function showReturnPopover() {
   });
 
   document.body.append(popover);
+
+  // Anchor to the asset's top-left, clamped within the viewport.
+  const rect = el.getBoundingClientRect();
+  const maxLeft = window.scrollX + document.documentElement.clientWidth - popover.offsetWidth - 8;
+  const left = Math.max(window.scrollX + 8, Math.min(rect.left + window.scrollX + 8, maxLeft));
+  popover.style.top = `${rect.top + window.scrollY + 8}px`;
+  popover.style.left = `${left}px`;
 }
 
 // Close the preflight modal and jump to the asset on the page.
@@ -99,7 +106,7 @@ function goToAsset(el) {
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
     clearAssetHighlight();
     el.classList.add('preflight-asset-highlight');
-    showReturnPopover();
+    showReturnPopover(el);
   });
 }
 

--- a/libs/blocks/preflight/panels/assets.js
+++ b/libs/blocks/preflight/panels/assets.js
@@ -64,6 +64,17 @@ function AssetsItem({ title, description }) {
 /**
  * Component to display a group of assets.
  */
+// Close the preflight modal and jump to the asset on the page.
+function goToAsset(el) {
+  if (!el) return;
+  document.getElementById('preflight')?.dispatchEvent(new CustomEvent('closeModal'));
+  requestAnimationFrame(() => {
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.classList.add('preflight-asset-highlight');
+    setTimeout(() => el.classList.remove('preflight-asset-highlight'), 2400);
+  });
+}
+
 function AssetMetric({ label, value, recommended }) {
   return html`
     <div class="asset-metric${recommended ? ' is-recommended' : ''}">
@@ -95,7 +106,13 @@ function AssetGroup({ group }) {
     const itemClass = isCriticalGroup ? 'assets-image-grid-item above-fold-critical' : 'assets-image-grid-item';
 
     return html`
-      <div class='${itemClass}' title='${isCriticalGroup ? 'Above-the-fold asset with critical dimension issues' : ''}'>
+      <div
+        class='${itemClass}'
+        role="button"
+        tabindex="0"
+        title='Go to this asset on the page'
+        onClick=${() => goToAsset(asset.asset)}
+        onKeyDown=${(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goToAsset(asset.asset); } }}>
         ${asset.type === 'image' && html`<img src='${asset.src}' />`}
         ${asset.type === 'video' && html`<video controls src='${asset.src}' />`}
         ${asset.type === 'mpc' && html`<iframe src='${asset.src}' />`}

--- a/libs/blocks/preflight/panels/assets.js
+++ b/libs/blocks/preflight/panels/assets.js
@@ -1,4 +1,5 @@
 import { html, signal, useEffect } from '../../../deps/htm-preact.js';
+import { createTag } from '../../../utils/utils.js';
 import { STATUS } from '../checks/constants.js';
 import { getPreflightResults } from '../checks/preflightApi.js';
 import { isViewportTooSmall } from '../checks/assets.js';
@@ -64,14 +65,41 @@ function AssetsItem({ title, description }) {
 /**
  * Component to display a group of assets.
  */
+function clearAssetHighlight() {
+  document.querySelectorAll('.preflight-asset-highlight')
+    .forEach((n) => n.classList.remove('preflight-asset-highlight'));
+}
+
+// Floating popover shown on the page after jumping to an asset, so the user can
+// hop straight back to preflight (which reopens on the same tab) or dismiss it.
+function showReturnPopover() {
+  document.querySelector('.preflight-return-popover')?.remove();
+
+  const label = createTag('span', { class: 'preflight-return-label' }, 'Reviewing asset on page');
+  const reopen = createTag('button', { class: 'preflight-return-reopen' }, 'Back to Preflight');
+  const dismiss = createTag('button', { class: 'preflight-return-dismiss' }, 'Dismiss');
+  const popover = createTag('div', { class: 'preflight-return-popover', role: 'dialog', 'aria-label': 'Asset review' }, [label, reopen, dismiss]);
+
+  const cleanup = () => { popover.remove(); clearAssetHighlight(); };
+  dismiss.addEventListener('click', cleanup);
+  reopen.addEventListener('click', () => {
+    cleanup();
+    document.querySelector('aem-sidekick, helix-sidekick')
+      ?.dispatchEvent(new CustomEvent('custom:preflight', { bubbles: true }));
+  });
+
+  document.body.append(popover);
+}
+
 // Close the preflight modal and jump to the asset on the page.
 function goToAsset(el) {
   if (!el) return;
   document.getElementById('preflight')?.dispatchEvent(new CustomEvent('closeModal'));
   requestAnimationFrame(() => {
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    clearAssetHighlight();
     el.classList.add('preflight-asset-highlight');
-    setTimeout(() => el.classList.remove('preflight-asset-highlight'), 2400);
+    showReturnPopover();
   });
 }
 

--- a/libs/blocks/preflight/panels/assets.js
+++ b/libs/blocks/preflight/panels/assets.js
@@ -64,12 +64,22 @@ function AssetsItem({ title, description }) {
 /**
  * Component to display a group of assets.
  */
+function AssetMetric({ label, value, recommended }) {
+  return html`
+    <div class="asset-metric${recommended ? ' is-recommended' : ''}">
+      <span class="asset-metric-label">${label}</span>
+      <span class="asset-metric-value">${value}</span>
+    </div>`;
+}
+
 function AssetGroup({ group }) {
-  const { title, assetArray } = group;
+  const { title, assetArray, empty } = group;
   const isCriticalGroup = title.includes('Critical');
+  const isWarningGroup = title.includes('Warning');
+  const headingClass = `grid-heading${isCriticalGroup ? ' is-critical' : ''}${isWarningGroup ? ' is-warning' : ''}`;
 
   return html`
-    <div class="grid-heading">
+    <div class="${headingClass}">
       <div class="grid-toggle">${title}</div>
     </div>
 
@@ -82,22 +92,21 @@ function AssetGroup({ group }) {
     ${!viewportTooSmall.value && assetArray.value.length > 0 && html`
     <div class='assets-image-grid'>
       ${assetArray.value.map((asset) => {
-    const isAboveFoldWithMismatch = isCriticalGroup;
-    const itemClass = isAboveFoldWithMismatch ? 'assets-image-grid-item above-fold-critical' : 'assets-image-grid-item';
+    const itemClass = isCriticalGroup ? 'assets-image-grid-item above-fold-critical' : 'assets-image-grid-item';
 
     return html`
-      <div class='${itemClass}' title='${isAboveFoldWithMismatch ? 'Above-the-fold asset with critical dimension issues' : ''}'>
+      <div class='${itemClass}' title='${isCriticalGroup ? 'Above-the-fold asset with critical dimension issues' : ''}'>
         ${asset.type === 'image' && html`<img src='${asset.src}' />`}
         ${asset.type === 'video' && html`<video controls src='${asset.src}' />`}
         ${asset.type === 'mpc' && html`<iframe src='${asset.src}' />`}
         <div class='assets-image-grid-item-text'>
-          <span>Factor: ${asset.roundedFactor}</span>
-          <span>Upload size: ${asset.naturalDimensions}</span>
-          <span>Display size: ${asset.displayDimensions}</span>
-          ${asset.hasMismatch && html`<span>Recommended size: ${asset.recommendedDimensions}</span>`}
-          <span>Type: ${asset.typeLabel}</span>
-          ${asset.notes && html`<span><strong>Notes:</strong> ${asset.notes}</span>`}
-          ${isAboveFoldWithMismatch && html`<span class="above-fold-notice"><strong>⚠️ CRITICAL:</strong></span>`}
+          <${AssetMetric} label="Factor" value=${asset.roundedFactor} />
+          <${AssetMetric} label="Upload" value=${asset.naturalDimensions} />
+          <${AssetMetric} label="Display" value=${asset.displayDimensions} />
+          ${asset.hasMismatch && html`<${AssetMetric} label="Recommended" value=${asset.recommendedDimensions} recommended=${true} />`}
+          <${AssetMetric} label="Type" value=${asset.typeLabel} />
+          ${asset.notes && html`<p class="asset-note"><strong>Notes:</strong> ${asset.notes}</p>`}
+          ${isCriticalGroup && html`<span class="asset-critical-pill">⚠️ Critical</span>`}
         </div>
       </div>`;
   })}
@@ -105,7 +114,7 @@ function AssetGroup({ group }) {
 
     ${!viewportTooSmall.value && assetArray.value.length === 0 && html`
       <div class='assets-image-grid'>
-        <div class='assets-image-grid-item full-width'>No assets found</div>
+        <div class='assets-image-grid-item full-width'>${empty || 'No assets found'}</div>
       </div>
     `}
   `;
@@ -139,9 +148,9 @@ export default function Assets() {
   }, []);
 
   const groups = [
-    { title: 'Critical Asset Issues (Above-the-fold)', assetArray: criticalAssetFailures },
-    { title: 'Warning Asset Issues (Below-the-fold)', assetArray: warningAssetFailures },
-    { title: 'Assets with matching dimensions', assetArray: assetsWithMatch },
+    { title: 'Critical Asset Issues (Above-the-fold)', assetArray: criticalAssetFailures, empty: 'No critical asset issues.' },
+    { title: 'Warning Asset Issues (Below-the-fold)', assetArray: warningAssetFailures, empty: 'No warnings.' },
+    { title: 'Assets with matching dimensions', assetArray: assetsWithMatch, empty: 'No matching assets found.' },
   ];
 
   return html`

--- a/libs/blocks/preflight/panels/martech.js
+++ b/libs/blocks/preflight/panels/martech.js
@@ -56,8 +56,11 @@ export default function Martech() {
   return html`
   <div class="access-columns martech">
     ${martechBlock.value && html`
-      <button class="preflight-action" onclick=${copyTable}>${btnText.value}</button>
-      <div dangerouslySetInnerHTML="${{ __html: martechBlock.value }}"></div>
+      <div class="martech-toolbar">
+        <p class="martech-hint">Copy this metadata to paste into your martech tooling.</p>
+        <button class="preflight-action" onclick=${copyTable}>${btnText.value}</button>
+      </div>
+      <div class="martech-table" dangerouslySetInnerHTML="${{ __html: martechBlock.value }}"></div>
     `}
   </div>`;
 }

--- a/libs/blocks/preflight/panels/martech.js
+++ b/libs/blocks/preflight/panels/martech.js
@@ -35,7 +35,6 @@ async function checkMartechMeta() {
 
 function copyTable() {
   try {
-    /* global ClipboardItem */
     const clipboardData = [new ClipboardItem({ 'text/html': new Blob([martechBlock.value], { type: 'text/html' }) })];
     navigator.clipboard.write(clipboardData);
     btnText.value = '✔ Copied!';

--- a/libs/blocks/preflight/panels/performance.js
+++ b/libs/blocks/preflight/panels/performance.js
@@ -13,6 +13,8 @@ const fragmentsResult = signal({ icon: 'purple', title: 'Fragments', description
 const personalizationResult = signal({ icon: 'purple', title: 'Personalization', description: 'Checking...' });
 const placeholdersResult = signal({ icon: 'purple', title: 'Placeholders', description: 'Checking...' });
 const iconsResult = signal({ icon: 'purple', title: 'Icons', description: 'Checking...' });
+// null = still checking, true/false once known.
+const lcpExists = signal(null);
 
 /**
  * Runs performance checks and updates signals with the results.
@@ -51,6 +53,12 @@ async function getResults() {
   });
 
   await Promise.all(checkPromises);
+
+  try {
+    lcpExists.value = !!(await getLcpEntry(window.location.pathname, document));
+  } catch {
+    lcpExists.value = false;
+  }
 }
 
 /**
@@ -131,11 +139,14 @@ export default function Panel() {
         <${PerformanceItem} ...${iconsResult.value} />
       </div>
       <div>Unsure on how to get this page fully into the green? Check out the <a class="performance-guidelines" href="https://milo.adobe.com/docs/authoring/performance/" target="_blank">Milo Performance Guidelines</a>.</div>
-      <div> 
+      ${lcpExists.value === false
+    ? html`<div><span class="performance-no-lcp">No LCP element detected on this page.</span></div>`
+    : html`
+      <div>
         <span class="performance-element-preview" onMouseEnter=${highlightElement} onMouseLeave=${removeHighlight}>
           Highlight the found LCP section
-        </span> 
-      </div>
+        </span>
+      </div>`}
       <div class="lcp-tooltip-modal"></div>
     </div>
   `;

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -28,11 +28,13 @@
   --preflight-hover: var(--s2a-color-transparent-black-08);
   --preflight-cta-bg: var(--s2a-color-blue-900);
   --preflight-cta-bg-hover: var(--s2a-color-blue-1000);
-  --preflight-cta-text: var(--s2a-color-gray-25);
+  --preflight-cta-fg: var(--s2a-color-gray-25);
   --preflight-success: var(--s2a-color-green-900);
   --preflight-warning: var(--s2a-color-orange-700);
   --preflight-error: var(--s2a-color-red-900);
   --preflight-focus: var(--s2a-color-focus-ring-default);
+  /* Avoid coupling to C1 --body-font-family; use C2 primitive directly. */
+  --preflight-font: var(--s2a-font-family-adobe-clean, adobe-clean, "Trebuchet MS", sans-serif);
 
   width: 1200px;
   max-width: calc(84vw - 40px);
@@ -40,7 +42,7 @@
   max-height: calc(100vh - 40px);
   background: var(--preflight-surface);
   color: var(--preflight-fg);
-  font-family: var(--body-font-family);
+  font-family: var(--preflight-font);
   overflow: hidden;
   box-shadow: 0 16px 48px var(--s2a-color-transparent-black-32);
 }
@@ -105,7 +107,7 @@ button.preflight-tab-button {
   white-space: nowrap;
   border: none;
   background: none;
-  font-family: var(--body-font-family);
+  font-family: var(--preflight-font);
   color: var(--preflight-fg-subtle);
   font-size: var(--s2a-font-size-14);
   font-weight: var(--s2a-font-weight-adobe-clean-medium);
@@ -237,7 +239,7 @@ p.preflight-content-heading {
 }
 
 p.preflight-content-heading-edit {
-  padding-left: 4px;
+  padding-inline-start: 4px;
 }
 
 .preflight-group-row {
@@ -305,7 +307,7 @@ p.preflight-content-heading-edit {
   mask: url('./img/empty.svg') no-repeat 50% / 32px;
   background-color: var(--s2a-color-gray-300);
   position: absolute;
-  left: 18px;
+  inset-inline-start: 18px;
   width: 32px;
   top: 0;
   bottom: 0;
@@ -369,7 +371,7 @@ a.preflight-edit.da-icon {
 }
 
 .preflight-group-detail p:first-child {
-  margin-left: 40px;
+  margin-inline-start: 40px;
 }
 
 span.preflight-date {
@@ -407,17 +409,16 @@ span.preflight-time {
   gap: var(--s2a-spacing-12);
   position: absolute;
   bottom: 0;
-  left: 0;
-  right: 0;
+  inset-inline: 0;
   padding: var(--s2a-spacing-24) var(--s2a-spacing-32);
   background: var(--preflight-surface);
   border-top: 1px solid var(--preflight-border);
   box-shadow: 0 -4px 16px var(--s2a-color-transparent-black-08);
 }
 
-/* Keep "select" on the left; preview/publish flow to the right. */
+/* Keep "select" on the inline-start; preview/publish flow to the inline-end. */
 #select-action {
-  margin-right: auto;
+  margin-inline-end: auto;
 }
 
 /* Canonical Adobe CTA: solid blue, rounded, focus ring. */
@@ -428,12 +429,12 @@ span.preflight-time {
   white-space: nowrap;
   cursor: pointer;
   background: var(--preflight-cta-bg);
-  color: var(--preflight-cta-text);
+  color: var(--preflight-cta-fg);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
   border: 2px solid var(--preflight-cta-bg);
   border-radius: var(--s2a-border-radius-16);
   height: 36px;
-  font-family: var(--body-font-family);
+  font-family: var(--preflight-font);
   font-size: var(--s2a-font-size-16);
   padding: 0 var(--s2a-spacing-24);
   transition: background-color 300ms, border-color 300ms;
@@ -456,7 +457,7 @@ span.preflight-time {
 .tooltip::before {
   content: attr(data-tooltip);
   position: absolute;
-  right: 74%;
+  inset-inline-end: 74%;
   transform: translateX(50%);
   bottom: 130%;
   margin-top: 15px;
@@ -478,7 +479,7 @@ span.preflight-time {
 .tooltip::after {
   content: '';
   bottom: 103%;
-  right: 69%;
+  inset-inline-end: 69%;
   position: absolute;
   margin: 12px 1px 0;
   border: 5px solid var(--s2a-color-gray-900);
@@ -648,7 +649,7 @@ span.preflight-time {
   overflow-x: scroll;
   position: absolute;
   top: 50%;
-  left: 0;
+  inset-inline-start: 0;
   scrollbar-width: none;
   transform: translateY(-50%);
   white-space: nowrap;
@@ -673,7 +674,7 @@ span.preflight-time {
 }
 
 .dialog-modal#preflight .problem-links table th:nth-child(2) {
-  text-align: left;
+  text-align: start;
   width: 75%;
 }
 
@@ -704,7 +705,7 @@ span.preflight-time {
 
 .problem-link::after {
   content: '(' attr(data-status) ')';
-  margin-left: 5px;
+  margin-inline-start: 5px;
   font-size: smaller;
   font-weight: bold;
 }
@@ -1003,8 +1004,8 @@ picture:has(.asset-meta),
 .asset-meta {
   position: absolute;
   top: 10px;
-  left: 10px;
-  right: 10px;
+  inset-inline-start: 10px;
+  inset-inline-end: 10px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -1110,7 +1111,7 @@ img:hover ~ .asset-meta,
 
 .preflight .image-filter {
   padding: 3px;
-  margin-left: 5px;
+  margin-inline-start: 5px;
   border-radius: var(--s2a-border-radius-4);
   border: 1px solid var(--preflight-border);
 }
@@ -1185,7 +1186,7 @@ img:hover ~ .asset-meta,
   font-size: var(--s2a-font-size-14);
   font-weight: var(--s2a-font-weight-adobe-clean-regular);
   line-height: 1.4;
-  font-family: var(--body-font-family);
+  font-family: var(--preflight-font);
 }
 
 .dialog-modal#preflight table {
@@ -1201,7 +1202,7 @@ img:hover ~ .asset-meta,
 
 .preflight h3 {
   margin: 16px 0;
-  font-family: var(--body-font-family);
+  font-family: var(--preflight-font);
 }
 
 .dialog-modal#preflight table td h3 {
@@ -1239,18 +1240,20 @@ img:hover ~ .asset-meta,
   position: fixed;
   top: var(--s2a-spacing-16);
   inset-inline-start: var(--s2a-spacing-16);
-  z-index: 9999;
+  z-index: 1000;
   display: flex;
   align-items: center;
   gap: var(--s2a-spacing-12);
   max-width: calc(100vw - 32px);
-  padding: var(--s2a-spacing-8) var(--s2a-spacing-8) var(--s2a-spacing-8) var(--s2a-spacing-16);
+  padding-block: var(--s2a-spacing-8);
+  padding-inline-start: var(--s2a-spacing-16);
+  padding-inline-end: var(--s2a-spacing-8);
   background: var(--s2a-color-background-default);
   color: var(--s2a-color-content-default);
   border: 1px solid var(--s2a-color-border-subtle);
   border-radius: var(--s2a-border-radius-999);
   box-shadow: 0 8px 24px var(--s2a-color-transparent-black-24);
-  font-family: var(--body-font-family);
+  font-family: var(--preflight-font);
   font-size: var(--s2a-font-size-14);
 }
 
@@ -1272,10 +1275,10 @@ img:hover ~ .asset-meta,
   height: 32px;
   padding: 0 var(--s2a-spacing-16);
   border: none;
-  border-radius: var(--s2a-border-radius-999, 999px);
-  background: var(--s2a-color-blue-900, #3b63fb);
-  color: var(--s2a-color-gray-25, #fff);
-  font-family: var(--body-font-family);
+  border-radius: var(--s2a-border-radius-999);
+  background: var(--s2a-color-blue-900);
+  color: var(--s2a-color-gray-25);
+  font-family: var(--preflight-font);
   font-size: var(--s2a-font-size-14);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
   white-space: nowrap;
@@ -1284,11 +1287,11 @@ img:hover ~ .asset-meta,
 }
 
 .preflight-return-reopen:hover {
-  background: var(--s2a-color-blue-1000, #274dea);
+  background: var(--s2a-color-blue-1000);
 }
 
 .preflight-return-reopen:focus-visible {
-  outline: 2px solid var(--s2a-color-focus-ring-default, #3b63fb);
+  outline: 2px solid var(--s2a-color-focus-ring-default);
   outline-offset: 2px;
 }
 
@@ -1298,14 +1301,14 @@ img:hover ~ .asset-meta,
   padding: 0 var(--s2a-spacing-8);
   white-space: nowrap;
   cursor: pointer;
-  color: var(--s2a-color-content-subtle, rgb(0 0 0 / 64%));
-  font-family: var(--body-font-family);
+  color: var(--s2a-color-content-subtle);
+  font-family: var(--preflight-font);
   font-size: var(--s2a-font-size-14);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
 }
 
 .preflight-return-dismiss:hover {
-  color: var(--s2a-color-content-default, #131313);
+  color: var(--s2a-color-content-default);
 }
 
 /* Page-injected: LCP element preview box (outside modal). */
@@ -1438,7 +1441,7 @@ img:hover ~ .asset-meta,
 }
 
 .violation-list {
-  padding-left: 0;
+  padding-inline-start: 0;
   margin-top: var(--s2a-spacing-12);
   padding-top: 0;
 }
@@ -1478,7 +1481,7 @@ img:hover ~ .asset-meta,
 
 .violation-index {
   font-weight: bold;
-  margin-right: 10px;
+  margin-inline-end: 10px;
   color: var(--preflight-fg-subtle);
 }
 
@@ -1504,12 +1507,12 @@ img:hover ~ .asset-meta,
 .violations-scroll-wrapper {
   max-height: 300px;
   overflow-y: auto;
-  padding-right: 0;
+  padding-inline-end: 0;
 }
 
 /* Affected Elements */
 .affected-elements {
-  padding-left: 20px;
+  padding-inline-start: 20px;
   margin-top: 5px;
 }
 
@@ -1651,32 +1654,32 @@ img:hover ~ .asset-meta,
   background: var(--preflight-surface-subtle);
   border: 1px solid var(--preflight-border);
   border-radius: var(--s2a-border-radius-4);
-  border-left: 4px solid transparent;
+  border-inline-start: 4px solid transparent;
 }
 
 .merch-item.merch-success {
-  border-left-color: var(--preflight-success);
+  border-inline-start-color: var(--preflight-success);
 }
 
 .merch-item.merch-error {
-  border-left-color: var(--preflight-error);
+  border-inline-start-color: var(--preflight-error);
 }
 
 .merch-item.merch-link-item {
-  border-left-color: var(--s2a-color-blue-700);
+  border-inline-start-color: var(--s2a-color-blue-700);
 }
 
 .merch-item.merch-wcs-item {
-  border-left-color: var(--s2a-color-blue-1100);
+  border-inline-start-color: var(--s2a-color-blue-1100);
 }
 
 .merch-item.merch-wcs-item.has-url-error {
-  border-left-color: var(--preflight-error);
+  border-inline-start-color: var(--preflight-error);
   background: var(--s2a-color-red-100);
 }
 
 .url-status-icon {
-  margin-left: 8px;
+  margin-inline-start: 8px;
   font-size: var(--s2a-font-size-18);
 }
 
@@ -1713,14 +1716,14 @@ img:hover ~ .asset-meta,
   border: 1px solid var(--preflight-border);
   padding: 2px 6px;
   border-radius: var(--s2a-border-radius-4);
-  font-family: var(--fixed-font-family, 'Courier New', monospace);
+  font-family: 'Courier New', monospace;
   font-size: 13px;
   color: var(--preflight-fg);
 }
 
 .merch-icon {
   font-size: var(--s2a-font-size-24);
-  margin-right: 8px;
+  margin-inline-end: 8px;
 }
 
 .merch-item .preflight-item-title {
@@ -1746,13 +1749,13 @@ img:hover ~ .asset-meta,
   cursor: pointer;
   font-size: var(--s2a-font-size-14);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
-  font-family: var(--body-font-family);
+  font-family: var(--preflight-font);
   transition: background-color 0.2s, color 0.2s;
 }
 
 .merch-scroll-btn:hover {
   background: var(--preflight-cta-bg);
-  color: var(--preflight-cta-text);
+  color: var(--preflight-cta-fg);
 }
 
 .merch-scroll-btn:focus-visible {
@@ -1788,13 +1791,13 @@ img:hover ~ .asset-meta,
   content: 'Not published';
   position: absolute;
   top: -1px;
-  right: -1px;
+  inset-inline-end: -1px;
   z-index: 2;
   padding: 4px 10px;
   background: var(--s2a-color-red-800);
   color: var(--s2a-color-gray-25);
-  font-family: var(--body-font-family);
-  font-size: var(--s2a-font-size-12, 12px);
+  font-family: var(--preflight-font);
+  font-size: var(--s2a-font-size-12);
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -1820,7 +1823,7 @@ img:hover ~ .asset-meta,
 
 /* Responsive layout — mobile-first. */
 
-/* Tablet/desktop: restore the sidebar rail and two-column layouts. */
+/* Medium and up: restore the sidebar rail and two-column layouts. */
 @media (min-width: 900px) {
   .preflight {
     grid-template-columns: 256px 1fr;
@@ -1890,7 +1893,7 @@ img:hover ~ .asset-meta,
   }
 }
 
-/* Large desktop: two-up card layout. */
+/* Large: two-up card layout. */
 @media (min-width: 1200px) {
   .preflight-structure-columns,
   .preflight-columns,

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -1,7 +1,8 @@
-:root {
-  --notch-size: 12px;
-  --action-color: #FF1593;
-}
+/*
+ * Milo Preflight — light theme built on c2 (--s2a-*) design tokens.
+ * Tokens are loaded at :root from preflight.js so both the modal and the
+ * page-injected overlays (which live outside #preflight) resolve them.
+ */
 
 #preflight .fragment,
 #preflight .section,
@@ -16,30 +17,29 @@
   z-index: 0;
 }
 
-.preflight > .bg-img {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-}
-
-.preflight > .bg-img img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.preflight > .preflight-heading,
-.preflight > .preflight-content {
-  z-index: 1;
-}
-
 .dialog-modal#preflight {
+  /* Local aliases (modal-scoped) → c2 semantic/primitive tokens. */
+  --preflight-surface: var(--s2a-color-background-default);
+  --preflight-surface-subtle: var(--s2a-color-background-subtle);
+  --preflight-text: var(--s2a-color-content-default);
+  --preflight-text-subtle: var(--s2a-color-content-subtle);
+  --preflight-border: var(--s2a-color-border-subtle);
+  --preflight-hover: var(--s2a-color-transparent-black-08);
+  --preflight-cta-bg: var(--s2a-color-blue-900);
+  --preflight-cta-bg-hover: var(--s2a-color-blue-1000);
+  --preflight-cta-text: var(--s2a-color-gray-25);
+  --preflight-success: var(--s2a-color-green-900);
+  --preflight-warning: var(--s2a-color-orange-700);
+  --preflight-error: var(--s2a-color-red-900);
+  --preflight-focus: var(--s2a-color-focus-ring-default);
+
   width: 1200px;
   max-width: calc(84vw - 40px);
   height: 680px;
   max-height: calc(100vh - 40px);
-  background: none;
-  color: #FFF;
+  background: var(--preflight-surface);
+  color: var(--preflight-text);
+  font-family: var(--body-font-family);
   overflow: hidden;
 }
 
@@ -49,54 +49,79 @@
 }
 
 .preflight-tab-panel a {
-  color: #fff;
+  color: var(--preflight-text);
 }
 
 .preflight-heading {
   display: flex;
-  align-items: end;
-  padding: 24px;
+  flex-direction: column;
+  gap: var(--s2a-spacing-12);
+  padding: var(--s2a-spacing-24) var(--s2a-spacing-32) 0;
+  border-bottom: 1px solid var(--preflight-border);
+  background: var(--preflight-surface);
 }
 
 .preflight-content {
   display: grid;
   overflow-x: hidden;
+  overflow-y: auto;
 }
 
 p#preflight-title {
   margin: 0;
-  font-weight: 700;
-  font-size: 38px;
-  text-transform: uppercase;
-  line-height: 1;
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  font-size: var(--s2a-font-size-24);
+  line-height: 1.1;
+  color: var(--preflight-text);
 }
 
 div.preflight-tab-button-group {
   display: flex;
-  margin: 0 0 2px 18px;
+  flex-wrap: wrap;
+  gap: var(--s2a-spacing-24);
+  margin: 0;
 }
 
 button.preflight-tab-button {
   border: none;
   background: none;
   font-family: var(--body-font-family);
-  color: #FFF;
-  font-size: 24px;
-  margin: 0 18px 0 0;
-  padding: 0;
+  color: var(--preflight-text-subtle);
+  font-size: var(--s2a-font-size-16);
+  font-weight: var(--s2a-font-weight-adobe-clean-medium);
+  margin: 0;
+  padding: 0 0 var(--s2a-spacing-12);
   line-height: 1;
   display: block;
   position: relative;
+  cursor: pointer;
+  transition: color 200ms;
+}
+
+button.preflight-tab-button:hover {
+  color: var(--preflight-text);
+}
+
+button.preflight-tab-button[aria-selected="true"] {
+  color: var(--preflight-text);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
 }
 
 button.preflight-tab-button[aria-selected="true"]::after {
   display: block;
   content: '';
-  height: 4px;
-  background: #FFF;
-  margin-top: 6px;
+  height: 2px;
+  background: var(--preflight-cta-bg);
   position: absolute;
+  bottom: -1px;
+  left: 0;
   width: 100%;
+  border-radius: 2px;
+}
+
+button.preflight-tab-button:focus-visible {
+  outline: 2px solid var(--preflight-focus);
+  outline-offset: 2px;
   border-radius: 2px;
 }
 
@@ -110,32 +135,34 @@ div.preflight-tab-panel[aria-selected="false"] {
 
 p.preflight-content-heading {
   text-transform: uppercase;
-  font-weight: 700;
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  font-size: var(--s2a-font-size-14);
+  color: var(--preflight-text-subtle);
+  letter-spacing: 0.04em;
 }
 
 p.preflight-content-heading-edit {
-    padding-left: 4px;
+  padding-left: 4px;
 }
 
 .preflight-group-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 80px 140px 140px;
-  padding: 12px 24px;
+  padding: var(--s2a-spacing-12) var(--s2a-spacing-24);
   align-items: center;
 }
 
 .preflight-group-row.preflight-group-heading {
-  padding: 12px 24px 12px 14px;
+  padding: var(--s2a-spacing-12) var(--s2a-spacing-24) var(--s2a-spacing-12) 14px;
   grid-template-columns: 42px 1fr 80px 140px 140px;
   box-sizing: border-box;
 }
 
 .preflight-group-expand {
   height: 18px;
-  background-image: url('./img/expand.svg');
-  background-repeat: no-repeat;
-  background-position: 50%;
-  background-size: 24px;
+  -webkit-mask: url('./img/expand.svg') no-repeat 50% / 24px;
+  mask: url('./img/expand.svg') no-repeat 50% / 24px;
+  background-color: var(--preflight-text-subtle);
   transition: transform .2s ease-in-out;
   transform: rotate(90deg);
 }
@@ -145,17 +172,18 @@ p.preflight-content-heading-edit {
 }
 
 .preflight-content-group {
-  margin-bottom: 24px;
+  margin-bottom: var(--s2a-spacing-24);
 }
 
 .preflight-group-row.preflight-group-detail {
   position: relative;
   box-sizing: border-box;
   min-height: 60px;
+  border-bottom: 1px solid var(--preflight-border);
 }
 
 .preflight-group-row.preflight-group-detail:hover {
-  background-color: rgb(0 0 0 / 20%);
+  background-color: var(--preflight-hover);
   cursor: pointer;
 }
 
@@ -177,10 +205,9 @@ p.preflight-content-heading-edit {
 
 .preflight-group-row.preflight-group-detail::before {
   content: '';
-  background-image: url(./img/empty.svg);
-  background-repeat: no-repeat;
-  background-size: 32px;
-  background-position: 50%;
+  -webkit-mask: url('./img/empty.svg') no-repeat 50% / 32px;
+  mask: url('./img/empty.svg') no-repeat 50% / 32px;
+  background-color: var(--s2a-color-gray-300);
   position: absolute;
   left: 18px;
   width: 32px;
@@ -190,15 +217,15 @@ p.preflight-content-heading-edit {
 
 .preflight-group-row.preflight-group-detail.is-checked::before,
 .preflight-group-row.preflight-group-detail.is-checked.not-found::before {
-  background-image: url('./img/check.svg');
-  background-repeat: no-repeat;
-  font-weight: 700;
+  -webkit-mask-image: url('./img/check.svg');
+  mask-image: url('./img/check.svg');
+  background-color: var(--preflight-success);
 }
 
 .preflight-group-row.preflight-group-detail.is-fetching::before {
-  background-image: url('./img/purple-working.svg');
-  background-repeat: no-repeat;
-  font-weight: 700;
+  -webkit-mask-image: url('./img/purple-working.svg');
+  mask-image: url('./img/purple-working.svg');
+  background-color: var(--preflight-cta-bg);
   animation: spin 2s linear infinite;
 }
 
@@ -220,9 +247,9 @@ a.preflight-edit.da-icon {
 }
 
 .preflight-group-row.preflight-group-detail.not-found::before {
-  background-image: url('./img/red-error.svg');
-  background-repeat: no-repeat;
-  font-weight: 700;
+  -webkit-mask-image: url('./img/red-error.svg');
+  mask-image: url('./img/red-error.svg');
+  background-color: var(--preflight-error);
 }
 
 .preflight-group-items {
@@ -250,6 +277,7 @@ p.preflight-date-wrapper {
 
 p.preflight-date-wrapper .disabled-publish {
   font-size: 0.8em;
+  color: var(--preflight-text-subtle);
 }
 
 .preflight-group-row p {
@@ -258,23 +286,25 @@ p.preflight-date-wrapper .disabled-publish {
 }
 
 .preflight-group-row a {
-  color: #FFF;
+  color: var(--preflight-text);
 }
 
 span.preflight-time {
-  font-size: 14px;
+  font-size: var(--s2a-font-size-14);
+  color: var(--preflight-text-subtle);
 }
 
 .preflight-actions {
   display: grid;
   grid-template-areas: 'select empty preview publish';
   grid-template-columns: auto 1fr 140px 140px;
+  gap: var(--s2a-spacing-12);
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 24px;
-  background: linear-gradient(0deg, rgb(255 255 255 / 10%) 0%, rgb(255 255 255 / 0%) 100%);
+  padding: var(--s2a-spacing-24) var(--s2a-spacing-32);
+  background: linear-gradient(0deg, var(--preflight-surface) 60%, rgb(255 255 255 / 0%) 100%);
 }
 
 #select-action {
@@ -289,21 +319,32 @@ span.preflight-time {
   grid-area: publish;
 }
 
+/* Canonical Adobe CTA: solid blue, rounded, focus ring. */
 .preflight-action {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
   cursor: pointer;
-  background: var(--action-color);
-  color: #FFF;
-  font-weight: 700;
-  outline: transparent solid 0;
-  transition: outline 300ms;
-  border: none;
+  background: var(--preflight-cta-bg);
+  color: var(--preflight-cta-text);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  border: 2px solid var(--preflight-cta-bg);
+  border-radius: var(--s2a-border-radius-16);
   height: 36px;
   font-family: var(--body-font-family);
-  font-size: 16px;
-  padding: 0 18px;
-  clip-path: polygon(0% 0%, var(--notch-size) 0%, calc(100% - var(--notch-size)) 0%, 100% var(--notch-size), 100% calc(100% - var(--notch-size)), 100% 100%, 0% 100%, 0% 100%);
+  font-size: var(--s2a-font-size-16);
+  padding: 0 var(--s2a-spacing-24);
+  transition: background-color 300ms, border-color 300ms;
+}
+
+.preflight-action:hover {
+  background: var(--preflight-cta-bg-hover);
+  border-color: var(--preflight-cta-bg-hover);
+}
+
+.preflight-action:focus-visible {
+  outline: 2px solid var(--preflight-focus);
+  outline-offset: 2px;
 }
 
 .tooltip {
@@ -320,11 +361,11 @@ span.preflight-time {
   width: max-content;
   max-width: 157px;
   padding: 10px;
-  border-radius: 4px;
-  background: white;
-  color: var(--action-color);
+  border-radius: var(--s2a-border-radius-4);
+  background: var(--s2a-color-gray-900);
+  color: var(--s2a-color-gray-25);
   text-align: center;
-  font-size: 14px;
+  font-size: var(--s2a-font-size-14);
   font-weight: 400;
   opacity: 0;
   transition: opacity 0.3s, visibility 0.3s;
@@ -338,8 +379,8 @@ span.preflight-time {
   right: 69%;
   position: absolute;
   margin: 12px 1px 0;
-  border: 5px solid white;
-  border-color: white transparent transparent;
+  border: 5px solid var(--s2a-color-gray-900);
+  border-color: var(--s2a-color-gray-900) transparent transparent;
   opacity: 0;
   transition: 200ms;
   visibility: hidden;
@@ -354,33 +395,34 @@ span.preflight-time {
 
 /* GENERAL */
 .preflight-structure-title {
-  margin: 0 0 24px;
-  font-weight: 700;
-  font-size: 32px;
-  line-height: 1;
-  padding-left: 24px;
+  margin: 0 0 var(--s2a-spacing-24);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  font-size: var(--s2a-font-size-20);
+  line-height: 1.1;
+  padding-left: var(--s2a-spacing-24);
 }
 
 .preflight-structure-columns {
-  margin: 0 48px 24px;
+  margin: 0 var(--s2a-spacing-32) var(--s2a-spacing-24);
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 48px;
+  gap: var(--s2a-spacing-32);
 }
 
 /* SEO */
 .preflight-columns {
-  margin: 24px 48px 0;
+  margin: var(--s2a-spacing-24) var(--s2a-spacing-32) 0;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 48px;
+  gap: var(--s2a-spacing-32);
 }
 
 .preflight-item {
-  margin-bottom: 48px;
+  margin-bottom: var(--s2a-spacing-32);
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 12px;
+  gap: var(--s2a-spacing-12);
+  align-items: center;
 }
 
 .preflight-item:last-child {
@@ -388,68 +430,63 @@ span.preflight-time {
 }
 
 .result-icon {
-  width: 60px;
-  height: 60px;
+  width: 48px;
+  height: 48px;
+  background-repeat: no-repeat;
+  background-size: 48px;
+  flex-shrink: 0;
 }
 
 .result-icon.purple {
-  background: url('./img/purple-working.svg');
-  background-size: 60px;
+  -webkit-mask: url('./img/purple-working.svg') no-repeat 50% / 48px;
+  mask: url('./img/purple-working.svg') no-repeat 50% / 48px;
+  background-color: var(--preflight-cta-bg);
   animation: spin 2s linear infinite;
 }
 
 .result-icon.empty {
-  background: url('./img/empty.svg');
-  background-size: 60px;
+  -webkit-mask: url('./img/empty.svg') no-repeat 50% / 48px;
+  mask: url('./img/empty.svg') no-repeat 50% / 48px;
+  background-color: var(--s2a-color-gray-300);
 }
 
 @keyframes spin {
   100% {
     -webkit-transform: rotate(360deg);
-    transform:rotate(360deg);
+    transform: rotate(360deg);
   }
 }
 
 .result-icon.green {
-  background: url('./img/green-check.svg');
-  background-size: 60px;
+  background-image: url('./img/green-check.svg');
 }
 
 .result-icon.red {
-  width: 60px;
-  height: 60px;
-  background: url('./img/red-error.svg');
-  background-size: 60px;
+  background-image: url('./img/red-error.svg');
 }
 
 .result-icon.orange {
-  width: 60px;
-  height: 60px;
-  background: url('./img/orange-limbo.svg');
-  background-size: 60px;
+  background-image: url('./img/orange-limbo.svg');
 }
 
 .result-icon.alt-text {
-  width: 60px;
-  height: 60px;
-  background: url('./img/alt-text-blue.png');
-  background-size: 60px;
-  background-repeat: no-repeat;
+  background-image: url('./img/alt-text-blue.png');
 }
 
 .preflight-item-title {
   margin: 0;
-  font-weight: 700;
-  font-size: 32px;
-  line-height: 1;
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  font-size: var(--s2a-font-size-20);
+  line-height: 1.1;
 }
 
 .preflight-item-description {
   margin: 0;
+  color: var(--preflight-text-subtle);
 }
 
 .problem-links {
-  margin: 24px 48px;
+  margin: var(--s2a-spacing-24) var(--s2a-spacing-32);
 }
 
 .problem-links .title {
@@ -458,22 +495,25 @@ span.preflight-time {
 
 .problem-links .note {
   margin-top: 20px;
+  color: var(--preflight-text-subtle);
 }
 
 .dialog-modal#preflight .problem-links table {
   width: 100%;
   border-collapse: collapse;
-  border-radius: 6px;
-  background-color: rgb(0 0 0 / 8%);
+  border-radius: var(--s2a-border-radius-8);
+  background-color: var(--preflight-surface-subtle);
 }
 
 .dialog-modal#preflight .problem-links table th {
   text-transform: uppercase;
   width: 10%;
+  font-size: var(--s2a-font-size-14);
+  color: var(--preflight-text-subtle);
 }
 
 .dialog-modal#preflight .problem-links table td a {
-  color: #fff;
+  color: var(--preflight-text);
   display: inline-block;
   overflow-x: scroll;
   position: absolute;
@@ -487,7 +527,7 @@ span.preflight-time {
 
 .dialog-modal#preflight .problem-links table th,
 .dialog-modal#preflight .problem-links table td {
-  padding: 12px 0;
+  padding: var(--s2a-spacing-12) 0;
   text-align: center;
 }
 
@@ -504,7 +544,7 @@ span.preflight-time {
 
 .dialog-modal#preflight .problem-links table th:nth-child(2) {
   text-align: left;
-  width: 75%
+  width: 75%;
 }
 
 .dialog-modal#preflight .problem-links table tr:first-child th {
@@ -512,23 +552,24 @@ span.preflight-time {
 }
 
 .dialog-modal#preflight .problem-links table tr:hover td {
-  background-color: rgb(0 0 0 / 20%);
+  background-color: var(--preflight-hover);
 }
 
+/* Page-injected: broken link highlight on the live page (outside modal). */
 .problem-link {
-  border: 3px solid #000!important;
-  color: #fff!important;
-  font-size: larger!important;
-  font-weight: bold!important;
-  padding-top: 12px!important;
-  padding-bottom: 12px!important;
+  border: 3px solid var(--s2a-color-red-1100) !important;
+  color: var(--s2a-color-gray-25) !important;
+  font-size: larger !important;
+  font-weight: bold !important;
+  padding-top: 12px !important;
+  padding-bottom: 12px !important;
   animation: pulse 1.5s ease-out infinite;
 }
 
 .problem-link:hover {
-  background-color: transparent!important;
-  color: inherit!important;
-  border-color:rgb(255 0 0)!important;
+  background-color: transparent !important;
+  color: inherit !important;
+  border-color: var(--s2a-color-red-700) !important;
 }
 
 .problem-link::after {
@@ -539,15 +580,15 @@ span.preflight-time {
 }
 
 @keyframes pulse {
-  0% {background-color: rgb(255 0 0);}
-  50% {background-color: rgb(150 0 0);}
-  100% {background-color: rgb(255 0 0);}
+  0% { background-color: var(--s2a-color-red-800); }
+  50% { background-color: var(--s2a-color-red-1000); }
+  100% { background-color: var(--s2a-color-red-800); }
 }
 
 /* Accessibility css */
 .access-columns {
-  margin: 24px 48px;
-  gap: 48px;
+  margin: var(--s2a-spacing-24) var(--s2a-spacing-32);
+  gap: var(--s2a-spacing-32);
 }
 
 .access-columns .grid-heading {
@@ -563,8 +604,8 @@ span.preflight-time {
 }
 
 .access-columns .grid-toggle {
-  color: #fff;
-  font-weight: 700;
+  color: var(--preflight-text);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
   text-transform: uppercase;
   display: grid;
   grid-template-columns: 42px 1fr;
@@ -574,18 +615,20 @@ span.preflight-time {
 .access-item {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 12px;
+  gap: var(--s2a-spacing-12);
+  align-items: center;
 }
 
 .access-item-title {
   margin: 0;
-  font-weight: 700;
-  font-size: 32px;
-  line-height: 1;
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  font-size: var(--s2a-font-size-20);
+  line-height: 1.1;
 }
 
 .access-item-description {
-  margin: 10px 0 48px;
+  margin: 10px 0 var(--s2a-spacing-32);
+  color: var(--preflight-text-subtle);
 }
 
 .access-image-grid {
@@ -607,12 +650,13 @@ span.preflight-time {
 .access-image-grid-item {
   position: relative;
   height: auto;
-  background: rgb(0 0 0 / 20%);
+  background: var(--preflight-surface-subtle);
+  border: 1px solid var(--preflight-border);
   display: flex;
   flex-flow: column;
   align-items: center;
   padding: 10px;
-  border-radius: 6px;
+  border-radius: var(--s2a-border-radius-8);
   box-sizing: border-box;
 }
 
@@ -625,12 +669,13 @@ span.preflight-time {
   grid-column: 1 / 5;
   align-items: start;
   background: none;
+  border: none;
   display: block;
-  font-size: 16px;
+  font-size: var(--s2a-font-size-16);
 }
 
 .access-image-grid-item span {
-  font-size: 16px;
+  font-size: var(--s2a-font-size-16);
   font-weight: bold;
   margin-top: 10px;
   line-height: 1.3rem;
@@ -638,7 +683,7 @@ span.preflight-time {
 
 .access-image-grid-item span:last-child {
   font-weight: initial;
-  opacity: 0.8;
+  color: var(--preflight-text-subtle);
   margin-top: 0;
 }
 
@@ -657,7 +702,7 @@ body.preflight-assets-analysis {
 }
 
 .assets-columns {
-  margin: 24px 48px;
+  margin: var(--s2a-spacing-24) var(--s2a-spacing-32);
   display: grid;
   gap: 20px;
 }
@@ -667,8 +712,8 @@ body.preflight-assets-analysis {
 }
 
 .assets-columns .grid-toggle {
-  color: #fff;
-  font-weight: 700;
+  color: var(--preflight-text);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
   text-transform: uppercase;
   display: flex;
   align-items: center;
@@ -676,8 +721,8 @@ body.preflight-assets-analysis {
 
 .assets-item-title {
   margin: 0;
-  font-weight: 700;
-  font-size: 32px;
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  font-size: var(--s2a-font-size-20);
 }
 
 .assets-image-grid {
@@ -693,20 +738,21 @@ body.preflight-assets-analysis {
 }
 
 .assets-image-grid-item {
-  background: rgb(0 0 0 / 20%);
+  background: var(--preflight-surface-subtle);
+  border: 1px solid var(--preflight-border);
   display: grid;
   justify-items: center;
   padding: 10px;
-  border-radius: 6px;
+  border-radius: var(--s2a-border-radius-8);
 }
 
 .above-fold-notice {
-  color: #dc2626;
+  color: var(--s2a-color-red-900);
   font-weight: bold;
-  background: rgba(220, 38, 38, 10%);
+  background: var(--s2a-color-red-100);
   padding: 4px 8px;
-  border-radius: 4px;
-  border-left: 3px solid #dc2626;
+  border-radius: var(--s2a-border-radius-4);
+  border-left: 3px solid var(--s2a-color-red-900);
   margin-top: 8px;
 }
 
@@ -723,7 +769,7 @@ body.preflight-assets-analysis {
 }
 
 .assets-image-grid-item span {
-  font-size: 16px;
+  font-size: var(--s2a-font-size-16);
   line-height: 1.4;
 }
 
@@ -738,6 +784,7 @@ body.preflight-assets-analysis {
   border: none;
 }
 
+/* Page-injected: asset metadata overlay drawn on top of media (outside modal). */
 picture:has(.asset-meta),
 .video-holder:has(.asset-meta) {
   position: relative;
@@ -755,20 +802,20 @@ picture:has(.asset-meta),
   align-items: flex-start;
   row-gap: 5px;
   min-width: 100px;
-  color: #fff;
+  color: var(--s2a-color-gray-25);
   font-weight: bold;
-  font-size: 14px;
+  font-size: var(--s2a-font-size-14);
   line-height: 1.2;
   z-index: 2;
   opacity: 0.7;
 }
 
 .asset-meta .above-fold-critical {
-  background: rgba(220, 38, 38, 90%);
-  color: #fff;
+  background: var(--s2a-color-red-800);
+  color: var(--s2a-color-gray-25);
   padding: 6px 8px;
-  border-radius: 4px;
-  border: 2px solid #fff;
+  border-radius: var(--s2a-border-radius-4);
+  border: 2px solid var(--s2a-color-gray-25);
   opacity: 1;
   font-weight: bold;
 }
@@ -815,7 +862,7 @@ picture:has(.asset-meta),
 .asset-meta.no-picture-tag {
   position: absolute;
   top: 30px;
-  left: 0px;
+  left: 0;
   width: max-content;
   max-width: calc(100% - 20px);
 }
@@ -834,7 +881,7 @@ img:hover ~ .asset-meta,
 .asset-meta > div,
 .brick .background .asset-meta > div {
   padding: 5px;
-  border-radius: 6px;
+  border-radius: var(--s2a-border-radius-8);
 }
 
 .asset-meta-entry {
@@ -842,25 +889,26 @@ img:hover ~ .asset-meta,
 }
 
 .asset-meta-entry.needs-attention {
-  background: #FFB74D;
+  background: var(--s2a-color-orange-500);
 }
 
 .asset-meta-entry.is-invalid {
-  background: #EF5350;
+  background: var(--s2a-color-red-700);
 }
 
 .asset-meta-entry.is-valid {
-  background: #4CAF50;
+  background: var(--s2a-color-green-600);
 }
 
 .preflight .image-filter {
   padding: 3px;
   margin-left: 5px;
-  border-radius: 4px;
+  border-radius: var(--s2a-border-radius-4);
+  border: 1px solid var(--preflight-border);
 }
 
 .preflight .image-filter:focus-visible {
-  outline-color: var(--action-color);
+  outline-color: var(--preflight-focus);
 }
 
 .preflight .martech {
@@ -876,8 +924,8 @@ img:hover ~ .asset-meta,
 .dialog-modal#preflight table {
   border-spacing: 0;
   border-collapse: collapse;
-  border-color: #fff;
-  background: rgba(0 0 0 / 10%);
+  border-color: var(--preflight-border);
+  background: var(--preflight-surface-subtle);
 }
 
 .dialog-modal#preflight table td {
@@ -890,18 +938,18 @@ img:hover ~ .asset-meta,
 }
 
 .dialog-modal#preflight table td h3 {
-  font-size: 16px;
+  font-size: var(--s2a-font-size-16);
 }
 
 .performance-guidelines {
-  color: #fff;
+  color: var(--s2a-color-blue-900);
   text-decoration: underline;
 }
 
 .performance-element-preview {
   position: relative;
   display: inline-block;
-  color: #fff;
+  color: var(--s2a-color-blue-900);
   text-decoration: underline;
 }
 
@@ -909,13 +957,13 @@ img:hover ~ .asset-meta,
   text-decoration: none;
 }
 
-/* styles.css */
+/* Page-injected: LCP element preview box (outside modal). */
 .lcp-tooltip-modal {
   width: 0;
   height: 0;
   position: fixed;
-  border: 2px solid red;
-  background-color: white;
+  border: 2px solid var(--s2a-color-red-800);
+  background-color: var(--s2a-color-gray-25);
   z-index: 4;
   overflow: hidden;
   pointer-events: none;
@@ -931,6 +979,7 @@ img:hover ~ .asset-meta,
   display: flex;
   margin: 0;
   font-style: italic;
+  color: var(--preflight-text-subtle);
 }
 
 .ai-suggestion .result-icon {
@@ -943,21 +992,21 @@ img:hover ~ .asset-meta,
 .accessibility-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 48px;
+  gap: var(--s2a-spacing-32);
   height: 280px;
 }
 
 .preflight-accessibility-item {
-  margin-bottom: 12px;
+  margin-bottom: var(--s2a-spacing-12);
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 12px;
+  gap: var(--s2a-spacing-12);
 }
 
 .preflight-accessibility-note {
-  margin-top: 12px;
-  font-size: 14px;
-  color: #ccc;
+  margin-top: var(--s2a-spacing-12);
+  font-size: var(--s2a-font-size-14);
+  color: var(--preflight-text-subtle);
   line-height: 1.5;
   font-style: italic;
 }
@@ -966,7 +1015,7 @@ img:hover ~ .asset-meta,
 .violations-column {
   overflow-y: auto;
   max-height: 100%;
-  margin-bottom: 32px;
+  margin-bottom: var(--s2a-spacing-32);
   padding-bottom: 8px;
 }
 
@@ -975,17 +1024,16 @@ img:hover ~ .asset-meta,
 }
 
 .violations-column::-webkit-scrollbar-thumb {
-  background-color: #888;
-  border-radius: 4px;
+  background-color: var(--s2a-color-gray-400);
+  border-radius: var(--s2a-border-radius-4);
 }
 
 /* Toggle Arrow */
 .violation-expand {
   height: 18px;
-  background-image: url('./img/expand.svg');
-  background-repeat: no-repeat;
-  background-position: 50%;
-  background-size: 24px;
+  -webkit-mask: url('./img/expand.svg') no-repeat 50% / 24px;
+  mask: url('./img/expand.svg') no-repeat 50% / 24px;
+  background-color: var(--preflight-text-subtle);
   transition: transform 0.2s ease-in-out;
   transform: rotate(0deg);
 }
@@ -996,17 +1044,17 @@ img:hover ~ .asset-meta,
 
 .success,
 .violations {
-  font-size: 16px;
+  font-size: var(--s2a-font-size-16);
   font-weight: bold;
   margin-bottom: 6px;
 }
 
 .success {
-  color: green;
+  color: var(--preflight-success);
 }
 
 .violations {
-  color: red;
+  color: var(--preflight-error);
 }
 
 .violation-list {
@@ -1022,41 +1070,41 @@ img:hover ~ .asset-meta,
 
 .violation-details {
   padding-left: 20px;
-  font-size: 14px;
-  color: #ddd;
+  font-size: var(--s2a-font-size-14);
+  color: var(--preflight-text-subtle);
 }
 
 .violation-details strong {
-  color: #fff;
+  color: var(--preflight-text);
 }
 
 .violation-link {
-  color: #e6e6e6;
+  color: var(--s2a-color-blue-900);
   text-decoration: underline;
 }
 
 .violation-index {
   font-weight: bold;
   margin-right: 10px;
-  color: #ccc;
+  color: var(--preflight-text-subtle);
 }
 
 .violation-summary {
   display: grid;
   grid-template-columns: 42px 1fr;
   align-items: center;
-  padding: 12px 24px;
+  padding: var(--s2a-spacing-12) var(--s2a-spacing-24);
   cursor: pointer;
 }
 
 .violation-summary:hover {
-  background-color: rgba(255, 255, 255, 5%);
+  background-color: var(--preflight-hover);
 }
 
 .violations-scroll-wrapper {
   max-height: 300px;
   overflow-y: auto;
-  padding-right: 0%;
+  padding-right: 0;
 }
 
 /* Affected Elements */
@@ -1066,8 +1114,8 @@ img:hover ~ .asset-meta,
 }
 
 .affected-elements li {
-  font-size: 14px;
-  color: #eee;
+  font-size: var(--s2a-font-size-14);
+  color: var(--preflight-text-subtle);
 }
 
 /* Severity Colors */
@@ -1076,29 +1124,28 @@ img:hover ~ .asset-meta,
 }
 
 .severity.critical {
-  color: red;
+  color: var(--s2a-color-red-900);
 }
 
 .severity.serious {
-  color: orange;
+  color: var(--s2a-color-orange-700);
 }
 
 .severity.moderate {
-  color: goldenrod;
+  color: var(--s2a-color-yellow-900);
 }
 
 .severity.minor {
-  color: lightgray;
+  color: var(--s2a-color-gray-500);
 }
 
 /* Image Alt section */
 .preflight-full-width {
   grid-column: 1 / -1;
   width: 100%;
-  margin-top: 24px;
+  margin-top: var(--s2a-spacing-24);
   padding-top: 16px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  border-top: 2px rgba(0, 0, 0, 0.2);
+  border-top: 1px solid var(--preflight-border);
 }
 
 .preflight-auth-error {
@@ -1110,45 +1157,46 @@ img:hover ~ .asset-meta,
 
 /* Merch Panel Styles */
 .merch-panel {
-  padding: 24px;
+  padding: var(--s2a-spacing-24);
   overflow-y: auto;
 }
 
 .merch-loading {
   text-align: center;
-  font-size: 18px;
-  padding: 48px;
+  font-size: var(--s2a-font-size-18);
+  padding: var(--s2a-spacing-32);
 }
 
 .merch-summary {
   display: flex;
-  gap: 24px;
-  padding: 24px;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 8px;
-  margin-bottom: 32px;
+  gap: var(--s2a-spacing-24);
+  padding: var(--s2a-spacing-24);
+  background: var(--preflight-surface-subtle);
+  border: 1px solid var(--preflight-border);
+  border-radius: var(--s2a-border-radius-8);
+  margin-bottom: var(--s2a-spacing-32);
 }
 
 .merch-summary.no-blocks {
   flex-direction: column;
   text-align: center;
-  padding: 48px;
+  padding: var(--s2a-spacing-32);
 }
 
 .merch-summary.no-blocks h3 {
-  margin: 0 0 12px;
-  font-size: 24px;
+  margin: 0 0 var(--s2a-spacing-12);
+  font-size: var(--s2a-font-size-24);
 }
 
 .merch-summary.no-blocks p {
   margin: 0;
-  opacity: 0.8;
+  color: var(--preflight-text-subtle);
 }
 
 .merch-help-text {
-  font-size: 14px !important;
-  margin-top: 12px !important;
-  opacity: 0.6 !important;
+  font-size: var(--s2a-font-size-14) !important;
+  margin-top: var(--s2a-spacing-12) !important;
+  color: var(--preflight-text-subtle) !important;
   font-style: italic;
 }
 
@@ -1160,41 +1208,41 @@ img:hover ~ .asset-meta,
 }
 
 .merch-summary-stat.has-errors .merch-stat-number {
-  color: #ff4444;
+  color: var(--preflight-error);
 }
 
 .merch-stat-number {
   font-size: 48px;
-  font-weight: 700;
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
   line-height: 1;
 }
 
 .merch-stat-label {
-  font-size: 14px;
+  font-size: var(--s2a-font-size-14);
   text-transform: uppercase;
-  opacity: 0.7;
+  color: var(--preflight-text-subtle);
 }
 
 .merch-section {
-  margin-bottom: 32px;
+  margin-bottom: var(--s2a-spacing-32);
 }
 
 .merch-section-title {
-  font-size: 20px;
-  font-weight: 700;
+  font-size: var(--s2a-font-size-20);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
   margin: 0 0 16px;
   text-transform: uppercase;
 }
 
 .merch-empty {
-  opacity: 0.6;
+  color: var(--preflight-text-subtle);
   font-style: italic;
 }
 
 .merch-blocks-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--s2a-spacing-12);
 }
 
 .merch-item {
@@ -1202,76 +1250,78 @@ img:hover ~ .asset-meta,
   grid-template-columns: auto 1fr;
   gap: 16px;
   padding: 16px;
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 4px;
+  background: var(--preflight-surface-subtle);
+  border: 1px solid var(--preflight-border);
+  border-radius: var(--s2a-border-radius-4);
   border-left: 4px solid transparent;
 }
 
 .merch-item.merch-success {
-  border-left-color: #4CAF50;
+  border-left-color: var(--preflight-success);
 }
 
 .merch-item.merch-error {
-  border-left-color: #ff4444;
+  border-left-color: var(--preflight-error);
 }
 
 .merch-item.merch-link-item {
-  border-left-color: #1E90FF;
+  border-left-color: var(--s2a-color-blue-700);
 }
 
 .merch-item.merch-wcs-item {
-  border-left-color: #9370DB;
+  border-left-color: var(--s2a-color-blue-1100);
 }
 
 .merch-item.merch-wcs-item.has-url-error {
-  border-left-color: #ff4444;
-  background: rgba(255, 68, 68, 0.05);
+  border-left-color: var(--preflight-error);
+  background: var(--s2a-color-red-100);
 }
 
 .url-status-icon {
   margin-left: 8px;
-  font-size: 18px;
+  font-size: var(--s2a-font-size-18);
 }
 
 .url-checking {
-  color: #FFD700;
+  color: var(--s2a-color-yellow-1000);
   font-style: italic;
 }
 
 .url-error {
-  color: #ff4444;
+  color: var(--preflight-error);
   font-weight: 500;
 }
 
 .url-success {
-  color: #4CAF50;
+  color: var(--preflight-success);
 }
 
 .url-error-message {
-  color: #ff4444;
+  color: var(--preflight-error);
   font-weight: 600;
   display: inline-block;
   margin-top: 4px;
 }
 
 .id-comparison {
-  color: #FFD700;
+  color: var(--s2a-color-yellow-1000);
   font-size: 13px;
   display: block;
   margin-top: 4px;
 }
 
 .wcs-osi-code {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--preflight-surface-subtle);
+  border: 1px solid var(--preflight-border);
   padding: 2px 6px;
-  border-radius: 3px;
-  font-family: 'Courier New', monospace;
+  border-radius: var(--s2a-border-radius-4);
+  font-family: var(--fixed-font-family, 'Courier New', monospace);
   font-size: 13px;
-  color: #FFD700;
+  color: var(--preflight-text);
 }
 
 .merch-icon {
-  font-size: 24px;
+  font-size: var(--s2a-font-size-24);
   margin-right: 8px;
 }
 
@@ -1279,50 +1329,58 @@ img:hover ~ .asset-meta,
   display: flex;
   align-items: center;
   margin: 0 0 8px;
-  font-weight: 700;
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
 }
 
 .merch-item .preflight-item-description {
-  margin: 0 0 12px;
-  opacity: 0.8;
-  font-size: 14px;
+  margin: 0 0 var(--s2a-spacing-12);
+  color: var(--preflight-text-subtle);
+  font-size: var(--s2a-font-size-14);
 }
 
+/* Secondary/outline action — distinct from the primary blue CTAs. */
 .merch-scroll-btn {
   padding: 8px 16px;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: #fff;
-  border-radius: 4px;
+  background: transparent;
+  border: 2px solid var(--preflight-cta-bg);
+  color: var(--preflight-cta-bg);
+  border-radius: var(--s2a-border-radius-16);
   cursor: pointer;
-  font-size: 14px;
+  font-size: var(--s2a-font-size-14);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
   font-family: var(--body-font-family);
-  transition: background 0.2s;
+  transition: background-color 0.2s, color 0.2s;
 }
 
 .merch-scroll-btn:hover {
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--preflight-cta-bg);
+  color: var(--preflight-cta-text);
 }
 
-/* Highlight merch elements with errors on the page */
+.merch-scroll-btn:focus-visible {
+  outline: 2px solid var(--preflight-focus);
+  outline-offset: 2px;
+}
+
+/* Page-injected: highlight merch elements with errors on the live page. */
 .preflight-merch-error {
-  outline: 3px solid #ff4444 !important;
+  outline: 3px solid var(--s2a-color-red-800) !important;
   outline-offset: 2px !important;
 }
 
-/* Highlight blocks with multiple M@S fragment IDs (M@S preflight warning) */
+/* Page-injected: blocks with multiple M@S fragment IDs (preflight warning). */
 .preflight-mas-multiple-fragments {
-  border: 3px solid #e68600 !important;
+  border: 3px solid var(--s2a-color-orange-700) !important;
 }
 
-/* Highlight cards whose M@S fragment is unpublished */
+/* Page-injected: cards whose M@S fragment is unpublished. */
 .preflight-mas-unpublished {
   position: relative !important;
-  outline: 4px solid #f44 !important;
+  outline: 4px solid var(--s2a-color-red-800) !important;
   background-image: repeating-linear-gradient(
     135deg,
-    rgb(255 68 68 / 8%) 0,
-    rgb(255 68 68 / 8%) 8px,
+    rgb(240 56 35 / 8%) 0,
+    rgb(240 56 35 / 8%) 8px,
     transparent 8px,
     transparent 16px
   ) !important;
@@ -1335,15 +1393,15 @@ img:hover ~ .asset-meta,
   right: -1px;
   z-index: 2;
   padding: 4px 10px;
-  background: #f44;
-  color: #fff;
+  background: var(--s2a-color-red-800);
+  color: var(--s2a-color-gray-25);
   font-family: var(--body-font-family);
-  font-size: 12px;
+  font-size: var(--s2a-font-size-12, 12px);
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  border-top-right-radius: 8px;
-  border-bottom-left-radius: 8px;
+  border-top-right-radius: var(--s2a-border-radius-8);
+  border-bottom-left-radius: var(--s2a-border-radius-8);
   box-shadow: 0 1px 4px rgb(0 0 0 / 20%);
   pointer-events: none;
   line-height: 2.5;
@@ -1359,5 +1417,5 @@ img:hover ~ .asset-meta,
 }
 
 .dialog-modal#preflight .dialog-close line {
-  stroke: var(--color-white, #fff);
+  stroke: var(--s2a-color-gray-25);
 }

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -1020,13 +1020,71 @@ img:hover ~ .asset-meta,
 }
 
 .preflight .martech {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: block;
 }
 
 .preflight .martech .preflight-action {
   cursor: pointer;
+  flex-shrink: 0;
+}
+
+.martech-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s2a-spacing-16);
+  margin-bottom: var(--s2a-spacing-16);
+}
+
+.martech-hint {
+  margin: 0;
+  font-size: var(--s2a-font-size-14);
+  color: var(--preflight-text-subtle);
+}
+
+.martech-table {
+  overflow-x: auto;
+  border: 1px solid var(--preflight-border);
+  border-radius: var(--s2a-border-radius-12);
+}
+
+.dialog-modal#preflight .martech-table table {
+  width: 100%;
+  border: none;
+  background: var(--preflight-surface);
+}
+
+.dialog-modal#preflight .martech-table th,
+.dialog-modal#preflight .martech-table td {
+  text-align: left;
+  padding: var(--s2a-spacing-12) var(--s2a-spacing-16);
+  border-bottom: 1px solid var(--preflight-border);
+  vertical-align: top;
+}
+
+.dialog-modal#preflight .martech-table th {
+  background: var(--preflight-surface-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: var(--s2a-font-size-12);
+  color: var(--preflight-text-subtle);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+}
+
+.dialog-modal#preflight .martech-table tr:last-child td {
+  border-bottom: none;
+}
+
+.dialog-modal#preflight .martech-table tr:hover td {
+  background: var(--preflight-hover);
+}
+
+.dialog-modal#preflight .martech-table td h3 {
+  margin: 0;
+  font-size: var(--s2a-font-size-14);
+  font-weight: var(--s2a-font-weight-adobe-clean-regular);
+  line-height: 1.4;
+  font-family: var(--body-font-family);
 }
 
 .dialog-modal#preflight table {
@@ -1619,6 +1677,11 @@ img:hover ~ .asset-meta,
 
   .preflight-structure-title {
     padding-left: var(--s2a-spacing-16);
+  }
+
+  .martech-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .accessibility-columns {

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -12,7 +12,8 @@
 
 .preflight {
   display: grid;
-  grid-template-columns: 256px 1fr;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto 1fr;
   position: relative;
   z-index: 0;
 }
@@ -21,8 +22,8 @@
   /* Local aliases (modal-scoped) → c2 semantic/primitive tokens. */
   --preflight-surface: var(--s2a-color-background-default);
   --preflight-surface-subtle: var(--s2a-color-background-subtle);
-  --preflight-text: var(--s2a-color-content-default);
-  --preflight-text-subtle: var(--s2a-color-content-subtle);
+  --preflight-fg: var(--s2a-color-content-default);
+  --preflight-fg-subtle: var(--s2a-color-content-subtle);
   --preflight-border: var(--s2a-color-border-subtle);
   --preflight-hover: var(--s2a-color-transparent-black-08);
   --preflight-cta-bg: var(--s2a-color-blue-900);
@@ -38,7 +39,7 @@
   height: 680px;
   max-height: calc(100vh - 40px);
   background: var(--preflight-surface);
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
   font-family: var(--body-font-family);
   overflow: hidden;
   box-shadow: 0 16px 48px var(--s2a-color-transparent-black-32);
@@ -52,18 +53,20 @@
 }
 
 .preflight-tab-panel a {
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
 }
 
 /* ---- Left navigation rail ---- */
 .preflight-sidebar {
   display: flex;
   flex-direction: column;
-  gap: var(--s2a-spacing-24);
+  gap: var(--s2a-spacing-12);
   padding: var(--s2a-spacing-24) var(--s2a-spacing-16);
   background: var(--preflight-surface-subtle);
-  border-right: 1px solid var(--preflight-border);
-  overflow-y: auto;
+  border-inline-end: none;
+  border-block-end: 1px solid var(--preflight-border);
+  min-width: 0;
+  overflow: visible;
 }
 
 .preflight-brand {
@@ -75,20 +78,21 @@ p#preflight-title {
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
   font-size: var(--s2a-font-size-20);
   line-height: 1.15;
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
 }
 
 .preflight-subtitle {
   margin: 4px 0 0;
   font-size: var(--s2a-font-size-12);
   line-height: 1.35;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .preflight-tab-button-group {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  flex-flow: row wrap;
+  gap: 4px var(--s2a-spacing-8);
+  min-width: 0;
   margin: 0;
 }
 
@@ -96,14 +100,16 @@ button.preflight-tab-button {
   display: flex;
   align-items: center;
   gap: var(--s2a-spacing-12);
-  width: 100%;
+  width: auto;
+  flex: 0 0 auto;
+  white-space: nowrap;
   border: none;
   background: none;
   font-family: var(--body-font-family);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
   font-size: var(--s2a-font-size-14);
   font-weight: var(--s2a-font-weight-adobe-clean-medium);
-  text-align: left;
+  text-align: start;
   margin: 0;
   padding: 9px var(--s2a-spacing-12);
   line-height: 1.1;
@@ -150,7 +156,7 @@ button.preflight-tab-button {
 
 button.preflight-tab-button:hover {
   background: var(--s2a-color-transparent-black-04);
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
 }
 
 button.preflight-tab-button[aria-selected="true"] {
@@ -161,9 +167,10 @@ button.preflight-tab-button[aria-selected="true"] {
 }
 
 button.preflight-tab-button[aria-selected="true"]::before {
+  display: none;
   content: '';
   position: absolute;
-  left: 0;
+  inset-inline-start: 0;
   top: 50%;
   transform: translateY(-50%);
   width: 3px;
@@ -187,6 +194,7 @@ button.preflight-tab-button:focus-visible {
 }
 
 .preflight-main-header {
+  display: none;
   padding: var(--s2a-spacing-24) var(--s2a-spacing-32);
   border-bottom: 1px solid var(--preflight-border);
 }
@@ -201,7 +209,7 @@ button.preflight-tab-button:focus-visible {
 .preflight-main-desc {
   margin: 4px 0 0;
   font-size: var(--s2a-font-size-14);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .preflight-content {
@@ -224,7 +232,7 @@ p.preflight-content-heading {
   text-transform: uppercase;
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
   font-size: var(--s2a-font-size-14);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
   letter-spacing: 0.04em;
 }
 
@@ -249,7 +257,7 @@ p.preflight-content-heading-edit {
   height: 18px;
   -webkit-mask: url('./img/expand.svg') no-repeat 50% / 24px;
   mask: url('./img/expand.svg') no-repeat 50% / 24px;
-  background-color: var(--preflight-text-subtle);
+  background-color: var(--preflight-fg-subtle);
   transition: transform .2s ease-in-out;
   transform: rotate(90deg);
 }
@@ -260,6 +268,7 @@ p.preflight-content-heading-edit {
 
 .preflight-content-group {
   margin-bottom: var(--s2a-spacing-24);
+  overflow-x: auto;
 }
 
 .preflight-group-row.preflight-group-detail {
@@ -319,7 +328,7 @@ p.preflight-content-heading-edit {
   box-sizing: border-box;
   width: 22px;
   height: 22px;
-  left: 23px;
+  inset-inline-start: 23px;
   top: 50%;
   bottom: auto;
   transform: translateY(-50%);
@@ -374,7 +383,7 @@ p.preflight-date-wrapper {
 
 p.preflight-date-wrapper .disabled-publish {
   font-size: 0.8em;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .preflight-group-row p {
@@ -383,12 +392,12 @@ p.preflight-date-wrapper .disabled-publish {
 }
 
 .preflight-group-row a {
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
 }
 
 span.preflight-time {
   font-size: var(--s2a-font-size-14);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .preflight-actions {
@@ -494,8 +503,8 @@ span.preflight-time {
   line-height: 1.1;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--preflight-text-subtle);
-  padding-left: var(--s2a-spacing-32);
+  color: var(--preflight-fg-subtle);
+  padding-inline-start: var(--s2a-spacing-16);
 }
 
 /* Add separation between successive sections in the General panel. */
@@ -505,18 +514,18 @@ span.preflight-time {
 }
 
 .preflight-structure-columns {
-  margin: 0 var(--s2a-spacing-32) var(--s2a-spacing-24);
+  margin: 0 var(--s2a-spacing-16) var(--s2a-spacing-24);
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--s2a-spacing-32);
+  grid-template-columns: 1fr;
+  gap: var(--s2a-spacing-16);
 }
 
 /* SEO */
 .preflight-columns {
-  margin: var(--s2a-spacing-24) var(--s2a-spacing-32) 0;
+  margin: var(--s2a-spacing-24) var(--s2a-spacing-16) 0;
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--s2a-spacing-32);
+  grid-template-columns: 1fr;
+  gap: var(--s2a-spacing-16);
 }
 
 .preflight-item {
@@ -602,11 +611,12 @@ span.preflight-time {
 
 .preflight-item-description {
   margin: 0;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .problem-links {
-  margin: var(--s2a-spacing-24) var(--s2a-spacing-32);
+  margin: var(--s2a-spacing-24) var(--s2a-spacing-16);
+  overflow-x: auto;
 }
 
 .problem-links .title {
@@ -615,7 +625,7 @@ span.preflight-time {
 
 .problem-links .note {
   margin-top: 20px;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .dialog-modal#preflight .problem-links table {
@@ -629,11 +639,11 @@ span.preflight-time {
   text-transform: uppercase;
   width: 10%;
   font-size: var(--s2a-font-size-14);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .dialog-modal#preflight .problem-links table td a {
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
   display: inline-block;
   overflow-x: scroll;
   position: absolute;
@@ -724,7 +734,7 @@ span.preflight-time {
 }
 
 .access-columns .grid-toggle {
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
   font-size: var(--s2a-font-size-12);
   letter-spacing: 0.06em;
@@ -751,7 +761,7 @@ span.preflight-time {
 
 .access-item-description {
   margin: 10px 0 var(--s2a-spacing-32);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .access-image-grid {
@@ -806,7 +816,7 @@ span.preflight-time {
 
 .access-image-grid-item span:last-child {
   font-weight: initial;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
   margin-top: 0;
 }
 
@@ -835,7 +845,7 @@ body.preflight-assets-analysis {
 }
 
 .assets-columns .grid-toggle {
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
   font-size: var(--s2a-font-size-12);
   letter-spacing: 0.06em;
@@ -861,7 +871,7 @@ body.preflight-assets-analysis {
 
 .assets-item-description {
   margin: 0;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .assets-image-grid {
@@ -930,7 +940,7 @@ body.preflight-assets-analysis {
   grid-column: 1 / -1;
   padding: var(--s2a-spacing-16);
   text-align: center;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .assets-image-grid-item-text {
@@ -949,12 +959,12 @@ body.preflight-assets-analysis {
 }
 
 .asset-metric-label {
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .asset-metric-value {
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
-  text-align: right;
+  text-align: end;
 }
 
 .asset-metric.is-recommended .asset-metric-value {
@@ -964,7 +974,7 @@ body.preflight-assets-analysis {
 .asset-note {
   margin: 0;
   font-size: var(--s2a-font-size-12);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
   line-height: 1.4;
 }
 
@@ -1060,7 +1070,7 @@ picture:has(.asset-meta),
 .asset-meta.no-picture-tag {
   position: absolute;
   top: 30px;
-  left: 0;
+  inset-inline-start: 0;
   width: max-content;
   max-width: calc(100% - 20px);
 }
@@ -1120,7 +1130,8 @@ img:hover ~ .asset-meta,
 
 .martech-toolbar {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   justify-content: space-between;
   gap: var(--s2a-spacing-16);
   margin-bottom: var(--s2a-spacing-16);
@@ -1129,7 +1140,7 @@ img:hover ~ .asset-meta,
 .martech-hint {
   margin: 0;
   font-size: var(--s2a-font-size-14);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .martech-table {
@@ -1146,7 +1157,7 @@ img:hover ~ .asset-meta,
 
 .dialog-modal#preflight .martech-table th,
 .dialog-modal#preflight .martech-table td {
-  text-align: left;
+  text-align: start;
   padding: var(--s2a-spacing-12) var(--s2a-spacing-16);
   border-bottom: 1px solid var(--preflight-border);
   vertical-align: top;
@@ -1157,7 +1168,7 @@ img:hover ~ .asset-meta,
   text-transform: uppercase;
   letter-spacing: 0.06em;
   font-size: var(--s2a-font-size-12);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
 }
 
@@ -1214,7 +1225,7 @@ img:hover ~ .asset-meta,
 }
 
 .performance-no-lcp {
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 /* Page-injected: highlight + return popover when jumping to an asset. */
@@ -1227,18 +1238,18 @@ img:hover ~ .asset-meta,
 .preflight-return-popover {
   position: fixed;
   top: var(--s2a-spacing-16);
-  left: var(--s2a-spacing-16);
-  z-index: 10000;
+  inset-inline-start: var(--s2a-spacing-16);
+  z-index: 9999;
   display: flex;
   align-items: center;
   gap: var(--s2a-spacing-12);
   max-width: calc(100vw - 32px);
   padding: var(--s2a-spacing-8) var(--s2a-spacing-8) var(--s2a-spacing-8) var(--s2a-spacing-16);
-  background: var(--s2a-color-background-default, #fff);
-  color: var(--s2a-color-content-default, #131313);
-  border: 1px solid var(--s2a-color-border-subtle, #dadada);
-  border-radius: var(--s2a-border-radius-999, 999px);
-  box-shadow: 0 8px 24px var(--s2a-color-transparent-black-24, rgb(0 0 0 / 24%));
+  background: var(--s2a-color-background-default);
+  color: var(--s2a-color-content-default);
+  border: 1px solid var(--s2a-color-border-subtle);
+  border-radius: var(--s2a-border-radius-999);
+  box-shadow: 0 8px 24px var(--s2a-color-transparent-black-24);
   font-family: var(--body-font-family);
   font-size: var(--s2a-font-size-14);
 }
@@ -1319,7 +1330,7 @@ img:hover ~ .asset-meta,
   display: flex;
   margin: 0;
   font-style: italic;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .ai-suggestion .result-icon {
@@ -1331,8 +1342,9 @@ img:hover ~ .asset-meta,
 /* Accessibility Tab */
 .accessibility-columns {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: var(--s2a-spacing-24);
+  grid-template-columns: 1fr;
+  gap: var(--s2a-spacing-16);
+  margin-inline: var(--s2a-spacing-16);
   align-items: start;
 }
 
@@ -1375,7 +1387,7 @@ img:hover ~ .asset-meta,
 .preflight-accessibility-note {
   margin-top: var(--s2a-spacing-12);
   font-size: var(--s2a-font-size-12);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
   line-height: 1.5;
   font-style: italic;
 }
@@ -1401,7 +1413,7 @@ img:hover ~ .asset-meta,
   height: 18px;
   -webkit-mask: url('./img/expand.svg') no-repeat 50% / 24px;
   mask: url('./img/expand.svg') no-repeat 50% / 24px;
-  background-color: var(--preflight-text-subtle);
+  background-color: var(--preflight-fg-subtle);
   transition: transform 0.2s ease-in-out;
   transform: rotate(0deg);
 }
@@ -1445,18 +1457,18 @@ img:hover ~ .asset-meta,
   letter-spacing: 0;
   font-size: var(--s2a-font-size-14);
   font-weight: var(--s2a-font-weight-adobe-clean-regular);
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
   line-height: 1.4;
 }
 
 .violation-details {
   padding: 0 var(--s2a-spacing-8) var(--s2a-spacing-8) var(--s2a-spacing-32);
   font-size: var(--s2a-font-size-14);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .violation-details strong {
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
 }
 
 .violation-link {
@@ -1467,7 +1479,7 @@ img:hover ~ .asset-meta,
 .violation-index {
   font-weight: bold;
   margin-right: 10px;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .violation-summary {
@@ -1503,7 +1515,7 @@ img:hover ~ .asset-meta,
 
 .affected-elements li {
   font-size: var(--s2a-font-size-14);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 /* Severity Colors */
@@ -1576,13 +1588,13 @@ img:hover ~ .asset-meta,
 
 .merch-summary.no-blocks p {
   margin: 0;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .merch-help-text {
   font-size: var(--s2a-font-size-14) !important;
   margin-top: var(--s2a-spacing-12) !important;
-  color: var(--preflight-text-subtle) !important;
+  color: var(--preflight-fg-subtle) !important;
   font-style: italic;
 }
 
@@ -1606,7 +1618,7 @@ img:hover ~ .asset-meta,
 .merch-stat-label {
   font-size: var(--s2a-font-size-14);
   text-transform: uppercase;
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
 }
 
 .merch-section {
@@ -1621,7 +1633,7 @@ img:hover ~ .asset-meta,
 }
 
 .merch-empty {
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
   font-style: italic;
 }
 
@@ -1703,7 +1715,7 @@ img:hover ~ .asset-meta,
   border-radius: var(--s2a-border-radius-4);
   font-family: var(--fixed-font-family, 'Courier New', monospace);
   font-size: 13px;
-  color: var(--preflight-text);
+  color: var(--preflight-fg);
 }
 
 .merch-icon {
@@ -1720,7 +1732,7 @@ img:hover ~ .asset-meta,
 
 .merch-item .preflight-item-description {
   margin: 0 0 var(--s2a-spacing-12);
-  color: var(--preflight-text-subtle);
+  color: var(--preflight-fg-subtle);
   font-size: var(--s2a-font-size-14);
 }
 
@@ -1806,80 +1818,80 @@ img:hover ~ .asset-meta,
   stroke: var(--s2a-color-gray-25);
 }
 
-/* Responsive layout uses Milo's standard breakpoints (600 / 900 / 1200). */
+/* Responsive layout — mobile-first. */
 
-/* Tablet/desktop below large: too narrow for two-up cards — single column,
-   keep the navigation rail. */
-@media (max-width: 1199px) {
-  .preflight-structure-columns,
-  .preflight-columns,
-  .accessibility-columns {
-    grid-template-columns: 1fr;
-  }
-
-  .accessibility-columns {
-    height: auto;
-  }
-
-  /* Fixed-width content/link tables scroll within themselves so they don't
-     force the whole panel wide and clip the cards above. */
-  .preflight-content-group,
-  .problem-links {
-    overflow-x: auto;
-  }
-}
-
-/* Mobile + tablet: collapse the rail into a horizontal top nav. */
-@media (max-width: 899px) {
+/* Tablet/desktop: restore the sidebar rail and two-column layouts. */
+@media (min-width: 900px) {
   .preflight {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto 1fr;
+    grid-template-columns: 256px 1fr;
+    grid-template-rows: 1fr;
   }
 
   .preflight-sidebar {
-    border-right: none;
-    border-bottom: 1px solid var(--preflight-border);
-    gap: var(--s2a-spacing-12);
-    min-width: 0;
-    overflow: visible;
+    border-inline-end: 1px solid var(--preflight-border);
+    border-block-end: none;
+    gap: var(--s2a-spacing-24);
+    min-width: initial;
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 
-  /* Wrap the tabs so every one is reachable without horizontal scrolling
-     (scrolling a top nav isn't discoverable with a mouse). */
+  /* Vertical column layout with individual tab buttons filling the rail. */
   .preflight-tab-button-group {
-    flex-flow: row wrap;
-    gap: 4px var(--s2a-spacing-8);
-    min-width: 0;
+    flex-flow: column;
+    gap: 2px;
+    min-width: initial;
   }
 
   button.preflight-tab-button {
-    width: auto;
-    flex: 0 0 auto;
-    white-space: nowrap;
+    width: 100%;
+    flex: initial;
+    white-space: normal;
   }
 
+  /* Active indicator strip on the inline-start edge of the selected tab. */
   button.preflight-tab-button[aria-selected="true"]::before {
-    display: none;
+    display: block;
   }
 
   .preflight-main-header {
-    display: none;
+    display: block;
   }
 
-  .preflight-structure-columns,
-  .preflight-columns,
-  .accessibility-columns {
-    gap: var(--s2a-spacing-16);
-    margin-left: var(--s2a-spacing-16);
-    margin-right: var(--s2a-spacing-16);
+  .preflight-structure-columns {
+    margin-inline: var(--s2a-spacing-32);
+    gap: var(--s2a-spacing-32);
+  }
+
+  .preflight-columns {
+    margin-inline: var(--s2a-spacing-32);
+    gap: var(--s2a-spacing-32);
   }
 
   .preflight-structure-title {
-    padding-left: var(--s2a-spacing-16);
+    padding-inline-start: var(--s2a-spacing-32);
+  }
+
+  .accessibility-columns {
+    gap: var(--s2a-spacing-24);
+    margin-inline: 0;
+  }
+
+  .problem-links {
+    margin-inline: var(--s2a-spacing-32);
   }
 
   .martech-toolbar {
-    flex-direction: column;
-    align-items: flex-start;
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+/* Large desktop: two-up card layout. */
+@media (min-width: 1200px) {
+  .preflight-structure-columns,
+  .preflight-columns,
+  .accessibility-columns {
+    grid-template-columns: 1fr 1fr;
   }
 }

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -717,7 +717,7 @@ span.preflight-time {
 
 /* Accessibility css */
 .access-columns {
-  margin: var(--s2a-spacing-24) var(--s2a-spacing-32);
+  margin: var(--s2a-spacing-24) var(--s2a-spacing-16);
   gap: var(--s2a-spacing-32);
 }
 
@@ -1874,7 +1874,10 @@ img:hover ~ .asset-meta,
 
   .accessibility-columns {
     gap: var(--s2a-spacing-24);
-    margin-inline: 0;
+  }
+
+  .access-columns {
+    margin-inline: var(--s2a-spacing-32);
   }
 
   .problem-links {

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -1225,10 +1225,7 @@ img:hover ~ .asset-meta,
 }
 
 .preflight-return-popover {
-  position: fixed;
-  bottom: var(--s2a-spacing-24);
-  left: 50%;
-  transform: translateX(-50%);
+  position: absolute;
   z-index: 1000;
   display: flex;
   align-items: center;

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -892,6 +892,7 @@ body.preflight-assets-analysis {
   object-fit: contain;
   box-sizing: border-box;
   border-bottom: 1px solid var(--preflight-border);
+  transition: transform 0.2s ease;
   background-color: var(--s2a-color-gray-100);
   background-image:
     linear-gradient(45deg, var(--s2a-color-gray-200) 25%, transparent 25%),
@@ -904,6 +905,20 @@ body.preflight-assets-analysis {
 
 .assets-image-grid-item iframe {
   border: none;
+}
+
+/* Cards are clickable: jump to the asset on the page. */
+.assets-image-grid-item[role="button"] {
+  cursor: pointer;
+}
+
+.assets-image-grid-item[role="button"]:focus-visible {
+  outline: 2px solid var(--preflight-focus);
+  outline-offset: 2px;
+}
+
+.assets-image-grid-item[role="button"]:hover > :is(img, video, iframe) {
+  transform: scale(1.08);
 }
 
 .assets-image-grid-item.above-fold-critical {
@@ -1196,6 +1211,17 @@ img:hover ~ .asset-meta,
 
 .performance-element-preview:hover {
   text-decoration: none;
+}
+
+.performance-no-lcp {
+  color: var(--preflight-text-subtle);
+}
+
+/* Page-injected: transient highlight when jumping to an asset from the modal. */
+.preflight-asset-highlight {
+  outline: 4px solid var(--s2a-color-blue-900) !important;
+  outline-offset: 3px !important;
+  scroll-margin: 100px;
 }
 
 /* Page-injected: LCP element preview box (outside modal). */
@@ -1733,7 +1759,7 @@ img:hover ~ .asset-meta,
 /* Mobile + tablet: collapse the rail into a horizontal top nav. */
 @media (max-width: 899px) {
   .preflight {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto 1fr;
   }
 
@@ -1741,17 +1767,21 @@ img:hover ~ .asset-meta,
     border-right: none;
     border-bottom: 1px solid var(--preflight-border);
     gap: var(--s2a-spacing-12);
+    min-width: 0;
+    overflow: visible;
   }
 
   .preflight-tab-button-group {
-    flex-direction: row;
+    flex-flow: row nowrap;
     overflow-x: auto;
     gap: 4px;
+    min-width: 0;
     scrollbar-width: none;
   }
 
   button.preflight-tab-button {
     width: auto;
+    flex: 0 0 auto;
     white-space: nowrap;
   }
 

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -1225,8 +1225,10 @@ img:hover ~ .asset-meta,
 }
 
 .preflight-return-popover {
-  position: absolute;
-  z-index: 1000;
+  position: fixed;
+  top: var(--s2a-spacing-16);
+  left: var(--s2a-spacing-16);
+  z-index: 10000;
   display: flex;
   align-items: center;
   gap: var(--s2a-spacing-12);

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -12,7 +12,7 @@
 
 .preflight {
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-columns: 256px 1fr;
   position: relative;
   z-index: 0;
 }
@@ -41,88 +41,150 @@
   color: var(--preflight-text);
   font-family: var(--body-font-family);
   overflow: hidden;
+  box-shadow: 0 16px 48px var(--s2a-color-transparent-black-32);
 }
 
 .preflight-tab-panel {
   display: grid;
   grid-template-rows: 1fr;
+  grid-template-columns: minmax(0, 1fr);
+  min-width: 0;
 }
 
 .preflight-tab-panel a {
   color: var(--preflight-text);
 }
 
-.preflight-heading {
+/* ---- Left navigation rail ---- */
+.preflight-sidebar {
   display: flex;
   flex-direction: column;
-  gap: var(--s2a-spacing-12);
-  padding: var(--s2a-spacing-24) var(--s2a-spacing-32) 0;
-  border-bottom: 1px solid var(--preflight-border);
-  background: var(--preflight-surface);
+  gap: var(--s2a-spacing-24);
+  padding: var(--s2a-spacing-24) var(--s2a-spacing-16);
+  background: var(--preflight-surface-subtle);
+  border-right: 1px solid var(--preflight-border);
+  overflow-y: auto;
 }
 
-.preflight-content {
-  display: grid;
-  overflow-x: hidden;
-  overflow-y: auto;
+.preflight-brand {
+  padding: 0 var(--s2a-spacing-12);
 }
 
 p#preflight-title {
   margin: 0;
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
-  font-size: var(--s2a-font-size-24);
-  line-height: 1.1;
+  font-size: var(--s2a-font-size-20);
+  line-height: 1.15;
   color: var(--preflight-text);
 }
 
-div.preflight-tab-button-group {
+.preflight-subtitle {
+  margin: 4px 0 0;
+  font-size: var(--s2a-font-size-12);
+  line-height: 1.35;
+  color: var(--preflight-text-subtle);
+}
+
+.preflight-tab-button-group {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--s2a-spacing-24);
+  flex-direction: column;
+  gap: 2px;
   margin: 0;
 }
 
 button.preflight-tab-button {
+  display: flex;
+  align-items: center;
+  gap: var(--s2a-spacing-12);
+  width: 100%;
   border: none;
   background: none;
   font-family: var(--body-font-family);
   color: var(--preflight-text-subtle);
-  font-size: var(--s2a-font-size-16);
+  font-size: var(--s2a-font-size-14);
   font-weight: var(--s2a-font-weight-adobe-clean-medium);
+  text-align: left;
   margin: 0;
-  padding: 0 0 var(--s2a-spacing-12);
-  line-height: 1;
-  display: block;
+  padding: 9px var(--s2a-spacing-12);
+  line-height: 1.1;
+  border-radius: var(--s2a-border-radius-8);
   position: relative;
   cursor: pointer;
-  transition: color 200ms;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.preflight-tab-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.preflight-tab-icon svg {
+  width: 20px;
+  height: 20px;
+  display: block;
 }
 
 button.preflight-tab-button:hover {
+  background: var(--s2a-color-transparent-black-04);
   color: var(--preflight-text);
 }
 
 button.preflight-tab-button[aria-selected="true"] {
-  color: var(--preflight-text);
+  background: var(--preflight-surface);
+  color: var(--s2a-color-blue-900);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  box-shadow: 0 1px 4px var(--s2a-color-transparent-black-08);
 }
 
-button.preflight-tab-button[aria-selected="true"]::after {
-  display: block;
+button.preflight-tab-button[aria-selected="true"]::before {
   content: '';
-  height: 2px;
-  background: var(--preflight-cta-bg);
   position: absolute;
-  bottom: -1px;
   left: 0;
-  width: 100%;
-  border-radius: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 18px;
+  border-radius: 0 3px 3px 0;
+  background: var(--s2a-color-blue-900);
 }
 
 button.preflight-tab-button:focus-visible {
   outline: 2px solid var(--preflight-focus);
   outline-offset: 2px;
-  border-radius: 2px;
+}
+
+/* ---- Main content area ---- */
+.preflight-main {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.preflight-main-header {
+  padding: var(--s2a-spacing-24) var(--s2a-spacing-32);
+  border-bottom: 1px solid var(--preflight-border);
+}
+
+.preflight-main-title {
+  margin: 0;
+  font-size: var(--s2a-font-size-24);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  line-height: 1.1;
+}
+
+.preflight-main-desc {
+  margin: 4px 0 0;
+  font-size: var(--s2a-font-size-14);
+  color: var(--preflight-text-subtle);
+}
+
+.preflight-content {
+  display: grid;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 div.preflight-tab-panel[aria-selected="false"] {
@@ -130,6 +192,7 @@ div.preflight-tab-panel[aria-selected="false"] {
 }
 
 .preflight-general-content {
+  padding-top: var(--s2a-spacing-24);
   margin-bottom: 72px;
 }
 
@@ -223,10 +286,20 @@ p.preflight-content-heading-edit {
 }
 
 .preflight-group-row.preflight-group-detail.is-fetching::before {
-  -webkit-mask-image: url('./img/purple-working.svg');
-  mask-image: url('./img/purple-working.svg');
-  background-color: var(--preflight-cta-bg);
-  animation: spin 2s linear infinite;
+  -webkit-mask: none;
+  mask: none;
+  background: none;
+  border: 3px solid var(--s2a-color-blue-200);
+  border-top-color: var(--s2a-color-blue-900);
+  border-radius: 50%;
+  box-sizing: border-box;
+  width: 22px;
+  height: 22px;
+  left: 23px;
+  top: 50%;
+  bottom: auto;
+  transform: translateY(-50%);
+  animation: spin 0.8s linear infinite;
 }
 
 a.preflight-edit {
@@ -304,7 +377,9 @@ span.preflight-time {
   left: 0;
   right: 0;
   padding: var(--s2a-spacing-24) var(--s2a-spacing-32);
-  background: linear-gradient(0deg, var(--preflight-surface) 60%, rgb(255 255 255 / 0%) 100%);
+  background: var(--preflight-surface);
+  border-top: 1px solid var(--preflight-border);
+  box-shadow: 0 -4px 16px var(--s2a-color-transparent-black-08);
 }
 
 #select-action {
@@ -395,11 +470,20 @@ span.preflight-time {
 
 /* GENERAL */
 .preflight-structure-title {
-  margin: 0 0 var(--s2a-spacing-24);
+  margin: 0 0 var(--s2a-spacing-16);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
-  font-size: var(--s2a-font-size-20);
+  font-size: var(--s2a-font-size-12);
   line-height: 1.1;
-  padding-left: var(--s2a-spacing-24);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--preflight-text-subtle);
+  padding-left: var(--s2a-spacing-32);
+}
+
+/* Add separation between successive sections in the General panel. */
+.preflight-structure-columns + .preflight-structure-title,
+.preflight-content-group + .preflight-structure-title {
+  margin-top: var(--s2a-spacing-32);
 }
 
 .preflight-structure-columns {
@@ -418,36 +502,50 @@ span.preflight-time {
 }
 
 .preflight-item {
-  margin-bottom: var(--s2a-spacing-32);
+  margin-bottom: var(--s2a-spacing-16);
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: var(--s2a-spacing-12);
+  gap: var(--s2a-spacing-16);
   align-items: center;
+  padding: var(--s2a-spacing-16);
+  background: var(--preflight-surface-subtle);
+  border: 1px solid var(--preflight-border);
+  border-radius: var(--s2a-border-radius-12);
+  transition: box-shadow 0.2s, border-color 0.2s;
+}
+
+.preflight-item:hover {
+  border-color: var(--s2a-color-gray-400);
+  box-shadow: 0 var(--s2a-shadow-level-2-y) var(--s2a-shadow-level-2-blur) var(--s2a-shadow-level-2-color);
 }
 
 .preflight-item:last-child {
   margin-bottom: 0;
 }
 
+/* Status indicators as tonal circular chips (Spectrum-style). */
 .result-icon {
-  width: 48px;
-  height: 48px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
   background-repeat: no-repeat;
-  background-size: 48px;
+  background-position: center;
+  background-size: 26px;
   flex-shrink: 0;
+  box-sizing: border-box;
 }
 
+/* Clean progress ring for the loading state. */
 .result-icon.purple {
-  -webkit-mask: url('./img/purple-working.svg') no-repeat 50% / 48px;
-  mask: url('./img/purple-working.svg') no-repeat 50% / 48px;
-  background-color: var(--preflight-cta-bg);
-  animation: spin 2s linear infinite;
+  background: none;
+  border: 4px solid var(--s2a-color-blue-200);
+  border-top-color: var(--s2a-color-blue-900);
+  animation: spin 0.8s linear infinite;
 }
 
 .result-icon.empty {
-  -webkit-mask: url('./img/empty.svg') no-repeat 50% / 48px;
-  mask: url('./img/empty.svg') no-repeat 50% / 48px;
-  background-color: var(--s2a-color-gray-300);
+  background-color: var(--s2a-color-gray-100);
+  box-shadow: inset 0 0 0 2px var(--s2a-color-gray-300);
 }
 
 @keyframes spin {
@@ -459,18 +557,22 @@ span.preflight-time {
 
 .result-icon.green {
   background-image: url('./img/green-check.svg');
+  background-color: var(--s2a-color-green-100);
 }
 
 .result-icon.red {
   background-image: url('./img/red-error.svg');
+  background-color: var(--s2a-color-red-100);
 }
 
 .result-icon.orange {
   background-image: url('./img/orange-limbo.svg');
+  background-color: var(--s2a-color-orange-100);
 }
 
 .result-icon.alt-text {
   background-image: url('./img/alt-text-blue.png');
+  background-color: var(--s2a-color-blue-100);
 }
 
 .preflight-item-title {
@@ -606,7 +708,10 @@ span.preflight-time {
 .access-columns .grid-toggle {
   color: var(--preflight-text);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  font-size: var(--s2a-font-size-12);
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+  text-decoration: none;
   display: grid;
   grid-template-columns: 42px 1fr;
   align-items: center;
@@ -714,7 +819,10 @@ body.preflight-assets-analysis {
 .assets-columns .grid-toggle {
   color: var(--preflight-text);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  font-size: var(--s2a-font-size-12);
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+  text-decoration: none;
   display: flex;
   align-items: center;
 }
@@ -985,27 +1093,56 @@ img:hover ~ .asset-meta,
 .ai-suggestion .result-icon {
   width: 30px;
   height: 30px;
-  background-size: contain;
+  background-size: 18px;
 }
 
 /* Accessibility Tab */
 .accessibility-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--s2a-spacing-32);
-  height: 280px;
+  gap: var(--s2a-spacing-24);
+  align-items: start;
+}
+
+/* The summary and violations blocks read as cards, matching the other tabs. */
+.accessibility-columns .preflight-content-group {
+  margin-bottom: 0;
+  padding: var(--s2a-spacing-20) var(--s2a-spacing-24);
+  background: var(--preflight-surface-subtle);
+  border: 1px solid var(--preflight-border);
+  border-radius: var(--s2a-border-radius-12);
 }
 
 .preflight-accessibility-item {
-  margin-bottom: var(--s2a-spacing-12);
+  margin-bottom: 0;
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: var(--s2a-spacing-12);
+  gap: var(--s2a-spacing-16);
+  align-items: start;
+}
+
+.summary-list {
+  list-style: none;
+  margin: var(--s2a-spacing-12) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: var(--s2a-font-size-14);
+}
+
+.summary-list li {
+  line-height: 1.45;
+}
+
+.summary-list a {
+  color: var(--s2a-color-blue-900);
+  word-break: break-all;
 }
 
 .preflight-accessibility-note {
   margin-top: var(--s2a-spacing-12);
-  font-size: var(--s2a-font-size-14);
+  font-size: var(--s2a-font-size-12);
   color: var(--preflight-text-subtle);
   line-height: 1.5;
   font-style: italic;
@@ -1014,9 +1151,8 @@ img:hover ~ .asset-meta,
 /* Violations Section */
 .violations-column {
   overflow-y: auto;
-  max-height: 100%;
-  margin-bottom: var(--s2a-spacing-32);
-  padding-bottom: 8px;
+  max-height: 420px;
+  margin-bottom: 0;
 }
 
 .violations-column::-webkit-scrollbar {
@@ -1058,8 +1194,8 @@ img:hover ~ .asset-meta,
 }
 
 .violation-list {
-  padding-left: 16px;
-  margin-top: 0;
+  padding-left: 0;
+  margin-top: var(--s2a-spacing-12);
   padding-top: 0;
 }
 
@@ -1068,8 +1204,21 @@ img:hover ~ .asset-meta,
   list-style-type: disc;
 }
 
+.violation-item + .violation-item {
+  border-top: 1px solid var(--preflight-border);
+}
+
+.violation-summary .preflight-content-heading {
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: var(--s2a-font-size-14);
+  font-weight: var(--s2a-font-weight-adobe-clean-regular);
+  color: var(--preflight-text);
+  line-height: 1.4;
+}
+
 .violation-details {
-  padding-left: 20px;
+  padding: 0 var(--s2a-spacing-8) var(--s2a-spacing-8) var(--s2a-spacing-32);
   font-size: var(--s2a-font-size-14);
   color: var(--preflight-text-subtle);
 }
@@ -1091,14 +1240,21 @@ img:hover ~ .asset-meta,
 
 .violation-summary {
   display: grid;
-  grid-template-columns: 42px 1fr;
-  align-items: center;
-  padding: var(--s2a-spacing-12) var(--s2a-spacing-24);
+  grid-template-columns: 24px 1fr;
+  gap: var(--s2a-spacing-8);
+  align-items: start;
+  padding: var(--s2a-spacing-12) var(--s2a-spacing-8);
+  border-radius: var(--s2a-border-radius-8);
   cursor: pointer;
+  transition: background-color 0.15s;
 }
 
 .violation-summary:hover {
   background-color: var(--preflight-hover);
+}
+
+.violation-summary .violation-expand {
+  margin-top: 1px;
 }
 
 .violations-scroll-wrapper {
@@ -1143,9 +1299,7 @@ img:hover ~ .asset-meta,
 .preflight-full-width {
   grid-column: 1 / -1;
   width: 100%;
-  margin-top: var(--s2a-spacing-24);
-  padding-top: 16px;
-  border-top: 1px solid var(--preflight-border);
+  margin-top: var(--s2a-spacing-32);
 }
 
 .preflight-auth-error {
@@ -1418,4 +1572,67 @@ img:hover ~ .asset-meta,
 
 .dialog-modal#preflight .dialog-close line {
   stroke: var(--s2a-color-gray-25);
+}
+
+/* ---- Narrow viewports: collapse rail to a top nav (placed last so it wins) ---- */
+@media (max-width: 700px) {
+  .preflight {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+
+  .preflight-sidebar {
+    border-right: none;
+    border-bottom: 1px solid var(--preflight-border);
+    gap: var(--s2a-spacing-12);
+  }
+
+  .preflight-tab-button-group {
+    flex-direction: row;
+    overflow-x: auto;
+    gap: 4px;
+    scrollbar-width: none;
+  }
+
+  button.preflight-tab-button {
+    width: auto;
+    white-space: nowrap;
+  }
+
+  button.preflight-tab-button[aria-selected="true"]::before {
+    display: none;
+  }
+
+  .preflight-main-header {
+    display: none;
+  }
+
+  /* Collapse multi-column check grids so cards never clip. */
+  .preflight-structure-columns,
+  .preflight-columns,
+  .accessibility-columns {
+    grid-template-columns: 1fr;
+    gap: var(--s2a-spacing-16);
+    margin-left: var(--s2a-spacing-16);
+    margin-right: var(--s2a-spacing-16);
+  }
+
+  .preflight-structure-title {
+    padding-left: var(--s2a-spacing-16);
+  }
+
+  .accessibility-columns {
+    height: auto;
+  }
+
+  .assets-image-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* The fixed-width content/link tables scroll within themselves so they
+     don't force the whole panel wide and clip the cards above. */
+  .preflight-content-group,
+  .problem-links {
+    overflow-x: auto;
+  }
 }

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -1217,11 +1217,85 @@ img:hover ~ .asset-meta,
   color: var(--preflight-text-subtle);
 }
 
-/* Page-injected: transient highlight when jumping to an asset from the modal. */
+/* Page-injected: highlight + return popover when jumping to an asset. */
 .preflight-asset-highlight {
   outline: 4px solid var(--s2a-color-blue-900) !important;
   outline-offset: 3px !important;
   scroll-margin: 100px;
+}
+
+.preflight-return-popover {
+  position: fixed;
+  bottom: var(--s2a-spacing-24);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: var(--s2a-spacing-12);
+  max-width: calc(100vw - 32px);
+  padding: var(--s2a-spacing-8) var(--s2a-spacing-8) var(--s2a-spacing-8) var(--s2a-spacing-16);
+  background: var(--s2a-color-background-default, #fff);
+  color: var(--s2a-color-content-default, #131313);
+  border: 1px solid var(--s2a-color-border-subtle, #dadada);
+  border-radius: var(--s2a-border-radius-999, 999px);
+  box-shadow: 0 8px 24px var(--s2a-color-transparent-black-24, rgb(0 0 0 / 24%));
+  font-family: var(--body-font-family);
+  font-size: var(--s2a-font-size-14);
+}
+
+.preflight-return-label {
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  white-space: nowrap;
+}
+
+/* On small phones drop the label — the buttons are self-explanatory. */
+@media (max-width: 599px) {
+  .preflight-return-label {
+    display: none;
+  }
+}
+
+.preflight-return-reopen {
+  display: inline-flex;
+  align-items: center;
+  height: 32px;
+  padding: 0 var(--s2a-spacing-16);
+  border: none;
+  border-radius: var(--s2a-border-radius-999, 999px);
+  background: var(--s2a-color-blue-900, #3b63fb);
+  color: var(--s2a-color-gray-25, #fff);
+  font-family: var(--body-font-family);
+  font-size: var(--s2a-font-size-14);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.preflight-return-reopen:hover {
+  background: var(--s2a-color-blue-1000, #274dea);
+}
+
+.preflight-return-reopen:focus-visible {
+  outline: 2px solid var(--s2a-color-focus-ring-default, #3b63fb);
+  outline-offset: 2px;
+}
+
+.preflight-return-dismiss {
+  background: none;
+  border: none;
+  padding: 0 var(--s2a-spacing-8);
+  white-space: nowrap;
+  cursor: pointer;
+  color: var(--s2a-color-content-subtle, rgb(0 0 0 / 64%));
+  font-family: var(--body-font-family);
+  font-size: var(--s2a-font-size-14);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+}
+
+.preflight-return-dismiss:hover {
+  color: var(--s2a-color-content-default, #131313);
 }
 
 /* Page-injected: LCP element preview box (outside modal). */
@@ -1771,12 +1845,12 @@ img:hover ~ .asset-meta,
     overflow: visible;
   }
 
+  /* Wrap the tabs so every one is reachable without horizontal scrolling
+     (scrolling a top nav isn't discoverable with a mouse). */
   .preflight-tab-button-group {
-    flex-flow: row nowrap;
-    overflow-x: auto;
-    gap: 4px;
+    flex-flow: row wrap;
+    gap: 4px var(--s2a-spacing-8);
     min-width: 0;
-    scrollbar-width: none;
   }
 
   button.preflight-tab-button {

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -392,9 +392,9 @@ span.preflight-time {
 }
 
 .preflight-actions {
-  display: grid;
-  grid-template-areas: 'select empty preview publish';
-  grid-template-columns: auto 1fr 140px 140px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: var(--s2a-spacing-12);
   position: absolute;
   bottom: 0;
@@ -406,16 +406,9 @@ span.preflight-time {
   box-shadow: 0 -4px 16px var(--s2a-color-transparent-black-08);
 }
 
+/* Keep "select" on the left; preview/publish flow to the right. */
 #select-action {
-  grid-area: select;
-}
-
-#preview-action {
-  grid-area: preview;
-}
-
-#publish-action {
-  grid-area: publish;
+  margin-right: auto;
 }
 
 /* Canonical Adobe CTA: solid blue, rounded, focus ring. */
@@ -423,6 +416,7 @@ span.preflight-time {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  white-space: nowrap;
   cursor: pointer;
   background: var(--preflight-cta-bg);
   color: var(--preflight-cta-text);
@@ -1713,8 +1707,31 @@ img:hover ~ .asset-meta,
   stroke: var(--s2a-color-gray-25);
 }
 
-/* ---- Narrow viewports: collapse rail to a top nav (placed last so it wins) ---- */
-@media (max-width: 700px) {
+/* Responsive layout uses Milo's standard breakpoints (600 / 900 / 1200). */
+
+/* Tablet/desktop below large: too narrow for two-up cards — single column,
+   keep the navigation rail. */
+@media (max-width: 1199px) {
+  .preflight-structure-columns,
+  .preflight-columns,
+  .accessibility-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .accessibility-columns {
+    height: auto;
+  }
+
+  /* Fixed-width content/link tables scroll within themselves so they don't
+     force the whole panel wide and clip the cards above. */
+  .preflight-content-group,
+  .problem-links {
+    overflow-x: auto;
+  }
+}
+
+/* Mobile + tablet: collapse the rail into a horizontal top nav. */
+@media (max-width: 899px) {
   .preflight {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;
@@ -1746,11 +1763,9 @@ img:hover ~ .asset-meta,
     display: none;
   }
 
-  /* Collapse multi-column check grids so cards never clip. */
   .preflight-structure-columns,
   .preflight-columns,
   .accessibility-columns {
-    grid-template-columns: 1fr;
     gap: var(--s2a-spacing-16);
     margin-left: var(--s2a-spacing-16);
     margin-right: var(--s2a-spacing-16);
@@ -1763,20 +1778,5 @@ img:hover ~ .asset-meta,
   .martech-toolbar {
     flex-direction: column;
     align-items: flex-start;
-  }
-
-  .accessibility-columns {
-    height: auto;
-  }
-
-  .assets-image-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  /* The fixed-width content/link tables scroll within themselves so they
-     don't force the whole panel wide and clip the cards above. */
-  .preflight-content-group,
-  .problem-links {
-    overflow-x: auto;
   }
 }

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -124,6 +124,30 @@ button.preflight-tab-button {
   display: block;
 }
 
+.preflight-tab-label {
+  flex: 1;
+}
+
+/* Issue-count badge: red for errors, orange for warnings. */
+.preflight-tab-badge {
+  flex-shrink: 0;
+  min-width: 20px;
+  height: 18px;
+  padding: 0 6px;
+  box-sizing: border-box;
+  border-radius: var(--s2a-border-radius-999);
+  font-size: var(--s2a-font-size-12);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  line-height: 18px;
+  text-align: center;
+  color: var(--s2a-color-gray-25);
+  background: var(--s2a-color-red-900);
+}
+
+.preflight-tab-badge.has-warnings {
+  background: var(--s2a-color-orange-700);
+}
+
 button.preflight-tab-button:hover {
   background: var(--s2a-color-transparent-black-04);
   color: var(--preflight-text);

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -837,11 +837,11 @@ body.preflight-assets-analysis {
 }
 
 .assets-columns .grid-heading {
-  margin-bottom: 20px;
+  margin-bottom: var(--s2a-spacing-16);
 }
 
 .assets-columns .grid-toggle {
-  color: var(--preflight-text);
+  color: var(--preflight-text-subtle);
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
   font-size: var(--s2a-font-size-12);
   letter-spacing: 0.06em;
@@ -851,17 +851,30 @@ body.preflight-assets-analysis {
   align-items: center;
 }
 
+.assets-columns .grid-heading.is-critical .grid-toggle {
+  color: var(--s2a-color-red-900);
+}
+
+.assets-columns .grid-heading.is-warning .grid-toggle {
+  color: var(--s2a-color-orange-700);
+}
+
 .assets-item-title {
-  margin: 0;
+  margin: 0 0 4px;
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
   font-size: var(--s2a-font-size-20);
 }
 
+.assets-item-description {
+  margin: 0;
+  color: var(--preflight-text-subtle);
+}
+
 .assets-image-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 10px;
-  margin-bottom: 35px;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--s2a-spacing-12);
+  margin-bottom: var(--s2a-spacing-32);
   width: 100%;
 }
 
@@ -872,48 +885,92 @@ body.preflight-assets-analysis {
 .assets-image-grid-item {
   background: var(--preflight-surface-subtle);
   border: 1px solid var(--preflight-border);
-  display: grid;
-  justify-items: center;
-  padding: 10px;
-  border-radius: var(--s2a-border-radius-8);
+  border-radius: var(--s2a-border-radius-12);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-.above-fold-notice {
-  color: var(--s2a-color-red-900);
-  font-weight: bold;
-  background: var(--s2a-color-red-100);
-  padding: 4px 8px;
-  border-radius: var(--s2a-border-radius-4);
-  border-left: 3px solid var(--s2a-color-red-900);
-  margin-top: 8px;
+/* Compact thumbnail on a neutral checkerboard so the metadata stays visible. */
+.assets-image-grid-item > :is(img, video, iframe) {
+  width: 100%;
+  height: 132px;
+  object-fit: contain;
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--preflight-border);
+  background-color: var(--s2a-color-gray-100);
+  background-image:
+    linear-gradient(45deg, var(--s2a-color-gray-200) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--s2a-color-gray-200) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--s2a-color-gray-200) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--s2a-color-gray-200) 75%);
+  background-size: 16px 16px;
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+}
+
+.assets-image-grid-item iframe {
+  border: none;
+}
+
+.assets-image-grid-item.above-fold-critical {
+  border-color: var(--s2a-color-red-900);
+  box-shadow: inset 0 0 0 1px var(--s2a-color-red-900);
 }
 
 .assets-image-grid-item.full-width {
   grid-column: 1 / -1;
+  padding: var(--s2a-spacing-16);
+  text-align: center;
+  color: var(--preflight-text-subtle);
 }
 
 .assets-image-grid-item-text {
   display: flex;
-  align-self: flex-end;
   flex-direction: column;
-  width: 100%;
-  margin-top: 10px;
+  gap: 6px;
+  padding: var(--s2a-spacing-12);
 }
 
-.assets-image-grid-item span {
-  font-size: var(--s2a-font-size-16);
+.asset-metric {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--s2a-spacing-8);
+  font-size: var(--s2a-font-size-12);
   line-height: 1.4;
 }
 
-.assets-image-grid-item span:first-of-type {
-  margin: 10px 0;
-  font-weight: bold;
+.asset-metric-label {
+  color: var(--preflight-text-subtle);
 }
 
-.assets-image-grid-item iframe {
-  width: 100%;
-  height: 100%;
-  border: none;
+.asset-metric-value {
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  text-align: right;
+}
+
+.asset-metric.is-recommended .asset-metric-value {
+  color: var(--s2a-color-green-900);
+}
+
+.asset-note {
+  margin: 0;
+  font-size: var(--s2a-font-size-12);
+  color: var(--preflight-text-subtle);
+  line-height: 1.4;
+}
+
+.asset-critical-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  align-self: flex-start;
+  margin-top: 2px;
+  padding: 2px 8px;
+  border-radius: var(--s2a-border-radius-999);
+  background: var(--s2a-color-red-100);
+  color: var(--s2a-color-red-900);
+  font-size: var(--s2a-font-size-12);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
 }
 
 /* Page-injected: asset metadata overlay drawn on top of media (outside modal). */

--- a/libs/blocks/preflight/preflight.js
+++ b/libs/blocks/preflight/preflight.js
@@ -1,6 +1,7 @@
 import { html, render, signal } from '../../deps/htm-preact.js';
 import { createTag, getConfig, loadStyle } from '../../utils/utils.js';
 import { getPreflightResults } from './checks/preflightApi.js';
+import { runChecks as runLocalizationChecks } from './checks/localization.js';
 import { SEVERITY } from './checks/constants.js';
 import General from './panels/general.js';
 import SEO from './panels/seo.js';
@@ -94,14 +95,31 @@ function countCategory(title, runChecks) {
   return countChecks(checks);
 }
 
+// Localization (faulty links) is shown in the General panel but is not part of
+// the central run, so fold its violations into the General badge separately.
+async function getLocalizationErrors() {
+  try {
+    const [loc] = await runLocalizationChecks({ area: document });
+    return loc?.details?.violations?.length || 0;
+  } catch {
+    return 0;
+  }
+}
+
 async function loadIssueCounts() {
   try {
     const results = await getPreflightResults({ url: window.location.href, area: document });
     if (!results?.runChecks) return;
-    tabStatus.value = Object.keys(TAB_CATEGORY).reduce((acc, title) => {
+    const status = Object.keys(TAB_CATEGORY).reduce((acc, title) => {
       acc[title] = countCategory(title, results.runChecks);
       return acc;
     }, {});
+    const locErrors = await getLocalizationErrors();
+    status.General = {
+      errors: status.General.errors + locErrors,
+      warnings: status.General.warnings,
+    };
+    tabStatus.value = status;
   } catch (e) {
     window.lana?.log?.(`Preflight tab badges failed: ${e}`, { tags: 'preflight' });
   }

--- a/libs/blocks/preflight/preflight.js
+++ b/libs/blocks/preflight/preflight.js
@@ -1,5 +1,5 @@
 import { html, render, signal } from '../../deps/htm-preact.js';
-import { createTag, getConfig } from '../../utils/utils.js';
+import { createTag, getConfig, loadStyle } from '../../utils/utils.js';
 import General from './panels/general.js';
 import SEO from './panels/seo.js';
 import Accessibility from './accessibility/accessibility.js';
@@ -10,6 +10,9 @@ import Assets from './panels/assets.js';
 
 const HEADING = 'Milo Preflight';
 const IMG_PATH = '/blocks/preflight/img';
+// c2 (--s2a-*) design tokens are only defined on c2 pages; preflight runs on every Milo
+// page, so load them at :root so both the modal and the page-injected overlays resolve.
+const C2_TOKENS = ['tokens.primitives.css', 'tokens.semantic.light.css'];
 
 const tabs = signal([
   { title: 'General', selected: true },
@@ -80,7 +83,7 @@ function TabPanel(props) {
     </div>`;
 }
 
-function Preflight() {
+export function Preflight() {
   return html`
     <div class=preflight-heading>
       <p id=preflight-title>${HEADING}</p>
@@ -94,25 +97,17 @@ function Preflight() {
   `;
 }
 
-function preloadAssets(el) {
-  return new Promise((resolve) => {
-    const { miloLibs, codeRoot } = getConfig();
-    const base = miloLibs || codeRoot;
-    const bg = createTag('img', { src: `${base}${IMG_PATH}/preflight-bg.png` });
-    const pic = createTag('picture', { class: 'bg-img' }, bg);
-    bg.addEventListener('load', () => {
-      resolve(pic);
-      el.insertAdjacentElement('afterbegin', pic);
-
-      // Lazily load other images
-      const check = createTag('link', { rel: 'preload', as: 'image', href: `${base}${IMG_PATH}/check.svg` });
-      const expand = createTag('link', { rel: 'preload', as: 'image', href: `${base}${IMG_PATH}/expand.svg` });
-      document.head.append(check, expand);
-    });
-  });
+function loadAssets() {
+  const { miloLibs, codeRoot } = getConfig();
+  const base = miloLibs || codeRoot;
+  C2_TOKENS.forEach((file) => loadStyle(`${base}/c2/styles/deps/${file}`));
+  // Preload the icons used as CSS masks across the panels.
+  const check = createTag('link', { rel: 'preload', as: 'image', href: `${base}${IMG_PATH}/check.svg` });
+  const expand = createTag('link', { rel: 'preload', as: 'image', href: `${base}${IMG_PATH}/expand.svg` });
+  document.head.append(check, expand);
 }
 
-export default async function init(el) {
-  await preloadAssets(el);
+export default function init(el) {
+  loadAssets();
   render(html`<${Preflight} />`, el);
 }

--- a/libs/blocks/preflight/preflight.js
+++ b/libs/blocks/preflight/preflight.js
@@ -1,5 +1,7 @@
 import { html, render, signal } from '../../deps/htm-preact.js';
 import { createTag, getConfig, loadStyle } from '../../utils/utils.js';
+import { getPreflightResults } from './checks/preflightApi.js';
+import { SEVERITY } from './checks/constants.js';
 import General from './panels/general.js';
 import SEO from './panels/seo.js';
 import Accessibility from './accessibility/accessibility.js';
@@ -44,6 +46,67 @@ function setTab(active) {
   });
 }
 
+// Per-tab issue counts surfaced as badges in the rail. Keyed by tab title.
+const tabStatus = signal({});
+
+// Each tab maps to a category returned by getPreflightResults().runChecks.
+// Martech extracts metadata only, so it has no pass/fail state.
+const TAB_CATEGORY = {
+  General: 'structure',
+  SEO: 'seo',
+  'M@S': 'merch',
+  Accessibility: 'accessibility',
+  Performance: 'performance',
+  Assets: 'assets',
+};
+
+// structure/seo/performance return one check per item, so failing checks map 1:1
+// to the cards the panel shows.
+function countChecks(checks = []) {
+  return checks.reduce((acc, check) => {
+    if (check?.status === 'fail') {
+      if (check.severity === SEVERITY.WARNING) acc.warnings += 1;
+      else acc.errors += 1;
+    } else if (check?.status === 'limbo') {
+      acc.warnings += 1;
+    }
+    return acc;
+  }, { errors: 0, warnings: 0 });
+}
+
+// accessibility/merch/assets return a single aggregate check whose granular counts
+// live in `details`, so the badge matches the items the panel actually lists.
+function countCategory(title, runChecks) {
+  const checks = runChecks[TAB_CATEGORY[title]] || [];
+  const [first] = checks;
+  if (title === 'Accessibility') {
+    return { errors: first?.status === 'fail' ? first.details?.issuesCount || 0 : 0, warnings: 0 };
+  }
+  if (title === 'M@S') {
+    return { errors: first?.status === 'fail' ? first.details?.unpublished?.length || 0 : 0, warnings: 0 };
+  }
+  if (title === 'Assets') {
+    return {
+      errors: first?.details?.criticalAssetFailures?.length || 0,
+      warnings: first?.details?.warningAssetFailures?.length || 0,
+    };
+  }
+  return countChecks(checks);
+}
+
+async function loadIssueCounts() {
+  try {
+    const results = await getPreflightResults({ url: window.location.href, area: document });
+    if (!results?.runChecks) return;
+    tabStatus.value = Object.keys(TAB_CATEGORY).reduce((acc, title) => {
+      acc[title] = countCategory(title, results.runChecks);
+      return acc;
+    }, {});
+  } catch (e) {
+    window.lana?.log?.(`Preflight tab badges failed: ${e}`, { tags: 'preflight' });
+  }
+}
+
 function setPanel(title) {
   switch (title) {
     case 'General':
@@ -78,6 +141,14 @@ function TabButton(props) {
       onClick=${() => setTab(props.tab)}>
       <span class=preflight-tab-icon>${props.tab.icon}</span>
       <span class=preflight-tab-label>${props.tab.title}</span>
+      ${(() => {
+    const counts = tabStatus.value[props.tab.title];
+    const total = counts ? counts.errors + counts.warnings : 0;
+    if (!total) return null;
+    const badgeClass = counts.errors ? 'has-errors' : 'has-warnings';
+    const label = `${total} ${counts.errors ? 'issue' : 'warning'}${total === 1 ? '' : 's'}`;
+    return html`<span class="preflight-tab-badge ${badgeClass}" title=${label} aria-label=${label}>${total}</span>`;
+  })()}
     </button>`;
 }
 
@@ -135,4 +206,5 @@ function loadAssets() {
 export default function init(el) {
   loadAssets();
   render(html`<${Preflight} />`, el);
+  loadIssueCounts();
 }

--- a/libs/blocks/preflight/preflight.js
+++ b/libs/blocks/preflight/preflight.js
@@ -9,19 +9,32 @@ import Performance from './panels/performance.js';
 import Assets from './panels/assets.js';
 
 const HEADING = 'Milo Preflight';
+const SUBHEADING = 'Pre-publish quality checks for this page';
 const IMG_PATH = '/blocks/preflight/img';
 // c2 (--s2a-*) design tokens are only defined on c2 pages; preflight runs on every Milo
 // page, so load them at :root so both the modal and the page-injected overlays resolve.
 const C2_TOKENS = ['tokens.primitives.css', 'tokens.semantic.light.css'];
 
+const svg = (paths) => html`<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
+
+const ICONS = {
+  general: svg(html`<rect x="2.5" y="2.5" width="6" height="6" rx="1.5" /><rect x="11.5" y="2.5" width="6" height="6" rx="1.5" /><rect x="2.5" y="11.5" width="6" height="6" rx="1.5" /><rect x="11.5" y="11.5" width="6" height="6" rx="1.5" />`),
+  seo: svg(html`<circle cx="8.5" cy="8.5" r="5.5" /><line x1="12.5" y1="12.5" x2="17" y2="17" />`),
+  martech: svg(html`<line x1="4" y1="16.5" x2="4" y2="11" /><line x1="10" y1="16.5" x2="10" y2="5.5" /><line x1="16" y1="16.5" x2="16" y2="9" />`),
+  mas: svg(html`<path d="M9.6 2.5H4A1.5 1.5 0 0 0 2.5 4v5.6L10.9 18l6.6-6.6L9.6 2.5z" /><circle cx="6" cy="6" r="1.1" />`),
+  accessibility: svg(html`<circle cx="10" cy="3.8" r="1.6" /><path d="M3.5 7.3c2 1 4 1.5 6.5 1.5s4.5-.5 6.5-1.5" /><path d="M10 7v5" /><path d="M6.8 17.5 10 12l3.2 5.5" />`),
+  performance: svg(html`<path d="M3.2 15.5a7 7 0 1 1 13.6 0" /><line x1="10" y1="13.5" x2="13.2" y2="9.2" /><circle cx="10" cy="13.5" r="1" fill="currentColor" stroke="none" />`),
+  assets: svg(html`<rect x="2.5" y="3.8" width="15" height="12.4" rx="2" /><circle cx="7" cy="8" r="1.4" /><path d="M3.2 14.5 7.5 11l3 2.2L14 9.8l3.5 3.4" />`),
+};
+
 const tabs = signal([
-  { title: 'General', selected: true },
-  { title: 'SEO' },
-  { title: 'Martech' },
-  { title: 'M@S' },
-  { title: 'Accessibility' },
-  { title: 'Performance' },
-  { title: 'Assets' },
+  { title: 'General', desc: 'Page structure, localization and content status.', icon: ICONS.general, selected: true },
+  { title: 'SEO', desc: 'Search engine optimization checks for this page.', icon: ICONS.seo },
+  { title: 'Martech', desc: 'Marketing metadata extracted for tagging.', icon: ICONS.martech },
+  { title: 'M@S', desc: 'Merch-at-scale fragment and offer checks.', icon: ICONS.mas },
+  { title: 'Accessibility', desc: 'WCAG conformance and alt-text auditing.', icon: ICONS.accessibility },
+  { title: 'Performance', desc: 'Core Web Vitals and LCP readiness.', icon: ICONS.performance },
+  { title: 'Assets', desc: 'Image dimensions and asset optimization.', icon: ICONS.assets },
 ]);
 
 function setTab(active) {
@@ -59,10 +72,12 @@ function TabButton(props) {
     <button
       id=${id}
       class=preflight-tab-button
+      role="tab"
       key=${props.tab.title}
       aria-selected=${selected}
       onClick=${() => setTab(props.tab)}>
-      ${props.tab.title}
+      <span class=preflight-tab-icon>${props.tab.icon}</span>
+      <span class=preflight-tab-label>${props.tab.title}</span>
     </button>`;
 }
 
@@ -84,16 +99,26 @@ function TabPanel(props) {
 }
 
 export function Preflight() {
+  const active = tabs.value.find((tab) => tab.selected) || tabs.value[0];
   return html`
-    <div class=preflight-heading>
-      <p id=preflight-title>${HEADING}</p>
-      <div class=preflight-tab-button-group role="tablist" aria-labelledby=preflight-title>
-        ${tabs.value.map((tab, idx) => html`<${TabButton} tab=${tab} idx=${idx} />`)}
+    <aside class=preflight-sidebar>
+      <div class=preflight-brand>
+        <p id=preflight-title>${HEADING}</p>
+        <p class=preflight-subtitle>${SUBHEADING}</p>
       </div>
-    </div>
-    <div class=preflight-content>
-      ${tabs.value.map((tab, idx) => html`<${TabPanel} tab=${tab} idx=${idx} />`)}
-    </div>
+      <nav class=preflight-tab-button-group role="tablist" aria-orientation="vertical" aria-labelledby=preflight-title>
+        ${tabs.value.map((tab, idx) => html`<${TabButton} tab=${tab} idx=${idx} />`)}
+      </nav>
+    </aside>
+    <main class=preflight-main>
+      <header class=preflight-main-header>
+        <h2 class=preflight-main-title>${active.title}</h2>
+        <p class=preflight-main-desc>${active.desc}</p>
+      </header>
+      <div class=preflight-content>
+        ${tabs.value.map((tab, idx) => html`<${TabPanel} tab=${tab} idx=${idx} />`)}
+      </div>
+    </main>
   `;
 }
 

--- a/libs/blocks/preflight/preflight.js
+++ b/libs/blocks/preflight/preflight.js
@@ -16,7 +16,7 @@ const SUBHEADING = 'Pre-publish quality checks for this page';
 const IMG_PATH = '/blocks/preflight/img';
 // c2 (--s2a-*) design tokens are only defined on c2 pages; preflight runs on every Milo
 // page, so load them at :root so both the modal and the page-injected overlays resolve.
-const C2_TOKENS = ['tokens.primitives.css', 'tokens.semantic.light.css'];
+const C2_TOKENS = ['tokens.primitives.css', 'tokens.primitives.light.css', 'tokens.semantic.light.css'];
 
 const svg = (paths) => html`<svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
 

--- a/libs/utils/preflight-notification.js
+++ b/libs/utils/preflight-notification.js
@@ -24,6 +24,18 @@ function openPreflightPanel() {
   });
 });
 
+function dismissNotification() {
+  document.querySelector('.milo-preflight-overlay')?.remove();
+  wasDismissed = true;
+  if (!linkCheckListener) return;
+  window.removeEventListener('preflightLinksComplete', linkCheckListener);
+  linkCheckListener = null;
+}
+
+// Dismiss the notification the moment preflight is opened (via the review link or
+// the sidekick plugin) — both routes fire `custom:preflight` on the sidekick.
+sidekick?.addEventListener('custom:preflight', dismissNotification);
+
 function getMasUnpublishedCount(results) {
   const merchResults = results?.runChecks?.merch || [];
   return merchResults.reduce((sum, check) => {
@@ -63,13 +75,7 @@ async function createPreflightNotification(masUnpublishedCount = 0) {
   });
 
   const closeBtn = overlay.querySelector('.notification-close');
-  closeBtn.addEventListener('click', () => {
-    overlay.remove();
-    wasDismissed = true;
-    if (!linkCheckListener) return;
-    window.removeEventListener('preflightLinksComplete', linkCheckListener);
-    linkCheckListener = null;
-  });
+  closeBtn.addEventListener('click', dismissNotification);
 
   document.body.appendChild(overlay);
 }

--- a/libs/utils/preflight-notification.js
+++ b/libs/utils/preflight-notification.js
@@ -44,9 +44,15 @@ function getMasUnpublishedCount(results) {
   }, 0);
 }
 
+function isPreflightOpen() {
+  return !!document.getElementById('preflight');
+}
+
 async function createPreflightNotification(masUnpublishedCount = 0) {
   const existingNotification = document.querySelector('.milo-preflight-overlay');
   if (existingNotification) return;
+  // The modal already surfaces the results, so don't also show the notification.
+  if (isPreflightOpen()) return;
   const { miloLibs, codeRoot } = getConfig();
   const base = miloLibs || codeRoot;
   loadStyle(`${base}/styles/preflight-notification.css`);

--- a/test/blocks/preflight/preflight.test.js
+++ b/test/blocks/preflight/preflight.test.js
@@ -1,0 +1,66 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { html, render } from '../../../libs/deps/htm-preact.js';
+import { Preflight } from '../../../libs/blocks/preflight/preflight.js';
+
+const TAB_TITLES = ['General', 'SEO', 'Martech', 'M@S', 'Accessibility', 'Performance', 'Assets'];
+// Signal-driven re-renders (tab switch) and useEffect checks resolve on a later tick.
+const tick = () => new Promise((resolve) => { setTimeout(resolve, 50); });
+
+describe('Preflight modal (isolation)', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.className = 'preflight';
+    document.body.appendChild(container);
+    // Silence the async checks that the panels fire from useEffect; every check
+    // is wrapped in a .catch(), so a rejected fetch keeps the initial render intact.
+    sinon.stub(window, 'fetch').rejects(new Error('blocked in test'));
+    if (!navigator.clipboard) navigator.clipboard = {};
+    sinon.stub(navigator.clipboard, 'write').resolves();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    sinon.restore();
+  });
+
+  it('renders all seven tabs with the correct labels', () => {
+    render(html`<${Preflight} />`, container);
+    const buttons = [...container.querySelectorAll('.preflight-tab-button')];
+    expect(buttons).to.have.lengthOf(TAB_TITLES.length);
+    expect(buttons.map((b) => b.textContent.trim())).to.eql(TAB_TITLES);
+  });
+
+  it('selects General by default', () => {
+    render(html`<${Preflight} />`, container);
+    expect(container.querySelector('#tab-1').getAttribute('aria-selected')).to.equal('true');
+    expect(container.querySelector('#panel-1').getAttribute('aria-selected')).to.equal('true');
+  });
+
+  it('switches the active panel when each tab is clicked and surfaces content', async () => {
+    render(html`<${Preflight} />`, container);
+    /* eslint-disable no-await-in-loop */
+    for (let idx = 0; idx < TAB_TITLES.length; idx += 1) {
+      const button = container.querySelector(`#tab-${idx + 1}`);
+      button.click();
+      await tick();
+      const panel = container.querySelector(`#panel-${idx + 1}`);
+      expect(button.getAttribute('aria-selected'), `tab ${idx + 1} selected`).to.equal('true');
+      expect(panel.getAttribute('aria-selected'), `panel ${idx + 1} visible`).to.equal('true');
+      // The selected panel must actually render something.
+      expect(panel.childElementCount, `panel ${idx + 1} has content`).to.be.greaterThan(0);
+    }
+    /* eslint-enable no-await-in-loop */
+  });
+
+  it('exposes a clickable CTA in the Martech panel', async () => {
+    render(html`<${Preflight} />`, container);
+    container.querySelector('#tab-3').click(); // Martech
+    await tick();
+    const cta = container.querySelector('#panel-3 .preflight-action');
+    expect(cta, 'martech CTA exists').to.exist;
+    expect(() => cta.click()).to.not.throw();
+  });
+});


### PR DESCRIPTION
### Description
Ground-up restyle of the Milo Preflight modal to a premium, Adobe Spectrum-2-style light theme built on c2 (`--s2a-*`) design tokens. Functionality is unchanged — only the visual/UX layer.

**Highlights**
- Left navigation rail with section icons, active states, and per-tab issue badges (errors red / warnings orange)
- Main content header per section; card-based checks with tonal status chips and a clean progress-ring loading state
- Redesigned Assets tab: compact thumbnails, scannable metric rows, critical accent, and click-to-navigate that closes preflight and jumps to the element, with a "Back to Preflight" popover pinned to the top-left of the screen
- Redesigned Martech metadata table
- Notification dismisses when preflight opens and is suppressed while the modal is open
- General badge also counts localization (faulty link) issues
- Performance hides the "Highlight LCP" link when there is no LCP element
- Responsive across Milo standard breakpoints (900/1200) with a wrapping mobile top-nav
- When clicking on an individual asset, it now takes you there, highlights it, and provides a link back to the preflight
<img width="975" height="243" alt="Screenshot 2026-06-17 at 14 49 44" src="https://github.com/user-attachments/assets/57b6c902-bcf5-4fa9-bc21-85d67fe41471" />

**Testing**
- `npm run test` — 47 preflight tests pass; eslint clean; stylelint clean (aside from pre-existing repo-wide env-noise rules)
- Open the Preflight tool via the sidekick **Preflight** plugin. To preview this branch on any Milo page, append `?milolibs=preflight-redesign-light-theme`.

Resolves: [MWPW-198875](https://jira.corp.adobe.com/browse/MWPW-198875)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Before / After
Before: https://main--milo--adobecom.aem.live/
After: https://preflight-redesign-light-theme--milo--adobecom.aem.live/
<img width="2488" height="1174" alt="Screenshot 2026-06-17 at 14 48 59" src="https://github.com/user-attachments/assets/20197bfa-3fcf-4ccc-b68b-7cec2f367e61" />









