### PR TITLE
BRANDCON: pass host env into brand concierge bootstrap()

### DIFF
--- a/libs/blocks/brand-concierge/bc-bootstrap.js
+++ b/libs/blocks/brand-concierge/bc-bootstrap.js
@@ -213,7 +213,7 @@ export function loadWebclient() {
 
 export async function bcBootstrap(initialMessage, mountIdentifier) {
   const mountEl = document.querySelector(`#${mountIdentifier}`);
-  const { locale } = getConfig();
+  const { locale, env } = getConfig();
 
   loadWebclient();
 
@@ -293,6 +293,7 @@ export async function bcBootstrap(initialMessage, mountIdentifier) {
       instanceName: 'alloy',
       stylingConfigurations: getUpdatedChatUIConfig(),
       selector: `#${mountId}`,
+      env: env?.name,
       onBeforeEventSend,
       onEvent: (event) => {
         bcAnalytics(event);


### PR DESCRIPTION
## What

Forward the milo env name (`stage` | `prod` | `local`) from `getConfig()` into the Brand Concierge web client's `bootstrap()` call.

```js
window.adobe.concierge.bootstrap({
  instanceName: 'alloy',
  stylingConfigurations: getUpdatedChatUIConfig(),
  selector: `#${mountId}`,
  env: env?.name,          // <-- added
  onBeforeEventSend,
  onEvent: (event) => { bcAnalytics(event); },
});
```

## Why

The web client is adding its own NewRelic browser monitoring and needs to route telemetry to the correct browser-app entity (stage vs prod). Rather than sniff the hostname inside the embeddable client, milo already has the authoritative env signal — so we pass it through.

## Merge-order independence

The web client treats `env` as **optional and defaults to stage** when absent, so this PR and the web-client PR can merge in either order without breaking anything.

## Scope / notes

- Single call site (`bcBootstrap`); the global-nav variant reuses it.
- Additive field only — existing `bcBootstrap` unit test asserts individual fields and continues to pass.
- A parallel copy exists at `libs/c2/blocks/brand-concierge/bc-bootstrap.js`; left untouched here since `env` is optional (those surfaces safely default to stage). Can follow up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

