### PR TITLE
Add z-index on focused cards in hub hero

### DIFF
--- a/libs/mep/ace1205/hub-hero/hub-hero.css
+++ b/libs/mep/ace1205/hub-hero/hub-hero.css
@@ -536,6 +536,14 @@
     height: auto;
   }
 
+  .hub-hero-carousel-item:focus-visible {
+    z-index: 5;
+    animation-name: none !important;
+    opacity: 1;
+    filter: contrast(1);
+    transform: translateY(calc(var(--stack-offset) - var(--offset-adjuster)));
+  }
+
   .hub-hero-carousel-item-container {
     position: relative;
     background-color: var(--s2a-color-gray-1000);


### PR DESCRIPTION
This is intended to fix the issue present in this A11y PR (https://github.com/adobecom/milo/pull/6177). Issue: on mobile when 'Tab' through the card we can see each card properly. But when we 'Shift+Tab' to go back to previous card, its hidden as per animation behind the next card. This issue is present on elastic carousel on a.com homepage as well.

This PR fixes it by updating CSS to show the focused card on top of other cards. I have added it as a separate PR from (https://github.com/adobecom/milo/pull/6197) if this needs to be fixed by scrolling back to the right positions of the card instead of relying on browser scroll on focused element. 

Resolves: [MWPW-198651](https://jira.corp.adobe.com/browse/MWPW-198651)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://sr-hub-hero-a11y-fix-3--milo--adobecom.aem.page/?martech=off

https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=sr-hub-hero-a11y-fix-3&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
