### PR TITLE
Brand Concierge - Fix for side overlay top cutoff - To Main

### DIFF
--- a/libs/blocks/brand-concierge-global/brand-concierge-global.css
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.css
@@ -1,3 +1,10 @@
+:root {
+  --bc-modal-animation-time: 500ms;
+  --bc-susi-modal-width: 370px;
+  --bc-susi-min-height: 462px;
+  --bc-susi-standard-padding: 24px;
+}
+
 .global-navigation .feds-bc-wrapper {
   width: 340px;
   margin-inline-start: auto;
@@ -24,7 +31,7 @@
   --bc-button-radius: 50%;
   --bc-button-color: #292929;
   --bc-button-hover-color: #131313;
-  --bc-gnav-height: 64px;
+  --bc-side-overlay-top: 64px;
 
   align-items: center;
   box-sizing: content-box;
@@ -327,13 +334,13 @@
   }
 
   to {
-    right: 0;
+    right: 24px;
   }
 }
 
 @keyframes slide-out {
   from {
-    right: 0;
+    right: 24px;
   }
 
   to {
@@ -618,10 +625,11 @@
   #brand-concierge-side.dialog-modal {
     border-radius: 12px;
     box-shadow: 0 4px 32px 0 rgba(0 0 0 / 16%), 0 4px 8px 0 rgba(0 0 0 / 16%);
-    height: calc(100vh - 48px - var(--bc-gnav-height));
-    margin: 24px 24px 24px auto;
-    bottom: 0;
-    right: 0;
+    height: auto;
+    top: calc(20px + var(--bc-side-overlay-top));
+    margin: 0 0 0 auto;
+    bottom: 20px;
+    right: 20px;
     width: 448px;
     z-index: 5;
   }

--- a/libs/blocks/brand-concierge-global/brand-concierge-global.js
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.js
@@ -5,7 +5,6 @@ import {
   decorateCards,
   updateReplicatedValue,
   handleConsent,
-  setCssGnavHeight,
   hasChatCookie,
 } from '../brand-concierge/bc-utils.js';
 import {
@@ -13,6 +12,7 @@ import {
   bcBootstrap,
   openSideModal,
   setAuthoredContent,
+  sideOverlayTop,
 } from '../brand-concierge/bc-bootstrap.js';
 
 let stayActive = false;
@@ -39,7 +39,7 @@ function handleInput(text, gnavInput) {
   submitButton.disabled = true;
   textArea.blur();
   gnavDeactivate(gnavInput, gnavCards);
-  setCssGnavHeight();
+  sideOverlayTop();
   openSideModal(text, bcBootstrap);
 }
 
@@ -47,7 +47,7 @@ function handleSuggestedPrompt(text, gnavCards, event) {
   const gnavInput = document.querySelector('.feds-bc-wrapper .bc-input-field');
   event.target.blur();
   gnavDeactivate(gnavInput, gnavCards);
-  setCssGnavHeight();
+  sideOverlayTop();
   openSideModal(text, bcBootstrap);
 }
 
@@ -167,7 +167,7 @@ export default function init(el) {
 
   if (!hasChatCookie()) localStorage.setItem('bc-side-overlay', 'closed');
   if (localStorage.getItem('bc-side-overlay') === 'open' && !document.body.classList.contains('bc-side-open')) {
-    setCssGnavHeight();
+    sideOverlayTop();
     openSideModal(null, bcBootstrap);
   }
 }

--- a/libs/blocks/brand-concierge/bc-bootstrap.js
+++ b/libs/blocks/brand-concierge/bc-bootstrap.js
@@ -1,6 +1,6 @@
 import { getModal, closeModal } from '../modal/modal.js';
 import { createTag, getConfig, getMetadata, loadScript } from '../../utils/utils.js';
-import { getBetaLabel, waitForCondition, expandIcon, setCssGnavHeight } from './bc-utils.js';
+import { getBetaLabel, waitForCondition, expandIcon } from './bc-utils.js';
 import { bcAnalytics, getAnalyticsLabel } from './bc-analytics.js';
 import chatUIConfig from './chat-ui-config.js';
 
@@ -17,6 +17,35 @@ const susiScopes = 'AdobeID,openid,gnav,pps.read,firefly_api,additional_info.rol
 let bcToken;
 let susiListener;
 let lastImsState = null;
+let lastSideTop = 0;
+let sideScrollListener;
+
+export function sideOverlayTop() {
+  const gnav = document.querySelector('header.global-navigation');
+
+  if (!gnav) return;
+  const gnavTop = gnav.getBoundingClientRect().top;
+  const hasLocalNav = gnav.classList.contains('local-nav');
+  const hasBreadcrumbs = gnav.classList.contains('has-breadcrumbs');
+  const isCompact = gnav.classList.contains('is-compact');
+
+  const rootStyles = getComputedStyle(document.documentElement);
+  const gnavHeight = Number(rootStyles.getPropertyValue('--global-height-nav').trim().slice(0, -2));
+  const localNavHeight = Number(rootStyles.getPropertyValue('--feds-localnav-height').trim().slice(0, -2));
+  const breadcrumbHeight = Number(rootStyles.getPropertyValue('--global-height-breadcrumbs').trim().slice(0, -2));
+
+  const gnavMeasure = ((
+    window.scrollY > gnavHeight && isCompact && hasLocalNav) ? 0 : gnavTop + gnavHeight
+  );
+  const localNavMeasure = hasLocalNav && isCompact ? localNavHeight : 0;
+  const breadcrumbMeasure = hasBreadcrumbs && !isCompact ? breadcrumbHeight : 0;
+
+  const newTop = gnavMeasure + localNavMeasure + breadcrumbMeasure;
+  if (newTop !== lastSideTop) {
+    document.body.style.setProperty('--bc-side-overlay-top', `${newTop}px`);
+    lastSideTop = newTop;
+  }
+}
 
 function handleLocalNav() {
   const localGnav = document.querySelector('div.feds-localnav');
@@ -29,7 +58,7 @@ function handleLocalNav() {
 
           if (currentDisplay !== lastDisplay) {
             lastDisplay = currentDisplay;
-            setCssGnavHeight();
+            sideOverlayTop();
           }
         }
       }
@@ -422,6 +451,41 @@ export async function openSideModal(initialMessage, bootstrap) {
       document.body.classList.remove('bc-side-open');
     }
   });
