### PR TITLE
[Site Redesign] Globe-Gallery: resolve PR review comments

### DIFF
--- a/.eslintrc-code-compatibility.js
+++ b/.eslintrc-code-compatibility.js
@@ -17,5 +17,6 @@ module.exports = {
     '/libs/navigation/dist/*',
     '/tools/loc/*',
     '/libs/mep/ace1209/globe-gallery/three.module.min.js',
+    '/libs/mep/ace1209/globe-gallery/src/three-src.js',
   ],
 };

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -497,6 +497,26 @@ localT `FOLD_START_LOCAL_T = 1 − FOLD_PEEL_OVERLAP^(1/3)`; the global fold win
 derive from it, so camera / depth-sort / interactivity stay aligned. `0` restores "settle, then
 fold."
 
+**Arc-copy fade-out** (`updateArcCopy`) is expressed as a *fraction of the grid→globe fold window*
+(`FOLD_FIRST_PROGRESS` → `SPHERE_FORMED_PROGRESS`), not as raw progress, so it stays aligned if the
+fold constants move: `ARC_COPY_OUT_FORM_START = 0.20` → `ARC_COPY_OUT_FORM_END = 0.90`, i.e.
+progress ≈ `0.096` → `0.294` against a formed sphere at `0.322`. It therefore starts only once the
+fold is underway and is fully gone *before* the sphere (md) / barrel (sm) finishes forming — one
+window for both profiles, since the fold constants are shared. The out-ease is `easeInOutCubic`,
+**not** the `easeOutCubic` used for the fade-in: `easeOutCubic` is ~88% done at the window's
+midpoint, which would collapse the copy to invisible almost as soon as it began; `easeInOutCubic`
+spreads the fade over the whole window and still lands exactly on 0 at `outEnd`.
+
+`FOLD_FIRST_PROGRESS` (module scope) is the mirror of `computeFrame`'s `foldFirst` — the same
+single-source role `SPHERE_FORMED_PROGRESS` plays for `foldLast` — and `computeFrame` reads it
+rather than recomputing.
+
+**Arc-copy placement** is split between CSS and JS: CSS owns the block edge (`bottom` — `8px` at
+sm, `24px` from `min-width:768px`, docking it to the viewport bottom on the same 24px gutter the JS
+uses inline-start), JS owns the inline-start inset per frame in `updateArcCopy` (`8px` at sm; at md
+`24 + max(0, (W − 48 − 1392) / 2)`, the 24px-grid-aligned position with centering) plus the opacity
+and the 24px entry slide.
+
 **Entry timing** — two independent constants: `ENTRY_LEAD_VH` (`0.4`) viewport-heights before the
 block top that entry begins (`0` late; `0.85` is the prototype's hero pre-roll but sweeps meshes
 over content above), and `ENTRY_RAMP_VH` (`1.05`) the ramp over which `arcCopyEntryT` goes 0→1

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -173,7 +173,7 @@ images** (24…N-1) with no sphere slot: it mints a lazy **modal-only carrier** 
 quad + SDF material in `modalScene`, its texture disposed on nav-away so ≤1 resident) that
 **dissolves** in/out instead of flying to/from the globe. Barrel-slot cards still fly. Overflow is
 reached only via modal **navigation** — `open()` is always a barrel card (tap / a11y browse). **All**
-modal nav — on-screen arrows, Left/Right keys, and touch swipe — routes through the same cross-warp
+modal nav — on-screen arrows and touch swipe — routes through the same cross-warp
 transition on **every** breakpoint (`navigate` → `startDesktopNavTransition`); touch swipe just
 builds a warp preview during the drag, then commits that transition on release. The old mobile instant-swap /
 swipe-neighbour slot reorg was removed — a slotless overflow card can only cross-warp anyway.
@@ -425,11 +425,10 @@ auto-spin (`a11y.isBrowsing()`); mouse drag still works.
   **name heading** (`tabindex="-1"`), NOT the dialog container — focusing the `<dialog>` makes
   VoiceOver enumerate it as a group and swallow its name; landing on a child makes VO announce the
   dialog name then the heading. Prev/Next/Close are tab stops (native inert keeps focus in);
-  navigation is via the on-screen Prev/Next buttons, touch swipe, or **Left/Right arrow keys —
-  bound to prev/next ONLY while focus is on the dialog's own controls** (`focusInChrome`, i.e.
-  focus mode), never at document level, so a screen reader arrowing through the description text
-  (browse / virtual-cursor mode) is never hijacked; the buttons stay the primary, discoverable
-  path (a11y audit). **Esc** (the `cancel` event,
+  navigation is via the on-screen Prev/Next buttons or touch swipe. There is **no arrow-key
+  card nav** — the buttons cover keyboard + SR users, and with no document-level key handler a
+  screen reader arrowing through the description text (browse / virtual-cursor mode) is never
+  hijacked. **Esc** (the `cancel` event,
   `preventDefault`'d so the close animation plays) / Enter-on-Close exit and the dialog **restores
   focus to the opening image**. No backdrop-click-to-close; no arrow-key globe rotation (browsing
   replaced it).
@@ -579,11 +578,21 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
   12px; mobile full-bleed to screen width, square corners `uRadius=0`), native aspect kept — the
   sizing math backs the geometry out of the SDF corner inset (`uRadius·cardHPx`) so the *photo*, not
   the geometry, reaches the margin. Desktop adds a fixed-width (`DT_SCRIM_W` 316px) dark frosted
-  scrim on the **viewport's left edge, full height**, holding the left-aligned, top-anchored
-  role/name/description (badges keep `margin-top:auto` → pinned bottom, so long copy grows downward
-  into the scrim rather than overflowing past its top edge); mobile's
-  scrim is one full-width 266px chunk pinned to the bottom. All dark frosted (`rgb(0 0 0 / 64%)` +
-  `blur(12px)`, light text).
+  scrim on the **viewport's left edge, full height**; mobile's scrim is one full-width bottom chunk
+  (content-sized, capped at `60dvh`). Both are a **pinned header / scrolling body / pinned footer**:
+  role + name are `flex-shrink:0` at the top, the **badges** are `flex-shrink:0` at the bottom (so
+  those tabbable controls are always on-screen), and the **description** is the only scroll region
+  (`min-height:0; overflow-y:auto`) — long copy scrolls instead of overflowing or
+  hiding the badges. A `mask-image` scroll-shadow (`updateDescFade`, re-measured on
+  scroll / resize / card-change) fades whichever edge has more copy, so the scroll affordance
+  survives macOS's hidden overlay scrollbar. JS gives the description `tabindex="0"` only while it actually overflows, so it's
+  keyboard-scrollable then without leaving a pointless tab stop when the copy fits; the full text is
+  always in the a11y tree via the dialog's `aria-describedby`; `touchstart` skips the swipe/pull
+  gesture when a drag starts inside it so the copy scrolls rather than closing the modal. It also
+  carries **`data-lenis-prevent`** — Milo loads the Lenis smooth-scroll lib on `foundation:c2` pages
+  (`utils.js`), which hijacks the wheel/touch and applies it to the (scroll-locked) page, so a nested
+  scroll region silently won't scroll without opting out via that attribute. All dark frosted
+  (`rgb(0 0 0 / 64%)` + `blur(12px)`, light text).
   - **Touch gestures (in the modal) are gated on a coarse primary pointer**
     (`matchMedia('(pointer: coarse)')`, mirroring `usesCylinderGeometry`), not on the `sm` width
     band — so tablets at md (≥768) get them too. A per-gesture axis lock (`AXIS_LOCK_PX` 10px)

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -267,7 +267,7 @@ document-wide id references): the CA SVG filter (referenced from JS as
 `<dialog>`'s `aria-labelledby` (role + name) / `aria-describedby` IDREFs). `el` itself is the scroll runway
 (height is `--runway-height` on `.globe-gallery`, collapsed to `100vh` under `.globe-gallery-reduced`);
 the canvas is `position:fixed`. The shared body-level global (acceptable, one modal at a
-time) is the `.modal-open` scroll lock.
+time) is the `.globe-gallery-modal-open` scroll lock.
 
 **Scroll model.** The block element *is* the scroll runway (its height is `--runway-height`) — there's
 no separate runway element. Raw scroll is measured against the block's own metrics (`blockDocTop` =
@@ -518,7 +518,7 @@ the runtime closure survives a `destroy()`+`initRuntime()` rebuild, `destroy()` 
 rebuild would otherwise inherit:
 - `modal.destroy()` calls `resetModalDom()` — synchronously returns the modal DOM + page state to
   the closed baseline (clears `is-visible`/`is-open`/`aria-hidden`, hides `.modal-card-canvas`,
-  clears `modal-open`, restarts Lenis). Else a modal open at a breakpoint crossing survives visually
+  clears `globe-gallery-modal-open`, restarts Lenis). Else a modal open at a breakpoint crossing survives visually
   stuck open (its mesh dropped with the old `modalScene`, `modalIdx` reset to -1 so chrome buttons
   are dead, scroll lock stuck). An open modal closes cleanly on crossing; it doesn't re-open.
 - `destroy()` **resets the sphere orientation + drag/nudge state** (`sphereRotX/Y/Z`,

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -568,9 +568,10 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
 - **Modal chrome — edge-anchored nav arrows + counter; desktop adds a screen-edge scrim.** The
   prev/next arrows and counter are independent chrome children (no wrapper), positioned per-frame by
   `positionModalChrome`, reading as one bottom-centre row at every breakpoint. **Desktop/tablet:** the
-  counter pill centres on the image's bottom edge, an arrow `DT_NAV_GAP` (12px) each side; the pill is
+  counter pill centres horizontally on the image, an arrow `DT_NAV_GAP` (12px) each side; the pill is
   a fixed `DT_COUNTER_W` (138px, mirror its CSS `width`) so the flank offset needs no measuring; all
-  three share one `bottom`, 44px tall. **Mobile:** the same row spread wide into the bottom-left/right
+  three share one `bottom` — a fixed 24px from the *viewport* bottom (not the image bottom), so the
+  row sits at the same height across images regardless of the photo's aspect ratio — 44px tall. **Mobile:** the same row spread wide into the bottom-left/right
   corners inside the bottom scrim. The three frosted controls (both arrows + close) share one style
   (1px `--s2a-color-transparent-white-24` border, `--s2a-border-radius-4`,
   `--s2a-color-transparent-black-64`, `blur(12px)`); close sits top-right at every breakpoint. The
@@ -578,8 +579,9 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
   12px; mobile full-bleed to screen width, square corners `uRadius=0`), native aspect kept — the
   sizing math backs the geometry out of the SDF corner inset (`uRadius·cardHPx`) so the *photo*, not
   the geometry, reaches the margin. Desktop adds a fixed-width (`DT_SCRIM_W` 316px) dark frosted
-  scrim on the **viewport's left edge, full height**, holding the left-aligned, vertically-centred
-  role/name/description (two `margin-top:auto` splits the free space, badges pinned bottom); mobile's
+  scrim on the **viewport's left edge, full height**, holding the left-aligned, top-anchored
+  role/name/description (badges keep `margin-top:auto` → pinned bottom, so long copy grows downward
+  into the scrim rather than overflowing past its top edge); mobile's
   scrim is one full-width 266px chunk pinned to the bottom. All dark frosted (`rgb(0 0 0 / 64%)` +
   `blur(12px)`, light text).
   - **Touch gestures (in the modal) are gated on a coarse primary pointer**

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -48,7 +48,9 @@ through each image (centring it on the globe) rather than exposing a flat per-ca
 | `three.module.min.js` | Tree-shaken Three.js r160 ESM build (~453KB). Build artifact — do not edit. |
 | `package.json` | Local mini build. `npm install && npm run build` regenerates `three.module.min.js`. |
 
-Registered as `'globe'` in `C2_BLOCKS` (`libs/utils/utils.js`). `three.module.min.js` is eslint-ignored.
+Experimental block: loaded via MEP from `libs/mep/ace1209/globe-gallery/` — **not** registered in
+`C2_BLOCKS` (`libs/utils/utils.js`). `three.module.min.js` and `src/three-src.js` are eslint-ignored
+(the compat config skips them — the tree-shaken bundle and the bare `three` build-entry import).
 
 ### Module layout
 
@@ -81,7 +83,7 @@ are optional):
 
 | Row | Purpose | Content |
 | --- | --- | --- |
-| 0 | **Arc-copy** | heading → `.globe-gallery-arc-copy__title`; `<p>` → `.globe-gallery-arc-copy__body` |
+| 0 | **Arc-copy** | heading → `.globe-gallery-arc-copy-title`; `<p>` → `.globe-gallery-arc-copy-body` |
 | 1 | **Cards** | a Milo fragment link with `#_dnb` appended (see below) |
 | 2 | **Hint + instructions + labels** | first `<p>` → WebGL "Click & Drag" affordance (falls back to `Click & Drag` if empty/absent); optional second `<p>` → a11y entry-widget instructions (English fallback); optional third `<p>` → the four UI labels, `\|\|`-separated in on-screen order **prev-arrow \|\| card-position template \|\| next-arrow \|\| close** (each part falls back to English) |
 | 3 | **Pull-quote** | heading → quote; first `<p>` → name; second `<p>` → role |
