### PR TITLE
MWPW-203971: restore Geo Routing Modal load analytics

### DIFF
--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -1,5 +1,5 @@
 import { getFederatedContentRoot, getCountry, setMarket } from '../../utils/utils.js';
-import { sendAnalytics } from '../../martech/helpers.js';
+import { sendAnalytics } from '../../blocks/modal/modal.js';
 import { norm } from '../../utils/market.js';
 
 const OLD_GEOROUTING = 'oldgeorouting';

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -1,5 +1,4 @@
-import { getFederatedContentRoot, getCountry, setMarket } from '../../utils/utils.js';
-import { norm } from '../../utils/market.js';
+import { getFederatedContentRoot, getCountry, setMarket, normCountryCode as norm } from '../../utils/utils.js';
 
 const OLD_GEOROUTING = 'oldgeorouting';
 

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import { getFederatedContentRoot, getCountry, setMarket, normCountryCode as norm } from '../../utils/utils.js';
 
 const OLD_GEOROUTING = 'oldgeorouting';
@@ -8,6 +9,25 @@ let getMetadata;
 let loadBlock;
 let loadStyle;
 let isC2Page;
+
+function fireAnalyticsEvent(event) {
+  const data = {
+    xdm: {},
+    data: { web: { webInteraction: { name: event?.type } } },
+  };
+  if (event?.data) data.data._adobe_corpnew = { digitalData: event.data };
+  window._satellite?.track('event', data);
+}
+
+function sendAnalytics(event) {
+  if (window._satellite?.track) {
+    fireAnalyticsEvent(event);
+  } else {
+    window.addEventListener('alloy_sendEvent', () => {
+      fireAnalyticsEvent(event);
+    }, { once: true });
+  }
+}
 
 const createTabsContainer = (tabNames) => {
   const ol = createTag('ol');
@@ -500,7 +520,6 @@ export default async function loadGeoRouting(
         handleOverflow(await showModal(details));
         const akamaiCode = await getCountry();
         const eventString = `Load:${storedLocaleGeo || 'us'}-${urlLocaleGeo || 'us'}|Geo_Routing_Modal|locale:${config.locale.prefix?.replace('/', '') || 'us'}|country:${akamaiCode}|intl:${storedInter || 'none'}`;
-        const { sendAnalytics } = await import('../../blocks/modal/modal.js');
         sendAnalytics(new Event(eventString));
         if (config.lingoProjectSuccessLogging === 'on') {
           window.lana.log(eventString, { sampleRate: 10, tags: 'lingo,lingo-georouting-load', severity: 'i' });
@@ -526,7 +545,6 @@ export default async function loadGeoRouting(
         handleOverflow(await showModal(details));
         if (akamaiCode === 'gb') akamaiCode = 'uk';
         const eventString = `Load:${urlLocale || 'us'}-${akamaiCode || 'us'}|Geo_Routing_Modal|locale:${config.locale.prefix?.replace('/', '') || 'us'}|country:${akamaiCode}|intl:none`;
-        const { sendAnalytics } = await import('../../blocks/modal/modal.js');
         sendAnalytics(new Event(eventString));
         if (config.lingoProjectSuccessLogging === 'on') {
           window.lana.log(eventString, { sampleRate: 10, tags: 'lingo,lingo-georouting-load', severity: 'i' });

--- a/libs/features/georoutingv2/georoutingv2.js
+++ b/libs/features/georoutingv2/georoutingv2.js
@@ -1,5 +1,4 @@
 import { getFederatedContentRoot, getCountry, setMarket } from '../../utils/utils.js';
-import { sendAnalytics } from '../../blocks/modal/modal.js';
 import { norm } from '../../utils/market.js';
 
 const OLD_GEOROUTING = 'oldgeorouting';
@@ -502,6 +501,7 @@ export default async function loadGeoRouting(
         handleOverflow(await showModal(details));
         const akamaiCode = await getCountry();
         const eventString = `Load:${storedLocaleGeo || 'us'}-${urlLocaleGeo || 'us'}|Geo_Routing_Modal|locale:${config.locale.prefix?.replace('/', '') || 'us'}|country:${akamaiCode}|intl:${storedInter || 'none'}`;
+        const { sendAnalytics } = await import('../../blocks/modal/modal.js');
         sendAnalytics(new Event(eventString));
         if (config.lingoProjectSuccessLogging === 'on') {
           window.lana.log(eventString, { sampleRate: 10, tags: 'lingo,lingo-georouting-load', severity: 'i' });
@@ -527,6 +527,7 @@ export default async function loadGeoRouting(
         handleOverflow(await showModal(details));
         if (akamaiCode === 'gb') akamaiCode = 'uk';
         const eventString = `Load:${urlLocale || 'us'}-${akamaiCode || 'us'}|Geo_Routing_Modal|locale:${config.locale.prefix?.replace('/', '') || 'us'}|country:${akamaiCode}|intl:none`;
+        const { sendAnalytics } = await import('../../blocks/modal/modal.js');
         sendAnalytics(new Event(eventString));
         if (config.lingoProjectSuccessLogging === 'on') {
           window.lana.log(eventString, { sampleRate: 10, tags: 'lingo,lingo-georouting-load', severity: 'i' });

--- a/test/features/georoutingv2/georoutingv2.test.js
+++ b/test/features/georoutingv2/georoutingv2.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import { stub } from 'sinon';
 import { expect } from '@esm-bundle/chai';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
@@ -311,6 +312,26 @@ describe('GeoRouting', () => {
     const modal = document.querySelector('.dialog-modal');
     // assert
     expect(modal).to.not.be.null;
+  });
+
+  const EXPECTED_LOAD_EVENT = 'Load:us-ch|Geo_Routing_Modal|locale:us|country:ch|intl:none';
+  const trackedEventNames = (track) => track.getCalls()
+    .map((c) => c.args?.[1]?.data?.web?.webInteraction?.name);
+
+  it('Fires the modal-load analytics event with the correct name', async () => {
+    setUserCountryFromIP();
+    mockConfig.locale.prefix = '';
+    const track = stub();
+    const ogSatellite = window._satellite;
+    window._satellite = { track };
+    try {
+      await init(mockConfig, createTag, getMetadata, loadBlock, loadStyle, v2JSONPromise());
+      const names = trackedEventNames(track);
+      expect(names).to.include(EXPECTED_LOAD_EVENT);
+    } finally {
+      if (ogSatellite === undefined) delete window._satellite;
+      else window._satellite = ogSatellite;
+    }
   });
 
   it('Does not create a modal if the user IP matches session storage.', async () => {


### PR DESCRIPTION
Resolves: [MWPW-203971
](https://jira.corp.adobe.com/browse/MWPW-203971)

## What
The Geo Routing Modal's Adobe Analytics **load** event stopped being recorded correctly around **17 June 2026**, artificially suppressing the **Mismatch Rate** KPI (a key metric for EN-phase / Lingo reporting). The modal still displayed to users — only the tracking broke.

## Why
PR #6168 switched the modal-load analytics call to the shared `martech/helpers.js` `sendAnalytics`, which has a different contract — it takes a plain string, whereas georouting passes an `Event` — and emits a different event payload shape. As a result the event name was corrupted and the event no longer landed the way the KPI expects.

The original sender lived on the modal block's export, but that export had already been removed from the C2 modal — which is what threw on C2 pages and prompted the switch in the first place.

## Fix
Give georouting its own small analytics sender (the same pattern `language-banner.js` already uses): it takes an `Event` and emits the original payload, so the load event fires with the correct name on both classic and C2 pages. It depends on neither the modal block nor `martech/helpers.js`, so it can't be broken again by changes to either. Self-contained function plus a unit test.

## Test URLs
- **Before (broken):** https://main--da-cc--adobecom.aem.live/de/products/photoshop?georouting=on&martech=on
- **After (this branch):** https://main--da-cc--adobecom.aem.live/de/products/photoshop?milolibs=MWPW-203971-georouting-analytics&georouting=on&martech=on

## How to test
1. Open the **After** URL (keep martech on). The Geo Routing Modal appears.
2. DevTools → Network, filter **`collect`**.
3. Confirm the payload has `events[0].data.web.webInteraction.name` containing **`Geo_Routing_Modal`**, e.g. `Load:de-ch|Geo_Routing_Modal|locale:de|country:ch|intl:none`.

On the **Before** URL that event is missing or its name is a broken `[object Event]`.

## Tests
`npm run test:file -- test/features/georoutingv2/georoutingv2.test.js` — passing, including a new test asserting the load event fires with the correct name.
