### PR TITLE
Fix MWPW-205174: restore missing utils.js exports for stream-dev

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2839,4 +2839,4 @@ export function loadLana(options = {}) {
   window.addEventListener('unhandledrejection', lanaError);
 }
 
-export const reloadPage = () => window.location.reload(); 
+export const reloadPage = () => window.location.reload();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -475,6 +475,35 @@ export const getFederatedUrl = (url = '') => {
   return url;
 };
 
+const TRUSTED_DOMAINS = ['.adobe.com'];
+const TRUSTED_AEM_PATTERN = /--adobecom\.(hlx|aem)\.(page|live)$/;
+
+export function isTrustedUrl(url) {
+  if (typeof url !== 'string' || !url) return false;
+  if (/^[^/]*:/.test(url) && !/^https:\/\//i.test(url)) return false;
+  let parsed;
+  try {
+    parsed = new URL(url, window.location.origin);
+  } catch {
+    return false;
+  }
+  if (parsed.origin === window.location.origin) return true;
+  if (parsed.protocol !== 'https:') return false;
+  return TRUSTED_DOMAINS.some(
+    (domain) => parsed.hostname === domain.slice(1) || parsed.hostname.endsWith(domain),
+  ) || TRUSTED_AEM_PATTERN.test(parsed.hostname);
+}
+
+export function isSameOriginManifestPath(manifestPath) {
+  if (typeof manifestPath !== 'string' || !manifestPath) return false;
+  if (!manifestPath.startsWith('/') || manifestPath.startsWith('//')) return false;
+  try {
+    return new URL(manifestPath, window.location.origin).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
 function isPathMatch(path, href) {
   if (path.includes('*')) {
     const regex = new RegExp(path.replace(/\*/g, '[a-zA-Z]{1}'));


### PR DESCRIPTION
Resolves: [MWPW-205174](https://jira.corp.adobe.com/browse/MWPW-205174) 

Restores isTrustedUrl and isSameOriginManifestPath exports to libs/utils/utils.js, dropped from stream-dev after a branch delete/restore caused a CDN desync
personalization.js, fragment.js, and quiz/utils.js on the CDN already import these (from upstream security commit 14898465b), but utils.js didn't export them — causing a SyntaxError that blank-paged the Stream collab UI
Code is copied verbatim from main, purely additive (no existing exports touched)
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/f0a48b80-172a-4e88-adbb-09beb1c43eac" />




