### PR TITLE
MWPW-200813 Allow the csat 5pt form to be be viewed on narrower viewports without a scrollbar

### DIFF
--- a/libs/blocks/nps-csat-form/nps-csat-form.css
+++ b/libs/blocks/nps-csat-form/nps-csat-form.css
@@ -3,7 +3,6 @@
   padding: 32px;
   height: 404px;
   max-width: 576px;
-  width: 100%;
   margin: 0 auto;
 }
 


### PR DESCRIPTION


<!-- Before submitting, please review all open PRs. -->

* Removed the `width: 100%` rule from the main container

Resolves: [MWPW-200813](https://jira.corp.adobe.com/browse/MWPW-200813)

**Test URLs:**
- Before: 
  - https://main--milo--adobecom.aem.page/nps-csat/photoshop/ps-nps-csat-5
  - https://main--milo--adobecom.aem.page/nps-csat/express/express-nps-csat-5
- After: 
  - https://nps-csat-width--milo--adobecom.aem.page/nps-csat/photoshop/ps-nps-csat-5
  - https://nps-csat-width--milo--adobecom.aem.page/nps-csat/express/express-nps-csat-5