@@ -102,10 +104,10 @@ itself — AEM Edge Delivery returns all card sections as bare `<div>`s (one per
 racing the parse.
 
 Cards come solely from the fetched fragment. If the fetch yields none — a failed
-request, or no fragment link authored — the block collapses to `.globe-gallery--empty`
+request, or no fragment link authored — the block collapses to `.globe-gallery-empty`
 (`height:auto`) rather than rendering an empty scene. There is no inline-DOM-card
 fallback (authoring is expected to provide a valid fragment link). (Distinct from
-`.globe-gallery--reduced`, the reduced-motion render path — see Accessibility.)
+`.globe-gallery-reduced`, the reduced-motion render path — see Accessibility.)
 
 The same `--empty` collapse is the fallback when **WebGL is unavailable**: `initRuntime`
 creates the `WebGLRenderer` in a `try/catch` (Three.js throws when `getContext` returns
@@ -261,19 +263,67 @@ unique per instance via that `gid` suffix (ids, not classes, because both are
 document-wide id references): the CA SVG filter (referenced from JS as
 `filter: url(#ca-filter-<gid>)`) and the modal role-label/heading/description (the
 `<dialog>`'s `aria-labelledby` (role + name) / `aria-describedby` IDREFs). `el` itself is the scroll runway
-(height is `--runway-height` on `.globe-gallery`, collapsed to `100vh` under `.globe-gallery--reduced`);
+(height is `--runway-height` on `.globe-gallery`, collapsed to `100vh` under `.globe-gallery-reduced`);
 the canvas is `position:fixed`. The shared body-level global (acceptable, one modal at a
 time) is the `.modal-open` scroll lock.
 
-**Scroll model.** The block element *is* the scroll runway (its height is the
-`--runway-height` custom property) — there's no separate runway element, and nothing
-hard-codes the value: progress is measured against the block's own
-metrics: `progress = clamp((scrollY - blockDocTop) / blockHeight, 0, 1)`, where
-`blockDocTop` is the block's top in document space and `blockHeight` its full scroll
-length (both refreshed in `doLayout` + a body `ResizeObserver`). Milo's page-level
-Lenis keeps `window.scrollY` in sync (gsap was dropped for a `requestAnimationFrame`
-driver, `startTicker`/`stopTicker`). The modal pauses Lenis via
-`window.lenis.stop()/start()` plus a `.modal-open { overflow:hidden }` CSS lock.
+**Scroll model.** The block element *is* the scroll runway (its height is `--runway-height`) — there's
+no separate runway element. Raw scroll is measured against the block's own metrics (`blockDocTop` =
+top in document space, `blockHeight` = `offsetHeight`, both refreshed in `doLayout` + a body
+`ResizeObserver`), then remapped **piecewise** (in `computeFrame`) into the `progress` 0→1 the phase
+math consumes. This decouples formation length from the tail, so the runway can be trimmed without
+speeding up the globe:
+
+| segment | raw scroll | → progress | owns |
+|---|---|---|---|
+| **formation** (arc→grid→fold→settle) | `0 → --formation-vh` (304vh) | `0 → foldLast` (≈0.322) | the `P_*` phase constants |
+| **tail** (zoom-through + pull-quote) | `--formation-vh → --runway-height` | `foldLast → 1` | `zoomT`, cursor retire, pull-quote |
+
+Formation is **locked** to a fixed scroll length: `FORMATION_SCROLL_VH` (JS) = `--formation-vh` (CSS)
+= 304vh (≈ `SPHERE_FORMED_PROGRESS` × the original 945vh single-runway tuning). `formedScrollPx()` is
+the single source used by the remap, the reduced-motion pin, and the focus-snap. Within the tail,
+`zoomT = clamp((scroll − formation) / (runway − formation), 0, 1)` drives the camera
+(`CAM_Z_SPHERE → CAM_Z_END`), the cursor retirement, and the pull-quote.
+
+Because formation is fixed, `--runway-height` sets tail length only. `--runway-height` is **shared**
+across breakpoints; `--pq-pin-factor` is **per-breakpoint** (`@media (min-width:768px)` overrides the
+sm base). CSS custom props on `.globe-gallery`:
+
+| prop | sm (base) | md+ | effect |
+|---|---|---|---|
+| `--runway-height` | 520vh | 520vh | total height = formation + tail; ↓ = shorter stretch after the globe (shrinks gap **and** hold together) |
+| `--formation-vh` | 304vh | 304vh | locked formation length; must equal `FORMATION_SCROLL_VH` in JS |
+| `--pq-pin-factor` | 0.65 | 0.55 | share of the tail the (bottom-anchored) quote pin occupies → its hold |
+
+sm uses a **bigger** pin factor than md on purpose: its globe clears earlier (`zoomT≈0.30` vs md
+`≈0.42`), so the quote can start sooner *and* hold longer — which sm needs, because the fixed 583px
+quote is taller in vh on a phone (~73vh at 800px vs ~54vh at 1080), i.e. it eats more of the pin. md's
+factor is capped ~0.55: above it the fade-in would cross md's globe-clear (`zoomT≈0.42`) and land the
+quote over the globe.
+
+**Pull-quote timing is derived, not hand-set.** The pin height is `(runway − formation) ×
+--pq-pin-factor`, so it always exits exactly at the runway end (no dead scroll), and the JS fade-in
+threshold `pqAppearZoomT = (1 − --pq-pin-factor) − PQ_APPEAR_LEAD` (0.03) is **read from the CSS var in
+`doLayout`** — so the pin geometry and the opacity trigger can't drift, per breakpoint or across a
+768px resize. Higher `--pq-pin-factor` → quote appears earlier **and** holds longer (they trade off at
+a fixed runway); to change both together, move `--runway-height`.
+
+**Tuning cheatsheet** (all visual — no test harness, so eyeball each):
+- *Whole stretch after the globe too long:* lower `--runway-height` (both breakpoints).
+- *Quote hold too short/long, or appears too early/late:* `--pq-pin-factor` for that breakpoint (JS
+  threshold auto-follows). md is capped ~0.55 (globe-clear); sm can go to ~0.67.
+- *"Click & Drag" cursor lingers too long/short:* `CURSOR_ZOOM_RETIRE_T` (0.40) — keep it ≥ the md
+  camera-clear `zoomT` (≈0.42... it currently fires just before, at camz≈−33, accepted) and, on md,
+  `< pqAppearZoomT` so it retires before the quote. `CURSOR_ZOOM_DISMISS_T` (0.38) fades the label
+  first. (Cursor is desktop-only, so sm's earlier quote doesn't affect it.)
+- *Formation (arc/grid/fold) pacing:* the `P_*` constants below — independent of the runway.
+
+Current result (from the progress math; hold is viewport-dependent since the quote is a fixed 583px):
+md gap ≈91vh / hold ≈65vh; sm gap ≈69vh / hold ≈68vh.
+
+Milo's page-level Lenis keeps `window.scrollY` in sync (gsap was dropped for a `requestAnimationFrame`
+driver, `startTicker`/`stopTicker`). The modal pauses Lenis via `window.lenis.stop()/start()` plus a
+`.globe-gallery-modal-open { overflow:hidden }` CSS lock.
 
 **Ticker gating (rAF only while visible).** The loop runs only when BOTH `renderReady`
 (cards built — contours paint immediately, textures fill in progressively; see Progressive
@@ -332,6 +382,20 @@ on screen (its clicks/drags/hover land on the off-screen globe's paused canvas).
 loop's `updateCanvasVisibility` restores the display. A single off-screen globe hiding its
 own canvas is a no-op (it's out of view anyway).
 
+**z-index / stacking order.** All values live in `globe-gallery.css` (plus the two canvas inline
+styles in `authoring.js`). Two bands in the page-root stacking context:
+
+- **Hero — 2–5:** world `2`, main canvas `3`, arc-copy / a11y widgets `4`, pull-quote / a11y tip `5`.
+- **Modal — 13–17:** backdrop `13`, modal canvas `14`, chrome `15`, cursor disc `16`, cursor container `17`.
+
+The modal band sits just above the **C2 gnav (`12`)** so the immersive card view covers the nav, and
+deliberately **below** the higher-priority interrupts that should appear over the globe — caas (`200`),
+market-selector (`9999`), georouting / Milo modals (`100000`), and the consent banner. It can't collapse
+into the 1–10 range precisely because it must clear the gnav. C1 core blocks (e.g. legacy gnav, the
+authored `notification` block) aren't authored alongside C2, so nothing occupies the 18–199 gap here.
+The modal chrome is a native `<dialog>`/`showModal()` in the top layer, so its z-index is only a
+non-supporting-browser fallback.
+
 ## Accessibility
 
 The globe is exposed as a **two-level gallery** (`a11y.js`), not a flat per-card list. Both levels
@@ -384,7 +448,7 @@ auto-spin (`a11y.isBrowsing()`); mouse drag still works.
   couldn't reliably cover the open case, which is why it was dropped.)
 
 **Reduced motion** (`prefers-reduced-motion: reduce`) renders a **static interactive** globe
-instead of the scroll choreography, laid out as **plain document flow** (`.globe-gallery--reduced`):
+instead of the scroll choreography, laid out as **plain document flow** (`.globe-gallery-reduced`):
 `computeFrame` pins scroll to `SPHERE_FORMED_PROGRESS` (formed sphere, `scrollVel` 0), auto-spin is
 off (drag + arrow-spin still work), the hover fisheye/scale/CA is suppressed (`hoverTarget` forced
 to 0 in `updateCardTransform`; the `cursor:pointer` affordance stays), and the modal snaps with no
@@ -410,14 +474,18 @@ cleanly). The pieces:
   box so it sits under the globe; `updatePullQuote` early-returns (CSS owns it).
 - **Arc-copy** — `display:none` (no arc phase; a fixed pill would hang over the scrolling page).
 
-The `--reduced` overrides are grouped at the **end of `globe-gallery.css`** (`no-descending-specificity`). The no-cards / WebGL-unavailable fallback is the separate `.globe-gallery--empty`.
+The `--reduced` overrides are grouped at the **end of `globe-gallery.css`** (`no-descending-specificity`). The no-cards / WebGL-unavailable fallback is the separate `.globe-gallery-empty`.
 
-Phase constants (module scope):
+Phase constants (module scope). The `P_*` values live in **progress-space** (0→1) and shape formation
++ zoom; the runway split, pull-quote, and cursor retirement are covered under **Scroll model → the
+runway / progress model** above (they're driven by `--runway-height` / `--formation-vh` /
+`--pq-pin-factor` in CSS, read/derived in JS):
 
 ```
 P_PAN_END=0.55  P_ARC_PREROLL=0.30  P_GRID_ARC_START=0.30  P_GRID_ARC_END=0.60
 P_FOLD_DUR=0.25  P_ZOOM_END=1.00  GRID_PEEL_STAGGER=0.20  SPHERE_INTERACTIVE_T=0.8
 FOLD_PEEL_OVERLAP=0.35  CA_ENABLED=true
+FORMATION_SCROLL_VH=304  PQ_APPEAR_LEAD=0.03  CURSOR_ZOOM_DISMISS_T=0.38  CURSOR_ZOOM_RETIRE_T=0.40
 ```
 
 `FOLD_PEEL_OVERLAP` (0–1) makes each card begin folding to the sphere that far — in peel
@@ -684,10 +752,10 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
   - No dwell needed: touch scrolling is self-terminating, so on lift the sphere is stationary and
     `sphereFormT >= 0.8` holds — scroll and spin are mutually exclusive in time. (How easy it is to
     *land* on the pristine formed globe is a pacing matter — see Open items.)
-- **`.globe-gallery`-scoped type-scale tokens in `globe-gallery.css`.** The prototype relied on
-  `:root` tokens from a typography stylesheet Milo doesn't ship; `globe-gallery.css` defines the
-  needed `--font-display`/`--type-title-1-*`/`--type-body-*` tokens scoped to `.globe`. Keep in sync
-  with `hub-creative/styles/global/typography.css`.
+- **Typography rides Milo's S2A type system.** Display/body copy carries the standard `heading-1` /
+  `body-lg` / `body-md` classes (added in `buildMarkup`), which supply responsive
+  size/line-height/letter-spacing; `globe-gallery.css` sets only family (`--heading-font-family` /
+  `--body-font-family`), weight (`--s2a-font-weight-*`), colour, and margins on top.
 
 ## Tuning reference
 
@@ -734,3 +802,20 @@ Known follow-ups, not blocking this integration branch:
 - **Pacing: landing on the pristine formed globe.** On touch, scroll-spin arbitration is correct
   (see Behavior notes → Touch gesture arbitration), but how easily a user *comes to rest* exactly on
   the fully-formed, still globe is a scroll-pacing tuning matter still open.
+- **Pull-quote uses a hardcoded `--pq-height: 583px`.** It's a shortcut (enables `top: calc(50vh -
+  h/2)` centering + a predictable hold = `pin − h`), but it's brittle to copy length — longer/localized
+  strings overflow the fixed box (no `overflow` handling), shorter copy leaves a dead gap under
+  `justify-content: space-between`. Make it copy-flexible (revisit in a future session). Two options:
+  - **A (recommended) — content-sized, transform-centered.** `position: sticky; top: 50vh;
+    transform: translateY(-50%) scale(…)` (the `-50%` is own-height-relative, so no fixed height);
+    drop `height` + `justify-content: space-between` for a `gap`; add `max-height: 90vh; overflow`
+    for pathologically long quotes. Keeps the "small quote → longer hold, no runway penalty" property;
+    the attribution sits directly under the quote (grouped, not spread). Retune `PQ_APPEAR_LEAD` — the
+    stick/centre point shifts by ~½ the quote height — and re-verify pacing. (A "100vh sticky wrapper +
+    `place-items:center`" variant is bulletproof but costs ~+100vh of runway for the same hold, so it's
+    not preferred.)
+  - **B — keep the top/bottom spread look.** Retain a defined height (`min-height` instead of a hard
+    `height`) so the quote/attribution stay spread; tolerates overflow better than today but partly
+    keeps the rigidity. Only if the spread is a deliberate editorial layout worth preserving.
+  - Decision needed from design: grouped (A) vs spread (B). See Scroll model → runway / progress model
+    for how `--pq-height` feeds the hold.

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -22,7 +22,9 @@ Once the sphere forms (`sphereFormT >= 0.8`) it's **interactive**: drag to spin,
 tap a card to open a detail **modal** (separate WebGL canvas + HTML chrome). Mouse
 drags spin **yaw freely** but **pitch is clamped to ±60°** (cards never pass vertical
 or read upside down, and the globe self-levels); **touch drags spin yaw only** so
-vertical swipes stay page scroll (see Sphere rotation + Touch gesture arbitration).
+vertical swipes stay page scroll, and **the barrel is yaw-only for mouse too** (pitch
+follows the geometry, not the pointer — a cylinder can't centre vertically). See
+Sphere rotation + Touch gesture arbitration.
 Extras: per-frame chromatic-aberration SVG filter, a fixed arc-copy overlay, a
 fixed pull-quote that fades in near the zoom end, a WebGL **"Click & Drag" hint
 text** behind the sphere (warps in on fold, dissolves away on first drag — see
@@ -648,9 +650,14 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
     *primary* pointer's precision), not `(hover: none)` or a UA sniff. Precision is read **once at
     init** (`usesCylinderGeometry`), so the geometry that bakes at `buildCards()` matches the device
     the page loaded on; a **mid-session mouse/trackpad swap needs a reload** (out of scope — rare,
-    and not worth a live-rebuild listener). Distinct from `interaction.js`'s per-*gesture*
-    `e.pointerType` check, so a hybrid device still gets full pitch from its mouse and yaw-only from
-    a finger within one session.
+    and not worth a live-rebuild listener). The width half *is* live, though: crossing 768px rebuilds
+    the geometry and flips `bp.YAW_ONLY`, and drag-pitch follows it (`getYawOnly: () => bp.YAW_ONLY`),
+    so a desktop window narrowed to `sm` gets the barrel *and* yaw-only mouse drags in lockstep.
+  - **Pitch is gated on `bp.YAW_ONLY` (geometry), not `e.pointerType`.** The barrel is yaw-only for
+    everyone — mouse included — because a cylinder can't centre a card vertically (matching the
+    keyboard/modal centring path, which holds pitch on `YAW_ONLY`). Pointer type still matters for
+    the *touch* half: a finger on the sphere is yaw-only (vertical = scroll) even though the sphere
+    itself pitches, so the drag path suppresses `velY` when `isTouchDrag || getYawOnly()`.
 
     ```
     device                  band cards  shape            cols  cardW  wall@near  col imb
@@ -737,11 +744,13 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
     sparsity the old fixed ±14° read as debris. md keeps the collage character.
 - **Touch gesture arbitration — yaw-only, via a directional axis lock** (`interaction.js`). On
   touch a vertical drag *is* the page-scroll gesture, so touch gets **yaw only** (horizontal spins,
-  vertical scrolls); pitch (`drag.velY`) stays mouse-only. `touch-action: pan-y` alone isn't enough
+  vertical scrolls); pitch (`drag.velY`) is written only when `!isTouchDrag && !getYawOnly()` — i.e.
+  a mouse on the sphere. `touch-action: pan-y` alone isn't enough
   — moves before the browser commits to the pan leak a pitch kick — so the axis is resolved in JS
   from the first `AXIS_LOCK_THRESHOLD` (8px) of travel, then **latched** for the gesture (a curved
   swipe can't flip axes; a 45° tie resolves to vertical). `isTouchDrag` is per-gesture from
-  `e.pointerType`, so a touchscreen laptop locks finger input but keeps full mouse pitch.
+  `e.pointerType`, so a touchscreen laptop locks finger input but keeps mouse pitch **on the sphere**
+  (its mouse still yaws-only on the barrel, since pitch follows geometry).
   - **Taps aren't gated on the lock** — `CLICK_MAX_MOVE` (10px) > the 8px threshold, so a jittery
     tap may have latched an axis; `onPointerUp`'s independent distance/time test keeps tap-to-open
     unchanged.

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -34,7 +34,6 @@
   z-index: 2;
 }
 
-/* JS positions left each frame. */
 .globe-gallery-arc-copy {
   position: fixed;
 
@@ -53,6 +52,10 @@
   will-change: opacity, transform;
   transform-origin: left bottom;
   z-index: 4;
+}
+
+html[dir="rtl"] .globe-gallery-arc-copy {
+  transform-origin: right bottom;
 }
 
 .globe-gallery-arc-copy-title {
@@ -78,7 +81,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  height: calc((var(--runway-height) - var(--formation-vh)) * var(--pq-pin-factor));
+  height: max(1px, calc((var(--runway-height) - var(--formation-vh)) * var(--pq-pin-factor)));
   pointer-events: none;
 }
 
@@ -162,6 +165,7 @@
   inset: 0;
   z-index: 15;
   width: 100vw;
+  height: 100vh;
   height: 100dvh;
   max-width: none;
   max-height: none;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -1,13 +1,8 @@
-/* Mobile-first (Milo convention): unscoped base = sm (<768); each @media (min-width) layers md/lg on top. */
 /* stylelint-disable property-no-vendor-prefix, value-no-vendor-prefix, custom-property-pattern */
 
