### PR TITLE
[Exceptional release] dc1198: fix shadow DOM styles and CSS styles for promo-text, subtitle alignment, and offers padding

### DIFF
--- a/libs/mep/dc1198/merch-card-combo/merch-card-combo.css
+++ b/libs/mep/dc1198/merch-card-combo/merch-card-combo.css
@@ -92,6 +92,7 @@ merch-card.merch-card-combo[variant="mini-compare-chart"].bullet-list [slot="bod
 /* UI: quantity selector row — side padding to align with card content */
 merch-card.merch-card-combo[variant="mini-compare-chart"].bullet-list [slot="offers"] {
   padding-inline: var(--consonant-merch-spacing-xs, 16px) !important;
+  padding-block: 0 !important;
 }
 
 /* UI: section wrapper that holds all cards side by side */

--- a/libs/mep/dc1198/merch-card-combo/merch-card-combo.js
+++ b/libs/mep/dc1198/merch-card-combo/merch-card-combo.js
@@ -896,24 +896,24 @@ export default async function init(el) {
         const style = document.createElement('style');
         style.textContent = `
           footer { padding-top: var(--consonant-merch-spacing-xxs, 8px) !important; }
-          slot[name="offers"] { padding-top: 0 !important; }
           @media (min-width: 768px) {
-            slot[name="promo-text"] { min-height: 48px !important; }
+            slot[name="promo-text"] { min-height: 8px !important; }
           }
           .card-subtitle-injected {
             display: flex;
-            align-items: center;
+            align-items: flex-start;
             gap: 6px;
             font-size: var(--consonant-merch-card-body-xs-font-size, 14px);
             font-weight: var(--consonant-merch-card-detail-m-font-weight, 700);
             font-style: normal;
             line-height: 1.5;
             min-height: 42px;
-            padding: 0 var(--consonant-merch-spacing-s, 24px) var(--consonant-merch-spacing-xxs, 8px) 12px;
+            padding: 0 var(--consonant-merch-spacing-s, 24px) 0 var(--consonant-merch-spacing-xs, 16px);
           }
           :host(.has-sparkle) .card-subtitle-injected { color: #c12f84; }
           :host(:not(.has-sparkle)) .card-subtitle-injected { color: #4b4b4b; }
           .card-subtitle-injected em { font-style: normal; }
+          .card-subtitle-injected::before { padding-top: 3px; }
         `;
 
         const subtitleEl = merchCard.querySelector('.card-subtitle');


### PR DESCRIPTION
1. Reduce `promo-text` min-height from 48px to 8px to collapse the empty gap on cards without promo text
2. Top-align sparkle subtitle (`flex-start`)
3. Add 3px top padding to sparkle icon for alignment
4. Increase sparkle subtitle left padding from 12px to 16px to align with card content
5. Remove bottom padding from the sparkle subtitle row
6. Remove top/bottom padding from the quantity selector slot

Resolves: [DC-1198](https://jira.corp.adobe.com/browse/DC-1198)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/acrobat/pricing/business?milolibs=main&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fdc1198%2Fdc1198.json--target-var1&martech=off
- After: https://main--da-dc--adobecom.aem.page/acrobat/pricing/business?milolibs=dc1198-2&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fdc1198%2Fdc1198.json--target-var1&martech=off

Before Screenshot: (Issues marked — all 6 cosmetic issues)
<img width="1558" height="854" alt="image" src="https://github.com/user-attachments/assets/fd0ee83a-3020-4740-bb44-1abce8b144cd" />

After Screenshot: (All 6 issues fixed as described above)
<img width="1428" height="726" alt="image" src="https://github.com/user-attachments/assets/d6ad2d58-ba5f-432a-a6bc-d04d33f5ef60" />

