### PR TITLE
MWPW-198959 Log Marketo failure states

### DIFF
--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -550,6 +550,8 @@
 
 .marketo .marketo-overlay {
   position: absolute;
+  max-width: 600px;
+  margin: 0 auto;
   inset: 0;
   background: var(--marketo-form-overlay-background);
   display: flex;
@@ -576,6 +578,12 @@
   text-align: center;
   color: var(--marketo-form-text);
   margin-bottom: 12px;
+}
+
+.marketo .marketo-overlay .debug-info {
+  font-size: 14px;
+  text-align: center;
+  color: var(--marketo-form-text);
 }
 
 @media screen and (min-width: 600px) {

--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -25,13 +25,22 @@ import {
   SLD,
   MILO_EVENTS,
 } from '../../utils/utils.js';
-import { replaceKey } from '../../features/placeholders.js';
+import { replaceKeyArray } from '../../features/placeholders.js';
 
 const ROOT_MARGIN = 50;
-const IFRAME_TIMEOUT = 3000;
+const FAILURE_TIMEOUT = 10000;
+export const LANA_MESSAGE = {
+  RENDER_FAILED: 'Marketo form did not render',
+  HANDSHAKE_FAILED: 'Marketo form handshake failed',
+  RENDER_RECOVERED: 'Marketo form rendered after timeout',
+  SUBMIT_FAILED: 'Marketo form submit failed',
+  MARKETO_FORMS_JS: 'Marketo form failed to load forms2.min.js',
+};
 const FORM_ID = 'form id';
 const BASE_URL = 'marketo host';
 const MUNCHKIN_ID = 'marketo munckin';
+const FORM_STATUS = 'form.status';
+const FORM_XDFRAME = 'form.xdframe';
 const SUCCESS_TYPE = 'form.success.type';
 const SUCCESS_CONTENT = 'form.success.content';
 const SUCCESS_SECTION = 'form.success.section';
@@ -49,6 +58,30 @@ const FORM_MAP = {
   'hardcoded-poi': 'program.poi',
 };
 export const FORM_PARAM = 'form';
+
+const isVisible = (el) => !!el && (typeof el.checkVisibility === 'function'
+  ? el.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true })
+  : !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length));
+
+export const setDataLayer = (key = '', value = '') => {
+  window.mcz_marketoForm_pref = window.mcz_marketoForm_pref || {};
+  if (!value || !key.includes('.')) return;
+  const keyParts = key.split('.');
+  const lastKey = keyParts.pop();
+  const formDataObject = keyParts.reduce((obj, part) => {
+    obj[part] = obj[part] || {};
+    return obj[part];
+  }, window.mcz_marketoForm_pref);
+  formDataObject[lastKey] = value;
+};
+
+export const setDataLayerObj = (formData) => {
+  Object.entries(formData).forEach(([key, value]) => setDataLayer(key, value));
+};
+
+export const getDataLayer = (key = '') => key
+  .split('.')
+  .reduce((obj, part) => obj?.[part], window.mcz_marketoForm_pref);
 
 export const formValidate = (formEl) => {
   formEl.classList.remove('hide-errors');
@@ -89,23 +122,6 @@ export const decorateURL = async (destination, baseURL = window.location) => {
   }
 
   return null;
-};
-
-const setPreference = (key = '', value = '') => {
-  window.mcz_marketoForm_pref = window.mcz_marketoForm_pref || {};
-  if (!value || !key.includes('.')) return;
-  const keyParts = key.split('.');
-  const lastKey = keyParts.pop();
-  const formDataObject = keyParts.reduce((obj, part) => {
-    obj[part] = obj[part] || {};
-    return obj[part];
-  }, window.mcz_marketoForm_pref);
-  formDataObject[lastKey] = value;
-};
-
-export const setPreferences = (formData) => {
-  setPreference('form.status', 'pending');
-  Object.entries(formData).forEach(([key, value]) => setPreference(key, value));
 };
 
 const showSuccessSection = (formData) => {
@@ -167,9 +183,88 @@ const hideSuccessSection = (formData) => {
   );
 };
 
