### PR TITLE
MWPW-202734 MEP PZN Replace for Headless Fragment Field

### DIFF
--- a/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
+++ b/libs/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.js
@@ -318,9 +318,10 @@ export async function createCollection(el, options) {
   let attributes;
   if (Object.keys(mepFragments).length > 0) {
     const overrides = Object.entries(mepFragments)
-      .map(([fragment, data]) => `${fragment}:${data.content}`)
+      .filter(([, data]) => data['']?.content)
+      .map(([fragment, data]) => `${fragment}:${data[''].content}`)
       .join(',');
-    attributes = { overrides };
+    if (overrides) attributes = { overrides };
   }
   const collection = createTag('merch-card-collection', attributes, aemFragment);
   const container = createTag('div', null, collection);

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1516,11 +1516,9 @@ export const MEP_SELECTOR = 'mas';
 export function overrideOptions(fragment, options) {
   const { mep } = getConfig();
   const fragments = mep?.inBlock?.[MEP_SELECTOR]?.fragments;
-  if (fragments) {
-    const command = fragments[fragment];
-    if (command && command.action === 'replace') {
-      return { ...options, fragment: command.content };
-    }
+  const command = fragments?.[fragment]?.[options.field || ''];
+  if (command && command.action === 'replace') {
+    return { ...options, fragment: command.content };
   }
   return options;
 }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -516,18 +516,23 @@ function registerInBlockActions(command) {
     blockSelector = blockAndSelector.slice(1).join(' ');
     command.selector = blockSelector;
     if (blockSelector.startsWith('https://mas.adobe.com/')) {
-      const getFragmentId = (masUrl) => {
+      const getFragmentParams = (masUrl) => {
         const { hash } = new URL(masUrl);
         const hashValue = hash.startsWith('#') ? hash.substring(1) : hash;
         const searchParams = new URLSearchParams(hashValue);
-        return searchParams.get('fragment') || searchParams.get('query');
+        return {
+          fragment: searchParams.get('fragment') || searchParams.get('query'),
+          field: searchParams.get('field') || '',
+        };
       };
-      blockSelector = getFragmentId(blockSelector);
+      const { fragment: sourceFragment, field } = getFragmentParams(blockSelector);
+      blockSelector = sourceFragment;
       if (blockSelector) {
         config.mep.inBlock[blockName].fragments ??= {};
         const { fragments } = config.mep.inBlock[blockName];
-        command.content = getFragmentId(command.content);
-        fragments[blockSelector] = command;
+        command.content = getFragmentParams(command.content).fragment;
+        fragments[blockSelector] ??= {};
+        fragments[blockSelector][field] = command;
         let overridesParent = document.querySelector('div.mas-overrides');
         if (!overridesParent) {
           overridesParent = createTag('div', { style: 'display: none;', class: 'mas-overrides' });

--- a/test/blocks/mas-compare-chart-autoblock/mas-compare-chart-autoblock.test.js
+++ b/test/blocks/mas-compare-chart-autoblock/mas-compare-chart-autoblock.test.js
@@ -140,9 +140,11 @@ describe('mas-compare-chart-autoblock', () => {
           mas: {
             fragments: {
               'compare-chart-original': {
-                action: 'replace',
-                manifestId: 'promo1.json',
-                content: 'compare-chart-promo',
+                '': {
+                  action: 'replace',
+                  manifestId: 'promo1.json',
+                  content: 'compare-chart-promo',
+                },
               },
             },
           },

--- a/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
+++ b/test/blocks/merch-card-autoblock/merch-card-autoblock.test.js
@@ -128,9 +128,11 @@ describe('merch-card-autoblock autoblock', () => {
             mas: {
               fragments: {
                 a657fd3d9f67: {
-                  action: 'replace',
-                  manifestId: 'promo1.json',
-                  content: '1234',
+                  '': {
+                    action: 'replace',
+                    manifestId: 'promo1.json',
+                    content: '1234',
+                  },
                 },
               },
             },
@@ -147,6 +149,39 @@ describe('merch-card-autoblock autoblock', () => {
       await init(a);
       const card = document.querySelector('merch-card');
       expect(card.querySelector('[slot="heading-xs"]')?.textContent).to.equal('Creative Cloud All Apps PROMO');
+    });
+
+    it('mep replace on one headless field does not affect other fields sharing the same source fragment', async () => {
+      setConfig({
+        mep: {
+          inBlock: {
+            mas: {
+              fragments: {
+                'field-scope-1': {
+                  cardTitle: {
+                    action: 'replace',
+                    content: '1234',
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      const title = document.createElement('a');
+      title.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=field-scope-1&field=cardTitle';
+      title.textContent = '[[field-scope-test:cardTitle]]';
+      const description = document.createElement('a');
+      description.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=field-scope-1&field=description';
+      description.textContent = '[[field-scope-test:description]]';
+      document.body.append(title, description);
+      await init(title);
+      await init(description);
+      const masFields = [...document.querySelectorAll('mas-field')];
+      const titleField = masFields.find((mf) => mf.getAttribute('field') === 'cardTitle');
+      const descriptionField = masFields.find((mf) => mf.getAttribute('field') === 'description');
+      expect(titleField.querySelector('aem-fragment').getAttribute('fragment')).to.equal('1234');
+      expect(descriptionField.querySelector('aem-fragment').getAttribute('fragment')).to.equal('field-scope-1');
     });
 
     it('creates mas-field wrapping aem-fragment with correct attributes', async () => {

--- a/test/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.test.js
+++ b/test/blocks/merch-card-collection-autoblock/merch-card-collection-autoblock.test.js
@@ -151,9 +151,11 @@ describe('merch-card-collection autoblock', () => {
             mas: {
               fragments: {
                 'e58f8f75-b882-409a-9ff8-8826b36a8368': {
-                  action: 'replace',
-                  manifestId: 'promo1.json',
-                  content: '1234',
+                  '': {
+                    action: 'replace',
+                    manifestId: 'promo1.json',
+                    content: '1234',
+                  },
                 },
               },
             },
@@ -183,14 +185,18 @@ describe('merch-card-collection autoblock', () => {
             mas: {
               fragments: {
                 'should-be-replaced': {
-                  action: 'replace',
-                  manifestId: 'promo1.json',
-                  content: 'promo-1',
+                  '': {
+                    action: 'replace',
+                    manifestId: 'promo1.json',
+                    content: 'promo-1',
+                  },
                 },
                 'should-also-be-replaced': {
-                  action: 'replace',
-                  manifestId: 'promo2.json',
-                  content: 'promo-2',
+                  '': {
+                    action: 'replace',
+                    manifestId: 'promo2.json',
+                    content: 'promo-2',
+                  },
                 },
               },
             },

--- a/test/features/personalization/actions.test.js
+++ b/test/features/personalization/actions.test.js
@@ -359,13 +359,15 @@ describe('custom actions', async () => {
       'mas-block': {
         fragments: {
           '64e0c5b8-9572-43e6-b0a7-fc68563589de': {
-            action: 'replace',
-            content: 'aec092ef-d5b5-4271-8b6f-4bbd535fcc56',
-            manifestId: false,
-            selector: 'https://mas.adobe.com/studio.html#page=content&path=sandbox&query=64e0c5b8-9572-43e6-b0a7-fc68563589de',
-            targetManifestId: false,
-            pageFilter: '',
-            selectorType: 'in-block:',
+            '': {
+              action: 'replace',
+              content: 'aec092ef-d5b5-4271-8b6f-4bbd535fcc56',
+              manifestId: false,
+              selector: 'https://mas.adobe.com/studio.html#page=content&path=sandbox&query=64e0c5b8-9572-43e6-b0a7-fc68563589de',
+              targetManifestId: false,
+              pageFilter: '',
+              selectorType: 'in-block:',
+            },
           },
         },
       },
@@ -392,6 +394,34 @@ describe('custom actions', async () => {
 
     expect(document.querySelector(lcpLink)).to.exist;
     expect(document.querySelector(notLcpLink)).not.to.exist;
+  });
+});
+
+describe('in-block:mas field-scoped replace', () => {
+  it('registers the replace under the targeted field only, not the whole fragment', async () => {
+    let manifestJson = await readFile({ path: './mocks/actions/manifestMasFieldReplace.json' });
+    manifestJson = JSON.parse(manifestJson);
+    setFetchResponse(manifestJson);
+
+    await init(mepSettings);
+
+    const { fragments } = getConfig().mep.inBlock.mas;
+    const entry = fragments['d4304085-20ed-4478-a0ef-27c146f1c9fd'];
+
+    expect(entry).to.deep.equal({
+      cardTitle: {
+        action: 'replace',
+        content: 'f3151128-a0fb-4946-97a6-72f4acea07e8',
+        manifestId: false,
+        targetManifestId: false,
+        pageFilter: '',
+        selector: 'https://mas.adobe.com/studio.html#content-type=merch-card&page=content&path=acom-cc&query=d4304085-20ed-4478-a0ef-27c146f1c9fd&field=cardTitle',
+        selectorType: 'in-block:',
+      },
+    });
+    // Only the cardTitle field was registered - no unscoped ('') entry that would
+    // leak the override to other fields (description, ctas, ...) sharing this fragment.
+    expect(Object.keys(entry)).to.deep.equal(['cardTitle']);
   });
 });
 

--- a/test/features/personalization/mocks/actions/manifestMasFieldReplace.json
+++ b/test/features/personalization/mocks/actions/manifestMasFieldReplace.json
@@ -1,0 +1,61 @@
+{
+  "info": {
+    "total": 3,
+    "offset": 0,
+    "limit": 3,
+    "data": [
+      {
+        "key": "manifest-type",
+        "value": "Personalization"
+      },
+      {
+        "key": "manifest-override-name",
+        "value": ""
+      },
+      {
+        "key": "manifest-execution-order",
+        "value": "Normal"
+      }
+    ],
+    "columns": [
+      "key",
+      "value"
+    ]
+  },
+  "experiences": {
+    "total": 1,
+    "offset": 0,
+    "limit": 1,
+    "data": [
+      {
+        "action": "replace",
+        "selector": "in-block:mas https://mas.adobe.com/studio.html#content-type=merch-card&page=content&path=acom-cc&query=d4304085-20ed-4478-a0ef-27c146f1c9fd&field=cardTitle",
+        "page filter (optional)": "",
+        "all": "https://mas.adobe.com/studio.html#content-type=merch-card&page=content&path=acom-cc&query=f3151128-a0fb-4946-97a6-72f4acea07e8&field=cardTitle"
+      }
+    ],
+    "columns": [
+      "action",
+      "selector",
+      "page filter (optional)",
+      "all"
+    ]
+  },
+  "placeholders": {
+    "total": 0,
+    "offset": 0,
+    "limit": 0,
+    "data": [],
+    "columns": [
+      "key",
+      "value"
+    ]
+  },
+  ":version": 3,
+  ":names": [
+    "info",
+    "experiences",
+    "placeholders"
+  ],
+  ":type": "multi-sheet"
+}


### PR DESCRIPTION
* Add field for MAS fragment override in personalization

Resolves: [MWPW-202734](https://jira.corp.adobe.com/browse/MWPW-202734)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/photoshop?mep=%2Fcc-shared%2Ffragments%2Ftests%2Fheadless-fragment-test.json--all
- After: https://main--da-cc--adobecom.aem.page/products/photoshop?mep=%2Fcc-shared%2Ffragments%2Ftests%2Fheadless-fragment-test.json--all&milolibs=mwpw-202734

The personalization file https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/headless-fragment-test.json wants to replace the cardTitle of the headless fragment only. 

