### PR TITLE
forge UI: pre-run Settings format validation + tests (MWPW-199254)

### DIFF
--- a/tools/forge/src/app/SettingsSlideover.tsx
+++ b/tools/forge/src/app/SettingsSlideover.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
 import { TextField } from '@react-spectrum/s2';
 import Close from '@react-spectrum/s2/icons/Close';
-import { useConfig } from '../config';
-import type { ForgeConfig } from '../config';
+import { useConfig, validateForgeConfig, isForgeConfigValid } from '../config';
+import type { ForgeConfig, ForgeConfigErrors } from '../config';
 import styles from './SettingsSlideover.module.css';
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -22,12 +22,25 @@ export function SettingsSlideover({ isOpen, onClose }: SettingsSlideoverProps) {
   // Local draft — committed only on Save. Re-synced from config each time the
   // panel opens, so a Cancel-then-reopen always shows the saved values.
   const [draft, setDraft] = useState<ForgeConfig>(config);
+  // Per-field format errors from the last Save attempt. Cleared when the panel
+  // re-opens (fresh draft) and when the offending field is edited.
+  const [errors, setErrors] = useState<ForgeConfigErrors>({});
   useEffect(() => {
-    if (isOpen) setDraft(config);
+    if (isOpen) {
+      setDraft(config);
+      setErrors({});
+    }
   }, [isOpen, config]);
 
   function update<K extends keyof ForgeConfig>(key: K, value: ForgeConfig[K]) {
     setDraft((d) => ({ ...d, [key]: value }));
+    // Drop this field's error as soon as the user edits it — don't nag mid-fix.
+    setErrors((e) => {
+      if (!(key in e)) return e;
+      const next = { ...e };
+      delete (next as Record<string, unknown>)[key as string];
+      return next;
+    });
   }
 
   function updateExport<K extends keyof ForgeConfig['export']>(
@@ -38,6 +51,13 @@ export function SettingsSlideover({ isOpen, onClose }: SettingsSlideoverProps) {
   }
 
   function handleSave() {
+    // Pre-run format validation — a mistyped value fails inline HERE instead of
+    // cryptically minutes into a run (MWPW-199254).
+    const found = validateForgeConfig(draft);
+    if (!isForgeConfigValid(found)) {
+      setErrors(found);
+      return;
+    }
     setConfig(draft);
     try {
       localStorage.setItem('forge.config', JSON.stringify(draft));
@@ -84,6 +104,8 @@ export function SettingsSlideover({ isOpen, onClose }: SettingsSlideoverProps) {
                 value={draft.serverUrl}
                 onChange={(v) => update('serverUrl', v)}
                 description="Where the page-forge server is running. Default: http://localhost:8080"
+                isInvalid={Boolean(errors.serverUrl)}
+                errorMessage={errors.serverUrl}
                 UNSAFE_style={{ width: '100%' }}
               />
             </div>
@@ -101,6 +123,8 @@ export function SettingsSlideover({ isOpen, onClose }: SettingsSlideoverProps) {
                 onChange={(v) => update('repoPath', v)}
                 placeholder="/Users/you/path/to/your-consumer-site"
                 description="Local clone of your consumer site, for example adobecom/da-playground."
+                isInvalid={Boolean(errors.repoPath)}
+                errorMessage={errors.repoPath}
                 UNSAFE_style={{ width: '100%' }}
               />
             </div>
@@ -111,6 +135,8 @@ export function SettingsSlideover({ isOpen, onClose }: SettingsSlideoverProps) {
                 onChange={(v) => update('consumerPreviewUrl', v)}
                 placeholder="http://localhost:3000"
                 description="Where your consumer's local dev server is reachable."
+                isInvalid={Boolean(errors.consumerPreviewUrl)}
+                errorMessage={errors.consumerPreviewUrl}
                 UNSAFE_style={{ width: '100%' }}
               />
             </div>
@@ -125,6 +151,8 @@ export function SettingsSlideover({ isOpen, onClose }: SettingsSlideoverProps) {
                 onChange={(v) => update('miloPath', v)}
                 placeholder="/Users/you/path/to/milo"
                 description="Local clone of adobecom/milo. Required when new blocks go to Milo."
+                isInvalid={Boolean(errors.miloPath)}
+                errorMessage={errors.miloPath}
                 UNSAFE_style={{ width: '100%' }}
               />
             </div>
@@ -139,6 +167,8 @@ export function SettingsSlideover({ isOpen, onClose }: SettingsSlideoverProps) {
                 onChange={(v) => update('daUsername', v)}
                 placeholder="your-ldap, for example jdoe"
                 description="Required to send to Authoring. Sets the folder: /drafts/<username>/forge/<slug>."
+                isInvalid={Boolean(errors.daUsername)}
+                errorMessage={errors.daUsername}
                 UNSAFE_style={{ width: '100%' }}
               />
             </div>

--- a/tools/forge/src/app/confirmDialog.test.tsx
+++ b/tools/forge/src/app/confirmDialog.test.tsx
@@ -1,0 +1,109 @@
+// MWPW-199254 — the destructive/confirm path of ConfirmDialog. Driven through the
+// real UiState reducer (openConfirm → closeModal), no @react-spectrum/s2 in the
+// tree, so it renders under the standalone vitest config.
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { UiStateProvider, useUiState, type ConfirmPayload } from './UiStateContext';
+import { ConfirmDialog } from './ConfirmDialog';
+
+afterEach(cleanup);
+
+// Fires openConfirm with the given payload on button click, so each test drives
+// the dialog through the real reducer rather than faking state.
+function Opener({ payload }: { payload: ConfirmPayload }) {
+  const { dispatch } = useUiState();
+  return (
+    <button type="button" onClick={() => dispatch({ type: 'openConfirm', payload })}>
+      trigger
+    </button>
+  );
+}
+
+function setup(payload: ConfirmPayload) {
+  render(
+    <UiStateProvider>
+      <Opener payload={payload} />
+      <ConfirmDialog />
+    </UiStateProvider>,
+  );
+}
+
+function basePayload(over: Partial<ConfirmPayload> = {}): ConfirmPayload {
+  return {
+    title: 'Delete session?',
+    message: 'This removes the run and its history.',
+    onConfirm: vi.fn(),
+    ...over,
+  };
+}
+
+describe('ConfirmDialog — closed until opened', () => {
+  it('renders nothing before openConfirm', () => {
+    setup(basePayload());
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('ConfirmDialog — destructive confirm', () => {
+  it('shows the payload title/message and a danger-styled labeled action', () => {
+    setup(basePayload({ destructive: true, confirmLabel: 'Delete' }));
+    fireEvent.click(screen.getByText('trigger'));
+
+    const dialog = screen.getByRole('alertdialog');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'confirm-title');
+    expect(screen.getByText('Delete session?')).toBeInTheDocument();
+    expect(screen.getByText('This removes the run and its history.')).toBeInTheDocument();
+
+    const confirmBtn = screen.getByRole('button', { name: 'Delete' });
+    expect(confirmBtn).toHaveClass('pf-btn-danger');
+  });
+
+  it('confirm runs onConfirm exactly once and closes the dialog', () => {
+    const onConfirm = vi.fn();
+    setup(basePayload({ destructive: true, confirmLabel: 'Delete', onConfirm }));
+    fireEvent.click(screen.getByText('trigger'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  it('cancel closes WITHOUT running onConfirm', () => {
+    const onConfirm = vi.fn();
+    setup(basePayload({ destructive: true, confirmLabel: 'Delete', onConfirm }));
+    fireEvent.click(screen.getByText('trigger'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('ConfirmDialog — non-destructive default', () => {
+  it('defaults the confirm label to "Confirm" and uses the primary (non-danger) style', () => {
+    setup(basePayload());
+    fireEvent.click(screen.getByText('trigger'));
+
+    const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+    expect(confirmBtn).toHaveClass('pf-btn-primary');
+    expect(confirmBtn).not.toHaveClass('pf-btn-danger');
+  });
+});
+
+describe('ConfirmDialog — backdrop dismiss', () => {
+  it('clicking the backdrop closes without confirming; clicking the dialog does not', () => {
+    const onConfirm = vi.fn();
+    setup(basePayload({ onConfirm }));
+    fireEvent.click(screen.getByText('trigger'));
+
+    // Clicking the dialog body must NOT close (target !== backdrop).
+    fireEvent.click(screen.getByRole('alertdialog'));
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+
+    // Clicking the backdrop itself closes.
+    const backdrop = screen.getByRole('alertdialog').parentElement as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/tools/forge/src/config/index.tsx
+++ b/tools/forge/src/config/index.tsx
@@ -48,6 +48,79 @@ export interface ForgeConfig {
   };
 }
 
+// ── Pre-run validation (MWPW-199254) ──────────────────────────────────────────
+// Client-side FORMAT validation only. A browser cannot verify that a path exists
+// on disk, that a token is accepted, or that a URL is reachable — those need a
+// server round-trip (the page-forge server still does the missing-path check at
+// run time). What we CAN do synchronously is catch the malformed input that
+// otherwise fails cryptically minutes into a run: empty required fields and
+// obviously-wrong shapes. Fields are validated only when present (except the
+// always-required serverUrl), so an incomplete-but-valid config never blocks Save.
+
+export type ForgeConfigField =
+  | 'serverUrl'
+  | 'repoPath'
+  | 'consumerPreviewUrl'
+  | 'miloPath'
+  | 'daUsername';
+
+export type ForgeConfigErrors = Partial<Record<ForgeConfigField, string>>;
+
+function isHttpUrl(v: string): boolean {
+  try {
+    const u = new URL(v.trim());
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+// Absolute POSIX path (or a ~-relative one). We don't touch the filesystem —
+// this only rejects a value that plainly isn't a path (e.g. a bare repo name).
+function isAbsolutePath(v: string): boolean {
+  const t = v.trim();
+  return t.startsWith('/') || t.startsWith('~/');
+}
+
+// A bare LDAP: letters/digits/dot/dash/underscore. Rejects spaces, '@' (an email),
+// and '/' (a path) — the common mistypes for this field.
+function isLdap(v: string): boolean {
+  return /^[a-zA-Z0-9._-]+$/.test(v.trim());
+}
+
+export function validateForgeConfig(cfg: ForgeConfig): ForgeConfigErrors {
+  const errors: ForgeConfigErrors = {};
+
+  if (!cfg.serverUrl?.trim()) {
+    errors.serverUrl = 'Server URL is required.';
+  } else if (!isHttpUrl(cfg.serverUrl)) {
+    errors.serverUrl = 'Enter a full URL, e.g. http://localhost:8080.';
+  }
+
+  if (cfg.consumerPreviewUrl?.trim() && !isHttpUrl(cfg.consumerPreviewUrl)) {
+    errors.consumerPreviewUrl = 'Enter a full URL, e.g. http://localhost:3000.';
+  }
+
+  if (cfg.repoPath?.trim() && !isAbsolutePath(cfg.repoPath)) {
+    errors.repoPath = 'Enter an absolute path, e.g. /Users/you/your-consumer-site.';
+  }
+
+  if (cfg.miloPath?.trim() && !isAbsolutePath(cfg.miloPath)) {
+    errors.miloPath = 'Enter an absolute path, e.g. /Users/you/milo.';
+  }
+
+  if (cfg.daUsername?.trim() && !isLdap(cfg.daUsername)) {
+    errors.daUsername = 'Use your bare LDAP, e.g. jdoe (no spaces, @ or /).';
+  }
+
+  return errors;
+}
+
+// True when a validation result has no field errors → safe to commit.
+export function isForgeConfigValid(errors: ForgeConfigErrors): boolean {
+  return Object.keys(errors).length === 0;
+}
+
 // ── Config helpers ────────────────────────────────────────────────────────────
 
 const DEFAULT_SERVER_URL = 'http://localhost:8080';

--- a/tools/forge/src/config/settingsConfig.test.ts
+++ b/tools/forge/src/config/settingsConfig.test.ts
@@ -1,0 +1,129 @@
+// MWPW-199254 — unit tests for the Settings config layer: the new pre-run format
+// validation, and the load/save round-trip + legacy migration that back the
+// draft/commit/re-sync behavior of SettingsSlideover. Pure logic + localStorage
+// (jsdom), no React / no @react-spectrum/s2.
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  validateForgeConfig,
+  isForgeConfigValid,
+  emptyForgeConfig,
+  loadForgeConfig,
+  saveForgeConfig,
+  FORGE_CONFIG_KEY,
+  type ForgeConfig,
+} from './index';
+
+// A config that passes validation: default server URL, everything else blank.
+function validCfg(overrides: Partial<ForgeConfig> = {}): ForgeConfig {
+  return { ...emptyForgeConfig(), ...overrides };
+}
+
+describe('validateForgeConfig — serverUrl (always required)', () => {
+  it('accepts the default localhost URL', () => {
+    expect(validateForgeConfig(validCfg())).toEqual({});
+  });
+  it('rejects an empty server URL', () => {
+    expect(validateForgeConfig(validCfg({ serverUrl: '' })).serverUrl).toMatch(/required/i);
+  });
+  it('rejects a whitespace-only server URL', () => {
+    expect(validateForgeConfig(validCfg({ serverUrl: '   ' })).serverUrl).toMatch(/required/i);
+  });
+  it('rejects a malformed server URL', () => {
+    expect(validateForgeConfig(validCfg({ serverUrl: 'localhost:8080' })).serverUrl).toMatch(/full URL/i);
+  });
+  it('rejects a non-http(s) scheme', () => {
+    expect(validateForgeConfig(validCfg({ serverUrl: 'ftp://x' })).serverUrl).toBeTruthy();
+  });
+  it('accepts https', () => {
+    expect(validateForgeConfig(validCfg({ serverUrl: 'https://forge.example.com' })).serverUrl).toBeUndefined();
+  });
+});
+
+describe('validateForgeConfig — optional fields validated only when present', () => {
+  it('blank optional fields are all valid', () => {
+    expect(isForgeConfigValid(validateForgeConfig(validCfg()))).toBe(true);
+  });
+
+  it('consumerPreviewUrl must be a URL when set', () => {
+    expect(validateForgeConfig(validCfg({ consumerPreviewUrl: 'not a url' })).consumerPreviewUrl).toBeTruthy();
+    expect(validateForgeConfig(validCfg({ consumerPreviewUrl: 'http://localhost:3000' })).consumerPreviewUrl).toBeUndefined();
+  });
+
+  it('repoPath must be absolute when set', () => {
+    expect(validateForgeConfig(validCfg({ repoPath: 'da-playground' })).repoPath).toBeTruthy();
+    expect(validateForgeConfig(validCfg({ repoPath: '/Users/me/da-playground' })).repoPath).toBeUndefined();
+    expect(validateForgeConfig(validCfg({ repoPath: '~/da-playground' })).repoPath).toBeUndefined();
+  });
+
+  it('miloPath must be absolute when set', () => {
+    expect(validateForgeConfig(validCfg({ miloPath: 'milo' })).miloPath).toBeTruthy();
+    expect(validateForgeConfig(validCfg({ miloPath: '/Users/me/milo' })).miloPath).toBeUndefined();
+  });
+
+  it('daUsername must be a bare LDAP when set', () => {
+    expect(validateForgeConfig(validCfg({ daUsername: 'jane@adobe.com' })).daUsername).toBeTruthy();
+    expect(validateForgeConfig(validCfg({ daUsername: 'has space' })).daUsername).toBeTruthy();
+    expect(validateForgeConfig(validCfg({ daUsername: 'a/b' })).daUsername).toBeTruthy();
+    expect(validateForgeConfig(validCfg({ daUsername: 'jdoe' })).daUsername).toBeUndefined();
+  });
+
+  it('accumulates multiple field errors in one pass', () => {
+    const errs = validateForgeConfig(validCfg({ serverUrl: '', repoPath: 'x', daUsername: 'a b' }));
+    expect(Object.keys(errs).sort()).toEqual(['daUsername', 'repoPath', 'serverUrl']);
+    expect(isForgeConfigValid(errs)).toBe(false);
+  });
+});
+
+describe('isForgeConfigValid', () => {
+  it('true for an empty error object', () => {
+    expect(isForgeConfigValid({})).toBe(true);
+  });
+  it('false when any field error is present', () => {
+    expect(isForgeConfigValid({ serverUrl: 'bad' })).toBe(false);
+  });
+});
+
+describe('load/save round-trip (backs draft commit + re-sync)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('save then load returns the committed config', () => {
+    const cfg = validCfg({ repoPath: '/Users/me/site', daUsername: 'jdoe', debugMode: true });
+    saveForgeConfig(cfg);
+    const loaded = loadForgeConfig();
+    expect(loaded.repoPath).toBe('/Users/me/site');
+    expect(loaded.daUsername).toBe('jdoe');
+    expect(loaded.debugMode).toBe(true);
+  });
+
+  it('missing fields are backfilled from defaults (no undefined access downstream)', () => {
+    localStorage.setItem(FORGE_CONFIG_KEY, JSON.stringify({ repoPath: '/Users/me/site' }));
+    const loaded = loadForgeConfig();
+    expect(loaded.serverUrl).toBe('http://localhost:8080'); // default
+    expect(loaded.export.mode).toBe('milo'); // default nested
+    expect(loaded.miloPath).toBe(''); // default blank
+  });
+
+  it('corrupt JSON falls back to defaults instead of throwing', () => {
+    localStorage.setItem(FORGE_CONFIG_KEY, '{not json');
+    expect(() => loadForgeConfig()).not.toThrow();
+    expect(loadForgeConfig().serverUrl).toBe('http://localhost:8080');
+  });
+
+  it('migrates a legacy export shape (sendBlocksToMilo:false → project)', () => {
+    localStorage.setItem(
+      FORGE_CONFIG_KEY,
+      JSON.stringify({ serverUrl: 'http://x:8080', export: { sendBlocksToMilo: false } }),
+    );
+    expect(loadForgeConfig().export.mode).toBe('project');
+  });
+
+  it('migrates a legacy export shape (block dev left on → milo)', () => {
+    localStorage.setItem(
+      FORGE_CONFIG_KEY,
+      JSON.stringify({ serverUrl: 'http://x:8080', export: { sendBlocksToMilo: true } }),
+    );
+    expect(loadForgeConfig().export.mode).toBe('milo');
+  });
+});


### PR DESCRIPTION
## MWPW-199254 — Land settings + connect modals (residual: validation + test)

Adds the missing pre-run per-field Settings validation and the first tests for the settings/confirm surfaces.

### Changes
- **`validateForgeConfig` + `isForgeConfigValid` → `config/index.tsx`** (pure, format-only): serverUrl required + http(s); repoPath/miloPath absolute; consumerPreviewUrl http(s); daUsername bare-LDAP. All optional-when-blank.
- **Wired into `SettingsSlideover.handleSave`**: blocks commit on a bad value, shows inline `isInvalid`/`errorMessage` per field, clears on edit + on reopen.
- **Tests**: `settingsConfig.test.ts` (validation + load/save round-trip + legacy migration) and `confirmDialog.test.tsx` (RTL destructive/confirm/cancel/backdrop via the real reducer).

### Scope note
Deep checks (path-exists / token-valid / reachable) require a server probe — out of scope for a client-side pre-run guard; the server still does the missing-path check at run time. This closes the format-validation AC.

### Verification
134 tests green, `tsc --noEmit` clean. Visual check (headless): inline error treatment renders correctly.

### Review
Manual devil's-advocate + security pass: format-only checks (URL-parse in try/catch, static regexes); errors render via S2 `errorMessage` (React-escaped); no injection/eval surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

