### PR TITLE
ENB-10049 [NPS-CSAT] `window._satellite.track` doesn't send out a collect call before the iframe is closed in CCH

### DIFF
--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -494,7 +494,7 @@ const createIdForLabel = (label) => label
 
 const cancelActions = (() => {
   let cancelActionsDone = false;
-  return () => {
+  return async () => {
     if (cancelActionsDone) return;
     cancelActionsDone = true;
     const d = {
@@ -505,7 +505,7 @@ const cancelActions = (() => {
     const isNPSForm = !!document.querySelector('form#nps nps-picker.nps-picker');
     const surveyType = isNPSForm ? 'NPS' : 'CSAT 5pt';
     const dataObj = buildDataObject(d, surveyType, CancelSurvey);
-    window._satellite?.track?.('event', dataObj) // eslint-disable-line
+    await sendToMartech(dataObj)
   };
 })();
 
@@ -619,8 +619,7 @@ const initKeyboardAccessibility = (form, sendMessage) => {
 
     if (e.key === 'Escape' || e.key === 'Esc') {
       e.preventDefault();
-      cancelActions();
-      sendMessage(CANCEL);
+      cancelActions().then(() => sendMessage(CANCEL));
     }
   });
 
@@ -698,6 +697,14 @@ const buildDataObject = (formData, surveyType, eventType) => {
     },
     data,
   };
+};
+
+const sendToMartech = async (dataObj) => {
+  try {
+    await window.alloy("sendEvent", dataObj);
+  } catch (e) {
+    console.warn("Failed to send form data to AEP", e);
+  }
 };
 
 // ############################################
@@ -807,8 +814,8 @@ const initMessageClient = (registerCleanup = () => {}) => {
           state = STATE_BASE;
           clearAckTimeout();
         }
-        cancelActions();
-        sendMessage(ACK);
+        cancelActions().then(() => sendMessage(ACK));
+
         break;
       case Acknowledged: {
         if (state === STATE_EXPECT_ACK) {
@@ -1136,26 +1143,22 @@ export default async (block) => {
     };
     const surveyType = isNPSForm ? 'NPS' : 'CSAT 5pt';
     const dataObj = buildDataObject(d, surveyType, SubmitSurvey);
-    window._satellite?.track?.('event', dataObj) // eslint-disable-line
-    sendMessage(SUBMIT(d));
+    sendToMartech(dataObj).then(() => sendMessage(SUBMIT(d)));
   });
 
   const cancelButton = form.querySelector('button.nps-cancel');
   const closeButton = form.querySelector('button.nps-close');
   cancelButton?.addEventListener('click', () => {
-    cancelActions();
-    sendMessage(CANCEL);
+    cancelActions().then(() => sendMessage(CANCEL));
   }, { once: true });
   cancelButton?.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      cancelActions();
-      sendMessage(CANCEL);
+      cancelActions().then(() => sendMessage(CANCEL));
     }
   }, { once: true });
   closeButton?.addEventListener('click', () => {
-    cancelActions();
-    sendMessage(CANCEL);
+    cancelActions().then(() => sendMessage(CANCEL));
   }, { once: true });
   const radioButtons = form.querySelectorAll('input[type="radio"]');
   radioButtons.forEach((r) => {

--- a/libs/blocks/nps-csat-form/nps-csat-form.js
+++ b/libs/blocks/nps-csat-form/nps-csat-form.js
@@ -505,7 +505,7 @@ const cancelActions = (() => {
     const isNPSForm = !!document.querySelector('form#nps nps-picker.nps-picker');
     const surveyType = isNPSForm ? 'NPS' : 'CSAT 5pt';
     const dataObj = buildDataObject(d, surveyType, CancelSurvey);
-    await sendToMartech(dataObj)
+    await sendToMartech(dataObj);
   };
 })();
 
@@ -701,9 +701,9 @@ const buildDataObject = (formData, surveyType, eventType) => {
 
 const sendToMartech = async (dataObj) => {
   try {
-    await window.alloy("sendEvent", dataObj);
+    await window.alloy('sendEvent', dataObj);
   } catch (e) {
-    console.warn("Failed to send form data to AEP", e);
+    console.warn('Failed to send form data to AEP', e);
   }
 };
 

--- a/test/blocks/nps-csat-form/nps-csat-form.test.html
+++ b/test/blocks/nps-csat-form/nps-csat-form.test.html
@@ -1047,11 +1047,10 @@
             const textarea = form.querySelector('#explanation-input');
             const checkbox = form.querySelector('#contact-me');
 
-            // Mock _satellite to capture analytics
-            window._satellite = {
-              track: (eventType, data) => {
-                window.lastTrackedEvent = { eventType, data };
-              }
+            // Mock window.alloy to capture analytics
+            window.alloy = (eventName, dataObj) => {
+              window.lastTrackedEvent = { eventName, dataObj };
+              return Promise.resolve();
             };
 
             // Fill out form completely
@@ -1071,13 +1070,15 @@
 
             // Verify analytics was sent
             expect(window.lastTrackedEvent).to.exist;
-            expect(window.lastTrackedEvent.eventType).to.equal('event');
-            
-            const analyticsData = window.lastTrackedEvent.data.data._adobe_corpnew.evolved_survey;
+            expect(window.lastTrackedEvent.eventName).to.equal('sendEvent');
+
+            const analyticsData = window.lastTrackedEvent.dataObj.data._adobe_corpnew.evolved_survey;
             expect(analyticsData.surveyScore).to.equal(2);
             expect(analyticsData.surveyFeedback).to.equal('This is my detailed feedback');
             expect(analyticsData.adobeCanContact).to.equal(true);
             expect(analyticsData.surveyType).to.equal('CSAT 5pt');
+
+            delete window.alloy;
           });
 
           it('should prevent double submission', async () => {
@@ -1090,8 +1091,9 @@
             const radioButton = form.querySelector('input[type="radio"]');
 
             let submitCount = 0;
-            window._satellite = {
-              track: () => { submitCount++; }
+            window.alloy = () => {
+              submitCount++;
+              return Promise.resolve();
             };
 
             // Select radio and submit
@@ -1107,6 +1109,8 @@
 
             // Should only have submitted once
             expect(submitCount).to.equal(1);
+
+            delete window.alloy;
           });
 
         });


### PR DESCRIPTION
Use window.alloy to ingest data as it returns a promise and allows us to send `SUBMIT` or `CANCEL` only once the promise is resolved

<!-- Before submitting, please review all open PRs. -->

Resolves: [ENB-10049](https://jira.corp.adobe.com/browse/ENB-10049)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/nps-csat/adobe-home/adobe-home-nps-csat
- After: https://nps-csat-alloy--milo--adobecom.aem.page/nps-csat/adobe-home/adobe-home-nps-csat






