### PR TITLE
MWPW-201351: add unit tests for c2 modal-metadata block

### DIFF
--- a/test/blocks/modal-metadata/mocks/default.html
+++ b/test/blocks/modal-metadata/mocks/default.html
@@ -1,0 +1,18 @@
+<main>
+  <div class="dialog-modal" id="test-modal">
+    <div class="modal-metadata">
+      <div>
+        <div>style</div>
+        <div>center, grid width 2</div>
+      </div>
+      <div>
+        <div>curtain</div>
+        <div>off</div>
+      </div>
+      <div>
+        <div>background</div>
+        <div><picture><img src="" alt="background" /></picture></div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/modal-metadata/mocks/no-modal.html
+++ b/test/blocks/modal-metadata/mocks/no-modal.html
@@ -1,0 +1,14 @@
+<main>
+  <div class="section">
+    <div class="modal-metadata">
+      <div>
+        <div>style</div>
+        <div>center</div>
+      </div>
+      <div>
+        <div>curtain</div>
+        <div>off</div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/modal-metadata/mocks/tall-video.html
+++ b/test/blocks/modal-metadata/mocks/tall-video.html
@@ -1,0 +1,10 @@
+<main>
+  <div class="dialog-modal tall-video" id="tall-video-modal">
+    <div class="modal-metadata">
+      <div>
+        <div>background</div>
+        <div><picture><img src="" alt="background" /></picture></div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/modal-metadata/modal-metadata.test.js
+++ b/test/blocks/modal-metadata/modal-metadata.test.js
@@ -1,0 +1,63 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/modal-metadata/modal-metadata.js';
+
+describe('Modal Metadata (c2)', () => {
+  it('does nothing when the block is not inside a dialog-modal', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/no-modal.html' });
+    const block = document.querySelector('.modal-metadata');
+    await init(block);
+
+    const section = document.querySelector('.section');
+    expect(section.classList.contains('center')).to.be.false;
+    expect(section.classList.contains('curtain-off')).to.be.false;
+  });
+
+  it('applies style metadata as classes on the modal', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.modal-metadata');
+    await init(block);
+
+    const modal = document.querySelector('.dialog-modal');
+    expect(modal.classList.contains('center')).to.be.true;
+    expect(modal.classList.contains('grid-width-2')).to.be.true;
+  });
+
+  it('adds curtain-off when curtain metadata is off', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.modal-metadata');
+    await init(block);
+
+    expect(document.querySelector('.dialog-modal').classList.contains('curtain-off')).to.be.true;
+  });
+
+  it('does not apply a background when the modal is not tall-video', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.modal-metadata');
+    await init(block);
+
+    const modal = document.querySelector('.dialog-modal');
+    expect(modal.classList.contains('has-background')).to.be.false;
+    expect(modal.querySelector(':scope > picture.section-background')).to.be.null;
+  });
+
+  it('moves the background picture into a tall-video modal', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/tall-video.html' });
+    const block = document.querySelector('.modal-metadata');
+    await init(block);
+
+    const modal = document.querySelector('.dialog-modal');
+    expect(modal.classList.contains('has-background')).to.be.true;
+    const bgPicture = modal.querySelector(':scope > picture.section-background');
+    expect(bgPicture).to.exist;
+  });
+
+  it('does not add curtain-off when there is no curtain=off metadata', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/tall-video.html' });
+    const block = document.querySelector('.modal-metadata');
+    await init(block);
+
+    expect(document.querySelector('.dialog-modal').classList.contains('curtain-off')).to.be.false;
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for the `modal-metadata` c2 block (`libs/c2/blocks/modal-metadata`), which previously had no coverage in `test/blocks`
- The c2 block is a pass-through re-export of the shared `libs/blocks/modal-metadata` init, so these tests also cover that previously-untested shared logic
- Covers: the no-modal guard, `style` class application, `curtain: off` toggle, the `tall-video` background guard, and background picture handling for tall-video modals
- Follows conventions from existing block tests (e.g. `test/blocks/section-metadata`)

Resolves: https://jira.corp.adobe.com/browse/MWPW-201351

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/modal-metadata/modal-metadata.test.js" --node-resolve --port=2000` — 6/6 passing
- [x] `npx eslint test/blocks/modal-metadata/modal-metadata.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

