### PR TITLE
[MWPW-203651] Geo-IP placeholders: single sheet per repo (column-per-market + language tabs)

### DIFF
--- a/libs/c2/blocks/global-navigation/global-navigation.js
+++ b/libs/c2/blocks/global-navigation/global-navigation.js
@@ -44,12 +44,13 @@ export default async function init(el) {
 
   const placeholdersPromise = (async () => {
     const { fetchPlaceholders, getGeoIpPlaceholders } = await import('../../../features/placeholders.js');
-    // Federal replaces {{key}} tokens with a flat string swap and never runs
-    // milo's geo-aware decoration, so merge geo-IP overrides into the map here —
-    // otherwise {{…-geo-ip}} tokens in the gnav resolve to the base value.
+    // Federal does a flat token swap with no geo decoration, so merge geo-IP overrides
+    // here or {{…-geo-ip}} tokens resolve to the base value. The sheet is federal-owned
+    // (parallel to federal's placeholders.json), authored once for every site.
+    const geoIpSource = `${federalDomain}/globalnav/placeholders-geo-ip.json`;
     const [placeholders, geoIp] = await Promise.all([
       fetchPlaceholders({ config }),
-      isLingo ? getGeoIpPlaceholders(config) : null,
+      isLingo ? getGeoIpPlaceholders(config, geoIpSource) : null,
     ]);
     const map = new Map(Object.entries(placeholders));
     geoIp?.forEach((value, key) => map.set(key, value));

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -1,10 +1,11 @@
 import {
   customFetch,
   getConfig,
+  getGeoIpSheetHoist,
   getMetadata,
-  getGeoLocalePrefix,
-  getPlaceholderPaths,
   lingoActive,
+  normCountryCode,
+  resolveDetectedMarketCountry,
 } from '../utils/utils.js';
 
 const fetchedPlaceholders = {};
@@ -67,51 +68,72 @@ function keyToStr(key) {
 const isGeoIpKey = (key) => key.endsWith('-geo-ip');
 const PLACEHOLDER_REGEX = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
 
-async function getGeoPlaceholders(config, sheet) {
-  if (!lingoActive()) return null;
-  const geoPrefix = await getGeoLocalePrefix();
-  if (!geoPrefix) return null;
-  const siteConfig = getConfig();
-  let geoOrigin = window.location.origin;
-  let pathSuffix = siteConfig.contentRoot ?? '';
-  const callerContentRoot = config.locale?.contentRoot ?? '';
-  const siteContentRoot = siteConfig.locale?.contentRoot ?? '';
-  if (callerContentRoot && callerContentRoot !== siteContentRoot) {
-    let path = callerContentRoot;
-    try {
-      const url = new URL(path);
-      geoOrigin = url.origin;
-      path = url.pathname;
-    } catch { /* relative path */ }
-    const prefix = config.locale?.prefix ?? '';
-    if (prefix && path.startsWith(prefix)) path = path.slice(prefix.length);
-    pathSuffix = path;
-  }
+// Geo-IP column sheet: one row per key, one uppercase-ISO country column per market, one tab per
+// lingo site (`?sheet=<siteKey>`); flattened to `{ key: value }` for the visitor's market country.
+// Authoring contract: home-market column first (it's the fallback default); every `-geo-ip` key
+// also needs a base row in placeholders.json; add a site's tab before enabling langfirst. A missing
+// tab 404s → geo-ip inert, tokens keep their base (intended; an `en` fallback would leak English).
 
-  const geoContentRoot = `${geoOrigin}${geoPrefix}${pathSuffix}`;
-  const geoConfig = { locale: { contentRoot: geoContentRoot }, env: siteConfig.env || {} };
-  const paths = getPlaceholderPaths(geoConfig);
+// geo-ip file uses non-ISO `UK`; normCountryCode uses `gb`.
+const COUNTRY_COL_ALIAS = { gb: 'UK' };
+const countryToColumn = (c) => (c ? (COUNTRY_COL_ALIAS[c] ?? c).toUpperCase() : null);
 
-  const placeholderRequest = Promise.all(
-    paths.map((path) => customFetch({ resource: path, withCacheRules: true }).catch(() => ({}))),
-  );
+// source: caller-supplied sheet (e.g. C2 gnav's federal one); else the page content root.
+const getGeoIpPlaceholderPath = (config, source) => {
+  if (source) return source;
+  return `${config.locale?.contentRoot}/placeholders-geo-ip.json`;
+};
 
-  return fetchPlaceholders({
-    config: geoConfig,
-    sheet,
-    placeholderRequest,
-    placeholderPath: paths[0],
-  }).catch((e) => {
-    window.lana?.log(`Error fetching geo placeholders: ${e?.message}`, { tags: 'placeholders', severity: 'warn' });
-    return {};
+const parseGeoIpColumnJson = (json, column, out) => {
+  const defaultColumn = json.columns?.find((c) => c !== 'key');
+  json.data?.forEach((row) => {
+    const val = row[column] || row[defaultColumn]; // visitor's market, else the default column
+    if (typeof val === 'string' && val.length) out[row.key] = val;
   });
+};
+
+async function getGeoIpColumnPlaceholders(config, source) {
+  // detected-market country, not pure geo, to match MEP targeting + MAS pricing
+  const rawCountry = await resolveDetectedMarketCountry();
+  const column = countryToColumn(normCountryCode(rawCountry));
+  if (!column) return null;
+
+  const basePath = getGeoIpPlaceholderPath(config, source);
+  // tab = lingo site key (not ietf, which merges distinct sites): child's `base`, else own prefix
+  const { base, prefix } = config.locale ?? {};
+  const lang = (base ?? (prefix ?? '').replace('/', '')) || 'en';
+  const path = `${basePath}${basePath.includes('?') ? '&' : '?'}sheet=${lang}`;
+  const cacheKey = `${path}#${column}`;
+
+  fetchedPlaceholders[cacheKey] ||= (async () => {
+    const out = {};
+    try {
+      // reuse the page-load hoist for this sheet if present, else fetch now
+      const hoist = getGeoIpSheetHoist();
+      const req = hoist?.url === path
+        ? hoist.resp
+        : customFetch({ resource: path, withCacheRules: true });
+      const resp = await req.catch(() => null);
+      const json = resp?.ok ? await resp.json() : null;
+      if (json) parseGeoIpColumnJson(json, column, out);
+    } catch (e) {
+      window.lana?.log(`Error parsing geo-ip placeholder json: ${e.message}`, { tags: 'placeholders', severity: 'error' });
+    }
+    return out;
+  })();
+
+  return fetchedPlaceholders[cacheKey];
 }
 
-// Map of `-geo-ip` placeholder overrides for the visitor's geo, or null when
-// inactive/none apply. Exposed for surfaces that do their own token replacement
-// outside milo's decorateArea pipeline (e.g. the C2 federal gnav).
-export async function getGeoIpPlaceholders(config = getConfig(), sheet = 'default') {
-  const geo = await getGeoPlaceholders(config, sheet);
+async function getGeoPlaceholders(config, source) {
+  if (!lingoActive()) return null;
+  return getGeoIpColumnPlaceholders(config, source);
+}
+
+// Map of `-geo-ip` overrides (or null), for surfaces that replace tokens outside milo's
+// decorateArea pipeline — e.g. the C2 federal gnav, which passes its own federal sheet `source`.
+export async function getGeoIpPlaceholders(config = getConfig(), source = undefined) {
+  const geo = await getGeoPlaceholders(config, source);
   if (!geo) return null;
   const overrides = new Map();
   Object.entries(geo).forEach(([key, value]) => {
@@ -198,7 +220,6 @@ export async function replaceText(
   config,
   regex = PLACEHOLDER_REGEX,
   sheet = 'default',
-  { defer = false } = {},
 ) {
   if (typeof text !== 'string' || !text.length) return '';
 
@@ -207,15 +228,18 @@ export async function replaceText(
     return text;
   }
   const keys = Array.from(matches, (match) => match[1] || match[2]);
+  const geoIpKeys = keys.filter(isGeoIpKey);
   let geoPlaceholders = null;
-  if (keys.some(isGeoIpKey) && !defer) {
-    geoPlaceholders = await getGeoPlaceholders(config, sheet);
+  if (geoIpKeys.length) {
+    geoPlaceholders = await getGeoPlaceholders(config);
   }
 
   const resolved = await Promise.all(keys.map(async (key) => {
     if (config.placeholders?.[key]) return config.placeholders[key];
     if (geoPlaceholders && isGeoIpKey(key)
-      && typeof geoPlaceholders[key] === 'string') return geoPlaceholders[key];
+      && typeof geoPlaceholders[key] === 'string') {
+      return geoPlaceholders[key];
+    }
     return getPlaceholder(key, config, sheet);
   }));
 
@@ -226,25 +250,6 @@ export async function replaceText(
   return finalText;
 }
 
-const geoIpPattern = /{{([^{}]*?-geo-ip)}}|%7B%7B((?:(?!%7[BD]).)*?-geo-ip)%7D%7D/g;
-const findGeoIpKeys = (t) => (t ? [...t.matchAll(geoIpPattern)].map((m) => m[1] || m[2]) : []);
-
-async function deferGeoIpUpdate(deferredItems, config, sheet) {
-  const geo = await getGeoPlaceholders(config, sheet);
-  if (!geo) return;
-  await Promise.all(deferredItems.map(async ({ node, type, attrName, key }) => {
-    if (config.placeholders?.[key] || typeof geo[key] !== 'string') return;
-    const base = await getPlaceholder(key, config, sheet);
-    if (geo[key] === base) return;
-    if (type === 'text') {
-      node.nodeValue = node.nodeValue.replace(base, geo[key]);
-    } else {
-      const cur = node.getAttribute(attrName);
-      if (cur) node.setAttribute(attrName, cur.replace(base, geo[key]));
-    }
-  }));
-}
-
 export async function decoratePlaceholderArea({
   placeholderPath,
   placeholderRequest,
@@ -253,18 +258,13 @@ export async function decoratePlaceholderArea({
   if (!nodes.length) return;
   const config = getConfig();
   await fetchPlaceholders({ placeholderPath, config, placeholderRequest });
-  const deferred = [];
-  const deferOpt = { defer: true };
-  const track = (keys, item) => keys.forEach((key) => deferred.push({ ...item, key }));
 
   const replaceNodes = nodes.map(async (nodeEl) => {
     if (nodeEl.nodeType === Node.TEXT_NODE) {
-      track(findGeoIpKeys(nodeEl.nodeValue), { node: nodeEl, type: 'text' });
-      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config, PLACEHOLDER_REGEX, 'default', deferOpt);
+      nodeEl.nodeValue = await replaceText(nodeEl.nodeValue, config);
     } else if (nodeEl.nodeType === Node.ELEMENT_NODE) {
       const attrPromises = [...nodeEl.attributes].map(async (attr) => {
-        track(findGeoIpKeys(attr.value), { node: nodeEl, type: 'attr', attrName: attr.name });
-        const val = await replaceText(attr.value, config, PLACEHOLDER_REGEX, 'default', deferOpt);
+        const val = await replaceText(attr.value, config);
         return { name: attr.name, value: val };
       });
       (await Promise.all(attrPromises)).forEach(({ name, value }) => {
@@ -273,8 +273,4 @@ export async function decoratePlaceholderArea({
     }
   });
   await Promise.all(replaceNodes);
-
-  if (deferred.length) {
-    decoratePlaceholderArea.deferredGeo = deferGeoIpUpdate(deferred, config);
-  }
 }

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -1,8 +1,8 @@
 import {
   customFetch,
   getConfig,
-  getGeoIpSheetHoist,
   geoIpSiteKey,
+  getGeoIpWarmSheet,
   getMetadata,
   lingoActive,
   normCountryCode,
@@ -10,6 +10,7 @@ import {
 } from '../utils/utils.js';
 
 const fetchedPlaceholders = {};
+const fetchedGeoSheets = {};
 window.mph = {};
 
 const getPlaceholdersPath = (config, sheet) => {
@@ -69,52 +70,55 @@ function keyToStr(key) {
 const isGeoIpKey = (key) => key.endsWith('-geo-ip');
 const PLACEHOLDER_REGEX = /{{(.*?)}}|%7B%7B(.*?)%7D%7D/g;
 
-// Geo-IP column sheet: one row per key, one uppercase-ISO country column per market, one tab per
-// lingo site (`?sheet=<siteKey>`); flattened to `{ key: value }` for the visitor's market country.
-// Authoring contract: home-market column first (it's the fallback default); every `-geo-ip` key
-// also needs a base row in placeholders.json; add a site's tab before enabling langfirst. A missing
-// tab 404s → geo-ip inert, tokens keep their base (intended; an `en` fallback would leak English).
-
-// geo-ip file uses non-ISO `UK`; normCountryCode uses `gb`.
 const COUNTRY_COL_ALIAS = { gb: 'UK' };
 const countryToColumn = (c) => (c ? (COUNTRY_COL_ALIAS[c] ?? c).toUpperCase() : null);
 
-// source: caller-supplied sheet (e.g. C2 gnav's federal one); else the page content root.
 const getGeoIpPlaceholderPath = (config, source) => {
   if (source) return source;
   return `${config.locale?.contentRoot}/placeholders-geo-ip.json`;
 };
 
+const NONE_SENTINEL = '--none--';
+const cellVal = (v) => (typeof v === 'string' ? v.trim() : '');
+
 const parseGeoIpColumnJson = (json, column, out) => {
-  const defaultColumn = json.columns?.find((c) => c !== 'key');
+  const cols = json.columns ?? [];
+  const defaultColumn = cols.find((c) => c.toLowerCase() === 'default')
+    ?? cols.find((c) => c !== 'key');
   json.data?.forEach((row) => {
-    const val = row[column] || row[defaultColumn]; // visitor's market, else the default column
-    if (typeof val === 'string' && val.length) out[row.key] = val;
+    const val = cellVal(row[column]) || cellVal(row[defaultColumn]);
+    if (val === NONE_SENTINEL) { out[row.key] = ''; return; }
+    if (val) out[row.key] = val;
   });
 };
 
+const geoIpSheetPath = (config, source) => {
+  const basePath = getGeoIpPlaceholderPath(config, source);
+  const lang = geoIpSiteKey(config.locale);
+  return `${basePath}${basePath.includes('?') ? '&' : '?'}sheet=${lang}`;
+};
+
+const fetchGeoIpSheet = (path) => {
+  fetchedGeoSheets[path] ||= getGeoIpWarmSheet(path)
+    || customFetch({ resource: path, withCacheRules: true })
+      .then((r) => (r?.ok ? r.json() : null))
+      .catch(() => null);
+  return fetchedGeoSheets[path];
+};
+
 async function getGeoIpColumnPlaceholders(config, source) {
+  const path = geoIpSheetPath(config, source);
+  const jsonPromise = fetchGeoIpSheet(path); // start fetch before awaiting country
   // detected-market country, not pure geo, to match MEP targeting + MAS pricing
   const rawCountry = await resolveDetectedMarketCountry();
   const column = countryToColumn(normCountryCode(rawCountry));
   if (!column) return null;
 
-  const basePath = getGeoIpPlaceholderPath(config, source);
-  // tab = lingo site key (not ietf, which merges distinct sites): child's `base`, else own prefix
-  const lang = geoIpSiteKey(config.locale);
-  const path = `${basePath}${basePath.includes('?') ? '&' : '?'}sheet=${lang}`;
   const cacheKey = `${path}#${column}`;
-
   fetchedPlaceholders[cacheKey] ||= (async () => {
     const out = {};
     try {
-      // reuse the page-load hoist for this sheet if present, else fetch now
-      const hoist = getGeoIpSheetHoist();
-      const req = hoist?.url === path
-        ? hoist.resp
-        : customFetch({ resource: path, withCacheRules: true });
-      const resp = await req.catch(() => null);
-      const json = resp?.ok ? await resp.json() : null;
+      const json = await jsonPromise;
       if (json) parseGeoIpColumnJson(json, column, out);
     } catch (e) {
       window.lana?.log(`Error parsing geo-ip placeholder json: ${e.message}`, { tags: 'placeholders', severity: 'error' });
@@ -130,10 +134,8 @@ async function getGeoPlaceholders(config, source) {
   return getGeoIpColumnPlaceholders(config, source);
 }
 
-// Map of `-geo-ip` overrides (or null), for surfaces that replace tokens outside milo's
-// decorateArea pipeline. `source` is an optional absolute URL to a placeholders-geo-ip.json
-// file (e.g. `${federalDomain}/globalnav/placeholders-geo-ip.json`); when omitted the URL
-// is derived from config.locale.contentRoot. Returns null when lingo is inactive.
+// Map of `-geo-ip` overrides (or null) for surfaces outside milo's decorateArea pipeline (e.g.
+// C2 gnav); `source` is an optional absolute sheet URL, else derived from config.locale.
 export async function getGeoIpPlaceholders(config = getConfig(), source = undefined) {
   const geo = await getGeoPlaceholders(config, source);
   if (!geo) return null;

--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -2,6 +2,7 @@ import {
   customFetch,
   getConfig,
   getGeoIpSheetHoist,
+  geoIpSiteKey,
   getMetadata,
   lingoActive,
   normCountryCode,
@@ -100,8 +101,7 @@ async function getGeoIpColumnPlaceholders(config, source) {
 
   const basePath = getGeoIpPlaceholderPath(config, source);
   // tab = lingo site key (not ietf, which merges distinct sites): child's `base`, else own prefix
-  const { base, prefix } = config.locale ?? {};
-  const lang = (base ?? (prefix ?? '').replace('/', '')) || 'en';
+  const lang = geoIpSiteKey(config.locale);
   const path = `${basePath}${basePath.includes('?') ? '&' : '?'}sheet=${lang}`;
   const cacheKey = `${path}#${column}`;
 
@@ -131,7 +131,9 @@ async function getGeoPlaceholders(config, source) {
 }
 
 // Map of `-geo-ip` overrides (or null), for surfaces that replace tokens outside milo's
-// decorateArea pipeline — e.g. the C2 federal gnav, which passes its own federal sheet `source`.
+// decorateArea pipeline. `source` is an optional absolute URL to a placeholders-geo-ip.json
+// file (e.g. `${federalDomain}/globalnav/placeholders-geo-ip.json`); when omitted the URL
+// is derived from config.locale.contentRoot. Returns null when lingo is inactive.
 export async function getGeoIpPlaceholders(config = getConfig(), source = undefined) {
   const geo = await getGeoPlaceholders(config, source);
   if (!geo) return null;

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2881,6 +2881,20 @@ function loadLingoIndexes(area = document) {
   }).catch((e) => window.lana?.log(`Failed to get mep lingo prefix: ${e}`, { tags: 'lingo', severity: 'error' }));
 }
 
+let geoIpSheetHoist;
+
+// In-flight geo-IP sheet fetch, reused by placeholders.js.
+export const getGeoIpSheetHoist = () => geoIpSheetHoist;
+
+// Fetch the geo-IP sheet at page load (low priority) so decoratePlaceholders reuses it instead of
+// serially blocking the LCP image. URL must match the one getGeoIpColumnPlaceholders builds.
+const hoistGeoIpSheet = (config) => {
+  const { contentRoot, base, prefix } = config.locale ?? {};
+  const lang = (base ?? (prefix ?? '').replace('/', '')) || 'en';
+  const url = `${contentRoot}/placeholders-geo-ip.json?sheet=${lang}`;
+  geoIpSheetHoist ??= { url, resp: fetch(url, { priority: 'low' }).catch(() => null) };
+};
+
 export async function loadArea(area = document) {
   const isDoc = area === document;
   if (isDoc) {
@@ -2906,6 +2920,8 @@ export async function loadArea(area = document) {
   }
 
   if (isLingoActive) loadLingoIndexes(area);
+
+  if (isDoc && isLingoActive) hoistGeoIpSheet(config);
 
   if (isDoc) {
     await decorateDocumentExtras();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2881,24 +2881,15 @@ function loadLingoIndexes(area = document) {
   }).catch((e) => window.lana?.log(`Failed to get mep lingo prefix: ${e}`, { tags: 'lingo', severity: 'error' }));
 }
 
-let geoIpSheetHoist;
-
-// In-flight geo-IP sheet fetch, reused by placeholders.js.
-export const getGeoIpSheetHoist = () => geoIpSheetHoist;
-
-// Shared lingo site-key derivation: used by both the hoist and getGeoIpColumnPlaceholders to build
-// the same ?sheet= value so hoist.url === path holds.
 export const geoIpSiteKey = ({ base, prefix } = {}) => (base ?? (prefix ?? '').replace('/', '')) || 'en';
 
-// Fetch the geo-IP sheet at page load (low priority) so decoratePlaceholders reuses it instead of
-// serially blocking the LCP image.
-const hoistGeoIpSheet = (config) => {
-  const { contentRoot } = config.locale ?? {};
-  const lang = geoIpSiteKey(config.locale);
-  const url = `${contentRoot}/placeholders-geo-ip.json?sheet=${lang}`;
-  const params = new URLSearchParams(window.location.search);
-  const cache = params.get('cache') === 'off' ? 'reload' : 'default';
-  geoIpSheetHoist ??= { url, resp: fetch(url, { priority: 'low', cache }).catch(() => null) };
+const geoIpWarm = {};
+export const getGeoIpWarmSheet = (url) => geoIpWarm[url];
+const warmGeoIpSheet = (config) => {
+  const url = `${config.locale?.contentRoot}/placeholders-geo-ip.json?sheet=${geoIpSiteKey(config.locale)}`;
+  geoIpWarm[url] ??= customFetch({ resource: url, withCacheRules: true })
+    .then((r) => (r?.ok ? r.json() : null))
+    .catch(() => null);
 };
 
 export async function loadArea(area = document) {
@@ -2921,13 +2912,17 @@ export async function loadArea(area = document) {
   const htmlSections = [...area.querySelectorAll(isDoc ? 'body > main > div' : ':scope > div')];
   htmlSections.forEach((section) => { section.className = 'section'; section.dataset.status = 'pending'; });
 
-  if (area.querySelector('a[href*="/fragments/"], a[data-mep-lingo-section-swap], a[data-mep-lingo-block-swap], a[href*="#_inline"]')) {
+  const fragmentLink = area.querySelector('a[href*="/fragments/"], a[data-mep-lingo-section-swap], a[data-mep-lingo-block-swap], a[href*="#_inline"]');
+  if (fragmentLink) {
     loadLink(`${config.base}/blocks/fragment/fragment.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
   }
 
   if (isLingoActive) loadLingoIndexes(area);
 
-  if (isDoc && isLingoActive) hoistGeoIpSheet(config);
+  if (isDoc && isLingoActive) {
+    const tokenInLcp = htmlSections[0]?.innerHTML.includes('-geo-ip');
+    if (tokenInLcp || getMepEnablement('geo-ip-lcp')) warmGeoIpSheet(config);
+  }
 
   if (isDoc) {
     await decorateDocumentExtras();

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2886,13 +2886,19 @@ let geoIpSheetHoist;
 // In-flight geo-IP sheet fetch, reused by placeholders.js.
 export const getGeoIpSheetHoist = () => geoIpSheetHoist;
 
+// Shared lingo site-key derivation: used by both the hoist and getGeoIpColumnPlaceholders to build
+// the same ?sheet= value so hoist.url === path holds.
+export const geoIpSiteKey = ({ base, prefix } = {}) => (base ?? (prefix ?? '').replace('/', '')) || 'en';
+
 // Fetch the geo-IP sheet at page load (low priority) so decoratePlaceholders reuses it instead of
-// serially blocking the LCP image. URL must match the one getGeoIpColumnPlaceholders builds.
+// serially blocking the LCP image.
 const hoistGeoIpSheet = (config) => {
-  const { contentRoot, base, prefix } = config.locale ?? {};
-  const lang = (base ?? (prefix ?? '').replace('/', '')) || 'en';
+  const { contentRoot } = config.locale ?? {};
+  const lang = geoIpSiteKey(config.locale);
   const url = `${contentRoot}/placeholders-geo-ip.json?sheet=${lang}`;
-  geoIpSheetHoist ??= { url, resp: fetch(url, { priority: 'low' }).catch(() => null) };
+  const params = new URLSearchParams(window.location.search);
+  const cache = params.get('cache') === 'off' ? 'reload' : 'default';
+  geoIpSheetHoist ??= { url, resp: fetch(url, { priority: 'low', cache }).catch(() => null) };
 };
 
 export async function loadArea(area = document) {

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2912,16 +2912,15 @@ export async function loadArea(area = document) {
   const htmlSections = [...area.querySelectorAll(isDoc ? 'body > main > div' : ':scope > div')];
   htmlSections.forEach((section) => { section.className = 'section'; section.dataset.status = 'pending'; });
 
-  const fragmentLink = area.querySelector('a[href*="/fragments/"], a[data-mep-lingo-section-swap], a[data-mep-lingo-block-swap], a[href*="#_inline"]');
-  if (fragmentLink) {
+  if (area.querySelector('a[href*="/fragments/"], a[data-mep-lingo-section-swap], a[data-mep-lingo-block-swap], a[href*="#_inline"]')) {
     loadLink(`${config.base}/blocks/fragment/fragment.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
   }
 
   if (isLingoActive) loadLingoIndexes(area);
 
-  if (isDoc && isLingoActive) {
-    const tokenInLcp = htmlSections[0]?.innerHTML.includes('-geo-ip');
-    if (tokenInLcp || getMepEnablement('geo-ip-lcp')) warmGeoIpSheet(config);
+  if (isLingoActive) {
+    const tokenInLcp = /-geo-ip(}}|%7D%7D)/.test(htmlSections[0]?.innerHTML ?? '');
+    if (tokenInLcp || (isDoc && getMepEnablement('geo-ip-lcp'))) warmGeoIpSheet(config);
   }
 
   if (isDoc) {

--- a/test/blocks/merch/mocks/embed-utils.js
+++ b/test/blocks/merch/mocks/embed-utils.js
@@ -60,7 +60,7 @@ export const shouldAllowKrTrial = stub();
 export const lingoActive = () => false;
 export const getGeoLocalePrefix = () => Promise.resolve(null);
 export const getPlaceholderPaths = () => [];
-export const getGeoIpSheetHoist = () => undefined;
+export const getGeoIpWarmSheet = () => undefined;
 export const geoIpSiteKey = ({ base, prefix } = {}) => (base ?? (prefix ?? '').replace('/', '')) || 'en';
 export const normCountryCode = (country) => {
   if (typeof country !== 'string') return undefined;

--- a/test/blocks/merch/mocks/embed-utils.js
+++ b/test/blocks/merch/mocks/embed-utils.js
@@ -60,6 +60,13 @@ export const shouldAllowKrTrial = stub();
 export const lingoActive = () => false;
 export const getGeoLocalePrefix = () => Promise.resolve(null);
 export const getPlaceholderPaths = () => [];
+export const getGeoIpSheetHoist = () => undefined;
+export const normCountryCode = (country) => {
+  if (typeof country !== 'string') return undefined;
+  const lower = country.toLowerCase();
+  return lower === 'uk' ? 'gb' : lower.split('_')[0];
+};
+export const resolveDetectedMarketCountry = () => Promise.resolve(undefined);
 
 const MASLIBS_PATTERN = /^([a-z0-9]+(-[a-z0-9]+)*)(--([a-z0-9]+(-[a-z0-9]+)*)){0,2}$/;
 const MASLIBS_MAX_LENGTH = 100;

--- a/test/blocks/merch/mocks/embed-utils.js
+++ b/test/blocks/merch/mocks/embed-utils.js
@@ -61,6 +61,7 @@ export const lingoActive = () => false;
 export const getGeoLocalePrefix = () => Promise.resolve(null);
 export const getPlaceholderPaths = () => [];
 export const getGeoIpSheetHoist = () => undefined;
+export const geoIpSiteKey = ({ base, prefix } = {}) => (base ?? (prefix ?? '').replace('/', '')) || 'en';
 export const normCountryCode = (country) => {
   if (typeof country !== 'string') return undefined;
   const lower = country.toLowerCase();

--- a/test/blocks/ost/mocks/ost-utils.js
+++ b/test/blocks/ost/mocks/ost-utils.js
@@ -140,6 +140,13 @@ const shouldAllowKrTrial = (button, localePrefix) => {
 const lingoActive = () => false;
 const getGeoLocalePrefix = () => Promise.resolve(null);
 const getPlaceholderPaths = () => [];
+const getGeoIpSheetHoist = () => undefined;
+const normCountryCode = (country) => {
+  if (typeof country !== 'string') return undefined;
+  const lower = country.toLowerCase();
+  return lower === 'uk' ? 'gb' : lower.split('_')[0];
+};
+const resolveDetectedMarketCountry = () => Promise.resolve(undefined);
 
 const MASLIBS_PATTERN = /^([a-z0-9]+(-[a-z0-9]+)*)(--([a-z0-9]+(-[a-z0-9]+)*)){0,2}$/;
 const MASLIBS_MAX_LENGTH = 100;
@@ -183,5 +190,8 @@ export {
   lingoActive,
   getGeoLocalePrefix,
   getPlaceholderPaths,
+  getGeoIpSheetHoist,
+  normCountryCode,
+  resolveDetectedMarketCountry,
   getValidatedMasLibsUrl,
 };

--- a/test/blocks/ost/mocks/ost-utils.js
+++ b/test/blocks/ost/mocks/ost-utils.js
@@ -140,7 +140,7 @@ const shouldAllowKrTrial = (button, localePrefix) => {
 const lingoActive = () => false;
 const getGeoLocalePrefix = () => Promise.resolve(null);
 const getPlaceholderPaths = () => [];
-const getGeoIpSheetHoist = () => undefined;
+const getGeoIpWarmSheet = () => undefined;
 const geoIpSiteKey = ({ base, prefix } = {}) => (base ?? (prefix ?? '').replace('/', '')) || 'en';
 const normCountryCode = (country) => {
   if (typeof country !== 'string') return undefined;
@@ -191,7 +191,7 @@ export {
   lingoActive,
   getGeoLocalePrefix,
   getPlaceholderPaths,
-  getGeoIpSheetHoist,
+  getGeoIpWarmSheet,
   geoIpSiteKey,
   normCountryCode,
   resolveDetectedMarketCountry,

--- a/test/blocks/ost/mocks/ost-utils.js
+++ b/test/blocks/ost/mocks/ost-utils.js
@@ -141,6 +141,7 @@ const lingoActive = () => false;
 const getGeoLocalePrefix = () => Promise.resolve(null);
 const getPlaceholderPaths = () => [];
 const getGeoIpSheetHoist = () => undefined;
+const geoIpSiteKey = ({ base, prefix } = {}) => (base ?? (prefix ?? '').replace('/', '')) || 'en';
 const normCountryCode = (country) => {
   if (typeof country !== 'string') return undefined;
   const lower = country.toLowerCase();
@@ -191,6 +192,7 @@ export {
   getGeoLocalePrefix,
   getPlaceholderPaths,
   getGeoIpSheetHoist,
+  geoIpSiteKey,
   normCountryCode,
   resolveDetectedMarketCountry,
   getValidatedMasLibsUrl,

--- a/test/c2/blocks/global-navigation/global-navigation.test.html
+++ b/test/c2/blocks/global-navigation/global-navigation.test.html
@@ -26,17 +26,17 @@
     import { calls } from './mocks/federal-main.js';
     import init from '../../../../libs/c2/blocks/global-navigation/global-navigation.js';
 
-    const geoFixturePath = '/test/features/placeholders/lu_fr';
+    const gnavSheet = '/test/features/placeholders/placeholders-geo-ip-gnav.json';
     let langfirstMeta;
 
-    // Mirrors enableLingo() in placeholders.test.js — drives the real lingo +
-    // geo-IP code against local fixtures, no network.
+    // Activates lingo/geo-IP against local fixtures. The wrapper's geo-IP source is the remote
+    // federal domain, so the fetch stub below redirects it to the local gnav sheet.
     function enableLingo() {
       langfirstMeta = document.createElement('meta');
       langfirstMeta.name = 'langfirst';
       langfirstMeta.content = 'on';
       document.head.appendChild(langfirstMeta);
-      sessionStorage.setItem('akamai', 'lu');
+      sessionStorage.setItem('akamai', 'us');
       setConfig({
         locales: {
           '': { ietf: 'en-US', tk: 'hah7vzn.css' },
@@ -48,7 +48,6 @@
       const cfg = getConfig();
       cfg.locale.prefix = '/fr';
       cfg.locale.contentRoot = '/test/features/placeholders';
-      cfg.locale.regions = { lu_fr: { prefix: geoFixturePath } };
       return cfg;
     }
 
@@ -68,15 +67,24 @@
     runTests(() => {
       describe('C2 global-navigation wrapper wiring', () => {
         let paramsGetStub;
+        let fetchStub;
 
         before(() => {
           // keep the runner URL's query out of getFederalDomain/getEnv/lingoActive
           paramsGetStub = sinon.stub(URLSearchParams.prototype, 'get');
           paramsGetStub.withArgs('cache').returns('off');
+          // Redirect the remote federal geo-IP sheet to the local fixture; pass everything else through.
+          const realFetch = window.fetch.bind(window);
+          fetchStub = sinon.stub(window, 'fetch').callsFake((resource, opts) => {
+            const url = typeof resource === 'string' ? resource : resource?.url;
+            if (url?.includes('placeholders-geo-ip.json')) return realFetch(gnavSheet);
+            return realFetch(resource, opts);
+          });
         });
 
         after(() => {
           paramsGetStub.restore();
+          fetchStub.restore();
         });
 
         afterEach(() => {
@@ -114,7 +122,7 @@
           enableLingo();
           const args = await runInit();
           const map = await args.placeholders;
-          expect(map.get('phone-number-geo-ip')).to.equal('+352 800 99999');
+          expect(map.get('hello-geo-ip')).to.equal('hello US GNAV');
         });
 
         it('leaves the base value when lingo is inactive (no geo-IP merge)', async () => {

--- a/test/features/placeholders/placeholders-geo-ip-default.json
+++ b/test/features/placeholders/placeholders-geo-ip-default.json
@@ -1,0 +1,13 @@
+{
+  "total": 4,
+  "offset": 0,
+  "limit": 4,
+  "data": [
+    { "key": "hello-geo-ip", "default": "hello DEFAULT", "US": "hello US", "AR": "--none--" },
+    { "key": "phone-number-geo-ip", "default": "+1 000 000 0000", "AR": "+54 800 222 2222" },
+    { "key": "explicit-only-geo-ip", "default": "--none--", "AR": "only AR" },
+    { "key": "unlisted-thing-geo-ip", "default": "" }
+  ],
+  "columns": ["key", "default", "US", "AR"],
+  ":type": "sheet"
+}

--- a/test/features/placeholders/placeholders-geo-ip-gnav.json
+++ b/test/features/placeholders/placeholders-geo-ip-gnav.json
@@ -1,0 +1,10 @@
+{
+  "total": 1,
+  "offset": 0,
+  "limit": 1,
+  "data": [
+    { "key": "hello-geo-ip", "US": "hello US GNAV", "AR": "hello AR GNAV", "UK": "hello UK GNAV" }
+  ],
+  "columns": ["key", "US", "AR", "UK"],
+  ":type": "sheet"
+}

--- a/test/features/placeholders/placeholders-geo-ip.json
+++ b/test/features/placeholders/placeholders-geo-ip.json
@@ -1,10 +1,11 @@
 {
-  "total": 2,
+  "total": 3,
   "offset": 0,
-  "limit": 2,
+  "limit": 3,
   "data": [
     { "key": "hello-geo-ip", "US": "hello US", "AR": "hello AR", "UK": "hello UK" },
-    { "key": "phone-number-geo-ip", "US": "+1 800 111 1111", "AR": "+54 800 222 2222", "UK": "+44 800 333 3333" }
+    { "key": "phone-number-geo-ip", "US": "+1 800 111 1111", "AR": "+54 800 222 2222", "UK": "+44 800 333 3333" },
+    { "key": "cleared-geo-ip", "US": "--none--", "AR": "cleared AR", "UK": "cleared UK" }
   ],
   "columns": ["key", "US", "AR", "UK"],
   ":type": "sheet"

--- a/test/features/placeholders/placeholders-geo-ip.json
+++ b/test/features/placeholders/placeholders-geo-ip.json
@@ -1,0 +1,11 @@
+{
+  "total": 2,
+  "offset": 0,
+  "limit": 2,
+  "data": [
+    { "key": "hello-geo-ip", "US": "hello US", "AR": "hello AR", "UK": "hello UK" },
+    { "key": "phone-number-geo-ip", "US": "+1 800 111 1111", "AR": "+54 800 222 2222", "UK": "+44 800 333 3333" }
+  ],
+  "columns": ["key", "US", "AR", "UK"],
+  ":type": "sheet"
+}

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
-import { setConfig, getConfig, customFetch } from '../../../libs/utils/utils.js';
+import { setConfig, getConfig, customFetch, geoIpSiteKey } from '../../../libs/utils/utils.js';
 import {
   replaceText,
   replaceKey,
@@ -205,5 +205,27 @@ describe('Geo-IP Placeholders (column-per-market sheet)', () => {
     cfg.locale.contentRoot = '/nonexistent';
     const overrides = await getGeoIpPlaceholders(cfg, gnavSheet);
     expect(overrides.get('hello-geo-ip')).to.equal('hello US GNAV');
+  });
+});
+
+describe('geoIpSiteKey', () => {
+  it('returns base when set', () => {
+    expect(geoIpSiteKey({ base: 'fr_FR' })).to.equal('fr_FR');
+  });
+
+  it('strips the leading slash from prefix', () => {
+    expect(geoIpSiteKey({ prefix: '/fr' })).to.equal('fr');
+  });
+
+  it('prefers base over prefix', () => {
+    expect(geoIpSiteKey({ base: 'fr_CH', prefix: '/fr' })).to.equal('fr_CH');
+  });
+
+  it('defaults to en when locale is empty', () => {
+    expect(geoIpSiteKey({})).to.equal('en');
+  });
+
+  it('defaults to en when called with no argument', () => {
+    expect(geoIpSiteKey()).to.equal('en');
   });
 });

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -173,6 +173,11 @@ describe('Geo-IP Placeholders (column-per-market sheet)', () => {
     expect(await replaceText('{{unlisted-thing-geo-ip}}', cfg)).to.equal('unlisted thing geo ip');
   });
 
+  it('renders --none-- as empty, not the humanized key', async () => {
+    const cfg = enableGeo('us');
+    expect(await replaceText('{{cleared-geo-ip}}', cfg)).to.equal('');
+  });
+
   it('falls back to the base placeholder when langfirst is off', async () => {
     const cfg = disableGeo();
     expect(await replaceText('{{hello-geo-ip}}', cfg)).to.equal('hello geo ip');
@@ -205,6 +210,52 @@ describe('Geo-IP Placeholders (column-per-market sheet)', () => {
     cfg.locale.contentRoot = '/nonexistent';
     const overrides = await getGeoIpPlaceholders(cfg, gnavSheet);
     expect(overrides.get('hello-geo-ip')).to.equal('hello US GNAV');
+  });
+
+  describe('named `default` column and --none-- clearing', () => {
+    const defaultSheet = '/test/features/placeholders/placeholders-geo-ip-default.json';
+
+    it('uses the market column over the default column', async () => {
+      const cfg = enableGeo('us');
+      const overrides = await getGeoIpPlaceholders(cfg, defaultSheet);
+      expect(overrides.get('hello-geo-ip')).to.equal('hello US');
+    });
+
+    it('falls back to the named default column when the market has no cell', async () => {
+      // phone-number has no US column → inherits the default column
+      const cfg = enableGeo('us');
+      const overrides = await getGeoIpPlaceholders(cfg, defaultSheet);
+      expect(overrides.get('phone-number-geo-ip')).to.equal('+1 000 000 0000');
+    });
+
+    it('uses the default column for a market with no column of its own', async () => {
+      const cfg = enableGeo('jp');
+      const overrides = await getGeoIpPlaceholders(cfg, defaultSheet);
+      expect(overrides.get('hello-geo-ip')).to.equal('hello DEFAULT');
+    });
+
+    it('clears a market with --none-- so the token renders empty (not the default)', async () => {
+      // hello-geo-ip AR cell is --none-- → explicit empty, not inherited from the default column
+      const cfg = enableGeo('ar');
+      const overrides = await getGeoIpPlaceholders(cfg, defaultSheet);
+      expect(overrides.get('hello-geo-ip')).to.equal('');
+    });
+
+    it('a --none-- default means only explicit market cells resolve; others render empty', async () => {
+      // explicit-only-geo-ip default is --none--: AR gets its cell, other markets clear to empty
+      const cfg = enableGeo('ar');
+      const arOverrides = await getGeoIpPlaceholders(cfg, defaultSheet);
+      expect(arOverrides.get('explicit-only-geo-ip')).to.equal('only AR');
+      sessionStorage.setItem('akamai', 'us');
+      const usOverrides = await getGeoIpPlaceholders(cfg, defaultSheet);
+      expect(usOverrides.get('explicit-only-geo-ip')).to.equal('');
+    });
+
+    it('omits a key whose default column is empty', async () => {
+      const cfg = enableGeo('jp');
+      const overrides = await getGeoIpPlaceholders(cfg, defaultSheet);
+      expect(overrides.has('unlisted-thing-geo-ip')).to.be.false;
+    });
   });
 });
 

--- a/test/features/placeholders/placeholders.test.js
+++ b/test/features/placeholders/placeholders.test.js
@@ -100,10 +100,11 @@ describe('Placeholders', () => {
   });
 });
 
-describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
+describe('Geo-IP Placeholders (column-per-market sheet)', () => {
   let paramsGetStub;
   let langfirstMeta;
-  const geoFixturePath = '/test/features/placeholders/lu_fr';
+  const contentRoot = '/test/features/placeholders';
+  const gnavSheet = '/test/features/placeholders/placeholders-geo-ip-gnav.json';
 
   before(() => {
     paramsGetStub = stub(URLSearchParams.prototype, 'get');
@@ -114,153 +115,95 @@ describe('Geo-IP Placeholders (-geo-ip suffix)', () => {
     paramsGetStub.restore();
   });
 
-  function enableLingo() {
+  // Geo-IP is gated on lingoActive() (langfirst meta); the country comes from sessionStorage
+  // 'akamai'. UK is the non-ISO alias for gb; the test server ignores the ?sheet= query.
+  function enableGeo(country) {
     langfirstMeta = document.createElement('meta');
     langfirstMeta.name = 'langfirst';
     langfirstMeta.content = 'on';
     document.head.appendChild(langfirstMeta);
-    sessionStorage.setItem('akamai', 'lu');
-    const geoLocales = {
-      '': { ietf: 'en-US', tk: 'hah7vzn.css' },
-      '/fr': { ietf: 'fr-FR', tk: 'hah7vzn.css' },
-    };
-    const regions = { lu_fr: { prefix: geoFixturePath } };
-    setConfig({ locales: geoLocales, locale: { region: 'fr' }, contentRoot: '' });
+    if (country) sessionStorage.setItem('akamai', country);
+    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
     const cfg = getConfig();
-    cfg.locale.prefix = '/fr';
-    cfg.locale.regions = regions;
+    cfg.locale.contentRoot = contentRoot;
     return cfg;
   }
 
-  function disableLingo() {
-    if (langfirstMeta?.parentNode) langfirstMeta.parentNode.removeChild(langfirstMeta);
-    sessionStorage.removeItem('akamai');
+  function disableGeo() {
+    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
+    const cfg = getConfig();
+    cfg.locale.contentRoot = contentRoot;
+    return cfg;
   }
 
   afterEach(() => {
-    disableLingo();
+    if (langfirstMeta?.parentNode) langfirstMeta.parentNode.removeChild(langfirstMeta);
+    langfirstMeta = undefined;
+    sessionStorage.removeItem('akamai');
   });
 
-  it('replaceText resolves geo value for -geo-ip keys (default, non-deferred)', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const text = await replaceText('tel:{{phone-number-geo-ip}}', cfg);
-    expect(text).to.equal('tel:+352 800 99999');
+  it('resolves the visitor country column for a -geo-ip key', async () => {
+    const cfg = enableGeo('us');
+    expect(await replaceText('{{hello-geo-ip}}', cfg)).to.equal('hello US');
   });
 
-  it('replaceText resolves geo value for non-phone -geo-ip key', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const text = await replaceText('{{buy-now-geo-ip}}', cfg);
-    expect(text).to.equal('Acheter maintenant');
+  it('resolves a different country column', async () => {
+    const cfg = enableGeo('ar');
+    expect(await replaceText('tel:{{phone-number-geo-ip}}', cfg)).to.equal('tel:+54 800 222 2222');
   });
 
-  it('falls back to base placeholder when langfirst is off', async () => {
-    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
-    const cfg = getConfig();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const text = await replaceText('{{buy-now-geo-ip}}', cfg);
-    expect(text).to.equal('Buy now');
+  it('maps a gb visitor to the non-ISO UK column', async () => {
+    const cfg = enableGeo('gb');
+    expect(await replaceText('{{hello-geo-ip}}', cfg)).to.equal('hello UK');
   });
 
-  it('getGeoIpPlaceholders returns a Map of -geo-ip overrides (for the C2 gnav map merge)', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
+  it('maps a uk visitor (normalised to gb) to the UK column', async () => {
+    const cfg = enableGeo('uk');
+    expect(await replaceText('{{hello-geo-ip}}', cfg)).to.equal('hello UK');
+  });
+
+  it('falls back to the first value column when the visitor country has no column', async () => {
+    // Positional default: an unlisted market resolves to the first value column (US), not the base.
+    const cfg = enableGeo('jp');
+    expect(await replaceText('{{hello-geo-ip}}', cfg)).to.equal('hello US');
+  });
+
+  it('keeps the authored base value for a -geo-ip key absent from the sheet', async () => {
+    const cfg = enableGeo('us');
+    expect(await replaceText('{{unlisted-thing-geo-ip}}', cfg)).to.equal('unlisted thing geo ip');
+  });
+
+  it('falls back to the base placeholder when langfirst is off', async () => {
+    const cfg = disableGeo();
+    expect(await replaceText('{{hello-geo-ip}}', cfg)).to.equal('hello geo ip');
+  });
+
+  it('lets a MEP placeholder override the geo-ip value', async () => {
+    const cfg = enableGeo('us');
+    cfg.placeholders = { 'hello-geo-ip': 'MEP override value' };
+    expect(await replaceText('{{hello-geo-ip}}', cfg)).to.equal('MEP override value');
+    delete cfg.placeholders;
+  });
+
+  it('getGeoIpPlaceholders returns a Map of -geo-ip overrides (for the C2 gnav merge)', async () => {
+    const cfg = enableGeo('us');
     const overrides = await getGeoIpPlaceholders(cfg);
     expect(overrides).to.be.instanceOf(Map);
-    expect(overrides.get('phone-number-geo-ip')).to.equal('+352 800 99999');
-    expect(overrides.get('buy-now-geo-ip')).to.equal('Acheter maintenant');
+    expect(overrides.get('hello-geo-ip')).to.equal('hello US');
+    expect(overrides.get('phone-number-geo-ip')).to.equal('+1 800 111 1111');
     // only -geo-ip keys are included — base keys must not leak into the merge
     [...overrides.keys()].forEach((key) => expect(key.endsWith('-geo-ip')).to.be.true);
   });
 
   it('getGeoIpPlaceholders returns null when langfirst is off', async () => {
-    setConfig({ locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
-    const cfg = getConfig();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const overrides = await getGeoIpPlaceholders(cfg);
-    expect(overrides).to.equal(null);
+    const cfg = disableGeo();
+    expect(await getGeoIpPlaceholders(cfg)).to.equal(null);
   });
 
-  it('deferred update swaps base to geo value in href, preserves custom text', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const link = document.createElement('a');
-    link.setAttribute('href', 'tel:%7B%7Bphone-number-geo-ip%7D%7D');
-    link.textContent = 'Call Adobe Support';
-
-    await decoratePlaceholderArea({ nodes: [link] });
-    expect(link.getAttribute('href')).to.equal('tel:800 555 1234');
-    expect(link.textContent).to.equal('Call Adobe Support');
-
-    await decoratePlaceholderArea.deferredGeo;
-    expect(link.getAttribute('href')).to.equal('tel:+352 800 99999');
-    expect(link.textContent).to.equal('Call Adobe Support');
-  });
-
-  it('deferred update swaps both href and text node to geo values', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const link = document.createElement('a');
-    link.setAttribute('href', 'tel:%7B%7Bphone-number-geo-ip%7D%7D');
-    const textNode = document.createTextNode('{{phone-number-geo-ip}}');
-    link.appendChild(textNode);
-
-    await decoratePlaceholderArea({ nodes: [link, textNode] });
-    expect(link.getAttribute('href')).to.equal('tel:800 555 1234');
-    expect(textNode.nodeValue).to.equal('800 555 1234');
-
-    await decoratePlaceholderArea.deferredGeo;
-    expect(link.getAttribute('href')).to.equal('tel:+352 800 99999');
-    expect(textNode.nodeValue).to.equal('+352 800 99999');
-  });
-
-  it('deferred update swaps geo-ip value when preceded by another placeholder in the same text node', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const textNode = document.createTextNode('{{add-to-cart}} and {{buy-now-geo-ip}}');
-
-    await decoratePlaceholderArea({ nodes: [textNode] });
-    expect(textNode.nodeValue).to.equal('Add to cart and Buy now');
-
-    await decoratePlaceholderArea.deferredGeo;
-    expect(textNode.nodeValue).to.equal('Add to cart and Acheter maintenant');
-  });
-
-  it('MEP placeholder overrides geo-ip value', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    cfg.placeholders = { 'phone-number-geo-ip': 'MEP override value' };
-    const text = await replaceText('{{phone-number-geo-ip}}', cfg);
-    expect(text).to.equal('MEP override value');
-    delete cfg.placeholders;
-  });
-
-  it('resolves geo value for federated content root (GNAV path)', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    const federatedConfig = {
-      locale: {
-        ...cfg.locale,
-        contentRoot: `${window.location.origin}/fr/federal/globalnav`,
-      },
-    };
-    const text = await replaceText('{{phone-number-geo-ip}}', federatedConfig);
-    expect(text).to.equal('+352 GNAV 99999');
-  });
-
-  it('deferred update skips keys overridden by MEP', async () => {
-    const cfg = enableLingo();
-    cfg.locale.contentRoot = '/test/features/placeholders';
-    cfg.placeholders = { 'phone-number-geo-ip': 'MEP override value' };
-    const link = document.createElement('a');
-    link.setAttribute('href', 'tel:%7B%7Bphone-number-geo-ip%7D%7D');
-    link.textContent = 'Call us';
-
-    await decoratePlaceholderArea({ nodes: [link] });
-    await decoratePlaceholderArea.deferredGeo;
-    expect(link.getAttribute('href')).to.equal('tel:MEP override value');
-    expect(link.textContent).to.equal('Call us');
-    delete cfg.placeholders;
+  it('resolves from an explicit source sheet, ignoring contentRoot (C2 gnav federal path)', async () => {
+    const cfg = enableGeo('us');
+    cfg.locale.contentRoot = '/nonexistent';
+    const overrides = await getGeoIpPlaceholders(cfg, gnavSheet);
+    expect(overrides.get('hello-geo-ip')).to.equal('hello US GNAV');
   });
 });

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -3369,4 +3369,75 @@ describe('Utils', () => {
       expect(result).to.equal('be');
     });
   });
+
+  describe('geo-ip sheet prewarm', () => {
+    let warmCount = 0;
+    let savedFetch;
+
+    const geoUrl = () => {
+      const { locale } = utils.getConfig();
+      return `${locale.contentRoot}/placeholders-geo-ip.json?sheet=${utils.geoIpSiteKey(locale)}`;
+    };
+
+    // Unique contentRoot per test → unique sheet URL → sidesteps the module-level
+    // warm dedupe cache, so getGeoIpWarmSheet reflects only this test's warm.
+    const setup = ({ lingo = true, geoLcp = false } = {}) => {
+      warmCount += 1;
+      utils.setConfig({ ...config, contentRoot: `/geo-warm-${warmCount}` });
+      document.head.innerHTML = head;
+      if (lingo) document.head.appendChild(createTag('meta', { name: 'langfirst', content: 'on' }));
+      if (geoLcp) document.head.appendChild(createTag('meta', { name: 'geo-ip-lcp', content: 'on' }));
+    };
+
+    const fragmentArea = (html) => {
+      const area = createTag('div');
+      area.innerHTML = html;
+      return area;
+    };
+
+    beforeEach(() => {
+      savedFetch = window.fetch;
+      window.fetch = mockFetch({ payload: { data: [] } });
+    });
+
+    afterEach(() => {
+      window.fetch = savedFetch;
+    });
+
+    it('warms when a -geo-ip token is in the first section', async () => {
+      setup();
+      const url = geoUrl();
+      await utils.loadArea(fragmentArea('<div>{{promo-geo-ip}}</div>'));
+      expect(utils.getGeoIpWarmSheet(url)).to.not.be.undefined;
+    });
+
+    it('warms on the geo-ip-lcp opt-in even with no token in the section', async () => {
+      setup({ geoLcp: true });
+      const url = geoUrl();
+      document.body.innerHTML = '<main><div>no token here</div></main>';
+      await utils.loadArea();
+      expect(utils.getGeoIpWarmSheet(url)).to.not.be.undefined;
+    });
+
+    it('does not warm when there is no token and no opt-in', async () => {
+      setup();
+      const url = geoUrl();
+      await utils.loadArea(fragmentArea('<div>plain copy</div>'));
+      expect(utils.getGeoIpWarmSheet(url)).to.be.undefined;
+    });
+
+    it('does not warm when lingo is inactive even if a token is present', async () => {
+      setup({ lingo: false });
+      const url = geoUrl();
+      await utils.loadArea(fragmentArea('<div>{{promo-geo-ip}}</div>'));
+      expect(utils.getGeoIpWarmSheet(url)).to.be.undefined;
+    });
+
+    it('does not warm on a bare -geo-ip substring with no token closer', async () => {
+      setup();
+      const url = geoUrl();
+      await utils.loadArea(fragmentArea('<div class="foo-geo-ip-bar">copy</div>'));
+      expect(utils.getGeoIpWarmSheet(url)).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
## Geo-IP placeholders: single sheet per repo (column-per-market + tab-per-language)

Reworks geo-IP placeholders from the per-geo-locale sheet model to a **single `placeholders-geo-ip.json` per repo**, and removes the deferred second-pass write that caused an intermittent race in self-rebuilding blocks (merch cards).

### Safe to merge — no production impact
Merging the code is safe: the new `placeholders-geo-ip.json` sheet has **never been published**, so `-geo-ip` tokens fall back to their `placeholders.json` value everywhere until a real sheet is authored and published. There's no regression window.

**🧹 Clean up the test data before the sheet is published.** The dummy values I authored for validation are not production content — and some sit on `-geo-ip` keys that real pages already use, so **publishing the sheet with them still in place would surface test strings on live placeholders**. Update them with real values or remove them (the code merge itself is unaffected — the sheet has never been published):
* Temporary market columns on the da-cc geo-IP sheet ([`/cc-shared/placeholders-geo-ip.json`](https://main--da-cc--adobecom.aem.page/cc-shared/placeholders-geo-ip.json), da-cc auth required) and the cc sheet — in **both the `en` and `fr` tabs**.
* The `/drafts/markp/…` demo pages referenced under **Testing** below.

**Per-site rollout (separate task, not this PR).** For geo-IP to actually work on a site, author a real `placeholders-geo-ip.json` (`en`/`fr` tabs, home-market column first; every `-geo-ip` key also has a base value in that site's `placeholders.json`). Federal gnav reads `…/globalnav/placeholders-geo-ip.json` — author that before any gnav `-geo-ip` keys resolve. See the [Geo-IP Placeholders authoring guide](https://wiki.corp.adobe.com/spaces/marketingtech/pages/3865547890/Geo-IP+Placeholders) for how to author the sheet. The EN phone-number rollout is tracked in [DOTCOM-195048](https://jira.corp.adobe.com/browse/DOTCOM-195048) — real geo-IP phone numbers across the 60 en-fallback / umbrella geos for the 9/15 release.


### What changed
* **One sheet per repo** instead of a fetch per geo-locale. Rows are keys, columns are markets (uppercase ISO country code, e.g. `US`, `AR`; `UK` for GB), and each lingo site is a tab (`?sheet=<siteKey>`). The visitor's market column is flattened to `{ key: value }` at parse time.
* **Resolves in the first, awaited placeholder pass** — the old default-then-async-upgrade (`deferGeoIpUpdate`) is deleted. Because `decoratePlaceholders` is awaited before `loadBlock`, the final geo value is written once, before a merch card serializes its DOM. This removes the root cause of DOTCOM-193971 rather than patching it.
* **Page-load hoist** (`hoistGeoIpSheet` in `utils.js`) starts the sheet fetch at `loadArea` on `lingoActive()` pages at `priority: 'low'`, and `getGeoIpColumnPlaceholders` reuses that in-flight response — so the fetch doesn't serially block the LCP image. The hoist URL needs no country (the column is picked at parse time).
* **Country = detected market** (`resolveDetectedMarketCountry`: param → cookie → IMS → geo), matching MEP `country` targeting and MAS pricing, so geo-IP strings never contradict the market a signed-in user is targeted/priced as.
* **C2 / federal gnav** points at a separate, federal-owned sheet via a `source` arg (`…/globalnav/placeholders-geo-ip.json`); milo resolves it and hands federal the map. Until that file is authored, gnav geo-IP 404s → base (graceful).

### Fallback contract (documented in code)
Per token: MEP override → visitor's market column → the tab's first value column (home-market default) → the base key in the normal `placeholders.json`. Two authoring rules this depends on: each tab must be authored **home-market column first**, and every `-geo-ip` key must also have a **base row in `placeholders.json`** (else it degrades to `keyToStr` text). A `?sheet=<tab>` that 404s leaves geo-IP inert for that site (tokens keep their base) — intended; an `en`-tab fallback would leak English onto a non-English site.

### Follow-ups (not in this PR)
* After this merges and deploys, remove the “pending release” banner from the [authoring doc](https://wiki.corp.adobe.com/spaces/marketingtech/pages/3865547890/Geo-IP+Placeholders).
* Positional first-column default is a silent contract (column reorder changes fallbacks) — consider a named `default` column.
* No `supported-markets.json` gate; column presence is the de-facto market list. Reintroducing `isSupportedMarket` would re-tie placeholders to the pricing market set — but it adds a cold-cache fetch dependency on `supported-markets.json`, which for an LCP-section geo token could serialize onto the LCP critical path. Note `preloadMarketsConfig()` already HTTP-preloads that file at `loadArea` (gated on `languageBanner`/`mas-geo-detection`), and it was measured deduping cleanly with `getMarketConfig`'s `fetch` on creativecloud.html (single network request), so the fix is to reuse/extend that preload — widen its gate to these pages — **not** add a fresh hoist. Keep any `config.marketsConfig` population after `checkForPageMods()` so a MEP `updatemetadata` rewrite of `marketssource` isn't clobbered.

Resolves: [MWPW-203651](https://jira.corp.adobe.com/browse/MWPW-203651)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://MWPW-203651-geoip-placeholders--milo--adobecom.aem.page/?martech=off

**Testing**
- Unit: `test/features/placeholders/placeholders.test.js` (21 pass) — country→column, `gb`→`UK`, first-column fallback, base-key omission, MEP override, C2 federal `source` sheet.
- Manual: `/fr` resolves `?sheet=fr`; `?country=<code>` / `?akamaiLocale=<code>` override detection on preview (Akamai geo isn't active on `.page`/`.live`).
- Merch cards resolve the temp geo value (DOTCOM-193971 repro, key `annual-paid-monthly-geo-ip`, IL): https://www.stage.adobe.com/products/illustrator/wallpaper-maker.html?akamaiLocale=IL&milolibs=MWPW-203651-geoip-placeholders&langfirst=on
- Geo-IP token authored directly in the LCP section (no MEP), Photoshop copy (temp demo page): https://main--da-cc--adobecom.aem.page/drafts/markp/photoshop-my-copy?milolibs=MWPW-203651-geoip-placeholders&env=prod&langfirst=on
- Worst case — MEP swaps a fragment carrying a `-geo-ip` token into the LCP section; the card resolves from the da-cc `placeholders-geo-ip.json` (temp columns) with no default→geo flash from the removed deferred pass. Creative Cloud copy, SG (temp demo page): https://main--da-cc--adobecom.aem.page/drafts/markp/creativecloud-my-copy?langfirst=on&milolibs=MWPW-203651-geoip-placeholders&env=prod&akamaiLocale=sg









