### PR TITLE
Resolve unintended click behavior in editorial card

### DIFF
--- a/libs/blocks/editorial-card/editorial-card.css
+++ b/libs/blocks/editorial-card/editorial-card.css
@@ -55,6 +55,10 @@
   font-size: var(--type-body-s-size);
 }
 
+.editorial-card .card-footer > div > a:only-child { 
+  align-self: end; 
+}
+
 .editorial-card.static-links-copy .foreground a:not([class*="button"]) {
   color: inherit;
   text-decoration: underline;

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -57,9 +57,6 @@ const decorateForeground = async (el, rows) => {
     } else if (i === (rows.length - 1)) {
       row.classList.add('card-footer');
       if (!row.textContent.trim()) row.classList.add('empty');
-      row.querySelectorAll('div > a:only-child').forEach((link) => {
-        link.parentElement.classList.add('action-area');
-      });
     } else {
       row.classList.add('extra-row');
     }

--- a/libs/blocks/editorial-card/editorial-card.js
+++ b/libs/blocks/editorial-card/editorial-card.js
@@ -57,6 +57,9 @@ const decorateForeground = async (el, rows) => {
     } else if (i === (rows.length - 1)) {
       row.classList.add('card-footer');
       if (!row.textContent.trim()) row.classList.add('empty');
+      row.querySelectorAll('div > a:only-child').forEach((link) => {
+        link.parentElement.classList.add('action-area');
+      });
     } else {
       row.classList.add('extra-row');
     }


### PR DESCRIPTION
Resolves: [MWPW-199911](https://jira.corp.adobe.com/browse/MWPW-199911)

**Description**
 
Hi While exploring the Adobe Blog components in Milo, I came across an interaction issue in the Editorial Card footer. Since this was a good opportunity to contribute, I implemented a fix for the issue.
 
When the Editorial Card footer contains only a text-based call-to-action, the entire footer area becomes interactive instead of just the intended link. This change limits the clickable area to the call-to-action element, ensuring consistent interaction behavior across all footer variants.
 
 
**Steps to Reproduce**
 
1. Add an Editorial Card (default or open variant).
2. Add a text-based call-to-action in the card footer.
 
**Expected:** Only the CTA text is clickable.

**Actual:** The entire footer area is clickable.
 
**Test URLs**

**Before:**  https://main--mitrah-milo-hub--jsmitrah26.aem.live/

**After:** https://main--mitrah-milo-hub--jsmitrah26.aem.live/?milolibs=fix-editorial-cta-click--milo--jsmitrah26




