### PR TITLE
MWPW-199881: Hide free-trial CTAs from router-marquee on KR

### DIFF
--- a/libs/blocks/merch/merch.css
+++ b/libs/blocks/merch/merch.css
@@ -28,7 +28,7 @@ a[is='checkout-link'].con-button > span {
   min-width: 66px;
 }
 
-a[data-hide-kr-free-trial="true"] {
+a[data-hide-kr-free-trial] {
   display: none !important;
 }
 

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1508,16 +1508,18 @@ export async function buildCta(el, params) {
       return cta;
     }
 
-    cta.setAttribute('data-hide-kr-free-trial', 'true');
+    cta.setAttribute('data-hide-kr-free-trial', crypto.randomUUID());
     cta.onceSettled().then(() => {
-      const { offerType: ctaOfferType } = cta.value[0] || {};
+      const uuid = cta.getAttribute('data-hide-kr-free-trial');
+      const { offerType: ctaOfferType } = cta.value?.[0] || {};
       if (ctaOfferType === OFFER_TYPE_TRIAL) cta.remove();
       else cta.removeAttribute('data-hide-kr-free-trial');
 
-      const ctaClone = document.querySelector('[data-hide-kr-free-trial="true"]');
+      const ctaClone = [...document.querySelectorAll(`[data-hide-kr-free-trial="${uuid}"]`)]
+        .find((clone) => clone !== cta);
       if (!ctaClone) return;
       const { offerType: cloneOfferType } = ctaClone.value?.[0] || {};
-      if (cloneOfferType === OFFER_TYPE_TRIAL) ctaClone.remove();
+      if (!cloneOfferType || cloneOfferType === OFFER_TYPE_TRIAL) ctaClone.remove();
       else ctaClone.removeAttribute('data-hide-kr-free-trial');
     });
   }

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1497,15 +1497,30 @@ export async function buildCta(el, params) {
    * @see https://jira.corp.adobe.com/browse/MWPW-173470
    * @see https://jira.corp.adobe.com/browse/MWPW-174411
    */
-  cta.onceSettled().then(() => {
-    const prefix = getConfig()?.locale?.prefix;
-    if (!(prefix === '/kr' && cta.value[0]?.offerType === OFFER_TYPE_TRIAL)) return;
-    if (shouldAllowKrTrial(el, prefix)) {
-      cta.removeAttribute('data-hide-kr-free-trial');
-      return;
+  const localePrefix = getConfig()?.locale?.prefix;
+  if (localePrefix === '/kr') {
+    const hasAllowKrTrial = shouldAllowKrTrial(el, localePrefix);
+    const hasAllowKrTrialMeta = getMetadata('allow-kr-free-trial') === 'on';
+    const elAlreadyHasAllow = el.getAttribute('data-allow-kr-free-trial') === 'true';
+
+    if (hasAllowKrTrial || hasAllowKrTrialMeta || elAlreadyHasAllow) {
+      cta.setAttribute('data-allow-kr-free-trial', 'true');
+      return cta;
     }
-    cta.remove();
-  });
+
+    cta.setAttribute('data-hide-kr-free-trial', 'true');
+    cta.onceSettled().then(() => {
+      const { offerType: ctaOfferType } = cta.value[0] || {};
+      if (ctaOfferType === OFFER_TYPE_TRIAL) cta.remove();
+      else cta.removeAttribute('data-hide-kr-free-trial');
+
+      const ctaClone = document.querySelector('[data-hide-kr-free-trial="true"]');
+      if (!ctaClone) return;
+      const { offerType: cloneOfferType } = ctaClone.value?.[0] || {};
+      if (cloneOfferType === OFFER_TYPE_TRIAL) ctaClone.remove();
+      else ctaClone.removeAttribute('data-hide-kr-free-trial');
+    });
+  }
 
   return cta;
 }

--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -1,6 +1,6 @@
 import { sendAnalytics } from '../../../martech/helpers.js';
 import { processTrackingLabels } from '../../../martech/attributes.js';
-import { createTag, getFederatedUrl, getFederatedContentRoot, getConfig } from '../../../utils/utils.js';
+import { createTag, getFederatedUrl, getFederatedContentRoot, getConfig, shouldBlockFreeTrialLinks } from '../../../utils/utils.js';
 import { getMetadata } from '../section-metadata/section-metadata.js';
 
 let USER_ACTION = false;
@@ -165,7 +165,8 @@ const decorateCtas = (textCol) => {
   const secondary = cta.querySelector('em > a');
   primary?.classList.add('con-button', 'rm-cta-primary', 'fill', 'outline');
   secondary?.classList.add('con-button', 'outline');
-  cta.replaceChildren(...[primary, secondary].filter(Boolean));
+  cta.replaceChildren(...[primary, secondary]
+    .filter((btn) => btn && !shouldBlockFreeTrialLinks(btn)));
 };
 
 const prepareVideo = (imageCol) => {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -566,6 +566,7 @@ export const shouldAllowKrTrial = (link, localePrefix) => {
   const allowKrTrialHash = '#_allow-kr-trial';
   const hasAllowKrTrial = link.href?.includes(allowKrTrialHash);
   if (hasAllowKrTrial) {
+    link.setAttribute('data-allow-kr-free-trial', 'true');
     link.href = link.href.replace(allowKrTrialHash, '');
     const modalHash = link.getAttribute('data-modal-hash');
     if (modalHash) link.setAttribute('data-modal-hash', modalHash.replace(allowKrTrialHash, ''));
@@ -581,15 +582,14 @@ export const shouldAllowKrTrial = (link, localePrefix) => {
 export const shouldBlockFreeTrialLinks = (link) => {
   const localePrefix = getConfig()?.locale?.prefix;
   const hasAllowKrTrialMeta = getMetadata('allow-kr-free-trial') === 'on';
-  if (hasAllowKrTrialMeta || shouldAllowKrTrial(link, localePrefix) || localePrefix !== '/kr'
-      || (!link.dataset?.modalPath?.includes('/kr/cc-shared/fragments/trial-modals')
-       && !['free-trial', 'free trial', '무료 체험판', '무료 체험하기', '{{try-for-free}}', '무료', 'free']
-         .some((pattern) => link.textContent?.toLowerCase()?.includes(pattern.toLowerCase())))) {
-    return false;
-  }
-
-  if (link.dataset.wcsOsi) {
-    link.dataset.hideKrFreeTrial = 'true';
+  const hasAllowAttribute = link.getAttribute('data-allow-kr-free-trial') === 'true';
+  if (hasAllowKrTrialMeta
+    || hasAllowAttribute
+    || shouldAllowKrTrial(link, localePrefix)
+    || localePrefix !== '/kr'
+    || (!link.dataset?.modalPath?.includes('/kr/cc-shared/fragments/trial-modals')
+      && !['free-trial', 'free trial', '무료 체험판', '무료 체험하기', '{{try-for-free}}', '무료', 'free']
+        .some((pattern) => link.textContent?.toLowerCase()?.includes(pattern.toLowerCase())))) {
     return false;
   }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Use `shouldBlockFreeTrialLinks` in `router-marquee` button decoration
* Update `merch` fallback so that cloned nodes are removed also
Resolves: [MWPW-199881](https://jira.corp.adobe.com/browse/MWPW-199881)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/index-loggedout
- After: https://main--upp--adobecom.aem.page/homepage/index-loggedout?milolibs=upp-kr-freetrial
- Before: https://main--upp--adobecom.aem.page/kr/homepage/drafts/msale/2026/sr/06-18-sr-ff-ps-index-loggedout
- After: https://main--upp--adobecom.aem.page/kr/homepage/drafts/msale/2026/sr/06-18-sr-ff-ps-index-loggedout?milolibs=upp-kr-freetrial
- Before: https://main--milo--adobecom.aem.page/kr/drafts/dusan/test-cta-removal
- After: https://upp-kr-freetrial--milo--adobecom.aem.page/kr/drafts/dusan/test-cta-removal
- Before: https://main--milo--adobecom.aem.page/kr/drafts/dusan/test-cta-removal-merch-modal
- After: https://upp-kr-freetrial--milo--adobecom.aem.page/kr/drafts/dusan/test-cta-removal-merch-modal
- Before: https://main--milo--adobecom.aem.page/kr/drafts/ratko/kr-free-trial-links
- After: https://upp-kr-freetrial--milo--adobecom.aem.page/kr/drafts/ratko/kr-free-trial-links
- Before: https://main--milo--adobecom.aem.page/kr/drafts/ratko/kr-free-trial-links1
- After: https://upp-kr-freetrial--milo--adobecom.aem.page/kr/drafts/ratko/kr-free-trial-links1

**NOTE:** Last URL has a `allow-kr-free-trial` metadata so all links will be shown. 







