### PR TITLE
[SR] Side-by-side: authorable body text color

### DIFF
--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -12,6 +12,10 @@
     background-color: unset;
   }
 
+  .foreground {
+    max-width: 450px;
+  }
+
   .card {
     border-radius: var(--s2a-border-radius-md);
     position: relative;
@@ -29,10 +33,6 @@
 
   > .card:last-child {
     --parallax-stagger-index: 1.5;
-  }
-
-  .foreground {
-    max-width: 450px;
   }
 
   .media {
@@ -73,34 +73,14 @@
         color: var(--s2a-color-content-subtle);
       }
     }
+  }
 
-    &.first-card {
-      .card:first-child {
-        .foreground [class^='body-'] {
-          color: var(--s2a-color-content-subtle);
-        }
-      }
+  .card.body-subtle .foreground [class^='body-'] {
+    color: var(--s2a-color-content-subtle);
+  }
 
-      .card:last-child {
-        .foreground [class^='body-'] {
-          color: inherit;
-        }
-      }
-    }
-
-    &.second-card {
-      .card:last-child {
-        .foreground [class^='body-'] {
-          color: var(--s2a-color-content-subtle);
-        }
-      }
-
-      .card:first-child {
-        .foreground [class^='body-'] {
-          color: inherit;
-        }
-      }
-    }
+  .card.body-solid .foreground [class^='body-'] {
+    color: inherit;
   }
 
   .card-overlay {

--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -15,6 +15,12 @@
   .card {
     border-radius: var(--s2a-border-radius-md);
     position: relative;
+
+    .foreground {
+      [class^='body-'] {
+        color: inherit;
+      }
+    }
   }
 
   > .card:first-child {
@@ -58,6 +64,42 @@
       z-index: 1;
       inset-block-start: var(--s2a-spacing-md);
       inset-inline-start: var(--s2a-spacing-md);
+    }
+  }
+
+  &.body-color-subtle {
+    .card {
+      .foreground [class^='body-'] {
+        color: var(--s2a-color-content-subtle);
+      }
+    }
+
+    &.first-card {
+      .card:first-child {
+        .foreground [class^='body-'] {
+          color: var(--s2a-color-content-subtle);
+        }
+      }
+
+      .card:last-child {
+        .foreground [class^='body-'] {
+          color: inherit;
+        }
+      }
+    }
+
+    &.second-card {
+      .card:last-child {
+        .foreground [class^='body-'] {
+          color: var(--s2a-color-content-subtle);
+        }
+      }
+
+      .card:first-child {
+        .foreground [class^='body-'] {
+          color: inherit;
+        }
+      }
     }
   }
 
@@ -123,10 +165,6 @@
       display: flex;
       flex-direction: column;
       gap: var(--s2a-spacing-2xs);
-
-      [class^='body-'] {
-        color: var(--s2a-color-content-subtle);
-      }
     }
 
     .media {

--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -67,15 +67,18 @@
     }
   }
 
-  &.body-color-subtle .card .foreground [class^='body-'] {
+  /* Not named body-* — that prefix is reserved by decorateTextOverrides()
+     (libs/utils/decorate.js) for block-level text-size overrides and gets
+     stripped/corrupted if used here. */
+  &.content-subtle .card .foreground [class^='body-'] {
     color: var(--s2a-color-content-subtle);
   }
 
-  .card.body-subtle .foreground [class^='body-'] {
+  .card.content-subtle .foreground [class^='body-'] {
     color: var(--s2a-color-content-subtle);
   }
 
-  .card.body-solid .foreground [class^='body-'] {
+  .card.content-solid .foreground [class^='body-'] {
     color: inherit;
   }
 

--- a/libs/mep/ace1209/side-by-side/side-by-side.css
+++ b/libs/mep/ace1209/side-by-side/side-by-side.css
@@ -67,12 +67,8 @@
     }
   }
 
-  &.body-color-subtle {
-    .card {
-      .foreground [class^='body-'] {
-        color: var(--s2a-color-content-subtle);
-      }
-    }
+  &.body-color-subtle .card .foreground [class^='body-'] {
+    color: var(--s2a-color-content-subtle);
   }
 
   .card.body-subtle .foreground [class^='body-'] {


### PR DESCRIPTION
## Summary

Adds an authorable **body text color** control to the `side-by-side` (ace1209) block. By default, body copy inherits its color from the surrounding context; authors can opt into the subtle content token block-wide, and fine-tune per card using the per-card customization mechanism from #6628.

Resolves: [MWPW-205055](https://jira.corp.adobe.com/browse/MWPW-205055)


## Changes

- **Default behavior unchanged in appearance, but simplified:** body text (`[class^='body-']`) now defaults to `color: inherit` instead of being hardcoded to the subtle token only inside `.card-stacked`. Previously `.card-overlay` and `.card-stacked` handled this inconsistently.
- **New block-level variant `content-subtle`:** applies the subtle content color token (`--s2a-color-content-subtle`) to body text on both cards.
- **New per-card overrides, `content-subtle` / `content-solid`:** authored as `first-card-content-subtle`, `second-card-content-solid`, etc., using the generic `first-card-<token>`/`second-card-<token>` pass-through mechanism added in #6628. Lets an author set the block-wide default and then dial an individual card back the other way.

### Authoring examples

| Authored block name | First card | Second card |
|---|---|---|
| `Side by Side` | solid (default, inherit) | solid (default) |
| `Side by Side (content-subtle)` | subtle | subtle |
| `Side by Side (first-card-content-subtle)` | subtle | solid (default) |
| `Side by Side (content-subtle, first-card-content-solid)` | solid (overridden) | subtle |

## Coordination with #6628

This update adds on to what @zagi25 worked on in #6628. All of those features/updates should work as expected. 

## Testing

- All 12 existing `side-by-side` unit tests pass.
- Stylelint clean (no new issues introduced; 3 pre-existing baseline warnings unrelated to this change remain).
- Manually verified all authoring combinations above in a local disposable branch merging this work with #6628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






