### PR TITLE
MWPW-201352: add unit tests for c2 news block

### DIFF
--- a/test/blocks/news/mocks/default.html
+++ b/test/blocks/news/mocks/default.html
@@ -1,0 +1,28 @@
+<main>
+  <div class="section">
+    <div class="news">
+      <div>
+        <div><p>Latest news</p></div>
+      </div>
+      <div>
+        <div>
+          <h3>Item one headline</h3>
+          <p>Body copy for item one.</p>
+          <p><a href="https://www.adobe.com/one">Read more</a></p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h3>Item two headline</h3>
+          <p>Body copy for item two.</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h3>Item three headline</h3>
+          <p>Body copy for item three.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/news/mocks/four-up.html
+++ b/test/blocks/news/mocks/four-up.html
@@ -1,0 +1,13 @@
+<main>
+  <div class="section">
+    <div class="news">
+      <div>
+        <div><p>Latest news</p></div>
+      </div>
+      <div><div><h3>Item one</h3><p>Body one.</p></div></div>
+      <div><div><h3>Item two</h3><p>Body two.</p></div></div>
+      <div><div><h3>Item three</h3><p>Body three.</p></div></div>
+      <div><div><h3>Item four</h3><p>Body four.</p></div></div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/news/mocks/header-icon.html
+++ b/test/blocks/news/mocks/header-icon.html
@@ -1,0 +1,24 @@
+<main>
+  <div class="section">
+    <div class="news">
+      <div>
+        <div>
+          <picture><img src="/federal/icons/news-icon.svg" alt="news icon" /></picture>
+          <p>Latest news</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h3>Item one headline</h3>
+          <p>Body copy for item one.</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h3>Item two headline</h3>
+          <p>Body copy for item two.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/news/mocks/header-png-icon.html
+++ b/test/blocks/news/mocks/header-png-icon.html
@@ -1,0 +1,24 @@
+<main>
+  <div class="section">
+    <div class="news">
+      <div>
+        <div>
+          <picture><img src="/federal/icons/news-icon.png" alt="news icon" /></picture>
+          <p>Latest news</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h3>Item one headline</h3>
+          <p>Body copy for item one.</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h3>Item two headline</h3>
+          <p>Body copy for item two.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/news/mocks/header-png-icon.html
+++ b/test/blocks/news/mocks/header-png-icon.html
@@ -1,3 +1,6 @@
+<!-- The .png icon src is intentionally an unresolvable fixture path: the test asserts a
+     non-svg header icon src is left as-authored (not rewritten via getFederatedUrl). The
+     404 wtr logs for it is harmless and expected — the image is never loaded, only its src read. -->
 <main>
   <div class="section">
     <div class="news">

