### PR TITLE
perf: add 5s timeout + dedup to geo2 fetch, remove redundant fallback…

### DIFF
--- a/libs/utils/geo.js
+++ b/libs/utils/geo.js
@@ -1,24 +1,43 @@
 /* eslint-disable no-console */
 
+const GEO_TIMEOUT_MS = 5000;
+
+// Shared in-flight promise so concurrent callers don't issue duplicate fetches.
+let inflight = null;
+
 /**
  * Gets the Akamai country code from the geo2.adobe.com service.
- * @returns {Promise<string|null>} A promise that resolves to the lowercase Akamai country code.
+ * Times out after GEO_TIMEOUT_MS and deduplicates concurrent calls.
+ * @returns {Promise<string>} Resolves to the lowercase country code.
  */
-export const getAkamaiCode = () => new Promise((resolve, reject) => {
-  /* c8 ignore next 5 */
-  fetch('https://geo2.adobe.com/json/', { cache: 'no-cache' }).then((resp) => {
+export const getAkamaiCode = () => {
+  /* c8 ignore next */
+  if (inflight) return inflight;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), GEO_TIMEOUT_MS);
+
+  /* c8 ignore next 15 */
+  inflight = fetch('https://geo2.adobe.com/json/', {
+    cache: 'no-cache',
+    signal: controller.signal,
+  }).then((resp) => {
     if (resp.ok) {
-      resp.json().then((data) => {
+      return resp.json().then((data) => {
         const code = data.country.toLowerCase();
         sessionStorage.setItem('akamai', code);
-        resolve(code);
+        return code;
       });
-    } else {
-      reject(new Error(`Something went wrong getting the akamai Code. Response status text: ${resp.statusText}`));
     }
+    throw new Error(`Something went wrong getting the akamai Code. Response status text: ${resp.statusText}`);
   }).catch((error) => {
-    reject(new Error(`Something went wrong getting the akamai Code. ${error.message}`));
+    throw new Error(`Something went wrong getting the akamai Code. ${error.message}`);
+  }).finally(() => {
+    clearTimeout(timeout);
+    inflight = null;
   });
-});
+
+  return inflight;
+};
 
 export default getAkamaiCode;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1003,20 +1003,11 @@ export async function resolveDetectedMarketCountry() {
   if (isBot()) return null;
   const cookieMarket = getCookie('country');
   const countryFromGeo = await getCountry();
-  let detectedMarket = computeDetectedMarketCountry(
+  return computeDetectedMarketCountry(
     window.location.search,
     cookieMarket,
     countryFromGeo,
   );
-  if (!detectedMarket) {
-    try {
-      const { default: getAkamaiCode } = await import('./geo.js');
-      detectedMarket = normCountryCode(await getAkamaiCode());
-    } catch (error) {
-      window.lana?.log(`Error getting Akamai code: ${error}`, { severity: 'error' });
-    }
-  }
-  return detectedMarket;
 }
 
 export async function getLingoRegion({ useGeoLocation = false } = {}) {


### PR DESCRIPTION
… call

geo2.adobe.com/json/ was fetched with no timeout (browser TCP timeout ~30s) and no deduplication — concurrent callers each started an independent fetch. resolveDetectedMarketCountry() compounded this by making a second serial geo2 attempt on failure, meaning a blocked geo2 could cost 60s total.

Changes:
- geo.js: wrap fetch in AbortController with 5s timeout; cache the in-flight promise so concurrent calls share one fetch instead of each issuing a duplicate request
- utils.js: remove the redundant getAkamaiCode() fallback block from resolveDetectedMarketCountry() — getCountry() already tried geo2 and returned null, an immediate retry will have the same result

lana.js loading late is a symptom, not a cause: it lazy-loads on the first window.lana.log() call, which fires when geo2 times out.

<!-- Before submitting, please review all open PRs. -->

* Add your
* Specific
* Features or fixes

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://feature-perf-geo-timeout--milo--adobecom.aem.page/?martech=off


