### PR TITLE
MWPW-203828: Router Marquee — defer hero video & gate autoplay on first frame

### DIFF
--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -73,6 +73,7 @@ const CHEVRON_SVG = '<svg aria-hidden="true" width="5" height="8" viewBox="0 0 5
 const RESET_SVG = '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none"><g clip-path="url(#clip0_3399_7947)"><rect x="0.333984" y="2" width="1" height="8" rx="0.5" fill="white"/><path d="M7.10412 1.28574C7.36448 1.02559 7.78654 1.02546 8.04682 1.28574C8.30711 1.54602 8.30698 1.96808 8.04682 2.22845L4.94201 5.33327H11.3326C11.7008 5.33327 11.9993 5.63174 11.9993 5.99993C11.9993 6.36812 11.7008 6.6666 11.3326 6.6666H4.94201L8.04682 9.77142C8.30698 10.0318 8.30711 10.4538 8.04682 10.7141C7.78654 10.9744 7.36448 10.9743 7.10412 10.7141L2.86128 6.47129C2.60093 6.21094 2.60093 5.78893 2.86128 5.52858L7.10412 1.28574Z" fill="white"/></g><defs><clipPath id="clip0_3399_7947"><rect width="12" height="12" fill="white"/></clipPath></defs></svg>';
 const BREAKPOINTS = ['mobile', 'tablet', 'desktop'];
 const AUTOPLAY_MS = 5000;
+const FIRST_FRAME_FALLBACK_MS = 8000;
 const SLIDE_MS = 300;
 const STAGGER_MS = 1000;
 const STAGGER_BASE = 60;