--- a/test/blocks/news/mocks/quiet.html
+++ b/test/blocks/news/mocks/quiet.html
@@ -1,0 +1,21 @@
+<main>
+  <div class="section">
+    <div class="news quiet">
+      <div>
+        <div><p>Latest news</p></div>
+      </div>
+      <div>
+        <div>
+          <h3>Item one headline</h3>
+          <p><a href="https://www.adobe.com/one">Read more</a></p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h3>Item two headline</h3>
+          <p><a href="https://www.adobe.com/two">Read more</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/news/mocks/single-row.html
+++ b/test/blocks/news/mocks/single-row.html
@@ -1,0 +1,9 @@
+<main>
+  <div class="section">
+    <div class="news">
+      <div>
+        <div><p>Latest news</p></div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/news/mocks/six-up.html
+++ b/test/blocks/news/mocks/six-up.html
@@ -1,0 +1,15 @@
+<main>
+  <div class="section">
+    <div class="news">
+      <div>
+        <div><p>Latest news</p></div>
+      </div>
+      <div><div><h3>Item one</h3><p>Body one.</p></div></div>
+      <div><div><h3>Item two</h3><p>Body two.</p></div></div>
+      <div><div><h3>Item three</h3><p>Body three.</p></div></div>
+      <div><div><h3>Item four</h3><p>Body four.</p></div></div>
+      <div><div><h3>Item five</h3><p>Body five.</p></div></div>
+      <div><div><h3>Item six</h3><p>Body six.</p></div></div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/news/news.test.js
+++ b/test/blocks/news/news.test.js
@@ -1,0 +1,105 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/news/news.js';
+
+describe('News', () => {
+  it('does nothing when there is only a single row', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/single-row.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    expect(block.querySelector('.news-headline')).to.be.null;
+    expect(block.querySelector('.news-items')).to.be.null;
+  });
+
+  it('formats the first row into a headline with an eyebrow', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/header-icon.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const headlineRow = block.querySelector('.news-headline');
+    expect(headlineRow).to.exist;
+
+    const headlineText = headlineRow.querySelector('.headline .headline-text .eyebrow');
+    expect(headlineText).to.exist;
+    expect(headlineText.textContent.trim()).to.equal('Latest news');
+
+    // the original authored cell is removed, leaving only the built headline
+    expect(headlineRow.children.length).to.equal(1);
+    expect(headlineRow.firstElementChild.classList.contains('headline')).to.be.true;
+  });
+
+  it('moves a header svg picture into the headline and rewrites its federated src', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/header-icon.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const headline = block.querySelector('.news-headline .headline');
+    const picture = headline.querySelector('picture');
+    expect(picture).to.exist;
+    // picture is prepended before the headline text
+    expect(headline.firstElementChild).to.equal(picture);
+
+    const img = picture.querySelector('img');
+    expect(img.classList.contains('icon')).to.be.true;
+    expect(img.getAttribute('src')).to.equal('https://main--federal--adobecom.aem.page/federal/icons/news-icon.svg');
+  });
+
+  it('wraps items in a news-items container with the count-based up class', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const items = block.querySelector('.news-items');
+    expect(items).to.exist;
+    expect(items.classList.contains('parallax-stagger-ltr')).to.be.true;
+    expect(items.classList.contains('three-up')).to.be.true;
+    expect(items.querySelectorAll('.news-item').length).to.equal(3);
+  });
+
+  it('uses the two-up class when there are two items', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/header-icon.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const items = block.querySelector('.news-items');
+    expect(items.classList.contains('two-up')).to.be.true;
+    expect(items.querySelectorAll('.news-item').length).to.equal(2);
+  });
+
+  it('marks the item cell as foreground and classifies its contents', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const firstItem = block.querySelector('.news-item');
+    expect(firstItem.querySelector(':scope > div.foreground')).to.exist;
+    expect(firstItem.querySelector('.news-item-headline').textContent.trim()).to.equal('Item one headline');
+    expect(firstItem.querySelector('.news-item-body').textContent.trim()).to.equal('Body copy for item one.');
+  });
+
+  it('marks a standalone link in a non-quiet block', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const link = block.querySelector('.news-item-link a');
+    expect(link).to.exist;
+    expect(link.classList.contains('standalone-link')).to.be.true;
+    expect(link.classList.contains('label')).to.be.true;
+    // no quiet class on a non-quiet block
+    expect(link.classList.contains('quiet')).to.be.false;
+  });
+
+  it('adds the quiet class to standalone links in the quiet variant', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/quiet.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const link = block.querySelector('.news-item-link a');
+    expect(link.classList.contains('standalone-link')).to.be.true;
+    expect(link.classList.contains('label')).to.be.true;
+    expect(link.classList.contains('quiet')).to.be.true;
+  });
+});

--- a/test/blocks/news/news.test.js
+++ b/test/blocks/news/news.test.js
@@ -68,6 +68,38 @@ describe('News', () => {
     expect(items.querySelectorAll('.news-item').length).to.equal(2);
   });
 
+  it('uses the four-up class when there are four items', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/four-up.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const items = block.querySelector('.news-items');
+    expect(items.classList.contains('four-up')).to.be.true;
+    expect(items.querySelectorAll('.news-item').length).to.equal(4);
+  });
+
+  it('uses the six-up class when there are six items', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/six-up.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const items = block.querySelector('.news-items');
+    expect(items.classList.contains('six-up')).to.be.true;
+    expect(items.querySelectorAll('.news-item').length).to.equal(6);
+  });
+
+  it('leaves a non-svg header icon src unrewritten', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/header-png-icon.html' });
+    const block = document.querySelector('.news');
+    await init(block);
+
+    const img = block.querySelector('.news-headline .headline picture img');
+    expect(img).to.exist;
+    expect(img.classList.contains('icon')).to.be.true;
+    // non-svg src is not passed through getFederatedUrl
+    expect(img.getAttribute('src')).to.equal('/federal/icons/news-icon.png');
+  });
+
   it('marks the item cell as foreground and classifies its contents', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/default.html' });
     const block = document.querySelector('.news');


### PR DESCRIPTION
## Summary
- Adds unit tests for the `news` c2 block (`libs/c2/blocks/news`), which previously had no coverage in `test/blocks`
- Covers: single-row no-op, header eyebrow formatting (`.headline > .headline-text > .eyebrow`, original cell removed), header svg icon move with federated `src` rewrite, count-based `news-items` up class (two-up/three-up), item `foreground` cell + content classification (`news-item-headline`/`news-item-body`), and standalone-link handling in both non-quiet and quiet variants
- The non-quiet standalone-link path used to throw (`classList.add('')`); that was fixed in MWPW-202052 (PR #6360, merged), and this suite locks in the corrected behavior
- Follows conventions from existing block tests (e.g. `test/blocks/base-card`, `test/blocks/brand-concierge`)

Resolves: https://jira.corp.adobe.com/browse/MWPW-201352

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/news/news.test.js" --node-resolve --port=2000` — 11/11 passing
- [x] `npx eslint test/blocks/news/news.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)





