### PR TITLE
MWPW-202201: add unit tests for c2 split-aside-grid block

### DIFF
--- a/test/blocks/split-aside-grid/mocks/default.html
+++ b/test/blocks/split-aside-grid/mocks/default.html
@@ -1,0 +1,34 @@
+<main>
+  <div class="section">
+    <div class="split-aside-grid">
+      <div>
+        <div>
+          <h3>First slide</h3>
+          <p>Body copy with an <a href="https://www.adobe.com/inline">inline link</a> in a sentence.</p>
+          <p><a href="https://www.adobe.com/one">Learn more</a></p>
+        </div>
+        <div>
+          <picture><img src="" alt="media one" /></picture>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h3>Second slide</h3>
+          <p>Body copy for the second slide.</p>
+        </div>
+        <div>
+          <picture><img src="" alt="media two" /></picture>
+        </div>
+      </div>
+      <div>
+        <div>
+          <h3>Third slide</h3>
+          <p>Body copy for the third slide.</p>
+        </div>
+        <div>
+          <picture><img src="" alt="media three" /></picture>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/split-aside-grid/mocks/no-heading.html
+++ b/test/blocks/split-aside-grid/mocks/no-heading.html
@@ -1,0 +1,22 @@
+<main>
+  <div class="section">
+    <div class="split-aside-grid">
+      <div>
+        <div>
+          <p>Body copy with no heading.</p>
+        </div>
+        <div>
+          <picture><img src="" alt="media one" /></picture>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p>Second slide body, also no heading.</p>
+        </div>
+        <div>
+          <picture><img src="" alt="media two" /></picture>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/split-aside-grid/split-aside-grid.test.js
+++ b/test/blocks/split-aside-grid/split-aside-grid.test.js
@@ -1,0 +1,104 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/split-aside-grid/split-aside-grid.js';
+
+describe('Split Aside Grid', () => {
+  it('builds the items wrapper, controls, media stack and aria-live region', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const el = document.querySelector('.split-aside-grid');
+    init(el);
+
+    expect(el.querySelector('.split-aside-grid-items')).to.exist;
+    expect(el.querySelector('.split-aside-grid-controls')).to.exist;
+    expect(el.querySelector('.split-aside-grid-stack')).to.exist;
+    expect(el.querySelector('.aria-live-container[aria-live="polite"]')).to.exist;
+    expect(el.querySelector('.split-aside-grid-controls button.prev')).to.exist;
+    expect(el.querySelector('.split-aside-grid-controls button.next')).to.exist;
+  });
+
+  it('decorates each slide with an index, toggle button, foreground and media', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const el = document.querySelector('.split-aside-grid');
+    init(el);
+
+    const items = el.querySelectorAll('.split-aside-grid-item');
+    expect(items.length).to.equal(3);
+    items.forEach((item, i) => {
+      expect(item.dataset.slideIndex).to.equal(String(i));
+      expect(item.querySelector(':scope > .split-aside-grid-toggle[aria-expanded]')).to.exist;
+      expect(item.querySelector('.foreground')).to.exist;
+    });
+
+    const firstToggleText = items[0].querySelector('.grid-item-toggle-text');
+    expect(firstToggleText.textContent.trim()).to.equal('First slide');
+  });
+
+  it('decorates the foreground content (heading, content-container, standalone link)', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const el = document.querySelector('.split-aside-grid');
+    init(el);
+
+    const content = el.querySelector('.split-aside-grid-item .foreground');
+    expect(content.querySelector('h3.heading-5')).to.exist;
+    expect(content.querySelector('.content-container')).to.exist;
+
+    const link = content.querySelector('a.standalone-link.label');
+    expect(link).to.exist;
+    expect(link.textContent.trim()).to.equal('Learn more');
+
+    // an inline link (text differs from its paragraph) is not marked standalone
+    const inline = [...content.querySelectorAll('a')].find((a) => a.textContent.trim() === 'inline link');
+    expect(inline).to.exist;
+    expect(inline.classList.contains('standalone-link')).to.be.false;
+  });
+
+  it('falls back to "Slide N" toggle text when a slide has no heading', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/no-heading.html' });
+    const el = document.querySelector('.split-aside-grid');
+    init(el);
+
+    const toggles = el.querySelectorAll('.split-aside-grid-toggle .grid-item-toggle-text');
+    expect(toggles[0].textContent.trim()).to.equal('Slide 1');
+    expect(toggles[1].textContent.trim()).to.equal('Slide 2');
+  });
+
+  it('moves every media into the stack', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const el = document.querySelector('.split-aside-grid');
+    init(el);
+
+    const stackMedia = el.querySelectorAll('.split-aside-grid-stack .media');
+    expect(stackMedia.length).to.equal(3);
+    stackMedia.forEach((m) => expect(m.querySelector('picture')).to.exist);
+  });
+
+  it('builds one dot per slide in a tablist, with the first marked current', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const el = document.querySelector('.split-aside-grid');
+    init(el);
+
+    const dotList = el.querySelector('.split-aside-grid-dots');
+    expect(dotList.getAttribute('role')).to.equal('tablist');
+    const dots = dotList.querySelectorAll('.split-aside-grid-dot');
+    expect(dots.length).to.equal(3);
+    expect(dots[0].getAttribute('aria-current')).to.equal('location');
+    expect(dots[0].classList.contains('is-active')).to.be.true;
+    expect(dots[1].getAttribute('aria-current')).to.be.null;
+  });
+
+  it('activates the first slide on load', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const el = document.querySelector('.split-aside-grid');
+    init(el);
+
+    const items = el.querySelectorAll('.split-aside-grid-item');
+    expect(items[0].classList.contains('split-aside-grid-active')).to.be.true;
+    expect(items[0].querySelector('.split-aside-grid-toggle').getAttribute('aria-expanded')).to.equal('true');
+
+    const medias = el.querySelectorAll('.split-aside-grid-stack .media');
+    expect(medias[0].getAttribute('data-slot')).to.equal('0');
+    expect(medias[0].getAttribute('aria-hidden')).to.equal('false');
+    expect(medias[1].getAttribute('aria-hidden')).to.equal('true');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for the `split-aside-grid` c2 block (`libs/c2/blocks/split-aside-grid`), which previously had no coverage in `test/blocks`
- Covers: block structure (`.split-aside-grid-items` / `-controls` / `-stack` / `.aria-live-container`), per-slide decoration (`data-slide-index`, toggle button, `.foreground`), content decoration (`heading-5`, `.content-container`, standalone-link marking **and** the negative inline-link branch), media moved into the stack, the dot `tablist` (first `aria-current`/`is-active`), the initial active-slide state from `applyRotation(0)` (item active, toggle expanded, media `data-slot=0`/`aria-hidden`), and the `Slide N` heading fallback
- Follows conventions from existing block tests (e.g. `test/blocks/base-card`)

Scope note: covers deterministic decoration + the initial active state (viewport-independent). The swipe/drag pointer gestures, desktop/mobile matchMedia rebinding, stack fly/snap animations, and Resize/Intersection observers are intentionally not asserted (timer/pointer/observer/matchMedia-driven, flaky in unit tests); they run without error here.

Resolves: https://jira.corp.adobe.com/browse/MWPW-202201

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/split-aside-grid/split-aside-grid.test.js" --node-resolve --port=2000` — 7/7 passing
- [x] `npx eslint test/blocks/split-aside-grid/split-aside-grid.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

