### PR TITLE
Fix: last column not visible in 2x2 tables on mobile and tablet views

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -692,6 +692,10 @@
     margin: 0;
   }
 
+  .table.preserve-columns .section-row-title {
+    grid-column: auto !important;
+  }
+
   .table:not(.merch) .row .section-head-title,
   .table:not(.merch) .row .section-row-title {
     border-right: 1px solid var(--border-color);
@@ -701,10 +705,23 @@
     display: block;
   }
 
+  .table.preserve-columns .col-heading.col-1,
+  .table.preserve-columns .row-highlight .col-highlight.col-1 {
+    display: flex !important;
+  }
+
   .table .section-head .col:not(.section-head-title),
   .table:not(.merch) .col-heading.col-1,
   .table:not(.merch) .row-highlight .col-highlight.col-1:not(:only-child) {
     display: none;
+  }
+
+  .table.preserve-columns .row-heading .col-heading:first-child {
+    border-top-left-radius: var(--border-radius);
+  }
+
+  .table.preserve-columns .row-heading .col-heading:last-child {
+    border-top-left-radius: 0;
   }
 
   .table:not(.merch) .row-highlight:has(> :only-child) {

--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -692,8 +692,8 @@
     margin: 0;
   }
 
-  .table.preserve-columns .section-row-title {
-    grid-column: auto !important;
+  .table.preserve-columns .row .section-row-title {
+    grid-column: auto;
   }
 
   .table:not(.merch) .row .section-head-title,
@@ -705,9 +705,9 @@
     display: block;
   }
 
-  .table.preserve-columns .col-heading.col-1,
-  .table.preserve-columns .row-highlight .col-highlight.col-1 {
-    display: flex !important;
+  .table.preserve-columns .row-heading .col-heading.col-1,
+  .table.preserve-columns .row.row-highlight .col-highlight.col-1 {
+    display: flex;
   }
 
   .table .section-head .col:not(.section-head-title),

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -477,9 +477,7 @@ function applyStylesBasedOnScreenSize(table, originTable) {
   const deviceBySize = defineDeviceByScreenSize();
 
   const setRowStyle = () => {
-    if (table.classList.contains('preserve-columns')) {
-      return;
-    }
+    if (table.classList.contains('preserve-columns')) return;
     if (isMerch) return;
     const sectionRow = Array.from(table.getElementsByClassName('section-row'));
     if (sectionRow.length) {
@@ -676,12 +674,9 @@ export default function init(el) {
     expandSection = handleSection(sectionParams);
   });
 
-  const firstRow = el.querySelector('.row-1');
-  const columnCount = firstRow?.children.length || 0;
+  const columnCount = el.querySelector('.row-1')?.children.length || 0;
 
-  if (columnCount <= 2) {
-    el.classList.add('preserve-columns');
-  }
+  if (columnCount <= 2) el.classList.add('preserve-columns');
 
   handleHighlight(el);
   handleStickyHeader(el);

--- a/libs/blocks/table/table.js
+++ b/libs/blocks/table/table.js
@@ -477,6 +477,9 @@ function applyStylesBasedOnScreenSize(table, originTable) {
   const deviceBySize = defineDeviceByScreenSize();
 
   const setRowStyle = () => {
+    if (table.classList.contains('preserve-columns')) {
+      return;
+    }
     if (isMerch) return;
     const sectionRow = Array.from(table.getElementsByClassName('section-row'));
     if (sectionRow.length) {
@@ -614,7 +617,10 @@ function applyStylesBasedOnScreenSize(table, originTable) {
   }
 
   removeClones();
-  if (deviceBySize === 'MOBILE' || (isMerch && deviceBySize === 'TABLET')) {
+  if (
+    !table.classList.contains('preserve-columns')
+    && (deviceBySize === 'MOBILE' || (isMerch && deviceBySize === 'TABLET'))
+  ) {
     mobileRenderer();
   } else {
     table.querySelectorAll('.hide-mobile, .left-round, .right-round').forEach((col) => { col.classList.remove('hide-mobile', 'left-round', 'right-round'); });
@@ -669,6 +675,13 @@ export default function init(el) {
 
     expandSection = handleSection(sectionParams);
   });
+
+  const firstRow = el.querySelector('.row-1');
+  const columnCount = firstRow?.children.length || 0;
+
+  if (columnCount <= 2) {
+    el.classList.add('preserve-columns');
+  }
 
   handleHighlight(el);
   handleStickyHeader(el);

--- a/test/blocks/table/mocks/two-column-table.html
+++ b/test/blocks/table/mocks/two-column-table.html
@@ -1,0 +1,10 @@
+<div class="table">
+  <div>
+    <div><p>Feature</p></div>
+    <div><p>Details</p></div>
+  </div>
+  <div>
+    <div><p>Row 2 label</p></div>
+    <div><p>Row 2 value</p></div>
+  </div>
+</div>

--- a/test/blocks/table/table.test.js
+++ b/test/blocks/table/table.test.js
@@ -29,6 +29,22 @@ describe('table and tablemetadata', () => {
       expect(table.querySelector('.row-heading')).to.exist;
     });
 
+    it('does not add preserve-columns class to tables with more than two columns', () => {
+      expect(table.classList.contains('preserve-columns')).to.be.false;
+    });
+
+    it('adds preserve-columns class to a table with two or fewer columns', async () => {
+      const html = await readFile({ path: './mocks/two-column-table.html' });
+      const container = document.createElement('div');
+      container.innerHTML = html;
+      document.body.appendChild(container);
+
+      const twoColTable = container.querySelector('.table');
+      init(twoColTable);
+      expect(twoColTable.classList.contains('preserve-columns')).to.be.true;
+      container.remove();
+    });
+
     it('expand icon event by mouse click', () => {
       const expandIcon = table.querySelector('.icon.expand');
       expect(expandIcon.ariaExpanded).to.be.equal('true');


### PR DESCRIPTION
Resolves: [MWPW-199959](https://jira.corp.adobe.com/browse/MWPW-199959)

**Description**

As part of exploring the Adobe Blog components in Milo, I identified an issue with the Table block's responsive column display. I investigated the root cause, implemented a fix, and contributed the changes.

When a Table block contains exactly two columns, the first column becomes hidden on mobile and tablet viewports, leaving only one column visible. This change automatically preserves both columns for two-column tables, ensuring they remain visible and accessible across smaller viewports while keeping the existing behavior unchanged for tables with more than two columns.

**Steps to Reproduce**

1. Add a Table block with exactly two columns.
2. View the page on a mobile or tablet viewport.

**Expected:** Both columns remain visible.

**Actual:** The first column is hidden, leaving only one column visible.


**Test URLs**

**Before:** https://main--mitrah-milo-hub--jsmitrah26.aem.live/table-block

**After:** https://main--mitrah-milo-hub--jsmitrah26.aem.live/table-block?milolibs=table-preserve-column--milo--jsmitrah26





