### PR TITLE
MWPW-207162: Hoist late-resolving CTA mas-fields regardless of em/strong ancestor

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1898,6 +1898,21 @@ function decorateInlineCtas(masField, content) {
 }
 
 /**
+ * mas-field can render its own resolved CTA as a direct sibling of the stale fallback
+ * content it didn't clean up (seen when a cached fragment resolves fast enough to race
+ * the field's own render). Hoisting the stale content in that case would throw away the
+ * working, already-styled button and leave the raw fallback link in its place. Drop the
+ * stale content instead; the real button already works.
+ */
+function dropStaleContentIfAlreadyResolved(masField, content) {
+  const resolvedSibling = [...masField.children]
+    .find((child) => child !== content && child.matches('a, button'));
+  if (!resolvedSibling) return false;
+  content.remove();
+  return true;
+}
+
+/**
  * A headless mas-field CTA can fire 'mas:ready' after its block decorated (slow network,
  * or a cached fragment resolving before the component's own render finishes), too late for
  * decorateButtons. One document listener hoists + decorates it, no per-block wiring. Not
@@ -1913,8 +1928,9 @@ function watchMasFieldCtas() {
   document.addEventListener('mas:ready', async ({ target: mf }) => {
     if (mf?.tagName !== 'MAS-FIELD') return;
     const content = mf.querySelector(':scope > [data-role="mas-field-content"]');
+    if (!content || dropStaleContentIfAlreadyResolved(mf, content)) return;
     // Same gate createInline uses: a single CTA anchor, not block-level content.
-    if (content?.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
+    if (content.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
       // Upgrade to checkout-link before hoisting, else the late CTA never hydrates.
       upgradeCommerceLinks(content);
       await decorateContentLinks(content);
@@ -1941,6 +1957,7 @@ async function createInlineField(el, options) {
 
   const content = masField.querySelector(':scope > [data-role="mas-field-content"]');
   if (!content) return masField;
+  if (dropStaleContentIfAlreadyResolved(masField, content)) return masField;
 
   // Upgrade any plain commerce elements (missing `is`) so the commerce service resolves
   // them. Applies to both CTA (<a>) and price (<span>) fields.

--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1898,17 +1898,22 @@ function decorateInlineCtas(masField, content) {
 }
 
 /**
- * A headless mas-field CTA can fire 'mas:ready' after its block decorated (slow network),
- * too late for decorateButtons. One document listener hoists + decorates it, no per-block wiring.
+ * A headless mas-field CTA can fire 'mas:ready' after its block decorated (slow network,
+ * or a cached fragment resolving before the component's own render finishes), too late for
+ * decorateButtons. One document listener hoists + decorates it, no per-block wiring. Not
+ * limited to em/strong CTAs — a block-level CTA (e.g. a rich-content cta-area link, or an
+ * offer-hero action-area CTA once decorateButtons has already stripped its em/strong) can
+ * race the same way, and leaving it unhoisted strands the raw fallback link next to the
+ * resolved button.
  */
 let masReadyWatched = false;
 function watchMasFieldCtas() {
   if (masReadyWatched) return;
   masReadyWatched = true;
   document.addEventListener('mas:ready', async ({ target: mf }) => {
-    if (mf?.tagName !== 'MAS-FIELD' || !mf.closest('em, strong')) return;
+    if (mf?.tagName !== 'MAS-FIELD') return;
     const content = mf.querySelector(':scope > [data-role="mas-field-content"]');
-    // Same gate createInline uses: an inline CTA anchor, not block-level content.
+    // Same gate createInline uses: a single CTA anchor, not block-level content.
     if (content?.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
       // Upgrade to checkout-link before hoisting, else the late CTA never hydrates.
       upgradeCommerceLinks(content);

--- a/test/blocks/merch/mas-field.test.js
+++ b/test/blocks/merch/mas-field.test.js
@@ -575,8 +575,7 @@ describe('mas-field', () => {
     it('hoists a late block-level CTA (no em/strong ancestor) on mas:ready, no stray duplicate', async () => {
       // Regression: a CTA authored directly in a block-level cell (not wrapped in em/strong --
       // e.g. rich-content's cta-area, or an offer-hero action-area once decorateButtons has
-      // already stripped the strong) that resolves late must still be cleaned up. Without this,
-      // the raw fallback link is stranded next to the separately self-styled button.
+      // already stripped the strong) that resolves late must still be hoisted and styled.
       setConfig({ codeRoot: '/libs' });
       const section = document.createElement('div');
       section.classList.add('section');
@@ -603,6 +602,40 @@ describe('mas-field', () => {
       expect(links.length, 'exactly one hoisted CTA, no stray duplicate').to.equal(1);
       expect(links[0].outerHTML).to.include('is="checkout-link"');
       expect(links[0].classList.contains('con-button')).to.be.true;
+    });
+
+    it('drops a stale fallback span on mas:ready when mas-field already rendered its own resolved CTA', async () => {
+      // Regression: mas-field can render its OWN resolved, styled CTA as a direct sibling
+      // of the stale fallback content it never cleaned up (a cached fragment racing the
+      // field's own render). The late listener must drop the stale span, not hoist it --
+      // hoisting the stale (unstyled) content would discard the working button and leave
+      // plain unstyled text in its place.
+      setConfig({ codeRoot: '/libs' });
+      const section = document.createElement('div');
+      section.classList.add('section');
+      const block = document.createElement('div');
+      block.classList.add('rich-content', 'media');
+      const ctaArea = document.createElement('div');
+      ctaArea.classList.add('cta-area');
+      ctaArea.innerHTML = '<mas-field field="ctas[0]">'
+        + '<aem-fragment fragment="frag-1" hidden></aem-fragment>'
+        + '<a is="checkout-link" data-wcs-osi="abc" class="con-button fill placeholder-resolved">Free trial</a>'
+        + '<span data-role="mas-field-content"><a data-wcs-osi="abc" data-checkout-workflow="UCv3">Free trial</a></span>'
+        + '</mas-field>';
+      block.append(ctaArea);
+      section.append(block);
+      document.body.append(section);
+
+      ctaArea.querySelector('mas-field').dispatchEvent(
+        new CustomEvent('mas:ready', { bubbles: true, composed: true }),
+      );
+      await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+      expect(ctaArea.querySelectorAll('[data-role="mas-field-content"]').length).to.equal(0);
+      const links = ctaArea.querySelectorAll('a[data-wcs-osi]');
+      expect(links.length, 'the already-resolved button survives, no duplicate').to.equal(1);
+      expect(links[0].classList.contains('con-button')).to.be.true;
+      expect(links[0].getAttribute('is')).to.equal('checkout-link');
     });
 
     it('decorates two CTAs in the same paragraph correctly when processed concurrently', async () => {

--- a/test/blocks/merch/mas-field.test.js
+++ b/test/blocks/merch/mas-field.test.js
@@ -572,6 +572,39 @@ describe('mas-field', () => {
       expect(link.classList.contains('con-button')).to.be.true;
     });
 
+    it('hoists a late block-level CTA (no em/strong ancestor) on mas:ready, no stray duplicate', async () => {
+      // Regression: a CTA authored directly in a block-level cell (not wrapped in em/strong --
+      // e.g. rich-content's cta-area, or an offer-hero action-area once decorateButtons has
+      // already stripped the strong) that resolves late must still be cleaned up. Without this,
+      // the raw fallback link is stranded next to the separately self-styled button.
+      setConfig({ codeRoot: '/libs' });
+      const section = document.createElement('div');
+      section.classList.add('section');
+      const block = document.createElement('div');
+      block.classList.add('rich-content', 'media');
+      const ctaArea = document.createElement('div');
+      ctaArea.classList.add('cta-area');
+      // MAS self-styles the anchor with con-button before hoisting.
+      ctaArea.innerHTML = '<mas-field field="ctas[0]"><span data-role="mas-field-content">'
+        + '<a class="con-button fill" data-wcs-osi="abc" data-checkout-workflow="UCv3">Free trial</a>'
+        + '</span></mas-field>';
+      block.append(ctaArea);
+      section.append(block);
+      document.body.append(section);
+
+      // Late resolution: the component fires mas:ready after the block already decorated.
+      ctaArea.querySelector('mas-field').dispatchEvent(
+        new CustomEvent('mas:ready', { bubbles: true, composed: true }),
+      );
+      await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+      expect(ctaArea.querySelectorAll('[data-role="mas-field-content"]').length).to.equal(0);
+      const links = ctaArea.querySelectorAll('mas-field a[data-wcs-osi]');
+      expect(links.length, 'exactly one hoisted CTA, no stray duplicate').to.equal(1);
+      expect(links[0].outerHTML).to.include('is="checkout-link"');
+      expect(links[0].classList.contains('con-button')).to.be.true;
+    });
+
     it('decorates two CTAs in the same paragraph correctly when processed concurrently', async () => {
       setConfig({ codeRoot: '/libs' });
       const section = document.createElement('div');


### PR DESCRIPTION
## Summary
- A CTA `<mas-field>` that resolves after its block already decorated is cleaned up by a late `mas:ready` listener, but that listener only fired when the mas-field sat inside an `<em>`/`<strong>` ancestor.
- In practice that almost never matches: `decorateButtons` strips `<em>`/`<strong>` immediately, before the mas-field's own async resolution ever runs. Any standalone CTA field can hit the gap when its fragment is reused/cached elsewhere on the page, leaving a stale raw link next to the resolved button.
- Confirmed on adobe.com/products/photoshop.html (rich-content `cta-area`) and the Acrobat Studio hero (`offer-hero` `action-area`).
- Widens the listener's gate to any single-CTA-anchor mas-field, regardless of ancestor. The existing "is this a CTA anchor, not block content" check already scopes it safely.

Jira: MWPW-207162

## Test plan
- [x] Added a regression test for a block-level (non-em/strong) late-resolving CTA in `test/blocks/merch/mas-field.test.js`; confirmed it fails without the fix and passes with it.
- [x] Full `mas-field.test.js` suite passes (30/30) against current `main`.
- [x] `eslint` clean on both changed files.
- [ ] Manual visual re-check on the two confirmed pages once deployed to a preview branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





