### PR TITLE
MWPW-201355: add unit tests for c2 visually-hidden block

### DIFF
--- a/test/blocks/visually-hidden/mocks/default.html
+++ b/test/blocks/visually-hidden/mocks/default.html
@@ -1,0 +1,7 @@
+<main>
+  <div class="section">
+    <div class="visually-hidden">
+      <div><p>Screen-reader only text</p></div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/visually-hidden/visually-hidden.test.js
+++ b/test/blocks/visually-hidden/visually-hidden.test.js
@@ -1,0 +1,25 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/visually-hidden/visually-hidden.js';
+
+// visually-hidden is a CSS-only block; its JS init is an intentional no-op.
+describe('Visually Hidden (c2)', () => {
+  it('exports a default init function', () => {
+    expect(init).to.be.a('function');
+  });
+
+  it('is a no-op that returns undefined and does not throw', () => {
+    expect(init()).to.equal(undefined);
+  });
+
+  it('leaves the block markup untouched', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.visually-hidden');
+    const before = block.outerHTML;
+
+    init(block);
+
+    expect(block.outerHTML).to.equal(before);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a smoke test for the `visually-hidden` c2 block (`libs/c2/blocks/visually-hidden`), which previously had no coverage in `test/blocks`
- This is a CSS-only block: its JS `init` is an intentional no-op (all styling lives in `visually-hidden.css`), so the test verifies `init` is a callable no-op that returns `undefined` and leaves the block markup untouched
- Provides line coverage for the block and a test folder consistent with the other c2 blocks

Resolves: https://jira.corp.adobe.com/browse/MWPW-201355

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/visually-hidden/visually-hidden.test.js" --node-resolve --port=2000` — 3/3 passing
- [x] `npx eslint test/blocks/visually-hidden/visually-hidden.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

