### PR TITLE
MWPW-201725 Fix hoverstate for author links

### DIFF
--- a/libs/blocks/article-header/article-header.css
+++ b/libs/blocks/article-header/article-header.css
@@ -162,6 +162,11 @@
   color: var(--color-black);
 }
 
+.article-author a:any-link:hover,
+.article-author a:any-link:focus {
+  color: var(--link-hover-color);
+}
+
 .article-author p {
   margin: 0;
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fix link color for article-author links

Resolves: [MWPW-201725](https://jira.corp.adobe.com/browse/MWPW-201725)

<img width="626" height="82" alt="image" src="https://github.com/user-attachments/assets/5b76d290-69d5-4eb6-91ee-b02f482449dd" />

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bmarshal-article-links--milo--adobecom.aem.page/?martech=off

**Blog URLs:**
- Before: https://main--da-blog--adobecom.aem.live/en/publish/2026/02/09/adobe-partners-openai-test-ads-chatgpt?martech=off
- After: https://main--da-blog--adobecom.aem.live/en/publish/2026/02/09/adobe-partners-openai-test-ads-chatgpt?martech=off&milolibs=bmarshal-article-links

**BACOM Blog URLs:**
- Before: https://main--da-bacom-blog--adobecom.aem.live/blog/customer-experience-orchestration-from-ambition-to-execution?martech=off
- After: https://main--da-bacom-blog--adobecom.aem.live/blog/customer-experience-orchestration-from-ambition-to-execution?martech=off&milolibs=bmarshal-article-links



