### PR TITLE
MWPW-203261: Hang localized opening quotes in rich-content

### DIFF
--- a/libs/c2/blocks/rich-content/rich-content.js
+++ b/libs/c2/blocks/rich-content/rich-content.js
@@ -5,12 +5,6 @@ const HERO_OVERLAY_PROP = '--rc-hero-overlay';
 
 function hangOpeningQuote(header) {
   if (!header) return;
-  // \p{Pi} = high curly quotes (“ ‘) and guillemets (« ‹). Also match opening quotes that
-  // Unicode files under Ps/Po instead of Pi: straight " (U+0022); German / Central- &
-  // Eastern-European low-9 „ ‚ (U+201E, U+201A); CJK corner brackets 「 『 ｢ ﹁ ﹃
-  // (U+300C, U+300E, U+FF62, U+FE41, U+FE43); full-width ＂ (U+FF02); reversed low-9 ⹂
-  // (U+2E42). The straight single quote (') is intentionally excluded to avoid mangling
-  // headings like "'90s nostalgia" / "'Twas".
   const openingQuotes = /^(\p{Pi}|["„‚「『｢﹁﹃＂⹂])/u;
   const match = header.textContent.match(openingQuotes);
   if (!match) return;

--- a/libs/c2/blocks/rich-content/rich-content.js
+++ b/libs/c2/blocks/rich-content/rich-content.js
@@ -5,7 +5,13 @@ const HERO_OVERLAY_PROP = '--rc-hero-overlay';
 
 function hangOpeningQuote(header) {
   if (!header) return;
-  const openingQuotes = /^(\p{Pi})/u;
+  // \p{Pi} = high curly quotes (“ ‘) and guillemets (« ‹). Also match opening quotes that
+  // Unicode files under Ps/Po instead of Pi: straight " (U+0022); German / Central- &
+  // Eastern-European low-9 „ ‚ (U+201E, U+201A); CJK corner brackets 「 『 ｢ ﹁ ﹃
+  // (U+300C, U+300E, U+FF62, U+FE41, U+FE43); full-width ＂ (U+FF02); reversed low-9 ⹂
+  // (U+2E42). The straight single quote (') is intentionally excluded to avoid mangling
+  // headings like "'90s nostalgia" / "'Twas".
+  const openingQuotes = /^(\p{Pi}|["„‚「『｢﹁﹃＂⹂])/u;
   const match = header.textContent.match(openingQuotes);
   if (!match) return;
   const quote = match[1];

--- a/test/blocks/rich-content/rich-content.test.js
+++ b/test/blocks/rich-content/rich-content.test.js
@@ -28,6 +28,29 @@ describe('Rich Content', () => {
     expect(heading.firstElementChild).to.equal(quote);
   });
 
+  ['"', '„', '‚', '「', '『'].forEach((mark) => {
+    it(`hangs a non-Pi opening quote (${mark}) into its own span`, () => {
+      document.body.innerHTML = `<main><div class="section"><div class="rich-content"><div><div>
+        <h2>${mark}Localized heading</h2><p>Copy.</p></div></div></div></div></main>`;
+      const block = document.querySelector('.rich-content');
+      init(block);
+
+      const quote = block.querySelector('.content h2 .opening-quote');
+      expect(quote).to.exist;
+      expect(quote.textContent).to.equal(mark);
+      expect(block.querySelector('.content h2').firstElementChild).to.equal(quote);
+    });
+  });
+
+  it("does not hang a straight single quote (') so headings like '90s stay intact", () => {
+    document.body.innerHTML = `<main><div class="section"><div class="rich-content"><div><div>
+      <h2>'90s nostalgia</h2><p>Copy.</p></div></div></div></div></main>`;
+    const block = document.querySelector('.rich-content');
+    init(block);
+
+    expect(block.querySelector('.opening-quote')).to.be.null;
+  });
+
   it('does not add an opening-quote span when the heading has no opening quote', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/no-quote.html' });
     const block = document.querySelector('.rich-content');

--- a/test/blocks/rich-content/rich-content.test.js
+++ b/test/blocks/rich-content/rich-content.test.js
@@ -28,6 +28,11 @@ describe('Rich Content', () => {
     expect(heading.firstElementChild).to.equal(quote);
   });
 
+  // hangOpeningQuote matches \p{Pi} (curly quotes “ ‘, guillemets « ‹) plus a whitelist of
+  // opening quotes Unicode files under Ps/Po: straight " (U+0022), German/CE-European low-9
+  // „ ‚ (U+201E, U+201A), CJK corner brackets 「 『 ｢ ﹁ ﹃, full-width ＂, reversed low-9 ⹂.
+  // An explicit whitelist (not \p{Ps}) keeps ( [ { from hanging; straight ' is excluded so
+  // headings like "'90s nostalgia" stay intact. The cases below lock in that behaviour.
   ['"', '„', '‚', '「', '『'].forEach((mark) => {
     it(`hangs a non-Pi opening quote (${mark}) into its own span`, () => {
       document.body.innerHTML = `<main><div class="section"><div class="rich-content"><div><div>


### PR DESCRIPTION
Broadens rich-content's opening-quote hanging beyond curly quotes and guillemets (`\p{Pi}`) to cover opening quotes used across other languages, so localized quote headers hang consistently instead of sitting inline.

Newly hung:
- Straight `"` (U+0022)
- German / Central- & Eastern-European low-9 `„` `‚` (U+201E, U+201A)
- CJK corner brackets `「` `『` `｢` `﹁` `﹃` (U+300C, U+300E, U+FF62, U+FE41, U+FE43)
- Full-width `＂` (U+FF02) and reversed low-9 `⹂` (U+2E42)

Uses an explicit character whitelist rather than `\p{Ps}`, so open punctuation like `(` `[` `{` does not hang. The straight single quote `'` stays excluded to avoid mangling headings like "'90s nostalgia".

Resolves: N/A (no Jira ticket)

**Test URLs** (redesign demo, C2 rich-content in a carousel):
- Before: https://main--upp--adobecom.aem.page/drafts/mgardziola/homepage?martech=off
- After: https://main--upp--adobecom.aem.page/drafts/mgardziola/homepage?martech=off&milolibs=hang-localized-opening-quotes--milo--tabletalkstudio

Dedicated i18n carousel (one language per slide, with controls):
- Before: https://main--upp--adobecom.aem.page/drafts/mgardziola/hang-quote-i18n?martech=off
- After: https://main--upp--adobecom.aem.page/drafts/mgardziola/hang-quote-i18n?martech=off&milolibs=hang-localized-opening-quotes--milo--tabletalkstudio

Milo preview:
- After: https://hang-localized-opening-quotes--milo--tabletalkstudio.aem.page/?martech=off

**Testing:**
- `npm run lint` — clean
- Unit tests — added coverage for each new opening-quote character and for the excluded straight single quote; `test/blocks/rich-content/rich-content.test.js` passes (13 tests)




