### PR TITLE
MWPW-201867: Web performance improvements — critical load path, block payloads, request dedupe

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,4 +1,34 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="preload" href="/libs/styles/styles.css" as="style"/>
+<link rel="modulepreload" href="/libs/utils/utils.js"/>
+<link rel="modulepreload" href="/libs/utils/locales.js"/>
+<link rel="modulepreload" href="/libs/utils/fonts.js"/>
+<link rel="preconnect" href="https://use.typekit.net" crossorigin/>
+<script type="module">
+/* Early LCP image hint: runs at parse end, before the scripts.js module graph is
+   fetched. Keep in sync with loadLCPImage in /libs/scripts/scripts.js. */
+try {
+  const eager = (img) => { img?.setAttribute('loading', 'eager'); img?.setAttribute('fetchpriority', 'high'); };
+  const firstDiv = document.querySelector('body > main > div:nth-child(1) > div');
+  if (firstDiv?.classList.contains('marquee') || firstDiv?.classList.contains('hero-marquee')) {
+    const rows = firstDiv.querySelectorAll(':scope > div');
+    const bgRow = rows.length > 1 ? rows[0] : null;
+    if (bgRow) {
+      const cells = [...bgRow.children];
+      let idx = 0;
+      if (cells.length === 2 && window.matchMedia('(min-width: 600px)').matches) idx = 1;
+      if (cells.length >= 3) {
+        if (window.matchMedia('(min-width: 1200px)').matches) idx = 2;
+        else if (window.matchMedia('(min-width: 600px)').matches) idx = 1;
+      }
+      eager(cells[idx]?.querySelector('img'));
+    }
+    firstDiv.querySelectorAll(bgRow ? ':scope > div:not(:first-child) img' : 'img').forEach(eager);
+  } else {
+    eager(document.querySelector('img'));
+  }
+} catch (e) { /* best effort only */ }
+</script>
 <script src="/libs/scripts/scripts.js" type="module"></script>
 <link rel="icon" href="data:," size="any"/>
 <style>body { display: none; }</style>

--- a/libs/blocks/article-feed/article-feed.js
+++ b/libs/blocks/article-feed/article-feed.js
@@ -14,6 +14,7 @@ import { updateLinkWithLangRoot } from '../../utils/helpers.js';
 const ROOT_MARGIN = 50;
 
 const replacePlaceholder = async (key) => replaceKey(key, getConfig());
