### PR TITLE
MWPW-205481 | Make accordion content visible to Claude chat

### DIFF
--- a/libs/blocks/accordion/accordion.css
+++ b/libs/blocks/accordion/accordion.css
@@ -23,6 +23,10 @@ div.accordion:not(.descr-list) {
   line-height: var(--type-body-s-lh);
 }
 
+.accordion .descr-details.is-collapsed {
+  display: none;
+}
+
 .accordion-expand-all {
   display: flex;
   flex-wrap: wrap;

--- a/libs/blocks/accordion/accordion.js
+++ b/libs/blocks/accordion/accordion.js
@@ -43,14 +43,14 @@ function openPanel(btn, panel) {
   const analyticsValue = btn.getAttribute('daa-ll');
   btn.setAttribute('aria-expanded', 'true');
   btn.setAttribute('daa-ll', analyticsValue.replace(/open-/, 'close-'));
-  panel.removeAttribute('hidden');
+  panel.classList.remove('is-collapsed');
 }
 
 function closePanel(btn, panel) {
   const analyticsValue = btn.getAttribute('daa-ll');
   btn.setAttribute('aria-expanded', 'false');
   btn.setAttribute('daa-ll', analyticsValue.replace(/close-/, 'open-'));
-  panel.setAttribute('hidden', '');
+  panel.classList.add('is-collapsed');
 }
 
 function closeMediaPanel({ displayArea, el, dd, clickedId }) {
@@ -138,7 +138,7 @@ function createItem(accordion, id, heading, num, isEditorial) {
   const dtAttrs = hTag ? { class: 'descr-term' } : { role: 'heading', 'aria-level': 3, class: 'descr-term' };
   const dtHtml = hTag ? createTag(hTag.tagName, { class: 'accordion-heading' }, button) : button;
   const dt = createTag('div', dtAttrs, dtHtml);
-  const dd = createTag('div', { 'aria-labelledby': triggerId, id: panelId, hidden: true, class: 'descr-details' }, panel);
+  const dd = createTag('div', { 'aria-labelledby': triggerId, id: panelId, class: 'descr-details is-collapsed' }, panel);
   if (isEditorial) dd.prepend(mediaCollection[id][num - 1]);
 
   button.addEventListener('click', (e) => { handleClick(e.target, dd, num, id); });

--- a/test/blocks/accordion/editorial-accordion.test.js
+++ b/test/blocks/accordion/editorial-accordion.test.js
@@ -115,7 +115,7 @@ describe('Accordion', () => {
       const btn = el.querySelector('.expand-btn');
       btn.click();
       const details = [...el.querySelectorAll('.descr-details')];
-      expect(details.every((detail) => detail.getAttribute('hidden') === null)).to.be.true;
+      expect(details.every((detail) => !detail.classList.contains('is-collapsed'))).to.be.true;
       const images = el.querySelectorAll('.descr-details img');
       expect(images.length).to.be.equal(3);
     });


### PR DESCRIPTION
- Replace the HTML hidden attribute on collapsed accordion panels with a CSS class (is-collapsed) so that AI tools and web scrapers can read accordion content from the rendered page
- The hidden attribute causes claude chat to skip panel content entirely making it unable to answer questions based on FAQ/accordion pages which is otherwise accessible on all other chat tools like openai/gemini etc.
- Adds .accordion .descr-details.is-collapsed { display: none; } CSS rule to preserve the same visual behaviour

Resolves: [MWPW-205481](https://jira.corp.adobe.com/browse/MWPW-205481)

**Test URLs:**

- Before: https://stage--milo--adobecom.aem.live/docs/library/kitchen-sink/accordion?georouting=off&martech=off
- After: https://mwpw-205481--milo--adobecom.aem.live/docs/library/kitchen-sink/accordion?georouting=off&martech=off

- Before: https://stage--da-cc--adobecom.aem.live/products/firefly/features/image-to-video?georouting=off&martech=off
- After: https://stage--da-cc--adobecom.aem.live/products/firefly/features/image-to-video?georouting=off&martech=off&milolibs=mwpw-205481




