### PR TITLE
MWPW-201353: add unit tests for c2 rich-content block

### DIFF
--- a/test/blocks/rich-content/mocks/bg-image.html
+++ b/test/blocks/rich-content/mocks/bg-image.html
@@ -1,0 +1,12 @@
+<main>
+  <div class="section">
+    <div class="rich-content">
+      <div>
+        <div>
+          <h2>Heading over media</h2>
+        </div>
+        <div><picture><img src="" alt="background" /></picture></div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/rich-content/mocks/default.html
+++ b/test/blocks/rich-content/mocks/default.html
@@ -1,0 +1,13 @@
+<main>
+  <div class="section">
+    <div class="rich-content">
+      <div>
+        <div>
+          <h2>“Great things ahead</h2>
+          <p>Some supporting copy.</p>
+        </div>
+        <div>rgba(0, 0, 0, 0.5)</div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/rich-content/mocks/no-quote.html
+++ b/test/blocks/rich-content/mocks/no-quote.html
@@ -1,0 +1,12 @@
+<main>
+  <div class="section">
+    <div class="rich-content">
+      <div>
+        <div>
+          <h2>Great things ahead</h2>
+          <p>Some supporting copy.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/rich-content/mocks/promote-heading.html
+++ b/test/blocks/rich-content/mocks/promote-heading.html
@@ -1,0 +1,12 @@
+<main>
+  <div class="section">
+    <div class="rich-content">
+      <div>
+        <div>
+          <p>Lead paragraph becomes the heading.</p>
+          <p>Second paragraph stays body copy.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/rich-content/rich-content.test.js
+++ b/test/blocks/rich-content/rich-content.test.js
@@ -1,0 +1,83 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/rich-content/rich-content.js';
+
+describe('Rich Content', () => {
+  it('adds foreground and content classes to the first row and cell', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.rich-content');
+    init(block);
+
+    const foreground = block.children[0];
+    expect(foreground.classList.contains('foreground')).to.be.true;
+    expect(foreground.children[0].classList.contains('content')).to.be.true;
+  });
+
+  it('hangs an opening quote into its own span', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.rich-content');
+    init(block);
+
+    const heading = block.querySelector('.content h2');
+    const quote = heading.querySelector('.opening-quote');
+    expect(quote).to.exist;
+    expect(quote.textContent).to.equal('“');
+    // the quote character is removed from the heading text itself
+    expect(heading.textContent).to.equal('“Great things ahead');
+    expect(heading.firstElementChild).to.equal(quote);
+  });
+
+  it('does not add an opening-quote span when the heading has no opening quote', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/no-quote.html' });
+    const block = document.querySelector('.rich-content');
+    init(block);
+
+    expect(block.querySelector('.opening-quote')).to.be.null;
+  });
+
+  it('marks a text-only second cell as the hero overlay source and sets the section variable', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.rich-content');
+    init(block);
+
+    const bgCell = block.children[0].children[1];
+    expect(bgCell.classList.contains('hero-overlay-source')).to.be.true;
+
+    const section = block.closest('.section');
+    expect(section.style.getPropertyValue('--rc-hero-overlay').trim()).to.equal('rgba(0, 0, 0, 0.5)');
+  });
+
+  it('does not treat a second cell containing an image as an overlay source', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/bg-image.html' });
+    const block = document.querySelector('.rich-content');
+    init(block);
+
+    const bgCell = block.children[0].children[1];
+    expect(bgCell.classList.contains('hero-overlay-source')).to.be.false;
+
+    const section = block.closest('.section');
+    expect(section.style.getPropertyValue('--rc-hero-overlay')).to.equal('');
+  });
+
+  it('promotes the first paragraph to a heading when the content has no heading', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/promote-heading.html' });
+    const block = document.querySelector('.rich-content');
+    init(block);
+
+    const paragraphs = block.querySelectorAll('.content p');
+    expect([...paragraphs[0].classList].some((c) => c.startsWith('heading-'))).to.be.true;
+    expect([...paragraphs[0].classList].some((c) => c.startsWith('body-'))).to.be.false;
+    // subsequent paragraphs stay body copy
+    expect([...paragraphs[1].classList].some((c) => c.startsWith('body-'))).to.be.true;
+  });
+
+  it('leaves paragraphs alone when the content already has a heading', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/no-quote.html' });
+    const block = document.querySelector('.rich-content');
+    init(block);
+
+    const paragraph = block.querySelector('.content p');
+    expect([...paragraph.classList].some((c) => c.startsWith('heading-'))).to.be.false;
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for the `rich-content` c2 block (`libs/c2/blocks/rich-content`), which previously had no coverage in `test/blocks`
- Covers: foreground/content decoration, opening-quote hanging into a `.opening-quote` span, hero-overlay source detection + section `--rc-hero-overlay` variable, image-cell guard (no overlay source), and first-paragraph heading promotion
- Follows conventions from existing block tests (e.g. `test/blocks/brand-concierge`, `test/blocks/base-card`)

Resolves: https://jira.corp.adobe.com/browse/MWPW-201353

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/rich-content/rich-content.test.js" --node-resolve --port=2000` — 7/7 passing
- [x] `npx eslint test/blocks/rich-content/rich-content.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

