### PR TITLE
[sr] Mobile bento support

### DIFF
--- a/libs/deps/bento-stack.js
+++ b/libs/deps/bento-stack.js
@@ -1,0 +1,75 @@
+const MOBILE = '(max-width: 767px)';
+
+export function getCards(section) {
+  return [...section.querySelectorAll(':scope > .explore-card')];
+}
+
+// Natural-height element per card: the content box is not slot-height-locked
+// so reading its offsetHeight is transform-agnostic and loop-free to observe.
+function naturalEl(card) {
+  return card.querySelector('.explore-card-content') || card;
+}
+
+export function maxCardHeight(cards) {
+  return cards.reduce((max, card) => Math.max(max, naturalEl(card).offsetHeight), 0);
+}
+
+function setIndices(section, cards) {
+  section.style.setProperty('--slides', cards.length);
+  cards.forEach((card, i) => card.style.setProperty('--card-idx', i));
+}
+
+function measure(section, cards) {
+  // Clear the imposed height first so offsetHeight reads each card's NATURAL height.
+  // Without this, the slot-locked content would report the previously-set --card-height,
+  // so the value could only grow and never shrink on widen/reflow. The offsetHeight read
+  // below forces a synchronous reflow, so the natural value is current.
+  section.style.removeProperty('--card-height');
+  const max = maxCardHeight(cards);
+  if (max) section.style.setProperty('--card-height', `${Math.round(max)}px`);
+
+  const title = section.querySelector(':scope > .rich-content');
+  if (title) section.style.setProperty('--title-height', `${Math.round(title.offsetHeight)}px`);
+
+  const gnav = document.querySelector('header.global-navigation nav');
+  const bottom = gnav?.getBoundingClientRect().bottom;
+  if (bottom > 0) section.style.setProperty('--gnav-offset', `${Math.round(bottom)}px`);
+}
+
+function clearMeasurements(section) {
+  section.style.removeProperty('--card-height');
+  section.style.removeProperty('--title-height');
+  section.style.removeProperty('--gnav-offset');
+}
+
+export default function initBentoStack(section) {
+  const cards = getCards(section);
+  if (!cards.length) return;
+  setIndices(section, cards);
+  // Gate the stacking CSS on JS readiness: if this module fails to load/run,
+  // the class is never added and the bento degrades to its normal static layout
+  section.classList.add('bento-stack-ready');
+
+  const mq = window.matchMedia(MOBILE);
+  let frame = 0;
+  let measuring = false;
+  const update = () => {
+    // (clearing/setting --card-height resizes the observed content).
+    if (measuring) return;
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => {
+      measuring = true;
+      if (mq.matches) measure(section, cards);
+      else clearMeasurements(section);
+      requestAnimationFrame(() => { measuring = false; });
+    });
+  };
+
+  update();
+
+  const ro = new ResizeObserver(update);
+  cards.forEach((card) => ro.observe(naturalEl(card)));
+  const title = section.querySelector(':scope > .rich-content');
+  if (title) ro.observe(title);
+  mq.addEventListener('change', update);
+}

