### PR TITLE
[SR] Removing rounded corner spacing for Floating CTA section.

### DIFF
--- a/libs/mep/ace1209/floating-cta/floating-cta.css
+++ b/libs/mep/ace1209/floating-cta/floating-cta.css
@@ -4,12 +4,27 @@
     position: sticky;
     z-index: 4;
   }
+
   &.rounded-corners-bottom,
   &.rounded-corners {
     & + .section {
       &:has(.floating-cta) {
         margin-block: var(--s2a-spacing-xl) calc(-1 * var(--s2a-spacing-xl));
+
+        /* cancel section-metadata's generic rounded-corners overlap spacer
+           so the two don't stack */
+        &::before {
+          content: none;
+        }
       }
+    }
+  }
+
+  /* the reverse adjacency: cancel section-metadata's generic overlap spacer the same way. */
+  &:has(.floating-cta):has(+ .rounded-corners),
+  &:has(.floating-cta):has(+ .rounded-corners-top) {
+    &::after {
+      content: none;
     }
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Removing rounded corner spacing for floating cta block.


Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=sr-rc-floating-cta&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

Before:
<img width="846" height="182" alt="image" src="https://github.com/user-attachments/assets/ca2a6ad2-4625-4495-9e70-4d6c8a135afc" />


After:
<img width="807" height="134" alt="image" src="https://github.com/user-attachments/assets/7a7a536e-526b-44cb-9894-f1ab10975e46" />



