### PR TITLE
MWPW-207231: fix(router-marquee): keep mas-field paragraphs inside the field

### DIFF
--- a/libs/c2/blocks/router-marquee/router-marquee.css
+++ b/libs/c2/blocks/router-marquee/router-marquee.css
@@ -531,3 +531,8 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* Rejoin parser-split nested paragraphs into one line. */
+.router-marquee mas-field > [data-role="mas-field-content"] p {
+  display: inline;
+}

--- a/libs/c2/blocks/router-marquee/router-marquee.js
+++ b/libs/c2/blocks/router-marquee/router-marquee.js
@@ -148,7 +148,8 @@ const decorateText = (textCol) => {
   const icon = textCol.querySelector('p a[href*=".svg"]');
   const label = textCol.querySelector(':scope > p:has(a[href*=".svg"]) + p');
   const cta = textCol.querySelector('p:has(em)');
-  const body = [...textCol.querySelectorAll('p')]
+  // Direct children only: skip <p>s a mas-field renders inside itself.
+  const body = [...textCol.querySelectorAll(':scope > p')]
     .filter((p) => [eyebrow, icon?.closest('p'), label, cta].every((x) => x !== p));
 
   if (!body.length) return;

--- a/test/blocks/router-marquee/mocks/nested-paragraphs.html
+++ b/test/blocks/router-marquee/mocks/nested-paragraphs.html
@@ -1,0 +1,35 @@
+<main>
+  <div class="section">
+    <div class="router-marquee">
+      <div>
+        <div>mobile</div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow one</p>
+          <h2>Slide one title</h2>
+          <p>Body copy for slide one. <mas-field field="prices"><span data-role="mas-field-content"></span></mas-field></p>
+          <p><em><strong><a href="https://www.adobe.com/buy">Buy now</a></strong></em></p>
+          <p><img src="/federal/icons/card-one.svg" alt="card one icon" /></p>
+          <p><a href="https://www.adobe.com/slide-one">Slide one</a></p>
+        </div>
+        <div>
+          <picture><img src="" alt="background one" /></picture>
+        </div>
+      </div>
+      <div>
+        <div>
+          <p>Eyebrow two</p>
+          <h2>Slide two title</h2>
+          <p>Body copy for slide two.</p>
+          <p><em><strong><a href="https://www.adobe.com/buy2">Buy now</a></strong></em></p>
+          <p><img src="/federal/icons/card-two.svg" alt="card two icon" /></p>
+          <p><a href="https://www.adobe.com/slide-two">Slide two</a></p>
+        </div>
+        <div>
+          <picture><img src="" alt="background two" /></picture>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/test/blocks/router-marquee/router-marquee.test.js
+++ b/test/blocks/router-marquee/router-marquee.test.js
@@ -121,6 +121,19 @@ describe('Router Marquee', () => {
     expect(cards[1].getAttribute('daa-ll')).to.equal('rm-nav-2--Slide two title');
   });
 
+  it('leaves paragraphs rendered inside a mas-field where they are', async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/nested-paragraphs.html' });
+    const block = document.querySelector('.router-marquee');
+    // mas-field resolves before the block decorates and writes its own paragraphs
+    document.querySelector('mas-field [data-role="mas-field-content"]').innerHTML = '<p>A$9.99/mo</p><p>Terms apply.</p>';
+    init(block);
+
+    const body = mobileVp(block).querySelector('.rm-slide .rm-body');
+    expect(body.querySelectorAll(':scope > p').length).to.equal(1);
+    expect(body.querySelectorAll('mas-field p').length).to.equal(2);
+    expect(body.textContent.match(/A\$9\.99\/mo/g).length).to.equal(1);
+  });
+
   it('reorders slides based on the starting-marquee section metadata', async () => {
     document.body.innerHTML = await readFile({ path: './mocks/reorder.html' });
     const block = document.querySelector('.router-marquee');


### PR DESCRIPTION
Collect only direct child paragraphs in `decorateText`, so the ones a mas-field renders inside itself stay there instead of being hoisted into `.rm-body` and duplicated on the field's next render.

Resolves: [MWPW-207231](https://jira.corp.adobe.com/browse/MWPW-207231) [MWPW-207257 ](https://jira.corp.adobe.com/browse/MWPW-207257)


**Test URLs:**
- Before: https://main--upp--adobecom.aem.page/au/drafts/mirafedas/?martech=off
- After: https://main--upp--adobecom.aem.page/au/drafts/mirafedas/?martech=off&milolibs=MWPW-207231












