### PR TITLE
Brand Concierge - UI update based on chat history

### DIFF
--- a/libs/blocks/brand-concierge-global/brand-concierge-global.css
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.css
@@ -578,12 +578,12 @@ nav.feds-topnav .feds-bc-wrapper {
 
 /* gnav collapse */
 @media screen and (min-width: 900px) {
-  .bc-gnav-button {
+  .bc-gnav:not(.has-chat-history) .bc-gnav-button {
     display: none;
   }
 
-  .bc-gnav .bc-prompt-cards,
-  .bc-gnav .bc-input-field {
+  .bc-gnav:not(.has-chat-history) .bc-prompt-cards,
+  .bc-gnav:not(.has-chat-history) .bc-input-field {
     display: flex;
   }
 }

--- a/libs/blocks/brand-concierge-global/brand-concierge-global.css
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.css
@@ -1,5 +1,6 @@
-nav.feds-topnav .feds-bc-wrapper {
+.global-navigation .feds-bc-wrapper {
   width: 340px;
+  margin-left: auto;
   padding: 0 8px;
 }
 

--- a/libs/blocks/brand-concierge-global/brand-concierge-global.css
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.css
@@ -114,6 +114,7 @@ nav.feds-topnav .feds-bc-wrapper {
   background: #fff;
   border: none;
   border-radius: 20px;
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/libs/blocks/brand-concierge-global/brand-concierge-global.js
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.js
@@ -30,14 +30,6 @@ function gnavDeactivate(gnavInput, gnavCards) {
   }
 }
 
-function updateGnavHistoryUi() {
-  if (bcGlobal) {
-    if (!bcGlobal.classList.contains('has-chat-history')) {
-      bcGlobal.classList.add('has-chat-history');
-    }
-  }
-}
-
 function handleInput(text, gnavInput) {
   const textWrapper = gnavInput.querySelector('.bc-textarea-grow-wrap');
   const textArea = gnavInput.querySelector('textarea');
@@ -50,7 +42,6 @@ function handleInput(text, gnavInput) {
   gnavDeactivate(gnavInput, gnavCards);
   setCssGnavHeight();
   openSideModal(text, bcBootstrap);
-  updateGnavHistoryUi();
 }
 
 function handleSuggestedPrompt(text, gnavCards, event) {
@@ -59,7 +50,6 @@ function handleSuggestedPrompt(text, gnavCards, event) {
   gnavDeactivate(gnavInput, gnavCards);
   setCssGnavHeight();
   openSideModal(text, bcBootstrap);
-  updateGnavHistoryUi();
 }
 
 function handleGnavButton(event) {
@@ -89,13 +79,15 @@ function decorateGnav(cards, input, topNav, el) {
     gnavButtonSection.appendChild(gnavButton);
     bcGnav.appendChild(gnavButtonSection);
 
-    if (!bcGlobal) bcGlobal = bcGnav;
+    window.addEventListener('bc:side-modal-open', () => {
+      if (!bcGnav.classList.contains('has-chat-history')) {
+        bcGnav.classList.add('has-chat-history');
+      }
+    });
     // remove the has-chat-history class if the overlay is closed before chat history is written
     window.addEventListener('bc:side-modal-close', () => {
-      if (bcGlobal) {
-        if (!hasChatCookie()) {
-          bcGlobal.classList.remove('has-chat-history');
-        }
+      if (!hasChatCookie()) {
+        bcGnav.classList.remove('has-chat-history');
       }
     });
 

--- a/libs/blocks/brand-concierge-global/brand-concierge-global.js
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.js
@@ -86,9 +86,18 @@ function decorateGnav(cards, input, topNav, el) {
   const gnavButton = createTag('button', { class: 'gnav-button' }, `${aiIcon('gb-ai-icon', 'gnav-button-icon', 'Ask', 20)}`);
 
   if (bcWrapper) {
-    if (!bcGlobal) bcGlobal = bcGnav;
     gnavButtonSection.appendChild(gnavButton);
     bcGnav.appendChild(gnavButtonSection);
+
+    if (!bcGlobal) bcGlobal = bcGnav;
+    // remove the has-chat-history class if the overlay is closed before chat history is written
+    window.addEventListener('bc:side-modal-close', () => {
+      if (bcGlobal) {
+        if (!hasChatCookie()) {
+          bcGlobal.classList.remove('has-chat-history');
+        }
+      }
+    });
 
     bcWrapper.appendChild(bcGnav);
     const gnavInput = decorateInput(bcGnav, input, { handle: handleInput }, 'bcg-');

--- a/libs/blocks/brand-concierge-global/brand-concierge-global.js
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.js
@@ -16,6 +16,7 @@ import {
 } from '../brand-concierge/bc-bootstrap.js';
 
 let stayActive = false;
+let bcGlobal;
 
 function gnavActivate(gnavInput, gnavCards) {
   gnavInput.classList.add('active');
@@ -26,6 +27,14 @@ function gnavDeactivate(gnavInput, gnavCards) {
   if (!stayActive) {
     gnavInput.classList.remove('active');
     gnavCards.classList.remove('active');
+  }
+}
+
+function updateGnavHistoryUi() {
+  if (bcGlobal) {
+    if (!bcGlobal.classList.contains('has-chat-history')) {
+      bcGlobal.classList.add('has-chat-history');
+    }
   }
 }
 
@@ -41,6 +50,7 @@ function handleInput(text, gnavInput) {
   gnavDeactivate(gnavInput, gnavCards);
   setCssGnavHeight();
   openSideModal(text, bcBootstrap);
+  updateGnavHistoryUi();
 }
 
 function handleSuggestedPrompt(text, gnavCards, event) {
@@ -49,6 +59,7 @@ function handleSuggestedPrompt(text, gnavCards, event) {
   gnavDeactivate(gnavInput, gnavCards);
   setCssGnavHeight();
   openSideModal(text, bcBootstrap);
+  updateGnavHistoryUi();
 }
 
 function handleGnavButton(event) {
@@ -69,12 +80,13 @@ function promptUp() {
 
 function decorateGnav(cards, input, topNav, el) {
   const bcWrapper = topNav.querySelector('.feds-bc-wrapper');
-  const bcGnav = createTag('div', { class: 'bc-gnav' });
+  const bcGnav = createTag('div', { class: `bc-gnav${hasChatCookie() ? ' has-chat-history' : ''}` });
   const hasNoMobile = el.classList.contains('no-gnav-mobile');
-  const gnavButtonSection = createTag('section', { class: `bc-gnav-button ${hasNoMobile ? ' no-gnav-mobile' : ''}` });
+  const gnavButtonSection = createTag('section', { class: `bc-gnav-button${hasNoMobile ? ' no-gnav-mobile' : ''}` });
   const gnavButton = createTag('button', { class: 'gnav-button' }, `${aiIcon('gb-ai-icon', 'gnav-button-icon', 'Ask', 20)}`);
 
   if (bcWrapper) {
+    if (!bcGlobal) bcGlobal = bcGnav;
     gnavButtonSection.appendChild(gnavButton);
     bcGnav.appendChild(gnavButtonSection);
 

--- a/libs/blocks/brand-concierge-global/brand-concierge-global.js
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.js
@@ -16,7 +16,6 @@ import {
 } from '../brand-concierge/bc-bootstrap.js';
 
 let stayActive = false;
-let bcGlobal;
 
 function gnavActivate(gnavInput, gnavCards) {
   gnavInput.classList.add('active');

--- a/libs/blocks/brand-concierge/bc-bootstrap.js
+++ b/libs/blocks/brand-concierge/bc-bootstrap.js
@@ -368,6 +368,7 @@ export async function openSideModal(initialMessage, bootstrap) {
       });
     },
   });
+  window.dispatchEvent(new CustomEvent('bc:side-modal-open'));
 
   setTimeout(() => {
     modal.classList.remove('opening');

--- a/libs/blocks/brand-concierge/bc-bootstrap.js
+++ b/libs/blocks/brand-concierge/bc-bootstrap.js
@@ -359,6 +359,7 @@ export async function openSideModal(initialMessage, bootstrap) {
     id: 'brand-concierge-side',
     content: innerModal,
     closeCallback: async () => {
+      window.dispatchEvent(new CustomEvent('bc:side-modal-close'));
       localStorage.setItem('bc-side-overlay', 'closed');
       document.body.classList.remove('bc-side-open');
       modal.classList.add('closing');


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* When the chat overlay is closed, swap tp the button in place of the full input, if there is chat history present
* small css selector update and rule to ensure that the block is always flush right.

Resolves: [MWPW-204339](https://jira.corp.adobe.com/browse/MWPW-204339)

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/drafts/colloyd/brand-concierge/bc-global
- After: https://bcg-history-ui--milo--adobecom.aem.page/drafts/colloyd/brand-concierge/bc-global

Testing notes: 
- Use an incognito tab to test the "After" page to ensure that you don't have any chat history. 
- Submit a query to open the overlay.
- If you close before the response had finished, it will revert back to the input as chat history is populated after the first complete response.
- If you wait for the response to finish, so that history is fully written, then close the overlay, it will use the button, persisting through page refreshes as well. 





