### PR TITLE
[SR] Section hairline gap

### DIFF
--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -353,7 +353,11 @@ body:has(header.local-nav) .section.bento.stack-mobile {
 .section-background {
   z-index: 0;
 
-  &,
+  /* Bleed -0.5px into the section background top/bottom to remove hairline gap created by
+     sub-pixel compositor (from parallax/view-timeline animations during smooth-scroll) */
+  position: absolute;
+  inset: -0.5px 0;
+
   & > * {
     position: absolute;
     inset: 0;

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -130,6 +130,9 @@ body:has(header.local-nav) .section.bento.stack-mobile {
     overflow: clip;
     z-index: 3;
     margin-block: calc(-1 * var(--s2a-border-radius-lg));
+    /* Bleed 1px into the section top/bottom to remove hairline gap created by
+     sub-pixel compositor */
+    inset: 1px 0;
   }
 
   &.rounded-corners-top {
@@ -353,10 +356,10 @@ body:has(header.local-nav) .section.bento.stack-mobile {
 .section-background {
   z-index: 0;
 
-  /* Bleed -0.5px into the section background top/bottom to remove hairline gap created by
+  /* Bleed -1px into the section background top/bottom to remove hairline gap created by
      sub-pixel compositor (from parallax/view-timeline animations during smooth-scroll) */
   position: absolute;
-  inset: -0.5px 0;
+  inset: -1px 0;
 
   & > * {
     position: absolute;

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -130,9 +130,6 @@ body:has(header.local-nav) .section.bento.stack-mobile {
     overflow: clip;
     z-index: 3;
     margin-block: calc(-1 * var(--s2a-border-radius-lg));
-    /* Bleed 1px into the section top/bottom to remove hairline gap created by
-     sub-pixel compositor */
-    inset: 1px 0;
   }
 
   &.rounded-corners-top {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
This issue is showing up more on the new Cpro pages due to the dark background throughout the page.
* Added -0.5px inset to top and bottom of `.section-background` to remove hairline gap.


Resolves: [MWPW-201576](https://jira.corp.adobe.com/browse/MWPW-201576)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=sr-section-gap&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

Before:
<img width="288" height="225" alt="image" src="https://github.com/user-attachments/assets/4242d71d-97cd-4226-a097-1084b980f63a" />

After:
<img width="290" height="303" alt="image" src="https://github.com/user-attachments/assets/10aa536a-7d90-46ac-831d-d7f499ec2ce3" />








