### PR TITLE
Use body font for headings for Vietnamese

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -480,6 +480,11 @@
     --body-font-family: adobe-clean-thai, var(--body-font-family-base);
     --heading-font-family: var(--body-font-family);
   }
+
+  &:lang(vi-VN),
+  &:lang(vi) {
+    --heading-font-family: var(--body-font-family);
+  }
 }
 
 .dark {


### PR DESCRIPTION
Set the heading font family to the regular body one, to ensure headings use Adobe Clean, which has the character subsetting for Vietnamese. This is relevant to the Homepage ROW release.

Resolves: [MWPW-200856](https://jira.corp.adobe.com/browse/MWPW-200856)


