### PR TITLE
MWPW-200958 Allow poi override in configurator

### DIFF
--- a/libs/blocks/marketo-config/marketo-config.js
+++ b/libs/blocks/marketo-config/marketo-config.js
@@ -252,7 +252,7 @@ const Configurator = ({ title, panelsData, lsKey }) => {
     const validatedState = validateState(state, panelsData);
     const windowUrl = new URL(window.location.href);
     const iframeUrl = new URL(windowUrl.origin + windowUrl.pathname);
-    const allowedParams = ['preview', 'milolibs', 'lang'];
+    const allowedParams = ['preview', 'milolibs', 'lang', 'mktfrm_poi'];
     const { searchParams } = windowUrl;
     allowedParams.forEach((param) => {
       if (searchParams.has(param)) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Allow the Dynamic POI override to be used in the configurator

Resolves: [MWPW-200958](https://jira.corp.adobe.com/browse/MWPW-200958)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bmarshal-mktfrm-poi--milo--adobecom.aem.page/?martech=off

**BACOM URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/tools/marketo?mktfrm_poi=commerce&preview=1
- After: https://main--da-bacom--adobecom.aem.live/tools/marketo?mktfrm_poi=commerce&preview=1&milolibs=bmarshal-mktfrm-poi

