### PR TITLE
MWPW-192062: Add z-index to plain content when section has background

### DIFF
--- a/libs/c2/blocks/section-metadata/section-metadata.css
+++ b/libs/c2/blocks/section-metadata/section-metadata.css
@@ -5,6 +5,10 @@
 .section {
   &.has-background {
     background-color: unset;
+
+    > .content {
+      z-index: 0;
+    }
   }
 
   &.divider {

--- a/libs/mep/ace1201/section-metadata/section-metadata.css
+++ b/libs/mep/ace1201/section-metadata/section-metadata.css
@@ -5,6 +5,10 @@
 .section {
   &.has-background {
     background-color: unset;
+
+    > .content {
+      z-index: 0;
+    }
   }
 
   &.divider {

--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -5,6 +5,10 @@
 .section {
   &.has-background {
     background-color: unset;
+
+    > .content {
+      z-index: 0;
+    }
   }
 
   &.divider {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Resolves: [MWPW-192062](https://jira.corp.adobe.com/browse/MWPW-192062)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/document
- After: https://mwpw-192062-section-background--milo--adobecom.aem.page/drafts/ratko/document
- Before: https://main--milo--adobecom.aem.page/drafts/klee/c2/background-zindex
- After: https://mwpw-192062-section-background--milo--adobecom.aem.page/drafts/klee/c2/background-zindex



