### PR TITLE
[MWPW-206300] - Parallax promo fix

### DIFF
--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1439,7 +1439,7 @@ span.hang-opening-quote {
   /* Section 1 to section 2 parallax declarations */
   /* TODO: decide if this is general enough to be a global class */
   .section.parallax-move-up-fast {
-    --parallax-move-up-to: calc(-35vh - var(--feds-promo-bar-height, 0px));
+    --parallax-move-up-to: calc(var(--feds-promo-bar-height, 0px) - 35vh);
 
     will-change: transform;
     position: sticky;
@@ -1452,7 +1452,7 @@ span.hang-opening-quote {
 
     /* Shorter viewports in the common laptop width band need more travel */
     @media (width >= 1280px) and (width < 1440px) and (height < 900px) {
-      --parallax-move-up-to: calc(-50vh - var(--feds-promo-bar-height, 0px));
+      --parallax-move-up-to: calc(var(--feds-promo-bar-height, 0px) - 50vh);
     }
 
     /* Once the promo bar has scrolled out (feds-header-scrolled), it no longer

--- a/libs/c2/styles/styles.css
+++ b/libs/c2/styles/styles.css
@@ -1439,7 +1439,7 @@ span.hang-opening-quote {
   /* Section 1 to section 2 parallax declarations */
   /* TODO: decide if this is general enough to be a global class */
   .section.parallax-move-up-fast {
-    --parallax-move-up-to: calc(var(--feds-promo-bar-height, 0px) - 35vh);
+    --parallax-move-up-to: calc(-35vh - var(--feds-promo-bar-height, 0px));
 
     will-change: transform;
     position: sticky;
@@ -1452,7 +1452,17 @@ span.hang-opening-quote {
 
     /* Shorter viewports in the common laptop width band need more travel */
     @media (width >= 1280px) and (width < 1440px) and (height < 900px) {
-      --parallax-move-up-to: calc(var(--feds-promo-bar-height, 0px) - 50vh);
+      --parallax-move-up-to: calc(-50vh - var(--feds-promo-bar-height, 0px));
+    }
+
+    /* Once the promo bar has scrolled out (feds-header-scrolled), it no longer
+       offsets this section, so drop the var and move by the flat vh amount. */
+    body:has(header.feds-header-scrolled) & {
+      --parallax-move-up-to: -35vh;
+
+      @media (width >= 1280px) and (width < 1440px) and (height < 900px) {
+        --parallax-move-up-to: -50vh;
+      }
     }
 
     &::after {


### PR DESCRIPTION
## Description

The section-to-section parallax marquee on the redesigned homepage revealed a **black background behind the marquee** on pages that render a promo bar. The `.parallax-move-up-fast` section's upward travel (`--parallax-move-up-to`) always factored in `--feds-promo-bar-height` to offset the space the promo pushes content down by. But once the promo bar scrolls out of view and the global nav gains `feds-header-scrolled`, that offset is no longer valid — the section over-travels and the black `::after` fade overlay is exposed as a gap between section 1 and section 2.

This PR makes the promo-bar-height compensation conditional on the promo bar actually being visible:

* Fix black background / gap appearing behind the marquee on homepages with a promo bar
* While the promo bar is showing, keep offsetting the parallax travel by `--feds-promo-bar-height` (unchanged behavior)
* Once the header gains `feds-header-scrolled` (promo bar scrolled out), drop the var and move by the flat `-35vh` / `-50vh` amount so the section no longer over-travels

Resolves: [MWPW-206300](https://jira.corp.adobe.com/browse/MWPW-206300)

**Test URLs:**
- **Redesign demo**
  - Before: https://main--upp--adobecom.aem.page/homepage/drafts/blaishram/redesign-demo?milolibs=stage
  - After: https://main--upp--adobecom.aem.page/homepage/drafts/blaishram/redesign-demo?milolibs=parallax-promo-fix-nav
- **Promo bar — maximized**
  - Before: https://main--upp--adobecom.aem.page/homepage/drafts/blaishram/redesign-demo-promo-maximized?milolibs=stage
  - After: https://main--upp--adobecom.aem.page/homepage/drafts/blaishram/redesign-demo-promo-maximized?milolibs=parallax-promo-fix-nav
- **Promo bar — minimized**
  - Before: https://main--upp--adobecom.aem.page/homepage/drafts/blaishram/redesign-demo-promo-minimized?milolibs=stage
  - After: https://main--upp--adobecom.aem.page/homepage/drafts/blaishram/redesign-demo-promo-minimized?milolibs=parallax-promo-fix-nav

**_Test URLs that require parallax to be removed from section nesting fragment - NEED GWP_**
- Before: https://main--upp--adobecom.aem.live/homepage/index-loggedout?mep=%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fen-lingo-ip%2Fen-lingo-ip.json--countryip%28ie%29---%2Fhomepage%2Fmanifests%2F2026%2Flingo-customization%2Ffooter-de-kr%2Fseparate-de.json--default---%2Fhomepage%2Fmanifests%2F2026%2Flingo-customization%2Ffooter-de-kr%2Fseparate-kr.json--default---%2Fhomepage%2Fmanifests%2F2026%2Flatam%2Fbts-q3-promo%2Fus-bts-q3-promo-190753.json--all---%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fff-ext-q4%2Fff-ext-q4-en-lingo-192863.json--default---%2Fhomepage%2Ffragments%2Fmep%2Fhp-06-02-26-redesign-pzn.json--default&milolibs=stage
- After: https://main--upp--adobecom.aem.live/homepage/index-loggedout?mep=%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fen-lingo-ip%2Fen-lingo-ip.json--countryip%28ie%29---%2Fhomepage%2Fmanifests%2F2026%2Flingo-customization%2Ffooter-de-kr%2Fseparate-de.json--default---%2Fhomepage%2Fmanifests%2F2026%2Flingo-customization%2Ffooter-de-kr%2Fseparate-kr.json--default---%2Fhomepage%2Fmanifests%2F2026%2Flatam%2Fbts-q3-promo%2Fus-bts-q3-promo-190753.json--all---%2Fhomepage%2Fmanifests%2F2026%2Fglobal%2Fff-ext-q4%2Fff-ext-q4-en-lingo-192863.json--default---%2Fhomepage%2Ffragments%2Fmep%2Fhp-06-02-26-redesign-pzn.json--default&milolibs=parallax-promo-fix-nav