+export const shouldLoadArticleImageEager = (offset, index) => offset === 0 && index === 0;
 
 const blogIndex = {
   data: [],
@@ -635,7 +636,7 @@ async function decorateArticleFeed(
   const max = pageEnd > articles.length ? articles.length : pageEnd;
   for (let i = offset; i < max; i += 1) {
     const article = articles[i];
-    const card = buildArticleCard(article);
+    const card = buildArticleCard(article, 'article', shouldLoadArticleImageEager(offset, i));
     articleCards.append(card);
   }
   if (articles.length > pageEnd || !feed.complete) {

--- a/libs/blocks/article-feed/article-helpers.js
+++ b/libs/blocks/article-feed/article-helpers.js
@@ -207,13 +207,50 @@ export function formatCardLocaleDate(date) {
  * @param {string} src The image URL
  * @param {boolean} eager load image eager
  * @param {Array} breakpoints breakpoints and corresponding params (eg. width)
+ * @param {Object} attributes responsive image attributes
  */
 
-export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }]) {
+export function createOptimizedPicture(
+  src,
+  alt = '',
+  eager = false,
+  breakpoints = [{ media: '(min-width: 400px)', width: '2000' }, { width: '750' }],
+  attributes = {},
+) {
   const url = new URL(src, window.location.href);
   const picture = document.createElement('picture');
   const { pathname } = url;
   const ext = pathname.substring(pathname.lastIndexOf('.') + 1);
+  const responsiveWidths = breakpoints.length > 1 && breakpoints.every((br) => !br.media);
+  const getSrc = (width, format) => `${pathname}?width=${width}&format=${format}&optimize=medium`;
+  const getSrcset = (format) => breakpoints
+    .map((br) => `${getSrc(br.width, format)} ${br.width}w`)
+    .join(', ');
+  const setImageAttributes = (img) => {
+    img.setAttribute('loading', eager ? 'eager' : 'lazy');
+    img.setAttribute('decoding', 'async');
+    img.setAttribute('alt', alt);
+    if (eager) img.setAttribute('fetchpriority', 'high');
+    if (attributes.sizes) img.setAttribute('sizes', attributes.sizes);
+    if (attributes.width) img.setAttribute('width', attributes.width);
+    if (attributes.height) img.setAttribute('height', attributes.height);
+  };
+
+  if (responsiveWidths) {
+    const source = document.createElement('source');
+    source.setAttribute('type', 'image/webp');
+    source.setAttribute('srcset', getSrcset('webply'));
+    if (attributes.sizes) source.setAttribute('sizes', attributes.sizes);
+    picture.appendChild(source);
+
+    const largest = breakpoints[breakpoints.length - 1];
+    const img = document.createElement('img');
+    img.setAttribute('src', getSrc(largest.width, ext));
+    img.setAttribute('srcset', getSrcset(ext));
+    setImageAttributes(img);
+    picture.appendChild(img);
+    return picture;
+  }
 
   // webp
   breakpoints.forEach((br) => {
@@ -234,8 +271,7 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
     } else {
       const img = document.createElement('img');
       img.setAttribute('src', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
-      img.setAttribute('loading', eager ? 'eager' : 'lazy');
-      img.setAttribute('alt', alt);
+      setImageAttributes(img);
       picture.appendChild(img);
     }
   });
@@ -296,7 +332,17 @@ export function buildArticleCard(article, type = 'article', eager = false) {
 
   const path = article.path.split('.')[0];
 
-  const picture = createOptimizedPicture(image, imageAlt || title, eager, [{ width: '750' }]);
+  const picture = createOptimizedPicture(
+    image,
+    imageAlt || title,
+    eager,
+    [{ width: '320' }, { width: '480' }, { width: '750' }],
+    {
+      sizes: '(min-width: 1200px) 378px, (min-width: 600px) min(378px, calc((100vw - 96px) / 2)), clamp(268px, calc(100vw - 64px), 378px)',
+      width: '378',
+      height: '250',
+    },
+  );
   const pictureTag = picture.outerHTML;
   const card = document.createElement('a');
   card.className = `${type}-card`;

--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -854,6 +854,11 @@ const reducer = (state, action) => {
   }
 };
 
+const STORAGE_DEBOUNCE_DELAY = 250;
+let storageTimer;
+let pendingSerialization;
+let persistedSerialization;
+
 const getInitialState = async () => {
   let state = await getHashConfig();
   // /* c8 ignore next 2 */
@@ -875,8 +880,27 @@ const getInitialState = async () => {
   return updateObj(state, defaultState);
 };
 
-const saveStateToLocalStorage = (state) => {
-  localStorage.setItem(LS_KEY, JSON.stringify(state));
+export const saveStateToLocalStorage = (state) => {
+  const serialized = JSON.stringify(state);
+  if (serialized === pendingSerialization) return;
+  if (serialized === persistedSerialization
+    && localStorage.getItem(LS_KEY) === persistedSerialization) {
+    clearTimeout(storageTimer);
+    storageTimer = undefined;
+    pendingSerialization = undefined;
+    return;
+  }
+
+  pendingSerialization = serialized;
+  clearTimeout(storageTimer);
+  storageTimer = setTimeout(() => {
+    if (localStorage.getItem(LS_KEY) !== pendingSerialization) {
+      localStorage.setItem(LS_KEY, pendingSerialization);
+    }
+    persistedSerialization = pendingSerialization;
+    pendingSerialization = undefined;
+    storageTimer = undefined;
+  }, STORAGE_DEBOUNCE_DELAY);
 };
 
 /**

--- a/libs/blocks/caas-marquee/caas-marquee.css
+++ b/libs/blocks/caas-marquee/caas-marquee.css
@@ -1577,3 +1577,9 @@ main > .section[class*='-up'] > .content {
   .section.masonry-layout .grid-span-10 {grid-column: span 10; }
   .section.masonry-layout .grid-span-11 {grid-column: span 11; }
 }
+
+@media screen and (min-width: 1200px) {
+  .marquee .background .responsive-background img {
+    object-position: 32% center;
+  }
+}

--- a/libs/blocks/caas-marquee/caas-marquee.js
+++ b/libs/blocks/caas-marquee/caas-marquee.js
@@ -519,7 +519,22 @@ function getImageHtml(src, screen, belowFold, style = '', width = '', height = '
         <source type="image/webp" srcset="${src}?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
         <source type="image/webp" srcset="${src}?width=750&amp;format=webply&amp;optimize=medium">
         <source type="image/${format}" srcset="${src}?width=2000&amp;format=${format}&amp;optimize=medium" media="(min-width: 600px)">
-        <img loading="${loadingType}" alt src="${src}?width=750&amp;format=${format}&amp;optimize=medium" width="${width}" height="${height}" ${fetchPriority} style="${style}">
+        <img loading="${loadingType}" decoding="async" alt src="${src}?width=750&amp;format=${format}&amp;optimize=medium" width="${width}" height="${height}" ${fetchPriority} style="${style}">
+  </picture>`;
+}
+
+export function getResponsiveImageHtml({
+  mobile,
+  tablet = mobile,
+  desktop = tablet,
+}) {
+  return `<picture class="responsive-background">
+        <source type="image/webp" srcset="${desktop}?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 1200px)">
+        <source type="image/png" srcset="${desktop}?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 1200px)">
+        <source type="image/webp" srcset="${tablet}?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+        <source type="image/jpeg" srcset="${tablet}?width=2000&amp;format=jpeg&amp;optimize=medium" media="(min-width: 600px)">
+        <source type="image/webp" srcset="${mobile}?width=750&amp;format=webply&amp;optimize=medium">
+        <img loading="eager" decoding="async" fetchpriority="high" alt src="${mobile}?width=750&amp;format=jpeg&amp;optimize=medium" width="${WIDTHS.mobile}" height="${HEIGHTS.mobile}">
   </picture>`;
 }
 
@@ -537,6 +552,13 @@ function getContent(src, screen, style = '') {
     return `<div data-valign="middle" class="asset image bleed">${inner}</div>`;
   }
   return `<div class=${screen}-only>${inner}</div>`;
+}
+
+export function getBackgroundContent(imageSources) {
+  const hasResponsiveImages = Object.values(imageSources).every((src) => IMAGE_EXTENSIONS.test(src));
+  return hasResponsiveImages
+    ? getResponsiveImageHtml(imageSources)
+    : `${getContent(imageSources.mobile, 'mobile')}${getContent(imageSources.tablet, 'tablet')}${getContent(imageSources.desktop, 'desktop', 'object-position: 32% center;')}`;
 }
 
 function addLoadingSpinner(marquee) {
@@ -748,13 +770,15 @@ export function renderMarquee(marquee, marquees, id, fallback) {
     return;
   }
 
-  const mobileBgContent = getContent(metadata.image, 'mobile');
-  const tabletBgContent = getContent(metadata.imagetablet, 'tablet');
-  const desktopBgContent = getContent(metadata.imagedesktop, 'desktop', 'object-position: 32% center;');
   const splitImage = metadata.imageDesktop || metadata.imageTablet || metadata.image;
   const splitContent = getContent(splitImage, 'split');
 
-  const bgContent = `${mobileBgContent}${tabletBgContent}${desktopBgContent}`;
+  const imageSources = {
+    mobile: metadata.image,
+    tablet: metadata.imagetablet || metadata.image,
+    desktop: metadata.imagedesktop || metadata.imagetablet || metadata.image,
+  };
+  const bgContent = getBackgroundContent(imageSources);
   let background = createTag('div', { class: 'background' }, '');
   if (isSplit) {
     background = createBackground(splitContent);

--- a/libs/blocks/carousel/carousel.js
+++ b/libs/blocks/carousel/carousel.js
@@ -316,6 +316,12 @@ function checkSlideForVideo(activeSlide) {
   /* c8 ignore end */
 }
 
+function loadSlideImages(activeSlide) {
+  activeSlide?.querySelectorAll('img[loading="lazy"]').forEach((img) => {
+    img.setAttribute('loading', 'eager');
+  });
+}
+
 // Sets a multiplier variable, used by CSS, to move the indicator dots.
 function setIndicatorMultiplier(carouselElements, activeSlideIndicator, event) {
   const { slides, direction } = carouselElements;
@@ -484,6 +490,7 @@ function moveSlides(event, carouselElements) {
 
   // Update active slide and indicator dot attributes
   activeSlide.classList.add('active');
+  loadSlideImages(activeSlide);
   setAriaHiddenAndTabIndex(carouselElements, activeSlide);
 
   if ((isHintingTablet(el) || isHintingMobile) && !prefersReducedMotion()) {
@@ -780,10 +787,7 @@ export default function init(el) {
   window.addEventListener('resize', debounce(() => { if (el.classList.contains('align-height')) normalizeVideoHeights(); }));
 
   function handleDeferredImages() {
-    const images = el.querySelectorAll('img[loading="lazy"]');
-    images.forEach((img) => {
-      img.removeAttribute('loading');
-    });
+    loadSlideImages(el.querySelector('.carousel-slide.active'));
     parentArea.removeEventListener(MILO_EVENTS.DEFERRED, handleDeferredImages, true);
   }
   parentArea.addEventListener(MILO_EVENTS.DEFERRED, handleDeferredImages, true);

--- a/libs/blocks/fragment/fragment.js
+++ b/libs/blocks/fragment/fragment.js
@@ -4,6 +4,21 @@ import {
 } from '../../utils/utils.js';
 
 const fragMap = {};
+const fragmentRequests = new Map();
+
+function fetchPlainHtml(resource) {
+  const key = new URL(resource, window.location.href).href;
+  if (!fragmentRequests.has(key)) {
+    const pending = Promise.resolve()
+      .then(() => customFetch({ resource: key, withCacheRules: true }))
+      .catch(() => ({}));
+    fragmentRequests.set(key, pending);
+    pending.finally(() => {
+      if (fragmentRequests.get(key) === pending) fragmentRequests.delete(key);
+    });
+  }
+  return fragmentRequests.get(key).then((resp) => resp?.clone?.() ?? resp);
+}
 
 const removeHash = (url) => {
   const urlNoHash = url.split('#')[0];
@@ -212,8 +227,7 @@ export default async function init(a) {
       try { relHref = new URL(fallbackPath).pathname; } catch { relHref = fallbackPath; }
     }
   } else {
-    resp = await customFetch({ resource: `${resourcePath}.plain.html`, withCacheRules: true })
-      .catch(() => ({}));
+    resp = await fetchPlainHtml(`${resourcePath}.plain.html`);
   }
 
   const mepLingoPrefix = await getGeoLocalePrefix();

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -57,15 +57,15 @@ const asideJsPromise = getMetadata('gnav-promo-source') ? import('./features/asi
 
 const breadCrumbsJsPromise = document.querySelector('header')?.classList.contains('has-breadcrumbs') ? import('./features/breadcrumbs/breadcrumbs.js') : null;
 
-const [utilities, placeholders, merch, { processTrackingLabels }] = await Promise.all([
+const [utilities, placeholders, merchLocale, { processTrackingLabels }] = await Promise.all([
   import('./utilities/utilities.js'),
   import('../../features/placeholders.js'),
-  import('../merch/merch.js'),
+  import('../merch/locale.js'),
   import('../../martech/attributes.js'),
 ]);
 
 const { replaceKey, replaceKeyArray } = placeholders;
-const { getMiloLocaleSettings, isMasGeoDetectionEnabled } = merch;
+const { getMiloLocaleSettings, isMasGeoDetectionEnabled } = merchLocale;
 
 const {
   closeAllDropdowns,

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -13,7 +13,7 @@ import {
   createTag,
 } from '../../../utils/utils.js';
 import { replaceKey, replaceText, fetchPlaceholders } from '../../../features/placeholders.js';
-import { PERSONALIZATION_TAGS, FLAGS, handleCommands } from '../../../features/personalization/personalization.js';
+import { PERSONALIZATION_TAGS, FLAGS } from '../../../features/personalization/constants.js';
 
 loadLana();
 
@@ -614,7 +614,8 @@ export async function fetchAndProcessPlainHtml({
   commands = commands.concat(gnavMepCommands);
 
   if (commands?.length) {
-    /* c8 ignore next 3 */
+    /* c8 ignore next 4 */
+    const { handleCommands } = await import('../../../features/personalization/personalization.js');
     await handleCommands(commands, body, true, true);
   }
   const inlineFrags = [...body.querySelectorAll('a[href*="#_inline"]')];

--- a/libs/blocks/merch/locale.js
+++ b/libs/blocks/merch/locale.js
@@ -1,0 +1,161 @@
+import { getMetadata } from '../../utils/utils.js';
+
+const LanguageMap = {
+  en: 'US',
+  'en-gb': 'GB',
+  'es-mx': 'MX',
+  'fr-ca': 'CA',
+  da: 'DK',
+  et: 'EE',
+  ar: 'DZ',
+  el: 'GR',
+  iw: 'IL',
+  he: 'IL',
+  id: 'ID',
+  ms: 'MY',
+  nb: 'NO',
+  sl: 'SI',
+  sv: 'SE',
+  cs: 'CZ',
+  uk: 'UA',
+  hi: 'IN',
+  'zh-hans': 'CN',
+  'zh-hant': 'TW',
+  ja: 'JP',
+  ko: 'KR',
+  fil: 'PH',
+  th: 'TH',
+  vi: 'VN',
+};
+
+export const GeoMap = {
+  ar: 'AR_es',
+  be_en: 'BE_en',
+  be_fr: 'BE_fr',
+  be_nl: 'BE_nl',
+  br: 'BR_pt',
+  ca: 'CA_en',
+  ch_de: 'CH_de',
+  ch_fr: 'CH_fr',
+  ch_it: 'CH_it',
+  cl: 'CL_es',
+  co: 'CO_es',
+  la: 'DO_es',
+  mx: 'MX_es',
+  pe: 'PE_es',
+  africa: 'MU_en',
+  dk: 'DK_da',
+  de: 'DE_de',
+  ee: 'EE_et',
+  eg_ar: 'EG_ar',
+  eg_en: 'EG_en',
+  es: 'ES_es',
+  fr: 'FR_fr',
+  gr_el: 'GR_el',
+  gr_en: 'GR_en',
+  ie: 'IE_en',
+  il_he: 'IL_he',
+  it: 'IT_it',
+  lv: 'LV_lv',
+  lt: 'LT_lt',
+  lu_de: 'LU_de',
+  lu_en: 'LU_en',
+  lu_fr: 'LU_fr',
+  my_en: 'MY_en',
+  my_ms: 'MY_ms',
+  hu: 'HU_hu',
+  mt: 'MT_en',
+  mena_en: 'DZ_en',
+  mena_ar: 'DZ_ar',
+  nl: 'NL_nl',
+  no: 'NO_nb',
+  pl: 'PL_pl',
+  pt: 'PT_pt',
+  ro: 'RO_ro',
+  si: 'SI_sl',
+  sk: 'SK_sk',
+  fi: 'FI_fi',
+  se: 'SE_sv',
+  tr: 'TR_tr',
+  uk: 'GB_en',
+  at: 'AT_de',
+  cz: 'CZ_cs',
+  bg: 'BG_bg',
+  ru: 'RU_ru',
+  ua: 'UA_uk',
+  au: 'AU_en',
+  in_en: 'IN_en',
+  in_hi: 'IN_hi',
+  id_en: 'ID_en',
+  id_id: 'ID_id',
+  nz: 'NZ_en',
+  sa_ar: 'SA_ar',
+  sa_en: 'SA_en',
+  sg: 'SG_en',
+  cn: 'CN_zh',
+  tw: 'TW_zh',
+  hk_zh: 'HK_zh',
+  jp: 'JP_ja',
+  kr: 'KR_ko',
+  za: 'ZA_en',
+  ng: 'NG_en',
+  cr: 'CR_es',
+  ec: 'EC_es',
+  pr: 'US_es', // not a typo, should be US
+  gt: 'GT_es',
+  cis_en: 'TM_en',
+  cis_ru: 'TM_ru',
+  sea: 'SG_en',
+  th_en: 'TH_en',
+  th_th: 'TH_th',
+};
+
+/**
+ * MAS WCS `locale` when it differs from `${language}_${country}` derived from {@link GeoMap}.
+ * @type {Record<string, string>}
+ */
+const EXTRA_MAS_LOCALES = { pr: 'es_PR' };
+const LANG_STORE_PREFIX = 'langstore/';
+
+function getDefaultLangstoreCountry(language) {
+  let country = LanguageMap[language];
+  if (!country && GeoMap[language]) {
+    country = language; // es, fr, pt, de
+  }
+  if (!country && language.includes('-')) {
+    [country] = language.split('-'); // variations like es-419, pt-PT
+  }
+
+  return country || 'US';
+}
+
+export function getMiloLocaleSettings(miloLocale) {
+  const localePrefix = miloLocale?.prefix || 'US_en';
+  const geo = localePrefix.replace('/', '') ?? '';
+  let [country = 'US', language = 'en'] = (GeoMap[geo] ?? geo).split('_', 2);
+
+  if (
+    geo.startsWith(LANG_STORE_PREFIX)
+    || window.location.pathname.startsWith(`/${LANG_STORE_PREFIX}`)
+  ) {
+    const localeLang = geo.replace(LANG_STORE_PREFIX, '').toLowerCase();
+    country = getDefaultLangstoreCountry(localeLang);
+    language = localeLang;
+  }
+
+  country = country.toUpperCase();
+  language = language.toLowerCase();
+
+  return {
+    language,
+    country,
+    locale: EXTRA_MAS_LOCALES[geo] ?? `${language}_${country}`,
+  };
+}
+
+export function isMasGeoDetectionEnabled() {
+  const queryParam = new URLSearchParams(window.location.search).get('mas-geo-detection');
+  const metaValue = getMetadata('mas-geo-detection');
+  const geoDetection = queryParam ?? metaValue;
+  return !!(geoDetection && ['on', 'true'].includes(geoDetection.toLowerCase()));
+}

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -3,6 +3,17 @@ import {
   shouldAllowKrTrial, getCountry,
 } from '../../utils/utils.js';
 import { replaceKey } from '../../features/placeholders.js';
+import {
+  GeoMap,
+  getMiloLocaleSettings,
+  isMasGeoDetectionEnabled,
+} from './locale.js';
+
+export {
+  GeoMap,
+  getMiloLocaleSettings,
+  isMasGeoDetectionEnabled,
+};
 
 // MAS Component Names
 export const COMMERCE_LIBRARY = 'commerce';
@@ -65,122 +76,6 @@ export const CC_SINGLE_APPS = [
   ['CC_PRO_APPS'], ['NIMBUS_LIGHTROOM'], ['NIMBUS_LIGHTROOM_PHOTOSHOP'],
 ];
 
-const LanguageMap = {
-  en: 'US',
-  'en-gb': 'GB',
-  'es-mx': 'MX',
-  'fr-ca': 'CA',
-  da: 'DK',
-  et: 'EE',
-  ar: 'DZ',
-  el: 'GR',
-  iw: 'IL',
-  he: 'IL',
-  id: 'ID',
-  ms: 'MY',
-  nb: 'NO',
-  sl: 'SI',
-  sv: 'SE',
-  cs: 'CZ',
-  uk: 'UA',
-  hi: 'IN',
-  'zh-hans': 'CN',
-  'zh-hant': 'TW',
-  ja: 'JP',
-  ko: 'KR',
-  fil: 'PH',
-  th: 'TH',
-  vi: 'VN',
-};
-
-export const GeoMap = {
-  ar: 'AR_es',
-  be_en: 'BE_en',
-  be_fr: 'BE_fr',
-  be_nl: 'BE_nl',
-  br: 'BR_pt',
-  ca: 'CA_en',
-  ch_de: 'CH_de',
-  ch_fr: 'CH_fr',
-  ch_it: 'CH_it',
-  cl: 'CL_es',
-  co: 'CO_es',
-  la: 'DO_es',
-  mx: 'MX_es',
-  pe: 'PE_es',
-  africa: 'MU_en',
-  dk: 'DK_da',
-  de: 'DE_de',
-  ee: 'EE_et',
-  eg_ar: 'EG_ar',
-  eg_en: 'EG_en',
-  es: 'ES_es',
-  fr: 'FR_fr',
-  gr_el: 'GR_el',
-  gr_en: 'GR_en',
-  ie: 'IE_en',
-  il_he: 'IL_he',
-  it: 'IT_it',
-  lv: 'LV_lv',
-  lt: 'LT_lt',
-  lu_de: 'LU_de',
-  lu_en: 'LU_en',
-  lu_fr: 'LU_fr',
-  my_en: 'MY_en',
-  my_ms: 'MY_ms',
-  hu: 'HU_hu',
-  mt: 'MT_en',
-  mena_en: 'DZ_en',
-  mena_ar: 'DZ_ar',
-  nl: 'NL_nl',
-  no: 'NO_nb',
-  pl: 'PL_pl',
-  pt: 'PT_pt',
-  ro: 'RO_ro',
-  si: 'SI_sl',
-  sk: 'SK_sk',
-  fi: 'FI_fi',
-  se: 'SE_sv',
-  tr: 'TR_tr',
-  uk: 'GB_en',
-  at: 'AT_de',
-  cz: 'CZ_cs',
-  bg: 'BG_bg',
-  ru: 'RU_ru',
-  ua: 'UA_uk',
-  au: 'AU_en',
-  in_en: 'IN_en',
-  in_hi: 'IN_hi',
-  id_en: 'ID_en',
-  id_id: 'ID_id',
-  nz: 'NZ_en',
-  sa_ar: 'SA_ar',
-  sa_en: 'SA_en',
-  sg: 'SG_en',
-  cn: 'CN_zh',
-  tw: 'TW_zh',
-  hk_zh: 'HK_zh',
-  jp: 'JP_ja',
-  kr: 'KR_ko',
-  za: 'ZA_en',
-  ng: 'NG_en',
-  cr: 'CR_es',
-  ec: 'EC_es',
-  pr: 'US_es', // not a typo, should be US
-  gt: 'GT_es',
-  cis_en: 'TM_en',
-  cis_ru: 'TM_ru',
-  sea: 'SG_en',
-  th_en: 'TH_en',
-  th_th: 'TH_th',
-};
-
-/**
- * MAS WCS `locale` when it differs from `${language}_${country}` derived from {@link GeoMap}.
- * @type {Record<string, string>}
- */
-const EXTRA_MAS_LOCALES = { pr: 'es_PR' };
-
 /**
  * Used when 3in1 modals are configured with ms=e or cs=t extra parameter, but 3in1 is disabled.
  * Dexter modals should deeplink to plan=edu or plan=team tabs.
@@ -193,44 +88,6 @@ const TAB_DEEPLINK_MAPPING = {
   t: 'team',
 };
 
-const LANG_STORE_PREFIX = 'langstore/';
-
-function getDefaultLangstoreCountry(language) {
-  let country = LanguageMap[language];
-  if (!country && GeoMap[language]) {
-    country = language; // es, fr, pt, de
-  }
-  if (!country && language.includes('-')) {
-    [country] = language.split('-'); // variations like es-419, pt-PT
-  }
-
-  return country || 'US';
-}
-
-export function getMiloLocaleSettings(miloLocale) {
-  const localePrefix = miloLocale?.prefix || 'US_en';
-  const geo = localePrefix.replace('/', '') ?? '';
-  let [country = 'US', language = 'en'] = (GeoMap[geo] ?? geo).split('_', 2);
-
-  if (
-    geo.startsWith(LANG_STORE_PREFIX)
-    || window.location.pathname.startsWith(`/${LANG_STORE_PREFIX}`)
-  ) {
-    const localeLang = geo.replace(LANG_STORE_PREFIX, '').toLowerCase();
-    country = getDefaultLangstoreCountry(localeLang);
-    language = localeLang;
-  }
-
-  country = country.toUpperCase();
-  language = language.toLowerCase();
-
-  return {
-    language,
-    country,
-    locale: EXTRA_MAS_LOCALES[geo] ?? `${language}_${country}`,
-  };
-}
-
 export async function getGeoLocaleSettings(miloLocale) {
   const settings = getMiloLocaleSettings(miloLocale);
   let country = await getCountry();
@@ -239,13 +96,6 @@ export async function getGeoLocaleSettings(miloLocale) {
     settings.country = country;
   }
   return settings;
-}
-
-export function isMasGeoDetectionEnabled() {
-  const queryParam = new URLSearchParams(window.location.search).get('mas-geo-detection');
-  const metaValue = getMetadata('mas-geo-detection');
-  const geoDetection = queryParam ?? metaValue;
-  return !!(geoDetection && ['on', 'true'].includes(geoDetection.toLowerCase()));
 }
 
 export async function getLocaleSettings(miloLocale) {

--- a/libs/blocks/tabs/tabs.js
+++ b/libs/blocks/tabs/tabs.js
@@ -87,6 +87,12 @@ function getContentElement(parent, traversalDepth) {
   return element.lastElementChild;
 }
 
+const loadPanelImages = (panel) => {
+  panel?.querySelectorAll('img[loading="lazy"]').forEach((img) => {
+    img.setAttribute('loading', 'eager');
+  });
+};
+
 function changeTabs(e, config) {
   const target = e.currentTarget;
   const targetId = target.getAttribute('id');
@@ -130,6 +136,7 @@ function changeTabs(e, config) {
     .querySelectorAll(`.tabpanel[data-block-id="${blockId}"]`)
     .forEach((p) => p.setAttribute('hidden', true));
   targetContent?.removeAttribute('hidden');
+  loadPanelImages(targetContent);
   if (tabsBlock.classList.contains('stacked-mobile')) scrollStackedMobile(targetContent);
   window.dispatchEvent(tabChangeEvent);
   saveActiveTabInStorage(targetId, config);
@@ -289,12 +296,8 @@ function initPaddles(tabList, left, right, isRadio) {
 }
 
 const handleDeferredImages = (block) => {
-  /* c8 ignore next 6 */
   const loadLazyImages = () => {
-    const images = block.querySelectorAll('img[loading="lazy"]');
-    images.forEach((img) => {
-      img.removeAttribute('loading');
-    });
+    block.querySelectorAll('.tabpanel:not([hidden])').forEach(loadPanelImages);
   };
   document.addEventListener(MILO_EVENTS.DEFERRED, loadLazyImages, { once: true, capture: true });
 };

--- a/libs/features/icons/icons.js
+++ b/libs/features/icons/icons.js
@@ -1,7 +1,21 @@
 import { getConfig, getFederatedContentRoot } from '../../utils/utils.js';
 
 const iconCache = new Map();
-let miloIconsPromise;
+const iconRequests = new Map();
+
+function getIconRequest(path, request) {
+  const key = new URL(path, window.location.href).href;
+  if (!iconRequests.has(key)) {
+    const pending = Promise.resolve()
+      .then(request)
+      .catch((error) => {
+        iconRequests.delete(key);
+        throw error;
+      });
+    iconRequests.set(key, pending);
+  }
+  return iconRequests.get(key);
+}
 
 function decorateToolTip(icon, iconName) {
   const hasTooltip = icon.closest('em')?.textContent.includes('|') && [...icon.classList].some((cls) => cls.includes('tooltip'));
@@ -30,24 +44,26 @@ function decorateToolTip(icon, iconName) {
 
 async function getSVGsfromFile(path) {
   if (!path) return null;
-  const resp = await fetch(path);
-  if (!resp.ok) return null;
+  return getIconRequest(path, async () => {
+    const resp = await fetch(path);
+    if (!resp.ok) return null;
 
-  const miloIcons = {};
-  const text = await resp.text();
-  const parser = new DOMParser();
-  const parsedText = parser.parseFromString(text, 'image/svg+xml');
-  const symbols = parsedText.querySelectorAll('symbol');
+    const miloIcons = {};
+    const text = await resp.text();
+    const parser = new DOMParser();
+    const parsedText = parser.parseFromString(text, 'image/svg+xml');
+    const symbols = parsedText.querySelectorAll('symbol');
 
-  symbols.forEach((symbol) => {
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    while (symbol.firstChild) svg.appendChild(symbol.firstChild);
-    [...symbol.attributes].forEach((attr) => svg.attributes.setNamedItem(attr.cloneNode()));
-    svg.classList.add('icon-milo', `icon-milo-${svg.id}`);
-    miloIcons[svg.id] = svg;
+    symbols.forEach((symbol) => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      while (symbol.firstChild) svg.appendChild(symbol.firstChild);
+      [...symbol.attributes].forEach((attr) => svg.attributes.setNamedItem(attr.cloneNode()));
+      svg.classList.add('icon-milo', `icon-milo-${svg.id}`);
+      miloIcons[svg.id] = svg;
+    });
+
+    return miloIcons;
   });
-
-  return miloIcons;
 }
 
 async function fetchAndParseSVG(url, iconName) {
@@ -69,7 +85,7 @@ async function fetchFederalIcon(iconName) {
   const url = `${fedRoot}/federal/assets/icons/svgs/${iconName}.svg`;
 
   try {
-    const svgElement = await fetchAndParseSVG(url, iconName);
+    const svgElement = await getIconRequest(url, () => fetchAndParseSVG(url, iconName));
     iconCache.set(iconName, svgElement);
     return svgElement;
   } catch (error) {
@@ -79,15 +95,11 @@ async function fetchFederalIcon(iconName) {
 }
 
 async function fetchMiloIcon(iconName) {
-  if (!miloIconsPromise) {
-    const { miloLibs, codeRoot } = getConfig();
-    const base = miloLibs || codeRoot;
-    miloIconsPromise = getSVGsfromFile(`${base}/img/icons/icons.svg`);
-  }
-
-  const miloIcons = await miloIconsPromise;
+  const { miloLibs, codeRoot } = getConfig();
+  const base = miloLibs || codeRoot;
+  const miloIcons = await getSVGsfromFile(`${base}/img/icons/icons.svg`);
   if (miloIcons?.[iconName]) {
-    const icon = miloIcons[iconName].cloneNode(true);
+    const icon = miloIcons[iconName];
     iconCache.set(iconName, icon);
     return icon;
   }
@@ -97,10 +109,11 @@ async function fetchMiloIcon(iconName) {
 }
 
 async function getIcon(iconName) {
-  if (iconCache.has(iconName)) return iconCache.get(iconName);
+  if (iconCache.has(iconName)) return iconCache.get(iconName).cloneNode(true);
   const federalIcon = await fetchFederalIcon(iconName);
-  if (federalIcon) return federalIcon;
-  return fetchMiloIcon(iconName);
+  if (federalIcon) return federalIcon.cloneNode(true);
+  const miloIcon = await fetchMiloIcon(iconName);
+  return miloIcon?.cloneNode(true);
 }
 
 export default async function loadIcons(icons) {
@@ -113,8 +126,7 @@ export default async function loadIcons(icons) {
 
     const svgElement = await getIcon(iconName);
     if (svgElement && !icon.dataset.svgInjected) {
-      const svgClone = svgElement.cloneNode(true);
-      icon.appendChild(svgClone);
+      icon.appendChild(svgElement);
       icon.dataset.svgInjected = 'true';
 
       const parent = icon.parentElement;
@@ -137,7 +149,11 @@ export default async function loadIcons(icons) {
 export const fetchIcons = (config) => {
   const { miloLibs, codeRoot } = config;
   const base = miloLibs || codeRoot;
-  return getSVGsfromFile(`${base}/img/icons/icons.svg`);
+  return getSVGsfromFile(`${base}/img/icons/icons.svg`).then((icons) => (
+    icons && Object.fromEntries(
+      Object.entries(icons).map(([name, svg]) => [name, svg.cloneNode(true)]),
+    )
+  ));
 };
 
 export function fetchIconList(url) {

--- a/libs/features/personalization/constants.js
+++ b/libs/features/personalization/constants.js
@@ -1,0 +1,37 @@
+import { isSignedOut } from '../../utils/utils.js';
+
+/* c8 ignore start */
+const getUA = () => navigator.userAgent;
+const PHONE_SIZE = window.screen.width < 550 || window.screen.height < 550;
+const safariIpad = getUA().includes('Macintosh') && navigator.maxTouchPoints > 1;
+const isGalaxyTab = getUA().includes('Linux') && navigator.maxTouchPoints > 1;
+const isChromeIOS = getUA().includes('CriOS');
+const isEdgeIOS = getUA().includes('EdgiOS');
+const isFirefoxIOS = getUA().includes('FxiOS');
+
+export const PERSONALIZATION_TAGS = {
+  all: () => true,
+  chrome: () => (getUA().includes('Chrome') && !getUA().includes('Edg')) || isChromeIOS,
+  firefox: () => getUA().includes('Firefox') || isFirefoxIOS,
+  safari: () => getUA().includes('Safari') && !getUA().includes('Chrome') && !isChromeIOS && !isEdgeIOS && !isFirefoxIOS,
+  edge: () => getUA().includes('Edg'),
+  android: () => getUA().includes('Android') || isGalaxyTab,
+  ios: () => /iPad|iPhone|iPod/.test(getUA()) || safariIpad,
+  windows: () => getUA().includes('Windows'),
+  mac: () => getUA().includes('Macintosh') && !safariIpad,
+  'mobile-device': () => safariIpad
+    || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Touch/i
+      .test(getUA()) || isGalaxyTab,
+  phone: () => PERSONALIZATION_TAGS['mobile-device']() && PHONE_SIZE,
+  tablet: () => PERSONALIZATION_TAGS['mobile-device']() && !PHONE_SIZE,
+  desktop: () => !PERSONALIZATION_TAGS['mobile-device'](),
+  loggedout: () => isSignedOut(),
+  loggedin: () => !isSignedOut(),
+};
+/* c8 ignore stop */
+
+export const FLAGS = {
+  all: 'all',
+  includeFragments: 'include-fragments',
+  includeGnav: 'include-gnav',
+};

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -10,43 +10,16 @@ import {
   loadScript,
   localizeLinkAsync,
   getFederatedUrl,
-  isSignedOut,
   resolveDetectedMarketCountry,
 } from '../../utils/utils.js';
 import { getMepConsentConfig, sendAnalytics } from '../../martech/helpers.js';
 import { sanitizeHtmlBody } from '../../utils/sanitizeHtml.js';
+import { FLAGS, PERSONALIZATION_TAGS } from './constants.js';
 
-/* c8 ignore start */
-const getUA = () => navigator.userAgent;
-const PHONE_SIZE = window.screen.width < 550 || window.screen.height < 550;
-const safariIpad = getUA().includes('Macintosh') && navigator.maxTouchPoints > 1;
-const isGalaxyTab = getUA().includes('Linux') && navigator.maxTouchPoints > 1;
-const isChromeIOS = getUA().includes('CriOS');
-const isEdgeIOS = getUA().includes('EdgiOS');
-const isFirefoxIOS = getUA().includes('FxiOS');
+export { FLAGS, PERSONALIZATION_TAGS };
 
 export const US_GEO = 'en-us';
-export const PERSONALIZATION_TAGS = {
-  all: () => true,
-  chrome: () => (getUA().includes('Chrome') && !getUA().includes('Edg')) || isChromeIOS,
-  firefox: () => getUA().includes('Firefox') || isFirefoxIOS,
-  safari: () => getUA().includes('Safari') && !getUA().includes('Chrome') && !isChromeIOS && !isEdgeIOS && !isFirefoxIOS,
-  edge: () => getUA().includes('Edg'),
-  android: () => getUA().includes('Android') || isGalaxyTab,
-  ios: () => /iPad|iPhone|iPod/.test(getUA()) || safariIpad,
-  windows: () => getUA().includes('Windows'),
-  mac: () => getUA().includes('Macintosh') && !safariIpad,
-  'mobile-device': () => safariIpad
-    || /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Touch/i
-      .test(getUA()) || isGalaxyTab,
-  phone: () => PERSONALIZATION_TAGS['mobile-device']() && PHONE_SIZE,
-  tablet: () => PERSONALIZATION_TAGS['mobile-device']() && !PHONE_SIZE,
-  desktop: () => !PERSONALIZATION_TAGS['mobile-device'](),
-  loggedout: () => isSignedOut(),
-  loggedin: () => !isSignedOut(),
-};
 const PERSONALIZATION_KEYS = Object.keys(PERSONALIZATION_TAGS);
-/* c8 ignore stop */
 
 const CLASS_EL_DELETE = 'p13n-deleted';
 const CLASS_EL_REPLACE = 'p13n-replaced';
@@ -55,11 +28,6 @@ const TARGET_EXP_PREFIX = 'target-';
 const INLINE_HASH = '_inline';
 const MARTECH_RETURNED_EVENT = 'martechReturned';
 const PAGE_URL = new URL(window.location.href);
-export const FLAGS = {
-  all: 'all',
-  includeFragments: 'include-fragments',
-  includeGnav: 'include-gnav',
-};
 let isPostLCP = false;
 const SELECTOR_TYPES = {
   fragment: 'fragment',

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -8,6 +8,7 @@ import {
 } from '../utils/utils.js';
 
 const fetchedPlaceholders = {};
+const geoPlaceholderRequests = new Map();
 window.mph = {};
 
 const getPlaceholdersPath = (config, sheet) => {
@@ -91,20 +92,29 @@ async function getGeoPlaceholders(config, sheet) {
   const geoContentRoot = `${geoOrigin}${geoPrefix}${pathSuffix}`;
   const geoConfig = { locale: { contentRoot: geoContentRoot }, env: siteConfig.env || {} };
   const paths = getPlaceholderPaths(geoConfig);
+  const normalizedPaths = paths.map((path) => new URL(path, window.location.href).href);
+  const key = `${normalizedPaths.join('|')}|${sheet || 'default'}`;
 
-  const placeholderRequest = Promise.all(
-    paths.map((path) => customFetch({ resource: path, withCacheRules: true }).catch(() => ({}))),
-  );
-
-  return fetchPlaceholders({
-    config: geoConfig,
-    sheet,
-    placeholderRequest,
-    placeholderPath: paths[0],
-  }).catch((e) => {
-    window.lana?.log(`Error fetching geo placeholders: ${e?.message}`, { tags: 'placeholders', severity: 'warn' });
-    return {};
-  });
+  if (!geoPlaceholderRequests.has(key)) {
+    const pending = Promise.resolve()
+      .then(() => Promise.all(
+        paths.map((path) => customFetch(
+          { resource: path, withCacheRules: true },
+        ).catch(() => ({}))),
+      ))
+      .then((placeholderRequest) => fetchPlaceholders({
+        config: geoConfig,
+        sheet,
+        placeholderRequest,
+        placeholderPath: paths[0],
+      }))
+      .catch((e) => {
+        window.lana?.log(`Error fetching geo placeholders: ${e?.message}`, { tags: 'placeholders', severity: 'warn' });
+        return {};
+      });
+    geoPlaceholderRequests.set(key, pending);
+  }
+  return geoPlaceholderRequests.get(key);
 }
 
 async function getPlaceholder(key, config, sheet) {

--- a/libs/martech/martech.js
+++ b/libs/martech/martech.js
@@ -7,7 +7,7 @@ const ALLOY_SEND_EVENT = 'alloy_sendEvent';
 const ALLOY_SEND_EVENT_ERROR = 'alloy_sendEvent_error';
 const ENTITLEMENT_TIMEOUT = 3000;
 
-const TARGET_TIMEOUT_MS = 4000;
+const TARGET_TIMEOUT_MS = 2500;
 const params = new URL(window.location.href).searchParams;
 const timeout = parseInt(params.get('target-timeout'), 10)
   || parseInt(getMetadata('target-timeout'), 10)

--- a/libs/scripts/scripts.js
+++ b/libs/scripts/scripts.js
@@ -71,14 +71,32 @@ const eagerLoad = (img) => {
   img?.setAttribute('fetchpriority', 'high');
 };
 
-(async function loadLCPImage() {
-  const firstDiv = document.querySelector('body > main > div:nth-child(1) > div');
-  if (firstDiv?.classList.contains('marquee')) {
-    firstDiv.querySelectorAll('img').forEach(eagerLoad);
-  } else {
-    eagerLoad(document.querySelector('img'));
+/* Keep in sync with the inline early-hint script in head.html. */
+export default function loadLCPImage(doc = document) {
+  const firstDiv = doc.querySelector('body > main > div:nth-child(1) > div');
+  const isMarquee = firstDiv?.classList.contains('marquee') || firstDiv?.classList.contains('hero-marquee');
+  if (!isMarquee) {
+    eagerLoad(doc.querySelector('img'));
+    return;
   }
-}());
+  const rows = firstDiv.querySelectorAll(':scope > div');
+  const bgRow = rows.length > 1 ? rows[0] : null;
+  if (bgRow) {
+    // Background cells are authored [all], [mobile, tablet+desktop] or [mobile, tablet, desktop].
+    const cells = [...bgRow.children];
+    let idx = 0;
+    if (cells.length === 2 && window.matchMedia('(min-width: 600px)').matches) idx = 1;
+    if (cells.length >= 3) {
+      if (window.matchMedia('(min-width: 1200px)').matches) idx = 2;
+      else if (window.matchMedia('(min-width: 600px)').matches) idx = 1;
+    }
+    eagerLoad(cells[idx]?.querySelector('img'));
+  }
+  const contentImgs = bgRow ? ':scope > div:not(:first-child) img' : 'img';
+  firstDiv.querySelectorAll(contentImgs).forEach(eagerLoad);
+}
+
+loadLCPImage();
 
 function loadStyles() {
   const paths = [];

--- a/libs/scripts/taxonomy.js
+++ b/libs/scripts/taxonomy.js
@@ -32,6 +32,7 @@ const CATEGORIES = Object.freeze('categories');
 const PRODUCTS = Object.freeze('products');
 const INDUSTRIES = Object.freeze('industries');
 const INTERNALS = Object.freeze('internals');
+const taxonomyRequests = new Map();
 
 /**
  * Filters a string to become a filename of a url
@@ -64,7 +65,14 @@ const findItem = (topic, category, taxonomy) => [topic].map((t) => {
 })[0];
 
 async function fetchTaxonomy(target) {
-  return fetch(target).then((response) => response.json());
+  const key = new URL(target, window.location.href).href;
+  if (!taxonomyRequests.has(key)) {
+    const pending = Promise.resolve()
+      .then(() => fetch(target))
+      .then((response) => response.json());
+    taxonomyRequests.set(key, pending);
+  }
+  return taxonomyRequests.get(key);
 }
 
 function parseTaxonomyJson(data, root, route) {

--- a/libs/utils/service-config.js
+++ b/libs/utils/service-config.js
@@ -6,7 +6,7 @@ import { getConfig, SLD } from './utils.js';
 
 const DOT_MILO = '/.milo/config.json';
 
-let config;
+const configRequests = new Map();
 
 /* c8 ignore next 6 */
 function getSiteOrigin() {
@@ -23,37 +23,44 @@ function getSiteOrigin() {
  * @returns the config
  */
 export default async function getServiceConfig(suppliedOrigin, envName) {
-  if (config) return config;
   const origin = suppliedOrigin || getSiteOrigin();
   const utilsConfig = getConfig();
   const queryEnv = new URLSearchParams(window.location.search).get('env');
   const env = queryEnv || envName || utilsConfig.env.name;
-  const resp = await fetch(`${origin}${DOT_MILO}`);
-  if (!resp.ok) return { error: 'Could not fetch .milo/config.' };
-  const json = await resp.json();
-  const configs = {};
-  json.configs.data.forEach((conf) => {
-    const [confEnv, confService, confType] = conf.key.split('.');
-    configs[confEnv] ??= {};
-    configs[confEnv][confService] ??= {};
-    configs[confEnv][confService][confType] = conf.value;
-  });
-  config = configs.prod;
-  if (env === 'prod') return config;
+  const normalizedOrigin = new URL(origin, window.location.href).href.replace(/\/$/, '');
+  const key = `${normalizedOrigin}|${env}`;
+  if (!configRequests.has(key)) {
+    const pending = Promise.resolve().then(async () => {
+      const resp = await fetch(`${normalizedOrigin}${DOT_MILO}`);
+      if (!resp.ok) return { error: 'Could not fetch .milo/config.' };
+      const json = await resp.json();
+      const configs = {};
+      json.configs.data.forEach((conf) => {
+        const [confEnv, confService, confType] = conf.key.split('.');
+        configs[confEnv] ??= {};
+        configs[confEnv][confService] ??= {};
+        configs[confEnv][confService][confType] = conf.value;
+      });
+      const config = { ...configs.prod };
+      if (env === 'prod') return config;
 
-  // Stage inheritance
-  Object.keys(config).forEach((key) => {
-    if (configs.stage && configs.stage[key]) {
-      config[key] = { ...config[key], ...configs.stage[key] };
-    }
-  });
-  if (env === 'stage') return config;
+      // Stage inheritance
+      Object.keys(config).forEach((service) => {
+        if (configs.stage && configs.stage[service]) {
+          config[service] = { ...config[service], ...configs.stage[service] };
+        }
+      });
+      if (env === 'stage') return config;
 
-  // Local inheritance
-  Object.keys(config).forEach((key) => {
-    if (configs.local && configs.local[key]) {
-      config[key] = { ...config[key], ...configs.local[key] };
-    }
-  });
-  return config;
+      // Local inheritance
+      Object.keys(config).forEach((service) => {
+        if (configs.local && configs.local[service]) {
+          config[service] = { ...config[service], ...configs.local[service] };
+        }
+      });
+      return config;
+    });
+    configRequests.set(key, pending);
+  }
+  return configRequests.get(key);
 }

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+import loadFonts from './fonts.js';
+
 const BOT_REGEX = /GoogleBot|Google-InspectionTool|BingBot|PerplexityBot|Perplexity-User|ClaudeBot|Claude-User|Claude-SearchBot|Tokowaka-AI|ChatGPT-User|GPTBot|OAI-SearchBot|AdobeEdgeOptimize-AI/i;
 export const isBot = () => BOT_REGEX.test(navigator.userAgent);
 
@@ -206,7 +208,7 @@ export const MILO_EVENTS = {
   QUERY_INDEX_PRIMARY_LOADED: 'milo:query-index:primary-loaded',
   QUERY_INDEX_ALL_LOADED: 'milo:query-index:all-loaded',
 };
-const TARGET_TIMEOUT_MS = 4000;
+const TARGET_TIMEOUT_MS = 2500;
 
 const LANGSTORE = 'langstore';
 const PREVIEW = 'target-preview';
@@ -2022,10 +2024,19 @@ export const getMepEnablement = (mdKey, paramKey = false) => {
 let imsLoaded;
 export async function loadIms() {
   imsLoaded = imsLoaded || (async () => {
-    const lingoRegion = lingoActive() ? await getLingoRegion({ useGeoLocation: true }) : null;
+    const { base } = getConfig();
+    const path = PAGE_URL.searchParams.get('useAlternateImsDomain')
+      ? 'https://auth.services.adobe.com/imslib/imslib.min.js'
+      : `${base}/deps/imslib.min.js`;
+    let lingoRegion = null;
+    if (lingoActive()) {
+      // Warm the imslib fetch while the region lookup (potentially a geo call) resolves.
+      loadLink(path, { rel: 'preload', as: 'script' });
+      lingoRegion = await getLingoRegion({ useGeoLocation: true });
+    }
     return new Promise((resolve, reject) => {
       const {
-        locale, imsClientId, imsScope, env, base, adobeid, imsTimeout,
+        locale, imsClientId, imsScope, env, adobeid, imsTimeout,
       } = getConfig();
       if (!imsClientId) {
         reject(new Error('Missing IMS Client ID'));
@@ -2060,9 +2071,6 @@ export async function loadIms() {
         }),
         ...adobeid,
       };
-      const path = PAGE_URL.searchParams.get('useAlternateImsDomain')
-        ? 'https://auth.services.adobe.com/imslib/imslib.min.js'
-        : `${base}/deps/imslib.min.js`;
       loadScript(path);
     });
   })().then(() => {
@@ -2265,6 +2273,7 @@ function initModalEventListener() {
 
 async function loadPostLCP(config) {
   import('./favicon.js').then(({ default: loadFavIcon }) => loadFavIcon(createTag, getConfig(), getMetadata));
+  loadFonts(config.locale, loadStyle);
 
   await decoratePlaceholders(document.body.querySelector('header'), config);
   const sk = document.querySelector('aem-sidekick, helix-sidekick');
@@ -2281,6 +2290,7 @@ async function loadPostLCP(config) {
   config.georouting = { loadedPromise: Promise.resolve(), enabled: config.geoRouting };
 
   if (languageBanner === 'on') {
+    await langBannerPromise;
     const routingConfig = getLangRoutingConfig();
     if (routingConfig?.showBanner && routingConfig.markets?.length) {
       const { default: init } = await import('../features/language-banner/language-banner.js');
@@ -2306,45 +2316,46 @@ async function loadPostLCP(config) {
     header.classList.remove('gnav-hide');
   }
   loadTemplate();
-  const { default: loadFonts } = await import('./fonts.js');
-  loadFonts(config.locale, loadStyle);
 
   if (config?.mep) {
     import('../features/personalization/personalization.js')
       .then(({ addMepAnalytics }) => addMepAnalytics(config, header));
   }
   if (getMetadata('foundation') === 'c2') {
-    await Promise.all([
+    Promise.all([
       new Promise((resolve) => { loadStyle(`${config.base}/deps/lenis.min.css`, resolve); }),
       loadScript(`${config.base}/deps/lenis.min.js`),
-    ]);
-    const lerp = 0.06;
-    const fsThreshold = 110;
-    const fsFactor = 0.11;
-    const fsDelay = 700;
-    const lenisPreventSelectors = [
-      '.dialog-modal',
-      '.ot-sdk-container',
-      'div[data-testid="main-content-area"]',
-    ];
-    window.lenis = new window.Lenis({
-      autoRaf: true,
-      lerp,
-      wheelMultiplier: 0.7,
-      prevent: (node) => node.matches?.(lenisPreventSelectors.join(', ')),
-    });
-    if (document.querySelector('.modal-curtain.is-open')) {
-      window.lenis.stop();
-    }
-    // Reduce inertia during fast scrolling to avoid sustained RAF CPU usage
-    let fsScrollTimer;
-    window.addEventListener('wheel', (e) => {
-      if (Math.abs(e.deltaY) > fsThreshold) {
-        window.lenis.options.lerp = fsFactor;
-        clearTimeout(fsScrollTimer);
-        fsScrollTimer = setTimeout(() => { window.lenis.options.lerp = lerp; }, fsDelay);
+    ]).then(() => {
+      const lerp = 0.06;
+      const fsThreshold = 110;
+      const fsFactor = 0.11;
+      const fsDelay = 700;
+      const lenisPreventSelectors = [
+        '.dialog-modal',
+        '.ot-sdk-container',
+        'div[data-testid="main-content-area"]',
+      ];
+      window.lenis = new window.Lenis({
+        autoRaf: true,
+        lerp,
+        wheelMultiplier: 0.7,
+        prevent: (node) => node.matches?.(lenisPreventSelectors.join(', ')),
+      });
+      if (document.querySelector('.modal-curtain.is-open')) {
+        window.lenis.stop();
       }
-    }, { passive: true });
+      // Reduce inertia during fast scrolling to avoid sustained RAF CPU usage
+      let fsScrollTimer;
+      window.addEventListener('wheel', (e) => {
+        if (Math.abs(e.deltaY) > fsThreshold) {
+          window.lenis.options.lerp = fsFactor;
+          clearTimeout(fsScrollTimer);
+          fsScrollTimer = setTimeout(() => { window.lenis.options.lerp = lerp; }, fsDelay);
+        }
+      }, { passive: true });
+    }).catch((e) => {
+      window.lana?.log(`Failed to load lenis: ${e.toString()}`, { tags: 'utils', severity: 'error' });
+    });
 
     if (!CSS.supports('animation-timeline: view()')
       && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
@@ -2485,7 +2496,11 @@ function getMarketsByRegionPriority(markets, geoIp) {
 }
 
 function reserveBannerSpace() {
+  if (document.body.querySelector(':scope > .language-banner')) return;
   document.body.prepend(createTag('div', { class: 'language-banner', 'daa-lh': 'language-banner' }));
+}
+
+function removeGnavPromoForBanner() {
   const existingWrapper = document.querySelector('.feds-promo-aside-wrapper');
   if (existingWrapper) {
     existingWrapper.remove();
@@ -2494,19 +2509,29 @@ function reserveBannerSpace() {
 }
 
 export async function pageExist(url) {
+  let cached;
+  try {
+    cached = sessionStorage.getItem(`pageExist:${url}`);
+  } catch (e) { /* sessionStorage unavailable */ }
+  if (cached === 'true' || cached === 'false') return cached === 'true';
+  let exists;
   const headResp = await fetch(url, { method: 'HEAD', cache: 'no-store' }).catch(() => null);
-  if (headResp?.status !== 401) return headResp?.ok ?? false;
-  if (!(url.includes('.aem.page') || url.includes('.aem.live'))) return false;
-  return (await fetch(url, { method: 'GET', cache: 'no-store' }).catch(() => null))?.ok ?? false;
+  if (headResp?.status !== 401) {
+    exists = headResp?.ok ?? false;
+  } else if (!(url.includes('.aem.page') || url.includes('.aem.live'))) {
+    exists = false;
+  } else {
+    exists = (await fetch(url, { method: 'GET', cache: 'no-store' }).catch(() => null))?.ok ?? false;
+  }
+  try {
+    sessionStorage.setItem(`pageExist:${url}`, String(exists));
+  } catch (e) { /* sessionStorage unavailable */ }
+  return exists;
 }
 
-export async function decorateLanguageBanner() {
-  const { locale, locales, languageBanner } = getConfig();
-  const languageBannerEnabled = PAGE_URL.searchParams.get('languageBanner') ?? (getMetadata('languagebanner') || languageBanner);
-  if (languageBannerEnabled !== 'on') return;
-  const internationalCookie = getCookie('international');
+async function resolveLanguageBanner(internationalCookie) {
+  const { locale, locales } = getConfig();
   let showBanner = false;
-  if (internationalCookie === (locale.prefix?.replace('/', '') || 'us')) return;
   const pageLang = locale.ietf.split('-')[0];
   const prefLang = internationalCookie
     ? (locales[internationalCookie === 'us' ? '' : internationalCookie]?.ietf?.split('-')[0] || internationalCookie.split('_').pop())
@@ -2612,14 +2637,31 @@ export async function decorateLanguageBanner() {
     }
     if (!targetMarket) return;
     setLangRoutingConfig({ showBanner: true, showModal: false, markets: [targetMarket] });
-    reserveBannerSpace();
+    removeGnavPromoForBanner();
   } else {
     // ACOM : supported market, show banner
     const results = await Promise.all(fetchPromises);
     const validatedMarkets = results.filter((r) => r.ok).map((r) => r.market);
     if (!validatedMarkets.length) return;
     setLangRoutingConfig({ showBanner: true, showModal: false, markets: validatedMarkets });
-    reserveBannerSpace();
+    removeGnavPromoForBanner();
+  }
+}
+
+export async function decorateLanguageBanner() {
+  const { locale, languageBanner } = getConfig();
+  const languageBannerEnabled = PAGE_URL.searchParams.get('languageBanner') ?? (getMetadata('languagebanner') || languageBanner);
+  if (languageBannerEnabled !== 'on') return;
+  const internationalCookie = getCookie('international');
+  if (internationalCookie === (locale.prefix?.replace('/', '') || 'us')) return;
+  // Reserve space before first paint; the LCP section reveal no longer waits on the decision.
+  reserveBannerSpace();
+  try {
+    await resolveLanguageBanner(internationalCookie);
+  } finally {
+    if (!getLangRoutingConfig()?.showBanner) {
+      document.body.querySelector(':scope > .language-banner')?.remove();
+    }
   }
 }
 
@@ -2635,7 +2677,7 @@ export function preloadMarketsConfig(callback) {
 }
 
 async function decorateDocumentExtras() {
-  await decorateMeta();
+  decorateMeta();
   await decorateHeader();
   langBannerPromise = decorateLanguageBanner();
 }
@@ -2655,12 +2697,12 @@ async function documentPostSectionLoading(config) {
       { locationUrl: window.location.href, getMetadata, createTag, getConfig },
     ));
   }
+  loadFooter();
   const richResults = getMetadata('richresults');
   if (richResults) {
     const { default: addRichResults } = await import('../features/richresults.js');
     addRichResults(richResults, { createTag, getMetadata });
   }
-  loadFooter();
   if (config.experiment?.selectedVariant?.scripts?.length) {
     config.experiment.selectedVariant.scripts.forEach((script) => loadScript(script));
   }
@@ -2739,6 +2781,44 @@ const preloadBlockResources = (blocks = []) => blocks.map((block) => {
   return hasStyles && new Promise((resolve) => { loadStyle(`${blockPath}.css`, resolve); });
 }).filter(Boolean);
 
+// Preload-only variant of preloadBlockResources: warms the HTTP cache without inserting
+// stylesheets, so loadBlock still gates section reveal on the actual CSS load.
+const hintBlockResources = (blocks = []) => blocks.forEach((block) => {
+  if (block.classList.contains('hide-block')) return;
+  const { blockPath, hasStyles, name, isInvalid } = getBlockData(block);
+  if (isInvalid || !name) return;
+  if (['marquee', 'hero-marquee'].includes(name)) {
+    const { base } = getConfig();
+    loadLink(`${base}/utils/decorate.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+    loadLink(`${base}/styles/iconography.css`, { rel: 'preload', as: 'style' });
+    loadLink(`${base}/styles/breakpoint-theme.css`, { rel: 'preload', as: 'style' });
+  }
+  loadLink(`${blockPath}.js`, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+  (blockDeps.get(name) ?? []).forEach((dep) => {
+    if (typeof dep === 'string') loadLink(dep, { rel: 'preload', as: 'script', crossorigin: 'anonymous' });
+  });
+  if (hasStyles) loadLink(`${blockPath}.css`, { rel: 'preload', as: 'style' });
+});
+
+// Speculative resource hints from the raw DOM, issued before MEP so the LCP section's
+// assets fetch during the personalization wait. Wrong guesses only cost a cached fetch.
+function preloadLCPResources() {
+  const sections = [...document.querySelectorAll('body > main > div')];
+  const lcpSection = sections.find((section) => section.querySelector(':scope > div[class]'));
+  if (lcpSection) hintBlockResources([...lcpSection.querySelectorAll(':scope > div[class]')]);
+  if (lingoActive()) return;
+  sections[0]?.querySelectorAll('a[href*="/fragments/"]').forEach((a) => {
+    const [rawHref, hash] = a.href.split('#');
+    if (hash && !hash.startsWith('_')) return; // modal-style fragment links load on demand
+    try {
+      const href = a.href.includes('#_dnt') ? rawHref : localizeLink(rawHref);
+      const url = new URL(href, window.location.origin);
+      if (url.origin !== window.location.origin) return;
+      loadLink(`${url.pathname}.plain.html`, { rel: 'preload', as: 'fetch', crossorigin: 'anonymous' });
+    } catch (e) { /* speculative only */ }
+  });
+}
+
 async function loadFragments(section, selector) {
   const anchors = [...section.querySelectorAll(selector)];
   if (!anchors.length) return false;
@@ -2785,8 +2865,6 @@ async function processSection(section, config, isDoc, lcpSectionId) {
 
   section.blocks.forEach((block) => loadBlocks.push(loadBlock(block)));
 
-  if (isLcpSection && langBannerPromise) await langBannerPromise;
-
   // Only move on to the next section when all blocks are loaded.
   await Promise.all(loadBlocks);
 
@@ -2810,12 +2888,32 @@ function loadLingoIndexes(area = document) {
   }).catch((e) => window.lana?.log(`Failed to get mep lingo prefix: ${e}`, { tags: 'lingo', severity: 'error' }));
 }
 
+function preconnectGeoService() {
+  try {
+    if (sessionStorage.getItem('akamai')) return;
+  } catch (e) { /* sessionStorage unavailable */ }
+  const config = getConfig();
+  const banner = PAGE_URL.searchParams.get('languageBanner') ?? (getMetadata('languagebanner') || config.languageBanner);
+  const georouting = getMetadata('georouting') || config.geoRouting;
+  if (banner === 'on' || georouting === 'on' || lingoActive() || getMepEnablement('mepgeolocation')) {
+    loadLink('https://geo2.adobe.com', { rel: 'preconnect', crossorigin: 'anonymous' });
+  }
+}
+
 export async function loadArea(area = document) {
   const isDoc = area === document;
+  if (isDoc && document.getElementById('page-load-ok-milo')) return;
+
+  let languageConfigPromise;
+  if (!langConfig && (getConfig().languages || hasLanguageLinks(area))) {
+    languageConfigPromise = loadLanguageConfig();
+  }
+
   if (isDoc) {
-    if (document.getElementById('page-load-ok-milo')) return;
     setCountry();
+    preconnectGeoService();
     preloadMarketsConfig();
+    preloadLCPResources();
     await checkForPageMods();
     appendHtmlToCanonicalUrl();
     appendSuffixToTitles();
@@ -2824,7 +2922,7 @@ export async function loadArea(area = document) {
   const isLingoActive = lingoActive();
 
   if (!langConfig && (config.languages || hasLanguageLinks(area))) {
-    await loadLanguageConfig();
+    await (languageConfigPromise || loadLanguageConfig());
   }
 
   const htmlSections = [...area.querySelectorAll(isDoc ? 'body > main > div' : ':scope > div')];
@@ -2842,14 +2940,24 @@ export async function loadArea(area = document) {
   }
 
   const areaBlocks = [];
-  let lcpSectionId = null;
-
+  const sections = [];
   for (const htmlSection of htmlSections) {
     const section = await decorateSection(htmlSection, htmlSections.indexOf(htmlSection));
+    sections.push(section);
+  }
+
+  let lcpSectionId = null;
+  sections.forEach((section) => {
     const isLastSection = section.idx === htmlSections.length - 1;
     if (lcpSectionId === null && (section.blocks.length !== 0 || isLastSection)) {
       lcpSectionId = section.idx;
     }
+    // Warm every section's block resources now; the serial loop below only gates reveal.
+    hintBlockResources(section.blocks);
+    hintBlockResources(section.preloadLinks);
+  });
+
+  for (const section of sections) {
     const sectionBlocks = await processSection(section, config, isDoc, lcpSectionId);
     areaBlocks.push(...sectionBlocks);
 

--- a/test/blocks/article-feed/article-feed.test.js
+++ b/test/blocks/article-feed/article-feed.test.js
@@ -1,5 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
+import { shouldLoadArticleImageEager } from '../../../libs/blocks/article-feed/article-feed.js';
 
 describe('article-feed accessibility', () => {
   beforeEach(async () => {
@@ -37,5 +38,11 @@ describe('article-feed accessibility', () => {
     filterButton.click();
     const expandedAfter = filterButton.getAttribute('aria-expanded');
     expect(expandedAfter).to.not.equal(expandedBefore);
+  });
+
+  it('prioritizes only the first card in the initial result set', () => {
+    expect(shouldLoadArticleImageEager(0, 0)).to.be.true;
+    expect(shouldLoadArticleImageEager(0, 1)).to.be.false;
+    expect(shouldLoadArticleImageEager(10, 10)).to.be.false;
   });
 });

--- a/test/blocks/article-feed/article-helpers.test.js
+++ b/test/blocks/article-feed/article-helpers.test.js
@@ -1,5 +1,9 @@
 import { expect } from '@esm-bundle/chai';
-import { getArticleTaxonomy } from '../../../libs/blocks/article-feed/article-helpers.js';
+import {
+  buildArticleCard,
+  createOptimizedPicture,
+  getArticleTaxonomy,
+} from '../../../libs/blocks/article-feed/article-helpers.js';
 
 describe('adobetv autoblock', () => {
   it('Creates article taxonomy from strings', async () => {
@@ -18,5 +22,59 @@ describe('adobetv autoblock', () => {
     };
     const taxonomy = getArticleTaxonomy(article);
     expect(taxonomy.topics[0]).to.equal('goodnight');
+  });
+
+  it('creates responsive card images with intrinsic dimensions and priority hints', () => {
+    const sizes = '(min-width: 1200px) 378px, 100vw';
+    const picture = createOptimizedPicture(
+      '/media/card.jpg',
+      'Card',
+      true,
+      [{ width: '320' }, { width: '480' }, { width: '750' }],
+      { sizes, width: '378', height: '250' },
+    );
+    const source = picture.querySelector('source');
+    const img = picture.querySelector('img');
+
+    expect(source.srcset).to.include('320w');
+    expect(source.srcset).to.include('480w');
+    expect(source.srcset).to.include('750w');
+    expect(source.sizes).to.equal(sizes);
+    expect(img.srcset).to.include('320w');
+    expect(img.sizes).to.equal(sizes);
+    expect(img.width).to.equal(378);
+    expect(img.height).to.equal(250);
+    expect(img.loading).to.equal('eager');
+    expect(img.decoding).to.equal('async');
+    expect(img.getAttribute('fetchpriority')).to.equal('high');
+  });
+
+  it('keeps media-based picture support lazy by default', () => {
+    const picture = createOptimizedPicture('/media/card.jpg', 'Card');
+    const img = picture.querySelector('img');
+
+    expect(picture.querySelectorAll('source').length).to.equal(3);
+    expect(img.loading).to.equal('lazy');
+    expect(img.getAttribute('fetchpriority')).to.be.null;
+  });
+
+  it('builds cards with the feed layout sizes and lazy defaults', () => {
+    const card = buildArticleCard({
+      title: 'Article',
+      description: 'Description',
+      image: '/media/card.jpg',
+      imageAlt: 'Card',
+      date: 45000,
+      path: '/article.html',
+      tags: 'News',
+    });
+    const img = card.querySelector('img');
+
+    expect(img.sizes).to.equal(
+      '(min-width: 1200px) 378px, (min-width: 600px) min(378px, calc((100vw - 96px) / 2)), clamp(268px, calc(100vw - 64px), 378px)',
+    );
+    expect(img.loading).to.equal('lazy');
+    expect(img.width).to.equal(378);
+    expect(img.height).to.equal(250);
   });
 });

--- a/test/blocks/caas-config/caas-config.test.html
+++ b/test/blocks/caas-config/caas-config.test.html
@@ -30,7 +30,14 @@
     import { runTests } from '@web/test-runner-mocha';
     import { expect } from '@esm-bundle/chai';
     import { stub } from 'sinon';
-    import { default as init, cloneObj, updateObj, getHashConfig, addIdOverlays } from '../../../libs/blocks/caas-config/caas-config.js';
+    import {
+      default as init,
+      cloneObj,
+      updateObj,
+      getHashConfig,
+      addIdOverlays,
+      saveStateToLocalStorage,
+    } from '../../../libs/blocks/caas-config/caas-config.js';
     import {
       findByLabel,
       tagSelectorDropdownChoose,
@@ -372,6 +379,29 @@
 
         // Clean up after the test
         document.body.removeChild(cardElement);
+      });
+
+      it('debounces localStorage writes and skips unchanged state', async () => {
+        await delay(300);
+        const setItemStub = stub(Storage.prototype, 'setItem').callThrough();
+
+        saveStateToLocalStorage({ test: 'first' });
+        saveStateToLocalStorage({ test: 'first' });
+        saveStateToLocalStorage({ test: 'second' });
+        await delay(300);
+
+        const stateWrites = setItemStub.getCalls().filter(
+          ({ args }) => args[0] === 'caasConfiguratorState',
+        );
+        expect(stateWrites.length).to.equal(1);
+        expect(JSON.parse(stateWrites[0].args[1])).to.eql({ test: 'second' });
+
+        saveStateToLocalStorage({ test: 'second' });
+        await delay(300);
+        expect(setItemStub.getCalls().filter(
+          ({ args }) => args[0] === 'caasConfiguratorState',
+        ).length).to.equal(1);
+        setItemStub.restore();
       });
 
     });

--- a/test/blocks/caas-marquee/caas-marquee.test.js
+++ b/test/blocks/caas-marquee/caas-marquee.test.js
@@ -1,0 +1,47 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  getBackgroundContent,
+  getResponsiveImageHtml,
+} from '../../../libs/blocks/caas-marquee/caas-marquee.js';
+
+describe('CaaS marquee responsive background', () => {
+  const sources = {
+    mobile: '/media/mobile.jpg',
+    tablet: '/media/tablet.jpg',
+    desktop: '/media/desktop.png',
+  };
+
+  it('uses viewport sources with one prioritized image', () => {
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = getResponsiveImageHtml(sources);
+
+    const picture = wrapper.querySelector('picture');
+    const img = picture.querySelector('img');
+    const pictureSources = picture.querySelectorAll('source');
+
+    expect(pictureSources.length).to.equal(5);
+    expect(picture.querySelectorAll('img').length).to.equal(1);
+    expect(pictureSources[0].media).to.equal('(min-width: 1200px)');
+    expect(pictureSources[0].srcset).to.include('/media/desktop.png');
+    expect(pictureSources[2].media).to.equal('(min-width: 600px)');
+    expect(pictureSources[2].srcset).to.include('/media/tablet.jpg');
+    expect(pictureSources[4].srcset).to.include('/media/mobile.jpg');
+    expect(img.loading).to.equal('eager');
+    expect(img.getAttribute('fetchpriority')).to.equal('high');
+    expect(img.decoding).to.equal('async');
+  });
+
+  it('selects the responsive picture path only when every source is an image', () => {
+    const imageContent = getBackgroundContent(sources);
+    expect(imageContent.match(/<picture/g).length).to.equal(1);
+    expect(imageContent.match(/<img/g).length).to.equal(1);
+
+    const videoContent = getBackgroundContent({
+      ...sources,
+      mobile: '/media/mobile.mp4',
+    });
+    expect(videoContent).to.include('<video');
+    expect(videoContent).to.include('tablet-only');
+    expect(videoContent).to.include('desktop-only');
+  });
+});

--- a/test/blocks/carousel/carousel.test.js
+++ b/test/blocks/carousel/carousel.test.js
@@ -626,3 +626,39 @@ describe('carousel disable-buttons deferred heights on desktop', () => {
     });
   });
 });
+
+describe('carousel image loading', () => {
+  let fixtureRoot;
+
+  beforeEach(() => {
+    const html = multiSectionCarouselFixture({
+      carouselClass: 'loading-test',
+      blockTitle: 'Loading test',
+      companions: [
+        { h2: 'First', body: `<img loading="lazy" src="${DATA_URL_GIF}" alt="">` },
+        { h2: 'Second', body: `<img loading="lazy" src="${DATA_URL_GIF}" alt="">` },
+        { h2: 'Third', body: `<img loading="lazy" src="${DATA_URL_GIF}" alt="">` },
+      ],
+    });
+    fixtureRoot = appendCarouselFixture(html);
+    init(fixtureRoot.querySelector('.carousel'));
+  });
+
+  afterEach(() => {
+    fixtureRoot.remove();
+  });
+
+  it('promotes only the active image on deferred load and navigation', () => {
+    const carousel = fixtureRoot.querySelector('.carousel');
+    const images = carousel.querySelectorAll('.carousel-slide img');
+
+    document.dispatchEvent(new Event('milo:deferred'));
+    expect(images[0].loading).to.equal('eager');
+    expect(images[1].loading).to.equal('lazy');
+    expect(images[2].loading).to.equal('lazy');
+
+    carousel.querySelector('.carousel-next').click();
+    expect(images[1].loading).to.equal('eager');
+    expect(images[2].loading).to.equal('lazy');
+  });
+});

--- a/test/blocks/fragment/fragment.test.js
+++ b/test/blocks/fragment/fragment.test.js
@@ -88,6 +88,25 @@ describe('Fragments', () => {
     expect(h1).to.exist;
   });
 
+  it('deduplicates concurrent plain HTML fragment requests', async () => {
+    const fetchStub = stub(window, 'fetch').callsFake((...args) => originalFetch(...args));
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `
+      <a href="/test/blocks/fragment/mocks/fragments/dedupe">First</a>
+      <a href="/test/blocks/fragment/mocks/fragments/dedupe">Second</a>
+    `;
+    document.body.append(wrapper);
+
+    await Promise.all([...wrapper.querySelectorAll('a')].map(getFragment));
+
+    const fragmentCalls = fetchStub.getCalls().filter(
+      ({ args }) => String(args[0]?.resource || args[0]).includes('/dedupe.plain.html'),
+    );
+    fetchStub.restore();
+    expect(fragmentCalls.length).to.equal(1);
+    expect(wrapper.querySelectorAll(':scope > .fragment').length).to.equal(2);
+  });
+
   it('Doesnt load a fragment', async () => {
     const a = document.querySelector('a.bad');
     await getFragment(a);

--- a/test/blocks/fragment/mocks/fragments/dedupe.plain.html
+++ b/test/blocks/fragment/mocks/fragments/dedupe.plain.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Deduplicated fragment</p>
+</div>

--- a/test/blocks/tabs/tabs.test.js
+++ b/test/blocks/tabs/tabs.test.js
@@ -24,6 +24,20 @@ describe('tabs', () => {
     });
   });
 
+  it('promotes images only in the active tab panel', () => {
+    const tabs = document.querySelector('#tabs-demo');
+    const panels = tabs.querySelectorAll('.tabpanel');
+    const firstImage = panels[0].querySelector('img');
+    const secondImage = panels[1].querySelector('img');
+
+    document.dispatchEvent(new Event('milo:deferred'));
+    expect(firstImage.loading).to.equal('eager');
+    expect(secondImage.loading).to.equal('lazy');
+
+    tabs.querySelector('[aria-controls="tab-panel-demo-2"]').click();
+    expect(secondImage.loading).to.equal('eager');
+  });
+
   it('clicks on a tabList button', async () => {
     const selectedButton = allTabs[0].querySelector('div[role="tablist"] button[aria-selected="true"]');
     const unselectedButton = allTabs[0].querySelectorAll('div[role="tablist"] button[aria-selected="false"]');

--- a/test/features/icons/icons.test.js
+++ b/test/features/icons/icons.test.js
@@ -3,7 +3,10 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { setConfig, getConfig, createTag } from '../../../libs/utils/utils.js';
 
-const { default: loadIcons } = await import('../../../libs/features/icons/icons.js');
+const {
+  default: loadIcons,
+  fetchIcons,
+} = await import('../../../libs/features/icons/icons.js');
 
 setConfig({ codeRoot: '/libs' });
 const config = getConfig();
@@ -103,6 +106,44 @@ describe('Icon Support', () => {
     await loadIcons(icons, config);
     const svgs = icons[0].querySelectorAll(':scope svg');
     expect(svgs.length).to.equal(1);
+  });
+
+  it('deduplicates in-flight icon requests and clones the resolved SVG', async () => {
+    const first = createTag('span', { class: 'icon icon-concurrent' });
+    const second = createTag('span', { class: 'icon icon-concurrent' });
+    document.body.append(first, second);
+
+    await Promise.all([loadIcons([first], config), loadIcons([second], config)]);
+
+    const firstSvg = first.querySelector('svg');
+    const secondSvg = second.querySelector('svg');
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(firstSvg).to.exist;
+    expect(secondSvg).to.exist;
+    expect(firstSvg).to.not.equal(secondSvg);
+    firstSvg.classList.add('consumer-only');
+    expect(secondSvg.classList.contains('consumer-only')).to.be.false;
+  });
+
+  it('deduplicates icon sprite requests and returns clones to each consumer', async () => {
+    fetchStub.resolves({
+      ok: true,
+      text: () => Promise.resolve(`
+        <svg xmlns="http://www.w3.org/2000/svg">
+          <symbol id="play"><path d="M0 0h1v1z"/></symbol>
+        </svg>
+      `),
+    });
+
+    const [first, second] = await Promise.all([
+      fetchIcons({ codeRoot: '/clone-test' }),
+      fetchIcons({ codeRoot: '/clone-test' }),
+    ]);
+
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(first.play).to.exist;
+    expect(second.play).to.exist;
+    expect(first.play).to.not.equal(second.play);
   });
 
   it('Creates default tooltip (right-aligned)', async () => {

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -140,6 +140,26 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     disableLingo();
   });
 
+  it('deduplicates concurrent geo placeholder fetches', async () => {
+    const originalFetch = window.fetch;
+    const fetchStub = stub(window, 'fetch').callsFake((...args) => originalFetch(...args));
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+
+    const [first, second] = await Promise.all([
+      replaceText('{{phone-number-geo-ip}}', cfg),
+      replaceText('{{buy-now-geo-ip}}', cfg),
+    ]);
+
+    const geoCalls = fetchStub.getCalls()
+      .map(({ args }) => String(args[0]?.resource || args[0]))
+      .filter((url) => url.includes(`${geoFixturePath}/placeholders.json`));
+    expect(first).to.equal('+352 800 99999');
+    expect(second).to.equal('Acheter maintenant');
+    expect(geoCalls.length).to.equal(1);
+    fetchStub.restore();
+  });
+
   it('replaceText resolves geo value for -geo-ip keys (default, non-deferred)', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';

--- a/test/features/region-modal/region-modal.test.js
+++ b/test/features/region-modal/region-modal.test.js
@@ -70,6 +70,9 @@ describe('Region modal feature', () => {
     document.cookie = 'country=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
     sessionStorage.removeItem('akamai');
     sessionStorage.removeItem('market');
+    Object.keys(sessionStorage)
+      .filter((key) => key.startsWith('pageExist:'))
+      .forEach((key) => sessionStorage.removeItem(key));
   });
 
   it('returns without rendering when suggestedMarkets is missing or empty', async () => {

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -1,4 +1,4 @@
-import { readFile } from '@web/test-runner-commands';
+import { readFile, setViewport } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 import { waitForElement } from '../helpers/waitfor.js';
 
@@ -33,5 +33,75 @@ describe('Decorating', async () => {
     );
     expect(el).to.exist;
     expect(window.alloy_all).to.exist;
+  });
+});
+
+describe('loadLCPImage', () => {
+  let loadLCPImage;
+
+  before(async () => {
+    ({ default: loadLCPImage } = await import('../../libs/scripts/scripts.js'));
+  });
+
+  const isEager = (img) => img.getAttribute('loading') === 'eager'
+    && img.getAttribute('fetchpriority') === 'high';
+
+  const setMarquee = (name, bgCells, contentImg = true) => {
+    const cells = bgCells.map((id) => `<div><picture><img data-bg="${id}"></picture></div>`).join('');
+    const bgRow = bgCells.length ? `<div>${cells}</div>` : '';
+    const content = `<div><div><h1>Heading</h1>${contentImg ? '<picture><img data-fg="fg"></picture>' : ''}</div></div>`;
+    document.body.innerHTML = `<main><div><div class="${name}">${bgRow}${content}</div></div></main>`;
+  };
+
+  it('eager loads only the desktop background variant on wide viewports', async () => {
+    await setViewport({ width: 1300, height: 800 });
+    setMarquee('marquee', ['mobile', 'tablet', 'desktop']);
+    loadLCPImage();
+    expect(isEager(document.querySelector('img[data-bg="desktop"]'))).to.be.true;
+    expect(isEager(document.querySelector('img[data-bg="mobile"]'))).to.be.false;
+    expect(isEager(document.querySelector('img[data-bg="tablet"]'))).to.be.false;
+    expect(isEager(document.querySelector('img[data-fg]'))).to.be.true;
+  });
+
+  it('eager loads the tablet background variant on medium viewports', async () => {
+    await setViewport({ width: 800, height: 800 });
+    setMarquee('marquee', ['mobile', 'tablet', 'desktop']);
+    loadLCPImage();
+    expect(isEager(document.querySelector('img[data-bg="tablet"]'))).to.be.true;
+    expect(isEager(document.querySelector('img[data-bg="mobile"]'))).to.be.false;
+    expect(isEager(document.querySelector('img[data-bg="desktop"]'))).to.be.false;
+  });
+
+  it('eager loads the mobile background variant on small viewports', async () => {
+    await setViewport({ width: 500, height: 800 });
+    setMarquee('marquee', ['mobile', 'tablet', 'desktop']);
+    loadLCPImage();
+    expect(isEager(document.querySelector('img[data-bg="mobile"]'))).to.be.true;
+    expect(isEager(document.querySelector('img[data-bg="tablet"]'))).to.be.false;
+    expect(isEager(document.querySelector('img[data-bg="desktop"]'))).to.be.false;
+  });
+
+  it('handles two-cell backgrounds and hero-marquee blocks', async () => {
+    await setViewport({ width: 800, height: 800 });
+    setMarquee('hero-marquee', ['mobile', 'wide']);
+    loadLCPImage();
+    expect(isEager(document.querySelector('img[data-bg="wide"]'))).to.be.true;
+    expect(isEager(document.querySelector('img[data-bg="mobile"]'))).to.be.false;
+  });
+
+  it('eager loads all images in a single-row marquee', async () => {
+    setMarquee('marquee', [], true);
+    loadLCPImage();
+    expect(isEager(document.querySelector('img[data-fg]'))).to.be.true;
+  });
+
+  it('falls back to the first document image for non-marquee pages', async () => {
+    document.body.innerHTML = '<main><div><div class="hero"><picture><img data-first></picture></div></div></main>';
+    loadLCPImage();
+    expect(isEager(document.querySelector('img[data-first]'))).to.be.true;
+  });
+
+  after(async () => {
+    await setViewport({ width: 1000, height: 800 });
   });
 });

--- a/test/scripts/taxonomy.test.js
+++ b/test/scripts/taxonomy.test.js
@@ -1,0 +1,25 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import loadTaxonomy from '../../libs/scripts/taxonomy.js';
+
+describe('Taxonomy requests', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('deduplicates concurrent requests for the normalized target URL', async () => {
+    const fetchStub = sinon.stub(window, 'fetch')
+      .resolves({ json: () => Promise.resolve({ data: [] }) });
+    const config = { locale: { contentRoot: '/content' } };
+    const target = './taxonomy-concurrent.json';
+
+    const [first, second] = await Promise.all([
+      loadTaxonomy(config, undefined, target),
+      loadTaxonomy(config, undefined, target),
+    ]);
+
+    expect(fetchStub.calledOnceWith(target)).to.be.true;
+    expect(first.CATEGORIES).to.equal('categories');
+    expect(second.PRODUCTS).to.equal('products');
+  });
+});

--- a/test/utils/service-config.test.js
+++ b/test/utils/service-config.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 import getServiceConfig from '../../libs/utils/service-config.js';
 
 const ORIGIN = 'http://localhost:2000/test/utils/mocks';
@@ -28,5 +29,47 @@ describe('Service Config', () => {
   it('Should fallbck to prod value', async () => {
     const { sharepoint } = await getServiceConfig(ORIGIN);
     expect(sharepoint.siteId).to.equal('milo-stage');
+  });
+
+  it('deduplicates by normalized origin and environment', async () => {
+    const fetchStub = sinon.stub(window, 'fetch').resolves({
+      ok: true,
+      json: () => Promise.resolve({
+        configs: {
+          data: [
+            { key: 'prod.service.url', value: 'prod' },
+            { key: 'stage.service.url', value: 'stage' },
+          ],
+        },
+      }),
+    });
+    const origin = 'https://config.example/';
+
+    const [first, second] = await Promise.all([
+      getServiceConfig(origin, 'prod'),
+      getServiceConfig('https://config.example', 'prod'),
+    ]);
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(first.service.url).to.equal('prod');
+    expect(second).to.equal(first);
+
+    const stage = await getServiceConfig(origin, 'stage');
+    expect(fetchStub.calledTwice).to.be.true;
+    expect(stage.service.url).to.equal('stage');
+    fetchStub.restore();
+  });
+
+  it('caches failed config responses for the same origin and environment', async () => {
+    const fetchStub = sinon.stub(window, 'fetch').resolves({ ok: false });
+    const origin = 'https://missing-config.example';
+    const [first, second] = await Promise.all([
+      getServiceConfig(origin, 'prod'),
+      getServiceConfig(origin, 'prod'),
+    ]);
+
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(first.error).to.equal('Could not fetch .milo/config.');
+    expect(second).to.equal(first);
+    fetchStub.restore();
   });
 });

--- a/test/utils/utils-loadpath.test.js
+++ b/test/utils/utils-loadpath.test.js
@@ -1,0 +1,313 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { waitFor, delay } from '../helpers/waitfor.js';
+import {
+  setConfig,
+  loadArea,
+  pageExist,
+  decorateLanguageBanner,
+  getLangRoutingConfig,
+  setLangRoutingConfig,
+  registerBlockDeps,
+} from '../../libs/utils/utils.js';
+
+const BASE_HEAD = '<link rel="icon" href="data:,"><meta name="martech" content="off">';
+
+const baseLocales = {
+  '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+  de: { ietf: 'de-DE', tk: 'hah7vzn.css' },
+  fr: { ietf: 'fr-FR', tk: 'hah7vzn.css' },
+};
+
+const baseConfig = () => ({
+  imsClientId: 'milo',
+  codeRoot: '/libs',
+  contentRoot: window.location.origin,
+  locales: baseLocales,
+  marketsSource: 'loadpath',
+  pathname: '/',
+});
+
+const mockMarkets = {
+  data: [
+    {
+      prefix: '', lang: 'en', languageName: 'English', text: 'This page is also available in', continueText: 'Continue', supportedRegions: 'us, gb',
+    },
+    {
+      prefix: 'de', lang: 'de', languageName: 'Deutsch', text: 'Diese Seite ist auch auf', continueText: 'Weiter', supportedRegions: 'de, at, ch, us', regionPriorities: 'ch:1',
+    },
+    {
+      prefix: 'fr', lang: 'fr', languageName: 'Français', text: 'Cette page est également disponible en', continueText: 'Continuer', supportedRegions: 'fr, ch', regionPriorities: 'ch:2',
+    },
+  ],
+};
+
+const stubNetwork = (sandbox, { headOk = true, geoCountry = 'DE' } = {}) => {
+  const fetchStub = sandbox.stub(window, 'fetch');
+  fetchStub.callsFake((resource, opts) => {
+    const href = typeof resource === 'string' ? resource : (resource?.url ?? '');
+    const method = opts?.method ?? 'GET';
+    if (href.includes('supported-markets')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(JSON.parse(JSON.stringify(mockMarkets))),
+      });
+    }
+    if (href.includes('lingo-site-mapping')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) });
+    }
+    if (href.includes('languages-config')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          'locale-to-language-map': { data: [] },
+          'site-languages': { data: [] },
+          'langmap-native-to-en': { data: [] },
+        }),
+      });
+    }
+    if (href.includes('geo2.adobe.com')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ country: geoCountry }),
+      });
+    }
+    if (method === 'HEAD') {
+      return Promise.resolve({ ok: headOk, status: headOk ? 200 : 404 });
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}), text: () => Promise.resolve('') });
+  });
+  return fetchStub;
+};
+
+describe('Load path optimizations', () => {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(() => {
+    document.head.innerHTML = BASE_HEAD;
+    document.body.innerHTML = '';
+    sessionStorage.clear();
+    setLangRoutingConfig(null);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    sessionStorage.clear();
+    setLangRoutingConfig(null);
+    document.cookie = 'international=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+    if (navigator.language) delete navigator.language;
+  });
+
+  describe('speculative LCP resource hints', () => {
+    it('preloads first-section block assets and fragment content before page mods', async () => {
+      registerBlockDeps('marquee', '/libs/utils/logWebVitals.js');
+      document.body.innerHTML = `<main>
+        <div>
+          <div class="marquee">
+            <div>
+              <div><picture><img alt="mobile"></picture></div>
+              <div><picture><img alt="tablet"></picture></div>
+              <div><picture><img alt="desktop"></picture></div>
+            </div>
+            <div><div><h1>Heading</h1></div></div>
+          </div>
+          <div class="hide-block"></div>
+          <p><a href="/fragments/loadpath-frag">Fragment</a></p>
+          <p><a href="/fragments/loadpath-modal#open-modal">Modal fragment</a></p>
+          <p><a href="https://www.external-example.com/fragments/ext">External fragment</a></p>
+          <p><a href="/fragments/loadpath-dnt#_dnt">DNT fragment</a></p>
+        </div>
+      </main>`;
+      setConfig(baseConfig());
+      await loadArea();
+      expect(document.head.querySelector('link[rel="preload"][as="script"][href*="/libs/blocks/marquee/marquee.js"]')).to.exist;
+      expect(document.head.querySelector('link[rel="preload"][as="style"][href*="/libs/blocks/marquee/marquee.css"]')).to.exist;
+      expect(document.head.querySelector('link[rel="preload"][href*="/libs/utils/decorate.js"]')).to.exist;
+      expect(document.head.querySelector('link[rel="preload"][href*="/libs/utils/logWebVitals.js"]')).to.exist;
+      expect(document.head.querySelector('link[rel="preload"][as="fetch"][href*="/fragments/loadpath-frag.plain.html"]')).to.exist;
+      expect(document.head.querySelector('link[href*="/fragments/loadpath-dnt.plain.html"]')).to.exist;
+      expect(document.head.querySelector('link[href*="loadpath-modal"]')).to.be.null;
+      expect(document.head.querySelector('link[href*="external-example.com"]')).to.be.null;
+      registerBlockDeps('marquee');
+    });
+
+    it('starts the language config fetch before page mods', async () => {
+      const fetchStub = stubNetwork(sandbox);
+      document.body.innerHTML = `<main>
+        <div><p><a href="https://news.adobe.com/loadpath">News link</a></p></div>
+      </main>`;
+      setConfig(baseConfig());
+      await loadArea();
+      expect(fetchStub.getCalls().some((call) => String(call.args[0]).includes('languages-config'))).to.be.true;
+    });
+
+    it('warms the imslib fetch while the lingo region resolves', async () => {
+      document.head.innerHTML = `${BASE_HEAD}<meta name="langfirst" content="on">`;
+      setConfig(baseConfig());
+      const { loadIms } = await import('../../libs/utils/utils.js');
+      loadIms().catch(() => {});
+      await delay(50);
+      expect(document.head.querySelector('link[rel="preload"][as="script"][href*="imslib.min.js"]')).to.exist;
+    });
+
+    it('skips fragment content preloads when lingo is active', async () => {
+      document.head.innerHTML = `${BASE_HEAD}<meta name="langfirst" content="on">`;
+      sessionStorage.setItem('akamai', 'us');
+      document.body.innerHTML = `<main>
+        <div><p><a href="/fragments/lingo-frag">Fragment</a></p></div>
+      </main>`;
+      setConfig(baseConfig());
+      await loadArea();
+      expect(document.head.querySelector('link[href*="lingo-frag.plain.html"]')).to.be.null;
+    });
+  });
+
+  describe('geo service preconnect', () => {
+    it('preconnects to geo2 when the language banner is on and no geo is cached', async () => {
+      stubNetwork(sandbox);
+      document.head.innerHTML = `${BASE_HEAD}<meta name="languagebanner" content="on">`;
+      setConfig(baseConfig());
+      await loadArea();
+      expect(document.head.querySelector('link[rel="preconnect"][href="https://geo2.adobe.com"]')).to.exist;
+      await delay(20);
+    });
+
+    it('skips the geo2 preconnect when the country is already cached', async () => {
+      stubNetwork(sandbox);
+      sessionStorage.setItem('akamai', 'us');
+      document.head.innerHTML = `${BASE_HEAD}<meta name="languagebanner" content="on">`;
+      setConfig(baseConfig());
+      await loadArea();
+      expect(document.head.querySelector('link[rel="preconnect"][href="https://geo2.adobe.com"]')).to.be.null;
+      await delay(20);
+    });
+  });
+
+  describe('pageExist session cache', () => {
+    it('caches positive results in sessionStorage', async () => {
+      const fetchStub = stubNetwork(sandbox);
+      const url = `${window.location.origin}/loadpath-exists`;
+      expect(await pageExist(url)).to.be.true;
+      expect(await pageExist(url)).to.be.true;
+      expect(fetchStub.callCount).to.equal(1);
+      expect(sessionStorage.getItem(`pageExist:${url}`)).to.equal('true');
+    });
+
+    it('caches negative results in sessionStorage', async () => {
+      const fetchStub = stubNetwork(sandbox, { headOk: false });
+      const url = `${window.location.origin}/loadpath-missing`;
+      expect(await pageExist(url)).to.be.false;
+      expect(await pageExist(url)).to.be.false;
+      expect(fetchStub.callCount).to.equal(1);
+      expect(sessionStorage.getItem(`pageExist:${url}`)).to.equal('false');
+    });
+
+    it('returns false on 401 responses for non-aem hosts', async () => {
+      sandbox.stub(window, 'fetch').resolves({ ok: false, status: 401 });
+      expect(await pageExist(`${window.location.origin}/loadpath-401`)).to.be.false;
+    });
+
+    it('falls back to GET for aem hosts on 401', async () => {
+      const fetchStub = sandbox.stub(window, 'fetch');
+      fetchStub.onFirstCall().resolves({ ok: false, status: 401 });
+      fetchStub.onSecondCall().resolves({ ok: true, status: 200 });
+      expect(await pageExist('https://main--milo--adobecom.aem.page/loadpath')).to.be.true;
+      expect(fetchStub.callCount).to.equal(2);
+    });
+  });
+
+  describe('language banner reveal decoupling', () => {
+    it('reserves then removes the banner space when no banner shows', async () => {
+      stubNetwork(sandbox);
+      sessionStorage.setItem('akamai', 'de');
+      Object.defineProperty(navigator, 'language', { value: 'de-DE', configurable: true });
+      document.head.innerHTML = `${BASE_HEAD}<meta name="languagebanner" content="on">`;
+      setConfig({ ...baseConfig(), pathname: '/de/page' });
+      await decorateLanguageBanner();
+      expect(document.body.querySelector(':scope > .language-banner')).to.be.null;
+      expect(getLangRoutingConfig()).to.be.null;
+    });
+
+    it('keeps the reserved space and clears the gnav promo when the banner shows', async () => {
+      stubNetwork(sandbox);
+      sessionStorage.setItem('akamai', 'ch');
+      Object.defineProperty(navigator, 'language', { value: 'en-US', configurable: true });
+      document.head.innerHTML = `${BASE_HEAD}
+        <meta name="languagebanner" content="on">
+        <meta name="onlybanner" content="on">
+      `;
+      document.body.innerHTML = `
+        <header class="global-navigation has-promo"></header>
+        <div class="feds-promo-aside-wrapper"></div>
+      `;
+      setConfig(baseConfig());
+      await decorateLanguageBanner();
+      expect(getLangRoutingConfig()?.showBanner).to.be.true;
+      expect(document.body.querySelector(':scope > .language-banner')).to.exist;
+      expect(document.querySelector('.feds-promo-aside-wrapper')).to.be.null;
+      expect(document.querySelector('header').classList.contains('has-promo')).to.be.false;
+    });
+
+    it('does not duplicate an already reserved banner space', async () => {
+      stubNetwork(sandbox);
+      sessionStorage.setItem('akamai', 'ch');
+      Object.defineProperty(navigator, 'language', { value: 'en-US', configurable: true });
+      document.head.innerHTML = `${BASE_HEAD}
+        <meta name="languagebanner" content="on">
+        <meta name="onlybanner" content="on">
+      `;
+      document.body.innerHTML = '<div class="language-banner"></div>';
+      setConfig(baseConfig());
+      await decorateLanguageBanner();
+      expect(document.body.querySelectorAll(':scope > .language-banner').length).to.equal(1);
+    });
+  });
+
+  describe('loadPostLCP ordering', () => {
+    it('starts fonts early and resolves the banner decision without gating reveal', async () => {
+      stubNetwork(sandbox);
+      sessionStorage.setItem('akamai', 'de');
+      Object.defineProperty(navigator, 'language', { value: 'de-DE', configurable: true });
+      document.head.innerHTML = `${BASE_HEAD}<meta name="languagebanner" content="on">`;
+      document.body.innerHTML = '<main><div><p>Content</p></div></main>';
+      setConfig({ ...baseConfig(), pathname: '/de/page' });
+      await loadArea();
+      expect(document.head.querySelector('link[href*="use.typekit.net"]')).to.exist;
+      expect(document.body.querySelector(':scope > .language-banner')).to.be.null;
+    });
+  });
+
+  describe('c2 lenis loading', () => {
+    afterEach(() => {
+      window.lenis?.destroy?.();
+      delete window.lenis;
+    });
+
+    it('initializes lenis without blocking section processing', async () => {
+      document.head.innerHTML = `${BASE_HEAD}<meta name="foundation" content="c2">`;
+      document.body.innerHTML = `<main>
+        <div>
+          <div class="columns"><div><div>Invalid on c2</div></div></div>
+          <p>Content</p>
+        </div>
+      </main><div class="modal-curtain is-open"></div>`;
+      setConfig(baseConfig());
+      await loadArea();
+      await waitFor(() => window.lenis, 3000, 50);
+      expect(window.lenis).to.exist;
+      window.dispatchEvent(new WheelEvent('wheel', { deltaY: 200 }));
+      expect(window.lenis.options.lerp).to.equal(0.11);
+      await delay(800);
+      expect(window.lenis.options.lerp).to.equal(0.06);
+    }).timeout(5000);
+
+    it('continues without lenis when its assets fail to load', async () => {
+      document.head.innerHTML = `${BASE_HEAD}<meta name="foundation" content="c2">`;
+      document.body.innerHTML = '<main><div><p>Content</p></div></main>';
+      setConfig({ ...baseConfig(), codeRoot: '/loadpath-missing' });
+      await loadArea();
+      await delay(200);
+      expect(window.lenis).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
Web-performance improvements across the critical load path, block payloads, and shared request loaders, so cumulative gains can be measured on one branch URL.

**Critical load path**
* Add head resource hints — `styles.css` preload, `utils.js`/`locales.js`/`fonts.js` modulepreload, `use.typekit.net` preconnect — plus an inline early LCP-image hint, so first paint and the hero image no longer wait on the full JS module graph
* Eager-load only the viewport-matching marquee background variant and include `hero-marquee` in the first-block check
* Warm LCP-section block resources speculatively before the MEP/Target wait; warm every section's block JS/CSS up front while keeping the serial reveal loop; preload first-section fragment `.plain.html`; kick `loadLanguageConfig` concurrently with MEP; lower Target timeout 4000ms → 2500ms
* Language banner no longer gates the LCP section reveal: banner space is reserved synchronously and the geo/markets/page-probe decision resolves after reveal; `pageExist` results are cached per session; preconnect to `geo2.adobe.com` when a geo feature is enabled
* `loadPostLCP` de-serialized: fonts start first (static import), lenis download no longer blocks later sections, footer no longer serialized behind rich-results, imslib warmed during the lingo geo lookup, `decorateMeta` fire-and-forget

**Block payloads and images**
* Global navigation no longer statically imports `merch.js`/`personalization.js` (~156KB raw JS) — shared helpers extracted to `merch/locale.js` and `personalization/constants.js` with original export surfaces preserved; `handleCommands` is dynamically imported only when MEP commands exist
* CaaS marquee renders a single responsive `<picture>` with one eager/high-priority image instead of three per-viewport pictures that boosted a hidden mobile image on desktop
* Carousel and tabs keep native lazy-loading and promote only the active slide/tab images
* Article-feed cards get 320/480/750 `srcset` + `sizes`, intrinsic dimensions, `decoding="async"`, eager/high priority only on the first card

**Request dedupe and caching**
* In-flight promise dedupe for icons, fragment HTML, taxonomy, service-config, and geo placeholders (consumers receive cloned SVG/Response objects)
* caas-config localStorage persistence debounced and skipped when unchanged

**Notes for reviewers**
* `languageBanner=on` pages now paint immediately with a reserved 44px banner bar that is removed if the decision is "no banner" (small one-time shift) instead of blocking LCP on a geo fetch with a 5s timeout — flagging this trade-off explicitly
* Lenis load failure on C2 pages now logs to lana instead of rejecting the whole `loadArea` chain

**Follow-ups (intentionally out of scope)**
* pzn-only manifest fetch concurrency
* Card-only `caas.css` artifact; modular ECharts bundle; replace the Spectrum spinner in the merch upgrade flow
* Minimal JSON fallback for CaaS tags; preflight lazy panels; production MSAL build; removal of unreferenced deps (`plans-modal.js`, `dist/themes`)
* Gnav placeholder resolution via reference-preserving node mutation (loading gnav concurrently with placeholders is unsafe today — breadcrumbs clone raw text)
* Consumer-site head.html guidance (same preload hints + `fonts.js` modulepreload)

Resolves: [MWPW-201867](https://jira.corp.adobe.com/browse/MWPW-201867)

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-201867--milo--adobecom.aem.page/?martech=off

Consumer pages can be tested against this branch with `?milolibs=mwpw-201867`.


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=MWPW-201867--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=MWPW-201867--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-201867--milo--adobecom
- Milo: https://MWPW-201867--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-201867--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-201867--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-201867--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201867--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201867--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201867--milo--adobecom
- Milo: https://MWPW-201867--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201867--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201867--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201867--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201867--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201867--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201867--milo--adobecom
- Milo: https://MWPW-201867--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201867--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201867--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201867--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-201867--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-201867--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-201867--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-201867--milo--adobecom
</details>