### PR TITLE
[MWPW-205039] - Side by side content clashing fix

### DIFF
--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -128,9 +128,27 @@
   }
 
   &.featured {
-    .card-overlay {
+    .content-aux {
+      display: none;
+    }
+
+    div.card-overlay {
       display: flex;
       border: none;
+      aspect-ratio: unset;
+      flex-direction: column;
+      align-items: flex-start;
+
+      .foreground {
+        max-width: unset;
+        min-width: 100%;
+        box-sizing: border-box;
+        background-color: black;
+      }
+    }
+
+    .media {
+      position: unset;
     }
 
     &:has(+ .side-by-side.equal) {
@@ -232,7 +250,6 @@
 
 @media (width >= 1440px) {
   .side-by-side.featured .card-overlay {
-    height: 1200px;
     aspect-ratio: unset;
   }
 }

--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -138,13 +138,7 @@
       aspect-ratio: unset;
       flex-direction: column;
       align-items: flex-start;
-
-      .foreground {
-        max-width: unset;
-        min-width: 100%;
-        box-sizing: border-box;
-        background-color: var(--s2a-color-content-default);
-      }
+      background-color: var(--s2a-color-gray-1000);
     }
 
     .media {

--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -143,6 +143,7 @@
 
     .media {
       position: unset;
+      margin: 0 auto;
     }
 
     &:has(+ .side-by-side.equal) {

--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -143,7 +143,7 @@
         max-width: unset;
         min-width: 100%;
         box-sizing: border-box;
-        background-color: black;
+        background-color: var(--s2a-color-content-default);
       }
     }
 


### PR DESCRIPTION
Restructuring the side-by-side feature variant so we don't depend on spacing for the text from the video, so any dynamic amount of text can be accommodated.

**NOTE**
To fully fix this issue design needs to provide a video without black spacing at the bottom as commented in the ticket.

**UPDATE**
New assets have been uploaded.

Resolves: [MWPW-205039](https://jira.corp.adobe.com/browse/MWPW-205039)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=side-by-side-featured-fix




