### PR TITLE
[MWPW-204802] - Perf: scope will-change to active hover-list layer only

### DIFF
--- a/libs/c2/blocks/hover-list/hover-list.css
+++ b/libs/c2/blocks/hover-list/hover-list.css
@@ -185,6 +185,9 @@
     position: absolute;
     top: 0;
     transform-origin: 50% 100%;
+  }
+
+  .hover-list-media picture.is-active {
     will-change: transform, opacity;
   }
 }

--- a/libs/c2/blocks/hover-list/hover-list.js
+++ b/libs/c2/blocks/hover-list/hover-list.js
@@ -36,6 +36,7 @@ function renderLayer(layer) {
   const { config: c, pic } = layer;
   const fade = (1 - layer.exit) ** 1.9;
   const scale = introScale(layer.intro);
+  pic.classList.add('is-active');
   pic.style.transform = `translate3d(${layer.x + c.stagger.x}px, ${layer.y + c.stagger.y}px, 0) translate(-50%, -100%) scale(${scale}) rotate(${layer.rotate}deg)`;
   pic.style.opacity = String(fade);
 }
@@ -44,6 +45,7 @@ function hideMedia(media) {
   if (!media) return;
   if (media.matches(':popover-open')) media.hidePopover();
   media.querySelectorAll('picture').forEach((p) => {
+    p.classList.remove('is-active');
     p.style.transform = '';
     p.style.opacity = '';
   });


### PR DESCRIPTION
## What/why
- `will-change: transform, opacity` was applied to every `.hover-list-media picture`, including inactive/off-screen layers, forcing the browser to keep GPU compositing layers alive for media that isn't animating.
- Added an `is-active` class toggled in `renderLayer`/`hideMedia`, and scoped the `will-change` CSS rule to `picture.is-active` only, so the promotion only applies while a layer is actually transitioning.


Resolves: [MWPW-204802](https://jira.corp.adobe.com/browse/MWPW-204802)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205/ace1205-product?milolibs=stage&georouting=off
- After: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205/ace1205-product?milolibs=sr-perf-dd-hover-list&georouting=off


