### PR TITLE
MWPW-205235 - Contribute Blog Author Block From da-bacom-blog to Milo

### DIFF
--- a/libs/blocks/blog-author/blog-author.css
+++ b/libs/blocks/blog-author/blog-author.css
@@ -29,6 +29,11 @@
   margin: 0 0 8px;
 }
 
+.blog-author-name h1 {
+  font: inherit;
+  margin: 0;
+}
+
 .blog-author-title {
   font-size: 20px;
   font-weight: 700;

--- a/libs/blocks/blog-author/blog-author.css
+++ b/libs/blocks/blog-author/blog-author.css
@@ -1,0 +1,145 @@
+.blog-author > div:not(.blog-author-content) {
+  display: contents;
+}
+
+.blog-author {
+  display: flex;
+  flex-direction: column;
+  padding: 56px 30px;
+}
+
+.blog-author-image {
+  margin-bottom: 24px;
+}
+
+.blog-author-image img {
+  display: block;
+  width: 100%;
+  max-width: 148px;
+  aspect-ratio: 1;
+  object-fit: cover;
+  object-position: top center;
+  border-radius: 50%;
+}
+
+.blog-author-name {
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0 0 8px;
+}
+
+.blog-author-title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0 0 8px;
+}
+
+.blog-author-description {
+  font-size: 20px;
+  margin: 0;
+}
+
+.blog-author-social {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-top: 32px;
+}
+
+.blog-author-social a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--color-gray-700, #2c2c2c);
+  border-radius: 8px;
+  color: #fff;
+  text-decoration: none;
+}
+
+.blog-author-social .icon {
+  display: contents;
+}
+
+.blog-author-social .icon svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+  transform: translateY(-2px);
+}
+
+@media (min-width: 600px) {
+  .blog-author {
+    padding: 56px 32px;
+  }
+
+  .blog-author-image picture {
+    width: 300px;
+  }
+
+  .blog-author-image img {
+    width: 300px;
+    max-width: none;
+    aspect-ratio: auto;
+  }
+
+  .blog-author-social {
+    gap: 16px;
+  }
+}
+
+@media (min-width: 768px) {
+  .blog-author {
+    padding: 56px 48px;
+  }
+
+  .blog-author-image {
+    margin-bottom: 52px;
+  }
+
+  .blog-author-image picture {
+    width: 328px;
+  }
+
+  .blog-author-image img {
+    width: 328px;
+    max-width: none;
+    aspect-ratio: auto;
+  }
+
+}
+
+@media (min-width: 1200px) {
+  .blog-author {
+    display: grid;
+    grid-template-columns: 328px minmax(0, 600px);
+    column-gap: 32px;
+    align-items: start;
+    justify-content: center;
+  }
+
+  .blog-author-image {
+    grid-column: 1;
+    margin-bottom: 0;
+  }
+
+  .blog-author-image picture {
+    display: contents;
+  }
+
+  .blog-author-image img {
+    width: 328px;
+    max-width: none;
+    height: 328px;
+    aspect-ratio: 1;
+    object-fit: cover;
+    object-position: top center;
+  }
+
+  .blog-author-content {
+    grid-column: 2;
+  }
+}

