### PR TITLE
[SR] Tabs Block (Wave 3)

### DIFF
--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -35,12 +35,6 @@
       padding: var(--s2a-spacing-2xs) var(--s2a-spacing-lg);
     }
 
-    .tab-list-container::before {
-      content: attr(data-pretext);
-      color: var(--s2a-color-content-default);
-      white-space: nowrap;
-    }
-
     button.tab-button {
       display: flex;
       align-items: center;

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -24,22 +24,28 @@
         display: flex;
         align-items: center;
         min-width: 0;
-        gap: var(--s2a-spacing-lg);
-        background: var(--s2a-color-transparent-black-04);
+        gap: var(--s2a-spacing-md);
+        background: var(--s2a-color-background-subtle);
         border-radius: var(--pill-rounded-corners-setting);
-        padding: var(--s2a-spacing-2xs) var(--s2a-spacing-lg);
+        padding: var(--s2a-spacing-sm) var(--s2a-spacing-md);
+      }
+
+      .tab-list-label {
+        color: var(--s2a-color-content-subtle);
+        white-space: nowrap;
+        margin: 0;
       }
 
       button.tab-button {
         display: flex;
         align-items: center;
-        gap: var(--s2a-spacing-2xs);
+        gap: var(--s2a-spacing-xs);
         height: auto;
         flex: 0 0 auto;
         padding: 0;
         background: transparent;
         border: none;
-        color: var(--s2a-color-content-default);
+        color: var(--s2a-color-content-subtle);
         cursor: pointer;
         font-family: var(--body-font-family);
         text-decoration: none;
@@ -50,9 +56,9 @@
         &::before {
           content: '';
           box-sizing: border-box;
-          width: 14px;
-          height: 14px;
-          min-width: 14px;
+          width: 20px;
+          height: 20px;
+          min-width: 20px;
           border: 2px solid var(--s2a-color-gray-400);
           border-radius: 100%;
           transition: border 150ms;
@@ -62,9 +68,13 @@
           border-color: var(--pill-bg-color-selected);
         }
 
-        &[aria-checked="true"]::before {
-          border-width: 5px;
-          border-color: var(--pill-bg-color-selected);
+        &[aria-checked="true"] {
+          color: var(--s2a-color-content-default);
+
+          &::before {
+            border-width: 6px;
+            border-color: var(--pill-bg-color-selected);
+          }
         }
 
         &:focus-visible {

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -190,7 +190,25 @@
         background: var(--s2a-color-background-inverse);
         color: var(--s2a-color-content-inverse);
       }
+
+      button.tab-button:hover:not([aria-selected="true"]) {
+        color: var(--s2a-color-gray-100);
+      }
+
+      .tab-indicator {
+        background: var(--s2a-color-background-inverse);
+      }
     }
+  }
+
+  /*
+   * Plain pill is the only variant that keeps a solid block-level background
+   * in light mode (radio/quiet already force it transparent unconditionally
+   * above). Nothing overrode it for dark, so it stayed at the light value —
+   * matching radio/quiet's transparent treatment for now.
+   */
+  &.dark:not(.radio):not(.quiet) {
+    background: transparent;
   }
 
   .tabs-wrapper {

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -19,58 +19,58 @@
 
     [role='radiogroup'] {
       overflow: visible;
-    }
 
-    .tab-list-container {
-      display: flex;
-      align-items: center;
-      min-width: 0;
-      gap: var(--s2a-spacing-lg);
-      background: var(--s2a-color-transparent-black-04);
-      border-radius: var(--pill-rounded-corners-setting);
-      padding: var(--s2a-spacing-2xs) var(--s2a-spacing-lg);
-    }
-
-    button.tab-button {
-      display: flex;
-      align-items: center;
-      gap: var(--s2a-spacing-2xs);
-      height: auto;
-      flex: 0 0 auto;
-      padding: 0;
-      background: transparent;
-      border: none;
-      color: var(--s2a-color-content-default);
-      cursor: pointer;
-      font-family: var(--body-font-family);
-      text-decoration: none;
-      outline: none;
-      -webkit-tap-highlight-color: transparent;
-      white-space: nowrap;
-
-      &::before {
-        content: '';
-        box-sizing: border-box;
-        width: 14px;
-        height: 14px;
-        min-width: 14px;
-        border: 2px solid var(--s2a-color-gray-400);
-        border-radius: 100%;
-        transition: border 150ms;
+      .tab-list-container {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        gap: var(--s2a-spacing-lg);
+        background: var(--s2a-color-transparent-black-04);
+        border-radius: var(--pill-rounded-corners-setting);
+        padding: var(--s2a-spacing-2xs) var(--s2a-spacing-lg);
       }
 
-      &:hover::before {
-        border-color: var(--pill-bg-color-selected);
-      }
+      button.tab-button {
+        display: flex;
+        align-items: center;
+        gap: var(--s2a-spacing-2xs);
+        height: auto;
+        flex: 0 0 auto;
+        padding: 0;
+        background: transparent;
+        border: none;
+        color: var(--s2a-color-content-default);
+        cursor: pointer;
+        font-family: var(--body-font-family);
+        text-decoration: none;
+        outline: none;
+        -webkit-tap-highlight-color: transparent;
+        white-space: nowrap;
 
-      &[aria-checked="true"]::before {
-        border-width: 5px;
-        border-color: var(--pill-bg-color-selected);
-      }
+        &::before {
+          content: '';
+          box-sizing: border-box;
+          width: 14px;
+          height: 14px;
+          min-width: 14px;
+          border: 2px solid var(--s2a-color-gray-400);
+          border-radius: 100%;
+          transition: border 150ms;
+        }
 
-      &:focus-visible {
-        outline: 2px solid var(--s2a-color-blue-800);
-        outline-offset: 2px;
+        &:hover::before {
+          border-color: var(--pill-bg-color-selected);
+        }
+
+        &[aria-checked="true"]::before {
+          border-width: 5px;
+          border-color: var(--pill-bg-color-selected);
+        }
+
+        &:focus-visible {
+          outline: 2px solid var(--s2a-color-blue-800);
+          outline-offset: 2px;
+        }
       }
     }
   }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -1,3 +1,4 @@
+/* stylelint-disable no-descending-specificity */
 :root {
   --pill-bg-color-selected: var(--s2a-color-background-knockout);
   --pill-rounded-corners-setting: 50px;
@@ -11,6 +12,94 @@
 
   &.background-transparent {
     background: transparent;
+  }
+
+  &.radio {
+    background: transparent;
+
+    .tab-dropdown {
+      display: none;
+    }
+
+    [role='radiogroup'] {
+      display: flex;
+      align-items: center;
+      gap: var(--s2a-spacing-lg);
+      overflow: visible;
+      background: var(--s2a-color-transparent-black-04);
+      border-radius: var(--pill-rounded-corners-setting);
+    }
+
+    .tab-list-container {
+      min-width: 0;
+      gap: var(--s2a-spacing-lg);
+      padding: var(--s2a-spacing-2xs) var(--s2a-spacing-lg);
+    }
+
+    .tab-list-container::before {
+      content: attr(data-pretext);
+      color: var(--s2a-color-content-default);
+      white-space: nowrap;
+    }
+
+    button.tab-button {
+      display: flex;
+      align-items: center;
+      gap: var(--s2a-spacing-2xs);
+      height: auto;
+      flex: 0 0 auto;
+      padding: 0;
+      background: transparent;
+      border: none;
+      color: var(--s2a-color-content-default);
+      cursor: pointer;
+      font-family: var(--body-font-family);
+      text-decoration: none;
+      outline: none;
+      -webkit-tap-highlight-color: transparent;
+      white-space: nowrap;
+
+      &::before {
+        content: '';
+        box-sizing: border-box;
+        width: 14px;
+        height: 14px;
+        min-width: 14px;
+        border: 2px solid var(--s2a-color-gray-400);
+        border-radius: 100%;
+        transition: border 150ms;
+      }
+
+      &:hover::before {
+        border-color: var(--pill-bg-color-selected);
+      }
+
+      &[aria-checked="true"]::before {
+        border-width: 5px;
+        border-color: var(--pill-bg-color-selected);
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--s2a-color-blue-800);
+        outline-offset: 2px;
+      }
+    }
+
+    @media (width < 768px) {
+      [role='radiogroup'] {
+        display: none;
+      }
+
+      .tab-dropdown {
+        display: block;
+        width: 100%;
+        padding: var(--s2a-spacing-2xs) var(--s2a-spacing-lg);
+        border: 1px solid var(--s2a-color-gray-300);
+        border-radius: var(--pill-rounded-corners-setting);
+        background: var(--s2a-color-background-default);
+        color: var(--s2a-color-content-default);
+      }
+    }
   }
 
   .tabs-wrapper {

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -14,9 +14,15 @@
     background: transparent;
   }
 
-  &.radio {
-    background: transparent;
-
+  /*
+   * Every variant below scopes through `> .tabs-wrapper` first. A
+   * `.tabs-wrapper` only ever contains this block's own tab list — nested
+   * tabs blocks live under `.tab-content-container` instead — so this single
+   * direct-child step guarantees a variant's rules can never bleed into a
+   * differently-classed tabs block nested inside one of this block's panels,
+   * regardless of shared class/role names further down the tree.
+   */
+  &.radio > .tabs-wrapper {
     [role='radiogroup'] {
       overflow: visible;
 
@@ -83,6 +89,50 @@
         }
       }
     }
+  }
+
+  &.radio {
+    background: transparent;
+  }
+
+  &.quiet > .tabs-wrapper {
+    [role='tablist'] {
+      background: transparent;
+      border-radius: 0;
+      padding-bottom: 20px;
+      padding-top: 20px;
+
+      .tab-list-container {
+        min-width: 0;
+        gap: var(--s2a-spacing-lg);
+      }
+
+      .btn-wrapper {
+        padding: 0;
+        align-items: center;
+        align-self: auto;
+      }
+
+      button.tab-button {
+        border-radius: 0;
+        border-width: 0;
+        border-bottom: var(--s2a-border-width-md) solid transparent;
+        padding: var(--s2a-spacing-3xs) 0;
+        height: auto;
+        flex: 0 0 auto;
+        color: var(--s2a-color-content-subtle);
+
+        &[aria-selected="true"] {
+          background: transparent;
+          color: var(--s2a-color-content-default);
+          border-bottom-color: var(--s2a-color-blue-800);
+        }
+      }
+    }
+  }
+
+  &.quiet {
+    background: transparent;
   }
 
   .tabs-wrapper {

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -22,17 +22,16 @@
     }
 
     [role='radiogroup'] {
-      display: flex;
-      align-items: center;
-      gap: var(--s2a-spacing-lg);
       overflow: visible;
-      background: var(--s2a-color-transparent-black-04);
-      border-radius: var(--pill-rounded-corners-setting);
     }
 
     .tab-list-container {
+      display: flex;
+      align-items: center;
       min-width: 0;
       gap: var(--s2a-spacing-lg);
+      background: var(--s2a-color-transparent-black-04);
+      border-radius: var(--pill-rounded-corners-setting);
       padding: var(--s2a-spacing-2xs) var(--s2a-spacing-lg);
     }
 

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -79,16 +79,21 @@
           transition: border 150ms;
         }
 
