### PR TITLE
Update radius for CPro based on new S2A values

### DIFF
--- a/libs/mep/ace1209/hover-list/hover-list.css
+++ b/libs/mep/ace1209/hover-list/hover-list.css
@@ -57,7 +57,7 @@
 .hover-list-media {
   align-self: flex-start;
   block-size: 81px;
-  border-radius: var(--s2a-border-radius-sm);
+  border-radius: var(--s2a-border-radius-xs);
   flex-shrink: 0;
   inline-size: 80px;
   overflow: hidden;
@@ -176,7 +176,7 @@
 
   .hover-list-media picture {
     block-size: 320px;
-    border-radius: var(--s2a-border-radius-sm);
+    border-radius: var(--s2a-border-radius-xs);
     inline-size: 280px;
     inset: auto;
     left: 0;

--- a/libs/mep/ace1209/hub-hero/hub-hero.css
+++ b/libs/mep/ace1209/hub-hero/hub-hero.css
@@ -176,9 +176,9 @@
   img {
     border-radius: var(--s2a-border-radius-md);
   }
-  
+
   .video-holder {
-    border-radius: var(--s2a-border-radius-sm);
+    border-radius: var(--s2a-border-radius-xs);
   }
 }
 
@@ -362,7 +362,7 @@
   }
 }
 
