### PR TITLE
[MWPW-204698] Remove manifest overline

### DIFF
--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
@@ -1,9 +1,6 @@
 :root {
   interpolate-size: allow-keywords;
 
-  --mep-overline-font: normal 500 12px / var(--Static-Label-Medium-Line-Height, 16px) "Adobe Clean";
-  --mep-overline-letter-spacing: var(--Static-Label-Medium-Tracking, 0.5px);
-
   --mep-h1-font: normal 700 var(--Typography-Heading-s, 20px) / 24px var(--Font-adobe-clean, "Adobe Clean");
 
   --mep-h2-font: normal 500 var(--Static-Title-Medium-Size, 16px) / var(--Static-Title-Medium-Line-Height, 24px) "Adobe Clean";
@@ -516,14 +513,6 @@ body:has(#mep-drawer:popover-open) .mep-fab {
 
 .mep-drawer .mep-switch input:checked + .mep-switch-track::after {
   transform: translateX(20px);
-}
-
-.mep-drawer .mep-overline {
-  text-transform: uppercase;
-  font-weight: 400;
-  color: var(--mep-white-60);
-  font: var(--mep-overline-font);
-  letter-spacing: var(--mep-overline-letter-spacing);
 }
 
 .mep-drawer .mep-manifest-link {

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -137,7 +137,7 @@ function toggleExpandedCard(cardEl) {
   localStorage.setItem(CARD_STORAGE_KEY, JSON.stringify([...expanded]));
 }
 
-function buildManifestCard(manifest, { mmm = false } = {}) {
+function buildManifestCard(manifest) {
   const filename = createTag('span', { class: 'mep-manifest-filename' });
   filename.textContent = manifest.fileName ?? '';
   const link = createTag('a', { href: safeUrl(manifest.editUrl), target: '_blank', rel: 'noopener' }, [
@@ -145,13 +145,11 @@ function buildManifestCard(manifest, { mmm = false } = {}) {
     filename,
   ]);
   const header = createTag('div', { class: 'mep-manifest-header' }, [
-    createTag('span', { class: 'mep-overline' }, mmm ? '7 Day Manifest' : 'Manifest'),
     createTag('h1', {}, [link, svgIcon('icon-expand-circle-down')]),
   ]);
 
   const rows = [];
   if (manifest.targetActivityName) rows.push(buildRow('Campaign', manifest.targetActivityName));
-  rows.push(buildRow('Experience', manifest.isDefaultSelected ? 'default (control)' : manifest.selectedVariantName));
   rows.push(buildRow('Source', manifest.source));
   rows.push(buildRow('Mktg Action', manifest.mktgAction));
   if (manifest.geoRestriction) rows.push(buildRow('Geo', manifest.geoRestriction));
@@ -164,6 +162,7 @@ function buildManifestCard(manifest, { mmm = false } = {}) {
     rows.push(onRow, buildRow('Off', manifest.eventEnd));
   }
 
+  rows.push(buildRow('Experience', manifest.isDefaultSelected ? 'default (control)' : manifest.selectedVariantName));
   const select = createTag('select', { name: 'experiences', class: 'mep-manifest-variants' });
   manifest.options.forEach((option) => {
     const attrs = {
@@ -480,7 +479,7 @@ async function buildAdditionalManifests() {
 
   let insertionPoint = lastManifestEl;
   for (const manifest of manifests) {
-    const manifestEl = buildManifestCard(manifest, { mmm: true });
+    const manifestEl = buildManifestCard(manifest);
     manifestEl.classList.add('mmm-manifest-card');
     insertionPoint.after(manifestEl);
     insertionPoint = manifestEl;


### PR DESCRIPTION
**Updates**
* [MWPW-204698] Remove the "Manifest"/"7 Day Manifest" overline label from the manifest card header, along with the now-unused `mmm` param and `.mep-overline` CSS it depended on
* [MWPW-204698] Move the "Experience" data row to sit directly above the experience variants dropdown, so it reads as a heading for that control instead of being grouped with Campaign/Source/Mktg Action

**Instructions**

1. Open the before link and note the manifest card header shows an overline label ("Manifest") above the filename, and the "Experience" row appears near the top of the card, separate from the variants dropdown.
2. Open the after link with `?milolibs=mn-mwpw-204698` to load the updated overlay code.
3. Open the MEP overlay (FAB) and expand a manifest card — confirm the overline label is gone from the header.
4. Confirm the "Experience" row now appears immediately above the experience-selector dropdown at the bottom of the card.
5. Confirm all other rows (Campaign, Source, Mktg Action, Geo, Active?, Last Seen, On/Off) and their order are otherwise unchanged.

Resolves: [MWPW-204698](https://jira.corp.adobe.com/browse/MWPW-204698)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/products/photoshop?mep=&mepnext=on
- After: https://main--da-cc--adobecom.aem.page/products/photoshop?mep=&mepnext=on&milolibs=mn-mwpw-204698

PSI: https://mn-mwpw-204698--milo--adobecom.aem.page/?martech=off


