### PR TITLE
[SR] Bento's - Fix for video width witth videos that hide controls fix

### DIFF
--- a/libs/mep/ace1209/explore-card/explore-card.css
+++ b/libs/mep/ace1209/explore-card/explore-card.css
@@ -63,12 +63,12 @@
     transition: opacity 0.5s var(--parallax-easing);
     width: auto;
     position: relative;
+  }
 
-    video {
-      object-fit: cover;
-      width: 100%;
-      height: 100%;
-    }
+  video {
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
   }
 
   img {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
When the `hide-controls` hash utils is added to a video it removes the container `.video-container` which has `width: 100%` so the video always fits the bento box. This update targets the video instead of `.video-container` that was previously targeted to correct the noted issue.

This was missed in https://github.com/adobecom/milo/pull/6505


Resolves: [MWPW-204137](https://jira.corp.adobe.com/browse/MWPW-204137)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=sr-bento-video-hide-controls-fix&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


**Before screenshot:**
<img width="2038" height="1180" alt="bento-video-issue" src="https://github.com/user-attachments/assets/2c246ec8-2d5f-4dfb-b4e1-9d5be406ff7a" />

**After screenshot:**
<img width="2042" height="1196" alt="image" src="https://github.com/user-attachments/assets/c8b90848-8138-43ad-8e53-4c211bf07280" />