+export const debugTags = () => {
+  const len = document.cookie.length;
+  const tags = ['marketo'];
+  const signedIn = window.adobeIMS?.isSignedInUser();
+  const frameStatus = getDataLayer(FORM_XDFRAME);
+  if (getDataLayer('form.id')) tags.push(`form-${getDataLayer('form.id')}`);
+  if (getDataLayer('program.id')) tags.push(`program-${getDataLayer('program.id')}`);
+  if (getDataLayer(FORM_STATUS)) tags.push(`status-${getDataLayer(FORM_STATUS)}`);
+  if (len >= 8192) tags.push('cookie-8k');
+  else if (len >= 6144) tags.push('cookie-6k');
+  else if (len >= 4096) tags.push('cookie-4k');
+  tags.push(`ims-${signedIn ? 'signed-in' : 'signed-out'}`);
+  tags.push(frameStatus === 'ready' ? 'sync-ok' : 'sync-error');
+  if (getDataLayer('form.progressive')) tags.push('progressive');
+  if (getDataLayer('profile.known_visitor') === true) tags.push('known-visitor');
+  tags.push(`pref-lang-${getDataLayer('profile.prefLanguage') ?? ''}`);
+  return tags;
+};
+
+const decorateOverlay = async (el, message, callback) => {
+  if (el.querySelector('.marketo-overlay')) return;
+  const [errorRefresh, tryAgain] = await replaceKeyArray(['marketo-load-error', 'marketo-try-again'], getConfig());
+  const formEl = el.querySelector('form');
+  if (formEl) formEl.inert = true;
+  const searchParams = new URLSearchParams(window.location.search);
+  const debugMsg = searchParams.get('preview') === '1' ? message : '';
+  const errorMessage = createTag('p', { class: 'error', id: 'marketo-error-message' }, errorRefresh);
+  const formError = createTag('div', { class: 'error-container' }, errorMessage);
+  if (debugMsg) {
+    const debugInfo = createTag('p', { class: 'debug-info' });
+    debugInfo.textContent = debugMsg;
+    formError.appendChild(debugInfo);
+  }
+  const retryButton = createTag('button', { class: 'retry-button' }, tryAgain);
+  formError.appendChild(retryButton);
+  const errorOverlay = createTag(
+    'div',
+    {
+      class: 'marketo-overlay',
+      role: 'alertdialog',
+      'aria-modal': 'true',
+      'aria-labelledby': 'marketo-error-message',
+    },
+    formError,
+  );
+
+  retryButton.addEventListener('click', () => {
+    /* c8 ignore next 3 */
+    if (formEl) formEl.inert = false;
+    errorOverlay.remove();
+    if (callback) callback();
+  });
+
+  el.appendChild(errorOverlay);
+};
+
+export const logFailure = (el, msg) => {
+  if (el.dataset.mktoFailed) return;
+  const tags = debugTags();
+  el.dataset.mktoFailed = 'true';
+  window.lana?.log(msg, { tags: tags.join(','), severity: 'e', sampleRate: 100 });
+  decorateOverlay(el, `${msg}: ${tags.join(', ')}`, () => { window.location.reload(); });
+};
+
+export const formTimeout = (el, condition, message, timeout = FAILURE_TIMEOUT) => {
+  setTimeout(() => {
+    if (condition()) {
+      logFailure(el, message);
+    }
+  }, timeout);
+};
+
 const toggleSuccessSection = (formData) => {
   showSuccessSection(formData);
   hideSuccessSection(formData);
+};
+
+export const formSubmit = (formEl) => {
+  const el = formEl.closest('.marketo');
+  const testRecord = window.mkto_isTestRecord?.();
+  if (testRecord && testRecord !== 'not_test') return;
+  formTimeout(el, () => !el.classList.contains('success'), LANA_MESSAGE.SUBMIT_FAILED);
 };
 
 export const formSuccess = (formEl, formData) => {
@@ -210,75 +305,8 @@ export const formSuccess = (formEl, formData) => {
 
   if (formData?.[SUCCESS_TYPE] !== 'section') return true;
   toggleSuccessSection(formData);
-  setPreference(SUCCESS_TYPE, 'message');
+  setDataLayer(SUCCESS_TYPE, 'message');
   return false;
-};
-
-export const handleIframeTimeout = (el) => {
-  const searchParams = new URLSearchParams(window.location.search);
-  const config = getConfig();
-  const iframe = document.querySelector('iframe[src*="/index.php/form/XDFrame"]');
-  const formEl = el.querySelector('form');
-  let iframeTimeout = null;
-
-  const handleIframeReady = (event) => {
-    if (event.origin !== 'https://engage.adobe.com') return;
-    const message = JSON.parse(event.data);
-    if (!message.mktoReady) return;
-    setPreference('form.status', 'ready');
-    if (iframeTimeout) clearTimeout(iframeTimeout);
-    const errorOverlay = el.querySelector('.marketo-overlay');
-    if (formEl) formEl.inert = false;
-    if (errorOverlay) errorOverlay.remove();
-    window.removeEventListener('message', handleIframeReady);
-  };
-
-  const decorateOverlay = async () => {
-    const cookieSize = document.cookie.length > 4096 ? '> 4k' : '< 4k';
-    window.lana?.log(`Marketo iframe timeout - Cookie Size ${cookieSize}`, { tags: 'marketo', severity: 'e' });
-    setPreference('form.status', 'error');
-    if (el.querySelector('.marketo-overlay')) return;
-    if (!config.marketo?.showError && searchParams.get('marketoOverlay') !== 'error') return;
-
-    const marketoErrorText = await replaceKey('marketo-load-error', config);
-    const marketoTryAgainText = await replaceKey('marketo-try-again', config);
-    if (formEl) formEl.inert = true;
-
-    const errorMessage = createTag('p', { class: 'error', id: 'marketo-error-message' }, marketoErrorText);
-    const retryButton = createTag('button', { class: 'retry-button' }, marketoTryAgainText);
-    const formError = createTag('div', { class: 'error-container' }, [errorMessage, retryButton]);
-    const errorOverlay = createTag(
-      'div',
-      {
-        class: 'marketo-overlay',
-        role: 'alertdialog',
-        'aria-modal': 'true',
-        'aria-labelledby': 'marketo-error-message',
-      },
-      formError,
-    );
-
-    retryButton.addEventListener('click', () => {
-      const iframeSrc = iframe.src;
-      errorOverlay.remove();
-      if (formEl) formEl.inert = false;
-      iframe.src = '';
-      iframe.src = iframeSrc;
-      clearTimeout(iframeTimeout);
-      iframeTimeout = setTimeout(decorateOverlay, config.marketo?.iframeTimeout ?? IFRAME_TIMEOUT);
-    });
-
-    el.appendChild(errorOverlay);
-  };
-
-  /* c8 ignore next 4 */
-  if (searchParams.get('marketoOverlay') === 'error') {
-    decorateOverlay();
-    return;
-  }
-
-  iframeTimeout = setTimeout(decorateOverlay, config.marketo?.iframeTimeout ?? IFRAME_TIMEOUT);
-  window.addEventListener('message', handleIframeReady);
 };
 
 const readyForm = (form, formData) => {
@@ -286,7 +314,24 @@ const readyForm = (form, formData) => {
   const el = formEl.closest('.marketo');
   const isDesktop = matchMedia('(min-width: 900px)');
   el.classList.remove('loading');
-  handleIframeTimeout(el);
+
+  const handleIframeReady = (event) => {
+    if (event.origin !== 'https://engage.adobe.com') return;
+    const message = JSON.parse(event.data);
+    if (!message.mktoReady) return;
+    const hadFailed = el.dataset.mktoFailed === 'true';
+    setDataLayer(FORM_XDFRAME, 'ready');
+    const formVisible = isVisible(formEl);
+    if (hadFailed && formVisible) {
+      window.lana?.log(LANA_MESSAGE.RENDER_RECOVERED, { tags: 'marketo,render-recovered', severity: 'i', sampleRate: 100 });
+      delete el.dataset.mktoFailed;
+      el.querySelector('.marketo-overlay')?.remove();
+      formEl.inert = false;
+    }
+    window.removeEventListener('message', handleIframeReady);
+  };
+  window.addEventListener('message', handleIframeReady);
+  formTimeout(el, () => getDataLayer(FORM_XDFRAME) !== 'ready', LANA_MESSAGE.HANDSHAKE_FAILED);
 
   formEl.addEventListener('focus', ({ target }) => {
     /* c8 ignore next 9 */
@@ -301,21 +346,24 @@ const readyForm = (form, formData) => {
     window.scrollTo(0, offsetPosition);
   }, true);
   form.onValidate(() => formValidate(formEl));
+  form.onSubmit(() => formSubmit(formEl));
   form.onSuccess(() => formSuccess(formEl, formData));
 };
 
 export const loadMarketo = (el, formData) => {
+  setDataLayer(FORM_STATUS, 'loading');
   const baseURL = formData[BASE_URL];
   const munchkinID = formData[MUNCHKIN_ID];
   const formID = formData[FORM_ID];
   const { base } = getConfig();
 
-  loadScript(`${base}/deps/forms2.min.js`)
+  return loadScript(`${base}/deps/forms2.min.js`)
     .then(() => {
       const { MktoForms2 } = window;
       if (!MktoForms2) throw new Error('Marketo forms not loaded');
 
-      MktoForms2.loadForm(`//${baseURL}`, munchkinID, formID);
+      formTimeout(el, () => !isVisible(el.querySelector('form')), LANA_MESSAGE.RENDER_FAILED);
+      MktoForms2.loadForm(`//${baseURL}`, munchkinID, formID, () => { setDataLayer(FORM_STATUS, 'loaded'); });
       MktoForms2.whenReady((form) => { readyForm(form, formData); });
 
       /* c8 ignore next 3 */
@@ -326,7 +374,7 @@ export const loadMarketo = (el, formData) => {
     .catch(() => {
       /* c8 ignore next 2 */
       el.style.display = 'none';
-      window.lana?.log(`Error loading Marketo form for ${munchkinID}_${formID}`, { tags: 'marketo', severity: 'e' });
+      logFailure(el, LANA_MESSAGE.MARKETO_FORMS_JS);
     });
 };
 
@@ -367,6 +415,7 @@ function decorateForm(el, formData) {
 }
 
 export default async function init(el) {
+  setDataLayer(FORM_STATUS, 'init');
   const children = Array.from(el.querySelectorAll(':scope > div'));
   const encodedConfigDiv = children.shift();
   const link = encodedConfigDiv.querySelector('a');
@@ -423,7 +472,8 @@ export default async function init(el) {
     if (destinationUrl) formData[SUCCESS_CONTENT] = destinationUrl;
   }
 
-  setPreferences(formData);
+  formData[FORM_STATUS] = 'decorated';
+  setDataLayerObj(formData);
   decorateForm(el, formData);
 
   loadLink(`https://${baseURL}`, { rel: 'dns-prefetch' });

--- a/test/blocks/marketo/marketo.test.html
+++ b/test/blocks/marketo/marketo.test.html
@@ -85,7 +85,7 @@
     import { expect } from '@esm-bundle/chai';
     import { waitForElement } from '../../helpers/waitfor.js';
     import { setConfig, loadScript, loadLink, parseEncodedConfig } from '../../../libs/utils/utils.js';
-    import init, { setPreferences, formValidate, formSuccess } from '../../../libs/blocks/marketo/marketo.js';
+    import init, { formValidate, formSuccess } from '../../../libs/blocks/marketo/marketo.js';
 
 
     runTests(() => {

--- a/test/blocks/marketo/marketo.test.js
+++ b/test/blocks/marketo/marketo.test.js
@@ -2,13 +2,28 @@ import sinon from 'sinon';
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { setConfig, getConfig, MILO_EVENTS } from '../../../libs/utils/utils.js';
-import init, { setPreferences, decorateURL, formSuccess, FORM_PARAM, handleIframeTimeout } from '../../../libs/blocks/marketo/marketo.js';
+import init, {
+  setDataLayer,
+  setDataLayerObj,
+  getDataLayer,
+  decorateURL,
+  formSuccess,
+  formSubmit,
+  loadMarketo,
+  logFailure,
+  formTimeout,
+  LANA_MESSAGE,
+  FORM_PARAM,
+} from '../../../libs/blocks/marketo/marketo.js';
+import { waitForElement } from '../../helpers/waitfor.js';
 
-const ogFetch = window.fetch;
+const FAILURE_TIMEOUT = 10000;
+
 const blockHTML = await readFile({ path: './mocks/block.html' });
 const onePage = await readFile({ path: './mocks/one-page-experience.html' });
 const config = {
   codeRoot: '/test/blocks/marketo/mocks',
+  placeholders: { 'marketo-load-error': 'marketo load error', 'marketo-try-again': 'try again' },
   marketo: {
     iframeTimeout: 3000,
     showError: true,
@@ -51,15 +66,24 @@ describe('marketo', () => {
       'second.key': 'value2',
     };
 
-    setPreferences(formData);
+    setDataLayerObj(formData);
 
-    expect(window.mcz_marketoForm_pref.form.status).to.equal('pending');
     expect(window.mcz_marketoForm_pref).to.have.property('first');
     expect(window.mcz_marketoForm_pref.first).to.have.property('key');
     expect(window.mcz_marketoForm_pref.first.key).to.equal('value1');
     expect(window.mcz_marketoForm_pref).to.have.property('second');
     expect(window.mcz_marketoForm_pref.second).to.have.property('key');
     expect(window.mcz_marketoForm_pref.second.key).to.equal('value2');
+  });
+
+  it('gets a nested value from the data layer', () => {
+    setDataLayer('form.status', 'ready');
+    expect(getDataLayer('form.status')).to.equal('ready');
+  });
+
+  it('returns undefined for a key that has not been set', () => {
+    expect(getDataLayer('form.status')).to.be.undefined;
+    expect(getDataLayer('nothing.here')).to.be.undefined;
   });
 });
 
@@ -208,78 +232,173 @@ describe('Marketo ungated one page experience', () => {
   });
 });
 
-describe('Marketo Iframe Timeout Handler', () => {
+describe('Marketo failure logging', () => {
   let clock;
-  let marketoBlock;
+  let el;
 
-  beforeEach(() => {
-    clock = sinon.useFakeTimers();
-    window.fetch = sinon.stub();
-    setConfig(config);
-    document.body.innerHTML = blockHTML;
-    marketoBlock = document.querySelector('.marketo');
-    if (!marketoBlock.parentNode) document.body.appendChild(marketoBlock);
-    const iframe = document.createElement('iframe');
-    iframe.src = '/index.php/form/XDFrame';
-    marketoBlock.appendChild(iframe);
-  });
+  const formData = {
+    'form id': '1723',
+    'marketo host': 'engage.adobe.com',
+    'marketo munckin': '360-KCI-804',
+  };
 
-  afterEach(() => {
-    sinon.restore();
-    clock.restore();
-    window.fetch = ogFetch;
-  });
+  const buildBlock = ({ visibleForm = true } = {}) => {
+    el = document.createElement('div');
+    el.className = 'marketo';
+    const form = document.createElement('form');
+    if (!visibleForm) form.style.visibility = 'hidden';
+    el.appendChild(form);
+    document.body.appendChild(el);
+    return el;
+  };
 
   const tick = async (ms) => {
     clock.tick(ms);
     await clock.nextAsync();
   };
 
-  it('shows overlay on timeout', async () => {
-    handleIframeTimeout(marketoBlock);
-    await tick(5000);
-
-    const overlay = marketoBlock.querySelector('.marketo-overlay');
-    const errorMsg = marketoBlock.querySelector('.error');
-
-    expect(overlay).to.exist;
-    expect(errorMsg.textContent).to.equal('marketo load error');
-    expect(window.mcz_marketoForm_pref.form.status).to.equal('error');
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    window.lana = { log: sinon.spy() };
+    setConfig(config);
+    document.body.innerHTML = '';
   });
 
-  it('removes overlay when iframe is ready', async () => {
-    handleIframeTimeout(marketoBlock);
-    await tick(5000);
-
-    expect(marketoBlock.querySelector('.marketo-overlay')).to.exist;
-
-    window.dispatchEvent(new MessageEvent('message', {
-      origin: 'https://engage.adobe.com',
-      data: JSON.stringify({ mktoReady: true }),
-    }));
-    await tick(200);
-
-    expect(marketoBlock.querySelector('.marketo-overlay')).to.not.exist;
-    expect(window.mcz_marketoForm_pref.form.status).to.equal('ready');
+  afterEach(() => {
+    clock.restore();
+    sinon.restore();
+    window.mcz_marketoForm_pref = undefined;
+    document.body.innerHTML = '';
   });
 
-  it('retry with success', async () => {
-    handleIframeTimeout(marketoBlock);
-    await tick(5000);
+  describe('logFailure', () => {
+    it('logs once, sets error status, and shows an overlay', async () => {
+      buildBlock();
+      logFailure(el, LANA_MESSAGE.RENDER_FAILED);
 
-    const overlay = marketoBlock.querySelector('.marketo-overlay');
-    expect(overlay).to.exist;
-    expect(window.mcz_marketoForm_pref.form.status).to.equal('error');
-    overlay.querySelector('button').click();
+      expect(window.lana.log.calledOnce).to.be.true;
+      expect(window.lana.log.firstCall.args[0]).to.equal(LANA_MESSAGE.RENDER_FAILED);
+      expect(window.lana.log.firstCall.args[1]).to.include({ severity: 'e', sampleRate: 100 });
+      expect(window.mcz_marketoForm_pref.form.status).to.equal('init');
+      expect(el.dataset.mktoFailed).to.equal('true');
+      expect(await waitForElement('.marketo-overlay', { rootEl: el })).to.exist;
+    });
 
-    window.dispatchEvent(new MessageEvent('message', {
-      origin: 'https://engage.adobe.com',
-      data: JSON.stringify({ mktoReady: true }),
-    }));
+    it('does not log or duplicate the overlay on a repeat failure', async () => {
+      buildBlock();
+      logFailure(el, LANA_MESSAGE.RENDER_FAILED);
+      await waitForElement('.marketo-overlay', { rootEl: el });
+      logFailure(el, LANA_MESSAGE.HANDSHAKE_FAILED);
 
-    await tick(500);
-    expect(marketoBlock.querySelector('.marketo-overlay')).to.not.exist;
-    expect(window.mcz_marketoForm_pref.form.status).to.equal('ready');
+      expect(window.lana.log.calledOnce).to.be.true;
+      expect(el.querySelectorAll('.marketo-overlay').length).to.equal(1);
+    });
+  });
+
+  describe('formTimeout', () => {
+    it('logs the failure when the condition is still true after the timeout', async () => {
+      buildBlock();
+      formTimeout(el, () => true, LANA_MESSAGE.RENDER_FAILED);
+      await tick(FAILURE_TIMEOUT);
+
+      expect(window.lana.log.calledOnceWith(LANA_MESSAGE.RENDER_FAILED)).to.be.true;
+    });
+
+    it('does not log when the condition resolves before the timeout', async () => {
+      buildBlock();
+      formTimeout(el, () => false, LANA_MESSAGE.RENDER_FAILED);
+      await tick(FAILURE_TIMEOUT);
+
+      expect(window.lana.log.called).to.be.false;
+    });
+  });
+
+  describe('loadMarketo', () => {
+    it('logs handshake failure when the iframe never signals ready', async () => {
+      buildBlock();
+      await loadMarketo(el, formData);
+      await tick(FAILURE_TIMEOUT);
+
+      expect(window.lana.log.calledWith(
+        LANA_MESSAGE.HANDSHAKE_FAILED,
+        sinon.match({ severity: 'e', sampleRate: 100 }),
+      )).to.be.true;
+      expect(window.mcz_marketoForm_pref.form.status).to.equal('loaded');
+      expect(el.dataset.mktoFailed).to.equal('true');
+      expect(await waitForElement('.marketo-overlay', { rootEl: el })).to.exist;
+    });
+
+    it('logs recovery and removes the overlay when the iframe signals ready after a failure', async () => {
+      buildBlock();
+      await loadMarketo(el, formData);
+      await tick(FAILURE_TIMEOUT);
+      expect(await waitForElement('.marketo-overlay', { rootEl: el })).to.exist;
+
+      window.dispatchEvent(new MessageEvent('message', {
+        origin: 'https://engage.adobe.com',
+        data: JSON.stringify({ mktoReady: true }),
+      }));
+
+      expect(window.lana.log.calledWith(
+        LANA_MESSAGE.RENDER_RECOVERED,
+        sinon.match({ severity: 'i', sampleRate: 100 }),
+      )).to.be.true;
+      expect(window.mcz_marketoForm_pref.form.xdframe).to.equal('ready');
+      expect(el.querySelector('.marketo-overlay')).to.not.exist;
+    });
+
+    it('logs render failure when the form never becomes visible', async () => {
+      buildBlock({ visibleForm: false });
+      window.MktoForms2 = {
+        getFormElem: () => ({ get: () => el.querySelector('form') }),
+        onValidate: () => {},
+        onSubmit: () => {},
+        onSuccess: () => {},
+        loadForm: (host, munchkin, formID, callback) => callback?.(),
+        whenReady: () => {},
+      };
+      await loadMarketo(el, formData);
+      await tick(FAILURE_TIMEOUT);
+
+      expect(window.lana.log.calledWith(
+        LANA_MESSAGE.RENDER_FAILED,
+        sinon.match({ severity: 'e' }),
+      )).to.be.true;
+    });
+
+    it('logs a forms2 load failure and hides the block when the script fails to load', async () => {
+      buildBlock();
+      setConfig({ ...config, codeRoot: '/test/blocks/marketo/mocks/missing' });
+      await loadMarketo(el, formData);
+
+      expect(el.style.display).to.equal('none');
+      expect(window.lana.log.calledWith(
+        LANA_MESSAGE.MARKETO_FORMS_JS,
+        sinon.match({ severity: 'e' }),
+      )).to.be.true;
+    });
+  });
+
+  describe('formSubmit', () => {
+    it('logs submit failure when the form is not marked success in time', async () => {
+      buildBlock();
+      formSubmit(el.querySelector('form'));
+      await tick(FAILURE_TIMEOUT);
+
+      expect(window.lana.log.calledWith(
+        LANA_MESSAGE.SUBMIT_FAILED,
+        sinon.match({ severity: 'e' }),
+      )).to.be.true;
+    });
+
+    it('does not log submit failure once the form is marked success', async () => {
+      buildBlock();
+      el.classList.add('success');
+      formSubmit(el.querySelector('form'));
+      await tick(FAILURE_TIMEOUT);
+
+      expect(window.lana.log.called).to.be.false;
+    });
   });
 });
 

--- a/test/blocks/marketo/mocks/deps/forms2.min.js
+++ b/test/blocks/marketo/mocks/deps/forms2.min.js
@@ -4,11 +4,15 @@ const formHTML = `
 `;
 
 const forms2Mock = {
-  getFormElem: () => ({ get: () => document.querySelector('form') }),
+  getFormElem: () => ({ get: () => document.querySelector('.marketo form') }),
   onValidate: () => {},
+  onSubmit: () => {},
   onSuccess: () => {},
-  loadForm: () => { document.querySelector('.marketo').innerHTML = formHTML; },
+  loadForm: (host, munchkin, formId, callback) => {
+    document.querySelector('.marketo').innerHTML = formHTML;
+    callback?.();
+  },
   whenReady: (callback) => callback(forms2Mock),
 };
 
-window.MktoForms2 = forms2Mock;
+if (!window.MktoForms2) window.MktoForms2 = forms2Mock;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Log Marketo failure states (iframe, pp, lang, cookie size)
* Show failure overlay after 10s timeout.

Resolves: [MWPW-198959](https://jira.corp.adobe.com/browse/MWPW-198959)

<img width="565" height="502" alt="image" src="https://github.com/user-attachments/assets/5eb8574a-9276-461d-8af0-8de67863f300" />

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bmarshal-marketo-logging--milo--adobecom.aem.page/?martech=off

**BACOM URLs:**
- Before: https://business.stage.adobe.com/request-consultation.html?martech=off
- After: https://business.stage.adobe.com/request-consultation.html?martech=off&milolibs=bmarshal-marketo-logging



