### PR TITLE
[MWPW-204062] Fix geo-ip placeholder override when preceded by another placeholder

### DIFF
--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -226,7 +226,7 @@ export async function replaceText(
   return finalText;
 }
 
-const geoIpPattern = /{{(.*?-geo-ip)}}|%7B%7B(.*?-geo-ip)%7D%7D/g;
+const geoIpPattern = /{{([^{}]*?-geo-ip)}}|%7B%7B((?:(?!%7[BD]).)*?-geo-ip)%7D%7D/g;
 const findGeoIpKeys = (t) => (t ? [...t.matchAll(geoIpPattern)].map((m) => m[1] || m[2]) : []);
 
 async function deferGeoIpUpdate(deferredItems, config, sheet) {

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -215,6 +215,18 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     expect(textNode.nodeValue).to.equal('+352 800 99999');
   });
 
+  it('deferred update swaps geo-ip value when preceded by another placeholder in the same text node', async () => {
+    const cfg = enableLingo();
+    cfg.locale.contentRoot = '/test/features/placeholders';
+    const textNode = document.createTextNode('{{add-to-cart}} and {{buy-now-geo-ip}}');
+
+    await decoratePlaceholderArea({ nodes: [textNode] });
+    expect(textNode.nodeValue).to.equal('Add to cart and Buy now');
+
+    await decoratePlaceholderArea.deferredGeo;
+    expect(textNode.nodeValue).to.equal('Add to cart and Acheter maintenant');
+  });
+
   it('MEP placeholder overrides geo-ip value', async () => {
     const cfg = enableLingo();
     cfg.locale.contentRoot = '/test/features/placeholders';


### PR DESCRIPTION

  - Fix `findGeoIpKeys` regex so a `-geo-ip` key can't span placeholder
    boundaries. Previously `.*?` matched across `{{`/`}}`, so when a non-geo
    placeholder preceded a geo-ip token in the same text node it captured a
    malformed key; `deferGeoIpUpdate` couldn't find it in the geo map and
    skipped the override, leaving the host-locale base value.
  - Handles both raw (`{{…}}`) and URL-encoded (`%7B%7B…%7D%7D`) tokens.
  - Add a regression test for a placeholder immediately preceding a geo-ip
    token in one text node.

  Resolves: [MWPW-204062](https://jira.corp.adobe.com/browse/MWPW-204062)

  **Test URLs:**
  - Before: https://www.stage.adobe.com/offer-terms/cc-full-special-offer.html?mepFragments=true&akamaiLocale=be&milolibs=main
  - After: https://www.stage.adobe.com/offer-terms/cc-full-special-offer.html?mepFragments=true&akamaiLocale=be&milolibs=MWPW-204062-geo-ip-placeholder-boundary
- psi-check: https://MWPW-204062-geo-ip-placeholder-boundary--milo--adobecom.aem.page/?martech=off
-
  
  Expected: the offer-terms sentence reads "…for customers in Belgium".
  Before (milolibs=main) shows "…United States".


