### PR TITLE
[MWPW-206517] Fix breadcrumb rendering for dynamic reflow of C1 nav

### DIFF
--- a/libs/blocks/brand-concierge-global/brand-concierge-global.css
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.css
@@ -1,6 +1,6 @@
 .global-navigation .feds-bc-wrapper {
   width: 340px;
-  margin-left: auto;
+  margin-inline-start: auto;
   padding: 0 8px;
 }
 

--- a/libs/blocks/global-navigation/base.css
+++ b/libs/blocks/global-navigation/base.css
@@ -212,7 +212,7 @@ header.global-navigation.ready {
     margin: 0 12px;
   }
 
-  .feds-navItem--activeDeferred > .feds-navLink {
+  :where(header.global-navigation:not(.is-compact)) .feds-navItem--activeDeferred > .feds-navLink {
     padding: 0;
     width: 100%;
     justify-content: center;

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -596,6 +596,14 @@ header.global-navigation.has-breadcrumbs.is-compact {
   padding-bottom: 0;
 }
 
+header.global-navigation.is-compact .feds-navItem--active > .feds-navLink {
+  font-weight: 400;
+}
+
+header.global-navigation.is-compact .feds-navItem--active > .feds-navLink::before {
+  display: none;
+}
+
 header.global-navigation.is-compact + .feds-localnav .feds-navItem--active > .feds-navLink::before {
   display: none;
 }

--- a/libs/blocks/global-navigation/global-navigation.css
+++ b/libs/blocks/global-navigation/global-navigation.css
@@ -600,6 +600,11 @@ header.global-navigation.is-compact .feds-navItem--active > .feds-navLink {
   font-weight: 400;
 }
 
+header.global-navigation.is-compact .feds-navItem--section:only-of-type {
+  border-left: none;
+  border-right: none;
+}
+
 header.global-navigation.is-compact .feds-navItem--active > .feds-navLink::before {
   display: none;
 }

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -852,7 +852,6 @@ class Gnav {
         }
 
         // On mobile (or forced-compact), breadcrumbs are before the search and nav,
-        // i.e. inside the drawer (hidden until the hamburger is opened).
         if (this.elements.navWrapper instanceof HTMLElement
           && this.elements.breadcrumbsWrapper instanceof HTMLElement) {
           this.elements.navWrapper.prepend(this.elements.breadcrumbsWrapper);
@@ -860,8 +859,6 @@ class Gnav {
       }
     };
     isDesktop.addEventListener('change', syncElementOrder);
-    // Forced-compact at desktop width is effectively mobile; keep DOM order in sync
-    // when the compact state toggles so the breadcrumb moves into/out of the drawer.
     if (this.dynamicReflowEnabled) window.addEventListener('feds:compactchange', syncElementOrder);
 
     // Add a modifier when the nav is tangent to the viewport and content is partly hidden

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -829,9 +829,10 @@ class Gnav {
   };
 
   addChangeEventListeners = () => {
-    // Ensure correct DOM order for elements between mobile and desktop
-    isDesktop.addEventListener('change', () => {
-      if (isDesktop.matches) {
+    // Ensure correct DOM order for elements between desktop and effectively-mobile
+    // (real mobile, or forced-compact at desktop width via dynamic reflow).
+    const syncElementOrder = () => {
+      if (!this.isEffectivelyMobile()) {
         // On desktop, search is after nav
         if (this.elements.mainNav instanceof HTMLElement
           && this.elements.search instanceof HTMLElement) {
@@ -844,19 +845,24 @@ class Gnav {
           this.elements.topnav.after(this.elements.breadcrumbsWrapper);
         }
       } else {
-        // On mobile, nav is after search
+        // On mobile (or forced-compact), nav is after search
         if (this.elements.mainNav instanceof HTMLElement
           && this.elements.search instanceof HTMLElement) {
           this.elements.mainNav.before(this.elements.search);
         }
 
-        // On mobile, breadcrumbs are before the search and nav
+        // On mobile (or forced-compact), breadcrumbs are before the search and nav,
+        // i.e. inside the drawer (hidden until the hamburger is opened).
         if (this.elements.navWrapper instanceof HTMLElement
           && this.elements.breadcrumbsWrapper instanceof HTMLElement) {
           this.elements.navWrapper.prepend(this.elements.breadcrumbsWrapper);
         }
       }
-    });
+    };
+    isDesktop.addEventListener('change', syncElementOrder);
+    // Forced-compact at desktop width is effectively mobile; keep DOM order in sync
+    // when the compact state toggles so the breadcrumb moves into/out of the drawer.
+    if (this.dynamicReflowEnabled) window.addEventListener('feds:compactchange', syncElementOrder);
 
     // Add a modifier when the nav is tangent to the viewport and content is partly hidden
     const toggleContraction = () => {


### PR DESCRIPTION
* Show breadcrumb inside the hamburger drawer in compact view (matches mobile)
* Fix leaked desktop active-title styling (bold + underline) in the compact drawer
* Fix RTL alignment for BC input 

Resolves: [MWPW-206517](https://github.com/adobecom/milo/tree/MWPW-206517)

**Test URLs:**
- Before: https://business.stage.adobe.com/blog/?milolibs=stage
- After: https://business.stage.adobe.com/blog/?milolibs=MWPW-206517

<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=MWPW-206517--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=MWPW-206517--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-206517--milo--adobecom
- Milo: https://MWPW-206517--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-206517--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-206517--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-206517--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206517--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206517--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206517--milo--adobecom
- Milo: https://MWPW-206517--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206517--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206517--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-206517--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206517--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206517--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206517--milo--adobecom
- Milo: https://MWPW-206517--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206517--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206517--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-206517--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-206517--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-206517--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-206517--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-206517--milo--adobecom
</details>