### PR TITLE
[MWPW-205278] - Make rich content media spacing authorable

### DIFF
--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -493,7 +493,7 @@
   flex-direction: column;
   align-items: center;
   gap: var(--s2a-spacing-lg);
-  padding-block: calc(var(--s2a-spacing-4xl) + var(--rc-pull-offset)) var(--s2a-spacing-4xl);
+  padding-block: calc(var(--rc-media-spacing-top, var(--s2a-spacing-4xl)) + var(--rc-pull-offset)) var(--rc-media-spacing-bottom, var(--s2a-spacing-4xl));
   overflow: clip;
   --grid-margin-width: 0px; /* Keep unit for calc */
 
@@ -615,7 +615,7 @@
 
 @media (width >= 768px) {
   .rich-content.media {
-    padding-block: var(--s2a-layout-sm);
+    padding-block: var(--rc-media-spacing-top, var(--s2a-layout-sm)) var(--rc-media-spacing-bottom, var(--s2a-layout-sm));
 
     img {
       max-width: unset;
@@ -739,7 +739,7 @@
 @media (width >= 1024px) {
   .rich-content.media {
     gap: var(--s2a-spacing-3xl);
-    padding-block: var(--s2a-layout-lg);
+    padding-block: var(--rc-media-spacing-top, var(--s2a-layout-lg)) var(--rc-media-spacing-bottom, var(--s2a-layout-lg));
   }
 
   .rich-content.media img {

--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -721,7 +721,7 @@
 .section:has(+ .section.parallax-video-garage-door .rich-content.media),
 .section.parallax-video-garage-door:has(.rich-content.media),
 .section.parallax-video-garage-door:has(.rich-content.media) ~ .section {
-  --rc-pull-offset: 80px;
+  --rc-pull-offset: 0px;
   --rc-sweep-offset: 200px;
   --rc-sweep-peek: var(--s2a-border-radius-lg);
   --rc-video-enter-scale: 1.15;

--- a/libs/mep/ace1209/rich-content/rich-content.js
+++ b/libs/mep/ace1209/rich-content/rich-content.js
@@ -1,5 +1,6 @@
 import { decorateBlockText, decorateViewportContent } from '../../../utils/decorate.js';
 import { createTag, getFederatedUrl, scrollToHashedElement } from '../../../utils/utils.js';
+import { debounce } from '../../../utils/action.js';
 
 const HERO_OVERLAY_PROP = '--rc-hero-overlay';
 
@@ -73,17 +74,22 @@ function decorateJumpLinks(content, foreground) {
   foreground.append(nav);
 }
 
-const SPACING_CLASS_RE = /^spacing-([a-z0-9]+)(-top|-bottom)?$/;
+const SPACING_CLASS_RE = /^spacing-[a-z0-9]+(-static)?(-top|-bottom)?$/;
 
 function applyMediaSpacing(root) {
-  [...root.classList].forEach((cls) => {
-    const match = cls.match(SPACING_CLASS_RE);
-    if (!match) return;
-    const [, size, direction] = match;
-    const value = `var(--s2a-section-spacing-${size})`;
-    if (direction !== '-bottom') root.style.setProperty('--rc-media-spacing-top', value);
-    if (direction !== '-top') root.style.setProperty('--rc-media-spacing-bottom', value);
-  });
+  const spacingClasses = [...root.classList].filter((cls) => SPACING_CLASS_RE.test(cls));
+  if (!spacingClasses.length) return;
+
+  const authorsTop = spacingClasses.some((cls) => !cls.endsWith('-bottom'));
+  const authorsBottom = spacingClasses.some((cls) => !cls.endsWith('-top'));
+
+  const probe = createTag('div', { class: spacingClasses.join(' '), style: 'position:absolute;visibility:hidden' });
+  root.append(probe);
+  const { paddingTop, paddingBottom } = getComputedStyle(probe);
+  probe.remove();
+
+  if (authorsTop) root.style.setProperty('--rc-media-spacing-top', paddingTop);
+  if (authorsBottom) root.style.setProperty('--rc-media-spacing-bottom', paddingBottom);
 }
 
 const MEDIA_SELECTOR = 'picture, video, .video-container, a[href*=".mp4"]';
@@ -174,6 +180,10 @@ function applyHeroOverlay(el) {
 
 export default function init(el) {
   const viewports = decorateViewportContent(el, decorate);
+
+  if (el.classList.contains('media') && [...el.classList].some((cls) => SPACING_CLASS_RE.test(cls))) {
+    window.addEventListener('resize', debounce(() => applyMediaSpacing(el)));
+  }
 
   if (!el.classList.contains('hero')) return;
 

--- a/libs/mep/ace1209/rich-content/rich-content.js
+++ b/libs/mep/ace1209/rich-content/rich-content.js
@@ -73,6 +73,19 @@ function decorateJumpLinks(content, foreground) {
   foreground.append(nav);
 }
 
+const SPACING_CLASS_RE = /^spacing-([a-z0-9]+)(-top|-bottom)?$/;
+
+function applyMediaSpacing(root) {
+  [...root.classList].forEach((cls) => {
+    const match = cls.match(SPACING_CLASS_RE);
+    if (!match) return;
+    const [, size, direction] = match;
+    const value = `var(--s2a-section-spacing-${size})`;
+    if (direction !== '-bottom') root.style.setProperty('--rc-media-spacing-top', value);
+    if (direction !== '-top') root.style.setProperty('--rc-media-spacing-bottom', value);
+  });
+}
+
 const MEDIA_SELECTOR = 'picture, video, .video-container, a[href*=".mp4"]';
 
 function isMediaCell(cell) {
@@ -120,6 +133,7 @@ function decorateMediaVariant(container) {
 
 function decorate(block, root = block) {
   if (root.classList.contains('media')) {
+    applyMediaSpacing(root);
     decorateMediaVariant(block);
     return;
   }


### PR DESCRIPTION
Make rich-content media block padding respect authored spacing classes

## Summary
- `.rich-content.media`'s padding-block was hardcoded, so an author-applied
  spacing class (e.g. `spacing-4xl`) had no effect — it tied in specificity
  with the styles.css utility rule and always lost on source order.
- rich-content.js now reads any authored `spacing-<size>[-top|-bottom]`
  class and points `--rc-media-spacing-top`/`-bottom` at the same
  `--s2a-section-spacing-<size>` token the utility rule uses — no duplicated
  mapping, styles.css untouched.
- padding-block at all three breakpoints now consumes those variables,
  falling back to the previous hardcoded defaults when no class is authored.
  The mobile rule still adds `--rc-pull-offset` on top, as before.


Resolves: [MWPW-205278](https://jira.corp.adobe.com/browse/MWPW-205278)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=rc-media-spacing&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all






