### PR TITLE
VQA changes for roller carousel

### DIFF
--- a/libs/mep/ace1209/roller-carousel/roller-carousel.css
+++ b/libs/mep/ace1209/roller-carousel/roller-carousel.css
@@ -1,6 +1,9 @@
 .roller-carousel {
   background: var(--s2a-color-background-knockout);
   color: var(--s2a-color-content-knockout);
+  --gnav-offset: 72px;
+  --rcc-top-gap: 40px;
+  --rcc-sticky-top: var(--gnav-offset);
 
   .rcc-scroll-wrapper {
     position: relative;
@@ -9,8 +12,8 @@
 
   .rcc-sticky {
     position: sticky;
-    top: 0;
-    height: 100dvh;
+    top: var(--rcc-sticky-top);
+    height: calc(100dvh - var(--rcc-sticky-top));
     overflow: hidden;
   }
 
@@ -43,7 +46,7 @@
     img {
       width: 100%;
       height: 100%;
-      object-fit: cover;
+      object-fit: fill;
       filter: blur(145px);
     }
   }
@@ -60,7 +63,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    padding: var(--s2a-layout-md) var(--s2a-spacing-lg) 0;
+    padding: var(--rcc-top-gap) var(--s2a-spacing-lg) 0;
     box-sizing: border-box;
   }
 
@@ -152,6 +155,7 @@
     max-width: 70vw;
     border-radius: var(--s2a-border-radius-sm);
     overflow: hidden;
+    background: #000;
   }
 
   .rcc-media-icon {
@@ -203,12 +207,12 @@
     }
 
     .rcc-content {
-      padding-top: 0;
+      padding-top: var(--rcc-top-gap);
     }
 
     .rcc-sticky {
-      top: var(--s2a-layout-sm);
-      height: calc(100dvh - var(--s2a-layout-sm));
+      top: var(--rcc-sticky-top);
+      height: calc(100dvh - var(--rcc-sticky-top));
     }
   }
 
@@ -264,12 +268,16 @@
   }
 }
 
