### PR TITLE
MWPW-202478 Fix mas-field button style in localnav

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1496,10 +1496,12 @@ class Gnav {
       && itemTopParent.closest('.large-menu') instanceof HTMLElement;
     if (hasAsyncDropdown) return 'asyncDropdownTrigger';
     const isPrimaryCta = item.closest('strong') instanceof HTMLElement
-      || item.matches('a.con-button.blue');
+      || item.matches('a.con-button.blue')
+      || item.querySelector('a.con-button.blue') instanceof HTMLElement;
     if (isPrimaryCta) return 'primaryCta';
     const isSecondaryCta = item.closest('em') instanceof HTMLElement
-      || item.matches('a.con-button.outline');
+      || item.matches('a.con-button.outline')
+      || item.querySelector('a.con-button.outline') instanceof HTMLElement;
     if (isSecondaryCta) return 'secondaryCta';
     const isText = !(item.querySelector('a') instanceof HTMLElement);
     if (isText) return 'text';
@@ -1789,13 +1791,16 @@ class Gnav {
           return addMepHighlightAndTargetId(triggerTemplate, item);
         }
         case 'primaryCta':
-        case 'secondaryCta':
-          // Remove its 'em' or 'strong' wrapper
-          item.parentElement.replaceWith(item);
+        case 'secondaryCta': {
+          const ctaLink = item.matches('a') ? item : item.querySelector('a');
+          if (ctaLink.parentElement.tagName === 'STRONG' || ctaLink.parentElement.tagName === 'EM') {
+            ctaLink.parentElement.replaceWith(ctaLink);
+          }
 
           return addMepHighlightAndTargetId(toFragment`<div class="feds-navItem feds-navItem--centered" role="listitem">
-              ${decorateCta({ elem: item.classList.contains('merch') ? await (await import('../merch/merch.js')).default(item) : item, type: itemType, index: index + 1 })}
+              ${decorateCta({ elem: ctaLink.classList.contains('merch') ? await (await import('../merch/merch.js')).default(ctaLink) : ctaLink, type: itemType, index: index + 1 })}
             </div>`, item);
+        }
         case 'link': {
           let customLinkModifier = '';
           let removeCustomLink = false;

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -216,10 +216,15 @@ const decorateElements = async ({ elem, className = 'feds-navLink', itemIndex = 
     }
 
     // If the link is wrapped in a 'strong' or 'em' tag, make it a CTA
-    if (link.parentElement.tagName === 'STRONG' || link.parentElement.tagName === 'EM') {
-      const type = link.parentElement.tagName === 'EM' ? 'secondaryCta' : 'primaryCta';
-      // Remove its 'em' or 'strong' wrapper
-      link.parentElement.replaceWith(link);
+    const isPrimaryCta = link.parentElement.tagName === 'STRONG' || link.matches('a.con-button.blue');
+    const isSecondaryCta = !isPrimaryCta
+      && (link.parentElement.tagName === 'EM' || link.matches('a.con-button.outline'));
+    if (isPrimaryCta || isSecondaryCta) {
+      const type = isSecondaryCta ? 'secondaryCta' : 'primaryCta';
+      // Remove its 'em' or 'strong' wrapper, if still present
+      if (link.parentElement.tagName === 'STRONG' || link.parentElement.tagName === 'EM') {
+        link.parentElement.replaceWith(link);
+      }
       const clonedLink = link.cloneNode(true);
       const processedLink = link.classList.contains('merch') ? await merch.default(clonedLink) : link;
       const decoratedLink = decorateCta({ elem: processedLink, type, index: itemIndex.position });


### PR DESCRIPTION
* Merch/mas-field CTAs have their em/strong wrapper already consumed by the generic decorateButtons() in
   merch-card-autoblock.js, so fall back to the con-button/blue|outline classes it leaves behind to recover the same primary/secondary intent.

Resolves: [MWPW-202478](https://jira.corp.adobe.com/browse/MWPW-202478)

**Test URLs:**
- Before: https://main--edu--adobecom.aem.page/edu-shared/gnav/localnav-edu-tsay?martech=off
- After: https://main--edu--adobecom.aem.page/edu-shared/gnav/localnav-edu-tsay?martech=off&milolibs=mwpw-202478


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=MWPW-202478--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=MWPW-202478--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-202478--milo--adobecom
- Milo: https://MWPW-202478--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-202478--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-202478--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-202478--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-202478--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-202478--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-202478--milo--adobecom
- Milo: https://MWPW-202478--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-202478--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-202478--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-202478--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-202478--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-202478--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-202478--milo--adobecom
- Milo: https://MWPW-202478--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-202478--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-202478--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-202478--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-202478--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-202478--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-202478--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-202478--milo--adobecom
</details>