### PR TITLE
[MWPW-201870] - C2 comparison a11y

### DIFF
--- a/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
+++ b/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
@@ -519,8 +519,8 @@ function setupResponsiveHiding(el) {
 
 function setAccessibilityLabels(el) {
   import('../../../features/placeholders.js').then(({ replaceKeyArray }) => {
-    replaceKeyArray(['choose-table-column', 'empty-table-cell', 'not-a-feature', 'primary-feature'], getConfig())
-      .then(([ariaLabel, emptyText, notAFeatureText, primaryFeatureText]) => {
+    replaceKeyArray(['choose-table-column', 'not-a-feature', 'primary-feature'], getConfig())
+      .then(([ariaLabel, notAFeatureText, primaryFeatureText]) => {
         [...el.querySelectorAll('.mobile-filter-select')].forEach((element, index) => element.setAttribute('aria-label', `${ariaLabel} ${index + 1}`));
 
         el.querySelectorAll('.table-cell > .cell-content').forEach((cellDiv) => {
@@ -539,7 +539,7 @@ function setAccessibilityLabels(el) {
             return;
           }
           if (!cellDiv.classList.contains('empty-cell') || cellDiv.querySelector('.sr-only')) return;
-          cellDiv.appendChild(createTag('span', { class: 'sr-only' }, emptyText));
+          cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
         });
       });
   });

--- a/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
+++ b/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
@@ -399,6 +399,7 @@ function processCellContent(child) {
 }
 
 function isEmptyCellContent(cellDiv) {
+  if (cellDiv.querySelector('.icon-checkmark, .icon-close')) return false;
   const content = cellDiv.textContent.trim();
   return !content || /^-+$/.test(content);
 }
@@ -518,14 +519,29 @@ function setupResponsiveHiding(el) {
 
 function setAccessibilityLabels(el) {
   import('../../../features/placeholders.js').then(({ replaceKeyArray }) => {
-    replaceKeyArray(['choose-table-column', 'empty-table-cell'], getConfig()).then(([ariaLabel, emptyText]) => {
-      [...el.querySelectorAll('.mobile-filter-select')].forEach((element, index) => element.setAttribute('aria-label', `${ariaLabel} ${index + 1}`));
+    replaceKeyArray(['choose-table-column', 'empty-table-cell', 'not-a-feature', 'primary-feature'], getConfig())
+      .then(([ariaLabel, emptyText, notAFeatureText, primaryFeatureText]) => {
+        [...el.querySelectorAll('.mobile-filter-select')].forEach((element, index) => element.setAttribute('aria-label', `${ariaLabel} ${index + 1}`));
 
-      el.querySelectorAll('.table-cell > .cell-content.empty-cell').forEach((cellDiv) => {
-        if (cellDiv.querySelector('.sr-only')) return;
-        cellDiv.appendChild(createTag('span', { class: 'sr-only' }, emptyText));
+        el.querySelectorAll('.table-cell > .cell-content').forEach((cellDiv) => {
+          const closeIcon = cellDiv.querySelector('.icon-close');
+          if (closeIcon) {
+            closeIcon.querySelector('title')?.remove();
+            closeIcon.setAttribute('aria-hidden', 'true');
+            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
+            return;
+          }
+          const checkmarkIcon = cellDiv.querySelector('.icon-checkmark');
+          if (checkmarkIcon) {
+            checkmarkIcon.querySelector('title')?.remove();
+            checkmarkIcon.setAttribute('aria-hidden', 'true');
+            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, primaryFeatureText));
+            return;
+          }
+          if (!cellDiv.classList.contains('empty-cell') || cellDiv.querySelector('.sr-only')) return;
+          cellDiv.appendChild(createTag('span', { class: 'sr-only' }, emptyText));
+        });
       });
-    });
   });
 }
 

--- a/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
+++ b/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
@@ -525,21 +525,17 @@ function setAccessibilityLabels(el) {
 
         el.querySelectorAll('.table-cell > .cell-content').forEach((cellDiv) => {
           const closeIcon = cellDiv.querySelector('.icon-close');
-          if (closeIcon) {
-            closeIcon.querySelector('title')?.remove();
-            closeIcon.setAttribute('aria-hidden', 'true');
-            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
-            return;
-          }
           const checkmarkIcon = cellDiv.querySelector('.icon-checkmark');
-          if (checkmarkIcon) {
-            checkmarkIcon.querySelector('title')?.remove();
-            checkmarkIcon.setAttribute('aria-hidden', 'true');
-            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, primaryFeatureText));
+          const icon = closeIcon || checkmarkIcon;
+
+          if (icon) {
+            icon.querySelector('title')?.remove();
+            icon.setAttribute('aria-hidden', 'true');
+          } else if (!cellDiv.classList.contains('empty-cell') || cellDiv.querySelector('.sr-only')) {
             return;
           }
-          if (!cellDiv.classList.contains('empty-cell') || cellDiv.querySelector('.sr-only')) return;
-          cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
+
+          cellDiv.appendChild(createTag('span', { class: 'sr-only' }, checkmarkIcon ? primaryFeatureText : notAFeatureText));
         });
       });
   });

--- a/libs/mep/ace1205/comparison-table-c2/comparison-table-c2.js
+++ b/libs/mep/ace1205/comparison-table-c2/comparison-table-c2.js
@@ -400,6 +400,7 @@ function processCellContent(child) {
 }
 
 function isEmptyCellContent(cellDiv) {
+  if (cellDiv.querySelector('.icon-checkmark, .icon-close')) return false;
   const content = cellDiv.textContent.trim();
   return !content || /^-+$/.test(content);
 }
@@ -519,14 +520,29 @@ function setupResponsiveHiding(el) {
 
 function setAccessibilityLabels(el) {
   import('../../../features/placeholders.js').then(({ replaceKeyArray }) => {
-    replaceKeyArray(['choose-table-column', 'empty-table-cell'], getConfig()).then(([ariaLabel, emptyText]) => {
-      [...el.querySelectorAll('.mobile-filter-select')].forEach((element, index) => element.setAttribute('aria-label', `${ariaLabel} ${index + 1}`));
+    replaceKeyArray(['choose-table-column', 'not-a-feature', 'primary-feature'], getConfig())
+      .then(([ariaLabel, notAFeatureText, primaryFeatureText]) => {
+        [...el.querySelectorAll('.mobile-filter-select')].forEach((element, index) => element.setAttribute('aria-label', `${ariaLabel} ${index + 1}`));
 
-      el.querySelectorAll('.table-cell > .cell-content.empty-cell').forEach((cellDiv) => {
-        if (cellDiv.querySelector('.sr-only')) return;
-        cellDiv.appendChild(createTag('span', { class: 'sr-only' }, emptyText));
+        el.querySelectorAll('.table-cell > .cell-content').forEach((cellDiv) => {
+          const closeIcon = cellDiv.querySelector('.icon-close');
+          if (closeIcon) {
+            closeIcon.querySelector('title')?.remove();
+            closeIcon.setAttribute('aria-hidden', 'true');
+            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
+            return;
+          }
+          const checkmarkIcon = cellDiv.querySelector('.icon-checkmark');
+          if (checkmarkIcon) {
+            checkmarkIcon.querySelector('title')?.remove();
+            checkmarkIcon.setAttribute('aria-hidden', 'true');
+            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, primaryFeatureText));
+            return;
+          }
+          if (!cellDiv.classList.contains('empty-cell') || cellDiv.querySelector('.sr-only')) return;
+          cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
+        });
       });
-    });
   });
 }
 

--- a/libs/mep/ace1205/comparison-table-c2/comparison-table-c2.js
+++ b/libs/mep/ace1205/comparison-table-c2/comparison-table-c2.js
@@ -400,7 +400,6 @@ function processCellContent(child) {
 }
 
 function isEmptyCellContent(cellDiv) {
-  if (cellDiv.querySelector('.icon-checkmark, .icon-close')) return false;
   const content = cellDiv.textContent.trim();
   return !content || /^-+$/.test(content);
 }
@@ -520,29 +519,14 @@ function setupResponsiveHiding(el) {
 
 function setAccessibilityLabels(el) {
   import('../../../features/placeholders.js').then(({ replaceKeyArray }) => {
-    replaceKeyArray(['choose-table-column', 'not-a-feature', 'primary-feature'], getConfig())
-      .then(([ariaLabel, notAFeatureText, primaryFeatureText]) => {
-        [...el.querySelectorAll('.mobile-filter-select')].forEach((element, index) => element.setAttribute('aria-label', `${ariaLabel} ${index + 1}`));
+    replaceKeyArray(['choose-table-column', 'empty-table-cell'], getConfig()).then(([ariaLabel, emptyText]) => {
+      [...el.querySelectorAll('.mobile-filter-select')].forEach((element, index) => element.setAttribute('aria-label', `${ariaLabel} ${index + 1}`));
 
-        el.querySelectorAll('.table-cell > .cell-content').forEach((cellDiv) => {
-          const closeIcon = cellDiv.querySelector('.icon-close');
-          if (closeIcon) {
-            closeIcon.querySelector('title')?.remove();
-            closeIcon.setAttribute('aria-hidden', 'true');
-            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
-            return;
-          }
-          const checkmarkIcon = cellDiv.querySelector('.icon-checkmark');
-          if (checkmarkIcon) {
-            checkmarkIcon.querySelector('title')?.remove();
-            checkmarkIcon.setAttribute('aria-hidden', 'true');
-            cellDiv.appendChild(createTag('span', { class: 'sr-only' }, primaryFeatureText));
-            return;
-          }
-          if (!cellDiv.classList.contains('empty-cell') || cellDiv.querySelector('.sr-only')) return;
-          cellDiv.appendChild(createTag('span', { class: 'sr-only' }, notAFeatureText));
-        });
+      el.querySelectorAll('.table-cell > .cell-content.empty-cell').forEach((cellDiv) => {
+        if (cellDiv.querySelector('.sr-only')) return;
+        cellDiv.appendChild(createTag('span', { class: 'sr-only' }, emptyText));
       });
+    });
   });
 }
 

--- a/test/blocks/comparison-table-c2/comparison-table-c2.test.js
+++ b/test/blocks/comparison-table-c2/comparison-table-c2.test.js
@@ -146,6 +146,36 @@ describe('Comparison Table C2', () => {
     expect(srOnly.textContent).to.equal('Not included');
   });
 
+  it('close icon has an accessible name distinguishing it from an empty cell', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/icons.html' });
+    const el = document.querySelector('.comparison-table-c2');
+    init(el);
+
+    const closeIcon = el.querySelector('.icon-close');
+    await waitFor(() => closeIcon.closest('.cell-content').querySelector('.sr-only'), 2000);
+
+    expect(closeIcon.getAttribute('aria-hidden')).to.equal('true');
+    expect(closeIcon.closest('.cell-content').classList.contains('empty-cell')).to.be.false;
+    const srOnly = closeIcon.closest('.cell-content').querySelector('.sr-only');
+    expect(srOnly).to.exist;
+    expect(srOnly.textContent).to.equal('not a feature');
+  });
+
+  it('checkmark icon has an sr-only accessible name and no native title', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/icons.html' });
+    const el = document.querySelector('.comparison-table-c2');
+    init(el);
+
+    const checkmarkIcon = el.querySelector('.icon-checkmark');
+    await waitFor(() => checkmarkIcon.closest('.cell-content').querySelector('.sr-only'), 2000);
+
+    expect(checkmarkIcon.getAttribute('aria-hidden')).to.equal('true');
+    expect(checkmarkIcon.querySelector('title')).to.not.exist;
+    const srOnly = checkmarkIcon.closest('.cell-content').querySelector('.sr-only');
+    expect(srOnly).to.exist;
+    expect(srOnly.textContent).to.equal('primary feature');
+  });
+
   it('builds a labelled mobile filter select per column when there are 3+ columns', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/three-columns.html' });
     const el = document.querySelector('.comparison-table-c2');

--- a/test/blocks/comparison-table-c2/comparison-table-c2.test.js
+++ b/test/blocks/comparison-table-c2/comparison-table-c2.test.js
@@ -134,7 +134,7 @@ describe('Comparison Table C2', () => {
     expect(el.textContent).to.not.contain('+++');
   });
 
-  it('adds placeholder-driven screen-reader text to empty cells', async () => {
+  it('adds "not a feature" screen-reader text to empty (dash) cells', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/default.html' });
     const el = document.querySelector('.comparison-table-c2');
     init(el);
@@ -143,7 +143,7 @@ describe('Comparison Table C2', () => {
     await waitFor(() => el.querySelector('.cell-content.empty-cell .sr-only'), 2000);
     const srOnly = el.querySelector('.cell-content.empty-cell .sr-only');
     expect(srOnly).to.exist;
-    expect(srOnly.textContent).to.equal('Not included');
+    expect(srOnly.textContent).to.equal('not a feature');
   });
 
   it('close icon has an accessible name distinguishing it from an empty cell', async () => {

--- a/test/blocks/comparison-table-c2/mocks/icons.html
+++ b/test/blocks/comparison-table-c2/mocks/icons.html
@@ -1,0 +1,35 @@
+<main>
+  <div class="section">
+    <div class="comparison-table-c2">
+      <div>
+        <div><h2>Compare plans</h2><p>Pick the best plan for you.</p></div>
+        <div>
+          <h3>Free</h3>
+          <p><strong>$0</strong></p>
+          <p>-</p>
+          <p>Basic features included</p>
+          <p>-</p>
+          <p><em><a href="#free">Choose Free</a></em></p>
+        </div>
+        <div>
+          <h3>Pro</h3>
+          <p><strong>$9.99</strong></p>
+          <p>-</p>
+          <p>All features included</p>
+          <p>-</p>
+          <p><em><a href="#pro">Choose Pro</a></em></p>
+        </div>
+      </div>
+      <div>
+        <div><h4>Features</h4></div>
+        <div></div>
+        <div>primary</div>
+      </div>
+      <div>
+        <div>Priority support</div>
+        <div><span class="icon icon-close"></span></div>
+        <div><span class="icon icon-checkmark"><svg><title>Checkmark</title></svg></span></div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/comparison-table-c2/mocks/placeholders.json
+++ b/test/blocks/comparison-table-c2/mocks/placeholders.json
@@ -1,9 +1,11 @@
 {
-  "total": 2,
+  "total": 4,
   "offset": 0,
-  "limit": 2,
+  "limit": 4,
   "data": [
     { "key": "choose-table-column", "value": "Choose table column" },
-    { "key": "empty-table-cell", "value": "Not included" }
+    { "key": "empty-table-cell", "value": "Not included" },
+    { "key": "not-a-feature", "value": "not a feature" },
+    { "key": "primary-feature", "value": "primary feature" }
   ]
 }

--- a/test/blocks/comparison-table-c2/mocks/placeholders.json
+++ b/test/blocks/comparison-table-c2/mocks/placeholders.json
@@ -1,10 +1,9 @@
 {
-  "total": 4,
+  "total": 3,
   "offset": 0,
-  "limit": 4,
+  "limit": 3,
   "data": [
     { "key": "choose-table-column", "value": "Choose table column" },
-    { "key": "empty-table-cell", "value": "Not included" },
     { "key": "not-a-feature", "value": "not a feature" },
     { "key": "primary-feature", "value": "primary feature" }
   ]


### PR DESCRIPTION
Strip the icon <title> and mark icons aria-hidden, replacing them with an equivalent visually-hidden (sr-only) label: "not a feature" for the X icon or empty, "primary feature" for the checkmark.
Apply the same "not a feature" label to empty cells that don't already have an sr-only label.

Resolves: [MWPW-201870](https://jira.corp.adobe.com/browse/MWPW-201870)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/drafts/dusan/comparison-table-c2-a11y-test?milolibs=stage
- After: https://main--da-dc--adobecom.aem.page/drafts/dusan/comparison-table-c2-a11y-test?milolibs=c2-comparison-a11y


