### PR TITLE
[MWPW-206676] [LANA] The requested module '../utils/utils.js' does not provide an export named 'geoIpSiteKey'

### DIFF
--- a/libs/features/placeholders.js
+++ b/libs/features/placeholders.js
@@ -1,13 +1,17 @@
-import {
+import * as utils from '../utils/utils.js';
+
+const {
   customFetch,
   getConfig,
-  geoIpSiteKey,
   getGeoIpWarmSheet,
   getMetadata,
   lingoActive,
   normCountryCode,
   resolveDetectedMarketCountry,
-} from '../utils/utils.js';
+} = utils;
+
+const geoIpSiteKey = utils.geoIpSiteKey
+  ?? (({ base, prefix } = {}) => (base ?? (prefix ?? '').replace('/', '')) || 'en');
 
 const fetchedPlaceholders = {};
 const fetchedGeoSheets = {};


### PR DESCRIPTION
** Summary: **
Milo serves utils.js/placeholders.js unversioned with a shared 2h cache TTL. When PR #6589 added the geoIpSiteKey export, browsers with a stale cached utils.js + fresh placeholders.js hit "SyntaxError: does not provide an export named 'geoIpSiteKey'".

** Changes added : **
 - Changed import { geoIpSiteKey, ... } to import * as utils + destructure other named exports.
 - Added geoIpSiteKey fallback: uses utils.geoIpSiteKey if present, else an inline reimplementation — so a stale cached utils.js degrades gracefully instead of throwing.


Resolves: [MWPW-206676](https://jira.corp.adobe.com/browse/MWPW-206676)


