### PR TITLE
MWPW-201497: decorate mas-field via one mas:ready

### DIFF
--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -171,6 +171,86 @@ function copyMasFieldIdToParent(masField, name) {
   }
 }
 
+/**
+ * Hoists a resolved inline CTA out of its mas-field into the authored em/strong,
+ * then runs decorateButtons. Size and utility classes come from an already-decorated
+ * sibling button, else from the block's own classes. Deferred until every CTA
+ * mas-field in the container has been hoisted, so a still-wrapped sibling isn't
+ * matched by 'em a'/'strong a' with the wrong parent (its content span).
+ */
+function decorateInlineCtas(masField, content) {
+  const container = masField.closest('p, div');
+
+  // The block this CTA belongs to (direct child of a section). Bounds the sibling
+  // lookup so a foreign block's button can't dictate this CTA's size.
+  let blockEl = container?.parentElement;
+  while (blockEl?.parentElement && !blockEl.parentElement.classList.contains('section')
+    && blockEl.parentElement !== document.body) {
+    blockEl = blockEl.parentElement;
+  }
+
+  // Match an already-decorated sibling button in the same block, else derive from the block.
+  const siblingBtn = [...(blockEl?.querySelectorAll('.con-button') ?? [])]
+    .find((b) => !masField.contains(b));
+  let size;
+  let utilClasses = [];
+
+  if (siblingBtn) {
+    // Inherit the sibling's exact size and utility classes (null size honoured).
+    size = [...siblingBtn.classList].find((c) => /^button-(s|m|l|xl)$/.test(c)) ?? null;
+    utilClasses = [...siblingBtn.classList].filter((c) => c.startsWith('button-') && c !== size);
+  } else {
+    // No decorated sibling yet — derive size from the block, mirroring its decorateButtons call.
+    const btnVariant = [...(blockEl?.classList ?? [])].find((c) => c.endsWith('-button'));
+    if (btnVariant) {
+      size = `button-${btnVariant.split('-')[0]}`;
+    } else if (blockEl?.classList.contains('hero-marquee')) {
+      size = 'button-xl';
+    } else if (blockEl?.classList.contains('accordion') || blockEl?.classList.contains('media')) {
+      size = null;
+    } else {
+      const blockSize = getBlockSize(blockEl ?? container);
+      size = (blockSize === 'large' || blockSize === 'xlarge') ? 'button-xl' : 'button-l';
+    }
+  }
+  copyMasFieldIdToParent(masField, 'fragment-id');
+  copyMasFieldIdToParent(masField, 'variation-id');
+  masField.replaceWith(...[...content.childNodes]);
+
+  const pendingCTAs = container?.querySelectorAll('em > mas-field, strong > mas-field');
+  if (container && !pendingCTAs?.length) {
+    decorateButtons(container, size);
+    if (utilClasses.length) {
+      container.querySelectorAll('.con-button').forEach((b) => utilClasses.forEach((c) => b.classList.add(c)));
+    }
+  }
+}
+
+/**
+ * A headless mas-field CTA can resolve after its block decorated (slow network),
+ * firing 'mas:ready' too late for decorateButtons. One document-level listener
+ * hoists + decorates it regardless of block, so no per-block wiring is needed.
+ * Registered once, on the first merch init.
+ */
+let masReadyWatched = false;
+function watchMasFieldCtas() {
+  if (masReadyWatched) return;
+  masReadyWatched = true;
+  // Hide an inline CTA while it's still wrapped in a mas-field (rendered but not yet
+  // hoisted/decorated) so its half-styled state doesn't flash on slow loads. Removing
+  // the mas-field on decoration reveals the finished button.
+  const style = createTag('style', undefined, 'em > mas-field:has(a), strong > mas-field:has(a) { visibility: hidden; }');
+  document.head.append(style);
+  document.addEventListener('mas:ready', ({ target: mf }) => {
+    if (mf?.tagName !== 'MAS-FIELD' || !mf.closest('em, strong')) return;
+    const content = mf.querySelector(':scope > [data-role="mas-field-content"]');
+    // Same gate createInline uses: an inline CTA anchor, not block-level content.
+    if (content?.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
+      decorateInlineCtas(mf, content);
+    }
+  });
+}
+
 /** Replaces an inline fragment link with a mas-field wrapping an aem-fragment. */
 async function createInline(el, options) {
   const aemFragment = createAemFragment(options, seenFragments);
@@ -191,70 +271,14 @@ async function createInline(el, options) {
   // them. Applies to both CTA (<a>) and price (<span>) fields.
   upgradeCommerceLinks(content);
 
-  // For inline link content (CTAs), replace mas-field with the rendered content so the
-  // links sit inside the page's original em/strong wrappers. Then run Milo's decorateButtons
-  // using the size and utility classes already applied to sibling buttons by the block
-  // (e.g. marquee's button-l and button-justified-mobile).
+  // Inline CTAs: hoist the anchor into the authored em/strong and let decorateButtons style it.
   if (content.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
-    const container = masField.closest('p, div');
-
-    // Read size + utility classes from already-decorated sibling .con-button elements
-    // (the block ran decorateButtons on its regular CTAs before our checkReady resolved).
-    let siblingBtn = null;
-    let searchEl = container?.parentElement;
-    while (searchEl && searchEl !== document.body && !siblingBtn) {
-      siblingBtn = [...searchEl.querySelectorAll('.con-button')].find((b) => !masField.contains(b));
-      if (!siblingBtn) searchEl = searchEl.parentElement;
-    }
-    let size;
-    let utilClasses = [];
-
-    if (siblingBtn) {
-      // Sibling authored buttons exist — inherit their exact size and utility classes.
-      // If siblings have no size class (e.g. accordion, media), honour that with null.
-      size = [...siblingBtn.classList].find((c) => /^button-(s|m|l|xl)$/.test(c)) ?? null;
-      utilClasses = [...siblingBtn.classList].filter((c) => c.startsWith('button-') && c !== size);
-    } else {
-      // No sibling reference yet — block ran decorateButtons before our checkReady resolved.
-      // Derive size from the block's own classes, mirroring each block's decorateButtons call.
-      let blockEl = container?.parentElement;
-      while (blockEl?.parentElement && !blockEl.parentElement.classList.contains('section')
-        && blockEl.parentElement !== document.body) {
-        blockEl = blockEl.parentElement;
-      }
-      // Explicit *-button variation class (hero-marquee/notification: 'xl-button' → 'button-xl')
-      const btnVariant = [...(blockEl?.classList ?? [])].find((c) => c.endsWith('-button'));
-      if (btnVariant) {
-        size = `button-${btnVariant.split('-')[0]}`;
-      } else if (blockEl?.classList.contains('hero-marquee')) {
-        size = 'button-xl'; // hero-marquee always defaults to button-xl
-      } else if (blockEl?.classList.contains('accordion') || blockEl?.classList.contains('media')) {
-        size = null; // these blocks call decorateButtons with no size
-      } else {
-        const blockSize = getBlockSize(blockEl ?? container);
-        size = (blockSize === 'large' || blockSize === 'xlarge') ? 'button-xl' : 'button-l';
-      }
-    }
-    copyMasFieldIdToParent(masField, 'fragment-id');
-    copyMasFieldIdToParent(masField, 'variation-id');
-    masField.replaceWith(...[...content.childNodes]);
-
-    // Defer decorateButtons until the last CTA mas-field in this container has been
-    // replaced. If decorateButtons ran while another mas-field was still in the DOM,
-    // it would find the checkout link inside that pending mas-field via 'strong a'/'em a'
-    // but with the wrong parentElement (the content span, not strong/em), causing the
-    // wrong button type and breaking the pending mas-field's content span.
-    const pendingCTAs = container?.querySelectorAll('em > mas-field, strong > mas-field');
-    if (container && !pendingCTAs?.length) {
-      decorateButtons(container, size);
-      if (utilClasses.length) {
-        container.querySelectorAll('.con-button').forEach((b) => utilClasses.forEach((c) => b.classList.add(c)));
-      }
-    }
+    decorateInlineCtas(masField, content);
   }
 }
 
 export default async function init(el) {
+  watchMasFieldCtas();
   let options = getOptions(el);
   const { fragment } = options;
   if (!fragment) return;

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -189,15 +189,19 @@ function decorateInlineCtas(masField, content) {
     blockEl = blockEl.parentElement;
   }
 
-  // Match an already-decorated sibling button in the same block, else derive from the block.
+  // Match a fully-decorated sibling button in the same block, else derive from the block.
+  // Only a button that carries a size class counts: mas-field self-styles its CTAs with
+  // con-button but no size, so an unsized (self-styled, not-yet-Milo-decorated) sibling must
+  // not be used as the size reference — doing so would drop button-xl on every CTA.
+  const SIZE_CLASS = /^button-(s|m|l|xl)$/;
   const siblingBtn = [...(blockEl?.querySelectorAll('.con-button') ?? [])]
-    .find((b) => !masField.contains(b));
+    .find((b) => !masField.contains(b) && [...b.classList].some((c) => SIZE_CLASS.test(c)));
   let size;
   let utilClasses = [];
 
   if (siblingBtn) {
-    // Inherit the sibling's exact size and utility classes (null size honoured).
-    size = [...siblingBtn.classList].find((c) => /^button-(s|m|l|xl)$/.test(c)) ?? null;
+    // Inherit the sibling's exact size and utility classes.
+    size = [...siblingBtn.classList].find((c) => SIZE_CLASS.test(c));
     utilClasses = [...siblingBtn.classList].filter((c) => c.startsWith('button-') && c !== size);
   } else {
     // No decorated sibling yet — derive size from the block, mirroring its decorateButtons call.
@@ -205,7 +209,11 @@ function decorateInlineCtas(masField, content) {
     if (btnVariant) {
       size = `button-${btnVariant.split('-')[0]}`;
     } else if (blockEl?.classList.contains('hero-marquee')) {
+      // Mirror hero-marquee's extendButtonsClass, which adds button-xl AND
+      // button-justified-mobile to every .con-button. Without the util class an
+      // all-headless-CTA marquee renders inline instead of full-width on mobile.
       size = 'button-xl';
+      utilClasses = ['button-justified-mobile'];
     } else if (blockEl?.classList.contains('accordion') || blockEl?.classList.contains('media')) {
       size = null;
     } else {

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -217,7 +217,7 @@ function decorateInlineCtas(masField, content) {
   }
   copyMasFieldIdToParent(masField, 'fragment-id');
   copyMasFieldIdToParent(masField, 'variation-id');
-  masField.replaceWith(...[...content.childNodes]);
+  masField.replaceWith(...content.childNodes);
 
   const pendingCTAs = container?.querySelectorAll('em > mas-field, strong > mas-field');
   if (container && !pendingCTAs?.length) {

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -236,16 +236,15 @@ let masReadyWatched = false;
 function watchMasFieldCtas() {
   if (masReadyWatched) return;
   masReadyWatched = true;
-  // Hide an inline CTA while it's still wrapped in a mas-field (rendered but not yet
-  // hoisted/decorated) so its half-styled state doesn't flash on slow loads. Removing
-  // the mas-field on decoration reveals the finished button.
-  const style = createTag('style', undefined, 'em > mas-field:has(a), strong > mas-field:has(a) { visibility: hidden; }');
-  document.head.append(style);
   document.addEventListener('mas:ready', ({ target: mf }) => {
     if (mf?.tagName !== 'MAS-FIELD' || !mf.closest('em, strong')) return;
     const content = mf.querySelector(':scope > [data-role="mas-field-content"]');
     // Same gate createInline uses: an inline CTA anchor, not block-level content.
     if (content?.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
+      // Mirror createInline: upgrade plain commerce anchors (missing `is`) to their
+      // customized built-in before hoisting, or the late-resolved CTA never hydrates
+      // (no href, no modal). upgradeCommerceLinks is idempotent (skips [is]).
+      upgradeCommerceLinks(content);
       decorateInlineCtas(mf, content);
     }
   });

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -241,9 +241,7 @@ function watchMasFieldCtas() {
     const content = mf.querySelector(':scope > [data-role="mas-field-content"]');
     // Same gate createInline uses: an inline CTA anchor, not block-level content.
     if (content?.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
-      // Mirror createInline: upgrade plain commerce anchors (missing `is`) to their
-      // customized built-in before hoisting, or the late-resolved CTA never hydrates
-      // (no href, no modal). upgradeCommerceLinks is idempotent (skips [is]).
+      // Upgrade to checkout-link before hoisting, else the late CTA never hydrates.
       upgradeCommerceLinks(content);
       decorateInlineCtas(mf, content);
     }

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -82,10 +82,7 @@ export async function checkReady(masElement, fragment) {
   const readyPromise = masElement.checkReady();
   const success = await Promise.race([readyPromise, getTimeoutPromise()]);
   if (success === 'timeout') {
-    // log.error already forwards to LANA (tags: acom, clientId: merch-at-scale); include the
-    // fragment id + timeout so slow/failed hydration (3G, cache miss) is actionable there.
-    const uuid = fragment ?? masElement.querySelector('aem-fragment')?.getAttribute('fragment');
-    log.error(`${masElement.tagName} did not initialize within ${CARD_AUTOBLOCK_TIMEOUT}ms: ${uuid}`);
+    log.error(`${masElement.tagName} did not initialize withing give timeout`);
   } else if (!success) {
     log.error(`${masElement.tagName} failed to initialize`);
   }
@@ -175,11 +172,9 @@ function copyMasFieldIdToParent(masField, name) {
 }
 
 /**
- * Hoists a resolved inline CTA out of its mas-field into the authored em/strong,
- * then runs decorateButtons. Size and utility classes come from an already-decorated
- * sibling button, else from the block's own classes. Deferred until every CTA
- * mas-field in the container has been hoisted, so a still-wrapped sibling isn't
- * matched by 'em a'/'strong a' with the wrong parent (its content span).
+ * Hoists a resolved inline CTA into the authored em/strong and runs decorateButtons.
+ * Deferred until every CTA mas-field in the container is hoisted, so a still-wrapped
+ * sibling isn't matched by 'em a'/'strong a' with the wrong parent (its content span).
  */
 function decorateInlineCtas(masField, content) {
   const container = masField.closest('p, div');
@@ -192,10 +187,8 @@ function decorateInlineCtas(masField, content) {
     blockEl = blockEl.parentElement;
   }
 
-  // Match a fully-decorated sibling button in the same block, else derive from the block.
-  // Only a button that carries a size class counts: mas-field self-styles its CTAs with
-  // con-button but no size, so an unsized (self-styled, not-yet-Milo-decorated) sibling must
-  // not be used as the size reference — doing so would drop button-xl on every CTA.
+  // Only a sized sibling counts: mas-field self-styles CTAs with con-button but no size,
+  // and using an unsized one as reference would drop button-xl on every CTA.
   const SIZE_CLASS = /^button-(s|m|l|xl)$/;
   const siblingBtn = [...(blockEl?.querySelectorAll('.con-button') ?? [])]
     .find((b) => !masField.contains(b) && [...b.classList].some((c) => SIZE_CLASS.test(c)));
@@ -212,9 +205,7 @@ function decorateInlineCtas(masField, content) {
     if (btnVariant) {
       size = `button-${btnVariant.split('-')[0]}`;
     } else if (blockEl?.classList.contains('hero-marquee')) {
-      // Mirror hero-marquee's extendButtonsClass, which adds button-xl AND
-      // button-justified-mobile to every .con-button. Without the util class an
-      // all-headless-CTA marquee renders inline instead of full-width on mobile.
+      // Mirror hero-marquee's extendButtonsClass; the util class keeps CTAs full-width on mobile.
       size = 'button-xl';
       utilClasses = ['button-justified-mobile'];
     } else if (blockEl?.classList.contains('accordion') || blockEl?.classList.contains('media')) {
@@ -238,10 +229,8 @@ function decorateInlineCtas(masField, content) {
 }
 
 /**
- * A headless mas-field CTA can resolve after its block decorated (slow network),
- * firing 'mas:ready' too late for decorateButtons. One document-level listener
- * hoists + decorates it regardless of block, so no per-block wiring is needed.
- * Registered once, on the first merch init.
+ * A headless mas-field CTA can fire 'mas:ready' after its block decorated (slow network),
+ * too late for decorateButtons. One document listener hoists + decorates it, no per-block wiring.
  */
 let masReadyWatched = false;
 function watchMasFieldCtas() {

--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -82,7 +82,10 @@ export async function checkReady(masElement, fragment) {
   const readyPromise = masElement.checkReady();
   const success = await Promise.race([readyPromise, getTimeoutPromise()]);
   if (success === 'timeout') {
-    log.error(`${masElement.tagName} did not initialize withing give timeout`);
+    // log.error already forwards to LANA (tags: acom, clientId: merch-at-scale); include the
+    // fragment id + timeout so slow/failed hydration (3G, cache miss) is actionable there.
+    const uuid = fragment ?? masElement.querySelector('aem-fragment')?.getAttribute('fragment');
+    log.error(`${masElement.tagName} did not initialize within ${CARD_AUTOBLOCK_TIMEOUT}ms: ${uuid}`);
   } else if (!success) {
     log.error(`${masElement.tagName} failed to initialize`);
   }

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -330,6 +330,62 @@ describe('merch-card-autoblock autoblock', () => {
       expect(link).to.exist;
     });
 
+    it('adds button-justified-mobile to a hero-marquee CTA with no decorated sibling', async () => {
+      setConfig({ codeRoot: '/libs' });
+      const section = document.createElement('div');
+      section.classList.add('section');
+      const block = document.createElement('div');
+      block.classList.add('hero-marquee');
+
+      // Single headless CTA, no already-decorated sibling button in the block.
+      const p = document.createElement('p');
+      const strong = document.createElement('strong');
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=hero-solo-cta-1&field=ctas';
+      a.textContent = '[[hero-cta:ctas]]';
+      strong.append(a);
+      p.append(strong);
+      block.append(p);
+      section.append(block);
+      document.body.append(section);
+
+      await init(a);
+
+      expect(document.querySelector('mas-field')).to.not.exist;
+      const link = p.querySelector('a.con-button');
+      expect(link).to.exist;
+      expect(link.classList.contains('button-xl')).to.be.true;
+      expect(link.classList.contains('button-justified-mobile')).to.be.true;
+    });
+
+    it('sizes late self-styled CTAs even when a sibling is an unsized con-button (mas-field self-styling)', async () => {
+      // Real mas-field self-styles indexed CTAs with con-button (no size class).
+      // The other CTA's self-styled anchor must NOT be treated as a sized sibling.
+      setConfig({ codeRoot: '/libs' });
+      const section = document.createElement('div');
+      section.classList.add('section');
+      const block = document.createElement('div');
+      block.classList.add('hero-marquee');
+      const p = document.createElement('p');
+      p.innerHTML = `
+        <em><mas-field field="ctas[0]"><span data-role="mas-field-content"><a class="button con-button outline" is="checkout-link" href="https://commerce.adobe.com/">Free trial</a></span></mas-field></em>
+        <strong><mas-field field="ctas[1]"><span data-role="mas-field-content"><a class="button con-button blue" is="checkout-link" href="https://commerce.adobe.com/">Buy now</a></span></mas-field></strong>`;
+      block.append(p);
+      section.append(block);
+      document.body.append(section);
+
+      // watchMasFieldCtas is registered on first init (module-level); prior tests did that.
+      // Dispatch the late mas:ready from each mas-field, as the real component does.
+      [...p.querySelectorAll('mas-field')].forEach((mf) => {
+        mf.dispatchEvent(new CustomEvent('mas:ready', { bubbles: true, composed: true }));
+      });
+
+      expect(p.querySelectorAll('mas-field').length).to.equal(0);
+      const links = [...p.querySelectorAll('a.con-button')];
+      expect(links.length).to.equal(2);
+      links.forEach((link) => expect(link.classList.contains('button-xl')).to.be.true);
+    });
+
     it('decorates two CTAs in the same paragraph correctly when processed concurrently', async () => {
       setConfig({ codeRoot: '/libs' });
       const section = document.createElement('div');

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -387,6 +387,35 @@ describe('merch-card-autoblock autoblock', () => {
       links.forEach((link) => expect(link.classList.contains('button-xl')).to.be.true);
     });
 
+    it('upgrades a late plain commerce CTA to checkout-link on mas:ready (MWPW-201497)', async () => {
+      // Regression: a CTA that resolves after its block decorated fires mas:ready and is
+      // hoisted, but the late path skipped upgradeCommerceLinks — so the anchor got button
+      // classes yet no is="checkout-link", leaving it unhydrated (no href, no modal).
+      setConfig({ codeRoot: '/libs' });
+      const section = document.createElement('div');
+      section.classList.add('section');
+      const block = document.createElement('div');
+      block.classList.add('hero-marquee');
+      const p = document.createElement('p');
+      p.innerHTML = '<em><mas-field field="ctas[0]"><span data-role="mas-field-content">'
+        + '<a data-wcs-osi="abc" data-checkout-workflow="UCv3" data-modal="twp">Free trial</a>'
+        + '</span></mas-field></em>';
+      block.append(p);
+      section.append(block);
+      document.body.append(section);
+
+      // Late resolution: the component fires mas:ready after the block already decorated.
+      p.querySelector('mas-field').dispatchEvent(
+        new CustomEvent('mas:ready', { bubbles: true, composed: true }),
+      );
+
+      expect(p.querySelectorAll('mas-field').length).to.equal(0);
+      const link = p.querySelector('a[data-wcs-osi]');
+      expect(link, 'CTA anchor should be hoisted').to.exist;
+      expect(link.outerHTML).to.include('is="checkout-link"');
+      expect(link.classList.contains('con-button')).to.be.true;
+    });
+
     it('decorates two CTAs in the same paragraph correctly when processed concurrently', async () => {
       setConfig({ codeRoot: '/libs' });
       const section = document.createElement('div');

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -358,9 +358,10 @@ describe('merch-card-autoblock autoblock', () => {
       expect(link.classList.contains('button-justified-mobile')).to.be.true;
     });
 
-    it('sizes late self-styled CTAs even when a sibling is an unsized con-button (mas-field self-styling)', async () => {
-      // Real mas-field self-styles indexed CTAs with con-button (no size class).
-      // The other CTA's self-styled anchor must NOT be treated as a sized sibling.
+    it('keeps button-xl on late CTAs when a sibling con-button has no size class', async () => {
+      // A pre-existing unsized con-button (e.g. a mas-field footer CTA, self-styled with
+      // con-button but no size) must NOT be used as the size reference, or button-xl is
+      // dropped. Two unsized con-buttons resolving late stand in for that case.
       setConfig({ codeRoot: '/libs' });
       const section = document.createElement('div');
       section.classList.add('section');


### PR DESCRIPTION
* Decorate late-resolving headless `mas-field` CTAs via one `mas:ready` listener, so cold/slow loads style them the same as fast loads.
* Hide a wrapped CTA until it is decorated, removing the half-styled flicker.

Resolves: [MWPW-201497](https://jira.corp.adobe.com/browse/MWPW-201497)

**Why:** On a cold load the fragment resolves after `createInline`'s 5s timeout, so the CTA is left unstyled (no `button-xl`, still wrapped in `em`/`strong`). The listener decorates it whenever it renders, independent of the timeout.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-201497--milo--adobecom.aem.page/?martech=off
- Product page (throttle to Slow 3G): https://www.stage.adobe.com/products/photoshop.html?maslibs=MWPW-201497&milolibs=MWPW-201497
- https://stage--da-cc--adobecom.aem.page/ca/drafts/ravneet/dotcom-188566/downloads-test?maslibs=MWPW-201497&milolibs=MWPW-201497
















