### PR TITLE
Brand Concierge - Critical m2.5 bug fixes | for Main

### DIFF
--- a/libs/blocks/brand-concierge-global/brand-concierge-global.js
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.js
@@ -6,6 +6,7 @@ import {
   updateReplicatedValue,
   handleConsent,
   setCssGnavHeight,
+  hasChatCookie,
 } from '../brand-concierge/bc-utils.js';
 import {
   loadWebclient,
@@ -149,6 +150,7 @@ export default function init(el) {
     el.removeChild(row);
   });
 
+  if (!hasChatCookie()) localStorage.setItem('bc-side-overlay', 'closed');
   if (localStorage.getItem('bc-side-overlay') === 'open' && !document.body.classList.contains('bc-side-open')) {
     openSideModal(null, bcBootstrap);
   }

--- a/libs/blocks/brand-concierge/bc-bootstrap.js
+++ b/libs/blocks/brand-concierge/bc-bootstrap.js
@@ -64,6 +64,11 @@ export function createSusiComponentForModal({
 }
 
 async function openSusiLightModal() {
+  window.history.replaceState(
+    {},
+    document.title,
+    `${window.location.pathname}${window.location.search}`,
+  );
   const config = getConfig();
   const { env, locale, imsClientId } = config || {};
   const isStage = env?.name !== 'prod';

--- a/libs/blocks/brand-concierge/bc-utils.js
+++ b/libs/blocks/brand-concierge/bc-utils.js
@@ -27,6 +27,18 @@ const getTargetHeight = (target) => {
   return target.scrollHeight + (parseFloat(marginBottom) * 2);
 };
 
+export function hasChatCookie() {
+  const cookies = document.cookie.split(';');
+  const cookieName = 'kndctr_9E1005A551ED61CA0A490D45_AdobeOrg_bc_session_id';
+  for (let i = 0; i < cookies.length; i += 1) {
+    const cookie = cookies[i].trim();
+    if (cookie.includes(cookieName)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function setCssGnavHeight() {
   const gnav = document.querySelector('header.global-navigation');
   if (!gnav) return;

--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -11,6 +11,7 @@ import {
   updateReplicatedValue,
   handleConsent,
   setCssGnavHeight,
+  hasChatCookie,
 } from './bc-utils.js';
 import {
   loadWebclient,
@@ -189,6 +190,7 @@ export default async function init(el) {
     el.removeChild(row);
   });
 
+  if (!hasChatCookie()) localStorage.setItem('bc-side-overlay', 'closed');
   if (localStorage.getItem('bc-side-overlay') === 'open' && !document.body.classList.contains('bc-side-open')) {
     openSideModal(null, bcBootstrap);
   }

--- a/libs/c2/blocks/brand-concierge/bc-bootstrap.js
+++ b/libs/c2/blocks/brand-concierge/bc-bootstrap.js
@@ -64,6 +64,11 @@ export function createSusiComponentForModal({
 }
 
 async function openSusiLightModal() {
+  window.history.replaceState(
+    {},
+    document.title,
+    `${window.location.pathname}${window.location.search}`,
+  );
   const config = getConfig();
   const { env, locale, imsClientId } = config || {};
   const isStage = env?.name !== 'prod';
@@ -316,7 +321,8 @@ export async function openModal(initialMessage, bootstrap) {
   if (susiListener !== 'signIn:decorateNav') {
     window.addEventListener('signIn:decorateNav', async () => {
       await window.adobeIMS?.refreshToken();
-      (window.feds?.nav?.reloadUnav ?? window.feds?.nav?.reload)?.();
+      const globalNavigation = await getConfig().federal?.fedsGlobalNavigation;
+      globalNavigation?.reloadUnav?.();
     });
     susiListener = 'signIn:decorateNav';
   }
@@ -356,7 +362,8 @@ export async function openSideModal(initialMessage, bootstrap) {
   if (susiListener !== 'signIn:decorateNav') {
     window.addEventListener('signIn:decorateNav', async () => {
       await window.adobeIMS?.refreshToken();
-      (window.feds?.nav?.reloadUnav ?? window.feds?.nav?.reload)?.();
+      const globalNavigation = await getConfig().federal?.fedsGlobalNavigation;
+      globalNavigation?.reloadUnav?.();
     });
     susiListener = 'signIn:decorateNav';
   }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Fixes for the following bugs | Based on Main

* [MWPW-204304](https://jira.corp.adobe.com/browse/MWPW-204304) Suppresses auto opening of the side overlay if there is no chat history
* [MWPW-199685](https://jira.corp.adobe.com/browse/MWPW-199685) Fix for c2 gnav not updating to show as logged in after logging in via the bc susi flow
* [BRANDCON-8504](https://jira.corp.adobe.com/browse/BRANDCON-8504) Fix for short circuited modal closer due to hash values in the URL when logging in for firefly image generation via the bc susi flow

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/
- After: https://bc-m2-5-fixes--milo--adobecom.aem.page/




