### PR TITLE
bacom0005: Add sticky navigation block with CSS and JS implementation

### DIFF
--- a/libs/mep/bacom0005/sticky-nav/sticky-nav.css
+++ b/libs/mep/bacom0005/sticky-nav/sticky-nav.css
@@ -236,4 +236,9 @@
     padding-left: 0 !important;
     padding-right: 0 !important;
   }
+
+  /* Aligns intro/outro sections to the same content column as sticky-nav sections */
+  .sticky-nav-align {
+    padding-left: calc(var(--grid-margins-width-10) + 268px + 40px) !important;
+  }
 }

--- a/libs/mep/bacom0005/sticky-nav/sticky-nav.css
+++ b/libs/mep/bacom0005/sticky-nav/sticky-nav.css
@@ -45,8 +45,7 @@
   font-weight: 400;
   line-height: 1.5;
   color: var(--color-black, #2c2c2c) !important;
-  text-decoration: underline !important;
-  text-underline-offset: 2px;
+  text-decoration: none !important;
   transition: opacity 0.15s;
 }
 
@@ -185,8 +184,7 @@
   font-weight: 400;
   line-height: 1.5;
   color: var(--color-black, #2c2c2c);
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  text-decoration: none;
   transition: opacity 0.15s;
 }
 

--- a/libs/mep/bacom0005/sticky-nav/sticky-nav.css
+++ b/libs/mep/bacom0005/sticky-nav/sticky-nav.css
@@ -1,0 +1,239 @@
+/* ── Two-column layout ───────────────────────────────────── */
+.ssn-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 40px;
+  padding-left: var(--grid-margins-width-10);
+  padding-right: var(--grid-margins-width-10);
+  padding-bottom: var(--spacing-m, 24px);
+}
+
+.ssn-nav-col {
+  width: 268px;
+  flex-shrink: 0;
+  position: sticky;
+  top: var(--nav-height, 80px);
+  align-self: flex-start;
+  box-sizing: border-box;
+}
+
+.ssn-content-col {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ── Desktop side nav ────────────────────────────────────── */
+.ssn-label {
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.5;
+  color: var(--color-black, #2c2c2c);
+  margin: 0 0 4px;
+  text-transform: uppercase;
+}
+
+.ssn-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ssn-nav-col .ssn-link {
+  display: block;
+  padding-top: 24px;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--color-black, #2c2c2c) !important;
+  text-decoration: underline !important;
+  text-underline-offset: 2px;
+  transition: opacity 0.15s;
+}
+
+.ssn-nav-col .ssn-link:hover {
+  opacity: 0.65;
+}
+
+.ssn-nav-col .ssn-link.is-active {
+  font-weight: 700 !important;
+  text-decoration: none !important;
+}
+
+/* Numbered nav */
+.ssn-link .ssn-num,
+.ssn-dropdown-link .ssn-num {
+  display: inline-block;
+  min-width: 24px;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.ssn-link .ssn-num::after,
+.ssn-dropdown-link .ssn-num::after {
+  content: ':';
+}
+
+.ssn-nav-col .ssn-link:has(.ssn-num),
+.ssn-dropdown-link:has(.ssn-num) {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+/* ── Overlay ─────────────────────────────────────────────── */
+.ssn-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 199;
+}
+
+.ssn-overlay.is-open {
+  display: block;
+}
+
+/* ── Mobile/tablet sticky bar ────────────────────────────── */
+.ssn-mobile {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  background: #fff;
+  border-bottom: 1px solid #e8e8e8;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+}
+
+.ssn-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 16px 20px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+}
+
+/* Closed: current section name */
+.ssn-bar-current {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--color-black, #2c2c2c);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Open: "JUMP TO SECTION" header */
+.ssn-bar-label {
+  display: none;
+  flex: 1;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.5;
+  color: var(--color-black, #2c2c2c);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.ssn-mobile.is-open .ssn-bar-current {
+  display: none;
+}
+
+.ssn-mobile.is-open .ssn-bar-label {
+  display: block;
+}
+
+.ssn-bar-icon {
+  flex-shrink: 0;
+  font-size: 18px;
+  font-weight: 300;
+  line-height: 1;
+  color: var(--color-black, #2c2c2c);
+  width: 18px;
+  text-align: center;
+}
+
+.ssn-dropdown {
+  background: #fff;
+  border-top: 1px solid #e8e8e8;
+  padding: 8px 20px 24px;
+}
+
+.ssn-dropdown[hidden] {
+  display: none;
+}
+
+.ssn-dropdown-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ssn-dropdown-link {
+  display: block;
+  padding-top: 24px;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--color-black, #2c2c2c);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: opacity 0.15s;
+}
+
+.ssn-dropdown-link:hover {
+  opacity: 0.65;
+}
+
+.ssn-dropdown-link.is-active {
+  font-weight: 700;
+  text-decoration: none;
+}
+
+/* ── Breakpoints ─────────────────────────────────────────── */
+@media (max-width: 1199px) {
+  .ssn-layout {
+    display: block;
+    padding: 0;
+  }
+
+  .ssn-nav-col {
+    display: none;
+  }
+
+  .ssn-mobile {
+    display: block;
+  }
+}
+
+@media (min-width: 1200px) {
+  .ssn-layout {
+    padding-bottom: var(--spacing-xl, 48px);
+  }
+
+  .ssn-mobile {
+    display: none !important;
+  }
+
+  .ssn-overlay {
+    display: none !important;
+  }
+
+  /* Strip section's own grid-width centering at desktop only — layout owns it */
+  .ssn-content-col .section {
+    max-width: none;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+}

--- a/libs/mep/bacom0005/sticky-nav/sticky-nav.css
+++ b/libs/mep/bacom0005/sticky-nav/sticky-nav.css
@@ -102,8 +102,8 @@
   left: 0;
   right: 0;
   z-index: 200;
-  background: #fff;
-  border-bottom: 1px solid #e8e8e8;
+  background: var(--color-white);
+  border-bottom: 1px solid var(--color-gray-200);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
 }
 
@@ -164,8 +164,8 @@
 }
 
 .ssn-dropdown {
-  background: #fff;
-  border-top: 1px solid #e8e8e8;
+  background: var(--color-white);
+  border-top: 1px solid var(--color-gray-200);
   padding: 8px 20px 24px;
 }
 

--- a/libs/mep/bacom0005/sticky-nav/sticky-nav.css
+++ b/libs/mep/bacom0005/sticky-nav/sticky-nav.css
@@ -30,6 +30,8 @@
   color: var(--color-black, #2c2c2c);
   margin: 0 0 4px;
   text-transform: uppercase;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .ssn-list {
@@ -40,7 +42,7 @@
 
 .ssn-nav-col .ssn-link {
   display: block;
-  padding-top: 24px;
+  padding-top: 16px;
   font-size: 16px;
   font-weight: 400;
   line-height: 1.5;
@@ -179,7 +181,7 @@
 
 .ssn-dropdown-link {
   display: block;
-  padding-top: 24px;
+  padding-top: 16px;
   font-size: 16px;
   font-weight: 400;
   line-height: 1.5;

--- a/libs/mep/bacom0005/sticky-nav/sticky-nav.js
+++ b/libs/mep/bacom0005/sticky-nav/sticky-nav.js
@@ -21,11 +21,11 @@ function getAnchorId(href) {
 function hasMeta(section, value) {
   if (section.classList.contains(value)) return true;
   // Milo section-metadata uses divs not table cells — check value cells (second div in each row)
-  const meta = section.querySelector('.section-metadata');
-  if (!meta) return false;
-  return [...meta.querySelectorAll(':scope > div > div:last-child')].some(
+  const metas = section.querySelectorAll('.section-metadata');
+  if (!metas.length) return false;
+  return [...metas].some((meta) => [...meta.querySelectorAll(':scope > div > div:last-child')].some(
     (cell) => cell.textContent.toLowerCase().split(',').map((s) => s.trim().replace(/\s+/g, '-')).includes(value),
-  );
+  ));
 }
 
 function getBlockConfig(block) {
@@ -306,7 +306,5 @@ export default function init(block) {
 
   const { links: blockLinks, label } = getBlockConfig(block);
   block.innerHTML = '';
-
-  // Defer discovery until after section-metadata has applied classes to siblings
-  setTimeout(() => setup(navSection, blockLinks, label), 0);
+  setup(navSection, blockLinks, label);
 }

--- a/libs/mep/bacom0005/sticky-nav/sticky-nav.js
+++ b/libs/mep/bacom0005/sticky-nav/sticky-nav.js
@@ -1,0 +1,285 @@
+import { createTag, loadStyle } from '../../../utils/utils.js';
+
+const ACTIVE_CLASS = 'is-active';
+const OPEN_CLASS = 'is-open';
+const DESKTOP_BREAKPOINT = 1200;
+const DEFAULT_LABEL = 'Jump to section';
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+function getAnchorId(href) {
+  return href?.split('#')[1] ?? '';
+}
+
+function hasMeta(section, value) {
+  if (section.classList.contains(value)) return true;
+  // Milo section-metadata uses divs not table cells — check value cells (second div in each row)
+  const meta = section.querySelector('.section-metadata');
+  if (!meta) return false;
+  return [...meta.querySelectorAll(':scope > div > div:last-child')].some(
+    (cell) => cell.textContent.toLowerCase().split(',').map((s) => s.trim().replace(/\s+/g, '-')).includes(value),
+  );
+}
+
+function getBlockConfig(block) {
+  const ol = block.querySelector('ol');
+  const ul = block.querySelector('ul');
+  const list = ol || ul;
+  const label = block.querySelector('p')?.textContent?.trim() || DEFAULT_LABEL;
+  if (!list) return { links: null, label };
+  const numbered = !!ol;
+  const links = [...list.querySelectorAll('li')].map((li, i) => {
+    const a = li.querySelector('a');
+    const text = li.textContent.trim();
+    const href = a?.getAttribute('href') ?? `#${slugify(text)}`;
+    return { label: text, href, ...(numbered && { num: i + 1 }) };
+  });
+  return { links: links.length ? links : null, label };
+}
+
+function discoverSections(navSection) {
+  let startEl = navSection.nextElementSibling;
+
+  const explicitStart = [...document.querySelectorAll('.section')].find((s) => hasMeta(s, 'sticky-nav-start'));
+  if (explicitStart) startEl = explicitStart;
+
+  const navLinks = [];
+  const allSections = [];
+  let el = startEl;
+
+  while (el) {
+    const skip = hasMeta(el, 'sticky-nav-skip');
+    if (!skip) {
+      const heading = el.querySelector('h2, h3');
+      if (heading) {
+        if (!heading.id) heading.id = slugify(heading.textContent);
+        navLinks.push({ label: heading.textContent.trim(), href: `#${heading.id}`, id: heading.id });
+      }
+    }
+    allSections.push(el);
+    if (hasMeta(el, 'sticky-nav-end')) break;
+    el = el.nextElementSibling;
+  }
+
+  return { navLinks, allSections };
+}
+
+function buildDesktopNav(links, label) {
+  const nav = createTag('nav', { class: 'ssn-desktop', 'aria-label': label });
+  const labelEl = createTag('p', { class: 'ssn-label' }, label.toUpperCase());
+  const list = createTag('ul', { class: 'ssn-list' });
+
+  links.forEach(({ label: text, href, num }) => {
+    const li = createTag('li');
+    const a = createTag('a', { href, class: 'ssn-link' });
+    if (num !== undefined) a.append(createTag('span', { class: 'ssn-num' }, String(num)));
+    a.append(createTag('span', { class: 'ssn-link-label' }, text));
+    li.append(a);
+    list.append(li);
+  });
+
+  nav.append(labelEl, list);
+  return nav;
+}
+
+function buildMobileNav(links, label) {
+  const nav = createTag('nav', { class: 'ssn-mobile', 'aria-label': label });
+  const overlay = createTag('div', { class: 'ssn-overlay', 'aria-hidden': 'true' });
+
+  const bar = createTag('button', { class: 'ssn-bar', 'aria-expanded': 'false', 'aria-haspopup': 'listbox' });
+  const firstLink = links[0];
+  let firstLabel = '';
+  if (firstLink) firstLabel = firstLink.num !== undefined ? `${firstLink.num}: ${firstLink.label}` : firstLink.label;
+  const barCurrent = createTag('span', { class: 'ssn-bar-current' }, firstLabel);
+  const barLabel = createTag('span', { class: 'ssn-bar-label' }, label.toUpperCase());
+  const barIcon = createTag('span', { class: 'ssn-bar-icon', 'aria-hidden': 'true' }, '+');
+  bar.append(barCurrent, barLabel, barIcon);
+
+  const dropdown = createTag('div', { class: 'ssn-dropdown', hidden: true, role: 'listbox' });
+  const dropList = createTag('ul', { class: 'ssn-dropdown-list' });
+
+  links.forEach(({ label: text, href, num }) => {
+    const li = createTag('li', { role: 'option' });
+    const a = createTag('a', { href, class: 'ssn-dropdown-link' });
+    if (num !== undefined) a.append(createTag('span', { class: 'ssn-num' }, String(num)));
+    a.append(createTag('span', { class: 'ssn-link-label' }, text));
+    li.append(a);
+    dropList.append(li);
+  });
+
+  dropdown.append(dropList);
+  nav.append(bar, dropdown);
+
+  function openDropdown() {
+    bar.setAttribute('aria-expanded', 'true');
+    dropdown.hidden = false;
+    nav.classList.add(OPEN_CLASS);
+    overlay.classList.add(OPEN_CLASS);
+    barIcon.textContent = '—';
+  }
+
+  function closeDropdown() {
+    bar.setAttribute('aria-expanded', 'false');
+    dropdown.hidden = true;
+    nav.classList.remove(OPEN_CLASS);
+    overlay.classList.remove(OPEN_CLASS);
+    barIcon.textContent = '+';
+  }
+
+  bar.addEventListener('click', () => {
+    if (bar.getAttribute('aria-expanded') === 'true') closeDropdown();
+    else openDropdown();
+  });
+
+  overlay.addEventListener('click', closeDropdown);
+
+  dropList.addEventListener('click', (e) => {
+    if (e.target.closest('a')) closeDropdown();
+  });
+
+  return { nav, overlay, barCurrent, dropList };
+}
+
+function setupLayout(navSection, desktopNav, allSections) {
+  if (!allSections.length) return;
+
+  const layout = createTag('div', { class: 'ssn-layout' });
+  const navCol = createTag('div', { class: 'ssn-nav-col' });
+  const contentCol = createTag('div', { class: 'ssn-content-col' });
+
+  navCol.append(desktopNav);
+  allSections.forEach((s) => contentCol.append(s));
+
+  layout.append(navCol, contentCol);
+  navSection.replaceWith(layout);
+}
+
+function observeSections(allSections, onActive, defaultId) {
+  const THRESHOLD = 0.3;
+
+  function update() {
+    const limit = window.innerHeight * THRESHOLD;
+    let activeId = null;
+    for (const section of allSections) {
+      const { top } = section.getBoundingClientRect();
+      if (top <= limit) {
+        const heading = section.querySelector('h2[id], h3[id]');
+        if (heading) activeId = heading.id;
+      }
+    }
+    onActive(activeId ?? defaultId);
+  }
+
+  window.addEventListener('scroll', update, { passive: true });
+}
+
+function setup(navSection, blockLinks, label) {
+  const { navLinks, allSections } = discoverSections(navSection);
+
+  // blockLinks supply display labels (and optional numbering);
+  // hrefs/ids come from discovered headings
+  let links;
+  if (blockLinks && navLinks.length) {
+    links = blockLinks.map((bl, i) => ({
+      ...bl,
+      href: navLinks[i]?.href ?? bl.href,
+      id: navLinks[i]?.id ?? bl.href.split('#')[1],
+    }));
+  } else {
+    links = blockLinks ?? navLinks;
+  }
+  if (!links.length) return;
+
+  const desktopNav = buildDesktopNav(links, label);
+  const { nav: mobileNav, overlay, barCurrent, dropList } = buildMobileNav(links, label);
+
+  const main = document.querySelector('main');
+  document.body.insertBefore(overlay, main ?? null);
+  document.body.insertBefore(mobileNav, main ?? null);
+
+  const anchorHeadings = links.map(({ id }) => document.getElementById(id)).filter(Boolean);
+
+  function getHeaderBottom() {
+    return document.querySelector('header')?.getBoundingClientRect().bottom ?? 0;
+  }
+
+  function positionMobileNav() {
+    const top = getHeaderBottom();
+    mobileNav.style.top = `${top}px`;
+    overlay.style.top = `${top}px`;
+    const offset = top + mobileNav.offsetHeight;
+    anchorHeadings.forEach((h) => { h.style.scrollMarginTop = `${offset}px`; });
+  }
+
+  function positionDesktopNav() {
+    const top = getHeaderBottom();
+    anchorHeadings.forEach((h) => { h.style.scrollMarginTop = `${top}px`; });
+  }
+
+  function positionNav() {
+    if (window.innerWidth >= DESKTOP_BREAKPOINT) positionDesktopNav();
+    else positionMobileNav();
+  }
+
+  positionNav();
+  window.addEventListener('resize', positionNav, { passive: true });
+
+  const header = document.querySelector('header');
+  if (header && window.ResizeObserver) {
+    new ResizeObserver(positionNav).observe(header);
+  }
+
+  setupLayout(navSection, desktopNav, allSections);
+
+  let currentId = null;
+
+  function setActive(id) {
+    if (id === currentId) return;
+    currentId = id;
+
+    desktopNav.querySelectorAll('.ssn-link').forEach((a) => {
+      a.classList.toggle(ACTIVE_CLASS, getAnchorId(a.getAttribute('href')) === id);
+    });
+
+    dropList.querySelectorAll('.ssn-dropdown-link').forEach((a) => {
+      a.classList.toggle(ACTIVE_CLASS, getAnchorId(a.getAttribute('href')) === id);
+    });
+
+    const active = links.find((l) => l.id === id);
+    if (active) {
+      barCurrent.textContent = active.num !== undefined ? `${active.num}: ${active.label}` : active.label;
+    }
+  }
+
+  // Set active immediately on click, don't wait for scroll observer
+  desktopNav.querySelectorAll('.ssn-link').forEach((a) => {
+    a.addEventListener('click', () => setActive(getAnchorId(a.getAttribute('href'))));
+  });
+
+  dropList.querySelectorAll('.ssn-dropdown-link').forEach((a) => {
+    a.addEventListener('click', () => setActive(getAnchorId(a.getAttribute('href'))));
+  });
+
+  setActive(links[0].id);
+  observeSections(allSections, setActive, links[0].id);
+}
+
+export default function init(block) {
+  loadStyle(new URL('./sticky-nav.css', import.meta.url).href);
+
+  const navSection = block.closest('.section');
+  if (!navSection) return;
+
+  const { links: blockLinks, label } = getBlockConfig(block);
+  block.innerHTML = '';
+
+  // Defer discovery until after section-metadata has applied classes to siblings
+  setTimeout(() => setup(navSection, blockLinks, label), 0);
+}

--- a/libs/mep/bacom0005/sticky-nav/sticky-nav.js
+++ b/libs/mep/bacom0005/sticky-nav/sticky-nav.js
@@ -3,7 +3,6 @@ import { createTag, loadStyle } from '../../../utils/utils.js';
 const ACTIVE_CLASS = 'is-active';
 const OPEN_CLASS = 'is-open';
 const DESKTOP_BREAKPOINT = 1200;
-const DEFAULT_LABEL = 'Jump to section';
 
 function slugify(text) {
   return text
@@ -32,7 +31,7 @@ function getBlockConfig(block) {
   const ol = block.querySelector('ol');
   const ul = block.querySelector('ul');
   const list = ol || ul;
-  const label = block.querySelector('p')?.textContent?.trim() || DEFAULT_LABEL;
+  const label = block.querySelector('p')?.textContent?.trim() || '';
   if (!list) return { links: null, label };
   const numbered = !!ol;
   const links = [...list.querySelectorAll('li')].map((li, i) => {
@@ -53,6 +52,7 @@ function discoverSections(navSection) {
   const navLinks = [];
   const allSections = [];
   let el = startEl;
+  let foundEnd = false;
 
   while (el) {
     const skip = hasMeta(el, 'sticky-nav-skip');
@@ -64,16 +64,20 @@ function discoverSections(navSection) {
       }
     }
     allSections.push(el);
-    if (hasMeta(el, 'sticky-nav-end')) break;
+    if (hasMeta(el, 'sticky-nav-end')) { foundEnd = true; break; }
     el = el.nextElementSibling;
+  }
+
+  if (!foundEnd) {
+    // eslint-disable-next-line no-console
+    console.warn('[sticky-nav] No sticky-nav-end marker found — walked to end of main.');
   }
 
   return { navLinks, allSections };
 }
 
 function buildDesktopNav(links, label) {
-  const nav = createTag('nav', { class: 'ssn-desktop', 'aria-label': label });
-  const labelEl = createTag('p', { class: 'ssn-label' }, label.toUpperCase());
+  const nav = createTag('nav', { class: 'ssn-desktop', ...(label && { 'aria-label': label }) });
   const list = createTag('ul', { class: 'ssn-list' });
 
   links.forEach(({ label: text, href, num }) => {
@@ -85,26 +89,26 @@ function buildDesktopNav(links, label) {
     list.append(li);
   });
 
-  nav.append(labelEl, list);
+  if (label) nav.append(createTag('p', { class: 'ssn-label' }, label.toUpperCase()));
+  nav.append(list);
   return nav;
 }
 
 function buildMobileNav(links, label) {
-  const nav = createTag('nav', { class: 'ssn-mobile', 'aria-label': label });
+  const nav = createTag('nav', { class: 'ssn-mobile', ...(label && { 'aria-label': label }) });
   const overlay = createTag('div', { class: 'ssn-overlay', 'aria-hidden': 'true' });
 
   const dropId = `ssn-dropdown-${Math.random().toString(36).slice(2, 7)}`;
   const bar = createTag('button', {
     class: 'ssn-bar',
     'aria-expanded': 'false',
-    'aria-haspopup': 'true',
     'aria-controls': dropId,
   });
   const firstLink = links[0];
   let firstLabel = '';
   if (firstLink) firstLabel = firstLink.num !== undefined ? `${firstLink.num}: ${firstLink.label}` : firstLink.label;
   const barCurrent = createTag('span', { class: 'ssn-bar-current' }, firstLabel);
-  const barLabel = createTag('span', { class: 'ssn-bar-label' }, label.toUpperCase());
+  const barLabel = createTag('span', { class: 'ssn-bar-label' }, label ? label.toUpperCase() : '');
   const barIcon = createTag('span', { class: 'ssn-bar-icon', 'aria-hidden': 'true' }, '+');
   bar.append(barCurrent, barLabel, barIcon);
 

--- a/libs/mep/bacom0005/sticky-nav/sticky-nav.js
+++ b/libs/mep/bacom0005/sticky-nav/sticky-nav.js
@@ -93,7 +93,13 @@ function buildMobileNav(links, label) {
   const nav = createTag('nav', { class: 'ssn-mobile', 'aria-label': label });
   const overlay = createTag('div', { class: 'ssn-overlay', 'aria-hidden': 'true' });
 
-  const bar = createTag('button', { class: 'ssn-bar', 'aria-expanded': 'false', 'aria-haspopup': 'listbox' });
+  const dropId = `ssn-dropdown-${Math.random().toString(36).slice(2, 7)}`;
+  const bar = createTag('button', {
+    class: 'ssn-bar',
+    'aria-expanded': 'false',
+    'aria-haspopup': 'true',
+    'aria-controls': dropId,
+  });
   const firstLink = links[0];
   let firstLabel = '';
   if (firstLink) firstLabel = firstLink.num !== undefined ? `${firstLink.num}: ${firstLink.label}` : firstLink.label;
@@ -102,11 +108,11 @@ function buildMobileNav(links, label) {
   const barIcon = createTag('span', { class: 'ssn-bar-icon', 'aria-hidden': 'true' }, '+');
   bar.append(barCurrent, barLabel, barIcon);
 
-  const dropdown = createTag('div', { class: 'ssn-dropdown', hidden: true, role: 'listbox' });
-  const dropList = createTag('ul', { class: 'ssn-dropdown-list' });
+  const dropdown = createTag('div', { class: 'ssn-dropdown', id: dropId, hidden: true });
+  const dropList = createTag('ul', { class: 'ssn-dropdown-list', role: 'list' });
 
   links.forEach(({ label: text, href, num }) => {
-    const li = createTag('li', { role: 'option' });
+    const li = createTag('li', { role: 'listitem' });
     const a = createTag('a', { href, class: 'ssn-dropdown-link' });
     if (num !== undefined) a.append(createTag('span', { class: 'ssn-num' }, String(num)));
     a.append(createTag('span', { class: 'ssn-link-label' }, text));
@@ -123,6 +129,7 @@ function buildMobileNav(links, label) {
     nav.classList.add(OPEN_CLASS);
     overlay.classList.add(OPEN_CLASS);
     barIcon.textContent = '—';
+    dropdown.querySelector('.ssn-dropdown-link')?.focus();
   }
 
   function closeDropdown() {
@@ -131,11 +138,25 @@ function buildMobileNav(links, label) {
     nav.classList.remove(OPEN_CLASS);
     overlay.classList.remove(OPEN_CLASS);
     barIcon.textContent = '+';
+    bar.focus();
   }
 
   bar.addEventListener('click', () => {
     if (bar.getAttribute('aria-expanded') === 'true') closeDropdown();
     else openDropdown();
+  });
+
+  bar.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeDropdown();
+  });
+
+  dropdown.addEventListener('keydown', (e) => {
+    const items = [...dropdown.querySelectorAll('.ssn-dropdown-link')];
+    const idx = items.indexOf(document.activeElement);
+    if (e.key === 'ArrowDown') { e.preventDefault(); items[idx + 1]?.focus(); }
+    if (e.key === 'ArrowUp') { e.preventDefault(); if (items[idx - 1]) items[idx - 1].focus(); else bar.focus(); }
+    if (e.key === 'Escape') closeDropdown();
+    if (e.key === 'Tab' && !e.shiftKey && idx === items.length - 1) closeDropdown();
   });
 
   overlay.addEventListener('click', closeDropdown);
@@ -245,11 +266,17 @@ function setup(navSection, blockLinks, label) {
     currentId = id;
 
     desktopNav.querySelectorAll('.ssn-link').forEach((a) => {
-      a.classList.toggle(ACTIVE_CLASS, getAnchorId(a.getAttribute('href')) === id);
+      const isActive = getAnchorId(a.getAttribute('href')) === id;
+      a.classList.toggle(ACTIVE_CLASS, isActive);
+      if (isActive) a.setAttribute('aria-current', 'location');
+      else a.removeAttribute('aria-current');
     });
 
     dropList.querySelectorAll('.ssn-dropdown-link').forEach((a) => {
-      a.classList.toggle(ACTIVE_CLASS, getAnchorId(a.getAttribute('href')) === id);
+      const isActive = getAnchorId(a.getAttribute('href')) === id;
+      a.classList.toggle(ACTIVE_CLASS, isActive);
+      if (isActive) a.setAttribute('aria-current', 'location');
+      else a.removeAttribute('aria-current');
     });
 
     const active = links.find((l) => l.id === id);


### PR DESCRIPTION
* Add sticky side navigation block for BACOM0005 A/B test on Adobe Business blog pages
* Desktop: two-column layout with sticky side nav column
* Mobile/tablet: fixed sticky bar with collapsible dropdown
* Auto-discovers sections and headings — no authoring of anchor links required
* Supports sticky-nav-start, sticky-nav-end, sticky-nav-skip section-metadata flags

Resolves: [OPT-36730](https://jira.corp.adobe.com/browse/OPT-36730)

**Test URLs:**
- Before: https://main--da-bacom-blog--adobecom.aem.page/blog/fragments/tests/2026/bacom0005/bacom0005-best-website-design-examples?mep=%2Fblog%2Ffragments%2Ftests%2F2026%2Fbacom0005%2Fbacom0005.json--all
- After: https://main--da-bacom-blog--adobecom.aem.page/blog/fragments/tests/2026/bacom0005/bacom0005-best-website-design-examples?milolibs=bacom0005&mep=%2Fblog%2Ffragments%2Ftests%2F2026%2Fbacom0005%2Fbacom0005.json--all

**Images/Recordings:**
- Before: 
<img width="1713" height="941" alt="baccom0005-before-recording" src="https://github.com/user-attachments/assets/f253e586-3fa2-466d-8d72-6bb0e6dfb66c" />

- After: 
<img width="1713" height="941" alt="baccom0005-after-recording" src="https://github.com/user-attachments/assets/9d4176de-018d-49e0-8bda-34b51fb577da" />


















