### PR TITLE
[NALA] Fix marquee image assertion for mobile-first authoring

### DIFF
--- a/nala/blocks/brand-concierge/brand-concierge.test.js
+++ b/nala/blocks/brand-concierge/brand-concierge.test.js
@@ -1057,7 +1057,10 @@ test.describe('Milo Brand Concierge Block test suite', () => {
 
         await test.step('step-7: Verify marquee background images render', async () => {
           expect(await bc.marqueeImages.count()).toBeGreaterThanOrEqual(data.minimumImageCount);
-          await expect(bc.marqueeImages.first()).toBeVisible();
+          // Marquee authors per-viewport images (mobile-only/tablet-only/
+          // desktop-only), so the first <picture> may be hidden on this
+          // viewport. Assert at least one picture is actually visible.
+          await expect(bc.block.locator('picture:visible').first()).toBeVisible({ timeout: 12000 });
         });
 
         await test.step('step-8: Run accessibility test on the marquee', async () => {


### PR DESCRIPTION
## Summary
Fixes the 2 failing marquee nala tests (tcid 18/19) introduced by MWPW-203941's mobile-first viewport reorder. Targets `bc-marquee-auth-order` so the test fix lands together with the authoring change (keeps stage green on merge).

## Problem
MWPW-203941 reorders the marquee viewport mapping to **mobile-first**: `['mobile-only', 'tablet-only', 'desktop-only']`. The rendered `<picture>` order is now:
1. mobile-only — `display:none` on desktop
2. tablet-only — `display:none` on desktop
3. desktop-only — visible

The render test asserted `bc.marqueeImages.first()` is visible, but `.first()` is now the **mobile-only** picture (hidden on the desktop test viewport) → `toBeVisible` fails (`received: hidden`). Verified on the preview: `[mobile hidden, tablet hidden, desktop visible]`, `anyVisible: true`.

## Fix
Assert **at least one** picture is visible (`picture:visible`) rather than the first — correct regardless of authoring order or viewport.
```js
expect(await bc.marqueeImages.count()).toBeGreaterThanOrEqual(data.minimumImageCount);
await expect(bc.block.locator('picture:visible').first()).toBeVisible({ timeout: 12000 });
```

## Verification
- `https://bc-marquee-auth-order--milo--adobecom.aem.live` — marquee tcid 18–22: **5/5 pass**
- BC unit tests: 29/29 (unaffected)
- eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

