### PR TITLE
MWPW-203780: Support carousel-c2 with two slides

### DIFF
--- a/libs/c2/blocks/carousel-c2/carousel-c2.js
+++ b/libs/c2/blocks/carousel-c2/carousel-c2.js
@@ -123,16 +123,47 @@ function goToActive(carouselEls) {
   wrapper._timeout = null;
 }
 
+function createSlideClone(slide) {
+  const clone = slide.cloneNode(true);
+  clone.setAttribute('data-cloned', 'true');
+  clone.removeAttribute('data-index');
+  clone.classList.remove('active');
+  clone.style.removeProperty('--slide-spread-sign');
+  return clone;
+}
+
+function expectsBackground(source) {
+  return [...source.querySelectorAll(':scope > .section-metadata > div > div:first-child')]
+    .some((key) => key.textContent.trim().toLowerCase() === 'background');
+}
+
+function syncHintClone(source, clone) {
+  if (source.querySelector('.section-background') || !expectsBackground(source)) return;
+  const observer = new MutationObserver(() => {
+    if (!source.querySelector('.section-background')) return;
+    observer.disconnect();
+    if (!clone.parentNode) return;
+    const fresh = createSlideClone(source);
+    fresh.style.setProperty('--slide-spread-sign', clone.style.getPropertyValue('--slide-spread-sign'));
+    clone.replaceWith(fresh);
+  });
+  observer.observe(source, { childList: true });
+}
+
+function fillHintSlides(wrapper, slides) {
+  while (slides.length && wrapper.children.length < 3) {
+    const source = slides[wrapper.children.length % slides.length];
+    const clone = createSlideClone(source);
+    clone.querySelectorAll('img').forEach((img) => img.setAttribute('loading', 'eager'));
+    wrapper.append(clone);
+    syncHintClone(source, clone);
+  }
+}
+
 function cloneSlides(carouselEls) {
   const { wrapper, slides, activeSlide } = carouselEls;
-  const cloneBack = slides.slice(0, 3).map((slide) => slide.cloneNode(true));
-  const cloneFront = slides.slice(-3).map((slide) => slide.cloneNode(true));
-  [...cloneFront, ...cloneBack].forEach((slide) => {
-    slide.setAttribute('data-cloned', 'true');
-    slide.removeAttribute('data-index');
-    slide.style.removeProperty('--slide-spread-sign');
-    slide.classList.remove('active');
-  });
+  const cloneBack = slides.slice(0, 3).map(createSlideClone);
+  const cloneFront = slides.slice(-3).map(createSlideClone);
   const allSlides = [...cloneFront, ...slides, ...cloneBack];
   allSlides.forEach((slide) => {
     slide.querySelectorAll('img').forEach((img) => {
@@ -354,12 +385,13 @@ export default function init(el) {
   const lastSlide = slides.pop();
   slides.unshift(lastSlide);
   slides[1].classList.add('active');
-  setSlideSpreadSign(slides[1], slides);
   indicatorsContainer.children[0]?.classList.add('active');
   indicatorsContainer.children[0]?.setAttribute('aria-current', 'location');
 
   el.textContent = '';
   wrapper.append(...slides);
+  fillHintSlides(wrapper, slides);
+  setSlideSpreadSign(slides[1], [...wrapper.children]);
   const [prevBtn, nextBtn] = decorateNavigation();
   el.append(ariaLive, prevBtn, wrapper, nextBtn, indicatorsContainer);
 
@@ -376,6 +408,6 @@ export default function init(el) {
     activeSlide: slides[1],
   };
 
-  setAriaHiddenAndTabIndex(slides, slides[1]);
+  setAriaHiddenAndTabIndex([...wrapper.children], slides[1]);
   attachListeners(carouselEls);
 }

--- a/libs/c2/blocks/carousel-c2/carousel-c2.js
+++ b/libs/c2/blocks/carousel-c2/carousel-c2.js
@@ -1,4 +1,4 @@
-import { createTag } from '../../../utils/utils.js';
+import { createTag, MILO_EVENTS } from '../../../utils/utils.js';
 
 const PREV = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="9" viewBox="0 0 11 9" fill="none">
   <title>Previous slide</title>
@@ -13,6 +13,10 @@ const NEXT = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="9" view
 const FOCUSABLE_SELECTOR = 'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"]), video';
 const MIN_SLIDE_TRANISTION_DURATION = 100;
 const MAX_SLIDE_TRANISTION_DURATION = 500;
+const SLIDES_TO_SHOW = 3;
+// Maps a clone back to the authored slide it was made from, so a clone can be
+// rebuilt once its source's async .section-background is decorated.
+const cloneSources = new WeakMap();
 let carouselGap = 8;
 const prefersReducedMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 const isRTL = document.documentElement.dir === 'rtl';
@@ -129,41 +133,38 @@ function createSlideClone(slide) {
   clone.removeAttribute('data-index');
   clone.classList.remove('active');
   clone.style.removeProperty('--slide-spread-sign');
+  clone.querySelectorAll('img').forEach((img) => img.setAttribute('loading', 'eager'));
+  cloneSources.set(clone, slide);
   return clone;
 }
 
-function expectsBackground(source) {
-  return [...source.querySelectorAll(':scope > .section-metadata > div > div:first-child')]
-    .some((key) => key.textContent.trim().toLowerCase() === 'background');
-}
-
-function syncHintClone(source, clone) {
-  if (source.querySelector('.section-background') || !expectsBackground(source)) return;
-  const observer = new MutationObserver(() => {
-    if (!source.querySelector('.section-background')) return;
-    observer.disconnect();
-    if (!clone.parentNode) return;
+function refreshCloneBackgrounds(carouselEls) {
+  const { wrapper, allSlides } = carouselEls;
+  [...wrapper.children].forEach((node) => {
+    if (!node.hasAttribute('data-cloned')) return;
+    const source = cloneSources.get(node);
+    if (!source?.querySelector(':scope > .section-background') || node.querySelector(':scope > .section-background')) return;
     const fresh = createSlideClone(source);
-    fresh.style.setProperty('--slide-spread-sign', clone.style.getPropertyValue('--slide-spread-sign'));
-    clone.replaceWith(fresh);
+    fresh.style.setProperty('--slide-spread-sign', node.style.getPropertyValue('--slide-spread-sign'));
+    fresh.classList.toggle('active-clone', node.classList.contains('active-clone'));
+    const idx = allSlides?.indexOf(node) ?? -1;
+    if (idx > -1) allSlides[idx] = fresh;
+    if (carouselEls.activeClone === node) carouselEls.activeClone = fresh;
+    node.replaceWith(fresh);
   });
-  observer.observe(source, { childList: true });
 }
 
 function fillHintSlides(wrapper, slides) {
-  while (slides.length && wrapper.children.length < 3) {
+  while (slides.length && wrapper.children.length < SLIDES_TO_SHOW) {
     const source = slides[wrapper.children.length % slides.length];
-    const clone = createSlideClone(source);
-    clone.querySelectorAll('img').forEach((img) => img.setAttribute('loading', 'eager'));
-    wrapper.append(clone);
-    syncHintClone(source, clone);
+    wrapper.append(createSlideClone(source));
   }
 }
 
 function cloneSlides(carouselEls) {
   const { wrapper, slides, activeSlide } = carouselEls;
-  const cloneBack = slides.slice(0, 3).map(createSlideClone);
-  const cloneFront = slides.slice(-3).map(createSlideClone);
+  const cloneBack = slides.slice(0, SLIDES_TO_SHOW).map(createSlideClone);
+  const cloneFront = slides.slice(-SLIDES_TO_SHOW).map(createSlideClone);
   const allSlides = [...cloneFront, ...slides, ...cloneBack];
   allSlides.forEach((slide) => {
     slide.querySelectorAll('img').forEach((img) => {
@@ -357,14 +358,22 @@ export default function init(el) {
   const candidateKeys = parentArea.querySelectorAll('div.section-metadata > div > div:first-child');
   const slides = [...candidateKeys].reduce((rdx, key) => {
     if (key.textContent === 'carousel' && key.nextElementSibling.textContent === carouselName) {
-      const slide = key.closest('.section');
-      slide.classList.add('carousel-slide');
-      rdx.push(slide);
-      const slideIndex = rdx.indexOf(slide);
-      slide.setAttribute('data-index', slideIndex);
+      rdx.push(key.closest('.section'));
     }
     return rdx;
   }, []);
+
+  // Carousel behavior needs at least two slides; the layout below reads slides[1].
+  // Clear the block so its raw config rows don't render as stray text.
+  if (slides.length < 2) {
+    el.textContent = '';
+    return;
+  }
+
+  slides.forEach((slide, index) => {
+    slide.classList.add('carousel-slide');
+    slide.setAttribute('data-index', index);
+  });
 
   const indicatorsContainer = createTag('ul', { class: 'indicators-container' });
   slides.forEach((slide, index) => {
@@ -410,4 +419,10 @@ export default function init(el) {
 
   setAriaHiddenAndTabIndex([...wrapper.children], slides[1]);
   attachListeners(carouselEls);
+
+  const handleDeferred = () => {
+    parentArea.removeEventListener(MILO_EVENTS.DEFERRED, handleDeferred, true);
+    refreshCloneBackgrounds(carouselEls);
+  };
+  parentArea.addEventListener(MILO_EVENTS.DEFERRED, handleDeferred, true);
 }

--- a/test/blocks/carousel-c2/carousel-c2.test.js
+++ b/test/blocks/carousel-c2/carousel-c2.test.js
@@ -120,4 +120,105 @@ describe('Carousel C2', () => {
     expect(indicators[1].classList.contains('active')).to.be.true;
     expect(block.querySelector('.aria-live-container').textContent).to.contain('Slide 2 of 3');
   });
+
+  it('does not pad the wrapper when there are three or more slides', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/default.html' });
+    const block = document.querySelector('.carousel-c2');
+    init(block);
+
+    const wrapperSlides = [...block.querySelectorAll('.carousel-wrapper > .carousel-slide')];
+    expect(wrapperSlides.length).to.equal(3);
+    expect(block.querySelectorAll('.carousel-wrapper [data-cloned]').length).to.equal(0);
+  });
+
+  describe('with only two slides (MWPW-203780)', () => {
+    it('fills the trailing hint slot so no blank slide shows before interaction', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/two-slides.html' });
+      const block = document.querySelector('.carousel-c2');
+      init(block);
+
+      const wrapperSlides = [...block.querySelectorAll('.carousel-wrapper > .carousel-slide')];
+      // padded to three so both the left and right peek slots are filled
+      expect(wrapperSlides.length).to.equal(3);
+      // active authored slide sits at wrapper index 1 (CSS centers index 1)
+      expect(wrapperSlides[1].classList.contains('active')).to.be.true;
+      expect(wrapperSlides[1].getAttribute('data-index')).to.equal('0');
+      // the right hint slot (index 2) is filled by a clone instead of being blank
+      expect(wrapperSlides[2].getAttribute('data-cloned')).to.equal('true');
+    });
+
+    it('keeps only the two authored slides real, with two indicators', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/two-slides.html' });
+      const block = document.querySelector('.carousel-c2');
+      init(block);
+
+      const realSlides = block.querySelectorAll('.carousel-wrapper > .carousel-slide:not([data-cloned])');
+      expect(realSlides.length).to.equal(2);
+
+      const indicators = block.querySelectorAll('.indicators-container .slide-indicator');
+      expect(indicators.length).to.equal(2);
+      expect(indicators[0].getAttribute('aria-label')).to.equal('Slide 1 of 2');
+    });
+
+    it('hides the padded clone from assistive tech and removes it from the tab order', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/two-slides.html' });
+      const block = document.querySelector('.carousel-c2');
+      init(block);
+
+      const clone = block.querySelector('.carousel-wrapper > .carousel-slide[data-cloned]');
+      expect(clone.getAttribute('aria-hidden')).to.equal('true');
+      expect(clone.hasAttribute('data-index')).to.be.false;
+      expect(clone.querySelector('a').getAttribute('tabindex')).to.equal('-1');
+    });
+
+    it('still advances through the loop clones when clicking next', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/two-slides.html' });
+      const block = document.querySelector('.carousel-c2');
+      init(block);
+
+      block.querySelector('button.next').click();
+
+      const active = block.querySelector('.carousel-wrapper .active:not([data-cloned])');
+      expect(active.getAttribute('data-index')).to.equal('1');
+      // first interaction rebuilds the full loop ring
+      expect(block.querySelector('.carousel-wrapper').getAttribute('data-slides-cloned')).to.equal('true');
+
+      const indicators = block.querySelectorAll('.indicators-container .slide-indicator');
+      expect(indicators[1].classList.contains('active')).to.be.true;
+      expect(block.querySelector('.aria-live-container').textContent).to.contain('Slide 2 of 2');
+    });
+
+    it('rebuilds the padded clone once the source slide gains a section-background', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/two-slides.html' });
+      // the authored slides declare a background, so their own section-metadata
+      // block adds `.section-background` asynchronously, after this init runs
+      document.querySelectorAll('.section-metadata').forEach((sm) => {
+        const row = document.createElement('div');
+        row.innerHTML = '<div>background</div><div>#000000</div>';
+        sm.appendChild(row);
+      });
+      const block = document.querySelector('.carousel-c2');
+      init(block);
+
+      const wrapper = block.querySelector('.carousel-wrapper');
+      const source = wrapper.children[0]; // the slide the trailing clone was made from
+      const staleClone = wrapper.querySelector('.carousel-slide[data-cloned]');
+      expect(staleClone.querySelector('.section-background')).to.be.null;
+      const spreadSign = staleClone.style.getPropertyValue('--slide-spread-sign');
+
+      // simulate section-metadata decorating the source's background later
+      const bg = document.createElement('div');
+      bg.className = 'section-background';
+      bg.innerHTML = '<img src="https://example.com/bg.png">';
+      source.insertAdjacentElement('afterbegin', bg);
+      await new Promise((resolve) => { setTimeout(resolve, 0); }); // flush the observer
+
+      const clone = wrapper.querySelector('.carousel-slide[data-cloned]');
+      expect(clone.querySelector('.section-background')).to.not.be.null;
+      expect(clone.getAttribute('aria-hidden')).to.equal('true');
+      expect(clone.hasAttribute('data-index')).to.be.false;
+      expect(clone.style.getPropertyValue('--slide-spread-sign')).to.equal(spreadSign);
+      expect(clone.querySelector('a').getAttribute('tabindex')).to.equal('-1');
+    });
+  });
 });

--- a/test/blocks/carousel-c2/carousel-c2.test.js
+++ b/test/blocks/carousel-c2/carousel-c2.test.js
@@ -1,6 +1,7 @@
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
 
+import { MILO_EVENTS } from '../../../libs/utils/utils.js';
 import init from '../../../libs/c2/blocks/carousel-c2/carousel-c2.js';
 
 describe('Carousel C2', () => {
@@ -188,15 +189,8 @@ describe('Carousel C2', () => {
       expect(block.querySelector('.aria-live-container').textContent).to.contain('Slide 2 of 2');
     });
 
-    it('rebuilds the padded clone once the source slide gains a section-background', async () => {
+    it('rebuilds the padded hint clone once the source slide gains a section-background', async () => {
       document.body.innerHTML = await readFile({ path: './mocks/two-slides.html' });
-      // the authored slides declare a background, so their own section-metadata
-      // block adds `.section-background` asynchronously, after this init runs
-      document.querySelectorAll('.section-metadata').forEach((sm) => {
-        const row = document.createElement('div');
-        row.innerHTML = '<div>background</div><div>#000000</div>';
-        sm.appendChild(row);
-      });
       const block = document.querySelector('.carousel-c2');
       init(block);
 
@@ -206,19 +200,59 @@ describe('Carousel C2', () => {
       expect(staleClone.querySelector('.section-background')).to.be.null;
       const spreadSign = staleClone.style.getPropertyValue('--slide-spread-sign');
 
-      // simulate section-metadata decorating the source's background later
+      // a slide's section-metadata block appends .section-background asynchronously,
+      // after init has already snapshotted the hint clone
       const bg = document.createElement('div');
       bg.className = 'section-background';
       bg.innerHTML = '<img src="https://example.com/bg.png">';
       source.insertAdjacentElement('afterbegin', bg);
-      await new Promise((resolve) => { setTimeout(resolve, 0); }); // flush the observer
+      // MILO_EVENTS.DEFERRED fires once every section's background has processed
+      document.dispatchEvent(new Event(MILO_EVENTS.DEFERRED));
 
       const clone = wrapper.querySelector('.carousel-slide[data-cloned]');
-      expect(clone.querySelector('.section-background')).to.not.be.null;
+      expect(clone.querySelector(':scope > .section-background')).to.not.be.null;
       expect(clone.getAttribute('aria-hidden')).to.equal('true');
       expect(clone.hasAttribute('data-index')).to.be.false;
       expect(clone.style.getPropertyValue('--slide-spread-sign')).to.equal(spreadSign);
       expect(clone.querySelector('a').getAttribute('tabindex')).to.equal('-1');
+    });
+
+    it('rebuilds the loop-ring clones when a background arrives after interaction', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/two-slides.html' });
+      const block = document.querySelector('.carousel-c2');
+      init(block);
+
+      // interact first so the permanent loop ring is built from the still-blank slides
+      block.querySelector('button.next').click();
+      const wrapper = block.querySelector('.carousel-wrapper');
+      expect(wrapper.getAttribute('data-slides-cloned')).to.equal('true');
+      const ringClone = wrapper.querySelector('.carousel-slide[data-cloned]');
+      expect(ringClone.querySelector(':scope > .section-background')).to.be.null;
+
+      // the source slide gains its background afterwards, then DEFERRED fires
+      wrapper.querySelectorAll('.carousel-slide:not([data-cloned])').forEach((slide) => {
+        const bg = document.createElement('div');
+        bg.className = 'section-background';
+        bg.innerHTML = '<img src="https://example.com/bg.png">';
+        slide.insertAdjacentElement('afterbegin', bg);
+      });
+      document.dispatchEvent(new Event(MILO_EVENTS.DEFERRED));
+
+      wrapper.querySelectorAll('.carousel-slide[data-cloned]').forEach((clone) => {
+        expect(clone.querySelector(':scope > .section-background')).to.not.be.null;
+      });
+    });
+
+    it('clears the block for a single-slide carousel instead of throwing', async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/one-slide.html' });
+      const block = document.querySelector('.carousel-c2');
+      expect(() => init(block)).to.not.throw();
+      // no carousel is built and the raw config rows are removed
+      expect(block.querySelector('.carousel-wrapper')).to.be.null;
+      expect(block.textContent.trim()).to.equal('');
+      // the lone section is not left half-decorated
+      expect(document.querySelector('.section .carousel-slide')).to.be.null;
+      expect(document.querySelector('[data-index]')).to.be.null;
     });
   });
 });

--- a/test/blocks/carousel-c2/mocks/one-slide.html
+++ b/test/blocks/carousel-c2/mocks/one-slide.html
@@ -1,0 +1,18 @@
+<main>
+  <div class="section">
+    <div class="carousel-c2">
+      <div>
+        <div>my-carousel</div>
+        <div>My carousel label</div>
+      </div>
+    </div>
+  </div>
+  <div class="section">
+    <div class="text">
+      <div><div><h2>Slide one</h2><p>First slide body.</p><p><a href="https://example.com/one">Link one</a></p></div></div>
+    </div>
+    <div class="section-metadata">
+      <div><div>carousel</div><div>my-carousel</div></div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/carousel-c2/mocks/two-slides.html
+++ b/test/blocks/carousel-c2/mocks/two-slides.html
@@ -1,0 +1,26 @@
+<main>
+  <div class="section">
+    <div class="carousel-c2">
+      <div>
+        <div>my-carousel</div>
+        <div>My carousel label</div>
+      </div>
+    </div>
+  </div>
+  <div class="section">
+    <div class="text">
+      <div><div><h2>Slide one</h2><p>First slide body.</p><p><a href="https://example.com/one">Link one</a></p></div></div>
+    </div>
+    <div class="section-metadata">
+      <div><div>carousel</div><div>my-carousel</div></div>
+    </div>
+  </div>
+  <div class="section">
+    <div class="text">
+      <div><div><h2>Slide two</h2><p>Second slide body.</p><p><a href="https://example.com/two">Link two</a></p></div></div>
+    </div>
+    <div class="section-metadata">
+      <div><div>carousel</div><div>my-carousel</div></div>
+    </div>
+  </div>
+</main>


### PR DESCRIPTION
Adds support for the `carousel-c2` block when it has only **two** slides (e.g. non-AIA geos where the Acrobat social-proof card is removed).

* **Fills the trailing hint-peek slot on first paint.** With 2 authored slides the wrapper only had `[peek, active]`, so the right hint slot was blank until a nav arrow was clicked. A padded clone now fills it immediately. Strict no-op for carousels with 3+ slides.
* **Rebuilds the padded clone once its `.section-background` is decorated.** The slide's background is added asynchronously by its own `section-metadata` block, after this block's `init`, so a clone snapshotted at init time missed the background and rendered blank. 
* The real loop clones still take over on the first interaction via `replaceChildren`, so the padded clone is discarded cleanly with no duplication.
* Adds unit tests for the 2-slide padding, a11y (`aria-hidden` / `tabindex`), and the async background rebuild.

Resolves: [MWPW-203780](https://jira.corp.adobe.com/browse/MWPW-203780)

**Test URLs — 2-slide carousel (the fix), CZ:**
- Before: https://main--upp--adobecom.aem.page/cz/homepage/index-loggedout?milolibs=stage
- After: https://main--upp--adobecom.aem.page/cz/homepage/index-loggedout?milolibs=carousel-c2-2-slides

**Test URLs — 3-slide carousel (regression check), non-CZ:**
- Before: https://main--upp--adobecom.aem.page/homepage/index-loggedout?milolibs=stage
- After: https://main--upp--adobecom.aem.page/homepage/index-loggedout?milolibs=carousel-c2-2-slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)








