### PR TITLE
 MWPW-202632 [MEP] ACE1225 upload-marquee: poster image → video swap + CLS fix

### DIFF
--- a/libs/mep/ace1225/upload-marquee/upload-marquee.css
+++ b/libs/mep/ace1225/upload-marquee/upload-marquee.css
@@ -159,6 +159,11 @@
   background: var(--color-gray-800);
 }
 
+.upload-marquee-block .video-container .pause-play-wrapper:focus-visible {
+  outline: 2px solid var(--um-accent-focus);
+  outline-offset: 2px;
+}
+
 .upload-marquee-block .video-container .pause-play-wrapper img.accessibility-control {
   width: 40px;
   height: 40px;

--- a/libs/mep/ace1225/upload-marquee/upload-marquee.css
+++ b/libs/mep/ace1225/upload-marquee/upload-marquee.css
@@ -128,6 +128,45 @@
 .upload-marquee-block .upload-marquee-right .media-container .video-container {
   width: 100%;
   height: 100%;
+  position: relative;
+}
+
+/* Pause/play control: absolute + reserved 40x40 box so the async icon SVGs don't shift the
+   media (CLS). Mirrors libs/blocks/video/video.css, which a useBlockCode block doesn't load. */
+.upload-marquee-block .video-container .pause-play-wrapper {
+  position: absolute;
+  bottom: 2%;
+  top: auto;
+  inset-inline-end: 2%;
+  inset-inline-start: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+  padding: 3px;
+  border-radius: 50%;
+  z-index: 3;
+  cursor: pointer;
+}
+
+.upload-marquee-block .video-container .pause-play-wrapper .offset-filler {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: inherit;
+  background: var(--color-gray-800);
+}
+
+.upload-marquee-block .video-container .pause-play-wrapper img.accessibility-control {
+  width: 40px;
+  height: 40px;
+}
+
+.upload-marquee-block .video-container .pause-play-wrapper .offset-filler.is-playing .play-icon,
+.upload-marquee-block .video-container .pause-play-wrapper .offset-filler:not(.is-playing) .pause-icon {
+  display: none;
 }
 
 .upload-marquee-block .upload-marquee-uploads > .tablet-up,

--- a/libs/mep/ace1225/upload-marquee/upload-marquee.js
+++ b/libs/mep/ace1225/upload-marquee/upload-marquee.js
@@ -426,17 +426,23 @@ function setupLayoutDragAndDrop(layout, uploadsWrapper) {
   window.addEventListener('dragend', () => clearActiveDropZone());
 }
 
-// ace1225: turn an authored mp4 link in a cell into an accessible autoplay video via
-// milo's decorateAnchorVideo. It produces the `.video-container.video-holder` the block
-// already treats as media (so the video lands in the media column, not the dropzone), adds
-// a pause/play control, and lazy-appends the <source> on intersection — so a desktop-only
-// clip never downloads on the hidden mobile/tablet cells. The poster is authored as the
-// image's alt-text pipe-syntax (`<video-url>|<alt text>`, i.e. the Title field in Google
-// Docs' Alt-text dialog); milo's decorateImageLinks() already converts that into this anchor
-// with a `data-video-poster` attribute before this block's init() runs, so decorateAnchorVideo
-// picks up the poster natively — no manual picture/poster DOM surgery needed here.
+// Poster→video authoring: the mp4 URL is authored in the image's Title field (DA emits it as
+// `data-title`). Reshape the poster into the `<a href=mp4 data-video-poster=...>` that milo's
+// decorateImageLinks produces for its alt-pipe convention, so decorateAnchorVideo takes over.
+function bridgePosterVideoImage(cell) {
+  const img = cell.querySelector('img[data-title*=".mp4"]');
+  if (!img) return;
+  const posterEl = img.closest('picture') || img;
+  const anchor = createTag('a', {
+    href: img.dataset.title,
+    'data-video-poster': posterEl.outerHTML,
+  });
+  posterEl.replaceWith(anchor);
+}
+
 function decorateUploadVideos(uploadRow, decorateAnchorVideo) {
   [...uploadRow.children].forEach((cell) => {
+    bridgePosterVideoImage(cell);
     const videoLink = cell.querySelector('a[href*=".mp4"]');
     if (!videoLink) return;
     if (!videoLink.hash) videoLink.hash = '#autoplay';
@@ -522,8 +528,7 @@ export default async function init(el) {
     backgroundRow.classList.add('background');
     decorateBlockBg(el, backgroundRow, { useHandleFocalpoint: true });
   }
-  // Video must exist before decorateContentRow (setUploadRowMediaPriority) resizes its
-  // poster and sets preload — otherwise column.querySelector('video') finds nothing.
+  // Build the video first: decorateContentRow's setUploadRowMediaPriority needs the <video>.
   decorateUploadVideos(contentRow, decorateAnchorVideo);
   decorateContentRow(contentRow);
   const layoutParts = buildLayout();

--- a/libs/mep/ace1225/upload-marquee/upload-marquee.js
+++ b/libs/mep/ace1225/upload-marquee/upload-marquee.js
@@ -426,23 +426,11 @@ function setupLayoutDragAndDrop(layout, uploadsWrapper) {
   window.addEventListener('dragend', () => clearActiveDropZone());
 }
 
-// Poster→video authoring: the mp4 URL is authored in the image's Title field (DA emits it as
-// `data-title`). Reshape the poster into the `<a href=mp4 data-video-poster=...>` that milo's
-// decorateImageLinks produces for its alt-pipe convention, so decorateAnchorVideo takes over.
-function bridgePosterVideoImage(cell) {
-  const img = cell.querySelector('img[data-title*=".mp4"]');
-  if (!img) return;
-  const posterEl = img.closest('picture') || img;
-  const anchor = createTag('a', {
-    href: img.dataset.title,
-    'data-video-poster': posterEl.outerHTML,
-  });
-  posterEl.replaceWith(anchor);
-}
-
+// Poster→video authoring: author the mp4 URL in the image's alt text as `url#_autoplay | caption`.
+// Milo's decorateImageLinks() converts that into `<a href=mp4 data-video-poster=<picture>>` before
+// this block's init() runs, so we just hand the resulting anchor to decorateAnchorVideo.
 function decorateUploadVideos(uploadRow, decorateAnchorVideo) {
   [...uploadRow.children].forEach((cell) => {
-    bridgePosterVideoImage(cell);
     const videoLink = cell.querySelector('a[href*=".mp4"]');
     if (!videoLink) return;
     if (!videoLink.hash) videoLink.hash = '#autoplay';

--- a/libs/mep/ace1225/upload-marquee/upload-marquee.js
+++ b/libs/mep/ace1225/upload-marquee/upload-marquee.js
@@ -430,21 +430,21 @@ function setupLayoutDragAndDrop(layout, uploadsWrapper) {
 // milo's decorateAnchorVideo. It produces the `.video-container.video-holder` the block
 // already treats as media (so the video lands in the media column, not the dropzone), adds
 // a pause/play control, and lazy-appends the <source> on intersection — so a desktop-only
-// clip never downloads on the hidden mobile/tablet cells.
+// clip never downloads on the hidden mobile/tablet cells. The poster is authored as the
+// image's alt-text pipe-syntax (`<video-url>|<alt text>`, i.e. the Title field in Google
+// Docs' Alt-text dialog); milo's decorateImageLinks() already converts that into this anchor
+// with a `data-video-poster` attribute before this block's init() runs, so decorateAnchorVideo
+// picks up the poster natively — no manual picture/poster DOM surgery needed here.
 function decorateUploadVideos(uploadRow, decorateAnchorVideo) {
   [...uploadRow.children].forEach((cell) => {
     const videoLink = cell.querySelector('a[href*=".mp4"]');
     if (!videoLink) return;
-    const posterImg = cell.querySelector('picture img');
-    const posterSrc = posterImg?.getAttribute('src') || '';
     if (!videoLink.hash) videoLink.hash = '#autoplay';
     const src = videoLink.href.split('#')[0];
-    posterImg?.closest('picture')?.remove();
     // Move the link out of its <p> before decorating: decorateAnchorVideo swaps it for a
     // block-level <video> wrapper, which browsers fracture/misplace if left inside a <p>.
     cell.insertBefore(videoLink, cell.firstElementChild);
     decorateAnchorVideo({ src, anchorTag: videoLink });
-    if (posterSrc) cell.querySelector('video')?.setAttribute('poster', posterSrc);
   });
 }
 
@@ -522,8 +522,10 @@ export default async function init(el) {
     backgroundRow.classList.add('background');
     decorateBlockBg(el, backgroundRow, { useHandleFocalpoint: true });
   }
-  decorateContentRow(contentRow);
+  // Video must exist before decorateContentRow (setUploadRowMediaPriority) resizes its
+  // poster and sets preload — otherwise column.querySelector('video') finds nothing.
   decorateUploadVideos(contentRow, decorateAnchorVideo);
+  decorateContentRow(contentRow);
   const layoutParts = buildLayout();
   const marqueeCell = marqueeRow?.querySelector(':scope > div');
   const marqueeContent = marqueeCell ? buildMarqueeContent(marqueeCell) : null;


### PR DESCRIPTION
### What
  The media cell shows a poster image that swaps to the video once it buffers — **same slot, no layout change**. Authors put the mp4 URL in the image's **alt text** using milo's standard convention:
  `https://…/clip.mp4#_autoplay | caption`.

  ### Why
  The current code (from #6392) authors a separate `<picture>` + `.mp4` link and does manual DOM surgery to wire the poster, which is fragile — poster landing in the wrong place, video not loading. This
  replaces it with milo's native video/poster pipeline, and consolidates on the same `alt="url | caption"` convention the other fragments already use so authors don't have to remember which field each block
  expects.

  ### Changes
  - **Poster→video** — relies on milo's built-ins: `decorateImageLinks` (global) converts the alt-pipe image into an `<a href="…mp4" data-video-poster="…">` before the block runs, then `decorateAnchorVideo`
  (shared) builds the native `<video poster>`. `decorateUploadVideos` is now just glue (find anchor, ensure hash, lift out of `<p>`, hand off); drops the bespoke picture extraction.
  - **Ordering** — run `decorateUploadVideos` before `decorateContentRow` so the media-priority pass can find the `<video>`.
  - **CLS fix** — add the pause/play control styles `video.css` supplies but a `useBlockCode` block doesn't load (absolute positioning + reserved 40×40 `offset-filler`). Stops the async icon SVGs from
  reflowing the media.

  ### Authoring note
  The alt **must** contain a `|` and a full `https://` URL — both are how `decorateImageLinks` gates conversion. Missing either = static poster, no video, no error.

  ### Scope
  ace1225 MEP test code only (`libs/mep/ace1225/`), delivered via `useBlockCode`. **No shared/core files touched.**


  Resolves: [MWPW-202632](https://jira.corp.adobe.com/browse/MWPW-202632)
  - Test URL: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1225/ps-index/z-ace1225-index-new-b?milolibs=mep-ace1225-vid-poster&mep=%2Fproducts%2Fphotoshop.json--desktop---%2Fdrafts%2Fmarkp%2Funity-quick-check.json
 

  - PSI-check: https://mep-ace1225-vid-poster--milo--adobecom.aem.page/?martech=off



