### PR TITLE
Brand Concierge - bug fix for chat history ui

### DIFF
--- a/libs/blocks/brand-concierge-global/brand-concierge-global.css
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.css
@@ -541,7 +541,7 @@
 }
 
 /* functional controls */
-.bc-side-open .bc-gnav-button {
+.bc-side-open .bc-gnav-button:not(.no-gnav-mobile) {
   display: flex;
 }
 

--- a/libs/blocks/brand-concierge-global/brand-concierge-global.css
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.css
@@ -580,6 +580,10 @@
 
 /* gnav collapse */
 @media screen and (min-width: 900px) {
+  .bc-gnav.has-chat-history .bc-gnav-button.no-gnav-mobile {
+    display: flex;
+  }
+
   .bc-gnav:not(.has-chat-history) .bc-gnav-button {
     display: none;
   }

--- a/libs/blocks/brand-concierge-global/brand-concierge-global.js
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.js
@@ -115,7 +115,12 @@ function decorateGnav(cards, input, topNav, el) {
       }, 500);
       if (document.body.classList.contains('bc-side-open')) {
         const closeButton = document.querySelector('#brand-concierge-side button.dialog-close');
-        closeButton.click();
+        if (closeButton) {
+          closeButton.click();
+        } else {
+          document.body.classList.remove('bc-side-open');
+          handleGnavButton(event);
+        }
       } else handleGnavButton(event);
     });
     if (window?.milo) {


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Bug Fix: When the chat history is present and the input swaps to a button, when combined with the "no-gnav-mobile" variant, the button is not shown
* no-gnav-mobile will still honor hiding the button at mobile widths.
* Bug Fix: a small bug that shows the button in mobile with "no-gnav-mobile" when chat is open.
* Bug Fix: when clicking the gnav button when the overlay is still closing, it would throw an error and render the chat overlay broken. You can now rapidly click with no error and the overlay will continue to open on subsequent attempts

Resolves: [MWPW-204339](https://jira.corp.adobe.com/browse/MWPW-204339)
Resolves: [MWPW-204311](https://jira.corp.adobe.com/browse/MWPW-204311)

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/drafts/colloyd/brand-concierge/bc-global-no-mobile
- After: https://bcg-no-gnav-mobile-fix--milo--adobecom.aem.page/drafts/colloyd/brand-concierge/bc-global-no-mobile

Testing notes: 
- This is a fix for a bug related to the change made in this PR: https://github.com/adobecom/milo/pull/6624
- Use an incognito tab to test the "After" page to ensure that you don't have any chat history. 
- Submit a query to open the overlay.
- If you close before the response had finished, it will revert back to the input as chat history is populated after the first complete response.
- If you wait for the response to finish, so that history is fully written, then close the overlay, it will use the button, persisting through page refreshes as well. 







