### PR TITLE
MWPW-202192: add unit tests for c2 hover-list block

### DIFF
--- a/test/blocks/hover-list/hover-list.test.js
+++ b/test/blocks/hover-list/hover-list.test.js
@@ -1,0 +1,82 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/hover-list/hover-list.js';
+
+describe('Hover List', () => {
+  it('marks the block as a container and builds headline + list columns', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.hover-list');
+    init(block);
+
+    expect(block.classList.contains('container')).to.be.true;
+
+    const children = [...block.children];
+    expect(children[0].classList.contains('hover-list-headline-wrapper')).to.be.true;
+    expect(children[1].classList.contains('hover-list-col')).to.be.true;
+    expect(block.querySelector('.hover-list-col > ol.hover-list-items')).to.exist;
+  });
+
+  it('decorates the headline from the first row', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.hover-list');
+    init(block);
+
+    const heading = block.querySelector('.hover-list-headline-wrapper .hover-list-headline h2');
+    expect(heading).to.exist;
+    expect(heading.classList.contains('heading-2')).to.be.true;
+    expect(heading.textContent.trim()).to.equal('Explore features');
+  });
+
+  it('builds one list item per content row with a number and text', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.hover-list');
+    init(block);
+
+    const items = block.querySelectorAll('.hover-list-items > li.hover-list-item');
+    expect(items.length).to.equal(3);
+
+    const firstCopy = items[0].querySelector(':scope > .hover-list-copy');
+    expect(firstCopy).to.exist;
+    const number = firstCopy.querySelector('.hover-list-number.eyebrow');
+    expect(number.textContent.trim()).to.equal('1.');
+    const text = firstCopy.querySelector('.hover-list-text.heading-5');
+    expect(text.textContent.trim()).to.equal('Design');
+
+    const numbers = [...block.querySelectorAll('.hover-list-number')].map((n) => n.textContent.trim());
+    expect(numbers).to.eql(['1.', '2.', '3.']);
+  });
+
+  it('wraps a row\'s pictures in a manual popover media element', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.hover-list');
+    init(block);
+
+    const items = block.querySelectorAll('.hover-list-item');
+    const media = items[0].querySelector('.hover-list-media');
+    expect(media).to.exist;
+    expect(media.getAttribute('popover')).to.equal('manual');
+    expect(media.querySelectorAll('picture').length).to.equal(2);
+
+    // second item has a single picture
+    expect(items[1].querySelectorAll('.hover-list-media picture').length).to.equal(1);
+  });
+
+  it('omits the media element for a row without pictures', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.hover-list');
+    init(block);
+
+    const items = block.querySelectorAll('.hover-list-item');
+    expect(items[2].querySelector('.hover-list-media')).to.be.null;
+  });
+
+  it('does nothing when the block has no rows', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/empty.html' });
+    const block = document.querySelector('.hover-list');
+    init(block);
+
+    expect(block.querySelector('.hover-list-items')).to.be.null;
+    expect(block.querySelector('.hover-list-headline-wrapper')).to.be.null;
+  });
+});

--- a/test/blocks/hover-list/mocks/default.html
+++ b/test/blocks/hover-list/mocks/default.html
@@ -1,0 +1,24 @@
+<main>
+  <div class="section">
+    <div class="hover-list">
+      <div>
+        <div><h2>Explore features</h2></div>
+      </div>
+      <div>
+        <div><p>Design</p></div>
+        <div>
+          <picture><img src="" alt="design a" /></picture>
+          <picture><img src="" alt="design b" /></picture>
+        </div>
+      </div>
+      <div>
+        <div><p>Develop</p></div>
+        <div><picture><img src="" alt="develop" /></picture></div>
+      </div>
+      <div>
+        <div><p>Deploy</p></div>
+        <div></div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/hover-list/mocks/empty.html
+++ b/test/blocks/hover-list/mocks/empty.html
@@ -1,0 +1,5 @@
+<main>
+  <div class="section">
+    <div class="hover-list"></div>
+  </div>
+</main>


### PR DESCRIPTION
## Summary
- Adds unit tests for the `hover-list` c2 block (`libs/c2/blocks/hover-list`), which previously had no coverage in `test/blocks`
- Covers: `container` class + `.hover-list-headline-wrapper` / `.hover-list-col > ol.hover-list-items` structure, first-row headline decoration (`h2.heading-2`), per-row list items (`.hover-list-copy` with `.hover-list-number.eyebrow` "N." + `.hover-list-text.heading-5`), picture rows wrapped in a `.hover-list-media[popover=manual]`, the no-picture negative branch, and the empty-block no-op
- Follows conventions from existing block tests (e.g. `test/blocks/base-card`)

Scope note: covers the deterministic decoration. The cursor-follower animation (mousemove / rAF / popover), sticky-boundary ResizeObserver, and matchMedia desktop/tablet behavior are intentionally not asserted (pointer/timer/observer-driven, flaky in unit tests); they run without error here.

Resolves: https://jira.corp.adobe.com/browse/MWPW-202192

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/hover-list/hover-list.test.js" --node-resolve --port=2000` — 6/6 passing
- [x] `npx eslint test/blocks/hover-list/hover-list.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

