### PR TITLE
[MWPW-204845] - Parallax promo gap fix

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1393,7 +1393,7 @@ span.hang-opening-quote {
   /* Section 1 to section 2 parallax declarations */
   /* TODO: decide if this is general enough to be a global class */
   .section.parallax-move-up-fast {
-    --parallax-move-up-to: -35vh;
+    --parallax-move-up-to: calc(var(--feds-promo-bar-height, 0px) - 35vh);
 
     will-change: transform;
     position: sticky;
@@ -1406,7 +1406,7 @@ span.hang-opening-quote {
 
     /* Shorter viewports in the common laptop width band need more travel */
     @media (width >= 1280px) and (width < 1440px) and (height < 900px) {
-      --parallax-move-up-to: -50vh;
+      --parallax-move-up-to: calc(var(--feds-promo-bar-height, 0px) - 50vh);
     }
 
     &::after {


### PR DESCRIPTION
Fixes gap on homepage from promo banner being added.

https://jira.corp.adobe.com/browse/MWPW-204845

**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/homepage/index-loggedout?mep=%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fen-lingo-ip%2Fen-lingo-ip.json--countryip%28ie%29---%2Fhomepage%2Fmanifests%2F2026%2Flingo-customization%2Ffooter-de-kr%2Fseparate-de.json--default---%2Fhomepage%2Fmanifests%2F2026%2Flingo-customization%2Ffooter-de-kr%2Fseparate-kr.json--default---%2Fhomepage%2Fmanifests%2F2026%2Flatam%2Fbts-q3-promo%2Fus-bts-q3-promo-190753.json--all---%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fff-ext-q4%2Fff-ext-q4-en-lingo-192863.json--default---%2Fhomepage%2Ffragments%2Fmep%2Fhp-06-02-26-redesign-pzn.json--default
- After: https://main--upp--adobecom.aem.page/homepage/index-loggedout?mep=%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fen-lingo-ip%2Fen-lingo-ip.json--countryip%28ie%29---%2Fhomepage%2Fmanifests%2F2026%2Flingo-customization%2Ffooter-de-kr%2Fseparate-de.json--default---%2Fhomepage%2Fmanifests%2F2026%2Flingo-customization%2Ffooter-de-kr%2Fseparate-kr.json--default---%2Fhomepage%2Fmanifests%2F2026%2Flatam%2Fbts-q3-promo%2Fus-bts-q3-promo-190753.json--all---%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fff-ext-q4%2Fff-ext-q4-en-lingo-192863.json--default---%2Fhomepage%2Ffragments%2Fmep%2Fhp-06-02-26-redesign-pzn.json--default&milolibs=parallax-promo-fix


