### PR TITLE
[MWPW-183694] Preflight: make accessibility results read as automated-only

### DIFF
--- a/libs/blocks/preflight/accessibility/accessibility.js
+++ b/libs/blocks/preflight/accessibility/accessibility.js
@@ -71,7 +71,7 @@ export default function Accessibility() {
               </p>
               <p class="preflight-item-description">
                 ${results.pass
-    ? 'No accessibility issues found.'
+    ? 'No automated issues found. Manual testing still required.'
     : `${results.violations.length} accessibility violations detected.`}
               </p>
               <ul class="summary-list">
@@ -79,9 +79,6 @@ export default function Accessibility() {
                 <li><strong>Test Scope:</strong> body</li>
                 <li><strong>WCAG Tags:</strong> ${AXE_CORE_CONFIG.runOnly?.values?.join(', ') || 'NONE'}</li>
               </ul>
-              <p class="preflight-accessibility-note">
-                <strong>Note:</strong> This test does not include screen reader behavior, focus order, or voice navigation checks.
-              </p>
             </div>
           </div>
         </div>
@@ -167,6 +164,9 @@ export default function Accessibility() {
     `;
   }
   return html`
+  <div class="preflight-accessibility-disclaimer" role="note">
+    <strong>Automated checks only.</strong> Preflight runs automated accessibility tests, which catch only a portion of possible issues. A passing result does not mean the page is fully accessible — manual testing (screen reader, keyboard and focus order, voice navigation) is still required.
+  </div>
   <div class="preflight-columns accessibility-columns">
     ${resultsSummary(testResults, pageURL)}
     <div class="preflight-column violations-column">

--- a/libs/blocks/preflight/preflight.css
+++ b/libs/blocks/preflight/preflight.css
@@ -1387,12 +1387,17 @@ img:hover ~ .asset-meta,
   word-break: break-all;
 }
 
-.preflight-accessibility-note {
-  margin-top: var(--s2a-spacing-12);
-  font-size: var(--s2a-font-size-12);
-  color: var(--preflight-fg-subtle);
+/* Automated-only disclaimer — persistent warning above the results. */
+.preflight-accessibility-disclaimer {
+  margin: 0 var(--s2a-spacing-16) var(--s2a-spacing-16);
+  padding: var(--s2a-spacing-12) var(--s2a-spacing-16);
+  background: var(--s2a-color-orange-100);
+  border: 1px solid var(--preflight-warning);
+  border-inline-start-width: 4px;
+  border-radius: var(--s2a-border-radius-8);
+  font-size: var(--s2a-font-size-14);
   line-height: 1.5;
-  font-style: italic;
+  color: var(--preflight-fg);
 }
 
 /* Violations Section */


### PR DESCRIPTION
## Problem
Authors read a green Preflight **Accessibility** result as a full pass and skip manual testing. The checks are automated (axe-core) and only cover a portion of WCAG issues — a green result is **not** a clean bill of health. This has already let real issues through (e.g. the MAX carousel-on-mobile / cards-on-desktop functional breakage).

Source: [MWPW-183694](https://jira.corp.adobe.com/browse/MWPW-183694) ·context in [this Slack thread](https://adobe-mwp.slack.com/archives/C08GJP18528/p1762255598982969).

## What changed
Scope: the Preflight **Accessibility** tab only (`libs/blocks/preflight/accessibility/`). The `#accessibility-test` Slack bot is a separate surface and is out of scope here.

- **Persistent warning banner** above the results — states the checks are automated-only and that manual testing (screen reader, keyboard/focus order, voice navigation) is still required. Shown for both pass and fail.
- **Reworded the pass subtext**: `No accessibility issues found.` → `No automated issues found. Manual testing still required.`
- **Removed** the faint grey footnote the banner replaces.

No logic/control-flow changes; copy + one CSS rule.

## Verification
- ESLint clean; stylelint at baseline (no net-new debt).
- Existing Preflight unit tests pass (4/4).
- Rendered against the real `preflight.css` + C2 tokens in both states; banner text contrast verified **19.6:1** (WCAG AA pass).


