### PR TITLE
[PDF-Space][SR] Fix safari img stretch

### DIFF
--- a/libs/mep/ace1205/pdf-space/pdf-space.css
+++ b/libs/mep/ace1205/pdf-space/pdf-space.css
@@ -157,6 +157,10 @@
       padding: 10px;
       width: auto;
       height: 95%;
+
+      img {
+        width: auto;
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fix acrobat mockup ui side panel getting stretched on Safari

Resolves: https://jira.corp.adobe.com/browse/MWPW-198501

**Test URLs:**
- Before: https://www.stage.adobe.com/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all&martech=off
- After: https://www.stage.adobe.com/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all&milolibs=pdf-space-safari-fix&martech=off
