### PR TITLE
MWPW-202193: add unit tests for c2 hub-hero block

### DIFF
--- a/test/blocks/hub-hero/hub-hero.test.js
+++ b/test/blocks/hub-hero/hub-hero.test.js
@@ -1,0 +1,162 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+import init from '../../../libs/c2/blocks/hub-hero/hub-hero.js';
+
+const loadBlock = async (path) => {
+  document.body.innerHTML = await readFile({ path });
+  const block = document.querySelector('.hub-hero');
+  await init(block);
+  return block;
+};
+
+describe('hub-hero block', () => {
+  describe('top-level structure (default.html)', () => {
+    let block;
+    before(async () => {
+      block = await loadBlock('./mocks/default.html');
+    });
+
+    it('replaces the block content with header, grid and carousel in order', () => {
+      const kids = [...block.children];
+      expect(kids).to.have.lengthOf(3);
+      expect(kids[0].classList.contains('hub-hero-header')).to.be.true;
+      expect(kids[1].classList.contains('hub-hero-image-grid-container')).to.be.true;
+      expect(kids[2].classList.contains('hub-hero-carousel')).to.be.true;
+    });
+
+    it('decorates the hero header CTA as a promo-cta with an alias aria-label', () => {
+      const cta = block.querySelector('.hub-hero-header a.promo-cta');
+      expect(cta).to.exist;
+      // text before the pipe is the label, text after is the aria-label
+      expect(cta.getAttribute('aria-label')).to.equal('Explore all Adobe products');
+      expect(cta.textContent).to.contain('Explore now');
+      expect(cta.textContent).to.not.contain('Explore all Adobe products');
+      expect(cta.querySelector('img')).to.exist;
+      expect(cta.querySelector('span.icon-button svg')).to.exist;
+    });
+
+    it('builds a 5-column image grid and clones slide media into columns 2 and 4', () => {
+      const grid = block.querySelector('.hub-hero-image-grid-container');
+      const cols = grid.querySelectorAll('.hub-hero-image-grid-container-col');
+      expect(cols).to.have.lengthOf(5);
+      expect(cols[1].querySelector('img[alt="s2"]')).to.exist;
+      expect(cols[3].querySelector('img[alt="s4"]')).to.exist;
+    });
+
+    it('prepends the carousel header and exposes carousel aria metadata', () => {
+      const carousel = block.querySelector('.hub-hero-carousel');
+      const header = carousel.firstElementChild;
+      expect(header.classList.contains('hub-hero-carousel-header')).to.be.true;
+      expect(header.querySelector('h2').textContent).to.contain('Featured cards');
+      expect(carousel.querySelector('.hub-hero-carousel-container')).to.exist;
+      expect(carousel.dataset.ariaRoledescription).to.equal('carousel');
+      // name comes from the first slide link text after the pipe
+      expect(carousel.dataset.ariaLabel).to.equal('Adobe Creative Cloud');
+    });
+  });
+
+  describe('carousel slides (default.html)', () => {
+    let slides;
+    before(async () => {
+      const block = await loadBlock('./mocks/default.html');
+      slides = [...block.querySelectorAll('.hub-hero-carousel-item')];
+    });
+
+    it('creates four authored slides plus one placeholder slide', () => {
+      expect(slides).to.have.lengthOf(5);
+      const placeholders = slides.filter((s) => s.classList.contains('placeholder'));
+      expect(placeholders).to.have.lengthOf(1);
+      // the placeholder is injected as the third slide and carries no link or index
+      expect(slides[2].classList.contains('placeholder')).to.be.true;
+      expect(slides[2].getAttribute('href')).to.be.null;
+      expect(slides[2].getAttribute('data-index')).to.be.null;
+    });
+
+    it('assigns continuous data-index values across the real slides', () => {
+      const indices = slides
+        .filter((s) => !s.classList.contains('placeholder'))
+        .map((s) => s.getAttribute('data-index'));
+      expect(indices).to.eql(['1', '2', '3', '4']);
+    });
+
+    it('builds header/media/footer containers with the add icon for each real slide', () => {
+      slides
+        .filter((s) => !s.classList.contains('placeholder'))
+        .forEach((slide) => {
+          expect(slide.querySelector('.hub-hero-carousel-item-container')).to.exist;
+          expect(slide.querySelector('.hub-hero-carousel-item-header')).to.exist;
+          expect(slide.querySelector('.hub-hero-carousel-item-media')).to.exist;
+          const footer = slide.querySelector('.hub-hero-carousel-item-footer');
+          expect(footer).to.exist;
+          expect(footer.querySelector('span[aria-hidden="true"] svg')).to.exist;
+        });
+    });
+
+    it('links eyebrow and heading ids through aria-labelledby', () => {
+      const first = slides[0];
+      expect(first.getAttribute('aria-labelledby')).to.equal('hub-hero-slide-1-title hub-hero-slide-1-desc');
+      expect(first.querySelector('#hub-hero-slide-1-title')).to.exist;
+      expect(first.querySelector('#hub-hero-slide-1-desc')).to.exist;
+      expect(first.getAttribute('daa-ll')).to.equal('Slide One Heading-1--Slide One Heading');
+    });
+
+    it('marks a standard link slide with role="link" and no modal data', () => {
+      const standard = slides[0];
+      expect(standard.getAttribute('role')).to.equal('link');
+      expect(standard.getAttribute('href')).to.equal('https://www.adobe.com/slide1');
+      expect(standard.dataset.modalHash).to.be.undefined;
+      expect(standard.dataset.modalPath).to.be.undefined;
+    });
+
+    it('marks a modal link slide with role="button" and modal data attributes', () => {
+      const modal = slides[1];
+      expect(modal.getAttribute('role')).to.equal('button');
+      expect(modal.dataset.modalHash).to.equal('#slide2-modal');
+      expect(modal.dataset.modalPath).to.equal('/modals/slide2');
+    });
+
+    it('prepares a video asset slide with autoplay-friendly attributes', () => {
+      const videoSlide = slides.find((s) => s.getAttribute('data-index') === '3');
+      const video = videoSlide.querySelector('.hub-hero-carousel-item-media video');
+      expect(video).to.exist;
+      expect(video.getAttribute('preload')).to.equal('none');
+      expect(video.getAttribute('muted')).to.equal('true');
+      expect(video.getAttribute('tabindex')).to.equal('-1');
+      expect(video.hasAttribute('controls')).to.be.false;
+      const source = video.querySelector('source');
+      expect(source.getAttribute('type')).to.equal('video/mp4');
+      expect(source.getAttribute('src')).to.equal('https://example.com/slide3.mp4');
+    });
+
+    it('renders picture-based slides with an image in the media area', () => {
+      const pictureSlide = slides[0];
+      expect(pictureSlide.querySelector('.hub-hero-carousel-item-media img[alt="s1"]')).to.exist;
+      expect(pictureSlide.querySelector('.hub-hero-carousel-item-media video')).to.be.null;
+    });
+  });
+
+  describe('fallback branches (fallbacks.html)', () => {
+    let block;
+    before(async () => {
+      block = await loadBlock('./mocks/fallbacks.html');
+    });
+
+    it('falls back to the CTA text for the aria-label when there is no alias', () => {
+      const cta = block.querySelector('.hub-hero-header a.promo-cta');
+      expect(cta.getAttribute('aria-label')).to.equal('Get started');
+      expect(cta.textContent).to.contain('Get started');
+    });
+
+    it('falls back to the default carousel name when no name is authored', () => {
+      const carousel = block.querySelector('.hub-hero-carousel');
+      expect(carousel.dataset.ariaLabel).to.equal('Adobe Cards');
+    });
+
+    it('still produces the full header/grid/carousel structure', () => {
+      expect(block.querySelector('.hub-hero-header')).to.exist;
+      expect(block.querySelectorAll('.hub-hero-image-grid-container-col')).to.have.lengthOf(5);
+      expect(block.querySelectorAll('.hub-hero-carousel-item')).to.have.lengthOf(5);
+    });
+  });
+});

