### PR TITLE
MWPW-200785 [Lingo] Stop reading the international cookie in sign-in region resolution

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1028,11 +1028,6 @@ export async function getLingoRegion({ useGeoLocation = false } = {}) {
 
   if (!regions || !Object.keys(regions).length) return null;
 
-  if (useGeoLocation) {
-    const intlPrefix = sessionStorage.getItem('international') || getCookie('international');
-    if (intlPrefix) return Object.values(regions).find((r) => r.prefix === `/${intlPrefix}`) ?? null;
-  }
-
   const country = useGeoLocation
     ? normCountryCode(await getCountry())
     : (await resolveDetectedMarketCountry())?.toLowerCase();

--- a/test/blocks/susi-light-login/susi-light-login.test.js
+++ b/test/blocks/susi-light-login/susi-light-login.test.js
@@ -85,7 +85,7 @@ describe('susi light', () => {
       expect(susiElement.authParams.dctx_id).equals('v:2,test-id');
     });
   });
-  describe('lingo sign-in locale follows the explicit region pick', () => {
+  describe('lingo sign-in locale follows the user geo (physical location)', () => {
     before(async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
@@ -100,9 +100,10 @@ describe('susi light', () => {
         },
         pathname: '/de/',
       };
-      // Explicit CH-German region pick; a divergent FR market cookie must be
-      // ignored on the sign-in path (it drives pricing only).
-      document.cookie = 'international=ch_de; path=/';
+      // Physically in CH (geo). Neither the `international` cookie (a divergent
+      // region pick) nor the market `country` cookie (pricing) is consulted here.
+      sessionStorage.setItem('akamai', 'ch');
+      document.cookie = 'international=de; path=/';
       document.cookie = 'country=fr; path=/';
       document.body.innerHTML = susiHtml;
       setConfig(config);
@@ -111,10 +112,11 @@ describe('susi light', () => {
     });
     after(() => {
       document.querySelector('meta[name="langfirst"]')?.remove();
+      sessionStorage.removeItem('akamai');
       document.cookie = 'international=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
       document.cookie = 'country=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
     });
-    it('uses the international pick (de-CH), not the market cookie (fr)', async () => {
+    it('uses geo (de-CH), ignoring the international and market cookies', async () => {
       susiElement = document.querySelector('susi-sentry-light');
       expect(susiElement.authParams.locale).equals('de-CH');
     });

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2836,31 +2836,31 @@ describe('Utils', () => {
       expect(region.prefix).to.equal('/ch_de');
     });
 
-    it('with useGeoLocation honors the international cookie (explicit pick) over geo', async () => {
+    it('with useGeoLocation ignores the international cookie and resolves from geo', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
       document.head.append(lingoMeta);
       lingoModule.setConfig(lingoRegionConfig);
-      // Explicit CH region pick; geo says US (no region) — the pick wins.
+      // The `international` cookie is no longer consulted; geo (US, no region) wins.
       document.cookie = 'international=ch_de; path=/';
       sessionStorage.setItem('akamai', 'us');
       const region = await lingoModule.getLingoRegion({ useGeoLocation: true });
-      expect(region).to.not.be.null;
-      expect(region.prefix).to.equal('/ch_de');
+      expect(region).to.be.null;
     });
 
-    it('with useGeoLocation, an explicit base/root pick is not overridden by geo', async () => {
+    it('with useGeoLocation, geo picks the region even when the international cookie diverges', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
       document.head.append(lingoMeta);
       lingoModule.setConfig(lingoRegionConfig);
-      // User explicitly chose the root (us) — geo CH must NOT pull them to ch_de.
+      // `international=us` is ignored; geo (CH) resolves to ch_de.
       document.cookie = 'international=us; path=/';
       sessionStorage.setItem('akamai', 'ch');
       const region = await lingoModule.getLingoRegion({ useGeoLocation: true });
-      expect(region).to.be.null;
+      expect(region).to.not.be.null;
+      expect(region.prefix).to.equal('/ch_de');
     });
 
     it('by default honors the market cookie over geo (mep/content callers)', async () => {
@@ -3047,8 +3047,8 @@ describe('Utils', () => {
       expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=ca_fr');
     });
 
-    // Explicit region pick (international cookie) wins over a divergent geo.
-    it('uses the international cookie over geo for the Adobe Home redirect_uri', async () => {
+    // The international cookie is no longer consulted; geo picks the region.
+    it('ignores the international cookie and uses geo for the Adobe Home redirect_uri', async () => {
       const lingoMeta = document.createElement('meta');
       lingoMeta.setAttribute('name', 'langfirst');
       lingoMeta.setAttribute('content', 'on');
@@ -3058,12 +3058,12 @@ describe('Utils', () => {
       ahomeMeta.setAttribute('content', 'on');
       document.head.append(ahomeMeta);
       lingoModule.setConfig(imsLingoConfig);
-      // Explicitly picked CA French; physically in CH — the pick wins over geo.
+      // international=ca_fr is ignored; geo (CH) resolves to ch_fr.
       document.cookie = 'international=ca_fr; path=/';
       sessionStorage.setItem('akamai', 'ch');
       lingoModule.loadIms().catch(() => {});
       await new Promise((resolve) => { setTimeout(resolve, 100); });
-      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=ca_fr');
+      expect(window.adobeid.redirect_uri).to.equal('https://www.stage.adobe.com/home?acomLocale=ch_fr');
     });
 
     it('builds a bare /home redirect_uri (no acomLocale) on the root locale', async () => {


### PR DESCRIPTION
Split off from #6268 (MWPW-200345). Per Shane Do, `acomCountry` is not a CCHome requirement yet (Akamai-only shipped), so the `acomLocale`/`acomCountry` split is shelved. This PR carries only the small, low-risk half we want to land now.

Resolves: [MWPW-200785](https://jira.corp.adobe.com/browse/MWPW-200785)

## What changes

`getLingoRegion({ useGeoLocation: true })` no longer consults `sessionStorage.international` / the `international` cookie. On the sign-in path the Lingo region now resolves from the user's **geo** (physical location) only — matching the Akamai redirect and webps's implementation.

```diff
   if (!regions || !Object.keys(regions).length) return null;

-  if (useGeoLocation) {
-    const intlPrefix = sessionStorage.getItem('international') || getCookie('international');
-    if (intlPrefix) return Object.values(regions).find((r) => r.prefix === `/${intlPrefix}`) ?? null;
-  }
-
   const country = useGeoLocation
     ? normCountryCode(await getCountry())
     : (await resolveDetectedMarketCountry())?.toLowerCase();
```

**Why:** under Lingo the `international` cookie holds only the language (not a region), so it is no longer meaningful for sign-in region resolution. Resolving from geo makes the sign-in path emit the same region as the Akamai redirect, giving CCH/Adobe Home one consistent contract.

## Scope / non-changes
- The **default (no-arg)** `getLingoRegion` path used by MEP/content is unchanged (still the selected-market `country` cookie).
- The Adobe Home redirect param shape is **unchanged** (stays `acomLocale=<region-prefix>` as on stage today). The `acomCountry` split lives in the shelved #6268.
- Non-Lingo locales are unchanged.

## Tests
- `test/utils/utils.test.js` — `getLingoRegion` with `useGeoLocation` now **ignores** the `international` cookie and resolves from geo (both the "diverges" and "no region" cases); the `loadIms` redirect test asserts geo wins over a divergent `international` cookie.
- `test/blocks/susi-light-login/susi-light-login.test.js` — sign-in widget locale follows geo, ignoring the `international` and market cookies.
- Full `npm test`: 3691 passed; the only failure is the known `fetchAndProcessPlainHtml with MEP` gnav network flake (fails identically on clean `stage`, unrelated to this change).

## Test URLs
- Before (stage): https://www.stage.adobe.com/fr/products/photoshop.html?martech=off&akamaiLocale=ch&country=ch
- After (branch): https://www.stage.adobe.com/fr/products/photoshop.html?martech=off&milolibs=vhargrave-lingo-drop-international-cookie&akamaiLocale=ch&country=ch

Steps to test: 
set your international cookie to lu_fr using the region picker in the footer for example and notice how it has no impact on the after url anymore. You'll be taken to https://www.stage.adobe.com/home?acomLocale=ch_fr instead of  https://www.stage.adobe.com/home?acomLocale=lu_fr

