### PR TITLE
MWPW-202194: add unit tests for c2 logo-ticker block

### DIFF
--- a/test/blocks/logo-ticker/logo-ticker.test.js
+++ b/test/blocks/logo-ticker/logo-ticker.test.js
@@ -1,0 +1,61 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/logo-ticker/logo-ticker.js';
+
+describe('Logo Ticker', () => {
+  it('builds a single track (role=img) that replaces the block content', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.logo-ticker');
+    init(block);
+
+    expect(block.children.length).to.equal(1);
+    const track = block.querySelector(':scope > .logo-ticker-track');
+    expect(track).to.exist;
+    expect(track.getAttribute('role')).to.equal('img');
+  });
+
+  it('duplicates the logos into two sets, hiding the second from assistive tech', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.logo-ticker');
+    init(block);
+
+    const sets = block.querySelectorAll('.logo-ticker-set');
+    expect(sets.length).to.equal(2);
+    expect(sets[0].hasAttribute('aria-hidden')).to.be.false;
+    expect(sets[1].getAttribute('aria-hidden')).to.equal('true');
+
+    // each set has a clone of all three logos → six icons total
+    expect(sets[0].querySelectorAll('span.icon').length).to.equal(3);
+    expect(sets[1].querySelectorAll('span.icon').length).to.equal(3);
+    expect(block.querySelectorAll('span.icon').length).to.equal(6);
+  });
+
+  it('labels the track from the second block row', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.logo-ticker');
+    init(block);
+
+    expect(block.querySelector('.logo-ticker-track').getAttribute('aria-label'))
+      .to.equal('Trusted by leading brands');
+  });
+
+  it('omits the aria-label when there is no second row', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/no-aria.html' });
+    const block = document.querySelector('.logo-ticker');
+    init(block);
+
+    const track = block.querySelector('.logo-ticker-track');
+    expect(track).to.exist;
+    expect(track.hasAttribute('aria-label')).to.be.false;
+    expect(block.querySelectorAll('.logo-ticker-set span.icon').length).to.equal(4);
+  });
+
+  it('does nothing when there are no logos', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/no-logos.html' });
+    const block = document.querySelector('.logo-ticker');
+    init(block);
+
+    expect(block.querySelector('.logo-ticker-track')).to.be.null;
+  });
+});

--- a/test/blocks/logo-ticker/mocks/default.html
+++ b/test/blocks/logo-ticker/mocks/default.html
@@ -1,0 +1,12 @@
+<main>
+  <div class="section">
+    <div class="logo-ticker">
+      <div>
+        <p><span class="icon icon-adobe"></span></p>
+        <p><span class="icon icon-photoshop"></span></p>
+        <p><span class="icon icon-illustrator"></span></p>
+      </div>
+      <div>Trusted by leading brands</div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/logo-ticker/mocks/no-aria.html
+++ b/test/blocks/logo-ticker/mocks/no-aria.html
@@ -1,0 +1,10 @@
+<main>
+  <div class="section">
+    <div class="logo-ticker">
+      <div>
+        <p><span class="icon icon-adobe"></span></p>
+        <p><span class="icon icon-photoshop"></span></p>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/logo-ticker/mocks/no-logos.html
+++ b/test/blocks/logo-ticker/mocks/no-logos.html
@@ -1,0 +1,9 @@
+<main>
+  <div class="section">
+    <div class="logo-ticker">
+      <div>
+        <p>No logos authored here.</p>
+      </div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
## Summary
- Adds unit tests for the `logo-ticker` c2 block (`libs/c2/blocks/logo-ticker`), which previously had no coverage in `test/blocks`
- Covers: track build (single `.logo-ticker-track[role=img]` replacing the block content), duplicated logo sets (two `.logo-ticker-set`s, the second `aria-hidden`, logos cloned not moved), `aria-label` sourced from the second block row, the no-second-row case (no label), and the no-logos no-op
- Follows conventions from existing block tests (e.g. `test/blocks/base-card`)

Scope note: covers the deterministic track construction. `syncTrackMetrics`/`.is-static` and the `ResizeObserver` are layout/observer-driven (depend on rendered widths) and intentionally not asserted; they run without error in the tests. Consistent with the other c2 suites.

Resolves: https://jira.corp.adobe.com/browse/MWPW-202194

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/logo-ticker/logo-ticker.test.js" --node-resolve --port=2000` — 5/5 passing
- [x] `npx eslint test/blocks/logo-ticker/logo-ticker.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

