### PR TITLE
[UNAV 1.6] - Added correct AUP SDK prod url

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -993,8 +993,12 @@ class Gnav {
     const lingoRegion = lingoActive() ? await getLingoRegion() : null;
     const locale = lingoRegion?.ietf || config.locale?.ietf || 'en-US';
 
+    const aupHost = environment === 'prod'
+      ? 'shared-components.adobe.com'
+      : `shared-components.${environment}.adobe.com`;
+
     await loadScript(
-      `https://shared-components.${environment}.adobe.com/aup-sdk/1.0.756/main.js`,
+      `https://${aupHost}/aup-sdk/1.0.756/main.js`,
       null,
       { mode: 'async' },
     );

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -993,12 +993,8 @@ class Gnav {
     const lingoRegion = lingoActive() ? await getLingoRegion() : null;
     const locale = lingoRegion?.ietf || config.locale?.ietf || 'en-US';
 
-    const aupHost = environment === 'prod'
-      ? 'shared-components.adobe.com'
-      : `shared-components.${environment}.adobe.com`;
-
     await loadScript(
-      `https://${aupHost}/aup-sdk/1.0.756/main.js`,
+      `https://shared-components.${environment === 'prod' ? '' : `${environment}.`}adobe.com/aup-sdk/1.0.756/main.js`,
       null,
       { mode: 'async' },
     );


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Added correct prod url for AUP SDK

Resolves: [MWPW-199346](https://jira.corp.adobe.com/browse/MWPW-199346)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://aup-prod-url--milo--adobecom.aem.page/?martech=off

QA: https://www.stage.adobe.com/products/photoshop.html?milolibs=aup-prod-url


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=aup-prod-url--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=aup-prod-url--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=aup-prod-url--milo--adobecom
- Milo: https://aup-prod-url--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=aup-prod-url--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=aup-prod-url--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=aup-prod-url--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=aup-prod-url--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=aup-prod-url--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=aup-prod-url--milo--adobecom
- Milo: https://aup-prod-url--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=aup-prod-url--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=aup-prod-url--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=aup-prod-url--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=aup-prod-url--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=aup-prod-url--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=aup-prod-url--milo--adobecom
- Milo: https://aup-prod-url--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=aup-prod-url--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=aup-prod-url--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=aup-prod-url--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=aup-prod-url--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=aup-prod-url--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=aup-prod-url--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=aup-prod-url--milo--adobecom
</details>