### PR TITLE
MWPW-204498: Fix C2 video play/pause focus indicator contrast (WCAG 1.4.11)

### DIFF
--- a/libs/blocks/video/video.css
+++ b/libs/blocks/video/video.css
@@ -198,8 +198,9 @@ video {
     }
 
     &:focus-visible {
-      outline: 1px solid var(--s2a-color-focus-ring-default);
-      outline-offset: 1px;
+      outline: var(--s2a-border-width-2) solid var(--s2a-color-gray-1000);
+      outline-offset: var(--s2a-border-width-2);
+      box-shadow: 0 0 0 var(--s2a-border-width-2) var(--s2a-color-gray-25);
     }
 
     &:active {


### PR DESCRIPTION
## MWPW-204498

The C2 video play/pause button used a single blue focus ring (`--s2a-color-focus-ring-default`, `#3b63fb`) that dropped to ~1.9:1 against darker animation frames, failing WCAG 1.4.11 (Non-text Contrast, needs ≥3:1).

This swaps it for a two-color (black + white) focus indicator — the WCAG Technique C40 approach endorsed by accessibility — so one of the two rings is always ≥3:1 against any background. Fixed gray primitives are used (not the theme-flipping `knockout`/`inverse` tokens) since the button sits over arbitrary video, not a themed surface. Legacy `.pause-play-wrapper` is untouched.

Resolves: [MWPW-204498](https://jira.corp.adobe.com/browse/MWPW-204498)

## Test URLs

Tab to a play/pause button (bottom-right of a media/animation) and check the focus ring contrast.

- **Before:** https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- **After:** https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=play-pause-focus&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

🤖 Generated with [Claude Code](https://claude.com/claude-code)

