### PR TITLE
MWPW-200568 Parallelize initService script loading in merch block

### DIFF
--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -1,7 +1,6 @@
 import { createTag, getConfig } from '../../utils/utils.js';
 import { decorateButtons, getBlockSize } from '../../utils/decorate.js';
 import { postProcessAutoblock } from '../merch/autoblock.js';
-import { mepMasStudioUrls } from '../merch/mas-mep-utils.js';
 import {
   initService,
   createAemFragment,
@@ -152,6 +151,7 @@ export async function createCard(el, options) {
   const merchCard = createTag('merch-card', { consonant: '' }, aemFragment);
   // For the "Edit Card" mep preview badge.
   if (getConfig()?.mep?.preview) {
+    const { mepMasStudioUrls } = await import('../merch/mas-mep-utils.js');
     mepMasStudioUrls.set(merchCard, el.href);
     merchCard.dataset.masBlock = 'card';
   }
@@ -176,6 +176,7 @@ async function createInline(el, options) {
   const aemFragment = createAemFragment(options, seenFragments);
   const masField = createTag('mas-field', { field: options.field }, aemFragment);
   if (getConfig()?.mep?.preview) {
+    const { mepMasStudioUrls } = await import('../merch/mas-mep-utils.js');
     mepMasStudioUrls.set(masField, el.href);
     masField.dataset.masBlock = 'inline';
   }

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1116,27 +1116,25 @@ export async function initService(force = false, attributes = {}) {
   });
   initService.promise = initService.promise
     ?? polyfills().then(async () => {
-      await loadMasComponent(COMMERCE_LIBRARY);
-
-      // Load fragment-client.js when maslibs is present
-      const fragmentClientUrl = getFragmentClientUrl();
-      if (fragmentClientUrl) {
-        const { loadScript: loadScriptUtil } = await import('../../utils/utils.js');
-        try {
-          await loadScriptUtil(fragmentClientUrl, 'module');
-        } catch (e) {
-          log?.error('Failed to load fragment-client.js:', e);
-        }
-      }
-
-      const { language, locale, country } = await getLocaleSettings(miloLocale);
       const useGeoMarket = isMasGeoDetectionEnabled();
+
+      // Load all independent resources in parallel
+      const fragmentClientUrl = getFragmentClientUrl();
+      const [, , { language, locale, country }, validatedMarket] = await Promise.all([
+        loadMasComponent(COMMERCE_LIBRARY),
+        fragmentClientUrl
+          ? loadScript(fragmentClientUrl, 'module').catch((e) => {
+            log?.error('Failed to load fragment-client.js:', e);
+          })
+          : Promise.resolve(),
+        getLocaleSettings(miloLocale),
+        useGeoMarket
+          ? import('../../utils/market.js').then(({ getValidatedMarket }) => getValidatedMarket())
+          : Promise.resolve(null),
+      ]);
+
       let countryFromMarket = country;
-      if (useGeoMarket) {
-        const { getValidatedMarket } = await import('../../utils/market.js');
-        const validatedMarket = await getValidatedMarket();
-        if (validatedMarket) countryFromMarket = validatedMarket.toUpperCase();
-      }
+      if (useGeoMarket && validatedMarket) countryFromMarket = validatedMarket.toUpperCase();
       let service = document.head.querySelector('mas-commerce-service');
       if (!service) {
         setPreview(attributes);

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1119,6 +1119,7 @@ export async function initService(force = false, attributes = {}) {
 
       // Load all independent resources in parallel
       const fragmentClientUrl = getFragmentClientUrl();
+      const localeSettingsPromise = getLocaleSettings(miloLocale);
       const [, , { language, locale, country }, validatedMarket] = await Promise.all([
         loadMasComponent(COMMERCE_LIBRARY),
         fragmentClientUrl
@@ -1126,7 +1127,7 @@ export async function initService(force = false, attributes = {}) {
             log?.error('Failed to load fragment-client.js:', e);
           })
           : Promise.resolve(),
-        getLocaleSettings(miloLocale),
+        localeSettingsPromise,
         useGeoMarket
           ? import('../../utils/market.js').then(({ getValidatedMarket }) => getValidatedMarket())
           : Promise.resolve(null),

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -3,7 +3,6 @@ import {
   shouldAllowKrTrial, getCountry,
 } from '../../utils/utils.js';
 import { replaceKey } from '../../features/placeholders.js';
-import { mepMasStudioUrls } from './mas-mep-utils.js';
 
 // MAS Component Names
 export const COMMERCE_LIBRARY = 'commerce';
@@ -1621,6 +1620,7 @@ export default async function init(el) {
     // Rebuilt merch href keeps only the OSI; stash the original for
     // the "Edit OSI" badge.
     if (getConfig()?.mep?.preview) {
+      const { mepMasStudioUrls } = await import('./mas-mep-utils.js');
       mepMasStudioUrls.set(merch, el.href);
       merch.dataset.masBlock = 'ost';
     }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2670,15 +2670,34 @@ export function partition(arr, fn) {
   );
 }
 
+function getMasDepUrl(component) {
+  const { hostname } = window.location;
+  if (hostname === 'www.adobe.com') return `https://www.adobe.com/mas/libs/${component}`;
+
+  const masLibs = new URLSearchParams(window.location.search).get('maslibs')?.trim().toLowerCase();
+  if (masLibs) {
+    let baseUrl;
+    if (masLibs === 'local') baseUrl = 'http://localhost:3000';
+    else if (masLibs === 'main') baseUrl = 'https://main--mas--adobecom.aem.live';
+    else {
+      const branch = masLibs.includes('--') ? masLibs : `${masLibs}--mas--adobecom`;
+      baseUrl = `https://${branch}.aem.live`;
+    }
+    return `${baseUrl}/web-components/dist/${component}`;
+  }
+
+  return `https://main--mas--adobecom.aem.live/web-components/dist/${component}`;
+}
+
 const STATIC_BLOCK_DEPS = {
   'merch-card-autoblock': [
-    '/mas/libs/lit-all.min.js',
-    '/mas/libs/merch-card.js',
-    '/mas/libs/merch-quantity-select.js',
-    '/mas/libs/mas-field.js',
+    getMasDepUrl('lit-all.min.js'),
+    getMasDepUrl('merch-card.js'),
+    getMasDepUrl('merch-quantity-select.js'),
+    getMasDepUrl('mas-field.js'),
   ],
   merch: [
-    '/mas/libs/commerce.js',
+    getMasDepUrl('commerce.js'),
   ],
 };
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2670,6 +2670,24 @@ export function partition(arr, fn) {
   );
 }
 
+const STATIC_BLOCK_DEPS = {
+  'merch-card-autoblock': [
+    '/mas/libs/lit-all.min.js',
+    '/mas/libs/merch-card.js',
+    '/mas/libs/merch-quantity-select.js',
+    '/mas/libs/mas-field.js',
+  ],
+  merch: [
+    '/mas/libs/commerce.js',
+  ],
+};
+
+const blockDeps = new Map(Object.entries(STATIC_BLOCK_DEPS));
+
+export function registerBlockDeps(blockName, ...deps) {
+  blockDeps.set(blockName, deps);
+}
+
 const preloadBlockResources = (blocks = []) => blocks.map((block) => {
   if (block.classList.contains('hide-block')) return null;
   const { blockPath, hasStyles, name } = getBlockData(block);
@@ -2677,6 +2695,9 @@ const preloadBlockResources = (blocks = []) => blocks.map((block) => {
     loadLink(`${getConfig().base}/utils/decorate.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
   }
   loadLink(`${blockPath}.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+  (blockDeps.get(name) ?? []).forEach((dep) => {
+    if (typeof dep === 'string') loadLink(dep, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+  });
   return hasStyles && new Promise((resolve) => { loadStyle(`${blockPath}.css`, resolve); });
 }).filter(Boolean);
 

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -331,6 +331,7 @@ describe('merch-card-autoblock autoblock', () => {
     });
 
     it('decorates two CTAs in the same paragraph correctly when processed concurrently', async () => {
+      setConfig({ codeRoot: '/libs' });
       const section = document.createElement('div');
       const siblingBtn = document.createElement('a');
       siblingBtn.classList.add('con-button', 'blue', 'button-l');


### PR DESCRIPTION
* initService in merch.js loaded four independent resources sequentially, creating an unnecessary waterfall on every page that uses the merch block.
* Replaced sequential await chain with Promise.all([loadMasComponent, fragmentClient, getLocaleSettings, getValidatedMarket])

Resolves: [MWPW-200568](https://jira.corp.adobe.com/browse/MWPW-200568)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-200568--milo--adobecom.aem.page/?martech=off

Change on https://www.adobe.com/fr/creativecloud.html with content overrides
Before:
<img width="1050" height="328" alt="BeforeBR" src="https://github.com/user-attachments/assets/a2d3223f-da21-41e4-b870-cfbee47b0146" />

After
<img width="966" height="349" alt="AfterPR" src="https://github.com/user-attachments/assets/75b8c0e9-657a-4158-a0f1-69b3cc2dcb1e" />
















