### PR TITLE
[Site Redesign] PDF-Space fallback to reduced experience on short window

### DIFF
--- a/libs/c2/blocks/pdf-space/pdf-space.js
+++ b/libs/c2/blocks/pdf-space/pdf-space.js
@@ -1518,7 +1518,7 @@ export default function init(el) {
   };
 
   const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  const shortViewportQuery = window.matchMedia('(max-height: 500px) and (min-resolution: 1.5dppx)');
+  const shortViewportQuery = window.matchMedia('(max-height: 300px) and (min-resolution: 1.5dppx)');
   const prefersReducedMotion = () => reducedMotionQuery.matches || shortViewportQuery.matches;
 
   let teardownMotion = null;

--- a/libs/c2/blocks/pdf-space/pdf-space.js
+++ b/libs/c2/blocks/pdf-space/pdf-space.js
@@ -1518,7 +1518,8 @@ export default function init(el) {
   };
 
   const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  const prefersReducedMotion = () => reducedMotionQuery.matches;
+  const shortViewportQuery = window.matchMedia('(max-height: 500px) and (min-resolution: 1.5dppx)');
+  const prefersReducedMotion = () => reducedMotionQuery.matches || shortViewportQuery.matches;
 
   let teardownMotion = null;
   let mountedReduced = null;
@@ -1543,11 +1544,13 @@ export default function init(el) {
 
   syncMotionPreference();
   reducedMotionQuery.addEventListener('change', syncMotionPreference);
+  shortViewportQuery.addEventListener('change', syncMotionPreference);
 
   const removalObserver = new MutationObserver((_, observer) => {
     if (document.contains(el)) return;
     teardownMotion?.();
     reducedMotionQuery.removeEventListener('change', syncMotionPreference);
+    shortViewportQuery.removeEventListener('change', syncMotionPreference);
     observer.disconnect();
   });
   if (el.parentElement) {

--- a/libs/c2/blocks/pdf-space/pdf-space.js
+++ b/libs/c2/blocks/pdf-space/pdf-space.js
@@ -1518,7 +1518,7 @@ export default function init(el) {
   };
 
   const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-  const shortViewportQuery = window.matchMedia('(max-height: 300px) and (min-resolution: 1.5dppx)');
+  const shortViewportQuery = window.matchMedia('(max-height: 400px) and (min-resolution: 1.5dppx)');
   const prefersReducedMotion = () => reducedMotionQuery.matches || shortViewportQuery.matches;
 
   let teardownMotion = null;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* On extremely short+zoomed window where animation no longer looks good and texts could get clipped, we fall back to the reduced-motion experience to at least ensure correctness.

Resolves: https://jira.corp.adobe.com/browse/MWPW-199069

How to test:

1. Set viewport to 1280x width by 1024px height by resizing the browser (not using responsive sizing)
2. set browser zoom to 400%.
3. Refresh the page
4. Scroll down to "Create beautifully..."
5. The paragraph would be visible in feature branch but cut off at stage

**Test URLs:**
- Before: https://main--da-dc--adobecom.aem.live/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=stage&mep=off
- After: https://main--da-dc--adobecom.aem.live/dc-shared/fragments/tests/2026/q2/ace1205/fragments/ace1205-bizpro-hub?milolibs=pdf-space-a11y-zoom&mep=off



