### PR TITLE
MWPW-191707 [Site Redesign][Cards] Fix multi-row card destagger at top on short viewports

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1285,21 +1285,15 @@ span.hang-opening-quote {
         animation-timeline: view(block);
       }
 
-      /* Prolong animation for 2 rows */
+      /* End at the viewport top so multi-row cards settle level on short viewports. */
       &.two-up:has(> :nth-child(3 of :not([class*="section-"]))),
       &.three-up:has(> :nth-child(4 of :not([class*="section-"]))),
       &.four-up:has(> :nth-child(5 of :not([class*="section-"]))),
       &.six-up:has(> :nth-child(7 of :not([class*="section-"]))) {
-        --parallax-range-end-name: cover;
-        --parallax-range-end-length: 70%;
-      }
+        --parallax-range-end-name: exit-crossing;
+        --parallax-range-end-length: 0%;
 
-      /* Prolong animation for 3+ rows */
-      &.two-up:has(> :nth-child(5 of :not([class*="section-"]))),
-      &.three-up:has(> :nth-child(7 of :not([class*="section-"]))),
-      &.four-up:has(> :nth-child(9 of :not([class*="section-"]))),
-      &.six-up:has(> :nth-child(13 of :not([class*="section-"]))) {
-        --parallax-range-end-length: 80%;
+        view-timeline-inset: 0 10%;
       }
     }
   }


### PR DESCRIPTION
* Multi-row parallax-stagger grids now finish destaggering exactly when the grid's top row reaches the top of the viewport, instead of at a fixed `cover` percentage
* Switches the multi-row animation end from `cover 70%` / `cover 80%` to `exit-crossing 0%` with a `0` top inset, making the finish line height- and viewport-independent
* Collapses the old two-tier rule (2 rows vs 3+ rows) into one, since the new endpoint no longer depends on grid height
* No change to single-row grids (run on the bottom-anchored `entry` range) or masonry stagger grids (own `view(block)` timeline, no `-up` class); the mid-scroll stagger animation itself is unchanged — only where it resolves

Trade-off: The resolve point shifts slightly vs. before (finishes at the viewport top instead of a fixed cover %). That's deliberate — tying "done" to the viewport top is what makes it height-independent, which the old fixed percentage couldn't do without reintroducing the misalignment.

Before: 
<img width="1725" height="1043" alt="Screenshot 2026-08-10 at 13 36 41" src="https://github.com/user-attachments/assets/95107eec-eae4-4960-88b2-551a2938644e" />
After: 
<img width="1728" height="1044" alt="Screenshot 2026-08-10 at 13 36 51" src="https://github.com/user-attachments/assets/42dc75a3-a95a-4920-8fc8-ff420825dc4c" />

Before:
<img width="1697" height="290" alt="Screenshot 2026-08-10 at 13 37 18" src="https://github.com/user-attachments/assets/c36e3307-ed7f-416c-8fad-55f726d1e2e9" />
After:
<img width="1698" height="325" alt="Screenshot 2026-08-10 at 13 37 32" src="https://github.com/user-attachments/assets/c275aa9d-3953-4002-8d89-f0a653707dbd" />


Resolves: [MWPW-191707](https://jira.corp.adobe.com/browse/MWPW-191707)

**Test URLs:**
- Before: https://www.stage.adobe.com/
- After: https://www.stage.adobe.com/?milolibs=mwpw-191707-parallax-staggering

**Verification:** On the stage homepage at a 1440×820 (laptop) viewport, the 3-row `product-grid` cards were misaligned by ~3px per row at the topmost position on `main`, and resolve flush (`translateY: 0` across all 9 cards) with this change. Single-row grids measured identical before/after.


