### PR TITLE
[MWPW-200979] CMR Dependency GHA Fix

### DIFF
--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -9,7 +9,7 @@ on:
       - opened
       - closed
     branches:
-      - cmr-dependency-test
+      - main
 
 permissions:
   pull-requests: write
@@ -18,9 +18,9 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IMSACCESS_CLIENT_ID: ${{ secrets.IMSACCESS_CLIENT_ID }}
-  IMSACCESS_CLIENT_SECRET: ${{ secrets.IMSACCESS_CLIENT_SECRET_STAGE }}
-  IMSACCESS_AUTH_CODE: ${{ secrets.IMSACCESS_AUTH_CODE_STAGE }}
-  IPAAS_KEY: ${{ secrets.IPAAS_KEY_STAGE }}
+  IMSACCESS_CLIENT_SECRET: ${{ secrets.IMSACCESS_CLIENT_SECRET_PROD }}
+  IMSACCESS_AUTH_CODE: ${{ secrets.IMSACCESS_AUTH_CODE_PROD }}
+  IPAAS_KEY: ${{ secrets.IPAAS_KEY_PROD }}
   MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}
   PR_TITLE: ${{ github.event.pull_request.title }}
   PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -45,7 +45,7 @@ jobs:
         python-version: "3.x"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip requests timedelta
+        python -m pip install --upgrade pip requests
 
     - name: Retrieve transaction ID from PR Comments
       id: retrieve-transactionId-step

--- a/.github/workflows/servicenow.yaml
+++ b/.github/workflows/servicenow.yaml
@@ -9,7 +9,7 @@ on:
       - opened
       - closed
     branches:
-      - main
+      - cmr-dependency-test
 
 permissions:
   pull-requests: write
@@ -18,9 +18,9 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   IMSACCESS_CLIENT_ID: ${{ secrets.IMSACCESS_CLIENT_ID }}
-  IMSACCESS_CLIENT_SECRET: ${{ secrets.IMSACCESS_CLIENT_SECRET_PROD }}
-  IMSACCESS_AUTH_CODE: ${{ secrets.IMSACCESS_AUTH_CODE_PROD }}
-  IPAAS_KEY: ${{ secrets.IPAAS_KEY_PROD }}
+  IMSACCESS_CLIENT_SECRET: ${{ secrets.IMSACCESS_CLIENT_SECRET_STAGE }}
+  IMSACCESS_AUTH_CODE: ${{ secrets.IMSACCESS_AUTH_CODE_STAGE }}
+  IPAAS_KEY: ${{ secrets.IPAAS_KEY_STAGE }}
   MILO_RELEASE_SLACK_WH: ${{ secrets.MILO_RELEASE_SLACK_WH }}
   PR_TITLE: ${{ github.event.pull_request.title }}
   PR_BODY: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
* Removed timedelta from needed dependency installs since Python 3.14 no longer requires the 3rd party library, where the standard libs provide it.

Resolves: [MWPW-200979](https://jira.corp.adobe.com/browse/MWPW-200979)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-200979--milo--adobecom.aem.page/?martech=off
