### PR TITLE
[MWPW-200996] Use Adobe Clean for headings for Hebrew

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -482,7 +482,8 @@
   }
 
   &:lang(vi-VN),
-  &:lang(vi) {
+  &:lang(vi),
+  &:lang(he) {
     --heading-font-family: var(--body-font-family);
   }
 }


### PR DESCRIPTION
Forces Adobe Clean to be used for headings on Hebrew pages, instead of Adobe Clean Display, which isn't available for non-latin-character languages.

Resolves: [MWPW-200996](https://jira.corp.adobe.com/browse/MWPW-200996)

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/il_he/homepage/drafts/msale/2026/sr/06-18-sr-ff-ps-index-loggedout
- After: https://main--upp--adobecom.aem.page/il_he/homepage/drafts/msale/2026/sr/06-18-sr-ff-ps-index-loggedout?milolibs=hp-hebrew-font


