### PR TITLE
MWPW-202460: Clear account cookies on Universal Nav sign-out

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -163,9 +163,6 @@ const getMessageEventListener = () => {
           .catch(() => { setUserProfile({}); });
         break;
       case 'SignOut':
-        // Clear domain-scoped account cookies before the Universal Nav runs the default
-        // IMS sign-out. On UNAV pages this listener is the only SignOut handler, so nothing
-        // else clears these (unlike the feds profile dropdown path).
         clearSignOutCookies();
         executeDefaultAction();
         break;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -15,7 +15,6 @@ import {
   getLingoRegion,
   lingoActive,
 } from '../../utils/utils.js';
-import { clearSignOutCookies } from './utilities/utilities.js';
 
 const cssPromise = (async () => {
   const { miloLibs, codeRoot, theme } = getConfig();
@@ -69,6 +68,7 @@ const { replaceKey, replaceKeyArray } = placeholders;
 const { getMiloLocaleSettings, isMasGeoDetectionEnabled } = merch;
 
 const {
+  clearSignOutCookies,
   closeAllDropdowns,
   createErrorPopup,
   fetchAndProcessPlainHtml,

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -15,6 +15,7 @@ import {
   getLingoRegion,
   lingoActive,
 } from '../../utils/utils.js';
+import { clearSignOutCookies } from './utilities/utilities.js';
 
 const cssPromise = (async () => {
   const { miloLibs, codeRoot, theme } = getConfig();
@@ -162,6 +163,10 @@ const getMessageEventListener = () => {
           .catch(() => { setUserProfile({}); });
         break;
       case 'SignOut':
+        // Clear domain-scoped account cookies before the Universal Nav runs the default
+        // IMS sign-out. On UNAV pages this listener is the only SignOut handler, so nothing
+        // else clears these (unlike the feds profile dropdown path).
+        clearSignOutCookies();
         executeDefaultAction();
         break;
       case 'ProfileSwitch':

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -134,11 +134,6 @@ export const logErrorFor = async (fn, message, tags, errorType, severity = 'erro
   }
 };
 
-// Domain-scoped account cookies (set at the edge / by the Universal Nav) that must not
-// outlive sign-out. Shared by both sign-out paths: the feds profile dropdown and the
-// Universal Nav SignOut event. Walks host -> registrable domain so the correct Domain=
-// variant is hit regardless of subdomain (prod adobe.com, stage stage.adobe.com). No-ops
-// off adobe.com (localhost, other hosts); browsers reject foreign-Domain cookie writes.
 export const clearSignOutCookies = () => {
   const { host } = window.location;
   if (host !== 'adobe.com' && !host.endsWith('.adobe.com')) return;

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -134,6 +134,23 @@ export const logErrorFor = async (fn, message, tags, errorType, severity = 'erro
   }
 };
 
+// Domain-scoped account cookies (set at the edge / by the Universal Nav) that must not
+// outlive sign-out. Shared by both sign-out paths: the feds profile dropdown and the
+// Universal Nav SignOut event. Walks host -> registrable domain so the correct Domain=
+// variant is hit regardless of subdomain (prod adobe.com, stage stage.adobe.com). No-ops
+// off adobe.com (localhost, other hosts); browsers reject foreign-Domain cookie writes.
+export const clearSignOutCookies = () => {
+  const { host } = window.location;
+  if (host !== 'adobe.com' && !host.endsWith('.adobe.com')) return;
+  const labels = host.split('.');
+  ['ims_country_code', 'acomsis', 'acomsis_stage'].forEach((name) => {
+    const base = `${name}=;path=/;expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
+    for (let i = 0; i < labels.length - 1; i += 1) {
+      document.cookie = `${base}domain=${labels.slice(i).join('.')};`;
+    }
+  });
+};
+
 export function addMepHighlightAndTargetId(el, source) {
   let { manifestId, targetManifestId } = source.dataset;
   const manifestIdEl = source?.closest('[data-manifest-id]');


### PR DESCRIPTION
Resolves: [MWPW-202460](https://jira.corp.adobe.com/browse/MWPW-202460)

## What
On sign-out from the **Universal Nav** account menu on Milo pages, clear the account cookies a signed-out user should not keep: the edge-set `ims_country_code` pricing cookie, plus the signed-in-status cookies `acomsis` (prod) / `acomsis_stage` (stage).

## Why
On Milo pages that render the Universal Nav, sign-out runs through Milo's own message-event listener (`getMessageEventListener` in `global-navigation.js`), whose `SignOut` case only called `executeDefaultAction()` (the IMS sign-out) and cleared nothing. So all three cookies could outlive the session — and `ims_country_code` keeps influencing pricing after sign-out. This is the Universal Nav companion to the feds gnav fix in #6335 (MWPW-201518).

Each cookie's `Domain` varies by environment (`adobe.com` on prod, `stage.adobe.com` on stage), so the clear walks the host → registrable-domain chain to cover both; the cookie name that doesn't apply to the current environment is a harmless no-op. The `clearSignOutCookies` helper lives in `global-navigation/utilities/utilities.js` so both sign-out paths can share it.

## Scope
- Covers the **Universal Nav** sign-out path (`getMessageEventListener`) on Milo pages that render the unav (e.g. adobe.com product pages).
- Clears `ims_country_code`, `acomsis`, `acomsis_stage`.
- **Out of scope:** the feds `ProfileDropdown` sign-out path — handled separately in #6335.

## Test
- Branch: https://ims-country-signout-unav--milo--adobecom.aem.page/?martech=off

**Steps to test**
**Acrobat**
1. go stage.adobe.com
2. sign in
3. open your developer tools -> application tab -> Cookies -> search for ims_country_code / acomsis_stage
4. you should see values set
5. go to https://www.stage.adobe.com/acrobat.html?milolibs=ims-country-signout-unav
6. look at your cookies - you should see the ims_country_code and acomsis_stage cookies
7. sign out from the Universal Nav profile menu (top-right avatar)
8. watch the cookies also be cleared

**Creative Cloud**
1. go stage.adobe.com
2. sign in
3. open your developer tools -> application tab -> Cookies -> search for ims_country_code / acomsis_stage
4. you should see values set
5. https://www.stage.adobe.com/products/premiere.html?milolibs=ims-country-signout-unav
6. look at your cookies - you should see the ims_country_code and acomsis_stage cookies
7. sign out from the Universal Nav profile menu (top-right avatar)
8. watch the cookies also be cleared

**Helpx**
1. go to helpx.adobe.com
2. sign in
3. manually set the ims_country_code cookie to CH for example and acomsis to 1 for the domain .adobe.com
4. watch your cookies - sign out
5. watch the ims_country_code and acomsis cookies also be cleared

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- Milo: https://ims-country-signout-unav--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=ims-country-signout-unav--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- Milo: https://ims-country-signout-unav--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ims-country-signout-unav--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- Milo: https://ims-country-signout-unav--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ims-country-signout-unav--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=ims-country-signout-unav--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=ims-country-signout-unav--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=ims-country-signout-unav--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=ims-country-signout-unav--milo--adobecom
</details>