### PR TITLE
MWPW-204917 build unav locale from lingo region, not its language tag

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1102,9 +1102,7 @@ class Gnav {
     }
     const config = getConfig();
     const lingoRegion = lingoActive() ? await getLingoRegion({ useGeoLocation: true }) : null;
-    const locale = lingoRegion?.ietf
-      ? lingoRegion.ietf.replace('-', '_')
-      : getUniversalNavLocale(config.locale);
+    const locale = getUniversalNavLocale(lingoRegion ?? config.locale);
     const environment = config.env.name === 'prod' ? 'prod' : 'stage';
     const visitorGuid = window.alloy ? await window.alloy('getIdentity')
       .then((data) => data?.identity?.ECID).catch(() => undefined) : undefined;


### PR DESCRIPTION
## What
Resolves [MWPW-204917](https://jira.corp.adobe.com/browse/MWPW-204917)

On langfirst pages the Universal Nav built its `locale` from the Lingo region's language tag (`ietf`, e.g. `en-GB`). The Unav uses that value to route its links, so English-speaking "global fallback" regions (Ireland, South Africa, Nigeria, New Zealand, …) had their app-switcher "Apps", "All apps / Catalog" and Home links sent to the **UK site** (`/uk/...`), while the page's own links and the cart correctly resolved to the global site + local market.

This derives the Unav locale from the region itself via the existing `getUniversalNavLocale`, so the country is preserved (`en_IE`, `en_ZA`, …) and links route to the region path (which redirects to the global root) instead of `/uk`.

`ietf` stays the language tag; routing follows the region, matching the principle already used for the Adobe Home sign-in redirect (MWPW-194172).

## The change

```diff
-    const locale = lingoRegion?.ietf
-      ? lingoRegion.ietf.replace('-', '_')
-      : getUniversalNavLocale(config.locale);
+    const locale = getUniversalNavLocale(lingoRegion ?? config.locale);
```

Behaviour is identical for every region where the language tag already matched the path (`/fr`, `/de`, `/ca_fr`, `/uk`, …). Only the `en-GB` global-fallback regions change — and the `ietf: 'en'` regions (`africa`, `mena_en`, …), which previously received an invalid bare `en` locale, now receive a valid one.

## How to test

Reproduce the bug on prod (no branch needed):
1. Connect to a Dublin (Ireland) VPN, or append `?akamaiLocale=ie` to simulate the geo.
2. Open `https://www.adobe.com/creativecloud.html`, open the app switcher.
3. **Bug:** "All apps / Catalog" → `https://www.adobe.com/uk/products/catalog.html`, Home → `https://www.adobe.com/uk/`.

Verify the fix with this branch's libs:
1. Open `https://www.stage.adobe.com/creativecloud.html?milolibs=MWPW-204917-unav-region-locale&langfirst=on&mas-geo-detection=on&akamaiLocale=ie`
2. Open the app switcher and inspect the "All apps / Catalog" and Home link hrefs.
3. **Expected:** they point to the Irish region path (`/ie/...`), which 301-redirects to the global root (`https://www.adobe.com/...`) — not `/uk`.
4. Sanity check no regression: repeat with `akamaiLocale=fr` (French links unchanged) and `akamaiLocale=de` (German links unchanged).

Local alternative: `aem up` in milo, then `http://localhost:6456` consumer page with `?milolibs=local&langfirst=on&mas-geo-detection=on&akamaiLocale=ie`.


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- Milo: https://MWPW-204917-unav-region-locale--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- Milo: https://MWPW-204917-unav-region-locale--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- Milo: https://MWPW-204917-unav-region-locale--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-204917-unav-region-locale--milo--adobecom
</details>