### PR TITLE
[SR] Side by side authoring fix - Inherit content from default to tablet and desktop

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -683,30 +683,24 @@ function warnDuplicateH1s(viewportData) {
   }
 }
 
+function inheritRowCells(row, prevRow) {
+  if (!row || !prevRow) return;
+  [...row.children].forEach((col, i) => {
+    const prevCol = prevRow.children[i];
+    if (isEmptyCell(col) && prevCol && !isEmptyCell(prevCol)) {
+      col.replaceChildren(...cloneChildren(prevCol));
+    }
+  });
+}
+
 function resolveInheritance(rows, previousContent) {
   if (!previousContent) return;
 
   const [contentRow, ...extraRows] = rows;
-  const prevChildren = [...previousContent.children];
-  const [prevContentRow, ...prevExtraRows] = prevChildren;
+  const [prevContentRow, ...prevExtraRows] = previousContent.children;
 
-  if (contentRow && prevContentRow) {
-    [...contentRow.children].forEach((col, i) => {
-      const prevCol = prevContentRow.children[i];
-      if (isEmptyCell(col) && prevCol && !isEmptyCell(prevCol)) {
-        col.replaceChildren(...cloneChildren(prevCol));
-      }
-    });
-  }
-
-  extraRows.forEach((row, i) => {
-    const prevRow = prevExtraRows[i];
-    const cell = row?.children[0];
-    const prevCell = prevRow?.children[0];
-    if (cell && isEmptyCell(cell) && prevCell && !isEmptyCell(prevCell)) {
-      cell.replaceChildren(...cloneChildren(prevCell));
-    }
-  });
+  inheritRowCells(contentRow, prevContentRow);
+  extraRows.forEach((row, i) => inheritRowCells(row, prevExtraRows[i]));
 }
 
 function parseViewportContent(el) {

--- a/test/utils/decorate.test.js
+++ b/test/utils/decorate.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { expect } from '@esm-bundle/chai';
-import { setBackgroundFocus, decorateBlockText, getButtonType, decoratePictures } from '../../libs/utils/decorate.js';
+import { setBackgroundFocus, decorateBlockText, getButtonType, decoratePictures, decorateViewportContent } from '../../libs/utils/decorate.js';
 
 describe('setBackgroundFocus', () => {
   let container;
@@ -300,5 +300,93 @@ describe('decoratePictures', () => {
     expect(noSources.classList.contains('large-image-decorated')).to.be.false;
     expect(noImg.classList.contains('large-image-decorated')).to.be.false;
     expect(nanWidth.classList.contains('large-image-decorated')).to.be.false;
+  });
+});
+
+describe('decorateViewportContent — resolveInheritance extra-row handling', () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  // Builds a block with a content row (2 media cells) + one extra row
+  // (2 text cells) per viewport, mirroring side-by-side's row shape.
+  function buildBlock({ mobileText, tabletMedia, tabletText }) {
+    container.innerHTML = `
+      <div><div>Mobile-viewport</div></div>
+      <div>
+        <div><p>mobile media A</p></div>
+        <div><p>mobile media B</p></div>
+      </div>
+      <div>
+        <div><p>${mobileText[0]}</p></div>
+        <div><p>${mobileText[1]}</p></div>
+      </div>
+      <div><div>Tablet-viewport</div></div>
+      <div>
+        <div>${tabletMedia[0] ? `<p>${tabletMedia[0]}</p>` : ''}</div>
+        <div>${tabletMedia[1] ? `<p>${tabletMedia[1]}</p>` : ''}</div>
+      </div>
+      <div>
+        <div>${tabletText[0] ? `<p>${tabletText[0]}</p>` : ''}</div>
+        <div>${tabletText[1] ? `<p>${tabletText[1]}</p>` : ''}</div>
+      </div>
+    `;
+    return container;
+  }
+
+  // decorateViewportContent swaps the active viewport's rows directly onto
+  // `el` (via applyViewportContent's replaceChildren), so assert against
+  // `el.children` — the same DOM a block's own decorate() would see — rather
+  // than the internal per-viewport container references.
+
+  it('content row (row 0): empty cell still inherits from the previous viewport', () => {
+    const el = buildBlock({
+      mobileText: ['mobile text A', 'mobile text B'],
+      tabletMedia: ['', 'tablet media B'],
+      tabletText: ['', ''],
+    });
+
+    decorateViewportContent(el, () => {});
+    const [mediaRow] = el.children;
+
+    expect(mediaRow.children[0].textContent.trim()).to.equal('mobile media A');
+    expect(mediaRow.children[1].textContent.trim()).to.equal('tablet media B');
+  });
+
+  it('extra row (row 1+): an empty cell inherits from the previous viewport, for every column', () => {
+    const el = buildBlock({
+      mobileText: ['mobile text A', 'mobile text B'],
+      tabletMedia: ['tablet media A', 'tablet media B'],
+      tabletText: ['', ''],
+    });
+
+    decorateViewportContent(el, () => {});
+    const [, textRow] = el.children;
+
+    // Before the fix, only cell 0 (card 1) inherited — cell 1 (card 2) stayed
+    // blank instead of picking up mobile's text. Both must inherit now.
+    expect(textRow.children[0].textContent.trim()).to.equal('mobile text A');
+    expect(textRow.children[1].textContent.trim()).to.equal('mobile text B');
+  });
+
+  it('extra row (row 1+): explicitly authored content on the new viewport is preserved', () => {
+    const el = buildBlock({
+      mobileText: ['mobile text A', 'mobile text B'],
+      tabletMedia: ['tablet media A', 'tablet media B'],
+      tabletText: ['tablet text A', 'tablet text B'],
+    });
+
+    decorateViewportContent(el, () => {});
+    const [, textRow] = el.children;
+
+    expect(textRow.children[0].textContent.trim()).to.equal('tablet text A');
+    expect(textRow.children[1].textContent.trim()).to.equal('tablet text B');
   });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

### Problem
decorateViewportContent's per-viewport content authoring pattern (Mobile-viewport / Tablet-viewport / Desktop-viewport rows) lets authors leave a cell empty to inherit that cell's content from the previous breakpoint, instead of retyping it. This works correctly for the block's main content row (contentRow) — every cell in that row is checked independently.

It did not work correctly for any row beyond the first ("extra rows") in a viewport section. resolveInheritance's handling of extra rows only ever read/wrote row.children[0] — the first cell. In blocks with a single-cell extra row (e.g. explore-card's foreground row) this happened to be harmless, since cell 0 is the only cell. But in blocks with a multi-cell extra row — side-by-side's text row, one cell per card — only the first card's text cell inherited from the previous viewport. The second card's text cell was never touched by the loop, so leaving it empty (the documented, intended way to reuse the previous breakpoint's copy) just left it permanently blank instead of inheriting.

Reproduced with a real authored page: a side-by-side block with an empty Tablet-viewport text row (intending to reuse the mobile copy) rendered with no text on either card at tablet width once media inheritance ran — card 1's cell was inheriting silently-incorrectly and card 2's wasn't inheriting at all.

### Fix
Generalize the row-inheritance logic so every cell in an extra row is checked, not just index 0 — using the same per-column loop already used for the content row:

No block-specific code changes needed — this is a shared-helper fix in libs/utils/decorate.js, so it applies to any block using decorateViewportContent with an extra row. Behavior for single-cell extra rows (e.g. explore-card) is unchanged, since cell 0 is already the only cell there.

Resolves: [MWPW-203601](https://jira.corp.adobe.com/browse/MWPW-203601)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=sr-breakpoint-content&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

### Testing

- Unit tests added.
- Look at the side-by-side block and notice the text or lack of text for each image.

