### PR TITLE
MWPW-201349: add unit tests for c2 explore-card block

### DIFF
--- a/test/blocks/explore-card/explore-card.test.js
+++ b/test/blocks/explore-card/explore-card.test.js
@@ -1,0 +1,86 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/explore-card/explore-card.js';
+
+describe('Explore Card', () => {
+  it('adds container, content and background classes to the first row', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.explore-card');
+    init(block);
+
+    const container = block.querySelector('.explore-card-container');
+    expect(container).to.exist;
+    expect(container.querySelector('.explore-card-content')).to.exist;
+    expect(container.querySelector('.explore-card-background')).to.exist;
+  });
+
+  it('rewrites a federated svg product icon source', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.explore-card');
+    init(block);
+
+    const icon = block.querySelector('.explore-card-content img');
+    expect(icon.getAttribute('src')).to.equal('https://main--federal--adobecom.aem.page/federal/icons/prod.svg');
+  });
+
+  it('decorates the heading at level 5', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.explore-card');
+    init(block);
+
+    const heading = block.querySelector('.explore-card-content h3');
+    expect(heading.classList.contains('heading-5')).to.be.true;
+  });
+
+  it('moves foreground-row content into the content div with a foreground class', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.explore-card');
+    init(block);
+
+    const content = block.querySelector('.explore-card-content');
+    const foreground = content.querySelector('.explore-card-foreground');
+    expect(foreground).to.exist;
+    expect(foreground.textContent.trim()).to.equal('New');
+    // the original foreground row is removed
+    expect(block.querySelectorAll(':scope > div').length).to.equal(1);
+  });
+
+  it('wraps the content in a tracking link when a link is present', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.explore-card');
+    init(block);
+
+    const container = block.querySelector('.explore-card-container');
+    const linkContainer = container.querySelector(':scope > a.explore-card-link-container');
+    expect(linkContainer).to.exist;
+    expect(linkContainer.getAttribute('href')).to.equal('https://www.adobe.com/explore');
+    expect(linkContainer.getAttribute('data-tracking-label')).to.equal('Card heading');
+    // the content div now lives inside the link container
+    expect(linkContainer.querySelector(':scope > .explore-card-content')).to.exist;
+    // the original inline link is removed
+    expect(block.querySelector('.explore-card-content p a')).to.be.null;
+  });
+
+  it('does not create a link container when there is no link, and removes an empty foreground row', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/no-link.html' });
+    const block = document.querySelector('.explore-card');
+    init(block);
+
+    expect(block.querySelector('.explore-card-link-container')).to.be.null;
+    // content stays a direct child of the container
+    const container = block.querySelector('.explore-card-container');
+    expect(container.querySelector(':scope > .explore-card-content')).to.exist;
+    // empty foreground row removed, no foreground content added
+    expect(block.querySelectorAll(':scope > div').length).to.equal(1);
+    expect(block.querySelector('.explore-card-foreground')).to.be.null;
+  });
+
+  it('does nothing when the block has no rows', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/empty.html' });
+    const block = document.querySelector('.explore-card');
+    init(block);
+
+    expect(block.querySelector('.explore-card-container')).to.be.null;
+  });
+});

--- a/test/blocks/explore-card/mocks/default.html
+++ b/test/blocks/explore-card/mocks/default.html
@@ -1,0 +1,20 @@
+<main>
+  <div class="section">
+    <div class="explore-card">
+      <div>
+        <div>
+          <p><img src="/federal/icons/prod.svg" alt="product icon" /></p>
+          <h3>Card heading</h3>
+          <p>Some body copy for the card.</p>
+          <p><a href="https://www.adobe.com/explore">Explore</a></p>
+        </div>
+        <div>
+          <picture><img src="" alt="background" /></picture>
+        </div>
+      </div>
+      <div>
+        <div>New</div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/explore-card/mocks/empty.html
+++ b/test/blocks/explore-card/mocks/empty.html
@@ -1,0 +1,5 @@
+<main>
+  <div class="section">
+    <div class="explore-card"></div>
+  </div>
+</main>

--- a/test/blocks/explore-card/mocks/no-link.html
+++ b/test/blocks/explore-card/mocks/no-link.html
@@ -1,0 +1,16 @@
+<main>
+  <div class="section">
+    <div class="explore-card">
+      <div>
+        <div>
+          <h3>No link card</h3>
+          <p>Body copy only.</p>
+        </div>
+        <div>
+          <picture><img src="" alt="background" /></picture>
+        </div>
+      </div>
+      <div></div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
## Summary
- Adds unit tests for the `explore-card` c2 block (`libs/c2/blocks/explore-card`), which previously had no coverage in `test/blocks`
- Covers: container/content/background decoration, federated svg icon `src` rewrite, heading level 5, foreground-row content merge (with `-foreground` class + row removal), tracking link wrapping (`explore-card-link-container` with href + `data-tracking-label`), and the no-link and empty-block paths
- Follows conventions from existing block tests (e.g. `test/blocks/base-card`, `test/blocks/rich-content`)

Resolves: https://jira.corp.adobe.com/browse/MWPW-201349

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/explore-card/explore-card.test.js" --node-resolve --port=2000` — 7/7 passing
- [x] `npx eslint test/blocks/explore-card/explore-card.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

