### PR TITLE
[SR][Hub Hero] Reduced Motion at 320px or less

### DIFF
--- a/libs/mep/ace1205/hub-hero/hub-hero.css
+++ b/libs/mep/ace1205/hub-hero/hub-hero.css
@@ -870,7 +870,7 @@
 }
 
 /** prefers-reduced-motion + extra small screens (320px = 640px at 200% zoom) */
-@media (prefers-reduced-motion: reduce), (width <= 480px) {
+@media (prefers-reduced-motion: reduce), (width <= 320px) {
 
   .hub-hero,
   .hub-hero-header,
@@ -1004,7 +1004,7 @@
 }
 
 /** mobile layout overrides for reduced-motion and extra small screens */
-@media (prefers-reduced-motion: reduce) and (width < 768px), (width <= 480px) {
+@media (prefers-reduced-motion: reduce) and (width < 768px), (width <= 320px) {
 
   .hub-hero-carousel-item-container .hub-hero-carousel-item-footer,
   .hub-hero-carousel-item-container .hub-hero-carousel-item-header {


### PR DESCRIPTION
Reduced media rule to <=320px instead of <=480px for "reduced motion"-like behavior to kick in

Resolves: [MWPW-200353](https://jira.corp.adobe.com/browse/MWPW-200353)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://<branch>--milo--adobecom.aem.page/?martech=off

BEFORE: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=stage&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

AFTER: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=sr-hub-hero-a11y-fix&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

