### PR TITLE
MWPW-202526: Remove stroke from Side by Sides card-overlay

### DIFF
--- a/libs/c2/blocks/side-by-side/side-by-side.css
+++ b/libs/c2/blocks/side-by-side/side-by-side.css
@@ -31,7 +31,6 @@
     position: relative;
     overflow: hidden;
     aspect-ratio: 33/37;
-    border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12);
 
     &.dark {
       background-color: unset;


### PR DESCRIPTION
* Removes the transparent-white stroke (`border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12)`) from the `.card-overlay` on the C2 Side by Side block, per the global "remove strokes from components" request.

Resolves: [MWPW-202526](https://jira.corp.adobe.com/browse/MWPW-202526)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=stage&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=mwpw-202526&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all


