### PR TITLE
MWPW-204021: Add support for icon in side-by-side smaller card

### DIFF
--- a/libs/blocks/video/video.css
+++ b/libs/blocks/video/video.css
@@ -177,8 +177,8 @@ video {
     justify-content: center;
     position: absolute;
     z-index: 1;
-    right: var(--s2a-spacing-lg);
-    bottom: var(--s2a-spacing-lg);
+    inset-inline-end: var(--s2a-spacing-md);
+    inset-block-end: var(--s2a-spacing-md);
 
     svg path {
       fill: var(--s2a-color-gray-25);
@@ -214,10 +214,17 @@ video {
     }
   }
 
+  @media (width >= 768px) {
+    button.play-pause-button {
+      inset-inline-end: var(--s2a-spacing-lg);
+      inset-block-end: var(--s2a-spacing-lg);
+    }
+  }
+
   @media (width >= 1280px) {
     button.play-pause-button {
-      right: var(--s2a-spacing-xl);
-      bottom: var(--s2a-spacing-xl);
+      inset-inline-end: var(--s2a-spacing-xl);
+      inset-block-end: var(--s2a-spacing-xl);
     }
   }
 

--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -25,6 +25,7 @@
   }
 
   .media {
+    position: relative;
     border-radius: inherit;
 
     picture,
@@ -43,6 +44,15 @@
 
     video, img {
       object-fit: cover;
+    }
+
+    .icon {
+      position: absolute;
+      width: 32px;
+      height: auto;
+      z-index: 1;
+      inset-block-start: var(--s2a-spacing-md);
+      inset-inline-start: var(--s2a-spacing-md);
     }
   }
 
@@ -158,6 +168,11 @@
 
       .media {
         min-height: 306px;
+
+        .icon {
+          inset-block-start: var(--s2a-spacing-lg);
+          inset-inline-start: var(--s2a-spacing-lg);
+        }
       }
 
       .foreground {
@@ -194,8 +209,15 @@
       --card-overlay-padding: var(--s2a-spacing-xl);
     }
 
-    .card-stacked .foreground {
-      padding: var(--s2a-spacing-xl);
+    .card-stacked {
+      .foreground {
+        padding: var(--s2a-spacing-xl);
+      }
+
+      .media .icon {
+        inset-block-start: var(--s2a-spacing-xl);
+        inset-inline-start: var(--s2a-spacing-xl);
+      }
     }
 
     &.featured .card-overlay .foreground {

--- a/libs/mep/ace1209/side-by-side/side-by-side.js
+++ b/libs/mep/ace1209/side-by-side/side-by-side.js
@@ -4,7 +4,7 @@ import { createTag, getFederatedUrl } from '../../../utils/utils.js';
 const DEFAULT_TEXT_CONFIG = { heading: '6', body: 'md' };
 let videoObserver = null;
 
-const isSvgUrl = (url) => /\.svg(\?.*)?$/i.test(url || '');
+function isSvgUrl(url) { return /\.svg(\?.*)?$/i.test(url || ''); }
 
 function decorateCardText(foreground) {
   decorateBlockText(foreground, DEFAULT_TEXT_CONFIG);

--- a/libs/mep/ace1209/side-by-side/side-by-side.js
+++ b/libs/mep/ace1209/side-by-side/side-by-side.js
@@ -1,8 +1,10 @@
 import { decorateBlockText, decorateViewportContent, syncPausePlayIcon, USER_PAUSED_ATTR } from '../../../utils/decorate.js';
-import { createTag } from '../../../utils/utils.js';
+import { createTag, getFederatedUrl } from '../../../utils/utils.js';
 
 const DEFAULT_TEXT_CONFIG = { heading: '6', body: 'md' };
 let videoObserver = null;
+
+const isSvgUrl = (url) => /\.svg(\?.*)?$/i.test(url || '');
 
 function decorateCardText(foreground) {
   decorateBlockText(foreground, DEFAULT_TEXT_CONFIG);
@@ -54,6 +56,18 @@ function getCardType(block) {
   return CARD_TYPE;
 }
 
+function decorateCardStackedIcon(mediaContainer) {
+  const medias = mediaContainer.querySelectorAll('img, video');
+  if (medias.length <= 1) return;
+  const icon = medias[0];
+  const iconContainer = icon.closest('p');
+  iconContainer.classList.add('icon');
+  if (isSvgUrl(icon.src)) icon.src = getFederatedUrl(icon.src);
+  const imgVideoContainer = medias[1].closest('p');
+  mediaContainer.append(...imgVideoContainer.children);
+  imgVideoContainer.remove();
+}
+
 function decorate(block, el) {
   const [mediaRow, textRow] = block.children;
   if (!mediaRow || !textRow) return;
@@ -72,6 +86,7 @@ function decorate(block, el) {
     decorateCardText(foreground);
 
     const variant = cardType[i];
+    if (variant === 'card-stacked') decorateCardStackedIcon(media);
     const card = createTag('div', { class: `card ${variant}` });
     card.append(media, foreground);
     cards.push(card);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

- Side-by-side (mep/ace1209): Added support for an app icon in the card-stacked variant. When a card-stacked media cell contains two media items, the first is treated as the icon (positioned top-left of the media) and the second as the main media.
  - side-by-side.js: new decorateCardStackedIcon() — tags the icon's wrapper with .icon, federates the SVG source via getFederatedUrl, and unwraps the main media. Guarded to no-op when only one media is present.
  - side-by-side.css: .icon styles — 32px, absolutely positioned top-left, with responsive inset (md → lg → xl) using logical properties for RTL support.
- Video (blocks/video): Updated the c2 play/pause button to use logical properties (inset-inline-end/inset-block-end) and a responsive inset scale — md (mobile) → lg (≥768) → xl (≥1280) — so it aligns with the media padding in the design.

Authoring: Icon is authored above the image/video as `svg` or plain image
<img width="541" height="497" alt="Screenshot 2026-08-13 at 15 36 44" src="https://github.com/user-attachments/assets/589400f2-3ffc-45c1-a2b6-95841c9eae81" />


Resolves: [MWPW-204021](https://jira.corp.adobe.com/browse/MWPW-204021)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/drafts/ratko/side-by-side-icon?milolibs=site-redesign-foundation&georouting=off
- After: https://main--da-cc--adobecom.aem.page/drafts/ratko/side-by-side-icon?milolibs=side-by-side-icon&georouting=off
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=side-by-side-icon&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all




