### PR TITLE
dc1198: subtitle min-height, promo-text spacing, two-line-subtitle support

### DIFF
--- a/libs/mep/dc1198/merch-card-combo/merch-card-combo.js
+++ b/libs/mep/dc1198/merch-card-combo/merch-card-combo.js
@@ -897,7 +897,7 @@ export default async function init(el) {
         style.textContent = `
           footer { padding-top: var(--consonant-merch-spacing-xxs, 8px) !important; }
           @media (min-width: 768px) {
-            slot[name="promo-text"] { min-height: 8px !important; }
+            slot[name="promo-text"] { min-height: var(--consonant-merch-spacing-xxxs, 4px) !important; }
           }
           .card-subtitle-injected {
             display: flex;
@@ -907,13 +907,14 @@ export default async function init(el) {
             font-weight: var(--consonant-merch-card-detail-m-font-weight, 700);
             font-style: normal;
             line-height: 1.5;
-            min-height: 42px;
+            min-height: 28px;
             padding: 0 var(--consonant-merch-spacing-s, 24px) 0 var(--consonant-merch-spacing-xs, 16px);
           }
           :host(.has-sparkle) .card-subtitle-injected { color: #c12f84; }
           :host(:not(.has-sparkle)) .card-subtitle-injected { color: #4b4b4b; }
           .card-subtitle-injected em { font-style: normal; }
           .card-subtitle-injected::before { padding-top: 3px; }
+          :host(.two-line-subtitle) .card-subtitle-injected { min-height: 42px; }
         `;
 
         const subtitleEl = merchCard.querySelector('.card-subtitle');


### PR DESCRIPTION
1. Reduce subtitle min-height from 42px to 28px for single-line subtitles
2. Add `two-line-subtitle` DA style to opt into 42px min-height for wrapping subtitles
3. Reduce `promo-text` min-height from 8px to 4px to tighten spacing on tablet/desktop

Resolves: [DC-1198](https://jira.corp.adobe.com/browse/DC-1198)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/acrobat/pricing/business?milolibs=main&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fdc1198%2Fdc1198.json--target-var1&martech=off
- After: https://main--da-dc--adobecom.aem.page/acrobat/pricing/business?milolibs=dc1198-3&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fdc1198%2Fdc1198.json--target-var1&martech=off

**Before Screenshot:**
<img width="369" height="337" alt="Screenshot 2026-07-16 at 2 16 26 PM" src="https://github.com/user-attachments/assets/198ff2cd-689d-4c2f-81d6-e6fcecf54eea" /> <img width="374" height="313" alt="Screenshot 2026-07-16 at 2 19 06 PM" src="https://github.com/user-attachments/assets/719ccabc-4941-471b-abb3-687332c5fe47" />



**After Screenshot:**

<img width="389" height="298" alt="image" src="https://github.com/user-attachments/assets/de2ed162-ff3e-4682-bcd8-2ca0350a0855" /> 
<img width="370" height="296" alt="image" src="https://github.com/user-attachments/assets/51000958-0bf4-4ead-aa7b-eed436fd95ba" />
