### PR TITLE
MWPW-204695: Fix video play/pause interaction

### DIFF
--- a/libs/utils/decorate.js
+++ b/libs/utils/decorate.js
@@ -414,7 +414,7 @@ export function applyAccessibilityEvents(videoEl) {
       videoEl.pause();
       return;
     }
-    videoEl.addEventListener('canplay', () => isVideoReady(videoEl) && videoEl.play());
+    videoEl.addEventListener('canplay', () => !videoEl.hasAttribute(USER_PAUSED_ATTR) && isVideoReady(videoEl) && videoEl.play());
   }
 }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Problem — Pause button doesn't stick (desktop). Clicking pause paused the video, but on every loop the canplay handler called play() again, ignoring the user's pause. Fix: made canplay (and applyRotation) skip play when data-user-paused is set. It seems that this only happens for videos that are on `loop` without `viewportplay` attribute. 

Resolves: [MWPW-204695](https://jira.corp.adobe.com/browse/MWPW-204695)

**Reproduce:** Easiest and most reliable way to reproduce is to throttle network to slow 4g/3g, reload a page, scroll down to the video, wait for video to start playing, pause it and wait for a few seconds and video will play again even thought it was paused manually. 

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/drafts/ratko/mwpw-204695-video-play/document
- After: https://mwpw-204695-video-fix--milo--adobecom.aem.page/drafts/ratko/mwpw-204695-video-play/document