--- a/libs/deps/bento-stack.js
+++ b/libs/deps/bento-stack.js
@@ -21,9 +21,7 @@ function setIndices(section, cards) {
 
 function measure(section, cards) {
   // Clear the imposed height first so offsetHeight reads each card's NATURAL height.
-  // Without this, the slot-locked content would report the previously-set --card-height,
-  // so the value could only grow and never shrink on widen/reflow. The offsetHeight read
-  // below forces a synchronous reflow, so the natural value is current.
+  // The offsetHeight read below forces a synchronous reflow, so the natural value is current.
   section.style.removeProperty('--card-height');
   const max = maxCardHeight(cards);
   if (max) section.style.setProperty('--card-height', `${Math.round(max)}px`);
@@ -46,8 +44,8 @@ export default function initBentoStack(section) {
   const cards = getCards(section);
   if (!cards.length) return;
   setIndices(section, cards);
-  // Gate the stacking CSS on JS readiness: if this module fails to load/run,
-  // the class is never added and the bento degrades to its normal static layout
+  // If this module fails to load/run, the class is never added and the
+  // bento degrades to its normal static layout
   section.classList.add('bento-stack-ready');
 
   const mq = window.matchMedia(MOBILE);

--- a/libs/features/bento-stack.js
+++ b/libs/features/bento-stack.js
@@ -40,43 +40,62 @@ function clearMeasurements(section) {
   section.style.removeProperty('--gnav-offset');
 }
 
+export function contentReady(cards) {
+  return cards.every((card) => card.querySelector('.explore-card-content'));
+}
+
+// Sibling blocks (e.g. explore-card) decorate in parallel with this module's own
+// (lazy-imported) load, so a card's content wrapper may not exist yet on first run —
+// wait for it (bounded, so a malformed card can't stall the feature forever) rather
+// than measuring the raw, undecorated card and locking that height in permanently.
+export function whenReady(cards, cb, deadline = performance.now() + 1000) {
+  if (contentReady(cards) || performance.now() >= deadline) {
+    cb();
+    return;
+  }
+  requestAnimationFrame(() => whenReady(cards, cb, deadline));
+}
+
 export default function initBentoStack(section) {
   const cards = getCards(section);
-  if (!cards.length) return;
-  setIndices(section, cards);
-  // If this module fails to load/run, the class is never added and the
-  // bento degrades to its normal static layout
-  section.classList.add('bento-stack-ready');
+  if (!cards.length || section.classList.contains('bento-stack-ready')) return;
 
-  const mq = window.matchMedia(MOBILE);
-  let frame = 0;
-  let measuring = false;
-  let ro;
-  const update = () => {
-    // Self-heal: an MEP replaceInner() can detach this section and re-init on a
-    // fresh one. Drop the orphaned observer + listener so they neither pin the
-    // detached nodes nor keep firing on a dead section.
-    if (!section.isConnected) {
-      ro?.disconnect();
-      mq.removeEventListener('change', update);
-      return;
-    }
-    // (clearing/setting --card-height resizes the observed content).
-    if (measuring) return;
-    cancelAnimationFrame(frame);
-    frame = requestAnimationFrame(() => {
-      measuring = true;
-      if (mq.matches) measure(section, cards);
-      else clearMeasurements(section);
-      requestAnimationFrame(() => { measuring = false; });
-    });
-  };
+  whenReady(cards, () => {
+    setIndices(section, cards);
+    // If this module fails to load/run, the class is never added and the
+    // bento degrades to its normal static layout
+    section.classList.add('bento-stack-ready');
 
-  update();
+    const mq = window.matchMedia(MOBILE);
+    let frame = 0;
+    let measuring = false;
+    let ro;
+    const update = () => {
+      // Self-heal: an MEP replaceInner() can detach this section and re-init on a
+      // fresh one. Drop the orphaned observer + listener so they neither pin the
+      // detached nodes nor keep firing on a dead section.
+      if (!section.isConnected) {
+        ro?.disconnect();
+        mq.removeEventListener('change', update);
+        return;
+      }
+      // (clearing/setting --card-height resizes the observed content).
+      if (measuring) return;
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        measuring = true;
+        if (mq.matches) measure(section, cards);
+        else clearMeasurements(section);
+        requestAnimationFrame(() => { measuring = false; });
+      });
+    };
 
-  ro = new ResizeObserver(update);
-  cards.forEach((card) => ro.observe(naturalEl(card)));
-  const title = section.querySelector(':scope > .rich-content');
-  if (title) ro.observe(title);
-  mq.addEventListener('change', update);
+    update();
+
+    ro = new ResizeObserver(update);
+    cards.forEach((card) => ro.observe(naturalEl(card)));
+    const title = section.querySelector(':scope > .rich-content');
+    if (title) ro.observe(title);
+    mq.addEventListener('change', update);
+  });
 }

--- a/libs/features/bento-stack.js
+++ b/libs/features/bento-stack.js
@@ -1,4 +1,4 @@
-const MOBILE = '(max-width: 767px)';
+const MOBILE = '(width < 768px)';
 
 export function getCards(section) {
   return [...section.querySelectorAll(':scope > .explore-card')];
@@ -51,7 +51,16 @@ export default function initBentoStack(section) {
   const mq = window.matchMedia(MOBILE);
   let frame = 0;
   let measuring = false;
+  let ro;
   const update = () => {
+    // Self-heal: an MEP replaceInner() can detach this section and re-init on a
+    // fresh one. Drop the orphaned observer + listener so they neither pin the
+    // detached nodes nor keep firing on a dead section.
+    if (!section.isConnected) {
+      ro?.disconnect();
+      mq.removeEventListener('change', update);
+      return;
+    }
     // (clearing/setting --card-height resizes the observed content).
     if (measuring) return;
     cancelAnimationFrame(frame);
@@ -65,7 +74,7 @@ export default function initBentoStack(section) {
 
   update();
 
-  const ro = new ResizeObserver(update);
+  ro = new ResizeObserver(update);
   cards.forEach((card) => ro.observe(naturalEl(card)));
   const title = section.querySelector(':scope > .rich-content');
   if (title) ro.observe(title);

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -362,7 +362,7 @@
 
 @media (width >= 1440px) {
   .rich-content.indent {
-    margin-block-end: none;
+    margin-block-end: 0;
   }
 
   .section.bento {
@@ -637,11 +637,13 @@
 }
 
 @supports not (animation-timeline: view()) {
-  .section.bento.stack-mobile > .rich-content {
-    position: static;
-    transform: none;
-    opacity: 1;
-    animation: none;
+  @media (width < 768px) {
+    .section.bento.stack-mobile > .rich-content {
+      position: static;
+      transform: none;
+      opacity: 1;
+      animation: none;
+    }
   }
 }
 

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -574,8 +574,8 @@
     line-height: 1;
     will-change: opacity, transform, translate;
     animation:
-      stack-title-stagger var(--paralax-easing) both,
-      stack-title-card-match var(--paralax-easing) both;
+      stack-title-stagger var(--parallax-easing) both,
+      stack-title-card-match var(--parallax-easing) both;
     animation-timeline: --stack-title-vt, --section-vt;
     animation-range: cover 0% cover 30%, exit var(--cards-release-offset) exit var(--title-release-offset);
   }

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -283,9 +283,14 @@
     }
   }
 
-  .section.bento .rich-content.grid-full-width {
+  .section.bento .rich-content.grid-full-width,
+  .rich-content.indent {
     margin-inline-start: var(--s2a-spacing-xs);
     margin-block-end: calc(var(--s2a-spacing-lg) - var(--grid-gutter));
+  }
+
+  .rich-content.indent {
+    margin-block-end: 0;
   }
 }
 
@@ -356,8 +361,13 @@
 }
 
 @media (width >= 1440px) {
+  .rich-content.indent {
+    margin-block-end: none;
+  }
+
   .section.bento {
-    .rich-content.grid-full-width {
+    .rich-content.grid-full-width,
+    .rich-content.indent {
       margin-inline-start: var(--s2a-spacing-md);
       margin-block-end: calc(var(--s2a-spacing-2xl) - var(--grid-gutter));
     }
@@ -537,6 +547,44 @@
   initial-value: 200px;
 }
 
+@keyframes stack-title-stagger {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, var(--parallax-translate-y), 0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate(0, 0);
+  }
+}
+
+@keyframes stack-title-card-match {
+  100% { translate: 0 calc(-1 * var(--title-catchup)); }
+}
+
+@media (width < 768px) {
+  .section.bento.stack-mobile:where(.bento-stack-ready) > .rich-content {
+    --parallax-translate-y: -60px;
+    --scrollport-h: min(var(--phone-h), 100svh);
+    --cards-release-offset: max(0px, calc(var(--scrollport-h) - var(--card-front-y) - var(--card-height)));
+    --title-release-offset: max(0px, calc(var(--scrollport-h) - var(--stack-pin-top) - var(--title-height)));
+    --title-catchup: calc(var(--card-front-y) + var(--card-height) - var(--stack-pin-top) - var(--title-height));
+
+    position: sticky;
+    top: var(--stack-pin-top);
+    z-index: 1;
+    margin: 0;
+    line-height: 1;
+    will-change: opacity, transform, translate;
+    animation:
+      stack-title-stagger var(--paralax-easing) both,
+      stack-title-card-match var(--paralax-easing) both;
+    animation-timeline: --stack-title-vt, --section-vt;
+    animation-range: cover 0% cover 30%, exit var(--cards-release-offset) exit var(--title-release-offset);
+  }
+}
+
 /* mobile */
 .section:has(+ .section.parallax-video-garage-door .rich-content.video),
 .section.parallax-video-garage-door:has(.rich-content.video),
@@ -585,6 +633,24 @@
   .section.parallax-video-garage-door:has(.rich-content.video) ~ .section {
     --rc-pull-offset: 70px;
     --rc-sweep-offset: 280px;
+  }
+}
+
+@supports not (animation-timeline: view()) {
+  .section.bento.stack-mobile > .rich-content {
+    position: static;
+    transform: none;
+    opacity: 1;
+    animation: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) and (width < 768px) {
+  .section.bento.stack-mobile > .rich-content {
+    position: static;
+    transform: none;
+    opacity: 1;
+    animation: none;
   }
 }
 

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -285,7 +285,7 @@
 
   .section.bento .rich-content.grid-full-width,
   .rich-content.indent {
-    margin-inline-start: var(--s2a-spacing-xs);
+    margin-inline-start: var(--s2a-spacing-md);
     margin-block-end: calc(var(--s2a-spacing-lg) - var(--grid-gutter));
   }
 

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -361,10 +361,6 @@
 }
 
 @media (width >= 1440px) {
-  .rich-content.indent {
-    margin-block-end: 0;
-  }
-
   .section.bento {
     .rich-content.grid-full-width,
     .rich-content.indent {
@@ -550,7 +546,7 @@
 @keyframes stack-title-stagger {
   0% {
     opacity: 0;
-    transform: translate3d(0, var(--parallax-translate-y), 0);
+    transform: translate(0, var(--parallax-translate-y));
   }
 
   100% {

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -2,6 +2,115 @@
   display: none;
 }
 
+@property --stack-depth-mask-t {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0;
+}
+
+@keyframes bento-mobile-stack-slides {
+  0% {
+    transform: translateY(var(--stack-offset));
+    opacity: 0;
+  }
+
+  10% {
+    transform: translateY(calc(var(--stack-offset) - var(--offset-adjuster)));
+    opacity: 1;
+  }
+
+  70% {
+    transform: translateY(calc(var(--stack-offset) - var(--offset-adjuster)));
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateY(calc(var(--stack-offset) - var(--offset-adjuster)));
+    opacity: 0;
+  }
+}
+
+@keyframes bento-mobile-stack-slides-front {
+  0% {
+    transform: translateY(var(--stack-offset));
+    opacity: 0;
+  }
+
+  10% {
+    transform: translateY(calc(var(--stack-offset) - var(--offset-adjuster)));
+    opacity: 1;
+  }
+
+  100% {
+    transform: translateY(calc(var(--stack-offset) - var(--offset-adjuster)));
+    opacity: 1;
+  }
+}
+
+@keyframes stack-section-exit {
+  0% { transform: translate(0, 0); }
+  100% { transform: translate3d(0, calc(-1 * var(--section-exit-y)), 0); }
+}
+
+@keyframes bento-items-shrink {
+  0%,
+  20% {
+    transform: scale(1);
+    box-shadow: var(--bento-shadow-none);
+  }
+
+  100% {
+    transform: scale(var(--stack-scale, 1));
+    box-shadow: var(--bento-shadow);
+  }
+}
+
+@keyframes bento-depth-mask-drive {
+  0%,
+  20% { --stack-depth-mask-t: 0; }
+  100% { --stack-depth-mask-t: 1; }
+}
+
+.section.bento.stack-mobile {
+  --phone-h: 775px;
+  --phone-vh: calc(var(--phone-h) / 100);
+  --gnav-offset: 72px;
+
+  /* Single knob for design fine-tuning — everything pins at --stack-pin-top. */
+  --bento-stack-top-gap: 20px;
+  --stack-pin-top: calc(var(--gnav-offset) + var(--bento-stack-top-gap));
+  --title-height: 24px;
+  --title-card-gap: var(--s2a-spacing-24, 24px);
+
+  /* To re-enable, set this back to 40px; the stack-section-exit animation
+     + --section-vt timeline are kept intact */
+  --section-exit-y: 0;
+  --paralax-easing: cubic-bezier(0.42, 0, 0, 1);
+  --last-offset: 2.5rem;
+  --offset-adjuster: 6px;
+  --offset-variance-index: -2px;
+  --stack-scale-max: 0.08;
+  --bento-surface-front: #fff;
+  --bento-surface-middle: #edebeb;
+  --bento-surface-deepest: #e3e2e2;
+  --bento-shadow:
+    0 86.137px 34.455px #00000012,
+    0 35.986px 14.394px #0000000d,
+    0 19.24px 7.696px #0000000a,
+    0 10.786px 4.314px #0000000a,
+    0 5.728px 2.291px #00000008,
+    0 2.384px 0.953px #00000005;
+  --bento-shadow-none: 0 0 0 #0000;
+}
+
+body:has(header.has-breadcrumbs) .section.bento.stack-mobile {
+  --stack-pin-top: calc(var(--gnav-offset) + var(--feds-breadcrumbs-height, 52px) + var(--bento-stack-top-gap));
+}
+
+body:has(header.local-nav) .section.bento.stack-mobile {
+  --stack-pin-top: calc(var(--gnav-offset) + var(--feds-localnav-height, 40px) + var(--bento-stack-top-gap));
+}
+
 .section {
   &.has-background {
     background-color: unset;
@@ -69,6 +178,7 @@
     padding-inline: 0;
     padding-bottom: var(--s2a-spacing-xl);
     padding-top: 0;
+    z-index: 2;
 
     [class*='heading-'] {
       z-index: 1;
@@ -113,7 +223,7 @@
     }
 
     .content-aux {
-      aspect-ratio: 1 / 1;
+      aspect-ratio: 1 / 1.1;
       display: block;
       height: auto;
       order: -1;
@@ -139,8 +249,8 @@
   }
 
   &.bento .scrim {
-    .explore-card-content {
-      &::before {
+    .explore-card-container {
+      &::after {
         content: '';
         position: absolute;
         inset: 0;
@@ -150,7 +260,7 @@
     }
 
     &.dark {
-      .explore-card-content::before {
+      .explore-card-container::after {
         content: '';
         position: absolute;
         inset: 0;
@@ -169,7 +279,7 @@
       }
 
       .content-aux {
-        aspect-ratio: 1.02 / 1;
+        aspect-ratio: 1 / 1.1;
       }
     }
   }
@@ -178,9 +288,18 @@
   &.bento .explore-card.light {background-color: transparent;} 
 
   &.bento .explore-card {
-    border-radius: var(--s2a-border-radius-md);
-    border: var(--s2a-border-width-md) inset var(--s2a-color-transparent-white-12);
+    /* border-radius: var(--s2a-border-radius-md);
+    border: var(--s2a-border-width-md) inset var(--s2a-color-transparent-white-12); */
     z-index: inherit;
+
+    .explore-card-container::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: var(--s2a-border-radius-md);
+      border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12);
+      z-index: 2;
+    }
 
     .explore-card-container:hover [class*='body-'] {
       opacity: initial;
@@ -198,6 +317,7 @@
 
   &.bento .explore-card-link-container {
     box-sizing: border-box;
+    z-index: 2;
 
     &:focus-visible {
       border: 2px solid var(--color-accent-focus-ring);
@@ -226,6 +346,7 @@
 
   &.bento .explore-card-background {
     transition: filter 0.3s ease-in-out, transform 0.3s ease-out;
+
     img,
     .video-container {
       opacity: 1;
@@ -287,6 +408,89 @@
 
 /* mobile only */
 @media (width < 768px) {
+  .section.bento.stack-mobile:where(.bento-stack-ready) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--title-card-gap);
+    padding-bottom: calc(var(--offset-adjuster) + var(--phone-vh) * 12);
+    scroll-margin-top: var(--stack-pin-top);
+
+    --card-front-y: calc(var(--stack-pin-top) + var(--title-height) + var(--title-card-gap));
+
+    view-timeline-name: --section-vt, --stack-title-vt;
+    view-timeline-axis: block;
+    animation: stack-section-exit linear both;
+    animation-timeline: --section-vt;
+    animation-range: exit;
+
+    &:not(:has(> .rich-content)) {
+      --card-front-y: var(--stack-pin-top);
+    }
+
+    > .explore-card {
+      --depth: calc((var(--slides) - 1 - var(--card-idx)) / max(1, (var(--slides) - 1)));
+      --stack-offset: calc(
+        var(--last-offset)
+        - (var(--last-offset) / var(--slides) * (var(--slides) - var(--card-idx)))
+        - var(--offset-variance-index) * (var(--slides) - var(--card-idx))
+      );
+      --stack-scale: calc(1 - var(--depth) * var(--stack-scale-max));
+      --stack-depth-mask-opacity: calc(var(--depth) * 0.15);
+
+      position: sticky;
+      top: var(--card-front-y);
+      width: 100%;
+      max-width: 100%;
+      height: var(--card-height, auto);
+      z-index: calc(var(--card-idx) + 1);
+      animation: bento-mobile-stack-slides var(--paralax-easing) both;
+      animation-timeline: view();
+      animation-range: entry exit;
+    }
+
+    > .explore-card:nth-last-child(1 of .explore-card) {
+      --stack-scale: 1;
+      --stack-depth-mask-opacity: 0;
+
+      animation-name: bento-mobile-stack-slides-front;
+    }
+
+    > .explore-card .explore-card-container {
+      transform-origin: center top;
+      height: 100%;
+      border-radius: inherit;
+      overflow: clip;
+      animation:
+        bento-items-shrink var(--paralax-easing) both,
+        bento-depth-mask-drive var(--paralax-easing) both;
+      animation-timeline: view(), view();
+      animation-range: entry exit, entry exit;
+    }
+
+    > .explore-card:not(.dark):not(.scrim) .explore-card-background {
+      background-color: color-mix(
+        in srgb,
+        var(--bento-surface-deepest) calc(var(--depth) * 100%),
+        var(--bento-surface-front)
+      );
+    }
+
+    > .explore-card .explore-card-content::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      border-radius: inherit;
+      pointer-events: none;
+      background: #000;
+      opacity: calc(var(--stack-depth-mask-opacity) * var(--stack-depth-mask-t));
+    }
+
+    > .explore-card:nth-last-child(1 of .explore-card) .explore-card-content::after {
+      content: none;
+    }
+  }
+
   .section-background .mobile-only {
     display: block;
   }
@@ -383,4 +587,44 @@
       }
     }
   }
+}
+
+@supports not (animation-timeline: view()) {
+  .section.bento.stack-mobile {
+    display: flex;
+    flex-direction: column;
+    gap: var(--title-card-gap, 24px);
+  }
+
+  .section.bento.stack-mobile > .explore-card {
+    position: static;
+    height: auto;
+    transform: none;
+    opacity: 1;
+    animation: none;
+  }
+
+  .section.bento.stack-mobile > .explore-card .explore-card-container {
+    transform: none;
+    animation: none;
+  }
+
+  .section.bento.stack-mobile > .explore-card .explore-card-container::after { content: none; }
+}
+
+@media (prefers-reduced-motion: reduce) and (width < 768px) {
+  .section.bento.stack-mobile > .explore-card {
+    position: static;
+    height: auto;
+    transform: none;
+    opacity: 1;
+    animation: none;
+  }
+
+  .section.bento.stack-mobile > .explore-card .explore-card-container {
+    transform: none;
+    animation: none;
+  }
+
+  .section.bento.stack-mobile > .explore-card .explore-card-container::after { content: none; }
 }

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -288,18 +288,8 @@ body:has(header.local-nav) .section.bento.stack-mobile {
   &.bento .explore-card.light {background-color: transparent;} 
 
   &.bento .explore-card {
-    /* border-radius: var(--s2a-border-radius-md);
-    border: var(--s2a-border-width-md) inset var(--s2a-color-transparent-white-12); */
+    border-radius: var(--s2a-border-radius-md);
     z-index: inherit;
-
-    .explore-card-container::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      border-radius: var(--s2a-border-radius-md);
-      border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12);
-      z-index: 2;
-    }
 
     .explore-card-container:hover [class*='body-'] {
       opacity: initial;

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -49,7 +49,7 @@
 
 @keyframes stack-section-exit {
   0% { transform: translate(0, 0); }
-  100% { transform: translate3d(0, calc(-1 * var(--section-exit-y)), 0); }
+  100% { transform: translate(0, calc(-1 * var(--section-exit-y))); }
 }
 
 @keyframes bento-items-shrink {
@@ -80,12 +80,11 @@
   --bento-stack-top-gap: 40px;
   --stack-pin-top: calc(var(--gnav-offset) + var(--bento-stack-top-gap));
   --title-height: 24px;
-  --title-card-gap: var(--s2a-spacing-24, 24px);
+  --title-card-gap: var(--s2a-spacing-24);
 
   /* To re-enable, set this back to 40px; the stack-section-exit animation
      + --section-vt timeline are kept intact */
   --section-exit-y: 0;
-  --paralax-easing: cubic-bezier(0.42, 0, 0, 1);
   --last-offset: 2.5rem;
   --offset-adjuster: 6px;
   --offset-variance-index: -2px;
@@ -100,7 +99,7 @@
     0 10.786px 4.314px #0000000a,
     0 5.728px 2.291px #00000008,
     0 2.384px 0.953px #00000005;
-  --bento-shadow-none: 0 0 0 #0000;
+  --bento-shadow-none: 0 0 0 var(--s2a-color-transparent-black-00);
 }
 
 body:has(header.has-breadcrumbs) .section.bento.stack-mobile {
@@ -428,13 +427,14 @@ body:has(header.local-nav) .section.bento.stack-mobile {
       --stack-scale: calc(1 - var(--depth) * var(--stack-scale-max));
       --stack-depth-mask-opacity: calc(var(--depth) * 0.15);
 
+      overflow: visible;
       position: sticky;
       top: var(--card-front-y);
       width: 100%;
       max-width: 100%;
       height: var(--card-height, auto);
       z-index: calc(var(--card-idx) + 1);
-      animation: bento-mobile-stack-slides var(--paralax-easing) both;
+      animation: bento-mobile-stack-slides var(--parallax-easing) both;
       animation-timeline: view();
       animation-range: entry exit;
     }
@@ -452,8 +452,8 @@ body:has(header.local-nav) .section.bento.stack-mobile {
       border-radius: inherit;
       overflow: clip;
       animation:
-        bento-items-shrink var(--paralax-easing) both,
-        bento-depth-mask-drive var(--paralax-easing) both;
+        bento-items-shrink var(--parallax-easing) both,
+        bento-depth-mask-drive var(--parallax-easing) both;
       animation-timeline: view(), view();
       animation-range: entry exit, entry exit;
     }
@@ -473,7 +473,7 @@ body:has(header.local-nav) .section.bento.stack-mobile {
       z-index: 1;
       border-radius: inherit;
       pointer-events: none;
-      background: #000;
+      background: var(--s2a-color-gray-1000);
       opacity: calc(var(--stack-depth-mask-opacity) * var(--stack-depth-mask-t));
     }
 

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -77,7 +77,7 @@
   --gnav-offset: 72px;
 
   /* Single knob for design fine-tuning — everything pins at --stack-pin-top. */
-  --bento-stack-top-gap: 20px;
+  --bento-stack-top-gap: 40px;
   --stack-pin-top: calc(var(--gnav-offset) + var(--bento-stack-top-gap));
   --title-height: 24px;
   --title-card-gap: var(--s2a-spacing-24, 24px);
@@ -104,7 +104,7 @@
 }
 
 body:has(header.has-breadcrumbs) .section.bento.stack-mobile {
-  --stack-pin-top: calc(var(--gnav-offset) + var(--feds-breadcrumbs-height, 52px) + var(--bento-stack-top-gap));
+  --stack-pin-top: calc(var(--gnav-offset) + var(--feds-height-breadcrumbs, 33px) + var(--bento-stack-top-gap));
 }
 
 body:has(header.local-nav) .section.bento.stack-mobile {
@@ -336,6 +336,7 @@ body:has(header.local-nav) .section.bento.stack-mobile {
 
   &.bento .explore-card-background {
     transition: filter 0.3s ease-in-out, transform 0.3s ease-out;
+    border-radius: inherit;
 
     img,
     .video-container {
@@ -580,6 +581,31 @@ body:has(header.local-nav) .section.bento.stack-mobile {
 }
 
 @supports not (animation-timeline: view()) {
+  @media (width < 768px) {
+    .section.bento.stack-mobile {
+      display: flex;
+      flex-direction: column;
+      gap: var(--title-card-gap, 24px);
+    }
+
+    .section.bento.stack-mobile > .explore-card {
+      position: static;
+      height: auto;
+      transform: none;
+      opacity: 1;
+      animation: none;
+    }
+
+    .section.bento.stack-mobile > .explore-card .explore-card-container {
+      transform: none;
+      animation: none;
+    }
+
+    .section.bento.stack-mobile > .explore-card .explore-card-content::after { content: none; }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) and (width < 768px) {
   .section.bento.stack-mobile {
     display: flex;
     flex-direction: column;
@@ -599,22 +625,5 @@ body:has(header.local-nav) .section.bento.stack-mobile {
     animation: none;
   }
 
-  .section.bento.stack-mobile > .explore-card .explore-card-container::after { content: none; }
-}
-
-@media (prefers-reduced-motion: reduce) and (width < 768px) {
-  .section.bento.stack-mobile > .explore-card {
-    position: static;
-    height: auto;
-    transform: none;
-    opacity: 1;
-    animation: none;
-  }
-
-  .section.bento.stack-mobile > .explore-card .explore-card-container {
-    transform: none;
-    animation: none;
-  }
-
-  .section.bento.stack-mobile > .explore-card .explore-card-container::after { content: none; }
+  .section.bento.stack-mobile > .explore-card .explore-card-content::after { content: none; }
 }

--- a/libs/mep/ace1209/section-metadata/section-metadata.js
+++ b/libs/mep/ace1209/section-metadata/section-metadata.js
@@ -205,6 +205,8 @@ export default async function init(el) {
   if (metadata.images) handleImages(metadata.images?.text[0], section);
   handleStickyFocus(section);
   if (section?.matches('.bento.stack-mobile')) {
-    import('../../../deps/bento-stack.js').then(({ default: initBentoStack }) => initBentoStack(section));
+    import('../../../features/bento-stack.js')
+      .then(({ default: initBentoStack }) => initBentoStack(section))
+      .catch((e) => window.lana?.log(`bento-stack init failed: ${e}`, { tags: 'bento-stack', severity: 'info' }));
   }
 }

--- a/libs/mep/ace1209/section-metadata/section-metadata.js
+++ b/libs/mep/ace1209/section-metadata/section-metadata.js
@@ -204,4 +204,7 @@ export default async function init(el) {
   if (metadata.layout) handleStyle(metadata.layout.text, section);
   if (metadata.images) handleImages(metadata.images?.text[0], section);
   handleStickyFocus(section);
+  if (section?.matches('.bento.stack-mobile')) {
+    import('../../../deps/bento-stack.js').then(({ default: initBentoStack }) => initBentoStack(section));
+  }
 }

--- a/libs/mep/ace1209/section-metadata/section-metadata.js
+++ b/libs/mep/ace1209/section-metadata/section-metadata.js
@@ -184,6 +184,12 @@ function handleImages(imageOptions, section) {
   decoratePictures(section, imageOptions);
 }
 
+function handleBentoStack(section) {
+  import('../../../features/bento-stack.js')
+    .then(({ default: initBentoStack }) => initBentoStack(section))
+    .catch((e) => window.lana?.log(`bento-stack init failed: ${e}`, { tags: 'bento-stack', severity: 'info' }));
+}
+
 export const getMetadata = (el) => [...el.childNodes].reduce((rdx, row) => {
   if (row.children) {
     const key = row.children[0].textContent.trim().toLowerCase();
@@ -204,9 +210,5 @@ export default async function init(el) {
   if (metadata.layout) handleStyle(metadata.layout.text, section);
   if (metadata.images) handleImages(metadata.images?.text[0], section);
   handleStickyFocus(section);
-  if (section?.matches('.bento.stack-mobile')) {
-    import('../../../features/bento-stack.js')
-      .then(({ default: initBentoStack }) => initBentoStack(section))
-      .catch((e) => window.lana?.log(`bento-stack init failed: ${e}`, { tags: 'bento-stack', severity: 'info' }));
-  }
+  if (section?.matches('.bento.stack-mobile')) handleBentoStack(section);
 }

--- a/test/features/bento-stack/bento-stack.test.js
+++ b/test/features/bento-stack/bento-stack.test.js
@@ -1,0 +1,151 @@
+import sinon from 'sinon';
+import { expect } from '@esm-bundle/chai';
+
+const {
+  default: initBentoStack,
+  contentReady,
+  whenReady,
+} = await import('../../../libs/features/bento-stack.js');
+
+function createCard({ withContent = true, height = 100 } = {}) {
+  const card = document.createElement('div');
+  card.className = 'explore-card';
+  if (withContent) {
+    const content = document.createElement('div');
+    content.className = 'explore-card-content';
+    Object.defineProperty(content, 'offsetHeight', { value: height, configurable: true });
+    card.append(content);
+  } else {
+    Object.defineProperty(card, 'offsetHeight', { value: height, configurable: true });
+  }
+  return card;
+}
+
+function createSection(cards) {
+  const section = document.createElement('div');
+  section.className = 'section bento stack-mobile';
+  cards.forEach((card) => section.append(card));
+  document.body.append(section);
+  return section;
+}
+
+function nextFrame() {
+  return new Promise((resolve) => { requestAnimationFrame(resolve); });
+}
+
+function waitUntil(predicate) {
+  return new Promise((resolve) => {
+    const check = () => {
+      if (predicate()) resolve();
+      else requestAnimationFrame(check);
+    };
+    check();
+  });
+}
+
+describe('contentReady', () => {
+  it('is true when every card has a decorated content wrapper', () => {
+    expect(contentReady([createCard(), createCard()])).to.be.true;
+  });
+
+  it('is false when any card is missing the content wrapper', () => {
+    expect(contentReady([createCard(), createCard({ withContent: false })])).to.be.false;
+  });
+});
+
+describe('whenReady', () => {
+  it('calls back immediately when cards are already ready', () => {
+    const cb = sinon.spy();
+    whenReady([createCard()], cb);
+    expect(cb.calledOnce).to.be.true;
+  });
+
+  it('waits for a card decorated after the initial call, then calls back', async () => {
+    const card = createCard({ withContent: false });
+    const cb = sinon.spy();
+
+    whenReady([card], cb, performance.now() + 2000);
+    await nextFrame();
+    await nextFrame();
+    expect(cb.called).to.be.false;
+
+    const content = document.createElement('div');
+    content.className = 'explore-card-content';
+    card.append(content);
+
+    await waitUntil(() => cb.called);
+    expect(cb.calledOnce).to.be.true;
+  });
+
+  it('gives up at the deadline and calls back anyway if content never appears', async () => {
+    const card = createCard({ withContent: false });
+    const cb = sinon.spy();
+
+    whenReady([card], cb, performance.now() + 10);
+    await waitUntil(() => cb.called);
+
+    expect(cb.calledOnce).to.be.true;
+    expect(contentReady([card])).to.be.false;
+  });
+});
+
+describe('initBentoStack', () => {
+  let originalMatchMedia;
+  let originalResizeObserver;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    originalResizeObserver = window.ResizeObserver;
+
+    const mql = { matches: true, addEventListener: () => {}, removeEventListener: () => {} };
+    window.matchMedia = () => mql;
+
+    function NoopResizeObserver() {}
+    NoopResizeObserver.prototype.observe = () => {};
+    NoopResizeObserver.prototype.disconnect = () => {};
+    window.ResizeObserver = NoopResizeObserver;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    window.ResizeObserver = originalResizeObserver;
+    document.querySelectorAll('.section.bento.stack-mobile').forEach((section) => section.remove());
+  });
+
+  it('measures decorated content height when a sibling block decorates late', async () => {
+    // Reproduces the real-world race: explore-card.js hasn't created .explore-card-content
+    // yet when initBentoStack (lazily imported from section-metadata.js) first runs.
+    // 1222 = raw/undecorated natural height; the correct decorated height is 528 (below).
+    const rawCard = createCard({ withContent: false, height: 1222 });
+    const section = createSection([rawCard]);
+
+    initBentoStack(section);
+
+    await nextFrame();
+    const content = document.createElement('div');
+    content.className = 'explore-card-content';
+    Object.defineProperty(content, 'offsetHeight', { value: 528, configurable: true });
+    rawCard.append(content);
+
+    await waitUntil(() => section.style.getPropertyValue('--card-height'));
+    expect(section.style.getPropertyValue('--card-height')).to.equal('528px');
+  });
+
+  it('does not reinitialize a section already marked bento-stack-ready', async () => {
+    const card = createCard();
+    const section = createSection([card]);
+    section.classList.add('bento-stack-ready');
+
+    initBentoStack(section);
+    await nextFrame();
+    await nextFrame();
+
+    expect(card.style.getPropertyValue('--card-idx')).to.equal('');
+  });
+
+  it('does nothing for a section with no cards', () => {
+    const section = createSection([]);
+    expect(() => initBentoStack(section)).to.not.throw();
+    expect(section.classList.contains('bento-stack-ready')).to.be.false;
+  });
+});


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds opt in mobile stacking feature (`stack-mobile`). Mobile only feature.
* Removed border per design ask - originally added in [this PR](https://github.com/adobecom/milo/pull/6228)
* Bento aspect ratio update to 1 / 1.1
* Supports sticky title when authored with a rich-content block as the first element in a bento section.

Resolves: [MWPW-199414](https://jira.corp.adobe.com/browse/MWPW-199414)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=sr-mobile-bento&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


<img width="288" height="690" alt="image" src="https://github.com/user-attachments/assets/d7cb5b9b-b311-4b05-96dd-ee5b5938dfde" />






