### PR TITLE
[MWPW-197665] Router Marquee RTL changes

### DIFF
--- a/libs/c2/blocks/router-marquee/router-marquee.css
+++ b/libs/c2/blocks/router-marquee/router-marquee.css
@@ -35,6 +35,10 @@
 }
 .rm-overlay { z-index: 1; }
 
+[dir="rtl"] .rm-overlay {
+  background: linear-gradient(108deg, rgba(0, 0, 0, 0.75) 45%, rgba(0, 0, 0, 0) 98.86%);
+}
+
 .rm-background picture {
   display: block;
   height: 100%;
@@ -71,6 +75,10 @@
     }
   }
 }
+
+ [dir="rtl"] .rm-content {
+    margin-inline-start: auto;
+  }
 
 .rm-eyebrow {
   font-weight: var(--s2a-font-weight-adobe-clean-bold);
@@ -407,6 +415,7 @@
 }
 
 /* tablet */
+
 @media (767px < width < 1280px) {
   .rm-viewport[data-viewport="tablet"] {
     display: flex;

--- a/libs/c2/blocks/router-marquee/router-marquee.css
+++ b/libs/c2/blocks/router-marquee/router-marquee.css
@@ -76,9 +76,9 @@
   }
 }
 
- [dir="rtl"] .rm-content {
-    margin-inline-start: auto;
-  }
+[dir="rtl"] .rm-content {
+  margin-inline-start: auto;
+}
 
 .rm-eyebrow {
   font-weight: var(--s2a-font-weight-adobe-clean-bold);

--- a/libs/c2/blocks/router-marquee/router-marquee.css
+++ b/libs/c2/blocks/router-marquee/router-marquee.css
@@ -415,7 +415,6 @@
 }
 
 /* tablet */
-
 @media (767px < width < 1280px) {
   .rm-viewport[data-viewport="tablet"] {
     display: flex;


### PR DESCRIPTION
## Description
This PR is enhancing the Router Marquee, for RTL locales:
- to move the text on the left hand side of the screen
- change the background overlay to a darker variant

## Related Issue
Resolves: [MWPW-197665](https://jira.corp.adobe.com/browse/MWPW-197665)

## Test URLs
- Before: https://main--upp--adobecom.aem.page/homepage/06-02-26-redesign-rollout-index-loggedout?martech=off
- After: https://main--upp--adobecom.aem.page/homepage/06-02-26-redesign-rollout-index-loggedout?milolibs=mwpw-197665&martech=off


