### PR TITLE
[SR] - Rich content media vqa

### DIFF
--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -491,8 +491,7 @@
   flex-direction: column;
   align-items: center;
   gap: var(--s2a-spacing-lg);
-  padding-top: calc(var(--s2a-spacing-4xl) + var(--rc-pull-offset));
-  padding-bottom: var(--s2a-spacing-4xl);
+  padding-block: calc(var(--s2a-spacing-4xl) + var(--rc-pull-offset)) var(--s2a-spacing-4xl);
   overflow: clip;
   --grid-margin-width: 0px; /* Keep unit for calc */
 
@@ -614,8 +613,7 @@
 
 @media (width >= 768px) {
   .rich-content.media {
-    padding-top: var(--s2a-layout-sm);
-    padding-bottom: var(--s2a-layout-sm);
+    padding-block: var(--s2a-layout-sm);
 
     img {
       max-width: unset;
@@ -739,8 +737,7 @@
 @media (width >= 1024px) {
   .rich-content.media {
     gap: var(--s2a-spacing-3xl);
-    padding-top: var(--s2a-layout-lg);
-    padding-bottom: var(--s2a-layout-lg);
+    padding-block: var(--s2a-layout-lg);
   }
 
   .rich-content.media img {

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -491,8 +491,8 @@
   flex-direction: column;
   align-items: center;
   gap: var(--s2a-spacing-lg);
-  padding-top: calc(var(--s2a-layout-sm) + var(--rc-pull-offset));
-  padding-bottom: var(--s2a-layout-lg);
+  padding-top: calc(var(--s2a-spacing-4xl) + var(--rc-pull-offset));
+  padding-bottom: var(--s2a-spacing-4xl);
   overflow: clip;
   --grid-margin-width: 0px; /* Keep unit for calc */
 
@@ -613,6 +613,9 @@
 
 @media (width >= 768px) {
   .rich-content.media {
+    padding-top: var(--s2a-layout-sm);
+    padding-bottom: var(--s2a-layout-sm);
+
     img {
       max-width: unset;
     }
@@ -734,7 +737,9 @@
 
 @media (width >= 1024px) {
   .rich-content.media {
-    gap: var(--s2a-spacing-xl);
+    gap: var(--s2a-spacing-3xl);
+    padding-top: var(--s2a-layout-lg);
+    padding-bottom: var(--s2a-layout-lg);
   }
 
   .rich-content.media img {

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -579,7 +579,6 @@
     --glass-frame-width: 4px;
     --glass-stroke: 0.6px;
     --glass-fill: rgb(255 255 255 / 5%);
-    box-sizing: border-box;
     border: var(--s2a-border-width-2) solid var(--s2a-color-transparent-white-24);
     padding: var(--glass-frame-width);
     background: var(--glass-fill);

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -579,6 +579,7 @@
     --glass-frame-width: 4px;
     --glass-stroke: 0.6px;
     --glass-fill: rgb(255 255 255 / 5%);
+    box-sizing: border-box;
     border: var(--s2a-border-width-2) solid var(--s2a-color-transparent-white-24);
     padding: var(--glass-frame-width);
     background: var(--glass-fill);
@@ -591,6 +592,7 @@
     @media (width >= 768px) {
       --glass-frame-width: 6.5px;
       --glass-stroke: 1px;
+      box-sizing: unset;
     }
 
     @media (width >= 1280px) {


### PR DESCRIPTION
## Summary

Reworks `.rich-content.media` vertical rhythm to match the ace1209 Figma spec:

- **Top/bottom padding:** 64px mobile → 80px tablet (≥768px) → 124px desktop (≥1024px), using `--s2a-spacing-4xl` / `--s2a-layout-sm` / `--s2a-layout-lg` respectively.
- **Gap between video and CTA:** unchanged at 24px (`--s2a-spacing-lg`) through mobile/tablet, bumped to 48px (`--s2a-spacing-3xl`) at desktop.
- `--rc-pull-offset` (the garage-door scroll-animation offset) is left untouched at its original 80px default and no longer factors into the tablet/desktop padding — only the mobile base padding still adds it, preserving the parallax pull effect where that variant is used.
- Sets `box-sizing: unset` on `.glass-border .media-cell :is(picture, .video-container)` at ≥768px, so the frame border/padding math switches back off `border-box` once `--glass-frame-width` grows for larger viewports.


Resolves: 
[MWPW-204177](https://jira.corp.adobe.com/browse/MWPW-204177)
[MWPW-204179](https://jira.corp.adobe.com/browse/MWPW-204179)
[MWPW-204181](https://jira.corp.adobe.com/browse/MWPW-204181)
[MWPW-204186](https://jira.corp.adobe.com/browse/MWPW-204186)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=rc-media-vqa




