### PR TITLE
MWPW-203985 [Preview Indexer] Replace all site admin tokens with a single AEM EDS Service token

### DIFF
--- a/.github/workflows/preview-indexer/internal/helix-client.js
+++ b/.github/workflows/preview-indexer/internal/helix-client.js
@@ -17,7 +17,7 @@ const axiosWithRetryError = async (request) => {
   }
 };
 
-const { LOCAL_RUN = '' } = process.env;
+const { AEM_ORG_AUTH_TOKEN: aemOrgToken } = process.env;
 const JOB_STATUS_POLL_INTERVAL = Number(process.env.JOB_STATUS_POLL_INTERVAL || '15');
 const JOB_STATUS_TIMEOUT = Number(process.env.JOB_STATUS_TIMEOUT || '2700');
 const LOG_FETCH_MAX_REQUESTS = Number(process.env.LOG_FETCH_MAX_REQUESTS || '10');
@@ -181,13 +181,12 @@ async function getPreviewPathsForRegion(siteOrg, siteRepo, regionPath) {
 }
 
 async function getRedirects(siteOrg, siteRepo) {
-  const adminToken = process.env.AEM_ORG_AUTH_TOKEN;
   const url = `https://main--${siteRepo}--${siteOrg}.aem.page/redirects.json?limit=${MAX_REDIRECT_ENTRIES}`;
   try {
     const response = await axiosWithRetryError({
       method: 'GET',
       url,
-      headers: { Authorization: `token ${adminToken}` }
+      headers: { Authorization: `token ${aemOrgToken}` }
     });
     return response.data?.data?.map(item => item.Source) || [];
   } catch (error) {

--- a/.github/workflows/preview-indexer/internal/helix-client.js
+++ b/.github/workflows/preview-indexer/internal/helix-client.js
@@ -181,8 +181,7 @@ async function getPreviewPathsForRegion(siteOrg, siteRepo, regionPath) {
 }
 
 async function getRedirects(siteOrg, siteRepo) {
-  const adminTokenKey = getSiteEnvKey(siteOrg, siteRepo, 'AEM_ADMIN_TOKEN_');
-  const adminToken = process.env[adminTokenKey];
+  const adminToken = process.env.AEM_ORG_AUTH_TOKEN;
   const url = `https://main--${siteRepo}--${siteOrg}.aem.page/redirects.json?limit=${MAX_REDIRECT_ENTRIES}`;
   try {
     const response = await axiosWithRetryError({


### PR DESCRIPTION
Previous PR - https://github.com/adobecom/milo/pull/6521

Reference of AEM_ADMIN_TOKEN_ in redirects is also replaced with single helix org token

Resolves: [MWPW-203985](https://jira.corp.adobe.com/browse/MWPW-203985)

Test URLs:

Before: https://main--milo--adobecom.aem.page/?martech=off
After: https://main--milo--adobecom.aem.page/?martech=off




