### PR TITLE
[MWPW-205011] Add metadata enabled dynamic reflow to C1 global navigation

### DIFF
--- a/libs/blocks/brand-concierge-global/brand-concierge-global.js
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.js
@@ -133,8 +133,6 @@ export default function init(el) {
     }
   });
 
-  setCssGnavHeight();
-
   const rows = el.querySelectorAll(':scope > div');
   const [cards, input] = rows;
   setAuthoredContent(null, cards, input);
@@ -152,6 +150,7 @@ export default function init(el) {
 
   if (!hasChatCookie()) localStorage.setItem('bc-side-overlay', 'closed');
   if (localStorage.getItem('bc-side-overlay') === 'open' && !document.body.classList.contains('bc-side-open')) {
+    setCssGnavHeight();
     openSideModal(null, bcBootstrap);
   }
 }

--- a/libs/blocks/brand-concierge/bc-bootstrap.js
+++ b/libs/blocks/brand-concierge/bc-bootstrap.js
@@ -1,6 +1,6 @@
 import { getModal, closeModal } from '../modal/modal.js';
 import { createTag, getConfig, getMetadata, loadScript } from '../../utils/utils.js';
-import { getBetaLabel, waitForCondition, expandIcon } from './bc-utils.js';
+import { getBetaLabel, waitForCondition, expandIcon, setCssGnavHeight } from './bc-utils.js';
 import { bcAnalytics, getAnalyticsLabel } from './bc-analytics.js';
 import chatUIConfig from './chat-ui-config.js';
 
@@ -17,6 +17,29 @@ const susiScopes = 'AdobeID,openid,gnav,pps.read,firefly_api,additional_info.rol
 let bcToken;
 let susiListener;
 let lastImsState = null;
