### PR TITLE
VULN-38270: Validate repo/owner and pin sharepoint.site to Adobe's Graph host

### DIFF
--- a/libs/blocks/library-config/library-config.js
+++ b/libs/blocks/library-config/library-config.js
@@ -1,4 +1,4 @@
-import { createTag, SLD } from '../../utils/utils.js';
+import { createTag, getValidatedRepoOwnerOrigin } from '../../utils/utils.js';
 
 const LIBRARY_PATH = '/docs/library/library.json';
 
@@ -140,13 +140,32 @@ async function fetchLibrary(domain, suppliedLibrary) {
   }
 }
 
+/**
+ * Restricts `library` to the validated repo/owner origin so it can't point
+ * at an arbitrary third-party host (VULN-38270).
+ * @param {string} library raw `library` query parameter value
+ * @param {string} domain validated repo/owner origin
+ * @returns {string|null} the resolved library URL, or null if unsafe/absent
+ */
+export function getValidatedSuppliedLibrary(library, domain) {
+  if (!library) return null;
+  let url;
+  try {
+    url = new URL(library, domain);
+  } catch {
+    return null;
+  }
+  return url.origin === domain ? url.href : null;
+}
+
 async function getSuppliedLibrary() {
   const { searchParams } = new URL(window.location.href);
   const repo = searchParams.get('repo');
   const owner = searchParams.get('owner');
   const library = searchParams.get('library');
-  if (!repo || !owner) return null;
-  return fetchLibrary(`https://main--${repo}--${owner}.${SLD}.live`, library);
+  const domain = getValidatedRepoOwnerOrigin(repo, owner);
+  if (!domain) return null;
+  return fetchLibrary(domain, getValidatedSuppliedLibrary(library, domain));
 }
 
 async function fetchAssetsData(path) {

--- a/libs/blocks/path-finder/path-finder.js
+++ b/libs/blocks/path-finder/path-finder.js
@@ -2,7 +2,7 @@ import login from '../../tools/sharepoint/login.js';
 import { account } from '../../tools/sharepoint/state.js';
 import getServiceConfig from '../../utils/service-config.js';
 import { getReqOptions } from '../../tools/sharepoint/msal.js';
-import { createTag } from '../../utils/utils.js';
+import { createTag, getValidatedSharePointSite } from '../../utils/utils.js';
 
 const SCOPES = ['files.readwrite', 'sites.readwrite.all'];
 const TELEMETRY = { application: { appName: 'Milo - Path Finder' } };
@@ -15,9 +15,11 @@ const getSharePointDetails = (() => {
   return async () => {
     if (site && driveId && reqOpts) return { site, driveId, reqOpts };
 
-    // Fetching SharePoint details
+    // `sharepoint.site` is where the Bearer token below gets sent, so it must
+    // resolve to Adobe's real Graph host (VULN-38270).
     const { sharepoint } = await getServiceConfig();
-    ({ site } = sharepoint);
+    site = getValidatedSharePointSite(sharepoint.site);
+    if (!site) throw new Error('Could not verify SharePoint site.');
     driveId = sharepoint.driveId ? `drives/${sharepoint.driveId}` : 'drive';
     reqOpts = getReqOptions();
 

--- a/libs/blocks/version-history/index.js
+++ b/libs/blocks/version-history/index.js
@@ -7,17 +7,10 @@ import {
   showLogin,
 } from './state.js';
 import { getVersions, createVersion } from '../../tools/sharepoint/version.js';
+import { getSiteOrigin } from '../../utils/service-config.js';
 
 const TELEMETRY = { application: { appName: 'Adobe Version History' } };
 const CREATE_ERROR = 'Error creating version.';
-
-function getSiteOrigin() {
-  const search = new URLSearchParams(window.location.search);
-  const repo = search.get('repo');
-  const owner = search.get('owner');
-
-  return repo && owner ? `https://main--${repo}--${owner}.aem.live` : window.location.origin;
-}
 
 function getItemId() {
   const referrer = new URLSearchParams(window.location.search).get('referrer');

--- a/libs/tools/sharepoint/version.js
+++ b/libs/tools/sharepoint/version.js
@@ -1,5 +1,5 @@
 import getServiceConfig from '../../utils/service-config.js';
-import { getValidatedSharePointSite } from '../../utils/utils.js';
+import { getValidatedSharePointSite, ADOBE_SHAREPOINT_HOSTNAME } from '../../utils/utils.js';
 import { getReqOptions } from './msal.js';
 import login from './login.js';
 
@@ -27,9 +27,9 @@ async function getSharePointDetails(hlxOrigin) {
   // so it must resolve to Adobe's real host (VULN-38270).
   const site = getValidatedSharePointSite(sharepoint.site);
   if (!site) throw new Error('Could not verify SharePoint site.');
-  const spSiteHostname = site.split(',')[0].split('/').pop();
+  // site is already pinned to ADOBE_SHAREPOINT_HOSTNAME, so no need to parse it back out.
   return {
-    origin: `https://${spSiteHostname}`,
+    origin: `https://${ADOBE_SHAREPOINT_HOSTNAME}`,
     siteId: sharepoint.siteId,
     site,
     driveId: sharepoint.driveId ? `drives/${sharepoint.driveId}` : 'drive',

--- a/libs/tools/sharepoint/version.js
+++ b/libs/tools/sharepoint/version.js
@@ -1,4 +1,5 @@
 import getServiceConfig from '../../utils/service-config.js';
+import { getValidatedSharePointSite } from '../../utils/utils.js';
 import { getReqOptions } from './msal.js';
 import login from './login.js';
 
@@ -22,11 +23,15 @@ async function loginToSharePoint(origin, telemetry) {
 
 async function getSharePointDetails(hlxOrigin) {
   const { sharepoint } = await getServiceConfig(hlxOrigin);
-  const spSiteHostname = sharepoint.site.split(',')[0].split('/').pop();
+  // `sharepoint.site` feeds the Graph fetch and SharePoint REST origin below,
+  // so it must resolve to Adobe's real host (VULN-38270).
+  const site = getValidatedSharePointSite(sharepoint.site);
+  if (!site) throw new Error('Could not verify SharePoint site.');
+  const spSiteHostname = site.split(',')[0].split('/').pop();
   return {
     origin: `https://${spSiteHostname}`,
     siteId: sharepoint.siteId,
-    site: sharepoint.site,
+    site,
     driveId: sharepoint.driveId ? `drives/${sharepoint.driveId}` : 'drive',
   };
 }

--- a/libs/utils/service-config.js
+++ b/libs/utils/service-config.js
@@ -2,18 +2,22 @@
  * Get author-facing config options.
  */
 
-import { getConfig, SLD } from './utils.js';
+import { getConfig, getValidatedRepoOwnerOrigin } from './utils.js';
 
 const DOT_MILO = '/.milo/config.json';
 
 let config;
 
-/* c8 ignore next 6 */
-function getSiteOrigin() {
+/**
+ * Resolves the origin to fetch the service config from. Falls back to the
+ * current origin when `repo`/`owner` are absent, or do not resolve to a
+ * safe *.aem.live host (VULN-38270).
+ */
+export function getSiteOrigin() {
   const search = new URLSearchParams(window.location.search);
   const repo = search.get('repo');
   const owner = search.get('owner');
-  return repo && owner ? `https://main--${repo}--${owner}.${SLD}.live` : window.location.origin;
+  return getValidatedRepoOwnerOrigin(repo, owner) || window.location.origin;
 }
 
 /**

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2734,17 +2734,19 @@ export function getValidatedRepoOwnerOrigin(repo, owner) {
   ) return null;
   let url;
   try {
-    url = new URL(`https://main--${cleanRepo}--${cleanOwner}.aem.live`);
+    url = new URL(`https://main--${cleanRepo}--${cleanOwner}.${SLD}.live`);
   } catch {
     // stricter URL parsers (e.g. Node) reject invalid punycode labels
     return null;
   }
-  if (!url.hostname.endsWith('.aem.live')) return null;
+  if (!url.hostname.endsWith(`.${SLD}.live`)) return null;
   return url.origin;
 }
 
+export const ADOBE_SHAREPOINT_HOSTNAME = 'adobe.sharepoint.com';
+const ESCAPED_SHAREPOINT_HOSTNAME = ADOBE_SHAREPOINT_HOSTNAME.replace(/\./g, '\\.');
 const GUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
-const GRAPH_SHAREPOINT_SITE_PATTERN = new RegExp(`^https://graph\\.microsoft\\.com/v1\\.0/sites/adobe\\.sharepoint\\.com,${GUID_PATTERN},${GUID_PATTERN}$`);
+const GRAPH_SHAREPOINT_SITE_PATTERN = new RegExp(`^https://graph\\.microsoft\\.com/v1\\.0/sites/${ESCAPED_SHAREPOINT_HOSTNAME},${GUID_PATTERN},${GUID_PATTERN}$`);
 
 /**
  * Pins `sharepoint.site` to Adobe's real Graph/SharePoint host, since

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2743,6 +2743,20 @@ export function getValidatedRepoOwnerOrigin(repo, owner) {
   return url.origin;
 }
 
+const GUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+const GRAPH_SHAREPOINT_SITE_PATTERN = new RegExp(`^https://graph\\.microsoft\\.com/v1\\.0/sites/adobe\\.sharepoint\\.com,${GUID_PATTERN},${GUID_PATTERN}$`);
+
+/**
+ * Pins `sharepoint.site` to Adobe's real Graph/SharePoint host, since
+ * repo/owner validation alone can't guarantee a config isn't attacker-owned (VULN-38270).
+ * @param {string} site raw `sharepoint.site` config value
+ * @returns {string|null} the validated site value, or null if unsafe
+ */
+export function getValidatedSharePointSite(site) {
+  if (typeof site !== 'string') return null;
+  return GRAPH_SHAREPOINT_SITE_PATTERN.test(site) ? site : null;
+}
+
 const MASLIBS_PATTERN = /^([a-z0-9]+(-[a-z0-9]+)*)(--([a-z0-9]+(-[a-z0-9]+)*)){0,2}$/;
 const MASLIBS_MAX_LENGTH = 100;
 

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2710,6 +2710,39 @@ export function partition(arr, fn) {
   );
 }
 
+const AEM_HOST_SEGMENT_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+const AEM_HOST_SEGMENT_MAX_LENGTH = 63;
+
+/**
+ * Validates a repo/owner pair intended for use in an *.aem.live host and
+ * returns the resulting origin, or null if either value is missing or does
+ * not look like a safe AEM repo/owner segment. Guards against arbitrary host
+ * injection via the `repo`/`owner` query params (VULN-38270).
+ * @param {string} repo raw repo query parameter value
+ * @param {string} owner raw owner query parameter value
+ * @returns {string|null} origin, or null if repo/owner are missing or invalid
+ */
+export function getValidatedRepoOwnerOrigin(repo, owner) {
+  if (!repo || !owner) return null;
+  const cleanRepo = repo.trim().toLowerCase();
+  const cleanOwner = owner.trim().toLowerCase();
+  if (
+    cleanRepo.length > AEM_HOST_SEGMENT_MAX_LENGTH
+    || cleanOwner.length > AEM_HOST_SEGMENT_MAX_LENGTH
+    || !AEM_HOST_SEGMENT_PATTERN.test(cleanRepo)
+    || !AEM_HOST_SEGMENT_PATTERN.test(cleanOwner)
+  ) return null;
+  let url;
+  try {
+    url = new URL(`https://main--${cleanRepo}--${cleanOwner}.aem.live`);
+  } catch {
+    // stricter URL parsers (e.g. Node) reject invalid punycode labels
+    return null;
+  }
+  if (!url.hostname.endsWith('.aem.live')) return null;
+  return url.origin;
+}
+
 const MASLIBS_PATTERN = /^([a-z0-9]+(-[a-z0-9]+)*)(--([a-z0-9]+(-[a-z0-9]+)*)){0,2}$/;
 const MASLIBS_MAX_LENGTH = 100;
 

--- a/test/blocks/library-config/library-config.test.js
+++ b/test/blocks/library-config/library-config.test.js
@@ -176,3 +176,44 @@ describe('Library Config: containers', () => {
     expect(isMatching(containers[4], 'tag4', 'blocks')).to.be.true;
   });
 });
+
+describe('Library Config: getValidatedSuppliedLibrary (VULN-38270)', () => {
+  const DOMAIN = 'https://main--milo--adobecom.aem.live';
+  let getValidatedSuppliedLibrary;
+
+  before(async () => {
+    ({ getValidatedSuppliedLibrary } = await import('../../../libs/blocks/library-config/library-config.js'));
+  });
+
+  it('returns null when library is absent', () => {
+    expect(getValidatedSuppliedLibrary(null, DOMAIN)).to.be.null;
+    expect(getValidatedSuppliedLibrary('', DOMAIN)).to.be.null;
+  });
+
+  it('resolves a relative path against the validated domain', () => {
+    expect(getValidatedSuppliedLibrary('/custom/library.json', DOMAIN))
+      .to.equal('https://main--milo--adobecom.aem.live/custom/library.json');
+  });
+
+  it('accepts an absolute URL that matches the validated domain', () => {
+    expect(getValidatedSuppliedLibrary(`${DOMAIN}/custom/library.json`, DOMAIN))
+      .to.equal('https://main--milo--adobecom.aem.live/custom/library.json');
+  });
+
+  it('rejects an absolute URL pointing at a different host (arbitrary-fetch payload)', () => {
+    expect(getValidatedSuppliedLibrary('https://attacker.example/evil.json', DOMAIN)).to.be.null;
+    expect(getValidatedSuppliedLibrary('https://main--evil--x.aem.live/library.json', DOMAIN)).to.be.null;
+  });
+
+  it('rejects a protocol-relative URL that resolves off the validated domain', () => {
+    expect(getValidatedSuppliedLibrary('//attacker.example/evil.json', DOMAIN)).to.be.null;
+  });
+
+  it('does not throw on malformed payloads', () => {
+    // eslint-disable-next-line no-script-url -- payload must prove script URLs are rejected
+    const payloads = ['javascript:alert(1)', '//attacker.example/evil.json', 'not a url either'];
+    payloads.forEach((library) => {
+      expect(() => getValidatedSuppliedLibrary(library, DOMAIN), library).to.not.throw();
+    });
+  });
+});

--- a/test/tools/sharepoint/mocks/malicious/.milo/config.json
+++ b/test/tools/sharepoint/mocks/malicious/.milo/config.json
@@ -1,0 +1,22 @@
+{
+  "configs": {
+    "total": 2,
+    "offset": 0,
+    "limit": 2,
+    "data": [
+      {
+        "key": "prod.sharepoint.site",
+        "value": "https://attacker-collector.example",
+        "Comments": ""
+      },
+      {
+        "key": "prod.sharepoint.driveId",
+        "value": "attacker-drive-id",
+        "Comments": ""
+      }
+    ]
+  },
+  ":version": 3,
+  ":names": ["configs"],
+  ":type": "multi-sheet"
+}

--- a/test/tools/sharepoint/version.test.js
+++ b/test/tools/sharepoint/version.test.js
@@ -1,0 +1,35 @@
+import { expect } from '@esm-bundle/chai';
+import { getVersions, createVersion } from '../../../libs/tools/sharepoint/version.js';
+
+// getServiceConfig() memoizes per session, so only one sharepoint.site value
+// can be tested here; the "valid site" case is covered in getValidatedSharePointSite.test.js.
+const MALICIOUS_ORIGIN = 'http://localhost:2000/test/tools/sharepoint/mocks/malicious';
+
+describe('version.js SharePoint site validation (VULN-38270)', () => {
+  before(async () => {
+    const { setConfig } = await import('../../../libs/utils/utils.js');
+    setConfig({ codeRoot: '/libs', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
+  });
+
+  it('getVersions rejects a config whose sharepoint.site does not resolve to Adobe\'s Graph/SharePoint host', async () => {
+    let error;
+    try {
+      await getVersions({}, MALICIOUS_ORIGIN, 'some-item-id');
+    } catch (err) {
+      error = err;
+    }
+    expect(error).to.exist;
+    expect(error.message).to.equal('Could not verify SharePoint site.');
+  });
+
+  it('createVersion rejects the same malicious config before any SharePoint call is made', async () => {
+    let error;
+    try {
+      await createVersion(MALICIOUS_ORIGIN, 'some-item-id', 'a comment');
+    } catch (err) {
+      error = err;
+    }
+    expect(error).to.exist;
+    expect(error.message).to.equal('Could not verify SharePoint site.');
+  });
+});

--- a/test/utils/getValidatedRepoOwnerOrigin.test.js
+++ b/test/utils/getValidatedRepoOwnerOrigin.test.js
@@ -1,0 +1,62 @@
+import { expect } from '@esm-bundle/chai';
+import { getValidatedRepoOwnerOrigin } from '../../libs/utils/utils.js';
+
+describe('getValidatedRepoOwnerOrigin', () => {
+  it('returns null when repo or owner is missing', () => {
+    expect(getValidatedRepoOwnerOrigin(null, 'adobecom')).to.be.null;
+    expect(getValidatedRepoOwnerOrigin('milo', null)).to.be.null;
+    expect(getValidatedRepoOwnerOrigin('', '')).to.be.null;
+  });
+
+  it('resolves a valid repo/owner pair to the matching aem.live origin', () => {
+    expect(getValidatedRepoOwnerOrigin('milo', 'adobecom'))
+      .to.equal('https://main--milo--adobecom.aem.live');
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(getValidatedRepoOwnerOrigin(' MILO ', ' AdobeCom '))
+      .to.equal('https://main--milo--adobecom.aem.live');
+  });
+
+  it('rejects host-escape payloads (VULN-38270)', () => {
+    const hostile = [
+      ['evil.com', 'adobecom'],
+      ['milo', 'evil.com'],
+      ['milo@evil.com', 'adobecom'],
+      ['milo', 'adobecom#evil.com'],
+      ['milo', 'adobecom:evil.com'],
+      ['milo/evil', 'adobecom'],
+      // eslint-disable-next-line no-script-url -- payload must prove script URLs are rejected
+      ['javascript:alert(1)', 'adobecom'],
+    ];
+    hostile.forEach(([repo, owner]) => {
+      expect(getValidatedRepoOwnerOrigin(repo, owner), `${repo} / ${owner}`).to.be.null;
+    });
+  });
+
+  it('rejects malformed repo/owner shapes', () => {
+    const malformed = [
+      ['-milo', 'adobecom'],
+      ['milo-', 'adobecom'],
+      ['milo', '-adobecom'],
+      ['mi--lo', 'adobecom'],
+      ['milo_test', 'adobecom'],
+      ['milo.test', 'adobecom'],
+    ];
+    malformed.forEach(([repo, owner]) => {
+      expect(getValidatedRepoOwnerOrigin(repo, owner), `${repo} / ${owner}`).to.be.null;
+    });
+  });
+
+  it('rejects overlong values', () => {
+    expect(getValidatedRepoOwnerOrigin('a'.repeat(100), 'adobecom')).to.be.null;
+    expect(getValidatedRepoOwnerOrigin('milo', 'a'.repeat(100))).to.be.null;
+  });
+
+  it('does not throw on invalid punycode-like labels', () => {
+    const payloads = [['xn--abc', 'adobecom'], ['milo', 'xn--a']];
+    payloads.forEach(([repo, owner]) => {
+      expect(() => getValidatedRepoOwnerOrigin(repo, owner), `${repo} / ${owner}`).to.not.throw();
+    });
+  });
+});

--- a/test/utils/getValidatedSharePointSite.test.js
+++ b/test/utils/getValidatedSharePointSite.test.js
@@ -1,0 +1,85 @@
+import { expect } from '@esm-bundle/chai';
+import { getValidatedSharePointSite } from '../../libs/utils/utils.js';
+
+// Real production shape, confirmed against
+// main--milo--adobecom.aem.live/.milo/config.json.
+const VALID_SITE = 'https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com,aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee,11111111-2222-3333-4444-555555555555';
+
+describe('getValidatedSharePointSite', () => {
+  it('returns null when site is missing', () => {
+    expect(getValidatedSharePointSite(null)).to.be.null;
+    expect(getValidatedSharePointSite(undefined)).to.be.null;
+    expect(getValidatedSharePointSite('')).to.be.null;
+  });
+
+  it('returns the site verbatim when it matches Adobe\'s Graph/SharePoint host', () => {
+    expect(getValidatedSharePointSite(VALID_SITE)).to.equal(VALID_SITE);
+  });
+
+  it('rejects a client-fetched config pointing straight at an attacker host (VULN-38270 PoC payload)', () => {
+    expect(getValidatedSharePointSite('https://attacker-collector.example')).to.be.null;
+    expect(getValidatedSharePointSite('https://webhook.site/00000000-0000-0000-0000-000000000000')).to.be.null;
+  });
+
+  it('rejects a Graph-shaped URL served from a non-Microsoft origin', () => {
+    expect(getValidatedSharePointSite(
+      'https://evil.com/v1.0/sites/adobe.sharepoint.com,aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee,11111111-2222-3333-4444-555555555555',
+    )).to.be.null;
+  });
+
+  it('rejects a real Graph origin pointed at a non-Adobe SharePoint tenant', () => {
+    expect(getValidatedSharePointSite(
+      'https://graph.microsoft.com/v1.0/sites/evil.sharepoint.com,aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee,11111111-2222-3333-4444-555555555555',
+    )).to.be.null;
+  });
+
+  it('rejects a Graph origin used for an unrelated resource path', () => {
+    expect(getValidatedSharePointSite('https://graph.microsoft.com/v1.0/me')).to.be.null;
+  });
+
+  it('rejects subdomain-spoofing lookalikes', () => {
+    const lookalikes = [
+      'https://graph.microsoft.com.evil.com/v1.0/sites/adobe.sharepoint.com,a,b',
+      'https://notgraph.microsoft.com/v1.0/sites/adobe.sharepoint.com,a,b',
+      'https://graph.microsoft.com@evil.com/v1.0/sites/adobe.sharepoint.com,a,b',
+    ];
+    lookalikes.forEach((site) => {
+      expect(getValidatedSharePointSite(site), site).to.be.null;
+    });
+  });
+
+  it('rejects trailing-path injection after the valid segment', () => {
+    expect(getValidatedSharePointSite(`${VALID_SITE}/../../evil`)).to.be.null;
+    expect(getValidatedSharePointSite(`${VALID_SITE}?redirect=https://evil.com`)).to.be.null;
+  });
+
+  it('rejects the correct origin/tenant with malformed GUID segments', () => {
+    const malformed = [
+      'https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com,a,b',
+      'https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com,aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee,not-a-guid',
+      'https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com,,',
+    ];
+    malformed.forEach((site) => {
+      expect(getValidatedSharePointSite(site), site).to.be.null;
+    });
+  });
+
+  it('rejects scheme downgrade and is case-sensitive on the host', () => {
+    expect(getValidatedSharePointSite(VALID_SITE.replace('https://', 'http://'))).to.be.null;
+    expect(getValidatedSharePointSite(VALID_SITE.toUpperCase())).to.be.null;
+  });
+
+  it('does not throw on malformed/non-URL payloads', () => {
+    const payloads = [
+      // eslint-disable-next-line no-script-url -- payload must prove script URLs are rejected
+      'javascript:alert(1)',
+      'not a url',
+      42,
+      {},
+    ];
+    payloads.forEach((site) => {
+      expect(() => getValidatedSharePointSite(site), JSON.stringify(site)).to.not.throw();
+      expect(getValidatedSharePointSite(site), JSON.stringify(site)).to.be.null;
+    });
+  });
+});

--- a/test/utils/service-config.test.js
+++ b/test/utils/service-config.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import getServiceConfig from '../../libs/utils/service-config.js';
+import getServiceConfig, { getSiteOrigin } from '../../libs/utils/service-config.js';
 
 const ORIGIN = 'http://localhost:2000/test/utils/mocks';
 
@@ -28,5 +28,28 @@ describe('Service Config', () => {
   it('Should fallbck to prod value', async () => {
     const { sharepoint } = await getServiceConfig(ORIGIN);
     expect(sharepoint.siteId).to.equal('milo-stage');
+  });
+
+  describe('getSiteOrigin', () => {
+    const originalHref = window.location.href;
+
+    afterEach(() => {
+      window.history.pushState({}, '', originalHref);
+    });
+
+    it('falls back to the current origin when repo/owner are absent', () => {
+      window.history.pushState({}, '', '/test/utils/service-config.test.js');
+      expect(getSiteOrigin()).to.equal(window.location.origin);
+    });
+
+    it('resolves a valid repo/owner pair to an aem.live origin', () => {
+      window.history.pushState({}, '', '/?repo=milo&owner=adobecom');
+      expect(getSiteOrigin()).to.equal('https://main--milo--adobecom.aem.live');
+    });
+
+    it('falls back to the current origin for hostile repo/owner values (VULN-38270)', () => {
+      window.history.pushState({}, '', '/?repo=evil.com&owner=x');
+      expect(getSiteOrigin()).to.equal(window.location.origin);
+    });
   });
 });


### PR DESCRIPTION
`getSiteOrigin()` built the service-config fetch origin directly from the unvalidated repo/owner query params, so an attacker who registered any repo/owner pair on the public *.aem.live platform could serve a poisoned .milo/config.json to milo.adobe.com/tools/path-finder. The tool then sent the victim's Microsoft Graph access token (Files.ReadWrite, Sites.ReadWrite.All) to sharepoint.site from that attacker-controlled config.

Add getValidatedRepoOwnerOrigin() (libs/utils/utils.js), mirroring the VULN-36379 maslibs fix: allowlist each segment's shape, cap its length, and verify the constructed host actually ends in .aem.live before trusting it. getSiteOrigin() now falls back to the current origin for any repo/owner pair that doesn't validate.

Follow-up (per review from J. Casalino): repo/owner shape validation alone doesn't close the reported chain, since *.aem.live is public and self-service — a syntactically valid repo/owner pair (the report's own repo=ccc&owner=hoodhmnd) still resolves to a real, attacker-owned site. Add getValidatedSharePointSite() (libs/utils/utils.js) and use it in path-finder.js and libs/tools/sharepoint/version.js — the two places sharepoint.site actually gets turned into a request carrying the post-login Bearer token. Both now refuse to proceed unless sharepoint.site resolves to Adobe's real Graph/SharePoint host (https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com,\<id\>,\<id\>), regardless of which origin served the config. This is the host-pinning approach the review called out as preferable, and it closes the exfiltration path without needing to solve repo/owner ownership at the source.

Also fixes two more unpatched copies of the same underlying bug found during this pass, neither previously covered:
- version-history/index.js had its own zero-validation getSiteOrigin() (not even the shape check from the first fix); now reuses the shared, tested one from service-config.js.
- library-config.js (the Sidekick Library panel) was worse — its library query param was used as a raw, unvalidated fetch URL with no repo/owner check at all. Now pinned to the validated repo/owner origin.

Scope note: this closes the reported repo/owner → sharepoint.site vector, including the ownership gap the shape-only check left open. The ticket also asks for a systemic pass over other params that reach host position (caashost, caasver, navbranch, eventlibs) — still open, left for the assigned engineer/security review.

Resolves: [VULN-38270](https://jira.corp.adobe.com/browse/VULN-38270)

**Test URLs:**
- Before (stage): https://main--milo--adobecom.aem.live/tools/path-finder?repo=evil&owner=x
- After (this branch): https://main--milo--adobecom.aem.live/tools/path-finder?milolibs=vuln-38270-repo-owner-host-validation&repo=evil&owner=x

The `sharepoint.site` pinning itself is best checked directly, since it can't be safely demoed against a live attacker-registered site — DevTools console on either URL above:
```js
const { getValidatedSharePointSite } = await import('/libs/utils/utils.js');
getValidatedSharePointSite('https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com,d21b93ad-...,563e43e2-...'); // real prod value, still resolves
getValidatedSharePointSite('https://<attacker-collector>'); // PoC-style payload, now null
```

**Testing:**
Quickest check on the actual fix – DevTools console on any Milo page:

```
const { getValidatedSharePointSite } = await import('/libs/utils/utils.js');
getValidatedSharePointSite('https://graph.microsoft.com/v1.0/sites/adobe.sharepoint.com,d21b93ad-...,563e43e2-...'); // real prod value, still resolves
getValidatedSharePointSite('https://<attacker-collector>'); // PoC-style payload, now null
```


Ran this against the real prod config (https://main--milo--adobecom.aem.live/.milo/config.json) – legit value still validates, attacker-shaped payload doesn't.

Same milolibs= flow as before still applies for the repo/owner layer:
https://main--milo--adobecom.aem.live/tools/path-finder?milolibs=vuln-38270-repo-owner-host-validation&repo=evil&owner=x

Full negative-payload coverage is in the test suite if useful: test/utils/getValidatedSharePointSite.test.js, test/tools/sharepoint/version.test.js, test/blocks/library-config/library-config.test.js.

