### PR TITLE
[MWPW-203872] Add support for M@S CTA

### DIFF
--- a/libs/c2/blocks/product-marquee-grid/product-marquee-grid.js
+++ b/libs/c2/blocks/product-marquee-grid/product-marquee-grid.js
@@ -7,8 +7,8 @@ function parseColumn(col, isSoftOffer) {
   const iconEl = col.querySelector('p img[src*=".svg"]');
   if (iconEl) iconEl.src = getFederatedUrl(iconEl.src);
 
-  const ctaLinkPara = col.querySelector('p:has(em a), p:has(strong a)');
-  const ctaLink = ctaLinkPara?.querySelector('em a, strong a');
+  const ctaLinkPara = col.querySelector('p:has(em a), p:has(strong a), p:has(a[data-wcs-osi])');
+  const ctaLink = ctaLinkPara?.querySelector('em a, strong a, a[data-wcs-osi]');
   ctaLinkPara?.remove();
 
   const heading = col.querySelector('h1, h2, h3, h4, h5, h6');

--- a/libs/mep/ace1205/product-marquee-grid/product-marquee-grid.js
+++ b/libs/mep/ace1205/product-marquee-grid/product-marquee-grid.js
@@ -7,8 +7,8 @@ function parseColumn(col, isSoftOffer) {
   const iconEl = col.querySelector('p img[src*=".svg"]');
   if (iconEl) iconEl.src = getFederatedUrl(iconEl.src);
 
-  const ctaLinkPara = col.querySelector('p:has(em a), p:has(strong a)');
-  const ctaLink = ctaLinkPara?.querySelector('em a, strong a');
+  const ctaLinkPara = col.querySelector('p:has(em a), p:has(strong a), p:has(a[data-wcs-osi])');
+  const ctaLink = ctaLinkPara?.querySelector('em a, strong a, a[data-wcs-osi]');
   ctaLinkPara?.remove();
 
   const heading = col.querySelector('h1, h2, h3, h4, h5, h6');


### PR DESCRIPTION
Add support for M@S CTAs in the Product Marquee.
**Note:** selector might need to be updated to `a[is="checkout-link"]` once the property is coming to every M@S CTA link.

Resolves: [MWPW-203872](https://jira.corp.adobe.com/browse/MWPW-203872)

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-203872--milo--adobecom.aem.page/?martech=off

The code has been pushed to the feature branch: https://github.com/adobecom/milo/pull/6449 and is needed on STAGE as well.




