### PR TITLE
MWPW-201713: Keep promo code on inline prices when unwrapping mas-field

### DIFF
--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -237,6 +237,13 @@ async function createInline(el, options) {
     }
     copyMasFieldIdToParent(masField, 'fragment-id');
     copyMasFieldIdToParent(masField, 'variation-id');
+    // Prices lose their mas-field ancestor on unwrap, and with it the promo code the
+    // price options provider reads from it — stamp the code on each price first.
+    const promotionCode = masField.getAttribute('data-promotion-code');
+    if (promotionCode) {
+      content.querySelectorAll('span[is="inline-price"]:not([data-promotion-code])')
+        .forEach((price) => price.setAttribute('data-promotion-code', promotionCode));
+    }
     masField.replaceWith(...[...content.childNodes]);
 
     // Defer decorateButtons until the last CTA mas-field in this container has been

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -1,4 +1,4 @@
-import { createTag, getConfig } from '../../utils/utils.js';
+import { createTag, getConfig, loadStyle } from '../../utils/utils.js';
 import { decorateButtons, getBlockSize } from '../../utils/decorate.js';
 import { postProcessAutoblock } from '../merch/autoblock.js';
 import {
@@ -237,12 +237,16 @@ async function createInline(el, options) {
     }
     copyMasFieldIdToParent(masField, 'fragment-id');
     copyMasFieldIdToParent(masField, 'variation-id');
-    // Prices lose their mas-field ancestor on unwrap, and with it the promo code the
-    // price options provider reads from it — stamp the code on each price first.
+    // Prices lose their mas-field ancestor on unwrap, and with it both the promo code the
+    // price options provider reads from it and the mas-field-scoped strikethrough styling —
+    // stamp the code on each price and load the page-level merch price styles first.
     const promotionCode = masField.getAttribute('data-promotion-code');
     if (promotionCode) {
       content.querySelectorAll('span[is="inline-price"]:not([data-promotion-code])')
         .forEach((price) => price.setAttribute('data-promotion-code', promotionCode));
+    }
+    if (content.querySelector('span[is="inline-price"]')) {
+      loadStyle(`${getConfig().base}/blocks/merch/merch.css`);
     }
     masField.replaceWith(...[...content.childNodes]);
 

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -237,13 +237,14 @@ async function createInline(el, options) {
     }
     copyMasFieldIdToParent(masField, 'fragment-id');
     copyMasFieldIdToParent(masField, 'variation-id');
-    // Prices lose their mas-field ancestor on unwrap, and with it both the promo code the
-    // price options provider reads from it and the mas-field-scoped strikethrough styling —
-    // stamp the code on each price and load the page-level merch price styles first.
+    // Commerce elements lose their mas-field ancestor on unwrap, and with it both the promo
+    // code the options providers read from it and the mas-field-scoped strikethrough styling —
+    // stamp the code on each price and checkout element and load the page-level merch price
+    // styles first.
     const promotionCode = masField.getAttribute('data-promotion-code');
     if (promotionCode) {
-      content.querySelectorAll('span[is="inline-price"]:not([data-promotion-code])')
-        .forEach((price) => price.setAttribute('data-promotion-code', promotionCode));
+      content.querySelectorAll('span[is="inline-price"]:not([data-promotion-code]), a[is="checkout-link"]:not([data-promotion-code]), button[is="checkout-button"]:not([data-promotion-code])')
+        .forEach((commerceEl) => commerceEl.setAttribute('data-promotion-code', promotionCode));
     }
     if (content.querySelector('span[is="inline-price"]')) {
       loadStyle(`${getConfig().base}/blocks/merch/merch.css`);

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -22,6 +22,12 @@ if (!customElements.get('mas-field')) {
         } else if (field === 'ctas-checkout') {
           // Simulates a plain commerce link (no em/strong from MAS — e.g. checkout-link)
           content.innerHTML = '<a is="checkout-link" href="https://commerce.adobe.com/">Buy now</a>';
+        } else if (field === 'prices-promo') {
+          // Simulates a prices field from a fragment with an applied promo project:
+          // inline-only content (prices + terms link, no block elements) so the unwrap
+          // branch fires, with the promo code carried on the mas-field element.
+          this.setAttribute('data-promotion-code', 'PROMO26');
+          content.innerHTML = '<span is="inline-price" data-template="price" data-wcs-osi="OSI-X"></span> <a href="https://www.adobe.com/">See terms</a>';
         } else {
           content.textContent = 'Resolved inline value';
         }
@@ -305,6 +311,24 @@ describe('merch-card-autoblock autoblock', () => {
       const linkNotDecorated = p.querySelector('a.some-class');
       expect(linkNotDecorated).to.exist;
       expect(linkNotDecorated.className).to.equal('some-class merch-card-autoblock link-block');
+    });
+
+    it('stamps the mas-field promo code onto inline prices before unwrapping', async () => {
+      const section = document.createElement('div');
+      const p = document.createElement('p');
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=promo-1&field=prices-promo';
+      a.textContent = '[[promo-test:prices-promo]]';
+      p.append(a);
+      section.append(p);
+      document.body.append(section);
+
+      await init(a);
+
+      expect(document.querySelector('mas-field')).to.not.exist;
+      const price = p.querySelector('span[is="inline-price"]');
+      expect(price).to.exist;
+      expect(price.getAttribute('data-promotion-code')).to.equal('PROMO26');
     });
 
     it('upgrades plain commerce links and decorates using block context', async () => {

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -331,6 +331,21 @@ describe('merch-card-autoblock autoblock', () => {
       expect(price.getAttribute('data-promotion-code')).to.equal('PROMO26');
     });
 
+    it('loads merch.css when unwrapping price content', async () => {
+      const section = document.createElement('div');
+      const p = document.createElement('p');
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=promo-2&field=prices-promo';
+      a.textContent = '[[promo-css-test:prices-promo]]';
+      p.append(a);
+      section.append(p);
+      document.body.append(section);
+
+      await init(a);
+
+      expect(document.head.querySelector('link[href*="blocks/merch/merch.css"]')).to.exist;
+    });
+
     it('upgrades plain commerce links and decorates using block context', async () => {
       const section = document.createElement('div');
       const siblingBtn = document.createElement('a');

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -22,6 +22,10 @@ if (!customElements.get('mas-field')) {
         } else if (field === 'ctas-checkout') {
           // Simulates a plain commerce link (no em/strong from MAS — e.g. checkout-link)
           content.innerHTML = '<a is="checkout-link" href="https://commerce.adobe.com/">Buy now</a>';
+        } else if (field === 'ctas-promo') {
+          // Simulates a CTA field from a fragment with an applied promo project.
+          this.setAttribute('data-promotion-code', 'PROMO26');
+          content.innerHTML = '<a is="checkout-link" href="https://commerce.adobe.com/">Buy now</a>';
         } else if (field === 'prices-promo') {
           // Simulates a prices field from a fragment with an applied promo project:
           // inline-only content (prices + terms link, no block elements) so the unwrap
@@ -329,6 +333,24 @@ describe('merch-card-autoblock autoblock', () => {
       const price = p.querySelector('span[is="inline-price"]');
       expect(price).to.exist;
       expect(price.getAttribute('data-promotion-code')).to.equal('PROMO26');
+    });
+
+    it('stamps the mas-field promo code onto checkout links before unwrapping', async () => {
+      const section = document.createElement('div');
+      const p = document.createElement('p');
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=promo-3&field=ctas-promo';
+      a.textContent = '[[promo-cta-test:ctas-promo]]';
+      p.append(a);
+      section.append(p);
+      document.body.append(section);
+
+      await init(a);
+
+      expect(document.querySelector('mas-field')).to.not.exist;
+      const cta = section.querySelector('a[is="checkout-link"]');
+      expect(cta).to.exist;
+      expect(cta.getAttribute('data-promotion-code')).to.equal('PROMO26');
     });
 
     it('loads merch.css when unwrapping price content', async () => {


### PR DESCRIPTION
Resolves https://jira.corp.adobe.com/browse/MWPW-201713

When merch-card-autoblock unwraps a mas-field whose inline content contains a link (marquee price lines with a See terms link), the price spans lose the mas-field ancestor that supplies the promotion code, so they re-resolve at the base price. This stamps data-promotion-code onto each inline price before the unwrap.

Test URLs:

- Before: https://main--edu--adobecom.aem.page/education/students/creativecloud?instant=2026-08-19T00%3A00%3A00.000Z&mep=off&mas.preview=on&clearCaches.io&maslibs=mwpw-201713
- After: https://main--edu--adobecom.aem.page/education/students/creativecloud?instant=2026-08-19T00%3A00%3A00.000Z&mep=off&mas.preview=on&clearCaches.io&maslibs=mwpw-201713&milolibs=mwpw-201713

Verified: hero marquee promo line reads US$19.99/mo on Before, US$15.99/mo (with promo code stamped) on After.





