### PR TITLE
forge UI: pure resultState.ts selector + tests (MWPW-199251)

### DIFF
--- a/tools/forge/src/app/ResultCard.tsx
+++ b/tools/forge/src/app/ResultCard.tsx
@@ -34,14 +34,13 @@ import { ReimagineVariants } from './ReimagineVariants';
 import { deriveSectionRows } from './SectionsDrawer';
 import type { SectionViewRow } from './SectionsDrawer';
 import { resolveIntentPolicy, isReimagine, INTENT_CHIP, INTENT_SUMMARY_VERB } from './intent';
+import { selectResultState } from './resultState';
+
+// The busy/cancelled/error/published/awaiting-publish/empty selection lives in the
+// pure, React-free ./resultState module (MWPW-199251) so it can be unit-tested
+// without the S2 icon chain. This card renders one block per state below.
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function isBusy(s: Session): boolean {
-  return ['queued', 'generating', 'waiting', 'refining', 'shipping', 'deploying', 'running'].includes(
-    s.status,
-  );
-}
 
 // A plain-language title for the page (jargon-free; no internal slugs/branches).
 // The intent MODE is now carried by the chip (IntentChip), so the title keeps a
@@ -431,14 +430,14 @@ export function ResultCard({ session, onDeploy, onCancel, onRetry, onRefine, onN
     }
   }
 
-  const busy = isBusy(session);
+  const state = selectResultState(session);
   const figmaAuthUrl = (session as Session & { figmaAuthUrl?: string }).figmaAuthUrl;
 
   // ── State 1: busy ───────────────────────────────────────────────────────────
   // GeneratingCard owns its full two-column layout — render it directly, NOT
   // inside the old .pf-result-card--gen (whose overflow:hidden + flex column
   // clipped the build skeleton and squeezed the copy).
