### PR TITLE
[VULN] Pin msal.js OAuth clientId/authority to first-party values (MWPW-206105)

### DIFF
--- a/libs/tools/sharepoint/msal.js
+++ b/libs/tools/sharepoint/msal.js
@@ -1,4 +1,3 @@
-import getServiceConfig from '../../utils/service-config.js';
 import { loadScript, getConfig } from '../../utils/utils.js';
 import { accessToken, accessTokenExtra } from './state.js';
 
@@ -10,16 +9,21 @@ const BASE_CONFIG = {
   },
 };
 
+// Milo's first-party Entra app and Adobe's tenant authority. Pinned here
+// rather than read from getServiceConfig(), whose .milo/config.json is fetched
+// from a client-controlled repo/owner origin: a poisoned config could otherwise
+// point login at an attacker's app registration (MWPW-206105 / VULN-38270).
+const CLIENT_ID = '008626ae-f818-43d8-9d7f-26afe05e771d';
+const AUTHORITY = 'https://login.microsoftonline.com/fa7b1b5a-7b34-4387-94ae-d2c178decee1';
+
 export async function getMSALConfig(telemetry) {
   try {
     const { base } = getConfig();
     await loadScript(`${base}/deps/msal-browser-2.34.0.js`);
 
-    const { sharepoint } = await getServiceConfig();
-
     const auth = {
-      clientId: sharepoint.clientId,
-      authority: sharepoint.authority,
+      clientId: CLIENT_ID,
+      authority: AUTHORITY,
     };
 
     return { ...BASE_CONFIG, auth, telemetry };

--- a/test/tools/sharepoint/mocks/malicious/.milo/config.json
+++ b/test/tools/sharepoint/mocks/malicious/.milo/config.json
@@ -1,8 +1,8 @@
 {
   "configs": {
-    "total": 2,
+    "total": 4,
     "offset": 0,
-    "limit": 2,
+    "limit": 4,
     "data": [
       {
         "key": "prod.sharepoint.site",
@@ -12,6 +12,16 @@
       {
         "key": "prod.sharepoint.driveId",
         "value": "attacker-drive-id",
+        "Comments": ""
+      },
+      {
+        "key": "prod.sharepoint.clientId",
+        "value": "attacker-client-id-00000000-0000-0000-0000-000000000000",
+        "Comments": ""
+      },
+      {
+        "key": "prod.sharepoint.authority",
+        "value": "https://login.microsoftonline.com/attacker-tenant-00000000-0000-0000-0000-000000000000",
         "Comments": ""
       }
     ]

--- a/test/tools/sharepoint/msal.test.js
+++ b/test/tools/sharepoint/msal.test.js
@@ -1,0 +1,32 @@
+import { expect } from '@esm-bundle/chai';
+import getServiceConfig from '../../../libs/utils/service-config.js';
+import { getMSALConfig } from '../../../libs/tools/sharepoint/msal.js';
+
+// Milo's first-party Entra app + Adobe tenant, confirmed against
+// main--milo--adobecom.aem.live/.milo/config.json.
+const FIRST_PARTY_CLIENT_ID = '008626ae-f818-43d8-9d7f-26afe05e771d';
+const FIRST_PARTY_AUTHORITY = 'https://login.microsoftonline.com/fa7b1b5a-7b34-4387-94ae-d2c178decee1';
+
+// A poisoned .milo/config.json served from an attacker-controlled repo/owner
+// origin, carrying clientId/authority that point login at the attacker's app.
+const MALICIOUS_ORIGIN = 'http://localhost:2000/test/tools/sharepoint/mocks/malicious';
+
+describe('msal.js OAuth config pinning (MWPW-206105 / VULN-38270)', () => {
+  before(async () => {
+    const { setConfig } = await import('../../../libs/utils/utils.js');
+    setConfig({ codeRoot: '/libs', locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } });
+    // getServiceConfig() memoizes per session; prime it with the malicious
+    // config so getMSALConfig()'s own no-arg call resolves to attacker values.
+    await getServiceConfig(MALICIOUS_ORIGIN);
+  });
+
+  it('pins clientId to Milo\'s first-party Entra app, ignoring the client-fetched config', async () => {
+    const { auth } = await getMSALConfig({});
+    expect(auth.clientId).to.equal(FIRST_PARTY_CLIENT_ID);
+  });
+
+  it('pins authority to Adobe\'s tenant, ignoring the client-fetched config', async () => {
+    const { auth } = await getMSALConfig({});
+    expect(auth.authority).to.equal(FIRST_PARTY_AUTHORITY);
+  });
+});


### PR DESCRIPTION
VULN-38270's merged fix pinned sharepoint.site (getValidatedSharePointSite), closing the leg where the victim's Graph Bearer token gets sent. This closes the remaining leg the report called out: login itself.

getMSALConfig() still built the MSAL auth config from sharepoint.clientId and sharepoint.authority, both read from getServiceConfig() - a .milo/config.json fetched from a client-controlled repo/owner origin, unvalidated. An attacker controlling repo/owner (same mechanism as VULN-38270) could point those at their own Entra app, driving login() into requesting consent for the attacker's app with the tool's hardcoded Files.ReadWrite / Sites.ReadWrite.All scopes.

Pin clientId/authority to Milo's known first-party values (008626ae app / the fa7b1b5a tenant authority) directly in msal.js, dropping the getServiceConfig read for these two fields. This is consistent with the already-hardcoded redirectUri and the Adobe tenant baked into getValidatedSharePointSite's regex, and also removes the ordering concern in path-finder.js (login() runs before site validation): login no longer depends on client-fetched config at all.

Test: new test/tools/sharepoint/msal.test.js primes getServiceConfig with a poisoned config (clientId/authority added to the existing malicious mock) and asserts getMSALConfig() ignores it and returns the pinned first-party values.

<!-- Before submitting, please review all open PRs. -->

Resolves: [MWPW-206105](https://jira.corp.adobe.com/browse/MWPW-206105)

**Test URLs:**
- Before (stage): https://main--milo--adobecom.aem.live/tools/path-finder?repo=evil&owner=x
- After (this branch): https://main--milo--adobecom.aem.live/tools/path-finder?milolibs=vuln-38270-msal-clientid-authority-pin&repo=evil&owner=x

Same caveat as VULN-38270's PR: `repo`/`owner` need to point at a real, attacker-registered `.aem.live` site to actually serve a poisoned config, so the clientId/authority pin itself is best checked directly rather than via a live attacker site — DevTools console on either URL above:
```js
const { getMSALConfig } = await import('/libs/tools/sharepoint/msal.js');
const { auth } = await getMSALConfig({});
auth.clientId; // always '008626ae-f818-43d8-9d7f-26afe05e771d', even with a poisoned config
auth.authority; // always 'https://login.microsoftonline.com/fa7b1b5a-7b34-4387-94ae-d2c178decee1'
```