### PR TITLE
[SR] Faq body text to use the content-subtle token

### DIFF
--- a/libs/mep/ace1209/faq/faq.css
+++ b/libs/mep/ace1209/faq/faq.css
@@ -27,6 +27,7 @@
   }
 
   > .faq-panel {
+    color: var(--s2a-color-content-subtle);
     display: grid;
     grid-template-rows: 0fr;
     visibility: hidden;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Set FAQ body text to use `--s2a-color-content-subtle` token (slightly transparent).

Resolves: [MWPW-204138](https://jira.corp.adobe.com/browse/MWPW-204138)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=sr-faq-body-color&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


<img width="1416" height="840" alt="image" src="https://github.com/user-attachments/assets/b96cc62c-0f33-48c5-a765-f18edce23dc4" />


