### PR TITLE
add ff unauth changes

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -268,12 +268,10 @@ async function openSusiLightModal() {
     window.dispatchEvent(new CustomEvent('signIn:decorateNav', { detail: 'signIn' }));
     window?.lana.log('SUSI login success', { tags: 'brand-concierge', severity: 'info' });
     const token = detail;
-    if (!bcToken) {
-      bcToken = token;
-      const mountEl = document.getElementById(mountId);
-      if (mountEl) {
-        mountEl.dispatchEvent(new CustomEvent('bc:cta-action-handled', { detail: { token } }));
-      }
+    bcToken = token;
+    const mountEl = document.getElementById(mountId);
+    if (mountEl) {
+      mountEl.dispatchEvent(new CustomEvent('bc:cta-action-handled', { detail: { token } }));
     }
   };
 
@@ -402,7 +400,7 @@ async function openChatModal(initialMessage, el) {
     }
 
     if (!bcToken) {
-      bcToken = window.adobeIMS?.isSignedInUser() ? window.adobeIMS?.getAccessToken()?.token : null;
+      bcToken = window.adobeIMS?.getAccessToken()?.token;
     }
 
     if (bcToken) {

--- a/libs/blocks/brand-concierge/chat-ui-config.js
+++ b/libs/blocks/brand-concierge/chat-ui-config.js
@@ -21,6 +21,7 @@ export default {
     chat: {
       messageAlignment: 'normal',
       messageWidth: '100%',
+      feedbackAlignment: 'left',
       widgetsInMessageContentTypes: [
         'cta-actions',
         'firefly-community-gallery',

--- a/libs/c2/blocks/brand-concierge/brand-concierge.js
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.js
@@ -268,12 +268,10 @@ async function openSusiLightModal() {
     window.dispatchEvent(new CustomEvent('signIn:decorateNav', { detail: 'signIn' }));
     window?.lana.log('SUSI login success', { tags: 'brand-concierge', severity: 'info' });
     const token = detail;
-    if (!bcToken) {
-      bcToken = token;
-      const mountEl = document.getElementById(mountId);
-      if (mountEl) {
-        mountEl.dispatchEvent(new CustomEvent('bc:cta-action-handled', { detail: { token } }));
-      }
+    bcToken = token;
+    const mountEl = document.getElementById(mountId);
+    if (mountEl) {
+      mountEl.dispatchEvent(new CustomEvent('bc:cta-action-handled', { detail: { token } }));
     }
   };
 
@@ -402,7 +400,7 @@ async function openChatModal(initialMessage, el) {
     }
 
     if (!bcToken) {
-      bcToken = window.adobeIMS?.isSignedInUser() ? window.adobeIMS?.getAccessToken()?.token : null;
+      bcToken = window.adobeIMS?.getAccessToken()?.token;
     }
 
     if (bcToken) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2048,12 +2048,14 @@ export async function loadIms() {
           clearTimeout(timeout);
         },
         onError: reject,
+        ...adobeid,
         ...(imsGuest === 'on' && {
           api_parameters: { check_token: { guest_allowed: true } },
           enableGuestAccounts: true,
           enableGuestTokenForceRefresh: true,
+          enableGuestBotDetection: true,
+          guestBotDetectionProvider: 'bfp',
         }),
-        ...adobeid,
       };
       const path = PAGE_URL.searchParams.get('useAlternateImsDomain')
         ? 'https://auth.services.adobe.com/imslib/imslib.min.js'


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* remove checks for logged in users in the brand-concierge block
* add support for guest bot detection when the "ims-guest-token" metadata property is set to "on"

Resolves: [MWPW-202616](https://jira.corp.adobe.com/browse/MWPW-202616)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bc-ff-unauth--milo--adobecom.aem.page/?martech=off

Additional Info: There is a known issue in which a BFP CORS error can be seen in the console on raw aem.[page, live,reviews] pages only if guest tokens are turned on. Stage and Prod URLs will work properly with no issue. 

Resolution for this is in the hands of both the BFP and IMS teams. See this wiki page for more details: 

https://wiki.corp.adobe.com/spaces/~colloyd/pages/3990258284/Brand+Concierge+Firefly+Unauth+flow+changes+in+Milo+to+add+guest+bot+protection



