### PR TITLE
Bring spacing updates and S2A tokens 0.0.21 into SRF

### DIFF
--- a/.github/workflows/update-s2a-styles.js
+++ b/.github/workflows/update-s2a-styles.js
@@ -19,8 +19,8 @@ const DEPS_DIR = './libs/c2/styles/deps';
 // flat list of `.tgz` files; the package name has no consistent naming pattern,
 // so it is pinned here and bumped manually when a new release ships.
 const DEPS_RELEASE_BASE_URL = 'https://github.com/adobecom/consonant/raw/main/releases';
-const DEPS_PACKAGE = 'adobecom-s2a-tokens-0.0.17.tgz';
-const DEPS_PACKAGE_SHA256 = 'fc1f98e52b723fd2d7c7060826c66a1c0bd3afc4b730478ae6d9609f542bf4a4';
+const DEPS_PACKAGE = 'adobecom-s2a-tokens-0.0.21.tgz';
+const DEPS_PACKAGE_SHA256 = '105edbd0dceaf702af5987255e231a701bc678190d9b5fda475d54fba46b408d';
 // Path inside the extracted package that holds the CSS sources we want to
 // mirror into DEPS_DIR.
 const DEPS_PACKAGE_CSS_SUBPATH = path.join('css', 'dev');
@@ -45,6 +45,9 @@ const EXCLUDED_VAR_PATTERNS = [
   /* waiting for some clarity */
   '--s2a-color-button-*',
   '--s2a-color-iconbutton-*',
+  /* Deprecated */
+  '--s2a-spacing-124',
+  '--s2a-viewport-vertical-padding-*',
 ];
 
 // S2A Build Logic

--- a/libs/blocks/video/video.css
+++ b/libs/blocks/video/video.css
@@ -56,7 +56,7 @@ video {
   }
 }
 
