### PR TITLE
[MWPW-204859] - Fix forced reflow in brand-concierge floating-element scroll handler

### DIFF
--- a/libs/c2/blocks/brand-concierge/brand-concierge.js
+++ b/libs/c2/blocks/brand-concierge/brand-concierge.js
@@ -40,7 +40,11 @@ const getTargetHeight = (target) => {
 };
 
 function floatingElement(targetEl, el, focusableEl = null) {
+  // handleScroll calls these unconditionally on most scroll frames; bail out
+  // when the target is already in the requested state to avoid a style
+  // recalc (classList + attribute writes) on every single rAF tick.
   const hideFloating = () => {
+    if (targetEl.classList.contains('bc-floating-hidden')) return;
     if (focusableEl) {
       focusableEl.setAttribute('aria-hidden', 'true');
       focusableEl.setAttribute('tabindex', '-1');
@@ -51,6 +55,7 @@ function floatingElement(targetEl, el, focusableEl = null) {
   };
 
   const showFloating = () => {
+    if (targetEl.classList.contains('bc-floating-show')) return;
     if (focusableEl) {
       focusableEl.removeAttribute('aria-hidden');
       focusableEl.removeAttribute('tabindex');
@@ -92,9 +97,14 @@ function floatingElement(targetEl, el, focusableEl = null) {
     hideFloating();
   }
 
+  let lastBottomPx = null;
+  let lastSpacerCssText = null;
   const handleScroll = (target) => {
     // only values that need to be calculated on scroll are here, to optimize performance
-    const threshold = window.scrollY + window.innerHeight - mainTop;
+    // scrollY is read once and reused below — re-reading it after the style writes further
+    // down in this function would force a synchronous layout flush of those writes.
+    const { scrollY } = window;
+    const threshold = scrollY + window.innerHeight - mainTop;
     const topDelay = variants.floatingDelay ? variants.floatingDelayAmount : elHeight;
     const bottomValue = threshold - mainHeight;
 
@@ -104,21 +114,31 @@ function floatingElement(targetEl, el, focusableEl = null) {
     }
 
     if (threshold > mainHeight) {
-      target.style.bottom = `${bottomValue}px`;
+      if (lastBottomPx !== bottomValue) {
+        target.style.bottom = `${bottomValue}px`;
+        lastBottomPx = bottomValue;
+      }
       if (variants.isFloatingAnchorHide || variants.floatingAnchorDelay) {
         hideFloating();
       } else {
-        floatingSpacer.style.cssText = `height: ${targetHeight}px; pointer-events: none; display: block;`;
+        const spacerCssText = `height: ${targetHeight}px; pointer-events: none; display: block;`;
+        if (lastSpacerCssText !== spacerCssText) {
+          floatingSpacer.style.cssText = spacerCssText;
+          lastSpacerCssText = spacerCssText;
+        }
       }
     } else {
       showFloating();
-      target.style.bottom = '0';
+      if (lastBottomPx !== 0) {
+        target.style.bottom = '0';
+        lastBottomPx = 0;
+      }
     }
     if (hasDelay) {
-      if (window.scrollY > topDelay && threshold <= mainHeight) {
+      if (scrollY > topDelay && threshold <= mainHeight) {
         showFloating();
       }
-      if (window.scrollY < topDelay
+      if (scrollY < topDelay
         || (variants.floatingAnchorDelay && threshold > mainHeight - anchorDelay)) {
         hideFloating();
       }


### PR DESCRIPTION
## What/why
- `handleScroll` read `window.scrollY` twice per call, with a `target.style.bottom` write in between. `scrollY`/`innerHeight` force a synchronous layout flush when there's a pending style write (classic layout-thrashing pattern), so every scroll frame paid for a 200ms forced reflow. Read `scrollY` once and reuse it.
- `hideFloating()`/`showFloating()` ran their classList + `aria-hidden`/`tabindex` attribute writes unconditionally on every scroll frame, even during the long stretches where the floating element's state doesn't change (which is most of a page's scroll length). Added an early return when the target is already in the requested state.
- `target.style.bottom` and the spacer's `cssText` were rewritten every scroll frame even when the computed value was identical to the last write. Cached the last-written values and skip the DOM write when unchanged — the value is still recalculated fresh every frame, only the redundant write is skipped.

<img width="523" height="89" alt="Screenshot 2026-08-19 at 11 35 14" src="https://github.com/user-attachments/assets/8f03548e-d9fe-4afb-bd5a-a9791bab2d04" />


Resolves: [MWPW-204859](https://jira.corp.adobe.com/browse/MWPW-204859)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205/ace1205-product?milolibs=stage&georouting=off
- After: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205/ace1205-product?milolibs=sr-perf-dd-brand-concierge-floating&georouting=off


