### PR TITLE
Use correct font in CPro product marquee

### DIFF
--- a/libs/mep/ace1209/product-marquee-grid/product-marquee-grid.css
+++ b/libs/mep/ace1209/product-marquee-grid/product-marquee-grid.css
@@ -55,7 +55,7 @@
     .mas-description,
     .mas-price-commitment {
       color: var(--s2a-color-content-default);
-      font-family: var(--s2a-font-family-body);
+      font-family: var(--body-font-family);
       font-size: var(--s2a-typography-font-size-body-sm);
       font-weight: var(--s2a-font-weight-adobe-clean-regular);
       line-height: var(--s2a-typography-line-height-body-sm);


### PR DESCRIPTION
Use correct font-family value in the product marquee.

Resolves: [MWPW-205701](https://jira.corp.adobe.com/browse/MWPW-205701)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=product-marquee-font&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