-.video-container .pause-play-wrapper .offset-filler {  
+.video-container .pause-play-wrapper .offset-filler {
   display: inherit;
   justify-content: center;
   align-items: center;
@@ -149,7 +149,7 @@ video {
     left: 2%;
   }
 
-  :is(.section[class*="-up"] .media .foreground .image:first-child, .aside .foreground .image:nth-last-child(1)) 
+  :is(.section[class*="-up"] .media .foreground .image:first-child, .aside .foreground .image:nth-last-child(1))
   .video-container .pause-play-wrapper {
     left: auto;
     right: 2%;
@@ -174,7 +174,7 @@ video {
   button.play-pause-button {
     width: 32px;
     height: 32px;
-    border-radius: var(--s2a-border-radius-xs);
+    border-radius: var(--s2a-border-radius-2xs);
     border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-24);
     background: var(--s2a-color-transparent-black-64);
     backdrop-filter: blur(4px);

--- a/libs/c2/blocks/global-footer/global-footer.css
+++ b/libs/c2/blocks/global-footer/global-footer.css
@@ -159,7 +159,7 @@
   overflow-y: auto;
   background: var(--feds-background-nav);
   border: 1px solid var(--feds-borderColor);
-  border-radius: var(--s2a-border-radius-xs);
+  border-radius: var(--s2a-border-radius-2xs);
 }
 
 [dir = "rtl"] .feds-regionPicker-wrapper > .fragment {

--- a/libs/c2/blocks/hover-list/hover-list.css
+++ b/libs/c2/blocks/hover-list/hover-list.css
@@ -57,7 +57,7 @@
 .hover-list-media {
   align-self: flex-start;
   block-size: 81px;
-  border-radius: var(--s2a-border-radius-sm);
+  border-radius: var(--s2a-border-radius-xs);
   flex-shrink: 0;
   inline-size: 80px;
   overflow: hidden;
@@ -176,7 +176,7 @@
 
   .hover-list-media picture {
     block-size: 320px;
-    border-radius: var(--s2a-border-radius-sm);
+    border-radius: var(--s2a-border-radius-xs);
     inline-size: 280px;
     inset: auto;
     left: 0;

--- a/libs/c2/blocks/offer-hero/offer-hero.css
+++ b/libs/c2/blocks/offer-hero/offer-hero.css
@@ -4,7 +4,7 @@
 
   > .section-background {
     overflow: clip;
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
   }
 }
 
@@ -63,7 +63,7 @@
     position: relative;
     padding-block: 0 var(--s2a-spacing-lg);
     z-index: 2;
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
   }
 
   .hero-eyebrow {
@@ -379,6 +379,6 @@
 
 @media (width > 1440px) {
   .offer-hero .what-included {
-    padding-bottom: var(--s2a-spacing-124);
+    padding-bottom: var(--s2a-spacing-128);
   }
 }

--- a/libs/c2/blocks/pdf-space/pdf-space.css
+++ b/libs/c2/blocks/pdf-space/pdf-space.css
@@ -454,7 +454,7 @@
 
     @media (width >= 1280px) {
       .no-motion-grid-section {
-        padding: var(--s2a-spacing-124) var(--s2a-spacing-64) 0;
+        padding: var(--s2a-spacing-128) var(--s2a-spacing-64) 0;
       }
 
       .text-block {

--- a/libs/c2/blocks/product-marquee-grid/product-marquee-grid.css
+++ b/libs/c2/blocks/product-marquee-grid/product-marquee-grid.css
@@ -54,7 +54,7 @@
     }
 
     .pm-promo-chevron {
-      border-radius: var(--s2a-border-radius-xs);
+      border-radius: var(--s2a-border-radius-2xs);
       border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-12);
       background: var(--s2a-color-transparent-white-16);
       align-items: center;

--- a/libs/c2/blocks/rich-content/rich-content.css
+++ b/libs/c2/blocks/rich-content/rich-content.css
@@ -178,7 +178,7 @@
       justify-content: center;
       width: 30px;
       height: 30px;
-      border-radius: var(--s2a-border-radius-xs);
+      border-radius: var(--s2a-border-radius-2xs);
       background: var(--s2a-color-transparent-white-32);
       border: 1px solid var(--s2a-color-transparent-white-24);
       transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
@@ -573,7 +573,7 @@
 .section.parallax-video-garage-door:has(.rich-content.media) ~ .section {
   --rc-pull-offset: 80px;
   --rc-sweep-offset: 200px;
-  --rc-sweep-peek: var(--s2a-border-radius-lg);
+  --rc-sweep-peek: var(--s2a-border-radius-xl);
   --rc-video-enter-scale: 1.15;
   --rc-video-enter-y: 30px;
 }
@@ -592,12 +592,12 @@
   }
 
   .rich-content.media img {
-    max-width: 1200px; 
+    max-width: 1200px;
     margin: 0 auto;
   }
 
-  .rich-content.media .media-cell .video-container { 
-    max-width: 1200px; 
+  .rich-content.media .media-cell .video-container {
+    max-width: 1200px;
     margin: 0 auto;
   }
 

--- a/libs/c2/blocks/section-metadata/section-metadata.css
+++ b/libs/c2/blocks/section-metadata/section-metadata.css
@@ -22,19 +22,19 @@
   &.rounded-corners,
   &.rounded-corners-top,
   &.rounded-corners-bottom {
-    border-radius: var(--s2a-border-radius-lg);
+    border-radius: var(--s2a-border-radius-xl);
     overflow: clip;
     z-index: 3;
-    margin-block: calc(-1 * var(--s2a-border-radius-lg));
+    margin-block: calc(-1 * var(--s2a-border-radius-xl));
   }
 
   &.rounded-corners-top {
-    border-radius: var(--s2a-border-radius-lg) var(--s2a-border-radius-lg) 0 0;
+    border-radius: var(--s2a-border-radius-xl) var(--s2a-border-radius-xl) 0 0;
     margin-bottom: initial;
   }
 
   &.rounded-corners-bottom {
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
     margin-top: initial;
   }
 

--- a/libs/c2/blocks/social-proof/social-proof.css
+++ b/libs/c2/blocks/social-proof/social-proof.css
@@ -90,7 +90,7 @@
 
 @media (width >= 768px) {
   .social-proof {
-    border-radius: var(--s2a-border-radius-lg);
+    border-radius: var(--s2a-border-radius-xl);
 
     > div {
       flex-direction: row;

--- a/libs/c2/blocks/tour/tour.css
+++ b/libs/c2/blocks/tour/tour.css
@@ -39,7 +39,7 @@
   img {
     width: 100%;
     height: 100%;
-    border-radius: var(--s2a-border-radius-sm);
+    border-radius: var(--s2a-border-radius-xs);
     object-fit: cover;
   }
 }
@@ -98,9 +98,9 @@
     }
     img {
       border-start-start-radius: 0;
-      border-start-end-radius: var(--s2a-border-radius-sm);
+      border-start-end-radius: var(--s2a-border-radius-xs);
       border-end-start-radius: 0;
-      border-end-end-radius: var(--s2a-border-radius-sm);
+      border-end-end-radius: var(--s2a-border-radius-xs);
     }
   }
   &.row-3 {
@@ -193,7 +193,7 @@
   &.is-dismissing {
     --tour-drag-y: 100%;
   }
-  
+
   .dialog-close {
     width: 48px;
     height: 48px;

--- a/libs/c2/styles/deps/tokens.primitives.css
+++ b/libs/c2/styles/deps/tokens.primitives.css
@@ -147,9 +147,11 @@
   --s2a-border-radius-0: 0;
   --s2a-border-radius-2: 2px;
   --s2a-border-radius-4: 4px;
+  --s2a-border-radius-6: 6px;
   --s2a-border-radius-8: 8px;
   --s2a-border-radius-12: 12px;
   --s2a-border-radius-16: 16px;
+  --s2a-border-radius-22: 22px;
   --s2a-border-radius-24: 24px;
   --s2a-border-radius-32: 32px;
   --s2a-border-radius-999: 999px;
@@ -207,7 +209,8 @@
   --s2a-spacing-64: 64px;
   --s2a-spacing-80: 80px;
   --s2a-spacing-96: 96px;
-  --s2a-spacing-124: 124px;
+  --s2a-spacing-124: 124px; /** DEPRECATED — use spacing/128 instead. Retained temporarily because Milo still references 124px; do not use in new work. Remove once Milo migrates off it. (MWPW-202891) */
+  --s2a-spacing-128: 128px;
   --s2a-spacing-160: 160px;
   --s2a-spacing-240: 240px;
 

--- a/libs/c2/styles/deps/tokens.responsive.lg.css
+++ b/libs/c2/styles/deps/tokens.responsive.lg.css
@@ -5,13 +5,27 @@
 
 :root {
   /* Viewport & Section Padding */
-  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl);
-  --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl);
-  --s2a-viewport-vertical-padding-md: var(--s2a-layout-lg);
-  --s2a-viewport-vertical-padding-sm: var(--s2a-layout-sm);
-  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-4xl);
-  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl);
-  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
+  --s2a-section-spacing-none: var(--s2a-spacing-none); /** Milo-specific declarations */
+  --s2a-section-spacing-5xs: var(--s2a-spacing-xs);
+  --s2a-section-spacing-4xs: var(--s2a-spacing-sm);
+  --s2a-section-spacing-3xs: var(--s2a-spacing-md);
+  --s2a-section-spacing-2xs: var(--s2a-spacing-lg);
+  --s2a-section-spacing-xs: var(--s2a-spacing-xl);
+  --s2a-section-spacing-sm: var(--s2a-spacing-2xl);
+  --s2a-section-spacing-md: var(--s2a-spacing-3xl);
+  --s2a-section-spacing-lg: var(--s2a-spacing-4xl); /** Milo-specific declarations */
+  --s2a-section-spacing-xl: var(--s2a-layout-lg); /** Milo-specific declarations */
+  --s2a-section-spacing-2xl: var(--s2a-layout-lg); /** Milo-specific declarations */
+  --s2a-section-spacing-3xl: var(--s2a-layout-lg); /** Milo-specific declarations */
+  --s2a-section-spacing-4xl: var(--s2a-layout-lg); /** Milo-specific declarations */
+  --s2a-section-spacing-5xl: var(--s2a-layout-2xl); /** Milo-specific declarations */
+  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-md: var(--s2a-layout-lg); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-sm: var(--s2a-layout-sm); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-4xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
 
   /* Layout */
   --s2a-layout-guide-gap: var(--s2a-spacing-xs);
@@ -63,6 +77,14 @@
   --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-lg);
   --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-md);
   --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
+
+  /* Other */
+  --s2a-hover-list-number-container-width: 64px;
+  --s2a-hover-list-padding-vertical: var(--s2a-spacing-lg);
+  --s2a-side-by-side-max-width-overlay: 400px;
+  --s2a-side-by-side-padding-overlay: var(--s2a-spacing-xl);
+  --s2a-side-by-side-padding-underlay: var(--s2a-spacing-lg);
+  --s2a-tab-side-padding: var(--s2a-spacing-lg);
 }
 
 }

--- a/libs/c2/styles/deps/tokens.responsive.md.css
+++ b/libs/c2/styles/deps/tokens.responsive.md.css
@@ -5,13 +5,27 @@
 
 :root {
   /* Viewport & Section Padding */
-  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-xl);
-  --s2a-viewport-vertical-padding-lg: var(--s2a-layout-lg);
-  --s2a-viewport-vertical-padding-md: var(--s2a-layout-sm);
-  --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-4xl);
-  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-2xl);
-  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl);
-  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
+  --s2a-section-spacing-none: var(--s2a-spacing-none); /** Milo-specific declarations */
+  --s2a-section-spacing-5xs: var(--s2a-spacing-xs);
+  --s2a-section-spacing-4xs: var(--s2a-spacing-sm);
+  --s2a-section-spacing-3xs: var(--s2a-spacing-md);
+  --s2a-section-spacing-2xs: var(--s2a-spacing-lg);
+  --s2a-section-spacing-xs: var(--s2a-spacing-lg);
+  --s2a-section-spacing-sm: var(--s2a-spacing-xl);
+  --s2a-section-spacing-md: var(--s2a-spacing-lg);
+  --s2a-section-spacing-lg: var(--s2a-spacing-xl); /** Milo-specific declarations */
+  --s2a-section-spacing-xl: var(--s2a-layout-sm); /** Milo-specific declarations */
+  --s2a-section-spacing-2xl: var(--s2a-layout-sm); /** Milo-specific declarations */
+  --s2a-section-spacing-3xl: var(--s2a-spacing-4xl); /** Milo-specific declarations */
+  --s2a-section-spacing-4xl: var(--s2a-layout-sm); /** Milo-specific declarations */
+  --s2a-section-spacing-5xl: var(--s2a-layout-xl); /** Milo-specific declarations */
+  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-lg: var(--s2a-layout-lg); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-md: var(--s2a-layout-sm); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-4xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-2xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
 
   /* Layout */
   --s2a-layout-guide-gap: var(--s2a-spacing-xs);
