### PR TITLE
MWPW-200345 [Lingo] Split Adobe Home redirect into acomLocale + acomCountry

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1029,11 +1029,9 @@ export async function getLingoRegion({ useGeoLocation = false } = {}) {
 
   if (!regions || !Object.keys(regions).length) return null;
 
-  if (useGeoLocation) {
-    const intlPrefix = sessionStorage.getItem('international') || getCookie('international');
-    if (intlPrefix) return Object.values(regions).find((r) => r.prefix === `/${intlPrefix}`) ?? null;
-  }
-
+  // Under Lingo the `international` cookie holds only the language (not a region),
+  // so it is not consulted here. On the geo path the region/country comes from the
+  // user's physical location; the default path keeps the selected-market cookie.
   const country = useGeoLocation
     ? normCountryCode(await getCountry())
     : (await resolveDetectedMarketCountry())?.toLowerCase();
@@ -2012,6 +2010,10 @@ let imsLoaded;
 export async function loadIms() {
   imsLoaded = imsLoaded || (async () => {
     const lingoRegion = lingoActive() ? await getLingoRegion({ useGeoLocation: true }) : null;
+    // Geo country for the Adobe Home redirect (`acomCountry`). Resolved from the
+    // user's physical location only; sessionStorage `akamai` is already set by
+    // loadArea, so this reuses it rather than re-fetching geo.
+    const acomCountry = lingoActive() ? normCountryCode(await getCountry())?.toUpperCase() : null;
     return new Promise((resolve, reject) => {
       const {
         locale, imsClientId, imsScope, env, base, adobeid, imsTimeout,
@@ -2030,9 +2032,15 @@ export async function loadIms() {
         redirect_uri: ahomeMeta === 'on'
           ? (() => {
             const baseUrl = `https://www${env.name !== 'prod' ? '.stage' : ''}.adobe.com`;
-            const acomPrefix = (lingoRegion?.prefix || locale.prefix).slice(1);
-            if (acomPrefix === 'cn' || acomPrefix === 'sea') return `${baseUrl}${locale.prefix}`;
-            return `${baseUrl}/home${acomPrefix ? `?acomLocale=${acomPrefix}` : ''}`;
+            const acomLocale = locale.prefix.slice(1);
+            if (acomLocale === 'cn' || acomLocale === 'sea') return `${baseUrl}${locale.prefix}`;
+            // Language in `acomLocale`, geo country in `acomCountry` (Lingo pages
+            // only). Matches the Akamai/CCH redirect shape, e.g. ?acomLocale=fr&acomCountry=CA.
+            const query = [
+              acomLocale && `acomLocale=${acomLocale}`,
+              acomCountry && `acomCountry=${acomCountry}`,
+            ].filter(Boolean).join('&');
+            return `${baseUrl}/home${query ? `?${query}` : ''}`;
           })() : undefined,
         autoValidateToken: true,
         environment: env.ims,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2030,7 +2030,7 @@ export async function loadIms() {
             const baseUrl = `https://www${env.name !== 'prod' ? '.stage' : ''}.adobe.com`;
             const localePrefix = locale.prefix.slice(1);
             if (localePrefix === 'cn' || localePrefix === 'sea') return `${baseUrl}${locale.prefix}`;
-            const acomLocale = isLingo ? (locale.ietf || 'en').split('-')[0] : localePrefix;
+            const acomLocale = isLingo ? (locale.ietf || 'en').split(/[-_]/)[0] : localePrefix;
             const query = [
               acomLocale && `acomLocale=${acomLocale}`,
               acomCountry && `acomCountry=${acomCountry}`,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1021,6 +1021,17 @@ export async function resolveDetectedMarketCountry() {
   );
 }
 
+function resolveLingoRegionKey(regions, country, localeKey, mepMap) {
+  const directKey = Object.entries(regions).find(
+    ([key]) => key === country || key === `${country}_${localeKey}`,
+  )?.[0];
+  if (directKey) return directKey;
+  if (!mepMap) return undefined;
+  return Object.entries(mepMap).find(
+    ([key, countries]) => Array.isArray(countries) && countries.includes(country) && regions[key],
+  )?.[0];
+}
+
 export async function getLingoRegion({ useGeoLocation = false } = {}) {
   if (!lingoActive()) return null;
   const config = getConfig();
@@ -1035,18 +1046,40 @@ export async function getLingoRegion({ useGeoLocation = false } = {}) {
   if (!country) return null;
 
   const localeKey = locale.prefix === '' ? 'en' : locale.prefix.replace('/', '');
-
-  let regionKey = Object.entries(regions).find(
-    ([key]) => key === country || key === `${country}_${localeKey}`,
-  )?.[0];
-
-  if (!regionKey && config.mepLingoCountryToRegion) {
-    regionKey = Object.entries(config.mepLingoCountryToRegion).find(
-      ([key, countries]) => Array.isArray(countries) && countries.includes(country) && regions[key],
-    )?.[0];
-  }
-
+  const mepMap = config.mepLingoCountryToRegion;
+  const regionKey = resolveLingoRegionKey(regions, country, localeKey, mepMap);
   return regionKey ? regions[regionKey] : null;
+}
+
+// The set of valid regions for the current page's base. A base locale (no `base`
+// key, e.g. /fr) carries its hydrated `regions` map; a regional variant (/ch_de)
+// has none of its own, so reconstruct its base's region set from the siblings
+// that point at the same base.
+function getBaseRegions(config) {
+  const { locale, locales } = config || {};
+  if (!locale) return {};
+  if (locale.base === undefined) return locale.regions || {};
+  if (!locales) return {};
+  return Object.fromEntries(
+    Object.entries(locales).filter(([, l]) => l.base === locale.base),
+  );
+}
+
+// acomCountry is the user's geo country, but only passed when that country maps
+// to a valid region of the current base (e.g. on /fr only ch/ca/be/lu qualify).
+// Otherwise the language alone (acomLocale) is sent.
+async function resolveAcomCountry(config) {
+  const geoCountry = normCountryCode(await getCountry());
+  if (!geoCountry) return null;
+  const { locale } = config || {};
+  if (!locale) return null;
+  const regions = getBaseRegions(config);
+  if (!Object.keys(regions).length) return null;
+  const baseKey = locale.base !== undefined ? locale.base : (locale.prefix?.slice(1) || '');
+  const localeKey = baseKey === '' ? 'en' : baseKey;
+  const mepMap = config.mepLingoCountryToRegion;
+  const fits = resolveLingoRegionKey(regions, geoCountry, localeKey, mepMap);
+  return fits ? geoCountry.toUpperCase() : null;
 }
 
 export async function getGeoLocalePrefix() {
@@ -2009,7 +2042,7 @@ export async function loadIms() {
     const isLingo = lingoActive();
     const lingoRegion = isLingo ? await getLingoRegion({ useGeoLocation: true }) : null;
     const acomCountry = isLingo && getMetadata('adobe-home-redirect') === 'on'
-      ? normCountryCode(await getCountry())?.toUpperCase() : null;
+      ? await resolveAcomCountry(getConfig()) : null;
     return new Promise((resolve, reject) => {
       const {
         locale, imsClientId, imsScope, env, base, adobeid, imsTimeout,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1051,32 +1051,14 @@ export async function getLingoRegion({ useGeoLocation = false } = {}) {
   return regionKey ? regions[regionKey] : null;
 }
 
-// The set of valid regions for the current page's base. A base locale (no `base`
-// key, e.g. /fr) carries its hydrated `regions` map; a regional variant (/ch_de)
-// has none of its own, so reconstruct its base's region set from the siblings
-// that point at the same base.
-function getBaseRegions(config) {
-  const { locale, locales } = config || {};
-  if (!locale) return {};
-  if (locale.base === undefined) return locale.regions || {};
-  if (!locales) return {};
-  return Object.fromEntries(
-    Object.entries(locales).filter(([, l]) => l.base === locale.base),
-  );
-}
-
-// acomCountry is the user's geo country, but only passed when that country maps
-// to a valid region of the current base (e.g. on /fr only ch/ca/be/lu qualify).
-// Otherwise the language alone (acomLocale) is sent.
 async function resolveAcomCountry(config) {
   const geoCountry = normCountryCode(await getCountry());
-  if (!geoCountry) return null;
-  const { locale } = config || {};
-  if (!locale) return null;
-  const regions = getBaseRegions(config);
-  if (!Object.keys(regions).length) return null;
-  const baseKey = locale.base !== undefined ? locale.base : (locale.prefix?.slice(1) || '');
-  const localeKey = baseKey === '' ? 'en' : baseKey;
+  const { locale, locales } = config || {};
+  if (!geoCountry || !locale) return null;
+  const regions = locale.base === undefined
+    ? (locale.regions || {})
+    : Object.fromEntries(Object.entries(locales || {}).filter(([, l]) => l.base === locale.base));
+  const localeKey = (locale.base ?? locale.prefix?.slice(1)) || 'en';
   const mepMap = config.mepLingoCountryToRegion;
   const fits = resolveLingoRegionKey(regions, geoCountry, localeKey, mepMap);
   return fits ? geoCountry.toUpperCase() : null;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1029,9 +1029,6 @@ export async function getLingoRegion({ useGeoLocation = false } = {}) {
 
   if (!regions || !Object.keys(regions).length) return null;
 
-  // Under Lingo the `international` cookie holds only the language (not a region),
-  // so it is not consulted here. On the geo path the region/country comes from the
-  // user's physical location; the default path keeps the selected-market cookie.
   const country = useGeoLocation
     ? normCountryCode(await getCountry())
     : (await resolveDetectedMarketCountry())?.toLowerCase();
@@ -2010,9 +2007,6 @@ let imsLoaded;
 export async function loadIms() {
   imsLoaded = imsLoaded || (async () => {
     const lingoRegion = lingoActive() ? await getLingoRegion({ useGeoLocation: true }) : null;
-    // Geo country for the Adobe Home redirect (`acomCountry`). Resolved from the
-    // user's physical location only; sessionStorage `akamai` is already set by
-    // loadArea, so this reuses it rather than re-fetching geo.
     const acomCountry = lingoActive() ? normCountryCode(await getCountry())?.toUpperCase() : null;
     return new Promise((resolve, reject) => {
       const {
@@ -2034,8 +2028,6 @@ export async function loadIms() {
             const baseUrl = `https://www${env.name !== 'prod' ? '.stage' : ''}.adobe.com`;
             const acomLocale = locale.prefix.slice(1);
             if (acomLocale === 'cn' || acomLocale === 'sea') return `${baseUrl}${locale.prefix}`;
-            // Language in `acomLocale`, geo country in `acomCountry` (Lingo pages
-            // only). Matches the Akamai/CCH redirect shape, e.g. ?acomLocale=fr&acomCountry=CA.
             const query = [
               acomLocale && `acomLocale=${acomLocale}`,
               acomCountry && `acomCountry=${acomCountry}`,

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2006,8 +2006,10 @@ export const getMepEnablement = (mdKey, paramKey = false) => {
 let imsLoaded;
 export async function loadIms() {
   imsLoaded = imsLoaded || (async () => {
-    const lingoRegion = lingoActive() ? await getLingoRegion({ useGeoLocation: true }) : null;
-    const acomCountry = lingoActive() ? normCountryCode(await getCountry())?.toUpperCase() : null;
+    const isLingo = lingoActive();
+    const lingoRegion = isLingo ? await getLingoRegion({ useGeoLocation: true }) : null;
+    const acomCountry = isLingo && getMetadata('adobe-home-redirect') === 'on'
+      ? normCountryCode(await getCountry())?.toUpperCase() : null;
     return new Promise((resolve, reject) => {
       const {
         locale, imsClientId, imsScope, env, base, adobeid, imsTimeout,
@@ -2026,8 +2028,9 @@ export async function loadIms() {
         redirect_uri: ahomeMeta === 'on'
           ? (() => {
             const baseUrl = `https://www${env.name !== 'prod' ? '.stage' : ''}.adobe.com`;
-            const acomLocale = locale.prefix.slice(1);
-            if (acomLocale === 'cn' || acomLocale === 'sea') return `${baseUrl}${locale.prefix}`;
+            const localePrefix = locale.prefix.slice(1);
+            if (localePrefix === 'cn' || localePrefix === 'sea') return `${baseUrl}${locale.prefix}`;
+            const acomLocale = isLingo ? (locale.ietf || 'en').split('-')[0] : localePrefix;
             const query = [
               acomLocale && `acomLocale=${acomLocale}`,
               acomCountry && `acomCountry=${acomCountry}`,

--- a/test/blocks/susi-light-login/susi-light-login.test.js
+++ b/test/blocks/susi-light-login/susi-light-login.test.js
@@ -85,7 +85,7 @@ describe('susi light', () => {
       expect(susiElement.authParams.dctx_id).equals('v:2,test-id');
     });
   });
-  describe('lingo sign-in locale follows the explicit region pick', () => {
+  describe('lingo sign-in locale follows the user geo (physical location)', () => {
     before(async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
@@ -100,9 +100,10 @@ describe('susi light', () => {
         },
         pathname: '/de/',
       };
-      // Explicit CH-German region pick; a divergent FR market cookie must be
-      // ignored on the sign-in path (it drives pricing only).
-      document.cookie = 'international=ch_de; path=/';
+      // Physically in CH (geo). Neither the market `country` cookie (pricing) nor
+      // the `international` cookie (language-only under Lingo) is consulted here.
+      sessionStorage.setItem('akamai', 'ch');
+      document.cookie = 'international=ca_fr; path=/';
       document.cookie = 'country=fr; path=/';
       document.body.innerHTML = susiHtml;
       setConfig(config);
@@ -111,10 +112,11 @@ describe('susi light', () => {
     });
     after(() => {
       document.querySelector('meta[name="langfirst"]')?.remove();
+      sessionStorage.removeItem('akamai');
       document.cookie = 'international=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
       document.cookie = 'country=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
     });
-    it('uses the international pick (de-CH), not the market cookie (fr)', async () => {
+    it('uses geo (de-CH), ignoring the international and market cookies', async () => {
       susiElement = document.querySelector('susi-sentry-light');
       expect(susiElement.authParams.locale).equals('de-CH');
     });

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2836,29 +2836,30 @@ describe('Utils', () => {
       expect(region.prefix).to.equal('/ch_de');
     });
 
-    it('with useGeoLocation honors the international cookie (explicit pick) over geo', async () => {
+    it('with useGeoLocation ignores the international cookie and resolves by geo', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
       document.head.append(lingoMeta);
       lingoModule.setConfig(lingoRegionConfig);
-      // Explicit CH region pick; geo says US (no region) — the pick wins.
-      document.cookie = 'international=ch_de; path=/';
-      sessionStorage.setItem('akamai', 'us');
+      // Under Lingo the international cookie holds only the language, so it is no
+      // longer consulted: a divergent international pick must not override geo.
+      document.cookie = 'international=fr; path=/';
+      sessionStorage.setItem('akamai', 'ch');
       const region = await lingoModule.getLingoRegion({ useGeoLocation: true });
       expect(region).to.not.be.null;
       expect(region.prefix).to.equal('/ch_de');
     });
 
-    it('with useGeoLocation, an explicit base/root pick is not overridden by geo', async () => {
+    it('with useGeoLocation returns null when geo has no region, even if an international cookie is set', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
       document.head.append(lingoMeta);
       lingoModule.setConfig(lingoRegionConfig);
-      // User explicitly chose the root (us) — geo CH must NOT pull them to ch_de.
-      document.cookie = 'international=us; path=/';
-      sessionStorage.setItem('akamai', 'ch');
+      // international cookie is ignored; geo US maps to no region.
+      document.cookie = 'international=ch_de; path=/';
+      sessionStorage.setItem('akamai', 'us');
       const region = await lingoModule.getLingoRegion({ useGeoLocation: true });
       expect(region).to.be.null;
     });
@@ -2961,7 +2962,7 @@ describe('Utils', () => {
       expect(window.adobeid.locale).to.equal('fr_FR');
     });
 
-    it('builds Adobe Home redirect_uri with region acomLocale when lingo is active', async () => {
+    it('builds Adobe Home redirect_uri with language acomLocale + geo acomCountry when lingo is active', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
@@ -2974,7 +2975,7 @@ describe('Utils', () => {
       sessionStorage.setItem('akamai', 'ch');
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
-      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=ch_fr');
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=CH');
     });
 
     it('builds Adobe Home redirect_uri with locale-prefix acomLocale when lingo is not active', async () => {
@@ -3011,8 +3012,9 @@ describe('Utils', () => {
       expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/sea');
     });
 
-    // AC#2: signing in from /fr with a Canadian IP lands on Adobe Home as ca_fr.
-    it('builds ca_fr Adobe Home redirect_uri for a Canadian user on the base /fr page', async () => {
+    // AC#1/#2: signing in from /fr with a Canadian IP lands on Adobe Home as
+    // acomLocale=fr (language) + acomCountry=CA (geo country).
+    it('builds acomLocale=fr&acomCountry=CA for a Canadian user on the base /fr page', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
@@ -3025,11 +3027,29 @@ describe('Utils', () => {
       sessionStorage.setItem('akamai', 'ca');
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
-      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=ca_fr');
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=CA');
     });
 
-    // Sign-in uses geo (akamai 'ca'), not the selected-market cookie (country=fr),
-    // so a Canadian who previously picked the FR market still lands on ca_fr.
+    // AC#2: acomCountry is always the geo country, even when it maps to no Lingo
+    // region (a user physically in France still gets acomCountry=FR).
+    it('sets acomCountry to the geo country even when it maps to no region', async () => {
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig(imsLingoConfig);
+      sessionStorage.setItem('akamai', 'fr');
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=FR');
+    });
+
+    // AC#4: sign-in uses geo (akamai 'ca'), not the selected-market cookie
+    // (country=fr), so acomCountry follows physical location.
     it('uses geo over a divergent market cookie for the Adobe Home redirect_uri', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
@@ -3044,11 +3064,11 @@ describe('Utils', () => {
       sessionStorage.setItem('akamai', 'ca');
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
-      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=ca_fr');
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=CA');
     });
 
-    // Explicit region pick (international cookie) wins over a divergent geo.
-    it('uses the international cookie over geo for the Adobe Home redirect_uri', async () => {
+    // AC#3: the international cookie is no longer consulted; geo wins.
+    it('ignores the international cookie and uses geo for the Adobe Home redirect_uri', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
@@ -3058,12 +3078,31 @@ describe('Utils', () => {
       ahomeMeta.setAttribute('content', 'on');
       document.head.append(ahomeMeta);
       lingoModule.setConfig(imsLingoConfig);
-      // Explicitly picked CA French; physically in CH — the pick wins over geo.
+      // international cookie set to CA French, but physically in CH — geo wins.
       document.cookie = 'international=ca_fr; path=/';
       sessionStorage.setItem('akamai', 'ch');
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
-      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=ca_fr');
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=CH');
+    });
+
+    // A Lingo page with no resolvable geo omits acomCountry (only the language).
+    it('omits acomCountry when no geo country is available', async () => {
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig(imsLingoConfig);
+      const originalFetch = window.fetch;
+      window.fetch = sinon.stub().rejects(new Error('network error'));
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      window.fetch = originalFetch;
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr');
     });
 
     it('builds a bare /home redirect_uri (no acomLocale) on the root locale', async () => {

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -3026,12 +3026,12 @@ describe('Utils', () => {
       lingoModule.setConfig({
         ...imsLingoConfig,
         pathname: '/fr/',
-        locales: { '': { ietf: 'en-US' }, fr: { ietf: 'fr_FR' } },
+        locales: { '': { ietf: 'en-US' }, fr: { ietf: 'fr_FR' }, ch_fr: { ietf: 'fr-CH', base: 'fr' } },
       });
-      sessionStorage.setItem('akamai', 'fr');
+      sessionStorage.setItem('akamai', 'ch');
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
-      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=FR');
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=CH');
     });
 
     it('keeps the combined prefix and no acomCountry for a pre-lingo regional locale (lu_de)', async () => {
@@ -3090,9 +3090,28 @@ describe('Utils', () => {
       expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=CA');
     });
 
-    // AC#2: acomCountry is always the geo country, even when it maps to no Lingo
-    // region (a user physically in France still gets acomCountry=FR).
-    it('sets acomCountry to the geo country even when it maps to no region', async () => {
+    // acomCountry is only sent when the geo country maps to a valid region of the
+    // base. On /fr the base regions are ca/ch, so a German IP (no fr-DE) gets the
+    // language alone.
+    it('omits acomCountry when the geo country is not a region of the base', async () => {
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig(imsLingoConfig);
+      sessionStorage.setItem('akamai', 'de');
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr');
+    });
+
+    // The base country itself is not a region variant: France on /fr gets no
+    // acomCountry (there is no fr-FR variant, /fr already is France).
+    it('omits acomCountry when the geo country is the base country (fr on /fr)', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
@@ -3105,7 +3124,89 @@ describe('Utils', () => {
       sessionStorage.setItem('akamai', 'fr');
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
-      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=FR');
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr');
+    });
+
+    // Regional-variant page: acomCountry follows geo only when it fits the base.
+    // A Canadian on /ch_de does not fit base 'de' (regions at/ch/lu), so no country.
+    it('omits acomCountry on a regional page when geo does not fit the base (ca on /ch_de)', async () => {
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig({
+        ...imsLingoConfig,
+        pathname: '/ch_de/',
+        locales: {
+          '': { ietf: 'en-US' },
+          de: { ietf: 'de-DE' },
+          at: { ietf: 'de-AT', base: 'de' },
+          ch_de: { ietf: 'de-CH', base: 'de' },
+          lu_de: { ietf: 'de-LU', base: 'de' },
+        },
+      });
+      sessionStorage.setItem('akamai', 'ca');
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=de');
+    });
+
+    // Regional-variant page: a geo that does fit the base (Austria on /ch_de)
+    // sends that geo country.
+    it('sends geo acomCountry on a regional page when geo fits the base (at on /ch_de)', async () => {
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig({
+        ...imsLingoConfig,
+        pathname: '/ch_de/',
+        locales: {
+          '': { ietf: 'en-US' },
+          de: { ietf: 'de-DE' },
+          at: { ietf: 'de-AT', base: 'de' },
+          ch_de: { ietf: 'de-CH', base: 'de' },
+          lu_de: { ietf: 'de-LU', base: 'de' },
+        },
+      });
+      sessionStorage.setItem('akamai', 'at');
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=de&acomCountry=AT');
+    });
+
+    // Aggregate region via mepLingoCountryToRegion: a Kenyan on the root maps to
+    // the africa region, so acomCountry=KE is sent.
+    it('sends acomCountry for a mepLingoCountryToRegion aggregate region (ke -> africa)', async () => {
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig({
+        ...imsLingoConfig,
+        pathname: '/',
+        locales: {
+          '': { ietf: 'en-US' },
+          africa: { ietf: 'en', base: '' },
+        },
+        mepLingoCountryToRegion: { africa: ['ke', 'mu', 'ng', 'za'] },
+      });
+      sessionStorage.setItem('akamai', 'ke');
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=en&acomCountry=KE');
     });
 
     // AC#4: sign-in uses geo (akamai 'ca'), not the selected-market cookie
@@ -3176,7 +3277,7 @@ describe('Utils', () => {
       expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home');
     });
 
-    it('sends acomLocale=en (ietf language) + geo acomCountry on the post-lingo international site', async () => {
+    it('sends acomLocale=en with no acomCountry on the international root (us is the base country)', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
@@ -3189,7 +3290,7 @@ describe('Utils', () => {
       sessionStorage.setItem('akamai', 'us');
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
-      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=en&acomCountry=US');
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=en');
     });
 
     // AC#3 guard: pages without adobe-home-redirect must not get a /home redirect_uri.

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -3014,6 +3014,26 @@ describe('Utils', () => {
       expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=de&acomCountry=CH');
     });
 
+    it('splits acomLocale on an underscore ietf (getLanguage fallback fr_FR -> fr)', async () => {
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig({
+        ...imsLingoConfig,
+        pathname: '/fr/',
+        locales: { '': { ietf: 'en-US' }, fr: { ietf: 'fr_FR' } },
+      });
+      sessionStorage.setItem('akamai', 'fr');
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=FR');
+    });
+
     it('keeps the combined prefix and no acomCountry for a pre-lingo regional locale (lu_de)', async () => {
       const ahomeMeta = document.createElement('meta');
       ahomeMeta.setAttribute('name', 'adobe-home-redirect');

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2978,7 +2978,7 @@ describe('Utils', () => {
       expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr&acomCountry=CH');
     });
 
-    it('builds Adobe Home redirect_uri with locale-prefix acomLocale when lingo is not active', async () => {
+    it('keeps the prefix acomLocale and sends no acomCountry when lingo is not active', async () => {
       const ahomeMeta = document.createElement('meta');
       ahomeMeta.setAttribute('name', 'adobe-home-redirect');
       ahomeMeta.setAttribute('content', 'on');
@@ -2988,6 +2988,46 @@ describe('Utils', () => {
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
       expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=fr');
+    });
+
+    it('derives acomLocale from the ietf language for a regional prefix (ch_de -> de)', async () => {
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig({
+        ...imsLingoConfig,
+        pathname: '/ch_de/',
+        locales: {
+          '': { ietf: 'en-US' },
+          de: { ietf: 'de-DE' },
+          ch_de: { ietf: 'de-CH', base: 'de' },
+        },
+      });
+      sessionStorage.setItem('akamai', 'ch');
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=de&acomCountry=CH');
+    });
+
+    it('keeps the combined prefix and no acomCountry for a pre-lingo regional locale (lu_de)', async () => {
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig({
+        ...imsLingoConfig,
+        pathname: '/lu_de/',
+        locales: { '': { ietf: 'en-US' }, lu_de: { ietf: 'de-LU' } },
+      });
+      sessionStorage.setItem('akamai', 'lu');
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=lu_de');
     });
 
     it('keeps cn and sea on their locale homepage instead of /home for Adobe Home redirect_uri', async () => {
@@ -3114,6 +3154,22 @@ describe('Utils', () => {
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
       expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home');
+    });
+
+    it('sends acomLocale=en (ietf language) + geo acomCountry on the post-lingo international site', async () => {
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+      const ahomeMeta = document.createElement('meta');
+      ahomeMeta.setAttribute('name', 'adobe-home-redirect');
+      ahomeMeta.setAttribute('content', 'on');
+      document.head.append(ahomeMeta);
+      lingoModule.setConfig({ ...imsLingoConfig, pathname: '/' });
+      sessionStorage.setItem('akamai', 'us');
+      lingoModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=en&acomCountry=US');
     });
 
     // AC#3 guard: pages without adobe-home-redirect must not get a /home redirect_uri.


### PR DESCRIPTION
Follow-up to MWPW-194172 ([#6100](https://github.com/adobecom/milo/pull/6100)). Makes the post-sign-in Adobe Home redirect emit the Akamai/CCH param shape on Lingo pages, and drops the `international` cookie from sign-in region resolution.

Resolves: [MWPW-200345](https://jira.corp.adobe.com/browse/MWPW-200345)

## What changes

**On Lingo pages** the redirect is now `…/home?acomLocale=<language>&acomCountry=<geoCountry>`:
- `acomLocale` = the locale's **ietf language** (e.g. `de-CH`→`de`, `fr-FR`→`fr`, `en-US`→`en`). This correctly handles regional Lingo prefixes (`/ch_de`→`de`) and the international base site (`/`→`en`), which a path-prefix approach could not. Split tolerates the underscore ietf form (`fr_FR`→`fr`) that `getLanguage` synthesizes for language-first config rows.
- `acomCountry` = the user's **geo country** (uppercased/ISO-normalised via `getCountry()`, so `uk`→`gb`) — **but only when that geo country maps to a valid region of the current page's base.**

**The base-region gate (the important part).** A base locale like `/fr` only has a fixed set of regional variants — `ca_fr`, `ch_fr`, `be_fr`, `lu_fr` → countries **ca, ch, be, lu**. We only pass `acomCountry` when the user's geo is one of those:
- User on `/fr` in Switzerland → `acomLocale=fr&acomCountry=CH` (fr-CH exists).
- User on `/fr` in Germany → `acomLocale=fr` only (no fr-DE variant).
- User on `/fr` in France → `acomLocale=fr` only (France *is* the base, not a variant).

The gate is resolved the same way `getLingoRegion` resolves a region — including:
- **Regional-variant pages** (`/ch_de`): resolved against the variant's base (`de`, whose regions are at/ch/lu). Swiss user on `/ch_de` → `acomCountry=CH`; Canadian on `/ch_de` → `acomLocale=de` only.
- **Aggregate regions** via `mepLingoCountryToRegion` (`africa`, `la`, `mena_en`): a Kenyan on the root maps to the `africa` region → `acomLocale=en&acomCountry=KE`.

This matches the Akamai redirect shape (`?acomLocale=…&acomCountry=…`) so Adobe Home / CCH receives one consistent contract regardless of which path (sign-in vs. Akamai) produced the redirect.

**Pre-Lingo pages are intentionally unchanged** (lower risk): `acomLocale` stays the path prefix (the combined value we've always passed, e.g. `lu_de`) and no `acomCountry` is sent.

**The `international` cookie is no longer consulted** for sign-in region resolution — under Lingo it holds only the language (not a region), so region/country comes from the user's physical location (geo) only.

`cn`/`sea` still redirect to their locale homepage rather than `/home` (unchanged).

<details><summary><strong>Code Changes (libs/utils/utils.js)</strong></summary>

- **`getLingoRegion({ useGeoLocation })`** — removed the `international` sessionStorage/cookie lookup from the geo path; with `useGeoLocation: true` the region resolves purely from geo. The region-matching logic (direct key + `mepLingoCountryToRegion`) is extracted into a shared helper `resolveLingoRegionKey`; behavior for existing callers is unchanged. The default (no-arg) path — used by `getGeoLocalePrefix`/MEP/content — is unchanged (still the selected-market `country` cookie).
- **`getBaseRegions` / `resolveAcomCountry`** (new, internal) — resolve the valid region set for the current page's base (a base locale uses its hydrated `regions`; a regional variant reconstructs its base's siblings) and return the geo country **only if it fits** that set.
- **`loadIms` redirect_uri** — `acomLocale = isLingo ? locale.ietf-language : locale.prefix`; `acomCountry = resolveAcomCountry(...)` (geo, gated on base fit). The SUSI widget display locale is still region-aware (`lingoRegion.ietf`) — only the redirect params changed. `acomCountry` reads geo from `sessionStorage.akamai` (already set by `loadArea`→`setCountry`; `getAkamaiCode` dedupes+caches), so there is no duplicate geo fetch, and it's only computed on `adobe-home-redirect` pages.
</details>

## Behavior matrix

| Page | Lingo? | Geo | Fits base? | redirect_uri |
|---|---|---|---|---|
| `/fr` | yes | CH | ✅ ch_fr | `/home?acomLocale=fr&acomCountry=CH` |
| `/fr` | yes | CA | ✅ ca_fr | `/home?acomLocale=fr&acomCountry=CA` |
| `/fr` | yes | DE | ❌ no fr-DE | `/home?acomLocale=fr` |
| `/fr` | yes | FR | ❌ base country | `/home?acomLocale=fr` |
| `/ch_de` (regional) | yes | CH | ✅ base=de | `/home?acomLocale=de&acomCountry=CH` |
| `/ch_de` (regional) | yes | CA | ❌ base=de | `/home?acomLocale=de` |
| `/` (international) | yes | US | ❌ base country | `/home?acomLocale=en` |
| `/` (international) | yes | KE | ✅ africa (mep) | `/home?acomLocale=en&acomCountry=KE` |
| `/fr` | yes | (no geo) | — | `/home?acomLocale=fr` |
| `/lu_de` | no (pre-Lingo) | — | — | `/home?acomLocale=lu_de` (unchanged) |
| `/cn`, `/sea` | any | — | — | `/cn`, `/sea` (unchanged) |

## Pairs with

- Akamai/CCH: `acomCountry` is consumed on the Adobe Home side (CCH — CCH-37414). Until CCH maps `acomCountry` to a display language, the visible CCH language may not change yet, but the **redirect URL params are verifiable in the address bar**.

## Test URLs

Branch libs override: `?milolibs=vhargrave-lingo-acom-country--milo--adobecom`

#### Test 1 — Canadian on `/fr` → `acomLocale=fr&acomCountry=CA`
- Before (stage): https://www.stage.adobe.com/fr/products/photoshop.html?akamaiLocale=ca
- After (branch): https://www.stage.adobe.com/fr/products/photoshop.html?akamaiLocale=ca&milolibs=vhargrave-lingo-acom-country--milo--adobecom
1. Sign in → land on `…/home?acomLocale=`**`fr`**`&acomCountry=`**`CA`** (CA fits the /fr base — ca_fr exists)

#### Test 2 — Swiss on `/fr` → `acomLocale=fr&acomCountry=CH`
- After (branch): https://www.stage.adobe.com/fr/products/photoshop-lightroom.html?milolibs=vhargrave-lingo-acom-country--milo--adobecom
1. Join Swiss/Basel VPN → Sign in → `…/home?acomLocale=`**`fr`**`&acomCountry=`**`CH`**

#### Test 3 — Geo that does NOT fit the base → language only
- After (branch): https://www.stage.adobe.com/fr/acrobat.html?milolibs=vhargrave-lingo-acom-country--milo--adobecom
1. Join a Germany VPN (or any country with no fr-XX variant)
2. Sign in → `…/home?acomLocale=`**`fr`** — no `acomCountry`, because Germany is not a region of the `/fr` base.

#### Test 4 — `international` cookie is IGNORED (geo wins)
- After (branch): https://www.stage.adobe.com/fr/acrobat.html?milolibs=vhargrave-lingo-acom-country--milo--adobecom
1. Join Swiss/Basel VPN
2. Open `…/fr/acrobat.html#langnav`, set region to Luxembourg – Français (writes `international=lu_fr`)
3. Sign in → `…/home?acomLocale=`**`fr`**`&acomCountry=`**`CH`** — the `international` pick is not honored; geo (CH) wins.

#### Test 5 — Pre-Lingo locale unchanged (no `acomCountry`)
- After (branch): https://www.stage.adobe.com/lu_de/acrobat.html?milolibs=vhargrave-lingo-acom-country--milo--adobecom
1. Sign in → `…/home?acomLocale=`**`lu_de`** (combined prefix, no `acomCountry`) — `/lu_de` isn't on Lingo, so behavior is unchanged.

## Tests
- `test/utils/utils.test.js` — `getLingoRegion` (geo-only, `international` ignored) + `loadIms` redirect: ietf language on Lingo pages (incl. underscore-ietf split), regional prefix (`ch_de`→`de`), international base (`/`→`en`), and the base-fit gate: geo that fits (ca/ch on `/fr`, at/ch on `/ch_de`, ke→africa via mep) sends `acomCountry`; geo that does not fit (de/fr on `/fr`, ca on `/ch_de`, us on root) sends language only; plus no-geo and pre-Lingo unchanged (`fr`, `lu_de`, bare root).
- `test/blocks/susi-light-login/susi-light-login.test.js` — sign-in widget locale follows geo, ignoring the market and `international` cookies.
- Full `npm test`: green (the only failure is a pre-existing language-selector timing flake, verified to fail ~2/3 runs on clean `stage`).




