### PR TITLE
MWPW-205215: fix Upgrade CTA not resolving on CC plans page (getUpgradeAction TypeError)

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -397,7 +397,6 @@ const OFFER_TYPE_TRIAL = 'TRIAL';
 const LOADING_ENTITLEMENTS = 'loading-entitlements';
 
 let log;
-let upgradeOffer = null;
 
 /**
  * Parses the maslibs URL parameter and returns a validated base URL.
@@ -713,13 +712,15 @@ export async function getUpgradeAction(
   const loggedIn = await imsSignedInPromise;
   if (!loggedIn) return undefined;
   const entitlements = await fetchEntitlements();
-  if (upgradeOffer === null) {
-    upgradeOffer = undefined;
-    // will enter only once
-    upgradeOffer = await document.querySelector(
-      '.merch-offers.upgrade [data-wcs-osi]',
-    );
+  // Memoized on the function (like fetchEntitlements.promise) so tests can reset it.
+  // Must stay synchronous: getUpgradeAction runs concurrently for every CTA, and an
+  // await between the check and the assignment would let another call observe a
+  // half-initialized memo. A miss is retried on the next call.
+  if (!getUpgradeAction.upgradeOffer) {
+    getUpgradeAction.upgradeOffer = document.querySelector('.merch-offers.upgrade [data-wcs-osi]');
   }
+  const { upgradeOffer } = getUpgradeAction;
+  if (!upgradeOffer) return undefined;
 
   if (upgradeOffer.getAttribute('data-wcs-osi') === 'V3W0kzf4e6M2Ht1hP9ZAt3dQNmhuDFrmYmEPlE2SlG0') {
     SOURCE_PF = ['ACROBAT', 'ACROBAT_STOCK_BUNDLE', 'ACAI', 'APCC', 'apcc_direct_individual'];
@@ -728,8 +729,8 @@ export async function getUpgradeAction(
     SOURCE_PF = CC_SINGLE_APPS_ALL;
     TARGET_PF = CC_ALL_APPS;
   }
-  await upgradeOffer?.onceSettled();
-  if (upgradeOffer && entitlements?.length && offerFamily) {
+  await upgradeOffer.onceSettled();
+  if (entitlements?.length && offerFamily) {
     const { default: handleUpgradeOffer } = await import('./upgrade.js');
     const upgradeAction = await handleUpgradeOffer(
       offerFamily,

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -16,6 +16,7 @@ import merch, {
   fetchCheckoutLinkConfigs,
   getCheckoutLinkConfig,
   getDownloadAction,
+  getUpgradeAction,
   fetchEntitlements,
   getModalAction,
   getCheckoutAction,
@@ -1143,6 +1144,67 @@ describe('Merch Block', () => {
 
       document.body.removeChild(merchCard);
       document.body.removeChild(upgradeOfferContainer);
+    });
+
+    describe('upgrade offer lookup (MWPW-205215)', () => {
+      const OSI = 'UPGRADE_TARGET_OSI';
+      const OFFERS = [{ productArrangement: { productFamily: 'CC_ALL_APPS' } }];
+      let stashedOffers;
+      let prevUpgradeOffer;
+
+      const createUpgradeOffer = () => {
+        const offer = createTag('a', {
+          'data-wcs-osi': OSI,
+          href: `/tools/ost?osi=${OSI}&type=checkoutUrl`,
+        });
+        offer.onceSettled = () => Promise.resolve(offer);
+        offer.value = [{ offerId: 'UPGRADE_TARGET_OFFER_ID' }];
+        const container = createTag('div', { class: 'merch-offers upgrade' }, offer);
+        document.body.append(container);
+        return container;
+      };
+
+      const callGetUpgradeAction = () => getUpgradeAction(
+        { upgrade: true },
+        Promise.resolve(true),
+        OFFERS,
+        createCtaInMerchCard(),
+      );
+
+      beforeEach(() => {
+        prevUpgradeOffer = getUpgradeAction.upgradeOffer;
+        getUpgradeAction.upgradeOffer = undefined;
+        // Detach the fixture's upgrade offers so each test controls the DOM state.
+        stashedOffers = [...document.querySelectorAll('.merch-offers.upgrade')]
+          .map((node) => ({ node, parent: node.parentNode, next: node.nextSibling }));
+        stashedOffers.forEach(({ node }) => node.remove());
+        // A signed-out call clears the entitlements cache; then sign in.
+        mockIms();
+        getUserEntitlements();
+        mockIms('US');
+        setSubscriptionsData(SUBSCRIPTION_DATA_PHSP_RAW_ELIGIBLE);
+      });
+
+      afterEach(() => {
+        getUpgradeAction.upgradeOffer = prevUpgradeOffer;
+        document.querySelectorAll('.merch-offers.upgrade').forEach((node) => node.remove());
+        stashedOffers.forEach(({ node, parent, next }) => parent.insertBefore(node, next));
+      });
+
+      it('returns undefined when no upgrade offer is in the DOM, then retries', async () => {
+        expect(await callGetUpgradeAction()).to.be.undefined;
+        createUpgradeOffer();
+        const action = await callGetUpgradeAction();
+        expect(action.className).to.equal('upgrade');
+        expect(action.url).to.include('toOfferId=UPGRADE_TARGET_OFFER_ID');
+      });
+
+      it('resolves concurrent calls without throwing', async () => {
+        createUpgradeOffer();
+        const actions = await Promise.all([callGetUpgradeAction(), callGetUpgradeAction()]);
+        expect(actions).to.have.length(2);
+        actions.forEach((action) => expect(action.className).to.equal('upgrade'));
+      });
     });
   });
 


### PR DESCRIPTION
* **Problem:** On the Creative Cloud plans page, the **Upgrade** button could stop working for signed-in customers who own a single app. The lookup for the upgrade offer crashed with `TypeError: Cannot read properties of undefined (reading 'getAttribute')` (reported in Sentry), so the button never resolved.
* **Why:** Every button on the page asks for the upgrade offer at the same time. The lookup marked itself "in progress", then paused; a second button read the half-finished result and crashed. The same line also crashed when the page had no upgrade offer at all.
* **Fix:** Do the lookup in one uninterrupted step, and quietly return "no upgrade" when the offer isn't on the page instead of crashing (the next button simply looks again).
* **Housekeeping:** The cached offer now lives on `getUpgradeAction.upgradeOffer` (same pattern as `fetchEntitlements.promise`) so unit tests can reset it.
* **Tests:** Two new regression tests (missing offer; two simultaneous lookups). Both fail on the current code with the exact errors from the ticket and pass with the fix. `merch.test.js`: 153 passed, 0 failed.
* Regression introduced by MWPW-185849 (#5353).

Resolves: [MWPW-205215](https://jira.corp.adobe.com/browse/MWPW-205215)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-205215--milo--adobecom.aem.page/?martech=off

***CC plans page (where the bug happens)***
- Before: https://main--cc--adobecom.aem.live/in/creativecloud/plans?martech=off&milolibs=stage--milo--adobecom
- After: https://main--cc--adobecom.aem.live/in/creativecloud/plans?martech=off&milolibs=mwpw-205215--milo--adobecom

**How to verify:** sign in with an Adobe ID that has a single-app plan (e.g. Photoshop) so the Upgrade button appears. Before: the browser console logs `Failed to resolve checkout action TypeError: Cannot read properties of undefined (reading 'getAttribute')` and the button doesn't resolve. After: no error, and the Upgrade button resolves.


