### PR TITLE
[SR] Update section rounded corners border-radius per breakpoint.

### DIFF
--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -126,14 +126,16 @@ body:has(header.local-nav) .section.bento.stack-mobile {
   &.rounded-corners,
   &.rounded-corners-top,
   &.rounded-corners-bottom {
-    border-radius: var(--s2a-border-radius-xl);
+    /* TODO: Replace the primative border-radius tokens with the semantic one
+      once the stale adoptive-styles are removed or updated */
+    border-radius: var(--s2a-border-radius-22);
     overflow: clip;
     z-index: 3;
-    margin-block: calc(-1 * var(--s2a-border-radius-xl));
+    margin-block: calc(-1 * var(--s2a-border-radius-22));
   }
 
   &.rounded-corners-top {
-    border-radius: var(--s2a-border-radius-xl) var(--s2a-border-radius-xl) 0 0;
+    border-radius: var(--s2a-border-radius-22) var(--s2a-border-radius-22) 0 0;
     margin-bottom: initial;
   }
 
@@ -152,11 +154,11 @@ body:has(header.local-nav) .section.bento.stack-mobile {
     display: block;
     grid-column: 1 / -1;
     width: 100%;
-    height: var(--s2a-border-radius-xl);
+    height: var(--s2a-border-radius-22);
   }
 
   &.rounded-corners-bottom {
-    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
+    border-radius: 0 0 var(--s2a-border-radius-22) var(--s2a-border-radius-22);
     margin-top: initial;
   }
 
@@ -599,6 +601,29 @@ body:has(header.local-nav) .section.bento.stack-mobile {
       &.grid-width-6 { --grid-content-width: var(--grid-width-6); }
       &.grid-width-8 { --grid-content-width: var(--grid-width-8); }
       &.grid-width-10 { --grid-content-width: var(--grid-width-10); }
+    }
+
+    &.rounded-corners,
+    &.rounded-corners-top,
+    &.rounded-corners-bottom {
+      border-radius: var(--s2a-border-radius-xl);
+      margin-block: calc(-1 * var(--s2a-border-radius-xl));
+    }
+
+    &.rounded-corners-top {
+      border-radius: var(--s2a-border-radius-xl) var(--s2a-border-radius-xl) 0 0;
+    }
+
+    &:has(+ .rounded-corners)::after,
+    &:has(+ .rounded-corners-top)::after,
+    &.rounded-corners + .section::before,
+    &.rounded-corners-bottom + .section::before {
+      content: '';
+      height: var(--s2a-border-radius-xl);
+    }
+
+    &.rounded-corners-bottom {
+      border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
     }
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

Update section rounded corners border-radius to change per breakpoint:
- mobile/tablet = 22px
- desktop = 32px



Resolves: [MWPW-203768](https://jira.corp.adobe.com/browse/MWPW-203768)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=sr-section-rounded-corners-breakpoint&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

**Note**
Ran into an issue with some tokens not being updated despite the code being merged. 

Details:

- Root cause confirmed. A JS-constructed stylesheet is getting added directly onto the page document rather than inserted as a <link>/<style> element. And per spec, adopted stylesheets are cascaded as if appended after every other document stylesheet — so for any property it defines, it wins outright, regardless of specificity.
- The source: `https://stage.adobeccstatic.com/unav/1.6/UniversalNav.css’s` companion JS (Adobe’s shared, cross-property global-nav widget, loaded from a remote, version-pinned CDN bundle). **It adopts its own stylesheet carrying a stale, pre-token-rename snapshot of the shared “s2a” design tokens.**

