### PR TITLE
[MWPW-204913]: C2 persistent cart

### DIFF
--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -77,6 +77,14 @@ export default async function init(el) {
 
   const lingoRegion = isLingo ? await getLingoRegion({ useGeoLocation: true }) : null;
 
+  const countryCodePromise = (async () => {
+    const { isMasGeoDetectionEnabled } = await import('../../../blocks/merch/merch.js');
+    if (!isMasGeoDetectionEnabled()) return undefined;
+    const base = config.miloLibs || config.codeRoot;
+    const { getValidatedMarket } = await import(`${base}/utils/market.js`);
+    return (await getValidatedMarket())?.toUpperCase();
+  })().catch(() => undefined);
+
   const gnavPromise = main({
     localizeLink,
     // Lingo link transformation only — skip when lingo is off so federal doesn't
@@ -89,6 +97,7 @@ export default async function init(el) {
     unavEnabled: getMetadata('unav') === 'on',
     placeholders: placeholdersPromise,
     miloConfig: config,
+    countryCode: countryCodePromise,
     mepMartech: config.mep?.martech || '',
     lingoRegion,
     personalization: {


### PR DESCRIPTION
Adding changes for C2 persistent cart

Resolve the geo-validated market (gated by mas-geo-detection) in the C2 global-navigation wrapper and pass it to federal so the C2 cart opens with the correct country/pricing instead of the locale default.

Resolves: [MWPW-204913](https://jira.corp.adobe.com/browse/MWPW-204913)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://c2cart--milo--adobecom.aem.page/?martech=off

**QA:**
https://main--upp--adobecom.aem.page/homepage/index-loggedout?fedsbranch=c2cart&milolibs=c2cart&akamaiLocale=ie

