### PR TITLE
[MWPW-204157] Stick quote to viewport

### DIFF
--- a/libs/mep/ace1209/quote/quote.css
+++ b/libs/mep/ace1209/quote/quote.css
@@ -11,6 +11,7 @@
   position: relative;
   box-sizing: border-box;
   padding: var(--quote-pad);
+  margin-inline: calc(-1 * var(--grid-padding));
   color: var(--s2a-color-content-default);
 
   .foreground {


### PR DESCRIPTION
Add a negative offset to the Quote block, to take it out of the usual grid and stick it to the viewport, until it hits the container's width. It's not 100% clear if this is the strategy we'll use for rollout, but it achieves our goal for the test phase.

Resolves: [MWPW-204157](https://jira.corp.adobe.com/browse/MWPW-204157)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=lush-quote&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

