### PR TITLE
[SR] Tabs Block - quiet variant font-family css fix (Wave 3)

### DIFF
--- a/libs/mep/ace1209/tabs/tabs.css
+++ b/libs/mep/ace1209/tabs/tabs.css
@@ -231,6 +231,7 @@
         height: auto;
         flex: 0 0 auto;
         color: var(--s2a-color-content-subtle);
+        font-family: var(--heading-font-family);
 
         &[aria-selected="true"] {
           background: transparent;


### PR DESCRIPTION
This is a single line CSS change to the ACE1209 `tabs.css` file meant to fix VQA font issue.

Resolves: [MWPW-204494](https://jira.corp.adobe.com/browse/MWPW-204494)

**TEST URLs**

**How to test:**
On quiet variant (the top level parent tabs) tabs, check the css styling so that the font family is set to `var(--heading-font-family)`, which resolves to `"Adobe Clean Display Black", "Adobe Clean Display"`.

- base/light
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-pill-light?milolibs=sr3-quiet-font-fix

- base/dark
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-pill-dark?milolibs=sr3-quiet-font-fix

- radio/light
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-radio-light?milolibs=sr3-quiet-font-fix

- radio/dark
https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/playground/viloria/tabs-layers-poc-radio-dark?milolibs=sr3-quiet-font-fix

