### PR TITLE
BRANDCON-7710: Bc susi modal close btn

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -444,6 +444,11 @@
   letter-spacing: -2%;
 }
 
+  .dialog-modal.bc-susi-modal button.dialog-close {
+    right: 12px;
+    top: 12px;
+  }
+
 /* hero */
 .brand-concierge.hero {
   padding: 40px 24px 12px;

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -444,10 +444,10 @@
   letter-spacing: -2%;
 }
 
-  .dialog-modal.bc-susi-modal button.dialog-close {
-    right: 12px;
-    top: 12px;
-  }
+.dialog-modal.bc-susi-modal button.dialog-close {
+  right: 12px;
+  top: 12px;
+}
 
 /* hero */
 .brand-concierge.hero {

--- a/libs/c2/blocks/brand-concierge/brand-concierge.css
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.css
@@ -444,6 +444,11 @@
   letter-spacing: -2%;
 }
 
+.dialog-modal.bc-susi-modal button.dialog-close {
+  right: 12px;
+  top: 12px;
+}
+
 /* hero */
 .brand-concierge.hero {
   padding: 40px 24px 12px;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adjusts Susi modal close button for BC specific needs. S2A custom vars were causing a collision on some devices. 

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bc-susi-modal-close-btn--milo--adobecom.aem.page/?martech=off

Actual Test Page:
https://www.stage.adobe.com/?milolibs=bc-susi-modal-close-btn 

Window size needs to be reduced to 346 to see the fix. Issue was only occurring on single device. 