-        &:hover::before {
-          border-color: var(--pill-bg-color-selected);
+        &:hover {
+          color: var(--s2a-color-content-default);
+
+          &::before {
+            border-color: var(--pill-bg-color-selected);
+          }
         }
 
         &[aria-checked="true"] {
           color: var(--s2a-color-content-default);
 
           &::before {
-            border-width: 6px;
             border-color: var(--pill-bg-color-selected);
+            background: var(--pill-bg-color-selected);
+            box-shadow: inset 0 0 0 4px var(--s2a-color-background-subtle);
           }
         }
 
@@ -102,6 +107,31 @@
 
   &.radio {
     background: transparent;
+  }
+
+  /*
+   * Confirmed against Figma: radio-dark's container is #131313
+   * (--s2a-color-gray-900, i.e. --s2a-color-background-default), not
+   * --s2a-color-background-subtle (--s2a-color-gray-700, lighter). The
+   * selected dot's gap must match this same value so it keeps blending
+   * seamlessly with the container instead of showing as a visible ring.
+   */
+  &.radio.dark > .tabs-wrapper {
+    [role='radiogroup'] {
+      .tab-list-container {
+        background: var(--s2a-color-background-default);
+      }
+
+      button.tab-button[aria-checked="true"]::before {
+        border-color: var(--s2a-color-background-inverse);
+        background: var(--s2a-color-background-inverse);
+        box-shadow: inset 0 0 0 4px var(--s2a-color-background-default);
+      }
+
+      button.tab-button:hover::before {
+        border-color: var(--s2a-color-background-inverse);
+      }
+    }
   }
 
   &.quiet > .tabs-wrapper {

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -192,11 +192,15 @@
       }
 
       button.tab-button:hover:not([aria-selected="true"]) {
-        color: var(--s2a-color-gray-100);
+        color: var(--s2a-color-content-default);
       }
 
       .tab-indicator {
         background: var(--s2a-color-background-inverse);
+      }
+
+      button.tab-button:focus-visible {
+        outline: var(--s2a-border-width-sm) solid var(--s2a-color-focus-ring-default);
       }
     }
   }
