### PR TITLE
[Milo][Martech] Remove performance consent check from analytics event sending

### DIFF
--- a/libs/martech/helpers.js
+++ b/libs/martech/helpers.js
@@ -920,7 +920,6 @@ function fireAnalyticsEvent(val) {
 
 export async function sendAnalytics(val) {
   /* eslint-disable no-underscore-dangle */
-  if (!getMepConsentConfig()?.performance) return;
   if (window._satellite?.track) {
     fireAnalyticsEvent(val);
   } else {


### PR DESCRIPTION
After further consultation with the martech team, a consent check we added for sending analytics is unnecessary and filtering out allowed tracking. We need to remove the consent check from the sendAnalytics function in libs/martech/helpers.js.

Resolves: [MWPW-204692](https://jira.corp.adobe.com/browse/MWPW-204692)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://remove-performance-check--milo--adobecom.aem.page/?martech=off


