### PR TITLE
[SR]MWPW-203507: Fix side-by-side variants in multyviewport

### DIFF
--- a/libs/mep/ace1209/side-by-side/side-by-side.js
+++ b/libs/mep/ace1209/side-by-side/side-by-side.js
@@ -54,11 +54,11 @@ function getCardType(block) {
   return CARD_TYPE;
 }
 
-function decorate(block) {
+function decorate(block, el) {
   const [mediaRow, textRow] = block.children;
   if (!mediaRow || !textRow) return;
 
-  const cardType = getCardType(block);
+  const cardType = getCardType(el);
 
   const medias = [...mediaRow.children];
   const texts = [...textRow.children];


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Issue: When multi-viewport content is authored, `side-by-side` looks for the variant on the container element instead on the actual block. 

* Fix variants for multi-viewport 

Resolves:[MWPW-203507](https://jira.corp.adobe.com/browse/MWPW-203507)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=side-by-side-variants-fix&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


