### PR TITLE
[sr] bentos wave 3

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1015,6 +1015,12 @@ p {
 }
 
 .dark {
+  a.standalone-link {
+    &::after {
+      filter: invert(1);
+    }
+  }
+
   .con-button {
     &.outline {
       background-color: var(--s2a-color-transparent-white-00);

--- a/libs/mep/ace1209/explore-card/explore-card.css
+++ b/libs/mep/ace1209/explore-card/explore-card.css
@@ -109,6 +109,8 @@
   min-height: 240px;
 
   .icon {
+    display: flex;
+    gap: var(--s2a-spacing-xs);
     flex-shrink: 0;
     margin-bottom: var(--s2a-spacing-2xl);
   }

--- a/libs/mep/ace1209/explore-card/explore-card.js
+++ b/libs/mep/ace1209/explore-card/explore-card.js
@@ -39,11 +39,10 @@ function decorate(block, root, el) {
     prodIcons.forEach((icon) => {
       if (isSvgUrl(icon.src)) icon.src = getFederatedUrl(icon.src);
       const para = icon.closest('p');
-      if (para && para !== iconPara) {
-        const pic = icon.parentElement?.tagName === 'PICTURE' ? icon.parentElement : icon;
-        iconPara?.append(pic);
-        para.remove();
-      }
+      if (!para || para === iconPara) return;
+      const pic = icon.parentElement?.tagName === 'PICTURE' ? icon.parentElement : icon;
+      iconPara?.append(pic);
+      para.remove();
     });
   }
 

--- a/libs/mep/ace1209/explore-card/explore-card.js
+++ b/libs/mep/ace1209/explore-card/explore-card.js
@@ -26,16 +26,25 @@ function decorate(block, root, el) {
   const contentDiv = firstRow.querySelector(':scope > div:first-child');
   const backgroundDiv = firstRow.querySelector(':scope > div:last-child');
   const isSvgUrl = (url) => /\.svg(\?.*)?$/i.test(url || '');
-  const prodIcon = contentDiv?.querySelector('img');
+  const prodIcons = [...(contentDiv?.querySelectorAll('img') ?? [])];
   const isVideoHref = (href) => /\.(mp4|webm|ogg|mov|m4v)(\?[^#]*)?(#.*)?$/i.test(href);
   const link = [...(contentDiv?.querySelectorAll('a[href]:not([data-video-poster])') ?? [])]
     .find((a) => !isVideoHref(a.href)) ?? null;
   const heading = contentDiv?.querySelector(':is(h1, h2, h3, h4, h5, h6)');
   const contentAux = createTag('div', { class: 'content-aux' });
 
-  if (prodIcon && isSvgUrl(prodIcon.src)) {
-    prodIcon.src = getFederatedUrl(prodIcon.src);
-    prodIcon.closest('p').classList.add('icon');
+  if (prodIcons.length) {
+    const iconPara = prodIcons[0].closest('p');
+    iconPara?.classList.add('icon');
+    prodIcons.forEach((icon) => {
+      if (isSvgUrl(icon.src)) icon.src = getFederatedUrl(icon.src);
+      const para = icon.closest('p');
+      if (para && para !== iconPara) {
+        const pic = icon.parentElement?.tagName === 'PICTURE' ? icon.parentElement : icon;
+        iconPara?.append(pic);
+        para.remove();
+      }
+    });
   }
 
   backgroundDiv?.classList.add(`${blockName}-background`);

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -179,7 +179,7 @@
 
   &.bento .explore-card {
     border-radius: var(--s2a-border-radius-md);
-    border: 2px inset rgb(255 255 255 / 10%);
+    border: var(--s2a-border-width-md) inset var(--s2a-color-transparent-white-12);
     z-index: inherit;
 
     .explore-card-container:hover [class*='body-'] {

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -85,13 +85,21 @@
 
     [class*='heading-'],
     [class*='body-'] {
-      padding-inline: var(--s2a-spacing-xl);
+      padding-inline: var(--s2a-spacing-lg);
       max-width: 450px;
+    }
+
+    .icon {
+      position: absolute;
+      inset: var(--s2a-spacing-lg);
+      z-index: 1;
+      text-align: start;
     }
 
     .explore-card-foreground {
       aspect-ratio: 1 / 1.2;
       transition: filter 0.3s ease-in-out, transform 0.3s ease-out;
+      will-change: transform;
 
       img {
         object-fit: cover;
@@ -166,8 +174,12 @@
     }
   }
 
+  &.bento .explore-card.dark,
+  &.bento .explore-card.light {background-color: transparent;} 
+
   &.bento .explore-card {
     border-radius: var(--s2a-border-radius-md);
+    border: 2px inset rgb(255 255 255 / 10%);
     z-index: inherit;
 
     .explore-card-container:hover [class*='body-'] {
@@ -202,6 +214,7 @@
       & .explore-card-foreground {
         filter: brightness(0.98);
         transform: scale(1.015);
+        will-change: transform;
       }
     }
   }
@@ -357,12 +370,16 @@
 @media (width >= 1440px) {
   .section.bento {
     .explore-card-content {
-      padding-bottom: var(--s2a-spacing-3xl);
+      padding-bottom: var(--s2a-spacing-xl);
       min-height: initial;
 
       [class*='heading-'],
       [class*='body-'] {
-        padding-inline: var(--s2a-spacing-3xl);
+        padding-inline: var(--s2a-spacing-xl);
+      }
+
+      .icon {
+        inset: var(--s2a-spacing-xl);
       }
     }
   }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Added inset border around bento boxes
* Display icon/nemonic (supports multiple)
* Spacing updates within bentos:
  * XL, L : From 48px –> 32px
  * M: From 32px –> 24px
  * S : 24px (same)
* Global fix for `stand-alone `link icon to work with dark mode  


Resolves: 
* [MWPW-199377](https://jira.corp.adobe.com/browse/MWPW-199377)
* [MWPW-198997](https://jira.corp.adobe.com/browse/MWPW-198997)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=bentos-w3&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all




