### PR TITLE
[SR] - [MWPW-205084] - Router Marquee: preload remaining slides' poster/image to fix white flash on hover

### DIFF
--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -252,6 +252,30 @@ const loadSlideMedia = (slide) => {
   loadVideo(slide?.querySelector('video'));
 };
 
+const promotePoster = (video) => {
+  if (video?.dataset.rmPoster && !video.getAttribute('poster')) {
+    video.setAttribute('poster', video.dataset.rmPoster);
+  }
+};
+
+// Once the page has settled, warm the background image and video poster for every
+// slide the user hasn't seen yet, so hovering a card reveals its art immediately
+// instead of a blank/white slide while the network fetch is still in flight. This
+// runs on idle time (well after the hero's own LCP fetch), and deliberately skips
+// the video's own source - that stays lazy and only loads on real activation - so
+// it doesn't reintroduce the eager-fetch cost this lazy-loading was added to avoid.
+const preloadRemainingSlides = (slides) => {
+  const warm = () => {
+    slides.forEach((slide) => {
+      if (slide.classList.contains('is-active')) return;
+      loadSlideImage(slide);
+      promotePoster(slide.querySelector('video'));
+    });
+  };
+  if ('requestIdleCallback' in window) requestIdleCallback(warm, { timeout: 5000 });
+  else setTimeout(warm, 2000);
+};
+
 const playActiveVideo = (video) => {
   loadVideo(video);
   if (!prefersReducedMotion()) video.play().catch(() => {});
@@ -778,6 +802,7 @@ export default function init(el) {
     setSlideObserver(slides);
     setAnalytics(slides, cards, container, el);
     autoplayControllers.push(startAutoplay(slides, cards, container, el));
+    preloadRemainingSlides([...slides]);
   };
 
   loadViewportVideos(el);


### PR DESCRIPTION
The lazy-loading work defers each non-active slide's background image and video poster until the slide actually activates, saving first-paint bytes. The trade-off: hovering a card the autoplay loop hasn't reached yet (e.g. the 5th card right after load) triggers the slide-change animation before anything has been fetched, so the slide flashes blank/white while the image and poster download.

This adds an idle-time warm-up in `router-marquee.js` — `preloadRemainingSlides()`, wired into `initViewportAutoplay`. Once a viewport's autoplay starts, it uses `requestIdleCallback` (falling back to a `setTimeout`) to load every not-yet-active slide's background image and promote its `data-rm-poster` to a real `poster`. The video body itself stays untouched — `loadVideo()`'s full fetch is still deferred to real activation — so the byte savings the original tickets measured are preserved.

The idle-preloaded posters for other slides didn't finish downloading until after LCP had already been recorded, so they don't count against LCP or first-paint bytes. In the before run, slides the autoplay loop hadn't reached yet had zero bytes loaded even 8+ seconds in, reproducing the reported white flash; in the after run, all slides' posters were present within ~30ms of each other, well ahead of any hover.


Resolves: [MWPW-205084](https://jira.corp.adobe.com/browse/MWPW-205084)

**Test URLs:**
- Before: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=sr-perf-dd
- After: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=rc-poster-delay








