### PR TITLE
MWPW-202197: add unit tests for c2 product-marquee-grid block

### DIFF
--- a/test/blocks/product-marquee-grid/mocks/empty.html
+++ b/test/blocks/product-marquee-grid/mocks/empty.html
@@ -1,0 +1,5 @@
+<main>
+  <div class="section">
+    <div class="product-marquee-grid"></div>
+  </div>
+</main>

--- a/test/blocks/product-marquee-grid/mocks/featured-offer.html
+++ b/test/blocks/product-marquee-grid/mocks/featured-offer.html
@@ -1,0 +1,15 @@
+<main>
+  <div class="section">
+    <div class="product-marquee-grid featured-offer">
+      <div>
+        <div>
+          <p><picture><img src="/federal/assets/svgs/lightroom.svg" alt="Lightroom" /></picture></p>
+          <h2>Lightroom</h2>
+          <p>Edit, organize, store, and share photos from anywhere.</p>
+          <p>Limited-time launch pricing.</p>
+          <p><strong><a href="https://www.adobe.com/buy/lightroom">Learn more</a></strong></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/product-marquee-grid/mocks/no-cta.html
+++ b/test/blocks/product-marquee-grid/mocks/no-cta.html
@@ -1,0 +1,14 @@
+<main>
+  <div class="section">
+    <div class="product-marquee-grid">
+      <div>
+        <div>
+          <p><picture><img src="/federal/assets/svgs/illustrator.svg" alt="Illustrator" /></picture></p>
+          <h2>Illustrator</h2>
+          <p>Create beautiful vector art and illustrations.</p>
+          <p>Included with your subscription.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/product-marquee-grid/mocks/no-icon.html
+++ b/test/blocks/product-marquee-grid/mocks/no-icon.html
@@ -1,0 +1,14 @@
+<main>
+  <div class="section">
+    <div class="product-marquee-grid">
+      <div>
+        <div>
+          <h2>Premiere Pro</h2>
+          <p>Edit video with professional tools.</p>
+          <p>New subscribers save more.</p>
+          <p><em><a href="https://www.adobe.com/buy/premiere">Buy now</a></em></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/product-marquee-grid/mocks/single-para.html
+++ b/test/blocks/product-marquee-grid/mocks/single-para.html
@@ -1,0 +1,13 @@
+<main>
+  <div class="section">
+    <div class="product-marquee-grid">
+      <div>
+        <div>
+          <h2>Acrobat</h2>
+          <p>The complete PDF solution for a mobile, connected world.</p>
+          <p><em><a href="https://www.adobe.com/buy/acrobat">Buy now</a></em></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/product-marquee-grid/mocks/soft-offer.html
+++ b/test/blocks/product-marquee-grid/mocks/soft-offer.html
@@ -1,0 +1,15 @@
+<main>
+  <div class="section">
+    <div class="product-marquee-grid">
+      <div>
+        <div>
+          <p><picture><img src="/federal/assets/svgs/photoshop.svg" alt="Photoshop" /></picture></p>
+          <h2>Photoshop</h2>
+          <p>Create and enhance photographs, illustrations, and 3D artwork.</p>
+          <p>Save over 40% on your first year.</p>
+          <p><em><a href="https://www.adobe.com/buy/photoshop">Buy now</a></em></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/product-marquee-grid/product-marquee-grid.test.js
+++ b/test/blocks/product-marquee-grid/product-marquee-grid.test.js
@@ -1,0 +1,146 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/product-marquee-grid/product-marquee-grid.js';
+
+const FEDERAL_SVG = 'https://main--federal--adobecom.aem.page/federal/assets/svgs/photoshop.svg';
+
+async function initBlock(path) {
+  document.body.innerHTML = await readFile({ path });
+  const block = document.querySelector('.product-marquee-grid');
+  await init(block);
+  return block;
+}
+
+describe('Product Marquee Grid', () => {
+  describe('soft offer (default) variant', () => {
+    let block;
+    let content;
+    beforeEach(async () => {
+      block = await initBlock('./mocks/soft-offer.html');
+      content = block.querySelector('.pm-content');
+    });
+
+    it('replaces the block content with a single pm-content container', () => {
+      expect(block.children.length).to.equal(1);
+      expect(content).to.exist;
+      expect(content.classList.contains('container')).to.be.true;
+      expect(content.children.length).to.equal(2);
+      expect(content.children[0].classList.contains('pm-foreground')).to.be.true;
+      expect(content.children[1].classList.contains('pm-promo-area')).to.be.true;
+    });
+
+    it('builds the chiclet row with the icon and the super heading', () => {
+      const chicletRow = content.querySelector('.pm-foreground .pm-chiclet-row');
+      expect(chicletRow).to.exist;
+
+      const icon = chicletRow.querySelector('img.icon');
+      expect(icon).to.exist;
+
+      const heading = chicletRow.querySelector('h2.heading-super');
+      expect(heading).to.exist;
+      expect(heading.textContent).to.equal('Photoshop');
+    });
+
+    it('rewrites the federated svg icon src to the absolute federal URL', () => {
+      const icon = content.querySelector('.pm-chiclet-row img.icon');
+      expect(icon.getAttribute('src')).to.equal(FEDERAL_SVG);
+    });
+
+    it('marks body paragraphs with heading-5 and excludes the label paragraph', () => {
+      const bodyEls = content.querySelectorAll('.pm-foreground > p.heading-5');
+      expect(bodyEls.length).to.equal(1);
+      expect(bodyEls[0].textContent).to.equal(
+        'Create and enhance photographs, illustrations, and 3D artwork.',
+      );
+      // the label paragraph is moved into the promo cta, not left in the foreground
+      expect(content.querySelector('.pm-foreground .pm-promo-cta-label')).to.be.null;
+    });
+
+    it('builds a soft-offer cta with the trailing paragraph as the label', () => {
+      const cta = content.querySelector('.pm-promo-area .pm-promo-cta');
+      expect(cta).to.exist;
+
+      const label = cta.querySelector('.pm-promo-cta-label');
+      expect(label).to.exist;
+      expect(label.textContent).to.equal('Save over 40% on your first year.');
+
+      const button = cta.querySelector('a.con-button');
+      expect(button).to.exist;
+      expect(button.getAttribute('href')).to.equal('https://www.adobe.com/buy/photoshop');
+      expect(button.textContent.trim()).to.equal('Buy now');
+
+      // soft offer must NOT produce the featured-offer promo button
+      expect(content.querySelector('.pm-promo-button')).to.be.null;
+    });
+  });
+
+  describe('featured-offer variant', () => {
+    let block;
+    let content;
+    beforeEach(async () => {
+      block = await initBlock('./mocks/featured-offer.html');
+      content = block.querySelector('.pm-content');
+    });
+
+    it('builds a promo button instead of a soft-offer cta', () => {
+      const promoButton = content.querySelector('.pm-promo-area a.pm-promo-button');
+      expect(promoButton).to.exist;
+      expect(promoButton.getAttribute('href')).to.equal('https://www.adobe.com/buy/lightroom');
+
+      const text = promoButton.querySelector('span.pm-promo-text.eyebrow');
+      expect(text).to.exist;
+      expect(text.textContent).to.equal('Learn more');
+
+      const chevron = promoButton.querySelector('span.pm-promo-chevron');
+      expect(chevron).to.exist;
+      expect(chevron.getAttribute('aria-hidden')).to.equal('true');
+      expect(chevron.querySelector('svg')).to.exist;
+
+      // the soft-offer cta path must NOT run for the featured variant
+      expect(content.querySelector('.pm-promo-cta')).to.be.null;
+    });
+
+    it('treats every non-cta paragraph as body copy (no label extraction)', () => {
+      const bodyEls = content.querySelectorAll('.pm-foreground > p.heading-5');
+      expect(bodyEls.length).to.equal(2);
+      expect(content.querySelector('.pm-promo-cta-label')).to.be.null;
+    });
+  });
+
+  describe('fallback / negative branches', () => {
+    it('leaves the promo area empty when the column has no cta link', async () => {
+      const block = await initBlock('./mocks/no-cta.html');
+      const promoArea = block.querySelector('.pm-promo-area');
+      expect(promoArea).to.exist;
+      expect(promoArea.children.length).to.equal(0);
+      expect(block.querySelector('.pm-promo-cta')).to.be.null;
+      expect(block.querySelector('.pm-promo-button')).to.be.null;
+    });
+
+    it('omits the cta label when there is only a single paragraph', async () => {
+      const block = await initBlock('./mocks/single-para.html');
+      const cta = block.querySelector('.pm-promo-cta');
+      expect(cta).to.exist;
+      expect(cta.querySelector('.pm-promo-cta-label')).to.be.null;
+      expect(cta.querySelector('a.con-button')).to.exist;
+
+      const bodyEls = block.querySelectorAll('.pm-foreground > p.heading-5');
+      expect(bodyEls.length).to.equal(1);
+    });
+
+    it('builds a chiclet row with only the heading when there is no icon', async () => {
+      const block = await initBlock('./mocks/no-icon.html');
+      const chicletRow = block.querySelector('.pm-chiclet-row');
+      expect(chicletRow).to.exist;
+      expect(chicletRow.querySelector('img.icon')).to.be.null;
+      expect(chicletRow.querySelector('h2.heading-super')).to.exist;
+    });
+
+    it('is a no-op and does not throw when the block has no rows', async () => {
+      const block = await initBlock('./mocks/empty.html');
+      expect(block.querySelector('.pm-content')).to.be.null;
+      expect(block.children.length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit test coverage for the c2 Milo block `product-marquee-grid`. Tests exercise `init(el)` against realistic Milo block DOM mocks and assert the deterministic DOM decoration produced by `decorate`.

Coverage:
- Soft-offer (default) variant: single `.pm-content.container` wrapper, `.pm-foreground` + `.pm-promo-area`, chiclet row with `img.icon` + super heading, `heading-5` body paragraphs, trailing paragraph promoted to `.pm-promo-cta-label`, and a `con-button` CTA link.
- Federated svg icon `src` rewrite (`/federal/...svg` -> `https://main--federal--adobecom.aem.page/federal/...svg`).
- Featured-offer variant: `.pm-promo-button` with `.pm-promo-text.eyebrow` label and `.pm-promo-chevron` svg; no label extraction (all paragraphs are body copy).
- Fallback / negative branches: no CTA link (empty promo area), single paragraph (no label), no icon (chiclet row with heading only), empty block with no rows (no-op, no throw).

## Scope
Test-only change. Nothing under `libs/` is modified. Scope is limited to deterministic DOM decoration; timer/rAF/observer/matchMedia/pointer/network behaviors are not asserted, but `init` must not throw.

Resolves: https://jira.corp.adobe.com/browse/MWPW-202197

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/product-marquee-grid/product-marquee-grid.test.js" --node-resolve` — 11 passing
- [x] `npx eslint test/blocks/product-marquee-grid/product-marquee-grid.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

