### PR TITLE
[MWPW-203122] - Cpro video mobile fullwidth

### DIFF
--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -494,7 +494,7 @@
   padding-top: calc(var(--s2a-layout-sm) + var(--rc-pull-offset));
   padding-bottom: var(--s2a-layout-lg);
   overflow: clip;
-  --grid-margin-width: 5px;
+  --grid-margin-width: 0px; /* Keep unit for calc */
 
   @media (width >= 768px) {
     --grid-margin-width: var(--grid-margin-width-base);
@@ -521,7 +521,6 @@
     picture {
       display: block;
       width: 100%;
-      aspect-ratio: 365 / 350;
       border-radius: var(--s2a-border-radius-24);
       overflow: hidden;
       transform-origin: center bottom;
@@ -535,16 +534,24 @@
       video {
         display: block;
         width: 100%;
-        height: 100%;
+        height: auto;
         object-fit: cover;
+
+        @media (width >= 768px) {
+          height: 100%;
+        }
       }
     }
 
     picture img {
       display: block;
       width: 100%;
-      height: 100%;
+      height: auto;
       object-fit: cover;
+
+      @media (width >= 768px) {
+        height: 100%;
+      }
     }
 
     .action-area {
@@ -837,6 +844,15 @@
     @media (width >= 1440px) {
       .section.parallax-video-garage-door:has(.rich-content.media) {
         animation-range: entry 0% entry 70%, exit 50% exit 90%;
+      }
+    }
+
+    /* Mobile video is full-width at a fixed size — no scale-in-on-scroll,
+       so the CTA that rides the same timeline stays put too. */
+    @media (width < 768px) {
+      .section.parallax-video-garage-door .rich-content.media :is(.cta-area, .media-cell .action-area) :is(a, button),
+      .section.parallax-video-garage-door .rich-content.media .media-cell :is(.video-container, picture) {
+        animation: none;
       }
     }
   }

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -586,7 +586,7 @@
     background: var(--glass-fill);
     background-clip: padding-box;
     box-shadow: inset 0 0 0 var(--glass-stroke) var(--glass-fill);
-    border-radius: var(--s2a-border-radius-24);
+    border-radius: var(--s2a-border-radius-16);
     backdrop-filter: blur(var(--s2a-blur-md));
     overflow: hidden;
 
@@ -607,7 +607,7 @@
 
     :is(img, video) {
       max-width: 100%;
-      border-radius: var(--s2a-border-radius-24);
+      border-radius: var(--s2a-border-radius-8);
     }
   }
 }

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -536,10 +536,6 @@
         width: 100%;
         height: auto;
         object-fit: cover;
-
-        @media (width >= 768px) {
-          height: 100%;
-        }
       }
     }
 
@@ -548,8 +544,11 @@
       width: 100%;
       height: auto;
       object-fit: cover;
+    }
 
-      @media (width >= 768px) {
+    @media (width >= 768px) {
+      .video-container video,
+      picture img {
         height: 100%;
       }
     }
@@ -850,9 +849,11 @@
     /* Mobile video is full-width at a fixed size — no scale-in-on-scroll,
        so the CTA that rides the same timeline stays put too. */
     @media (width < 768px) {
-      .section.parallax-video-garage-door .rich-content.media :is(.cta-area, .media-cell .action-area) :is(a, button),
-      .section.parallax-video-garage-door .rich-content.media .media-cell :is(.video-container, picture) {
-        animation: none;
+      .section.parallax-video-garage-door .rich-content.media {
+        :is(.cta-area, .media-cell .action-area) :is(a, button),
+        .media-cell :is(.video-container, picture) {
+          animation: none;
+        }
       }
     }
   }


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/MWPW-203122

- **Mobile (`<768px`)**: video is now full-width with 0 side padding, height follows the video's natural aspect ratio (no forced crop), and the scroll-linked scale-in animation is disabled (video no longer starts large and shrinks on scroll). Desktop/tablet behavior is unchanged.
- **`.glass-border` radius**: corrected from a flat `24px` (outer + inner) to `16px` outer / `8px` inner, matching Figma across all breakpoints.

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=cpro-video-mobile-fullwidth&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all




