### PR TITLE
[MWPW-200316] [Lingo] Set country cookie for geo-expansion markets

### DIFF
--- a/libs/blocks/region-nav/region-nav.js
+++ b/libs/blocks/region-nav/region-nav.js
@@ -12,6 +12,13 @@ import { norm } from '../../utils/market.js';
 
 let config;
 
+// Commerce geo-expansion markets: no adobe.com site; picker only sets the country
+// cookie and routes to US site
+const GEO_EXPANSION_MARKETS = new Set([
+  'mu', 'ke', 'gh', 'tz', 'am', 'az', 'ge', 'md', 'kz', 'kg', 'tj',
+  'tm', 'uz', 'tn', 'om', 'ma', 'lb', 'jo', 'iq', 'dz', 'bh',
+]);
+
 const queriedPages = [];
 
 function handleEvent({ prefix, link, callback } = {}) {
@@ -53,10 +60,15 @@ export function decorateLink(link, path, localeToLanguageMap = []) {
     ? getLanguage(languages, mergedLocales, pathname) : getLocale(mergedLocales, pathname);
   const prefix = currentLocaleObj.prefix.replace('/', '');
 
+  const geoSegment = pathname.split('/')[1]?.toLowerCase();
+  const geoMarket = GEO_EXPANSION_MARKETS.has(geoSegment) ? geoSegment : null;
+
   let { href } = link;
   if (href.endsWith('/')) href = href.slice(0, -1);
 
-  if (languageMap && !locales[prefix] && (languages && !languages[prefix])) {
+  if (geoMarket) {
+    href = href.replace(`/${geoMarket}`, '');
+  } else if (languageMap && !locales[prefix] && (languages && !languages[prefix])) {
     const valueInMap = languageMap[prefix];
     href = href.replace(`/${prefix}`, valueInMap ? `/${valueInMap}` : '');
   }
@@ -87,7 +99,7 @@ export function decorateLink(link, path, localeToLanguageMap = []) {
 
   link.addEventListener('click', (e) => {
     setInternational(prefix === '' ? 'us' : prefix);
-    const resolved = norm(prefix) || 'us';
+    const resolved = geoMarket || norm(prefix) || 'us';
     const market = resolved === 'la' ? 'latam' : resolved; // TODO: remove this fallback after ACOM consumes market-selector
     if (market) setMarket(market);
     if (hrefAdapted) return;


### PR DESCRIPTION
Lingo : Ensure geo-expansion markets are setting the country cookie on legacy region picker

* Set country cookie on the legacy region picker, so that users can select their markets.
* On selecting route user to base US site and set International cookie to 'US'
* [List of Geos](https://adobe-my.sharepoint.com/:x:/p/blytt/IQCEdh2tC0p2SY-R0sQYtsRXAcfWmq5tzqKvOaZI95zPL0Y?e=Utd009 )

Resolves: [MWPW-200316](https://jira.corp.adobe.com/browse/MWPW-200316)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://geo-expansion--milo--adobecom.aem.page/?martech=off

**QA:**
https://www.stage.adobe.com/cc-shared/fragments/drafts/lingo/ccregionpage?milolibs=geo-expansion#langnav

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=geo-expansion--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=geo-expansion--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=geo-expansion--milo--adobecom
- Milo: https://geo-expansion--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=geo-expansion--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=geo-expansion--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=geo-expansion--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=geo-expansion--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=geo-expansion--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=geo-expansion--milo--adobecom
- Milo: https://geo-expansion--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=geo-expansion--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=geo-expansion--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=geo-expansion--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=geo-expansion--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=geo-expansion--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=geo-expansion--milo--adobecom
- Milo: https://geo-expansion--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=geo-expansion--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=geo-expansion--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=geo-expansion--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=geo-expansion--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=geo-expansion--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=geo-expansion--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=geo-expansion--milo--adobecom
</details>