--- a/test/blocks/hub-hero/mocks/default.html
+++ b/test/blocks/hub-hero/mocks/default.html
@@ -1,0 +1,65 @@
+<main>
+  <div class="section">
+    <div class="hub-hero heading-1 body-lg button-lg">
+      <div>
+        <div>
+          <h1>Create with Adobe</h1>
+          <p>Explore the tools that bring your ideas to life.</p>
+          <p><a href="https://www.adobe.com/explore"><img src="/cta-icon.png" alt="cta" />Explore now | Explore all Adobe products</a></p>
+        </div>
+      </div>
+      <div>
+        <div><picture><img src="https://example.com/g1.png" alt="g1" /></picture></div>
+        <div><picture><img src="https://example.com/g2.png" alt="g2" /></picture></div>
+        <div><picture><img src="https://example.com/g3.png" alt="g3" /></picture></div>
+        <div><picture><img src="https://example.com/g4.png" alt="g4" /></picture></div>
+        <div><picture><img src="https://example.com/g5.png" alt="g5" /></picture></div>
+      </div>
+      <div>
+        <div><picture><img src="https://example.com/g6.png" alt="g6" /></picture></div>
+        <div><picture><img src="https://example.com/g7.png" alt="g7" /></picture></div>
+        <div><picture><img src="https://example.com/g8.png" alt="g8" /></picture></div>
+        <div><picture><img src="https://example.com/g9.png" alt="g9" /></picture></div>
+        <div><picture><img src="https://example.com/g10.png" alt="g10" /></picture></div>
+      </div>
+      <div>
+        <div>
+          <h2>Featured cards | Adobe Express Cards</h2>
+          <p>Browse our collection.</p>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow One</p>
+          <h3>Slide One Heading</h3>
+          <p><a href="https://www.adobe.com/slide1">Slide one | Adobe Creative Cloud</a></p>
+        </div>
+        <div><picture><img src="https://example.com/s1.png" alt="s1" /></picture></div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow Two</p>
+          <h3>Slide Two Heading</h3>
+          <p><a href="https://www.adobe.com/slide2" data-modal-hash="#slide2-modal" data-modal-path="/modals/slide2">Slide two</a></p>
+        </div>
+        <div><picture><img src="https://example.com/s2.png" alt="s2" /></picture></div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow Three</p>
+          <h3>Slide Three Heading</h3>
+          <p><a href="https://www.adobe.com/slide3">Slide three</a></p>
+        </div>
+        <div><video data-video-source="https://example.com/slide3.mp4" controls></video></div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow Four</p>
+          <h3>Slide Four Heading</h3>
+          <p><a href="https://www.adobe.com/slide4">Slide four</a></p>
+        </div>
+        <div><picture><img src="https://example.com/s4.png" alt="s4" /></picture></div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/hub-hero/mocks/fallbacks.html
+++ b/test/blocks/hub-hero/mocks/fallbacks.html
@@ -1,0 +1,61 @@
+<main>
+  <div class="section">
+    <div class="hub-hero">
+      <div>
+        <div>
+          <h1>Design without limits</h1>
+          <p><a href="https://www.adobe.com/get"><img src="https://example.com/cta-icon.png" alt="cta" />Get started</a></p>
+        </div>
+      </div>
+      <div>
+        <div><picture><img src="https://example.com/g1.png" alt="g1" /></picture></div>
+        <div><picture><img src="https://example.com/g2.png" alt="g2" /></picture></div>
+        <div><picture><img src="https://example.com/g3.png" alt="g3" /></picture></div>
+        <div><picture><img src="https://example.com/g4.png" alt="g4" /></picture></div>
+        <div><picture><img src="https://example.com/g5.png" alt="g5" /></picture></div>
+      </div>
+      <div>
+        <div><picture><img src="https://example.com/g6.png" alt="g6" /></picture></div>
+        <div><picture><img src="https://example.com/g7.png" alt="g7" /></picture></div>
+        <div><picture><img src="https://example.com/g8.png" alt="g8" /></picture></div>
+        <div><picture><img src="https://example.com/g9.png" alt="g9" /></picture></div>
+        <div><picture><img src="https://example.com/g10.png" alt="g10" /></picture></div>
+      </div>
+      <div>
+        <div><h2>Cards</h2></div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow One</p>
+          <h3>Slide One Heading</h3>
+          <p><a href="https://www.adobe.com/slide1">Slide one</a></p>
+        </div>
+        <div><picture><img src="https://example.com/s1.png" alt="s1" /></picture></div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow Two</p>
+          <h3>Slide Two Heading</h3>
+          <p><a href="https://www.adobe.com/slide2">Slide two</a></p>
+        </div>
+        <div><picture><img src="https://example.com/s2.png" alt="s2" /></picture></div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow Three</p>
+          <h3>Slide Three Heading</h3>
+          <p><a href="https://www.adobe.com/slide3">Slide three</a></p>
+        </div>
+        <div><picture><img src="https://example.com/s3.png" alt="s3" /></picture></div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow Four</p>
+          <h3>Slide Four Heading</h3>
+          <p><a href="https://www.adobe.com/slide4">Slide four</a></p>
+        </div>
+        <div><picture><img src="https://example.com/s4.png" alt="s4" /></picture></div>
+      </div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
## Summary
Adds unit tests for the c2 Milo block `hub-hero` (`libs/c2/blocks/hub-hero/hub-hero.js`). This is test-only; nothing under `libs/` was changed. 15 tests across two mocks cover the deterministic DOM decoration performed by `init(el)`:

