### PR TITLE
[MWPW-205310] - Load plans-hero image eagerly

### DIFF
--- a/libs/c2/blocks/plans-hero/plans-hero.js
+++ b/libs/c2/blocks/plans-hero/plans-hero.js
@@ -9,7 +9,10 @@ function decorate(block) {
 
   const media = createTag('div', { class: 'plans-hero-media' });
   const picture = mediaCell?.querySelector('picture');
-  if (picture) media.append(picture);
+  if (picture) {
+    picture.querySelector('img')?.setAttribute('loading', 'eager');
+    media.append(picture);
+  }
 
   if (textCell) {
     decorateBlockText(textCell, { heading: '2', body: 'md' });


### PR DESCRIPTION
## Summary
- Sets `loading="eager"` on the plans-hero picture's `<img>` as lighthouse was reporting the element as an lcp and it was being lazily loaded leading to longer load time.
- No change to `fetchpriority`: the image is server-rendered raw HTML present at initial parse, so any post-hoc `setAttribute` call (block-level or in the shared `scripts.js` LCP hook) runs after the browser's preload scanner has already dispatched the fetch at default priority — verified this has no real effect on network priority, so it was left out.

Resolves: [MWPW-205310](https://jira.corp.adobe.com/browse/MWPW-205310)

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205/ace1205-plans?milolibs=stage&georouting=off
- After: https://main--da-dc--adobecom.aem.live/drafts/ramuntea/ace1205/ace1205-plans?milolibs=plans-hero-lcp&georouting=off


