### PR TITLE
MWPW-206139 Fix MAS fields in mega menu

### DIFF
--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -1,5 +1,5 @@
 import { processTrackingLabels } from '../../../../martech/attributes.js';
-import { getConfig, shouldBlockFreeTrialLinks } from '../../../../utils/utils.js';
+import { createTag, getConfig, shouldBlockFreeTrialLinks } from '../../../../utils/utils.js';
 import { debounce } from '../../../../utils/action.js';
 import {
   fetchAndProcessPlainHtml,
@@ -26,6 +26,21 @@ try {
   merch = await import('../../../merch/merch.js');
 } catch (e) {
   merch = { default: async (elem) => elem };
+}
+
+// A cloned link has no parent, so merch.default()'s internal `el.replaceWith(...)` no-ops and
+// the built element never connects/fetches; stage it here first so it can.
+let merchStagingContainer;
+function getMerchStagingContainer() {
+  merchStagingContainer ??= createTag('div', { style: 'display: none' }, null, { parent: document.body });
+  return merchStagingContainer;
+}
+
+async function resolveMerch(clonedElement) {
+  getMerchStagingContainer().append(clonedElement);
+  const result = await merch.default(clonedElement);
+  if (!result) clonedElement.remove();
+  return result;
 }
 
 function getAnalyticsValue(str, index) {
@@ -193,26 +208,28 @@ const decorateElements = async ({ elem, className = 'feds-navLink', itemIndex = 
     if (shouldBlockFreeTrialLinks(link)) return null;
     // Increase analytics index every time a link is decorated
     itemIndex.position += 1;
+    // Capture now: links decorate concurrently, so this may move on before an `await` resolves
+    const index = itemIndex.position;
 
     // Decorate link group
     if (link.matches('.link-group')) {
       const merchAnchor = link.querySelector('a.merch');
       if (merchAnchor) {
         const clonedElement = merchAnchor.cloneNode(true);
-        const merchElement = await merch.default(clonedElement);
+        const merchElement = await resolveMerch(clonedElement);
         const primaryAnchor = link.querySelector('a:not(.merch)');
         if (merchElement && primaryAnchor && merchAnchor !== primaryAnchor) {
-          return decorateLinkGroupWithEmbeddedMerch(link, itemIndex.position, merchElement);
+          return decorateLinkGroupWithEmbeddedMerch(link, index, merchElement);
         }
         if (merchElement) {
-          const decoratedElement = decorateLinkGroup(link, itemIndex.position);
+          const decoratedElement = decorateLinkGroup(link, index);
           merchElement.classList.value = decoratedElement.classList.value;
           merchElement.innerHTML = decoratedElement.innerHTML;
           merchElement.setAttribute('daa-ll', decoratedElement.getAttribute('daa-ll'));
           return merchElement;
         }
       }
-      return decorateLinkGroup(link, itemIndex.position);
+      return decorateLinkGroup(link, index);
     }
 
     // If the link is wrapped in a 'strong' or 'em' tag, make it a CTA
@@ -226,21 +243,21 @@ const decorateElements = async ({ elem, className = 'feds-navLink', itemIndex = 
         link.parentElement.replaceWith(link);
       }
       const clonedLink = link.cloneNode(true);
-      const processedLink = link.classList.contains('merch') ? await merch.default(clonedLink) : link;
-      const decoratedLink = decorateCta({ elem: processedLink, type, index: itemIndex.position });
+      const processedLink = link.classList.contains('merch') ? await resolveMerch(clonedLink) : link;
+      const decoratedLink = decorateCta({ elem: processedLink, type, index });
       return decoratedLink;
     }
 
     // Simple links get analytics attributes and appropriate class name
     if (link.classList.contains('merch')) {
       const clonedLink = link.cloneNode(true);
-      const merchLink = await merch.default(clonedLink);
-      merchLink.setAttribute('daa-ll', getAnalyticsValue(link.textContent, itemIndex.position));
+      const merchLink = await resolveMerch(clonedLink);
+      merchLink.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index));
       merchLink.classList.value = className;
       return merchLink;
     }
 
-    link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, itemIndex.position));
+    link.setAttribute('daa-ll', getAnalyticsValue(link.textContent, index));
     link.classList.add(className);
 
     return link;
@@ -253,11 +270,13 @@ const decorateElements = async ({ elem, className = 'feds-navLink', itemIndex = 
     return toFragment`<li>${await decorateLink(elem)}</li>`;
   }
 
-  // Otherwise, this might be a collection of elements;
-  // decorate all links in the collection and return it
-  for (const link of elem.querySelectorAll(linkSelector)) {
-    link.replaceWith(await decorateLink(link));
-  }
+  // Otherwise, this might be a collection of elements; decorate all links in the collection
+  // concurrently, replacing each as soon as its own decoration resolves
+  const links = [...elem.querySelectorAll(linkSelector)];
+  await Promise.all(links.map(async (link) => {
+    const decorated = await decorateLink(link);
+    link.replaceWith(decorated);
+  }));
 
   return elem;
 };
