### PR TITLE
[MWPW-191155]-Added RTL support for the Play/Pause control

### DIFF
--- a/libs/blocks/video/video.css
+++ b/libs/blocks/video/video.css
@@ -50,7 +50,7 @@ video {
 }
 
 @media (max-width: 599px) {
-  [dir='rtl'] .video-container .pause-play-wrapper {
+  [dir="rtl"] .video-container .pause-play-wrapper {
     right: auto;
     left: 2%;
   }

--- a/libs/blocks/video/video.css
+++ b/libs/blocks/video/video.css
@@ -49,9 +49,11 @@ video {
   cursor: pointer;
 }
 
-[dir='rtl'] .video-container .pause-play-wrapper {
+@media (max-width: 599px) {
+  [dir='rtl'] .video-container .pause-play-wrapper {
     right: auto;
     left: 2%;
+  }
 }
 
 .video-container .pause-play-wrapper .offset-filler {  

--- a/libs/blocks/video/video.css
+++ b/libs/blocks/video/video.css
@@ -49,6 +49,11 @@ video {
   cursor: pointer;
 }
 
+[dir='rtl'] .video-container .pause-play-wrapper {
+    right: auto;
+    left: 2%;
+}
+
 .video-container .pause-play-wrapper .offset-filler {  
   display: inherit;
   justify-content: center;


### PR DESCRIPTION
* Added RTL support for the Play/Pause control on mobile.
* Updated the `.pause-play-wrapper` positioning to use `left` instead of `right` in RTL layouts.
* Ensures the Play/Pause button is correctly aligned and accessible in RTL mobile view.

Resolves: [MWPW-191155](https://jira.corp.adobe.com/browse/MWPW-191155)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://main--da-cc--adobecom.aem.page/il_he/products/photoshop?milolibs=mwpw-191155-rtlfix






