### PR TITLE
fix(c2-modal): don't force focus ring on CTA when modal opened by mouse click

### DIFF
--- a/libs/c2/blocks/modal/modal.js
+++ b/libs/c2/blocks/modal/modal.js
@@ -181,11 +181,18 @@ export async function getModal(details, custom) {
   const { id, deepLink } = details || custom;
   if (id !== LOCALE_MODAL_ID) isDeepLink = deepLink;
   const activeElementData = document.activeElement.dataset;
-  if (!isDeepLink
-    && (activeElementData.modalHash === `#${id}`
-    || activeElementData.modalId === id)
-  ) {
+  const isConfirmedTrigger = !isDeepLink
+    && (activeElementData.modalHash === `#${id}` || activeElementData.modalId === id);
+  if (isConfirmedTrigger) {
     document.activeElement.dataset.isModalTrigger = 'true';
+  }
+  let openedViaKeyboard = true;
+  if (isConfirmedTrigger) {
+    try {
+      openedViaKeyboard = document.activeElement.matches(':focus-visible');
+    } catch (e) {
+      openedViaKeyboard = true;
+    }
   }
 
   dialogLoadingSet.add(id);
@@ -259,7 +266,7 @@ export async function getModal(details, custom) {
   dialog.append(focusPlaceholder);
   document.body.append(dialog);
   dialogLoadingSet.delete(id);
-  firstFocusable?.focus({ preventScroll: true, ...focusVisible });
+  firstFocusable?.focus({ preventScroll: true, focusVisible: openedViaKeyboard });
   window.dispatchEvent(loadedEvent);
 
   if (!dialog.classList.contains('curtain-off')) {


### PR DESCRIPTION
## Summary
- Ports the `openedViaKeyboard` fix already shipped in the main Milo modal (`libs/blocks/modal/modal.js`, #6320) into the shared C2 modal (`libs/c2/blocks/modal/modal.js`), which never received it.
- Mouse-triggered modal opens no longer force a visible focus ring on the first focusable element (e.g. the close button); keyboard-triggered opens still show it correctly.

Split out of #6441 per review feedback — this changes `getModal()` behavior for every C2 block that opens a modal, not just `email-collection-c2`, so it warrants review on its own.

Resolves: [MWPW-194884](https://jira.corp.adobe.com/browse/MWPW-194884)

## Test plan
- [ ] Open a C2-block-triggered modal via mouse click; confirm no focus ring appears on the close button/first focusable element
- [ ] Open the same modal via keyboard (Enter/Space on the trigger); confirm the focus ring still appears
- [ ] Deep-link/auto-shown modal opens still show the focus ring by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

