### PR TITLE
MWPW-198342: Fix C2 CTA focus indicator contrast (WCAG 1.4.11)

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -878,8 +878,9 @@ p {
     color 300ms var(--parallax-easing);
 
   &:focus-visible {
-    outline: var(--s2a-border-width-2) solid var(--s2a-color-focus-ring-default);
+    outline: var(--s2a-border-width-2) solid var(--s2a-color-border-knockout);
     outline-offset: var(--s2a-border-width-2);
+    box-shadow: 0 0 0 var(--s2a-border-width-2) var(--s2a-color-border-inverse);
   }
 
   &:is(:disabled, [aria-disabled="true"], .disabled) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fixes the C2 CTA focus indicator failing WCAG 2.2 SC 1.4.11 (non-text contrast) — the single blue focus ring dropped to ~1.2:1 over some backgrounds (reported: ring `#8EB9FC` on background `#9AAC9A`).
* Replaces it with a two-color focus ring on `.con-button:focus-visible`: a black+white pair that guarantees ≥3:1 against any background (WCAG Technique C40), matching the design "Update" spec.
* Uses two existing theme-inverse border tokens that auto-swap by theme, so light and dark are covered by one rule with no `.dark` override:
  * outer ring — `--s2a-color-border-knockout` (`#000` light / `#fff` dark)
  * inner gap ring — `--s2a-color-border-inverse` (`#fff` light / `#000` dark)

Resolves: [MWPW-198342](https://jira.corp.adobe.com/browse/MWPW-198342)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=stage
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=mwpw-198342
- Before (all CTA variants): https://main--milo--adobecom.aem.page/drafts/ratko/updated-text-block/document1
- After (all CTA variants): https://mwpw-198342--milo--adobecom.aem.page/drafts/ratko/updated-text-block/document1

_How to verify:_ Tab (keyboard) to the "Free Trial" / "See All Plans" CTAs and observe the focus ring. Before: a single blue ring that is barely visible on the mid-tone background. After: a two-tone black+white ring clearly visible on any background, in both light and dark sections.
