### PR TITLE
[MWPW-200182] - Parallax move up fast adaptation

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1381,6 +1381,8 @@ span.hang-opening-quote {
   /* Section 1 to section 2 parallax declarations */
   /* TODO: decide if this is general enough to be a global class */
   .section.parallax-move-up-fast {
+    --parallax-move-up-to: -35vh;
+
     will-change: transform;
     position: sticky;
     top: 0;
@@ -1389,6 +1391,10 @@ span.hang-opening-quote {
     animation-timeline: scroll(root block);
     animation-range: 0 80vh;
     animation-timing-function: ease-out;
+
+    @media (width >= 1280px) and (width < 1440px) {
+      --parallax-move-up-to: -50vh;
+    }
 
     &::after {
       content: '';
@@ -1406,14 +1412,7 @@ span.hang-opening-quote {
 
   @keyframes parallax-move-up-fast {
     from { transform: translateY(0); }
-    to { transform: translateY(-35vh); }
-  }
-
-  @media (width >= 1280px) and (width < 1440px) {
-    @keyframes parallax-move-up-fast {
-      from { transform: translateY(0); }
-      to { transform: translateY(-50vh); }
-    }
+    to { transform: translateY(var(--parallax-move-up-to)); }
   }
 
   @keyframes parallax-fade-to-dark {

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1392,7 +1392,8 @@ span.hang-opening-quote {
     animation-range: 0 80vh;
     animation-timing-function: ease-out;
 
-    @media (width >= 1280px) and (width < 1440px) {
+    /* Shorter viewports in the common laptop width band need more travel */
+    @media (width >= 1280px) and (width < 1440px) and (height < 900px) {
       --parallax-move-up-to: -50vh;
     }
 

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1409,6 +1409,13 @@ span.hang-opening-quote {
     to { transform: translateY(-35vh); }
   }
 
+  @media (width >= 1280px) and (width < 1440px) {
+    @keyframes parallax-move-up-fast {
+      from { transform: translateY(0); }
+      to { transform: translateY(-50vh); }
+    }
+  }
+
   @keyframes parallax-fade-to-dark {
     from { opacity: 0; }
     to { opacity: 0.75; }


### PR DESCRIPTION
Prolongs parallax animation between 1st and 2nd section for specific resolution width and height, with the goal of giving the users on those resolutions more time to click the CTA's in the 1st section.

Resolves: [MWPW-200182](https://jira.corp.adobe.com/browse/MWPW-200182)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/br/homepage/drafts/msale/2026/sr/06-18-sr-ff-ps-index-loggedout?milolibs=stage
- After: https://main--upp--adobecom.aem.page/br/homepage/drafts/msale/2026/sr/06-18-sr-ff-ps-index-loggedout?milolibs=parallax-move-up-breakpoint


