### PR TITLE
MWPW-206311: address #6643 review feedback

### DIFF
--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2299,8 +2299,6 @@ export function preloadLcpCodeFiles(area = document) {
   const { base, iconsExcludeBlocks, autoBlocks = AUTO_BLOCKS } = config;
   const isMediaVideo = (str) => /media_.*\.mp4/.test(str);
   const autoNames = new Set();
-  // Approximate match against decorateAutoBlock's own detector: good enough for a speculative
-  // preload (worst case is one wasted request), not meant to be kept byte-for-byte in sync with it.
   firstSection.querySelectorAll('a[href]').forEach((a) => {
     let url;
     try { url = new URL(a.href); } catch { return; }
@@ -2346,10 +2344,8 @@ async function checkForPageMods() {
   let targetInteractionPromise = null;
   let calculatedTimeout = null;
 
-  // Not MEP-specific (ordinary block/icon/placeholder resources), so it must run even when
-  // ?mep=off disables personalization/Target below - only its own kill switch should skip it.
-  preloadLcpCodeFiles();
   if (mepParam === 'off') return;
+  preloadLcpCodeFiles();
   const pzn = getMepEnablement('personalization');
   const pznroc = getMepEnablement('personalization-roc');
   const promo = getMepEnablement('manifestnames', PROMO_PARAM);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2299,9 +2299,11 @@ export function preloadLcpCodeFiles(area = document) {
   const { base, iconsExcludeBlocks, autoBlocks = AUTO_BLOCKS } = config;
   const isMediaVideo = (str) => /media_.*\.mp4/.test(str);
   const autoNames = new Set();
+  // Approximate match against decorateAutoBlock's own detector: good enough for a speculative
+  // preload (worst case is one wasted request), not meant to be kept byte-for-byte in sync with it.
   firstSection.querySelectorAll('a[href]').forEach((a) => {
     let url;
-    try { url = new URL(a.href); } catch (e) { return; }
+    try { url = new URL(a.href); } catch { return; }
     const match = autoBlocks.find((c) => isTrustedAutoBlock(c[Object.keys(c)[0]], url));
     if (!match) return;
     const name = Object.keys(match)[0];
@@ -2311,7 +2313,7 @@ export function preloadLcpCodeFiles(area = document) {
   if ([...firstSection.querySelectorAll('img[alt]')].some((img) => isMediaVideo(img.alt))) {
     autoNames.add('video');
   }
-  const isCommerceBlock = (name) => /merch|^mas-/.test(name);
+  const isCommerceBlock = (name) => /^merch|^mas-/.test(name);
   const blocks = [...firstSection.querySelectorAll(':scope > div[class]:not(.content)')]
     .filter((el) => !isCommerceBlock(el.classList[0]));
   const autoBlockEls = [...autoNames].filter((name) => !isCommerceBlock(name)).map((name) => createTag('div', { class: name }));
@@ -2320,7 +2322,7 @@ export function preloadLcpCodeFiles(area = document) {
 
   if (/{{|%7B%7B/.test(firstSection.innerHTML) && config.locale?.contentRoot) {
     loadLink(`${base}/features/placeholders.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
-    getPlaceholderPaths(config).forEach((path) => loadLink(path, { rel: 'preload', as: 'fetch' }));
+    getPlaceholderPaths(config).forEach((path) => loadLink(path, { rel: 'preload', as: 'fetch', crossorigin: 'anonymous' }));
   }
 
   warmGeoIpSheet(config, firstSection);
@@ -2344,8 +2346,10 @@ async function checkForPageMods() {
   let targetInteractionPromise = null;
   let calculatedTimeout = null;
 
-  if (mepParam === 'off') return;
+  // Not MEP-specific (ordinary block/icon/placeholder resources), so it must run even when
+  // ?mep=off disables personalization/Target below - only its own kill switch should skip it.
   preloadLcpCodeFiles();
+  if (mepParam === 'off') return;
   const pzn = getMepEnablement('personalization');
   const pznroc = getMepEnablement('personalization-roc');
   const promo = getMepEnablement('manifestnames', PROMO_PARAM);

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -169,6 +169,17 @@ describe('Utils', () => {
       document.body.innerHTML = '<main><div>{{buy-now}}</div></main>';
       utils.preloadLcpCodeFiles();
       expect(document.head.querySelector('link[href*="/features/placeholders.js"]')).to.exist;
+      // as=fetch preloads only get reused by the later customFetch() call if crossorigin is
+      // set - otherwise the browser treats them as a mismatched resource and double-fetches.
+      const placeholderPreload = document.head.querySelector('link[rel="preload"][as="fetch"][href*="/placeholders.json"]');
+      expect(placeholderPreload).to.exist;
+      expect(placeholderPreload.getAttribute('crossorigin')).to.equal('anonymous');
+    });
+
+    it('does not treat a block whose name merely contains "merch" as commerce', () => {
+      document.body.innerHTML = '<main><div><div class="aftermerch"></div></div></main>';
+      utils.preloadLcpCodeFiles();
+      expect(document.head.querySelector('link[href*="/libs/blocks/aftermerch/aftermerch.js"]')).to.exist;
     });
 
     it('warms icons.js and icons.css when the first section contains icons', () => {


### PR DESCRIPTION
Addresses review feedback from #6643, into that branch:

- **overmyheadandbody**: missing `crossorigin` on the placeholders.json preload
  (`as="fetch"` preloads only get reused by a later same-URL `fetch()` call when
  `crossorigin` matches - otherwise the browser treats it as a mismatched
  resource and double-fetches, which is the "new additional request" the
  before/after comparison in #6643 surfaced). Added, plus a test pinning it.
- **overmyheadandbody**: dropped the unused `catch (e)` binding to match the
  no-op-catch convention used elsewhere in this same PR (`getValidatedMasLibsUrl`'s
  own `catch { ... }`).
- **mokimo**: anchored `isCommerceBlock`'s `merch` alternative
  (`/merch|^mas-/` -> `/^merch|^mas-/`) so a block whose name merely *contains*
  "merch" isn't misclassified as commerce. Harmless today, added a regression test.

**Not changed** (kept as-is, confirmed intentional - replied on both threads in #6643):
- **mokimo / zagi25**'s `?mep=off` ordering question: `preloadLcpCodeFiles()` stays
  gated behind the existing `if (mepParam === 'off') return;`. When MEP is off there's
  no MEP/Target await to hide the preload behind, and the normal block-loading path
  already loads everything fast enough on its own - so this only needs to run when
  MEP is present, and adding the coupling isn't worth it.
- **zagi25**'s JSDoc-removal note on `getValidatedMasLibsUrl` - that JSDoc isn't new
  authorship, it's the pre-existing block (incl. its VULN-36379 security rationale)
  being relocated verbatim as part of this PR's reordering, and the neighboring
  `getValidatedRepoOwnerOrigin`-style validator elsewhere in the file keeps the same
  JSDoc convention.
- **mokimo**'s "approximate auto-block detector" comment suggestion - no new comments
  in `libs/utils/utils.js`, per this repo's convention for that file.

**Verification:** full `Utils` suite locally (215/215 passing, incl. 2 new tests for
the crossorigin fix and the `isCommerceBlock` anchor), ESLint clean. I intended to also
drive a live before/after comparison on the PR's own `aem.page` links via Playwright,
but couldn't get exclusive access to the browser instance in my environment - flagging
so nobody assumes that pass happened. Worth a manual before/after look before merge
given this touches a perf-sensitive path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)