### PR TITLE
[SR] Remove stroke from animated boxes/bento's

### DIFF
--- a/libs/mep/ace1209/offer-hero/offer-hero.css
+++ b/libs/mep/ace1209/offer-hero/offer-hero.css
@@ -381,7 +381,6 @@
   .offer-hero {
     .hero-card {
       &.is-settled {
-        border: var(--s2a-border-width-md) solid var(--s2a-color-transparent-white-12);
         border-radius: var(--s2a-border-radius-24);
       }
     }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Removes stroke/border from the hero animated boxes/bento's. 

Resolves: [MWPW-204897](https://jira.corp.adobe.com/browse/MWPW-204897)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=sr-offer-hero-stroke&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


<img width="1224" height="1074" alt="image" src="https://github.com/user-attachments/assets/a137947c-7743-4ba6-b39f-31b8303856fa" />


