### PR TITLE
MWPW-201348: add unit tests for c2 elastic-carousel block

### DIFF
--- a/test/blocks/elastic-carousel/elastic-carousel.test.js
+++ b/test/blocks/elastic-carousel/elastic-carousel.test.js
@@ -1,0 +1,105 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/elastic-carousel/elastic-carousel.js';
+
+describe('Elastic Carousel', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('dir');
+  });
+
+  it('wraps slides in a carousel container and sets carousel dataset roles', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.elastic-carousel');
+    await init(block);
+
+    const container = block.querySelector('.elastic-carousel-container');
+    expect(container).to.exist;
+    expect(container.querySelectorAll('.elastic-carousel-item').length).to.equal(2);
+
+    expect(block.dataset.role).to.equal('group');
+    expect(block.dataset.ariaRoledescription).to.equal('carousel');
+    expect(block.dataset.ariaRole).to.equal('group');
+    expect(block.dataset.ariaLabel).to.equal('My Carousel');
+  });
+
+  it('builds each slide as an anchor with link, index and accessibility attributes', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.elastic-carousel');
+    await init(block);
+
+    const slide = block.querySelector('.elastic-carousel-item');
+    expect(slide.tagName).to.equal('A');
+    expect(slide.getAttribute('href')).to.equal('https://www.adobe.com/one');
+    expect(slide.getAttribute('role')).to.equal('link');
+    expect(slide.getAttribute('data-index')).to.equal('1');
+    expect(slide.getAttribute('aria-describedby')).to.equal('elastic-carousel-slide-1');
+    expect(slide.getAttribute('daa-ll')).to.equal('Learn more-1--Slide one heading');
+  });
+
+  it('lays out the header, media and footer regions inside the slide', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.elastic-carousel');
+    await init(block);
+
+    const slide = block.querySelector('.elastic-carousel-item');
+    const inner = slide.querySelector('.elastic-carousel-item-container');
+    expect(inner.id).to.equal('elastic-carousel-slide-1');
+
+    const header = slide.querySelector('.elastic-carousel-item-header');
+    expect(header.querySelector('img')).to.exist;
+    expect(header.querySelector('h3').textContent.trim()).to.equal('Slide one heading');
+
+    expect(slide.querySelector('.elastic-carousel-item-media video')).to.exist;
+
+    const footer = slide.querySelector('.elastic-carousel-item-footer');
+    expect(footer.textContent).to.contain('Learn more');
+  });
+
+  it('rewrites federated svg icon sources to the federated content root', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.elastic-carousel');
+    await init(block);
+
+    const icon = block.querySelector('.elastic-carousel-item-header img');
+    expect(icon.getAttribute('src')).to.equal('https://main--federal--adobecom.aem.page/federal/icons/icon-one.svg');
+  });
+
+  it('prepares a video asset with a source, muted playback and no controls', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.elastic-carousel');
+    await init(block);
+
+    const video = block.querySelector('.elastic-carousel-item-media video');
+    expect(video.getAttribute('preload')).to.equal('none');
+    expect(video.hasAttribute('muted')).to.be.true;
+    expect(video.getAttribute('tabindex')).to.equal('-1');
+    expect(video.hasAttribute('controls')).to.be.false;
+
+    const source = video.querySelector('source');
+    expect(source.getAttribute('src')).to.equal('/media/one.mp4');
+    expect(source.getAttribute('type')).to.equal('video/mp4');
+  });
+
+  it('rewrites a federated svg media asset and falls back to the default carousel name', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/image-asset.html' });
+    const block = document.querySelector('.elastic-carousel');
+    await init(block);
+
+    const media = block.querySelector('.elastic-carousel-item-media img');
+    expect(media.getAttribute('src')).to.equal('https://main--federal--adobecom.aem.page/federal/media/hero.svg');
+    // link text has no pipe, so the carousel name falls back to the default
+    expect(block.dataset.ariaLabel).to.equal('Adobe slides');
+  });
+
+  it('reverses slide order in RTL', async () => {
+    document.documentElement.setAttribute('dir', 'rtl');
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.elastic-carousel');
+    await init(block);
+
+    const firstSlide = block.querySelector('.elastic-carousel-item');
+    // in RTL the authored last slide becomes the first rendered slide
+    expect(firstSlide.querySelector('h3').textContent.trim()).to.equal('Slide two heading');
+  });
+});

--- a/test/blocks/elastic-carousel/mocks/default.html
+++ b/test/blocks/elastic-carousel/mocks/default.html
@@ -1,0 +1,28 @@
+<main>
+  <div class="section">
+    <div class="elastic-carousel">
+      <div>
+        <div>
+          <p><img src="/federal/icons/icon-one.svg" alt="icon one" /></p>
+          <h3>Slide one heading</h3>
+          <p>Learn more</p>
+          <p><a href="https://www.adobe.com/one">Explore | My Carousel</a></p>
+        </div>
+        <div>
+          <video data-video-source="/media/one.mp4" controls></video>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p><img src="/federal/icons/icon-two.svg" alt="icon two" /></p>
+          <h3>Slide two heading</h3>
+          <p>Discover</p>
+          <p><a href="https://www.adobe.com/two">Explore | My Carousel</a></p>
+        </div>
+        <div>
+          <video data-video-source="/media/two.mp4" controls></video>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/elastic-carousel/mocks/image-asset.html
+++ b/test/blocks/elastic-carousel/mocks/image-asset.html
@@ -1,0 +1,17 @@
+<main>
+  <div class="section">
+    <div class="elastic-carousel">
+      <div>
+        <div>
+          <p><img src="/federal/icons/icon-one.svg" alt="icon one" /></p>
+          <h3>Slide one heading</h3>
+          <p>Learn more</p>
+          <p><a href="https://www.adobe.com/one">Explore our work</a></p>
+        </div>
+        <div>
+          <img src="/federal/media/hero.svg" alt="hero asset" />
+        </div>
+      </div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
## Summary
- Adds unit tests for the `elastic-carousel` c2 block (`libs/c2/blocks/elastic-carousel`), which previously had no coverage in `test/blocks`
- Covers: carousel container wrapping + dataset roles (`role`/`aria-roledescription`/`aria-label`/`aria-role`), slide anchor build (href, `data-index`, `role`, `aria-describedby`, `daa-ll`), header/media/footer layout, federated svg icon + media `src` rewriting, video asset preparation (source, muted, no controls), default carousel-name fallback, and RTL slide reversal
- Follows conventions from existing block tests (e.g. `test/blocks/carousel`, `test/blocks/base-card`)

Resolves: https://jira.corp.adobe.com/browse/MWPW-201348

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/elastic-carousel/elastic-carousel.test.js" --node-resolve --port=2000` — 7/7 passing
- [x] `npx eslint test/blocks/elastic-carousel/elastic-carousel.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

