### PR TITLE
MWPW-204984: Revert eager IMS load (#6511)

### DIFF
--- a/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
+++ b/libs/blocks/merch-card-autoblock/merch-card-autoblock.js
@@ -1,4 +1,4 @@
-import { createTag, getConfig, loadStyle, loadIms } from '../../utils/utils.js';
+import { createTag, getConfig, loadStyle } from '../../utils/utils.js';
 import { decorateButtons, getBlockSize } from '../../utils/decorate.js';
 import { postProcessAutoblock, localizePreviewLinks, decorateContentLinks } from '../merch/autoblock.js';
 import {
@@ -14,8 +14,6 @@ import {
   MAS_MERCH_QUANTITY_SELECT,
   MAS_FIELD,
 } from '../merch/merch.js';
-
-loadIms();
 
 const CARD_AUTOBLOCK_TIMEOUT = 5000;
 const seenFragments = new Set();

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1,10 +1,8 @@
 import {
-  createTag, getConfig, loadArea, loadScript, loadStyle, localizeLinkAsync, getMetadata, loadIms,
+  createTag, getConfig, loadArea, loadScript, loadStyle, localizeLinkAsync, getMetadata,
   shouldAllowKrTrial, getCountry, getValidatedMasLibsUrl,
 } from '../../utils/utils.js';
 import { replaceKey } from '../../features/placeholders.js';
-
-loadIms();
 
 // MAS Component Names
 export const COMMERCE_LIBRARY = 'commerce';


### PR DESCRIPTION
Reverts the eager IMS load and keeps the Lingo IMS Country Code feature intact.

* Revert [#6511](https://github.com/adobecom/milo/pull/6511) — MWPW-204875: eagerly load ims

Resolves: [MWPW-204984](https://jira.corp.adobe.com/browse/MWPW-204984)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-204984-2--milo--adobecom.aem.page/?martech=off

