### PR TITLE
[MWPW-203833] Debounce brand-concierge floating-input resize handler

### DIFF
--- a/libs/blocks/brand-concierge/bc-utils.js
+++ b/libs/blocks/brand-concierge/bc-utils.js
@@ -372,6 +372,7 @@ export function decorateFloatingInput(el, cards, input, floatingInputEvents, var
   if (variants.isFloatingInputOnly) {
     el.classList.add('floating-input');
   }
+  let pillVisibilityRaf;
   function updatePillVisibility(target) {
     const prompts = target.querySelector('.bc-prompt-cards');
     if (!prompts) return;
@@ -379,7 +380,9 @@ export function decorateFloatingInput(el, cards, input, floatingInputEvents, var
     const buttons = [...prompts.querySelectorAll('.prompt-card-button')];
     buttons.forEach((btn) => { btn.style.display = ''; });
 
-    requestAnimationFrame(() => {
+    if (pillVisibilityRaf) cancelAnimationFrame(pillVisibilityRaf);
+    pillVisibilityRaf = requestAnimationFrame(() => {
+      pillVisibilityRaf = null;
       const { left: containerLeft, right: containerRight } = prompts.getBoundingClientRect();
 
       buttons.forEach((btn) => {
@@ -397,14 +400,7 @@ export function decorateFloatingInput(el, cards, input, floatingInputEvents, var
   decorateCards(floatingInput, cards, { handle: floatingInputEvents.cardHandle }, false);
   el.append(floatingInput);
 
-  let resizeRaf;
-  const updateLayout = () => {
-    if (resizeRaf) cancelAnimationFrame(resizeRaf);
-    resizeRaf = requestAnimationFrame(() => {
-      resizeRaf = null;
-      updatePillVisibility(floatingInput);
-    });
-  };
+  const updateLayout = () => updatePillVisibility(floatingInput);
 
   window.addEventListener('resize', updateLayout);
   updateLayout();

--- a/libs/blocks/brand-concierge/bc-utils.js
+++ b/libs/blocks/brand-concierge/bc-utils.js
@@ -397,12 +397,17 @@ export function decorateFloatingInput(el, cards, input, floatingInputEvents, var
   decorateCards(floatingInput, cards, { handle: floatingInputEvents.cardHandle }, false);
   el.append(floatingInput);
 
+  let resizeRaf;
   const updateLayout = () => {
-    updatePillVisibility(floatingInput);
+    if (resizeRaf) cancelAnimationFrame(resizeRaf);
+    resizeRaf = requestAnimationFrame(() => {
+      resizeRaf = null;
+      updatePillVisibility(floatingInput);
+    });
   };
 
   window.addEventListener('resize', updateLayout);
-  requestAnimationFrame(updateLayout);
+  updateLayout();
   floatingElement(floatingInput, el, variants, el.querySelector('.bc-input-field'));
 
   return floatingInput;

--- a/libs/c2/blocks/brand-concierge/bc-utils.js
+++ b/libs/c2/blocks/brand-concierge/bc-utils.js
@@ -382,12 +382,17 @@ export function decorateFloatingInput(el, cards, input, floatingInputEvents, var
   decorateCards(floatingInput, cards, { handle: floatingInputEvents.cardHandle }, false);
   el.append(floatingInput);
 
+  let resizeRaf;
   const updateLayout = () => {
-    updatePillVisibility(floatingInput);
+    if (resizeRaf) cancelAnimationFrame(resizeRaf);
+    resizeRaf = requestAnimationFrame(() => {
+      resizeRaf = null;
+      updatePillVisibility(floatingInput);
+    });
   };
 
   window.addEventListener('resize', updateLayout);
-  requestAnimationFrame(updateLayout);
+  updateLayout();
   floatingElement(floatingInput, el, variants, el.querySelector('.bc-input-field'));
 
   return floatingInput;

--- a/libs/c2/blocks/brand-concierge/bc-utils.js
+++ b/libs/c2/blocks/brand-concierge/bc-utils.js
@@ -357,6 +357,7 @@ export function decorateFloatingInput(el, cards, input, floatingInputEvents, var
   if (variants.isFloatingInputOnly) {
     el.classList.add('floating-input');
   }
+  let pillVisibilityRaf;
   function updatePillVisibility(target) {
     const prompts = target.querySelector('.bc-prompt-cards');
     if (!prompts) return;
@@ -364,7 +365,9 @@ export function decorateFloatingInput(el, cards, input, floatingInputEvents, var
     const buttons = [...prompts.querySelectorAll('.prompt-card-button')];
     buttons.forEach((btn) => { btn.style.display = ''; });
 
-    requestAnimationFrame(() => {
+    if (pillVisibilityRaf) cancelAnimationFrame(pillVisibilityRaf);
+    pillVisibilityRaf = requestAnimationFrame(() => {
+      pillVisibilityRaf = null;
       const { left: containerLeft, right: containerRight } = prompts.getBoundingClientRect();
 
       buttons.forEach((btn) => {
@@ -382,14 +385,7 @@ export function decorateFloatingInput(el, cards, input, floatingInputEvents, var
   decorateCards(floatingInput, cards, { handle: floatingInputEvents.cardHandle }, false);
   el.append(floatingInput);
 
-  let resizeRaf;
-  const updateLayout = () => {
-    if (resizeRaf) cancelAnimationFrame(resizeRaf);
-    resizeRaf = requestAnimationFrame(() => {
-      resizeRaf = null;
-      updatePillVisibility(floatingInput);
-    });
-  };
+  const updateLayout = () => updatePillVisibility(floatingInput);
 
   window.addEventListener('resize', updateLayout);
   updateLayout();


### PR DESCRIPTION
[MWPW-203833] Debounce brand-concierge floating-input resize handler

## What/why
`updatePillVisibility` resets every pill to visible, then measures each with `getBoundingClientRect` to hide the ones that overflow the row. It runs on every `resize` event. The measurement was already deferred with `requestAnimationFrame`, but nothing cancelled a pending frame — each call queued an independent callback, so if the handler fires more than once before those callbacks run, every one of them executes a full measurement pass.

Add `cancelAnimationFrame` to drop the pending measurement before scheduling a new one, bounding it to at most one `getBoundingClientRect` pass per animation frame.

Applied to both `libs/blocks/brand-concierge/bc-utils.js` and `libs/c2/blocks/brand-concierge/bc-utils.js`.

Resolves: [MWPW-203833](https://jira.corp.adobe.com/browse/MWPW-203833)


**Test URLs:**
- Before: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo
- After: https://load-c2-styles--upp--adobecom.aem.live/homepage/drafts/ramuntea/redesign-demo?milolibs=brand-concierge-raf


