### PR TITLE
[SR][HP-PERF]MWPW-203838: Use transform for grid scale animation

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1179,20 +1179,28 @@ span.hang-opening-quote {
 
   /* Grid parallax declarations */
   .parallax-scale-down-grid {
+    --parallax-scale-grid-margin: var(--grid-margin-width);
+    --grid-scale-multiplier: tan(atan2(
+      min(var(--grid-max-width-fluid), 100vw),
+      min(var(--grid-max-width), calc(100vw - 2 * var(--parallax-scale-grid-margin)))
+    ));
+
     animation-name: enable-grid-parallax;
-    overflow: clip;
+    transform-origin: top center;
+    overflow-x: clip;
+    will-change: scale;
+
+    @media (width >= 768px) {
+      /* 8.333% grid margin as a length (a % can't resolve inside atan2) */
+      &:not(.fixed, .fluid) { --parallax-scale-grid-margin: 8.333vw; }
+    }
+
+    :has(> &) { overflow-x: clip; }
   }
 
   @keyframes enable-grid-parallax {
-    from {
-      --grid-max-width: var(--grid-max-width-fluid);
-      --grid-margin-width: 0px;
-    }
-
-    to {
-      --grid-max-width: var(--grid-max-width-target);
-      --grid-margin-width: var(--grid-margin-width-target);
-    }
+    from { scale: var(--grid-scale-multiplier, 1); }
+    to   { scale: 1; }
   }
 
   /* Stagger parallax declarations */


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Use transform for grid scaling

Resolves: [MWPW-203838](https://jira.corp.adobe.com/browse/MWPW-203838)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/scale-down-grid/document
- After: https://scale-down-grid--milo--adobecom.aem.page/drafts/ratko/scale-down-grid/document
- Before: https://www.stage.adobe.com/
- After: https://www.stage.adobe.com/?milolibs=scale-down-grid