@@ -63,6 +77,14 @@
   --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-md);
   --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
+
+  /* Other */
+  --s2a-hover-list-number-container-width: 32px;
+  --s2a-hover-list-padding-vertical: var(--s2a-spacing-lg);
+  --s2a-side-by-side-max-width-overlay: 250px;
+  --s2a-side-by-side-padding-overlay: var(--s2a-spacing-lg);
+  --s2a-side-by-side-padding-underlay: var(--s2a-spacing-md);
+  --s2a-tab-side-padding: var(--s2a-spacing-lg);
 }
 
 }

--- a/libs/c2/styles/deps/tokens.responsive.sm.css
+++ b/libs/c2/styles/deps/tokens.responsive.sm.css
@@ -4,13 +4,27 @@
 
 :root {
   /* Viewport & Section Padding */
-  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-sm);
-  --s2a-viewport-vertical-padding-lg: var(--s2a-spacing-4xl);
-  --s2a-viewport-vertical-padding-md: var(--s2a-spacing-2xl);
-  --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-xl);
-  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-lg);
-  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-md);
-  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
+  --s2a-section-spacing-none: var(--s2a-spacing-none); /** Milo-specific declarations */
+  --s2a-section-spacing-5xs: var(--s2a-spacing-xs);
+  --s2a-section-spacing-4xs: var(--s2a-spacing-sm);
+  --s2a-section-spacing-3xs: var(--s2a-spacing-md);
+  --s2a-section-spacing-2xs: var(--s2a-spacing-xs);
+  --s2a-section-spacing-xs: var(--s2a-spacing-lg);
+  --s2a-section-spacing-sm: var(--s2a-spacing-lg);
+  --s2a-section-spacing-md: var(--s2a-spacing-lg);
+  --s2a-section-spacing-lg: var(--s2a-spacing-xl); /** Milo-specific declarations */
+  --s2a-section-spacing-xl: var(--s2a-spacing-2xl); /** Milo-specific declarations */
+  --s2a-section-spacing-2xl: var(--s2a-spacing-lg); /** Milo-specific declarations */
+  --s2a-section-spacing-3xl: var(--s2a-spacing-2xl); /** Milo-specific declarations */
+  --s2a-section-spacing-4xl: var(--s2a-spacing-4xl); /** Milo-specific declarations */
+  --s2a-section-spacing-5xl: var(--s2a-layout-sm); /** Milo-specific declarations */
+  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-sm); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-lg: var(--s2a-spacing-4xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-md: var(--s2a-spacing-2xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-lg); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-md); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
 
   /* Layout */
   --s2a-layout-guide-gap: var(--s2a-spacing-xs);
@@ -62,4 +76,12 @@
   --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-sm);
   --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
+
+  /* Other */
+  --s2a-hover-list-number-container-width: 24px;
+  --s2a-hover-list-padding-vertical: var(--s2a-spacing-xl);
+  --s2a-side-by-side-max-width-overlay: 320px;
+  --s2a-side-by-side-padding-overlay: var(--s2a-spacing-lg);
+  --s2a-side-by-side-padding-underlay: var(--s2a-spacing-sm);
+  --s2a-tab-side-padding: 20px;
 }

--- a/libs/c2/styles/deps/tokens.responsive.xl.css
+++ b/libs/c2/styles/deps/tokens.responsive.xl.css
@@ -5,13 +5,27 @@
 
 :root {
   /* Viewport & Section Padding */
-  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl);
-  --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl);
-  --s2a-viewport-vertical-padding-md: var(--s2a-layout-lg);
-  --s2a-viewport-vertical-padding-sm: var(--s2a-layout-sm);
-  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-4xl);
-  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl);
-  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
+  --s2a-section-spacing-none: var(--s2a-spacing-none); /** Milo-specific declarations */
+  --s2a-section-spacing-5xs: var(--s2a-spacing-xs);
+  --s2a-section-spacing-4xs: var(--s2a-spacing-sm);
+  --s2a-section-spacing-3xs: var(--s2a-spacing-md);
+  --s2a-section-spacing-2xs: var(--s2a-spacing-lg);
+  --s2a-section-spacing-xs: var(--s2a-spacing-xl);
+  --s2a-section-spacing-sm: var(--s2a-spacing-2xl);
+  --s2a-section-spacing-md: var(--s2a-spacing-3xl);
+  --s2a-section-spacing-lg: var(--s2a-spacing-4xl); /** Milo-specific declarations */
+  --s2a-section-spacing-xl: var(--s2a-layout-lg); /** Milo-specific declarations */
+  --s2a-section-spacing-2xl: var(--s2a-layout-lg); /** Milo-specific declarations */
+  --s2a-section-spacing-3xl: var(--s2a-layout-lg); /** Milo-specific declarations */
+  --s2a-section-spacing-4xl: var(--s2a-layout-lg); /** Milo-specific declarations */
+  --s2a-section-spacing-5xl: var(--s2a-layout-2xl); /** Milo-specific declarations */
+  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-md: var(--s2a-layout-lg); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-sm: var(--s2a-layout-sm); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-4xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
+  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none); /** Deprecated — scheduled for removal in favor of --s2a-section-spacing-*. Restored 2026-08 after being accidentally dropped from a Figma export; keeping bound until we confirm nothing else still consumes it. */
 
   /* Layout */
   --s2a-layout-guide-gap: var(--s2a-spacing-xs);
@@ -63,6 +77,14 @@
   --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-lg);
   --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-md);
   --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
+
+  /* Other */
+  --s2a-hover-list-number-container-width: 64px;
+  --s2a-hover-list-padding-vertical: var(--s2a-spacing-lg);
+  --s2a-side-by-side-max-width-overlay: 400px;
+  --s2a-side-by-side-padding-overlay: var(--s2a-spacing-2xl);
+  --s2a-side-by-side-padding-underlay: var(--s2a-spacing-2xl);
+  --s2a-tab-side-padding: var(--s2a-spacing-lg);
 }
 
 }

