### PR TITLE
MWPW-201311: adds Search Terms to searchable field list

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -194,6 +194,7 @@ const defaultOptions = {
     'contentArea.detailText': 'Card Details',
     'overlays.label.description': 'Card Labels',
     'overlays.banner.description': 'Banner Descriptions',
+    'search.search': 'Search Terms',
   },
   sort: {
     featured: 'Featured',


### PR DESCRIPTION
**Description**
Adds Search Terms (search.search) to the default searchable field list within the CaaS card configuration options.

**Changes**
libs/blocks/caas-config/caas-config.js: Added 'search.search' : 'Search Terms' to defaultOptions configuration object.

**Resolves**
[MWPW-201311](https://jira.corp.adobe.com/browse/MWPW-201311)

**Usage**
CaaS: Add a new arbitrary entry un the card-metadata table with the Key "search"
` Arbitrary  | search: space separated terms to search. `

Milo configurator: Add Search Terms to the list of search fields
<img width="342" height="388" alt="Screenshot 2026-07-21 at 3 47 53 PM" src="https://github.com/user-attachments/assets/47ae9903-b610-424a-b873-3155a2d8f643" />

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-201311--milo--adobecom.aem.page/?martech=off


