### PR TITLE
[SR] Correct double negtative margins being applied sections with rounded corners

### DIFF
--- a/libs/mep/ace1209/offer-hero/offer-hero.css
+++ b/libs/mep/ace1209/offer-hero/offer-hero.css
@@ -10,7 +10,7 @@
 
   > .section-background {
     overflow: clip;
-    border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
+    border-radius: 0 0 var(--s2a-border-radius-22) var(--s2a-border-radius-22);
   }
 }
 
@@ -360,6 +360,12 @@
 }
 
 @media (width >= 1280px) {
+  .section.rounded-corners-bottom:has(.offer-hero):not(.parallax-move-up-fast):not(.parallax-garage-door-reveal) {
+    > .section-background {
+      border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
+    }
+  }
+
   .offer-hero {
     .hero-content {
       padding-inline: 120px;

--- a/libs/mep/ace1209/section-metadata/section-metadata.css
+++ b/libs/mep/ace1209/section-metadata/section-metadata.css
@@ -127,7 +127,7 @@ body:has(header.local-nav) .section.bento.stack-mobile {
   &.rounded-corners-top,
   &.rounded-corners-bottom {
     /* TODO: Replace the primative border-radius tokens with the semantic one
-      once the stale adoptive-styles are removed or updated */
+      once the stale adoptive-styles are removed or updated  */
     border-radius: var(--s2a-border-radius-22);
     overflow: clip;
     z-index: 3;
@@ -136,7 +136,7 @@ body:has(header.local-nav) .section.bento.stack-mobile {
 
   &.rounded-corners-top {
     border-radius: var(--s2a-border-radius-22) var(--s2a-border-radius-22) 0 0;
-    margin-bottom: initial;
+    margin-block: calc(-1 * var(--s2a-border-radius-22)) auto;
   }
 
   /* Fix to remove blank gap caused by rounded-corners :before/:after
@@ -159,7 +159,7 @@ body:has(header.local-nav) .section.bento.stack-mobile {
 
   &.rounded-corners-bottom {
     border-radius: 0 0 var(--s2a-border-radius-22) var(--s2a-border-radius-22);
-    margin-top: initial;
+    margin-block: auto calc(-1 * var(--s2a-border-radius-22));
   }
 
   /* Fix for consecutive rounded corner sections in order
@@ -624,6 +624,7 @@ body:has(header.local-nav) .section.bento.stack-mobile {
 
     &.rounded-corners-top {
       border-radius: var(--s2a-border-radius-xl) var(--s2a-border-radius-xl) 0 0;
+      margin-block: calc(-1 * var(--s2a-border-radius-xl)) auto;
     }
 
     &:has(+ .rounded-corners)::after,
@@ -636,6 +637,7 @@ body:has(header.local-nav) .section.bento.stack-mobile {
 
     &.rounded-corners-bottom {
       border-radius: 0 0 var(--s2a-border-radius-xl) var(--s2a-border-radius-xl);
+      margin-block: auto calc(-1 * var(--s2a-border-radius-xl));
     }
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Remove double negative margins being applied to `rounded-corners-top` and `rounded-corners-bottom`. This fixes a spacing issue for adjacent sections not respecting the spacing token applied. 
* House cleaning - updated `offer-hero` rounded corners for sections (this was missed with the token update) and causing a minor visual issue on tablet with out this fix in place.


Resolves: [MWPW-205587](https://jira.corp.adobe.com/browse/MWPW-205587)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all#plans
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=sr-rounded-corners-double-margin&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all#plans

Before:
<img width="1449" height="315" alt="image" src="https://github.com/user-attachments/assets/134d76d8-1d1e-4216-99fd-c71ccacbafb5" />

After:
<img width="1461" height="336" alt="image" src="https://github.com/user-attachments/assets/4155e1e2-0f79-4dce-921b-2eec299efc63" />


