### PR TITLE
[SR]MWPW-198935: Fix obscured focus

### DIFF
--- a/libs/scripts/accessibility.js
+++ b/libs/scripts/accessibility.js
@@ -1,3 +1,8 @@
+import { getMetadata } from '../utils/utils.js';
+
+let c2DefferTimeout = null;
+const isC2 = getMetadata('foundation') === 'c2';
+
 function getActiveEl(target) {
   let active = target.shadowRoot?.activeElement ?? target;
   while (active.shadowRoot?.activeElement) {
@@ -96,7 +101,17 @@ function scrollTabFocusedElIntoView() {
 
   document.addEventListener('focusin', (e) => {
     if (!isTab && !e.target.closest('footer')) return;
-    scrollElement(e.target);
+    const { target } = e;
+    if (!isC2) {
+      scrollElement(target);
+      return;
+    }
+
+    clearTimeout(c2DefferTimeout);
+    c2DefferTimeout = setTimeout(() => {
+      if (document.activeElement !== target) return;
+      scrollElement(target);
+    });
   });
 }
 


### PR DESCRIPTION
Issue: Because of the `line-height` animation in the `rich-content` above the `side-by-side`, at the time of the `focusin` firing, `play/pause` is in center, logic runs at concludes that there is no need for additional scroll. After that `line-height` animation finishes and element ends up bellow the navigation. 

* Add timeout for c2 pages to delay execution. 

Resolves: [MWPW-198935](https://jira.corp.adobe.com/browse/MWPW-198935)

**QA NOTE:** To properly test the fix, please await for `/scripts/accessibility.js` to load.    

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=side-by-side-focus&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


