### PR TITLE
MWPW-205706: bottom-align compare-pod CTAs when a promo makes a price taller

### DIFF
--- a/libs/blocks/table/table.css
+++ b/libs/blocks/table/table.css
@@ -471,6 +471,16 @@
   align-items: flex-end;
 }
 
+/* Bottom-align CTAs across pods when a promo makes one price taller. */
+.table.has-addon:has(mas-field) .row-heading .col.col-heading:not(.col-1) .heading-button {
+  display: flex;
+  flex-direction: column;
+}
+
+.table.has-addon:has(mas-field) .row-heading .col.col-heading:not(.col-1) .heading-button .buttons-wrapper {
+  margin-top: auto;
+}
+
 .table.has-addon p.body {
   font-size: var(--type-body-xxs-size);
   line-height: var(--type-body-xxs-lh);


### PR DESCRIPTION
Resolves: [MWPW-205706](https://jira.corp.adobe.com/browse/MWPW-205706)

Bottom-aligns the compare-plans table CTAs so they line up across pods when one pod's price is taller.

Companion PR (mas): https://github.com/adobecom/mas/pull/1186

**Test URLs:**
- Before: https://www.stage.adobe.com/se/products/photoshop/plans.html?instant=2026-09-02T05%3A00%3A00.000Z
- After: https://www.stage.adobe.com/se/products/photoshop/plans.html?instant=2026-09-02T05%3A00%3A00.000Z&maslibs=MWPW-205706&milolibs=MWPW-205706
