### PR TITLE
forge UI: pure sessionGrouping.ts extraction + tests (MWPW-199253)

### DIFF
--- a/tools/forge/src/app/Sidebar.tsx
+++ b/tools/forge/src/app/Sidebar.tsx
@@ -9,6 +9,7 @@ import { useSessions } from '../sessions/SessionsProvider';
 import type { HistoryEntry } from '../sessions/types';
 import { sourceLabel, stateWord, statusKind, isLive } from './sessionStatus';
 import styles from './Sidebar.module.css';
+import { groupSessions } from './sessionGrouping';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -28,53 +29,6 @@ function sourceWordClass(source: string): string {
 	return `${styles.src} ${styles.srcHtml}`;
 }
 
-// Start-of-today / start-of-yesterday boundaries for recency grouping.
-function dayStart(offsetDays: number): number {
-	const d = new Date();
-	d.setHours(0, 0, 0, 0);
-	return d.getTime() - offsetDays * 86_400_000;
-}
-
-interface Group {
-	label: string;
-	entries: HistoryEntry[];
-}
-
-// Group order grafts urgency-then-recency WITHOUT churn: only LIVE and ERROR rows
-// hoist into their own pinned groups; done rows stay in their time bucket and
-// never jump under the user's cursor mid-run.
-function groupSessions(history: HistoryEntry[]): Group[] {
-	const inProgress: HistoryEntry[] = [];
-	const needsReview: HistoryEntry[] = [];
-	const today: HistoryEntry[] = [];
-	const yesterday: HistoryEntry[] = [];
-	const earlier: HistoryEntry[] = [];
-
-	const todayStart = dayStart(0);
-	const yesterdayStart = dayStart(1);
-
-	for (const e of history) {
-		if (isLive(e.status)) {
-			inProgress.push(e);
-		} else if (e.status === 'error') {
-			needsReview.push(e);
-		} else if (e.ts >= todayStart) {
-			today.push(e);
-		} else if (e.ts >= yesterdayStart) {
-			yesterday.push(e);
-		} else {
-			earlier.push(e);
-		}
-	}
-
-	const groups: Group[] = [];
-	if (inProgress.length) groups.push({ label: 'In progress', entries: inProgress });
-	if (needsReview.length) groups.push({ label: 'Needs review', entries: needsReview });
-	if (today.length) groups.push({ label: 'Today', entries: today });
-	if (yesterday.length) groups.push({ label: 'Yesterday', entries: yesterday });
-	if (earlier.length) groups.push({ label: 'Earlier', entries: earlier });
-	return groups;
-}
 
 // The non-gradient status glyph: shape encodes settled-ness, color encodes meaning.
 function StatusGlyph({ entry }: { entry: HistoryEntry }) {

--- a/tools/forge/src/app/sessionGrouping.test.ts
+++ b/tools/forge/src/app/sessionGrouping.test.ts
@@ -1,0 +1,101 @@
+// MWPW-199253 — unit tests for the sessions-shell sidebar grouping logic.
+// Pure logic; day boundaries pinned with fake timers for determinism.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { groupSessions, dayStart } from './sessionGrouping';
+import type { HistoryEntry, SessionStatus } from '../sessions/types';
+
+// Fixed "now" = 2026-07-14 12:00 local, so day boundaries never straddle midnight.
+const NOW = new Date(2026, 6, 14, 12, 0, 0);
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+});
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+let seq = 0;
+function entry(status: SessionStatus, ts: number, sessionId = `e${seq++}`): HistoryEntry {
+	return { sessionId, source: 'figma', status, ts };
+}
+
+const labels = (h: HistoryEntry[]) => groupSessions(h).map((g) => g.label);
+
+const LIVE: SessionStatus[] = ['generating', 'refining', 'running', 'waiting', 'deploying', 'shipping'];
+
+describe('groupSessions — bucketing', () => {
+	it('a live row lands in "In progress"', () => {
+		expect(labels([entry('running', Date.now())])).toEqual(['In progress']);
+	});
+	it('an error row lands in "Needs review"', () => {
+		expect(labels([entry('error', Date.now())])).toEqual(['Needs review']);
+	});
+	it('a settled row with today ts → "Today"', () => {
+		expect(labels([entry('done', Date.now())])).toEqual(['Today']);
+	});
+	it('a settled row with yesterday ts → "Yesterday"', () => {
+		expect(labels([entry('done', Date.now() - 86_400_000)])).toEqual(['Yesterday']);
+	});
+	it('a settled row with 3-days-ago ts → "Earlier"', () => {
+		expect(labels([entry('done', Date.now() - 3 * 86_400_000)])).toEqual(['Earlier']);
+	});
+
+	it.each(LIVE)('status %s hoists to "In progress"', (status) => {
+		expect(labels([entry(status, Date.now())])).toEqual(['In progress']);
+	});
+});
+
+describe('groupSessions — urgency hoisting (no time-bucket leakage)', () => {
+	it('a LIVE row with an OLD ts still hoists to "In progress" (not "Earlier")', () => {
+		expect(labels([entry('generating', Date.now() - 10 * 86_400_000)])).toEqual(['In progress']);
+	});
+	it('an ERROR row with today ts hoists to "Needs review" (not "Today")', () => {
+		expect(labels([entry('error', Date.now())])).toEqual(['Needs review']);
+	});
+});
+
+describe('groupSessions — group order + omission', () => {
+	it('emits groups in fixed order regardless of input order', () => {
+		// Deliberately shuffled input; each row targets a distinct bucket.
+		const history: HistoryEntry[] = [
+			entry('done', Date.now() - 3 * 86_400_000),   // Earlier
+			entry('error', Date.now()),                    // Needs review
+			entry('done', Date.now()),                     // Today
+			entry('running', Date.now()),                  // In progress
+			entry('done', Date.now() - 86_400_000),        // Yesterday
+		];
+		expect(labels(history)).toEqual(['In progress', 'Needs review', 'Today', 'Yesterday', 'Earlier']);
+	});
+
+	it('omits empty groups', () => {
+		expect(labels([entry('done', Date.now())])).toEqual(['Today']);
+	});
+
+	it('empty history → no groups', () => {
+		expect(groupSessions([])).toEqual([]);
+	});
+
+	it('preserves entry order within a group', () => {
+		const a = entry('running', Date.now(), 'a');
+		const b = entry('generating', Date.now(), 'b');
+		const groups = groupSessions([a, b]);
+		expect(groups).toHaveLength(1);
+		expect(groups[0].entries.map((e) => e.sessionId)).toEqual(['a', 'b']);
+	});
+});
+
+describe('groupSessions — day-boundary edges', () => {
+	it('ts exactly at start-of-today → "Today"', () => {
+		expect(labels([entry('done', dayStart(0))])).toEqual(['Today']);
+	});
+	it('ts one ms before start-of-today → "Yesterday"', () => {
+		expect(labels([entry('done', dayStart(0) - 1)])).toEqual(['Yesterday']);
+	});
+	it('ts exactly at start-of-yesterday → "Yesterday"', () => {
+		expect(labels([entry('done', dayStart(1))])).toEqual(['Yesterday']);
+	});
+	it('ts one ms before start-of-yesterday → "Earlier"', () => {
+		expect(labels([entry('done', dayStart(1) - 1)])).toEqual(['Earlier']);
+	});
+});

