### PR TITLE
MWPW-204936: Adds Product Icon option to details text

### DIFF
--- a/libs/blocks/caas-config/caas-config.js
+++ b/libs/blocks/caas-config/caas-config.js
@@ -247,6 +247,7 @@ const defaultOptions = {
     modifiedDate: 'Modified Date',
     staticDate: 'Static Date',
     productName: 'Product Name',
+    productIcon: 'Product Icon',
   },
   cardHoverEffect: {
     default: 'Default',

--- a/libs/blocks/caas/utils.js
+++ b/libs/blocks/caas/utils.js
@@ -1110,7 +1110,7 @@ export const getConfig = async (originalState, strs = {}) => {
     excludedCardsWithCurrent = excludedCards;
   }
 
-  const products = state.detailsTextOption === 'productName' ? await getProducts(state) : {};
+  const products = state.detailsTextOption.startsWith('product') ? await getProducts(state) : {};
 
   const config = {
     collection: {


### PR DESCRIPTION
**Description**
Adds the "Product Icon" option to the details text configuration in the CaaS configuration block (caas-config.js), enabling support for product icons within card details.

**Changes**
libs/blocks/caas-config/caas-config.js: Added productIcon: 'Product Icon' to the default configuration options.

Resolves: [MWPW-204936](https://jira.corp.adobe.com/browse/MWPW-204936)

**Screenshots**
<img width="296" height="210" alt="Screenshot 2026-08-19 at 3 22 24 PM" src="https://github.com/user-attachments/assets/32a4f6a0-16f4-4688-862e-b6511e08ed6a" />


<img width="392" height="151" alt="Screenshot 2026-08-19 at 3 27 45 PM" src="https://github.com/user-attachments/assets/222244fe-0871-44f8-be2c-688d3669860a" />



**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-204936--milo--adobecom.aem.page/?martech=off




