### PR TITLE
[SR] MWPW-204679: Split Aside Grid VQA updates

### DIFF
--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
@@ -111,7 +111,9 @@
       .media {
         position: static;
         height: auto;
-        min-width: 200%;
+        flex-shrink: 0;
+        /* Cap width so aspect-ratio keeps height at/under 600px while staying 16:9. */
+        width: min(200%, calc(600px * 16 / 9));
         transform: none;
         aspect-ratio: 16 / 9;
       }
@@ -201,6 +203,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-wrap: pretty;
 
   &:not(.split-aside-grid-active) {
     visibility: hidden;
@@ -407,7 +410,7 @@
 
   .split-aside-grid-toggle {
     display: inline-flex;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--grid-item-header-gap);
     flex-shrink: 0;
     background: transparent;
@@ -474,7 +477,6 @@
 
 @media (width >= 1600px) {
   .split-aside-grid-stack {
-    padding-inline-end: var(--grid-padding);
     inset-inline-end: unset;
   }
 }


### PR DESCRIPTION
## MWPW-204679 — [C2 Block] Split Aside update

Design VQA follow-ups on the Split Aside Grid (`libs/mep/ace1209/split-aside-grid`), from the CPro review.

### What changed (CSS only, one file)

1. **Mobile: cap media height at 600px while keeping 16:9.** The media area was getting too tall near 767px. Instead of a hard `max-height` (which flattens the box against `aspect-ratio`), the width is clamped to `min(200%, calc(600px * 16 / 9))` so `aspect-ratio: 16/9` drives the height to ≤600px. `flex-shrink: 0` replaces the old `min-width: 200%` to keep the carousel slide from collapsing.
2. **`text-wrap: pretty`** on the item contents.
3. **Top-align the accordion toggle** icon + text on desktop (`align-items: center` → `flex-start`); previously center-aligned.
4. **XL (≥1600px): media sits flush** with the grid on the right (removed the right `padding-inline-end`).

Out of scope per the ticket (intentionally untouched): media aspect ratio stays 16:9 (not 4:3), and rounded corners are unchanged. Both verified intact.

### Testing

Verified on the CPro test page with local libs, and independently re-tested in a clean review pass:

- Mobile 375px → media 654×368 (16:9); 767px → 1067×600 (16:9, capped) — no collapse, no distortion.
- Mobile carousel still slides correctly (stack translate advances by exactly one slide; no desync).
- Desktop: toggle icon pinned to top even when the label wraps to multiple lines.
- XL ≥1600px: stack right edge flush with grid (gap 0); mid sizes keep existing spacing.
- Rounded corners (28px/20px) and 16:9 aspect ratio unchanged.

Resolves: [MWPW-204679](https://jira.corp.adobe.com/browse/MWPW-204679)

- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=split-aside-grid-updates&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


🤖 Generated with [Claude Code](https://claude.com/claude-code)


