### PR TITLE
[MWPW-TBD] Perf: parallelize personalization manifests and start lingo indexes earlier

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1017,17 +1017,22 @@ const getXLGListURL = (config) => {
 export const getEntitlementMap = async () => {
   const config = getConfig();
   if (config.mep?.entitlementMap) return config.mep.entitlementMap;
-  const entitlementUrl = getXLGListURL(config);
-  const fetchedData = await fetchData(entitlementUrl, DATA_TYPE.JSON, { redirect: 'error' });
-  if (!fetchedData) return config.consumerEntitlements || {};
-  const entitlements = {};
-  fetchedData?.data?.forEach((ent) => {
-    const { id, tagname } = ent;
-    entitlements[id] = tagname;
-  });
   config.mep ??= {};
-  config.mep.entitlementMap = { ...config.consumerEntitlements, ...entitlements };
-  return config.mep.entitlementMap;
+  if (config.mep.entitlementMapFetch) return config.mep.entitlementMapFetch;
+  config.mep.entitlementMapFetch = (async () => {
+    const entitlementUrl = getXLGListURL(config);
+    const fetchedData = await fetchData(entitlementUrl, DATA_TYPE.JSON, { redirect: 'error' });
+    if (!fetchedData) return config.consumerEntitlements || {};
+    const entitlements = {};
+    fetchedData?.data?.forEach((ent) => {
+      const { id, tagname } = ent;
+      entitlements[id] = tagname;
+    });
+    config.mep.entitlementMap = { ...config.consumerEntitlements, ...entitlements };
+    config.mep.entitlementMapFetch = null;
+    return config.mep.entitlementMap;
+  })();
+  return config.mep.entitlementMapFetch;
 };
 
 export const getEntitlements = async (data) => {
@@ -1426,22 +1431,15 @@ export async function applyPers({ manifests }) {
   let experiments = manifests;
   const config = getConfig();
 
-  for (let i = 0; i < experiments.length; i += 1) {
-    experiments[i] = await getManifestConfig(
-      experiments[i],
-      config.mep?.variantOverride,
-    );
-  }
+  experiments = await Promise.all(
+    experiments.map((exp) => getManifestConfig(exp, config.mep?.variantOverride)),
+  );
   experiments = cleanAndSortManifestList(experiments, config);
   parseNestedPlaceholders(config);
 
   let results = [];
 
-  for (const experiment of experiments) {
-    const result = await categorizeActions(experiment, config);
-    if (result) results.push(result);
-  }
-  results = results.filter(Boolean);
+  results = (await Promise.all(experiments.map((exp) => categorizeActions(exp, config)))).filter(Boolean);
 
   config.mep.experiments = [...config.mep.experiments, ...experiments];
   config.mep.blocks = consolidateObjects(results, 'blocks', config.mep.blocks);
@@ -1722,7 +1720,10 @@ export async function init(enablements = {}) {
   }
   try {
     if (manifests?.length) await applyPers({ manifests });
-    if (config.mep?.preview) await import('./preview.js').then(({ saveToMmm }) => saveToMmm());
+    if (config.mep?.preview) {
+      loadLink(`${config.base}/utils/market.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
+      await import('./preview.js').then(({ saveToMmm }) => saveToMmm());
+    }
   } catch (e) {
     log(`MEP Error: ${e.toString()}`);
     window.lana?.log(`MEP Error: ${e.toString()}`);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -744,12 +744,14 @@ async function loadQueryIndexes(prefix, links = []) {
   const host = window.location.hostname;
   const indexUrl = (pfx, sfx = suffix) => `${origin}${pfx}${contentRoot}/assets/lingo/query-index${sfx}.json`;
 
-  queryIndexes[siteId] = processQueryIndexMap(indexUrl(prefix), host);
+  const primaryUrl = indexUrl(prefix);
+  queryIndexes[siteId] = processQueryIndexMap(primaryUrl, host);
 
   const { base: localeBase, prefix: localePrefix } = config.locale;
   let basePfx = localePrefix ?? '';
   if (localeBase !== undefined) basePfx = localeBase ? `/${localeBase}` : '';
-  baseQueryIndex = processQueryIndexMap(indexUrl(basePfx, ''), host);
+  const baseUrl = indexUrl(basePfx, '');
+  baseQueryIndex = primaryUrl === baseUrl ? queryIndexes[siteId] : processQueryIndexMap(baseUrl, host);
 
   Promise.all([queryIndexes[siteId]?.pathsRequest, baseQueryIndex?.pathsRequest].filter(Boolean))
     .then(() => window.dispatchEvent(new CustomEvent(MILO_EVENTS.QUERY_INDEX_PRIMARY_LOADED)));
@@ -2758,15 +2760,15 @@ export async function loadArea(area = document) {
     await loadLanguageConfig();
   }
 
-  if (isDoc) {
-    await decorateDocumentExtras();
-    initModalEventListener();
-  }
-
   const htmlSections = [...area.querySelectorAll(isDoc ? 'body > main > div' : ':scope > div')];
   htmlSections.forEach((section) => { section.className = 'section'; section.dataset.status = 'pending'; });
 
   if (isLingoActive) loadLingoIndexes(area);
+
+  if (isDoc) {
+    await decorateDocumentExtras();
+    initModalEventListener();
+  }
 
   const areaBlocks = [];
   let lcpSectionId = null;


### PR DESCRIPTION
### Description

Quick-win performance improvements for the personalization + lingo pipeline.

**1. `getManifestConfig` serial loop → `Promise.all`** (`personalization.js:1429`)
Each manifest JSON fetch was blocking the next. Now all fetches fire in parallel.
Estimated gain: 300–800 ms on pages with 3+ manifests.

**2. `categorizeActions` serial loop → `Promise.all`** (`personalization.js:1440`)
`categorizeActions` is effectively synchronous but was wrapped in a serial `for-await` loop. Now runs via `Promise.all` — eliminates microtask waterfall.

**3. `getEntitlementMap` in-flight dedup** (`personalization.js:1017`)
When `getManifestConfig` calls run concurrently via `Promise.all`, each calls `getPersonalizationVariant` → `getEntitlementMap`. Without dedup, N concurrent callers each issued a separate XLG tags fetch. Fixed by caching the in-flight promise on `config.mep.entitlementMapFetch`.

**4. `loadLingoIndexes` before `decorateDocumentExtras`** (`utils.js:2757`)
Sections (`.section` class) are now set up before `decorateDocumentExtras()` is awaited, so query-index fetches start while header/meta decoration runs.
Estimated gain: overlaps ~100–300 ms of `decorateDocumentExtras` latency.

**5. Query index URL dedup** (`utils.js:747`)
`loadQueryIndexes` was calling `processQueryIndexMap` twice with the same URL on prod/live when the locale prefix resolves to the same path for both the primary and base index. Now shares one in-flight fetch object.

**6. `market.js` modulepreload before `preview.js` import** (`personalization.js:1722`)
`preview.js` has a static `import` of `market.js`, creating a serial fetch waterfall. A `modulepreload` hint for `market.js` added right before the dynamic `import('./preview.js')` call lets both load in parallel.

Resolves: [MWPW-TBD](https://jira.corp.adobe.com/browse/MWPW-TBD)

**Test URLs (da-cc fr/creativecloud):**
- Before: https://main--da-cc--adobecom.aem.live/fr/creativecloud
- After: https://main--da-cc--adobecom.aem.live/fr/creativecloud?milolibs=mokimo-perf-quick-wins

**milo aem.page:**
- Before: https://main--milo--adobecom.aem.page/
- After: https://mokimo-perf-quick-wins--milo--adobecom.aem.page/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

