### PR TITLE
[MWPW-204799] - Perf: debounce resize handler and cache sticky-top read in comparison…

### DIFF
--- a/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
+++ b/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
@@ -604,8 +604,8 @@ function setupCollapsingHeader(el) {
     if (!goingDown && wasCollapsed) removeCollapsed();
   }, { passive: true });
 
-  const nav = document.querySelector('header > nav') ?? document.querySelector('header');
-  if (nav) new ResizeObserver(syncTop).observe(nav);
+  const header = document.querySelector('header');
+  if (header) new ResizeObserver(syncTop).observe(header);
 
   new ResizeObserver(() => {
     if (!isExpanding) syncHeaderHeight();

--- a/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
+++ b/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
@@ -545,10 +545,6 @@ function setupCollapsingHeader(el) {
 
   const getStickyTop = () => parseFloat(getComputedStyle(cardsContainer).top) || 0;
 
-  // getStickyTop() only ever changes when syncTop() runs (nav height/
-  // breakpoint change) — it's a static CSS value the rest of the time, not
-  // something that needs a fresh getComputedStyle read on every scroll
-  // event. Cache it here and refresh only when syncTop() actually runs.
   let stickyTopCache = 0;
 
   const syncTop = () => {

--- a/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
+++ b/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
@@ -1,5 +1,6 @@
 import { createTag, getConfig, loadStyle } from '../../../utils/utils.js';
 import { getMetadata as getSectionMetadata } from '../section-metadata/section-metadata.js';
+import { getGnavHeight } from '../../../blocks/global-navigation/utilities/utilities.js';
 
 const COLUMN_TYPES = { PRIMARY: 'primary' };
 
@@ -542,18 +543,18 @@ function setupCollapsingHeader(el) {
 
   const isMobile = () => window.matchMedia('(max-width: 899px)').matches;
 
-  const getNavHeight = () => {
-    const nav = document.querySelector('header > nav') ?? document.querySelector('header');
-    if (!nav) return 0;
-    const pos = getComputedStyle(nav).position;
-    const bottom = (pos === 'fixed' || pos === 'sticky')
-      ? Math.max(0, Math.round(nav.getBoundingClientRect().bottom)) : 0;
-    return bottom + (document.querySelector('.feds-localnav')?.offsetHeight ?? 0);
-  };
-
-  const syncTop = () => cardsContainer.style.setProperty('--ct-nav-height', `${getNavHeight()}px`);
-
   const getStickyTop = () => parseFloat(getComputedStyle(cardsContainer).top) || 0;
+
+  // getStickyTop() only ever changes when syncTop() runs (nav height/
+  // breakpoint change) — it's a static CSS value the rest of the time, not
+  // something that needs a fresh getComputedStyle read on every scroll
+  // event. Cache it here and refresh only when syncTop() actually runs.
+  let stickyTopCache = getStickyTop();
+
+  const syncTop = () => {
+    cardsContainer.style.setProperty('--ct-nav-height', `${getGnavHeight()}px`);
+    stickyTopCache = getStickyTop();
+  };
 
   const syncHeaderHeight = () => {
     if (isMobile()) { headerContent.style.minHeight = ''; return; }
@@ -582,8 +583,14 @@ function setupCollapsingHeader(el) {
     syncHeaderHeight();
   });
 
+  let resizeRafPending = false;
   window.addEventListener('resize', () => {
-    removeCollapsed();
+    if (resizeRafPending) return;
+    resizeRafPending = true;
+    requestAnimationFrame(() => {
+      resizeRafPending = false;
+      removeCollapsed();
+    });
   });
 
   window.addEventListener('scroll', () => {
@@ -591,7 +598,7 @@ function setupCollapsingHeader(el) {
     const y = window.scrollY;
     const goingDown = y > lastScrollY;
     lastScrollY = y;
-    const isStuck = cardsContainer.getBoundingClientRect().top <= getStickyTop();
+    const isStuck = cardsContainer.getBoundingClientRect().top <= stickyTopCache;
     if (!isStuck) { removeCollapsed(); return; }
     if (goingDown && !wasCollapsed) applyCollapsed();
     if (!goingDown && wasCollapsed) removeCollapsed();

--- a/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
+++ b/libs/c2/blocks/comparison-table-c2/comparison-table-c2.js
@@ -549,12 +549,13 @@ function setupCollapsingHeader(el) {
   // breakpoint change) — it's a static CSS value the rest of the time, not
   // something that needs a fresh getComputedStyle read on every scroll
   // event. Cache it here and refresh only when syncTop() actually runs.
-  let stickyTopCache = getStickyTop();
+  let stickyTopCache = 0;
 
   const syncTop = () => {
     cardsContainer.style.setProperty('--ct-nav-height', `${getGnavHeight()}px`);
     stickyTopCache = getStickyTop();
   };
+  syncTop();
 
   const syncHeaderHeight = () => {
     if (isMobile()) { headerContent.style.minHeight = ''; return; }


### PR DESCRIPTION
## What/why
- The `resize` listener called `removeCollapsed()` synchronously on every event; batched into a single `requestAnimationFrame` per resize burst to avoid redundant layout work.
- `getStickyTop()` (a `getComputedStyle` call) ran on every `scroll` event even though the value only changes when `syncTop()` runs (nav height/breakpoint change). Cached it and only refresh on `syncTop()`.
- Swapped the block-local `getNavHeight()` calculation for the shared `getGnavHeight()` utility from `global-navigation/utilities.js`, so it stays consistent with the rest of the codebase instead of maintaining a duplicate nav-height calc.

Resolves: [MWPW-204799](https://jira.corp.adobe.com/browse/MWPW-204799)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205/ace1205-plans?milolibs=stage&georouting=off
- After: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205/ace1205-plans?milolibs=sr-perf-dd-comparison-table-c2&georouting=off








