### PR TITLE
Update plans hero scrim for a11y

### DIFF
--- a/libs/mep/ace1205/plans-hero/plans-hero.css
+++ b/libs/mep/ace1205/plans-hero/plans-hero.css
@@ -24,13 +24,15 @@
   &::after {
     --scrim-stop-start: 0.88%;
     --scrim-stop-end: 99.12%;
+    --scrim-color-start: var(--s2a-color-transparent-black-00);
+    --scrim-color-end: var(--s2a-color-transparent-black-72);
 
     content: '';
     position: absolute;
     inset: 0;
     background-image: linear-gradient(271deg,
-      var(--s2a-color-transparent-black-00) var(--scrim-stop-start),
-      var(--s2a-color-transparent-black-64) var(--scrim-stop-end));
+      var(--scrim-color-start) var(--scrim-stop-start),
+      var(--scrim-color-end) var(--scrim-stop-end));
     pointer-events: none;
   }
 
@@ -65,7 +67,7 @@
 
   .plans-hero-media::after {
     --scrim-stop-start: 50.27%;
-    --scrim-stop-end: 99.12%;
+    --scrim-color-end: var(--s2a-color-transparent-black-64);
   }
 }
 

--- a/libs/mep/ace1209/plans-hero/plans-hero.css
+++ b/libs/mep/ace1209/plans-hero/plans-hero.css
@@ -24,13 +24,15 @@
   &::after {
     --scrim-stop-start: 0.88%;
     --scrim-stop-end: 99.12%;
+    --scrim-color-start: var(--s2a-color-transparent-black-00);
+    --scrim-color-end: var(--s2a-color-transparent-black-72);
 
     content: '';
     position: absolute;
     inset: 0;
     background-image: linear-gradient(271deg,
-      var(--s2a-color-transparent-black-00) var(--scrim-stop-start),
-      var(--s2a-color-transparent-black-64) var(--scrim-stop-end));
+      var(--scrim-color-start) var(--scrim-stop-start),
+      var(--scrim-color-end) var(--scrim-stop-end));
     pointer-events: none;
   }
 
@@ -65,7 +67,7 @@
 
   .plans-hero-media::after {
     --scrim-stop-start: 50.27%;
-    --scrim-stop-end: 99.12%;
+    --scrim-color-end: var(--s2a-color-transparent-black-64);
   }
 }
 


### PR DESCRIPTION
This brings in the changes from https://github.com/adobecom/milo/pull/6245, to ensure the Site Redesign Foundation branch has the latest version of the Plan Hero block for both the BizPro and CPro pages.

Resolves: [MWPW-197903](https://jira.corp.adobe.com/browse/MWPW-197903)

**Test URLs:**
- Before (BizPro): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans
- After (BizPro): https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=plans-hero-a11y
- Before (CPro): https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-plans?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After (CPro): https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-plans?milolibs=plans-hero-a11y-mep&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

