### PR TITLE
Site Redesign Wave 1 VQA updates

### DIFF
--- a/.claude/skills/build-scroll-animation/references/animation-patterns.md
+++ b/.claude/skills/build-scroll-animation/references/animation-patterns.md
@@ -195,7 +195,6 @@ Before finalizing any animation, answer these questions:
 | Zoom out + blur clear | `parallax-scale-down parallax-blur` |
 | Card grid stagger (LTR) | `parallax-stagger-ltr` on section |
 | Card grid stagger (RTL) | `parallax-stagger-rtl` on section |
-| Text line-height reveal | `parallax-line-height` |
 | Sticky section with darkening | `parallax-move-up-fast` |
 | Section growing from below | `parallax-garage-door-reveal` |
 | Custom slide distance | Override `--parallax-translate-y` in new class |

--- a/.claude/skills/build-scroll-animation/references/existing-animations.md
+++ b/.claude/skills/build-scroll-animation/references/existing-animations.md
@@ -166,17 +166,6 @@ A sticky section that scrolls away quickly while darkening.
 - Two keyframes: `parallax-move-up-fast` (translateY to -35vh)
   and `parallax-fade-to-dark`
 
-### Line height reveal (`parallax-line-height`)
-
-Text children animate from `line-height: 3` to default, creating
-a text "spreading apart then settling" reveal effect.
-
-- Applied to: a container element
-- Animates all `*` children
-- Uses `animation-timeline: view()`
-- Range: `entry 10% cover 40%`
-- Keyframe: `text-reveal-up`
-
 ---
 
 ## Reduced motion

--- a/libs/c2/blocks/base-card/base-card.css
+++ b/libs/c2/blocks/base-card/base-card.css
@@ -39,12 +39,12 @@
       width: 100%;
       object-fit: cover;
       aspect-ratio: 4/3;
-      transition: transform 0.3s ease;
+      transition: transform 0.75s ease;
     }
   }
 