@@ -700,9 +701,18 @@ const startAutoplay = (slides, cards, container, block) => {
   const heroVideo = slides[active]?.querySelector('video');
   if (heroVideo && typeof heroVideo.requestVideoFrameCallback === 'function' && !prefersReducedMotion()) {
     let started = false;
-    const kick = () => { if (started) return; started = true; beginAutoplay(); };
+    let fallbackTimer = null;
+    const kick = () => {
+      if (started) return;
+      started = true;
+      clearTimeout(fallbackTimer);
+      beginAutoplay();
+    };
     heroVideo.requestVideoFrameCallback(() => kick());
-    setTimeout(kick, 8000);
+    ['error', 'stalled', 'loadeddata'].forEach((ev) => {
+      heroVideo.addEventListener(ev, kick, { once: true });
+    });
+    fallbackTimer = setTimeout(kick, FIRST_FRAME_FALLBACK_MS);
   } else {
     requestAnimationFrame(beginAutoplay);
   }

--- a/test/blocks/router-marquee/mocks/video.html
+++ b/test/blocks/router-marquee/mocks/video.html
@@ -1,0 +1,41 @@
+<main>
+  <div class="section">
+    <div class="router-marquee">
+      <div>
+        <div>mobile</div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow one</p>
+          <h2>Slide one title</h2>
+          <p>Body copy for slide one.</p>
+          <p><em><strong><a href="https://www.adobe.com/buy">Buy now</a></strong></em> <em><a href="https://www.adobe.com/learn">Learn more</a></em></p>
+          <p><img src="/federal/icons/card-one.svg" alt="card one icon" /></p>
+          <p><a href="https://www.adobe.com/slide-one">Slide one</a></p>
+        </div>
+        <div>
+          <div class="video-container">
+            <video src="https://www.adobe.com/hero-one.mp4" autoplay muted data-rm-poster="https://www.adobe.com/hero-one-poster.jpg"></video>
+            <div class="pause-play-wrapper"></div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow two</p>
+          <h2>Slide two title</h2>
+          <p>Body copy for slide two.</p>
+          <p><em><strong><a href="https://www.adobe.com/buy2">Buy now</a></strong></em></p>
+          <p><img src="/federal/icons/card-two.svg" alt="card two icon" /></p>
+          <p><a href="https://www.adobe.com/slide-two">Slide two</a></p>
+        </div>
+        <div>
+          <div class="video-container">
+            <video src="https://www.adobe.com/hero-two.mp4" autoplay muted data-rm-poster="https://www.adobe.com/hero-two-poster.jpg"></video>
+            <div class="pause-play-wrapper"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/router-marquee/router-marquee.test.js
+++ b/test/blocks/router-marquee/router-marquee.test.js
@@ -121,6 +121,58 @@ describe('Router Marquee', () => {
     expect(cards[1].getAttribute('daa-ll')).to.equal('rm-nav-2--Slide two title');
   });
 
+  it('defers every slide video so none is eager-fetched', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/video.html' });
+    const block = document.querySelector('.router-marquee');
+    init(block);
+
+    // Assert synchronously after init: the mock video URLs are non-loadable, so an
+    // async `error` would kick autoplay and load slide[1]'s video. Do not add awaits
+    // before these assertions without stubbing play()/requestVideoFrameCallback.
+    // second slide is never the active slide, so its video stays fully deferred
+    const slide = mobileVp(block).querySelectorAll('.rm-slide')[1];
+    const video = slide.querySelector('video');
+    expect(video).to.exist;
+    // the .video-container wrapper (and its pause/play controls) is unwrapped
+    expect(slide.querySelector('.video-container')).to.not.exist;
+    expect(slide.querySelector('.pause-play-wrapper')).to.not.exist;
+    expect(video.parentElement.classList.contains('rm-background')).to.be.true;
+
+    // nothing that would trigger a network fetch is left on the element
+    expect(video.preload).to.equal('none');
+    expect(video.hasAttribute('autoplay')).to.be.false;
+    expect(video.getAttribute('src')).to.equal(null);
+    expect(video.querySelector('source')).to.not.exist;
+    // the real source is stashed for loadVideo to restore later
+    expect(video.dataset.lazySrc).to.equal('https://www.adobe.com/hero-two.mp4');
+    // autoplay-safe attributes are still applied
+    expect(video.muted).to.be.true;
+    expect(video.hasAttribute('playsinline')).to.be.true;
+    expect(video.hasAttribute('loop')).to.be.true;
+  });
+
+  it('loads exactly the active viewport hero video, restoring source and poster', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/video.html' });
+    const block = document.querySelector('.router-marquee');
+    init(block);
+
+    // Assert synchronously (see note above): an awaited video `error` would kick
+    // autoplay and preload a second video, making loaded.length 2.
+    // loadViewportVideos promotes only the active viewport's active-slide video
+    const loaded = [...block.querySelectorAll('video')].filter((v) => v.dataset.loaded === 'true');
+    expect(loaded.length).to.equal(1);
+
+    const video = loaded[0];
+    expect(video.preload).to.equal('auto');
+    // the stashed source is re-appended and the deferred poster is promoted
+    const source = video.querySelector('source');
+    expect(source).to.exist;
+    expect(source.getAttribute('src')).to.equal('https://www.adobe.com/hero-one.mp4');
+    expect(video.getAttribute('poster')).to.equal('https://www.adobe.com/hero-one-poster.jpg');
+    // it belongs to the first (active) slide
+    expect(video.closest('.rm-slide').classList.contains('is-active')).to.be.true;
+  });
+
   it('reorders slides based on the starting-marquee section metadata', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/reorder.html' });
     const block = document.querySelector('.router-marquee');


### PR DESCRIPTION
## What

Implements the router-marquee perf fix for [MWPW-203828](https://jira.corp.adobe.com/browse/MWPW-203828): stop the hero `<video>` from being eager-fetched and becoming the LCP element, and hold the first auto-advance until the hero's first frame is ready so the heading paints first.

## Changes

- **Defer all slide videos** — `preload="none"`, strip `src`/`<source>`, stash the real source on `data-lazy-src`. No slide video is eager-fetched; `loadVideo` opts one back in (restoring source + deferred poster) only when its slide becomes active.
- **Gate autoplay on the hero's first frame** — the autoplay timer, progress bar, and next-slide preload only start once the hero video presents a frame via `requestVideoFrameCallback` (8s fallback). Keeps the first transition and the next slide's media out of the hero's poster→first-frame window.
- **Harden the gate** — also kick on `error`/`stalled`/`loadeddata`, not just rVFC, so the carousel recovers promptly instead of waiting the full fallback when the hero video is rejected, errors, or stalls. Fallback timeout extracted to a named constant.
- **Tests + mock** covering deferred slide videos and active-hero loading.

## Impact (from ticket)

- Desktop LCP 11.4s → 6.1s; this change in isolation 10.4s → 5.3s — biggest single win.

## Note

On slow networks the first auto-advance is held until the hero video is ready (opening slide lingers slightly) — pacing to confirm with design.

Resolves: [MWPW-203828](https://jira.corp.adobe.com/browse/MWPW-203828)

- Before: www.stage.adobe.com
- After: www.stage.adobe.com?milolibs=router-marquee-first-frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)

