### PR TITLE
MWPW-206109: Add "card-metadata" to c2 blocks

### DIFF
--- a/libs/c2/blocks/card-metadata/card-metadata.css
+++ b/libs/c2/blocks/card-metadata/card-metadata.css
@@ -1,0 +1,3 @@
+.card-metadata {
+    display: none;
+}

--- a/libs/c2/blocks/card-metadata/card-metadata.js
+++ b/libs/c2/blocks/card-metadata/card-metadata.js
@@ -1,0 +1,1 @@
+export default function init() {}

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -1376,7 +1376,7 @@ function getBlockData(block) {
   const isC2Block = C2_BLOCKS.includes(name);
   const isAutoBlock = AUTO_BLOCKS.some((autoBlock) => autoBlock[name]);
 
-  const PAGE_AGNOSTIC_BLOCKS = ['preflight'];
+  const PAGE_AGNOSTIC_BLOCKS = ['preflight', 'card-metadata'];
   const isPageAgnostic = PAGE_AGNOSTIC_BLOCKS.includes(name);
   if (isC2Page && isC1Block && !isC2Block && !isAutoBlock && !isPageAgnostic) {
     return { name, isInvalid: true };

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -114,6 +114,7 @@ const C2_BLOCKS = [
   'base-card',
   'box',
   'brand-concierge',
+  'card-metadata',
   'carousel-c2',
   'comparison-table-c2',
   'elastic-carousel',
@@ -1376,7 +1377,7 @@ function getBlockData(block) {
   const isC2Block = C2_BLOCKS.includes(name);
   const isAutoBlock = AUTO_BLOCKS.some((autoBlock) => autoBlock[name]);
 
-  const PAGE_AGNOSTIC_BLOCKS = ['preflight', 'card-metadata'];
+  const PAGE_AGNOSTIC_BLOCKS = ['preflight'];
   const isPageAgnostic = PAGE_AGNOSTIC_BLOCKS.includes(name);
   if (isC2Page && isC1Block && !isC2Block && !isAutoBlock && !isPageAgnostic) {
     return { name, isInvalid: true };


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds card-metadata to c2 blocks 

Resolves: [MWPW-206109:](https://jira.corp.adobe.com/browse/MWPW-206109:)

The below test urls are for bacom content alone, as I believe the current issue only resides there. Likewise, stage is necessary, since stage has the necessary code to reflect these changes. 

**Test URLs:**
- Before: https://stage--da-bacom--adobecom.aem.page/drafts/slavin/iswa/iswa-v2/it-starts-with-adobe-8-31
- After: https://stage--da-bacom--adobecom.aem.page/drafts/slavin/iswa/iswa-v2/it-starts-with-adobe-8-31?milolibs=card-metadata-c2