+body:has(header.has-breadcrumbs) .roller-carousel {
+  --rcc-sticky-top: calc(var(--gnav-offset) + var(--feds-height-breadcrumbs, 33px));
+}
+
+body:has(header.local-nav) .roller-carousel {
+  --rcc-sticky-top: calc(var(--gnav-offset) + var(--feds-localnav-height, 40px));
+}
+
 @media (width >= 768px) {
   .roller-carousel {
-    .rcc-content {
-      padding-top: var(--s2a-layout-lg);
-    }
-
     .rcc-item {
       font-size: var(--s2a-typography-font-size-heading-1);
       line-height: var(--s2a-typography-line-height-heading-1);
@@ -292,6 +300,12 @@
 }
 
 @media (width >= 1280px) {
+  .roller-carousel,
+  body:has(header.has-breadcrumbs) .roller-carousel,
+  body:has(header.local-nav) .roller-carousel {
+    --rcc-sticky-top: 0px;
+  }
+
   .roller-carousel {
     .rcc-content {
       flex-direction: row;

--- a/libs/mep/ace1209/roller-carousel/roller-carousel.css
+++ b/libs/mep/ace1209/roller-carousel/roller-carousel.css
@@ -269,11 +269,11 @@
 }
 
 body:has(header.has-breadcrumbs) .roller-carousel {
-  --rcc-sticky-top: calc(var(--gnav-offset) + var(--feds-height-breadcrumbs, 33px));
+  --rcc-sticky-top: calc(var(--global-height-nav, 64px) + var(--feds-height-breadcrumbs, 33px));
 }
 
 body:has(header.local-nav) .roller-carousel {
-  --rcc-sticky-top: calc(var(--gnav-offset) + var(--feds-localnav-height, 40px));
+  --rcc-sticky-top: calc(var(--global-height-nav, 64px) + var(--feds-localnav-height, 40px));
 }
 
 @media (width >= 768px) {

--- a/libs/mep/ace1209/roller-carousel/roller-carousel.css
+++ b/libs/mep/ace1209/roller-carousel/roller-carousel.css
@@ -1,9 +1,8 @@
 .roller-carousel {
   background: var(--s2a-color-background-knockout);
   color: var(--s2a-color-content-knockout);
-  --gnav-offset: 72px;
   --rcc-top-gap: 40px;
-  --rcc-sticky-top: var(--gnav-offset);
+  --rcc-sticky-top: var(--global-height-nav, 64px);
 
   .rcc-scroll-wrapper {
     position: relative;

--- a/libs/mep/ace1209/roller-carousel/roller-carousel.js
+++ b/libs/mep/ace1209/roller-carousel/roller-carousel.js
@@ -96,7 +96,9 @@ function parseContent(rows) {
     const prodIcon = row.querySelector('img');
     const isSvgIcon = prodIcon && isSvgUrl(prodIcon.src);
     if (isSvgIcon) prodIcon.src = getFederatedUrl(prodIcon.src);
-    const icon = isSvgIcon ? prodIcon : (pics.length > 1 ? pics[0] : null);
+    let icon = null;
+    if (isSvgIcon) icon = prodIcon;
+    else if (pics.length > 1) icon = pics[0];
     const picture = pics[pics.length - 1] ?? null;
     if (name) apps.push({ category: currentCategory, name, picture, icon });
   });
@@ -295,7 +297,7 @@ function createReflow({
 
 function initScroll(block, refs, apps) {
   const {
-    bg, scrollWrapper, content, left, header, carousel, sticky, categoryWrapper,
+    bg, scrollWrapper, content, left, header, carousel,
     categoryLabel, divider, listWrapper, list, media,
   } = refs;
 

--- a/libs/mep/ace1209/roller-carousel/roller-carousel.js
+++ b/libs/mep/ace1209/roller-carousel/roller-carousel.js
@@ -96,9 +96,8 @@ function parseContent(rows) {
     const prodIcon = row.querySelector('img');
     const isSvgIcon = prodIcon && isSvgUrl(prodIcon.src);
     if (isSvgIcon) prodIcon.src = getFederatedUrl(prodIcon.src);
-    let icon = null;
-    if (isSvgIcon) icon = prodIcon;
-    else if (pics.length > 1) icon = pics[0];
+    // eslint-disable-next-line no-nested-ternary
+    const icon = isSvgIcon ? prodIcon : (pics.length > 1 ? pics[0] : null);
     const picture = pics[pics.length - 1] ?? null;
     if (name) apps.push({ category: currentCategory, name, picture, icon });
   });

--- a/libs/mep/ace1209/roller-carousel/roller-carousel.js
+++ b/libs/mep/ace1209/roller-carousel/roller-carousel.js
@@ -93,11 +93,11 @@ function parseContent(rows) {
     }
     const name = cols[0]?.textContent?.trim() ?? '';
     const pics = [...row.querySelectorAll('picture')];
-    const svgIconImg = [...row.querySelectorAll('img')]
-      .find((img) => !img.closest('picture') && isSvgUrl(img.src));
-    if (svgIconImg) svgIconImg.src = getFederatedUrl(svgIconImg.getAttribute('src'));
-    const icon = svgIconImg || (pics.length > 1 ? pics[0] : null);
-    const picture = svgIconImg ? (pics[0] ?? null) : (pics.length > 1 ? pics[1] : (pics[0] ?? null));
+    const prodIcon = row.querySelector('img');
+    const isSvgIcon = prodIcon && isSvgUrl(prodIcon.src);
+    if (isSvgIcon) prodIcon.src = getFederatedUrl(prodIcon.src);
+    const icon = isSvgIcon ? prodIcon : (pics.length > 1 ? pics[0] : null);
+    const picture = pics[pics.length - 1] ?? null;
     if (name) apps.push({ category: currentCategory, name, picture, icon });
   });
 

--- a/libs/mep/ace1209/roller-carousel/roller-carousel.js
+++ b/libs/mep/ace1209/roller-carousel/roller-carousel.js
@@ -1,9 +1,12 @@
-import { createTag } from '../../../utils/utils.js';
+import { createTag, getFederatedUrl } from '../../../utils/utils.js';
 import { decorateViewportContent } from '../../../utils/decorate.js';
+
+const isSvgUrl = (url) => /\.svg(\?.*)?$/i.test(url || '');
 
 const SCROLL_PER_APP = 200;
 const M_BREAKPOINT = 1024;
 const L_BREAKPOINT = 1280;
+const S_BREAKPOINT = 768;
 const MIN_ROLLER_ROOM = 120;
 
 function prepPic(picture) {
@@ -90,8 +93,11 @@ function parseContent(rows) {
     }
     const name = cols[0]?.textContent?.trim() ?? '';
     const pics = [...row.querySelectorAll('picture')];
-    const icon = pics.length > 1 ? pics[0] : null;
-    const picture = pics.length > 1 ? pics[1] : (pics[0] ?? null);
+    const svgIconImg = [...row.querySelectorAll('img')]
+      .find((img) => !img.closest('picture') && isSvgUrl(img.src));
+    if (svgIconImg) svgIconImg.src = getFederatedUrl(svgIconImg.getAttribute('src'));
+    const icon = svgIconImg || (pics.length > 1 ? pics[0] : null);
+    const picture = svgIconImg ? (pics[0] ?? null) : (pics.length > 1 ? pics[1] : (pics[0] ?? null));
     if (name) apps.push({ category: currentCategory, name, picture, icon });
   });
 
@@ -177,6 +183,8 @@ function buildRoller(block, eyebrowEl, headingEl, apps) {
     left,
     header,
     carousel,
+    sticky,
+    categoryWrapper,
     categoryLabel,
     divider,
     listWrapper,
@@ -226,7 +234,7 @@ function createUpdatePosition({
     const itemH = items[0]?.offsetHeight || 32;
     let lineY;
     let bottomAlign;
-    if (block.classList.contains('rcc-reflow') || mediaHidden) {
+    if (mediaHidden || (block.classList.contains('rcc-reflow') && w >= S_BREAKPOINT)) {
       lineY = itemH * 0.5;
       bottomAlign = false;
     } else if (w >= L_BREAKPOINT) {
@@ -266,6 +274,11 @@ function createReflow({
   };
   return () => {
     const vh = window.innerHeight;
+    const w = window.innerWidth;
+    if (w < S_BREAKPOINT) {
+      setReflow(true);
+      return;
+    }
     if (!block.classList.contains('rcc-reflow')) {
       const dividerOffset = divider.getBoundingClientRect().bottom
         - content.getBoundingClientRect().top;
@@ -282,7 +295,7 @@ function createReflow({
 
 function initScroll(block, refs, apps) {
   const {
-    bg, scrollWrapper, content, left, header, carousel,
+    bg, scrollWrapper, content, left, header, carousel, sticky, categoryWrapper,
     categoryLabel, divider, listWrapper, list, media,
   } = refs;
 


### PR DESCRIPTION
Below are the changes based on VQA for roller carosuel.

1: Added a black background to the media foreground so that when the images change on scroll, the letters are not visible behind them.
2: Added localnav spacing so that the heading and eyebrow does hide behind the navbar
3: Changes the app names font to h2 for large breakpoint.
4: For mobile, the heading and eyebrow will scroll past the screen and the category heading will stick to the top.
5: Support for federal SVGs

Resolves: [[MWPW-204432](https://jira.corp.adobe.com/browse/MWPW-204432)](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all#legal-tour
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=roller-carousel-vqa&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all#legal-tour












