### PR TITLE
MWPW-195239-Fixed extra space in KitchenSink page

### DIFF
--- a/libs/blocks/columns/columns.css
+++ b/libs/blocks/columns/columns.css
@@ -52,6 +52,10 @@
   padding-inline-start: var(--spacing-xs);
 }
 
+.columns.columns-table > .row > .col {
+   min-width: 0 ;
+} 
+
 .columns.columns-table .row .row-title {
   grid-column: 1 / -1;
 }

--- a/libs/blocks/columns/columns.css
+++ b/libs/blocks/columns/columns.css
@@ -53,8 +53,8 @@
 }
 
 .columns.columns-table > .row > .col {
-   min-width: 0;
-} 
+  min-width: 0;
+}
 
 .columns.columns-table .row .row-title {
   grid-column: 1 / -1;

--- a/libs/blocks/columns/columns.css
+++ b/libs/blocks/columns/columns.css
@@ -53,7 +53,7 @@
 }
 
 .columns.columns-table > .row > .col {
-   min-width: 0 ;
+   min-width: 0;
 } 
 
 .columns.columns-table .row .row-title {


### PR DESCRIPTION
- The fix applies min-width: 0 to column elements within the Columns Table variant, allowing grid items to shrink correctly and preventing content from forcing a column to expand beyond its allocated space.

- Changes Made
.columns.columns-table > .row > .col {
  min-width: 0;
}

Impact-
- Ensures columns maintain equal widths in the Columns Table layout.
- Resolves overflow and uneven column sizing issues on smaller viewports.
- Scope is limited to the Columns Table variant and does not affect other Columns block layouts.


Resolves: [MWPW-195239](https://jira.corp.adobe.com/browse/MWPW-195239)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/docs/library/kitchen-sink/editorial-card
- After: https://mwpw-195239-kitchen-sinkpage--milo--adobecom.aem.page/docs/library/kitchen-sink/editorial-card

Dev validation:

Before:
<img width="1511" height="607" alt="Screenshot 2026-06-18 at 4 48 57 PM" src="https://github.com/user-attachments/assets/29d907bc-1e66-4318-a551-5a98e3c44249" />

After:
<img width="1511" height="718" alt="Screenshot 2026-06-18 at 4 49 19 PM" src="https://github.com/user-attachments/assets/52cf2146-3e79-4fab-987c-783b5b488e4f" />







