### PR TITLE
MWPW-202191: add unit tests for c2 floating-cta block

### DIFF
--- a/test/blocks/floating-cta/floating-cta.test.js
+++ b/test/blocks/floating-cta/floating-cta.test.js
@@ -1,0 +1,73 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/floating-cta/floating-cta.js';
+
+describe('Floating CTA', () => {
+  it('builds a promo-cta anchor from the image and link, replacing the block content', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.floating-cta');
+    await init(block);
+
+    expect(block.children.length).to.equal(1);
+    const cta = block.querySelector(':scope > a.promo-cta');
+    expect(cta).to.exist;
+    expect(cta.getAttribute('href')).to.equal('https://www.adobe.com/buy');
+    expect(cta.getAttribute('tabindex')).to.equal('-1');
+    expect(cta.querySelector('img')).to.exist;
+    expect(cta.querySelector('span.icon-button[aria-hidden="true"]')).to.exist;
+    expect(cta.textContent).to.contain('Buy now');
+  });
+
+  it('splits the label on "|" into cta text and aria-label', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.floating-cta');
+    await init(block);
+
+    const cta = block.querySelector('a.promo-cta');
+    expect(cta.getAttribute('aria-label')).to.equal('Purchase Photoshop');
+    expect(cta.textContent).to.contain('Buy now');
+    expect(cta.textContent).to.not.contain('Purchase Photoshop');
+  });
+
+  it('uses the cta text as the aria-label when there is no "|"', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/no-pipe.html' });
+    const block = document.querySelector('.floating-cta');
+    await init(block);
+
+    const cta = block.querySelector('a.promo-cta');
+    expect(cta.getAttribute('aria-label')).to.equal('Learn more');
+    expect(cta.getAttribute('href')).to.equal('https://www.adobe.com/learn');
+  });
+
+  it('rewrites a federated svg image source', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.floating-cta');
+    await init(block);
+
+    const img = block.querySelector('a.promo-cta img');
+    expect(img.getAttribute('src')).to.equal('https://main--federal--adobecom.aem.page/federal/icons/cta.svg');
+  });
+
+  it('falls back to text content and "#" href when there is no anchor', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/text-only.html' });
+    const block = document.querySelector('.floating-cta');
+    await init(block);
+
+    const cta = block.querySelector('a.promo-cta');
+    expect(cta).to.exist;
+    expect(cta.getAttribute('href')).to.equal('#');
+    expect(cta.getAttribute('aria-label')).to.equal('Text aria label');
+    expect(cta.textContent).to.contain('Just text');
+  });
+
+  it('does nothing when the link paragraph is missing', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/invalid.html' });
+    const block = document.querySelector('.floating-cta');
+    await init(block);
+
+    expect(block.querySelector('a.promo-cta')).to.be.null;
+    // original content is left untouched
+    expect(block.querySelector('div > div > p img')).to.exist;
+  });
+});

--- a/test/blocks/floating-cta/mocks/default.html
+++ b/test/blocks/floating-cta/mocks/default.html
@@ -1,0 +1,12 @@
+<main>
+  <div class="section">
+    <div class="floating-cta">
+      <div>
+        <div>
+          <p><img src="/federal/icons/cta.svg" alt="cta icon" /></p>
+          <p><a href="https://www.adobe.com/buy">Buy now | Purchase Photoshop</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/floating-cta/mocks/invalid.html
+++ b/test/blocks/floating-cta/mocks/invalid.html
@@ -1,0 +1,11 @@
+<main>
+  <div class="section">
+    <div class="floating-cta">
+      <div>
+        <div>
+          <p><img src="/federal/icons/cta.svg" alt="cta icon" /></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/floating-cta/mocks/no-pipe.html
+++ b/test/blocks/floating-cta/mocks/no-pipe.html
@@ -1,0 +1,12 @@
+<main>
+  <div class="section">
+    <div class="floating-cta">
+      <div>
+        <div>
+          <p><img src="/federal/icons/cta.svg" alt="cta icon" /></p>
+          <p><a href="https://www.adobe.com/learn">Learn more</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/floating-cta/mocks/text-only.html
+++ b/test/blocks/floating-cta/mocks/text-only.html
@@ -1,0 +1,12 @@
+<main>
+  <div class="section">
+    <div class="floating-cta">
+      <div>
+        <div>
+          <p><img src="/federal/icons/cta.svg" alt="cta icon" /></p>
+          <p>Just text | Text aria label</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
## Summary
- Adds unit tests for the `floating-cta` c2 block (`libs/c2/blocks/floating-cta`), which previously had no coverage in `test/blocks`
- Covers: `a.promo-cta` build (img + arrow `span.icon-button` + `tabindex=-1`, block content replaced), label split on `|` into CTA text + `aria-label`, no-pipe fallback (`aria-label` = CTA text), federated svg `src` rewrite, plain-text fallback when there is no anchor (uses `textContent`, `#` href), and the missing-link-paragraph early return
- Follows conventions from existing block tests (e.g. `test/blocks/base-card`, `test/blocks/explore-card`)

Scope note: covers the deterministic non-merch CTA build. The merch/checkout path (`waitForCheckoutLink` + `onceSettled`) and the `applyCustomHide` IntersectionObserver are intentionally not asserted (async / commerce / observer-driven, flaky in unit tests), consistent with the other c2 suites.

Resolves: https://jira.corp.adobe.com/browse/MWPW-202191

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/floating-cta/floating-cta.test.js" --node-resolve --port=2000` — 6/6 passing
- [x] `npx eslint test/blocks/floating-cta/floating-cta.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

