### PR TITLE
MWPW-201518: Clear account cookies (ims_country_code, acomsis) on feds gnav sign-out

### DIFF
--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -37,14 +37,19 @@ const decorateProfileLink = (service, path = '') => {
 
 const decorateAction = (label, path) => toFragment`<li><a class="feds-profile-action" href="${decorateProfileLink('adminconsole', path)}">${label}</a></li>`;
 
-const clearImsCountryCookie = () => {
+// Account cookies set at the edge / by the unav (Domain=adobe.com) that must not outlive sign-out.
+const SIGN_OUT_COOKIES = ['ims_country_code', 'acomsis', 'acomsis_stage'];
+
+const clearSignOutCookies = () => {
   const { host } = window.location;
   if (host !== 'adobe.com' && !host.endsWith('.adobe.com')) return;
-  const base = 'ims_country_code=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT;';
   const labels = host.split('.');
-  for (let i = 0; i < labels.length - 1; i += 1) {
-    document.cookie = `${base}domain=${labels.slice(i).join('.')};`;
-  }
+  SIGN_OUT_COOKIES.forEach((name) => {
+    const base = `${name}=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
+    for (let i = 0; i < labels.length - 1; i += 1) {
+      document.cookie = `${base}domain=${labels.slice(i).join('.')};`;
+    }
+  });
 };
 
 class ProfileDropdown {
@@ -173,7 +178,7 @@ class ProfileDropdown {
 
     signOutLink.addEventListener('click', (e) => {
       e.preventDefault();
-      clearImsCountryCookie();
+      clearSignOutCookies();
       window.dispatchEvent(new Event('feds:signOut'));
       window.adobeIMS.signOut({ redirect_uri: window.location.href });
     });

--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -37,14 +37,12 @@ const decorateProfileLink = (service, path = '') => {
 
 const decorateAction = (label, path) => toFragment`<li><a class="feds-profile-action" href="${decorateProfileLink('adminconsole', path)}">${label}</a></li>`;
 
-// Domain-scoped account cookies set at the edge / by the unav that must not outlive sign-out.
-const SIGN_OUT_COOKIES = ['ims_country_code', 'acomsis', 'acomsis_stage'];
-
 const clearSignOutCookies = () => {
   const { host } = window.location;
   if (host !== 'adobe.com' && !host.endsWith('.adobe.com')) return;
   const labels = host.split('.');
-  SIGN_OUT_COOKIES.forEach((name) => {
+  // Domain-scoped account cookies set at the edge / by the unav that must not outlive sign-out.
+  ['ims_country_code', 'acomsis', 'acomsis_stage'].forEach((name) => {
     const base = `${name}=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
     for (let i = 0; i < labels.length - 1; i += 1) {
       document.cookie = `${base}domain=${labels.slice(i).join('.')};`;

--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -37,6 +37,17 @@ const decorateProfileLink = (service, path = '') => {
 
 const decorateAction = (label, path) => toFragment`<li><a class="feds-profile-action" href="${decorateProfileLink('adminconsole', path)}">${label}</a></li>`;
 
+// The ims_country_code cookie is set at the edge (Home EdgeWorker, MWPW-200862) from the
+// signed-in user's IMS profile country and read for pricing. The Universal Nav already
+// clears it on sign-out (nest doPreLogOutProcessing); the feds gnav renders on surfaces
+// the unav does not (e.g. business.adobe.com, news.adobe.com), so clear it here too.
+// Domain=adobe.com so one clear removes it browser-wide; also clear the host-only variant.
+const clearImsCountryCookie = () => {
+  const expired = 'Thu, 01 Jan 1970 00:00:00 GMT';
+  document.cookie = `ims_country_code=;path=/;expires=${expired};`;
+  document.cookie = `ims_country_code=;path=/;expires=${expired};domain=adobe.com;`;
+};
+
 class ProfileDropdown {
   constructor({
     rawElem,
@@ -163,6 +174,7 @@ class ProfileDropdown {
 
     signOutLink.addEventListener('click', (e) => {
       e.preventDefault();
+      clearImsCountryCookie();
       window.dispatchEvent(new Event('feds:signOut'));
       window.adobeIMS.signOut({ redirect_uri: window.location.href });
     });

--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -37,7 +37,7 @@ const decorateProfileLink = (service, path = '') => {
 
 const decorateAction = (label, path) => toFragment`<li><a class="feds-profile-action" href="${decorateProfileLink('adminconsole', path)}">${label}</a></li>`;
 
-// Account cookies set at the edge / by the unav (Domain=adobe.com) that must not outlive sign-out.
+// Domain-scoped account cookies set at the edge / by the unav that must not outlive sign-out.
 const SIGN_OUT_COOKIES = ['ims_country_code', 'acomsis', 'acomsis_stage'];
 
 const clearSignOutCookies = () => {

--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -37,15 +37,14 @@ const decorateProfileLink = (service, path = '') => {
 
 const decorateAction = (label, path) => toFragment`<li><a class="feds-profile-action" href="${decorateProfileLink('adminconsole', path)}">${label}</a></li>`;
 
-// The ims_country_code cookie is set at the edge (Home EdgeWorker, MWPW-200862) from the
-// signed-in user's IMS profile country and read for pricing. The Universal Nav already
-// clears it on sign-out (nest doPreLogOutProcessing); the feds gnav renders on surfaces
-// the unav does not (e.g. business.adobe.com, news.adobe.com), so clear it here too.
-// Domain=adobe.com so one clear removes it browser-wide; also clear the host-only variant.
 const clearImsCountryCookie = () => {
-  const expired = 'Thu, 01 Jan 1970 00:00:00 GMT';
-  document.cookie = `ims_country_code=;path=/;expires=${expired};`;
-  document.cookie = `ims_country_code=;path=/;expires=${expired};domain=adobe.com;`;
+  const { host } = window.location;
+  if (host !== 'adobe.com' && !host.endsWith('.adobe.com')) return;
+  const base = 'ims_country_code=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT;';
+  const labels = host.split('.');
+  for (let i = 0; i < labels.length - 1; i += 1) {
+    document.cookie = `${base}domain=${labels.slice(i).join('.')};`;
+  }
 };
 
 class ProfileDropdown {


### PR DESCRIPTION
Resolves: [MWPW-201518](https://jira.corp.adobe.com/browse/MWPW-201518)

## What
On sign-out from the Milo "feds" global-nav profile menu, clear the account cookies that a signed-out user should not keep: the edge-set `ims_country_code` pricing cookie, plus the signed-in-status cookies `acomsis` (prod) / `acomsis_stage` (stage).

## Why
`ims_country_code` is set at the Akamai edge for signed-in users (their Adobe account country) and read for pricing. `acomsis` / `acomsis_stage` are the adobe.com signed-in-status cookies set by the Universal Nav and shared to feds surfaces via their `Domain` scope. The feds gnav previously cleared nothing on sign-out, so all three could outlive the session. Each cookie's `Domain` varies by environment (`adobe.com` on prod, `stage.adobe.com` on stage), so the clear walks the host → registrable-domain chain to cover both; the cookie name that doesn't apply to the current environment is a harmless no-op.

## Scope
- Covers the **feds `ProfileDropdown`** sign-out path (business.adobe.com, news.adobe.com, and other Milo sites that render the feds profile menu).
- Clears `ims_country_code`, `acomsis`, `acomsis_stage`.
- **Out of scope:** Milo pages that render the Universal Nav account menu use a different sign-out path (`getMessageEventListener` → `executeDefaultAction`) and are not touched here. The unav already resets `acomsis` itself.


## Test
- Branch: https://ims-country-signout-clear--milo--adobecom.aem.page/?martech=off
- On a signed-in feds-gnav surface (e.g. `business.adobe.com/...?milolibs=ims-country-signout-clear`): confirm the cookies are present, sign out, confirm they're gone.

**Steps to test:**

**Business.adobe.com flow**
1. go stage.adobe.com
2. sign in
3. open your developer tools -> application tab -> Cookies -> search for ims_country_code / acomsis_stage
4. you should see values set
5. go to https://business.stage.adobe.com/?milolibs=ims-country-signout-clear
6. look at your cookies - you should see the ims_country_code and acomsis_stage cookies
7. sign out
8. watch the cookies also be cleared

**News.adobe.com flow**
1. go stage.adobe.com
2. sign in
3. open your developer tools -> application tab -> Cookies -> search for ims_country_code / acomsis_stage
4. you should see values set
5. go to https://news.stage.adobe.com
6. you'll need to override the dropdown.js file in your browser with the file from this project unfortunately.
8. sign out
9. watch the cookies also be cleared on news



<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- Milo: https://ims-country-signout-clear--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=ims-country-signout-clear--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- Milo: https://ims-country-signout-clear--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-clear--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- Milo: https://ims-country-signout-clear--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-clear--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=ims-country-signout-clear--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=ims-country-signout-clear--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=ims-country-signout-clear--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=ims-country-signout-clear--milo--adobecom
</details>
