### PR TITLE
[MWPW-204298] Pin MAS web-components to node_modules in unit tests

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -56,7 +56,8 @@ export default {
         <script type="importmap">
           {
             "imports": {
-              "https://www.adobe.com/mas/libs/": "/node_modules/@adobecom/mas-platform/web-components/dist/"
+              "https://www.adobe.com/mas/libs/": "/node_modules/@adobecom/mas-platform/web-components/dist/",
+              "https://main--mas--adobecom.aem.live/web-components/dist/": "/node_modules/@adobecom/mas-platform/web-components/dist/"
             }
           }
         </script>


### PR DESCRIPTION
### Problem
test/blocks/merch-card-autoblock/merch-card-autoblock.test.js fails locally — 32 of 35 tests — with:

  NotSupportedError: Failed to execute 'define' on 'CustomElementRegistry':
  the name "mas-field" has already been used with this registry
      at web-components/dist/commerce.js:530

  Environment-dependent: reproduces on any machine that can reach the live MAS host, but not in CI, so it slips through.

  ### Root cause

  The tests load the MAS web-components bundle from a live, unpinned CDN instead of the pinned node_modules copy:

  - getMasComponentUrl() returns the https://www.adobe.com/mas/libs/… URL only when hostname === 'www.adobe.com'. On localhost (unit tests) it returns https://main--mas--adobecom.aem.live/web-components/dist/….
  - The test-runner import map only redirects the www.adobe.com/mas/libs/ prefix to node_modules, so the aem.live URL is fetched live over the network.
  - The live commerce.js now defines mas-field, which collides with the test's mas-field stub.

  The pinned bundle is innocent — node_modules/@adobecom/mas-platform/…/commerce.js has zero mas-field references. And @adobecom/mas-platform is pinned as github:adobecom/mas (a floating branch ref), so the bundle the tests actually run is whatever MAS last deployed.

 ###  Fix

  Add the aem.live prefix to the test-runner import map so MAS components resolve to the pinned node_modules copy on all hostnames
  
Resolves: [MWPW-204298](https://jira.corp.adobe.com/browse/MWPW-204298)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-204298-mas-test-importmap--milo--adobecom.aem.page/?martech=off


