### PR TITLE
[MWPW-200316] [Lingo] [C2] country cookie for geo-expansion markets

### DIFF
--- a/libs/c2/blocks/region-nav/region-nav.js
+++ b/libs/c2/blocks/region-nav/region-nav.js
@@ -11,6 +11,13 @@ import {
 
 let config;
 
+// Commerce geo-expansion markets: no adobe.com site; picker only sets the country
+// cookie and routes to US site
+const GEO_EXPANSION_MARKETS = new Set([
+  'mu', 'ke', 'gh', 'tz', 'am', 'az', 'ge', 'md', 'kz', 'kg', 'tj',
+  'tm', 'uz', 'tn', 'om', 'ma', 'lb', 'jo', 'iq', 'dz', 'bh',
+]);
+
 const queriedPages = [];
 
 function handleEvent({ prefix, link, callback } = {}) {
@@ -52,10 +59,15 @@ export function decorateLink(link, path, localeToLanguageMap = []) {
     ? getLanguage(languages, mergedLocales, pathname) : getLocale(mergedLocales, pathname);
   const prefix = currentLocaleObj.prefix.replace('/', '');
 
+  const geoSegment = pathname.split('/')[1]?.toLowerCase();
+  const geoMarket = GEO_EXPANSION_MARKETS.has(geoSegment) ? geoSegment : null;
+
   let { href } = link;
   if (href.endsWith('/')) href = href.slice(0, -1);
 
-  if (languageMap && !locales[prefix] && (languages && !languages[prefix])) {
+  if (geoMarket) {
+    href = href.replace(`/${geoMarket}`, '');
+  } else if (languageMap && !locales[prefix] && (languages && !languages[prefix])) {
     const valueInMap = languageMap[prefix];
     href = href.replace(`/${prefix}`, valueInMap ? `/${valueInMap}` : '');
   }
@@ -79,7 +91,7 @@ export function decorateLink(link, path, localeToLanguageMap = []) {
 
   link.addEventListener('click', (e) => {
     setInternational(prefix === '' ? 'us' : prefix);
-    const resolved = normCountryCode(prefix) || 'us';
+    const resolved = geoMarket || normCountryCode(prefix) || 'us';
     const market = resolved === 'la' ? 'latam' : resolved;
     if (market) setMarket(market);
     if (hrefAdapted) return;


### PR DESCRIPTION
Lingo : Ensure geo-expansion markets are setting the country cookie on legacy region picker for C2

- Set country cookie on the legacy C2 region picker, so that users can select their markets.
- On selecting, route the user to base US site and set International cookie to 'US'
- [List of Geos](https://adobe-my.sharepoint.com/:x:/p/blytt/IQCEdh2tC0p2SY-R0sQYtsRXAcfWmq5tzqKvOaZI95zPL0Y?e=Utd009)

Resolves: [MWPW-200136](https://jira.corp.adobe.com/browse/MWPW-200316)
[MWPW-201364](https://jira.corp.adobe.com/browse/MWPW-201364)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://c2geo-expansion--milo--adobecom.aem.page/?martech=off

**QA:**
https://www.stage.adobe.com/?milolibs=c2geo-expansion

