### PR TITLE
[SR]Add a guard in decorateAutoBlock for merch links

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1537,6 +1537,7 @@ export function isTrustedAutoBlock(autoBlock, url) {
 }
 
 export function decorateAutoBlock(a) {
+  if (a.hasAttribute('data-wcs-osi')) return false;
   const config = getConfig();
   let url;
   try {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

PR #6373 added a decorateAutoBlock pass over inline mas-field CTAs. It runs on the checkout link while its href is still empty, which resolves to the page's own /fragments/… URL, so the link gets mis-tagged as a fragment autoblock and hidden by a.fragment { display:none } — and the tag is never re-checked after the real commerce href arrives.

Resolves: [MWPW-205280](https://jira.corp.adobe.com/browse/MWPW-205280)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=missing-video-cta&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


