### PR TITLE
[MWPW-204193] Side by side: make small cards 4:5 ratio

### DIFF
--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -122,7 +122,7 @@
     }
 
     .media {
-      aspect-ratio: 32/39;
+      aspect-ratio: 4/5;
     }
 
   }


### PR DESCRIPTION
Small (`card-stacked`) card media was `aspect-ratio: 32/39` (0.821). Changed to `4/5` (0.8) to match the Figma 491×614 spec.

**Jira:** [MWPW-204193](https://jira.corp.adobe.com/browse/MWPW-204193)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=side-by-side-small&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

🤖 Generated with [Claude Code](https://claude.com/claude-code)



