### PR TITLE
[SR]Pin img to the top in side-by-side card overlay

### DIFF
--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -76,6 +76,10 @@
     .media {
       position: absolute;
       inset: 0;
+
+      :is(img, video) {
+        object-position: top;
+      }
     }
 
     .media::after {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Pin assets to the top in the card-overlay

Resolves: [MWPW-205039](https://jira.corp.adobe.com/browse/MWPW-205039)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=side-by-side-position&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


