### PR TITLE
[MWPW-201460] Lingo Languagebanner : update for region-priority 

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2487,6 +2487,15 @@ function getMarketsByRegionPriority(markets, geoIp) {
   return marketsWithPriority.map(({ market }) => market);
 }
 
+function pickPreferredMarket(markets, prefLang, geoIp) {
+  const candidates = markets.filter((m) => m.lang === prefLang);
+  if (!candidates.length) return null;
+  // regionPriorities -> site whose market matches the user's geo -> first-by-order
+  return getMarketsByRegionPriority(candidates, geoIp)?.[0]
+    ?? candidates.find((m) => (m.defaultMarket || '').toLowerCase() === geoIp)
+    ?? candidates[0];
+}
+
 function reserveBannerSpace() {
   document.body.prepend(createTag('div', { class: 'language-banner', 'daa-lh': 'language-banner' }));
   const existingWrapper = document.querySelector('.feds-promo-aside-wrapper');
@@ -2547,10 +2556,8 @@ export async function decorateLanguageBanner() {
   // Supported Market Path
   if (isSupportedMarket) {
     if (!prefLang || pageLang === prefLang) return;
-    const prefMarket = languageEntries.find((market) => (
-      market.lang === prefLang
-      && market.supportedRegions.includes(geoIp)
-    ));
+    const geoMarkets = languageEntries.filter((market) => market.supportedRegions.includes(geoIp));
+    const prefMarket = pickPreferredMarket(geoMarkets, prefLang, geoIp);
     if (prefMarket) addAndShow(prefMarket);
     else return;
   } else {
@@ -2561,7 +2568,7 @@ export async function decorateLanguageBanner() {
     if (useBannerFlow) {
       let prefMarketForGeo;
       if (prefLang) {
-        prefMarketForGeo = marketsForGeo.find((market) => market.lang === prefLang);
+        prefMarketForGeo = pickPreferredMarket(marketsForGeo, prefLang, geoIp);
         if (prefMarketForGeo) addAndShow(prefMarketForGeo);
       }
       if (!prefMarketForGeo) {


### PR DESCRIPTION
Adobe Express | Update region-priority for Language Banner

Express recently updated to onlybanner=ON configuration and added US as a supported region on the IN, UK sites(few more), so a GeoIP + PREF-LANG combination can now match multiple sites in Case [#4](https://www.figma.com/board/D24xSM6dlR4TOG5YRzu88t/lingo-routing-acom-bacom-v1.3?node-id=0-1&p=f&t=KSxEbQt5h6YbkxVv-0) and Case [#2](https://www.figma.com/board/D24xSM6dlR4TOG5YRzu88t/lingo-routing-acom-bacom-v1.3?node-id=0-1&p=f&t=KSxEbQt5h6YbkxVv-0).
These paths were not considering regionPriorities, with the assumption that Lingo will have only one site per language, so a combo could only resolve to one option. regionPriorities were applied only in Case [#5](https://www.figma.com/board/D24xSM6dlR4TOG5YRzu88t/lingo-routing-acom-bacom-v1.3?node-id=0-1&p=f&t=KSxEbQt5h6YbkxVv-0) (GeoIP-based banner/modal).
Fix : Added pickPreferredMarket helper. Resolves same-language candidates by considering regionPriorities and user's geoIp.

Resolves: [MWPW-201460](https://jira.corp.adobe.com/browse/MWPW-201460)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://acomlingo-rp--milo--adobecom.aem.page/?martech=off

**QA:**
Express : https://www.stage.adobe.com/fr/express/?milolibs=acomlingo-rp&akamaiLocale=us&languageBanner=on&onlybanner=on&marketsSource=expresstest
BACOM : https://business.stage.adobe.com/?milolibs=acomlingo-rp
ACOM : https://www.stage.adobe.com/?milolibs=acomlingo-rp


