### PR TITLE
MWPW-207055 [MEP] Add within-firewall auth bypass and make mep-next the default

### DIFF
--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.css
@@ -553,6 +553,19 @@ body.mep-align-left .mep-drawer:not(:popover-open) {
   border: 2px solid var(--mep-primary-60);
 }
 
+.mep-drawer .mep-card.center .con-button {
+  cursor: pointer;
+  text-align: center;
+  color: var(--mep-white-100);
+  background: var(--mep-primary-100);
+  border-color: var(--mep-primary-100);
+}
+
+.mep-drawer .mep-card.center .con-button:hover {
+  background: var(--mep-primary-60);
+  border: 2px solid var(--mep-primary-60);
+}
+
 .mep-drawer .mep-spoof-geo-option label {
   cursor: pointer;
   font: var(--mep-body-font);

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -414,10 +414,19 @@ function buildFAB(gnavOffset) {
   return fab;
 }
 
-function buildLoginCard() {
+function buildLoginCard(pageId) {
+  const recheckLink = createTag('a', { href: '#' }, 'Check again');
+  recheckLink.addEventListener('click', (event) => {
+    event.preventDefault();
+    // eslint-disable-next-line no-use-before-define
+    checkAuthAndBuild(pageId);
+  });
   return createTag('div', { class: 'mep-card expanded center' }, [
     createTag('h1', {}, 'Content Unavailable'),
-    createTag('p', { class: 'mep-card-body' }, 'Sign into AEM Sidekick for options.'),
+    createTag('p', { class: 'mep-card-body' }, [
+      'Sign into AEM Sidekick or be inside the Adobe firewall for options. ',
+      recheckLink,
+    ]),
   ]);
 }
 
@@ -428,7 +437,7 @@ function buildFooter() {
 }
 
 function buildActionsContent(pageId) {
-  if (!authenticated) return [buildLoginCard()];
+  if (!authenticated) return [buildLoginCard(pageId)];
   return [
     ...buildManifestList(),
     ...CARD_DATA.actions.map(([header, data]) => (
@@ -511,7 +520,7 @@ function checkAuthAndBuild(pageId) {
     if (!contentEl) return;
 
     if (!authenticated) {
-      contentEl.replaceChildren(buildLoginCard());
+      contentEl.replaceChildren(buildLoginCard(pageId));
       drawerEl.querySelector('.mep-footer')?.remove();
       return;
     }

--- a/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
+++ b/libs/features/mep/mep-next/mep-overlay/mep-overlay.js
@@ -415,17 +415,17 @@ function buildFAB(gnavOffset) {
 }
 
 function buildLoginCard(pageId) {
-  const recheckLink = createTag('a', { href: '#' }, 'Check again');
-  recheckLink.addEventListener('click', (event) => {
+  const refreshButton = createTag('a', { href: '#', class: 'con-button button-l fill' }, 'Refresh');
+  refreshButton.addEventListener('click', (event) => {
     event.preventDefault();
     // eslint-disable-next-line no-use-before-define
     checkAuthAndBuild(pageId);
   });
   return createTag('div', { class: 'mep-card expanded center' }, [
     createTag('h1', {}, 'Content Unavailable'),
-    createTag('p', { class: 'mep-card-body' }, [
-      'Sign into AEM Sidekick or be inside the Adobe firewall for options. ',
-      recheckLink,
+    createTag('div', { class: 'mep-card-body' }, [
+      createTag('p', {}, 'Sign into AEM Sidekick or be inside the Adobe firewall for options.'),
+      refreshButton,
     ]),
   ]);
 }

--- a/libs/features/mep/sidekick-auth.js
+++ b/libs/features/mep/sidekick-auth.js
@@ -55,12 +55,30 @@ function shouldGate() {
   return !isUngatedHost(hostname);
 }
 
+// Corp-only hostname: resolvable only on the internal network/VPN, so the fetch
+// itself (not its response, which is opaque under no-cors) is the signal — it
+// rejects on DNS/connection failure off-network and resolves on-network.
+const FIREWALL_CHECK_URL = 'https://mep-auth-check.awesome-sites.corp.adobe.com';
+export async function isWithinFirewall() {
+  try {
+    await fetch(FIREWALL_CHECK_URL, { mode: 'no-cors' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /*
  * Ungated hosts fire true immediately. Gated hosts fire the initial verdict, then
  * again whenever auth flips (author signs in/out mid-session).
  */
-export function onSidekickAuth(callback) {
+export async function onSidekickAuth(callback) {
   if (!shouldGate()) {
+    callback(true);
+    return;
+  }
+
+  if (await isWithinFirewall()) {
     callback(true);
     return;
   }

--- a/libs/features/personalization/personalization.js
+++ b/libs/features/personalization/personalization.js
@@ -1733,9 +1733,9 @@ export async function init(enablements = {}) {
       // Flatten the preview.js → caas/utils.js → {lingo-active, getUuid} discovery chain
       loadLink(`${config.base}/utils/lingo-active.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
       loadLink(`${config.base}/utils/getUuid.js`, { rel: 'modulepreload', crossorigin: 'anonymous' });
-      // TEMP: ?mepnext=on -> mep-next, else preview.js; gate + toLowerCase() hack die on removal.
-      const previewSrc = new URLSearchParams(window.location.search.toLowerCase()).get('mepnext') === 'on'
-        ? '../mep/mep-next/mep-next.js' : './preview.js';
+      // TEMP: ?mepnext=off -> preview.js, else mep-next; gate + toLowerCase() hack die on removal.
+      const previewSrc = new URLSearchParams(window.location.search.toLowerCase()).get('mepnext') === 'off'
+        ? './preview.js' : '../mep/mep-next/mep-next.js';
       import(previewSrc).then(({ saveToMmm }) => saveToMmm()).catch((e) => {
         log(`MEP save error: ${e.toString()}`);
         window.lana?.log(`MEP save error: ${e.toString()}`);

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -2596,15 +2596,15 @@ export async function loadDeferred(area, blocks, config) {
       }));
   }
   if (config.mep?.preview) {
-    // TEMP: ?mepnext=on -> mep-next, else preview.js; gate + toLowerCase() hack die on removal.
-    if (new URLSearchParams(window.location.search.toLowerCase()).get('mepnext') === 'on') {
+    // TEMP: ?mepnext=off -> preview.js, else mep-next; gate + toLowerCase() hack die on removal.
+    if (new URLSearchParams(window.location.search.toLowerCase()).get('mepnext') === 'off') {
+      import('../features/personalization/preview.js')
+        .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
+    } else {
       import('../features/mep/mep-next/mep-overlay/mep-overlay-highlight.js')
         .then(({ default: init }) => init());
       import('../features/mep/mep-next/mep-overlay/mep-overlay.js')
         .then(({ default: init }) => init());
-    } else {
-      import('../features/personalization/preview.js')
-        .then(({ default: decoratePreviewMode }) => decoratePreviewMode());
     }
   }
   if (config?.dynamicNavKey && config?.env?.name !== 'prod') {

--- a/test/features/mep/mep-next/mep-overlay.test.js
+++ b/test/features/mep/mep-next/mep-overlay.test.js
@@ -44,6 +44,11 @@ const fetchStub = sinon.stub(window, 'fetch').callsFake((url) => {
   if (href.includes('supported-markets')) {
     return Promise.resolve({ ok: true, json: async () => ({ languages: { data: [] } }) });
   }
+  // isWithinFirewall()'s corp-only reachability check: reject by default so tests
+  // exercise the intended Sidekick-auth path instead of always bypassing via firewall.
+  if (href.includes('awesome-sites.corp.adobe.com')) {
+    return Promise.reject(new Error('offline'));
+  }
   // Lambda/API calls return 404 by default so getAdditionalManifests returns undefined
   return Promise.resolve({ ok: false, status: 404, json: async () => ({}), text: async () => '' });
 });

--- a/test/features/mep/mep-next/mep-overlay.test.js
+++ b/test/features/mep/mep-next/mep-overlay.test.js
@@ -46,7 +46,7 @@ const fetchStub = sinon.stub(window, 'fetch').callsFake((url) => {
   }
   // isWithinFirewall()'s corp-only reachability check: reject by default so tests
   // exercise the intended Sidekick-auth path instead of always bypassing via firewall.
-  if (href.includes('awesome-sites.corp.adobe.com')) {
+  if ((url instanceof URL ? url.hostname : new URL(href).hostname) === 'mep-auth-check.awesome-sites.corp.adobe.com') {
     return Promise.reject(new Error('offline'));
   }
   // Lambda/API calls return 404 by default so getAdditionalManifests returns undefined

--- a/test/features/mep/sidekick-auth.test.js
+++ b/test/features/mep/sidekick-auth.test.js
@@ -5,6 +5,7 @@ const { setConfig } = await import('../../../libs/utils/utils.js');
 const {
   isSidekickAuthed,
   isUngatedHost,
+  isWithinFirewall,
   onSidekickAuth,
 } = await import('../../../libs/features/mep/sidekick-auth.js');
 
@@ -35,6 +36,12 @@ const signIn = (user) => user.classList.remove('not-authorized');
 const signOut = (user) => user.classList.add('not-authorized');
 
 describe('sidekick-auth (shadow-DOM login-button probe)', () => {
+  beforeEach(() => {
+    // isWithinFirewall() hits a real corp-only host; reject by default so tests
+    // stay off the network and exercise the DOM/event signals deterministically.
+    sinon.stub(window, 'fetch').rejects(new Error('offline'));
+  });
+
   afterEach(() => {
     sinon.restore();
     document.querySelectorAll('aem-sidekick, helix-sidekick').forEach((el) => el.remove());
@@ -201,7 +208,9 @@ describe('sidekick-auth (shadow-DOM login-button probe)', () => {
       setConfig({ env: { name: 'prod' } });
       const { sk } = mountSidekick({ authed: false });
       const cb = sinon.spy();
-      onSidekickAuth(cb);
+      // onSidekickAuth awaits isWithinFirewall() before attaching event listeners;
+      // await the call so the listener is in place before we dispatch.
+      await onSidekickAuth(cb);
       sk.dispatchEvent(new CustomEvent('logged-in'));
       await wait(50);
       expect(cb.calledWith(true)).to.be.true;
@@ -211,7 +220,7 @@ describe('sidekick-auth (shadow-DOM login-button probe)', () => {
       setConfig({ env: { name: 'prod' } });
       const { sk } = mountSidekick({ authed: false });
       const cb = sinon.spy();
-      onSidekickAuth(cb);
+      await onSidekickAuth(cb);
       sk.dispatchEvent(new CustomEvent('status-fetched', { detail: { profile: { email: 'a@adobe.com' } } }));
       await wait(50);
       expect(cb.calledWith(true)).to.be.true;
@@ -227,6 +236,26 @@ describe('sidekick-auth (shadow-DOM login-button probe)', () => {
       sk.dispatchEvent(new CustomEvent('logged-out'));
       await wait(50);
       expect(cb.calledWith(false)).to.be.true;
+    });
+  });
+
+  describe('onSidekickAuth — firewall bypass', () => {
+    it('isWithinFirewall resolves false when the reachability fetch fails', async () => {
+      expect(await isWithinFirewall()).to.equal(false);
+    });
+
+    it('isWithinFirewall resolves true when the reachability fetch succeeds', async () => {
+      window.fetch.resolves({});
+      expect(await isWithinFirewall()).to.equal(true);
+    });
+
+    it('calls back true when within the firewall, even with no sidekick present', async () => {
+      setConfig({ env: { name: 'prod' } });
+      window.fetch.resolves({});
+      const cb = sinon.spy();
+      onSidekickAuth(cb);
+      await wait(50);
+      expect(cb.calledWith(true)).to.be.true;
     });
   });
 });


### PR DESCRIPTION
### Branch summary:
- Within-firewall auth bypass — added isWithinFirewall() in [sidekick-auth.js]: does a DNS-only reachability check against an internal-only corp host (mep-auth-check.awesome-sites.corp.adobe.com) that only resolves on the Adobe network/VPN.
- onSidekickAuth now grants access without Sidekick login if the firewall check resolves, in addition to the existing "signed into Sidekick" and "ungated host" paths ([sidekick-auth.js:78-91]
- Updated login card copy and added a recheck link in [mep-overlay.js] — now reads "Sign into AEM Sidekick or be inside the Adobe firewall for options." with a "Check again" link that re-runs the auth/firewall check on click without a page reload.
- mep-next is now the default overlay — flipped the gate in [utils.js] and [personalization.js] from opt-in (?mepnext=on) to opt-out (?mepnext=off falls back to legacy preview.js).


**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mepfirewallauth--milo--adobecom.aem.page/?martech=off
- **QA URL:** https://main--da-cc--adobecom.aem.live/products/illustrator?mep&milolibs=mepfirewallauth

### QA instructions:
Note: Most of this testing cannot be done at the office.  You need to be able to use VPN to go inside and back outside the firewall.
1. Default mep-next path — load the base URL as-is (no mepnext param). Confirm the MEP overlay (FAB + drawer) renders via mep-next, not the legacy preview UI.
2. Legacy fallback still works — append &mepnext=off. Confirm the legacy MEP button UI loads instead of mep-next.
3. Firewall bypass, off VPN — with VPN/corp network disconnected and not signed into AEM Sidekick (or use another browser like Firefox), open the base URL. Confirm the drawer's Actions tab shows the login card with the updated copy: "Sign into AEM Sidekick or be inside the Adobe firewall for options." and a "Refresh" link.
4. Firewall bypass, on VPN — connect to the Adobe VPN/corp network (still signed out of Sidekick) and reload. Confirm the Actions tab now shows the full actions list (no login card), since isWithinFirewall() should resolve true.
5. Recheck link, live transition — start off VPN with the login card showing, then connect VPN (or sign into Sidekick) without reloading the page, and click "Refresh." Confirm the drawer updates to the actions list in place.
6. Sidekick auth still works standalone — off VPN, sign into AEM Sidekick. Confirm access is granted via the existing Sidekick-auth path (unchanged behavior).
7. Regression check — verify prod/gated hosts still require one of the two auth signals (Sidekick login or firewall) and ungated hosts (.page) still bypass auth entirely as before. Example page: https://main--da-cc--adobecom.aem.page/products/illustrator?mep&milolibs=mepfirewallauth Load the page (you'll need the sidekick on). Pause the sidekick then reload.  The manifest list should still load.

Resolves: [MWPW-207055](https://jira.corp.adobe.com/browse/MWPW-207055)

















