### PR TITLE
[MWPW-201841] - Fix comparison-table-c2 sticky header covered by gnav; 

### DIFF
--- a/libs/mep/ace1205/comparison-table-c2/comparison-table-c2.js
+++ b/libs/mep/ace1205/comparison-table-c2/comparison-table-c2.js
@@ -1,5 +1,6 @@
 import { createTag, getConfig, loadStyle } from '../../../utils/utils.js';
 import { getMetadata as getSectionMetadata } from '../section-metadata/section-metadata.js';
+import { getGnavHeight } from '../../../blocks/global-navigation/utilities/utilities.js';
 
 const COLUMN_TYPES = { PRIMARY: 'primary' };
 
@@ -542,16 +543,7 @@ function setupCollapsingHeader(el) {
 
   const isMobile = () => window.matchMedia('(max-width: 899px)').matches;
 
-  const getNavHeight = () => {
-    const nav = document.querySelector('header > nav') ?? document.querySelector('header');
-    if (!nav) return 0;
-    const pos = getComputedStyle(nav).position;
-    const bottom = (pos === 'fixed' || pos === 'sticky')
-      ? Math.max(0, Math.round(nav.getBoundingClientRect().bottom)) : 0;
-    return bottom + (document.querySelector('.feds-localnav')?.offsetHeight ?? 0);
-  };
-
-  const syncTop = () => cardsContainer.style.setProperty('--ct-nav-height', `${getNavHeight()}px`);
+  const syncTop = () => cardsContainer.style.setProperty('--ct-nav-height', `${getGnavHeight()}px`);
 
   const getStickyTop = () => parseFloat(getComputedStyle(cardsContainer).top) || 0;
 
@@ -597,8 +589,8 @@ function setupCollapsingHeader(el) {
     if (!goingDown && wasCollapsed) removeCollapsed();
   }, { passive: true });
 
-  const nav = document.querySelector('header > nav') ?? document.querySelector('header');
-  if (nav) new ResizeObserver(syncTop).observe(nav);
+  const header = document.querySelector('header');
+  if (header) new ResizeObserver(syncTop).observe(header);
 
   new ResizeObserver(() => {
     if (!isExpanding) syncHeaderHeight();


### PR DESCRIPTION
The sticky `.header-cards-container` computed its top offset from the nav element inside header, but that inner nav isn't the sticky one — the outer header element is. This made `--ct-nav-height` always resolve to `0px`, so the comparison table header stacked underneath (and got hidden by) the sticky global nav on scroll.

Replaced the hand-rolled offset calculation with the shared `getGnavHeight()` utility (`libs/blocks/global-navigation/utilities/utilities.js`), already used by `table.js` and `sticky-section.js` for the same purpose. This also picks up correct handling for the mobile local-nav and promo-banner cases that the previous logic didn't account for.

**Resolves:** [MWPW-201841](https://jira.corp.adobe.com/browse/MWPW-201841)

**Test URLs:**

- Before: https://main--da-dc--adobecom.aem.live/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=stage
- After: https://main--da-dc--adobecom.aem.live/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-plans?milolibs=c2-comparison-table-header


🤖 Generated with Claude Code