@@ -288,11 +307,11 @@ const decoratePromo = async (elem, index) => {
 
   if (promoHeader?.textContent.trim()) {
     const headingParagraph = promoHeader.parentElement;
-    const headingMerchLinks = headingParagraph.querySelectorAll('a.merch');
-    for (const link of headingMerchLinks) {
-      const priceEl = await merch.default(link.cloneNode(true));
+    const headingMerchLinks = [...headingParagraph.querySelectorAll('a.merch')];
+    await Promise.all(headingMerchLinks.map(async (link) => {
+      const priceEl = await resolveMerch(link.cloneNode(true));
       if (priceEl instanceof HTMLElement) link.replaceWith(priceEl);
-    }
+    }));
     headingParagraph.querySelectorAll('strong').forEach((strong) => {
       strong.replaceWith(...strong.childNodes);
     });
@@ -482,9 +501,9 @@ const decorateMenu = (config) => logErrorFor(async () => {
     const initialHeadingElem = itemTopParent.querySelector('h2');
     itemTopParent.removeChild(initialHeadingElem);
 
-    const merchLinks = itemTopParent.querySelectorAll('.merch');
+    const merchLinks = [...itemTopParent.querySelectorAll('.merch')];
     if (merchLinks.length) {
-      for (const link of merchLinks) {
+      await Promise.all(merchLinks.map(async (link) => {
         const linkContent = link.innerHTML;
         const merchBlock = await merch.default(link);
         if (merchBlock) {
@@ -492,7 +511,7 @@ const decorateMenu = (config) => logErrorFor(async () => {
           merchBlock.innerHTML = linkContent;
           link.replaceWith(merchBlock);
         }
-      }
+      }));
     }
 
     menuTemplate = toFragment`<div class="feds-popup">
@@ -518,7 +537,15 @@ const decorateMenu = (config) => logErrorFor(async () => {
       </div>`;
     addMepHighlightAndTargetId(menuTemplate, content);
 
+    // decorateCrossCloudMenu resolves merch via its own staging container, so it doesn't
+    // need menuTemplate connected - run it first, while the tree is still cheap to mutate.
     await decorateCrossCloudMenu(menuTemplate);
+
+    // Connect now (hidden) so mas-field/aem-fragment elements below can start fetching
+    // immediately instead of hitting FIELD_TIMEOUT; `display: none`, not `visibility`,
+    // so decorateColumns' many mutations don't force real layout work.
+    menuTemplate.style.setProperty('display', 'none');
+    config.template?.append(menuTemplate);
 
     await decorateColumns({ content: menuContent });
 
@@ -561,8 +588,10 @@ const decorateMenu = (config) => logErrorFor(async () => {
 
   // Remove the loading state created in delayDropdownDecoration
   config.template?.querySelector('.feds-popup.loading')?.remove();
+  // Already attached for asyncDropdownTrigger; append here is a no-op for it in that case.
   config.template?.append(menuTemplate);
   if (config.type === 'asyncDropdownTrigger') {
+    menuTemplate.style.removeProperty('display');
     setAriaAtributes(menuTemplate.previousElementSibling);
     performance.mark(`DecorateMenu-${asyncDropDownCount}-End`);
   }


### PR DESCRIPTION
Root causes found (in libs/blocks/global-navigation/utilities/menu/menu.js):

1. Sequential blocking loops. decorateElements, decoratePromo, and the syncDropdownTrigger merch loop each awaited merch.default() one link at a time in a for loop, with no yield back to the browser — N mas fields cost N × (fetch time) in total, blocking the main thread the whole way.
1. Detached decoration tree (the real 5s/15s bug). For mega-menus (asyncDropdownTrigger), the entire menu — menuContent/menuTemplate — was built via toFragment (document.createRange().createContextualFragment) and only attached to the live document after decorateColumns finished. Custom elements only run connectedCallback (which is what triggers <aem-fragment>'s actual fetch) once truly connected to window.document. Since attachment happened last, every mas field's checkReady() wait was guaranteed to hit the hard-coded 5000ms FIELD_TIMEOUT in merch.js — never a real aem:load. With fields running sequentially (cause `#1`) this compounded into very long waits.
1. Cloned elements never connect at all. Every .merch call site clones the anchor (cloneNode(true)) before passing it to merch.default(), to keep the original link intact for other code paths. But merch.js's internal el.replaceWith(masField) — how the real <mas-field> gets inserted — is a no-op on a parentless clone. So even after fixing `#2` (making the outer container connected), the individual field elements built from clones still never connected to anything, so they still always timed out. This was the actual reason the first attempt (attaching menuTemplate early) didn't fix the timing at all.

Fixes applied:

1. Parallelized every merch/mas loop with Promise.all, replacing each link in the DOM as soon as its own promise resolves (not waiting on the whole batch) — one slow field no longer blocks its siblings.
1. Attach menuTemplate to the live DOM before decoration, hidden via display: none (not visibility: hidden — that still costs real layout/paint work for the many incremental mutations decorateColumns makes; display: none is skipped by layout entirely). The loading skeleton stays visible the whole time and is swapped for the real menu only once decoration fully completes, so revealed UX timing is unchanged.
1. Added a hidden staging container (getMerchStagingContainer()/resolveMerch()) that every cloned merch link gets appended into before calling merch.default(), giving el.replaceWith(masField) a real connected parent to splice into — so fields actually connect, connectedCallback fires, and the real fetch starts immediately instead of always timing out. Falls back to removing the clone if merch.default() returns nothing, to avoid leaking orphaned nodes.


Resolves: [MWPW-206139](https://jira.corp.adobe.com/browse/MWPW-206139)

**Test URLs:**
- Before: https://www.stage.adobe.com/creativecloud.html?martech=off
- After: https://www.stage.adobe.com/creativecloud.html?martech=off&milolibs=mwpw-206139

Click "Creative & Design" on the gnav to show the mega menu. There are MAS fields in Column 1. 

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=MWPW-206139--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=MWPW-206139--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-206139--milo--adobecom
- Milo: https://MWPW-206139--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-206139--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-206139--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-206139--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206139--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206139--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206139--milo--adobecom
- Milo: https://MWPW-206139--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206139--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206139--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206139--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206139--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206139--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206139--milo--adobecom
- Milo: https://MWPW-206139--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206139--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206139--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206139--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-206139--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-206139--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-206139--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-206139--milo--adobecom
</details>