### PR TITLE
[MWPW-200944] Fix servicenow.yaml CI: remove defunct timedelta pip dependency

### DIFF
--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -45,7 +45,7 @@ jobs:
         python-version: "3.x"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip requests timedelta
+        python -m pip install --upgrade pip requests
 
     - name: Retrieve transaction ID from PR Comments
       id: retrieve-transactionId-step


### PR DESCRIPTION
### Description
The "Create CMR in ServiceNow" job in `.github/workflows/servicenow.yaml` has been failing on every PR since ~2026-07-07.

Root cause: the "Install dependencies" step runs `pip install --upgrade pip requests timedelta`. The third-party PyPI package `timedelta` (last released 2020-12-3, effectively abandoned) has since been removed from PyPI entirely (`pypi.org/pypi/timedelta/json` now returns 404), so pip fails to resolve it and the job exits before creating the CMR.

The dependency was always dead weight — `servicenow.py` only ever uses Python's stdlib `datetime.timedelta`, never the third-party package.

Fix: drop `timedelta` from the pip install line.

Resolves: [MWPW-200944](https://jira.corp.adobe.com/browse/MWPW-200944)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

