### PR TITLE
fix(modal): don't force focus ring on CTA when modal opened by mouse click

### DIFF
--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -205,17 +205,12 @@ export async function getModal(details, custom) {
   if (isConfirmedTrigger) {
     document.activeElement.dataset.isModalTrigger = 'true';
   }
-  // Default to a visible focus ring on the modal's initial focus target — the safe
-  // fallback for deep links, delayed/auto-shown modals, and any open with no confirmed
-  // trigger click, so keyboard/AT users never lose their focus indicator. Only suppress
-  // it when the confirmed trigger for this modal was itself reached by mouse/pointer
-  // (i.e. doesn't match :focus-visible), which is the reported bug.
   let openedViaKeyboard = true;
   if (isConfirmedTrigger) {
     try {
       openedViaKeyboard = document.activeElement.matches(':focus-visible');
     } catch (e) {
-      // :focus-visible unsupported in matches() — keep the safe default
+      openedViaKeyboard = true;
     }
   }
 

--- a/libs/blocks/modal/modal.js
+++ b/libs/blocks/modal/modal.js
@@ -200,11 +200,23 @@ export async function getModal(details, custom) {
   const { id, deepLink } = details || custom;
   if (id !== LOCALE_MODAL_ID) isDeepLink = deepLink;
   const activeElementData = document.activeElement.dataset;
-  if (!isDeepLink
-    && (activeElementData.modalHash === `#${id}`
-    || activeElementData.modalId === id)
-  ) {
+  const isConfirmedTrigger = !isDeepLink
+    && (activeElementData.modalHash === `#${id}` || activeElementData.modalId === id);
+  if (isConfirmedTrigger) {
     document.activeElement.dataset.isModalTrigger = 'true';
+  }
+  // Default to a visible focus ring on the modal's initial focus target — the safe
+  // fallback for deep links, delayed/auto-shown modals, and any open with no confirmed
+  // trigger click, so keyboard/AT users never lose their focus indicator. Only suppress
+  // it when the confirmed trigger for this modal was itself reached by mouse/pointer
+  // (i.e. doesn't match :focus-visible), which is the reported bug.
+  let openedViaKeyboard = true;
+  if (isConfirmedTrigger) {
+    try {
+      openedViaKeyboard = document.activeElement.matches(':focus-visible');
+    } catch (e) {
+      // :focus-visible unsupported in matches() — keep the safe default
+    }
   }
 
   dialogLoadingSet.add(id);
@@ -279,7 +291,7 @@ export async function getModal(details, custom) {
   dialog.append(focusPlaceholder);
   document.body.append(dialog);
   dialogLoadingSet.delete(id);
-  firstFocusable?.focus({ preventScroll: true, ...focusVisible });
+  firstFocusable?.focus({ preventScroll: true, focusVisible: openedViaKeyboard });
   window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {

--- a/test/blocks/modals/modals.test.js
+++ b/test/blocks/modals/modals.test.js
@@ -168,6 +168,57 @@ describe('Modals', () => {
     expect(document.getElementById('milo')).not.to.exist;
   });
 
+  it('shows a focus ring on the initial focus target when the confirmed trigger was reached via keyboard', async () => {
+    sinon.stub(Element.prototype, 'matches').callThrough().withArgs(':focus-visible').returns(true);
+    const focusSpy = sinon.spy(HTMLElement.prototype, 'focus');
+
+    document.getElementById('milo-modal-link').focus();
+    window.location.hash = '#milo';
+    await waitForElement('#milo');
+    await delay(100);
+
+    const initialFocusCall = focusSpy.getCalls().find((call) => call.thisValue.id === 'milo-button-1');
+    expect(initialFocusCall).to.exist;
+    expect(initialFocusCall.args[0]).to.include({ focusVisible: true });
+
+    window.location.hash = '';
+    await waitForRemoval('#milo');
+  });
+
+  it('does not force a focus ring on the initial focus target when the confirmed trigger was reached via mouse', async () => {
+    sinon.stub(Element.prototype, 'matches').callThrough().withArgs(':focus-visible').returns(false);
+    const focusSpy = sinon.spy(HTMLElement.prototype, 'focus');
+
+    document.getElementById('milo-modal-link').focus();
+    window.location.hash = '#milo';
+    await waitForElement('#milo');
+    await delay(100);
+
+    const initialFocusCall = focusSpy.getCalls().find((call) => call.thisValue.id === 'milo-button-1');
+    expect(initialFocusCall).to.exist;
+    expect(initialFocusCall.args[0]).to.include({ focusVisible: false });
+
+    window.location.hash = '';
+    await waitForRemoval('#milo');
+  });
+
+  it('defaults to showing a focus ring when there is no confirmed trigger element (e.g. deep link or auto-shown modal)', async () => {
+    sinon.stub(Element.prototype, 'matches').callThrough().withArgs(':focus-visible').returns(false);
+    const focusSpy = sinon.spy(HTMLElement.prototype, 'focus');
+
+    document.activeElement?.blur?.();
+    window.location.hash = '#milo';
+    await waitForElement('#milo');
+    await delay(100);
+
+    const initialFocusCall = focusSpy.getCalls().find((call) => call.thisValue.id === 'milo-button-1');
+    expect(initialFocusCall).to.exist;
+    expect(initialFocusCall.args[0]).to.include({ focusVisible: true });
+
+    window.location.hash = '';
+    await waitForRemoval('#milo');
+  });
+
   it('Focuses on close when there are no other focusables', async () => {
     const meta = document.createElement('meta');
     meta.name = '-paragraph';


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

- Fixes an unwanted blue focus ring appearing on modal CTAs (e.g. a video modal's "Watch full session" button) when the modal is opened by a mouse click. `getModal()` in `libs/blocks/modal/modal.js` was unconditionally calling the initial focus with `focusVisible: true`, forcing the ring regardless of input modality — browser support differences for that focus option explain why only ~50% of users saw it.
- The ring is now only suppressed when the *confirmed* trigger for this modal (the element already tracked via `data-modal-hash`/`data-modal-id`) was itself activated via mouse/pointer (i.e. doesn't match `:focus-visible`). Deep links, delayed/auto-shown modals, and any open with no confirmed trigger element keep the ring visible by default, so keyboard and assistive-technology users never lose their focus indicator.
- Added unit tests in `test/blocks/modals/modals.test.js` covering the keyboard-trigger, mouse-trigger, and no-confirmed-trigger (deep-link/auto-shown) cases.
- Scope: only the shared `libs/blocks/modal/modal.js` implementation was changed; the C2 and MEP-experiment copies of the modal were intentionally left untouched.

Resolves: [MWPW-194884](https://jira.corp.adobe.com/browse/MWPW-194884)

**Test URLs:**
- Before: https://main--da-events--adobecom.aem.page/events
- After: https://main--da-events--adobecom.aem.page/events?milolibs=fix-modal-focus-visible-mouse-click


