### PR TITLE
Adjusts the glass-border varaint border-radius per breakpoint.

### DIFF
--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -586,7 +586,7 @@
     background: var(--glass-fill);
     background-clip: padding-box;
     box-shadow: inset 0 0 0 var(--glass-stroke) var(--glass-fill);
-    border-radius: var(--s2a-border-radius-16);
+    border-radius: var(--s2a-border-radius-8);
     backdrop-filter: blur(var(--s2a-blur-md));
     overflow: hidden;
 
@@ -594,6 +594,10 @@
       --glass-frame-width: 6.5px;
       --glass-stroke: 1px;
       box-sizing: unset;
+    }
+
+    @media (width >= 1024px) {
+      border-radius: var(--s2a-border-radius-16);
     }
 
     @media (width >= 1280px) {
@@ -608,7 +612,11 @@
 
     :is(img, video) {
       max-width: 100%;
-      border-radius: var(--s2a-border-radius-8);
+      border-radius: var(--s2a-border-radius-4);
+
+      @media (width >= 1024px) {
+        border-radius: var(--s2a-border-radius-8);
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Adjusts the `rich-content` blocks `glass-border` variant `border-radius` per breakpoint.
* `Video-container/picture` `border-radius`: **Mobile/Tablet** =  8px - **Desktop** = 16px
* `video/image` `border-radius`: **Mobile/tablet =** 4px - **Desktop =** 8px


Resolves:
[DOTCOM-194327](https://jira.corp.adobe.com/browse/DOTCOM-194327)
[MWPW-201092](https://jira.corp.adobe.com/browse/MWPW-201092)

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=sr-rc-glass-border-corners&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

Specs for this highlighted in green:
<img width="2108" height="1284" alt="image" src="https://github.com/user-attachments/assets/bec3f35a-d418-4d52-9e3e-149ccb66c850" />


