### PR TITLE
[NALA] Stabilize BC floating-button scroll assertions (webkit flake)

### DIFF
--- a/nala/blocks/brand-concierge/brand-concierge.test.js
+++ b/nala/blocks/brand-concierge/brand-concierge.test.js
@@ -9,6 +9,23 @@ let webUtil;
 
 const miloLibs = process.env.MILO_LIBS || '';
 
+// The floating button's show/hide is driven by a requestAnimationFrame-throttled,
+// passive scroll handler. Webkit (and headless in general) can miss a single
+// programmatic scrollTo, leaving the `bc-floating-hidden` class stale — the main
+// source of flakiness. Re-scroll + re-dispatch on each poll iteration until the
+// button reaches the expected hidden/visible state, instead of a one-shot scroll
+// plus a fixed wait.
+async function pollFloatingState(page, floatingButton, scrollFn, shouldBeHidden) {
+  await expect(async () => {
+    await page.evaluate(scrollFn);
+    if (shouldBeHidden) {
+      await expect(floatingButton).toHaveClass(/bc-floating-hidden/, { timeout: 2000 });
+    } else {
+      await expect(floatingButton).not.toHaveClass(/bc-floating-hidden/, { timeout: 2000 });
+    }
+  }).toPass({ timeout: 20000 });
+}
+
 test.describe('Milo Brand Concierge Block test suite', () => {
   test.beforeEach(async ({ page }) => {
     bc = new BrandConciergeBlock(page);
@@ -269,17 +286,11 @@ test.describe('Milo Brand Concierge Block test suite', () => {
       });
 
       await test.step('step-4: Verify floating button appears after scrolling past hero', async () => {
-        await page.evaluate(() => {
+        await pollFloatingState(page, bc.floatingButton, () => {
           const el = document.querySelector('.brand-concierge.hero');
           window.scrollTo(0, el.scrollHeight + 100);
-          // Webkit doesn't always fire a `scroll` event for programmatic
-          // scrollTo in headless mode, so the BC scroll handler never runs.
-          // Dispatch one manually so the handler updates the bc-floating-hidden
-          // class regardless of browser quirk.
           window.dispatchEvent(new Event('scroll'));
-        });
-        await page.waitForTimeout(1000);
-        await expect(bc.floatingButton).not.toHaveClass(/bc-floating-hidden/, { timeout: 10000 });
+        }, false);
         expect(await bc.floatingButtonInput.textContent()).toBeTruthy();
       });
 
@@ -496,13 +507,13 @@ test.describe('Milo Brand Concierge Block test suite', () => {
       });
 
       await test.step('step-4: After scrolling past hero, aria-hidden is removed', async () => {
-        await page.evaluate(() => {
+        await pollFloatingState(page, bc.floatingButton, () => {
           const el = document.querySelector('.brand-concierge.hero');
-          if (el) window.scrollTo(0, el.scrollHeight + 1);
-        });
-        await page.waitForTimeout(1000);
-
-        await expect(bc.floatingButton).not.toHaveClass(/bc-floating-hidden/, { timeout: 10000 });
+          if (el) {
+            window.scrollTo(0, el.scrollHeight + 1);
+            window.dispatchEvent(new Event('scroll'));
+          }
+        }, false);
         const ariaHidden = await bc.floatingButtonContainer.getAttribute('aria-hidden');
         expect(ariaHidden).toBeNull();
       });
@@ -568,23 +579,19 @@ test.describe('Milo Brand Concierge Block test suite', () => {
       });
 
       await test.step('step-4: Floating button is visible in the middle of the page', async () => {
-        await page.evaluate(() => {
-          // Scroll well past topDelay but well before the footer.
+        // Scroll well past topDelay but well before the footer.
+        await pollFloatingState(page, bc.floatingButton, () => {
           window.scrollTo(0, Math.floor(document.body.scrollHeight / 2));
           window.dispatchEvent(new Event('scroll'));
-        });
-        await page.waitForTimeout(1000);
-        await expect(bc.floatingButton).not.toHaveClass(/bc-floating-hidden/, { timeout: 10000 });
+        }, false);
       });
 
       await test.step('step-5: Floating button is hidden again near the footer', async () => {
-        await page.evaluate(() => {
-          // Scroll to within anchor-delay distance of the footer.
+        // Scroll to within anchor-delay distance of the footer.
+        await pollFloatingState(page, bc.floatingButton, () => {
           window.scrollTo(0, document.body.scrollHeight);
           window.dispatchEvent(new Event('scroll'));
-        });
-        await page.waitForTimeout(1000);
-        await expect(bc.floatingButton).toHaveClass(/bc-floating-hidden/, { timeout: 10000 });
+        }, true);
       });
 
       await test.step('step-6: Floating button has correct text content', async () => {


### PR DESCRIPTION
## Problem(https://jira.corp.adobe.com/browse/MWPW-206222)
The Brand Concierge floating-button tests (tcid 5, 11, 13) intermittently fail on **webkit** — most recently seen on unrelated PRs' full nala runs (e.g. #6619), passing only on a full retry. The failing assertion is always:
```
Error: expect(locator).not.toHaveClass(expected) failed
Expected pattern: not /bc-floating-hidden/
Received string:  "bc-floating-button bc-floating-element bc-floating-hidden"
```

## Root cause
The floating button's show/hide is driven by a **requestAnimationFrame-throttled, passive scroll handler**. Webkit (and headless browsers generally) can miss a single programmatic `scrollTo`, so the handler never runs and `bc-floating-hidden` stays stale. The tests did a **one-shot** scroll + fixed `waitForTimeout(1000)` + single 10s assertion — if the handler lagged past that window, the test failed; a full retry re-ran the scroll and passed. Classic timing flake.

## Fix
Add `pollFloatingState()` — a re-scrolling `toPass` poll that re-runs the `scrollTo` **and** re-dispatches the `scroll` event on each iteration until the button reaches the expected hidden/visible state (20s budget). Applied to all 4 scroll-driven class assertions (tcid 5 step-4, tcid 11 step-4, tcid 13 step-4/step-5). Also added the missing manual scroll-event dispatch to the aria-hidden step (it only called `scrollTo` before).

Test-only change; no product code touched.

## Verification
- webkit against stage, previously-flaky steps, `--repeat-each=3 --retries=0` → **12/12 pass**
- eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

