### PR TITLE
[MWPW-198999] - Added style updates for offer hero after using dark theme assets

### DIFF
--- a/libs/mep/ace1209/offer-hero/offer-hero.css
+++ b/libs/mep/ace1209/offer-hero/offer-hero.css
@@ -124,7 +124,7 @@
     box-shadow: inset 0 0 0 2px rgb(255 255 255 / 10%);
     overflow: hidden;
     transform-origin: top left;
-    padding-top: calc(100% * 100 / 109);
+    padding-top: calc(100% * 110 / 100);
     will-change: transform;
   }
 
@@ -373,6 +373,23 @@
 
     .hero-card-text {
       padding: var(--s2a-spacing-3xl);
+    }
+  }
+}
+
+.dark {
+  .offer-hero {
+    .hero-card {
+      border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12);
+      border-radius: var(--s2a-border-radius-24);
+    }
+
+    .hero-card-tile {
+      background: transparent;
+    }
+
+    .hero-card-body-text {
+      color: var(--s2a-color-transparent-white-64);
     }
   }
 }

--- a/libs/mep/ace1209/offer-hero/offer-hero.css
+++ b/libs/mep/ace1209/offer-hero/offer-hero.css
@@ -380,8 +380,10 @@
 .dark {
   .offer-hero {
     .hero-card {
-      border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12);
-      border-radius: var(--s2a-border-radius-24);
+      &.is-settled {
+        border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12);
+        border-radius: var(--s2a-border-radius-24);
+      }
     }
 
     .hero-card-tile {

--- a/libs/mep/ace1209/offer-hero/offer-hero.js
+++ b/libs/mep/ace1209/offer-hero/offer-hero.js
@@ -222,9 +222,11 @@ function initAnimation(block) {
       videoObserver?.disconnect();
       videoObserver = null;
       needsReset = true;
+      cards.forEach((card) => card.classList.remove('is-settled'));
       return;
     }
 
+    cards.forEach((card) => card.classList.add('is-settled'));
     fades.forEach((fade) => { fade.style.transition = 'none'; fade.style.opacity = '0'; });
     if (needsReset) {
       needsReset = false;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Found some style updates after updating the dark theme assets for offer hero block.
This PR address those updates.
Also, changed aspect ratio of cards to 1:1.1 in mobile as per the slack [discussion](https://adobe-mwp.slack.com/archives/C09C8DLTNJZ/p1782336815481769).

Resolves: [MWPW-198999](https://jira.corp.adobe.com/browse/MWPW-198999)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://offer-hero-dark--milo--adobecom.aem.page/?martech=off

**QA:**
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=offer-hero-dark&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

