### PR TITLE
MWPW-204653: stop prefetch of Lingo query index on pages that don't need it

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -282,6 +282,9 @@ function hydrateLocale(locales, key) {
       }, {});
 
     const hydratedBase = buildExpandedLocale(locale, key);
+    // Only a Lingo base locale gets `regions`. Omitting the key when there are no regional
+    // children keeps legacy locale-based sites out of the Lingo link path entirely.
+    if (!Object.keys(hydratedChildren).length) return hydratedBase;
     return { ...hydratedBase, regions: hydratedChildren };
   }
 
@@ -293,6 +296,13 @@ function hydrateLocale(locales, key) {
   }
 
   return { ...locale };
+}
+
+// A Lingo base locale has at least one regional child. Count the entries rather than
+// testing `locale.regions` for truthiness: an empty object is truthy, which would make
+// every legacy locale-based site look like a Lingo base page.
+function hasLingoRegions(locale) {
+  return !!Object.keys(locale?.regions ?? {}).length;
 }
 
 export function getLocale(locales, pathname = window.location.pathname) {
@@ -911,7 +921,7 @@ function localizeLinkCore(
       return relative ? urlPath : `${url.origin}${urlPath}`;
     };
 
-    const isLingoPage = locale.base !== undefined || !!locale.regions;
+    const isLingoPage = locale.base !== undefined || hasLingoRegions(locale);
     const isLcpSection = aTag?.closest('.section')?.dataset.idx === '0';
     const siteId = uniqueSiteId ?? '';
     const qiResolved = queryIndexes[siteId]?.requestResolved;
@@ -919,7 +929,7 @@ function localizeLinkCore(
         && (mepLingoSkipQI() || (isLcpSection && !qiResolved));
     const enterAsync = useAsync && aTag && extension !== 'json' && !skipQueryIndex
       && lingoActive() && isLingoPage
-      && (!isFragment || (isMepLingoFragment && !!locale.regions));
+      && (!isFragment || (isMepLingoFragment && hasLingoRegions(locale)));
 
     if (enterAsync) {
       return (async () => {
@@ -944,7 +954,7 @@ function localizeLinkCore(
 
         const domainInSiteMap = !lingoSiteMappingLoaded
           || Object.values(queryIndexes).some((q) => q.domains.includes(url.hostname));
-        const isBasePage = !!locale.regions;
+        const isBasePage = hasLingoRegions(locale);
 
         let resolvedPrefix = basePrefix;
         if (lingoModule) {
@@ -1054,7 +1064,7 @@ export async function getLingoRegion({ useGeoLocation = false } = {}) {
   const { locale } = config || {};
   const { regions } = locale || {};
 
-  if (!regions || !Object.keys(regions).length) return null;
+  if (!hasLingoRegions(locale)) return null;
 
   const country = useGeoLocation
     ? normCountryCode(await getCountry())
@@ -1148,7 +1158,7 @@ export async function localizeLinkAsync(
     || aTag?.dataset?.mepLingoBlockSwap;
 
   const { locale } = getConfig() || {};
-  const isBasePage = !!locale?.regions;
+  const isBasePage = hasLingoRegions(locale);
   const needsOverride = lingoActive()
     && (isMepLingoLink || isBasePage || locale?.base !== undefined);
 

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -2824,6 +2824,167 @@ describe('Utils', () => {
     });
   });
 
+  describe('Lingo query index gating on non-Lingo locales', () => {
+    let originalFetch;
+    let originalLana;
+    let fetchStub;
+    let lingoUtils;
+    let testAnchors;
+
+    const QUERY_INDEX_PATH = 'assets/lingo/query-index';
+    const CLEAR_COUNTRY = 'country=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+
+    // Monotonic, so two sub-millisecond beforeEach calls can't share a cached module.
+    let moduleId = 0;
+    const nextModuleId = () => { moduleId += 1; return `lingo-gating-${moduleId}`; };
+
+    const addAnchor = (href) => {
+      const a = document.createElement('a');
+      a.href = href;
+      document.body.appendChild(a);
+      testAnchors.push(a);
+      return a;
+    };
+
+    // No locale declares `base`, so no locale is part of a base/regional pair. This is the
+    // shape of every legacy locale-based site, e.g. da-bacom-blog.
+    const nonLingoConfig = {
+      locales: {
+        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+        uk: { ietf: 'en-GB', tk: 'hah7vzn.css' },
+        jp: { ietf: 'ja-JP', tk: 'dvg6awq' },
+      },
+      prodDomains: ['business.adobe.com'],
+      pathname: '/uk/blog/',
+      contentRoot: '/blog',
+      codeRoot: '/libs',
+    };
+
+    // `sg` declares `base: ''`, so `''` is a real Lingo base locale with one region.
+    const lingoConfig = {
+      locales: {
+        '': { ietf: 'en-US', tk: 'hah7vzn.css' },
+        sg: { ietf: 'en-SG', tk: 'hah7vzn.css', base: '' },
+      },
+      prodDomains: ['www.adobe.com'],
+      pathname: '/',
+      uniqueSiteId: 'cc',
+      contentRoot: '/cc-shared',
+      codeRoot: '/libs',
+    };
+
+    const fetchedUrls = (needle) => fetchStub.getCalls()
+      .map((call) => `${call.args[0]}`)
+      .filter((url) => url.includes(needle));
+
+    beforeEach(async () => {
+      originalFetch = window.fetch;
+      fetchStub = sinon.stub();
+      fetchStub.callsFake((url) => {
+        const href = `${url}`;
+        if (href.includes('lingo-site-mapping')) {
+          return mockRes({
+            payload: {
+              'site-locales': { data: [{ uniqueSiteId: 'cc', baseSite: '/', regionalSites: '/sg' }] },
+              'site-query-index-map': {
+                data: [{
+                  uniqueSiteId: 'cc',
+                  queryIndexWebPath: 'www.adobe.com/*/cc-shared/assets/lingo/query-index.json',
+                }],
+              },
+            },
+          });
+        }
+        if (href.includes(QUERY_INDEX_PATH) && href.includes('/sg/')) {
+          return mockRes({ payload: { data: [{ path: '/sg/products/photoshop' }] } });
+        }
+        return mockRes({ payload: { data: [] } });
+      });
+      window.fetch = fetchStub;
+      originalLana = window.lana;
+      testAnchors = [];
+      // `akamai` feeds the lowest-priority slot in computeDetectedMarketCountry, so a
+      // leaked `country` cookie from an earlier test would win and break region lookup.
+      document.cookie = CLEAR_COUNTRY;
+      sessionStorage.setItem('akamai', 'sg');
+      lingoUtils = await import(`../../libs/utils/utils.js?t=${nextModuleId()}`);
+      const lingoMeta = document.createElement('meta');
+      lingoMeta.setAttribute('name', 'langfirst');
+      lingoMeta.setAttribute('content', 'on');
+      document.head.append(lingoMeta);
+    });
+
+    afterEach(() => {
+      window.fetch = originalFetch;
+      if (originalLana) window.lana = originalLana; else delete window.lana;
+      testAnchors.forEach((a) => a.remove());
+      document.querySelector('meta[name="langfirst"]')?.remove();
+      document.cookie = CLEAR_COUNTRY;
+      sessionStorage.removeItem('akamai');
+    });
+
+    it('does not attach regions to a locale with no regional children', () => {
+      const locale = lingoUtils.getLocale(nonLingoConfig.locales, '/uk/blog/');
+      expect(locale.prefix).to.equal('/uk');
+      expect(locale.base).to.be.undefined;
+      expect('regions' in locale).to.be.false;
+    });
+
+    it('attaches regions to a base locale that does have regional children', () => {
+      const locale = lingoUtils.getLocale(lingoConfig.locales, '/');
+      expect(locale.prefix).to.equal('');
+      expect(Object.keys(locale.regions)).to.deep.equal(['sg']);
+    });
+
+    it('does not fetch a lingo query index on a regional locale when no locale declares a base', async () => {
+      lingoUtils.setConfig(nonLingoConfig);
+      expect(lingoUtils.lingoActive()).to.be.true;
+      const href = 'https://business.adobe.com/blog/basics/marketing-personalization';
+      const a = addAnchor(href);
+
+      const localized = await lingoUtils.localizeLinkAsync(href, 'business.adobe.com', false, a);
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+      expect(fetchedUrls(QUERY_INDEX_PATH)).to.deep.equal([]);
+      expect(fetchedUrls('lingo-site-mapping')).to.deep.equal([]);
+      // Ordinary locale prefixing must still happen.
+      expect(localized).to.equal('/uk/blog/basics/marketing-personalization');
+    });
+
+    it('does not fetch a lingo query index on the root locale of a non-Lingo site', async () => {
+      // The reported case: business.adobe.com/blog, where matchedKey is '' - the same key
+      // that would carry `regions` on a real Lingo site.
+      lingoUtils.setConfig({ ...nonLingoConfig, pathname: '/blog/' });
+      expect(lingoUtils.lingoActive()).to.be.true;
+      const href = 'https://business.adobe.com/blog/basics/marketing-personalization';
+      const a = addAnchor(href);
+
+      const localized = await lingoUtils.localizeLinkAsync(href, 'business.adobe.com', false, a);
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+      expect(fetchedUrls(QUERY_INDEX_PATH)).to.deep.equal([]);
+      expect(fetchedUrls('lingo-site-mapping')).to.deep.equal([]);
+      expect(localized).to.equal('/blog/basics/marketing-personalization');
+    });
+
+    it('still fetches the lingo query index and localizes on a real Lingo base locale', async () => {
+      const allLoaded = new Promise((resolve) => {
+        const evt = lingoUtils.MILO_EVENTS.QUERY_INDEX_ALL_LOADED;
+        window.addEventListener(evt, resolve, { once: true });
+      });
+      lingoUtils.setConfig(lingoConfig);
+      const href = 'https://www.adobe.com/products/photoshop';
+      const a = addAnchor(href);
+
+      a.href = await lingoUtils.localizeLinkAsync(href, 'www.adobe.com', false, a);
+      await allLoaded;
+      await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+      expect(fetchedUrls(QUERY_INDEX_PATH).length).to.be.greaterThan(0);
+      expect(new URL(a.href).pathname).to.equal('/sg/products/photoshop');
+    });
+  });
+
   describe('computeDetectedMarketCountry', () => {
     it('prefers country query param over country cookie', () => {
       expect(utils.computeDetectedMarketCountry('?country=lu', 'be', null)).to.equal('lu');


### PR DESCRIPTION
Resolves: [MWPW-204653](https://jira.corp.adobe.com/browse/MWPW-204653)

## What

Stop Milo fetching the Lingo query index prefetch on locales that don't need it — no `base`, no regional children.

## Why

`hydrateLocale` gave every childless locale an empty `regions: {}`, and `!!locale.regions` reads `{}` as truthy — so legacy locale-based sites were treated as Lingo base pages. Symptoms:

- **`business.adobe.com/blog`**: a 404 on every page view (`GET /blog/assets/lingo/query-index.json -> 404`) plus a `lana` error. The blog has no such index.
- **`business.adobe.com`**: 23 base-less locales (`/uk`, `/jp`, …) download the index every view (e.g. `/jp`: 346 KB parsed) even though it can't change a single link.

Regression from #5680, which hoisted `!!locale.regions` into a standalone check and dropped its old pairing with a MEP-Lingo test.

## Fix

1. `hydrateLocale` omits `regions` entirely when there are no regional children. **This is the operative fix.**
2. All five `regions` checks now go through one `hasLingoRegions` helper that counts entries — a no-op today, but a tripwire against reintroducing the bug. Not exported; no public API change.

## Tests

5 new tests in `test/utils/utils.test.js` (`Lingo query index gating on non-Lingo locales`) — 3 negative (fail on `stage`, pass here), 2 positive regression guards for real Lingo sites.

Full suite: with fix 4243 passed / 2 failed; without 4240 / 5. The delta is exactly the 3 new tests; the 2 remaining failures are pre-existing on `stage`. `npm run lint:js` clean.

## Test URLs

Blog 404 (check network for `assets/lingo/query-index`):
- Before: https://main--da-bacom-blog--adobecom.aem.live/blog/?martech=off
- After: https://main--da-bacom-blog--adobecom.aem.live/blog/?milolibs=MWPW-204653-lingo-query-index-non-lingo-sites&martech=off

Wasted index download:
- Before: https://main--da-bacom--adobecom.aem.live/uk/products/adobe-analytics?martech=off
- After: https://main--da-bacom--adobecom.aem.live/uk/products/adobe-analytics?milolibs=MWPW-204653-lingo-query-index-non-lingo-sites&martech=off

Lingo still resolves regional prefixes:
- Before: https://main--da-bacom--adobecom.aem.live/fr/?martech=off
- After: https://main--da-bacom--adobecom.aem.live/fr/?milolibs=MWPW-204653-lingo-query-index-non-lingo-sites&martech=off


## Blast radius

`config.locale.regions` is now absent rather than `{}` for a base locale with no regional children. All in-repo readers and the one consumer repo that reads it (`da-cc`) already key-count, so they're unaffected.