- Block is rebuilt into three children in order: `.hub-hero-header`, `.hub-hero-image-grid-container`, `.hub-hero-carousel`.
- Hero header CTA is decorated into an `a.promo-cta` with the arrow icon and image, using the text after `|` as the `aria-label` (alias) and falling back to the CTA text when no alias is authored.
- Image grid builds 5 columns and clones the media of authored slides 2 and 4 into columns 2 and 4.
- Carousel exposes `aria-roledescription="carousel"` and an `aria-label` taken from the first slide link name, falling back to `Adobe Cards` when unnamed; the carousel header is prepended.
- Per-slide decoration: 4 authored slides + 1 injected placeholder; continuous `data-index` (1-4) skipping the placeholder; header/media/footer containers with the add icon; `aria-labelledby` wired to generated eyebrow/heading ids; `daa-ll` tracking label.
- Opposite/negative branches: modal link slide (`role="button"` + `data-modal-hash`/`data-modal-path`) vs standard link slide (`role="link"`, no modal data); video asset slide (`preload=none`, `muted`, `tabindex=-1`, no `controls`, `<source type=video/mp4>`) vs picture asset slide.

## Scope
Only the deterministic DOM decoration is asserted. Intentionally NOT asserted, because they are driven by runtime environment/behavior rather than initial decoration: IntersectionObserver-based mobile autoplay/rewind, `MutationObserver` cleanup, `requestAnimationFrame`-based slide offset measurement (`setCarouselSlideOffsets`), `matchMedia` mobile checks, hover/focus/mouseleave/wheel/scroll event handlers, video playback and rewind timers, `AbortController`-based preload upgrade, and analytics `sendAnalytics` calls. `init` is still executed in every test and must run without throwing. The block has no empty/no-rows early return, so no such no-op case exists to assert.

Resolves: https://jira.corp.adobe.com/browse/MWPW-202193

## Test plan
- [x] `npx wtr --config ./web-test-runner.config.mjs "./test/blocks/hub-hero/hub-hero.test.js" --node-resolve --port=2091` — 15/15 passing
- [x] `npx eslint test/blocks/hub-hero/hub-hero.test.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

