### PR TITLE
[MWPW-204435][SR] Base card: scale media on hover only if there's a link

### DIFF
--- a/libs/c2/blocks/base-card/base-card.css
+++ b/libs/c2/blocks/base-card/base-card.css
@@ -43,7 +43,7 @@
     }
   }
 
-  &:hover .media picture:not(.icon) img {
+  &:has(a):hover .media picture:not(.icon) img {
     transform: scale(1.05);
   }
 


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Enable media scale on hover only if the base card contains a valid link.

Resolves: [MWPW-204435](https://jira.corp.adobe.com/browse/MWPW-204435)

**Test URLs:**
- Before: https://site-redesign-foundation--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-204435--milo--adobecom.aem.page/?martech=off

QA URL:
* base cards without URL (no scale on hover) - https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=mwpw-204435&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
* base cards with URL (scale on hover) - https://main--upp--adobecom.aem.page/homepage/index-loggedout?milolibs=mwpw-204435



