### PR TITLE
 MWPW-202632 [MEP] ACE1225 Ps "Start for Free" freemium test — upload-marquee via useBlockCode

### DIFF
--- a/libs/mep/ace1225/upload-marquee/upload-marquee.css
+++ b/libs/mep/ace1225/upload-marquee/upload-marquee.css
@@ -1,0 +1,520 @@
+/*
+ * ace1225 ONLY — temporary MEP test code, NOT suitable for rollout/production.
+ * Forked from da-cc creativecloud/blocks/upload-marquee and delivered via MEP
+ * useBlockCode; hardcoded to this test's design (layout, fixed sizes, dashed dropzone).
+ * Delete during the RTP process — see libs/mep/readme.md.
+ */
+
+/* stylelint-disable no-descending-specificity */
+
+/* ===== BASE / TOKENS ===== */
+.upload-marquee-block {
+  --um-white: #fff;
+  --um-heading-text: #f2f2f2;
+  --um-body-muted: #dbdbdb;
+  --um-accent: #5681ff;
+  --um-accent-focus: #7f96ff;
+  --um-accent-strong: #3b63fb;
+  --um-hover-bg: #0f1c52;
+  --um-radius-sm: 8px;
+  --um-radius-md: 20px;
+  --um-radius-pill: 999px;
+  --um-shadow-media: 0 2px 12px rgb(0 0 0 / 8%);
+  --um-shadow-layout: 0 4px 24px rgb(0 0 0 / 12%);
+  --um-text-shadow: 0 4px 39px rgb(0 0 0 / 25%);
+  --um-drop-zone-border: 1px dashed rgb(255 255 255 / 50%);
+  --um-cta-border: 2px solid var(--um-white);
+  --um-button-font-size: 19px;
+
+  position: relative;
+  overflow: hidden;
+}
+
+.upload-marquee-block .hide { display: none; }
+
+/* ===== BUTTON ===== */
+.upload-marquee-block .upload-action-container {
+  margin: 0 auto;
+}
+
+.upload-marquee-block .action-button {
+  font-family: var(--body-font-family);
+  border-radius: var(--um-radius-pill);
+  border: 0;
+  background: var(--um-accent-strong);
+  color: var(--um-white);
+  cursor: pointer;
+  gap: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 24px 14px;
+  font-size: var(--um-button-font-size);
+  font-weight: 700;
+  line-height: 24px;
+  text-decoration: none;
+}
+
+.upload-marquee-block .action-button > picture {
+  margin-inline-end: 0;
+}
+
+.upload-marquee-block .action-button > picture,
+.upload-marquee-block .action-button > picture > img {
+  width: 24px;
+  height: 24px;
+}
+
+.upload-marquee-block .action-button .icon-upload-to-cloud-outline svg {
+  height: 1.3em;
+  width: 1.3em;
+  line-height: 0;
+}
+
+.upload-marquee-block .action-button:focus-visible {
+  background: var(--um-accent-strong);
+  color: var(--um-white);
+  text-decoration: none;
+}
+
+/* ===== LAYOUT =====
+   ace1225: card wraps media + widget at every breakpoint. Mobile/tablet stack vertically
+   (widget on top, media on the bottom); desktop is two columns (media left, widget right). */
+.upload-marquee-block .upload-marquee-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin: 0 var(--grid-margins-width) 40px;
+  padding: 8px;
+  background: rgb(255 255 255 / 10%);
+  border-radius: 18px;
+  overflow: hidden;
+}
+
+.upload-marquee-block .upload-marquee-left {
+  background: transparent;
+  color: var(--um-white);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0;
+}
+
+.upload-marquee-block .upload-marquee-right {
+  order: 1; /* media below the widget when stacked */
+  height: auto;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.upload-marquee-block .upload-marquee-media {
+  width: 100%;
+  max-width: 910px;
+  align-self: center;
+}
+
+.upload-marquee-block .upload-marquee-right .media-container {
+  height: 100%;
+  width: 100%;
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: var(--um-shadow-media);
+}
+
+.upload-marquee-block .upload-marquee-right .media-container .video-container {
+  width: 100%;
+  height: 100%;
+}
+
+.upload-marquee-block .upload-marquee-uploads > .tablet-up,
+.upload-marquee-block .upload-marquee-uploads > .tablet-up.desktop-up,
+.upload-marquee-block .upload-marquee-uploads > .desktop-up,
+.upload-marquee-block .upload-marquee-media > .tablet-up,
+.upload-marquee-block .upload-marquee-media > .tablet-up.desktop-up,
+.upload-marquee-block .upload-marquee-media > .desktop-up {
+  display: none;
+}
+
+/* ===== CONTENT (ace1225: centered hero above the card) ===== */
+.upload-marquee-block .upload-marquee-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  max-width: var(--grid-container-width);
+  margin: 0 auto;
+  padding: 48px var(--grid-margins-width) 24px;
+}
+
+.upload-marquee-block .upload-marquee-content p,
+.upload-marquee-block .upload-marquee-content h1,
+.upload-marquee-block .upload-marquee-content h2 {
+  color: inherit;
+  margin: 0;
+  text-align: center;
+}
+
+.upload-marquee-block .upload-marquee-content p:first-child {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+  margin-bottom: 12px;
+}
+
+.upload-marquee-block .upload-marquee-content .upload-marquee-branding {
+  margin-bottom: 20px;
+  padding-bottom: 0;
+}
+
+.upload-marquee-block .upload-marquee-content .upload-marquee-branding-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.upload-marquee-block .upload-marquee-content .upload-marquee-branding-first picture,
+.upload-marquee-block .upload-marquee-content .upload-marquee-branding-second picture {
+  display: block;
+}
+
+.upload-marquee-block .upload-marquee-content .upload-marquee-branding-first img,
+.upload-marquee-block .upload-marquee-content .upload-marquee-branding-second img {
+  width: auto;
+  height: 30px;
+  display: block;
+  object-fit: contain;
+}
+
+.upload-marquee-block .upload-marquee-content p:first-child picture,
+.upload-marquee-block .upload-marquee-content p:first-child img {
+  height: 26px;
+  display: block;
+}
+
+.upload-marquee-block .upload-marquee-content > *:first-child > picture img,
+.upload-marquee-block .upload-marquee-content > *:first-child > picture svg {
+  width: auto;
+  height: 100%;
+  object-fit: contain;
+  border-radius: inherit;
+}
+
+.upload-marquee-block .upload-marquee-content p.upload-marquee-branding .upload-marquee-branding-second picture {
+  height: 15.5px;
+  margin-top: 2.75px;
+}
+
+.upload-marquee-block .upload-marquee-content p.upload-marquee-branding .upload-marquee-branding-second img {
+  height: 15.5px;
+}
+
+.upload-marquee-block .upload-marquee-content a {
+  color: var(--um-white);
+}
+
+.upload-marquee-block .upload-marquee-content .upload-marquee-cta {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 9px 18px 10px;
+  background: transparent;
+  color: var(--um-white);
+  border: var(--um-cta-border);
+  border-radius: var(--um-radius-pill);
+  box-sizing: border-box;
+  font-size: 21px;
+  font-weight: 700;
+  line-height: 21px;
+  text-decoration: none;
+  transition: border-color 0.2s ease;
+}
+
+.upload-marquee-block .upload-marquee-content h1 {
+  color: var(--um-white);
+  text-shadow: var(--um-text-shadow);
+  font-family: var(--body-font-family);
+  font-size: 40px;
+  font-style: normal;
+  font-weight: 800;
+  line-height: 125%;
+  letter-spacing: -1.8px;
+  margin-bottom: 16px;
+}
+
+:root:lang(en) .upload-marquee-block .upload-marquee-content h1 {
+  line-height: 98%;
+}
+
+.upload-marquee-block .upload-marquee-content p {
+  color: var(--um-white);
+  text-shadow: var(--um-text-shadow);
+  font-family: var(--body-font-family);
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 136%;
+  letter-spacing: var(--letter-spacing, 0);
+  margin-bottom: 16px;
+}
+
+.upload-marquee-block .upload-marquee-content .upload-marquee-dropzone-label {
+  font-size: 16px;
+  line-height: 150%;
+  margin-top: 24px;
+  margin-bottom: 8px;
+  text-shadow: none;
+}
+
+/* ===== PROMPT VARIANT ===== */
+.upload-marquee-block .upload-marquee-left.copy {
+  justify-content: center;
+}
+
+.upload-marquee-block.unity-prompt {
+  overflow: visible;
+}
+
+.upload-marquee-block.unity-prompt .upload-marquee-layout {
+  overflow: visible;
+}
+
+/* ===== DROP ZONE ===== */
+.upload-marquee-block .drop-zone-container {
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  margin: 0;
+  max-width: none;
+  text-align: center;
+}
+
+.upload-marquee-block .drop-zone {
+  border-radius: var(--um-radius-sm);
+  padding: 34px 24px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  box-sizing: border-box;
+  background-color: inherit;
+  border: 1px dashed #fff;
+
+  /* dotted texture inside the dropzone (all breakpoints) to match the Figma */
+  background-image: radial-gradient(circle, rgb(255 255 255 / 18%) 1px, transparent 1px);
+  background-size: 26px 26px;
+}
+
+.upload-marquee-block .upload-marquee-left:has(.upload-marquee-dropzone-label) .drop-zone {
+  margin-top: 0;
+}
+
+.upload-marquee-block .drop-zone:hover,
+.upload-marquee-block .drop-zone.active {
+  background-image: none;
+  cursor: pointer;
+  border: 2px solid var(--um-accent);
+  background-color: var(--um-hover-bg);
+}
+
+.upload-marquee-block .drop-zone:focus-visible {
+  outline: 2px solid var(--um-accent-focus);
+  outline-offset: 2px;
+  border-color: var(--um-accent);
+}
+
+.upload-marquee-block .upload-marquee-layout .upload-marquee-left .drop-zone > p:first-child {
+  color: var(--um-white);
+  margin: 0;
+  text-align: center;
+}
+
+.upload-marquee-block .upload-marquee-layout .upload-marquee-left .drop-zone > p:first-child img,
+.upload-marquee-block .upload-marquee-layout .upload-marquee-left .drop-zone > p:first-child svg {
+  display: block;
+  margin: 0 auto;
+  width: 40px;
+  height: 40px;
+  opacity: 0.9;
+}
+
+.upload-marquee-block .drop-zone .upload-action-container {
+  margin: 4px 0 2px;
+}
+
+.upload-marquee-block .upload-marquee-layout .upload-marquee-left .drop-zone-container > p:last-child {
+  font-size: var(--type-body-xs-size);
+  line-height: var(--type-body-xs-lh);
+  margin: 16px auto 0;
+  max-width: 347px;
+  color: var(--um-white);
+  text-align: center;
+}
+
+.upload-marquee-block .upload-marquee-layout .upload-marquee-left .drop-zone > p:not(:first-child):not(:last-child):not(.upload-action-container) {
+  color: var(--um-white);
+  margin: 0;
+  text-align: center;
+  line-height: 1.4;
+}
+
+.upload-marquee-block .drop-zone > .drop-zone-heading {
+  color: var(--um-heading-text);
+  font-size: 17px; /* mobile/tablet; desktop bumps to 22px */
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: 0;
+  margin: 0 auto;
+  max-width: 380px;
+  text-align: center;
+}
+
+.upload-marquee-block .upload-marquee-layout .upload-marquee-left .drop-zone > .drop-zone-body {
+  color: var(--um-body-muted);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  max-width: 380px;
+  margin: 0;
+  text-align: center;
+}
+
+.upload-marquee-block .upload-marquee-layout .upload-marquee-left .drop-zone-container > p:last-child a {
+  color: var(--um-white);
+  text-decoration: underline;
+}
+
+/* ===== MEDIA ASSETS ===== */
+.upload-marquee-block .foreground .upload-marquee-layout .upload-marquee-right .media-container picture,
+.upload-marquee-block .foreground .upload-marquee-layout .upload-marquee-right .media-container picture > img,
+.upload-marquee-block .foreground .upload-marquee-layout .upload-marquee-right .media-container video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  line-height: 0;
+}
+
+/* ===== RESPONSIVE ===== */
+@media screen and (max-width: 350px) {
+  .upload-marquee-block {
+    --um-button-font-size: 16px;
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .upload-marquee-block .upload-marquee-right .media-container {
+    border-radius: 10px;
+  }
+
+  .upload-marquee-block .upload-marquee-left {
+    margin: 48px var(--grid-margins-width) 0;
+  }
+
+  .upload-marquee-block .upload-marquee-uploads > .tablet-up,
+  .upload-marquee-block .upload-marquee-uploads > .tablet-up.desktop-up,
+  .upload-marquee-block .upload-marquee-media > .tablet-up,
+  .upload-marquee-block .upload-marquee-media > .tablet-up.desktop-up {
+    display: block;
+  }
+
+  .upload-marquee-block .upload-marquee-uploads > .mobile-up,
+  .upload-marquee-block .upload-marquee-uploads > .desktop-up,
+  .upload-marquee-block .upload-marquee-media > .mobile-up,
+  .upload-marquee-block .upload-marquee-media > .desktop-up {
+    display: none;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .upload-marquee-block .drop-zone { 
+    margin: 16px 4px 0 0;
+    padding: 34px 24px 0;
+  } 
+
+  .upload-marquee-block .upload-marquee-layout .upload-marquee-left .drop-zone > p:first-child {
+    font-size: 22px;
+    font-weight: 700;
+    margin: 8px 0 16px;
+  }
+
+  .upload-marquee-block .upload-marquee-layout .upload-marquee-left .drop-zone > p:last-child {
+    margin-top: 0;
+  }
+
+  .upload-marquee-block .upload-marquee-layout .upload-marquee-left .upload-marquee-content h1 {
+    font-size: 64px;
+    letter-spacing: -2.88px;
+  }
+
+  .upload-marquee-block .upload-marquee-left {
+    margin: 0;
+    box-sizing: border-box;
+    justify-content: center;
+  }
+
+  /* ace1225: the grid IS the rounded card wrapping media (left) + widget (right) */
+  .upload-marquee-block .upload-marquee-layout {
+    grid-template-columns: 500fr 461fr; /* Figma: media 500 / widget 461 */
+    grid-template-rows: 1fr;
+    gap: 16px;
+    max-width: 1000px;
+    margin: 0 auto 40px;
+    padding: 14px;
+    background: rgb(255 255 255 / 10%);
+    border-radius: 20px;
+    overflow: hidden;
+  }
+
+  .upload-marquee-block .upload-marquee-right {
+    order: 0; /* media back to the left column on desktop */
+    min-height: auto;
+    height: 100%;
+    align-self: stretch; /* media fills the card height so there's no gap below it */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  .upload-marquee-block .upload-marquee-media {
+    height: 100%;
+    width: 100%;
+  }
+
+  .upload-marquee-block .upload-marquee-right .media-container {
+    width: 100%;
+    max-height: 100%;
+  }
+
+  .upload-marquee-block .upload-marquee-uploads > .desktop-up,
+  .upload-marquee-block .upload-marquee-uploads > .tablet-up.desktop-up,
+  .upload-marquee-block .upload-marquee-media > .desktop-up,
+  .upload-marquee-block .upload-marquee-media > .tablet-up.desktop-up {
+    display: block;
+  }
+
+  .upload-marquee-block .upload-marquee-uploads > .mobile-up,
+  .upload-marquee-block .upload-marquee-uploads > .tablet-up,
+  .upload-marquee-block .upload-marquee-media > .mobile-up,
+  .upload-marquee-block .upload-marquee-media > .tablet-up {
+    display: none;
+  }
+
+  .upload-marquee-block .upload-marquee-right .media-container .video-container .pause-play-wrapper {
+    bottom: 2%;
+    top: auto;
+    inset-inline-end: 2%;
+    inset-inline-start: auto;
+  }
+}

--- a/libs/mep/ace1225/upload-marquee/upload-marquee.js
+++ b/libs/mep/ace1225/upload-marquee/upload-marquee.js
@@ -1,0 +1,536 @@
+/*
+ * ace1225 ONLY — temporary MEP test code, NOT suitable for rollout.
+ * Forked from da-cc `creativecloud/blocks/upload-marquee` and delivered via MEP
+ * `useBlockCode`; hardcoded to this test's design (layout, fixed sizes, video handling).
+ * Delete during the RTP process — see `libs/mep/readme.md`.
+ */
+import { createTag, getConfig } from '../../../utils/utils.js';
+
+const VIEWPORTS = ['mobile-up', 'tablet-up', 'desktop-up'];
+const AnalyticsKeys = {
+  uploadAssetCTA: 'Upload asset CTA|UnityWidget',
+  editPhotosCTA: 'Edit Photos CTA|UnityWidget',
+};
+let uploadColumnCounter = 0;
+const LCP_IMAGE_PARAMS = {
+  webpLarge: 'width=1000&format=webply&optimize=medium',
+  webpSmall: 'width=500&format=webply&optimize=medium',
+  jpgLarge: 'width=1000&format=jpg&optimize=medium',
+  jpgSmall: 'width=500&format=jpg&optimize=medium',
+};
+
+// Inlined from da-cc creativecloud/scripts/utils.js (not exported by milo utils).
+function getScreenSizeCategory(overridenBreakpoints) {
+  const DEFAULT_BREAKPOINTS = { mobile: 599, tablet: 899 };
+  const { mobile, tablet } = { ...DEFAULT_BREAKPOINTS, ...overridenBreakpoints };
+  const MEDIA_QUERIES = {
+    mobile: window.matchMedia(`(max-width: ${mobile}px)`),
+    tablet: window.matchMedia(`(min-width: ${mobile + 1}px) and (max-width: ${tablet}px)`),
+    desktop: window.matchMedia(`(min-width: ${tablet + 1}px)`),
+  };
+  if (MEDIA_QUERIES.mobile.matches) return 'mobile';
+  if (MEDIA_QUERIES.tablet.matches) return 'tablet';
+  return 'desktop';
+}
+
+function getBaseImageUrlFromPicture(picture) {
+  if (!picture) return null;
+  const img = picture.querySelector('img');
+  const imgSrc = img?.src;
+  if (imgSrc) {
+    return { baseUrl: imgSrc.split('?')[0], img };
+  }
+  const srcset = picture.querySelector('source[srcset]')?.srcset;
+  if (!srcset) return null;
+  const url = srcset.split(',')[0].trim().split(/\s+/)[0];
+  const baseUrl = url ? url.split('?')[0] : null;
+  return baseUrl && img ? { baseUrl, img } : null;
+}
+
+function rewritePictureToOurSizes(picture) {
+  const result = getBaseImageUrlFromPicture(picture);
+  if (!result?.baseUrl || !result.img) return null;
+  const { baseUrl, img } = result;
+  picture.textContent = '';
+  picture.append(
+    createTag('source', {
+      type: 'image/webp',
+      srcset: `${baseUrl}?${LCP_IMAGE_PARAMS.webpLarge}`,
+      media: '(min-width: 600px)',
+    }),
+    createTag('source', {
+      type: 'image/webp',
+      srcset: `${baseUrl}?${LCP_IMAGE_PARAMS.webpSmall}`,
+    }),
+    createTag('source', {
+      type: 'image/jpeg',
+      srcset: `${baseUrl}?${LCP_IMAGE_PARAMS.jpgLarge}`,
+      media: '(min-width: 600px)',
+    }),
+  );
+  img.setAttribute('src', `${baseUrl}?${LCP_IMAGE_PARAMS.jpgSmall}`);
+  img.removeAttribute('loading');
+  img.removeAttribute('fetchpriority');
+  picture.append(img);
+  return img;
+}
+
+function rewriteVideoPosterToOurSizes(video, columnIndex) {
+  const poster = video.getAttribute('poster');
+  if (!poster || poster.startsWith('data:') || poster.startsWith('blob:')) return;
+  const baseUrl = poster.trim().split('?')[0];
+  if (!baseUrl) return;
+  const params = columnIndex === 0
+    ? LCP_IMAGE_PARAMS.webpSmall
+    : LCP_IMAGE_PARAMS.webpLarge;
+  video.setAttribute('poster', `${baseUrl}?${params}`);
+}
+
+function setUploadRowMediaPriority(uploadRow) {
+  const screenCategory = getScreenSizeCategory({ mobile: 599, tablet: 1199 });
+  const activeColumnIndex = { mobile: 0, tablet: 1, desktop: 2 }[screenCategory];
+  [...uploadRow.children].forEach((column, index) => {
+    const isActive = index === activeColumnIndex;
+    const firstPara = column.querySelector('p');
+    const mediaPicture = firstPara?.querySelector('picture');
+    if (mediaPicture) {
+      const img = rewritePictureToOurSizes(mediaPicture);
+      if (img) {
+        img.setAttribute('loading', isActive ? 'eager' : 'lazy');
+        if (isActive) img.setAttribute('fetchpriority', 'high');
+      }
+    }
+    const video = column.querySelector('video');
+    if (video) {
+      rewriteVideoPosterToOurSizes(video, index);
+      video.setAttribute('preload', isActive ? 'auto' : 'none');
+    }
+  });
+}
+
+function logUploadMarqueeInfo(message, errorType = 'i') {
+  window.lana?.log(message, { tags: 'upload-marquee', errorType, severity: 'error' });
+}
+
+function nextUploadColumnId() {
+  uploadColumnCounter += 1;
+  return uploadColumnCounter;
+}
+
+function buildScopedId(prefix, columnId) {
+  return `${prefix}-${columnId}`;
+}
+
+function extractUploadContentParts(content) {
+  const media = content.querySelector('picture, .video-container.video-holder');
+  const terms = content.querySelector('p:last-child');
+  const mediaPara = media?.closest('p');
+  const hasUploadMarker = (para) => para.querySelector(
+    'span[class*=icon-share], span[class*=icon-upload], img[src$=".svg"]:not(.video-container img)',
+  );
+  const candidateParagraphs = [
+    ...content.querySelectorAll('p:not(:last-child)'),
+  ].filter(
+    (para) => para.textContent.trim() !== '' || para.querySelector('img, svg'),
+  );
+  const uploadPara = candidateParagraphs.find((para) => hasUploadMarker(para));
+  const contentParagraphs = candidateParagraphs.filter((para) => {
+    const isMediaOnlyPara = para === mediaPara
+      && !hasUploadMarker(para)
+      && para.textContent.trim() === '';
+    return !isMediaOnlyPara;
+  });
+  const textParas = contentParagraphs.filter((para) => para !== uploadPara);
+  const headingPara = textParas[0];
+  const bodyPara = textParas[1];
+  return {
+    media, terms, contentParagraphs, uploadPara, headingPara, bodyPara,
+  };
+}
+
+function applyViewportClasses(foreground) {
+  foreground.firstElementChild?.classList.add('upload-grid');
+  if (
+    foreground.childElementCount === 2
+    || foreground.childElementCount === 3
+  ) {
+    [...foreground.children].forEach((child, index) => {
+      child.classList.add('upload-grid', VIEWPORTS[index]);
+      if (foreground.childElementCount === 2 && index === 1) {
+        child.className = 'upload-grid tablet-up desktop-up';
+      }
+    });
+  } else if (foreground.childElementCount === 1) {
+    foreground.firstElementChild?.classList.add(...VIEWPORTS);
+  }
+  return foreground;
+}
+
+function getViewportClasses(el) {
+  return [...el.classList].filter((cls) => VIEWPORTS.includes(cls));
+}
+
+function assignDropZoneTextIds(headingPara, bodyPara, columnId) {
+  const describedByIds = [];
+  if (headingPara) {
+    headingPara.classList.add('drop-zone-heading');
+    headingPara.id = buildScopedId('drop-zone-heading', columnId);
+    describedByIds.push(headingPara.id);
+  }
+  if (bodyPara) {
+    bodyPara.classList.add('drop-zone-body');
+    bodyPara.id = buildScopedId('drop-zone-body', columnId);
+    describedByIds.push(bodyPara.id);
+  }
+  return describedByIds;
+}
+
+function makeDecorativeMediaNonFocusable(container) {
+  container.querySelectorAll('picture, picture img').forEach((el) => {
+    el.setAttribute('tabindex', '-1');
+    el.setAttribute('role', 'presentation');
+  });
+}
+
+async function buildUploadActionControls(para) {
+  const button = createTag(
+    'a',
+    {
+      tabindex: '0',
+      class: 'con-button blue action-button button-xl no-track',
+      'daa-ll': AnalyticsKeys.uploadAssetCTA,
+    },
+    para.innerHTML,
+  );
+  makeDecorativeMediaNonFocusable(button);
+  const input = createTag('input', {
+    type: 'file',
+    name: 'file-upload',
+    id: 'file-upload',
+    class: 'file-upload hide',
+    accept: 'image/*',
+    'aria-hidden': 'true',
+  });
+  button.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      input.click();
+    }
+  });
+  para.classList.add('upload-action-container');
+  para.textContent = '';
+  para.append(button, input);
+  return { fileInput: input };
+}
+
+function wireDropZoneAccessibility(dropZone, fileInput) {
+  dropZone.setAttribute('tabindex', '-1');
+  dropZone.addEventListener('click', (event) => {
+    event.stopPropagation();
+    fileInput?.click();
+  });
+}
+
+async function buildDropZone(uploadParts, columnId) {
+  const dropZone = createTag('div', { class: 'drop-zone' });
+  const { fileInput } = await buildUploadActionControls(uploadParts.uploadPara);
+  assignDropZoneTextIds(
+    uploadParts.headingPara,
+    uploadParts.bodyPara,
+    columnId,
+  );
+  wireDropZoneAccessibility(dropZone, fileInput);
+  // ace1225: skip the decorative default dropzone icon (not in the design) so we
+  // don't eagerly fetch an unused SVG per viewport cell.
+  dropZone.append(...uploadParts.contentParagraphs);
+  return dropZone;
+}
+
+function replaceUploadColumnContent(content, mediaContainer, dropZoneContainer, terms) {
+  content.textContent = '';
+  content.append(mediaContainer, dropZoneContainer);
+  if (terms) {
+    dropZoneContainer.append(terms);
+  }
+}
+
+function buildMarqueeContent(marqueeCell) {
+  const marqueeContent = createTag('div', { class: 'upload-marquee-content' });
+  [...marqueeCell.children].forEach((child) => marqueeContent.append(child.cloneNode(true)));
+
+  const brandingPara = marqueeContent.querySelector(':scope > p:first-child');
+  const [firstPicture, secondPicture] = brandingPara
+    ? [...brandingPara.querySelectorAll('picture')]
+    : [];
+  if (firstPicture && secondPicture) {
+    const brandingRow = createTag('span', { class: 'upload-marquee-branding-row' });
+    const firstWrap = createTag('span', { class: 'upload-marquee-branding-first' });
+    const secondWrap = createTag('span', { class: 'upload-marquee-branding-second' });
+    firstWrap.append(firstPicture.cloneNode(true));
+    secondWrap.append(secondPicture.cloneNode(true));
+    brandingRow.append(firstWrap, secondWrap);
+    brandingPara.textContent = '';
+    brandingPara.classList.add('upload-marquee-branding');
+    brandingPara.append(brandingRow);
+    brandingRow.querySelectorAll('picture img, img').forEach((img) => {
+      img.setAttribute('loading', 'eager');
+    });
+  }
+  const ctaLink = marqueeContent.querySelector('p strong a[href]');
+  if (ctaLink) {
+    ctaLink.classList.add('con-button', 'upload-marquee-cta', 'no-track');
+    ctaLink.setAttribute('aria-label', ctaLink.textContent.trim());
+    ctaLink.setAttribute('daa-ll', AnalyticsKeys.editPhotosCTA);
+  }
+  const ctaParentPara = ctaLink?.closest('p');
+  const heading = marqueeContent.querySelector(':scope > h1');
+  const descriptionPara = heading?.nextElementSibling?.tagName === 'P'
+    ? heading.nextElementSibling : null;
+  const allParas = [...marqueeContent.querySelectorAll(':scope > p')];
+  const lastPara = allParas[allParas.length - 1];
+  if (
+    lastPara
+    && lastPara !== ctaParentPara
+    && lastPara !== brandingPara
+    && lastPara !== descriptionPara
+    && lastPara.textContent.trim()
+  ) {
+    lastPara.classList.add('upload-marquee-dropzone-label');
+  }
+  return marqueeContent;
+}
+
+function buildLayout() {
+  const layout = createTag('div', { class: 'upload-marquee-layout' });
+  const leftCol = createTag('div', { class: 'upload-marquee-left' });
+  const rightCol = createTag('div', { class: 'upload-marquee-right' });
+  const uploadsWrapper = createTag('div', { class: 'upload-marquee-uploads' });
+  const mediaWrapper = createTag('div', { class: 'upload-marquee-media' });
+  return { layout, leftCol, rightCol, uploadsWrapper, mediaWrapper };
+}
+
+function appendColumns(viewportContent, uploadsWrapper, mediaWrapper) {
+  viewportContent.forEach(({ media, dropZone, viewportClasses }) => {
+    if (dropZone && uploadsWrapper) {
+      dropZone.classList.add(...viewportClasses);
+      uploadsWrapper.append(dropZone);
+    }
+    if (media) {
+      media.classList.add(...viewportClasses);
+      mediaWrapper.append(media);
+    }
+  });
+}
+
+function collectViewportContent(row, extractMedia) {
+  return [...row.children].map((content) => ({
+    media: extractMedia(content),
+    dropZone: content.querySelector(':scope > .drop-zone-container'),
+    viewportClasses: getViewportClasses(content),
+  }));
+}
+
+function extractMediaFromColumn(content) {
+  const media = content.querySelector('picture, .video-container.video-holder');
+  if (!media) return null;
+  const mediaContainer = createTag('div', { class: 'media-container' });
+  mediaContainer.append(media);
+  return mediaContainer;
+}
+
+async function decorateUploadColumn(content) {
+  const columnId = nextUploadColumnId();
+  const mediaContainer = createTag('div', { class: 'media-container' });
+  const dropZoneContainer = createTag('div', { class: 'drop-zone-container' });
+  const uploadParts = extractUploadContentParts(content);
+  if (uploadParts.media) {
+    mediaContainer.append(uploadParts.media);
+    if (
+      uploadParts.media.parentElement?.tagName === 'P'
+      && uploadParts.media.parentElement.textContent.trim() === ''
+    ) {
+      uploadParts.media.parentElement.remove();
+    }
+  }
+  if (!uploadParts.uploadPara) {
+    logUploadMarqueeInfo(
+      'Failed to create upload button for upload-marquee block.',
+    );
+    return;
+  }
+  const dropZone = await buildDropZone(uploadParts, columnId);
+  dropZoneContainer.append(dropZone);
+  replaceUploadColumnContent(
+    content,
+    mediaContainer,
+    dropZoneContainer,
+    uploadParts.terms,
+  );
+}
+
+function setupLayoutDragAndDrop(layout, uploadsWrapper) {
+  let activeDropZone;
+  const setActiveDropZone = () => {
+    const dropZones = [
+      ...uploadsWrapper.querySelectorAll(
+        ':scope > .drop-zone-container > .drop-zone',
+      ),
+    ];
+    const nextDropZone = dropZones.find((zone) => zone.offsetParent !== null) || dropZones[0];
+    if (activeDropZone && activeDropZone !== nextDropZone) {
+      activeDropZone.classList.remove('active');
+    }
+    activeDropZone = nextDropZone;
+    activeDropZone?.classList.add('active');
+  };
+  const clearActiveDropZone = () => {
+    activeDropZone?.classList.remove('active');
+    activeDropZone = null;
+  };
+  layout.addEventListener('dragenter', (event) => {
+    event.preventDefault();
+    setActiveDropZone();
+  });
+  layout.addEventListener('dragover', (event) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+    setActiveDropZone();
+  });
+  layout.addEventListener('dragleave', (event) => {
+    event.preventDefault();
+    clearActiveDropZone();
+  });
+  document.addEventListener('dragend', () => clearActiveDropZone());
+  layout.addEventListener('drop', (event) => {
+    event.preventDefault();
+    setActiveDropZone();
+    const fileInput = activeDropZone?.querySelector('.file-upload');
+    const files = event.dataTransfer?.files;
+    if (files?.length && fileInput) {
+      try {
+        fileInput.files = files;
+      } catch {
+        // TODO: Trigger lana log
+        // Some browsers may not allow assigning FileList directly.
+      }
+      fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+    clearActiveDropZone();
+  });
+  uploadsWrapper.querySelectorAll('.drop-zone').forEach((zone) => {
+    zone.addEventListener('drop', () => {
+      clearActiveDropZone();
+    });
+  });
+  window.addEventListener('drop', () => clearActiveDropZone());
+  window.addEventListener('dragend', () => clearActiveDropZone());
+}
+
+// ace1225: turn an authored mp4 link in a cell into an accessible autoplay video via
+// milo's decorateAnchorVideo. It produces the `.video-container.video-holder` the block
+// already treats as media (so the video lands in the media column, not the dropzone), adds
+// a pause/play control, and lazy-appends the <source> on intersection — so a desktop-only
+// clip never downloads on the hidden mobile/tablet cells.
+function decorateUploadVideos(uploadRow, decorateAnchorVideo) {
+  [...uploadRow.children].forEach((cell) => {
+    const videoLink = cell.querySelector('a[href*=".mp4"]');
+    if (!videoLink) return;
+    const posterImg = cell.querySelector('picture img');
+    const posterSrc = posterImg?.getAttribute('src') || '';
+    if (!videoLink.hash) videoLink.hash = '#autoplay';
+    const src = videoLink.href.split('#')[0];
+    posterImg?.closest('picture')?.remove();
+    // Move the link out of its <p> before decorating: decorateAnchorVideo swaps it for a
+    // block-level <video> wrapper, which browsers fracture/misplace if left inside a <p>.
+    cell.insertBefore(videoLink, cell.firstElementChild);
+    decorateAnchorVideo({ src, anchorTag: videoLink });
+    if (posterSrc) cell.querySelector('video')?.setAttribute('poster', posterSrc);
+  });
+}
+
+function decorateContentRow(row) {
+  row.classList.add('foreground');
+  applyViewportClasses(row);
+  setUploadRowMediaPriority(row);
+}
+
+function mountLayout(el, { layout, leftCol, rightCol }, mediaWrapper) {
+  rightCol.append(mediaWrapper);
+  layout.append(leftCol, rightCol);
+  const foreground = createTag('div', { class: 'foreground' });
+  foreground.append(layout);
+  el.textContent = '';
+  el.append(foreground);
+}
+
+async function initDropzoneVariant(el, uploadRow, layoutParts, marqueeContent) {
+  const { layout, leftCol, rightCol, uploadsWrapper, mediaWrapper } = layoutParts;
+  for (let i = 0; i < uploadRow.children.length; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await decorateUploadColumn(uploadRow.children[i]);
+  }
+  appendColumns(
+    collectViewportContent(uploadRow, (c) => c.querySelector(':scope > .media-container')),
+    uploadsWrapper,
+    mediaWrapper,
+  );
+  if (!uploadsWrapper.children.length || !mediaWrapper.children.length) return;
+  leftCol.append(uploadsWrapper);
+  rightCol.append(mediaWrapper);
+  // ace1225 design: hero copy centered on top; card grid = media (left) + dropzone (right)
+  layout.append(rightCol, leftCol);
+  setupLayoutDragAndDrop(layout, uploadsWrapper);
+  const foreground = createTag('div', { class: 'foreground' });
+  // ace1225: hero copy now lives in a separate block above; only render it here if authored.
+  const hasHeroCopy = marqueeContent
+    && (marqueeContent.textContent.trim() !== '' || marqueeContent.querySelector('picture, img, svg, a'));
+  if (hasHeroCopy) foreground.append(marqueeContent);
+  foreground.append(layout);
+  el.textContent = '';
+  el.append(foreground);
+}
+
+async function initPromptVariant(el, mediaRow, layoutParts) {
+  const { leftCol, mediaWrapper } = layoutParts;
+  // 'copy' class is required by Unity to locate and inject the prompt bar
+  leftCol.classList.add('copy');
+  const promptContainer = createTag('div', { class: 'upload-marquee-prompt-container' });
+  leftCol.append(promptContainer);
+  appendColumns(
+    collectViewportContent(mediaRow, extractMediaFromColumn),
+    null,
+    mediaWrapper,
+  );
+  if (!mediaWrapper.children.length) return;
+  mountLayout(el, layoutParts, mediaWrapper);
+}
+
+export default async function init(el) {
+  const { miloLibs, codeRoot } = getConfig();
+  const base = miloLibs || codeRoot;
+  const { decorateBlockBg, decorateAnchorVideo } = await import(`${base}/utils/decorate.js`);
+  el.classList.add('upload-marquee-block', 'con-block');
+  const rows = [...el.querySelectorAll(':scope > div')];
+  if (!rows.length) return;
+  // Rows: last = upload content; first = background (optional); middle = marquee/hero (optional,
+  // now usually authored in a separate block above, so upload-marquee is often just [bg, content]).
+  const contentRow = rows[rows.length - 1];
+  const backgroundRow = rows.length >= 2 ? rows[0] : null;
+  const marqueeRow = rows.length >= 3 ? rows[1] : null;
+  const isPromptVariant = el.classList.contains('unity-prompt');
+  if (backgroundRow && backgroundRow.textContent.trim() !== '') {
+    backgroundRow.classList.add('background');
+    decorateBlockBg(el, backgroundRow, { useHandleFocalpoint: true });
+  }
+  decorateContentRow(contentRow);
+  decorateUploadVideos(contentRow, decorateAnchorVideo);
+  const layoutParts = buildLayout();
+  const marqueeCell = marqueeRow?.querySelector(':scope > div');
+  const marqueeContent = marqueeCell ? buildMarqueeContent(marqueeCell) : null;
+  if (isPromptVariant) {
+    if (marqueeContent) layoutParts.leftCol.append(marqueeContent);
+    await initPromptVariant(el, contentRow, layoutParts);
+  } else {
+    await initDropzoneVariant(el, contentRow, layoutParts, marqueeContent);
+  }
+}


