### PR TITLE
[SR] Section rounded corners adjustment for z-index with parallax

### DIFF
--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -170,6 +170,18 @@ body:has(header.local-nav) .section.bento.stack-mobile {
     z-index: 4;
   }
 
+  /* 
+     Deliberately excludes .rounded-corners-top: it only overlaps *upward* */
+  &.rounded-corners:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast),
+  &.rounded-corners-bottom:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
+    z-index: 3;
+  }
+
+  &.rounded-corners:has(+ .section[class*='rounded-corners']):has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast),
+  &.rounded-corners-bottom:has(+ .section[class*='rounded-corners']):has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
+    z-index: 4;
+  }
+
   &.masonry-layout {
     display: grid;
     gap: var(--grid-gutter);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Sets rounded-corners css for z-index to be more specific than parallax so rounded corners are not hidden behind the next section. 

Trying to get more surgical with section rounded corners. We are to the point where we have to many competing features. Fixing something breaks something else. This does fix the current issue. Hopefully this fix doesn't break anything else 🤞 .

Resolves: [MWPW-205461](https://jira.corp.adobe.com/browse/MWPW-205461)
https://jira.corp.adobe.com/browse/MWPW-204439

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesgin-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=sr-section-rounded-parallax-battle&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

