### PR TITLE
MWPW-204652: use country=PR for Puerto Rico

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -166,7 +166,7 @@ export const GeoMap = {
   ng: 'NG_en',
   cr: 'CR_es',
   ec: 'EC_es',
-  pr: 'US_es', // not a typo, should be US
+  pr: 'PR_es', // Puerto Rico: es content, PR pricing (see EXTRA_MAS_LOCALES for MAS locale)
   gt: 'GT_es',
   cis_en: 'TM_en',
   cis_ru: 'TM_ru',
@@ -174,12 +174,6 @@ export const GeoMap = {
   th_en: 'TH_en',
   th_th: 'TH_th',
 };
-
-/**
- * MAS WCS `locale` when it differs from `${language}_${country}` derived from {@link GeoMap}.
- * @type {Record<string, string>}
- */
-const EXTRA_MAS_LOCALES = { pr: 'es_PR' };
 
 /**
  * MAS locale overrides for markets that share a language but have different country codes
@@ -232,7 +226,7 @@ export function getMiloLocaleSettings(miloLocale) {
   return {
     language,
     country,
-    locale: EXTRA_MAS_LOCALES[geo] ?? `${language}_${country}`,
+    locale: `${language}_${country}`,
   };
 }
 

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -276,11 +276,11 @@ describe('Merch Block', () => {
       });
     });
 
-    it('should use es_PR, es, US for Puerto Rico path', () => {
+    it('should use es_PR, es, PR for Puerto Rico path', () => {
       const s = getMiloLocaleSettings({ prefix: '/pr' });
       expect(s.locale).to.equal('es_PR');
       expect(s.language).to.equal('es');
-      expect(s.country).to.equal('US');
+      expect(s.country).to.equal('PR');
     });
 
     it('should use geo locale for lang-first sites', async () => {


### PR DESCRIPTION
Puerto Rico pages (/pr/) now resolve to country=PR instead of US, since WCS accepts country=PR directly. GeoMap entry changed from US_es to PR_es, so getMiloLocaleSettings returns { language: es, country: PR, locale: es_PR } and mas-commerce-service is stamped with country=PR.

The es_PR locale now falls out of `${language}_${country}` naturally, so the EXTRA_MAS_LOCALES override (its only entry was pr: es_PR) is removed.



