### PR TITLE
fix(ace1209 hub-hero): clamp() the carousel card cap so a narrower viewport cannot widen the card (MWPW-204141)

### DIFF
--- a/libs/mep/ace1209/hub-hero/hub-hero.css
+++ b/libs/mep/ace1209/hub-hero/hub-hero.css
@@ -1063,7 +1063,7 @@
 /* below large */
 @media (1380px > width) {
   .hub-hero {
-    --hub-hero-carousel-item-max-width: max(292px, calc(var(--slide-max-viewport) - 16px));
+    --hub-hero-carousel-item-max-width: clamp(292px, calc(var(--slide-max-viewport) - 16px), 392px);
     --hub-hero-carousel-item-min-width: 146px;
   }
 }


### PR DESCRIPTION
## The defect

`libs/mep/ace1209/hub-hero/hub-hero.css` uses `max()` on a **max-width** inside `@media (1380px > width)`, which *removes* the cap instead of tightening it:

```css
/* .hub-hero default — a real cap */
--hub-hero-carousel-item-max-width: min(392px, calc(var(--slide-max-viewport) - var(--s2a-spacing-md)));

/* @media (1380px > width) — max() removes it */
--hub-hero-carousel-item-max-width: max(292px, calc(var(--slide-max-viewport) - 16px));
```

`--s2a-spacing-md` resolves to `16px`, so the two declarations share the **identical** inner expression. The only difference is `min`-with-a-392-cap versus `max`-with-a-292-floor — and on a `max-width`, `max()` is unbounded above.

**Consequence: a narrower viewport makes the card wider.** At 1379px the card is **443.67px**; at 1440px it is **392px**.

## Measured, not computed

Measured in real Chromium against the live `site-redesign-foundation` CPro Hub fragment, replayed from a byte-exact archive of this page. The `hub-hero.css` those measurements ran against is **sha256 `8dc65ec05912bfc075c2fbe05ebf00fe77997853af4a074b299c1db752d88cc4` — byte-identical to the copy on this branch right now**, so the numbers apply to exactly these bytes.

The subject carries `class="hub-hero slides-3 dark"` with 3 carousel items, so `--slide-max-viewport` is `calc(100vw/3)`.

Used `max-width` on `.hub-hero-carousel-item`, at the carousel's expanded end state:

| viewport | current `max()` | this PR `clamp()` | if the line were deleted |
|---|---|---|---|
| 1440 | 392px | 392px | 392px |
| **1379** | **443.667px** | **392px** | 392px |
| 1231 | 394.325px | 391.992px | 391.992px |
| 1032 | 327.839px | 327.839px | 327.839px |
| 872 | **292px** | **292px** | **274.667px** |

After the fix the sequence is monotonic — 392 → 392 → 391.99 → 327.84 → 292 — and no viewport produces a card wider than 1440's.

The crossover is exactly **1224px**: `100vw/3 − 16 = 392` ⟺ `100vw = 1224`. So on `slides-3` the cap is *removed* for the whole `1224–1380` band, which is the band this fragment is reviewed in.

<details>
<summary>Why the ticket's 438.3px and this PR's 443.67px differ (they agree)</summary>

`100vw` includes a classic scrollbar; the media-query `width` feature excludes it. At outer 1379 with a 16px classic scrollbar, `100vw` is 1379 but MQ width is 1363 — so `1363/3 − 16 = 438.33` (Windows/classic scrollbars) and `1379/3 − 16 = 443.67` (macOS overlay scrollbars, and the value measured here). Direction, magnitude and crossover are the same either way.
</details>

## Why `clamp()` and not deleting the line

`clamp(292px, X, 392px)` is exactly `max(292px, min(X, 392px))`. It restores the 392px cap the default declares **while keeping the 292px floor** — the one thing the `max()` gets right.

Deleting the declaration also fixes the ≥1224px band, and is identical to `clamp()` everywhere except **below** the crossover, where it drops the floor: measured **292px → 274.667px at 872px** (−17.33px, −5.9%). That is a visible narrowing on a band reviewers actually use.

**Whether the 292px floor was intended is your call, not mine** — that is the one decision this PR is asking for. If it was accidental, delete the declaration instead and the cascade computes the right value; the table above is the cost. Note the paired `--hub-hero-carousel-item-min-width: 146px` in the same block was presumably chosen alongside that floor.

Two follow-ups deliberately **not** bundled here, to keep the regression fix a one-liner:
- hoist `392px`/`292px` into `--hub-hero-carousel-item-cap`/`--hub-hero-carousel-item-floor` so the two declarations cannot drift apart again;
- swap the literal `16px` for `var(--s2a-spacing-md)` (they resolve identically today).

`clamp()` raises no browser floor: this file already uses `min()`, `max()` and CSS nesting.

## Provenance — this is inherited, not newly written

Only three commits have ever touched this path on `site-redesign-foundation`:

- `37235086` (Wave 3 base, #6219) — `libs/mep/ace1209/` and `libs/mep/ace1205/` were the **same git blob** `203b46016fde64521286d61013fa3b9a41cc871b`. ace1209 was a byte-for-byte copy.
- `a4ab7513` (#6406) — raised the cap `329px → 392px`, introduced `--slide-max-viewport: calc(100vw/var(--slides))`, and added the `.slides-3` variant.
- `3e6841c9` — unrelated to this line.

**In `ace1205` the `max()` is provably inert**, by numeric coincidence: with a 329px cap and a hardcoded `25vw`, `25vw − 16 > 329` ⟺ `100vw > 1380` — *exactly* the media query's own ceiling, so the `max()` arm is unreachable. ace1205 has no `slides-3` and no `--slide-max-viewport` at all.

So nobody chose `max()` for ace1209. Raising the cap to 392 and adding a 3-slide variant **de-coincided the crossover from the unchanged 1380px ceiling**, moving it to 1224px and opening the band. That is why this survived review: the line was correct in the file it was copied from.

`ace1205` on `main` still carries the same inert line and needs no change — but it acquires this exact bug the moment it gets a `slides-3` variant or a raised cap. Worth a note wherever that is tracked; deliberately **not** bundled here (different branch, different blast radius, live production MEP).

## Not a Forge bug, and Forge cannot work around it

Filed from Forge tooling because that is where it was seen, but there is no Forge-side change: `FORGE_REPLAY.captureViewport` is `{ width: 1440, height: 900 }` — **above** the 1380 boundary — so Forge captures *outside* the buggy band and the archive is complete. The band is entered at **review** time, when the reviewer's 872/1032px stage lays out this same CSS. "Just capture wider" is therefore not available as a workaround.

## Out of scope, and it is a separate question

`--carousel-item-media-height: 394px` is set as both `height` and `max-height`, and the source images here are portrait `582 × 788` (measured), so ~24.7% of the image is cropped at 1440 and ~33.6% at 1379. Whether that pin is intended is an independent decision from the cap, and this PR does not touch it.

Relatedly, and worth stating because it reads like dead CSS and is not: the `s3SlideMediaExpand` keyframe **must not be deleted**. It is nested inside `.hub-hero.slides-3` *and* `@media (width >= 768px)`, so on default `slides-4` content it does not exist at all; where it does exist it is clamped-and-invisible only at ≥~1407px, and it **does** animate at the 872/1032px widths reviewers use.

Ref: MWPW-204141 (split out of MWPW-203976).


