### PR TITLE
Disabling test branch params on prod

### DIFF
--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -11,12 +11,16 @@ import {
 const DEFAULT_FEDERAL_URL = 'https://main--federal--adobecom.aem.page';
 
 function getFederalDomain(config) {
-  const queryParams = new URLSearchParams(window.location.search);
-  const federalBranch = queryParams.get('fedsbranch');
-  if (federalBranch?.trim()) {
-    const sanitized = federalBranch.trim().toLowerCase();
-    if (sanitized === 'local') return 'http://localhost:3000/federal';
-    return `https://${sanitized}--federal--adobecom.aem.page/federal`;
+  const env = getEnv(config);
+
+  if (env.name !== 'prod') {
+    const queryParams = new URLSearchParams(window.location.search);
+    const federalBranch = queryParams.get('fedsbranch');
+    if (federalBranch?.trim()) {
+      const sanitized = federalBranch.trim().toLowerCase();
+      if (sanitized === 'local') return 'http://localhost:3000/federal';
+      return `https://${sanitized}--federal--adobecom.aem.page/federal`;
+    }
   }
 
   const { hostname } = window.location;
@@ -26,7 +30,6 @@ function getFederalDomain(config) {
 
   if (extension) return `${DEFAULT_FEDERAL_URL.replace('aem.page', `aem.${extension}`)}/federal`;
 
-  const env = getEnv(config);
   if (env.name === 'stage') return 'https://www.stage.adobe.com/federal';
   if (env.name === 'prod') return 'https://www.adobe.com/federal';
   return `${DEFAULT_FEDERAL_URL}/federal`;

--- a/libs/navigation/navigation.js
+++ b/libs/navigation/navigation.js
@@ -120,7 +120,9 @@ export default async function loadBlock(configs, customLib) {
     console.error('Global navigation Error: header and footer configurations are missing.');
     return;
   }
-  const branch = new URLSearchParams(window.location.search).get('navbranch');
+  const branch = env !== 'prod'
+    ? new URLSearchParams(window.location.search).get('navbranch')
+    : null;
   let miloLibs = branch ? `https://${branch}--milo--adobecom.aem.page` : customLib || envMap[env];
   const useLocal = new URLSearchParams(window.location.search).get('useLocal') || false;
   if (useLocal) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adding env check before using test branch params
* We can't limit to stage.adobe.com and aem urls as standalone gnav has non milo clients

Resolves: [VULN-37839](https://jira.corp.adobe.com/browse/VULN-37839)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://gnav-branch--milo--adobecom.aem.page/?martech=off


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=gnav-branch--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=gnav-branch--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=gnav-branch--milo--adobecom
- Milo: https://gnav-branch--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=gnav-branch--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=gnav-branch--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=gnav-branch--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-branch--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-branch--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-branch--milo--adobecom
- Milo: https://gnav-branch--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-branch--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-branch--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=gnav-branch--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-branch--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-branch--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-branch--milo--adobecom
- Milo: https://gnav-branch--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-branch--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-branch--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=gnav-branch--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=gnav-branch--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=gnav-branch--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=gnav-branch--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=gnav-branch--milo--adobecom
</details>