### PR TITLE
MWPW-201614: enable AUP Select for signed-out M@S users

### DIFF
--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -3,6 +3,7 @@
 import {
   getConfig,
   getMetadata,
+  isAupEnabled,
   loadIms,
   loadStyle,
   loadLana,
@@ -986,7 +987,7 @@ class Gnav {
 
   imsReady = async () => {
     if (!window.adobeIMS.isSignedInUser() || !this.useUniversalNav) setUserProfile({});
-    if (this.useUniversalNav && window.adobeIMS.isSignedInUser()) {
+    if (isAupEnabled(this.useUniversalNav)) {
       this.aupsdkInstancePromise = Gnav.preloadAupSdk();
       this.aupsdkInstancePromise.catch((e) => {
         this.aupsdkInstancePromise = null;
@@ -1139,7 +1140,9 @@ class Gnav {
       appId: 'adobe_com',
       apiKey: imsClientId,
       getAccessToken: () => Promise.resolve(window.adobeIMS?.getAccessToken()?.token),
-      getProfile: () => Promise.resolve(window.adobeIMS?.getProfile()),
+      getProfile: () => Promise.resolve(
+        window.adobeIMS?.isSignedInUser() ? window.adobeIMS.getProfile() : undefined,
+      ),
       environment,
       cdnEnvironment: environment,
       locale,

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -1155,19 +1155,24 @@ class Gnav {
         dialog.id = 'feds-manage-people-dialog';
         dialog.appendChild(element);
         document.body.appendChild(dialog);
-        dialog.addEventListener('cancel', () => {
+        element.addEventListener('close', () => {
           closeCallback({ type: 'close' });
           dialog.close();
           dialog.remove();
           document.documentElement.classList.remove('disable-scroll');
+        }, { once: true });
+        const cancel = () => {
+          // The orchestrator settles on cancel; close releases its event listeners.
+          element.dispatchEvent(new Event('cancel'));
+          element.dispatchEvent(new Event('close'));
+        };
+        dialog.addEventListener('cancel', (e) => {
+          if (e.target !== dialog) return;
+          e.preventDefault();
+          cancel();
         });
         dialog.addEventListener('click', (e) => {
-          if (e.target === dialog) {
-            closeCallback({ type: 'close' });
-            dialog.close();
-            dialog.remove();
-            document.documentElement.classList.remove('disable-scroll');
-          }
+          if (e.target === dialog) cancel();
         });
         document.documentElement.classList.add('disable-scroll');
         dialog.showModal();

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1,6 +1,6 @@
 import {
   createTag, getConfig, loadArea, loadScript, loadStyle, localizeLinkAsync, getMetadata,
-  shouldAllowKrTrial, getCountry, getValidatedMasLibsUrl,
+  shouldAllowKrTrial, getCountry, getValidatedMasLibsUrl, isAupEnabled,
 } from '../../utils/utils.js';
 import { replaceKey } from '../../features/placeholders.js';
 import { decorateButtons, getBlockSize } from '../../utils/decorate.js';
@@ -494,6 +494,19 @@ export async function loadMasComponent(componentName) {
   loadPromise.finally(() => loadingPromises.delete(componentName));
 
   return loadPromise;
+}
+
+async function preloadAupSelect() {
+  const sdk = window.aupsdk;
+  if (!sdk) return;
+  try {
+    await Promise.all([
+      sdk.getOrchestratorContext(),
+      sdk.loadUIComponent('commerce-select'),
+    ]);
+  } catch (error) {
+    log?.warn('AUP Select preload failed', error);
+  }
 }
 
 function getCommercePreloadUrl() {
@@ -1011,12 +1024,16 @@ export async function getModalAction(offers, options, el, isMiloPreview = isPrev
 
   const preload = new URLSearchParams(window.location.search).get('commerce.preload') !== 'off';
   if (el?.isOpen3in1Modal && preload) {
-    const baseUrl = getCommercePreloadUrl();
-    // The script can preload more, based on clientId, but for the ones in use
-    // ('mini-plans', 'creative') there is no difference, so we can just use either one.
-    const client = 'creative';
     window.milo.deferredPromise.then(() => {
       setTimeout(() => {
+        if (isAupEnabled()) {
+          preloadAupSelect();
+          return;
+        }
+        const baseUrl = getCommercePreloadUrl();
+        // The script can preload more, based on clientId, but for the ones in use
+        // ('mini-plans', 'creative') there is no difference, so we can just use either one.
+        const client = 'creative';
         loadScript(`${baseUrl}?cli=${client}`, 'text/javascript', { mode: 'defer', id: 'ucv3-preload-script' });
       }, 1000);
     });

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -375,6 +375,12 @@ export function getMetadata(name, doc = document) {
   return meta && meta.content;
 }
 
+export function isAupEnabled(useUniversalNav = false) {
+  return (useUniversalNav && window.adobeIMS?.isSignedInUser())
+    || (new URLSearchParams(window.location.search).get('aup-select')
+      ?? getMetadata('aup-select')) === 'on';
+}
+
 (() => { if (getMetadata('mweb') === 'on') document.body.classList.add('mweb-enabled'); })();
 
 const handleEntitlements = (() => {

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -431,6 +431,113 @@ describe('global navigation', () => {
     });
   });
 
+  describe('AUP SDK preload', () => {
+    let gnav;
+    let preload;
+    let meta;
+    let originalUrl;
+
+    beforeEach(async () => {
+      originalUrl = window.location.href;
+      gnav = await createFullGlobalNavigation({ signedIn: false });
+      window.adobeIMS = { isSignedInUser: sinon.stub().returns(false) };
+      preload = sinon.stub(gnav.constructor, 'preloadAupSdk').resolves({});
+      sinon.stub(gnav, 'decorateUniversalNav').resolves();
+      sinon.stub(gnav, 'decorateProfile').resolves();
+      sinon.stub(gnav, 'setUpProductCTA').resolves();
+    });
+
+    afterEach(() => {
+      window.history.replaceState(null, '', originalUrl);
+      meta?.remove();
+      meta = null;
+      window.adobeIMS = undefined;
+      sinon.restore();
+    });
+
+    it('only requests an IMS profile while signed in', async () => {
+      preload.restore();
+      const previousSdk = window.aupsdk;
+      const previousSdkFactory = window.AUPSDK;
+      const script = document.createElement('script');
+      script.type = 'javascript/blocked';
+      script.src = 'https://shared-components.stage.adobe.com/aup-sdk/1.0.756/main.js';
+      script.dataset.loaded = 'true';
+      document.head.append(script);
+      const instance = { updateConfig: sinon.stub().resolves() };
+      window.aupsdk = undefined;
+      window.AUPSDK = { preloadSDK: sinon.stub().resolves(instance) };
+      try {
+        window.adobeIMS.getProfile = sinon.stub().throws(new Error('please login before getting the profile'));
+        await gnav.constructor.preloadAupSdk();
+        const { getProfile } = window.AUPSDK.preloadSDK.firstCall.args[1];
+        expect(await getProfile()).to.be.undefined;
+        expect(window.adobeIMS.getProfile.called).to.be.false;
+
+        const profile = { userId: 'test-user' };
+        window.adobeIMS.isSignedInUser.returns(true);
+        window.adobeIMS.getProfile.resetBehavior();
+        window.adobeIMS.getProfile.resolves(profile);
+        expect(await getProfile()).to.equal(profile);
+        expect(window.adobeIMS.getProfile.calledOnce).to.be.true;
+
+        window.adobeIMS.isSignedInUser.returns(false);
+        expect(await getProfile()).to.be.undefined;
+        expect(window.adobeIMS.getProfile.calledOnce).to.be.true;
+        window.adobeIMS = undefined;
+        expect(await getProfile()).to.be.undefined;
+      } finally {
+        script.remove();
+        window.aupsdk = previousSdk;
+        window.AUPSDK = previousSdkFactory;
+      }
+    });
+
+    it('keeps preloading for signed-in Universal Nav users without metadata', async () => {
+      gnav.useUniversalNav = true;
+      window.adobeIMS.isSignedInUser.returns(true);
+      await gnav.imsReady();
+      expect(preload.calledOnce).to.be.true;
+    });
+
+    [false, true].forEach((useUniversalNav) => {
+      it(`does not preload for signed-out users without metadata (Universal Nav: ${useUniversalNav})`, async () => {
+        gnav.useUniversalNav = useUniversalNav;
+        await gnav.imsReady();
+        expect(preload.called).to.be.false;
+      });
+
+      ['on', 'off', ''].forEach((query) => {
+        it(`uses query "${query}" over metadata for signed-out users (Universal Nav: ${useUniversalNav})`, async () => {
+          gnav.useUniversalNav = useUniversalNav;
+          meta = document.createElement('meta');
+          meta.name = 'aup-select';
+          meta.content = query === 'on' ? 'off' : 'on';
+          document.head.append(meta);
+          const url = new URL(originalUrl);
+          url.searchParams.set('aup-select', query);
+          window.history.replaceState(null, '', url);
+          await gnav.imsReady();
+          await gnav.aupsdkInstancePromise;
+          expect(preload.calledOnce).to.equal(query === 'on');
+        });
+      });
+
+      ['on', 'off', ''].forEach((content) => {
+        it(`checks AUP for signed-out users with aup-select="${content}" (Universal Nav: ${useUniversalNav})`, async () => {
+          gnav.useUniversalNav = useUniversalNav;
+          meta = document.createElement('meta');
+          meta.name = 'aup-select';
+          meta.content = content;
+          document.head.append(meta);
+          await gnav.imsReady();
+          await gnav.aupsdkInstancePromise;
+          expect(preload.calledOnce).to.equal(content === 'on');
+        });
+      });
+    });
+  });
+
   describe('Universal navigation', () => {
     const orgAlloy = window.alloy;
     let clock;

--- a/test/blocks/global-navigation/global-navigation.test.js
+++ b/test/blocks/global-navigation/global-navigation.test.js
@@ -493,6 +493,62 @@ describe('global navigation', () => {
       }
     });
 
+    it('settles and cleans up repeated workflows for every dialog close path', async () => {
+      preload.restore();
+      const previousSdk = window.aupsdk;
+      const previousSdkFactory = window.AUPSDK;
+      const script = document.createElement('script');
+      script.type = 'javascript/blocked';
+      script.src = 'https://shared-components.stage.adobe.com/aup-sdk/1.0.756/main.js';
+      script.dataset.loaded = 'true';
+      document.head.append(script);
+      window.aupsdk = undefined;
+      const instance = { updateConfig: sinon.stub().resolves() };
+      window.AUPSDK = { preloadSDK: sinon.stub().resolves(instance) };
+      try {
+        await gnav.constructor.preloadAupSdk();
+        const { showDialog } = window.AUPSDK.preloadSDK.firstCall.args[1];
+        for (const method of ['escape', 'backdrop', 'workflow-cancel', 'workflow-success']) {
+          const element = document.createElement('div');
+          const callback = sinon.spy();
+          await showDialog(element, {}, callback);
+          const dialog = document.getElementById('feds-manage-people-dialog');
+          const cancel = sinon.spy();
+          const close = sinon.spy();
+          element.addEventListener('cancel', cancel);
+          element.addEventListener('close', close);
+          const outcome = new Promise((resolve) => {
+            element.addEventListener('cancel', () => resolve('cancel'), { once: true });
+            element.addEventListener('success', () => resolve('success'), { once: true });
+          });
+          expect(dialog.open).to.be.true;
+          expect(document.documentElement.classList.contains('disable-scroll')).to.be.true;
+          if (method === 'escape') {
+            dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+          } else if (method === 'backdrop') {
+            dialog.click();
+          } else {
+            element.dispatchEvent(new CustomEvent(method.replace('workflow-', ''), { bubbles: true }));
+            element.dispatchEvent(new CustomEvent('close', { bubbles: true }));
+          }
+          expect(await outcome).to.equal(method === 'workflow-success' ? 'success' : 'cancel');
+          expect(cancel.callCount).to.equal(method === 'workflow-success' ? 0 : 1);
+          expect(close.calledOnce).to.be.true;
+          expect(callback.calledOnceWithExactly({ type: 'close' })).to.be.true;
+          expect(document.getElementById('feds-manage-people-dialog')).to.be.null;
+          expect(document.documentElement.classList.contains('disable-scroll')).to.be.false;
+          element.dispatchEvent(new Event('close'));
+          expect(callback.calledOnce).to.be.true;
+        }
+      } finally {
+        script.remove();
+        document.getElementById('feds-manage-people-dialog')?.remove();
+        document.documentElement.classList.remove('disable-scroll');
+        window.aupsdk = previousSdk;
+        window.AUPSDK = previousSdkFactory;
+      }
+    });
+
     it('keeps preloading for signed-in Universal Nav users without metadata', async () => {
       gnav.useUniversalNav = true;
       window.adobeIMS.isSignedInUser.returns(true);

--- a/test/blocks/merch/merch.test.js
+++ b/test/blocks/merch/merch.test.js
@@ -1263,6 +1263,90 @@ describe('Merch Block', () => {
       expect(checkoutLinkConfig.DOWNLOAD_TEXT).to.equal('productCode');
     });
 
+    [
+      { content: 'on', aup: true },
+      { content: 'off', query: 'on', aup: true },
+      { content: 'on', query: 'off', legacy: true },
+      { content: 'off', legacy: true },
+      { content: 'off', commercePreload: 'off' },
+      { content: 'on', commercePreload: 'off' },
+      { content: 'off', lateContent: 'on', aup: true },
+      { content: 'on', lateContent: 'off', legacy: true },
+      { content: 'on', missingSdk: true },
+      { content: 'on', failure: 'getOrchestratorContext', aup: true },
+      { content: 'on', failure: 'loadUIComponent', aup: true },
+      { content: 'on', modal: false },
+    ].forEach(({
+      content, query, commercePreload, lateContent, missingSdk, failure,
+      modal = true, aup = false, legacy = false,
+    }) => {
+      it(`defers commerce preload and chooses the current experience: ${JSON.stringify({
+        content, query, commercePreload, lateContent, missingSdk, failure, modal,
+      })}`, async () => {
+        const previousUrl = window.location.href;
+        const previousDeferred = window.milo.deferredPromise;
+        const previousSdk = window.aupsdk;
+        const sdk = {
+          getOrchestratorContext: sinon.stub().resolves(),
+          loadUIComponent: sinon.stub().resolves(),
+        };
+        if (failure) sdk[failure].rejects(new Error('Preload failed'));
+        window.aupsdk = missingSdk ? undefined : sdk;
+        let resolveDeferred;
+        window.milo.deferredPromise = new Promise((resolve) => { resolveDeferred = resolve; });
+        const meta = createTag('meta', { name: 'aup-select', content });
+        document.head.append(meta);
+        const url = new URL(previousUrl);
+        if (query) url.searchParams.set('aup-select', query);
+        if (commercePreload) url.searchParams.set('commerce.preload', commercePreload);
+        window.history.replaceState(null, '', url);
+        const scripts = [];
+        const { append } = document.head;
+        const appendStub = sinon.stub(document.head, 'append').callsFake((node) => {
+          if (node.id === 'ucv3-preload-script') {
+            scripts.push(node);
+            node.dataset.loaded = 'true';
+          } else {
+            append.call(document.head, node);
+          }
+        });
+        let clock;
+        try {
+          const el = document.createElement('a');
+          el.isOpen3in1Modal = modal;
+          const action = await getModalAction(
+            [{ productArrangement: { productFamily: 'ILLUSTRATOR' } }],
+            { modal: true },
+            el,
+          );
+          expect(action.handler).to.be.a('function');
+          expect(sdk.getOrchestratorContext.called).to.be.false;
+          expect(sdk.loadUIComponent.called).to.be.false;
+          expect(scripts).to.be.empty;
+          clock = sinon.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+          resolveDeferred();
+          await Promise.resolve();
+          if (lateContent) meta.content = lateContent;
+          await clock.tickAsync(999);
+          expect(sdk.getOrchestratorContext.called).to.be.false;
+          expect(sdk.loadUIComponent.called).to.be.false;
+          expect(scripts).to.be.empty;
+          await clock.tickAsync(1);
+          expect(sdk.getOrchestratorContext.calledOnce).to.equal(aup);
+          expect(sdk.loadUIComponent.calledOnceWithExactly('commerce-select')).to.equal(aup);
+          expect(scripts.length).to.equal(legacy ? 1 : 0);
+          if (legacy) expect(scripts[0].src).to.include('/store/iframe/preload.js?cli=creative');
+        } finally {
+          clock?.restore();
+          appendStub.restore();
+          meta.remove();
+          window.history.replaceState(null, '', previousUrl);
+          window.milo.deferredPromise = previousDeferred;
+          window.aupsdk = previousSdk;
+        }
+      });
+    });
+
     it('getModalAction: returns undefined if modal path is cancelled', async () => {
       setConfig({
         ...config,

--- a/test/blocks/merch/mocks/embed-utils.js
+++ b/test/blocks/merch/mocks/embed-utils.js
@@ -75,6 +75,7 @@ export const createIntersectionObserver = stub();
 export const getFederatedContentRoot = () => '';
 export const getFedsPlaceholderConfig = () => ({});
 export const shouldBlockFreeTrialLinks = () => false;
+export const isAupEnabled = () => false;
 export const decorateLinksAsync = stub().resolves();
 export const loadBlock = stub().resolves();
 

--- a/test/blocks/ost/mocks/ost-utils.js
+++ b/test/blocks/ost/mocks/ost-utils.js
@@ -155,6 +155,7 @@ const createIntersectionObserver = () => {};
 const getFederatedContentRoot = () => '';
 const getFedsPlaceholderConfig = () => ({});
 const shouldBlockFreeTrialLinks = () => false;
+const isAupEnabled = () => false;
 const decorateLinksAsync = () => Promise.resolve();
 const loadBlock = () => Promise.resolve();
 
@@ -209,6 +210,7 @@ export {
   getFederatedContentRoot,
   getFedsPlaceholderConfig,
   shouldBlockFreeTrialLinks,
+  isAupEnabled,
   decorateLinksAsync,
   loadBlock,
 };

--- a/test/utils/utils.test.js
+++ b/test/utils/utils.test.js
@@ -74,6 +74,62 @@ describe('Utils', () => {
     expect(resp.json()).to.be.true;
   });
 
+  describe('isAupEnabled', () => {
+    let originalUrl;
+    let meta;
+
+    beforeEach(() => {
+      originalUrl = window.location.href;
+      const url = new URL(originalUrl);
+      url.searchParams.delete('aup-select');
+      window.history.replaceState(null, '', url);
+      meta = document.createElement('meta');
+      meta.name = 'aup-select';
+    });
+
+    afterEach(() => {
+      meta.remove();
+      window.history.replaceState(null, '', originalUrl);
+    });
+
+    it('defaults to disabled and reads metadata insertion, replacement, and removal', () => {
+      expect(utils.isAupEnabled()).to.be.false;
+      meta.content = 'on';
+      document.head.append(meta);
+      expect(utils.isAupEnabled()).to.be.true;
+      const replacement = meta.cloneNode();
+      replacement.content = 'off';
+      meta.replaceWith(replacement);
+      meta = replacement;
+      expect(utils.isAupEnabled()).to.be.false;
+      meta.content = 'on';
+      expect(utils.isAupEnabled()).to.be.true;
+      meta.remove();
+      expect(utils.isAupEnabled()).to.be.false;
+    });
+
+    ['on', 'off', '', 'ON', 'true'].forEach((value) => {
+      it(`requires exact on for metadata "${value}"`, () => {
+        meta.content = value;
+        document.head.append(meta);
+        expect(utils.isAupEnabled()).to.equal(value === 'on');
+      });
+
+      it(`reads query "${value}" with and without metadata`, () => {
+        const url = new URL(window.location.href);
+        url.searchParams.set('aup-select', value);
+        window.history.replaceState(null, '', url);
+        expect(utils.isAupEnabled()).to.equal(value === 'on');
+        meta.content = value === 'on' ? 'off' : 'on';
+        document.head.append(meta);
+        expect(utils.isAupEnabled()).to.equal(value === 'on');
+        url.searchParams.delete('aup-select');
+        window.history.replaceState(null, '', url);
+        expect(utils.isAupEnabled()).to.equal(meta.content === 'on');
+      });
+    });
+  });
+
   describe('prerendered support', () => {
     it('loads milo minimally when document is prerendered', async () => {
       document.head.innerHTML = head;


### PR DESCRIPTION
M@S checkout needs the host-provided AUP SDK for both signed-in and signed-out visitors. Global navigation previously preloaded it only for signed-in Universal Nav users; its profile callback also rejected anonymous launches with "please login before getting the profile".

- Centralize enablement in `isAupEnabled(useUniversalNav)`: preserve signed-in Universal Nav behavior, and opt in with exact `aup-select=on` from query parameters or metadata. Query parameters take precedence.
- Preload the SDK for opted-in signed-out visitors. Request an IMS profile only while signed in, checking the current state each time the SDK calls back.
- Cover metadata/query precedence and live changes, both navigation modes, and profile callbacks across sign-in/sign-out transitions.

The flag is evaluated when Gnav reaches IMS-ready. Metadata injected afterward does not trigger SDK initialization. C2/Federal navigation is outside this change; its loader still needs a separate signed-out enablement API.

Resolves: [MWPW-201614](https://jira.corp.adobe.com/browse/MWPW-201614)
Related M@S PR: https://github.com/adobecom/mas/pull/1264

### Deferred Select preload

- `merch.js` owns the preload decision in `getModalAction()`, using the same three-in-one CTA eligibility, deferred page loading, and one-second delay as the existing legacy preload. Gnav only initializes the SDK.
- At execution time, exact `aup-select=on` selects AUP: reuse `window.aupsdk` and call `getOrchestratorContext()` and `loadUIComponent('commerce-select')` in parallel. No dialog is mounted and no workflow recommendation is requested during preload.
- When AUP is disabled, retain `getCommercePreloadUrl()` and the legacy `ucv3-preload-script`. Reading the flag inside the delayed callback allows metadata changes before execution to select the correct path.
- `commerce.preload=off` disables both preload paths. If the SDK is not ready, skip AUP preloading; preload failures are logged without blocking checkout or starting the legacy preload.

Preload validation: 246 merch/navigation tests passed; ESLint passed. Browser verification confirmed AUP resources loaded before clicking, the legacy preload script stayed absent, and an ordinary CTA click still opened AUP.

**Validation:**
- Utility and global-navigation browser suites: 308 passed, 0 failed.
- ESLint passed for the SDK enablement and preload changes.
- Manually verified the signed-out Photoshop Buy now CTA opens AUP's Pick a plan dialog with both local libraries.
- Hosted branch validation and CI pending.

**Test URLs:**
- Before: https://stage--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-201614--milo--adobecom.aem.page/?martech=off
- M@S integration before: https://main--cc--adobecom.aem.live/uk/creativecloud/plans?maslibs=mwpw-201614-2&milolibs=stage&aup-select=on
- M@S integration after (signed in or out): https://main--cc--adobecom.aem.live/uk/creativecloud/plans?maslibs=mwpw-201614-2&milolibs=mwpw-201614&aup-select=on


<details><summary><strong>GNav Test URLs</strong></summary>

**Gnav + Footer + Region Picker modal:**
- Acrobat: https://main--dc--adobecom.aem.live/acrobat?martech=off&milolibs=MWPW-201614--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=MWPW-201614--milo--adobecom
- CC: https://main--cc--adobecom.aem.live/creativecloud?martech=off&milolibs=MWPW-201614--milo--adobecom
- Milo: https://MWPW-201614--milo--adobecom.aem.page/drafts/blaishram/test-urls/page?martech=off
- Express: https://main--express-milo--adobecom.aem.live/express/?martech=off&milolibs=MWPW-201614--milo--adobecom
- News: https://main--news--adobecom.aem.live/?martech=off&milolibs=MWPW-201614--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off&milolibs=MWPW-201614--milo--adobecom

**Thin Gnav + ThinFooter + Region Picker dropup:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201614--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201614--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201614--milo--adobecom
- Milo: https://MWPW-201614--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201614--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201614--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-gnav-footer-thin?martech=off&milolibs=MWPW-201614--milo--adobecom

**Localnav + Promo:**
- Acrobat: https://main--dc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201614--milo--adobecom
- BACOM: https://main--da-bacom--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201614--milo--adobecom
- CC: https://main--cc--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201614--milo--adobecom
- Milo: https://MWPW-201614--milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off
- Express: https://main--express-milo--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201614--milo--adobecom
- News: https://main--news--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201614--milo--adobecom
- Homepage: https://main--homepage--adobecom.aem.page/drafts/blaishram/test-urls/page-with-promo?martech=off&milolibs=MWPW-201614--milo--adobecom

**Sticky Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-sticky?martech=off&milolibs=MWPW-201614--milo--adobecom

**Inline Branch Banner:**
- URL: https://main--federal--adobecom.aem.page/drafts/blaishram/banner/branch-banner-inline?martech=off&milolibs=MWPW-201614--milo--adobecom

**Blog**
- URL: https://main--blog--adobecom.aem.page/?martech=off&milolibs=MWPW-201614--milo--adobecom

**RTL Locale**
- URL: https://main--homepage--adobecom.aem.live/mena_ar/homepage/index-loggedout?martech=off&milolibs=MWPW-201614--milo--adobecom
</details>