### PR TITLE
[SR] Fix for plans hero with an adjacent rounded-corners-top section

### DIFF
--- a/libs/mep/ace1209/plans-hero/plans-hero.css
+++ b/libs/mep/ace1209/plans-hero/plans-hero.css
@@ -41,6 +41,22 @@
   }
 }
 
+/* Extend the hero image into the space next to a rounded-corners section
+   so the rounded corner reveals the hero image instead of blank background. */
+.rounded-corners + .section,
+.rounded-corners-bottom + .section {
+  .plans-hero-media {
+    top: calc(-1 * var(--s2a-border-radius-lg));
+  }
+}
+
+.section:has(+ .rounded-corners),
+.section:has(+ .rounded-corners-top) {
+  .plans-hero-media {
+    bottom: calc(-1 * var(--s2a-border-radius-lg));
+  }
+}
+
 .plans-hero-content {
   position: relative;
   z-index: 1;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Fixes `plans-hero's` rounded-corner reveal when it sits next to a .`rounded-corners/.rounded-corners-top/.rounded-corners-bottom` section — the corner curve rendered as a flat seam instead, since there was nothing behind it to reveal.

**Context**
section-metadata.css reclaims the negative-margin overlap next to a rounded-corners section with a spacer, so that section's content isn't clipped. But `.plans-hero-media's` background is `position: absolute; inset: 0` relative to `.plans-hero`, whose own height is content/viewport-driven (`height: 35vw; max-height: 600px`) — it has no awareness of the spacer's reclaimed space. Since the hero's background doesn't extend into that space, the rounded corner's notch had nothing to reveal, showing blank background instead of the hero image.

Resolves: [MWPW-204089](https://jira.corp.adobe.com/browse/MWPW-204089)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-plans?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-plans?milolibs=sr-plans-hero-corner-bleed-fix&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


Fix to show rounded corners after plans-hero:
<img width="1178" height="591" alt="image" src="https://github.com/user-attachments/assets/ada394b3-0d89-441f-855d-b84df99f60c6" />


