### PR TITLE
MWPW-202828 bind en/(uk,au,in) to m@s en_GB

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -182,6 +182,11 @@ export const GeoMap = {
 const EXTRA_MAS_LOCALES = { pr: 'es_PR' };
 
 /**
+ * MAS locale overrides for markets that share a language but have different country codes
+ */
+const MARKET_LOCALE_OVERRIDES = { en: { AU: 'en_GB', IN: 'en_GB', GB: 'en_GB' } };
+
+/**
  * Used when 3in1 modals are configured with ms=e or cs=t extra parameter, but 3in1 is disabled.
  * Dexter modals should deeplink to plan=edu or plan=team tabs.
  * @type {Record<string, string>}
@@ -1145,14 +1150,23 @@ export async function initService(force = false, attributes = {}) {
       ]);
 
       let countryFromMarket = country;
-      if (useGeoMarket && validatedMarket) countryFromMarket = validatedMarket.toUpperCase();
+      let localeFromMarket = locale;
+      if (useGeoMarket && validatedMarket) {
+        const market = validatedMarket.toUpperCase();
+        const localeOverride = MARKET_LOCALE_OVERRIDES[language]?.[market];
+        localeFromMarket = localeOverride ?? locale;
+        // When the fallback locale already encodes this market's country (e.g. GB -> en_GB),
+        // sending an explicit country is redundant and would override the locale's market, so
+        // it's dropped; other markets (e.g. AU, IN -> en_GB) still need their own country.
+        countryFromMarket = localeOverride?.endsWith(`_${market}`) ? undefined : market;
+      }
       let service = document.head.querySelector('mas-commerce-service');
       if (!service) {
         setPreview(attributes);
         service = createTag('mas-commerce-service', {
-          locale,
+          locale: localeFromMarket,
           language,
-          country: countryFromMarket,
+          ...(countryFromMarket ? { country: countryFromMarket } : {}),
           ...attributes,
           ...commerce,
         });
@@ -1178,8 +1192,12 @@ export async function initService(force = false, attributes = {}) {
           if (isSignedIn) fetchEntitlements();
         });
         if (useGeoMarket) guardCheckoutLinkImsCountry(service);
-      } else if (useGeoMarket && countryFromMarket !== country) {
-        service.setAttribute('country', countryFromMarket);
+      } else if (useGeoMarket) {
+        if (countryFromMarket !== country) {
+          if (countryFromMarket) service.setAttribute('country', countryFromMarket);
+          else service.removeAttribute('country');
+        }
+        if (localeFromMarket !== locale) service.setAttribute('locale', localeFromMarket);
       }
       if (isAnnualPriceEnabled()) {
         loadStyle(`${getConfig().base}/blocks/merch/au-merch.css`);

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1153,12 +1153,20 @@ export async function initService(force = false, attributes = {}) {
       let localeFromMarket = locale;
       if (useGeoMarket && validatedMarket) {
         const market = validatedMarket.toUpperCase();
-        const localeOverride = MARKET_LOCALE_OVERRIDES[language]?.[market];
-        localeFromMarket = localeOverride ?? locale;
-        // When the fallback locale already encodes this market's country (e.g. GB -> en_GB),
-        // sending an explicit country is redundant and would override the locale's market, so
-        // it's dropped; other markets (e.g. AU, IN -> en_GB) still need their own country.
-        countryFromMarket = localeOverride?.endsWith(`_${market}`) ? undefined : market;
+        countryFromMarket = market;
+        // `country` above is already geo-adjusted; the page's own market comes from its native
+        // milo locale. Only fall back to a market's Global-EN locale when the page isn't
+        // already that market's localized site: e.g. the / EN site (en_US) serving an AU/IN/GB
+        // visitor, never /au, /in or /uk, which keep their native locale.
+        const { country: pageCountry } = getMiloLocaleSettings(miloLocale);
+        if (market !== pageCountry) {
+          const localeOverride = MARKET_LOCALE_OVERRIDES[language]?.[market];
+          if (localeOverride) {
+            localeFromMarket = localeOverride;
+            // en_GB already resolves the GB market; don't also stamp a (non-GB) country.
+            if (localeOverride.endsWith(`_${market}`)) countryFromMarket = undefined;
+          }
+        }
       }
       let service = document.head.querySelector('mas-commerce-service');
       if (!service) {

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -805,6 +805,78 @@ describe('Merch Block', () => {
       }
     });
 
+    [
+      { akamai: 'AU', expectedCountry: 'AU', expectedLocale: 'en_GB' },
+      { akamai: 'IN', expectedCountry: 'IN', expectedLocale: 'en_GB' },
+    ].forEach(({ akamai, expectedCountry, expectedLocale }) => {
+      it(`sends locale ${expectedLocale} while keeping country ${expectedCountry} for validated market ${akamai} on the EN site`, async () => {
+        const geoDetectionMeta = createTag('meta', { name: 'mas-geo-detection', content: 'on' });
+        document.head.append(geoDetectionMeta);
+        sessionStorage.setItem('akamai', akamai);
+        getConfig().marketsConfig = { data: [{ prefix: '', defaultMarket: 'us', supportedRegions: 'us,au,in,gb,fr' }] };
+        try {
+          const service = await initService(true);
+          expect(service.settings.country).to.equal(expectedCountry);
+          expect(service.settings.locale).to.equal(expectedLocale);
+        } finally {
+          geoDetectionMeta.remove();
+          sessionStorage.removeItem('akamai');
+          delete getConfig().marketsConfig;
+        }
+      });
+    });
+
+    it('resolves en_US to en_GB without a country for validated market GB', async () => {
+      const geoDetectionMeta = createTag('meta', { name: 'mas-geo-detection', content: 'on' });
+      document.head.append(geoDetectionMeta);
+      sessionStorage.setItem('akamai', 'GB');
+      getConfig().marketsConfig = { data: [{ prefix: '', defaultMarket: 'us', supportedRegions: 'us,au,in,gb,fr' }] };
+      try {
+        const service = await initService(true);
+        expect(service.settings.locale).to.equal('en_GB');
+        // en_GB already resolves the GB market; no explicit country must be stamped.
+        expect(service.getAttribute('country')).to.be.null;
+      } finally {
+        geoDetectionMeta.remove();
+        sessionStorage.removeItem('akamai');
+        delete getConfig().marketsConfig;
+      }
+    });
+
+    it('keeps en_GB (and drops country) for a GB page when the validated market is GB', async () => {
+      setConfig({ ...config, pathname: '/uk/test.html', locales: { uk: { ietf: 'en-GB' } } });
+      const geoDetectionMeta = createTag('meta', { name: 'mas-geo-detection', content: 'on' });
+      document.head.append(geoDetectionMeta);
+      sessionStorage.setItem('akamai', 'GB');
+      getConfig().marketsConfig = { data: [{ prefix: '', defaultMarket: 'us', supportedRegions: 'us,au,in,gb,fr' }] };
+      try {
+        const service = await initService(true);
+        expect(service.settings.locale).to.equal('en_GB');
+        expect(service.getAttribute('country')).to.be.null;
+      } finally {
+        geoDetectionMeta.remove();
+        sessionStorage.removeItem('akamai');
+        delete getConfig().marketsConfig;
+        setConfig(config);
+      }
+    });
+
+    it('does not override the locale for a validated market outside the fallback map', async () => {
+      const geoDetectionMeta = createTag('meta', { name: 'mas-geo-detection', content: 'on' });
+      document.head.append(geoDetectionMeta);
+      sessionStorage.setItem('akamai', 'FR');
+      getConfig().marketsConfig = { data: [{ prefix: '', defaultMarket: 'us', supportedRegions: 'us,au,in,gb,fr' }] };
+      try {
+        const service = await initService(true);
+        expect(service.settings.country).to.equal('FR');
+        expect(service.settings.locale).to.equal('en_US');
+      } finally {
+        geoDetectionMeta.remove();
+        sessionStorage.removeItem('akamai');
+        delete getConfig().marketsConfig;
+      }
+    });
+
     it('does not set data-ims-country when mas-geo-detection is off', async () => {
       const el = document.createElement('a');
       el.setAttribute('href', '/tools/ost?osi=29&type=checkoutUrl');

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -843,7 +843,7 @@ describe('Merch Block', () => {
       }
     });
 
-    it('keeps en_GB (and drops country) for a GB page when the validated market is GB', async () => {
+    it('keeps native en_GB/GB for the /uk page when the validated market is GB', async () => {
       setConfig({ ...config, pathname: '/uk/test.html', locales: { uk: { ietf: 'en-GB' } } });
       const geoDetectionMeta = createTag('meta', { name: 'mas-geo-detection', content: 'on' });
       document.head.append(geoDetectionMeta);
@@ -851,8 +851,28 @@ describe('Merch Block', () => {
       getConfig().marketsConfig = { data: [{ prefix: '', defaultMarket: 'us', supportedRegions: 'us,au,in,gb,fr' }] };
       try {
         const service = await initService(true);
+        // The dedicated GB site already serves en_GB natively; the fallback must not alter it.
         expect(service.settings.locale).to.equal('en_GB');
-        expect(service.getAttribute('country')).to.be.null;
+        expect(service.settings.country).to.equal('GB');
+      } finally {
+        geoDetectionMeta.remove();
+        sessionStorage.removeItem('akamai');
+        delete getConfig().marketsConfig;
+        setConfig(config);
+      }
+    });
+
+    it('keeps native en_AU/AU for the /au page when the validated market is AU', async () => {
+      setConfig({ ...config, pathname: '/au/test.html', locales: { au: { ietf: 'en-AU' } } });
+      const geoDetectionMeta = createTag('meta', { name: 'mas-geo-detection', content: 'on' });
+      document.head.append(geoDetectionMeta);
+      sessionStorage.setItem('akamai', 'AU');
+      getConfig().marketsConfig = { data: [{ prefix: '', defaultMarket: 'us', supportedRegions: 'us,au,in,gb,fr' }] };
+      try {
+        const service = await initService(true);
+        // The dedicated AU site must not fall back to the Global-EN (en_GB) catalog.
+        expect(service.settings.locale).to.equal('en_AU');
+        expect(service.settings.country).to.equal('AU');
       } finally {
         geoDetectionMeta.remove();
         sessionStorage.removeItem('akamai');


### PR DESCRIPTION
- mapping for locale override,
- do not add superfluous country parameter (if superfluous)

Resolves: [MWPW-202828](https://jira.corp.adobe.com/browse/MWPW-202828)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-202828--milo--adobecom.aem.page/?martech=off
- Before: https://main--da-cc--adobecom.aem.page/products/photoshop?akamaiLocale=AU
- After: https://main--da-cc--adobecom.aem.page/products/photoshop?milolibs=MWPW-202828&akamaiLocale=AU
- Before: https://main--cc--adobecom.aem.page/creativecloud/plans?akamaiLocale=AU
- After: https://main--cc--adobecom.aem.page/creativecloud/plans?milolibs=MWPW-202828&akamaiLocale=AU
- Before: https://main--da-cc--adobecom.aem.page/products/photoshop?akamaiLocale=IN
- After: https://main--da-cc--adobecom.aem.page/products/photoshop?milolibs=MWPW-202828&akamaiLocale=IN
- Before: https://main--cc--adobecom.aem.page/creativecloud/plans?akamaiLocale=IN
- After: https://main--cc--adobecom.aem.page/creativecloud/plans?milolibs=MWPW-202828&akamaiLocale=IN
- Before: https://main--da-cc--adobecom.aem.page/products/photoshop?akamaiLocale=UK
- After: https://main--da-cc--adobecom.aem.page/products/photoshop?milolibs=MWPW-202828&akamaiLocale=UK
- Before: https://main--cc--adobecom.aem.page/creativecloud/plans?akamaiLocale=UK
- After: https://main--cc--adobecom.aem.page/creativecloud/plans?milolibs=MWPW-202828&akamaiLocale=UK



