### PR TITLE
MWPW-197358 Add stream-login-controller template for Sidekick login flow.

### DIFF
--- a/libs/templates/stream-login-controller/stream-login-controller.js
+++ b/libs/templates/stream-login-controller/stream-login-controller.js
@@ -1,0 +1,36 @@
+
+function notifyParent(redirRef, ackCode, targetUrl) {
+  if (!redirRef) return;
+  const payload = {
+    source: 'stream-login',
+    status: 'success',
+    data: 'Sidekick login successful!!',
+    code: ackCode,
+    url: targetUrl || null,
+  };
+  // Inform the parent if we still have a handle to it. This works when the IMS
+  // sign-in did NOT sever window.opener (e.g. the user was already signed in).
+  if (window.opener) {
+    // Popup case: opened via window.open() from the stream app.
+    window.opener.postMessage(payload, redirRef);
+  } else if (window.parent && window.parent !== window) {
+    // Iframe case: loaded inside the stream-client preview iframe.
+    window.parent.postMessage(payload, redirRef);
+  }
+  setTimeout(() => {
+    window.close();
+  }, 1000);
+}
+
+export default async function init() {
+  const params = new URLSearchParams(window.location.search);
+  const redirRef = params.get('redirectRef');
+  const ackCode = params.get('ackCode');
+  const targetUrl = params.get('url');
+  if (!redirRef || !ackCode) return;
+  notifyParent(redirRef, ackCode, targetUrl);
+}
+
+(async () => {
+  await init();
+})();

--- a/libs/templates/stream-login-controller/stream-login-controller.js
+++ b/libs/templates/stream-login-controller/stream-login-controller.js
@@ -1,4 +1,3 @@
-
 function notifyParent(redirRef, ackCode, targetUrl) {
   if (!redirRef) return;
   const payload = {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -7,6 +7,7 @@ const MILO_TEMPLATES = [
   'featured-story',
   'stream-preflight',
   'stream-sidekick',
+  'stream-login-controller',
 ];
 const C1_BLOCKS = [
   'accordion',


### PR DESCRIPTION
Sidekick login for protected .aem.page previews 
Jira: [MWPW-197358](https://jira.corp.adobe.com/browse/MWPW-197358)
When a collab preview URL is a protected .aem.page, the preview is gated behind a Sidekick login screen instead of loading a 401'd page. After the user signs in, the preview reloads and renders.

Changes
stream-client

IframeContent.jsx / IframePanel.jsx: show a "Please login to Sidekick to continue" gate for .aem.page previews (preflight excluded). Clicking (or an auto-timer after 1s) opens the login controller; on success the preview reloads.
Login state is not persisted — re-gates on refresh, on preview change, and on Reset.
Gate styled to match the preflight intermediary screen.
Milo (stream-dev)

Added stream-login-controller template (libs/templates/stream-login-controller/) and registered it in MILO_TEMPLATES. It posts the login result back to the parent and closes.
DA pages created at /drafts/stream/tools/stream-login-controller on da-cc and da-cc-sandbox.