@@ -287,7 +291,7 @@
       height: 32px;
 
       &:hover {
-        color: #2c2c2c;
+        color: var(--s2a-color-content-default);
       }
 
       &[aria-selected="true"] {
@@ -297,7 +301,7 @@
       }
 
       &:focus-visible {
-        outline: 2px solid var(--s2a-color-blue-800);
+        outline: var(--s2a-border-width-sm) solid var(--s2a-color-focus-ring-default);
         outline-offset: -2px;
       }
     }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -1,6 +1,15 @@
 /* stylelint-disable no-descending-specificity */
 :root {
-  --pill-bg-color-selected: var(--s2a-color-background-knockout);
+  /*
+   * background-inverse (not background-knockout) is the correct token here:
+   * knockout resolves to the same fixed near-black value in both the light
+   * and dark semantic token sets, while inverse actually flips (near-black in
+   * light, white in dark) — required for the selected pill/radio-dot to stay
+   * visible once a `.dark` block renders on a dark surface. This produces the
+   * exact same value as before in light mode (both resolve to gray-1000), so
+   * it's a no-op visually today.
+   */
+  --pill-bg-color-selected: var(--s2a-color-background-inverse);
   --pill-rounded-corners-setting: 50px;
 }
 
@@ -135,6 +144,24 @@
     background: transparent;
   }
 
+  /*
+   * `.dark` is an opt-in variant class (like radio/quiet), not inherited from
+   * an ancestor section. It relies on Milo's global `.dark { ... }` rule
+   * (libs/c2/styles/styles.css) to redefine every --s2a-color-* semantic
+   * token on this exact element, which is why content-subtle/content-default
+   * /content-inverse/background-inverse/background-subtle usages elsewhere
+   * in this file (radio, quiet) already adapt automatically with no extra
+   * rules needed. The only gap is the plain pill variant's container
+   * background, which uses a raw black-tinted primitive with no dark
+   * equivalent — excluded here from radio/quiet since those already have
+   * their own correct, theme-aware background.
+   */
+  &.dark:not(.radio):not(.quiet) > .tabs-wrapper {
+    [role='tablist'] {
+      background: var(--s2a-color-background-subtle);
+    }
+  }
+
   .tabs-wrapper {
     display: flex;
     width: 100%;
@@ -189,7 +216,7 @@
     }
 
     button.tab-button {
-      color: var(--s2a-color-transparent-black-64);
+      color: var(--s2a-color-content-subtle);
       cursor: pointer;
       font-family: var(--body-font-family);
       text-align: center;
@@ -215,7 +242,7 @@
       }
 
       &[aria-selected="true"] {
-        color: var(--s2a-color-content-knockout);
+        color: var(--s2a-color-content-inverse);
         background: var(--pill-bg-color-selected);
         transition: background 0s 0.25s, color 0.2s 0s ease-out;
       }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -17,10 +17,6 @@
   &.radio {
     background: transparent;
 
-    .tab-dropdown {
-      display: none;
-    }
-
     [role='radiogroup'] {
       overflow: visible;
     }
@@ -75,22 +71,6 @@
       &:focus-visible {
         outline: 2px solid var(--s2a-color-blue-800);
         outline-offset: 2px;
-      }
-    }
-
-    @media (width < 768px) {
-      [role='radiogroup'] {
-        display: none;
-      }
-
-      .tab-dropdown {
-        display: block;
-        width: 100%;
-        padding: var(--s2a-spacing-2xs) var(--s2a-spacing-lg);
-        border: 1px solid var(--s2a-color-gray-300);
-        border-radius: var(--pill-rounded-corners-setting);
-        background: var(--s2a-color-background-default);
-        color: var(--s2a-color-content-default);
       }
     }
   }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -176,19 +176,20 @@
 
   /*
    * `.dark` is an opt-in variant class (like radio/quiet), not inherited from
-   * an ancestor section. It relies on Milo's global `.dark { ... }` rule
-   * (libs/c2/styles/styles.css) to redefine every --s2a-color-* semantic
-   * token on this exact element, which is why content-subtle/content-default
-   * /content-inverse/background-inverse/background-subtle usages elsewhere
-   * in this file (radio, quiet) already adapt automatically with no extra
-   * rules needed. The only gap is the plain pill variant's container
-   * background, which uses a raw black-tinted primitive with no dark
-   * equivalent — excluded here from radio/quiet since those already have
-   * their own correct, theme-aware background.
+   * an ancestor section. Matches radio-dark's confirmed container value
+   * (#131313 / --s2a-color-background-default) for consistency. The selected
+   * pill's background/text are set explicitly here rather than relying on
+   * --pill-bg-color-selected / --s2a-color-content-inverse to flip on their
+   * own — same fix that was needed for radio-dark's selected dot.
    */
   &.dark:not(.radio):not(.quiet) > .tabs-wrapper {
     [role='tablist'] {
-      background: var(--s2a-color-background-subtle);
+      background: var(--s2a-color-background-default);
+
+      button.tab-button[aria-selected="true"] {
+        background: var(--s2a-color-background-inverse);
+        color: var(--s2a-color-content-inverse);
+      }
     }
   }
 

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -15,6 +15,100 @@
     background: transparent;
   }
 
