### PR TITLE
MWPW-206319: center mas preview content

### DIFF
--- a/libs/blocks/mas-preview/mas-preview.css
+++ b/libs/blocks/mas-preview/mas-preview.css
@@ -1,6 +1,7 @@
 
 .fragment-meta {
-    margin: 10px 50px 20px 50px;
+    width: var(--grid-container-width);
+    margin: 10px auto 20px;
     display: flex;
     gap: 10px;
     flex-wrap: wrap;
@@ -44,7 +45,8 @@
 
 .fragment-preview {
   min-height: 100px;
-  margin: 0 0 10px 50px;
+  width: var(--grid-container-width);
+  margin: 0 auto 10px;
 }
 
 .fragment-preview.hidden {


### PR DESCRIPTION
Resolves: [MWPW-206319](https://jira.corp.adobe.com/browse/MWPW-206319)

* Center the MAS preview content and meta bar
* Reuse Milo's container width (`--grid-container-width`) instead of a one-sided 50px margin
* Keeps proportional side gutters on smaller screens

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/merch/mas/preview?fragment-id=e942f7d4-153e-4e0d-aedb-87c41874945d&content-type=merch-card&locale=en_US
- After: https://MWPW-206319--milo--adobecom.aem.page/merch/mas/preview?fragment-id=e942f7d4-153e-4e0d-aedb-87c41874945d&content-type=merch-card&locale=en_US
