### PR TITLE
MWPW-206931: Fix split aside grid image border radius

### DIFF
--- a/libs/c2/blocks/split-aside-grid/split-aside-grid.css
+++ b/libs/c2/blocks/split-aside-grid/split-aside-grid.css
@@ -59,21 +59,14 @@
       width: 100%;
       height: 100%;
       pointer-events: none;
-
-      img {
-        display: block;
-        width: 100%;
-        height: 100%;
-        -webkit-user-drag: none;
-        border-radius: var(--s2a-border-radius-md);
-      }
     }
+
     .video-holder {
       width: 100%;
       pointer-events: none;
     }
 
-    video {
+    :is(video, img) {
       display: block;
       width: 100%;
       height: 100%;

--- a/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
+++ b/libs/mep/ace1209/split-aside-grid/split-aside-grid.css
@@ -59,15 +59,8 @@
       width: 100%;
       height: 100%;
       pointer-events: none;
-
-      img {
-        display: block;
-        width: 100%;
-        height: 100%;
-        -webkit-user-drag: none;
-        border-radius: var(--s2a-border-radius-md);
-      }
     }
+
     .video-holder {
       width: 100%;
       pointer-events: none;
@@ -78,7 +71,7 @@
       }
     }
 
-    video {
+    :is(video, img) {
       display: block;
       width: 100%;
       height: 100%;


### PR DESCRIPTION
## MWPW-206931

Resolves [MWPW-206931](https://jira.corp.adobe.com/browse/MWPW-206931)

## What was fixed

The image asset in the `split-aside-grid` block was not getting its rounded corners. The intended media `border-radius` (`--s2a-border-radius-md`) was being overwritten by a higher-specificity CSS rule, so images rendered with square corners inside the rounded slide.

Previously the `border-radius` was applied to `<img>` via a rule nested under `picture` (`picture { img { ... } }`), while `<video>` had its own top-level rule. The nested `picture img` selector lost the specificity battle against another rule, so the radius never took effect for images.

The fix removes the separate nested `picture img` block and applies the shared media styling — including `border-radius` — through a single `:is(video, img)` rule. Both images and videos now share identical layout and rounding.

**This problem only occurs with image assets.** Video assets were already styled by the standalone `video` rule and rendered with correct rounded corners; only images were affected by the specificity conflict.

## Testing

Draft page: `/drafts/ratko/split-aside-grid`

**Before (stage):**
https://main--da-cc--adobecom.aem.page/drafts/ratko/split-aside-grid?milolibs=stage&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--default

**After (this branch):**
https://main--da-cc--adobecom.aem.page/drafts/ratko/split-aside-grid?milolibs=split-aside-grid-radius-fix&mep=%2Fcc-shared%2Ffragments%2Ftests%2F2026%2Fq3%2Face1209%2Face1209-cpro-redesign.json--default

Verify that the image asset renders with rounded corners matching the slide, and that video assets are unchanged.


