### PR TITLE
[Lingo]  MWPW-198872 - Exclude redirects from preview query index

### DIFF
--- a/.github/workflows/preview-indexer/internal/helix-client.js
+++ b/.github/workflows/preview-indexer/internal/helix-client.js
@@ -1,5 +1,7 @@
 import { createAxiosWithRetry } from './utils.js';
 
+const MAX_REDIRECT_ENTRIES = 999999;
+
 const axiosWithRetry = createAxiosWithRetry();
 
 const axiosWithRetryError = async (request) => {
@@ -188,4 +190,25 @@ async function getPreviewPathsForRegion(siteOrg, siteRepo, regionPath) {
   throw new Error(`Job not stopped: ${job.links.self}`);
 }
 
-export { getSiteEnvKey, fetchLogsForSite, triggerPreview, getPreviewPathsForRegion };
+async function getRedirects(siteOrg, siteRepo) {
+  const adminTokenKey = getSiteEnvKey(siteOrg, siteRepo, 'AEM_ADMIN_TOKEN_');
+  const adminToken = process.env[adminTokenKey];
+  const url = `https://main--${siteRepo}--${siteOrg}.aem.page/redirects.json?limit=${MAX_REDIRECT_ENTRIES}`;
+  try {
+    const response = await axiosWithRetryError({
+      method: 'GET',
+      url,
+      headers: { Authorization: `token ${adminToken}` }
+    });
+    return response.data?.data?.map(item => item.Source) || [];
+  } catch (error) {
+    const status = error.status || error.response?.status;
+    if (status === 404 || status === 401) {
+      console.warn(`Redirects not found or unauthorized for ${siteOrg}/${siteRepo} (status ${status}). Returning empty list.`);
+      return [];
+    }
+    throw error;
+  }
+}
+
+export { getSiteEnvKey, fetchLogsForSite, triggerPreview, getPreviewPathsForRegion, getRedirects };

--- a/.github/workflows/preview-indexer/internal/indexer.js
+++ b/.github/workflows/preview-indexer/internal/indexer.js
@@ -1,5 +1,5 @@
 // node --env-file=.env .github/workflows/preview-indexer/incremental.js (node >= 21)
-import { fetchLogsForSite, getSiteEnvKey, triggerPreview, getPreviewPathsForRegion } from './helix-client.js';
+import { fetchLogsForSite, getSiteEnvKey, triggerPreview, getPreviewPathsForRegion, getRedirects } from './helix-client.js';
 import { getLastRunInfo, saveLastRuns } from './indexer-state.js';
 import SiteConfig from './site-config.js';
 
@@ -33,6 +33,7 @@ const initIndexer = async (siteOrg, siteRepo, lingoConfigMap, datalayer) => {
   // Initialize site configuration
   const config = SiteConfig(siteOrg, siteRepo, lingoConfigMap);
   const orgWithRepo = getSiteEnvKey(siteOrg, siteRepo);
+  const pathExtn = config.getPreviewPathExtension();
 
   function getISOSinceXDaysAgo(days) {
     const now = new Date();
@@ -87,7 +88,6 @@ const initIndexer = async (siteOrg, siteRepo, lingoConfigMap, datalayer) => {
   }
 
   function getPathsPerRoot(previewRoots, filteredPreviewPaths) {
-    const pathExtn = config.getPreviewPathExtension();
     return previewRoots.reduce((acc, root) => {
       const paths = filteredPreviewPaths.filter((path) => path.startsWith(root));
       if (paths.length) {
@@ -128,6 +128,16 @@ const initIndexer = async (siteOrg, siteRepo, lingoConfigMap, datalayer) => {
       return;
     }
 
+    const redirectPaths = [];
+    const redirectFolders = [];
+    for (const redirectEntry of await getRedirects(siteOrg, siteRepo)) {
+      if (redirectEntry.endsWith('*')) {
+        redirectFolders.push(redirectEntry.slice(0, -1));
+      } else {
+        redirectPaths.push(`${redirectEntry}${pathExtn}`);
+      }
+    }
+
     const unpreviewPaths = await getUnpreviewPaths(entries);
     const filteredUnpreviewPaths = getFilteredPaths(unpreviewPaths);
 
@@ -154,13 +164,17 @@ const initIndexer = async (siteOrg, siteRepo, lingoConfigMap, datalayer) => {
           mergedSet.add(path);
         });
         const mergedData = [...mergedSet].map((path) => ({ Path: path }));
-        const { length } = mergedData;
-        previewIndex = { ...previewIndex, total: length, limit: length, data: mergedData };
+        previewIndex = { ...previewIndex, data: mergedData };
       } else if (previewRoot?.paths) {
         const pathData = previewRoot.paths.map((path) => ({ Path: path }));
-        const { length } = previewRoot.paths;
-        previewIndex = { ...previewIndex, total: length, limit: length, data: pathData };
+        previewIndex = { ...previewIndex, data: pathData };
       }
+      // Remove the redirect paths from the preview index
+      previewIndex.data = previewIndex.data
+        .filter((item) => !redirectPaths.find((path) => path.startsWith(rootPath) && item.Path.startsWith(path)))
+        .filter((item) => !redirectFolders.find((fldr) => item.Path.startsWith(fldr)));
+      const { length } = previewIndex.data;
+      previewIndex = { ...previewIndex, total: length, limit: length };
       const result = await datalayer.savePreviewIndexJson(siteOrg, siteRepo, `${previewIndexPath}${config.getPreviewFileExtension()}`, previewIndex);
       console.log(`Preview index saved at ${result.href} with ${result.status}`);
       const previewResult = await triggerPreview(siteOrg, siteRepo, previewIndexPreviewPath);


### PR DESCRIPTION
When a file preview is triggered for a file that belongs to a redirected path, the redirected path should be excluded from the preview index.

Resolves: [MWPW-198872](https://jira.corp.adobe.com/browse/MWPW-198872)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://main--milo--adobecom.aem.page/?martech=off