--- a/tools/forge/src/app/sessionGrouping.ts
+++ b/tools/forge/src/app/sessionGrouping.ts
@@ -1,0 +1,54 @@
+// ── Session-list grouping (pure) ────────────────────────────────────────────
+// Extracted from Sidebar.tsx (MWPW-199253) so the time-grouped, urgency-hoisted
+// bucketing can be unit-tested without importing React or @react-spectrum/s2.
+// Depends only on the pure isLive() + Date-based dayStart().
+import type { HistoryEntry } from '../sessions/types';
+import { isLive } from './sessionStatus';
+
+export interface Group {
+	label: string;
+	entries: HistoryEntry[];
+}
+
+// Start-of-today / start-of-yesterday boundaries for recency grouping.
+export function dayStart(offsetDays: number): number {
+	const d = new Date();
+	d.setHours(0, 0, 0, 0);
+	return d.getTime() - offsetDays * 86_400_000;
+}
+
+// Group order grafts urgency-then-recency WITHOUT churn: only LIVE and ERROR rows
+// hoist into their own pinned groups; done rows stay in their time bucket and
+// never jump under the user's cursor mid-run.
+export function groupSessions(history: HistoryEntry[]): Group[] {
+	const inProgress: HistoryEntry[] = [];
+	const needsReview: HistoryEntry[] = [];
+	const today: HistoryEntry[] = [];
+	const yesterday: HistoryEntry[] = [];
+	const earlier: HistoryEntry[] = [];
+
+	const todayStart = dayStart(0);
+	const yesterdayStart = dayStart(1);
+
+	for (const e of history) {
+		if (isLive(e.status)) {
+			inProgress.push(e);
+		} else if (e.status === 'error') {
+			needsReview.push(e);
+		} else if (e.ts >= todayStart) {
+			today.push(e);
+		} else if (e.ts >= yesterdayStart) {
+			yesterday.push(e);
+		} else {
+			earlier.push(e);
+		}
+	}
+
+	const groups: Group[] = [];
+	if (inProgress.length) groups.push({ label: 'In progress', entries: inProgress });
+	if (needsReview.length) groups.push({ label: 'Needs review', entries: needsReview });
+	if (today.length) groups.push({ label: 'Today', entries: today });
+	if (yesterday.length) groups.push({ label: 'Yesterday', entries: yesterday });
+	if (earlier.length) groups.push({ label: 'Earlier', entries: earlier });
+	return groups;
+}


### PR DESCRIPTION
## MWPW-199253 — sessions sidebar grouping (residual: test)

Extracts the sidebar's time-grouped, urgency-hoisted bucketing to a pure module so it's unit-testable without React/@react-spectrum/s2.

### Changes
- **`groupSessions` + `dayStart` + `Group` → `src/app/sessionGrouping.ts`** (pure; depends only on `isLive` + Date). `Sidebar.tsx` imports it (local block removed).
- **`sessionGrouping.test.ts`** — 21 cases: bucketing, urgency hoisting (LIVE/ERROR rows never leak into time buckets), fixed group order, empty-group omission, day-boundary edges (fake timers).

### Verification
70 tests green, `tsc --noEmit` clean. Behavior-preserving.

### Review
Manual devil's-advocate + security pass: pure logic extraction, no new surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

