### PR TITLE
[Standalone GNAV] - Resolve mep-overlay and commerce.js bundler compatibility issues

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -480,7 +480,7 @@ export async function loadMasComponent(componentName) {
     }
 
     try {
-      return await import(targetUrl);
+      return await import(/* webpackIgnore: true */ /* @vite-ignore */ targetUrl);
     } catch (error) {
       failedExternalLoads.add(targetUrl);
       throw error;

--- a/libs/navigation/build.mjs
+++ b/libs/navigation/build.mjs
@@ -68,11 +68,19 @@ const LitResolver = {
 };
 
 // mep-overlay modules are authoring/preview tools not needed in the standalone-feds bundle.
-// Marking them external prevents code-split chunks and the associated CSS asset issues.
-const MepOverlayExternal = {
-  name: 'mep-overlay-external',
-  setup({ onResolve }) {
-    onResolve({ filter: /mep-overlay/ }, () => ({ external: true }));
+// Stubbing them out prevents the raw relative import paths from appearing in the dist output,
+// which would cause bundlers (webpack, etc.) in consumer projects to fail resolution.
+const MepOverlayStub = {
+  name: 'mep-overlay-stub',
+  setup({ onResolve, onLoad }) {
+    onResolve({ filter: /mep-overlay/ }, (args) => ({
+      path: args.path,
+      namespace: 'mep-overlay-stub',
+    }));
+    onLoad({ filter: /.*/, namespace: 'mep-overlay-stub' }, () => ({
+      contents: 'export default function() {}',
+      loader: 'js',
+    }));
   },
 };
 
@@ -83,5 +91,5 @@ await esbuild.build({
   format: 'esm',
   sourcemap: true,
   outdir: './dist/',
-  plugins: [LitResolver, MepOverlayExternal, StyleLoader],
+  plugins: [LitResolver, MepOverlayStub, StyleLoader],
 });

--- a/libs/navigation/build.mjs
+++ b/libs/navigation/build.mjs
@@ -67,6 +67,15 @@ const LitResolver = {
   },
 };
 
+// mep-overlay modules are authoring/preview tools not needed in the standalone-feds bundle.
+// Marking them external prevents code-split chunks and the associated CSS asset issues.
+const MepOverlayExternal = {
+  name: 'mep-overlay-external',
+  setup({ onResolve }) {
+    onResolve({ filter: /mep-overlay/ }, () => ({ external: true }));
+  },
+};
+
 await esbuild.build({
   entryPoints: ['navigation.js'],
   bundle: true,
@@ -74,5 +83,5 @@ await esbuild.build({
   format: 'esm',
   sourcemap: true,
   outdir: './dist/',
-  plugins: [LitResolver, StyleLoader],
+  plugins: [LitResolver, MepOverlayExternal, StyleLoader],
 });

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",

--- a/libs/navigation/package.json
+++ b/libs/navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobecom/standalone-feds",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "",
   "main": "dist/navigation.js",
   "type": "module",


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

### @adobecom/tacocat we need a fix while loading commerce.js through bundle build by webpack bundler.
## Summary

Fixes two bundler-compatibility issues in `@adobecom/standalone-feds` that caused consumer projects using **webpack 5** to fail at both build time and runtime.

---

## Problems fixed

### 1. Build-time: unresolvable `mep-overlay` paths

Module not found: Can't resolve '../features/mep/mep-next/mep-overlay/mep-overlay.js'

The standalone-feds dist contained dynamic imports with raw relative paths pointing outside the `dist/` directory (the only folder published in the package). Any bundler in a consumer project that re-processes the dist failed to resolve them.

These are authoring/preview-only tools — they only run when `?mepnext=on` is in the URL. They are never needed by consumers of the standalone nav.

### 2. Runtime: webpack intercepts absolute URL import

Cannot find module `https://main--mas--adobecom.aem.live/web-components/dist/commerce.js`

`loadMasComponent` in `merch.js` calls `import(targetUrl)` where `targetUrl` is a runtime-computed absolute URL. Webpack 5 intercepts all `import()` calls and tries to resolve them through its own module graph — it has no entry for `https://…` URLs, so it throws at runtime. The browser's native `import()` handles this fine, which is why it works on `aem.live`/`adobe.com` but fails in webpack-bundled consumers.

---

## Changes

### `libs/navigation/build.mjs`

Replaced the previous `MepOverlayExternal` esbuild plugin (which left raw relative import paths in the output) with a `MepOverlayStub` plugin. The stub intercepts mep-overlay imports during the esbuild bundle and replaces them with a no-op module (`export default function() {}`). esbuild then emits proper self-contained chunk files and all dynamic imports in the output point to those chunks — no unresolvable paths remain in the dist.

### `libs/blocks/merch/merch.js`

Added `/* webpackIgnore: true */` and `/* @vite-ignore */` to the dynamic import in `loadMasComponent`:

```js
// Before
return await import(targetUrl);

// After
return await import(/* webpackIgnore: true */ /* @vite-ignore */ targetUrl);
```

This is the [official webpack 5 magic comment](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to opt a specific import() out of webpack's module resolution, letting the browser's native loader handle the absolute URL at runtime. This pattern is already used in [navigation.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (line 45) for the same reason.

### Things which resolved now:

| Context | Before | After |
|---|---|---|
| Browser native ESM (`aem.live`, `adobe.com`) | ✅ Works | ✅ No change |
| esbuild (standalone-feds build) | ❌ Errors on `mep-overlay` paths | ✅ Clean build |
| Webpack 5 consumer build | ❌ Build errors + runtime crash on `commerce.js` | ✅ Works |
| Vite consumer build | ⚠️ Warning on absolute URL import | ✅ Suppressed via `@vite-ignore` |



Resolves: [MWPW-202408](https://jira.corp.adobe.com/browse/MWPW-202408)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://ost-standalone--milo--adobecom.aem.page/?martech=off




<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=ost-standalone--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=ost-standalone--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=ost-standalone--milo--adobecom
- Milo: https://ost-standalone--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=ost-standalone--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=ost-standalone--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=ost-standalone--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ost-standalone--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ost-standalone--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ost-standalone--milo--adobecom
- Milo: https://ost-standalone--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ost-standalone--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ost-standalone--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=ost-standalone--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ost-standalone--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ost-standalone--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ost-standalone--milo--adobecom
- Milo: https://ost-standalone--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ost-standalone--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ost-standalone--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=ost-standalone--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=ost-standalone--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=ost-standalone--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=ost-standalone--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=ost-standalone--milo--adobecom
</details>