### PR TITLE
Adding support to author BC global block in Gnav Document

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -164,6 +164,7 @@ const getMessageEventListener = () => {
         break;
       case 'SignOut':
         executeDefaultAction();
+        window.dispatchEvent(new Event('feds:signOut'));
         break;
       case 'ProfileSwitch':
         Promise.resolve(executeDefaultAction()).then((profile) => {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -6,6 +6,7 @@ import {
   loadIms,
   loadStyle,
   loadLana,
+  loadBlock,
   decorateLinksAsync,
   loadScript,
   getGnavSource,
@@ -590,6 +591,7 @@ class Gnav {
       // We needn't worry about delays now since decorateAside
       // needed to run anyway prior to decorateTopNavWrapper
       this.decorateAside,
+      this.decorateBrandConciergeGlobal,
       this.decorateMainNav,
       this.decorateTopNav,
       this.decorateTopnavWrapper,
@@ -1450,6 +1452,12 @@ class Gnav {
     includeLabel: false,
     analyticsValue: 'Logo',
   });
+
+  decorateBrandConciergeGlobal = async () => {
+    const rawBlock = this.content.querySelector('.brand-concierge-global');
+    if (!rawBlock) return;
+    await loadBlock(rawBlock);
+  };
 
   decorateMainNav = async () => {
     performance.mark('Decorate-MainNav-Start');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding support to author BC global block in Gnav Document

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bc-global-gnav-init--milo--adobecom.aem.page/drafts/blaishram/bc-global/?martech=off


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- Milo: https://bc-global-gnav-init--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=bc-global-gnav-init--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- Milo: https://bc-global-gnav-init--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=bc-global-gnav-init--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- Milo: https://bc-global-gnav-init--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=bc-global-gnav-init--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=bc-global-gnav-init--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=bc-global-gnav-init--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=bc-global-gnav-init--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=bc-global-gnav-init--milo--adobecom
</details>