### PR TITLE
[MWPW-201436] - Garage door remove dip

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1337,6 +1337,8 @@ span.hang-opening-quote {
     --gd-grow-from: -50vh;
     --gd-reveal-from: 20vh;
     --gd-range-end: cover 36%;
+    --gd-foreground-range: entry -35% cover 50%;
+    --gd-line-height-range: cover 20% cover 50%;
 
     transform-origin: top center;
     animation: garage-door-grow linear both;
@@ -1352,6 +1354,10 @@ span.hang-opening-quote {
     animation-timeline: --gd-timeline;
     animation-range: entry 0% var(--gd-range-end);
 
+    @media (width >= 768px){
+      --gd-line-height-range: cover 30% cover 50%;
+    }
+
     @media (width >= 1280px) {
       /* Capped so the entry travel distance can't outrun the scroll
          distance the --gd-timeline range actually covers on tall
@@ -1361,12 +1367,15 @@ span.hang-opening-quote {
       --gd-grow-from: max(-90vh, -1050px);
       --gd-reveal-from: 30vh;
       --gd-range-end: cover 48%;
+      --gd-foreground-range: cover -10% cover 50%;
     }
 
     @media (width >= 1920px) {
       --gd-grow-from: max(-70vh, -800px);
       --gd-range-end: cover 36%;
       --gd-reveal-from: 30vh;
+      --gd-foreground-range: cover -30% cover 50%;
+      --gd-line-height-range: cover 20% cover 50%;
     }
 
     .section-background {
@@ -1384,12 +1393,12 @@ span.hang-opening-quote {
       position: relative;
       animation: garage-door-reveal ease-out both;
       animation-timeline: --gd-timeline;
-      animation-range: cover -30% cover 50%;
+      animation-range: var(--gd-foreground-range);
 
       * {
         animation: garage-door-line-height ease-out both;
         animation-timeline: --gd-timeline;
-        animation-range: cover 30% cover 50%;
+        animation-range: var(--gd-line-height-range);
       }
     }
   }

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1359,7 +1359,7 @@ span.hang-opening-quote {
          faster than the page scrolls, and it visibly dips down before
          pulling up. */
       --gd-grow-from: max(-90vh, -1050px);
-      --gd-reveal-from: 30vh;
+      --gd-reveal-from: 20vh;
       --gd-range-end: cover 48%;
     }
 
@@ -1381,9 +1381,9 @@ span.hang-opening-quote {
     .foreground {
       z-index: 1;
       position: relative;
-      animation: garage-door-reveal linear both;
+      animation: garage-door-reveal ease-out both;
       animation-timeline: --gd-timeline;
-      animation-range: entry 0% var(--gd-range-end);
+      animation-range: entry 0% cover 42%;
 
       * {
         animation: garage-door-line-height ease-out both;
@@ -1399,7 +1399,8 @@ span.hang-opening-quote {
   }
 
   @keyframes garage-door-reveal {
-    from { transform: translateY(var(--gd-reveal-from)); }
+    0%, 65% { transform: translateY(var(--gd-reveal-from)); }
+    100% { transform: translateY(0); }
   }
 
   @keyframes garage-door-bg-scale {

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1340,7 +1340,16 @@ span.hang-opening-quote {
 
     transform-origin: top center;
     animation: garage-door-grow ease-out both;
-    animation-timeline: view();
+
+    /* Named so .foreground can share this exact timeline below — view()
+       timelines are scoped to each element's own geometry, so giving
+       .foreground its own anonymous view() (even with identical range
+       percentages) maps to a different scroll position than the
+       section's, and the two transforms briefly fight each other on
+       entry. That mismatch was the reported "dip". */
+    view-timeline-name: --gd-timeline;
+    view-timeline-axis: block;
+    animation-timeline: --gd-timeline;
     animation-range: entry 0% var(--gd-range-end);
 
     @media (width >= 1280px) {
@@ -1368,12 +1377,7 @@ span.hang-opening-quote {
       z-index: 1;
       position: relative;
       animation: garage-door-reveal ease-out both;
-      animation-timeline: view();
-
-      /* Same range as the section's own grow animation (not its own,
-         later-starting range) so the two motions move together instead
-         of the foreground sitting still while its parent section is
-         still settling — that gap was the reported "dip". */
+      animation-timeline: --gd-timeline;
       animation-range: entry 0% var(--gd-range-end);
 
       * {

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1359,13 +1359,14 @@ span.hang-opening-quote {
          faster than the page scrolls, and it visibly dips down before
          pulling up. */
       --gd-grow-from: max(-90vh, -1050px);
-      --gd-reveal-from: 20vh;
+      --gd-reveal-from: 30vh;
       --gd-range-end: cover 48%;
     }
 
     @media (width >= 1920px) {
       --gd-grow-from: max(-70vh, -800px);
       --gd-range-end: cover 36%;
+      --gd-reveal-from: 30vh;
     }
 
     .section-background {
@@ -1383,12 +1384,12 @@ span.hang-opening-quote {
       position: relative;
       animation: garage-door-reveal ease-out both;
       animation-timeline: --gd-timeline;
-      animation-range: entry 0% cover 42%;
+      animation-range: cover -30% cover 50%;
 
       * {
         animation: garage-door-line-height ease-out both;
-        animation-timeline: view();
-        animation-range: entry 30% cover 60%;
+        animation-timeline: --gd-timeline;
+        animation-range: cover 30% cover 50%;
       }
     }
   }

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1336,21 +1336,22 @@ span.hang-opening-quote {
   .section.parallax-garage-door-reveal {
     --gd-grow-from: -50vh;
     --gd-reveal-from: 20vh;
+    --gd-range-end: cover 36%;
 
     transform-origin: top center;
     animation: garage-door-grow ease-out both;
     animation-timeline: view();
-    animation-range: entry 0% cover 36%;
+    animation-range: entry 0% var(--gd-range-end);
 
     @media (width >= 1280px) {
       --gd-grow-from: -90vh;
       --gd-reveal-from: 30vh;
-      animation-range: entry 0% cover 48%;
+      --gd-range-end: cover 48%;
     }
 
     @media (width >= 1920px) {
       --gd-grow-from: -70vh;
-      animation-range: entry 0% cover 36%;
+      --gd-range-end: cover 36%;
     }
 
     .section-background {
@@ -1368,7 +1369,12 @@ span.hang-opening-quote {
       position: relative;
       animation: garage-door-reveal ease-out both;
       animation-timeline: view();
-      animation-range: cover -10% cover 70%;
+
+      /* Same range as the section's own grow animation (not its own,
+         later-starting range) so the two motions move together instead
+         of the foreground sitting still while its parent section is
+         still settling — that gap was the reported "dip". */
+      animation-range: entry 0% var(--gd-range-end);
 
       * {
         animation: garage-door-line-height ease-out both;

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1339,7 +1339,7 @@ span.hang-opening-quote {
     --gd-range-end: cover 36%;
 
     transform-origin: top center;
-    animation: garage-door-grow ease-out both;
+    animation: garage-door-grow linear both;
 
     /* Named so .foreground can share this exact timeline below — view()
        timelines are scoped to each element's own geometry, so giving
@@ -1376,7 +1376,7 @@ span.hang-opening-quote {
     .foreground {
       z-index: 1;
       position: relative;
-      animation: garage-door-reveal ease-out both;
+      animation: garage-door-reveal linear both;
       animation-timeline: --gd-timeline;
       animation-range: entry 0% var(--gd-range-end);
 

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1353,13 +1353,18 @@ span.hang-opening-quote {
     animation-range: entry 0% var(--gd-range-end);
 
     @media (width >= 1280px) {
-      --gd-grow-from: -90vh;
+      /* Capped so the entry travel distance can't outrun the scroll
+         distance the --gd-timeline range actually covers on tall
+         viewports — otherwise the section's transform recovers toward 0
+         faster than the page scrolls, and it visibly dips down before
+         pulling up. */
+      --gd-grow-from: max(-90vh, -1050px);
       --gd-reveal-from: 30vh;
       --gd-range-end: cover 48%;
     }
 
     @media (width >= 1920px) {
-      --gd-grow-from: -70vh;
+      --gd-grow-from: max(-70vh, -800px);
       --gd-range-end: cover 36%;
     }
 


### PR DESCRIPTION
- `.foreground` and the `.section` were each on their own anonymous `view()` timeline, so identical range percentages still mapped to different scroll positions and the two transforms briefly fought each other on entry. Fixed by sharing one named `--gd-timeline` between them.
- The grow animation used `ease-out`, whose initial slope could exceed scroll speed and reintroduce the dip. Switched to `linear`.
- `--gd-grow-from` was expressed purely in `vh`, but the scroll distance the `entry`/`cover` timeline range actually spans scales with `viewport height + section height` — a different relationship. On tall viewports for a given width bucket (e.g. `2560x1300`), the transform recovered toward `0` faster than the page scrolled, producing a net downward dip before the pull-up resumed. Capped `--gd-grow-from` with `max()` per breakpoint so it only engages above the height where that overshoot occurs.

Resolves: [MWPW-201436](https://jira.corp.adobe.com/browse/MWPW-201436)

**HP Test URLs:**
- Before: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=stage
- After: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=garage-door-remove-dip

**BizPro Wave 2 Garage Test URLs:**
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-offer?milolibs=garage-door-remove-dip