-.hub-hero.slides-3 .hub-hero-image-grid-container-col div p:nth-child(2), 
+.hub-hero.slides-3 .hub-hero-image-grid-container-col div p:nth-child(2),
 .hub-hero-carousel-item .hub-hero-carousel-item-media picture:nth-child(2),
 .hub-hero.slides-3 .hub-hero-image-grid-container-col div picture:nth-child(2) {
   position: absolute;
@@ -424,17 +424,17 @@
   @media (768px <= width < 1024px) {
     .hub-hero-image-grid-container-col div {
       position: relative;
-  
+
       img {
-        border-radius: var(--s2a-border-radius-sm);
+        border-radius: var(--s2a-border-radius-xs);
       }
     }
 
     .hub-hero-carousel-item, .hub-hero-carousel-item-media {
-      border-radius: var(--s2a-border-radius-sm);
+      border-radius: var(--s2a-border-radius-xs);
     }
   }
-  
+
   @media (width < 768px) {
     .hub-hero-carousel-item {
       background: transparent;
@@ -466,7 +466,7 @@
     }
   }
 
-  
+
   .hub-hero-carousel-item-media>p:nth-child(2),
   .hub-hero-carousel-item-media>p:has(picture),
   .hub-hero-carousel-item-media>picture:nth-child(2) {

--- a/libs/mep/ace1209/offer-hero/offer-hero.css
+++ b/libs/mep/ace1209/offer-hero/offer-hero.css
@@ -10,7 +10,7 @@
 
   > .section-background {
     overflow: clip;
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
   }
 }
 
@@ -69,7 +69,7 @@
     position: relative;
     padding-block: 0 var(--s2a-spacing-lg);
     z-index: 2;
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
   }
 
   .hero-eyebrow {

--- a/libs/mep/ace1209/plans-hero/plans-hero.css
+++ b/libs/mep/ace1209/plans-hero/plans-hero.css
@@ -46,14 +46,14 @@
 .rounded-corners + .section,
 .rounded-corners-bottom + .section {
   .plans-hero-media {
-    top: calc(-1 * var(--s2a-border-radius-lg));
+    top: calc(-1 * var(--s2a-border-radius-xl));
   }
 }
 
 .section:has(+ .rounded-corners),
 .section:has(+ .rounded-corners-top) {
   .plans-hero-media {
-    bottom: calc(-1 * var(--s2a-border-radius-lg));
+    bottom: calc(-1 * var(--s2a-border-radius-xl));
   }
 }
 

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -155,7 +155,7 @@
       justify-content: center;
       width: 30px;
       height: 30px;
-      border-radius: var(--s2a-border-radius-xs);
+      border-radius: var(--s2a-border-radius-2xs);
       background: var(--s2a-color-transparent-white-32);
       border: 1px solid var(--s2a-color-transparent-white-24);
       transition: background-color 0.2s ease, color 0.2s ease;
@@ -723,7 +723,7 @@
 .section.parallax-video-garage-door:has(.rich-content.media) ~ .section {
   --rc-pull-offset: 80px;
   --rc-sweep-offset: 200px;
-  --rc-sweep-peek: var(--s2a-border-radius-lg);
+  --rc-sweep-peek: var(--s2a-border-radius-xl);
   --rc-video-enter-scale: 1.15;
   --rc-video-enter-y: 30px;
 }

--- a/libs/mep/ace1209/roller-carousel/roller-carousel.css
+++ b/libs/mep/ace1209/roller-carousel/roller-carousel.css
@@ -152,7 +152,7 @@
     aspect-ratio: 650 / 766;
     height: clamp(265px, 100dvh - 382px, 360px);
     max-width: 70vw;
-    border-radius: var(--s2a-border-radius-sm);
+    border-radius: var(--s2a-border-radius-xs);
     overflow: hidden;
     background: #000;
   }

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -126,14 +126,14 @@ body:has(header.local-nav) .section.bento.stack-mobile {
   &.rounded-corners,
   &.rounded-corners-top,
   &.rounded-corners-bottom {
-    border-radius: var(--s2a-border-radius-lg);
+    border-radius: var(--s2a-border-radius-xl);
     overflow: clip;
     z-index: 3;
-    margin-block: calc(-1 * var(--s2a-border-radius-lg));
+    margin-block: calc(-1 * var(--s2a-border-radius-xl));
   }
 
   &.rounded-corners-top {
-    border-radius: var(--s2a-border-radius-lg) var(--s2a-border-radius-lg) 0 0;
+    border-radius: var(--s2a-border-radius-xl) var(--s2a-border-radius-xl) 0 0;
     margin-bottom: initial;
   }
 
@@ -152,16 +152,16 @@ body:has(header.local-nav) .section.bento.stack-mobile {
     display: block;
     grid-column: 1 / -1;
     width: 100%;
-    height: var(--s2a-border-radius-lg);
+    height: var(--s2a-border-radius-xl);
   }
 
   &.rounded-corners-bottom {
-    border-radius: 0 0 var(--s2a-border-radius-lg) var(--s2a-border-radius-lg);
+    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
     margin-top: initial;
   }
 
   /* Fix for consecutive rounded corner sections in order
-    to have the first section overlay on to the following section 
+    to have the first section overlay on to the following section
     For later - need to find a more elegant solution */
   &.rounded-corners:has(+ .section[class*='rounded-corners']),
   &.rounded-corners-bottom:has(+ .section[class*='rounded-corners']) {
@@ -315,7 +315,7 @@ body:has(header.local-nav) .section.bento.stack-mobile {
   }
 
   &.bento .explore-card.dark,
-  &.bento .explore-card.light {background-color: transparent;} 
+  &.bento .explore-card.light {background-color: transparent;}
 
   &.bento .explore-card {
     border-radius: var(--s2a-border-radius-md);

--- a/libs/mep/ace1209/tour/tour.css
+++ b/libs/mep/ace1209/tour/tour.css
@@ -45,7 +45,7 @@
   img {
     width: 100%;
     height: 100%;
-    border-radius: var(--s2a-border-radius-sm);
+    border-radius: var(--s2a-border-radius-xs);
     object-fit: cover;
   }
 }
@@ -103,9 +103,9 @@
     }
     img {
       border-start-start-radius: 0;
-      border-start-end-radius: var(--s2a-border-radius-sm);
+      border-start-end-radius: var(--s2a-border-radius-xs);
       border-end-start-radius: 0;
-      border-end-end-radius: var(--s2a-border-radius-sm);
+      border-end-end-radius: var(--s2a-border-radius-xs);
     }
   }
   &.row-3 {
@@ -201,7 +201,7 @@
   &.is-dismissing {
     --tour-drag-y: 100%;
   }
-  
+
   .dialog-close {
     width: 48px;
     height: 48px;
@@ -241,7 +241,7 @@
         background-color: var(--s2a-color-content-knockout);
       }
 
-      &:hover, 
+      &:hover,
       &:focus {
         background-color: var(--s2a-color-gray-700);
         border-color: var(--s2a-color-gray-500);


### PR DESCRIPTION
Similar to https://github.com/adobecom/milo/pull/6439, this updates the `border-radius` token values used for the CPro blocks, to keep the scale used before the 0.0.21 token package update.

Resolves: [MWPW-205324](https://jira.corp.adobe.com/browse/MWPW-205324)

**Test URLs:**
- Offer: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=srf-radius-update&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- Product: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=srf-radius-update&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- Hub: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=srf-radius-update&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- Plans: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-plans?milolibs=srf-radius-update&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all



