### PR TITLE
guard bot detection behind a new property

### DIFF
--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -1,5 +1,5 @@
 import { getModal, closeModal } from '../modal/modal.js';
-import { createTag, getConfig, loadScript } from '../../utils/utils.js';
+import { createTag, getConfig, getMetadata, loadScript } from '../../utils/utils.js';
 import chatUIConfig from './chat-ui-config.js';
 import bcAnalytics from './bc-analytics.js';
 
@@ -399,7 +399,10 @@ async function openChatModal(initialMessage, el) {
       return;
     }
 
-    if (!bcToken) {
+    const guestBotDetectionEnabled = getMetadata('ims-guest-token-bot-detection') === 'on'
+      && window.location.host.endsWith('.adobe.com')
+      && params.get('guestBotDetection') !== 'off';
+    if (!bcToken && (window.adobeIMS?.isSignedInUser() || guestBotDetectionEnabled)) {
       bcToken = window.adobeIMS?.getAccessToken()?.token;
     }
 

--- a/libs/c2/blocks/brand-concierge/brand-concierge.js
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.js
@@ -1,5 +1,5 @@
 import { getModal, closeModal } from '../modal/modal.js';
-import { createTag, getConfig, loadScript } from '../../../utils/utils.js';
+import { createTag, getConfig, getMetadata, loadScript } from '../../../utils/utils.js';
 import chatUIConfig from './chat-ui-config.js';
 import bcAnalytics from './bc-analytics.js';
 
@@ -399,7 +399,10 @@ async function openChatModal(initialMessage, el) {
       return;
     }
 
-    if (!bcToken) {
+    const guestBotDetectionEnabled = getMetadata('ims-guest-token-bot-detection') === 'on'
+      && window.location.host.endsWith('.adobe.com')
+      && params.get('guestBotDetection') !== 'off';
+    if (!bcToken && (window.adobeIMS?.isSignedInUser() || guestBotDetectionEnabled)) {
       bcToken = window.adobeIMS?.getAccessToken()?.token;
     }
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2044,7 +2044,8 @@ export async function loadIms() {
         reject(new Error('Missing IMS Client ID'));
         return;
       }
-      const [unavMeta, ahomeMeta, imsGuest] = [getMetadata('universal-nav')?.trim(), getMetadata('adobe-home-redirect'), getMetadata('ims-guest-token')];
+      const [unavMeta, ahomeMeta, imsGuest, botDetection] = [getMetadata('universal-nav')?.trim(), getMetadata('adobe-home-redirect'), getMetadata('ims-guest-token'), getMetadata('ims-guest-token-bot-detection')];
+      const guestBotDetection = PAGE_URL.searchParams.get('guestBotDetection');
       const defaultScope = `AdobeID,openid,gnav,pps.read,read_organizations${unavMeta && unavMeta !== 'off' ? ',firefly_api,additional_info.roles,account_cluster.read' : ''}`;
       const timeout = setTimeout(() => reject(new Error('IMS timeout')), imsTimeout || 5000);
       window.adobeid = {
@@ -2071,6 +2072,8 @@ export async function loadIms() {
           api_parameters: { check_token: { guest_allowed: true } },
           enableGuestAccounts: true,
           enableGuestTokenForceRefresh: true,
+        }),
+        ...(imsGuest === 'on' && botDetection === 'on' && window.location.host.endsWith('.adobe.com') && guestBotDetection !== 'off' && {
           enableGuestBotDetection: true,
           guestBotDetectionProvider: 'bfp',
         }),

--- a/test/blocks/brand-concierge/brand-concierge.test.js
+++ b/test/blocks/brand-concierge/brand-concierge.test.js
@@ -285,6 +285,98 @@ describe('Brand Concierge', () => {
     delete window.adobe;
   });
 
+  describe('onBeforeEventSend auth token', () => {
+    const originalHref = window.location.href;
+
+    // bcToken and the guestBotDetection query param are frozen per module instance,
+    // so each test imports a cache-busted copy to avoid leaking state between tests.
+    const getOnBeforeEventSend = async () => {
+      const timestamp = Date.now();
+      const { default: freshInit } = await import(`../../../libs/blocks/brand-concierge/brand-concierge.js?t=${timestamp}`);
+      document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+      const block = document.querySelector('.brand-concierge');
+
+      const bootstrapSpy = sinon.spy();
+      window.adobe = { concierge: { bootstrap: bootstrapSpy } };
+
+      await freshInit(block);
+      const input = block.querySelector('#bc-input-field');
+      input.value = 'Test message';
+      input.dispatchEvent(new Event('input'));
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      await waitForElement('#brand-concierge-modal');
+
+      await new Promise((resolve) => {
+        const checkBootstrap = () => {
+          if (bootstrapSpy.called) {
+            resolve();
+          } else {
+            setTimeout(checkBootstrap, 50);
+          }
+        };
+        setTimeout(() => resolve(), 2000);
+        checkBootstrap();
+      });
+
+      return bootstrapSpy.firstCall.args[0].onBeforeEventSend;
+    };
+
+    afterEach(() => {
+      document.querySelector('meta[name="ims-guest-token-bot-detection"]')?.remove();
+      delete window.adobe;
+      delete window.adobeIMS;
+      window.history.pushState({}, '', originalHref);
+    });
+
+    it('sends the IMS token when the user is signed in', async () => {
+      window.adobeIMS = {
+        isSignedInUser: () => true,
+        getAccessToken: () => ({ token: 'signed-in-token' }),
+      };
+      const onBeforeEventSend = await getOnBeforeEventSend();
+      const content = {};
+      onBeforeEventSend(content);
+      expect(content.data).to.deep.equal({ type: 'auth', payload: { token: 'signed-in-token' } });
+    });
+
+    it('sends no token when signed out and guest bot-detection metadata is absent', async () => {
+      window.adobeIMS = { isSignedInUser: () => false };
+      const onBeforeEventSend = await getOnBeforeEventSend();
+      const content = {};
+      onBeforeEventSend(content);
+      expect(content.data).to.be.undefined;
+    });
+
+    // This test environment is served from localhost, which never ends in ".adobe.com", so this
+    // also guards the domain gate: if that check were dropped, this would start failing.
+    it('withholds the guest token off adobe.com even when bot-detection metadata is "on"', async () => {
+      expect(window.location.host.endsWith('.adobe.com')).to.be.false;
+      const meta = document.createElement('meta');
+      meta.setAttribute('name', 'ims-guest-token-bot-detection');
+      meta.setAttribute('content', 'on');
+      document.head.append(meta);
+      window.adobeIMS = {
+        isSignedInUser: () => false,
+        getAccessToken: () => ({ token: 'guest-token' }),
+      };
+      const onBeforeEventSend = await getOnBeforeEventSend();
+      const content = {};
+      onBeforeEventSend(content);
+      expect(content.data).to.be.undefined;
+    });
+
+    it('caches the token and does not call getAccessToken again on subsequent events', async () => {
+      window.adobeIMS = {
+        isSignedInUser: () => true,
+        getAccessToken: sinon.stub().returns({ token: 'signed-in-token' }),
+      };
+      const onBeforeEventSend = await getOnBeforeEventSend();
+      onBeforeEventSend({});
+      onBeforeEventSend({});
+      expect(window.adobeIMS.getAccessToken.callCount).to.equal(1);
+    });
+  });
+
   describe('Marquee variant', () => {
     it('decorates the header with eyebrow (h3), title (h2) and subtitle (p) in order', async () => {
       document.body.innerHTML = await readFile({ path: './mocks/marquee.html' });

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -3268,6 +3268,94 @@ describe('Utils', () => {
     });
   });
 
+  describe('loadIms guest IMS config', () => {
+    const originalHref = window.location.href;
+    let originalAdobeId;
+
+    const imsGuestConfig = { imsClientId: 'test-client-id' };
+
+    const setGuestMeta = (name, content) => {
+      const meta = document.createElement('meta');
+      meta.setAttribute('name', name);
+      meta.setAttribute('content', content);
+      document.head.append(meta);
+    };
+
+    const runLoadIms = async () => {
+      const timestamp = Date.now();
+      const guestModule = await import(`../../libs/utils/utils.js?t=${timestamp}`);
+      guestModule.setConfig(imsGuestConfig);
+      guestModule.loadIms().catch(() => {});
+      await new Promise((resolve) => { setTimeout(resolve, 100); });
+    };
+
+    beforeEach(() => {
+      originalAdobeId = window.adobeid;
+    });
+
+    afterEach(() => {
+      document.querySelector('meta[name="ims-guest-token"]')?.remove();
+      document.querySelector('meta[name="ims-guest-token-with-bfp"]')?.remove();
+      window.history.pushState({}, '', originalHref);
+      window.adobeid = originalAdobeId;
+    });
+
+    it('omits all guest fields when ims-guest-token metadata is absent', async () => {
+      await runLoadIms();
+      expect(window.adobeid.enableGuestAccounts).to.be.undefined;
+      expect(window.adobeid.enableGuestBotDetection).to.be.undefined;
+    });
+
+    it('enables base guest accounts when ims-guest-token is "on"', async () => {
+      setGuestMeta('ims-guest-token', 'on');
+      await runLoadIms();
+      expect(window.adobeid.api_parameters).to.deep.equal({ check_token: { guest_allowed: true } });
+      expect(window.adobeid.enableGuestAccounts).to.be.true;
+      expect(window.adobeid.enableGuestTokenForceRefresh).to.be.true;
+    });
+
+    it('does not enable bot detection alongside base guest accounts by default', async () => {
+      setGuestMeta('ims-guest-token', 'on');
+      await runLoadIms();
+      expect(window.adobeid.enableGuestBotDetection).to.be.undefined;
+      expect(window.adobeid.guestBotDetectionProvider).to.be.undefined;
+    });
+
+    // This test environment is served from localhost, which never ends in ".adobe.com",
+    // so it also guards the domain gate: if that check were dropped, this would start failing.
+    it('keeps bot detection disabled off adobe.com even when ims-guest-token-with-bfp is "on"', async () => {
+      expect(window.location.host.endsWith('.adobe.com')).to.be.false;
+      setGuestMeta('ims-guest-token', 'on');
+      setGuestMeta('ims-guest-token-with-bfp', 'on');
+      await runLoadIms();
+      expect(window.adobeid.enableGuestBotDetection).to.be.undefined;
+      expect(window.adobeid.guestBotDetectionProvider).to.be.undefined;
+    });
+
+    it('does not enable bot detection when ims-guest-token-with-bfp metadata is not "on"', async () => {
+      setGuestMeta('ims-guest-token', 'on');
+      setGuestMeta('ims-guest-token-with-bfp', 'off');
+      await runLoadIms();
+      expect(window.adobeid.enableGuestBotDetection).to.be.undefined;
+    });
+
+    it('respects the guestBotDetection=off kill switch', async () => {
+      setGuestMeta('ims-guest-token', 'on');
+      setGuestMeta('ims-guest-token-with-bfp', 'on');
+      window.history.pushState({}, '', '/?guestBotDetection=off');
+      await runLoadIms();
+      expect(window.adobeid.enableGuestBotDetection).to.be.undefined;
+      expect(window.adobeid.guestBotDetectionProvider).to.be.undefined;
+    });
+
+    it('does not gate base guest accounts on the guestBotDetection kill switch', async () => {
+      setGuestMeta('ims-guest-token', 'on');
+      window.history.pushState({}, '', '/?guestBotDetection=off');
+      await runLoadIms();
+      expect(window.adobeid.enableGuestAccounts).to.be.true;
+    });
+  });
+
   describe('getCountry bot detection', () => {
     const originalUserAgent = navigator.userAgent;
     let savedFetch;


### PR DESCRIPTION
Guard the IMS guest-token bot-detection config (enableGuestBotDetection / guestBotDetectionProvider) behind a new ims-guest-token-bot-detection metadata flag, restricted to .adobe.com subdomains, with a ?guestBotDetection=off kill switch
Split base guest-account IMS config from bot-detection config so they can be enabled independently
Add unit tests for both the loadIms guest config (libs/utils/utils.js) and the Brand Concierge auth-token logic (libs/blocks/brand-concierge/brand-concierge.js)

Resolves: [BRANDCON-8235(https://jira.corp.adobe.com/browse/BRANDCON-8235)

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://guest-token-updates--milo--adobecom.aem.page/?martech=off
