### PR TITLE
MWPW-207084: fix(merch): keep inline mas-field description text when it has a link

### DIFF
--- a/libs/blocks/merch/merch.js
+++ b/libs/blocks/merch/merch.js
@@ -1691,6 +1691,15 @@ const HEADING_SELECTOR = 'h1, h2, h3, h4, h5, h6';
 const BLOCK_CONTENT_SELECTOR = `${HEADING_SELECTOR}, p, div, ul, ol, table, blockquote, pre, figure, section, article, hr`;
 const INLINE_WRAPPER_SELECTOR = 'strong, em, span, b, i, u, small, mark';
 
+// A description with a link (e.g. "save 40%. Terms apply") isn't a button (MWPW-207084).
+function isCtaFieldContent(content) {
+  if (!content || content.querySelector(BLOCK_CONTENT_SELECTOR)) return false;
+  const anchors = [...content.querySelectorAll('a')];
+  if (!anchors.length) return false;
+  const strip = (text) => text.replace(/\s+/g, '');
+  return strip(content.textContent) === strip(anchors.map((a) => a.textContent).join(''));
+}
+
 /**
  * Upgrades plain commerce elements (missing `is` attribute) to their proper
  * customized built-in equivalents so the commerce service resolves them.
@@ -1908,8 +1917,7 @@ function watchMasFieldCtas() {
   document.addEventListener('mas:ready', async ({ target: mf }) => {
     if (mf?.tagName !== 'MAS-FIELD' || !mf.closest('em, strong')) return;
     const content = mf.querySelector(':scope > [data-role="mas-field-content"]');
-    // Same gate createInline uses: an inline CTA anchor, not block-level content.
-    if (content?.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
+    if (isCtaFieldContent(content)) {
       // Upgrade to checkout-link before hoisting, else the late CTA never hydrates.
       upgradeCommerceLinks(content);
       await decorateContentLinks(content);
@@ -1944,7 +1952,7 @@ async function createInlineField(el, options) {
   await decorateContentLinks(content);
 
   // Inline CTAs: hoist the anchor into the authored em/strong and let decorateButtons style it.
-  if (content.querySelector('a') && !content.querySelector(BLOCK_CONTENT_SELECTOR)) {
+  if (isCtaFieldContent(content)) {
     return decorateInlineCtas(masField, content) ?? masField;
   }
   return masField;

--- a/test/blocks/merch/mas-field.test.js
+++ b/test/blocks/merch/mas-field.test.js
@@ -17,6 +17,9 @@ if (!customElements.get('mas-field')) {
         const field = this.getAttribute('field');
         if (field === 'description') {
           content.innerHTML = '<h3><strong>Resolved description</strong></h3><a href="https://www.adobe.com/">See terms</a><a href="https://main--milo--adobecom.aem.live/test/fragments/modal#cardmodal">Open modal</a>';
+        } else if (field === 'description-inline') {
+          // Copy with an inline link and no block wrapper — must stay a description (MWPW-207084).
+          content.innerHTML = 'Save 40% off your first year. <a href="https://www.adobe.com/terms">Terms apply</a>';
         } else if (field === 'ctas') {
           content.innerHTML = '<strong><a href="https://www.adobe.com/">Buy now</a></strong><em><a href="https://main--milo--adobecom.aem.page/some/test/page">Go</a></em>';
         } else if (field === 'ctas-checkout') {
@@ -161,6 +164,22 @@ describe('mas-field', () => {
       const modalLink = document.querySelector('mas-field a[href="#cardmodal"]');
       expect(modalLink.classList.contains('modal')).to.be.true;
       expect(modalLink.getAttribute('data-modal-path')).to.equal('/test/fragments/modal');
+    });
+
+    it('keeps description copy and its discount percentage when a link is authored inline (MWPW-207084)', async () => {
+      const a = document.createElement('a');
+      a.href = 'https://mas.adobe.com/studio.html#content-type=merch-card&fragment=inline-link-1&field=description-inline';
+      a.textContent = '[[inline-link-test:description]]';
+      document.body.append(a);
+      await init(a);
+      const masField = document.querySelector('mas-field');
+      expect(masField).to.exist;
+      const content = masField.querySelector('[data-role="mas-field-content"]');
+      expect(content).to.exist;
+      // The copy (carrying the discount percentage) survives instead of collapsing to the link.
+      expect(content.textContent).to.contain('Save 40% off your first year.');
+      expect(content.querySelector('a[href="https://www.adobe.com/terms"]')).to.exist;
+      expect(masField.querySelector('.con-button')).to.not.exist;
     });
 
     it('returns early for inline fragment when fragment is missing', async () => {


### PR DESCRIPTION
## Description
A description with an inline link (for example a "Terms apply" link) lost the rest of its text, including the "Save X%" discount line. The field was treated as a button, so only the link survived. A field now counts as a button only when the link is its whole content, so descriptions keep their text.

## Related Issue
Resolves: [MWPW-207084](https://jira.corp.adobe.com/browse/MWPW-207084)

## Testing instructions
Open the After URL and open the Creative Cloud promo in the global navigation. The description shows in full: the copy, the discount percentage, and the terms link. Without the fix only the terms link shows.

## Test URLs
- Before: https://main--da-cc--adobecom.aem.page/creativecloud?instant=2028-08-13T19:30:00.000Z&country=ca
- After: https://main--da-cc--adobecom.aem.page/creativecloud?instant=2028-08-13T19:30:00.000Z&country=ca&milolibs=MWPW-207084--milo--adobecom