+
+function handleLocalNav() {
+  const localGnav = document.querySelector('div.feds-localnav');
+  let lastDisplay = localGnav ? window.getComputedStyle(localGnav).display : null;
+  if (localGnav) {
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'attributes') {
+          const currentDisplay = window.getComputedStyle(localGnav).display;
+
+          if (currentDisplay !== lastDisplay) {
+            lastDisplay = currentDisplay;
+            setCssGnavHeight();
+          }
+        }
+      }
+    });
+    observer.observe(localGnav, {
+      attributes: true,
+      attributeFilter: ['style', 'class'],
+    });
+  }
+}
 
 /**
  * Creates the SUSI Light component for the sign-in modal.
@@ -379,6 +402,8 @@ export async function openSideModal(initialMessage, bootstrap) {
     });
     susiListener = 'signIn:decorateNav';
   }
+
+  handleLocalNav();
 
   modal.querySelector('.dialog-close').setAttribute('daa-ll', getAnalyticsLabel('modal-close'));
   document.querySelector('.modal-curtain').setAttribute('daa-ll', getAnalyticsLabel('modal-close'));

--- a/libs/blocks/brand-concierge/bc-utils.js
+++ b/libs/blocks/brand-concierge/bc-utils.js
@@ -41,9 +41,16 @@ export function hasChatCookie() {
 
 export function setCssGnavHeight() {
   const gnav = document.querySelector('header.global-navigation');
+  const localGnav = document.querySelector('div.feds-localnav');
+  const localNavStyle = localGnav ? getComputedStyle(localGnav) : null;
+  const localNavOn = localGnav && localNavStyle ? localNavStyle.display === 'block' : false;
+
   if (!gnav) return;
-  const gnavHeight = gnav.getBoundingClientRect().height;
-  document.documentElement.style.setProperty('--bc-gnav-height', `${gnavHeight}px`);
+  const rootStyles = getComputedStyle(document.documentElement);
+  const gnavHeight = Number(rootStyles.getPropertyValue('--global-height-nav').trim().slice(0, -2));
+  const localNavHeight = Number(rootStyles.getPropertyValue('--feds-localnav-height').trim().slice(0, -2));
+  const newHeight = gnavHeight + (localGnav && localNavOn ? localNavHeight : 0);
+  document.documentElement.style.setProperty('--bc-gnav-height', `${newHeight}px`);
 }
 
 export function handleConsent(el) {

--- a/libs/blocks/brand-concierge/bc-utils.js
+++ b/libs/blocks/brand-concierge/bc-utils.js
@@ -43,7 +43,7 @@ export function setCssGnavHeight() {
   const gnav = document.querySelector('header.global-navigation');
   const localGnav = document.querySelector('div.feds-localnav');
   const localNavStyle = localGnav ? getComputedStyle(localGnav) : null;
-  const localNavOn = localGnav && localNavStyle ? localNavStyle.display === 'block' : false;
+  const localNavOn = localGnav && localNavStyle ? localNavStyle.display !== 'none' : false;
 
   if (!gnav) return;
   const rootStyles = getComputedStyle(document.documentElement);

--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -236,8 +236,8 @@ header.global-navigation.ready {
     padding: 0;
   }
 
-  .feds-navLink--hoverCaret:hover,
-  .feds-navLink--hoverCaret:focus {
+  :where(header.global-navigation:not(.is-compact)) .feds-navLink--hoverCaret:hover,
+  :where(header.global-navigation:not(.is-compact)) .feds-navLink--hoverCaret:focus {
     background-color: var(--feds-background-popup);
   }
 

--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -179,9 +179,9 @@ header.global-navigation.ready {
 
 /* Desktop styles */
 @media (min-width: 900px) {
-  .feds-navLink,
-  .feds-navLink--hoverCaret,
-  [dir = "rtl"] .feds-navLink--hoverCaret {
+  :where(header.global-navigation:not(.is-compact)) .feds-navLink,
+  :where(header.global-navigation:not(.is-compact)) .feds-navLink--hoverCaret,
+  [dir = "rtl"] :where(header.global-navigation:not(.is-compact)) .feds-navLink--hoverCaret {
     padding: 0 12px;
   }
 
@@ -241,7 +241,7 @@ header.global-navigation.ready {
     background-color: var(--feds-background-popup);
   }
 
-  .feds-navLink--hoverCaret:after {
+  :where(header.global-navigation:not(.is-compact)) .feds-navLink--hoverCaret:after {
     position: static;
     margin-top: 0;
     margin-left: 5px;

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -572,6 +572,14 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
   }
 }
 
+header.global-navigation.is-compact .feds-brand-container {
+  margin-right: auto;
+}
+
+header.global-navigation.is-compact .feds-client-plans-cta {
+  margin-left: 0;
+}
+
 
 @media (max-width: 320px) {
   .feds-promo-aside-wrapper[aria-hidden="true"] {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -584,6 +584,17 @@ header.global-navigation.is-compact .feds-logo {
   display: flex;
 }
 
+header.global-navigation.is-compact + .feds-localnav {
+  display: block;
+}
+
+header.global-navigation.has-breadcrumbs.is-compact {
+  padding-bottom: 0;
+}
+
+header.global-navigation.is-compact + .feds-localnav .feds-navItem--active > .feds-navLink::before {
+  display: none;
+}
 
 @media (max-width: 320px) {
   .feds-promo-aside-wrapper[aria-hidden="true"] {
@@ -848,7 +859,8 @@ header.global-navigation.is-compact .feds-logo {
   :where(header.global-navigation:not(.is-compact)) .feds-brand-image + .feds-brand-label {
     display: none;
   }
-  :where(header.global-navigation:not(.is-compact)) .feds-localnav {
+
+  .feds-localnav {
     display: none;
   }
 }
@@ -868,7 +880,7 @@ header.global-navigation.is-compact .feds-logo {
     margin: 0 auto;
   }
 
-  :where(header.global-navigation:not(.is-compact)) .feds-localnav {
+  .feds-localnav {
     display: none;
   }
 }

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -573,11 +573,11 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
 }
 
 header.global-navigation.is-compact .feds-brand-container {
-  margin-right: auto;
+  margin-inline-end: auto;
 }
 
 header.global-navigation.is-compact .feds-client-plans-cta {
-  margin-left: 0;
+  margin-inline-start: 0;
 }
 
 header.global-navigation.is-compact .feds-logo {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -584,7 +584,7 @@ header.global-navigation.is-compact .feds-logo {
   display: flex;
 }
 
-header.global-navigation.is-compact.local-nav .feds-nav-wrapper--expanded ~ .feds-bc-wrapper {
+header.global-navigation.is-compact .feds-nav-wrapper--expanded ~ .feds-bc-wrapper {
   display: none;
 }
 

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -580,6 +580,10 @@ header.global-navigation.is-compact .feds-client-plans-cta {
   margin-left: 0;
 }
 
+header.global-navigation.is-compact .feds-logo {
+  display: flex;
+}
+
 
 @media (max-width: 320px) {
   .feds-promo-aside-wrapper[aria-hidden="true"] {

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -605,11 +605,11 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     box-sizing: content-box;
   }
 
-  .feds-toggle {
+  :where(header.global-navigation:not(.is-compact)) .feds-toggle {
     display: none;
   }
 
-  .feds-nav-wrapper {
+  :where(header.global-navigation:not(.is-compact)) .feds-nav-wrapper {
     position: static;
     display: flex;
     flex-direction: row;
@@ -621,13 +621,13 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     background-color: transparent;
   }
 
-  .feds-nav {
+  :where(header.global-navigation:not(.is-compact)) .feds-nav {
     flex-direction: row;
     overflow-y: visible;
     padding-bottom: 0 !important; /* Remove JS-set one */
   }
 
-  .has-plans-cta.mini-gnav .feds-nav {
+  :where(header.global-navigation.has-plans-cta.mini-gnav:not(.is-compact)) .feds-nav {
     display: none;
   }
 
@@ -652,7 +652,7 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
   }
 
   /* Popup */
-  .feds-popup {
+  :where(header.global-navigation:not(.is-compact)) .feds-popup {
     position: absolute;
     top: 100%;
     left: 0;
@@ -667,17 +667,17 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     right: 0;
   }
 
-  .feds-menu-container {
+  :where(header.global-navigation:not(.is-compact)) .feds-menu-container {
     min-width: 100%;
     padding: 0 12px 40px;
   }
 
   /* Nav Links */
-  .feds-navItem {
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem {
     flex-direction: initial;
   }
 
-  .feds-navItem--mobile-only {
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem--mobile-only {
     display: none;
   }
 
@@ -686,8 +686,8 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     position: static;
   }
 
-  .feds-navItem--megaMenu .feds-popup,
-  .feds-navItem.full-width .feds-popup {
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem--megaMenu .feds-popup,
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem.full-width .feds-popup {
     right: 0;
     padding: 40px 0 0;
     max-height: calc(100dvh - 100%);
@@ -695,15 +695,15 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     box-sizing: border-box;
   }
 
-  .feds-navItem.full-width .feds-menu-content {
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem.full-width .feds-menu-content {
      width: inherit;
      min-width: var(--feds-minWidth-menu);
      margin: 0 auto;
      padding: 0 12px 40px;
    }
 
-  .global-navigation.has-promo .feds-navItem--megaMenu .feds-popup,
-  .global-navigation.has-promo .feds-navItem.full-width .feds-popup {
+  :where(header.global-navigation:not(.is-compact)).has-promo .feds-navItem--megaMenu .feds-popup,
+  :where(header.global-navigation:not(.is-compact)).has-promo .feds-navItem.full-width .feds-popup {
     max-height: calc(100dvh - 100% - var(--global-height-navPromo));
   }
 
@@ -712,7 +712,7 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     left: 0;
   }
 
-  .feds-navItem--centered {
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem--centered {
     padding: 0 12px;
     align-items: center;
   }
@@ -726,8 +726,8 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     border-right: 1px solid var(--feds-borderColor);
   }
 
-  .feds-navItem--section > .feds-navLink,
-  .feds-navItem > .feds-navLink {
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem--section > .feds-navLink,
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem > .feds-navLink {
     padding: 0 20px;
     outline-offset: -2px;
   }
@@ -757,12 +757,12 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     margin: 0 12px;
   }
 
-  .feds-navItem:not(:last-child) > .feds-navLink {
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem:not(:last-child) > .feds-navLink {
     border-bottom: none;
   }
 
   /* Search */
-  .feds-search {
+  :where(header.global-navigation:not(.is-compact)) .feds-search {
     display: flex;
     align-items: center;
     order: 1;
@@ -799,7 +799,7 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
   }
 
   /* Breadcrumbs */
-  .feds-breadcrumbs-wrapper {
+  :where(header.global-navigation:not(.is-compact)) .feds-breadcrumbs-wrapper {
     position: absolute;
     top: calc(100% + 1px); /* Accounting for nav bottom border */
     left: 0;
@@ -833,17 +833,17 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
 
 /* Small desktop styles */
 @media (min-width: 900px) and (max-width: 1199px) {
-  .feds-brand-image + .feds-brand-label {
+  :where(header.global-navigation:not(.is-compact)) .feds-brand-image + .feds-brand-label {
     display: none;
   }
-  .feds-localnav {
+  :where(header.global-navigation:not(.is-compact)) .feds-localnav {
     display: none;
   }
 }
 
 /* Desktop styles */
 @media (min-width: 1200px) {
-  .feds-logo {
+  :where(header.global-navigation:not(.is-compact)) .feds-logo {
     display: flex;
   }
 
@@ -851,12 +851,12 @@ header.new-nav.global-navigation:not(:has(.feds-dropdown--active)) .feds-profile
     display: none;
   }
 
-  .feds-menu-container {
+  :where(header.global-navigation:not(.is-compact)) .feds-menu-container {
     min-width: var(--feds-minWidth-menu);
     margin: 0 auto;
   }
 
-  .feds-localnav {
+  :where(header.global-navigation:not(.is-compact)) .feds-localnav {
     display: none;
   }
 }

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -584,6 +584,10 @@ header.global-navigation.is-compact .feds-logo {
   display: flex;
 }
 
+header.global-navigation.is-compact.local-nav .feds-nav-wrapper--expanded ~ .feds-bc-wrapper {
+  display: none;
+}
+
 header.global-navigation.is-compact + .feds-localnav {
   display: block;
 }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -922,7 +922,7 @@ class Gnav {
         [el.style.width, el.style.flexShrink] = savedFlex[i];
       });
       const EXPAND_BUFFER = 40;
-     const navMaxWidth = parseFloat(getComputedStyle(topnav).maxWidth) || Infinity;
+      const navMaxWidth = parseFloat(getComputedStyle(topnav).maxWidth) || Infinity;
       const hasRoomToGrow = available < navMaxWidth - 1;
       const threshold = wasCompact && hasRoomToGrow ? available - EXPAND_BUFFER : available;
       const shouldCompact = contentWidth > threshold;

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -904,9 +904,25 @@ class Gnav {
       if (this.newMobileNav) header.classList.remove('new-nav');
       const wasOverflowing = topnav.classList.contains(overflowingClass);
       topnav.classList.remove(overflowingClass);
+      // topnav is clamped by its max-width, so compare against its own width.
+      const available = topnav.clientWidth;
+      // Reserve the brand-concierge / search widget at its full authored width for
+      // so the nav collapses before the box is squeezed
+      const flexible = [...topnav.querySelectorAll('.feds-bc-wrapper, .feds-client-search')];
+      const savedFlex = flexible.map((el) => [el.style.width, el.style.flexShrink]);
+      flexible.forEach((el) => { el.style.width = ''; el.style.flexShrink = '0'; });
+      const prevWidth = topnav.style.width;
+      const prevMaxWidth = topnav.style.maxWidth;
+      topnav.style.width = 'max-content';
+      topnav.style.maxWidth = 'none';
       const contentWidth = topnav.scrollWidth;
+      topnav.style.width = prevWidth;
+      topnav.style.maxWidth = prevMaxWidth;
+      flexible.forEach((el, i) => {
+        [el.style.width, el.style.flexShrink] = savedFlex[i];
+      });
       const EXPAND_BUFFER = 40;
-      const threshold = wasCompact ? header.clientWidth - EXPAND_BUFFER : header.clientWidth;
+      const threshold = wasCompact ? available - EXPAND_BUFFER : available;
       const shouldCompact = contentWidth > threshold;
       header.classList.toggle('is-compact', shouldCompact);
       if (this.newMobileNav) header.classList.toggle('new-nav', shouldCompact);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -922,7 +922,9 @@ class Gnav {
         [el.style.width, el.style.flexShrink] = savedFlex[i];
       });
       const EXPAND_BUFFER = 40;
-      const threshold = wasCompact ? available - EXPAND_BUFFER : available;
+     const navMaxWidth = parseFloat(getComputedStyle(topnav).maxWidth) || Infinity;
+      const hasRoomToGrow = available < navMaxWidth - 1;
+      const threshold = wasCompact && hasRoomToGrow ? available - EXPAND_BUFFER : available;
       const shouldCompact = contentWidth > threshold;
       header.classList.toggle('is-compact', shouldCompact);
       if (this.newMobileNav) header.classList.toggle('new-nav', shouldCompact);

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -578,6 +578,8 @@ class Gnav {
     this.setupUniversalNav();
     this.elements = {};
     this.newMobileNav = newMobileNav;
+    // Opt-in dynamic reflow: collapse to the mobile drawer when the nav overflows.
+    this.dynamicReflowEnabled = getMetadata('gnav-dynamic-reflow')?.toLowerCase() === 'on';
   }
 
   // eslint-disable-next-line no-return-assign
@@ -620,6 +622,7 @@ class Gnav {
       this.revealGnav,
       this.ims,
       this.addChangeEventListeners,
+      this.initCompactOverflow,
     ];
     const fetchKeyboardNav = () => {
       setupKeyboardNav(this.isLocalNav());
@@ -857,7 +860,9 @@ class Gnav {
 
     // Add a modifier when the nav is tangent to the viewport and content is partly hidden
     const toggleContraction = () => {
-      const isOverflowing = isTangentToViewport.matches
+      // Skip when effectively mobile — the row cosmetic would bleed into the drawer.
+      const isOverflowing = !this.isEffectivelyMobile()
+        && isTangentToViewport.matches
         && this.elements.topnav?.scrollWidth
         && this.elements.topnav.scrollWidth > document.body.clientWidth;
 
@@ -867,6 +872,62 @@ class Gnav {
 
     toggleContraction();
     isTangentToViewport.addEventListener('change', toggleContraction);
+  };
+
+  // Mobile behaviour source of truth: real mobile, or forced-compact at desktop width.
+  isEffectivelyMobile = () => !isDesktop.matches || this.block.classList.contains('is-compact');
+
+  // Collapse to is-compact (+ .new-nav) when the nav overflows at desktop widths
+  // (mirrors C2's initCompactOverflow); fires feds:compactchange for dropdowns.
+  initCompactOverflow = () => {
+    if (!this.dynamicReflowEnabled) return;
+    const header = this.block;
+    const { topnav } = this.elements;
+    if (!(header instanceof HTMLElement) || !(topnav instanceof HTMLElement)) return;
+    const overflowingClass = selectors.overflowingTopNav.slice(1);
+    let rafId = null;
+
+    const measure = () => {
+      rafId = null;
+      const wasCompact = header.classList.contains('is-compact');
+      // Below the breakpoint the native mobile path owns .new-nav and the rebuild;
+      // firing feds:compactchange here would race it and blank the popup.
+      if (!isDesktop.matches) {
+        if (wasCompact) header.classList.remove('is-compact');
+        return;
+      }
+      const { navWrapper } = this.elements;
+      if (this.newMobileNav && navWrapper instanceof HTMLElement) navWrapper.style.transition = 'none';
+      // Strip is-compact + new-nav to measure the true row width (new-nav translates
+      // items off-screen, under-reporting); drop the cosmetic overflow class too.
+      header.classList.remove('is-compact');
+      if (this.newMobileNav) header.classList.remove('new-nav');
+      const wasOverflowing = topnav.classList.contains(overflowingClass);
+      topnav.classList.remove(overflowingClass);
+      const contentWidth = topnav.scrollWidth;
+      const EXPAND_BUFFER = 40;
+      const threshold = wasCompact ? header.clientWidth - EXPAND_BUFFER : header.clientWidth;
+      const shouldCompact = contentWidth > threshold;
+      header.classList.toggle('is-compact', shouldCompact);
+      if (this.newMobileNav) header.classList.toggle('new-nav', shouldCompact);
+      // Desktop-row cosmetic only — keep off in compact so it can't bleed into the drawer.
+      if (wasOverflowing && !shouldCompact) topnav.classList.add(overflowingClass);
+      if (this.newMobileNav && navWrapper instanceof HTMLElement) {
+        navWrapper.getBoundingClientRect(); // reflow: commit translate with transitions off
+        requestAnimationFrame(() => navWrapper.style.removeProperty('transition'));
+      }
+      if (shouldCompact !== wasCompact) window.dispatchEvent(new CustomEvent('feds:compactchange'));
+    };
+
+    const schedule = () => { if (rafId === null) rafId = requestAnimationFrame(measure); };
+
+    new ResizeObserver(schedule).observe(header);
+    // ResizeObserver(header) misses late-streamed content at a fixed width; watch
+    // topnav mutations + font load so reload comes up compact without a resize.
+    new MutationObserver(schedule).observe(topnav, { childList: true, subtree: true });
+    isDesktop.addEventListener('change', schedule);
+    document.fonts?.ready?.then(schedule);
+    schedule();
   };
 
   loadDelayed = async () => {
@@ -1342,7 +1403,7 @@ class Gnav {
       </button>`;
 
     const setHamburgerPadding = () => {
-      if (isDesktop.matches) {
+      if (!this.isEffectivelyMobile()) {
         this.elements.mainNav.style.removeProperty('padding-bottom');
       } else {
         const offset = Math.ceil(this.elements.topnavWrapper.getBoundingClientRect().bottom);
@@ -1365,7 +1426,7 @@ class Gnav {
     toggle.addEventListener('click', () => logErrorFor(onToggleClick, 'Toggle click failed', 'gnav', 'e'));
 
     const onDeviceChange = () => {
-      if (isDesktop.matches) {
+      if (!this.isEffectivelyMobile()) {
         toggle.setAttribute('aria-expanded', false);
         this.elements.navWrapper.classList.remove('feds-nav-wrapper--expanded');
         document.body.classList.remove('disable-scroll');
@@ -1376,6 +1437,8 @@ class Gnav {
     };
 
     isDesktop.addEventListener('change', () => logErrorFor(onDeviceChange, 'Toggle logic failed on device change', 'gnav', 'e'));
+    // Only when dynamic reflow is enabled does forced-compact fire this event.
+    if (this.dynamicReflowEnabled) window.addEventListener('feds:compactchange', () => logErrorFor(onDeviceChange, 'Toggle logic failed on compact change', 'gnav', 'e'));
 
     return toggle;
   };
@@ -1718,7 +1781,7 @@ class Gnav {
             const popup = template.querySelector('.feds-popup');
             desktopMegaMenuHTML = popup.innerHTML;
             if (!this.newMobileNav) return;
-            if (isDesktop.matches || !popup) return;
+            if (!this.isEffectivelyMobile() || !popup) return;
             mobileNavCleanup();
             mobileNavCleanup = await transformTemplateToMobile({
               popup,
@@ -1744,7 +1807,7 @@ class Gnav {
         })();
         if (this.newMobileNav) {
           const popup = template.querySelector('.feds-popup');
-          if (!isDesktop.matches && popup) {
+          if (this.isEffectivelyMobile() && popup) {
             mobileNavCleanup();
             mobileNavCleanup = await transformTemplateToMobile({
               popup,
@@ -1753,33 +1816,51 @@ class Gnav {
               toggleMenu: this.toggleMenuMobile,
             });
             popup.style.removeProperty('visibility');
-          } else if (isDesktop.matches) {
+          } else if (!this.isEffectivelyMobile()) {
             popup?.style.removeProperty('visibility');
           }
-          isDesktop.addEventListener('change', async () => {
-            const newPopup = template.querySelector('.feds-popup');
-            if (!newPopup) return;
-            enableMobileScroll();
-            if (isDesktop.matches) {
-              newPopup.innerHTML = desktopMegaMenuHTML ?? loadingDesktopMegaMenuHTML;
-              if (newPopup.classList.contains('error')) {
-                const errorDiv = await createErrorPopup();
-                if (newPopup) newPopup.replaceWith(errorDiv);
+          // Rebuild the popup for the current mode. lastMode skips no-op flips
+          // (compact>900 and real<900 are both mobile; re-transforming mobile DOM
+          // blanks it); serialized so runs don't race the shared mobileNavCleanup.
+          let syncing = false;
+          let pendingSync = false;
+          let lastMode = this.isEffectivelyMobile() ? 'mobile' : 'desktop';
+          const syncPopupForViewport = async () => {
+            const mode = this.isEffectivelyMobile() ? 'mobile' : 'desktop';
+            if (mode === lastMode) return;
+            if (syncing) { pendingSync = true; return; }
+            syncing = true;
+            lastMode = mode;
+            try {
+              const newPopup = template.querySelector('.feds-popup');
+              if (!newPopup) return;
+              enableMobileScroll();
+              if (mode === 'desktop') {
+                newPopup.innerHTML = desktopMegaMenuHTML ?? loadingDesktopMegaMenuHTML;
+                if (newPopup.classList.contains('error')) {
+                  const errorDiv = await createErrorPopup();
+                  if (newPopup) newPopup.replaceWith(errorDiv);
+                }
+                this.block.classList.remove('new-nav');
+                disableAriaHidden();
+                removeA11YMobileDropdowns();
+              } else {
+                mobileNavCleanup();
+                mobileNavCleanup = await transformTemplateToMobile({
+                  popup: newPopup,
+                  item,
+                  localnav: this.isLocalNav(),
+                  toggleMenu: this.toggleMenuMobile,
+                });
+                this.block.classList.add('new-nav');
               }
-              this.block.classList.remove('new-nav');
-              disableAriaHidden();
-              removeA11YMobileDropdowns();
-            } else {
-              mobileNavCleanup();
-              mobileNavCleanup = await transformTemplateToMobile({
-                popup: newPopup,
-                item,
-                localnav: this.isLocalNav(),
-                toggleMenu: this.toggleMenuMobile,
-              });
-              this.block.classList.add('new-nav');
+            } finally {
+              syncing = false;
+              if (pendingSync) { pendingSync = false; syncPopupForViewport(); }
             }
-          });
+          };
+          isDesktop.addEventListener('change', syncPopupForViewport);
+          if (this.dynamicReflowEnabled) window.addEventListener('feds:compactchange', syncPopupForViewport);
         }
       }, 'Decorate dropdown failed', 'gnav', 'i');
 
@@ -1825,7 +1906,7 @@ class Gnav {
 
           // Toggle trigger's dropdown on click
           dropdownTrigger.addEventListener('click', (e) => {
-            if (!isDesktop.matches && this.newMobileNav && isSectionMenu) {
+            if (this.isEffectivelyMobile() && this.newMobileNav && isSectionMenu) {
               const popup = dropdownTrigger.nextElementSibling;
               // document.body.style.top should always be set
               // at this point by calling disableMobileScroll
@@ -1833,7 +1914,7 @@ class Gnav {
                 this.updatePopupPosition(popup);
               }
               makeTabActive(popup);
-            } else if (isDesktop.matches && this.newMobileNav && isSectionMenu) {
+            } else if (!this.isEffectivelyMobile() && this.newMobileNav && isSectionMenu) {
               const popup = dropdownTrigger.nextElementSibling;
               if (popup) popup.style.removeProperty('top');
             }

--- a/test/blocks/brand-concierge-global/brand-concierge-global.test.js
+++ b/test/blocks/brand-concierge-global/brand-concierge-global.test.js
@@ -7,6 +7,7 @@ import { setConfig } from '../../../libs/utils/utils.js';
 setConfig({ codeRoot: '/libs', brandConciergeAA: 'testAA' });
 
 const { default: init } = await import('../../../libs/blocks/brand-concierge-global/brand-concierge-global.js');
+const { setCssGnavHeight } = await import('../../../libs/blocks/brand-concierge/bc-utils.js');
 
 describe('Brand Concierge Global', () => {
   let block;
@@ -60,11 +61,14 @@ describe('Brand Concierge Global', () => {
     // global flag exposed on window.milo
     expect(window.milo.brandConcierge.brandConciergeGlobal).to.be.true;
 
-    // main-top CSS variable is set
-    expect(document.documentElement.style.getPropertyValue('--bc-gnav-height')).to.match(/px$/);
-
     // authored rows are removed from the block
     expect(block.children.length).to.equal(0);
+  });
+
+  it('sets the --bc-gnav-height CSS variable when the gnav is present', () => {
+    document.documentElement.style.removeProperty('--bc-gnav-height');
+    setCssGnavHeight();
+    expect(document.documentElement.style.getPropertyValue('--bc-gnav-height')).to.match(/px$/);
   });
 
   it('adds the no-gnav-mobile modifier to the button section', async () => {


### PR DESCRIPTION
Adds an opt-in **dynamic reflow** to the C1 global navigation: when the nav content overflows the header at desktop widths, the nav collapses to the mobile drawer — the same content-driven collapse C2 (federal) already has via `is-compact`, which C1 lacked. This is the foundation for pinning CTAs in the collapsed nav (follow-up).

**Opt-in** via page metadata — no behaviour change on pages without it: `<meta name="gnav-dynamic-reflow" content="on">`

* Add `initCompactOverflow`: a rAF-debounced ResizeObserver (+ MutationObserver on the topnav and `fonts.ready`) measures the natural row width and toggles `is-compact` / `.new-nav`, firing `feds:compactchange`.
* Add an `isEffectivelyMobile()` predicate (`!isDesktop.matches || is-compact`) and route all mobile-vs-desktop runtime branches through it, so forced-compact behaves exactly like real mobile (drawer, mega-menu drill-in, hamburger).
* Guard the desktop `@media (min-width: 900px)` rules with a zero-specificity `:where(header.global-navigation:not(.is-compact))` so they switch off in compact and the mobile-first base cascades through — the non-compact cascade is byte-for-byte unchanged.

Zero footprint when the flag is off (no observers, no listeners; predicate collapses to the existing `isDesktop.matches` behaviour).

Resolves: [MWPW-205011](https://jira.corp.adobe.com/browse/MWPW-205011)

**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.page/drafts/maagrawal/feds-test/dynamic-reflow?martech=off
- After: https://main--da-bacom--adobecom.aem.page/drafts/maagrawal/feds-test/dynamic-reflow?milolibs=MWPW-205011&martech=off


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=MWPW-205011--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=MWPW-205011--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-205011--milo--adobecom
- Milo: https://MWPW-205011--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-205011--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-205011--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-205011--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-205011--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-205011--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-205011--milo--adobecom
- Milo: https://MWPW-205011--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-205011--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-205011--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-205011--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-205011--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-205011--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-205011--milo--adobecom
- Milo: https://MWPW-205011--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-205011--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-205011--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-205011--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-205011--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-205011--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-205011--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-205011--milo--adobecom
</details>