### PR TITLE
[SR][MWPW-204695] Fix video play/pause

### DIFF
--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
@@ -71,6 +71,11 @@
     .video-holder {
       width: 100%;
       pointer-events: none;
+
+      button.play-pause-button,
+      .pause-play-wrapper {
+        pointer-events: auto;
+      }
     }
 
     video {

--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.js
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.js
@@ -183,6 +183,7 @@ function setupBlock(el) {
       const { playedOnce = false } = video.dataset;
       if (playedOnce) return;
       if (isActive) {
+        if (video.hasAttribute(USER_PAUSED_ATTR)) return;
         video.play();
         syncPausePlayIcon(video, { type: 'playing' });
         return;

--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -413,7 +413,7 @@ export function applyAccessibilityEvents(videoEl) {
       videoEl.pause();
       return;
     }
-    videoEl.addEventListener('canplay', () => isVideoReady(videoEl) && videoEl.play());
+    videoEl.addEventListener('canplay', () => !videoEl.hasAttribute(USER_PAUSED_ATTR) && isVideoReady(videoEl) && videoEl.play());
   }
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Problem 1 — Pause button doesn't stick (desktop). Clicking pause paused the video, but on every loop the canplay handler called play() again, ignoring the user's pause. Fix: made canplay (and applyRotation) skip play when data-user-paused is set. It seems that this only happens for videos that are on `loop` without `viewportplay` attribute. 

Problem 2 — Pause button unclickable (mobile). The video holder had pointer-events: none (so swipes reach the media), and the button inherited it, so taps hit the media instead of the button. Fix: gave the button pointer-events: auto so it stays tappable while swipes still work.

Resolves: [MWPW-204695](https://jira.corp.adobe.com/browse/MWPW-204695)

**Reproduce:** Easiest and most reliable way to reproduce is to throttle network to slow 4g/3g, reload a page, scroll down to the video, wait for video to start playing, pause it and wait for a few seconds and video will play again even thought it was paused manually. 

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=mwpw-204695&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


