### PR TITLE
Add pill-group block

### DIFF
--- a/libs/c2/blocks/pill-group/pill-group.css
+++ b/libs/c2/blocks/pill-group/pill-group.css
@@ -1,0 +1,66 @@
+.pill-group {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s2a-spacing-md);
+
+  ul {
+    --pill-gap: var(--s2a-spacing-2xs);
+
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--pill-gap);
+    justify-items: center;
+    align-content: center;
+
+    :is(li, .con-button) {
+      width: 100%;
+      min-width: 0;
+    }
+  }
+
+}
+
+.pill-group-heading {
+  text-align: center;
+}
+
+.pill-group-row-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s2a-spacing-2xs);
+}
+
+.pill-group-row {
+  width: 100%;
+}
+
+.pill-group-cta {
+  border: none;
+  background: var(--s2a-color-gray-900);
+  color: var(--s2a-color-gray-25);
+
+  &:hover {
+    background: var(--s2a-color-gray-25);
+    color: var(--s2a-color-gray-1000);
+  }
+}
+
+@media(width >= 768px) {
+  .pill-group ul {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+
+    :is(li, .con-button) {
+      width: unset;
+    }
+  }
+}

--- a/libs/c2/blocks/pill-group/pill-group.js
+++ b/libs/c2/blocks/pill-group/pill-group.js
@@ -1,0 +1,48 @@
+import { createTag } from '../../../utils/utils.js';
+import { decorateBlockText, decorateViewportContent } from '../../../utils/decorate.js';
+
+const HEADING_LEVEL = '5';
+const MOBILE_MQ = '(width < 768px)';
+const mobileMQ = window.matchMedia(MOBILE_MQ);
+
+function reversePillRows(block) {
+  const container = block.querySelector('.pill-group-row-container');
+  if (!container) return;
+  const reversedRows = [...container.children].reverse();
+  container.replaceChildren(...reversedRows);
+}
+
+function decorate(block) {
+  decorateBlockText(block, { heading: HEADING_LEVEL });
+  const rowsContainer = createTag('div', { class: 'pill-group-row-container' });
+  const rows = block.querySelectorAll(`:scope > :not(:has(.heading-${HEADING_LEVEL}))`);
+  rows.forEach((row) => {
+    row.className = 'pill-group-row';
+    const list = createTag('ul');
+    row.querySelectorAll('a').forEach((cta) => {
+      const li = createTag('li');
+      li.append(cta);
+      list.append(li);
+      if (cta.classList.contains('con-button')) return;
+      cta.classList.add('con-button', 'pill-group-cta');
+    });
+    row.replaceChildren(list);
+    rowsContainer.appendChild(row);
+  });
+
+  block.appendChild(rowsContainer);
+
+  const headingRow = block.querySelector(`:scope > :has(.heading-${HEADING_LEVEL})`);
+  if (!headingRow) return;
+  headingRow.className = 'pill-group-heading';
+  const heading = headingRow.querySelector(`.heading-${HEADING_LEVEL}`);
+  rowsContainer.setAttribute('role', 'group');
+  rowsContainer.setAttribute('aria-labelledby', heading.id);
+}
+
+export default function init(el) {
+  decorateViewportContent(el, decorate);
+  if (!el.classList.contains('pill-reverse-mobile')) return;
+  if (mobileMQ.matches) reversePillRows(el);
+  mobileMQ.addEventListener('change', () => reversePillRows(el));
+}

--- a/libs/utils/utils.js
+++ b/libs/utils/utils.js
@@ -133,6 +133,7 @@ const C2_BLOCKS = [
   'news',
   'offer-hero',
   'pdf-space',
+  'pill-group',
   'plans-hero',
   'product-marquee-grid',
   'quick-actions',


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
Adds `pill-group` block. 

* `pill-reverse-mobile` variant reverses order of pill rows on mobile (this can also be accomplished by using `mobile-viewport` ...) 

**Authoring:**
- If CTAs are authored as plain links (without `bold`, `italic` or any modifiers), new CTAs style from the design will be applied.
- If authored with modifiers, CTAs will have already implemented global variants.
<img width="839" height="435" alt="Screenshot 2026-09-11 at 11 28 07" src="https://github.com/user-attachments/assets/f9e2f4a7-3a30-48df-be04-0293fd6fc31f" />

Design: https://www.figma.com/design/6FQTDUAttFbukvtskDAkPS/Product?node-id=20272-134096&m=dev
Resolves: [MWPW-206092](https://jira.corp.adobe.com/browse/MWPW-206092)

**Test URLs:**
- https://main--da-cc--adobecom.aem.page/drafts/ramuntea/firefly-w5?milolibs=pill-group
- https://main--da-cc--adobecom.aem.page/drafts/ratko/seo?milolibs=pill-group


