### PR TITLE
[UNIT] Fix BC unit test isolation for the side-overlay singleton

### DIFF
--- a/test/blocks/brand-concierge/brand-concierge.test.js
+++ b/test/blocks/brand-concierge/brand-concierge.test.js
@@ -11,6 +11,18 @@ const { updateReplicatedValue } = await import('../../../libs/blocks/brand-conci
 const { getUpdatedChatUIConfig, createSusiComponentForModal } = await import('../../../libs/blocks/brand-concierge/bc-bootstrap.js');
 
 describe('Brand Concierge', () => {
+  afterEach(() => {
+    // The side overlay is a singleton with persistent state (localStorage +
+    // body class + a single #brand-concierge-side element). Without cleanup
+    // it leaks across tests, so a second modal-open test collides with the
+    // overlay left open by the first. Reset it between tests.
+    document.getElementById('brand-concierge-side')?.remove();
+    document.querySelector('.modal-curtain')?.remove();
+    document.body.classList.remove('bc-side-open');
+    localStorage.removeItem('bc-side-overlay');
+    sinon.restore();
+  });
+
   it('decorates default variant with header, cards, input and legal, and sets background', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/default.html' });
     const block = document.querySelector('.brand-concierge');


### PR DESCRIPTION
## Summary
Fixes the 3 failing Brand Concierge unit tests on `bc-global` (the `Running tests (20.x)` CI failure on PR #6443). Targets `bc-global` so it lands with the side-overlay refactor.

## Failing tests (before)
`test/blocks/brand-concierge/brand-concierge.test.js` — 3 tests, all `Timeout of 2000ms exceeded`:
- `clicking a prompt card fills input and opens modal with card text`
- `decorates floating button with correct structure and opens modal on click`
- `sets up bootstrap API parameters, onBeforeEventSend callback, and event handlers correctly`

(26 passed, 3 failed)

## Root cause
The "Side overlay everywhere" refactor made the overlay a **singleton with persistent state** — `localStorage['bc-side-overlay']`, `document.body.bc-side-open`, and a single `#brand-concierge-side` element. The `describe('Brand Concierge')` block has **no top-level `afterEach`**, so the overlay opened by the first modal-open test (the Enter-key test) leaked into later tests. The subsequent modal-open tests then collided with the stale overlay: `bcBootstrap` resolved `#brand-concierge-mount` to `null` and threw `Cannot read properties of null (reading 'dataset')` (`bc-bootstrap.js:231`), which hung the async test until the 2000ms timeout. (This is why the first modal test passed and the rest failed.)

## Fix
Add an `afterEach` to `describe('Brand Concierge')` that resets the singleton between tests:
- remove `#brand-concierge-side` + `.modal-curtain`
- clear `document.body.bc-side-open`
- `localStorage.removeItem('bc-side-overlay')`
- `sinon.restore()`

Test-only change; no product code touched.

## Verification
- BC + BC-global unit tests: **29/29 pass** (was 26 passed, 3 failed)
- eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

