### PR TITLE
MWPW-193755 country param

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -964,12 +964,15 @@ function setCountry() {
   sessionStorage.setItem('feds_location', JSON.stringify({ country: country.toUpperCase() }));
 }
 
+export function getCountryFromParams(searchParams) {
+  const validate = (v) => (typeof v === 'string' && /^[a-zA-Z]{2,6}$/.test(v) ? v : null);
+  return validate(searchParams.get('country')) || validate(searchParams.get('akamaiLocale'));
+}
+
 export async function getCountry(skipFallback = false) {
   if (isBot()) return null;
 
-  const rawAkamai = PAGE_URL.searchParams.get('akamaiLocale');
-  const akamaiLocale = /^[a-zA-Z]{2,6}$/.test(rawAkamai) ? rawAkamai : null;
-  const country = akamaiLocale || sessionStorage.getItem('akamai');
+  const country = getCountryFromParams(PAGE_URL.searchParams) || sessionStorage.getItem('akamai');
   if (country || skipFallback) return country?.toLowerCase();
 
   try {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -964,12 +964,15 @@ function setCountry() {
   sessionStorage.setItem('feds_location', JSON.stringify({ country: country.toUpperCase() }));
 }
 
-export async function getCountry(skipFallback = false) {
+export async function getCountry(skipFallback = false, searchParams = PAGE_URL.searchParams) {
   if (isBot()) return null;
 
-  const rawAkamai = PAGE_URL.searchParams.get('akamaiLocale');
-  const akamaiLocale = /^[a-zA-Z]{2,6}$/.test(rawAkamai) ? rawAkamai : null;
-  const country = akamaiLocale || sessionStorage.getItem('akamai');
+  const validate = (v) => (typeof v === 'string' && /^[a-zA-Z]{2,6}$/.test(v) ? v : null);
+  const getParam = (name) => [...searchParams]
+    .find(([key]) => key.toLowerCase() === name)?.[1] ?? null;
+  const country = validate(getParam('country'))
+    || validate(getParam('akamailocale'))
+    || sessionStorage.getItem('akamai');
   if (country || skipFallback) return country?.toLowerCase();
 
   try {

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2729,6 +2729,47 @@ describe('Utils', () => {
     });
   });
 
+  describe('getCountry query params', () => {
+    // getCountry reads PAGE_URL.searchParams (frozen at module load); the optional
+    // searchParams arg is the test seam. skipFallback=true avoids the geo import.
+    const params = (qs) => new URLSearchParams(qs);
+    const country = (qs) => utils.getCountry(true, params(qs));
+
+    beforeEach(() => sessionStorage.removeItem('akamai'));
+    afterEach(() => sessionStorage.removeItem('akamai'));
+
+    it('reads the country param (country-only)', async () => {
+      expect(await country('country=sg')).to.equal('sg');
+    });
+
+    it('reads the akamaiLocale param (akamaiLocale-only)', async () => {
+      expect(await country('akamaiLocale=sg')).to.equal('sg');
+    });
+
+    it('resolves ?country=sg the same as ?akamaiLocale=sg', async () => {
+      expect(await country('country=sg')).to.equal(await country('akamaiLocale=sg'));
+    });
+
+    it('prefers country over akamaiLocale when both are set', async () => {
+      expect(await country('country=sg&akamaiLocale=fr')).to.equal('sg');
+    });
+
+    it('falls through to akamaiLocale when country is invalid', async () => {
+      expect(await country('country=123&akamaiLocale=fr')).to.equal('fr');
+    });
+
+    it('falls through to sessionStorage when neither param is valid', async () => {
+      sessionStorage.setItem('akamai', 'de');
+      expect(await country('country=1&akamaiLocale=99')).to.equal('de');
+    });
+
+    it('matches the param name case-insensitively (and lowercases the value)', async () => {
+      expect(await country('akamailocale=SG')).to.equal('sg');
+      expect(await country('AkamaiLocale=sg')).to.equal('sg');
+      expect(await country('COUNTRY=sg')).to.equal('sg');
+    });
+  });
+
   describe('getLingoRegion', () => {
     let lingoModule;
 

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2729,6 +2729,39 @@ describe('Utils', () => {
     });
   });
 
+  describe('getCountryFromParams', () => {
+    const params = (qs) => new URLSearchParams(qs);
+
+    it('reads the country param (country-only)', () => {
+      expect(utils.getCountryFromParams(params('country=sg'))).to.equal('sg');
+    });
+
+    it('reads the akamaiLocale param (akamaiLocale-only)', () => {
+      expect(utils.getCountryFromParams(params('akamaiLocale=sg'))).to.equal('sg');
+    });
+
+    it('produces the same result for ?country= as ?akamaiLocale=', () => {
+      expect(utils.getCountryFromParams(params('country=sg')))
+        .to.equal(utils.getCountryFromParams(params('akamaiLocale=sg')));
+    });
+
+    it('prefers country over akamaiLocale when both are set', () => {
+      expect(utils.getCountryFromParams(params('country=sg&akamaiLocale=fr'))).to.equal('sg');
+    });
+
+    it('falls through to akamaiLocale when country is invalid', () => {
+      expect(utils.getCountryFromParams(params('country=123&akamaiLocale=fr'))).to.equal('fr');
+    });
+
+    it('ignores an invalid akamaiLocale too (neither valid)', () => {
+      expect(utils.getCountryFromParams(params('country=1&akamaiLocale=99'))).to.equal(null);
+    });
+
+    it('returns null when neither param is set', () => {
+      expect(utils.getCountryFromParams(params(''))).to.equal(null);
+    });
+  });
+
   describe('getLingoRegion', () => {
     let lingoModule;
 


### PR DESCRIPTION
Allow for country param to be used as default now instead of both it and akamaiLocale.

Resolves: [MWPW-193755](https://jira.corp.adobe.com/browse/MWPW-193755)

**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?country=fr
- After: https://main--da-bacom--adobecom.aem.live/?country=fr&milolibs=vhargrave-country-param

Steps to test: 
1. Join the basel vpn
2. Go to the before link - notice how the language banner wants to take you to the german experience
3. Go to the after link
4. Notice how the language banner now wants to take you to french experience. That shows the country param now working for this use case too. 

