### PR TITLE
[Site Redesign] Globe A11y Cleanups

### DIFF
--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -1585,12 +1585,16 @@ auto-spin (`a11y.isBrowsing()`); mouse drag still works.
   `preventDefault`'d so the close animation plays) / Enter-on-Close exit and the dialog **restores
   focus to the opening image**. No backdrop-click-to-close; no arrow-key globe rotation (browsing
   replaced it).
-- **Modal counter:** the visible `.globe-gallery-modal-counter` ("05 / 47") and the sr-only
-  `.globe-gallery-modal-position` ("5 of 47", from `cardLabel`) are **both `aria-hidden`**. The
-  position is spoken only through the heading's `aria-describedby`, which still resolves it —
-  description computation traverses `aria-hidden` subtrees. Hiding it keeps NVDA's dialog sweep
-  from reading it on top of the heading, and keeps it from being a redundant virtual-cursor stop
-  now that open and nav both announce it.
+- **Modal counter reading order:** the visible `.globe-gallery-modal-counter` ("05 / 47") is
+  `aria-hidden`; the spoken form lives in the sr-only `.globe-gallery-modal-position` ("5 of 47",
+  from `cardLabel`), which is also the heading's `aria-describedby` target. Both sit in the markup
+  **between Prev and Next**, so a virtual cursor reads Prev → position → Next → Close, matching the
+  on-screen row. The whole bottom row is `position: absolute`, so that markup order is free.
+  The span carries **`role="note"`**: NVDA does not descend into a `note` when it sweeps the dialog
+  on open, so the position is spoken once (with the heading) instead of twice, while the span stays
+  a virtual-cursor stop for VoiceOver. `aria-hidden` would also silence the sweep but kills the
+  stop; `group` does not stop the sweep at all; `article`/`region` do, but VoiceOver announces
+  entering/leaving them.
 - **Instructions popup:** on focus the entry widget shows a **visible pill** so sighted keyboard
   users get the affordance (a11y audit). ONE element (`.globe-gallery-a11y-tip`) — hidden by
   default, shown on `:focus-visible`, and simultaneously the button's `aria-labelledby` target, so
@@ -1618,9 +1622,9 @@ auto-spin (`a11y.isBrowsing()`); mouse drag still works.
   **native `<dialog>`** makes NVDA read the dialog's prose aloud; the same markup as a
   `div[role="dialog"][aria-modal="true"]` does not, so this is the element's behavior and not the
   role's. NVDA does not descend into a `document` subtree, so the attribute opts the long copy out.
-  Measured, not inferred — see the variant probe results: focusing a control instead of the heading
-  makes no difference, and neither does inserting the copy a frame after the dialog is shown (NVDA
-  re-reads live rather than snapshotting at appear-time). Putting the copy in the dialog's
+  Measured in NVDA, not inferred. Three things that do **not** help: focusing a control instead of
+  the heading, inserting the copy a frame after the dialog is shown (NVDA re-reads live rather than
+  snapshotting at appear-time), and making the copy focusable. Putting it in the dialog's
   `aria-describedby` makes it read **twice**.
 - **Only two announcement primitives are portable**: focus moving into a named dialog, and a live
   region's text changing. Each event uses exactly one of them — open → the focused heading, nav →
@@ -1635,7 +1639,8 @@ auto-spin (`a11y.isBrowsing()`); mouse drag still works.
 - **Prev/Next announcement:** nav keeps focus on the button, so the new card is spoken only through
   `.globe-gallery-modal-announce` — an sr-only `aria-live="polite"` span, last child of the dialog,
   written as `"Name. Role. N of M"` by `populateModal(i, speak)` when `speak` is true (the nav call
-  site only; `open()` passes nothing and so clears it, keeping the open path single-read). It
+  site only; `open()` passes nothing and so clears it, keeping the open path single-read — and it
+  clears **before** `showModal()`, so a stale nav line can never be spoken as the dialog appears). It
   carries the **whole** card, position included, because it is the only thing that speaks on nav —
   focus stays on the button and the dialog's name is static by design.
   The text is **not** cleared on a timer — it holds the current card until the next nav or the next

