### PR TITLE
[NALA] Fix floating-input BC tests for bc-global session persistence

### DIFF
--- a/nala/blocks/brand-concierge/brand-concierge.test.js
+++ b/nala/blocks/brand-concierge/brand-concierge.test.js
@@ -640,7 +640,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         await page.keyboard.press('Enter');
         await expect(bc.modal).toBeVisible({ timeout: 10000 });
         await expect(bc.modalMount).toBeVisible({ timeout: 10000 });
-        await expect(bc.modalMount.locator(`text=${data.inputText}`)).toBeVisible({ timeout: 10000 });
+        await expect(bc.modalMount.locator(`text=${data.inputText}`).first()).toBeVisible({ timeout: 10000 });
       });
 
       await test.step('step-8: Close modal via close button — floating-input bar remains attached', async () => {
@@ -655,7 +655,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         await bc.floatingInputSubmitButton.click();
         await expect(bc.modal).toBeVisible({ timeout: 10000 });
         await expect(bc.modalMount).toBeVisible({ timeout: 10000 });
-        await expect(bc.modalMount.locator(`text=${data.inputText}`)).toBeVisible({ timeout: 10000 });
+        await expect(bc.modalMount.locator(`text=${data.inputText}`).first()).toBeVisible({ timeout: 10000 });
       });
 
       await test.step('step-10: Close modal — floating-input bar remains attached', async () => {
@@ -745,7 +745,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         await page.keyboard.press('Enter');
         await expect(bc.modal).toBeVisible({ timeout: 10000 });
         await expect(bc.modalMount).toBeVisible({ timeout: 10000 });
-        await expect(bc.modalMount.locator(`text=${data.inputText}`)).toBeVisible({ timeout: 10000 });
+        await expect(bc.modalMount.locator(`text=${data.inputText}`).first()).toBeVisible({ timeout: 10000 });
       });
 
       await test.step('step-9: Close modal via close button — floating-input dark bar remains attached', async () => {
@@ -760,7 +760,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         await bc.floatingInputSubmitButton.click();
         await expect(bc.modal).toBeVisible({ timeout: 10000 });
         await expect(bc.modalMount).toBeVisible({ timeout: 10000 });
-        await expect(bc.modalMount.locator(`text=${data.inputText}`)).toBeVisible({ timeout: 10000 });
+        await expect(bc.modalMount.locator(`text=${data.inputText}`).first()).toBeVisible({ timeout: 10000 });
       });
 
       await test.step('step-11: Close modal — floating-input dark bar remains attached', async () => {
@@ -852,7 +852,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         await page.keyboard.press('Enter');
         await expect(bc.modal).toBeVisible({ timeout: 10000 });
         await expect(bc.modalMount).toBeVisible({ timeout: 10000 });
-        await expect(bc.modalMount.locator(`text=${data.inputText}`)).toBeVisible({ timeout: 10000 });
+        await expect(bc.modalMount.locator(`text=${data.inputText}`).first()).toBeVisible({ timeout: 10000 });
       });
 
       await test.step('step-8: Close modal via close button — bar remains attached', async () => {
@@ -867,7 +867,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         await bc.inputSubmitButton.click();
         await expect(bc.modal).toBeVisible({ timeout: 10000 });
         await expect(bc.modalMount).toBeVisible({ timeout: 10000 });
-        await expect(bc.modalMount.locator(`text=${data.inputText}`)).toBeVisible({ timeout: 10000 });
+        await expect(bc.modalMount.locator(`text=${data.inputText}`).first()).toBeVisible({ timeout: 10000 });
       });
 
       await test.step('step-10: Close modal via Escape — bar remains attached', async () => {
@@ -964,7 +964,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         await page.keyboard.press('Enter');
         await expect(bc.modal).toBeVisible({ timeout: 10000 });
         await expect(bc.modalMount).toBeVisible({ timeout: 10000 });
-        await expect(bc.modalMount.locator(`text=${data.inputText}`)).toBeVisible({ timeout: 10000 });
+        await expect(bc.modalMount.locator(`text=${data.inputText}`).first()).toBeVisible({ timeout: 10000 });
       });
 
       await test.step('step-9: Close modal via close button — bar remains attached', async () => {
@@ -981,7 +981,7 @@ test.describe('Milo Brand Concierge Block test suite', () => {
         await page.keyboard.press('Enter');
         await expect(bc.modal).toBeVisible({ timeout: 10000 });
         await expect(bc.modalMount).toBeVisible({ timeout: 10000 });
-        await expect(bc.modalMount.locator(`text=${data.inputText}`)).toBeVisible({ timeout: 10000 });
+        await expect(bc.modalMount.locator(`text=${data.inputText}`).first()).toBeVisible({ timeout: 10000 });
       });
 
       await test.step('step-11: Close modal via Escape — bar remains attached', async () => {


### PR DESCRIPTION
## Summary
Fixes the 4 failing Brand Concierge floating-input Nala tests (tcid 14–17) on the `bc-global` branch. Targets `bc-global` so it lands alongside PR #6443 and keeps the suite green when bc-global merges to stage.

## Problem
The floating-input tests submit the **same query twice** in one page session (Enter in step-7, then Send button in step-9). With the global-block refactor, the conversation **persists** across modal close/reopen, so `#brand-concierge-mount` ends up with **two** `.message-text` nodes containing the query. The assertion `locator('text=${data.inputText}')` then resolves to 2 elements → Playwright **strict-mode violation**.

```
strict mode violation: locator('#brand-concierge-mount').locator('text=i need help with billing')
resolved to 2 elements:
  1) <div class="message-text">i need help with billing</div>
  2) <div class="message-text">i need help with billing</div>
```

The modal opens correctly every time — only the "verify submitted text" step fails.

## Fix
Add `.first()` to the 8 modal message-text assertions. Asserting the first occurrence is correct whether the conversation shows one message (fresh) or two (persisted), so it's safe on both stage and bc-global — pure test hardening, no product change.

## Verification
- `https://bc-global--milo--adobecom.aem.live` — floating-input tcid 14–17: **4/4 pass**
- eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

