### PR TITLE
MWPW-204279 [MEP] Sync country spoofing with Target IP geo-fencing

### DIFF
--- a/libs/features/mep/mep-next/mep-next.js
+++ b/libs/features/mep/mep-next/mep-next.js
@@ -7,6 +7,7 @@ import {
 import { getMarketConfig, marketsLangForLocale } from '../../../utils/market.js';
 import { getMiloLocaleSettings, isMasGeoDetectionEnabled } from '../../../blocks/merch/merch.js';
 import { mepMasSubCollections } from './mep-mas-subcollection.js';
+import { applyGeoSpoof } from './spoof-country-ip.js';
 import { US_GEO, getFileName, normalizePath } from '../../personalization/personalization.js';
 import {
   MAS_OSI_SELECTOR,
@@ -212,32 +213,21 @@ function updatePreviewButton(popup, pageId) {
   }
   if (masMarketOn) {
     simulateHref.searchParams.set('mepMasMarket', 'true');
-    const masVal = mepMasMarketSelect?.value;
-    if (masVal) {
-      simulateHref.searchParams.set('akamaiLocale', masVal);
-    } else {
-      simulateHref.searchParams.delete('akamaiLocale');
-    }
+    applyGeoSpoof(simulateHref.searchParams, mepMasMarketSelect?.value);
   } else if (!mepMasMarketCheckbox && mepMasMarketSelect) {
     // Standalone shape (non-Lingo + M@S): dropdown is authoritative,
     // mepMasMarket=true persists the selection across reloads.
     const masVal = mepMasMarketSelect.value;
     if (masVal) {
       simulateHref.searchParams.set('mepMasMarket', 'true');
-      simulateHref.searchParams.set('akamaiLocale', masVal);
     } else {
       simulateHref.searchParams.delete('mepMasMarket');
-      simulateHref.searchParams.delete('akamaiLocale');
     }
+    applyGeoSpoof(simulateHref.searchParams, masVal);
   } else {
     simulateHref.searchParams.delete('mepMasMarket');
     if (mepLingoRegionSelect) {
-      const selectedRegion = mepLingoRegionSelect.value;
-      if (selectedRegion) {
-        simulateHref.searchParams.set('akamaiLocale', selectedRegion);
-      } else {
-        simulateHref.searchParams.delete('akamaiLocale');
-      }
+      applyGeoSpoof(simulateHref.searchParams, mepLingoRegionSelect.value);
     }
   }
 

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay-logic.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay-logic.js
@@ -1,5 +1,6 @@
 import { mepMasSubCollections } from '../mep-mas-subcollection.js';
 import { HIGHLIGHT_KEYS } from './mep-overlay-highlight.js';
+import { applyGeoSpoof } from '../spoof-country-ip.js';
 import { getMarketConfig, marketsLangForLocale } from '../../../../utils/market.js';
 import {
   hasMasSurfaces,
@@ -490,13 +491,17 @@ export async function setPreviewButton() {
   ];
 
   const simulateHref = new URL(window.location.href);
-  simulateHref.searchParams.set('mep', manifestParameter.join('---'));
-
   const setOrDelete = (key, value) => (value
     ? simulateHref.searchParams.set(key, value)
     : simulateHref.searchParams.delete(key));
 
-  setOrDelete('akamaiLocale', getSpoofGeoParams(popup));
+  if (getCheckboxParam(popup, 'toggle-manifest-parameters')) {
+    simulateHref.searchParams.delete('mep');
+  } else {
+    simulateHref.searchParams.set('mep', manifestParameter.join('---'));
+  }
+
+  applyGeoSpoof(simulateHref.searchParams, getSpoofGeoParams(popup));
   setOrDelete('mepButton', getCheckboxParam(popup, 'toggle-preview-link') && 'off');
   setOrDelete(HIGHLIGHT_KEYS.mep, getCheckboxParam(popup, 'toggle-mep'));
   setOrDelete(HIGHLIGHT_KEYS.caas, getCheckboxParam(popup, 'toggle-caas'));

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay-logic.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay-logic.js
@@ -44,6 +44,22 @@ export function getExpandedCards() {
   } catch { return new Set(); }
 }
 
+// Session-scoped so the choice survives a preview reload but doesn't linger into
+// a later QA session (a sticky "don't apply manifests" would be a footgun).
+export const EXCLUDE_MANIFEST_PARAMS_KEY = 'mep-exclude-manifest-params';
+
+export function getExcludeManifestParams() {
+  try {
+    return sessionStorage.getItem(EXCLUDE_MANIFEST_PARAMS_KEY) === 'true';
+  } catch { return false; }
+}
+
+export function setExcludeManifestParams(on) {
+  try {
+    sessionStorage.setItem(EXCLUDE_MANIFEST_PARAMS_KEY, on ? 'true' : 'false');
+  } catch { /* storage unavailable (private mode) — non-fatal */ }
+}
+
 export const toSlug = (str) => str.toLowerCase().replace(/@|\s+/g, (m) => (m === '@' ? 'a' : '-')).replace(/[^\w-]/g, '');
 
 const STAGE_ALLOWED_HOSTS = [

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -535,7 +535,7 @@ function setEventListeners() {
       });
       return;
     }
-    const cardEl = event.target.closest('.mep-card svg') && event.target.closest('.mep-card');
+    const cardEl = event.target.closest('.mep-card h1 svg') && event.target.closest('.mep-card');
     if (cardEl) toggleExpandedCard(cardEl);
   });
 

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -42,6 +42,7 @@ const CARD_DATA = {
     ]],
     ['Toggle', [
       ['Preview Link', 'Add mepButton=off'],
+      ['Manifest Parameters', 'Exclude from URL'],
       ['Manifest Manager', 'Data for last 7 days'],
     ]],
     ['Spoof Geo', ['Top Markets', 'MEP Lingo', 'Lingo M@S']],

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -3,6 +3,8 @@ import { onSidekickAuth } from '../../sidekick-auth.js';
 import {
   CARD_STORAGE_KEY,
   getExpandedCards,
+  getExcludeManifestParams,
+  setExcludeManifestParams,
   toSlug,
   getPageId,
   getManifestList,
@@ -403,6 +405,9 @@ async function setDefaultValues() {
     toggleHighlight({ target: checkbox });
   });
 
