### PR TITLE
[Site Redesign] Globe-Gallery Updates

### DIFF
--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -103,7 +103,7 @@ Who writes what:
 
 | | fields |
 | --- | --- |
-| `frameInput` ← the runtime, each tick | `scrollY`, `reducedMotion`, `blockDocTop`, `blockHeight`, `formPx` (= `formedScrollPx()`), `viewportH`, `arcScale` (= `CARD_W_ARC / CARD_W_SPHERE`), `now` (= `performance.now()`), plus `prevLenisY` / `prevNow` — the **only** inter-frame state, carried back after each derive (both re-baselined in `startTicker`, so a resume after an off-screen scroll doesn't spike `scrollVel` or charge the parked interval to `dtScale`) |
+| `frameInput` ← the runtime, each tick | `scrollY`, `reducedMotion`, `blockDocTop`, `blockHeight`, `formPx` (= `formedScrollPx()`), `viewportH` (= `H`, the CSS viewport height — **not** `innerHeight`; see One viewport height), `arcScale` (= `CARD_W_ARC / CARD_W_SPHERE`), `now` (= `performance.now()`), plus `prevLenisY` / `prevNow` — the **only** inter-frame state, carried back after each derive (both re-baselined in `startTicker`, so a resume after an off-screen scroll doesn't spike `scrollVel` or charge the parked interval to `dtScale`) |
 | `frame` ← `deriveFrame` | `lenisY`, `scrollingDown`, `scrollVel`, `dtScale` (real frame time ÷ 16.67ms, clamped `[0.25, 3]`), the six clocks (`progress`, `arcCopyEntryT`, `arcPanT`, `gridFormT`, `sphereFormT`, `zoomT`), `gpWin`, and the arc-branch entry transforms `entryRot` / `entryYOffset` / `arcScale` |
 | `frame` ← the producer stages | `activeCamera` (`updateActiveCamera`), `sphereRotActive` (`updateSphereRotation`), `sphGroupZ` (`updateSphereGroupDepth`), `foldSphDist` (same) — declared in `createFrame` so the object's shape stays monomorphic |
 
@@ -413,9 +413,20 @@ authored product links.
 ### Hanging the opening mark
 
 The pull-quote outdents its opening quote into the margin, so the first line's text meets the
-same column the rest of the quote and the name/role below it sit on. `hanging-punctuation: first`
-(`.css`) does this natively but **only in WebKit**; `hangOpeningMark` (`authoring.js`) reproduces
-it everywhere else by measuring the mark and setting a negative `text-indent`.
+same column the rest of the quote and the name/role below it sit on. `hangOpeningMark`
+(`authoring.js`) does this in **every** browser by measuring the mark and setting a negative
+`text-indent` in `em`.
+
+**`hanging-punctuation: first` is deliberately not used.** It's the native spelling of this and it
+was in the CSS, gated by `CSS.supports` so the measurement only ran where the property is missing
+(Chrome, which has never shipped it). That split the behaviour by *character*: **WebKit hangs only
+`Ps`/`Pi`/`Pf`** — `“` `«` `(` all hang — **and not ASCII `"` or `'`**, which the CSS Text hangable
+set includes and this block's regex therefore includes too. So an authored straight `"` (what
+translators and DA authors actually type) outdented in Chrome and sat inline on iOS Safari, while a
+curly `“` worked in both. Measured in Playwright WebKit vs Chromium on a replica of this exact
+structure (`quote-hang-probe.cjs`); `CSS.supports` is `true` in WebKit either way, so no feature
+query can express the difference. The measurement now runs unconditionally and the property stays
+out of the CSS entirely — re-adding it would double-outdent WebKit on the marks it does hang.
 
 **Measured, not tabulated.** The mark and its width both change by locale — `“` (~0.49em), `«`,
 `„`, `「` (a full em) — and *which* mark appears comes from the **authored copy, not the page's
@@ -424,14 +435,14 @@ character and measures that glyph in the font the locale actually resolved, rath
 per-locale table that would be both unmaintainable and keyed on the wrong thing.
 
 **Which characters count** — Unicode general categories, matching the set CSS Text hangs, so the
-fallback and WebKit's native path act on identical characters:
+measured outdent acts on exactly the characters the spec would hang:
 
 | Category | Meaning | Examples |
 | --- | --- | --- |
 | `Ps` | open bracket | `(` `「` `（` — and `„` `‚`, which Unicode files as brackets, not quotes |
 | `Pi` | initial quote | `“` `‘` `«` `‹` |
 | `Pf` | final quote | `”` `’` `»` `›` — several locales **open** on these (sv/fi `”`, da `»`) |
-| + `"` `'` | ASCII | category `Po`, since one character serves as both opener and closer |
+| + `"` `'` | ASCII | category `Po`, since one character serves as both opener and closer — and the one WebKit's native path skips |
 
 Categories rather than a literal list, so a new locale needs no code change. `Pe` closers (`」`),
 dashes, and the rest of `Po` (`!` `¿`) are excluded.
@@ -439,9 +450,9 @@ dashes, and the rest of `Po` (`!` `¿`) are excluded.
 **Full-width CJK brackets are skipped**, on two tests: the mark measuring **≥ 0.8em** (`「『（` run
 ~0.96em vs ~0.55em for the widest Latin quote `«`, so the cutoff isn't delicate), or **exceeding the
 padding**, where it would be shoved past the viewport edge into the block's `overflow-x: clip` and
-sheared. Either test suppresses the hang **including WebKit's native one**, so every browser lands on
-the same result. The width test is what makes that result breakpoint-independent: `--gg-copy-pad`
-(24→48→64) and `heading-1` (40→56→80px) step at *different* widths, so the padding test alone leaves
+sheared. Either test leaves the mark inline. The width test is what makes that result
+breakpoint-independent: `--gg-copy-pad` (24→48→64) and `heading-1` (40→56→80px) step at *different*
+widths, so the padding test alone leaves
 `768–1023` a band where a `「` fits and hangs while being suppressed everywhere else — and since the
 measurement runs once at init, a later resize would strand it and shear.
 
@@ -533,6 +544,67 @@ Formation is **locked** to a fixed scroll length, so `--gg-runway-height` sets t
 Within the tail, `zoomT = clamp((scroll − formation) / (runway − formation), 0, 1)` drives the camera
 (`CAM_Z_SPHERE → CAM_Z_END`), the cursor retirement, and the pull-quote.
 
+### One viewport height
+
+`H` is **not** `window.innerHeight` — that identifier does not appear in the block. It is
+`.globe-gallery-world`'s `offsetHeight`: that box is `height: 100vh` and it is the canvas' own parent,
+so `measureViewportH()` is a direct read of 100vh in px, straight from CSS. Scroll clocks and rendering
+both use it, and it is the only viewport height here.
+
+**Why not the window.** On iOS the URL bar resizes the *layout* viewport: `innerHeight` shrinks and
+grows mid-scroll — every change of scroll direction collapses or restores it — while `vh` resolves
+against the large viewport and never moves (measured on-device: `100vh` and `worldH` held at 1005 while
+`innerHeight` went 1005 → 952). Two separate failures came out of reading the window, and one number
+fixes both:
+
+| what read `innerHeight` | what the bar did to it |
+| --- | --- |
+| `formPx` + the entry ramps (scroll → `progress`) | `blockHeight` is `vh`-based and `formPx` was not, so they disagreed by the bar × 3.04 (~150–250px of scroll). Each collapse *rewound* `progress`: the barrel visibly re-played. Where in the timeline it landed depended on when that browser moves the bar (Safari mid-run, Chrome iOS right at the start — same cause). |
+| `arcCamZ(H)`, the ortho frustum, `computeGridLayout()`, `renderer.setSize` | the composition re-fitted to the new height: a ~10% camera-distance step (measured: 624.9 → 559.5 at `progress` 0.35) plus a drawing-buffer reallocation. Reads as the "enlarge/shrink" pop, and on Safari as a stutter, because iOS delivers it all in one `resize` at settle. |
+
+A URL-bar move is now a **complete no-op**: `doLayout` re-reads the same `H` and takes its
+unchanged-`W`/`H` exit. Verified in the harness (`innerHeight` shadowed 90px smaller at a fixed
+`scrollY`): camera z identical in the formation *and* tail phases, `arcOp` identical, zero writes to
+`canvas.width`/`height`. Confirmed on-device with `gg-viewport-hud.js` (harness dir), which overlays
+`innerHeight` / a live `100vh` probe / `worldH` / the drawing buffer / a `canvas.width` write counter
+per resize event — the settle-time row reads `cvBox` and `buf` unchanged with `writes` flat.
+
+**The trade-off, deliberate:** the canvas is sized to the large viewport, so while the bar is showing
+its bottom ~50–90px sits behind the bar and the globe reads slightly larger than the visible area.
+That matches what the block's own CSS already does (`.globe-gallery-world` is `100vh`, the quote rail
+is `top: 50vh`), so the WebGL layer and the DOM chrome now agree instead of being mis-registered by
+the bar's height whenever it is visible. The alternative is re-fitting on every bar move, which is the
+artifact being removed. The modal's chrome stays on `100dvh` (its buttons must stay reachable); only
+its photo canvas rides `H`, and the scroll lock means the bar can't move while it's open.
+
+**Consequences worth knowing:**
+- **`1` while the section is hidden.** `display: none` → `offsetHeight` 0, clamped to 1 so nothing
+  divides by zero. Everything sized from `H` is recomputed at the un-hide, and the `IntersectionObserver`
+  keeps the ticker parked until then, so no frame is ever drawn at that size.
+- **`layoutObs` calls `doLayout({ fromResize: true })`** rather than measuring by hand — that un-hide
+  arrives as a body resize with *no window resize behind it*, so it is the only thing that upgrades `H`
+  at that moment. `measureBlock()` + `readCssVars()` sit above the exit so this stays exactly as cheap
+  as the bare measure it replaced. Verified (`HIDDEN=1`): the buffer starts at the clamp and lands on
+  100vh × DPR after the un-hide.
+- **Reduced motion needs no branch.** `.globe-gallery-reduced` leaves `.globe-gallery-world` at
+  `height: 100vh` and only un-sticks it, so `measureViewportH()` is exact in both modes (verified: the
+  RM drawing buffer is the same 100vh × DPR as the non-RM one). Keep it that way — a `vh` override on
+  that element would put an imprecision into the one function every clock depends on.
+- A genuine viewport change still lands: 844→600px tall moves `blockHeight` 4389→3120 and the same
+  *fraction* of the runway holds the same phase (camera z within 0.02).
+
+**Why not a viewport unit instead?** No unit choice removes the problem, because the gap is between a
+CSS length and a JS number — JS still has to learn how many px that unit produced:
+- **`lvh`** is what `vh` already means here (spec: `vh` = large viewport), so `100lvh` would be pure
+  documentation; `svh` is constant too. Neither changes anything.
+- **`dvh`** *would* make CSS agree with `innerHeight` — by making the box grow and shrink mid-scroll.
+  Put it on `.globe-gallery-world` and `H` tracks the bar again, pop included; put it on
+  `--gg-runway-height` and the runway rescales under the scroll mapping instead. Either way the
+  artifact returns by a different route. Don't.
+- **Scroll-driven animations** would hand the whole mapping to CSS, but reading progress back per
+  frame (`getComputedStyle`) is a style recalc, it can't feed `deriveFrame`'s pure clocks, and it
+  wouldn't help the render side at all.
+
 **CSS is the source of truth for all three props**, read per layout in `readCssVars()`, so retuning is
 a CSS-only edit:
 
@@ -549,25 +621,28 @@ properties exist. Two rules make an unresolved read harmless rather than somethi
 substitute value:
 
 - `readCssVars()` **leaves the previous value in place** when a property doesn't resolve, instead of
-  writing a fallback. So `formationVh` / `pqAppearZoomT` keep their declared initializers (`0` /
-  `0.5`) and can never become `NaN` — which matters because `Math.max(1, NaN)` is `NaN`, so a single
+  writing a fallback. So `formationVh` / `pqAppearZoomT` keep their declared initializers
+  (`0` / `0.5`) and can never become `NaN` — which matters because `Math.max(1, NaN)` is `NaN`, so a single
   unresolved read would otherwise poison `progress` and silently kill the animation. Its `cssNum`
   helper tests `Number.isFinite` rather than `||` so an authored `0` isn't swallowed.
 - **`0` is a safe value**, unlike `NaN`: every division in `deriveFrame` is guarded (`Math.max(1,
   formPx)`, `Math.max(1, blockHeight - formPx)`) and clamped, so a pre-stylesheet frame renders at
   `progress` 0 or 1 rather than breaking. Keep it that way — a new unguarded `/ formPx` would turn
-  this into a crash.
+  this into a crash. `measureViewportH()` clamps to `1` for the same reason: it is a divisor too.
 
-`layoutObs` then calls `readCssVars()` alongside `measureBlock()`, which is what guarantees the real
-values land. It needs no extra listener and no "already resolved" flag: `processSection` un-hides the
+`layoutObs` → `doLayout()`, whose first act is `measureBlock()` + `readCssVars()`, is what guarantees
+the real values land. It needs no extra listener and no "already resolved" flag: `processSection` un-hides the
 section (`main .section[data-status='pending'] { display: none }`) only after `Promise.all([styleLoaded,
 scriptLoaded])`, and that un-hide changes the body height, so the `ResizeObserver` is guaranteed to
 fire at least once with the stylesheet applied. Re-reading on every body resize is free next to the
-`getBoundingClientRect()` `measureBlock()` already does there.
+`getBoundingClientRect()` `measureBlock()` already does there, and `doLayout`'s unchanged-`W`/`H` exit
+means nothing beyond those two reads runs on a fire that changes neither.
 
-`measureBlock()` (from `doLayout` and `layoutObs`) sets `blockDocTop` + `blockHeight`. `blockHeight`
-is plain `offsetHeight`, itself CSS-driven, so `--gg-runway-height` is never read from JS at all — and
-needs no fallback either, since `offsetHeight` is `0` (never `NaN`) while the section is hidden.
+`measureBlock()` (`doLayout`, so also `layoutObs`) sets `blockDocTop` + `blockHeight`. `blockHeight`
+is plain `offsetHeight`, itself CSS-driven, and needs no fallback either, since `offsetHeight` is `0`
+(never `NaN`) while the section is hidden. `--gg-runway-height` is never read from JS at all — `H` comes
+off `.globe-gallery-world` instead (see **One viewport height**), so the runway's size lives in exactly
+one place.
 
 So **no JS file anywhere holds a copy of these three numbers** — not even for docs. The event table's
 `vh` column needs the runway lengths, but Milo ships `timeline.js` unbundled and byte-for-byte, so a
@@ -948,18 +1023,25 @@ resolves the preference, and persists across rebuilds, so a snapshot would go st
 normal flow. The preference is **re-read on every `initRuntime`**, and a
 `matchMedia('(prefers-reduced-motion: reduce)')` `change` listener feeds `doLayout`, so toggling
 the OS setting mid-session rebuilds through the same `destroy()`+`init()` path as a band / pointer
-change (no reload; the non-RM path clears the canvas `position`/`top` so a toggle-off reverts
-cleanly). The pieces:
+change (no reload; the non-RM path clears the canvas `position` so a toggle-off reverts cleanly).
 
-- **Canvas** — `position:absolute` + `top:8vh` (not `fixed`), inside the now-`relative`
-  `.globe-gallery-world`, so it scrolls and clips with the page; `updateCanvasVisibility` reveals it
-  once (no coverage math).
-- **`.globe-gallery-world`** — `position:relative` (was sticky); height `108vh` = 8vh + the canvas.
+**RM overrides `position` and nothing else** for the three viewport-sized boxes — no duplicated
+geometry, and `measureViewportH()` reads the same 100vh in both modes. That works because the base
+rules are written against the canvas box rather than the window: `.globe-gallery-a11y` sits at
+`top: 50vh` (not `50%`) and `.globe-gallery-a11y-cards` is a `100vh`-tall box (not `inset: 0`), so
+each resolves identically whether it's `fixed` to the viewport or `absolute` inside the
+`100vh` `.globe-gallery-world`. It also fixes the focus-ring overlay on iOS, where `inset: 0` on a
+`fixed` element tracked `innerHeight` and so mis-scaled the ring by the URL bar's height (the ring is
+positioned in canvas px). The pieces:
+
+- **Canvas** — `position:absolute` (not `fixed`), inside the now-`relative` `.globe-gallery-world`, so
+  it scrolls and clips with the page; `updateCanvasVisibility` reveals it once (no coverage math).
+- **`.globe-gallery-world`** — `position:relative` (was sticky); keeps its base `height: 100vh`.
 - **Globe size (desktop)** — the formed `md` sphere fills ~93% of viewport height, so `buildCards`
   scales `sphereGroup` by `RM_GLOBE_SCALE_MD` on md to bring the whole ball in view (rotation
   is per-card, so a group scale is safe). `sm` (~49%) stays 1.
-- **A11y widget** — `position:absolute` (was fixed), re-centred at `top:58vh` since the base
-  `top:50%` would track the taller world.
+- **A11y widget + focus-ring overlay** — `position:absolute` (were fixed); the base `top: 50vh` /
+  `100vh` box already centre on the sphere, so neither override carries any offset.
 - **Pull-quote** — drops `absolute`/`sticky` → `static`, forced `opacity:1`, hugs the top of its
   box so it sits under the globe; `updatePullQuote` early-returns (CSS owns it).
 - **Arc-copy** — `display:none` (no arc phase; a fixed pill would hang over the scrolling page).
@@ -979,16 +1061,26 @@ the cheap path (renderer/camera resize). The `resize` handler is the sole driver
 boundary — no `matchMedia` listener for 768px. The one `matchMedia` `change` listener is for
 reduced motion (see Reduced motion); pointer precision is read at init only (see Shape).
 
-**`doLayout` cost control.** `resize` fires ~once per frame during a desktop window drag, and once
-mid-scroll whenever iOS Safari collapses the URL bar (changing `innerHeight`) — the latter landing
-inside the formation animation. So the handler is split three ways:
-- Unchanged `W` **and** `H` → return immediately, skipping two WebGL buffer reallocations. Only the
-  `resize` path takes this exit (`doLayout({ fromResize: true })`); the init call and the
+**`doLayout` cost control.** `resize` fires ~once per frame during a desktop window drag. On iOS it
+does **not** fire during the URL-bar animation: `visualViewport` resizes many times as the bar moves
+(and `innerHeight` reports the new value throughout), then `window.resize` fires **once, at settle** —
+so every resize-driven cost lands in a single event, at the one moment the eye is already tracking the
+bar. Measured on-device with `gg-viewport-hud.js`; nothing here listens to `visualViewport`, so the
+animation itself costs zero. So the handler is split four ways:
+- Unchanged `W` **and** `H` → return immediately, skipping two WebGL buffer reallocations. `H` is an
+  `offsetHeight`, so that compare is exact integers. This
+  is the exit an iOS bar move takes, since `H` doesn't depend on `innerHeight` — see **One viewport
+  height**. Only the `resize` path takes it (`doLayout({ fromResize: true })`); the init call and the
   reduced-motion `change` listener run with the viewport unchanged and must still execute the body.
   Both listeners are wrapped rather than passed `doLayout` directly, or the event argument would land
   in its options object.
+- **DPR is re-applied only when it actually changed** (`appliedDpr`, and `appliedModalDpr` in
+  `modal.js`). `setPixelRatio` calls `setSize(_width, _height, false)` internally, so an unconditional
+  call reallocates the drawing buffer at the *old* dimensions immediately before our `setSize`
+  reallocates at the new ones — two full reallocations per resize, per canvas. Measured with a
+  `canvas.width`/`height` write counter: 4 writes → 2 on a genuine resize.
 - Renderer/camera/`computeGridLayout()` stay **synchronous** — a stale `W`/`H` renders the canvas
-  stretched and desyncs `formedScrollPx()`.
+  stretched and mis-sizes the arc grid against the viewport it's laid out in.
 - `buildTextMesh()` is **trailing-debounced** (`TEXT_REBUILD_DEBOUNCE_MS`), but only while
   `textMesh.visible` is false — it disposes a GPU texture, redraws a 2D canvas and uploads a new one.
   On screen it rebuilds synchronously, since a deferred rebuild would leave it stretched at the old
@@ -1008,6 +1100,21 @@ rebuild would otherwise inherit:
   it tilted until a scroll-out zeroed it.
 
 ## CSS
+
+**Viewport units — one rule per axis.** The block never reads the window in CSS either, for the same
+reason the JS doesn't (see **One viewport height**):
+
+| axis | use | never |
+| --- | --- | --- |
+| vertical | **`vh`** — resolves against the large viewport, so it matches the canvas box and holds still while the iOS URL bar moves | `%` on a `fixed`/`sticky` box (that's the *layout* viewport, which the bar shrinks: `top: 50%` put the a11y widget ~26px off the sphere whenever the bar showed), and `dvh` anywhere the scroll timeline can see |
+| horizontal | **`%`** — the containing block / ICB width, which excludes the classic-scrollbar gutter | `vw`, which *includes* it: a `vw`-sized `fixed` box is ~15px wider than the viewport on desktop, and `--gg-content-inset` built from `100vw` put the arc copy half a scrollbar off the pull-quote's column it is supposed to share |
+
+There is no `vw` left in the block. The one place two axes had to share an expression —
+`.globe-gallery-a11y`'s square — uses `width: min(80%, 80vh)` + `aspect-ratio: 1` rather than
+repeating a `min()` per axis, since `%` on `height` would mean the wrong thing. **`dvh` is the modal
+chrome only** (`.globe-gallery-modal-chrome`, the description's `max-height`): that layer *must* stay
+inside the visible viewport so its buttons stay reachable while the bar is up, and it can't disturb the
+timeline because opening the modal locks the scroll.
 
 **Tokens.** Every spacing, radius, border-width, font-size, font-weight and blur value that lands on
 an S2A scale uses the token, not the literal — including positional insets (`bottom`,
@@ -1045,7 +1152,7 @@ this block *defines* is `--gg-*`, the initials convention other C2 blocks use (`
 brand-concierge, `--rm-` in router-marquee). Nothing here defines an unprefixed property: the block
 is a full-viewport hero on shared pages, so a bare `--runway-height` or `--desc-fade-top` could
 inherit a stranger's value from an ancestor. The only props read from JS are `--gg-formation-vh` /
-`--gg-pq-pin-factor` in `readCssVars()` — grep both files before renaming one. **No prop is written
+`--gg-runway-height` / `--gg-pq-pin-factor` in `readCssVars()` — grep both files before renaming one. **No prop is written
 from JS**: where JS decides a *state*, it toggles a class and CSS owns the resulting value
 (`updateDescFade` → `.is-faded-top` / `.is-faded-bottom`, length in `--gg-desc-fade-len`), so a
 retune stays a CSS-only edit and no magic number is stranded in JS. Only `--s2a-*` tokens come from upstream, and one of them
@@ -1750,6 +1857,10 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     globe drag while `drag.isDragging` is still true — e.g. `updateHintExitProgress` skips it, or its
     hold-time term would retire the hint during ordinary scrolling. Gated on `drag.isDragging`
     (`isTouchDrag` persists after pointerup).
+  - **Both canvases are `user-select: none` + `-webkit-touch-callout: none`** (`.css`). A long press
+    on iOS Safari otherwise selects the canvas as a replaced element — blue overlay, Copy callout —
+    and the selection takes the pointer away, so WebKit fires `pointercancel` and `cancelDrag` drops
+    the in-flight spin. Scoped to the canvases, so the quote and the modal copy stay selectable.
   - No dwell needed: touch scrolling is self-terminating, so on lift the sphere is stationary and
     `sphereFormT >= 0.8` holds — scroll and spin are mutually exclusive in time. (How easy it is to
     *land* on the pristine formed globe is a pacing matter — see Open items.)

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -319,6 +319,72 @@ browse-image button's `aria-label` and the modal's `role="img"` label is the car
 **alt** (→ `alt text to be authored` when none); badge names + logos come straight from the
 authored product links.
 
+### Hanging the opening mark
+
+The pull-quote outdents its opening quote into the margin, so the first line's text meets the
+same column the rest of the quote and the name/role below it sit on. `hanging-punctuation: first`
+(`.css`) does this natively but **only in WebKit**; `hangOpeningMark` (`authoring.js`) reproduces
+it everywhere else by measuring the mark and setting a negative `text-indent`.
+
+**Measured, not tabulated.** The mark and its width both change by locale — `“` (~0.49em), `«`,
+`„`, `「` (a full em) — and *which* mark appears comes from the **authored copy, not the page's
+locale**: a `de` page whose translator typed `"` gets ASCII, not `„`. So the code tests the first
+character and measures that glyph in the font the locale actually resolved, rather than keeping a
+per-locale table that would be both unmaintainable and keyed on the wrong thing.
+
+**Which characters count** — Unicode general categories, matching the set CSS Text hangs, so the
+fallback and WebKit's native path act on identical characters:
+
+| Category | Meaning | Examples |
+| --- | --- | --- |
+| `Ps` | open bracket | `(` `「` `（` — and `„` `‚`, which Unicode files as brackets, not quotes |
+| `Pi` | initial quote | `“` `‘` `«` `‹` |
+| `Pf` | final quote | `”` `’` `»` `›` — several locales **open** on these (sv/fi `”`, da `»`) |
+| + `"` `'` | ASCII | category `Po`, since one character serves as both opener and closer |
+
+Categories rather than a literal list, so a new locale needs no code change. `Pe` closers (`」`),
+dashes, and the rest of `Po` (`!` `¿`) are excluded.
+
+**Full-width CJK brackets are skipped**, on two tests: the mark measuring **≥ 0.8em** (`「『（`
+run ~0.96em; the widest Latin quote, `«`, is ~0.55em, so the gap is wide and the cutoff is not
+delicate), or simply **exceeding the padding**, where it would be shoved past the viewport edge
+into the block's `overflow-x: clip` and sheared. Either way the code suppresses the hang
+**including WebKit's native one** — only a measurement can detect these limits, which CSS can't
+express — so every browser lands on the same result.
+
+The width test is what makes that result **breakpoint-independent**, and it is load-bearing rather
+than belt-and-braces. Both inputs to the padding test move: `--gg-copy-pad` steps 24→48→64 (see
+Crosshair frame) and `heading-1` steps 40→56→80px, and they step at *different* widths. On the
+padding test alone, `768–1023` is a band where the padding has already grown to 48px but the type
+is still 40px, so a `「` fits and hangs there while being suppressed at every other size. Worse,
+the measurement runs once at init and is never recomputed, so a resize from that band up to
+`1280` would strand a 0.96em hang against a 48px pad and shear it.
+
+Covering CJK is a different rule rather than a smaller number: JIS sets a line-head opening
+bracket half-width, aligning its *ink* to the margin instead of aligning the following character
+to the column. Worth building only if a CJK locale ships this block.
+
+**Implementation notes** — each of these is load-bearing:
+
+- Runs after `document.fonts.ready`; Adobe Clean's metrics differ from the fallback font's, so
+  measuring earlier bakes in the wrong advance.
+- Canvas, not `getBoundingClientRect`: the pull-quote sits under `transform: scale(.9)` until it
+  activates, which scales a client rect but not a canvas measurement.
+- The **advance**, not the ink width, is what lands the second character on the column — and
+  `measureText` omits `letter-spacing`, which `heading-1` sets, so it is added back.
+- Emitted in `em`, not px. `heading-1` is **responsive** (40px → 56px at 1024 → 80px at 1280), so
+  a px indent would go stale on every breakpoint crossing; the em ratio holds without a recompute.
+  It holds only *approximately* — `letter-spacing` is a fixed px that does not scale with the type,
+  so the ratio drifts ~0.02em (≈1px at 80px) across breakpoints. Also covers text-only zoom.
+- Accurate to the pixel while the webfont is up. If Adobe Clean is missing the stack falls to c2's
+  `Arial Bold Adjusted`, whose `size-adjust: 92%` layout applies but the canvas measurement does
+  not, leaving the hang ~1px out at 80px type. Invisible, and only on the fallback path — but it is
+  why this measures the glyph rather than trusting the number to be exact.
+- `textContent` is trimmed first: authored markup arrives with newlines and indentation, which
+  collapse in rendering but would otherwise defeat the first-character test.
+- The `ctx.font` readback guards a silent failure — canvas ignores an unparseable shorthand and
+  keeps its `10px sans-serif` default, which would measure a small, plausible, wrong advance.
+
 ## Architecture notes
 
 **DOM is JS-built and scoped to the block root.** `init(el)` calls
@@ -809,6 +875,42 @@ copy on the inset; at md+ the pill background is gone, so the box is offset back
 Before this, `updateArcCopy` positioned the box per-frame from a 1392px content grid
 (`24 + max(0, (W - 48 - 1392) / 2)`), which put the arc copy 16px inboard of the pull-quote below
 1440px and up to 256px inboard above it (1920px viewport: copy at 280px vs the quote's 24px).
+
+### Crosshair frame
+
+`--gg-copy-pad` steps **24px → 48px (≥768) → 64px (≥1440)**, and the pull-quote draws a hairline
+crosshair on it — so the quote's own text edge lands on the vertical line, and the hanging opening
+mark is the one thing outside it. Because that var also feeds `--gg-content-inset`, **the arc copy
+widens with it** — the two share one edge by design, so they still cannot drift.
+
+| Width | `--gg-copy-pad` | Token |
+| --- | --- | --- |
+| < 768 | 24px | `--s2a-spacing-lg` |
+| 768–1439 | 48px | `--s2a-spacing-3xl` |
+| ≥ 1440 | 64px | `--s2a-spacing-4xl` |
+
+Note this uses c2's **grid** breakpoint (768, where `--grid-columns` becomes 12) for the first step
+and its **token tier** `xl` (1440) for the second. c2's responsive token tiers are `sm` = base,
+`md` = 1024, `lg` = 1280, `xl` = 1440 — so lg (1280–1439) holds md's 48px here.
+
+Drawn as two pseudo-elements on `.globe-gallery-pullquote`, not four: `::before` insets top/bottom
+and borders its block edges, `::after` insets inline and borders its inline edges. Each pair spans
+the full box instead of stopping at the corners, so the runs **cross** and read as a crosshair
+rather than a closed rectangle. They are `position: absolute`, which both keeps them out of the
+flex flow (an abspos child of a flex container is not a flex item) and lets them inherit the
+parent's fade and `scale(.9)→1`, so the frame animates in with the quote.
+
+Two constraints worth not re-deriving:
+
+- The reduced-motion pull-quote is `position: **relative**`, not `static`. Static would drop it as
+  a containing block and the pseudos would resolve against `.globe-gallery`, stretching the frame
+  over the whole runway.
+- The block padding lives in `--gg-pq-pad-block`, which feeds both `padding-block` and the
+  `::before` `inset-block`. It holds *two* values, so the reduced-motion variant overrides the one
+  property (`10vh 8vh`) and the crosshair follows — no second rule, and no way to move the padding
+  without the lines moving with it.
+- Widening the padding gives the hanging quote more room, which is exactly what makes the
+  measured hang's fit test breakpoint-dependent — see **Localization → Hanging the opening mark**.
 
 ## Analytics
 

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -666,9 +666,9 @@ cards       ###arc##|#####peel to grid######|..........peel done............
                        |##################fold to sphere####################
 camera      ..ortho.|#############perspective -> CAM_Z_SPHERE###############
 arc-copy    ######visible######|~~~~~~~~~~~~~~fade out~~~~~~~~~~~~~~~|gone..
-hint text   ....hidden...|##############warp in -> faint rest###############
+hint text   ....hidden...|#############warp in -> faint##############|#rest#
 depth sort  ................off................|############on##############
-input       ........................inert.......................|###live####
+input       ..........................inert..........................|#live#
 ```
 
 The overlap in the top two lanes is the point of `FOLD_PEEL_OVERLAP`: the first cards begin folding
@@ -706,8 +706,9 @@ constant moves, don't hand-edit. `vh` assumes the `CSS_FALLBACK` runway/formatio
 | 90 | 0.096 | `ARC_COPY_OUT_FORM_START` of the fold window | **arc-copy starts fading out** | `updateArcCopy` |
 | 156 | 0.165 | `arcPanT = PROGRESS_GRID_ARC_END` | last card lands in the grid (`gridFormT` = 1) | `updateCardTransform` |
 | 170 | 0.180 | `sphereFormT > DEPTH_SORT_FORM_T` | `renderer.sortObjects` on (arc needs manual order, sphere needs depth sort) | `tick` |
-| 251 | 0.265 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` | hover / drag / click / auto-rotate go **live**; a11y browse enabled | `updateSphereRotation`, `updateCardTransform` |
+| 273 | 0.289 | first card's `fdE` hits 1 | earliest card actually **on the shell** (`sphereFormT` ≈ 0.884) | `updateCardTransform` |
 | 277 | 0.294 | `ARC_COPY_OUT_FORM_END` of the fold window | **arc-copy fully gone** | `updateArcCopy` |
+| 277 | 0.294 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` | hover / drag / click / auto-rotate go **live**; a11y browse enabled; desktop cursor appears; hint-plane entrance **resolves** (warp → 0) | `updateSphereRotation`, `updateCardTransform`, `cursor.update`, `updateClickDragText` |
 | 304 | 0.322 | `SPHERE_FORMED_PROGRESS` | sphere/barrel formed; `sphereFormT` = 1, `zoomT` leaves 0; keyboard focus snaps here | `computeFrame` |
 | 376 | 0.548 | `zoomT ≥ 1 / TEXT_ZOOM_FADE_RATE` | hint text fully faded | `updateClickDragText` |
 | 369 / 395 | 0.525 / 0.607 | camera passes the cards | globe clears the viewport — sm ≈ `zoomT` 0.30, md ≈ 0.42 | `updateActiveCamera` |
@@ -751,6 +752,7 @@ row('fold starts / sphereFormT>0', T.FOLD_FIRST_PROGRESS);
 row('hint text appears', T.progressAtFormT(T.TEXT_APPEAR_START));
 row('arc-copy fade start', T.ARC_COPY_OUT_START);
 row('depth sort on', T.progressAtFormT(T.DEPTH_SORT_FORM_T));
+row('first card on the shell', T.cardFoldStartProgress(0) + T.PROGRESS_FOLD_DUR);
 row('interactive', T.progressAtFormT(T.SPHERE_INTERACTIVE_T));
 row('arc-copy gone', T.ARC_COPY_OUT_END);
 row('SPHERE FORMED', T.SPHERE_FORMED_PROGRESS);
@@ -1143,7 +1145,14 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   surface (`z = −(SPHERE_R + TEXT_BEHIND_GAP)`, `renderOrder = -1`), so it rotates with the globe and
   draws behind the cards. Hidden until `sphereFormT > TEXT_APPEAR_START`, then warps in (barrel
   warp + particle dissolve via `TEXT_FRAG`), settles to a faint resting opacity (`TEXT_OPACITY_PEAK
-  0.15 → RESTING 0.06`), fades out over the zoom. Sized to fill the frustum at its live camera
+  0.15 → RESTING 0.06`), fades out over the zoom. **The entrance resolves on
+  `SPHERE_INTERACTIVE_T`, not at `sphereFormT` 1**: `sfT` remaps `[TEXT_APPEAR_START,
+  SPHERE_INTERACTIVE_T]`, so the warp reaches 0 exactly when the globe goes live and the cursor
+  arrives. Running it to 1 (the original) left the hint still visibly warping in for 27vh *after* the
+  thing it names was already draggable — measured `uWarp` 0.946 of `TEXT_WARP_ENTER_MAX` 4.5 still
+  active at the gate, now 0.002. The plane's *scale* is unaffected and keeps tracking `foldSphDist`
+  to 1.0 at `sphereFormT` 1; that is distance compensation, not entrance, and holds apparent size
+  constant. Sized to fill the frustum at its live camera
   distance (`textPlaneSize` × a per-frame scale off `frame.foldSphDist`), with warp-proportional
   overflow so letterforms bleed off-screen. On **first drag** it dissolves away permanently:
   `textExitProgress` (0→1, from drag distance + hold time + velocity) drives the shader's `uExitP`;
@@ -1420,9 +1429,20 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     (0.25 → −0.20 clearance). `0` is an exact cylinder. The layout returns a per-card **`normal`**
     and `buildCards` aims each card along it (target = `pos − normal`, since `lookAt` points local +Z
     from target toward eye) — a plain `lookAt` at the axis would ignore the slope.
-  - **Near-camera fade scales with each card's OWN rendered height** (`card.sphereWorldH`), not
-    `bp.CARD_H_SPHERE` (only the `PlaneGeometry` base on this path; solved heights run 8.7–19.6). Per
-    card gives every card the intended ~1.85× fill-margin at any band/count/bulge.
+  - **Near-camera fade bands off ONE wall-wide height** (`fadeRefH`, the mean `sphereWorldH`,
+    recomputed alongside `dragFlipZ`) — **not** each card's own height, and not `bp.CARD_H_SPHERE`
+    (only the `PlaneGeometry` base on this path). Per-card was the original choice, for a constant
+    fill-margin, but it makes the trigger a function of *size* while the metric is *depth*, and on
+    this layout those fight: heights span ~2.4× (measured 6.5–15.9), so a tall card starts dissolving
+    ~2.4× farther out than a short one at the same azimuth. Since `pack` places **tallest-first at
+    `offset = 0`** — the top of each column — the tall cards ARE the top row, so the top row always
+    went first and the physically nearest card often went last (measured at `camZ 39.5`: the closest
+    card, depth 23.6, was 31% dispersed while one 5 units *farther* was 96%). One shared band restores
+    the read the fly-through wants: nearest goes first, and since a barrel column shares one azimuth
+    (hence one `z`), the whole column — top, middle and bottom — comes apart together. The cost is
+    that a tall card is a bigger share of the frame when it finally vanishes; `NEAR_FADE_START`/`_END`
+    are the dial if that goes too far. `dragFlipZ` uses `fadeRefH` too, so the flip still lands
+    exactly where cards vanish.
   - **Drag-flip threshold is DERIVED, not `SPHERE_R`** (`dragFlipZ = maxRadial + NEAR_FADE_END ×
     CARD_H_SPHERE`, in `buildCards`, read by `updateActiveCamera`). Once the camera is inside the
     shell the far wall moves opposite the same rotation, so the drag delta is negated. Firing at the
@@ -1541,6 +1561,16 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     constant across window sizes: a bigger ball on screen needs *fewer* rad/px, which one fixed
     number got wrong in both directions — over-geared on a tall desktop window, under-geared on a
     phone. Drag by the ball's on-screen radius and it turns `90° × DRAG_GEARING`.
+  - **`SPHERE_INTERACTIVE_T` is 0.9, not 0.8, because 0.8 is ahead of every card.** Cards land
+    between `sphereFormT` 0.884 (the first) and exactly 1 (the last — its fold end *is*
+    `SPHERE_FORMED_PROGRESS`), so at 0.8 the drag was spinning a swarm still mid-assembly and a tap
+    was being refused on cards that already read as part of the globe. Both went through the same
+    gate, in opposite kinds of wrong. 0.9 sits just past the first landing: something is on the shell
+    to grab and to click. ONE constant for **everything** that says or does "the globe is live":
+    hover, click, drag, auto-rotate, the desktop cursor, and the GL hint plane's entrance. A separate
+    earlier gate for the cursor was tried and reverted — it put the affordance 26vh ahead of the
+    input it advertises, which reads worse than a late cursor. Raycasting was never the problem at
+    any value: a tap below the gate hits (`hits: 1`, harness-measured), `onPointerUp` discards it.
   - **Inertia coasts below `SPHERE_INTERACTIVE_T`; only `SPHERE_ORIENT_RESET_T` zeroes it.**
     Hard-zeroing at the interactive gate stopped a released spin dead whenever the page was still
     settling across it. A drag *started* below the gate stays inert and can't fling on release, and

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -495,8 +495,8 @@ Formation is **locked** to a fixed scroll length, so `--gg-runway-height` sets t
 Within the tail, `zoomT = clamp((scroll − formation) / (runway − formation), 0, 1)` drives the camera
 (`CAM_Z_SPHERE → CAM_Z_END`), the cursor retirement, and the pull-quote.
 
-**CSS is the source of truth for all three props**, read per layout in `doLayout`, so retuning is a
-CSS-only edit:
+**CSS is the source of truth for all three props**, read per layout in `readCssVars()`, so retuning is
+a CSS-only edit:
 
 | prop | per breakpoint | effect |
 |---|---|---|
@@ -504,18 +504,37 @@ CSS-only edit:
 | `--gg-formation-vh` | same at both | locked formation length |
 | `--gg-pq-pin-factor` | **lower at md+** | share of the tail the (bottom-anchored) quote pin occupies → its hold |
 
-`timeline.js`'s exported `CSS_FALLBACK` is the **only** JS copy of these numbers, read only when a
-property fails to resolve — possible because `loadBlock` races a block's stylesheet against its script
-(`libs/utils/utils.js:1369`), and an unresolved property parses to `NaN`, which would propagate into
-`progress` and kill the animation silently. It is not a second source of truth: if it and CSS
-disagree, CSS wins and `CSS_FALLBACK` is simply stale. Nothing else in JS may re-inline these values.
-`timeline.js` stays pure (no DOM), so `doLayout` does the reading, via a `cssNum(prop, fallback)`
-helper testing `Number.isFinite` rather than `||` so an authored `0` isn't swallowed.
+**No JS fallback copy of these numbers exists**, so CSS cannot be quietly overridden by a stale
+literal. That takes some care, because `loadBlock` races a block's stylesheet against its script
+(`libs/utils/utils.js:1370`), so the `readCssVars()` call in `initRuntime` can run before the
+properties exist. Two rules make an unresolved read harmless rather than something needing a
+substitute value:
+
+- `readCssVars()` **leaves the previous value in place** when a property doesn't resolve, instead of
+  writing a fallback. So `formationVh` / `pqAppearZoomT` keep their declared initializers (`0` /
+  `0.5`) and can never become `NaN` — which matters because `Math.max(1, NaN)` is `NaN`, so a single
+  unresolved read would otherwise poison `progress` and silently kill the animation. Its `cssNum`
+  helper tests `Number.isFinite` rather than `||` so an authored `0` isn't swallowed.
+- **`0` is a safe value**, unlike `NaN`: every division in `deriveFrame` is guarded (`Math.max(1,
+  formPx)`, `Math.max(1, blockHeight - formPx)`) and clamped, so a pre-stylesheet frame renders at
+  `progress` 0 or 1 rather than breaking. Keep it that way — a new unguarded `/ formPx` would turn
+  this into a crash.
+
+`layoutObs` then calls `readCssVars()` alongside `measureBlock()`, which is what guarantees the real
+values land. It needs no extra listener and no "already resolved" flag: `processSection` un-hides the
+section (`main .section[data-status='pending'] { display: none }`) only after `Promise.all([styleLoaded,
+scriptLoaded])`, and that un-hide changes the body height, so the `ResizeObserver` is guaranteed to
+fire at least once with the stylesheet applied. Re-reading on every body resize is free next to the
+`getBoundingClientRect()` `measureBlock()` already does there.
 
 `measureBlock()` (from `doLayout` and `layoutObs`) sets `blockDocTop` + `blockHeight`. `blockHeight`
-is `offsetHeight`, itself CSS-driven, so `--gg-runway-height` is never read directly; `offsetHeight`
-is `0` only before the stylesheet applies, when the property wouldn't resolve either — hence the
-fallback there is `CSS_FALLBACK.RUNWAY_VH`.
+is plain `offsetHeight`, itself CSS-driven, so `--gg-runway-height` is never read from JS at all — and
+needs no fallback either, since `offsetHeight` is `0` (never `NaN`) while the section is hidden.
+
+So **no JS file anywhere holds a copy of these three numbers** — not even for docs. The event table's
+`vh` column needs the runway lengths, but Milo ships `timeline.js` unbundled and byte-for-byte, so a
+doc-only export would ride along in every page's payload; the derivation snippet reads them out of
+`globe-gallery.css` instead (see **Re-deriving these numbers**). Don't reintroduce one.
 
 sm uses a **bigger** pin factor than md on purpose: its globe clears earlier (`zoomT≈0.30` vs md
 `≈0.42`), so the quote can start sooner *and* hold longer — which sm needs, because the fixed 583px
@@ -525,7 +544,7 @@ above it the fade-in would cross md's globe-clear and land the quote over the gl
 **Pull-quote timing is derived, not hand-set.** The pin height is `(runway − formation) ×
 --gg-pq-pin-factor`, so it always exits exactly at the runway end (no dead scroll), and the JS fade-in
 threshold `pqAppearZoomT = (1 − --gg-pq-pin-factor) − PQ_APPEAR_LEAD` is **read from the CSS var in
-`doLayout`** — so the pin geometry and the opacity trigger can't drift, per breakpoint or across a
+`readCssVars()`** — so the pin geometry and the opacity trigger can't drift, per breakpoint or across a
 768px resize. Higher `--gg-pq-pin-factor` → quote appears earlier **and** holds longer (they trade off at
 a fixed runway); to change both together, move `--gg-runway-height`.
 
@@ -691,8 +710,8 @@ canvas      ###########################visible##########################|...
 ### Event table
 
 The `vh` and `progress` columns are **derived** — regenerate them with the snippet below when a
-constant moves, don't hand-edit. `vh` assumes the `CSS_FALLBACK` runway/formation defaults;
-`progress` and the gate columns are runway-independent.
+constant moves, don't hand-edit. `vh` is relative to the runway/formation lengths the snippet scrapes
+from `globe-gallery.css`; `progress` and the gate columns are runway-independent.
 
 | vh | `progress` | gate | what happens | where |
 | ---: | ---: | --- | --- | --- |
@@ -736,13 +755,21 @@ to "the fold has started" should gate on `gridFormT`/`fdE` if it must match the 
 ### Re-deriving these numbers
 
 `timeline.js` is importable on its own (no THREE, no DOM), so this reads the **live** constants
-rather than restating them — it cannot drift from the code:
+rather than restating them — it cannot drift from the code. The two runway lengths are scraped out of
+the stylesheet for the same reason: they belong to CSS, and shipping a JS copy of them just to
+generate a table would put doc-only bytes in every page's payload.
 
 ```sh
 cd libs/mep/ace1209/globe-gallery && node --input-type=module -e "
+import { readFileSync } from 'node:fs';
 import * as T from './src/timeline.js';
-const { RUNWAY_VH, FORMATION_VH } = T.CSS_FALLBACK; // = the CSS defaults
+const css = readFileSync('./globe-gallery.css', 'utf8');
+const cssVh = (p) => parseFloat(css.match(new RegExp(p + ':\\\\s*([0-9.]+)vh'))[1]);
+const FORMATION_VH = cssVh('--gg-formation-vh');
+const RUNWAY_VH = cssVh('--gg-runway-height');
 const tail = RUNWAY_VH - FORMATION_VH;
+const atZoomT = (t) => T.SPHERE_FORMED_PROGRESS
+  + t * (T.PROGRESS_ZOOM_END - T.SPHERE_FORMED_PROGRESS);
 const vh = (p) => (p <= T.SPHERE_FORMED_PROGRESS
   ? (p / T.SPHERE_FORMED_PROGRESS) * FORMATION_VH
   : FORMATION_VH
@@ -756,9 +783,9 @@ row('first card on the shell', T.cardFoldStartProgress(0) + T.PROGRESS_FOLD_DUR)
 row('interactive', T.progressAtFormT(T.SPHERE_INTERACTIVE_T));
 row('arc-copy gone', T.ARC_COPY_OUT_END);
 row('SPHERE FORMED', T.SPHERE_FORMED_PROGRESS);
-row('hint text faded', T.progressAtZoomT(1 / T.TEXT_ZOOM_FADE_RATE));
-row('cursor label / retire', T.progressAtZoomT(T.CURSOR_ZOOM_RETIRE_T));
-row('canvas hidden', T.progressAtZoomT(T.CANVAS_HIDE_ZOOM_T));
+row('hint text faded', atZoomT(1 / T.TEXT_ZOOM_FADE_RATE));
+row('cursor label / retire', atZoomT(T.CURSOR_ZOOM_RETIRE_T));
+row('canvas hidden', atZoomT(T.CANVAS_HIDE_ZOOM_T));
 "
 ```
 
@@ -973,9 +1000,11 @@ with a reader's browser font-size setting — the intended C2 behaviour, and why
 this block *defines* is `--gg-*`, the initials convention other C2 blocks use (`--bc-` in
 brand-concierge, `--rm-` in router-marquee). Nothing here defines an unprefixed property: the block
 is a full-viewport hero on shared pages, so a bare `--runway-height` or `--desc-fade-top` could
-inherit a stranger's value from an ancestor. Props read or written from JS
-(`--gg-pq-pin-factor` in `doLayout`, `--gg-desc-fade-top` / `--gg-desc-fade-bottom` in
-`updateDescFade`) are the coupling points — grep both files before renaming one. Only `--s2a-*` tokens come from upstream, and one of them
+inherit a stranger's value from an ancestor. The only props read from JS are `--gg-formation-vh` /
+`--gg-pq-pin-factor` in `readCssVars()` — grep both files before renaming one. **No prop is written
+from JS**: where JS decides a *state*, it toggles a class and CSS owns the resulting value
+(`updateDescFade` → `.is-faded-top` / `.is-faded-bottom`, length in `--gg-desc-fade-len`), so a
+retune stays a CSS-only edit and no magic number is stranded in JS. Only `--s2a-*` tokens come from upstream, and one of them
 (`--s2a-font-letter-spacing-neg-0_48`) has an underscore, which is why `custom-property-pattern` is
 disabled on that single line rather than file-wide.
 
@@ -1658,8 +1687,8 @@ self-evident from the name:
 ### `timeline.js` constants
 
 Most of this file's exports are documented where they matter: the `P_*` phase constants and
-`FOLD_PEEL_OVERLAP` under Phase constants; `CSS_FALLBACK` /
-`PQ_APPEAR_LEAD` under Scroll model; `ENTRY_LEAD_VH` / `ENTRY_RAMP_VH` under Entry timing; and
+`FOLD_PEEL_OVERLAP` under Phase constants; `PQ_APPEAR_LEAD` under Scroll model;
+`ENTRY_LEAD_VH` / `ENTRY_RAMP_VH` under Entry timing; and
 every gate threshold in the Lifecycle timeline event table. The remainder — carried in code as
 bare names — are:
 
@@ -1675,7 +1704,7 @@ bare names — are:
 | `TEXT_ZOOM_FADE_RATE` | `zoomT` | hint text is fully faded at `zoomT` = `1 / RATE` |
 | `GRID_PEEL_WINDOW` | `gridFormT` | `1 − GRID_PEEL_STAGGER`; the span each card's peel occupies after its stagger delay (`frame.gpWin`) |
 | `GRID_ARC_RANGE` / `FOLD_WINDOW` | — | derived spans: `PROGRESS_GRID_ARC_END − _START`, and `SPHERE_FORMED_PROGRESS − FOLD_FIRST_PROGRESS` |
-| `progressAtFormT` / `progressAtZoomT` | — | helpers mapping a `sphereFormT` / `zoomT` back to progress. For docs and tests — not called per frame |
+| `progressAtFormT` | — | maps a `sphereFormT` back to progress; used to derive `ARC_COPY_OUT_START` / `_END`. Nothing here exists only for docs — Milo ships these files unbundled, so a doc-only export is pure payload (the `zoomT` inverse lives in the derivation snippet instead) |
 
 ## Open items / backlog
 

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -1239,18 +1239,30 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   rounded rect — the quad IS the card, and `rrSDF` zeroes everything beyond it — so the fade read as
   pixels dying inside a frame. In `CARD_FRAG` / `CARD_DISPERSE_VERT`:
   - **The quad overscans.** `CARD_DISPERSE_VERT` scales `position.xy` by `s + j/(uAspect, 1)`, where
-    `s = 1 + e × DISPERSE_EXPAND` is the cloud's radial reach and `j` is the jitter margin (absolute,
+    `s = 1 + uDisperse × DISPERSE_EXPAND` is the cloud's radial reach and `j` is `DISPERSE_MARGIN`,
+    jitter's share of it (absolute,
     in card heights — hence the `/uAspect`), and stretches `vUv` to match. Card-space uv therefore
     runs *past* `[0,1]`, which is the room the flying grains need. Hit-testing is untouched (raycasts
     use the geometry, not the shader).
-  - **Per-grain lift-off, not a uniform expansion.** Each grain cell holds a lottery number `det`;
-    once the ramp `e = dispRamp(uDisperse)` passes it, that grain has detached and is `t` of the way
-    through its flight, so `sg = 1 + EXPAND × spd × t`. A detached grain drawn at `pos` reads its
-    content from `pos / sg`; a grain that hasn't lifted off keeps `sg = 1` and renders exactly as
-    before. **That split is the whole trick**: at any instant most grains are still in place, so the
-    photo stays readable while the detached minority spreads over a growing cloud. `t` is normalised
-    by `1 − det` so a grain's flight is monotonic — using the lottery value as the speed instead makes
-    grains fly out and then come *back* as the ramp advances.
+  - **Per-CHUNK lift-off, not a uniform expansion.** Each chunk holds a lottery number `det`; once
+    `uDisperse` passes it, that chunk has detached and is `t` of the way
+    through its flight, so `sg = 1 + EXPAND × spd × t`. A detached chunk drawn at `pos` reads its
+    content from `pos / sg`; a chunk that hasn't lifted off keeps `sg = 1` and renders exactly as
+    before. **That split is the whole trick**: at any instant most of the card is still in place, so
+    the photo stays readable while the detached part spreads over a growing cloud. `t` is normalised
+    by `1 − det` so a flight is monotonic — using the lottery value as the speed instead makes chunks
+    fly out and then come *back* as the ramp advances.
+  - **Two grain scales, on purpose.** Flight is decided on a COARSE grid (`DISPERSE_CHUNKS` per card
+    height) while the RGB kill-dither stays on the finer `GRAIN_CELLS` grid. Chunks carry a coherent piece of
+    photo, so what flies reads as *debris* — deciding flight on the fine grid instead sprays
+    structureless 1px dust, which looks like noise rather than a card coming apart. The fine dither
+    on top keeps eroding each chunk while it travels.
+  - **Lift-off is rim-first** (`DISPERSE_EDGE_LEAD`): `det` is divided by `1 + rim × EDGE_LEAD`, where
+    `rim` is the destination's proximity to the card's edge, so the outline is the first thing to go.
+  - **The silhouette is eroded per chunk** (`DISPERSE_ERODE`, card heights, scaled by `uDisperse`) — a random
+    bite added straight onto `srcSD`. Without it the surviving in-place chunks still trace a clean
+    rounded rect with 1px AA, so the card's **border stays legible right through the explosion**,
+    which is exactly the "still bounded by a box" read this is meant to avoid.
   - **No thinning term, and nothing keyed to the border.** A fragment at radius `f` only draws if its
     own cell's flight reached that far, so coverage outward is just the odds of a grain being that
     fast — the falloff is free, and it's continuous through the card's old edge. Two earlier attempts
@@ -1258,19 +1270,39 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     gate) puts a hard seam at the border and reads as a box inside a box — a 回; and expanding
     *every* grain scrambles the still-opaque photo and, with a density-conserving `1/sg²` thinning,
     dusts the card away long before it reaches the lens.
-  - **`DISPERSE_EXPAND` is the "how dramatic" dial**, and it costs **fill**: the quad grows to
-    `1 + EXPAND` per axis (plus jitter), so `2.0` is ~13× the card's pixels at full dispersion —
-    affordable only because `CARD_FRAG` computes its alpha first and **discards zero-alpha fragments
-    before the three texture fetches** (most of the cloud's bounding box is empty). Keep that
-    ordering if you touch the shader. The `dispRamp` exponent (in `DISPERSE_RAMP`, deliberately < 1) front-loads
-    lift-off because `uDisperse` near 1 means the card is nearly transparent — a late ramp hides the
-    whole effect. For the same reason the prox opacity ramp is biased late
+  - **The melt is netted against `uDisperse`** (`melt = max(uDissolve − uDisperse, 0)`). The melt is
+    a *uniform* magnification of the whole card, so running it alongside the explosion reads as the
+    image swelling from its centre on one clock while debris leaves on another — two motions, out of
+    sync. The explosion owns the motion in the sphere phase; the melt is left to the texture-ready
+    reveal, which is the path that still needs it (`uDisperse` is 0 there).
+  - **`DISPERSE_EXPAND` is the "how dramatic" dial**, and what it costs is **fill**: the quad grows
+    to `1 + DISPERSE_EXPAND` per axis plus `DISPERSE_MARGIN`, and the square of that is the card's
+    pixel count at full dispersion (an order of magnitude at the current setting). Three things keep
+    it affordable, all load-bearing — measured on-vs-off, the effect costs ~10% of frame time in the
+    zoom-through, and that held when `DISPERSE_EXPAND` was raised by half again, i.e. the cost tracks
+    the grains actually drawn, not the bounding box:
+    - **`placeSphereCard` skips the draw once `proxFade` hits 0** (`mesh.visible`). Those cards are
+      fully transparent *and* at maximum overscan, so they were the most expensive thing on screen
+      while contributing nothing: culling them cut the worst frame's overscan-weighted card area
+      by ~3×. It sets `visible` rather than returning early — an early return leaves the
+      transform stale, which scroll jitter shows as a flash.
+    - **`CARD_FRAG` resolves alpha first and discards before its three texture fetches**, so the
+      empty part of the cloud's bounding box costs a few ALU ops. Keep that ordering.
+    - **Both effect blocks are gated on a uniform** (`uDisperse > 0`, `uDissolve > 0`), so the branch
+      is coherent across the draw and a card in any other phase pays nothing: no chunk/grain hashes,
+      and `srcSD`/`a` fall back to the plain `dsd`/`shapeA` instead of a second `rrSDF`.
+    The lift-off ramp (`NEAR_FADE_DISPERSE_RAMP`, deliberately < 1) is applied **in the core**, not
+    the shader — it's uniform-valued, so a `pow` per vertex *and* per fragment bought nothing. It
+    front-loads lift-off because `uDisperse` near 1 means the card is nearly transparent — a late
+    ramp hides the whole effect. For the same reason the prox opacity ramp is biased late
     (`NEAR_FADE_OPACITY_BIAS`): the grain mask already carries the fade, and a linear ramp muted
     the grains exactly as they flew.
   - **The mask is evaluated at the grain's ORIGIN** (`srcSD`), so a detached grain draws only if it
     started inside the card; its AA band is `px / sg`, since one destination pixel is `1/sg` of a
     pixel back at the origin. The UNdisplaced `dsd` stays the source for the contour and the `fwidth`
     AA width (a displaced `fwidth` explodes on per-cell noise).
+  - **Chunk randomness comes from two hashes, not five.** `det`/`spd` are hashed; `erode` and the
+    jitter vector are `fract`-derived off them. Visually indistinguishable, and this is the hot path.
   - **Dispersion is near-camera only.** `uDissolve` is shared with the texture-ready reveal (see
     Progressive texture loading), which must un-dissolve *in place* — hence a second uniform, reset
     to 0 every frame in the non-sphere default block. With `uDisperse` at 0 every added term is
@@ -1582,7 +1614,10 @@ self-evident from the name:
 | `ARC_DENSE_SPLIT` | fanT | boundary between the clustered off-screen flank and the visible spread |
 | `NEAR_FADE_START` / `_END` | card-heights | depth in front of the lens where the near-camera dissolve starts / completes |
 | `NEAR_FADE_OPACITY_BIAS` | exponent | on the prox opacity ramp; `< 1` holds the card visible longer so the dispersing grains read (the grain mask carries the fade) |
-| `DISPERSE_EXPAND` / `_JITTER` (`shaders.js`) | × card radius / fraction | how far the fastest grain flies (the "how dramatic" dial) / its sideways wander as a fraction of its own travel. Shared by the vertex overscan and the fragment scatter; costs fill, since the quad grows to `1 + EXPAND` per axis |
+| `NEAR_FADE_DISPERSE_RAMP` | exponent | on `uDisperse`; `< 1` front-loads lift-off. Applied here, not in the shader — it's uniform-valued, so a per-fragment `pow` bought nothing |
+| `DISPERSE_EXPAND` / `_JITTER` (`shaders.js`) | × card radius / fraction of own flight | how far the fastest chunk flies (the "how dramatic" dial) / its sideways wander. Both feed the vertex overscan AND the fragment scatter, via `DISPERSE_MARGIN` (derived — never hand-copy it, or the two stages drift and chunks clip at the quad edge) |
+| `DISPERSE_CHUNKS` / `_ERODE` / `_EDGE_LEAD` (`shaders.js`) | per card height / card-heights / ratio | debris grid the flight is decided on / random bite out of the silhouette, so no clean border survives the explosion / extra lift-off odds at the rim vs the middle |
+| `GRAIN_CELLS` (`shaders.js`) | per card height | the dissolve's RGB grain grid — finer than `DISPERSE_CHUNKS`. Both grids are laid out in the card's OWN uv (× `uAspect`, so cells stay square and travel with the card rather than swimming in screen space) |
 | `SPHERE_DRAG_WARP_BASELINE` / `_VEL` / `_MAX` | uWarp | barrel-warp while dragging: constant baseline + a velocity-driven burst (decays with `DRAG_FRICTION`), capped |
 | `TEXT_BEHIND_GAP` | world units | how far the hint plane sits behind the sphere's back surface |
 | `TEXT_WARP_ENTER_MAX` | uWarp | at the hint's entrance (barrel distortion) |

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -739,6 +739,125 @@ profiles: sm is the unscoped `.globe` base, then `@media (min-width:768px)` (md)
 layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted panels) base,
 `min-width:768px` overrides to the desktop card.
 
+## Analytics
+
+The block answers one question: **what fraction of card opens lead to a clickthrough to a
+product page.** Nothing is tracked per-card — with ~50 cards that is cardinality nobody asked
+for. Card identity appears nowhere.
+
+### Why this needs any custom code
+
+Milo's `decorateDefaultLinkAnalytics` (`libs/martech/attributes.js`) runs **once**, from
+`documentPostSectionLoading`, and only ever touches `<a>` and `<button>`. That leaves this
+block with four holes:
+
+1. A card is WebGL pixels raycast in `interaction.js` — there is no DOM node to decorate.
+2. Auto-generated labels are `${label}-${linkCount}--${header}`, where `linkCount` is the
+   ordinal among *all* links/buttons in the block. The ~50 `.globe-gallery-a11y-card` buttons
+   precede the modal controls, so prev used to read `previous card-52--`. That ordinal is also
+   **race-dependent** (the a11y buttons only exist after the async fragment fetch) and is
+   **never re-applied** after a breakpoint rebuild destroys and recreates them.
+3. Badge CTAs are minted per card inside `populateModal`, always after the decoration pass.
+4. Escape and the mobile gestures produce no DOM click at all.
+
+### The approach
+
+**Everything is a `daa-ll` on a real element. There is no custom analytics code in this block.**
+
+Every interaction that lacks a DOM click of its own — a canvas card tap, a swipe, a pull-down,
+Escape — is routed through the real control that already means that action, via `.click()`.
+DAA reads `daa-ll` off the clicked node and does not check `isTrusted`, so a synthetic click
+reports exactly like a user's. Same idiom as Milo's own modal (`libs/blocks/modal/modal.js`,
+Escape → `close.click()`).
+
+For a card tap, that control is the card's own `.globe-gallery-a11y-card` button — the one real
+element that already means "open card i". It is `pointer-events: none` and 0×0, but `.click()`
+dispatches programmatically and ignores hit-testing entirely. `a11y.trackCardOpen(idx)` is the
+explicit entry point, so this dependency shows up in the module's contract rather than being an
+implicit reach into the DOM.
+
+Every `daa-ll` is set explicitly — in `buildMarkup`, at card-button creation, or at badge mint
+time — so none of it depends on when decoration runs. `attributes.js` preserves an existing
+`daa-ll`, re-running each `-`-separated segment through `processTrackingLabels` for localization
+only, which round-trips these values unchanged. **That removes the race in hole 2 rather than
+working around it.**
+
+| Interaction | Mechanism | Label |
+| --- | --- | --- |
+| Card open (canvas tap) | `a11y.trackCardOpen` clicks the card's button | `card_open--globe_gallery` |
+| Card open (keyboard) | real click on that same button | `card_open--globe_gallery` |
+| Enter keyboard gallery (BROWSE) | `daa-ll` on the entry widget | `enter_gallery_kbd--globe_gallery` |
+| Badge CTA | `daa-ll`, minted in `populateModal` | `Photoshop--globe_card_modal` |
+| Prev (button or swipe) | `daa-ll` in `buildMarkup` | `prev_card-1--globe_card_modal` |
+| Next (button or swipe) | `daa-ll` in `buildMarkup` | `next_card-2--globe_card_modal` |
+| Close (button, Escape, pull-down) | `daa-ll` in `buildMarkup` | `close-3--globe_card_modal` |
+
+Pointer and keyboard opens converge on the *same element and label*, so parity is structural
+rather than something to remember.
+
+Full DAA chain for a CTA, via the block's inherited `daa-lh`:
+`Photoshop|globe_card_modal|b2|globe-gallery|s3`. `showModal()` moves the dialog to the top
+layer but does not change DOM ancestry, so that chain survives.
+
+**The ratio:** `sum(globe_card_modal CTA clicks) / sum(card_open)`. It is session-level, not
+strictly per-card — a user may browse several cards before clicking through. Cards-viewed
+(opens + navs) is derivable if a deeper denominator is ever wanted. Because both sides now go
+through DAA, they share one consent path; there is no gate on one and not the other.
+
+### Details worth not re-deriving
+
+- **Badge labels carry no index.** Derived from badge row position it would differ per card
+  (Photoshop `-1` on one card, `-3` on another), splitting the one aggregate that matters. One
+  product = one label. Milo's gnav ships numberless labels too (`daa-ll="Brand"`).
+  `processTrackingLabels` also strips `-`, so a product name like `Photoshop-Web` becomes
+  `Photoshop Web` and cannot corrupt the level split.
+- **20 characters per segment.** `decorateDefaultLinkAnalytics` re-runs every `-`-separated
+  segment of an existing `daa-ll` through `processTrackingLabels(part, config, 20)`, which
+  hard-slices at 20 — silently. `enter_gallery_keyboard` became `enter_gallery_keyboa`, hence
+  the `_kbd` abbreviation. Check any new label the same way: split on `-`, and no piece may
+  exceed 20 characters. Product names are already sliced to 20 at mint time.
+- **Every card button carries the *same* explicit `daa-ll`** (`CARD_OPEN_DAA_LL` in `a11y.js`).
+  Left to auto-decoration they would each derive a label from `aria-label` — the card's alt
+  text — producing ~50 per-card labels, exactly the cardinality this design rejects. Explicit
+  also means the label cannot drift with the button's ordinal.
+- **`event.isTrusted` separates acting from reporting.** A synthetic click carries
+  `isTrusted: false`; genuine user activation is always `true`, including keyboard Enter/Space
+  and screen-reader activation (AT goes through the platform accessibility API, which browsers
+  surface as a trusted click). So `onCardClick` bails on untrusted events: `trackCardOpen`'s
+  click is report-only, and without that bail it would reopen the modal at viewport centre,
+  discarding the tap coordinates the raycast passes. The marker rides on the event, so unlike a
+  module-scope flag it cannot latch, leak, or need a `finally`.
+  **Test gotcha:** an E2E test driving the block with `page.evaluate(el => el.click())` produces
+  an untrusted click and will appear to do nothing. Use the real click API (Playwright's
+  `locator.click()` dispatches trusted input).
+- **Only the canvas path calls `trackCardOpen`** (`openModalFromCanvas` in `globe-gallery.js`,
+  kept separate from `openModalAndDismissHint` for exactly this reason). A keyboard open is
+  already a real click on that button, so reporting there too would double-count it.
+- **`enter_gallery` is the one engagement signal here.** The entry widget is a real button, so
+  it costs a single label and roughly one event per keyboard session. It answers a question
+  nothing else does: whether the two-level a11y gallery is ever entered at all. Note the widget
+  is only *clicked* to enter BROWSE; merely focusing it (which scrolls the page to the
+  interactive globe via `snapToInteractive`) is a focus event and is not reported.
+- **Caveat inherent to `daa-ll` on any button:** a real click reports even when the handler
+  then declines to act — `enterBrowse()` bails if the sphere isn't formed, and `onCardClick`
+  bails if `isInteractive()` is false. Expect a small over-count on both.
+- **`close(e.isTrusted)`** (`modal.js`) is the same idea. `close(viaPointer)` ignores a close
+  within 200ms of open, to swallow the *browser's* synthetic click after a touch pointerup —
+  which is trusted, so the guard still applies to it. Escape and pull-to-close route through
+  `clickClose()`, are untrusted, and so are exempt; without that, Escape within 200ms of open
+  would be silently ignored. `viaPointer` and `isTrusted` turn out to be the same predicate,
+  so it is derived from the event rather than stashed.
+- **Do not add `daa-lh` anywhere in the block.** `attributes.md` forbids it, and a `daa-lh` on
+  the block element makes `decorateSectionAnalytics` skip link decoration for the whole block.
+- **Not tracked, deliberately:** globe drag/hover/auto-rotation, scroll milestones, card
+  impressions, and close *method* (button vs Escape vs swipe all collapse to one label). The
+  first two are the highest-volume signals here. Note these are the one class of signal the
+  all-`daa-ll` design cannot express: nothing is clicked, and there is no element that means
+  "the user reached the formed globe". Adding one would mean reintroducing `sendAnalytics`
+  (`libs/martech/helpers.js`) at the `SPHERE_INTERACTIVE_T` gate behind a once-only flag — and
+  with it a second reporting path, which gates on consent separately from DAA. Worth weighing
+  against the consolidation before adding the first one.
+
 ## Behavior notes (intentional differences from the prototype)
 
 - **"Click & Drag" hint text (WebGL).** A `PlaneGeometry` in `sphereGroup` behind the sphere's back

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -1183,6 +1183,47 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     card back from where it was released; upward drag is clamped to 0). matchMedia-less → no
     gestures. The gesture code transforms the canvas, not the chrome, so it's layout-agnostic
     across the sm scrim and the md full-height panel.
+- **Near-camera dissolve EXPLODES past the card box** (`uDisperse`, set from `proxDis` in
+  `placeSphereCard` only). The plain particle dissolve (`uDissolve`) can never draw outside the
+  rounded rect — the quad IS the card, and `rrSDF` zeroes everything beyond it — so the fade read as
+  pixels dying inside a frame. In `CARD_FRAG` / `CARD_DISPERSE_VERT`:
+  - **The quad overscans.** `CARD_DISPERSE_VERT` scales `position.xy` by `s + j/(uAspect, 1)`, where
+    `s = 1 + e × DISPERSE_EXPAND` is the cloud's radial reach and `j` is the jitter margin (absolute,
+    in card heights — hence the `/uAspect`), and stretches `vUv` to match. Card-space uv therefore
+    runs *past* `[0,1]`, which is the room the flying grains need. Hit-testing is untouched (raycasts
+    use the geometry, not the shader).
+  - **Per-grain lift-off, not a uniform expansion.** Each grain cell holds a lottery number `det`;
+    once the ramp `e = dispRamp(uDisperse)` passes it, that grain has detached and is `t` of the way
+    through its flight, so `sg = 1 + EXPAND × spd × t`. A detached grain drawn at `pos` reads its
+    content from `pos / sg`; a grain that hasn't lifted off keeps `sg = 1` and renders exactly as
+    before. **That split is the whole trick**: at any instant most grains are still in place, so the
+    photo stays readable while the detached minority spreads over a growing cloud. `t` is normalised
+    by `1 − det` so a grain's flight is monotonic — using the lottery value as the speed instead makes
+    grains fly out and then come *back* as the ramp advances.
+  - **No thinning term, and nothing keyed to the border.** A fragment at radius `f` only draws if its
+    own cell's flight reached that far, so coverage outward is just the odds of a grain being that
+    fast — the falloff is free, and it's continuous through the card's old edge. Two earlier attempts
+    failed here and are worth not repeating: confining the scatter to *outside* the box (via an `ow`
+    gate) puts a hard seam at the border and reads as a box inside a box — a 回; and expanding
+    *every* grain scrambles the still-opaque photo and, with a density-conserving `1/sg²` thinning,
+    dusts the card away long before it reaches the lens.
+  - **`DISPERSE_EXPAND` is the "how dramatic" dial**, and it costs **fill**: the quad grows to
+    `1 + EXPAND` per axis (plus jitter), so `2.0` is ~13× the card's pixels at full dispersion —
+    affordable only because `CARD_FRAG` computes its alpha first and **discards zero-alpha fragments
+    before the three texture fetches** (most of the cloud's bounding box is empty). Keep that
+    ordering if you touch the shader. The `dispRamp` exponent (0.9, deliberately < 1) front-loads
+    lift-off because `uDisperse` near 1 means the card is nearly transparent — a late ramp hides the
+    whole effect. For the same reason the prox opacity ramp is biased late
+    (`NEAR_FADE_OPACITY_BIAS` 0.4): the grain mask already carries the fade, and a linear ramp muted
+    the grains exactly as they flew.
+  - **The mask is evaluated at the grain's ORIGIN** (`srcSD`), so a detached grain draws only if it
+    started inside the card; its AA band is `px / sg`, since one destination pixel is `1/sg` of a
+    pixel back at the origin. The UNdisplaced `dsd` stays the source for the contour and the `fwidth`
+    AA width (a displaced `fwidth` explodes on per-cell noise).
+  - **Dispersion is near-camera only.** `uDissolve` is shared with the texture-ready reveal (see
+    Progressive texture loading), which must un-dissolve *in place* — hence a second uniform, reset
+    to 0 every frame in the non-sphere default block. With `uDisperse` at 0 every added term is
+    identity (`sg = 1`, `grow = 1`), so that path renders bit-for-bit as it did before.
 - **Sphere rotation — clamped Euler pitch/yaw (yaw free, pitch capped ±60°).** The orientation
   SOURCE is a pitch/yaw pair (`sphereOrient.x`, `sphereOrient.y`); the shared `sphereRotQuat` every
   consumer reads (card transforms, modal close, snap) is **rebuilt from it each frame**
@@ -1403,6 +1444,9 @@ self-explanatory:
 | `ARC_STAGGER` | `0.594` | span of the per-card peel-time stagger along the arc |
 | `ARC_PEEL_JITTER` | `0.40` | per-card random offset on the peel delay (organic cascade) |
 | `ARC_DENSE_SPLIT` | `0.50` | `fanT` boundary between the clustered off-screen flank and the visible spread |
+| `NEAR_FADE_START` / `_END` | `2.5` / `1.6` | card-heights of depth where the near-camera dissolve starts / completes |
+| `NEAR_FADE_OPACITY_BIAS` | `0.4` | exponent on the prox opacity ramp; `< 1` holds the card visible longer so the dispersing grains read (the grain mask carries the fade) |
+| `DISPERSE_EXPAND` / `_JITTER` (`shaders.js`) | `2.0` / `0.15` | how far the fastest grain flies as a multiple of the card's radius (the "how dramatic" dial) / its sideways wander as a fraction of its own travel. Shared by the vertex overscan and the fragment scatter; costs fill, since the quad grows to `1 + EXPAND` per axis |
 | `SPHERE_DRAG_WARP_BASELINE` / `_VEL` / `_MAX` | `0.05` / `3.5` / `0.25` | barrel-warp while dragging: constant baseline + a velocity-driven burst (decays with `DRAG_FRICTION`), capped |
 | `TEXT_BEHIND_GAP` | `15` | world units the hint plane sits behind the sphere's back surface |
 | `TEXT_WARP_ENTER_MAX` | `4.50` | `uWarp` at the hint's entrance (barrel distortion) |

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -1933,6 +1933,13 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     earlier gate for the cursor was tried and reverted — it put the affordance 26vh ahead of the
     input it advertises, which reads worse than a late cursor. Raycasting was never the problem at
     any value: a tap below the gate hits (`hits: 1`, harness-measured), `onPointerUp` discards it.
+  - **Hover uniforms are applied in `updateCardTransform`, not `placeSphereCard`** — that gate is
+    global, `fdE` is per-card. Between `sphereFormT` 0.9 and 1 the late-staggered cards sit at `fdE`
+    0.999: seated to the eye, but routed to `placeFoldingCard`, which sets `opacity = 1` (so they
+    pick, show `cursor: pointer`, and open on click) and wrote no `uWarp` — they raised `hoverT` and
+    rendered nothing, for ~9% of the formation scroll. The broken set follows `gpDelay` (index
+    cascade + `peelJitter`), not depth, which is what made it read as random. `placeSphereCard` now
+    only adds `sphereDragWarp`; `placeFoldingCard` applies `hs` so nothing pops at `fdE` 1.
   - **Inertia coasts below `SPHERE_INTERACTIVE_T`; only `SPHERE_ORIENT_RESET_T` zeroes it.**
     Hard-zeroing at the interactive gate stopped a released spin dead whenever the page was still
     settling across it. A drag *started* below the gate stays inert and can't fling on release, and

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -4,6 +4,10 @@ A scroll-driven **Three.js WebGL** hero, running in a real Milo page. The core
 arc→grid→sphere→zoom, the detail modal, the a11y gallery, and chromatic aberration (CA) are all
 shipped; remaining items are in Open items / backlog.
 
+**New here, or changing *when* something happens?** Read **Lifecycle timeline** — it maps every
+scroll position to what each subsystem is doing, and names the six separate normalized clocks the
+code mixes.
+
 ## What it is
 
 Over a tall, pinned scroll range (`--runway-height` in the CSS), the authored photo cards
@@ -36,13 +40,14 @@ through each image (centring it on the globe) rather than exposing a flat per-ca
 
 | File | What it is |
 | --- | --- |
-| `globe-gallery.js` | The block + sphere render core. `export default init(el)` → builds DOM, runs `createGlobeGalleryRuntime()` → `{ init, destroy }`. Holds the tuning constants + pure helpers (module scope) and the stateful core (arc/grid/fold/sphere placement, drag-rotation physics + the sphere-to-card alignment ease, lifecycle). `tick()` is a thin orchestrator over named single-concern stages plus `modal.*` / `a11y.*`; per-card placement is a dispatcher (`updateCardTransform`) over four branch fns (`placeSphereCard`/`placeFoldingCard`/`placeGridCard`/`placeArcCard`). Instantiates the DI modules. |
+| `globe-gallery.js` | The block + sphere render core. `export default init(el)` → builds DOM, runs `createGlobeGalleryRuntime()` → `{ init, destroy }`. Holds the *visual* tuning constants + pure helpers (module scope) — all scroll-**timing** constants live in `timeline.js` — and the stateful core (arc/grid/fold/sphere placement, drag-rotation physics + the sphere-to-card alignment ease, lifecycle). `tick()` is a thin orchestrator over named single-concern stages plus `modal.*` / `a11y.*`; per-card placement is a dispatcher (`updateCardTransform`) over four branch fns (`placeSphereCard`/`placeFoldingCard`/`placeGridCard`/`placeArcCard`). Instantiates the DI modules. |
 | `authoring.js` | `parseAuthoredContent` + `fetchFragmentCards` + `buildGlobeDom(el, labels, { arcCopy, pullQuote })` (+ internal parsers). Reads the block rows positionally, fetches the card fragment, and builds the canvas/overlay/modal DOM — minting + returning the per-instance `gid` id suffix, filling the arc-copy / pull-quote slots. Badge logos are `/federal` assets resolved via Milo's `getFederatedUrl`. |
 | `shaders.js` | GLSL: `CARD_VERT`/`CARD_FRAG`, `MODAL_VERT`/`MODAL_FRAG`, `TEXT_FRAG`. Card/modal frags round corners with one analytic SDF (`rrSDF`, `uRadius` = 22/631 of height + `uAspect`), no rasterized mask (`MODAL_FRAG` `uRadius` 0 on mobile). `TEXT_FRAG` (the hint) adds a barrel warp + particle dissolve + the `uExitP` one-way exit. |
 | `materials.js` | GPU-asset factories (all named exports, no per-instance state). **Materials:** `createCardMaterial` (card ShaderMaterial — cover-crop + optional CA/warp + SDF corners, with the property-proxy), `createModalMaterial` (modal SDF), `createTextMaterial` (hint `TEXT_FRAG`, uniforms only). **Textures:** `loadCardTextures({ maxTex })` (cover-cropped `CanvasTexture` per card, downscaled to the per-device cap — see Texture memory budget), `loadModalTexture(src, maxTex, onReady)` (lazy full image at a higher cap, returns the pending `Image` to cancel), `createClickDragTexture(aspect, hintText)` (renders the hint string, auto-scaled font). |
 | `a11y.js` | `createGalleryA11y(deps)` → `{ setup, updateTabStops, teardown, isBrowsing }`. The two-level gallery (see Accessibility). All runtime state + actions (`centerCard`, `openCard`, `onFocus`) injected; holds no globe state but its DOM. |
 | `modal.js` | `createGlobeModal(deps)` → `{ setup, resize, render, updateAnimation, updateDesktopNav, open, navigate, close, getModalIdx, isCardManaged, destroy }`. The card-detail modal: own WebGL canvas/scene, the `MODAL_PHASE` state machine, SDF material swap, cross-warp nav (all breakpoints), touch swipe/pull gestures (gated on a coarse primary pointer, so tablets at ≥768 get them too), chrome layout in a native `<dialog>`. Owns all modal tuning constants. `getCount()` is the FULL authored count (see Card count). Sphere coupling is narrow + injected: shared `sphereRotQuat` + `snapToSphereSlot` / `applySphereFacing` / `requestNavNudge` / `applyMotionCA` callbacks. |
 | `math.js` | Pure stateless helpers. **Easings:** `easeOutCubic`, `easeInOutCubic`, `easeOutSine`, `lerpN`. **Arc-phase geometry:** `arcRotationEase`, `buildArcCtx`, `getFanData`, `cssToWorld`, `rotateArcPoint`, `arcCamZ` — the fanned-arc layout + CSS↔WebGL bridge, derived from the viewport + `ARC_SPAN` + the per-frame `arcCtx` the core owns; `getFanData`/`cssToWorld`/`rotateArcPoint` take an optional `out` and **write into it** (the core passes reused scratch objects), so per-frame card placement produces no garbage. |
+| `timeline.js` | **The scroll timeline.** Every phase constant, entry knob and threshold, plus `createFrame` / `createFrameInput` / `deriveFrame(frame, input)` — the pure derivation of all six clocks (`progress`, `arcCopyEntryT`, `arcPanT`, `gridFormT`, `sphereFormT`, `zoomT`) — and `cardFoldStartProgress(gpDelay)`, the per-card fold gate that `FOLD_FIRST_PROGRESS` is the `gpDelay = 0` case of. No THREE, no DOM, no closure state, so it is unit-testable in isolation and is the single place to change **when** something happens. `deriveFrame` writes into a caller-owned frame, allocates nothing, and clamps NaN-safely (a degenerate viewport/runway makes the ratios 0/0, and one NaN would poison every mesh position). Imported as a namespace (`import * as TL`, mirroring `THREE`) so adding a threshold doesn't mean editing an import list. See Lifecycle timeline. |
 | `interaction.js` | `createInteraction(deps)` → `{ setup, teardown }`. Canvas pointer plumbing: drag-to-spin, click-vs-drag, raycast hover + click→modal. Shares drag velocity by reference via the `drag` object. Owns the **touch axis lock** and exports `isPageScrollGesture()` (see Behavior notes). Cedes its hover cursor to the custom cursor via `isCursorActive()`. |
 | `cursor.js` | `createCursor(deps)` → `{ setup, update, teardown, isActive }`. The desktop custom cursor (see Behavior notes): two body-level layers (`mix-blend-mode` disc + fixed chevron/label container), per-frame state from injected getters, the two-step retirement, `isActive()` gating interaction's cursor. No-op on touch. |
 | `globe-gallery.css` | Globe-only CSS. Also defines `.globe-gallery`-scoped type-scale tokens (see Behavior notes). |
@@ -62,16 +67,42 @@ the arc-phase geometry live in `math.js`); (3) `createGlobeGalleryRuntime()` —
 holding sphere state + behavior. The active breakpoint's resolved render profile is one frozen `bp`
 object built by `resolveBpProfile()` on each (re)init; functions destructure what they need from it,
 DI getters read `bp.*` live. Inside the closure the **per-frame pipeline** is single-concern stages
-run in a fixed order by `tick()`: `computeFrame()` builds one `frame` context (scroll + phase
-t-values + card-entry transforms), each stage reads what it needs from it and the producer stages
-write results back onto it (`activeCamera`, `sphereRotActive`, `sphGroupZ`), so one object flows
-through to the card loop. Per-card placement (the largest stage) is a dispatcher over four
-runtime-scope branch fns — kept in this file, not a module, because they read deeply from the
-closure and run in the hot loop. Five DI modules are injected with live-state getters: GPU resources
-(`materials.js`), the a11y widget, the modal, `interaction.js` (sharing drag
-velocity via the `drag` object), and the cursor (its `isActive()` gates interaction's hover cursor).
-The modal owns its canvas/scene + the `MODAL_PHASE` state machine and reaches the sphere only
-through the shared `sphereRotQuat` + `snapToSphereSlot` / `requestNavNudge` callbacks.
+run in a fixed order by `tick()`: `computeFrame()` is a thin wrapper that refreshes the persistent
+`frameInput` from live layout/scroll state and calls `timeline.js`'s pure `deriveFrame`, which writes
+every clock onto the persistent `frame` context (scroll + the six clocks + card-entry transforms);
+each stage reads what it needs from it and the producer stages write results back onto it
+(`activeCamera`, `sphereRotActive`, `sphGroupZ`), so one object flows through to the card loop.
+**`frame` and `frameInput` are allocated once and mutated in place** — stages consume them
+synchronously within a tick and never retain them, so the per-frame pipeline allocates nothing.
+`frame` is also the single source for the clocks: read `frame.progress` / `frame.zoomT` rather than
+caching them in the closure. (In `globe-gallery.js` the persistent object is named `frameState`;
+stages take it as a parameter named `frame`, so the two don't shadow.)
+
+Who writes what:
+
+| | fields |
+| --- | --- |
+| `frameInput` ← the runtime, each tick | `scrollY`, `reducedMotion`, `blockDocTop`, `blockHeight`, `formPx` (= `formedScrollPx()`), `viewportH`, `arcScale` (= `CARD_W_ARC / CARD_W_SPHERE`), plus `prevLenisY` — the **only** inter-frame scroll state, carried back from `frame.lenisY` after each derive (and re-baselined in `startTicker`, so a resume after an off-screen scroll doesn't spike `scrollVel`) |
+| `frame` ← `deriveFrame` | `lenisY`, `scrollingDown`, `scrollVel`, the six clocks (`progress`, `arcCopyEntryT`, `arcPanT`, `gridFormT`, `sphereFormT`, `zoomT`), `gpWin`, and the arc-branch entry transforms `entryRot` / `entryYOffset` / `arcScale` |
+| `frame` ← the producer stages | `activeCamera` (`updateActiveCamera`), `sphereRotActive` (`updateSphereRotation`), `sphGroupZ` (`updateSphereGroupDepth`), `foldSphDist` (same) — declared in `createFrame` so the object's shape stays monomorphic |
+
+**Grouped closure state.** Related mutable state is held in small plain objects rather than loose
+`let`s, so the runtime closure stays legible: `drag` (`isDragging`/`velX`/`velY`, shared by
+reference with `interaction.js`), `masonryMorph` (`active`/`t`), `sphereOrient` (`x` = pitch, `y` =
+yaw, `z` = roll — see Sphere rotation), `navNudge` (`active`, `target{X,Y,Z}` = destination pose,
+`start{X,Y,Z}` = pose captured when armed, `frame`/`frames` = elapsed/total count from
+`KEY_BROWSE_FRAMES` or `KEY_MODAL_FRAMES`; `targetZ` is roll, set by keyboard centring only — the
+modal leaves it as-is), `arcCopy` (`el` + the last-written style strings `startSide`/`startStr`/
+`opStr`/`transformStr`, so `updateArcCopy` only touches the DOM when a value actually changed), and
+`ctxLoss` (`rebuilds`/`stableTimer`/`recovering`/`recoverTimer` — see WebGL context loss).
+
+Per-card placement (the largest stage) is a dispatcher over four runtime-scope branch fns — kept in
+this file, not a module, because they read deeply from the closure and run in the hot loop. Five DI
+modules are injected with live-state getters: GPU resources (`materials.js`), the a11y widget, the
+modal, `interaction.js` (sharing drag velocity via the `drag` object), and the cursor (its
+`isActive()` gates interaction's hover cursor). The modal owns its canvas/scene + the `MODAL_PHASE`
+state machine and reaches the sphere only through the shared `sphereRotQuat` / `snapToSphereSlot` /
+`requestNavNudge` callbacks.
 
 ## How to run
 
@@ -124,7 +155,7 @@ low-memory eviction) would leave a blank canvas. `initRuntime` binds `webglconte
 `webglcontextrestored` on **both** canvases (main + modal, `bindContextListeners`): lost stops the
 ticker and clears `renderReady`; restored rebuilds all GPU state via the same
 `destroy()`+`initRuntime()` path a breakpoint crossing uses. The two canvases' restore events are
-coalesced into ONE rebuild (`contextRecovering` guard + a macrotask defer). A rebuild cap
+coalesced into ONE rebuild (`ctxLoss.recovering` guard + a macrotask defer). A rebuild cap
 (`MAX_CONTEXT_REBUILDS`) collapses to `--empty` under sustained GPU pressure rather than looping;
 the counter resets once a rebuild survives `CONTEXT_STABLE_MS`. (Three.js's renderer already
 `preventDefault()`s the lost event — which is what makes the browser fire `restored`.)
@@ -144,16 +175,37 @@ Each fragment section is flat P/UL elements:
 | `<p><em>…</em></p>` | **role** | empty if unauthored (no hardcoded default) |
 | `<p><strong>…</strong></p>` | **name** | empty if unauthored (no hardcoded default) |
 | plain `<p>` | **description** | shown in the modal |
-| `<ul>` with nested `<ul><li>` per badge | **badges** | outer li = product name + links (see below), inner li = role |
+| `<ul>`, one `<li>` per badge | **badges** | see below — nested `<ul><li>` = the product feature |
 | `<p><picture>…</picture></p>` | **image** (+ its `<img alt>` → **alt**) | required — sections without one are skipped; `alt` falls back to an `alt text to be authored` placeholder when the image has none |
 
-Each badge's outer `<li>` may carry up to two direct-child links: an **optional logo**
-(a link whose href/text is an `.svg` — omit it and no logo renders) and the **product
-link** that supplies the badge name and its click target. Logo assets live under
-`/federal` on the federated content root, so the URL is resolved through Milo's
-`getFederatedUrl` (NOT `decorateSVG`, which would rewrite the host to a bare pathname on
-the consumer origin). A bare name (no product link) renders as plain text; the legacy
-pipe-separated `Name | Role` single-`<li>` form is still parsed.
+**Badge rows.** A badge `<li>` splits into exactly two parts: the **nested `<ul>`** is the
+product feature, and **everything else in the row** is the product — an optional logo plus the
+product link that supplies the name and its click target. That's the whole rule, so wrapper
+markup doesn't matter: DA emits a bare `<li>` when there's no feature and wraps the row in a
+`<p>` as soon as there is one, and both parse identically.
+
+```html
+<!-- feature authored → DA wraps the row in <p> -->
+<li>
+  <p><a href="…/photoshop-64.svg">…/photoshop-64.svg</a> <a href="…/photoshop.html">Photoshop</a></p>
+  <ul><li>Feature X</li></ul>
+</li>
+
+<!-- no feature → bare row, role left empty -->
+<li><a href="…/illustrator-64.svg">…/illustrator-64.svg</a> <a href="…/illustrator.html">Adobe Illustrator</a></li>
+```
+
+The logo may be an `.svg` link (href *or* visible URL text) or a plain `<img>`; omit it and no
+logo renders. It's decorative — the badge name is the labelled link — so it renders
+`aria-hidden` with an empty `alt`. Assets live under `/federal` on the federated content root,
+so the URL is resolved through Milo's `getFederatedUrl` (NOT `decorateSVG`, which would rewrite
+the host to a bare pathname on the consumer origin). A row with no product link takes its name
+from its own text and renders as plain text; a row with no feature renders with an empty role.
+
+> The row is read from a **clone** with the feature `<ul>` detached, so the product half can be
+> matched with plain `querySelector` without walking into the feature list and without mutating
+> authored DOM. The earlier direct-children-only read silently dropped every `<p>`-wrapped badge
+> (empty name → no row pushed), which looked like a modal layout bug rather than a parse miss.
 
 **Card count.** `N_TOTAL` follows the authored count, capped per breakpoint by `N_MAX`:
 
@@ -269,7 +321,9 @@ document-wide id references): the CA SVG filter (referenced from JS as
 the canvas is `position:fixed`. The shared body-level global (acceptable, one modal at a
 time) is the `.globe-gallery-modal-open` scroll lock.
 
-**Scroll model.** The block element *is* the scroll runway (its height is `--runway-height`) — there's
+**Scroll model.** (For *what happens at each point* on that scroll, see **Lifecycle timeline**
+below — charts + an event table. This subsection is the mechanism that gets you there.) The block
+element *is* the scroll runway (its height is `--runway-height`) — there's
 no separate runway element. Raw scroll is measured against the block's own metrics (`blockDocTop` =
 top in document space, `blockHeight` = `offsetHeight`, both refreshed in `doLayout` + a body
 `ResizeObserver`), then remapped **piecewise** (in `computeFrame`) into the `progress` 0→1 the phase
@@ -398,6 +452,138 @@ authored `notification` block) aren't authored alongside C2, so nothing occupies
 The modal chrome is a native `<dialog>`/`showModal()` in the top layer, so its z-index is only a
 non-supporting-browser fallback.
 
+## Lifecycle timeline
+
+**Start here if you're changing *when* something happens.** The code that owns all of this is
+**`src/timeline.js`** — every phase constant, every threshold, and the pure `deriveFrame` that
+produces the clocks. Scroll model (above) explains how raw scroll becomes `progress`. This section
+is the cross-section: *at a given scroll position, what is every subsystem doing?*
+
+Nothing here is a source of truth — every number below is derived from `timeline.js`, so if you
+retune a constant, re-run the snippet at the end of this section and update the tables from its
+output rather than hand-editing them.
+
+### The six clocks
+
+Most confusion in this block comes from code that mixes normalized timers. There are six, and they
+do **not** share a zero:
+
+| clock | 0 → 1 spans | formula | read by |
+| --- | --- | --- | --- |
+| `arcCopyEntryT` | `ENTRY_LEAD_VH` before the block top → `ENTRY_RAMP_VH` later | raw `window.scrollY`, *not* `progress` | arc-copy fade-in, arc pre-roll, entry slide |
+| `progress` | block top → runway end | piecewise remap (formation / tail) | the master clock; everything below derives from it |
+| `arcPanT` | arc pre-roll → arc fully panned | `progress / PROGRESS_PAN_END + PROGRESS_ARC_PREROLL · arcCopyEntryT` | arc geometry (`buildArcCtx`), `gridFormT` |
+| `gridFormT` | peel start → all cards in grid | `(arcPanT − 0.30) / 0.30` | per-card peel (`gpLocalT` after per-card delay + jitter) |
+| `sphereFormT` | `FOLD_FIRST_PROGRESS` → `SPHERE_FORMED_PROGRESS` | `(progress − 0.039) / (0.322 − 0.039)` | camera, depth sort, interactivity, hint text, arc-copy fade-out |
+| `zoomT` | sphere formed → runway end | `(progress − 0.322) / (1 − 0.322)` | zoom camera, cursor retire, pull-quote, canvas hide |
+
+Two consequences worth internalizing: `arcPanT` is the only clock that depends on
+`arcCopyEntryT`, so arc/grid timing shifts with *how the user entered the block*; and `sphereFormT`
+/ `zoomT` are back-to-back (`zoomT` starts the frame `sphereFormT` reaches 1), so there is no
+interactive dwell built into the scroll — the "formed globe" is a single point, not a range.
+
+### Formation — `progress` 0 → 0.322, scroll 0 → 304vh
+
+```
+            0      37   64    90           156                 251  277   304  (vh)
+            |       |    |     |            |                   |    |     |
+cards       ###arc##|#####peel to grid######|..........peel done............
+                       |##################fold to sphere####################
+camera      ..ortho.|#############perspective -> CAM_Z_SPHERE###############
+arc-copy    ######visible######|~~~~~~~~~~~~~~fade out~~~~~~~~~~~~~~~|gone..
+hint text   ....hidden...|##############warp in -> faint rest###############
+depth sort  ................off................|############on##############
+input       ........................inert.......................|###live####
+```
+
+The overlap in the top two lanes is the point of `FOLD_PEEL_OVERLAP`: the first cards begin folding
+(54vh) long before the last cards finish peeling (156vh), so the grid never visibly "resolves".
+
+### Tail — `zoomT` 0 → 1, scroll 304 → 520vh
+
+```
+            0.00             0.30   0.42                              0.95
+            |                  |      |                                 |  |
+camera      ###################CAM_Z_SPHERE -> CAM_Z_END####################
+globe       #sweeps past viewer|.........gone (sm 0.30 / md 0.42)...........
+hint text   ~~~~~~~~~fade~~~~~~~~|..................gone....................
+cursor      ##########live##########||...............retired................
+quote (sm)  .......hidden.......|############in -> hold -> exit#############
+quote (md)  ..........hidden..........|#########in -> hold -> exit##########
+canvas      ###########################visible##########################|...
+```
+
+### Event table
+
+`vh` assumes the default `--runway-height: 520vh` / `--formation-vh: 304vh`; `progress` and the
+gate columns are runway-independent.
+
+| vh | `progress` | gate | what happens | where |
+| ---: | ---: | --- | --- | --- |
+| −40 | — | `lenisY ≥ blockDocTop − ENTRY_LEAD_VH·H` | canvas `display:block`; `arcCopyEntryT` starts | `updateCanvasVisibility` |
+| −40→65 | — | `arcCopyEntryT` 0→1 over `ENTRY_RAMP_VH` | arc pre-roll speeds up, cards slide up, arc-copy fades **in** (done at `entryT` 0.336) | `computeFrame`, `updateArcCopy` |
+| 0 | 0.000 | block top | `progress` starts; cards on the arc | — |
+| 37 | 0.039 | `FOLD_FIRST_PROGRESS` | `sphereFormT` leaves 0 → camera switches **ortho → perspective** | `updateActiveCamera` |
+| ~41 | ~0.041 | `arcPanT ≥ PROGRESS_GRID_ARC_START` | arc → grid **peel** begins (staggered by `i` + `ARC_PEEL_JITTER`) | `updateCardTransform` |
+| ~54 | ~0.057 | `gpLocalT ≥ FOLD_START_LOCAL_T` | first card actually starts **folding** to the sphere | `updateCardTransform` |
+| 64 | 0.067 | `sphereFormT > TEXT_APPEAR_START` (0.10) | "Click & Drag" hint plane un-hides, warps in | `updateClickDragText` |
+| 90 | 0.096 | 20% of the fold window | **arc-copy starts fading out** | `updateArcCopy` |
+| 156 | 0.165 | `arcPanT = PROGRESS_GRID_ARC_END` | last card lands in the grid (`gridFormT` = 1) | `updateCardTransform` |
+| 170 | 0.180 | `sphereFormT > 0.5` | `renderer.sortObjects` on (arc needs manual order, sphere needs depth sort) | `tick` |
+| 251 | 0.265 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` (0.8) | hover / drag / click / auto-rotate go **live**; a11y browse enabled | `updateSphereRotation`, `updateCardTransform` |
+| 277 | 0.294 | 90% of the fold window | **arc-copy fully gone** | `updateArcCopy` |
+| 304 | 0.322 | `SPHERE_FORMED_PROGRESS` | sphere/barrel formed; `sphereFormT` = 1, `zoomT` leaves 0; keyboard focus snaps here | `computeFrame` |
+| 376 | 0.548 | `zoomT ≥ 1/3` | hint text fully faded | `updateClickDragText` |
+| 369 / 395 | 0.525 / 0.607 | camera passes the cards | globe clears the viewport — sm ≈ `zoomT` 0.30, md ≈ 0.42 | `updateActiveCamera` |
+| 373 / 395 | 0.539 / 0.607 | `zoomT ≥ pqAppearZoomT` | pull-quote fades in — sm 0.32, md 0.42 (from `--pq-pin-factor`) | `updatePullQuote` |
+| 386 | 0.580 | `CURSOR_ZOOM_DISMISS_T` (0.38) | cursor label fades | `cursor.update` |
+| 390 | 0.593 | `CURSOR_ZOOM_RETIRE_T` (0.40) | cursor disc retires | `cursor.update` |
+| 509 | 0.966 | `zoomT ≥ 0.95` | canvas `display:none` (quote alone to the end) | `updateCanvasVisibility` |
+| 520 | 1.000 | runway end | pull-quote pin exits | CSS (`--pq-pin-factor`) |
+
+Also on the timeline but **not** scroll-driven, so absent from the charts: texture loading
+(contours → un-dissolve, plus the one-time sm masonry re-solve on `onDone`), the modal
+(`sphereFormT ≥ SPHERE_INTERACTIVE_T` is its only scroll gate), and `textExitProgress` — the hint
+dissolve / cursor retirement accrue from **drag activity**, not scroll, and reset whenever
+`sphereFormT` drops below the interactive threshold.
+
+### Known wrinkle: `sphereFormT` leads the cards during entry
+
+`FOLD_FIRST_PROGRESS` is computed as if `arcCopyEntryT` were already 1, but the per-card fold gate
+reads the **live** `gridFormT`, which is still ramping. Entering the block from the top,
+`arcCopyEntryT` only reaches 1 at `progress` ≈ 0.069, so between `progress` 0.039 and ~0.057
+`sphereFormT` reports the fold as underway while every card is still on the arc. Visible effect is
+limited to the camera flipping ortho → perspective ~17vh early (existing, accepted behavior). Anything newly keyed
+to "the fold has started" should gate on `gridFormT`/`fdE` if it must match the cards exactly.
+
+### Re-deriving these numbers
+
+`timeline.js` is importable on its own (no THREE, no DOM), so this reads the **live** constants
+rather than restating them — it cannot drift from the code:
+
+```sh
+cd libs/mep/ace1209/globe-gallery && node --input-type=module -e "
+import * as T from './src/timeline.js';
+const RUNWAY_VH = 520; // --runway-height
+const tail = RUNWAY_VH - T.FORMATION_SCROLL_VH;
+const vh = (p) => (p <= T.SPHERE_FORMED_PROGRESS
+  ? (p / T.SPHERE_FORMED_PROGRESS) * T.FORMATION_SCROLL_VH
+  : T.FORMATION_SCROLL_VH
+    + ((p - T.SPHERE_FORMED_PROGRESS) / (1 - T.SPHERE_FORMED_PROGRESS)) * tail);
+const row = (n, p) => console.log(String(Math.round(vh(p))).padStart(4) + 'vh', p.toFixed(3), n);
+row('fold starts / sphereFormT>0', T.FOLD_FIRST_PROGRESS);
+row('hint text appears', T.progressAtFormT(T.TEXT_APPEAR_START));
+row('arc-copy fade start', T.ARC_COPY_OUT_START);
+row('depth sort on', T.progressAtFormT(T.DEPTH_SORT_FORM_T));
+row('interactive', T.progressAtFormT(T.SPHERE_INTERACTIVE_T));
+row('arc-copy gone', T.ARC_COPY_OUT_END);
+row('SPHERE FORMED', T.SPHERE_FORMED_PROGRESS);
+row('hint text faded', T.progressAtZoomT(1 / T.TEXT_ZOOM_FADE_RATE));
+row('cursor label / retire', T.progressAtZoomT(T.CURSOR_ZOOM_RETIRE_T));
+row('canvas hidden', T.progressAtZoomT(T.CANVAS_HIDE_ZOOM_T));
+"
+```
+
 ## Accessibility
 
 The globe is exposed as a **two-level gallery** (`a11y.js`), not a flat per-card list. Both levels
@@ -477,7 +663,8 @@ cleanly). The pieces:
 
 The `--reduced` overrides are grouped at the **end of `globe-gallery.css`** (`no-descending-specificity`). The no-cards / WebGL-unavailable fallback is the separate `.globe-gallery-empty`.
 
-Phase constants (module scope). The `P_*` values live in **progress-space** (0→1) and shape formation
+Phase constants (all in **`src/timeline.js`**) — these are the *inputs*; **Lifecycle timeline**
+above shows what they add up to. The `P_*` values live in **progress-space** (0→1) and shape formation
 + zoom; the runway split, pull-quote, and cursor retirement are covered under **Scroll model → the
 runway / progress model** above (they're driven by `--runway-height` / `--formation-vh` /
 `--pq-pin-factor` in CSS, read/derived in JS):
@@ -493,9 +680,9 @@ FORMATION_SCROLL_VH=304  PQ_APPEAR_LEAD=0.03  CURSOR_ZOOM_DISMISS_T=0.38  CURSOR
 position-space — **before** it fully lands in the grid (folding from its live peel position, no
 snap), so the grid never visibly "resolves" and the sphere forms earlier. The fold opens at peel
 localT `FOLD_START_LOCAL_T = 1 − FOLD_PEEL_OVERLAP^(1/3)`; the global fold window
-(`SPHERE_FORMED_PROGRESS`, `computeFrame`'s `foldFirst`/`foldLast`) and the per-card fold timer all
-derive from it, so camera / depth-sort / interactivity stay aligned. `0` restores "settle, then
-fold."
+(`FOLD_FIRST_PROGRESS` → `SPHERE_FORMED_PROGRESS`) and the per-card fold timer
+(`cardFoldStartProgress`) both derive from it in `timeline.js`, so camera / depth-sort /
+interactivity stay aligned. `0` restores "settle, then fold."
 
 **Arc-copy fade-out** (`updateArcCopy`) is expressed as a *fraction of the grid→globe fold window*
 (`FOLD_FIRST_PROGRESS` → `SPHERE_FORMED_PROGRESS`), not as raw progress, so it stays aligned if the
@@ -507,9 +694,10 @@ window for both profiles, since the fold constants are shared. The out-ease is `
 midpoint, which would collapse the copy to invisible almost as soon as it began; `easeInOutCubic`
 spreads the fade over the whole window and still lands exactly on 0 at `outEnd`.
 
-`FOLD_FIRST_PROGRESS` (module scope) is the mirror of `computeFrame`'s `foldFirst` — the same
-single-source role `SPHERE_FORMED_PROGRESS` plays for `foldLast` — and `computeFrame` reads it
-rather than recomputing.
+`FOLD_FIRST_PROGRESS` and `SPHERE_FORMED_PROGRESS` are the fold window's two ends, and
+`cardFoldStartProgress(gpDelay)` is the same computation per card — `FOLD_FIRST_PROGRESS` is its
+`gpDelay = 0` case. All three live in `timeline.js`, so the global window and the per-card gate
+cannot drift apart.
 
 **Arc-copy placement** is split between CSS and JS: CSS owns the block edge (`bottom` — `8px` at
 sm, `24px` from `min-width:768px`, docking it to the viewport bottom on the same 24px gutter the JS
@@ -541,8 +729,8 @@ rebuild would otherwise inherit:
   clears `globe-gallery-modal-open`, restarts Lenis). Else a modal open at a breakpoint crossing survives visually
   stuck open (its mesh dropped with the old `modalScene`, `modalIdx` reset to -1 so chrome buttons
   are dead, scroll lock stuck). An open modal closes cleanly on crossing; it doesn't re-open.
-- `destroy()` **resets the sphere orientation + drag/nudge state** (`sphereRotX/Y/Z`,
-  `pitchReleaseCap`, `sphereDragWarp`, `drag.velX/velY`, `navNudge*`, `wasBrowsing`) to the upright
+- `destroy()` **resets the sphere orientation + drag/nudge state** (`sphereOrient.x/y/z`,
+  `sphereOrient.pitchReleaseCap`, `sphereDragWarp`, `drag.velX/velY`, `navNudge.*`, `wasBrowsing`) to the upright
   pose — else pitch/yaw dragged before a device change carried into the rebuilt barrel and rendered
   it tilted until a scroll-out zeroed it.
 
@@ -622,7 +810,7 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
     gestures. The gesture code transforms the canvas, not the chrome, so it's layout-agnostic
     across the sm scrim and the md full-height panel.
 - **Sphere rotation — clamped Euler pitch/yaw (yaw free, pitch capped ±60°).** The orientation
-  SOURCE is a pitch/yaw pair (`sphereRotX`, `sphereRotY`); the shared `sphereRotQuat` every
+  SOURCE is a pitch/yaw pair (`sphereOrient.x`, `sphereOrient.y`); the shared `sphereRotQuat` every
   consumer reads (card transforms, modal close, snap) is **rebuilt from it each frame**
   (`refreshSphereRotQuat` → `setFromEuler`, order `'XYZ'`). Yaw is an unclamped turntable spin;
   pitch tilts about world X, **clamped ±π/3 (±60°)**, so cards never pass vertical and the globe
@@ -636,12 +824,12 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
     triple and eased per-axis (yaw shortest-path, pitch, upright **roll**). **On `YAW_ONLY`
     geometry it's yaw-only** (`cardCenterYawPitch` holds pitch) — a barrel can't centre vertically,
     so a top image stays high and only its column turns front.
-  - **Roll (`sphereRotZ`) exists ONLY for keyboard uprighting** — 0 for drag/ambient, set by
+  - **Roll (`sphereOrient.z`) exists ONLY for keyboard uprighting** — 0 for drag/ambient, set by
     `centerCardOnScreen`, eased back to 0 (`PITCH_RELAX`) when browsing ends.
   - **Pitch exception (±85°) via a GLIDING cap.** Drag keeps ±60°, but sphere keyboard-centring
     may tilt to **±85°** (`KEY_PITCH_CAP`) so a near-polar image reaches vertical centre. The seam
-    is `pitchReleaseCap`: while browsing it tracks the held pitch; on exit it eases back to ±60°
-    (`PITCH_RELAX`) with `sphereRotX` clamped to it each frame, so leaving a beyond-cap card slides
+    is `sphereOrient.pitchReleaseCap`: while browsing it tracks the held pitch; on exit it eases back
+    to ±60° (`PITCH_RELAX`) with `sphereOrient.x` clamped to it each frame, so leaving a beyond-cap card slides
     down to level instead of snapping. (Yaw-only browse never leaves ±60°, so the glide never fires.)
   - **No-overshoot ease.** Keyboard and modal centring share one **frame-counted `easeInOutCubic`
     tween** (`KEY_BROWSE_FRAMES` visible; `KEY_MODAL_FRAMES` faster, behind the blur) — never
@@ -799,8 +987,10 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
 
 ## Tuning reference
 
-The module-scope constants in `globe-gallery.js` are the core's tuning surface. The ones whose
-*value* isn't self-explanatory (and whose rationale used to live in long inline comments):
+The module-scope constants are the core's tuning surface, split by kind: **scroll timing** (phase
+constants, entry ramp, and every threshold) lives in `src/timeline.js` — see Lifecycle timeline —
+and the **visual/physics** constants below stay in `globe-gallery.js`. The ones whose *value* isn't
+self-explanatory (and whose rationale used to live in long inline comments):
 
 | Constant(s) | Value | Role |
 | --- | --- | --- |
@@ -822,8 +1012,29 @@ The module-scope constants in `globe-gallery.js` are the core's tuning surface. 
 | `TEXT_CA_DIR_STRENGTH` / `_WARP_MUL` | `0.05` / `1.5` | drag-CA strength on the hint text / warp-driven CA boost |
 | `TEXT_WARP_OVERFLOW` | `0.6` | extra mesh scale per warp unit, so letterforms bleed off-screen |
 
+### `timeline.js` constants
+
+Most of this file's exports are documented where they matter: the `P_*` phase constants and
+`FOLD_PEEL_OVERLAP` under Behavior notes → Phase constants; `FORMATION_SCROLL_VH` /
+`PQ_APPEAR_LEAD` under Scroll model; `ENTRY_LEAD_VH` / `ENTRY_RAMP_VH` under Entry timing; and
+every gate threshold in the Lifecycle timeline event table. The remainder — carried in code as
+bare names — are:
+
+| Constant | Value | Space | Role |
+| --- | --- | --- | --- |
+| `SLIDE_IN_PROGRESS` | `0.07` | progress | progress by which the card entry slide-up has completed |
+| `ARC_ENTRY_HOLD_T` | `0.05` | `arcCopyEntryT` | hold before the arc starts sweeping in |
+| `ENTRY_ROT_MAX` | `0.9` | radians | arc sweep-in rotation at `arcCopyEntryT` = 0; `entryRot` decays from it, and `updateCardTransform` divides by it to renormalize for the per-card entry CA |
+| `ENTRY_SLIDE_H_FRAC` | `0.30` | fraction of `H` | `entryYOffset` at slide 0 — how far below its arc position a card starts |
+| `ARC_COPY_IN_ENTRY_T` | `0.336` | `arcCopyEntryT` | arc-copy fade-**in** completes here (the fade-out is a fold-window fraction — see Arc-copy fade-out) |
+| `SPHERE_ORIENT_RESET_T` | `0.01` | `sphereFormT` | below this a scroll-out resets the sphere orientation (a brief dip mid-scroll keeps it) |
+| `TEXT_ZOOM_FADE_RATE` | `3` | `zoomT` | hint text is fully faded at `zoomT` = 1/rate |
+| `GRID_PEEL_WINDOW` | `0.8` | `gridFormT` | `1 − GRID_PEEL_STAGGER`; the span each card's peel occupies after its stagger delay (`frame.gpWin`) |
+| `GRID_ARC_RANGE` / `FOLD_WINDOW` | `0.30` / `0.283` | — | derived spans: the grid-peel arc range, and `SPHERE_FORMED_PROGRESS − FOLD_FIRST_PROGRESS` |
+| `progressAtFormT` / `progressAtZoomT` | — | — | helpers mapping a `sphereFormT` / `zoomT` back to progress. For docs and tests — not called per frame |
+
 Constants whose rationale is covered in the sections above (and so kept terse in code): the phase
-timeline + `FOLD_PEEL_OVERLAP`, `ENTRY_*`, the `CYL_*` / `SPHERE_AREA_NORM` / `CARD_FACE_CAMERA`
+timeline + `FOLD_PEEL_OVERLAP`, `ENTRY_*` (all now in `timeline.js`), the `CYL_*` / `SPHERE_AREA_NORM` / `CARD_FACE_CAMERA`
 shape knobs, the near-fade + `dragFlipZ` constants, and the keyboard/modal centring frames + pitch
 caps (all under Behavior notes / Card count).
 

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -11,9 +11,13 @@ code mixes.
 ## Conventions for editing this block
 
 **Prose belongs here, not in the code.** These files ship unminified, so every comment is payload on
-a hero block. Keep code comments to a line or two — a pointer like `// See README (Scroll model).`
-beats a paragraph. When a change needs real explanation, write it in the relevant README section and
-point at it.
+a hero block. A code comment earns its bytes only as **contract** (what a function returns or
+mutates, a unit, an invariant) or as a **hazard at the exact line** an edit would break — `// Do NOT
+forceContextLoss() here`, `// must run before the branch reads them`, `// Stage order is
+load-bearing`. Mechanism, derivations, and rationale go in the matching README section instead.
+Practically: one or two lines, never a paragraph, and add `See README (Section)` **only** when the
+code alone wouldn't lead you there — the pointer costs bytes too, and `const BREAKPOINTS` doesn't
+need to be told it's about breakpoints.
 
 **This README documents current behavior, not how it got here.** It is long because the block is
 intricate; keep it that way rather than growing an archaeology of every past decision. When you
@@ -112,6 +116,18 @@ Who writes what:
 by keyboard centring only), `arcCopy` (`el` + last-written style strings, so `updateArcCopy` only
 touches the DOM on change), and `ctxLoss` (see WebGL context loss).
 
+**`tick()`'s stage order is load-bearing** — producers before consumers, and two stages read *last*
+frame's value on purpose: `modal.updateAnimation` wants the previous `sphereGroup.position` with this
+frame's refreshed `sphereRotQuat`, and `updateA11yFocusRing` must run after the card transforms so it
+projects fresh world positions. `updateHintExitProgress` owns `textExitProgress` and precedes its two
+consumers (the hint plane and the cursor). Reordering is a silent one-frame-lag bug, not a crash.
+
+**Per-frame vs. baked.** Anything the sphere's rotation can change is recomputed every frame rather
+than stored: the facing tilt (`applyCardFacing` — a baked tilt rotates away from the camera), the
+crop (see Architecture notes), and the fold's orientation. Two derived values are cached because
+their inputs only change on a rebuild or a texture landing: `dragFlipZ` (`recomputeDragFlip`) and the
+masonry solve.
+
 Per-card placement (the largest stage) is a dispatcher over four runtime-scope branch fns — kept in
 this file because they read deeply from the closure and run in the hot loop. Five DI modules are
 injected with live-state getters: `materials.js`, the a11y widget, the modal, `interaction.js`, and
@@ -173,6 +189,11 @@ coalesced into ONE rebuild (`ctxLoss.recovering` guard + a macrotask defer). A r
 (`MAX_CONTEXT_REBUILDS`) collapses to `--empty` under sustained GPU pressure rather than looping;
 the counter resets once a rebuild survives `CONTEXT_STABLE_MS`. (Three.js's renderer already
 `preventDefault()`s the lost event — which is what makes the browser fire `restored`.)
+
+**`destroy()` must not `forceContextLoss()`.** The canvas *element* is reused across rebuilds (band
+crossings, reduced-motion toggles), and a force-lost context is never restored — the next renderer on
+that canvas is born dead ("Context Lost"). `renderer.dispose()` alone frees this renderer's GPU
+resources. There is a comment guarding this line; leave it there.
 
 Regression-test with the `WEBGL_lose_context` extension: `const x = document.querySelector('.globe-gallery-canvas').getContext('webgl2').getExtension('WEBGL_lose_context'); x.loseContext(); setTimeout(() => x.restoreContext(), 1000);`
 — the globe repaints within a frame or two of `restoreContext()`.
@@ -285,10 +306,11 @@ arc→grid settle) overruns the WebKit per-tab cap and kills the tab with no JS 
   instead starves wide sources on exactly that axis — a 16:9 image landed 256×144 and then lost half
   its width to the arc's crop, ~1.8× softer than a portrait card in the same slot. The request asks
   by height too (`optimizeImgUrl(src, px, 'height')`; the media service honours a lone `height=`).
-  `WIDE_TEX_RATIO` (2.5) bounds width for a panorama nobody sized for. `256` on sm, `768` on md.
+  `WIDE_TEX_RATIO` bounds width for a panorama nobody sized for. `CARD_TEX_SM` / `CARD_TEX_MD`
+  cap the height.
   Not an fps cost — mipmapping makes sampling track screen pixels; only memory + upload scale.
   - **Sizing reality check** (measured, DPR 2): the biggest card render is the **arc**, not the grid
-    — `CARD_W_ARC` is 220 CSS px at sm, so 440×608 *device* px against a 256px-tall texture (~0.44
+    — `CARD_W_ARC` is 220 CSS px at sm, so 440×608 *device* px against a `CARD_TEX_SM`-tall texture (~0.44
     texels/device px, i.e. upscaled ~2×). The sm barrel card is ~140 CSS px (~0.6–0.9 texels/device
     px) and the grid card ~100. md is oversampled everywhere (1.6–4.6). If sm cards ever read as
     soft, `CARD_TEX_SM` is the dial — and the arc is the frame to judge it on.
@@ -306,11 +328,11 @@ change residency. So a card costs `cap² × aspect × 5.33` bytes: at 256, a 3:4
 16:9 ≈ 0.62MB. Measured against the authored set (aspects 0.57–1.79): **sm 24 cards ≈ 7.6MB**
 (6.4MB under the old longest-side rule, +18%) and **md all 50 ≈ 139MB** (116MB before, +20%) — md
 sets no `N_MAX`, so every authored card is resident there. Watch this on iPad, which takes the md
-profile: if it needs trimming, `CARD_TEX_MD` 768 → 640 lands ~97MB, *below* today's figure, and md
+profile: if it needs trimming, dropping `CARD_TEX_MD` to 640 lands ~97MB, *below* today's figure, and md
 would still be oversampled (~2.8 texels/device px on the largest card).
 
 The **"Click & Drag" hint** (`createClickDragTexture`) is a separate line item: its canvas matches the
-camera aspect, so `TEXT_MAX_SIDE` caps the *longest* side at 2048 — uncapped, a portrait phone derives
+camera aspect, so `TEXT_MAX_SIDE` caps the *longest* side — uncapped, a portrait phone derives
 a 2048×4180 ≈ 45MB canvas, mostly empty. Capped, portrait tops ~1004×2048 (~11MB).
 
 `ANTIALIAS_SM`/`ANTIALIAS_MD` toggle MSAA per band (set at renderer creation): on for md (card
@@ -465,7 +487,7 @@ speeding up the globe:
 
 | segment | raw scroll | → progress | owns |
 |---|---|---|---|
-| **formation** (arc→grid→fold→settle) | `0 → --gg-formation-vh` (304vh) | `0 → foldLast` (≈0.322) | the `P_*` phase constants |
+| **formation** (arc→grid→fold→settle) | `0 → --gg-formation-vh` | `0 → foldLast` (≈0.322) | the `P_*` phase constants |
 | **tail** (zoom-through + pull-quote) | `--gg-formation-vh → --gg-runway-height` | `foldLast → 1` | `zoomT`, cursor retire, pull-quote |
 
 Formation is **locked** to a fixed scroll length, so `--gg-runway-height` sets tail length only.
@@ -476,11 +498,11 @@ Within the tail, `zoomT = clamp((scroll − formation) / (runway − formation),
 **CSS is the source of truth for all three props**, read per layout in `doLayout`, so retuning is a
 CSS-only edit:
 
-| prop | sm (base) | md+ | effect |
-|---|---|---|---|
-| `--gg-runway-height` | 520vh | 520vh | total height = formation + tail; ↓ = shorter stretch after the globe (shrinks gap **and** hold together) |
-| `--gg-formation-vh` | 304vh | 304vh | locked formation length |
-| `--gg-pq-pin-factor` | 0.65 | 0.55 | share of the tail the (bottom-anchored) quote pin occupies → its hold |
+| prop | per breakpoint | effect |
+|---|---|---|
+| `--gg-runway-height` | same at both | total height = formation + tail; ↓ = shorter stretch after the globe (shrinks gap **and** hold together) |
+| `--gg-formation-vh` | same at both | locked formation length |
+| `--gg-pq-pin-factor` | **lower at md+** | share of the tail the (bottom-anchored) quote pin occupies → its hold |
 
 `timeline.js`'s exported `CSS_FALLBACK` is the **only** JS copy of these numbers, read only when a
 property fails to resolve — possible because `loadBlock` races a block's stylesheet against its script
@@ -502,7 +524,7 @@ above it the fade-in would cross md's globe-clear and land the quote over the gl
 
 **Pull-quote timing is derived, not hand-set.** The pin height is `(runway − formation) ×
 --gg-pq-pin-factor`, so it always exits exactly at the runway end (no dead scroll), and the JS fade-in
-threshold `pqAppearZoomT = (1 − --gg-pq-pin-factor) − PQ_APPEAR_LEAD` (0.03) is **read from the CSS var in
+threshold `pqAppearZoomT = (1 − --gg-pq-pin-factor) − PQ_APPEAR_LEAD` is **read from the CSS var in
 `doLayout`** — so the pin geometry and the opacity trigger can't drift, per breakpoint or across a
 768px resize. Higher `--gg-pq-pin-factor` → quote appears earlier **and** holds longer (they trade off at
 a fixed runway); to change both together, move `--gg-runway-height`.
@@ -511,9 +533,9 @@ a fixed runway); to change both together, move `--gg-runway-height`.
 - *Whole stretch after the globe too long:* lower `--gg-runway-height` (both breakpoints).
 - *Quote hold too short/long, or appears too early/late:* `--gg-pq-pin-factor` for that breakpoint (JS
   threshold auto-follows). md is capped ~0.55 (globe-clear); sm can go to ~0.67.
-- *"Click & Drag" cursor lingers too long/short:* `CURSOR_ZOOM_RETIRE_T` (0.40) — keep it ≥ the md
+- *"Click & Drag" cursor lingers too long/short:* `CURSOR_ZOOM_RETIRE_T` — keep it ≥ the md
   camera-clear `zoomT` (≈0.42... it currently fires just before, at camz≈−33, accepted) and, on md,
-  `< pqAppearZoomT` so it retires before the quote. `CURSOR_ZOOM_DISMISS_T` (0.38) fades the label
+  `< pqAppearZoomT` so it retires before the quote. `CURSOR_ZOOM_DISMISS_T` fades the label
   first. (Cursor is desktop-only, so sm's earlier quote doesn't affect it.)
 - *Formation (arc/grid/fold) pacing:* the `P_*` constants below — independent of the runway.
 
@@ -560,12 +582,31 @@ case). `dragFlipZ` is recomputed in `onDone` / when the morph settles. Images de
 thread (`img.decode()`) so many decode concurrently. So `renderReady` means *cards built* (contours
 visible), not *all textures loaded*.
 
+**Rotation through the peel → fold → sphere handoff.** Three separate traps, all fixed in the
+placement branches:
+
+- **The fold slerps from `gridQuat`, the UPRIGHT grid orientation — not the card's live peel
+  orientation.** Slerping from the live spin flips the face through the camera plane mid-fold. The
+  residual peel spin (`stage.rotZ − gridTilt`, itself easing to 0 by peel end) is instead reapplied
+  *about local Z* afterwards, so it reads as in-plane rotation like the peel it continues.
+- **The peel lerps its z-angle directly, not by slerp.** `peelStartRot` snapshots the first peel
+  frame's rotation normalized to within ±π of `gridTilt`; a quaternion slerp here picks the shorter
+  arc across `atan2`'s wrap and visibly spins the wrong way.
+- **Position lerps FROM the live `stage` transform**, which collapses to the grid slot at `gpE ≥ 1`,
+  so the fold can open mid-peel (`FOLD_PEEL_OVERLAP`) without a snap. The facing tilt blends in over
+  the fold scaled by `fdE` so it lands continuous with `placeSphereCard`.
+
+**`updateSphereGroupDepth` runs at `sphereFormT === 0` too.** During the fold it slides `sphereGroup`
+forward so the sphere-camera distance lerps `FOLD_SPHERE_DIST → CAM_Z_SPHERE` (cards not yet on the
+sphere subtract `sphGroupZ` to stay at world z≈0). Skipping the stage before the fold starts makes
+`sphGroupZ` discontinuous at that boundary — the whole group darts forward on the first fold frame.
+
 **Right-sized image requests.** `loadCardTextures`' `getSrc` and the modal upgrade both route the
 authored URL through `optimizeImgUrl(src, cap)` (`authoring.js`), which for a helix/DA `media_*` asset
 rewrites it to `?width=<cap>&format=webply`, mirroring `decoratePictures`' convention. Non-`media_`
 URLs pass through. Because we downscale client-side anyway (`fitDims`), this trims bytes on the wire
 (≈10–30× on slow links), not the final texture resolution — and it lets the modal request its own cap
-(`MODAL_TEX_MD` 2048) rather than being limited by the authored `<img>` src width.
+(`MODAL_TEX_MD`) rather than being limited by the authored `<img>` src width.
 
 **Pausing must hide the canvas (multi-globe correctness).** The main canvas is `position:fixed` +
 full-viewport + `pointer-events:auto`, and `updateCanvasVisibility` — the stage that `display:none`s
@@ -649,29 +690,30 @@ canvas      ###########################visible##########################|...
 
 ### Event table
 
-`vh` assumes the default `--gg-runway-height: 520vh` / `--gg-formation-vh: 304vh`; `progress` and the
-gate columns are runway-independent.
+The `vh` and `progress` columns are **derived** — regenerate them with the snippet below when a
+constant moves, don't hand-edit. `vh` assumes the `CSS_FALLBACK` runway/formation defaults;
+`progress` and the gate columns are runway-independent.
 
 | vh | `progress` | gate | what happens | where |
 | ---: | ---: | --- | --- | --- |
 | −40 | — | `lenisY ≥ blockDocTop − ENTRY_LEAD_VH·H` | canvas `display:block`; `arcCopyEntryT` starts | `updateCanvasVisibility` |
-| −40→65 | — | `arcCopyEntryT` 0→1 over `ENTRY_RAMP_VH` | arc pre-roll speeds up, cards slide up, arc-copy fades **in** (done at `entryT` 0.336) | `computeFrame`, `updateArcCopy` |
+| −40→65 | — | `arcCopyEntryT` 0→1 over `ENTRY_RAMP_VH` | arc pre-roll speeds up, cards slide up, arc-copy fades **in** (done at `ARC_COPY_IN_ENTRY_T`) | `computeFrame`, `updateArcCopy` |
 | 0 | 0.000 | block top | `progress` starts; cards on the arc | — |
 | 37 | 0.039 | `FOLD_FIRST_PROGRESS` | `sphereFormT` leaves 0 → camera switches **ortho → perspective** | `updateActiveCamera` |
 | ~41 | ~0.041 | `arcPanT ≥ PROGRESS_GRID_ARC_START` | arc → grid **peel** begins (staggered by `i` + `ARC_PEEL_JITTER`) | `updateCardTransform` |
 | ~54 | ~0.057 | `gpLocalT ≥ FOLD_START_LOCAL_T` | first card actually starts **folding** to the sphere | `updateCardTransform` |
-| 64 | 0.067 | `sphereFormT > TEXT_APPEAR_START` (0.10) | "Click & Drag" hint plane un-hides, warps in | `updateClickDragText` |
-| 90 | 0.096 | 20% of the fold window | **arc-copy starts fading out** | `updateArcCopy` |
+| 64 | 0.067 | `sphereFormT > TEXT_APPEAR_START` | "Click & Drag" hint plane un-hides, warps in | `updateClickDragText` |
+| 90 | 0.096 | `ARC_COPY_OUT_FORM_START` of the fold window | **arc-copy starts fading out** | `updateArcCopy` |
 | 156 | 0.165 | `arcPanT = PROGRESS_GRID_ARC_END` | last card lands in the grid (`gridFormT` = 1) | `updateCardTransform` |
-| 170 | 0.180 | `sphereFormT > 0.5` | `renderer.sortObjects` on (arc needs manual order, sphere needs depth sort) | `tick` |
-| 251 | 0.265 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` (0.8) | hover / drag / click / auto-rotate go **live**; a11y browse enabled | `updateSphereRotation`, `updateCardTransform` |
-| 277 | 0.294 | 90% of the fold window | **arc-copy fully gone** | `updateArcCopy` |
+| 170 | 0.180 | `sphereFormT > DEPTH_SORT_FORM_T` | `renderer.sortObjects` on (arc needs manual order, sphere needs depth sort) | `tick` |
+| 251 | 0.265 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` | hover / drag / click / auto-rotate go **live**; a11y browse enabled | `updateSphereRotation`, `updateCardTransform` |
+| 277 | 0.294 | `ARC_COPY_OUT_FORM_END` of the fold window | **arc-copy fully gone** | `updateArcCopy` |
 | 304 | 0.322 | `SPHERE_FORMED_PROGRESS` | sphere/barrel formed; `sphereFormT` = 1, `zoomT` leaves 0; keyboard focus snaps here | `computeFrame` |
-| 376 | 0.548 | `zoomT ≥ 1/3` | hint text fully faded | `updateClickDragText` |
+| 376 | 0.548 | `zoomT ≥ 1 / TEXT_ZOOM_FADE_RATE` | hint text fully faded | `updateClickDragText` |
 | 369 / 395 | 0.525 / 0.607 | camera passes the cards | globe clears the viewport — sm ≈ `zoomT` 0.30, md ≈ 0.42 | `updateActiveCamera` |
 | 373 / 395 | 0.539 / 0.607 | `zoomT ≥ pqAppearZoomT` | pull-quote fades in — sm 0.32, md 0.42 (from `--gg-pq-pin-factor`) | `updatePullQuote` |
-| 386 | 0.580 | `CURSOR_ZOOM_DISMISS_T` (0.38) | cursor label fades | `cursor.update` |
-| 390 | 0.593 | `CURSOR_ZOOM_RETIRE_T` (0.40) | cursor disc retires | `cursor.update` |
+| 386 | 0.580 | `CURSOR_ZOOM_DISMISS_T` | cursor label fades | `cursor.update` |
+| 390 | 0.593 | `CURSOR_ZOOM_RETIRE_T` | cursor disc retires | `cursor.update` |
 | 509 | 0.966 | `zoomT ≥ 0.95` | canvas `display:none` (quote alone to the end) | `updateCanvasVisibility` |
 | 520 | 1.000 | runway end | pull-quote pin exits | CSS (`--gg-pq-pin-factor`) |
 
@@ -725,11 +767,17 @@ add up to. The `P_*` values live in **progress-space** (0→1) and shape formati
 split, pull-quote, and cursor retirement are covered under **Scroll model** (driven by the CSS props,
 read in JS):
 
-```
-P_PAN_END=0.55  P_ARC_PREROLL=0.30  P_GRID_ARC_START=0.30  P_GRID_ARC_END=0.60
-P_FOLD_DUR=0.25  P_ZOOM_END=1.00  GRID_PEEL_STAGGER=0.20  SPHERE_INTERACTIVE_T=0.8
-FOLD_PEEL_OVERLAP=0.35  CA_ENABLED=true
-PQ_APPEAR_LEAD=0.03  CURSOR_ZOOM_DISMISS_T=0.38  CURSOR_ZOOM_RETIRE_T=0.40
+The set is `PROGRESS_PAN_END`, `PROGRESS_ARC_PREROLL`, `PROGRESS_GRID_ARC_START` / `_END`,
+`PROGRESS_FOLD_DUR`, `PROGRESS_ZOOM_END`, `GRID_PEEL_STAGGER` and `FOLD_PEEL_OVERLAP`, plus the
+gates (`SPHERE_INTERACTIVE_T`, `PQ_APPEAR_LEAD`, `CURSOR_ZOOM_DISMISS_T` / `_RETIRE_T`). Dump the
+live values instead of trusting a list here:
+
+```sh
+cd libs/mep/ace1209/globe-gallery && node --input-type=module -e "
+import * as T from './src/timeline.js';
+console.log(Object.entries(T).filter(([, v]) => typeof v === 'number')
+  .map(([k, v]) => k.padEnd(26) + v).join('\n'))
+"
 ```
 
 `FOLD_PEEL_OVERLAP` (0–1) makes each card begin folding to the sphere that far — in peel
@@ -742,8 +790,8 @@ interactivity stay aligned. `0` restores "settle, then fold."
 
 **Arc-copy fade-out** (`updateArcCopy`) is expressed as a *fraction of the grid→globe fold window*
 (`FOLD_FIRST_PROGRESS` → `SPHERE_FORMED_PROGRESS`), not as raw progress, so it stays aligned if the
-fold constants move: `ARC_COPY_OUT_FORM_START = 0.20` → `ARC_COPY_OUT_FORM_END = 0.90`, i.e.
-progress ≈ `0.096` → `0.294` against a formed sphere at `0.322`. It therefore starts only once the
+fold constants move: `ARC_COPY_OUT_FORM_START` → `ARC_COPY_OUT_FORM_END` of that window (the event
+table's derived progress column shows where they land). It therefore starts only once the
 fold is underway and is fully gone *before* the sphere (md) / barrel (sm) finishes forming — one
 window for both profiles, since the fold constants are shared. The out-ease is `easeInOutCubic`,
 **not** the `easeOutCubic` used for the fade-in: `easeOutCubic` is ~88% done at the window's
@@ -761,9 +809,9 @@ and `inset-inline-start`, which shares the pull-quote's `--gg-content-inset` (se
 below for the derivation and for why md+ offsets it back by `--gg-arc-pad`). The logical property
 handles RTL, so no JS is involved in the side-swap.
 
-**Entry timing** — two independent constants: `ENTRY_LEAD_VH` (`0.4`) viewport-heights before the
+**Entry timing** — two independent constants: `ENTRY_LEAD_VH` viewport-heights before the
 block top that entry begins (`0` late; `0.85` is the prototype's hero pre-roll but sweeps meshes
-over content above), and `ENTRY_RAMP_VH` (`1.05`) the ramp over which `arcCopyEntryT` goes 0→1
+over content above), and `ENTRY_RAMP_VH` the ramp over which `arcCopyEntryT` goes 0→1
 (arc-copy fade, arc pre-roll speed, text→arc gap).
 
 ## Accessibility
@@ -835,7 +883,7 @@ cleanly). The pieces:
   once (no coverage math).
 - **`.globe-gallery-world`** — `position:relative` (was sticky); height `108vh` = 8vh + the canvas.
 - **Globe size (desktop)** — the formed `md` sphere fills ~93% of viewport height, so `buildCards`
-  scales `sphereGroup` by `RM_GLOBE_SCALE_MD` (0.9) on md to bring the whole ball in view (rotation
+  scales `sphereGroup` by `RM_GLOBE_SCALE_MD` on md to bring the whole ball in view (rotation
   is per-card, so a group scale is safe). `sm` (~49%) stays 1.
 - **A11y widget** — `position:absolute` (was fixed), re-centred at `top:58vh` since the base
   `top:50%` would track the taller world.
@@ -849,7 +897,7 @@ The `--reduced` overrides are grouped at the **end of `globe-gallery.css`** (`no
 
 **Breakpoints** resolve once in `init()`: two render profiles split at 768px — `md` (≥768, all
 cards, 9×5 grid, large sphere; covers Milo md *and* lg) and `sm` (<768, first 24, 3×8, smaller
-sphere). Per-profile knobs in `BREAKPOINTS`: `N_MAX` (0=uncapped), `ARC_SPAN`, `SPHERE_R`, `CARD_*`,
+sphere). Per-profile knobs in `BREAKPOINTS`: `N_MAX` (`0` = uncapped), `ARC_SPAN`, `SPHERE_R`, `CARD_*`,
 `CAM_Z_*`, `GRID_COLS/ROWS`, `CARD_ROLL_JITTER`, `ARC_DENSE_FRACTION`, `DRAG_GEARING`, plus precise-pointer defaults
 for the shape keys (`CARD_FACE_CAMERA`) that `YAW_ONLY_GEOMETRY` overrides. No
 md↔lg split — they render identically (code branches only on `'sm'`). Crossing 768px changes the
@@ -868,7 +916,7 @@ inside the formation animation. So the handler is split three ways:
   in its options object.
 - Renderer/camera/`computeGridLayout()` stay **synchronous** — a stale `W`/`H` renders the canvas
   stretched and desyncs `formedScrollPx()`.
-- `buildTextMesh()` is **trailing-debounced** (`TEXT_REBUILD_DEBOUNCE_MS`, 150ms), but only while
+- `buildTextMesh()` is **trailing-debounced** (`TEXT_REBUILD_DEBOUNCE_MS`), but only while
   `textMesh.visible` is false — it disposes a GPU texture, redraws a 2D canvas and uploads a new one.
   On screen it rebuilds synchronously, since a deferred rebuild would leave it stretched at the old
   aspect. `destroy()` clears any pending timer so a band crossing can't rebuild into a torn-down scene.
@@ -892,10 +940,13 @@ rebuild would otherwise inherit:
 an S2A scale uses the token, not the literal — including positional insets (`bottom`,
 `inset-inline-start`) and the `p + p` copy rhythm. Sizes tied to a specific design measurement stay
 literal, because pinning them to a coincidentally-equal token would imply a relationship that isn't
-there: the arc-copy `359px`/`382px` widths, the `138px` counter pill (`--gg-counter-w`, which the
-md+ nav offsets read), the `316px` scrim (`--gg-scrim-w`), `--gg-pq-height` 583px, the 24/28px badge
-icons, and the 48px cursor disc. These values are **off every S2A scale** and stay literal on purpose — if any is retuned,
+there: the arc-copy `359px`/`382px` widths, the counter pill (`--gg-counter-w`, which the
+md+ nav offsets read), the scrim (`--gg-scrim-w`), `--gg-pq-height`, the 24/28px badge icons, and the
+48px cursor disc. These values are **off every S2A scale** and stay literal on purpose — if any is retuned,
 snapping it to the nearest token is the cheaper fix:
+
+Inventory of the literals themselves (a snapshot — the CSS is authoritative; where a value has a var,
+the var is its home):
 
 | value | where | nearest token |
 | --- | --- | --- |
@@ -904,12 +955,11 @@ snapping it to the nearest token is the cheaper fix:
 | `-0.6px` letter-spacing | modal name, both breakpoints | none (−0.48 / −0.96) |
 | `10px` gap | badge-left, badges at md+ | `--s2a-spacing-xs` 8 / `--s2a-spacing-sm` 12 |
 | `10px` padding-inline | cursor text pill | same |
-| `6px` radius | `--gg-control-radius` | `--s2a-border-radius-xs` 4 / `-sm` 8 |
-| `12px` blur | `--gg-chrome-blur` | `--s2a-blur-xs` 8 / `--s2a-blur-sm` 16 |
+| `--gg-control-radius` | modal controls | `--s2a-border-radius-xs` / `-sm` |
+| `--gg-chrome-blur` | modal arrows, close, info scrim, md counter pill, a11y tip, cursor label | `--s2a-blur-xs` / `--s2a-blur-sm` |
 | `18px` blur | modal backdrop | `--s2a-blur-sm` 16 |
 
-`--gg-chrome-blur` exists because that 12px appeared six times (modal arrows, close, info scrim, the
-md counter pill, the a11y tip, the cursor label). It is declared on `.globe-gallery` **and**
+`--gg-chrome-blur` exists because that one blur appeared six times across those places. It is declared on `.globe-gallery` **and**
 `.globe-gallery-cursor` — `cursor.js` appends the cursor container to `<body>`, outside the block, so
 it cannot inherit. The same is true of any future local var the cursor needs.
 
@@ -934,7 +984,7 @@ layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted pane
 
 The **arc copy and the pull-quote share one left copy edge**, `--gg-content-inset` on
 `.globe-gallery`: `max(0px, 100vw - --gg-copy-max) / 2 + --gg-copy-pad`, i.e. the pull-quote's own
-text edge (it centres a `--gg-copy-max` 1920px box and pads it by `--gg-copy-pad`, and the rule
+text edge (it centres a `--gg-copy-max` box and pads it by `--gg-copy-pad`, and the rule
 consumes the same two vars so the pair cannot drift). The arc copy is `position: fixed`, so its
 `inset-inline-start` resolves against the viewport and RTL is handled by the logical property —
 there is no JS involved. At sm it pins 8px from the edge and its own `--gg-arc-pad` (16px) lands the
@@ -1091,7 +1141,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
 
 - **"Click & Drag" hint text (WebGL).** A `PlaneGeometry` in `sphereGroup` behind the sphere's back
   surface (`z = −(SPHERE_R + TEXT_BEHIND_GAP)`, `renderOrder = -1`), so it rotates with the globe and
-  draws behind the cards. Hidden until `sphereFormT > TEXT_APPEAR_START (0.10)`, then warps in (barrel
+  draws behind the cards. Hidden until `sphereFormT > TEXT_APPEAR_START`, then warps in (barrel
   warp + particle dissolve via `TEXT_FRAG`), settles to a faint resting opacity (`TEXT_OPACITY_PEAK
   0.15 → RESTING 0.06`), fades out over the zoom. Sized to fill the frustum at its live camera
   distance (`textPlaneSize` × a per-frame scale off `frame.foldSphDist`), with warp-proportional
@@ -1107,8 +1157,8 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   disc (inverts what's beneath) flanked by chevrons that squeeze 4px inward while dragging, plus a
   "Click & Drag" label in a **frosted pill** (the modal-chrome glass, so `backdrop-filter` frosts the
   cards behind it). It **retires in two steps** on the same `textExitProgress` signal as the hint
-  text: at `CURSOR_HINT_DISMISS_T` (0.12, `getHintDismissed`) the label fades with the text; at the
-  later `CURSOR_RETIRE_T` (0.55, `getCursorRetired`) the disc + chevrons fade over `RETIRE_FADE_MS`
+  text: at `CURSOR_HINT_DISMISS_T` (`getHintDismissed`) the label fades with the text; at the
+  later `CURSOR_RETIRE_T` (`getCursorRetired`) the disc + chevrons fade over `RETIRE_FADE_MS`
   (0.42s, mirrored by `--retiring` CSS), then `active` drops, clearing `cursor: none` so the system
   cursor takes back over. The disc **shrinks** rather than fades (partial opacity under
   `mix-blend-mode: difference` is a gray wash). Opening a card sets `textExitProgress = 1` (instant
@@ -1127,7 +1177,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     a **per-breakpoint constant**: the modal card is always horizontally centred
     (`computeModalTarget` pins `x` to 0), so "centred under the image" is just `50%` — nothing to
     project, nothing to track. **Desktop/tablet:** the counter pill sits at `left: 50%` (physical, because its
-    `translateX(-50%)` is physical) with an arrow `--gg-nav-gap` (12px) out each side, offset from
+    `translateX(-50%)` is physical) with an arrow `--gg-nav-gap` out each side, offset from
     the centre by `--gg-counter-w / 2 + gap + --gg-control-size` on `inset-inline-start` so RTL
     mirrors for free. All three share one `bottom` — `--gg-modal-edge` from the *viewport* bottom,
     not the image bottom, so the row holds its height whatever the photo's aspect. **Mobile:** the
@@ -1136,18 +1186,18 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     target everywhere; close sits at the top inline-end corner at every breakpoint. Geometry is five
     locals on `.globe-gallery-modal-chrome`: `--gg-modal-edge` (`--s2a-spacing-md` → `-lg` at md+ —
     the single inset for all four controls *and* the scrim padding), `--gg-control-size`,
-    `--gg-control-radius` (6px literal; no S2A step), `--gg-counter-w` (`auto` at sm, `138px` at md+,
-    where the pill's own `width` reads it) and `--gg-scrim-w` (316px, md+ only). `--gg-modal-edge` is
+    `--gg-control-radius` (a literal; no S2A step), `--gg-counter-w` (`auto` at sm, fixed at md+,
+    where the pill's own `width` reads it) and `--gg-scrim-w` (md+ only). `--gg-modal-edge` is
     also the sm scrim's `padding-bottom` reserve (`edge + control + edge`, so the arrows clear the
     badges); at md+ the arrows sit under the image, so the override drops it to a flat `edge`.
   - **Image fit + corner radius.** The **visible image** is contain-fit to the viewport minus a
-    symmetric margin (desktop `DT_IMG_MARGIN` 12px; mobile full-bleed, square corners `uRadius=0`),
+    symmetric margin (desktop `DT_IMG_MARGIN`; mobile full-bleed, square corners `uRadius=0`),
     native aspect kept. `MODAL_FRAG`'s rounded-rect is measured against the **full plane**
     (`vec2(uAspect·0.5, 0.5)`, same as `CARD_FRAG`) — the plane edge *is* the photo edge, so the fit
     is plain `min(H − 2·margin, (W − 2·margin) / uAspect)` with nothing to back out. An inset box
     (half-extents minus `uRadius`) would clip `uRadius` worth of photo off all four edges, i.e. the
     modal would show *less* of the image than the globe does. Desktop keeps a constant
-    `MODAL_RADIUS_PX` (16px) **on screen for every card**, not a fraction of height: `uRadius` is
+    `MODAL_RADIUS_PX` **on screen for every card**, not a fraction of height: `uRadius` is
     normalised to card height, so `modalDesktopFit(uAspect)` derives `radiusFrac = 16 / cardHPx` —
     per card, since `cardHPx` depends on whether that card's aspect makes the fit width- or
     height-limited. `modalRadiusFrac(uAspect)` wraps it with the mobile `0`, taking the **aspect**
@@ -1164,7 +1214,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     notes*). Without it, the first frame of the fly would show the *whole* image at the *barrel's*
     aspect — a visible horizontal squash that resolves over `MODAL_ANIM_DURATION`. A desktop nav
     cross-warp owns its own cards' uniforms, so the push is skipped while `dnNavActive`.
-  - **Scrim + scroll region.** Desktop gets a fixed-width (`--gg-scrim-w` 316px) dark frosted scrim
+  - **Scrim + scroll region.** Desktop gets a fixed-width (`--gg-scrim-w`) dark frosted scrim
     on the **viewport's inline-start edge, full height**; mobile gets one full-width bottom chunk
     (content-sized, capped at `60dvh`). Both are **pinned header / scrolling body / pinned footer**: role + name are
     `flex-shrink:0` at the top, **badges** are `flex-shrink:0` at the bottom (so those tabbable
@@ -1178,7 +1228,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     a nested scroll region silently won't scroll without that attribute.
   - **Touch gestures (in the modal) are gated on a coarse primary pointer**
     (`matchMedia('(pointer: coarse)')`, mirroring `usesCylinderGeometry`), not on the `sm` width
-    band — so tablets at md (≥768) get them too. A per-gesture axis lock (`AXIS_LOCK_PX` 10px)
+    band — so tablets at md (≥768) get them too. A per-gesture axis lock (`AXIS_LOCK_PX`)
     splits horizontal **swipe → prev/next** (warp preview during the drag, cross-warp on commit)
     from a vertical **pull-down → dismiss** (finger-tracked `translate`+`scale`, commit flies the
     card back from where it was released; upward drag is clamped to 0). matchMedia-less → no
@@ -1212,10 +1262,10 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     `1 + EXPAND` per axis (plus jitter), so `2.0` is ~13× the card's pixels at full dispersion —
     affordable only because `CARD_FRAG` computes its alpha first and **discards zero-alpha fragments
     before the three texture fetches** (most of the cloud's bounding box is empty). Keep that
-    ordering if you touch the shader. The `dispRamp` exponent (0.9, deliberately < 1) front-loads
+    ordering if you touch the shader. The `dispRamp` exponent (in `DISPERSE_RAMP`, deliberately < 1) front-loads
     lift-off because `uDisperse` near 1 means the card is nearly transparent — a late ramp hides the
     whole effect. For the same reason the prox opacity ramp is biased late
-    (`NEAR_FADE_OPACITY_BIAS` 0.4): the grain mask already carries the fade, and a linear ramp muted
+    (`NEAR_FADE_OPACITY_BIAS`): the grain mask already carries the fade, and a linear ramp muted
     the grains exactly as they flew.
   - **The mask is evaluated at the grain's ORIGIN** (`srcSD`), so a detached grain draws only if it
     started inside the card; its AA band is `px / sg`, since one destination pixel is `1/sg` of a
@@ -1307,7 +1357,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   Layout is cylindrical **masonry**: fixed columns around the circumference, cards packed down each.
   - **Uniform WIDTH fixes alignment; varying HEIGHT is the effect.** Width = column width (columns
     read as true verticals); height follows each image's native aspect (the stagger) — which is why
-    this path never needed an equal-area dial. `CYL_ASPECT_CAP` (1.5) stops one panorama dominating a
+    this path never needed an equal-area dial. `CYL_ASPECT_CAP` stops one panorama dominating a
     column: past the cap the card is laid out at the *clamped* aspect and `applyCardFit` crops the
     overflow (one `coverFit` call drives the crop and the corner SDF, so they cannot disagree). The
     cap is a **guard against pathological input**, not a house style — the masonry packs any aspect
@@ -1317,20 +1367,21 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     about the layout (same column count, same card width, wall height within 1%, column imbalance
     marginally worse at 1.084 vs 1.073).
     Without that crop a 3:1 image would be **squashed to half its width** in the wall — the barrel
-    scales the plane per card, it does not letterbox. `CYL_GAP_RATIO` (0.20) sets both gaps (card
+    scales the plane per card, it does not letterbox. `CYL_GAP_RATIO` sets both gaps (card
     width = pitch / (1 + ratio)).
   - **Packing: shortest column, tallest card first** (longest-processing-time-first) — holds column
     imbalance at ~1.05 vs 1.64× for source order. Free to reorder: the layout scatters consecutive
     cards, so authored order carries no spatial meaning and modal prev/next walks card *index*. Each
     column's stack is centred about y=0.
   - **Column count is DERIVED** (`CYL_COLS_FIT`, the wall-HEIGHT dial): fewest columns whose tallest
-    fits that fraction of frustum height (must scale with count). Default `0.80`; **sm overrides to
-    `0.65`** (`BREAKPOINTS.sm.CYL_COLS_FIT`). iPad's md cylinder keeps 0.80.
+    fits that fraction of frustum height (must scale with count). The shared default is in
+    `YAW_ONLY_GEOMETRY`; **sm overrides it lower** (`BREAKPOINTS.sm.CYL_COLS_FIT`) — iPad's md
+    cylinder keeps the shared one.
   - **Barrel size is the RADIUS** — the width lever. The wall sizes against the centre-plane frustum,
     but viewers see the FRONT cards at the near radius, magnified
-    `CAM_Z_SPHERE / (CAM_Z_SPHERE − SPHERE_R)`. sm runs `SPHERE_R` 16 (1.30× near magnification) so
-    the barrel clears a narrow phone's screen edges, paired with `CYL_COLS_FIT` 0.65 for height.
-  - **`CYL_BULGE` (0.12) barrels the wall** — `r = R·(1 − bulge·t²)`, `t = 2y/wallH` — so the
+    `CAM_Z_SPHERE / (CAM_Z_SPHERE − SPHERE_R)`. sm runs a much smaller `SPHERE_R` (less near magnification) so
+    the barrel clears a narrow phone's screen edges, paired with `CYL_COLS_FIT` for height.
+  - **`CYL_BULGE` barrels the wall** — `r = R·(1 − bulge·t²)`, `t = 2y/wallH` — so the
     silhouette curves like a globe while every column keeps a constant azimuth (still projects to a
     vertical line; only radial displacement). Costs ~9° normal tilt on sm / ~14° on md. **Don't push
     past ~0.2**: the inter-column chord shrinks with `r` while card width doesn't, so edges overlap
@@ -1345,9 +1396,9 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     shell the far wall moves opposite the same rotation, so the drag delta is negated. Firing at the
     geometric wall (`SPHERE_R`) drifted from the dissolve distance when card heights changed; tying
     it to the fade keeps the flip aligned. `maxRadial` is radial (rotation-invariant); `sphereGroup.
-    scale` (RM shrink) folded in; capped at `CAM_Z_SPHERE × DRAG_FLIP_MAX_CAM_FRAC` (0.95) so it
+    scale` (RM shrink) folded in; capped at `CAM_Z_SPHERE × DRAG_FLIP_MAX_CAM_FRAC` so it
     can't fire at zoom start; gated on `zoomT > 0`.
-  - **No roll jitter here** (columns lining up *is* the effect). **`CARD_FACE_CAMERA` is `0.10`** — on
+  - **No roll jitter here** (columns lining up *is* the effect). **`CARD_FACE_CAMERA` is nonzero on the barrel** — on
     a barrel it buys limb legibility at the cost of the curve (below).
   - **Not a masonry sphere:** masonry needs a developable surface. Meridian columns on a sphere
     project to curves, so in-column alignment breaks, and a 0.7 band holds only ~2 cards/column while
@@ -1355,13 +1406,14 @@ through DAA, they share one consent path; there is no gate on one and not the ot
 - **Density + facing pass** (full-sphere path; fixes the "edgy / unevenly distributed" read). Adding
   cards doesn't help — nearest-neighbour spacing is already even at N=24 and worsens with more cards
   (foreshortening variance). Four independent levers:
-  - **Edge-on slivers → `CARD_FACE_CAMERA` (`0.10` cylinder / `0` full sphere).** A
+  - **Edge-on slivers → `CARD_FACE_CAMERA`** (nonzero on the cylinder via `YAW_ONLY_GEOMETRY`, `0`
+    on the full sphere, which faces cards radially outward by definition). A
     radial card's obliquity equals its angular distance from front-centre, so limb cards render as
     lines. `applyCardFacing` turns each card partway toward the camera (slivers 5→0, worst obliquity
     81°→41°). Must be **per-frame** (a baked tilt rotates away from the camera). The target is
     `sign(n.z) × viewDir`, not `viewDir` (a uniform blend toward +Z rotates a back card to
     perpendicular — a new sliver). The effect must **fade to zero at edge-on** or the 180°-apart
-    targets teleport a card up to 63° as `normal.z` crosses 0: `FACING_EDGE_ON_BAND` (0.25, in
+    targets teleport a card up to 63° as `normal.z` crosses 0: `FACING_EDGE_ON_BAND` (in
     `|normal.z|`) smoothsteps `k` to 0 across edge-on (max per-frame change 63.3°→1.9°); widening
     past ~0.35 eats the limb correction. Applied at **three** sites that must agree or the card
     snaps: `placeSphereCard`, `snapCardToSphereSlot`, and `placeFoldingCard` (scaled by `fdE` so it
@@ -1372,7 +1424,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     limb. Both come from this one dial: the tilt is a full 3D re-aim, so it partly cancels each card's
     *vertical* slope (the one `cylinderMasonryLayout` computes so cards sit flush on the bulge), and
     it unwinds much faster than it winds up once `|n.z|` enters the edge-on band. Measured on the sm
-    barrel (`R` 16, `CAM_Z` 70) — both costs scale linearly with the dial; only the snap responds to
+    barrel (sm's `SPHERE_R` / `CAM_Z_SPHERE`) — both costs scale linearly with the dial; only the snap responds to
     the band:
 
     | `CARD_FACE_CAMERA` / `FACING_EDGE_ON_BAND` | maxSnap °/° | front pitch err | limb width |
@@ -1396,49 +1448,67 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     same problem with the masonry's uniform column width. Reinstate from git if the sphere path
     needs it (it also has to be applied in `modal.js`'s close target, or the card jumps when
     `snapToSphereSlot` runs).
-  - **Sparseness → `CARD_H_SPHERE` `11.0` on sm** (sphere path only). Coverage scales with **H²**, so
+  - **Sparseness → `BREAKPOINTS.sm.CARD_H_SPHERE`** (sphere path only). Coverage scales with **H²**, so
     size is a far stronger lever than count and adds no textures/draw calls. Net ~42% of the sphere
     face.
-  - **Scatter → `CARD_ROLL_JITTER` (sm `0.18` ≈ ±5°, md `0.5` ≈ ±14°).** Per-BP: at sm's sparsity
-    ±14° reads as debris, while md keeps the collage character.
+  - **Scatter → `CARD_ROLL_JITTER`** (radians, the roll spans ±half its value). Per-BP, and much
+    tighter on sm: at that sparsity md's spread reads as debris, while md keeps the collage
+    character.
 - **Drag physics — position-driven while held, velocity-driven once released.** The two halves of a
   drag want different inputs, so the shared `drag` object carries both and `updateSphereRotation`
   picks one per frame:
   - **`pendingX`/`pendingY` — exact unapplied travel (rad).** `interaction.js` *accumulates* every
     `pointermove` delta into it; the core **drains it every frame** (unconditionally, even while
-    frozen, so it can't pool and dump on resume) and, while `isDragging`, adds it straight to
-    `sphereOrient`. The surface therefore tracks the pointer **1:1 with no smoothing lag**, and no
-    travel is lost when several moves land in one frame.
-  - **`velX`/`velY` — an EMA of pointer speed (`VEL_SMOOTH_MS` 35ms), in rad per 60fps frame.** This
+    frozen, so it can't pool and dump on resume) and, while `isDragging`, adds it to `sphereOrient`.
+    The surface therefore tracks the pointer **1:1 with no smoothing lag**, and no travel is lost
+    when several moves land in one frame.
+  - **Jerk limiter — the held step is capped at `MAX_VEL`, the remainder stays banked.** Exact 1:1
+    can't be the whole story: Chrome coalesces `pointermove` to one event per frame, so a fast flick
+    arrives as a *single* several-hundred-pixel delta, and applying it whole rotates the globe tens
+    of degrees in one frame — indistinguishable from a dropped frame. Any step under one frame's
+    worth of rotation (`MAX_VEL × dtScale`) passes through **untouched**, so ordinary dragging keeps
+    its exact tracking; past that the step is rate-capped and then eased down by `DRAG_CATCHUP` as
+    the backlog shrinks, with the rest left in `pendingX` for the following frames. Nothing is
+    discarded, so total travel still matches the pointer. Measured on a 500px single-event jump:
+    biggest frame drops from the whole rotation at once (≈1000°/s) to exactly `MAX_VEL × dtScale`,
+    spread over ~7 frames, same total. The old code got this for free by clamping `velX`; making
+    the held path position-driven is what removed it. On release the backlog is dropped and `velX`
+    — clamped to the same `MAX_VEL` — takes over, so the handoff is continuous.
+  - **`velX`/`velY` — an EMA of pointer speed (`VEL_SMOOTH_MS`), in rad per 60fps frame.** This
     is the **release inertia**, and also every drag-driven CA/warp amplitude (normalized by
     `MAX_VEL`). It's sampled **by elapsed time, not per event** (`flushVel`): the old code assigned
     `velX` from the *last event's* pixel delta, which made the release velocity a function of the
-    pointer's event rate — the same 0.25 px/ms drag released at 0.020 rad/frame from a 60Hz mouse
-    but 0.00125 from a 1000Hz one (measured), and Chrome coalescing moves to rAF while Safari
-    doesn't is why the momentum felt inconsistent across browsers. Moves sharing a millisecond bank
-    into `sampX`/`sampY` rather than dividing by a zero dt.
+    pointer's event rate. Under the old scheme one constant-speed drag released at velocities
+    **proportional to the event interval** — measured 16× apart between a 60Hz and a 1000Hz pointer
+    for the identical hand motion — and Chrome coalescing moves to rAF while Safari doesn't is why
+    the momentum felt inconsistent across browsers. Moves sharing a millisecond bank into
+    `sampX`/`sampY` rather than dividing by a zero dt.
   - **The idle gap before release is part of the measurement.** `endGesture` flushes the EMA one
     last time with nothing banked, so *slowing to a stop before lifting* decays the inertia toward
-    0 (150ms ≈ e⁻⁴·³) instead of flinging on a stale sample — and *the sample being stale in the
-    other direction* (a still hold, no move event, so the old `velX` kept its pre-pause value) can't
-    fling either. Both were the "sometimes it stops dead / sometimes it lurches" bug.
+    0 (a gap of a few `VEL_SMOOTH_MS` time constants is effectively a stop) instead of flinging on a
+    stale sample — and *the sample being stale the other way* (a still hold sends no move event, so
+    the old `velX` kept its pre-pause value) can't fling either. Both were the "sometimes it stops
+    dead / sometimes it lurches" bug.
   - **Everything per-frame is rescaled by `frame.dtScale`** (`DRAG_FRICTION ** dtScale`, and
-    velocity/ambient-spin integrated as `v * dtScale`). Unscaled, `0.94`/frame coasts for ~270ms at
-    60Hz but ~135ms on a 120Hz display — the same code, half the feel.
+    velocity/ambient-spin integrated as `v * dtScale`). Unscaled, a per-frame decay coasts for half
+    as long on a 120Hz display as on a 60Hz one — the same code, half the feel. Coast time constant
+    is `−FRAME_MS / ln(DRAG_FRICTION)` ms, independent of refresh rate.
   - **Ambient spin is a separate additive term, not a bias folded into `velX`.** Added into the
     velocity (as it used to be) it *brakes* a leftward coast while extending a rightward one, so
     inertia decayed asymmetrically by drag direction. Note the unit change that came with it:
-    accumulating an increment against friction amplified it by `1 / (1 − DRAG_FRICTION)` = 16.67×,
-    so `AUTO_ROT_SPEED` is now the honest rate (`0.0005` ≈ 1.7°/s; the old loop settled at 2.6°/s) —
-    keep the old `0.000045` and the globe barely drifts.
+    accumulating an increment against friction amplified it by `1 / (1 − DRAG_FRICTION)` (≈17× at
+    the friction in code), so `AUTO_ROT_SPEED` is now the honest rate. Carrying the old increment
+    over unchanged would have left the globe barely drifting — if you port a value from git history,
+    multiply by that factor.
   - **Gearing is derived, not a baked rad/px** (`dragSensitivity()`, injected as
     `getDragSensitivity` and re-read per move). True 1:1 surface tracking is **90° per on-screen
     ball radius** (`SPHERE_R × H / CYL_FRUSTUM_H` px), and `bp.DRAG_GEARING` is a fraction of that:
-    **md `0.6`** (≈54° per radius-drag), **sm `0.53`** (the barrel is only ~167px wide on a phone,
-    so 1:1 would whip it >180° per swipe — 0.53 also reproduces the old fixed `0.005` rad/px to
-    within 0.3%). Deriving it keeps the feel constant across window sizes: a bigger ball on screen
-    needs *fewer* rad/px, which one fixed number got wrong in both directions (the old `0.005` was
-    1.34× over-geared on a 900px-tall desktop and 0.53× under on a phone).
+    geared down on **sm**, where the barrel is only a couple of hundred pixels wide and 1:1 would
+    whip it past half a turn per swipe (that band's value also reproduces the old fixed rad/px
+    almost exactly, so touch feel was preserved through the change). Deriving it keeps the feel
+    constant across window sizes: a bigger ball on screen needs *fewer* rad/px, which one fixed
+    number got wrong in both directions — over-geared on a tall desktop window, under-geared on a
+    phone. Drag by the ball's on-screen radius and it turns `90° × DRAG_GEARING`.
   - **Inertia coasts below `SPHERE_INTERACTIVE_T`; only `SPHERE_ORIENT_RESET_T` zeroes it.**
     Hard-zeroing at the interactive gate stopped a released spin dead whenever the page was still
     settling across it. A drag *started* below the gate stays inert and can't fling on release, and
@@ -1453,11 +1523,11 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   vertical scrolls); pitch (`drag.velY`) is written only when `!isTouchDrag && !getYawOnly()` — i.e.
   a mouse on the sphere. `touch-action: pan-y` alone isn't enough
   — moves before the browser commits to the pan leak a pitch kick — so the axis is resolved in JS
-  from the first `AXIS_LOCK_THRESHOLD` (8px) of travel, then **latched** for the gesture (a curved
+  from the first `AXIS_LOCK_THRESHOLD` of travel, then **latched** for the gesture (a curved
   swipe can't flip axes; a 45° tie resolves to vertical). `isTouchDrag` is per-gesture from
   `e.pointerType`, so a touchscreen laptop locks finger input but keeps mouse pitch **on the sphere**
   (its mouse still yaws-only on the barrel, since pitch follows geometry).
-  - **Taps aren't gated on the lock** — `CLICK_MAX_MOVE` (10px) > the 8px threshold, so a jittery
+  - **Taps aren't gated on the lock** — `CLICK_MAX_MOVE` > `AXIS_LOCK_THRESHOLD`, so a jittery
     tap may have latched an axis; `onPointerUp`'s independent distance/time test keeps tap-to-open
     unchanged.
   - **`isPageScrollGesture()`** (exported) lets per-frame stages distinguish a scroll swipe from a
@@ -1474,35 +1544,51 @@ through DAA, they share one consent path; there is no gate on one and not the ot
 
 ## Tuning reference
 
+> **One home per number.** A value is written **once, at its definition in code**. This file and the
+> code comments name the constant and say what it *means*, its *unit*, and how to derive a human
+> figure from it (`rad/frame × 60 × 180/π = °/s`) — never the value itself, and never a figure
+> computed from it. Anything else goes stale the first time someone tunes the dial, silently, in a
+> place the tuner never opens. Per-band knobs are cited as `BREAKPOINTS.<band>.<KEY>`; read the
+> live values out of the source (`globe-gallery.js` module scope, `src/timeline.js`, or the
+> per-module blocks in `interaction.js` / `modal.js` / `shaders.js`).
+>
+> Three deliberate exceptions: **sentinels**, where the number *is* the meaning (`N_MAX` `0` =
+> uncapped, `CARD_FACE_CAMERA` `0` = faces radially outward); **cross-system contracts**, where the
+> number is the interface, not our choice (the 768px Milo band split, the 456/631 card aspect, c2's
+> z-index tiers); and **worked examples** — the memory budget, the sizing reality check, the event
+> table's `vh`/`progress` columns — which are snapshots measured at the values in code when written.
+> Those carry the formula that produced them, so re-derive rather than trust the figure.
+
 The module-scope constants are the core's tuning surface, split by kind: **scroll timing** (phase
 constants, entry ramp, and every threshold) lives in `src/timeline.js` — see Lifecycle timeline —
-and the **visual/physics** constants below stay in `globe-gallery.js`. The ones whose *value* isn't
-self-explanatory:
+and the **visual/physics** constants below stay in `globe-gallery.js`. The ones whose role isn't
+self-evident from the name:
 
-| Constant(s) | Value | Role |
+| Constant(s) | Unit | Role |
 | --- | --- | --- |
-| `DRAG_FRICTION` | `0.94` | velocity decay per 60fps frame after a drag release (spin coastdown); applied as `** dtScale` — see Drag physics |
-| `MAX_VEL` | `0.06` | drag-velocity clamp; the core normalizes speed by it (shared with `interaction.js`) |
-| `AUTO_ROT_SPEED` | `0.0005` | ambient yaw drift per 60fps frame (≈1.7°/s) when not dragging / browsing — added alongside `velX`, never into it |
-| `DRAG_GEARING` (per band) | md `0.6` / sm `0.53` | pointer→rotation gearing as a fraction of true 1:1 surface tracking; `dragSensitivity()` turns it into rad/px off the live viewport |
-| `VEL_SMOOTH_MS` (`interaction.js`) | `35` | time constant of the release-velocity EMA |
-| `HOVER_RATE` | `0.15` | per-frame lerp toward the hover target (~125ms to 80%) |
-| `CA_STRENGTH` | `0.012` | radial UV shift per channel at transition peaks (Option B bell curve) |
-| `CA_MOTION_STRENGTH` / `…_ARC` | `1.0` / `0.04` | directional (motion-trail) UV-shift max — full during peel/fold/sphere/modal, softly clamped on the arc |
-| `SCROLL_VEL_MAX` / `_DEADBAND` | `14` / `7` | px/frame that saturates the motion trail / below which Lenis settle-noise is ignored (anti-shimmer) |
-| `CA_PX_MAX` | `4` | max vertical px shift for the global canvas SVG filter (Option C, md only) |
-| `ARC_STAGGER` | `0.594` | span of the per-card peel-time stagger along the arc |
-| `ARC_PEEL_JITTER` | `0.40` | per-card random offset on the peel delay (organic cascade) |
-| `ARC_DENSE_SPLIT` | `0.50` | `fanT` boundary between the clustered off-screen flank and the visible spread |
-| `NEAR_FADE_START` / `_END` | `2.5` / `1.6` | card-heights of depth where the near-camera dissolve starts / completes |
-| `NEAR_FADE_OPACITY_BIAS` | `0.4` | exponent on the prox opacity ramp; `< 1` holds the card visible longer so the dispersing grains read (the grain mask carries the fade) |
-| `DISPERSE_EXPAND` / `_JITTER` (`shaders.js`) | `2.0` / `0.15` | how far the fastest grain flies as a multiple of the card's radius (the "how dramatic" dial) / its sideways wander as a fraction of its own travel. Shared by the vertex overscan and the fragment scatter; costs fill, since the quad grows to `1 + EXPAND` per axis |
-| `SPHERE_DRAG_WARP_BASELINE` / `_VEL` / `_MAX` | `0.05` / `3.5` / `0.25` | barrel-warp while dragging: constant baseline + a velocity-driven burst (decays with `DRAG_FRICTION`), capped |
-| `TEXT_BEHIND_GAP` | `15` | world units the hint plane sits behind the sphere's back surface |
-| `TEXT_WARP_ENTER_MAX` | `4.50` | `uWarp` at the hint's entrance (barrel distortion) |
-| `TEXT_DRAG_WARP_MUL` | `3.0` | hint drag-warp vs sphere cards (more violent) |
-| `TEXT_CA_DIR_STRENGTH` / `_WARP_MUL` | `0.05` / `1.5` | drag-CA strength on the hint text / warp-driven CA boost |
-| `TEXT_WARP_OVERFLOW` | `0.6` | extra mesh scale per warp unit, so letterforms bleed off-screen |
+| `DRAG_FRICTION` | per 60fps frame | velocity decay after a drag release (spin coastdown); applied as `** dtScale`. Coast time constant = `−FRAME_MS / ln(FRICTION)` ms — see Drag physics |
+| `MAX_VEL` | rad per 60fps frame | one speed ceiling for both the fling and a held drag's step (`× 60 × 180/π` for °/s); also the normalizer every drag-driven CA/warp amplitude divides by |
+| `DRAG_CATCHUP` | share per 60fps frame | how fast an over-`MAX_VEL` backlog is worked off (jerk limiter). Higher = snappier catch-up after a flick, lower = softer |
+| `AUTO_ROT_SPEED` | rad per 60fps frame | ambient yaw drift when not dragging / browsing — added alongside `velX`, never into it |
+| `DRAG_GEARING` (per band) | fraction | pointer→rotation gearing as a fraction of true 1:1 surface tracking; `dragSensitivity()` turns it into rad/px off the live viewport. `1` = the surface follows the pointer exactly |
+| `VEL_SMOOTH_MS` (`interaction.js`) | ms | time constant of the release-velocity EMA |
+| `HOVER_RATE` | per-frame lerp | rate toward the hover target; reaches 80% in `ln(0.2) / ln(1 − RATE)` frames |
+| `CA_STRENGTH` | UV | radial shift per channel at transition peaks (Option B bell curve) |
+| `CA_MOTION_STRENGTH` / `…_ARC` | UV | directional (motion-trail) shift max — full during peel/fold/sphere/modal, softly clamped on the arc |
+| `SCROLL_VEL_MAX` / `_DEADBAND` | px/frame | scroll speed that saturates the motion trail / below which Lenis settle-noise is ignored (anti-shimmer) |
+| `CA_PX_MAX` | px | max vertical shift for the global canvas SVG filter (Option C, md only) |
+| `ARC_STAGGER` | fanT | span of the per-card peel-time stagger along the arc |
+| `ARC_PEEL_JITTER` | fanT | per-card random offset on the peel delay (organic cascade) |
+| `ARC_DENSE_SPLIT` | fanT | boundary between the clustered off-screen flank and the visible spread |
+| `NEAR_FADE_START` / `_END` | card-heights | depth in front of the lens where the near-camera dissolve starts / completes |
+| `NEAR_FADE_OPACITY_BIAS` | exponent | on the prox opacity ramp; `< 1` holds the card visible longer so the dispersing grains read (the grain mask carries the fade) |
+| `DISPERSE_EXPAND` / `_JITTER` (`shaders.js`) | × card radius / fraction | how far the fastest grain flies (the "how dramatic" dial) / its sideways wander as a fraction of its own travel. Shared by the vertex overscan and the fragment scatter; costs fill, since the quad grows to `1 + EXPAND` per axis |
+| `SPHERE_DRAG_WARP_BASELINE` / `_VEL` / `_MAX` | uWarp | barrel-warp while dragging: constant baseline + a velocity-driven burst (decays with `DRAG_FRICTION`), capped |
+| `TEXT_BEHIND_GAP` | world units | how far the hint plane sits behind the sphere's back surface |
+| `TEXT_WARP_ENTER_MAX` | uWarp | at the hint's entrance (barrel distortion) |
+| `TEXT_DRAG_WARP_MUL` | × | hint drag-warp vs sphere cards (more violent) |
+| `TEXT_CA_DIR_STRENGTH` / `_WARP_MUL` | UV / × | drag-CA strength on the hint text / warp-driven CA boost |
+| `TEXT_WARP_OVERFLOW` | mesh scale per uWarp | extra scale so letterforms bleed off-screen |
 
 ### `timeline.js` constants
 
@@ -1512,19 +1598,19 @@ Most of this file's exports are documented where they matter: the `P_*` phase co
 every gate threshold in the Lifecycle timeline event table. The remainder — carried in code as
 bare names — are:
 
-| Constant | Value | Space | Role |
-| --- | --- | --- | --- |
-| `SLIDE_IN_PROGRESS` | `0.07` | progress | progress by which the card entry slide-up has completed |
-| `ARC_ENTRY_HOLD_T` | `0.05` | `arcCopyEntryT` | hold before the arc starts sweeping in |
-| `ENTRY_ROT_MAX` | `0.9` | radians | arc sweep-in rotation at `arcCopyEntryT` = 0; `entryRot` decays from it, and `updateCardTransform` divides by it to renormalize for the per-card entry CA |
-| `ENTRY_SLIDE_H_FRAC` | `0.30` | fraction of `H` | `entryYOffset` at slide 0 — how far below its arc position a card starts |
-| `ARC_COPY_IN_ENTRY_T` | `0.336` | `arcCopyEntryT` | arc-copy fade-**in** completes here (the fade-out is a fold-window fraction — see Arc-copy fade-out) |
-| `SPHERE_ORIENT_RESET_T` | `0.01` | `sphereFormT` | below this a scroll-out resets the sphere orientation **and drag inertia** (a brief dip mid-scroll keeps both) |
-| `FRAME_MS` / `DT_SCALE_MIN` / `_MAX` | `16.67` / `0.25` / `3` | ms, ratio | the frame every per-frame rate is authored against, and the clamp on `frame.dtScale` — a stall must not teleport what it drives, a >240Hz frame must not underflow a decay (see Drag physics) |
-| `TEXT_ZOOM_FADE_RATE` | `3` | `zoomT` | hint text is fully faded at `zoomT` = 1/rate |
-| `GRID_PEEL_WINDOW` | `0.8` | `gridFormT` | `1 − GRID_PEEL_STAGGER`; the span each card's peel occupies after its stagger delay (`frame.gpWin`) |
-| `GRID_ARC_RANGE` / `FOLD_WINDOW` | `0.30` / `0.283` | — | derived spans: the grid-peel arc range, and `SPHERE_FORMED_PROGRESS − FOLD_FIRST_PROGRESS` |
-| `progressAtFormT` / `progressAtZoomT` | — | — | helpers mapping a `sphereFormT` / `zoomT` back to progress. For docs and tests — not called per frame |
+| Constant | Space | Role |
+| --- | --- | --- |
+| `SLIDE_IN_PROGRESS` | progress | progress by which the card entry slide-up has completed |
+| `ARC_ENTRY_HOLD_T` | `arcCopyEntryT` | hold before the arc starts sweeping in |
+| `ENTRY_ROT_MAX` | radians | arc sweep-in rotation at `arcCopyEntryT` = 0; `entryRot` decays from it, and `updateCardTransform` divides by it to renormalize for the per-card entry CA |
+| `ENTRY_SLIDE_H_FRAC` | fraction of `H` | `entryYOffset` at slide 0 — how far below its arc position a card starts |
+| `ARC_COPY_IN_ENTRY_T` | `arcCopyEntryT` | arc-copy fade-**in** completes here (the fade-out is a fold-window fraction — see Arc-copy fade-out) |
+| `SPHERE_ORIENT_RESET_T` | `sphereFormT` | below this a scroll-out resets the sphere orientation **and drag inertia** (a brief dip mid-scroll keeps both) |
+| `FRAME_MS` / `DT_SCALE_MIN` / `_MAX` | ms / ratio | the frame every per-frame rate is authored against (`1000/60`), and the clamp on `frame.dtScale` — a stall must not teleport what it drives, a very short frame must not underflow a decay (see Drag physics) |
+| `TEXT_ZOOM_FADE_RATE` | `zoomT` | hint text is fully faded at `zoomT` = `1 / RATE` |
+| `GRID_PEEL_WINDOW` | `gridFormT` | `1 − GRID_PEEL_STAGGER`; the span each card's peel occupies after its stagger delay (`frame.gpWin`) |
+| `GRID_ARC_RANGE` / `FOLD_WINDOW` | — | derived spans: `PROGRESS_GRID_ARC_END − _START`, and `SPHERE_FORMED_PROGRESS − FOLD_FIRST_PROGRESS` |
+| `progressAtFormT` / `progressAtZoomT` | — | helpers mapping a `sphereFormT` / `zoomT` back to progress. For docs and tests — not called per frame |
 
 ## Open items / backlog
 
@@ -1541,7 +1627,7 @@ Known follow-ups, not blocking this integration branch:
 - **Pacing: landing on the pristine formed globe.** On touch, scroll-spin arbitration is correct
   (see Behavior notes → Touch gesture arbitration), but how easily a user *comes to rest* exactly on
   the fully-formed, still globe is a scroll-pacing tuning matter still open.
-- **Pull-quote uses a hardcoded `--gg-pq-height: 583px`.** It's a shortcut (enables `top: calc(50vh -
+- **Pull-quote uses a hardcoded `--gg-pq-height`.** It's a shortcut (enables `top: calc(50vh -
   h/2)` centering + a predictable hold = `pin − h`), but it's brittle to copy length — longer/localized
   strings overflow the fixed box (no `overflow` handling), shorter copy leaves a dead gap under
   `justify-content: space-between`. Make it copy-flexible (revisit in a future session). Two options:

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -10,7 +10,7 @@ code mixes.
 
 ## What it is
 
-Over a tall, pinned scroll range (`--runway-height` in the CSS), the authored photo cards
+Over a tall, pinned scroll range (`--gg-runway-height` in the CSS), the authored photo cards
 (any count on desktop; first 24 on mobile — but the **modal browses all** authored images on
 mobile, see Card count) animate through four phases:
 
@@ -42,7 +42,7 @@ through each image (centring it on the globe) rather than exposing a flat per-ca
 | --- | --- |
 | `globe-gallery.js` | The block + sphere render core. `export default init(el)` → builds DOM, runs `createGlobeGalleryRuntime()` → `{ init, destroy }`. Holds the *visual* tuning constants + pure helpers (module scope) — all scroll-**timing** constants live in `timeline.js` — and the stateful core (arc/grid/fold/sphere placement, drag-rotation physics + the sphere-to-card alignment ease, lifecycle). `tick()` is a thin orchestrator over named single-concern stages plus `modal.*` / `a11y.*`; per-card placement is a dispatcher (`updateCardTransform`) over four branch fns (`placeSphereCard`/`placeFoldingCard`/`placeGridCard`/`placeArcCard`). Instantiates the DI modules. |
 | `authoring.js` | `parseAuthoredContent` + `fetchFragmentCards` + `buildGlobeDom(el, labels, { arcCopy, pullQuote })` (+ internal parsers). Reads the block rows positionally, fetches the card fragment, and builds the canvas/overlay/modal DOM — minting + returning the per-instance `gid` id suffix, filling the arc-copy / pull-quote slots. Badge logos are `/federal` assets resolved via Milo's `getFederatedUrl`. |
-| `shaders.js` | GLSL: `CARD_VERT`/`CARD_FRAG`, `MODAL_VERT`/`MODAL_FRAG`, `TEXT_FRAG`. Card/modal frags round corners with one analytic SDF (`rrSDF`, `uRadius` = 22/631 of height + `uAspect`), no rasterized mask (`MODAL_FRAG` `uRadius` 0 on mobile). `TEXT_FRAG` (the hint) adds a barrel warp + particle dissolve + the `uExitP` one-way exit. |
+| `shaders.js` | GLSL: `CARD_VERT`/`CARD_FRAG`, `MODAL_VERT`/`MODAL_FRAG`, `TEXT_FRAG`. Card/modal frags round corners with one analytic SDF (`rrSDF`, `uRadius` = fraction of card height + `uAspect`), no rasterized mask. Note the two frags use *different* SDF box conventions: `CARD_FRAG` fills the plane edge-to-edge (barrel cards keep the proportional 22/631 radius), while `MODAL_FRAG` insets the shape by `uRadius` on all four sides — modal.js sizes the plane around that inset and sets `uRadius` for a constant 16px on-screen radius (0 on mobile). `TEXT_FRAG` (the hint) adds a barrel warp + particle dissolve + the `uExitP` one-way exit. |
 | `materials.js` | GPU-asset factories (all named exports, no per-instance state). **Materials:** `createCardMaterial` (card ShaderMaterial — cover-crop + optional CA/warp + SDF corners, with the property-proxy), `createModalMaterial` (modal SDF), `createTextMaterial` (hint `TEXT_FRAG`, uniforms only). **Textures:** `loadCardTextures({ maxTex })` (cover-cropped `CanvasTexture` per card, downscaled to the per-device cap — see Texture memory budget), `loadModalTexture(src, maxTex, onReady)` (lazy full image at a higher cap, returns the pending `Image` to cancel), `createClickDragTexture(aspect, hintText)` (renders the hint string, auto-scaled font). |
 | `a11y.js` | `createGalleryA11y(deps)` → `{ setup, updateTabStops, teardown, isBrowsing }`. The two-level gallery (see Accessibility). All runtime state + actions (`centerCard`, `openCard`, `onFocus`) injected; holds no globe state but its DOM. |
 | `modal.js` | `createGlobeModal(deps)` → `{ setup, resize, render, updateAnimation, updateDesktopNav, open, navigate, close, getModalIdx, isCardManaged, destroy }`. The card-detail modal: own WebGL canvas/scene, the `MODAL_PHASE` state machine, SDF material swap, cross-warp nav (all breakpoints), touch swipe/pull gestures (gated on a coarse primary pointer, so tablets at ≥768 get them too), chrome layout in a native `<dialog>`. Owns all modal tuning constants. `getCount()` is the FULL authored count (see Card count). Sphere coupling is narrow + injected: shared `sphereRotQuat` + `snapToSphereSlot` / `applySphereFacing` / `requestNavNudge` / `applyMotionCA` callbacks. |
@@ -92,8 +92,8 @@ reference with `interaction.js`), `masonryMorph` (`active`/`t`), `sphereOrient` 
 yaw, `z` = roll — see Sphere rotation), `navNudge` (`active`, `target{X,Y,Z}` = destination pose,
 `start{X,Y,Z}` = pose captured when armed, `frame`/`frames` = elapsed/total count from
 `KEY_BROWSE_FRAMES` or `KEY_MODAL_FRAMES`; `targetZ` is roll, set by keyboard centring only — the
-modal leaves it as-is), `arcCopy` (`el` + the last-written style strings `startSide`/`startStr`/
-`opStr`/`transformStr`, so `updateArcCopy` only touches the DOM when a value actually changed), and
+modal leaves it as-is), `arcCopy` (`el` + the last-written style strings `opStr`/`transformStr`, so
+`updateArcCopy` only touches the DOM when a value actually changed), and
 `ctxLoss` (`rebuilds`/`stableTimer`/`recovering`/`recoverTimer` — see WebGL context loss).
 
 Per-card placement (the largest stage) is a dispatcher over four runtime-scope branch fns — kept in
@@ -335,13 +335,13 @@ unique per instance via that `gid` suffix (ids, not classes, because both are
 document-wide id references): the CA SVG filter (referenced from JS as
 `filter: url(#ca-filter-<gid>)`) and the modal role-label/heading/description (the
 `<dialog>`'s `aria-labelledby` (role + name) / `aria-describedby` IDREFs). `el` itself is the scroll runway
-(height is `--runway-height` on `.globe-gallery`, collapsed to `100vh` under `.globe-gallery-reduced`);
+(height is `--gg-runway-height` on `.globe-gallery`, collapsed to `100vh` under `.globe-gallery-reduced`);
 the canvas is `position:fixed`. The shared body-level global (acceptable, one modal at a
 time) is the `.globe-gallery-modal-open` scroll lock.
 
 **Scroll model.** (For *what happens at each point* on that scroll, see **Lifecycle timeline**
 below — charts + an event table. This subsection is the mechanism that gets you there.) The block
-element *is* the scroll runway (its height is `--runway-height`) — there's
+element *is* the scroll runway (its height is `--gg-runway-height`) — there's
 no separate runway element. Raw scroll is measured against the block's own metrics (`blockDocTop` =
 top in document space, `blockHeight` = `offsetHeight`, both refreshed in `doLayout` + a body
 `ResizeObserver`), then remapped **piecewise** (in `computeFrame`) into the `progress` 0→1 the phase
@@ -350,24 +350,24 @@ speeding up the globe:
 
 | segment | raw scroll | → progress | owns |
 |---|---|---|---|
-| **formation** (arc→grid→fold→settle) | `0 → --formation-vh` (304vh) | `0 → foldLast` (≈0.322) | the `P_*` phase constants |
-| **tail** (zoom-through + pull-quote) | `--formation-vh → --runway-height` | `foldLast → 1` | `zoomT`, cursor retire, pull-quote |
+| **formation** (arc→grid→fold→settle) | `0 → --gg-formation-vh` (304vh) | `0 → foldLast` (≈0.322) | the `P_*` phase constants |
+| **tail** (zoom-through + pull-quote) | `--gg-formation-vh → --gg-runway-height` | `foldLast → 1` | `zoomT`, cursor retire, pull-quote |
 
-Formation is **locked** to a fixed scroll length: `FORMATION_SCROLL_VH` (JS) = `--formation-vh` (CSS)
+Formation is **locked** to a fixed scroll length: `FORMATION_SCROLL_VH` (JS) = `--gg-formation-vh` (CSS)
 = 304vh (≈ `SPHERE_FORMED_PROGRESS` × the original 945vh single-runway tuning). `formedScrollPx()` is
 the single source used by the remap, the reduced-motion pin, and the focus-snap. Within the tail,
 `zoomT = clamp((scroll − formation) / (runway − formation), 0, 1)` drives the camera
 (`CAM_Z_SPHERE → CAM_Z_END`), the cursor retirement, and the pull-quote.
 
-Because formation is fixed, `--runway-height` sets tail length only. `--runway-height` is **shared**
-across breakpoints; `--pq-pin-factor` is **per-breakpoint** (`@media (min-width:768px)` overrides the
+Because formation is fixed, `--gg-runway-height` sets tail length only. `--gg-runway-height` is **shared**
+across breakpoints; `--gg-pq-pin-factor` is **per-breakpoint** (`@media (min-width:768px)` overrides the
 sm base). CSS custom props on `.globe-gallery`:
 
 | prop | sm (base) | md+ | effect |
 |---|---|---|---|
-| `--runway-height` | 520vh | 520vh | total height = formation + tail; ↓ = shorter stretch after the globe (shrinks gap **and** hold together) |
-| `--formation-vh` | 304vh | 304vh | locked formation length; must equal `FORMATION_SCROLL_VH` in JS |
-| `--pq-pin-factor` | 0.65 | 0.55 | share of the tail the (bottom-anchored) quote pin occupies → its hold |
+| `--gg-runway-height` | 520vh | 520vh | total height = formation + tail; ↓ = shorter stretch after the globe (shrinks gap **and** hold together) |
+| `--gg-formation-vh` | 304vh | 304vh | locked formation length; must equal `FORMATION_SCROLL_VH` in JS |
+| `--gg-pq-pin-factor` | 0.65 | 0.55 | share of the tail the (bottom-anchored) quote pin occupies → its hold |
 
 sm uses a **bigger** pin factor than md on purpose: its globe clears earlier (`zoomT≈0.30` vs md
 `≈0.42`), so the quote can start sooner *and* hold longer — which sm needs, because the fixed 583px
@@ -376,15 +376,15 @@ factor is capped ~0.55: above it the fade-in would cross md's globe-clear (`zoom
 quote over the globe.
 
 **Pull-quote timing is derived, not hand-set.** The pin height is `(runway − formation) ×
---pq-pin-factor`, so it always exits exactly at the runway end (no dead scroll), and the JS fade-in
-threshold `pqAppearZoomT = (1 − --pq-pin-factor) − PQ_APPEAR_LEAD` (0.03) is **read from the CSS var in
+--gg-pq-pin-factor`, so it always exits exactly at the runway end (no dead scroll), and the JS fade-in
+threshold `pqAppearZoomT = (1 − --gg-pq-pin-factor) − PQ_APPEAR_LEAD` (0.03) is **read from the CSS var in
 `doLayout`** — so the pin geometry and the opacity trigger can't drift, per breakpoint or across a
-768px resize. Higher `--pq-pin-factor` → quote appears earlier **and** holds longer (they trade off at
-a fixed runway); to change both together, move `--runway-height`.
+768px resize. Higher `--gg-pq-pin-factor` → quote appears earlier **and** holds longer (they trade off at
+a fixed runway); to change both together, move `--gg-runway-height`.
 
 **Tuning cheatsheet** (all visual — no test harness, so eyeball each):
-- *Whole stretch after the globe too long:* lower `--runway-height` (both breakpoints).
-- *Quote hold too short/long, or appears too early/late:* `--pq-pin-factor` for that breakpoint (JS
+- *Whole stretch after the globe too long:* lower `--gg-runway-height` (both breakpoints).
+- *Quote hold too short/long, or appears too early/late:* `--gg-pq-pin-factor` for that breakpoint (JS
   threshold auto-follows). md is capped ~0.55 (globe-clear); sm can go to ~0.67.
 - *"Click & Drag" cursor lingers too long/short:* `CURSOR_ZOOM_RETIRE_T` (0.40) — keep it ≥ the md
   camera-clear `zoomT` (≈0.42... it currently fires just before, at camz≈−33, accepted) and, on md,
@@ -533,7 +533,7 @@ canvas      ###########################visible##########################|...
 
 ### Event table
 
-`vh` assumes the default `--runway-height: 520vh` / `--formation-vh: 304vh`; `progress` and the
+`vh` assumes the default `--gg-runway-height: 520vh` / `--gg-formation-vh: 304vh`; `progress` and the
 gate columns are runway-independent.
 
 | vh | `progress` | gate | what happens | where |
@@ -553,11 +553,11 @@ gate columns are runway-independent.
 | 304 | 0.322 | `SPHERE_FORMED_PROGRESS` | sphere/barrel formed; `sphereFormT` = 1, `zoomT` leaves 0; keyboard focus snaps here | `computeFrame` |
 | 376 | 0.548 | `zoomT ≥ 1/3` | hint text fully faded | `updateClickDragText` |
 | 369 / 395 | 0.525 / 0.607 | camera passes the cards | globe clears the viewport — sm ≈ `zoomT` 0.30, md ≈ 0.42 | `updateActiveCamera` |
-| 373 / 395 | 0.539 / 0.607 | `zoomT ≥ pqAppearZoomT` | pull-quote fades in — sm 0.32, md 0.42 (from `--pq-pin-factor`) | `updatePullQuote` |
+| 373 / 395 | 0.539 / 0.607 | `zoomT ≥ pqAppearZoomT` | pull-quote fades in — sm 0.32, md 0.42 (from `--gg-pq-pin-factor`) | `updatePullQuote` |
 | 386 | 0.580 | `CURSOR_ZOOM_DISMISS_T` (0.38) | cursor label fades | `cursor.update` |
 | 390 | 0.593 | `CURSOR_ZOOM_RETIRE_T` (0.40) | cursor disc retires | `cursor.update` |
 | 509 | 0.966 | `zoomT ≥ 0.95` | canvas `display:none` (quote alone to the end) | `updateCanvasVisibility` |
-| 520 | 1.000 | runway end | pull-quote pin exits | CSS (`--pq-pin-factor`) |
+| 520 | 1.000 | runway end | pull-quote pin exits | CSS (`--gg-pq-pin-factor`) |
 
 Also on the timeline but **not** scroll-driven, so absent from the charts: texture loading
 (contours → un-dissolve, plus the one-time sm masonry re-solve on `onDone`), the modal
@@ -582,7 +582,7 @@ rather than restating them — it cannot drift from the code:
 ```sh
 cd libs/mep/ace1209/globe-gallery && node --input-type=module -e "
 import * as T from './src/timeline.js';
-const RUNWAY_VH = 520; // --runway-height
+const RUNWAY_VH = 520; // --gg-runway-height
 const tail = RUNWAY_VH - T.FORMATION_SCROLL_VH;
 const vh = (p) => (p <= T.SPHERE_FORMED_PROGRESS
   ? (p / T.SPHERE_FORMED_PROGRESS) * T.FORMATION_SCROLL_VH
@@ -684,8 +684,8 @@ The `--reduced` overrides are grouped at the **end of `globe-gallery.css`** (`no
 Phase constants (all in **`src/timeline.js`**) — these are the *inputs*; **Lifecycle timeline**
 above shows what they add up to. The `P_*` values live in **progress-space** (0→1) and shape formation
 + zoom; the runway split, pull-quote, and cursor retirement are covered under **Scroll model → the
-runway / progress model** above (they're driven by `--runway-height` / `--formation-vh` /
-`--pq-pin-factor` in CSS, read/derived in JS):
+runway / progress model** above (they're driven by `--gg-runway-height` / `--gg-formation-vh` /
+`--gg-pq-pin-factor` in CSS, read/derived in JS):
 
 ```
 P_PAN_END=0.55  P_ARC_PREROLL=0.30  P_GRID_ARC_START=0.30  P_GRID_ARC_END=0.60
@@ -717,11 +717,11 @@ spreads the fade over the whole window and still lands exactly on 0 at `outEnd`.
 `gpDelay = 0` case. All three live in `timeline.js`, so the global window and the per-card gate
 cannot drift apart.
 
-**Arc-copy placement** is split between CSS and JS: CSS owns the block edge (`bottom` — `8px` at
-sm, `24px` from `min-width:768px`, docking it to the viewport bottom on the same 24px gutter the JS
-uses inline-start), JS owns the inline-start inset per frame in `updateArcCopy` (`8px` at sm; at md
-`24 + max(0, (W − 48 − 1392) / 2)`, the 24px-grid-aligned position with centering) plus the opacity
-and the 24px entry slide.
+**Arc-copy placement is all CSS**; `updateArcCopy` owns only the opacity and the 24px entry slide.
+CSS sets both edges: `bottom` (`--s2a-spacing-xs` at sm, `--s2a-spacing-lg` from `min-width:768px`)
+and `inset-inline-start`, which shares the pull-quote's `--gg-content-inset` (see the CSS section
+below for the derivation and for why md+ offsets it back by `--gg-arc-pad`). The logical property
+handles RTL, so the JS side-swap that used to maintain `left`/`right` by hand is gone.
 
 **Entry timing** — two independent constants: `ENTRY_LEAD_VH` (`0.4`) viewport-heights before the
 block top that entry begins (`0` late; `0.85` is the prototype's hero pre-roll but sweeps meshes
@@ -752,10 +752,63 @@ rebuild would otherwise inherit:
   pose — else pitch/yaw dragged before a device change carried into the rebuilt barrel and rendered
   it tilted until a scroll-out zeroed it.
 
+**Tokens.** Every spacing, radius, border-width, font-size, font-weight and blur value that lands on
+an S2A scale uses the token, not the literal — including positional insets (`bottom`,
+`inset-inline-start`) and the `p + p` copy rhythm. Sizes tied to a specific design measurement stay
+literal, because pinning them to a coincidentally-equal token would imply a relationship that isn't
+there: the arc-copy `359px`/`382px` widths, the `138px` counter pill (mirrored by `DT_COUNTER_W`),
+the `375px` description measure, `--gg-pq-height` 583px, the 24/28px badge icons, and the 48px cursor
+disc. These values are **off every S2A scale** and stay literal on purpose — if any is retuned,
+snapping it to the nearest token is the cheaper fix:
+
+| value | where | nearest token |
+| --- | --- | --- |
+| `13px` font-size | modal role-label, badge app + role (sm) | none (scale is 12 / 14) |
+| `28px` line-height | modal name at md+ | none (24 / 32) |
+| `-0.6px` letter-spacing | modal name, both breakpoints | none (−0.48 / −0.96) |
+| `10px` gap | badge-left, badges at md+ | `--s2a-spacing-xs` 8 / `--s2a-spacing-sm` 12 |
+| `10px` padding-inline | cursor text pill | same |
+| `6px` radius | `--gg-control-radius` | `--s2a-border-radius-xs` 4 / `-sm` 8 |
+| `12px` blur | `--gg-chrome-blur` | `--s2a-blur-xs` 8 / `--s2a-blur-sm` 16 |
+| `18px` blur | modal backdrop | `--s2a-blur-sm` 16 |
+
+`--gg-chrome-blur` exists because that 12px appeared six times (modal arrows, close, info scrim, the
+md counter pill, the a11y tip, the cursor label). It is declared on `.globe-gallery` **and**
+`.globe-gallery-cursor` — `cursor.js` appends the cursor container to `<body>`, outside the block, so
+it cannot inherit. The same is true of any future local var the cursor needs.
+
+Note the font-size tokens are **rem** (`--s2a-font-size-sm` is `0.875rem`). Neither `libs/styles` nor
+`libs/c2/styles` overrides the root font-size, so they resolve to their nominal px — but unlike the
+px literals they replaced, this block's type now scales with a reader's browser font-size setting,
+which is the intended C2 behaviour.
+
+**Naming.** Classes are `globe-gallery-*` (BEM-ish, matching the block name); every custom property
+this block *defines* is `--gg-*`, the initials convention other C2 blocks use (`--bc-` in
+brand-concierge, `--rm-` in router-marquee). Nothing here defines an unprefixed property: the block
+is a full-viewport hero on shared pages, so a bare `--runway-height` or `--desc-fade-top` could
+inherit a stranger's value from an ancestor. Props read or written from JS
+(`--gg-pq-pin-factor` in `doLayout`, `--gg-desc-fade-top` / `--gg-desc-fade-bottom` in
+`updateDescFade`, `--gg-modal-edge` in `positionModalChrome`) are the coupling points — grep both
+files before renaming one. Only `--s2a-*` tokens come from upstream, and one of them
+(`--s2a-font-letter-spacing-neg-0_48`) has an underscore, which is why `custom-property-pattern` is
+disabled on that single line rather than file-wide.
+
 CSS is authored **mobile-first** and keeps its own three type tiers independently of the JS
 profiles: sm is the unscoped `.globe` base, then `@media (min-width:768px)` (md) and `1280px` (lg)
 layer larger scales on top. Modal/arc-copy is the same — sm (dark frosted panels) base,
 `min-width:768px` overrides to the desktop card.
+
+The **arc copy and the pull-quote share one left copy edge**, `--gg-content-inset` on
+`.globe-gallery`: `max(0px, 100vw - --gg-copy-max) / 2 + --gg-copy-pad`, i.e. the pull-quote's own
+text edge (it centres a `--gg-copy-max` 1920px box and pads it by `--gg-copy-pad`, and the rule
+consumes the same two vars so the pair cannot drift). The arc copy is `position: fixed`, so its
+`inset-inline-start` resolves against the viewport and RTL is handled by the logical property —
+there is no JS involved. At sm it pins 8px from the edge and its own `--gg-arc-pad` (16px) lands the
+copy on the inset; at md+ the pill background is gone, so the box is offset back by that padding
+(`calc(var(--gg-content-inset) - var(--gg-arc-pad))`) to put the *copy*, not the box, on the edge.
+Before this, `updateArcCopy` positioned the box per-frame from a 1392px content grid
+(`24 + max(0, (W - 48 - 1392) / 2)`), which put the arc copy 16px inboard of the pull-quote below
+1440px and up to 256px inboard above it (1920px viewport: copy at 280px vs the quote's 24px).
 
 ## Analytics
 
@@ -914,15 +967,38 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   `positionModalChrome`, reading as one bottom-centre row at every breakpoint. **Desktop/tablet:** the
   counter pill centres horizontally on the image, an arrow `DT_NAV_GAP` (12px) each side; the pill is
   a fixed `DT_COUNTER_W` (138px, mirror its CSS `width`) so the flank offset needs no measuring; all
-  three share one `bottom` — a fixed 24px from the *viewport* bottom (not the image bottom), so the
-  row sits at the same height across images regardless of the photo's aspect ratio — 44px tall. **Mobile:** the same row spread wide into the bottom-left/right
+  three share one `bottom` — `--gg-modal-edge` from the *viewport* bottom (not the image bottom), so the
+  row sits at the same height across images regardless of the photo's aspect ratio — 48px tall. **Mobile:** the same row spread wide into the bottom-left/right
   corners inside the bottom scrim. The three frosted controls (both arrows + close) share one style
-  (1px `--s2a-color-transparent-white-24` border, `--s2a-border-radius-4`,
-  `--s2a-color-transparent-black-64`, `blur(12px)`); close sits top-right at every breakpoint. The
+  (1px `--s2a-color-transparent-white-24` border, `--gg-control-radius`,
+  `--s2a-color-transparent-black-64`, `blur(12px)`) and one 48×48 `--gg-control-size` hit target at
+  every breakpoint; close sits top-right at every breakpoint. Chrome geometry is three locals on
+  `.globe-gallery-modal-chrome`: `--gg-modal-edge` (`--s2a-spacing-md` → `--s2a-spacing-lg` at md+;
+  the single inset for all four controls *and* the scrim padding — `positionModalChrome` assigns the
+  `var()` string so nothing is duplicated in JS), `--gg-control-size` (48px, mirrored as `NAV_SIZE`
+  only because the desktop flank offset needs it as a number), and `--gg-control-radius` (6px — a
+  literal; S2A's radius scale has no 6px step). `--gg-modal-edge` is also the sm scrim's
+  `padding-bottom` reserve (`edge + control + edge`, so the arrows clear the badges); at md+ the
+  arrows sit under the image instead, so the override drops the reserve to a flat `edge`. The
   **visible image** is contain-fit to the viewport minus a symmetric margin (desktop `DT_IMG_MARGIN`
   12px; mobile full-bleed to screen width, square corners `uRadius=0`), native aspect kept — the
   sizing math backs the geometry out of the SDF corner inset (`uRadius·cardHPx`) so the *photo*, not
-  the geometry, reaches the margin. Desktop adds a fixed-width (`DT_SCRIM_W` 316px) dark frosted
+  the geometry, reaches the margin. The desktop corner radius is a **constant `MODAL_RADIUS_PX`
+  (16px) on screen for every card**, not a fixed fraction of height. `uRadius` is normalised to card
+  *height*, so `modalDesktopFit(uAspect)` solves the plane height as photo + 2·16px and derives
+  `radiusFrac = 16 / cardHPx` — per card, because `cardHPx` depends on whether that card's aspect
+  makes the fit width- or height-limited. Fixing the radius in px also removes the old circular
+  dependency (with a fractional radius the fit divided by `1 - 2·uRadius`).
+  `modalRadiusFrac(uAspect)` wraps it with the mobile `0`; it takes the **aspect**, not the card,
+  because that is the only per-card input — `uAspect = cardAspect × sphereScaleX`, and despite the
+  name `sphereScaleX` is not a sphere-phase transform, it is the card's native image aspect relative
+  to the base card aspect (set on texture decode, see `loadOverflowTexture`). The modal is still
+  WebGL geometry (a plane in `modalScene` under the same perspective camera), so this is the same
+  aspect the sphere phase uses. Because the fraction depends on the fit, `computeModalTarget`
+  re-pushes `uRadius` **per-frame** — a resize, or an overflow card's late aspect correction on
+  decode, changes `cardHPx`; the `getModalMaterial` / `createOverflowCard` assignments (and the
+  `createModalMaterial` initialiser) only seed the frames before it first runs.
+  Desktop adds a fixed-width (`DT_SCRIM_W` 316px) dark frosted
   scrim on the **viewport's left edge, full height**; mobile's scrim is one full-width bottom chunk
   (content-sized, capped at `60dvh`). Both are a **pinned header / scrolling body / pinned footer**:
   role + name are `flex-shrink:0` at the top, the **badges** are `flex-shrink:0` at the bottom (so
@@ -1223,7 +1299,7 @@ Known follow-ups, not blocking this integration branch:
 - **Pacing: landing on the pristine formed globe.** On touch, scroll-spin arbitration is correct
   (see Behavior notes → Touch gesture arbitration), but how easily a user *comes to rest* exactly on
   the fully-formed, still globe is a scroll-pacing tuning matter still open.
-- **Pull-quote uses a hardcoded `--pq-height: 583px`.** It's a shortcut (enables `top: calc(50vh -
+- **Pull-quote uses a hardcoded `--gg-pq-height: 583px`.** It's a shortcut (enables `top: calc(50vh -
   h/2)` centering + a predictable hold = `pin − h`), but it's brittle to copy length — longer/localized
   strings overflow the fixed box (no `overflow` handling), shorter copy leaves a dead gap under
   `justify-content: space-between`. Make it copy-flexible (revisit in a future session). Two options:
@@ -1239,4 +1315,4 @@ Known follow-ups, not blocking this integration branch:
     `height`) so the quote/attribution stay spread; tolerates overflow better than today but partly
     keeps the rigidity. Only if the spread is a deliberate editorial layout worth preserving.
   - Decision needed from design: grouped (A) vs spread (B). See Scroll model → runway / progress model
-    for how `--pq-height` feeds the hold.
+    for how `--gg-pq-height` feeds the hold.

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -917,11 +917,10 @@ from `globe-gallery.css`; `progress` and the gate columns are runway-independent
 | 277 | 0.294 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` | hover / drag / click / auto-rotate go **live**; a11y browse enabled; desktop cursor appears; globe controls fade in; hint-plane entrance **resolves** (warp → 0) | `updateSphereRotation`, `updateCardTransform`, `cursor.update`, `controls.update`, `updateClickDragText` |
 | 304 | 0.322 | `SPHERE_FORMED_PROGRESS` | sphere/barrel formed; `sphereFormT` = 1, `zoomT` leaves 0; keyboard focus snaps here | `computeFrame` |
 | ~338 | ~0.470 | camera passes the shell's centre | shell is **effectively empty** — only far-pole cards left in frame (`zoomT` ≈ 0.22) | `updateActiveCamera` |
-| 343 | 0.491 | `CONTROLS_ZOOM_HIDE_T` | globe controls fade out (also leave the tab order) | `controls.update` |
-| 352 | 0.529 | `zoomT ≥ pqAppearZoomT` (sm 0.3057) | **sm**: camera clears the barrel's far wall → quote revealed centred **and** un-stuck the same frame | `updatePullQuote` + CSS |
+| 352 | 0.529 | `zoomT ≥ pqAppearZoomT` (sm 0.3057) | **sm**: camera clears the barrel's far wall → quote revealed centred **and** un-stuck the same frame; globe controls fade out (also leave the tab order) | `updatePullQuote` + CSS, `controls.update` |
 | 356 | 0.548 | `zoomT ≥ 1 / TEXT_ZOOM_FADE_RATE` | hint text fully faded | `updateClickDragText` |
 | 359 | 0.559 | `CURSOR_ZOOM_RETIRE_T` | cursor label + disc retire together (desktop only, so ahead of md's reveal) | `cursor.update` |
-| 369 | 0.605 | `zoomT ≥ pqAppearZoomT` (md 0.4170) | **md**: same, one card-shell radius later; next section's top is 91vh down the viewport | `updatePullQuote` + CSS |
+| 369 | 0.605 | `zoomT ≥ pqAppearZoomT` (md 0.4170) | **md**: same, one card-shell radius later, controls included; next section's top is 91vh down the viewport | `updatePullQuote` + CSS, `controls.update` |
 | 452 | 0.966 | `zoomT ≥ 0.95` | canvas `display:none` | `updateCanvasVisibility` |
 | 460 | 1.000 | runway end | quote is long gone; next section's top reaches the viewport top | CSS |
 
@@ -1056,16 +1055,35 @@ on the barrel only, a **rotate ← / hint copy / rotate →** row on the bottom 
 | Rotate row | barrel only (`.globe-gallery-barrel`, from `bp.CYLINDER`) | The barrel has neither the WebGL hint plane (`buildTextMesh` is skipped) nor the custom cursor (hover+fine only), so touch users otherwise get **no** affordance at all. The arrows also make the copy's "click and drag" claim actionable without a drag. |
 
 - **One visibility window** for the whole layer: `sphereFormT >= SPHERE_INTERACTIVE_T`, no modal
-  open, `zoomT < CONTROLS_ZOOM_HIDE_T` — i.e. exactly while the globe is draggable. `controls.js`
+  open, `zoomT < pqAppearZoomT` — i.e. exactly while the globe is draggable. `controls.js`
   writes the `is-visible` class only when that boolean flips. CSS transitions `opacity` **and
   `visibility`**; the latter is what pulls the buttons out of the tab order while hidden, so the
   block's tab stops never point at invisible chrome.
+- **The hide edge is a place in the scene, not a scalar** — the same cue the pull-quote rides, so
+  the two share one number and can't drift apart. It used to be its own constant,
+  `CONTROLS_ZOOM_HIDE_T` = 0.25, which was **band-independent while every input to the cue is
+  per-band**: `publishPqAppearZoomT` derives the clear point from `SPHERE_R`, the card's radial
+  extent, `CAM_Z_SPHERE` and `CAM_Z_END`, landing on **0.306 on sm but 0.417 on md**. So 0.25 fit
+  the barrel to within 0.056 — you couldn't see it — and retired the sphere's controls a third of
+  the way early, leaving a stretch where the globe was still in frame and still auto-spinning with
+  its pause button already gone (a WCAG **2.2.2** hole, since the ambient spin is the one motion in
+  the zoom-through that *isn't* scroll-driven). md is the band that exposes it because its shell is
+  proportionally far deeper into the camera's travel — `SPHERE_R/CAM_Z_SPHERE` is 0.538 against
+  sm's 0.229 — and because its cards mount radially, so the extent term is the card's full
+  diagonal rather than the cylinder's `CARD_W/2`. Anything else keyed to "the globe has left" wants
+  `pqAppearZoomT` too, not a fresh constant.
 - **Tab order is entry widget → spin → rotate ← → rotate →.** `a11y.js` appends its nodes during
   its own setup, which would leave the controls *ahead* of them in the DOM — where a
   forward-tabbing user would walk past them while they're still hidden and never come back.
   `controls.setup()` therefore runs after `a11y.setup()` and re-appends its layer last. Focusing
   the entry widget snaps the page to the formed globe, so the controls are visible by the time the
-  next Tab lands on them.
+  next Tab lands on them. **Hiding does NOT hand focus anywhere, deliberately.** When the fade takes
+  a focused control unfocusable, `document.activeElement` goes to `<body>` — which looks like a
+  dropped tab stop but isn't: the browser keeps its *sequential focus navigation starting point*
+  where the control was, so Tab continues into the sections below and Shift+Tab returns to the entry
+  stop. Verified in-browser. Re-focusing the entry widget here would be a regression, not a fix — the
+  scroll that hides the controls is the user leaving the block, so pulling focus back would put them
+  behind where they were and walk them through the globe chrome a second time.
 - **The spin toggle names the action it performs**, so both the `aria-label` and the `daa-ll` swap
   with the state (authored `pause spinning` / `resume spinning`). No `aria-pressed` — a toggle whose
   label already changes would announce twice.
@@ -1079,7 +1097,7 @@ on the barrel only, a **rotate ← / hint copy / rotate →** row on the bottom 
   visible wall moves opposite and `rotateStep` negates `dir` exactly as drag negates via `dragDir`.
   That window is real, not theoretical: `dragFlipZ` is clamped to `[SPHERE_R, 0.95 · CAM_Z_SPHERE]`,
   so the camera is inside from `zoomT` ≈ 0.09–0.16 at the latest while the controls stay up until
-  `CONTROLS_ZOOM_HIDE_T` = 0.25.
+  `pqAppearZoomT` (sm 0.306 / md 0.417).
 - **A press eases to the next column BOUNDARY, it does not add a column pitch.** Ambient spin
   leaves the barrel at an arbitrary angle, so `y += 2π/cols` carries that offset forward forever
   — face 1.5 columns, press, face 2.5. Snapping instead means a column lands front-centre from any
@@ -1105,6 +1123,11 @@ on the barrel only, a **rotate ← / hint copy / rotate →** row on the bottom 
   breadcrumbs the fixed layer sits under.
 - **Reduced motion** keeps the rotate row (it's the non-drag path to the rest of the wall, and the
   nudge lands instantly under RM) and **hides the spin toggle** — there is no auto-spin to pause.
+- **RTL pins the row's visual order, and does NOT flip the arrow icons.** The modal's prev/next are
+  reading-order, so their SVGs mirror; rotate is *spatial* — `dir −1` sends the surface screen-left
+  in every locale — so a mirrored ← would lie about which way the globe goes. Left alone, though,
+  the flex row mirrors under `dir="rtl"` and parks the ← button on the right, so
+  `html[dir="rtl"] .globe-gallery-hint` sets `flex-direction: row-reverse` to cancel it.
 
 ## Accessibility
 
@@ -2113,7 +2136,6 @@ bare names — are:
 | `SPHERE_ORIENT_RESET_T` | `sphereFormT` | below this a scroll-out resets the sphere orientation **and drag inertia** (a brief dip mid-scroll keeps both) |
 | `FRAME_MS` / `DT_SCALE_MIN` / `_MAX` | ms / ratio | the frame every per-frame rate is authored against (`1000/60`), and the clamp on `frame.dtScale` — a stall must not teleport what it drives, a very short frame must not underflow a decay (see Drag physics) |
 | `TEXT_ZOOM_FADE_RATE` | `zoomT` | hint text is fully faded at `zoomT` = `1 / RATE` |
-| `CONTROLS_ZOOM_HIDE_T` | `zoomT` | globe controls fade out here — they steer a globe the camera is already flying through (see Globe controls) |
 | `GRID_PEEL_WINDOW` | `gridFormT` | `1 − GRID_PEEL_STAGGER`; the span each card's peel occupies after its stagger delay (`frame.gpWin`) |
 | `GRID_ARC_RANGE` / `FOLD_WINDOW` | — | derived spans: `PROGRESS_GRID_ARC_END − _START`, and `SPHERE_FORMED_PROGRESS − FOLD_FIRST_PROGRESS` |
 | `progressAtFormT` | — | maps a `sphereFormT` back to progress; used to derive `ARC_COPY_OUT_START` / `_END`. Nothing here exists only for docs — Milo ships these files unbundled, so a doc-only export is pure payload (the `zoomT` inverse lives in the derivation snippet instead) |

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -54,7 +54,8 @@ Sphere rotation + Touch gesture arbitration.
 Extras: per-frame chromatic-aberration SVG filter, a fixed arc-copy overlay, a
 fixed pull-quote that fades in near the zoom end, a WebGL **"Click & Drag" hint
 text** behind the sphere (warps in on fold, dissolves away on first drag — see
-Behavior notes), and a **two-level a11y gallery** (see Accessibility below): a single
+Behavior notes), **globe controls** (an auto-spin play/pause toggle everywhere plus a
+rotate/hint/rotate row on the barrel — see Globe controls), and a **two-level a11y gallery** (see Accessibility below): a single
 focusable entry widget whose Enter opens a keyboard/screen-reader browse mode that tabs
 through each image (centring it on the globe) rather than exposing a flat per-card list.
 
@@ -63,7 +64,7 @@ through each image (centring it on the globe) rather than exposing a flat per-ca
 | File | What it is |
 | --- | --- |
 | `globe-gallery.js` | The block + sphere render core. `export default init(el)` → builds DOM, runs `createGlobeGalleryRuntime()` → `{ init, destroy }`. Holds the *visual* tuning constants (scroll **timing** lives in `timeline.js`) and the stateful core: arc/grid/fold/sphere placement, drag physics, lifecycle. `tick()` orchestrates single-concern stages; `updateCardTransform` dispatches over four placement branch fns. Instantiates the DI modules. See Module layout. |
-| `authoring.js` | `parseAuthoredContent` + `fetchFragmentCards` + `buildGlobeDom(el, labels, { arcCopy, pullQuote })` (+ internal parsers). Reads the block rows positionally, fetches the card fragment, and builds the canvas/overlay/modal DOM — minting + returning the per-instance `gid` id suffix, filling the arc-copy / pull-quote slots. Badge logos are `/federal` assets resolved via Milo's `getFederatedUrl`. |
+| `authoring.js` | `parseAuthoredContent` + `fetchFragmentCards` + `buildGlobeDom(el, labels, { arcCopy, pullQuote, touchHint })` (+ internal parsers). Reads the block rows positionally, fetches the card fragment, and builds the canvas/overlay/modal DOM — minting + returning the per-instance `gid` id suffix, filling the arc-copy / pull-quote slots. Badge logos are `/federal` assets resolved via Milo's `getFederatedUrl`. |
 | `shaders.js` | GLSL: `CARD_VERT`/`CARD_FRAG`, `MODAL_VERT`/`MODAL_FRAG`, `TEXT_FRAG`. Card/modal frags round corners with one analytic SDF (`rrSDF`), no rasterized mask. The two use *different* box conventions: `CARD_FRAG` fills the plane edge-to-edge, while `MODAL_FRAG` insets the shape by `uRadius` on all four sides (see Modal chrome). `TEXT_FRAG` adds a barrel warp + particle dissolve + the `uExitP` one-way exit. |
 | `materials.js` | GPU-asset factories (named exports, no per-instance state). **Materials:** `createCardMaterial`, `createModalMaterial`, `createTextMaterial`. **Textures:** `loadCardTextures({ maxTexH })` (a `CanvasTexture` per card, capped on height — see Texture memory budget — reporting each image's native aspect and nothing else), `loadModalTexture(src, maxTex, onReady)` (lazy, longest-side cap, returns the pending `Image` to cancel), `createClickDragTexture(aspect, hintText)`. |
 | `a11y.js` | `createGalleryA11y(deps)` → `{ setup, updateTabStops, teardown, isBrowsing }`. The two-level gallery (see Accessibility). All runtime state + actions (`centerCard`, `openCard`, `onFocus`) injected; holds no globe state but its DOM. |
@@ -71,6 +72,7 @@ through each image (centring it on the globe) rather than exposing a flat per-ca
 | `math.js` | Pure stateless helpers. **Easings:** `easeOutCubic`, `easeInOutCubic`, `easeOutSine`, `lerpN`. **Arc-phase geometry:** `arcRotationEase`, `buildArcCtx`, `getFanData`, `cssToWorld`, `rotateArcPoint`, `arcCamZ` — the fanned-arc layout + CSS↔WebGL bridge. The last three take an optional `out` and **write into it** (the core passes reused scratch objects), so per-frame placement produces no garbage. |
 | `timeline.js` | **The scroll timeline** — the single place to change **when** something happens. Every phase constant and threshold, plus `createFrame` / `createFrameInput` / `deriveFrame(frame, input)`, the pure derivation of all six clocks, and `cardFoldStartProgress(gpDelay)` (the per-card fold gate; `FOLD_FIRST_PROGRESS` is its `gpDelay = 0` case). No THREE, no DOM, no closure state, so it's unit-testable in isolation. `deriveFrame` writes into a caller-owned frame, allocates nothing, and clamps NaN-safely — one NaN would poison every mesh position. Imported as a namespace (`import * as TL`). See Lifecycle timeline. |
 | `interaction.js` | `createInteraction(deps)` → `{ setup, teardown, isPageScrollGesture }`. Canvas pointer plumbing: drag-to-spin, click-vs-drag, raycast hover + click→modal. Shares travel + velocity by reference via the `drag` object (see **Drag physics**). Owns the **touch axis lock** and exports `isPageScrollGesture()` (see Behavior notes). Cedes its hover cursor to the custom cursor via `isCursorActive()`. |
+| `controls.js` | `createGlobeControls(deps)` → `{ setup, update, teardown, isSpinPaused }`. The on-canvas globe chrome (see Globe controls): the auto-spin play/pause toggle and the barrel's rotate/hint/rotate bottom row. Owns `paused` (the core reads `isSpinPaused()` each frame); its DOM is minted by `buildGlobeDom`, so it only binds, labels, and toggles classes. |
 | `cursor.js` | `createCursor(deps)` → `{ setup, update, teardown, isActive }`. The desktop custom cursor (see Behavior notes): two body-level layers (`mix-blend-mode` disc + fixed chevron/label container), per-frame state from injected getters, the two-step retirement, `isActive()` gating interaction's cursor. No-op on touch. |
 | `globe-gallery.css` | Globe-only CSS. Also defines `.globe-gallery`-scoped type-scale tokens (see Behavior notes). |
 | `three-src.js` | Build entry — re-exports only the Three.js symbols the block uses. |
@@ -112,8 +114,9 @@ Who writes what:
 `interaction.js` — see Drag physics),
 `masonryMorph` (`active`/`t`), `sphereOrient` (`x` pitch / `y` yaw / `z` roll — see Sphere rotation),
 `navNudge` (`active`, `target{X,Y,Z}` destination pose, `start{X,Y,Z}` pose when armed,
-`frame`/`frames` elapsed/total from `KEY_BROWSE_FRAMES` or `KEY_MODAL_FRAMES`; `targetZ` is roll, set
-by keyboard centring only), `arcCopy` (`el` + last-written style strings, so `updateArcCopy` only
+`frame`/`frames` elapsed/total from `KEY_BROWSE_FRAMES`, `KEY_MODAL_FRAMES` or
+`ROTATE_STEP_FRAMES`; `targetZ` is roll, *changed* by keyboard centring only — the other two
+callers pin it), `arcCopy` (`el` + last-written style strings, so `updateArcCopy` only
 touches the DOM on change), and `ctxLoss` (see WebGL context loss).
 
 **`tick()`'s stage order is load-bearing** — producers before consumers, and two stages read *last*
@@ -129,9 +132,9 @@ their inputs only change on a rebuild or a texture landing: `dragFlipZ` (`recomp
 masonry solve.
 
 Per-card placement (the largest stage) is a dispatcher over four runtime-scope branch fns — kept in
-this file because they read deeply from the closure and run in the hot loop. Five DI modules are
-injected with live-state getters: `materials.js`, the a11y widget, the modal, `interaction.js`, and
-the cursor. The modal owns its canvas/scene + the `MODAL_PHASE` state machine and reaches the sphere
+this file because they read deeply from the closure and run in the hot loop. Six DI modules are
+injected with live-state getters: `materials.js`, the a11y widget, the modal, `interaction.js`, the
+cursor, and the globe controls. The modal owns its canvas/scene + the `MODAL_PHASE` state machine and reaches the sphere
 only through the shared `sphereRotQuat` / `snapToSphereSlot` / `requestNavNudge` callbacks.
 
 ## Rebuilding Three.js
@@ -141,20 +144,34 @@ After adding a new `THREE.*` call, add the symbol to `src/three-src.js`, then
 
 ## Authoring contract
 
-The block expects up to **four direct child rows** (the hint and pull-quote rows
-are optional):
+The block expects up to **five direct child rows** (the pull-quote row is optional):
 
 | Row | Purpose | Content |
 | --- | --- | --- |
 | 0 | **Arc-copy** | heading → `.globe-gallery-arc-copy-title`; remaining `<p>`s → `.globe-gallery-arc-copy-body` (each authored paragraph is reused as-is, inline markup included) |
 | 1 | **Cards** | a Milo fragment link with `#_dnb` appended (see below) |
-| 2 | **Hint + instructions + labels** | first `<p>` → WebGL "Click & Drag" affordance (falls back to `Click & Drag` if empty/absent); optional second `<p>` → a11y entry-widget instructions (English fallback); optional third `<p>` → the four UI labels, `\|\|`-separated in on-screen order **prev-arrow \|\| card-position template \|\| next-arrow \|\| close** (each part falls back to English) |
-| 3 | **Pull-quote** | heading → quote; first `<p>` → name; second `<p>` → role |
+| 2 | **Hint copy** — two cells | **cell 0** → the barrel's visible bottom row (mobile), the sentence between the rotate arrows; **cell 1** → the WebGL hint plane + desktop cursor label (the short one). Either cell may be authored as several `<p>`s — they're joined with a space — or as bare cell text |
+| 3 | **A11y strings** | one cell, `\|\|`-separated in on-screen order: **instructions \|\| rotate-left \|\| rotate-right \|\| pause-spin \|\| resume-spin \|\| prev-arrow \|\| card-position template \|\| next-arrow \|\| close** — nine parts, the entry-widget instructions first. Each part falls back to English independently |
+| 4 | **Pull-quote** | heading → quote; first `<p>` → name; second `<p>` → role |
 
 Rows are positional. `parseAuthoredContent(el)` returns
-`{ arcCopy, pullQuote, fragmentHref, hintText, instructions, labels }` (`labels` =
-`{ prevCard, nextCard, closeBtn, cardLabel }`, built by `buildLabels` from row 2's
-third `<p>`); cards are loaded separately from the fragment link by `fetchFragmentCards`.
+`{ arcCopy, pullQuote, fragmentHref, hintText, touchHint, instructions, labels }` (`labels` =
+`{ rotateLeft, rotateRight, pauseSpin, resumeSpin, prevCard, nextCard, closeBtn, cardLabel }`, built
+by `buildLabels` from row 3's parts — which it indexes 1:1, so `DEFAULT_LABELS[0]` is the
+instructions slot even though `buildLabels` itself doesn't expose it); cards are loaded separately
+from the fragment link by `fetchFragmentCards`.
+
+**Two cells, not one `||` pair.** The hint strings render in two unrelated places — a WebGL texture
+and an HTML row — at different breakpoints and different lengths, so they get a column each rather
+than sharing a divider. The divider now means exactly one thing: "this is row 3."
+
+**No back-compat path.** An earlier contract packed rows 2 and 3 into a single row (a `<p>` of
+`<cursor label> \|\| <touch instruction>`, an instructions `<p>`, a label-list `<p>`) with the
+pull-quote at row 3, and content published before the globe controls shipped carried only the four
+modal labels. None of that is read any more: the parse is **strictly positional**, because on this
+block re-authoring the table is cheaper than carrying a second parse shape forever. A page still on
+an old shape doesn't half-work — it mis-assigns strings — so **republish the content and the code
+together**.
 
 ### Fragment loading
 
@@ -386,20 +403,25 @@ The block ships **no hardcoded user-facing copy** and reads **no placeholders sh
 user-facing string is authored (block rows + card fragment) and localized with the page; hardcoded
 literals in the code are only fallbacks that never show on a correctly-authored page.
 
-**Row 2 carries all the block-chrome copy** in up to three `<p>`s, each localized inline:
+**Rows 2 and 3 carry all the block-chrome copy**, each string localized inline:
 
-| Row 2 `<p>` | String | Used for | Fallback |
+| Where | String | Used for | Fallback |
 | --- | --- | --- | --- |
-| 1st | "Click & Drag" | WebGL hint + desktop cursor label (decorative, not exposed to AT — the a11y instructions cover the real affordance; `createClickDragTexture` auto-scales the font) | `Click & Drag` (empty-cell) |
-| 2nd | instructions | a11y entry-widget accessible name (see below) | `Press Enter to enter the gallery, then Tab through the images.` (`DEFAULT_GALLERY_INSTRUCTIONS`) |
-| 3rd | `prev \|\| {index} of {count} \|\| next \|\| close` | the four UI labels: modal prev/next/close `aria-label`s + the sr-only card **position** — `\|\|`-separated in on-screen left→right order (`buildLabels`) | each part → English (`DEFAULT_LABELS`) |
+| Row 2, cell 0 | touch instruction | the barrel's visible bottom-row copy, between the rotate arrows (see Globe controls). Real on-screen prose, so it's a sentence, not a label — author it as one `<p>` per sentence if you like, they're joined | `Click and drag to rotate. Tap to dive deep into the artwork.` (`DEFAULT_TOUCH_HINT`) |
+| Row 2, cell 1 | "Click & Drag" | WebGL hint + desktop cursor label (decorative, not exposed to AT — the a11y instructions cover the real affordance; `createClickDragTexture` auto-scales the font, so keep it short) | `Click & Drag` (`DEFAULT_HINT`) |
+| Row 3, part 1 | instructions | a11y entry-widget accessible name (see below) | `Press Enter to enter the gallery, then Tab through the images.` (`DEFAULT_GALLERY_INSTRUCTIONS`) |
+| Row 3, parts 2–9 | `rotate left \|\| rotate right \|\| pause \|\| resume \|\| prev \|\| {index} of {count} \|\| next \|\| close` | the eight UI labels: the globe controls' four `aria-label`s (the spin toggle names the action it performs, so it needs both states) + modal prev/next/close `aria-label`s + the sr-only card **position** — `\|\|`-separated in on-screen order (`buildLabels`) | each part → English (`DEFAULT_LABELS`) |
+
+The instructions lead row 3 because they are the a11y row's subject: one cell holding every string
+a screen-reader or keyboard user hears, in the order they meet them — the entry announcement first,
+then the controls it tells them about.
 
 The card-position part is a **tokenized template**: single-brace ICU-style `{index}`/`{count}`
 substituted at runtime so each locale controls word order. Single brace keeps them distinct from
 Milo's `{{key}}` placeholder syntax; a value missing either token falls back to `{index} of {count}`.
 The `\|\|` divider is safe because the pipe is not natural-language punctuation in any locale.
 
-The entry widget has **no separate name label**: its authored **instructions** (row 2, 2nd `<p>`)
+The entry widget has **no separate name label**: its authored **instructions** (row 3, 1st part)
 ARE its accessible name (one hidden-until-focus element serving as both the popup and the
 `aria-labelledby` target), so a screen reader announces exactly the on-page instruction — no
 redundant "N images" prefix. The modal announcement is position only (the creator name is already
@@ -847,8 +869,9 @@ from `globe-gallery.css`; `progress` and the gate columns are runway-independent
 | 170 | 0.180 | `sphereFormT > DEPTH_SORT_FORM_T` | `renderer.sortObjects` on (arc needs manual order, sphere needs depth sort) | `tick` |
 | 273 | 0.289 | first card's `fdE` hits 1 | earliest card actually **on the shell** (`sphereFormT` ≈ 0.884) | `updateCardTransform` |
 | 277 | 0.294 | `ARC_COPY_OUT_FORM_END` of the fold window | **arc-copy fully gone** | `updateArcCopy` |
-| 277 | 0.294 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` | hover / drag / click / auto-rotate go **live**; a11y browse enabled; desktop cursor appears; hint-plane entrance **resolves** (warp → 0) | `updateSphereRotation`, `updateCardTransform`, `cursor.update`, `updateClickDragText` |
+| 277 | 0.294 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` | hover / drag / click / auto-rotate go **live**; a11y browse enabled; desktop cursor appears; globe controls fade in; hint-plane entrance **resolves** (warp → 0) | `updateSphereRotation`, `updateCardTransform`, `cursor.update`, `controls.update`, `updateClickDragText` |
 | 304 | 0.322 | `SPHERE_FORMED_PROGRESS` | sphere/barrel formed; `sphereFormT` = 1, `zoomT` leaves 0; keyboard focus snaps here | `computeFrame` |
+| 358 | 0.491 | `CONTROLS_ZOOM_HIDE_T` | globe controls fade out (also leave the tab order) | `controls.update` |
 | 376 | 0.548 | `zoomT ≥ 1 / TEXT_ZOOM_FADE_RATE` | hint text fully faded | `updateClickDragText` |
 | 369 / 395 | 0.525 / 0.607 | camera passes the cards | globe clears the viewport — sm ≈ `zoomT` 0.30, md ≈ 0.42 | `updateActiveCamera` |
 | 373 / 395 | 0.539 / 0.607 | `zoomT ≥ pqAppearZoomT` | pull-quote fades in — sm 0.32, md 0.42 (from `--gg-pq-pin-factor`) | `updatePullQuote` |
@@ -962,6 +985,64 @@ block top that entry begins (`0` late; `0.85` is the prototype's hero pre-roll b
 over content above), and `ENTRY_RAMP_VH` the ramp over which `arcCopyEntryT` goes 0→1
 (arc-copy fade, arc pre-roll speed, text→arc gap).
 
+## Globe controls
+
+HTML chrome over the live globe (`controls.js`, markup from `buildGlobeDom`, styled from the
+`--gg-controls-*` custom properties): a **spin play/pause** toggle in the top inline-end corner and,
+on the barrel only, a **rotate ← / hint copy / rotate →** row on the bottom edge.
+
+| | Where | Why |
+| --- | --- | --- |
+| Spin toggle | every breakpoint / shape | Auto-spin is motion that starts on its own and never stops. WCAG **2.2.2** wants a pause mechanism, so this ships on the sphere too, not just the barrel. |
+| Rotate row | barrel only (`.globe-gallery-barrel`, from `bp.CYLINDER`) | The barrel has neither the WebGL hint plane (`buildTextMesh` is skipped) nor the custom cursor (hover+fine only), so touch users otherwise get **no** affordance at all. The arrows also make the copy's "click and drag" claim actionable without a drag. |
+
+- **One visibility window** for the whole layer: `sphereFormT >= SPHERE_INTERACTIVE_T`, no modal
+  open, `zoomT < CONTROLS_ZOOM_HIDE_T` — i.e. exactly while the globe is draggable. `controls.js`
+  writes the `is-visible` class only when that boolean flips. CSS transitions `opacity` **and
+  `visibility`**; the latter is what pulls the buttons out of the tab order while hidden, so the
+  block's tab stops never point at invisible chrome.
+- **Tab order is entry widget → spin → rotate ← → rotate →.** `a11y.js` appends its nodes during
+  its own setup, which would leave the controls *ahead* of them in the DOM — where a
+  forward-tabbing user would walk past them while they're still hidden and never come back.
+  `controls.setup()` therefore runs after `a11y.setup()` and re-appends its layer last. Focusing
+  the entry widget snaps the page to the formed globe, so the controls are visible by the time the
+  next Tab lands on them.
+- **The spin toggle names the action it performs**, so both the `aria-label` and the `daa-ll` swap
+  with the state (authored `pause spinning` / `resume spinning`). No `aria-pressed` — a toggle whose
+  label already changes would announce twice.
+- **A rotate press is a `navNudge`**, the same eased tween keyboard centring uses, with pitch and
+  roll pinned to their current values so a tap can never tilt the globe off level. `navNudge.kind`
+  records who armed it: the browse-exit edge in `updateSphereRotation` cancels only `'browse'`
+  tweens, because a pointer press on a rotate button collapses browse mode (`focusout` → `collapse`)
+  in the same event turn it arms its own nudge — without the tag, the next frame would silently eat
+  the press and the button would look dead. `dir −1` = the
+  surface travels screen-left, matching a leftward drag.
+- **A press eases to the next column BOUNDARY, it does not add a column pitch.** Ambient spin
+  leaves the barrel at an arbitrary angle, so `y += 2π/cols` carries that offset forward forever
+  — face 1.5 columns, press, face 2.5. Snapping instead means a column lands front-centre from any
+  starting yaw, and the first press absorbs the drift. The boundaries come from the **cards**, not
+  the layout: every card in a column shares an azimuth and therefore a `yawDeltaToCenter`, so the
+  distinct deltas across `cards` *are* the boundaries — which makes their count the column count
+  too, so nothing has to be threaded out of `cylinderMasonryLayout`. `ROTATE_DEADZONE` (a fraction
+  of a pitch) skips a boundary we're already sitting on, so ambient drift can't turn a press into a
+  twitch; travel is therefore 0.15–1.15 columns. Repeat taps **queue**: the boundary search measures
+  from `navNudge.targetY` while a rotate tween is in flight, so a second tap adds a column instead of
+  re-picking the one already in motion (which made a double-tap slower than a single one). **Mid-morph the read switches to `morph.posTo`**:
+  `resolveMasonryLayout` runs off the async texture callback, so on a slow connection the reflow can
+  start while the controls are already live, and during it `spherePos` is a per-frame lerp off the
+  sphere — no shared azimuths, so the distinct-delta count reads as one column per card and the step
+  collapses. The target slot outlives the morph and is what the tween should land on anyway.
+- **Auto-spin keeps running through a press.** `AUTO_ROT_SPEED` is ≈1.7°/s against a ~45° pitch
+  (8 columns on sm), so an aligned column holds for ~25s and each press re-snaps. Pausing on press
+  would make the arrows silently flip the play/pause button — two controls sharing one state.
+- **Spacing.** One gap off every viewport edge, `--gg-controls-inset`, stepping `--s2a-spacing-md`
+  (sm) → `--s2a-spacing-lg` (md+) in lockstep with the modal's `--gg-modal-edge`, so the two chrome
+  layers never disagree about how far off the edge a control sits. The spin toggle's `top` adds that
+  same gap to `--gg-controls-nav` (124px, measured — see CSS, Tokens), clearing the sticky gnav +
+  breadcrumbs the fixed layer sits under.
+- **Reduced motion** keeps the rotate row (it's the non-drag path to the rest of the wall, and the
+  nudge lands instantly under RM) and **hides the spin toggle** — there is no auto-spin to pause.
+
 ## Accessibility
 
 The globe is exposed as a **two-level gallery** (`a11y.js`), not a flat per-card list. Both levels
@@ -1025,7 +1106,7 @@ normal flow. The preference is **re-read on every `initRuntime`**, and a
 the OS setting mid-session rebuilds through the same `destroy()`+`init()` path as a band / pointer
 change (no reload; the non-RM path clears the canvas `position` so a toggle-off reverts cleanly).
 
-**RM overrides `position` and nothing else** for the three viewport-sized boxes — no duplicated
+**RM overrides `position` and nothing else** for the four viewport-sized boxes — no duplicated
 geometry, and `measureViewportH()` reads the same 100vh in both modes. That works because the base
 rules are written against the canvas box rather than the window: `.globe-gallery-a11y` sits at
 `top: 50vh` (not `50%`) and `.globe-gallery-a11y-cards` is a `100vh`-tall box (not `inset: 0`), so
@@ -1042,6 +1123,8 @@ positioned in canvas px). The pieces:
   is per-card, so a group scale is safe). `sm` (~49%) stays 1.
 - **A11y widget + focus-ring overlay** — `position:absolute` (were fixed); the base `top: 50vh` /
   `100vh` box already centre on the sphere, so neither override carries any offset.
+- **Globe controls** — `position:absolute` (was fixed), so the layer scrolls with the static globe;
+  the spin toggle is additionally `display:none` (nothing to pause). See Globe controls.
 - **Pull-quote** — drops `absolute`/`sticky` → `static`, forced `opacity:1`, hugs the top of its
   box so it sits under the globe; `updatePullQuote` early-returns (CSS owns it).
 - **Arc-copy** — `display:none` (no arc phase; a fixed pill would hang over the scrolling page).
@@ -1135,8 +1218,10 @@ the var is its home):
 | `-0.6px` letter-spacing | modal name, both breakpoints | none (−0.48 / −0.96) |
 | `10px` gap | badge-left, badges at md+ | `--s2a-spacing-xs` 8 / `--s2a-spacing-sm` 12 |
 | `10px` padding-inline | cursor text pill | same |
-| `--gg-control-radius` | modal controls | `--s2a-border-radius-xs` / `-sm` |
-| `--gg-chrome-blur` | modal arrows, close, info scrim, md counter pill, a11y tip, cursor label | `--s2a-blur-xs` / `--s2a-blur-sm` |
+| `--gg-control-radius` / `--gg-controls-radius` | modal controls / globe controls | `--s2a-border-radius-xs` / `-sm` |
+| `--gg-controls-size` 48px | globe controls | none (matches `--gg-control-size`) |
+| `--gg-controls-nav` 124px | globe controls' top offset | none — a *measured* value (top of screen → bottom of the breadcrumbs bar), not a design step. Re-measure it if the gnav or localnav changes height; the `--feds-*` vars can't be trusted for this (see Naming below) |
+| `--gg-chrome-blur` | modal arrows, close, info scrim, md counter pill, a11y tip, cursor label, globe controls | `--s2a-blur-xs` / `--s2a-blur-sm` |
 | `18px` blur | modal backdrop | `--s2a-blur-sm` 16 |
 
 `--gg-chrome-blur` exists because that one blur appeared six times across those places. It is declared on `.globe-gallery` **and**
@@ -1155,7 +1240,15 @@ inherit a stranger's value from an ancestor. The only props read from JS are `--
 `--gg-runway-height` / `--gg-pq-pin-factor` in `readCssVars()` — grep both files before renaming one. **No prop is written
 from JS**: where JS decides a *state*, it toggles a class and CSS owns the resulting value
 (`updateDescFade` → `.is-faded-top` / `.is-faded-bottom`, length in `--gg-desc-fade-len`), so a
-retune stays a CSS-only edit and no magic number is stranded in JS. Only `--s2a-*` tokens come from upstream, and one of them
+retune stays a CSS-only edit and no magic number is stranded in JS. **No upstream (`--feds-*`)
+property is read either.** The control layer is `fixed` and would otherwise sit under the sticky
+gnav, so `--gg-controls-top` has to clear it — but `var(--feds-height-nav, 63px)` +
+`var(--feds-height-breadcrumbs, 33px)` is the wrong instrument for that, and the earlier version of
+this file used it. Both vars are declared upstream (`libs/styles/styles.css` `:root` and
+`global-navigation/base.css`), so the px fallbacks never fire and the calc resolves to a fixed 96px
+whatever the live nav paints; `--feds-height-breadcrumbs` isn't even a bar height, it's the
+`line-height` of breadcrumb links. `--gg-controls-nav` is therefore a **measured literal** (see the
+literals inventory above). One of the tokens
 (`--s2a-font-letter-spacing-neg-0_48`) has an underscore, which is why `custom-property-pattern` is
 disabled on that single line rather than file-wide.
 
@@ -1296,6 +1389,8 @@ working around it.**
 | Card open (canvas tap) | `a11y.trackCardOpen` clicks the card's button | `card_open--globe_gallery` |
 | Card open (keyboard) | real click on that same button | `card_open--globe_gallery` |
 | Enter keyboard gallery (BROWSE) | `daa-ll` on the entry widget | `enter_gallery_kbd--globe_gallery` |
+| Rotate the globe a step | `daa-ll` in `buildMarkup` | `rotate_left--globe_gallery` / `rotate_right--globe_gallery` |
+| Pause / resume auto-spin | `daa-ll` rewritten with the state (`controls.js`) — one button, two meanings, so a fixed label would merge them | `pause_spin--globe_gallery` / `resume_spin--globe_gallery` |
 | Badge CTA | `daa-ll`, minted in `populateModal` | `Photoshop--globe_card_modal` |
 | Prev (button or swipe) | `daa-ll` in `buildMarkup` | `prev_card-1--globe_card_modal` |
 | Next (button or swipe) | `daa-ll` in `buildMarkup` | `next_card-2--globe_card_modal` |
@@ -1678,7 +1773,9 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   - **Column count is DERIVED** (`CYL_COLS_FIT`, the wall-HEIGHT dial): fewest columns whose tallest
     fits that fraction of frustum height (must scale with count). The shared default is in
     `YAW_ONLY_GEOMETRY`; **sm overrides it lower** (`BREAKPOINTS.sm.CYL_COLS_FIT`) — iPad's md
-    cylinder keeps the shared one.
+    cylinder keeps the shared one. The solve does **not** return the count — the rotate buttons
+    recover it from the cards' distinct yaw-deltas instead (see Globe controls), so the layout keeps
+    returning a flat placements array.
   - **Barrel size is the RADIUS** — the width lever. The wall sizes against the centre-plane frustum,
     but viewers see the FRONT cards at the near radius, magnified
     `CAM_Z_SPHERE / (CAM_Z_SPHERE − SPHERE_R)`. sm runs a much smaller `SPHERE_R` (less near magnification) so
@@ -1919,6 +2016,7 @@ self-evident from the name:
 | `TEXT_DRAG_WARP_MUL` | × | hint drag-warp vs sphere cards (more violent) |
 | `TEXT_CA_DIR_STRENGTH` / `_WARP_MUL` | UV / × | drag-CA strength on the hint text / warp-driven CA boost |
 | `TEXT_WARP_OVERFLOW` | mesh scale per uWarp | extra scale so letterforms bleed off-screen |
+| `ROTATE_STEP_FRAMES` / `ROTATE_DEADZONE` | 60fps frames / fraction of a column pitch | one rotate-button press: the `navNudge` tween length, and how close to a column boundary counts as already there — see Globe controls |
 
 ### `timeline.js` constants
 
@@ -1938,6 +2036,7 @@ bare names — are:
 | `SPHERE_ORIENT_RESET_T` | `sphereFormT` | below this a scroll-out resets the sphere orientation **and drag inertia** (a brief dip mid-scroll keeps both) |
 | `FRAME_MS` / `DT_SCALE_MIN` / `_MAX` | ms / ratio | the frame every per-frame rate is authored against (`1000/60`), and the clamp on `frame.dtScale` — a stall must not teleport what it drives, a very short frame must not underflow a decay (see Drag physics) |
 | `TEXT_ZOOM_FADE_RATE` | `zoomT` | hint text is fully faded at `zoomT` = `1 / RATE` |
+| `CONTROLS_ZOOM_HIDE_T` | `zoomT` | globe controls fade out here — they steer a globe the camera is already flying through (see Globe controls) |
 | `GRID_PEEL_WINDOW` | `gridFormT` | `1 − GRID_PEEL_STAGGER`; the span each card's peel occupies after its stagger delay (`frame.gpWin`) |
 | `GRID_ARC_RANGE` / `FOLD_WINDOW` | — | derived spans: `PROGRESS_GRID_ARC_END − _START`, and `SPHERE_FORMED_PROGRESS − FOLD_FIRST_PROGRESS` |
 | `progressAtFormT` | — | maps a `sphereFormT` back to progress; used to derive `ARC_COPY_OUT_START` / `_END`. Nothing here exists only for docs — Milo ships these files unbundled, so a doc-only export is pure payload (the `zoomT` inverse lives in the derivation snippet instead) |

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -1065,17 +1065,17 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     it to the fade keeps the flip aligned. `maxRadial` is radial (rotation-invariant); `sphereGroup.
     scale` (RM shrink) folded in; capped at `CAM_Z_SPHERE × DRAG_FLIP_MAX_CAM_FRAC` (0.95) so it
     can't fire at zoom start; gated on `zoomT > 0`.
-  - **No roll jitter here** (columns lining up *is* the effect). **`CARD_FACE_CAMERA` is `0.35`** (vs
-    the sphere's 0.5) — only limb polish, since a cylinder has no polar cards to rescue.
+  - **No roll jitter here** (columns lining up *is* the effect). **`CARD_FACE_CAMERA` is `0.10`** —
+    it shipped at `0.35`; on a barrel it buys limb legibility at the cost of the curve (below).
   - **Why not a chopped masonry globe** (rejected): meridian columns on a sphere project to curves,
     so in-column alignment breaks; a 0.7 band holds only ~2 cards/column and returns latitude
     obliquity. Masonry needs a developable surface — a cylinder is one, a sphere isn't.
 - **Density + facing pass** (full-sphere path; fixes the "edgy / unevenly distributed" read).
   Adding cards fixes none of it — nearest-neighbour spacing is already even at N=24 and worsens with
   more cards (foreshortening variance). Four independent levers:
-  - **Edge-on slivers → `CARD_FACE_CAMERA` (`0.35` cylinder / `0` full sphere).** A radial card's
-    obliquity equals its angular distance from front-centre, so limb cards render as lines.
-    `applyCardFacing` turns each card partway toward the camera (slivers 5→0, worst obliquity
+  - **Edge-on slivers → `CARD_FACE_CAMERA` (`0.10` cylinder / `0` full sphere).** A
+    radial card's obliquity equals its angular distance from front-centre, so limb cards render as
+    lines. `applyCardFacing` turns each card partway toward the camera (slivers 5→0, worst obliquity
     81°→41°). Must be **per-frame** (a baked tilt rotates away from the camera). The target is
     `sign(n.z) × viewDir`, not `viewDir` (a uniform blend toward +Z rotates a back card to
     perpendicular — a new sliver). The effect must **fade to zero at edge-on** or the 180°-apart
@@ -1084,6 +1084,39 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     past ~0.35 eats the limb correction. Applied at **three** sites that must agree or the card
     snaps: `placeSphereCard`, `snapCardToSphereSlot`, and `placeFoldingCard` (scaled by `fdE` so it
     eases in over the fold, continuous with the sphere branch).
+  - **Why the barrel runs `0.10`, not `0.35`.** The full-sphere path is `0`, so this only ever runs
+    on the cylinder — where it fights the geometry as much as it helps. At `0.35` it read as "cards
+    pop up when they face the camera, and spin on their own past a certain angle." Both symptoms are
+    this one dial. Measured on the sm barrel (`R` 16, `CAM_Z` 70, `CYL_BULGE` 0.18):
+    - **It un-seats cards from the bulge** (the "pop"). The tilt is a full 3D re-aim, so it also
+      cancels part of each card's *vertical* slope — the slope `cylinderMasonryLayout` computes
+      precisely so cards sit flush. The cancellation scales with card height, so a front column's
+      pitch error runs `0°` at mid-height → **`−4.33°` at top/bottom row at `0.35`** (`−1.24°` at
+      `0.10`). The column stops being a curve and reads as hinged slats.
+    - **It unwinds far faster than it winds up** (the "self-rotation"). From 0→75° of azimuth the
+      tilt grows at a constant `+0.35°` per degree of spin — locked to the rotation, so invisible.
+      Past 75.5° (`|n.z|` enters the band) it reverses and peaks at **`−2.84°`/° at `0.35`**
+      (`−0.81°`/° at `0.10`), dumping the accumulated tilt in ~14.5° of spin. C1, so no literal
+      jump, but it reads as cards spinning on their own near the limb. It also pushes the edge-on
+      crossing out from `acos(R/CAM_Z)` = 77.0° (82.0° at `0.10`, 85.3° at `0.35`) and steepens it,
+      so cards hold more than their true width to the limb, then pinch to a line and flip to their
+      back face.
+    - **Tuning table** (maxSnap °/° · front pitch error · limb width vs a true barrel). Both costs
+      scale linearly with the dial; only the snap responds to the band:
+
+      | `CARD_FACE_CAMERA` / `FACING_EDGE_ON_BAND` | maxSnap | pitch err | limb width |
+      | --- | --- | --- | --- |
+      | `0` (true barrel) | `0.00` | `0°` | `1.00×` |
+      | **`.10` / `.25` — shipped** | `0.81` | `−1.24°` | `1.33×` |
+      | `.10` / `.45` | `0.40` | `−1.24°` | `1.33×` |
+      | `.20` / `.45` | `0.80` | `−2.47°` | `1.64×` |
+      | `.35` / `.25` — was shipped | `2.84` | `−4.33°` | `2.07×` |
+
+      Widening the band is close to free: it buys back snap without touching limb width (the pitch
+      error is set by the dial alone). `FACING_EDGE_ON_BAND` is safe to retune — no sphere path
+      reads it. If the pop ever needs to go to zero while keeping limb width, make the re-aim
+      **yaw-only** on this path (project `cardNormal` into XZ before `setFromUnitVectors`): the
+      geometry is yaw-only anyway, and it zeroes the pitch error outright at any dial value.
   - **Uneven card SIZE → `SPHERE_AREA_NORM` (`0.5` yaw-only / `0` else).** Native-aspect sizing
     (height `CARD_H_SPHERE`, width `sphereScaleX`) makes a 16:9 image 2.67× the area of a 2:3 one, so
     wide cards blot out neighbours. Scaling *both* axes by `sphereScaleX^-norm` equalizes area at

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -116,7 +116,7 @@ are optional):
 
 | Row | Purpose | Content |
 | --- | --- | --- |
-| 0 | **Arc-copy** | heading → `.globe-gallery-arc-copy-title`; `<p>` → `.globe-gallery-arc-copy-body` |
+| 0 | **Arc-copy** | heading → `.globe-gallery-arc-copy-title`; remaining `<p>`s → `.globe-gallery-arc-copy-body` (each authored paragraph is reused as-is, inline markup included) |
 | 1 | **Cards** | a Milo fragment link with `#_dnb` appended (see below) |
 | 2 | **Hint + instructions + labels** | first `<p>` → WebGL "Click & Drag" affordance (falls back to `Click & Drag` if empty/absent); optional second `<p>` → a11y entry-widget instructions (English fallback); optional third `<p>` → the four UI labels, `\|\|`-separated in on-screen order **prev-arrow \|\| card-position template \|\| next-arrow \|\| close** (each part falls back to English) |
 | 3 | **Pull-quote** | heading → quote; first `<p>` → name; second `<p>` → role |
@@ -166,17 +166,18 @@ Regression-test with the `WEBGL_lose_context` extension: `const x = document.que
 ### Card shape
 
 `{ img, alt, picture, name, role, description, badges:[{name, role, href, icon}] }`
-(`href` = optional product link on the badge name; `icon` = optional decorated `<picture>` markup for the authored logo SVG, else null)
+(`href` = optional product link on the badge name; `icon` = optional decorated `<picture>` markup for the authored logo SVG, else null;
+`description` = an **array of authored `<p>` elements**, not a string — see *Reusing authored paragraphs* below)
 
 Each fragment section is flat P/UL elements:
 
 | Element | Becomes | Notes |
 | --- | --- | --- |
-| `<p><em>…</em></p>` | **role** | empty if unauthored (no hardcoded default) |
-| `<p><strong>…</strong></p>` | **name** | empty if unauthored (no hardcoded default) |
-| plain `<p>` | **description** | shown in the modal |
+| `<p><em>…</em></p>` | **role** | only when the `<em>` is the *whole* paragraph; first one wins; empty if unauthored (no hardcoded default) |
+| `<p><strong>…</strong></p>` or `<h1>`–`<h6>` | **name** | `<strong>` must be the *whole* paragraph; first one wins; empty if unauthored (no hardcoded default) |
+| every other non-empty `<p>` | **description** | any number of paragraphs, in authored order, shown in the modal — inline `<a>`/`<strong>`/`<em>` are preserved (a sentence with emphasis or a link stays description; it is not mistaken for the name/role) |
 | `<ul>`, one `<li>` per badge | **badges** | see below — nested `<ul><li>` = the product feature |
-| `<p><picture>…</picture></p>` | **image** (+ its `<img alt>` → **alt**) | required — sections without one are skipped; `alt` falls back to an `alt text to be authored` placeholder when the image has none |
+| `<p><picture>…</picture></p>` | **image** (+ its `<img alt>` → **alt**) | required — sections without one are skipped; a bare inline `<img>` works too; the **first** image wins, later ones are ignored; `alt` falls back to an `alt text to be authored` placeholder when the image has none |
 
 **Badge rows.** A badge `<li>` splits into exactly two parts: the **nested `<ul>`** is the
 product feature, and **everything else in the row** is the product — an optional logo plus the
@@ -206,6 +207,23 @@ from its own text and renders as plain text; a row with no feature renders with 
 > matched with plain `querySelector` without walking into the feature list and without mutating
 > authored DOM. The earlier direct-children-only read silently dropped every `<p>`-wrapped badge
 > (empty name → no row pushed), which looked like a modal layout bug rather than a parse miss.
+
+### Reusing authored paragraphs
+
+Both the card **description** and the arc-copy **body** hold the authored `<p>` elements
+themselves, not extracted strings, and `renderParagraphs(container, paras)` moves them on screen
+with `replaceChildren`. Reusing the authored node is what keeps inline `<a>`/`<strong>`/`<em>`
+alive — a `textContent` read flattens them, and re-serializing to an HTML string means escaping
+and re-parsing markup we already have as DOM. This is also why both containers are `<div>`s in
+`buildMarkup`: paragraphs can't nest inside a `<p>`.
+
+**Nothing is cloned, because a paragraph is never in two places.** `buildGlobeDom` and
+`fetchFragmentCards` each run once per block instance, so two globes on a page parse their own
+nodes and share nothing; within one globe, only one modal exists and only one card is shown at a
+time. Re-rendering the same card is safe: `replaceChildren` moves nodes that a previous render
+already detached (the parse holds the reference, so they survive detached), and re-rendering the
+*same* nodes into the *same* container is a no-op. Cloning would only be needed if some future
+feature rendered one card's paragraphs into two live containers at once.
 
 **Card count.** `N_TOTAL` follows the authored count, capped per breakpoint by `N_MAX`:
 

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -612,7 +612,7 @@ its photo canvas rides `H`, and the scroll lock means the bar can't move while i
   `height: 100vh` and only un-sticks it, so `measureViewportH()` is exact in both modes (verified: the
   RM drawing buffer is the same 100vh × DPR as the non-RM one). Keep it that way — a `vh` override on
   that element would put an imprecision into the one function every clock depends on.
-- A genuine viewport change still lands: 844→600px tall moves `blockHeight` 4389→3120 and the same
+- A genuine viewport change still lands: 844→600px tall moves `blockHeight` 3882→2760 and the same
   *fraction* of the runway holds the same phase (camera z within 0.02).
 
 **Why not a viewport unit instead?** No unit choice removes the problem, because the gap is between a
@@ -627,14 +627,17 @@ CSS length and a JS number — JS still has to learn how many px that unit produ
   frame (`getComputedStyle`) is a style recalc, it can't feed `deriveFrame`'s pure clocks, and it
   wouldn't help the render side at all.
 
-**CSS is the source of truth for all three props**, read per layout in `readCssVars()`, so retuning is
-a CSS-only edit:
+**CSS is the source of truth for both lengths**, `--gg-formation-vh` read per layout in
+`readCssVars()`, so retuning is a CSS-only edit:
 
 | prop | per breakpoint | effect |
 |---|---|---|
-| `--gg-runway-height` | same at both | total height = formation + tail; ↓ = shorter stretch after the globe (shrinks gap **and** hold together) |
+| `--gg-runway-height` | same at both | total height = formation + tail; ↓ = shorter stretch after the globe — it scales the whole tail, including the sparse-shell stretch before the quote |
 | `--gg-formation-vh` | same at both | locked formation length |
-| `--gg-pq-pin-factor` | **lower at md+** | share of the tail the (bottom-anchored) quote pin occupies → its hold |
+
+A third prop, `--gg-pq-appear-t`, is on the same element but is **not authored** — the runtime
+publishes it (see below), and CSS only declares a `var(…, 0.42)` fallback inline on the pin for the
+frames before the script runs. It is the one prop written from JS, and the exception is deliberate.
 
 **No JS fallback copy of these numbers exists**, so CSS cannot be quietly overridden by a stale
 literal. That takes some care, because `loadBlock` races a block's stylesheet against its script
@@ -643,8 +646,8 @@ properties exist. Two rules make an unresolved read harmless rather than somethi
 substitute value:
 
 - `readCssVars()` **leaves the previous value in place** when a property doesn't resolve, instead of
-  writing a fallback. So `formationVh` / `pqAppearZoomT` keep their declared initializers
-  (`0` / `0.5`) and can never become `NaN` — which matters because `Math.max(1, NaN)` is `NaN`, so a single
+  writing a fallback. So `formationVh` keeps its declared initializer
+  (`0`) and can never become `NaN` — which matters because `Math.max(1, NaN)` is `NaN`, so a single
   unresolved read would otherwise poison `progress` and silently kill the animation. Its `cssNum`
   helper tests `Number.isFinite` rather than `||` so an authored `0` isn't swallowed.
 - **`0` is a safe value**, unlike `NaN`: every division in `deriveFrame` is guarded (`Math.max(1,
@@ -666,32 +669,67 @@ is plain `offsetHeight`, itself CSS-driven, and needs no fallback either, since 
 off `.globe-gallery-world` instead (see **One viewport height**), so the runway's size lives in exactly
 one place.
 
-So **no JS file anywhere holds a copy of these three numbers** — not even for docs. The event table's
+So **no JS file anywhere holds a copy of these two lengths** — not even for docs. The event table's
 `vh` column needs the runway lengths, but Milo ships `timeline.js` unbundled and byte-for-byte, so a
 doc-only export would ride along in every page's payload; the derivation snippet reads them out of
 `globe-gallery.css` instead (see **Re-deriving these numbers**). Don't reintroduce one.
 
-sm uses a **bigger** pin factor than md on purpose: its globe clears earlier (`zoomT≈0.30` vs md
-`≈0.42`), so the quote can start sooner *and* hold longer — which sm needs, because the quote box fills
-much more of a phone screen (its height is copy-driven, ~490–590px: ~70vh at 800px vs ~54vh at 1080),
-leaving less slack around it. md's factor is capped ~0.55: above it the fade-in would cross md's
-globe-clear and land the quote over the globe.
+**The pull-quote's cue is the camera, not a scroll number.** Earlier versions hand-set the fade-in as
+a share of the tail (a `--gg-pq-pin-factor`, then an authored `--gg-pq-appear-t`), which meant a
+threshold *about the scene* was written in *scroll* units: too late and the reader waits out a blank
+screen, too early and the quote lands on cards still sweeping past, and either could silently drift
+when a camera or radius constant moved. It is now derived, in `publishPqAppearZoomT()`, from where the
+camera is:
 
-**Pull-quote timing is derived, not hand-set.** The pin height is `(runway − formation) ×
---gg-pq-pin-factor`, so it always exits exactly at the runway end (no dead scroll), and the JS fade-in
-threshold `pqAppearZoomT = (1 − --gg-pq-pin-factor) − PQ_APPEAR_LEAD` is **read from the CSS var in
-`readCssVars()`** — so the pin geometry and the opacity trigger can't drift, per breakpoint or across a
-768px resize. Higher `--gg-pq-pin-factor` → quote appears earlier **and** holds longer (they trade off at
-a fixed runway); to change both together, move `--gg-runway-height`.
+```
+clearZ = −hypot(SPHERE_R, half the card's in-plane extent)   // deepest a card can sit behind centre
+pqAppearZoomT = zoomTAtCamZ(clearZ, CAM_Z_SPHERE, CAM_Z_END)  // timeline.js, inverse of easeOutCubic
+```
+
+`zoomTAtCamZ` inverts the same `easeOutCubic` ramp `updateActiveCamera` drives the zoom with, so the
+threshold is exactly *"the frame the camera passes the shell's far wall"* — **0.3057 sm / 0.4170 md**
+with today's constants. The cards are mounted radially, so the deepest point of the outermost card is
+`hypot(R, halfExtent)`: half its width on the yaw-only barrel (sm), half its diagonal on the freely
+rolled sphere (md). Nothing about it is authored, and it re-derives itself for free if `SPHERE_R`,
+`CARD_H_SPHERE` or either `CAM_Z_*` changes. It is computed in `initRuntime` right after `bp` resolves
+— a band crossing rebuilds the runtime, so that is exactly when it can move.
+
+**The pin's release edge rides the same number, which is why nothing is stuck.** `publishPqAppearZoomT`
+writes the value to `--gg-pq-appear-t` on the block, and the pin's bottom edge is
+`(1 − appear-t) × tail − 50vh` above the runway end — i.e. the sticky rail hits the pin's bottom
+**exactly as the quote fades in**. So the quote is revealed dead-centre (the sticky did the centring
+while it was invisible) and is free the same instant: it scrolls with the page from its first frame,
+and there is no held stretch where scrolling does nothing. The reveal transition is `0.45s` for the
+same reason — a `0.7s` fade belongs to a quote that stays put.
+
+This also closes the overlap for good. At the reveal the runway end (= the next section's top) is
+`(1 − appear-t) × tail` down the viewport — **91vh md / 108vh sm** — comfortably below the quote's own
+bottom edge (`50vh + half the box`: ~71vh md, ~92vh sm for a tall one). From there the quote and the
+section travel up together at 1:1, so the gap between them is frozen and the section can never climb
+over the quote. Verified in Chromium at 1440×900 and 390×844 (probe: quote centre pinned at 50vh up to
+the reveal scroll, then `centre = 50vh − (r − r_a)`, section top never above the quote's bottom).
+
+**What the runway still controls.** Whatever is left is the stretch where the camera has passed the
+shell's centre but not yet its far wall — a few far-pole cards, then nothing. That is `≈0.20` of the
+tail on md by the camera curve, so it shrinks only with `--gg-runway-height`: **31vh md / 12vh sm** at
+460vh (it was 43vh / 26vh at 520). The floor on the runway is the other side of the same coin — the
+tail after the reveal must stay longer than half the quote box, or the section arrives on top of it.
 
 **Tuning cheatsheet** (all visual — no test harness, so eyeball each):
-- *Whole stretch after the globe too long:* lower `--gg-runway-height` (both breakpoints).
-- *Quote hold too short/long, or appears too early/late:* `--gg-pq-pin-factor` for that breakpoint (JS
-  threshold auto-follows). md is capped ~0.55 (globe-clear); sm can go to ~0.67.
+- *Whole stretch after the globe too long, or too much blank before the quote:* lower
+  `--gg-runway-height` (both breakpoints). It is the only knob for either — the quote's own timing is
+  camera-derived and rides along. Floor: `(1 − appear-t) × tail` must stay above half the quote box
+  (at 460vh that is 91vh md / 108vh sm against a ~43–92vh box), or the next section lands on the quote.
+- *Quote lands while cards are still in frame, or waits too long after they go:* nothing to tune —
+  it is `zoomTAtCamZ` of the shell's far wall. If it reads early, the card extent is the term to
+  revisit (`publishPqAppearZoomT`), not a scroll number.
+- *Quote should linger instead of scrolling straight off:* that is a held frame, and it is what the pin
+  used to do — extend the pin's bottom edge past the reveal and lengthen the reveal transition to
+  match, but keep the clearance above.
 - *"Click & Drag" cursor lingers too long/short:* `CURSOR_ZOOM_RETIRE_T` — keep it ≥ the md
-  camera-clear `zoomT` (≈0.42... it currently fires just before, at camz≈−33, accepted) and, on md,
-  `< pqAppearZoomT` so it retires before the quote. One threshold for both stages on this clock —
-  label and disc go together. (Cursor is desktop-only, so sm's earlier quote doesn't affect it.)
+  camera-clear `zoomT` (≈0.42... it fires just before, at camz≈−26, accepted) and, on md,
+  `< --gg-pq-appear-t` so it retires before the quote (0.35 vs 0.417 — 10vh of clearance). One
+  threshold for both stages on this clock — label and disc go together. (Cursor is desktop-only, so sm's earlier quote doesn't affect it.)
 - *Cursor disc survives too many drags after the label goes:* `CURSOR_DRAG_RETIRE_T` (0.30) vs
   `CURSOR_DRAG_DISMISS_T` (0.12) — both on drag-accrued `textExitProgress`, so the ratio is how many
   extra drags the disc outlives the label. `updateHintExitProgress` adds ~0.0022/frame held plus
@@ -699,9 +737,12 @@ a fixed runway); to change both together, move `--gg-runway-height`.
   same drag continued. Keep `CURSOR_DRAG_RETIRE_T > CURSOR_DRAG_DISMISS_T` or the two steps collapse.
 - *Formation (arc/grid/fold) pacing:* the `P_*` constants below — independent of the runway.
 
-Current result (from the progress math): md gap ≈91vh; sm gap ≈69vh. The centred hold is the whole pin —
-`(520 − 304) × factor` = **≈119vh md / ≈140vh sm**, independent of viewport and copy length, because the
-0-tall rail (see **CSS → Pull-quote box**) keeps the box's own height out of the sticky clamp.
+Current result (runway 460 / formation 304, tail 156): the quote is revealed centred and released at
+**369vh md / 352vh sm** — the frame the camera clears the shell — and scrolls away from there over the
+remaining **91vh md / 108vh sm**. Held scroll: **none**. The sparse-shell stretch before it (camera
+between centre and far wall) is ≈31vh md / ≈12vh sm. The 0-tall rail (see **CSS → Pull-quote box**)
+is what keeps the box's own height out of the sticky clamp, so the centring at the reveal holds for any
+copy length.
 
 Milo's page-level Lenis keeps `window.scrollY` in sync; the driver is a plain `requestAnimationFrame`
 loop (`startTicker`/`stopTicker`). The modal pauses Lenis via `window.lenis.stop()/start()` plus a
@@ -835,19 +876,23 @@ input       ..........................inert..........................|#live#
 The overlap in the top two lanes is the point of `FOLD_PEEL_OVERLAP`: the first cards begin folding
 (54vh) long before the last cards finish peeling (156vh), so the grid never visibly "resolves".
 
-### Tail — `zoomT` 0 → 1, scroll 304 → 520vh
+### Tail — `zoomT` 0 → 1, scroll 304 → 460vh
 
 ```
-            0.00             0.30   0.42                              0.95
-            |                  |      |                                 |  |
+            0.00        0.22   0.31       0.42                            0.95
+            |             |      |          |                               |  |
 camera      ###################CAM_Z_SPHERE -> CAM_Z_END####################
-globe       #sweeps past viewer|.........gone (sm 0.30 / md 0.42)...........
-hint text   ~~~~~~~~~fade~~~~~~~~|..................gone....................
-cursor      ##########live##########||...............retired................
-quote (sm)  .......hidden.......|############in -> hold -> exit#############
-quote (md)  ..........hidden..........|#########in -> hold -> exit##########
+globe       #sweeps past viewer|.far-pole cards.|......past the far wall......
+hint text   ~~~~~~~~fade~~~~~~~~~|.................gone......................
+cursor      ##########live###########|..............retired..................
+quote (sm)  ......hidden........|###revealed centred, scrolls up + off#######
+quote (md)  ..........hidden...............|###revealed centred, scrolls up###
+next sect.  ...................below the fold.........|#####rises in#########
 canvas      ###########################visible##########################|...
 ```
+
+Each breakpoint's reveal *is* its camera-clear (`zoomTAtCamZ`), and the pin's bottom edge is 50vh
+past it, so the reveal and the un-stick are the same frame at both — no held scroll on either.
 
 ### Event table
 
@@ -871,13 +916,14 @@ from `globe-gallery.css`; `progress` and the gate columns are runway-independent
 | 277 | 0.294 | `ARC_COPY_OUT_FORM_END` of the fold window | **arc-copy fully gone** | `updateArcCopy` |
 | 277 | 0.294 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` | hover / drag / click / auto-rotate go **live**; a11y browse enabled; desktop cursor appears; globe controls fade in; hint-plane entrance **resolves** (warp → 0) | `updateSphereRotation`, `updateCardTransform`, `cursor.update`, `controls.update`, `updateClickDragText` |
 | 304 | 0.322 | `SPHERE_FORMED_PROGRESS` | sphere/barrel formed; `sphereFormT` = 1, `zoomT` leaves 0; keyboard focus snaps here | `computeFrame` |
-| 358 | 0.491 | `CONTROLS_ZOOM_HIDE_T` | globe controls fade out (also leave the tab order) | `controls.update` |
-| 376 | 0.548 | `zoomT ≥ 1 / TEXT_ZOOM_FADE_RATE` | hint text fully faded | `updateClickDragText` |
-| 369 / 395 | 0.525 / 0.607 | camera passes the cards | globe clears the viewport — sm ≈ `zoomT` 0.30, md ≈ 0.42 | `updateActiveCamera` |
-| 373 / 395 | 0.539 / 0.607 | `zoomT ≥ pqAppearZoomT` | pull-quote fades in — sm 0.32, md 0.42 (from `--gg-pq-pin-factor`) | `updatePullQuote` |
-| 390 | 0.593 | `CURSOR_ZOOM_RETIRE_T` | cursor label + disc retire together | `cursor.update` |
-| 509 | 0.966 | `zoomT ≥ 0.95` | canvas `display:none` (quote alone to the end) | `updateCanvasVisibility` |
-| 520 | 1.000 | runway end | pull-quote pin exits | CSS (`--gg-pq-pin-factor`) |
+| ~338 | ~0.470 | camera passes the shell's centre | shell is **effectively empty** — only far-pole cards left in frame (`zoomT` ≈ 0.22) | `updateActiveCamera` |
+| 343 | 0.491 | `CONTROLS_ZOOM_HIDE_T` | globe controls fade out (also leave the tab order) | `controls.update` |
+| 352 | 0.529 | `zoomT ≥ pqAppearZoomT` (sm 0.3057) | **sm**: camera clears the barrel's far wall → quote revealed centred **and** un-stuck the same frame | `updatePullQuote` + CSS |
+| 356 | 0.548 | `zoomT ≥ 1 / TEXT_ZOOM_FADE_RATE` | hint text fully faded | `updateClickDragText` |
+| 359 | 0.559 | `CURSOR_ZOOM_RETIRE_T` | cursor label + disc retire together (desktop only, so ahead of md's reveal) | `cursor.update` |
+| 369 | 0.605 | `zoomT ≥ pqAppearZoomT` (md 0.4170) | **md**: same, one card-shell radius later; next section's top is 91vh down the viewport | `updatePullQuote` + CSS |
+| 452 | 0.966 | `zoomT ≥ 0.95` | canvas `display:none` | `updateCanvasVisibility` |
+| 460 | 1.000 | runway end | quote is long gone; next section's top reaches the viewport top | CSS |
 
 Also on the timeline but **not** scroll-driven, so absent from the charts: texture loading
 (contours → un-dissolve, plus the one-time sm masonry re-solve on `onDone`), the modal
@@ -910,6 +956,18 @@ const cssVh = (p) => parseFloat(css.match(new RegExp(p + ':\\\\s*([0-9.]+)vh'))[
 const FORMATION_VH = cssVh('--gg-formation-vh');
 const RUNWAY_VH = cssVh('--gg-runway-height');
 const tail = RUNWAY_VH - FORMATION_VH;
+// The quote's cue is computed from BREAKPOINTS, which globe-gallery.js does not export — this is the
+// one place the doc restates runtime logic (publishPqAppearZoomT), so keep the two in step.
+const js = readFileSync('./globe-gallery.js', 'utf8');
+const asp = js.match(new RegExp('CARD_ASPECT = ([0-9]+) / ([0-9]+)'));
+const appearT = (band) => {
+  const body = js.split('\n  ' + band + ': {')[1].split('\n  },')[0];
+  const num = (k) => +body.match(new RegExp(k + ': (-?[0-9.]+)'))[1];
+  const h = num('CARD_H_SPHERE');
+  const w = h * (asp[1] / asp[2]);
+  const half = band === 'sm' ? w / 2 : Math.hypot(w, h) / 2; // sm is the yaw-only barrel
+  return T.zoomTAtCamZ(-Math.hypot(num('SPHERE_R'), half), num('CAM_Z_SPHERE'), num('CAM_Z_END'));
+};
 const atZoomT = (t) => T.SPHERE_FORMED_PROGRESS
   + t * (T.PROGRESS_ZOOM_END - T.SPHERE_FORMED_PROGRESS);
 const vh = (p) => (p <= T.SPHERE_FORMED_PROGRESS
@@ -927,6 +985,7 @@ row('arc-copy gone', T.ARC_COPY_OUT_END);
 row('SPHERE FORMED', T.SPHERE_FORMED_PROGRESS);
 row('hint text faded', atZoomT(1 / T.TEXT_ZOOM_FADE_RATE));
 row('cursor label / retire', atZoomT(T.CURSOR_ZOOM_RETIRE_T));
+['sm', 'md'].forEach((b) => row('quote in + un-stuck (' + b + ')', atZoomT(appearT(b))));
 row('canvas hidden', atZoomT(T.CANVAS_HIDE_ZOOM_T));
 "
 ```
@@ -940,7 +999,7 @@ read in JS):
 
 The set is `PROGRESS_PAN_END`, `PROGRESS_ARC_PREROLL`, `PROGRESS_GRID_ARC_START` / `_END`,
 `PROGRESS_FOLD_DUR`, `PROGRESS_ZOOM_END`, `GRID_PEEL_STAGGER` and `FOLD_PEEL_OVERLAP`, plus the
-gates (`SPHERE_INTERACTIVE_T`, `PQ_APPEAR_LEAD`, `CURSOR_ZOOM_RETIRE_T`). Dump the
+gates (`SPHERE_INTERACTIVE_T`, `CURSOR_ZOOM_RETIRE_T`). Dump the
 live values instead of trusting a list here:
 
 ```sh
@@ -1240,11 +1299,15 @@ with a reader's browser font-size setting — the intended C2 behaviour, and why
 this block *defines* is `--gg-*`, the initials convention other C2 blocks use (`--bc-` in
 brand-concierge, `--rm-` in router-marquee). Nothing here defines an unprefixed property: the block
 is a full-viewport hero on shared pages, so a bare `--runway-height` or `--desc-fade-top` could
-inherit a stranger's value from an ancestor. The only props read from JS are `--gg-formation-vh` /
-`--gg-runway-height` / `--gg-pq-pin-factor` in `readCssVars()` — grep both files before renaming one. **No prop is written
-from JS**: where JS decides a *state*, it toggles a class and CSS owns the resulting value
+inherit a stranger's value from an ancestor. The only prop read from JS is `--gg-formation-vh`, in
+`readCssVars()` (`--gg-runway-height` stays CSS-only) — grep both files before renaming one. **JS
+writes exactly one prop, `--gg-pq-appear-t`** (`publishPqAppearZoomT`, once per `initRuntime`), and the
+narrowness is the rule: where JS decides a *state*, it toggles a class and CSS owns the resulting value
 (`updateDescFade` → `.is-faded-top` / `.is-faded-bottom`, length in `--gg-desc-fade-len`), so a
-retune stays a CSS-only edit and no magic number is stranded in JS. **No upstream (`--feds-*`)
+retune stays a CSS-only edit and no magic number is stranded in JS. The pull-quote cue is the one
+value CSS cannot compute — it comes off the WebGL camera curve and the shell radius — so it travels the
+other way, and CSS derives the pin's release edge from it rather than restating it. Anything that
+*could* be a CSS number must not follow it out of the stylesheet. **No upstream (`--feds-*`)
 property is read either.** The control layer is `fixed` and would otherwise sit under the sticky
 gnav, so `--gg-controls-top` has to clear it — but `var(--feds-height-nav, 63px)` +
 `var(--feds-height-breadcrumbs, 33px)` is the wrong instrument for that, and the earlier version of
@@ -1301,9 +1364,12 @@ Consequences worth knowing before retuning:
   make the quote jump half its height as it fades in. The reduced-motion variant deliberately resets
   `transform: none` — it is `position: relative` and flows, so it must *not* be shifted (and its rail
   goes `position: static; height: auto` alongside the pin).
-- **The centred hold is the whole pin**, independent of viewport and copy length, and the quote holds
-  to the runway end and then scrolls away with the block — there is no upward drift-out. Nothing in JS
-  reads the box height, so a copy change is CSS-only, but re-eyeball pacing. See **Scroll model**.
+- **The pin centres the quote while it is invisible, and lets go the frame it appears.** The sticky is
+  what guarantees the reveal happens dead-centre whatever the copy length, but it releases on that same
+  frame (pin bottom = reveal + 50vh), so nothing is held and the quote scrolls away with the block —
+  there is no upward drift-out either. Nothing in JS reads the box height, so a copy change is CSS-only
+  — but the tail left after the reveal must stay longer than half the box, or the next section arrives
+  on top of it. See **Scroll model**.
 - No `overflow` handling: a pathologically long quote spills past the viewport rather than scrolling.
   Adding a scroller here would need `data-lenis-prevent`.
 
@@ -2032,7 +2098,7 @@ self-evident from the name:
 ### `timeline.js` constants
 
 Most of this file's exports are documented where they matter: the `P_*` phase constants and
-`FOLD_PEEL_OVERLAP` under Phase constants; `PQ_APPEAR_LEAD` under Scroll model;
+`FOLD_PEEL_OVERLAP` under Phase constants; the runway split under Scroll model;
 `ENTRY_LEAD_VH` / `ENTRY_RAMP_VH` under Entry timing; and
 every gate threshold in the Lifecycle timeline event table. The remainder — carried in code as
 bare names — are:
@@ -2067,7 +2133,8 @@ Known follow-ups, not blocking this integration branch:
 - **Pacing: landing on the pristine formed globe.** On touch, scroll-spin arbitration is correct
   (see Behavior notes → Touch gesture arbitration), but how easily a user *comes to rest* exactly on
   the fully-formed, still globe is a scroll-pacing tuning matter still open.
-- **Pull-quote pacing and overflow.** The quote is content-sized and holds centred for the whole pin
-  (see **CSS → Pull-quote box**), so `PQ_APPEAR_LEAD` / `--gg-pq-pin-factor` want an eyeball pass per
-  breakpoint against the final copy, and there is no `overflow` handling for a pathologically long or
-  localized quote (it spills rather than scrolls).
+- **Pull-quote pacing and overflow.** The reveal is camera-derived and needs no tuning, but the quote
+  is content-sized (see **CSS → Pull-quote box**), so the *clearance* wants an eyeball pass per
+  breakpoint against the final copy: the tail after the reveal (91vh md / 108vh sm) must stay longer
+  than half the box, and `--gg-runway-height` is the lever. There is no `overflow` handling for a
+  pathologically long or localized quote (it spills rather than scrolls).

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -61,7 +61,7 @@ through each image (centring it on the globe) rather than exposing a flat per-ca
 | `globe-gallery.js` | The block + sphere render core. `export default init(el)` → builds DOM, runs `createGlobeGalleryRuntime()` → `{ init, destroy }`. Holds the *visual* tuning constants (scroll **timing** lives in `timeline.js`) and the stateful core: arc/grid/fold/sphere placement, drag physics, lifecycle. `tick()` orchestrates single-concern stages; `updateCardTransform` dispatches over four placement branch fns. Instantiates the DI modules. See Module layout. |
 | `authoring.js` | `parseAuthoredContent` + `fetchFragmentCards` + `buildGlobeDom(el, labels, { arcCopy, pullQuote })` (+ internal parsers). Reads the block rows positionally, fetches the card fragment, and builds the canvas/overlay/modal DOM — minting + returning the per-instance `gid` id suffix, filling the arc-copy / pull-quote slots. Badge logos are `/federal` assets resolved via Milo's `getFederatedUrl`. |
 | `shaders.js` | GLSL: `CARD_VERT`/`CARD_FRAG`, `MODAL_VERT`/`MODAL_FRAG`, `TEXT_FRAG`. Card/modal frags round corners with one analytic SDF (`rrSDF`), no rasterized mask. The two use *different* box conventions: `CARD_FRAG` fills the plane edge-to-edge, while `MODAL_FRAG` insets the shape by `uRadius` on all four sides (see Modal chrome). `TEXT_FRAG` adds a barrel warp + particle dissolve + the `uExitP` one-way exit. |
-| `materials.js` | GPU-asset factories (named exports, no per-instance state). **Materials:** `createCardMaterial`, `createModalMaterial`, `createTextMaterial`. **Textures:** `loadCardTextures({ maxTex })` (cover-cropped `CanvasTexture` per card, downscaled to the per-device cap — see Texture memory budget), `loadModalTexture(src, maxTex, onReady)` (lazy, returns the pending `Image` to cancel), `createClickDragTexture(aspect, hintText)`. |
+| `materials.js` | GPU-asset factories (named exports, no per-instance state). **Materials:** `createCardMaterial`, `createModalMaterial`, `createTextMaterial`. **Textures:** `loadCardTextures({ maxTexH })` (a `CanvasTexture` per card, capped on height — see Texture memory budget — reporting each image's native aspect and nothing else), `loadModalTexture(src, maxTex, onReady)` (lazy, longest-side cap, returns the pending `Image` to cancel), `createClickDragTexture(aspect, hintText)`. |
 | `a11y.js` | `createGalleryA11y(deps)` → `{ setup, updateTabStops, teardown, isBrowsing }`. The two-level gallery (see Accessibility). All runtime state + actions (`centerCard`, `openCard`, `onFocus`) injected; holds no globe state but its DOM. |
 | `modal.js` | `createGlobeModal(deps)` → `{ setup, resize, render, updateAnimation, updateDesktopNav, open, navigate, close, getModalIdx, isCardManaged, destroy }`. The card-detail modal: own WebGL canvas/scene, the `MODAL_PHASE` state machine, SDF material swap, cross-warp nav, touch swipe/pull gestures, chrome layout in a native `<dialog>`. Owns all modal tuning constants. `getCount()` is the FULL authored count (see Card count). Sphere coupling is narrow + injected. |
 | `math.js` | Pure stateless helpers. **Easings:** `easeOutCubic`, `easeInOutCubic`, `easeOutSine`, `lerpN`. **Arc-phase geometry:** `arcRotationEase`, `buildArcCtx`, `getFanData`, `cssToWorld`, `rotateArcPoint`, `arcCamZ` — the fanned-arc layout + CSS↔WebGL bridge. The last three take an optional `out` and **write into it** (the core passes reused scratch objects), so per-frame placement produces no garbage. |
@@ -278,10 +278,19 @@ textures as uncompressed RGBA + mipmaps: uncapped, the base set (all cards resid
 arc→grid settle) overruns the WebKit per-tab cap and kills the tab with no JS error. Caps live in
 `globe-gallery.js` (`CARD_TEX_SM/MD`, `MODAL_TEX_SM/MD`):
 
-- **Base set** (`loadCardTextures({ maxTex })`), all cards resident — dominates. `256` on sm (just
-  above the ~270 device-px a phone grid card needs, ~6MB for 24), `768` on md (~1:1 with the largest
-  card render, downsampled everywhere smaller). Not an fps cost — mipmapping makes sampling track
-  screen pixels; only memory + upload scale with it.
+- **Base set** (`loadCardTextures({ maxTexH })`), all cards resident — dominates. The cap is on
+  **height**, not the longest side (`fitCardDims`): every card slot is portrait-ish, so the
+  cover-crop discards width and height is the axis that reaches the screen. Capping the longest side
+  instead starves wide sources on exactly that axis — a 16:9 image landed 256×144 and then lost half
+  its width to the arc's crop, ~1.8× softer than a portrait card in the same slot. The request asks
+  by height too (`optimizeImgUrl(src, px, 'height')`; the media service honours a lone `height=`).
+  `WIDE_TEX_RATIO` (2.5) bounds width for a panorama nobody sized for. `256` on sm, `768` on md.
+  Not an fps cost — mipmapping makes sampling track screen pixels; only memory + upload scale.
+  - **Sizing reality check** (measured, DPR 2): the biggest card render is the **arc**, not the grid
+    — `CARD_W_ARC` is 220 CSS px at sm, so 440×608 *device* px against a 256px-tall texture (~0.44
+    texels/device px, i.e. upscaled ~2×). The sm barrel card is ~140 CSS px (~0.6–0.9 texels/device
+    px) and the grid card ~100. md is oversampled everywhere (1.6–4.6). If sm cards ever read as
+    soft, `CARD_TEX_SM` is the dial — and the arc is the frame to judge it on.
 - **Modal** (opened card only), loaded lazily, disposed on close/nav, so ≤1 resident. `768` on sm,
   `2048` on md (the on-screen modal tops ~1400–1600 device px, so 2048 bounds the transient ~17MB vs
   ~64MB for a 4000px original). When the modal cap ≤ the base cap it reuses the base texture
@@ -291,8 +300,13 @@ arc→grid settle) overruns the WebKit per-tab cap and kills the tab with no JS 
 
 **Estimating the cost.** GPU textures store uncompressed regardless of file size: `resident ≈ w × h ×
 4 × 1.333` (RGBA + the mipmap pyramid, converging to +⅓). Dimensions are the *downscaled canvas*
-(longest side = cap), not the source; cover-crop doesn't change residency. A 4:3 source at 256 →
-256×192 → ~0.26MB, ×24 ≈ 6MB; at 768, ~2.3MB (9× area).
+(**height** = cap, width = height × the source aspect), not the source; the cover-crop doesn't
+change residency. So a card costs `cap² × aspect × 5.33` bytes: at 256, a 3:4 source ≈ 0.26MB and a
+16:9 ≈ 0.62MB. Measured against the authored set (aspects 0.57–1.79): **sm 24 cards ≈ 7.6MB**
+(6.4MB under the old longest-side rule, +18%) and **md all 50 ≈ 139MB** (116MB before, +20%) — md
+sets no `N_MAX`, so every authored card is resident there. Watch this on iPad, which takes the md
+profile: if it needs trimming, `CARD_TEX_MD` 768 → 640 lands ~97MB, *below* today's figure, and md
+would still be oversampled (~2.8 texels/device px on the largest card).
 
 The **"Click & Drag" hint** (`createClickDragTexture`) is a separate line item: its canvas matches the
 camera aspect, so `TEXT_MAX_SIDE` caps the *longest* side at 2048 — uncapped, a portrait phone derives
@@ -388,6 +402,38 @@ Worth building only if a CJK locale ships this block.
   its `10px sans-serif` default, which would measure a plausible but wrong advance.
 
 ## Architecture notes
+
+**Aspect: one crop rule, derived every frame, never stored.** A decode contributes exactly one
+number per card — `card.srcAspect`, the image's native aspect (`loadCardTextures`' `onEach`). Every
+phase then calls `applyCardFit(mesh, card, planeAspect?)`, which asks `coverFit(srcAspect, aspect)`
+(`math.js`) for the UV repeat/offset and pushes the same `aspect` into the corner SDF's `uAspect`.
+`planeAspect` defaults to the mesh's **live** scale — `CARD_W_SPHERE = CARD_H_SPHERE × CARD_ASPECT`,
+so the geometry's own aspect factors out and `scale.x / scale.y` is the shape on screen. Arc and grid
+pass `CARD_ASPECT` explicitly (uniform scale, so it is the same number, just cheaper).
+
+Consequences worth keeping:
+
+- **Nothing to keep in sync.** Caching a crop is what broke this three times: the fold lerped a
+  cached `imgAspect` independently of the scale it described (distorted mid-flight); `placeArcCard`
+  never pushed the cached crop at all, so a card that decoded while still on the arc rendered
+  stretched to `CARD_ASPECT` until the next phase overwrote the uniforms; and the modal fitted itself
+  from the base texture's rounded dimensions instead of the one it was displaying.
+- **A uniform scale is a no-op**, so the hover scale (`hs` on both axes) and the RM group shrink
+  cancel out, and the md sphere — which sizes each card to its own aspect — resolves to identity: the
+  desktop globe crops nothing, measurably (`repeat = [1, 1]` on every card).
+- **The crop follows the card into the modal, by the same rule.** `MODAL_FRAG` carries the same
+  `uRepeat`/`uOffset` pair, and `pushModalCoverUV` crops the *displayed* texture
+  (`modalUAspect`) to the aspect the plane is drawn at this frame — read from `mesh.scale` straight
+  after the frame's scale write. No eased crop state: it *is* the barrel's crop on the frame the card
+  leaves (mid-fold included — the interactive gate is global `SPHERE_INTERACTIVE_T`, not per-card
+  `fdE`, so a card can be opened part-way through its fold), and identity once the fly lands, because
+  `computeModalTarget` sizes the plane to exactly that aspect. Easing the crop on the animation's `t`
+  instead is *not* equivalent — a linear crop lerp against a ratio-of-lerps scale mismatches by ~2%
+  mid-flight (measured); tracking the scale is 0.00%. Overflow carriers land at their own aspect, so
+  they resolve to identity too.
+- **Where cropping is therefore visible:** the arc/grid deck (every card in a `CARD_ASPECT` slot, so
+  a 16:9 image keeps ~48% of its width) and the sm/coarse barrel *only past* `CYL_ASPECT_CAP`. The
+  desktop globe and the settled modal show the whole photo.
 
 **DOM is JS-built and scoped to the block root.** `init(el)` calls
 `parseAuthoredContent(el)` first (arc-copy, pull-quote, fragment href), then
@@ -498,8 +544,11 @@ loads, so the block paints immediately: `initRuntime` runs `buildCards()`/`build
 — a faint rounded-rect fill + ~1px stroke drawn in `CARD_FRAG` from `rrSDF`, driven by `uReveal`
 (contour→photo crossfade) and `uContourFade` (proxFade, so the contour respects the near-camera cull).
 `loadCardTextures` reports **per image** via `onEach`, plus `onDone` once all settle; the caller owns
-the `textureLoadGeneration` stale-guard in both. `onEach` swaps in the real texture, refreshes
-cover-crop UVs + native `sphereScaleX`, and flips `hasTexture`; `revealT` then eases 0→1 and the photo
+the `textureLoadGeneration` stale-guard in both. `onEach` swaps in the real texture, records its
+native aspect (`card.srcAspect` — the *only* per-card value a decode contributes) and flips
+`hasTexture`; it writes no UV state, because each phase branch calls `applyCardFit` every frame
+(`placeArcCard` included, or a card that lands its texture while still on the arc would keep the
+identity UVs `buildCards` seeded and render stretched to `CARD_ASPECT`); `revealT` then eases 0→1 and the photo
 **un-dissolves** in — the same edge-first particle effect as the near-camera fade (`uDissolve`), so
 the two compose in `placeSphereCard` by **max-dissolve / min-opacity**, neither un-hiding what the
 other hides. On **md** positions are index-based (`fibSpherePos`), so a landed texture only morphs
@@ -801,7 +850,7 @@ The `--reduced` overrides are grouped at the **end of `globe-gallery.css`** (`no
 cards, 9×5 grid, large sphere; covers Milo md *and* lg) and `sm` (<768, first 24, 3×8, smaller
 sphere). Per-profile knobs in `BREAKPOINTS`: `N_MAX` (0=uncapped), `ARC_SPAN`, `SPHERE_R`, `CARD_*`,
 `CAM_Z_*`, `GRID_COLS/ROWS`, `CARD_ROLL_JITTER`, `ARC_DENSE_FRACTION`, plus precise-pointer defaults
-for the shape keys (`CARD_FACE_CAMERA`, `SPHERE_AREA_NORM`) that `YAW_ONLY_GEOMETRY` overrides. No
+for the shape keys (`CARD_FACE_CAMERA`) that `YAW_ONLY_GEOMETRY` overrides. No
 md↔lg split — they render identically (code branches only on `'sm'`). Crossing 768px changes the
 card count, so `doLayout` triggers a full `destroy()`+`init()` rebuild; resizing within a band takes
 the cheap path (renderer/camera resize). The `resize` handler is the sole driver of the **width**
@@ -842,9 +891,9 @@ rebuild would otherwise inherit:
 an S2A scale uses the token, not the literal — including positional insets (`bottom`,
 `inset-inline-start`) and the `p + p` copy rhythm. Sizes tied to a specific design measurement stay
 literal, because pinning them to a coincidentally-equal token would imply a relationship that isn't
-there: the arc-copy `359px`/`382px` widths, the `138px` counter pill (mirrored by `DT_COUNTER_W`),
-the `375px` description measure, `--gg-pq-height` 583px, the 24/28px badge icons, and the 48px cursor
-disc. These values are **off every S2A scale** and stay literal on purpose — if any is retuned,
+there: the arc-copy `359px`/`382px` widths, the `138px` counter pill (`--gg-counter-w`, which the
+md+ nav offsets read), the `316px` scrim (`--gg-scrim-w`), `--gg-pq-height` 583px, the 24/28px badge
+icons, and the 48px cursor disc. These values are **off every S2A scale** and stay literal on purpose — if any is retuned,
 snapping it to the nearest token is the cheaper fix:
 
 | value | where | nearest token |
@@ -873,8 +922,7 @@ brand-concierge, `--rm-` in router-marquee). Nothing here defines an unprefixed 
 is a full-viewport hero on shared pages, so a bare `--runway-height` or `--desc-fade-top` could
 inherit a stranger's value from an ancestor. Props read or written from JS
 (`--gg-pq-pin-factor` in `doLayout`, `--gg-desc-fade-top` / `--gg-desc-fade-bottom` in
-`updateDescFade`, `--gg-modal-edge` in `positionModalChrome`) are the coupling points — grep both
-files before renaming one. Only `--s2a-*` tokens come from upstream, and one of them
+`updateDescFade`) are the coupling points — grep both files before renaming one. Only `--s2a-*` tokens come from upstream, and one of them
 (`--s2a-font-letter-spacing-neg-0_48`) has an underscore, which is why `custom-property-pattern` is
 disabled on that single line rather than file-wide.
 
@@ -1072,38 +1120,52 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   makes its own pair but only the hovered one activates (inactive discs `visibility: hidden`). Label
   copy is the authored hint string (see Localization).
 - **Modal chrome — edge-anchored nav arrows + counter; desktop adds a screen-edge scrim.**
-  - **Controls.** Prev/next arrows and the counter are independent chrome children (no wrapper),
-    positioned per-frame by `positionModalChrome`, reading as one bottom-centre row at every
-    breakpoint. **Desktop/tablet:** the counter pill centres on the image with an arrow `DT_NAV_GAP`
-    (12px) each side; the pill's fixed `DT_COUNTER_W` (138px, mirroring its CSS `width`) means the
-    flank offset needs no measuring. All three share one `bottom` — `--gg-modal-edge` from the
-    *viewport* bottom, not the image bottom, so the row holds its height whatever the photo's aspect.
-    **Mobile:** the same row spread into the bottom corners inside the scrim. The three frosted
-    controls (both arrows + close) share one style and one 48×48 `--gg-control-size` hit target
-    everywhere; close sits top-right at every breakpoint. Geometry is three locals on
-    `.globe-gallery-modal-chrome`: `--gg-modal-edge` (`--s2a-spacing-md` → `-lg` at md+ — the single
-    inset for all four controls *and* the scrim padding; `positionModalChrome` assigns the `var()`
-    string so nothing is duplicated in JS), `--gg-control-size` (mirrored as `NAV_SIZE` only because
-    the desktop flank offset needs a number), and `--gg-control-radius` (6px literal; no S2A step).
-    `--gg-modal-edge` is also the sm scrim's `padding-bottom` reserve (`edge + control + edge`, so the
-    arrows clear the badges); at md+ the arrows sit under the image, so the override drops it to a
-    flat `edge`.
+  - **Controls — placed entirely in CSS** (`revealModalChrome` only fades them in). Prev/next arrows
+    and the counter are independent chrome children (no wrapper, so each one's `:hover` scale
+    survives the reveal fade), reading as one bottom-centre row at every breakpoint. Every offset is
+    a **per-breakpoint constant**: the modal card is always horizontally centred
+    (`computeModalTarget` pins `x` to 0), so "centred under the image" is just `50%` — nothing to
+    project, nothing to track. **Desktop/tablet:** the counter pill sits at `left: 50%` (physical, because its
+    `translateX(-50%)` is physical) with an arrow `--gg-nav-gap` (12px) out each side, offset from
+    the centre by `--gg-counter-w / 2 + gap + --gg-control-size` on `inset-inline-start` so RTL
+    mirrors for free. All three share one `bottom` — `--gg-modal-edge` from the *viewport* bottom,
+    not the image bottom, so the row holds its height whatever the photo's aspect. **Mobile:** the
+    same row spread into the bottom corners inside the scrim (`inset-inline-start`/`-end`). The three
+    frosted controls (both arrows + close) share one style and one 48×48 `--gg-control-size` hit
+    target everywhere; close sits at the top inline-end corner at every breakpoint. Geometry is five
+    locals on `.globe-gallery-modal-chrome`: `--gg-modal-edge` (`--s2a-spacing-md` → `-lg` at md+ —
+    the single inset for all four controls *and* the scrim padding), `--gg-control-size`,
+    `--gg-control-radius` (6px literal; no S2A step), `--gg-counter-w` (`auto` at sm, `138px` at md+,
+    where the pill's own `width` reads it) and `--gg-scrim-w` (316px, md+ only). `--gg-modal-edge` is
+    also the sm scrim's `padding-bottom` reserve (`edge + control + edge`, so the arrows clear the
+    badges); at md+ the arrows sit under the image, so the override drops it to a flat `edge`.
   - **Image fit + corner radius.** The **visible image** is contain-fit to the viewport minus a
     symmetric margin (desktop `DT_IMG_MARGIN` 12px; mobile full-bleed, square corners `uRadius=0`),
-    native aspect kept — the sizing math backs the geometry out of the SDF corner inset
-    (`uRadius·cardHPx`) so the *photo*, not the geometry, reaches the margin. Desktop keeps a constant
+    native aspect kept. `MODAL_FRAG`'s rounded-rect is measured against the **full plane**
+    (`vec2(uAspect·0.5, 0.5)`, same as `CARD_FRAG`) — the plane edge *is* the photo edge, so the fit
+    is plain `min(H − 2·margin, (W − 2·margin) / uAspect)` with nothing to back out. An inset box
+    (half-extents minus `uRadius`) would clip `uRadius` worth of photo off all four edges, i.e. the
+    modal would show *less* of the image than the globe does. Desktop keeps a constant
     `MODAL_RADIUS_PX` (16px) **on screen for every card**, not a fraction of height: `uRadius` is
-    normalised to card height, so `modalDesktopFit(uAspect)` solves the plane height as photo + 2·16px
-    and derives `radiusFrac = 16 / cardHPx` — per card, since `cardHPx` depends on whether that card's
-    aspect makes the fit width- or height-limited. `modalRadiusFrac(uAspect)` wraps it with the mobile
-    `0`, taking the **aspect** because that's the only per-card input: `uAspect = cardAspect ×
-    sphereScaleX`, and despite the name `sphereScaleX` is not a sphere-phase transform but the card's
-    native image aspect relative to the base card aspect (set on texture decode). Because the fraction
-    depends on the fit, `computeModalTarget` re-pushes `uRadius` **per-frame** — a resize, or an
-    overflow card's late aspect correction on decode, changes `cardHPx`.
-  - **Scrim + scroll region.** Desktop gets a fixed-width (`DT_SCRIM_W` 316px) dark frosted scrim on
-    the **viewport's left edge, full height**; mobile gets one full-width bottom chunk (content-sized,
-    capped at `60dvh`). Both are **pinned header / scrolling body / pinned footer**: role + name are
+    normalised to card height, so `modalDesktopFit(uAspect)` derives `radiusFrac = 16 / cardHPx` —
+    per card, since `cardHPx` depends on whether that card's aspect makes the fit width- or
+    height-limited. `modalRadiusFrac(uAspect)` wraps it with the mobile `0`, taking the **aspect**
+    because that's the only per-card input. That aspect is `modalUAspect(card)`: the aspect of the
+    texture the modal is actually *displaying* (`card.modalAspect`, set when the hi-res upgrade
+    decodes and cleared when it's released), falling back to `card.srcAspect`. Preferring the
+    displayed texture matters because `srcAspect` comes from the small *base* texture, whose rounded
+    dimensions are off by a few tenths of a percent, and because a card opened before its base photo
+    lands would otherwise be fitted at the placeholder aspect. Because both values depend on the fit
+    and the live texture, `computeModalTarget` re-pushes `uAspect` + `uRadius` **per-frame**.
+  - **The crop opens up with the fly.** The barrel may cover-crop a card (see `CYL_ASPECT_CAP`) while
+    the flown-out card shows the whole photo, so `MODAL_FRAG` carries the same `uRepeat`/`uOffset`
+    pair as `CARD_FRAG` and `pushModalCoverUV` tracks the plane's live aspect (see *Architecture
+    notes*). Without it, the first frame of the fly would show the *whole* image at the *barrel's*
+    aspect — a visible horizontal squash that resolves over `MODAL_ANIM_DURATION`. A desktop nav
+    cross-warp owns its own cards' uniforms, so the push is skipped while `dnNavActive`.
+  - **Scrim + scroll region.** Desktop gets a fixed-width (`--gg-scrim-w` 316px) dark frosted scrim
+    on the **viewport's inline-start edge, full height**; mobile gets one full-width bottom chunk
+    (content-sized, capped at `60dvh`). Both are **pinned header / scrolling body / pinned footer**: role + name are
     `flex-shrink:0` at the top, **badges** are `flex-shrink:0` at the bottom (so those tabbable
     controls stay on-screen), and the **description** is the only scroll region (`min-height:0;
     overflow-y:auto`). A `mask-image` scroll-shadow (`updateDescFade`, re-measured on
@@ -1202,10 +1264,19 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   — so yaw brings any card face-on at any height. Reads as the sphere's caps unfolded into a wall.
   Layout is cylindrical **masonry**: fixed columns around the circumference, cards packed down each.
   - **Uniform WIDTH fixes alignment; varying HEIGHT is the effect.** Width = column width (columns
-    read as true verticals); height follows each image's native aspect (the stagger). Makes
-    `SPHERE_AREA_NORM` unnecessary here (0). `CYL_ASPECT_CAP` (1.5) stops one panorama dominating a
-    column (cover-crop UVs crop harder; `imgAspect` derives from the *solved* size so the corner SDF
-    still matches). `CYL_GAP_RATIO` (0.20) sets both gaps (card width = pitch / (1 + ratio)).
+    read as true verticals); height follows each image's native aspect (the stagger) — which is why
+    this path never needed an equal-area dial. `CYL_ASPECT_CAP` (1.5) stops one panorama dominating a
+    column: past the cap the card is laid out at the *clamped* aspect and `applyCardFit` crops the
+    overflow (one `coverFit` call drives the crop and the corner SDF, so they cannot disagree). The
+    cap is a **guard against pathological input**, not a house style — the masonry packs any aspect
+    inside it losslessly, so it is sized to clear the authored set (`1.9` vs a widest 1.79 and a
+    tallest 1/0.57 = 1.75) and nothing real is cropped in the barrel. Re-run the column solve before
+    lowering it: with this content, dropping to 1.5 cropped 4 images ~15% and changed **nothing**
+    about the layout (same column count, same card width, wall height within 1%, column imbalance
+    marginally worse at 1.084 vs 1.073).
+    Without that crop a 3:1 image would be **squashed to half its width** in the wall — the barrel
+    scales the plane per card, it does not letterbox. `CYL_GAP_RATIO` (0.20) sets both gaps (card
+    width = pitch / (1 + ratio)).
   - **Packing: shortest column, tallest card first** (longest-processing-time-first) — holds column
     imbalance at ~1.05 vs 1.64× for source order. Free to reorder: the layout scatters consecutive
     cards, so authored order carries no spatial meaning and modal prev/next walks card *index*. Each
@@ -1274,17 +1345,18 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     pitch error is set by the dial alone — and `FACING_EDGE_ON_BAND` is safe to retune because no
     sphere path reads it. To zero the pop while keeping limb width, make the re-aim **yaw-only** here
     (project `cardNormal` into XZ before `setFromUnitVectors`); the geometry is yaw-only anyway.
-  - **Uneven card SIZE → `SPHERE_AREA_NORM` (`0.5` yaw-only / `0` else).** Native-aspect sizing
-    (height `CARD_H_SPHERE`, width `sphereScaleX`) makes a 16:9 image 2.67× the area of a 2:3 one, so
-    wide cards blot out neighbours. Scaling *both* axes by `sphereScaleX^-norm` equalizes area at
-    `norm=0.5` (area ∝ ssx·ssx⁻¹ = 1) with the aspect — and the image — undistorted (spread
-    2.67×→1.00×). Baked into `card.sphereScaleSX/SY` at build (raw `sphereScaleX` kept for arc/grid/
-    modal); applied at the same three sites **plus** `modal.js`'s close target (needs
-    `applySphereFacing` injected, else it jumps when `snapToSphereSlot` runs). `norm=0` is the
-    unscaled case; uniform scale preserves `uAspect` so corners stay circular.
+  - **Uneven card SIZE (sphere path).** Native-aspect sizing (height `CARD_H_SPHERE`, width = the
+    image's aspect ratio, baked into `card.sphereScaleS{X,Y}` at build) makes a 16:9 image 2.67× the
+    area of a 2:3 one, so wide cards can blot out neighbours. There used to be a `SPHERE_AREA_NORM`
+    dial for it — scale *both* axes by `(srcAspect / CARD_ASPECT)^-norm` and area equalizes at
+    `norm=0.5` (area ∝ ssx·ssx⁻¹ = 1) with the aspect, and the image, undistorted (spread
+    2.67×→1.00×). It shipped `0` on every config, so it was deleted; the yaw-only path solves the
+    same problem with the masonry's uniform column width. Reinstate from git if the sphere path
+    needs it (it also has to be applied in `modal.js`'s close target, or the card jumps when
+    `snapToSphereSlot` runs).
   - **Sparseness → `CARD_H_SPHERE` `11.0` on sm** (sphere path only). Coverage scales with **H²**, so
-    size is a far stronger lever than count and adds no textures/draw calls. Nominal height before
-    `SPHERE_AREA_NORM`; net ~42% of the sphere face.
+    size is a far stronger lever than count and adds no textures/draw calls. Net ~42% of the sphere
+    face.
   - **Scatter → `CARD_ROLL_JITTER` (sm `0.18` ≈ ±5°, md `0.5` ≈ ±14°).** Per-BP: at sm's sparsity
     ±14° reads as debris, while md keeps the collage character.
 - **Touch gesture arbitration — yaw-only, via a directional axis lock** (`interaction.js`). On

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -150,7 +150,7 @@ The block expects up to **five direct child rows** (the pull-quote row is option
 | --- | --- | --- |
 | 0 | **Arc-copy** | heading → `.globe-gallery-arc-copy-title`; remaining `<p>`s → `.globe-gallery-arc-copy-body` (each authored paragraph is reused as-is, inline markup included) |
 | 1 | **Cards** | a Milo fragment link with `#_dnb` appended (see below) |
-| 2 | **Hint copy** — two cells | **cell 0** → the barrel's visible bottom row (mobile), the sentence between the rotate arrows; **cell 1** → the WebGL hint plane + desktop cursor label (the short one). Either cell may be authored as several `<p>`s — they're joined with a space — or as bare cell text |
+| 2 | **Hint copy** — two cells | **cell 0** → the barrel's visible bottom row (mobile), the sentence between the rotate arrows; **cell 1** → the WebGL hint plane + desktop cursor label (the short one). Cell 0 keeps its authored `<p>`s, one per line; cell 1 is a canvas texture, so its `<p>`s are joined with a space. Either may be bare cell text |
 | 3 | **A11y strings** | one cell, `\|\|`-separated in on-screen order: **instructions \|\| rotate-left \|\| rotate-right \|\| pause-spin \|\| resume-spin \|\| prev-arrow \|\| card-position template \|\| next-arrow \|\| close** — nine parts, the entry-widget instructions first. Each part falls back to English independently |
 | 4 | **Pull-quote** | heading → quote; first `<p>` → name; second `<p>` → role |
 
@@ -407,7 +407,7 @@ literals in the code are only fallbacks that never show on a correctly-authored 
 
 | Where | String | Used for | Fallback |
 | --- | --- | --- | --- |
-| Row 2, cell 0 | touch instruction | the barrel's visible bottom-row copy, between the rotate arrows (see Globe controls). Real on-screen prose, so it's a sentence, not a label — author it as one `<p>` per sentence if you like, they're joined | `Click and drag to rotate. Tap to dive deep into the artwork.` (`DEFAULT_TOUCH_HINT`) |
+| Row 2, cell 0 | touch instruction | the barrel's visible bottom-row copy, between the rotate arrows (see Globe controls). Real on-screen prose, so it's a sentence, not a label. **The authored `<p>`s are kept as nodes, one per line**, so the author owns the line break; a cell with no `<p>` renders as plain text | `Click and drag to rotate. Tap to dive deep into the artwork.` (`DEFAULT_TOUCH_HINT`) |
 | Row 2, cell 1 | "Click & Drag" | WebGL hint + desktop cursor label (decorative, not exposed to AT — the a11y instructions cover the real affordance; `createClickDragTexture` auto-scales the font, so keep it short) | `Click & Drag` (`DEFAULT_HINT`) |
 | Row 3, part 1 | instructions | a11y entry-widget accessible name (see below) | `Press Enter to enter the gallery, then Tab through the images.` (`DEFAULT_GALLERY_INSTRUCTIONS`) |
 | Row 3, parts 2–9 | `rotate left \|\| rotate right \|\| pause \|\| resume \|\| prev \|\| {index} of {count} \|\| next \|\| close` | the eight UI labels: the globe controls' four `aria-label`s (the spin toggle names the action it performs, so it needs both states) + modal prev/next/close `aria-label`s + the sr-only card **position** — `\|\|`-separated in on-screen order (`buildLabels`) | each part → English (`DEFAULT_LABELS`) |

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -8,6 +8,24 @@ shipped; remaining items are in Open items / backlog.
 scroll position to what each subsystem is doing, and names the six separate normalized clocks the
 code mixes.
 
+## Conventions for editing this block
+
+**Prose belongs here, not in the code.** These files ship unminified, so every comment is payload on
+a hero block. Keep code comments to a line or two — a pointer like `// See README (Scroll model).`
+beats a paragraph. When a change needs real explanation, write it in the relevant README section and
+point at it.
+
+**This README documents current behavior, not how it got here.** It is long because the block is
+intricate; keep it that way rather than growing an archaeology of every past decision. When you
+change something, *replace* the old explanation instead of appending to it. Specifically:
+
+- No change-logs, no "used to / was removed / shipped at X / now does Y", no reverted-attempt
+  write-ups, no rejected-alternative essays — git holds all of that.
+- Keep rationale only where it would change a future decision: a constraint that will bite again, a
+  number that must not be retuned blindly, a footgun. Prefer the rule over the incident that found it.
+- Prefer a table or a runnable snippet over paragraphs. Anything derivable from the code should be
+  derived (see **Re-deriving these numbers**) rather than restated and left to drift.
+
 ## What it is
 
 Over a tall, pinned scroll range (`--gg-runway-height` in the CSS), the authored photo cards
@@ -40,14 +58,14 @@ through each image (centring it on the globe) rather than exposing a flat per-ca
 
 | File | What it is |
 | --- | --- |
-| `globe-gallery.js` | The block + sphere render core. `export default init(el)` → builds DOM, runs `createGlobeGalleryRuntime()` → `{ init, destroy }`. Holds the *visual* tuning constants + pure helpers (module scope) — all scroll-**timing** constants live in `timeline.js` — and the stateful core (arc/grid/fold/sphere placement, drag-rotation physics + the sphere-to-card alignment ease, lifecycle). `tick()` is a thin orchestrator over named single-concern stages plus `modal.*` / `a11y.*`; per-card placement is a dispatcher (`updateCardTransform`) over four branch fns (`placeSphereCard`/`placeFoldingCard`/`placeGridCard`/`placeArcCard`). Instantiates the DI modules. |
+| `globe-gallery.js` | The block + sphere render core. `export default init(el)` → builds DOM, runs `createGlobeGalleryRuntime()` → `{ init, destroy }`. Holds the *visual* tuning constants (scroll **timing** lives in `timeline.js`) and the stateful core: arc/grid/fold/sphere placement, drag physics, lifecycle. `tick()` orchestrates single-concern stages; `updateCardTransform` dispatches over four placement branch fns. Instantiates the DI modules. See Module layout. |
 | `authoring.js` | `parseAuthoredContent` + `fetchFragmentCards` + `buildGlobeDom(el, labels, { arcCopy, pullQuote })` (+ internal parsers). Reads the block rows positionally, fetches the card fragment, and builds the canvas/overlay/modal DOM — minting + returning the per-instance `gid` id suffix, filling the arc-copy / pull-quote slots. Badge logos are `/federal` assets resolved via Milo's `getFederatedUrl`. |
-| `shaders.js` | GLSL: `CARD_VERT`/`CARD_FRAG`, `MODAL_VERT`/`MODAL_FRAG`, `TEXT_FRAG`. Card/modal frags round corners with one analytic SDF (`rrSDF`, `uRadius` = fraction of card height + `uAspect`), no rasterized mask. Note the two frags use *different* SDF box conventions: `CARD_FRAG` fills the plane edge-to-edge (barrel cards keep the proportional 22/631 radius), while `MODAL_FRAG` insets the shape by `uRadius` on all four sides — modal.js sizes the plane around that inset and sets `uRadius` for a constant 16px on-screen radius (0 on mobile). `TEXT_FRAG` (the hint) adds a barrel warp + particle dissolve + the `uExitP` one-way exit. |
-| `materials.js` | GPU-asset factories (all named exports, no per-instance state). **Materials:** `createCardMaterial` (card ShaderMaterial — cover-crop + optional CA/warp + SDF corners, with the property-proxy), `createModalMaterial` (modal SDF), `createTextMaterial` (hint `TEXT_FRAG`, uniforms only). **Textures:** `loadCardTextures({ maxTex })` (cover-cropped `CanvasTexture` per card, downscaled to the per-device cap — see Texture memory budget), `loadModalTexture(src, maxTex, onReady)` (lazy full image at a higher cap, returns the pending `Image` to cancel), `createClickDragTexture(aspect, hintText)` (renders the hint string, auto-scaled font). |
+| `shaders.js` | GLSL: `CARD_VERT`/`CARD_FRAG`, `MODAL_VERT`/`MODAL_FRAG`, `TEXT_FRAG`. Card/modal frags round corners with one analytic SDF (`rrSDF`), no rasterized mask. The two use *different* box conventions: `CARD_FRAG` fills the plane edge-to-edge, while `MODAL_FRAG` insets the shape by `uRadius` on all four sides (see Modal chrome). `TEXT_FRAG` adds a barrel warp + particle dissolve + the `uExitP` one-way exit. |
+| `materials.js` | GPU-asset factories (named exports, no per-instance state). **Materials:** `createCardMaterial`, `createModalMaterial`, `createTextMaterial`. **Textures:** `loadCardTextures({ maxTex })` (cover-cropped `CanvasTexture` per card, downscaled to the per-device cap — see Texture memory budget), `loadModalTexture(src, maxTex, onReady)` (lazy, returns the pending `Image` to cancel), `createClickDragTexture(aspect, hintText)`. |
 | `a11y.js` | `createGalleryA11y(deps)` → `{ setup, updateTabStops, teardown, isBrowsing }`. The two-level gallery (see Accessibility). All runtime state + actions (`centerCard`, `openCard`, `onFocus`) injected; holds no globe state but its DOM. |
-| `modal.js` | `createGlobeModal(deps)` → `{ setup, resize, render, updateAnimation, updateDesktopNav, open, navigate, close, getModalIdx, isCardManaged, destroy }`. The card-detail modal: own WebGL canvas/scene, the `MODAL_PHASE` state machine, SDF material swap, cross-warp nav (all breakpoints), touch swipe/pull gestures (gated on a coarse primary pointer, so tablets at ≥768 get them too), chrome layout in a native `<dialog>`. Owns all modal tuning constants. `getCount()` is the FULL authored count (see Card count). Sphere coupling is narrow + injected: shared `sphereRotQuat` + `snapToSphereSlot` / `applySphereFacing` / `requestNavNudge` / `applyMotionCA` callbacks. |
-| `math.js` | Pure stateless helpers. **Easings:** `easeOutCubic`, `easeInOutCubic`, `easeOutSine`, `lerpN`. **Arc-phase geometry:** `arcRotationEase`, `buildArcCtx`, `getFanData`, `cssToWorld`, `rotateArcPoint`, `arcCamZ` — the fanned-arc layout + CSS↔WebGL bridge, derived from the viewport + `ARC_SPAN` + the per-frame `arcCtx` the core owns; `getFanData`/`cssToWorld`/`rotateArcPoint` take an optional `out` and **write into it** (the core passes reused scratch objects), so per-frame card placement produces no garbage. |
-| `timeline.js` | **The scroll timeline.** Every phase constant, entry knob and threshold, plus `createFrame` / `createFrameInput` / `deriveFrame(frame, input)` — the pure derivation of all six clocks (`progress`, `arcCopyEntryT`, `arcPanT`, `gridFormT`, `sphereFormT`, `zoomT`) — and `cardFoldStartProgress(gpDelay)`, the per-card fold gate that `FOLD_FIRST_PROGRESS` is the `gpDelay = 0` case of. No THREE, no DOM, no closure state, so it is unit-testable in isolation and is the single place to change **when** something happens. `deriveFrame` writes into a caller-owned frame, allocates nothing, and clamps NaN-safely (a degenerate viewport/runway makes the ratios 0/0, and one NaN would poison every mesh position). Imported as a namespace (`import * as TL`, mirroring `THREE`) so adding a threshold doesn't mean editing an import list. See Lifecycle timeline. |
+| `modal.js` | `createGlobeModal(deps)` → `{ setup, resize, render, updateAnimation, updateDesktopNav, open, navigate, close, getModalIdx, isCardManaged, destroy }`. The card-detail modal: own WebGL canvas/scene, the `MODAL_PHASE` state machine, SDF material swap, cross-warp nav, touch swipe/pull gestures, chrome layout in a native `<dialog>`. Owns all modal tuning constants. `getCount()` is the FULL authored count (see Card count). Sphere coupling is narrow + injected. |
+| `math.js` | Pure stateless helpers. **Easings:** `easeOutCubic`, `easeInOutCubic`, `easeOutSine`, `lerpN`. **Arc-phase geometry:** `arcRotationEase`, `buildArcCtx`, `getFanData`, `cssToWorld`, `rotateArcPoint`, `arcCamZ` — the fanned-arc layout + CSS↔WebGL bridge. The last three take an optional `out` and **write into it** (the core passes reused scratch objects), so per-frame placement produces no garbage. |
+| `timeline.js` | **The scroll timeline** — the single place to change **when** something happens. Every phase constant and threshold, plus `createFrame` / `createFrameInput` / `deriveFrame(frame, input)`, the pure derivation of all six clocks, and `cardFoldStartProgress(gpDelay)` (the per-card fold gate; `FOLD_FIRST_PROGRESS` is its `gpDelay = 0` case). No THREE, no DOM, no closure state, so it's unit-testable in isolation. `deriveFrame` writes into a caller-owned frame, allocates nothing, and clamps NaN-safely — one NaN would poison every mesh position. Imported as a namespace (`import * as TL`). See Lifecycle timeline. |
 | `interaction.js` | `createInteraction(deps)` → `{ setup, teardown }`. Canvas pointer plumbing: drag-to-spin, click-vs-drag, raycast hover + click→modal. Shares drag velocity by reference via the `drag` object. Owns the **touch axis lock** and exports `isPageScrollGesture()` (see Behavior notes). Cedes its hover cursor to the custom cursor via `isCursorActive()`. |
 | `cursor.js` | `createCursor(deps)` → `{ setup, update, teardown, isActive }`. The desktop custom cursor (see Behavior notes): two body-level layers (`mix-blend-mode` disc + fixed chevron/label container), per-frame state from injected getters, the two-step retirement, `isActive()` gating interaction's cursor. No-op on touch. |
 | `globe-gallery.css` | Globe-only CSS. Also defines `.globe-gallery`-scoped type-scale tokens (see Behavior notes). |
@@ -61,22 +79,21 @@ Experimental block: loaded via MEP from `libs/mep/ace1209/globe-gallery/` — **
 
 ### Module layout
 
-`globe-gallery.js` is organized top-down: (1) module-scope tuning constants (the core's tuning
-surface); (2) domain helpers `fibSpherePos` / `cylinderMasonryLayout` (generic easings + `lerpN` +
-the arc-phase geometry live in `math.js`); (3) `createGlobeGalleryRuntime()` — the per-instance closure
-holding sphere state + behavior. The active breakpoint's resolved render profile is one frozen `bp`
-object built by `resolveBpProfile()` on each (re)init; functions destructure what they need from it,
-DI getters read `bp.*` live. Inside the closure the **per-frame pipeline** is single-concern stages
-run in a fixed order by `tick()`: `computeFrame()` is a thin wrapper that refreshes the persistent
-`frameInput` from live layout/scroll state and calls `timeline.js`'s pure `deriveFrame`, which writes
-every clock onto the persistent `frame` context (scroll + the six clocks + card-entry transforms);
-each stage reads what it needs from it and the producer stages write results back onto it
-(`activeCamera`, `sphereRotActive`, `sphGroupZ`), so one object flows through to the card loop.
-**`frame` and `frameInput` are allocated once and mutated in place** — stages consume them
-synchronously within a tick and never retain them, so the per-frame pipeline allocates nothing.
-`frame` is also the single source for the clocks: read `frame.progress` / `frame.zoomT` rather than
-caching them in the closure. (In `globe-gallery.js` the persistent object is named `frameState`;
-stages take it as a parameter named `frame`, so the two don't shadow.)
+`globe-gallery.js` is organized top-down: (1) module-scope tuning constants; (2) domain helpers
+`fibSpherePos` / `cylinderMasonryLayout` (generic easings, `lerpN` and the arc-phase geometry live in
+`math.js`); (3) `createGlobeGalleryRuntime()` — the per-instance closure holding sphere state +
+behavior. The active breakpoint's render profile is one frozen `bp` object from `resolveBpProfile()`
+per (re)init; functions destructure what they need, DI getters read `bp.*` live.
+
+Inside the closure the **per-frame pipeline** is single-concern stages run in a fixed order by
+`tick()`. `computeFrame()` refreshes the persistent `frameInput` from live layout/scroll state and
+calls `timeline.js`'s pure `deriveFrame`, which writes every clock onto the persistent `frame`
+context; each stage reads from it, and producer stages write results back, so one object flows
+through to the card loop. **Both objects are allocated once and mutated in place** — stages consume
+them synchronously and never retain them, so the pipeline allocates nothing. `frame` is the single
+source for the clocks: read `frame.progress` / `frame.zoomT` rather than caching them in the closure.
+(The persistent object is `frameState`; stages take it as a parameter named `frame`, so the two don't
+shadow.)
 
 Who writes what:
 
@@ -86,28 +103,24 @@ Who writes what:
 | `frame` ← `deriveFrame` | `lenisY`, `scrollingDown`, `scrollVel`, the six clocks (`progress`, `arcCopyEntryT`, `arcPanT`, `gridFormT`, `sphereFormT`, `zoomT`), `gpWin`, and the arc-branch entry transforms `entryRot` / `entryYOffset` / `arcScale` |
 | `frame` ← the producer stages | `activeCamera` (`updateActiveCamera`), `sphereRotActive` (`updateSphereRotation`), `sphGroupZ` (`updateSphereGroupDepth`), `foldSphDist` (same) — declared in `createFrame` so the object's shape stays monomorphic |
 
-**Grouped closure state.** Related mutable state is held in small plain objects rather than loose
-`let`s, so the runtime closure stays legible: `drag` (`isDragging`/`velX`/`velY`, shared by
-reference with `interaction.js`), `masonryMorph` (`active`/`t`), `sphereOrient` (`x` = pitch, `y` =
-yaw, `z` = roll — see Sphere rotation), `navNudge` (`active`, `target{X,Y,Z}` = destination pose,
-`start{X,Y,Z}` = pose captured when armed, `frame`/`frames` = elapsed/total count from
-`KEY_BROWSE_FRAMES` or `KEY_MODAL_FRAMES`; `targetZ` is roll, set by keyboard centring only — the
-modal leaves it as-is), `arcCopy` (`el` + the last-written style strings `opStr`/`transformStr`, so
-`updateArcCopy` only touches the DOM when a value actually changed), and
-`ctxLoss` (`rebuilds`/`stableTimer`/`recovering`/`recoverTimer` — see WebGL context loss).
+**Grouped closure state.** Related mutable state lives in small plain objects rather than loose
+`let`s: `drag` (`isDragging`/`velX`/`velY`, shared by reference with `interaction.js`),
+`masonryMorph` (`active`/`t`), `sphereOrient` (`x` pitch / `y` yaw / `z` roll — see Sphere rotation),
+`navNudge` (`active`, `target{X,Y,Z}` destination pose, `start{X,Y,Z}` pose when armed,
+`frame`/`frames` elapsed/total from `KEY_BROWSE_FRAMES` or `KEY_MODAL_FRAMES`; `targetZ` is roll, set
+by keyboard centring only), `arcCopy` (`el` + last-written style strings, so `updateArcCopy` only
+touches the DOM on change), and `ctxLoss` (see WebGL context loss).
 
 Per-card placement (the largest stage) is a dispatcher over four runtime-scope branch fns — kept in
-this file, not a module, because they read deeply from the closure and run in the hot loop. Five DI
-modules are injected with live-state getters: GPU resources (`materials.js`), the a11y widget, the
-modal, `interaction.js` (sharing drag velocity via the `drag` object), and the cursor (its
-`isActive()` gates interaction's hover cursor). The modal owns its canvas/scene + the `MODAL_PHASE`
-state machine and reaches the sphere only through the shared `sphereRotQuat` / `snapToSphereSlot` /
-`requestNavNudge` callbacks.
+this file because they read deeply from the closure and run in the hot loop. Five DI modules are
+injected with live-state getters: `materials.js`, the a11y widget, the modal, `interaction.js`, and
+the cursor. The modal owns its canvas/scene + the `MODAL_PHASE` state machine and reaches the sphere
+only through the shared `sphereRotQuat` / `snapToSphereSlot` / `requestNavNudge` callbacks.
 
-## How to run
+## Rebuilding Three.js
 
-To regenerate Three.js after adding a new `THREE.*` call: add the symbol to
-`three-src.js`, then `cd libs/c2/blocks/globe-gallery && npm install && npm run build`.
+After adding a new `THREE.*` call, add the symbol to `src/three-src.js`, then
+`cd libs/mep/ace1209/globe-gallery && npm install && npm run build`.
 
 ## Authoring contract
 
@@ -177,7 +190,14 @@ Each fragment section is flat P/UL elements:
 | `<p><strong>…</strong></p>` or `<h1>`–`<h6>` | **name** | `<strong>` must be the *whole* paragraph; first one wins; empty if unauthored (no hardcoded default) |
 | every other non-empty `<p>` | **description** | any number of paragraphs, in authored order, shown in the modal — inline `<a>`/`<strong>`/`<em>` are preserved (a sentence with emphasis or a link stays description; it is not mistaken for the name/role) |
 | `<ul>`, one `<li>` per badge | **badges** | see below — nested `<ul><li>` = the product feature |
-| `<p><picture>…</picture></p>` | **image** (+ its `<img alt>` → **alt**) | required — sections without one are skipped; a bare inline `<img>` works too; the **first** image wins, later ones are ignored; `alt` falls back to an `alt text to be authored` placeholder when the image has none |
+| `<p><picture>…</picture></p>` | **image** (+ its `<img alt>` → **alt**) | required — sections without one are skipped (and logged to `lana`); a `<picture>`/`<img>` **direct child** of the section works too (see below), as does a bare inline `<img>`; the **first** image wins, later ones are ignored; `alt` falls back to an `alt text to be authored` placeholder when the image has none |
+
+**A card with no copy is a lone unwrapped image.** When the image is the section's *only* content
+the pipeline drops the `<p>`, so `.plain.html` serves `<div><picture>…</picture></div>`. Both the
+section/container dispatch (`CARD_CONTENT_TAGS`) and the segment reader must therefore accept
+`PICTURE`/`IMG`, not just `P`/`UL` — otherwise the section reads as a *container*, yields no cards,
+and drops silently. An imageless section logs to `lana`. A card with no copy renders on the globe
+and opens a modal with empty role/name/description/badges — there is no non-clickable-card path.
 
 **Badge rows.** A badge `<li>` splits into exactly two parts: the **nested `<ul>`** is the
 product feature, and **everything else in the row** is the product — an optional logo plus the
@@ -203,10 +223,9 @@ so the URL is resolved through Milo's `getFederatedUrl` (NOT `decorateSVG`, whic
 the host to a bare pathname on the consumer origin). A row with no product link takes its name
 from its own text and renders as plain text; a row with no feature renders with an empty role.
 
-> The row is read from a **clone** with the feature `<ul>` detached, so the product half can be
-> matched with plain `querySelector` without walking into the feature list and without mutating
-> authored DOM. The earlier direct-children-only read silently dropped every `<p>`-wrapped badge
-> (empty name → no row pushed), which looked like a modal layout bug rather than a parse miss.
+The row is read from a **clone** with the feature `<ul>` detached, so the product half matches with
+plain `querySelector` without walking into the feature list or mutating authored DOM. A
+direct-children-only read would silently drop every `<p>`-wrapped badge.
 
 ### Reusing authored paragraphs
 
@@ -217,13 +236,11 @@ alive — a `textContent` read flattens them, and re-serializing to an HTML stri
 and re-parsing markup we already have as DOM. This is also why both containers are `<div>`s in
 `buildMarkup`: paragraphs can't nest inside a `<p>`.
 
-**Nothing is cloned, because a paragraph is never in two places.** `buildGlobeDom` and
-`fetchFragmentCards` each run once per block instance, so two globes on a page parse their own
-nodes and share nothing; within one globe, only one modal exists and only one card is shown at a
-time. Re-rendering the same card is safe: `replaceChildren` moves nodes that a previous render
-already detached (the parse holds the reference, so they survive detached), and re-rendering the
-*same* nodes into the *same* container is a no-op. Cloning would only be needed if some future
-feature rendered one card's paragraphs into two live containers at once.
+**Nothing is cloned, because a paragraph is never in two places.** Each instance parses its own
+nodes, and only one modal shows one card at a time. Re-rendering the same card is safe:
+`replaceChildren` moves nodes a previous render detached (the parse holds the reference), and
+re-rendering the same nodes into the same container is a no-op. Cloning would only be needed to
+render one card's paragraphs into two live containers at once.
 
 **Card count.** `N_TOTAL` follows the authored count, capped per breakpoint by `N_MAX`:
 
@@ -243,10 +260,10 @@ images** (24…N-1) with no sphere slot: it mints a lazy **modal-only carrier** 
 quad + SDF material in `modalScene`, its texture disposed on nav-away so ≤1 resident) that
 **dissolves** in/out instead of flying to/from the globe. Barrel-slot cards still fly. Overflow is
 reached only via modal **navigation** — `open()` is always a barrel card (tap / a11y browse). **All**
-modal nav — on-screen arrows and touch swipe — routes through the same cross-warp
-transition on **every** breakpoint (`navigate` → `startDesktopNavTransition`); touch swipe just
-builds a warp preview during the drag, then commits that transition on release. The old mobile instant-swap /
-swipe-neighbour slot reorg was removed — a slotless overflow card can only cross-warp anyway.
+modal nav — on-screen arrows and touch swipe — routes through the same cross-warp transition on
+**every** breakpoint (`navigate` → `startDesktopNavTransition`); touch swipe just builds a warp
+preview during the drag, then commits that transition on release. (A slotless overflow card can only
+cross-warp, so there is no instant-swap path.)
 The **keyboard/SR browse gallery stays at 24** (its centring targets real sphere cards); SR users
 reach every image through modal ←→ nav. Overflow carriers + textures are disposed on `destroy`.
 
@@ -256,9 +273,9 @@ clustered:spread arc ratio holds at any count.
 
 ### Texture memory budget
 
-Card images are downscaled to a per-device cap on upload (iOS uploads textures as uncompressed
-RGBA + mipmaps; the full base set — all cards resident during the arc→grid settle — otherwise
-overran the WebKit per-tab cap and crashed the tab with no JS error). Caps live in
+Card images are downscaled to a per-device cap on upload. This is load-bearing on iOS, which uploads
+textures as uncompressed RGBA + mipmaps: uncapped, the base set (all cards resident during the
+arc→grid settle) overruns the WebKit per-tab cap and kills the tab with no JS error. Caps live in
 `globe-gallery.js` (`CARD_TEX_SM/MD`, `MODAL_TEX_SM/MD`):
 
 - **Base set** (`loadCardTextures({ maxTex })`), all cards resident — dominates. `256` on sm (just
@@ -272,14 +289,13 @@ overran the WebKit per-tab cap and crashed the tab with no JS error). Caps live 
   `getModalMaterial` placeholders the base texture, `requestModalUpgrade` swaps the sharper one when
   decoded, `releaseModalTexture` disposes on close/nav/destroy.
 
-**Estimating the cost.** GPU textures store uncompressed regardless of file size: `resident ≈ w × h
-× 4 × 1.333` (RGBA + the mipmap pyramid, which converges to +⅓). Dimensions are the *downscaled
-canvas* (longest side = cap), not the source; cover-crop doesn't change residency. E.g. a 4:3 source
-at 256 → 256×192 → ~0.26MB, ×24 ≈ 6MB; at 768, ~2.3MB (9× area); the 2048 modal texture ≈ 17MB
-transient.
+**Estimating the cost.** GPU textures store uncompressed regardless of file size: `resident ≈ w × h ×
+4 × 1.333` (RGBA + the mipmap pyramid, converging to +⅓). Dimensions are the *downscaled canvas*
+(longest side = cap), not the source; cover-crop doesn't change residency. A 4:3 source at 256 →
+256×192 → ~0.26MB, ×24 ≈ 6MB; at 768, ~2.3MB (9× area).
 
-The **"Click & Drag" hint** (`createClickDragTexture`) is a separate line item: its canvas matches
-the camera aspect, so `TEXT_MAX_SIDE` caps the *longest* side (2048) — else a portrait phone derived
+The **"Click & Drag" hint** (`createClickDragTexture`) is a separate line item: its canvas matches the
+camera aspect, so `TEXT_MAX_SIDE` caps the *longest* side at 2048 — uncapped, a portrait phone derives
 a 2048×4180 ≈ 45MB canvas, mostly empty. Capped, portrait tops ~1004×2048 (~11MB).
 
 `ANTIALIAS_SM`/`ANTIALIAS_MD` toggle MSAA per band (set at renderer creation): on for md (card
@@ -345,45 +361,31 @@ fallback and WebKit's native path act on identical characters:
 Categories rather than a literal list, so a new locale needs no code change. `Pe` closers (`」`),
 dashes, and the rest of `Po` (`!` `¿`) are excluded.
 
-**Full-width CJK brackets are skipped**, on two tests: the mark measuring **≥ 0.8em** (`「『（`
-run ~0.96em; the widest Latin quote, `«`, is ~0.55em, so the gap is wide and the cutoff is not
-delicate), or simply **exceeding the padding**, where it would be shoved past the viewport edge
-into the block's `overflow-x: clip` and sheared. Either way the code suppresses the hang
-**including WebKit's native one** — only a measurement can detect these limits, which CSS can't
-express — so every browser lands on the same result.
+**Full-width CJK brackets are skipped**, on two tests: the mark measuring **≥ 0.8em** (`「『（` run
+~0.96em vs ~0.55em for the widest Latin quote `«`, so the cutoff isn't delicate), or **exceeding the
+padding**, where it would be shoved past the viewport edge into the block's `overflow-x: clip` and
+sheared. Either test suppresses the hang **including WebKit's native one**, so every browser lands on
+the same result. The width test is what makes that result breakpoint-independent: `--gg-copy-pad`
+(24→48→64) and `heading-1` (40→56→80px) step at *different* widths, so the padding test alone leaves
+`768–1023` a band where a `「` fits and hangs while being suppressed everywhere else — and since the
+measurement runs once at init, a later resize would strand it and shear.
 
-The width test is what makes that result **breakpoint-independent**, and it is load-bearing rather
-than belt-and-braces. Both inputs to the padding test move: `--gg-copy-pad` steps 24→48→64 (see
-Crosshair frame) and `heading-1` steps 40→56→80px, and they step at *different* widths. On the
-padding test alone, `768–1023` is a band where the padding has already grown to 48px but the type
-is still 40px, so a `「` fits and hangs there while being suppressed at every other size. Worse,
-the measurement runs once at init and is never recomputed, so a resize from that band up to
-`1280` would strand a 0.96em hang against a 48px pad and shear it.
+Proper CJK support is a different rule, not a smaller number: JIS sets a line-head opening bracket
+half-width, aligning its *ink* to the margin rather than the following character to the column.
+Worth building only if a CJK locale ships this block.
 
-Covering CJK is a different rule rather than a smaller number: JIS sets a line-head opening
-bracket half-width, aligning its *ink* to the margin instead of aligning the following character
-to the column. Worth building only if a CJK locale ships this block.
+**Implementation notes** — each is load-bearing:
 
-**Implementation notes** — each of these is load-bearing:
-
-- Runs after `document.fonts.ready`; Adobe Clean's metrics differ from the fallback font's, so
-  measuring earlier bakes in the wrong advance.
-- Canvas, not `getBoundingClientRect`: the pull-quote sits under `transform: scale(.9)` until it
+- Runs after `document.fonts.ready`: Adobe Clean's metrics differ from the fallback's.
+- Canvas, not `getBoundingClientRect` — the quote sits under `transform: scale(.9)` until it
   activates, which scales a client rect but not a canvas measurement.
-- The **advance**, not the ink width, is what lands the second character on the column — and
-  `measureText` omits `letter-spacing`, which `heading-1` sets, so it is added back.
-- Emitted in `em`, not px. `heading-1` is **responsive** (40px → 56px at 1024 → 80px at 1280), so
-  a px indent would go stale on every breakpoint crossing; the em ratio holds without a recompute.
-  It holds only *approximately* — `letter-spacing` is a fixed px that does not scale with the type,
-  so the ratio drifts ~0.02em (≈1px at 80px) across breakpoints. Also covers text-only zoom.
-- Accurate to the pixel while the webfont is up. If Adobe Clean is missing the stack falls to c2's
-  `Arial Bold Adjusted`, whose `size-adjust: 92%` layout applies but the canvas measurement does
-  not, leaving the hang ~1px out at 80px type. Invisible, and only on the fallback path — but it is
-  why this measures the glyph rather than trusting the number to be exact.
-- `textContent` is trimmed first: authored markup arrives with newlines and indentation, which
-  collapse in rendering but would otherwise defeat the first-character test.
-- The `ctx.font` readback guards a silent failure — canvas ignores an unparseable shorthand and
-  keeps its `10px sans-serif` default, which would measure a small, plausible, wrong advance.
+- Uses the **advance**, not ink width, and adds back the `letter-spacing` that `measureText` omits.
+- Emitted in `em`: `heading-1` is responsive, so a px indent would go stale on every breakpoint. The
+  ratio drifts ~0.02em (≈1px at 80px) because `letter-spacing` is a fixed px. Also covers text zoom.
+- `textContent` is trimmed — authored markup arrives with newlines that would defeat the
+  first-character test.
+- The `ctx.font` readback guards a silent failure: canvas ignores an unparseable shorthand and keeps
+  its `10px sans-serif` default, which would measure a plausible but wrong advance.
 
 ## Architecture notes
 
@@ -419,27 +421,37 @@ speeding up the globe:
 | **formation** (arc→grid→fold→settle) | `0 → --gg-formation-vh` (304vh) | `0 → foldLast` (≈0.322) | the `P_*` phase constants |
 | **tail** (zoom-through + pull-quote) | `--gg-formation-vh → --gg-runway-height` | `foldLast → 1` | `zoomT`, cursor retire, pull-quote |
 
-Formation is **locked** to a fixed scroll length: `FORMATION_SCROLL_VH` (JS) = `--gg-formation-vh` (CSS)
-= 304vh (≈ `SPHERE_FORMED_PROGRESS` × the original 945vh single-runway tuning). `formedScrollPx()` is
-the single source used by the remap, the reduced-motion pin, and the focus-snap. Within the tail,
-`zoomT = clamp((scroll − formation) / (runway − formation), 0, 1)` drives the camera
+Formation is **locked** to a fixed scroll length, so `--gg-runway-height` sets tail length only.
+`formedScrollPx()` is the single source used by the remap, the reduced-motion pin, and the focus-snap.
+Within the tail, `zoomT = clamp((scroll − formation) / (runway − formation), 0, 1)` drives the camera
 (`CAM_Z_SPHERE → CAM_Z_END`), the cursor retirement, and the pull-quote.
 
-Because formation is fixed, `--gg-runway-height` sets tail length only. `--gg-runway-height` is **shared**
-across breakpoints; `--gg-pq-pin-factor` is **per-breakpoint** (`@media (min-width:768px)` overrides the
-sm base). CSS custom props on `.globe-gallery`:
+**CSS is the source of truth for all three props**, read per layout in `doLayout`, so retuning is a
+CSS-only edit:
 
 | prop | sm (base) | md+ | effect |
 |---|---|---|---|
 | `--gg-runway-height` | 520vh | 520vh | total height = formation + tail; ↓ = shorter stretch after the globe (shrinks gap **and** hold together) |
-| `--gg-formation-vh` | 304vh | 304vh | locked formation length; must equal `FORMATION_SCROLL_VH` in JS |
+| `--gg-formation-vh` | 304vh | 304vh | locked formation length |
 | `--gg-pq-pin-factor` | 0.65 | 0.55 | share of the tail the (bottom-anchored) quote pin occupies → its hold |
+
+`timeline.js`'s exported `CSS_FALLBACK` is the **only** JS copy of these numbers, read only when a
+property fails to resolve — possible because `loadBlock` races a block's stylesheet against its script
+(`libs/utils/utils.js:1369`), and an unresolved property parses to `NaN`, which would propagate into
+`progress` and kill the animation silently. It is not a second source of truth: if it and CSS
+disagree, CSS wins and `CSS_FALLBACK` is simply stale. Nothing else in JS may re-inline these values.
+`timeline.js` stays pure (no DOM), so `doLayout` does the reading, via a `cssNum(prop, fallback)`
+helper testing `Number.isFinite` rather than `||` so an authored `0` isn't swallowed.
+
+`measureBlock()` (from `doLayout` and `layoutObs`) sets `blockDocTop` + `blockHeight`. `blockHeight`
+is `offsetHeight`, itself CSS-driven, so `--gg-runway-height` is never read directly; `offsetHeight`
+is `0` only before the stylesheet applies, when the property wouldn't resolve either — hence the
+fallback there is `CSS_FALLBACK.RUNWAY_VH`.
 
 sm uses a **bigger** pin factor than md on purpose: its globe clears earlier (`zoomT≈0.30` vs md
 `≈0.42`), so the quote can start sooner *and* hold longer — which sm needs, because the fixed 583px
-quote is taller in vh on a phone (~73vh at 800px vs ~54vh at 1080), i.e. it eats more of the pin. md's
-factor is capped ~0.55: above it the fade-in would cross md's globe-clear (`zoomT≈0.42`) and land the
-quote over the globe.
+quote eats more of the pin on a phone (~73vh at 800px vs ~54vh at 1080). md's factor is capped ~0.55:
+above it the fade-in would cross md's globe-clear and land the quote over the globe.
 
 **Pull-quote timing is derived, not hand-set.** The pin height is `(runway − formation) ×
 --gg-pq-pin-factor`, so it always exits exactly at the runway end (no dead scroll), and the JS fade-in
@@ -461,8 +473,8 @@ a fixed runway); to change both together, move `--gg-runway-height`.
 Current result (from the progress math; hold is viewport-dependent since the quote is a fixed 583px):
 md gap ≈91vh / hold ≈65vh; sm gap ≈69vh / hold ≈68vh.
 
-Milo's page-level Lenis keeps `window.scrollY` in sync (gsap was dropped for a `requestAnimationFrame`
-driver, `startTicker`/`stopTicker`). The modal pauses Lenis via `window.lenis.stop()/start()` plus a
+Milo's page-level Lenis keeps `window.scrollY` in sync; the driver is a plain `requestAnimationFrame`
+loop (`startTicker`/`stopTicker`). The modal pauses Lenis via `window.lenis.stop()/start()` plus a
 `.globe-gallery-modal-open { overflow:hidden }` CSS lock.
 
 **Ticker gating (rAF only while visible).** The loop runs only when BOTH `renderReady`
@@ -479,48 +491,38 @@ long off-screen scroll doesn't read a spurious one-frame `scrollVel` spike. The 
 created in `initRuntime`, disconnected in `destroy` (mirrors `layoutObs`); it fires once on
 `observe()` to correct the `onScreen` default.
 
-**Progressive texture loading (contours → un-dissolve).** Card meshes are built up front,
-before any photo loads, so the block paints immediately: `initRuntime` runs
-`buildCards()`/`buildTextMesh()`/`a11y.setup()` and flips `renderReady` **before**
-`loadCardTextures`, seeding each card with a shared 1×1 `placeholderTex` and a placeholder
-aspect. Until a card's photo lands it renders as a **contour** — a faint rounded-rect fill +
-~1px edge stroke drawn in `CARD_FRAG` from the existing `rrSDF`, driven by two uniforms
-(`uReveal` 0→1 = contour→photo crossfade, `uContourFade` = proxFade so the contour respects the
-near-camera cull). `loadCardTextures` reports **per image** via `onEach` (plus `onDone` once all
-settle; the caller owns the `textureLoadGeneration` stale-guard in both). `onEach` swaps in the
-real texture, refreshes the card's cover-crop UVs + native `sphereScaleX`, and flips
-`hasTexture`; `revealT` then eases 0→1 in `updateCardTransform` and the photo **un-dissolves**
-in — the same edge-first particle effect as the near-camera proximity fade (`uDissolve`), so the
-two compose in `placeSphereCard` by **max-dissolve / min-opacity** (neither un-hides what the
-other hides). On **md** (sphere) positions are index-based (`fibSpherePos`), so a landed texture
-only morphs the card's scale/aspect in place (`updateCardSphereSizing`) — never a reflow. On
-**sm** the masonry barrel is a whole-set solve (packing needs every aspect), so it's packed once
-with placeholder aspects and **re-solved once** in `onDone` (`resolveMasonryLayout`); each card
-then eases from its provisional slot to the final one via a one-time `masonryMorph` tween
-(invisible while the user is still in arc/grid, the common case). `dragFlipZ` (aspect-dependent)
-is recomputed in `onDone` / when the morph settles. Images decode off the main thread
-(`img.decode()` before rasterizing) so many decode concurrently instead of serializing on
-`onload`. Net: `renderReady` now means *cards built* (contours visible), not *all textures
-loaded* — the old all-or-nothing barrier is gone.
+**Progressive texture loading (contours → un-dissolve).** Card meshes are built before any photo
+loads, so the block paints immediately: `initRuntime` runs `buildCards()`/`buildTextMesh()`/
+`a11y.setup()` and flips `renderReady` **before** `loadCardTextures`, seeding each card with a shared
+1×1 `placeholderTex` and a placeholder aspect. Until a card's photo lands it renders as a **contour**
+— a faint rounded-rect fill + ~1px stroke drawn in `CARD_FRAG` from `rrSDF`, driven by `uReveal`
+(contour→photo crossfade) and `uContourFade` (proxFade, so the contour respects the near-camera cull).
+`loadCardTextures` reports **per image** via `onEach`, plus `onDone` once all settle; the caller owns
+the `textureLoadGeneration` stale-guard in both. `onEach` swaps in the real texture, refreshes
+cover-crop UVs + native `sphereScaleX`, and flips `hasTexture`; `revealT` then eases 0→1 and the photo
+**un-dissolves** in — the same edge-first particle effect as the near-camera fade (`uDissolve`), so
+the two compose in `placeSphereCard` by **max-dissolve / min-opacity**, neither un-hiding what the
+other hides. On **md** positions are index-based (`fibSpherePos`), so a landed texture only morphs
+scale/aspect in place — never a reflow. On **sm** the masonry barrel is a whole-set solve, so it's
+packed once with placeholder aspects and **re-solved once** in `onDone`, each card easing to its final
+slot via a one-time `masonryMorph` tween (invisible while the user is still in arc/grid, the common
+case). `dragFlipZ` is recomputed in `onDone` / when the morph settles. Images decode off the main
+thread (`img.decode()`) so many decode concurrently. So `renderReady` means *cards built* (contours
+visible), not *all textures loaded*.
 
 **Right-sized image requests.** `loadCardTextures`' `getSrc` and the modal upgrade both route the
-authored image URL through `optimizeImgUrl(src, cap)` (`authoring.js`), which for a helix/DA
-`media_*` asset rewrites it to `?width=<cap>&format=webply` — mirroring `libs/utils/decorate.js`'s
-`decoratePictures` convention (strip query, width + `webply`). Non-`media_` URLs pass through
-untouched. Because we downscale client-side anyway (`fitDims`), this only trims bytes on the wire
-(≈10–30× on slow links), not the final texture resolution. A side benefit: the modal now requests
-its own cap (`MODAL_TEX_MD` 2048) explicitly, so it reaches the intended sharpness instead of being
-limited by whatever width the authored `<img>` src happened to be.
+authored URL through `optimizeImgUrl(src, cap)` (`authoring.js`), which for a helix/DA `media_*` asset
+rewrites it to `?width=<cap>&format=webply`, mirroring `decoratePictures`' convention. Non-`media_`
+URLs pass through. Because we downscale client-side anyway (`fitDims`), this trims bytes on the wire
+(≈10–30× on slow links), not the final texture resolution — and it lets the modal request its own cap
+(`MODAL_TEX_MD` 2048) rather than being limited by the authored `<img>` src width.
 
-**Pausing must hide the canvas (multi-globe correctness).** The main canvas is
-`position:fixed` + full-viewport + `pointer-events:auto`, and `updateCanvasVisibility` — the
-stage that `display:none`s it when the block is out of range — runs *inside* `tick()`. So
-when `syncTicker()` stops the loop it also sets `renderer.domElement.style.display = 'none'`;
-otherwise a paused globe's fixed canvas keeps intercepting pointer events across the whole
-viewport, which with **multiple globes per page** silently blocks whichever globe is actually
-on screen (its clicks/drags/hover land on the off-screen globe's paused canvas). The resumed
-loop's `updateCanvasVisibility` restores the display. A single off-screen globe hiding its
-own canvas is a no-op (it's out of view anyway).
+**Pausing must hide the canvas (multi-globe correctness).** The main canvas is `position:fixed` +
+full-viewport + `pointer-events:auto`, and `updateCanvasVisibility` — the stage that `display:none`s
+it when out of range — runs *inside* `tick()`. So when `syncTicker()` stops the loop it also sets
+`display = 'none'` directly; otherwise a paused globe's fixed canvas keeps intercepting pointer events
+across the whole viewport, which with **multiple globes per page** silently swallows the clicks meant
+for whichever globe is actually on screen. The resumed loop's `updateCanvasVisibility` restores it.
 
 **z-index / stacking order.** All values live in `globe-gallery.css` (plus the two canvas inline
 styles in `authoring.js`). Two bands in the page-root stacking context:
@@ -528,13 +530,11 @@ styles in `authoring.js`). Two bands in the page-root stacking context:
 - **Hero — 2–5:** world `2`, main canvas `3`, arc-copy / a11y widgets `4`, pull-quote / a11y tip `5`.
 - **Modal — 13–17:** backdrop `13`, modal canvas `14`, chrome `15`, cursor disc `16`, cursor container `17`.
 
-The modal band sits just above the **C2 gnav (`12`)** so the immersive card view covers the nav, and
-deliberately **below** the higher-priority interrupts that should appear over the globe — caas (`200`),
-market-selector (`9999`), georouting / Milo modals (`100000`), and the consent banner. It can't collapse
-into the 1–10 range precisely because it must clear the gnav. C1 core blocks (e.g. legacy gnav, the
-authored `notification` block) aren't authored alongside C2, so nothing occupies the 18–199 gap here.
-The modal chrome is a native `<dialog>`/`showModal()` in the top layer, so its z-index is only a
-non-supporting-browser fallback.
+The modal band sits just above the **C2 gnav (`12`)** so the card view covers the nav, and
+deliberately **below** the interrupts that should appear over the globe — caas (`200`),
+market-selector (`9999`), georouting / Milo modals (`100000`), and the consent banner. It can't
+collapse into the 1–10 range precisely because it must clear the gnav. The modal chrome is a native
+`<dialog>`/`showModal()` in the top layer, so its z-index is only a non-supporting-browser fallback.
 
 ## Lifecycle timeline
 
@@ -648,11 +648,11 @@ rather than restating them — it cannot drift from the code:
 ```sh
 cd libs/mep/ace1209/globe-gallery && node --input-type=module -e "
 import * as T from './src/timeline.js';
-const RUNWAY_VH = 520; // --gg-runway-height
-const tail = RUNWAY_VH - T.FORMATION_SCROLL_VH;
+const { RUNWAY_VH, FORMATION_VH } = T.CSS_FALLBACK; // = the CSS defaults
+const tail = RUNWAY_VH - FORMATION_VH;
 const vh = (p) => (p <= T.SPHERE_FORMED_PROGRESS
-  ? (p / T.SPHERE_FORMED_PROGRESS) * T.FORMATION_SCROLL_VH
-  : T.FORMATION_SCROLL_VH
+  ? (p / T.SPHERE_FORMED_PROGRESS) * FORMATION_VH
+  : FORMATION_VH
     + ((p - T.SPHERE_FORMED_PROGRESS) / (1 - T.SPHERE_FORMED_PROGRESS)) * tail);
 const row = (n, p) => console.log(String(Math.round(vh(p))).padStart(4) + 'vh', p.toFixed(3), n);
 row('fold starts / sphereFormT>0', T.FOLD_FIRST_PROGRESS);
@@ -667,6 +667,54 @@ row('cursor label / retire', T.progressAtZoomT(T.CURSOR_ZOOM_RETIRE_T));
 row('canvas hidden', T.progressAtZoomT(T.CANVAS_HIDE_ZOOM_T));
 "
 ```
+
+## Phase constants
+
+All in **`src/timeline.js`** — these are the *inputs*; **Lifecycle timeline** above shows what they
+add up to. The `P_*` values live in **progress-space** (0→1) and shape formation + zoom; the runway
+split, pull-quote, and cursor retirement are covered under **Scroll model** (driven by the CSS props,
+read in JS):
+
+```
+P_PAN_END=0.55  P_ARC_PREROLL=0.30  P_GRID_ARC_START=0.30  P_GRID_ARC_END=0.60
+P_FOLD_DUR=0.25  P_ZOOM_END=1.00  GRID_PEEL_STAGGER=0.20  SPHERE_INTERACTIVE_T=0.8
+FOLD_PEEL_OVERLAP=0.35  CA_ENABLED=true
+PQ_APPEAR_LEAD=0.03  CURSOR_ZOOM_DISMISS_T=0.38  CURSOR_ZOOM_RETIRE_T=0.40
+```
+
+`FOLD_PEEL_OVERLAP` (0–1) makes each card begin folding to the sphere that far — in peel
+position-space — **before** it fully lands in the grid (folding from its live peel position, no
+snap), so the grid never visibly "resolves" and the sphere forms earlier. The fold opens at peel
+localT `FOLD_START_LOCAL_T = 1 − FOLD_PEEL_OVERLAP^(1/3)`; the global fold window
+(`FOLD_FIRST_PROGRESS` → `SPHERE_FORMED_PROGRESS`) and the per-card fold timer
+(`cardFoldStartProgress`) both derive from it in `timeline.js`, so camera / depth-sort /
+interactivity stay aligned. `0` restores "settle, then fold."
+
+**Arc-copy fade-out** (`updateArcCopy`) is expressed as a *fraction of the grid→globe fold window*
+(`FOLD_FIRST_PROGRESS` → `SPHERE_FORMED_PROGRESS`), not as raw progress, so it stays aligned if the
+fold constants move: `ARC_COPY_OUT_FORM_START = 0.20` → `ARC_COPY_OUT_FORM_END = 0.90`, i.e.
+progress ≈ `0.096` → `0.294` against a formed sphere at `0.322`. It therefore starts only once the
+fold is underway and is fully gone *before* the sphere (md) / barrel (sm) finishes forming — one
+window for both profiles, since the fold constants are shared. The out-ease is `easeInOutCubic`,
+**not** the `easeOutCubic` used for the fade-in: `easeOutCubic` is ~88% done at the window's
+midpoint, which would collapse the copy to invisible almost as soon as it began; `easeInOutCubic`
+spreads the fade over the whole window and still lands exactly on 0 at `outEnd`.
+
+`FOLD_FIRST_PROGRESS` and `SPHERE_FORMED_PROGRESS` are the fold window's two ends, and
+`cardFoldStartProgress(gpDelay)` is the same computation per card — `FOLD_FIRST_PROGRESS` is its
+`gpDelay = 0` case. All three live in `timeline.js`, so the global window and the per-card gate
+cannot drift apart.
+
+**Arc-copy placement is all CSS**; `updateArcCopy` owns only the opacity and the 24px entry slide.
+CSS sets both edges: `bottom` (`--s2a-spacing-xs` at sm, `--s2a-spacing-lg` from `min-width:768px`)
+and `inset-inline-start`, which shares the pull-quote's `--gg-content-inset` (see the CSS section
+below for the derivation and for why md+ offsets it back by `--gg-arc-pad`). The logical property
+handles RTL, so no JS is involved in the side-swap.
+
+**Entry timing** — two independent constants: `ENTRY_LEAD_VH` (`0.4`) viewport-heights before the
+block top that entry begins (`0` late; `0.85` is the prototype's hero pre-roll but sweeps meshes
+over content above), and `ENTRY_RAMP_VH` (`1.05`) the ramp over which `arcCopyEntryT` goes 0→1
+(arc-copy fade, arc pre-roll speed, text→arc gap).
 
 ## Accessibility
 
@@ -715,8 +763,8 @@ auto-spin (`a11y.isBrowsing()`); mouse drag still works.
   in one sr-only element referenced by BOTH the dialog's `aria-labelledby` and the heading's
   `aria-describedby` — **no `aria-live`** — so it's deterministic on both paths: on open it's read
   with the focused heading; on nav (focus stays on Prev/Next) the accessible-name text changes, so
-  VoiceOver re-announces the dialog name. (A live region would be more portable across AT but
-  couldn't reliably cover the open case, which is why it was dropped.)
+  VoiceOver re-announces the dialog name. A live region would be more portable across AT but can't
+  reliably cover the open case.
 
 **Reduced motion** (`prefers-reduced-motion: reduce`) renders a **static interactive** globe
 instead of the scroll choreography, laid out as **plain document flow** (`.globe-gallery-reduced`):
@@ -747,52 +795,7 @@ cleanly). The pieces:
 
 The `--reduced` overrides are grouped at the **end of `globe-gallery.css`** (`no-descending-specificity`). The no-cards / WebGL-unavailable fallback is the separate `.globe-gallery-empty`.
 
-Phase constants (all in **`src/timeline.js`**) — these are the *inputs*; **Lifecycle timeline**
-above shows what they add up to. The `P_*` values live in **progress-space** (0→1) and shape formation
-+ zoom; the runway split, pull-quote, and cursor retirement are covered under **Scroll model → the
-runway / progress model** above (they're driven by `--gg-runway-height` / `--gg-formation-vh` /
-`--gg-pq-pin-factor` in CSS, read/derived in JS):
-
-```
-P_PAN_END=0.55  P_ARC_PREROLL=0.30  P_GRID_ARC_START=0.30  P_GRID_ARC_END=0.60
-P_FOLD_DUR=0.25  P_ZOOM_END=1.00  GRID_PEEL_STAGGER=0.20  SPHERE_INTERACTIVE_T=0.8
-FOLD_PEEL_OVERLAP=0.35  CA_ENABLED=true
-FORMATION_SCROLL_VH=304  PQ_APPEAR_LEAD=0.03  CURSOR_ZOOM_DISMISS_T=0.38  CURSOR_ZOOM_RETIRE_T=0.40
-```
-
-`FOLD_PEEL_OVERLAP` (0–1) makes each card begin folding to the sphere that far — in peel
-position-space — **before** it fully lands in the grid (folding from its live peel position, no
-snap), so the grid never visibly "resolves" and the sphere forms earlier. The fold opens at peel
-localT `FOLD_START_LOCAL_T = 1 − FOLD_PEEL_OVERLAP^(1/3)`; the global fold window
-(`FOLD_FIRST_PROGRESS` → `SPHERE_FORMED_PROGRESS`) and the per-card fold timer
-(`cardFoldStartProgress`) both derive from it in `timeline.js`, so camera / depth-sort /
-interactivity stay aligned. `0` restores "settle, then fold."
-
-**Arc-copy fade-out** (`updateArcCopy`) is expressed as a *fraction of the grid→globe fold window*
-(`FOLD_FIRST_PROGRESS` → `SPHERE_FORMED_PROGRESS`), not as raw progress, so it stays aligned if the
-fold constants move: `ARC_COPY_OUT_FORM_START = 0.20` → `ARC_COPY_OUT_FORM_END = 0.90`, i.e.
-progress ≈ `0.096` → `0.294` against a formed sphere at `0.322`. It therefore starts only once the
-fold is underway and is fully gone *before* the sphere (md) / barrel (sm) finishes forming — one
-window for both profiles, since the fold constants are shared. The out-ease is `easeInOutCubic`,
-**not** the `easeOutCubic` used for the fade-in: `easeOutCubic` is ~88% done at the window's
-midpoint, which would collapse the copy to invisible almost as soon as it began; `easeInOutCubic`
-spreads the fade over the whole window and still lands exactly on 0 at `outEnd`.
-
-`FOLD_FIRST_PROGRESS` and `SPHERE_FORMED_PROGRESS` are the fold window's two ends, and
-`cardFoldStartProgress(gpDelay)` is the same computation per card — `FOLD_FIRST_PROGRESS` is its
-`gpDelay = 0` case. All three live in `timeline.js`, so the global window and the per-card gate
-cannot drift apart.
-
-**Arc-copy placement is all CSS**; `updateArcCopy` owns only the opacity and the 24px entry slide.
-CSS sets both edges: `bottom` (`--s2a-spacing-xs` at sm, `--s2a-spacing-lg` from `min-width:768px`)
-and `inset-inline-start`, which shares the pull-quote's `--gg-content-inset` (see the CSS section
-below for the derivation and for why md+ offsets it back by `--gg-arc-pad`). The logical property
-handles RTL, so the JS side-swap that used to maintain `left`/`right` by hand is gone.
-
-**Entry timing** — two independent constants: `ENTRY_LEAD_VH` (`0.4`) viewport-heights before the
-block top that entry begins (`0` late; `0.85` is the prototype's hero pre-roll but sweeps meshes
-over content above), and `ENTRY_RAMP_VH` (`1.05`) the ramp over which `arcCopyEntryT` goes 0→1
-(arc-copy fade, arc pre-roll speed, text→arc gap).
+## Breakpoints & rebuilds
 
 **Breakpoints** resolve once in `init()`: two render profiles split at 768px — `md` (≥768, all
 cards, 9×5 grid, large sphere; covers Milo md *and* lg) and `sm` (<768, first 24, 3×8, smaller
@@ -804,6 +807,21 @@ card count, so `doLayout` triggers a full `destroy()`+`init()` rebuild; resizing
 the cheap path (renderer/camera resize). The `resize` handler is the sole driver of the **width**
 boundary — no `matchMedia` listener for 768px. The one `matchMedia` `change` listener is for
 reduced motion (see Reduced motion); pointer precision is read at init only (see Shape).
+
+**`doLayout` cost control.** `resize` fires ~once per frame during a desktop window drag, and once
+mid-scroll whenever iOS Safari collapses the URL bar (changing `innerHeight`) — the latter landing
+inside the formation animation. So the handler is split three ways:
+- Unchanged `W` **and** `H` → return immediately, skipping two WebGL buffer reallocations. Only the
+  `resize` path takes this exit (`doLayout({ fromResize: true })`); the init call and the
+  reduced-motion `change` listener run with the viewport unchanged and must still execute the body.
+  Both listeners are wrapped rather than passed `doLayout` directly, or the event argument would land
+  in its options object.
+- Renderer/camera/`computeGridLayout()` stay **synchronous** — a stale `W`/`H` renders the canvas
+  stretched and desyncs `formedScrollPx()`.
+- `buildTextMesh()` is **trailing-debounced** (`TEXT_REBUILD_DEBOUNCE_MS`, 150ms), but only while
+  `textMesh.visible` is false — it disposes a GPU texture, redraws a 2D canvas and uploads a new one.
+  On screen it rebuilds synchronously, since a deferred rebuild would leave it stretched at the old
+  aspect. `destroy()` clears any pending timer so a band crossing can't rebuild into a torn-down scene.
 
 Because the block's `innerHTML` is built once in the outer `init(el)` (not per `initRuntime`) and
 the runtime closure survives a `destroy()`+`initRuntime()` rebuild, `destroy()` resets state a
@@ -817,6 +835,8 @@ rebuild would otherwise inherit:
   `sphereOrient.pitchReleaseCap`, `sphereDragWarp`, `drag.velX/velY`, `navNudge.*`, `wasBrowsing`) to the upright
   pose — else pitch/yaw dragged before a device change carried into the rebuilt barrel and rendered
   it tilted until a scroll-out zeroed it.
+
+## CSS
 
 **Tokens.** Every spacing, radius, border-width, font-size, font-weight and blur value that lands on
 an S2A scale uses the token, not the literal — including positional insets (`bottom`,
@@ -844,9 +864,8 @@ md counter pill, the a11y tip, the cursor label). It is declared on `.globe-gall
 it cannot inherit. The same is true of any future local var the cursor needs.
 
 Note the font-size tokens are **rem** (`--s2a-font-size-sm` is `0.875rem`). Neither `libs/styles` nor
-`libs/c2/styles` overrides the root font-size, so they resolve to their nominal px — but unlike the
-px literals they replaced, this block's type now scales with a reader's browser font-size setting,
-which is the intended C2 behaviour.
+`libs/c2/styles` overrides the root font-size, so they resolve to their nominal px while still scaling
+with a reader's browser font-size setting — the intended C2 behaviour, and why px literals aren't used.
 
 **Naming.** Classes are `globe-gallery-*` (BEM-ish, matching the block name); every custom property
 this block *defines* is `--gg-*`, the initials convention other C2 blocks use (`--bc-` in
@@ -872,9 +891,6 @@ consumes the same two vars so the pair cannot drift). The arc copy is `position:
 there is no JS involved. At sm it pins 8px from the edge and its own `--gg-arc-pad` (16px) lands the
 copy on the inset; at md+ the pill background is gone, so the box is offset back by that padding
 (`calc(var(--gg-content-inset) - var(--gg-arc-pad))`) to put the *copy*, not the box, on the edge.
-Before this, `updateArcCopy` positioned the box per-frame from a 1392px content grid
-(`24 + max(0, (W - 48 - 1392) / 2)`), which put the arc copy 16px inboard of the pull-quote below
-1440px and up to 256px inboard above it (1920px viewport: copy at 280px vs the quote's 24px).
 
 ### Crosshair frame
 
@@ -925,11 +941,11 @@ Milo's `decorateDefaultLinkAnalytics` (`libs/martech/attributes.js`) runs **once
 block with four holes:
 
 1. A card is WebGL pixels raycast in `interaction.js` — there is no DOM node to decorate.
-2. Auto-generated labels are `${label}-${linkCount}--${header}`, where `linkCount` is the
-   ordinal among *all* links/buttons in the block. The ~50 `.globe-gallery-a11y-card` buttons
-   precede the modal controls, so prev used to read `previous card-52--`. That ordinal is also
-   **race-dependent** (the a11y buttons only exist after the async fragment fetch) and is
-   **never re-applied** after a breakpoint rebuild destroys and recreates them.
+2. Auto-generated labels are `${label}-${linkCount}--${header}`, where `linkCount` is the ordinal
+   among *all* links/buttons in the block. The ~50 `.globe-gallery-a11y-card` buttons precede the
+   modal controls, so prev would read `previous card-52--`. That ordinal is **race-dependent** (the
+   a11y buttons only exist after the async fragment fetch) and **never re-applied** after a
+   breakpoint rebuild recreates them.
 3. Badge CTAs are minted per card inside `populateModal`, always after the decoration pass.
 4. Escape and the mobile gestures produce no DOM click at all.
 
@@ -979,59 +995,50 @@ through DAA, they share one consent path; there is no gate on one and not the ot
 
 ### Details worth not re-deriving
 
-- **Badge labels carry no index.** Derived from badge row position it would differ per card
-  (Photoshop `-1` on one card, `-3` on another), splitting the one aggregate that matters. One
-  product = one label. Milo's gnav ships numberless labels too (`daa-ll="Brand"`).
-  `processTrackingLabels` also strips `-`, so a product name like `Photoshop-Web` becomes
-  `Photoshop Web` and cannot corrupt the level split.
-- **20 characters per segment.** `decorateDefaultLinkAnalytics` re-runs every `-`-separated
-  segment of an existing `daa-ll` through `processTrackingLabels(part, config, 20)`, which
-  hard-slices at 20 — silently. `enter_gallery_keyboard` became `enter_gallery_keyboa`, hence
-  the `_kbd` abbreviation. Check any new label the same way: split on `-`, and no piece may
-  exceed 20 characters. Product names are already sliced to 20 at mint time.
-- **Every card button carries the *same* explicit `daa-ll`** (`CARD_OPEN_DAA_LL` in `a11y.js`).
-  Left to auto-decoration they would each derive a label from `aria-label` — the card's alt
-  text — producing ~50 per-card labels, exactly the cardinality this design rejects. Explicit
-  also means the label cannot drift with the button's ordinal.
+- **Badge labels carry no index.** Derived from row position it would differ per card (Photoshop
+  `-1` on one, `-3` on another), splitting the one aggregate that matters. One product = one label.
+  `processTrackingLabels` also strips `-`, so `Photoshop-Web` becomes `Photoshop Web` and can't
+  corrupt the level split.
+- **20 characters per segment.** `decorateDefaultLinkAnalytics` re-runs every `-`-separated segment
+  of an existing `daa-ll` through `processTrackingLabels(part, config, 20)`, which hard-slices at 20
+  **silently** — hence `_kbd` rather than `_keyboard`. Check any new label the same way: split on
+  `-`, and no piece may exceed 20 characters. Product names are sliced to 20 at mint time.
+- **Every card button carries the *same* explicit `daa-ll`** (`CARD_OPEN_DAA_LL` in `a11y.js`). Left
+  to auto-decoration each would derive a label from `aria-label` — the card's alt text — producing
+  ~50 per-card labels, the exact cardinality this design rejects.
 - **`event.isTrusted` separates acting from reporting.** A synthetic click carries
-  `isTrusted: false`; genuine user activation is always `true`, including keyboard Enter/Space
-  and screen-reader activation (AT goes through the platform accessibility API, which browsers
-  surface as a trusted click). So `onCardClick` bails on untrusted events: `trackCardOpen`'s
-  click is report-only, and without that bail it would reopen the modal at viewport centre,
-  discarding the tap coordinates the raycast passes. The marker rides on the event, so unlike a
-  module-scope flag it cannot latch, leak, or need a `finally`.
-  **Test gotcha:** an E2E test driving the block with `page.evaluate(el => el.click())` produces
-  an untrusted click and will appear to do nothing. Use the real click API (Playwright's
-  `locator.click()` dispatches trusted input).
-- **Only the canvas path calls `trackCardOpen`** (`openModalFromCanvas` in `globe-gallery.js`,
-  kept separate from `openModalAndDismissHint` for exactly this reason). A keyboard open is
-  already a real click on that button, so reporting there too would double-count it.
-- **`enter_gallery` is the one engagement signal here.** The entry widget is a real button, so
-  it costs a single label and roughly one event per keyboard session. It answers a question
-  nothing else does: whether the two-level a11y gallery is ever entered at all. Note the widget
-  is only *clicked* to enter BROWSE; merely focusing it (which scrolls the page to the
-  interactive globe via `snapToInteractive`) is a focus event and is not reported.
-- **Caveat inherent to `daa-ll` on any button:** a real click reports even when the handler
-  then declines to act — `enterBrowse()` bails if the sphere isn't formed, and `onCardClick`
-  bails if `isInteractive()` is false. Expect a small over-count on both.
-- **`close(e.isTrusted)`** (`modal.js`) is the same idea. `close(viaPointer)` ignores a close
-  within 200ms of open, to swallow the *browser's* synthetic click after a touch pointerup —
-  which is trusted, so the guard still applies to it. Escape and pull-to-close route through
-  `clickClose()`, are untrusted, and so are exempt; without that, Escape within 200ms of open
-  would be silently ignored. `viaPointer` and `isTrusted` turn out to be the same predicate,
-  so it is derived from the event rather than stashed.
-- **Do not add `daa-lh` anywhere in the block.** `attributes.md` forbids it, and a `daa-lh` on
-  the block element makes `decorateSectionAnalytics` skip link decoration for the whole block.
-- **Not tracked, deliberately:** globe drag/hover/auto-rotation, scroll milestones, card
-  impressions, and close *method* (button vs Escape vs swipe all collapse to one label). The
-  first two are the highest-volume signals here. Note these are the one class of signal the
-  all-`daa-ll` design cannot express: nothing is clicked, and there is no element that means
-  "the user reached the formed globe". Adding one would mean reintroducing `sendAnalytics`
-  (`libs/martech/helpers.js`) at the `SPHERE_INTERACTIVE_T` gate behind a once-only flag — and
-  with it a second reporting path, which gates on consent separately from DAA. Worth weighing
-  against the consolidation before adding the first one.
+  `isTrusted: false`; genuine user activation is always `true`, including keyboard Enter/Space and
+  screen-reader activation (AT goes through the platform accessibility API, which browsers surface as
+  a trusted click). So `onCardClick` bails on untrusted events: `trackCardOpen`'s click is
+  report-only, and without that bail it would reopen the modal at viewport centre, discarding the tap
+  coordinates the raycast passes. The marker rides on the event, so unlike a module-scope flag it
+  can't latch or leak.
+  **Test gotcha:** driving the block with `page.evaluate(el => el.click())` produces an untrusted
+  click and appears to do nothing. Use a real click API (Playwright's `locator.click()`).
+- **Only the canvas path calls `trackCardOpen`** (`openModalFromCanvas`, kept separate from
+  `openModalAndDismissHint` for this reason). A keyboard open is already a real click on that button,
+  so reporting there too would double-count.
+- **`enter_gallery` is the one engagement signal here** — one label, ~one event per keyboard session,
+  answering whether the two-level gallery is ever entered at all. The widget is only *clicked* to
+  enter BROWSE; merely focusing it (which scrolls via `snapToInteractive`) is not reported.
+- **Caveat inherent to `daa-ll` on any button:** a real click reports even when the handler declines
+  to act — `enterBrowse()` bails if the sphere isn't formed, `onCardClick` if `isInteractive()` is
+  false. Expect a small over-count on both.
+- **`close(e.isTrusted)`** (`modal.js`) is the same idea. `close(viaPointer)` ignores a close within
+  200ms of open, to swallow the *browser's* synthetic click after a touch pointerup — which is
+  trusted, so the guard applies. Escape and pull-to-close route through `clickClose()`, are
+  untrusted, and are exempt; otherwise Escape within 200ms of open would be silently ignored.
+  `viaPointer` and `isTrusted` are the same predicate, so it's derived from the event, not stashed.
+- **Do not add `daa-lh` anywhere in the block.** `attributes.md` forbids it, and a `daa-lh` on the
+  block element makes `decorateSectionAnalytics` skip link decoration for the whole block.
+- **Not tracked, deliberately:** globe drag/hover/auto-rotation, scroll milestones, card impressions,
+  and close *method* (button vs Escape vs swipe collapse to one label). These are the one class of
+  signal the all-`daa-ll` design cannot express — nothing is clicked, and no element means "the user
+  reached the formed globe". Adding one means reintroducing `sendAnalytics`
+  (`libs/martech/helpers.js`) at the `SPHERE_INTERACTIVE_T` gate behind a once-only flag, and with it
+  a second reporting path that gates on consent separately from DAA.
 
-## Behavior notes (intentional differences from the prototype)
+## Behavior notes
 
 - **"Click & Drag" hint text (WebGL).** A `PlaneGeometry` in `sphereGroup` behind the sphere's back
   surface (`z = −(SPHERE_R + TEXT_BEHIND_GAP)`, `renderOrder = -1`), so it rotates with the globe and
@@ -1064,58 +1071,48 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   reload, unless a re-init — e.g. an RM toggle — re-reads it). With multiple globes each
   makes its own pair but only the hovered one activates (inactive discs `visibility: hidden`). Label
   copy is the authored hint string (see Localization).
-- **Modal chrome — edge-anchored nav arrows + counter; desktop adds a screen-edge scrim.** The
-  prev/next arrows and counter are independent chrome children (no wrapper), positioned per-frame by
-  `positionModalChrome`, reading as one bottom-centre row at every breakpoint. **Desktop/tablet:** the
-  counter pill centres horizontally on the image, an arrow `DT_NAV_GAP` (12px) each side; the pill is
-  a fixed `DT_COUNTER_W` (138px, mirror its CSS `width`) so the flank offset needs no measuring; all
-  three share one `bottom` — `--gg-modal-edge` from the *viewport* bottom (not the image bottom), so the
-  row sits at the same height across images regardless of the photo's aspect ratio — 48px tall. **Mobile:** the same row spread wide into the bottom-left/right
-  corners inside the bottom scrim. The three frosted controls (both arrows + close) share one style
-  (1px `--s2a-color-transparent-white-24` border, `--gg-control-radius`,
-  `--s2a-color-transparent-black-64`, `blur(12px)`) and one 48×48 `--gg-control-size` hit target at
-  every breakpoint; close sits top-right at every breakpoint. Chrome geometry is three locals on
-  `.globe-gallery-modal-chrome`: `--gg-modal-edge` (`--s2a-spacing-md` → `--s2a-spacing-lg` at md+;
-  the single inset for all four controls *and* the scrim padding — `positionModalChrome` assigns the
-  `var()` string so nothing is duplicated in JS), `--gg-control-size` (48px, mirrored as `NAV_SIZE`
-  only because the desktop flank offset needs it as a number), and `--gg-control-radius` (6px — a
-  literal; S2A's radius scale has no 6px step). `--gg-modal-edge` is also the sm scrim's
-  `padding-bottom` reserve (`edge + control + edge`, so the arrows clear the badges); at md+ the
-  arrows sit under the image instead, so the override drops the reserve to a flat `edge`. The
-  **visible image** is contain-fit to the viewport minus a symmetric margin (desktop `DT_IMG_MARGIN`
-  12px; mobile full-bleed to screen width, square corners `uRadius=0`), native aspect kept — the
-  sizing math backs the geometry out of the SDF corner inset (`uRadius·cardHPx`) so the *photo*, not
-  the geometry, reaches the margin. The desktop corner radius is a **constant `MODAL_RADIUS_PX`
-  (16px) on screen for every card**, not a fixed fraction of height. `uRadius` is normalised to card
-  *height*, so `modalDesktopFit(uAspect)` solves the plane height as photo + 2·16px and derives
-  `radiusFrac = 16 / cardHPx` — per card, because `cardHPx` depends on whether that card's aspect
-  makes the fit width- or height-limited. Fixing the radius in px also removes the old circular
-  dependency (with a fractional radius the fit divided by `1 - 2·uRadius`).
-  `modalRadiusFrac(uAspect)` wraps it with the mobile `0`; it takes the **aspect**, not the card,
-  because that is the only per-card input — `uAspect = cardAspect × sphereScaleX`, and despite the
-  name `sphereScaleX` is not a sphere-phase transform, it is the card's native image aspect relative
-  to the base card aspect (set on texture decode, see `loadOverflowTexture`). The modal is still
-  WebGL geometry (a plane in `modalScene` under the same perspective camera), so this is the same
-  aspect the sphere phase uses. Because the fraction depends on the fit, `computeModalTarget`
-  re-pushes `uRadius` **per-frame** — a resize, or an overflow card's late aspect correction on
-  decode, changes `cardHPx`; the `getModalMaterial` / `createOverflowCard` assignments (and the
-  `createModalMaterial` initialiser) only seed the frames before it first runs.
-  Desktop adds a fixed-width (`DT_SCRIM_W` 316px) dark frosted
-  scrim on the **viewport's left edge, full height**; mobile's scrim is one full-width bottom chunk
-  (content-sized, capped at `60dvh`). Both are a **pinned header / scrolling body / pinned footer**:
-  role + name are `flex-shrink:0` at the top, the **badges** are `flex-shrink:0` at the bottom (so
-  those tabbable controls are always on-screen), and the **description** is the only scroll region
-  (`min-height:0; overflow-y:auto`) — long copy scrolls instead of overflowing or
-  hiding the badges. A `mask-image` scroll-shadow (`updateDescFade`, re-measured on
-  scroll / resize / card-change) fades whichever edge has more copy, so the scroll affordance
-  survives macOS's hidden overlay scrollbar. JS gives the description `tabindex="0"` only while it actually overflows, so it's
-  keyboard-scrollable then without leaving a pointless tab stop when the copy fits; the full text is
-  always in the a11y tree via the dialog's `aria-describedby`; `touchstart` skips the swipe/pull
-  gesture when a drag starts inside it so the copy scrolls rather than closing the modal. It also
-  carries **`data-lenis-prevent`** — Milo loads the Lenis smooth-scroll lib on `foundation:c2` pages
-  (`utils.js`), which hijacks the wheel/touch and applies it to the (scroll-locked) page, so a nested
-  scroll region silently won't scroll without opting out via that attribute. All dark frosted
-  (`rgb(0 0 0 / 64%)` + `blur(12px)`, light text).
+- **Modal chrome — edge-anchored nav arrows + counter; desktop adds a screen-edge scrim.**
+  - **Controls.** Prev/next arrows and the counter are independent chrome children (no wrapper),
+    positioned per-frame by `positionModalChrome`, reading as one bottom-centre row at every
+    breakpoint. **Desktop/tablet:** the counter pill centres on the image with an arrow `DT_NAV_GAP`
+    (12px) each side; the pill's fixed `DT_COUNTER_W` (138px, mirroring its CSS `width`) means the
+    flank offset needs no measuring. All three share one `bottom` — `--gg-modal-edge` from the
+    *viewport* bottom, not the image bottom, so the row holds its height whatever the photo's aspect.
+    **Mobile:** the same row spread into the bottom corners inside the scrim. The three frosted
+    controls (both arrows + close) share one style and one 48×48 `--gg-control-size` hit target
+    everywhere; close sits top-right at every breakpoint. Geometry is three locals on
+    `.globe-gallery-modal-chrome`: `--gg-modal-edge` (`--s2a-spacing-md` → `-lg` at md+ — the single
+    inset for all four controls *and* the scrim padding; `positionModalChrome` assigns the `var()`
+    string so nothing is duplicated in JS), `--gg-control-size` (mirrored as `NAV_SIZE` only because
+    the desktop flank offset needs a number), and `--gg-control-radius` (6px literal; no S2A step).
+    `--gg-modal-edge` is also the sm scrim's `padding-bottom` reserve (`edge + control + edge`, so the
+    arrows clear the badges); at md+ the arrows sit under the image, so the override drops it to a
+    flat `edge`.
+  - **Image fit + corner radius.** The **visible image** is contain-fit to the viewport minus a
+    symmetric margin (desktop `DT_IMG_MARGIN` 12px; mobile full-bleed, square corners `uRadius=0`),
+    native aspect kept — the sizing math backs the geometry out of the SDF corner inset
+    (`uRadius·cardHPx`) so the *photo*, not the geometry, reaches the margin. Desktop keeps a constant
+    `MODAL_RADIUS_PX` (16px) **on screen for every card**, not a fraction of height: `uRadius` is
+    normalised to card height, so `modalDesktopFit(uAspect)` solves the plane height as photo + 2·16px
+    and derives `radiusFrac = 16 / cardHPx` — per card, since `cardHPx` depends on whether that card's
+    aspect makes the fit width- or height-limited. `modalRadiusFrac(uAspect)` wraps it with the mobile
+    `0`, taking the **aspect** because that's the only per-card input: `uAspect = cardAspect ×
+    sphereScaleX`, and despite the name `sphereScaleX` is not a sphere-phase transform but the card's
+    native image aspect relative to the base card aspect (set on texture decode). Because the fraction
+    depends on the fit, `computeModalTarget` re-pushes `uRadius` **per-frame** — a resize, or an
+    overflow card's late aspect correction on decode, changes `cardHPx`.
+  - **Scrim + scroll region.** Desktop gets a fixed-width (`DT_SCRIM_W` 316px) dark frosted scrim on
+    the **viewport's left edge, full height**; mobile gets one full-width bottom chunk (content-sized,
+    capped at `60dvh`). Both are **pinned header / scrolling body / pinned footer**: role + name are
+    `flex-shrink:0` at the top, **badges** are `flex-shrink:0` at the bottom (so those tabbable
+    controls stay on-screen), and the **description** is the only scroll region (`min-height:0;
+    overflow-y:auto`). A `mask-image` scroll-shadow (`updateDescFade`, re-measured on
+    scroll/resize/card-change) fades whichever edge has more copy, so the affordance survives macOS's
+    hidden overlay scrollbar. JS gives the description `tabindex="0"` only while it actually overflows;
+    the full text is always in the a11y tree via `aria-describedby`; `touchstart` skips the swipe/pull
+    gesture when a drag starts inside it. It also carries **`data-lenis-prevent`** — Milo loads Lenis
+    on `foundation:c2` pages, which hijacks wheel/touch and applies it to the (scroll-locked) page, so
+    a nested scroll region silently won't scroll without that attribute.
   - **Touch gestures (in the modal) are gated on a coarse primary pointer**
     (`matchMedia('(pointer: coarse)')`, mirroring `usesCylinderGeometry`), not on the `sm` width
     band — so tablets at md (≥768) get them too. A per-gesture axis lock (`AXIS_LOCK_PX` 10px)
@@ -1149,14 +1146,12 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   - **No-overshoot ease.** Keyboard and modal centring share one **frame-counted `easeInOutCubic`
     tween** (`KEY_BROWSE_FRAMES` visible; `KEY_MODAL_FRAMES` faster, behind the blur) — never
     overshoots, and a low frame rate stretches the spin smoothly instead of jumping. RM snaps.
-  - **Why capped, not a free trackball.** A pure-trackball version was tried and **reverted** (git
-    commit `desktop no clamp, drag yaw-only`): full tumbling read as too free, and — the deciding
-    factor — trackball roll is path-dependent, so curved drags accumulate tilt that never
-    self-cancels (a closed input loop isn't a closed orientation loop). Clamped Euler makes
-    orientation a pure function of `(pitch, yaw)`: roll returns to 0 whenever pitch does, bounded by
-    `|roll| ≤ |pitch| ≤ 60°`. That self-correction is the reason for the cap; don't restore a
-    blanket clamp / drop the roll / hard-switch the cap without re-breaking polar centring,
-    uprighting, or the smooth exit.
+  - **Why capped, not a free trackball.** Trackball roll is path-dependent, so curved drags
+    accumulate tilt that never self-cancels (a closed input loop isn't a closed orientation loop).
+    Clamped Euler makes orientation a pure function of `(pitch, yaw)`: roll returns to 0 whenever
+    pitch does, bounded by `|roll| ≤ |pitch| ≤ 60°`. That self-correction is the reason for the cap;
+    don't restore a blanket clamp, drop the roll, or hard-switch the cap without re-breaking polar
+    centring, uprighting, or the smooth exit.
   - **Modal TRAVERSAL centres the viewed card (shared with the keyboard gallery); it doesn't
     "nudge."** `centerModalCard` (injected as `requestNavNudge`, called on modal **prev / next /
     swipe** — NOT open) rotates the sphere so the revealed card faces centre behind the modal, so
@@ -1169,8 +1164,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     close and the focus ring hugs the card. On **yaw-only geometry** pitch is held. **Camera INSIDE
     the globe** (modal opened mid-zoom-through then traversed): once inside the camera sees the FAR
     (−Z) wall, so `cardCenterYawPitch` flips the target to −Z (keyed off `cameraInsideSphere`;
-    keyboard browse never hits it). Replaced an earlier capped-spring "reactivity nudge" that never
-    reached centre.
+    keyboard browse never hits it).
 - **Two independent axes: viewport WIDTH and INPUT PRECISION** — resolved separately, never
   conflated.
   - **Width** (`resolveBP`, 768px) picks the render profile: card count, grid dims, sphere
@@ -1206,26 +1200,23 @@ through DAA, they share one consent path; there is no gate on one and not the ot
 - **Yaw-only devices render a barrelled CYLINDER, not a sphere** (`cylinderMasonryLayout`). Every
   card's normal is **horizontal**, so obliquity depends only on azimuth — exactly what yaw controls
   — so yaw brings any card face-on at any height. Reads as the sphere's caps unfolded into a wall.
-  Layout is cylindrical **masonry**: fixed columns around the circumference, cards packed down each
-  (replacing a golden-angle helix that clumped and sized unevenly).
+  Layout is cylindrical **masonry**: fixed columns around the circumference, cards packed down each.
   - **Uniform WIDTH fixes alignment; varying HEIGHT is the effect.** Width = column width (columns
     read as true verticals); height follows each image's native aspect (the stagger). Makes
     `SPHERE_AREA_NORM` unnecessary here (0). `CYL_ASPECT_CAP` (1.5) stops one panorama dominating a
     column (cover-crop UVs crop harder; `imgAspect` derives from the *solved* size so the corner SDF
     still matches). `CYL_GAP_RATIO` (0.20) sets both gaps (card width = pitch / (1 + ratio)).
-  - **Packing: shortest column, tallest card first** (longest-processing-time-first) — cuts column
-    imbalance from 1.64× to ~1.05 vs source order. Free to reorder: the layout scatters consecutive
+  - **Packing: shortest column, tallest card first** (longest-processing-time-first) — holds column
+    imbalance at ~1.05 vs 1.64× for source order. Free to reorder: the layout scatters consecutive
     cards, so authored order carries no spatial meaning and modal prev/next walks card *index*. Each
     column's stack is centred about y=0.
   - **Column count is DERIVED** (`CYL_COLS_FIT`, the wall-HEIGHT dial): fewest columns whose tallest
     fits that fraction of frustum height (must scale with count). Default `0.80`; **sm overrides to
-    `0.65`** (`BREAKPOINTS.sm.CYL_COLS_FIT`) to trim height after `SPHERE_R` was pulled in. iPad's md
-    cylinder keeps 0.80.
-  - **Barrel size is the RADIUS.** The wall sizes against the centre-plane frustum, but viewers see
-    the FRONT cards at the near radius, magnified `CAM_Z_SPHERE / (CAM_Z_SPHERE − SPHERE_R)`. On a
-    narrow phone the sm barrel clipped the screen edges, so **sm `SPHERE_R` was reduced 20 → 16**
-    (radius is the width lever; 1.4×→1.30× near magnification), paired with the `CYL_COLS_FIT` 0.65
-    for height. md unchanged.
+    `0.65`** (`BREAKPOINTS.sm.CYL_COLS_FIT`). iPad's md cylinder keeps 0.80.
+  - **Barrel size is the RADIUS** — the width lever. The wall sizes against the centre-plane frustum,
+    but viewers see the FRONT cards at the near radius, magnified
+    `CAM_Z_SPHERE / (CAM_Z_SPHERE − SPHERE_R)`. sm runs `SPHERE_R` 16 (1.30× near magnification) so
+    the barrel clears a narrow phone's screen edges, paired with `CYL_COLS_FIT` 0.65 for height.
   - **`CYL_BULGE` (0.12) barrels the wall** — `r = R·(1 − bulge·t²)`, `t = 2y/wallH` — so the
     silhouette curves like a globe while every column keeps a constant azimuth (still projects to a
     vertical line; only radial displacement). Costs ~9° normal tilt on sm / ~14° on md. **Don't push
@@ -1243,14 +1234,14 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     it to the fade keeps the flip aligned. `maxRadial` is radial (rotation-invariant); `sphereGroup.
     scale` (RM shrink) folded in; capped at `CAM_Z_SPHERE × DRAG_FLIP_MAX_CAM_FRAC` (0.95) so it
     can't fire at zoom start; gated on `zoomT > 0`.
-  - **No roll jitter here** (columns lining up *is* the effect). **`CARD_FACE_CAMERA` is `0.10`** —
-    it shipped at `0.35`; on a barrel it buys limb legibility at the cost of the curve (below).
-  - **Why not a chopped masonry globe** (rejected): meridian columns on a sphere project to curves,
-    so in-column alignment breaks; a 0.7 band holds only ~2 cards/column and returns latitude
-    obliquity. Masonry needs a developable surface — a cylinder is one, a sphere isn't.
-- **Density + facing pass** (full-sphere path; fixes the "edgy / unevenly distributed" read).
-  Adding cards fixes none of it — nearest-neighbour spacing is already even at N=24 and worsens with
-  more cards (foreshortening variance). Four independent levers:
+  - **No roll jitter here** (columns lining up *is* the effect). **`CARD_FACE_CAMERA` is `0.10`** — on
+    a barrel it buys limb legibility at the cost of the curve (below).
+  - **Not a masonry sphere:** masonry needs a developable surface. Meridian columns on a sphere
+    project to curves, so in-column alignment breaks, and a 0.7 band holds only ~2 cards/column while
+    reintroducing latitude obliquity.
+- **Density + facing pass** (full-sphere path; fixes the "edgy / unevenly distributed" read). Adding
+  cards doesn't help — nearest-neighbour spacing is already even at N=24 and worsens with more cards
+  (foreshortening variance). Four independent levers:
   - **Edge-on slivers → `CARD_FACE_CAMERA` (`0.10` cylinder / `0` full sphere).** A
     radial card's obliquity equals its angular distance from front-centre, so limb cards render as
     lines. `applyCardFacing` turns each card partway toward the camera (slivers 5→0, worst obliquity
@@ -1262,53 +1253,40 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     past ~0.35 eats the limb correction. Applied at **three** sites that must agree or the card
     snaps: `placeSphereCard`, `snapCardToSphereSlot`, and `placeFoldingCard` (scaled by `fdE` so it
     eases in over the fold, continuous with the sphere branch).
-  - **Why the barrel runs `0.10`, not `0.35`.** The full-sphere path is `0`, so this only ever runs
-    on the cylinder — where it fights the geometry as much as it helps. At `0.35` it read as "cards
-    pop up when they face the camera, and spin on their own past a certain angle." Both symptoms are
-    this one dial. Measured on the sm barrel (`R` 16, `CAM_Z` 70, `CYL_BULGE` 0.18):
-    - **It un-seats cards from the bulge** (the "pop"). The tilt is a full 3D re-aim, so it also
-      cancels part of each card's *vertical* slope — the slope `cylinderMasonryLayout` computes
-      precisely so cards sit flush. The cancellation scales with card height, so a front column's
-      pitch error runs `0°` at mid-height → **`−4.33°` at top/bottom row at `0.35`** (`−1.24°` at
-      `0.10`). The column stops being a curve and reads as hinged slats.
-    - **It unwinds far faster than it winds up** (the "self-rotation"). From 0→75° of azimuth the
-      tilt grows at a constant `+0.35°` per degree of spin — locked to the rotation, so invisible.
-      Past 75.5° (`|n.z|` enters the band) it reverses and peaks at **`−2.84°`/° at `0.35`**
-      (`−0.81°`/° at `0.10`), dumping the accumulated tilt in ~14.5° of spin. C1, so no literal
-      jump, but it reads as cards spinning on their own near the limb. It also pushes the edge-on
-      crossing out from `acos(R/CAM_Z)` = 77.0° (82.0° at `0.10`, 85.3° at `0.35`) and steepens it,
-      so cards hold more than their true width to the limb, then pinch to a line and flip to their
-      back face.
-    - **Tuning table** (maxSnap °/° · front pitch error · limb width vs a true barrel). Both costs
-      scale linearly with the dial; only the snap responds to the band:
+  - **Why the barrel runs `0.10`.** The full-sphere path is `0`, so this dial only ever runs on the
+    cylinder, where it fights the geometry as much as it helps. Raising it produces two coupled
+    symptoms — cards "popping up" as they face the camera, and appearing to spin on their own near the
+    limb. Both come from this one dial: the tilt is a full 3D re-aim, so it partly cancels each card's
+    *vertical* slope (the one `cylinderMasonryLayout` computes so cards sit flush on the bulge), and
+    it unwinds much faster than it winds up once `|n.z|` enters the edge-on band. Measured on the sm
+    barrel (`R` 16, `CAM_Z` 70) — both costs scale linearly with the dial; only the snap responds to
+    the band:
 
-      | `CARD_FACE_CAMERA` / `FACING_EDGE_ON_BAND` | maxSnap | pitch err | limb width |
-      | --- | --- | --- | --- |
-      | `0` (true barrel) | `0.00` | `0°` | `1.00×` |
-      | **`.10` / `.25` — shipped** | `0.81` | `−1.24°` | `1.33×` |
-      | `.10` / `.45` | `0.40` | `−1.24°` | `1.33×` |
-      | `.20` / `.45` | `0.80` | `−2.47°` | `1.64×` |
-      | `.35` / `.25` — was shipped | `2.84` | `−4.33°` | `2.07×` |
+    | `CARD_FACE_CAMERA` / `FACING_EDGE_ON_BAND` | maxSnap °/° | front pitch err | limb width |
+    | --- | --- | --- | --- |
+    | `0` (true barrel) | `0.00` | `0°` | `1.00×` |
+    | **`.10` / `.25` — shipped** | `0.81` | `−1.24°` | `1.33×` |
+    | `.10` / `.45` | `0.40` | `−1.24°` | `1.33×` |
+    | `.20` / `.45` | `0.80` | `−2.47°` | `1.64×` |
+    | `.35` / `.25` | `2.84` | `−4.33°` | `2.07×` |
 
-      Widening the band is close to free: it buys back snap without touching limb width (the pitch
-      error is set by the dial alone). `FACING_EDGE_ON_BAND` is safe to retune — no sphere path
-      reads it. If the pop ever needs to go to zero while keeping limb width, make the re-aim
-      **yaw-only** on this path (project `cardNormal` into XZ before `setFromUnitVectors`): the
-      geometry is yaw-only anyway, and it zeroes the pitch error outright at any dial value.
+    Widening the band is close to free — it buys back snap without touching limb width, since the
+    pitch error is set by the dial alone — and `FACING_EDGE_ON_BAND` is safe to retune because no
+    sphere path reads it. To zero the pop while keeping limb width, make the re-aim **yaw-only** here
+    (project `cardNormal` into XZ before `setFromUnitVectors`); the geometry is yaw-only anyway.
   - **Uneven card SIZE → `SPHERE_AREA_NORM` (`0.5` yaw-only / `0` else).** Native-aspect sizing
     (height `CARD_H_SPHERE`, width `sphereScaleX`) makes a 16:9 image 2.67× the area of a 2:3 one, so
     wide cards blot out neighbours. Scaling *both* axes by `sphereScaleX^-norm` equalizes area at
     `norm=0.5` (area ∝ ssx·ssx⁻¹ = 1) with the aspect — and the image — undistorted (spread
     2.67×→1.00×). Baked into `card.sphereScaleSX/SY` at build (raw `sphereScaleX` kept for arc/grid/
     modal); applied at the same three sites **plus** `modal.js`'s close target (needs
-    `applySphereFacing` injected, else it jumps when `snapToSphereSlot` runs). `norm=0` reproduces
-    the old scaling exactly (precise-pointer untouched); uniform scale preserves `uAspect` so corners
-    stay circular.
-  - **Sparseness → `CARD_H_SPHERE` 6.0 → 11.0 on sm** (sphere path only). 24 cards at 6.0 covered
-    only 12.4% of the sphere face. Coverage scales with **H²**, so size is a far stronger lever than
-    count and adds no textures/draw calls. Nominal height before `SPHERE_AREA_NORM`; net ~42%.
-  - **Scatter → `CARD_ROLL_JITTER` (sm `0.18` ≈ ±5°, md `0.5` ≈ ±14°).** Per-BP now; at sm's
-    sparsity the old fixed ±14° read as debris. md keeps the collage character.
+    `applySphereFacing` injected, else it jumps when `snapToSphereSlot` runs). `norm=0` is the
+    unscaled case; uniform scale preserves `uAspect` so corners stay circular.
+  - **Sparseness → `CARD_H_SPHERE` `11.0` on sm** (sphere path only). Coverage scales with **H²**, so
+    size is a far stronger lever than count and adds no textures/draw calls. Nominal height before
+    `SPHERE_AREA_NORM`; net ~42% of the sphere face.
+  - **Scatter → `CARD_ROLL_JITTER` (sm `0.18` ≈ ±5°, md `0.5` ≈ ±14°).** Per-BP: at sm's sparsity
+    ±14° reads as debris, while md keeps the collage character.
 - **Touch gesture arbitration — yaw-only, via a directional axis lock** (`interaction.js`). On
   touch a vertical drag *is* the page-scroll gesture, so touch gets **yaw only** (horizontal spins,
   vertical scrolls); pitch (`drag.velY`) is written only when `!isTouchDrag && !getYawOnly()` — i.e.
@@ -1338,7 +1316,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
 The module-scope constants are the core's tuning surface, split by kind: **scroll timing** (phase
 constants, entry ramp, and every threshold) lives in `src/timeline.js` — see Lifecycle timeline —
 and the **visual/physics** constants below stay in `globe-gallery.js`. The ones whose *value* isn't
-self-explanatory (and whose rationale used to live in long inline comments):
+self-explanatory:
 
 | Constant(s) | Value | Role |
 | --- | --- | --- |
@@ -1363,7 +1341,7 @@ self-explanatory (and whose rationale used to live in long inline comments):
 ### `timeline.js` constants
 
 Most of this file's exports are documented where they matter: the `P_*` phase constants and
-`FOLD_PEEL_OVERLAP` under Behavior notes → Phase constants; `FORMATION_SCROLL_VH` /
+`FOLD_PEEL_OVERLAP` under Phase constants; `CSS_FALLBACK` /
 `PQ_APPEAR_LEAD` under Scroll model; `ENTRY_LEAD_VH` / `ENTRY_RAMP_VH` under Entry timing; and
 every gate threshold in the Lifecycle timeline event table. The remainder — carried in code as
 bare names — are:
@@ -1380,11 +1358,6 @@ bare names — are:
 | `GRID_PEEL_WINDOW` | `0.8` | `gridFormT` | `1 − GRID_PEEL_STAGGER`; the span each card's peel occupies after its stagger delay (`frame.gpWin`) |
 | `GRID_ARC_RANGE` / `FOLD_WINDOW` | `0.30` / `0.283` | — | derived spans: the grid-peel arc range, and `SPHERE_FORMED_PROGRESS − FOLD_FIRST_PROGRESS` |
 | `progressAtFormT` / `progressAtZoomT` | — | — | helpers mapping a `sphereFormT` / `zoomT` back to progress. For docs and tests — not called per frame |
-
-Constants whose rationale is covered in the sections above (and so kept terse in code): the phase
-timeline + `FOLD_PEEL_OVERLAP`, `ENTRY_*` (all now in `timeline.js`), the `CYL_*` / `SPHERE_AREA_NORM` / `CARD_FACE_CAMERA`
-shape knobs, the near-fade + `dragFlipZ` constants, and the keyboard/modal centring frames + pitch
-caps (all under Behavior notes / Card count).
 
 ## Open items / backlog
 
@@ -1416,5 +1389,5 @@ Known follow-ups, not blocking this integration branch:
   - **B — keep the top/bottom spread look.** Retain a defined height (`min-height` instead of a hard
     `height`) so the quote/attribution stay spread; tolerates overflow better than today but partly
     keeps the rigidity. Only if the spread is a deliberate editorial layout worth preserving.
-  - Decision needed from design: grouped (A) vs spread (B). See Scroll model → runway / progress model
-    for how `--gg-pq-height` feeds the hold.
+  - Decision needed from design: grouped (A) vs spread (B). See **Scroll model** for how
+    `--gg-pq-height` feeds the hold.

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -66,7 +66,7 @@ through each image (centring it on the globe) rather than exposing a flat per-ca
 | `modal.js` | `createGlobeModal(deps)` → `{ setup, resize, render, updateAnimation, updateDesktopNav, open, navigate, close, getModalIdx, isCardManaged, destroy }`. The card-detail modal: own WebGL canvas/scene, the `MODAL_PHASE` state machine, SDF material swap, cross-warp nav, touch swipe/pull gestures, chrome layout in a native `<dialog>`. Owns all modal tuning constants. `getCount()` is the FULL authored count (see Card count). Sphere coupling is narrow + injected. |
 | `math.js` | Pure stateless helpers. **Easings:** `easeOutCubic`, `easeInOutCubic`, `easeOutSine`, `lerpN`. **Arc-phase geometry:** `arcRotationEase`, `buildArcCtx`, `getFanData`, `cssToWorld`, `rotateArcPoint`, `arcCamZ` — the fanned-arc layout + CSS↔WebGL bridge. The last three take an optional `out` and **write into it** (the core passes reused scratch objects), so per-frame placement produces no garbage. |
 | `timeline.js` | **The scroll timeline** — the single place to change **when** something happens. Every phase constant and threshold, plus `createFrame` / `createFrameInput` / `deriveFrame(frame, input)`, the pure derivation of all six clocks, and `cardFoldStartProgress(gpDelay)` (the per-card fold gate; `FOLD_FIRST_PROGRESS` is its `gpDelay = 0` case). No THREE, no DOM, no closure state, so it's unit-testable in isolation. `deriveFrame` writes into a caller-owned frame, allocates nothing, and clamps NaN-safely — one NaN would poison every mesh position. Imported as a namespace (`import * as TL`). See Lifecycle timeline. |
-| `interaction.js` | `createInteraction(deps)` → `{ setup, teardown }`. Canvas pointer plumbing: drag-to-spin, click-vs-drag, raycast hover + click→modal. Shares drag velocity by reference via the `drag` object. Owns the **touch axis lock** and exports `isPageScrollGesture()` (see Behavior notes). Cedes its hover cursor to the custom cursor via `isCursorActive()`. |
+| `interaction.js` | `createInteraction(deps)` → `{ setup, teardown, isPageScrollGesture }`. Canvas pointer plumbing: drag-to-spin, click-vs-drag, raycast hover + click→modal. Shares travel + velocity by reference via the `drag` object (see **Drag physics**). Owns the **touch axis lock** and exports `isPageScrollGesture()` (see Behavior notes). Cedes its hover cursor to the custom cursor via `isCursorActive()`. |
 | `cursor.js` | `createCursor(deps)` → `{ setup, update, teardown, isActive }`. The desktop custom cursor (see Behavior notes): two body-level layers (`mix-blend-mode` disc + fixed chevron/label container), per-frame state from injected getters, the two-step retirement, `isActive()` gating interaction's cursor. No-op on touch. |
 | `globe-gallery.css` | Globe-only CSS. Also defines `.globe-gallery`-scoped type-scale tokens (see Behavior notes). |
 | `three-src.js` | Build entry — re-exports only the Three.js symbols the block uses. |
@@ -99,12 +99,13 @@ Who writes what:
 
 | | fields |
 | --- | --- |
-| `frameInput` ← the runtime, each tick | `scrollY`, `reducedMotion`, `blockDocTop`, `blockHeight`, `formPx` (= `formedScrollPx()`), `viewportH`, `arcScale` (= `CARD_W_ARC / CARD_W_SPHERE`), plus `prevLenisY` — the **only** inter-frame scroll state, carried back from `frame.lenisY` after each derive (and re-baselined in `startTicker`, so a resume after an off-screen scroll doesn't spike `scrollVel`) |
-| `frame` ← `deriveFrame` | `lenisY`, `scrollingDown`, `scrollVel`, the six clocks (`progress`, `arcCopyEntryT`, `arcPanT`, `gridFormT`, `sphereFormT`, `zoomT`), `gpWin`, and the arc-branch entry transforms `entryRot` / `entryYOffset` / `arcScale` |
+| `frameInput` ← the runtime, each tick | `scrollY`, `reducedMotion`, `blockDocTop`, `blockHeight`, `formPx` (= `formedScrollPx()`), `viewportH`, `arcScale` (= `CARD_W_ARC / CARD_W_SPHERE`), `now` (= `performance.now()`), plus `prevLenisY` / `prevNow` — the **only** inter-frame state, carried back after each derive (both re-baselined in `startTicker`, so a resume after an off-screen scroll doesn't spike `scrollVel` or charge the parked interval to `dtScale`) |
+| `frame` ← `deriveFrame` | `lenisY`, `scrollingDown`, `scrollVel`, `dtScale` (real frame time ÷ 16.67ms, clamped `[0.25, 3]`), the six clocks (`progress`, `arcCopyEntryT`, `arcPanT`, `gridFormT`, `sphereFormT`, `zoomT`), `gpWin`, and the arc-branch entry transforms `entryRot` / `entryYOffset` / `arcScale` |
 | `frame` ← the producer stages | `activeCamera` (`updateActiveCamera`), `sphereRotActive` (`updateSphereRotation`), `sphGroupZ` (`updateSphereGroupDepth`), `foldSphDist` (same) — declared in `createFrame` so the object's shape stays monomorphic |
 
 **Grouped closure state.** Related mutable state lives in small plain objects rather than loose
-`let`s: `drag` (`isDragging`/`velX`/`velY`, shared by reference with `interaction.js`),
+`let`s: `drag` (`isDragging`/`velX`/`velY`/`pendingX`/`pendingY`, shared by reference with
+`interaction.js` — see Drag physics),
 `masonryMorph` (`active`/`t`), `sphereOrient` (`x` pitch / `y` yaw / `z` roll — see Sphere rotation),
 `navNudge` (`active`, `target{X,Y,Z}` destination pose, `start{X,Y,Z}` pose when armed,
 `frame`/`frames` elapsed/total from `KEY_BROWSE_FRAMES` or `KEY_MODAL_FRAMES`; `targetZ` is roll, set
@@ -849,7 +850,7 @@ The `--reduced` overrides are grouped at the **end of `globe-gallery.css`** (`no
 **Breakpoints** resolve once in `init()`: two render profiles split at 768px — `md` (≥768, all
 cards, 9×5 grid, large sphere; covers Milo md *and* lg) and `sm` (<768, first 24, 3×8, smaller
 sphere). Per-profile knobs in `BREAKPOINTS`: `N_MAX` (0=uncapped), `ARC_SPAN`, `SPHERE_R`, `CARD_*`,
-`CAM_Z_*`, `GRID_COLS/ROWS`, `CARD_ROLL_JITTER`, `ARC_DENSE_FRACTION`, plus precise-pointer defaults
+`CAM_Z_*`, `GRID_COLS/ROWS`, `CARD_ROLL_JITTER`, `ARC_DENSE_FRACTION`, `DRAG_GEARING`, plus precise-pointer defaults
 for the shape keys (`CARD_FACE_CAMERA`) that `YAW_ONLY_GEOMETRY` overrides. No
 md↔lg split — they render identically (code branches only on `'sm'`). Crossing 768px changes the
 card count, so `doLayout` triggers a full `destroy()`+`init()` rebuild; resizing within a band takes
@@ -881,7 +882,7 @@ rebuild would otherwise inherit:
   stuck open (its mesh dropped with the old `modalScene`, `modalIdx` reset to -1 so chrome buttons
   are dead, scroll lock stuck). An open modal closes cleanly on crossing; it doesn't re-open.
 - `destroy()` **resets the sphere orientation + drag/nudge state** (`sphereOrient.x/y/z`,
-  `sphereOrient.pitchReleaseCap`, `sphereDragWarp`, `drag.velX/velY`, `navNudge.*`, `wasBrowsing`) to the upright
+  `sphereOrient.pitchReleaseCap`, `sphereDragWarp`, `drag.velX/velY/pendingX/pendingY`, `navNudge.*`, `wasBrowsing`) to the upright
   pose — else pitch/yaw dragged before a device change carried into the rebuilt barrel and rendered
   it tilted until a scroll-out zeroed it.
 
@@ -1400,6 +1401,53 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     face.
   - **Scatter → `CARD_ROLL_JITTER` (sm `0.18` ≈ ±5°, md `0.5` ≈ ±14°).** Per-BP: at sm's sparsity
     ±14° reads as debris, while md keeps the collage character.
+- **Drag physics — position-driven while held, velocity-driven once released.** The two halves of a
+  drag want different inputs, so the shared `drag` object carries both and `updateSphereRotation`
+  picks one per frame:
+  - **`pendingX`/`pendingY` — exact unapplied travel (rad).** `interaction.js` *accumulates* every
+    `pointermove` delta into it; the core **drains it every frame** (unconditionally, even while
+    frozen, so it can't pool and dump on resume) and, while `isDragging`, adds it straight to
+    `sphereOrient`. The surface therefore tracks the pointer **1:1 with no smoothing lag**, and no
+    travel is lost when several moves land in one frame.
+  - **`velX`/`velY` — an EMA of pointer speed (`VEL_SMOOTH_MS` 35ms), in rad per 60fps frame.** This
+    is the **release inertia**, and also every drag-driven CA/warp amplitude (normalized by
+    `MAX_VEL`). It's sampled **by elapsed time, not per event** (`flushVel`): the old code assigned
+    `velX` from the *last event's* pixel delta, which made the release velocity a function of the
+    pointer's event rate — the same 0.25 px/ms drag released at 0.020 rad/frame from a 60Hz mouse
+    but 0.00125 from a 1000Hz one (measured), and Chrome coalescing moves to rAF while Safari
+    doesn't is why the momentum felt inconsistent across browsers. Moves sharing a millisecond bank
+    into `sampX`/`sampY` rather than dividing by a zero dt.
+  - **The idle gap before release is part of the measurement.** `endGesture` flushes the EMA one
+    last time with nothing banked, so *slowing to a stop before lifting* decays the inertia toward
+    0 (150ms ≈ e⁻⁴·³) instead of flinging on a stale sample — and *the sample being stale in the
+    other direction* (a still hold, no move event, so the old `velX` kept its pre-pause value) can't
+    fling either. Both were the "sometimes it stops dead / sometimes it lurches" bug.
+  - **Everything per-frame is rescaled by `frame.dtScale`** (`DRAG_FRICTION ** dtScale`, and
+    velocity/ambient-spin integrated as `v * dtScale`). Unscaled, `0.94`/frame coasts for ~270ms at
+    60Hz but ~135ms on a 120Hz display — the same code, half the feel.
+  - **Ambient spin is a separate additive term, not a bias folded into `velX`.** Added into the
+    velocity (as it used to be) it *brakes* a leftward coast while extending a rightward one, so
+    inertia decayed asymmetrically by drag direction. Note the unit change that came with it:
+    accumulating an increment against friction amplified it by `1 / (1 − DRAG_FRICTION)` = 16.67×,
+    so `AUTO_ROT_SPEED` is now the honest rate (`0.0005` ≈ 1.7°/s; the old loop settled at 2.6°/s) —
+    keep the old `0.000045` and the globe barely drifts.
+  - **Gearing is derived, not a baked rad/px** (`dragSensitivity()`, injected as
+    `getDragSensitivity` and re-read per move). True 1:1 surface tracking is **90° per on-screen
+    ball radius** (`SPHERE_R × H / CYL_FRUSTUM_H` px), and `bp.DRAG_GEARING` is a fraction of that:
+    **md `0.6`** (≈54° per radius-drag), **sm `0.53`** (the barrel is only ~167px wide on a phone,
+    so 1:1 would whip it >180° per swipe — 0.53 also reproduces the old fixed `0.005` rad/px to
+    within 0.3%). Deriving it keeps the feel constant across window sizes: a bigger ball on screen
+    needs *fewer* rad/px, which one fixed number got wrong in both directions (the old `0.005` was
+    1.34× over-geared on a 900px-tall desktop and 0.53× under on a phone).
+  - **Inertia coasts below `SPHERE_INTERACTIVE_T`; only `SPHERE_ORIENT_RESET_T` zeroes it.**
+    Hard-zeroing at the interactive gate stopped a released spin dead whenever the page was still
+    settling across it. A drag *started* below the gate stays inert and can't fling on release, and
+    `stopTicker` retires inertia outright (it can't coast while the loop is parked).
+  - **Gesture ownership is `activePointerId`, not `hasPointerCapture()`.** The tap test no longer
+    depends on *when* the browser releases capture relative to `pointerup`. `pointercancel` →
+    `cancelDrag` (no inertia, no tap — routed to `onPointerUp` it let a cancelled press pass the tap
+    test and open a card); `lostpointercapture` → `endGesture`, a no-op after a normal release and a
+    clean exit on a genuine loss (rather than leaving `isDragging` latched true forever).
 - **Touch gesture arbitration — yaw-only, via a directional axis lock** (`interaction.js`). On
   touch a vertical drag *is* the page-scroll gesture, so touch gets **yaw only** (horizontal spins,
   vertical scrolls); pitch (`drag.velY`) is written only when `!isTouchDrag && !getYawOnly()` — i.e.
@@ -1433,9 +1481,11 @@ self-explanatory:
 
 | Constant(s) | Value | Role |
 | --- | --- | --- |
-| `DRAG_FRICTION` | `0.94` | per-frame velocity decay after a drag release (spin coastdown) |
+| `DRAG_FRICTION` | `0.94` | velocity decay per 60fps frame after a drag release (spin coastdown); applied as `** dtScale` — see Drag physics |
 | `MAX_VEL` | `0.06` | drag-velocity clamp; the core normalizes speed by it (shared with `interaction.js`) |
-| `AUTO_ROT_SPEED` | `0.000045` | idle yaw drift per frame when not dragging / browsing |
+| `AUTO_ROT_SPEED` | `0.0005` | ambient yaw drift per 60fps frame (≈1.7°/s) when not dragging / browsing — added alongside `velX`, never into it |
+| `DRAG_GEARING` (per band) | md `0.6` / sm `0.53` | pointer→rotation gearing as a fraction of true 1:1 surface tracking; `dragSensitivity()` turns it into rad/px off the live viewport |
+| `VEL_SMOOTH_MS` (`interaction.js`) | `35` | time constant of the release-velocity EMA |
 | `HOVER_RATE` | `0.15` | per-frame lerp toward the hover target (~125ms to 80%) |
 | `CA_STRENGTH` | `0.012` | radial UV shift per channel at transition peaks (Option B bell curve) |
 | `CA_MOTION_STRENGTH` / `…_ARC` | `1.0` / `0.04` | directional (motion-trail) UV-shift max — full during peel/fold/sphere/modal, softly clamped on the arc |
@@ -1469,7 +1519,8 @@ bare names — are:
 | `ENTRY_ROT_MAX` | `0.9` | radians | arc sweep-in rotation at `arcCopyEntryT` = 0; `entryRot` decays from it, and `updateCardTransform` divides by it to renormalize for the per-card entry CA |
 | `ENTRY_SLIDE_H_FRAC` | `0.30` | fraction of `H` | `entryYOffset` at slide 0 — how far below its arc position a card starts |
 | `ARC_COPY_IN_ENTRY_T` | `0.336` | `arcCopyEntryT` | arc-copy fade-**in** completes here (the fade-out is a fold-window fraction — see Arc-copy fade-out) |
-| `SPHERE_ORIENT_RESET_T` | `0.01` | `sphereFormT` | below this a scroll-out resets the sphere orientation (a brief dip mid-scroll keeps it) |
+| `SPHERE_ORIENT_RESET_T` | `0.01` | `sphereFormT` | below this a scroll-out resets the sphere orientation **and drag inertia** (a brief dip mid-scroll keeps both) |
+| `FRAME_MS` / `DT_SCALE_MIN` / `_MAX` | `16.67` / `0.25` / `3` | ms, ratio | the frame every per-frame rate is authored against, and the clamp on `frame.dtScale` — a stall must not teleport what it drives, a >240Hz frame must not underflow a decay (see Drag physics) |
 | `TEXT_ZOOM_FADE_RATE` | `3` | `zoomT` | hint text is fully faded at `zoomT` = 1/rate |
 | `GRID_PEEL_WINDOW` | `0.8` | `gridFormT` | `1 − GRID_PEEL_STAGGER`; the span each card's peel occupies after its stagger delay (`frame.gpWin`) |
 | `GRID_ARC_RANGE` / `FOLD_WINDOW` | `0.30` / `0.283` | — | derived spans: the grid-peel arc range, and `SPHERE_FORMED_PROGRESS − FOLD_FIRST_PROGRESS` |

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -1016,7 +1016,11 @@ on the barrel only, a **rotate ← / hint copy / rotate →** row on the bottom 
   tweens, because a pointer press on a rotate button collapses browse mode (`focusout` → `collapse`)
   in the same event turn it arms its own nudge — without the tag, the next frame would silently eat
   the press and the button would look dead. `dir −1` = the
-  surface travels screen-left, matching a leftward drag.
+  surface travels screen-left, matching a leftward drag — **including inside the barrel**, where the
+  visible wall moves opposite and `rotateStep` negates `dir` exactly as drag negates via `dragDir`.
+  That window is real, not theoretical: `dragFlipZ` is clamped to `[SPHERE_R, 0.95 · CAM_Z_SPHERE]`,
+  so the camera is inside from `zoomT` ≈ 0.09–0.16 at the latest while the controls stay up until
+  `CONTROLS_ZOOM_HIDE_T` = 0.25.
 - **A press eases to the next column BOUNDARY, it does not add a column pitch.** Ambient spin
   leaves the barrel at an arbitrary angle, so `y += 2π/cols` carries that offset forward forever
   — face 1.5 columns, press, face 2.5. Snapping instead means a column lands front-centre from any

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -331,9 +331,47 @@ sets no `N_MAX`, so every authored card is resident there. Watch this on iPad, w
 profile: if it needs trimming, dropping `CARD_TEX_MD` to 640 lands ~97MB, *below* today's figure, and md
 would still be oversampled (~2.8 texels/device px on the largest card).
 
-The **"Click & Drag" hint** (`createClickDragTexture`) is a separate line item: its canvas matches the
-camera aspect, so `TEXT_MAX_SIDE` caps the *longest* side — uncapped, a portrait phone derives
-a 2048×4180 ≈ 45MB canvas, mostly empty. Capped, portrait tops ~1004×2048 (~11MB).
+The **"Click & Drag" hint** (`createClickDragTexture`) is a separate line item, but **only on sphere
+geometry** — the barrel path never builds it (see Behavior notes), which is what removes it from the
+phone budget entirely. Where it is built, its canvas matches the camera aspect, so `TEXT_MAX_SIDE`
+caps the *longest* side: uncapped, a portrait phone derived a 2048×4180 ≈ 45MB canvas, mostly empty.
+Capped, portrait topped ~1004×2048 (~11MB); a 1512-wide desktop lands 2048×1330 (10.9MB).
+
+**Every `CanvasTexture` costs its pixels twice** — once on the GPU, once in the `<canvas>` 2D backing
+store Three keeps referenced as `texture.image`. `releaseCanvasAfterUpload` (`materials.js`) reclaims
+the CPU half by zeroing the canvas from `texture.onUpdate`, which Three fires immediately after
+`texImage2D` + `generateMipmap`. **Only the hint texture meets its preconditions**, and that is the
+only place it is applied — worth a measured **10.39MiB** (2048×1330) on a 1512-wide desktop, the
+third-largest canvas on the page and about double the biggest card. It is a desktop-only win now
+that the barrel skips the hint plane altogether.
+
+Three preconditions, all load-bearing. Check them before applying it anywhere else:
+
+1. **Exactly one `WebGLRenderer` may ever upload it.** Renderers upload independently, so a texture
+   shared across contexts re-uploads from a 0×0 canvas and renders empty.
+2. **Nothing may set `needsUpdate` on it afterwards** — same re-upload trap. A resize is fine: it
+   rebuilds mesh *and* texture from scratch (`doLayout` → `buildTextMesh`).
+3. **Nothing may read `texture.image.width/height` afterwards** — the aspect is gone. `modal.js`'s
+   two reads are guarded and run pre-render, but tooling that probes `.image` goes blind to it.
+
+It also pays off **lazily**: Three uploads a texture only when a visible object using it is drawn,
+so the canvas survives at full size until the hint first renders (verified — 2048×1330 at scroll 0,
+0×0 once formed). A visitor who never scrolls into the globe keeps the whole 10.39MiB. Forcing it
+earlier would mean `renderer.initTexture()` at build time, i.e. eagerly uploading ~13.8MB to the GPU
+for a plane that may never show — a worse trade.
+
+Deliberately **not** applied elsewhere:
+
+- **The base card set** — where the win would actually be (~105MB on md). `getModalMaterial` hands a
+  card's base texture to the *modal* renderer as its fly-out placeholder, so two contexts upload it
+  independently, and freeing the canvas after the first would blank the opening card until its
+  hi-res decode lands. Claiming it needs the modal card drawn by the main renderer (separate today
+  because CSS blurs the main canvas and the modal card must stay sharp above it), or the placeholder
+  decoupled from the base texture. Do **not** "fix" this by calling `releaseCanvasAfterUpload` in
+  `loadCardTextures`.
+- **The modal upgrade** — it would work, but ≤1 is ever resident and it is disposed on close/nav, so
+  the ~11MB is transient; and it blinds `aspect-probe-harness.cjs`, which measures the opened card's
+  aspect distortion through `map.image`. A bad trade for the block's main correctness probe.
 
 `ANTIALIAS_SM`/`ANTIALIAS_MD` toggle MSAA per band (set at renderer creation): on for md (card
 silhouettes alias without it), off for sm to save framebuffer memory (MSAA is the largest GPU cost
@@ -721,7 +759,7 @@ from `globe-gallery.css`; `progress` and the gate columns are runway-independent
 | 37 | 0.039 | `FOLD_FIRST_PROGRESS` | `sphereFormT` leaves 0 → camera switches **ortho → perspective** | `updateActiveCamera` |
 | ~41 | ~0.041 | `arcPanT ≥ PROGRESS_GRID_ARC_START` | arc → grid **peel** begins (staggered by `i` + `ARC_PEEL_JITTER`) | `updateCardTransform` |
 | ~54 | ~0.057 | `gpLocalT ≥ FOLD_START_LOCAL_T` | first card actually starts **folding** to the sphere | `updateCardTransform` |
-| 64 | 0.067 | `sphereFormT > TEXT_APPEAR_START` | "Click & Drag" hint plane un-hides, warps in | `updateClickDragText` |
+| 64 | 0.067 | `sphereFormT > TEXT_APPEAR_START` | "Click & Drag" hint plane un-hides, warps in (**sphere geometry only** — the barrel never builds it) | `updateClickDragText` |
 | 90 | 0.096 | `ARC_COPY_OUT_FORM_START` of the fold window | **arc-copy starts fading out** | `updateArcCopy` |
 | 156 | 0.165 | `arcPanT = PROGRESS_GRID_ARC_END` | last card lands in the grid (`gridFormT` = 1) | `updateCardTransform` |
 | 170 | 0.180 | `sphereFormT > DEPTH_SORT_FORM_T` | `renderer.sortObjects` on (arc needs manual order, sphere needs depth sort) | `tick` |
@@ -1170,7 +1208,19 @@ through DAA, they share one consent path; there is no gate on one and not the ot
 
 ## Behavior notes
 
-- **"Click & Drag" hint text (WebGL).** A `PlaneGeometry` in `sphereGroup` behind the sphere's back
+- **"Click & Drag" hint text (WebGL).** **Sphere geometry only** — `initRuntime` skips
+  `buildTextMesh()` when `bp.CYLINDER`. The plane sits behind *both* walls, and the masonry barrel is
+  near-solid (`CYL_GAP_RATIO` 0.20, columns wrapping 360°), so it is occluded to nothing there:
+  A/B'd against the drawing buffer with an on/on control for the noise floor, the barrel's whole-frame
+  contribution is a mean **≤0.08/255** per channel with <1% of channels past a just-noticeable Δ8,
+  versus **mean 2.5 across 8.6%** of the frame on the sphere. Invisible, but it still cost a
+  viewport-filling transparent quad every frame plus ~17MB (7.4MB canvas + ~9.9MB texture).
+  The gate is on the **geometry, not the pointer**, so a narrow desktop window skips it too — its
+  custom cursor is independent (`textExitProgress` still drives cursor retirement). Nothing needs to
+  add it back on a resize: a band crossing rebuilds the whole runtime (`doLayout`), and `doLayout`'s
+  own rebuild branch is already `if (textMesh)`. Verified across sm-touch / md-fine / md-coarse
+  (iPad → barrel → skipped) / narrow-desktop, and across repeated sm↔md resizes.
+  A `PlaneGeometry` in `sphereGroup` behind the sphere's back
   surface (`z = −(SPHERE_R + TEXT_BEHIND_GAP)`, `renderOrder = -1`), so it rotates with the globe and
   draws behind the cards. Hidden until `sphereFormT > TEXT_APPEAR_START`, then warps in (barrel
   warp + particle dissolve via `TEXT_FRAG`), settles to a faint resting opacity (`TEXT_OPACITY_PEAK

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -575,9 +575,10 @@ doc-only export would ride along in every page's payload; the derivation snippet
 `globe-gallery.css` instead (see **Re-deriving these numbers**). Don't reintroduce one.
 
 sm uses a **bigger** pin factor than md on purpose: its globe clears earlier (`zoomT≈0.30` vs md
-`≈0.42`), so the quote can start sooner *and* hold longer — which sm needs, because the fixed 583px
-quote eats more of the pin on a phone (~73vh at 800px vs ~54vh at 1080). md's factor is capped ~0.55:
-above it the fade-in would cross md's globe-clear and land the quote over the globe.
+`≈0.42`), so the quote can start sooner *and* hold longer — which sm needs, because the quote box fills
+much more of a phone screen (its height is copy-driven, ~490–590px: ~70vh at 800px vs ~54vh at 1080),
+leaving less slack around it. md's factor is capped ~0.55: above it the fade-in would cross md's
+globe-clear and land the quote over the globe.
 
 **Pull-quote timing is derived, not hand-set.** The pin height is `(runway − formation) ×
 --gg-pq-pin-factor`, so it always exits exactly at the runway end (no dead scroll), and the JS fade-in
@@ -592,12 +593,18 @@ a fixed runway); to change both together, move `--gg-runway-height`.
   threshold auto-follows). md is capped ~0.55 (globe-clear); sm can go to ~0.67.
 - *"Click & Drag" cursor lingers too long/short:* `CURSOR_ZOOM_RETIRE_T` — keep it ≥ the md
   camera-clear `zoomT` (≈0.42... it currently fires just before, at camz≈−33, accepted) and, on md,
-  `< pqAppearZoomT` so it retires before the quote. `CURSOR_ZOOM_DISMISS_T` fades the label
-  first. (Cursor is desktop-only, so sm's earlier quote doesn't affect it.)
+  `< pqAppearZoomT` so it retires before the quote. One threshold for both stages on this clock —
+  label and disc go together. (Cursor is desktop-only, so sm's earlier quote doesn't affect it.)
+- *Cursor disc survives too many drags after the label goes:* `CURSOR_DRAG_RETIRE_T` (0.30) vs
+  `CURSOR_DRAG_DISMISS_T` (0.12) — both on drag-accrued `textExitProgress`, so the ratio is how many
+  extra drags the disc outlives the label. `updateHintExitProgress` adds ~0.0022/frame held plus
+  `norm * 0.018` and `norm² * 0.010` per frame of motion, so ~0.12 is a flick and ~0.30 is roughly the
+  same drag continued. Keep `CURSOR_DRAG_RETIRE_T > CURSOR_DRAG_DISMISS_T` or the two steps collapse.
 - *Formation (arc/grid/fold) pacing:* the `P_*` constants below — independent of the runway.
 
-Current result (from the progress math; hold is viewport-dependent since the quote is a fixed 583px):
-md gap ≈91vh / hold ≈65vh; sm gap ≈69vh / hold ≈68vh.
+Current result (from the progress math): md gap ≈91vh; sm gap ≈69vh. The centred hold is the whole pin —
+`(520 − 304) × factor` = **≈119vh md / ≈140vh sm**, independent of viewport and copy length, because the
+0-tall rail (see **CSS → Pull-quote box**) keeps the box's own height out of the sticky clamp.
 
 Milo's page-level Lenis keeps `window.scrollY` in sync; the driver is a plain `requestAnimationFrame`
 loop (`startTicker`/`stopTicker`). The modal pauses Lenis via `window.lenis.stop()/start()` plus a
@@ -770,8 +777,7 @@ from `globe-gallery.css`; `progress` and the gate columns are runway-independent
 | 376 | 0.548 | `zoomT ≥ 1 / TEXT_ZOOM_FADE_RATE` | hint text fully faded | `updateClickDragText` |
 | 369 / 395 | 0.525 / 0.607 | camera passes the cards | globe clears the viewport — sm ≈ `zoomT` 0.30, md ≈ 0.42 | `updateActiveCamera` |
 | 373 / 395 | 0.539 / 0.607 | `zoomT ≥ pqAppearZoomT` | pull-quote fades in — sm 0.32, md 0.42 (from `--gg-pq-pin-factor`) | `updatePullQuote` |
-| 386 | 0.580 | `CURSOR_ZOOM_DISMISS_T` | cursor label fades | `cursor.update` |
-| 390 | 0.593 | `CURSOR_ZOOM_RETIRE_T` | cursor disc retires | `cursor.update` |
+| 390 | 0.593 | `CURSOR_ZOOM_RETIRE_T` | cursor label + disc retire together | `cursor.update` |
 | 509 | 0.966 | `zoomT ≥ 0.95` | canvas `display:none` (quote alone to the end) | `updateCanvasVisibility` |
 | 520 | 1.000 | runway end | pull-quote pin exits | CSS (`--gg-pq-pin-factor`) |
 
@@ -836,7 +842,7 @@ read in JS):
 
 The set is `PROGRESS_PAN_END`, `PROGRESS_ARC_PREROLL`, `PROGRESS_GRID_ARC_START` / `_END`,
 `PROGRESS_FOLD_DUR`, `PROGRESS_ZOOM_END`, `GRID_PEEL_STAGGER` and `FOLD_PEEL_OVERLAP`, plus the
-gates (`SPHERE_INTERACTIVE_T`, `PQ_APPEAR_LEAD`, `CURSOR_ZOOM_DISMISS_T` / `_RETIRE_T`). Dump the
+gates (`SPHERE_INTERACTIVE_T`, `PQ_APPEAR_LEAD`, `CURSOR_ZOOM_RETIRE_T`). Dump the
 live values instead of trusting a list here:
 
 ```sh
@@ -1008,7 +1014,7 @@ an S2A scale uses the token, not the literal — including positional insets (`b
 `inset-inline-start`) and the `p + p` copy rhythm. Sizes tied to a specific design measurement stay
 literal, because pinning them to a coincidentally-equal token would imply a relationship that isn't
 there: the arc-copy `359px`/`382px` widths, the counter pill (`--gg-counter-w`, which the
-md+ nav offsets read), the scrim (`--gg-scrim-w`), `--gg-pq-height`, the 24/28px badge icons, and the
+md+ nav offsets read), the scrim (`--gg-scrim-w`), the 24/28px badge icons, and the
 48px cursor disc. These values are **off every S2A scale** and stay literal on purpose — if any is retuned,
 snapping it to the nearest token is the cheaper fix:
 
@@ -1060,6 +1066,43 @@ there is no JS involved. At sm it pins 8px from the edge and its own `--gg-arc-p
 copy on the inset; at md+ the pill background is gone, so the box is offset back by that padding
 (`calc(var(--gg-content-inset) - var(--gg-arc-pad))`) to put the *copy*, not the box, on the edge.
 
+### Pull-quote box: content-sized, gap-controlled
+
+The quote box has **no height**. It is a column flex container whose only tunable vertical measure is
+`--gg-pq-gap`, the space between the `blockquote` and the name/role `.globe-gallery-pullquote-attribution`;
+everything else (padding + copy) sizes itself.
+
+`--gg-pq-gap` is `--s2a-layout-xl` (160px) at every breakpoint — one declaration, no media query. A
+larger gap runs the box's top edge into the localnav at lg/xl, so re-check that clearance before
+raising it.
+
+**Three nested elements, and the middle one is why.** `.globe-gallery-pullquote-pin` (the sticky
+window) → `.globe-gallery-pullquote-rail` (`position: sticky; top: 50vh; height: 0`) →
+`.globe-gallery-pullquote` (`position: absolute; top: 0; transform: translateY(-50%) …`). The rail
+is a zero-height line stuck to the viewport middle, and the quote hangs centred on it — `-50%` is
+own-height-relative, so no number is needed anywhere.
+
+Do **not** collapse the rail and stick the quote itself. `transform` is paint-only: a
+`top: 50vh; translateY(-50%)` sticky box still *lays out* starting at 50vh, so its layout box hangs
+half its own height below where you see it, and sticky position is clamped to the containing block.
+That box therefore reaches the pin's bottom edge **half a box-height early** and gets dragged upward
+for the rest of the pin (~110px off centre by mid-pin at 1440×900, worse the taller the box). A 0-tall
+rail keeps the clamp height-blind, so the quote holds dead-centre across the whole pin. (A
+`height: 100vh; place-items: center` sticky wrapper also works, but it spends ~100vh of pin to hold a
+~600px box — same fix, shorter hold.)
+
+Consequences worth knowing before retuning:
+
+- **Both `transform` values must carry the `translateY(-50%)`.** Dropping it from `.is-active` would
+  make the quote jump half its height as it fades in. The reduced-motion variant deliberately resets
+  `transform: none` — it is `position: relative` and flows, so it must *not* be shifted (and its rail
+  goes `position: static; height: auto` alongside the pin).
+- **The centred hold is the whole pin**, independent of viewport and copy length, and the quote holds
+  to the runway end and then scrolls away with the block — there is no upward drift-out. Nothing in JS
+  reads the box height, so a copy change is CSS-only, but re-eyeball pacing. See **Scroll model**.
+- No `overflow` handling: a pathologically long quote spills past the viewport rather than scrolling.
+  Adding a scroller here would need `data-lenis-prevent`.
+
 ### Crosshair frame
 
 `--gg-copy-pad` steps **24px → 48px (≥768) → 64px (≥1440)**, and the pull-quote draws a hairline
@@ -1082,7 +1125,9 @@ and borders its block edges, `::after` insets inline and borders its inline edge
 the full box instead of stopping at the corners, so the runs **cross** and read as a crosshair
 rather than a closed rectangle. They are `position: absolute`, which both keeps them out of the
 flex flow (an abspos child of a flex container is not a flex item) and lets them inherit the
-parent's fade and `scale(.9)→1`, so the frame animates in with the quote.
+parent's fade and `translateY(-50%) scale(.9)→1`, so the frame animates in with the quote. The frame
+tracks the content-sized box: `::after` spans `inset-block: 0` (the full height) and `::before` sits
+on the padding edges, so both follow a copy or `--gg-pq-gap` change with no second number to update.
 
 Two constraints worth not re-deriving:
 
@@ -1234,28 +1279,58 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   constant. Sized to fill the frustum at its live camera
   distance (`textPlaneSize` × a per-frame scale off `frame.foldSphDist`), with warp-proportional
   overflow so letterforms bleed off-screen. On **first drag** it dissolves away permanently:
-  `textExitProgress` (0→1, from drag distance + hold time + velocity) drives the shader's `uExitP`;
-  it resets only on scroll-out (`sphereFormT < SPHERE_INTERACTIVE_T`). Owned by its own tick stage
-  (`updateHintExitProgress`, not `updateClickDragText`, which early-returns before the interactive
-  range — the very scroll-out that must reset it — and the cursor reads it too). Shows on all
-  devices. Built async in `buildTextMesh` (waits for `document.fonts.ready` → Adobe Clean), rebuilt
-  on resize, static-and-faint under RM. Copy is hardcoded (see Localization).
+  `textExitProgress` (0→1, from drag distance + hold time + velocity) drives the shader's `uExitP`.
+  Owned by its own tick stage (`updateHintExitProgress`, not `updateClickDragText`, which
+  early-returns below `TEXT_APPEAR_START` and so can't own the re-arm; the cursor reads it too).
+  Built async in `buildTextMesh` (waits for `document.fonts.ready` → Adobe Clean), rebuilt on resize,
+  static-and-faint under RM. Copy is hardcoded (see Localization).
+
+  **`textExitProgress` is a one-way latch.** It only ever climbs, and nothing re-arms it: once a drag
+  has retired the hint it stays retired for the life of the runtime. This matches what both consumers
+  always claimed — "dissolves away permanently" here, "one-way label dismissal" in `cursor.js` — and
+  it is the reason the stage needs no thresholds beyond the interactive gate.
+
+  It used to reset whenever `sphereFormT` fell below `SPHERE_INTERACTIVE_T`, which broke twice over
+  once that gate moved 0.8 → 0.9. The gate is only ~275px of scroll-back on a 982px viewport
+  (~28vh), so a quarter-viewport nudge brought a dismissed hint straight back. And the plane's
+  opacity and warp are pure functions of `sphereFormT`, already settled at the gate (measured
+  `opacity` 0.06, `uWarp` 0.019) — so the reset popped it back **fully formed in a single frame**,
+  while the cursor label faded in over its CSS `opacity 0.5s ease 0.15s`. That asymmetry is what read
+  as broken. Re-arming on a *lower* threshold with an eased bleed also fixes it, but the latch
+  deletes the whole tuning surface instead, so prefer it.
+
+  Caveat: `destroy()` zeroes `textExitProgress`, so a **rebuild** re-arms the hint — a band crossing
+  (sm↔md), a reduced-motion toggle, or WebGL context-loss recovery. That is "until reload" for every
+  practical purpose, and it is deliberate: a rebuild is a new mesh with a fresh entrance. Making it
+  survive a rebuild would mean hoisting state out of the per-instance closure, which breaks the
+  multi-instance scoping for no user-visible gain.
+
+  Consequence of the latch: a **short drag freezes the dissolve mid-way** for the rest of the session
+  (`uExitP` ~0.3–0.5, letterforms partly scattered) where it used to clear on scroll-out. Accepted —
+  at `TEXT_OPACITY_RESTING` 0.06 it is not perceptible, and the whole plane only contributes a mean
+  ~2.5/255 per channel at full strength. If `TEXT_OPACITY_RESTING` is ever raised, revisit: the fix
+  is to let the dissolve run to completion once started rather than tracking the drag.
 - **Desktop custom cursor (`src/cursor.js`).** On `(hover: hover) and (pointer: fine)` only, over the
   interactive sphere with no modal open: the system cursor becomes a 48px `mix-blend-mode: difference`
   disc (inverts what's beneath) flanked by chevrons that squeeze 4px inward while dragging, plus a
   "Click & Drag" label in a **frosted pill** (the modal-chrome glass, so `backdrop-filter` frosts the
   cards behind it). It **retires in two steps** on the same `textExitProgress` signal as the hint
-  text: at `CURSOR_HINT_DISMISS_T` (`getHintDismissed`) the label fades with the text; at the
-  later `CURSOR_RETIRE_T` (`getCursorRetired`) the disc + chevrons fade over `RETIRE_FADE_MS`
+  text: at `CURSOR_DRAG_DISMISS_T` (`getHintDismissed`) the label fades with the text; at the
+  later `CURSOR_DRAG_RETIRE_T` (`getCursorRetired`) the disc + chevrons fade over `RETIRE_FADE_MS`
   (0.42s, mirrored by `--retiring` CSS), then `active` drops, clearing `cursor: none` so the system
-  cursor takes back over. The disc **shrinks** rather than fades (partial opacity under
+  cursor takes back over. Scrolling out short-circuits the staging: past `CURSOR_ZOOM_RETIRE_T` both
+  getters flip together, so label and disc go at once. The disc **shrinks** rather than fades (partial opacity under
   `mix-blend-mode: difference` is a gray wash). Opening a card sets `textExitProgress = 1` (instant
   retire); both steps reset on scroll-out. Two **body-level** DOM layers: the disc **must** be a
   direct `<body>` child (`mix-blend-mode` only reaches page content from outside a `position: fixed`
   container); chevrons + label live in a fixed container. Sets `cursor: none` while active;
   `interaction.js` cedes its hover cursor via `isActive()`. No-op on touch: `(hover: hover) and
   (pointer: fine)` is read **once at setup** (a device that gains a fine pointer mid-session needs a
-  reload, unless a re-init — e.g. an RM toggle — re-reads it). With multiple globes each
+  reload, unless a re-init — e.g. an RM toggle — re-reads it). Activation also requires
+  `state.hasCoords` — a real `mousemove` must have landed first. Scrolling the canvas under a
+  *stationary* pointer fires `mouseenter` on its own (browsers dispatch boundary events for
+  scroll-induced hover changes), so without that gate the cursor plays its entrance at `0,0` (the
+  coord defaults) and then hard-snaps to the pointer on the next move. With multiple globes each
   makes its own pair but only the hovered one activates (inactive discs `visibility: hidden`). Label
   copy is the authored hint string (see Localization).
 - **Modal chrome — edge-anchored nav arrows + counter; desktop adds a screen-edge scrim.**
@@ -1771,20 +1846,7 @@ Known follow-ups, not blocking this integration branch:
 - **Pacing: landing on the pristine formed globe.** On touch, scroll-spin arbitration is correct
   (see Behavior notes → Touch gesture arbitration), but how easily a user *comes to rest* exactly on
   the fully-formed, still globe is a scroll-pacing tuning matter still open.
-- **Pull-quote uses a hardcoded `--gg-pq-height`.** It's a shortcut (enables `top: calc(50vh -
-  h/2)` centering + a predictable hold = `pin − h`), but it's brittle to copy length — longer/localized
-  strings overflow the fixed box (no `overflow` handling), shorter copy leaves a dead gap under
-  `justify-content: space-between`. Make it copy-flexible (revisit in a future session). Two options:
-  - **A (recommended) — content-sized, transform-centered.** `position: sticky; top: 50vh;
-    transform: translateY(-50%) scale(…)` (the `-50%` is own-height-relative, so no fixed height);
-    drop `height` + `justify-content: space-between` for a `gap`; add `max-height: 90vh; overflow`
-    for pathologically long quotes. Keeps the "small quote → longer hold, no runway penalty" property;
-    the attribution sits directly under the quote (grouped, not spread). Retune `PQ_APPEAR_LEAD` — the
-    stick/centre point shifts by ~½ the quote height — and re-verify pacing. (A "100vh sticky wrapper +
-    `place-items:center`" variant is bulletproof but costs ~+100vh of runway for the same hold, so it's
-    not preferred.)
-  - **B — keep the top/bottom spread look.** Retain a defined height (`min-height` instead of a hard
-    `height`) so the quote/attribution stay spread; tolerates overflow better than today but partly
-    keeps the rigidity. Only if the spread is a deliberate editorial layout worth preserving.
-  - Decision needed from design: grouped (A) vs spread (B). See **Scroll model** for how
-    `--gg-pq-height` feeds the hold.
+- **Pull-quote pacing and overflow.** The quote is content-sized and holds centred for the whole pin
+  (see **CSS → Pull-quote box**), so `PQ_APPEAR_LEAD` / `--gg-pq-pin-factor` want an eyeball pass per
+  breakpoint against the final copy, and there is no `overflow` handling for a pathologically long or
+  localized quote (it spills rather than scrolls).

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -7,10 +7,9 @@
 
 /* Scroll model (see README). .globe-gallery-reduced and .globe-gallery-empty overrides are at the end of this file. */
 .globe-gallery {
-  /* Full scroll-runway model: README. */
-  --gg-runway-height: 520vh;
+  /* Full scroll-runway model: README. --gg-pq-appear-t is published by the JS, off the camera. */
+  --gg-runway-height: 460vh;
   --gg-formation-vh: 304vh;
-  --gg-pq-pin-factor: 0.65;
 
   /* Shared copy edge: the pull-quote's own left text edge, reused by the arc copy. See README. */
   --gg-copy-max: 1920px;
@@ -206,13 +205,16 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   margin: 0;
 }
 
-/* Absolute at runway bottom; sticky quote inside reveals/holds/exits without JS. */
+/* Ends 50vh past the camera-clear point, so the sticky rail inside lets go on the frame the quote
+   fades in: revealed dead-centre, then free to scroll. Nothing is held. See README. */
 .globe-gallery-pullquote-pin {
   position: absolute;
-  bottom: 0;
+  top: var(--gg-formation-vh);
+  bottom: max(0px, calc(
+    (1 - var(--gg-pq-appear-t, 0.42)) * (var(--gg-runway-height) - var(--gg-formation-vh)) - 50vh
+  ));
   left: 0;
   right: 0;
-  height: max(1px, calc((var(--gg-runway-height) - var(--gg-formation-vh)) * var(--gg-pq-pin-factor)));
   pointer-events: none;
 }
 
@@ -244,7 +246,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   opacity: 0;
   pointer-events: none;
   transform: translateY(-50%) scale(0.9);
-  transition: opacity 0.7s ease, transform 0.7s ease;
+  transition: opacity 0.45s ease, transform 0.45s ease;
 }
 
 .globe-gallery-pullquote.is-active {
@@ -695,9 +697,6 @@ body.globe-gallery-modal-open { overflow: hidden; }
 }
 
 @media (min-width: 768px) {
-  /* Smaller quote-pin factor at md; see README. */
-  .globe-gallery { --gg-pq-pin-factor: 0.55; }
-
   .globe-gallery-modal-chrome {
     --gg-modal-edge: var(--s2a-spacing-lg);
     --gg-counter-w: 138px;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -16,6 +16,7 @@
   --gg-copy-max: 1920px;
   --gg-copy-pad: var(--s2a-spacing-lg);
   --gg-content-inset: calc(max(0px, 100vw - var(--gg-copy-max)) / 2 + var(--gg-copy-pad));
+  --gg-crosshair-width: 1px;
 
   height: var(--gg-runway-height);
   position: relative;
@@ -31,6 +32,14 @@
     height: auto;
     min-height: 0;
   }
+}
+
+@media (width >= 768px) {
+  .globe-gallery { --gg-copy-pad: var(--s2a-spacing-3xl); }
+}
+
+@media (width >= 1440px) {
+  .globe-gallery { --gg-copy-pad: var(--s2a-spacing-4xl); }
 }
 
 /* z-index bands: hero 2–5, modal 13–17. See README. */
@@ -105,6 +114,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 /* Starts hidden; JS adds .is-active once the zoom-in threshold passes. */
 .globe-gallery-pullquote {
   --gg-pq-height: 583px;
+  --gg-pq-pad-block: var(--gg-copy-pad);
 
   position: sticky;
   top: calc(50vh - var(--gg-pq-height) / 2);
@@ -118,7 +128,8 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: var(--gg-copy-pad);
+  padding-block: var(--gg-pq-pad-block);
+  padding-inline: var(--gg-copy-pad);
   opacity: 0;
   pointer-events: none;
   transform: scale(0.9);
@@ -130,9 +141,31 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   transform: scale(1);
 }
 
+.globe-gallery-pullquote::before,
+.globe-gallery-pullquote::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  border: 0 solid var(--s2a-color-gray-800);
+}
+
+.globe-gallery-pullquote::before {
+  inset-block: var(--gg-pq-pad-block);
+  inset-inline: 0;
+  border-block-width: var(--gg-crosshair-width);
+}
+
+.globe-gallery-pullquote::after {
+  inset-block: 0;
+  inset-inline: var(--gg-copy-pad);
+  border-inline-width: var(--gg-crosshair-width);
+}
+
+/* WebKit hangs the opening quote; authoring.js does the rest. See README (Hanging the opening mark). */
 .globe-gallery-pullquote-quote {
   color: var(--s2a-color-gray-25);
   margin: 0;
+  hanging-punctuation: first;
 }
 
 /* Gap between quote and name/role; only bites when they cluster (e.g. the RM centred layout). */
@@ -740,16 +773,18 @@ body.globe-gallery-modal-open { overflow: hidden; }
 }
 
 .globe-gallery-reduced .globe-gallery-pullquote {
-  position: static;
+  --gg-pq-pad-block: 10vh 8vh;
+
+  position: relative;
   top: auto;
   height: auto;
   min-height: 0;
   justify-content: flex-start;
-  padding: 10vh var(--gg-copy-pad) 8vh;
   opacity: 1;
   transform: none;
   transition: none;
 }
+
 
 /* Drop nav scale hover animation; colour cue stays. */
 @media (prefers-reduced-motion: reduce) {

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -44,8 +44,8 @@
   box-sizing: border-box;
   padding: 16px;
   background: var(--s2a-color-transparent-black-32);
-  -webkit-backdrop-filter: blur(var(--s2a-blur-64));
-  backdrop-filter: blur(var(--s2a-blur-64));
+  -webkit-backdrop-filter: blur(var(--s2a-blur-lg));
+  backdrop-filter: blur(var(--s2a-blur-lg));
   border-radius: var(--s2a-border-radius-md);
   pointer-events: none;
   opacity: 0;
@@ -192,7 +192,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 .globe-gallery-modal-nav {
   width: 44px;
   height: 44px;
-  border-radius: var(--s2a-border-radius-4);
+  border-radius: var(--s2a-border-radius-xs);
   border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
   background: var(--s2a-color-transparent-black-64);
   -webkit-backdrop-filter: blur(12px);
@@ -219,7 +219,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   position: absolute;
   width: 38px;
   height: 38px;
-  border-radius: var(--s2a-border-radius-4);
+  border-radius: var(--s2a-border-radius-xs);
   border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
   background: var(--s2a-color-transparent-black-64);
   -webkit-backdrop-filter: blur(12px);
@@ -284,7 +284,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   font-family: var(--heading-font-family);
   font-weight: var(--s2a-font-weight-adobe-clean-black);
   font-size: 20px;
-  line-height: var(--s2a-font-line-height-24);
+  line-height: var(--s2a-font-line-height-md);
   letter-spacing: -0.6px;
   color: var(--s2a-color-gray-25);
   margin: 2px 0 8px;
@@ -293,7 +293,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 .globe-gallery-modal-description {
   font-family: var(--body-font-family);
   font-size: 13px;
-  line-height: var(--s2a-font-line-height-18);
+  line-height: var(--s2a-font-line-height-xs);
   color: var(--s2a-color-gray-400);
   margin: 0 0 12px;
   max-width: 375px;
@@ -536,7 +536,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   .globe-gallery-modal-counter {
     width: 138px;
     box-sizing: border-box;
-    border-radius: var(--s2a-border-radius-4);
+    border-radius: var(--s2a-border-radius-xs);
     border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
     background: var(--s2a-color-transparent-black-64);
     -webkit-backdrop-filter: blur(12px);
@@ -595,7 +595,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
     display: flex;
     align-items: center;
     padding: 4px 10px;
-    border-radius: var(--s2a-border-radius-4);
+    border-radius: var(--s2a-border-radius-xs);
     border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
     background: var(--s2a-color-transparent-black-64);
     -webkit-backdrop-filter: blur(12px);

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -58,7 +58,7 @@
 
   position: fixed;
 
-  /* (viewport - 16px), 8px gap each side, capped at 359px; calc(100vw - 32px) clamped to 343 on SE. */
+  /* Full width less a gap each side, capped. See README (CSS) for the literal-vs-token rule. */
   width: calc(100vw - var(--s2a-spacing-xs) * 2);
   max-width: 359px;
   bottom: var(--s2a-spacing-xs);

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -234,12 +234,13 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 }
 .globe-gallery-modal-close:hover { background: var(--s2a-color-transparent-black-80); }
 
-/* Position set by JS. Badges margin-top:auto pins them to bottom; padding-bottom reserves the nav row. */
+/* Position set by JS. Badges margin-top:auto pins them to bottom; padding-bottom reserves the nav row.
+   sm bottom = EDGE 16 + nav 44 + 16 clearance; the arrows sit under the badges at this breakpoint. */
 .globe-gallery-modal-info {
   position: absolute;
   max-height: 60dvh;
   margin: 0;
-  padding: 24px 24px 84px;
+  padding: 16px 16px 76px;
   border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-00);
   border-radius: var(--s2a-border-radius-md);
   background: var(--s2a-color-transparent-black-64);
@@ -523,7 +524,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
     height: auto;
     max-height: none;
     border-radius: 0;
-    padding: 40px 32px;
+    padding: 24px;
   }
 
   .globe-gallery-modal-role-label { margin-top: 0; }

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -20,7 +20,7 @@
   --gg-controls-size: 48px;
   --gg-controls-radius: 6px;
   --gg-controls-inset: var(--s2a-spacing-md);
-  --gg-controls-nav: 124px;
+  --gg-controls-nav: calc(var(--gnav-height-nav, 72px) + var(--feds-breadcrumbs-height, 52px));
   --gg-controls-top: calc(var(--gg-controls-nav) + var(--gg-controls-inset));
 
   height: var(--gg-runway-height);
@@ -147,6 +147,13 @@
   text-align: center;
   text-wrap: balance;
   user-select: none;
+
+  box-sizing: border-box;
+  padding: var(--s2a-spacing-xs) var(--s2a-spacing-sm);
+  border-radius: var(--gg-controls-radius);
+  background: var(--s2a-color-transparent-black-64);
+  -webkit-backdrop-filter: blur(var(--gg-chrome-blur));
+  backdrop-filter: blur(var(--gg-chrome-blur));
 
   & > p { margin: 0; }
 }

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -374,12 +374,16 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   scrollbar-width: thin;
   scrollbar-color: var(--s2a-color-transparent-white-24) transparent;
 
-  /* Scroll-shadow fade cue; JS (updateDescFade) sets each length to 0 (no fade) or 20px. */
+  /* Scroll-shadow fade cue; JS (updateDescFade) toggles .is-faded-top/-bottom. */
+  --gg-desc-fade-len: 20px;
   --gg-desc-fade-top: 0;
   --gg-desc-fade-bottom: 0;
 
   -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 var(--gg-desc-fade-top), #000 calc(100% - var(--gg-desc-fade-bottom)), transparent 100%);
   mask-image: linear-gradient(to bottom, transparent 0, #000 var(--gg-desc-fade-top), #000 calc(100% - var(--gg-desc-fade-bottom)), transparent 100%);
+
+  &.is-faded-top { --gg-desc-fade-top: var(--gg-desc-fade-len); }
+  &.is-faded-bottom { --gg-desc-fade-bottom: var(--gg-desc-fade-len); }
 }
 
 .globe-gallery-arc-copy-body p,

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -111,34 +111,40 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   pointer-events: none;
 }
 
+/* Zero-height rail at the viewport mid-line; the quote hangs centred off it. See README. */
+.globe-gallery-pullquote-rail {
+  position: sticky;
+  top: 50vh;
+  height: 0;
+}
+
 /* Starts hidden; JS adds .is-active once the zoom-in threshold passes. */
 .globe-gallery-pullquote {
-  --gg-pq-height: 583px;
+  --gg-pq-gap: var(--s2a-layout-xl);
   --gg-pq-pad-block: var(--gg-copy-pad);
 
-  position: sticky;
-  top: calc(50vh - var(--gg-pq-height) / 2);
+  position: absolute;
+  top: 0;
+  inset-inline: 0;
   box-sizing: border-box;
-  width: 100%;
   max-width: var(--gg-copy-max);
-  margin: 0 auto;
-  height: var(--gg-pq-height);
+  margin-inline: auto;
   z-index: 5;
   background: transparent;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: var(--gg-pq-gap);
   padding-block: var(--gg-pq-pad-block);
   padding-inline: var(--gg-copy-pad);
   opacity: 0;
   pointer-events: none;
-  transform: scale(0.9);
+  transform: translateY(-50%) scale(0.9);
   transition: opacity 0.7s ease, transform 0.7s ease;
 }
 
 .globe-gallery-pullquote.is-active {
   opacity: 1;
-  transform: scale(1);
+  transform: translateY(-50%) scale(1);
 }
 
 .globe-gallery-pullquote::before,
@@ -166,11 +172,6 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   color: var(--s2a-color-gray-25);
   margin: 0;
   hanging-punctuation: first;
-}
-
-/* Gap between quote and name/role; only bites when they cluster (e.g. the RM centred layout). */
-.globe-gallery-pullquote-attribution {
-  margin-top: var(--s2a-spacing-lg);
 }
 
 .globe-gallery-pullquote-name {
@@ -802,8 +803,9 @@ html .globe-gallery-reduced .globe-gallery-arc-copy {
   height: 100vh;
 }
 
-/* Pull-quote flows normally after the globe: drop the pin/sticky, show statically, top-aligned with a gap above. */
-.globe-gallery-reduced .globe-gallery-pullquote-pin {
+/* Pull-quote flows normally after the globe: drop the pin/rail/sticky, show statically with a gap above. */
+.globe-gallery-reduced .globe-gallery-pullquote-pin,
+.globe-gallery-reduced .globe-gallery-pullquote-rail {
   position: static;
   height: auto;
 }
@@ -813,9 +815,6 @@ html .globe-gallery-reduced .globe-gallery-arc-copy {
 
   position: relative;
   top: auto;
-  height: auto;
-  min-height: 0;
-  justify-content: flex-start;
   opacity: 1;
   transform: none;
   transition: none;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -147,6 +147,8 @@
   text-align: center;
   text-wrap: balance;
   user-select: none;
+
+  & > p { margin: 0; }
 }
 
 .globe-gallery-arc-copy {

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -214,6 +214,9 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   --gg-modal-edge: var(--s2a-spacing-md);
   --gg-control-size: 48px;
   --gg-control-radius: 6px;
+  --gg-counter-w: auto; /* md+ pill is a fixed width; the md offsets below need the number */
+  --gg-nav-gap: 12px; /* counter pill edge → each arrow */
+  --gg-scrim-w: 316px; /* md+ info scrim (sm is full-width) */
 
   position: fixed;
   inset: 0;
@@ -242,7 +245,17 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 /* Transparent ::backdrop — a styled one would sit ABOVE the photo canvas and hide it. */
 .globe-gallery-modal-chrome::backdrop { background: transparent; }
 
-/* Position set per-frame by JS; CSS is visual style only. */
+/* Bottom row (arrows + counter): sm spreads it into the corners, md+ centres it as one group under
+   the image. All static — JS only fades the chrome in. See README (Modal chrome). */
+.globe-gallery-modal-nav,
+.globe-gallery-modal-counter {
+  position: absolute;
+  bottom: var(--gg-modal-edge);
+}
+
+.globe-gallery-modal-nav-prev { inset-inline-start: var(--gg-modal-edge); }
+.globe-gallery-modal-nav-next { inset-inline-end: var(--gg-modal-edge); }
+
 .globe-gallery-modal-nav {
   width: var(--gg-control-size);
   height: var(--gg-control-size);
@@ -268,9 +281,12 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 
 .globe-gallery-modal-nav:active { transform: scale(0.98); }
 
-/* Close button — position set by JS; same frosted treatment as the nav arrows. */
+/* Close button — top inline-end corner of the viewport at every breakpoint; same frosted
+   treatment as the nav arrows. */
 .globe-gallery-modal-close {
   position: absolute;
+  top: var(--gg-modal-edge);
+  inset-inline-end: var(--gg-modal-edge);
   width: var(--gg-control-size);
   height: var(--gg-control-size);
   border-radius: var(--gg-control-radius);
@@ -288,10 +304,11 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 }
 .globe-gallery-modal-close:hover { background: var(--s2a-color-transparent-black-80); }
 
-/* Position set by JS. Badges margin-top:auto pins them to bottom; padding-bottom reserves the sm nav
-   row (edge + control + edge). See README (Modal chrome). */
+/* sm = full-width chunk on the viewport's bottom edge, content-sized. Badges margin-top:auto pins
+   them to bottom; padding-bottom reserves the sm nav row (edge + control + edge). */
 .globe-gallery-modal-info {
   position: absolute;
+  inset: auto 0 0;
   max-height: 60dvh;
   margin: 0;
   padding: var(--gg-modal-edge) var(--gg-modal-edge) calc(var(--gg-modal-edge) * 2 + var(--gg-control-size));
@@ -446,8 +463,11 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   color: var(--s2a-color-gray-400);
 }
 
-/* Counter ("1/N"), positioned by JS. Base (sm) = plain text; min-width:768 = frosted pill. */
+/* Counter ("1/N"). Base (sm) = plain text; min-width:768 = frosted pill. Centres on physical
+   `left`, not an inset-inline, because the translateX(-50%) it pairs with is physical. */
 .globe-gallery-modal-counter {
+  left: 50%;
+  transform: translateX(-50%);
   height: var(--gg-control-size);
   display: flex;
   align-items: center;
@@ -565,7 +585,10 @@ body.globe-gallery-modal-open { overflow: hidden; }
   /* Smaller quote-pin factor at md; see README. */
   .globe-gallery { --gg-pq-pin-factor: 0.55; }
 
-  .globe-gallery-modal-chrome { --gg-modal-edge: var(--s2a-spacing-lg); }
+  .globe-gallery-modal-chrome {
+    --gg-modal-edge: var(--s2a-spacing-lg);
+    --gg-counter-w: 138px;
+  }
 
   /* md+: no pill background, so the copy's own left edge must sit on --gg-content-inset. */
   .globe-gallery-arc-copy {
@@ -576,12 +599,24 @@ body.globe-gallery-modal-open { overflow: hidden; }
     background: none;
   }
 
-  /* Full-height left-edge; JS sets top/bottom/inset-inline-start/width. */
+  /* Full-height scrim on the viewport's inline-start edge. */
   .globe-gallery-modal-info {
+    inset: 0 auto 0;
+    inset-inline-start: 0;
+    width: var(--gg-scrim-w);
     height: auto;
     max-height: none;
     border-radius: 0;
     padding: var(--gg-modal-edge);
+  }
+
+  /* One centred row: counter pill in the middle, an arrow --gg-nav-gap out on each side. */
+  .globe-gallery-modal-nav-prev {
+    inset-inline-start: calc(50% - var(--gg-counter-w) / 2 - var(--gg-nav-gap) - var(--gg-control-size));
+  }
+
+  .globe-gallery-modal-nav-next {
+    inset-inline-start: calc(50% + var(--gg-counter-w) / 2 + var(--gg-nav-gap));
   }
 
   .globe-gallery-modal-role-label { margin-top: 0; }
@@ -606,7 +641,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   .globe-gallery-modal-badge-role { font-size: var(--s2a-font-size-sm); }
 
   .globe-gallery-modal-counter {
-    width: 138px;
+    width: var(--gg-counter-w);
     box-sizing: border-box;
     border-radius: var(--gg-control-radius);
     border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -946,6 +946,10 @@ html[dir="rtl"] .globe-gallery-modal-nav svg {
   transform: scaleX(-1);
 }
 
+html[dir="rtl"] .globe-gallery-hint {
+  flex-direction: row-reverse;
+}
+
 html[dir="rtl"] .globe-gallery-modal-badge-app-link::after {
   transform: scaleX(-1) rotate(45deg) translateY(-1px);
 }

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -17,6 +17,11 @@
   --gg-copy-pad: var(--s2a-spacing-lg);
   --gg-content-inset: calc(max(0px, 100% - var(--gg-copy-max)) / 2 + var(--gg-copy-pad));
   --gg-crosshair-width: 1px;
+  --gg-controls-size: 48px;
+  --gg-controls-radius: 6px;
+  --gg-controls-inset: var(--s2a-spacing-md);
+  --gg-controls-nav: 124px;
+  --gg-controls-top: calc(var(--gg-controls-nav) + var(--gg-controls-inset));
 
   height: var(--gg-runway-height);
   position: relative;
@@ -35,7 +40,10 @@
 }
 
 @media (width >= 768px) {
-  .globe-gallery { --gg-copy-pad: var(--s2a-spacing-3xl); }
+  .globe-gallery {
+    --gg-copy-pad: var(--s2a-spacing-3xl);
+    --gg-controls-inset: var(--s2a-spacing-lg);
+  }
 }
 
 @media (width >= 1440px) {
@@ -58,6 +66,87 @@
   overflow: visible;
   pointer-events: none;
   z-index: 2;
+}
+
+.globe-gallery-controls {
+  position: fixed;
+  inset: 0;
+  pointer-events: none; /* not intercepting canvas drag */
+  z-index: 5;
+  opacity: 0;
+  visibility: hidden; /* pulls the buttons out of the tab order while the globe isn't live */
+
+  /* visibility flips AFTER the fade, never during: an interpolated `visible` would leave the
+     buttons tappable and tabbable at opacity 0 for the whole 0.35s. */
+  transition: opacity 0.35s ease, visibility 0s linear 0.35s;
+}
+
+.globe-gallery-controls.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.35s ease, visibility 0s;
+}
+
+.globe-gallery-control {
+  width: var(--gg-controls-size);
+  height: var(--gg-controls-size);
+  flex: none;
+  box-sizing: border-box;
+  padding: 0;
+  border-radius: var(--gg-controls-radius);
+  border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
+  background: var(--s2a-color-transparent-black-64);
+  -webkit-backdrop-filter: blur(var(--gg-chrome-blur));
+  backdrop-filter: blur(var(--gg-chrome-blur));
+  color: var(--s2a-color-gray-25);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: none;
+  pointer-events: auto;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.globe-gallery-control:hover {
+  background: var(--s2a-color-transparent-black-80);
+  transform: scale(1.05);
+}
+
+.globe-gallery-control:active { transform: scale(0.98); }
+
+.globe-gallery-spin-toggle {
+  position: absolute;
+  top: var(--gg-controls-top);
+  inset-inline-end: var(--gg-controls-inset);
+}
+
+.globe-gallery-spin-toggle .globe-gallery-icon-play { display: none; }
+.globe-gallery-spin-toggle.is-paused .globe-gallery-icon-pause { display: none; }
+.globe-gallery-spin-toggle.is-paused .globe-gallery-icon-play { display: block; }
+
+.globe-gallery-hint { display: none; } /* barrel only */
+
+.globe-gallery-barrel .globe-gallery-hint {
+  position: absolute;
+  inset-inline: var(--gg-controls-inset);
+  bottom: var(--gg-controls-inset);
+  display: flex;
+  align-items: center;
+  gap: var(--s2a-spacing-md);
+}
+
+.globe-gallery-hint-text {
+  flex: 1;
+  margin: 0;
+  color: var(--s2a-color-gray-25);
+  font-family: var(--body-font-family);
+  font-size: var(--s2a-font-size-sm);
+  font-weight: var(--s2a-font-weight-body);
+  line-height: 1.35;
+  text-align: center;
+  text-wrap: balance;
+  user-select: none;
 }
 
 .globe-gallery-arc-copy {
@@ -589,6 +678,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
 /* Keyboard focus indicators (2px S2A focus ring, 2px offset). */
 .globe-gallery-a11y:focus-visible,
 .globe-gallery-a11y-card:focus-visible,
+.globe-gallery-control:focus-visible,
 .globe-gallery-modal-close:focus-visible,
 .globe-gallery-modal-nav:focus-visible {
   outline: var(--s2a-border-width-md) solid var(--s2a-color-focus-ring-default);
@@ -808,6 +898,14 @@ html .globe-gallery-reduced .globe-gallery-arc-copy {
   position: absolute;
 }
 
+.globe-gallery-reduced .globe-gallery-controls {
+  position: absolute;
+}
+
+html .globe-gallery-reduced .globe-gallery-spin-toggle {
+  display: none;
+}
+
 /* Pull-quote flows normally after the globe: drop the pin/rail/sticky, show statically with a gap above. */
 .globe-gallery-reduced .globe-gallery-pullquote-pin,
 .globe-gallery-reduced .globe-gallery-pullquote-rail {
@@ -829,7 +927,9 @@ html .globe-gallery-reduced .globe-gallery-arc-copy {
 /* Drop nav scale hover animation; colour cue stays. */
 @media (prefers-reduced-motion: reduce) {
   .globe-gallery-modal-nav:hover,
-  .globe-gallery-modal-nav:active {
+  .globe-gallery-modal-nav:active,
+  .globe-gallery-control:hover,
+  .globe-gallery-control:active {
     transform: none;
   }
 }

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -1,13 +1,23 @@
-/* stylelint-disable property-no-vendor-prefix, value-no-vendor-prefix, custom-property-pattern */
+/* stylelint-disable property-no-vendor-prefix, value-no-vendor-prefix */
+
+.globe-gallery,
+.globe-gallery-cursor {
+  --gg-chrome-blur: 12px;
+}
 
 /* Scroll model (see README). .globe-gallery-reduced and .globe-gallery-empty overrides are at the end of this file. */
 .globe-gallery {
   /* Full scroll-runway model: README. */
-  --runway-height: 520vh;
-  --formation-vh: 304vh;
-  --pq-pin-factor: 0.65;
+  --gg-runway-height: 520vh;
+  --gg-formation-vh: 304vh;
+  --gg-pq-pin-factor: 0.65;
 
-  height: var(--runway-height);
+  /* Shared copy edge: the pull-quote's own left text edge, reused by the arc copy. See README. */
+  --gg-copy-max: 1920px;
+  --gg-copy-pad: var(--s2a-spacing-lg);
+  --gg-content-inset: calc(max(0px, 100vw - var(--gg-copy-max)) / 2 + var(--gg-copy-pad));
+
+  height: var(--gg-runway-height);
   position: relative;
   background: var(--s2a-color-gray-900);
   margin-top: 0;
@@ -35,14 +45,19 @@
 }
 
 .globe-gallery-arc-copy {
+  --gg-arc-pad: var(--s2a-spacing-md);
+
   position: fixed;
 
   /* (viewport - 16px), 8px gap each side, capped at 359px; calc(100vw - 32px) clamped to 343 on SE. */
-  width: calc(100vw - 16px);
+  width: calc(100vw - var(--s2a-spacing-xs) * 2);
   max-width: 359px;
-  bottom: 8px;
+  bottom: var(--s2a-spacing-xs);
+
+  /* sm: the pill hugs the edge and its own padding lands the copy on --gg-content-inset. */
+  inset-inline-start: var(--s2a-spacing-xs);
   box-sizing: border-box;
-  padding: 16px;
+  padding: var(--gg-arc-pad);
   background: var(--s2a-color-transparent-black-32);
   -webkit-backdrop-filter: blur(var(--s2a-blur-lg));
   backdrop-filter: blur(var(--s2a-blur-lg));
@@ -62,11 +77,13 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   /* 18px custom mini-headline (between Title-4 and body) — no standard type class fits. */
   font-family: var(--heading-font-family);
   font-weight: var(--s2a-font-weight-adobe-clean-black);
-  font-size: 18px;
+  font-size: var(--s2a-font-size-lg);
   line-height: var(--s2a-font-line-height-21);
+
+  /* stylelint-disable-next-line custom-property-pattern -- upstream S2A token has an underscore */
   letter-spacing: var(--s2a-font-letter-spacing-neg-0_48);
   color: var(--s2a-color-gray-25);
-  margin: 0 0 4px;
+  margin: 0 0 var(--s2a-spacing-2xs);
 }
 
 .globe-gallery-arc-copy-body {
@@ -81,27 +98,27 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   bottom: 0;
   left: 0;
   right: 0;
-  height: max(1px, calc((var(--runway-height) - var(--formation-vh)) * var(--pq-pin-factor)));
+  height: max(1px, calc((var(--gg-runway-height) - var(--gg-formation-vh)) * var(--gg-pq-pin-factor)));
   pointer-events: none;
 }
 
 /* Starts hidden; JS adds .is-active once the zoom-in threshold passes. */
 .globe-gallery-pullquote {
-  --pq-height: 583px;
+  --gg-pq-height: 583px;
 
   position: sticky;
-  top: calc(50vh - var(--pq-height) / 2);
+  top: calc(50vh - var(--gg-pq-height) / 2);
   box-sizing: border-box;
   width: 100%;
-  max-width: 1920px;
+  max-width: var(--gg-copy-max);
   margin: 0 auto;
-  height: var(--pq-height);
+  height: var(--gg-pq-height);
   z-index: 5;
   background: transparent;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 24px;
+  padding: var(--gg-copy-pad);
   opacity: 0;
   pointer-events: none;
   transform: scale(0.9);
@@ -120,7 +137,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 
 /* Gap between quote and name/role; only bites when they cluster (e.g. the RM centred layout). */
 .globe-gallery-pullquote-attribution {
-  margin-top: 24px;
+  margin-top: var(--s2a-spacing-lg);
 }
 
 .globe-gallery-pullquote-name {
@@ -161,6 +178,10 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 
 /* Native <dialog> via showModal(); full-viewport top-layer overlay. Gesture surface: siblings go inert. */
 .globe-gallery-modal-chrome {
+  --gg-modal-edge: var(--s2a-spacing-md);
+  --gg-control-size: 48px;
+  --gg-control-radius: 6px;
+
   position: fixed;
   inset: 0;
   z-index: 15;
@@ -190,13 +211,13 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 
 /* Position set per-frame by JS; CSS is visual style only. */
 .globe-gallery-modal-nav {
-  width: 44px;
-  height: 44px;
-  border-radius: var(--s2a-border-radius-xs);
+  width: var(--gg-control-size);
+  height: var(--gg-control-size);
+  border-radius: var(--gg-control-radius);
   border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
   background: var(--s2a-color-transparent-black-64);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(var(--gg-chrome-blur));
+  backdrop-filter: blur(var(--gg-chrome-blur));
   color: var(--s2a-color-gray-25);
   cursor: pointer;
   display: flex;
@@ -217,13 +238,13 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 /* Close button — position set by JS; same frosted treatment as the nav arrows. */
 .globe-gallery-modal-close {
   position: absolute;
-  width: 38px;
-  height: 38px;
-  border-radius: var(--s2a-border-radius-xs);
+  width: var(--gg-control-size);
+  height: var(--gg-control-size);
+  border-radius: var(--gg-control-radius);
   border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
   background: var(--s2a-color-transparent-black-64);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(var(--gg-chrome-blur));
+  backdrop-filter: blur(var(--gg-chrome-blur));
   color: var(--s2a-color-gray-25);
   cursor: pointer;
   display: flex;
@@ -234,18 +255,18 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 }
 .globe-gallery-modal-close:hover { background: var(--s2a-color-transparent-black-80); }
 
-/* Position set by JS. Badges margin-top:auto pins them to bottom; padding-bottom reserves the nav row.
-   sm bottom = EDGE 16 + nav 44 + 16 clearance; the arrows sit under the badges at this breakpoint. */
+/* Position set by JS. Badges margin-top:auto pins them to bottom; padding-bottom reserves the sm nav
+   row (edge + control + edge). See README (Modal chrome). */
 .globe-gallery-modal-info {
   position: absolute;
   max-height: 60dvh;
   margin: 0;
-  padding: 16px 16px 76px;
+  padding: var(--gg-modal-edge) var(--gg-modal-edge) calc(var(--gg-modal-edge) * 2 + var(--gg-control-size));
   border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-00);
   border-radius: var(--s2a-border-radius-md);
   background: var(--s2a-color-transparent-black-64);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(var(--gg-chrome-blur));
+  backdrop-filter: blur(var(--gg-chrome-blur));
   box-shadow: none;
   pointer-events: auto;
   display: flex;
@@ -262,7 +283,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 .globe-gallery-modal-badges {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--s2a-spacing-xs);
   list-style: none;
   margin: 0;
   padding: 0;
@@ -284,19 +305,19 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 .globe-gallery-modal-name {
   font-family: var(--heading-font-family);
   font-weight: var(--s2a-font-weight-adobe-clean-black);
-  font-size: 20px;
+  font-size: var(--s2a-font-size-xl);
   line-height: var(--s2a-font-line-height-md);
   letter-spacing: -0.6px;
   color: var(--s2a-color-gray-25);
-  margin: 2px 0 8px;
+  margin: var(--s2a-spacing-3xs) 0 var(--s2a-spacing-xs);
 }
 
 .globe-gallery-modal-description {
   font-family: var(--body-font-family);
-  font-size: 13px;
-  line-height: var(--s2a-font-line-height-xs);
+  font-size: var(--s2a-font-size-sm);
+  line-height: var(--s2a-font-line-height-sm);
   color: var(--s2a-color-gray-400);
-  margin: 0 0 12px;
+  margin: 0 0 var(--s2a-spacing-sm);
   max-width: 375px;
   min-height: 0; /* let this flex item shrink below its content so it scrolls, not overflows */
   overflow-y: auto;
@@ -305,11 +326,11 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   scrollbar-color: var(--s2a-color-transparent-white-24) transparent;
 
   /* Scroll-shadow fade cue; JS (updateDescFade) sets each length to 0 (no fade) or 20px. */
-  --desc-fade-top: 0;
-  --desc-fade-bottom: 0;
+  --gg-desc-fade-top: 0;
+  --gg-desc-fade-bottom: 0;
 
-  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 var(--desc-fade-top), #000 calc(100% - var(--desc-fade-bottom)), transparent 100%);
-  mask-image: linear-gradient(to bottom, transparent 0, #000 var(--desc-fade-top), #000 calc(100% - var(--desc-fade-bottom)), transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 var(--gg-desc-fade-top), #000 calc(100% - var(--gg-desc-fade-bottom)), transparent 100%);
+  mask-image: linear-gradient(to bottom, transparent 0, #000 var(--gg-desc-fade-top), #000 calc(100% - var(--gg-desc-fade-bottom)), transparent 100%);
 }
 
 .globe-gallery-arc-copy-body p,
@@ -319,7 +340,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 
 .globe-gallery-arc-copy-body p + p,
 .globe-gallery-modal-description p + p {
-  margin-top: 8px;
+  margin-top: var(--s2a-spacing-xs);
 }
 
 .globe-gallery-modal-description a {
@@ -335,7 +356,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--s2a-spacing-sm);
 }
 
 .globe-gallery-modal-badge-left {
@@ -369,7 +390,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   text-decoration: none;
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--s2a-spacing-3xs);
 }
 
 .globe-gallery-modal-badge-app-link::after {
@@ -377,8 +398,8 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   display: inline-block;
   width: 6px;
   height: 6px;
-  border-right: 2px solid var(--s2a-color-gray-25);
-  border-top: 2px solid var(--s2a-color-gray-25);
+  border-right: var(--s2a-border-width-md) solid var(--s2a-color-gray-25);
+  border-top: var(--s2a-border-width-md) solid var(--s2a-color-gray-25);
   transform: rotate(45deg) translateY(-1px);
   flex-shrink: 0;
 }
@@ -395,13 +416,13 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 
 /* Counter ("1/N"), positioned by JS. Base (sm) = plain text; min-width:768 = frosted pill. */
 .globe-gallery-modal-counter {
-  height: 44px;
+  height: var(--gg-control-size);
   display: flex;
   align-items: center;
   justify-content: center;
   color: var(--s2a-color-gray-25);
   font-family: var(--body-font-family);
-  font-size: 14px;
+  font-size: var(--s2a-font-size-sm);
   font-weight: var(--s2a-font-weight-body);
   letter-spacing: 0.02em;
   pointer-events: none;
@@ -462,15 +483,15 @@ body.globe-gallery-modal-open { overflow: hidden; }
   left: 50%;
   transform: translate(-50%, -50%) scale(0.96);
   max-width: min(78vw, 320px);
-  padding: 12px 20px;
+  padding: var(--s2a-spacing-sm) var(--s2a-spacing-20);
   border-radius: var(--s2a-border-radius-sm);
   border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
   background: var(--s2a-color-transparent-black-64);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(var(--gg-chrome-blur));
+  backdrop-filter: blur(var(--gg-chrome-blur));
   color: var(--s2a-color-gray-25);
-  font-size: 1rem;
-  font-weight: 500;
+  font-size: var(--s2a-font-size-md);
+  font-weight: var(--s2a-font-weight-adobe-clean-medium);
   line-height: 1.35;
   text-align: center;
   white-space: normal;
@@ -504,18 +525,22 @@ body.globe-gallery-modal-open { overflow: hidden; }
 .globe-gallery-a11y-card:focus-visible,
 .globe-gallery-modal-close:focus-visible,
 .globe-gallery-modal-nav:focus-visible {
-  outline: 2px solid var(--s2a-color-focus-ring-default);
+  outline: var(--s2a-border-width-md) solid var(--s2a-color-focus-ring-default);
   outline-offset: 2px;
 }
 
 @media (min-width: 768px) {
   /* Smaller quote-pin factor at md; see README. */
-  .globe-gallery { --pq-pin-factor: 0.55; }
+  .globe-gallery { --gg-pq-pin-factor: 0.55; }
 
+  .globe-gallery-modal-chrome { --gg-modal-edge: var(--s2a-spacing-lg); }
+
+  /* md+: no pill background, so the copy's own left edge must sit on --gg-content-inset. */
   .globe-gallery-arc-copy {
     width: 382px;
     max-width: none;
-    bottom: 24px;
+    bottom: var(--s2a-spacing-lg);
+    inset-inline-start: calc(var(--gg-content-inset) - var(--gg-arc-pad));
     background: none;
   }
 
@@ -524,21 +549,19 @@ body.globe-gallery-modal-open { overflow: hidden; }
     height: auto;
     max-height: none;
     border-radius: 0;
-    padding: 24px;
+    padding: var(--gg-modal-edge);
   }
 
   .globe-gallery-modal-role-label { margin-top: 0; }
 
   .globe-gallery-modal-name {
-    font-size: 24px;
+    font-size: var(--s2a-font-size-2xl);
     line-height: 28px;
     letter-spacing: -0.6px;
-    margin: 4px 0 12px;
+    margin: var(--s2a-spacing-2xs) 0 var(--s2a-spacing-sm);
   }
 
   .globe-gallery-modal-description {
-    font-size: 15px;
-    line-height: 22px;
     margin: 0;
     max-width: none;
   }
@@ -550,17 +573,17 @@ body.globe-gallery-modal-open { overflow: hidden; }
     height: 28px;
   }
 
-  .globe-gallery-modal-badge-app { font-size: 14px; }
-  .globe-gallery-modal-badge-role { font-size: 14px; }
+  .globe-gallery-modal-badge-app { font-size: var(--s2a-font-size-sm); }
+  .globe-gallery-modal-badge-role { font-size: var(--s2a-font-size-sm); }
 
   .globe-gallery-modal-counter {
     width: 138px;
     box-sizing: border-box;
-    border-radius: var(--s2a-border-radius-xs);
+    border-radius: var(--gg-control-radius);
     border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
     background: var(--s2a-color-transparent-black-64);
-    -webkit-backdrop-filter: blur(12px);
-    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(var(--gg-chrome-blur));
+    backdrop-filter: blur(var(--gg-chrome-blur));
   }
 }
 
@@ -618,8 +641,8 @@ body.globe-gallery-modal-open { overflow: hidden; }
     border-radius: var(--s2a-border-radius-xs);
     border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
     background: var(--s2a-color-transparent-black-64);
-    -webkit-backdrop-filter: blur(12px);
-    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(var(--gg-chrome-blur));
+    backdrop-filter: blur(var(--gg-chrome-blur));
     opacity: 0;
     transition: opacity 0.5s ease 0.15s;
   }
@@ -660,7 +683,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   .globe-gallery-cursor-text {
     display: block;
     font-family: var(--heading-font-family);
-    font-size: 12px;
+    font-size: var(--s2a-font-size-xs);
     font-weight: var(--s2a-font-weight-adobe-clean-bold);
     letter-spacing: 0.02em;
     white-space: nowrap;
@@ -722,7 +745,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   height: auto;
   min-height: 0;
   justify-content: flex-start;
-  padding: 10vh 24px 8vh;
+  padding: 10vh var(--gg-copy-pad) 8vh;
   opacity: 1;
   transform: none;
   transition: none;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -311,6 +311,25 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   mask-image: linear-gradient(to bottom, transparent 0, #000 var(--desc-fade-top), #000 calc(100% - var(--desc-fade-bottom)), transparent 100%);
 }
 
+.globe-gallery-arc-copy-body p,
+.globe-gallery-modal-description p {
+  margin: 0;
+}
+
+.globe-gallery-arc-copy-body p + p,
+.globe-gallery-modal-description p + p {
+  margin-top: 8px;
+}
+
+.globe-gallery-modal-description a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.globe-gallery-modal-description a:hover {
+  color: var(--s2a-color-gray-25);
+}
+
 .globe-gallery-modal-badge {
   display: flex;
   align-items: center;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -748,8 +748,9 @@ body.globe-gallery-modal-open { overflow: hidden; }
   height: 108vh;
 }
 
-/* No arc phase under RM — a fixed pill would hang over the scrolling page. */
-.globe-gallery-reduced .globe-gallery-arc-copy {
+/* No arc phase under RM — a fixed pill would hang over the scrolling page.
+   `html` prefix matches the specificity of the html[dir="rtl"] rule above. */
+html .globe-gallery-reduced .globe-gallery-arc-copy {
   display: none;
 }
 

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -15,7 +15,7 @@
   /* Shared copy edge: the pull-quote's own left text edge, reused by the arc copy. See README. */
   --gg-copy-max: 1920px;
   --gg-copy-pad: var(--s2a-spacing-lg);
-  --gg-content-inset: calc(max(0px, 100vw - var(--gg-copy-max)) / 2 + var(--gg-copy-pad));
+  --gg-content-inset: calc(max(0px, 100% - var(--gg-copy-max)) / 2 + var(--gg-copy-pad));
   --gg-crosshair-width: 1px;
 
   height: var(--gg-runway-height);
@@ -42,6 +42,13 @@
   .globe-gallery { --gg-copy-pad: var(--s2a-spacing-4xl); }
 }
 
+.globe-gallery-canvas,
+.globe-gallery-modal-canvas {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+}
+
 /* z-index bands: hero 2–5, modal 13–17. See README. */
 
 .globe-gallery-world {
@@ -59,7 +66,7 @@
   position: fixed;
 
   /* Full width less a gap each side, capped. See README (CSS) for the literal-vs-token rule. */
-  width: calc(100vw - var(--s2a-spacing-xs) * 2);
+  width: calc(100% - var(--s2a-spacing-xs) * 2);
   max-width: 359px;
   bottom: var(--s2a-spacing-xs);
 
@@ -167,11 +174,10 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   border-inline-width: var(--gg-crosshair-width);
 }
 
-/* WebKit hangs the opening quote; authoring.js does the rest. See README (Hanging the opening mark). */
+/* Opening mark is outdented by authoring.js; `hanging-punctuation` deliberately unused. See README. */
 .globe-gallery-pullquote-quote {
   color: var(--s2a-color-gray-25);
   margin: 0;
-  hanging-punctuation: first;
 }
 
 .globe-gallery-pullquote-name {
@@ -222,7 +228,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   position: fixed;
   inset: 0;
   z-index: 15;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   height: 100dvh;
   max-width: none;
@@ -493,10 +499,10 @@ body.globe-gallery-modal-open { overflow: hidden; }
 /* pointer-events:none — never intercepts canvas drag; tabbable only while interactive (JS). */
 .globe-gallery-a11y {
   position: fixed;
-  top: 50%;
+  top: 50vh;
   left: 50%;
-  width: min(80vw, 80vh);
-  height: min(80vw, 80vh);
+  width: min(80%, 80vh);
+  aspect-ratio: 1;
   transform: translate(-50%, -50%);
   padding: 0;
   margin: 0;
@@ -511,7 +517,10 @@ body.globe-gallery-modal-open { overflow: hidden; }
 /* JS sizes/positions per-frame to each card's projected screen rect. See README (Accessibility). */
 .globe-gallery-a11y-cards {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100vh;
   pointer-events: none;
   z-index: 4; /* same layer as the entry widget */
 }
@@ -539,7 +548,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) scale(0.96);
-  max-width: min(78vw, 320px);
+  max-width: min(78%, 320px);
   padding: var(--s2a-spacing-sm) var(--s2a-spacing-20);
   border-radius: var(--s2a-border-radius-sm);
   border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
@@ -778,10 +787,9 @@ body.globe-gallery-modal-open { overflow: hidden; }
 
 /* Reduced-motion overrides — grouped here to avoid no-descending-specificity lint errors. See README (Accessibility). */
 
-/* static + relative: scrolls away and anchors the absolute canvas. Height = 8vh + 100vh. */
+/* relative: scrolls away and anchors the absolute canvas. Keeps the base 100vh. */
 .globe-gallery-reduced .globe-gallery-world {
   position: relative;
-  height: 108vh;
 }
 
 /* No arc phase under RM — a fixed pill would hang over the scrolling page.
@@ -790,17 +798,14 @@ html .globe-gallery-reduced .globe-gallery-arc-copy {
   display: none;
 }
 
-/* Absolute so it scrolls with the globe; top:58vh re-centres on the sphere. */
+/* Absolute so it scrolls with the globe; the base 50vh still centres on the sphere. */
 .globe-gallery-reduced .globe-gallery-a11y {
   position: absolute;
-  top: 58vh;
 }
 
-/* Focus-ring overlay tracks the scrolled canvas (matching its 8vh top + 100vh box). */
+/* Focus-ring overlay tracks the scrolled canvas; the base box already matches it. */
 .globe-gallery-reduced .globe-gallery-a11y-cards {
   position: absolute;
-  inset: 8vh 0 auto;
-  height: 100vh;
 }
 
 /* Pull-quote flows normally after the globe: drop the pin/rail/sticky, show statically with a gap above. */

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -351,7 +351,6 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   line-height: var(--s2a-font-line-height-sm);
   color: var(--s2a-color-gray-400);
   margin: 0 0 var(--s2a-spacing-sm);
-  max-width: 375px;
   min-height: 0; /* let this flex item shrink below its content so it scrolls, not overflows */
   overflow-y: auto;
   touch-action: pan-y; /* dialog is touch-action:none — re-enable vertical touch scroll here */
@@ -594,10 +593,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
     margin: var(--s2a-spacing-2xs) 0 var(--s2a-spacing-sm);
   }
 
-  .globe-gallery-modal-description {
-    margin: 0;
-    max-width: none;
-  }
+  .globe-gallery-modal-description { margin: 0; }
 
   .globe-gallery-modal-badges { gap: 10px; }
 

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -19,7 +19,6 @@ const CARD_ASPECT = 456 / 631; // portrait
 const prefersReducedMotion = () => !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
 
 // Two render profiles split at 768px (Milo sm↔md); resolved once via resolveBP(W).
-// See README (Breakpoints).
 const BREAKPOINTS = {
   md: {
     minWidth: 768,
@@ -34,7 +33,7 @@ const BREAKPOINTS = {
     GRID_ROWS: 5,
     // 0 = cards face radially outward (true sphere). See applyCardFacing.
     CARD_FACE_CAMERA: 0,
-    CARD_ROLL_JITTER: 0.5, // per-card random roll, radians (±0.25 ≈ ±14°)
+    CARD_ROLL_JITTER: 0.5, // per-card random roll: ±half this, in radians
     ARC_DENSE_FRACTION: 0.6, // share of cards clustered into the off-screen arc flank
     DRAG_GEARING: 0.6, // fraction of 1:1 surface tracking — see dragSensitivity
   },
@@ -54,7 +53,7 @@ const BREAKPOINTS = {
     CARD_ROLL_JITTER: 0.18,
     ARC_DENSE_FRACTION: 0,
     CYL_COLS_FIT: 0.65, // phone-only override of the shared wall-height dial
-    DRAG_GEARING: 0.53, // geared down from 1:1 — the phone barrel is only ~167px wide
+    DRAG_GEARING: 0.53, // geared down from 1:1 — the phone barrel is small on screen
   },
 };
 
@@ -73,22 +72,19 @@ const ANTIALIAS_MD = true;
 const GLOBAL_CA_SM = false;
 const GLOBAL_CA_MD = true;
 
-// Shape overlay applied wherever drags are yaw-only (touch / narrow viewport): a cylindrical
-// masonry wall replaces the Fibonacci sphere so yaw can bring any card face-on at any height.
-// Selected per pointer precision (independent of the width band). See README (yaw-only geometry).
+// Shape overlay for yaw-only drags (touch / narrow): a cylindrical masonry wall replaces the
+// Fibonacci sphere.
 const YAW_ONLY_GEOMETRY = {
   CYLINDER: true,
   CYL_COLS_FIT: 0.80, // wall-height dial: fewest columns whose tallest fits this × frustum
   CYL_GAP_RATIO: 0.20, // inter-card gap as a fraction of card width
-  // Guard on the aspect a card is LAID OUT at; past it the fit crops. Clears the authored set, so
-  // nothing real is cropped — re-run the column solve before lowering. See README (yaw-only).
+  // Guard on the LAID-OUT aspect; past it the fit crops. See README (yaw-only) before lowering.
   CYL_ASPECT_CAP: 1.9,
   CYL_BULGE: 0.18, // barrel bulge: r = R·(1 − bulge·t²); keep ≤~0.2 or edges overlap
   CARD_FACE_CAMERA: 0.1, // limb polish; costs barrel smoothness — read the README before raising
 };
 
-// Cylinder-masonry wall vs Fibonacci sphere. True on the sm width band OR a coarse primary
-// pointer. matchMedia-less environments are treated as precise-pointer. See README.
+// True on the sm band OR a coarse primary pointer (matchMedia-less = precise).
 function usesCylinderGeometry(bandName) {
   if (bandName === 'sm') return true;
   return !!window.matchMedia?.('(pointer: coarse)').matches;
@@ -104,21 +100,19 @@ const TEXT_REBUILD_DEBOUNCE_MS = 150;
 
 // Grid peel / fold.
 const GRID_GAP_RATIO = 0.5; // gap between cards = 0.5× card width
-// Non-uniform fanT split: low-i cards cluster into fanT [0, this] off-screen and peel first;
-// the rest spread across the visible upper arc. ARC_DENSE_COUNT (per-BP) scales with N_TOTAL.
+// fanT boundary: low-i cards cluster below it off-screen and peel first.
 const ARC_DENSE_SPLIT = 0.50;
 
 // Drag / auto-rotation. MAX_VEL is shared with interaction.js (it clamps, core normalizes).
 // FRICTION and AUTO_ROT_SPEED are authored per 60fps frame and rescaled by frame.dtScale.
 const DRAG_FRICTION = 0.94;
-const MAX_VEL = 0.06; // rad/frame ≈ 206°/s — the ceiling on a flick
-const AUTO_ROT_SPEED = 0.0005; // ambient yaw RATE (not an increment into velX) ≈ 1.7°/s
-// Keyboard browse pitch cap ±85° (vs ±60° drag); excess eases back at PITCH_RELAX once
-// browsing ends. See updateSphereRotation.
+const MAX_VEL = 0.08; // rad per 60fps frame (×60·180/π for °/s): ceiling on a flick AND a held step
+const DRAG_CATCHUP = 0.5; // share of an over-max backlog worked off per 60fps frame (jerk limiter)
+const AUTO_ROT_SPEED = 0.0005; // ambient yaw RATE per 60fps frame (NOT an increment into velX)
+// Browse-only pitch cap (drag stops at the resting cap); excess eases back at PITCH_RELAX.
 const KEY_PITCH_CAP = (85 * Math.PI) / 180;
 const PITCH_RELAX = 0.85;
-// Frame counts for the sphere-centring easeInOutCubic tweens: browse slow (anti-dizziness),
-// modal faster (runs behind the blur). See README (Accessibility).
+// Frame counts for the sphere-centring tweens: browse slow (anti-dizziness), modal faster.
 const KEY_BROWSE_FRAMES = 90;
 const KEY_MODAL_FRAMES = 20;
 const RING_TANHALF = Math.tan(Math.PI / 6); // tan(30°) — projects a card for the focus ring
@@ -135,15 +129,14 @@ const CA_PX_MAX = 4; // max vertical pixel shift for the global canvas SVG filte
 const HOVER_CA = 0.025; // CA bump composed additively onto transition CA
 const HOVER_WARP = 0.4; // barrel-distortion amount sent to shader
 const HOVER_SCALE = 0.25; // scale multiplier added: 1.0 → 1.25
-const HOVER_RATE = 0.15; // per-frame lerp toward target (~125ms to 80%)
+const HOVER_RATE = 0.15; // per-frame lerp toward target
 
 // Progressive texture reveal: per-card un-dissolve once its photo lands. See buildCards + onEach.
-const REVEAL_RATE = 0.06; // per-frame reveal ease (~0.28s @60fps)
+const REVEAL_RATE = 0.06; // per-frame reveal ease
 // One-time masonry (sm barrel) reflow after all textures load, if the barrel is already formed.
-const MASONRY_MORPH_RATE = 0.05; // per-frame ease of the position/scale morph (~0.33s)
+const MASONRY_MORPH_RATE = 0.05; // per-frame ease of the position/scale morph
 
-// Near-camera proximity fade (zoom-through): dissolve a card by its depth in front of the
-// lens before it can fill the frame. Thresholds in card-heights. See README (near fade).
+// Near-camera proximity fade, in card-heights of depth.
 const FACING_EDGE_ON_BAND = 0.25; // |normal.z| half-width of the facing fade-out band
 const DRAG_FLIP_MAX_CAM_FRAC = 0.95; // ceiling on dragFlipZ as a fraction of CAM_Z_SPHERE
 const NEAR_FADE_START = 2.5; // begin fading below 2.5 card-heights depth
@@ -155,7 +148,7 @@ const SPHERE_DRAG_WARP_BASELINE = 0.05; // constant while isDragging
 const SPHERE_DRAG_WARP_VEL = 3.5; // multiplier on drag-speed
 const SPHERE_DRAG_WARP_MAX = 0.25; // cap on combined value
 
-// "Click & Drag" hint text (WebGL plane behind the sphere). See README (Behavior notes).
+// "Click & Drag" hint text (WebGL plane behind the sphere).
 const TEXT_BEHIND_GAP = 15; // world units behind the sphere's back surface
 const TEXT_WARP_ENTER_MAX = 4.50; // uWarp at entrance
 const TEXT_OPACITY_PEAK = 0.15; // opacity at peak fade-in
@@ -166,9 +159,8 @@ const TEXT_DRAG_WARP_MUL = 3.0; // text drag-warp vs sphere cards — more viole
 const TEXT_WARP_OVERFLOW = 0.6; // extra mesh scale per warp unit — letterforms bleed off
 
 const GOLDEN_ANGLE = Math.PI * (1 + Math.sqrt(5));
-// Cylindrical masonry layout — a WHOLE-SET solve (card heights depend on image aspects, so
-// balancing columns needs all of them). Cards packed greedily into the shortest column;
-// column count = fewest that fit `colsFit` of the frustum. Returns { pos, w, h } per card.
+// Cylindrical masonry layout — a WHOLE-SET solve; returns { pos, w, h } per card.
+// See README (yaw-only geometry) for the packing + column-count rules.
 function cylinderMasonryLayout({
   aspects, radius, frustumH, colsFit, gapRatio, aspectCap, bulge = 0,
 }) {
@@ -211,8 +203,7 @@ function cylinderMasonryLayout({
   }
 
   const cols = packed.totals.length;
-  // Barrel bulge: r(t) = radius·(1 − bulge·t²), t = 2y/wallH ∈ [−1,1] — curves the
-  // silhouette while columns keep constant azimuth (straight alignment preserved).
+  // Barrel bulge: r(t) = radius·(1 − bulge·t²), t = 2y/wallH ∈ [−1,1]. Azimuth is untouched.
   const wallH = packed.wallH || 1;
   return packed.placed.map((p, i) => {
     // Centre each column's own stack vertically (reads as masonry, not a ragged edge).
@@ -221,8 +212,7 @@ function cylinderMasonryLayout({
     const azimuth = (2 * Math.PI * p.col) / cols;
     const t = Math.max(-1, Math.min(1, (2 * y) / wallH));
     const r = radius * (1 - bulge * t * t);
-    // Outward normal of the surface of revolution r(y): (1, −dr/dy) normalized, swung to
-    // this azimuth, so buildCards can aim the card flat against its own tilted surface.
+    // Outward normal of the surface of revolution r(y): (1, −dr/dy) normalized, at this azimuth.
     const dRdy = bulge === 0 ? 0 : radius * -2 * bulge * t * (2 / wallH);
     const nScale = 1 / Math.hypot(1, dRdy);
     return {
@@ -253,9 +243,8 @@ function fibSpherePos(i, total, radius) {
   );
 }
 
-// Factory returning { init, destroy }. `root` is the block element; all DOM lookups are
-// scoped to it (root.querySelector) so >1 globe can coexist. `gid` is this instance's
-// unique-id suffix (minted by buildGlobeDom) so the CA filter url(#…) ref matches its node.
+// Factory returning { init, destroy }. All DOM lookups are scoped to `root` so >1 globe can
+// coexist; `gid` is this instance's unique-id suffix (CA filter url(#…) ref).
 function createGlobeGalleryRuntime(
   authoredCards,
   hintText,
@@ -275,12 +264,10 @@ function createGlobeGalleryRuntime(
 
   let reducedMotion = false;
 
-  // Active breakpoint profile — frozen, constant within a band. Assigned by resolveBpProfile
-  // in initRuntime, rebuilt on a band crossing. null until then — do NOT read at module load.
+  // Frozen, constant within a band; rebuilt on a crossing. null until initRuntime runs.
   let bp = null;
 
-  // Resolve a band's static cfg into the active profile. Pure — returns a frozen object.
-  // `cylinder` (from usesCylinderGeometry) selects the shape constants.
+  // Resolve a band's cfg into the active profile (pure, frozen). `cylinder` picks the shape keys.
   function resolveBpProfile(name, cfg, cylinder) {
     // N_TOTAL follows the authored count, capped only where a band sets N_MAX (sm: 24).
     const nTotal = cfg.N_MAX > 0
@@ -324,8 +311,7 @@ function createGlobeGalleryRuntime(
       CYL_FRUSTUM_H: 2 * Math.tan(Math.PI / 6) * cfg.CAM_Z_SPHERE,
       CARD_ROLL_JITTER: cfg.CARD_ROLL_JITTER,
       DRAG_GEARING: cfg.DRAG_GEARING,
-      // Dense-arc cluster as a share of the count (count-independent ratio); clamped below
-      // nTotal-1 so the spread region always keeps at least one card.
+      // Share of the count (count-independent), clamped so the spread keeps ≥1 card.
       ARC_DENSE_COUNT: Math.min(
         Math.round(cfg.ARC_DENSE_FRACTION * nTotal),
         Math.max(0, nTotal - 1),
@@ -345,8 +331,7 @@ function createGlobeGalleryRuntime(
   let gridCardW = 0; let
     gridTilts = [];
 
-  // Persistent clock context + its input (see src/timeline.js). frameState is the single source
-  // for the clocks — don't cache them in the closure. See README (Module layout).
+  // Persistent clock context + input. The single source for the clocks — never cache them.
   const frameState = TL.createFrame();
   const frameInput = TL.createFrameInput();
 
@@ -379,11 +364,9 @@ function createGlobeGalleryRuntime(
   let textMesh = null;
   let textExitProgress = 0;
 
-  // Per-card sphere-rotation state. Drag rotation is applied MANUALLY per card in tick()'s
-  // sphere/fold blocks (sphereGroup.rotation stays identity). Source is a pitch/yaw Euler
-  // pair; sphereRotQuat is rebuilt each frame and shared by reference into modal.js. 'XYZ'
-  // keeps the clamped pitch as the outer rotation (self-levels; no gimbal flip). See README
-  // (Sphere rotation). x = pitch, y = yaw, z = keyboard-uprighting roll.
+  // x = pitch, y = yaw, z = keyboard-uprighting roll. Applied MANUALLY per card (sphereGroup
+  // .rotation stays identity); sphereRotQuat is rebuilt each frame and shared into modal.js by
+  // reference. Euler order 'XYZ' is load-bearing — see README (Sphere rotation).
   const sphereOrient = { x: 0, y: 0, z: 0 };
   // Pitch cap that glides ±85°→±60° when leaving browse (see updateSphereRotation).
   let pitchReleaseCap = Math.PI / 3;
@@ -408,7 +391,7 @@ function createGlobeGalleryRuntime(
   const wpScratch = {};
   const stageScratch = {};
 
-  // Sphere-to-card alignment tween. See README (Module layout → grouped closure state).
+  // Sphere-to-card alignment tween.
   const navNudge = {
     active: false,
     targetX: 0,
@@ -424,8 +407,7 @@ function createGlobeGalleryRuntime(
   const kbTargetEuler = new THREE.Euler(0, 0, 0, 'XYZ');
   const kbUp = new THREE.Vector3(); // scratch: focused card's world up (for the upright roll)
   let wasBrowsing = false; // tracks the keyboard-gallery browse edge
-  // Return the sphere to its upright resting orientation. Shared by the scroll-out zero and
-  // the rebuild. Does NOT touch drag velocity or sphereDragWarp (callers handle those).
+  // Back to the upright resting orientation. Does NOT touch drag velocity or sphereDragWarp.
   function resetSphereOrientation() {
     sphereOrient.x = 0;
     sphereOrient.y = 0;
@@ -451,9 +433,7 @@ function createGlobeGalleryRuntime(
 
   let arcCtx = null; // current arc context, rebuilt per frame in tick() via buildArcCtx
 
-  // Grid layout — GRID_COLS/ROWS are the NOMINAL grid (size, gap, centering origin);
-  // totalW/totalH derive from the nominal dims so adding cards never shifts already-placed cards.
-  // See README (Card count).
+  // GRID_COLS/ROWS are NOMINAL (size, gap, origin) so adding cards never shifts placed ones.
   function computeGridLayout() {
     if (cards.length === 0) return;
     const { GRID_COLS, GRID_ROWS, CARD_W_SPHERE } = bp;
@@ -530,9 +510,8 @@ function createGlobeGalleryRuntime(
         ? mas.pos.clone()
         : fibSpherePos(i, N_TOTAL, SPHERE_R);
 
-      // Face outward: masonry aims along its computed surface normal (flat against the
-      // barrel); the sphere aims at the origin. lookAt target is INSIDE the surface (sp −
-      // normal) so local +Z points out.
+      // Face outward: masonry along its surface normal, sphere at the origin. lookAt target is
+      // INSIDE the surface so local +Z points out.
       const faceTarget = mas
         ? sp.clone().sub(mas.normal)
         : new THREE.Vector3(0, 0, 0);
@@ -554,13 +533,12 @@ function createGlobeGalleryRuntime(
         gridCol: GRID_COLS - 1 - Math.floor(i / GRID_ROWS),
         gridRow: GRID_ROWS - 1 - (i % GRID_ROWS),
         peelJitter: Math.random(),
-        // The only per-card texture value stored; every phase's fit derives from it. See README.
+        // The only per-card texture value stored; every phase's fit derives from it.
         srcAspect,
         // Sphere-phase scale: native aspect, or the masonry's solved world size as a scale.
         sphereScaleSX: mas ? mas.w / CARD_W_SPHERE : srcAspect / CARD_ASPECT,
         sphereScaleSY: mas ? mas.h / CARD_H_SPHERE : 1,
-        // This card's ACTUAL rendered world height — the near fade is in card-heights, and on
-        // masonry CARD_H_SPHERE is only the geometry base. See README (near fade).
+        // ACTUAL rendered world height: on masonry CARD_H_SPHERE is only the geometry base.
         sphereWorldH: mas ? mas.h : CARD_H_SPHERE,
         hoverT: 0, // eased 0→1 hover progress (sphere phase only)
         hoverTarget: 0, // instant 0|1 set by onHover() raycast
@@ -580,10 +558,8 @@ function createGlobeGalleryRuntime(
     computeGridLayout();
   }
 
-  // Drag-flip threshold: camera z below which drag inverts, anchored to where cards VANISH
-  // (front wall's max radial distance + the tallest card's fade-end) so the flip lands with
-  // the dissolve. Fold in sphereGroup.scale (RM shrinks the group on md). See README.
-  // Recomputed once all textures land, since sphereWorldH starts at a placeholder aspect.
+  // Camera z below which drag inverts, anchored to where cards VANISH so the flip lands with the
+  // dissolve. Recomputed once textures land (sphereWorldH starts at a placeholder).
   function recomputeDragFlip() {
     if (!sphereGroup || cards.length === 0) return;
     const groupScale = sphereGroup.scale.x || 1;
@@ -592,16 +568,15 @@ function createGlobeGalleryRuntime(
       0,
     ) * groupScale;
     const maxCardH = cards.reduce((m, c) => Math.max(m, c.sphereWorldH), 0) * groupScale;
-    // Clamped below the zoom-start distance (DRAG_FLIP_MAX_CAM_FRAC) so the flip stays inside
-    // the zoom-through.
+    // Clamped below the zoom-start distance so the flip stays inside the zoom-through.
     dragFlipZ = Math.min(
       maxRadial + NEAR_FADE_END * maxCardH,
       bp.CAM_Z_SPHERE * DRAG_FLIP_MAX_CAM_FRAC,
     );
   }
 
-  // Sphere-phase sizing for one card from its loaded image aspect (non-masonry path). Read live
-  // each frame by placeSphereCard, so updating these "morphs" the card into its native shape.
+  // Sphere-phase sizing from the loaded aspect (non-masonry). Read live each frame, so writing
+  // these morphs the card into its native shape.
   function updateCardSphereSizing(card, srcAspect) {
     card.srcAspect = srcAspect;
     card.sphereScaleSX = srcAspect / CARD_ASPECT;
@@ -609,9 +584,8 @@ function createGlobeGalleryRuntime(
     card.sphereWorldH = bp.CARD_H_SPHERE;
   }
 
-  // sm barrel only: masonry packing needs every image aspect, so it's solved once with placeholder
-  // aspects up front and re-solved here after all textures land. Each card morphs from its
-  // provisional slot to the final one (invisible if the user is still in arc/grid). See onDone.
+  // sm barrel: re-solve the whole-set packing once every aspect is known; each card morphs to its
+  // final slot. See README (progressive texture reveal).
   function resolveMasonryLayout() {
     const { N_TOTAL, SPHERE_R, CARD_W_SPHERE, CARD_H_SPHERE } = bp;
     const masonry = cylinderMasonryLayout({
@@ -696,16 +670,13 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  // Card facing — tilts limb cards partway toward the camera so edge-on slivers stay legible.
-  // MUST be per-frame (the sphere rotates). Target is sign(n.z) × view dir so back cards keep
-  // facing away. k=0 is a true sphere (no-op). `amount` (fold passes fdE) eases the tilt in.
-  // Operates on a Quaternion in place (also modal.js's close-anim target). See README.
+  // Tilts limb cards partway toward the camera (edge-on legibility); mutates the quat in place.
+  // Target is sign(n.z) × view dir so back cards keep facing away; k=0 is a no-op.
   function applySphereFacing(quat, amount = 1) {
     let k = bp.CARD_FACE_CAMERA * amount;
     if (!k) return;
     cardNormal.set(0, 0, 1).applyQuaternion(quat); // current outward normal (local +Z)
-    // Fade to 0 across a band around edge-on so the target's sign flip (normal.z crossing 0)
-    // doesn't teleport the card ~63°. See README (FACING_EDGE_ON_BAND).
+    // Fade out around edge-on, else the target's sign flip teleports the card.
     const edgeOnT = Math.min(1, Math.abs(cardNormal.z) / FACING_EDGE_ON_BAND);
     k *= edgeOnT * edgeOnT * (3 - 2 * edgeOnT); // smoothstep — C1, so no velocity kink
     if (k < 1e-6) return;
@@ -718,8 +689,7 @@ function createGlobeGalleryRuntime(
 
   const applyCardFacing = (mesh, amount = 1) => applySphereFacing(mesh.quaternion, amount);
 
-  // Set a card to its sphere slot with the current drag rotation baked in, so a reparent
-  // doesn't flash an unrotated card for one frame before tick() re-applies rotation.
+  // Sphere slot with the live drag rotation baked in, so a reparent can't flash it unrotated.
   function snapCardToSphereSlot(card) {
     if (!card || !card.mesh) return;
     const hasRot = (sphereOrient.y !== 0 || sphereOrient.x !== 0 || sphereOrient.z !== 0);
@@ -737,10 +707,8 @@ function createGlobeGalleryRuntime(
     card.hoverT = 0;
   }
 
-  // Shared: the sphere yaw + pitch that bring card `idx` to screen centre. Yaw is exact
-  // (rotate spherePos about Y by the current yaw, null its x). Pitch drives height → 0,
-  // clamped to `pitchCap`. yawOnly holds pitch (cylinder can't centre vertically). Inside the
-  // globe both terms flip to the far (−Z) wall. Used by the modal + keyboard gallery.
+  // Shared solve: the yaw + pitch bringing card `idx` to screen centre (yawOnly holds pitch — a
+  // cylinder can't centre vertically). Inside the globe both flip to the far wall.
   function cardCenterYawPitch(idx, pitchCap, yawOnly) {
     const { spherePos } = cards[idx];
     const cy = Math.cos(sphereOrient.y);
@@ -773,9 +741,8 @@ function createGlobeGalleryRuntime(
     navNudge.active = true;
   }
 
-  // Keyboard-gallery centring: rotate so card `idx` lands dead-centre and stands upright.
-  // Injected into a11y.js as centerCard. Yaw + pitch from the shared solve; the extra term is
-  // the upright screen-Z roll cancelling the card's residual tilt (eased back to 0 on exit).
+  // Keyboard-gallery centring (a11y.js's centerCard): the shared yaw/pitch solve plus the
+  // screen-Z roll that cancels the card's residual tilt. See README (Accessibility).
   function centerCardOnScreen(idx) {
     if (!cards[idx]) return;
     const { sphereQuat } = cards[idx];
@@ -803,8 +770,8 @@ function createGlobeGalleryRuntime(
     drag.velY = 0;
   }
 
-  // Motion-trail CA. dx/dy: world-space position delta this frame. ampOverride: optional 0-1;
-  // when omitted, derived from max(scroll velocity, drag speed) so spin + modal both drive CA.
+  // Motion-trail CA. dx/dy: world-space delta this frame. ampOverride defaults to
+  // max(scroll velocity, drag speed).
   function applyMotionCA(mesh, dx, dy, ampOverride, strength) {
     if (!CA_ENABLED) return;
     const { CARD_W_SPHERE, CARD_H_SPHERE } = bp;
@@ -822,8 +789,7 @@ function createGlobeGalleryRuntime(
     mesh.material.uniforms.uMotionDir.value.set(mx, my);
   }
 
-  // Cover-crop + corner aspect for the shape the card is drawn at THIS frame; `planeAspect`
-  // defaults to the mesh's live scale. See README (Architecture notes).
+  // Cover-crop + corner aspect for THIS frame's shape. See README (Architecture notes).
   const uvScratch = {};
   function applyCardFit(mesh, card, planeAspect) {
     const aspect = planeAspect !== undefined
@@ -836,8 +802,7 @@ function createGlobeGalleryRuntime(
     u.uAspect.value = aspect;
   }
 
-  // Modal DI module — assigned after the helpers its callbacks depend on. Reads live state via
-  // getters; reaches the sphere only through sphereRotQuat + the snap/nudge callbacks.
+  // Modal DI module — assigned after the helpers its callbacks depend on.
   modal = createGlobeModal({
     q,
     getScene: () => scene,
@@ -847,8 +812,8 @@ function createGlobeGalleryRuntime(
     getCards: () => cards,
     getCount: () => CARD_CONTENT.length,
     getCardMetadata,
-    // Lazily load a sharper texture for the opened card. Returns the pending Image (so the
-    // modal can cancel it) or null when the base cap already meets the modal cap (reuse, no load).
+    // Sharper texture for the opened card. Returns the pending Image (cancellable), or null when
+    // the base cap already meets the modal cap.
     loadModalUpgrade: (idx, onReady, onError) => {
       const base = bp.name === 'sm' ? CARD_TEX_SM : CARD_TEX_MD;
       const modalCap = bp.name === 'sm' ? MODAL_TEX_SM : MODAL_TEX_MD;
@@ -875,20 +840,18 @@ function createGlobeGalleryRuntime(
     restoreFocusOnClose: (idx) => { if (a11y && a11y.isBrowsing()) a11y.focusCard(idx); },
   });
 
-  // Block top in document space + full scroll length. See README (Scroll model).
+  // Block top in document space + full scroll length.
   function measureBlock() {
     blockDocTop = root.getBoundingClientRect().top + window.scrollY;
     blockHeight = root.offsetHeight || (TL.CSS_FALLBACK.RUNWAY_VH / 100) * H;
   }
 
-  // Scroll px from the block top where the sphere is fully formed (progress = foldLast); locked to
-  // --gg-formation-vh, clamped to the runway. See README (Scroll model).
+  // Scroll px from the block top where the sphere is formed. See README (Scroll model).
   function formedScrollPx() {
     return Math.min((formationVh / 100) * H, blockHeight);
   }
 
-  // Focusing the widget snaps the page to the interactive globe state (formed-sphere offset;
-  // block top under RM). Deferred a frame so focus settles first (pdf-space). See README.
+  // Focus snaps the page to the interactive globe state, deferred a frame so focus settles.
   function snapToInteractive() {
     if (suppressFocusSnap) return;
     const top = reducedMotion
@@ -900,8 +863,7 @@ function createGlobeGalleryRuntime(
     });
   }
 
-  // Focus-snap guard: a tab-return refocuses the widget and would re-fire the snap. Arm on
-  // blur/hidden; disarm a frame after focus so the synchronous refocus stays suppressed.
+  // Guard: armed on blur/hidden, disarmed a frame after focus, so a tab-return can't re-snap.
   const armFocusGuard = () => { suppressFocusSnap = true; };
   const disarmFocusGuard = () => { requestAnimationFrame(() => { suppressFocusSnap = false; }); };
   const onVisibilityChange = () => {
@@ -940,8 +902,7 @@ function createGlobeGalleryRuntime(
     gid,
   });
 
-  // Desktop custom cursor (no-op on touch). Created before interaction so its isActive()
-  // can gate interaction's hover cursor writes (the two share the canvas).
+  // Created before interaction so isActive() can gate its hover-cursor writes (shared canvas).
   cursor = createCursor({
     getCanvas: () => (renderer ? renderer.domElement : null),
     getSphereInteractive: () => frameState.sphereFormT >= TL.SPHERE_INTERACTIVE_T,
@@ -956,8 +917,7 @@ function createGlobeGalleryRuntime(
     drag,
   });
 
-  // Rad per pointer px, live off the viewport + band: bp.DRAG_GEARING as a fraction of true 1:1
-  // surface tracking (90° per on-screen ball radius). See README (Drag physics).
+  // Rad per pointer px, live off the viewport + band. See README (Drag physics).
   const dragSensitivity = () => {
     const radiusPx = (bp.SPHERE_R * H) / bp.CYL_FRUSTUM_H;
     return ((Math.PI / 2) * bp.DRAG_GEARING) / Math.max(1, radiusPx);
@@ -979,9 +939,8 @@ function createGlobeGalleryRuntime(
     getYawOnly: () => bp.YAW_ONLY,
   });
 
-  // Per-frame pipeline. tick() is a thin orchestrator over the single-concern stages below;
-  // computeFrame builds one `frameState` context, producer stages write results back onto it.
-  // Stage order matters (see tick()'s note). See README (Module layout).
+  // Per-frame pipeline: computeFrame builds one `frameState`, producer stages write back onto it.
+  // Stage order is load-bearing — see README (Module layout).
 
   // Refresh the derivation's input from live layout/scroll state, then derive onto frameState.
   function computeFrame() {
@@ -999,11 +958,8 @@ function createGlobeGalleryRuntime(
     return frameState;
   }
 
-  // Pick + position the camera for this frame and return it.
-  //   Arc phase (no folding yet): ortho — flat 2D.
-  //   Fold phase: perspective approaching CAM_Z_SPHERE in lockstep with the fold so
-  //     the sphere reaches normal size exactly when cards finish folding.
-  //   Zoom-through: perspective continuing CAM_Z_SPHERE → CAM_Z_END.
+  // Pick + position the camera: ortho on the arc, perspective from the fold on. See README
+  // (Lifecycle timeline).
   function updateActiveCamera(frame) {
     const { sphereFormT, zoomT } = frame;
     const { CAM_Z_SPHERE, CAM_Z_END } = bp;
@@ -1015,44 +971,33 @@ function createGlobeGalleryRuntime(
       camera.updateProjectionMatrix();
     } else {
       activeCamera = camera;
-      // Approach uses easeInCubic (accelerates in, matching the zoom's easeOutCubic). Sphere
-      // apparent size is held by the sphereGroup.position.z offset, not camera proximity.
+      // easeInCubic matches the zoom's easeOutCubic. Apparent size is held by sphereGroup.z.
       const camZ = zoomT === 0
         ? lerpN(camZArc, CAM_Z_SPHERE, sphereFormT * sphereFormT * sphereFormT)
         : lerpN(CAM_Z_SPHERE, CAM_Z_END, easeOutCubic(zoomT));
       camera.position.z = camZ;
       camera.updateProjectionMatrix();
     }
-    // Flip the drag once the camera is INSIDE (near wall's cards gone). Threshold is dragFlipZ
-    // (derived in buildCards from where cards actually disappear), not SPHERE_R.
+    // Flip the drag once the camera is INSIDE; the threshold is dragFlipZ, not SPHERE_R.
     cameraInsideSphere = zoomT > 0 && Math.abs(camera.position.z) < dragFlipZ;
     return activeCamera;
   }
 
-  // Sphere rotation (drag inertia + auto-rotate) + nav-nudge ease + drag-warp easing. Returns
-  // sphereRotActive and refreshes sphereRotQuat. Rotation is applied PER-CARD (scaled by fdE)
-  // in updateCardTransform, not to sphereGroup.rotation (kept identity for world-matrix queries).
+  // Drag inertia + auto-rotate + nav-nudge + drag-warp. Returns sphereRotActive and refreshes
+  // sphereRotQuat; the rotation itself is applied per-card in updateCardTransform.
   function updateSphereRotation(frame) {
     const { sphereFormT, dtScale } = frame;
     sphereGroup.rotation.x = 0;
     sphereGroup.rotation.y = 0;
 
-    // Drained unconditionally — pooled travel must never dump on resume.
-    const pendX = drag.pendingX;
-    const pendY = drag.pendingY;
-    drag.pendingX = 0;
-    drag.pendingY = 0;
-
-    // Leaving browse: cancel any in-flight nudge so its targets stop fighting resumed
-    // auto-spin + the drag clamp. The pitch excess eases back to 60° below.
+    // Leaving browse: cancel the nudge so its targets stop fighting resumed auto-spin.
     const browsing = a11y && a11y.isBrowsing();
     if (wasBrowsing && !browsing) {
       navNudge.active = false;
     }
     wasBrowsing = browsing;
 
-    // Sphere-to-card alignment ease. Runs even while the modal is open (so the sphere aligns
-    // behind the blur), a frame-counted easeInOutCubic tween toward the nudge target.
+    // Card-alignment tween. Runs while the modal is open too (the sphere aligns behind the blur).
     if (navNudge.active) {
       navNudge.frame += 1;
       const e = easeInOutCubic(Math.min(1, navNudge.frame / navNudge.frames));
@@ -1065,19 +1010,35 @@ function createGlobeGalleryRuntime(
     // no auto-spin, but inertia keeps coasting. See README (Drag physics).
     const frozen = modal.getModalIdx() >= 0;
     const interactive = sphereFormT >= TL.SPHERE_INTERACTIVE_T;
+    // Consume the banked travel; anything but held-and-live drops it (no pooling on resume).
+    const holding = drag.isDragging && !frozen && interactive;
+    let stepX = 0;
+    let stepY = 0;
+    if (holding) {
+      // Jerk limiter: under one frame's worth of rotation passes through exactly, past it the step
+      // is capped then eased and the rest stays banked. See README (Drag physics).
+      const maxStep = MAX_VEL * dtScale;
+      const catchup = 1 - (1 - DRAG_CATCHUP) ** dtScale;
+      const limit = (v) => (Math.abs(v) <= maxStep
+        ? v
+        : Math.max(-maxStep, Math.min(maxStep, v * catchup)));
+      stepX = limit(drag.pendingX);
+      stepY = limit(drag.pendingY);
+      drag.pendingX -= stepX;
+      drag.pendingY -= stepY;
+    } else {
+      drag.pendingX = 0;
+      drag.pendingY = 0;
+    }
     if (!frozen) {
-      // Inside the globe the far wall moves opposite the same world rotation, so negate the
-      // delta to keep dragging tracking the surface the user sees.
+      // Inside the globe the far wall moves opposite, so negate to track the visible surface.
       const dragDir = cameraInsideSphere ? -1 : 1;
       // Yaw (y) spins freely; pitch (x) is clamped below so the globe self-levels.
       if (drag.isDragging) {
-        // Held: position-driven off the exact travel — no smoothing lag.
-        if (interactive) {
-          sphereOrient.y += pendX * dragDir;
-          sphereOrient.x += pendY * dragDir;
-        } else {
-          drag.velX = 0; drag.velY = 0; // an inert mid-fold drag must not fling on release
-        }
+        // Held: position-driven off the (rate-limited) travel — no smoothing lag on normal frames.
+        sphereOrient.y += stepX * dragDir;
+        sphereOrient.x += stepY * dragDir;
+        if (!interactive) { drag.velX = 0; drag.velY = 0; } // inert mid-fold: must not fling
       } else {
         // Released: velocity-driven coast. Both rates are per 60fps frame → rescaled by dtScale.
         const friction = DRAG_FRICTION ** dtScale;
@@ -1089,8 +1050,7 @@ function createGlobeGalleryRuntime(
         sphereOrient.y += (drag.velX + spin) * dtScale * dragDir;
         sphereOrient.x += drag.velY * dtScale * dragDir;
       }
-      // Pitch cap glides via pitchReleaseCap: ±60° for drag, up to ±85° while browsing, easing
-      // back to 60° (PITCH_RELAX) after browse so leaving a beyond-cap card slides, not snaps.
+      // pitchReleaseCap glides the browse cap back to the resting one.
       const RESTING_PITCH = Math.PI / 3;
       if (browsing) {
         sphereOrient.x = Math.max(-KEY_PITCH_CAP, Math.min(KEY_PITCH_CAP, sphereOrient.x));
@@ -1109,8 +1069,7 @@ function createGlobeGalleryRuntime(
       }
     }
 
-    // Sphere-drag warp: baseline (while held) + velocity burst, eased toward a target rather
-    // than snapped (a hard drop popped the barrel distortion when the modal opened).
+    // Drag warp: baseline while held + velocity burst, EASED toward the target, never snapped.
     let warpTarget = 0;
     if (!frozen && interactive) {
       const dragSpeed = Math.sqrt(drag.velX * drag.velX + drag.velY * drag.velY);
@@ -1120,8 +1079,7 @@ function createGlobeGalleryRuntime(
     sphereDragWarp += (warpTarget - sphereDragWarp) * 0.20;
     if (Math.abs(sphereDragWarp) < 0.001) sphereDragWarp = 0;
 
-    // Full reset (orientation + inertia) only at the very top of the section — a dip mid-scroll
-    // keeps both.
+    // Full reset (orientation + inertia) only at the very top — a dip mid-scroll keeps both.
     if (sphereFormT < TL.SPHERE_ORIENT_RESET_T) {
       resetSphereOrientation();
       drag.velX = 0;
@@ -1134,8 +1092,7 @@ function createGlobeGalleryRuntime(
     return sphereRotActive;
   }
 
-  // Project the focused browse image to screen space each frame so a11y.js's :focus-visible
-  // ring hugs it as the nudge rotates it to centre. Closed-form (camera at (0,0,z), 60° FOV).
+  // Project the focused browse image to screen space so a11y.js's ring hugs it (closed-form).
   const ringWorld = new THREE.Vector3();
   function updateA11yFocusRing() {
     const idx = a11y.getFocusedIdx();
@@ -1176,8 +1133,7 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  // Pull-quote: JS adds .is-active once zoomT crosses pqAppearZoomT (sticky handles exit). On
-  // scroll-up, a fast 0.15s fade so it disappears before the sticky element drifts down.
+  // JS only adds .is-active past pqAppearZoomT; CSS sticky handles the exit.
   function updatePullQuote(frame) {
     const { zoomT, scrollingDown } = frame;
     // Reduced motion: CSS owns it (opacity:1, no reveal) — no JS toggling.
@@ -1197,9 +1153,8 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  // During fold: slide sphereGroup forward so the sphere-camera distance lerps FOLD_SPHERE_DIST
-  // → CAM_Z_SPHERE. Cards not yet on the sphere subtract sphGroupZ so they stay at world z≈0.
-  // Runs at sphereFormT===0 too so sphGroupZ is CONTINUOUS at that boundary (else a forward dart).
+  // Slides sphereGroup forward over the fold (cards not yet on the sphere subtract sphGroupZ).
+  // Must run at sphereFormT===0 too, for continuity — see README (Architecture notes).
   function updateSphereGroupDepth(frame) {
     const { sphereFormT, zoomT } = frame;
     const { FOLD_SPHERE_DIST, CAM_Z_SPHERE } = bp;
@@ -1212,8 +1167,7 @@ function createGlobeGalleryRuntime(
     return sphGroupZ;
   }
 
-  // Global chromatic-aberration SVG filter on the canvas: vertical R/B shift tracks scroll
-  // velocity, cleared on settle.
+  // Canvas-wide CA filter: vertical R/B shift tracks scroll velocity, cleared on settle.
   function updateGlobalCA() {
     if (!bp.GLOBAL_CA) {
       if (globalCaFilterOn) {
@@ -1268,9 +1222,7 @@ function createGlobeGalleryRuntime(
     modal.render();
   }
 
-  // Card transform stage. Each card runs one phase branch per frame: arc → peel → grid-dwell →
-  // fold → sphere. The four place*Card branches + dispatcher stay in this file (they read deeply
-  // from the closure). Per-frame values come from the shared `frame` context. See README.
+  // One phase branch per card per frame: arc → peel → grid-dwell → fold → sphere.
 
   // Branch: fully in sphere.
   function placeSphereCard(card, mesh, cardCA, frame) {
@@ -1283,8 +1235,8 @@ function createGlobeGalleryRuntime(
     } else {
       mesh.position.copy(card.spherePos);
     }
-    // Near-camera proximity fade: card depth in front of the lens (world z = sphGroupZ +
-    // mesh.position.z). Cull only at depth ≤ 0 (not the fade edge, else scroll jitter flashes it).
+    // Prox fade by depth in front of the lens. Cull only at depth ≤ 0 — culling at the fade edge
+    // lets scroll jitter flash the card.
     const depth = camera.position.z - (sphGroupZ + mesh.position.z);
     if (depth <= 0) { mesh.visible = false; return; }
     // Thresholds scale with THIS card's rendered height (card.sphereWorldH), not the geometry base.
@@ -1300,8 +1252,8 @@ function createGlobeGalleryRuntime(
     }
     applyCardFacing(mesh);
     mesh.renderOrder = 0;
-    // Compose the near-camera proximity fade with the texture-ready reveal (both drive dissolve +
-    // opacity): take the max dissolve / min opacity so neither un-hides what the other hides.
+    // Prox fade + texture reveal both drive dissolve/opacity: max dissolve, min opacity, so
+    // neither un-hides what the other hides.
     const proxDis = 1 - proxFade;
     const revealDis = 1 - card.revealT;
     mesh.material.opacity = Math.min(proxFade ** NEAR_FADE_OPACITY_BIAS, card.revealT);
@@ -1309,8 +1261,7 @@ function createGlobeGalleryRuntime(
     mesh.material.uniforms.uDisperse.value = proxDis;
     mesh.material.uniforms.uReveal.value = card.revealT;
     mesh.material.uniforms.uContourFade.value = proxFade;
-    // Hover composes additively on transition CA. uHoverPos anchors the warp at the cursor UV
-    // when hovered; otherwise the drag warp uses the card centre (0.5, 0.5).
+    // Hover CA is additive on transition CA; uHoverPos anchors the warp at the cursor UV.
     if (CA_ENABLED) {
       mesh.material.uniforms.uCA.value = cardCA + card.hoverT * HOVER_CA;
       mesh.material.uniforms.uWarp.value = card.hoverT * HOVER_WARP + sphereDragWarp;
@@ -1324,8 +1275,7 @@ function createGlobeGalleryRuntime(
     applyMotionCA(mesh, card.spherePos.z * drag.velX, -card.spherePos.z * drag.velY);
   }
 
-  // Branch: grid → sphere fold. Lerps FROM the card's live `stage` transform (collapses to the
-  // grid slot at gpE >= 1) TO its sphere slot by fdE, so the fold can open mid-peel without a snap.
+  // Branch: grid → sphere fold, lerping from the live `stage` transform by fdE.
   function placeFoldingCard(card, mesh, fdE, stage, prevMeshX, prevMeshY, frame) {
     const { sphereRotActive } = frame;
     mesh.visible = true;
@@ -1348,9 +1298,8 @@ function createGlobeGalleryRuntime(
       1,
     );
     applyCardFit(mesh, card); // reads the scale set just above, so the fold framing stays exact
-    // Orientation slerps gridQuat → sphereQuat (upright, not the live peel orientation, which
-    // would flip the face through the camera plane). The residual peel spin (stage.rotZ −
-    // gridTilt, → 0 at peel end) is reapplied about local Z so it spins in-plane like the peel.
+    // Slerp gridQuat → sphereQuat (the UPRIGHT grid quat, not the live peel spin), then reapply
+    // the residual peel spin about local Z. Both are load-bearing.
     if (sphereRotActive) {
       foldRotQuat.copy(sphereRotQuat).multiply(card.sphereQuat);
       mesh.quaternion.slerpQuaternions(card.gridQuat, foldRotQuat, fdE);
@@ -1362,8 +1311,7 @@ function createGlobeGalleryRuntime(
       stageQuat.setFromEuler(stageEuler.set(0, 0, residualZ));
       mesh.quaternion.multiply(stageQuat); // local-Z (in-plane) spin, post-multiply
     }
-    // Blend the facing tilt in over the fold (scaled by fdE) so it lands continuous with
-    // placeSphereCard (else it snaps when fdE hits 1).
+    // Blend the facing tilt in by fdE so it lands continuous with placeSphereCard.
     applyCardFacing(mesh, fdE);
     mesh.renderOrder = 0;
     mesh.material.opacity = 1;
@@ -1384,9 +1332,8 @@ function createGlobeGalleryRuntime(
     applyMotionCA(mesh, mesh.position.x - prevMeshX, mesh.position.y - prevMeshY);
   }
 
-  // Compute a card's live "stage" transform on the arc→grid continuum at peel ease gpE (0 = arc,
-  // 1 = grid slot). Returns { slot, x, y, z, scale, rotZ } — serves both the arc/peel render and
-  // the ORIGIN of the fold lerp (at gpE >= 1 it collapses to the grid slot).
+  // The card's live transform on the arc→grid continuum at peel ease gpE (0 = arc, 1 = grid).
+  // Serves the arc/peel render AND the origin of the fold lerp.
   function computeCardStage(card, i, gpE, frame) {
     const { arcPanT, entryRot, entryYOffset, arcScale, sphGroupZ } = frame;
     const { N_VISIBLE, ARC_DENSE_COUNT } = bp;
@@ -1416,8 +1363,8 @@ function createGlobeGalleryRuntime(
     const arcY = wp.y - entryYOffset;
     const webglRot = -fan.cssRot - entryRot;
 
-    // peelStartRot: reset on the arc; else snapshot the first peel frame's rotation, normalized
-    // within ±π of gridTilt. Direct z-angle lerp avoids the slerp hemisphere flip at atan2's wrap.
+    // peelStartRot: first peel frame's rotation, normalized within ±π of gridTilt. Direct z-angle
+    // lerp, NOT slerp — see README (Architecture notes).
     if (gpE <= 0) {
       card.peelStartRot = null;
     } else if (card.peelStartRot == null) {
@@ -1438,8 +1385,7 @@ function createGlobeGalleryRuntime(
     return stageScratch;
   }
 
-  // Branch: arc phase (waiting to peel, or peeling arc→grid). Renders the live `stage`; render
-  // order + motion-CA strength differ between the pure-arc (gpE <= 0) and peeling sub-phases.
+  // Branch: arc phase. Render order + motion-CA strength differ once the peel starts.
   function placeArcCard(card, mesh, i, gpE, stage, prevMeshX, prevMeshY) {
     const { N_TOTAL, N_VISIBLE } = bp;
     mesh.visible = true;
@@ -1463,8 +1409,7 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  // Per-card dispatcher: derive this card's timing (peel/fold easings, CA, hover), then run one
-  // phase branch. Called once per card by updateCardTransforms.
+  // Per-card dispatcher: derive timing (peel/fold easings, CA, hover), then run one branch.
   function updateCardTransform(i, frame) {
     const { progress, gridFormT, gpWin, sphereFormT, entryRot } = frame;
     const { N_TOTAL } = bp;
@@ -1474,8 +1419,7 @@ function createGlobeGalleryRuntime(
     // Skip cards the modal manages (active card + swipe-neighbors) — modal.js drives them.
     if (modal.isCardManaged(card)) return;
 
-    // Advance the texture-ready reveal (started in onEach) and the one-time sm-barrel reflow morph
-    // (set up in resolveMasonryLayout). Both must run before the branch reads revealT/spherePos.
+    // Advance the reveal + the one-time masonry morph, both BEFORE the branch reads them.
     if (card.hasTexture && card.revealT < 1) {
       card.revealT = Math.min(1, card.revealT + REVEAL_RATE);
     }
@@ -1496,8 +1440,7 @@ function createGlobeGalleryRuntime(
     const gpLocalT = Math.max(0, Math.min(1, (gridFormT - gpDelay) / Math.max(0.01, gpWin)));
     const gpE = easeOutCubic(gpLocalT);
 
-    // Grid → sphere fold: begins when this card's peel reaches FOLD_START_LOCAL_T. The gate is
-    // on the raw peel localT, not the eased gpE.
+    // Fold gate is the RAW peel localT vs FOLD_START_LOCAL_T, not the eased gpE.
     const foldStartProg = TL.cardFoldStartProgress(gpDelay);
     const fdLocalT = Math.max(0, Math.min(1, (progress - foldStartProg) / TL.PROGRESS_FOLD_DUR));
     const fdE = gpLocalT >= TL.FOLD_START_LOCAL_T ? easeInOutCubic(fdLocalT) : 0;
@@ -1514,14 +1457,12 @@ function createGlobeGalleryRuntime(
       mesh.material.uniforms.uWarp.value = 0; // sphere block re-applies from hoverT below
     }
 
-    // Hover state ease — gated on the global interactive threshold (not per-card fdE, so
-    // late-folding cards hover at sphereFormT=0.8). Visual effects render only in the sphere block.
+    // Hover ease gates on the GLOBAL interactive threshold, not per-card fdE.
     if (sphereFormT < TL.SPHERE_INTERACTIVE_T || reducedMotion) card.hoverTarget = 0;
     card.hoverT += (card.hoverTarget - card.hoverT) * HOVER_RATE;
 
-    // Contour/reveal defaults for the non-sphere phases (placeSphereCard overrides them with its
-    // own proximity+reveal combine). uDissolve doubles as the reveal un-dissolve here and the
-    // near-camera dissolve in the sphere phase, so it must be (re)set every frame.
+    // Contour/reveal defaults for the non-sphere phases. uDissolve is shared with the sphere
+    // phase's near-camera dissolve, so it must be (re)set every frame.
     mesh.material.uniforms.uReveal.value = card.revealT;
     mesh.material.uniforms.uContourFade.value = 1;
     mesh.material.uniforms.uDissolve.value = 1 - card.revealT;
@@ -1556,9 +1497,8 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  // Stage: hint-exit signal. Owns textExitProgress (0→1) driving the hint dissolve + cursor
-  // retirement. Separate from updateClickDragText because that stage early-returns before the
-  // interactive range — the scroll-out that resets this.
+  // Owns textExitProgress (hint dissolve + cursor retirement). Separate from updateClickDragText
+  // because that stage early-returns before the interactive range, which is what resets this.
   function updateHintExitProgress(frame) {
     const { sphereFormT } = frame;
     // Reset on scroll-out of the interactive range (fresh on re-entry).
@@ -1567,8 +1507,7 @@ function createGlobeGalleryRuntime(
       return;
     }
     if (reducedMotion || !drag.isDragging || textExitProgress >= 1) return;
-    // A vertical touch drag is page scroll, not a globe drag — don't accrue during it (else the
-    // hint retires before the user ever spun the globe). See interaction.js's axis lock.
+    // A vertical touch drag is page scroll, not a globe drag — don't accrue during it.
     if (interaction.isPageScrollGesture()) return;
     const spd = Math.sqrt(drag.velX * drag.velX + drag.velY * drag.velY);
     const norm = spd / MAX_VEL; // 0–1
@@ -1581,9 +1520,8 @@ function createGlobeGalleryRuntime(
     );
   }
 
-  // Stage: "Click & Drag" hint text. Warps in on fold, settles faint, fades on zoom, dissolves
-  // on first drag (textExitProgress). Reads frame.foldSphDist + live sphereDragWarp, so it runs
-  // after both. No-op until the async font build assigns textMesh. See README (Behavior notes).
+  // Hint text: warps in on fold, settles faint, fades on zoom, dissolves on first drag. Reads
+  // frame.foldSphDist + live sphereDragWarp, so it runs after both.
   function updateClickDragText(frame) {
     if (!textMesh) return;
     const { sphereFormT, zoomT, foldSphDist } = frame;
@@ -1643,9 +1581,7 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  // Per-frame tick — thin orchestrator. Builds `frame`, runs each stage in a FIXED, load-bearing
-  // order (producers before consumers; modal.updateAnimation reads the prev frame's
-  // sphereGroup.position + this frame's refreshed sphereRotQuat). Keep it intact.
+  // Thin orchestrator. Stage order is FIXED and load-bearing — see README (Module layout).
   function tick() {
     if (!renderer || !scene || !camera || !sphereGroup) return;
 
@@ -1765,8 +1701,7 @@ function createGlobeGalleryRuntime(
     reducedMotion = prefersReducedMotion();
     root.classList.toggle('globe-gallery-reduced', reducedMotion);
 
-    // Reduced motion: canvas into normal flow (absolute in the static world) so the globe
-    // scrolls away; top nudge clears the section above. See README (Reduced motion).
+    // RM: canvas into normal flow so the globe scrolls away. See README (Reduced motion).
     if (reducedMotion) {
       canvas.style.position = 'absolute';
       canvas.style.top = '8vh';
@@ -1816,10 +1751,8 @@ function createGlobeGalleryRuntime(
       W = nextW;
       H = nextH;
 
-      // A band crossing (768px) or a reduced-motion toggle rebuilds via destroy()+init()
-      // (geometry + RM layout are baked at build time); resizing within a band takes the cheap
-      // path. Pointer precision is read at init only — a mid-session mouse/trackpad swap needs a
-      // reload (out of scope; see README).
+      // A band crossing or an RM toggle rebuilds (geometry is baked at build time); resizing
+      // within a band takes the cheap path. See README (Breakpoints & rebuilds).
       const nextBand = resolveBP(W);
       const nextReducedMotion = prefersReducedMotion();
       if (nextBand.name !== bp.name || nextReducedMotion !== reducedMotion) {
@@ -1868,8 +1801,7 @@ function createGlobeGalleryRuntime(
     resizeHandler = () => doLayout({ fromResize: true });
     window.addEventListener('resize', resizeHandler, { passive: true });
 
-    // Reduced motion can toggle mid-session (OS setting) without a resize, so listen directly;
-    // doLayout rebuilds so the static/animated layout switch never needs a reload.
+    // RM can toggle mid-session without a resize, so listen directly; doLayout rebuilds.
     if (reducedMotionMQ && reducedMotionHandler) {
       reducedMotionMQ.removeEventListener('change', reducedMotionHandler);
     }
@@ -1879,8 +1811,7 @@ function createGlobeGalleryRuntime(
       reducedMotionMQ.addEventListener('change', reducedMotionHandler);
     }
 
-    // Recompute block metrics whenever page height changes (content loading above shifts
-    // offsetTop; blockHeight=0 at first paint would make progress=Infinity).
+    // Page height changes shift offsetTop; blockHeight=0 at first paint → progress=Infinity.
     if (layoutObs) layoutObs.disconnect();
     layoutObs = new ResizeObserver(() => { measureBlock(); });
     layoutObs.observe(document.body);
@@ -1913,8 +1844,7 @@ function createGlobeGalleryRuntime(
 
     modal.setup();
 
-    // Build the scene up front so the block paints immediately: cards render as contours and each
-    // photo un-dissolves in as its texture lands, instead of blocking on the whole set.
+    // Build up front so the block paints immediately; photos un-dissolve in as they land.
     buildCards();
     buildTextMesh();
     a11y.setup();
@@ -1930,8 +1860,7 @@ function createGlobeGalleryRuntime(
       if (!card) return;
       card.mesh.material.map = tex; // property proxy writes uMap
       card.srcAspect = srcAspect; // every phase's fit derives from it; the modal falls back to it
-      // md sphere also sizes the rendered card per-card now (positions are index-based, no reflow);
-      // the sm barrel packs against all aspects, so it re-solves its render sizing once in onDone.
+      // md sizes per-card in place (index-based positions); sm re-solves its packing in onDone.
       if (!bp.CYLINDER) updateCardSphereSizing(card, srcAspect);
       card.hasTexture = true; // revealT eases up in updateCardTransform
     };
@@ -1948,8 +1877,7 @@ function createGlobeGalleryRuntime(
     const cardMaxTexH = bp.name === 'sm' ? CARD_TEX_SM : CARD_TEX_MD;
     loadCardTextures({
       count: bp.N_TOTAL,
-      // Ask at the cap so slow links download ~tens of KB, not the full-res source. By HEIGHT,
-      // matching fitCardDims (the service clamps to native — it never upscales).
+      // Ask at the cap, by HEIGHT, matching fitCardDims. See README (image requests).
       getSrc: (i) => optimizeImgUrl(getCardMetadata(i).img, cardMaxTexH, 'height'),
       maxTexH: cardMaxTexH,
     }, onEachTexture, onDoneTextures);
@@ -1993,10 +1921,8 @@ function createGlobeGalleryRuntime(
     if (renderer) {
       renderer.domElement.style.filter = '';
       globalCaFilterOn = false;
-      // NOTE: do NOT forceContextLoss() here — the canvas element is reused across rebuilds
-      // (band crossings / reduced-motion toggles), and a force-lost context is never restored,
-      // so the next renderer on the same canvas is born dead ("Context Lost"). dispose() alone
-      // frees this renderer's GPU resources.
+      // Do NOT forceContextLoss() here — the canvas element is reused across rebuilds and a
+      // force-lost context never restores. See README (WebGL context loss).
       renderer.dispose();
       renderer.domElement.style.display = 'none';
     }
@@ -2029,8 +1955,7 @@ function createGlobeGalleryRuntime(
     if (arcCopy.el) arcCopy.el.style.cssText = '';
     if (pqEl) { pqEl.classList.remove('is-active'); pqEl.style.transition = ''; pqShown = false; }
     frameInput.prevLenisY = 0; frameInput.prevNow = 0; frameState.scrollVel = 0;
-    // Reset sphere orientation + drag/nudge state: the closure survives a rebuild, so without
-    // this a pre-rebuild tilt carries over. See README (destroy resets).
+    // The closure survives a rebuild, so a pre-rebuild tilt would carry over.
     resetSphereOrientation();
     sphereDragWarp = 0;
     drag.isDragging = false;
@@ -2043,7 +1968,7 @@ function createGlobeGalleryRuntime(
 }
 
 export default async function init(el) {
-  // Reduced motion: static, still-interactive globe in plain document flow. See README.
+  // Reduced motion: static, still-interactive globe in plain document flow.
   if (prefersReducedMotion()) {
     el.classList.add('globe-gallery-reduced');
   }
@@ -2053,8 +1978,7 @@ export default async function init(el) {
     arcCopy, pullQuote, hintText, instructions, labels, fragmentHref,
   } = parseAuthoredContent(el);
 
-  // buildGlobeDom mints + returns the per-instance id suffix (reused for the CA filter ref)
-  // and fills the arc-copy / pull-quote slots.
+  // Returns the per-instance id suffix (CA filter ref) and fills the copy slots.
   const gid = buildGlobeDom(el, labels, { arcCopy, pullQuote });
 
   // Cards come from the authored fragment link.

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -98,6 +98,8 @@ const ARC_STAGGER = 0.594;
 // Reduced motion: shrink the static desktop sphere so the whole ball fits (sm left at 1).
 const RM_GLOBE_SCALE_MD = 0.9;
 
+const TEXT_REBUILD_DEBOUNCE_MS = 150;
+
 // Grid peel / fold.
 const GRID_GAP_RATIO = 0.5; // gap between cards = 0.5× card width
 // Non-uniform fanT split: low-i cards cluster into fanT [0, this] off-screen and peel first;
@@ -349,6 +351,7 @@ function createGlobeGalleryRuntime(
   let blockHeight = 0; // its full scroll length
   // zoomT the pull-quote fades in at; from --gg-pq-pin-factor (see doLayout)
   let pqAppearZoomT = 0.5;
+  let formationVh = 0; // from --gg-formation-vh (see doLayout)
   let W = 0; let
     H = 0;
 
@@ -892,10 +895,16 @@ function createGlobeGalleryRuntime(
     restoreFocusOnClose: (idx) => { if (a11y && a11y.isBrowsing()) a11y.focusCard(idx); },
   });
 
+  // Block top in document space + full scroll length. See README (Scroll model).
+  function measureBlock() {
+    blockDocTop = root.getBoundingClientRect().top + window.scrollY;
+    blockHeight = root.offsetHeight || (TL.CSS_FALLBACK.RUNWAY_VH / 100) * H;
+  }
+
   // Scroll px from the block top where the sphere is fully formed (progress = foldLast); locked to
-  // FORMATION_SCROLL_VH, clamped to the runway. See README → runway / progress model.
+  // --gg-formation-vh, clamped to the runway. See README (Scroll model).
   function formedScrollPx() {
-    return Math.min((TL.FORMATION_SCROLL_VH / 100) * H, blockHeight);
+    return Math.min((formationVh / 100) * H, blockHeight);
   }
 
   // Focusing the widget snaps the page to the interactive globe state (formed-sphere offset;
@@ -1739,6 +1748,7 @@ function createGlobeGalleryRuntime(
   }
 
   let resizeHandler = null;
+  let textRebuildTimer = 0;
   // Reduced-motion media query + listener (a mid-session OS toggle rebuilds; see doLayout).
   let reducedMotionMQ = null;
   let reducedMotionHandler = null;
@@ -1796,9 +1806,13 @@ function createGlobeGalleryRuntime(
     cameraOrtho.position.set(0, 0, 100);
     cameraOrtho.lookAt(0, 0, 0);
 
-    function doLayout() {
-      W = window.innerWidth;
-      H = window.innerHeight;
+    // Only the resize path passes fromResize — see README (doLayout cost control).
+    function doLayout({ fromResize = false } = {}) {
+      const nextW = window.innerWidth;
+      const nextH = window.innerHeight;
+      if (fromResize && nextW === W && nextH === H) return;
+      W = nextW;
+      H = nextH;
 
       // A band crossing (768px) or a reduced-motion toggle rebuilds via destroy()+init()
       // (geometry + RM layout are baked at build time); resizing within a band takes the cheap
@@ -1812,10 +1826,15 @@ function createGlobeGalleryRuntime(
         if (initRuntime() === false) root.classList.add('globe-gallery-empty');
         return;
       }
-      blockDocTop = root.getBoundingClientRect().top + window.scrollY;
-      blockHeight = root.offsetHeight || window.innerHeight * 7;
-      const pinFactor = parseFloat(getComputedStyle(root).getPropertyValue('--gg-pq-pin-factor')) || 0.44;
+      measureBlock();
+      const rootStyle = getComputedStyle(root);
+      const cssNum = (prop, fallback) => {
+        const n = parseFloat(rootStyle.getPropertyValue(prop));
+        return Number.isFinite(n) ? n : fallback;
+      };
+      const pinFactor = cssNum('--gg-pq-pin-factor', TL.CSS_FALLBACK.PQ_PIN_FACTOR);
       pqAppearZoomT = Math.max(0, (1 - pinFactor) - TL.PQ_APPEAR_LEAD);
+      formationVh = cssNum('--gg-formation-vh', TL.CSS_FALLBACK.FORMATION_VH);
       // Re-apply DPR (can change when dragging between monitors of different density).
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
       renderer.setSize(W, H);
@@ -1828,12 +1847,23 @@ function createGlobeGalleryRuntime(
       cameraOrtho.bottom = -H / 2;
       cameraOrtho.updateProjectionMatrix();
       computeGridLayout();
-      // Hint-text plane size tracks the viewport — rebuild on within-band resize.
-      if (textMesh) buildTextMesh();
+      // Deferred only while off-screen. See README (doLayout cost control).
+      if (textMesh) {
+        clearTimeout(textRebuildTimer);
+        textRebuildTimer = 0;
+        if (textMesh.visible) {
+          buildTextMesh();
+        } else {
+          textRebuildTimer = setTimeout(() => {
+            textRebuildTimer = 0;
+            if (textMesh) buildTextMesh();
+          }, TEXT_REBUILD_DEBOUNCE_MS);
+        }
+      }
     }
     doLayout();
     if (resizeHandler) window.removeEventListener('resize', resizeHandler);
-    resizeHandler = doLayout;
+    resizeHandler = () => doLayout({ fromResize: true });
     window.addEventListener('resize', resizeHandler, { passive: true });
 
     // Reduced motion can toggle mid-session (OS setting) without a resize, so listen directly;
@@ -1843,17 +1873,14 @@ function createGlobeGalleryRuntime(
     }
     reducedMotionMQ = window.matchMedia?.('(prefers-reduced-motion: reduce)') ?? null;
     if (reducedMotionMQ) {
-      reducedMotionHandler = doLayout;
+      reducedMotionHandler = () => doLayout();
       reducedMotionMQ.addEventListener('change', reducedMotionHandler);
     }
 
     // Recompute block metrics whenever page height changes (content loading above shifts
     // offsetTop; blockHeight=0 at first paint would make progress=Infinity).
     if (layoutObs) layoutObs.disconnect();
-    layoutObs = new ResizeObserver(() => {
-      blockDocTop = root.getBoundingClientRect().top + window.scrollY;
-      blockHeight = root.offsetHeight || window.innerHeight * 7;
-    });
+    layoutObs = new ResizeObserver(() => { measureBlock(); });
     layoutObs.observe(document.body);
 
     if (intersectionObs) intersectionObs.disconnect();
@@ -1952,6 +1979,7 @@ function createGlobeGalleryRuntime(
       window.removeEventListener('resize', resizeHandler);
       resizeHandler = null;
     }
+    if (textRebuildTimer) { clearTimeout(textRebuildTimer); textRebuildTimer = 0; }
     if (reducedMotionMQ && reducedMotionHandler) {
       reducedMotionMQ.removeEventListener('change', reducedMotionHandler);
       reducedMotionMQ = null;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -338,9 +338,9 @@ function createGlobeGalleryRuntime(
 
   let blockDocTop = 0; // block's top in document space (the scroll runway)
   let blockHeight = 0; // its full scroll length
-  // zoomT the pull-quote fades in at; from --gg-pq-pin-factor (see doLayout)
+  // zoomT the pull-quote fades in at; from --gg-pq-pin-factor (see readCssVars)
   let pqAppearZoomT = 0.5;
-  let formationVh = 0; // from --gg-formation-vh (see doLayout)
+  let formationVh = 0; // from --gg-formation-vh (see readCssVars)
   let W = 0; let
     H = 0;
 
@@ -845,7 +845,20 @@ function createGlobeGalleryRuntime(
   // Block top in document space + full scroll length.
   function measureBlock() {
     blockDocTop = root.getBoundingClientRect().top + window.scrollY;
-    blockHeight = root.offsetHeight || (TL.CSS_FALLBACK.RUNWAY_VH / 100) * H;
+    blockHeight = root.offsetHeight;
+  }
+
+  // Reads the runway props. See README (CSS is the source of truth).
+  function readCssVars() {
+    const rootStyle = getComputedStyle(root);
+    const cssNum = (prop) => {
+      const n = parseFloat(rootStyle.getPropertyValue(prop));
+      return Number.isFinite(n) ? n : null;
+    };
+    const pinFactor = cssNum('--gg-pq-pin-factor');
+    if (pinFactor !== null) pqAppearZoomT = Math.max(0, (1 - pinFactor) - TL.PQ_APPEAR_LEAD);
+    const vh = cssNum('--gg-formation-vh');
+    if (vh !== null) formationVh = vh;
   }
 
   // Scroll px from the block top where the sphere is formed. See README (Scroll model).
@@ -1767,14 +1780,7 @@ function createGlobeGalleryRuntime(
         return;
       }
       measureBlock();
-      const rootStyle = getComputedStyle(root);
-      const cssNum = (prop, fallback) => {
-        const n = parseFloat(rootStyle.getPropertyValue(prop));
-        return Number.isFinite(n) ? n : fallback;
-      };
-      const pinFactor = cssNum('--gg-pq-pin-factor', TL.CSS_FALLBACK.PQ_PIN_FACTOR);
-      pqAppearZoomT = Math.max(0, (1 - pinFactor) - TL.PQ_APPEAR_LEAD);
-      formationVh = cssNum('--gg-formation-vh', TL.CSS_FALLBACK.FORMATION_VH);
+      readCssVars();
       // Re-apply DPR (can change when dragging between monitors of different density).
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
       renderer.setSize(W, H);
@@ -1818,7 +1824,7 @@ function createGlobeGalleryRuntime(
 
     // Page height changes shift offsetTop; blockHeight=0 at first paint → progress=Infinity.
     if (layoutObs) layoutObs.disconnect();
-    layoutObs = new ResizeObserver(() => { measureBlock(); });
+    layoutObs = new ResizeObserver(() => { measureBlock(); readCssVars(); });
     layoutObs.observe(document.body);
 
     if (intersectionObs) intersectionObs.disconnect();

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -341,9 +341,10 @@ function createGlobeGalleryRuntime(
   // zoomT the pull-quote fades in at; from --gg-pq-pin-factor (see readCssVars)
   let pqAppearZoomT = 0.5;
   let formationVh = 0; // from --gg-formation-vh (see readCssVars)
-  let W = 0; let
-    H = 0;
+  let W = 0;
+  let H = 0;
 
+  const worldEl = q('.globe-gallery-world');
   const pqEl = q('.globe-gallery-pullquote');
   let pqShown = false;
 
@@ -860,6 +861,8 @@ function createGlobeGalleryRuntime(
     const vh = cssNum('--gg-formation-vh');
     if (vh !== null) formationVh = vh;
   }
+
+  const measureViewportH = () => Math.max(1, worldEl.offsetHeight);
 
   // Scroll px from the block top where the sphere is formed. See README (Scroll model).
   function formedScrollPx() {
@@ -1708,6 +1711,7 @@ function createGlobeGalleryRuntime(
   // Reduced-motion media query + listener (a mid-session OS toggle rebuilds; see doLayout).
   let reducedMotionMQ = null;
   let reducedMotionHandler = null;
+  let appliedDpr = 0;
   let layoutObs = null; // ResizeObserver keeping block metrics fresh as page content loads
   let intersectionObs = null; // IntersectionObserver gating the rAF loop on visibility
   let textureLoadGeneration = 0;
@@ -1720,16 +1724,10 @@ function createGlobeGalleryRuntime(
     root.classList.toggle('globe-gallery-reduced', reducedMotion);
 
     // RM: canvas into normal flow so the globe scrolls away. See README (Reduced motion).
-    if (reducedMotion) {
-      canvas.style.position = 'absolute';
-      canvas.style.top = '8vh';
-    } else {
-      canvas.style.position = '';
-      canvas.style.top = '';
-    }
+    canvas.style.position = reducedMotion ? 'absolute' : '';
 
     W = window.innerWidth;
-    H = window.innerHeight;
+    H = measureViewportH();
 
     // Resolve the breakpoint profile before anything reads bp.*.
     const band = resolveBP(W);
@@ -1742,7 +1740,8 @@ function createGlobeGalleryRuntime(
       renderer = null;
       return false;
     }
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    appliedDpr = Math.min(window.devicePixelRatio, 2);
+    renderer.setPixelRatio(appliedDpr);
     renderer.setSize(W, H);
     renderer.setClearColor(0x000000, 0);
     renderer.sortObjects = false; // we manage order via mesh.renderOrder
@@ -1763,8 +1762,10 @@ function createGlobeGalleryRuntime(
 
     // Only the resize path passes fromResize — see README (doLayout cost control).
     function doLayout({ fromResize = false } = {}) {
+      measureBlock();
+      readCssVars();
       const nextW = window.innerWidth;
-      const nextH = window.innerHeight;
+      const nextH = measureViewportH();
       if (fromResize && nextW === W && nextH === H) return;
       W = nextW;
       H = nextH;
@@ -1779,10 +1780,11 @@ function createGlobeGalleryRuntime(
         if (initRuntime() === false) root.classList.add('globe-gallery-empty');
         return;
       }
-      measureBlock();
-      readCssVars();
-      // Re-apply DPR (can change when dragging between monitors of different density).
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      const dpr = Math.min(window.devicePixelRatio, 2);
+      if (dpr !== appliedDpr) {
+        appliedDpr = dpr;
+        renderer.setPixelRatio(dpr);
+      }
       renderer.setSize(W, H);
       modal.resize(W, H);
       camera.aspect = W / H;
@@ -1824,7 +1826,7 @@ function createGlobeGalleryRuntime(
 
     // Page height changes shift offsetTop; blockHeight=0 at first paint → progress=Infinity.
     if (layoutObs) layoutObs.disconnect();
-    layoutObs = new ResizeObserver(() => { measureBlock(); readCssVars(); });
+    layoutObs = new ResizeObserver(() => doLayout({ fromResize: true }));
     layoutObs.observe(document.body);
 
     if (intersectionObs) intersectionObs.disconnect();

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -17,7 +17,6 @@ import * as TL from './src/timeline.js';
 const CARD_ASPECT = 456 / 631; // portrait
 
 const prefersReducedMotion = () => !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-const isRtl = () => document.documentElement.dir === 'rtl';
 
 // Two render profiles split at 768px (Milo sm↔md); resolved once via resolveBP(W).
 // See README (Breakpoints).
@@ -348,7 +347,8 @@ function createGlobeGalleryRuntime(
 
   let blockDocTop = 0; // block's top in document space (the scroll runway)
   let blockHeight = 0; // its full scroll length
-  let pqAppearZoomT = 0.5; // zoomT the pull-quote fades in at; from --pq-pin-factor (see doLayout)
+  // zoomT the pull-quote fades in at; from --gg-pq-pin-factor (see doLayout)
+  let pqAppearZoomT = 0.5;
   let W = 0; let
     H = 0;
 
@@ -359,7 +359,7 @@ function createGlobeGalleryRuntime(
   let caFilterB = null; // SVG feOffset element for blue channel
   let globalCaFilterOn = false; // whether canvas.style.filter currently holds the CA url
   // Cached node + last-written style strings (DOM writes only on change).
-  const arcCopy = { el: null, startSide: '', startStr: '', opStr: '', transformStr: '' };
+  const arcCopy = { el: null, opStr: '', transformStr: '' };
 
   const drag = { isDragging: false, velX: 0, velY: 0 };
   let renderReady = false;
@@ -1241,25 +1241,8 @@ function createGlobeGalleryRuntime(
     const arcCopyOutE = easeInOutCubic(arcCopyOutT);
     const arcCopyOp = arcCopyInE * (1 - arcCopyOutE);
     const arcCopySlide = 24 * (1 - arcCopyInE);
-    // sm pins 8px from viewport inline-start;
-    // md uses the 24px-grid-aligned position with centering.
-    const gridLeft = (bp.name === 'sm')
-      ? 8
-      : 24 + Math.max(0, (W - 48 - 1392) / 2);
-    const inlineStartSide = isRtl() ? 'right' : 'left';
-    const inlineEndSide = isRtl() ? 'left' : 'right';
-    const insetStr = `${gridLeft}px`;
     const opStr = arcCopyOp.toFixed(3);
     const transformStr = `translateY(${arcCopySlide.toFixed(1)}px)`;
-    if (inlineStartSide !== arcCopy.startSide) {
-      arcCopy.el.style[inlineEndSide] = '';
-      arcCopy.startSide = inlineStartSide;
-      arcCopy.startStr = '';
-    }
-    if (insetStr !== arcCopy.startStr) {
-      arcCopy.el.style[inlineStartSide] = insetStr;
-      arcCopy.startStr = insetStr;
-    }
     if (opStr !== arcCopy.opStr) { arcCopy.el.style.opacity = opStr; arcCopy.opStr = opStr; }
     if (transformStr !== arcCopy.transformStr) {
       arcCopy.el.style.transform = transformStr;
@@ -1831,7 +1814,7 @@ function createGlobeGalleryRuntime(
       }
       blockDocTop = root.getBoundingClientRect().top + window.scrollY;
       blockHeight = root.offsetHeight || window.innerHeight * 7;
-      const pinFactor = parseFloat(getComputedStyle(root).getPropertyValue('--pq-pin-factor')) || 0.44;
+      const pinFactor = parseFloat(getComputedStyle(root).getPropertyValue('--gg-pq-pin-factor')) || 0.44;
       pqAppearZoomT = Math.max(0, (1 - pinFactor) - TL.PQ_APPEAR_LEAD);
       // Re-apply DPR (can change when dragging between monitors of different density).
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
@@ -1896,8 +1879,6 @@ function createGlobeGalleryRuntime(
     caFilterR = q('.globe-gallery-ca-r-offset');
     caFilterB = q('.globe-gallery-ca-b-offset');
     arcCopy.el = q('.globe-gallery-arc-copy');
-    arcCopy.startSide = '';
-    arcCopy.startStr = '';
     arcCopy.opStr = '';
     arcCopy.transformStr = '';
 

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -36,6 +36,7 @@ const BREAKPOINTS = {
     CARD_FACE_CAMERA: 0,
     CARD_ROLL_JITTER: 0.5, // per-card random roll, radians (±0.25 ≈ ±14°)
     ARC_DENSE_FRACTION: 0.6, // share of cards clustered into the off-screen arc flank
+    DRAG_GEARING: 0.6, // fraction of 1:1 surface tracking — see dragSensitivity
   },
   sm: {
     minWidth: 0,
@@ -53,6 +54,7 @@ const BREAKPOINTS = {
     CARD_ROLL_JITTER: 0.18,
     ARC_DENSE_FRACTION: 0,
     CYL_COLS_FIT: 0.65, // phone-only override of the shared wall-height dial
+    DRAG_GEARING: 0.53, // geared down from 1:1 — the phone barrel is only ~167px wide
   },
 };
 
@@ -107,9 +109,10 @@ const GRID_GAP_RATIO = 0.5; // gap between cards = 0.5× card width
 const ARC_DENSE_SPLIT = 0.50;
 
 // Drag / auto-rotation. MAX_VEL is shared with interaction.js (it clamps, core normalizes).
+// FRICTION and AUTO_ROT_SPEED are authored per 60fps frame and rescaled by frame.dtScale.
 const DRAG_FRICTION = 0.94;
-const MAX_VEL = 0.06;
-const AUTO_ROT_SPEED = 0.000045;
+const MAX_VEL = 0.06; // rad/frame ≈ 206°/s — the ceiling on a flick
+const AUTO_ROT_SPEED = 0.0005; // ambient yaw RATE (not an increment into velX) ≈ 1.7°/s
 // Keyboard browse pitch cap ±85° (vs ±60° drag); excess eases back at PITCH_RELAX once
 // browsing ends. See updateSphereRotation.
 const KEY_PITCH_CAP = (85 * Math.PI) / 180;
@@ -320,6 +323,7 @@ function createGlobeGalleryRuntime(
       // Frustum height at the cylinder's centre plane — the column solve's vertical budget.
       CYL_FRUSTUM_H: 2 * Math.tan(Math.PI / 6) * cfg.CAM_Z_SPHERE,
       CARD_ROLL_JITTER: cfg.CARD_ROLL_JITTER,
+      DRAG_GEARING: cfg.DRAG_GEARING,
       // Dense-arc cluster as a share of the count (count-independent ratio); clamped below
       // nTotal-1 so the spread region always keeps at least one card.
       ARC_DENSE_COUNT: Math.min(
@@ -363,7 +367,9 @@ function createGlobeGalleryRuntime(
   // Cached node + last-written style strings (DOM writes only on change).
   const arcCopy = { el: null, opStr: '', transformStr: '' };
 
-  const drag = { isDragging: false, velX: 0, velY: 0 };
+  // Shared by reference with interaction.js: pendingX/Y = exact unapplied travel (rad), velX/Y =
+  // smoothed velocity per 60fps frame. See README (Drag physics).
+  const drag = { isDragging: false, velX: 0, velY: 0, pendingX: 0, pendingY: 0 };
   let renderReady = false;
   let onScreen = true; // assume visible until the observer's first callback corrects it
   let sphereDragWarp = 0;
@@ -950,6 +956,13 @@ function createGlobeGalleryRuntime(
     drag,
   });
 
+  // Rad per pointer px, live off the viewport + band: bp.DRAG_GEARING as a fraction of true 1:1
+  // surface tracking (90° per on-screen ball radius). See README (Drag physics).
+  const dragSensitivity = () => {
+    const radiusPx = (bp.SPHERE_R * H) / bp.CYL_FRUSTUM_H;
+    return ((Math.PI / 2) * bp.DRAG_GEARING) / Math.max(1, radiusPx);
+  };
+
   interaction = createInteraction({
     getRenderer: () => renderer,
     getCamera: () => camera,
@@ -957,6 +970,7 @@ function createGlobeGalleryRuntime(
     getModalIdx: () => modal.getModalIdx(),
     openModal: (idx, x, y) => openModalFromCanvas(idx, x, y),
     getSphereFormT: () => frameState.sphereFormT,
+    getDragSensitivity: dragSensitivity,
     interactiveThreshold: TL.SPHERE_INTERACTIVE_T,
     maxVel: MAX_VEL,
     drag,
@@ -978,8 +992,10 @@ function createGlobeGalleryRuntime(
     frameInput.formPx = formedScrollPx();
     frameInput.viewportH = H;
     frameInput.arcScale = bp.CARD_W_ARC / bp.CARD_W_SPHERE;
+    frameInput.now = performance.now();
     TL.deriveFrame(frameState, frameInput);
     frameInput.prevLenisY = frameState.lenisY;
+    frameInput.prevNow = frameInput.now;
     return frameState;
   }
 
@@ -1017,9 +1033,15 @@ function createGlobeGalleryRuntime(
   // sphereRotActive and refreshes sphereRotQuat. Rotation is applied PER-CARD (scaled by fdE)
   // in updateCardTransform, not to sphereGroup.rotation (kept identity for world-matrix queries).
   function updateSphereRotation(frame) {
-    const { sphereFormT } = frame;
+    const { sphereFormT, dtScale } = frame;
     sphereGroup.rotation.x = 0;
     sphereGroup.rotation.y = 0;
+
+    // Drained unconditionally — pooled travel must never dump on resume.
+    const pendX = drag.pendingX;
+    const pendY = drag.pendingY;
+    drag.pendingX = 0;
+    drag.pendingY = 0;
 
     // Leaving browse: cancel any in-flight nudge so its targets stop fighting resumed
     // auto-spin + the drag clamp. The pitch excess eases back to 60° below.
@@ -1039,64 +1061,71 @@ function createGlobeGalleryRuntime(
       sphereOrient.z = navNudge.startZ + (navNudge.targetZ - navNudge.startZ) * e;
       if (e >= 1) navNudge.active = false;
     }
-    if (sphereFormT >= TL.SPHERE_INTERACTIVE_T) {
-      // Pause auto-rotation + drag while a modal is open — sphere freezes at its current rotation
-      if (modal.getModalIdx() < 0) {
-        if (!drag.isDragging) {
-          drag.velX *= DRAG_FRICTION;
-          drag.velY *= DRAG_FRICTION;
-          // Auto-spin off under reduced motion and while browsing (globe holds the image).
-          if (!reducedMotion && !(a11y && a11y.isBrowsing())) drag.velX += AUTO_ROT_SPEED;
-        }
-        // Inside the globe the far wall moves opposite the same world rotation, so negate the
-        // delta to keep dragging tracking the surface the user sees.
-        const dragDir = cameraInsideSphere ? -1 : 1;
-        // Yaw spins freely; pitch is clamped (absolute angle) so the globe self-levels.
-        sphereOrient.y += drag.velX * dragDir;
-        sphereOrient.x += drag.velY * dragDir;
-        // Pitch cap glides via pitchReleaseCap: ±60° for drag, up to ±85° while browsing, easing
-        // back to 60° (PITCH_RELAX) after browse so leaving a beyond-cap card slides, not snaps.
-        const RESTING_PITCH = Math.PI / 3;
-        if (browsing) {
-          sphereOrient.x = Math.max(-KEY_PITCH_CAP, Math.min(KEY_PITCH_CAP, sphereOrient.x));
-          pitchReleaseCap = Math.max(RESTING_PITCH, Math.abs(sphereOrient.x)); // prime the glide
+    // frozen (modal open): sphere holds its rotation. !interactive (still folding): no new drag and
+    // no auto-spin, but inertia keeps coasting. See README (Drag physics).
+    const frozen = modal.getModalIdx() >= 0;
+    const interactive = sphereFormT >= TL.SPHERE_INTERACTIVE_T;
+    if (!frozen) {
+      // Inside the globe the far wall moves opposite the same world rotation, so negate the
+      // delta to keep dragging tracking the surface the user sees.
+      const dragDir = cameraInsideSphere ? -1 : 1;
+      // Yaw (y) spins freely; pitch (x) is clamped below so the globe self-levels.
+      if (drag.isDragging) {
+        // Held: position-driven off the exact travel — no smoothing lag.
+        if (interactive) {
+          sphereOrient.y += pendX * dragDir;
+          sphereOrient.x += pendY * dragDir;
         } else {
-          sphereOrient.x = Math.max(-pitchReleaseCap, Math.min(pitchReleaseCap, sphereOrient.x));
-          if (pitchReleaseCap > RESTING_PITCH) {
-            pitchReleaseCap = RESTING_PITCH + (pitchReleaseCap - RESTING_PITCH) * PITCH_RELAX;
-            if (pitchReleaseCap - RESTING_PITCH < 0.001) pitchReleaseCap = RESTING_PITCH;
-          }
-          // Upright roll relaxes to 0 over the same glide (so pitch + roll settle together).
-          if (sphereOrient.z !== 0) {
-            sphereOrient.z *= PITCH_RELAX;
-            if (Math.abs(sphereOrient.z) < 0.001) sphereOrient.z = 0;
-          }
+          drag.velX = 0; drag.velY = 0; // an inert mid-fold drag must not fling on release
+        }
+      } else {
+        // Released: velocity-driven coast. Both rates are per 60fps frame → rescaled by dtScale.
+        const friction = DRAG_FRICTION ** dtScale;
+        drag.velX *= friction;
+        drag.velY *= friction;
+        // Ambient spin stays OUT of velX (a bias in it decays asymmetrically by direction).
+        const spin = interactive && !reducedMotion && !(a11y && a11y.isBrowsing())
+          ? AUTO_ROT_SPEED : 0;
+        sphereOrient.y += (drag.velX + spin) * dtScale * dragDir;
+        sphereOrient.x += drag.velY * dtScale * dragDir;
+      }
+      // Pitch cap glides via pitchReleaseCap: ±60° for drag, up to ±85° while browsing, easing
+      // back to 60° (PITCH_RELAX) after browse so leaving a beyond-cap card slides, not snaps.
+      const RESTING_PITCH = Math.PI / 3;
+      if (browsing) {
+        sphereOrient.x = Math.max(-KEY_PITCH_CAP, Math.min(KEY_PITCH_CAP, sphereOrient.x));
+        pitchReleaseCap = Math.max(RESTING_PITCH, Math.abs(sphereOrient.x)); // prime the glide
+      } else {
+        sphereOrient.x = Math.max(-pitchReleaseCap, Math.min(pitchReleaseCap, sphereOrient.x));
+        if (pitchReleaseCap > RESTING_PITCH) {
+          pitchReleaseCap = RESTING_PITCH + (pitchReleaseCap - RESTING_PITCH) * PITCH_RELAX;
+          if (pitchReleaseCap - RESTING_PITCH < 0.001) pitchReleaseCap = RESTING_PITCH;
+        }
+        // Upright roll relaxes to 0 over the same glide (so pitch + roll settle together).
+        if (sphereOrient.z !== 0) {
+          sphereOrient.z *= PITCH_RELAX;
+          if (Math.abs(sphereOrient.z) < 0.001) sphereOrient.z = 0;
         }
       }
+    }
 
-      // Sphere-drag warp: baseline (while held) + velocity burst, eased toward a target rather
-      // than snapped (a hard drop popped the barrel distortion when the modal opened).
-      let warpTarget;
-      if (modal.getModalIdx() < 0) {
-        const dragSpeed = Math.sqrt(drag.velX * drag.velX + drag.velY * drag.velY);
-        const burst = dragSpeed * SPHERE_DRAG_WARP_VEL;
-        const baseline = drag.isDragging ? SPHERE_DRAG_WARP_BASELINE : 0;
-        warpTarget = Math.min(SPHERE_DRAG_WARP_MAX, baseline + burst);
-      } else {
-        warpTarget = 0;
-      }
-      sphereDragWarp += (warpTarget - sphereDragWarp) * 0.20;
-      if (Math.abs(sphereDragWarp) < 0.001) sphereDragWarp = 0;
-    } else {
-      // Below interactive threshold: stop accumulating drag/auto-rot. Rotation is preserved
-      // mid-scroll (a brief dip doesn't lose it); zeroed only at the very top of the section.
+    // Sphere-drag warp: baseline (while held) + velocity burst, eased toward a target rather
+    // than snapped (a hard drop popped the barrel distortion when the modal opened).
+    let warpTarget = 0;
+    if (!frozen && interactive) {
+      const dragSpeed = Math.sqrt(drag.velX * drag.velX + drag.velY * drag.velY);
+      const baseline = drag.isDragging ? SPHERE_DRAG_WARP_BASELINE : 0;
+      warpTarget = Math.min(SPHERE_DRAG_WARP_MAX, baseline + dragSpeed * SPHERE_DRAG_WARP_VEL);
+    }
+    sphereDragWarp += (warpTarget - sphereDragWarp) * 0.20;
+    if (Math.abs(sphereDragWarp) < 0.001) sphereDragWarp = 0;
+
+    // Full reset (orientation + inertia) only at the very top of the section — a dip mid-scroll
+    // keeps both.
+    if (sphereFormT < TL.SPHERE_ORIENT_RESET_T) {
+      resetSphereOrientation();
       drag.velX = 0;
       drag.velY = 0;
-      sphereDragWarp += (0 - sphereDragWarp) * 0.20;
-      if (Math.abs(sphereDragWarp) < 0.001) sphereDragWarp = 0;
-      if (sphereFormT < TL.SPHERE_ORIENT_RESET_T) {
-        resetSphereOrientation();
-      }
     }
 
     // sphereRotActive is a fast-path flag so the rotation math can be skipped when upright.
@@ -1651,11 +1680,18 @@ function createGlobeGalleryRuntime(
   function rafLoop() { tick(); rafId = requestAnimationFrame(rafLoop); }
   function startTicker() {
     if (rafId) return;
-    // Reset the velocity baseline so a resume after an off-screen scroll doesn't spike scrollVel.
+    // Re-baseline scroll (no scrollVel spike) + the frame clock (the parked interval isn't dt).
     frameInput.prevLenisY = window.scrollY;
+    frameInput.prevNow = 0;
     rafId = requestAnimationFrame(rafLoop);
   }
-  function stopTicker() { if (rafId) { cancelAnimationFrame(rafId); rafId = 0; } }
+  function stopTicker() {
+    if (!rafId) return;
+    cancelAnimationFrame(rafId);
+    rafId = 0;
+    // Inertia can't coast while the loop is parked — retire it rather than resume it later.
+    drag.velX = 0; drag.velY = 0; drag.pendingX = 0; drag.pendingY = 0;
+  }
   // Run the loop only while renderReady AND onScreen; called whenever either input changes.
   function syncTicker() {
     if (renderReady && onScreen) {
@@ -1992,12 +2028,13 @@ function createGlobeGalleryRuntime(
     a11y.teardown();
     if (arcCopy.el) arcCopy.el.style.cssText = '';
     if (pqEl) { pqEl.classList.remove('is-active'); pqEl.style.transition = ''; pqShown = false; }
-    frameInput.prevLenisY = 0; frameState.scrollVel = 0;
+    frameInput.prevLenisY = 0; frameInput.prevNow = 0; frameState.scrollVel = 0;
     // Reset sphere orientation + drag/nudge state: the closure survives a rebuild, so without
     // this a pre-rebuild tilt carries over. See README (destroy resets).
     resetSphereOrientation();
     sphereDragWarp = 0;
-    drag.isDragging = false; drag.velX = 0; drag.velY = 0;
+    drag.isDragging = false;
+    drag.velX = 0; drag.velY = 0; drag.pendingX = 0; drag.pendingY = 0;
     wasBrowsing = false;
     // NOTE: `bp` intentionally NOT cleared — doLayout compares it, initRuntime overwrites it.
   }

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -361,6 +361,7 @@ function createGlobeGalleryRuntime(
   let sphereDragWarp = 0;
   let cameraInsideSphere = false;
   let dragFlipZ = 0; // camera z at which drag inverts; set in buildCards
+  let fadeRefH = 0; // wall-wide card height the near-camera fade bands off; recomputeDragFlip
   // "Click & Drag" hint text mesh (built async, null until fonts load) + one-way exit progress.
   let textMesh = null;
   let textExitProgress = 0;
@@ -560,7 +561,7 @@ function createGlobeGalleryRuntime(
   }
 
   // Camera z below which drag inverts, anchored to where cards VANISH so the flip lands with the
-  // dissolve. Recomputed once textures land (sphereWorldH starts at a placeholder).
+  // dissolve; also sets fadeRefH. Recomputed once textures land (sphereWorldH is a placeholder).
   function recomputeDragFlip() {
     if (!sphereGroup || cards.length === 0) return;
     const groupScale = sphereGroup.scale.x || 1;
@@ -568,10 +569,10 @@ function createGlobeGalleryRuntime(
       (m, c) => Math.max(m, Math.hypot(c.spherePos.x, c.spherePos.z)),
       0,
     ) * groupScale;
-    const maxCardH = cards.reduce((m, c) => Math.max(m, c.sphereWorldH), 0) * groupScale;
+    fadeRefH = cards.reduce((s, c) => s + c.sphereWorldH, 0) / cards.length;
     // Clamped below the zoom-start distance so the flip stays inside the zoom-through.
     dragFlipZ = Math.min(
-      maxRadial + NEAR_FADE_END * maxCardH,
+      maxRadial + NEAR_FADE_END * fadeRefH * groupScale,
       bp.CAM_Z_SPHERE * DRAG_FLIP_MAX_CAM_FRAC,
     );
   }
@@ -1240,9 +1241,9 @@ function createGlobeGalleryRuntime(
     // transform stale, which scroll jitter shows as a flash.
     const depth = camera.position.z - (sphGroupZ + mesh.position.z);
     if (depth <= 0) { mesh.visible = false; return; }
-    // Thresholds scale with THIS card's rendered height (card.sphereWorldH), not the geometry base.
-    const fadeEnd = NEAR_FADE_END * card.sphereWorldH;
-    const fadeStart = NEAR_FADE_START * card.sphereWorldH;
+    // One band for the whole wall (fadeRefH), so the order is purely by depth. See README.
+    const fadeEnd = NEAR_FADE_END * fadeRefH;
+    const fadeStart = NEAR_FADE_START * fadeRefH;
     const proxFade = Math.max(0, Math.min(1, (depth - fadeEnd) / (fadeStart - fadeEnd)));
     // Skip the DRAW (not the state updates) once fully faded. See README (near-camera dissolve).
     mesh.visible = proxFade > 0;
@@ -1550,8 +1551,9 @@ function createGlobeGalleryRuntime(
     }
 
     const { CAM_Z_SPHERE, SPHERE_R } = bp;
-    // Remap so 0→1 covers [TEXT_APPEAR_START, 1].
-    const sfRaw = (sphereFormT - TL.TEXT_APPEAR_START) / (1 - TL.TEXT_APPEAR_START);
+    // Entrance resolves ON the interactive gate, not at sphereFormT 1. See README (hint text).
+    const sfRaw = (sphereFormT - TL.TEXT_APPEAR_START)
+      / (TL.SPHERE_INTERACTIVE_T - TL.TEXT_APPEAR_START);
     const sfT = Math.max(0, Math.min(1, sfRaw));
     const txtT = easeOutCubic(sfT);
     // Warp: strong at entrance, 0 at rest.

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -82,7 +82,7 @@ const YAW_ONLY_GEOMETRY = {
   CYL_GAP_RATIO: 0.20, // inter-card gap as a fraction of card width
   CYL_ASPECT_CAP: 1.5, // clamp on card aspect (cover-crop crops harder past it)
   CYL_BULGE: 0.18, // barrel bulge: r = R·(1 − bulge·t²); keep ≤~0.2 or edges overlap
-  CARD_FACE_CAMERA: 0.35, // limb polish (weaker than the sphere's 0.5)
+  CARD_FACE_CAMERA: 0.1, // limb polish; costs barrel smoothness — read the README before raising
   SPHERE_AREA_NORM: 0,
 };
 

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -139,9 +139,10 @@ const MASONRY_MORPH_RATE = 0.05; // per-frame ease of the position/scale morph
 // Near-camera proximity fade, in card-heights of depth.
 const FACING_EDGE_ON_BAND = 0.25; // |normal.z| half-width of the facing fade-out band
 const DRAG_FLIP_MAX_CAM_FRAC = 0.95; // ceiling on dragFlipZ as a fraction of CAM_Z_SPHERE
-const NEAR_FADE_START = 2.5; // begin fading below 2.5 card-heights depth
-const NEAR_FADE_END = 1.6; // fully transparent below 1.6 card-heights
+const NEAR_FADE_START = 2.5; // depth where the fade begins
+const NEAR_FADE_END = 1.6; // depth at which the card is fully transparent
 const NEAR_FADE_OPACITY_BIAS = 0.4; // exponent on the prox opacity ramp (< 1 = fade out later)
+const NEAR_FADE_DISPERSE_RAMP = 0.9; // exponent on uDisperse, applied here not in the shader
 
 // Sphere-drag warp: baseline while dragging + velocity burst that decays via DRAG_FRICTION.
 const SPHERE_DRAG_WARP_BASELINE = 0.05; // constant while isDragging
@@ -1235,14 +1236,16 @@ function createGlobeGalleryRuntime(
     } else {
       mesh.position.copy(card.spherePos);
     }
-    // Prox fade by depth in front of the lens. Cull only at depth ≤ 0 — culling at the fade edge
-    // lets scroll jitter flash the card.
+    // Prox fade by depth in front of the lens. Return early ONLY at depth ≤ 0 — a return leaves the
+    // transform stale, which scroll jitter shows as a flash.
     const depth = camera.position.z - (sphGroupZ + mesh.position.z);
     if (depth <= 0) { mesh.visible = false; return; }
     // Thresholds scale with THIS card's rendered height (card.sphereWorldH), not the geometry base.
     const fadeEnd = NEAR_FADE_END * card.sphereWorldH;
     const fadeStart = NEAR_FADE_START * card.sphereWorldH;
     const proxFade = Math.max(0, Math.min(1, (depth - fadeEnd) / (fadeStart - fadeEnd)));
+    // Skip the DRAW (not the state updates) once fully faded. See README (near-camera dissolve).
+    mesh.visible = proxFade > 0;
     mesh.scale.set(card.sphereScaleSX * hs, card.sphereScaleSY * hs, hs);
     applyCardFit(mesh, card);
     if (sphereRotActive) {
@@ -1258,7 +1261,7 @@ function createGlobeGalleryRuntime(
     const revealDis = 1 - card.revealT;
     mesh.material.opacity = Math.min(proxFade ** NEAR_FADE_OPACITY_BIAS, card.revealT);
     mesh.material.uniforms.uDissolve.value = Math.max(proxDis, revealDis);
-    mesh.material.uniforms.uDisperse.value = proxDis;
+    mesh.material.uniforms.uDisperse.value = proxDis ** NEAR_FADE_DISPERSE_RAMP;
     mesh.material.uniforms.uReveal.value = card.revealT;
     mesh.material.uniforms.uContourFade.value = proxFade;
     // Hover CA is additive on transition CA; uHoverPos anchors the warp at the cursor UV.

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -9,7 +9,7 @@ import createGlobeModal from './src/modal.js';
 import createInteraction from './src/interaction.js';
 import createCursor from './src/cursor.js';
 import {
-  easeOutCubic, easeInOutCubic, lerpN,
+  easeOutCubic, easeInOutCubic, lerpN, coverFit,
   buildArcCtx, getFanData, cssToWorld, rotateArcPoint, arcCamZ,
 } from './src/math.js';
 import * as TL from './src/timeline.js';
@@ -34,7 +34,6 @@ const BREAKPOINTS = {
     GRID_ROWS: 5,
     // 0 = cards face radially outward (true sphere). See applyCardFacing.
     CARD_FACE_CAMERA: 0,
-    SPHERE_AREA_NORM: 0, // 0 = native-aspect sizing. See SPHERE_AREA_NORM in buildCards.
     CARD_ROLL_JITTER: 0.5, // per-card random roll, radians (±0.25 ≈ ±14°)
     ARC_DENSE_FRACTION: 0.6, // share of cards clustered into the off-screen arc flank
   },
@@ -52,7 +51,6 @@ const BREAKPOINTS = {
     // Shape keys unreachable on sm (always cylinder); kept for the uniform contract.
     CARD_FACE_CAMERA: 0,
     CARD_ROLL_JITTER: 0.18,
-    SPHERE_AREA_NORM: 0,
     ARC_DENSE_FRACTION: 0,
     CYL_COLS_FIT: 0.65, // phone-only override of the shared wall-height dial
   },
@@ -63,6 +61,7 @@ function resolveBP(w) {
   return { name: 'sm', cfg: BREAKPOINTS.sm };
 }
 
+// Card caps are on texture HEIGHT (fitCardDims); modal caps are on the longest side.
 const CARD_TEX_SM = 256;
 const CARD_TEX_MD = 768;
 const MODAL_TEX_SM = 768;
@@ -79,10 +78,11 @@ const YAW_ONLY_GEOMETRY = {
   CYLINDER: true,
   CYL_COLS_FIT: 0.80, // wall-height dial: fewest columns whose tallest fits this × frustum
   CYL_GAP_RATIO: 0.20, // inter-card gap as a fraction of card width
-  CYL_ASPECT_CAP: 1.5, // clamp on card aspect (cover-crop crops harder past it)
+  // Guard on the aspect a card is LAID OUT at; past it the fit crops. Clears the authored set, so
+  // nothing real is cropped — re-run the column solve before lowering. See README (yaw-only).
+  CYL_ASPECT_CAP: 1.9,
   CYL_BULGE: 0.18, // barrel bulge: r = R·(1 − bulge·t²); keep ≤~0.2 or edges overlap
   CARD_FACE_CAMERA: 0.1, // limb polish; costs barrel smoothness — read the README before raising
-  SPHERE_AREA_NORM: 0,
 };
 
 // Cylinder-masonry wall vs Fibonacci sphere. True on the sm width band OR a coarse primary
@@ -154,7 +154,6 @@ const SPHERE_DRAG_WARP_MAX = 0.25; // cap on combined value
 // "Click & Drag" hint text (WebGL plane behind the sphere). See README (Behavior notes).
 const TEXT_BEHIND_GAP = 15; // world units behind the sphere's back surface
 const TEXT_WARP_ENTER_MAX = 4.50; // uWarp at entrance
-const TEXT_SCALE_ENTER = 1.0; // plane stays viewport-sized; warp handles the look
 const TEXT_OPACITY_PEAK = 0.15; // opacity at peak fade-in
 const TEXT_OPACITY_RESTING = 0.06; // settled opacity once the sphere is formed
 const TEXT_CA_DIR_STRENGTH = 0.05; // uMotionDir strength for drag CA on the text
@@ -311,7 +310,6 @@ function createGlobeGalleryRuntime(
       GRID_ROWS: cfg.GRID_ROWS,
       // Shape keys listed explicitly (not spread) so the overlay's layout keys can't leak on.
       CARD_FACE_CAMERA: shape.CARD_FACE_CAMERA,
-      SPHERE_AREA_NORM: shape.SPHERE_AREA_NORM,
       CYLINDER: !!shape.CYLINDER,
       // A band may override the shared wall-height dial to contain its own near face (sm does).
       CYL_COLS_FIT: cfg.CYL_COLS_FIT !== undefined ? cfg.CYL_COLS_FIT : shape.CYL_COLS_FIT,
@@ -335,7 +333,7 @@ function createGlobeGalleryRuntime(
   let cards = [];
   // Cards + meshes are built up front (with contours); textures fill in progressively via onEach.
   let textures = [];
-  let cardTexData = []; // per-card sphereScaleX + arc UV crop values
+  let cardAspects = []; // per-card native image aspect (index-aligned with CARD_CONTENT)
   let placeholderTex = null; // shared transparent texture for not-yet-loaded cards
   // One-time sm-barrel reflow once all aspects are known (masonry packing is a whole-set solve).
   const masonryMorph = { active: false, t: 0 };
@@ -476,10 +474,15 @@ function createGlobeGalleryRuntime(
     }
   }
 
+  // Native aspect of card i's image; the portrait placeholder until its texture decodes.
+  function cardAspect(i) {
+    return cardAspects[i] || CARD_ASPECT;
+  }
+
   function buildCards() {
     const {
       N_TOTAL, N_VISIBLE, SPHERE_R, CARD_W_SPHERE, CARD_H_SPHERE, GRID_COLS, GRID_ROWS,
-      CARD_ROLL_JITTER, SPHERE_AREA_NORM, CYLINDER,
+      CARD_ROLL_JITTER, CYLINDER,
     } = bp;
     if (!placeholderTex) placeholderTex = createPlaceholderTexture();
     sphereGroup = new THREE.Group();
@@ -491,10 +494,7 @@ function createGlobeGalleryRuntime(
     // Masonry is a whole-set solve, run ONCE before the per-card loop. Null on the sphere path.
     const masonry = CYLINDER
       ? cylinderMasonryLayout({
-        aspects: Array.from({ length: N_TOTAL }, (unused, i) => {
-          const d = cardTexData[i] || {};
-          return (d.sphereScaleX !== undefined ? d.sphereScaleX : 1) * CARD_ASPECT;
-        }),
+        aspects: Array.from({ length: N_TOTAL }, (unused, i) => cardAspect(i)),
         radius: SPHERE_R,
         frustumH: bp.CYL_FRUSTUM_H,
         colsFit: bp.CYL_COLS_FIT,
@@ -505,32 +505,15 @@ function createGlobeGalleryRuntime(
       : null;
 
     for (let i = 0; i < N_TOTAL; i += 1) {
-      // cardTexData is fully populated by the time buildCards() fires (called from onDone)
-      const ctd = cardTexData[i] || {};
-      const sphereScaleX = ctd.sphereScaleX !== undefined ? ctd.sphereScaleX : 1;
-      const imgAspect = sphereScaleX * CARD_ASPECT;
-      // Equal-area normalization: scaling both axes by sphereScaleX^-norm equalizes area at
-      // norm=0.5 without distorting aspect; norm=0 = native size. See README.
-      const areaNorm = SPHERE_AREA_NORM
-        ? sphereScaleX ** -SPHERE_AREA_NORM
-        : 1;
+      const srcAspect = cardAspect(i);
       // Masonry solves absolute world w/h; convert to scale factors against the shared geometry.
       const mas = masonry ? masonry[i] : null;
-      // Cover-crop UVs (fall back to the no-crop identity if the texture errored).
-      const repeatX = ctd.arcRepeatX !== undefined ? ctd.arcRepeatX : 1;
-      const repeatY = ctd.arcRepeatY !== undefined ? ctd.arcRepeatY : 1;
-      const offsetX = ctd.arcOffsetX !== undefined ? ctd.arcOffsetX : 0;
-      const offsetY = ctd.arcOffsetY !== undefined ? ctd.arcOffsetY : 0;
 
       const geo = new THREE.PlaneGeometry(CARD_W_SPHERE, CARD_H_SPHERE, 1, 1);
       const mat = createCardMaterial({
         // Contour until this card's photo lands (onEach swaps in the real texture).
         texture: textures[i] || placeholderTex,
         aspect: CARD_ASPECT, // arc/grid start shape; per-phase stages update uAspect
-        repeatX,
-        repeatY,
-        offsetX,
-        offsetY,
       });
       const mesh = new THREE.Mesh(geo, mat);
       mesh.renderOrder = N_VISIBLE - i;
@@ -564,20 +547,14 @@ function createGlobeGalleryRuntime(
         gridCol: GRID_COLS - 1 - Math.floor(i / GRID_ROWS),
         gridRow: GRID_ROWS - 1 - (i % GRID_ROWS),
         peelJitter: Math.random(),
-        // Sphere-phase scale factors (equal-area norm folded in). sphereScaleX is the raw
-        // aspect stretch (grid/arc/modal read it); sphereScaleS{X,Y} the sphere/fold apply.
-        sphereScaleX,
-        sphereScaleSX: mas ? mas.w / CARD_W_SPHERE : sphereScaleX * areaNorm,
-        sphereScaleSY: mas ? mas.h / CARD_H_SPHERE : areaNorm,
+        // The only per-card texture value stored; every phase's fit derives from it. See README.
+        srcAspect,
+        // Sphere-phase scale: native aspect, or the masonry's solved world size as a scale.
+        sphereScaleSX: mas ? mas.w / CARD_W_SPHERE : srcAspect / CARD_ASPECT,
+        sphereScaleSY: mas ? mas.h / CARD_H_SPHERE : 1,
         // This card's ACTUAL rendered world height — the near fade is in card-heights, and on
         // masonry CARD_H_SPHERE is only the geometry base. See README (near fade).
-        sphereWorldH: mas ? mas.h : CARD_H_SPHERE * areaNorm,
-        // World-space aspect for the rounded-corner SDF — must equal actual rendered w/h.
-        imgAspect: mas ? mas.w / mas.h : imgAspect,
-        arcRepeatX: repeatX,
-        arcRepeatY: repeatY,
-        arcOffsetX: offsetX,
-        arcOffsetY: offsetY,
+        sphereWorldH: mas ? mas.h : CARD_H_SPHERE,
         hoverT: 0, // eased 0→1 hover progress (sphere phase only)
         hoverTarget: 0, // instant 0|1 set by onHover() raycast
         hoverUV: new THREE.Vector2(0.5, 0.5), // cursor position on card in UV space
@@ -617,14 +594,12 @@ function createGlobeGalleryRuntime(
   }
 
   // Sphere-phase sizing for one card from its loaded image aspect (non-masonry path). Read live
-  // each frame by placeSphereCard, so updating these here "morphs" the card into its native shape.
-  function updateCardSphereSizing(card, sphereScaleX) {
-    const areaNorm = bp.SPHERE_AREA_NORM ? sphereScaleX ** -bp.SPHERE_AREA_NORM : 1;
-    card.sphereScaleX = sphereScaleX;
-    card.sphereScaleSX = sphereScaleX * areaNorm;
-    card.sphereScaleSY = areaNorm;
-    card.sphereWorldH = bp.CARD_H_SPHERE * areaNorm;
-    card.imgAspect = sphereScaleX * CARD_ASPECT;
+  // each frame by placeSphereCard, so updating these "morphs" the card into its native shape.
+  function updateCardSphereSizing(card, srcAspect) {
+    card.srcAspect = srcAspect;
+    card.sphereScaleSX = srcAspect / CARD_ASPECT;
+    card.sphereScaleSY = 1;
+    card.sphereWorldH = bp.CARD_H_SPHERE;
   }
 
   // sm barrel only: masonry packing needs every image aspect, so it's solved once with placeholder
@@ -633,10 +608,7 @@ function createGlobeGalleryRuntime(
   function resolveMasonryLayout() {
     const { N_TOTAL, SPHERE_R, CARD_W_SPHERE, CARD_H_SPHERE } = bp;
     const masonry = cylinderMasonryLayout({
-      aspects: Array.from({ length: N_TOTAL }, (unused, i) => {
-        const d = cardTexData[i] || {};
-        return (d.sphereScaleX !== undefined ? d.sphereScaleX : 1) * CARD_ASPECT;
-      }),
+      aspects: Array.from({ length: N_TOTAL }, (unused, i) => cardAspect(i)),
       radius: SPHERE_R,
       frustumH: bp.CYL_FRUSTUM_H,
       colsFit: bp.CYL_COLS_FIT,
@@ -664,8 +636,6 @@ function createGlobeGalleryRuntime(
         ssyTo: mas.h / CARD_H_SPHERE,
         swhFrom: card.sphereWorldH,
         swhTo: mas.h,
-        iaFrom: card.imgAspect,
-        iaTo: mas.w / mas.h,
       };
     }
     masonryMorph.active = true;
@@ -845,15 +815,18 @@ function createGlobeGalleryRuntime(
     mesh.material.uniforms.uMotionDir.value.set(mx, my);
   }
 
-  // UV helper — drives the cover-crop through the card shader's uniforms.
-  function setCardUV(mesh, rx, ry, ox, oy) {
-    mesh.material.uniforms.uRepeat.value.set(rx, ry);
-    mesh.material.uniforms.uOffset.value.set(ox, oy);
-  }
-
-  // Sets the rounded-corner SDF's world-space aspect so corners stay circular as the card scales.
-  function setCardAspect(mesh, aspect) {
-    mesh.material.uniforms.uAspect.value = aspect;
+  // Cover-crop + corner aspect for the shape the card is drawn at THIS frame; `planeAspect`
+  // defaults to the mesh's live scale. See README (Architecture notes).
+  const uvScratch = {};
+  function applyCardFit(mesh, card, planeAspect) {
+    const aspect = planeAspect !== undefined
+      ? planeAspect
+      : CARD_ASPECT * (mesh.scale.x / (mesh.scale.y || 1));
+    const uv = coverFit(card.srcAspect, aspect, uvScratch);
+    const u = mesh.material.uniforms;
+    u.uRepeat.value.set(uv.rx, uv.ry);
+    u.uOffset.value.set(uv.ox, uv.oy);
+    u.uAspect.value = aspect;
   }
 
   // Modal DI module — assigned after the helpers its callbacks depend on. Reads live state via
@@ -1289,8 +1262,7 @@ function createGlobeGalleryRuntime(
     const fadeStart = NEAR_FADE_START * card.sphereWorldH;
     const proxFade = Math.max(0, Math.min(1, (depth - fadeEnd) / (fadeStart - fadeEnd)));
     mesh.scale.set(card.sphereScaleSX * hs, card.sphereScaleSY * hs, hs);
-    setCardUV(mesh, 1, 1, 0, 0);
-    setCardAspect(mesh, card.imgAspect);
+    applyCardFit(mesh, card);
     if (sphereRotActive) {
       mesh.quaternion.copy(sphereRotQuat).multiply(card.sphereQuat);
     } else {
@@ -1344,14 +1316,7 @@ function createGlobeGalleryRuntime(
       lerpN(stage.scale, card.sphereScaleSY, fdE),
       1,
     );
-    setCardUV(
-      mesh,
-      lerpN(card.arcRepeatX, 1, fdE),
-      lerpN(card.arcRepeatY, 1, fdE),
-      lerpN(card.arcOffsetX, 0, fdE),
-      lerpN(card.arcOffsetY, 0, fdE),
-    );
-    setCardAspect(mesh, lerpN(CARD_ASPECT, card.imgAspect, fdE));
+    applyCardFit(mesh, card); // reads the scale set just above, so the fold framing stays exact
     // Orientation slerps gridQuat → sphereQuat (upright, not the live peel orientation, which
     // would flip the face through the camera plane). The residual peel spin (stage.rotZ −
     // gridTilt, → 0 at peel end) is reapplied about local Z so it spins in-plane like the peel.
@@ -1381,8 +1346,7 @@ function createGlobeGalleryRuntime(
     mesh.visible = true;
     mesh.position.set(card.gridPos.x, card.gridPos.y, card.gridPos.z - sphGroupZ);
     mesh.scale.setScalar(card.gridScale);
-    setCardUV(mesh, card.arcRepeatX, card.arcRepeatY, card.arcOffsetX, card.arcOffsetY);
-    setCardAspect(mesh, CARD_ASPECT);
+    applyCardFit(mesh, card, CARD_ASPECT);
     mesh.quaternion.copy(card.gridQuat);
     mesh.renderOrder = N_TOTAL - i;
     mesh.material.opacity = 1;
@@ -1448,7 +1412,7 @@ function createGlobeGalleryRuntime(
   function placeArcCard(card, mesh, i, gpE, stage, prevMeshX, prevMeshY) {
     const { N_TOTAL, N_VISIBLE } = bp;
     mesh.visible = true;
-    setCardAspect(mesh, CARD_ASPECT);
+    applyCardFit(mesh, card, CARD_ASPECT); // first phase a card renders in — must fit here too
     mesh.position.set(stage.x, stage.y, stage.z);
     mesh.scale.setScalar(stage.scale);
     mesh.rotation.set(0, 0, stage.rotZ);
@@ -1492,7 +1456,6 @@ function createGlobeGalleryRuntime(
       card.sphereScaleSX = lerpN(mo.ssxFrom, mo.ssxTo, e);
       card.sphereScaleSY = lerpN(mo.ssyFrom, mo.ssyTo, e);
       card.sphereWorldH = lerpN(mo.swhFrom, mo.swhTo, e);
-      card.imgAspect = lerpN(mo.iaFrom, mo.iaTo, e);
     }
 
     // Arc → grid peel stagger: i-based cascade + per-card jitter.
@@ -1609,7 +1572,7 @@ function createGlobeGalleryRuntime(
     if (sphereFormT <= TL.TEXT_APPEAR_START) {
       // Hidden until the fold is underway.
       textMesh.visible = false;
-      textMesh.scale.setScalar(TEXT_SCALE_ENTER);
+      textMesh.scale.setScalar(1); // plane is viewport-sized; the warp does the entrance
       return;
     }
 
@@ -1920,43 +1883,36 @@ function createGlobeGalleryRuntime(
     syncTicker();
 
     const loadGeneration = textureLoadGeneration;
-    const onEachTexture = (i, tex, texData) => {
+    const onEachTexture = (i, tex, srcAspect) => {
       if (loadGeneration !== textureLoadGeneration) { tex.dispose(); return; }
       textures[i] = tex;
-      cardTexData[i] = texData;
+      cardAspects[i] = srcAspect;
       const card = cards[i];
       if (!card) return;
       card.mesh.material.map = tex; // property proxy writes uMap
-      // Cover-crop UVs (used by the arc/grid/fold phases; the sphere renders identity UVs).
-      card.arcRepeatX = texData.arcRepeatX;
-      card.arcRepeatY = texData.arcRepeatY;
-      card.arcOffsetX = texData.arcOffsetX;
-      card.arcOffsetY = texData.arcOffsetY;
-      // Native image aspect — the modal reads this on every breakpoint for its plane aspect.
-      card.sphereScaleX = texData.sphereScaleX;
+      card.srcAspect = srcAspect; // every phase's fit derives from it; the modal falls back to it
       // md sphere also sizes the rendered card per-card now (positions are index-based, no reflow);
       // the sm barrel packs against all aspects, so it re-solves its render sizing once in onDone.
-      if (!bp.CYLINDER) updateCardSphereSizing(card, texData.sphereScaleX);
+      if (!bp.CYLINDER) updateCardSphereSizing(card, srcAspect);
       card.hasTexture = true; // revealT eases up in updateCardTransform
     };
-    const onDoneTextures = (loadedTextures, loadedTexData) => {
+    const onDoneTextures = (loadedTextures, loadedAspects) => {
       if (loadGeneration !== textureLoadGeneration) {
         loadedTextures.forEach((t) => t && t.dispose());
         return;
       }
       textures = loadedTextures;
-      cardTexData = loadedTexData;
+      cardAspects = loadedAspects;
       if (bp.CYLINDER) resolveMasonryLayout(); // recomputeDragFlip runs when the morph settles
       else recomputeDragFlip();
     };
-    const cardMaxTex = bp.name === 'sm' ? CARD_TEX_SM : CARD_TEX_MD;
+    const cardMaxTexH = bp.name === 'sm' ? CARD_TEX_SM : CARD_TEX_MD;
     loadCardTextures({
       count: bp.N_TOTAL,
-      // Request the image already sized to our texture cap so slow links download ~tens of KB,
-      // not the full-res source (we downscale to cardMaxTex client-side regardless).
-      getSrc: (i) => optimizeImgUrl(getCardMetadata(i).img, cardMaxTex),
-      planeAspect: CARD_ASPECT,
-      maxTex: cardMaxTex,
+      // Ask at the cap so slow links download ~tens of KB, not the full-res source. By HEIGHT,
+      // matching fitCardDims (the service clamps to native — it never upscales).
+      getSrc: (i) => optimizeImgUrl(getCardMetadata(i).img, cardMaxTexH, 'height'),
+      maxTexH: cardMaxTexH,
     }, onEachTexture, onDoneTextures);
     return true;
   }
@@ -2023,7 +1979,7 @@ function createGlobeGalleryRuntime(
     masonryMorph.active = false; masonryMorph.t = 0;
     cards = [];
     textures = [];
-    cardTexData = [];
+    cardAspects = [];
     // Free the hint-text GPU resources + reset its exit progress before scene teardown.
     disposeTextMesh();
     textExitProgress = 0;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -1339,15 +1339,9 @@ function createGlobeGalleryRuntime(
     mesh.material.uniforms.uDisperse.value = proxDis ** NEAR_FADE_DISPERSE_RAMP;
     mesh.material.uniforms.uReveal.value = card.revealT;
     mesh.material.uniforms.uContourFade.value = proxFade;
-    // Hover CA is additive on transition CA; uHoverPos anchors the warp at the cursor UV.
+    // Hover uniforms come from updateCardTransform; this phase only adds the drag warp.
     if (CA_ENABLED) {
-      mesh.material.uniforms.uCA.value = cardCA + card.hoverT * HOVER_CA;
       mesh.material.uniforms.uWarp.value = card.hoverT * HOVER_WARP + sphereDragWarp;
-      if (card.hoverT > 0.01) {
-        mesh.material.uniforms.uHoverPos.value.copy(card.hoverUV);
-      } else {
-        mesh.material.uniforms.uHoverPos.value.set(0.5, 0.5);
-      }
     }
     // CA smear: approximate world delta as depth × angular velocity (front cards smear more).
     applyMotionCA(mesh, card.spherePos.z * drag.velX, -card.spherePos.z * drag.velY);
@@ -1370,9 +1364,12 @@ function createGlobeGalleryRuntime(
       lerpN(stage.y, sY, fdE),
       lerpN(stage.z, sZ, fdE),
     );
+    // Hover lands before the fold ends, so scale for it here too or the card pops at fdE 1.
+    // Both axes, so applyCardFit's aspect is unchanged.
+    const hs = 1 + card.hoverT * HOVER_SCALE;
     mesh.scale.set(
-      lerpN(stage.scale, card.sphereScaleSX, fdE),
-      lerpN(stage.scale, card.sphereScaleSY, fdE),
+      lerpN(stage.scale, card.sphereScaleSX, fdE) * hs,
+      lerpN(stage.scale, card.sphereScaleSY, fdE) * hs,
       1,
     );
     applyCardFit(mesh, card); // reads the scale set just above, so the fold framing stays exact
@@ -1530,14 +1527,24 @@ function createGlobeGalleryRuntime(
         entryRot / TL.ENTRY_ROT_MAX,
         gpE * (1 - gpE) * 4,
         fdE * (1 - fdE) * 4,
-      ) * CA_STRENGTH;
-      mesh.material.uniforms.uCA.value = cardCA;
-      mesh.material.uniforms.uWarp.value = 0; // sphere block re-applies from hoverT below
+      ) * CA_STRENGTH; // written to uCA with the hover term below
     }
 
     // Hover ease gates on the GLOBAL interactive threshold, not per-card fdE.
     if (sphereFormT < TL.SPHERE_INTERACTIVE_T || reducedMotion) card.hoverTarget = 0;
     card.hoverT += (card.hoverTarget - card.hoverT) * HOVER_RATE;
+
+    // Applied here, not in placeSphereCard: the gate above is global but fdE is per-card, so a
+    // card still folding at fdE 0.999 would raise hoverT and render nothing. See README.
+    if (CA_ENABLED) {
+      mesh.material.uniforms.uCA.value = cardCA + card.hoverT * HOVER_CA;
+      mesh.material.uniforms.uWarp.value = card.hoverT * HOVER_WARP;
+      if (card.hoverT > 0.01) {
+        mesh.material.uniforms.uHoverPos.value.copy(card.hoverUV);
+      } else {
+        mesh.material.uniforms.uHoverPos.value.set(0.5, 0.5);
+      }
+    }
 
     // Contour/reveal defaults for the non-sphere phases. uDissolve is shared with the sphere
     // phase's near-camera dissolve, so it must be (re)set every frame.

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -342,7 +342,8 @@ function createGlobeGalleryRuntime(
 
   let blockDocTop = 0; // block's top in document space (the scroll runway)
   let blockHeight = 0; // its full scroll length
-  // zoomT the pull-quote fades in at; from the camera (see publishPqAppearZoomT)
+  // zoomT the camera clears the shell's far wall at; from the geometry (see
+  // publishPqAppearZoomT). TWO consumers: the pull-quote's reveal and the globe controls' hide.
   let pqAppearZoomT = 0.5;
   let formationVh = 0; // from --gg-formation-vh (see readCssVars)
   let W = 0;
@@ -996,7 +997,7 @@ function createGlobeGalleryRuntime(
     q,
     labels,
     getVisible: () => frameState.sphereFormT >= TL.SPHERE_INTERACTIVE_T
-      && frameState.zoomT < TL.CONTROLS_ZOOM_HIDE_T
+      && frameState.zoomT < pqAppearZoomT
       && modal.getModalIdx() < 0,
     rotate: rotateStep,
   });

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -772,7 +772,7 @@ function createGlobeGalleryRuntime(
     if (!deltas.length) return;
     // Skip a boundary we're already on, else ambient drift eats the press.
     const deadzone = ((2 * Math.PI) / deltas.length) * ROTATE_DEADZONE;
-    const ahead = deltas.filter((d) => d * dir > deadzone);
+    const ahead = deltas.filter((d) => d * (cameraInsideSphere ? -dir : dir) > deadzone);
     if (!ahead.length) return; // one column: nothing to step to
     const delta = ahead.reduce((a, b) => (Math.abs(a) < Math.abs(b) ? a : b));
     navNudge.targetY = from + delta;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -923,16 +923,16 @@ function createGlobeGalleryRuntime(
     getSphereInteractive: () => frameState.sphereFormT >= TL.SPHERE_INTERACTIVE_T,
     getModalOpen: () => modal.getModalIdx() >= 0,
     getReducedMotion: () => reducedMotion,
-    // Two-step exit off the shared hint signal (see the threshold constants).
-    getHintDismissed: () => textExitProgress > TL.CURSOR_HINT_DISMISS_T
-      || frameState.zoomT > TL.CURSOR_ZOOM_DISMISS_T,
-    getCursorRetired: () => textExitProgress > TL.CURSOR_RETIRE_T
+    // Two-step exit on drag activity; scrolling out collapses both steps
+    getHintDismissed: () => textExitProgress > TL.CURSOR_DRAG_DISMISS_T
+      || frameState.zoomT > TL.CURSOR_ZOOM_RETIRE_T,
+    getCursorRetired: () => textExitProgress > TL.CURSOR_DRAG_RETIRE_T
       || frameState.zoomT > TL.CURSOR_ZOOM_RETIRE_T,
     labelText: hintText || 'Click & Drag',
     drag,
   });
 
-  // Rad per pointer px, live off the viewport + band. See README (Drag physics).
+  // Rad per pointer px, live off the viewport + band. See README (Drag physics)
   const dragSensitivity = () => {
     const radiusPx = (bp.SPHERE_R * H) / bp.CYL_FRUSTUM_H;
     return ((Math.PI / 2) * bp.DRAG_GEARING) / Math.max(1, radiusPx);
@@ -1514,16 +1514,16 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  // Owns textExitProgress (hint dissolve + cursor retirement). Separate from updateClickDragText
-  // because that stage early-returns before the interactive range, which is what resets this.
+  // Owns textExitProgress (hint dissolve + cursor retirement) for both consumers — the hint plane
+  // and the cursor label. A separate stage because updateClickDragText early-returns below
+  // TEXT_APPEAR_START. Monotonic 0→1 and never re-armed: the first drag retires the hint for the
+  // life of this runtime. See README (hint text).
   function updateHintExitProgress(frame) {
     const { sphereFormT } = frame;
-    // Reset on scroll-out of the interactive range (fresh on re-entry).
-    if (sphereFormT < TL.SPHERE_INTERACTIVE_T) {
-      textExitProgress = 0;
-      return;
-    }
-    if (reducedMotion || !drag.isDragging || textExitProgress >= 1) return;
+    if (textExitProgress >= 1 || reducedMotion || !drag.isDragging) return;
+    // A held drag can scroll out of the live range (pointer capture outlives the gate) — a globe
+    // that isn't interactive must not accrue.
+    if (sphereFormT < TL.SPHERE_INTERACTIVE_T) return;
     // A vertical touch drag is page scroll, not a globe drag — don't accrue during it.
     if (interaction.isPageScrollGesture()) return;
     const spd = Math.sqrt(drag.velX * drag.velX + drag.velY * drag.velY);

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -342,7 +342,7 @@ function createGlobeGalleryRuntime(
 
   let blockDocTop = 0; // block's top in document space (the scroll runway)
   let blockHeight = 0; // its full scroll length
-  // zoomT the pull-quote fades in at; from --gg-pq-pin-factor (see readCssVars)
+  // zoomT the pull-quote fades in at; from the camera (see publishPqAppearZoomT)
   let pqAppearZoomT = 0.5;
   let formationVh = 0; // from --gg-formation-vh (see readCssVars)
   let W = 0;
@@ -903,13 +903,23 @@ function createGlobeGalleryRuntime(
       const n = parseFloat(rootStyle.getPropertyValue(prop));
       return Number.isFinite(n) ? n : null;
     };
-    const pinFactor = cssNum('--gg-pq-pin-factor');
-    if (pinFactor !== null) pqAppearZoomT = Math.max(0, (1 - pinFactor) - TL.PQ_APPEAR_LEAD);
     const vh = cssNum('--gg-formation-vh');
     if (vh !== null) formationVh = vh;
   }
 
   const measureViewportH = () => Math.max(1, worldEl.offsetHeight);
+
+  // The quote's cue is a place in the scene, not a scroll number: the zoomT the camera clears the
+  // shell's far wall at, so it can never land while cards are still in frame. Cards mount radially,
+  // so the deepest one sits hypot(R, half its in-plane extent) back. Published to CSS — see README.
+  function publishPqAppearZoomT() {
+    const halfExtent = bp.CYLINDER
+      ? bp.CARD_W_SPHERE / 2
+      : Math.hypot(bp.CARD_W_SPHERE, bp.CARD_H_SPHERE) / 2;
+    const clearZ = -Math.hypot(bp.SPHERE_R, halfExtent);
+    pqAppearZoomT = TL.zoomTAtCamZ(clearZ, bp.CAM_Z_SPHERE, bp.CAM_Z_END);
+    root.style.setProperty('--gg-pq-appear-t', pqAppearZoomT.toFixed(4));
+  }
 
   // Scroll px from the block top where the sphere is formed. See README (Scroll model).
   function formedScrollPx() {
@@ -1216,7 +1226,7 @@ function createGlobeGalleryRuntime(
     if (reducedMotion) return;
     if (pqEl) {
       if (zoomT >= pqAppearZoomT && !pqShown) {
-        pqEl.style.transition = ''; // restore CSS default (0.7s, set in .css)
+        pqEl.style.transition = ''; // restore CSS default (0.45s, set in .css)
         pqShown = true;
         pqEl.classList.add('is-active');
       } else if (zoomT < pqAppearZoomT && pqShown) {
@@ -1798,6 +1808,7 @@ function createGlobeGalleryRuntime(
     // Resolve the breakpoint profile before anything reads bp.*.
     const band = resolveBP(W);
     bp = resolveBpProfile(band.name, band.cfg, usesCylinderGeometry(band.name));
+    publishPqAppearZoomT();
 
     try {
       const aa = bp.name === 'sm' ? ANTIALIAS_SM : ANTIALIAS_MD;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -145,6 +145,7 @@ const FACING_EDGE_ON_BAND = 0.25; // |normal.z| half-width of the facing fade-ou
 const DRAG_FLIP_MAX_CAM_FRAC = 0.95; // ceiling on dragFlipZ as a fraction of CAM_Z_SPHERE
 const NEAR_FADE_START = 2.5; // begin fading below 2.5 card-heights depth
 const NEAR_FADE_END = 1.6; // fully transparent below 1.6 card-heights
+const NEAR_FADE_OPACITY_BIAS = 0.4; // exponent on the prox opacity ramp (< 1 = fade out later)
 
 // Sphere-drag warp: baseline while dragging + velocity burst that decays via DRAG_FRICTION.
 const SPHERE_DRAG_WARP_BASELINE = 0.05; // constant while isDragging
@@ -1274,8 +1275,9 @@ function createGlobeGalleryRuntime(
     // opacity): take the max dissolve / min opacity so neither un-hides what the other hides.
     const proxDis = 1 - proxFade;
     const revealDis = 1 - card.revealT;
-    mesh.material.opacity = Math.min(proxFade, card.revealT);
+    mesh.material.opacity = Math.min(proxFade ** NEAR_FADE_OPACITY_BIAS, card.revealT);
     mesh.material.uniforms.uDissolve.value = Math.max(proxDis, revealDis);
+    mesh.material.uniforms.uDisperse.value = proxDis;
     mesh.material.uniforms.uReveal.value = card.revealT;
     mesh.material.uniforms.uContourFade.value = proxFade;
     // Hover composes additively on transition CA. uHoverPos anchors the warp at the cursor UV
@@ -1494,6 +1496,7 @@ function createGlobeGalleryRuntime(
     mesh.material.uniforms.uReveal.value = card.revealT;
     mesh.material.uniforms.uContourFade.value = 1;
     mesh.material.uniforms.uDissolve.value = 1 - card.revealT;
+    mesh.material.uniforms.uDisperse.value = 0;
 
     // Capture position before the branch updates it — delta drives motion CA.
     const prevMeshX = mesh.position.x;

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -1857,7 +1857,8 @@ function createGlobeGalleryRuntime(
 
     // Build up front so the block paints immediately; photos un-dissolve in as they land.
     buildCards();
-    buildTextMesh();
+
+    if (!bp.CYLINDER) buildTextMesh();
     a11y.setup();
     renderReady = true;
     syncTicker();

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -926,6 +926,12 @@ function createGlobeGalleryRuntime(
     modal.open(idx, x, y);
   };
 
+  // Canvas taps only — the keyboard path reports itself. See README (Analytics).
+  const openModalFromCanvas = (idx, x, y) => {
+    openModalAndDismissHint(idx, x, y);
+    if (modal.getModalIdx() >= 0) a11y?.trackCardOpen(idx);
+  };
+
   a11y = createGalleryA11y({
     q,
     getCount: () => bp.N_TOTAL,
@@ -966,7 +972,7 @@ function createGlobeGalleryRuntime(
     getCamera: () => camera,
     getCards: () => cards,
     getModalIdx: () => modal.getModalIdx(),
-    openModal: (idx, x, y) => openModalAndDismissHint(idx, x, y),
+    openModal: (idx, x, y) => openModalFromCanvas(idx, x, y),
     getSphereFormT: () => frameState.sphereFormT,
     interactiveThreshold: TL.SPHERE_INTERACTIVE_T,
     maxVel: MAX_VEL,

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -9,9 +9,10 @@ import createGlobeModal from './src/modal.js';
 import createInteraction from './src/interaction.js';
 import createCursor from './src/cursor.js';
 import {
-  easeOutCubic, easeInOutCubic, easeOutSine, lerpN,
+  easeOutCubic, easeInOutCubic, lerpN,
   buildArcCtx, getFanData, cssToWorld, rotateArcPoint, arcCamZ,
 } from './src/math.js';
+import * as TL from './src/timeline.js';
 
 const CARD_ASPECT = 456 / 631; // portrait
 
@@ -92,54 +93,14 @@ function usesCylinderGeometry(bandName) {
   return !!window.matchMedia?.('(pointer: coarse)').matches;
 }
 
-// Phase timeline (progress 0→1 across the full scroll length). See README (Phase constants).
+// Scroll-timing constants live in src/timeline.js.
 const ARC_STAGGER = 0.594;
-const PROGRESS_PAN_END = 0.55;
-const PROGRESS_ARC_PREROLL = 0.30;
-// Grid peel expressed as arc-rotation fraction (0=arc start, 1=arc end).
-const PROGRESS_GRID_ARC_START = 0.30;
-const PROGRESS_GRID_ARC_END = 0.60;
-const PROGRESS_FOLD_DUR = 0.25;
-const PROGRESS_ZOOM_END = 1.00;
-// Pull-quote fade-in lead before the pin centres: pqAppearZoomT = (1 − --pq-pin-factor) − this (set
-// per breakpoint in doLayout). See README → runway / progress model.
-const PQ_APPEAR_LEAD = 0.03;
-// Peel stagger; defined here since the fold window derives from it.
-const GRID_PEEL_STAGGER = 0.20;
-// Grid→sphere fold overlap. See README (FOLD_PEEL_OVERLAP). 0 restores "settle then fold".
-const FOLD_PEEL_OVERLAP = 0.35;
-const FOLD_START_LOCAL_T = 1 - (FOLD_PEEL_OVERLAP ** (1 / 3));
-const GRID_ARC_RANGE = PROGRESS_GRID_ARC_END - PROGRESS_GRID_ARC_START;
-const FOLD_FIRST_PROGRESS = Math.max(
-  0,
-  (PROGRESS_GRID_ARC_START
-    + FOLD_START_LOCAL_T * (1 - GRID_PEEL_STAGGER) * GRID_ARC_RANGE
-    - PROGRESS_ARC_PREROLL) * PROGRESS_PAN_END,
-);
-// Progress at sphereFormT=1, zoomT=0 — the "interactive globe" position keyboard focus snaps
-// to. Mirrors computeFrame's foldLast (single source).
-const SPHERE_FORMED_PROGRESS = Math.max(
-  0,
-  (PROGRESS_GRID_ARC_START
-    + Math.min(1, GRID_PEEL_STAGGER + FOLD_START_LOCAL_T * (1 - GRID_PEEL_STAGGER))
-      * (PROGRESS_GRID_ARC_END - PROGRESS_GRID_ARC_START)
-    - PROGRESS_ARC_PREROLL) * PROGRESS_PAN_END,
-) + PROGRESS_FOLD_DUR;
-
-// Fixed formation scroll length; `progress` is remapped piecewise around it so trimming the runway
-// only compresses the tail. Keep = --formation-vh (CSS). See README → runway / progress model.
-const FORMATION_SCROLL_VH = 304; // ≈ SPHERE_FORMED_PROGRESS × 945
-
-// Entry timing — two independent knobs. See README (Entry timing).
-const ENTRY_LEAD_VH = 0.4;
-const ENTRY_RAMP_VH = 1.05;
 
 // Reduced motion: shrink the static desktop sphere so the whole ball fits (sm left at 1).
 const RM_GLOBE_SCALE_MD = 0.9;
 
 // Grid peel / fold.
 const GRID_GAP_RATIO = 0.5; // gap between cards = 0.5× card width
-const ARC_PEEL_JITTER = 0.40; // per-card random offset on gpDelay — organic cascade
 // Non-uniform fanT split: low-i cards cluster into fanT [0, this] off-screen and peel first;
 // the rest spread across the visible upper arc. ARC_DENSE_COUNT (per-BP) scales with N_TOTAL.
 const ARC_DENSE_SPLIT = 0.50;
@@ -158,16 +119,12 @@ const KEY_BROWSE_FRAMES = 90;
 const KEY_MODAL_FRAMES = 20;
 const RING_TANHALF = Math.tan(Math.PI / 6); // tan(30°) — projects a card for the focus ring
 
-// Sphere becomes interactive at this sphereFormT (grabbable mid-fold). See README.
-const SPHERE_INTERACTIVE_T = 0.8;
-
 // Chromatic aberration.
 const CA_ENABLED = true; // master kill switch
 const CA_STRENGTH = 0.012; // radial UV shift per channel (bell-curve at transition peaks)
 const CA_MOTION_STRENGTH = 1.0; // directional UV shift max — peel / fold / sphere / modal
 const CA_MOTION_STRENGTH_ARC = 0.04; // softer clamp while cards sit on the arc
 const SCROLL_VEL_MAX = 14; // px/frame scroll speed that saturates the motion trail
-const SCROLL_VEL_DEADBAND = 7; // px/frame below this = Lenis settle noise → no CA
 const CA_PX_MAX = 4; // max vertical pixel shift for the global canvas SVG filter
 
 // Hover (sphere phase only) — settles in/out, no continuous animation.
@@ -197,19 +154,12 @@ const SPHERE_DRAG_WARP_MAX = 0.25; // cap on combined value
 const TEXT_BEHIND_GAP = 15; // world units behind the sphere's back surface
 const TEXT_WARP_ENTER_MAX = 4.50; // uWarp at entrance
 const TEXT_SCALE_ENTER = 1.0; // plane stays viewport-sized; warp handles the look
-const TEXT_APPEAR_START = 0.10; // sphereFormT before the text starts appearing
 const TEXT_OPACITY_PEAK = 0.15; // opacity at peak fade-in
 const TEXT_OPACITY_RESTING = 0.06; // settled opacity once the sphere is formed
 const TEXT_CA_DIR_STRENGTH = 0.05; // uMotionDir strength for drag CA on the text
 const TEXT_CA_WARP_MUL = 1.5; // warp-driven CA boost
 const TEXT_DRAG_WARP_MUL = 3.0; // text drag-warp vs sphere cards — more violent
 const TEXT_WARP_OVERFLOW = 0.6; // extra mesh scale per warp unit — letterforms bleed off
-// Two-step cursor retirement (label, then whole cursor), off textExitProgress (drag) or zoomT (once
-// the camera clears the globe). Thresholds/constraints: README → runway / progress model.
-const CURSOR_HINT_DISMISS_T = 0.12;
-const CURSOR_RETIRE_T = 0.55;
-const CURSOR_ZOOM_DISMISS_T = 0.38;
-const CURSOR_ZOOM_RETIRE_T = 0.40;
 
 const GOLDEN_ANGLE = Math.PI * (1 + Math.sqrt(5));
 // Cylindrical masonry layout — a WHOLE-SET solve (card heights depend on image aspects, so
@@ -391,8 +341,11 @@ function createGlobeGalleryRuntime(
   let gridCardW = 0; let
     gridTilts = [];
 
-  let progress = 0;
-  let arcCopyEntryT = 0;
+  // Persistent clock context + its input (see src/timeline.js). frameState is the single source
+  // for the clocks — don't cache them in the closure. See README (Module layout).
+  const frameState = TL.createFrame();
+  const frameInput = TL.createFrameInput();
+
   let blockDocTop = 0; // block's top in document space (the scroll runway)
   let blockHeight = 0; // its full scroll length
   let pqAppearZoomT = 0.5; // zoomT the pull-quote fades in at; from --pq-pin-factor (see doLayout)
@@ -405,14 +358,8 @@ function createGlobeGalleryRuntime(
   let caFilterR = null; // SVG feOffset element for red channel
   let caFilterB = null; // SVG feOffset element for blue channel
   let globalCaFilterOn = false; // whether canvas.style.filter currently holds the CA url
-  // Arc-copy overlay: cached node + last-written style strings (see updateArcCopy).
-  let arcCopyEl = null;
-  let arcCopyInlineStartSide = '';
-  let arcCopyInlineStartStr = '';
-  let arcCopyOpStr = '';
-  let arcCopyTransformStr = '';
-  let prevLenisY = 0; // previous frame scroll position
-  let scrollVel = 0; // |lenisY - prevLenisY| — drives motion trail intensity
+  // Cached node + last-written style strings (DOM writes only on change).
+  const arcCopy = { el: null, startSide: '', startStr: '', opStr: '', transformStr: '' };
 
   const drag = { isDragging: false, velX: 0, velY: 0 };
   let renderReady = false;
@@ -428,21 +375,19 @@ function createGlobeGalleryRuntime(
   // sphere/fold blocks (sphereGroup.rotation stays identity). Source is a pitch/yaw Euler
   // pair; sphereRotQuat is rebuilt each frame and shared by reference into modal.js. 'XYZ'
   // keeps the clamped pitch as the outer rotation (self-levels; no gimbal flip). See README
-  // (Sphere rotation) and the sphere-rotation-state notes below.
-  let sphereRotY = 0; // yaw — unclamped turntable spin
-  let sphereRotX = 0; // pitch — clamped ±π/3 in updateSphereRotation
-  // Screen-space roll (world Z), outer premultiply. 0 for drag; set only by keyboard centring
-  // to upright a focused card, eased to 0 once browsing ends.
-  let sphereRotZ = 0;
+  // (Sphere rotation). x = pitch, y = yaw, z = keyboard-uprighting roll.
+  const sphereOrient = { x: 0, y: 0, z: 0 };
+  // Pitch cap that glides ±85°→±60° when leaving browse (see updateSphereRotation).
+  let pitchReleaseCap = Math.PI / 3;
   const sphereRotEuler = new THREE.Euler(0, 0, 0, 'XYZ');
   const sphereRotQuat = new THREE.Quaternion();
   const screenRollQuat = new THREE.Quaternion();
   const Z_UNIT = new THREE.Vector3(0, 0, 1);
   const refreshSphereRotQuat = () => {
-    sphereRotEuler.set(sphereRotX, sphereRotY, 0);
+    sphereRotEuler.set(sphereOrient.x, sphereOrient.y, 0);
     sphereRotQuat.setFromEuler(sphereRotEuler);
-    if (sphereRotZ !== 0) {
-      screenRollQuat.setFromAxisAngle(Z_UNIT, sphereRotZ);
+    if (sphereOrient.z !== 0) {
+      screenRollQuat.setFromAxisAngle(Z_UNIT, sphereOrient.z);
       sphereRotQuat.premultiply(screenRollQuat); // world-Z roll applied last (screen space)
     }
   };
@@ -455,29 +400,30 @@ function createGlobeGalleryRuntime(
   const wpScratch = {};
   const stageScratch = {};
 
-  let navNudgeActive = false;
-  let navNudgeTargetY = 0;
-  let navNudgeTargetX = 0;
-  let navNudgeTargetZ = 0; // roll target — keyboard centring only (modal leaves it at current)
-  let navNudgeStartY = 0; // ease start pose (captured when the nudge is armed)
-  let navNudgeStartX = 0;
-  let navNudgeStartZ = 0;
-  let navNudgeFrame = 0; // frames elapsed
-  let navNudgeFrames = 0; // total frames for this nudge (KEY_BROWSE_FRAMES / KEY_MODAL_FRAMES)
+  // Sphere-to-card alignment tween. See README (Module layout → grouped closure state).
+  const navNudge = {
+    active: false,
+    targetX: 0,
+    targetY: 0,
+    targetZ: 0,
+    startX: 0,
+    startY: 0,
+    startZ: 0,
+    frame: 0,
+    frames: 0,
+  };
   const kbTargetQuat = new THREE.Quaternion(); // scratch: keyboard-centring target orientation
   const kbTargetEuler = new THREE.Euler(0, 0, 0, 'XYZ');
   const kbUp = new THREE.Vector3(); // scratch: focused card's world up (for the upright roll)
   let wasBrowsing = false; // tracks the keyboard-gallery browse edge
-  // Pitch cap that glides ±85°→±60° when leaving browse (see updateSphereRotation).
-  let pitchReleaseCap = Math.PI / 3;
   // Return the sphere to its upright resting orientation. Shared by the scroll-out zero and
   // the rebuild. Does NOT touch drag velocity or sphereDragWarp (callers handle those).
   function resetSphereOrientation() {
-    sphereRotX = 0;
-    sphereRotY = 0;
-    sphereRotZ = 0;
+    sphereOrient.x = 0;
+    sphereOrient.y = 0;
+    sphereOrient.z = 0;
     pitchReleaseCap = Math.PI / 3;
-    navNudgeActive = false;
+    navNudge.active = false;
   }
   // Scratch for applyCardFacing (reused per card, per frame — never retained).
   const cardNormal = new THREE.Vector3();
@@ -770,11 +716,6 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  // sphereFormT is computed in tick(); cached so interaction.js's click/hover handlers
-  // (which fire between ticks) know whether the sphere is clickable.
-  let sphereFormTAtLastTick = 0;
-  let zoomTAtLastTick = 0;
-
   // Card facing — tilts limb cards partway toward the camera so edge-on slivers stay legible.
   // MUST be per-frame (the sphere rotates). Target is sign(n.z) × view dir so back cards keep
   // facing away. k=0 is a true sphere (no-op). `amount` (fold passes fdE) eases the tilt in.
@@ -801,7 +742,7 @@ function createGlobeGalleryRuntime(
   // doesn't flash an unrotated card for one frame before tick() re-applies rotation.
   function snapCardToSphereSlot(card) {
     if (!card || !card.mesh) return;
-    const hasRot = (sphereRotY !== 0 || sphereRotX !== 0 || sphereRotZ !== 0);
+    const hasRot = (sphereOrient.y !== 0 || sphereOrient.x !== 0 || sphereOrient.z !== 0);
     if (hasRot) {
       refreshSphereRotQuat();
       card.mesh.position.copy(card.spherePos).applyQuaternion(sphereRotQuat);
@@ -822,16 +763,16 @@ function createGlobeGalleryRuntime(
   // globe both terms flip to the far (−Z) wall. Used by the modal + keyboard gallery.
   function cardCenterYawPitch(idx, pitchCap, yawOnly) {
     const { spherePos } = cards[idx];
-    const cy = Math.cos(sphereRotY);
-    const sy = Math.sin(sphereRotY);
+    const cy = Math.cos(sphereOrient.y);
+    const sy = Math.sin(sphereOrient.y);
     const px = spherePos.x * cy + spherePos.z * sy;
     const pz = -spherePos.x * sy + spherePos.z * cy;
     const inside = cameraInsideSphere;
     let deltaY = -Math.atan2(px, pz); // → +Z (near wall, camera outside)
     if (inside) deltaY += Math.PI; // → −Z (far wall, camera inside)
     deltaY = Math.atan2(Math.sin(deltaY), Math.cos(deltaY)); // shortest signed spin
-    const targetYaw = sphereRotY + deltaY;
-    if (yawOnly) return { targetYaw, targetPitch: sphereRotX };
+    const targetYaw = sphereOrient.y + deltaY;
+    if (yawOnly) return { targetYaw, targetPitch: sphereOrient.x };
     const h = Math.sqrt(px * px + pz * pz); // horizontal radius after yaw alignment
     const pitchMag = Math.atan2(spherePos.y, h); // drives the card's height → centre
     const targetPitch = Math.max(-pitchCap, Math.min(pitchCap, inside ? -pitchMag : pitchMag));
@@ -841,15 +782,15 @@ function createGlobeGalleryRuntime(
   function centerModalCard(idx) {
     if (!cards[idx]) return;
     const { targetYaw, targetPitch } = cardCenterYawPitch(idx, Math.PI / 3, bp.YAW_ONLY);
-    navNudgeTargetY = targetYaw;
-    navNudgeTargetX = targetPitch;
-    navNudgeTargetZ = sphereRotZ; // no roll change — keep the globe level
-    navNudgeStartY = sphereRotY;
-    navNudgeStartX = sphereRotX;
-    navNudgeStartZ = sphereRotZ;
-    navNudgeFrames = KEY_MODAL_FRAMES;
-    navNudgeFrame = reducedMotion ? KEY_MODAL_FRAMES : 0;
-    navNudgeActive = true;
+    navNudge.targetY = targetYaw;
+    navNudge.targetX = targetPitch;
+    navNudge.targetZ = sphereOrient.z; // no roll change — keep the globe level
+    navNudge.startY = sphereOrient.y;
+    navNudge.startX = sphereOrient.x;
+    navNudge.startZ = sphereOrient.z;
+    navNudge.frames = KEY_MODAL_FRAMES;
+    navNudge.frame = reducedMotion ? KEY_MODAL_FRAMES : 0;
+    navNudge.active = true;
   }
 
   // Keyboard-gallery centring: rotate so card `idx` lands dead-centre and stands upright.
@@ -865,18 +806,18 @@ function createGlobeGalleryRuntime(
     kbUp.set(0, 1, 0).applyQuaternion(kbTargetQuat);
     const rollTarget = Math.atan2(kbUp.x, kbUp.y); // screen-Z roll that returns up → +Y
     const dRoll = Math.atan2(
-      Math.sin(rollTarget - sphereRotZ),
-      Math.cos(rollTarget - sphereRotZ),
+      Math.sin(rollTarget - sphereOrient.z),
+      Math.cos(rollTarget - sphereOrient.z),
     );
-    navNudgeTargetY = targetYaw;
-    navNudgeTargetX = targetPitch;
-    navNudgeTargetZ = sphereRotZ + dRoll; // shortest-path roll
-    navNudgeStartY = sphereRotY;
-    navNudgeStartX = sphereRotX;
-    navNudgeStartZ = sphereRotZ;
-    navNudgeFrames = KEY_BROWSE_FRAMES;
-    navNudgeFrame = reducedMotion ? KEY_BROWSE_FRAMES : 0;
-    navNudgeActive = true;
+    navNudge.targetY = targetYaw;
+    navNudge.targetX = targetPitch;
+    navNudge.targetZ = sphereOrient.z + dRoll; // shortest-path roll
+    navNudge.startY = sphereOrient.y;
+    navNudge.startX = sphereOrient.x;
+    navNudge.startZ = sphereOrient.z;
+    navNudge.frames = KEY_BROWSE_FRAMES;
+    navNudge.frame = reducedMotion ? KEY_BROWSE_FRAMES : 0;
+    navNudge.active = true;
     // Kill residual spin (auto-rotate/drag inertia) so it can't fight the ease.
     drag.velX = 0;
     drag.velY = 0;
@@ -895,7 +836,7 @@ function createGlobeGalleryRuntime(
     const dragSpeed = Math.sqrt(drag.velX * drag.velX + drag.velY * drag.velY);
     const amp = ampOverride !== undefined
       ? ampOverride
-      : Math.min(1.0, Math.max(scrollVel / SCROLL_VEL_MAX, dragSpeed / MAX_VEL));
+      : Math.min(1.0, Math.max(frameState.scrollVel / SCROLL_VEL_MAX, dragSpeed / MAX_VEL));
     const mx = Math.max(-s, Math.min(s, uvDX * amp));
     const my = Math.max(-s, Math.min(s, uvDY * amp));
     mesh.material.uniforms.uMotionDir.value.set(mx, my);
@@ -954,7 +895,7 @@ function createGlobeGalleryRuntime(
   // Scroll px from the block top where the sphere is fully formed (progress = foldLast); locked to
   // FORMATION_SCROLL_VH, clamped to the runway. See README → runway / progress model.
   function formedScrollPx() {
-    return Math.min((FORMATION_SCROLL_VH / 100) * H, blockHeight);
+    return Math.min((TL.FORMATION_SCROLL_VH / 100) * H, blockHeight);
   }
 
   // Focusing the widget snaps the page to the interactive globe state (formed-sphere offset;
@@ -988,9 +929,9 @@ function createGlobeGalleryRuntime(
   a11y = createGalleryA11y({
     q,
     getCount: () => bp.N_TOTAL,
-    getSphereFormT: () => sphereFormTAtLastTick,
+    getSphereFormT: () => frameState.sphereFormT,
     getModalIdx: () => modal.getModalIdx(),
-    interactiveThreshold: SPHERE_INTERACTIVE_T,
+    interactiveThreshold: TL.SPHERE_INTERACTIVE_T,
     getCardLabel: (i) => {
       const m = getCardMetadata(i);
       return (m && m.alt) || `Image ${i + 1}`;
@@ -1008,14 +949,14 @@ function createGlobeGalleryRuntime(
   // can gate interaction's hover cursor writes (the two share the canvas).
   cursor = createCursor({
     getCanvas: () => (renderer ? renderer.domElement : null),
-    getSphereInteractive: () => sphereFormTAtLastTick >= SPHERE_INTERACTIVE_T,
+    getSphereInteractive: () => frameState.sphereFormT >= TL.SPHERE_INTERACTIVE_T,
     getModalOpen: () => modal.getModalIdx() >= 0,
     getReducedMotion: () => reducedMotion,
     // Two-step exit off the shared hint signal (see the threshold constants).
-    getHintDismissed: () => textExitProgress > CURSOR_HINT_DISMISS_T
-      || zoomTAtLastTick > CURSOR_ZOOM_DISMISS_T,
-    getCursorRetired: () => textExitProgress > CURSOR_RETIRE_T
-      || zoomTAtLastTick > CURSOR_ZOOM_RETIRE_T,
+    getHintDismissed: () => textExitProgress > TL.CURSOR_HINT_DISMISS_T
+      || frameState.zoomT > TL.CURSOR_ZOOM_DISMISS_T,
+    getCursorRetired: () => textExitProgress > TL.CURSOR_RETIRE_T
+      || frameState.zoomT > TL.CURSOR_ZOOM_RETIRE_T,
     labelText: hintText || 'Click & Drag',
     drag,
   });
@@ -1026,8 +967,8 @@ function createGlobeGalleryRuntime(
     getCards: () => cards,
     getModalIdx: () => modal.getModalIdx(),
     openModal: (idx, x, y) => openModalAndDismissHint(idx, x, y),
-    getSphereFormT: () => sphereFormTAtLastTick,
-    interactiveThreshold: SPHERE_INTERACTIVE_T,
+    getSphereFormT: () => frameState.sphereFormT,
+    interactiveThreshold: TL.SPHERE_INTERACTIVE_T,
     maxVel: MAX_VEL,
     drag,
     isCursorActive: () => cursor.isActive(),
@@ -1036,87 +977,21 @@ function createGlobeGalleryRuntime(
   });
 
   // Per-frame pipeline. tick() is a thin orchestrator over the single-concern stages below;
-  // computeFrame builds one `frame` context, producer stages write results back onto it.
+  // computeFrame builds one `frameState` context, producer stages write results back onto it.
   // Stage order matters (see tick()'s note). See README (Module layout).
 
-  // Read scroll position and derive every phase progress value for this frame. Also refreshes
-  // closure scroll state read between ticks (scrollVel, sphereFormTAtLastTick).
+  // Refresh the derivation's input from live layout/scroll state, then derive onto frameState.
   function computeFrame() {
-    const { CARD_W_ARC, CARD_W_SPHERE } = bp;
-    // Reduced motion: pin scroll input to the formed-sphere position (static globe, no motion
-    // trail). The pin cancels in `progress`; canvas visibility still uses real scroll.
-    const lenisY = reducedMotion
-      ? blockDocTop + formedScrollPx()
-      : window.scrollY;
-    const scrollingDown = lenisY >= prevLenisY;
-    // px/frame scroll speed — drives the velocity-based CA. Dead-banded to suppress Lenis
-    // settle noise (sub-pixel wobble) that would otherwise shimmer near cards.
-    const rawScrollVel = reducedMotion ? 0 : Math.abs(lenisY - prevLenisY);
-    scrollVel = rawScrollVel < SCROLL_VEL_DEADBAND ? 0 : rawScrollVel;
-    prevLenisY = lenisY;
-    const entryStart = blockDocTop - H * ENTRY_LEAD_VH;
-    const entryRange = H * ENTRY_RAMP_VH;
-    arcCopyEntryT = Math.max(0, Math.min(1, (lenisY - entryStart) / entryRange));
-    // Piecewise: formation over [0, formPx] (fixed length), zoom-through + quote over the rest.
-    const rawScroll = lenisY - blockDocTop;
-    const formPx = formedScrollPx();
-    const tailPx = Math.max(1, blockHeight - formPx);
-    progress = rawScroll <= formPx
-      ? Math.max(0, Math.min(1, rawScroll / formPx)) * SPHERE_FORMED_PROGRESS
-      : SPHERE_FORMED_PROGRESS
-        + Math.max(0, Math.min(1, (rawScroll - formPx) / tailPx)) * (1 - SPHERE_FORMED_PROGRESS);
-
-    // arcPanT: preroll animates in with the entry so the arc is already moving as it enters view.
-    const arcPanT = Math.min(1, progress / PROGRESS_PAN_END + PROGRESS_ARC_PREROLL * arcCopyEntryT);
-    const slideT = Math.max(arcCopyEntryT, Math.max(0, Math.min(1, progress / 0.07)));
-    const slideE = easeOutSine(slideT);
-
-    // gridFormT driven by arc rotation (peel is relative to how far the arc has rotated).
-    const gridFormT = Math.max(0, Math.min(
-      1,
-      (arcPanT - PROGRESS_GRID_ARC_START) / (PROGRESS_GRID_ARC_END - PROGRESS_GRID_ARC_START),
-    ));
-
-    // Convert arc-pan arrival times to progress units for the fold/zoom phases.
-    const gpWin = 1.0 - GRID_PEEL_STAGGER;
-    // foldFirst: first card folds when its peel reaches FOLD_START_LOCAL_T·gpWin; foldLast
-    // (= SPHERE_FORMED_PROGRESS) tracks the latest card's finish.
-    const foldFirst = FOLD_FIRST_PROGRESS;
-    const foldLast = SPHERE_FORMED_PROGRESS;
-    const sphereFormT = Math.max(0, Math.min(1, (progress - foldFirst) / (foldLast - foldFirst)));
-    // Zoom-through starts the instant the sphere finishes forming (no interactive gap).
-    const zoomT = Math.max(0, Math.min(1, (progress - foldLast) / (PROGRESS_ZOOM_END - foldLast)));
-    sphereFormTAtLastTick = sphereFormT; // cache for interaction's click/hover handlers
-    zoomTAtLastTick = zoomT;
-
-    // Card-entry transforms (arc branch): entryRot sweeps the arc in after a 5% hold;
-    // entryYOffset is the vertical slide-up; arcScale is the arc→sphere size ratio.
-    const arcEntryT = Math.max(0, Math.min(1, (arcCopyEntryT - 0.05) / 0.95));
-    const entryRot = (1 - easeOutCubic(arcEntryT)) * 0.9;
-    const entryYOffset = (1 - slideE) * H * 0.30;
-    const arcScale = CARD_W_ARC / CARD_W_SPHERE;
-
-    return {
-      // scroll
-      lenisY,
-      scrollingDown,
-      // phase t-values
-      arcPanT,
-      gridFormT,
-      gpWin,
-      sphereFormT,
-      zoomT,
-      // card-entry transforms (arc branch)
-      entryRot,
-      entryYOffset,
-      arcScale,
-      // Filled in by the pipeline stages below (declared here so the frame shape is stable):
-      // activeCamera, sphereRotActive, sphGroupZ, foldSphDist.
-      activeCamera: null,
-      sphereRotActive: false,
-      sphGroupZ: 0,
-      foldSphDist: 0,
-    };
+    frameInput.scrollY = window.scrollY;
+    frameInput.reducedMotion = reducedMotion;
+    frameInput.blockDocTop = blockDocTop;
+    frameInput.blockHeight = blockHeight;
+    frameInput.formPx = formedScrollPx();
+    frameInput.viewportH = H;
+    frameInput.arcScale = bp.CARD_W_ARC / bp.CARD_W_SPHERE;
+    TL.deriveFrame(frameState, frameInput);
+    frameInput.prevLenisY = frameState.lenisY;
+    return frameState;
   }
 
   // Pick + position the camera for this frame and return it.
@@ -1161,21 +1036,21 @@ function createGlobeGalleryRuntime(
     // auto-spin + the drag clamp. The pitch excess eases back to 60° below.
     const browsing = a11y && a11y.isBrowsing();
     if (wasBrowsing && !browsing) {
-      navNudgeActive = false;
+      navNudge.active = false;
     }
     wasBrowsing = browsing;
 
     // Sphere-to-card alignment ease. Runs even while the modal is open (so the sphere aligns
     // behind the blur), a frame-counted easeInOutCubic tween toward the nudge target.
-    if (navNudgeActive) {
-      navNudgeFrame += 1;
-      const e = easeInOutCubic(Math.min(1, navNudgeFrame / navNudgeFrames));
-      sphereRotY = navNudgeStartY + (navNudgeTargetY - navNudgeStartY) * e;
-      sphereRotX = navNudgeStartX + (navNudgeTargetX - navNudgeStartX) * e;
-      sphereRotZ = navNudgeStartZ + (navNudgeTargetZ - navNudgeStartZ) * e;
-      if (e >= 1) navNudgeActive = false;
+    if (navNudge.active) {
+      navNudge.frame += 1;
+      const e = easeInOutCubic(Math.min(1, navNudge.frame / navNudge.frames));
+      sphereOrient.y = navNudge.startY + (navNudge.targetY - navNudge.startY) * e;
+      sphereOrient.x = navNudge.startX + (navNudge.targetX - navNudge.startX) * e;
+      sphereOrient.z = navNudge.startZ + (navNudge.targetZ - navNudge.startZ) * e;
+      if (e >= 1) navNudge.active = false;
     }
-    if (sphereFormT >= SPHERE_INTERACTIVE_T) {
+    if (sphereFormT >= TL.SPHERE_INTERACTIVE_T) {
       // Pause auto-rotation + drag while a modal is open — sphere freezes at its current rotation
       if (modal.getModalIdx() < 0) {
         if (!drag.isDragging) {
@@ -1188,24 +1063,24 @@ function createGlobeGalleryRuntime(
         // delta to keep dragging tracking the surface the user sees.
         const dragDir = cameraInsideSphere ? -1 : 1;
         // Yaw spins freely; pitch is clamped (absolute angle) so the globe self-levels.
-        sphereRotY += drag.velX * dragDir;
-        sphereRotX += drag.velY * dragDir;
+        sphereOrient.y += drag.velX * dragDir;
+        sphereOrient.x += drag.velY * dragDir;
         // Pitch cap glides via pitchReleaseCap: ±60° for drag, up to ±85° while browsing, easing
         // back to 60° (PITCH_RELAX) after browse so leaving a beyond-cap card slides, not snaps.
         const RESTING_PITCH = Math.PI / 3;
         if (browsing) {
-          sphereRotX = Math.max(-KEY_PITCH_CAP, Math.min(KEY_PITCH_CAP, sphereRotX));
-          pitchReleaseCap = Math.max(RESTING_PITCH, Math.abs(sphereRotX)); // prime the glide
+          sphereOrient.x = Math.max(-KEY_PITCH_CAP, Math.min(KEY_PITCH_CAP, sphereOrient.x));
+          pitchReleaseCap = Math.max(RESTING_PITCH, Math.abs(sphereOrient.x)); // prime the glide
         } else {
-          sphereRotX = Math.max(-pitchReleaseCap, Math.min(pitchReleaseCap, sphereRotX));
+          sphereOrient.x = Math.max(-pitchReleaseCap, Math.min(pitchReleaseCap, sphereOrient.x));
           if (pitchReleaseCap > RESTING_PITCH) {
             pitchReleaseCap = RESTING_PITCH + (pitchReleaseCap - RESTING_PITCH) * PITCH_RELAX;
             if (pitchReleaseCap - RESTING_PITCH < 0.001) pitchReleaseCap = RESTING_PITCH;
           }
           // Upright roll relaxes to 0 over the same glide (so pitch + roll settle together).
-          if (sphereRotZ !== 0) {
-            sphereRotZ *= PITCH_RELAX;
-            if (Math.abs(sphereRotZ) < 0.001) sphereRotZ = 0;
+          if (sphereOrient.z !== 0) {
+            sphereOrient.z *= PITCH_RELAX;
+            if (Math.abs(sphereOrient.z) < 0.001) sphereOrient.z = 0;
           }
         }
       }
@@ -1230,13 +1105,13 @@ function createGlobeGalleryRuntime(
       drag.velY = 0;
       sphereDragWarp += (0 - sphereDragWarp) * 0.20;
       if (Math.abs(sphereDragWarp) < 0.001) sphereDragWarp = 0;
-      if (sphereFormT < 0.01) {
+      if (sphereFormT < TL.SPHERE_ORIENT_RESET_T) {
         resetSphereOrientation();
       }
     }
 
     // sphereRotActive is a fast-path flag so the rotation math can be skipped when upright.
-    const sphereRotActive = (sphereRotY !== 0 || sphereRotX !== 0 || sphereRotZ !== 0);
+    const sphereRotActive = (sphereOrient.y !== 0 || sphereOrient.x !== 0 || sphereOrient.z !== 0);
     refreshSphereRotQuat();
     return sphereRotActive;
   }
@@ -1274,8 +1149,8 @@ function createGlobeGalleryRuntime(
       canvas.style.opacity = '1';
       return;
     }
-    const showTrigger = blockDocTop - H * ENTRY_LEAD_VH; // matches entryStart in computeFrame
-    if (lenisY < showTrigger || zoomT >= 0.95) {
+    const showTrigger = blockDocTop - H * TL.ENTRY_LEAD_VH; // matches entryStart in computeFrame
+    if (lenisY < showTrigger || zoomT >= TL.CANVAS_HIDE_ZOOM_T) {
       canvas.style.display = 'none';
     } else {
       canvas.style.display = 'block';
@@ -1331,7 +1206,7 @@ function createGlobeGalleryRuntime(
     }
     if (CA_ENABLED && caFilterR) {
       const canvas = renderer.domElement;
-      const scrollVelNorm = Math.min(1.0, scrollVel / SCROLL_VEL_MAX);
+      const scrollVelNorm = Math.min(1.0, frameState.scrollVel / SCROLL_VEL_MAX);
       const globalCA = scrollVelNorm * CA_PX_MAX;
       if (globalCA > 0.05) {
         caFilterR.setAttribute('dx', '0');
@@ -1350,15 +1225,13 @@ function createGlobeGalleryRuntime(
     }
   }
 
-  function updateArcCopy() {
-    if (!arcCopyEl) return;
-    const ARC_COPY_OUT_FORM_START = 0.20;
-    const ARC_COPY_OUT_FORM_END = 0.90;
-    const foldWindow = SPHERE_FORMED_PROGRESS - FOLD_FIRST_PROGRESS;
-    const outStart = FOLD_FIRST_PROGRESS + ARC_COPY_OUT_FORM_START * foldWindow;
-    const outEnd = FOLD_FIRST_PROGRESS + ARC_COPY_OUT_FORM_END * foldWindow;
-    const arcCopyInE = easeOutCubic(Math.min(1, arcCopyEntryT / 0.336));
-    const arcCopyOutT = Math.max(0, Math.min(1, (progress - outStart) / (outEnd - outStart)));
+  function updateArcCopy(frame) {
+    if (!arcCopy.el) return;
+    const arcCopyInE = easeOutCubic(Math.min(1, frame.arcCopyEntryT / TL.ARC_COPY_IN_ENTRY_T));
+    const arcCopyOutT = Math.max(0, Math.min(
+      1,
+      (frame.progress - TL.ARC_COPY_OUT_START) / (TL.ARC_COPY_OUT_END - TL.ARC_COPY_OUT_START),
+    ));
     const arcCopyOutE = easeInOutCubic(arcCopyOutT);
     const arcCopyOp = arcCopyInE * (1 - arcCopyOutE);
     const arcCopySlide = 24 * (1 - arcCopyInE);
@@ -1372,19 +1245,19 @@ function createGlobeGalleryRuntime(
     const insetStr = `${gridLeft}px`;
     const opStr = arcCopyOp.toFixed(3);
     const transformStr = `translateY(${arcCopySlide.toFixed(1)}px)`;
-    if (inlineStartSide !== arcCopyInlineStartSide) {
-      arcCopyEl.style[inlineEndSide] = '';
-      arcCopyInlineStartSide = inlineStartSide;
-      arcCopyInlineStartStr = '';
+    if (inlineStartSide !== arcCopy.startSide) {
+      arcCopy.el.style[inlineEndSide] = '';
+      arcCopy.startSide = inlineStartSide;
+      arcCopy.startStr = '';
     }
-    if (insetStr !== arcCopyInlineStartStr) {
-      arcCopyEl.style[inlineStartSide] = insetStr;
-      arcCopyInlineStartStr = insetStr;
+    if (insetStr !== arcCopy.startStr) {
+      arcCopy.el.style[inlineStartSide] = insetStr;
+      arcCopy.startStr = insetStr;
     }
-    if (opStr !== arcCopyOpStr) { arcCopyEl.style.opacity = opStr; arcCopyOpStr = opStr; }
-    if (transformStr !== arcCopyTransformStr) {
-      arcCopyEl.style.transform = transformStr;
-      arcCopyTransformStr = transformStr;
+    if (opStr !== arcCopy.opStr) { arcCopy.el.style.opacity = opStr; arcCopy.opStr = opStr; }
+    if (transformStr !== arcCopy.transformStr) {
+      arcCopy.el.style.transform = transformStr;
+      arcCopy.transformStr = transformStr;
     }
   }
 
@@ -1600,7 +1473,7 @@ function createGlobeGalleryRuntime(
   // Per-card dispatcher: derive this card's timing (peel/fold easings, CA, hover), then run one
   // phase branch. Called once per card by updateCardTransforms.
   function updateCardTransform(i, frame) {
-    const { gridFormT, gpWin, sphereFormT, entryRot } = frame;
+    const { progress, gridFormT, gpWin, sphereFormT, entryRot } = frame;
     const { N_TOTAL } = bp;
     const card = cards[i];
     const { mesh } = card;
@@ -1625,26 +1498,23 @@ function createGlobeGalleryRuntime(
     }
 
     // Arc → grid peel stagger: i-based cascade + per-card jitter.
-    const baseDelay = (i / Math.max(1, N_TOTAL - 1)) * GRID_PEEL_STAGGER;
-    const jitter = (card.peelJitter - 0.5) * ARC_PEEL_JITTER;
-    const gpDelay = Math.max(0, Math.min(GRID_PEEL_STAGGER, baseDelay + jitter));
+    const baseDelay = (i / Math.max(1, N_TOTAL - 1)) * TL.GRID_PEEL_STAGGER;
+    const jitter = (card.peelJitter - 0.5) * TL.ARC_PEEL_JITTER;
+    const gpDelay = Math.max(0, Math.min(TL.GRID_PEEL_STAGGER, baseDelay + jitter));
     const gpLocalT = Math.max(0, Math.min(1, (gridFormT - gpDelay) / Math.max(0.01, gpWin)));
     const gpE = easeOutCubic(gpLocalT);
 
     // Grid → sphere fold: begins when this card's peel reaches FOLD_START_LOCAL_T. The gate is
     // on the raw peel localT, not the eased gpE.
-    const foldStartFormT = gpDelay + FOLD_START_LOCAL_T * gpWin;
-    const foldStartArcT = PROGRESS_GRID_ARC_START
-      + Math.min(1, foldStartFormT) * (PROGRESS_GRID_ARC_END - PROGRESS_GRID_ARC_START);
-    const foldStartProg = Math.max(0, (foldStartArcT - PROGRESS_ARC_PREROLL) * PROGRESS_PAN_END);
-    const fdLocalT = Math.max(0, Math.min(1, (progress - foldStartProg) / PROGRESS_FOLD_DUR));
-    const fdE = gpLocalT >= FOLD_START_LOCAL_T ? easeInOutCubic(fdLocalT) : 0;
+    const foldStartProg = TL.cardFoldStartProgress(gpDelay);
+    const fdLocalT = Math.max(0, Math.min(1, (progress - foldStartProg) / TL.PROGRESS_FOLD_DUR));
+    const fdE = gpLocalT >= TL.FOLD_START_LOCAL_T ? easeInOutCubic(fdLocalT) : 0;
 
     // Per-card CA strength: arc entry peaks with entryRot; peel + fold use a bell curve.
     let cardCA = 0;
     if (CA_ENABLED) {
       cardCA = Math.max(
-        entryRot / 0.9,
+        entryRot / TL.ENTRY_ROT_MAX,
         gpE * (1 - gpE) * 4,
         fdE * (1 - fdE) * 4,
       ) * CA_STRENGTH;
@@ -1654,7 +1524,7 @@ function createGlobeGalleryRuntime(
 
     // Hover state ease — gated on the global interactive threshold (not per-card fdE, so
     // late-folding cards hover at sphereFormT=0.8). Visual effects render only in the sphere block.
-    if (sphereFormT < SPHERE_INTERACTIVE_T || reducedMotion) card.hoverTarget = 0;
+    if (sphereFormT < TL.SPHERE_INTERACTIVE_T || reducedMotion) card.hoverTarget = 0;
     card.hoverT += (card.hoverTarget - card.hoverT) * HOVER_RATE;
 
     // Contour/reveal defaults for the non-sphere phases (placeSphereCard overrides them with its
@@ -1699,7 +1569,7 @@ function createGlobeGalleryRuntime(
   function updateHintExitProgress(frame) {
     const { sphereFormT } = frame;
     // Reset on scroll-out of the interactive range (fresh on re-entry).
-    if (sphereFormT < SPHERE_INTERACTIVE_T) {
+    if (sphereFormT < TL.SPHERE_INTERACTIVE_T) {
       textExitProgress = 0;
       return;
     }
@@ -1738,7 +1608,7 @@ function createGlobeGalleryRuntime(
       uniforms.uMotionDir.value.set(0, 0);
       return;
     }
-    if (sphereFormT <= TEXT_APPEAR_START) {
+    if (sphereFormT <= TL.TEXT_APPEAR_START) {
       // Hidden until the fold is underway.
       textMesh.visible = false;
       textMesh.scale.setScalar(TEXT_SCALE_ENTER);
@@ -1747,7 +1617,7 @@ function createGlobeGalleryRuntime(
 
     const { CAM_Z_SPHERE, SPHERE_R } = bp;
     // Remap so 0→1 covers [TEXT_APPEAR_START, 1].
-    const sfRaw = (sphereFormT - TEXT_APPEAR_START) / (1 - TEXT_APPEAR_START);
+    const sfRaw = (sphereFormT - TL.TEXT_APPEAR_START) / (1 - TL.TEXT_APPEAR_START);
     const sfT = Math.max(0, Math.min(1, sfRaw));
     const txtT = easeOutCubic(sfT);
     // Warp: strong at entrance, 0 at rest.
@@ -1759,7 +1629,7 @@ function createGlobeGalleryRuntime(
     textMesh.scale.setScalar(currDist / restDist + warpTot * TEXT_WARP_OVERFLOW);
     // Opacity settles peak→resting over the fold, then fades on zoom (no fade-in).
     const txtOp = lerpN(TEXT_OPACITY_PEAK, TEXT_OPACITY_RESTING, txtT)
-      * (1 - Math.min(1, zoomT * 3));
+      * (1 - Math.min(1, zoomT * TL.TEXT_ZOOM_FADE_RATE));
 
     textMesh.visible = txtOp > 0.001 && textExitProgress < 0.999;
     uniforms.uUVScale.value = 1.0;
@@ -1798,7 +1668,7 @@ function createGlobeGalleryRuntime(
     updatePullQuote(frame);
 
     // Arc needs manual render order; sphere needs camera-distance sorting.
-    renderer.sortObjects = frame.sphereFormT > 0.5;
+    renderer.sortObjects = frame.sphereFormT > TL.DEPTH_SORT_FORM_T;
 
     frame.sphGroupZ = updateSphereGroupDepth(frame);
     updateGlobalCA();
@@ -1808,7 +1678,7 @@ function createGlobeGalleryRuntime(
 
     updateClickDragText(frame);
     cursor.update();
-    updateArcCopy();
+    updateArcCopy(frame);
     renderScene(frame.activeCamera);
   }
 
@@ -1818,7 +1688,7 @@ function createGlobeGalleryRuntime(
   function startTicker() {
     if (rafId) return;
     // Reset the velocity baseline so a resume after an off-screen scroll doesn't spike scrollVel.
-    prevLenisY = window.scrollY;
+    frameInput.prevLenisY = window.scrollY;
     rafId = requestAnimationFrame(rafLoop);
   }
   function stopTicker() { if (rafId) { cancelAnimationFrame(rafId); rafId = 0; } }
@@ -1834,22 +1704,20 @@ function createGlobeGalleryRuntime(
 
   const MAX_CONTEXT_REBUILDS = 4;
   const CONTEXT_STABLE_MS = 10000;
-  let contextRebuilds = 0;
-  let contextStableTimer = 0;
-  let contextRecovering = false;
-  let contextRecoverTimer = 0;
+  // WebGL context-loss recovery state. See README (WebGL context loss).
+  const ctxLoss = { rebuilds: 0, stableTimer: 0, recovering: false, recoverTimer: 0 };
   function onContextLost(e) {
     e.preventDefault();
-    if (contextStableTimer) { clearTimeout(contextStableTimer); contextStableTimer = 0; }
+    if (ctxLoss.stableTimer) { clearTimeout(ctxLoss.stableTimer); ctxLoss.stableTimer = 0; }
     stopTicker();
     renderReady = false;
     window.lana?.log?.('globe-gallery: WebGL context lost', { tags: 'globe-gallery', severity: 'warn' });
   }
   function recoverFromContextLoss() {
-    contextRecoverTimer = 0;
-    contextRecovering = false;
-    contextRebuilds += 1;
-    const collapsed = contextRebuilds > MAX_CONTEXT_REBUILDS;
+    ctxLoss.recoverTimer = 0;
+    ctxLoss.recovering = false;
+    ctxLoss.rebuilds += 1;
+    const collapsed = ctxLoss.rebuilds > MAX_CONTEXT_REBUILDS;
     window.lana?.log?.(
       collapsed
         ? 'globe-gallery: WebGL context keeps failing — collapsing'
@@ -1863,14 +1731,14 @@ function createGlobeGalleryRuntime(
       root.classList.add('globe-gallery-empty');
       return;
     }
-    contextStableTimer = window.setTimeout(() => {
-      contextRebuilds = 0; contextStableTimer = 0;
+    ctxLoss.stableTimer = window.setTimeout(() => {
+      ctxLoss.rebuilds = 0; ctxLoss.stableTimer = 0;
     }, CONTEXT_STABLE_MS);
   }
   function onContextRestored() {
-    if (contextRecovering) return; // coalesce the main + modal canvases' restore events (README)
-    contextRecovering = true;
-    contextRecoverTimer = window.setTimeout(recoverFromContextLoss, 0);
+    if (ctxLoss.recovering) return; // coalesce the main + modal canvases' restore events (README)
+    ctxLoss.recovering = true;
+    ctxLoss.recoverTimer = window.setTimeout(recoverFromContextLoss, 0);
   }
   function bindContextListeners(add) {
     const fn = add ? 'addEventListener' : 'removeEventListener';
@@ -1958,7 +1826,7 @@ function createGlobeGalleryRuntime(
       blockDocTop = root.getBoundingClientRect().top + window.scrollY;
       blockHeight = root.offsetHeight || window.innerHeight * 7;
       const pinFactor = parseFloat(getComputedStyle(root).getPropertyValue('--pq-pin-factor')) || 0.44;
-      pqAppearZoomT = Math.max(0, (1 - pinFactor) - PQ_APPEAR_LEAD);
+      pqAppearZoomT = Math.max(0, (1 - pinFactor) - TL.PQ_APPEAR_LEAD);
       // Re-apply DPR (can change when dragging between monitors of different density).
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
       renderer.setSize(W, H);
@@ -2021,11 +1889,11 @@ function createGlobeGalleryRuntime(
     // Cache the global-CA SVG filter elements.
     caFilterR = q('.globe-gallery-ca-r-offset');
     caFilterB = q('.globe-gallery-ca-b-offset');
-    arcCopyEl = q('.globe-gallery-arc-copy');
-    arcCopyInlineStartSide = '';
-    arcCopyInlineStartStr = '';
-    arcCopyOpStr = '';
-    arcCopyTransformStr = '';
+    arcCopy.el = q('.globe-gallery-arc-copy');
+    arcCopy.startSide = '';
+    arcCopy.startStr = '';
+    arcCopy.opStr = '';
+    arcCopy.transformStr = '';
 
     modal.setup();
 
@@ -2086,9 +1954,9 @@ function createGlobeGalleryRuntime(
 
     onScreen = true; // reset the visibility default; the next init's observer re-corrects it
     bindContextListeners(false);
-    if (contextStableTimer) { clearTimeout(contextStableTimer); contextStableTimer = 0; }
-    if (contextRecoverTimer) { clearTimeout(contextRecoverTimer); contextRecoverTimer = 0; }
-    contextRecovering = false;
+    if (ctxLoss.stableTimer) { clearTimeout(ctxLoss.stableTimer); ctxLoss.stableTimer = 0; }
+    if (ctxLoss.recoverTimer) { clearTimeout(ctxLoss.recoverTimer); ctxLoss.recoverTimer = 0; }
+    ctxLoss.recovering = false;
     if (intersectionObs) {
       intersectionObs.disconnect();
       intersectionObs = null;
@@ -2148,9 +2016,9 @@ function createGlobeGalleryRuntime(
     renderer = null; scene = null; camera = null; cameraOrtho = null; sphereGroup = null;
     modal.destroy();
     a11y.teardown();
-    if (arcCopyEl) arcCopyEl.style.cssText = '';
+    if (arcCopy.el) arcCopy.el.style.cssText = '';
     if (pqEl) { pqEl.classList.remove('is-active'); pqEl.style.transition = ''; pqShown = false; }
-    prevLenisY = 0; scrollVel = 0;
+    frameInput.prevLenisY = 0; frameState.scrollVel = 0;
     // Reset sphere orientation + drag/nudge state: the closure survives a rebuild, so without
     // this a pre-rebuild tilt carries over. See README (destroy resets).
     resetSphereOrientation();

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -8,6 +8,7 @@ import createGalleryA11y from './src/a11y.js';
 import createGlobeModal from './src/modal.js';
 import createInteraction from './src/interaction.js';
 import createCursor from './src/cursor.js';
+import createGlobeControls from './src/controls.js';
 import {
   easeOutCubic, easeInOutCubic, lerpN, coverFit,
   buildArcCtx, getFanData, cssToWorld, rotateArcPoint, arcCamZ,
@@ -115,6 +116,9 @@ const PITCH_RELAX = 0.85;
 // Frame counts for the sphere-centring tweens: browse slow (anti-dizziness), modal faster.
 const KEY_BROWSE_FRAMES = 90;
 const KEY_MODAL_FRAMES = 20;
+const ROTATE_STEP_FRAMES = 34;
+const ROTATE_DEADZONE = 0.15;
+const COLUMN_EPS = 1e-6;
 const RING_TANHALF = Math.tan(Math.PI / 6); // tan(30°) — projects a card for the focus ring
 
 // Chromatic aberration.
@@ -397,6 +401,7 @@ function createGlobeGalleryRuntime(
   // Sphere-to-card alignment tween.
   const navNudge = {
     active: false,
+    kind: '', // 'browse' | 'modal' | 'rotate' — who armed it; see the browse-exit edge + rotateStep
     targetX: 0,
     targetY: 0,
     targetZ: 0,
@@ -430,6 +435,7 @@ function createGlobeGalleryRuntime(
   let a11y = null;
   let interaction = null;
   let cursor = null;
+  let controls = null;
 
   // Suppresses the focus→snap-scroll while the tab is backgrounded (pdf-space pattern).
   let suppressFocusSnap = false;
@@ -655,7 +661,7 @@ function createGlobeGalleryRuntime(
       const { SPHERE_R } = bp;
       const sz = textPlaneSize();
       const mat = createTextMaterial({
-        texture: createClickDragTexture(aspect, hintText || 'Click & Drag'),
+        texture: createClickDragTexture(aspect, hintText),
         aspect,
         resolution: { x: W * dpr, y: H * dpr },
       });
@@ -712,20 +718,25 @@ function createGlobeGalleryRuntime(
 
   // Shared solve: the yaw + pitch bringing card `idx` to screen centre (yawOnly holds pitch — a
   // cylinder can't centre vertically). Inside the globe both flip to the far wall.
-  function cardCenterYawPitch(idx, pitchCap, yawOnly) {
-    const { spherePos } = cards[idx];
-    const cy = Math.cos(sphereOrient.y);
-    const sy = Math.sin(sphereOrient.y);
+  // Shortest signed yaw that brings a slot front-centre. Scale-invariant, so on the barrel it
+  // depends only on azimuth — i.e. only on the column. rotateStep relies on that.
+  function yawDeltaToCenter(spherePos, fromYaw = sphereOrient.y) {
+    const cy = Math.cos(fromYaw);
+    const sy = Math.sin(fromYaw);
     const px = spherePos.x * cy + spherePos.z * sy;
     const pz = -spherePos.x * sy + spherePos.z * cy;
-    const inside = cameraInsideSphere;
     let deltaY = -Math.atan2(px, pz); // → +Z (near wall, camera outside)
-    if (inside) deltaY += Math.PI; // → −Z (far wall, camera inside)
-    deltaY = Math.atan2(Math.sin(deltaY), Math.cos(deltaY)); // shortest signed spin
-    const targetYaw = sphereOrient.y + deltaY;
+    if (cameraInsideSphere) deltaY += Math.PI; // → −Z (far wall, camera inside)
+    return Math.atan2(Math.sin(deltaY), Math.cos(deltaY));
+  }
+
+  function cardCenterYawPitch(idx, pitchCap, yawOnly) {
+    const { spherePos } = cards[idx];
+    const targetYaw = sphereOrient.y + yawDeltaToCenter(spherePos);
     if (yawOnly) return { targetYaw, targetPitch: sphereOrient.x };
-    const h = Math.sqrt(px * px + pz * pz); // horizontal radius after yaw alignment
+    const h = Math.hypot(spherePos.x, spherePos.z);
     const pitchMag = Math.atan2(spherePos.y, h); // drives the card's height → centre
+    const inside = cameraInsideSphere;
     const targetPitch = Math.max(-pitchCap, Math.min(pitchCap, inside ? -pitchMag : pitchMag));
     return { targetYaw, targetPitch };
   }
@@ -741,7 +752,42 @@ function createGlobeGalleryRuntime(
     navNudge.startZ = sphereOrient.z;
     navNudge.frames = KEY_MODAL_FRAMES;
     navNudge.frame = reducedMotion ? KEY_MODAL_FRAMES : 0;
+    navNudge.kind = 'modal';
     navNudge.active = true;
+  }
+
+  // One rotate-button press: ease to the next column BOUNDARY (never `y += pitch`), dir −1 = the
+  // surface travels screen-left. Pitch/roll pinned. See README (Globe controls).
+  function rotateStep(dir) {
+    // Measure from where the last press is HEADED, not where we are, so taps queue instead of
+    // re-targeting the boundary already in flight (which made a double-tap slower than a single).
+    const from = navNudge.active && navNudge.kind === 'rotate' ? navNudge.targetY : sphereOrient.y;
+    const deltas = [];
+    cards.forEach((card) => {
+      // Mid-morph spherePos is a per-frame lerp with no column structure yet — read the target.
+      const slot = masonryMorph.active && card.morph ? card.morph.posTo : card.spherePos;
+      const d = yawDeltaToCenter(slot, from);
+      if (!deltas.some((seen) => Math.abs(seen - d) < COLUMN_EPS)) deltas.push(d);
+    });
+    if (!deltas.length) return;
+    // Skip a boundary we're already on, else ambient drift eats the press.
+    const deadzone = ((2 * Math.PI) / deltas.length) * ROTATE_DEADZONE;
+    const ahead = deltas.filter((d) => d * dir > deadzone);
+    if (!ahead.length) return; // one column: nothing to step to
+    const delta = ahead.reduce((a, b) => (Math.abs(a) < Math.abs(b) ? a : b));
+    navNudge.targetY = from + delta;
+    navNudge.targetX = sphereOrient.x;
+    navNudge.targetZ = sphereOrient.z;
+    navNudge.startY = sphereOrient.y;
+    navNudge.startX = sphereOrient.x;
+    navNudge.startZ = sphereOrient.z;
+    navNudge.frames = ROTATE_STEP_FRAMES;
+    navNudge.frame = reducedMotion ? ROTATE_STEP_FRAMES : 0;
+    navNudge.kind = 'rotate';
+    navNudge.active = true;
+    // Kill residual spin (auto-rotate/drag inertia) so it can't fight the ease.
+    drag.velX = 0;
+    drag.velY = 0;
   }
 
   // Keyboard-gallery centring (a11y.js's centerCard): the shared yaw/pitch solve plus the
@@ -767,6 +813,7 @@ function createGlobeGalleryRuntime(
     navNudge.startZ = sphereOrient.z;
     navNudge.frames = KEY_BROWSE_FRAMES;
     navNudge.frame = reducedMotion ? KEY_BROWSE_FRAMES : 0;
+    navNudge.kind = 'browse';
     navNudge.active = true;
     // Kill residual spin (auto-rotate/drag inertia) so it can't fight the ease.
     drag.velX = 0;
@@ -931,8 +978,17 @@ function createGlobeGalleryRuntime(
       || frameState.zoomT > TL.CURSOR_ZOOM_RETIRE_T,
     getCursorRetired: () => textExitProgress > TL.CURSOR_DRAG_RETIRE_T
       || frameState.zoomT > TL.CURSOR_ZOOM_RETIRE_T,
-    labelText: hintText || 'Click & Drag',
+    labelText: hintText,
     drag,
+  });
+
+  controls = createGlobeControls({
+    q,
+    labels,
+    getVisible: () => frameState.sphereFormT >= TL.SPHERE_INTERACTIVE_T
+      && frameState.zoomT < TL.CONTROLS_ZOOM_HIDE_T
+      && modal.getModalIdx() < 0,
+    rotate: rotateStep,
   });
 
   // Rad per pointer px, live off the viewport + band. See README (Drag physics)
@@ -1008,9 +1064,10 @@ function createGlobeGalleryRuntime(
     sphereGroup.rotation.x = 0;
     sphereGroup.rotation.y = 0;
 
-    // Leaving browse: cancel the nudge so its targets stop fighting resumed auto-spin.
+    // Leaving browse: cancel browse's own tween so it stops fighting resumed auto-spin. A rotate
+    // press collapses browse (focusout) in the same turn it arms its nudge — don't eat that.
     const browsing = a11y && a11y.isBrowsing();
-    if (wasBrowsing && !browsing) {
+    if (wasBrowsing && !browsing && navNudge.kind === 'browse') {
       navNudge.active = false;
     }
     wasBrowsing = browsing;
@@ -1064,6 +1121,7 @@ function createGlobeGalleryRuntime(
         drag.velY *= friction;
         // Ambient spin stays OUT of velX (a bias in it decays asymmetrically by direction).
         const spin = interactive && !reducedMotion && !(a11y && a11y.isBrowsing())
+          && !controls.isSpinPaused()
           ? AUTO_ROT_SPEED : 0;
         sphereOrient.y += (drag.velX + spin) * dtScale * dragDir;
         sphereOrient.x += drag.velY * dtScale * dragDir;
@@ -1628,6 +1686,7 @@ function createGlobeGalleryRuntime(
 
     updateClickDragText(frame);
     cursor.update();
+    controls.update();
     updateArcCopy(frame);
     renderScene(frame.activeCamera);
   }
@@ -1840,6 +1899,7 @@ function createGlobeGalleryRuntime(
 
     interaction.setup(canvas);
     cursor.setup();
+    root.classList.toggle('globe-gallery-barrel', bp.CYLINDER);
 
     // Focus-snap guard listeners (see snapToInteractive).
     window.addEventListener('blur', armFocusGuard);
@@ -1862,6 +1922,8 @@ function createGlobeGalleryRuntime(
 
     if (!bp.CYLINDER) buildTextMesh();
     a11y.setup();
+    controls.setup();
+
     renderReady = true;
     syncTicker();
 
@@ -1932,6 +1994,7 @@ function createGlobeGalleryRuntime(
     interaction.teardown();
     // Cursor cleanup — runs while renderer exists so getCanvas() resolves.
     cursor.teardown();
+    controls.teardown();
     if (renderer) {
       renderer.domElement.style.filter = '';
       globalCaFilterOn = false;
@@ -1989,11 +2052,11 @@ export default async function init(el) {
 
   // Extract authored content (incl. the UI labels) before buildGlobeDom() wipes the children.
   const {
-    arcCopy, pullQuote, hintText, instructions, labels, fragmentHref,
+    arcCopy, pullQuote, hintText, touchHint, instructions, labels, fragmentHref,
   } = parseAuthoredContent(el);
 
   // Returns the per-instance id suffix (CA filter ref) and fills the copy slots.
-  const gid = buildGlobeDom(el, labels, { arcCopy, pullQuote });
+  const gid = buildGlobeDom(el, labels, { arcCopy, pullQuote, touchHint });
 
   // Cards come from the authored fragment link.
   const cards = fragmentHref ? await fetchFragmentCards(fragmentHref) : null;

--- a/libs/mep/ace1209/globe-gallery/src/a11y.js
+++ b/libs/mep/ace1209/globe-gallery/src/a11y.js
@@ -93,10 +93,8 @@ export default function createGalleryA11y({
     widgetEl.setAttribute('daa-ll', ENTER_GALLERY_DAA_LL);
     widgetEl.tabIndex = getModalIdx() < 0 ? 0 : -1;
 
-    // Instructions serve both audiences from one element: visible :focus-visible popup and
-    // the button's aria-labelledby name. See README (Accessibility).
-    // galleryInstructions is authored inline (row 2, 2nd <p>) with an English code fallback,
-    // so it's always set here. See authoring.js / README (Localization).
+    // One element serves both audiences: the visible :focus-visible popup and the button's
+    // aria-labelledby name. Always set (authored inline + code fallback). See README.
     if (galleryInstructions) {
       const descEl = document.createElement('span');
       descEl.className = 'globe-gallery-a11y-tip';

--- a/libs/mep/ace1209/globe-gallery/src/a11y.js
+++ b/libs/mep/ace1209/globe-gallery/src/a11y.js
@@ -1,5 +1,10 @@
 // Keyboard + screen-reader gallery for the globe (DI module). See README (Accessibility).
 
+// Explicit, uniform analytics labels — never per card. Each `-`-separated segment must stay
+// within 20 chars or Milo truncates it. See README (Analytics).
+const CARD_OPEN_DAA_LL = 'card_open--globe_gallery';
+const ENTER_GALLERY_DAA_LL = 'enter_gallery_kbd--globe_gallery';
+
 export default function createGalleryA11y({
   q,
   getCount,
@@ -50,6 +55,8 @@ export default function createGalleryA11y({
     if (focusedIdx === Number(e.currentTarget.dataset.idx)) focusedIdx = -1;
   }
   function onCardClick(e) {
+    // Untrusted = synthesized by trackCardOpen(), report-only. See README (Analytics).
+    if (!e.isTrusted) return;
     if (isInteractive()) openCard(Number(e.currentTarget.dataset.idx));
   }
   function onCardKeydown(e) {
@@ -83,6 +90,7 @@ export default function createGalleryA11y({
     widgetEl = document.createElement('button');
     widgetEl.type = 'button';
     widgetEl.className = 'globe-gallery-a11y';
+    widgetEl.setAttribute('daa-ll', ENTER_GALLERY_DAA_LL);
     widgetEl.tabIndex = getModalIdx() < 0 ? 0 : -1;
 
     // Instructions serve both audiences from one element: visible :focus-visible popup and
@@ -112,6 +120,7 @@ export default function createGalleryA11y({
       btn.className = 'globe-gallery-a11y-card';
       btn.tabIndex = -1; // joins the tab order only while entered
       btn.dataset.idx = String(i);
+      btn.setAttribute('daa-ll', CARD_OPEN_DAA_LL);
       btn.setAttribute('aria-label', getCardLabel(i));
       btn.addEventListener('focus', onCardFocus);
       btn.addEventListener('blur', onCardBlur);
@@ -165,6 +174,11 @@ export default function createGalleryA11y({
     if (btn) btn.focus();
   }
 
+  // Report a canvas card open by clicking that card's button. See README (Analytics).
+  function trackCardOpen(idx) {
+    cardButtons[idx]?.click();
+  }
+
   // The image the focus ring should trace, -1 if none.
   function getFocusedIdx() {
     return focusedIdx;
@@ -194,6 +208,13 @@ export default function createGalleryA11y({
   }
 
   return {
-    setup, updateTabStops, teardown, isBrowsing, getFocusedIdx, setFocusRect, focusCard,
+    setup,
+    updateTabStops,
+    teardown,
+    isBrowsing,
+    getFocusedIdx,
+    setFocusRect,
+    focusCard,
+    trackCardOpen,
   };
 }

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -28,9 +28,7 @@ function badgeIconHtml(url) {
 
 // See README (Authoring contract) for the authored-row layout.
 
-// English fallback for the a11y entry-widget instructions when row 2 has no
-// second paragraph. Authored inline (row 2, 2nd <p>) so it's localizable
-// without the placeholders sheet.
+// English fallback for the a11y instructions; authored inline so it stays localizable.
 const DEFAULT_GALLERY_INSTRUCTIONS = 'Press Enter to enter the gallery, then Tab through the images.';
 
 const LABEL_DIVIDER = '||';
@@ -235,10 +233,8 @@ export async function fetchFragmentCards(href) {
   }
 }
 
-// Right-size a helix/DA media image to the dimension we rasterize, so slow connections don't
-// download the full-res source. Requests webp at `px` on `axis` (a lone `height=` is honoured
-// aspect-preservingly); cards ask by height, the modal by width — see README (Texture memory
-// budget). Non-media URLs (external assets that don't honor these params) are returned as-is.
+// Right-size a helix/DA media image to what we rasterize. Cards ask by height, the modal by
+// width; non-media URLs pass through. See README (Texture memory budget).
 export function optimizeImgUrl(src, px, axis = 'width') {
   if (!src) return src;
   try {
@@ -268,9 +264,8 @@ export function parseAuthoredContent(el) {
   };
 }
 
-// Runtime queries nodes within the block root, so multiple globes can coexist.
-// `gid` makes the two document-wide id refs unique per instance: the CA SVG
-// filter (url(#ca-filter-<gid>)) and the modal's aria-labelledby/describedby.
+// `gid` makes the two document-wide id refs unique per instance: the CA SVG filter and the
+// modal's aria-labelledby/describedby.
 const buildMarkup = (gid, labels) => `
   <div class="globe-gallery-world">
     <canvas class="globe-gallery-canvas" style="position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:3;display:none;pointer-events:auto;touch-action:pan-y;"></canvas>

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -54,16 +54,19 @@ function buildLabels(labelPara) {
   };
 }
 
+// Move the authored <p>s into a container. See README (Reusing authored paragraphs).
+export function renderParagraphs(container, paras) {
+  if (container) container.replaceChildren(...paras);
+}
+
 function parseArcCopy(row) {
-  if (!row) return { title: '', body: '' };
+  if (!row) return { title: '', body: [] };
   const heading = row.querySelector('h1,h2,h3,h4,h5,h6');
   const paras = [...row.querySelectorAll('p')]
-    .filter((p) => !p.querySelector('picture,img'))
-    .map((p) => p.textContent)
-    .filter(Boolean);
+    .filter((p) => !p.querySelector('picture,img') && p.textContent.trim());
   return {
-    title: heading ? heading.textContent : paras.shift() || '',
-    body: paras.join(' '),
+    title: heading ? heading.textContent : paras.shift()?.textContent.trim() || '',
+    body: paras,
   };
 }
 
@@ -77,38 +80,40 @@ function parsePullQuote(row) {
   };
 }
 
+// The <em>/<strong> text, but only when it IS the whole paragraph. See README (Card shape).
+function wholeParaChild(p, selector) {
+  const child = p.querySelector(selector);
+  const text = child?.textContent.trim();
+  return text && text === p.textContent.trim() ? text : '';
+}
+
 function parseFragmentCardSegment(nodes) {
   let img = null;
-  let role = ''; let name = ''; let description = '';
+  let role = ''; let name = '';
+  const description = [];
   const badges = [];
 
   nodes.forEach((node) => {
     const tag = node.nodeName && node.nodeName.toUpperCase();
     if (!tag) return;
 
-    if (tag === 'P') {
-      const pic = node.querySelector('picture');
-      if (pic) {
-        img = pic.querySelector('img');
-        return;
-      }
-      const inlineImg = node.querySelector('img');
+    if (/^H[1-6]$/.test(tag)) {
+      if (!name) name = node.textContent.trim();
+    } else if (tag === 'P') {
+      const inlineImg = node.querySelector('img'); // <picture> or bare <img>; first wins
       if (inlineImg) {
-        img = inlineImg;
+        if (!img) img = inlineImg;
         return;
       }
-      const em = node.querySelector('em');
-      if (em) {
-        role = em.textContent.trim();
-        return;
+      if (!role) {
+        const em = wholeParaChild(node, 'em');
+        if (em) { role = em; return; }
       }
-      const strong = node.querySelector('strong');
-      if (strong) {
-        name = strong.textContent.trim();
-        return;
+      if (!name) {
+        const strong = wholeParaChild(node, 'strong');
+        if (strong) { name = strong; return; }
       }
-      const text = node.textContent.trim();
-      if (text && !description) description = text;
+      if (node.textContent.trim()) description.push(node); // everything else is description
     } else if (tag === 'UL') {
       node.querySelectorAll(':scope > li').forEach((li) => {
         // Row (on a clone, so authored DOM is untouched) = product; nested <ul> = its feature.
@@ -124,10 +129,10 @@ function parseFragmentCardSegment(nodes) {
         );
         svgAnchor?.remove(); // its URL text is markup, never part of the name
 
-        const name = (linkAnchor ? linkAnchor.textContent : row.textContent).trim();
-        if (name) {
+        const badgeName = (linkAnchor ? linkAnchor.textContent : row.textContent).trim();
+        if (badgeName) {
           badges.push({
-            name,
+            name: badgeName,
             role: featureLi?.textContent.trim() || '',
             href: linkAnchor?.getAttribute('href') || null,
             icon,
@@ -246,7 +251,7 @@ const buildMarkup = (gid, labels) => `
 
   <div class="globe-gallery-arc-copy">
     <h2 class="globe-gallery-arc-copy-title"></h2>
-    <p class="globe-gallery-arc-copy-body body-md"></p>
+    <div class="globe-gallery-arc-copy-body body-md"></div>
   </div>
 
   <div class="globe-gallery-pullquote-pin">
@@ -269,7 +274,7 @@ const buildMarkup = (gid, labels) => `
     <div class="globe-gallery-modal-info">
       <p class="globe-gallery-modal-role-label" id="globe-gallery-modal-role-${gid}"></p>
       <h2 class="globe-gallery-modal-name" id="globe-gallery-modal-name-${gid}" tabindex="-1" aria-describedby="globe-gallery-modal-role-${gid} globe-gallery-modal-position-${gid}"></h2>
-      <p class="globe-gallery-modal-description" id="globe-gallery-modal-description-${gid}" data-lenis-prevent></p>
+      <div class="globe-gallery-modal-description" id="globe-gallery-modal-description-${gid}" data-lenis-prevent></div>
       <ul class="globe-gallery-modal-badges"></ul>
     </div>
     <!-- sr-only alt for the WebGL photo; after the info so the heading is read first. -->
@@ -298,7 +303,7 @@ export function buildGlobeDom(el, labels, { arcCopy, pullQuote }) {
   const gid = globeInstanceSeq;
   el.innerHTML = buildMarkup(gid, labels);
   el.querySelector('.globe-gallery-arc-copy-title').textContent = arcCopy.title;
-  el.querySelector('.globe-gallery-arc-copy-body').textContent = arcCopy.body;
+  renderParagraphs(el.querySelector('.globe-gallery-arc-copy-body'), arcCopy.body);
   if (pullQuote) {
     el.querySelector('.globe-gallery-pullquote-quote').textContent = pullQuote.quote;
     el.querySelector('.globe-gallery-pullquote-name').textContent = pullQuote.name;

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -31,25 +31,42 @@ function badgeIconHtml(url) {
 // English fallback for the a11y instructions; authored inline so it stays localizable.
 const DEFAULT_GALLERY_INSTRUCTIONS = 'Press Enter to enter the gallery, then Tab through the images.';
 
-const LABEL_DIVIDER = '||';
-const DEFAULT_LABELS = ['Previous card', '{index} of {count}', 'Next card', 'Close'];
+const DEFAULT_HINT = 'Click & Drag';
+const DEFAULT_TOUCH_HINT = 'Click and drag to rotate. Tap to dive deep into the artwork.';
 
-function buildLabels(labelPara) {
-  const parts = labelPara
-    ? labelPara.textContent.split(LABEL_DIVIDER).map((s) => s.trim())
-    : [];
-  const [prevCard, cardTplRaw, nextCard, closeBtn] = parts;
+const LABEL_DIVIDER = '||';
+const DEFAULT_LABELS = [
+  DEFAULT_GALLERY_INSTRUCTIONS,
+  'Rotate left', 'Rotate right', 'Pause spinning', 'Resume spinning',
+  'Previous card', '{index} of {count}', 'Next card', 'Close',
+];
+const CARD_TPL_INDEX = 6;
+
+function buildLabels(parts) {
+  const at = (i) => parts[i] || DEFAULT_LABELS[i];
+  const cardTplRaw = parts[CARD_TPL_INDEX];
   const cardTpl = cardTplRaw?.includes('{index}') && cardTplRaw?.includes('{count}')
     ? cardTplRaw
-    : DEFAULT_LABELS[1];
+    : DEFAULT_LABELS[CARD_TPL_INDEX];
   return {
-    prevCard: prevCard || DEFAULT_LABELS[0],
-    nextCard: nextCard || DEFAULT_LABELS[2],
-    closeBtn: closeBtn || DEFAULT_LABELS[3],
+    rotateLeft: at(1),
+    rotateRight: at(2),
+    pauseSpin: at(3),
+    resumeSpin: at(4),
+    prevCard: at(5),
+    nextCard: at(7),
+    closeBtn: at(8),
     cardLabel: (index, count) => cardTpl
       .replace('{index}', String(index))
       .replace('{count}', String(count)),
   };
+}
+
+// One cell's text: its <p>s joined, or the bare cell text when unwrapped.
+function cellText(cell) {
+  if (!cell) return '';
+  const paras = [...cell.querySelectorAll('p')].map((p) => p.textContent.trim()).filter(Boolean);
+  return (paras.length ? paras.join(' ') : cell.textContent).trim();
 }
 
 // Move the authored <p>s into a container. See README (Reusing authored paragraphs).
@@ -244,18 +261,19 @@ export function optimizeImgUrl(src, px, axis = 'width') {
 // Positional rows (see README, Authoring contract). Fragment links are authored
 // with #_dnb so Milo skips auto-resolution; the hash is stripped before fetching.
 export function parseAuthoredContent(el) {
-  const [arcCopyRow, cardsRow, hintTextRow, pullQuoteRow] = [...el.children];
+  const [arcCopyRow, cardsRow, hintTextRow, a11yRow, pullQuoteRow] = [...el.children];
   const fragmentLink = cardsRow?.querySelector('a[href]');
-  const hintParas = hintTextRow ? [...hintTextRow.querySelectorAll('p')] : [];
-  const hintText = (hintParas[0]?.textContent ?? hintTextRow?.textContent ?? '').trim();
-  const instructions = hintParas[1]?.textContent.trim() || DEFAULT_GALLERY_INSTRUCTIONS;
+  // Row 2 is two cells: the barrel's bottom-row copy, then the hint plane / cursor label.
+  const cells = hintTextRow ? [...hintTextRow.querySelectorAll(':scope > div')] : [];
+  const parts = (a11yRow?.textContent ?? '').split(LABEL_DIVIDER).map((s) => s.trim());
   return {
     arcCopy: parseArcCopy(arcCopyRow),
     pullQuote: pullQuoteRow ? parsePullQuote(pullQuoteRow) : null,
     fragmentHref: fragmentLink ? fragmentLink.href.replace(/#.*$/, '') : null,
-    hintText,
-    instructions,
-    labels: buildLabels(hintParas[2]),
+    touchHint: cellText(cells[0]) || DEFAULT_TOUCH_HINT,
+    hintText: cellText(cells[1]) || DEFAULT_HINT,
+    instructions: parts[0] || DEFAULT_GALLERY_INSTRUCTIONS,
+    labels: buildLabels(parts),
   };
 }
 
@@ -264,6 +282,21 @@ export function parseAuthoredContent(el) {
 const buildMarkup = (gid, labels) => `
   <div class="globe-gallery-world">
     <canvas class="globe-gallery-canvas" style="position:fixed;top:0;left:0;width:100%;height:100vh;z-index:3;display:none;pointer-events:auto;touch-action:pan-y;"></canvas>
+    <div class="globe-gallery-controls">
+      <button class="globe-gallery-control globe-gallery-spin-toggle" type="button" daa-ll="pause_spin--globe_gallery" aria-label="${escapeHtml(labels.pauseSpin)}">
+        <svg class="globe-gallery-icon-pause" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><rect x="8" y="5" width="3" height="14" rx="1" fill="currentColor"/><rect x="13" y="5" width="3" height="14" rx="1" fill="currentColor"/></svg>
+        <svg class="globe-gallery-icon-play" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path d="M8 5l11 7-11 7z" fill="currentColor"/></svg>
+      </button>
+      <div class="globe-gallery-hint">
+        <button class="globe-gallery-control globe-gallery-rotate" type="button" data-dir="-1" daa-ll="rotate_left--globe_gallery" aria-label="${escapeHtml(labels.rotateLeft)}">
+          <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path d="M20 12H4m0 0l6-6m-6 6l6 6" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <p class="globe-gallery-hint-text"></p>
+        <button class="globe-gallery-control globe-gallery-rotate" type="button" data-dir="1" daa-ll="rotate_right--globe_gallery" aria-label="${escapeHtml(labels.rotateRight)}">
+          <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path d="M4 12h16m0 0l-6-6m6 6l-6 6" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+      </div>
+    </div>
   </div>
 
   <svg class="globe-gallery-ca-svg" aria-hidden="true" focusable="false" style="position:absolute;width:0;height:0;overflow:hidden">
@@ -331,10 +364,11 @@ const buildMarkup = (gid, labels) => `
 let globeInstanceSeq = 0;
 
 // Build the block's DOM; returns the `gid` for this instance's unique ids.
-export function buildGlobeDom(el, labels, { arcCopy, pullQuote }) {
+export function buildGlobeDom(el, labels, { arcCopy, pullQuote, touchHint }) {
   globeInstanceSeq += 1;
   const gid = globeInstanceSeq;
   el.innerHTML = buildMarkup(gid, labels);
+  el.querySelector('.globe-gallery-hint-text').textContent = touchHint;
   el.querySelector('.globe-gallery-arc-copy-title').textContent = arcCopy.title;
   renderParagraphs(el.querySelector('.globe-gallery-arc-copy-body'), arcCopy.body);
   if (pullQuote) {

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -275,14 +275,14 @@ const buildMarkup = (gid, labels) => `
     <!-- sr-only alt for the WebGL photo; after the info so the heading is read first. -->
     <span class="globe-gallery-modal-image globe-gallery-sr-only" role="img"></span>
     <!-- Controls after the info scrim so they paint on top of it. -->
-    <button class="globe-gallery-modal-nav globe-gallery-modal-nav-prev" type="button" aria-label="${escapeHtml(labels.prevCard)}">
+    <button class="globe-gallery-modal-nav globe-gallery-modal-nav-prev" type="button" daa-ll="prev_card-1--globe_card_modal" aria-label="${escapeHtml(labels.prevCard)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M15 5l-7 7 7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>
-    <button class="globe-gallery-modal-nav globe-gallery-modal-nav-next" type="button" aria-label="${escapeHtml(labels.nextCard)}">
+    <button class="globe-gallery-modal-nav globe-gallery-modal-nav-next" type="button" daa-ll="next_card-2--globe_card_modal" aria-label="${escapeHtml(labels.nextCard)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M9 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>
     <div class="globe-gallery-modal-counter" aria-hidden="true"></div>
-    <button class="globe-gallery-modal-close" type="button" aria-label="${escapeHtml(labels.closeBtn)}">
+    <button class="globe-gallery-modal-close" type="button" daa-ll="close-3--globe_card_modal" aria-label="${escapeHtml(labels.closeBtn)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
     </button>
     <span class="globe-gallery-modal-position globe-gallery-sr-only" id="globe-gallery-modal-position-${gid}"></span>

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -59,6 +59,35 @@ export function renderParagraphs(container, paras) {
   if (container) container.replaceChildren(...paras);
 }
 
+const OPENING_MARK = /^[\p{Ps}\p{Pi}\p{Pf}"']/u;
+
+function hangOpeningMark(quoteEl) {
+  const text = quoteEl.textContent.trim();
+  const container = quoteEl.closest('.globe-gallery-pullquote');
+  if (!container || !OPENING_MARK.test(text)) return;
+  const cs = getComputedStyle(quoteEl);
+  const ctx = document.createElement('canvas').getContext('2d');
+  ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
+  if (!ctx.font.includes(cs.fontSize)) return; // font didn't parse; canvas is on its 10px default
+  // Canvas ignores letter-spacing, and heading-1 has some.
+  const advance = ctx.measureText([...text][0]).width + (parseFloat(cs.letterSpacing) || 0);
+  const room = parseFloat(getComputedStyle(container).paddingInlineStart) || 0;
+  // Too wide to hang — a CJK bracket, or just past the padding. Stop WebKit as well.
+  if (advance >= parseFloat(cs.fontSize) * 0.8 || advance > room) {
+    quoteEl.style.hangingPunctuation = 'none';
+    return;
+  }
+  if (advance > 0 && !CSS.supports('hanging-punctuation', 'first')) {
+    quoteEl.style.textIndent = `${-advance / parseFloat(cs.fontSize)}em`;
+  }
+}
+
+function applyQuoteHang(quoteEl) {
+  if (!quoteEl) return;
+  const run = () => hangOpeningMark(quoteEl);
+  document.fonts?.ready?.then(run, run);
+}
+
 function parseArcCopy(row) {
   if (!row) return { title: '', body: [] };
   const heading = row.querySelector('h1,h2,h3,h4,h5,h6');
@@ -305,9 +334,11 @@ export function buildGlobeDom(el, labels, { arcCopy, pullQuote }) {
   el.querySelector('.globe-gallery-arc-copy-title').textContent = arcCopy.title;
   renderParagraphs(el.querySelector('.globe-gallery-arc-copy-body'), arcCopy.body);
   if (pullQuote) {
-    el.querySelector('.globe-gallery-pullquote-quote').textContent = pullQuote.quote;
+    const quoteEl = el.querySelector('.globe-gallery-pullquote-quote');
+    quoteEl.textContent = pullQuote.quote;
     el.querySelector('.globe-gallery-pullquote-name').textContent = pullQuote.name;
     el.querySelector('.globe-gallery-pullquote-role').textContent = pullQuote.role;
+    applyQuoteHang(quoteEl);
   } else {
     el.querySelector('.globe-gallery-pullquote-pin').remove();
   }

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -291,11 +291,13 @@ const buildMarkup = (gid, labels) => `
   </div>
 
   <div class="globe-gallery-pullquote-pin">
-    <div class="globe-gallery-pullquote">
-      <blockquote class="globe-gallery-pullquote-quote heading-1"></blockquote>
-      <div class="globe-gallery-pullquote-attribution">
-        <p class="globe-gallery-pullquote-name body-lg"></p>
-        <p class="globe-gallery-pullquote-role body-lg"></p>
+    <div class="globe-gallery-pullquote-rail">
+      <div class="globe-gallery-pullquote">
+        <blockquote class="globe-gallery-pullquote-quote heading-1"></blockquote>
+        <div class="globe-gallery-pullquote-attribution">
+          <p class="globe-gallery-pullquote-name body-lg"></p>
+          <p class="globe-gallery-pullquote-role body-lg"></p>
+        </div>
       </div>
     </div>
   </div>

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -143,6 +143,9 @@ function parseFragmentCardSegment(nodes) {
         if (strong) { name = strong; return; }
       }
       if (node.textContent.trim()) description.push(node); // everything else is description
+    } else if (tag === 'PICTURE' || tag === 'IMG') {
+      const bare = tag === 'IMG' ? node : node.querySelector('img');
+      if (!img && bare) img = bare;
     } else if (tag === 'UL') {
       node.querySelectorAll(':scope > li').forEach((li) => {
         // Row (on a clone, so authored DOM is untouched) = product; nested <ul> = its feature.
@@ -171,7 +174,14 @@ function parseFragmentCardSegment(nodes) {
     }
   });
 
-  if (!img) return null;
+  if (!img) {
+    const label = nodes.map((n) => n.textContent || '').join(' ').trim().slice(0, 60);
+    window.lana?.log?.(
+      `globe-gallery: fragment section skipped, no image — "${label}"`,
+      { tags: 'globe-gallery', severity: 'info' },
+    );
+    return null;
+  }
   return {
     img: img.currentSrc || img.getAttribute('src') || img.src,
     alt: (img.getAttribute('alt') || '').trim(),
@@ -182,8 +192,10 @@ function parseFragmentCardSegment(nodes) {
   };
 }
 
+const CARD_CONTENT_TAGS = /^(P|UL|PICTURE|IMG|H[1-6])$/;
+
 function parseFragmentCards(row) {
-  const hasDirectContent = [...row.children].some((n) => n.nodeName === 'P' || n.nodeName === 'UL');
+  const hasDirectContent = [...row.children].some((n) => CARD_CONTENT_TAGS.test(n.nodeName));
 
   if (!hasDirectContent) {
     // Children are section divs (each fragment section = one card).

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -18,12 +18,9 @@ function isSvgAnchor(a) {
   return !!badgeSvgUrl(a);
 }
 
-// Inline <picture> markup for an authored SVG-logo anchor, or null. The assets live under
-// /federal on the federated content root (NOT the consumer origin), so resolve through
-// getFederatedUrl rather than decorateSVG — which would strip the host to a bare pathname.
-// The logo is decorative (the badge name is the labelled link), hence aria-hidden + empty alt.
-function badgeIconHtml(anchor) {
-  const url = badgeSvgUrl(anchor);
+// Inline <picture> markup for a badge logo URL, or null. getFederatedUrl (not decorateSVG) and
+// aria-hidden: see README (Card shape).
+function badgeIconHtml(url) {
   if (!url) return null;
   const src = getFederatedUrl(url);
   return `<picture class="globe-gallery-modal-badge-icon" aria-hidden="true"><img loading="lazy" src="${escapeHtml(src)}" alt=""></picture>`;
@@ -114,29 +111,27 @@ function parseFragmentCardSegment(nodes) {
       if (text && !description) description = text;
     } else if (tag === 'UL') {
       node.querySelectorAll(':scope > li').forEach((li) => {
-        // A row may carry two direct-child links: an optional .svg logo and the product
-        // link that labels it. Either may be absent.
-        const anchors = [...li.childNodes].filter((n) => n.nodeName === 'A');
+        // Row (on a clone, so authored DOM is untouched) = product; nested <ul> = its feature.
+        const row = li.cloneNode(true);
+        const featureLi = row.querySelector(':scope > ul > li');
+        row.querySelector(':scope > ul')?.remove();
+
+        const anchors = [...row.querySelectorAll('a')];
         const svgAnchor = anchors.find(isSvgAnchor) || null;
         const linkAnchor = anchors.find((a) => a !== svgAnchor) || null;
-        const icon = svgAnchor ? badgeIconHtml(svgAnchor) : null;
-        const href = linkAnchor ? (linkAnchor.getAttribute('href') || null) : null;
+        const icon = badgeIconHtml(
+          svgAnchor ? badgeSvgUrl(svgAnchor) : row.querySelector('img')?.getAttribute('src'),
+        );
+        svgAnchor?.remove(); // its URL text is markup, never part of the name
 
-        const nestedLi = li.querySelector('ul > li');
-        if (nestedLi) {
-          const badgeName = linkAnchor
-            ? linkAnchor.textContent.trim()
-            : [...li.childNodes]
-              .filter((n) => n.nodeType === Node.TEXT_NODE)
-              .map((n) => n.textContent.trim())
-              .join('').trim();
-          const badgeRole = nestedLi.textContent.trim();
-          if (badgeName) badges.push({ name: badgeName, role: badgeRole, href, icon });
-        } else {
-          // Legacy pipe-separated format: "Photoshop | Compositing".
-          const source = linkAnchor ? linkAnchor.textContent : li.textContent;
-          const parts = source.split('|').map((s) => s.trim()).filter(Boolean);
-          if (parts[0]) badges.push({ name: parts[0], role: parts.slice(1).join(' '), href, icon });
+        const name = (linkAnchor ? linkAnchor.textContent : row.textContent).trim();
+        if (name) {
+          badges.push({
+            name,
+            role: featureLi?.textContent.trim() || '',
+            href: linkAnchor?.getAttribute('href') || null,
+            icon,
+          });
         }
       });
     }

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -70,14 +70,9 @@ function hangOpeningMark(quoteEl) {
   // Canvas ignores letter-spacing, and heading-1 has some.
   const advance = ctx.measureText([...text][0]).width + (parseFloat(cs.letterSpacing) || 0);
   const room = parseFloat(getComputedStyle(container).paddingInlineStart) || 0;
-  // Too wide to hang — a CJK bracket, or just past the padding. Stop WebKit as well.
-  if (advance >= parseFloat(cs.fontSize) * 0.8 || advance > room) {
-    quoteEl.style.hangingPunctuation = 'none';
-    return;
-  }
-  if (advance > 0 && !CSS.supports('hanging-punctuation', 'first')) {
-    quoteEl.style.textIndent = `${-advance / parseFloat(cs.fontSize)}em`;
-  }
+  // Too wide to hang — a CJK bracket, or just past the padding.
+  if (advance >= parseFloat(cs.fontSize) * 0.8 || advance > room) return;
+  if (advance > 0) quoteEl.style.textIndent = `${-advance / parseFloat(cs.fontSize)}em`;
 }
 
 function applyQuoteHang(quoteEl) {
@@ -268,7 +263,7 @@ export function parseAuthoredContent(el) {
 // modal's aria-labelledby/describedby.
 const buildMarkup = (gid, labels) => `
   <div class="globe-gallery-world">
-    <canvas class="globe-gallery-canvas" style="position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:3;display:none;pointer-events:auto;touch-action:pan-y;"></canvas>
+    <canvas class="globe-gallery-canvas" style="position:fixed;top:0;left:0;width:100%;height:100vh;z-index:3;display:none;pointer-events:auto;touch-action:pan-y;"></canvas>
   </div>
 
   <svg class="globe-gallery-ca-svg" aria-hidden="true" focusable="false" style="position:absolute;width:0;height:0;overflow:hidden">
@@ -306,7 +301,7 @@ const buildMarkup = (gid, labels) => `
     <div class="globe-gallery-modal-backdrop"></div>
   </div>
 
-  <canvas class="globe-gallery-modal-canvas" style="position:fixed;top:0;left:0;width:100vw;height:100vh;z-index:14;display:none;pointer-events:none;"></canvas>
+  <canvas class="globe-gallery-modal-canvas" style="position:fixed;top:0;left:0;width:100%;height:100vh;z-index:14;display:none;pointer-events:none;"></canvas>
 
   <dialog class="globe-gallery-modal-chrome" tabindex="-1" aria-labelledby="globe-gallery-modal-role-${gid} globe-gallery-modal-name-${gid} globe-gallery-modal-position-${gid}" aria-describedby="globe-gallery-modal-description-${gid}">
     <div class="globe-gallery-modal-info">

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -235,16 +235,16 @@ export async function fetchFragmentCards(href) {
   }
 }
 
-// Right-size a helix/DA media image to the width we actually rasterize, so slow connections
-// don't download the full-res source only for us to downscale it client-side. Requests webp at
-// `width`px (mirrors the width/format convention in libs/utils/decorate.js's decoratePictures).
-// Non-media URLs (external assets that don't honor these params) are returned as-is.
-export function optimizeImgUrl(src, width) {
+// Right-size a helix/DA media image to the dimension we rasterize, so slow connections don't
+// download the full-res source. Requests webp at `px` on `axis` (a lone `height=` is honoured
+// aspect-preservingly); cards ask by height, the modal by width — see README (Texture memory
+// budget). Non-media URLs (external assets that don't honor these params) are returned as-is.
+export function optimizeImgUrl(src, px, axis = 'width') {
   if (!src) return src;
   try {
     const url = new URL(src, window.location.href);
     if (!/(^|\/)media_[0-9a-f]/i.test(url.pathname)) return src;
-    return `${url.origin}${url.pathname}?width=${Math.round(width)}&format=webply`;
+    return `${url.origin}${url.pathname}?${axis}=${Math.round(px)}&format=webply`;
   } catch (e) {
     return src;
   }

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -69,6 +69,10 @@ function cellText(cell) {
   return (paras.length ? paras.join(' ') : cell.textContent).trim();
 }
 
+function cellParas(cell) {
+  return cell ? [...cell.querySelectorAll('p')].filter((x) => x.textContent.trim()) : [];
+}
+
 // Move the authored <p>s into a container. See README (Reusing authored paragraphs).
 export function renderParagraphs(container, paras) {
   if (container) container.replaceChildren(...paras);
@@ -270,7 +274,7 @@ export function parseAuthoredContent(el) {
     arcCopy: parseArcCopy(arcCopyRow),
     pullQuote: pullQuoteRow ? parsePullQuote(pullQuoteRow) : null,
     fragmentHref: fragmentLink ? fragmentLink.href.replace(/#.*$/, '') : null,
-    touchHint: cellText(cells[0]) || DEFAULT_TOUCH_HINT,
+    touchHint: { paras: cellParas(cells[0]), text: cellText(cells[0]) || DEFAULT_TOUCH_HINT },
     hintText: cellText(cells[1]) || DEFAULT_HINT,
     instructions: parts[0] || DEFAULT_GALLERY_INSTRUCTIONS,
     labels: buildLabels(parts),
@@ -291,7 +295,7 @@ const buildMarkup = (gid, labels) => `
         <button class="globe-gallery-control globe-gallery-rotate" type="button" data-dir="-1" daa-ll="rotate_left--globe_gallery" aria-label="${escapeHtml(labels.rotateLeft)}">
           <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path d="M20 12H4m0 0l6-6m-6 6l6 6" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
-        <p class="globe-gallery-hint-text"></p>
+        <div class="globe-gallery-hint-text"></div>
         <button class="globe-gallery-control globe-gallery-rotate" type="button" data-dir="1" daa-ll="rotate_right--globe_gallery" aria-label="${escapeHtml(labels.rotateRight)}">
           <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path d="M4 12h16m0 0l-6-6m6 6l-6 6" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
@@ -368,7 +372,9 @@ export function buildGlobeDom(el, labels, { arcCopy, pullQuote, touchHint }) {
   globeInstanceSeq += 1;
   const gid = globeInstanceSeq;
   el.innerHTML = buildMarkup(gid, labels);
-  el.querySelector('.globe-gallery-hint-text').textContent = touchHint;
+  const hintEl = el.querySelector('.globe-gallery-hint-text');
+  if (touchHint.paras.length) renderParagraphs(hintEl, touchHint.paras);
+  else hintEl.textContent = touchHint.text;
   el.querySelector('.globe-gallery-arc-copy-title').textContent = arcCopy.title;
   renderParagraphs(el.querySelector('.globe-gallery-arc-copy-body'), arcCopy.body);
   if (pullQuote) {

--- a/libs/mep/ace1209/globe-gallery/src/controls.js
+++ b/libs/mep/ace1209/globe-gallery/src/controls.js
@@ -1,0 +1,63 @@
+// On-canvas globe chrome: auto-spin play/pause + the barrel's rotate row. See README.
+const SPIN_DAA_PAUSE = 'pause_spin--globe_gallery';
+const SPIN_DAA_RESUME = 'resume_spin--globe_gallery';
+
+export default function createGlobeControls({ q, labels, getVisible, rotate }) {
+  let layerEl = null;
+  let spinBtn = null;
+  let rotateBtns = [];
+  let paused = false; // survives breakpoint rebuilds — the closure outlives them
+  let appliedVisible = null; // last-written class state; update() only writes on a flip
+
+  function renderSpinState() {
+    if (!spinBtn) return;
+    spinBtn.setAttribute('aria-label', paused ? labels.resumeSpin : labels.pauseSpin);
+    spinBtn.setAttribute('daa-ll', paused ? SPIN_DAA_RESUME : SPIN_DAA_PAUSE);
+    spinBtn.classList.toggle('is-paused', paused);
+  }
+
+  function onSpinClick() {
+    paused = !paused;
+    renderSpinState();
+  }
+
+  function onRotateClick(e) {
+    rotate(Number(e.currentTarget.dataset.dir));
+  }
+
+  function setup() {
+    layerEl = q('.globe-gallery-controls');
+    if (!layerEl) return;
+    // Tab order, not layout: must land AFTER a11y.setup's nodes. See README (Globe controls).
+    layerEl.parentNode?.appendChild(layerEl);
+    spinBtn = layerEl.querySelector('.globe-gallery-spin-toggle');
+    rotateBtns = [...layerEl.querySelectorAll('.globe-gallery-rotate')];
+    spinBtn?.addEventListener('click', onSpinClick);
+    rotateBtns.forEach((btn) => btn.addEventListener('click', onRotateClick));
+    appliedVisible = null;
+    renderSpinState();
+  }
+
+  // Per-frame: fade the layer in/out with the globe's interactive window.
+  function update() {
+    if (!layerEl) return;
+    const visible = getVisible();
+    if (visible === appliedVisible) return;
+    appliedVisible = visible;
+    layerEl.classList.toggle('is-visible', visible);
+  }
+
+  function isSpinPaused() { return paused; }
+
+  function teardown() {
+    spinBtn?.removeEventListener('click', onSpinClick);
+    rotateBtns.forEach((btn) => btn.removeEventListener('click', onRotateClick));
+    layerEl?.classList.remove('is-visible');
+    layerEl = null;
+    spinBtn = null;
+    rotateBtns = [];
+    appliedVisible = null;
+  }
+
+  return { setup, update, teardown, isSpinPaused };
+}

--- a/libs/mep/ace1209/globe-gallery/src/cursor.js
+++ b/libs/mep/ace1209/globe-gallery/src/cursor.js
@@ -11,55 +11,65 @@ const RING_SVG = [
 // Must match the --retiring transition durations in globe-gallery.css.
 const RETIRE_FADE_MS = 420;
 
+const initialState = () => ({
+  onCanvas: false, // pointer currently over the globe canvas
+  suppressed: false, // keyboard focus / window blur took over; cleared on next mousemove
+  active: false, // cursor currently shown
+  hintDismissed: false, // label faded out after the user's first drag
+  retireT0: -1, // retirement fade start timestamp; -1 = not retiring
+  mx: 0,
+  my: 0,
+  hasCoords: false, // a real mousemove has landed; gates activation. See README (Behavior notes).
+});
+
 export default function createCursor(deps) {
   const {
     getCanvas, getSphereInteractive, getModalOpen, getReducedMotion,
     getHintDismissed, getCursorRetired, labelText, drag,
   } = deps;
-  let containerEl = null; // fixed container: chevrons + label (no blend mode)
-  let discEl = null; // body-level disc (mix-blend-mode: difference)
-  let ringWrap = null;
-  let textWrap = null;
-  let hasMouse = false; // device supports hover + fine pointer
-  let onCanvas = false; // pointer currently over the globe canvas
-  let suppressed = false; // keyboard focus / window blur took over; cleared on next mousemove
-  let active = false; // cursor currently shown
-  let hintDismissed = false; // label faded out after the user's first drag
-  let retireT0 = -1; // retirement fade start timestamp; -1 = not retiring
-  let mx = 0;
-  let my = 0;
+  let els = null; // { container, disc, ring, text }; null until setup and after teardown
+  let state = initialState();
 
   const now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
 
-  function onMove(e) { mx = e.clientX; my = e.clientY; suppressed = false; }
-  function onEnter() { onCanvas = true; }
-  function onLeave() { onCanvas = false; }
-  function onSuppress() { suppressed = true; }
+  function onMove(e) {
+    state.mx = e.clientX;
+    state.my = e.clientY;
+    state.hasCoords = true;
+    state.suppressed = false;
+  }
+  function onEnter() { state.onCanvas = true; }
+  function onLeave() { state.onCanvas = false; }
+  function onSuppress() { state.suppressed = true; }
 
   // Capability is read once. A device that gains/loses a fine pointer mid-session is out of scope
   // (a re-init re-reads it — e.g. an RM toggle; otherwise reload). See README (Behavior notes).
   function setup() {
+    if (els) return;
     if (!window.matchMedia) return;
-    hasMouse = window.matchMedia('(hover: hover) and (pointer: fine)').matches;
-    if (!hasMouse) return;
+    if (!window.matchMedia('(hover: hover) and (pointer: fine)').matches) return;
 
     // Disc — direct body child so mix-blend-mode blends against real page content.
-    discEl = document.createElement('div');
-    discEl.className = 'globe-gallery-cursor-disc';
-    document.body.appendChild(discEl);
+    const disc = document.createElement('div');
+    disc.className = 'globe-gallery-cursor-disc';
+    document.body.appendChild(disc);
 
     // Chevrons + label — no blend mode, safe inside the fixed container.
-    containerEl = document.createElement('div');
-    containerEl.className = 'globe-gallery-cursor';
+    const container = document.createElement('div');
+    container.className = 'globe-gallery-cursor';
     // Static structure via innerHTML; authored label set as textContent below.
-    containerEl.innerHTML = `<div class="globe-gallery-cursor-ring-wrap">${RING_SVG}</div>`
+    container.innerHTML = `<div class="globe-gallery-cursor-ring-wrap">${RING_SVG}</div>`
       + '<div class="globe-gallery-cursor-text-wrap">'
       + '<span class="globe-gallery-cursor-text"></span>'
       + '</div>';
-    document.body.appendChild(containerEl);
-    ringWrap = containerEl.querySelector('.globe-gallery-cursor-ring-wrap');
-    textWrap = containerEl.querySelector('.globe-gallery-cursor-text-wrap');
-    containerEl.querySelector('.globe-gallery-cursor-text').textContent = labelText || 'Click & Drag';
+    document.body.appendChild(container);
+    container.querySelector('.globe-gallery-cursor-text').textContent = labelText || 'Click & Drag';
+    els = {
+      container,
+      disc,
+      ring: container.querySelector('.globe-gallery-cursor-ring-wrap'),
+      text: container.querySelector('.globe-gallery-cursor-text-wrap'),
+    };
 
     const canvas = getCanvas();
     if (canvas) {
@@ -74,53 +84,52 @@ export default function createCursor(deps) {
 
   // Per-frame: toggle shown/dragging/retiring state and follow the pointer. No-op on touch.
   function update() {
-    if (!containerEl || !hasMouse) return;
+    if (!els) return;
     const canvas = getCanvas();
 
     // Retirement: start the CSS fade when the signal flips; after RETIRE_FADE_MS drop
     // `active` too, handing the canvas cursor back to the system.
     const wantRetired = getCursorRetired();
-    if (wantRetired !== (retireT0 >= 0)) {
-      retireT0 = wantRetired ? now() : -1;
-      containerEl.classList.toggle('globe-gallery-cursor-retiring', wantRetired);
-      if (discEl) discEl.classList.toggle('globe-gallery-cursor-disc-retiring', wantRetired);
+    if (wantRetired !== (state.retireT0 >= 0)) {
+      state.retireT0 = wantRetired ? now() : -1;
+      els.container.classList.toggle('globe-gallery-cursor-retiring', wantRetired);
+      els.disc.classList.toggle('globe-gallery-cursor-disc-retiring', wantRetired);
     }
-    const faded = retireT0 >= 0 && now() - retireT0 >= RETIRE_FADE_MS;
+    const faded = state.retireT0 >= 0 && now() - state.retireT0 >= RETIRE_FADE_MS;
 
     const wantActive = !getReducedMotion()
-      && onCanvas
-      && !suppressed
+      && state.hasCoords
+      && state.onCanvas
+      && !state.suppressed
       && getSphereInteractive()
       && !getModalOpen()
       && !faded;
-    if (wantActive !== active) {
-      active = wantActive;
-      containerEl.classList.toggle('globe-gallery-cursor-active', active);
-      if (discEl) discEl.classList.toggle('globe-gallery-cursor-disc-active', active);
+    if (wantActive !== state.active) {
+      state.active = wantActive;
+      els.container.classList.toggle('globe-gallery-cursor-active', state.active);
+      els.disc.classList.toggle('globe-gallery-cursor-disc-active', state.active);
       // Hide the system cursor while ours shows; interaction.js defers to isActive().
-      if (canvas) canvas.style.cursor = active ? 'none' : '';
+      if (canvas) canvas.style.cursor = state.active ? 'none' : '';
     }
     // One-way label dismissal: after the first drag the label fades (disc + chevrons stay).
     const wantDismissed = getHintDismissed();
-    if (wantDismissed !== hintDismissed) {
-      hintDismissed = wantDismissed;
-      containerEl.classList.toggle('globe-gallery-cursor-hint-dismissed', hintDismissed);
+    if (wantDismissed !== state.hintDismissed) {
+      state.hintDismissed = wantDismissed;
+      els.container.classList.toggle('globe-gallery-cursor-hint-dismissed', state.hintDismissed);
     }
     // From `active` so going inactive mid-drag clears the squeeze rather than freezing it.
-    const dragging = active && drag.isDragging;
-    containerEl.classList.toggle('globe-gallery-cursor-dragging', dragging);
-    if (discEl) discEl.classList.toggle('globe-gallery-cursor-disc-dragging', dragging);
-    if (!active) return;
-    if (discEl) {
-      // top/left (not transform) keeps `transform` free for the CSS scale entrance.
-      discEl.style.left = `${mx}px`;
-      discEl.style.top = `${my}px`;
-    }
-    ringWrap.style.transform = `translate(${mx}px, ${my}px)`;
-    textWrap.style.transform = `translate(${mx + 32}px, ${my - 11}px)`;
+    const dragging = state.active && drag.isDragging;
+    els.container.classList.toggle('globe-gallery-cursor-dragging', dragging);
+    els.disc.classList.toggle('globe-gallery-cursor-disc-dragging', dragging);
+    if (!state.active) return;
+    // top/left (not transform) keeps `transform` free for the CSS scale entrance.
+    els.disc.style.left = `${state.mx}px`;
+    els.disc.style.top = `${state.my}px`;
+    els.ring.style.transform = `translate(${state.mx}px, ${state.my}px)`;
+    els.text.style.transform = `translate(${state.mx + 32}px, ${state.my - 11}px)`;
   }
 
-  function isActive() { return active; }
+  function isActive() { return state.active; }
 
   function teardown() {
     const canvas = getCanvas();
@@ -132,11 +141,12 @@ export default function createCursor(deps) {
     window.removeEventListener('mousemove', onMove);
     document.removeEventListener('focusin', onSuppress);
     window.removeEventListener('blur', onSuppress);
-    if (containerEl && containerEl.parentNode) containerEl.parentNode.removeChild(containerEl);
-    if (discEl && discEl.parentNode) discEl.parentNode.removeChild(discEl);
-    containerEl = null; discEl = null; ringWrap = null; textWrap = null;
-    onCanvas = false; suppressed = false; active = false; hintDismissed = false; mx = 0; my = 0;
-    retireT0 = -1;
+    if (els) {
+      els.container.remove();
+      els.disc.remove();
+      els = null;
+    }
+    state = initialState();
   }
 
   return { setup, update, teardown, isActive };

--- a/libs/mep/ace1209/globe-gallery/src/interaction.js
+++ b/libs/mep/ace1209/globe-gallery/src/interaction.js
@@ -223,9 +223,8 @@ export default function createInteraction({
     resetDrag();
   }
 
-  // True when the in-flight touch gesture is a page scroll (or hasn't declared its axis):
-  // the globe is inert, so hint-text dismissal must exclude it. See README (Behavior notes).
-  // Gated on drag.isDragging since isTouchDrag persists after pointerup.
+  // True while an in-flight touch gesture is page scroll (or undecided): the globe is inert, so
+  // hint dismissal must skip it. Gated on isDragging — isTouchDrag persists after pointerup.
   const isPageScrollGesture = () => drag.isDragging
     && isTouchDrag
     && axisLock !== AXIS_HORIZONTAL;

--- a/libs/mep/ace1209/globe-gallery/src/interaction.js
+++ b/libs/mep/ace1209/globe-gallery/src/interaction.js
@@ -1,7 +1,9 @@
 // Pointer interaction for the globe (DI module). See README (Behavior notes).
 import * as THREE from '../three.module.min.js';
 
-const DRAG_SENSITIVITY = 0.005; // pointer px → rad/frame drag velocity
+// Release-velocity model (flushVel + endGesture): see README (Drag physics).
+const FRAME_MS = 1000 / 60; // velX/velY are per-60fps-frame; the core rescales by real frame dt
+const VEL_SMOOTH_MS = 35; // EMA time constant
 const CLICK_MAX_MOVE = 10; // px
 const CLICK_MAX_TIME = 500; // ms
 const PICK_MIN_OPACITY = 0.1;
@@ -11,17 +13,24 @@ const AXIS_UNDECIDED = 0;
 const AXIS_HORIZONTAL = 1; // spinning the globe — we consume the deltas
 const AXIS_VERTICAL = 2; // page scroll — we ignore the gesture entirely
 
+const now = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
 export default function createInteraction({
   getRenderer, getCamera, getCards, getModalIdx, openModal,
-  getSphereFormT, interactiveThreshold, maxVel, drag, isCursorActive, getYawOnly,
+  getSphereFormT, getDragSensitivity, interactiveThreshold, maxVel, drag, isCursorActive,
+  getYawOnly,
 }) {
   // Raycaster + NDC scratch for canvas picking.
   const raycaster = new THREE.Raycaster();
   const mouseNDC = new THREE.Vector2();
 
   let canvasEl = null;
+  let activePointerId = -1; // owner of the in-flight gesture (-1 = none), not hasPointerCapture()
   let lastMX = 0;
   let lastMY = 0;
+  let lastMoveT = 0;
+  let sampX = 0; // travel (rad) banked since the last velocity sample — see flushVel
+  let sampY = 0;
   let pointerDownX = 0;
   let pointerDownY = 0;
   let pointerDownT = 0;
@@ -38,20 +47,48 @@ export default function createInteraction({
     axisLock = tdx > tdy ? AXIS_HORIZONTAL : AXIS_VERTICAL;
   }
 
-  function ownsDrag(e) {
-    return drag.isDragging && canvasEl != null && canvasEl.hasPointerCapture(e.pointerId);
-  }
+  const ownsDrag = (e) => activePointerId === e.pointerId;
 
   // Zero the shared drag object. NOT called on pointerup — release keeps velX/velY (inertia).
   function resetDrag() {
     drag.isDragging = false;
     drag.velX = 0;
     drag.velY = 0;
+    drag.pendingX = 0;
+    drag.pendingY = 0;
+    sampX = 0;
+    sampY = 0;
+    activePointerId = -1;
+    axisLock = AXIS_UNDECIDED;
   }
 
+  // Abort the gesture outright: no inertia, no tap. For pointercancel / context menu.
   function cancelDrag() {
     if (!drag.isDragging) return;
     resetDrag();
+  }
+
+  // Fold the banked travel into the velocity EMA, sampled by elapsed time (not per event).
+  const clampVel = (v) => Math.max(-maxVel, Math.min(maxVel, v));
+  function flushVel(t) {
+    const dtMs = t - lastMoveT;
+    if (dtMs <= 0) return;
+    const a = 1 - Math.exp(-dtMs / VEL_SMOOTH_MS);
+    drag.velX = clampVel(drag.velX + ((sampX / dtMs) * FRAME_MS - drag.velX) * a);
+    drag.velY = clampVel(drag.velY + ((sampY / dtMs) * FRAME_MS - drag.velY) * a);
+    sampX = 0; sampY = 0;
+    lastMoveT = t;
+  }
+
+  // Release: keep velX/velY as inertia, decayed across the idle gap since the last move (the final
+  // flush banks nothing). False when there was no gesture to end.
+  function endGesture() {
+    if (!drag.isDragging) return false;
+    drag.isDragging = false;
+    activePointerId = -1;
+    axisLock = AXIS_UNDECIDED; // cleared for the next gesture; the tap test doesn't read it
+    flushVel(now());
+    return true;
   }
 
   // Raycast the cards under the pointer; returns intersections (nearest first).
@@ -73,12 +110,16 @@ export default function createInteraction({
     if (e.button !== 0 || !e.isPrimary) return;
     if (getModalIdx() >= 0) return;
     canvasEl.setPointerCapture(e.pointerId);
+    activePointerId = e.pointerId;
     drag.isDragging = true;
     lastMX = e.clientX; lastMY = e.clientY;
     drag.velX = 0; drag.velY = 0;
+    drag.pendingX = 0; drag.pendingY = 0;
+    sampX = 0; sampY = 0;
     pointerDownX = e.clientX;
     pointerDownY = e.clientY;
-    pointerDownT = Date.now();
+    pointerDownT = now();
+    lastMoveT = pointerDownT;
     // Pen grouped with touch: direct contact, drives the page scroll gesture too.
     isTouchDrag = e.pointerType === 'touch' || e.pointerType === 'pen';
     axisLock = AXIS_UNDECIDED;
@@ -87,18 +128,19 @@ export default function createInteraction({
   function onPointerMove(e) {
     if (!ownsDrag(e)) return;
     resolveAxisLock(e);
-    // Touch, axis not yet resolved → consume nothing (lastMX/MY NOT advanced, so no delta lost).
-    if (isTouchDrag && axisLock === AXIS_UNDECIDED) return;
-    // Touch, vertical → the page owns this gesture; leave the sphere inert.
-    if (isTouchDrag && axisLock === AXIS_VERTICAL) return;
-    drag.velX = Math.max(-maxVel, Math.min(maxVel, (e.clientX - lastMX) * DRAG_SENSITIVITY));
-    // Pitch is enabled only for a mouse on the sphere. Touch never pitches (vertical = scroll);
-    // the yaw-only barrel never pitches for anyone (a cylinder can't centre vertically — matches
-    // the keyboard/modal centring path, which holds pitch when bp.YAW_ONLY). +Y delta (drag down)
-    // tips the front down so the globe follows.
-    if (!isTouchDrag && !getYawOnly()) {
-      drag.velY = Math.max(-maxVel, Math.min(maxVel, (e.clientY - lastMY) * DRAG_SENSITIVITY));
-    }
+    // Touch: inert until the axis latches horizontal. lastMX/MY/lastMoveT are NOT advanced here,
+    // so neither the travel nor the elapsed time is lost.
+    if (isTouchDrag && axisLock !== AXIS_HORIZONTAL) return;
+    const t = now();
+    const sens = getDragSensitivity(); // rad/px, live off the viewport + band
+    const dx = (e.clientX - lastMX) * sens;
+    // Pitch only for a mouse on the sphere; +Y delta (drag down) tips the front down.
+    const dy = !isTouchDrag && !getYawOnly() ? (e.clientY - lastMY) * sens : 0;
+    // pendingX/Y: exact travel, applied 1:1. velX/Y: smoothed, for the release.
+    drag.pendingX += dx;
+    drag.pendingY += dy;
+    sampX += dx; sampY += dy;
+    flushVel(t);
     lastMX = e.clientX; lastMY = e.clientY;
   }
 
@@ -116,14 +158,10 @@ export default function createInteraction({
   }
 
   function onPointerUp(e) {
-    if (!ownsDrag(e)) return;
-    drag.isDragging = false;
-    // Clear the lock for the next gesture. The tap test below is independent of axisLock
-    // (CLICK_MAX_MOVE 10px > AXIS_LOCK_THRESHOLD 8px, so a jittery tap may have latched one).
-    axisLock = AXIS_UNDECIDED;
+    if (!ownsDrag(e) || !endGesture()) return;
     const dx = Math.abs(e.clientX - pointerDownX);
     const dy = Math.abs(e.clientY - pointerDownY);
-    const dt = Date.now() - pointerDownT;
+    const dt = now() - pointerDownT;
     if (dx < CLICK_MAX_MOVE && dy < CLICK_MAX_MOVE && dt < CLICK_MAX_TIME
       && getSphereFormT() >= interactiveThreshold && getModalIdx() < 0) {
       handleCardClick(e);
@@ -162,8 +200,10 @@ export default function createInteraction({
     canvas.addEventListener('pointerdown', onPointerDown);
     canvas.addEventListener('pointermove', onPointerMove);
     canvas.addEventListener('pointerup', onPointerUp);
-    canvas.addEventListener('pointercancel', onPointerUp);
-    canvas.addEventListener('lostpointercapture', cancelDrag);
+    // pointercancel = taken away, not released: no inertia, no tap. lostpointercapture is a no-op
+    // after a normal release and the escape hatch on a real loss. See README (Drag physics).
+    canvas.addEventListener('pointercancel', cancelDrag);
+    canvas.addEventListener('lostpointercapture', endGesture);
     canvas.addEventListener('contextmenu', cancelDrag);
     canvas.addEventListener('mousemove', onHover);
   }
@@ -173,8 +213,8 @@ export default function createInteraction({
       canvasEl.removeEventListener('pointerdown', onPointerDown);
       canvasEl.removeEventListener('pointermove', onPointerMove);
       canvasEl.removeEventListener('pointerup', onPointerUp);
-      canvasEl.removeEventListener('pointercancel', onPointerUp);
-      canvasEl.removeEventListener('lostpointercapture', cancelDrag);
+      canvasEl.removeEventListener('pointercancel', cancelDrag);
+      canvasEl.removeEventListener('lostpointercapture', endGesture);
       canvasEl.removeEventListener('contextmenu', cancelDrag);
       canvasEl.removeEventListener('mousemove', onHover);
       canvasEl.style.cursor = '';

--- a/libs/mep/ace1209/globe-gallery/src/materials.js
+++ b/libs/mep/ace1209/globe-gallery/src/materials.js
@@ -5,16 +5,15 @@ import { CARD_VERT, CARD_FRAG, MODAL_VERT, MODAL_FRAG, TEXT_FRAG } from './shade
 
 // Card ShaderMaterial: cover-crop, CA, hover warp, rounded corners (uAspect + uRadius).
 // Property proxies let the tick loop drive it via MeshBasicMaterial's opacity/map API.
-export function createCardMaterial({
-  texture, aspect, repeatX, repeatY, offsetX, offsetY,
-}) {
+// uRepeat/uOffset start identity; each phase pushes the frame's crop (see applyCardFit).
+export function createCardMaterial({ texture, aspect }) {
   const mat = new THREE.ShaderMaterial({
     uniforms: {
       uMap: { value: texture },
       uOpacity: { value: 0 },
       uCA: { value: 0 },
-      uRepeat: { value: new THREE.Vector2(repeatX, repeatY) },
-      uOffset: { value: new THREE.Vector2(offsetX, offsetY) },
+      uRepeat: { value: new THREE.Vector2(1, 1) },
+      uOffset: { value: new THREE.Vector2(0, 0) },
       uMotionDir: { value: new THREE.Vector2(0, 0) },
       uWarp: { value: 0 },
       uHoverPos: { value: new THREE.Vector2(0.5, 0.5) },
@@ -50,6 +49,8 @@ export function createModalMaterial(texture, aspect) {
       uMotionDir: { value: new THREE.Vector2(0, 0) },
       uWarp: { value: 0 },
       uWarpCenter: { value: new THREE.Vector2(0.5, 0.5) },
+      uRepeat: { value: new THREE.Vector2(1, 1) },
+      uOffset: { value: new THREE.Vector2(0, 0) },
     },
     vertexShader: MODAL_VERT,
     fragmentShader: MODAL_FRAG,
@@ -93,6 +94,15 @@ function fitDims(w, h, maxTex) {
   return { w: Math.max(1, Math.round(w * s)), h: Math.max(1, Math.round(h * s)) };
 }
 
+// Card textures are capped on HEIGHT (the axis a portrait-ish slot keeps), with WIDE_TEX_RATIO
+// bounding a panorama's width. See README (Texture memory budget).
+const WIDE_TEX_RATIO = 2.5;
+function fitCardDims(w, h, maxH) {
+  const s = Math.min(1, maxH / Math.max(1, h), (maxH * WIDE_TEX_RATIO) / Math.max(1, w));
+  if (s >= 1) return { w, h };
+  return { w: Math.max(1, Math.round(w * s)), h: Math.max(1, Math.round(h * s)) };
+}
+
 // Solid-color canvas — placeholder + untainted fallback (see imageToCanvas).
 function makeCanvas(w, h, color) {
   const cv = document.createElement('canvas');
@@ -103,10 +113,10 @@ function makeCanvas(w, h, color) {
   return cv;
 }
 
-// Draw an image into an aspect-preserving canvas clamped to `maxTex`.
+// Draw an image into an aspect-preserving canvas clamped by `fit` (fitDims / fitCardDims).
 // Loaded via plain Image (no crossOrigin) so file:// works; tainted canvas → solid fallback.
-function imageToCanvas(img, maxTex) {
-  const { w, h } = fitDims(img.naturalWidth || 512, img.naturalHeight || 512, maxTex);
+function imageToCanvas(img, cap, fit = fitDims) {
+  const { w, h } = fit(img.naturalWidth || 512, img.naturalHeight || 512, cap);
   const cv = makeCanvas(w, h, '#555');
   const ctx = cv.getContext('2d');
   try {
@@ -129,52 +139,38 @@ export function createPlaceholderTexture() {
   return tex;
 }
 
-// Cover-fit crop for one loaded texture. Mutates tex.repeat/offset and returns the per-card
-// data (sphereScaleX = native width stretch; arcRepeat/Offset = cover-crop UVs for arc/grid).
-function computeTexData(tex, planeAspect) {
-  tex.colorSpace = THREE.SRGBColorSpace;
+// Native aspect of a decoded texture — the only per-card value a decode contributes.
+function texAspect(tex) {
   const imgW = (tex.image && tex.image.width) || 1;
   const imgH = (tex.image && tex.image.height) || 1;
-  const imgAspect = imgW / imgH;
-  if (imgAspect > planeAspect) {
-    // Image wider than plane → crop left/right, keep center
-    tex.repeat.x = planeAspect / imgAspect;
-    tex.offset.x = (1 - tex.repeat.x) / 2;
-  } else if (imgAspect < planeAspect) {
-    // Image taller than plane → crop top/bottom, keep center
-    tex.repeat.y = imgAspect / planeAspect;
-    tex.offset.y = (1 - tex.repeat.y) / 2;
-  }
-  return {
-    sphereScaleX: imgAspect / planeAspect,
-    arcRepeatX: tex.repeat.x,
-    arcRepeatY: tex.repeat.y,
-    arcOffsetX: tex.offset.x,
-    arcOffsetY: tex.offset.y,
-  };
+  return imgW / imgH;
 }
 
-// Load every card image into a CanvasTexture with a cover-fit crop. `onEach(i, tex, texData)`
-// fires as each image settles (progressive reveal); `onDone(textures, cardTexData)` fires once
-// all `count` have settled. Callers own the stale-load guard in these callbacks.
-export function loadCardTextures({ count, getSrc, planeAspect, maxTex }, onEach, onDone) {
+// Load every card image into a CanvasTexture capped at `maxTexH` px tall (fitCardDims).
+// `onEach(i, tex, aspect)` fires per settled image (progressive reveal); `onDone(textures,
+// aspects)` once all `count` settle. Callers own the stale-load guard in these callbacks.
+export function loadCardTextures({ count, getSrc, maxTexH }, onEach, onDone) {
   let loaded = 0;
   const textures = new Array(count);
-  const cardTexData = new Array(count);
+  const aspects = new Array(count);
 
   function done(i, tex) {
-    const texData = computeTexData(tex, planeAspect);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    const aspect = texAspect(tex);
     textures[i] = tex;
-    cardTexData[i] = texData;
-    if (onEach) onEach(i, tex, texData);
+    aspects[i] = aspect;
+    if (onEach) onEach(i, tex, aspect);
     loaded += 1;
-    if (loaded === count && onDone) onDone(textures, cardTexData);
+    if (loaded === count && onDone) onDone(textures, aspects);
   }
 
   function tryLoad(i) {
     const img = new Image();
     img.onload = () => {
-      const rasterize = () => done(i, new THREE.CanvasTexture(imageToCanvas(img, maxTex)));
+      const rasterize = () => done(
+        i,
+        new THREE.CanvasTexture(imageToCanvas(img, maxTexH, fitCardDims)),
+      );
       if (img.decode) img.decode().then(rasterize, rasterize);
       else rasterize();
     };

--- a/libs/mep/ace1209/globe-gallery/src/materials.js
+++ b/libs/mep/ace1209/globe-gallery/src/materials.js
@@ -5,9 +5,8 @@ import {
 
 // GPU-asset factories: the card/modal/text ShaderMaterials + the card/modal/hint texture loaders.
 
-// Card ShaderMaterial: cover-crop, CA, hover warp, rounded corners (uAspect + uRadius).
-// Property proxies let the tick loop drive it via MeshBasicMaterial's opacity/map API.
-// uRepeat/uOffset start identity; each phase pushes the frame's crop (see applyCardFit).
+// Card ShaderMaterial: cover-crop, CA, hover warp, rounded corners. Property proxies let the
+// tick loop drive it via MeshBasicMaterial's opacity/map API.
 export function createCardMaterial({ texture, aspect }) {
   const mat = new THREE.ShaderMaterial({
     uniforms: {
@@ -149,9 +148,8 @@ function texAspect(tex) {
   return imgW / imgH;
 }
 
-// Load every card image into a CanvasTexture capped at `maxTexH` px tall (fitCardDims).
-// `onEach(i, tex, aspect)` fires per settled image (progressive reveal); `onDone(textures,
-// aspects)` once all `count` settle. Callers own the stale-load guard in these callbacks.
+// Load every card image into a CanvasTexture capped at `maxTexH` tall. onEach fires per
+// settled image (progressive reveal), onDone once all `count` settle.
 export function loadCardTextures({ count, getSrc, maxTexH }, onEach, onDone) {
   let loaded = 0;
   const textures = new Array(count);
@@ -187,10 +185,8 @@ export function loadCardTextures({ count, getSrc, maxTexH }, onEach, onDone) {
   for (let i = 0; i < count; i += 1) tryLoad(i);
 }
 
-// Load one card image at a higher cap for the modal (raw-UV, no cover-crop). onReady fires
-// once decoded; caller owns disposal. onError fires if the load fails so the caller can drop its
-// pending-Image reference (the base texture stays). Returns the Image so a pending load can be
-// cancelled (img.src = '').
+// Higher-cap texture for the modal (raw UV, no cover-crop). Returns the Image so a pending
+// load can be cancelled; caller owns disposal.
 export function loadModalTexture(src, maxTex, onReady, onError) {
   const img = new Image();
   img.onload = () => {

--- a/libs/mep/ace1209/globe-gallery/src/materials.js
+++ b/libs/mep/ace1209/globe-gallery/src/materials.js
@@ -1,5 +1,7 @@
 import * as THREE from '../three.module.min.js';
-import { CARD_VERT, CARD_FRAG, MODAL_VERT, MODAL_FRAG, TEXT_FRAG } from './shaders.js';
+import {
+  CARD_VERT, CARD_DISPERSE_VERT, CARD_FRAG, MODAL_VERT, MODAL_FRAG, TEXT_FRAG,
+} from './shaders.js';
 
 // GPU-asset factories: the card/modal/text ShaderMaterials + the card/modal/hint texture loaders.
 
@@ -20,10 +22,11 @@ export function createCardMaterial({ texture, aspect }) {
       uAspect: { value: aspect },
       uRadius: { value: 22.0 / 631.0 },
       uDissolve: { value: 0 }, // near-camera proximity dissolve (0 = solid, 1 = fully dispersed)
+      uDisperse: { value: 0 }, // near-camera explosion (near-camera only; 0 in other phases)
       uReveal: { value: 0 }, // texture-ready reveal (0 = contour only, 1 = full photo)
       uContourFade: { value: 1 }, // near-camera gate for the contour (mirrors proxFade)
     },
-    vertexShader: CARD_VERT,
+    vertexShader: CARD_DISPERSE_VERT,
     fragmentShader: CARD_FRAG,
     side: THREE.DoubleSide,
     transparent: true,

--- a/libs/mep/ace1209/globe-gallery/src/materials.js
+++ b/libs/mep/ace1209/globe-gallery/src/materials.js
@@ -131,6 +131,10 @@ function imageToCanvas(img, cap, fit = fitDims) {
   return cv;
 }
 
+function releaseCanvasAfterUpload(tex, cv) {
+  tex.onUpdate = () => { cv.width = 0; cv.height = 0; };
+}
+
 // A tiny transparent texture so a card mesh can be built (and its contour rendered) before its
 // real photo has loaded. Its pixels are never shown — the contour hides them until uReveal > 0.
 export function createPlaceholderTexture() {
@@ -149,7 +153,8 @@ function texAspect(tex) {
 }
 
 // Load every card image into a CanvasTexture capped at `maxTexH` tall. onEach fires per
-// settled image (progressive reveal), onDone once all `count` settle.
+// settled image (progressive reveal), onDone once all `count` settle. These deliberately do NOT
+// releaseCanvasAfterUpload — two renderers upload them. See README (Texture memory budget).
 export function loadCardTextures({ count, getSrc, maxTexH }, onEach, onDone) {
   let loaded = 0;
   const textures = new Array(count);
@@ -250,5 +255,6 @@ export function createClickDragTexture(aspect, hintText = 'Click & Drag') {
 
   const tex = new THREE.CanvasTexture(canvas);
   tex.colorSpace = THREE.SRGBColorSpace;
+  releaseCanvasAfterUpload(tex, canvas); // sphere-only, single renderer — see README
   return tex;
 }

--- a/libs/mep/ace1209/globe-gallery/src/materials.js
+++ b/libs/mep/ace1209/globe-gallery/src/materials.js
@@ -39,13 +39,13 @@ export function createCardMaterial({
 }
 
 // Modal SDF material for the flown-out card. `aspect` is the card's world-space
-// width/height; uRadius is a fraction of card height (22/631).
+// width/height; uRadius is a fraction of card height, owned by modal.js (see README).
 export function createModalMaterial(texture, aspect) {
   return new THREE.ShaderMaterial({
     uniforms: {
       map: { value: texture },
       uAspect: { value: aspect },
-      uRadius: { value: 22.0 / 631.0 }, // modal.js sets to 0 on mobile (square, full-bleed)
+      uRadius: { value: 22.0 / 631.0 },
       uOpacity: { value: 1.0 },
       uMotionDir: { value: new THREE.Vector2(0, 0) },
       uWarp: { value: 0 },

--- a/libs/mep/ace1209/globe-gallery/src/math.js
+++ b/libs/mep/ace1209/globe-gallery/src/math.js
@@ -7,6 +7,21 @@ export function easeOutSine(t) { return Math.sin((t * Math.PI) / 2); }
 
 export function lerpN(a, b, t) { return a + (b - a) * t; }
 
+// Cover-fit crop (UV repeat + offset) that fills `planeAspect` with `imgAspect`, centre-cropping
+// the overflow; identity when they match. Caller owns `out`. See README (Architecture notes).
+export function coverFit(imgAspect, planeAspect, out = {}) {
+  out.rx = 1; out.ry = 1; out.ox = 0; out.oy = 0;
+  if (!(imgAspect > 0) || !(planeAspect > 0)) return out;
+  if (imgAspect > planeAspect) {
+    out.rx = planeAspect / imgAspect; // wider than the plane → crop left/right
+    out.ox = (1 - out.rx) / 2;
+  } else if (imgAspect < planeAspect) {
+    out.ry = imgAspect / planeAspect; // taller than the plane → crop top/bottom
+    out.oy = (1 - out.ry) / 2;
+  }
+  return out;
+}
+
 // Arc rotation ease: quadratic ramp over the first `k`, then linear (C1 at the seam).
 export function arcRotationEase(t) {
   const k = 0.08;

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -1,6 +1,6 @@
 import * as THREE from '../three.module.min.js';
 import { createModalMaterial } from './materials.js';
-import { easeInOutCubic, easeOutCubic } from './math.js';
+import { easeInOutCubic, easeOutCubic, coverFit } from './math.js';
 import { escapeHtml, renderParagraphs } from './authoring.js';
 /* eslint-disable import/no-relative-packages */
 import { processTrackingLabels } from '../../../../martech/attributes.js';
@@ -29,11 +29,8 @@ const MODAL_WARP_SWIPE = 0.25;
 // Desktop/tablet modal-nav cross-warp transition.
 const DN_NAV_DUR = 500; // ms
 const DN_NAV_WARP = 0.40; // peak warp
-// Desktop/tablet modal layout — see computeModalTarget / positionModalChrome.
+// Desktop/tablet image fit — see computeModalTarget. Chrome placement is CSS.
 const DT_IMG_MARGIN = 12; // gap between image and each viewport edge
-const DT_SCRIM_W = 316; // info scrim fixed width
-const DT_NAV_GAP = 12; // gap between counter pill and each arrow
-const DT_COUNTER_W = 138; // .globe-gallery-modal-counter fixed width (md+ CSS)
 
 export default function createGlobeModal({
   q,
@@ -84,11 +81,11 @@ export default function createGlobeModal({
   let modalCloseStartPos = null;
   let modalCloseStartQuat = null;
   let modalCloseStartScale = null;
-  let chromeProjV = null; // reusable Vector3 for chrome positioning projection
   const scratchPos = new THREE.Vector3();
   const scratchQuat = new THREE.Quaternion();
   const scratchScale = new THREE.Vector3();
-  let chromeNodes = null;
+  const coverScratch = {}; // coverFit output (see pushModalCoverUV)
+  let chromeNodes = null; // { chromeEl, els, settled } — see revealModalChrome
 
   // Chrome reveal — elements fade + slide in after card is 90% settled.
   let modalChromeRevealT0 = -1; // timestamp when card first hit 90%; -1 = not yet
@@ -132,6 +129,7 @@ export default function createGlobeModal({
   function resetChromeReveal() {
     modalChromeRevealT0 = -1;
     modalChromeFadeT = 0;
+    if (chromeNodes) chromeNodes.settled = false; // else the next reveal would early-out at once
   }
 
   function getModalIdx() { return modalIdx; }
@@ -141,17 +139,21 @@ export default function createGlobeModal({
   // Desktop/tablet plane fit + the uRadius fraction for a constant MODAL_RADIUS_PX. See README.
   function modalDesktopFit(uAspect) {
     const { W, H } = getViewport();
-    const R = MODAL_RADIUS_PX;
     const cardHPx = Math.min(
-      (H - 2 * DT_IMG_MARGIN) + 2 * R,
-      ((W - 2 * DT_IMG_MARGIN) + 2 * R) / uAspect,
+      H - 2 * DT_IMG_MARGIN,
+      (W - 2 * DT_IMG_MARGIN) / uAspect,
     );
-    return { cardHPx, radiusFrac: R / cardHPx };
+    return { cardHPx, radiusFrac: MODAL_RADIUS_PX / cardHPx };
   }
 
   function modalRadiusFrac(uAspect) {
     if (getBP() === 'sm') return 0;
     return modalDesktopFit(uAspect).radiusFrac;
+  }
+
+  // Aspect the modal renders at: the DISPLAYED texture's, else the base texture's. See README.
+  function modalUAspect(card) {
+    return (card && (card.modalAspect || card.srcAspect)) || cardAspect;
   }
 
   // Barrel = cards with a real sphere slot; indices ≥ this are overflow.
@@ -171,7 +173,7 @@ export default function createGlobeModal({
   }
 
   // Lazily build + cache a modal-only carrier for an index past the barrel.
-  // aspect (sphereScaleX) seeded to 1 until the image decodes (loadOverflowTexture).
+  // Aspect stays at the base card aspect until the image decodes (loadOverflowTexture).
   function createOverflowCard(idx) {
     const { w, h } = getCardDims();
     const mat = createModalMaterial(ensureOverflowPlaceholder(), cardAspect);
@@ -186,7 +188,6 @@ export default function createGlobeModal({
       modalMat: mat,
       isOverflow: true,
       idx,
-      sphereScaleX: 1,
       // Dummy sphere-phase fields so defensive reads don't hit undefined (never flies to a slot).
       sphereScaleSX: 1,
       sphereScaleSY: 1,
@@ -214,9 +215,8 @@ export default function createGlobeModal({
       card.ownTex = tex;
       card.modalMat.uniforms.map.value = tex;
       if (tex.image && tex.image.width && tex.image.height) {
-        const asp = tex.image.width / tex.image.height;
-        card.sphereScaleX = asp / cardAspect;
-        card.modalMat.uniforms.uAspect.value = asp; // = cardAspect × sphereScaleX
+        card.modalAspect = tex.image.width / tex.image.height;
+        card.modalMat.uniforms.uAspect.value = card.modalAspect;
       }
     }, () => { card.pendingImg = null; });
   }
@@ -229,6 +229,7 @@ export default function createGlobeModal({
     card.mesh.visible = false;
     card.modalMat.uniforms.map.value = ensureOverflowPlaceholder();
     if (card.ownTex) { card.ownTex.dispose(); card.ownTex = null; }
+    card.modalAspect = 0; // aspect belonged to the texture we just dropped
     // Reset animated uniforms (inlined to avoid a forward ref to resetModalMaterialUniforms).
     const u = card.modalMat.uniforms;
     u.uOpacity.value = 1;
@@ -257,6 +258,7 @@ export default function createGlobeModal({
           const baseMat = modalTexCard.mesh.origMaterial || modalTexCard.mesh.material;
           if (baseMat) modalTexCard.modalMat.uniforms.map.value = baseMat.map;
         }
+        modalTexCard.modalAspect = 0; // back to the base texture, so back to the barrel's aspect
       }
       modalTexOwned.dispose();
       modalTexOwned = null;
@@ -273,12 +275,13 @@ export default function createGlobeModal({
       return card.modalMat;
     }
     if (!card.modalMat) {
-      card.modalMat = createModalMaterial(card.mesh.material.map, card.sphereScaleX * cardAspect);
+      card.modalMat = createModalMaterial(card.mesh.material.map, modalUAspect(card));
     } else {
       // Reset to base in case a prior open left a since-disposed hi-res texture.
       card.modalMat.uniforms.map.value = card.mesh.material.map;
+      card.modalMat.uniforms.uAspect.value = modalUAspect(card);
     }
-    card.modalMat.uniforms.uRadius.value = modalRadiusFrac(card.sphereScaleX * cardAspect);
+    card.modalMat.uniforms.uRadius.value = modalRadiusFrac(modalUAspect(card));
     return card.modalMat;
   }
 
@@ -298,6 +301,9 @@ export default function createGlobeModal({
       modalTexOwned = tex;
       modalTexCard = card;
       card.modalMat.uniforms.map.value = tex;
+      if (tex.image && tex.image.width && tex.image.height) {
+        card.modalAspect = tex.image.width / tex.image.height;
+      }
     }, () => { modalTexImg = null; });
   }
 
@@ -308,7 +314,20 @@ export default function createGlobeModal({
     if (u.uOpacity) u.uOpacity.value = (typeof opacity === 'number' ? opacity : 1);
     if (u.uWarp) u.uWarp.value = 0;
     if (u.uMotionDir) u.uMotionDir.value.set(0, 0);
+    if (u.uRepeat) u.uRepeat.value.set(1, 1);
+    if (u.uOffset) u.uOffset.value.set(0, 0);
     // uWarpCenter intentionally NOT reset — callers set it right after.
+  }
+
+  // Crop the displayed texture to the aspect the plane is drawn at THIS frame (the core's
+  // applyCardFit rule). Call after the frame's scale write. See README (Architecture notes).
+  function pushModalCoverUV(card) {
+    const u = card && card.mesh.material && card.mesh.material.uniforms;
+    if (!u || !u.uRepeat) return;
+    const { x, y } = card.mesh.scale;
+    const c = coverFit(modalUAspect(card), cardAspect * (x / (y || 1)), coverScratch);
+    u.uRepeat.value.set(c.rx, c.ry);
+    u.uOffset.value.set(c.ox, c.oy);
   }
 
   // Map a viewport touch/click position to an approximate asset UV (screen Y inverts).
@@ -330,7 +349,7 @@ export default function createGlobeModal({
   }
 
   // Target world pos/quat/scale for the modal card: visible photo contain-fit to the viewport
-  // with native aspect kept (via sphereScaleX). Recomputed per-frame. See README (Behavior notes).
+  // with native aspect kept (via modalUAspect). Recomputed per-frame. See README (Behavior notes).
   function computeModalTarget(outPos, outQuat, outScale, cardOverride) {
     // cardOverride: compute for this card (swipe-neighbors); defaults to modalCard.
     const card = cardOverride || modalCard;
@@ -343,10 +362,10 @@ export default function createGlobeModal({
     // CSS pixels per world unit at 'dist' from the perspective camera (FOV 60°).
     const pxPerWorld = H / (2 * dist * Math.tan(Math.PI / 6));
 
-    // Width is proportional via sphereScaleX (aspect kept); branches below diverge mobile/desktop.
+    // Width is proportional to the image aspect (kept); the branches diverge mobile/desktop.
     const isMobile = (getBP() === 'sm');
-    const sScaleX = (card && card.sphereScaleX) ? card.sphereScaleX : 1;
-    const uAspect = cardAspect * sScaleX;
+    const uAspect = modalUAspect(card);
+    const sScaleX = uAspect / cardAspect;
     let scaleY; let
       scaleX;
 
@@ -367,138 +386,41 @@ export default function createGlobeModal({
       outPos.set(0, 0, camZ - dist);
     }
     // uRadius tracks the fit, so it is re-pushed every frame — see README (Behavior notes).
-    if (card && card.modalMat) card.modalMat.uniforms.uRadius.value = modalRadiusFrac(uAspect);
+    // uAspect rides along: it changes when the hi-res texture decodes mid-flight.
+    if (card && card.modalMat) {
+      card.modalMat.uniforms.uAspect.value = uAspect;
+      card.modalMat.uniforms.uRadius.value = modalRadiusFrac(uAspect);
+    }
     outQuat.identity();
     outScale.set(scaleX, scaleY, 1.0);
   }
 
-  // Project the modal card's screen bounds and lock chrome (close/info/nav) to it each frame.
-  function positionModalChrome() {
+  // Reveal fade only (opacity + an 8px slide-up), driven by modalChromeFadeT. Placement is pure
+  // CSS — every offset is a per-breakpoint constant. See README (Modal chrome).
+  function revealModalChrome() {
     const chromeEl = q('.globe-gallery-modal-chrome');
-    const camera = getCamera();
-    if (!chromeEl || !camera) return;
-    const { W } = getViewport();
-    const { w: CARD_W_SPHERE } = getCardDims();
+    if (!chromeEl) return;
     if (!chromeNodes || chromeNodes.chromeEl !== chromeEl) {
       chromeNodes = {
         chromeEl,
-        infoEl: chromeEl.querySelector('.globe-gallery-modal-info'),
-        closeEl: chromeEl.querySelector('.globe-gallery-modal-close'),
-        prevEl: chromeEl.querySelector('.globe-gallery-modal-nav-prev'),
-        nextEl: chromeEl.querySelector('.globe-gallery-modal-nav-next'),
-        counterEl: chromeEl.querySelector('.globe-gallery-modal-counter'),
+        els: [...chromeEl.querySelectorAll('.globe-gallery-modal-info, .globe-gallery-modal-close,'
+          + ' .globe-gallery-modal-nav, .globe-gallery-modal-counter')],
       };
     }
-    const { infoEl, closeEl, prevEl, nextEl, counterEl } = chromeNodes;
-
-    const tgtPos = scratchPos;
-    const tgtQuat = scratchQuat;
-    const tgtScale = scratchScale;
-    computeModalTarget(tgtPos, tgtQuat, tgtScale);
-
-    const halfW = CARD_W_SPHERE * tgtScale.x * 0.5;
-
-    if (!chromeProjV) chromeProjV = new THREE.Vector3();
-    const pv = chromeProjV;
-
-    // Project the card's horizontal edges to screen pixels (used to centre the desktop control row
-    // under the image). Vertical placement is intentionally NOT derived from the card — see below.
-    pv.set(tgtPos.x - halfW, tgtPos.y, tgtPos.z).project(camera);
-    const cardLeftPx = (pv.x + 1) * 0.5 * W;
-
-    pv.set(tgtPos.x + halfW, tgtPos.y, tgtPos.z).project(camera);
-    const cardRightPx = (pv.x + 1) * 0.5 * W;
-
-    // Clamp to visible viewport (card may bleed off edges at large scale).
-    const visLeft = Math.max(0, cardLeftPx);
-    const visRight = Math.min(W, cardRightPx);
-
-    const isMobile = (getBP() === 'sm');
-    const rtl = isRtl();
-
-    const EDGE = 'var(--gg-modal-edge)';
-
-    // Close button → top inline-end corner of the viewport, at the same inset as everything else.
-    if (closeEl) {
-      closeEl.style.position = 'absolute';
-      closeEl.style.top = EDGE;
-      closeEl.style.insetInlineEnd = EDGE;
-    }
-
-    // Nav arrows + counter positioned individually (no wrapper) so :hover scale survives the fade.
-    // Mobile → arrows bottom corners, counter bottom-center. Desktop → one row at the image bottom.
-    const NAV_SIZE = 48;
-    const counterBase = 'translateX(-50%)';
-    if (prevEl) prevEl.style.position = 'absolute';
-    if (nextEl) nextEl.style.position = 'absolute';
-    if (counterEl) counterEl.style.position = 'absolute';
-
-    const setBottomEdge = (elx, side) => {
-      elx.style[side] = EDGE; elx.style[side === 'left' ? 'right' : 'left'] = 'auto';
-      elx.style.top = 'auto'; elx.style.bottom = EDGE;
-    };
-    if (isMobile) {
-      if (prevEl) setBottomEdge(prevEl, rtl ? 'right' : 'left');
-      if (nextEl) setBottomEdge(nextEl, rtl ? 'left' : 'right');
-      if (counterEl) {
-        counterEl.style.left = '50%'; counterEl.style.right = 'auto';
-        counterEl.style.top = 'auto'; counterEl.style.bottom = EDGE;
-      }
-    } else {
-      const rowBottom = EDGE;
-      const centerX = (visLeft + visRight) / 2;
-      const flank = DT_COUNTER_W / 2 + DT_NAV_GAP; // pill edge → arrow's near edge
-      if (counterEl) {
-        counterEl.style.left = `${Math.round(centerX)}px`; counterEl.style.right = 'auto';
-        counterEl.style.top = 'auto'; counterEl.style.bottom = rowBottom;
-      }
-      const prevX = rtl ? centerX + flank : centerX - flank - NAV_SIZE;
-      const nextX = rtl ? centerX - flank - NAV_SIZE : centerX + flank;
-      if (prevEl) {
-        prevEl.style.left = `${Math.round(prevX)}px`; prevEl.style.right = 'auto';
-        prevEl.style.top = 'auto'; prevEl.style.bottom = rowBottom;
-      }
-      if (nextEl) {
-        nextEl.style.left = `${Math.round(nextX)}px`; nextEl.style.right = 'auto';
-        nextEl.style.top = 'auto'; nextEl.style.bottom = rowBottom;
-      }
-    }
-
-    // Info scrim: mobile = full-width bottom chunk; desktop = full-height left edge.
-    if (infoEl) {
-      infoEl.style.position = 'absolute';
-      if (isMobile) {
-        infoEl.style.top = 'auto';
-        infoEl.style.bottom = '0';
-        infoEl.style.left = '0';
-        infoEl.style.right = '0';
-        infoEl.style.width = 'auto';
-        infoEl.style.height = '';
-      } else {
-        infoEl.style.top = '0';
-        infoEl.style.bottom = '0';
-        infoEl.style.insetInlineStart = '0';
-        infoEl.style.width = `${DT_SCRIM_W}px`;
-        infoEl.style.height = '';
-      }
-    }
-
-    // Chrome fade + slide-up via modalChromeFadeT; transition:none so CSS hover doesn't fight JS.
-    const cFade = easeOutCubic(modalChromeFadeT);
-    const cShift = Math.round((1 - cFade) * 8);
+    // transition:none while animating so CSS hover can't fight the per-frame write; cleared on the
+    // settled frame so :hover animates again, then bail — nothing changes after.
     const settled = modalChromeFadeT >= 1;
-    const cTrans = settled ? '' : 'none';
-    const applyFade = (el, base) => {
-      if (!el) return;
+    if (settled && chromeNodes.settled) return;
+    chromeNodes.settled = settled;
+    const cFade = easeOutCubic(modalChromeFadeT);
+    const shift = settled ? '' : ` translateY(${Math.round((1 - cFade) * 8)}px)`;
+    chromeNodes.els.forEach((el) => {
       el.style.opacity = String(cFade);
-      el.style.transform = settled ? base : `${base} translateY(${cShift}px)`.trim();
-      el.style.transition = cTrans;
-    };
-    applyFade(infoEl, '');
-    applyFade(closeEl, '');
-    applyFade(prevEl, '');
-    applyFade(nextEl, '');
-    applyFade(counterEl, counterBase);
+      // The counter's CSS centring transform must survive the slide (it has no wrapper).
+      const base = el.classList.contains('globe-gallery-modal-counter') ? 'translateX(-50%)' : '';
+      el.style.transform = settled ? '' : `${base}${shift}`.trim();
+      el.style.transition = settled ? '' : 'none';
+    });
   }
 
   // Set the description's mask fade lengths from scroll position; focusable only when it scrolls.
@@ -626,6 +548,7 @@ export default function createGlobeModal({
     newCard.mesh.position.copy(tgtPos);
     newCard.mesh.quaternion.copy(tgtQuat);
     newCard.mesh.scale.copy(tgtScale);
+    pushModalCoverUV(newCard); // at its modal size already → identity
 
     // Lock old card warp center to (0.5, 0.5) so the bell curve emanates from center.
     if (oldCard.mesh.material && oldCard.mesh.material.uniforms
@@ -682,8 +605,10 @@ export default function createGlobeModal({
     modalCard.mesh.origMaterial = modalCard.mesh.material;
     modalCard.mesh.material = getModalMaterial(modalCard);
     requestModalUpgrade(modalCard, i);
-    // Reset cached SDF uniforms (stale mid-fade would ghost the image).
+    // Reset cached SDF uniforms (stale mid-fade would ghost the image); the crop then comes from
+    // the mesh's live scale — still the shape it had on the globe, mid-fold included.
     resetModalMaterialUniforms(modalCard.mesh.material, 1);
+    pushModalCoverUV(modalCard);
 
     // Reset depth test/order — modal scene has only this one mesh.
     modalCard.mesh.renderOrder = 0;
@@ -703,7 +628,7 @@ export default function createGlobeModal({
     if (chromeEl && !chromeEl.open) {
       try { chromeEl.showModal(); } catch (e) { /* already open / not connected; ignore */ }
     }
-    positionModalChrome();
+    revealModalChrome();
     requestAnimationFrame(() => {
       modalEl.classList.add('is-open');
       if (chromeEl) chromeEl.classList.add('is-open');
@@ -824,6 +749,8 @@ export default function createGlobeModal({
           modalCard.mesh.quaternion.copy(modalStartQuat).slerp(tgtQuat, aE);
           modalCard.mesh.scale.lerpVectors(modalStartScale, tgtScale, aE);
         }
+        // Crop tracks that scale; a nav cross-warp owns its own cards' uniforms.
+        if (!dnNavActive) pushModalCoverUV(modalCard);
 
         // Chrome reveal: start fade once card is 90% to target (skip at 1 — navigate snaps).
         if (modalChromeFadeT < 1) {
@@ -866,6 +793,7 @@ export default function createGlobeModal({
         modalCard.mesh.position.lerpVectors(modalCloseStartPos, tgtPos, aE);
         modalCard.mesh.quaternion.copy(modalCloseStartQuat).slerp(tgtQuat, aE);
         modalCard.mesh.scale.lerpVectors(modalCloseStartScale, tgtScale, aE);
+        pushModalCoverUV(modalCard); // closes back down to the slot's crop, tracking the scale
 
         if (aT >= 1) {
           // Reset cached SDF uniforms before restoring the basic material (else it ghosts later).
@@ -914,7 +842,7 @@ export default function createGlobeModal({
 
       // Keep chrome locked to the card's projected position each frame (OPENING sets fade target).
       if (modalPhase === MODAL_PHASE.OPENING || modalPhase === MODAL_PHASE.OPEN) {
-        positionModalChrome();
+        revealModalChrome();
       }
     }
   }

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -55,7 +55,7 @@ export default function createGlobeModal({
   // Sphere-rotation bridge (live THREE object shared by reference).
   sphereRotQuat,
   snapToSphereSlot,
-  // Applies the sphere's camera-facing tilt to a quat in place (no-op when CARD_FACE_CAMERA=0).
+  // Applies the sphere's camera-facing tilt to a quat in place (no-op when CARD_FACE_CAMERA is 0).
   applySphereFacing,
   requestNavNudge,
   applyMotionCA,
@@ -111,9 +111,8 @@ export default function createGlobeModal({
   let dnNavOldCard = null;
   let dnNavNewCard = null;
 
-  // Overflow gallery cards: the modal browses all getCount() images; indices past the barrel
-  // get a lazy modal-only carrier that dissolves in/out instead of flying to a slot.
-  // See README (Card count / Architecture notes). Keyed by gallery index.
+  // Cards past the barrel get a lazy modal-only carrier that dissolves in/out instead of flying
+  // to a slot. Keyed by gallery index. See README (Card count).
   const overflowCards = new Map();
   // Shared 1×1 placeholder for overflow carriers before/after their image texture.
   let overflowPlaceholderTex = null;
@@ -955,9 +954,8 @@ export default function createGlobeModal({
     const PULL_SCALE_DAMPING = 1600; // larger → less scale change per px pulled
     const PULL_SCALE_MIN = 0.80;
 
-    // Swipe/pull applies to touch-primary devices, not just the sm width band — tablets at
-    // md (≥768, coarse pointer) get the same gesture nav the globe's yaw-only shape assumes.
-    // Mirrors usesCylinderGeometry's '(pointer: coarse)' check. matchMedia-less → no gestures.
+    // Gestures follow POINTER type, not the width band (tablets at md get them too), mirroring
+    // usesCylinderGeometry. matchMedia-less → none.
     const isTouchPrimary = () => !!window.matchMedia?.('(pointer: coarse)').matches;
 
     // Attach to the dialog (evtRoot), not modalEl — modalEl goes inert under showModal().
@@ -1029,9 +1027,8 @@ export default function createGlobeModal({
       if (swAxis === 'x') {
         const commit = Math.abs(dx) > window.innerWidth * COMMIT_DIST_X_FRAC
                   || Math.abs(swVelX) > COMMIT_VEL_X;
-        // swipe left → next (+1), swipe right → prev (−1). Commit clicks the matching nav
-        // button — same handler, plus it reports (see README, Analytics); a non-commit release
-        // lets the preview warp decay back to 0 in updateAnimation. No canvas slide either way.
+        // Commit clicks the matching nav button (same handler, and it reports);
+        // a non-commit release lets the preview warp decay in updateAnimation.
         if (commit) {
           // Clear the preview warp so it doesn't bleed onto the new card once the transition
           // ends and updateAnimation resumes pushing modalWarp — the cross-warp owns warp now.
@@ -1077,9 +1074,8 @@ export default function createGlobeModal({
     }, { passive: true });
   }
 
-  // Synchronously return the modal DOM + page state to closed. destroy() forces phase to CLOSED
-  // without the close animation, so a breakpoint re-init (same DOM) doesn't leave the modal stuck
-  // open. Uses q() for the main canvas because core destroy() nulls the renderer first.
+  // Synchronously return the modal DOM + page state to closed, so a breakpoint re-init on the
+  // same DOM can't leave it stuck open. q() because core destroy() nulls the renderer first.
   function resetModalDom() {
     if (modalEl) {
       modalEl.classList.remove('is-visible', 'is-open');

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -1,7 +1,7 @@
 import * as THREE from '../three.module.min.js';
 import { createModalMaterial } from './materials.js';
 import { easeInOutCubic, easeOutCubic } from './math.js';
-import { escapeHtml } from './authoring.js';
+import { escapeHtml, renderParagraphs } from './authoring.js';
 /* eslint-disable import/no-relative-packages */
 import { processTrackingLabels } from '../../../../martech/attributes.js';
 import { getConfig } from '../../../../utils/utils.js';
@@ -525,7 +525,7 @@ export default function createGlobeModal({
     const roleLabelEl = targetEl.querySelector('.globe-gallery-modal-role-label');
     if (roleLabelEl) roleLabelEl.textContent = meta.role;
     targetEl.querySelector('.globe-gallery-modal-name').textContent = meta.name;
-    targetEl.querySelector('.globe-gallery-modal-description').textContent = meta.description;
+    renderParagraphs(targetEl.querySelector('.globe-gallery-modal-description'), meta.description);
     const counterEl = targetEl.querySelector('.globe-gallery-modal-counter');
     if (counterEl) {
       const pad = (n) => (String(n).length < 2 ? `0${n}` : String(n));

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -548,11 +548,12 @@ export default function createGlobeModal({
     if (posEl) posEl.textContent = cardLabel(i + 1, getCount());
     const badgesEl = targetEl.querySelector('.globe-gallery-modal-badges');
     badgesEl.innerHTML = '';
+    const config = getConfig();
     meta.badges.forEach((b) => {
       const row = document.createElement('li');
       row.className = 'globe-gallery-modal-badge';
       // Labelled by product, not by card, and unindexed. See README (Analytics).
-      const daall = `${processTrackingLabels(b.name, getConfig(), 20)}--globe_card_modal`;
+      const daall = `${processTrackingLabels(b.name, config, 20)}--globe_card_modal`;
       const nameHtml = b.href
         ? `<a class="globe-gallery-modal-badge-app globe-gallery-modal-badge-app-link" href="${escapeHtml(b.href)}" daa-ll="${escapeHtml(daall)}">${escapeHtml(b.name)}</a>`
         : `<span class="globe-gallery-modal-badge-app">${escapeHtml(b.name)}</span>`;

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -18,8 +18,7 @@ const MODAL_PHASE = Object.freeze({
 });
 // Camera→card distance the modal card flies to (perspective FOV 60°).
 const MODAL_CAM_DIST = 16.4;
-// SDF corner radius: 22px on the 631px-tall source; materials.js mirrors it.
-const SDF_CORNER_RADIUS = 22 / 631;
+const MODAL_RADIUS_PX = 16; // on-screen modal corner radius at md+ (0 on mobile); see README
 const MODAL_ANIM_DURATION = 350; // ms open/close fly time
 const CHROME_REVEAL_DUR = 300; // ms chrome fade-in after card 90% settled
 // Fisheye warp peaks (sin bell curve) per modal interaction.
@@ -139,6 +138,22 @@ export default function createGlobeModal({
 
   const isRtl = () => document.documentElement.dir === 'rtl';
 
+  // Desktop/tablet plane fit + the uRadius fraction for a constant MODAL_RADIUS_PX. See README.
+  function modalDesktopFit(uAspect) {
+    const { W, H } = getViewport();
+    const R = MODAL_RADIUS_PX;
+    const cardHPx = Math.min(
+      (H - 2 * DT_IMG_MARGIN) + 2 * R,
+      ((W - 2 * DT_IMG_MARGIN) + 2 * R) / uAspect,
+    );
+    return { cardHPx, radiusFrac: R / cardHPx };
+  }
+
+  function modalRadiusFrac(uAspect) {
+    if (getBP() === 'sm') return 0;
+    return modalDesktopFit(uAspect).radiusFrac;
+  }
+
   // Barrel = cards with a real sphere slot; indices ≥ this are overflow.
   function barrelCount() { return getCards().length; }
   function isOverflowIdx(idx) { return idx >= barrelCount(); }
@@ -160,7 +175,7 @@ export default function createGlobeModal({
   function createOverflowCard(idx) {
     const { w, h } = getCardDims();
     const mat = createModalMaterial(ensureOverflowPlaceholder(), cardAspect);
-    mat.uniforms.uRadius.value = getBP() === 'sm' ? 0 : SDF_CORNER_RADIUS;
+    mat.uniforms.uRadius.value = modalRadiusFrac(cardAspect);
     const geo = new THREE.PlaneGeometry(w, h, 1, 1);
     const mesh = new THREE.Mesh(geo, mat);
     mesh.material.depthTest = true;
@@ -253,7 +268,8 @@ export default function createGlobeModal({
   function getModalMaterial(card) {
     // Overflow carriers ARE the modal material — just refresh the corner radius.
     if (card.isOverflow) {
-      card.modalMat.uniforms.uRadius.value = getBP() === 'sm' ? 0 : SDF_CORNER_RADIUS;
+      const u = card.modalMat.uniforms;
+      u.uRadius.value = modalRadiusFrac(u.uAspect.value);
       return card.modalMat;
     }
     if (!card.modalMat) {
@@ -262,8 +278,7 @@ export default function createGlobeModal({
       // Reset to base in case a prior open left a since-disposed hi-res texture.
       card.modalMat.uniforms.map.value = card.mesh.material.map;
     }
-    // Mobile: no corner radius; set each call so a breakpoint change is honored.
-    card.modalMat.uniforms.uRadius.value = getBP() === 'sm' ? 0 : SDF_CORNER_RADIUS;
+    card.modalMat.uniforms.uRadius.value = modalRadiusFrac(card.sphereScaleX * cardAspect);
     return card.modalMat;
   }
 
@@ -331,32 +346,28 @@ export default function createGlobeModal({
     // Width is proportional via sphereScaleX (aspect kept); branches below diverge mobile/desktop.
     const isMobile = (getBP() === 'sm');
     const sScaleX = (card && card.sphereScaleX) ? card.sphereScaleX : 1;
+    const uAspect = cardAspect * sScaleX;
     let scaleY; let
       scaleX;
 
     if (isMobile) {
       // Mobile: full-bleed width, top-aligned, square corners; height follows aspect.
-      const uAspect = cardAspect * sScaleX;
       const cardHPx = W / uAspect;
       scaleX = W / (CARD_W_SPHERE * pxPerWorld);
       scaleY = scaleX / sScaleX;
       outPos.set(0, (H / 2 - cardHPx / 2) / pxPerWorld, camZ - dist);
     } else {
       // Desktop/tablet: visible photo contain-fit to the viewport minus DT_IMG_MARGIN, aspect
-      // kept. Geometry is backed out of the SDF corner inset (uRadius·cardHPx on all four sides)
-      // so the visible photo — not the geometry — reaches the margin. See README (Behavior notes).
-      const uAspect = cardAspect * sScaleX;
-      const SDF_RADIUS = SDF_CORNER_RADIUS;
-      const cardHPxFillH = (H - 2 * DT_IMG_MARGIN) / (1 - 2 * SDF_RADIUS);
-      const cardHPxFillW = (W - 2 * DT_IMG_MARGIN) / (uAspect - 2 * SDF_RADIUS);
-      const cardHPx = Math.min(cardHPxFillH, cardHPxFillW);
-
+      // kept — see README (Behavior notes).
+      const { cardHPx } = modalDesktopFit(uAspect);
       scaleY = cardHPx / (CARD_H_SPHERE * pxPerWorld);
       scaleX = scaleY * sScaleX;
 
       // Centered at viewport center.
       outPos.set(0, 0, camZ - dist);
     }
+    // uRadius tracks the fit, so it is re-pushed every frame — see README (Behavior notes).
+    if (card && card.modalMat) card.modalMat.uniforms.uRadius.value = modalRadiusFrac(uAspect);
     outQuat.identity();
     outScale.set(scaleX, scaleY, 1.0);
   }
@@ -405,37 +416,36 @@ export default function createGlobeModal({
     const isMobile = (getBP() === 'sm');
     const rtl = isRtl();
 
-    // Uniform chrome inset from the viewport edges; matches the .globe-gallery-modal-info padding.
-    const EDGE = isMobile ? 16 : 24;
+    const EDGE = 'var(--gg-modal-edge)';
 
     // Close button → top inline-end corner of the viewport, at the same inset as everything else.
     if (closeEl) {
       closeEl.style.position = 'absolute';
-      closeEl.style.top = `${EDGE}px`;
-      closeEl.style.insetInlineEnd = `${EDGE}px`;
+      closeEl.style.top = EDGE;
+      closeEl.style.insetInlineEnd = EDGE;
     }
 
     // Nav arrows + counter positioned individually (no wrapper) so :hover scale survives the fade.
     // Mobile → arrows bottom corners, counter bottom-center. Desktop → one row at the image bottom.
-    const NAV_SIZE = 44; // matches the .globe-gallery-modal-nav width/height in CSS
+    const NAV_SIZE = 48;
     const counterBase = 'translateX(-50%)';
     if (prevEl) prevEl.style.position = 'absolute';
     if (nextEl) nextEl.style.position = 'absolute';
     if (counterEl) counterEl.style.position = 'absolute';
 
     const setBottomEdge = (elx, side) => {
-      elx.style[side] = `${EDGE}px`; elx.style[side === 'left' ? 'right' : 'left'] = 'auto';
-      elx.style.top = 'auto'; elx.style.bottom = `${EDGE}px`;
+      elx.style[side] = EDGE; elx.style[side === 'left' ? 'right' : 'left'] = 'auto';
+      elx.style.top = 'auto'; elx.style.bottom = EDGE;
     };
     if (isMobile) {
       if (prevEl) setBottomEdge(prevEl, rtl ? 'right' : 'left');
       if (nextEl) setBottomEdge(nextEl, rtl ? 'left' : 'right');
       if (counterEl) {
         counterEl.style.left = '50%'; counterEl.style.right = 'auto';
-        counterEl.style.top = 'auto'; counterEl.style.bottom = `${EDGE}px`;
+        counterEl.style.top = 'auto'; counterEl.style.bottom = EDGE;
       }
     } else {
-      const rowBottom = `${EDGE}px`;
+      const rowBottom = EDGE;
       const centerX = (visLeft + visRight) / 2;
       const flank = DT_COUNTER_W / 2 + DT_NAV_GAP; // pill edge → arrow's near edge
       if (counterEl) {
@@ -498,8 +508,8 @@ export default function createGlobeModal({
     const canScroll = overflow > 1;
     const top = canScroll && descEl.scrollTop > 1;
     const bottom = canScroll && descEl.scrollTop < overflow - 1;
-    descEl.style.setProperty('--desc-fade-top', top ? '20px' : '0');
-    descEl.style.setProperty('--desc-fade-bottom', bottom ? '20px' : '0');
+    descEl.style.setProperty('--gg-desc-fade-top', top ? '20px' : '0');
+    descEl.style.setProperty('--gg-desc-fade-bottom', bottom ? '20px' : '0');
     if (canScroll) descEl.tabIndex = 0;
     else if (document.activeElement !== descEl) descEl.removeAttribute('tabindex');
   }

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -405,17 +405,19 @@ export default function createGlobeModal({
     const isMobile = (getBP() === 'sm');
     const rtl = isRtl();
 
-    // Close button → top inline-end corner of the viewport (24px inset) at every breakpoint.
+    // Uniform chrome inset from the viewport edges; matches the .globe-gallery-modal-info padding.
+    const EDGE = isMobile ? 16 : 24;
+
+    // Close button → top inline-end corner of the viewport, at the same inset as everything else.
     if (closeEl) {
       closeEl.style.position = 'absolute';
-      closeEl.style.top = '24px';
-      closeEl.style.insetInlineEnd = '24px';
+      closeEl.style.top = `${EDGE}px`;
+      closeEl.style.insetInlineEnd = `${EDGE}px`;
     }
 
     // Nav arrows + counter positioned individually (no wrapper) so :hover scale survives the fade.
     // Mobile → arrows bottom corners, counter bottom-center. Desktop → one row at the image bottom.
     const NAV_SIZE = 44; // matches the .globe-gallery-modal-nav width/height in CSS
-    const EDGE = 24;
     const counterBase = 'translateX(-50%)';
     if (prevEl) prevEl.style.position = 'absolute';
     if (nextEl) nextEl.style.position = 'absolute';

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -2,6 +2,10 @@ import * as THREE from '../three.module.min.js';
 import { createModalMaterial } from './materials.js';
 import { easeInOutCubic, easeOutCubic } from './math.js';
 import { escapeHtml } from './authoring.js';
+/* eslint-disable import/no-relative-packages */
+import { processTrackingLabels } from '../../../../martech/attributes.js';
+import { getConfig } from '../../../../utils/utils.js';
+/* eslint-enable import/no-relative-packages */
 
 const perfNow = () => performance?.now() ?? Date.now();
 
@@ -97,6 +101,11 @@ export default function createGlobeModal({
   let closeTimeoutId = null;
   // click/touch listeners wired once — DOM persists across re-inits so re-adding would stack.
   let listenersWired = false;
+  // Held so Escape + the touch gestures can click them rather than call navigate()/close().
+  // See README (Analytics).
+  let prevBtn = null;
+  let nextBtn = null;
+  let closeBtn = null;
 
   let modalWarp = 0;
   const modalWarpCenter = new THREE.Vector2(0.5, 0.5);
@@ -530,8 +539,10 @@ export default function createGlobeModal({
     meta.badges.forEach((b) => {
       const row = document.createElement('li');
       row.className = 'globe-gallery-modal-badge';
+      // Labelled by product, not by card, and unindexed. See README (Analytics).
+      const daall = `${processTrackingLabels(b.name, getConfig(), 20)}--globe_card_modal`;
       const nameHtml = b.href
-        ? `<a class="globe-gallery-modal-badge-app globe-gallery-modal-badge-app-link" href="${escapeHtml(b.href)}">${escapeHtml(b.name)}</a>`
+        ? `<a class="globe-gallery-modal-badge-app globe-gallery-modal-badge-app-link" href="${escapeHtml(b.href)}" daa-ll="${escapeHtml(daall)}">${escapeHtml(b.name)}</a>`
         : `<span class="globe-gallery-modal-badge-app">${escapeHtml(b.name)}</span>`;
       // The logo is authored per row; rows without one just render the name (no empty chip).
       row.innerHTML = `<div class="globe-gallery-modal-badge-left">${b.icon || ''}${nameHtml}</div><span class="globe-gallery-modal-badge-role">${escapeHtml(b.role)}</span>`;
@@ -753,6 +764,11 @@ export default function createGlobeModal({
     if (canvas) canvas.classList.remove('is-modal-active');
   }
 
+  // Close via the button so Escape / pull-to-close report it. See README (Analytics).
+  function clickClose() {
+    if (closeBtn) closeBtn.click(); else close();
+  }
+
   function navigate(direction) {
     if (modalIdx < 0 || !modalCard) return;
     // Don't navigate while closing, or startDesktopNavTransition would flip CLOSING→OPEN and orphan
@@ -959,9 +975,12 @@ export default function createGlobeModal({
     const alreadyWired = listenersWired;
     listenersWired = true;
     if (!alreadyWired) {
-      evtRoot.querySelector('.globe-gallery-modal-close').addEventListener('click', () => close(true));
-      const prevBtn = evtRoot.querySelector('.globe-gallery-modal-nav-prev');
-      const nextBtn = evtRoot.querySelector('.globe-gallery-modal-nav-next');
+      closeBtn = evtRoot.querySelector('.globe-gallery-modal-close');
+      // isTrusted is exactly viaPointer: the guard exists to swallow the browser's synthetic
+      // click after a touch pointerup (trusted); ours from clickClose() are not.
+      closeBtn.addEventListener('click', (e) => close(e.isTrusted));
+      prevBtn = evtRoot.querySelector('.globe-gallery-modal-nav-prev');
+      nextBtn = evtRoot.querySelector('.globe-gallery-modal-nav-next');
       prevBtn.addEventListener('click', () => { navigate(-1); });
       nextBtn.addEventListener('click', () => { navigate(1); });
       // Single-card gallery: nav is a no-op, so hide the arrows entirely (count is fixed).
@@ -970,7 +989,7 @@ export default function createGlobeModal({
       if (descEl) descEl.addEventListener('scroll', () => updateDescFade(descEl), { passive: true });
       // Escape → dialog 'cancel'; preventDefault to play the close animation, not instant close.
       if (chromeEl) {
-        chromeEl.addEventListener('cancel', (e) => { e.preventDefault(); close(); });
+        chromeEl.addEventListener('cancel', (e) => { e.preventDefault(); clickClose(); });
       }
     }
 
@@ -1069,20 +1088,23 @@ export default function createGlobeModal({
       if (swAxis === 'x') {
         const commit = Math.abs(dx) > window.innerWidth * COMMIT_DIST_X_FRAC
                   || Math.abs(swVelX) > COMMIT_VEL_X;
-        // swipe left → next (+1), swipe right → prev (−1). Commit fires the same cross-warp
-        // transition as the nav buttons; a non-commit release lets the preview warp decay
-        // back to 0 in updateAnimation. No canvas slide to reset either way.
+        // swipe left → next (+1), swipe right → prev (−1). Commit clicks the matching nav
+        // button — same handler, plus it reports (see README, Analytics); a non-commit release
+        // lets the preview warp decay back to 0 in updateAnimation. No canvas slide either way.
         if (commit) {
           // Clear the preview warp so it doesn't bleed onto the new card once the transition
           // ends and updateAnimation resumes pushing modalWarp — the cross-warp owns warp now.
           modalWarp = 0;
-          navigate((dx < 0 ? 1 : -1) * (isRtl() ? -1 : 1));
+          const dir = (dx < 0 ? 1 : -1) * (isRtl() ? -1 : 1);
+          const btn = dir < 0 ? prevBtn : nextBtn;
+          // hidden on a single-card gallery — clicking would report a no-op nav.
+          if (btn?.hidden === false) btn.click(); else navigate(dir);
         }
       } else {
         const pullCommit = dy > window.innerHeight * COMMIT_DIST_Y_FRAC
                       || swVelY > COMMIT_VEL_Y;
         if (pullCommit) {
-          // Sync the mesh world pos+scale to the gesture's visible state, reset CSS, then close() —
+          // Sync the mesh world pos+scale to the gesture's visible state, reset CSS, then close —
           // so the fly-back starts from where the user dragged, not center. No snap.
           if (modalCard) {
             const { H: vpH } = getViewport();
@@ -1094,7 +1116,7 @@ export default function createGlobeModal({
           }
           modalCanvasEl.style.transition = 'none';
           modalCanvasEl.style.transform = '';
-          close();
+          clickClose();
         } else {
           // Rubber-band back.
           modalCanvasEl.style.transition = 'transform 0.25s cubic-bezier(0.25, 0.1, 0.25, 1)';

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -422,15 +422,15 @@ export default function createGlobeModal({
     });
   }
 
-  // Set the description's mask fade lengths from scroll position; focusable only when it scrolls.
+  // Flag which description edges have more copy; focusable only when it scrolls.
   function updateDescFade(descEl) {
     if (!descEl) return;
     const overflow = descEl.scrollHeight - descEl.clientHeight;
     const canScroll = overflow > 1;
     const top = canScroll && descEl.scrollTop > 1;
     const bottom = canScroll && descEl.scrollTop < overflow - 1;
-    descEl.style.setProperty('--gg-desc-fade-top', top ? '20px' : '0');
-    descEl.style.setProperty('--gg-desc-fade-bottom', bottom ? '20px' : '0');
+    descEl.classList.toggle('is-faded-top', top);
+    descEl.classList.toggle('is-faded-bottom', bottom);
     if (canScroll) descEl.tabIndex = 0;
     else if (document.activeElement !== descEl) descEl.removeAttribute('tabindex');
   }

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -62,6 +62,7 @@ export default function createGlobeModal({
   restoreFocusOnClose,
 }) {
   let modalRenderer = null;
+  let appliedModalDpr = 0;
   let modalScene = null;
   let modalCanvasEl = null;
   let modalEl = null;
@@ -879,7 +880,11 @@ export default function createGlobeModal({
   // Re-size the modal renderer to match the viewport (called from core doLayout).
   function resize(w, h) {
     if (!modalRenderer) return;
-    modalRenderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    const dpr = Math.min(window.devicePixelRatio, 2);
+    if (dpr !== appliedModalDpr) {
+      appliedModalDpr = dpr;
+      modalRenderer.setPixelRatio(dpr);
+    }
     modalRenderer.setSize(w, h);
     // Resize can change whether the description overflows — re-measure the fade cue.
     if (modalIdx >= 0) scheduleDescFade();
@@ -894,7 +899,8 @@ export default function createGlobeModal({
     if (modalCanvasEl) {
       const modalGlOpts = { canvas: modalCanvasEl, antialias: getAntialias(), alpha: true };
       modalRenderer = new THREE.WebGLRenderer(modalGlOpts);
-      modalRenderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      appliedModalDpr = Math.min(window.devicePixelRatio, 2);
+      modalRenderer.setPixelRatio(appliedModalDpr);
       modalRenderer.setSize(W, H);
       modalRenderer.setClearColor(0x000000, 0);
       modalScene = new THREE.Scene();
@@ -1001,17 +1007,18 @@ export default function createGlobeModal({
       }
       swLastX = x; swLastY = y; swLastT = now;
 
+      const { W: vpW, H: vpH } = getViewport();
       if (swAxis === 'x') {
         // Warp-only preview (no slide): the fisheye grows with drag, capped at MODAL_WARP_SWIPE.
         // Release commits the same cross-warp transition as the nav buttons.
-        modalWarp = Math.min(1, Math.abs(dx) / (window.innerWidth * 0.30)) * MODAL_WARP_SWIPE;
+        modalWarp = Math.min(1, Math.abs(dx) / (vpW * 0.30)) * MODAL_WARP_SWIPE;
       } else {
         // Pull-down only — upward drag does nothing (clamped to 0).
         const pullY = Math.max(0, dy);
         const scale = Math.max(PULL_SCALE_MIN, 1 - pullY / PULL_SCALE_DAMPING);
         modalCanvasEl.style.transform = `translate3d(0, ${pullY}px, 0) scale(${scale.toFixed(3)})`;
         // Pull-down warp: scales with pull / 20% viewport height, capped at MODAL_WARP_PULL.
-        modalWarp = Math.min(1, pullY / (window.innerHeight * 0.20)) * MODAL_WARP_PULL;
+        modalWarp = Math.min(1, pullY / (vpH * 0.20)) * MODAL_WARP_PULL;
       }
       pushModalWarpUniforms();
     }, { passive: true });
@@ -1023,9 +1030,10 @@ export default function createGlobeModal({
       if (e.changedTouches.length !== 1) return;
       const dx = e.changedTouches[0].clientX - swStartX;
       const dy = e.changedTouches[0].clientY - swStartY;
+      const { W: vpW, H: vpH } = getViewport();
 
       if (swAxis === 'x') {
-        const commit = Math.abs(dx) > window.innerWidth * COMMIT_DIST_X_FRAC
+        const commit = Math.abs(dx) > vpW * COMMIT_DIST_X_FRAC
                   || Math.abs(swVelX) > COMMIT_VEL_X;
         // Commit clicks the matching nav button (same handler, and it reports);
         // a non-commit release lets the preview warp decay in updateAnimation.
@@ -1039,13 +1047,12 @@ export default function createGlobeModal({
           if (btn?.hidden === false) btn.click(); else navigate(dir);
         }
       } else {
-        const pullCommit = dy > window.innerHeight * COMMIT_DIST_Y_FRAC
+        const pullCommit = dy > vpH * COMMIT_DIST_Y_FRAC
                       || swVelY > COMMIT_VEL_Y;
         if (pullCommit) {
           // Sync the mesh world pos+scale to the gesture's visible state, reset CSS, then close —
           // so the fly-back starts from where the user dragged, not center. No snap.
           if (modalCard) {
-            const { H: vpH } = getViewport();
             const pxPerWorld = vpH / (2 * MODAL_CAM_DIST * Math.tan(Math.PI / 6));
             const pulledY = Math.max(0, dy);
             const gestureScale = Math.max(PULL_SCALE_MIN, 1 - pulledY / PULL_SCALE_DAMPING);

--- a/libs/mep/ace1209/globe-gallery/src/shaders.js
+++ b/libs/mep/ace1209/globe-gallery/src/shaders.js
@@ -1,3 +1,20 @@
+// Signed-distance rounded rect (the corner mask). `b` is the FULL half-extent, radius included.
+const RR_SDF = [
+  'float rrSDF(vec2 p, vec2 b, float r) {',
+  '  vec2 q = abs(p) - b + r;',
+  '  return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - r;',
+  '}',
+];
+
+// Hash for the particle dissolves; inputs scaled first to dodge precision loss at large coords.
+const HASH21 = [
+  'float hash21(vec2 p) {',
+  '  p = fract(p * vec2(0.1031, 0.1030));',
+  '  p += dot(p, p + 33.33);',
+  '  return fract((p.x + p.y) * p.x);',
+  '}',
+];
+
 // Modal SDF shader material — rounded rect computed in the fragment shader (sharp
 // at any zoom). uAspect = card world-space width/height; uRadius = fraction of height.
 export const MODAL_VERT = [
@@ -16,15 +33,15 @@ export const MODAL_FRAG = [
   'uniform vec2 uMotionDir;', // card velocity in UV space — drives motion-trail CA; (0,0) = off
   'uniform float uWarp;', // fisheye intensity (0 = none, ~0.4 = strong bulge); used in open/close/drag
   'uniform vec2 uWarpCenter;', // UV anchor for fisheye (0.5, 0.5 default; touch UV during drag)
+  'uniform vec2 uRepeat;', // cover-crop carried from the barrel; eases to (1,1) over the fly-out
+  'uniform vec2 uOffset;',
   'varying vec2 vUv;',
-  'float rrSDF(vec2 p, vec2 b, float r) {',
-  '  vec2 q = abs(p) - b + r;',
-  '  return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - r;',
-  '}',
+  ...RR_SDF,
   'void main() {',
-  // SDF rounded-rect clip uses raw vUv so the card's geometry outline doesn't warp.
+  // Raw vUv so the card outline doesn't warp; half-extents are the FULL plane (as CARD_FRAG) —
+  // an inset box would clip uRadius of photo off every edge. See README (Image fit).
   '  vec2 pos = (vUv - 0.5) * vec2(uAspect, 1.0);',
-  '  float d = rrSDF(pos, vec2(uAspect * 0.5 - uRadius, 0.5 - uRadius), uRadius);',
+  '  float d = rrSDF(pos, vec2(uAspect * 0.5, 0.5), uRadius);',
   '  float px = fwidth(pos.y);',
   '  float alpha = 1.0 - smoothstep(-px, px, d);',
   // Flip uv.x + warp anchor on back faces so the back reads like the front (matches CARD_FRAG).
@@ -34,10 +51,12 @@ export const MODAL_FRAG = [
   '  vec2 d2 = fUv - wc;',
   '  float r2 = dot(d2, d2);',
   '  vec2 warpedUv = d2 / (1.0 + uWarp * r2 * 4.0) + wc;',
+  // Cover-crop (identity once the card has settled at its native-aspect modal size).
+  '  vec2 baseUv = warpedUv * uRepeat + uOffset;',
   // Motion-trail CA: R trails behind, B ghosts ahead.
-  '  float r = texture2D(map, warpedUv - uMotionDir).r;',
-  '  float g = texture2D(map, warpedUv).g;',
-  '  float b = texture2D(map, warpedUv + uMotionDir * 0.5).b;',
+  '  float r = texture2D(map, baseUv - uMotionDir).r;',
+  '  float g = texture2D(map, baseUv).g;',
+  '  float b = texture2D(map, baseUv + uMotionDir * 0.5).b;',
   // Re-encode linear→sRGB.
   '  vec3 srgb = pow(max(vec3(r, g, b), 0.0), vec3(1.0 / 2.2));',
   '  gl_FragColor = vec4(srgb, alpha * uOpacity);',
@@ -69,16 +88,8 @@ export const CARD_FRAG = [
   'uniform float uReveal;', // texture-ready reveal: 0 = contour only, 1 = full photo
   'uniform float uContourFade;', // near-camera gate for the contour (mirrors proxFade)
   'varying vec2 vUv;',
-  'float rrSDF(vec2 p, vec2 b, float r) {',
-  '  vec2 q = abs(p) - b + r;',
-  '  return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - r;',
-  '}',
-  // Hash — scale inputs first to avoid sin() precision issues at large pixel coords.
-  'float hash21(vec2 p) {',
-  '  p = fract(p * vec2(0.1031, 0.1030));',
-  '  p += dot(p, p + 33.33);',
-  '  return fract((p.x + p.y) * p.x);',
-  '}',
+  ...RR_SDF,
+  ...HASH21,
   'void main() {',
   // Flip uv.x on back faces so the back reads like the front.
   '  vec2 fUv = gl_FrontFacing ? vUv : vec2(1.0 - vUv.x, vUv.y);',
@@ -148,12 +159,7 @@ export const TEXT_FRAG = [
   'uniform vec2  uResolution;',
   'uniform vec2  uMotionDir;',
   'varying vec2  vUv;',
-  // Hash — scale inputs first to avoid sin() precision issues at large pixel coords
-  'float hash21(vec2 p) {',
-  '  p = fract(p * vec2(0.1031, 0.1030));',
-  '  p += dot(p, p + 33.33);',
-  '  return fract((p.x + p.y) * p.x);',
-  '}',
+  ...HASH21,
   'void main() {',
   '  vec2 d = vUv - 0.5;',
   // Exit: horizontal stretch (mimics drag direction) + radial scatter (letters fly outward)

--- a/libs/mep/ace1209/globe-gallery/src/shaders.js
+++ b/libs/mep/ace1209/globe-gallery/src/shaders.js
@@ -73,10 +73,8 @@ export const CARD_VERT = [
   '}',
 ].join('\n');
 
-// Near-camera dispersion (the card explodes into flying grains). Every piece of this — the two
-// dials, the ramp exponent, the vertex overscan, and why the fragment reads each grain's origin —
-// is documented in the README (Near-camera dissolve EXPLODES past the card box). Read it before
-// touching any of it.
+// Near-camera dispersion. Read README (Near-camera dissolve EXPLODES past the card box)
+// before touching any of it — the dials, ramp, overscan and grain-origin read are all coupled.
 const DISPERSE_EXPAND = '2.00';
 const DISPERSE_JITTER = '0.15';
 const DISPERSE_RAMP = [

--- a/libs/mep/ace1209/globe-gallery/src/shaders.js
+++ b/libs/mep/ace1209/globe-gallery/src/shaders.js
@@ -73,6 +73,35 @@ export const CARD_VERT = [
   '}',
 ].join('\n');
 
+// Near-camera dispersion (the card explodes into flying grains). Every piece of this — the two
+// dials, the ramp exponent, the vertex overscan, and why the fragment reads each grain's origin —
+// is documented in the README (Near-camera dissolve EXPLODES past the card box). Read it before
+// touching any of it.
+const DISPERSE_EXPAND = '2.00';
+const DISPERSE_JITTER = '0.15';
+const DISPERSE_RAMP = [
+  'float dispRamp(float x) {',
+  '  return pow(clamp(x, 0.0, 1.0), 0.9);',
+  '}',
+];
+
+// Card vertex shader: CARD_VERT plus the dispersion overscan. See README.
+export const CARD_DISPERSE_VERT = [
+  'uniform float uDisperse;',
+  'uniform float uAspect;',
+  'varying vec2 vUv;',
+  ...DISPERSE_RAMP,
+  'void main() {',
+  '  float e = dispRamp(uDisperse);',
+  `  float s = 1.0 + e * ${DISPERSE_EXPAND};`,
+  `  float j = 2.0 * ${DISPERSE_JITTER} * e * ${DISPERSE_EXPAND};`,
+  '  vec2 grow = s + j / vec2(max(uAspect, 0.0001), 1.0);',
+  '  vUv = (uv - 0.5) * grow + 0.5;',
+  '  vec3 p = vec3(position.xy * grow, position.z);',
+  '  gl_Position = projectionMatrix * modelViewMatrix * vec4(p, 1.0);',
+  '}',
+].join('\n');
+
 export const CARD_FRAG = [
   'uniform sampler2D uMap;',
   'uniform float uOpacity;',
@@ -85,62 +114,85 @@ export const CARD_FRAG = [
   'uniform float uAspect;', // card world-space width/height (set per phase) so corners stay circular
   'uniform float uRadius;', // corner radius as a fraction of card height (22/631)
   'uniform float uDissolve;', // near-camera dissolve (0 = solid, 1 = expanded + smeared + dispersed)
+  'uniform float uDisperse;', // near-camera explosion (0 = grains stay put); see README
   'uniform float uReveal;', // texture-ready reveal: 0 = contour only, 1 = full photo
   'uniform float uContourFade;', // near-camera gate for the contour (mirrors proxFade)
   'varying vec2 vUv;',
   ...RR_SDF,
   ...HASH21,
+  ...DISPERSE_RAMP,
   'void main() {',
   // Flip uv.x on back faces so the back reads like the front.
   '  vec2 fUv = gl_FrontFacing ? vUv : vec2(1.0 - vUv.x, vUv.y);',
-  // Fisheye magnify anchored at uHoverPos (cursor UV); (0.5,0.5) = centered.
-  '  vec2 d  = fUv - uHoverPos;',
-  '  float r2 = dot(d, d);',
-  '  vec2 warpedUv = d / (1.0 + uWarp * r2 * 4.0) + uHoverPos;',
-  // Near-camera dissolve (melt + particle): content expands as the card rushes the lens.
-  '  vec2 mdir = fUv - 0.5;',
-  '  vec2 meltUv = warpedUv;',
-  '  if (uDissolve > 0.0) {',
-  '    meltUv = (warpedUv - 0.5) / (1.0 + uDissolve * 1.8) + 0.5;',
-  '  }',
-  '  vec2 baseUv = meltUv * uRepeat + uOffset;',
+  // Grain cells in the card's own uv space (× uAspect so cells stay square) so the grain
+  // travels with the card. Shared by the dispersion offset and the particle mask below.
+  '  vec2 cell = floor(fUv * vec2(uAspect, 1.0) * 160.0);',
+  '  float nR = hash21(cell + vec2(0.00,  0.00));',
+  '  float nG = hash21(cell + vec2(2.10,  1.30));',
+  '  float nB = hash21(cell + vec2(1.70, -0.50));',
   // Rounded-corner alpha: rrSDF in world-proportional UV; box half-size is the full
   // plane (uAspect/2, 0.5) so the rect fills edge-to-edge. fwidth gives ~1px AA.
-  '  vec2 pos = (vUv - 0.5) * vec2(uAspect, 1.0);',
+  '  vec2 pos = (fUv - 0.5) * vec2(uAspect, 1.0);',
   '  float dsd = rrSDF(pos, vec2(uAspect * 0.5, 0.5), uRadius);',
   '  float px = fwidth(pos.y);',
-  '  float a = 1.0 - smoothstep(-px, px, dsd);',
-  '  float shapeA = a;', // solid rounded-rect alpha, kept before the particle dissolve eats `a`
-  // Radial CA + motion trail: R trails behind, B ghosts ahead; smear scales with dissolve.
-  '  vec2 meltRad = mdir * uDissolve * 0.22;',
-  '  vec2 radial = (fUv - 0.5) * uCA + meltRad;',
-  '  float r = texture2D(uMap, baseUv + radial - uMotionDir).r;',
-  '  float g = texture2D(uMap, baseUv).g;',
-  '  float b = texture2D(uMap, baseUv - radial + uMotionDir * 0.5).b;',
-  // Particle grain eaten edge-first (edgeProx from SDF dist); cells in the card's own
-  // uv space (× uAspect so cells stay square) so the grain travels with the card.
+  '  float shapeA = 1.0 - smoothstep(-px, px, dsd);', // solid box alpha, for the contour
+  // Explosion: per-grain lift-off, each detached grain reading its origin. See README.
+  '  float sg = 1.0;',
+  '  vec2 sUv = fUv;',
+  '  if (uDisperse > 0.0) {',
+  '    float e = dispRamp(uDisperse);',
+  '    float det = hash21(cell + vec2(13.10, 71.90));',
+  '    if (det < e) {',
+  '      float spd = hash21(cell + vec2(3.70, 47.10));',
+  '      float t = (e - det) / max(1.0 - det, 1e-4);',
+  `      sg = 1.0 + ${DISPERSE_EXPAND} * spd * t;`,
+  '      vec2 jit = vec2(hash21(cell + vec2(31.70, 11.30)), hash21(cell + vec2(57.30, 91.10)));',
+  `      vec2 wSrc = (pos - (jit * 2.0 - 1.0) * (${DISPERSE_JITTER} * (sg - 1.0))) / sg;`,
+  '      sUv = wSrc / vec2(uAspect, 1.0) + 0.5;',
+  '    }',
+  '  }',
+  // Photo alpha is masked at the grain's ORIGIN (pxs = the AA band back there). See README.
+  '  float pxs = px / sg;',
+  '  float srcSD = rrSDF((sUv - 0.5) * vec2(uAspect, 1.0), vec2(uAspect * 0.5, 0.5), uRadius);',
+  '  float a = 1.0 - smoothstep(-pxs, pxs, srcSD);',
+  // Particle grain eaten edge-first (edgeProx from SDF dist).
+  '  float dR = 1.0; float dG = 1.0; float dB = 1.0;',
   '  if (uDissolve > 0.0) {',
-  '    float edgeProx = 1.0 - smoothstep(0.0, 0.28, -dsd);',
-  '    vec2 cell = floor(fUv * vec2(uAspect, 1.0) * 160.0);',
-  '    float nR = hash21(cell + vec2(0.00,  0.00));',
-  '    float nG = hash21(cell + vec2(2.10,  1.30));',
-  '    float nB = hash21(cell + vec2(1.70, -0.50));',
+  '    float edgeProx = 1.0 - smoothstep(0.0, 0.28, -srcSD);',
   '    float localDis = clamp(uDissolve + edgeProx * uDissolve * 1.4, 0.0, 1.0);',
   '    float pedge = 0.10;',
-  '    float dR = smoothstep(localDis - pedge, localDis + pedge, nR);',
-  '    float dG = smoothstep(localDis - pedge, localDis + pedge, nG);',
-  '    float dB = smoothstep(localDis - pedge, localDis + pedge, nB);',
-  '    r *= dR; g *= dG; b *= dB;',
+  '    dR = smoothstep(localDis - pedge, localDis + pedge, nR);',
+  '    dG = smoothstep(localDis - pedge, localDis + pedge, nG);',
+  '    dB = smoothstep(localDis - pedge, localDis + pedge, nB);',
   '    a *= (dR + dG + dB) * 0.3333;',
   '  }',
-  '  vec3 srgb = pow(max(vec3(r, g, b), 0.0), vec3(1.0 / 2.2));',
   // Contour: faint fill + ~1px edge stroke (reuse dsd/px), shown before the photo un-dissolves in.
   '  float stroke = 1.0 - smoothstep(0.0, px * 1.5, abs(dsd));',
   '  float contourA = (shapeA * 0.06 + stroke * 0.5) * uContourFade;',
   // Crossfade contour → photo as reveal goes 0→1; the photo alpha `a` is already dispersing when
   // uDissolve > 0, so the reveal reads as the same edge-first un-dissolve.
-  '  vec3 outCol = mix(vec3(1.0), srgb, uReveal);',
   '  float outA = mix(contourA, a * uOpacity, uReveal);',
+  // Bail before the texture fetches — load-bearing for the dispersion's fill cost. See README.
+  '  if (outA < 0.002) discard;',
+  // Fisheye magnify anchored at uHoverPos (cursor UV); (0.5,0.5) = centered.
+  '  vec2 d  = sUv - uHoverPos;',
+  '  float r2 = dot(d, d);',
+  '  vec2 warpedUv = d / (1.0 + uWarp * r2 * 4.0) + uHoverPos;',
+  // Near-camera dissolve (melt + particle): content expands as the card rushes the lens.
+  '  vec2 mdir = sUv - 0.5;',
+  '  vec2 meltUv = warpedUv;',
+  '  if (uDissolve > 0.0) {',
+  '    meltUv = (warpedUv - 0.5) / (1.0 + uDissolve * 1.8) + 0.5;',
+  '  }',
+  '  vec2 baseUv = meltUv * uRepeat + uOffset;',
+  // Radial CA + motion trail: R trails behind, B ghosts ahead; smear scales with dissolve.
+  '  vec2 meltRad = mdir * uDissolve * 0.22;',
+  '  vec2 radial = mdir * uCA + meltRad;',
+  '  float r = texture2D(uMap, baseUv + radial - uMotionDir).r * dR;',
+  '  float g = texture2D(uMap, baseUv).g * dG;',
+  '  float b = texture2D(uMap, baseUv - radial + uMotionDir * 0.5).b * dB;',
+  '  vec3 srgb = pow(max(vec3(r, g, b), 0.0), vec3(1.0 / 2.2));',
+  '  vec3 outCol = mix(vec3(1.0), srgb, uReveal);',
   '  gl_FragColor = vec4(outCol, outA);',
   '}',
 ].join('\n');

--- a/libs/mep/ace1209/globe-gallery/src/shaders.js
+++ b/libs/mep/ace1209/globe-gallery/src/shaders.js
@@ -73,26 +73,25 @@ export const CARD_VERT = [
   '}',
 ].join('\n');
 
-// Near-camera dispersion. Read README (Near-camera dissolve EXPLODES past the card box)
-// before touching any of it — the dials, ramp, overscan and grain-origin read are all coupled.
-const DISPERSE_EXPAND = '2.00';
-const DISPERSE_JITTER = '0.15';
-const DISPERSE_RAMP = [
-  'float dispRamp(float x) {',
-  '  return pow(clamp(x, 0.0, 1.0), 0.9);',
-  '}',
-];
+// Card dissolve + near-camera dispersion dials. Units and roles: README (Tuning reference);
+// how they interact: README (Near-camera dissolve EXPLODES past the card box).
+const GRAIN_CELLS = 160;
+const DISPERSE_EXPAND = 2.5;
+const DISPERSE_JITTER = 0.2;
+const DISPERSE_CHUNKS = 44;
+const DISPERSE_ERODE = 0.22;
+const DISPERSE_EDGE_LEAD = 1.4;
+const DISPERSE_MARGIN = 2 * DISPERSE_JITTER * DISPERSE_EXPAND; // derived so the stages can't drift
+const glf = (n) => n.toFixed(3); // GLSL float literal (a bare `2` is an int there)
 
-// Card vertex shader: CARD_VERT plus the dispersion overscan. See README.
+// CARD_VERT plus the dispersion overscan. See README.
 export const CARD_DISPERSE_VERT = [
   'uniform float uDisperse;',
   'uniform float uAspect;',
   'varying vec2 vUv;',
-  ...DISPERSE_RAMP,
   'void main() {',
-  '  float e = dispRamp(uDisperse);',
-  `  float s = 1.0 + e * ${DISPERSE_EXPAND};`,
-  `  float j = 2.0 * ${DISPERSE_JITTER} * e * ${DISPERSE_EXPAND};`,
+  `  float s = 1.0 + uDisperse * ${glf(DISPERSE_EXPAND)};`,
+  `  float j = uDisperse * ${glf(DISPERSE_MARGIN)};`,
   '  vec2 grow = s + j / vec2(max(uAspect, 0.0001), 1.0);',
   '  vUv = (uv - 0.5) * grow + 0.5;',
   '  vec3 p = vec3(position.xy * grow, position.z);',
@@ -118,44 +117,46 @@ export const CARD_FRAG = [
   'varying vec2 vUv;',
   ...RR_SDF,
   ...HASH21,
-  ...DISPERSE_RAMP,
   'void main() {',
   // Flip uv.x on back faces so the back reads like the front.
   '  vec2 fUv = gl_FrontFacing ? vUv : vec2(1.0 - vUv.x, vUv.y);',
-  // Grain cells in the card's own uv space (× uAspect so cells stay square) so the grain
-  // travels with the card. Shared by the dispersion offset and the particle mask below.
-  '  vec2 cell = floor(fUv * vec2(uAspect, 1.0) * 160.0);',
-  '  float nR = hash21(cell + vec2(0.00,  0.00));',
-  '  float nG = hash21(cell + vec2(2.10,  1.30));',
-  '  float nB = hash21(cell + vec2(1.70, -0.50));',
   // Rounded-corner alpha: rrSDF in world-proportional UV; box half-size is the full
   // plane (uAspect/2, 0.5) so the rect fills edge-to-edge. fwidth gives ~1px AA.
   '  vec2 pos = (fUv - 0.5) * vec2(uAspect, 1.0);',
   '  float dsd = rrSDF(pos, vec2(uAspect * 0.5, 0.5), uRadius);',
   '  float px = fwidth(pos.y);',
   '  float shapeA = 1.0 - smoothstep(-px, px, dsd);', // solid box alpha, for the contour
-  // Explosion: per-grain lift-off, each detached grain reading its origin. See README.
-  '  float sg = 1.0;',
+  // Explosion (uniform-gated, so other phases pay nothing). See README.
   '  vec2 sUv = fUv;',
+  '  float srcSD = dsd;',
+  '  float a = shapeA;',
   '  if (uDisperse > 0.0) {',
-  '    float e = dispRamp(uDisperse);',
-  '    float det = hash21(cell + vec2(13.10, 71.90));',
-  '    if (det < e) {',
-  '      float spd = hash21(cell + vec2(3.70, 47.10));',
-  '      float t = (e - det) / max(1.0 - det, 1e-4);',
-  `      sg = 1.0 + ${DISPERSE_EXPAND} * spd * t;`,
-  '      vec2 jit = vec2(hash21(cell + vec2(31.70, 11.30)), hash21(cell + vec2(57.30, 91.10)));',
-  `      vec2 wSrc = (pos - (jit * 2.0 - 1.0) * (${DISPERSE_JITTER} * (sg - 1.0))) / sg;`,
+  `    vec2 chunk = floor(fUv * vec2(uAspect, 1.0) * ${glf(DISPERSE_CHUNKS)});`,
+  '    float h1 = hash21(chunk + vec2(13.10, 71.90));',
+  '    float h2 = hash21(chunk + vec2(3.70, 47.10));',
+  '    float rim = 1.0 - smoothstep(0.0, 0.35, -dsd);',
+  `    float det = h1 / (1.0 + rim * ${glf(DISPERSE_EDGE_LEAD)});`,
+  `    float erode = ${glf(DISPERSE_ERODE)} * uDisperse * fract(h1 * 43.7);`,
+  '    float sg = 1.0;',
+  '    if (det < uDisperse) {',
+  '      float spd = 0.25 + 0.75 * h2;',
+  '      float t = (uDisperse - det) / max(1.0 - det, 1e-4);',
+  `      sg = 1.0 + ${glf(DISPERSE_EXPAND)} * spd * t;`,
+  '      vec2 jit = fract(vec2(h1, h2) * vec2(97.13, 61.70)) * 2.0 - 1.0;',
+  `      vec2 wSrc = (pos - jit * (${glf(DISPERSE_JITTER)} * (sg - 1.0))) / sg;`,
   '      sUv = wSrc / vec2(uAspect, 1.0) + 0.5;',
   '    }',
+  '    float pxs = px / sg;',
+  '    srcSD = rrSDF((sUv - 0.5) * vec2(uAspect, 1.0), vec2(uAspect * 0.5, 0.5), uRadius) + erode;',
+  '    a = 1.0 - smoothstep(-pxs, pxs, srcSD);',
   '  }',
-  // Photo alpha is masked at the grain's ORIGIN (pxs = the AA band back there). See README.
-  '  float pxs = px / sg;',
-  '  float srcSD = rrSDF((sUv - 0.5) * vec2(uAspect, 1.0), vec2(uAspect * 0.5, 0.5), uRadius);',
-  '  float a = 1.0 - smoothstep(-pxs, pxs, srcSD);',
-  // Particle grain eaten edge-first (edgeProx from SDF dist).
+  // Particle grain, eaten edge-first. See README.
   '  float dR = 1.0; float dG = 1.0; float dB = 1.0;',
   '  if (uDissolve > 0.0) {',
+  `    vec2 cell = floor(fUv * vec2(uAspect, 1.0) * ${glf(GRAIN_CELLS)});`,
+  '    float nR = hash21(cell + vec2(0.00,  0.00));',
+  '    float nG = hash21(cell + vec2(2.10,  1.30));',
+  '    float nB = hash21(cell + vec2(1.70, -0.50));',
   '    float edgeProx = 1.0 - smoothstep(0.0, 0.28, -srcSD);',
   '    float localDis = clamp(uDissolve + edgeProx * uDissolve * 1.4, 0.0, 1.0);',
   '    float pedge = 0.10;',
@@ -176,11 +177,13 @@ export const CARD_FRAG = [
   '  vec2 d  = sUv - uHoverPos;',
   '  float r2 = dot(d, d);',
   '  vec2 warpedUv = d / (1.0 + uWarp * r2 * 4.0) + uHoverPos;',
-  // Near-camera dissolve (melt + particle): content expands as the card rushes the lens.
+  // Melt (content swells as the card rushes the lens) — net of uDisperse, so the explosion owns
+  // the motion in the sphere phase and this is left to the texture-ready reveal. See README.
   '  vec2 mdir = sUv - 0.5;',
   '  vec2 meltUv = warpedUv;',
-  '  if (uDissolve > 0.0) {',
-  '    meltUv = (warpedUv - 0.5) / (1.0 + uDissolve * 1.8) + 0.5;',
+  '  float melt = max(uDissolve - uDisperse, 0.0);',
+  '  if (melt > 0.0) {',
+  '    meltUv = (warpedUv - 0.5) / (1.0 + melt * 1.8) + 0.5;',
   '  }',
   '  vec2 baseUv = meltUv * uRepeat + uOffset;',
   // Radial CA + motion trail: R trails behind, B ghosts ahead; smear scales with dissolve.

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -77,6 +77,12 @@ export const CURSOR_ZOOM_RETIRE_T = 0.40;
 
 export const SCROLL_VEL_DEADBAND = 7; // px/frame — below this is Lenis settle noise
 
+// --- Frame pacing (frame.dtScale rescales per-60fps-frame rates; clamped) ---
+
+export const FRAME_MS = 1000 / 60;
+export const DT_SCALE_MIN = 0.25;
+export const DT_SCALE_MAX = 3;
+
 // --- Derived (docs/tests, not per frame) ---
 
 export const progressAtFormT = (t) => FOLD_FIRST_PROGRESS + t * FOLD_WINDOW;
@@ -97,6 +103,7 @@ export function createFrame() {
     lenisY: 0,
     scrollingDown: true,
     scrollVel: 0,
+    dtScale: 1,
     progress: 0,
     arcCopyEntryT: 0,
     arcPanT: 0,
@@ -118,6 +125,8 @@ export function createFrameInput() {
   return {
     scrollY: 0,
     prevLenisY: 0,
+    now: 0,
+    prevNow: 0, // 0 = no previous frame (first tick / resume) → dtScale 1
     reducedMotion: false,
     blockDocTop: 0,
     blockHeight: 0,
@@ -131,6 +140,10 @@ export function createFrameInput() {
 // input.prevLenisY.
 export function deriveFrame(frame, input) {
   const { reducedMotion, blockDocTop, blockHeight, formPx, viewportH } = input;
+
+  // Elapsed time as a multiple of a 60fps frame; the caller carries `now` into `prevNow`.
+  const dtMs = input.prevNow ? input.now - input.prevNow : FRAME_MS;
+  frame.dtScale = Math.max(DT_SCALE_MIN, Math.min(DT_SCALE_MAX, dtMs / FRAME_MS));
 
   // Reduced motion pins scroll input to the formed-sphere position; the pin cancels in `progress`
   // but canvas visibility still uses real scroll.

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -35,8 +35,6 @@ export const SPHERE_FORMED_PROGRESS = Math.max(
 ) + PROGRESS_FOLD_DUR;
 export const FOLD_WINDOW = SPHERE_FORMED_PROGRESS - FOLD_FIRST_PROGRESS;
 
-export const PQ_APPEAR_LEAD = 0.03;
-
 // --- Entry (raw-scroll space, before `progress` exists) ---
 
 export const ENTRY_LEAD_VH = 0.4;
@@ -67,7 +65,7 @@ export const CONTROLS_ZOOM_HIDE_T = 0.25;
 
 export const CURSOR_DRAG_DISMISS_T = 0.12;
 export const CURSOR_DRAG_RETIRE_T = 0.30;
-export const CURSOR_ZOOM_RETIRE_T = 0.40;
+export const CURSOR_ZOOM_RETIRE_T = 0.35;
 
 export const SCROLL_VEL_DEADBAND = 7; // px/frame — below this is Lenis settle noise
 
@@ -83,6 +81,15 @@ export const progressAtFormT = (t) => FOLD_FIRST_PROGRESS + t * FOLD_WINDOW;
 
 export const ARC_COPY_OUT_START = progressAtFormT(ARC_COPY_OUT_FORM_START);
 export const ARC_COPY_OUT_END = progressAtFormT(ARC_COPY_OUT_FORM_END);
+
+// Inverse of the zoom camera's easeOutCubic ramp (see updateActiveCamera): the zoomT at which the
+// camera reaches world z. Lets a threshold be stated as a place in the scene, not a scroll number.
+export function zoomTAtCamZ(z, camZSphere, camZEnd) {
+  const span = camZSphere - camZEnd;
+  if (!(span > 0)) return 0;
+  const eased = Math.min(1, Math.max(0, (camZSphere - z) / span));
+  return 1 - ((1 - eased) ** (1 / 3));
+}
 
 // --- Frame ---
 

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -63,6 +63,7 @@ export const ARC_COPY_OUT_FORM_END = 0.90;
 // zoomT
 export const TEXT_ZOOM_FADE_RATE = 3;
 export const CANVAS_HIDE_ZOOM_T = 0.95;
+export const CONTROLS_ZOOM_HIDE_T = 0.25;
 
 export const CURSOR_DRAG_DISMISS_T = 0.12;
 export const CURSOR_DRAG_RETIRE_T = 0.30;

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -55,8 +55,9 @@ export const SLIDE_IN_PROGRESS = 0.07;
 
 // --- Gates, each in its own clock's space ---
 
-// sphereFormT
-export const SPHERE_INTERACTIVE_T = 0.8;
+// sphereFormT. One gate for everything that says or does "the globe is live": hover, click, drag,
+// auto-rotate, desktop cursor, hint-plane entrance. Sits just past the first card landing (0.884).
+export const SPHERE_INTERACTIVE_T = 0.9;
 export const DEPTH_SORT_FORM_T = 0.5;
 export const SPHERE_ORIENT_RESET_T = 0.01;
 export const TEXT_APPEAR_START = 0.10;

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -36,7 +36,7 @@ export const SPHERE_FORMED_PROGRESS = Math.max(
 ) + PROGRESS_FOLD_DUR;
 export const FOLD_WINDOW = SPHERE_FORMED_PROGRESS - FOLD_FIRST_PROGRESS;
 
-export const FORMATION_SCROLL_VH = 304; // keep = --formation-vh (CSS)
+export const FORMATION_SCROLL_VH = 304; // keep = --gg-formation-vh (CSS)
 export const PQ_APPEAR_LEAD = 0.03;
 
 // --- Entry (raw-scroll space, before `progress` exists) ---

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -36,7 +36,13 @@ export const SPHERE_FORMED_PROGRESS = Math.max(
 ) + PROGRESS_FOLD_DUR;
 export const FOLD_WINDOW = SPHERE_FORMED_PROGRESS - FOLD_FIRST_PROGRESS;
 
-export const FORMATION_SCROLL_VH = 304; // keep = --gg-formation-vh (CSS)
+// CSS owns these; only read when the custom property doesn't resolve. See README (Scroll model).
+export const CSS_FALLBACK = {
+  FORMATION_VH: 304,
+  RUNWAY_VH: 520,
+  PQ_PIN_FACTOR: 0.65,
+};
+
 export const PQ_APPEAR_LEAD = 0.03;
 
 // --- Entry (raw-scroll space, before `progress` exists) ---

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -35,13 +35,6 @@ export const SPHERE_FORMED_PROGRESS = Math.max(
 ) + PROGRESS_FOLD_DUR;
 export const FOLD_WINDOW = SPHERE_FORMED_PROGRESS - FOLD_FIRST_PROGRESS;
 
-// CSS owns these; only read when the custom property doesn't resolve. See README (Scroll model).
-export const CSS_FALLBACK = {
-  FORMATION_VH: 304,
-  RUNWAY_VH: 520,
-  PQ_PIN_FACTOR: 0.65,
-};
-
 export const PQ_APPEAR_LEAD = 0.03;
 
 // --- Entry (raw-scroll space, before `progress` exists) ---
@@ -83,11 +76,9 @@ export const FRAME_MS = 1000 / 60;
 export const DT_SCALE_MIN = 0.25;
 export const DT_SCALE_MAX = 3;
 
-// --- Derived (docs/tests, not per frame) ---
+// --- Derived ---
 
 export const progressAtFormT = (t) => FOLD_FIRST_PROGRESS + t * FOLD_WINDOW;
-export const progressAtZoomT = (t) => SPHERE_FORMED_PROGRESS
-  + t * (PROGRESS_ZOOM_END - SPHERE_FORMED_PROGRESS);
 
 export const ARC_COPY_OUT_START = progressAtFormT(ARC_COPY_OUT_FORM_START);
 export const ARC_COPY_OUT_END = progressAtFormT(ARC_COPY_OUT_FORM_END);

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -61,7 +61,6 @@ export const ARC_COPY_OUT_FORM_END = 0.90;
 // zoomT
 export const TEXT_ZOOM_FADE_RATE = 3;
 export const CANVAS_HIDE_ZOOM_T = 0.95;
-export const CONTROLS_ZOOM_HIDE_T = 0.25;
 
 export const CURSOR_DRAG_DISMISS_T = 0.12;
 export const CURSOR_DRAG_RETIRE_T = 0.30;

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -1,6 +1,5 @@
-// Scroll timeline: every phase constant, every threshold, and the per-frame clock derivation.
-// Pure — no THREE, no DOM, no closure state. See README (Lifecycle timeline) for what each
-// constant gates, the six clocks, and the frame contract.
+// Scroll timeline: every phase constant, threshold, and the per-frame clock derivation.
+// Pure — no THREE, no DOM, no closure state. See README (Lifecycle timeline).
 
 import { easeOutCubic, easeOutSine } from './math.js';
 

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -1,0 +1,173 @@
+// Scroll timeline: every phase constant, every threshold, and the per-frame clock derivation.
+// Pure — no THREE, no DOM, no closure state. See README (Lifecycle timeline) for what each
+// constant gates, the six clocks, and the frame contract.
+
+import { easeOutCubic, easeOutSine } from './math.js';
+
+// --- Phase constants (progress-space) ---
+
+export const PROGRESS_PAN_END = 0.55;
+export const PROGRESS_ARC_PREROLL = 0.30;
+export const PROGRESS_GRID_ARC_START = 0.30;
+export const PROGRESS_GRID_ARC_END = 0.60;
+export const PROGRESS_FOLD_DUR = 0.25;
+export const PROGRESS_ZOOM_END = 1.00;
+export const GRID_ARC_RANGE = PROGRESS_GRID_ARC_END - PROGRESS_GRID_ARC_START;
+
+export const GRID_PEEL_STAGGER = 0.20;
+export const ARC_PEEL_JITTER = 0.40;
+export const GRID_PEEL_WINDOW = 1.0 - GRID_PEEL_STAGGER;
+
+export const FOLD_PEEL_OVERLAP = 0.35;
+export const FOLD_START_LOCAL_T = 1 - (FOLD_PEEL_OVERLAP ** (1 / 3));
+
+// Fold window ends: sphereFormT 0 and 1. cardFoldStartProgress(0) === FOLD_FIRST_PROGRESS.
+export const FOLD_FIRST_PROGRESS = Math.max(
+  0,
+  (PROGRESS_GRID_ARC_START
+    + FOLD_START_LOCAL_T * GRID_PEEL_WINDOW * GRID_ARC_RANGE
+    - PROGRESS_ARC_PREROLL) * PROGRESS_PAN_END,
+);
+export const SPHERE_FORMED_PROGRESS = Math.max(
+  0,
+  (PROGRESS_GRID_ARC_START
+    + Math.min(1, GRID_PEEL_STAGGER + FOLD_START_LOCAL_T * GRID_PEEL_WINDOW) * GRID_ARC_RANGE
+    - PROGRESS_ARC_PREROLL) * PROGRESS_PAN_END,
+) + PROGRESS_FOLD_DUR;
+export const FOLD_WINDOW = SPHERE_FORMED_PROGRESS - FOLD_FIRST_PROGRESS;
+
+export const FORMATION_SCROLL_VH = 304; // keep = --formation-vh (CSS)
+export const PQ_APPEAR_LEAD = 0.03;
+
+// --- Entry (raw-scroll space, before `progress` exists) ---
+
+export const ENTRY_LEAD_VH = 0.4;
+export const ENTRY_RAMP_VH = 1.05;
+export const ARC_ENTRY_HOLD_T = 0.05;
+export const ENTRY_ROT_MAX = 0.9;
+export const ENTRY_SLIDE_H_FRAC = 0.30;
+export const SLIDE_IN_PROGRESS = 0.07;
+
+// --- Gates, each in its own clock's space ---
+
+// sphereFormT
+export const SPHERE_INTERACTIVE_T = 0.8;
+export const DEPTH_SORT_FORM_T = 0.5;
+export const SPHERE_ORIENT_RESET_T = 0.01;
+export const TEXT_APPEAR_START = 0.10;
+
+// arcCopyEntryT / fold-window fraction
+export const ARC_COPY_IN_ENTRY_T = 0.336;
+export const ARC_COPY_OUT_FORM_START = 0.20;
+export const ARC_COPY_OUT_FORM_END = 0.90;
+
+// zoomT
+export const TEXT_ZOOM_FADE_RATE = 3;
+export const CANVAS_HIDE_ZOOM_T = 0.95;
+export const CURSOR_HINT_DISMISS_T = 0.12;
+export const CURSOR_RETIRE_T = 0.55;
+export const CURSOR_ZOOM_DISMISS_T = 0.38;
+export const CURSOR_ZOOM_RETIRE_T = 0.40;
+
+export const SCROLL_VEL_DEADBAND = 7; // px/frame — below this is Lenis settle noise
+
+// --- Derived (docs/tests, not per frame) ---
+
+export const progressAtFormT = (t) => FOLD_FIRST_PROGRESS + t * FOLD_WINDOW;
+export const progressAtZoomT = (t) => SPHERE_FORMED_PROGRESS
+  + t * (PROGRESS_ZOOM_END - SPHERE_FORMED_PROGRESS);
+
+export const ARC_COPY_OUT_START = progressAtFormT(ARC_COPY_OUT_FORM_START);
+export const ARC_COPY_OUT_END = progressAtFormT(ARC_COPY_OUT_FORM_END);
+
+// --- Frame ---
+
+const clamp01 = (v) => (v > 0 ? (v > 1 ? 1 : v) : 0);
+
+// Allocated once per runtime, mutated in place. Every field initialized here so the shape stays
+// monomorphic; activeCamera and below are written by tick()'s producer stages.
+export function createFrame() {
+  return {
+    lenisY: 0,
+    scrollingDown: true,
+    scrollVel: 0,
+    progress: 0,
+    arcCopyEntryT: 0,
+    arcPanT: 0,
+    gridFormT: 0,
+    gpWin: GRID_PEEL_WINDOW,
+    sphereFormT: 0,
+    zoomT: 0,
+    entryRot: ENTRY_ROT_MAX,
+    entryYOffset: 0,
+    arcScale: 1,
+    activeCamera: null,
+    sphereRotActive: false,
+    sphGroupZ: 0,
+    foldSphDist: 0,
+  };
+}
+
+export function createFrameInput() {
+  return {
+    scrollY: 0,
+    prevLenisY: 0,
+    reducedMotion: false,
+    blockDocTop: 0,
+    blockHeight: 0,
+    formPx: 0,
+    viewportH: 0,
+    arcScale: 1,
+  };
+}
+
+// Derive every clock onto `frame`. No allocation; caller carries frame.lenisY back into
+// input.prevLenisY.
+export function deriveFrame(frame, input) {
+  const { reducedMotion, blockDocTop, blockHeight, formPx, viewportH } = input;
+
+  // Reduced motion pins scroll input to the formed-sphere position; the pin cancels in `progress`
+  // but canvas visibility still uses real scroll.
+  const lenisY = reducedMotion ? blockDocTop + formPx : input.scrollY;
+  frame.lenisY = lenisY;
+  frame.scrollingDown = lenisY >= input.prevLenisY;
+  const rawScrollVel = reducedMotion ? 0 : Math.abs(lenisY - input.prevLenisY);
+  frame.scrollVel = rawScrollVel < SCROLL_VEL_DEADBAND ? 0 : rawScrollVel;
+
+  const entryStart = blockDocTop - viewportH * ENTRY_LEAD_VH;
+  const entryRange = Math.max(1, viewportH * ENTRY_RAMP_VH);
+  const arcCopyEntryT = clamp01((lenisY - entryStart) / entryRange);
+  frame.arcCopyEntryT = arcCopyEntryT;
+
+  // Piecewise: formation over [0, formPx] (fixed length), zoom-through + quote over the rest.
+  const rawScroll = lenisY - blockDocTop;
+  const tailPx = Math.max(1, blockHeight - formPx);
+  const progress = rawScroll <= formPx
+    ? clamp01(rawScroll / Math.max(1, formPx)) * SPHERE_FORMED_PROGRESS
+    : SPHERE_FORMED_PROGRESS
+      + clamp01((rawScroll - formPx) / tailPx) * (1 - SPHERE_FORMED_PROGRESS);
+  frame.progress = progress;
+
+  const arcPanT = Math.min(1, progress / PROGRESS_PAN_END + PROGRESS_ARC_PREROLL * arcCopyEntryT);
+  frame.arcPanT = arcPanT;
+  frame.gridFormT = clamp01((arcPanT - PROGRESS_GRID_ARC_START) / GRID_ARC_RANGE);
+  frame.gpWin = GRID_PEEL_WINDOW;
+  frame.sphereFormT = clamp01((progress - FOLD_FIRST_PROGRESS) / FOLD_WINDOW);
+  frame.zoomT = clamp01(
+    (progress - SPHERE_FORMED_PROGRESS) / (PROGRESS_ZOOM_END - SPHERE_FORMED_PROGRESS),
+  );
+
+  const slideT = Math.max(arcCopyEntryT, clamp01(progress / SLIDE_IN_PROGRESS));
+  const arcEntryT = clamp01((arcCopyEntryT - ARC_ENTRY_HOLD_T) / (1 - ARC_ENTRY_HOLD_T));
+  frame.entryRot = (1 - easeOutCubic(arcEntryT)) * ENTRY_ROT_MAX;
+  frame.entryYOffset = (1 - easeOutSine(slideT)) * viewportH * ENTRY_SLIDE_H_FRAC;
+  frame.arcScale = input.arcScale;
+
+  return frame;
+}
+
+export function cardFoldStartProgress(gpDelay) {
+  const foldStartFormT = gpDelay + FOLD_START_LOCAL_T * GRID_PEEL_WINDOW;
+  const foldStartArcT = PROGRESS_GRID_ARC_START + Math.min(1, foldStartFormT) * GRID_ARC_RANGE;
+  return Math.max(0, (foldStartArcT - PROGRESS_ARC_PREROLL) * PROGRESS_PAN_END);
+}

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -63,9 +63,9 @@ export const ARC_COPY_OUT_FORM_END = 0.90;
 // zoomT
 export const TEXT_ZOOM_FADE_RATE = 3;
 export const CANVAS_HIDE_ZOOM_T = 0.95;
-export const CURSOR_HINT_DISMISS_T = 0.12;
-export const CURSOR_RETIRE_T = 0.55;
-export const CURSOR_ZOOM_DISMISS_T = 0.38;
+
+export const CURSOR_DRAG_DISMISS_T = 0.12;
+export const CURSOR_DRAG_RETIRE_T = 0.30;
 export const CURSOR_ZOOM_RETIRE_T = 0.40;
 
 export const SCROLL_VEL_DEADBAND = 7; // px/frame — below this is Lenis settle noise

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -82,7 +82,7 @@ export const ARC_COPY_OUT_END = progressAtFormT(ARC_COPY_OUT_FORM_END);
 
 // --- Frame ---
 
-const clamp01 = (v) => (v > 0 ? (v > 1 ? 1 : v) : 0);
+const clamp01 = (v) => (v > 0 ? Math.min(1, v) : 0); // NaN → 0
 
 // Allocated once per runtime, mutated in place. Every field initialized here so the shape stays
 // monomorphic; activeCamera and below are written by tick()'s producer stages.


### PR DESCRIPTION
## Ticket

- https://jira.corp.adobe.com/browse/MWPW-204019
- https://jira.corp.adobe.com/browse/MWPW-204033

## What's in this PR

Follow-up polish on the `globe-gallery` block (ace1209). All changes are scoped to `libs/mep/ace1209/globe-gallery/`.

### A11y Controls
- Arrows for rotation on touch devices
- Play/Pause for auto-spin

### Mobile optimization
- Resilient to phone address bar changes
- Turn full canvas into non-selectable

### Added quotes crosshair

### Scroll timeline extracted to `src/timeline.js`
Every phase constant, threshold, and per-frame clock derivation moved out of `globe-gallery.js` into a new pure module (no THREE, no DOM, no closure state). `globe-gallery.js` shrinks by ~350 lines and the timeline is now readable and independently testable. README gained a "Lifecycle timeline" section documenting what each constant gates and the frame contract.

### Analytics
Added `daa-ll` tracking to the modal: card open/close, prev/next navigation, and product badge links (labelled by product, not by card, and unindexed). Escape and pull-to-close now route through the close button so keyboard/gesture dismissals report the same way clicks do. README documents the label scheme.

### Authoring
- Arc copy and card descriptions accept multiple authored paragraphs instead of collapsing to a single joined string; authored `<p>` nodes are reused rather than re-created, so inline markup survives.
- Card names can be authored as a heading; `<em>`/`<strong>` are only treated as role/name when they are the whole paragraph.
- Pull-quote opening quotation marks now hang into the pill's inline padding, with a canvas-measured fallback for WebKit (which lacks `hanging-punctuation`) and a bail-out for wide marks such as CJK brackets.

### Design tokens and spacing
- Replaced raw-value tokens with semantic ones (`--s2a-blur-lg`, `--s2a-border-radius-xs`, `--s2a-font-line-height-md/xs`).
- Arc-copy positioning moved from per-frame JS inline styles to CSS logical properties — the RTL side-flipping and grid-inset math in the render loop is gone.
- Uniform chrome inset across the modal: 16px on sm, 24px above, so the close button, nav arrows, and info panel padding all agree.
- Namespaced the pull-quote pin custom property to `--gg-pq-pin-factor`.

### Rendering
Lowered `CARD_FACE_CAMERA` on the barrel from 0.35 to 0.1 — cards at the limb were being over-rotated toward the camera, hurting legibility. README notes the trade-off against barrel smoothness.

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=globe-updates&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all









