### PR TITLE
MWPW-201346: add unit tests for c2 base-card block

### DIFF
--- a/test/blocks/base-card/base-card.test.js
+++ b/test/blocks/base-card/base-card.test.js
@@ -1,0 +1,91 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/base-card/base-card.js';
+
+describe('Base Card', () => {
+  it('adds base-card-section class to the closest section', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.base-card');
+    await init(block);
+
+    expect(block.closest('.section').classList.contains('base-card-section')).to.be.true;
+  });
+
+  it('decorates foreground and media, and marks only standalone links', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.base-card');
+    await init(block);
+
+    const foreground = block.querySelector('.foreground');
+    expect(foreground).to.exist;
+
+    const media = block.querySelector('.media');
+    expect(media).to.exist;
+    expect(media.classList.contains('parallax-featured-card-media')).to.be.false;
+    expect(media.querySelector('picture').classList.contains('parallax-scale-down')).to.be.true;
+
+    const links = foreground.querySelectorAll('a');
+    const standalone = [...links].find((a) => a.textContent.trim() === 'Learn more');
+    const inline = [...links].find((a) => a.textContent.trim() === 'terms');
+
+    expect(standalone.classList.contains('standalone-link')).to.be.true;
+    expect(standalone.classList.contains('label')).to.be.true;
+    expect(inline.classList.contains('standalone-link')).to.be.false;
+    expect(inline.classList.contains('label')).to.be.false;
+  });
+
+  it('adds parallax-featured-card-media class when the block is featured', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/featured.html' });
+    const block = document.querySelector('.base-card');
+    await init(block);
+
+    const media = block.querySelector('.media');
+    expect(media.classList.contains('parallax-featured-card-media')).to.be.true;
+  });
+
+  it('moves a single-picture first cell into media as the icon and rewrites its federated svg src', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/icon.html' });
+    const block = document.querySelector('.base-card');
+    await init(block);
+
+    const foreground = block.querySelector('.foreground');
+    const media = block.querySelector('.media');
+
+    const icon = media.querySelector('picture.icon');
+    expect(icon).to.exist;
+    expect(icon.querySelector('img').getAttribute('src')).to.equal('https://main--federal--adobecom.aem.page/federal/icons/icon.svg');
+
+    // original icon cell removed, heading is now the first child of foreground
+    expect(foreground.children[0].tagName).to.equal('H3');
+  });
+
+  it('leaves a non-icon first cell in place', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/non-icon-first-cell.html' });
+    const block = document.querySelector('.base-card');
+    await init(block);
+
+    const foreground = block.querySelector('.foreground');
+    const media = block.querySelector('.media');
+
+    expect(foreground.children[0].textContent.trim()).to.equal('Plain text first cell, not an icon.');
+    expect(media.querySelector('picture.icon')).to.be.null;
+  });
+
+  it('decorates foreground without throwing when there is no media cell', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/no-media.html' });
+    const block = document.querySelector('.base-card');
+    await init(block);
+
+    expect(block.querySelector('.foreground')).to.exist;
+    expect(block.querySelector('.media')).to.be.null;
+  });
+
+  it('does not throw when the block has no foreground cell', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/empty.html' });
+    const block = document.querySelector('.base-card');
+    await init(block);
+
+    expect(block.closest('.section').classList.contains('base-card-section')).to.be.true;
+  });
+});

--- a/test/blocks/base-card/mocks/default.html
+++ b/test/blocks/base-card/mocks/default.html
@@ -1,0 +1,17 @@
+<main>
+  <div class="section">
+    <div class="base-card">
+      <div>
+        <div>
+          <h3>Card title</h3>
+          <p>Some supporting body copy.</p>
+          <p><a href="https://www.adobe.com/standalone">Learn more</a></p>
+          <p>Read our <a href="https://www.adobe.com/terms">terms</a> for details.</p>
+        </div>
+        <div>
+          <picture><img src="" alt="card image" /></picture>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/base-card/mocks/empty.html
+++ b/test/blocks/base-card/mocks/empty.html
@@ -1,0 +1,7 @@
+<main>
+  <div class="section">
+    <div class="base-card">
+      <div></div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/base-card/mocks/featured.html
+++ b/test/blocks/base-card/mocks/featured.html
@@ -1,0 +1,15 @@
+<main>
+  <div class="section">
+    <div class="base-card featured">
+      <div>
+        <div>
+          <h3>Featured card title</h3>
+          <p>Featured card copy.</p>
+        </div>
+        <div>
+          <picture><img src="" alt="featured image" /></picture>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/base-card/mocks/icon.html
+++ b/test/blocks/base-card/mocks/icon.html
@@ -1,0 +1,16 @@
+<main>
+  <div class="section">
+    <div class="base-card">
+      <div>
+        <div>
+          <p><picture><img src="/federal/icons/icon.svg" alt="icon" /></picture></p>
+          <h3>Card with icon</h3>
+          <p>Body copy for icon card.</p>
+        </div>
+        <div>
+          <picture><img src="" alt="card image" /></picture>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/base-card/mocks/no-media.html
+++ b/test/blocks/base-card/mocks/no-media.html
@@ -1,0 +1,12 @@
+<main>
+  <div class="section">
+    <div class="base-card">
+      <div>
+        <div>
+          <h3>No media card</h3>
+          <p>This card has no media cell.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/base-card/mocks/non-icon-first-cell.html
+++ b/test/blocks/base-card/mocks/non-icon-first-cell.html
@@ -1,0 +1,15 @@
+<main>
+  <div class="section">
+    <div class="base-card">
+      <div>
+        <div>
+          <p>Plain text first cell, not an icon.</p>
+          <h3>Card title</h3>
+        </div>
+        <div>
+          <picture><img src="" alt="card image" /></picture>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
## Summary
- Adds unit tests for the `base-card` c2 block (`libs/c2/blocks/base-card`), which previously had no coverage in `test/blocks`
- Covers: foreground/media decoration, standalone-link marking, featured-card media class, icon extraction with federated svg src rewrite, non-icon first cell left untouched, no-media/no-foreground edge cases
- Follows conventions from existing block tests (e.g. `test/blocks/brand-concierge`, `test/blocks/region-nav`)

Resolves: https://jira.corp.adobe.com/browse/MWPW-201346

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/base-card/base-card.test.js" --node-resolve --port=2000` — 7/7 passing
- [x] `npx eslint test/blocks/base-card/base-card.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

