### PR TITLE
Brand Concierge - Side Overlay performance fixes

### DIFF
--- a/libs/blocks/brand-concierge-global/brand-concierge-global.css
+++ b/libs/blocks/brand-concierge-global/brand-concierge-global.css
@@ -625,11 +625,10 @@
   #brand-concierge-side.dialog-modal {
     border-radius: 12px;
     box-shadow: 0 4px 32px 0 rgba(0 0 0 / 16%), 0 4px 8px 0 rgba(0 0 0 / 16%);
-    height: auto;
-    top: calc(20px + var(--bc-side-overlay-top));
-    margin: 0 0 0 auto;
-    bottom: 20px;
-    right: 20px;
+    height: calc(100vh - 40px - var(--bc-side-overlay-top));
+    margin: 20px 20px 20px auto;
+    bottom: 0;
+    right: 0;
     width: 448px;
     z-index: 5;
   }

--- a/libs/blocks/brand-concierge/bc-bootstrap.js
+++ b/libs/blocks/brand-concierge/bc-bootstrap.js
@@ -18,7 +18,6 @@ let bcToken;
 let susiListener;
 let lastImsState = null;
 let lastSideTop = 0;
-let sideScrollListener;
 
 export function sideOverlayTop() {
   const gnav = document.querySelector('header.global-navigation');
@@ -405,6 +404,38 @@ export async function openSideModal(initialMessage, bootstrap) {
   const header = createTag('div', { class: 'bc-modal-header' }, [title, getBetaLabel(), expandButton]);
   const mountEl = createTag('div', { id: mountId });
 
+  // Call setSideOverlayTop when the gnav top changes on resize for any reason (promo reflow)
+  const gnav = document.querySelector('header.global-navigation');
+  let lastGnavTop = gnav ? gnav.getBoundingClientRect().top : 0;
+  let currentWidth = document.body.getBoundingClientRect().width;
+
+  const resizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.target === document.body && entry.contentRect.width !== currentWidth) {
+        if (lastGnavTop !== gnav.getBoundingClientRect().top) {
+          lastGnavTop = gnav.getBoundingClientRect().top;
+          sideOverlayTop();
+        }
+        currentWidth = entry.contentRect.width;
+      }
+    }
+  });
+  resizeObserver.observe(document.body);
+
+  let currentSidetop = document.body.style.getPropertyValue('--bc-side-overlay-top');
+  const scrollListener = () => {
+    if (gnav) {
+      if (currentSidetop !== document.body.style.getPropertyValue('--bc-side-overlay-top')
+      || window.scrollY < gnav.getBoundingClientRect().height) {
+        window.requestAnimationFrame(() => {
+          currentSidetop = document.body.style.getPropertyValue('--bc-side-overlay-top');
+          sideOverlayTop();
+        });
+      }
+    }
+  };
+  window.addEventListener('scroll', scrollListener, { passive: true });
+
   innerModal.append(header, mountEl);
   const modal = await getModal(null, {
     class: 'opening',
@@ -414,6 +445,8 @@ export async function openSideModal(initialMessage, bootstrap) {
       window.dispatchEvent(new CustomEvent('bc:side-modal-close'));
       localStorage.setItem('bc-side-overlay', 'closed');
       document.body.classList.remove('bc-side-open');
+      resizeObserver.disconnect();
+      window.removeEventListener('scroll', scrollListener);
       modal.classList.add('closing');
       await new Promise((resolve) => {
         setTimeout(() => resolve(), animationMs);
@@ -451,41 +484,6 @@ export async function openSideModal(initialMessage, bootstrap) {
       document.body.classList.remove('bc-side-open');
     }
   });
-
-  // Call setSideOverlayTop when the gnav top changes on resize for any reason (promo reflow)
-  const gnav = document.querySelector('header.global-navigation');
-  let lastGnavTop = gnav ? gnav.getBoundingClientRect().top : 0;
-  let currentWidth = document.body.getBoundingClientRect().width;
-
-  const resizeObserver = new ResizeObserver((entries) => {
-    for (const entry of entries) {
-      if (entry.target === document.body && entry.contentRect.width !== currentWidth) {
-        if (lastGnavTop !== gnav.getBoundingClientRect().top) {
-          lastGnavTop = gnav.getBoundingClientRect().top;
-          sideOverlayTop();
-        }
-        currentWidth = entry.contentRect.width;
-      }
-    }
-  });
-  resizeObserver.observe(document.body);
-
-  let currentSidetop = document.body.style.getPropertyValue('--bc-side-overlay-top');
-  // limit window scroll listener, so only one can be active.
-  if (sideScrollListener !== 'scroll') {
-    window.addEventListener('scroll', () => {
-      if (gnav) {
-        if (currentSidetop !== document.body.style.getPropertyValue('--bc-side-overlay-top')
-        || window.scrollY < gnav.getBoundingClientRect().height) {
-          window.requestAnimationFrame(() => {
-            currentSidetop = document.body.style.getPropertyValue('--bc-side-overlay-top');
-            sideOverlayTop();
-          });
-        }
-      }
-    });
-    sideScrollListener = 'scroll';
-  }
 
   bootstrap(initialMessage, mountId);
 }

--- a/libs/blocks/brand-concierge/brand-concierge.css
+++ b/libs/blocks/brand-concierge/brand-concierge.css
@@ -1296,8 +1296,8 @@
   #brand-concierge-side.dialog-modal {
     border-radius: 12px;
     box-shadow: 0 4px 32px 0 rgba(0 0 0 / 16%), 0 4px 8px 0 rgba(0 0 0 / 16%);
-    height: calc(100vh - 48px - var(--bc-gnav-height));
-    margin: 24px 24px 24px auto;
+    height: calc(100vh - 40px - var(--bc-side-overlay-top));
+    margin: 20px 20px 20px auto;
     bottom: 0;
     right: 0;
     width: 448px;

--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -27,13 +27,13 @@ const variants = {};
 
 function checkGlobal() {
   const params = new URLSearchParams(window.location.search);
-  let global = false;
   if (window?.milo?.brandConcierge?.brandConciergeGlobal) {
-    global = window.milo.brandConcierge.brandConciergeGlobal;
-  } else if (params.get('side-overlay') === 'true') {
-    global = true;
+    return window.milo.brandConcierge.brandConciergeGlobal;
+  } 
+  if (params.get('side-overlay') === 'true') {
+    return true;
   }
-  return global;
+  return false;
 }
 
 function routeInput(text) {

--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -26,9 +26,12 @@ import {
 const variants = {};
 
 function checkGlobal() {
+  const params = new URLSearchParams(window.location.search);
   let global = false;
   if (window?.milo?.brandConcierge?.brandConciergeGlobal) {
     global = window.milo.brandConcierge.brandConciergeGlobal;
+  } else if (params.get('side-overlay') === 'true') {
+    global = true;
   }
   return global;
 }

--- a/libs/blocks/brand-concierge/brand-concierge.js
+++ b/libs/blocks/brand-concierge/brand-concierge.js
@@ -29,7 +29,7 @@ function checkGlobal() {
   const params = new URLSearchParams(window.location.search);
   if (window?.milo?.brandConcierge?.brandConciergeGlobal) {
     return window.milo.brandConcierge.brandConciergeGlobal;
-  } 
+  }
   if (params.get('side-overlay') === 'true') {
     return true;
   }


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->

* Fixes to an issue observed in non bacom environments
* Performance fixes for changes made in this [PR](https://github.com/adobecom/milo/pull/6690) to remove listeners and observers on overlay close
* Add the ability to force the side overlay using the side-overlay=true query param for testing the overlay without a brand-concierge-global block.

Resolves: [MWPW-206560](https://jira.corp.adobe.com/browse/MWPW-206560)

**Test URLs:**
- Before: https://business.stage.adobe.com/ai/agentic-ai.html
- After: https://business.stage.adobe.com/ai/agentic-ai.html?milolibs=bc-side-overlay-top

Testing notes: 

Here's additional URLs to show the solution working on different, acom nav:
- https://www.stage.adobe.com/creativecloud.html?milolibs=bc-side-overlay-top&side-overlay=true&akamaiLocale=fr
- https://www.stage.adobe.com/cc-shared/fragments/uar/brand-concierge/brand-concierge?milolibs=bc-side-overlay-top&side-overlay=true







