### PR TITLE
MWPW-205140: Fix focus obscured by merch-moment garage-door reveal

### DIFF
--- a/libs/mep/ace1209/rich-content/rich-content.css
+++ b/libs/mep/ace1209/rich-content/rich-content.css
@@ -220,6 +220,10 @@
   &.parallax-garage-door-reveal:has(.rich-content.merch-moment) {
     .foreground {
       animation-range: cover -10% cover 90%;
+
+      p.body-lg a {
+        scroll-margin-bottom: calc(100vh - 200px);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

The CPRO offer's merch-moment `.parallax-garage-door-reveal` section (`libs/mep/ace1209/rich-content/`) ties its entrance transform and line-height reveal to a `view()` scroll-timeline. Tab focus could land on the "See terms." link once its raw bounding box was technically inside the viewport, but before that timeline finished settling — leaving the text squished to a near-zero line-height, effectively invisible even though focused (WCAG 2.4.11).

Adds `scroll-margin-bottom: calc(100vh - 200px)` to the "See terms." link specifically, mirroring the existing fix already used for the sibling `parallax-video-garage-door` component's CTAs. This pads the link's scrollIntoView target area so focus-driven scrolling lands past the reveal instead of mid-transition.

Scoped to the `p.body-lg a` selector inside the merch-moment `.foreground` block only — not the "Free trial"/"See all plans" CTA buttons, and not the generic `.parallax-garage-door-reveal` class. Applying it more broadly regressed backward (Shift+Tab) navigation by dragging those CTAs up under the sticky local-nav bar.

**Resolves:** [MWPW-205140](https://jira.corp.adobe.com/browse/MWPW-205140)

**Test URLs:**

- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-offer?milolibs=mwpw-205140-focus-obscured&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

## Test plan

- [x] Repro'd the original bug: tabbed from the last FAQ question onto "See terms." — landed with `line-height: 11.375px` (squished/invisible) before the fix, `24px` (settled/legible) after.
- [x] Verified forward Tab order through "See terms." → "Free trial" → "See all plans" all land visible and settled.
- [x] Verified backward Shift+Tab from `brand-concierge` back through "See all plans" → "Free trial" → "See terms." — all land visible, clear of the sticky local-nav bar, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

