### PR TITLE
Side-by-side standalone link support

### DIFF
--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -131,6 +131,14 @@
 
   }
 
+  .foreground .link-container {
+    margin-block-start: var(--s2a-spacing-2xs);
+
+    .standalone-link {
+      text-decoration: none;
+    }
+  }
+
   &.featured {
     .card-overlay {
       display: flex;

--- a/libs/mep/ace1209/side-by-side/side-by-side.js
+++ b/libs/mep/ace1209/side-by-side/side-by-side.js
@@ -11,7 +11,7 @@ function decorateStandaloneLink(foreground) {
     const parent = a.parentElement;
     if (!parent) return;
     const isStandalone = parent.textContent?.trim() === a.textContent?.trim();
-    if (!isStandalone) return;
+    if (!isStandalone || a.classList.contains('con-button')) return;
     parent.classList.replace(`body-${DEFAULT_TEXT_CONFIG.body}`, 'label');
     parent.classList.add('link-container');
     a.classList.add('standalone-link');

--- a/libs/mep/ace1209/side-by-side/side-by-side.js
+++ b/libs/mep/ace1209/side-by-side/side-by-side.js
@@ -6,11 +6,25 @@ let videoObserver = null;
 
 function isSvgUrl(url) { return /\.svg(\?.*)?$/i.test(url || ''); }
 
+function decorateStandaloneLink(foreground) {
+  foreground.querySelectorAll('a').forEach((a) => {
+    const parent = a.parentElement;
+    if (!parent) return;
+    const isStandalone = parent.textContent?.trim() === a.textContent?.trim();
+    if (!isStandalone) return;
+    parent.classList.replace(`body-${DEFAULT_TEXT_CONFIG.body}`, 'label');
+    parent.classList.add('link-container');
+    a.classList.add('standalone-link');
+  });
+}
+
 function decorateCardText(foreground) {
   decorateBlockText(foreground, DEFAULT_TEXT_CONFIG);
   const headingP = foreground.querySelector('p:has(strong)');
-  if (!headingP) return;
-  headingP.classList.replace(`body-${DEFAULT_TEXT_CONFIG.body}`, `title-${DEFAULT_TEXT_CONFIG.heading}`);
+  if (headingP) {
+    headingP.classList.replace(`body-${DEFAULT_TEXT_CONFIG.body}`, `title-${DEFAULT_TEXT_CONFIG.heading}`);
+  }
+  decorateStandaloneLink(foreground);
 }
 
 function replaceVideoIntersectionObserver(medias) {


### PR DESCRIPTION
Adds **standalone link** support to the `side-by-side` (ace1209) block.

* New `decorateStandaloneLink` helper detects links that are the sole content of their paragraph and restyles the container as a `label` with a `link-container` class, tagging the anchor as `standalone-link`.
* `decorateCardText` no longer early-returns when a card has no heading paragraph, so standalone links are decorated regardless of whether a heading is present.
* CSS adds spacing above the link container and removes the default underline from standalone links.

Resolves: [MWPW-204854](https://jira.corp.adobe.com/browse/MWPW-204854)

**Figma:** https://www.figma.com/design/6FQTDUAttFbukvtskDAkPS/Product?node-id=17317-168998&m=dev

**Test URLs:**
- Before: https://main--da-cc--adobecom.aem.page/drafts/ramuntea/firefly-w5?milolibs=site-redesign-foundation
- After: https://main--da-cc--adobecom.aem.page/drafts/ramuntea/firefly-w5?milolibs=side-by-side-link




