### PR TITLE
MWPW-180862: Respect section grid-width in how-to large-image/large-media variant

### DIFF
--- a/libs/blocks/how-to/how-to.css
+++ b/libs/blocks/how-to/how-to.css
@@ -41,6 +41,10 @@
   grid-template-areas: var(--grid-default);
  }
 
+ .section[class*='grid-width-'] .how-to .foreground {
+  max-width: unset;
+ }
+
  .how-to ol {
   list-style-type: none;
   padding: 0;
@@ -212,6 +216,15 @@
 
   .how-to.large-media .how-to-media.large {
     max-width: 500px;
+  }
+
+  .section[class*='grid-width-'] .how-to.large-image .foreground,
+  .section[class*='grid-width-'] .how-to.large-media .foreground {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .section[class*='grid-width-'] .how-to ol {
+    min-width: 0;
   }
  }
 

--- a/libs/blocks/how-to/how-to.css
+++ b/libs/blocks/how-to/how-to.css
@@ -41,9 +41,9 @@
   grid-template-areas: var(--grid-default);
  }
 
- .section[class*='grid-width-'] .how-to .foreground {
+.section[class*='grid-width-'] .how-to .foreground {
   max-width: unset;
- }
+}
 
  .how-to ol {
   list-style-type: none;
@@ -226,7 +226,7 @@
   .section[class*='grid-width-'] .how-to ol {
     min-width: 0;
   }
- }
+}
 
  .dark .how-to,
  .how-to.dark {


### PR DESCRIPTION
## Description
The `how-to` block's `large-image`/`large-media` variant ignored the section's `grid-width-*` setting. It used its own global container-width variable instead of the section's already-narrowed width, and a fixed `500px` media column (plus a `460px` list min-width) meant the block overflowed to ~1000px instead of the correct ~800px inside a `grid-width-8` section.

Fix is scoped entirely to `how-to.css`:
- Unset the block's own `max-width` when nested in a `grid-width-*` section, so it inherits the section's actual width (matches the existing pattern already used by `text-block`/`icon-block`).
- Media and list columns now split evenly (`minmax(0, 1fr) minmax(0, 1fr)`) inside `grid-width-*` sections instead of a rigid `500px` image column, matching the confirmed Figma spec (media = 380px = exactly half of the 800px section, minus gap, at grid-width-8).

Confirmed with design (Kyung Lee) that no changes to `section-metadata.css` were needed.

Figma tech spec: https://www.figma.com/design/FTIF5N4h0FWtbyjvUyrd32/How-To?node-id=2842-45117

Resolves: [MWPW-180862](https://jira.corp.adobe.com/browse/MWPW-180862)

## Test URLs
- Before: https://main--milo--adobecom.aem.page/drafts/klee/jira-ticket/mwpw-180862-grid-8-issue
- After: https://mwpw-180862-grid-width-fix--milo--adobecom.aem.page/drafts/klee/jira-ticket/mwpw-180862-grid-8-issue


- Live URL to test on (for QA): https://main--da-dc--adobecom.aem.page/acrobat/online/pdf-to-word?milolibs=mwpw-180862-grid-width-fix 





