### PR TITLE
[MWPW-201322, 201247, 201365] marketo dropdown overlapping + RTL dropdown issue fix

### DIFF
--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -260,6 +260,10 @@
   white-space: nowrap;
 }
 
+[dir="rtl"] .marketo .mktoForm select {
+  background-position: 3% 50%;
+}
+
 .marketo .mktoForm .mktoCheckboxList input,
 .marketo .mktoForm .mktoRadioList input {
   width: auto !important;

--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -254,6 +254,10 @@
   -webkit-appearance:none;
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-58 29 32 34' style='enable-background:new -58 29 32 34' xml:space='preserve'%3E%3Cpath d='m-56 43 6-12 6 12h-12zm12 6-6 12-6-12h12z' fill='%23535353'/%3E%3C/svg%3E") no-repeat 97% 50%;
   background-size: 1em 1em;
+  padding-inline-end: calc(var(--spacing-xs) + 20px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .marketo .mktoForm .mktoCheckboxList input,

--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -254,6 +254,10 @@
   -webkit-appearance:none;
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-58 29 32 34' style='enable-background:new -58 29 32 34' xml:space='preserve'%3E%3Cpath d='m-56 43 6-12 6 12h-12zm12 6-6 12-6-12h12z' fill='%23535353'/%3E%3C/svg%3E") no-repeat 97% 50%;
   background-size: 1em 1em;
+}
+
+/* scoped to .mktoField to outrank its padding shorthand and reserve space for the arrow icon */
+.marketo .mktoForm select.mktoField {
   padding-inline-end: calc(var(--spacing-xs) + 20px);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -268,6 +268,12 @@
   background-position: 3% 50%;
 }
 
+/* browsers default input[type="tel"] to direction:ltr regardless of page dir;
+   inherit here so it aligns the same way every other field already does */
+[dir="rtl"] .marketo .mktoForm input[type="tel"] {
+  direction: inherit;
+}
+
 .marketo .mktoForm .mktoCheckboxList input,
 .marketo .mktoForm .mktoRadioList input {
   width: auto !important;

--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -256,7 +256,6 @@
   background-size: 1em 1em;
 }
 
-/* scoped to .mktoField to outrank its padding shorthand and reserve space for the arrow icon */
 .marketo .mktoForm select.mktoField {
   padding-inline-end: calc(var(--spacing-xs) + 20px);
   overflow: hidden;
@@ -268,8 +267,6 @@
   background-position: 3% 50%;
 }
 
-/* browsers default input[type="tel"] to direction:ltr regardless of page dir;
-   inherit here so it aligns the same way every other field already does */
 [dir="rtl"] .marketo .mktoForm input[type="tel"] {
   direction: inherit;
 }


### PR DESCRIPTION
## Changes

Fixed the Marketo form dropdown fields so long selected values (like long job titles, departments, or country names) no longer overlap the arrow icon. The dropdown now reserves space for the icon and truncates overflowing text with an ellipsis instead of letting it run underneath.

Also fixed the same overlap for right-to-left locales (Arabic, Hebrew, etc.). The text truncation was already flipping correctly for RTL, but the arrow icon stayed fixed on the right instead of moving to the side where the reserved space actually is. The icon now mirrors to the correct side for RTL layouts. Along with this alignment issue for input type of "tel" placeholder has been fixed.

## Expected behaviour

 - Long selected values are cut off with "…" and leave clear space before the arrow icon.
 - Short values look exactly the same as before — no visual change.
 - On RTL-locale pages, the arrow icon now appears on the correct side and no longer overlaps the truncated text. And the input for "Business phone" aligns correctly to right.

Resolves: 
 - [MWPW-201322](https://jira.corp.adobe.com/browse/MWPW-201322)
 - [MWPW-201247](https://jira.corp.adobe.com/browse/MWPW-201247)
 - [MWPW-201365](https://jira.corp.adobe.com/browse/MWPW-201365)

**Test URLs:**

Overlapping issue : 
- Before: https://main--da-cc--adobecom.aem.live/th_th/products/substance3d/request-information/substance-sampler-trial
- After: https://main--da-cc--adobecom.aem.live/th_th/products/substance3d/request-information/substance-sampler-trial?milolibs=mwpw-201322-marketo-dropdownoverlappingfix

RTL Dropdown + Input type "tel" placeholder issue : 
 - https://main--da-cc--adobecom.aem.live/mena_ar/products/substance3d/request-information/substance-sampler-trial
 - https://main--da-cc--adobecom.aem.live/mena_ar/products/substance3d/request-information/substance-sampler-trial?milolibs=mwpw-201322-marketo-dropdownoverlappingfix


## Screenshots
<img width="846" height="749" alt="Screenshot 2026-07-21 at 12 11 11 PM" src="https://github.com/user-attachments/assets/9a57a0e5-b66a-4b13-acb5-95e1d6a8df0e" />


<img width="566" height="635" alt="Screenshot 2026-07-22 at 9 52 57 AM" src="https://github.com/user-attachments/assets/30800e62-4ab5-4555-bdfd-3a3edf62a34b" />








