### PR TITLE
MWPW-205872 Log hidden required Marketo field

### DIFF
--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -220,6 +220,10 @@
   content: '*';
 }
 
+.mktoHidden:has(.mktoRequired) {
+    display: block !important;
+}
+
 .marketo .mktoForm .mktoField {
   width: 100%!important;
   padding: 9px var(--spacing-xs);

--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -36,6 +36,7 @@ export const LANA_MESSAGE = {
   RENDER_RECOVERED: 'Marketo form rendered after timeout',
   SUBMIT_FAILED: 'Marketo form submit failed',
   MARKETO_FORMS_JS: 'Marketo form failed to load forms2.min.js',
+  HIDDEN_REQUIRED_FIELD: 'Marketo form has a hidden field marked as required',
 };
 const FORM_ID = 'form id';
 const BASE_URL = 'marketo host';
@@ -122,6 +123,9 @@ export const getDataLayer = (key = '') => key
 export const formValidate = (formEl) => {
   formEl.classList.remove('hide-errors');
   formEl.classList.add('show-warnings');
+  if (formEl.querySelectorAll('.mktoHidden:has(.mktoRequired)').length) {
+    window.lana?.log(LANA_MESSAGE.HIDDEN_REQUIRED_FIELD, { tags: 'marketo', severity: 'w', sampleRate: 100 });
+  }
 };
 
 export const decorateURL = async (destination, baseURL = window.location) => {
@@ -283,13 +287,11 @@ export const logFailure = (el, msg) => {
   decorateOverlay(el, `${msg}: ${tags.join(', ')}`, () => { window.location.reload(); });
 };
 
-export const formTimeout = (el, condition, message, timeout = FAILURE_TIMEOUT) => {
-  setTimeout(() => {
-    if (condition()) {
-      logFailure(el, message);
-    }
-  }, timeout);
-};
+export const formTimeout = (el, condition, message, timeout = FAILURE_TIMEOUT) => setTimeout(() => {
+  if (condition()) {
+    logFailure(el, message);
+  }
+}, timeout);
 
 const toggleSuccessSection = (formData) => {
   showSuccessSection(formData);
@@ -300,7 +302,7 @@ export const formSubmit = (formEl) => {
   const el = formEl.closest('.marketo');
   const testRecord = window.mkto_isTestRecord?.();
   if (testRecord && testRecord !== 'not_test') return;
-  formTimeout(el, () => !el.classList.contains('success'), LANA_MESSAGE.SUBMIT_FAILED);
+  el.dataset.submitTimeoutId = formTimeout(el, () => !el.classList.contains('success'), LANA_MESSAGE.SUBMIT_FAILED);
 };
 
 export const formSuccess = (formEl, formData) => {
@@ -308,6 +310,7 @@ export const formSuccess = (formEl, formData) => {
   const parentModal = formEl?.closest('.dialog-modal');
   const mktoSubmit = new Event('mktoSubmit');
 
+  clearTimeout(el.dataset.submitTimeoutId);
   el.classList.add('success');
   window.dispatchEvent(mktoSubmit);
   window.mktoSubmitted = true;

--- a/test/blocks/marketo/marketo.test.js
+++ b/test/blocks/marketo/marketo.test.js
@@ -9,6 +9,7 @@ import init, {
   decorateURL,
   formSuccess,
   formSubmit,
+  formValidate,
   loadMarketo,
   logFailure,
   formTimeout,
@@ -398,6 +399,43 @@ describe('Marketo failure logging', () => {
       el.classList.add('success');
       formSubmit(el.querySelector('form'));
       await tick(FAILURE_TIMEOUT);
+
+      expect(window.lana.log.called).to.be.false;
+    });
+
+    it('cancels the pending submit-failure timeout once formSuccess runs', async () => {
+      buildBlock();
+      const formEl = el.querySelector('form');
+      formSubmit(formEl);
+      formSuccess(formEl, {});
+      await tick(FAILURE_TIMEOUT);
+
+      expect(window.lana.log.calledWith(LANA_MESSAGE.SUBMIT_FAILED)).to.be.false;
+    });
+  });
+
+  describe('formValidate', () => {
+    it('logs a warning when a hidden field is marked required', () => {
+      buildBlock();
+      const formEl = el.querySelector('form');
+      const hiddenField = document.createElement('div');
+      hiddenField.className = 'mktoHidden';
+      hiddenField.innerHTML = '<input class="mktoRequired">';
+      formEl.appendChild(hiddenField);
+
+      formValidate(formEl);
+
+      expect(window.lana.log.calledWith(
+        LANA_MESSAGE.HIDDEN_REQUIRED_FIELD,
+        sinon.match({ severity: 'w', sampleRate: 100 }),
+      )).to.be.true;
+    });
+
+    it('does not log when no hidden fields are marked required', () => {
+      buildBlock();
+      const formEl = el.querySelector('form');
+
+      formValidate(formEl);
 
       expect(window.lana.log.called).to.be.false;
     });


### PR DESCRIPTION
* Log hidden required Marketo field to identify race condition
* Show hidden field to allow visitors to still submit the form instead of hard lock
* Fix form timeout after successful submit 

Resolves: [MWPW-205872](https://jira.corp.adobe.com/browse/MWPW-205872)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bmarshal-log-required--milo--adobecom.aem.page/?martech=off

**ACOM:**
- Before: https://www.stage.adobe.com/ae_ar/products/substance3d/request-information.html
- After: https://www.stage.adobe.com/ae_ar/products/substance3d/request-information.html?milolibs=bmarshal-log-required

**BACOM:**
- Before: https://business.stage.adobe.com/de/products/adobe-analytics.html
- After: https://business.stage.adobe.com/de/products/adobe-analytics.html?milolibs=bmarshal-log-required

