### PR TITLE
[MWPW-184222] Preflight unit tests

### DIFF
--- a/libs/blocks/preflight/panels/general.js
+++ b/libs/blocks/preflight/panels/general.js
@@ -89,7 +89,7 @@ function getAdminUrl(url, type) {
   return type === 'status' ? `${base}?editUrl=auto` : base;
 }
 
-async function getStatus(url) {
+export async function getStatus(url) {
   const adminUrl = getAdminUrl(url, 'status');
   if (!adminUrl) {
     return {

--- a/libs/blocks/preflight/panels/merch.js
+++ b/libs/blocks/preflight/panels/merch.js
@@ -10,7 +10,7 @@ const MAS_UNPUBLISHED_HIGHLIGHT = 'preflight-mas-unpublished';
 
 const ALLOWED_MAS_HOSTS = ['mas.adobe.com'];
 
-function isMasUrl(href) {
+export function isMasUrl(href) {
   if (!href) return false;
   try {
     const url = new URL(href);
@@ -20,7 +20,7 @@ function isMasUrl(href) {
   }
 }
 
-function getFragmentIdFromMasElement(el) {
+export function getFragmentIdFromMasElement(el) {
   if (el.tagName === 'MAS-FIELD') {
     const aem = el.querySelector('aem-fragment');
     return aem?.getAttribute('fragment') || null;
@@ -56,7 +56,7 @@ function getBlockLocation(element) {
   return Math.round(rect.top + scrollTop);
 }
 
-function checkMasFieldsMultipleFragments() {
+export function checkMasFieldsMultipleFragments() {
   const main = document.querySelector('main');
   main?.querySelectorAll(`.${MAS_MULTIPLE_FRAGMENTS_HIGHLIGHT}`).forEach((el) => el.classList.remove(MAS_MULTIPLE_FRAGMENTS_HIGHLIGHT));
   const sections = main?.querySelectorAll(':scope > div.section') || [];
@@ -119,7 +119,7 @@ function getService() {
   return document.getElementsByTagName('mas-commerce-service')?.[0];
 }
 
-function formatDate(dateString) {
+export function formatDate(dateString) {
   if (!dateString) return '';
   const date = new Date(dateString);
   return date.toLocaleDateString('en-US', {
@@ -132,7 +132,7 @@ function formatDate(dateString) {
   });
 }
 
-function selectOffers(offers, { country }) {
+export function selectOffers(offers, { country }) {
   let selected;
   if (offers.length < 2) {
     selected = offers;
@@ -153,7 +153,7 @@ function selectOffers(offers, { country }) {
   return selected;
 }
 
-function isPromotionActive(promotion, instant, quantity = 1) {
+export function isPromotionActive(promotion, instant, quantity = 1) {
   if (!promotion) return false;
   const {
     start,
@@ -182,7 +182,7 @@ function isPromotionActive(promotion, instant, quantity = 1) {
   return now >= startDate && now <= endDate;
 }
 
-async function checkUrl(url) {
+export async function checkUrl(url) {
   try {
     const response = await fetch(url, {
       method: 'HEAD',

--- a/libs/blocks/preflight/panels/merch.js
+++ b/libs/blocks/preflight/panels/merch.js
@@ -226,7 +226,7 @@ export async function checkUrl(url) {
   }
 }
 
-async function checkWcsElements() {
+export async function checkWcsElements() {
   const elements = [];
 
   const allWcsElements = document.querySelectorAll('[data-wcs-osi]');

--- a/libs/blocks/preflight/preflight.js
+++ b/libs/blocks/preflight/preflight.js
@@ -63,7 +63,7 @@ const TAB_CATEGORY = {
 
 // structure/seo/performance return one check per item, so failing checks map 1:1
 // to the cards the panel shows.
-function countChecks(checks = []) {
+export function countChecks(checks = []) {
   return checks.reduce((acc, check) => {
     if (check?.status === 'fail') {
       if (check.severity === SEVERITY.WARNING) acc.warnings += 1;
@@ -77,7 +77,7 @@ function countChecks(checks = []) {
 
 // accessibility/merch/assets return a single aggregate check whose granular counts
 // live in `details`, so the badge matches the items the panel actually lists.
-function countCategory(title, runChecks) {
+export function countCategory(title, runChecks) {
   const checks = runChecks[TAB_CATEGORY[title]] || [];
   const [first] = checks;
   if (title === 'Accessibility') {

--- a/test/blocks/preflight/accessibility/accessibility-config.test.js
+++ b/test/blocks/preflight/accessibility/accessibility-config.test.js
@@ -1,0 +1,25 @@
+import { expect } from '@esm-bundle/chai';
+import { AXE_CORE_CONFIG, CUSTOM_CHECKS_CONFIG } from '../../../../libs/blocks/preflight/accessibility/accessibility-config.js';
+
+describe('preflight accessibility config', () => {
+  it('AXE_CORE_CONFIG scopes to body and runs only WCAG tags', () => {
+    expect(AXE_CORE_CONFIG.include).to.deep.equal([['body']]);
+    expect(AXE_CORE_CONFIG.runOnly.type).to.equal('tag');
+    expect(AXE_CORE_CONFIG.runOnly.values).to.include('wcag2aa');
+    expect(AXE_CORE_CONFIG.exclude.map((s) => s[0])).to.include('#preflight');
+  });
+
+  it('CUSTOM_CHECKS_CONFIG lists all five custom checks', () => {
+    expect(CUSTOM_CHECKS_CONFIG.checks).to.have.members([
+      'altText', 'color-contrast', 'aria-labels', 'video-captions', 'keyboard',
+    ]);
+  });
+
+  it('both configs exclude preflight-owned decoration nodes', () => {
+    [AXE_CORE_CONFIG, CUSTOM_CHECKS_CONFIG].forEach((cfg) => {
+      const excluded = cfg.exclude.map((s) => s[0]);
+      expect(excluded).to.include('.preflight-decoration');
+      expect(excluded).to.include('.asset-meta-entry');
+    });
+  });
+});

--- a/test/blocks/preflight/accessibility/accessibility-custom-checks.test.js
+++ b/test/blocks/preflight/accessibility/accessibility-custom-checks.test.js
@@ -1,0 +1,47 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import customAccessibilityChecks from '../../../../libs/blocks/preflight/accessibility/accessibility-custom-checks.js';
+
+describe('preflight accessibility custom checks orchestrator', () => {
+  let lanaBackup;
+  let container;
+
+  beforeEach(() => {
+    lanaBackup = window.lana;
+    window.lana = { log: sinon.spy() };
+    container = document.createElement('div');
+    container.id = 'cc-fixture';
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    window.lana = lanaBackup;
+    container.remove();
+  });
+
+  it('aggregates violations from the enabled checks', async () => {
+    container.innerHTML = '<img>'; // missing alt
+    const res = await customAccessibilityChecks({
+      checks: ['altText'],
+      include: ['#cc-fixture'],
+      exclude: [],
+    });
+    expect(res.some((v) => v.id === 'image-alt')).to.be.true;
+  });
+
+  it('returns [] when no elements match the include selectors', async () => {
+    const res = await customAccessibilityChecks({
+      checks: ['altText'],
+      include: ['#no-such-node'],
+      exclude: [],
+    });
+    expect(res).to.deep.equal([]);
+  });
+
+  it('logs and returns [] when the config is malformed', async () => {
+    const res = await customAccessibilityChecks({ include: 'body' }); // string, not array
+    expect(res).to.deep.equal([]);
+    expect(window.lana.log.calledOnce).to.be.true;
+    expect(window.lana.log.firstCall.args[1]).to.include({ tags: 'preflight', severity: 'error' });
+  });
+});

--- a/test/blocks/preflight/accessibility/accessibility-runner.test.js
+++ b/test/blocks/preflight/accessibility/accessibility-runner.test.js
@@ -1,0 +1,51 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import runAccessibilityTest from '../../../../libs/blocks/preflight/accessibility/accessibility-runner.js';
+
+describe('preflight accessibility runner', () => {
+  let lanaBackup;
+
+  beforeEach(() => {
+    lanaBackup = window.lana;
+    window.lana = { log: sinon.spy() };
+    // Custom checks fire video-captions fetches against CUSTOM_CHECKS_CONFIG; keep them offline.
+    sinon.stub(window, 'fetch').callsFake(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+    window.axe = window.axe || {};
+    sinon.stub(window.axe, 'run').resolves({ violations: [{ id: 'axe-marker', impact: 'serious' }] });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    window.lana = lanaBackup;
+  });
+
+  it('merges axe violations with custom violations and reports pass=false', async () => {
+    const res = await runAccessibilityTest(document);
+    expect(res.violations.some((v) => v.id === 'axe-marker')).to.be.true;
+    expect(res.pass).to.be.false;
+  });
+
+  it('runs axe against the passed area when it is not the document', async () => {
+    window.axe.run.resolves({ violations: [] });
+    const area = document.createElement('div');
+    const res = await runAccessibilityTest(area);
+    // area !== document, so axe is run against the passed area context directly.
+    expect(window.axe.run.firstCall.args[0]).to.equal(area);
+    expect(res.violations).to.be.an('array');
+    expect(res.pass).to.equal(res.violations.length === 0);
+  });
+
+  it('passes include/exclude context when area is the document', async () => {
+    window.axe.run.resolves({ violations: [] });
+    await runAccessibilityTest(document);
+    const ctx = window.axe.run.firstCall.args[0];
+    expect(ctx).to.have.keys(['include', 'exclude']);
+  });
+
+  it('returns an error object when axe throws', async () => {
+    window.axe.run.rejects(new Error('axe boom'));
+    const res = await runAccessibilityTest(document);
+    expect(res.error).to.contain('axe boom');
+    expect(window.lana.log.called).to.be.true;
+  });
+});

--- a/test/blocks/preflight/accessibility/accessibility.test.js
+++ b/test/blocks/preflight/accessibility/accessibility.test.js
@@ -1,0 +1,70 @@
+/* eslint-disable import/no-named-as-default-member */
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { html, render } from '../../../../libs/deps/htm-preact.js';
+import Accessibility from '../../../../libs/blocks/preflight/accessibility/accessibility.js';
+
+const AXE_VIOLATION = {
+  id: 'axe-marker',
+  impact: 'serious',
+  description: 'A sample axe violation',
+  helpUrl: 'https://help.example/',
+  nodes: [{ html: '<img>' }],
+};
+
+const waitFor = async (fn, tries = 60) => {
+  for (let i = 0; i < tries; i += 1) {
+    if (fn()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => { setTimeout(r, 15); });
+  }
+  throw new Error('waitFor timed out');
+};
+
+describe('preflight accessibility panel', () => {
+  let container;
+  let lanaBackup;
+
+  beforeEach(() => {
+    lanaBackup = window.lana;
+    window.lana = { log: sinon.spy() };
+    sinon.stub(window, 'fetch').callsFake(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+    window.axe = window.axe || {};
+    sinon.stub(window.axe, 'run').resolves({ violations: [AXE_VIOLATION] });
+    container = document.createElement('div');
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+    sinon.restore();
+    window.lana = lanaBackup;
+  });
+
+  it('renders the failed results summary once the test completes', async () => {
+    render(html`<${Accessibility} />`, container);
+    await waitFor(() => container.querySelector('.preflight-item-title'));
+    const title = container.querySelector('.preflight-item-title').textContent;
+    expect(title).to.contain('Accessibility Test Failed');
+    expect(container.querySelector('.summary-list a').getAttribute('href')).to.equal(window.location.href);
+    expect(container.textContent).to.contain('wcag2aa');
+  });
+
+  it('expands a violation to reveal its details on click', async () => {
+    render(html`<${Accessibility} />`, container);
+    await waitFor(() => container.querySelector('.violation-summary'));
+    const summary = container.querySelector('.violation-summary');
+    expect(container.querySelector('.violation-details')).to.be.null;
+    summary.click();
+    await waitFor(() => container.querySelector('.violation-details'));
+    expect(container.querySelector('.violation-details').textContent).to.contain('axe-marker');
+  });
+
+  it('renders an error panel when the test run errors', async () => {
+    window.axe.run.rejects(new Error('kaboom'));
+    render(html`<${Accessibility} />`, container);
+    await waitFor(() => container.textContent.includes('Error'));
+    expect(container.textContent).to.contain('kaboom');
+  });
+});

--- a/test/blocks/preflight/accessibility/audit-image-alt-text.test.js
+++ b/test/blocks/preflight/accessibility/audit-image-alt-text.test.js
@@ -1,0 +1,95 @@
+/* eslint-disable import/no-named-as-default-member */
+import { expect } from '@esm-bundle/chai';
+import { html, render } from '../../../../libs/deps/htm-preact.js';
+import AuditImageAltText, { checkAlt } from '../../../../libs/blocks/preflight/accessibility/audit-image-alt-text.js';
+
+// 1x1 PNG so the image has intrinsic size and reads as visible.
+const PNG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
+
+const waitFor = async (fn, tries = 60) => {
+  for (let i = 0; i < tries; i += 1) {
+    if (fn()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => { setTimeout(r, 15); });
+  }
+  throw new Error('waitFor timed out');
+};
+
+describe('preflight accessibility audit-image-alt-text', () => {
+  let main;
+
+  before(() => {
+    main = document.createElement('main');
+    main.innerHTML = `
+      <img class="a11y-valid" src="${PNG}?valid" alt="A descriptive label">
+      <img class="a11y-decorative" src="${PNG}?deco" alt="">
+    `;
+    document.body.append(main);
+  });
+
+  after(() => main.remove());
+
+  it('classifies images with alt text vs decorative (empty alt)', async () => {
+    const result = await checkAlt();
+    expect(result).to.be.an('object');
+    const valid = result.altTextImages.find((i) => i.src.includes('?valid'));
+    expect(valid).to.exist;
+    expect(valid.alt).to.equal('A descriptive label');
+    expect(valid.parent).to.equal('main-content');
+
+    const deco = result.decorativeImages.find((i) => i.src.includes('?deco'));
+    expect(deco).to.exist;
+    expect(deco.altCheck).to.equal('Decorative');
+  });
+
+  it('decorates the DOM with alt-check metadata', () => {
+    const valid = main.querySelector('.a11y-valid');
+    expect(valid.dataset.pageLocation).to.equal('main-content');
+    const deco = main.querySelector('.a11y-decorative');
+    expect(deco.dataset.altCheck).to.equal('Decorative');
+    expect(main.querySelector('.asset-meta')).to.exist;
+  });
+
+  it('is idempotent - a second run short-circuits', async () => {
+    const second = await checkAlt();
+    expect(second).to.be.undefined;
+  });
+
+  describe('AuditImageAltText component', () => {
+    let container;
+
+    beforeEach(() => { container = document.createElement('div'); document.body.append(container); });
+    afterEach(() => { render(null, container); container.remove(); });
+
+    it('renders image groups populated from the earlier checkAlt run', async () => {
+      render(html`<${AuditImageAltText} />`, container);
+      await waitFor(() => container.querySelector('.access-image-grid'));
+      expect(container.querySelector('.image-filter')).to.exist;
+      expect(container.querySelectorAll('.access-image-grid-item').length).to.be.greaterThan(0);
+      // dropdown options rendered from filterOptions (per select)
+      expect(container.querySelector('.image-filter').querySelectorAll('option').length).to.equal(4);
+    });
+
+    it('toggles a group open/closed via the grid heading', async () => {
+      render(html`<${AuditImageAltText} />`, container);
+      await waitFor(() => container.querySelector('.grid-toggle'));
+      const toggle = container.querySelector('.grid-toggle');
+      const heading = toggle.closest('.grid-heading');
+      const before = heading.classList.contains('is-closed');
+      toggle.querySelector('.preflight-group-expand').click(); // SPAN branch
+      expect(heading.classList.contains('is-closed')).to.equal(!before);
+      toggle.click(); // anchor branch
+      expect(heading.classList.contains('is-closed')).to.equal(before);
+    });
+
+    it('applies a view filter when the dropdown changes', async () => {
+      render(html`<${AuditImageAltText} />`, container);
+      await waitFor(() => container.querySelector('.image-filter'));
+      const select = container.querySelector('.image-filter');
+      const grid = select.closest('.access-image-grid');
+      select.value = 'show-footer';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      expect(grid.classList.contains('show-footer')).to.be.true;
+    });
+  });
+});

--- a/test/blocks/preflight/accessibility/check-aria-labels.test.js
+++ b/test/blocks/preflight/accessibility/check-aria-labels.test.js
@@ -1,0 +1,65 @@
+import { expect } from '@esm-bundle/chai';
+import checkAriaLabels from '../../../../libs/blocks/preflight/accessibility/check-aria-labels.js';
+
+const CONFIG = { checks: ['aria-labels'] };
+
+describe('preflight accessibility check-aria-labels', () => {
+  const created = [];
+  const add = (html) => {
+    const tpl = document.createElement('template');
+    tpl.innerHTML = html.trim();
+    const el = tpl.content.firstElementChild;
+    document.body.append(el);
+    created.push(el);
+    return el;
+  };
+
+  afterEach(() => { while (created.length) created.pop().remove(); });
+
+  it('returns [] when aria-labels check is not enabled', () => {
+    const el = add('<button></button>');
+    expect(checkAriaLabels([el], { checks: [] })).to.deep.equal([]);
+  });
+
+  it('flags a button with no aria-label and no text content', () => {
+    const el = add('<button></button>');
+    const res = checkAriaLabels([el], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].description).to.contain('missing the aria-label');
+    expect(res[0].impact).to.equal('serious');
+  });
+
+  it('does not flag a button with visible text content', () => {
+    const el = add('<button>Save</button>');
+    expect(checkAriaLabels([el], CONFIG)).to.deep.equal([]);
+  });
+
+  it('flags an aria-label that does not start with the text content', () => {
+    const el = add('<button aria-label="Close dialog">Open</button>');
+    const res = checkAriaLabels([el], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].description).to.contain('does not start with element text content');
+    expect(res[0].impact).to.equal('moderate');
+  });
+
+  it('accepts an aria-label prefixed by the text content', () => {
+    const el = add('<button aria-label="Save changes">Save</button>');
+    expect(checkAriaLabels([el], CONFIG)).to.deep.equal([]);
+  });
+
+  it('flags con-button anchors sharing an aria-label but linking to different URLs', () => {
+    const a1 = add('<a class="con-button" aria-label="Learn more" href="https://a.example/">Learn more</a>');
+    const a2 = add('<a class="con-button" aria-label="Learn more" href="https://b.example/">Learn more</a>');
+    const res = checkAriaLabels([a1, a2], CONFIG);
+    const shared = res.find((v) => v.description.includes('share the same aria-label'));
+    expect(shared).to.exist;
+    expect(shared.nodes).to.have.lengthOf(2);
+  });
+
+  it('does not flag shared aria-labels that resolve to the same URL', () => {
+    const a1 = add('<a class="con-button" aria-label="Learn more" href="https://a.example/">Learn more</a>');
+    const a2 = add('<a class="con-button" aria-label="Learn more" href="https://a.example/">Learn more</a>');
+    const res = checkAriaLabels([a1, a2], CONFIG);
+    expect(res.find((v) => v.description.includes('share the same aria-label'))).to.be.undefined;
+  });
+});

--- a/test/blocks/preflight/accessibility/check-color-contrast.test.js
+++ b/test/blocks/preflight/accessibility/check-color-contrast.test.js
@@ -1,0 +1,83 @@
+import { expect } from '@esm-bundle/chai';
+import checkColorContrast from '../../../../libs/blocks/preflight/accessibility/check-color-contrast.js';
+
+// 1x1 transparent PNG data URI - loads synchronously, no network.
+const PNG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
+const CONFIG = { checks: ['color-contrast'] };
+
+describe('preflight accessibility check-color-contrast', () => {
+  const created = [];
+  const add = (html) => {
+    const tpl = document.createElement('template');
+    tpl.innerHTML = html.trim();
+    const el = tpl.content.firstElementChild;
+    document.body.append(el);
+    created.push(el);
+    return el;
+  };
+
+  beforeEach(() => {
+    // Stub ColorThief so loadColorThief() short-circuits (no network / colorThief.js load).
+    window.ColorThief = function ColorThief() {
+      this.getColor = () => [10, 10, 10];
+    };
+  });
+
+  afterEach(() => {
+    while (created.length) created.pop().remove();
+    delete window.ColorThief;
+  });
+
+  it('returns [] when color-contrast check is not enabled', async () => {
+    const el = add('<h1 style="color:#000">Heading</h1>');
+    expect(await checkColorContrast([el], { checks: [] })).to.deep.equal([]);
+  });
+
+  it('passes high-contrast text (black on white)', async () => {
+    const el = add('<h1 style="color:rgb(0,0,0)">Heading</h1>');
+    expect(await checkColorContrast([el], CONFIG)).to.deep.equal([]);
+  });
+
+  it('flags low-contrast text over a color background', async () => {
+    const el = add('<h1 style="color:rgb(180,180,180)">Low contrast</h1>');
+    const res = await checkColorContrast([el], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].id).to.equal('color-contrast');
+    expect(res[0].impact).to.equal('serious');
+  });
+
+  it('uses the relaxed 3:1 threshold for large text', async () => {
+    // rgb(140,140,140) on white ~= 3.3:1 -> fails at 4.5 (normal) but passes at 3.0 (large).
+    const large = add('<h1 style="color:rgb(140,140,140);font-size:30px">Big</h1>');
+    expect(await checkColorContrast([large], CONFIG)).to.deep.equal([]);
+    const normal = add('<h2 style="color:rgb(140,140,140);font-size:14px">Small</h2>');
+    expect(await checkColorContrast([normal], CONFIG)).to.have.lengthOf(1);
+  });
+
+  it('ignores non-heading/non-button elements', async () => {
+    const el = add('<p style="color:rgb(200,200,200)">paragraph</p>');
+    expect(await checkColorContrast([el], CONFIG)).to.deep.equal([]);
+  });
+
+  it('ignores hidden or empty elements', async () => {
+    const hidden = add('<h1 style="color:rgb(200,200,200);display:none">hidden</h1>');
+    const empty = add('<h2 style="color:rgb(200,200,200)">   </h2>');
+    expect(await checkColorContrast([hidden, empty], CONFIG)).to.deep.equal([]);
+  });
+
+  it('samples an ancestor background-image when present', async () => {
+    const el = add(`<h1 style="background-image:url(${PNG});color:rgb(20,20,20)">Over bg image</h1>`);
+    const res = await checkColorContrast([el], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].id).to.equal('color-contrast-image');
+    expect(res[0].nodes[0]).to.have.property('background', 'rgb(10, 10, 10)');
+  });
+
+  it('reports a color-contrast-image violation when a nearby image is sampled', async () => {
+    const el = add(`<h1 style="color:rgb(20,20,20)">Over image<img src="${PNG}" alt="x"></h1>`);
+    const res = await checkColorContrast([el], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].id).to.equal('color-contrast-image');
+    expect(res[0].nodes[0]).to.have.property('background', 'rgb(10, 10, 10)');
+  });
+});

--- a/test/blocks/preflight/accessibility/check-image-alt-text.test.js
+++ b/test/blocks/preflight/accessibility/check-image-alt-text.test.js
@@ -1,0 +1,70 @@
+import { expect } from '@esm-bundle/chai';
+import checkImageAltText from '../../../../libs/blocks/preflight/accessibility/check-image-alt-text.js';
+
+const CONFIG = { checks: ['altText'] };
+
+function img(attrs = {}) {
+  const el = document.createElement('img');
+  Object.entries(attrs).forEach(([k, v]) => el.setAttribute(k, v));
+  document.body.append(el);
+  return el;
+}
+
+describe('preflight accessibility check-image-alt-text', () => {
+  const created = [];
+  const make = (attrs) => { const el = img(attrs); created.push(el); return el; };
+
+  afterEach(() => { while (created.length) created.pop().remove(); });
+
+  it('returns [] when altText check is not enabled', () => {
+    make({ });
+    expect(checkImageAltText([document.querySelector('img')], { checks: [] })).to.deep.equal([]);
+  });
+
+  it('flags an image with no alt attribute', () => {
+    const el = make({});
+    const res = checkImageAltText([el], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].id).to.equal('image-alt');
+    expect(res[0].description).to.contain('missing an alt attribute');
+  });
+
+  it('flags numeric alt text', () => {
+    const el = make({ alt: '123' });
+    const res = checkImageAltText([el], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].description).to.contain('too short');
+  });
+
+  it('flags too-short alt text', () => {
+    const el = make({ alt: 'ab' });
+    expect(checkImageAltText([el], CONFIG)).to.have.lengthOf(1);
+  });
+
+  it('passes descriptive alt text', () => {
+    const el = make({ alt: 'A cat sitting on a sofa' });
+    expect(checkImageAltText([el], CONFIG)).to.deep.equal([]);
+  });
+
+  it('treats empty alt / role=presentation / aria-hidden as decorative', () => {
+    const decorative = [
+      make({ alt: '' }),
+      make({ alt: 'ab', role: 'presentation' }),
+      make({ alt: 'ab', 'aria-hidden': 'true' }),
+    ];
+    expect(checkImageAltText(decorative, CONFIG)).to.deep.equal([]);
+  });
+
+  it('skips hidden images', () => {
+    const el = make({});
+    el.style.display = 'none';
+    expect(checkImageAltText([el], CONFIG)).to.deep.equal([]);
+  });
+
+  it('ignores non-image elements', () => {
+    const div = document.createElement('div');
+    document.body.append(div);
+    created.push(div);
+    expect(checkImageAltText([div], CONFIG)).to.deep.equal([]);
+  });
+});

--- a/test/blocks/preflight/accessibility/check-keyboard-navigation.test.js
+++ b/test/blocks/preflight/accessibility/check-keyboard-navigation.test.js
@@ -1,0 +1,50 @@
+import { expect } from '@esm-bundle/chai';
+import checkKeyboardNavigation from '../../../../libs/blocks/preflight/accessibility/check-keyboard-navigation.js';
+
+const CONFIG = { checks: ['keyboard'] };
+
+describe('preflight accessibility check-keyboard-navigation', () => {
+  const created = [];
+  const add = (html) => {
+    const tpl = document.createElement('template');
+    tpl.innerHTML = html.trim();
+    const el = tpl.content.firstElementChild;
+    document.body.append(el);
+    created.push(el);
+    return el;
+  };
+
+  afterEach(() => { while (created.length) created.pop().remove(); });
+
+  it('returns [] when keyboard check is not enabled', () => {
+    const el = add('<a href="#x">link</a>');
+    expect(checkKeyboardNavigation([el], { checks: [] })).to.deep.equal([]);
+  });
+
+  it('reports a critical violation when there are no focusable elements', () => {
+    const el = add('<div>not focusable</div>');
+    const res = checkKeyboardNavigation([el], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].impact).to.equal('critical');
+    expect(res[0].nodes).to.deep.equal([]);
+  });
+
+  it('passes visible focusable elements', () => {
+    const el = add('<a href="#x">visible link</a>');
+    expect(checkKeyboardNavigation([el], CONFIG)).to.deep.equal([]);
+  });
+
+  it('flags a focusable element that is hidden by its own style', () => {
+    const el = add('<a href="#x" style="display:none">hidden link</a>');
+    const res = checkKeyboardNavigation([el], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].id).to.equal('focus-visible');
+    expect(res[0].description).to.contain('not visibly rendered');
+  });
+
+  it('ignores focusable elements hidden only via an ancestor', () => {
+    const wrapper = add('<div style="display:none"><a href="#x">child link</a></div>');
+    const link = wrapper.querySelector('a');
+    expect(checkKeyboardNavigation([link], CONFIG)).to.deep.equal([]);
+  });
+});

--- a/test/blocks/preflight/accessibility/check-video-captions.test.js
+++ b/test/blocks/preflight/accessibility/check-video-captions.test.js
@@ -1,0 +1,72 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import checkVideoCaptions from '../../../../libs/blocks/preflight/accessibility/check-video-captions.js';
+
+const CONFIG = { checks: ['video-captions'] };
+
+function mpcIframe(id = '12345') {
+  const el = document.createElement('iframe');
+  el.src = `https://video.tv.adobe.com/v/${id}/?quality=12`;
+  el.title = `Video ${id}`;
+  return el;
+}
+
+describe('preflight accessibility check-video-captions', () => {
+  let responses;
+
+  beforeEach(() => {
+    // captions-map maps captions language -> geos; ',us' includes the empty default geo.
+    responses = {
+      configMap: { data: [{ captions: 'eng', geos: ',us' }] },
+      videoByLang: {}, // e.g. { eng: { captions: [] } }
+    };
+    sinon.stub(window, 'fetch').callsFake((url) => {
+      const u = String(url);
+      if (u.includes('preflight-config.json')) {
+        return Promise.resolve({ json: () => Promise.resolve(responses.configMap) });
+      }
+      const langMatch = u.match(/\/vc\/\d+\/(\w+)\.json/);
+      if (langMatch) {
+        const body = responses.videoByLang[langMatch[1]] ?? { captions: [] };
+        return Promise.resolve({ json: () => Promise.resolve(body) });
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${u}`));
+    });
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('returns [] when video-captions check is not enabled', async () => {
+    expect(await checkVideoCaptions([mpcIframe()], { checks: [] })).to.deep.equal([]);
+  });
+
+  it('ignores non-MPC iframes', async () => {
+    const other = document.createElement('iframe');
+    other.src = 'https://example.com/embed/1';
+    expect(await checkVideoCaptions([other], CONFIG)).to.deep.equal([]);
+  });
+
+  it('returns [] when no captions language maps to the current geo', async () => {
+    responses.configMap = { data: [{ captions: 'eng', geos: 'jp,kr' }] };
+    expect(await checkVideoCaptions([mpcIframe()], CONFIG)).to.deep.equal([]);
+  });
+
+  it('flags an MPC video with no captions', async () => {
+    responses.videoByLang = { eng: { captions: [] } };
+    const res = await checkVideoCaptions([mpcIframe('999')], CONFIG);
+    expect(res).to.have.lengthOf(1);
+    expect(res[0].id).to.equal('video-captions');
+    expect(res[0].description).to.contain('999');
+  });
+
+  it('passes an MPC video that has captions in the geo language', async () => {
+    responses.videoByLang = { eng: { captions: [{ lang: 'eng' }] } };
+    expect(await checkVideoCaptions([mpcIframe()], CONFIG)).to.deep.equal([]);
+  });
+
+  it('falls back to English captions when the geo language has none', async () => {
+    responses.configMap = { data: [{ captions: 'fra', geos: ',us' }] };
+    responses.videoByLang = { fra: { captions: [] }, eng: { captions: [{ lang: 'eng' }] } };
+    expect(await checkVideoCaptions([mpcIframe()], CONFIG)).to.deep.equal([]);
+  });
+});

--- a/test/blocks/preflight/accessibility/helper.test.js
+++ b/test/blocks/preflight/accessibility/helper.test.js
@@ -1,0 +1,66 @@
+import { expect } from '@esm-bundle/chai';
+import { getUniqueSelector, getFilteredElements } from '../../../../libs/blocks/preflight/accessibility/helper.js';
+
+describe('preflight accessibility helper', () => {
+  describe('getUniqueSelector', () => {
+    it('returns empty string for null/undefined', () => {
+      expect(getUniqueSelector(null)).to.equal('');
+      expect(getUniqueSelector(undefined)).to.equal('');
+    });
+
+    it('prefers the element id', () => {
+      const el = document.createElement('div');
+      el.id = 'my-id';
+      el.className = 'ignored';
+      expect(getUniqueSelector(el)).to.equal('#my-id');
+    });
+
+    it('builds a tag.class selector when classes are present', () => {
+      const el = document.createElement('section');
+      el.className = 'foo bar';
+      expect(getUniqueSelector(el)).to.equal('section.foo.bar');
+    });
+
+    it('falls back to the tag name when there is no id or className', () => {
+      const fake = { tagName: 'SPAN', id: '', className: null };
+      expect(getUniqueSelector(fake)).to.equal('span');
+    });
+  });
+
+  describe('getFilteredElements', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      container.id = 'a11y-helper-fixture';
+      container.innerHTML = `
+        <div class="keep"><p class="keep-child">a</p></div>
+        <div class="drop"><span class="drop-child">b</span></div>
+      `;
+      document.body.append(container);
+    });
+
+    afterEach(() => container.remove());
+
+    it('includes matched elements and their descendants', () => {
+      const els = getFilteredElements(['#a11y-helper-fixture .keep']);
+      expect(els).to.include(container.querySelector('.keep'));
+      expect(els).to.include(container.querySelector('.keep-child'));
+    });
+
+    it('returns included elements untouched when no exclude selectors given', () => {
+      const els = getFilteredElements(['#a11y-helper-fixture .drop']);
+      expect(els.length).to.be.greaterThan(0);
+    });
+
+    it('removes excluded elements and their descendants', () => {
+      const els = getFilteredElements(
+        ['#a11y-helper-fixture'],
+        ['#a11y-helper-fixture .drop'],
+      );
+      expect(els).to.include(container.querySelector('.keep'));
+      expect(els).to.not.include(container.querySelector('.drop'));
+      expect(els).to.not.include(container.querySelector('.drop-child'));
+    });
+  });
+});

--- a/test/blocks/preflight/checks/accessibility.test.js
+++ b/test/blocks/preflight/checks/accessibility.test.js
@@ -1,0 +1,73 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import runChecks from '../../../../libs/blocks/preflight/checks/accessibility.js';
+
+describe('preflight checks accessibility', () => {
+  let lanaBackup;
+  let container;
+
+  beforeEach(() => {
+    lanaBackup = window.lana;
+    window.lana = { log: sinon.spy() };
+    sinon.stub(window, 'fetch').callsFake(() => Promise.resolve({ json: () => Promise.resolve({}) }));
+    window.axe = window.axe || {};
+    sinon.stub(window.axe, 'run').resolves({ violations: [{ id: 'axe-marker', impact: 'serious' }] });
+    container = document.createElement('div');
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    window.lana = lanaBackup;
+    container.remove();
+  });
+
+  it('returns a single check via the default runChecks export', () => {
+    const checks = runChecks({ area: container });
+    expect(checks).to.have.lengthOf(1);
+    expect(checks[0]).to.be.a('promise');
+  });
+
+  it('summarizes image alt text and reports FAIL when violations exist', async () => {
+    container.innerHTML = '<img alt="A described image"><img alt=""><img>';
+    const [check] = runChecks({ area: container });
+    const res = await check;
+    expect(res.checkId).to.equal('accessibility');
+    expect(res.severity).to.equal('critical');
+    expect(res.status).to.equal('fail');
+    expect(res.description).to.contain('accessibility violations detected');
+    expect(res.details.panelAltSummary).to.deep.equal({
+      totalImages: 3,
+      withAltText: 1,
+      decorativeImages: 1,
+      missingAlt: 1,
+    });
+    expect(res.details.issuesCount).to.be.greaterThan(0);
+  });
+
+  it('reports a zeroed alt summary when the area has no images', async () => {
+    const [check] = runChecks({ area: container });
+    const res = await check;
+    expect(res.details.panelAltSummary).to.deep.equal({
+      totalImages: 0,
+      withAltText: 0,
+      decorativeImages: 0,
+      missingAlt: 0,
+    });
+  });
+
+  it('returns LIMBO with the error message when the test run errors', async () => {
+    window.axe.run.rejects(new Error('axe exploded'));
+    const [check] = runChecks({ area: container });
+    const res = await check;
+    expect(res.status).to.equal('limbo');
+    expect(res.description).to.contain('axe exploded');
+    expect(res.details.issuesCount).to.be.null;
+  });
+
+  it('scopes to header/main/footer images when run against the document', async () => {
+    const [check] = runChecks({ area: document });
+    const res = await check;
+    expect(res.details.panelAltSummary).to.have.all.keys('totalImages', 'withAltText', 'decorativeImages', 'missingAlt');
+  });
+});

--- a/test/blocks/preflight/checks/asoApi.test.js
+++ b/test/blocks/preflight/checks/asoApi.test.js
@@ -1,0 +1,124 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import getChecks, { asoCache, getASOToken, fetchPreflightChecks } from '../../../../libs/blocks/preflight/checks/asoApi.js';
+
+const COMPLETED_AUDITS = [
+  { name: 'metatags', opportunities: [{ tagName: 'title', issue: 'Missing title', issueDetails: 'add one', aiSuggestion: 'My Title' }] },
+  { name: 'h1-count', opportunities: [{ issue: 'Multiple H1s' }] },
+  { name: 'canonical', opportunities: [] },
+  { name: 'body-size', opportunities: [] },
+  { name: 'lorem-ipsum', opportunities: [] },
+  { name: 'links', opportunities: [{ check: 'bad-links', issue: [{ url: '/broken', issue: '404' }] }] },
+];
+
+const resetCache = () => Object.assign(asoCache, {
+  identify: null,
+  identifyFinished: false,
+  suggest: null,
+  suggestFinished: false,
+  sessionToken: null,
+  identifyJobId: undefined,
+});
+
+describe('preflight checks asoApi', () => {
+  let lanaBackup;
+  let imsBackup;
+  let responses;
+
+  const router = (url, opts = {}) => {
+    const u = String(url);
+    if (u.endsWith('/auth/login')) return responses.login();
+    if (/\/preflight\/jobs\/[^/]+$/.test(u)) return responses.jobStatus();
+    if (u.endsWith('/preflight/jobs') && opts.method === 'POST') return responses.jobCreate();
+    return Promise.reject(new Error(`unexpected fetch ${u}`));
+  };
+
+  beforeEach(() => {
+    lanaBackup = window.lana;
+    imsBackup = window.asoIMS;
+    window.lana = { log: sinon.spy() };
+    resetCache();
+    responses = {
+      login: () => Promise.resolve({ ok: true, json: () => Promise.resolve({ sessionToken: 'sess-1' }) }),
+      jobCreate: () => Promise.resolve({ ok: true, json: () => Promise.resolve({ jobId: 'job-1' }) }),
+      jobStatus: () => Promise.resolve({ ok: true, json: () => Promise.resolve({ status: 'COMPLETED', result: [{ audits: COMPLETED_AUDITS }] }) }),
+    };
+    sinon.stub(window, 'fetch').callsFake(router);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    window.lana = lanaBackup;
+    window.asoIMS = imsBackup;
+    resetCache();
+  });
+
+  describe('getASOToken', () => {
+    it('returns null when there is no IMS access token', async () => {
+      window.asoIMS = { getAccessToken: () => null };
+      expect(await getASOToken()).to.be.null;
+    });
+
+    it('exchanges the IMS token for a session token', async () => {
+      window.asoIMS = { getAccessToken: () => ({ token: 'ims-tok' }) };
+      const token = await getASOToken();
+      expect(token).to.equal('sess-1');
+      expect(asoCache.sessionToken).to.equal('sess-1');
+    });
+
+    it('returns null and logs when the auth call fails', async () => {
+      window.asoIMS = { getAccessToken: () => ({ token: 'ims-tok' }) };
+      responses.login = () => Promise.resolve({ ok: false, status: 401 });
+      expect(await getASOToken()).to.be.null;
+      expect(window.lana.log.called).to.be.true;
+    });
+
+    it('returns null and logs when the auth call throws', async () => {
+      window.asoIMS = { getAccessToken: () => ({ token: 'ims-tok' }) };
+      responses.login = () => Promise.reject(new Error('network'));
+      expect(await getASOToken()).to.be.null;
+      expect(window.lana.log.called).to.be.true;
+    });
+  });
+
+  describe('getChecks', () => {
+    it('returns null when the job cannot be created', async () => {
+      asoCache.sessionToken = 'sess-1';
+      responses.jobCreate = () => Promise.resolve({ ok: false, status: 500 });
+      expect(await getChecks('IDENTIFY')).to.be.null;
+    });
+
+    it('formats a completed job into SEO check results', async () => {
+      asoCache.sessionToken = 'sess-1';
+      const checks = await getChecks('IDENTIFY');
+      const byId = Object.fromEntries(checks.map((c) => [c.id, c]));
+      expect(byId.title.status).to.equal('fail');
+      expect(byId.title.description).to.contain('Missing title');
+      expect(byId.title.aiSuggestion).to.equal('My Title');
+      expect(byId.description.status).to.equal('pass');
+      expect(byId['h1-count'].status).to.equal('fail');
+      expect(byId.canonical.status).to.equal('pass');
+      expect(byId.links.status).to.equal('fail');
+      expect(byId.links.details.badLinks).to.have.lengthOf(1);
+      expect(asoCache.identifyFinished).to.be.true;
+      expect(asoCache.identifyJobId).to.equal('job-1');
+    });
+  });
+
+  describe('fetchPreflightChecks', () => {
+    it('returns null when no session token can be obtained', async () => {
+      window.asoIMS = { getAccessToken: () => null };
+      expect(await fetchPreflightChecks()).to.be.null;
+    });
+
+    it('resolves identify results when signed in', async () => {
+      const clock = sinon.useFakeTimers();
+      window.asoIMS = { getAccessToken: () => ({ token: 'ims-tok' }) };
+      const promise = fetchPreflightChecks();
+      await clock.tickAsync(0);
+      const results = await promise;
+      expect(results.some((c) => c.id === 'title')).to.be.true;
+      clock.restore();
+    });
+  });
+});

--- a/test/blocks/preflight/checks/assets.test.js
+++ b/test/blocks/preflight/checks/assets.test.js
@@ -197,4 +197,37 @@ describe('Preflight Asset Checks', () => {
       expect(window.mockImport).to.be.true;
     });
   });
+
+  describe('Mismatch status branches', () => {
+    beforeEach(() => {
+      // No width/height attrs -> natural 1000 / offset 800 -> factor 1.25 < ideal 2 -> mismatch.
+      mockImage.getAttribute.withArgs('width').returns(null);
+      mockImage.getAttribute.withArgs('height').returns(null);
+      mockImage.getAttribute.withArgs('src').returns('test.jpg');
+    });
+
+    it('reports a critical failure for an above-the-fold mismatch', async () => {
+      const result = await checkImageDimensions('test-critical', mockDocument);
+      expect(result.status).to.equal(STATUS.FAIL);
+      expect(result.severity).to.equal('critical');
+      expect(result.details.criticalAssetFailures).to.have.lengthOf(1);
+    });
+
+    it('reports a warning (pass) for a below-the-fold mismatch', async () => {
+      mockMain.querySelectorAll.withArgs(':scope > div.section')
+        .returns([{ contains: () => false }, { contains: () => false }]);
+      const result = await checkImageDimensions('test-warning', mockDocument);
+      expect(result.status).to.equal(STATUS.PASS);
+      expect(result.severity).to.equal('warning');
+      expect(result.details.warningAssetFailures).to.have.lengthOf(1);
+    });
+
+    it('clears the mismatch when the image is not constrained by its container', async () => {
+      mockPicture.offsetWidth = 800;
+      mockPicture.parentElement = { offsetWidth: 1000, parentElement: null };
+      const result = await checkImageDimensions('test-unconstrained', mockDocument);
+      expect(result.status).to.equal(STATUS.PASS);
+      expect(result.details.assetsWithMismatch).to.have.lengthOf(0);
+    });
+  });
 });

--- a/test/blocks/preflight/checks/captureMetrics.test.js
+++ b/test/blocks/preflight/checks/captureMetrics.test.js
@@ -1,0 +1,81 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { setConfig } from '../../../../libs/utils/utils.js';
+import captureMetrics from '../../../../libs/blocks/preflight/checks/captureMetrics.js';
+
+const baseResults = () => ({
+  performance: [Promise.resolve({ id: 'lcp-element', status: 'pass' })],
+  seo: [Promise.resolve({ checkId: 'title-size', status: 'pass' })],
+  accessibility: [Promise.resolve({ details: { issuesCount: 3, violations: [{ id: 'x' }] } })],
+});
+
+const lastBody = (fetchStub) => JSON.parse(fetchStub.firstCall.args[1].body);
+
+describe('preflight checks captureMetrics', () => {
+  let fetchStub;
+  let imsBackup;
+
+  beforeEach(() => {
+    window.hasCapturedPreflightMetrics = false;
+    imsBackup = window.adobeIMS;
+    fetchStub = sinon.stub(window, 'fetch').resolves({ ok: true, status: 200, statusText: 'OK' });
+    setConfig({ imsClientId: 'test-client' });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    window.adobeIMS = imsBackup;
+    delete window.hasCapturedPreflightMetrics;
+  });
+
+  it('does nothing when imsClientId is not configured', async () => {
+    setConfig({});
+    await captureMetrics(baseResults());
+    expect(fetchStub.called).to.be.false;
+  });
+
+  it('posts transformed metrics with column keys and context data', async () => {
+    await captureMetrics(baseResults());
+    expect(fetchStub.calledOnce).to.be.true;
+    const [url, opts] = fetchStub.firstCall.args;
+    expect(url).to.contain('clientId=test-client');
+    expect(opts.method).to.equal('POST');
+    const body = lastBody(fetchStub);
+    expect(body.performance[0].key).to.equal('performance_valid_lcp');
+    expect(body.seo[0].key).to.equal('seo_title_size_status');
+    expect(body.accessibility_issues_count).to.equal(3);
+    expect(body.project_key).to.equal('test-client');
+    expect(opts.headers).to.not.have.property('authorization');
+  });
+
+  it('includes a bearer token and profile email when IMS is signed in', async () => {
+    window.adobeIMS = {
+      getAccessToken: () => ({ token: 'tok-123' }),
+      getProfile: async () => ({ email: 'author@adobe.com' }),
+    };
+    await captureMetrics(baseResults());
+    const [, opts] = fetchStub.firstCall.args;
+    expect(opts.headers.authorization).to.equal('Bearer tok-123');
+    expect(lastBody(fetchStub).email).to.equal('author@adobe.com');
+  });
+
+  it('continues without profile data when getProfile fails', async () => {
+    const lanaBackup = window.lana;
+    window.lana = { log: sinon.spy() };
+    window.adobeIMS = {
+      getAccessToken: () => ({ token: 'tok-123' }),
+      getProfile: async () => { throw new Error('ims down'); },
+    };
+    await captureMetrics(baseResults());
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(lastBody(fetchStub).email).to.equal('');
+    expect(window.lana.log.called).to.be.true;
+    window.lana = lanaBackup;
+  });
+
+  it('captures only once (guard flag)', async () => {
+    await captureMetrics(baseResults());
+    await captureMetrics(baseResults());
+    expect(fetchStub.calledOnce).to.be.true;
+  });
+});

--- a/test/blocks/preflight/checks/constants.test.js
+++ b/test/blocks/preflight/checks/constants.test.js
@@ -1,0 +1,33 @@
+import { expect } from '@esm-bundle/chai';
+import {
+  STATUS,
+  STATUS_TO_ICON_MAP,
+  SEVERITY,
+  SEO_CHECK_IDS,
+  ASO_TIMEOUT_MS,
+  ASO_POLL_INTERVAL_MS,
+  ASO_MAX_RETRIES,
+} from '../../../../libs/blocks/preflight/checks/constants.js';
+
+describe('preflight checks constants', () => {
+  it('maps every status to an icon color', () => {
+    expect(Object.keys(STATUS_TO_ICON_MAP).sort()).to.deep.equal(Object.values(STATUS).sort());
+    expect(STATUS_TO_ICON_MAP[STATUS.PASS]).to.equal('green');
+    expect(STATUS_TO_ICON_MAP[STATUS.FAIL]).to.equal('red');
+    expect(STATUS_TO_ICON_MAP[STATUS.LIMBO]).to.equal('orange');
+  });
+
+  it('exposes the severity levels', () => {
+    expect(SEVERITY).to.deep.equal({ CRITICAL: 'critical', WARNING: 'warning' });
+  });
+
+  it('maps native ASO checkIds for links to broken-links', () => {
+    expect(SEO_CHECK_IDS.links).to.equal('broken-links');
+    expect(SEO_CHECK_IDS.title).to.equal('title-size');
+  });
+
+  it('derives ASO_MAX_RETRIES from the timeout and poll interval', () => {
+    expect(ASO_MAX_RETRIES).to.equal(Math.ceil(ASO_TIMEOUT_MS / ASO_POLL_INTERVAL_MS));
+    expect(ASO_MAX_RETRIES).to.equal(30);
+  });
+});

--- a/test/blocks/preflight/checks/contentInsights.test.js
+++ b/test/blocks/preflight/checks/contentInsights.test.js
@@ -1,0 +1,57 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { openAllModals } from '../../../../libs/blocks/preflight/checks/contentInsights.js';
+
+describe('preflight checks contentInsights', () => {
+  it('registers preflight executors on the window on import', () => {
+    expect(window.preflightExecutors).to.be.an('object');
+    expect(window.preflightExecutors).to.have.all.keys('general', 'assets', 'accessibility', 'performance', 'seo');
+    expect(window.preflightExecutors.seo.checkH1s).to.be.a('function');
+    expect(window.preflightExecutors.performance.checkLcpEl).to.be.a('function');
+  });
+
+  describe('openAllModals', () => {
+    let clock;
+    let area;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers();
+      area = document.createElement('div');
+      area.innerHTML = `
+        <main>
+          <a data-modal-hash="#m1">one</a>
+          <a data-modal-hash="#m2">two</a>
+          <a href="/not-a-modal">ignore</a>
+        </main>`;
+      document.body.append(area);
+    });
+
+    afterEach(() => { clock.restore(); area.remove(); });
+
+    it('clicks every modal link, ignores non-modal links, then waits', async () => {
+      const clicked = [];
+      area.querySelectorAll('a').forEach((a) => a.addEventListener('click', (e) => clicked.push(e.target)));
+
+      const promise = openAllModals(area);
+      // Clicks are dispatched synchronously before the trailing wait.
+      expect(clicked).to.have.lengthOf(2);
+
+      let resolved = false;
+      promise.then(() => { resolved = true; });
+      await clock.tickAsync(4999);
+      expect(resolved).to.be.false;
+      await clock.tickAsync(1);
+      await promise;
+      expect(resolved).to.be.true;
+    });
+
+    it('swallows errors from individual links', async () => {
+      const link = area.querySelector('a[data-modal-hash]');
+      sinon.stub(link, 'scrollIntoView').throws(new Error('boom'));
+      const promise = openAllModals(area);
+      await clock.tickAsync(5000);
+      // Should resolve despite the thrown error.
+      await promise;
+    });
+  });
+});

--- a/test/blocks/preflight/checks/localization.test.js
+++ b/test/blocks/preflight/checks/localization.test.js
@@ -1,0 +1,72 @@
+/* eslint-disable import/no-named-as-default-member */
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import localization from '../../../../libs/blocks/preflight/checks/localization.js';
+
+// runChecks memoizes for the modal session, so the whole suite shares one run.
+describe('preflight checks localization', () => {
+  let container;
+  let result;
+  let runA;
+
+  before(async () => {
+    container = document.createElement('div');
+    container.innerHTML = `
+      <a href="/preflight-loc-ok">ok 200</a>
+      <a href="/preflight-loc-404">broken</a>
+      <a href="/preflight-loc-404">broken duplicate</a>
+      <a href="/preflight-loc-404b">broken 2</a>
+      <a href="#section">in-page anchor</a>
+      <a href="/#top">home hash</a>
+      <a href="/preflight-loc-headfail">head fails, get ok</a>
+    `;
+    document.body.append(container);
+
+    sinon.stub(window, 'fetch').callsFake((url, opts = {}) => {
+      const u = String(url);
+      const method = opts.method || 'GET';
+      if (u.includes('preflight-loc-headfail')) {
+        return method === 'HEAD'
+          ? Promise.reject(new Error('no head'))
+          : Promise.resolve({ ok: true, status: 200 });
+      }
+      if (u.includes('preflight-loc-404')) return Promise.resolve({ ok: false, status: 404 });
+      return Promise.resolve({ ok: true, status: 200 });
+    });
+
+    runA = localization.runChecks({ area: container });
+    [result] = await runA;
+  });
+
+  after(() => {
+    sinon.restore();
+    container.remove();
+  });
+
+  it('returns a single link-localization check result', () => {
+    expect(result.id).to.equal('link-localization');
+    expect(result.title).to.equal('Links');
+  });
+
+  it('flags broken links and de-duplicates repeated hrefs', () => {
+    const urls = result.details.violations.map((v) => v.url);
+    expect(urls.filter((u) => u.endsWith('/preflight-loc-404')).length).to.equal(1);
+    expect(urls.some((u) => u.endsWith('/preflight-loc-404b'))).to.be.true;
+  });
+
+  it('does not flag valid links or in-page anchors', () => {
+    const urls = result.details.violations.map((v) => v.url);
+    expect(urls.some((u) => u.includes('/preflight-loc-ok'))).to.be.false;
+    expect(urls.some((u) => u.includes('/preflight-loc-headfail'))).to.be.false;
+    expect(urls.some((u) => u.includes('#section'))).to.be.false;
+  });
+
+  it('reports FAIL status with a pluralized description', () => {
+    expect(result.status).to.equal('fail');
+    expect(result.description).to.match(/\d+ links/);
+  });
+
+  it('memoizes the run for the modal session', () => {
+    expect(localization.runChecks({ area: container })).to.equal(runA);
+  });
+});

--- a/test/blocks/preflight/checks/preflightApi.test.js
+++ b/test/blocks/preflight/checks/preflightApi.test.js
@@ -1,0 +1,34 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { setConfig } from '../../../../libs/utils/utils.js';
+import preflightApi, { getChecksSuite, getPreflightResults } from '../../../../libs/blocks/preflight/checks/preflightApi.js';
+
+describe('preflight checks preflightApi', () => {
+  afterEach(() => sinon.restore());
+
+  it('exposes a check suite namespace for each preflight tab', () => {
+    expect(preflightApi).to.have.all.keys('accessibility', 'assets', 'performance', 'seo', 'structure', 'merch');
+    expect(preflightApi.seo.checkH1s).to.be.a('function');
+    expect(preflightApi.performance.runChecks).to.be.a('function');
+    expect(preflightApi.assets.isViewportTooSmall).to.be.a('function');
+  });
+
+  it('resolves the ASO suite when the client is enabled (memoized)', async () => {
+    setConfig({ imsClientId: 'enabled-client' });
+    sinon.stub(window, 'fetch').resolves({ json: () => Promise.resolve({ data: [{ value: 'enabled-client' }] }) });
+    expect(await getChecksSuite()).to.equal('ASO');
+    // second call is served from the module cache without another fetch
+    expect(await getChecksSuite()).to.equal('ASO');
+  });
+
+  it('returns null for URLs matched by the exclusion list', async () => {
+    sinon.stub(window, 'fetch').callsFake((url) => {
+      if (String(url).includes('preflight-exclusions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [{ path: '/drafts/**' }] }) });
+      }
+      return Promise.reject(new Error(`unexpected fetch ${url}`));
+    });
+    const res = await getPreflightResults({ url: '/drafts/wip-page', useCache: false });
+    expect(res).to.be.null;
+  });
+});

--- a/test/blocks/preflight/checks/seo-checks.test.js
+++ b/test/blocks/preflight/checks/seo-checks.test.js
@@ -1,0 +1,196 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { setConfig } from '../../../../libs/utils/utils.js';
+import {
+  checkH1s,
+  checkTitle,
+  checkCanon,
+  checkDescription,
+  checkBody,
+  checkLorem,
+  connectionError,
+  validLinkFilter,
+  checkLinks,
+} from '../../../../libs/blocks/preflight/checks/seo.js';
+
+const areaWith = (innerHTML) => {
+  const div = document.createElement('div');
+  div.innerHTML = innerHTML;
+  return div;
+};
+
+describe('preflight checks seo', () => {
+  describe('checkH1s', () => {
+    it('fails with no H1', () => {
+      expect(checkH1s(areaWith('')).status).to.equal('fail');
+    });
+    it('passes with exactly one H1', () => {
+      expect(checkH1s(areaWith('<h1>Title</h1>')).status).to.equal('pass');
+    });
+    it('fails with multiple H1s', () => {
+      const res = checkH1s(areaWith('<h1>a</h1><h1>b</h1>'));
+      expect(res.status).to.equal('fail');
+      expect(res.description).to.contain('2 H1');
+    });
+  });
+
+  describe('checkTitle', () => {
+    it('fails a too-short title', () => {
+      expect(checkTitle({ title: 'short' }).status).to.equal('fail');
+    });
+    it('passes a reasonable title', () => {
+      expect(checkTitle({ title: 'A perfectly reasonable page title' }).status).to.equal('pass');
+    });
+    it('fails a too-long title', () => {
+      expect(checkTitle({ title: 'x'.repeat(80) }).status).to.equal('fail');
+    });
+  });
+
+  describe('checkCanon', () => {
+    afterEach(() => sinon.restore());
+
+    it('passes (self-referencing) when there is no canonical', async () => {
+      const res = await checkCanon(areaWith(''));
+      expect(res.status).to.equal('pass');
+      expect(res.description).to.contain('self-referencing');
+    });
+    it('passes when the canonical resolves ok', async () => {
+      sinon.stub(window, 'fetch').resolves({ ok: true, status: 200 });
+      const res = await checkCanon(areaWith('<link rel="canonical" href="https://example.com/x">'));
+      expect(res.status).to.equal('pass');
+    });
+    it('fails when the canonical errors', async () => {
+      sinon.stub(window, 'fetch').resolves({ ok: false, status: 404 });
+      expect((await checkCanon(areaWith('<link rel="canonical" href="https://example.com/x">'))).status).to.equal('fail');
+    });
+    it('fails when the canonical redirects', async () => {
+      sinon.stub(window, 'fetch').resolves({ ok: true, status: 301 });
+      const res = await checkCanon(areaWith('<link rel="canonical" href="https://example.com/x">'));
+      expect(res.status).to.equal('fail');
+      expect(res.description).to.contain('redirects');
+    });
+    it('is limbo when the canonical cannot be crawled', async () => {
+      sinon.stub(window, 'fetch').rejects(new Error('blocked'));
+      expect((await checkCanon(areaWith('<link rel="canonical" href="https://example.com/x">'))).status).to.equal('limbo');
+    });
+  });
+
+  describe('checkDescription', () => {
+    it('fails when there is no meta description', async () => {
+      expect((await checkDescription(areaWith(''))).status).to.equal('fail');
+    });
+    it('fails a too-short description', async () => {
+      expect((await checkDescription(areaWith('<meta name="description" content="short">'))).status).to.equal('fail');
+    });
+    it('passes a well-sized description', async () => {
+      const content = 'A meta description that is comfortably within the recommended length range.';
+      expect((await checkDescription(areaWith(`<meta name="description" content="${content}">`))).status).to.equal('pass');
+    });
+    it('fails a too-long description', async () => {
+      const content = 'x'.repeat(200);
+      expect((await checkDescription(areaWith(`<meta name="description" content="${content}">`))).status).to.equal('fail');
+    });
+  });
+
+  describe('checkBody', () => {
+    it('passes with enough content', async () => {
+      const area = { documentElement: { innerText: 'x'.repeat(150) } };
+      expect((await checkBody(area)).status).to.equal('pass');
+    });
+    it('fails with too little content', async () => {
+      const area = { documentElement: { innerText: 'short' } };
+      expect((await checkBody(area)).status).to.equal('fail');
+    });
+  });
+
+  describe('checkLorem', () => {
+    const area = (innerHTML) => ({
+      documentElement: { innerHTML },
+      getElementById: () => null,
+    });
+    it('fails when lorem ipsum is present', async () => {
+      expect((await checkLorem(area('<p>Lorem Ipsum dolor</p>'))).status).to.equal('fail');
+    });
+    it('passes when lorem ipsum is absent', async () => {
+      expect((await checkLorem(area('<p>Real content</p>'))).status).to.equal('pass');
+    });
+  });
+
+  describe('connectionError', () => {
+    it('returns a VPN-specific limbo message', () => {
+      const res = connectionError({ isVpnError: true });
+      expect(res.status).to.equal('limbo');
+      expect(res.description).to.contain('VPN');
+    });
+    it('returns a generic limbo message', () => {
+      expect(connectionError({ isVpnError: false }).description).to.contain('Unable to connect');
+    });
+  });
+
+  describe('validLinkFilter and checkLinks', () => {
+    let lanaBackup;
+
+    beforeEach(() => {
+      lanaBackup = window.lana;
+      window.lana = { log: sinon.spy() };
+      setConfig({ env: { name: 'prod' } });
+      sinon.stub(window, 'fetch').callsFake((url, opts = {}) => {
+        const u = String(url);
+        if (u.includes('/.milo/config.json')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({
+              configs: {
+                data: [
+                  { key: 'prod.preflight.ignoreDomains', value: 'news.adobe.com' },
+                  { key: 'prod.spidy.url', value: 'https://spidy.test' },
+                ],
+              },
+            }),
+          });
+        }
+        if (u.includes('/api/url-http-status')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ data: [{ url: 'https://example.com/broken', status: 404 }] }),
+          });
+        }
+        if (opts.method === 'HEAD' || u === 'https://spidy.test') {
+          return Promise.resolve({ ok: true, status: 200 });
+        }
+        return Promise.reject(new Error(`unexpected fetch ${u}`));
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+      window.lana = lanaBackup;
+    });
+
+    it('filters out tel/mailto/anchor/ignored-domain links and rewrites page->live', async () => {
+      const area = areaWith(`
+        <a href="https://example.com/ok">ok</a>
+        <a href="tel:123">tel</a>
+        <a href="mailto:x@y.z">mail</a>
+        <a href="https://news.adobe.com/x">ignored</a>
+        <a href="https://main--milo--adobecom.hlx.page/p">hlx</a>
+      `);
+      const links = await validLinkFilter(area);
+      const hrefs = links.map((l) => l.href);
+      expect(hrefs).to.include('https://example.com/ok');
+      expect(hrefs.some((h) => h.startsWith('tel:'))).to.be.false;
+      expect(hrefs.some((h) => h.includes('mailto:'))).to.be.false;
+      expect(hrefs.some((h) => h.includes('news.adobe.com'))).to.be.false;
+      const hlx = links.find((l) => l.href.includes('hlx.page'));
+      expect(hlx.liveHref).to.contain('hlx.live');
+    });
+
+    it('reports broken links from the spidy service', async () => {
+      const area = areaWith('<a href="https://example.com/broken">broken</a>');
+      const res = await checkLinks({ area });
+      expect(res.status).to.equal('fail');
+      expect(res.details.badLinks).to.have.lengthOf(1);
+      expect(area.querySelector('a').classList.contains('problem-link')).to.be.true;
+    });
+  });
+});

--- a/test/blocks/preflight/checks/seo-checks.test.js
+++ b/test/blocks/preflight/checks/seo-checks.test.js
@@ -179,9 +179,11 @@ describe('preflight checks seo', () => {
       const hrefs = links.map((l) => l.href);
       expect(hrefs).to.include('https://example.com/ok');
       expect(hrefs.some((h) => h.startsWith('tel:'))).to.be.false;
-      expect(hrefs.some((h) => h.includes('mailto:'))).to.be.false;
-      expect(hrefs.some((h) => h.includes('news.adobe.com'))).to.be.false;
-      const hlx = links.find((l) => l.href.includes('hlx.page'));
+      expect(hrefs.some((h) => h.startsWith('mailto:'))).to.be.false;
+      // Compare the parsed hostname, not a URL substring (CodeQL: incomplete URL
+      // substring sanitization — a substring can match arbitrary hosts).
+      expect(links.some((l) => l.hostname === 'news.adobe.com')).to.be.false;
+      const hlx = links.find((l) => l.hostname.endsWith('hlx.page'));
       expect(hlx.liveHref).to.contain('hlx.live');
     });
 

--- a/test/blocks/preflight/checks/structure.test.js
+++ b/test/blocks/preflight/checks/structure.test.js
@@ -1,0 +1,165 @@
+/* eslint-disable import/no-named-as-default-member */
+import { expect } from '@esm-bundle/chai';
+import { setConfig } from '../../../../libs/utils/utils.js';
+import structure from '../../../../libs/blocks/preflight/checks/structure.js';
+
+const {
+  checkNav, checkFooter, checkRegionSelector, checkGeorouting, checkBreadcrumbs, runChecks,
+} = structure;
+
+describe('preflight checks structure', () => {
+  let container;
+  const metas = [];
+
+  const setMeta = (name, content) => {
+    const m = document.createElement('meta');
+    m.setAttribute('name', name);
+    m.setAttribute('content', content);
+    document.head.append(m);
+    metas.push(m);
+  };
+  const body = (html) => { container.innerHTML = html; };
+
+  beforeEach(() => {
+    setConfig({ georouting: { enabled: 'off' } });
+    container = document.createElement('div');
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+    while (metas.length) metas.pop().remove();
+  });
+
+  describe('checkNav', () => {
+    it('is EMPTY when navigation is off via metadata', () => {
+      setMeta('header', 'off');
+      expect(checkNav(document).status).to.equal('empty');
+    });
+
+    it('FAILs when the header element is missing', () => {
+      const res = checkNav(document);
+      expect(res.status).to.equal('fail');
+      expect(res.description).to.contain('Header element not found');
+    });
+
+    it('is LIMBO when enabled but not yet loaded', () => {
+      body('<header><span>x</span></header>');
+      expect(checkNav(document).status).to.equal('limbo');
+    });
+
+    it('FAILs when loaded but empty', () => {
+      body('<header class="ready"></header>');
+      expect(checkNav(document).status).to.equal('fail');
+    });
+
+    it('FAILs when loaded but has unresolved fragment links', () => {
+      body('<header class="ready"><a href="/fragments/nav">nav</a></header>');
+      const res = checkNav(document);
+      expect(res.status).to.equal('fail');
+      expect(res.details.unresolvedFragments).to.equal(1);
+    });
+
+    it('PASSes when loaded with content', () => {
+      body('<header class="ready"><nav><a href="/home">Home</a></nav></header>');
+      const res = checkNav(document);
+      expect(res.status).to.equal('pass');
+      expect(res.details.type).to.equal('globalnav');
+    });
+
+    it('reports loaded via data-block-status', () => {
+      body('<header data-block-status="loaded"><nav><a>Home</a></nav></header>');
+      expect(checkNav(document).status).to.equal('pass');
+    });
+  });
+
+  describe('checkFooter', () => {
+    it('is EMPTY when footer is off', () => {
+      setMeta('footer', 'off');
+      expect(checkFooter(document).status).to.equal('empty');
+    });
+
+    it('FAILs when the footer element is missing', () => {
+      expect(checkFooter(document).description).to.contain('Footer element not found');
+    });
+
+    it('is LIMBO when enabled but not loaded', () => {
+      body('<footer><span>x</span></footer>');
+      expect(checkFooter(document).status).to.equal('limbo');
+    });
+
+    it('PASSes when loaded with content', () => {
+      body('<footer class="ready"><div>Adobe</div></footer>');
+      expect(checkFooter(document).status).to.equal('pass');
+    });
+  });
+
+  describe('checkRegionSelector', () => {
+    it('is EMPTY when the footer is off', () => {
+      setMeta('footer', 'off');
+      expect(checkRegionSelector(document).status).to.equal('empty');
+    });
+
+    it('FAILs when footer is enabled but missing', () => {
+      expect(checkRegionSelector(document).status).to.equal('fail');
+    });
+
+    it('PASSes when a modal-configured region anchor exists', () => {
+      body('<footer class="ready"><div class="region-selector"><a data-modal-path="/regions">Change region</a></div></footer>');
+      expect(checkRegionSelector(document).status).to.equal('pass');
+    });
+
+    it('FAILs when the region selector is not loaded', () => {
+      body('<footer class="ready"><div class="region-selector"></div></footer>');
+      expect(checkRegionSelector(document).status).to.equal('fail');
+    });
+  });
+
+  describe('checkGeorouting', () => {
+    it('is EMPTY when georouting is off in config', () => {
+      setConfig({ georouting: { enabled: 'off' } });
+      expect(checkGeorouting(document).status).to.equal('empty');
+    });
+
+    it('PASSes when georouting is on', () => {
+      setConfig({ georouting: { enabled: 'on' } });
+      const res = checkGeorouting(document);
+      expect(res.status).to.equal('pass');
+      expect(res.description).to.contain('on');
+    });
+
+    it('is EMPTY when metadata turns georouting off', () => {
+      setConfig({ georouting: { enabled: 'on' } });
+      setMeta('georouting', 'off');
+      expect(checkGeorouting(document).status).to.equal('empty');
+    });
+  });
+
+  describe('checkBreadcrumbs', () => {
+    it('is EMPTY when breadcrumbs are not enabled', () => {
+      expect(checkBreadcrumbs(document).status).to.equal('empty');
+    });
+
+    it('FAILs when enabled but not rendered', () => {
+      body('<header class="has-breadcrumbs"></header>');
+      expect(checkBreadcrumbs(document).status).to.equal('fail');
+    });
+
+    it('PASSes when breadcrumbs are rendered with items', () => {
+      body('<header class="has-breadcrumbs"></header><nav class="feds-breadcrumbs"><ul><li>Home</li></ul></nav>');
+      expect(checkBreadcrumbs(document).status).to.equal('pass');
+    });
+
+    it('FAILs when rendered but empty', () => {
+      body('<header class="has-breadcrumbs"></header><nav class="feds-breadcrumbs"></nav>');
+      expect(checkBreadcrumbs(document).status).to.equal('fail');
+    });
+  });
+
+  describe('runChecks', () => {
+    it('returns all five structure checks', () => {
+      const ids = runChecks({ area: document }).map((r) => r.id);
+      expect(ids).to.deep.equal(['navigation', 'footer', 'region-selector', 'georouting', 'breadcrumbs']);
+    });
+  });
+});

--- a/test/blocks/preflight/panels/accessibility.test.js
+++ b/test/blocks/preflight/panels/accessibility.test.js
@@ -1,0 +1,73 @@
+/* eslint-disable import/no-named-as-default-member */
+import { expect } from '@esm-bundle/chai';
+import { html, render } from '../../../../libs/deps/htm-preact.js';
+import Accessibility, { checkAlt } from '../../../../libs/blocks/preflight/panels/accessibility.js';
+
+const PNG = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
+
+const waitFor = async (fn, tries = 60) => {
+  for (let i = 0; i < tries; i += 1) {
+    if (fn()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => { setTimeout(r, 15); });
+  }
+  throw new Error('waitFor timed out');
+};
+
+describe('preflight panels accessibility', () => {
+  let main;
+
+  before(() => {
+    main = document.createElement('main');
+    main.innerHTML = `
+      <img class="p-valid" src="${PNG}?valid" alt="A described image">
+      <img class="p-deco" src="${PNG}?deco" alt="">
+    `;
+    document.body.append(main);
+  });
+
+  after(() => main.remove());
+
+  it('classifies images by alt text', async () => {
+    const result = await checkAlt();
+    expect(result.altTextImages.find((i) => i.src.includes('?valid')).alt).to.equal('A described image');
+    expect(result.decorativeImages.find((i) => i.src.includes('?deco')).altCheck).to.equal('Decorative');
+  });
+
+  it('decorates the images with metadata nodes', () => {
+    expect(main.querySelector('.p-valid').dataset.pageLocation).to.equal('main-content');
+    expect(main.querySelector('.p-deco').dataset.altCheck).to.equal('Decorative');
+    expect(main.querySelector('.asset-meta')).to.exist;
+  });
+
+  it('short-circuits on a second run', async () => {
+    expect(await checkAlt()).to.be.undefined;
+  });
+
+  describe('Accessibility component', () => {
+    let container;
+    beforeEach(() => { container = document.createElement('div'); document.body.append(container); });
+    afterEach(() => { render(null, container); container.remove(); });
+
+    it('renders the image groups and a working filter dropdown', async () => {
+      render(html`<${Accessibility} />`, container);
+      await waitFor(() => container.querySelector('.image-filter'));
+      expect(container.querySelector('.image-filter').querySelectorAll('option').length).to.equal(4);
+      const grid = container.querySelector('.image-filter').closest('.access-image-grid');
+      const select = container.querySelector('.image-filter');
+      select.value = 'show-gnav';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      expect(grid.classList.contains('show-gnav')).to.be.true;
+    });
+
+    it('toggles a group open and closed', async () => {
+      render(html`<${Accessibility} />`, container);
+      await waitFor(() => container.querySelector('.grid-toggle'));
+      const toggle = container.querySelector('.grid-toggle');
+      const heading = toggle.closest('.grid-heading');
+      const start = heading.classList.contains('is-closed');
+      toggle.querySelector('.preflight-group-expand').click();
+      expect(heading.classList.contains('is-closed')).to.equal(!start);
+    });
+  });
+});

--- a/test/blocks/preflight/panels/assets.test.js
+++ b/test/blocks/preflight/panels/assets.test.js
@@ -3,6 +3,15 @@ import sinon from 'sinon';
 import { html, render } from '../../../../libs/deps/htm-preact.js';
 import Assets from '../../../../libs/blocks/preflight/panels/assets.js';
 
+const waitFor = async (fn, tries = 100) => {
+  for (let i = 0; i < tries; i += 1) {
+    if (fn()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => { setTimeout(r, 15); });
+  }
+  throw new Error('waitFor timed out');
+};
+
 describe('Preflight Assets Panel', () => {
   let container;
   let originalWindowProps = {};
@@ -56,5 +65,47 @@ describe('Preflight Assets Panel', () => {
     expect(container.querySelector('.assets-item')).to.exist;
     expect(container.querySelector('.assets-item-title')).to.exist;
     expect(container.querySelector('.assets-item-description')).to.exist;
+  });
+});
+
+describe('Preflight Assets Panel (render paths)', () => {
+  let container;
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+    document.querySelectorAll('main, .preflight-return-popover').forEach((n) => n.remove());
+    sinon.restore();
+  });
+
+  const mount = () => {
+    container = document.createElement('div');
+    document.body.append(container);
+  };
+
+  it('shows the resize prompt when the viewport becomes too small', async () => {
+    sinon.stub(window, 'matchMedia').returns({ matches: false }); // isViewportTooSmall -> true
+    mount();
+    render(html`<${Assets} />`, container);
+    window.dispatchEvent(new Event('resize'));
+    await waitFor(() => container.textContent.includes('Please resize'));
+    expect(container.querySelector('.assets-image-grid-item.full-width').textContent).to.contain('1200px');
+  });
+
+  it('renders the three asset groups (empty) for an excluded page', async () => {
+    sinon.stub(window, 'matchMedia').returns({ matches: true }); // viewport ok
+    sinon.stub(window, 'fetch').callsFake((url) => {
+      if (String(url).includes('preflight-exclusions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [{ path: '**' }] }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) });
+    });
+    mount();
+    render(html`<${Assets} />`, container);
+    await new Promise((r) => { setTimeout(r, 50); }); // let the effect attach its resize listener
+    window.dispatchEvent(new Event('resize'));
+    await waitFor(() => container.querySelector('.assets-columns') && !container.textContent.includes('Please resize'));
+    await waitFor(() => container.querySelectorAll('.grid-heading').length >= 3);
+    expect(container.textContent).to.contain('No critical asset issues.');
   });
 });

--- a/test/blocks/preflight/panels/general.test.js
+++ b/test/blocks/preflight/panels/general.test.js
@@ -2,7 +2,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { html, render } from '../../../../libs/deps/htm-preact.js';
-import General, { runGeneralChecks } from '../../../../libs/blocks/preflight/panels/general.js';
+import General, { runGeneralChecks, getStatus } from '../../../../libs/blocks/preflight/panels/general.js';
 import { setConfig } from '../../../../libs/utils/utils.js';
 
 const waitFor = async (fn, tries = 80) => {
@@ -81,6 +81,91 @@ describe('preflight panels general', () => {
       expect(headings).to.include('Content');
       const itemTitles = [...container.querySelectorAll('.preflight-item-title')].map((p) => p.textContent);
       expect(itemTitles).to.include('Navigation');
+    });
+
+    it('selects all items and exposes the Preview action', async () => {
+      render(html`<${General} />`, container);
+      await waitFor(() => container.querySelector('#select-action button'));
+      container.querySelector('#select-action button').click();
+      await waitFor(() => container.querySelector('#preview-action'));
+      container.querySelector('#preview-action button').click();
+      // handleAction fires a POST for the checked page item.
+      await waitFor(() => window.fetch.getCalls().some((c) => c.args[1]?.method === 'POST'));
+      expect(window.fetch.getCalls().some((c) => c.args[1]?.method === 'POST')).to.be.true;
+    });
+
+    it('collapses a content group when its heading is clicked', async () => {
+      render(html`<${General} />`, container);
+      await waitFor(() => container.querySelector('.preflight-group-heading'));
+      const heading = container.querySelector('.preflight-group-heading');
+      const group = heading.closest('.preflight-content-group');
+      const wasClosed = group.classList.contains('is-closed');
+      heading.click();
+      await waitFor(() => group.classList.contains('is-closed') !== wasClosed);
+      expect(group.classList.contains('is-closed')).to.equal(!wasClosed);
+    });
+  });
+
+  describe('getStatus', () => {
+    afterEach(() => sinon.restore());
+
+    const stubAdmin = (statusJson, ok = true) => {
+      sinon.stub(window, 'fetch').callsFake((url) => {
+        if (String(url).includes('publish-permissions-config')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        }
+        return Promise.resolve({ ok, json: () => Promise.resolve(statusJson) });
+      });
+    };
+
+    it('returns Non AEM EDS Content for non-edge-delivery hosts', async () => {
+      const res = await getStatus(new URL('https://example.com/some/page'));
+      expect(res.preview).to.equal('Non AEM EDS Content');
+      expect(res.live).to.equal('Non AEM EDS Content');
+      expect(res.edit).to.be.null;
+    });
+
+    it('maps preview/live/edit from the admin status response', async () => {
+      stubAdmin({
+        preview: { lastModified: '2024-01-01' },
+        live: { lastModified: '2024-02-01' },
+        edit: { url: 'https://sharepoint/edit' },
+      });
+      const res = await getStatus(new URL('https://main--milo--adobecom.aem.page/foo'));
+      expect(res.preview).to.equal('2024-01-01');
+      expect(res.live).to.equal('2024-02-01');
+      expect(res.edit).to.equal('https://sharepoint/edit');
+      expect(res.publish).to.have.property('canPublish');
+    });
+
+    it('derives a da.live edit link from the source location', async () => {
+      stubAdmin({
+        preview: { lastModified: '2024-01-01', sourceLocation: 'markup:https://content.da.live/org/repo/foo' },
+        live: {},
+      });
+      const res = await getStatus(new URL('https://main--milo--adobecom.aem.page/foo'));
+      expect(res.edit).to.equal('https://da.live/edit#/org/repo/foo');
+      expect(res.live).to.equal('Never');
+    });
+
+    it('returns an empty object when the admin call is not ok', async () => {
+      stubAdmin({}, false);
+      const res = await getStatus(new URL('https://main--milo--adobecom.aem.page/foo'));
+      expect(res).to.deep.equal({});
+    });
+
+    it('resolves cross-repo /federal/ paths against the federal repo', async () => {
+      const captured = [];
+      sinon.stub(window, 'fetch').callsFake((url) => {
+        captured.push(String(url));
+        if (String(url).includes('publish-permissions-config')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+        }
+        const body = { preview: {}, live: {} };
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+      });
+      await getStatus(new URL('https://main--milo--adobecom.aem.page/federal/x'));
+      expect(captured.some((u) => u.includes('/adobecom/federal/main/federal/x'))).to.be.true;
     });
   });
 });

--- a/test/blocks/preflight/panels/general.test.js
+++ b/test/blocks/preflight/panels/general.test.js
@@ -1,0 +1,86 @@
+/* eslint-disable import/no-named-as-default-member */
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { html, render } from '../../../../libs/deps/htm-preact.js';
+import General, { runGeneralChecks } from '../../../../libs/blocks/preflight/panels/general.js';
+import { setConfig } from '../../../../libs/utils/utils.js';
+
+const waitFor = async (fn, tries = 80) => {
+  for (let i = 0; i < tries; i += 1) {
+    if (fn()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => { setTimeout(r, 15); });
+  }
+  throw new Error('waitFor timed out');
+};
+
+describe('preflight panels general', () => {
+  describe('runGeneralChecks', () => {
+    let main;
+    let header;
+
+    beforeEach(() => {
+      main = document.createElement('main');
+      main.innerHTML = `
+        <div class="fragment" data-path="/frag/one">frag</div>
+        <a data-modal-path="/modal/two" data-modal-hash="#open">modal</a>
+        <div data-path="/libs/excluded">excluded</div>
+        <a href="/internal-link">internal</a>
+        <img src="/pic.svg" alt="svg">
+      `;
+      header = document.createElement('header');
+      header.innerHTML = '<a href="/nav-link">nav</a>';
+      document.body.append(main, header);
+    });
+
+    afterEach(() => { main.remove(); header.remove(); });
+
+    it('always includes the current page as a single item', () => {
+      const content = runGeneralChecks();
+      expect(content.page.items).to.have.lengthOf(1);
+      expect(content.page.items[0].url.pathname).to.equal(window.location.pathname);
+    });
+
+    it('collects fragment/modal links and excludes /libs/ paths', () => {
+      const paths = runGeneralChecks().fragments.items.map((i) => i.url.pathname);
+      expect(paths).to.include('/frag/one');
+      expect(paths).to.include('/modal/two');
+      expect(paths).to.not.include('/libs/excluded');
+    });
+
+    it('marks the nav group closed by default', () => {
+      expect(runGeneralChecks().nav.closed).to.be.true;
+    });
+
+    it('collects internal links, svgs and nav links into their groups', () => {
+      const content = runGeneralChecks();
+      expect(content.links.items.map((i) => i.url.pathname)).to.include('/internal-link');
+      expect(content.svgs.items.map((i) => i.url.pathname)).to.include('/pic.svg');
+      expect(content.nav.items.map((i) => i.url.pathname)).to.include('/nav-link');
+    });
+  });
+
+  describe('General component', () => {
+    let container;
+
+    beforeEach(() => {
+      setConfig({ georouting: { enabled: 'off' } });
+      container = document.createElement('div');
+      document.body.append(container);
+      sinon.stub(window, 'fetch').resolves({ ok: true, status: 200, json: () => Promise.resolve({}) });
+    });
+
+    afterEach(() => { render(null, container); container.remove(); sinon.restore(); });
+
+    it('renders the Structure, Localization and Content sections', async () => {
+      render(html`<${General} />`, container);
+      await waitFor(() => container.querySelectorAll('.preflight-item').length > 0);
+      const headings = [...container.querySelectorAll('.preflight-structure-title')].map((p) => p.textContent);
+      expect(headings).to.include('Structure');
+      expect(headings).to.include('Localization');
+      expect(headings).to.include('Content');
+      const itemTitles = [...container.querySelectorAll('.preflight-item-title')].map((p) => p.textContent);
+      expect(itemTitles).to.include('Navigation');
+    });
+  });
+});

--- a/test/blocks/preflight/panels/martech.test.js
+++ b/test/blocks/preflight/panels/martech.test.js
@@ -1,0 +1,73 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { html, render } from '../../../../libs/deps/htm-preact.js';
+import Martech from '../../../../libs/blocks/preflight/panels/martech.js';
+
+const waitFor = async (fn, tries = 60) => {
+  for (let i = 0; i < tries; i += 1) {
+    if (fn()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => { setTimeout(r, 15); });
+  }
+  throw new Error('waitFor timed out');
+};
+
+describe('preflight panels martech', () => {
+  let main;
+  let container;
+
+  beforeEach(() => {
+    main = document.createElement('main');
+    main.innerHTML = `
+      <h1>Hero Heading</h1>
+      <a href="/learn">Learn more</a>
+      <a href="/learn">Learn more</a>
+      <div class="metadata"><h3>skip me</h3></div>
+      <a href="https://adobe.com">https://adobe.com</a>
+    `;
+    document.body.append(main);
+    container = document.createElement('div');
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+    main.remove();
+    sinon.restore();
+  });
+
+  it('builds a de-duplicated martech metadata table from main content', async () => {
+    render(html`<${Martech} />`, container);
+    await waitFor(() => container.querySelector('.martech-table table'));
+    const tableText = container.querySelector('.martech-table').textContent;
+    expect(tableText).to.contain('martech metadata');
+    expect(tableText).to.contain('Hero Heading');
+    expect(tableText).to.contain('Learn more');
+    // http-prefixed text and .metadata content are excluded.
+    expect(tableText).to.not.contain('adobe.com');
+    expect(tableText).to.not.contain('skip me');
+  });
+
+  it('copies the table to the clipboard and confirms via the button label', async () => {
+    const writeStub = sinon.stub(navigator.clipboard, 'write').resolves();
+    render(html`<${Martech} />`, container);
+    await waitFor(() => container.querySelector('.preflight-action'));
+    container.querySelector('.preflight-action').click();
+    expect(writeStub.calledOnce).to.be.true;
+    await waitFor(() => container.querySelector('.preflight-action').textContent.includes('Copied'));
+  });
+
+  it('shows an error label when copying fails', async () => {
+    const OriginalClipboardItem = window.ClipboardItem;
+    window.ClipboardItem = function ClipboardItemThrows() { throw new Error('no clipboard'); };
+    try {
+      render(html`<${Martech} />`, container);
+      await waitFor(() => container.querySelector('.preflight-action'));
+      container.querySelector('.preflight-action').click();
+      await waitFor(() => container.querySelector('.preflight-action').textContent.includes('Error'));
+    } finally {
+      window.ClipboardItem = OriginalClipboardItem;
+    }
+  });
+});

--- a/test/blocks/preflight/panels/merch.test.js
+++ b/test/blocks/preflight/panels/merch.test.js
@@ -1,6 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
-import {
+import { html, render } from '../../../../libs/deps/htm-preact.js';
+import Merch, {
   isMasUrl,
   getFragmentIdFromMasElement,
   formatDate,
@@ -8,7 +9,24 @@ import {
   isPromotionActive,
   checkUrl,
   checkMasFieldsMultipleFragments,
+  checkWcsElements,
 } from '../../../../libs/blocks/preflight/panels/merch.js';
+
+const waitFor = async (fn, tries = 80) => {
+  for (let i = 0; i < tries; i += 1) {
+    if (fn()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => { setTimeout(r, 15); });
+  }
+  throw new Error('waitFor timed out');
+};
+
+const activePromo = () => ({
+  start: '2020-01-01',
+  end: '2999-12-31',
+  displaySummary: { amount: 10, duration: 12, outcomeType: 'PERCENT_OFF', minProductQuantity: 1 },
+});
+const expiredPromo = () => ({ ...activePromo(), end: '2020-12-31' });
 
 describe('preflight panels merch', () => {
   describe('isMasUrl', () => {
@@ -162,6 +180,114 @@ describe('preflight panels merch', () => {
       document.body.append(main);
       checkMasFieldsMultipleFragments();
       expect(main.querySelector('.preflight-mas-multiple-fragments')).to.be.null;
+    });
+  });
+
+  describe('checkWcsElements', () => {
+    const created = [];
+    const add = (html2) => {
+      const wrap = document.createElement('div');
+      wrap.innerHTML = html2.trim();
+      const el = wrap.firstElementChild;
+      document.body.append(el);
+      created.push(el);
+      return el;
+    };
+
+    afterEach(() => {
+      while (created.length) created.pop().remove();
+      document.querySelectorAll('mas-commerce-service').forEach((s) => s.remove());
+      sinon.restore();
+    });
+
+    it('marks an element whose checkout URL redirects to an error', async () => {
+      sinon.stub(window, 'fetch').resolves({ url: 'https://commerce.adobe.com/error' });
+      const el = add('<a data-wcs-osi="osi-err" href="https://commerce.adobe.com/checkout">Buy</a>');
+      await checkWcsElements();
+      await waitFor(() => el.classList.contains('preflight-merch-error'));
+      expect(el.classList.contains('preflight-merch-error')).to.be.true;
+    });
+
+    it('leaves a clean checkout URL unmarked', async () => {
+      const okUrl = 'https://commerce.adobe.com/checkout?items[0][id]=A';
+      sinon.stub(window, 'fetch').resolves({ url: okUrl });
+      const el = add(`<a data-wcs-osi="osi-ok" href="${okUrl}">Buy</a>`);
+      await checkWcsElements();
+      await new Promise((r) => { setTimeout(r, 60); });
+      expect(el.classList.contains('preflight-merch-error')).to.be.false;
+    });
+
+    it('labels a price element whose offer is unavailable', async () => {
+      const el = add('<span data-wcs-osi="osi-pu" class="placeholder-failed">$9.99</span>');
+      await checkWcsElements();
+      expect(el.classList.contains('preflight-price-unavailable')).to.be.true;
+      expect(el.nextElementSibling?.classList.contains('preflight-price-unavailable-label')).to.be.true;
+    });
+
+    it('skips a disabled element with no text', async () => {
+      const el = add('<div data-wcs-osi="osi-dis"><button disabled></button></div>');
+      await checkWcsElements();
+      await new Promise((r) => { setTimeout(r, 40); });
+      expect(el.classList.contains('preflight-merch-error')).to.be.false;
+      expect(el.classList.contains('preflight-price-unavailable')).to.be.false;
+    });
+
+    it('flags an expired promotion code as an error', async () => {
+      add('<mas-commerce-service></mas-commerce-service>');
+      const service = document.querySelector('mas-commerce-service');
+      service.settings = { country: 'US', language: 'MULT' };
+      service.resolveOfferSelectors = () => [Promise.resolve([{ promotion: expiredPromo() }])];
+      const el = add('<span data-wcs-osi="osi-promo" data-promotion-code="OLD" data-quantity="1">$9.99</span>');
+      await checkWcsElements();
+      await waitFor(() => el.classList.contains('preflight-merch-error'));
+      expect(el.classList.contains('preflight-merch-error')).to.be.true;
+    });
+
+    it('flags a promotion code with no matching offer as not-found', async () => {
+      add('<mas-commerce-service></mas-commerce-service>');
+      const service = document.querySelector('mas-commerce-service');
+      service.settings = { country: 'US', language: 'MULT' };
+      service.resolveOfferSelectors = () => [Promise.resolve([{ }])];
+      const el = add('<span data-wcs-osi="osi-nf" data-promotion-code="NONE">$9.99</span>');
+      await checkWcsElements();
+      await waitFor(() => el.classList.contains('preflight-merch-error'));
+      expect(el.classList.contains('preflight-merch-error')).to.be.true;
+    });
+  });
+
+  describe('Merch component', () => {
+    let container;
+    let wrap;
+
+    beforeEach(async () => {
+      sinon.stub(window, 'fetch').resolves({ url: 'https://commerce.adobe.com/checkout?items[0][id]=A' });
+      // Populate the module signals directly so the component renders its full tree.
+      wrap = document.createElement('div');
+      wrap.innerHTML = '<a data-wcs-osi="osi-render" href="https://commerce.adobe.com/checkout?items[0][id]=A">Buy now</a>';
+      document.body.append(wrap);
+      await checkWcsElements();
+      await new Promise((r) => { setTimeout(r, 60); });
+      container = document.createElement('div');
+      document.body.append(container);
+    });
+
+    afterEach(() => {
+      render(null, container);
+      container.remove();
+      wrap.remove();
+      sinon.restore();
+    });
+
+    it('renders the summary and a WCS element item', async () => {
+      render(html`<${Merch} />`, container);
+      await waitFor(() => container.querySelector('.merch-summary'));
+      expect(container.querySelector('.merch-stat-number')).to.exist;
+      expect(container.textContent).to.contain('Buy now');
+      expect(container.querySelector('.merch-wcs-item')).to.exist;
+      // scroll button is wired
+      const scrollBtn = container.querySelector('.merch-scroll-btn');
+      expect(scrollBtn).to.exist;
+      scrollBtn.click();
     });
   });
 });

--- a/test/blocks/preflight/panels/merch.test.js
+++ b/test/blocks/preflight/panels/merch.test.js
@@ -1,0 +1,167 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import {
+  isMasUrl,
+  getFragmentIdFromMasElement,
+  formatDate,
+  selectOffers,
+  isPromotionActive,
+  checkUrl,
+  checkMasFieldsMultipleFragments,
+} from '../../../../libs/blocks/preflight/panels/merch.js';
+
+describe('preflight panels merch', () => {
+  describe('isMasUrl', () => {
+    it('recognizes mas.adobe.com URLs', () => {
+      expect(isMasUrl('https://mas.adobe.com/studio.html')).to.be.true;
+    });
+    it('rejects other hosts and invalid input', () => {
+      expect(isMasUrl('https://example.com')).to.be.false;
+      expect(isMasUrl('')).to.be.false;
+      expect(isMasUrl('not a url')).to.be.false;
+    });
+  });
+
+  describe('getFragmentIdFromMasElement', () => {
+    it('reads the fragment attribute from a mas-field', () => {
+      const field = document.createElement('mas-field');
+      field.innerHTML = '<aem-fragment fragment="frag-123"></aem-fragment>';
+      expect(getFragmentIdFromMasElement(field)).to.equal('frag-123');
+    });
+    it('returns null for a mas-field without an aem-fragment', () => {
+      expect(getFragmentIdFromMasElement(document.createElement('mas-field'))).to.be.null;
+    });
+    it('reads query/fragment params from a mas anchor hash', () => {
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#query=abc';
+      expect(getFragmentIdFromMasElement(a)).to.equal('abc');
+      a.href = 'https://mas.adobe.com/studio.html#fragment=def';
+      expect(getFragmentIdFromMasElement(a)).to.equal('def');
+    });
+    it('returns null for non-mas anchors and other elements', () => {
+      const a = document.createElement('a');
+      a.href = 'https://example.com/#query=abc';
+      expect(getFragmentIdFromMasElement(a)).to.be.null;
+      expect(getFragmentIdFromMasElement(document.createElement('div'))).to.be.null;
+    });
+  });
+
+  describe('formatDate', () => {
+    it('returns an empty string for falsy input', () => {
+      expect(formatDate('')).to.equal('');
+    });
+    it('formats an ISO date into a localized string', () => {
+      expect(formatDate('2024-01-15T10:00:00Z')).to.contain('2024');
+    });
+  });
+
+  describe('selectOffers', () => {
+    it('returns the offers as-is when there are fewer than two', () => {
+      const offers = [{ id: 'only' }];
+      expect(selectOffers(offers, { country: 'US' })).to.deep.equal([{ id: 'only' }]);
+    });
+    it('prefers the MULT language, term-less offer outside GB', () => {
+      const offers = [{ id: 'a', language: 'EN', term: 'ABM' }, { id: 'b', language: 'MULT' }];
+      const [selected] = selectOffers(offers, { country: 'US' });
+      expect(selected.id).to.equal('b');
+    });
+    it('prefers the EN offer in GB', () => {
+      const offers = [{ id: 'a', language: 'MULT', term: 'ABM' }, { id: 'b', language: 'EN' }];
+      const [selected] = selectOffers(offers, { country: 'GB' });
+      expect(selected.id).to.equal('b');
+    });
+  });
+
+  describe('isPromotionActive', () => {
+    const promo = {
+      start: '2020-01-01',
+      end: '2020-12-31',
+      displaySummary: { amount: 10, duration: 12, outcomeType: 'PERCENT_OFF', minProductQuantity: 1 },
+    };
+    it('is false without a promotion', () => {
+      expect(isPromotionActive(null)).to.be.false;
+    });
+    it('is false when the display summary is incomplete', () => {
+      const incomplete = { start: '2020-01-01', end: '2020-12-31', displaySummary: { amount: 5 } };
+      expect(isPromotionActive(incomplete)).to.be.false;
+    });
+    it('is false when start or end are missing', () => {
+      const noDates = { displaySummary: { amount: 10, duration: 12, outcomeType: 'PERCENT_OFF' } };
+      expect(isPromotionActive(noDates, '2020-06-01')).to.be.false;
+    });
+    it('is false below the minimum product quantity', () => {
+      const ds = { ...promo.displaySummary, minProductQuantity: 5 };
+      const gated = { ...promo, displaySummary: ds };
+      expect(isPromotionActive(gated, '2020-06-01', 1)).to.be.false;
+    });
+    it('is true within the active window', () => {
+      expect(isPromotionActive(promo, '2020-06-01')).to.be.true;
+    });
+    it('is false once expired', () => {
+      expect(isPromotionActive(promo, '2021-06-01')).to.be.false;
+    });
+  });
+
+  describe('checkUrl', () => {
+    afterEach(() => sinon.restore());
+
+    it('returns success for a clean redirect', async () => {
+      sinon.stub(window, 'fetch').resolves({ url: 'https://commerce.adobe.com/checkout?items[0][id]=A' });
+      const res = await checkUrl('https://commerce.adobe.com/checkout?items[0][id]=A');
+      expect(res.status).to.equal('success');
+      expect(res.idMismatch).to.be.false;
+    });
+    it('flags an error when the final URL contains "error"', async () => {
+      sinon.stub(window, 'fetch').resolves({ url: 'https://commerce.adobe.com/error' });
+      expect((await checkUrl('https://commerce.adobe.com/checkout')).status).to.equal('error');
+    });
+    it('flags an offer id mismatch as an error', async () => {
+      sinon.stub(window, 'fetch').resolves({ url: 'https://commerce.adobe.com/checkout?items[0][id]=B' });
+      const res = await checkUrl('https://commerce.adobe.com/checkout?items[0][id]=A');
+      expect(res.status).to.equal('error');
+      expect(res.idMismatch).to.be.true;
+    });
+    it('treats a failed fetch as success (CORS opaque)', async () => {
+      sinon.stub(window, 'fetch').rejects(new Error('Failed to fetch'));
+      expect((await checkUrl('https://commerce.adobe.com/checkout')).status).to.equal('success');
+    });
+    it('returns undetermined for other errors', async () => {
+      sinon.stub(window, 'fetch').rejects(new Error('boom'));
+      const res = await checkUrl('https://commerce.adobe.com/checkout');
+      expect(res.status).to.equal('undetermined');
+      expect(res.errorMessage).to.equal('boom');
+    });
+  });
+
+  describe('checkMasFieldsMultipleFragments', () => {
+    let main;
+    afterEach(() => main?.remove());
+
+    it('highlights a block that references multiple fragments in one section', () => {
+      main = document.createElement('main');
+      main.innerHTML = `
+        <div class="section">
+          <div class="con-block">
+            <mas-field><aem-fragment fragment="id-1"></aem-fragment></mas-field>
+            <mas-field><aem-fragment fragment="id-2"></aem-fragment></mas-field>
+          </div>
+        </div>`;
+      document.body.append(main);
+      checkMasFieldsMultipleFragments();
+      expect(main.querySelector('.con-block').classList.contains('preflight-mas-multiple-fragments')).to.be.true;
+    });
+
+    it('does not highlight a section with a single fragment', () => {
+      main = document.createElement('main');
+      main.innerHTML = `
+        <div class="section">
+          <div class="con-block">
+            <mas-field><aem-fragment fragment="id-1"></aem-fragment></mas-field>
+          </div>
+        </div>`;
+      document.body.append(main);
+      checkMasFieldsMultipleFragments();
+      expect(main.querySelector('.preflight-mas-multiple-fragments')).to.be.null;
+    });
+  });
+});

--- a/test/blocks/preflight/panels/merch.test.js
+++ b/test/blocks/preflight/panels/merch.test.js
@@ -290,4 +290,67 @@ describe('preflight panels merch', () => {
       scrollBtn.click();
     });
   });
+
+  describe('Merch component - varied element states', () => {
+    let container;
+    let wrap;
+
+    beforeEach(async () => {
+      sinon.stub(window, 'fetch').callsFake((url) => {
+        const u = String(url);
+        if (u.includes('items[0][id]=AAA')) {
+          return Promise.resolve({ url: 'https://commerce.adobe.com/co?items[0][id]=BBB' });
+        }
+        if (u.includes('/undet')) return Promise.reject(new Error('weird'));
+        return Promise.resolve({ url: u });
+      });
+
+      wrap = document.createElement('div');
+      wrap.innerHTML = `
+        <a data-wcs-osi="m1" href="https://commerce.adobe.com/co?items[0][id]=AAA">Mismatch</a>
+        <a data-wcs-osi="m2" href="https://commerce.adobe.com/undet">Undetermined</a>
+        <span data-wcs-osi="m3" data-promotion-code="GOOD" data-quantity="1">$1</span>
+        <span data-wcs-osi="m4" class="placeholder-failed">$2</span>
+        <mas-commerce-service></mas-commerce-service>
+        <main>
+          <div class="section"><div class="con-block">
+            <mas-field><aem-fragment fragment="f1"></aem-fragment></mas-field>
+            <mas-field><aem-fragment fragment="f2"></aem-fragment></mas-field>
+          </div></div>
+        </main>`;
+      document.body.append(wrap);
+      const service = wrap.querySelector('mas-commerce-service');
+      service.settings = { country: 'US', language: 'MULT' };
+      service.resolveOfferSelectors = () => [Promise.resolve([{ promotion: activePromo() }])];
+
+      await checkWcsElements();
+      await new Promise((r) => { setTimeout(r, 120); });
+      checkMasFieldsMultipleFragments();
+      container = document.createElement('div');
+      document.body.append(container);
+    });
+
+    afterEach(() => {
+      render(null, container);
+      container.remove();
+      wrap.remove();
+      sinon.restore();
+    });
+
+    it('renders id-mismatch, undetermined, active-promo, price-unavailable and mas-field warnings', async () => {
+      render(html`<${Merch} />`, container);
+      await waitFor(() => container.querySelector('.merch-wcs-item'));
+      const text = container.textContent;
+      expect(container.querySelector('.id-comparison'), 'id mismatch block').to.exist;
+      expect(text).to.contain('status is undetermined');
+      expect(text).to.contain('Promotion is active');
+      expect(text).to.contain('Offer unavailable');
+      // summary stats reflect failures/undetermined
+      expect(container.querySelector('.merch-summary-stat.has-errors')).to.exist;
+      expect(container.querySelector('.merch-summary-stat.has-warnings')).to.exist;
+      // mas-fields multiple-fragment section rendered
+      expect(container.querySelector('.mas-fields-warning-item')).to.exist;
+      expect(text).to.contain('multiple M@S fragment IDs');
+    });
+  });
 });

--- a/test/blocks/preflight/panels/seo-aso.test.js
+++ b/test/blocks/preflight/panels/seo-aso.test.js
@@ -1,0 +1,84 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { html, render } from '../../../../libs/deps/htm-preact.js';
+import SEO from '../../../../libs/blocks/preflight/panels/seo.js';
+import { asoCache } from '../../../../libs/blocks/preflight/checks/asoApi.js';
+import { setConfig } from '../../../../libs/utils/utils.js';
+
+// Isolated file so preflightApi's memoized getChecksSuite starts uncached and
+// resolves to the ASO suite here (a shared file would cache OG from other tests).
+describe('preflight panels seo - ASO suite', () => {
+  let container;
+  let clock;
+
+  const resetAso = () => Object.assign(asoCache, {
+    identify: null,
+    identifyFinished: false,
+    suggest: null,
+    suggestFinished: false,
+    sessionToken: null,
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    clock = sinon.useFakeTimers({ shouldAdvanceTime: false });
+    resetAso();
+    setConfig({ imsClientId: 'aso-client' });
+    sinon.stub(window, 'fetch').callsFake((url) => {
+      const u = String(url);
+      if (u.includes('preflight-exclusions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [{ path: '**' }] }) });
+      }
+      if (u.includes('preflight-config.json')) {
+        return Promise.resolve({ json: () => Promise.resolve({ data: [{ value: 'aso-client' }] }) });
+      }
+      return Promise.reject(new Error(`unexpected fetch ${u}`));
+    });
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+    clock.restore();
+    sinon.restore();
+    resetAso();
+  });
+
+  it('maps ASO identify results to pass/fail/limbo icons and shows an AI suggestion', async () => {
+    asoCache.sessionToken = 'session-token';
+    asoCache.identify = [
+      { id: 'title', status: 'fail', title: 'Title size', description: 'Too long' },
+      { id: 'h1-count', status: 'pass', title: 'H1 count', description: 'One H1' },
+      { id: 'body-size', status: 'limbo', title: 'Body size', description: 'Pending' },
+    ];
+    asoCache.identifyFinished = true;
+    asoCache.suggest = [{ id: 'title', aiSuggestion: 'A better title' }];
+    asoCache.suggestFinished = true;
+
+    render(html`<${SEO} />`, container);
+    await clock.tickAsync(1500);
+
+    const icons = [...container.querySelectorAll('.result-icon')].map((el) => el.className);
+    expect(icons.some((c) => c.includes('red'))).to.be.true;
+    expect(icons.some((c) => c.includes('green'))).to.be.true;
+    expect(icons.some((c) => c.includes('orange'))).to.be.true;
+    expect(container.textContent).to.contain('A better title');
+  });
+
+  it('shows the sign-in prompt and triggers IMS sign-in when unauthenticated', async () => {
+    window.asoIMS = { getAccessToken: () => null, signIn: sinon.stub().resolves() };
+    try {
+      render(html`<${SEO} />`, container);
+      await clock.tickAsync(50);
+      const signInBtn = container.querySelector('.preflight-auth-error .preflight-action');
+      expect(signInBtn, 'sign-in button should render').to.exist;
+      expect(container.textContent).to.contain('authenticated with IMS');
+      signInBtn.click();
+      await clock.tickAsync(50);
+      expect(window.asoIMS.signIn.calledOnce).to.be.true;
+    } finally {
+      delete window.asoIMS;
+    }
+  });
+});

--- a/test/blocks/preflight/panels/seo-aso.test.js
+++ b/test/blocks/preflight/panels/seo-aso.test.js
@@ -10,6 +10,7 @@ import { setConfig } from '../../../../libs/utils/utils.js';
 describe('preflight panels seo - ASO suite', () => {
   let container;
   let clock;
+  let loginStub;
 
   const resetAso = () => Object.assign(asoCache, {
     identify: null,
@@ -25,6 +26,7 @@ describe('preflight panels seo - ASO suite', () => {
     clock = sinon.useFakeTimers({ shouldAdvanceTime: false });
     resetAso();
     setConfig({ imsClientId: 'aso-client' });
+    loginStub = sinon.stub();
     sinon.stub(window, 'fetch').callsFake((url) => {
       const u = String(url);
       if (u.includes('preflight-exclusions')) {
@@ -32,6 +34,10 @@ describe('preflight panels seo - ASO suite', () => {
       }
       if (u.includes('preflight-config.json')) {
         return Promise.resolve({ json: () => Promise.resolve({ data: [{ value: 'aso-client' }] }) });
+      }
+      if (u.includes('/auth/login')) {
+        loginStub();
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ sessionToken: 'sess' }) });
       }
       return Promise.reject(new Error(`unexpected fetch ${u}`));
     });
@@ -77,6 +83,12 @@ describe('preflight panels seo - ASO suite', () => {
       signInBtn.click();
       await clock.tickAsync(50);
       expect(window.asoIMS.signIn.calledOnce).to.be.true;
+
+      // After sign-in the token becomes available; the poll interval then exchanges
+      // it for a session token and bumps the re-run trigger.
+      window.asoIMS.getAccessToken = () => ({ token: 'ims-tok' });
+      await clock.tickAsync(2100);
+      expect(loginStub.called, 'session token exchanged after sign-in').to.be.true;
     } finally {
       delete window.asoIMS;
     }

--- a/test/blocks/preflight/panels/seo.test.js
+++ b/test/blocks/preflight/panels/seo.test.js
@@ -1,0 +1,85 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { html, render } from '../../../../libs/deps/htm-preact.js';
+import SEO, { sendResults } from '../../../../libs/blocks/preflight/panels/seo.js';
+
+const waitFor = async (fn, tries = 80) => {
+  for (let i = 0; i < tries; i += 1) {
+    if (fn()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((r) => { setTimeout(r, 15); });
+  }
+  throw new Error('waitFor timed out');
+};
+
+describe('preflight panels seo', () => {
+  let robotsMeta;
+
+  beforeEach(() => {
+    robotsMeta = document.createElement('meta');
+    robotsMeta.setAttribute('name', 'robots');
+    robotsMeta.setAttribute('content', 'noindex, nofollow');
+    document.head.append(robotsMeta);
+  });
+
+  afterEach(() => {
+    robotsMeta.remove();
+    sinon.restore();
+  });
+
+  describe('sendResults', () => {
+    it('posts the SEO summary payload to the preflight endpoint', async () => {
+      const fetchStub = sinon.stub(window, 'fetch').resolves({ ok: true });
+      await sendResults();
+      expect(fetchStub.calledOnce).to.be.true;
+      const [url, opts] = fetchStub.firstCall.args;
+      expect(url).to.contain('/seo/preflight');
+      expect(opts.method).to.equal('POST');
+      const { data } = JSON.parse(opts.body);
+      expect(data.url).to.equal(window.location.href);
+      expect(data.robots).to.equal('noindex, nofollow');
+      expect(data.https).to.be.oneOf(['HTTPS', 'HTTP']);
+    });
+
+    it("defaults robots to 'all' when the meta content is empty", async () => {
+      robotsMeta.setAttribute('content', '');
+      const fetchStub = sinon.stub(window, 'fetch').resolves({ ok: true });
+      await sendResults();
+      const { data } = JSON.parse(fetchStub.firstCall.args[1].body);
+      expect(data.robots).to.equal('all');
+    });
+  });
+
+  describe('SEO component', () => {
+    let container;
+
+    beforeEach(() => {
+      container = document.createElement('div');
+      document.body.append(container);
+      // Exclude the current URL so getResults() bails before the heavy checks,
+      // and make the suite resolve to the non-ASO (OG) path.
+      sinon.stub(window, 'fetch').callsFake((url) => {
+        const u = String(url);
+        if (u.includes('preflight-exclusions')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [{ path: '**' }] }) });
+        }
+        if (u.includes('preflight-config.json')) {
+          return Promise.resolve({ json: () => Promise.resolve({ data: [] }) });
+        }
+        return Promise.reject(new Error(`unexpected fetch ${u}`));
+      });
+    });
+
+    afterEach(() => { render(null, container); container.remove(); });
+
+    it('renders the seven default SEO check items', async () => {
+      render(html`<${SEO} />`, container);
+      await waitFor(() => container.querySelectorAll('.preflight-item').length >= 7);
+      const titles = [...container.querySelectorAll('.preflight-item-title')].map((p) => p.textContent);
+      expect(titles).to.include('Title size');
+      expect(titles).to.include('H1 count');
+      expect(titles).to.include('Canonical');
+      expect(container.querySelectorAll('.preflight-item')).to.have.lengthOf(7);
+    });
+  });
+});

--- a/test/blocks/preflight/preflight.test.js
+++ b/test/blocks/preflight/preflight.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { html, render } from '../../../libs/deps/htm-preact.js';
-import { Preflight } from '../../../libs/blocks/preflight/preflight.js';
+import init, { Preflight, countChecks, countCategory } from '../../../libs/blocks/preflight/preflight.js';
 
 const TAB_TITLES = ['General', 'SEO', 'Martech', 'M@S', 'Accessibility', 'Performance', 'Assets'];
 // Signal-driven re-renders (tab switch) and useEffect checks resolve on a later tick.
@@ -62,5 +62,53 @@ describe('Preflight modal (isolation)', () => {
     const cta = container.querySelector('#panel-3 .preflight-action');
     expect(cta, 'martech CTA exists').to.exist;
     expect(() => cta.click()).to.not.throw();
+  });
+
+  it('init renders the modal and preloads the icon masks', async () => {
+    init(container);
+    expect(container.querySelectorAll('.preflight-tab-button')).to.have.lengthOf(TAB_TITLES.length);
+    expect(document.head.querySelector('link[rel="preload"][href*="check.svg"]')).to.exist;
+    await tick();
+  });
+});
+
+describe('Preflight badge counting', () => {
+  describe('countChecks', () => {
+    it('counts fail as an error and limbo as a warning', () => {
+      const res = countChecks([
+        { status: 'fail', severity: 'critical' },
+        { status: 'fail', severity: 'warning' },
+        { status: 'limbo' },
+        { status: 'pass' },
+      ]);
+      expect(res).to.deep.equal({ errors: 1, warnings: 2 });
+    });
+
+    it('defaults to zero counts for an empty list', () => {
+      expect(countChecks()).to.deep.equal({ errors: 0, warnings: 0 });
+    });
+  });
+
+  describe('countCategory', () => {
+    it('uses issuesCount for Accessibility failures', () => {
+      const runChecks = { accessibility: [{ status: 'fail', details: { issuesCount: 4 } }] };
+      expect(countCategory('Accessibility', runChecks)).to.deep.equal({ errors: 4, warnings: 0 });
+    });
+
+    it('uses unpublished length for M@S failures', () => {
+      const runChecks = { merch: [{ status: 'fail', details: { unpublished: [1, 2] } }] };
+      expect(countCategory('M@S', runChecks)).to.deep.equal({ errors: 2, warnings: 0 });
+    });
+
+    it('splits Assets failures into critical errors and below-fold warnings', () => {
+      const details = { criticalAssetFailures: [1], warningAssetFailures: [1, 2] };
+      const runChecks = { assets: [{ details }] };
+      expect(countCategory('Assets', runChecks)).to.deep.equal({ errors: 1, warnings: 2 });
+    });
+
+    it('falls back to countChecks for structure/seo/performance', () => {
+      const runChecks = { seo: [{ status: 'fail', severity: 'critical' }, { status: 'limbo' }] };
+      expect(countCategory('SEO', runChecks)).to.deep.equal({ errors: 1, warnings: 1 });
+    });
   });
 });

--- a/test/blocks/preflight/visual-metadata.test.js
+++ b/test/blocks/preflight/visual-metadata.test.js
@@ -1,0 +1,91 @@
+import { expect } from '@esm-bundle/chai';
+import { addAssetMetadata, displayPreflightVisuals } from '../../../libs/blocks/preflight/visual-metadata.js';
+
+describe('preflight visual-metadata', () => {
+  const created = [];
+  const mount = (html) => {
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html.trim();
+    document.body.append(wrap);
+    created.push(wrap);
+    return wrap;
+  };
+
+  afterEach(() => {
+    while (created.length) created.pop().remove();
+    document.body.classList.remove('preflight-assets-analysis');
+  });
+
+  describe('addAssetMetadata', () => {
+    it('adds a "correct" size entry for a valid image', () => {
+      const wrap = mount('<picture><img></picture>');
+      const img = wrap.querySelector('img');
+      addAssetMetadata(img, { hasMismatch: false, isAboveFold: false, recommendedDimensions: '800x600', type: 'image' });
+      const meta = wrap.querySelector('.asset-meta');
+      expect(meta).to.exist;
+      expect(meta.querySelector('.asset-meta-entry').textContent).to.equal('Size: correct');
+      expect(meta.querySelector('.is-valid')).to.exist;
+    });
+
+    it('flags a too-small image with the recommended dimensions', () => {
+      const wrap = mount('<picture><img></picture>');
+      addAssetMetadata(wrap.querySelector('img'), { hasMismatch: true, isAboveFold: false, recommendedDimensions: '1200x900', type: 'image' });
+      const entry = wrap.querySelector('.asset-meta-entry');
+      expect(entry.textContent).to.contain('too small, use > 1200x900');
+      expect(entry.classList.contains('is-invalid')).to.be.true;
+    });
+
+    it('marks an above-the-fold mismatch as CRITICAL', () => {
+      const wrap = mount('<picture><img></picture>');
+      addAssetMetadata(wrap.querySelector('img'), { hasMismatch: true, isAboveFold: true, recommendedDimensions: '1200x900', type: 'image' });
+      const entry = wrap.querySelector('.asset-meta-entry');
+      expect(entry.textContent).to.contain('CRITICAL');
+      expect(entry.classList.contains('above-fold-critical')).to.be.true;
+    });
+
+    it('adds a title entry for mpc assets with and without a title', () => {
+      const withTitle = mount('<div class="milo-video"><iframe title="My Video"></iframe></div>');
+      addAssetMetadata(withTitle.querySelector('iframe'), { hasMismatch: false, type: 'mpc' });
+      expect(withTitle.querySelector('.asset-meta').textContent).to.contain('Title: My Video');
+
+      const noTitle = mount('<div class="milo-video"><iframe></iframe></div>');
+      addAssetMetadata(noTitle.querySelector('iframe'), { hasMismatch: false, type: 'mpc' });
+      const entries = noTitle.querySelectorAll('.asset-meta-entry');
+      expect(entries[entries.length - 1].textContent).to.equal('Title: no title');
+      expect(entries[entries.length - 1].classList.contains('is-invalid')).to.be.true;
+    });
+
+    it('resolves the video-holder parent for video assets', () => {
+      const wrap = mount('<div class="video-holder"><video></video></div>');
+      addAssetMetadata(wrap.querySelector('video'), { hasMismatch: false, type: 'video' });
+      expect(wrap.querySelector('.video-holder > .asset-meta')).to.exist;
+    });
+
+    it('reuses an existing .asset-meta container', () => {
+      const wrap = mount('<picture><img></picture>');
+      const img = wrap.querySelector('img');
+      addAssetMetadata(img, { hasMismatch: false, type: 'image' });
+      addAssetMetadata(img, { hasMismatch: true, type: 'image' });
+      expect(wrap.querySelectorAll('.asset-meta')).to.have.lengthOf(1);
+      expect(wrap.querySelectorAll('.asset-meta-entry')).to.have.lengthOf(2);
+    });
+  });
+
+  describe('displayPreflightVisuals', () => {
+    it('does nothing for an empty asset list', () => {
+      displayPreflightVisuals([]);
+      expect(document.body.classList.contains('preflight-assets-analysis')).to.be.false;
+    });
+
+    it('marks the body and decorates each asset, skipping entries without an asset', () => {
+      const wrap = mount('<picture><img></picture>');
+      const img = wrap.querySelector('img');
+      displayPreflightVisuals([
+        { asset: img, hasMismatch: false, type: 'image' },
+        { hasMismatch: true, type: 'image' },
+      ]);
+      expect(document.body.classList.contains('preflight-assets-analysis')).to.be.true;
+      expect(wrap.querySelector('.asset-meta-entry')).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
### Description

The `libs/blocks/preflight` tree was largely untested — the entire `accessibility/`
directory and most of `checks/` and `panels/` had no unit coverage, and the SEO check
module only asserted its functions *exist*. This adds unit tests across the whole
feature and lifts every preflight source file to a meaningful coverage level.

### Testing
`npm run test` (green) and `npm run lint` (clean). This PR is test-only aside from the
additive exports above, so there is no user-facing change to verify on a page.

Resolves: [MWPW-184222](https://jira.corp.adobe.com/browse/MWPW-184222)

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://mwpw-184222-preflight-unit-tests--milo--adobecom.aem.page/?martech=off