-  if (busy) {
+  if (state === 'busy') {
     return (
       <div className="pf-gen2-wrap">
         {figmaAuthUrl && (
@@ -453,9 +452,7 @@ export function ResultCard({ session, onDeploy, onCancel, onRetry, onRefine, onN
   }
 
   // ── State 2: cancelled ──────────────────────────────────────────────────────
-  const isCancelled =
-    session.phase === 'cancelled' || /cancelled/i.test(session.error || '');
-  if (session.status === 'error' && isCancelled && (session.versions?.length ?? 0) === 0) {
+  if (state === 'cancelled') {
     return (
       <div className="pf-state2 pf-state2--stopped">
         <span className="pf-state2-glyph" aria-hidden>
@@ -471,7 +468,7 @@ export function ResultCard({ session, onDeploy, onCancel, onRetry, onRefine, onN
   }
 
   // ── State 3: error (no versions) ────────────────────────────────────────────
-  if (session.status === 'error' && (session.versions?.length ?? 0) === 0) {
+  if (state === 'error') {
     if (figmaAuthUrl) {
       return (
         <div className="pf-result-card pf-result-card--gen">
@@ -523,7 +520,9 @@ export function ResultCard({ session, onDeploy, onCancel, onRetry, onRefine, onN
     staticUrl || (shipped?.daPreviewUrl as string | undefined) || undefined;
 
   // ── State 4: published — live, shareable, with a "what now" loop ──────────────
-  if (shipped?.prototypeUrl) {
+  // (selectResultState returns 'published' only when shipped.prototypeUrl is set,
+  // so the `&& shipped` is a type guard, never a runtime gate.)
+  if (state === 'published' && shipped) {
     const milolibsHref =
       (shipped.milolibsUrl as string | undefined) ||
       (shipped.remotePreviewUrl as string | undefined) ||
@@ -629,7 +628,7 @@ export function ResultCard({ session, onDeploy, onCancel, onRetry, onRefine, onN
   }
 
   // ── State 5: generated, awaiting publish (the deliberate ship step) ───────────
-  if (session.versions && session.versions.length > 0) {
+  if (state === 'awaiting-publish') {
     async function handleDeploy() {
       setDeploying(true);
       try { await onDeploy(); } finally { setDeploying(false); }

--- a/tools/forge/src/app/resultState.test.ts
+++ b/tools/forge/src/app/resultState.test.ts
@@ -1,0 +1,137 @@
+// MWPW-199251 — unit tests for the result-surface state selection.
+// Pure logic (no React / no @react-spectrum/s2), so this runs in plain vitest.
+import { describe, it, expect } from 'vitest';
+import { selectResultState, isBusy, isCancelled, type ResultState } from './resultState';
+import type { Session, SessionStatus } from '../sessions/types';
+
+// Minimal Session factory — only the fields selectResultState reads matter.
+function session(overrides: Partial<Session>): Session {
+  return {
+    sessionId: 's1',
+    status: 'pending',
+    source: 'figma',
+    versions: [],
+    ...overrides,
+  };
+}
+
+const state = (o: Partial<Session>): ResultState => selectResultState(session(o));
+
+// A single built version — enough to flip noVersions / awaiting-publish.
+const V = [{ v: 1 }];
+
+describe('selectResultState — busy wins outright', () => {
+  const BUSY: SessionStatus[] = [
+    'queued', 'generating', 'waiting', 'refining', 'shipping', 'deploying', 'running',
+  ];
+  it.each(BUSY)('status %s → busy', (status) => {
+    expect(state({ status })).toBe('busy');
+  });
+
+  it('busy wins even with stale versions attached', () => {
+    expect(state({ status: 'running', versions: V })).toBe('busy');
+  });
+  it('busy wins even with a shipped.prototypeUrl attached', () => {
+    expect(state({ status: 'deploying', shipped: { prototypeUrl: 'https://x' }, versions: V }))
+      .toBe('busy');
+  });
+});
+
+describe('selectResultState — cancelled (error, no versions)', () => {
+  it('error + phase="cancelled" → cancelled', () => {
+    expect(state({ status: 'error', phase: 'cancelled' })).toBe('cancelled');
+  });
+  it('error + /cancelled/i in error string → cancelled', () => {
+    expect(state({ status: 'error', error: 'Run cancelled by user' })).toBe('cancelled');
+  });
+  it('cancelled detection is case-insensitive', () => {
+    expect(state({ status: 'error', error: 'CANCELLED' })).toBe('cancelled');
+  });
+});
+
+describe('selectResultState — error (error, no versions, not cancelled)', () => {
+  it('error + generic message → error', () => {
+    expect(state({ status: 'error', error: 'boom: something failed' })).toBe('error');
+  });
+  it('error + no message → error', () => {
+    expect(state({ status: 'error' })).toBe('error');
+  });
+});
+
+describe('selectResultState — errored run WITH versions falls through to done surfaces', () => {
+  it('error + versions + no shipped → awaiting-publish (a late failure keeps the built page)', () => {
+    expect(state({ status: 'error', versions: V })).toBe('awaiting-publish');
+  });
+  it('error + versions + shipped.prototypeUrl → published', () => {
+    expect(state({ status: 'error', versions: V, shipped: { prototypeUrl: 'https://x' } }))
+      .toBe('published');
+  });
+  it('a cancelled-phase run that still produced versions is NOT the cancelled card', () => {
+    expect(state({ status: 'error', phase: 'cancelled', versions: V })).toBe('awaiting-publish');
+  });
+});
+
+describe('selectResultState — published', () => {
+  it('done + shipped.prototypeUrl → published', () => {
+    expect(state({ status: 'done', versions: V, shipped: { prototypeUrl: 'https://x' } }))
+      .toBe('published');
+  });
+  it('published even without versions (shipped is the signal)', () => {
+    expect(state({ status: 'done', shipped: { prototypeUrl: 'https://x' } })).toBe('published');
+  });
+  it('empty shipped object (no prototypeUrl) is NOT published', () => {
+    expect(state({ status: 'done', versions: V, shipped: {} })).toBe('awaiting-publish');
+  });
+});
+
+describe('selectResultState — awaiting-publish', () => {
+  it('done + versions, no shipped → awaiting-publish', () => {
+    expect(state({ status: 'done', versions: V })).toBe('awaiting-publish');
+  });
+  it('paused + versions → awaiting-publish', () => {
+    expect(state({ status: 'paused', versions: V })).toBe('awaiting-publish');
+  });
+});
+
+describe('selectResultState — empty', () => {
+  it('pending + nothing produced → empty', () => {
+    expect(state({ status: 'pending' })).toBe('empty');
+  });
+  it('done but no versions and no shipped → empty', () => {
+    expect(state({ status: 'done' })).toBe('empty');
+  });
+  it('a status with no busy/error/done signal and no output → empty', () => {
+    expect(state({ status: 'paused' })).toBe('empty');
+  });
+});
+
+describe('selectResultState — every state is reachable + exhaustive', () => {
+  const reached = new Set<ResultState>([
+    state({ status: 'running' }),
+    state({ status: 'error', phase: 'cancelled' }),
+    state({ status: 'error' }),
+    state({ status: 'done', shipped: { prototypeUrl: 'x' } }),
+    state({ status: 'done', versions: V }),
+    state({ status: 'pending' }),
+  ]);
+  it('covers all six states', () => {
+    expect([...reached].sort()).toEqual(
+      ['awaiting-publish', 'busy', 'cancelled', 'empty', 'error', 'published'],
+    );
+  });
+});
+
+describe('isBusy / isCancelled helpers', () => {
+  it('isBusy true for an in-flight status', () => {
+    expect(isBusy(session({ status: 'generating' }))).toBe(true);
+  });
+  it('isBusy false for a settled status', () => {
+    expect(isBusy(session({ status: 'done' }))).toBe(false);
+  });
+  it('isCancelled reads phase OR error string', () => {
+    expect(isCancelled(session({ phase: 'cancelled' }))).toBe(true);
+    expect(isCancelled(session({ error: 'was Cancelled midway' }))).toBe(true);
+    expect(isCancelled(session({ error: 'network error' }))).toBe(false);
+    expect(isCancelled(session({}))).toBe(false);
+  });
+});

--- a/tools/forge/src/app/resultState.ts
+++ b/tools/forge/src/app/resultState.ts
@@ -1,0 +1,66 @@
+// ── Result-surface state selection (pure) ────────────────────────────────────
+// Extracted from ResultCard.tsx (MWPW-199251) so the busy/cancelled/error/
+// published/awaiting-publish/empty branching can be unit-tested without importing
+// React or @react-spectrum/s2. ResultCard renders one block per state and reads
+// the chosen state from here — this module is the single source of truth for
+// WHICH state a Session is in, so the render guards can never drift from the test.
+import type { Session } from '../sessions/types';
+
+// The six mutually-exclusive surfaces ResultCard can show, in priority order:
+//   busy             → a run is in flight (GeneratingCard)
+//   cancelled        → the user stopped a run with nothing produced yet
+//   error            → a run failed with nothing produced yet (retry / figma re-auth)
+//   published        → the page landed in Authoring (shipped.prototypeUrl)
+//   awaiting-publish → a page is built and awaiting the deliberate ship step
+//   empty            → pending / undefined (nothing to show)
+export type ResultState =
+  | 'busy'
+  | 'cancelled'
+  | 'error'
+  | 'published'
+  | 'awaiting-publish'
+  | 'empty';
+
+// Statuses where a run is actively in flight → the busy surface wins over
+// everything else (even if stale versions/shipped data is still attached).
+const BUSY_STATUSES: ReadonlySet<string> = new Set([
+  'queued',
+  'generating',
+  'waiting',
+  'refining',
+  'shipping',
+  'deploying',
+  'running',
+]);
+
+export function isBusy(s: Session): boolean {
+  return BUSY_STATUSES.has(s.status);
+}
+
+// A cancelled run reaches the client as status:'error' — distinguished from a
+// genuine failure by an explicit phase:'cancelled' or a /cancelled/i error string.
+export function isCancelled(s: Session): boolean {
+  return s.phase === 'cancelled' || /cancelled/i.test(s.error || '');
+}
+
+// Resolve the single surface to render. Order matters and mirrors ResultCard's
+// guard order exactly:
+//   1. busy wins outright.
+//   2. an errored run with NO versions is either cancelled (user stopped) or a
+//      genuine error — both show a terminal card with a restart action.
+//   3. an errored run WITH versions falls through to the done surfaces (a late
+//      failure shouldn't discard an already-built page).
+//   4. shipped.prototypeUrl → published; else any versions → awaiting-publish.
+//   5. nothing produced → empty.
+export function selectResultState(s: Session): ResultState {
+  if (isBusy(s)) return 'busy';
+
+  const noVersions = (s.versions?.length ?? 0) === 0;
+  if (s.status === 'error' && noVersions) {
+    return isCancelled(s) ? 'cancelled' : 'error';
+  }
+
+  if (s.shipped?.prototypeUrl) return 'published';
+  if ((s.versions?.length ?? 0) > 0) return 'awaiting-publish';
+  return 'empty';
+}


### PR DESCRIPTION
## MWPW-199251 — Land the result surface (residual: test)

Extracts ResultCard's busy/cancelled/error/published/awaiting-publish/empty selection to a pure module so the state logic is unit-testable and the render guards can't drift.

### Changes
- **`selectResultState` + `isBusy` + `isCancelled` → `src/app/resultState.ts`** (pure). `ResultCard.tsx` renders one block per resolved state (guards now read `state` — single source of truth).
- **`resultState.test.ts`** — 29 cases: busy-wins, cancelled vs error, errored-with-versions falls through to done surfaces (a late failure keeps the built page), published/awaiting/empty, exhaustive reachability of all six states.

### Verification
99 tests green, `tsc --noEmit` clean. Behavior-preserving (same ordering/conditions as the inline guards).

### Review
Manual devil's-advocate + security pass: pure state selection, no new surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