+  const excludeManifestsEl = document.querySelector('#toggle-manifest-parameters');
+  if (excludeManifestsEl) excludeManifestsEl.checked = getExcludeManifestParams();
+
   const selectEl = document.querySelector('select.mep-spoof-geo');
   if (!selectEl) return;
 
@@ -541,6 +546,7 @@ function setEventListeners() {
 
   drawerEl.addEventListener('change', (event) => {
     if (event.target.type === 'checkbox') event.target.toggleAttribute('checked', event.target.checked);
+    if (event.target.id === 'toggle-manifest-parameters') setExcludeManifestParams(event.target.checked);
     setPreviewButton(event);
   });
 

--- a/libs/features/mep/mep-next/spoof-country-ip.js
+++ b/libs/features/mep/mep-next/spoof-country-ip.js
@@ -1,0 +1,106 @@
+// `akamaiLocale` spoofs geo for Milo's own resolution but not for Adobe Target,
+// which resolves geo from the real request IP at the Edge. Emitting a matching
+// IP via Target's `mboxOverride.browserIp` QA param keeps both in sync. Values
+// are representative addresses inside each country's allocated block.
+export const COUNTRY_BROWSER_IP = {
+  US: '11.255.255.254',
+  GB: '5.10.159.255',
+  AU: '1.0.0.255',
+  NZ: '14.1.58.255',
+  CA: '23.91.159.255',
+  FR: '2.15.255.255',
+  DE: '2.247.255.255',
+  JP: '1.0.31.255',
+  AT: '37.143.191.254',
+  BE: '2.22.55.255',
+  BG: '5.32.135.255',
+  BR: '139.82.255.255',
+  CH: '5.44.112.0',
+  CY: '31.216.127.254',
+  CZ: '5.1.63.255',
+  DK: '2.131.255.255',
+  EE: '5.44.191.255',
+  ES: '5.45.175.255',
+  FI: '5.23.63.255',
+  GR: '2.16.179.255',
+  HU: '5.204.255.254',
+  IE: '5.61.119.255',
+  IT: '5.77.64.0',
+  LT: '5.20.255.255',
+  LU: '80.208.207.255',
+  LV: '5.44.223.255',
+  MT: '37.75.63.255',
+  MX: '8.14.226.255',
+  NL: '2.21.95.255',
+  NO: '2.151.255.255',
+  PL: '5.173.255.254',
+  PT: '2.83.255.255',
+  RO: '5.2.255.255',
+  SE: '2.16.69.255',
+  SI: '5.32.143.255',
+  SK: '5.22.154.255',
+  ZA: '41.66.191.254',
+  HK: '14.136.255.255',
+  IL: '31.210.191.25',
+  IN: '1.187.255.23',
+  KR: '1.201.255.255',
+  TR: '5.47.255.255',
+  RU: '5.8.223.25',
+  CN: '61.28.64.10',
+  TW: '27.51.255.25',
+  HR: '31.217.127.254',
+  RS: '46.240.255.25',
+  UA: '5.105.255.25',
+  BH: '46.184.255.254',
+  EG: '41.65.255.254',
+  SA: '2.91.255.254',
+  KW: '37.34.255.255',
+  LB: '78.108.175.255',
+  OM: '46.40.255.255',
+  QA: '78.101.255.255',
+  AE: '5.38.127.255',
+  YE: '89.189.64.1',
+  DZ: '80.249.79.254',
+  MA: '41.143.255.255',
+  JO: '37.123.95.255',
+  TN: '160.159.255.255',
+  PH: '49.151.255.254',
+  SG: '1.32.191.255',
+  ID: '66.96.255.255',
+  MY: '27.110.95.255',
+  TH: '1.4.255.255',
+  VN: '1.55.255.255',
+  CO: '128.90.108.7',
+  CL: '200.73.20.100',
+  AR: '190.210.180.181',
+  CR: '128.90.107.151',
+  PE: '190.60.30.254',
+  VE: '172.111.133.46',
+  EC: '104.224.10.55',
+  GT: '45.74.17.37',
+  PA: '181.179.127.255',
+  BO: '167.157.255.255',
+  DO: '148.101.255.255',
+  PY: '186.2.239.255',
+  SV: '23.92.127.255',
+  UY: '186.8.255.255',
+  TT: '190.6.239.255',
+  AF: '117.55.207.255',
+  NG: '41.184.255.255',
+  PR: '66.50.255.255',
+};
+
+const BROWSER_IP_PARAM = 'mboxOverride.browserIp';
+
+// akamaiLocale is written lowercase; map keys are uppercase → normalize on lookup.
+export function applyGeoSpoof(searchParams, countryCode) {
+  if (!countryCode) {
+    searchParams.delete('akamaiLocale');
+    searchParams.delete(BROWSER_IP_PARAM);
+    return;
+  }
+  searchParams.set('akamaiLocale', countryCode);
+  const ip = COUNTRY_BROWSER_IP[countryCode.toUpperCase()];
+  if (ip) searchParams.set(BROWSER_IP_PARAM, ip);
+  else searchParams.delete(BROWSER_IP_PARAM);
+}

--- a/libs/features/personalization/preview.js
+++ b/libs/features/personalization/preview.js
@@ -22,6 +22,7 @@ import {
   mepMasSubCollections,
 } from './preview-mas-subcollection.js';
 import { US_GEO, getFileName, normalizePath } from './personalization.js';
+import { applyGeoSpoof } from '../mep/mep-next/spoof-country-ip.js';
 
 export function escapeHtml(str) {
   if (str == null || str === '') return str;
@@ -805,32 +806,21 @@ function updatePreviewButton(popup, pageId) {
   }
   if (masMarketOn) {
     simulateHref.searchParams.set('mepMasMarket', 'true');
-    const masVal = mepMasMarketSelect?.value;
-    if (masVal) {
-      simulateHref.searchParams.set('akamaiLocale', masVal);
-    } else {
-      simulateHref.searchParams.delete('akamaiLocale');
-    }
+    applyGeoSpoof(simulateHref.searchParams, mepMasMarketSelect?.value);
   } else if (!mepMasMarketCheckbox && mepMasMarketSelect) {
     // Standalone shape (non-Lingo + M@S): dropdown is authoritative,
     // mepMasMarket=true persists the selection across reloads.
     const masVal = mepMasMarketSelect.value;
     if (masVal) {
       simulateHref.searchParams.set('mepMasMarket', 'true');
-      simulateHref.searchParams.set('akamaiLocale', masVal);
     } else {
       simulateHref.searchParams.delete('mepMasMarket');
-      simulateHref.searchParams.delete('akamaiLocale');
     }
+    applyGeoSpoof(simulateHref.searchParams, masVal);
   } else {
     simulateHref.searchParams.delete('mepMasMarket');
     if (mepLingoRegionSelect) {
-      const selectedRegion = mepLingoRegionSelect.value;
-      if (selectedRegion) {
-        simulateHref.searchParams.set('akamaiLocale', selectedRegion);
-      } else {
-        simulateHref.searchParams.delete('akamaiLocale');
-      }
+      applyGeoSpoof(simulateHref.searchParams, mepLingoRegionSelect.value);
     }
   }
 

--- a/test/features/mep/mep-next/mep-overlay-logic.test.js
+++ b/test/features/mep/mep-next/mep-overlay-logic.test.js
@@ -40,9 +40,12 @@ const fetchStub = sinon.stub(window, 'fetch').callsFake(fetchFn);
 
 const {
   CARD_STORAGE_KEY,
+  EXCLUDE_MANIFEST_PARAMS_KEY,
   TOP_MARKETS,
   API_URLS,
   getExpandedCards,
+  getExcludeManifestParams,
+  setExcludeManifestParams,
   toSlug,
   hasMasChanges,
   getTopMarketsAvailability,
@@ -74,6 +77,26 @@ describe('CARD_STORAGE_KEY', () => {
 
   it('equals "mep-expanded-cards"', () => {
     expect(CARD_STORAGE_KEY).to.equal('mep-expanded-cards');
+  });
+});
+
+describe('exclude manifest params persistence', () => {
+  afterEach(() => sessionStorage.removeItem(EXCLUDE_MANIFEST_PARAMS_KEY));
+
+  it('defaults to false when nothing is stored', () => {
+    expect(getExcludeManifestParams()).to.be.false;
+  });
+
+  it('round-trips true through sessionStorage', () => {
+    setExcludeManifestParams(true);
+    expect(sessionStorage.getItem(EXCLUDE_MANIFEST_PARAMS_KEY)).to.equal('true');
+    expect(getExcludeManifestParams()).to.be.true;
+  });
+
+  it('round-trips false through sessionStorage', () => {
+    setExcludeManifestParams(true);
+    setExcludeManifestParams(false);
+    expect(getExcludeManifestParams()).to.be.false;
   });
 });
 

--- a/test/features/mep/mep-next/mep-overlay-logic.test.js
+++ b/test/features/mep/mep-next/mep-overlay-logic.test.js
@@ -818,9 +818,10 @@ describe('setPreviewButton', () => {
     await setPreviewButton();
     const href = drawer.querySelector('.mep-footer a.con-button').getAttribute('href');
     expect(href).to.include('akamaiLocale=de');
+    expect(href).to.include('mboxOverride.browserIp=2.247.255.255');
   });
 
-  it('removes akamaiLocale from href when spoof geo select value is empty', async () => {
+  it('removes akamaiLocale and the browser IP from href when spoof geo select value is empty', async () => {
     const select = document.createElement('select');
     select.className = 'mep-spoof-geo';
     const opt = document.createElement('option');
@@ -831,6 +832,7 @@ describe('setPreviewButton', () => {
     await setPreviewButton();
     const href = drawer.querySelector('.mep-footer a.con-button').getAttribute('href');
     expect(href).to.not.include('akamaiLocale');
+    expect(href).to.not.include('mboxOverride.browserIp');
   });
 
   it('includes mepButton=off when toggle-preview-link checkbox is checked', async () => {
@@ -853,6 +855,28 @@ describe('setPreviewButton', () => {
     await setPreviewButton();
     const href = drawer.querySelector('.mep-footer a.con-button').getAttribute('href');
     expect(href).to.not.include('mepButton');
+  });
+
+  it('excludes the mep param from href when toggle-manifest-parameters is checked', async () => {
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.id = 'toggle-manifest-parameters';
+    cb.checked = true;
+    drawer.append(cb);
+    await setPreviewButton();
+    const href = drawer.querySelector('.mep-footer a.con-button').getAttribute('href');
+    expect(href).to.not.include('mep=');
+  });
+
+  it('includes the mep param in href when toggle-manifest-parameters is unchecked', async () => {
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.id = 'toggle-manifest-parameters';
+    cb.checked = false;
+    drawer.append(cb);
+    await setPreviewButton();
+    const href = drawer.querySelector('.mep-footer a.con-button').getAttribute('href');
+    expect(href).to.include('mep=');
   });
 
   it('includes mepHighlight param when toggle-mep checkbox is checked', async () => {

--- a/test/features/mep/mep-next/mep-overlay.test.js
+++ b/test/features/mep/mep-next/mep-overlay.test.js
@@ -752,6 +752,14 @@ describe('setEventListeners: toggleExpandedCard', () => {
       expect(stored).to.not.include(key);
     }
   });
+
+  it('clicking a Spoof Geo radio-row SVG does not collapse the card', () => {
+    const card = mainEl.querySelector('#mep-drawer [data-card-key="Spoof Geo"]');
+    const radioSvg = card.querySelector('.mep-radio-row svg');
+    const was = card.classList.contains('expanded');
+    radioSvg.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(card.classList.contains('expanded')).to.equal(was);
+  });
 });
 
 // ============================================================

--- a/test/features/mep/mep-next/mep-overlay.test.js
+++ b/test/features/mep/mep-next/mep-overlay.test.js
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 
 const { setConfig, updateConfig, getConfig } = await import('../../../../libs/utils/utils.js');
-const { CARD_STORAGE_KEY } = await import('../../../../libs/features/mep/mep-next/mep-overlay/mep-overlay-logic.js');
+const { CARD_STORAGE_KEY, EXCLUDE_MANIFEST_PARAMS_KEY } = await import('../../../../libs/features/mep/mep-next/mep-overlay/mep-overlay-logic.js');
 
 // icon-mep has onclick/onload attributes to exercise svgIcon() sanitization branch
 const SVG_DATA = {
@@ -213,6 +213,18 @@ describe('init: DOM structure — stage env first call', () => {
 
   it('Preview Link toggle exists (string description in buildToggleRow)', () => {
     expect(mainEl.querySelector('#toggle-preview-link')).to.exist;
+  });
+
+  it('persists the Manifest Parameters toggle to sessionStorage on change', () => {
+    const cb = mainEl.querySelector('#toggle-manifest-parameters');
+    expect(cb).to.exist;
+    cb.checked = true;
+    cb.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(sessionStorage.getItem(EXCLUDE_MANIFEST_PARAMS_KEY)).to.equal('true');
+    cb.checked = false;
+    cb.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(sessionStorage.getItem(EXCLUDE_MANIFEST_PARAMS_KEY)).to.equal('false');
+    sessionStorage.removeItem(EXCLUDE_MANIFEST_PARAMS_KEY);
   });
 
   it('MEP highlight toggle has function-computed description (0 Page Updates)', () => {

--- a/test/features/mep/mep-next/spoof-country-ip.test.js
+++ b/test/features/mep/mep-next/spoof-country-ip.test.js
@@ -1,0 +1,46 @@
+import { expect } from '@esm-bundle/chai';
+import { applyGeoSpoof, COUNTRY_BROWSER_IP } from '../../../../libs/features/mep/mep-next/spoof-country-ip.js';
+
+const IP_PARAM = 'mboxOverride.browserIp';
+
+describe('applyGeoSpoof', () => {
+  it('sets akamaiLocale and the matching browser IP for a mapped country', () => {
+    const params = new URLSearchParams();
+    applyGeoSpoof(params, 'de');
+    expect(params.get('akamaiLocale')).to.equal('de');
+    expect(params.get(IP_PARAM)).to.equal(COUNTRY_BROWSER_IP.DE);
+  });
+
+  it('looks up the IP case-insensitively while keeping akamaiLocale as given', () => {
+    const params = new URLSearchParams();
+    applyGeoSpoof(params, 'DE');
+    expect(params.get('akamaiLocale')).to.equal('DE');
+    expect(params.get(IP_PARAM)).to.equal(COUNTRY_BROWSER_IP.DE);
+  });
+
+  it('sets akamaiLocale but no browser IP for an unmapped country', () => {
+    const params = new URLSearchParams();
+    applyGeoSpoof(params, 'zz');
+    expect(params.get('akamaiLocale')).to.equal('zz');
+    expect(params.has(IP_PARAM)).to.be.false;
+  });
+
+  it('clears a stale browser IP when switching to an unmapped country', () => {
+    const params = new URLSearchParams('akamaiLocale=de&mboxOverride.browserIp=2.247.255.255');
+    applyGeoSpoof(params, 'zz');
+    expect(params.get('akamaiLocale')).to.equal('zz');
+    expect(params.has(IP_PARAM)).to.be.false;
+  });
+
+  it('deletes both params when the country code is empty', () => {
+    const params = new URLSearchParams('akamaiLocale=de&mboxOverride.browserIp=2.247.255.255');
+    applyGeoSpoof(params, '');
+    expect(params.has('akamaiLocale')).to.be.false;
+    expect(params.has(IP_PARAM)).to.be.false;
+  });
+
+  it('includes NG and PR to cover the live supported-market gap', () => {
+    expect(COUNTRY_BROWSER_IP.NG).to.be.a('string');
+    expect(COUNTRY_BROWSER_IP.PR).to.be.a('string');
+  });
+});


### PR DESCRIPTION
- Sync MEP-button country spoofing with Adobe Target's IP geo-fencing. The MEP
  spoofer only wrote `akamaiLocale`, which spoofs geo for Milo's own resolution
  but NOT for Target — Target resolves geo from the real request IP at the Edge.
  A new `applyGeoSpoof` helper now also emits Target's `mboxOverride.browserIp`
  QA param with a representative IP for the selected country, so one click
  previews the same country across both Milo MEP and Target (no more falling
  into US-only tests while spoofed to NG).
- Add a "Manifest Parameters" toggle to the MEP Next preview card. When on, the
  `mep` param is omitted from the preview URL so the previewed page loads with
  no manifest parameters applied. The choice is persisted in sessionStorage, so
  it survives a preview reload but clears when the tab closes.
- Fix the Spoof Geo card collapsing when its radio buttons are clicked — the
  collapse handler matched any `svg` in the card (including the radio icons);
  it's now scoped to the header chevron only.

Preview/QA tooling only — all changed modules load exclusively under
`config.mep?.preview`, so production pages without MEP are unaffected.

Resolves: [MWPW-204279](https://jira.corp.adobe.com/browse/MWPW-204279)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mep-spoof-mboxoverride-browserip--milo--adobecom.aem.page/?martech=off

**QA URL (Target geo-fence sync):** https://www.stage.adobe.com/?milolibs=mep-spoof-mboxoverride-browserip&mepnext=on
1. Open the QA URL, open the MEP button, and spoof geo to a non-US country (e.g. NG) in the Spoof Geo card.
2. Press Preview — the URL now carries both `akamaiLocale=ng` and `mboxOverride.browserIp=<NG IP>`.
3. On the reloaded page, confirm `ace1165v3.json` no longer fires (check `ttMETA`), matching real NG-user behavior. It still fires when spoofed to US.