--- a/libs/c2/styles/deps/tokens.semantic.css
+++ b/libs/c2/styles/deps/tokens.semantic.css
@@ -4,11 +4,13 @@
 
 :root {
   /* Border Radius */
-  --s2a-border-radius-2xs: var(--s2a-border-radius-2);
-  --s2a-border-radius-xs: var(--s2a-border-radius-4);
-  --s2a-border-radius-sm: var(--s2a-border-radius-8);
+  --s2a-border-radius-2xs: var(--s2a-border-radius-4);
+  --s2a-border-radius-xs: var(--s2a-border-radius-8);
+  --s2a-border-radius-sm: var(--s2a-border-radius-12);
   --s2a-border-radius-md: var(--s2a-border-radius-16);
-  --s2a-border-radius-lg: var(--s2a-border-radius-32);
+  --s2a-border-radius-lg: var(--s2a-border-radius-22);
+  --s2a-border-radius-xl: var(--s2a-border-radius-32);
+  --s2a-border-radius-3xs: var(--s2a-border-radius-2);
   --s2a-border-radius-none: var(--s2a-border-radius-0);
   --s2a-border-radius-round: var(--s2a-border-radius-999);
 
@@ -102,7 +104,8 @@
   /* Layout */
   --s2a-layout-sm: var(--s2a-spacing-80);
   --s2a-layout-md: var(--s2a-spacing-96);
-  --s2a-layout-lg: var(--s2a-spacing-124);
+  --s2a-layout-lg: var(--s2a-spacing-128);
   --s2a-layout-xl: var(--s2a-spacing-160);
   --s2a-layout-2xl: var(--s2a-spacing-240);
+  --s2a-layout-none: var(--s2a-spacing-0);
 }

--- a/libs/c2/styles/deps/tokens.semantic.dark.css
+++ b/libs/c2/styles/deps/tokens.semantic.dark.css
@@ -79,7 +79,7 @@
   --s2a-color-iconbutton-background-accent-solid-on-light-default: var(--s2a-color-blue-900);
   --s2a-color-iconbutton-background-accent-solid-on-light-hover: var(--s2a-color-blue-1000);
   --s2a-color-iconbutton-background-primary-outlined-on-dark-active: var(--s2a-color-gray-25);
-  --s2a-color-iconbutton-background-primary-outlined-on-dark-defatul: var(--s2a-color-transparent-white-24);
+  --s2a-color-iconbutton-background-primary-outlined-on-dark-default: var(--s2a-color-transparent-white-24);
   --s2a-color-iconbutton-background-primary-outlined-on-dark-hover: var(--s2a-color-transparent-white-64);
   --s2a-color-iconbutton-background-primary-outlined-on-light-active: var(--s2a-color-gray-25);
   --s2a-color-iconbutton-background-primary-outlined-on-light-default: var(--s2a-color-transparent-white-00);
@@ -97,12 +97,14 @@
   --s2a-color-iconbutton-background-primary-transparent-on-light-default: var(--s2a-color-transparent-white-00);
   --s2a-color-iconbutton-background-primary-transparent-on-light-hover: var(--s2a-color-transparent-white-12);
   --s2a-color-iconbutton-border-primary-outlined-default: var(--s2a-color-gray-25);
-  --s2a-color-iconbutton-border-primary-outlined-on-dark: var(--s2a-color-gray-700);
-  --s2a-color-iconbutton-border-primary-solid-default: var(--s2a-color-gray-25);
+  --s2a-color-iconbutton-border-primary-outlined-on-dark-default: var(--s2a-color-gray-700);
+  --s2a-color-iconbutton-border-primary-solid-on-dark-default: var(--s2a-color-gray-25);
+  --s2a-color-iconbutton-border-primary-solid-on-light-default: var(--s2a-color-gray-25);
   --s2a-color-iconbutton-content-primary-outlined-default: var(--s2a-color-gray-25);
   --s2a-color-iconbutton-content-primary-outlined-knockout: var(--s2a-color-gray-25);
   --s2a-color-iconbutton-content-primary-solid-default: var(--s2a-color-gray-1000);
   --s2a-color-iconbutton-content-primary-solid-inverse: var(--s2a-color-gray-1000);
   --s2a-color-iconbutton-content-primary-transparent-default: var(--s2a-color-gray-25);
   --s2a-color-iconbutton-content-primary-transparent-knockout: var(--s2a-color-gray-25);
+  --s2a-color-promo-cta-button-background-neutral-on-image-on-dark-active: var(--s2a-color-background-inverse);
 }

--- a/libs/c2/styles/deps/tokens.semantic.light.css
+++ b/libs/c2/styles/deps/tokens.semantic.light.css
@@ -79,7 +79,7 @@
   --s2a-color-iconbutton-background-accent-solid-on-light-default: var(--s2a-color-blue-900);
   --s2a-color-iconbutton-background-accent-solid-on-light-hover: var(--s2a-color-blue-1000);
   --s2a-color-iconbutton-background-primary-outlined-on-dark-active: var(--s2a-color-gray-25);
-  --s2a-color-iconbutton-background-primary-outlined-on-dark-defatul: var(--s2a-color-transparent-white-00);
+  --s2a-color-iconbutton-background-primary-outlined-on-dark-default: var(--s2a-color-transparent-white-00);
   --s2a-color-iconbutton-background-primary-outlined-on-dark-hover: var(--s2a-color-transparent-white-64);
   --s2a-color-iconbutton-background-primary-outlined-on-light-active: var(--s2a-color-gray-1000);
   --s2a-color-iconbutton-background-primary-outlined-on-light-default: var(--s2a-color-transparent-black-00);
@@ -97,12 +97,14 @@
   --s2a-color-iconbutton-background-primary-transparent-on-light-default: var(--s2a-color-transparent-black-00);
   --s2a-color-iconbutton-background-primary-transparent-on-light-hover: var(--s2a-color-transparent-black-08);
   --s2a-color-iconbutton-border-primary-outlined-default: var(--s2a-color-gray-1000);
-  --s2a-color-iconbutton-border-primary-outlined-on-dark: var(--s2a-color-gray-25);
-  --s2a-color-iconbutton-border-primary-solid-default: var(--s2a-color-transparent-white-12);
+  --s2a-color-iconbutton-border-primary-outlined-on-dark-default: var(--s2a-color-gray-25);
+  --s2a-color-iconbutton-border-primary-solid-on-dark-default: var(--s2a-color-gray-25);
+  --s2a-color-iconbutton-border-primary-solid-on-light-default: var(--s2a-color-gray-1000);
   --s2a-color-iconbutton-content-primary-outlined-default: var(--s2a-color-gray-1000);
   --s2a-color-iconbutton-content-primary-outlined-knockout: var(--s2a-color-gray-25);
   --s2a-color-iconbutton-content-primary-solid-default: var(--s2a-color-gray-25);
   --s2a-color-iconbutton-content-primary-solid-inverse: var(--s2a-color-gray-1000);
   --s2a-color-iconbutton-content-primary-transparent-default: var(--s2a-color-gray-1000);
   --s2a-color-iconbutton-content-primary-transparent-knockout: var(--s2a-color-gray-25);
