### PR TITLE
[MWPW-199159] Lingo web performance: re-apply #6210 with iconography.css fix

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1026,17 +1026,22 @@ const getXLGListURL = (config) => {
 export const getEntitlementMap = async () => {
   const config = getConfig();
   if (config.mep?.entitlementMap) return config.mep.entitlementMap;
-  const entitlementUrl = getXLGListURL(config);
-  const fetchedData = await fetchData(entitlementUrl, DATA_TYPE.JSON, { redirect: 'error' });
-  if (!fetchedData) return config.consumerEntitlements || {};
-  const entitlements = {};
-  fetchedData?.data?.forEach((ent) => {
-    const { id, tagname } = ent;
-    entitlements[id] = tagname;
-  });
   config.mep ??= {};
-  config.mep.entitlementMap = { ...config.consumerEntitlements, ...entitlements };
-  return config.mep.entitlementMap;
+  if (config.mep.entitlementMapFetch) return config.mep.entitlementMapFetch;
+  config.mep.entitlementMapFetch = (async () => {
+    const entitlementUrl = getXLGListURL(config);
+    const fetchedData = await fetchData(entitlementUrl, DATA_TYPE.JSON, { redirect: 'error' });
+    if (!fetchedData) return config.consumerEntitlements || {};
+    const entitlements = {};
+    fetchedData?.data?.forEach((ent) => {
+      const { id, tagname } = ent;
+      entitlements[id] = tagname;
+    });
+    config.mep.entitlementMap = { ...config.consumerEntitlements, ...entitlements };
+    config.mep.entitlementMapFetch = null;
+    return config.mep.entitlementMap;
+  })();
+  return config.mep.entitlementMapFetch;
 };
 
 export const getEntitlements = async (data) => {
@@ -1435,22 +1440,19 @@ export async function applyPers({ manifests }) {
   let experiments = manifests;
   const config = getConfig();
 
-  for (let i = 0; i < experiments.length; i += 1) {
-    experiments[i] = await getManifestConfig(
-      experiments[i],
-      config.mep?.variantOverride,
-    );
-  }
+  experiments = await Promise.all(
+    experiments.map((exp) => getManifestConfig(exp, config.mep?.variantOverride)),
+  );
   experiments = cleanAndSortManifestList(experiments, config);
   parseNestedPlaceholders(config);
 
   let results = [];
 
-  for (const experiment of experiments) {
-    const result = await categorizeActions(experiment, config);
-    if (result) results.push(result);
-  }
-  results = results.filter(Boolean);
+  // Safe to parallelize only because categorizeActions has no internal awaits —
+  // adding one would break last-write-wins order for replacepage/updateframework.
+  results = (await Promise.all(
+    experiments.map((exp) => categorizeActions(exp, config)),
+  )).filter(Boolean);
 
   config.mep.experiments = [...config.mep.experiments, ...experiments];
   config.mep.blocks = consolidateObjects(results, 'blocks', config.mep.blocks);
@@ -1715,7 +1717,7 @@ export async function init(enablements = {}) {
       const normalizedURL = normalizePath(manifest.manifestPath);
       loadLink(normalizedURL, { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
     });
-    if (pzn || pznroc) loadLink(getXLGListURL(config), { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
+    if (pzn || pznroc) loadLink(normalizePath(getXLGListURL(config)), { as: 'fetch', crossorigin: 'anonymous', rel: 'preload' });
   }
   if (enablePersV2 && target === true) {
     manifests = manifests.concat(await handleMartechTargetInteraction(
@@ -1731,7 +1733,16 @@ export async function init(enablements = {}) {
   }
   try {
     if (manifests?.length) await applyPers({ manifests });
-    if (config.mep?.preview) await import('./preview.js').then(({ saveToMmm }) => saveToMmm());
+    if (config.mep?.preview) {
+      loadLink(`${config.base}/utils/market.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
+      // Flatten the preview.js → caas/utils.js → {lingo-active, getUuid} discovery chain
+      loadLink(`${config.base}/utils/lingo-active.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
+      loadLink(`${config.base}/utils/getUuid.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
+      import('./preview.js').then(({ saveToMmm }) => saveToMmm()).catch((e) => {
+        log(`MEP save error: ${e.toString()}`);
+        window.lana?.log(`MEP save error: ${e.toString()}`);
+      });
+    }
   } catch (e) {
     log(`MEP Error: ${e.toString()}`);
     window.lana?.log(`MEP Error: ${e.toString()}`);

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1031,12 +1031,7 @@ export const getEntitlementMap = async () => {
   config.mep.entitlementMapFetch = (async () => {
     const entitlementUrl = getXLGListURL(config);
     const fetchedData = await fetchData(entitlementUrl, DATA_TYPE.JSON, { redirect: 'error' });
-    if (!fetchedData) {
-      // Clear the in-flight handle so a transient fetch failure can be retried
-      // on a later call, instead of permanently memoizing the fallback.
-      config.mep.entitlementMapFetch = null;
-      return config.consumerEntitlements || {};
-    }
+    if (!fetchedData) return config.consumerEntitlements || {};
     const entitlements = {};
     fetchedData?.data?.forEach((ent) => {
       const { id, tagname } = ent;

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1031,7 +1031,12 @@ export const getEntitlementMap = async () => {
   config.mep.entitlementMapFetch = (async () => {
     const entitlementUrl = getXLGListURL(config);
     const fetchedData = await fetchData(entitlementUrl, DATA_TYPE.JSON, { redirect: 'error' });
-    if (!fetchedData) return config.consumerEntitlements || {};
+    if (!fetchedData) {
+      // Clear the in-flight handle so a transient fetch failure can be retried
+      // on a later call, instead of permanently memoizing the fallback.
+      config.mep.entitlementMapFetch = null;
+      return config.consumerEntitlements || {};
+    }
     const entitlements = {};
     fetchedData?.data?.forEach((ent) => {
       const { id, tagname } = ent;

--- a/libs/utils/geo.js
+++ b/libs/utils/geo.js
@@ -1,24 +1,43 @@
 /* eslint-disable no-console */
 
+const GEO_TIMEOUT_MS = 5000;
+
+// Shared in-flight promise so concurrent callers don't issue duplicate fetches.
+let inflight = null;
+
 /**
  * Gets the Akamai country code from the geo2.adobe.com service.
- * @returns {Promise<string|null>} A promise that resolves to the lowercase Akamai country code.
+ * Times out after GEO_TIMEOUT_MS and deduplicates concurrent calls.
+ * @returns {Promise<string>} Resolves to the lowercase country code.
  */
-export const getAkamaiCode = () => new Promise((resolve, reject) => {
-  /* c8 ignore next 5 */
-  fetch('https://geo2.adobe.com/json/', { cache: 'no-cache' }).then((resp) => {
+export const getAkamaiCode = () => {
+  /* c8 ignore next */
+  if (inflight) return inflight;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), GEO_TIMEOUT_MS);
+
+  /* c8 ignore next 15 */
+  inflight = fetch('https://geo2.adobe.com/json/', {
+    cache: 'no-cache',
+    signal: controller.signal,
+  }).then((resp) => {
     if (resp.ok) {
-      resp.json().then((data) => {
+      return resp.json().then((data) => {
         const code = data.country.toLowerCase();
         sessionStorage.setItem('akamai', code);
-        resolve(code);
+        return code;
       });
-    } else {
-      reject(new Error(`Something went wrong getting the akamai Code. Response status text: ${resp.statusText}`));
     }
+    throw new Error(`Something went wrong getting the akamai Code. Response status text: ${resp.statusText}`);
   }).catch((error) => {
-    reject(new Error(`Something went wrong getting the akamai Code. ${error.message}`));
+    throw new Error(`Something went wrong getting the akamai Code. ${error.message}`);
+  }).finally(() => {
+    clearTimeout(timeout);
+    inflight = null;
   });
-});
+
+  return inflight;
+};
 
 export default getAkamaiCode;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2681,8 +2681,10 @@ const preloadBlockResources = (blocks = []) => blocks.map((block) => {
   if (['marquee', 'hero-marquee'].includes(name)) {
     const { base } = getConfig();
     loadLink(`${base}/utils/decorate.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
-    loadLink(`${base}/styles/iconography.css`, { rel: 'preload', as: 'style' });
-    loadLink(`${base}/styles/breakpoint-theme.css`, { rel: 'preload', as: 'style' });
+    // Do NOT rel=preload iconography.css / breakpoint-theme.css here. They are
+    // applied later via loadStyle(), and loadLink() dedupes by href regardless
+    // of rel — a preload link shadows that loadStyle() so the stylesheet is
+    // fetched but never applied, breaking icons. (Caused the #6210 → #6267 revert.)
   }
   loadLink(`${blockPath}.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
   return hasStyles && new Promise((resolve) => { loadStyle(`${blockPath}.css`, resolve); });

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -677,14 +677,14 @@ function isLocalizedPath(path, locales) {
     || legacyLocalePath;
 }
 
-function processQueryIndexMap(link, domain) {
+function processQueryIndexMap(link, domain, fetchOptions = {}) {
   const result = {
     pathsRequest: null,
     requestResolved: false,
     domains: [domain],
   };
 
-  result.pathsRequest = fetch(`${link}?limit=30000`)
+  result.pathsRequest = fetch(`${link}?limit=30000`, fetchOptions)
     .then((response) => response.json())
     .then((json) => json.data?.map((d) => (d.path ?? d.Path)?.replace(/\.html$/, '')) ?? [])
     .catch((error) => {
@@ -744,19 +744,23 @@ async function loadQueryIndexes(prefix, links = []) {
   const host = window.location.hostname;
   const indexUrl = (pfx, sfx = suffix) => `${origin}${pfx}${contentRoot}/assets/lingo/query-index${sfx}.json`;
 
-  queryIndexes[siteId] = processQueryIndexMap(indexUrl(prefix), host);
+  const primaryUrl = indexUrl(prefix);
+  queryIndexes[siteId] = processQueryIndexMap(primaryUrl, host);
 
   const { base: localeBase, prefix: localePrefix } = config.locale;
   let basePfx = localePrefix ?? '';
   if (localeBase !== undefined) basePfx = localeBase ? `/${localeBase}` : '';
-  baseQueryIndex = processQueryIndexMap(indexUrl(basePfx, ''), host);
+  const baseUrl = indexUrl(basePfx, '');
+  baseQueryIndex = primaryUrl === baseUrl
+    ? queryIndexes[siteId]
+    : processQueryIndexMap(baseUrl, host);
 
   Promise.all([queryIndexes[siteId]?.pathsRequest, baseQueryIndex?.pathsRequest].filter(Boolean))
     .then(() => window.dispatchEvent(new CustomEvent(MILO_EVENTS.QUERY_INDEX_PRIMARY_LOADED)));
 
   lingoSiteMapping = (async () => {
     try {
-      const resp = await fetch(`${getFederatedContentRoot()}/federal/assets/data/lingo-site-mapping.json`);
+      const resp = await fetch(`${getFederatedContentRoot()}/federal/assets/data/lingo-site-mapping.json`, { priority: 'low' });
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const json = await resp.json();
       siteQueryIndexMapLingo = json['site-query-index-map']?.data ?? [];
@@ -770,6 +774,12 @@ async function loadQueryIndexes(prefix, links = []) {
           if (qi && !qi.domains.includes(existingDomain)) qi.domains.push(existingDomain);
         });
       }
+
+      // Wait for Wave 1 (primary + base) before firing cross-site indexes,
+      // so Wave 2 fetches don't compete for bandwidth during the LCP window.
+      await Promise.all(
+        [queryIndexes[siteId]?.pathsRequest, baseQueryIndex?.pathsRequest].filter(Boolean),
+      );
 
       siteQueryIndexMapLingo
         .filter((d) => d.uniqueSiteId !== siteId
@@ -785,7 +795,7 @@ async function loadQueryIndexes(prefix, links = []) {
             suffix,
             window.location.hostname,
           );
-          queryIndexes[uid] = processQueryIndexMap(url, prodDomain);
+          queryIndexes[uid] = processQueryIndexMap(url, prodDomain, { priority: 'low' });
           if (envHost !== prodDomain) queryIndexes[uid].domains.push(envHost);
         });
     } catch (e) {
@@ -1004,20 +1014,11 @@ export async function resolveDetectedMarketCountry() {
   if (isBot()) return null;
   const cookieMarket = getCookie('country');
   const countryFromGeo = await getCountry();
-  let detectedMarket = computeDetectedMarketCountry(
+  return computeDetectedMarketCountry(
     window.location.search,
     cookieMarket,
     countryFromGeo,
   );
-  if (!detectedMarket) {
-    try {
-      const { default: getAkamaiCode } = await import('./geo.js');
-      detectedMarket = normCountryCode(await getAkamaiCode());
-    } catch (error) {
-      window.lana?.log(`Error getting Akamai code: ${error}`, { severity: 'error' });
-    }
-  }
-  return detectedMarket;
 }
 
 export async function getLingoRegion({ useGeoLocation = false } = {}) {
@@ -2157,7 +2158,11 @@ async function checkForPageMods() {
   if (!(pzn || pznroc || target || promo || mepParam
     || mepHighlight || mepButton || mepParam === '' || xlg || ajo || mepMarketingDecrease)) return;
 
-  loadLink(`${getConfig().base}/martech/helpers.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+  const { base } = getConfig();
+  loadLink(`${base}/martech/helpers.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+  loadLink(`${base}/features/personalization/personalization.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
+  loadLink(`${base}/utils/sanitizeHtml.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
+  if (promo) loadLink(`${base}/features/personalization/promo-utils.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
 
   const promises = loadMepAddons();
   const akamaiCode = getMepEnablement('akamaiLocale') || await getCountry(true);
@@ -2674,7 +2679,10 @@ const preloadBlockResources = (blocks = []) => blocks.map((block) => {
   if (block.classList.contains('hide-block')) return null;
   const { blockPath, hasStyles, name } = getBlockData(block);
   if (['marquee', 'hero-marquee'].includes(name)) {
-    loadLink(`${getConfig().base}/utils/decorate.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+    const { base } = getConfig();
+    loadLink(`${base}/utils/decorate.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+    loadLink(`${base}/styles/iconography.css`, { rel: 'preload', as: 'style' });
+    loadLink(`${base}/styles/breakpoint-theme.css`, { rel: 'preload', as: 'style' });
   }
   loadLink(`${blockPath}.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
   return hasStyles && new Promise((resolve) => { loadStyle(`${blockPath}.css`, resolve); });
@@ -2768,15 +2776,19 @@ export async function loadArea(area = document) {
     await loadLanguageConfig();
   }
 
+  const htmlSections = [...area.querySelectorAll(isDoc ? 'body > main > div' : ':scope > div')];
+  htmlSections.forEach((section) => { section.className = 'section'; section.dataset.status = 'pending'; });
+
+  if (area.querySelector('a[href*="/fragments/"], a[data-mep-lingo-section-swap], a[data-mep-lingo-block-swap], a[href*="#_inline"]')) {
+    loadLink(`${config.base}/blocks/fragment/fragment.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
+  }
+
+  if (isLingoActive) loadLingoIndexes(area);
+
   if (isDoc) {
     await decorateDocumentExtras();
     initModalEventListener();
   }
-
-  const htmlSections = [...area.querySelectorAll(isDoc ? 'body > main > div' : ':scope > div')];
-  htmlSections.forEach((section) => { section.className = 'section'; section.dataset.status = 'pending'; });
-
-  if (isLingoActive) loadLingoIndexes(area);
 
   const areaBlocks = [];
   let lcpSectionId = null;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1174,7 +1174,10 @@ export function localizeLink(
 export function loadLink(href, {
   id, as, callback, crossorigin, rel, fetchpriority,
 } = {}) {
-  let link = document.head.querySelector(`link[href="${href}"]`);
+  const selector = rel === 'stylesheet'
+    ? `link[href="${href}"][rel="stylesheet"]`
+    : `link[href="${href}"]`;
+  let link = document.head.querySelector(selector);
   if (!link) {
     link = document.createElement('link');
     link.setAttribute('rel', rel);
@@ -2689,6 +2692,8 @@ const preloadBlockResources = (blocks = []) => blocks.map((block) => {
   if (['marquee', 'hero-marquee'].includes(name)) {
     const { base } = getConfig();
     loadLink(`${base}/utils/decorate.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+    loadLink(`${base}/styles/iconography.css`, { rel: 'preload', as: 'style' });
+    loadLink(`${base}/styles/breakpoint-theme.css`, { rel: 'preload', as: 'style' });
   }
   loadLink(`${blockPath}.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
   return hasStyles && new Promise((resolve) => { loadStyle(`${blockPath}.css`, resolve); });

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -794,14 +794,9 @@ async function loadQueryIndexes(prefix, links = []) {
         if (envHost !== prodDomain) queryIndexes[uid].domains.push(envHost);
       };
 
-      // Cross-site indexes flagged with fetchPriority are fetched first (at
-      // default priority) alongside Wave 1 (primary + base); the rest wait.
       const priorityEntries = crossSiteEntries.filter((d) => d.fetchPriority === 'yes');
       priorityEntries.forEach((d) => startCrossSiteIndex(d));
 
-      // Wait for the priority wave (Wave 1 + fetchPriority cross-site indexes)
-      // before firing the low-priority remainder, so those don't compete for
-      // bandwidth during the LCP window.
       await Promise.all([
         queryIndexes[siteId]?.pathsRequest,
         baseQueryIndex?.pathsRequest,
@@ -2694,10 +2689,6 @@ const preloadBlockResources = (blocks = []) => blocks.map((block) => {
   if (['marquee', 'hero-marquee'].includes(name)) {
     const { base } = getConfig();
     loadLink(`${base}/utils/decorate.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
-    // Do NOT rel=preload iconography.css / breakpoint-theme.css here. They are
-    // applied later via loadStyle(), and loadLink() dedupes by href regardless
-    // of rel — a preload link shadows that loadStyle() so the stylesheet is
-    // fetched but never applied, breaking icons. (Caused the #6210 → #6267 revert.)
   }
   loadLink(`${blockPath}.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
   return hasStyles && new Promise((resolve) => { loadStyle(`${blockPath}.css`, resolve); });

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -760,7 +760,7 @@ async function loadQueryIndexes(prefix, links = []) {
 
   lingoSiteMapping = (async () => {
     try {
-      const resp = await fetch(`${getFederatedContentRoot()}/federal/assets/data/lingo-site-mapping.json`, { priority: 'low' });
+      const resp = await fetch(`${getFederatedContentRoot()}/federal/assets/data/lingo-site-mapping.json`);
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const json = await resp.json();
       siteQueryIndexMapLingo = json['site-query-index-map']?.data ?? [];
@@ -775,29 +775,42 @@ async function loadQueryIndexes(prefix, links = []) {
         });
       }
 
-      // Wait for Wave 1 (primary + base) before firing cross-site indexes,
-      // so Wave 2 fetches don't compete for bandwidth during the LCP window.
-      await Promise.all(
-        [queryIndexes[siteId]?.pathsRequest, baseQueryIndex?.pathsRequest].filter(Boolean),
-      );
-
-      siteQueryIndexMapLingo
+      const crossSiteEntries = siteQueryIndexMapLingo
         .filter((d) => d.uniqueSiteId !== siteId
           && config.prodDomains?.includes(getDomainLingo(d.queryIndexWebPath)))
-        .forEach(({ uniqueSiteId: uid, queryIndexWebPath, stageHost }) => {
-          const hasRegional = localesData
-            .some((s) => s.uniqueSiteId === uid && parseList(s.regionalSites).includes(prefix));
-          if (!hasRegional) return;
-          const prodDomain = getDomainLingo(queryIndexWebPath);
-          const { url, host: envHost } = resolveCrossSiteIndex(
-            { queryIndexWebPath, stageHost },
-            prefix,
-            suffix,
-            window.location.hostname,
-          );
-          queryIndexes[uid] = processQueryIndexMap(url, prodDomain, { priority: 'low' });
-          if (envHost !== prodDomain) queryIndexes[uid].domains.push(envHost);
-        });
+        .filter(({ uniqueSiteId: uid }) => localesData
+          .some((s) => s.uniqueSiteId === uid && parseList(s.regionalSites).includes(prefix)));
+
+      const startCrossSiteIndex = (entry, fetchOptions = {}) => {
+        const { uniqueSiteId: uid, queryIndexWebPath, stageHost } = entry;
+        const prodDomain = getDomainLingo(queryIndexWebPath);
+        const { url, host: envHost } = resolveCrossSiteIndex(
+          { queryIndexWebPath, stageHost },
+          prefix,
+          suffix,
+          window.location.hostname,
+        );
+        queryIndexes[uid] = processQueryIndexMap(url, prodDomain, fetchOptions);
+        if (envHost !== prodDomain) queryIndexes[uid].domains.push(envHost);
+      };
+
+      // Cross-site indexes flagged with fetchPriority are fetched first (at
+      // default priority) alongside Wave 1 (primary + base); the rest wait.
+      const priorityEntries = crossSiteEntries.filter((d) => d.fetchPriority === 'yes');
+      priorityEntries.forEach((d) => startCrossSiteIndex(d));
+
+      // Wait for the priority wave (Wave 1 + fetchPriority cross-site indexes)
+      // before firing the low-priority remainder, so those don't compete for
+      // bandwidth during the LCP window.
+      await Promise.all([
+        queryIndexes[siteId]?.pathsRequest,
+        baseQueryIndex?.pathsRequest,
+        ...priorityEntries.map((d) => queryIndexes[d.uniqueSiteId]?.pathsRequest),
+      ].filter(Boolean));
+
+      crossSiteEntries
+        .filter((d) => d.fetchPriority !== 'yes')
+        .forEach((d) => startCrossSiteIndex(d, { priority: 'low' }));
     } catch (e) {
       window.lana?.log(`Failed to load lingo-site-mapping.json: ${e}`, { tags: 'utils', severity: 'error' });
     } finally {

--- a/test/features/personalization/personalization.test.js
+++ b/test/features/personalization/personalization.test.js
@@ -6,7 +6,7 @@ import { getConfig, setConfig } from '../../../libs/utils/utils.js';
 import {
   handleFragmentCommand, applyPers, cleanAndSortManifestList, normalizePath,
   init, matchGlob, createContent, combineMepSources, buildVariantInfo, addSectionAnchors,
-  isTrustedUrl, fetchData, DATA_TYPE,
+  isTrustedUrl, fetchData, DATA_TYPE, categorizeActions,
 } from '../../../libs/features/personalization/personalization.js';
 import mepSettings from './mepSettings.js';
 import mepSettingsPreview from './mepPreviewSettings.js';
@@ -929,5 +929,43 @@ describe('analyticifseen', () => {
     expect(window._satellite.track.calledOnce).to.be.true;
     const [, payload] = window._satellite.track.firstCall.args;
     expect(payload.xdm.web.webInteraction.name).to.equal('my-marquee-tracking was seen');
+  });
+});
+
+describe('categorizeActions ordering (parallelization-safe)', () => {
+  const mkExp = (name, page, fw) => ({
+    manifestPath: `/m-${name}.json`,
+    selectedVariant: {
+      name,
+      replacepage: page ? [{ val: page }] : undefined,
+      updateframework: fw ? [fw] : undefined,
+    },
+  });
+
+  it('applies the later experiment replacepage/updateframework (last write wins)', async () => {
+    const config = getConfig();
+    config.mep = { ...(config.mep || {}) };
+    delete config.mep.replacepage;
+    delete config.mep.updateframework;
+
+    // applyPers runs categorizeActions via Promise.all(experiments.map(...)).
+    // categorizeActions has no internal awaits, so .map invokes each body
+    // synchronously in execution order and the last manifest's writes win —
+    // identical to the old sequential loop. Pin that observable contract.
+    const experiments = [mkExp('a', '/page-a', 'fw-a'), mkExp('b', '/page-b', 'fw-b')];
+    await Promise.all(experiments.map((exp) => categorizeActions(exp, config)));
+
+    expect(config.mep.replacepage).to.deep.equal({ val: '/page-b' });
+    expect(config.mep.updateframework).to.equal('fw-b');
+  });
+
+  it('returns { experiment } for a default variant without touching shared config', async () => {
+    const config = getConfig();
+    config.mep = { ...(config.mep || {}) };
+    delete config.mep.replacepage;
+    const experiment = { manifestPath: '/d.json', selectedVariant: 'default' };
+    const result = await categorizeActions(experiment, config);
+    expect(result).to.deep.equal({ experiment });
+    expect(config.mep.replacepage).to.be.undefined;
   });
 });

--- a/test/utils/geo.test.js
+++ b/test/utils/geo.test.js
@@ -1,0 +1,82 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+
+const { getAkamaiCode } = await import('../../libs/utils/geo.js');
+
+describe('getAkamaiCode (geo.js)', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(window, 'fetch');
+    sessionStorage.removeItem('akamai');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    sessionStorage.removeItem('akamai');
+  });
+
+  const okRes = (country) => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ country }),
+  });
+
+  it('resolves the lowercased country code and caches it in sessionStorage', async () => {
+    fetchStub.returns(okRes('US'));
+    const code = await getAkamaiCode();
+    expect(code).to.equal('us');
+    expect(sessionStorage.getItem('akamai')).to.equal('us');
+    expect(fetchStub.calledOnceWith('https://geo2.adobe.com/json/')).to.be.true;
+  });
+
+  it('deduplicates concurrent callers into a single in-flight fetch', async () => {
+    let resolveFetch;
+    fetchStub.returns(new Promise((res) => { resolveFetch = res; }));
+    const p1 = getAkamaiCode();
+    const p2 = getAkamaiCode();
+    // Both callers share the same in-flight promise; only one fetch is issued.
+    expect(p1).to.equal(p2);
+    expect(fetchStub.callCount).to.equal(1);
+    resolveFetch({ ok: true, json: () => Promise.resolve({ country: 'DE' }) });
+    const [c1, c2] = await Promise.all([p1, p2]);
+    expect(c1).to.equal('de');
+    expect(c2).to.equal('de');
+  });
+
+  it('re-fetches after a failed call instead of memoizing the failure', async () => {
+    fetchStub.onCall(0).returns(Promise.reject(new Error('network down')));
+    fetchStub.onCall(1).returns(okRes('FR'));
+
+    let firstErr;
+    try { await getAkamaiCode(); } catch (e) { firstErr = e; }
+    expect(firstErr).to.be.an('error');
+
+    // The in-flight handle is cleared in finally(), so the next call re-fetches.
+    const code = await getAkamaiCode();
+    expect(code).to.equal('fr');
+    expect(fetchStub.callCount).to.equal(2);
+  });
+
+  it('rejects when the response is not ok', async () => {
+    fetchStub.returns(Promise.resolve({ ok: false, statusText: 'Service Unavailable' }));
+    let err;
+    try { await getAkamaiCode(); } catch (e) { err = e; }
+    expect(err).to.be.an('error');
+    expect(err.message).to.include('akamai Code');
+  });
+
+  it('aborts after the 5s timeout and rejects', async () => {
+    const clock = sinon.useFakeTimers();
+    fetchStub.callsFake((url, opts) => new Promise((_, reject) => {
+      opts.signal.addEventListener('abort', () => {
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      });
+    }));
+    const p = getAkamaiCode();
+    clock.tick(5000);
+    let err;
+    try { await p; } catch (e) { err = e; }
+    expect(err).to.be.an('error');
+    clock.restore();
+  });
+});

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2030,6 +2030,86 @@ describe('Utils', () => {
       expect(anchors[2].href).to.include('/ch_de/creativecloud/features');
       anchors.forEach((a) => a.remove());
     });
+
+    it('fetches fetchPriority-flagged cross-site indexes before the low-priority remainder', async () => {
+      // `dc` is flagged fetchPriority: 'yes'; `da-bacom` is not. The flagged
+      // entry must be fetched in the priority wave (before the barrier, at
+      // default priority), while the rest are deferred at { priority: 'low' }.
+      const priorityMapping = {
+        'site-locales': lingoSiteMapping['site-locales'],
+        'site-query-index-map': {
+          data: [
+            {
+              uniqueSiteId: 'cc',
+              queryIndexWebPath: 'www.adobe.com/*/cc-shared/assets/lingo/query-index.json',
+            },
+            {
+              uniqueSiteId: 'dc',
+              queryIndexWebPath: 'www.adobe.com/*/dc-shared/assets/lingo/query-index.json',
+              fetchPriority: 'yes',
+            },
+            {
+              uniqueSiteId: 'da-bacom',
+              queryIndexWebPath: 'business.adobe.com/*/assets/lingo/query-index.json',
+            },
+          ],
+        },
+      };
+
+      fetchStub.callsFake((url) => {
+        if (url.includes('lingo-site-mapping')) {
+          return mockRes({ payload: priorityMapping });
+        }
+        if (url.includes('cc-shared') && url.includes('/ch_de/')) {
+          return mockRes({ payload: createQueryIndexData(['/ch_de/creativecloud/product']) });
+        }
+        if (url.includes('cc-shared') && url.includes('/de/')) {
+          return mockRes({ payload: ccBaseQueryIndex });
+        }
+        if (url.includes('dc-shared')) {
+          return mockRes({ payload: dcRegionalQueryIndex });
+        }
+        if (url.includes('business.adobe.com')) {
+          return mockRes({ payload: daBacomRegionalQueryIndex });
+        }
+        return mockRes({ payload: { data: [] } });
+      });
+
+      const allLoaded = new Promise((resolve) => {
+        const evt = lingoUtils.MILO_EVENTS.QUERY_INDEX_ALL_LOADED;
+        window.addEventListener(evt, resolve, { once: true });
+      });
+      const a = document.createElement('a');
+      a.href = 'https://www.adobe.com/creativecloud/product';
+      document.body.appendChild(a);
+      a.href = await lingoUtils.localizeLinkAsync(
+        'https://www.adobe.com/creativecloud/product',
+        'www.adobe.com',
+        false,
+        a,
+      );
+      await allLoaded;
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+      const calls = fetchStub.getCalls();
+      const dcIdx = calls.findIndex((c) => c.args[0].includes('dc-shared'));
+      const daBacomIdx = calls.findIndex(
+        (c) => c.args[0].includes('business.adobe.com') && c.args[0].includes('/ch_de/'),
+      );
+
+      // Both cross-site indexes were fetched.
+      expect(dcIdx).to.be.greaterThan(-1);
+      expect(daBacomIdx).to.be.greaterThan(-1);
+      // The flagged (`dc`) index is issued before the barrier resolves — i.e.
+      // before the low-priority remainder (`da-bacom`) is even requested.
+      expect(dcIdx).to.be.lessThan(daBacomIdx);
+      // Flagged entry fetched with no explicit priority hint (default);
+      // the remainder is deferred at low priority.
+      expect(calls[dcIdx].args[1]?.priority).to.be.undefined;
+      expect(calls[daBacomIdx].args[1]?.priority).to.equal('low');
+
+      a.remove();
+    });
   });
 
   describe('resolveCrossSiteIndex', () => {

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -1542,6 +1542,35 @@ describe('Utils', () => {
     });
   });
 
+  describe('loadLink stylesheet dedup', () => {
+    afterEach(() => {
+      document.head.querySelectorAll('link[data-milo-preload-test]').forEach((l) => l.remove());
+    });
+
+    it('loadStyle applies a stylesheet even when a preload for the same href exists', () => {
+      const href = 'data:text/css,x';
+      const preload = utils.loadLink(href, { rel: 'preload', as: 'style' });
+      preload.setAttribute('data-milo-preload-test', '');
+
+      let cbType;
+      const styleLink = utils.loadStyle(href, (type) => { cbType = type; });
+      styleLink.setAttribute('data-milo-preload-test', '');
+
+      // The preload must not shadow the stylesheet: a distinct rel=stylesheet
+      // link is created so the CSS actually applies (the #6210 icon regression).
+      expect(styleLink).to.not.equal(preload);
+      expect(styleLink.getAttribute('rel')).to.equal('stylesheet');
+      expect(preload.getAttribute('rel')).to.equal('preload');
+      expect(document.head.querySelectorAll(`link[href="${href}"]`).length).to.equal(2);
+
+      // A second loadStyle dedups against the stylesheet: no duplicate, noop callback.
+      const again = utils.loadStyle(href, (type) => { cbType = type; });
+      expect(again).to.equal(styleLink);
+      expect(cbType).to.equal('noop');
+      expect(document.head.querySelectorAll(`link[href="${href}"][rel="stylesheet"]`).length).to.equal(1);
+    });
+  });
+
   describe('Lingo Link Transformation', () => {
     let originalFetch;
     let fetchStub;


### PR DESCRIPTION
Re-applies the reverted Lingo web-performance PR #6210, with the iconography regression that caused the revert fixed at the root cause.

## Background
#6210 (_perf: improve lingo performance — personalization, geo, lingo, XLG_) was merged to `stage` and reverted ~3h later by #6267 because `iconography.css` stopped being applied — icons broke on almost all stage pages ([milo-dev thread](https://adobe-mwp.slack.com/archives/C03HAU5SU2E/p1783598532069229)). This PR restores #6210 and fixes that regression properly.

## Root cause of the icon regression
`loadLink()` (`libs/utils/utils.js`) deduped existing links by `href` **alone**, ignoring `rel`. #6210 added `rel=preload, as=style` hints for `iconography.css` and `breakpoint-theme.css` in `preloadBlockResources()` (for `marquee`/`hero-marquee`). Those stylesheets are applied later via `loadStyle()` (hero-marquee, notification, editorial-card, aside). Because a `<link>` with that href already existed (the preload), the later `loadStyle()` → `loadLink()` found it and no-oped instead of creating the applying `rel=stylesheet` link — so the CSS downloaded but was never applied.

## Changes
<details>
<summary>more details</summary>

- **Re-apply #6210 in full**, including the two CSS preloads — clean revert-of-the-revert onto current `stage`. All personalization / geo / lingo / XLG optimizations preserved unchanged.
- **fix (root cause): make `loadLink()` rel-aware.** A `rel=stylesheet` request now dedups only against an existing **stylesheet** link, so a preload no longer shadows the `loadStyle()`. The block's `loadStyle()` creates a fresh `<link rel=stylesheet>` (fires `load` reliably in every engine — no rel-swap, no dependency on preload `load` semantics) that reuses the preloaded bytes via HTTP cache — the canonical `preload → stylesheet` pattern ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload)). Non-stylesheet `rel` requests keep href-only dedup, unchanged. This keeps Okan's non-render-blocking early fetch *and* applies the CSS — rather than discarding the optimization.
- **perf:** priority-aware Lingo query-index loading. Wave 1 (primary + base) and any cross-site index flagged `fetchPriority` in `lingo-site-mapping.json` (today only `upp`) are fetched first; the remaining cross-site indexes wait behind a barrier and then fetch at `{ priority: 'low' }` so they don't compete during the LCP window. `lingo-site-mapping.json` itself fetches at default priority so the flagged indexes are discovered promptly.

</details>

## Design note (why the root-cause fix, not a rel-swap)
<details>
<summary>more details</summary>

An alternative — swap the preload link's `rel` to `stylesheet` on load — was designed and rejected after a devil's-advocate review: it depends on `rel=preload as=style` firing `load` in every engine (unverified on Safari/WebKit; our suite is Chromium-only), and if it doesn't, the awaited `loadStyle` callback can never fire → block decoration **hangs** (worse than the bug). The rel-aware-dedup fix has no such dependency: worst case is a benign double-fetch (perf, not correctness); icons always apply. Cross-repo audit: no adobecom consumer preloads a CSS URL then `loadStyle`s it, so the shared-fn change is behavior-preserving for every non-broken caller.

</details>




## Verification
- **Tests:** full `test/**` run green (3702 passed at last full run; the sole failure is a **pre-existing floating-promise flake** — `fetchAndProcessPlainHtml with MEP`, `utilities.test.js:42`, asserts inside a non-awaited `.then()`, proven non-deterministic by isolation and outside the CSS/`loadLink` path). New/added coverage for every risk-bearing change: the `loadLink` preload-dedup fix (a `loadStyle` for a preloaded href creates a distinct applying stylesheet, not shadowed), the `fetchPriority: "yes"` query-index branch, `geo.js` `getAkamaiCode` (concurrent-caller dedup, post-failure re-fetch, 5s abort→reject), and `categorizeActions` last-write-wins ordering under `Promise.all`. Lint clean.
- **Visual / DOM** — da-cc `/creativecloud`, `?milolibs=main` vs `?milolibs=MWPW-199159`, confirmed on this build: the branch shows `iconography.css` and `breakpoint-theme.css` each as **two links — a `rel=preload as=style` (not applied) plus an applied `rel=stylesheet` (`link.sheet` non-null)** — the canonical preload→stylesheet pair; main has the single applied stylesheet. **0 unstyled icons on both** (9 visible icons each). Confirms the preload optimization is preserved *and* the CSS applies.
- Did a test on https://main--da-cc--adobecom.aem.live/fr/creativecloud to ensure the query indexes still loaded , but in a different order. Looked great. 

Resolves: [MWPW-199159](https://jira.corp.adobe.com/browse/MWPW-199159)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-199159--milo--adobecom.aem.page/?martech=off

**Icon / perf comparison (consumer page):**
- Before: https://main--da-cc--adobecom.aem.live/creativecloud?milolibs=main
- After: https://main--da-cc--adobecom.aem.live/creativecloud?milolibs=MWPW-199159
