### PR TITLE
MWPW-202052: fix c2 news crash on standalone link in non-quiet variant

### DIFF
--- a/libs/c2/blocks/news/news.js
+++ b/libs/c2/blocks/news/news.js
@@ -44,7 +44,8 @@ export default async function init(el) {
       if (indx === 0) content.classList.add('news-item-headline');
       else if (isLinkOnlyContent(content, linkEl)) {
         content.classList.add('news-item-link');
-        linkEl.classList.add('standalone-link', 'label', `${el.classList.contains('quiet') ? 'quiet' : ''}`);
+        linkEl.classList.add('standalone-link', 'label');
+        if (el.classList.contains('quiet')) linkEl.classList.add('quiet');
       } else content.classList.add('news-item-body');
     });
   });


### PR DESCRIPTION
## Problem
`libs/c2/blocks/news/news.js:47` passed an empty-string token to `classList.add` for **non-quiet** blocks:

```js
linkEl.classList.add('standalone-link', 'label', `${el.classList.contains('quiet') ? 'quiet' : ''}`);
```

`DOMTokenList.add('')` throws `SyntaxError: The token provided must not be empty`. Since `quiet` is an opt-in modifier, a plain `news` block is **non-quiet by default**, so any default block containing a link-only (standalone) paragraph crashes mid-`init`, halting decoration for that block. The non-quiet standalone link is a designed, styled state (`libs/c2/styles/styles.css:613-643` styles base `a.standalone-link` independently of `quiet`).

## Fix
```js
linkEl.classList.add('standalone-link', 'label');
if (el.classList.contains('quiet')) linkEl.classList.add('quiet');
```

## How to test
- Non-quiet `news` block with a link-only item (`<p><a href="...">Read more</a></p>`): no error thrown, link gets `standalone-link label` (underlined + arrow), all following items decorate correctly.
- Regression — `news quiet` block with a link-only item: link gets `standalone-link label quiet` (no underline), unchanged from before.
- Rest of the block (headline/eyebrow, svg icon federated rewrite, `news-items` up-count, headline/body classification) unaffected.

## Notes
- Fix scoped to the canonical block. The same buggy line is duplicated in MEP experiment copies (`libs/mep/ace1201/news/news.js:47`, `libs/mep/ace1205/news/news.js:47`) — flagged in the ticket for a separate follow-up to avoid touching running experiments here.
- Unit tests for the block will be added in a follow-up PR (MWPW-201352) after this fix is deployed.

Resolves: https://jira.corp.adobe.com/browse/MWPW-202052

🤖 Generated with [Claude Code](https://claude.com/claude-code)