+  .tabs-wrapper {
+    display: flex;
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .tab-indicator {
+    position: absolute;
+    top: var(--s2a-spacing-2xs);
+    bottom: var(--s2a-spacing-2xs);
+    left: 0;
+    background: var(--pill-bg-color-selected);
+    border-radius: var(--pill-rounded-corners-setting);
+    transition: transform 0.25s ease, width 0.35s ease;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  [role='tablist'] {
+    position: relative;
+    display: flex;
+    z-index: 2;
+
+    /* ScrollProps - If content exceeds height of container, overflow! */
+    overflow: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none; /* Use alongside -webkit-scrollbar */
+    background: var(--s2a-color-transparent-black-04);
+    border-radius: var(--pill-rounded-corners-setting);
+
+    &::-webkit-scrollbar {
+      display: none; /* Safari and Chrome */
+    }
+
+    .tab-list-container {
+      display: flex;
+      width: auto;
+      min-width: 300px;
+      box-sizing: content-box;
+      align-items: center;
+      align-self: stretch;
+      position: relative; /* for slider */
+    }
+
+    .btn-wrapper {
+      display: flex;
+      padding: var(--s2a-spacing-2xs);
+      flex-direction: column;
+      align-items: flex-start;
+      align-self: stretch;
+    }
+
+    button.tab-button {
+      color: var(--s2a-color-content-subtle);
+      cursor: pointer;
+      font-family: var(--body-font-family);
+      text-align: center;
+      font-style: normal;
+      margin: 0;
+      border-radius: var(--pill-rounded-corners-setting);
+      border: var(--s2a-border-width-md) solid transparent;
+      padding: 0 var(--s2a-spacing-lg);
+      text-decoration: none;
+      transition: color 0.1s ease-in-out;
+      outline: none;
+      -webkit-tap-highlight-color: transparent;
+      white-space: nowrap;
+      width: auto;
+      position: relative;
+      z-index: 1;
+      flex: 1 0 auto;
+      background: transparent;
+      height: 32px;
+
+      &:hover {
+        color: var(--s2a-color-content-default);
+      }
+
+      &[aria-selected="true"] {
+        color: var(--s2a-color-content-inverse);
+        background: var(--pill-bg-color-selected);
+        transition: background 0s 0.25s, color 0.2s 0s ease-out;
+      }
+
+      &:focus-visible {
+        outline: var(--s2a-border-width-sm) solid var(--s2a-color-focus-ring-default);
+        outline-offset: -2px;
+      }
+    }
+  }
+
+  /* --- Variants below override the defaults above --- */
+
   &.radio > .tabs-wrapper {
     [role='radiogroup'] {
       overflow: visible;
@@ -166,101 +260,9 @@
     background: transparent;
   }
 
-  .tabs-wrapper {
-    display: flex;
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .tab-indicator {
-    position: absolute;
-    top: var(--s2a-spacing-2xs);
-    bottom: var(--s2a-spacing-2xs);
-    left: 0;
-    background: var(--pill-bg-color-selected);
-    border-radius: var(--pill-rounded-corners-setting);
-    transition: transform 0.25s ease, width 0.35s ease;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  [role='tablist'] {
-    position: relative;
-    display: flex;
-    z-index: 2;
-
-    /* ScrollProps - If content exceeds height of container, overflow! */
-    overflow: auto;
-    overflow-y: hidden;
-    scroll-snap-type: x mandatory;
-    scrollbar-width: none; /* Use alongside -webkit-scrollbar */
-    background: var(--s2a-color-transparent-black-04);
-    border-radius: var(--pill-rounded-corners-setting);
-
-    &::-webkit-scrollbar {
-      display: none; /* Safari and Chrome */
-    }
-
-    .tab-list-container {
-      display: flex;
-      width: auto;
-      min-width: 300px;
-      box-sizing: content-box;
-      align-items: center;
-      align-self: stretch;
-      position: relative; /* for slider */
-    }
-
-    .btn-wrapper {
-      display: flex;
-      padding: var(--s2a-spacing-2xs);
-      flex-direction: column;
-      align-items: flex-start;
-      align-self: stretch;
-    }
-
-    button.tab-button {
-      color: var(--s2a-color-content-subtle);
-      cursor: pointer;
-      font-family: var(--body-font-family);
-      text-align: center;
-      font-style: normal;
-      margin: 0;
-      border-radius: var(--pill-rounded-corners-setting);
-      border: var(--s2a-border-width-md) solid transparent;
-      padding: 0 var(--s2a-spacing-lg);
-      text-decoration: none;
-      transition: color 0.1s ease-in-out;
-      outline: none;
-      -webkit-tap-highlight-color: transparent;
-      white-space: nowrap;
-      width: auto;
-      position: relative;
-      z-index: 1;
-      flex: 1 0 auto;
-      background: transparent;
-      height: 32px;
-
-      &:hover {
-        color: var(--s2a-color-content-default);
-      }
-
-      &[aria-selected="true"] {
-        color: var(--s2a-color-content-inverse);
-        background: var(--pill-bg-color-selected);
-        transition: background 0s 0.25s, color 0.2s 0s ease-out;
-      }
-
-      &:focus-visible {
-        outline: var(--s2a-border-width-sm) solid var(--s2a-color-focus-ring-default);
-        outline-offset: -2px;
-      }
-    }
-  }
-
   @media (width < 768px) {
     overflow-x: clip;
-    
+
     .tabs-wrapper {
       width: 100vw;
       position: relative;
@@ -280,9 +282,15 @@
       margin: 0 var(--s2a-spacing-24);
     }
 
-    &.quiet > .tabs-wrapper {
-      width: auto;
-      margin: 0;
+    &.quiet {
+      > .tabs-wrapper {
+        width: auto;
+        margin: 0;
+      }
+
+      &.center > .tabs-wrapper {
+        justify-content: center;
+      }
     }
   }
 
@@ -341,7 +349,7 @@
 
 .tabs.staggered-intro-merch-cards .tab-content-container .tabpanel.tab-entering .section merch-card {
   animation: tab-content-in 0.5s ease both;
-  
+
   &:nth-child(2) { animation-delay: 0.1s; }
   &:nth-child(3) { animation-delay: 0.2s; }
   &:nth-child(4) { animation-delay: 0.3s; }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -235,7 +235,7 @@
     }
   }
 
-  &.dark:not(.radio):not(.quiet) > .tabs-wrapper {
+  &.pill.dark > .tabs-wrapper {
     [role='tablist'] {
       background: var(--s2a-color-background-default);
 
@@ -256,7 +256,7 @@
 
   &.radio,
   &.quiet,
-  &.dark:not(.radio):not(.quiet) {
+  &.pill.dark {
     background: transparent;
   }
 

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -292,7 +292,7 @@
   }
 }
 
-.tab-content [role='tabpanel'] {
+.tab-content .tabpanel {
   .section {
     position: relative;
 
@@ -334,7 +334,7 @@
   }
 }
 
-.tabs.staggered-intro-merch-cards .tab-content-container [role='tabpanel'].tab-entering .section merch-card {
+.tabs.staggered-intro-merch-cards .tab-content-container .tabpanel.tab-entering .section merch-card {
   animation: tab-content-in 0.5s ease both;
   
   &:nth-child(2) { animation-delay: 0.1s; }
@@ -348,14 +348,14 @@
 
 
 @media (prefers-reduced-motion: reduce) {
-  .tabs.staggered-intro-merch-cards .tab-content-container [role='tabpanel'].tab-entering .section merch-card {
+  .tabs.staggered-intro-merch-cards .tab-content-container .tabpanel.tab-entering .section merch-card {
     animation: none;
   }
 }
 
 @media (width >= 1920px) {
-  [role='tabpanel'] > .section[class*='-up'] > .content,
-  [role='tabpanel'] > .section[class*='grid-width-'] > .content {
+  .tabpanel > .section[class*='-up'] > .content,
+  .tabpanel > .section[class*='grid-width-'] > .content {
     width: auto;
   }
 }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -205,6 +205,7 @@
     [role='tablist'] {
       background: transparent;
       border-radius: 0;
+      overflow: visible;
 
       .tab-list-container {
         min-width: 0;
@@ -230,6 +231,7 @@
           background: transparent;
           color: var(--s2a-color-content-default);
           border-bottom-color: var(--s2a-color-blue-800);
+          padding-bottom: var(--s2a-spacing-2xs);
         }
       }
     }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -277,7 +277,8 @@
       }
     }
 
-    [role='tablist'] {
+    [role='tablist'],
+    [role='radiogroup'] {
       overflow: visible;
       margin: 0 var(--s2a-spacing-24);
     }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -138,8 +138,6 @@
     [role='tablist'] {
       background: transparent;
       border-radius: 0;
-      padding-bottom: 20px;
-      padding-top: 20px;
 
       .tab-list-container {
         min-width: 0;

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -1,14 +1,6 @@
 /* stylelint-disable no-descending-specificity */
 :root {
-  /*
-   * background-inverse (not background-knockout) is the correct token here:
-   * knockout resolves to the same fixed near-black value in both the light
-   * and dark semantic token sets, while inverse actually flips (near-black in
-   * light, white in dark) — required for the selected pill/radio-dot to stay
-   * visible once a `.dark` block renders on a dark surface. This produces the
-   * exact same value as before in light mode (both resolve to gray-1000), so
-   * it's a no-op visually today.
-   */
+  /* using inverse to support dark and light variants  */
   --pill-bg-color-selected: var(--s2a-color-background-inverse);
   --pill-rounded-corners-setting: 50px;
 }
@@ -23,14 +15,6 @@
     background: transparent;
   }
 
-  /*
-   * Every variant below scopes through `> .tabs-wrapper` first. A
-   * `.tabs-wrapper` only ever contains this block's own tab list — nested
-   * tabs blocks live under `.tab-content-container` instead — so this single
-   * direct-child step guarantees a variant's rules can never bleed into a
-   * differently-classed tabs block nested inside one of this block's panels,
-   * regardless of shared class/role names further down the tree.
-   */
   &.radio > .tabs-wrapper {
     [role='radiogroup'] {
       overflow: visible;
@@ -105,17 +89,6 @@
     }
   }
 
-  &.radio {
-    background: transparent;
-  }
-
-  /*
-   * Confirmed against Figma: radio-dark's container is #131313
-   * (--s2a-color-gray-900, i.e. --s2a-color-background-default), not
-   * --s2a-color-background-subtle (--s2a-color-gray-700, lighter). The
-   * selected dot's gap must match this same value so it keeps blending
-   * seamlessly with the container instead of showing as a visible ring.
-   */
   &.radio.dark > .tabs-wrapper {
     [role='radiogroup'] {
       .tab-list-container {
@@ -168,18 +141,6 @@
     }
   }
 
-  &.quiet {
-    background: transparent;
-  }
-
-  /*
-   * `.dark` is an opt-in variant class (like radio/quiet), not inherited from
-   * an ancestor section. Matches radio-dark's confirmed container value
-   * (#131313 / --s2a-color-background-default) for consistency. The selected
-   * pill's background/text are set explicitly here rather than relying on
-   * --pill-bg-color-selected / --s2a-color-content-inverse to flip on their
-   * own — same fix that was needed for radio-dark's selected dot.
-   */
   &.dark:not(.radio):not(.quiet) > .tabs-wrapper {
     [role='tablist'] {
       background: var(--s2a-color-background-default);
@@ -196,19 +157,11 @@
       .tab-indicator {
         background: var(--s2a-color-background-inverse);
       }
-
-      button.tab-button:focus-visible {
-        outline: var(--s2a-border-width-sm) solid var(--s2a-color-focus-ring-default);
-      }
     }
   }
 
-  /*
-   * Plain pill is the only variant that keeps a solid block-level background
-   * in light mode (radio/quiet already force it transparent unconditionally
-   * above). Nothing overrode it for dark, so it stayed at the light value —
-   * matching radio/quiet's transparent treatment for now.
-   */
+  &.radio,
+  &.quiet,
   &.dark:not(.radio):not(.quiet) {
     background: transparent;
   }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -277,7 +277,12 @@
 
     [role='tablist'] {
       overflow: visible;
-      margin: 0 var(--s2a-spacing-20);
+      margin: 0 var(--s2a-spacing-24);
+    }
+
+    &.quiet > .tabs-wrapper {
+      width: auto;
+      margin: 0;
     }
   }
 

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -92,28 +92,6 @@ function moveIndicator(indicator, target, container) {
   indicator.style.transform = `translateX(${btnRect.left - containerRect.left + container.scrollLeft}px)`;
 }
 
-function buildTabDropdown(items) {
-  const select = createTag('select', { class: 'tab-dropdown', 'aria-label': 'Select tab' });
-  items.forEach(({ id, controlId, label }, i) => {
-    const option = createTag('option', { value: controlId }, label);
-    option.dataset.tabId = id;
-    if (i === 0) option.setAttribute('selected', '');
-    select.append(option);
-  });
-  select.addEventListener('change', (e) => {
-    const selectedOption = e.target.selectedOptions[0];
-    document.getElementById(selectedOption.dataset.tabId)?.click();
-  });
-  return select;
-}
-
-function syncTabDropdown(tabsBlock, targetId) {
-  const dropdown = tabsBlock.querySelector('.tab-dropdown');
-  if (!dropdown) return;
-  const option = [...dropdown.options].find((opt) => opt.dataset.tabId === targetId);
-  if (option) dropdown.value = option.value;
-}
-
 function changeTabs(e, config) {
   const { target } = e;
   const isRadio = target.getAttribute('role') === 'radio';
@@ -153,7 +131,6 @@ function changeTabs(e, config) {
     target.style.backgroundColor = tabColor[targetId];
   }
   scrollTabIntoView(target);
-  syncTabDropdown(tabsBlock, targetId);
   content
     .querySelectorAll(`.tabpanel[data-block-id="${blockId}"]`)
     .forEach((p) => {
@@ -315,7 +292,6 @@ const init = async (block) => {
   if (tabListLabel) tabList.setAttribute('aria-label', tabListLabel);
 
   const tabListItems = rows[0].querySelectorAll(':scope li');
-  const dropdownItems = [];
 
   if (tabListItems.length) {
     tabListItems.forEach((item, i) => {
@@ -337,7 +313,6 @@ const init = async (block) => {
       const btnWrapper = createTag('div', { class: 'btn-wrapper' });
       btnWrapper.append(tabBtn);
       tabListContainer.append(btnWrapper);
-      dropdownItems.push({ id: btnId, controlId, label: item.textContent });
 
       const tabContentAttributes = {
         id: controlId,
@@ -360,9 +335,7 @@ const init = async (block) => {
   // Tab indicator (pill slider) only applies to the regular tabs UI; the radio
   // variant renders its own selection state via CSS on the radio dot instead.
   let indicator;
-  if (isRadio) {
-    tabsWrapper.append(buildTabDropdown(dropdownItems));
-  } else {
+  if (!isRadio) {
     indicator = createTag('div', { class: 'tab-indicator' });
     tabListContainer.prepend(indicator);
   }

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -280,8 +280,20 @@ const init = async (block) => {
   tabList.setAttribute('role', isRadio ? 'radiogroup' : 'tablist');
   const tabListContainer = tabList.querySelector(':scope > div');
   tabListContainer.classList.add('tab-list-container');
-  const tabListLabel = config.pretext;
-  if (tabListLabel) tabList.setAttribute('aria-label', tabListLabel);
+
+  // Authors can lead the tab-list cell with a <p> before the <ol> to give the
+  // radio variant a visible inline label (e.g. "Plans for:"). Non-radio tabs
+  // don't use this pattern, so a stray leading <p> there is simply dropped.
+  const tabListLabelEl = tabListContainer.querySelector(':scope > p');
+  if (tabListLabelEl && isRadio) {
+    tabListLabelEl.classList.add('tab-list-label', 'label');
+    tabListLabelEl.id = `tab-list-label-${tabId}`;
+    tabList.setAttribute('aria-labelledby', tabListLabelEl.id);
+  } else {
+    tabListLabelEl?.remove();
+    const tabListLabel = config.pretext;
+    if (tabListLabel) tabList.setAttribute('aria-label', tabListLabel);
+  }
 
   const tabListItems = rows[0].querySelectorAll(':scope li');
 

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -267,15 +267,7 @@ const init = async (block) => {
   block.id = `tabs-${tabId}`;
   parentSection?.classList.add(`tablist-${tabId}-section`);
 
-  // Radio variant: the `radio` class opts in, but the top-level tabs block in a
-  // nested setup (multiple .tabs blocks in the same fragment) is never allowed
-  // to render as radio, even if it carries the class by mistake.
-  const allTabsBlocks = rootElem.querySelectorAll('.tabs');
-  const position = [...allTabsBlocks].indexOf(block) + 1;
-  const isNested = allTabsBlocks.length > 1;
-  const hasRadioVariant = block.classList.contains('radio');
-  const isRadio = hasRadioVariant && !(isNested && position === 1);
-  if (hasRadioVariant && !isRadio) block.classList.remove('radio');
+  const isRadio = block.classList.contains('radio');
 
   // Tab Content
   const tabContentContainer = createTag('div', { class: 'tab-content-container' });

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -10,7 +10,7 @@ const linkedTabs = {};
 const tabChangeEvent = new Event('milo:tab:changed');
 
 const getScrollContainer = (tab) => {
-  const tabList = tab.closest('[role="tablist"]');
+  const tabList = tab.closest('[role="tablist"], [role="radiogroup"]');
   return tabList.scrollWidth > tabList.clientWidth ? tabList : tabList.parentElement;
 };
 
@@ -92,9 +92,33 @@ function moveIndicator(indicator, target, container) {
   indicator.style.transform = `translateX(${btnRect.left - containerRect.left + container.scrollLeft}px)`;
 }
 
+function buildTabDropdown(items) {
+  const select = createTag('select', { class: 'tab-dropdown', 'aria-label': 'Select tab' });
+  items.forEach(({ id, controlId, label }, i) => {
+    const option = createTag('option', { value: controlId }, label);
+    option.dataset.tabId = id;
+    if (i === 0) option.setAttribute('selected', '');
+    select.append(option);
+  });
+  select.addEventListener('change', (e) => {
+    const selectedOption = e.target.selectedOptions[0];
+    document.getElementById(selectedOption.dataset.tabId)?.click();
+  });
+  return select;
+}
+
+function syncTabDropdown(tabsBlock, targetId) {
+  const dropdown = tabsBlock.querySelector('.tab-dropdown');
+  if (!dropdown) return;
+  const option = [...dropdown.options].find((opt) => opt.dataset.tabId === targetId);
+  if (option) dropdown.value = option.value;
+}
+
 function changeTabs(e, config) {
   const { target } = e;
-  if (target.getAttribute('aria-selected') === 'true') return;
+  const isRadio = target.getAttribute('role') === 'radio';
+  const attributeName = isRadio ? 'aria-checked' : 'aria-selected';
+  if (target.getAttribute(attributeName) === 'true') return;
   const targetId = target.getAttribute('id');
   const redirectionUrl = getRedirectionUrl(linkedTabs, targetId);
   /* c8 ignore next 4 */
@@ -107,18 +131,20 @@ function changeTabs(e, config) {
   const content = tabsBlock.lastElementChild;
   const blockId = tabsBlock.id;
 
-  const targetContent = content.querySelector(`#${target.getAttribute('aria-controls')}`);
+  const targetContent = isRadio
+    ? content.querySelector(`#${target.getAttribute('data-control-id')}`)
+    : content.querySelector(`#${target.getAttribute('aria-controls')}`);
 
   parent
-    .querySelectorAll(`[aria-selected="true"][data-block-id="${blockId}"]`)
+    .querySelectorAll(`[${attributeName}="true"][data-block-id="${blockId}"]`)
     .forEach((t) => {
-      t.setAttribute('aria-selected', 'false');
+      t.setAttribute(attributeName, 'false');
       t.setAttribute('tabindex', '-1');
       if (Object.keys(tabColor).length) {
         t.style.backgroundColor = '';
       }
     });
-  target.setAttribute('aria-selected', 'true');
+  target.setAttribute(attributeName, 'true');
   target.setAttribute('tabindex', '0');
 
   const indicator = parent.querySelector('.tab-indicator');
@@ -127,6 +153,7 @@ function changeTabs(e, config) {
     target.style.backgroundColor = tabColor[targetId];
   }
   scrollTabIntoView(target);
+  syncTabDropdown(tabsBlock, targetId);
   content
     .querySelectorAll(`.tabpanel[data-block-id="${blockId}"]`)
     .forEach((p) => {
@@ -191,8 +218,8 @@ function configTabs(config, rootElem) {
 }
 
 function initTabs(elm, config, rootElem) {
-  const tabs = elm.querySelectorAll('[role="tab"]');
-  const tabLists = elm.querySelectorAll('[role="tablist"]');
+  const tabs = elm.querySelectorAll('[role="tab"], [role="radio"]');
+  const tabLists = elm.querySelectorAll('[role="tablist"], [role="radiogroup"]');
   let tabFocus = 0;
   tabLists.forEach((tabList) => {
     tabList.addEventListener('keydown', (e) => {
@@ -263,6 +290,16 @@ const init = async (block) => {
   block.id = `tabs-${tabId}`;
   parentSection?.classList.add(`tablist-${tabId}-section`);
 
+  // Radio variant: the `radio` class opts in, but the top-level tabs block in a
+  // nested setup (multiple .tabs blocks in the same fragment) is never allowed
+  // to render as radio, even if it carries the class by mistake.
+  const allTabsBlocks = rootElem.querySelectorAll('.tabs');
+  const position = [...allTabsBlocks].indexOf(block) + 1;
+  const isNested = allTabsBlocks.length > 1;
+  const hasRadioVariant = block.classList.contains('radio');
+  const isRadio = hasRadioVariant && !(isNested && position === 1);
+  if (hasRadioVariant && !isRadio) block.classList.remove('radio');
+
   // Tab Content
   const tabContentContainer = createTag('div', { class: 'tab-content-container' });
   const tabContent = createTag('div', { class: 'tab-content' }, tabContentContainer);
@@ -271,39 +308,43 @@ const init = async (block) => {
   // Tab List
   const tabList = rows[0];
   tabList.classList.add('tab-list');
-  tabList.setAttribute('role', 'tablist');
+  tabList.setAttribute('role', isRadio ? 'radiogroup' : 'tablist');
   const tabListContainer = tabList.querySelector(':scope > div');
   tabListContainer.classList.add('tab-list-container');
   const tabListLabel = config.pretext;
   if (tabListLabel) tabList.setAttribute('aria-label', tabListLabel);
+  tabListContainer.dataset.pretext = config.pretext;
 
   const tabListItems = rows[0].querySelectorAll(':scope li');
+  const dropdownItems = [];
 
   if (tabListItems.length) {
     tabListItems.forEach((item, i) => {
       const tabName = config.id ? i + 1 : getStringKeyName(item.textContent);
       const controlId = `tab-panel-${tabId}-${tabName}`;
+      const btnId = `tab-${tabId}-${tabName}`;
       const tabBtnAttributes = {
-        role: 'tab',
+        role: isRadio ? 'radio' : 'tab',
         class: 'tab-button label',
-        id: `tab-${tabId}-${tabName}`,
+        id: btnId,
         tabindex: (i === 0) ? '0' : '-1',
-        'aria-selected': (i === 0) ? 'true' : 'false',
+        [isRadio ? 'aria-checked' : 'aria-selected']: (i === 0) ? 'true' : 'false',
         'data-block-id': `tabs-${tabId}`,
         'daa-state': 'true',
-        'daa-ll': `tab-${tabId}-${tabName}`,
-        'aria-controls': controlId,
+        'daa-ll': btnId,
+        ...(isRadio ? { 'data-control-id': controlId } : { 'aria-controls': controlId }),
       };
       const tabBtn = createTag('button', tabBtnAttributes, item.textContent);
       const btnWrapper = createTag('div', { class: 'btn-wrapper' });
       btnWrapper.append(tabBtn);
       tabListContainer.append(btnWrapper);
+      dropdownItems.push({ id: btnId, controlId, label: item.textContent });
 
       const tabContentAttributes = {
-        id: `tab-panel-${tabId}-${tabName}`,
-        role: 'tabpanel',
+        id: controlId,
+        ...(isRadio ? {} : { role: 'tabpanel' }),
         class: 'tabpanel',
-        'aria-labelledby': `tab-${tabId}-${tabName}`,
+        'aria-labelledby': btnId,
         'data-block-id': `tabs-${tabId}`,
       };
       const tabListContent = createTag('div', tabContentAttributes);
@@ -317,9 +358,15 @@ const init = async (block) => {
   tabList.insertAdjacentElement('beforebegin', tabsWrapper);
   tabsWrapper.append(tabList);
 
-  // Tab indicator
-  const indicator = createTag('div', { class: 'tab-indicator' });
-  tabListContainer.prepend(indicator);
+  // Tab indicator (pill slider) only applies to the regular tabs UI; the radio
+  // variant renders its own selection state via CSS on the radio dot instead.
+  let indicator;
+  if (isRadio) {
+    tabsWrapper.append(buildTabDropdown(dropdownItems));
+  } else {
+    indicator = createTag('div', { class: 'tab-indicator' });
+    tabListContainer.prepend(indicator);
+  }
 
   // Tab Sections
   const allSections = Array.from(rootElem.querySelectorAll('div.section'));
@@ -364,15 +411,17 @@ const init = async (block) => {
   initTabs(block, config, rootElem);
 
   requestAnimationFrame(() => {
-    const activeTab = tabListContainer.querySelector('[aria-selected="true"]');
+    const activeTab = tabListContainer.querySelector('[aria-selected="true"], [aria-checked="true"]');
     if (activeTab) {
-      indicator.style.transition = 'none';
-      moveIndicator(indicator, activeTab, tabListContainer);
+      if (indicator) {
+        indicator.style.transition = 'none';
+        moveIndicator(indicator, activeTab, tabListContainer);
+        requestAnimationFrame(() => { indicator.style.transition = ''; });
+      }
       scrollTabIntoView(activeTab);
-      requestAnimationFrame(() => { indicator.style.transition = ''; });
     }
     if (block.classList.contains('staggered-intro-merch-cards')) {
-      const activePanel = tabContentContainer.querySelector('[role="tabpanel"]:not([hidden])');
+      const activePanel = tabContentContainer.querySelector('.tabpanel:not([hidden])');
       if (activePanel) triggerTabEnterAnimation(activePanel);
     }
   });

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -313,7 +313,6 @@ const init = async (block) => {
   tabListContainer.classList.add('tab-list-container');
   const tabListLabel = config.pretext;
   if (tabListLabel) tabList.setAttribute('aria-label', tabListLabel);
-  tabListContainer.dataset.pretext = config.pretext;
 
   const tabListItems = rows[0].querySelectorAll(':scope li');
   const dropdownItems = [];

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -268,6 +268,7 @@ const init = async (block) => {
   parentSection?.classList.add(`tablist-${tabId}-section`);
 
   const isRadio = block.classList.contains('radio');
+  const isQuiet = block.classList.contains('quiet');
 
   // Tab Content
   const tabContentContainer = createTag('div', { class: 'tab-content-container' });
@@ -304,7 +305,7 @@ const init = async (block) => {
       const btnId = `tab-${tabId}-${tabName}`;
       const tabBtnAttributes = {
         role: isRadio ? 'radio' : 'tab',
-        class: 'tab-button label',
+        class: isQuiet ? 'tab-button heading-4' : 'tab-button label',
         id: btnId,
         tabindex: (i === 0) ? '0' : '-1',
         [isRadio ? 'aria-checked' : 'aria-selected']: (i === 0) ? 'true' : 'false',
@@ -336,10 +337,11 @@ const init = async (block) => {
   tabList.insertAdjacentElement('beforebegin', tabsWrapper);
   tabsWrapper.append(tabList);
 
-  // Tab indicator (pill slider) only applies to the regular tabs UI; the radio
-  // variant renders its own selection state via CSS on the radio dot instead.
+  // Tab indicator (pill slider) only applies to the default pill tabs UI; the
+  // radio variant shows selection via the radio dot, and the quiet variant
+  // shows it via a static underline on the button itself.
   let indicator;
-  if (!isRadio) {
+  if (!isRadio && !isQuiet) {
     indicator = createTag('div', { class: 'tab-indicator' });
     tabListContainer.prepend(indicator);
   }

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -53,14 +53,12 @@ const generateStorageName = (tabId) => {
 
 const loadActiveTab = (config) => {
   if (config.remember !== 'on') return 0;
-
   const tabId = config['tab-id'];
   return sessionStorage.getItem(generateStorageName(tabId));
 };
 
 const saveActiveTabInStorage = (targetId, config) => {
   if (config.remember !== 'on') return;
-
   const delimiterIndex = targetId.lastIndexOf('-');
   const activeTabIndex = targetId.substring(delimiterIndex + 1);
   const storageName = generateStorageName(config['tab-id']);
@@ -113,34 +111,24 @@ function changeTabs(e, config) {
     ? content.querySelector(`#${target.getAttribute('data-control-id')}`)
     : content.querySelector(`#${target.getAttribute('aria-controls')}`);
 
-  parent
-    .querySelectorAll(`[${attributeName}="true"][data-block-id="${blockId}"]`)
-    .forEach((t) => {
-      t.setAttribute(attributeName, 'false');
-      t.setAttribute('tabindex', '-1');
-      if (Object.keys(tabColor).length) {
-        t.style.backgroundColor = '';
-      }
-    });
+  parent.querySelectorAll(`[${attributeName}="true"][data-block-id="${blockId}"]`).forEach((t) => {
+    t.setAttribute(attributeName, 'false');
+    t.setAttribute('tabindex', '-1');
+    if (Object.keys(tabColor).length) t.style.backgroundColor = '';
+  });
   target.setAttribute(attributeName, 'true');
   target.setAttribute('tabindex', '0');
 
   const indicator = parent.querySelector('.tab-indicator');
   if (indicator) moveIndicator(indicator, target, parent);
-  if (tabColor[targetId]) {
-    target.style.backgroundColor = tabColor[targetId];
-  }
+  if (tabColor[targetId]) target.style.backgroundColor = tabColor[targetId];
   scrollTabIntoView(target);
-  content
-    .querySelectorAll(`.tabpanel[data-block-id="${blockId}"]`)
-    .forEach((p) => {
-      p.setAttribute('hidden', true);
-      p.classList.remove('tab-entering');
-    });
+  content.querySelectorAll(`.tabpanel[data-block-id="${blockId}"]`).forEach((p) => {
+    p.setAttribute('hidden', true);
+    p.classList.remove('tab-entering');
+  });
   targetContent?.removeAttribute('hidden');
-  if (tabsBlock.classList.contains('staggered-intro-merch-cards') && targetContent) {
-    triggerTabEnterAnimation(targetContent);
-  }
+  if (tabsBlock.classList.contains('staggered-intro-merch-cards') && targetContent) triggerTabEnterAnimation(targetContent);
   window.dispatchEvent(tabChangeEvent);
   saveActiveTabInStorage(targetId, config);
 }
@@ -282,9 +270,6 @@ const init = async (block) => {
   const tabListContainer = tabList.querySelector(':scope > div');
   tabListContainer.classList.add('tab-list-container');
 
-  // Authors can lead the tab-list cell with a <p> before the <ol> to give the
-  // radio variant a visible inline label (e.g. "Plans for:"). Non-radio tabs
-  // don't use this pattern, so a stray leading <p> there is simply dropped.
   const tabListLabelEl = tabListContainer.querySelector(':scope > p');
   if (tabListLabelEl && isRadio) {
     tabListLabelEl.classList.add('tab-list-label', 'label');
@@ -297,7 +282,6 @@ const init = async (block) => {
   }
 
   const tabListItems = rows[0].querySelectorAll(':scope li');
-
   if (tabListItems.length) {
     tabListItems.forEach((item, i) => {
       const tabName = config.id ? i + 1 : getStringKeyName(item.textContent);
@@ -337,9 +321,6 @@ const init = async (block) => {
   tabList.insertAdjacentElement('beforebegin', tabsWrapper);
   tabsWrapper.append(tabList);
 
-  // Tab indicator (pill slider) only applies to the default pill tabs UI; the
-  // radio variant shows selection via the radio dot, and the quiet variant
-  // shows it via a static underline on the button itself.
   let indicator;
   if (!isRadio && !isQuiet) {
     indicator = createTag('div', { class: 'tab-indicator' });
@@ -368,19 +349,13 @@ const init = async (block) => {
       val = getStringKeyName(String(values[1]));
     }
     const associatedTabButton = rootElem.querySelector(`#tab-${id}-${val}`);
-    if (associatedTabButton && metaSettings.deeplink) {
-      associatedTabButton.setAttribute('data-deeplink', metaSettings.deeplink);
-    }
+    if (associatedTabButton && metaSettings.deeplink) associatedTabButton.setAttribute('data-deeplink', metaSettings.deeplink);
     const assocTabItem = rootElem.querySelector(`#tab-panel-${id}-${val}`);
     if (assocTabItem) {
-      if (metaSettings['tab-background']) {
-        tabColor[`tab-${id}-${val}`] = metaSettings['tab-background'];
-      }
+      if (metaSettings['tab-background']) tabColor[`tab-${id}-${val}`] = metaSettings['tab-background'];
       await assignLinkedTabs(linkedTabs, metaSettings, id, val);
       const tabLabel = tabListItems[val - 1]?.innerText;
-      if (tabLabel) {
-        assocTabItem.setAttribute('data-nested-lh', `t${val}${processTrackingLabels(tabLabel, getConfig(), 3)}`);
-      }
+      if (tabLabel) assocTabItem.setAttribute('data-nested-lh', `t${val}${processTrackingLabels(tabLabel, getConfig(), 3)}`);
       const section = sectionMetadata.closest('.section');
       assocTabItem.append(section);
     }

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -257,6 +257,7 @@ const init = async (block) => {
 
   const isRadio = block.classList.contains('radio');
   const isQuiet = block.classList.contains('quiet');
+  block.classList.toggle('pill', !isRadio && !isQuiet);
 
   // Tab Content
   const tabContentContainer = createTag('div', { class: 'tab-content-container' });

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -195,8 +195,8 @@ function configTabs(config, rootElem) {
 }
 
 function initTabs(elm, config, rootElem) {
-  const tabs = elm.querySelectorAll('[role="tab"], [role="radio"]');
-  const tabLists = elm.querySelectorAll('[role="tablist"], [role="radiogroup"]');
+  const tabs = elm.querySelectorAll(':scope > .tabs-wrapper [role="tab"], :scope > .tabs-wrapper [role="radio"]');
+  const tabLists = elm.querySelectorAll(':scope > .tabs-wrapper [role="tablist"], :scope > .tabs-wrapper [role="radiogroup"]');
   let tabFocus = 0;
   tabLists.forEach((tabList) => {
     tabList.addEventListener('keydown', (e) => {


### PR DESCRIPTION
This PR adds the tabs block needed for ACE1209 (Site redesign wave 3) test. 

Note: this is the first push to `site-redesign-foundation`, and **_I would like to push this PR through immediately._** There are still items to implement, but I want to at least have a draft version of the wave 3 tabs in our shared demo pages. 


**Features:** 
- **Add variant: radio** - radio variant is re-enabled
- **Add variant: quiet** - basic text with blue underline as clickable tabs
- **Add dark mode for base variant (pill)**
- **Add dark mode for radio variant**
- **Add dark mode for quiet variant** 

**TODO/Notes**
1. confirm spacing for top level tabs when nested (section spacing is not applied below the parent tab).
2. confirm left/right mode works as intended from ace1205.
3. implement autoscroll to center selected radio tab in lower breakpoints (this is already available for base pill). 

**Resolves:** 
[MWPW-198998](https://jira.corp.adobe.com/browse/MWPW-198998) 

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-radio-dark?milolibs=site-redesign-foundation&martech=off
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-pill-dark?milolibs=sr3-tabs-block-radio&martech=off

**DEMO PAGES WITH TABS BY TYPE AND MODE** 

**base pill - default**
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-pill-light?milolibs=sr3-tabs-block-radio

**base pill - dark**
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-pill-dark?milolibs=sr3-tabs-block-radio

**radio - default**
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-radio-light?milolibs=sr3-tabs-block-radio

**radio - dark**
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-radio-dark?milolibs=sr3-tabs-block-radio


















