### PR TITLE
MWPW-199677 - CTA links are not appearing as buttons inside Text blocks

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -55,6 +55,7 @@ export function decorateButtons(el, size) {
   if (buttons.length === 0) return;
 
   buttons.forEach((button) => {
+    if (button.classList.contains('merch-card-autoblock') && button.classList.contains('link-block')) return;
     const parent = button.parentElement;
     if (shouldBlockFreeTrialLinks(button)) return;
     let target = button;

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -281,6 +281,15 @@ describe('merch-card-autoblock autoblock', () => {
       a.textContent = '[[cta-test:ctas]]';
       strong.append(a);
       p.append(strong);
+
+      const em = document.createElement('em');
+      const a2 = document.createElement('a');
+      a2.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=ctas-inherit-2&field=ctas';
+      a2.textContent = '[[cta-test:ctas]]';
+      a2.classList.add('some-class', 'merch-card-autoblock', 'link-block');
+      em.append(a2);
+      p.append(em);
+
       section.append(p);
       document.body.append(section);
 
@@ -292,6 +301,10 @@ describe('merch-card-autoblock autoblock', () => {
       expect(link.classList.contains('blue')).to.be.true;
       expect(link.classList.contains('button-l')).to.be.true;
       expect(link.classList.contains('button-justified-mobile')).to.be.true;
+
+      const linkNotDecorated = p.querySelector('a.some-class');
+      expect(linkNotDecorated).to.exist;
+      expect(linkNotDecorated.className).to.equal('some-class merch-card-autoblock link-block');
     });
 
     it('upgrades plain commerce links and decorates using block context', async () => {


### PR DESCRIPTION
When in the same `P` or `DIV` element we have 2 `MAS-FIELD` elements with one merch link in each of them, only those without classes `'merch-card-autoblock'` and `'link-block'` should be decorated by `decorateButtons()` since these links will be decorated in their own threads. The same merch link should not be decorated twice.

Test pages : https://main--da-cc--adobecom.aem.live/drafts/golee/dotcom-188996/aftereffects-test?martech=off&milolibs=mwpw199677--milo--bozojovicic
https://mwpw199677--milo--bozojovicic.aem.live/drafts/bozo/mas-field1?martech=off

Resolves: [MWPW-199677](https://jira.corp.adobe.com/browse/MWPW-199677)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.live/?martech=off
- After: https://mwpw199677--milo--bozojovicic.aem.live/?martech=off




