### PR TITLE
[MWPW-204842] MEP Overlay general bug fixes

### DIFF
--- a/libs/features/mep/mep-next/mep-mas.js
+++ b/libs/features/mep/mep-next/mep-mas.js
@@ -217,7 +217,7 @@ function positionCardActionStack(card, stack) {
   if (rect.width === 0 && rect.height === 0) { stack.style.display = 'none'; return; }
   stack.style.display = '';
   stack.style.top = `${rect.top + window.scrollY + 4}px`;
-  stack.style.left = `${rect.right + window.scrollX - stack.offsetWidth - 4}px`;
+  stack.style.right = `${document.documentElement.clientWidth - rect.right + 4}px`;
 }
 
 export function repositionCardActionStacks() {
@@ -306,7 +306,7 @@ function injectMasCardActionStack(card) {
   }
 
   stack.style.position = 'absolute';
-  stack.style.right = 'auto';
+  stack.style.left = 'auto';
   stack.style.zIndex = CARD_STACK_Z_INDEX;
   document.body.append(stack);
   cardActionStacks.set(card, stack);
@@ -451,7 +451,7 @@ let masResizeHandler;
 let masResizeRaf;
 // Exported for tests. Long enough for M@S hydration after a tab/accordion
 // switch, short enough to feel responsive.
-export const MAS_RESTAMP_DEBOUNCE_MS = 300;
+export const MAS_RESTAMP_DEBOUNCE_MS = 150;
 export function watchForMasContent() {
   if (masObserver) return;
 

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay-highlight.css
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay-highlight.css
@@ -180,9 +180,9 @@ body[data-mep-highlight='true'] [data-code-manifest-id] {
 
 body[data-mep-highlight='true'] [data-code-manifest-id]::before {
   content: 'MEP Code:  ' attr(data-code-manifest-id);
-  border: 2px solid var(--mep-purple-20);
-  color: var(--mep-purple-20);
-  background-color: var(--mep-code-primary);
+  border: 2px solid var(--mep-code-primary);
+  color: var(--mep-code-primary);
+  background-color: var(--mep-code-accent);
 }
 
 body[data-mep-highlight='true'] [data-mep-lingo-roc] {
@@ -194,7 +194,7 @@ body[data-mep-highlight='true'] [data-mep-lingo-roc]::before {
   content: 'MEP Lingo:  ' attr(data-mep-lingo-roc);
   border: 2px solid var(--mep-lingo-primary);
   color: var(--mep-lingo-primary);
-  background-color: var(--mep-green-20);
+  background-color: var(--mep-lingo-accent);
 }
 
 body[data-mep-highlight='true'] [data-mep-lingo-fallback] {

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay-highlight.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay-highlight.js
@@ -215,7 +215,7 @@ function getBadgeHeight(el) {
   return getBadgeDimensions(getBadgeStyles(el)).height;
 }
 
-const BADGE_SELECTORS = `[data-mep-lingo-roc], [data-mep-lingo-fallback], [data-manifest-id][data-path], [data-fragment-default], ${REAL_DOM_BADGE_SELECTOR}`;
+const BADGE_SELECTORS = `[data-mep-lingo-roc], [data-mep-lingo-fallback], [data-manifest-id][data-path], [data-fragment-default], ${MAS_PSEUDO_BADGE_SELECTOR}, ${REAL_DOM_BADGE_SELECTOR}`;
 const BADGE_SPACING = 4;
 
 const BADGE_MAX_WIDTH_SELECTORS = `
@@ -318,13 +318,14 @@ function refreshBadges() {
   adjustBadgePositions();
 }
 
-let badgeAdjustTimer;
+let badgeAdjustRaf;
 const highlightObserver = new MutationObserver(() => {
-  clearTimeout(badgeAdjustTimer);
-  badgeAdjustTimer = setTimeout(() => {
+  if (badgeAdjustRaf) return;
+  badgeAdjustRaf = requestAnimationFrame(() => {
+    badgeAdjustRaf = null;
     refreshPageUpdateCounts();
     refreshBadges();
-  }, 50);
+  });
 });
 
 function isAnyHighlightActive() {

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
@@ -435,6 +435,10 @@ body:has(#mep-drawer:popover-open) .mep-fab {
   border-top: 1px solid var(--mep-white-12);
 }
 
+.mep-drawer .mep-footer.hidden {
+  display: none;
+}
+
 .mep-drawer .mep-footer .con-button {
   cursor: pointer;
   flex: 1;

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -438,7 +438,10 @@ function checkAuthAndBuild(pageId) {
 
     const cards = buildActionsContent(pageId);
     contentEl.replaceChildren(...cards);
-    drawerEl.appendChild(buildFooter());
+    const footerEl = buildFooter();
+    const activeTab = drawerEl.querySelector('.mep-tab.active');
+    footerEl.classList.toggle('hidden', activeTab?.textContent !== 'Actions');
+    drawerEl.appendChild(footerEl);
     await Promise.all(cards.map((c) => c.ready).filter(Boolean));
     setDefaultValues();
     setPreviewButton();
@@ -529,6 +532,7 @@ function setEventListeners() {
       drawerEl.querySelectorAll('[data-tab]').forEach((el) => {
         el.classList.toggle('active', el.getAttribute('data-tab') === tabIndex);
       });
+      drawerEl.querySelector('.mep-footer')?.classList.toggle('hidden', tab.textContent !== 'Actions');
       return;
     }
     const cardEl = event.target.closest('.mep-card svg') && event.target.closest('.mep-card');


### PR DESCRIPTION
Labeled high priority because it blocks other updates we need to make.

**Issue**
<img width="289" height="556" alt="image" src="https://github.com/user-attachments/assets/bd84b6b9-ecc6-48fd-906a-00a67163f434" />
<img width="241" height="123" alt="image" src="https://github.com/user-attachments/assets/d0e632ba-3779-4fde-91f4-92f01a5702fd" />
<img width="1214" height="254" alt="image" src="https://github.com/user-attachments/assets/7f8f1e7d-dd74-4be9-9e68-57e8a6ea843d" />

**Updates**
* Fix collision detection missing M@S `offer`/`inline`/`ost` badges — `BADGE_SELECTORS` only included the real-DOM edit badges and MEP/CAAS/Other pseudo-badges, so M@S's `[data-mas-block='offer']`/`[data-mas-block='inline']` `::before` badges (e.g. "View in OST" and inline field edit badges) were never measured or repositioned by the stacking pass, causing them to visually overlap when stacked
* Fix M@S collection card action stack (Edit / View in OST / Copy) landing in the wrong spot on first paint — position was computed as `left = rect.right - stack.offsetWidth`, which read the stack's own rendered width before web fonts finished sizing it; switched to anchoring via `right` (computed from the card's rect and viewport width) so positioning no longer depends on measuring the stack's own content width
* Reduce visual delay before badges snap into their collision-adjusted position — the badge/page-update-count `MutationObserver` now debounces via `requestAnimationFrame` instead of a flat 50ms `setTimeout`
* Reduce the M@S re-stamp debounce (`MAS_RESTAMP_DEBOUNCE_MS`) from 300ms to 150ms so action stacks re-appear sooner after a tab/accordion click, while still leaving room for M@S content to hydrate

**Instructions**

1. Open a page with M@S collection cards using `?mepnext=on&mep&milolibs=mn-mwpw-204842`.
2. Find a card with both an inline price/offer badge and an OST badge close together — confirm they no longer visually overlap and reposition correctly when stacked.
3. Reload the page and immediately look at a collection's card action stack (Edit Card / View in OST / Copy Fragment ID) — confirm it's right-aligned against its card on first paint, without needing a resize to "snap" into place.
4. Toggle a tab/accordion containing M@S collection cards — confirm the action stack reappears against the newly-visible card noticeably faster than before, without a long lag.
5. Toggle MEP/CAAS/Other highlighting on and off — confirm badge counts and positions still update promptly after DOM changes.

**Non-Claude Instructions (tl;dr)** 
* Ensure badge positioning is correct on load at various window sizes.
* Check any (stacked) badges to ensure they're not stacking and the offset is smooth. 
* Check to make sure the Preview button doesn't appear on the summary page.

Resolves: [MWPW-204842](https://jira.corp.adobe.com/browse/MWPW-204842)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/creativecloud/plans?mep&mepnext=on
- After: https://main--da-cc--adobecom.aem.page/creativecloud/plans?mep&mepnext=on&milolibs=mn-mwpw-204842

PSI: https://mn-mwpw-204842--milo--adobecom.aem.page/?martech=off




