### PR TITLE
[Site Redesign] split-aside-grid rounded corners (containers/borders)

### DIFF
--- a/libs/c2/blocks/split-aside-grid/split-aside-grid.css
+++ b/libs/c2/blocks/split-aside-grid/split-aside-grid.css
@@ -38,7 +38,7 @@
     position: absolute;
     width: 245px;
     height: 465px;
-    border-radius: 28px;
+    border-radius: var(--s2a-border-radius-24);
     border: var(--s2a-border-width-1) solid var(--s2a-color-transparent-white-04);
     padding: var(--s2a-spacing-xs);
     background-color: var(--s2a-color-transparent-white-04);
@@ -65,7 +65,7 @@
         width: 100%;
         height: 100%;
         -webkit-user-drag: none;
-        border-radius: 20px;
+        border-radius: var(--s2a-border-radius-md);
       }
     }
     .video-holder {
@@ -78,7 +78,7 @@
       width: 100%;
       height: 100%;
       -webkit-user-drag: none;
-      border-radius: 20px;
+      border-radius: var(--s2a-border-radius-md);
     }
 
     &:not([data-slot="0"], .incoming) {
@@ -246,6 +246,7 @@
       transition: none;
       width: 100%;
       height: 100%;
+      border-radius: var(--s2a-border-radius-xs);
 
       .video-holder {
         pointer-events: unset;
@@ -254,6 +255,7 @@
       :is(video, img) {
         opacity: 0;
         transition: opacity var(--dropdown-transition);
+        border-radius: var(--s2a-border-radius-2xs);
       }
 
       &[data-slot="0"] {
@@ -405,6 +407,14 @@
 
   .split-aside-grid-stack {
     grid-column: 5 / -1;
+
+    .media {
+      border-radius: var(--s2a-border-radius-md);
+
+      :is(video, img) {
+        border-radius: var(--s2a-border-radius-xs);
+      }
+    }
   }
 
   .split-aside-grid-items {

--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
@@ -38,7 +38,7 @@
     position: absolute;
     width: 245px;
     height: 465px;
-    border-radius: 28px;
+    border-radius: var(--s2a-border-radius-24);
     border: var(--s2a-border-width-1) solid var(--s2a-color-transparent-white-04);
     padding: var(--s2a-spacing-xs);
     background-color: var(--s2a-color-transparent-white-04);
@@ -65,7 +65,7 @@
         width: 100%;
         height: 100%;
         -webkit-user-drag: none;
-        border-radius: 20px;
+        border-radius: var(--s2a-border-radius-md);
       }
     }
     .video-holder {
@@ -83,7 +83,7 @@
       width: 100%;
       height: 100%;
       -webkit-user-drag: none;
-      border-radius: 20px;
+      border-radius: var(--s2a-border-radius-md);
     }
   }
 }
@@ -121,6 +121,11 @@
         width: min(200%, calc(600px * 16 / 9));
         transform: none;
         aspect-ratio: 16 / 9;
+        border-radius: var(--s2a-border-radius-xs);
+
+        :is(img, video) {
+          border-radius: var(--s2a-border-radius-2xs);
+        }
       }
     }
 
@@ -304,6 +309,7 @@
       transition: none;
       width: 100%;
       height: 100%;
+      border-radius: var(--s2a-border-radius-xs);
 
       .video-holder {
         pointer-events: unset;
@@ -312,6 +318,7 @@
       :is(video, img) {
         opacity: 0;
         transition: opacity var(--dropdown-transition);
+        border-radius: var(--s2a-border-radius-2xs);
       }
 
       &[data-slot="0"] {
@@ -472,6 +479,14 @@
 
   .split-aside-grid-stack {
     grid-column: 5 / -1;
+
+    .media {
+      border-radius: var(--s2a-border-radius-md);
+
+      :is(video, img) {
+        border-radius: var(--s2a-border-radius-xs);
+      }
+    }
   }
 
   .split-aside-grid-items {


### PR DESCRIPTION
Aligns `split-aside-grid` rounded corners with the Site Redesign "Rounded corners" spec (Portrait + Landscape UI containers/borders):

* Replace hardcoded `border-radius` px values with design tokens across breakpoints
* **Portrait UI** (mobile phone stack): frame/border `24px`, inner media container `16px`
* **Landscape UI** (desktop + mobile-carousel): border `8px` (S/M) → `16px` (L); container `4px` (S/M) → `8px` (L)
* Applied to both the c2 block and the `mep/ace1209` variant

Resolves: [MWPW-201090](https://jira.corp.adobe.com/browse/MWPW-201090)
Resolves: [MWPW-201092](https://jira.corp.adobe.com/browse/MWPW-201092)

**Test URLs:**

_BizPro — mobile portrait_
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=split-aside-grid-corners&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

_CPro_
- Before: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=site-redesign-foundation&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--default
- After: https://main--da-dc--adobecom.aem.page/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-product?milolibs=split-aside-grid-corners&mep=%2Fdc-shared%2Ffragments%2Ftests%2F2026%2Fq2%2Face1205%2Fdc1205-base-page-dc.json--default

🤖 Generated with [Claude Code](https://claude.com/claude-code)


