### PR TITLE
MWPW-203052 - M@S info mutation observer bug

### DIFF
--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -18,6 +18,7 @@ import {
   setPreviewButton,
   getMasRegions,
   findGeoGroupForLocale,
+  hasMasChanges,
 } from './mep-overlay-logic.js';
 import {
   TOGGLE_KEYS,
@@ -558,7 +559,8 @@ function setMasObserver() {
   };
 
   let debounceTimer;
-  const masObserver = new MutationObserver(() => {
+  const masObserver = new MutationObserver((mutations) => {
+    if (!hasMasChanges(mutations)) return;
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(runRefreshes, 200);
   });


### PR DESCRIPTION
**Updates**
* Fix MEP Next overlay's M@S card in the drawer causing an infinite self-triggering re-render loop, flooding DevTools with constant DOM churn — its `MutationObserver` watched `document.body` unfiltered, so `refreshMasSummary()`'s own `replaceChildren()` on the drawer counted as a mutation and immediately retriggered itself every ~200ms, forever
* Filter mutations through the existing (previously unused) `hasMasChanges` helper so the observer only reacts to real M@S content changes (`merch-card`, `mas-field`, `[data-mas-block]`, `[data-wcs-osi]`), not the drawer's own re-renders

**Instructions**

1. Open a page with M@S content (merch-cards / inline pricing / OST links) with the MEP overlay enabled (`?mepnext=on&mep`).
2. Open the drawer (FAB → M@S tab) and open Chrome DevTools → Elements, expanded on the drawer's `.mep-card-body` for M@S.
<img width="264" height="513" alt="image" src="https://github.com/user-attachments/assets/e64d3584-788a-4651-9f2e-c18777ffb3db" />

4. Before the fix: watch the M@S card's rows flicker/reinsert continuously in the Elements panel, roughly every 200ms, even with no real M@S content changes.
5. After the fix: the M@S card renders once and stays stable — no repeated teardown/rebuild — while still updating correctly when actual M@S surfaces (cards, collections, offers) are added to the page.

Resolves: [MWPW-203052](https://jira.corp.adobe.com/browse/MWPW-203052)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/photoshop?mep&mepnext=on
- After: https://main--da-cc--adobecom.aem.page/products/photoshop?mep&mepnext=on&milolibs=mn-mas-mutation-bug
- Psi: https://mn-mas-mutation-bug--milo--adobecom.aem.page/?martech=off


