### PR TITLE
[PERF]Update shouldSkipLenis method

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2258,15 +2258,12 @@ function initModalEventListener() {
   });
 }
 
-// CPU/RAM are coarse proxies (deviceMemory is Chromium-only), so pair them and
-// bias harder on Windows, whose integrated-GPU compositing is the real jank driver.
-// Missing signals compare false (undefined <= 4 === false) and read as capable.
-// Destructured (not navigator.x) so eslint-plugin-compat skips the guarded APIs.
 function shouldSkipLenis() {
   if (navigator.connection?.saveData
     || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return true;
-  const { deviceMemory, hardwareConcurrency: cores } = navigator;
-  const isWindows = navigator.userAgent.includes('Windows');
+  if (window.matchMedia('(width < 768px) and (pointer: coarse) and (hover: none)').matches) return true;
+  const { deviceMemory, hardwareConcurrency: cores, userAgentData, userAgent } = navigator;
+  const isWindows = (userAgentData?.platform || userAgent).includes('Windows');
   return isWindows
     ? deviceMemory <= 4 || cores <= 4
     : deviceMemory <= 4 && cores <= 4;
@@ -2323,9 +2320,7 @@ async function loadPostLCP(config) {
       .then(({ addMepAnalytics }) => addMepAnalytics(config, header));
   }
   if (getMetadata('foundation') === 'c2') {
-    // Skip Lenis on mobile and on devices that can't carry it smoothly
-    const enableLenis = !window.matchMedia('(width < 768px)').matches && !shouldSkipLenis();
-    if (enableLenis) {
+    if (!shouldSkipLenis()) {
       await Promise.all([
         new Promise((resolve) => { loadStyle(`${config.base}/deps/lenis.min.css`, resolve); }),
         loadScript(`${config.base}/deps/lenis.min.js`),


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

1. Single source of truth. Both tickets (MWPW-203834 mobile + MWPW-203835 low-end/Windows) now live in one shouldSkipLenis(); the gate is just !shouldSkipLenis().
2. Better mobile detection. Was pure width < 768px (a narrow Mac window wrongly counted as mobile). Now width < 768px AND (pointer: coarse) and (hover: none) — so a narrow desktop window keeps Lenis, real phones skip it.
3. Future-proof Windows check. UA sniffing → navigator.userAgentData?.platform with a UA fallback, so it survives Chromium's UA freezing.

Resolves: [MWPW-203835](https://jira.corp.adobe.com/browse/MWPW-203835), [MWPW-203834](https://jira.corp.adobe.com/browse/MWPW-203834)

**Test URLs:**
- Before: https://www.stage.adobe.com/
- After: https://www.stage.adobe.com/?milolibs=disable-lenis-mobile


