### PR TITLE
[SR] Tabs Block - General fixes, accessibility, and bug fixes (Wave 3)

### DIFF
--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -129,56 +129,61 @@
         margin: 0;
       }
 
-      button.tab-button {
+      .btn-wrapper {
         display: flex;
+        flex-direction: row;
         align-items: center;
         gap: var(--s2a-spacing-xs);
-        height: auto;
+      }
+
+      input.tab-button {
+        appearance: none;
+        box-sizing: border-box;
+        margin: 0;
+        width: 20px;
+        height: 20px;
+        min-width: 20px;
         flex: 0 0 auto;
-        padding: 0;
+        border: 2px solid var(--s2a-color-gray-400);
+        border-radius: 100%;
         background: transparent;
-        border: none;
+        cursor: pointer;
+        outline: none;
+        -webkit-tap-highlight-color: transparent;
+        transition: border 150ms;
+      }
+
+      .tab-button-label {
         color: var(--s2a-color-content-subtle);
         cursor: pointer;
         font-family: var(--body-font-family);
         text-decoration: none;
-        outline: none;
-        -webkit-tap-highlight-color: transparent;
         white-space: nowrap;
+      }
 
-        &::before {
-          content: '';
-          box-sizing: border-box;
-          width: 20px;
-          height: 20px;
-          min-width: 20px;
-          border: 2px solid var(--s2a-color-gray-400);
-          border-radius: 100%;
-          transition: border 150ms;
+      .btn-wrapper:hover {
+        input.tab-button {
+          border-color: var(--pill-bg-color-selected);
         }
 
-        &:hover {
+        .tab-button-label {
           color: var(--s2a-color-content-default);
-
-          &::before {
-            border-color: var(--pill-bg-color-selected);
-          }
         }
+      }
 
-        &[aria-checked="true"] {
+      input.tab-button:checked {
+        border-color: var(--pill-bg-color-selected);
+        background: var(--pill-bg-color-selected);
+        box-shadow: inset 0 0 0 4px var(--s2a-color-background-subtle);
+
+        + .tab-button-label {
           color: var(--s2a-color-content-default);
-
-          &::before {
-            border-color: var(--pill-bg-color-selected);
-            background: var(--pill-bg-color-selected);
-            box-shadow: inset 0 0 0 4px var(--s2a-color-background-subtle);
-          }
         }
+      }
 
-        &:focus-visible {
-          outline: 2px solid var(--s2a-color-blue-800);
-          outline-offset: 2px;
-        }
+      input.tab-button:focus-visible {
+        outline: 2px solid var(--s2a-color-blue-800);
+        outline-offset: 2px;
       }
     }
   }
@@ -189,13 +194,13 @@
         background: var(--s2a-color-background-default);
       }
 
-      button.tab-button[aria-checked="true"]::before {
+      input.tab-button:checked {
         border-color: var(--s2a-color-background-inverse);
         background: var(--s2a-color-background-inverse);
         box-shadow: inset 0 0 0 4px var(--s2a-color-background-default);
       }
 
-      button.tab-button:hover::before {
+      .btn-wrapper:hover input.tab-button {
         border-color: var(--s2a-color-background-inverse);
       }
     }

--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -227,7 +227,7 @@
         border-radius: 0;
         border-width: 0;
         border-bottom: var(--s2a-border-width-md) solid transparent;
-        padding: var(--s2a-spacing-3xs) 0;
+        padding: var(--s2a-spacing-3xs) 0 var(--s2a-spacing-2xs);
         height: auto;
         flex: 0 0 auto;
         color: var(--s2a-color-content-subtle);
@@ -236,7 +236,6 @@
           background: transparent;
           color: var(--s2a-color-content-default);
           border-bottom-color: var(--s2a-color-blue-800);
-          padding-bottom: var(--s2a-spacing-2xs);
         }
       }
     }

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -187,13 +187,18 @@ function initTabs(elm, config, rootElem) {
   const tabLists = elm.querySelectorAll(':scope > .tabs-wrapper [role="tablist"], :scope > .tabs-wrapper [role="radiogroup"]');
   let tabFocus = 0;
   tabLists.forEach((tabList) => {
+    const isRadioGroup = tabList.getAttribute('role') === 'radiogroup';
+    const keys = isRadioGroup
+      ? ['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp']
+      : ['ArrowRight', 'ArrowLeft'];
     tabList.addEventListener('keydown', (e) => {
-      if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
-      const forward = e.key === (document.dir === 'rtl' ? 'ArrowLeft' : 'ArrowRight');
+      if (!keys.includes(e.key)) return;
+      const forward = e.key === 'ArrowDown' || e.key === (document.dir === 'rtl' ? 'ArrowLeft' : 'ArrowRight');
       tabFocus = (tabFocus + (forward ? 1 : -1) + tabs.length) % tabs.length;
       tabs.forEach((t) => t.setAttribute('tabindex', '-1'));
       tabs[tabFocus].setAttribute('tabindex', '0');
       tabs[tabFocus].focus();
+      if (tabs[tabFocus].getAttribute('role') === 'radio') tabs[tabFocus].click();
     });
   });
   tabs.forEach((tab) => {

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -92,9 +92,8 @@ function moveIndicator(indicator, target, container) {
 
 function changeTabs(e, config) {
   const { target } = e;
-  const isRadio = target.getAttribute('role') === 'radio';
-  const attributeName = isRadio ? 'aria-checked' : 'aria-selected';
-  if (target.getAttribute(attributeName) === 'true') return;
+  const isRadio = target.matches('input[type="radio"]');
+  if (!isRadio && target.getAttribute('aria-selected') === 'true') return;
   const targetId = target.getAttribute('id');
   const redirectionUrl = getRedirectionUrl(linkedTabs, targetId);
   /* c8 ignore next 4 */
@@ -111,17 +110,26 @@ function changeTabs(e, config) {
     ? content.querySelector(`#${target.getAttribute('data-control-id')}`)
     : content.querySelector(`#${target.getAttribute('aria-controls')}`);
 
-  parent.querySelectorAll(`[${attributeName}="true"][data-block-id="${blockId}"]`).forEach((t) => {
-    t.setAttribute(attributeName, 'false');
-    t.setAttribute('tabindex', '-1');
-    if (Object.keys(tabColor).length) t.style.backgroundColor = '';
-  });
-  target.setAttribute(attributeName, 'true');
-  target.setAttribute('tabindex', '0');
+  if (isRadio) {
+    if (Object.keys(tabColor).length) {
+      parent.querySelectorAll(`input[type="radio"][data-block-id="${blockId}"]`).forEach((t) => {
+        if (t !== target) t.style.backgroundColor = '';
+      });
+      if (tabColor[targetId]) target.style.backgroundColor = tabColor[targetId];
+    }
+  } else {
+    parent.querySelectorAll(`[aria-selected="true"][data-block-id="${blockId}"]`).forEach((t) => {
+      t.setAttribute('aria-selected', 'false');
+      t.setAttribute('tabindex', '-1');
+      if (Object.keys(tabColor).length) t.style.backgroundColor = '';
+    });
+    target.setAttribute('aria-selected', 'true');
+    target.setAttribute('tabindex', '0');
+    if (tabColor[targetId]) target.style.backgroundColor = tabColor[targetId];
+  }
 
   const indicator = parent.querySelector('.tab-indicator');
   if (indicator) moveIndicator(indicator, target, parent);
-  if (tabColor[targetId]) target.style.backgroundColor = tabColor[targetId];
   scrollTabIntoView(target);
   content.querySelectorAll(`.tabpanel[data-block-id="${blockId}"]`).forEach((p) => {
     p.setAttribute('hidden', true);
@@ -183,26 +191,25 @@ function configTabs(config, rootElem) {
 }
 
 function initTabs(elm, config, rootElem) {
-  const tabs = elm.querySelectorAll(':scope > .tabs-wrapper [role="tab"], :scope > .tabs-wrapper [role="radio"]');
+  const tabs = elm.querySelectorAll(':scope > .tabs-wrapper [role="tab"], :scope > .tabs-wrapper input[type="radio"]');
   const tabLists = elm.querySelectorAll(':scope > .tabs-wrapper [role="tablist"], :scope > .tabs-wrapper [role="radiogroup"]');
   let tabFocus = 0;
   tabLists.forEach((tabList) => {
-    const isRadioGroup = tabList.getAttribute('role') === 'radiogroup';
-    const keys = isRadioGroup
-      ? ['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp']
-      : ['ArrowRight', 'ArrowLeft'];
+    // Radiogroups get keyboard nav, focus roving, and RTL support natively via <input type="radio">
+    // elements, so no custom keydown handling is attached for them here.
+    if (tabList.getAttribute('role') === 'radiogroup') return;
     tabList.addEventListener('keydown', (e) => {
-      if (!keys.includes(e.key)) return;
-      const forward = e.key === 'ArrowDown' || e.key === 'ArrowRight';
+      if (!['ArrowRight', 'ArrowLeft'].includes(e.key)) return;
+      const forward = e.key === 'ArrowRight';
       tabFocus = (tabFocus + (forward ? 1 : -1) + tabs.length) % tabs.length;
       tabs.forEach((t) => t.setAttribute('tabindex', '-1'));
       tabs[tabFocus].setAttribute('tabindex', '0');
       tabs[tabFocus].focus();
-      if (tabs[tabFocus].getAttribute('role') === 'radio') tabs[tabFocus].click();
     });
   });
   tabs.forEach((tab) => {
-    tab.addEventListener('click', (e) => changeTabs(e, config));
+    const isRadio = tab.matches('input[type="radio"]');
+    tab.addEventListener(isRadio ? 'change' : 'click', (e) => changeTabs(e, config));
     tab.addEventListener('focus', () => scrollTabIntoView(tab));
   });
   configTabs(config, rootElem);
@@ -287,26 +294,45 @@ const init = async (block) => {
     if (tabListLabel) tabList.setAttribute('aria-label', tabListLabel);
   }
 
+  const radioGroupName = `tabs-radio-${tabId}`;
   const tabListItems = rows[0].querySelectorAll(':scope li');
   if (tabListItems.length) {
     tabListItems.forEach((item, i) => {
       const tabName = config.id ? i + 1 : getStringKeyName(item.textContent);
       const controlId = `tab-panel-${tabId}-${tabName}`;
       const btnId = `tab-${tabId}-${tabName}`;
-      const tabBtnAttributes = {
-        role: isRadio ? 'radio' : 'tab',
-        class: isQuiet ? 'tab-button heading-4' : 'tab-button label',
-        id: btnId,
-        tabindex: (i === 0) ? '0' : '-1',
-        [isRadio ? 'aria-checked' : 'aria-selected']: (i === 0) ? 'true' : 'false',
-        'data-block-id': `tabs-${tabId}`,
-        'daa-state': 'true',
-        'daa-ll': btnId,
-        ...(isRadio ? { 'data-control-id': controlId } : { 'aria-controls': controlId }),
-      };
-      const tabBtn = createTag('button', tabBtnAttributes, item.textContent);
       const btnWrapper = createTag('div', { class: 'btn-wrapper' });
-      btnWrapper.append(tabBtn);
+
+      if (isRadio) {
+        const radioAttributes = {
+          type: 'radio',
+          class: 'tab-button',
+          id: btnId,
+          name: radioGroupName,
+          'data-block-id': `tabs-${tabId}`,
+          'data-control-id': controlId,
+          'daa-state': 'true',
+          'daa-ll': btnId,
+          ...(i === 0 ? { checked: '' } : {}),
+        };
+        const radioInput = createTag('input', radioAttributes);
+        const radioLabel = createTag('label', { for: btnId, class: 'tab-button-label label' }, item.textContent);
+        btnWrapper.append(radioInput, radioLabel);
+      } else {
+        const tabBtnAttributes = {
+          role: 'tab',
+          class: isQuiet ? 'tab-button heading-4' : 'tab-button label',
+          id: btnId,
+          tabindex: (i === 0) ? '0' : '-1',
+          'aria-selected': (i === 0) ? 'true' : 'false',
+          'data-block-id': `tabs-${tabId}`,
+          'daa-state': 'true',
+          'daa-ll': btnId,
+          'aria-controls': controlId,
+        };
+        const tabBtn = createTag('button', tabBtnAttributes, item.textContent);
+        btnWrapper.append(tabBtn);
+      }
       tabListContainer.append(btnWrapper);
 
       const tabContentAttributes = {
@@ -370,7 +396,7 @@ const init = async (block) => {
   initTabs(block, config, rootElem);
 
   requestAnimationFrame(() => {
-    const activeTab = tabListContainer.querySelector('[aria-selected="true"], [aria-checked="true"]');
+    const activeTab = tabListContainer.querySelector('[aria-selected="true"], input[type="radio"]:checked');
     if (activeTab) {
       if (indicator) {
         indicator.style.transition = 'none';

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -196,9 +196,7 @@ function initTabs(elm, config, rootElem) {
   tabLists.forEach((tabList) => {
     const isRadioGroup = tabList.getAttribute('role') === 'radiogroup';
     tabList.addEventListener('keydown', (e) => {
-      // Left/Right on radio inputs are left to the browser: Chrome and Firefox already flip
-      // them for RTL natively. Up/Down aren't part of that native Left/Right mapping, so they're
-      // handled here, driving the same focus+select behavior manually via focus() + click().
+      // Left/Right are native (Chrome/Firefox flip for RTL) - only Up/Down need manual handling.
       if (isRadioGroup) {
         if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
         e.preventDefault();

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -112,10 +112,9 @@ function changeTabs(e, config) {
 
   if (isRadio) {
     if (Object.keys(tabColor).length) {
-      parent.querySelectorAll(`input[type="radio"][data-block-id="${blockId}"]`).forEach((t) => {
+      parent.querySelectorAll('input[type="radio"]').forEach((t) => {
         if (t !== target) t.style.backgroundColor = '';
       });
-      if (tabColor[targetId]) target.style.backgroundColor = tabColor[targetId];
     }
   } else {
     parent.querySelectorAll(`[aria-selected="true"][data-block-id="${blockId}"]`).forEach((t) => {
@@ -125,8 +124,8 @@ function changeTabs(e, config) {
     });
     target.setAttribute('aria-selected', 'true');
     target.setAttribute('tabindex', '0');
-    if (tabColor[targetId]) target.style.backgroundColor = tabColor[targetId];
   }
+  if (tabColor[targetId]) target.style.backgroundColor = tabColor[targetId];
 
   const indicator = parent.querySelector('.tab-indicator');
   if (indicator) moveIndicator(indicator, target, parent);
@@ -191,16 +190,28 @@ function configTabs(config, rootElem) {
 }
 
 function initTabs(elm, config, rootElem) {
-  const tabs = elm.querySelectorAll(':scope > .tabs-wrapper [role="tab"], :scope > .tabs-wrapper input[type="radio"]');
+  const tabs = [...elm.querySelectorAll(':scope > .tabs-wrapper [role="tab"], :scope > .tabs-wrapper input[type="radio"]')];
   const tabLists = elm.querySelectorAll(':scope > .tabs-wrapper [role="tablist"], :scope > .tabs-wrapper [role="radiogroup"]');
   let tabFocus = 0;
   tabLists.forEach((tabList) => {
-    // Radiogroups get keyboard nav, focus roving, and RTL support natively via <input type="radio">
-    // elements, so no custom keydown handling is attached for them here.
-    if (tabList.getAttribute('role') === 'radiogroup') return;
+    const isRadioGroup = tabList.getAttribute('role') === 'radiogroup';
     tabList.addEventListener('keydown', (e) => {
-      if (!['ArrowRight', 'ArrowLeft'].includes(e.key)) return;
-      const forward = e.key === 'ArrowRight';
+      // Left/Right on radio inputs are left to the browser: Chrome and Firefox already flip
+      // them for RTL natively. Up/Down aren't part of that native Left/Right mapping, so they're
+      // handled here, driving the same focus+select behavior manually via focus() + click().
+      if (isRadioGroup) {
+        if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+        e.preventDefault();
+        const forward = e.key === 'ArrowDown';
+        const currentFocus = tabs.indexOf(e.target);
+        const nextFocus = (currentFocus + (forward ? 1 : -1) + tabs.length) % tabs.length;
+        tabs[nextFocus].focus();
+        tabs[nextFocus].click();
+        return;
+      }
+      if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+      const isRtl = document.dir === 'rtl';
+      const forward = e.key === (isRtl ? 'ArrowLeft' : 'ArrowRight');
       tabFocus = (tabFocus + (forward ? 1 : -1) + tabs.length) % tabs.length;
       tabs.forEach((t) => t.setAttribute('tabindex', '-1'));
       tabs[tabFocus].setAttribute('tabindex', '0');

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -193,7 +193,7 @@ function initTabs(elm, config, rootElem) {
       : ['ArrowRight', 'ArrowLeft'];
     tabList.addEventListener('keydown', (e) => {
       if (!keys.includes(e.key)) return;
-      const forward = e.key === 'ArrowDown' || e.key === (document.dir === 'rtl' ? 'ArrowLeft' : 'ArrowRight');
+      const forward = e.key === 'ArrowDown' || e.key === 'ArrowRight';
       tabFocus = (tabFocus + (forward ? 1 : -1) + tabs.length) % tabs.length;
       tabs.forEach((t) => t.setAttribute('tabindex', '-1'));
       tabs[tabFocus].setAttribute('tabindex', '0');

--- a/libs/mep/ace1209/tabs/tabs.js
+++ b/libs/mep/ace1209/tabs/tabs.js
@@ -314,16 +314,14 @@ const init = async (block) => {
       const btnId = `tab-${tabId}-${tabName}`;
       const btnWrapper = createTag('div', { class: 'btn-wrapper' });
 
+      const sharedAttrs = { id: btnId, 'data-block-id': `tabs-${tabId}`, 'daa-state': 'true', 'daa-ll': btnId };
       if (isRadio) {
         const radioAttributes = {
+          ...sharedAttrs,
           type: 'radio',
           class: 'tab-button',
-          id: btnId,
           name: radioGroupName,
-          'data-block-id': `tabs-${tabId}`,
           'data-control-id': controlId,
-          'daa-state': 'true',
-          'daa-ll': btnId,
           ...(i === 0 ? { checked: '' } : {}),
         };
         const radioInput = createTag('input', radioAttributes);
@@ -331,14 +329,11 @@ const init = async (block) => {
         btnWrapper.append(radioInput, radioLabel);
       } else {
         const tabBtnAttributes = {
+          ...sharedAttrs,
           role: 'tab',
           class: isQuiet ? 'tab-button heading-4' : 'tab-button label',
-          id: btnId,
           tabindex: (i === 0) ? '0' : '-1',
           'aria-selected': (i === 0) ? 'true' : 'false',
-          'data-block-id': `tabs-${tabId}`,
-          'daa-state': 'true',
-          'daa-ll': btnId,
           'aria-controls': controlId,
         };
         const tabBtn = createTag('button', tabBtnAttributes, item.textContent);


### PR DESCRIPTION
This PR introduces UI fixes, accessibility compliance items, and general refactors to wave 3 `tabs` ACE1209 block.

**Added features/changes**
- Convert the `radio` variant tabs from `<button role="radio">` to native `<input type="radio">` (accessibility refactor)
- Bring RTL-correct keyboard nav to all variants (accessibility refactor)
- Fix layout jump on the `quiet` variant [MWPW-204082](https://jira.corp.adobe.com/browse/MWPW-204082)

**Rationale**
The old implementation had hardcoded keyboard nav (arrow-key focus cycling, force-click-to-select) and manual `aria-checked`/tabindex tracking to fake what a native radio input already does for free - keyboard nav, focus roving, mutual exclusivity, and RTL-aware Left/Right direction.

Also fixed the tab/pill/quiet variant's arrow-key handler, which was hardcoded LTR-only - turned out C1's tabs block already solves this correctly (`document.dir === 'rtl'` check, flips which key means "forward"), so ace1209 just needed the same fix ported back in.

**Changes overview**
**`tabs.js`**
- Radio tabs now render as `<input type="radio" name="tabs-radio-{tabId}">` + sibling `<label for>`, dropping `role="radio"`, `aria-checked`, and manual `tabindex`. Radio inputs listen on `change` instead of `click` (matches how native arrow-key selection actually fires events). `changeTabs()` branches so the radio path only handles the one thing native behavior doesn't know about: the custom `tab-background` color override.
- Left/Right on radio is left entirely to the browser (native, RTL-correct in Chrome/Firefox).
- Up/Down reinstated for radio only, matching what this block did before the input conversion - rewritten to not fight native Left/Right handling (`preventDefault` only on Up/Down, current index read off `e.target` instead of a shared counter that native movement wouldn't update).
- Tab/pill/quiet's Left/Right handler now checks `document.dir === 'rtl'` and flips forward/backward, matching `libs/blocks/tabs/tabs.js`.
- Moved shared attributes between different tab variants to a single variable. 

**To consider**
- Tracking is confirmed for `radio` buttons that are nested within a `quiet` tab container! Confirmable by checking `collect` network calls per focus change (keyboard navigation) or actual click. 
- TODO: Deeplinking feature for muli level tabs to REMEMBER placement (requires cookie logic changes- does not affect wave 3 requirements)

**QA Links** 
- Base/Light
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-pill-light?milolibs=sr3-tabs-autoselect

- Base/Dark
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-pill-dark?milolibs=sr3-tabs-autoselect

- Radio/Light
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-radio-light?milolibs=sr3-tabs-autoselect

- Radio/Dark/RTL
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-radio-dark?milolibs=sr3-tabs-autoselect

