### PR TITLE
[MWPW-197903] Plans hero scrim update for a11y

### DIFF
--- a/libs/mep/ace1205/plans-hero/plans-hero.css
+++ b/libs/mep/ace1205/plans-hero/plans-hero.css
@@ -24,13 +24,15 @@
   &::after {
     --scrim-stop-start: 0.88%;
     --scrim-stop-end: 99.12%;
+    --scrim-color-start: var(--s2a-color-transparent-black-00);
+    --scrim-color-end: var(--s2a-color-transparent-black-72);
 
     content: '';
     position: absolute;
     inset: 0;
     background-image: linear-gradient(271deg,
-      var(--s2a-color-transparent-black-00) var(--scrim-stop-start),
-      var(--s2a-color-transparent-black-64) var(--scrim-stop-end));
+      var(--scrim-color-start) var(--scrim-stop-start),
+      var(--scrim-color-end) var(--scrim-stop-end));
     pointer-events: none;
   }
 
@@ -65,7 +67,7 @@
 
   .plans-hero-media::after {
     --scrim-stop-start: 50.27%;
-    --scrim-stop-end: 99.12%;
+    --scrim-color-end: var(--s2a-color-transparent-black-64);
   }
 }
 


### PR DESCRIPTION
Updates the scrim color of the mobile version of the plans-hero block relevant to the ACE1205 A/B test. Latest Figma spec available [here](https://www.figma.com/design/brgxjoNmioT7z6zFk1QHbR/Plans-%E2%80%94-A.com?node-id=4729-50644&m=dev).

Resolves: [MWPW-197903](https://jira.corp.adobe.com/browse/MWPW-197903)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=plans-hero-a11y