+  --s2a-color-promo-cta-button-background-neutral-on-image-on-dark-active: var(--s2a-color-background-default);
 }

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -146,9 +146,11 @@
   --s2a-border-radius-0: 0;
   --s2a-border-radius-2: 2px;
   --s2a-border-radius-4: 4px;
+  --s2a-border-radius-6: 6px;
   --s2a-border-radius-8: 8px;
   --s2a-border-radius-12: 12px;
   --s2a-border-radius-16: 16px;
+  --s2a-border-radius-22: 22px;
   --s2a-border-radius-24: 24px;
   --s2a-border-radius-32: 32px;
   --s2a-border-radius-999: 999px;
@@ -198,7 +200,7 @@
   --s2a-spacing-64: 64px;
   --s2a-spacing-80: 80px;
   --s2a-spacing-96: 96px;
-  --s2a-spacing-124: 124px;
+  --s2a-spacing-128: 128px;
   --s2a-spacing-160: 160px;
   --s2a-spacing-240: 240px;
   --s2a-font-family-adobe-clean: "Adobe Clean";
@@ -258,11 +260,13 @@
 
   /* tokens.semantic */
   --s2a-border-radius-none: var(--s2a-border-radius-0);
-  --s2a-border-radius-2xs: var(--s2a-border-radius-2);
-  --s2a-border-radius-xs: var(--s2a-border-radius-4);
-  --s2a-border-radius-sm: var(--s2a-border-radius-8);
+  --s2a-border-radius-3xs: var(--s2a-border-radius-2);
+  --s2a-border-radius-2xs: var(--s2a-border-radius-4);
+  --s2a-border-radius-xs: var(--s2a-border-radius-8);
+  --s2a-border-radius-sm: var(--s2a-border-radius-12);
   --s2a-border-radius-md: var(--s2a-border-radius-16);
-  --s2a-border-radius-lg: var(--s2a-border-radius-32);
+  --s2a-border-radius-lg: var(--s2a-border-radius-22);
+  --s2a-border-radius-xl: var(--s2a-border-radius-32);
   --s2a-border-radius-round: var(--s2a-border-radius-999);
   --s2a-border-width-sm: var(--s2a-border-width-1);
   --s2a-border-width-md: var(--s2a-border-width-2);
@@ -276,9 +280,9 @@
   --s2a-spacing-xs: var(--s2a-spacing-8);
   --s2a-spacing-sm: var(--s2a-spacing-12);
   --s2a-spacing-md: var(--s2a-spacing-16);
+  --s2a-spacing-lg: var(--s2a-spacing-24);
   --s2a-spacing-xl: var(--s2a-spacing-32);
   --s2a-spacing-2xl: var(--s2a-spacing-40);
-  --s2a-spacing-lg: var(--s2a-spacing-24);
   --s2a-spacing-3xl: var(--s2a-spacing-48);
   --s2a-spacing-4xl: var(--s2a-spacing-64);
   --s2a-font-family-heading: var(--s2a-font-family-adobe-clean-display);
@@ -328,9 +332,10 @@
   --s2a-blur-sm: var(--s2a-blur-16);
   --s2a-blur-md: var(--s2a-blur-32);
   --s2a-blur-lg: var(--s2a-blur-64);
+  --s2a-layout-none: var(--s2a-spacing-0);
   --s2a-layout-sm: var(--s2a-spacing-80);
   --s2a-layout-md: var(--s2a-spacing-96);
-  --s2a-layout-lg: var(--s2a-spacing-124);
+  --s2a-layout-lg: var(--s2a-spacing-128);
   --s2a-layout-xl: var(--s2a-spacing-160);
   --s2a-layout-2xl: var(--s2a-spacing-240);
 
@@ -369,13 +374,20 @@
   --s2a-color-focus-ring-knockout: var(--s2a-color-gray-25);
 
   /* tokens.responsive.sm */
-  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
-  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-md);
-  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-lg);
-  --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-xl);
-  --s2a-viewport-vertical-padding-md: var(--s2a-spacing-2xl);
-  --s2a-viewport-vertical-padding-lg: var(--s2a-spacing-4xl);
-  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-sm);
+  --s2a-section-spacing-none: var(--s2a-spacing-none);
+  --s2a-section-spacing-5xs: var(--s2a-spacing-xs);
+  --s2a-section-spacing-4xs: var(--s2a-spacing-sm);
+  --s2a-section-spacing-3xs: var(--s2a-spacing-md);
+  --s2a-section-spacing-2xs: var(--s2a-spacing-xs);
+  --s2a-section-spacing-xs: var(--s2a-spacing-lg);
+  --s2a-section-spacing-sm: var(--s2a-spacing-lg);
+  --s2a-section-spacing-md: var(--s2a-spacing-lg);
+  --s2a-section-spacing-lg: var(--s2a-spacing-xl);
+  --s2a-section-spacing-xl: var(--s2a-spacing-2xl);
+  --s2a-section-spacing-2xl: var(--s2a-spacing-lg);
+  --s2a-section-spacing-3xl: var(--s2a-spacing-2xl);
+  --s2a-section-spacing-4xl: var(--s2a-spacing-4xl);
+  --s2a-section-spacing-5xl: var(--s2a-layout-sm);
   --s2a-layout-guide-gap: var(--s2a-spacing-xs);
   --s2a-typography-font-size-super: var(--s2a-font-size-7xl);
   --s2a-typography-font-size-heading-1: var(--s2a-font-size-5xl);
@@ -763,29 +775,63 @@ p {
   display: none;
 }
 
