### PR TITLE
[SR] Rounded corner overlap and z-index issue

### DIFF
--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -137,6 +137,13 @@ body:has(header.local-nav) .section.bento.stack-mobile {
     margin-bottom: initial;
   }
 
+  /* Fix to remove blank gap caused by rounded-corners :before/:after
+     spacing/height adjustment that fall in "-up" layouts */
+  &.rounded-corners + .section,
+  &.rounded-corners-bottom + .section {
+    grid-template-rows: auto;
+  }
+
   &:has(+ .rounded-corners)::after,
   &:has(+ .rounded-corners-top)::after,
   &.rounded-corners + .section::before,
@@ -151,6 +158,14 @@ body:has(header.local-nav) .section.bento.stack-mobile {
   &.rounded-corners-bottom {
     border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
     margin-top: initial;
+  }
+
+  /* Fix for consecutive rounded corner sections in order
+    to have the first section overlay on to the following section 
+    For later - need to find a more elegant solution */
+  &.rounded-corners:has(+ .section[class*='rounded-corners']),
+  &.rounded-corners-bottom:has(+ .section[class*='rounded-corners']) {
+    z-index: 4;
   }
 
   &.masonry-layout {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
**Issue 1**
When the section receiving the spacer used the "ups" grid (e.g. product-grid) created an extra large space instead of the intended 32px of spacing to normalize heights between sections with rounded corners.

**Issue 2**
Rounded corner hidden when two rounded-corners sections are adjacent to each other.

If the first section used rounded-corners-bottom and the following section used the same, the 2nd section would cover up the first sections rounded corner due to a z-index issue.

**Fixes**
* Fix for extra space added when followed by a section that uses the `ups` grid
* Fixes overlap issue noted in issue 2

Resolves: [MWPW-204713](https://jira.corp.adobe.com/browse/MWPW-204713)

**Test URLs:**
- Before: https://site-redesign-foundation--milo--adobecom.aem.page/drafts/rclayton/bento-video-link
- After: https://sr-section-rounded-corners-fix--milo--adobecom.aem.page/drafts/rclayton/bento-video-link

Test page url:
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=sr-section-rounded-corners-fix&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

