### PR TITLE
test(nala,ci): fix two flakes hit while restarting dependabot PR tests

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -32,7 +32,13 @@ jobs:
         key: npm-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
 
     - name: Install dependencies
-      run: npm ci --no-fund --prefer-offline
+      # Retries transient install failures. Observed on PR #6682: npm ci preparing the
+      # git dependency @adobecom/mas-platform (github:adobecom/mas) hit
+      # "spawnSync .../web-components/node_modules/esbuild/bin/esbuild ETXTBSY" —
+      # npm executing esbuild's postinstall binary while it's still being written to
+      # disk. That's a known npm/git-dependency install race, unrelated to package
+      # content, and a bare rerun of the same job passed clean.
+      run: npm ci --no-fund --prefer-offline || npm ci --no-fund --prefer-offline || npm ci --no-fund --prefer-offline
 
     - name: Run the tests
       run: npm test

--- a/nala/features/personalization/mep-actions.test.js
+++ b/nala/features/personalization/mep-actions.test.js
@@ -73,6 +73,12 @@ test(`[Test Id - ${features[3].tcid}] ${features[3].name},${features[3].tags}`, 
 
 // Test 4: verify useBlockCode
 test(`[Test Id - ${features[4].tcid}] ${features[4].name},${features[4].tags}`, async ({ page, baseURL }) => {
+  // This is the only mep-actions test that does two full page.goto navigations, so it
+  // pays the mep-test.js pacer's per-worker throttle twice over. That regularly pushes
+  // it past the global 30s budget on webkit, the slowest of the three mep-* workers
+  // (observed: PR #6679, mep-webkit, "Test timeout of 30000ms exceeded" at the goto
+  // in step-2). Give it the same room nala/libs/commerce.js gives its own slow setup.
+  test.setTimeout(45000);
   const pznURL = `${baseURL}${features[4].path}${miloLibs}`;
   const defaultURL = `${baseURL}${features[4].data.defaultURL}${miloLibs}`;
   const marquee = new MarqueeBlock(page);

--- a/nala/features/personalization/mep-actions.test.js
+++ b/nala/features/personalization/mep-actions.test.js
@@ -72,32 +72,33 @@ test(`[Test Id - ${features[3].tcid}] ${features[3].name},${features[3].tags}`, 
 });
 
 // Test 4: verify useBlockCode
-test(`[Test Id - ${features[4].tcid}] ${features[4].name},${features[4].tags}`, async ({ page, baseURL }) => {
-  // This is the only mep-actions test that does two full page.goto navigations, so it
-  // pays the mep-test.js pacer's per-worker throttle twice over. That regularly pushes
-  // it past the global 30s budget on webkit, the slowest of the three mep-* workers
-  // (observed: PR #6679, mep-webkit, "Test timeout of 30000ms exceeded" at the goto
-  // in step-2). Give it the same room nala/libs/commerce.js gives its own slow setup.
-  test.setTimeout(45000);
-  const pznURL = `${baseURL}${features[4].path}${miloLibs}`;
+//
+// Split into two independent tests (was one test with two test.step() navigations sharing a
+// single 30s budget). Every mep-test.js pacer's per-worker EDS throttle applies per page.goto,
+// so a test doing two full navigations pays it twice over — that's what pushed this past the
+// 30s timeout on webkit (observed: PR #6679, mep-webkit, "Test timeout of 30000ms exceeded" at
+// the goto for step-2, after step-1 had already spent part of the shared clock). The two
+// navigations don't depend on each other's state — each gets its own page/context fixture
+// already — so giving each its own test() call, and therefore its own full budget, removes the
+// contention instead of just widening it.
+test(`[Test Id - ${features[4].tcid}] ${features[4].name} (default state),${features[4].tags}`, async ({ page, baseURL }) => {
   const defaultURL = `${baseURL}${features[4].data.defaultURL}${miloLibs}`;
   const marquee = new MarqueeBlock(page);
+  console.info(`[Test Page]: ${defaultURL}`);
+  await page.goto(defaultURL);
+  await expect(marquee.marquee).toBeVisible();
+  await expect(page.getByText('Marquee code was replaced MEP and the content was overwritten.')).toHaveCount(0);
+});
 
-  await test.step('step-1: verify the default', async () => {
-    console.info(`[Test Page]: ${defaultURL}`);
-    await page.goto(defaultURL);
-    await expect(marquee.marquee).toBeVisible();
-    await expect(page.getByText('Marquee code was replaced MEP and the content was overwritten.')).toHaveCount(0);
-  });
-  await test.step('step-2: Verify useBlockCode', async () => {
-    console.info(`[Test Page]: ${pznURL}`);
-    // domcontentloaded: waiting for 'load' stalls past the 30s budget because the
-    // mep-test.js pacer throttles subresources. waitForURL below syncs the redirect.
-    await page.goto(pznURL, { waitUntil: 'domcontentloaded' });
-    await page.waitForURL(/use-block-code/);
+test(`[Test Id - ${features[4].tcid}] ${features[4].name},${features[4].tags}`, async ({ page, baseURL }) => {
+  const pznURL = `${baseURL}${features[4].path}${miloLibs}`;
+  console.info(`[Test Page]: ${pznURL}`);
+  // domcontentloaded: waiting for 'load' stalls past the budget because the mep-test.js
+  // pacer throttles subresources. waitForURL below syncs the redirect.
+  await page.goto(pznURL, { waitUntil: 'domcontentloaded' });
+  await page.waitForURL(/use-block-code/);
 
-    const marqueeText = page.getByText('Marquee code was replaced MEP and the content was overwritten.');
-    await expect(marqueeText).toHaveCount(1);
-    await expect(marqueeText).toHaveCSS('color', 'rgb(128, 0, 128)'); // purple
-  });
+  const marqueeText = page.getByText('Marquee code was replaced MEP and the content was overwritten.');
+  await expect(marqueeText).toHaveCount(1);
+  await expect(marqueeText).toHaveCSS('color', 'rgb(128, 0, 128)'); // purple
 });


### PR DESCRIPTION
## Context

While pushing dependabot PRs #6677–#6682 to "Ready for Stage" and restarting their failed
checks, two unrelated tests failed and then passed clean on a bare rerun — both are genuine
flakes, not regressions from the dependency bumps (`basic-ftp` and `flatted` respectively have
no relation to either failure path). This PR fixes both root causes so they stop flaking on
future PRs.

## Fix 1 — `mep-actions.test.js` Test 4 (mepact4) timeout on webkit

**Hit on:** #6679 (`basic-ftp` bump), `mep-webkit` — `Test timeout of 30000ms exceeded` at the
`page.goto` in step-2.

**Root cause:** Test 4 was the only test in this file doing **two** full `page.goto`
navigations, packed into one `test()` with `test.step()`, sharing a single 30s test-wide clock.
`mep-test.js`'s own header comment documents that its per-worker EDS pacer "can exceed the test
budget on slow workers" — this test paid that throttle twice over (once per navigation) while
every other test in the file does one navigation and pays it once. The failure trace confirms
this: it timed out *inside step-2's own `page.goto`*, meaning step-1 had already spent part of
the shared budget before step-2 even started its own navigation.

**Fix:** split Test 4 into two independent `test()` calls instead of widening the timeout. The
two navigations don't depend on each other's state (each already gets a fresh `page`/`context`
fixture), so nothing is lost — each now gets its own full, untouched 30s budget, removing the
contention instead of just giving it more room.

## Fix 2 — `npm ci` ETXTBSY racing the `mas` git-dependency install

**Hit on:** #6682 (`flatted` bump), `Running tests (20.x)` → `Install dependencies`:

```
npm error npm error <ref *1> Error: spawnSync .../web-components/node_modules/esbuild/bin/esbuild ETXTBSY
```

**Root cause:** `@adobecom/mas-platform` is installed from `github:adobecom/mas` (see
`package.json`); npm has to clone and prepare it fresh during `npm ci` (git dependencies aren't
served from a prebuilt tarball cache the way registry deps are), which runs `mas`'s own nested
`web-components` install, including esbuild's postinstall (download a binary, chmod +x, then
`execFileSync(bin, ['--version'])` to validate it). `ETXTBSY` is npm/Node executing that binary
before its write has fully landed on disk — a transient race inherent to preparing a git
dependency's own nested native-binary postinstall, outside anything this repo's own code
controls. Unrelated to `flatted` or any package content.

**Fix:** retry the `Install dependencies` step (3 attempts). There's no code-level root cause to
eliminate here (it's an upstream OS/npm race during a third-party package's postinstall), so
retrying the transient failure is the appropriate mitigation rather than a design flaw to fix.

## Verification

Both reruns of the originally-failing jobs (no code changes, just a rerun) came back green,
confirming both are non-deterministic infra flakes rather than regressions:
- #6679 `mep-webkit`: https://github.com/adobecom/milo/actions/runs/34317938572/job/102372008070 — pass
- #6682 `Running tests (20.x)`: https://github.com/adobecom/milo/actions/runs/34318215064/job/102372012401 — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)