### PR TITLE
MWPW-205066 OST: use loadIms for IMS, keep AOS client id

### DIFF
--- a/libs/blocks/ost/README.md
+++ b/libs/blocks/ost/README.md
@@ -14,6 +14,10 @@ Offer Selector Tool is loaded in Milo as external JS and CSS files hosted in Sta
 
 For more info on Tacocat.js or Offer Selector Tool visit https://git.corp.adobe.com/Dexter/tacocat.js/tree/develop/packages/offer-selector-tool
 
+## IMS authentication
+
+OST authenticates through the shared `loadIms` helper (`libs/utils/utils.js`) instead of loading imslib itself. AOS requires the `aos_milo_commerce` IMS client, so `loadOstEnv` sets `imsClientId`/`imsScope` in the config **before dynamically importing `merch.js`** — merch eagerly initializes IMS (via `loadIms`) at module-evaluation time, and `loadIms` is memoized on its first call, so the client id must be in place beforehand.
+
 ## Development
 
 To prevent IMS from redirecting to sign-in page and back,

--- a/libs/blocks/ost/ost.js
+++ b/libs/blocks/ost/ost.js
@@ -1,15 +1,8 @@
 import ctaTextOption from './ctaTextOption.js';
 import {
-  getConfig, getLocale, getMetadata, loadScript, loadStyle, createTag,
+  getConfig, getLocale, getMetadata, loadScript, loadStyle, createTag, loadIms,
+  getValidatedMasLibsUrl,
 } from '../../utils/utils.js';
-import {
-  initService,
-  loadMasComponent,
-  getMasLibs,
-  getMiloLocaleSettings,
-  COMMERCE_LIBRARY,
-  getMasComponentUrl,
-} from '../merch/merch.js';
 
 export const AOS_API_KEY = 'wcms-commerce-ims-user-prod';
 export const CHECKOUT_CLIENT_ID = 'creative';
@@ -17,7 +10,6 @@ export const DEFAULT_CTA_TEXT = 'buy-now';
 const IMS_COMMERCE_CLIENT_ID = 'aos_milo_commerce';
 const IMS_SCOPE = 'AdobeID,openid';
 const IMS_ENV = 'prod';
-const IMS_PROD_URL = 'https://auth.services.adobe.com/imslib/imslib.min.js';
 const OST_SCRIPT_URL = '/studio/ost/index.js';
 const OST_STYLE_URL = '/studio/ost/index.css';
 /** @see https://git.corp.adobe.com/PandoraUI/core/blob/master/packages/react-env-provider/src/component.tsx#L49 */
