### PR TITLE
[MWPW-204097] MEP overlay scroll fix

### DIFF
--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
@@ -183,6 +183,7 @@ body:has(#mep-drawer:popover-open) .mep-fab {
 .mep-drawer .mep-body {
   flex-grow: 1;
   overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .mep-drawer .mep-body::-webkit-scrollbar {

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -462,6 +462,7 @@ function buildDrawer(gnavOffset, pageId) {
     id: 'mep-drawer',
     class: 'mep-drawer',
     popover: 'manual',
+    'data-lenis-prevent': '',
     style: `top: ${gnavOffset}px; height: calc(100vh - ${gnavOffset}px)`,
   }, children);
 }


### PR DESCRIPTION
**Updates**
* Fix MEP Next overlay drawer being unable to scroll on pages where Lenis smooth-scroll hijacks wheel events (e.g. `foundation: c2` pages), by opting the drawer out of Lenis's wheel/touch handling via `data-lenis-prevent`
* Add `overscroll-behavior: contain` to the drawer body so scroll doesn't chain into the underlying page once the panel is scrolled to its top/bottom

**Instructions**

The overlay's Actions tab only renders full card content when authenticated via AEM Sidekick, and this fix needs to be verified against a live prod page — so test with Chrome DevTools **Local Overrides** rather than just a local/preview URL.

1. Sign into AEM Sidekick (the extension) against the target page so the overlay's auth gate resolves as authenticated.
2. Open https://www.adobe.com/?mep&mepnext=on in Chrome, open DevTools → **Sources** → **Overrides** → select a local folder and grant access.
3. In **Overrides**, replace these files with the branch's local copies (same relative path under `/libs/`):
   - `libs/features/mep/mep-next/mep-overlay/mep-overlay.js`
   - `libs/features/mep/mep-next/mep-overlay/mep-overlay.css`
4. Reload the page, open the MEP overlay and expand a few cards in the Actions tab until the drawer body overflows.
5. Scroll the drawer body with the mouse wheel/trackpad:
   - It should scroll smoothly on its own — not get blocked, and not fall through to scrolling the page behind it
   - Scrolling past the top/bottom of the drawer body should not cause the page itself to scroll (overscroll containment)
6. Confirm existing overlay functionality wasn't impacted: tabs switch, cards expand/collapse, toggles and Spoof Geo controls still work as before.
7. Regression-check on a couple of other page types to confirm nothing else changed:
   - Another `foundation: c2` page (Lenis-enabled) with the same override applied — confirm the page's own smooth scroll still behaves normally outside the overlay
   - A non-C2 page with no Lenis loaded (e.g. any standard `/products/*.html` page) with `?mep&mepnext=on` — confirm the overlay drawer still scrolls natively and nothing regressed

Resolves: [MWPW-204097](https://jira.corp.adobe.com/browse/MWPW-204097)

**Test URLs:**
- Before: https://www.adobe.com/?mep&mepnext=on
- After: https://www.adobe.com/?mep&mepnext=on (with local overrides).
- Psi: https://mn-overlay-scroll-fix--milo--adobecom.aem.page/?martech=off




