### PR TITLE
[SR] Link icon update to support dark and light themes

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -596,8 +596,13 @@ a {
   &.standalone-link {
     &::after {
       display: inline-block;
+      width: 5px;
+      height: 8px;
       margin-inline-start: var(--s2a-spacing-8);
-      content: url('../assets/img/arrow-right.svg');
+      content: '';
+      background-color: currentcolor;
+      mask: url('../assets/img/arrow-right.svg') no-repeat center;
+      mask-size: contain;
       transition: transform 0.5s var(--parallax-easing);
     }
 
@@ -1015,12 +1020,6 @@ p {
 }
 
 .dark {
-  a.standalone-link {
-    &::after {
-      filter: invert(1);
-    }
-  }
-
   .con-button {
     &.outline {
       background-color: var(--s2a-color-transparent-white-00);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Standalone link icon update to align better with dark and light themes.

I was alerted to a regression I caused in [this PR](https://github.com/adobecom/milo/pull/6228/changes#diff-4b154f31bfe72dc8cba9c7db5926ab5ad053dc2b30256249e901da44b9112e40R1020) when adjusting the link icon to work with dark and light themes. 
Created a more robust solution based around work done in split-aside-grid.css
* Corrects standalone link icon color for all c2 pages.


Resolves: [MWPW-199377](https://jira.corp.adobe.com/browse/MWPW-199377)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=sr-dark-link-icon&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=sr-dark-link-icon&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

**Before fix:**
<img width="643" height="463" alt="before-fix" src="https://github.com/user-attachments/assets/b685ab25-846e-448c-b630-709c0389f55c" />

**After fix:**
<img width="638" height="450" alt="after-fix" src="https://github.com/user-attachments/assets/ade111d8-34cc-453c-a417-c6a83c6b3dee" />