-  &:hover .media picture:not(.icon) img {
-    transform: scale(1.05);
+  html:not(.lenis-scrolling) &:hover .media picture:not(.icon) img {
+    transform: scale(1.03);
   }
 
   .foreground {

--- a/libs/c2/scroll-animations.js
+++ b/libs/c2/scroll-animations.js
@@ -395,50 +395,6 @@ function initCarouselC2() {
   observer.observe(document.body, { childList: true, subtree: true });
 }
 
-function initLineHeight() {
-  const initialized = new WeakSet();
-
-  const setup = (el) => {
-    if (initialized.has(el)) return;
-    initialized.add(el);
-    let childData = null;
-    let docTop = null;
-    let cachedHeight = el.offsetHeight;
-    new ResizeObserver(([entry]) => {
-      cachedHeight = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
-      docTop = null;
-    }).observe(el);
-
-    scrollTasks.push((scroll) => {
-      if (!cachedHeight) return;
-      if (docTop === null) docTop = getDocTop(el);
-      if (!childData || !el.contains(childData[0]?.child)) {
-        const nodes = [...el.querySelectorAll('p, h1, h2, h3, h4, h5, h6, li, span, a')];
-        if (!nodes.length) return;
-        childData = nodes.map((c) => {
-          const cs = getComputedStyle(c);
-          const fontSize = parseFloat(cs.fontSize) || 16;
-          const natural = parseFloat(cs.lineHeight) || fontSize * 1.5;
-          return { child: c, from: 3 * fontSize, to: natural };
-        });
-      }
-      const m = getScrollMetrics(scroll, cachedHeight, docTop);
-      const t = viewRange(m, 'entry', 0.1, 'cover', 0.4);
-      childData.forEach(({ child, from, to }) => {
-        child.style.setProperty('line-height', t < 1 ? `${lerp(from, to, t)}px` : null);
-      });
-    });
-    cleanupTasks.push(() => {
-      if (!childData) return;
-      childData.forEach(({ child }) => { child.style.setProperty('line-height', null); });
-    });
-  };
-
-  document.querySelectorAll('.parallax-line-height').forEach(setup);
-
-  observeForNew('.parallax-line-height', setup);
-}
-
 function initGarageDoorReveal() {
   const sections = findSectionsByStyle('parallax-garage-door-reveal');
   if (!sections.length) return;
@@ -561,7 +517,6 @@ function initGarageDoorReveal() {
 
 export default function init() {
   initMoveUpFast();
-  initLineHeight();
   initScaleDownGrid();
   initStagger();
   initElasticCarousel();

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1203,23 +1203,23 @@ span.hang-opening-quote {
     &.two-up   > :nth-child(2n+1 of :not([class*="section-"])),
     &.three-up > :nth-child(3n+1 of :not([class*="section-"])),
     &.four-up  > :nth-child(4n+1 of :not([class*="section-"])),
-    &.six-up   > :nth-child(6n+1 of :not([class*="section-"])) { --parallax-stagger-index: 0.5; }
+    &.six-up   > :nth-child(6n+1 of :not([class*="section-"])) { --parallax-stagger-index: 1.5; }
 
     &.two-up   > :nth-child(2n of :not([class*="section-"])),
     &.three-up > :nth-child(3n+2 of :not([class*="section-"])),
     &.four-up  > :nth-child(4n+2 of :not([class*="section-"])),
-    &.six-up   > :nth-child(6n+2 of :not([class*="section-"])) { --parallax-stagger-index: 1.5; }
+    &.six-up   > :nth-child(6n+2 of :not([class*="section-"])) { --parallax-stagger-index: 3.25; }
 
     &.three-up > :nth-child(3n of :not([class*="section-"])),
     &.four-up  > :nth-child(4n+3 of :not([class*="section-"])),
-    &.six-up   > :nth-child(6n+3 of :not([class*="section-"])) { --parallax-stagger-index: 2.5; }
+    &.six-up   > :nth-child(6n+3 of :not([class*="section-"])) { --parallax-stagger-index: 5.5; }
 
     &.four-up  > :nth-child(4n of :not([class*="section-"])),
-    &.six-up   > :nth-child(6n+4 of :not([class*="section-"])) { --parallax-stagger-index: 3.5; }
+    &.six-up   > :nth-child(6n+4 of :not([class*="section-"])) { --parallax-stagger-index: 7.75; }
 
-    &.six-up   > :nth-child(6n+5 of :not([class*="section-"])) { --parallax-stagger-index: 4.5; }
+    &.six-up   > :nth-child(6n+5 of :not([class*="section-"])) { --parallax-stagger-index: 10; }
 
-    &.six-up   > :nth-child(6n of :not([class*="section-"])) { --parallax-stagger-index: 5.5; }
+    &.six-up   > :nth-child(6n of :not([class*="section-"])) { --parallax-stagger-index: 12.25; }
 
     /* Row stagger indices per -up class */
     /* Row 1 */
@@ -1437,15 +1437,28 @@ span.hang-opening-quote {
 
   /* Line height parallax declarations */
   /* TODO: Adapt authoring to move and rename class */
-  .parallax-line-height * {
-    animation: text-reveal-up var(--parallax-easing) both;
-    animation-timeline: view();
-    animation-range: entry 10% cover 40%;
-    will-change: line-height;
+  .parallax-line-height .foreground .content {
+    view-timeline: --text-reveal-timeline block;
   }
 
+  .parallax-line-height .foreground .content > * {
+    --text-reveal-ordinal: 0;
+    --text-reveal-step: 0.25;
+    --text-reveal-index: calc(1 + var(--text-reveal-ordinal) * var(--text-reveal-step));
+    --text-reveal-magnitude: 20px;
+
+    animation: text-reveal-up var(--parallax-easing) both;
+    animation-timeline: --text-reveal-timeline;
+    animation-range: entry 0% cover 40%;
+    will-change: transform;
+  }
+
+  .parallax-line-height .foreground .content > :nth-child(2) { --text-reveal-ordinal: 1; }
+  .parallax-line-height .foreground .content > :nth-child(3) { --text-reveal-ordinal: 2; }
+  .parallax-line-height .foreground .content > :nth-child(4) { --text-reveal-ordinal: 3; }
+
   @keyframes text-reveal-up {
-    from { line-height: 300%; }
+    from { transform: translate3d(0, calc(var(--text-reveal-index) * var(--text-reveal-magnitude)), 0); }
   }
 }
 
@@ -1518,6 +1531,11 @@ span.hang-opening-quote {
     --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-lg);
     --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-md);
     --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
+  }
+
+  .parallax-line-height .foreground .content > * {
+    --text-reveal-magnitude: 40px;
+    --text-reveal-step: 1;
   }
 }
 

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1434,32 +1434,6 @@ span.hang-opening-quote {
     from { transform: translateY(0); }
     to { transform: translateY(20vh); }
   }
-
-  /* Line height parallax declarations */
-  /* TODO: Adapt authoring to move and rename class */
-  .parallax-line-height .foreground .content {
-    view-timeline: --text-reveal-timeline block;
-  }
-
-  .parallax-line-height .foreground .content > * {
-    --text-reveal-ordinal: 0;
-    --text-reveal-step: 0.25;
-    --text-reveal-index: calc(1 + var(--text-reveal-ordinal) * var(--text-reveal-step));
-    --text-reveal-magnitude: 20px;
-
-    animation: text-reveal-up var(--parallax-easing) both;
-    animation-timeline: --text-reveal-timeline;
-    animation-range: entry 0% cover 40%;
-    will-change: transform;
-  }
-
-  .parallax-line-height .foreground .content > :nth-child(2) { --text-reveal-ordinal: 1; }
-  .parallax-line-height .foreground .content > :nth-child(3) { --text-reveal-ordinal: 2; }
-  .parallax-line-height .foreground .content > :nth-child(4) { --text-reveal-ordinal: 3; }
-
-  @keyframes text-reveal-up {
-    from { transform: translate3d(0, calc(var(--text-reveal-index) * var(--text-reveal-magnitude)), 0); }
-  }
 }
 
 .dark {
@@ -1531,11 +1505,6 @@ span.hang-opening-quote {
     --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-lg);
     --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-md);
     --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
-  }
-
-  .parallax-line-height .foreground .content > * {
-    --text-reveal-magnitude: 40px;
-    --text-reveal-step: 1;
   }
 }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2301,7 +2301,7 @@ async function loadPostLCP(config) {
       new Promise((resolve) => { loadStyle(`${config.base}/deps/lenis.min.css`, resolve); }),
       loadScript(`${config.base}/deps/lenis.min.js`),
     ]);
