### PR TITLE
MWPW-205480 Fix Marketo ARA error overlap

### DIFF
--- a/libs/blocks/marketo/marketo.css
+++ b/libs/blocks/marketo/marketo.css
@@ -237,6 +237,10 @@
   border: 1px solid var(--marketo-form-border);
 }
 
+.marketo .mktoForm.show-warnings .mktoField.mktoInvalid {
+  border: 1px solid var(--marketo-form-error);
+}
+
 .marketo .mktoForm .mktoField::placeholder {
   font-weight: normal;
   color: var(--marketo-form-text);
@@ -432,9 +436,12 @@
 }
 
 .marketo .mktoForm.show-warnings .mktoField.mktoInvalid:not(:focus) {
-  border: 1px solid var(--marketo-form-error);
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Cpath data-name='Path 356676' d='m10.564 2.206-9.249 16.55a.5.5 0 0 0 .436.744h18.5a.5.5 0 0 0 .436-.744l-9.251-16.55a.5.5 0 0 0-.872 0ZM12 17.25a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-1.5a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25Zm0-3.5a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-6a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25Z' fill='%23D31510'/%3E%3C/svg%3E") no-repeat 95% 50% var(--color-white);
   background-size: 19.5px;
+}
+
+[dir="rtl"] .marketo .mktoForm.show-warnings .mktoField.mktoInvalid:not(:focus) {
+  background-position: 5% 50%;
 }
 
 .marketo .mktoForm.show-warnings select.mktoField.mktoInvalid:not(:focus) {
@@ -444,12 +451,20 @@
   background-size: 19.5px, 1em 1em;
 }
 
+[dir="rtl"] .marketo .mktoForm.show-warnings select.mktoField.mktoInvalid:not(:focus){
+  background-position: 14% 50%, 3% 50%;
+}
+
 .marketo .mktoForm.show-warnings .mktoCheckboxList.mktoInvalid label::after {
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Cpath data-name='Path 356676' d='m10.564 2.206-9.249 16.55a.5.5 0 0 0 .436.744h18.5a.5.5 0 0 0 .436-.744l-9.251-16.55a.5.5 0 0 0-.872 0ZM12 17.25a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-1.5a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25Zm0-3.5a.25.25 0 0 1-.25.25h-1.5a.25.25 0 0 1-.25-.25v-6a.25.25 0 0 1 .25-.25h1.5a.25.25 0 0 1 .25.25Z' fill='%23D31510'/%3E%3C/svg%3E") no-repeat 100% 100%;
   background-size: 19.5px;
   display: inline-block;
   height: 24px;
   width: 28px;
+}
+
+[dir="rtl"] .marketo .mktoForm.show-warnings .mktoCheckboxList.mktoInvalid label::after {
+  background-position: 0% 100%
 }
 
 .marketo .mktoForm.show-warnings .mktoError {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fix Marketo ARA error icon and dropdown icon overlapping placeholder text

Resolves: [MWPW-205480](https://jira.corp.adobe.com/browse/MWPW-205480)

<img width="613" height="543" alt="image" src="https://github.com/user-attachments/assets/623249e0-95b4-4868-8fc4-7ab4ba5a06dc" />


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://bmarshal-ara-overlap--milo--adobecom.aem.page/?martech=off

**BACOM URLs:**
- Before: https://main--da-bacom--adobecom.aem.page/ae_ar/drafts/bmarshal/marketo/complete?martech=off
- After: https://main--da-bacom--adobecom.aem.live/ae_ar/drafts/bmarshal/marketo/complete?milolibs=bmarshal-ara-overlap