+
+  // Call setSideOverlayTop when the gnav top changes on resize for any reason (promo reflow)
+  const gnav = document.querySelector('header.global-navigation');
+  let lastGnavTop = gnav ? gnav.getBoundingClientRect().top : 0;
+  let currentWidth = document.body.getBoundingClientRect().width;
+
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.target === document.body && entry.contentRect.width !== currentWidth) {
+        if (lastGnavTop !== gnav.getBoundingClientRect().top) {
+          lastGnavTop = gnav.getBoundingClientRect().top;
+          sideOverlayTop();
+        }
+        currentWidth = entry.contentRect.width;
+      }
+    }
+  });
+  resizeObserver.observe(document.body);
+
+  let currentSidetop = document.body.style.getPropertyValue('--bc-side-overlay-top');
+  // limit window scroll listener, so only one can be active.
+  if (sideScrollListener !== 'scroll') {
+    window.addEventListener('scroll', () => {
+      if (gnav) {
+        if (currentSidetop !== document.body.style.getPropertyValue('--bc-side-overlay-top')
+        || window.scrollY < gnav.getBoundingClientRect().height) {
+          window.requestAnimationFrame(() => {
+            currentSidetop = document.body.style.getPropertyValue('--bc-side-overlay-top');
+            sideOverlayTop();
+          });
+        }
+      }
+    });
+    sideScrollListener = 'scroll';
+  }
 
   bootstrap(initialMessage, mountId);
 }

--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -10,7 +10,6 @@ import {
   decorateFloatingInput,
   updateReplicatedValue,
   handleConsent,
-  setCssGnavHeight,
   hasChatCookie,
 } from './bc-utils.js';
 import {
@@ -18,6 +17,7 @@ import {
   bcBootstrap,
   openModal,
   openSideModal,
+  sideOverlayTop,
   setAuthoredContent,
   mountId,
 } from './bc-bootstrap.js';
@@ -37,7 +37,7 @@ function routeInput(text) {
     const isOpen = document.body.classList.contains('bc-side-open');
     if (isOpen) bcBootstrap(text, mountId);
     else {
-      setCssGnavHeight();
+      sideOverlayTop();
       openSideModal(text, bcBootstrap);
     }
   } else {
@@ -86,7 +86,7 @@ export default async function init(el) {
     }
   });
 
-  setCssGnavHeight();
+  sideOverlayTop();
 
   const rows = el.querySelectorAll(':scope > div');
   const [background, header, cards, input, legal] = rows;


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Now properly handles elements that are placed above the gnav, like language or promo banners
* Now properly handles breadcrumbs in addition to the new local nav implementation

Resolves: [MWPW-206560](https://jira.corp.adobe.com/browse/MWPW-206560)

**Test URLs:**
- Before: https://business.stage.adobe.com/ai/agentic-ai.html
- After: https://business.stage.adobe.com/ai/agentic-ai.html?milolibs=bcg-overlay-refinement

Testing notes: To see the local nav, reduce the browser width until the gnav collapses and observe how the overlay maintains it's 20px placement.

Here are additional test URLs:
* Basic Nav: https://business.stage.adobe.com/?milolibs=bcg-overlay-refinement
* Basic with a language banner: https://business.stage.adobe.com/?milolibs=bcg-overlay-refinement&akamaiLocale=fr
* Breadcrumbs and localnav: https://business.stage.adobe.com/ai/agentic-ai.html?milolibs=bcg-overlay-refinement
* Breadcrumbs, localnav and a language banner: https://business.stage.adobe.com/ai/agentic-ai.html?milolibs=bcg-overlay-refinement&akamaiLocale=fr

