### PR TITLE
Add fix for a11y hub hero

### DIFF
--- a/libs/mep/ace1205/hub-hero/hub-hero.js
+++ b/libs/mep/ace1205/hub-hero/hub-hero.js
@@ -184,6 +184,11 @@ const buildSlide = ({ slide, index }) => {
 
   decorateBlockText(left);
 
+  const titleId = `hub-hero-slide-${index + 1}-title`;
+  const descId = `hub-hero-slide-${index + 1}-desc`;
+  if (eyebrow) eyebrow.id = titleId;
+  if (heading) heading.id = descId;
+
   const content = `
     <div class='hub-hero-carousel-item-container' id='hub-hero-carousel-card-${index + 1}'>
       <div class='hub-hero-carousel-item-header'>
@@ -207,7 +212,7 @@ const buildSlide = ({ slide, index }) => {
     href: link?.href,
     'data-index': index + 1,
     role: isModal ? 'button' : 'link',
-    'aria-labelledby': `${eyebrow?.innerText} - ${heading?.innerText}`,
+    'aria-labelledby': [eyebrow && titleId, heading && descId].filter(Boolean).join(' '),
     'daa-ll': `${processTrackingLabels(heading?.textContent)}-${index + 1}--${processTrackingLabels(heading?.textContent)}`,
   }, content);
 


### PR DESCRIPTION
Fixes the issue where the screen reader user is hearing "Button" twice. Using the aria-labelled by syntax provided in the ticket (MWPW-198651) comments by Taryn.

Resolves: [MWPW-198651](https://jira.corp.adobe.com/browse/MWPW-198651)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://sr-hub-hero-a11y-fix-2--milo--adobecom.aem.page/?martech=off

QA:
https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=sr-hub-hero-a11y-fix-2&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