-.spacing-none { padding-block: var(--s2a-viewport-vertical-padding-none); }
-.spacing-2xs  { padding-block: var(--s2a-viewport-vertical-padding-2xs); }
-.spacing-xs   { padding-block: var(--s2a-viewport-vertical-padding-xs); }
-.spacing-sm   { padding-block: var(--s2a-viewport-vertical-padding-sm); }
-.spacing-md   { padding-block: var(--s2a-viewport-vertical-padding-md); }
-.spacing-lg   { padding-block: var(--s2a-viewport-vertical-padding-lg); }
-.spacing-xl   { padding-block: var(--s2a-viewport-vertical-padding-xl); }
+/* Scaled spacing (viewport-responsive) */
+[class*="spacing-none"]:not([class*="spacing-none-static"], [class*="spacing-none-bottom"]) { padding-top: var(--s2a-section-spacing-none); }
+[class*="spacing-none"]:not([class*="spacing-none-static"], [class*="spacing-none-top"])    { padding-bottom: var(--s2a-section-spacing-none); }
+[class*="spacing-5xs"]:not([class*="spacing-5xs-static"], [class*="spacing-5xs-bottom"]) { padding-top: var(--s2a-section-spacing-5xs); }
+[class*="spacing-5xs"]:not([class*="spacing-5xs-static"], [class*="spacing-5xs-top"])    { padding-bottom: var(--s2a-section-spacing-5xs); }
+[class*="spacing-4xs"]:not([class*="spacing-4xs-static"], [class*="spacing-4xs-bottom"]) { padding-top: var(--s2a-section-spacing-4xs); }
+[class*="spacing-4xs"]:not([class*="spacing-4xs-static"], [class*="spacing-4xs-top"])    { padding-bottom: var(--s2a-section-spacing-4xs); }
+[class*="spacing-3xs"]:not([class*="spacing-3xs-static"], [class*="spacing-3xs-bottom"]) { padding-top: var(--s2a-section-spacing-3xs); }
+[class*="spacing-3xs"]:not([class*="spacing-3xs-static"], [class*="spacing-3xs-top"])    { padding-bottom: var(--s2a-section-spacing-3xs); }
+[class*="spacing-2xs"]:not([class*="spacing-2xs-static"], [class*="spacing-2xs-bottom"]) { padding-top: var(--s2a-section-spacing-2xs); }
+[class*="spacing-2xs"]:not([class*="spacing-2xs-static"], [class*="spacing-2xs-top"])    { padding-bottom: var(--s2a-section-spacing-2xs); }
+[class*="spacing-xs"]:not([class*="spacing-xs-static"], [class*="spacing-xs-bottom"]) { padding-top: var(--s2a-section-spacing-xs); }
+[class*="spacing-xs"]:not([class*="spacing-xs-static"], [class*="spacing-xs-top"])    { padding-bottom: var(--s2a-section-spacing-xs); }
+[class*="spacing-sm"]:not([class*="spacing-sm-static"], [class*="spacing-sm-bottom"]) { padding-top: var(--s2a-section-spacing-sm); }
+[class*="spacing-sm"]:not([class*="spacing-sm-static"], [class*="spacing-sm-top"])    { padding-bottom: var(--s2a-section-spacing-sm); }
+[class*="spacing-md"]:not([class*="spacing-md-static"], [class*="spacing-md-bottom"]) { padding-top: var(--s2a-section-spacing-md); }
+[class*="spacing-md"]:not([class*="spacing-md-static"], [class*="spacing-md-top"])    { padding-bottom: var(--s2a-section-spacing-md); }
+[class*="spacing-lg"]:not([class*="spacing-lg-static"], [class*="spacing-lg-bottom"]) { padding-top: var(--s2a-section-spacing-lg); }
+[class*="spacing-lg"]:not([class*="spacing-lg-static"], [class*="spacing-lg-top"])    { padding-bottom: var(--s2a-section-spacing-lg); }
+[class*="spacing-xl"]:not([class*="spacing-xl-static"], [class*="spacing-xl-bottom"]) { padding-top: var(--s2a-section-spacing-xl); }
+[class*="spacing-xl"]:not([class*="spacing-xl-static"], [class*="spacing-xl-top"])    { padding-bottom: var(--s2a-section-spacing-xl); }
+[class*="spacing-2xl"]:not([class*="spacing-2xl-static"], [class*="spacing-2xl-bottom"]) { padding-top: var(--s2a-section-spacing-2xl); }
+[class*="spacing-2xl"]:not([class*="spacing-2xl-static"], [class*="spacing-2xl-top"])    { padding-bottom: var(--s2a-section-spacing-2xl); }
+[class*="spacing-3xl"]:not([class*="spacing-3xl-static"], [class*="spacing-3xl-bottom"]) { padding-top: var(--s2a-section-spacing-3xl); }
+[class*="spacing-3xl"]:not([class*="spacing-3xl-static"], [class*="spacing-3xl-top"])    { padding-bottom: var(--s2a-section-spacing-3xl); }
+[class*="spacing-4xl"]:not([class*="spacing-4xl-static"], [class*="spacing-4xl-bottom"]) { padding-top: var(--s2a-section-spacing-4xl); }
+[class*="spacing-4xl"]:not([class*="spacing-4xl-static"], [class*="spacing-4xl-top"])    { padding-bottom: var(--s2a-section-spacing-4xl); }
+[class*="spacing-5xl"]:not([class*="spacing-5xl-static"], [class*="spacing-5xl-bottom"]) { padding-top: var(--s2a-section-spacing-5xl); }
+[class*="spacing-5xl"]:not([class*="spacing-5xl-static"], [class*="spacing-5xl-top"])    { padding-bottom: var(--s2a-section-spacing-5xl); }
 
