### PR TITLE
MWPW-202276 Add mas-field.js to dist/commerce.js

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2751,7 +2751,6 @@ const STATIC_BLOCK_DEPS = {
     getMasDepUrl('lit-all.min.js'),
     getMasDepUrl('merch-card.js'),
     getMasDepUrl('merch-quantity-select.js'),
-    getMasDepUrl('mas-field.js'),
   ],
   merch: [
     getMasDepUrl('commerce.js'),


### PR DESCRIPTION
* In this [MAS PR](https://github.com/adobecom/mas/pull/1129), mas-field.js is included in dist/commerce.js. This Milo PR only removes mas-field.js from the preloads.

Resolves: [MWPW-202276](https://jira.corp.adobe.com/browse/MWPW-202276)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/photoshop?martech=off
- After: https://main--da-cc--adobecom.aem.page/products/photoshop?martech=off&milolibs=mwpw-202276&maslibs=mwpw-202276

Check the network calls, the file mas-field.js should not be loaded.