@@ -73,8 +65,8 @@ export function getMasLibsBase() {
 
   if (!masLibs || masLibs.trim() === '' || masLibs.trim() === 'main') return 'https://mas.adobe.com';
 
-  // invalid maslibs values are rejected by getMasLibs and fall back to the default
-  return getMasLibs()?.replace('/web-components/dist', '') ?? 'https://mas.adobe.com';
+  // invalid maslibs values are rejected by getValidatedMasLibsUrl and fall back to the default
+  return getValidatedMasLibsUrl(masLibs) ?? 'https://mas.adobe.com';
 }
 
 /**
@@ -167,6 +159,24 @@ export async function loadOstEnv() {
     attributes['data-mas-ff-defaults'] = 'on';
   }
   if (countryParam) attributes.country = countryParam.toUpperCase();
+
+  // Set the AOS IMS client before merch.js is imported: merch eagerly initializes IMS
+  // (via loadIms) at module-evaluation time, and loadIms is memoized on first call.
+  // AOS is prod-only, so force the prod IMS environment regardless of the page env.
+  const config = getConfig();
+  config.imsClientId = IMS_COMMERCE_CLIENT_ID;
+  config.imsScope = IMS_SCOPE;
+  config.adobeid = { ...config.adobeid, environment: IMS_ENV };
+
+  const {
+    initService,
+    loadMasComponent,
+    getMasLibs,
+    getMiloLocaleSettings,
+    COMMERCE_LIBRARY,
+    getMasComponentUrl,
+  } = await import('../merch/merch.js');
+
   await initService(true, attributes);
   // Load commerce.js based on masLibs parameter
   masCommerceService = await loadMasComponent(COMMERCE_LIBRARY);
@@ -383,24 +393,14 @@ export default async function init(el) {
 
   if (ostEnv.aosAccessToken) {
     openOst();
-  } else {
-    window.adobeid = {
-      client_id: IMS_COMMERCE_CLIENT_ID,
-      environment: IMS_ENV,
-      optimizations: { fastEvents: true },
-      autoValidateToken: true,
-      scope: IMS_SCOPE,
-      onAccessToken: ({ token }) => {
-        ostEnv.aosAccessToken = token;
-        openOst();
-      },
-      onReady: () => {
-        if (!window.adobeIMS.isSignedInUser()) {
-          window.adobeIMS.signIn();
-        }
-      },
-    };
+    return;
+  }
 
-    await loadScript(IMS_PROD_URL);
+  await loadIms();
+  if (window.adobeIMS.isSignedInUser()) {
+    ostEnv.aosAccessToken = window.adobeIMS.getAccessToken()?.token;
+    openOst();
+  } else {
+    window.adobeIMS.signIn();
   }
 }

--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -3,6 +3,7 @@ import {
   getConfig,
   getMetadata,
   localizeLink,
+  decorateLinksAsync,
   convertStageLinks,
   lingoActive,
   getLingoRegion,
@@ -11,12 +12,16 @@ import {
 const DEFAULT_FEDERAL_URL = 'https://main--federal--adobecom.aem.page';
 
 function getFederalDomain(config) {
-  const queryParams = new URLSearchParams(window.location.search);
-  const federalBranch = queryParams.get('fedsbranch');
-  if (federalBranch?.trim()) {
-    const sanitized = federalBranch.trim().toLowerCase();
-    if (sanitized === 'local') return 'http://localhost:3000/federal';
-    return `https://${sanitized}--federal--adobecom.aem.page/federal`;
+  const env = getEnv(config);
+
+  if (env.name !== 'prod') {
+    const queryParams = new URLSearchParams(window.location.search);
+    const federalBranch = queryParams.get('fedsbranch');
+    if (federalBranch?.trim()) {
+      const sanitized = federalBranch.trim().toLowerCase();
+      if (sanitized === 'local') return 'http://localhost:3000/federal';
+      return `https://${sanitized}--federal--adobecom.aem.page/federal`;
+    }
   }
 
   const { hostname } = window.location;
@@ -26,7 +31,6 @@ function getFederalDomain(config) {
 
   if (extension) return `${DEFAULT_FEDERAL_URL.replace('aem.page', `aem.${extension}`)}/federal`;
 
-  const env = getEnv(config);
   if (env.name === 'stage') return 'https://www.stage.adobe.com/federal';
   if (env.name === 'prod') return 'https://www.adobe.com/federal';
   return `${DEFAULT_FEDERAL_URL}/federal`;
@@ -34,13 +38,25 @@ function getFederalDomain(config) {
 
 export default async function init(el) {
   const config = getConfig();
+  const isLingo = lingoActive();
   const federalDomain = getFederalDomain(config);
   const federalGnavUrl = new URL('libs/global-navigation/dist/main.js', `${federalDomain}/`).href;
 
   const placeholdersPromise = (async () => {
-    const { fetchPlaceholders } = await import('../../../features/placeholders.js');
-    const placeholders = await fetchPlaceholders({ config });
-    return new Map(Object.entries(placeholders));
+    const { fetchPlaceholders, getGeoIpPlaceholders } = await import('../../../features/placeholders.js');
+    // Federal replaces {{key}} tokens with a flat string swap and never runs
+    // milo's geo-aware decoration, so merge geo-IP overrides into the map here —
+    // otherwise {{…-geo-ip}} tokens in the gnav resolve to the base value.
+    const [placeholders, geoIp] = await Promise.all([
+      fetchPlaceholders({ config }),
+      isLingo ? getGeoIpPlaceholders(config) : null,
+    ]);
+    const map = new Map(Object.entries(placeholders));
+    geoIp?.forEach((value, key) => map.set(key, value));
+    // MEP manifest "placeholders" sheet overrides win last, matching getPlaceholder
+    // precedence (config.placeholders beats geo-IP in placeholders.js).
+    Object.entries(config.placeholders ?? {}).forEach(([key, value]) => map.set(key, value));
+    return map;
   })();
   // for now we only support inBlock commands.
   // Since MEP on gnav is relatively rare we'll
@@ -59,10 +75,21 @@ export default async function init(el) {
   const { main } = await import(federalGnavUrl);
   const gnavUrl = new URL(getMetadata('gnav-source') || `${config.locale?.contentRoot ?? window.location.origin}/gnav`);
 
-  const lingoRegion = lingoActive() ? await getLingoRegion({ useGeoLocation: true }) : null;
+  const lingoRegion = isLingo ? await getLingoRegion({ useGeoLocation: true }) : null;
+
+  const countryCodePromise = (async () => {
+    const { isMasGeoDetectionEnabled } = await import('../../../blocks/merch/merch.js');
+    if (!isMasGeoDetectionEnabled()) return undefined;
+    const base = config.miloLibs || config.codeRoot;
+    const { getValidatedMarket } = await import(`${base}/utils/market.js`);
+    return (await getValidatedMarket())?.toUpperCase();
+  })().catch(() => undefined);
 
   const gnavPromise = main({
     localizeLink,
+    // Lingo link transformation only — skip when lingo is off so federal doesn't
+    // re-run milo link decoration over links federal has already localized.
+    ...(isLingo && { decorateBody: decorateLinksAsync }),
     gnavSource: gnavUrl,
     asideSource: null,
     isLocalNav: false,
@@ -70,6 +97,8 @@ export default async function init(el) {
     unavEnabled: getMetadata('unav') === 'on',
     placeholders: placeholdersPromise,
     miloConfig: config,
+    countryCode: countryCodePromise,
+    mepMartech: config.mep?.martech || '',
     lingoRegion,
     personalization: {
       commands: [...commands, ...gnavMepCommands],
@@ -86,5 +115,6 @@ export default async function init(el) {
     });
     return {};
   });
+  gnavPromise.then(() => requestAnimationFrame(() => window.lenis?.resize()));
   config.federal = { fedsGlobalNavigation: gnavPromise };
 }

--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -3,7 +3,6 @@ import {
   getConfig,
   getMetadata,
   localizeLink,
-  decorateLinksAsync,
   convertStageLinks,
   lingoActive,
   getLingoRegion,
@@ -12,16 +11,12 @@ import {
 const DEFAULT_FEDERAL_URL = 'https://main--federal--adobecom.aem.page';
 
 function getFederalDomain(config) {
-  const env = getEnv(config);
-
-  if (env.name !== 'prod') {
-    const queryParams = new URLSearchParams(window.location.search);
-    const federalBranch = queryParams.get('fedsbranch');
-    if (federalBranch?.trim()) {
-      const sanitized = federalBranch.trim().toLowerCase();
-      if (sanitized === 'local') return 'http://localhost:3000/federal';
-      return `https://${sanitized}--federal--adobecom.aem.page/federal`;
-    }
+  const queryParams = new URLSearchParams(window.location.search);
+  const federalBranch = queryParams.get('fedsbranch');
+  if (federalBranch?.trim()) {
+    const sanitized = federalBranch.trim().toLowerCase();
+    if (sanitized === 'local') return 'http://localhost:3000/federal';
+    return `https://${sanitized}--federal--adobecom.aem.page/federal`;
   }
 
   const { hostname } = window.location;
@@ -31,6 +26,7 @@ function getFederalDomain(config) {
 
   if (extension) return `${DEFAULT_FEDERAL_URL.replace('aem.page', `aem.${extension}`)}/federal`;
 
+  const env = getEnv(config);
   if (env.name === 'stage') return 'https://www.stage.adobe.com/federal';
   if (env.name === 'prod') return 'https://www.adobe.com/federal';
   return `${DEFAULT_FEDERAL_URL}/federal`;
@@ -38,25 +34,13 @@ function getFederalDomain(config) {
 
 export default async function init(el) {
   const config = getConfig();
-  const isLingo = lingoActive();
   const federalDomain = getFederalDomain(config);
   const federalGnavUrl = new URL('libs/global-navigation/dist/main.js', `${federalDomain}/`).href;
 
   const placeholdersPromise = (async () => {
-    const { fetchPlaceholders, getGeoIpPlaceholders } = await import('../../../features/placeholders.js');
-    // Federal replaces {{key}} tokens with a flat string swap and never runs
-    // milo's geo-aware decoration, so merge geo-IP overrides into the map here —
-    // otherwise {{…-geo-ip}} tokens in the gnav resolve to the base value.
-    const [placeholders, geoIp] = await Promise.all([
-      fetchPlaceholders({ config }),
-      isLingo ? getGeoIpPlaceholders(config) : null,
-    ]);
-    const map = new Map(Object.entries(placeholders));
-    geoIp?.forEach((value, key) => map.set(key, value));
-    // MEP manifest "placeholders" sheet overrides win last, matching getPlaceholder
-    // precedence (config.placeholders beats geo-IP in placeholders.js).
-    Object.entries(config.placeholders ?? {}).forEach(([key, value]) => map.set(key, value));
-    return map;
+    const { fetchPlaceholders } = await import('../../../features/placeholders.js');
+    const placeholders = await fetchPlaceholders({ config });
+    return new Map(Object.entries(placeholders));
   })();
   // for now we only support inBlock commands.
   // Since MEP on gnav is relatively rare we'll
@@ -75,21 +59,10 @@ export default async function init(el) {
   const { main } = await import(federalGnavUrl);
   const gnavUrl = new URL(getMetadata('gnav-source') || `${config.locale?.contentRoot ?? window.location.origin}/gnav`);
 
-  const lingoRegion = isLingo ? await getLingoRegion({ useGeoLocation: true }) : null;
-
-  const countryCodePromise = (async () => {
-    const { isMasGeoDetectionEnabled } = await import('../../../blocks/merch/merch.js');
-    if (!isMasGeoDetectionEnabled()) return undefined;
-    const base = config.miloLibs || config.codeRoot;
-    const { getValidatedMarket } = await import(`${base}/utils/market.js`);
-    return (await getValidatedMarket())?.toUpperCase();
-  })().catch(() => undefined);
+  const lingoRegion = lingoActive() ? await getLingoRegion({ useGeoLocation: true }) : null;
 
   const gnavPromise = main({
     localizeLink,
-    // Lingo link transformation only — skip when lingo is off so federal doesn't
-    // re-run milo link decoration over links federal has already localized.
-    ...(isLingo && { decorateBody: decorateLinksAsync }),
     gnavSource: gnavUrl,
     asideSource: null,
     isLocalNav: false,
@@ -97,8 +70,6 @@ export default async function init(el) {
     unavEnabled: getMetadata('unav') === 'on',
     placeholders: placeholdersPromise,
     miloConfig: config,
-    countryCode: countryCodePromise,
-    mepMartech: config.mep?.martech || '',
     lingoRegion,
     personalization: {
       commands: [...commands, ...gnavMepCommands],
@@ -115,6 +86,5 @@ export default async function init(el) {
     });
     return {};
   });
-  gnavPromise.then(() => requestAnimationFrame(() => window.lenis?.resize()));
   config.federal = { fedsGlobalNavigation: gnavPromise };
 }

--- a/test/blocks/ost/mocks/ost-utils.js
+++ b/test/blocks/ost/mocks/ost-utils.js
@@ -89,6 +89,7 @@ function mockOstDeps({ failStatus = false, failMetadata = false, mockToken, over
   window.adobeIMS = {
     isSignedInUser: sinon.stub().returns(false),
     signIn: sinon.stub(),
+    getAccessToken: sinon.stub(),
   };
   window.ost = { openOfferSelectorTool: sinon.spy() };
   window.tacocat = {

--- a/test/blocks/ost/ost.test.html.js
+++ b/test/blocks/ost/ost.test.html.js
@@ -204,10 +204,12 @@ describe('OST: init', () => {
     });
   });
 
-  it('waits for IMS callback to open OST if query string does not include token', async () => {
+  it('opens OST with the IMS token when query string has no token and user is signed in', async () => {
     const { options: { country, language, workflow } } = mockOstDeps({ mockToken: false });
 
     const token = 'test-token';
+    window.adobeIMS.isSignedInUser.returns(true);
+    window.adobeIMS.getAccessToken.returns({ token });
     const {
       AOS_API_KEY,
       CHECKOUT_CLIENT_ID,
@@ -216,9 +218,6 @@ describe('OST: init', () => {
       default: init,
     } = await import('../../../libs/blocks/ost/ost.js');
     await init(document.body.firstChild);
-
-    expect(window.ost.openOfferSelectorTool.called).to.be.false;
-    window.adobeid.onAccessToken({ token });
 
     expect(window.ost.openOfferSelectorTool.called).to.be.true;
     expect(window.ost.openOfferSelectorTool.getCall(0).args[0]).to.include({
@@ -238,7 +237,7 @@ describe('OST: init', () => {
 
     const { default: init } = await import('../../../libs/blocks/ost/ost.js');
     await init(document.body.firstChild);
-    window.adobeid.onReady();
+    expect(window.ost.openOfferSelectorTool.called).to.be.false;
     expect(window.adobeIMS.signIn.called).to.be.true;
   });
 


### PR DESCRIPTION
* Route OST authentication through the shared `loadIms` helper instead of loading imslib directly with a custom `window.adobeid`
* Fix `/tools/ost` loading error caused by merch.js eagerly initializing IMS (memoized) before OST could set its client id — the merch import is deferred in `loadOstEnv` until after the AOS client id (`aos_milo_commerce`), scope, and prod IMS environment are set
* `getMasLibsBase` now uses `getValidatedMasLibsUrl` directly to drop its static merch dependency

Resolves: [MWPW-205066](https://jira.corp.adobe.com/browse/MWPW-205066)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/tools/ost
- After: https://MWPW-205066--milo--adobecom.aem.page/tools/ost






