### PR TITLE
MWPW-202659 [MEP] Fix mep-next Sidekick auth on prod (login-button signal)

### DIFF
--- a/libs/features/mep/sidekick-auth.js
+++ b/libs/features/mep/sidekick-auth.js
@@ -1,104 +1,46 @@
 import { getConfig } from '../../utils/utils.js';
 
 /*
- * Detects Sidekick login via the admin API: GET admin.hlx.page/status/… — the
- * extension injects the auth token, and a `profile` in the response means
- * authed. Auth stays orthogonal to the adobe.com session, so logged-out pages
- * can still be previewed.
+ * Detects AEM Sidekick login from the page world. <aem-sidekick> is defined in the
+ * extension's isolated world, so page JS sees no config/status and its status event
+ * fires before we attach. The page-world signal: login-button#user in
+ * plugin-action-bar's shadow is always present and carries `not-authorized` while
+ * signed out. Auth is orthogonal to the adobe.com session (logged-out pages preview).
  */
 
-const ADMIN = 'https://admin.hlx.page';
 const SIDEKICK_SELECTOR = 'aem-sidekick, helix-sidekick';
-const AUTH_EVENTS = ['logged-in', 'logged-out', 'status-fetched'];
+const USER_BUTTON_SELECTOR = 'login-button#user';
+const NOT_AUTHED_CLASS = 'not-authorized';
+// Catch class flips (not-authorized) and node re-renders in the shadow.
+const AUTH_MO = { childList: true, subtree: true, attributes: true, attributeFilter: ['class'] };
+// Stop waiting for the sidekick to mount after this long; never tears down the live
+// auth watcher (it runs for the page's life so logout is always caught).
 const WATCH_TIMEOUT_MS = 5 * 60 * 1000;
-const AUTH_FETCH_TIMEOUT_MS = 5000;
-// Bounded backoff for extra checks while unauthed (never polls) — rides out the
-// extension not having registered its request rules yet.
-const RETRY_DELAYS_MS = [300, 900];
-
-const wait = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+// Head start for the shadow/status to resolve before defaulting to unauthed, so a
+// signed-in author doesn't see a sign-in flash.
+const RESOLVE_DELAY_MS = 1200;
 
 function getSidekick() {
   return document.querySelector(SIDEKICK_SELECTOR);
 }
 
