### PR TITLE
MWPW-202526: Remove stroke from Side by Sides card-overlay (site-redesign)

### DIFF
--- a/libs/mep/ace1205/side-by-side/side-by-side.css
+++ b/libs/mep/ace1205/side-by-side/side-by-side.css
@@ -31,7 +31,6 @@
     position: relative;
     overflow: hidden;
     aspect-ratio: 33/37;
-    border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12);
 
     &.dark {
       background-color: unset;

--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -51,7 +51,6 @@
 
     overflow: hidden;
     aspect-ratio: 33/37;
-    border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12);
     display: flex;
     align-items: flex-end;
 


### PR DESCRIPTION
* Removes the transparent-white stroke (`border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12)`) from the `.card-overlay` on the Side by Side block, per the global "remove strokes from components" request.
* Applied to both site-redesign side-by-side variants on this branch: `ace1205` and `ace1209`.

Resolves: [MWPW-202526](https://jira.corp.adobe.com/browse/MWPW-202526)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=mwpw-202526-site-redesign&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