-/* Scroll model (see README, Architecture / Behavior notes). --reduced (Accessibility) = plain
-   document flow with a static interactive globe; --empty = no cards / WebGL unavailable. Both
-   collapse the runway. Per-descendant --reduced overrides are grouped at the END of the file. */
+/* Scroll model (see README). .globe-gallery-reduced and .globe-gallery-empty overrides are at the end of this file. */
 .globe-gallery {
-  /* Runway = formation (--formation-vh, locked; = FORMATION_SCROLL_VH in JS) + tail (zoom-through +
-     pull-quote). --runway-height trims only the tail. --pq-pin-factor (tail share the quote pin takes
-     → its hold) is per-breakpoint (base = sm; md overrides below). Full model + tuning: README. */
+  /* Full scroll-runway model: README. */
   --runway-height: 520vh;
   --formation-vh: 304vh;
   --pq-pin-factor: 0.65;
@@ -30,7 +25,6 @@
 
 /* z-index bands: hero 2–5, modal 13–17. See README. */
 
-/* Sticky viewport — cards are absolutely positioned within this. */
 .globe-gallery-world {
   position: sticky;
   top: 0;
@@ -40,8 +34,7 @@
   z-index: 2;
 }
 
-/* Arc copy. Base (sm) = dark frosted pill over the cards; min-width:768 strips it to floating text.
-   JS sets `left` each frame. */
+/* JS positions left each frame. */
 .globe-gallery-arc-copy {
   position: fixed;
 
@@ -73,15 +66,13 @@
   margin: 0 0 4px;
 }
 
-/* .body-md (added via JS) supplies size/line-height/letter-spacing. */
 .globe-gallery-arc-copy-body {
   font-family: var(--body-font-family);
   color: var(--s2a-color-gray-400);
   margin: 0;
 }
 
-/* Pin is absolute at the runway bottom; the quote is sticky inside it (reveals/holds/exits, no JS).
-   Height = tail × --pq-pin-factor. See README → runway / progress model. */
+/* Absolute at runway bottom; sticky quote inside reveals/holds/exits without JS. */
 .globe-gallery-pullquote-pin {
   position: absolute;
   bottom: 0;
@@ -91,7 +82,7 @@
   pointer-events: none;
 }
 
-/* Hidden (opacity:0/scale:0.9) until JS adds .is-active at the zoomT threshold, so it emerges in place. */
+/* Starts hidden; JS adds .is-active once the zoom-in threshold passes. */
 .globe-gallery-pullquote {
   --pq-height: 583px;
 
@@ -119,7 +110,6 @@
   transform: scale(1);
 }
 
-/* .heading-1 (added via JS) supplies font-family, weight, size/line-height/letter-spacing. */
 .globe-gallery-pullquote-quote {
   color: var(--s2a-color-gray-25);
   margin: 0;
@@ -130,7 +120,6 @@
   margin-top: 24px;
 }
 
-/* .body-lg (added via JS) supplies size/line-height/letter-spacing on name + role. */
 .globe-gallery-pullquote-name {
   font-family: var(--body-font-family);
   color: var(--s2a-color-gray-25);
@@ -142,8 +131,6 @@
   color: var(--s2a-color-gray-400);
   margin: 0;
 }
-
-/* Card detail modal (see README, Behavior notes / Accessibility). */
 
 /* Backdrop layer (z:13) — dims/blurs the globe canvas behind the sharp card canvas. */
 .globe-gallery-modal {
@@ -169,9 +156,7 @@
   pointer-events: none;
 }
 
-/* Chrome layer — a native <dialog> opened with showModal(), reset to a full-viewport transparent
-   overlay in the top layer (z-index is a non-modal fallback). It is the live gesture surface
-   (pointer-events:auto + touch-action:none); its siblings are inert once showModal() runs. */
+/* Native <dialog> via showModal(); full-viewport top-layer overlay. Gesture surface: siblings go inert. */
 .globe-gallery-modal-chrome {
   position: fixed;
   inset: 0;
@@ -199,7 +184,7 @@
 /* Transparent ::backdrop — a styled one would sit ABOVE the photo canvas and hide it. */
 .globe-gallery-modal-chrome::backdrop { background: transparent; }
 
-/* Nav arrows — position set per-frame by JS (positionModalChrome); CSS is visual style only. */
+/* Position set per-frame by JS; CSS is visual style only. */
 .globe-gallery-modal-nav {
   width: 44px;
   height: 44px;
@@ -245,8 +230,7 @@
 }
 .globe-gallery-modal-close:hover { background: var(--s2a-color-transparent-black-80); }
 
-/* Info panel — position set by JS. Base (sm) = bottom scrim chunk; min-width:768 = full-height
-   left-edge scrim. Badges margin-top:auto pins them low; padding-bottom reserves the arrow row. */
+/* Position set by JS. Badges margin-top:auto pins them to bottom; padding-bottom reserves the nav row. */
 .globe-gallery-modal-info {
   position: absolute;
   height: 266px;
@@ -390,13 +374,11 @@
   user-select: none;
 }
 
-/* Lock scroll while the modal is open. Lock BOTH html + body — either can be the scrolling
-   element, and body alone let wheel/trackpad scroll bypass it (JS is the second layer for iOS). */
+/* Lock both html + body: either may be the scrolling element; body alone leaks wheel events on some browsers. */
 html.globe-gallery-modal-open,
 body.globe-gallery-modal-open { overflow: hidden; }
 
-/* Globe entry widget — the single focusable a11y button over the sphere (see README, Accessibility).
-   pointer-events:none so it never intercepts canvas drag; tabbable only while interactive (JS). */
+/* pointer-events:none — never intercepts canvas drag; tabbable only while interactive (JS). */
 .globe-gallery-a11y {
   position: fixed;
   top: 50%;
@@ -414,8 +396,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
 }
 .globe-gallery-a11y:focus { outline: none; }
 
-/* Per-image browse buttons (keyboard browse mode). JS sizes/positions each per-frame to its image's
-   projected screen rect. pointer-events:none; tabbable only while browsing. See README (Accessibility). */
+/* JS sizes/positions per-frame to each card's projected screen rect. See README (Accessibility). */
 .globe-gallery-a11y-cards {
   position: fixed;
   inset: 0;
@@ -440,8 +421,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
 }
 .globe-gallery-a11y-card:focus { outline: none; }
 
-/* Entry-widget instructions popup — one element that is both the aria-labelledby target and a visible
-   pill shown on focus (see README, Accessibility). pointer-events:none so it never blocks the canvas. */
+/* aria-labelledby target + visible instructions pill on focus. pointer-events:none so it never blocks the canvas. */
 .globe-gallery-a11y-tip {
   position: absolute;
   top: 50%;
@@ -473,7 +453,6 @@ body.globe-gallery-modal-open { overflow: hidden; }
   transform: translate(-50%, -50%) scale(1);
 }
 
-/* Visually-hidden but screen-reader-readable — the standard 1×1 clipped sr-only recipe. */
 .globe-gallery-sr-only {
   position: absolute;
   width: 1px;
@@ -495,9 +474,8 @@ body.globe-gallery-modal-open { overflow: hidden; }
   outline-offset: 2px;
 }
 
-/* Milo md+ (≥768px) — desktop modal + arc-copy treatment over the sm base (see README, Behavior notes). */
 @media (min-width: 768px) {
-  /* md: smaller quote-pin factor (md globe clears later; see README). Runway shared with the base. */
+  /* Smaller quote-pin factor at md; see README. */
   .globe-gallery { --pq-pin-factor: 0.55; }
 
   .globe-gallery-arc-copy {
@@ -507,7 +485,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
     background: none;
   }
 
-  /* Info scrim → full-height left-edge (JS sets top/bottom/left/width); background/blur inherit. */
+  /* Full-height left-edge; JS sets top/bottom/inset-inline-start/width. */
   .globe-gallery-modal-info {
     height: auto;
     border-radius: 0;
@@ -555,8 +533,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   }
 }
 
-/* Custom "Click & Drag" cursor, desktop only (see README, Behavior notes). Body-level elements from
-   src/cursor.js; the @media guard mirrors the JS gate so it never applies on touch/coarse pointers. */
+/* Custom cursor (src/cursor.js); @media mirrors the JS gate (hover+fine only). */
 @media (hover: hover) and (pointer: fine) {
   .globe-gallery-cursor {
     pointer-events: none;
@@ -568,8 +545,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
     z-index: 17;
   }
 
-  /* Disc — direct body child so mix-blend-mode: difference blends against page content (a
-     position:fixed container would GPU-isolate it). top/left keeps `transform` free for the entrance. */
+  /* Direct body child so mix-blend-mode: difference blends against page content (not an isolated GPU layer). */
   .globe-gallery-cursor-disc {
     pointer-events: none;
     position: fixed;
@@ -642,7 +618,6 @@ body.globe-gallery-modal-open { overflow: hidden; }
     transition: opacity 0.35s ease, transform 0.15s ease;
   }
 
-  /* Chevrons squeeze inward while dragging. */
   .globe-gallery-cursor-chevron-l,
   .globe-gallery-cursor-chevron-r {
     transition: transform 0.15s ease;
@@ -678,10 +653,9 @@ body.globe-gallery-modal-open { overflow: hidden; }
   }
 }
 
-/* Reduced-motion flow overrides — grouped at the end so descendant selectors follow their bases
-   (no-descending-specificity). See README (Accessibility) for the plain-document-flow layout. */
+/* Reduced-motion overrides — grouped here to avoid no-descending-specificity lint errors. See README (Accessibility). */
 
-/* Globe section: static so it scrolls away; relative anchors the absolute canvas. Height = 8vh + 100vh canvas. */
+/* static + relative: scrolls away and anchors the absolute canvas. Height = 8vh + 100vh. */
 .globe-gallery-reduced .globe-gallery-world {
   position: relative;
   height: 108vh;
@@ -692,7 +666,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   display: none;
 }
 
-/* A11y widget scrolls with the globe; re-centre on the sphere (base top:50% tracks the taller world). */
+/* Absolute so it scrolls with the globe; top:58vh re-centres on the sphere. */
 .globe-gallery-reduced .globe-gallery-a11y {
   position: absolute;
   top: 58vh;
@@ -723,7 +697,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   transition: none;
 }
 
-/* Reduced-motion: drop the remaining CSS-only motion — the modal nav button scale (colour cue stays). */
+/* Drop nav scale hover animation; colour cue stays. */
 @media (prefers-reduced-motion: reduce) {
   .globe-gallery-modal-nav:hover,
   .globe-gallery-modal-nav:active {

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -233,7 +233,7 @@
 /* Position set by JS. Badges margin-top:auto pins them to bottom; padding-bottom reserves the nav row. */
 .globe-gallery-modal-info {
   position: absolute;
-  height: 266px;
+  max-height: 60dvh;
   margin: 0;
   padding: 24px 24px 84px;
   border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-00);
@@ -249,6 +249,10 @@
   /* padding must count toward width — no global border-box reset in Milo */
   box-sizing: border-box;
 }
+
+.globe-gallery-modal-role-label,
+.globe-gallery-modal-name,
+.globe-gallery-modal-badges { flex-shrink: 0; }
 
 .globe-gallery-modal-badges {
   display: flex;
@@ -289,12 +293,18 @@
   color: var(--s2a-color-gray-400);
   margin: 0 0 12px;
   max-width: 375px;
+  min-height: 0; /* let this flex item shrink below its content so it scrolls, not overflows */
+  overflow-y: auto;
+  touch-action: pan-y; /* dialog is touch-action:none — re-enable vertical touch scroll here */
+  scrollbar-width: thin;
+  scrollbar-color: var(--s2a-color-transparent-white-24) transparent;
 
-  /* Cap to 3 lines (sm) so badges stay on-screen; min-width:768 unclamps it. */
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  /* Scroll-shadow fade cue; JS (updateDescFade) sets each length to 0 (no fade) or 20px. */
+  --desc-fade-top: 0;
+  --desc-fade-bottom: 0;
+
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 var(--desc-fade-top), #000 calc(100% - var(--desc-fade-bottom)), transparent 100%);
+  mask-image: linear-gradient(to bottom, transparent 0, #000 var(--desc-fade-top), #000 calc(100% - var(--desc-fade-bottom)), transparent 100%);
 }
 
 .globe-gallery-modal-badge {
@@ -488,6 +498,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   /* Full-height left-edge; JS sets top/bottom/inset-inline-start/width. */
   .globe-gallery-modal-info {
     height: auto;
+    max-height: none;
     border-radius: 0;
     padding: 40px 32px;
   }
@@ -506,10 +517,6 @@ body.globe-gallery-modal-open { overflow: hidden; }
     line-height: 22px;
     margin: 0;
     max-width: none;
-
-    /* Undo the sm 3-line clamp — the full-height scrim has room. */
-    display: block;
-    overflow: visible;
   }
 
   .globe-gallery-modal-badges { gap: 10px; }

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -495,7 +495,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   .globe-gallery-arc-copy {
     width: 382px;
     max-width: none;
-    bottom: 72px;
+    bottom: 24px;
     background: none;
   }
 

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -1,26 +1,16 @@
 /* Mobile-first (Milo convention): unscoped base = sm (<768); each @media (min-width) layers md/lg on top. */
-/* stylelint-disable selector-class-pattern, property-no-vendor-prefix, value-no-vendor-prefix, custom-property-pattern */
+/* stylelint-disable property-no-vendor-prefix, value-no-vendor-prefix, custom-property-pattern */
 
-/* Reduced motion: plain document flow, static interactive globe (see README, Accessibility). */
-.globe-gallery.globe-gallery--reduced {
-  height: auto;
-  min-height: 0;
-}
-
-/* Per-descendant --reduced overrides are grouped at the END of the file (they must follow their bases). */
-
-/* No cards / WebGL unavailable: collapse the runway to nothing. Distinct from --reduced. */
-.globe-gallery.globe-gallery--empty {
-  height: auto;
-  min-height: 0;
-}
-
-/* Scroll model + type-scale tokens: see README (Architecture notes / Behavior notes). Milo
-   doesn't ship the prototype's :root tokens, so define them scoped to .globe. Keep in sync with
-   hub-creative/styles/global/typography.css. */
+/* Scroll model (see README, Architecture / Behavior notes). --reduced (Accessibility) = plain
+   document flow with a static interactive globe; --empty = no cards / WebGL unavailable. Both
+   collapse the runway. Per-descendant --reduced overrides are grouped at the END of the file. */
 .globe-gallery {
-  /* Total scroll length + single source of truth for pacing (JS + pull-quote pin derive from it). */
-  --runway-height: 945vh;
+  /* Runway = formation (--formation-vh, locked; = FORMATION_SCROLL_VH in JS) + tail (zoom-through +
+     pull-quote). --runway-height trims only the tail. --pq-pin-factor (tail share the quote pin takes
+     → its hold) is per-breakpoint (base = sm; md overrides below). Full model + tuning: README. */
+  --runway-height: 520vh;
+  --formation-vh: 304vh;
+  --pq-pin-factor: 0.65;
 
   height: var(--runway-height);
   position: relative;
@@ -31,46 +21,14 @@
   /* kill the mobile tap flash on cards / backdrop */
   -webkit-tap-highlight-color: transparent;
 
-  --font-display: "Adobe Clean Display Black", 'Adobe Clean Display', adobe-clean-display, "Arial Bold Adjusted", sans-serif;
-  --font-body: 'Adobe Clean', 'Adobe Clean Display', system-ui, sans-serif;
-
-  /* Title 1 — sm: 40/38.4/-1.2px */
-  --type-title-1-size: 40px;
-  --type-title-1-weight: 900;
-  --type-title-1-lh: 0.96;
-  --type-title-1-ls: -0.03em;
-
-  /* Body Large — sm: 16/20.8/0 */
-  --type-body-l-size: 16px;
-  --type-body-l-weight: 400;
-  --type-body-l-lh: 1.3;
-  --type-body-l-ls: 0;
-
-  /* Body Medium — 16/20.8/+0.16px (all tiers) */
-  --type-body-m-size: 16px;
-  --type-body-m-weight: 400;
-  --type-body-m-lh: 1.3;
-  --type-body-m-ls: 0.01em;
-}
-
-@media (min-width: 768px) {
-  .globe-gallery {
-    --type-title-1-size: 56px;
-    --type-body-l-size: 18px;
+  &.globe-gallery-reduced,
+  &.globe-gallery-empty {
+    height: auto;
+    min-height: 0;
   }
 }
 
-@media (min-width: 1280px) {
-  .globe-gallery {
-    --type-title-1-size: 80px;
-    --type-title-1-ls: -0.04em;
-    --type-body-l-size: 20px;
-    --type-body-l-lh: 1.2;
-  }
-}
-
-/* z-index bands (page root stacking context): hero 2–5, modal 110–112, cursor 113–114. The modal
-   chrome is a native <dialog>/showModal() in the top layer, so its z-index is a non-modal fallback. */
+/* z-index bands: hero 2–5, modal 13–17. See README. */
 
 /* Sticky viewport — cards are absolutely positioned within this. */
 .globe-gallery-world {
@@ -93,7 +51,7 @@
   bottom: 8px;
   box-sizing: border-box;
   padding: 16px;
-  background: rgb(0 0 0 / 30%);
+  background: var(--s2a-color-transparent-black-32);
   -webkit-backdrop-filter: blur(var(--s2a-blur-64));
   backdrop-filter: blur(var(--s2a-blur-64));
   border-radius: var(--s2a-border-radius-md);
@@ -104,10 +62,10 @@
   z-index: 4;
 }
 
-.globe-gallery-arc-copy__title {
-  /* 18px custom mini-headline (between Title-4 and body). */
-  font-family: var(--font-display);
-  font-weight: 900;
+.globe-gallery-arc-copy-title {
+  /* 18px custom mini-headline (between Title-4 and body) — no standard type class fits. */
+  font-family: var(--heading-font-family);
+  font-weight: var(--s2a-font-weight-adobe-clean-black);
   font-size: 18px;
   line-height: var(--s2a-font-line-height-21);
   letter-spacing: var(--s2a-font-letter-spacing-neg-0_48);
@@ -115,24 +73,21 @@
   margin: 0 0 4px;
 }
 
-.globe-gallery-arc-copy__body {
-  font-family: var(--font-body);
-  font-weight: var(--type-body-m-weight);
-  font-size: var(--type-body-m-size);
-  line-height: var(--type-body-m-lh);
-  letter-spacing: var(--type-body-m-ls);
+/* .body-md (added via JS) supplies size/line-height/letter-spacing. */
+.globe-gallery-arc-copy-body {
+  font-family: var(--body-font-family);
   color: var(--s2a-color-gray-400);
   margin: 0;
 }
 
-/* Pull-quote. The pin is absolute at the runway bottom; the quote is sticky inside it, so it reveals,
-   holds, and exits with no JS. Pin height is a fraction of --runway-height so it scales with the runway. */
+/* Pin is absolute at the runway bottom; the quote is sticky inside it (reveals/holds/exits, no JS).
+   Height = tail × --pq-pin-factor. See README → runway / progress model. */
 .globe-gallery-pullquote-pin {
   position: absolute;
   bottom: 0;
   left: 0;
   right: 0;
-  height: calc(var(--runway-height) * 0.4);
+  height: calc((var(--runway-height) - var(--formation-vh)) * var(--pq-pin-factor));
   pointer-events: none;
 }
 
@@ -164,48 +119,37 @@
   transform: scale(1);
 }
 
-.globe-gallery-pullquote__quote {
-  font-family: var(--font-display);
-  font-weight: var(--type-title-1-weight);
-  font-size: var(--type-title-1-size);
-  line-height: var(--type-title-1-lh);
-  letter-spacing: var(--type-title-1-ls);
+/* .heading-1 (added via JS) supplies font-family, weight, size/line-height/letter-spacing. */
+.globe-gallery-pullquote-quote {
   color: var(--s2a-color-gray-25);
   margin: 0;
 }
 
 /* Gap between quote and name/role; only bites when they cluster (e.g. the RM centred layout). */
-.globe-gallery-pullquote__attribution {
+.globe-gallery-pullquote-attribution {
   margin-top: 24px;
 }
 
-.globe-gallery-pullquote__name {
-  font-family: var(--font-body);
-  font-weight: var(--type-body-l-weight);
-  font-size: var(--type-body-l-size);
-  line-height: var(--type-body-l-lh);
-  letter-spacing: var(--type-body-l-ls);
+/* .body-lg (added via JS) supplies size/line-height/letter-spacing on name + role. */
+.globe-gallery-pullquote-name {
+  font-family: var(--body-font-family);
   color: var(--s2a-color-gray-25);
   margin: 0;
 }
 
-.globe-gallery-pullquote__role {
-  font-family: var(--font-body);
-  font-weight: var(--type-body-l-weight);
-  font-size: var(--type-body-l-size);
-  line-height: var(--type-body-l-lh);
-  letter-spacing: var(--type-body-l-ls);
+.globe-gallery-pullquote-role {
+  font-family: var(--body-font-family);
   color: var(--s2a-color-gray-400);
   margin: 0;
 }
 
 /* Card detail modal (see README, Behavior notes / Accessibility). */
 
-/* Backdrop layer (z:110) — dims/blurs the globe canvas behind the sharp card canvas. */
+/* Backdrop layer (z:13) — dims/blurs the globe canvas behind the sharp card canvas. */
 .globe-gallery-modal {
   position: fixed;
   inset: 0;
-  z-index: 110;
+  z-index: 13;
   display: none;
   pointer-events: none;
   opacity: 0;
@@ -214,10 +158,10 @@
 .globe-gallery-modal.is-visible { display: block; }
 .globe-gallery-modal.is-open    { opacity: 1; }
 
-.globe-gallery-modal__backdrop {
+.globe-gallery-modal-backdrop {
   position: absolute;
   inset: 0;
-  background: rgb(0 0 0 / 60%);
+  background: var(--s2a-color-transparent-black-64);
   -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
 
@@ -231,9 +175,9 @@
 .globe-gallery-modal-chrome {
   position: fixed;
   inset: 0;
-  z-index: 112;
+  z-index: 15;
   width: 100vw;
-  height: 100vh;
+  height: 100dvh;
   max-width: none;
   max-height: none;
   margin: 0;
@@ -256,7 +200,7 @@
 .globe-gallery-modal-chrome::backdrop { background: transparent; }
 
 /* Nav arrows — position set per-frame by JS (positionModalChrome); CSS is visual style only. */
-.globe-gallery-modal__nav {
+.globe-gallery-modal-nav {
   width: 44px;
   height: 44px;
   border-radius: var(--s2a-border-radius-4);
@@ -274,15 +218,15 @@
   transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.globe-gallery-modal__nav:hover {
-  background: rgb(0 0 0 / 78%);
+.globe-gallery-modal-nav:hover {
+  background: var(--s2a-color-transparent-black-80);
   transform: scale(1.05);
 }
 
-.globe-gallery-modal__nav:active { transform: scale(0.98); }
+.globe-gallery-modal-nav:active { transform: scale(0.98); }
 
 /* Close button — position set by JS; same frosted treatment as the nav arrows. */
-.globe-gallery-modal__close {
+.globe-gallery-modal-close {
   position: absolute;
   width: 38px;
   height: 38px;
@@ -299,11 +243,11 @@
   pointer-events: auto;
   transition: background 0.2s ease;
 }
-.globe-gallery-modal__close:hover { background: rgb(0 0 0 / 78%); }
+.globe-gallery-modal-close:hover { background: var(--s2a-color-transparent-black-80); }
 
 /* Info panel — position set by JS. Base (sm) = bottom scrim chunk; min-width:768 = full-height
    left-edge scrim. Badges margin-top:auto pins them low; padding-bottom reserves the arrow row. */
-.globe-gallery-modal__info {
+.globe-gallery-modal-info {
   position: absolute;
   height: 266px;
   margin: 0;
@@ -322,7 +266,7 @@
   box-sizing: border-box;
 }
 
-.globe-gallery-modal__badges {
+.globe-gallery-modal-badges {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -332,21 +276,21 @@
 }
 
 /* Push badges to the bottom of the content area; 0,2,0 beats the 0,1,0 rule above. */
-.globe-gallery-modal__info > .globe-gallery-modal__badges {
+.globe-gallery-modal-info > .globe-gallery-modal-badges {
   margin-top: auto;
 }
 
-.globe-gallery-modal__role-label {
-  font-family: 'Adobe Clean', system-ui, sans-serif;
+.globe-gallery-modal-role-label {
+  font-family: var(--body-font-family);
   font-size: 13px;
-  font-weight: 400;
+  font-weight: var(--s2a-font-weight-body);
   color: var(--s2a-color-gray-400);
   margin: 0;
 }
 
-.globe-gallery-modal__name {
-  font-family: 'Adobe Clean Display', 'Adobe Clean', system-ui, sans-serif;
-  font-weight: 900;
+.globe-gallery-modal-name {
+  font-family: var(--heading-font-family);
+  font-weight: var(--s2a-font-weight-adobe-clean-black);
   font-size: 20px;
   line-height: var(--s2a-font-line-height-24);
   letter-spacing: -0.6px;
@@ -354,8 +298,8 @@
   margin: 2px 0 8px;
 }
 
-.globe-gallery-modal__description {
-  font-family: 'Adobe Clean', system-ui, sans-serif;
+.globe-gallery-modal-description {
+  font-family: var(--body-font-family);
   font-size: 13px;
   line-height: var(--s2a-font-line-height-18);
   color: var(--s2a-color-gray-400);
@@ -369,78 +313,78 @@
   overflow: hidden;
 }
 
-.globe-gallery-modal__badge {
+.globe-gallery-modal-badge {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.globe-gallery-modal__badge-left {
+.globe-gallery-modal-badge-left {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
-.globe-gallery-modal__badge-icon {
+.globe-gallery-modal-badge-icon {
   width: 24px;
   height: 24px;
   flex-shrink: 0;
   display: block;
 }
 
-.globe-gallery-modal__badge-icon img {
+.globe-gallery-modal-badge-icon img {
   width: 100%;
   height: 100%;
   object-fit: contain;
   display: block;
 }
 
-.globe-gallery-modal__badge-app {
-  font-family: 'Adobe Clean', system-ui, sans-serif;
-  font-weight: 700;
+.globe-gallery-modal-badge-app {
+  font-family: var(--body-font-family);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
   font-size: 13px;
   color: var(--s2a-color-gray-25);
 }
 
-.globe-gallery-modal__badge-app--link {
+.globe-gallery-modal-badge-app-link {
   text-decoration: none;
   display: inline-flex;
   align-items: center;
   gap: 2px;
 }
 
-.globe-gallery-modal__badge-app--link::after {
+.globe-gallery-modal-badge-app-link::after {
   content: '';
   display: inline-block;
   width: 6px;
   height: 6px;
-  border-right: 1.5px solid var(--s2a-color-gray-25);
-  border-top: 1.5px solid var(--s2a-color-gray-25);
+  border-right: 2px solid var(--s2a-color-gray-25);
+  border-top: 2px solid var(--s2a-color-gray-25);
   transform: rotate(45deg) translateY(-1px);
   flex-shrink: 0;
 }
 
-.globe-gallery-modal__badge-app--link:hover {
+.globe-gallery-modal-badge-app-link:hover {
   text-decoration: underline;
 }
 
-.globe-gallery-modal__badge-role {
-  font-family: 'Adobe Clean', system-ui, sans-serif;
+.globe-gallery-modal-badge-role {
+  font-family: var(--body-font-family);
   font-size: 13px;
   color: var(--s2a-color-gray-400);
 }
 
 /* Counter ("1/N"), positioned by JS. Base (sm) = plain text; min-width:768 = frosted pill. */
-.globe-gallery-modal__counter {
+.globe-gallery-modal-counter {
   height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
   color: var(--s2a-color-gray-25);
-  font-family: 'Adobe Clean', system-ui, sans-serif;
+  font-family: var(--body-font-family);
   font-size: 14px;
-  font-weight: 400;
+  font-weight: var(--s2a-font-weight-body);
   letter-spacing: 0.02em;
   pointer-events: none;
   user-select: none;
@@ -448,8 +392,8 @@
 
 /* Lock scroll while the modal is open. Lock BOTH html + body — either can be the scrolling
    element, and body alone let wheel/trackpad scroll bypass it (JS is the second layer for iOS). */
-html.modal-open,
-body.modal-open { overflow: hidden; }
+html.globe-gallery-modal-open,
+body.globe-gallery-modal-open { overflow: hidden; }
 
 /* Globe entry widget — the single focusable a11y button over the sphere (see README, Accessibility).
    pointer-events:none so it never intercepts canvas drag; tabbable only while interactive (JS). */
@@ -542,17 +486,20 @@ body.modal-open { overflow: hidden; }
   border: 0;
 }
 
-/* Keyboard focus indicators (Spectrum-style: 2px #1473E6, 2px offset). */
+/* Keyboard focus indicators (2px S2A focus ring, 2px offset). */
 .globe-gallery-a11y:focus-visible,
 .globe-gallery-a11y-card:focus-visible,
-.globe-gallery-modal__close:focus-visible,
-.globe-gallery-modal__nav:focus-visible {
-  outline: 2px solid #1473E6;
+.globe-gallery-modal-close:focus-visible,
+.globe-gallery-modal-nav:focus-visible {
+  outline: 2px solid var(--s2a-color-focus-ring-default);
   outline-offset: 2px;
 }
 
 /* Milo md+ (≥768px) — desktop modal + arc-copy treatment over the sm base (see README, Behavior notes). */
 @media (min-width: 768px) {
+  /* md: smaller quote-pin factor (md globe clears later; see README). Runway shared with the base. */
+  .globe-gallery { --pq-pin-factor: 0.55; }
+
   .globe-gallery-arc-copy {
     width: 382px;
     max-width: none;
@@ -561,22 +508,22 @@ body.modal-open { overflow: hidden; }
   }
 
   /* Info scrim → full-height left-edge (JS sets top/bottom/left/width); background/blur inherit. */
-  .globe-gallery-modal__info {
+  .globe-gallery-modal-info {
     height: auto;
     border-radius: 0;
     padding: 40px 32px;
   }
 
-  .globe-gallery-modal__role-label { margin-top: auto; }
+  .globe-gallery-modal-role-label { margin-top: auto; }
 
-  .globe-gallery-modal__name {
+  .globe-gallery-modal-name {
     font-size: 24px;
     line-height: 28px;
     letter-spacing: -0.6px;
     margin: 4px 0 12px;
   }
 
-  .globe-gallery-modal__description {
+  .globe-gallery-modal-description {
     font-size: 15px;
     line-height: 22px;
     margin: 0;
@@ -587,17 +534,17 @@ body.modal-open { overflow: hidden; }
     overflow: visible;
   }
 
-  .globe-gallery-modal__badges { gap: 10px; }
+  .globe-gallery-modal-badges { gap: 10px; }
 
-  .globe-gallery-modal__badge-icon {
+  .globe-gallery-modal-badge-icon {
     width: 28px;
     height: 28px;
   }
 
-  .globe-gallery-modal__badge-app { font-size: 14px; }
-  .globe-gallery-modal__badge-role { font-size: 14px; }
+  .globe-gallery-modal-badge-app { font-size: 14px; }
+  .globe-gallery-modal-badge-role { font-size: 14px; }
 
-  .globe-gallery-modal__counter {
+  .globe-gallery-modal-counter {
     width: 138px;
     box-sizing: border-box;
     border-radius: var(--s2a-border-radius-4);
@@ -617,18 +564,18 @@ body.modal-open { overflow: hidden; }
     top: 0;
     left: 0;
 
-    /* body-level; above the modal band (≤112) to top everything the block draws */
-    z-index: 114;
+    /* body-level; above the modal band (≤15) to top everything the block draws */
+    z-index: 17;
   }
 
   /* Disc — direct body child so mix-blend-mode: difference blends against page content (a
      position:fixed container would GPU-isolate it). top/left keeps `transform` free for the entrance. */
-  .globe-gallery-cursor__disc {
+  .globe-gallery-cursor-disc {
     pointer-events: none;
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 113; /* just below the cursor container */
+    z-index: 16; /* just below the cursor container */
     width: 48px;
     height: 48px;
     margin: -24px; /* center on the pointer hot-point */
@@ -640,24 +587,24 @@ body.modal-open { overflow: hidden; }
     transition: transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
 
-  .globe-gallery-cursor__disc--active {
+  .globe-gallery-cursor-disc-active {
     transform: scale(1);
     visibility: visible;
   }
 
-  .globe-gallery-cursor__disc--dragging {
+  .globe-gallery-cursor-disc-dragging {
     transform: scale(0.82);
     transition: transform 0.15s ease;
   }
 
-  .globe-gallery-cursor__ring-wrap,
-  .globe-gallery-cursor__text-wrap {
+  .globe-gallery-cursor-ring-wrap,
+  .globe-gallery-cursor-text-wrap {
     position: absolute;
     top: 0;
     left: 0;
   }
 
-  .globe-gallery-cursor__text-wrap {
+  .globe-gallery-cursor-text-wrap {
     display: flex;
     align-items: center;
     padding: 4px 10px;
@@ -671,7 +618,7 @@ body.modal-open { overflow: hidden; }
   }
 
   /* Chevron SVG — no blend mode; own opacity/scale entrance, separate from the disc. */
-  .globe-gallery-cursor__ring {
+  .globe-gallery-cursor-ring {
     display: block;
     position: absolute;
     top: -24px;
@@ -684,48 +631,48 @@ body.modal-open { overflow: hidden; }
     transition: opacity 0.35s ease, transform 0.45s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
 
-  .globe-gallery-cursor--active .globe-gallery-cursor__ring {
+  .globe-gallery-cursor-active .globe-gallery-cursor-ring {
     opacity: 1;
     visibility: visible;
     transform: scale(1);
   }
 
-  .globe-gallery-cursor--dragging .globe-gallery-cursor__ring {
+  .globe-gallery-cursor-dragging .globe-gallery-cursor-ring {
     transform: scale(0.82);
     transition: opacity 0.35s ease, transform 0.15s ease;
   }
 
   /* Chevrons squeeze inward while dragging. */
-  .globe-gallery-cursor__chevron-l,
-  .globe-gallery-cursor__chevron-r {
+  .globe-gallery-cursor-chevron-l,
+  .globe-gallery-cursor-chevron-r {
     transition: transform 0.15s ease;
   }
 
-  .globe-gallery-cursor--dragging .globe-gallery-cursor__chevron-l { transform: translateX(4px); }
-  .globe-gallery-cursor--dragging .globe-gallery-cursor__chevron-r { transform: translateX(-4px); }
+  .globe-gallery-cursor-dragging .globe-gallery-cursor-chevron-l { transform: translateX(4px); }
+  .globe-gallery-cursor-dragging .globe-gallery-cursor-chevron-r { transform: translateX(-4px); }
 
-  .globe-gallery-cursor__text {
+  .globe-gallery-cursor-text {
     display: block;
-    font-family: 'Adobe Clean Display', 'Adobe Clean', system-ui, sans-serif;
+    font-family: var(--heading-font-family);
     font-size: 12px;
-    font-weight: 700;
+    font-weight: var(--s2a-font-weight-adobe-clean-bold);
     letter-spacing: 0.02em;
     white-space: nowrap;
     line-height: 1;
     color: var(--s2a-color-gray-25);
   }
 
-  .globe-gallery-cursor--active .globe-gallery-cursor__text-wrap { opacity: 0.9; }
+  .globe-gallery-cursor-active .globe-gallery-cursor-text-wrap { opacity: 0.9; }
 
-  .globe-gallery-cursor--hint-dismissed .globe-gallery-cursor__text-wrap { opacity: 0; }
+  .globe-gallery-cursor-hint-dismissed .globe-gallery-cursor-text-wrap { opacity: 0; }
 
-  .globe-gallery-cursor--retiring .globe-gallery-cursor__ring {
+  .globe-gallery-cursor-retiring .globe-gallery-cursor-ring {
     opacity: 0;
     transform: scale(0.6);
     transition: opacity 0.42s ease, transform 0.42s ease;
   }
 
-  .globe-gallery-cursor__disc--retiring {
+  .globe-gallery-cursor-disc-retiring {
     transform: scale(0);
     transition: transform 0.42s cubic-bezier(0.4, 0, 0.2, 1);
   }
@@ -735,36 +682,36 @@ body.modal-open { overflow: hidden; }
    (no-descending-specificity). See README (Accessibility) for the plain-document-flow layout. */
 
 /* Globe section: static so it scrolls away; relative anchors the absolute canvas. Height = 8vh + 100vh canvas. */
-.globe-gallery--reduced .globe-gallery-world {
+.globe-gallery-reduced .globe-gallery-world {
   position: relative;
   height: 108vh;
 }
 
 /* No arc phase under RM — a fixed pill would hang over the scrolling page. */
-.globe-gallery--reduced .globe-gallery-arc-copy {
+.globe-gallery-reduced .globe-gallery-arc-copy {
   display: none;
 }
 
 /* A11y widget scrolls with the globe; re-centre on the sphere (base top:50% tracks the taller world). */
-.globe-gallery--reduced .globe-gallery-a11y {
+.globe-gallery-reduced .globe-gallery-a11y {
   position: absolute;
   top: 58vh;
 }
 
 /* Focus-ring overlay tracks the scrolled canvas (matching its 8vh top + 100vh box). */
-.globe-gallery--reduced .globe-gallery-a11y-cards {
+.globe-gallery-reduced .globe-gallery-a11y-cards {
   position: absolute;
   inset: 8vh 0 auto;
   height: 100vh;
 }
 
 /* Pull-quote flows normally after the globe: drop the pin/sticky, show statically, top-aligned with a gap above. */
-.globe-gallery--reduced .globe-gallery-pullquote-pin {
+.globe-gallery-reduced .globe-gallery-pullquote-pin {
   position: static;
   height: auto;
 }
 
-.globe-gallery--reduced .globe-gallery-pullquote {
+.globe-gallery-reduced .globe-gallery-pullquote {
   position: static;
   top: auto;
   height: auto;
@@ -778,8 +725,16 @@ body.modal-open { overflow: hidden; }
 
 /* Reduced-motion: drop the remaining CSS-only motion — the modal nav button scale (colour cue stays). */
 @media (prefers-reduced-motion: reduce) {
-  .globe-gallery-modal__nav:hover,
-  .globe-gallery-modal__nav:active {
+  .globe-gallery-modal-nav:hover,
+  .globe-gallery-modal-nav:active {
     transform: none;
   }
+}
+
+html[dir="rtl"] .globe-gallery-modal-nav svg {
+  transform: scaleX(-1);
+}
+
+html[dir="rtl"] .globe-gallery-modal-badge-app-link::after {
+  transform: scaleX(-1) rotate(45deg) translateY(-1px);
 }

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -514,7 +514,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
     padding: 40px 32px;
   }
 
-  .globe-gallery-modal-role-label { margin-top: auto; }
+  .globe-gallery-modal-role-label { margin-top: 0; }
 
   .globe-gallery-modal-name {
     font-size: 24px;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -109,6 +109,13 @@ const GRID_PEEL_STAGGER = 0.20;
 // Grid→sphere fold overlap. See README (FOLD_PEEL_OVERLAP). 0 restores "settle then fold".
 const FOLD_PEEL_OVERLAP = 0.35;
 const FOLD_START_LOCAL_T = 1 - (FOLD_PEEL_OVERLAP ** (1 / 3));
+const GRID_ARC_RANGE = PROGRESS_GRID_ARC_END - PROGRESS_GRID_ARC_START;
+const FOLD_FIRST_PROGRESS = Math.max(
+  0,
+  (PROGRESS_GRID_ARC_START
+    + FOLD_START_LOCAL_T * (1 - GRID_PEEL_STAGGER) * GRID_ARC_RANGE
+    - PROGRESS_ARC_PREROLL) * PROGRESS_PAN_END,
+);
 // Progress at sphereFormT=1, zoomT=0 — the "interactive globe" position keyboard focus snaps
 // to. Mirrors computeFrame's foldLast (single source).
 const SPHERE_FORMED_PROGRESS = Math.max(
@@ -1072,11 +1079,9 @@ function createGlobeGalleryRuntime(
 
     // Convert arc-pan arrival times to progress units for the fold/zoom phases.
     const gpWin = 1.0 - GRID_PEEL_STAGGER;
-    const arcRange = PROGRESS_GRID_ARC_END - PROGRESS_GRID_ARC_START;
-    // First card folds when its peel reaches FOLD_START_LOCAL_T·gpWin; foldLast
+    // foldFirst: first card folds when its peel reaches FOLD_START_LOCAL_T·gpWin; foldLast
     // (= SPHERE_FORMED_PROGRESS) tracks the latest card's finish.
-    const foldFirstArcT = PROGRESS_GRID_ARC_START + FOLD_START_LOCAL_T * gpWin * arcRange;
-    const foldFirst = Math.max(0, (foldFirstArcT - PROGRESS_ARC_PREROLL) * PROGRESS_PAN_END);
+    const foldFirst = FOLD_FIRST_PROGRESS;
     const foldLast = SPHERE_FORMED_PROGRESS;
     const sphereFormT = Math.max(0, Math.min(1, (progress - foldFirst) / (foldLast - foldFirst)));
     // Zoom-through starts the instant the sphere finishes forming (no interactive gap).
@@ -1347,14 +1352,14 @@ function createGlobeGalleryRuntime(
 
   function updateArcCopy() {
     if (!arcCopyEl) return;
-    const PROGRESS_HEADLINE_IN = 0.25;
-    const PROGRESS_ARC_COPY_OUT = 0.50;
+    const ARC_COPY_OUT_FORM_START = 0.20;
+    const ARC_COPY_OUT_FORM_END = 0.90;
+    const foldWindow = SPHERE_FORMED_PROGRESS - FOLD_FIRST_PROGRESS;
+    const outStart = FOLD_FIRST_PROGRESS + ARC_COPY_OUT_FORM_START * foldWindow;
+    const outEnd = FOLD_FIRST_PROGRESS + ARC_COPY_OUT_FORM_END * foldWindow;
     const arcCopyInE = easeOutCubic(Math.min(1, arcCopyEntryT / 0.336));
-    const arcCopyOutT = Math.max(0, Math.min(
-      1,
-      (progress - PROGRESS_HEADLINE_IN) / (PROGRESS_ARC_COPY_OUT - PROGRESS_HEADLINE_IN),
-    ));
-    const arcCopyOutE = easeOutCubic(arcCopyOutT);
+    const arcCopyOutT = Math.max(0, Math.min(1, (progress - outStart) / (outEnd - outStart)));
+    const arcCopyOutE = easeInOutCubic(arcCopyOutT);
     const arcCopyOp = arcCopyInE * (1 - arcCopyOutE);
     const arcCopySlide = 24 * (1 - arcCopyInE);
     // sm pins 8px from viewport inline-start;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -16,6 +16,7 @@ import {
 const CARD_ASPECT = 456 / 631; // portrait
 
 const prefersReducedMotion = () => !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+const isRtl = () => document.documentElement.dir === 'rtl';
 
 // Two render profiles split at 768px (Milo sm↔md); resolved once via resolveBP(W).
 // See README (Breakpoints).
@@ -399,7 +400,8 @@ function createGlobeGalleryRuntime(
   let globalCaFilterOn = false; // whether canvas.style.filter currently holds the CA url
   // Arc-copy overlay: cached node + last-written style strings (see updateArcCopy).
   let arcCopyEl = null;
-  let arcCopyLeftStr = '';
+  let arcCopyInlineStartSide = '';
+  let arcCopyInlineStartStr = '';
   let arcCopyOpStr = '';
   let arcCopyTransformStr = '';
   let prevLenisY = 0; // previous frame scroll position
@@ -1355,14 +1357,25 @@ function createGlobeGalleryRuntime(
     const arcCopyOutE = easeOutCubic(arcCopyOutT);
     const arcCopyOp = arcCopyInE * (1 - arcCopyOutE);
     const arcCopySlide = 24 * (1 - arcCopyInE);
-    // sm pins 8px from viewport left; md uses the 24px-grid-aligned position with centering.
+    // sm pins 8px from viewport inline-start;
+    // md uses the 24px-grid-aligned position with centering.
     const gridLeft = (bp.name === 'sm')
       ? 8
       : 24 + Math.max(0, (W - 48 - 1392) / 2);
-    const leftStr = `${gridLeft}px`;
+    const inlineStartSide = isRtl() ? 'right' : 'left';
+    const inlineEndSide = isRtl() ? 'left' : 'right';
+    const insetStr = `${gridLeft}px`;
     const opStr = arcCopyOp.toFixed(3);
     const transformStr = `translateY(${arcCopySlide.toFixed(1)}px)`;
-    if (leftStr !== arcCopyLeftStr) { arcCopyEl.style.left = leftStr; arcCopyLeftStr = leftStr; }
+    if (inlineStartSide !== arcCopyInlineStartSide) {
+      arcCopyEl.style[inlineEndSide] = '';
+      arcCopyInlineStartSide = inlineStartSide;
+      arcCopyInlineStartStr = '';
+    }
+    if (insetStr !== arcCopyInlineStartStr) {
+      arcCopyEl.style[inlineStartSide] = insetStr;
+      arcCopyInlineStartStr = insetStr;
+    }
     if (opStr !== arcCopyOpStr) { arcCopyEl.style.opacity = opStr; arcCopyOpStr = opStr; }
     if (transformStr !== arcCopyTransformStr) {
       arcCopyEl.style.transform = transformStr;
@@ -2004,7 +2017,10 @@ function createGlobeGalleryRuntime(
     caFilterR = q('.globe-gallery-ca-r-offset');
     caFilterB = q('.globe-gallery-ca-b-offset');
     arcCopyEl = q('.globe-gallery-arc-copy');
-    arcCopyLeftStr = ''; arcCopyOpStr = ''; arcCopyTransformStr = '';
+    arcCopyInlineStartSide = '';
+    arcCopyInlineStartStr = '';
+    arcCopyOpStr = '';
+    arcCopyTransformStr = '';
 
     modal.setup();
 

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -15,6 +15,8 @@ import {
 
 const CARD_ASPECT = 456 / 631; // portrait
 
+const prefersReducedMotion = () => !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
 // Two render profiles split at 768px (Milo sm↔md); resolved once via resolveBP(W).
 // See README (Breakpoints).
 const BREAKPOINTS = {
@@ -86,8 +88,7 @@ const YAW_ONLY_GEOMETRY = {
 // pointer. matchMedia-less environments are treated as precise-pointer. See README.
 function usesCylinderGeometry(bandName) {
   if (bandName === 'sm') return true;
-  if (!window.matchMedia) return false;
-  return window.matchMedia('(pointer: coarse)').matches;
+  return !!window.matchMedia?.('(pointer: coarse)').matches;
 }
 
 // Phase timeline (progress 0→1 across the full scroll length). See README (Phase constants).
@@ -1874,8 +1875,7 @@ function createGlobeGalleryRuntime(
     const canvas = q('.globe-gallery-canvas');
     if (!canvas) return false;
 
-    reducedMotion = !!(window.matchMedia
-      && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+    reducedMotion = prefersReducedMotion();
     root.classList.toggle('globe-gallery-reduced', reducedMotion);
 
     // Reduced motion: canvas into normal flow (absolute in the static world) so the globe
@@ -1930,8 +1930,7 @@ function createGlobeGalleryRuntime(
       // path. Pointer precision is read at init only — a mid-session mouse/trackpad swap needs a
       // reload (out of scope; see README).
       const nextBand = resolveBP(W);
-      const nextReducedMotion = !!(window.matchMedia
-        && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+      const nextReducedMotion = prefersReducedMotion();
       if (nextBand.name !== bp.name || nextReducedMotion !== reducedMotion) {
         // eslint-disable-next-line no-use-before-define -- hoisted destroy/initRuntime mutual ref
         destroy();
@@ -1967,8 +1966,8 @@ function createGlobeGalleryRuntime(
     if (reducedMotionMQ && reducedMotionHandler) {
       reducedMotionMQ.removeEventListener('change', reducedMotionHandler);
     }
-    if (window.matchMedia) {
-      reducedMotionMQ = window.matchMedia('(prefers-reduced-motion: reduce)');
+    reducedMotionMQ = window.matchMedia?.('(prefers-reduced-motion: reduce)') ?? null;
+    if (reducedMotionMQ) {
       reducedMotionHandler = doLayout;
       reducedMotionMQ.addEventListener('change', reducedMotionHandler);
     }
@@ -2145,9 +2144,9 @@ function createGlobeGalleryRuntime(
 
 export default async function init(el) {
   // Reduced motion: static, still-interactive globe in plain document flow. See README.
-  const reducedMotion = !!(window.matchMedia
-    && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
-  if (reducedMotion) el.classList.add('globe-gallery-reduced');
+  if (prefersReducedMotion()) {
+    el.classList.add('globe-gallery-reduced');
+  }
 
   // Extract authored content (incl. the UI labels) before buildGlobeDom() wipes the children.
   const {

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -1021,6 +1021,8 @@ function createGlobeGalleryRuntime(
     maxVel: MAX_VEL,
     drag,
     isCursorActive: () => cursor.isActive(),
+    // Pitch follows geometry, not pointer type: the barrel (bp.YAW_ONLY) is yaw-only for mouse too.
+    getYawOnly: () => bp.YAW_ONLY,
   });
 
   // Per-frame pipeline. tick() is a thin orchestrator over the single-concern stages below;
@@ -2093,7 +2095,10 @@ function createGlobeGalleryRuntime(
     if (renderer) {
       renderer.domElement.style.filter = '';
       globalCaFilterOn = false;
-      renderer.forceContextLoss();
+      // NOTE: do NOT forceContextLoss() here — the canvas element is reused across rebuilds
+      // (band crossings / reduced-motion toggles), and a force-lost context is never restored,
+      // so the next renderer on the same canvas is born dead ("Context Lost"). dispose() alone
+      // frees this renderer's GPU resources.
       renderer.dispose();
       renderer.domElement.style.display = 'none';
     }

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -99,6 +99,9 @@ const PROGRESS_GRID_ARC_START = 0.30;
 const PROGRESS_GRID_ARC_END = 0.60;
 const PROGRESS_FOLD_DUR = 0.25;
 const PROGRESS_ZOOM_END = 1.00;
+// Pull-quote fade-in lead before the pin centres: pqAppearZoomT = (1 − --pq-pin-factor) − this (set
+// per breakpoint in doLayout). See README → runway / progress model.
+const PQ_APPEAR_LEAD = 0.03;
 // Peel stagger; defined here since the fold window derives from it.
 const GRID_PEEL_STAGGER = 0.20;
 // Grid→sphere fold overlap. See README (FOLD_PEEL_OVERLAP). 0 restores "settle then fold".
@@ -113,6 +116,10 @@ const SPHERE_FORMED_PROGRESS = Math.max(
       * (PROGRESS_GRID_ARC_END - PROGRESS_GRID_ARC_START)
     - PROGRESS_ARC_PREROLL) * PROGRESS_PAN_END,
 ) + PROGRESS_FOLD_DUR;
+
+// Fixed formation scroll length; `progress` is remapped piecewise around it so trimming the runway
+// only compresses the tail. Keep = --formation-vh (CSS). See README → runway / progress model.
+const FORMATION_SCROLL_VH = 304; // ≈ SPHERE_FORMED_PROGRESS × 945
 
 // Entry timing — two independent knobs. See README (Entry timing).
 const ENTRY_LEAD_VH = 0.4;
@@ -188,9 +195,12 @@ const TEXT_CA_DIR_STRENGTH = 0.05; // uMotionDir strength for drag CA on the tex
 const TEXT_CA_WARP_MUL = 1.5; // warp-driven CA boost
 const TEXT_DRAG_WARP_MUL = 3.0; // text drag-warp vs sphere cards — more violent
 const TEXT_WARP_OVERFLOW = 0.6; // extra mesh scale per warp unit — letterforms bleed off
-// Custom cursor two-step retirement off textExitProgress: label fades, then whole cursor.
+// Two-step cursor retirement (label, then whole cursor), off textExitProgress (drag) or zoomT (once
+// the camera clears the globe). Thresholds/constraints: README → runway / progress model.
 const CURSOR_HINT_DISMISS_T = 0.12;
 const CURSOR_RETIRE_T = 0.55;
+const CURSOR_ZOOM_DISMISS_T = 0.38;
+const CURSOR_ZOOM_RETIRE_T = 0.40;
 
 const GOLDEN_ANGLE = Math.PI * (1 + Math.sqrt(5));
 // Cylindrical masonry layout — a WHOLE-SET solve (card heights depend on image aspects, so
@@ -376,6 +386,7 @@ function createGlobeGalleryRuntime(
   let arcCopyEntryT = 0;
   let blockDocTop = 0; // block's top in document space (the scroll runway)
   let blockHeight = 0; // its full scroll length
+  let pqAppearZoomT = 0.5; // zoomT the pull-quote fades in at; from --pq-pin-factor (see doLayout)
   let W = 0; let
     H = 0;
 
@@ -752,6 +763,7 @@ function createGlobeGalleryRuntime(
   // sphereFormT is computed in tick(); cached so interaction.js's click/hover handlers
   // (which fire between ticks) know whether the sphere is clickable.
   let sphereFormTAtLastTick = 0;
+  let zoomTAtLastTick = 0;
 
   // Card facing — tilts limb cards partway toward the camera so edge-on slivers stay legible.
   // MUST be per-frame (the sphere rotates). Target is sign(n.z) × view dir so back cards keep
@@ -903,12 +915,12 @@ function createGlobeGalleryRuntime(
     getCardMetadata,
     // Lazily load a sharper texture for the opened card. Returns the pending Image (so the
     // modal can cancel it) or null when the base cap already meets the modal cap (reuse, no load).
-    loadModalUpgrade: (idx, onReady) => {
+    loadModalUpgrade: (idx, onReady, onError) => {
       const base = bp.name === 'sm' ? CARD_TEX_SM : CARD_TEX_MD;
       const modalCap = bp.name === 'sm' ? MODAL_TEX_SM : MODAL_TEX_MD;
       if (modalCap <= base) return null;
       const src = optimizeImgUrl(getCardMetadata(idx).img, modalCap);
-      return loadModalTextureRaw(src, modalCap, onReady);
+      return loadModalTextureRaw(src, modalCap, onReady, onError);
     },
     getViewport: () => ({ W, H }),
     getBP: () => bp.name,
@@ -929,13 +941,19 @@ function createGlobeGalleryRuntime(
     restoreFocusOnClose: (idx) => { if (a11y && a11y.isBrowsing()) a11y.focusCard(idx); },
   });
 
+  // Scroll px from the block top where the sphere is fully formed (progress = foldLast); locked to
+  // FORMATION_SCROLL_VH, clamped to the runway. See README → runway / progress model.
+  function formedScrollPx() {
+    return Math.min((FORMATION_SCROLL_VH / 100) * H, blockHeight);
+  }
+
   // Focusing the widget snaps the page to the interactive globe state (formed-sphere offset;
   // block top under RM). Deferred a frame so focus settles first (pdf-space). See README.
   function snapToInteractive() {
     if (suppressFocusSnap) return;
     const top = reducedMotion
       ? blockDocTop
-      : blockDocTop + SPHERE_FORMED_PROGRESS * blockHeight;
+      : blockDocTop + formedScrollPx();
     requestAnimationFrame(() => {
       if (window.lenis?.scrollTo) window.lenis.scrollTo(top, { force: true, immediate: true });
       else window.scrollTo(0, top);
@@ -984,8 +1002,10 @@ function createGlobeGalleryRuntime(
     getModalOpen: () => modal.getModalIdx() >= 0,
     getReducedMotion: () => reducedMotion,
     // Two-step exit off the shared hint signal (see the threshold constants).
-    getHintDismissed: () => textExitProgress > CURSOR_HINT_DISMISS_T,
-    getCursorRetired: () => textExitProgress > CURSOR_RETIRE_T,
+    getHintDismissed: () => textExitProgress > CURSOR_HINT_DISMISS_T
+      || zoomTAtLastTick > CURSOR_ZOOM_DISMISS_T,
+    getCursorRetired: () => textExitProgress > CURSOR_RETIRE_T
+      || zoomTAtLastTick > CURSOR_ZOOM_RETIRE_T,
     labelText: hintText || 'Click & Drag',
     drag,
   });
@@ -1014,7 +1034,7 @@ function createGlobeGalleryRuntime(
     // Reduced motion: pin scroll input to the formed-sphere position (static globe, no motion
     // trail). The pin cancels in `progress`; canvas visibility still uses real scroll.
     const lenisY = reducedMotion
-      ? blockDocTop + SPHERE_FORMED_PROGRESS * blockHeight
+      ? blockDocTop + formedScrollPx()
       : window.scrollY;
     const scrollingDown = lenisY >= prevLenisY;
     // px/frame scroll speed — drives the velocity-based CA. Dead-banded to suppress Lenis
@@ -1025,7 +1045,14 @@ function createGlobeGalleryRuntime(
     const entryStart = blockDocTop - H * ENTRY_LEAD_VH;
     const entryRange = H * ENTRY_RAMP_VH;
     arcCopyEntryT = Math.max(0, Math.min(1, (lenisY - entryStart) / entryRange));
-    progress = Math.max(0, Math.min(1, (lenisY - blockDocTop) / blockHeight));
+    // Piecewise: formation over [0, formPx] (fixed length), zoom-through + quote over the rest.
+    const rawScroll = lenisY - blockDocTop;
+    const formPx = formedScrollPx();
+    const tailPx = Math.max(1, blockHeight - formPx);
+    progress = rawScroll <= formPx
+      ? Math.max(0, Math.min(1, rawScroll / formPx)) * SPHERE_FORMED_PROGRESS
+      : SPHERE_FORMED_PROGRESS
+        + Math.max(0, Math.min(1, (rawScroll - formPx) / tailPx)) * (1 - SPHERE_FORMED_PROGRESS);
 
     // arcPanT: preroll animates in with the entry so the arc is already moving as it enters view.
     const arcPanT = Math.min(1, progress / PROGRESS_PAN_END + PROGRESS_ARC_PREROLL * arcCopyEntryT);
@@ -1050,6 +1077,7 @@ function createGlobeGalleryRuntime(
     // Zoom-through starts the instant the sphere finishes forming (no interactive gap).
     const zoomT = Math.max(0, Math.min(1, (progress - foldLast) / (PROGRESS_ZOOM_END - foldLast)));
     sphereFormTAtLastTick = sphereFormT; // cache for interaction's click/hover handlers
+    zoomTAtLastTick = zoomT;
 
     // Card-entry transforms (arc branch): entryRot sweeps the arc in after a 5% hold;
     // entryYOffset is the vertical slide-up; arcScale is the arc→sphere size ratio.
@@ -1245,18 +1273,18 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  // Pull-quote: JS adds .is-active once zoomT crosses 0.38 (sticky handles forward exit). On
+  // Pull-quote: JS adds .is-active once zoomT crosses pqAppearZoomT (sticky handles exit). On
   // scroll-up, a fast 0.15s fade so it disappears before the sticky element drifts down.
   function updatePullQuote(frame) {
     const { zoomT, scrollingDown } = frame;
     // Reduced motion: CSS owns it (opacity:1, no reveal) — no JS toggling.
     if (reducedMotion) return;
     if (pqEl) {
-      if (zoomT >= 0.38 && !pqShown) {
+      if (zoomT >= pqAppearZoomT && !pqShown) {
         pqEl.style.transition = ''; // restore CSS default (0.7s, set in .css)
         pqShown = true;
         pqEl.classList.add('is-active');
-      } else if (zoomT < 0.38 && pqShown) {
+      } else if (zoomT < pqAppearZoomT && pqShown) {
         if (!scrollingDown) {
           pqEl.style.transition = 'opacity 0.15s ease, transform 0.15s ease';
         }
@@ -1788,6 +1816,7 @@ function createGlobeGalleryRuntime(
   let contextRebuilds = 0;
   let contextStableTimer = 0;
   let contextRecovering = false;
+  let contextRecoverTimer = 0;
   function onContextLost(e) {
     e.preventDefault();
     if (contextStableTimer) { clearTimeout(contextStableTimer); contextStableTimer = 0; }
@@ -1796,6 +1825,7 @@ function createGlobeGalleryRuntime(
     window.lana?.log?.('globe-gallery: WebGL context lost', { tags: 'globe-gallery', severity: 'warn' });
   }
   function recoverFromContextLoss() {
+    contextRecoverTimer = 0;
     contextRecovering = false;
     contextRebuilds += 1;
     const collapsed = contextRebuilds > MAX_CONTEXT_REBUILDS;
@@ -1809,7 +1839,7 @@ function createGlobeGalleryRuntime(
     destroy();
     // eslint-disable-next-line no-use-before-define -- same hoisted mutual ref
     if (collapsed || initRuntime() === false) {
-      root.classList.add('globe-gallery--empty');
+      root.classList.add('globe-gallery-empty');
       return;
     }
     contextStableTimer = window.setTimeout(() => {
@@ -1819,7 +1849,7 @@ function createGlobeGalleryRuntime(
   function onContextRestored() {
     if (contextRecovering) return; // coalesce the main + modal canvases' restore events (README)
     contextRecovering = true;
-    window.setTimeout(recoverFromContextLoss, 0);
+    contextRecoverTimer = window.setTimeout(recoverFromContextLoss, 0);
   }
   function bindContextListeners(add) {
     const fn = add ? 'addEventListener' : 'removeEventListener';
@@ -1844,7 +1874,7 @@ function createGlobeGalleryRuntime(
 
     reducedMotion = !!(window.matchMedia
       && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
-    root.classList.toggle('globe-gallery--reduced', reducedMotion);
+    root.classList.toggle('globe-gallery-reduced', reducedMotion);
 
     // Reduced motion: canvas into normal flow (absolute in the static world) so the globe
     // scrolls away; top nudge clears the section above. See README (Reduced motion).
@@ -1903,11 +1933,13 @@ function createGlobeGalleryRuntime(
       if (nextBand.name !== bp.name || nextReducedMotion !== reducedMotion) {
         // eslint-disable-next-line no-use-before-define -- hoisted destroy/initRuntime mutual ref
         destroy();
-        if (initRuntime() === false) root.classList.add('globe-gallery--empty');
+        if (initRuntime() === false) root.classList.add('globe-gallery-empty');
         return;
       }
       blockDocTop = root.getBoundingClientRect().top + window.scrollY;
       blockHeight = root.offsetHeight || window.innerHeight * 7;
+      const pinFactor = parseFloat(getComputedStyle(root).getPropertyValue('--pq-pin-factor')) || 0.44;
+      pqAppearZoomT = Math.max(0, (1 - pinFactor) - PQ_APPEAR_LEAD);
       // Re-apply DPR (can change when dragging between monitors of different density).
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
       renderer.setSize(W, H);
@@ -2033,6 +2065,8 @@ function createGlobeGalleryRuntime(
     onScreen = true; // reset the visibility default; the next init's observer re-corrects it
     bindContextListeners(false);
     if (contextStableTimer) { clearTimeout(contextStableTimer); contextStableTimer = 0; }
+    if (contextRecoverTimer) { clearTimeout(contextRecoverTimer); contextRecoverTimer = 0; }
+    contextRecovering = false;
     if (intersectionObs) {
       intersectionObs.disconnect();
       intersectionObs = null;
@@ -2059,6 +2093,7 @@ function createGlobeGalleryRuntime(
     if (renderer) {
       renderer.domElement.style.filter = '';
       globalCaFilterOn = false;
+      renderer.forceContextLoss();
       renderer.dispose();
       renderer.domElement.style.display = 'none';
     }
@@ -2105,8 +2140,9 @@ function createGlobeGalleryRuntime(
 
 export default async function init(el) {
   // Reduced motion: static, still-interactive globe in plain document flow. See README.
-  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  if (reducedMotion) el.classList.add('globe-gallery--reduced');
+  const reducedMotion = !!(window.matchMedia
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+  if (reducedMotion) el.classList.add('globe-gallery-reduced');
 
   // Extract authored content (incl. the UI labels) before buildGlobeDom() wipes the children.
   const {
@@ -2120,7 +2156,7 @@ export default async function init(el) {
   // Cards come from the authored fragment link.
   const cards = fragmentHref ? await fetchFragmentCards(fragmentHref) : null;
   if (!cards || cards.length === 0) {
-    el.classList.add('globe-gallery--empty');
+    el.classList.add('globe-gallery-empty');
     return el;
   }
   const runtime = createGlobeGalleryRuntime(
@@ -2131,17 +2167,16 @@ export default async function init(el) {
     gid,
     labels,
   );
-  if (!runtime) { el.classList.add('globe-gallery--empty'); return el; }
-  if (runtime.init() === false) { el.classList.add('globe-gallery--empty'); return el; }
+  if (!runtime) { el.classList.add('globe-gallery-empty'); return el; }
+  if (runtime.init() === false) { el.classList.add('globe-gallery-empty'); return el; }
   el.globeRuntime = runtime;
 
-  // Teardown when the block is removed (SPA / MEP swaps).
   const removalObserver = new MutationObserver(() => {
     if (document.contains(el)) return;
     runtime.destroy();
     removalObserver.disconnect();
   });
-  if (el.parentElement) removalObserver.observe(el.parentElement, { childList: true });
+  removalObserver.observe(document.body, { childList: true, subtree: true });
 
   return el;
 }

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -91,13 +91,25 @@ function parseFragmentCardSegment(nodes) {
 
     if (tag === 'P') {
       const pic = node.querySelector('picture');
-      if (pic) { img = pic.querySelector('img'); return; }
+      if (pic) {
+        img = pic.querySelector('img');
+        return;
+      }
       const inlineImg = node.querySelector('img');
-      if (inlineImg) { img = inlineImg; return; }
+      if (inlineImg) {
+        img = inlineImg;
+        return;
+      }
       const em = node.querySelector('em');
-      if (em) { role = em.textContent.trim(); return; }
+      if (em) {
+        role = em.textContent.trim();
+        return;
+      }
       const strong = node.querySelector('strong');
-      if (strong) { name = strong.textContent.trim(); return; }
+      if (strong) {
+        name = strong.textContent.trim();
+        return;
+      }
       const text = node.textContent.trim();
       if (text && !description) description = text;
     } else if (tag === 'UL') {

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -274,7 +274,7 @@ const buildMarkup = (gid, labels) => `
     <div class="globe-gallery-modal-info">
       <p class="globe-gallery-modal-role-label" id="globe-gallery-modal-role-${gid}"></p>
       <h2 class="globe-gallery-modal-name" id="globe-gallery-modal-name-${gid}" tabindex="-1" aria-describedby="globe-gallery-modal-role-${gid} globe-gallery-modal-position-${gid}"></h2>
-      <p class="globe-gallery-modal-description" id="globe-gallery-modal-description-${gid}"></p>
+      <p class="globe-gallery-modal-description" id="globe-gallery-modal-description-${gid}" data-lenis-prevent></p>
       <ul class="globe-gallery-modal-badges"></ul>
     </div>
     <!-- sr-only alt for the WebGL photo; after the info so the heading is read first. -->

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -26,7 +26,7 @@ function badgeIconHtml(anchor) {
   const url = badgeSvgUrl(anchor);
   if (!url) return null;
   const src = getFederatedUrl(url);
-  return `<picture class="globe-gallery-modal__badge-icon" aria-hidden="true"><img loading="lazy" src="${escapeHtml(src)}" alt=""></picture>`;
+  return `<picture class="globe-gallery-modal-badge-icon" aria-hidden="true"><img loading="lazy" src="${escapeHtml(src)}" alt=""></picture>`;
 }
 
 // See README (Authoring contract) for the authored-row layout.
@@ -81,7 +81,7 @@ function parsePullQuote(row) {
 }
 
 function parseFragmentCardSegment(nodes) {
-  let picture = null; let img = null;
+  let img = null;
   let role = ''; let name = ''; let description = '';
   const badges = [];
 
@@ -91,7 +91,7 @@ function parseFragmentCardSegment(nodes) {
 
     if (tag === 'P') {
       const pic = node.querySelector('picture');
-      if (pic) { picture = pic; img = pic.querySelector('img'); return; }
+      if (pic) { img = pic.querySelector('img'); return; }
       const inlineImg = node.querySelector('img');
       if (inlineImg) { img = inlineImg; return; }
       const em = node.querySelector('em');
@@ -134,7 +134,6 @@ function parseFragmentCardSegment(nodes) {
   return {
     img: img.currentSrc || img.getAttribute('src') || img.src,
     alt: (img.getAttribute('alt') || '').trim(),
-    picture,
     name,
     role,
     description,
@@ -171,9 +170,10 @@ export async function fetchFragmentCards(href) {
     const resp = await fetch(`${href}.plain.html`);
     if (!resp.ok) return null;
     const html = await resp.text();
-    const tmp = document.createElement('div');
-    tmp.innerHTML = html;
-    const cards = [...tmp.querySelectorAll(':scope > div')]
+    // DOMParser yields an inert document (no browsing context), so card <img>/<picture>
+    // never fetch here — only the right-sized texture URL (optimizeImgUrl) is downloaded.
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    const cards = [...doc.body.querySelectorAll(':scope > div')]
       .flatMap((section) => parseFragmentCards(section))
       .filter(Boolean);
     return cards.length ? cards : null;
@@ -238,47 +238,47 @@ const buildMarkup = (gid, labels) => `
   </svg>
 
   <div class="globe-gallery-arc-copy">
-    <h2 class="globe-gallery-arc-copy__title"></h2>
-    <p class="globe-gallery-arc-copy__body"></p>
+    <h2 class="globe-gallery-arc-copy-title"></h2>
+    <p class="globe-gallery-arc-copy-body body-md"></p>
   </div>
 
   <div class="globe-gallery-pullquote-pin">
     <div class="globe-gallery-pullquote">
-      <blockquote class="globe-gallery-pullquote__quote"></blockquote>
-      <div class="globe-gallery-pullquote__attribution">
-        <p class="globe-gallery-pullquote__name"></p>
-        <p class="globe-gallery-pullquote__role"></p>
+      <blockquote class="globe-gallery-pullquote-quote heading-1"></blockquote>
+      <div class="globe-gallery-pullquote-attribution">
+        <p class="globe-gallery-pullquote-name body-lg"></p>
+        <p class="globe-gallery-pullquote-role body-lg"></p>
       </div>
     </div>
   </div>
 
   <div class="globe-gallery-modal" aria-hidden="true">
-    <div class="globe-gallery-modal__backdrop"></div>
+    <div class="globe-gallery-modal-backdrop"></div>
   </div>
 
-  <canvas class="globe-gallery-modal-canvas" style="position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:111;display:none;pointer-events:none;"></canvas>
+  <canvas class="globe-gallery-modal-canvas" style="position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:14;display:none;pointer-events:none;"></canvas>
 
   <dialog class="globe-gallery-modal-chrome" tabindex="-1" aria-labelledby="globe-gallery-modal-role-${gid} globe-gallery-modal-name-${gid} globe-gallery-modal-position-${gid}" aria-describedby="globe-gallery-modal-description-${gid}">
-    <div class="globe-gallery-modal__info">
-      <p class="globe-gallery-modal__role-label" id="globe-gallery-modal-role-${gid}"></p>
-      <h2 class="globe-gallery-modal__name" id="globe-gallery-modal-name-${gid}" tabindex="-1" aria-describedby="globe-gallery-modal-role-${gid} globe-gallery-modal-position-${gid}"></h2>
-      <p class="globe-gallery-modal__description" id="globe-gallery-modal-description-${gid}"></p>
-      <ul class="globe-gallery-modal__badges"></ul>
+    <div class="globe-gallery-modal-info">
+      <p class="globe-gallery-modal-role-label" id="globe-gallery-modal-role-${gid}"></p>
+      <h2 class="globe-gallery-modal-name" id="globe-gallery-modal-name-${gid}" tabindex="-1" aria-describedby="globe-gallery-modal-role-${gid} globe-gallery-modal-position-${gid}"></h2>
+      <p class="globe-gallery-modal-description" id="globe-gallery-modal-description-${gid}"></p>
+      <ul class="globe-gallery-modal-badges"></ul>
     </div>
     <!-- sr-only alt for the WebGL photo; after the info so the heading is read first. -->
-    <span class="globe-gallery-modal__image globe-gallery-sr-only" role="img"></span>
+    <span class="globe-gallery-modal-image globe-gallery-sr-only" role="img"></span>
     <!-- Controls after the info scrim so they paint on top of it. -->
-    <button class="globe-gallery-modal__nav globe-gallery-modal__nav--prev" type="button" aria-label="${escapeHtml(labels.prevCard)}">
+    <button class="globe-gallery-modal-nav globe-gallery-modal-nav-prev" type="button" aria-label="${escapeHtml(labels.prevCard)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M15 5l-7 7 7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>
-    <button class="globe-gallery-modal__nav globe-gallery-modal__nav--next" type="button" aria-label="${escapeHtml(labels.nextCard)}">
+    <button class="globe-gallery-modal-nav globe-gallery-modal-nav-next" type="button" aria-label="${escapeHtml(labels.nextCard)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M9 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>
-    <div class="globe-gallery-modal__counter" aria-hidden="true"></div>
-    <button class="globe-gallery-modal__close" type="button" aria-label="${escapeHtml(labels.closeBtn)}">
+    <div class="globe-gallery-modal-counter" aria-hidden="true"></div>
+    <button class="globe-gallery-modal-close" type="button" aria-label="${escapeHtml(labels.closeBtn)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
     </button>
-    <span class="globe-gallery-modal__position globe-gallery-sr-only" id="globe-gallery-modal-position-${gid}"></span>
+    <span class="globe-gallery-modal-position globe-gallery-sr-only" id="globe-gallery-modal-position-${gid}"></span>
   </dialog>
 `;
 
@@ -290,10 +290,14 @@ export function buildGlobeDom(el, labels, { arcCopy, pullQuote }) {
   globeInstanceSeq += 1;
   const gid = globeInstanceSeq;
   el.innerHTML = buildMarkup(gid, labels);
-  el.querySelector('.globe-gallery-arc-copy__title').textContent = arcCopy.title;
-  el.querySelector('.globe-gallery-arc-copy__body').textContent = arcCopy.body;
-  el.querySelector('.globe-gallery-pullquote__quote').textContent = pullQuote.quote;
-  el.querySelector('.globe-gallery-pullquote__name').textContent = pullQuote.name;
-  el.querySelector('.globe-gallery-pullquote__role').textContent = pullQuote.role;
+  el.querySelector('.globe-gallery-arc-copy-title').textContent = arcCopy.title;
+  el.querySelector('.globe-gallery-arc-copy-body').textContent = arcCopy.body;
+  if (pullQuote) {
+    el.querySelector('.globe-gallery-pullquote-quote').textContent = pullQuote.quote;
+    el.querySelector('.globe-gallery-pullquote-name').textContent = pullQuote.name;
+    el.querySelector('.globe-gallery-pullquote-role').textContent = pullQuote.role;
+  } else {
+    el.querySelector('.globe-gallery-pullquote-pin').remove();
+  }
   return gid;
 }

--- a/libs/mep/ace1209/globe-gallery/src/cursor.js
+++ b/libs/mep/ace1209/globe-gallery/src/cursor.js
@@ -2,9 +2,9 @@
 
 // 48px disc centered on the pointer via the −24px viewBox origin.
 const RING_SVG = [
-  '<svg class="globe-gallery-cursor__ring" width="48" height="48" viewBox="-24 -24 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">',
-  '<g class="globe-gallery-cursor__chevron-l"><polyline points="-8,-5 -13,0 -8,5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></g>',
-  '<g class="globe-gallery-cursor__chevron-r"><polyline points="8,-5 13,0 8,5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></g>',
+  '<svg class="globe-gallery-cursor-ring" width="48" height="48" viewBox="-24 -24 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">',
+  '<g class="globe-gallery-cursor-chevron-l"><polyline points="-8,-5 -13,0 -8,5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></g>',
+  '<g class="globe-gallery-cursor-chevron-r"><polyline points="8,-5 13,0 8,5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></g>',
   '</svg>',
 ].join('');
 
@@ -45,21 +45,21 @@ export default function createCursor(deps) {
 
     // Disc — direct body child so mix-blend-mode blends against real page content.
     discEl = document.createElement('div');
-    discEl.className = 'globe-gallery-cursor__disc';
+    discEl.className = 'globe-gallery-cursor-disc';
     document.body.appendChild(discEl);
 
     // Chevrons + label — no blend mode, safe inside the fixed container.
     containerEl = document.createElement('div');
     containerEl.className = 'globe-gallery-cursor';
     // Static structure via innerHTML; authored label set as textContent below.
-    containerEl.innerHTML = `<div class="globe-gallery-cursor__ring-wrap">${RING_SVG}</div>`
-      + '<div class="globe-gallery-cursor__text-wrap">'
-      + '<span class="globe-gallery-cursor__text"></span>'
+    containerEl.innerHTML = `<div class="globe-gallery-cursor-ring-wrap">${RING_SVG}</div>`
+      + '<div class="globe-gallery-cursor-text-wrap">'
+      + '<span class="globe-gallery-cursor-text"></span>'
       + '</div>';
     document.body.appendChild(containerEl);
-    ringWrap = containerEl.querySelector('.globe-gallery-cursor__ring-wrap');
-    textWrap = containerEl.querySelector('.globe-gallery-cursor__text-wrap');
-    containerEl.querySelector('.globe-gallery-cursor__text').textContent = labelText || 'Click & Drag';
+    ringWrap = containerEl.querySelector('.globe-gallery-cursor-ring-wrap');
+    textWrap = containerEl.querySelector('.globe-gallery-cursor-text-wrap');
+    containerEl.querySelector('.globe-gallery-cursor-text').textContent = labelText || 'Click & Drag';
 
     const canvas = getCanvas();
     if (canvas) {
@@ -82,8 +82,8 @@ export default function createCursor(deps) {
     const wantRetired = getCursorRetired();
     if (wantRetired !== (retireT0 >= 0)) {
       retireT0 = wantRetired ? now() : -1;
-      containerEl.classList.toggle('globe-gallery-cursor--retiring', wantRetired);
-      if (discEl) discEl.classList.toggle('globe-gallery-cursor__disc--retiring', wantRetired);
+      containerEl.classList.toggle('globe-gallery-cursor-retiring', wantRetired);
+      if (discEl) discEl.classList.toggle('globe-gallery-cursor-disc-retiring', wantRetired);
     }
     const faded = retireT0 >= 0 && now() - retireT0 >= RETIRE_FADE_MS;
 
@@ -95,8 +95,8 @@ export default function createCursor(deps) {
       && !faded;
     if (wantActive !== active) {
       active = wantActive;
-      containerEl.classList.toggle('globe-gallery-cursor--active', active);
-      if (discEl) discEl.classList.toggle('globe-gallery-cursor__disc--active', active);
+      containerEl.classList.toggle('globe-gallery-cursor-active', active);
+      if (discEl) discEl.classList.toggle('globe-gallery-cursor-disc-active', active);
       // Hide the system cursor while ours shows; interaction.js defers to isActive().
       if (canvas) canvas.style.cursor = active ? 'none' : '';
     }
@@ -104,12 +104,12 @@ export default function createCursor(deps) {
     const wantDismissed = getHintDismissed();
     if (wantDismissed !== hintDismissed) {
       hintDismissed = wantDismissed;
-      containerEl.classList.toggle('globe-gallery-cursor--hint-dismissed', hintDismissed);
+      containerEl.classList.toggle('globe-gallery-cursor-hint-dismissed', hintDismissed);
     }
     // From `active` so going inactive mid-drag clears the squeeze rather than freezing it.
     const dragging = active && drag.isDragging;
-    containerEl.classList.toggle('globe-gallery-cursor--dragging', dragging);
-    if (discEl) discEl.classList.toggle('globe-gallery-cursor__disc--dragging', dragging);
+    containerEl.classList.toggle('globe-gallery-cursor-dragging', dragging);
+    if (discEl) discEl.classList.toggle('globe-gallery-cursor-disc-dragging', dragging);
     if (!active) return;
     if (discEl) {
       // top/left (not transform) keeps `transform` free for the CSS scale entrance.

--- a/libs/mep/ace1209/globe-gallery/src/interaction.js
+++ b/libs/mep/ace1209/globe-gallery/src/interaction.js
@@ -13,7 +13,7 @@ const AXIS_VERTICAL = 2; // page scroll — we ignore the gesture entirely
 
 export default function createInteraction({
   getRenderer, getCamera, getCards, getModalIdx, openModal,
-  getSphereFormT, interactiveThreshold, maxVel, drag, isCursorActive,
+  getSphereFormT, interactiveThreshold, maxVel, drag, isCursorActive, getYawOnly,
 }) {
   // Raycaster + NDC scratch for canvas picking.
   const raycaster = new THREE.Raycaster();
@@ -92,8 +92,11 @@ export default function createInteraction({
     // Touch, vertical → the page owns this gesture; leave the sphere inert.
     if (isTouchDrag && axisLock === AXIS_VERTICAL) return;
     drag.velX = Math.max(-maxVel, Math.min(maxVel, (e.clientX - lastMX) * DRAG_SENSITIVITY));
-    // Pitch is mouse-only. +Y delta (drag down) tips the front down so the globe follows.
-    if (!isTouchDrag) {
+    // Pitch is enabled only for a mouse on the sphere. Touch never pitches (vertical = scroll);
+    // the yaw-only barrel never pitches for anyone (a cylinder can't centre vertically — matches
+    // the keyboard/modal centring path, which holds pitch when bp.YAW_ONLY). +Y delta (drag down)
+    // tips the front down so the globe follows.
+    if (!isTouchDrag && !getYawOnly()) {
       drag.velY = Math.max(-maxVel, Math.min(maxVel, (e.clientY - lastMY) * DRAG_SENSITIVITY));
     }
     lastMX = e.clientX; lastMY = e.clientY;

--- a/libs/mep/ace1209/globe-gallery/src/materials.js
+++ b/libs/mep/ace1209/globe-gallery/src/materials.js
@@ -189,14 +189,19 @@ export function loadCardTextures({ count, getSrc, planeAspect, maxTex }, onEach,
 }
 
 // Load one card image at a higher cap for the modal (raw-UV, no cover-crop). onReady fires
-// once decoded; caller owns disposal. On error nothing fires. Returns the Image so a pending
-// load can be cancelled (img.src = '').
-export function loadModalTexture(src, maxTex, onReady) {
+// once decoded; caller owns disposal. onError fires if the load fails so the caller can drop its
+// pending-Image reference (the base texture stays). Returns the Image so a pending load can be
+// cancelled (img.src = '').
+export function loadModalTexture(src, maxTex, onReady, onError) {
   const img = new Image();
   img.onload = () => {
     const tex = new THREE.CanvasTexture(imageToCanvas(img, maxTex));
     tex.colorSpace = THREE.SRGBColorSpace;
     onReady(tex);
+  };
+  img.onerror = () => {
+    window.lana?.log?.(`globe-gallery: modal texture upgrade failed: ${src}`, { tags: 'globe-gallery', severity: 'warn' });
+    if (onError) onError();
   };
   img.src = src; // no crossOrigin — needed so onload fires for file://
   return img;

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -95,8 +95,6 @@ export default function createGlobeModal({
   let modalOpenedAt = 0;
   // close-finalize timeout id; open() cancels a stale one so it can't yank the new modal's state.
   let closeTimeoutId = null;
-  // document keydown listener; setup() detaches a prior one before re-adding on re-init.
-  let keydownHandler = null;
   // click/touch listeners wired once — DOM persists across re-inits so re-adding would stack.
   let listenersWired = false;
 
@@ -447,7 +445,6 @@ export default function createGlobeModal({
     // Info scrim: mobile = full-width bottom chunk; desktop = full-height left edge.
     if (infoEl) {
       infoEl.style.position = 'absolute';
-      infoEl.style.minHeight = '';
       if (isMobile) {
         infoEl.style.top = 'auto';
         infoEl.style.bottom = '0';
@@ -480,6 +477,24 @@ export default function createGlobeModal({
     applyFade(prevEl, '');
     applyFade(nextEl, '');
     applyFade(counterEl, counterBase);
+  }
+
+  // Set the description's mask fade lengths from scroll position; focusable only when it scrolls.
+  function updateDescFade(descEl) {
+    if (!descEl) return;
+    const overflow = descEl.scrollHeight - descEl.clientHeight;
+    const canScroll = overflow > 1;
+    const top = canScroll && descEl.scrollTop > 1;
+    const bottom = canScroll && descEl.scrollTop < overflow - 1;
+    descEl.style.setProperty('--desc-fade-top', top ? '20px' : '0');
+    descEl.style.setProperty('--desc-fade-bottom', bottom ? '20px' : '0');
+    if (canScroll) descEl.tabIndex = 0;
+    else if (document.activeElement !== descEl) descEl.removeAttribute('tabindex');
+  }
+
+  function scheduleDescFade() {
+    const descEl = q('.globe-gallery-modal-description');
+    if (descEl) requestAnimationFrame(() => { if (modalIdx >= 0) updateDescFade(descEl); });
   }
 
   function populateModal(i) {
@@ -521,6 +536,9 @@ export default function createGlobeModal({
       row.innerHTML = `<div class="globe-gallery-modal-badge-left">${b.icon || ''}${nameHtml}</div><span class="globe-gallery-modal-badge-role">${escapeHtml(b.role)}</span>`;
       badgesEl.appendChild(row);
     });
+    const descEl = targetEl.querySelector('.globe-gallery-modal-description');
+    if (descEl) descEl.scrollTop = 0;
+    scheduleDescFade();
   }
 
   // Finalize the desktop nav transition: detach old card to sphere, reset uniforms on the new.
@@ -906,6 +924,8 @@ export default function createGlobeModal({
     if (!modalRenderer) return;
     modalRenderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     modalRenderer.setSize(w, h);
+    // Resize can change whether the description overflows — re-measure the fade cue.
+    if (modalIdx >= 0) scheduleDescFade();
   }
 
   // Create the modal renderer/scene + THREE temps and wire DOM interactions. Once per init.
@@ -945,31 +965,13 @@ export default function createGlobeModal({
       nextBtn.addEventListener('click', () => { navigate(1); });
       // Single-card gallery: nav is a no-op, so hide the arrows entirely (count is fixed).
       if (getCount() <= 1) { prevBtn.hidden = true; nextBtn.hidden = true; }
+      const descEl = evtRoot.querySelector('.globe-gallery-modal-description');
+      if (descEl) descEl.addEventListener('scroll', () => updateDescFade(descEl), { passive: true });
       // Escape → dialog 'cancel'; preventDefault to play the close animation, not instant close.
       if (chromeEl) {
         chromeEl.addEventListener('cancel', (e) => { e.preventDefault(); close(); });
       }
     }
-
-    // Detach prior keydown before re-adding (re-init calls setup() again — avoid stacking).
-    if (keydownHandler) document.removeEventListener('keydown', keydownHandler);
-    keydownHandler = (e) => {
-      if (modalIdx < 0) return;
-      const chromeRoot = q('.globe-gallery-modal-chrome');
-      const focusInChrome = chromeRoot && chromeRoot.contains(document.activeElement);
-      if (focusInChrome && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
-        e.preventDefault();
-        navigate((e.key === 'ArrowLeft' ? -1 : 1) * (isRtl() ? -1 : 1));
-        return;
-      }
-      if (e.key === 'PageUp' || e.key === 'PageDown'
-          || e.key === 'Home' || e.key === 'End'
-          || e.key === 'ArrowUp' || e.key === 'ArrowDown'
-          || (e.key === ' ' && !focusInChrome)) {
-        e.preventDefault();
-      }
-    };
-    document.addEventListener('keydown', keydownHandler);
 
     // Touch gestures wired once too; nothing runs after this, so early-return.
     if (alreadyWired) return;
@@ -1003,6 +1005,8 @@ export default function createGlobeModal({
       if (modalIdx < 0) return;
       if (e.touches.length !== 1) return;
       if (!modalCanvasEl) return;
+      // Description owns its own touch scroll — don't hijack it for swipe/pull-to-close.
+      if (e.target?.closest?.('.globe-gallery-modal-description')) return;
       swStartX = e.touches[0].clientX; swLastX = swStartX;
       swStartY = e.touches[0].clientY; swLastY = swStartY;
       swLastT = Date.now();
@@ -1136,10 +1140,8 @@ export default function createGlobeModal({
     resetChromeReveal();
   }
 
-  // Dispose the modal renderer + clear the close timeout, remove keydown, reset DOM/page state.
   function destroy() {
     if (closeTimeoutId) { clearTimeout(closeTimeoutId); closeTimeoutId = null; }
-    if (keydownHandler) { document.removeEventListener('keydown', keydownHandler); keydownHandler = null; }
     resetModalDom();
     releaseModalTexture();
     // Dispose lazy overflow carriers — Three frees GPU memory only on explicit dispose.

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -221,6 +221,7 @@ export default function createGlobeModal({
   function releaseModalTexture() {
     if (modalTexImg) {
       modalTexImg.onload = null;
+      modalTexImg.onerror = null;
       modalTexImg.src = '';
       modalTexImg = null;
     }

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -3,6 +3,8 @@ import { createModalMaterial } from './materials.js';
 import { easeInOutCubic, easeOutCubic } from './math.js';
 import { escapeHtml } from './authoring.js';
 
+const perfNow = () => performance?.now() ?? Date.now();
+
 // Modal lifecycle phases. CLOSED is null so `if (modalPhase)` reads as "modal live".
 const MODAL_PHASE = Object.freeze({
   CLOSED: null,
@@ -399,9 +401,7 @@ export default function createGlobeModal({
     if (closeEl) {
       closeEl.style.position = 'absolute';
       closeEl.style.top = '24px';
-      closeEl.style.bottom = 'auto';
-      closeEl.style[rtl ? 'left' : 'right'] = '24px';
-      closeEl.style[rtl ? 'right' : 'left'] = 'auto';
+      closeEl.style.insetInlineEnd = '24px';
     }
 
     // Nav arrows + counter positioned individually (no wrapper) so :hover scale survives the fade.
@@ -458,8 +458,7 @@ export default function createGlobeModal({
       } else {
         infoEl.style.top = '0';
         infoEl.style.bottom = '0';
-        infoEl.style[rtl ? 'right' : 'left'] = '0';
-        infoEl.style[rtl ? 'left' : 'right'] = 'auto';
+        infoEl.style.insetInlineStart = '0';
         infoEl.style.width = `${DT_SCRIM_W}px`;
         infoEl.style.height = '';
       }
@@ -602,7 +601,7 @@ export default function createGlobeModal({
 
     dnNavOldCard = oldCard;
     dnNavNewCard = newCard;
-    dnNavT0 = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    dnNavT0 = perfNow();
     dnNavActive = true;
   }
 
@@ -614,7 +613,7 @@ export default function createGlobeModal({
       clearTimeout(closeTimeoutId);
       closeTimeoutId = null;
     }
-    modalOpenedAt = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    modalOpenedAt = perfNow();
     modalIdx = i;
     modalCard = cards[i];
     // Pin warp center to click origin (default ~center).
@@ -649,7 +648,7 @@ export default function createGlobeModal({
     if (modalCanvasEl) modalCanvasEl.style.display = 'block';
 
     modalPhase = MODAL_PHASE.OPENING;
-    modalAnimT0 = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    modalAnimT0 = perfNow();
 
     // Reset chrome reveal so elements start hidden and fade in after card settles.
     resetChromeReveal();
@@ -682,7 +681,7 @@ export default function createGlobeModal({
     // Suppress only the synthetic click after touch pointerup (would immediately close the fresh
     // modal). Escape / pull-to-close are deliberate and must not be swallowed inside this window.
     if (viaPointer) {
-      const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+      const now = perfNow();
       if (now - modalOpenedAt < 200) return;
     }
     if (!modalEl || modalIdx < 0 || !modalCard) return;
@@ -704,7 +703,7 @@ export default function createGlobeModal({
     modalCard.mesh.getWorldScale(modalCloseStartScale);
 
     modalPhase = MODAL_PHASE.CLOSING;
-    modalAnimT0 = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    modalAnimT0 = perfNow();
 
     // Hide chrome immediately — it fades with the container.
     resetChromeReveal();
@@ -752,7 +751,7 @@ export default function createGlobeModal({
   function updateAnimation(sphereRotActive) {
     if (modalCard && modalPhase) {
       const sphereGroup = getSphereGroup();
-      const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+      const now = perfNow();
       // Reduced motion: force aT=1 so the fly snaps in one frame and the warp bell curves collapse.
       const aT = getReducedMotion()
         ? 1 : Math.max(0, Math.min(1, (now - modalAnimT0) / MODAL_ANIM_DURATION));
@@ -875,7 +874,7 @@ export default function createGlobeModal({
   // Desktop nav cross-warp: both cards' uWarp on a sin bell curve; opacity cross-fades.
   function updateDesktopNav() {
     if (dnNavActive) {
-      const dnNow = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+      const dnNow = perfNow();
       // Reduced motion: force completion — the new card just becomes visible.
       const dnT = getReducedMotion() ? 1 : Math.max(0, Math.min(1, (dnNow - dnNavT0) / DN_NAV_DUR));
       if (dnT >= 1) {
@@ -996,8 +995,7 @@ export default function createGlobeModal({
     // Swipe/pull applies to touch-primary devices, not just the sm width band — tablets at
     // md (≥768, coarse pointer) get the same gesture nav the globe's yaw-only shape assumes.
     // Mirrors usesCylinderGeometry's '(pointer: coarse)' check. matchMedia-less → no gestures.
-    const isTouchPrimary = () => !!(window.matchMedia
-      && window.matchMedia('(pointer: coarse)').matches);
+    const isTouchPrimary = () => !!window.matchMedia?.('(pointer: coarse)').matches;
 
     // Attach to the dialog (evtRoot), not modalEl — modalEl goes inert under showModal().
     evtRoot.addEventListener('touchstart', (e) => {
@@ -1105,10 +1103,9 @@ export default function createGlobeModal({
       if (!swActive) return;
       swActive = false;
       swAxis = null;
-      if (modalCanvasEl) {
-        modalCanvasEl.style.transition = 'transform 0.25s cubic-bezier(0.25, 0.1, 0.25, 1)';
-        modalCanvasEl.style.transform = '';
-      }
+      if (!modalCanvasEl) return;
+      modalCanvasEl.style.transition = 'transform 0.25s cubic-bezier(0.25, 0.1, 0.25, 1)';
+      modalCanvasEl.style.transform = '';
     }, { passive: true });
   }
 

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -28,7 +28,7 @@ const DN_NAV_WARP = 0.40; // peak warp
 const DT_IMG_MARGIN = 12; // gap between image and each viewport edge
 const DT_SCRIM_W = 316; // info scrim fixed width
 const DT_NAV_GAP = 12; // gap between counter pill and each arrow
-const DT_COUNTER_W = 138; // .globe-gallery-modal__counter fixed width (md+ CSS)
+const DT_COUNTER_W = 138; // .globe-gallery-modal-counter fixed width (md+ CSS)
 
 export default function createGlobeModal({
   q,
@@ -39,7 +39,7 @@ export default function createGlobeModal({
   getCards,
   getCount,
   getCardMetadata,
-  // Lazily load a sharper texture for the opened card. (idx, onReady) → Image|null; null = no-op.
+  // Lazily load a sharper texture for the opened card. (idx, onReady, onError) → Image|null.
   loadModalUpgrade,
   getViewport,
   getBP,
@@ -128,6 +128,8 @@ export default function createGlobeModal({
 
   function getModalIdx() { return modalIdx; }
 
+  const isRtl = () => document.documentElement.dir === 'rtl';
+
   // Barrel = cards with a real sphere slot; indices ≥ this are overflow.
   function barrelCount() { return getCards().length; }
   function isOverflowIdx(idx) { return idx >= barrelCount(); }
@@ -180,7 +182,7 @@ export default function createGlobeModal({
   // Load an overflow carrier's image at the modal cap, swap in on decode, derive aspect. Owns
   // its texture per-card (disposed in retireOverflowCard) so a cross-fade keeps the outgoing image.
   function loadOverflowTexture(card, idx) {
-    if (card.pendingImg) { card.pendingImg.onload = null; card.pendingImg.src = ''; card.pendingImg = null; }
+    if (card.pendingImg) { card.pendingImg.onload = null; card.pendingImg.onerror = null; card.pendingImg.src = ''; card.pendingImg = null; }
     if (!loadModalUpgrade) return;
     card.pendingImg = loadModalUpgrade(idx, (tex) => {
       card.pendingImg = null;
@@ -192,13 +194,13 @@ export default function createGlobeModal({
         card.sphereScaleX = asp / cardAspect;
         card.modalMat.uniforms.uAspect.value = asp; // = cardAspect × sphereScaleX
       }
-    });
+    }, () => { card.pendingImg = null; });
   }
 
   // Retire an overflow carrier on nav-away/close: unparent, hide, drop texture, reset material.
   function retireOverflowCard(card) {
     if (!isOverflowCard(card)) return;
-    if (card.pendingImg) { card.pendingImg.onload = null; card.pendingImg.src = ''; card.pendingImg = null; }
+    if (card.pendingImg) { card.pendingImg.onload = null; card.pendingImg.onerror = null; card.pendingImg.src = ''; card.pendingImg = null; }
     if (card.mesh.parent) card.mesh.parent.remove(card.mesh);
     card.mesh.visible = false;
     card.modalMat.uniforms.map.value = ensureOverflowPlaceholder();
@@ -271,7 +273,7 @@ export default function createGlobeModal({
       modalTexOwned = tex;
       modalTexCard = card;
       card.modalMat.uniforms.map.value = tex;
-    });
+    }, () => { modalTexImg = null; });
   }
 
   // Reset the cached SDF material's animated uniforms so a stale mid-fade value doesn't ghost.
@@ -359,11 +361,11 @@ export default function createGlobeModal({
     if (!chromeNodes || chromeNodes.chromeEl !== chromeEl) {
       chromeNodes = {
         chromeEl,
-        infoEl: chromeEl.querySelector('.globe-gallery-modal__info'),
-        closeEl: chromeEl.querySelector('.globe-gallery-modal__close'),
-        prevEl: chromeEl.querySelector('.globe-gallery-modal__nav--prev'),
-        nextEl: chromeEl.querySelector('.globe-gallery-modal__nav--next'),
-        counterEl: chromeEl.querySelector('.globe-gallery-modal__counter'),
+        infoEl: chromeEl.querySelector('.globe-gallery-modal-info'),
+        closeEl: chromeEl.querySelector('.globe-gallery-modal-close'),
+        prevEl: chromeEl.querySelector('.globe-gallery-modal-nav-prev'),
+        nextEl: chromeEl.querySelector('.globe-gallery-modal-nav-next'),
+        counterEl: chromeEl.querySelector('.globe-gallery-modal-counter'),
       };
     }
     const { infoEl, closeEl, prevEl, nextEl, counterEl } = chromeNodes;
@@ -402,34 +404,33 @@ export default function createGlobeModal({
     const INSET = 24 + Math.round(SDF_RADIUS_PX);
 
     const isMobile = (getBP() === 'sm');
+    const rtl = isRtl();
 
-    // Close button → top-right of the viewport (24px inset) at every breakpoint.
+    // Close button → top inline-end corner of the viewport (24px inset) at every breakpoint.
     if (closeEl) {
       closeEl.style.position = 'absolute';
       closeEl.style.top = '24px';
-      closeEl.style.right = '24px';
       closeEl.style.bottom = 'auto';
-      closeEl.style.left = 'auto';
+      closeEl.style[rtl ? 'left' : 'right'] = '24px';
+      closeEl.style[rtl ? 'right' : 'left'] = 'auto';
     }
 
     // Nav arrows + counter positioned individually (no wrapper) so :hover scale survives the fade.
     // Mobile → arrows bottom corners, counter bottom-center. Desktop → one row at the image bottom.
-    const NAV_SIZE = 44; // matches the .globe-gallery-modal__nav width/height in CSS
+    const NAV_SIZE = 44; // matches the .globe-gallery-modal-nav width/height in CSS
     const EDGE = 24;
     const counterBase = 'translateX(-50%)';
     if (prevEl) prevEl.style.position = 'absolute';
     if (nextEl) nextEl.style.position = 'absolute';
     if (counterEl) counterEl.style.position = 'absolute';
 
+    const setBottomEdge = (elx, side) => {
+      elx.style[side] = `${EDGE}px`; elx.style[side === 'left' ? 'right' : 'left'] = 'auto';
+      elx.style.top = 'auto'; elx.style.bottom = `${EDGE}px`;
+    };
     if (isMobile) {
-      if (prevEl) {
-        prevEl.style.left = `${EDGE}px`; prevEl.style.right = 'auto';
-        prevEl.style.top = 'auto'; prevEl.style.bottom = `${EDGE}px`;
-      }
-      if (nextEl) {
-        nextEl.style.left = 'auto'; nextEl.style.right = `${EDGE}px`;
-        nextEl.style.top = 'auto'; nextEl.style.bottom = `${EDGE}px`;
-      }
+      if (prevEl) setBottomEdge(prevEl, rtl ? 'right' : 'left');
+      if (nextEl) setBottomEdge(nextEl, rtl ? 'left' : 'right');
       if (counterEl) {
         counterEl.style.left = '50%'; counterEl.style.right = 'auto';
         counterEl.style.top = 'auto'; counterEl.style.bottom = `${EDGE}px`;
@@ -443,12 +444,14 @@ export default function createGlobeModal({
         counterEl.style.left = `${Math.round(centerX)}px`; counterEl.style.right = 'auto';
         counterEl.style.top = 'auto'; counterEl.style.bottom = rowBottom;
       }
+      const prevX = rtl ? centerX + flank : centerX - flank - NAV_SIZE;
+      const nextX = rtl ? centerX - flank - NAV_SIZE : centerX + flank;
       if (prevEl) {
-        prevEl.style.left = `${Math.round(centerX - flank - NAV_SIZE)}px`; prevEl.style.right = 'auto';
+        prevEl.style.left = `${Math.round(prevX)}px`; prevEl.style.right = 'auto';
         prevEl.style.top = 'auto'; prevEl.style.bottom = rowBottom;
       }
       if (nextEl) {
-        nextEl.style.left = `${Math.round(centerX + flank)}px`; nextEl.style.right = 'auto';
+        nextEl.style.left = `${Math.round(nextX)}px`; nextEl.style.right = 'auto';
         nextEl.style.top = 'auto'; nextEl.style.bottom = rowBottom;
       }
     }
@@ -467,8 +470,8 @@ export default function createGlobeModal({
       } else {
         infoEl.style.top = '0';
         infoEl.style.bottom = '0';
-        infoEl.style.left = '0';
-        infoEl.style.right = 'auto';
+        infoEl.style[rtl ? 'right' : 'left'] = '0';
+        infoEl.style[rtl ? 'left' : 'right'] = 'auto';
         infoEl.style.width = `${DT_SCRIM_W}px`;
         infoEl.style.height = '';
       }
@@ -497,7 +500,7 @@ export default function createGlobeModal({
     if (!targetEl) return;
     const meta = getCardMetadata(i);
     // role="img" text alternative for the WebGL photo (no src — the visible photo is the canvas).
-    const imgEl = targetEl.querySelector('.globe-gallery-modal__image');
+    const imgEl = targetEl.querySelector('.globe-gallery-modal-image');
     if (imgEl) {
       if (meta.alt) {
         imgEl.setAttribute('aria-label', meta.alt);
@@ -507,28 +510,28 @@ export default function createGlobeModal({
         imgEl.setAttribute('aria-hidden', 'true');
       }
     }
-    const roleLabelEl = targetEl.querySelector('.globe-gallery-modal__role-label');
+    const roleLabelEl = targetEl.querySelector('.globe-gallery-modal-role-label');
     if (roleLabelEl) roleLabelEl.textContent = meta.role;
-    targetEl.querySelector('.globe-gallery-modal__name').textContent = meta.name;
-    targetEl.querySelector('.globe-gallery-modal__description').textContent = meta.description;
-    const counterEl = targetEl.querySelector('.globe-gallery-modal__counter');
+    targetEl.querySelector('.globe-gallery-modal-name').textContent = meta.name;
+    targetEl.querySelector('.globe-gallery-modal-description').textContent = meta.description;
+    const counterEl = targetEl.querySelector('.globe-gallery-modal-counter');
     if (counterEl) {
       const pad = (n) => (String(n).length < 2 ? `0${n}` : String(n));
       counterEl.textContent = `${pad(i + 1)} / ${pad(getCount())}`;
     }
     // SR position — read via the dialog name (aria-labelledby) + heading (aria-describedby).
-    const posEl = targetEl.querySelector('.globe-gallery-modal__position');
+    const posEl = targetEl.querySelector('.globe-gallery-modal-position');
     if (posEl) posEl.textContent = cardLabel(i + 1, getCount());
-    const badgesEl = targetEl.querySelector('.globe-gallery-modal__badges');
+    const badgesEl = targetEl.querySelector('.globe-gallery-modal-badges');
     badgesEl.innerHTML = '';
     meta.badges.forEach((b) => {
       const row = document.createElement('li');
-      row.className = 'globe-gallery-modal__badge';
+      row.className = 'globe-gallery-modal-badge';
       const nameHtml = b.href
-        ? `<a class="globe-gallery-modal__badge-app globe-gallery-modal__badge-app--link" href="${escapeHtml(b.href)}">${escapeHtml(b.name)}</a>`
-        : `<span class="globe-gallery-modal__badge-app">${escapeHtml(b.name)}</span>`;
+        ? `<a class="globe-gallery-modal-badge-app globe-gallery-modal-badge-app-link" href="${escapeHtml(b.href)}">${escapeHtml(b.name)}</a>`
+        : `<span class="globe-gallery-modal-badge-app">${escapeHtml(b.name)}</span>`;
       // The logo is authored per row; rows without one just render the name (no empty chip).
-      row.innerHTML = `<div class="globe-gallery-modal__badge-left">${b.icon || ''}${nameHtml}</div><span class="globe-gallery-modal__badge-role">${escapeHtml(b.role)}</span>`;
+      row.innerHTML = `<div class="globe-gallery-modal-badge-left">${b.icon || ''}${nameHtml}</div><span class="globe-gallery-modal-badge-role">${escapeHtml(b.role)}</span>`;
       badgesEl.appendChild(row);
     });
   }
@@ -674,7 +677,7 @@ export default function createGlobeModal({
     requestAnimationFrame(() => {
       modalEl.classList.add('is-open');
       if (chromeEl) chromeEl.classList.add('is-open');
-      const nameEl = chromeEl && chromeEl.querySelector('.globe-gallery-modal__name');
+      const nameEl = chromeEl && chromeEl.querySelector('.globe-gallery-modal-name');
       const focusEl = nameEl || chromeEl;
       if (focusEl) { try { focusEl.focus(); } catch (e) { /* not focusable; ignore */ } }
     });
@@ -682,15 +685,18 @@ export default function createGlobeModal({
     const renderer = getRenderer();
     const canvas = renderer && renderer.domElement;
     if (canvas) canvas.classList.add('is-modal-active');
-    document.documentElement.classList.add('modal-open');
-    document.body.classList.add('modal-open');
+    document.documentElement.classList.add('globe-gallery-modal-open');
+    document.body.classList.add('globe-gallery-modal-open');
     if (window.lenis) window.lenis.stop();
   }
 
-  function close() {
-    // Suppress the synthetic click after touch pointerup (would immediately close the fresh modal).
-    const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
-    if (now - modalOpenedAt < 200) return;
+  function close(viaPointer) {
+    // Suppress only the synthetic click after touch pointerup (would immediately close the fresh
+    // modal). Escape / pull-to-close are deliberate and must not be swallowed inside this window.
+    if (viaPointer) {
+      const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+      if (now - modalOpenedAt < 200) return;
+    }
     if (!modalEl || modalIdx < 0 || !modalCard) return;
     // Re-entrancy guard: ignore extra close requests while already CLOSING (avoids jitter).
     if (modalPhase === MODAL_PHASE.CLOSING) return;
@@ -730,8 +736,8 @@ export default function createGlobeModal({
         if (chromeEl.open) chromeEl.close();
         if (restoreFocusOnClose) restoreFocusOnClose(restoreIdx);
       }
-      document.documentElement.classList.remove('modal-open');
-      document.body.classList.remove('modal-open');
+      document.documentElement.classList.remove('globe-gallery-modal-open');
+      document.body.classList.remove('globe-gallery-modal-open');
       if (window.lenis) window.lenis.start();
       closeTimeoutId = null;
     }, MODAL_ANIM_DURATION);
@@ -945,9 +951,9 @@ export default function createGlobeModal({
     const alreadyWired = listenersWired;
     listenersWired = true;
     if (!alreadyWired) {
-      evtRoot.querySelector('.globe-gallery-modal__close').addEventListener('click', close);
-      const prevBtn = evtRoot.querySelector('.globe-gallery-modal__nav--prev');
-      const nextBtn = evtRoot.querySelector('.globe-gallery-modal__nav--next');
+      evtRoot.querySelector('.globe-gallery-modal-close').addEventListener('click', () => close(true));
+      const prevBtn = evtRoot.querySelector('.globe-gallery-modal-nav-prev');
+      const nextBtn = evtRoot.querySelector('.globe-gallery-modal-nav-next');
       prevBtn.addEventListener('click', () => { navigate(-1); });
       nextBtn.addEventListener('click', () => { navigate(1); });
       // Single-card gallery: nav is a no-op, so hide the arrows entirely (count is fixed).
@@ -966,7 +972,7 @@ export default function createGlobeModal({
       const focusInChrome = chromeRoot && chromeRoot.contains(document.activeElement);
       if (focusInChrome && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
         e.preventDefault();
-        navigate(e.key === 'ArrowLeft' ? -1 : 1);
+        navigate((e.key === 'ArrowLeft' ? -1 : 1) * (isRtl() ? -1 : 1));
         return;
       }
       if (e.key === 'PageUp' || e.key === 'PageDown'
@@ -1079,7 +1085,7 @@ export default function createGlobeModal({
           // Clear the preview warp so it doesn't bleed onto the new card once the transition
           // ends and updateAnimation resumes pushing modalWarp — the cross-warp owns warp now.
           modalWarp = 0;
-          navigate(dx < 0 ? 1 : -1);
+          navigate((dx < 0 ? 1 : -1) * (isRtl() ? -1 : 1));
         }
       } else {
         const pullCommit = dy > window.innerHeight * COMMIT_DIST_Y_FRAC
@@ -1106,6 +1112,16 @@ export default function createGlobeModal({
       }
       swAxis = null;
     }, { passive: true });
+
+    evtRoot.addEventListener('touchcancel', () => {
+      if (!swActive) return;
+      swActive = false;
+      swAxis = null;
+      if (modalCanvasEl) {
+        modalCanvasEl.style.transition = 'transform 0.25s cubic-bezier(0.25, 0.1, 0.25, 1)';
+        modalCanvasEl.style.transform = '';
+      }
+    }, { passive: true });
   }
 
   // Synchronously return the modal DOM + page state to closed. destroy() forces phase to CLOSED
@@ -1129,8 +1145,8 @@ export default function createGlobeModal({
     }
     const mainCanvas = q('.globe-gallery-canvas');
     if (mainCanvas) mainCanvas.classList.remove('is-modal-active');
-    document.documentElement.classList.remove('modal-open');
-    document.body.classList.remove('modal-open');
+    document.documentElement.classList.remove('globe-gallery-modal-open');
+    document.body.classList.remove('globe-gallery-modal-open');
     if (window.lenis) window.lenis.start();
     resetChromeReveal();
   }
@@ -1143,7 +1159,7 @@ export default function createGlobeModal({
     releaseModalTexture();
     // Dispose lazy overflow carriers — Three frees GPU memory only on explicit dispose.
     overflowCards.forEach((card) => {
-      if (card.pendingImg) { card.pendingImg.onload = null; card.pendingImg.src = ''; card.pendingImg = null; }
+      if (card.pendingImg) { card.pendingImg.onload = null; card.pendingImg.onerror = null; card.pendingImg.src = ''; card.pendingImg = null; }
       if (card.mesh.parent) card.mesh.parent.remove(card.mesh);
       card.mesh.geometry.dispose();
       card.modalMat.dispose();

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -356,8 +356,8 @@ export default function createGlobeModal({
     const chromeEl = q('.globe-gallery-modal-chrome');
     const camera = getCamera();
     if (!chromeEl || !camera) return;
-    const { W, H } = getViewport();
-    const { w: CARD_W_SPHERE, h: CARD_H_SPHERE } = getCardDims();
+    const { W } = getViewport();
+    const { w: CARD_W_SPHERE } = getCardDims();
     if (!chromeNodes || chromeNodes.chromeEl !== chromeEl) {
       chromeNodes = {
         chromeEl,
@@ -375,19 +375,13 @@ export default function createGlobeModal({
     const tgtScale = scratchScale;
     computeModalTarget(tgtPos, tgtQuat, tgtScale);
 
-    const halfH = CARD_H_SPHERE * tgtScale.y * 0.5;
     const halfW = CARD_W_SPHERE * tgtScale.x * 0.5;
 
     if (!chromeProjV) chromeProjV = new THREE.Vector3();
     const pv = chromeProjV;
 
-    // Project card edges to screen pixels.
-    pv.set(0, tgtPos.y + halfH, tgtPos.z).project(camera);
-    const cardTopPx = (1 - pv.y) * 0.5 * H;
-
-    pv.set(0, tgtPos.y - halfH, tgtPos.z).project(camera);
-    const cardBotPx = (1 - pv.y) * 0.5 * H;
-
+    // Project the card's horizontal edges to screen pixels (used to centre the desktop control row
+    // under the image). Vertical placement is intentionally NOT derived from the card — see below.
     pv.set(tgtPos.x - halfW, tgtPos.y, tgtPos.z).project(camera);
     const cardLeftPx = (pv.x + 1) * 0.5 * W;
 
@@ -395,13 +389,8 @@ export default function createGlobeModal({
     const cardRightPx = (pv.x + 1) * 0.5 * W;
 
     // Clamp to visible viewport (card may bleed off edges at large scale).
-    const visBot = Math.min(H, cardBotPx);
     const visLeft = Math.max(0, cardLeftPx);
     const visRight = Math.min(W, cardRightPx);
-
-    // Inset by the SDF radius (px) so chrome sits over visible photo, not geometry.
-    const SDF_RADIUS_PX = SDF_CORNER_RADIUS * (cardBotPx - cardTopPx);
-    const INSET = 24 + Math.round(SDF_RADIUS_PX);
 
     const isMobile = (getBP() === 'sm');
     const rtl = isRtl();
@@ -436,8 +425,7 @@ export default function createGlobeModal({
         counterEl.style.top = 'auto'; counterEl.style.bottom = `${EDGE}px`;
       }
     } else {
-      // Counter and arrows share one `bottom` → one row.
-      const rowBottom = `${H - visBot + INSET}px`;
+      const rowBottom = `${EDGE}px`;
       const centerX = (visLeft + visRight) / 2;
       const flank = DT_COUNTER_W / 2 + DT_NAV_GAP; // pill edge → arrow's near edge
       if (counterEl) {


### PR DESCRIPTION
- Resolving comments left in https://github.com/adobecom/milo/pull/6433

- JS robustness: teardown on ancestor removal, tracked context-recovery timer, forceContextLoss before dispose, SSR-safe matchMedia guard, modal touchcancel + pointer-scoped close guard, hi-res texture onerror.

- Perf: fetch each card image once (parse fragment via inert DOMParser; drop the unused retained picture node).

- UX pacing: decouple formation from the runway so trimming --runway-height scales only the zoom/quote tail; retire the drag hint at globe passthrough; tune pull-quote gap/hold (per-breakpoint pin factor).

- CSS: S2A design tokens, native nesting, Milo-style flat class names, RTL, dvh units, flattened z-index band; README docs + eslint compat ignore for three-src.js.

<!-- Before submitting, please review all open PRs. -->

Resolves: https://jira.corp.adobe.com/browse/MWPW-202876

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=globe-merge-followups&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all














