### PR TITLE
[MWPW-187555] - Comparison table a11y

### DIFF
--- a/libs/blocks/comparison-table/comparison-table.js
+++ b/libs/blocks/comparison-table/comparison-table.js
@@ -472,15 +472,22 @@ function setupResponsiveHiding(el) {
 
 function setAccessibilityLabels(el) {
   import('../../features/placeholders.js').then(({ replaceKeyArray }) => {
-    replaceKeyArray(['choose-table-column', 'empty-table-cell', 'not-a-feature'], getConfig())
-      .then(([ariaLabel, emptyText, notAFeatureText]) => {
+    replaceKeyArray(['choose-table-column', 'empty-table-cell', 'not-a-feature', 'primary-feature'], getConfig())
+      .then(([ariaLabel, emptyText, notAFeatureText, primaryFeatureText]) => {
         [...el.querySelectorAll('.mobile-filter-select')].forEach((element) => element.setAttribute('aria-label', ariaLabel));
 
         [...el.querySelectorAll('.table-cell div')].forEach((cellDiv) => {
           const closeIcon = cellDiv.querySelector('.icon-close');
           if (closeIcon) {
-            closeIcon.setAttribute('role', 'img');
-            closeIcon.setAttribute('aria-label', notAFeatureText);
+            closeIcon.setAttribute('aria-hidden', 'true');
+            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
+            return;
+          }
+          const checkmarkIcon = cellDiv.querySelector('.icon-checkmark');
+          if (checkmarkIcon) {
+            checkmarkIcon.querySelector('title')?.remove();
+            checkmarkIcon.setAttribute('aria-hidden', 'true');
+            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, primaryFeatureText));
             return;
           }
           const content = cellDiv.textContent.trim();

--- a/libs/blocks/comparison-table/comparison-table.js
+++ b/libs/blocks/comparison-table/comparison-table.js
@@ -472,18 +472,25 @@ function setupResponsiveHiding(el) {
 
 function setAccessibilityLabels(el) {
   import('../../features/placeholders.js').then(({ replaceKeyArray }) => {
-    replaceKeyArray(['choose-table-column', 'empty-table-cell'], getConfig()).then(([ariaLabel, emptyText]) => {
-      [...el.querySelectorAll('.mobile-filter-select')].forEach((element) => element.setAttribute('aria-label', ariaLabel));
+    replaceKeyArray(['choose-table-column', 'empty-table-cell', 'not-a-feature'], getConfig())
+      .then(([ariaLabel, emptyText, notAFeatureText]) => {
+        [...el.querySelectorAll('.mobile-filter-select')].forEach((element) => element.setAttribute('aria-label', ariaLabel));
 
-      [...el.querySelectorAll('.table-cell div')].forEach((cellDiv) => {
-        const content = cellDiv.textContent.trim();
-        const hasEmptyContent = /^-+$/.test(content);
-        if (content && !hasEmptyContent) return;
-        const srOnly = createTag('span', { class: 'sr-only' }, emptyText);
-        cellDiv.appendChild(srOnly);
-        if (hasEmptyContent) cellDiv.children[0].setAttribute('aria-hidden', 'true');
+        [...el.querySelectorAll('.table-cell div')].forEach((cellDiv) => {
+          const closeIcon = cellDiv.querySelector('.icon-close');
+          if (closeIcon) {
+            closeIcon.setAttribute('role', 'img');
+            closeIcon.setAttribute('aria-label', notAFeatureText);
+            return;
+          }
+          const content = cellDiv.textContent.trim();
+          const hasEmptyContent = /^-+$/.test(content);
+          if (content && !hasEmptyContent) return;
+          const srOnly = createTag('span', { class: 'sr-only' }, emptyText);
+          cellDiv.appendChild(srOnly);
+          if (hasEmptyContent) cellDiv.children[0].setAttribute('aria-hidden', 'true');
+        });
       });
-    });
   });
 }
 

--- a/libs/blocks/comparison-table/comparison-table.js
+++ b/libs/blocks/comparison-table/comparison-table.js
@@ -479,6 +479,7 @@ function setAccessibilityLabels(el) {
         [...el.querySelectorAll('.table-cell div')].forEach((cellDiv) => {
           const closeIcon = cellDiv.querySelector('.icon-close');
           if (closeIcon) {
+            closeIcon.querySelector('title')?.remove();
             closeIcon.setAttribute('aria-hidden', 'true');
             cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
             return;

--- a/test/blocks/comparison-table/comparison-table.test.js
+++ b/test/blocks/comparison-table/comparison-table.test.js
@@ -212,6 +212,15 @@ describe('Comparison Table', () => {
       const accessibilityHeaders = comparisonTable.querySelectorAll('.accessibility-header-cell[data-column-index]');
       expect(accessibilityHeaders.length).to.be.greaterThan(0);
     });
+
+    it('close icon has an accessible name distinguishing it from an empty cell', async () => {
+      await delay(100);
+      const closeIcon = comparisonTable.querySelector('.icon-close');
+      expect(closeIcon).to.exist;
+      expect(closeIcon.getAttribute('role')).to.equal('img');
+      expect(closeIcon.getAttribute('aria-label')).to.equal('not a feature');
+      expect(closeIcon.closest('.table-cell').querySelector('.sr-only')).to.not.exist;
+    });
   });
 
   describe('Mobile Filter Select', () => {

--- a/test/blocks/comparison-table/comparison-table.test.js
+++ b/test/blocks/comparison-table/comparison-table.test.js
@@ -217,9 +217,21 @@ describe('Comparison Table', () => {
       await delay(100);
       const closeIcon = comparisonTable.querySelector('.icon-close');
       expect(closeIcon).to.exist;
-      expect(closeIcon.getAttribute('role')).to.equal('img');
-      expect(closeIcon.getAttribute('aria-label')).to.equal('not a feature');
-      expect(closeIcon.closest('.table-cell').querySelector('.sr-only')).to.not.exist;
+      expect(closeIcon.getAttribute('aria-hidden')).to.equal('true');
+      const srOnly = closeIcon.closest('div').querySelector('.sr-only');
+      expect(srOnly).to.exist;
+      expect(srOnly.textContent).to.equal('not a feature');
+    });
+
+    it('checkmark icon has an sr-only accessible name and no native title', async () => {
+      await delay(100);
+      const checkmarkIcon = comparisonTable.querySelector('.icon-checkmark');
+      expect(checkmarkIcon).to.exist;
+      expect(checkmarkIcon.getAttribute('aria-hidden')).to.equal('true');
+      expect(checkmarkIcon.querySelector('title')).to.not.exist;
+      const srOnly = checkmarkIcon.closest('div').querySelector('.sr-only');
+      expect(srOnly).to.exist;
+      expect(srOnly.textContent).to.equal('primary feature');
     });
   });
 

--- a/test/blocks/comparison-table/mocks/body.html
+++ b/test/blocks/comparison-table/mocks/body.html
@@ -65,7 +65,7 @@
     </div>
     <div>
       <div>Feature 3</div>
-      <div></div>
+      <div><span class="icon icon-close"></span></div>
       <div><span class="icon icon-checkmark"></span></div>
       <div><span class="icon icon-checkmark"></span></div>
       <div><span class="icon icon-checkmark"></span></div>

--- a/test/blocks/comparison-table/mocks/body.html
+++ b/test/blocks/comparison-table/mocks/body.html
@@ -58,7 +58,7 @@
     </div>
     <div>
       <div>Feature 2</div>
-      <div><span class="icon icon-checkmark"></span></div>
+      <div><span class="icon icon-checkmark"><svg><title>Checkmark</title></svg></span></div>
       <div><span class="icon icon-checkmark"></span></div>
       <div><span class="icon icon-checkmark"></span></div>
       <div><span class="icon icon-checkmark"></span></div>


### PR DESCRIPTION
Change has been vetted by the accessibility team.

Resolves: [MWPW-187555](https://jira.corp.adobe.com/browse/MWPW-187555)

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/docs/library/kitchen-sink/comparison-table
- After: https://comparison-table-a11y--milo--adobecom.aem.page/docs/library/kitchen-sink/comparison-table




