### PR TITLE
[MWPW-204271] Use pretty text wrap for C2 Quote

### DIFF
--- a/libs/mep/ace1209/quote/quote.css
+++ b/libs/mep/ace1209/quote/quote.css
@@ -71,6 +71,7 @@
   z-index: 1;
   max-width: var(--quote-copy-max-width);
   margin: 0;
+  text-wrap: pretty;
 }
 
 .quote-attribution {


### PR DESCRIPTION
Apply `text-wrap: pretty;` to the Quote's text, to reduce the likelihood of orphan words on the last line of the quote. It is understood by Design that this doesn't _eliminate_ the possibility, it just _reduces_ it.

Resolves: [MWPW-204271](https://jira.corp.adobe.com/browse/MWPW-204271), [MWPW-204031](https://jira.corp.adobe.com/browse/MWPW-204031)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=make-quote-pretty&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

