### PR TITLE
[MWPW-198706] - Added fix for focus indicator issue on Geo routing

### DIFF
--- a/libs/features/georoutingv2/georoutingv2.css
+++ b/libs/features/georoutingv2/georoutingv2.css
@@ -198,6 +198,7 @@ html:has(meta[name="foundation"][content="c2"]) {
 
       div[role="tablist"] {
         padding: calc(var(--s2a-spacing-xs) + var(--dialog-modal-close-size) + var(--s2a-spacing-lg)) 0 var(--s2a-spacing-xs);
+        border-radius: 0;
 
         .tab-list-container {
           margin: 0;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
### Bug Fix:
Bug fix for Geo routing tab focus indicator issue, where the focus outline appeared rounded due to updates made to the tab block during Wave 2.

Resolves: [MWPW-198706](https://jira.corp.adobe.com/browse/MWPW-198706)

### Screenshots:
**Before:**
<img width="872" height="393" alt="Screenshot 2026-07-07 at 1 55 47 PM" src="https://github.com/user-attachments/assets/185eda61-c506-4c23-a5ca-128868c212cf" />

**After:**
<img width="872" height="393" alt="Screenshot 2026-07-07 at 1 57 14 PM" src="https://github.com/user-attachments/assets/d8cc35d2-c391-4d7d-95c0-f98702dcfb7c" />

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-198706--milo--adobecom.aem.page/?martech=off

**QA:**
https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=mwpw-198706