### PR DESCRIPTION
## Why
  ACE1225 is a MEP A/B test, the Ps **"Start for Free" freemium test**, that adds a new upload-marquee design to the Photoshop/Firefly marketing pages: drop an image on the marquee and it uploads and takes you straight into the Firefly (FFIE) web app. We needed to stand this up quickly for the test **without being able to change the da-cc (creativecloud) or unitylibs repos**, and without a normal block onboarding cycle.

  ## What
  Adds a single test-scoped block under `libs/mep/ace1225/upload-marquee/` (JS + CSS) that MEP serves via **`useBlockCode`** to override da-cc's existing `upload-marquee` block on the test page. `useBlockCode` derives the block name from the last path segment, so the folder must stay named `upload-marquee`.

  **Approach:** we started from the da-cc `creativecloud/blocks/upload-marquee` block, chosen because it already carries the **unity `workflow-upload`** wiring we need for the test flow (`renderWidget:false`, so the visible UI is the block's own markup/CSS and is therefore restylable from milo), then copied it into the milo mep folder and reworked the UI/layout to match the ACE1225 Figma. The unity action hooks (`.drop-zone`, `#file-upload`, the upload CTA) are preserved so unity still binds to them.

  ### Key changes vs. the original creativecloud `upload-marquee`
  - **Import port for milo:** da-cc imports (`getLibs`, `getScreenSizeCategory` from `creativecloud/scripts/utils.js`) swapped for milo's `getConfig`; `decorate.js` is imported dynamically from `miloLibs`/`codeRoot`. `getScreenSizeCategory` is inlined since milo doesn't export an
  equivalent.
  - **New `decorateUploadVideos`:** turns an authored `.mp4` link into an accessible autoplay video via milo's `decorateAnchorVideo`, which produces the `.video-container.video-holder` the block already treats as media (so the clip lands in the media column, not the dropzone), adds a
  pause/play control, applies the authored poster, and lazy-appends the `<source>` on intersection so a desktop-only clip never downloads on the hidden mobile/tablet cells. It also lifts the link out of its `<p>` before decorating (a block-level `<video>` left inside a `<p>` gets
  fractured and misplaced by the browser).
  - **Layout reworked to the ACE1225 Figma:** hero copy moved to a separate block above the marquee (rendered here only if still authored inline); card grid is media-left / dropzone-right; row parsing made lenient (last row = upload content, background/marquee rows optional).
  - **Dropped the decorative default dropzone icon:** not in the design, and it avoids eagerly fetching an unused SVG per viewport cell.
  - **CSS restyled** to the dark Figma card (translucent-white card, dashed dropzone, fixed sizes), plus an accessibility fix: the legal links are white (WCAG AA contrast) with an underline (keeps them distinguishable per 1.4.1).

  ## Nature of this PR (read before reviewing)
  This is an **expedited, test-only** change and is **not an approach we'd roll to production as-is.** The block is a fork hardcoded to this one test (fixed layout/sizes, this test's video handling), lives entirely under `libs/mep/ace1225/`, and is delivered by overriding a da-cc block from milo at runtime via `useBlockCode`. It is **RTP-deletable**: the mep folder is temporary test code (`libs/mep/readme.md`) and should be removed when the test ends. A real productionization would require coordinated work in **both the unitylibs and creativecloud repos** (proper block + widget), not a milo-side override.

  ## Test URLs
  - **Example test page** (branch + MEP manifest, drives the override):
    https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1225/ps-index/z-ace1225-index-new-b?milolibs=mep-ace1225&mep=%2Fproducts%2Fphotoshop.json--desktop---%2Fdrafts%2Fmarkp%2Funity-quick-check.json
  - **PSI check:** https://mep-ace1225--milo--adobecom.aem.page/?martech=off


  ## QA steps
  1. Open the example test page above **in an incognito window** (no sign-in required; the flow works logged-out on preview).
  2. Confirm the marquee renders to the Figma at mobile / tablet / desktop with no console errors.
  3. Drag an image onto the dropzone (or click the upload CTA and pick one).
  4. **Expected:** the image uploads and you're **redirected to the Firefly (FFIE) web app**, and you should **not** see the edit result rendered inline on the marketing page.

  Resolves: [MWPW-202632](https://jira.corp.adobe.com/browse/MWPW-202632)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://<branch>--milo--adobecom.aem.page/?martech=off




