### PR TITLE
Preflight: only capture metrics on sidekick preview/publish events

### DIFF
--- a/libs/blocks/preflight/checks/preflightApi.js
+++ b/libs/blocks/preflight/checks/preflightApi.js
@@ -2,7 +2,6 @@ import { getConfig, getFederatedContentRoot } from '../../../utils/utils.js';
 import { fetchPreflightChecks, asoCache } from './asoApi.js';
 import { isViewportTooSmall, checkImageDimensions, runChecks as runChecksAssets } from './assets.js';
 import runChecksAccessibility from './accessibility.js';
-import captureMetrics from './captureMetrics.js';
 import {
   getLcpEntry,
   checkSingleBlock,
@@ -162,8 +161,6 @@ export async function getPreflightResults(options = {}) {
     runChecks: res,
     hasFailures: allResults.some((check) => check.status === 'fail' && check.severity === SEVERITY.CRITICAL),
   };
-
-  captureMetrics(res).catch((e) => window.lana?.log?.(`Preflight metrics capture failed: ${e}`, { tags: 'preflight' }));
 
   if (useCache) globalPreflightCache.set(cacheKey, result);
 

--- a/libs/utils/preflight-notification.js
+++ b/libs/utils/preflight-notification.js
@@ -1,4 +1,5 @@
 import { getPreflightResults } from '../blocks/preflight/checks/preflightApi.js';
+import captureMetrics from '../blocks/preflight/checks/captureMetrics.js';
 import { loadStyle, getConfig } from './utils.js';
 
 let wasDismissed = false;
@@ -9,6 +10,19 @@ function openPreflightPanel() {
   if (!sidekick) return;
   sidekick.dispatchEvent(new CustomEvent('custom:preflight', { bubbles: true }));
 }
+
+['previewed', 'published'].forEach((event) => {
+  sidekick?.addEventListener(event, async () => {
+    const results = await getPreflightResults({
+      url: window.location.href,
+      area: document,
+      useCache: false,
+    }).catch(() => null);
+    if (!results) return;
+    window.hasCapturedPreflightMetrics = false;
+    captureMetrics(results.runChecks).catch((e) => window.lana?.log?.(`Preflight metrics capture failed: ${e}`, { tags: 'preflight' }));
+  });
+});
 
 function getMasUnpublishedCount(results) {
   const merchResults = results?.runChecks?.merch || [];


### PR DESCRIPTION
Removes the automatic captureMetrics call from getPreflightResults so scores are no longer recorded on every page load. Listeners on the sidekick's `previewed` and `published` events now trigger a fresh check run and submit the results, keeping the log data meaningful and reducing noise.



Resolves: [MWPW-198893](https://jira.corp.adobe.com/browse/MWPW-198893)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-198893--milo--adobecom.aem.page/?martech=off


