### PR TITLE
MWPW-199473 Fix dynamic-nav status bar RTL layout

### DIFF
--- a/libs/features/dynamic-navigation/status.css
+++ b/libs/features/dynamic-navigation/status.css
@@ -115,7 +115,7 @@
   width: 6px;
   height: 6px;
   left: 4px;
-  top: -8px;
+  top: -7px;
   font-size: 18px;
   font-weight: 600;
 }
@@ -181,6 +181,35 @@
 .dynamic-nav-status .disable-values td {
   border: 1px solid rgb(160 160 160);
   padding: 8px 10px;
+}
+
+[dir="rtl"] .dynamic-nav-status {
+  right: auto;
+  left: 32px;
+  justify-content: center;
+}
+
+[dir="rtl"] .dynamic-nav-status .title {
+  align-items: center;
+}
+
+[dir="rtl"] .dynamic-nav-status .dns-badge {
+  margin: 4px 0 4px 8px;
+}
+
+[dir="rtl"] .dynamic-nav-status .details {
+  right: auto;
+  left: -14px;
+}
+
+[dir="rtl"] .dynamic-nav-status .dns-close::after {
+  top: -4px;
+  left: 6px;
+}
+
+[dir="rtl"] .dynamic-nav-status .details::before {
+  right: auto;
+  left: 75px;
 }
 
 @media screen and (max-width: 600px) {


### PR DESCRIPTION

- Adds `[dir="rtl"]` overrides to `libs/features/dynamic-navigation/status.css`
- Moves the fixed-position status pill to the left side in RTL so it no longer overlaps the hamburger menu
- Flips the details panel and its triangle pointer to the left
- Adjusts badge margin, close button, and title centering for RTL


Fixes: [MWPW-199473](https://jira.corp.adobe.com/browse/MWPW-199473)

- CC Before: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=stage
- CC After: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-199473-dynamic-nav-rtl-fix

Actual Test Page: 
https://www.stage.adobe.com/mena_ar/creativecloud.html?milolibs=MWPW-199473-dynamic-nav-rtl-fix