### PR TITLE
MWPW-204853: Split Aside — asset-driven aspect ratio + Tablet/Mobile V2

### DIFF
--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
@@ -20,6 +20,10 @@
 }
 
 .split-aside-grid-stack {
+  /* One side of the glass frame that sits outside the video: 8px padding (--s2a-spacing-xs)
+     + 1px border (--s2a-border-width-1) = 9px. Per axis the border-box is 2 * this larger. */
+  --split-aside-grid-glass: calc(var(--s2a-spacing-xs) + var(--s2a-border-width-1)); /* 9px */
+
   position: relative;
   z-index: 1;
   width: 100%;
@@ -29,10 +33,6 @@
   user-select: none;
   display: flex;
   justify-content: center;
-
-  /* One side of the glass frame that sits outside the video: 8px padding (--s2a-spacing-xs)
-     + 1px border (--s2a-border-width-1) = 9px. Per axis the border-box is 2 * this larger. */
-  --split-aside-grid-glass: calc(var(--s2a-spacing-xs) + var(--s2a-border-width-1)); /* 9px */
 
   .media {
     --split-aside-grid-stack-step: var(--split-aside-grid-stack-index, 0);

--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
@@ -30,6 +30,10 @@
   display: flex;
   justify-content: center;
 
+  /* One side of the glass frame that sits outside the video: 8px padding (--s2a-spacing-xs)
+     + 1px border (--s2a-border-width-1) = 9px. Per axis the border-box is 2 * this larger. */
+  --split-aside-grid-glass: calc(var(--s2a-spacing-xs) + var(--s2a-border-width-1)); /* 9px */
+
   .media {
     --split-aside-grid-stack-step: var(--split-aside-grid-stack-index, 0);
     --slide-scale: pow(0.960, var(--split-aside-grid-stack-index));
@@ -59,14 +63,6 @@
       width: 100%;
       height: 100%;
       pointer-events: none;
-
-      img {
-        display: block;
-        width: 100%;
-        height: 100%;
-        -webkit-user-drag: none;
-        border-radius: var(--s2a-border-radius-md);
-      }
     }
     .video-holder {
       width: 100%;
@@ -78,7 +74,7 @@
       }
     }
 
-    video {
+    :is(video, img) {
       display: block;
       width: 100%;
       height: 100%;
@@ -114,23 +110,26 @@
       transition: var(--split-aside-grid-container-transition, none);
 
       .media {
+        --split-aside-grid-border: calc(2 * var(--split-aside-grid-glass));
+
         position: static;
         height: auto;
         flex-shrink: 0;
-        /* Cap width so aspect-ratio keeps height at/under 600px while staying 16:9. */
-        width: min(200%, calc(600px * 16 / 9));
         transform: none;
-        aspect-ratio: 16 / 9;
+        box-sizing: content-box;
+        aspect-ratio: var(--split-aside-grid-aspect-ratio, 4 / 3);
+        /* Asset width is 120% of the screen - 48px (margins) with 600px max height */
+        width: min(
+          calc(1.2 * (100vw - 2 * var(--split-aside-grid-gap)) - var(--split-aside-grid-border)),
+          calc((600px - var(--split-aside-grid-border)) * var(--split-aside-grid-aspect-ratio, 4 / 3))
+        );
         border-radius: var(--s2a-border-radius-xs);
 
         :is(img, video) {
+          object-fit: cover;
           border-radius: var(--s2a-border-radius-2xs);
         }
       }
-    }
-
-    .split-aside-grid-controls {
-      margin-top: var(--s2a-spacing-md);
     }
 
     .split-aside-grid-items {
@@ -283,25 +282,19 @@
     align-items: center;
     overflow-x: clip;
     grid-template-columns: repeat(12, 1fr);
-    /* Height scales linearly from 465px at 768vw to 615px at 1280vw, then clamps (150 = 615-465 over 512 = 1280-768). */
-    height: clamp(
-      465px,
-      calc(465px + (100vw - 768px) * 150 / 512),
-      615px
-      );
   }
 
   .split-aside-grid-stack {
     inset-inline-end: calc(-1 * var(--grid-padding));
     grid-column: 6 / -1;
-    height: 100%;
     width: auto;
-    padding-left: 0;
+    height: calc(100% - 2 * var(--split-aside-grid-glass));
+    aspect-ratio: var(--split-aside-grid-aspect-ratio, 4 / 3);
     touch-action: auto;
     user-select: auto;
     align-items: center;
-    aspect-ratio: 213/155;
-    margin-block-end: unset;
+    min-height: 480px;
+    margin: var(--split-aside-grid-glass);
 
     .media {
       opacity: 0;
@@ -310,6 +303,7 @@
       width: 100%;
       height: 100%;
       border-radius: var(--s2a-border-radius-xs);
+      box-sizing: content-box;
 
       .video-holder {
         pointer-events: unset;
@@ -317,12 +311,16 @@
 
       :is(video, img) {
         opacity: 0;
+        object-fit: cover;
+        /* Anchor the crop to the left edge (tablet 480-floor trims horizontally). */
+        object-position: left;
         transition: opacity var(--dropdown-transition);
         border-radius: var(--s2a-border-radius-2xs);
       }
 
       &[data-slot="0"] {
         opacity: 1;
+
         :is(video, img) {
           opacity: 1;
         }
@@ -471,12 +469,7 @@
   }
 }
 
-
 @media (width >= 1280px) {
-  .split-aside-grid {
-    height: auto;
-  }
-
   .split-aside-grid-stack {
     grid-column: 5 / -1;
 
@@ -507,12 +500,16 @@
 
 :root:has(meta[name="foundation"][content="c2"]) {
   .split-aside-grid-stack {
-    --btn-spacing: var(--s2a-spacing-lg);
-    --border-padding: calc(var(--s2a-border-width-1) + var(--s2a-spacing-xs));
-    --btn-position: calc(var(--split-aside-grid-stack-cutoff) - var(--border-padding) + var(--btn-spacing));
+    --btn-spacing: var(--s2a-spacing-md);
+    --btn-position: calc(var(--split-aside-grid-stack-cutoff) - var(--split-aside-grid-glass) + var(--btn-spacing));
     button.play-pause-button {
-      right: unset;
       inset-inline-end: var(--btn-position);
+    }
+  }
+
+  @media (width >= 768px) {
+    .split-aside-grid-stack {
+      --btn-spacing: var(--s2a-spacing-lg);
     }
   }
 
@@ -545,6 +542,10 @@
   }
 
   @media (width >= 768px) {
+    .split-aside-grid-stack .media :is(video, img) {
+      object-position: right;
+    }
+
     .split-aside-grid-item {
       margin-block-end: unset;
       .foreground {

--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.js
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.js
@@ -8,7 +8,8 @@ const FADE_IN_MS = 160;
 const RIGHT_DRAG_DENOM = 160;
 
 const reducedMotion = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-const DESKTOP_MQ = '(width >= 768px)';
+const NON_MOBILE_MQ = '(width >= 768px)';
+const DESKTOP_MQ = '(width >= 1280px)';
 const CHEVRON_SVG = '<svg viewBox="0 0 12 12" aria-hidden="true" focusable="false"><path d="M4 1l5 5-5 5" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>';
 const ARROW_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none">
   <path d="M11.208 5.417L7.50781 1.7168C7.18554 1.39453 6.66406 1.39453 6.34179 1.7168C6.01953 2.03907 6.01953 2.56055 6.34179 2.88282L8.63281 5.17481H1.375C0.918955 5.17481 0.549805 5.54395 0.549805 6.00001C0.549805 6.45607 0.918945 6.82521 1.375 6.82521H8.63281L6.34179 9.1172C6.01953 9.43947 6.01953 9.96095 6.34179 10.2832C6.50292 10.4444 6.71386 10.5254 6.9248 10.5254C7.13574 10.5254 7.34668 10.4444 7.50781 10.2832L11.208 6.58302C11.5303 6.26075 11.5303 5.73927 11.208 5.417Z" fill="currentColor"/></svg>`;
@@ -108,14 +109,13 @@ function decorateItem(item, index) {
   return { content, media, toggle };
 }
 
-function setupBlock(el) {
+function setupBlock(el, isDesktop) {
   let stack;
   let medias;
   let items;
   let dotEls;
   let ariaLive;
   let slideNum;
-  let isMobile;
   let itemsWrap;
   let controlsWrap;
   let nextBtn;
@@ -127,6 +127,9 @@ function setupBlock(el) {
   let target = null;
   let resizeObserver = null;
 
+  const nonMobileMQ = window.matchMedia(NON_MOBILE_MQ);
+  const desktopMQ = window.matchMedia(DESKTOP_MQ);
+  const isMobile = () => !nonMobileMQ.matches;
   const isMobileCarousel = el.classList.contains('mobile-carousel');
   const mod = (n) => ((n % slideNum) + slideNum) % slideNum;
   const slotOf = (idx) => mod(idx - rotation);
@@ -148,7 +151,7 @@ function setupBlock(el) {
       item.querySelectorAll(FOCUSABLE_SELECTOR).forEach((focusable) => {
         focusable.removeAttribute('tabindex');
       });
-      const toHide = isMobile ? item : item.querySelector('.foreground');
+      const toHide = isMobile() ? item : item.querySelector('.foreground');
       toHide.setAttribute('aria-hidden', isActive ? 'false' : 'true');
       toHide.querySelectorAll(FOCUSABLE_SELECTOR).forEach((focusable) => {
         focusable.setAttribute('tabindex', isActive ? '0' : '-1');
@@ -206,7 +209,7 @@ function setupBlock(el) {
     });
 
     setAriaHiddenAndTabIndex();
-    if (!isSetup && isMobile) updateAriaLive(ariaLive, items);
+    if (!isSetup && isMobile()) updateAriaLive(ariaLive, items);
   }
 
   function updateStack(dir, progress, ignore) {
@@ -548,9 +551,63 @@ function setupBlock(el) {
     controlsWrap.after(stack);
   }
 
-  const desktopMQ = window.matchMedia(DESKTOP_MQ);
+  function setCutoff() {
+    const activeMedia = medias.find((media) => media.getAttribute('data-slot') === '0');
+    if (!activeMedia) return;
+    const { left, right } = activeMedia.getBoundingClientRect();
+    const viewportWidth = document.documentElement.clientWidth;
+    const cutoff = isRTL ? -left : right - viewportWidth;
+    setInline(stack, { 'stack-cutoff': `${Math.round(cutoff)}px` });
+  }
+
+  function setStackAspectRatio(width, height) {
+    if (!width || !height) return;
+    setInline(stack, { 'aspect-ratio': `${width} / ${height}` });
+    if (isMobile() && !isMobileCarousel) return;
+    setCutoff();
+  }
+
+  function resolveFirstMediaAspectRatio() {
+    const media = medias[0];
+    if (!media) return;
+
+    const asset = media.querySelector('img, video');
+    if (!asset) return;
+
+    const applyRatio = (targetAsset = asset) => {
+      const assetWidth = parseInt(targetAsset.getAttribute('width'), 10) || targetAsset.naturalWidth || targetAsset.videoWidth;
+      const assetHeight = parseInt(targetAsset.getAttribute('height'), 10) || targetAsset.naturalHeight || targetAsset.videoHeight;
+      if (!assetWidth || !assetHeight) return false;
+      setStackAspectRatio(assetWidth, assetHeight);
+      return true;
+    };
+
+    let ratioApplied = applyRatio();
+    if (ratioApplied) return;
+
+    const isVideo = asset.tagName === 'VIDEO';
+    const loadListenerType = isVideo ? 'loadedmetadata' : 'load';
+
+    asset.addEventListener(loadListenerType, () => {
+      if (!asset.isConnected) return;
+      ratioApplied = applyRatio();
+    }, { once: true });
+
+    if (!isVideo) return;
+
+    const poster = asset.getAttribute('poster');
+    if (!poster) return;
+
+    const posterImg = new Image();
+    posterImg.addEventListener('load', () => {
+      if (ratioApplied || !asset.isConnected) return;
+      applyRatio(posterImg);
+    }, { once: true });
+    posterImg.src = poster;
+  }
+
   let mobileBound = false;
-  let desktopBound = false;
+  let nonMobileBound = false;
 
   function enableMobileNavigation() {
     prevBtn.addEventListener('click', handleNavigation);
@@ -578,30 +635,14 @@ function setupBlock(el) {
     mobileCarouselIntersection.observe(el);
   }
 
-  function handleResizeDesktop() {
-    const { scrollWidth } = el;
-    const width = document.documentElement.clientWidth;
-    setInline(stack, { 'stack-cutoff': `${scrollWidth - width}px` });
-  }
-
-  function handleResizeMobileCarousel() {
-    const activeMedia = medias.find((media) => media.getAttribute('data-slot') === '0');
-    const { left, right } = activeMedia.getBoundingClientRect();
-    const viewportWidth = document.documentElement.clientWidth;
-    const cutoff = isRTL ? -left : right - viewportWidth;
-    setInline(stack, { 'stack-cutoff': `${cutoff}px` });
-  }
-
   function addResizeObserver() {
     resizeObserver = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) return;
-      if (isMobileCarousel && isMobile) {
-        goToMobileCarouselActive();
-        handleResizeMobileCarousel();
-      } else handleResizeDesktop();
+      if (isMobileCarousel && isMobile()) goToMobileCarouselActive();
+      setCutoff();
     });
-    resizeObserver.observe(stack);
+    resizeObserver.observe(el);
   }
 
   function removeResizeObserver() {
@@ -637,17 +678,17 @@ function setupBlock(el) {
     removeResizeObserver();
   }
 
-  function bindDesktop() {
-    if (desktopBound) return;
-    desktopBound = true;
+  function bindNonMobile() {
+    if (nonMobileBound) return;
+    nonMobileBound = true;
     items.forEach((item) => item.addEventListener('click', onItemClick));
     addResizeObserver();
     swapStackItems(false);
   }
 
-  function unbindDesktop() {
-    if (!desktopBound) return;
-    desktopBound = false;
+  function unbindNonMobile() {
+    if (!nonMobileBound) return;
+    nonMobileBound = false;
     items.forEach((item) => item.removeEventListener('click', onItemClick));
     removeResizeObserver();
   }
@@ -664,21 +705,22 @@ function setupBlock(el) {
     nextBtn = controlsWrap.querySelector('button.next');
     prevBtn = controlsWrap.querySelector('button.prev');
 
-    if (desktopMQ.matches) {
-      isMobile = false;
-      unbindMobile();
-      bindDesktop();
+    unbindMobile();
+    unbindNonMobile();
+
+    if (nonMobileMQ.matches) {
+      bindNonMobile();
     } else {
-      isMobile = true;
-      unbindDesktop();
       bindMobile();
     }
 
     applyRotation(0, true);
-    if (isMobile && isMobileCarousel) cloneMobileCarouselSlides();
+    resolveFirstMediaAspectRatio();
+    if (isMobile() && isMobileCarousel) cloneMobileCarouselSlides();
   }
 
-  desktopMQ.addEventListener('change', syncBindings);
+  nonMobileMQ.addEventListener('change', syncBindings);
+  if (isDesktop) desktopMQ.addEventListener('change', syncBindings);
   syncBindings();
 }
 
@@ -729,6 +771,6 @@ function decorate(block) {
 }
 
 export default function init(el) {
-  decorateViewportContent(el, decorate);
-  setupBlock(el);
+  const { content } = decorateViewportContent(el, decorate);
+  setupBlock(el, !!content?.desktop);
 }


### PR DESCRIPTION
Split Aside media aspect ratio is now **derived from each asset's own dimensions** (16:9 → 4:3 without forcing re-authoring), plus new **Tablet V2** and **Mobile V2** breakpoint layouts.

### What changed
- **Asset-driven aspect ratio** — `resolveFirstMediaAspectRatio()` reads the first slide's real dimensions (attrs → `naturalWidth`/`videoWidth` → `loadedmetadata`/poster) and writes `--split-aside-grid-aspect-ratio` on the stack. Old 16:9 assets render 16:9, new 4:3 assets render 4:3 — no re-authoring needed.
- **Tablet V2 (768–1279)** — 4 content + 1 spacer + 7 media grid; section follows the video (`height: auto`); 480px `min-height` floor; `object-fit: cover` crop anchored left (RTL: right).
- **Mobile V2 (<768)** — 120% card zone; 600px height cap with shrink-to-ratio; authorable block padding; media → controls → text order.
- **Non-mobile glass-frame overflow fix** — media geometry reworked so the 9px glass frame no longer clips at the bled edge; all-sides margin supplies the right gutter when there is no bleed (≥1600 / non-container).
- Resize + play/pause offset unified into `setCutoff()`; `isMobile` is now a live getter; per-viewport re-resolution + DOM-swap rebind for viewport-authored fragments.

Scope: `libs/mep/ace1209/split-aside-grid/` only — the `ace1205` and canonical `libs/c2/blocks` copies are untouched.

### Figma
C2 - Aside: https://www.figma.com/design/mDNVRruEGiqZaoV99IqYKP/C2---Aside?node-id=10137-79053&m=dev

Resolves: [MWPW-204853](https://jira.corp.adobe.com/browse/MWPW-204853)

**Test URLs:**

_Test page 1 — `/drafts/ratko/split-aside-grid`_
- Before: https://main--da-cc--adobecom.aem.page/drafts/ratko/split-aside-grid?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/drafts/ratko/split-aside-grid?milolibs=split-aside-grid-aspect&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

_Test page 2 — `/cc-shared/fragments/tests/.../cpro-product`_
- Before: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=site-redesign-foundation&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all
- After: https://main--da-cc--adobecom.aem.page/cc-shared/fragments/tests/2026/q3/ace1209/fragments/cpro-product?milolibs=split-aside-grid-aspect&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--all

🤖 Generated with [Claude Code](https://claude.com/claude-code)




