### PR TITLE
[MWPW-200234] - Comparison table price AU render

### DIFF
--- a/libs/blocks/comparison-table/comparison-table.css
+++ b/libs/blocks/comparison-table/comparison-table.css
@@ -296,6 +296,9 @@
   font-weight: var(--type-detail-all-weight);
   line-height: 1.25;
   color: var(--color-black);
+}
+
+.comparison-table .price.price-strikethrough {
   display: flex;
 }
 

--- a/libs/blocks/comparison-table/comparison-table.css
+++ b/libs/blocks/comparison-table/comparison-table.css
@@ -298,10 +298,6 @@
   color: var(--color-black);
 }
 
-.comparison-table .price.price-strikethrough {
-  display: flex;
-}
-
 .comparison-table .sub-header-item-container em {
   font-size: var(--type-body-xxs-size);
   font-weight: 400;
@@ -313,6 +309,7 @@
 }
 
 .comparison-table .price.price-strikethrough {
+  display: flex;
   font-size: var(--type-body-xxs-size);
 }
 


### PR DESCRIPTION
Fixes price render for AU pages for comparison table.

Resolves: [MWPW-200234](https://jira.corp.adobe.com/browse/MWPW-200234)

| Before | After |
| --- | --- |
| <img width="842" height="359" alt="Screenshot 2026-07-08 at 15 47 03" src="https://github.com/user-attachments/assets/4da77879-dddd-4aad-b926-37969ff08501" /> | <img width="815" height="277" alt="Screenshot 2026-07-08 at 15 47 09" src="https://github.com/user-attachments/assets/ce91e970-f8ec-4c70-a5f4-76fe7bbc2198" /> |

**VPN is required to view the issue!**

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/au/acrobat/pricing/students?milolibs=stage&mep=%2Facrobat%2Fpricing-devicetype.json--default&target=on&commerce.landscape=DRAFT&commerce.env=stage&at_preview_token=jxiEWiaZYGpPzT6A2eklrg&at_preview_index=1_2&at_preview_listed_activities_only=true
- After: https://main--da-dc--adobecom.aem.page/au/acrobat/pricing/students?milolibs=comparison-table-price&mep=%2Facrobat%2Fpricing-devicetype.json--default&target=on&commerce.landscape=DRAFT&commerce.env=stage&at_preview_token=jxiEWiaZYGpPzT6A2eklrg&at_preview_index=1_2&at_preview_listed_activities_only=true


