### PR TITLE
[SR] MWPW-204238: Fix split-aside-grid a11y and play/pause positioning

### DIFF
--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
@@ -338,6 +338,10 @@
     cursor: pointer;
     margin-block-end: var(--grid-item-spacing);
 
+    &[data-cloned="true"] {
+      display: none;
+    }
+
     .foreground {
       align-items: flex-start;
       text-align: unset;
@@ -476,21 +480,19 @@
 }
 
 :root:has(meta[name="foundation"][content="c2"]) {
-  @media (width >= 768px) {
-    .split-aside-grid-stack {
-      --btn-spacing: var(--s2a-spacing-lg);
-      --border-padding: calc(var(--s2a-border-width-1) + var(--s2a-spacing-xs));
-      --btn-position: calc(var(--split-aside-grid-stack-cutoff) - var(--border-padding) + var(--btn-spacing));
-      button.play-pause-button {
-        right: unset;
-        inset-inline-end: var(--btn-position);
-      }
+  .split-aside-grid-stack {
+    --btn-spacing: var(--s2a-spacing-lg);
+    --border-padding: calc(var(--s2a-border-width-1) + var(--s2a-spacing-xs));
+    --btn-position: calc(var(--split-aside-grid-stack-cutoff) - var(--border-padding) + var(--btn-spacing));
+    button.play-pause-button {
+      right: unset;
+      inset-inline-end: var(--btn-position);
     }
+  }
 
-    @media (width >= 1280px) {
-      .split-aside-grid-stack {
-        --btn-spacing: var(--s2a-spacing-xl);
-      }
+  @media (width >= 1280px) {
+    .split-aside-grid-stack {
+      --btn-spacing: var(--s2a-spacing-xl);
     }
   }
 

--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.js
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.js
@@ -144,6 +144,10 @@ function setupBlock(el) {
 
     items.forEach((item, idx) => {
       const isActive = slotOf(idx) === 0;
+      item.removeAttribute('aria-hidden');
+      item.querySelectorAll(FOCUSABLE_SELECTOR).forEach((focusable) => {
+        focusable.removeAttribute('tabindex');
+      });
       const toHide = isMobile ? item : item.querySelector('.foreground');
       toHide.setAttribute('aria-hidden', isActive ? 'false' : 'true');
       toHide.querySelectorAll(FOCUSABLE_SELECTOR).forEach((focusable) => {
@@ -398,7 +402,7 @@ function setupBlock(el) {
       const cloneFront = elements[elements.length - 1].cloneNode(true);
       [cloneBack, cloneFront].forEach((clone) => {
         clone.setAttribute('data-cloned', 'true');
-        clone.setAttribute('aria-hidden', 'true');
+        clone.setAttribute('inert', '');
         clone.removeAttribute('data-slide-index');
         clone.removeAttribute('data-slot');
       });
@@ -579,12 +583,22 @@ function setupBlock(el) {
     setInline(stack, { 'stack-cutoff': `${scrollWidth - width}px` });
   }
 
+  function handleResizeMobileCarousel() {
+    const activeMedia = medias.find((media) => media.getAttribute('data-slot') === '0');
+    const { left, right } = activeMedia.getBoundingClientRect();
+    const viewportWidth = document.documentElement.clientWidth;
+    const cutoff = isRTL ? -left : right - viewportWidth;
+    setInline(stack, { 'stack-cutoff': `${cutoff}px` });
+  }
+
   function addResizeObserver() {
     resizeObserver = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) return;
-      if (isMobileCarousel && isMobile) goToMobileCarouselActive();
-      else handleResizeDesktop();
+      if (isMobileCarousel && isMobile) {
+        goToMobileCarouselActive();
+        handleResizeMobileCarousel();
+      } else handleResizeDesktop();
     });
     resizeObserver.observe(stack);
   }


### PR DESCRIPTION
Fixes five bugs in the `split-aside-grid` (ace1209) block:

* **Dropdown a11y on resize** — clear stale `aria-hidden`/`tabindex` on item wrappers when switching between the mobile-carousel and desktop layouts, so dropdown toggles stay reachable by keyboard/screen reader.
* **Clone focus trap** — mark off-screen carousel clones `inert` (instead of only `aria-hidden`) so their focusable descendants (e.g. play/pause) leave the tab order.
* **Play/pause drift on resize** — recompute `--split-aside-grid-stack-cutoff` on resize in the mobile carousel (RTL-aware) so the button stays anchored to the visible slide edge.
* **Play/pause below 768px** — un-nest the c2 play/pause position rule from `@media (width >= 768px)` so it applies in the mobile carousel.
* **Duplicate dropdown items** — hide cloned dropdown items in the desktop accordion (`display:none`) to remove duplicate entries after the block has been in mobile-carousel mode.

Verified in LTR + RTL across mobile, desktop, and the mobile↔desktop transition. No regression on the non-carousel variant (ace1205).

Resolves: [MWPW-204238](https://jira.corp.adobe.com/browse/MWPW-204238)

**Test URLs:**

ace1209 (cpro-product):
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=mwpw-204238-split-aside-grid&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

ace1205 (regression — non-carousel):
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=mwpw-204238-split-aside-grid&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--all

🤖 Generated with [Claude Code](https://claude.com/claude-code)


