### PR TITLE
MWPW-202595: reuse page commerce service in mas-preview

### DIFF
--- a/libs/blocks/mas-preview/mas-preview.js
+++ b/libs/blocks/mas-preview/mas-preview.js
@@ -1,5 +1,5 @@
-import { createTag, decorateAutoBlock, loadBlock, getConfig } from '../../utils/utils.js';
-import { GeoMap, MAS_MERCH_CARD, MAS_MERCH_CARD_COLLECTION, getCheckoutAction } from '../merch/merch.js';
+import { createTag, decorateAutoBlock, loadBlock } from '../../utils/utils.js';
+import { GeoMap, MAS_MERCH_CARD, MAS_MERCH_CARD_COLLECTION, getCheckoutAction, initService } from '../merch/merch.js';
 
 const DEFAULT_LOCALE = 'en_US';
 const TAG_MAS_COM_SERVICE = 'mas-commerce-service';
@@ -15,18 +15,13 @@ function registerCheckoutAction() {
   }
 }
 
-function createMasCommerceService(selectLocale, selectCountry) {
-  const { commerce } = getConfig();
-  document.head.querySelector(TAG_MAS_COM_SERVICE)?.remove();
+async function createMasCommerceService(selectLocale, selectCountry) {
   const localeArray = selectLocale.value.split('_');
-  const attrs = {
+  await initService(true, {
     locale: selectLocale.value,
     country: selectCountry.value || localeArray[1],
     language: localeArray[0],
-    ...commerce,
-  };
-  const service = createTag(TAG_MAS_COM_SERVICE, attrs);
-  document.head.append(service);
+  });
   registerCheckoutAction();
 }
 
@@ -118,7 +113,7 @@ export default async function init(el) {
 
   selectLocale.value = url.searchParams.get(LOCALE) || DEFAULT_LOCALE;
   if (selectLocale.value !== DEFAULT_LOCALE || selectCountry.value) {
-    createMasCommerceService(selectLocale, selectCountry);
+    await createMasCommerceService(selectLocale, selectCountry);
   }
 
   const btnCopy = createTag('button', { type: 'button' }, 'Copy URL');
@@ -129,10 +124,10 @@ export default async function init(el) {
     preview(divPreview, selectType, selectLocale, selectCountry, fragmentIdEl, btnPreview, true);
   });
   selectLocale.addEventListener('change', async () => {
-    createMasCommerceService(selectLocale, selectCountry);
+    await createMasCommerceService(selectLocale, selectCountry);
   });
   selectCountry.addEventListener('change', async () => {
-    createMasCommerceService(selectLocale, selectCountry);
+    await createMasCommerceService(selectLocale, selectCountry);
   });
   btnCopy.addEventListener('click', async () => {
     await navigator.clipboard.writeText(window.location.href.split('#')[0]);

--- a/libs/blocks/mas-preview/mas-preview.js
+++ b/libs/blocks/mas-preview/mas-preview.js
@@ -1,29 +1,11 @@
 import { createTag, decorateAutoBlock, loadBlock } from '../../utils/utils.js';
-import { GeoMap, MAS_MERCH_CARD, MAS_MERCH_CARD_COLLECTION, getCheckoutAction, initService } from '../merch/merch.js';
+import { GeoMap, MAS_MERCH_CARD, MAS_MERCH_CARD_COLLECTION, initService } from '../merch/merch.js';
 
 const DEFAULT_LOCALE = 'en_US';
-const TAG_MAS_COM_SERVICE = 'mas-commerce-service';
 const FRAGMENT_ID = 'fragment-id';
 const CONTENT_TYPE = 'content-type';
 const LOCALE = 'locale';
 const COUNTRY = 'country';
-
-function registerCheckoutAction() {
-  const service = document.head.querySelector(TAG_MAS_COM_SERVICE);
-  if (typeof service?.registerCheckoutAction === 'function') {
-    service.registerCheckoutAction(getCheckoutAction);
-  }
-}
-
-async function createMasCommerceService(selectLocale, selectCountry) {
-  const localeArray = selectLocale.value.split('_');
-  await initService(true, {
-    locale: selectLocale.value,
-    country: selectCountry.value || localeArray[1],
-    language: localeArray[0],
-  });
-  registerCheckoutAction();
-}
 
 const MODEL_IDS = {
   L2NvbmYvbWFzL3NldHRpbmdzL2RhbS9jZm0vbW9kZWxzL2NvbGxlY3Rpb24: MAS_MERCH_CARD_COLLECTION,
@@ -33,7 +15,7 @@ const MODEL_IDS = {
 async function preview(divPreview, selectType, selectLoc, selectCo, fragmentEl, btn, deeplink) {
   divPreview.innerHTML = '';
 
-  registerCheckoutAction();
+  await initService();
 
   fetch(`https://odinpreview.corp.adobe.com/adobe/contentFragments/${fragmentEl.value}`)
     // eslint-disable-next-line consistent-return
@@ -112,9 +94,6 @@ export default async function init(el) {
   localeArray.forEach((value) => selectLocale.appendChild(createTag('option', { value }, value)));
 
   selectLocale.value = url.searchParams.get(LOCALE) || DEFAULT_LOCALE;
-  if (selectLocale.value !== DEFAULT_LOCALE || selectCountry.value) {
-    await createMasCommerceService(selectLocale, selectCountry);
-  }
 
   const btnCopy = createTag('button', { type: 'button' }, 'Copy URL');
   const btnPreview = createTag('button', { type: 'button' }, 'Preview');
@@ -122,12 +101,6 @@ export default async function init(el) {
   btnPreview.addEventListener('click', () => {
     divPreview.classList.add('hidden');
     preview(divPreview, selectType, selectLocale, selectCountry, fragmentIdEl, btnPreview, true);
-  });
-  selectLocale.addEventListener('change', async () => {
-    await createMasCommerceService(selectLocale, selectCountry);
-  });
-  selectCountry.addEventListener('change', async () => {
-    await createMasCommerceService(selectLocale, selectCountry);
   });
   btnCopy.addEventListener('click', async () => {
     await navigator.clipboard.writeText(window.location.href.split('#')[0]);


### PR DESCRIPTION
* Fix `mas-preview` making a duplicate, failing price request

The `mas-preview` block created its own `mas-commerce-service` (via `createMasCommerceService`) without the `allow-override` attribute. As a result the `commerce.env` URL override was ignored and the preview request always targeted **production**. On markets with no prod offer (e.g. Israel) that request fails (CORS/404) while the page's stage service still succeeds — two competing requests, one broken.

Fix: `mas-preview` no longer constructs a commerce service. The merch autoblock's `initService()` is the single owner of the page's service (`allow-override`, correct env, checkout action), so `preview()` simply `await`s it. Dropping the locale/country seeding removes the duplicate service entirely, so a single price request is made on the page environment.

Resolves: [MWPW-202595](https://jira.corp.adobe.com/browse/MWPW-202595)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ilyas/israel-fragment-tests?akamaiLocale=IL&commerce.env=stage
- After: https://MWPW-202595--milo--adobecom.aem.page/drafts/ilyas/israel-fragment-tests?akamaiLocale=IL&commerce.env=stage

Open DevTools → Network, filter `web_commerce`, reload: expect a single request on **stage**, no failing prod request.



