### PR TITLE
[Perf] MWPW-203837: Clean up unconditional / misapplied will-change hints

### DIFF
--- a/libs/c2/blocks/base-card/base-card.css
+++ b/libs/c2/blocks/base-card/base-card.css
@@ -83,7 +83,6 @@
 
     .parallax-featured-card-media {
       animation-name: grow-featured-card-radius;
-      will-change: clip-path;
     }
   }
 }

--- a/libs/c2/blocks/floating-cta/floating-cta.css
+++ b/libs/c2/blocks/floating-cta/floating-cta.css
@@ -27,7 +27,7 @@
       opacity 0.3s cubic-bezier(0.55, 0.085, 0.68, 0.53),
       clip-path 0.3s cubic-bezier(0.55, 0.085, 0.68, 0.53),
       transform 0.3s cubic-bezier(0.55, 0.085, 0.68, 0.53);
-    will-change: opacity, clip-path, transform;
+    will-change: opacity, transform;
     &.active {
       clip-path: inset(0% round var(--s2a-border-radius-12));
       opacity: 1;

--- a/libs/c2/blocks/quick-actions/quick-actions.css
+++ b/libs/c2/blocks/quick-actions/quick-actions.css
@@ -53,11 +53,11 @@
   display: block;
   inline-size: 100%;
   min-block-size: 180px;
-  will-change: transform;
   transition: transform 0.3s ease-out;
 }
 
 .quick-actions-tile:hover .quick-actions-media {
+  will-change: transform;
   transform: scale(1.015);
 }
 

--- a/libs/c2/blocks/tour/tour.css
+++ b/libs/c2/blocks/tour/tour.css
@@ -221,7 +221,6 @@
   & + .modal-curtain.is-open {
     background: var(--s2a-color-transparent-black-64);
     backdrop-filter: blur(var(--s2a-blur-32));
-    will-change: backdrop-filter;
   }
 }
 

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -980,10 +980,8 @@ p {
   inline-size: 32px;
   justify-content: center;
   transition: background-color 0.2s ease, border-color 0.2s ease;
-  will-change: background-color, border-color;
   path {
     transition: fill 0.2s ease;
-    will-change: fill;
   }
 }
 


### PR DESCRIPTION
## MWPW-203837

Removes always-on layer promotion and `will-change` hints on non-compositable properties across C2 blocks. No visual change — frees GPU memory and avoids needless compositor work.

### Changes
- **base-card** — drop `will-change: clip-path`
- **floating-cta** — drop `clip-path` from hint (keep `opacity, transform`)
- **quick-actions** — scope `will-change: transform` to `:hover` state instead of always-on
- **tour** — drop `will-change: backdrop-filter`
- **styles (icon button)** — drop `will-change` on `background-color`, `border-color`, `fill`

The four locations explicitly listed in the ticket (`carousel-c2`, `elastic-carousel` ×2, `.parallax-scale-down-grid`) were already addressed in earlier commits on `sr-perf-dd`; this PR covers the remaining misapplied/unconditional hints. After these changes, no `will-change` hint in `libs/c2` targets a layout or paint property.

### Testing
- Verified no `will-change` remains on layout/paint props (width/margin/padding/inline-size/clip-path/backdrop-filter/background/border-color/fill) across `libs/c2`.
- No visual change expected.

## URLs
- Before: https://stage.adobe.com
- After: https://stage.adobe.com?milolibs=misapplied-will-change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

