### PR TITLE
MWPW-202199: add unit tests for c2 side-by-side block

### DIFF
--- a/test/blocks/side-by-side/mocks/dark.html
+++ b/test/blocks/side-by-side/mocks/dark.html
@@ -1,0 +1,30 @@
+<main>
+  <div class="section">
+    <div class="side-by-side dark">
+      <div>
+        <div>
+          <picture>
+            <img src="/media/overlay.png" alt="Overlay media" width="800" height="600" />
+          </picture>
+        </div>
+        <div>
+          <picture>
+            <img src="/media/stacked.png" alt="Stacked media" width="800" height="600" />
+          </picture>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p><strong>Overlay heading</strong></p>
+          <h3>Overlay title</h3>
+          <p>Overlay body copy.</p>
+        </div>
+        <div>
+          <p><strong>Stacked heading</strong></p>
+          <h3>Stacked title</h3>
+          <p>Stacked body copy.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/side-by-side/mocks/default.html
+++ b/test/blocks/side-by-side/mocks/default.html
@@ -1,0 +1,32 @@
+<main>
+  <div class="section">
+    <div class="side-by-side">
+      <div>
+        <div>
+          <picture>
+            <img src="/media/overlay.png" alt="Overlay media" width="800" height="600" />
+          </picture>
+        </div>
+        <div>
+          <picture>
+            <img src="/media/stacked.png" alt="Stacked media" width="800" height="600" />
+          </picture>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p><strong>Overlay heading</strong></p>
+          <h3>Overlay title</h3>
+          <p>Overlay body copy that explains the first card.</p>
+          <p><em><a href="https://www.adobe.com/overlay">Overlay CTA</a></em></p>
+        </div>
+        <div>
+          <p><strong>Stacked heading</strong></p>
+          <h3>Stacked title</h3>
+          <p>Stacked body copy that explains the second card.</p>
+          <p><a href="https://www.adobe.com/stacked">Plain stacked link</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/side-by-side/mocks/single-row.html
+++ b/test/blocks/side-by-side/mocks/single-row.html
@@ -1,0 +1,18 @@
+<main>
+  <div class="section">
+    <div class="side-by-side">
+      <div>
+        <div>
+          <picture>
+            <img src="/media/overlay.png" alt="Overlay media" width="800" height="600" />
+          </picture>
+        </div>
+        <div>
+          <picture>
+            <img src="/media/stacked.png" alt="Stacked media" width="800" height="600" />
+          </picture>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/side-by-side/mocks/video.html
+++ b/test/blocks/side-by-side/mocks/video.html
@@ -1,0 +1,30 @@
+<main>
+  <div class="section">
+    <div class="side-by-side">
+      <div>
+        <div>
+          <div class="video-holder">
+            <video muted playsinline></video>
+          </div>
+        </div>
+        <div>
+          <picture>
+            <img src="/media/stacked.png" alt="Stacked media" width="800" height="600" />
+          </picture>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p><strong>Overlay heading</strong></p>
+          <h3>Overlay title</h3>
+          <p>Overlay body copy.</p>
+        </div>
+        <div>
+          <p><strong>Stacked heading</strong></p>
+          <h3>Stacked title</h3>
+          <p>Stacked body copy.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/side-by-side/side-by-side.test.js
+++ b/test/blocks/side-by-side/side-by-side.test.js
@@ -1,0 +1,109 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import init from '../../../libs/c2/blocks/side-by-side/side-by-side.js';
+
+describe('side-by-side (c2)', () => {
+  describe('default (two rows, picture media)', () => {
+    let block;
+    beforeEach(async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+      block = document.querySelector('.side-by-side');
+      init(block);
+    });
+
+    it('builds exactly two cards from the media and text rows', () => {
+      const cards = block.querySelectorAll(':scope > .card');
+      expect(cards.length).to.equal(2);
+    });
+
+    it('assigns the overlay and stacked card variants in order', () => {
+      const [first, second] = block.children;
+      expect(first.classList.contains('card-overlay')).to.be.true;
+      expect(second.classList.contains('card-stacked')).to.be.true;
+    });
+
+    it('pairs each card with a .media then a .foreground child', () => {
+      [...block.children].forEach((card) => {
+        const kids = [...card.children];
+        expect(kids.length).to.equal(2);
+        expect(kids[0].classList.contains('media')).to.be.true;
+        expect(kids[1].classList.contains('foreground')).to.be.true;
+      });
+    });
+
+    it('keeps the picture inside the decorated media cell', () => {
+      const media = block.querySelector('.card-overlay .media');
+      expect(media.querySelector('picture img')).to.exist;
+      expect(media.querySelector('img').getAttribute('src')).to.equal('/media/overlay.png');
+    });
+
+    it('decorates foreground text with heading, title and body styles', () => {
+      const foreground = block.querySelector('.card-overlay .foreground');
+      expect(foreground.querySelector('h3').classList.contains('heading-6')).to.be.true;
+      expect(foreground.querySelector('p:has(strong)').classList.contains('title-6')).to.be.true;
+      expect(foreground.querySelector('p:has(strong)').classList.contains('body-md')).to.be.false;
+      const bodyP = [...foreground.querySelectorAll('p')].find((p) => p.textContent.startsWith('Overlay body'));
+      expect(bodyP.classList.contains('body-md')).to.be.true;
+    });
+
+    it('promotes an inline (em > a) link into a con-button action area', () => {
+      const foreground = block.querySelector('.card-overlay .foreground');
+      const cta = foreground.querySelector('a[href="https://www.adobe.com/overlay"]');
+      expect(cta.classList.contains('con-button')).to.be.true;
+      expect(cta.closest('em')).to.be.null;
+      expect(cta.closest('p').classList.contains('action-area')).to.be.true;
+    });
+
+    it('leaves a standalone (plain) link untouched', () => {
+      const foreground = block.querySelector('.card-stacked .foreground');
+      const link = foreground.querySelector('a[href="https://www.adobe.com/stacked"]');
+      expect(link.classList.contains('con-button')).to.be.false;
+      expect(link.closest('p').classList.contains('action-area')).to.be.false;
+    });
+
+    it('adds the dark class to the overlay card when the block is not dark', () => {
+      expect(block.classList.contains('dark')).to.be.false;
+      expect(block.querySelector('.card-overlay').classList.contains('dark')).to.be.true;
+    });
+  });
+
+  describe('dark block variant', () => {
+    it('does not add dark to the overlay card when the block is already dark', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/dark.html' });
+      const block = document.querySelector('.side-by-side');
+      init(block);
+      expect(block.classList.contains('dark')).to.be.true;
+      const overlay = block.querySelector('.card-overlay');
+      expect(overlay.classList.contains('dark')).to.be.false;
+    });
+  });
+
+  describe('video media', () => {
+    it('decorates without throwing and keeps the video inside the media cell', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/video.html' });
+      const block = document.querySelector('.side-by-side');
+      expect(() => init(block)).to.not.throw();
+      const media = block.querySelector('.card-overlay .media');
+      expect(media.querySelector('video')).to.exist;
+      expect(block.querySelectorAll(':scope > .card').length).to.equal(2);
+    });
+  });
+
+  describe('no-op branches', () => {
+    it('does nothing when the block has only one row', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/single-row.html' });
+      const block = document.querySelector('.side-by-side');
+      const before = block.innerHTML;
+      init(block);
+      expect(block.querySelector('.card')).to.be.null;
+      expect(block.innerHTML).to.equal(before);
+    });
+
+    it('does nothing when the block is empty', () => {
+      document.body.innerHTML = '<main><div class="section"><div class="side-by-side"></div></div></main>';
+      const block = document.querySelector('.side-by-side');
+      expect(() => init(block)).to.not.throw();
+      expect(block.children.length).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for the c2 Milo block `side-by-side` (`libs/c2/blocks/side-by-side/side-by-side.js`). 12 tests, all green, covering deterministic DOM decoration produced by `init(el)`:

- Builds exactly two cards with `card-overlay` / `card-stacked` variants in order.
- Each card pairs a `.media` cell followed by a `.foreground` cell.
- Media cell retains its `picture`/`img`.
- Foreground text decoration: `heading-6` on headings, `title-6` on the `p:has(strong)` label, `body-md` on body copy.
- Inline (`em > a`) link is promoted to a `con-button` inside an `action-area`; standalone plain link is left untouched (opposite branch).
- Overlay card gets `dark` when the block is not dark; does NOT when the block already has `dark` (opposite branch).
- Video media path decorates without throwing and keeps the `<video>` in `.media`.
- No-op branches: single-row block and empty block leave the DOM unchanged / create no cards.

~94% line coverage of the block (74/79).

## Scope note
TEST-ONLY change — nothing under `libs/` was modified. Per scope, timer/rAF/IntersectionObserver/matchMedia/pointer/network behaviors are not asserted (the uncovered lines are inside the IntersectionObserver callback, which only fires on real intersection); tests assert only deterministic DOM decoration and that `init` does not throw.

Resolves: https://jira.corp.adobe.com/browse/MWPW-202199

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/side-by-side/side-by-side.test.js" --node-resolve` — 12 passed, 0 failed
- [x] `npx eslint test/blocks/side-by-side/side-by-side.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

