### PR TITLE
[DOTCOM-195142][DOTCOM-195241] Hub Hero on Firefox

### DIFF
--- a/libs/mep/ace1209/hub-hero/hub-hero.css
+++ b/libs/mep/ace1209/hub-hero/hub-hero.css
@@ -399,7 +399,7 @@
 .hub-hero.slides-3 {
   --slides: 3;
   --elastic-mobile-first-slide-offset: -240px;
-  
+
 
   .hub-hero-carousel-item-media {
     position: relative;
@@ -831,7 +831,7 @@
     padding: var(--s2a-spacing-lg);
     text-align: start;
   }
-  
+
   .hub-hero-carousel-item-media {
     --width: min(var(--media-mobile-max-width), calc(100vw - var(--s2a-spacing-lg)));
     --carousel-item-media-height: calc(var(--width) * .8);
@@ -1857,6 +1857,7 @@
 
   .hub-hero {
     --carousel-items-top: 15%;
+    --slide-max-width: var(--hub-hero-carousel-item-max-width);
   }
 
   .hub-hero-image-grid-container,
@@ -1904,12 +1905,6 @@
       animation: none;
     }
 
-    .hub-hero-carousel-container {
-      animation: none;
-      width: 100%;
-      max-width: 550px;
-    }
-
     .hub-hero-carousel-item-container .hub-hero-carousel-item-footer,
     .hub-hero-carousel-item-container .hub-hero-carousel-item-header {
       position: relative;
@@ -1947,7 +1942,9 @@
     }
 
     .hub-hero-carousel-container {
-      max-width: var(--slide-max-width);
+      animation: none;
+      width: 100%;
+      max-width: 550px;
       min-width: var(--hub-hero-carousel-item-min-width);
       display: flex;
       flex-direction: column;
@@ -1956,6 +1953,12 @@
 
     .hub-hero-carousel-item-container .hub-hero-carousel-item-footer {
       height: var(--slide-footer-h);
+    }
+  }
+
+  @media (width >= 768px) {
+    .hub-hero {
+      padding-bottom: calc(var(--slide-footer-h) + var(--s2a-spacing-2xl));
     }
   }
 }


### PR DESCRIPTION
This contains some minor adjustments to improve the Hub Hero's appearance on Firefox browsers. All fixes are contained within `@supports not (animation-timeline: view())`, since the issues occur only when animations can't run.

Resolves: [DOTCOM-195142](https://jira.corp.adobe.com/browse/MWPW-195142), [DOTCOM-195241](https://jira.corp.adobe.com/browse/MWPW-195241)

**Test URLs:**
- Before: https://www.stage.adobe.com/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://www.stage.adobe.com/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-hub?milolibs=hub-hero-firefox&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all