--- a/libs/blocks/blog-author/blog-author.js
+++ b/libs/blocks/blog-author/blog-author.js
@@ -1,0 +1,129 @@
+import loadIcons from '../../features/icons/icons.js';
+
+const SOCIAL_PLATFORMS = {
+  'linkedin.com': { name: 'LinkedIn', icon: 'linkedin' },
+  'twitter.com': { name: 'X', icon: 'twitter' },
+  'x.com': { name: 'X', icon: 'twitter' },
+  'facebook.com': { name: 'Facebook', icon: 'facebook' },
+  'instagram.com': { name: 'Instagram', icon: 'instagram' },
+};
+
+function resolvePlatform(href) {
+  return Object.keys(SOCIAL_PLATFORMS).find((domain) => href?.includes(domain));
+}
+
+function decorateSocial(row) {
+  const links = [...row.querySelectorAll('a')];
+  row.replaceChildren(...links);
+  row.className = 'blog-author-social';
+  links.forEach((a) => {
+    const domain = resolvePlatform(a.href);
+    if (!domain) { a.hidden = true; return; }
+    const { name, icon } = SOCIAL_PLATFORMS[domain];
+    a.setAttribute('aria-label', name);
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+    const span = document.createElement('span');
+    span.className = `icon icon-${icon}`;
+    a.replaceChildren(span);
+  });
+  loadIcons(row.querySelectorAll('span.icon'));
+}
+
+function injectSchema(el, company) {
+  const name = el.querySelector('.blog-author-name')?.textContent;
+  if (!name) return;
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name,
+    url: window.location.href,
+    '@id': `${window.location.origin}${window.location.pathname}#person`,
+  };
+
+  if (company) {
+    schema.worksFor = { '@type': 'Organization', name: company };
+  }
+
+  const title = el.querySelector('.blog-author-title')?.textContent;
+  if (title) schema.jobTitle = title;
+
+  const desc = [...el.querySelectorAll('.blog-author-description')]
+    .map((p) => p.textContent).join(' ');
+  if (desc) schema.description = desc;
+
+  const img = el.querySelector('picture img')?.src;
+  if (img) schema.image = img;
+
+  const sameAs = [...el.querySelectorAll('.blog-author-social a:not([hidden])')]
+    .map((a) => a.getAttribute('aria-label') && a.href).filter(Boolean);
+  if (sameAs.length) schema.sameAs = sameAs;
+
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(schema);
+  document.head.append(script);
+}
+
+export default async function init(el) {
+  let socialContainer = null;
+  let textIdx = 0;
+  let company = null;
+  const HEX = '#[0-9a-fA-F]{3,6}';
+  const TEXT_CLASSES = ['blog-author-name', 'blog-author-title', 'blog-author-description'];
+
+  function decorateRow(row) {
+    const text = row.textContent.trim();
+
+    const gradient = text.match(new RegExp(`^(${HEX})\\s*,\\s*(${HEX})$`));
+    if (gradient) {
+      el.style.background = `linear-gradient(to bottom, ${gradient[1]}, ${gradient[2]})`;
+      row.parentElement.remove();
+      return;
+    }
+
+    if (new RegExp(`^${HEX}$`).test(text)) {
+      el.style.backgroundColor = text;
+      row.parentElement.remove();
+      return;
+    }
+
+    if (row.querySelector('picture')) {
+      row.className = 'blog-author-image';
+      return;
+    }
+
+    if ([...row.querySelectorAll('a')].some((a) => resolvePlatform(a.href))) {
+      if (!socialContainer) {
+        socialContainer = row;
+      } else {
+        [...row.querySelectorAll('a')].forEach((a) => socialContainer.append(a));
+        row.parentElement.remove();
+      }
+      return;
+    }
+
+    if (socialContainer) {
+      company = text;
+      row.parentElement.remove();
+      return;
+    }
+
+    row.className = TEXT_CLASSES[Math.min(textIdx, 2)];
+    textIdx += 1;
+  }
+
+  el.querySelectorAll(':scope > div > div').forEach(decorateRow);
+
+  if (socialContainer) decorateSocial(socialContainer);
+
+  const content = document.createElement('div');
+  content.className = 'blog-author-content';
+  el.querySelectorAll('.blog-author-name, .blog-author-title, .blog-author-description, .blog-author-social')
+    .forEach((t) => content.append(t));
+  el.querySelectorAll(':scope > div:not(:has(*))').forEach((d) => d.remove());
+  el.append(content);
+
+  injectSchema(el, company);
+}

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -15,6 +15,7 @@ const C1_BLOCKS = [
   'article-header',
   'aside',
   'author-header',
+  'blog-author',
   'brand-concierge',
   'brand-concierge-global',
   'brick',

--- a/test/blocks/blog-author/blog-author.test.js
+++ b/test/blocks/blog-author/blog-author.test.js
@@ -1,0 +1,220 @@
+import { expect } from '@esm-bundle/chai';
+import sinon, { stub } from 'sinon';
+import init from '../../../libs/blocks/blog-author/blog-author.js';
+
+const MOCK_SVG = '<svg xmlns="http://www.w3.org/2000/svg"><symbol id="icon"></symbol></svg>';
+
+const BLOCK_HTML = `
+<div class="blog-author">
+  <div><div><picture><img src="https://example.com/author.jpg" alt="Jane Doe"></picture></div></div>
+  <div><div><p>Jane Doe</p></div></div>
+  <div><div><p>Senior Director, Marketing</p></div></div>
+  <div><div><p>Jane has 15 years of experience in B2B marketing.</p></div></div>
+  <div><div>
+    <a href="https://linkedin.com/in/janedoe">LinkedIn</a>
+    <a href="https://twitter.com/janedoe">Twitter</a>
+  </div></div>
+</div>`;
+
+function getPersonSchema() {
+  const scripts = [...document.head.querySelectorAll('script[type="application/ld+json"]')];
+  const script = scripts.find((s) => {
+    try { return JSON.parse(s.textContent)['@type'] === 'Person'; } catch { return false; }
+  });
+  return script ? JSON.parse(script.textContent) : null;
+}
+
+describe('Blog Author', () => {
+  beforeEach(() => {
+    document.body.innerHTML = BLOCK_HTML;
+    stub(window, 'fetch').callsFake(async (url) => {
+      if (url.includes('/svgs/') || url.includes('icons.svg')) {
+        return { ok: true, text: async () => MOCK_SVG };
+      }
+      return { ok: false };
+    });
+  });
+
+  afterEach(() => {
+    document.head.querySelectorAll('script[type="application/ld+json"]').forEach((s) => s.remove());
+    sinon.restore();
+  });
+
+  it('adds class to image row', async () => {
+    await init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-image')).to.exist;
+    expect(document.querySelector('.blog-author-image picture')).to.exist;
+  });
+
+  it('assigns name and title classes by row order', async () => {
+    await init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-name').textContent).to.equal('Jane Doe');
+    expect(document.querySelector('.blog-author-title').textContent).to.equal('Senior Director, Marketing');
+  });
+
+  it('assigns description class to third and subsequent text rows', async () => {
+    await init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-description').textContent).to.include('15 years');
+  });
+
+  it('assigns blog-author-name class to the first text row', async () => {
+    await init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-name')).to.exist;
+  });
+
+  it('adds blog-author-social class to links row', async () => {
+    await init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-social')).to.exist;
+  });
+
+  it('adds aria-labels to known social links', async () => {
+    await init(document.querySelector('.blog-author'));
+    const links = document.querySelectorAll('.blog-author-social a');
+    expect(links[0].getAttribute('aria-label')).to.equal('LinkedIn');
+    expect(links[1].getAttribute('aria-label')).to.equal('X');
+  });
+
+  it('sets target and rel on social links', async () => {
+    await init(document.querySelector('.blog-author'));
+    const link = document.querySelector('.blog-author-social a');
+    expect(link.target).to.equal('_blank');
+    expect(link.rel).to.equal('noopener noreferrer');
+  });
+
+  it('adds icon spans to social links', async () => {
+    await init(document.querySelector('.blog-author'));
+    const links = document.querySelectorAll('.blog-author-social a');
+    expect(links[0].querySelector('.icon-linkedin')).to.exist;
+    expect(links[1].querySelector('.icon-twitter')).to.exist;
+  });
+
+  it('injects Person JSON-LD schema', async () => {
+    await init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema).to.exist;
+    expect(schema['@type']).to.equal('Person');
+    expect(schema.name).to.equal('Jane Doe');
+    expect(schema.jobTitle).to.equal('Senior Director, Marketing');
+    expect(schema.url).to.be.a('string');
+    expect(schema['@id']).to.equal(`${window.location.origin}${window.location.pathname}#person`);
+    expect(schema.worksFor).to.be.undefined;
+  });
+
+  it('includes image and sameAs in schema', async () => {
+    await init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema.image).to.include('example.com/author.jpg');
+    expect(schema.sameAs).to.include('https://linkedin.com/in/janedoe');
+    expect(schema.sameAs).to.include('https://twitter.com/janedoe');
+  });
+
+  it('reads company row after social links into schema and removes it from DOM', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div><p>Jane Doe</p></div></div>
+        <div><div>
+          <a href="https://linkedin.com/in/jane">LinkedIn</a>
+        </div></div>
+        <div><div><p>Adobe</p></div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema.worksFor.name).to.equal('Adobe');
+    expect(document.querySelector('.blog-author').textContent).to.not.include('Adobe');
+  });
+
+  it('omits worksFor from schema when no company row is authored', async () => {
+    await init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema.worksFor).to.be.undefined;
+  });
+
+  it('omits schema fields when content is absent', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div><p>Jane Doe</p></div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema.image).to.be.undefined;
+    expect(schema.sameAs).to.be.undefined;
+    expect(schema.jobTitle).to.be.undefined;
+  });
+
+  it('merges social links from multiple authored rows into one container', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div>
+          <a href="https://linkedin.com/in/jane">LinkedIn</a>
+          <a href="https://instagram.com/jane">Instagram</a>
+        </div></div>
+        <div><div>
+          <a href="https://twitter.com/jane">Twitter</a>
+        </div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    const socialContainers = document.querySelectorAll('.blog-author-social');
+    expect(socialContainers).to.have.length(1);
+    expect(socialContainers[0].querySelectorAll('a')).to.have.length(3);
+  });
+
+  it('hides unrecognized links in the social row', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div>
+          <a href="https://linkedin.com/in/jane">LinkedIn</a>
+          <a href="https://example.com/jane">Website</a>
+        </div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    const links = document.querySelectorAll('.blog-author-social a');
+    expect(links[0].hidden).to.be.false;
+    expect(links[1].hidden).to.be.true;
+  });
+
+  it('does not inject schema when name is missing', async () => {
+    document.body.innerHTML = '<div class="blog-author"><div><div><picture><img src="x.jpg"></picture></div></div></div>';
+    await init(document.querySelector('.blog-author'));
+    expect(getPersonSchema()).to.be.null;
+  });
+
+  it('wraps text and social elements in blog-author-content', async () => {
+    await init(document.querySelector('.blog-author'));
+    const content = document.querySelector('.blog-author-content');
+    expect(content).to.exist;
+    expect(content.querySelector('.blog-author-name')).to.exist;
+    expect(content.querySelector('.blog-author-title')).to.exist;
+    expect(content.querySelector('.blog-author-description')).to.exist;
+    expect(content.querySelector('.blog-author-social')).to.exist;
+  });
+
+  it('applies solid hex background color and removes the row from DOM', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div><p>#f0e6d3</p></div></div>
+        <div><div><p>Jane Doe</p></div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    const el = document.querySelector('.blog-author');
+    expect(el.style.backgroundColor).to.equal('rgb(240, 230, 211)');
+    expect(el.textContent).to.not.include('#f0e6d3');
+  });
+
+  it('applies gradient background from two comma-separated hex colors', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div><p>#f0e6d3, #ffffff</p></div></div>
+        <div><div><p>Jane Doe</p></div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    const el = document.querySelector('.blog-author');
+    expect(el.style.background).to.include('linear-gradient');
+    expect(el.textContent).to.not.include('#f0e6d3');
+  });
+
+  it('does not treat non-hex text as a background color', async () => {
+    await init(document.querySelector('.blog-author'));
+    const el = document.querySelector('.blog-author');
+    expect(el.style.backgroundColor).to.equal('');
+  });
+});


### PR DESCRIPTION
* Ports the `blog-author` block (image, name/title/description, social links, JSON-LD person schema) from da-bacom-blog into milo's shared block library
* Registers `blog-author` as a C1 block so consuming sites load it from milo instead of maintaining a local copy

**Resolves**: [MWPW-205235](https://jira.corp.adobe.com/browse/MWPW-205235)

Test URLs:

**Before**:
https://main--da-bacom-blog--adobecom.aem.page/drafts/jsandlan/blog-author

**After**:
https://main--da-bacom-blog--adobecom.aem.page/drafts/jsandlan/blog-author?milolibs=bacom-blog-author-contribution





