### PR TITLE
MWPW-201307 Support MAS headless in localnav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1464,7 +1464,14 @@ class Gnav {
     `;
 
     // Get all main menu items, but exclude any that are nested inside other features
-    const items = [...this.content.querySelectorAll('h2, p:only-child > strong > a, p:only-child > em > a, p:only-child > a.merch')]
+    const mainNavItemsSelector = [
+      'h2',
+      'p:only-child > strong > a',
+      'p:only-child > em > a',
+      'p:only-child > a.merch',
+      'p:only-child > a.con-button',
+    ].join(', ');
+    const items = [...this.content.querySelectorAll(mainNavItemsSelector)]
       .filter((item) => CONFIG.features.every((feature) => !item.closest(`.${feature}`)));
 
     // Save number of items to decide whether a hamburger menu is required
@@ -1494,9 +1501,11 @@ class Gnav {
     const hasAsyncDropdown = itemTopParent instanceof HTMLElement
       && itemTopParent.closest('.large-menu') instanceof HTMLElement;
     if (hasAsyncDropdown) return 'asyncDropdownTrigger';
-    const isPrimaryCta = item.closest('strong') instanceof HTMLElement;
+    const isPrimaryCta = item.closest('strong') instanceof HTMLElement
+      || item.matches('a.con-button.blue');
     if (isPrimaryCta) return 'primaryCta';
-    const isSecondaryCta = item.closest('em') instanceof HTMLElement;
+    const isSecondaryCta = item.closest('em') instanceof HTMLElement
+      || item.matches('a.con-button.outline');
     if (isSecondaryCta) return 'secondaryCta';
     const isText = !(item.querySelector('a') instanceof HTMLElement);
     if (isText) return 'text';

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -11,6 +11,7 @@ import {
   getFederatedUrl,
   getFedsPlaceholderConfig,
   createTag,
+  loadBlock,
 } from '../../../utils/utils.js';
 import { replaceKey, replaceText, fetchPlaceholders } from '../../../features/placeholders.js';
 import { PERSONALIZATION_TAGS, FLAGS, handleCommands } from '../../../features/personalization/personalization.js';
@@ -577,6 +578,13 @@ export function trigger({
 
 export const yieldToMain = () => new Promise((resolve) => { setTimeout(resolve, 0); });
 
+export async function resolveMerchCardFields(content, loader = loadBlock) {
+  const fields = content.querySelectorAll(
+    'a.merch-card-autoblock.link-block[href*="field="]',
+  );
+  await Promise.all([...fields].map((field) => loader(field)));
+}
+
 export async function fetchAndProcessPlainHtml({
   url,
   plainHTMLPromise = null,
@@ -657,6 +665,7 @@ export async function fetchAndProcessPlainHtml({
   }
 
   body.innerHTML = await replaceText(body.innerHTML, getFedsPlaceholderConfig());
+  if (shouldDecorateLinks) await resolveMerchCardFields(body);
   return body;
 }
 

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -842,6 +842,21 @@ describe('global navigation', () => {
       expect(!!localNav).to.be.true;
     });
 
+    it('renders a MAS field CTA after button decoration unwraps its authoring element', async () => {
+      const resolvedField = `
+        <div>
+          <p class="action-area">
+            <a is="checkout-link" class="con-button blue button-l" href="#free-trial">Free trial</a>
+          </p>
+        </div>`;
+      await createFullGlobalNavigation({ globalNavigation: `${gnavWithlocalNav}${resolvedField}` });
+
+      const freeTrial = [...document.querySelectorAll('.feds-nav .feds-cta--primary')]
+        .find((cta) => cta.textContent === 'Free trial');
+      expect(freeTrial).to.exist;
+      expect(freeTrial.href.endsWith('#free-trial')).to.be.true;
+    });
+
     it('should open local nav on click of localnav title', async () => {
       await createFullGlobalNavigation({ globalNavigation: gnavWithlocalNav });
       const localNavTitle = document.querySelector(selectors.localNavTitle);

--- a/test/blocks/global-navigation/utilities/merch-fields.test.js
+++ b/test/blocks/global-navigation/utilities/merch-fields.test.js
@@ -1,0 +1,33 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import {
+  resolveMerchCardFields,
+  toFragment,
+} from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
+
+describe('global navigation merch fields', () => {
+  it('resolves inline links and CTAs but not full cards or undecorated links', async () => {
+    const content = toFragment`<div>
+      <h2>
+        <a class="merch-card-autoblock link-block"
+          href="https://mas.adobe.com/studio.html#content-type=merch-card&field=ctas%5B1%5D">Nav link</a>
+      </h2>
+      <p><strong>
+        <a class="merch-card-autoblock link-block"
+          href="https://mas.adobe.com/studio.html#content-type=merch-card&field=ctas%5B4%5D">CTA</a>
+      </strong></p>
+      <a class="merch-card-autoblock link-block"
+        href="https://mas.adobe.com/studio.html#content-type=merch-card">Full card</a>
+      <a href="https://mas.adobe.com/studio.html#content-type=merch-card&field=ctas%5B2%5D">
+        Undecorated field
+      </a>
+    </div>`;
+    const loader = sinon.spy(async () => {});
+
+    await resolveMerchCardFields(content, loader);
+
+    expect(loader.callCount).to.equal(2);
+    expect(loader.firstCall.args[0].textContent).to.equal('Nav link');
+    expect(loader.secondCall.args[0].textContent).to.equal('CTA');
+  });
+});


### PR DESCRIPTION
* Resolve headless mas-fields in a localnav

Resolves: [MWPW-201307](https://jira.corp.adobe.com/browse/MWPW-201307)

**Test URLs:**
- Before: https://main--edu--adobecom.aem.page/education/students/online-learners?martech=off
- After: https://main--edu--adobecom.aem.page/education/students/online-learners?martech=off&milolibs=MWPW-201307


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=MWPW-201307--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=MWPW-201307--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-201307--milo--adobecom
- Milo: https://MWPW-201307--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-201307--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-201307--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-201307--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201307--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201307--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201307--milo--adobecom
- Milo: https://MWPW-201307--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201307--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201307--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201307--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201307--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201307--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201307--milo--adobecom
- Milo: https://MWPW-201307--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201307--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201307--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201307--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-201307--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-201307--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-201307--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-201307--milo--adobecom
</details>