### PR TITLE
[SR] [MWPW-205010] -  Fix mobile jump-link hero CTA clipped by fixed height

### DIFF
--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -69,7 +69,8 @@
     padding-block-end: var(--s2a-spacing-4xl);
 
     &.hero {
-      height: 584px;
+      height: auto;
+      min-height: 584px;
       display: flex;
       flex-direction: column;
       padding-inline: 0;
@@ -286,7 +287,8 @@
 
 .section:has(.rich-content.jump-link.hero) {
   --rc-hero-overlay: linear-gradient(180deg, var(--s2a-color-transparent-black-80) -0.02%, var(--s2a-color-transparent-black-48) 39.99%, var(--s2a-color-transparent-black-24) 59.99%, var(--s2a-color-transparent-black-80) 100%);
-  height: 584px;
+  height: auto;
+  min-height: 584px;
 }
 
 .rich-content.hero .hero-overlay-source {


### PR DESCRIPTION
Fixes next section overlapping too much on rich content jump links.

Resolves: [MWPW-205010](https://jira.corp.adobe.com/browse/MWPW-205010)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=jump-links-rounded-fix


