### PR TITLE
Preserve current active link's href for restoration in updateGnavActiveLink

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -110,10 +110,10 @@ const {
   setupKeyboardNav,
   KEYBOARD_DELAY,
   isSmallScreen,
-  updateActiveLink,
+  updateGnavActiveLink,
 } = utilities;
 
-export { updateActiveLink };
+export { updateGnavActiveLink };
 
 const SIGNIN_CONTEXT = getConfig()?.signInContext;
 

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -74,7 +74,6 @@ const {
   getActiveLink,
   getExperienceName,
   isActiveLink,
-  resetActiveLink,
   icons,
   isDesktop,
   isTangentToViewport,
@@ -1903,25 +1902,6 @@ class Gnav {
     return this.elements.search;
   };
 }
-
-export const updateGnavActiveLink = () => {
-  resetActiveLink();
-
-  const nav = document.querySelector(selectors.globalNav)?.querySelector('.feds-nav');
-  if (!nav) return;
-
-  nav.querySelectorAll(selectors.activeNavItem).forEach((el) => {
-    el.classList.remove(selectors.activeNavItem.slice(1));
-    el.classList.remove(selectors.deferredActiveNavItem.slice(1));
-    el.style.width = '';
-  });
-
-  nav.querySelectorAll(selectors.navItem).forEach((navItem) => {
-    if (getActiveLink(navItem) instanceof HTMLElement) {
-      navItem.classList.add(selectors.activeNavItem.slice(1));
-    }
-  });
-};
 
 export default async function init(block) {
   const { mep, miniGnav = false, showPlansCta } = getConfig();

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1809,6 +1809,7 @@ class Gnav {
               const url = new URL(linkElem.href);
               linkElem.setAttribute('href', `${url.origin}${url.pathname}${url.search}`);
               if (isActiveLink(linkElem)) {
+                linkElem.dataset.activeLinkHref = linkElem.href;
                 linkElem.removeAttribute('href');
               }
               const linkHash = url.hash.slice(2);
@@ -1819,6 +1820,7 @@ class Gnav {
             });
             removeCustomLink = removeLink();
           } else if (itemHasActiveLink) {
+            linkElem.dataset.activeLinkHref = linkElem.href;
             linkElem.removeAttribute('href');
             linkElem.setAttribute('role', 'link');
             linkElem.setAttribute('aria-disabled', 'true');

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -110,7 +110,10 @@ const {
   setupKeyboardNav,
   KEYBOARD_DELAY,
   isSmallScreen,
+  updateActiveLink,
 } = utilities;
+
+export { updateActiveLink };
 
 const SIGNIN_CONTEXT = getConfig()?.signInContext;
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -448,7 +448,9 @@ export function updateActiveLink() {
   const nav = document.querySelector(`${selectors.globalNav}, ${selectors.localNav}`);
   if (!nav) return;
 
-  const newActiveLink = [...nav.querySelectorAll('a:not([data-modal-hash])')].find(matchesUrl);
+  const newActiveLink = [...nav.querySelectorAll('a:not([data-modal-hash])[href]')]
+    .filter((el) => !!el.getAttribute('href')).find(matchesUrl);
+
   if (!newActiveLink) return;
 
   const navItem = newActiveLink.closest(selectors.navItem);

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -423,7 +423,8 @@ export function updateGnavActiveLink() {
   const deferredActiveNavItemClass = selectors.deferredActiveNavItem.slice(1);
 
   document.querySelectorAll('a[data-active-link-href]').forEach((link) => {
-    link.setAttribute('href', link.getAttribute('data-active-link-href'));
+    const savedHref = link.getAttribute('data-active-link-href');
+    if (savedHref) link.setAttribute('href', savedHref);
     link.removeAttribute('data-active-link-href');
     ACTIVE_LINK_ATTRS.forEach((attr) => link.removeAttribute(attr));
   });

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -416,23 +416,16 @@ export const [hasActiveLink, setActiveLink, isActiveLink, getActiveLink] = (() =
   ];
 })();
 
-export function updateActiveLink() {
-  const { origin, pathname } = window.location;
-  const currentUrl = `${origin}${pathname}`;
-  const matchesUrl = (el) => el.href === currentUrl
-    || el.href.startsWith(`${currentUrl}?`)
-    || el.href.startsWith(`${currentUrl}#`);
+const ACTIVE_LINK_ATTRS = ['role', 'aria-disabled', 'aria-current', 'tabindex'];
 
+export function updateGnavActiveLink() {
   const activeNavItemClass = selectors.activeNavItem.slice(1);
   const deferredActiveNavItemClass = selectors.deferredActiveNavItem.slice(1);
 
-  const ATTRS_TO_REMOVE = ['role', 'aria-disabled', 'aria-current', 'tabindex'];
-
-  // Remove previous active state
   document.querySelectorAll('a[data-active-link-href]').forEach((link) => {
     link.setAttribute('href', link.getAttribute('data-active-link-href'));
     link.removeAttribute('data-active-link-href');
-    ATTRS_TO_REMOVE.forEach((attr) => link.removeAttribute(attr));
+    ACTIVE_LINK_ATTRS.forEach((attr) => link.removeAttribute(attr));
   });
   document
     .querySelectorAll(`${selectors.activeNavItem}, ${selectors.navItem}[data-active-link-href]`)
@@ -447,8 +440,14 @@ export function updateActiveLink() {
   const nav = document.querySelector(`${selectors.globalNav}, ${selectors.localNav}`);
   if (!nav) return;
 
+  const { origin, pathname } = window.location;
+  const currentUrl = `${origin}${pathname}`;
+  const matchesUrl = (el) => el.href === currentUrl
+    || el.href.startsWith(`${currentUrl}?`)
+    || el.href.startsWith(`${currentUrl}#`);
+
   const newActiveLink = [...nav.querySelectorAll('a:not([data-modal-hash])[href]')]
-    .filter((el) => !!el.getAttribute('href')).find(matchesUrl);
+    .find(matchesUrl);
 
   if (!newActiveLink) return;
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -426,32 +426,24 @@ export function updateActiveLink() {
   const activeNavItemClass = selectors.activeNavItem.slice(1);
   const deferredActiveNavItemClass = selectors.deferredActiveNavItem.slice(1);
 
+  const ATTRS_TO_REMOVE = ['role', 'aria-disabled', 'aria-current', 'tabindex'];
+
   // Remove previous active state
-  document.querySelectorAll('a[data-active-link-href]').forEach((prevLink) => {
-    prevLink.setAttribute('href', prevLink.dataset.activeLinkHref);
-    prevLink.removeAttribute('data-active-link-href');
-    prevLink.removeAttribute('role');
-    prevLink.removeAttribute('aria-disabled');
-    prevLink.removeAttribute('aria-current');
-    prevLink.removeAttribute('tabindex');
+  document.querySelectorAll('a[data-active-link-href]').forEach((link) => {
+    link.setAttribute('href', link.getAttribute('data-active-link-href'));
+    link.removeAttribute('data-active-link-href');
+    ATTRS_TO_REMOVE.forEach((attr) => link.removeAttribute(attr));
   });
-
-  // Nav items with dropdowns carry data-active-link-href directly on the nav item element
-  document.querySelectorAll(`${selectors.navItem}[data-active-link-href]`).forEach((navItem) => {
-    navItem.removeAttribute('data-active-link-href');
-    navItem.classList.remove(activeNavItemClass, deferredActiveNavItemClass);
-    navItem.style.removeProperty('width');
-  });
-
-  // Catch any remaining active nav items (e.g. single mega-menu fallback) that have no stamped link
-  document.querySelectorAll(selectors.activeNavItem).forEach((navItem) => {
-    navItem.classList.remove(activeNavItemClass, deferredActiveNavItemClass);
-    navItem.style.removeProperty('width');
-  });
+  document
+    .querySelectorAll(`${selectors.activeNavItem}, ${selectors.navItem}[data-active-link-href]`)
+    .forEach((navItem) => {
+      navItem.removeAttribute('data-active-link-href');
+      navItem.classList.remove(activeNavItemClass, deferredActiveNavItemClass);
+      navItem.style.removeProperty('width');
+    });
 
   setActiveLink(false);
 
-  // Find and apply new active state
   const nav = document.querySelector(`${selectors.globalNav}, ${selectors.localNav}`);
   if (!nav) return;
 
@@ -466,7 +458,6 @@ export function updateActiveLink() {
   navItem.classList.add(activeNavItemClass);
   newActiveLink.dataset.activeLinkHref = newActiveLink.href;
 
-  // Only strip href and apply aria attrs for simple link items (no dropdown popup sibling)
   if (!newActiveLink.nextElementSibling?.classList.contains('feds-popup')) {
     newActiveLink.removeAttribute('href');
     newActiveLink.setAttribute('role', 'link');

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -409,11 +409,65 @@ export const [hasActiveLink, setActiveLink, isActiveLink, getActiveLink] = (() =
 
       if (!activeLink) return null;
 
+      activeLink.dataset.activeLinkHref = activeLink.href;
       setActiveLink(true);
       return activeLink;
     },
   ];
 })();
+
+export function updateActiveLink() {
+  const { origin, pathname } = window.location;
+  const currentUrl = `${origin}${pathname}`;
+  const matchesUrl = (el) => el.href === currentUrl
+    || el.href.startsWith(`${currentUrl}?`)
+    || el.href.startsWith(`${currentUrl}#`);
+
+  const activeNavItemClass = selectors.activeNavItem.slice(1);
+  const deferredActiveNavItemClass = selectors.deferredActiveNavItem.slice(1);
+
+  // Remove previous active state
+  document.querySelectorAll(selectors.activeNavItem).forEach((navItem) => {
+    navItem.classList.remove(activeNavItemClass, deferredActiveNavItemClass);
+    navItem.style.width = '';
+
+    const prevLink = navItem.querySelector('a[data-active-link-href]');
+    if (prevLink) {
+      prevLink.setAttribute('href', prevLink.dataset.activeLinkHref);
+      prevLink.removeAttribute('data-active-link-href');
+      prevLink.removeAttribute('role');
+      prevLink.removeAttribute('aria-disabled');
+      prevLink.removeAttribute('aria-current');
+      prevLink.removeAttribute('tabindex');
+    }
+  });
+
+  setActiveLink(false);
+
+  // Find and apply new active state
+  const nav = document.querySelector(`${selectors.globalNav}, ${selectors.localNav}`);
+  if (!nav) return;
+
+  const newActiveLink = [...nav.querySelectorAll('a:not([data-modal-hash])')].find(matchesUrl);
+  if (!newActiveLink) return;
+
+  const navItem = newActiveLink.closest(selectors.navItem);
+  if (!navItem) return;
+
+  navItem.classList.add(activeNavItemClass);
+  newActiveLink.dataset.activeLinkHref = newActiveLink.href;
+
+  // Only strip href and apply aria attrs for simple link items (no dropdown popup sibling)
+  if (!newActiveLink.nextElementSibling?.classList.contains('feds-popup')) {
+    newActiveLink.removeAttribute('href');
+    newActiveLink.setAttribute('role', 'link');
+    newActiveLink.setAttribute('aria-disabled', 'true');
+    newActiveLink.setAttribute('aria-current', 'page');
+    newActiveLink.setAttribute('tabindex', '0');
+  }
+
+  setActiveLink(true);
+}
 
 export const setAriaAtributes = (dropdownTrigger) => {
   const popup = dropdownTrigger.nextElementSibling;

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -390,35 +390,28 @@ export const [setAsyncDropdownCount, getAsyncDropdownCount] = (() => {
   ];
 })();
 
-export const [hasActiveLink, setActiveLink, isActiveLink, getActiveLink, resetActiveLink] = (() => {
+export const [hasActiveLink, setActiveLink, isActiveLink, getActiveLink] = (() => {
   let activeLinkFound;
-
-  // Read window.location at call time
-  const getUrl = () => `${window.location.origin}${window.location.pathname}`;
-
-  const checkIsActiveLink = (el) => {
-    const url = getUrl();
-    return el.href === url || el.href.startsWith(`${url}?`) || el.href.startsWith(`${url}#`);
-  };
+  const { origin, pathname } = window.location;
+  const url = `${origin}${pathname}`;
 
   return [
     () => activeLinkFound,
     (val) => { activeLinkFound = !!val; },
-    checkIsActiveLink,
+    (el) => (el.href === url || el.href.startsWith(`${url}?`) || el.href.startsWith(`${url}#`)),
     (area) => {
       const isCustomLinks = area.closest('.link-group')?.classList.contains('mobile-only');
       const disableAED = getDisableAEDState() || isCustomLinks;
       if (disableAED || hasActiveLink() || !(area instanceof HTMLElement)) return null;
       const activeLink = [
         ...area.querySelectorAll('a:not([data-modal-hash])'),
-      ].find(checkIsActiveLink);
+      ].find(isActiveLink);
 
       if (!activeLink) return null;
 
       setActiveLink(true);
       return activeLink;
     },
-    () => { activeLinkFound = false; },
   ];
 })();
 

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -427,19 +427,26 @@ export function updateActiveLink() {
   const deferredActiveNavItemClass = selectors.deferredActiveNavItem.slice(1);
 
   // Remove previous active state
+  document.querySelectorAll('a[data-active-link-href]').forEach((prevLink) => {
+    prevLink.setAttribute('href', prevLink.dataset.activeLinkHref);
+    prevLink.removeAttribute('data-active-link-href');
+    prevLink.removeAttribute('role');
+    prevLink.removeAttribute('aria-disabled');
+    prevLink.removeAttribute('aria-current');
+    prevLink.removeAttribute('tabindex');
+  });
+
+  // Nav items with dropdowns carry data-active-link-href directly on the nav item element
+  document.querySelectorAll(`${selectors.navItem}[data-active-link-href]`).forEach((navItem) => {
+    navItem.removeAttribute('data-active-link-href');
+    navItem.classList.remove(activeNavItemClass, deferredActiveNavItemClass);
+    navItem.style.removeProperty('width');
+  });
+
+  // Catch any remaining active nav items (e.g. single mega-menu fallback) that have no stamped link
   document.querySelectorAll(selectors.activeNavItem).forEach((navItem) => {
     navItem.classList.remove(activeNavItemClass, deferredActiveNavItemClass);
-    navItem.style.width = '';
-
-    const prevLink = navItem.querySelector('a[data-active-link-href]');
-    if (prevLink) {
-      prevLink.setAttribute('href', prevLink.dataset.activeLinkHref);
-      prevLink.removeAttribute('data-active-link-href');
-      prevLink.removeAttribute('role');
-      prevLink.removeAttribute('aria-disabled');
-      prevLink.removeAttribute('aria-current');
-      prevLink.removeAttribute('tabindex');
-    }
+    navItem.style.removeProperty('width');
   });
 
   setActiveLink(false);

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -207,9 +207,10 @@ export default async function loadBlock(configs, customLib) {
             { key: 'promoSource', name: 'gnav-promo-source' },
           ];
           setMetaTags(metaTags, gnavConfigs, createTag);
-          const { default: init, closeGnavOptions } = await import('../blocks/global-navigation/global-navigation.js');
+          const { default: init, closeGnavOptions, updateActiveLink } = await import('../blocks/global-navigation/global-navigation.js');
           await bootstrapBlock(init, gnavConfigs);
           window.closeGnav = closeGnavOptions;
+          window.updateGnavActiveLink = updateActiveLink;
           configBlock.onReady?.();
         } catch (e) {
           configBlock.onError?.(e);

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -207,10 +207,10 @@ export default async function loadBlock(configs, customLib) {
             { key: 'promoSource', name: 'gnav-promo-source' },
           ];
           setMetaTags(metaTags, gnavConfigs, createTag);
-          const { default: init, closeGnavOptions, updateActiveLink } = await import('../blocks/global-navigation/global-navigation.js');
+          const { default: init, closeGnavOptions, updateGnavActiveLink } = await import('../blocks/global-navigation/global-navigation.js');
           await bootstrapBlock(init, gnavConfigs);
           window.closeGnav = closeGnavOptions;
-          window.updateGnavActiveLink = updateActiveLink;
+          window.updateGnavActiveLink = updateGnavActiveLink;
           configBlock.onReady?.();
         } catch (e) {
           configBlock.onError?.(e);

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -207,10 +207,9 @@ export default async function loadBlock(configs, customLib) {
             { key: 'promoSource', name: 'gnav-promo-source' },
           ];
           setMetaTags(metaTags, gnavConfigs, createTag);
-          const { default: init, closeGnavOptions, updateGnavActiveLink } = await import('../blocks/global-navigation/global-navigation.js');
+          const { default: init, closeGnavOptions } = await import('../blocks/global-navigation/global-navigation.js');
           await bootstrapBlock(init, gnavConfigs);
           window.closeGnav = closeGnavOptions;
-          window.updateGnavActiveLink = updateGnavActiveLink;
           configBlock.onReady?.();
         } catch (e) {
           configBlock.onError?.(e);

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.23-test",
+  "version": "0.0.24-1",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.24-1",
+  "version": "0.0.25",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.22",
+  "version": "0.0.23-test",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Keeping the href in dataset and assigning them back when it is non active after updateGnavActiveLink

Resolves: [MWPW-188232](https://jira.corp.adobe.com/browse/MWPW-188232)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://activelink-update--milo--adobecom.aem.page/?martech=off


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=activelink-update--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=activelink-update--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=activelink-update--milo--adobecom
- Milo: https://activelink-update--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=activelink-update--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=activelink-update--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=activelink-update--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=activelink-update--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=activelink-update--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=activelink-update--milo--adobecom
- Milo: https://activelink-update--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=activelink-update--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=activelink-update--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=activelink-update--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=activelink-update--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=activelink-update--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=activelink-update--milo--adobecom
- Milo: https://activelink-update--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=activelink-update--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=activelink-update--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=activelink-update--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=activelink-update--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=activelink-update--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=activelink-update--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=activelink-update--milo--adobecom
</details>