### PR TITLE
MWPW-204815 / MWPW-204887: Align side-by-side S viewport aspect ratio to Bento

### DIFF
--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -237,10 +237,8 @@
   }
 }
 
-:root:has(meta[name="foundation"][content="c2"]) {
-  @media (width < 768px) {
-    .side-by-side .card-overlay button.play-pause-button {
-      inset-block-start: var(--s2a-spacing-md);
-    }
+@media (width < 768px) {
+  .side-by-side .card-overlay button.play-pause-button {
+    inset-block-start: var(--s2a-spacing-md);
   }
 }

--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -60,9 +60,14 @@
     --card-overlay-gradient: var(--card-overlay-gradient-bottom);
 
     overflow: hidden;
-    aspect-ratio: 33/37;
     display: flex;
-    align-items: flex-end;
+    flex-direction: column;
+
+    .content-aux {
+      aspect-ratio: 1 / 1.1;
+      width: 100%;
+      height: auto;
+    }
 
     &.dark {
       background-color: unset;
@@ -84,20 +89,15 @@
 
     .foreground {
       --card-overlay-padding: var(--s2a-spacing-lg);
-      /* Play/pause button size + current padding */
-      --card-overlay-padding-bottom: calc(var(--play-pause-size, 0px) + var(--card-overlay-padding));
 
       position: relative;
-      padding: var(--card-overlay-padding) var(--card-overlay-padding) var(--card-overlay-padding-bottom);
+      padding-block: 0 var(--card-overlay-padding);
+      padding-inline: var(--card-overlay-padding);
       z-index: 1;
       display: flex;
       flex-direction: column;
       gap: var(--s2a-spacing-2xs);
-      max-width: 320px;
-    }
-
-    &:has(video) .foreground {
-      --play-pause-size: 32px;
+      max-width: 450px;
     }
   }
 
@@ -130,8 +130,6 @@
   &.featured {
     .card-overlay {
       display: flex;
-      align-items: flex-end;
-      aspect-ratio: 72 / 113;
       border: none;
     }
 
@@ -155,12 +153,17 @@
     .card-overlay {
       --card-overlay-gradient: var(--card-overlay-gradient-top);
 
+      flex-direction: row;
+      aspect-ratio: 33/37;
       align-items: flex-start;
       .foreground {
         --card-overlay-padding-bottom: var(--card-overlay-padding);
 
         max-width: 480px;
+        padding: var(--card-overlay-padding);
       }
+
+      .content-aux { display: none; }
     }
 
     .card-stacked {
@@ -197,6 +200,7 @@
       .card-overlay {
         --card-overlay-gradient: var(--card-overlay-gradient-bottom);
 
+        align-items: flex-end;
         aspect-ratio: 3 / 2;
       }
     }
@@ -230,5 +234,13 @@
   .side-by-side.featured .card-overlay {
     height: 1200px;
     aspect-ratio: unset;
+  }
+}
+
+:root:has(meta[name="foundation"][content="c2"]) {
+  @media (width < 768px) {
+    .side-by-side .card-overlay button.play-pause-button {
+      inset-block-start: var(--s2a-spacing-md);
+    }
   }
 }

--- a/libs/mep/ace1209/side-by-side/side-by-side.js
+++ b/libs/mep/ace1209/side-by-side/side-by-side.js
@@ -88,6 +88,7 @@ function decorate(block, el) {
     const variant = cardType[i];
     if (variant === 'card-stacked') decorateCardStackedIcon(media);
     const card = createTag('div', { class: `card ${variant}` });
+    if (variant === 'card-overlay') card.append(createTag('div', { class: 'content-aux' }));
     card.append(media, foreground);
     cards.push(card);
   }


### PR DESCRIPTION
## What was done

Aligns the side-by-side card-overlay layout on the small (mobile) viewport to match the Bento aspect ratio, and fixes the responsive sizing/overlap issues reported on the CPro Photoshop product page.

### CSS (`libs/mep/ace1209/side-by-side/side-by-side.css`)
- **Card-overlay S viewport**: switched the card overlay from a fixed `33/37` aspect-ratio flex-end layout to a **column layout** with a dedicated `.content-aux` element that carries the media aspect ratio (`1 / 1.1`, full width). This gives the animation enough vertical space and stacks copy below it, as the Figma mobile design intends — instead of overlaying copy on an undersized animation.
- **Foreground**: removed the play/pause-driven bottom padding math; now uses simpler `padding-block: 0 …` / `padding-inline: …`, and raised `max-width` from `320px` to `450px`.
- **Featured variant**: dropped the hard-coded `72/113` aspect-ratio and flex-end alignment (now handled by the shared column layout).
- **Larger breakpoint (≥ tablet)**: restored the side-by-side row layout — `flex-direction: row`, `aspect-ratio: 33/37`, top-aligned, `.content-aux` hidden, and foreground `max-width: 480px` with even padding. The `.content-aux` spacer only applies on the small viewport.
- **Play/pause placement**: under `foundation=c2` on `width < 768px`, the play/pause button is pinned to the upper area (`inset-block-start: var(--s2a-spacing-md)`) per MWPW-204887.

### JS (`libs/mep/ace1209/side-by-side/side-by-side.js`)
- For `card-overlay` variants, inject a `.content-aux` element into the card so the CSS column layout has the media-ratio spacer to size against.

Resolves: [MWPW-204815](https://jira.corp.adobe.com/browse/MWPW-204815), [MWPW-204887](https://jira.corp.adobe.com/browse/MWPW-204887)

- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=side-by-side-mobile&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=side-by-side-mobile&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
## Notes
🤖 This PR description was drafted with the assistance of Claude Code.




