### PR TITLE
Fix/ MWPW-201329 

### DIFF
--- a/libs/blocks/action-item/action-item.css
+++ b/libs/blocks/action-item/action-item.css
@@ -6,6 +6,10 @@
   width: 100%;
 }
 
+.action-item.static-links a.static {
+  text-decoration: none;
+}
+
 .action-item img {
   display: block;
   max-height: 240px;


### PR DESCRIPTION
[MWPW-201329](https://jira.corp.adobe.com/browse/MWPW-201329) 

Remove underline from action-item static links

Summary
Add CSS so .action-item.static-links a.static uses text-decoration: none.
Icon action gallery tile labels were underlined because global Milo styles set a { text-decoration: underline } and a.static only changes color.
Matches Figma static-link styling for gallery tiles when the mapper adds the static-links class.

