### PR TITLE
[MWPW-203011] C1 Gnav promo heading - ost pricing

### DIFF
--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -282,10 +282,17 @@ const decoratePromo = async (elem, index) => {
   }
 
   if (promoHeader?.textContent.trim()) {
-    const headingElem = toFragment`<div class="feds-promo-header" role="heading" aria-level="2">
-        ${promoHeader.textContent.trim()}
-      </div>`;
-    promoHeader.parentElement.replaceWith(headingElem);
+    const headingParagraph = promoHeader.parentElement;
+    const headingMerchLinks = headingParagraph.querySelectorAll('a.merch');
+    for (const link of headingMerchLinks) {
+      const priceEl = await merch.default(link.cloneNode(true));
+      if (priceEl instanceof HTMLElement) link.replaceWith(priceEl);
+    }
+    // Wrap heading in one inline <span> so the text and inline prices flow together on same line
+    const headingContent = document.createElement('span');
+    headingContent.append(...headingParagraph.childNodes);
+    const headingElem = toFragment`<div class="feds-promo-header" role="heading" aria-level="2">${headingContent}</div>`;
+    headingParagraph.replaceWith(headingElem);
   }
 
   await decorateElements({ elem, className: 'feds-promo-link', index });

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -288,6 +288,9 @@ const decoratePromo = async (elem, index) => {
       const priceEl = await merch.default(link.cloneNode(true));
       if (priceEl instanceof HTMLElement) link.replaceWith(priceEl);
     }
+    headingParagraph.querySelectorAll('strong').forEach((strong) => {
+      strong.replaceWith(...strong.childNodes);
+    });
     // Wrap heading in one inline <span> so the text and inline prices flow together on same line
     const headingContent = document.createElement('span');
     headingContent.append(...headingParagraph.childNodes);


### PR DESCRIPTION
Adding changes to resolve OST pricing for C1 Gnav promo heading

Resolves: [MWPW-203011](https://jira.corp.adobe.com/browse/MWPW-203011)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://c1promo-ost--milo--adobecom.aem.page/?martech=off

**QA:**
https://www.stage.adobe.com/uk/education.html?milolibs=c1promo-ost

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=c1promo-ost--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=c1promo-ost--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=c1promo-ost--milo--adobecom
- Milo: https://c1promo-ost--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=c1promo-ost--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=c1promo-ost--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=c1promo-ost--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=c1promo-ost--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=c1promo-ost--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=c1promo-ost--milo--adobecom
- Milo: https://c1promo-ost--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=c1promo-ost--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=c1promo-ost--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=c1promo-ost--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=c1promo-ost--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=c1promo-ost--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=c1promo-ost--milo--adobecom
- Milo: https://c1promo-ost--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=c1promo-ost--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=c1promo-ost--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=c1promo-ost--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=c1promo-ost--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=c1promo-ost--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=c1promo-ost--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=c1promo-ost--milo--adobecom
</details>