-// On aem.page/live the project is in the host label: {ref}--{repo}--{owner}.
-function projectFromHost() {
-  const { hostname } = window.location;
-  if (!/\.(aem|hlx)\.(page|live|reviews)$/.test(hostname)) return null;
-  const [label] = hostname.split('.');
-  const parts = label.split('--');
-  if (parts.length !== 3) return null;
-  const [ref, repo, owner] = parts;
-  return { owner, repo, ref };
+function getPluginActionBarShadow() {
+  return getSidekick()?.shadowRoot?.querySelector('plugin-action-bar')?.shadowRoot;
 }
 
-// Off aem hosts (adobe.com), the project comes from the Sidekick's public config.
-function projectFromSidekick() {
-  const sk = getSidekick();
-  const cfg = sk?.config || sk?.appStore?.siteStore || sk?.appStore?.status?.config;
-  if (cfg?.owner && cfg?.repo) return { owner: cfg.owner, repo: cfg.repo, ref: cfg.ref || 'main' };
-  return null;
+// Authed iff the always-present user button lacks the not-authorized marker.
+function isAuthedIn(pluginBarShadow) {
+  const user = pluginBarShadow?.querySelector(USER_BUTTON_SELECTOR);
+  return !!user && !user.classList.contains(NOT_AUTHED_CLASS);
 }
 
-function getProject() {
-  return projectFromHost() || projectFromSidekick();
+export function isSidekickAuthed() {
+  return isAuthedIn(getPluginActionBarShadow());
 }
 
-export async function isSidekickAuthed() {
-  const project = getProject();
-  if (!project) return false;
-  const { owner, repo, ref } = project;
-  const path = window.location.pathname || '/';
-  // owner/repo/ref can come from the DOM (Sidekick config) — encode every
-  // segment; the path keeps its slashes but each segment is encoded.
-  const enc = encodeURIComponent;
-  const encPath = path.split('/').map(enc).join('/');
-  const url = `${ADMIN}/status/${enc(owner)}/${enc(repo)}/${enc(ref)}${encPath}?editUrl=auto`;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), AUTH_FETCH_TIMEOUT_MS);
-  try {
-    const res = await fetch(url, { signal: controller.signal });
-    if (!res.ok) return false;
-    const data = await res.json();
-    // NOTE: a truthy `profile` means the response carried an authenticated
-    // Sidekick session; it does not by itself prove *edit* permission on the
-    // resolved owner/repo. Tightening to a per-repo role check is a tracked
-    // follow-up (review #9), pending confirmation of what /status exposes.
-    return !!data?.profile;
-  } catch (e) {
-    return false;
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-// Re-check on any Sidekick auth-state change (login-after-load, logout). The
-// event is only a nudge; isSidekickAuthed() re-derives the real state.
-function watchSidekick(onChange) {
-  const attach = (sk) => AUTH_EVENTS.forEach((evt) => sk.addEventListener(evt, onChange));
-
-  const existing = getSidekick();
-  if (existing) { attach(existing); return; }
-
-  let timeoutId;
-  const observer = new MutationObserver(() => {
-    const sk = getSidekick();
-    if (!sk) return;
-    observer.disconnect();
-    clearTimeout(timeoutId);
-    attach(sk);
-    onChange();
-  });
-  observer.observe(document.body, { childList: true });
-  timeoutId = setTimeout(() => observer.disconnect(), WATCH_TIMEOUT_MS);
-}
-
-// Only genuine non-prod preview/dev surfaces run ungated: *.aem.page /
-// *.hlx.page (preview), *.aem.reviews, and localhost. Everything else —
-// adobe.com, listed prodDomains, unknown hosts, and the public *.aem.live /
-// *.hlx.live edge — defaults to GATED. The env signal is query-spoofable
-// (?env=stage), so it may only tighten the gate (force prod), never re-open it.
+// Ungated = genuine preview/dev only (*.aem.page/*.hlx.page, *.aem.reviews,
+// localhost). Everything else — adobe.com, prodDomains, the public *.aem.live edge,
+// unknown hosts — is GATED. env is spoofable (?env=stage), so it may only tighten.
 const UNGATED_HOST = /(^|\.)(aem|hlx)\.(page|reviews)$/;
 export function isUngatedHost(hostname) {
   return hostname === 'localhost' || hostname === '127.0.0.1' || UNGATED_HOST.test(hostname);
@@ -106,14 +48,15 @@ export function isUngatedHost(hostname) {
 
 function shouldGate() {
   const { prodDomains, env } = getConfig();
-  if (prodDomains?.includes(window.location.hostname)) return true;
+  const { hostname } = window.location;
+  if (prodDomains?.includes(hostname)) return true;
   if (env?.name === 'prod') return true;
-  return !isUngatedHost(window.location.hostname);
+  return !isUngatedHost(hostname);
 }
 
 /*
- * Off the gated hosts the callback fires true (ungated). Otherwise it fires with
- * the initial verdict and again on any Sidekick auth-state change.
+ * Ungated hosts fire true immediately. Gated hosts fire the initial verdict, then
+ * again whenever auth flips (author signs in/out mid-session).
  */
 export function onSidekickAuth(callback) {
   if (!shouldGate()) {
@@ -122,25 +65,77 @@ export function onSidekickAuth(callback) {
   }
 
   let authed;
+  let mountTimer;
+  // Transient search observers; the steady-state auth watcher is NOT tracked here.
+  const observers = [];
+  const track = (observer) => { observers.push(observer); };
+  const stop = (observer) => {
+    observer.disconnect();
+    const i = observers.indexOf(observer);
+    if (i !== -1) observers.splice(i, 1);
+  };
+
   const set = (value) => {
     if (value === authed) return;
     authed = value;
     callback(value);
   };
 
-  (async () => {
-    if (await isSidekickAuthed()) { set(true); return; }
-    // No project → nothing to wait for; watchSidekick still catches a late mount.
-    if (!getProject()) { set(false); return; }
-    for (let i = 0; i < RETRY_DELAYS_MS.length; i += 1) {
-      if (authed === true) return; // an auth event already resolved us
-      // eslint-disable-next-line no-await-in-loop
-      await wait(RETRY_DELAYS_MS[i]);
-      // eslint-disable-next-line no-await-in-loop
-      if (await isSidekickAuthed()) { set(true); return; }
-    }
-    if (authed !== true) set(false);
-  })();
+  // Resolve true eagerly; defer the negative verdict to the bounded default so a
+  // late render doesn't flash a prompt. Observer re-resolves on class toggle / re-render.
+  const watchAuthState = (pluginBarShadow) => {
+    if (isAuthedIn(pluginBarShadow)) set(true);
+    const observer = new MutationObserver(() => {
+      if (isAuthedIn(pluginBarShadow)) set(true);
+      else if (authed === true) set(false);
+    });
+    observer.observe(pluginBarShadow, AUTH_MO);
+    // Steady state: left running for the page's life (never torn down) so logout is
+    // always caught. Transient observers have self-disconnected — stop the mount timer.
+    clearTimeout(mountTimer);
+  };
 
-  watchSidekick(async () => { set(await isSidekickAuthed()); });
+  // plugin-action-bar's shadowRoot renders async — wait for it.
+  const watchPluginActionBar = (sidekickShadow) => {
+    const bar = sidekickShadow.querySelector('plugin-action-bar');
+    if (bar?.shadowRoot) { watchAuthState(bar.shadowRoot); return; }
+    const observer = new MutationObserver(() => {
+      const nextBar = sidekickShadow.querySelector('plugin-action-bar');
+      if (!nextBar?.shadowRoot) return;
+      stop(observer);
+      watchAuthState(nextBar.shadowRoot);
+    });
+    observer.observe(sidekickShadow, { childList: true, subtree: true });
+    track(observer);
+  };
+
+  // Live backup to the DOM signal for mid-session changes; status-fetched has the profile.
+  const attachAuthEvents = (sk) => {
+    sk.addEventListener('status-fetched', (e) => { if (e?.detail?.profile) set(true); });
+    sk.addEventListener('logged-in', () => set(true));
+    sk.addEventListener('logged-out', () => set(false));
+  };
+
+  // The sidekick element may mount after we run — wait for it.
+  const sk = getSidekick();
+  if (sk?.shadowRoot) {
+    attachAuthEvents(sk);
+    watchPluginActionBar(sk.shadowRoot);
+  } else {
+    const observer = new MutationObserver(() => {
+      const el = getSidekick();
+      if (!el?.shadowRoot) return;
+      stop(observer);
+      attachAuthEvents(el);
+      watchPluginActionBar(el.shadowRoot);
+    });
+    observer.observe(document.body, { childList: true });
+    track(observer);
+  }
+
+  // Default to unauthed if nothing resolved us in the head start (no sidekick /
+  // signed out). A later sign-in still flips it.
+  setTimeout(() => { if (authed === undefined) set(false); }, RESOLVE_DELAY_MS);
+  // Tear down only the transient search observers, and only if none resolved.
+  mountTimer = setTimeout(() => { observers.slice().forEach(stop); }, WATCH_TIMEOUT_MS);
 }

--- a/libs/features/mep/sidekick-auth.js
+++ b/libs/features/mep/sidekick-auth.js
@@ -121,7 +121,13 @@ export function onSidekickAuth(callback) {
   if (sk?.shadowRoot) {
     attachAuthEvents(sk);
     watchPluginActionBar(sk.shadowRoot);
+    // Sidekick present: brief head start before defaulting to unauthed, so a late
+    // status resolution doesn't flash a sign-in prompt.
+    setTimeout(() => { if (authed === undefined) set(false); }, RESOLVE_DELAY_MS);
   } else {
+    // No sidekick → unauthed now (delay 0): no flash to avoid, and nothing lingering
+    // to fire after a consumer tears down. Still watch for a late mount.
+    setTimeout(() => { if (authed === undefined) set(false); }, 0);
     const observer = new MutationObserver(() => {
       const el = getSidekick();
       if (!el?.shadowRoot) return;
@@ -132,10 +138,6 @@ export function onSidekickAuth(callback) {
     observer.observe(document.body, { childList: true });
     track(observer);
   }
-
-  // Default to unauthed if nothing resolved us in the head start (no sidekick /
-  // signed out). A later sign-in still flips it.
-  setTimeout(() => { if (authed === undefined) set(false); }, RESOLVE_DELAY_MS);
   // Tear down only the transient search observers, and only if none resolved.
   mountTimer = setTimeout(() => { observers.slice().forEach(stop); }, WATCH_TIMEOUT_MS);
 }

--- a/test/features/mep/sidekick-auth.test.js
+++ b/test/features/mep/sidekick-auth.test.js
@@ -163,15 +163,15 @@ describe('sidekick-auth (shadow-DOM login-button probe)', () => {
       expect(cb.calledWith(false)).to.be.true;
     });
 
-    it('resolves once the sidekick mounts after load', async () => {
+    it('resolves unauthed promptly with no sidekick, then flips true when it mounts', async () => {
       setConfig({ env: { name: 'prod' } });
       const cb = sinon.spy();
       onSidekickAuth(cb); // no sidekick yet
       await wait(50);
-      expect(cb.called).to.be.false;
+      expect(cb.calledWith(false)).to.be.true; // no sidekick → unauthed promptly
       mountSidekick({ authed: true });
       await wait(50);
-      expect(cb.calledWith(true)).to.be.true;
+      expect(cb.calledWith(true)).to.be.true; // opening the sidekick flips it
     });
 
     it('does not emit the same verdict twice', async () => {

--- a/test/features/mep/sidekick-auth.test.js
+++ b/test/features/mep/sidekick-auth.test.js
@@ -10,26 +10,31 @@ const {
 
 const wait = (ms = 0) => new Promise((r) => { setTimeout(r, ms); });
 
-// Test host (localhost) isn't an aem host, so the project comes from the
-// Sidekick element's public config — mirrors the adobe.com path.
-function mountSidekick({ owner = 'adobecom', repo = 'milo', ref = 'main' } = {}) {
+// The real <aem-sidekick> exposes no config/status to page JS. The page-world
+// signal is its nested open shadow DOM: login-button#user is ALWAYS rendered
+// inside plugin-action-bar's shadow and carries the `not-authorized` class when
+// signed out, dropping it when an authenticated status is fetched.
+function mountSidekick({ authed = false, withUser = true } = {}) {
   const sk = document.createElement('aem-sidekick');
-  sk.config = { owner, repo, ref };
+  const skShadow = sk.attachShadow({ mode: 'open' });
+  const bar = document.createElement('plugin-action-bar');
+  skShadow.appendChild(bar);
+  const barShadow = bar.attachShadow({ mode: 'open' });
+  let user;
+  if (withUser) {
+    user = document.createElement('login-button');
+    user.id = 'user';
+    if (!authed) user.classList.add('not-authorized');
+    barShadow.appendChild(user);
+  }
   document.body.appendChild(sk);
-  return sk;
+  return { sk, barShadow, user };
 }
 
-function stubStatus({ authed }) {
-  return sinon.stub(window, 'fetch').callsFake(async (url) => {
-    if (String(url).includes('/status/')) {
-      if (authed) return { ok: true, json: async () => ({ profile: { email: 'author@adobe.com' } }) };
-      return { ok: false, status: 401, json: async () => ({}) };
-    }
-    return { ok: false, status: 404, json: async () => ({}) };
-  });
-}
+const signIn = (user) => user.classList.remove('not-authorized');
+const signOut = (user) => user.classList.add('not-authorized');
 
-describe('sidekick-auth (/status)', () => {
+describe('sidekick-auth (shadow-DOM login-button probe)', () => {
   afterEach(() => {
     sinon.restore();
     document.querySelectorAll('aem-sidekick, helix-sidekick').forEach((el) => el.remove());
@@ -60,33 +65,29 @@ describe('sidekick-auth (/status)', () => {
   });
 
   describe('isSidekickAuthed', () => {
-    it('returns false when there is no project (no sidekick, non-aem host)', async () => {
-      stubStatus({ authed: true });
-      expect(await isSidekickAuthed()).to.equal(false);
+    it('returns false when there is no sidekick', () => {
+      expect(isSidekickAuthed()).to.equal(false);
     });
 
-    it('returns true when /status returns a profile', async () => {
-      mountSidekick();
-      stubStatus({ authed: true });
-      expect(await isSidekickAuthed()).to.equal(true);
+    it('returns false when the user button carries not-authorized (signed out)', () => {
+      mountSidekick({ authed: false });
+      expect(isSidekickAuthed()).to.equal(false);
     });
 
-    it('returns false when /status is 401', async () => {
-      mountSidekick();
-      stubStatus({ authed: false });
-      expect(await isSidekickAuthed()).to.equal(false);
+    it('returns true when the user button lacks not-authorized (signed in)', () => {
+      mountSidekick({ authed: true });
+      expect(isSidekickAuthed()).to.equal(true);
     });
 
-    it('returns false when the fetch throws (CORS/network)', async () => {
-      mountSidekick();
-      sinon.stub(window, 'fetch').rejects(new Error('CORS'));
-      expect(await isSidekickAuthed()).to.equal(false);
+    it('returns false when the user button is not present yet', () => {
+      mountSidekick({ withUser: false });
+      expect(isSidekickAuthed()).to.equal(false);
     });
   });
 
-  describe('onSidekickAuth', () => {
-    // > sum of RETRY_DELAYS_MS (300 + 900) — long enough for the retry to exhaust.
-    const RETRY_WINDOW = 1500;
+  describe('onSidekickAuth — DOM signal', () => {
+    // > RESOLVE_DELAY_MS (1200) — long enough for the unauthed default to commit.
+    const RESOLVE_WINDOW = 1400;
 
     it('bypasses the gate off prod hosts / non-prod env', () => {
       setConfig({ env: { name: 'stage' } });
@@ -99,81 +100,124 @@ describe('sidekick-auth (/status)', () => {
       // host-keyed: ?env=stage on a real prod host must NOT disable the gate
       setConfig({ env: { name: 'stage' }, prodDomains: [window.location.hostname] });
       const cb = sinon.spy();
-      onSidekickAuth(cb); // no Sidekick mounted → resolves unauthed, i.e. gated
-      await wait(50);
+      onSidekickAuth(cb); // no sidekick → resolves unauthed, i.e. gated
+      await wait(RESOLVE_WINDOW);
       expect(cb.calledWith(false)).to.be.true;
       expect(cb.calledWith(true)).to.be.false;
     });
 
-    it('calls back true on the first attempt when the Sidekick is authed', async () => {
+    it('calls back true immediately when already signed in', async () => {
       setConfig({ env: { name: 'prod' } });
-      mountSidekick();
-      stubStatus({ authed: true });
+      mountSidekick({ authed: true });
       const cb = sinon.spy();
       onSidekickAuth(cb);
       await wait(50);
       expect(cb.calledWith(true)).to.be.true;
-      // authed on attempt 1 → no false ever emitted
-      expect(cb.calledWith(false)).to.be.false;
+      expect(cb.calledWith(false)).to.be.false; // no sign-in flash
     });
 
-    it('emits false only after the bounded retry is exhausted', async () => {
+    it('emits false only after the bounded window when signed out', async () => {
       setConfig({ env: { name: 'prod' } });
-      mountSidekick();
-      stubStatus({ authed: false });
+      mountSidekick({ authed: false });
       const cb = sinon.spy();
       onSidekickAuth(cb);
-      // retry window still open — no verdict yet
       await wait(50);
-      expect(cb.calledWith(false)).to.be.false;
-      // after the window elapses, resolves false
-      await wait(RETRY_WINDOW);
+      expect(cb.called).to.be.false; // window still open
+      await wait(RESOLVE_WINDOW);
       expect(cb.calledWith(false)).to.be.true;
     });
 
-    it('retries and resolves true when a later attempt authes (no false flash)', async () => {
+    it('flips to true (no false flash) when not-authorized clears before the window', async () => {
       setConfig({ env: { name: 'prod' } });
-      mountSidekick();
-      let calls = 0;
-      sinon.stub(window, 'fetch').callsFake(async (url) => {
-        if (!String(url).includes('/status/')) return { ok: false, status: 404, json: async () => ({}) };
-        calls += 1;
-        if (calls >= 2) return { ok: true, json: async () => ({ profile: { email: 'author@adobe.com' } }) };
-        return { ok: false, status: 401, json: async () => ({}) };
-      });
+      const { user } = mountSidekick({ authed: false });
       const cb = sinon.spy();
       onSidekickAuth(cb);
-      await wait(RETRY_WINDOW);
+      await wait(50);
+      signIn(user); // status resolves signed-in
+      await wait(50);
       expect(cb.calledWith(true)).to.be.true;
       expect(cb.calledWith(false)).to.be.false;
     });
 
-    it('flips to true when the Sidekick logs in after an unauthed load', async () => {
+    it('flips to true when the author signs in after an unauthed load', async () => {
       setConfig({ env: { name: 'prod' } });
-      const sk = mountSidekick();
-      const fetchStub = stubStatus({ authed: false });
+      const { user } = mountSidekick({ authed: false });
+      const cb = sinon.spy();
+      onSidekickAuth(cb);
+      await wait(RESOLVE_WINDOW); // commits to false first
+      expect(cb.calledWith(false)).to.be.true;
+      signIn(user);
+      await wait(50);
+      expect(cb.calledWith(true)).to.be.true;
+    });
+
+    it('flips back to false when the author signs out mid-session', async () => {
+      setConfig({ env: { name: 'prod' } });
+      const { user } = mountSidekick({ authed: true });
       const cb = sinon.spy();
       onSidekickAuth(cb);
       await wait(50);
+      expect(cb.calledWith(true)).to.be.true;
+      signOut(user);
+      await wait(50);
+      expect(cb.calledWith(false)).to.be.true;
+    });
 
-      // user logs into the Sidekick — /status now returns a profile
-      fetchStub.restore();
-      stubStatus({ authed: true });
-      sk.dispatchEvent(new CustomEvent('logged-in'));
+    it('resolves once the sidekick mounts after load', async () => {
+      setConfig({ env: { name: 'prod' } });
+      const cb = sinon.spy();
+      onSidekickAuth(cb); // no sidekick yet
+      await wait(50);
+      expect(cb.called).to.be.false;
+      mountSidekick({ authed: true });
       await wait(50);
       expect(cb.calledWith(true)).to.be.true;
     });
 
     it('does not emit the same verdict twice', async () => {
       setConfig({ env: { name: 'prod' } });
-      const sk = mountSidekick();
-      stubStatus({ authed: true });
+      const { barShadow } = mountSidekick({ authed: true });
       const cb = sinon.spy();
       onSidekickAuth(cb);
       await wait(50);
-      sk.dispatchEvent(new CustomEvent('status-fetched'));
+      // an unrelated mutation must not re-emit true
+      barShadow.appendChild(document.createElement('span'));
       await wait(50);
       expect(cb.callCount).to.equal(1);
+    });
+  });
+
+  describe('onSidekickAuth — event backup', () => {
+    it('resolves true on a logged-in event even before the DOM clears', async () => {
+      setConfig({ env: { name: 'prod' } });
+      const { sk } = mountSidekick({ authed: false });
+      const cb = sinon.spy();
+      onSidekickAuth(cb);
+      sk.dispatchEvent(new CustomEvent('logged-in'));
+      await wait(50);
+      expect(cb.calledWith(true)).to.be.true;
+    });
+
+    it('resolves true on a status-fetched event carrying a profile', async () => {
+      setConfig({ env: { name: 'prod' } });
+      const { sk } = mountSidekick({ authed: false });
+      const cb = sinon.spy();
+      onSidekickAuth(cb);
+      sk.dispatchEvent(new CustomEvent('status-fetched', { detail: { profile: { email: 'a@adobe.com' } } }));
+      await wait(50);
+      expect(cb.calledWith(true)).to.be.true;
+    });
+
+    it('flips to false on a logged-out event mid-session', async () => {
+      setConfig({ env: { name: 'prod' } });
+      const { sk } = mountSidekick({ authed: true });
+      const cb = sinon.spy();
+      onSidekickAuth(cb);
+      await wait(50);
+      expect(cb.calledWith(true)).to.be.true;
+      sk.dispatchEvent(new CustomEvent('logged-out'));
+      await wait(50);
+      expect(cb.calledWith(false)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
* [MEP] Fix mep-next Sidekick auth detection — the gated preview button was stuck
  unauthenticated on prod
* Switch from the impossible admin.hlx.page/status probe to the page-world
  `login-button#user` signal in the Sidekick's nested shadow DOM
* Add status-fetched/logged-in/logged-out events as a backup; remove the /status fetch
* Rewrite unit tests (18) against the real nested-shadow structure

Resolves: [MWPW-202659](https://jira.corp.adobe.com/browse/MWPW-202659)

### Why
`<aem-sidekick>` lives in the extension's isolated content-script world, so from
page JS it exposes no config/status/profile and no owner/repo/ref — `/status`
can't be built and its `status-fetched` event fires before we attach.
`login-button#user` carries `not-authorized` when signed out and drops it once
authenticated (a persistent reflection of the extension's `isAuthenticated()`).
Preview/dev hosts are ungated (short-circuit to authed), which is why this only
surfaced on gated prod.

### Testing — NOTE: requires a GATED host + AEM Sidekick
The auth path only runs on gated hosts (prod/adobe.com/`*.aem.live`). `*.aem.page`
is ungated and always shows authed, so the usual aem.page URLs won't exercise this.
- Before: `https://main--milo--adobecom.aem.live?mep=on&mepnext=on`
- After: `https://mep-fix-auth--milo--adobecom.aem.live?mep=on&mepnext=on`
  (with the AEM Sidekick open) — signed in → preview drawer; signed out → "Sign
  into AEM Sidekick" card; toggling login/logout flips it in place.
- Unit: `npm run test:file -- test/features/mep/sidekick-auth.test.js` (18 pass)
 
### Follow-up
Request a supported page-facing contract upstream (reflected boolean `logged-in`
attribute) in `adobe/aem-sidekick` 


Update: testing was done on prod pages with browser overrides.



