### PR TITLE
MWPW-202910 [MEP] Don't require Sidekick auth for mep-next overlay on stage/corp/graybox

### DIFF
--- a/libs/features/mep/sidekick-auth.js
+++ b/libs/features/mep/sidekick-auth.js
@@ -38,10 +38,11 @@ export function isSidekickAuthed() {
   return isAuthedIn(getPluginActionBarShadow());
 }
 
-// Ungated = genuine preview/dev only (*.aem.page/*.hlx.page, *.aem.reviews,
-// localhost). Everything else — adobe.com, prodDomains, the public *.aem.live edge,
-// unknown hosts — is GATED. env is spoofable (?env=stage), so it may only tighten.
-const UNGATED_HOST = /(^|\.)(aem|hlx)\.(page|reviews)$/;
+// Ungated (no auth) = preview/dev/stage/internal hosts only; prod, prodDomains, the
+// public *.aem.live edge, and unknown hosts stay GATED. graybox's [.-] covers both
+// graybox.adobe.com and the hyphenated business-graybox.adobe.com. Keyed on hostname,
+// not config.env.name (spoofable via ?env=stage on any host).
+const UNGATED_HOST = /(^|\.)(aem|hlx)\.(page|reviews)$|(^|\.)(stage|corp)\.adobe\.com$|(^|[.-])graybox\.adobe\.com$/;
 export function isUngatedHost(hostname) {
   return hostname === 'localhost' || hostname === '127.0.0.1' || UNGATED_HOST.test(hostname);
 }

--- a/test/features/mep/sidekick-auth.test.js
+++ b/test/features/mep/sidekick-auth.test.js
@@ -42,13 +42,18 @@ describe('sidekick-auth (shadow-DOM login-button probe)', () => {
   });
 
   describe('isUngatedHost (gate defaults to on for anything not a preview/dev host)', () => {
-    it('ungates genuine preview/dev surfaces', () => {
+    it('ungates genuine preview/dev/stage/internal surfaces', () => {
       [
         'main--milo--adobecom.aem.page',
         'mep-next-v1--milo--adobecom.hlx.page',
         'branch--repo--owner.aem.reviews',
         'localhost',
         '127.0.0.1',
+        'www.stage.adobe.com',
+        'business.stage.adobe.com',
+        'www.corp.adobe.com',
+        'graybox.adobe.com',
+        'business-graybox.adobe.com', // hyphenated graybox host
       ].forEach((host) => expect(isUngatedHost(host), host).to.be.true);
     });
 
@@ -59,6 +64,10 @@ describe('sidekick-auth (shadow-DOM login-button probe)', () => {
         'www.adobe.com',
         'business.adobe.com',
         'evil-aem.page.attacker.com', // not a real *.aem.page host
+        'evilstage.adobe.com', // no boundary before "stage"
+        'stage.adobe.com.attacker.com', // suffix trick
+        'notgraybox.adobe.com', // no boundary before "graybox"
+        'graybox.adobe.com.attacker.com', // suffix trick
         'example.com',
       ].forEach((host) => expect(isUngatedHost(host), host).to.be.false);
     });


### PR DESCRIPTION
  * Ungate the mep-next preview overlay on stage, corp, and graybox hosts — it no longer shows the "Sign into AEM Sidekick" prompt there
  * Adds `*.stage.adobe.com`, `*.corp.adobe.com`, and graybox (`graybox.adobe.com` + hyphenated `business-graybox.adobe.com`) to the ungated-host allowlist in `sidekick-auth.js`
  * Prod, prodDomains, and the public `*.aem.live` edge stay GATED; gate remains keyed on hostname, not `env.name` (which `?env=stage` can spoof)

  Resolves: [MWPW-202910](https://jira.corp.adobe.com/browse/MWPW-202910)
  
  **Steps to QA:**
  1. Open the "Not gated" urls below. Actions tab content should be available regardless of of aem sidekick login status.
  2. Open the "gated" url below ("prod url") and overide the sidekick-auth.js file in browser. MEP Actions tab content should only be available when signed in to aem sidekick.
  
**Test URLs:**
**Not gated:**
  - stage: https://www.stage.adobe.com/creativecloud.html?mep&mepnext=on&milolibs=mepnext-auth-remove-stage-gate
  - preview: https://main--da-cc--adobecom.aem.page/creativecloud?mep&mepnext=on&milolibs=mepnext-auth-remove-stage-gate

**Gated:** 
  - production: https://www.stage.adobe.com/creativecloud.html?mep&mepnext=on
  **Note must override libs/features/mep/sidekick-auth.js to confirm prod is still gated
  - PSI-check: https://mepnext-auth-remove-stage-gate--milo--adobecom.aem.page/?martech=off


