### PR TITLE
[SR] Normalize section rounded corners negative margin

### DIFF
--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -137,30 +137,15 @@ body:has(header.local-nav) .section.bento.stack-mobile {
     margin-bottom: initial;
   }
 
-  &:has(+ .rounded-corners),
-  &:has(+ .rounded-corners-top) {
-    /* add spacing to bottom of previous section to avoid content overlap  */
-    &::after {
-      content: '';
-      display: block;
-
-      /* Set full-width to account for masonry-layout / grid-width-*) */
-      grid-column: 1 / -1;
-      width: 100%;
-      height: var(--s2a-border-radius-lg);
-    }
-  }
-
-  &.rounded-corners + .section,
-  &.rounded-corners-bottom + .section {
-    /* add spacing to top of next section to avoid content overlap */
-    &::before {
-      content: '';
-      display: block;
-      grid-column: 1 / -1;
-      width: 100%;
-      height: var(--s2a-border-radius-lg);
-    }
+  &:has(+ .rounded-corners)::after,
+  &:has(+ .rounded-corners-top)::after,
+  &.rounded-corners + .section::before,
+  &.rounded-corners-bottom + .section::before {
+    content: '';
+    display: block;
+    grid-column: 1 / -1;
+    width: 100%;
+    height: var(--s2a-border-radius-lg);
   }
 
   &.rounded-corners-bottom {

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -137,6 +137,32 @@ body:has(header.local-nav) .section.bento.stack-mobile {
     margin-bottom: initial;
   }
 
+  &:has(+ .rounded-corners),
+  &:has(+ .rounded-corners-top) {
+    /* add spacing to bottom of previous section to avoid content overlap  */
+    &::after {
+      content: '';
+      display: block;
+
+      /* Set full-width to account for masonry-layout / grid-width-*) */
+      grid-column: 1 / -1;
+      width: 100%;
+      height: var(--s2a-border-radius-lg);
+    }
+  }
+
+  &.rounded-corners + .section,
+  &.rounded-corners-bottom + .section {
+    /* add spacing to top of next section to avoid content overlap */
+    &::before {
+      content: '';
+      display: block;
+      grid-column: 1 / -1;
+      width: 100%;
+      height: var(--s2a-border-radius-lg);
+    }
+  }
+
   &.rounded-corners-bottom {
     border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
     margin-top: initial;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Normalized negative margin being applied for rounded corners so GWP doesn't have to factor in that negative margin when applying spacing tokens. 

- Negative margin is still in place to ensure the rounded corners and the section above/below blend well.
- Adds a sudo element to the corresponding sibling element to offset the negative margin, equalizing it.

### Note:
This will require authoring updates to set updated spacing tokens to account for the margin adjustment.

Resolves: [MWPW-200371](https://jira.corp.adobe.com/browse/MWPW-200371)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=sr-section-rc-spacing&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

**Test URLs Milo page:**
- Before: https://site-redesing-foundation--milo--adobecom.aem.page/drafts/rclayton/sr-rounded-corners-test?mep=%2Fdrafts%2Frclayton%2Fdc1209-base-page-dc.json--all
- After: https://sr-section-rc-spacing--milo--adobecom.aem.page/drafts/rclayton/sr-rounded-corners-test?mep=%2Fdrafts%2Frclayton%2Fdc1209-base-page-dc.json--all




