### PR TITLE
MWPW-204299 MWPW-201612 [MEP] Unify country resolution for manifest-geo-restriction + remove dead countryIPPromise

### DIFF
--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -16,6 +16,7 @@ import {
   isBot,
   computeDetectedMarketCountry,
   getCookie,
+  getCountry,
   isMasImsLoginEnabled,
   normCountryCode,
 } from '../../utils/utils.js';
@@ -1417,6 +1418,13 @@ export async function applyPers({ manifests }) {
       getCookie('ims_country_code'),
       isMasImsLoginEnabled(),
     );
+    // Cold-load fallback: URL/cookie/IMS and the non-network akamaiCode were all
+    // unresolved (no edge geo server-timing header — e.g. aem.page, martech=off).
+    // Resolve via the geo2 network fetch once so countryIP(...) placeholders and
+    // manifest-geo-restriction match on first load instead of only on reload.
+    if (!config.mep.countryIP) {
+      config.mep.countryIP = normCountryCode(await getCountry());
+    }
   }
 
   experiments = await Promise.all(

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -16,7 +16,6 @@ import {
   isBot,
   computeDetectedMarketCountry,
   getCookie,
-  getCountry,
   isMasImsLoginEnabled,
   normCountryCode,
 } from '../../utils/utils.js';
@@ -1418,10 +1417,6 @@ export async function applyPers({ manifests }) {
       getCookie('ims_country_code'),
       isMasImsLoginEnabled(),
     );
-    // Off-Akamai origins lack the edge geo header; resolve via network once.
-    if (!config.mep.countryIP) {
-      config.mep.countryIP = normCountryCode(await getCountry());
-    }
   }
 
   experiments = await Promise.all(

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1418,10 +1418,7 @@ export async function applyPers({ manifests }) {
       getCookie('ims_country_code'),
       isMasImsLoginEnabled(),
     );
-    // Cold-load fallback: URL/cookie/IMS and the non-network akamaiCode were all
-    // unresolved (no edge geo server-timing header — e.g. aem.page, martech=off).
-    // Resolve via the geo2 network fetch once so countryIP(...) placeholders and
-    // manifest-geo-restriction match on first load instead of only on reload.
+    // Off-Akamai origins lack the edge geo header; resolve via network once.
     if (!config.mep.countryIP) {
       config.mep.countryIP = normCountryCode(await getCountry());
     }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1410,7 +1410,7 @@ export async function applyPers({ manifests }) {
   let experiments = manifests;
   const config = getConfig();
 
-  if (config.mep && !config.mep.countryIP && !isBot()) {
+  if (!config.mep.countryIP && !isBot()) {
     config.mep.countryIP = computeDetectedMarketCountry(
       window.location.search,
       getCookie('country'),

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -13,6 +13,7 @@ import {
   isSignedOut,
   isTrustedUrl,
   isSameOriginManifestPath,
+  isBot,
   computeDetectedMarketCountry,
   getCookie,
   isMasImsLoginEnabled,
@@ -1408,7 +1409,7 @@ export async function applyPers({ manifests }) {
   let experiments = manifests;
   const config = getConfig();
 
-  if (config.mep && !config.mep.countryIP) {
+  if (config.mep && !config.mep.countryIP && !isBot()) {
     config.mep.countryIP = computeDetectedMarketCountry(
       window.location.search,
       getCookie('country'),

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -13,7 +13,10 @@ import {
   isSignedOut,
   isTrustedUrl,
   isSameOriginManifestPath,
-  resolveDetectedMarketCountry,
+  computeDetectedMarketCountry,
+  getCookie,
+  isMasImsLoginEnabled,
+  normCountryCode,
 } from '../../utils/utils.js';
 import { getMepConsentConfig, sendAnalytics } from '../../martech/helpers.js';
 import { sanitizeHtmlBody } from '../../utils/sanitizeHtml.js';
@@ -1035,14 +1038,6 @@ export const getEntitlements = async (data) => {
   });
 };
 
-async function setMepCountry(config) {
-  const resolvedCountry = await resolveDetectedMarketCountry();
-  config.mep = config.mep || {};
-  if (resolvedCountry) {
-    config.mep.countryIP = resolvedCountry;
-  }
-}
-
 async function getPersonalizationVariant(
   manifestPath,
   variantNames = [],
@@ -1091,10 +1086,6 @@ async function getPersonalizationVariant(
     return !processedList.includes(false);
   };
 
-  if (config.mep?.geoLocation) {
-    await setMepCountry(config);
-  }
-
   const matchingVariant = variantNames.find((variant) => variantInfo[variant].some(matchVariant));
   return matchingVariant;
 }
@@ -1140,8 +1131,8 @@ export const overrideVariant = (manifestPath, variantName) => {
 export const getGeoRestriction = (manifestConfig) => {
   const { geoRestriction, manifestPath } = manifestConfig;
   if (!geoRestriction) return true;
-  const geoArray = geoRestriction?.split(',').map((item) => item.trim().toLowerCase());
-  const isAllowed = geoArray.includes(getConfig().mep.akamaiCode);
+  const geoArray = geoRestriction.split(',').map((item) => normCountryCode(item.trim()));
+  const isAllowed = geoArray.includes(getConfig().mep.countryIP);
   if (!isAllowed) overrideVariant(manifestPath, 'Default');
   return isAllowed;
 };
@@ -1417,6 +1408,16 @@ export async function applyPers({ manifests }) {
   let experiments = manifests;
   const config = getConfig();
 
+  if (config.mep && !config.mep.countryIP) {
+    config.mep.countryIP = computeDetectedMarketCountry(
+      window.location.search,
+      getCookie('country'),
+      config.mep.akamaiCode,
+      getCookie('ims_country_code'),
+      isMasImsLoginEnabled(),
+    );
+  }
+
   experiments = await Promise.all(
     experiments.map((exp) => getManifestConfig(exp, config.mep?.variantOverride)),
   );
@@ -1654,7 +1655,7 @@ export async function init(enablements = {}) {
   let manifests = [];
   const {
     mepParam, mepHighlight, mepButton, pzn, pznroc, promo, enablePersV2,
-    target, ajo, countryIPPromise, mepgeolocation, targetInteractionPromise, calculatedTimeout,
+    target, ajo, targetInteractionPromise, calculatedTimeout,
     postLCP, promises, mepMarketingDecrease, akamaiCode,
   } = enablements;
   const config = getConfig();
@@ -1674,8 +1675,6 @@ export async function init(enablements = {}) {
       experiments: [],
       prefix: config.locale?.prefix.split('/')[1]?.toLowerCase() || US_GEO,
       enablePersV2,
-      countryIPPromise,
-      geoLocation: mepgeolocation,
       targetInteractionPromise,
       promises,
       akamaiCode: akamaiCode?.toLowerCase(),

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2207,7 +2207,6 @@ async function checkForPageMods() {
     martech,
   } = Object.fromEntries(PAGE_URL.searchParams);
   let targetInteractionPromise = null;
-  let countryIPPromise = null;
   let calculatedTimeout = null;
 
   if (mepParam === 'off') return;
@@ -2217,7 +2216,6 @@ async function checkForPageMods() {
   const target = martech === 'off' ? false : getMepEnablement('target');
   const xlg = martech === 'off' ? false : getMepEnablement('xlg');
   const ajo = martech === 'off' ? false : getMepEnablement('ajo');
-  const mepgeolocation = getMepEnablement('mepgeolocation');
   const mepMarketingDecrease = getMepEnablement('mep-marketing-decrease');
 
   if (!(pzn || pznroc || target || promo || mepParam
@@ -2231,9 +2229,6 @@ async function checkForPageMods() {
 
   const promises = loadMepAddons();
   const akamaiCode = getMepEnablement('akamaiLocale') || await getCountry(true);
-  if (mepgeolocation && !akamaiCode) {
-    countryIPPromise = getCountry();
-  }
   const enablePersV2 = enablePersonalizationV2();
   if ((target || xlg) && enablePersV2) {
     const params = new URL(window.location.href).searchParams;
@@ -2275,8 +2270,6 @@ async function checkForPageMods() {
     promo,
     target,
     ajo,
-    countryIPPromise,
-    mepgeolocation,
     targetInteractionPromise,
     calculatedTimeout,
     enablePersV2,

--- a/test/features/personalization/canServeManifest.test.js
+++ b/test/features/personalization/canServeManifest.test.js
@@ -26,18 +26,21 @@ describe('overrideVariant', () => {
 
 describe('getGeoRestriction', () => {
   before(() => {
-    sessionStorage.setItem('akamai', 'us');
-    getConfig().mep = {};
+    getConfig().mep = { countryIP: 'us' };
   });
   it('should return true if the geo restriction is null', () => {
     expect(getGeoRestriction({ geoRestriction: null, manifestPath: '/test/test.json' })).to.be.true;
   });
-  it('should return true if the geo restriction includes US', () => {
-    expect(getGeoRestriction({ geoRestriction: 'fr, us', manifestPath: '/test/test.json' })).to.be.false;
+  it('should return true if the geo restriction includes the resolved country', () => {
+    expect(getGeoRestriction({ geoRestriction: 'fr, us', manifestPath: '/test/test.json' })).to.be.true;
   });
-  it('should return false and override the variant if the geo restriction does not include US', () => {
-    getGeoRestriction({ geoRestriction: 'fr, ca', manifestPath: '/test/test.json' });
+  it('should return false and override the variant if the geo restriction does not include the resolved country', () => {
+    expect(getGeoRestriction({ geoRestriction: 'fr, ca', manifestPath: '/test/test.json' })).to.be.false;
     expect(getConfig().mep.variantOverride['/test/test.json']).to.be.equal('Default');
+  });
+  it('should normalize authored uk to gb when matching the resolved country', () => {
+    getConfig().mep = { countryIP: 'gb' };
+    expect(getGeoRestriction({ geoRestriction: 'fr, uk', manifestPath: '/test/uk.json' })).to.be.true;
   });
 });
 

--- a/test/features/personalization/mepGeolocation.test.js
+++ b/test/features/personalization/mepGeolocation.test.js
@@ -84,6 +84,16 @@ describe('mepGeolocation', () => {
     expect(document.querySelector('.how-to')).to.be.null;
   });
 
+  it('skips countryIP resolution for bots', async () => {
+    const uaStub = stub(navigator, 'userAgent').value('Googlebot/2.1 (+http://www.google.com/bot.html)');
+    await setupEnvironment({ sessionKey: 'akamai', sessionValue: 'de' });
+    await setFetchResponse('./mocks/manifestMEPCountryIP.json');
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init({ ...mepSettings, akamaiCode: 'de' });
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    uaStub.restore();
+  });
+
   it('adobe account (ims_country_code) country counts when mas-ims-login is on', async () => {
     await setupEnvironment({ sessionKey: 'akamai', sessionValue: 'us' });
     document.head.insertAdjacentHTML('beforeend', '<meta name="mas-ims-login" content="on">');

--- a/test/features/personalization/mepGeolocation.test.js
+++ b/test/features/personalization/mepGeolocation.test.js
@@ -94,25 +94,6 @@ describe('mepGeolocation', () => {
     uaStub.restore();
   });
 
-  it('cold load resolves countryIP via geo2 fallback when akamaiCode is unresolved', async () => {
-    const manifestJson = JSON.parse(await readFile({ path: './mocks/manifestMEPCountryIP.json' }));
-    window.fetch = stub().callsFake((url) => {
-      let hostname = '';
-      try {
-        hostname = new URL(typeof url === 'string' ? url : url?.url ?? '').hostname;
-      } catch {
-        hostname = '';
-      }
-      if (hostname === 'geo2.adobe.com') {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({ country: 'DE' }) });
-      }
-      return Promise.resolve({ ok: true, json: () => manifestJson });
-    });
-    expect(document.querySelector('.how-to')).to.not.be.null;
-    await init({ ...mepSettings });
-    expect(document.querySelector('.how-to')).to.be.null;
-  });
-
   it('adobe account (ims_country_code) country counts when mas-ims-login is on', async () => {
     await setupEnvironment({ sessionKey: 'akamai', sessionValue: 'us' });
     document.head.insertAdjacentHTML('beforeend', '<meta name="mas-ims-login" content="on">');

--- a/test/features/personalization/mepGeolocation.test.js
+++ b/test/features/personalization/mepGeolocation.test.js
@@ -97,7 +97,13 @@ describe('mepGeolocation', () => {
   it('cold load resolves countryIP via geo2 fallback when akamaiCode is unresolved', async () => {
     const manifestJson = JSON.parse(await readFile({ path: './mocks/manifestMEPCountryIP.json' }));
     window.fetch = stub().callsFake((url) => {
-      if (typeof url === 'string' && url.includes('geo2.adobe.com')) {
+      let hostname = '';
+      try {
+        hostname = new URL(typeof url === 'string' ? url : url?.url ?? '').hostname;
+      } catch {
+        hostname = '';
+      }
+      if (hostname === 'geo2.adobe.com') {
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ country: 'DE' }) });
       }
       return Promise.resolve({ ok: true, json: () => manifestJson });

--- a/test/features/personalization/mepGeolocation.test.js
+++ b/test/features/personalization/mepGeolocation.test.js
@@ -40,13 +40,14 @@ describe('mepGeolocation', () => {
   afterEach(() => {
     sessionStorage.clear();
     document.cookie = 'country=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    document.cookie = 'ims_country_code=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
   });
 
   it('matches userIP(de) when countryIP is set to de', async () => {
     await setupEnvironment({ sessionKey: 'akamai', sessionValue: 'de' });
     await setFetchResponse('./mocks/manifestMEPCountryIP.json');
     expect(document.querySelector('.how-to')).to.not.be.null;
-    await init(mepSettings);
+    await init({ ...mepSettings, akamaiCode: 'de' });
     expect(document.querySelector('.how-to')).to.be.null;
   });
 
@@ -61,7 +62,7 @@ describe('mepGeolocation', () => {
     await setupEnvironment({ sessionKey: 'akamai', sessionValue: 'sg' });
     await setFetchResponse('./mocks/manifestMEPCountryIP.json');
     expect(document.querySelector('.how-to')).to.not.be.null;
-    await init(mepSettings);
+    await init({ ...mepSettings, akamaiCode: 'sg' });
     expect(document.querySelector('.how-to')).to.be.null;
   });
 
@@ -70,7 +71,26 @@ describe('mepGeolocation', () => {
     document.cookie = 'country=us';
     await setFetchResponse('./mocks/manifestMEPCountryIP.json');
     expect(document.querySelector('.how-to')).to.not.be.null;
-    await init(mepSettings);
+    await init({ ...mepSettings, akamaiCode: 'de' });
     expect(document.querySelector('.how-to')).to.not.be.null;
+  });
+
+  it('resolves countryIP with no mepgeolocation flag', async () => {
+    await setupEnvironment({ sessionKey: 'akamai', sessionValue: 'de' });
+    await setFetchResponse('./mocks/manifestMEPCountryIP.json');
+    expect(mepSettings.mepgeolocation).to.be.undefined;
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init({ ...mepSettings, akamaiCode: 'de' });
+    expect(document.querySelector('.how-to')).to.be.null;
+  });
+
+  it('adobe account (ims_country_code) country counts when mas-ims-login is on', async () => {
+    await setupEnvironment({ sessionKey: 'akamai', sessionValue: 'us' });
+    document.head.insertAdjacentHTML('beforeend', '<meta name="mas-ims-login" content="on">');
+    document.cookie = 'ims_country_code=de';
+    await setFetchResponse('./mocks/manifestMEPCountryIP.json');
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init({ ...mepSettings, akamaiCode: 'us' });
+    expect(document.querySelector('.how-to')).to.be.null;
   });
 });

--- a/test/features/personalization/mepGeolocation.test.js
+++ b/test/features/personalization/mepGeolocation.test.js
@@ -94,6 +94,19 @@ describe('mepGeolocation', () => {
     uaStub.restore();
   });
 
+  it('cold load resolves countryIP via geo2 fallback when akamaiCode is unresolved', async () => {
+    const manifestJson = JSON.parse(await readFile({ path: './mocks/manifestMEPCountryIP.json' }));
+    window.fetch = stub().callsFake((url) => {
+      if (typeof url === 'string' && url.includes('geo2.adobe.com')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ country: 'DE' }) });
+      }
+      return Promise.resolve({ ok: true, json: () => manifestJson });
+    });
+    expect(document.querySelector('.how-to')).to.not.be.null;
+    await init({ ...mepSettings });
+    expect(document.querySelector('.how-to')).to.be.null;
+  });
+
   it('adobe account (ims_country_code) country counts when mas-ims-login is on', async () => {
     await setupEnvironment({ sessionKey: 'akamai', sessionValue: 'us' });
     document.head.insertAdjacentHTML('beforeend', '<meta name="mas-ims-login" content="on">');

--- a/test/features/personalization/mepGeolocationSettings.js
+++ b/test/features/personalization/mepGeolocationSettings.js
@@ -5,7 +5,6 @@ const mepSettings = {
   pzn: '/path/to/manifest.json',
   promo: false,
   target: false,
-  mepgeolocation: true,
   promises: {},
 };
 

--- a/test/features/personalization/mocks/metadata-mepgeolocation.html
+++ b/test/features/personalization/mocks/metadata-mepgeolocation.html
@@ -1,4 +1,3 @@
 <meta name="description" content="Milo Description">
 <meta property="og:title" content="milo">
 <meta name="georouting" content="off">
-<meta name="mepgeolocation" content="on">

--- a/test/utils/mocks/mep/head-mepgeolocation-off.html
+++ b/test/utils/mocks/mep/head-mepgeolocation-off.html
@@ -1,4 +1,0 @@
-<meta name="mepgeolocation" content="off">
-<title>Document Title</title>
-<link rel="icon" href="data:,">
-

--- a/test/utils/mocks/mep/head-mepgeolocation-on.html
+++ b/test/utils/mocks/mep/head-mepgeolocation-on.html
@@ -1,4 +1,0 @@
-<meta name="mepgeolocation" content="on">
-<title>Document Title</title>
-<link rel="icon" href="data:,">
-

--- a/test/utils/utils-mep.test.js
+++ b/test/utils/utils-mep.test.js
@@ -80,16 +80,6 @@ describe('MEP Utils', () => {
       const ajoEnabled = getMepEnablement('ajo');
       expect(ajoEnabled).to.equal('postlcp');
     });
-    it('checks mepgeolocation metadata set to off', async () => {
-      document.head.innerHTML = await readFile({ path: './mocks/mep/head-mepgeolocation-off.html' });
-      const mepGelocationEnabled = getMepEnablement('mepgeolocation');
-      expect(mepGelocationEnabled).to.equal(false);
-    });
-    it('checks mepgeolocation metadata set to off', async () => {
-      document.head.innerHTML = await readFile({ path: './mocks/mep/head-mepgeolocation-on.html' });
-      const mepGelocationEnabled = getMepEnablement('mepgeolocation');
-      expect(mepGelocationEnabled).to.equal(true);
-    });
     it('checks from just metadata with no target metadata', async () => {
       document.head.innerHTML = await readFile({ path: './mocks/mep/head-promo.html' });
       const persEnabled = getMepEnablement('personalization');


### PR DESCRIPTION
* Resolve visitor country once per MEP page in `applyPers` via
    `computeDetectedMarketCountry` — reuses the non-network `akamaiCode`, no geo2
    fetch added to the LCP path
  * Drop the `mepgeolocation` feature-flag gate; remove the old `setMepCountry` /
    `await resolveDetectedMarketCountry()` path that ran inside `getPersonalizationVariant`
  * `manifest-geo-restriction` now honors the full country precedence
    (`?country=` → `?akamaiLocale=` → `country` cookie → `ims_country_code` →
    edge `akamaiCode`) by reading `config.mep.countryIP`, with `normCountryCode`
    normalization on the authored list (`uk` → `gb`).
  * Fixes the first-load geo race: geo-restricted manifests were wrongly filtered
    on a cold load (when `akamaiCode` was unresolved) and only correct on reload
  * Remove dead `countryIPPromise` plumbing — computed in `checkForPageMods`,
    passed through `init`, stored on `config.mep`, but never read

  Resolves: [MWPW-204299](https://jira.corp.adobe.com/browse/MWPW-204299)
  Resolves: [MWPW-201612](https://jira.corp.adobe.com/browse/MWPW-201612)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-204299-manifest-country-resolution--milo--adobecom.aem.page/?martech=off

**QA URLs
**countryIP placeholders:** 
- https://mwpw-204299-manifest-country-resolution--milo--adobecom.aem.page/drafts/jpratt/test1/pr6611/test-pr-6611-pt1?mepnext=on?akamaiLocale=us
- https://mwpw-204299-manifest-country-resolution--milo--adobecom.aem.page/drafts/jpratt/test1/pr6611/test-pr-6611-pt1?mepnext=on?akamaiLocale=JP

**manifest-geo-location:**
- https://www.stage.adobe.com/?milolibs=mep-spoof-mboxoverride-browserip&mepnext=on

**Update:** 

* **Cold-load fallback added.** The sync `computeDetectedMarketCountry` only
    reuses the non-network `akamaiCode`. On off-Akamai origins (aem.page,
    `martech=off`, localhost) the edge `geo` server-timing header is absent, so
    `akamaiCode` — and therefore `countryIP` — is empty on first load, and the
    `countryIP(...)` placeholders/variants + `manifest-geo-restriction` resolved
    only on reload. `applyPers` now awaits `getCountry()` once (non-bot only) when
    `countryIP` is still empty, before matching. On the prod Akamai edge the
    header is present, so the sync path wins and the fallback never fires.
  * Minor cleanup: dropped the redundant `config.mep &&` guard in `applyPers`
    (the function already dereferences `config.mep` unguarded) and tightened a
    test stub's host match (CodeQL).

**Update 2 — cold-load fallback reverted (7893e8348):**
  
 The awaited `getCountry()` fallback added above was removed. It was effectively
  dead code on production — the edge `geo` server-timing header warms `akamaiCode`
  before `applyPers`, so the synchronous path always wins and the fallback never
  fired — but the extra geo2 fetch broke tests that stub `fetch` positionally
  (`replacePage`, `pageFilter`): it shifted the stub call indices, leaked a real
  request, and hung the run to the 130s session timeout (surfacing as a "Running
  tests" failure that no re-run could clear). `countryIP` still resolves
  synchronously via URL → `country` cookie → `ims_country_code` → `akamaiCode`;
  off-Akamai preview environments can force a value with `?country=`. This also
  removes the geo2 test stub CodeQL flagged.






