### PR TITLE
[MWPW-201565] MEP Next - 7 Day Manifests

### DIFF
--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay-logic.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay-logic.js
@@ -136,6 +136,76 @@ function formatDate(dateTime, format = 'local') {
 
 const TARGET_MAP = { postlcp: 'postlcp', true: 'on', false: 'off' };
 
+function buildManifestEntry(manifest, mIdx, pageId, manifestParameter) {
+  const {
+    url,
+    variantNames,
+    selectedVariantName = 'default',
+    targetActivityName,
+    source,
+    analyticsTitle,
+    eventStart,
+    eventEnd,
+    disabled,
+    geoRestriction,
+    mktgAction,
+  } = manifest;
+
+  const editPath = normalizePath(url);
+  const variants = typeof variantNames === 'string' ? variantNames.split('||') : (variantNames ?? []);
+  const isDefaultSelected = !variants.includes(selectedVariantName) && pageId === 0;
+
+  if (isDefaultSelected) manifestParameter.push(`${url}--default`);
+
+  const options = [
+    { name: `${editPath}${pageId}`, value: '', title: 'none', label: "None (Don't add manifest)" },
+    {
+      name: `${editPath}${pageId}`,
+      value: 'default',
+      id: `${editPath}${pageId}--default`,
+      dataManifest: editPath,
+      title: 'Default (control)',
+      label: 'Default (control)',
+      selected: isDefaultSelected,
+    },
+  ];
+
+  variants.forEach((variant) => {
+    const isSelected = variant === selectedVariantName;
+    if (isSelected) manifestParameter.push(`${url}--${variant}`);
+    options.push({
+      name: `${editPath}${pageId}`,
+      value: variant,
+      id: `${editPath}${pageId}--${variant}`,
+      dataManifest: editPath,
+      title: variant,
+      label: variant,
+      selected: isSelected,
+    });
+  });
+
+  return {
+    index: mIdx + 1,
+    editUrl: url,
+    fileName: getFileName(url),
+    analyticsTitle,
+    targetActivityName: targetActivityName ?? null,
+    isDefaultSelected,
+    selectedVariantName,
+    source: Array.isArray(source) ? source.join(', ') : source,
+    mktgAction,
+    geoRestriction: geoRestriction ? geoRestriction.toUpperCase() : null,
+    showActive: !!(eventStart && eventEnd) || !!disabled,
+    isActive: disabled ? 'inactive' : 'active',
+    eventStart: eventStart ? formatDate(eventStart) : null,
+    eventStartIso: eventStart ? formatDate(eventStart, 'iso') : null,
+    eventEnd: eventEnd ? formatDate(eventEnd) : null,
+    lastSeen: manifest.lastSeen ? formatDate(new Date(manifest.lastSeen)) : null,
+    pageId,
+    options,
+  };
+}
+
 export function getManifestList() {
   const mepConfig = parseMepConfig();
   if (!mepConfig) return { manifests: [], manifestParameter: [] };
@@ -143,75 +213,9 @@ export function getManifestList() {
   const { pageId = 0 } = page;
   const manifestParameter = [];
 
-  const manifests = activities.map((manifest, mIdx) => {
-    const {
-      url,
-      variantNames,
-      selectedVariantName = 'default',
-      targetActivityName,
-      source,
-      analyticsTitle,
-      eventStart,
-      eventEnd,
-      disabled,
-      geoRestriction,
-      mktgAction,
-    } = manifest;
-
-    const editPath = normalizePath(url);
-    const variants = typeof variantNames === 'string' ? variantNames.split('||') : (variantNames ?? []);
-    const isDefaultSelected = !variants.includes(selectedVariantName) && pageId === 0;
-
-    if (isDefaultSelected) manifestParameter.push(`${url}--default`);
-
-    const options = [
-      { name: `${editPath}${pageId}`, value: '', title: 'none', label: "None (Don't add manifest)" },
-      {
-        name: `${editPath}${pageId}`,
-        value: 'default',
-        id: `${editPath}${pageId}--default`,
-        dataManifest: editPath,
-        title: 'Default (control)',
-        label: 'Default (control)',
-        selected: isDefaultSelected,
-      },
-    ];
-
-    variants.forEach((variant) => {
-      const isSelected = variant === selectedVariantName;
-      if (isSelected) manifestParameter.push(`${url}--${variant}`);
-      options.push({
-        name: `${editPath}${pageId}`,
-        value: variant,
-        id: `${editPath}${pageId}--${variant}`,
-        dataManifest: editPath,
-        title: variant,
-        label: variant,
-        selected: isSelected,
-      });
-    });
-
-    return {
-      index: mIdx + 1,
-      editUrl: url,
-      fileName: getFileName(url),
-      analyticsTitle,
-      targetActivityName: targetActivityName ?? null,
-      isDefaultSelected,
-      selectedVariantName,
-      source: Array.isArray(source) ? source.join(', ') : source,
-      mktgAction,
-      geoRestriction: geoRestriction ? geoRestriction.toUpperCase() : null,
-      showActive: !!(eventStart && eventEnd) || !!disabled,
-      isActive: disabled ? 'inactive' : 'active',
-      eventStart: eventStart ? formatDate(eventStart) : null,
-      eventStartIso: eventStart ? formatDate(eventStart, 'iso') : null,
-      eventEnd: eventEnd ? formatDate(eventEnd) : null,
-      lastSeen: manifest.lastSeen ? formatDate(new Date(manifest.lastSeen)) : null,
-      pageId,
-      options,
-    };
-  });
+  const manifests = activities.map(
+    (manifest, mIdx) => buildManifestEntry(manifest, mIdx, pageId, manifestParameter),
+  );
 
   return { manifests, manifestParameter };
 }
@@ -408,9 +412,10 @@ export async function getAdditionalManifests() {
 
     const data = await response.json();
     const existingPaths = new Set(mepConfig.activities.map((a) => normalizePath(a.url)));
+    const { pageId = 0 } = mepConfig.page;
     data.activities = data.activities
       .filter((a) => !existingPaths.has(normalizePath(a.url)))
-      .map((a) => ({ ...a, source: 'MMM' }));
+      .map((a, mIdx) => buildManifestEntry({ ...a, source: 'MMM' }, mIdx, pageId, []));
 
     additionalManifests = data;
   } catch (error) {

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
@@ -242,6 +242,10 @@ body:has(#mep-drawer:popover-open) .mep-fab {
   border: 1px solid var(--mep-white-12);
 }
 
+.mep-drawer .mep-card[hidden] {
+  display: none;
+}
+
 .mep-drawer .mep-card.center {
   align-items: center;
 }

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
@@ -97,20 +97,20 @@ body:has(#mep-drawer:popover-open) .mep-fab {
 
 .mep-drawer:popover-open {
   opacity: 1;
-  transform: translateX(0%);
+  transform: translate3d(0, 0, 0);
   transition: opacity 0.3s ease, transform 0.3s ease, display 0.3s allow-discrete, overlay 0.3s allow-discrete;
 }
 
 @starting-style {
   .mep-drawer:popover-open {
     opacity: 0;
-    transform: translateX(-100%);
+    transform: translate3d(-100%, 0, 0);
   }
 }
 
 .mep-drawer:not(:popover-open) {
   opacity: 0;
-  transform: translateX(-100%);
+  transform: translate3d(-100%, 0, 0);
   transition: opacity 0.3s ease, transform 0.3s ease, display 0.3s allow-discrete, overlay 0.3s allow-discrete;
 }
 

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -467,6 +467,7 @@ async function buildAdditionalManifests() {
   if (!manifests.length) return;
 
   const drawerEl = document.querySelector('#mep-drawer');
+  if (drawerEl.querySelector('.mmm-manifest-card')) return;
   const manifestEls = [...drawerEl.querySelectorAll('.mep-manifest-card')];
   const lastManifestEl = manifestEls[manifestEls.length - 1];
   if (!lastManifestEl) return;
@@ -478,6 +479,7 @@ async function buildAdditionalManifests() {
   }
 }
 
+let additionalManifestsPromise;
 async function toggleManifestManager(event) {
   const drawerEl = document.querySelector('#mep-drawer');
   const mmmManifestEls = drawerEl?.querySelectorAll('.mmm-manifest-card');
@@ -485,7 +487,16 @@ async function toggleManifestManager(event) {
     mmmManifestEls.forEach((el) => { el.hidden = !event.target.checked; });
     return;
   }
-  if (event.target.checked) await buildAdditionalManifests();
+  if (!event.target.checked) return;
+
+  additionalManifestsPromise ??= buildAdditionalManifests().finally(() => {
+    additionalManifestsPromise = null;
+  });
+  await additionalManifestsPromise;
+
+  drawerEl.querySelectorAll('.mmm-manifest-card').forEach((el) => {
+    el.hidden = !event.target.checked;
+  });
 }
 
 let gnavOffsetRaf;

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -18,6 +18,7 @@ import {
   setPreviewButton,
   getMasRegions,
   findGeoGroupForLocale,
+  hasMasChanges,
 } from './mep-overlay-logic.js';
 import {
   TOGGLE_KEYS,
@@ -89,8 +90,12 @@ function getGnavOffset() {
   });
 }
 
+let lastGnavOffset;
 function updateGnavOffset() {
   const offset = calcGnavOffset();
+  if (offset === lastGnavOffset) return;
+  lastGnavOffset = offset;
+
   document.querySelector('.mep-fab')?.style.setProperty('top', `${offset + 16}px`);
   const drawer = document.querySelector('#mep-drawer');
   if (drawer) {
@@ -540,11 +545,17 @@ function setEventListeners() {
 }
 
 function setMasObserver() {
+  let lastMasSummaryKey;
   const refreshMasSummary = () => {
     const bodyEl = document.querySelector('[data-card-key="M@S"] .mep-card-body');
     if (!bodyEl) return;
 
-    const rows = getMasSummary().flatMap(([label, value]) => (
+    const summary = getMasSummary();
+    const summaryKey = JSON.stringify(summary);
+    if (summaryKey === lastMasSummaryKey) return;
+    lastMasSummaryKey = summaryKey;
+
+    const rows = summary.flatMap(([label, value]) => (
       Array.isArray(value) ? buildNestedSection(label, value) : buildRow(label, value)
     ));
     bodyEl.replaceChildren(...rows);
@@ -578,7 +589,8 @@ function setMasObserver() {
   };
 
   let debounceTimer;
-  const masObserver = new MutationObserver(() => {
+  const masObserver = new MutationObserver((mutations) => {
+    if (!hasMasChanges(mutations)) return;
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(runRefreshes, 200);
   });
@@ -596,6 +608,7 @@ function setMasObserver() {
 
 async function buildOverlay() {
   const gnavOffset = await getGnavOffset();
+  lastGnavOffset = gnavOffset;
 
   const pageId = getPageId();
   document.querySelector('main').append(

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -132,7 +132,7 @@ function toggleExpandedCard(cardEl) {
   localStorage.setItem(CARD_STORAGE_KEY, JSON.stringify([...expanded]));
 }
 
-function buildManifestCard(manifest) {
+function buildManifestCard(manifest, { mmm = false } = {}) {
   const filename = createTag('span', { class: 'mep-manifest-filename' });
   filename.textContent = manifest.fileName ?? '';
   const link = createTag('a', { href: safeUrl(manifest.editUrl), target: '_blank', rel: 'noopener' }, [
@@ -140,7 +140,7 @@ function buildManifestCard(manifest) {
     filename,
   ]);
   const header = createTag('div', { class: 'mep-manifest-header' }, [
-    createTag('span', { class: 'mep-overline' }, 'Manifest'),
+    createTag('span', { class: 'mep-overline' }, mmm ? '7 Day Manifest' : 'Manifest'),
     createTag('h1', {}, [link, svgIcon('icon-expand-circle-down')]),
   ]);
 
@@ -469,14 +469,23 @@ async function buildAdditionalManifests() {
   const drawerEl = document.querySelector('#mep-drawer');
   const manifestEls = [...drawerEl.querySelectorAll('.mep-manifest-card')];
   const lastManifestEl = manifestEls[manifestEls.length - 1];
-
-  if (!lastManifestEl || lastManifestEl.classList.contains('mmm-manifest-card')) return;
+  if (!lastManifestEl) return;
 
   for (const manifest of manifests) {
-    const manifestEl = buildManifestCard(manifest);
+    const manifestEl = buildManifestCard(manifest, { mmm: true });
     manifestEl.classList.add('mmm-manifest-card');
     lastManifestEl.after(manifestEl);
   }
+}
+
+async function toggleManifestManager(event) {
+  const drawerEl = document.querySelector('#mep-drawer');
+  const mmmManifestEls = drawerEl?.querySelectorAll('.mmm-manifest-card');
+  if (mmmManifestEls?.length) {
+    mmmManifestEls.forEach((el) => { el.hidden = !event.target.checked; });
+    return;
+  }
+  if (event.target.checked) await buildAdditionalManifests();
 }
 
 let gnavOffsetRaf;
@@ -513,7 +522,7 @@ function setEventListeners() {
   });
 
   drawerEl.addEventListener('input', (event) => {
-    if (event.target.id === 'toggle-manifest-manager') buildAdditionalManifests();
+    if (event.target.id === 'toggle-manifest-manager') toggleManifestManager(event);
     toggleHighlight(event);
     if (event.target.type !== 'checkbox') setPreviewButton(event);
   });

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -477,10 +477,12 @@ async function buildAdditionalManifests() {
   const lastManifestEl = manifestEls[manifestEls.length - 1];
   if (!lastManifestEl) return;
 
+  let insertionPoint = lastManifestEl;
   for (const manifest of manifests) {
     const manifestEl = buildManifestCard(manifest, { mmm: true });
     manifestEl.classList.add('mmm-manifest-card');
-    lastManifestEl.after(manifestEl);
+    insertionPoint.after(manifestEl);
+    insertionPoint = manifestEl;
   }
 }
 

--- a/test/features/mep/mep-next/mep-overlay.flicker-check.test.js
+++ b/test/features/mep/mep-next/mep-overlay.flicker-check.test.js
@@ -1,0 +1,204 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+
+const { setConfig } = await import('../../../../libs/utils/utils.js');
+
+const SVG_DATA = {
+  svg: {
+    'icon-close': '<svg><path/></svg>',
+    'icon-expand-circle-down': '<svg><path/></svg>',
+    'icon-radio-checked': '<svg><path/></svg>',
+    'icon-radio-unchecked': '<svg><path/></svg>',
+    'icon-mep': '<svg><path/></svg>',
+    'logo-mep': '<svg><path/></svg>',
+  },
+};
+
+const BASE_CONFIG = {
+  miloLibs: 'https://main--milo--adobecom.aem.live/libs',
+  codeRoot: 'https://main--homepage--adobecom.aem.live/homepage',
+  locale: { ietf: 'en-US', tk: 'hah7vzn.css', prefix: '', region: 'us', regions: {} },
+  mep: {
+    experiments: [],
+    prefix: '',
+    highlight: true,
+    targetEnabled: true,
+    consentState: { functional: true, advertising: true },
+  },
+  env: { name: 'stage' },
+};
+
+setConfig(BASE_CONFIG);
+
+const fetchStub = sinon.stub(window, 'fetch').callsFake((url) => {
+  const href = url instanceof URL ? url.href : String(url);
+  if (href.includes('mep-overlay-svg.json')) {
+    return Promise.resolve({ ok: true, json: async () => SVG_DATA });
+  }
+  if (href.includes('supported-markets')) {
+    return Promise.resolve({ ok: true, json: async () => ({ languages: { data: [] } }) });
+  }
+  return Promise.resolve({ ok: false, status: 404, json: async () => ({}), text: async () => '' });
+});
+
+const { default: init } = await import('../../../../libs/features/mep/mep-next/mep-overlay/mep-overlay.js');
+
+after(() => fetchStub.restore());
+
+function makeMain() {
+  const el = document.createElement('main');
+  document.body.prepend(el);
+  return el;
+}
+
+function makeHeader(bottom = 50) {
+  const el = document.createElement('header');
+  el.getBoundingClientRect = () => ({ bottom });
+  document.body.prepend(el);
+  return el;
+}
+
+const wait = (ms = 0) => new Promise((r) => { setTimeout(r, ms); });
+
+describe('mep-drawer idle flicker check', () => {
+  it('does not mutate #mep-drawer style/attrs while idle (no scroll/resize/DOM changes)', async () => {
+    const mainEl = makeMain();
+    const headerEl = makeHeader(50);
+    await init();
+    await wait(150);
+
+    const drawer = mainEl.querySelector('#mep-drawer');
+    expect(drawer).to.exist;
+    try { drawer.showPopover(); } catch { /* jsdom/older engines */ }
+    await wait(150);
+
+    let attrMutations = 0;
+    let childMutations = 0;
+    const obs = new MutationObserver((mutations) => {
+      mutations.forEach((m) => {
+        if (m.type === 'attributes') attrMutations += 1;
+        if (m.type === 'childList') childMutations += 1;
+      });
+    });
+    obs.observe(drawer, { attributes: true, attributeFilter: ['style', 'class'], childList: true, subtree: true });
+
+    let rafCalls = 0;
+    const origRaf = window.requestAnimationFrame.bind(window);
+    window.requestAnimationFrame = (cb) => {
+      rafCalls += 1;
+      return origRaf(cb);
+    };
+
+    // Idle window: no scroll, no resize, no synthetic DOM mutation triggered by us.
+    await wait(3000);
+
+    obs.disconnect();
+    window.requestAnimationFrame = origRaf;
+
+    // eslint-disable-next-line no-console
+    console.log(`[flicker-check] attrMutations=${attrMutations} childMutations=${childMutations} rafCallsScheduled=${rafCalls}`);
+
+    expect(attrMutations, 'unexpected attribute mutations on #mep-drawer while idle').to.equal(0);
+    expect(childMutations, 'unexpected child mutations on #mep-drawer while idle').to.equal(0);
+    expect(rafCalls, 'unexpected requestAnimationFrame scheduling while idle').to.equal(0);
+
+    try { drawer.hidePopover(); } catch { /* jsdom/older engines */ }
+    mainEl.remove();
+    headerEl.remove();
+    document.querySelectorAll('#mep-drawer, .mep-fab').forEach((el) => el.remove());
+  }).timeout(6000);
+
+  it('does not rebuild the M@S summary DOM when a re-rendering merch-card leaves the count unchanged', async () => {
+    const mainEl = makeMain();
+    const headerEl = makeHeader(50);
+    await init();
+    await wait(150);
+
+    const drawer = mainEl.querySelector('#mep-drawer');
+    try { drawer.showPopover(); } catch { /* jsdom/older engines */ }
+    await wait(150);
+
+    // Switch to the Summary tab so the M@S card body exists in the DOM.
+    drawer.querySelector('.mep-tab[data-tab="1"]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await wait(50);
+
+    const masBody = drawer.querySelector('[data-card-key="M@S"] .mep-card-body');
+    expect(masBody).to.exist;
+
+    let childMutations = 0;
+    const obs = new MutationObserver((mutations) => {
+      mutations.forEach((m) => { if (m.type === 'childList') childMutations += 1; });
+    });
+    obs.observe(masBody, { childList: true });
+
+    // Establish a baseline: one real merch-card on the page (count 0 -> 1),
+    // a genuine data change that must rebuild the summary once.
+    let currentCard = document.createElement('merch-card');
+    document.body.append(currentCard);
+    await wait(300);
+    expect(childMutations, 'baseline card add should rebuild the summary once').to.equal(1);
+
+    // Simulate a component that re-renders itself (swaps its own element for a
+    // new one) several times, the way a web component often does on updates.
+    // The merch-card COUNT never actually changes (always exactly 1) because
+    // the old node is removed in the same tick the new one is added.
+    for (let i = 0; i < 5; i += 1) {
+      const nextCard = document.createElement('merch-card');
+      document.body.append(nextCard);
+      currentCard.remove();
+      currentCard = nextCard;
+      // eslint-disable-next-line no-await-in-loop
+      await wait(250);
+    }
+
+    obs.disconnect();
+
+    // eslint-disable-next-line no-console
+    console.log(`[flicker-check] M@S card-body childList mutations after 5 no-op merch-card swaps=${childMutations}`);
+
+    expect(childMutations, 'M@S summary DOM rebuilt even though the data never changed').to.equal(1);
+
+    mainEl.remove();
+    headerEl.remove();
+    document.querySelectorAll('#mep-drawer, .mep-fab, merch-card').forEach((el) => el.remove());
+  }).timeout(8000);
+
+  it('does not restyle #mep-drawer on repeated scroll events when the gnav offset is unchanged', async () => {
+    const mainEl = makeMain();
+    const headerEl = makeHeader(50);
+    await init();
+    await wait(150);
+
+    const drawer = mainEl.querySelector('#mep-drawer');
+    try { drawer.showPopover(); } catch { /* jsdom/older engines */ }
+    await wait(150);
+
+    let attrMutations = 0;
+    const obs = new MutationObserver((mutations) => {
+      mutations.forEach((m) => { if (m.type === 'attributes') attrMutations += 1; });
+    });
+    obs.observe(drawer, { attributes: true, attributeFilter: ['style'] });
+
+    // Simulate a scroll storm (as happens during a real touch/wheel scroll)
+    // against a header whose bottom never actually changes (e.g. a
+    // position: sticky header already pinned at top: 0).
+    for (let i = 0; i < 30; i += 1) {
+      window.dispatchEvent(new Event('scroll'));
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => { requestAnimationFrame(r); });
+    }
+    await wait(50);
+
+    obs.disconnect();
+
+    // eslint-disable-next-line no-console
+    console.log(`[flicker-check] #mep-drawer style mutations from 30 no-op scroll events=${attrMutations}`);
+
+    expect(attrMutations, '#mep-drawer restyled even though the gnav offset never changed').to.equal(0);
+
+    try { drawer.hidePopover(); } catch { /* jsdom/older engines */ }
+    mainEl.remove();
+    headerEl.remove();
+    document.querySelectorAll('#mep-drawer, .mep-fab').forEach((el) => el.remove());
+  }).timeout(8000);
+});

--- a/test/features/mep/mep-next/mep-overlay.test.js
+++ b/test/features/mep/mep-next/mep-overlay.test.js
@@ -259,6 +259,7 @@ describe('init: DOM structure — stage env first call', () => {
     const mmCb = document.createElement('input');
     mmCb.type = 'checkbox';
     mmCb.id = 'toggle-manifest-manager';
+    mmCb.checked = true;
     drawer.append(mmCb);
     mmCb.dispatchEvent(new Event('input', { bubbles: true }));
     await wait(200);
@@ -534,6 +535,7 @@ describe('buildAdditionalManifests: with activities returned', () => {
     const mmCb = document.createElement('input');
     mmCb.type = 'checkbox';
     mmCb.id = 'toggle-manifest-manager';
+    mmCb.checked = true;
     drawer.append(mmCb);
     mmCb.dispatchEvent(new Event('input', { bubbles: true }));
     await wait(200);
@@ -559,22 +561,40 @@ describe('buildAdditionalManifests: with activities returned', () => {
     expect(mmmCard?.textContent).to.include('Last Seen');
   });
 
-  it('second call skipped when last manifest card is already mmm (early return branch)', async () => {
+  it('unchecking hides mmm-manifest-card instead of removing/refetching it', async () => {
     const drawer = mainEl.querySelector('#mep-drawer');
     const before = drawer.querySelectorAll('.mmm-manifest-card').length;
 
-    // getAdditionalManifests is now cached; calling buildAdditionalManifests again
-    // will find lastManifestEl is the mmm card → returns early
     const mmCb = document.createElement('input');
     mmCb.type = 'checkbox';
     mmCb.id = 'toggle-manifest-manager';
+    mmCb.checked = false;
     drawer.append(mmCb);
     mmCb.dispatchEvent(new Event('input', { bubbles: true }));
     await wait(200);
     mmCb.remove();
 
-    const after = drawer.querySelectorAll('.mmm-manifest-card').length;
-    expect(after).to.equal(before);
+    const mmmCards = [...drawer.querySelectorAll('.mmm-manifest-card')];
+    expect(mmmCards.length).to.equal(before);
+    expect(mmmCards.every((card) => card.hidden)).to.be.true;
+  });
+
+  it('rechecking shows the existing mmm-manifest-card again without duplicating it', async () => {
+    const drawer = mainEl.querySelector('#mep-drawer');
+    const before = drawer.querySelectorAll('.mmm-manifest-card').length;
+
+    const mmCb = document.createElement('input');
+    mmCb.type = 'checkbox';
+    mmCb.id = 'toggle-manifest-manager';
+    mmCb.checked = true;
+    drawer.append(mmCb);
+    mmCb.dispatchEvent(new Event('input', { bubbles: true }));
+    await wait(200);
+    mmCb.remove();
+
+    const mmmCards = [...drawer.querySelectorAll('.mmm-manifest-card')];
+    expect(mmmCards.length).to.equal(before);
+    expect(mmmCards.every((card) => !card.hidden)).to.be.true;
   });
 });
 
@@ -599,6 +619,7 @@ describe('buildAdditionalManifests: no base manifest cards → early return', ()
     const mmCb = document.createElement('input');
     mmCb.type = 'checkbox';
     mmCb.id = 'toggle-manifest-manager';
+    mmCb.checked = true;
     drawer.append(mmCb);
     mmCb.dispatchEvent(new Event('input', { bubbles: true }));
     await wait(200);
@@ -802,6 +823,7 @@ describe('setEventListeners: input handler', () => {
     const mmCb = document.createElement('input');
     mmCb.type = 'checkbox';
     mmCb.id = 'toggle-manifest-manager';
+    mmCb.checked = true;
     drawer.append(mmCb);
     expect(() => mmCb.dispatchEvent(new Event('input', { bubbles: true }))).to.not.throw();
     await wait(100);


### PR DESCRIPTION
**Updates**
* Fix MEP Next overlay's Manifest Manager (MMM) 7-day additional manifests rendering with incomplete data (missing index, edit link, and variant options) by reusing the same manifest-entry builder as the primary manifest list
* Label 7-day manifests as "7 Day Manifest" in the overlay to distinguish them from the page's own manifests
* Fix the Manifest Manager toggle re-fetching and duplicating 7-day manifest cards on every checkbox change — it now shows/hides the existing cards instead

**Instructions**

The Manifest Manager toggle only renders when `env.name === 'prod'`, and the overlay itself is gated behind AEM Sidekick auth on real prod hosts — so this needs to be tested on a live adobe.com page with Chrome DevTools **Local Overrides**, not just the `.aem.page` preview URL above.

1. Sign into AEM Sidekick (the extension) against the target page so the overlay's auth gate resolves as authenticated.
2. Open the prod page in Chrome, open DevTools → **Sources** → **Overrides** → select a local folder and grant access.
3. In **Overrides**, replace these files with the branch's local copies (same relative path under `/libs/`):
   - `libs/features/mep/mep-next/mep-overlay/mep-overlay.js`
   - `libs/features/mep/mep-next/mep-overlay/mep-overlay-logic.js`
   - `libs/features/mep/mep-next/mep-overlay/mep-overlay.css`
4. Reload the page, open the MEP overlay (FAB → Actions tab), and toggle **Manifest Manager**:
   - Checking it on shows 7-day manifest cards labeled "7 Day Manifest" with full details (campaign, experience, source, edit link, variant select)
   - Unchecking hides the cards instantly with no network refetch
   - Re-checking re-shows the same cards without duplicating them

**Updates**
- Added safeguards to prevent scrolling offset from firing more than necessary.

Resolves: [MWPW-201565](https://jira.corp.adobe.com/browse/MWPW-201565)

**Test URLs:**
- Before: https://www.adobe.com/products/photoshop.html?mepnext=on&mep
- After: https://www.adobe.com/products/photoshop.html?mepnext=on&mep (with file override)
- Psi: https://mep-next-mmm-bug--milo--adobecom.aem.page/?martech=off










