### PR TITLE
DOTCOM-193553 App Name List Is Truncated in Interactive Blade

### DIFF
--- a/libs/mep/ace1209/roller-carousel/roller-carousel.css
+++ b/libs/mep/ace1209/roller-carousel/roller-carousel.css
@@ -362,7 +362,11 @@ body:has(header.local-nav) .roller-carousel {
       max-width: 1920px;
       margin-inline: auto;
     }
+  }
+}
 
+@media (width >= 1600px) {
+  .roller-carousel {
     .rcc-item {
       font-size: var(--s2a-typography-font-size-super);
       line-height: var(--s2a-typography-line-height-super);


### PR DESCRIPTION
App Name List Is Truncated in Interactive Blade

Resolves: [DOTCOM-193553](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all#legal-tour
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=rc-super&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all#legal-tour