-.spacing-none-top { padding-top: var(--s2a-viewport-vertical-padding-none); }
-.spacing-2xs-top  { padding-top: var(--s2a-viewport-vertical-padding-2xs); }
-.spacing-xs-top   { padding-top: var(--s2a-viewport-vertical-padding-xs); }
-.spacing-sm-top   { padding-top: var(--s2a-viewport-vertical-padding-sm); }
-.spacing-md-top   { padding-top: var(--s2a-viewport-vertical-padding-md); }
-.spacing-lg-top   { padding-top: var(--s2a-viewport-vertical-padding-lg); }
-.spacing-xl-top   { padding-top: var(--s2a-viewport-vertical-padding-xl); }
-
-.spacing-none-bottom { padding-bottom: var(--s2a-viewport-vertical-padding-none); }
-.spacing-2xs-bottom  { padding-bottom: var(--s2a-viewport-vertical-padding-2xs); }
-.spacing-xs-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-xs); }
-.spacing-sm-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-sm); }
-.spacing-md-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-md); }
-.spacing-lg-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-lg); }
-.spacing-xl-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-xl); }
+/* Static spacing (fixed tokens) */
+[class*="spacing-5xs-static"]:not([class*="spacing-5xs-static-bottom"]) { padding-top: var(--s2a-spacing-xs); }
+[class*="spacing-5xs-static"]:not([class*="spacing-5xs-static-top"])    { padding-bottom: var(--s2a-spacing-xs); }
+[class*="spacing-4xs-static"]:not([class*="spacing-4xs-static-bottom"]) { padding-top: var(--s2a-spacing-sm); }
+[class*="spacing-4xs-static"]:not([class*="spacing-4xs-static-top"])    { padding-bottom: var(--s2a-spacing-sm); }
+[class*="spacing-3xs-static"]:not([class*="spacing-3xs-static-bottom"]) { padding-top: var(--s2a-spacing-md); }
+[class*="spacing-3xs-static"]:not([class*="spacing-3xs-static-top"])    { padding-bottom: var(--s2a-spacing-md); }
+[class*="spacing-2xs-static"]:not([class*="spacing-2xs-static-bottom"]) { padding-top: var(--s2a-spacing-lg); }
+[class*="spacing-2xs-static"]:not([class*="spacing-2xs-static-top"])    { padding-bottom: var(--s2a-spacing-lg); }
+[class*="spacing-xs-static"]:not([class*="spacing-xs-static-bottom"]) { padding-top: var(--s2a-spacing-xl); }
+[class*="spacing-xs-static"]:not([class*="spacing-xs-static-top"])    { padding-bottom: var(--s2a-spacing-xl); }
+[class*="spacing-sm-static"]:not([class*="spacing-sm-static-bottom"]) { padding-top: var(--s2a-spacing-2xl); }
+[class*="spacing-sm-static"]:not([class*="spacing-sm-static-top"])    { padding-bottom: var(--s2a-spacing-2xl); }
+[class*="spacing-md-static"]:not([class*="spacing-md-static-bottom"]) { padding-top: var(--s2a-spacing-3xl); }
+[class*="spacing-md-static"]:not([class*="spacing-md-static-top"])    { padding-bottom: var(--s2a-spacing-3xl); }
+[class*="spacing-lg-static"]:not([class*="spacing-lg-static-bottom"]) { padding-top: var(--s2a-spacing-4xl); }
+[class*="spacing-lg-static"]:not([class*="spacing-lg-static-top"])    { padding-bottom: var(--s2a-spacing-4xl); }
+[class*="spacing-xl-static"]:not([class*="spacing-xl-static-bottom"]) { padding-top: var(--s2a-layout-sm); }
+[class*="spacing-xl-static"]:not([class*="spacing-xl-static-top"])    { padding-bottom: var(--s2a-layout-sm); }
+[class*="spacing-2xl-static"]:not([class*="spacing-2xl-static-bottom"]) { padding-top: var(--s2a-layout-md); }
+[class*="spacing-2xl-static"]:not([class*="spacing-2xl-static-top"])    { padding-bottom: var(--s2a-layout-md); }
+[class*="spacing-3xl-static"]:not([class*="spacing-3xl-static-bottom"]) { padding-top: var(--s2a-layout-lg); }
+[class*="spacing-3xl-static"]:not([class*="spacing-3xl-static-top"])    { padding-bottom: var(--s2a-layout-lg); }
+[class*="spacing-4xl-static"]:not([class*="spacing-4xl-static-bottom"]) { padding-top: var(--s2a-layout-xl); }
+[class*="spacing-4xl-static"]:not([class*="spacing-4xl-static-top"])    { padding-bottom: var(--s2a-layout-xl); }
+[class*="spacing-5xl-static"]:not([class*="spacing-5xl-static-bottom"]) { padding-top: var(--s2a-layout-2xl); }
+[class*="spacing-5xl-static"]:not([class*="spacing-5xl-static-top"])    { padding-bottom: var(--s2a-layout-2xl); }
 
 .container {
   --grid-max-width: var(--grid-max-width-default);
@@ -1546,12 +1592,13 @@ span.hang-opening-quote {
 @media (width >= 1024px) {
   :root {
     /* tokens.responsive.md */
-    --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl);
-    --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-2xl);
-    --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-4xl);
-    --s2a-viewport-vertical-padding-md: var(--s2a-layout-sm);
-    --s2a-viewport-vertical-padding-lg: var(--s2a-layout-lg);
-    --s2a-viewport-vertical-padding-xl: var(--s2a-layout-xl);
+    --s2a-section-spacing-2xs: var(--s2a-spacing-lg);
+    --s2a-section-spacing-sm: var(--s2a-spacing-xl);
+    --s2a-section-spacing-xl: var(--s2a-layout-sm);
+    --s2a-section-spacing-2xl: var(--s2a-layout-sm);
+    --s2a-section-spacing-3xl: var(--s2a-spacing-4xl);
+    --s2a-section-spacing-4xl: var(--s2a-layout-sm);
+    --s2a-section-spacing-5xl: var(--s2a-layout-xl);
     --s2a-typography-font-size-super: var(--s2a-font-size-9xl);
     --s2a-typography-font-size-heading-1: var(--s2a-font-size-7xl);
     --s2a-typography-font-size-heading-2: var(--s2a-font-size-6xl);
@@ -1576,11 +1623,15 @@ span.hang-opening-quote {
 @media (width >= 1280px) {
   :root {
     /* tokens.responsive.lg */
-    --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-4xl);
-    --s2a-viewport-vertical-padding-sm: var(--s2a-layout-sm);
-    --s2a-viewport-vertical-padding-md: var(--s2a-layout-lg);
-    --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl);
-    --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl);
+    --s2a-section-spacing-xs: var(--s2a-spacing-xl);
+    --s2a-section-spacing-sm: var(--s2a-spacing-2xl);
+    --s2a-section-spacing-md: var(--s2a-spacing-3xl);
+    --s2a-section-spacing-lg: var(--s2a-spacing-4xl);
+    --s2a-section-spacing-xl: var(--s2a-layout-lg);
+    --s2a-section-spacing-2xl: var(--s2a-layout-lg);
+    --s2a-section-spacing-3xl: var(--s2a-layout-lg);
+    --s2a-section-spacing-4xl: var(--s2a-layout-lg);
+    --s2a-section-spacing-5xl: var(--s2a-layout-2xl);
     --s2a-typography-font-size-super: var(--s2a-font-size-11xl);
     --s2a-typography-font-size-heading-1: var(--s2a-font-size-10xl);
     --s2a-typography-font-size-heading-2: var(--s2a-font-size-7xl);

--- a/libs/mep/ace1201/global-footer/global-footer.css
+++ b/libs/mep/ace1201/global-footer/global-footer.css
@@ -159,7 +159,7 @@
   overflow-y: auto;
   background: var(--feds-background-nav);
   border: 1px solid var(--feds-borderColor);
-  border-radius: var(--s2a-border-radius-xs);
+  border-radius: var(--s2a-border-radius-2xs);
 }
 
 [dir = "rtl"] .feds-regionPicker-wrapper > .fragment {
@@ -565,7 +565,7 @@ span.feds-footer-privacyLink-divider {
   .global-footer {
     padding-top: var(--s2a-layout-xl);
   }
-  
+
   .global-footer:not(.mobile) .feds-footer-options {
     display: grid;
     grid-template-areas: "region legal social";

--- a/libs/mep/ace1201/section-metadata/section-metadata.css
+++ b/libs/mep/ace1201/section-metadata/section-metadata.css
@@ -22,19 +22,19 @@
   &.rounded-corners,
   &.rounded-corners-top,
   &.rounded-corners-bottom {
-    border-radius: var(--s2a-border-radius-lg);
+    border-radius: var(--s2a-border-radius-xl);
     overflow: clip;
     z-index: 3;
-    margin-block: calc(-1 * var(--s2a-border-radius-lg));
+    margin-block: calc(-1 * var(--s2a-border-radius-xl));
   }
 
   &.rounded-corners-top {
-    border-radius: var(--s2a-border-radius-lg) var(--s2a-border-radius-lg) 0 0;
+    border-radius: var(--s2a-border-radius-xl) var(--s2a-border-radius-xl) 0 0;
     margin-bottom: initial;
   }
 
   &.rounded-corners-bottom {
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
     margin-top: initial;
   }
 

--- a/libs/mep/ace1205/hover-list/hover-list.css
+++ b/libs/mep/ace1205/hover-list/hover-list.css
@@ -57,7 +57,7 @@
 .hover-list-media {
   align-self: flex-start;
   block-size: 81px;
-  border-radius: var(--s2a-border-radius-sm);
+  border-radius: var(--s2a-border-radius-xs);
   flex-shrink: 0;
   inline-size: 80px;
   overflow: hidden;
@@ -176,7 +176,7 @@
 
   .hover-list-media picture {
     block-size: 320px;
-    border-radius: var(--s2a-border-radius-sm);
+    border-radius: var(--s2a-border-radius-xs);
     inline-size: 280px;
     inset: auto;
     left: 0;

--- a/libs/mep/ace1205/offer-hero/offer-hero.css
+++ b/libs/mep/ace1205/offer-hero/offer-hero.css
@@ -4,7 +4,7 @@
 
   > .section-background {
     overflow: clip;
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
   }
 }
 
@@ -63,7 +63,7 @@
     position: relative;
     padding-block: 0 var(--s2a-spacing-lg);
     z-index: 2;
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
   }
 
   .hero-eyebrow {
@@ -379,6 +379,6 @@
 
 @media (width > 1440px) {
   .offer-hero .what-included {
-    padding-bottom: var(--s2a-spacing-124);
+    padding-bottom: var(--s2a-spacing-128);
   }
 }

--- a/libs/mep/ace1205/pdf-space/pdf-space.css
+++ b/libs/mep/ace1205/pdf-space/pdf-space.css
@@ -457,7 +457,7 @@
 
     @media (width >= 1280px) {
       .no-motion-grid-section {
-        padding: var(--s2a-spacing-124) var(--s2a-spacing-64) 0;
+        padding: var(--s2a-spacing-128) var(--s2a-spacing-64) 0;
       }
 
       .text-block {

--- a/libs/mep/ace1205/product-marquee-grid/product-marquee-grid.css
+++ b/libs/mep/ace1205/product-marquee-grid/product-marquee-grid.css
@@ -54,7 +54,7 @@
     }
 
     .pm-promo-chevron {
-      border-radius: var(--s2a-border-radius-xs);
+      border-radius: var(--s2a-border-radius-2xs);
       border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-12);
       background: var(--s2a-color-transparent-white-16);
       align-items: center;

--- a/libs/mep/ace1205/rich-content/rich-content.css
+++ b/libs/mep/ace1205/rich-content/rich-content.css
@@ -178,7 +178,7 @@
       justify-content: center;
       width: 30px;
       height: 30px;
-      border-radius: var(--s2a-border-radius-xs);
+      border-radius: var(--s2a-border-radius-2xs);
       background: var(--s2a-color-transparent-white-32);
       border: 1px solid var(--s2a-color-transparent-white-24);
       transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
@@ -572,7 +572,7 @@
 .section.parallax-video-garage-door:has(.rich-content.media) ~ .section {
   --rc-pull-offset: 80px;
   --rc-sweep-offset: 200px;
-  --rc-sweep-peek: var(--s2a-border-radius-lg);
+  --rc-sweep-peek: var(--s2a-border-radius-xl);
   --rc-video-enter-scale: 1.15;
   --rc-video-enter-y: 30px;
 }
@@ -591,12 +591,12 @@
   }
 
   .rich-content.media img {
-    max-width: 1200px; 
+    max-width: 1200px;
     margin: 0 auto;
   }
 
-  .rich-content.media .media-cell .video-container { 
-    max-width: 1200px; 
+  .rich-content.media .media-cell .video-container {
+    max-width: 1200px;
     margin: 0 auto;
   }
 

--- a/libs/mep/ace1205/section-metadata/section-metadata.css
+++ b/libs/mep/ace1205/section-metadata/section-metadata.css
@@ -22,19 +22,19 @@
   &.rounded-corners,
   &.rounded-corners-top,
   &.rounded-corners-bottom {
-    border-radius: var(--s2a-border-radius-lg);
+    border-radius: var(--s2a-border-radius-xl);
     overflow: clip;
     z-index: 3;
-    margin-block: calc(-1 * var(--s2a-border-radius-lg));
+    margin-block: calc(-1 * var(--s2a-border-radius-xl));
   }
 
   &.rounded-corners-top {
-    border-radius: var(--s2a-border-radius-lg) var(--s2a-border-radius-lg) 0 0;
+    border-radius: var(--s2a-border-radius-xl) var(--s2a-border-radius-xl) 0 0;
     margin-bottom: initial;
   }
 
   &.rounded-corners-bottom {
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
     margin-top: initial;
   }
 

--- a/libs/mep/ace1205/social-proof/social-proof.css
+++ b/libs/mep/ace1205/social-proof/social-proof.css
@@ -90,7 +90,7 @@
 
 @media (width >= 768px) {
   .social-proof {
-    border-radius: var(--s2a-border-radius-lg);
+    border-radius: var(--s2a-border-radius-xl);
 
     > div {
       flex-direction: row;

--- a/libs/mep/ace1205/tour/tour.css
+++ b/libs/mep/ace1205/tour/tour.css
@@ -39,7 +39,7 @@
   img {
     width: 100%;
     height: 100%;
-    border-radius: var(--s2a-border-radius-sm);
+    border-radius: var(--s2a-border-radius-xs);
     object-fit: cover;
   }
 }
@@ -98,9 +98,9 @@
     }
     img {
       border-start-start-radius: 0;
-      border-start-end-radius: var(--s2a-border-radius-sm);
+      border-start-end-radius: var(--s2a-border-radius-xs);
       border-end-start-radius: 0;
-      border-end-end-radius: var(--s2a-border-radius-sm);
+      border-end-end-radius: var(--s2a-border-radius-xs);
     }
   }
   &.row-3 {
@@ -193,7 +193,7 @@
   &.is-dismissing {
     --tour-drag-y: 100%;
   }
-  
+
   .dialog-close {
     width: 48px;
     height: 48px;


### PR DESCRIPTION
This brings in https://github.com/adobecom/milo/pull/6439 into the `site-redesign-foundation` feature branch, since CPro pages have been authored to use the new spacing tokens. We're still waiting on some final confirmations, but the aim is to unblock VQA and GWP tasks for now and update/revert later if things dramatically shift.

Resolves: [MWPW-198349](https://jira.corp.adobe.com/browse/MWPW-198349), [MWPW-200911](https://jira.corp.adobe.com/browse/MWPW-200911)