--- a/libs/mep/ace1209/globe-gallery/README.md
+++ b/libs/mep/ace1209/globe-gallery/README.md
@@ -157,7 +157,8 @@ The block expects up to **five direct child rows** (the pull-quote row is option
 
 Rows are positional. `parseAuthoredContent(el)` returns
 `{ arcCopy, pullQuote, fragmentHref, hintText, touchHint, instructions, labels }` (`labels` =
-`{ rotateLeft, rotateRight, pauseSpin, resumeSpin, prevCard, nextCard, closeBtn, cardLabel }`, built
+`{ rotateLeft, rotateRight, pauseSpin, resumeSpin, prevCard, nextCard, closeBtn, modalTitle,
+cardLabel }`, built
 by `buildLabels` from row 3's parts — which it indexes 1:1, so `DEFAULT_LABELS[0]` is the
 instructions slot even though `buildLabels` itself doesn't expose it); cards are loaded separately
 from the fragment link by `fetchFragmentCards`.
@@ -434,7 +435,7 @@ literals in the code are only fallbacks that never show on a correctly-authored 
 | Row 2, cell 0 | touch instruction | the barrel's visible bottom-row copy, between the rotate arrows (see Globe controls). Real on-screen prose, so it's a sentence, not a label. **The authored `<p>`s are kept as nodes, one per line**, so the author owns the line break; a cell with no `<p>` renders as plain text | `Click and drag to rotate. Tap to dive deep into the artwork.` (`DEFAULT_TOUCH_HINT`) |
 | Row 2, cell 1 | "Click & Drag" | WebGL hint plane copy (decorative, not exposed to AT — the a11y instructions cover the real affordance; `createClickDragTexture` auto-scales the font, so keep it short) | `Click & Drag` (`DEFAULT_HINT`) |
 | Row 3, part 1 | instructions | a11y entry-widget accessible name (see below) | `Press Enter to enter the gallery, then Tab through the images.` (`DEFAULT_GALLERY_INSTRUCTIONS`) |
-| Row 3, parts 2–9 | `rotate left \|\| rotate right \|\| pause \|\| resume \|\| prev \|\| {index} of {count} \|\| next \|\| close` | the eight UI labels: the globe controls' four `aria-label`s (the spin toggle names the action it performs, so it needs both states) + modal prev/next/close `aria-label`s + the sr-only card **position** — `\|\|`-separated in on-screen order (`buildLabels`) | each part → English (`DEFAULT_LABELS`) |
+| Row 3, parts 2–10 | `rotate left \|\| rotate right \|\| pause \|\| resume \|\| prev \|\| {index} of {count} \|\| next \|\| close \|\| card details` | the nine UI labels: the globe controls' four `aria-label`s (the spin toggle names the action it performs, so it needs both states) + modal prev/next/close `aria-label`s + the sr-only card **position** + the `<dialog>`'s `aria-label` — `\|\|`-separated in on-screen order (`buildLabels`) | each part → English (`DEFAULT_LABELS`) |
 
 The instructions lead row 3 because they are the a11y row's subject: one cell holding every string
 a screen-reader or keyboard user hears, in the order they meet them — the entry announcement first,
@@ -584,8 +585,8 @@ per-instance unique-id suffix it mints from a module-level counter in
 **multiple globes can coexist on a page**. The only id-bearing nodes are made
 unique per instance via that `gid` suffix (ids, not classes, because both are
 document-wide id references): the CA SVG filter (referenced from JS as
-`filter: url(#ca-filter-<gid>)`) and the modal role-label/heading/description (the
-`<dialog>`'s `aria-labelledby` (name + role) / `aria-describedby` IDREFs). `el` itself is the scroll runway
+`filter: url(#ca-filter-<gid>)`) and the modal heading/role-label/position (the heading's own id
+plus its `aria-describedby` IDREFs). `el` itself is the scroll runway
 (height is `--gg-runway-height` on `.globe-gallery`, collapsed to `100vh` under `.globe-gallery-reduced`);
 the canvas is `position:fixed`. The shared body-level global (acceptable, one modal at a
 time) is the `.globe-gallery-modal-open` scroll lock.
@@ -1162,25 +1163,26 @@ from `globe-gallery.css`; `progress` and the gate columns are runway-independent
 
 | vh | `progress` | gate | what happens | where |
 | ---: | ---: | --- | --- | --- |
-| −40 | — | `lenisY ≥ blockDocTop − ENTRY_LEAD_VH·H` | canvas `display:block`; `arcCopyEntryT` starts | `updateCanvasVisibility` |
-| −40→65 | — | `arcCopyEntryT` 0→1 over `ENTRY_RAMP_VH` | arc pre-roll speeds up, cards slide up, arc-copy fades **in** (done at `ARC_COPY_IN_ENTRY_T`) | `computeFrame`, `updateArcCopy` |
+| −55 / −50 | — | `lenisY ≥ blockDocTop − ENTRY_LEAD_VH·H` (sm / md) | canvas `display:block`; `arcCopyEntryT` starts | `updateCanvasVisibility` |
+| −55→50 / −50→55 | — | `arcCopyEntryT` 0→1 over `ENTRY_RAMP_VH` (sm / md) | arc pre-roll speeds up, cards slide up, arc-copy fades **in** (done at `ARC_COPY_IN_ENTRY_T`) | `computeFrame`, `updateArcCopy` |
 | 0 | 0.000 | block top | `progress` starts; cards on the arc | — |
-| 37 | 0.039 | `FOLD_FIRST_PROGRESS` | `sphereFormT` leaves 0 → camera switches **ortho → perspective** | `updateActiveCamera` |
-| ~41 | ~0.041 | `arcPanT ≥ PROGRESS_GRID_ARC_START` | arc → grid **peel** begins (staggered by `i` + `GRID_PEEL_JITTER`) | `updateCardTransform` |
-| ~54 | ~0.057 | `gpLocalT ≥ FOLD_START_LOCAL_T` | first card actually starts **folding** to the sphere | `updateCardTransform` |
-| 64 | 0.067 | `sphereFormT > TEXT_APPEAR_START` | "Click & Drag" hint plane un-hides, warps in (**sphere geometry only** — the barrel never builds it) | `updateClickDragText` |
-| 90 | 0.096 | `ARC_COPY_OUT_FORM_START` of the fold window | **arc-copy starts fading out** | `updateArcCopy` |
-| 156 | 0.165 | `arcPanT = PROGRESS_GRID_ARC_END` | last card lands in the grid (`gridFormT` = 1) | `updateCardTransform` |
-| 170 | 0.180 | `sphereFormT > CARD_ORDER_HANDOVER_T` | card draw order switches from index order to destination depth (see **Card draw order**) | `applyCardOrder` |
-| 273 | 0.289 | first card's `fdE` hits 1 | earliest card actually **on the shell** (`sphereFormT` ≈ 0.884) | `updateCardTransform` |
-| 277 | 0.294 | `ARC_COPY_OUT_FORM_END` of the fold window | **arc-copy fully gone** | `updateArcCopy` |
-| 277 | 0.294 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` | hover / drag / click / auto-rotate go **live**; a11y browse enabled; canvas cursor becomes `grab`; globe controls fade in; hint-plane entrance **resolves** (warp → 0) | `updateSphereRotation`, `updateCardTransform`, `interaction.applyCursor`, `controls.update`, `updateClickDragText` |
-| 304 | 0.322 | `SPHERE_FORMED_PROGRESS` | sphere/barrel formed; `sphereFormT` = 1, `zoomT` leaves 0; keyboard focus snaps here | `computeFrame` |
-| 356 | 0.471 | `zoomT ≥ pqAppearZoomT` (sm 0.2204) | **sm**: last card vanishes into the prox fade → quote revealed centred and the hold begins; the crosshair draw starts here, nothing was on screen before it; globe controls fade out (also leave the tab order); **hint text reaches 0** — it fades linearly across the whole zoom, so it lands here by construction | `updatePullQuote` + CSS, `controls.update`, `updateClickDragText` |
-| ~356 | ~0.470 | camera passes the shell's centre | on **md** the shell is thinning; the last card does not vanish for another ~29vh | `updateActiveCamera` |
-| 385 | 0.555 | `zoomT ≥ pqAppearZoomT` (md 0.3433) | **md**: same, one card-shell radius later, controls **and the hint text's zero** included; next section's top is 155vh down the viewport. Both breakpoints then hold centred for `min(--gg-pq-hold, --gg-pq-hold-max)` — the draw and the copy play out over 700ms from the cue, and the rest of the pin is still — and un-stick at its end | `updatePullQuote` + CSS, `controls.update` |
-| 368 / 397 | — | `zoomT ≥ pqAppearZoomT + CANVAS_HIDE_MARGIN_T` | canvas `display:none` **and `renderer.render` skipped** — sm at 368vh, md at 397vh. Every card is prox-faded out at the reveal and the hint text went earlier, so the scene has nothing left to draw. The loop still runs to 640vh (the observer's `100%` rootMargin), so the skip covers that tail too, plus the 160vh before the canvas is first shown | `updateCanvasVisibility`, `renderScene` |
-| 540 | 1.000 | runway end | quote is long gone; next section's top reaches the viewport top | CSS |
+| 41 | 0.039 | `FOLD_FIRST_PROGRESS` | `sphereFormT` leaves 0 → camera switches **ortho → perspective** | `updateActiveCamera` |
+| ~43 | ~0.041 | `arcPanT ≥ PROGRESS_GRID_ARC_START` | arc → grid **peel** begins (staggered by `i` + `GRID_PEEL_JITTER`) | `updateCardTransform` |
+| ~60 | ~0.057 | `gpLocalT ≥ FOLD_START_LOCAL_T` | first card actually starts **folding** to the sphere | `updateCardTransform` |
+| 71 | 0.067 | `sphereFormT > TEXT_APPEAR_START` | "Click & Drag" hint plane un-hides, warps in (**sphere geometry only** — the barrel never builds it) | `updateClickDragText` |
+| 101 | 0.096 | `ARC_COPY_OUT_FORM_START` of the fold window | **arc-copy starts fading out** | `updateArcCopy` |
+| 174 | 0.165 | `arcPanT = PROGRESS_GRID_ARC_END` | last card lands in the grid (`gridFormT` = 1) | `updateCardTransform` |
+| 190 | 0.180 | `sphereFormT > CARD_ORDER_HANDOVER_T` | card draw order switches from index order to destination depth (see **Card draw order**) | `applyCardOrder` |
+| 305 | 0.289 | first card's `fdE` hits 1 | earliest card actually **on the shell** (`sphereFormT` ≈ 0.883) | `updateCardTransform` |
+| 310 | 0.294 | `ARC_COPY_OUT_FORM_END` of the fold window | **arc-copy fully gone** | `updateArcCopy` |
+| 322 | 0.305 | `sphereFormT ≥ SPHERE_INTERACTIVE_T` | hover / drag / click / auto-rotate go **live**; a11y browse enabled; canvas cursor becomes `grab`; globe controls fade in; hint-plane entrance **resolves** (warp → 0) | `updateSphereRotation`, `updateCardTransform`, `interaction.applyCursor`, `controls.update`, `updateClickDragText` |
+| 328 | 0.311 | `BROWSE_VIEW_T` | where a keyboard focus snap lands (`snapToBrowseView`) | `snapToBrowseView` |
+| 340 | 0.322 | `SPHERE_FORMED_PROGRESS` | sphere/barrel formed; `sphereFormT` = 1, `zoomT` leaves 0 | `computeFrame` |
+| ~376 | ~0.457 | camera passes the shell's centre | on **md** the shell is thinning; the last card does not vanish for another ~16vh | `updateActiveCamera` |
+| 382 | 0.480 | `zoomT ≥ pqAppearZoomT` (sm 0.2337) | **sm**: last card vanishes into the prox fade → quote revealed centred and the hold begins; the crosshair draw starts here, nothing was on screen before it; globe controls fade out (also leave the tab order); **hint text reaches 0** — it fades linearly across the whole zoom, so it lands here by construction | `updatePullQuote` + CSS, `controls.update`, `updateClickDragText` |
+| 392 | 0.519 | `zoomT ≥ pqAppearZoomT` (md 0.2904) | **md**: same, one card-shell radius later, controls **and the hint text's zero** included; next section's top is 128vh down the viewport. Both breakpoints then hold centred for `min(--gg-pq-hold, --gg-pq-hold-max)` — the draw and the copy play out over 700ms from the cue, and the rest of the pin is still — and un-stick at its end | `updatePullQuote` + CSS, `controls.update` |
+| 391 / 401 | — | `zoomT ≥ pqAppearZoomT + CANVAS_HIDE_MARGIN_T` | canvas `display:none` **and `renderer.render` skipped** — sm at 391vh, md at 401vh. Every card is prox-faded out at the reveal and the hint text went earlier, so the scene has nothing left to draw. The loop still runs to 620vh (the observer's `100%` rootMargin puts its window at −200vh..620vh), so the skip covers that tail too, plus the ~150vh before the canvas is first shown | `updateCanvasVisibility`, `renderScene` |
+| 520 | 1.000 | runway end | quote is long gone; next section's top reaches the viewport top | CSS |
 
 Also on the timeline but **not** scroll-driven, so absent from the charts: texture loading
 (contours → un-dissolve, plus the one-time sm masonry re-solve on `onDone`), the modal
@@ -1216,13 +1218,12 @@ const tail = RUNWAY_VH - FORMATION_VH;
 // The quote's cue is computed from BREAKPOINTS, which globe-gallery.js does not export — this is the
 // one place the doc restates runtime logic (publishPqAppearZoomT), so keep the two in step.
 const js = readFileSync('./globe-gallery.js', 'utf8');
-const NEAR_FADE_END = +js.match(new RegExp('NEAR_FADE_END = ([0-9.]+)'))[1];
 // APPROXIMATE: the runtime uses fadeRefH (mean per-card sphereWorldH, measured after build);
 // CARD_H_SPHERE stands in for it here and lands within ~1vh. Log fadeRefH for the real value.
 const appearT = (band) => {
   const body = js.split('\n  ' + band + ': {')[1].split('\n  },')[0];
   const num = (k) => +body.match(new RegExp(k + ': (-?[0-9.]+)'))[1];
-  const clearZ = -num('SPHERE_R') + NEAR_FADE_END * num('CARD_H_SPHERE');
+  const clearZ = -num('SPHERE_R') + num('NEAR_FADE_END') * num('CARD_H_SPHERE');
   return T.zoomTAtCamZ(clearZ, num('CAM_Z_SPHERE'), num('CAM_Z_END'));
 };
 const atZoomT = (t) => T.SPHERE_FORMED_PROGRESS
@@ -1253,7 +1254,7 @@ read in JS):
 
 The set is `PROGRESS_PAN_END`, `PROGRESS_ARC_PREROLL`, `PROGRESS_GRID_ARC_START` / `_END`,
 `PROGRESS_FOLD_DUR`, `PROGRESS_ZOOM_END`, `GRID_PEEL_STAGGER` and `FOLD_PEEL_OVERLAP`, plus the
-gates (`SPHERE_INTERACTIVE_T`, `CANVAS_HIDE_MARGIN_T`). `GRID_PEEL_JITTER` is **derived** from
+gates (`SPHERE_INTERACTIVE_T`, `BROWSE_VIEW_T`, `CANVAS_HIDE_MARGIN_T`). `GRID_PEEL_JITTER` is **derived** from
 `GRID_PEEL_STAGGER` (below) and `GRID_PEEL_WINDOW` is its complement, so neither is a knob. Dump the
 live values instead of trusting a list here:
 
@@ -1536,9 +1537,37 @@ are real `<button>`s over the sphere (`pointer-events:none` so they never block 
    frame-counted `easeInOutCubic` tween (`KEY_BROWSE_FRAMES`; see Behavior notes → Sphere rotation).
    RM snaps. Enter opens the detail modal for **that** image.
 
-Focusing the entry button or any browse image runs `snapToInteractive` (`window.lenis.scrollTo` to
+The entry widget's `.globe-gallery-a11y-tip` is `aria-hidden` **and** the `aria-labelledby` target:
+name computation traverses hidden referenced subtrees, so the button keeps the instructions as its
+accessible name while the span stops being a node of its own. Without it the button is not a leaf —
+a screen-reader cursor can land on the text inside it, where Enter has nowhere to go, while Tab onto
+the button itself works. The span still renders, so the `:focus-visible` pill is unaffected.
+
+**`.globe-gallery-a11y-cards` is `inert` unless browsing** (`setBrowseActive`). That one flag is the
+whole browse gate: it keeps the N image buttons out of the tab order **and** out of the accessibility
+tree, so the buttons carry no `tabindex` of their own. Collapsed, a screen-reader virtual cursor runs
+entry widget → globe controls. Two platform behaviors it rests on: an inert button cannot take focus, so `enterBrowse()`
+clears `inert` before `focus()`, and so does `focusCard` (the modal's close-time focus restore can
+land before `updateTabStops` has re-run); `trackCardOpen` clears and restores `inert` around its
+synthetic `.click()` rather than relying on inert click semantics.
+
+Focusing the entry button or any browse image runs `snapToFormed` (`window.lenis.scrollTo` to
 `SPHERE_FORMED_PROGRESS`), bringing the block into its interactive state *and* into view before the
-ring shows (the pdf-space focus pattern). A focus guard (`suppressFocusSnap`, armed on window blur /
+ring shows (the pdf-space focus pattern). It lands at **`BROWSE_VIEW_T`** (`sphereFormT` 0.96,
+328vh), not at `sphereFormT` 1: `BROWSE_VIEW_SCROLL_FRAC` is that formT re-expressed as a fraction
+of `formedScrollPx()`, which works because `deriveFrame` maps scroll to progress linearly below
+`formPx`. `centerCardOnScreen`'s `snapPending` still solves for it — `zoomT` is 0 there, so the
+camera is outside the sphere.
+
+Apparent size through the formation is set by `foldSphDist`, **not** by `camera.position.z`:
+`updateSphereGroupDepth` holds `sphereGroup` at `camera.position.z − foldSphDist` for the whole
+`zoomT === 0` span, so the group tracks the camera and only that distance matters. It runs
+`FOLD_SPHERE_DIST → CAM_Z_SPHERE` over `sphereFormT³` — on **md** 173 → 57, so landing at
+`sphereFormT` 1 put the globe **1.34x bigger** than at `SPHERE_INTERACTIVE_T`; 0.96 lands at 70.4
+and takes most of that back. On **sm** the whole span is 89 → 70, so it barely reads either way.
+`BROWSE_VIEW_T` must stay **above** `SPHERE_INTERACTIVE_T` with margin: `globeFormed()` gates on
+`sphereFormT >= SPHERE_INTERACTIVE_T`, so a landing on the threshold could round under it and
+`enterBrowse()` would refuse to enter. A focus guard (`suppressFocusSnap`, armed on window blur /
 `visibilitychange:hidden`) stops a tab-return from re-snapping. While browsing the core pauses
 auto-spin (`a11y.isBrowsing()`); mouse drag still works.
 
@@ -1556,6 +1585,12 @@ auto-spin (`a11y.isBrowsing()`); mouse drag still works.
   `preventDefault`'d so the close animation plays) / Enter-on-Close exit and the dialog **restores
   focus to the opening image**. No backdrop-click-to-close; no arrow-key globe rotation (browsing
   replaced it).
+- **Modal counter:** the visible `.globe-gallery-modal-counter` ("05 / 47") and the sr-only
+  `.globe-gallery-modal-position` ("5 of 47", from `cardLabel`) are **both `aria-hidden`**. The
+  position is spoken only through the heading's `aria-describedby`, which still resolves it —
+  description computation traverses `aria-hidden` subtrees. Hiding it keeps NVDA's dialog sweep
+  from reading it on top of the heading, and keeps it from being a redundant virtual-cursor stop
+  now that open and nav both announce it.
 - **Instructions popup:** on focus the entry widget shows a **visible pill** so sighted keyboard
   users get the affordance (a11y audit). ONE element (`.globe-gallery-a11y-tip`) — hidden by
   default, shown on `:focus-visible`, and simultaneously the button's `aria-labelledby` target, so
@@ -1566,11 +1601,47 @@ auto-spin (`a11y.isBrowsing()`); mouse drag still works.
   position); forward-nav then walks name → role → description → badges → photo before the controls.
   The photo is a `role="img"` sr-only element placed AFTER the info block (so the heading reads
   first), carrying the card's alt as a real text alternative. The card **position** ("N of M") lives
-  in one sr-only element referenced by BOTH the dialog's `aria-labelledby` and the heading's
-  `aria-describedby` — **no `aria-live`** — so it's deterministic on both paths: on open it's read
-  with the focused heading; on nav (focus stays on Prev/Next) the accessible-name text changes, so
-  VoiceOver re-announces the dialog name. A live region would be more portable across AT but can't
-  reliably cover the open case.
+  in one sr-only element referenced by the heading's `aria-describedby`, so it is read with the
+  focused heading on open.
+- **The `<dialog>`'s name is static and is not card text.** `aria-label` is `labels.modalTitle`,
+  row 3 part 10, defaulting to English like every other label. Two rules follow from this, and both
+  were learned the hard way:
+  1. It must not be **card** text (`aria-labelledby` → the heading, role or position). The dialog
+     name and the focused heading are two separate announcements on open; if they overlap, the card
+     is read twice. Leaving the dialog unnamed is not an escape — VoiceOver then falls back to
+     reading the contents, which overlaps too. An empty or whitespace `aria-label` is the same as
+     unnamed: name computation ignores it.
+  2. It must not **change** per card. VoiceOver re-announces a dialog whose name changed; NVDA never
+     does. A changing name is therefore a channel that double-speaks on one AT and is silent on the
+     other — it cannot be the carrier for anything.
+- **`role="document"` on `.globe-gallery-modal-description` is load-bearing for NVDA.** Opening a
+  **native `<dialog>`** makes NVDA read the dialog's prose aloud; the same markup as a
+  `div[role="dialog"][aria-modal="true"]` does not, so this is the element's behavior and not the
+  role's. NVDA does not descend into a `document` subtree, so the attribute opts the long copy out.
+  Measured, not inferred — see the variant probe results: focusing a control instead of the heading
+  makes no difference, and neither does inserting the copy a frame after the dialog is shown (NVDA
+  re-reads live rather than snapshotting at appear-time). Putting the copy in the dialog's
+  `aria-describedby` makes it read **twice**.
+- **Only two announcement primitives are portable**: focus moving into a named dialog, and a live
+  region's text changing. Each event uses exactly one of them — open → the focused heading, nav →
+  the live region — and nothing here relies on an AT re-reading a changed name or falling back to
+  contents.
+- **Focus on open is declarative** — `open()` never calls `focus()`. The heading carries `autofocus`
+  and the `<dialog>` has no `tabindex`, so `showModal()` lands on the heading itself. Measured:
+  NVDA announces the heading identically whether focus arrives via `autofocus` or via an explicit
+  post-`showModal()` `focus()`, so the explicit move earns nothing. Any JS `focus()` here must stay
+  in the same task as `showModal()` — a `requestAnimationFrame` later is a separate AX event and
+  VoiceOver announces it as one.
+- **Prev/Next announcement:** nav keeps focus on the button, so the new card is spoken only through
+  `.globe-gallery-modal-announce` — an sr-only `aria-live="polite"` span, last child of the dialog,
+  written as `"Name. Role. N of M"` by `populateModal(i, speak)` when `speak` is true (the nav call
+  site only; `open()` passes nothing and so clears it, keeping the open path single-read). It
+  carries the **whole** card, position included, because it is the only thing that speaks on nav —
+  focus stays on the button and the dialog's name is static by design.
+  The text is **not** cleared on a timer — it holds the current card until the next nav or the next
+  open, so a queued announcement can never be truncated. Cost: after navigating, a virtual cursor
+  reading to the very end hears the current card's name and role once more, after Close.
+  `assertive` also works and interrupts the previous card, but VoiceOver prefixes it with a tone.
 
 **Reduced motion** (`prefers-reduced-motion: reduce`) renders a **static interactive** globe
 instead of the scroll choreography, laid out as **plain document flow** (`.globe-gallery-reduced`):
@@ -1873,6 +1944,10 @@ The quote box has **no height**. It is a column flex container whose only tunabl
 `--gg-pq-gap`, the space between the `blockquote` and the name/role `.globe-gallery-pullquote-attribution`;
 everything else (padding + copy) sizes itself.
 
+`.globe-gallery-pullquote` is a **`<figure>`** and the attribution its **`<figcaption>`**, which is
+what associates the name/role with the `<blockquote>` for AT. Its `margin: 0 auto` zeroes the UA
+`margin-block`, which the pin math takes as zero.
+
 `--gg-pq-gap` is `min(--s2a-layout-xl, --gg-band-h × 0.2)` — one declaration, no media query. It is
 the full 160px on any viewport taller than ~924px and tapers below that, because the box is
 content-sized while the band it centres in is not: on a short, wide laptop (1280×720 is the worst
@@ -2020,7 +2095,15 @@ width**, not on the viewport's: a scrollbar arriving changes the box without cha
 `innerWidth` (the body `ResizeObserver` is what catches it), and a viewport change that only alters
 height leaves the split correct. `fonts.ready` forces one regardless. It drops the copy cache and
 rewrites the current frame straight after, because fresh line elements carry no progress var and
-would otherwise render at rest for a frame.
+would otherwise render at rest for a frame. Line text is assigned with `textContent`; `createTag`'s
+third argument parses a string as markup.
+
+**The split is presentational, and AT gets the unsplit text.** Each `.globe-gallery-pullquote-line`
+is `aria-hidden`, and `layoutQuote` appends one `.sr-only.globe-gallery-pullquote-sr` span holding
+the whole quote. Block-level line spans otherwise land in the accessibility tree as one static-text
+node **per visual line**, so a screen reader stops mid-phrase at break points that move with the box
+width; the sr-only span restores the single node a plain `<blockquote>` produces. It carries
+`user-select: none` so selecting the quote copies the visible lines only, never both copies.
 
 Details that are load-bearing:
 
@@ -2213,7 +2296,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   so reporting there too would double-count.
 - **`enter_gallery` is the one engagement signal here** — one label, ~one event per keyboard session,
   answering whether the two-level gallery is ever entered at all. The widget is only *clicked* to
-  enter BROWSE; merely focusing it (which scrolls via `snapToInteractive`) is not reported.
+  enter BROWSE; merely focusing it (which scrolls via `snapToFormed`) is not reported.
 - **Caveat inherent to `daa-ll` on any button:** a real click reports even when the handler declines
   to act — `enterBrowse()` bails if the sphere isn't formed, `onCardClick` if `isInteractive()` is
   false. Expect a small over-count on both.
@@ -2251,7 +2334,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
   0.15 → RESTING 0.06`), fades out over the zoom. **The entrance resolves on
   `SPHERE_INTERACTIVE_T`, not at `sphereFormT` 1**: `sfT` remaps `[TEXT_APPEAR_START,
   SPHERE_INTERACTIVE_T]`, so the warp reaches 0 exactly when the globe goes live and the `grab`
-  cursor arrives. Running it to 1 (the original) left the hint still visibly warping in for 27vh *after* the
+  cursor arrives. Running it to 1 (the original) left the hint still visibly warping in for 18vh *after* the
   thing it names was already draggable — measured `uWarp` 0.946 of `TEXT_WARP_ENTER_MAX` 4.5 still
   active at the gate, now 0.002. The plane's *scale* is unaffected and keeps tracking `foldSphDist`
   to 1.0 at `sphereFormT` 1; that is distance compensation, not entrance, and holds apparent size
@@ -2282,7 +2365,7 @@ through DAA, they share one consent path; there is no gate on one and not the ot
 
   **`hintDismissProgress` is a one-way latch.** Nothing re-arms it short of `destroy()` (band
   crossing, RM toggle, context-loss recovery), which is per-instance state and stays that way. Do
-  not re-arm it on `sphereFormT` dropping below `SPHERE_INTERACTIVE_T`: that gate is ~28vh of
+  not re-arm it on `sphereFormT` dropping below `SPHERE_INTERACTIVE_T`: that gate is ~18vh of
   scroll-back, so a small nudge would bring a dismissed hint straight back.
 
   The row's scrim matches **`.globe-gallery-modal-info`** — `transparent-black-64` +
@@ -2727,11 +2810,11 @@ through DAA, they share one consent path; there is no gate on one and not the ot
     constant across window sizes: a bigger ball on screen needs *fewer* rad/px, which one fixed
     number got wrong in both directions — over-geared on a tall desktop window, under-geared on a
     phone. Drag by the ball's on-screen radius and it turns `90° × DRAG_GEARING`.
-  - **`SPHERE_INTERACTIVE_T` is 0.9, not 0.8, because 0.8 is ahead of every card.** Cards land
-    between `sphereFormT` 0.884 (the first) and exactly 1 (the last — its fold end *is*
+  - **`SPHERE_INTERACTIVE_T` is 0.94, not 0.8, because 0.8 is ahead of every card.** Cards land
+    between `sphereFormT` 0.883 (the first) and exactly 1 (the last — its fold end *is*
     `SPHERE_FORMED_PROGRESS`), so at 0.8 the drag was spinning a swarm still mid-assembly and a tap
     was being refused on cards that already read as part of the globe. Both went through the same
-    gate, in opposite kinds of wrong. 0.9 sits just past the first landing: something is on the shell
+    gate, in opposite kinds of wrong. 0.94 sits just past the first landing: something is on the shell
     to grab and to click. ONE constant for **everything** that says or does "the globe is live":
     hover, click, drag, auto-rotate, the `grab` cursor, and the GL hint plane's entrance. Do not give
     the cursor its own earlier gate: it puts the affordance 26vh ahead of the input it advertises.
@@ -2813,7 +2896,7 @@ self-evident from the name:
 | `VEL_SMOOTH_MS` (`interaction.js`) | ms | time constant of the release-velocity EMA |
 | `HOVER_RATE` | per 60fps frame | ease toward the hover target, applied as `1 − (1 − RATE) ** dtScale`; reaches 80% in `ln(0.2) / ln(1 − RATE)` frames |
 | `CA_STRENGTH` | UV | radial shift per channel at transition peaks (bell curve) |
-| `CA_MOTION_STRENGTH` / `…_ARC` | UV | directional (motion-trail) shift max — full during peel/fold/sphere/modal, softly clamped on the arc. Amplitude is `sqrt` of the scroll/drag speed ratio (see `SCROLL_VEL_MAX`), not the ratio itself |
+| `CA_MOTION_CAP` | UV | directional (motion-trail) shift max. Amplitude is `sqrt` of the scroll/drag speed ratio (see `SCROLL_VEL_MAX`), not the ratio itself |
 | `SPHERE_DRAG_CA_MUL` | uCA per unit of `sphereDragWarp` | adds to `uCA` while spinning the sphere, on top of the transition bell and hover terms |
 | `SCROLL_VEL_MAX` | px/frame | scroll speed that saturates the motion-trail amplitude and the global canvas filter (`CA_PX_MAX`) |
 | `CA_PX_MAX` | px | max vertical shift for the global canvas SVG filter. Gated by `GLOBAL_CA_SM`/`_MD` — **sm stays off**: a CSS `filter` over the full canvas forces an offscreen composite every repainted frame, and falls off the GPU-accelerated path on mobile Safari in particular |

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -256,7 +256,7 @@ html[dir="rtl"] .globe-gallery-arc-copy {
   inset-inline: 0;
   box-sizing: border-box;
   max-width: var(--gg-copy-max);
-  margin-inline: auto;
+  margin: 0 auto;
   background: transparent;
   display: flex;
   flex-direction: column;
@@ -358,6 +358,11 @@ html[dir="rtl"] .globe-gallery-arc-copy {
 .globe-gallery-pullquote-line-inner {
   display: inline-block;
   transform: translate3d(0, calc((1 - var(--gg-pq-line-v, 1)) * var(--gg-pq-line-start)), 0);
+}
+
+.globe-gallery-pullquote-sr {
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .globe-gallery-pullquote-name {
@@ -753,18 +758,6 @@ body.globe-gallery-modal-open { overflow: hidden; }
   opacity: 1;
   visibility: visible;
   transform: translate(-50%, -50%) scale(1);
-}
-
-.globe-gallery-sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  white-space: nowrap;
-  border: 0;
 }
 
 /* Keyboard focus indicators (2px S2A focus ring, 2px offset). */

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.css
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.css
@@ -777,7 +777,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   outline-offset: 2px;
 }
 
-@media (min-width: 768px) {
+@media (width >= 768px) {
   .globe-gallery-modal-chrome {
     --gg-modal-edge: var(--s2a-spacing-lg);
     --gg-counter-w: 138px;
@@ -843,7 +843,7 @@ body.globe-gallery-modal-open { overflow: hidden; }
   }
 }
 
-@media (min-width: 1280px) {
+@media (width >= 1280px) {
   .globe-gallery-pullquote {
     --gg-pq-ideal-gap: var(--s2a-layout-2xl);
   }

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -42,7 +42,7 @@ const BREAKPOINTS = {
     GRID_ROWS: 8,
     CARD_FACE_CAMERA: 0,
     CARD_ROLL_JITTER: 0.18,
-    ARC_DENSE_FRACTION: 0.4,
+    ARC_DENSE_FRACTION: 0.55,
     CYL_COLS_FIT: 0.65,
     DRAG_GEARING: 0.53, // fraction of 1:1 surface tracking
     ENTRY_LEAD_VH: 0.55,
@@ -81,8 +81,6 @@ const MODAL_TEX_SM = 768;
 const MODAL_TEX_MD = 2048;
 const ANTIALIAS_SM = false;
 const ANTIALIAS_MD = true;
-const GLOBAL_CA_SM = false;
-const GLOBAL_CA_MD = true;
 
 // Yaw-only drags (touch / narrow): a cylindrical masonry wall replaces the Fibonacci sphere.
 const YAW_ONLY_GEOMETRY = {
@@ -138,14 +136,17 @@ const COLUMN_EPS = 1e-6;
 
 // Chromatic aberration.
 const CA_ENABLED = true;
-const CA_STRENGTH = 0.020; // radial UV shift per channel
-const CA_MOTION_STRENGTH = 1.0; // directional UV shift max
-const CA_MOTION_STRENGTH_ARC = 0.10;
-const SCROLL_VEL_MAX = 8; // px/frame scroll speed that saturates the motion trail
-const CA_PX_MAX = 8; // max vertical px shift for the canvas SVG filter
+const CA_STRENGTH = 0.01; // radial UV shift per channel
+const CA_MOTION_CAP = 0.03; // directional UV shift max
+const SCROLL_VEL_MAX = 18; // px/frame scroll speed that saturates the motion trail
+const CA_PX_MAX = 1; // max vertical px shift for the canvas SVG filter
+const GLOBAL_CA_SM = false;
+const GLOBAL_CA_MD = true;
+const HOVER_CA = 0.0125;
+const SPHERE_DRAG_CA_MUL = 0.2; // uCA per unit of sphereDragWarp
+const TEXT_CA_WARP_MUL = 0.75;
 
 // Hover (sphere phase only).
-const HOVER_CA = 0.025;
 const HOVER_WARP = 0.4;
 const HOVER_SCALE = 0.25; // added, not replacing: 1.0 → 1.25
 const HOVER_RATE = 0.15; // per-frame lerp toward target
@@ -173,14 +174,12 @@ const SPHERE_DRAG_WARP_BASELINE = 0.05; // while isDragging
 const SPHERE_DRAG_WARP_VEL = 3.5; // multiplier on drag-speed
 const SPHERE_DRAG_WARP_MAX = 0.25; // cap on the combined value
 const SPHERE_DRAG_WARP_EASE = 0.20; // per-frame ease toward the target
-const SPHERE_DRAG_CA_MUL = 0.10; // uCA per unit of sphereDragWarp
 
 // "Click & Drag" hint text: a WebGL plane behind the sphere.
 const TEXT_BEHIND_GAP = 15; // world units behind the sphere back surface
 const TEXT_WARP_ENTER_MAX = 4.50;
 const TEXT_OPACITY_PEAK = 0.15;
 const TEXT_OPACITY_RESTING = 0.06;
-const TEXT_CA_WARP_MUL = 1.5;
 const TEXT_WARP_OVERFLOW = 0.6; // extra mesh scale per warp unit
 // hintDismissProgress accrual per 60fps frame of drag.
 const HINT_EXIT_DIST_RATE = 0.018;
@@ -883,22 +882,24 @@ function createGlobeGalleryRuntime(
   }
 
   // dx/dy: world-space delta this frame. ampOverride defaults to sqrt(scroll/drag speed ratio).
-  function applyMotionCA(mesh, dx, dy, ampOverride, strength) {
+  function applyMotionCA(mesh, dx, dy, ampOverride, cap) {
     if (!CA_ENABLED) return;
     const { CARD_W_SPHERE, CARD_H_SPHERE } = bp;
-    const s = strength !== undefined ? strength : CA_MOTION_STRENGTH;
+    const s = cap !== undefined ? cap : CA_MOTION_CAP;
     const sX = Math.max(mesh.scale.x, 0.01);
     const sY = Math.max(mesh.scale.y, 0.01);
-    const uvDX = dx / (CARD_W_SPHERE * sX);
-    const uvDY = dy / (CARD_H_SPHERE * sY);
+    const dt = frameState.dtScale;
+    const uvDX = dx / (CARD_W_SPHERE * sX * dt);
+    const uvDY = dy / (CARD_H_SPHERE * sY * dt);
     const dragSpeed = Math.sqrt(drag.velX * drag.velX + drag.velY * drag.velY);
     const ampRaw = Math.min(
       1.0,
       Math.max(frameState.scrollVel / SCROLL_VEL_MAX, dragSpeed / MAX_VEL),
     );
     const amp = ampOverride !== undefined ? ampOverride : Math.sqrt(ampRaw);
-    const mx = Math.max(-s, Math.min(s, uvDX * amp));
-    const my = Math.max(-s, Math.min(s, uvDY * amp));
+    const rep = mesh.material.uniforms.uRepeat.value;
+    const mx = Math.max(-s, Math.min(s, uvDX * amp)) * rep.x;
+    const my = Math.max(-s, Math.min(s, uvDY * amp)) * rep.y;
     mesh.material.uniforms.uMotionDir.value.set(mx, my);
   }
 
@@ -1473,7 +1474,12 @@ function createGlobeGalleryRuntime(
       mesh.material.uniforms.uWarp.value = card.hoverT * HOVER_WARP + sphereDragWarp;
     }
     // World delta approximated as depth × angular velocity.
-    applyMotionCA(mesh, card.spherePos.z * drag.velX, -card.spherePos.z * drag.velY);
+    const dragDt = frameState.dtScale;
+    applyMotionCA(
+      mesh,
+      card.spherePos.z * drag.velX * dragDt,
+      -card.spherePos.z * drag.velY * dragDt,
+    );
   }
 
   function placeFoldingCard(card, mesh, fdE, stage, prevMeshX, prevMeshY, frame) {
@@ -1585,17 +1591,7 @@ function createGlobeGalleryRuntime(
     mesh.scale.setScalar(stage.scale);
     mesh.rotation.set(0, 0, stage.rotZ);
     mesh.material.opacity = 1;
-    if (gpE <= 0) {
-      applyMotionCA(
-        mesh,
-        mesh.position.x - prevMeshX,
-        mesh.position.y - prevMeshY,
-        undefined,
-        CA_MOTION_STRENGTH_ARC,
-      );
-    } else {
-      applyMotionCA(mesh, mesh.position.x - prevMeshX, mesh.position.y - prevMeshY);
-    }
+    applyMotionCA(mesh, mesh.position.x - prevMeshX, mesh.position.y - prevMeshY);
   }
 
   function applyCardOrder(card, mesh, i, frame) {

--- a/libs/mep/ace1209/globe-gallery/globe-gallery.js
+++ b/libs/mep/ace1209/globe-gallery/globe-gallery.js
@@ -1013,11 +1013,11 @@ function createGlobeGalleryRuntime(
     return Math.min((formationVh / 100) * H, blockHeight);
   }
 
-  function snapToInteractive() {
+  function snapToBrowseView() {
     if (suppressFocusSnap) return;
     const top = reducedMotion
       ? blockDocTop
-      : blockDocTop + formedScrollPx();
+      : blockDocTop + formedScrollPx() * TL.BROWSE_VIEW_SCROLL_FRAC;
     // The rAF loop re-arms itself each tick, so exactly one tick runs on the OLD scroll position
     // before the callback below lands. Above the block that tick would reset the orientation and
     // cancel the nudge focus just armed, leaving the card off screen. Hold the reset for it.
@@ -1049,7 +1049,7 @@ function createGlobeGalleryRuntime(
   };
 
   // The globe is on screen and nothing is covering it. The keyboard path stays on THIS even past
-  // the pull-quote cue: focusing a card runs snapToInteractive, which scrolls back into range, so
+  // the pull-quote cue: focusing a card runs snapToBrowseView, which scrolls back into range, so
   // retiring the tab stops early would remove the entry point before the snap could use it.
   const globeFormed = () => frameState.sphereFormT >= TL.SPHERE_INTERACTIVE_T
     && modal.getModalIdx() < 0;
@@ -1067,7 +1067,7 @@ function createGlobeGalleryRuntime(
     // A focus snap follows unless it is suppressed (tab-return): solve for where the camera lands.
     centerCard: (i) => centerCardOnScreen(i, !suppressFocusSnap),
     openCard: (i) => openModalAndDismissHint(i, W / 2, H / 2),
-    onFocus: snapToInteractive,
+    onFocus: snapToBrowseView,
     galleryInstructions: instructions,
     gid,
   });

--- a/libs/mep/ace1209/globe-gallery/src/a11y.js
+++ b/libs/mep/ace1209/globe-gallery/src/a11y.js
@@ -32,10 +32,14 @@ export default function createGalleryA11y({
     appliedEntered = null;
   }
 
+  function setBrowseActive(active) {
+    if (cardsEl) cardsEl.inert = !active;
+  }
+
   function collapse() {
     entered = false;
     focusedIdx = -1;
-    cardButtons.forEach((btn) => { btn.tabIndex = -1; });
+    setBrowseActive(false);
     if (widgetEl) widgetEl.tabIndex = getModalIdx() < 0 ? 0 : -1;
   }
 
@@ -64,7 +68,7 @@ export default function createGalleryA11y({
     if (!isGlobeFormed() || !cardButtons.length) return;
     entered = true;
     if (widgetEl) widgetEl.tabIndex = -1;
-    cardButtons.forEach((btn) => { btn.tabIndex = 0; });
+    setBrowseActive(true);
     cardButtons[cardOrder[0]].focus();
   }
 
@@ -92,6 +96,7 @@ export default function createGalleryA11y({
       descEl.className = 'globe-gallery-a11y-tip';
       descEl.id = `globe-gallery-a11y-desc-${gid}`;
       descEl.textContent = galleryInstructions;
+      descEl.setAttribute('aria-hidden', 'true');
       widgetEl.appendChild(descEl);
       widgetEl.setAttribute('aria-labelledby', descEl.id);
     }
@@ -101,6 +106,7 @@ export default function createGalleryA11y({
 
     cardsEl = document.createElement('div');
     cardsEl.className = 'globe-gallery-a11y-cards';
+    cardsEl.inert = true;
     const count = getCount();
     cardButtons = [];
     for (let n = 0; n < count; n += 1) {
@@ -108,7 +114,6 @@ export default function createGalleryA11y({
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'globe-gallery-a11y-card';
-      btn.tabIndex = -1; // joins the tab order only while entered
       btn.dataset.idx = String(i);
       btn.setAttribute('daa-ll', CARD_OPEN_DAA_LL);
       btn.setAttribute('aria-label', getCardLabel(i));
@@ -140,16 +145,8 @@ export default function createGalleryA11y({
     if (modalOpen === appliedModalOpen && entered === appliedEntered) return;
     appliedModalOpen = modalOpen;
     appliedEntered = entered;
-    if (modalOpen) {
-      widgetEl.tabIndex = -1;
-      cardButtons.forEach((btn) => { btn.tabIndex = -1; });
-    } else if (entered) {
-      widgetEl.tabIndex = -1;
-      cardButtons.forEach((btn) => { btn.tabIndex = 0; });
-    } else {
-      widgetEl.tabIndex = 0;
-      cardButtons.forEach((btn) => { btn.tabIndex = -1; });
-    }
+    widgetEl.tabIndex = !modalOpen && !entered ? 0 : -1;
+    setBrowseActive(!modalOpen && entered);
   }
 
   // The core reads this to pause auto-spin so the globe holds the centred image.
@@ -160,12 +157,19 @@ export default function createGalleryA11y({
   function focusCard(idx) {
     if (!entered) return;
     const btn = cardButtons[idx];
-    if (btn) btn.focus();
+    if (!btn) return;
+    setBrowseActive(true);
+    btn.focus();
   }
 
   // Report a canvas card open by clicking that card's button.
   function trackCardOpen(idx) {
-    cardButtons[idx]?.click();
+    const btn = cardButtons[idx];
+    if (!btn || !cardsEl) return;
+    const wasInert = cardsEl.inert;
+    cardsEl.inert = false;
+    btn.click();
+    cardsEl.inert = wasInert;
   }
 
   function getFocusedIdx() {

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -365,13 +365,14 @@ const buildMarkup = (gid, labels) => `
   <svg class="globe-gallery-ca-svg" aria-hidden="true" focusable="false" style="position:absolute;width:0;height:0;overflow:hidden">
     <defs>
       <filter id="ca-filter-${gid}" color-interpolation-filters="sRGB">
-        <feColorMatrix in="SourceGraphic" type="matrix" values="1 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 1 0" result="rch"/>
+        <feColorMatrix in="SourceGraphic" type="matrix" values="1 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0 1" result="rch"/>
         <feOffset in="rch" class="globe-gallery-ca-r-offset" dx="0" dy="0" result="rOff"/>
-        <feColorMatrix in="SourceGraphic" type="matrix" values="0 0 0 0 0  0 1 0 0 0  0 0 0 0 0  0 0 0 1 0" result="gch"/>
-        <feColorMatrix in="SourceGraphic" type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 1 0 0  0 0 0 1 0" result="bch"/>
+        <feColorMatrix in="SourceGraphic" type="matrix" values="0 0 0 0 0  0 1 0 0 0  0 0 0 0 0  0 0 0 0 1" result="gch"/>
+        <feColorMatrix in="SourceGraphic" type="matrix" values="0 0 0 0 0  0 0 0 0 0  0 0 1 0 0  0 0 0 0 1" result="bch"/>
         <feOffset in="bch" class="globe-gallery-ca-b-offset" dx="0" dy="0" result="bOff"/>
         <feBlend in="rOff" in2="gch" mode="screen" result="rg"/>
-        <feBlend in="rg" in2="bOff" mode="screen"/>
+        <feBlend in="rg" in2="bOff" mode="screen" result="rgb"/>
+        <feComposite in="rgb" in2="SourceGraphic" operator="in"/>
       </filter>
     </defs>
   </svg>

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -414,7 +414,7 @@ const buildMarkup = (gid, labels) => `
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M15 5l-7 7 7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>
     <div class="globe-gallery-modal-counter" aria-hidden="true"></div>
-    <span class="globe-gallery-modal-position sr-only" id="globe-gallery-modal-position-${gid}" aria-hidden="true"></span>
+    <span class="globe-gallery-modal-position sr-only" id="globe-gallery-modal-position-${gid}" role="note"></span>
     <button class="globe-gallery-modal-nav globe-gallery-modal-nav-next" type="button" daa-ll="next_card-2--globe_card_modal" aria-label="${escapeHtml(labels.nextCard)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M9 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -34,7 +34,7 @@ const LABEL_DIVIDER = '||';
 const DEFAULT_LABELS = [
   DEFAULT_GALLERY_INSTRUCTIONS,
   'Rotate left', 'Rotate right', 'Pause spinning', 'Resume spinning',
-  'Previous card', '{index} of {count}', 'Next card', 'Close',
+  'Previous card', '{index} of {count}', 'Next card', 'Close', 'Card details',
 ];
 const CARD_TPL_INDEX = 6;
 
@@ -52,6 +52,7 @@ function buildLabels(parts) {
     prevCard: at(5),
     nextCard: at(7),
     closeBtn: at(8),
+    modalTitle: at(9),
     cardLabel: (index, count) => cardTpl
       .replace('{index}', String(index))
       .replace('{count}', String(count)),
@@ -146,8 +147,10 @@ export function layoutQuote(quoteEl) {
     inner.textContent = wordsOnLine.join(' ');
     // A margin, not the text-indent it came from: that inherits into the inner and applies twice.
     if (i === 0 && indent) inner.style.marginInlineStart = indent;
-    return createTag('span', { class: 'globe-gallery-pullquote-line' }, inner);
+    return createTag('span', { class: 'globe-gallery-pullquote-line', 'aria-hidden': 'true' }, inner);
   });
+  const srEl = createTag('span', { class: 'sr-only globe-gallery-pullquote-sr' });
+  srEl.textContent = text;
   quoteEl.style.textIndent = '';
   quoteEl.classList.add('globe-gallery-pullquote-lines');
   // Spaced, or textContent runs the lines together ("the differentapps."). Whitespace between
@@ -157,6 +160,7 @@ export function layoutQuote(quoteEl) {
     if (i) nodes.push(document.createTextNode(' '));
     nodes.push(line);
   });
+  nodes.push(srEl);
   quoteEl.replaceChildren(...nodes);
   return lineEls;
 }
@@ -380,13 +384,13 @@ const buildMarkup = (gid, labels) => `
 
   <div class="globe-gallery-pullquote-pin">
     <div class="globe-gallery-pullquote-rail">
-      <div class="globe-gallery-pullquote">
+      <figure class="globe-gallery-pullquote">
         <blockquote class="globe-gallery-pullquote-quote heading-1"></blockquote>
-        <div class="globe-gallery-pullquote-attribution">
+        <figcaption class="globe-gallery-pullquote-attribution">
           <p class="globe-gallery-pullquote-name body-lg"></p>
           <p class="globe-gallery-pullquote-role body-lg"></p>
-        </div>
-      </div>
+        </figcaption>
+      </figure>
     </div>
   </div>
 
@@ -396,27 +400,28 @@ const buildMarkup = (gid, labels) => `
 
   <canvas class="globe-gallery-modal-canvas" style="position:fixed;top:0;left:0;width:100%;height:100vh;z-index:14;display:none;pointer-events:none;"></canvas>
 
-  <dialog class="globe-gallery-modal-chrome" tabindex="-1" aria-labelledby="globe-gallery-modal-name-${gid} globe-gallery-modal-role-${gid} globe-gallery-modal-position-${gid}" aria-describedby="globe-gallery-modal-description-${gid}">
+  <dialog class="globe-gallery-modal-chrome" aria-label="${escapeHtml(labels.modalTitle)}">
     <div class="globe-gallery-modal-info">
-      <h2 class="globe-gallery-modal-name" id="globe-gallery-modal-name-${gid}" tabindex="-1" aria-describedby="globe-gallery-modal-role-${gid} globe-gallery-modal-position-${gid}"></h2>
+      <h2 class="globe-gallery-modal-name" id="globe-gallery-modal-name-${gid}" tabindex="-1" autofocus aria-describedby="globe-gallery-modal-role-${gid} globe-gallery-modal-position-${gid}"></h2>
       <p class="globe-gallery-modal-role-label" id="globe-gallery-modal-role-${gid}"></p>
-      <div class="globe-gallery-modal-description" id="globe-gallery-modal-description-${gid}" data-lenis-prevent></div>
+      <div class="globe-gallery-modal-description" id="globe-gallery-modal-description-${gid}" role="document" data-lenis-prevent></div>
       <ul class="globe-gallery-modal-badges"></ul>
     </div>
     <!-- sr-only alt for the WebGL photo; after the info so the heading is read first. -->
-    <span class="globe-gallery-modal-image globe-gallery-sr-only" role="img"></span>
+    <span class="globe-gallery-modal-image sr-only" role="img"></span>
     <!-- Controls after the info scrim so they paint on top of it. -->
     <button class="globe-gallery-modal-nav globe-gallery-modal-nav-prev" type="button" daa-ll="prev_card-1--globe_card_modal" aria-label="${escapeHtml(labels.prevCard)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M15 5l-7 7 7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>
+    <div class="globe-gallery-modal-counter" aria-hidden="true"></div>
+    <span class="globe-gallery-modal-position sr-only" id="globe-gallery-modal-position-${gid}" aria-hidden="true"></span>
     <button class="globe-gallery-modal-nav globe-gallery-modal-nav-next" type="button" daa-ll="next_card-2--globe_card_modal" aria-label="${escapeHtml(labels.nextCard)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M9 5l7 7-7 7" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
     </button>
-    <div class="globe-gallery-modal-counter" aria-hidden="true"></div>
     <button class="globe-gallery-modal-close" type="button" daa-ll="close-3--globe_card_modal" aria-label="${escapeHtml(labels.closeBtn)}">
       <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg>
     </button>
-    <span class="globe-gallery-modal-position globe-gallery-sr-only" id="globe-gallery-modal-position-${gid}"></span>
+    <span class="globe-gallery-modal-announce sr-only" aria-live="polite"></span>
   </dialog>
 `;
 

--- a/libs/mep/ace1209/globe-gallery/src/authoring.js
+++ b/libs/mep/ace1209/globe-gallery/src/authoring.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-relative-packages
-import { getFederatedUrl } from '../../../../utils/utils.js';
+import { createTag, getFederatedUrl } from '../../../../utils/utils.js';
 
 export function escapeHtml(s) {
   const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
@@ -142,15 +142,11 @@ export function layoutQuote(quoteEl) {
   const indent = quoteEl.style.textIndent;
   const lines = measureLines(quoteEl, text.split(/\s+/));
   const lineEls = lines.map((wordsOnLine, i) => {
-    const line = document.createElement('span');
-    line.className = 'globe-gallery-pullquote-line';
-    const inner = document.createElement('span');
-    inner.className = 'globe-gallery-pullquote-line-inner';
+    const inner = createTag('span', { class: 'globe-gallery-pullquote-line-inner' });
     inner.textContent = wordsOnLine.join(' ');
-    line.append(inner);
     // A margin, not the text-indent it came from: that inherits into the inner and applies twice.
     if (i === 0 && indent) inner.style.marginInlineStart = indent;
-    return line;
+    return createTag('span', { class: 'globe-gallery-pullquote-line' }, inner);
   });
   quoteEl.style.textIndent = '';
   quoteEl.classList.add('globe-gallery-pullquote-lines');

--- a/libs/mep/ace1209/globe-gallery/src/modal.js
+++ b/libs/mep/ace1209/globe-gallery/src/modal.js
@@ -344,7 +344,12 @@ export default function createGlobeModal({
     if (descEl) requestAnimationFrame(() => { if (modalIdx >= 0) updateDescFade(descEl); });
   }
 
-  function populateModal(i) {
+  function announce(text) {
+    const el = chromeEl && chromeEl.querySelector('.globe-gallery-modal-announce');
+    if (el) el.textContent = text;
+  }
+
+  function populateModal(i, speak) {
     const targetEl = chromeEl || modalEl;
     if (!targetEl) return;
     const meta = getCardMetadata(i);
@@ -371,7 +376,9 @@ export default function createGlobeModal({
       counterEl.textContent = `${pad(authoredNo(i))} / ${pad(getCount())}`;
     }
     const posEl = targetEl.querySelector('.globe-gallery-modal-position');
-    if (posEl) posEl.textContent = cardLabel(authoredNo(i), getCount());
+    const position = cardLabel(authoredNo(i), getCount());
+    if (posEl) posEl.textContent = position;
+    announce(speak ? [meta.name, meta.role, position].filter(Boolean).join('. ') : '');
     const badgesEl = targetEl.querySelector('.globe-gallery-modal-badges');
     badgesEl.innerHTML = '';
     const config = getConfig();
@@ -454,7 +461,7 @@ export default function createGlobeModal({
     modalIdx = newIdx;
     modalCard = newCard;
     modalPhase = MODAL_PHASE.OPEN;
-    populateModal(newIdx);
+    populateModal(newIdx, true);
     requestNavNudge(newIdx);
 
     dnNavOldCard = oldCard;
@@ -520,9 +527,6 @@ export default function createGlobeModal({
     requestAnimationFrame(() => {
       modalEl.classList.add('is-open');
       if (chromeEl) chromeEl.classList.add('is-open');
-      const nameEl = chromeEl && chromeEl.querySelector('.globe-gallery-modal-name');
-      const focusEl = nameEl || chromeEl;
-      if (focusEl) { try { focusEl.focus(); } catch (e) { /* not focusable; ignore */ } }
     });
 
     const renderer = getRenderer();

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -134,7 +134,7 @@ export function deriveFrame(frame, input) {
   // canvas visibility still uses real scroll.
   const lenisY = reducedMotion ? blockDocTop + formPx : input.scrollY;
   frame.lenisY = lenisY;
-  frame.scrollVel = reducedMotion ? 0 : Math.abs(lenisY - input.prevLenisY);
+  frame.scrollVel = reducedMotion ? 0 : Math.abs(lenisY - input.prevLenisY) / frame.dtScale;
 
   const entryStart = blockDocTop - viewportH * entryLeadVh;
   const entryRange = Math.max(1, viewportH * ENTRY_RAMP_VH);

--- a/libs/mep/ace1209/globe-gallery/src/timeline.js
+++ b/libs/mep/ace1209/globe-gallery/src/timeline.js
@@ -41,6 +41,7 @@ export const ARC_ENTRY_STAGGER = 0.45;
 // sphereFormT. One gate for everything that says "the globe is live": hover, click, drag,
 // auto-rotate, desktop cursor, hint-plane entrance
 export const SPHERE_INTERACTIVE_T = 0.94;
+export const BROWSE_VIEW_T = 0.96;
 export const SPHERE_ORIENT_RESET_T = 0.01;
 export const TEXT_APPEAR_START = 0.10;
 
@@ -59,6 +60,8 @@ export const DT_SCALE_MIN = 0.25;
 export const DT_SCALE_MAX = 3;
 
 export const progressAtFormT = (t) => FOLD_FIRST_PROGRESS + t * FOLD_WINDOW;
+
+export const BROWSE_VIEW_SCROLL_FRAC = progressAtFormT(BROWSE_VIEW_T) / SPHERE_FORMED_PROGRESS;
 
 // zoomT is a fraction of the ZOOM span; the CSS pin and hold ceiling reason in fractions of the
 // whole tail. Identical only while PROGRESS_ZOOM_END is 1, so convert at the boundary.


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Dial back chromatic aberration and fine-tuned some other values
* Handle comments left in https://github.com/adobecom/milo/pull/6509
* Fix following A11y issues
  * Entire modal is announced when opened but it is too much content to auto announce
  * Quote is missing semantics
  * [reproducible only in NVDA before] 05/47 is not announced. It should be announced between the previous and next buttons
  * [reproducible only in NVDA before] Nothing is announced when the slides advance, so screen reader users will think it is broken. We need to announce the heading when the slide is advanced.
  * If a screen reader does not enter the gallery, they should not hear gallery content when navigating with the down arrow. It should all be hidden and they move to the next element, play/pause button.

Resolves: https://jira.corp.adobe.com/browse/MWPW-205295

**Test URLs:**
- Before: https://site-redesign-foundation--milo--adobecom.aem.live/drafts/jingle/simple-globe-page?mep=%2Fdrafts%2Fjingle%2Face1209-cpro-redesign.json--all
- After: https://globe-followups--milo--adobecom.aem.live/drafts/jingle/simple-globe-page?mep=%2Fdrafts%2Fjingle%2Face1209-cpro-redesign.json--all


