### PR TITLE
[SR] Tabs Block - RTL support (Wave 2 rollout)

### DIFF
--- a/libs/c2/blocks/tabs/tabs.css
+++ b/libs/c2/blocks/tabs/tabs.css
@@ -13,10 +13,6 @@
     background: transparent;
   }
 
-  &.rtl {
-    direction: rtl;
-  }
-
   .tabs-wrapper {
     display: flex;
     width: 100%;
@@ -209,4 +205,8 @@
   [role='tabpanel'] > .section[class*='grid-width-'] > .content {
     width: auto;
   }
+}
+
+html[dir="rtl"] .tabs {
+  direction: rtl;
 }

--- a/libs/c2/blocks/tabs/tabs.css
+++ b/libs/c2/blocks/tabs/tabs.css
@@ -13,6 +13,10 @@
     background: transparent;
   }
 
+  &.rtl {
+    direction: rtl;
+  }
+
   .tabs-wrapper {
     display: flex;
     width: 100%;

--- a/libs/c2/blocks/tabs/tabs.js
+++ b/libs/c2/blocks/tabs/tabs.js
@@ -193,11 +193,12 @@ function configTabs(config, rootElem) {
 function initTabs(elm, config, rootElem) {
   const tabs = elm.querySelectorAll('[role="tab"]');
   const tabLists = elm.querySelectorAll('[role="tablist"]');
+  const isRtl = document.documentElement.getAttribute('dir') === 'rtl';
   let tabFocus = 0;
   tabLists.forEach((tabList) => {
     tabList.addEventListener('keydown', (e) => {
       if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
-      const forward = e.key === (document.dir === 'rtl' ? 'ArrowLeft' : 'ArrowRight');
+      const forward = e.key === (isRtl ? 'ArrowLeft' : 'ArrowRight');
       tabFocus = (tabFocus + (forward ? 1 : -1) + tabs.length) % tabs.length;
       tabs.forEach((t) => t.setAttribute('tabindex', '-1'));
       tabs[tabFocus].setAttribute('tabindex', '0');


### PR DESCRIPTION
This PR adds RTL support to the wave 2 **tabs** block needed for ROW rollout. 

**Features:** 
- **Automatic check for `dir=rtl` on page html tag** - if the tabs block loads on an RTL page, the code will add `rtl` class automatically.
- **[removed]** **Add variant: `rtl`** - user can manually add `rtl` to block to enable RTL functionality manually (optional for debugging if needed). 

**Notes**
1. There** is JS logic that relies on page html attribute `dir=` check for pill selector to run properly. **Manually changing `dir=` attribute on the html tag after page load will break the implementation.**

**Resolves:** 
[MWPW-198998](https://jira.corp.adobe.com/browse/MWPW-197719) 

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/dnu-ace1205-plans-rtl?martech=off
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/dnu-ace1205-plans-rtl?milolibs=sr2-tabs-rtl-support






