-    const lerp = parseFloat(PAGE_URL.searchParams.get('inertialFactor')) || 0.08;
+    const lerp = 0.06;
     const fsThreshold = 110;
     const fsFactor = 0.11;
     const fsDelay = 700;
@@ -2314,6 +2314,7 @@ async function loadPostLCP(config) {
     window.lenis = new window.Lenis({
       autoRaf: true,
       lerp,
+      wheelMultiplier: 0.7,
       prevent: (node) => node.matches?.(lenisPreventSelectors.join(', ')),
     });
     // Reduce inertia during fast scrolling to avoid sustained RAF CPU usage
@@ -2325,6 +2326,7 @@ async function loadPostLCP(config) {
         fsScrollTimer = setTimeout(() => { window.lenis.options.lerp = lerp; }, fsDelay);
       }
     }, { passive: true });
+
     if (!CSS.supports('animation-timeline: view()')
       && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       import('../c2/scroll-animations.js').then(({ default: initScrollAnimations }) => initScrollAnimations());


### PR DESCRIPTION
This solves a few Site Redesign Wave 1 VQA items:
* [MWPW-194805](https://jira.corp.adobe.com/browse/MWPW-194805) - adapt `lerp` and `wheelMultiplier` values; note that a more recent story, [MWPW-199386](https://jira.corp.adobe.com/browse/MWPW-199386), is requesting a different value for `wheelMultiplier`, the latest suggested value has been used;
* [MWPW-194807](https://jira.corp.adobe.com/browse/MWPW-194807) - updates the staggering index values for the `.X-up` elements;
* [MWPW-194812](https://jira.corp.adobe.com/browse/MWPW-194812) - hover scale for base cards and behavior during page scroll have been tweaked; there is a version of the Base Card logic in the `ace1201` test folder, but that is irrelevant to update, since the test has concluded and the code should be obsolete;
* [MWPW-199387](https://jira.corp.adobe.com/browse/MWPW-199387) - removes line-height animations, as they led to performance issues, which are now a lot more visible with the `lerp` value update; this makes [MWPW-194811](https://jira.corp.adobe.com/browse/MWPW-194811) obsolete and will be closed.

**Test URLs:**
- Homepage:
    - Before: https://main--upp--adobecom.aem.live/upp-shared/fragments/tests/2026/q2/ace1201/sr-homepage
    - After: https://main--upp--adobecom.aem.live/upp-shared/fragments/tests/2026/q2/ace1201/sr-homepage?milolibs=sr-wave-1-vqa
 - BizPro Hub:
    - Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub
    - After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=sr-wave-1-vqa
 - BizPro Offer:
    - Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer
    - After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=sr-wave-1-vqa
 - BizPro Product:
    - Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product
    - After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=sr-wave-1-vqa
 - BizPro Plans:
    - Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans
    - After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=sr-wave-1-vqa


