### PR TITLE
Brand Concierge - fix overlay layout for new feds-localnav

### DIFF
--- a/libs/blocks/brand-concierge-global/brand-concierge-global.js
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.js
@@ -133,8 +133,6 @@ export default function init(el) {
     }
   });
 
-  setCssGnavHeight();
-
   const rows = el.querySelectorAll(':scope > div');
   const [cards, input] = rows;
   setAuthoredContent(null, cards, input);
@@ -152,6 +150,7 @@ export default function init(el) {
 
   if (!hasChatCookie()) localStorage.setItem('bc-side-overlay', 'closed');
   if (localStorage.getItem('bc-side-overlay') === 'open' && !document.body.classList.contains('bc-side-open')) {
+    setCssGnavHeight();
     openSideModal(null, bcBootstrap);
   }
 }

--- a/libs/blocks/brand-concierge/bc-bootstrap.js
+++ b/libs/blocks/brand-concierge/bc-bootstrap.js
@@ -1,6 +1,6 @@
 import { getModal, closeModal } from '../modal/modal.js';
 import { createTag, getConfig, getMetadata, loadScript } from '../../utils/utils.js';
-import { getBetaLabel, waitForCondition, expandIcon } from './bc-utils.js';
+import { getBetaLabel, waitForCondition, expandIcon, setCssGnavHeight } from './bc-utils.js';
 import { bcAnalytics, getAnalyticsLabel } from './bc-analytics.js';
 import chatUIConfig from './chat-ui-config.js';
 
@@ -17,6 +17,29 @@ const susiScopes = 'AdobeID,openid,gnav,pps.read,firefly_api,additional_info.rol
 let bcToken;
 let susiListener;
 let lastImsState = null;
+
+function handleLocalNav() {
+  const localGnav = document.querySelector('div.feds-localnav');
+  let lastDisplay = localGnav ? window.getComputedStyle(localGnav).display : null;
+  if (localGnav) {
+    const observer = new MutationObserver((mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === 'attributes') {
+          const currentDisplay = window.getComputedStyle(localGnav).display;
+
+          if (currentDisplay !== lastDisplay) {
+            lastDisplay = currentDisplay;
+            setCssGnavHeight();
+          }
+        }
+      }
+    });
+    observer.observe(localGnav, {
+      attributes: true,
+      attributeFilter: ['style', 'class'],
+    });
+  }
+}
 
 /**
  * Creates the SUSI Light component for the sign-in modal.
@@ -379,6 +402,8 @@ export async function openSideModal(initialMessage, bootstrap) {
     });
     susiListener = 'signIn:decorateNav';
   }
+
+  handleLocalNav();
 
   modal.querySelector('.dialog-close').setAttribute('daa-ll', getAnalyticsLabel('modal-close'));
   document.querySelector('.modal-curtain').setAttribute('daa-ll', getAnalyticsLabel('modal-close'));

--- a/libs/blocks/brand-concierge/bc-utils.js
+++ b/libs/blocks/brand-concierge/bc-utils.js
@@ -41,9 +41,16 @@ export function hasChatCookie() {
 
 export function setCssGnavHeight() {
   const gnav = document.querySelector('header.global-navigation');
+  const localGnav = document.querySelector('div.feds-localnav');
+  const localNavStyle = localGnav ? getComputedStyle(localGnav) : null;
+  const localNavOn = localGnav && localNavStyle ? localNavStyle.display === 'block' : false;
+
   if (!gnav) return;
-  const gnavHeight = gnav.getBoundingClientRect().height;
-  document.documentElement.style.setProperty('--bc-gnav-height', `${gnavHeight}px`);
+  const rootStyles = getComputedStyle(document.documentElement);
+  const gnavHeight = Number(rootStyles.getPropertyValue('--global-height-nav').trim().slice(0, -2));
+  const localNavHeight = Number(rootStyles.getPropertyValue('--feds-localnav-height').trim().slice(0, -2));
+  const newHeight = gnavHeight + (localGnav && localNavOn ? localNavHeight : 0);
+  document.documentElement.style.setProperty('--bc-gnav-height', `${newHeight}px`);
 }
 
 export function handleConsent(el) {

--- a/libs/blocks/brand-concierge/bc-utils.js
+++ b/libs/blocks/brand-concierge/bc-utils.js
@@ -43,7 +43,7 @@ export function setCssGnavHeight() {
   const gnav = document.querySelector('header.global-navigation');
   const localGnav = document.querySelector('div.feds-localnav');
   const localNavStyle = localGnav ? getComputedStyle(localGnav) : null;
-  const localNavOn = localGnav && localNavStyle ? localNavStyle.display === 'block' : false;
+  const localNavOn = localGnav && localNavStyle ? localNavStyle.display !== 'none' : false;
 
   if (!gnav) return;
   const rootStyles = getComputedStyle(document.documentElement);


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fixes to brand concierge side overlay so it adjusts to the presence of feds-localnav

Resolves: [BRANDCON-8585](https://jira.corp.adobe.com/browse/BRANDCON-8585)

**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.page/drafts/soujanya/loc1test?milolibs=MWPW-205011
- After: https://main--da-bacom--adobecom.aem.page/drafts/soujanya/loc1test?milolibs=bc-localnav-fix


