### PR TITLE
[MWPW-202037] - Added IMS scope configuration support for standalone GNAV

### DIFF
--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -6,7 +6,7 @@ const blockConfig = [
     name: 'global-navigation',
     targetEl: 'header',
     appendType: 'prepend',
-    params: ['imsClientId', 'searchEnabled', 'unav', 'customLinks', 'jarvis', 'selfIntegrateUnav', 'miniGnav', 'desktopAppsCta', 'useSusiModal', 'whatsNew', 'showPlansCta'],
+    params: ['imsClientId', 'imsScope', 'searchEnabled', 'unav', 'customLinks', 'jarvis', 'selfIntegrateUnav', 'miniGnav', 'desktopAppsCta', 'useSusiModal', 'whatsNew', 'showPlansCta'],
   },
   {
     key: 'footer',

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -6,7 +6,7 @@ const blockConfig = [
     name: 'global-navigation',
     targetEl: 'header',
     appendType: 'prepend',
-    params: ['imsClientId', 'imsScope', 'searchEnabled', 'unav', 'customLinks', 'jarvis', 'selfIntegrateUnav', 'miniGnav', 'desktopAppsCta', 'useSusiModal', 'whatsNew', 'showPlansCta'],
+    params: ['imsClientId', 'imsAdditionalScopes', 'searchEnabled', 'unav', 'customLinks', 'jarvis', 'selfIntegrateUnav', 'miniGnav', 'desktopAppsCta', 'useSusiModal', 'whatsNew', 'showPlansCta'],
   },
   {
     key: 'footer',

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2025,7 +2025,7 @@ export async function loadIms() {
     const lingoRegion = lingoActive() ? await getLingoRegion({ useGeoLocation: true }) : null;
     return new Promise((resolve, reject) => {
       const {
-        locale, imsClientId, imsScope, env, base, adobeid, imsTimeout,
+        locale, imsClientId, imsScope, imsAdditionalScopes, env, base, adobeid, imsTimeout,
       } = getConfig();
       if (!imsClientId) {
         reject(new Error('Missing IMS Client ID'));
@@ -2036,7 +2036,7 @@ export async function loadIms() {
       const timeout = setTimeout(() => reject(new Error('IMS timeout')), imsTimeout || 5000);
       window.adobeid = {
         client_id: imsClientId,
-        scope: imsScope || defaultScope,
+        scope: imsScope || (imsAdditionalScopes?.length ? `${defaultScope},${imsAdditionalScopes.join(',')}` : defaultScope),
         locale: (lingoRegion?.ietf || locale?.ietf)?.replace('-', '_') || 'en_US',
         redirect_uri: ahomeMeta === 'on'
           ? (() => {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
### Added **imsAdditionalScopes** configuration support for standalone GNAV
Allows consumers of the standalone GNAV to pass extra IMS scopes via block config, without overriding the default scope.

```javascript
loadBlock({
  header: {
    imsClientId: 'my-client-id',
    imsAdditionalScopes: ['my_custom_scope', 'another_scope'], // additional IMS scopes
  }
});
// Resulting scope: "AdobeID,openid,gnav,...,my_custom_scope,another_scope"
``` 

Resolves: [MWPW-202037](https://jira.corp.adobe.com/browse/MWPW-202037)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-202037--milo--adobecom.aem.page/?martech=off

**QA:**
https://adobecom.github.io/nav-consumer/navigation.html?env=stage&authoringpath=/federal/community&navbranch=mwpw-202037&imsAdditionalScopes=my_custom_scope,another_scope

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=mwpw-202037--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=mwpw-202037--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=mwpw-202037--milo--adobecom
- Milo: https://mwpw-202037--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=mwpw-202037--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=mwpw-202037--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=mwpw-202037--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-202037--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-202037--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-202037--milo--adobecom
- Milo: https://mwpw-202037--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-202037--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-202037--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=mwpw-202037--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-202037--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-202037--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-202037--milo--adobecom
- Milo: https://mwpw-202037--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-202037--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-202037--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=mwpw-202037--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=mwpw-202037--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=mwpw-202037--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=mwpw-202037--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=mwpw-202037--milo--adobecom
</details>