### PR TITLE
fix: Floodgate: Update da.live/app paths

### DIFF
--- a/test/tools/floodbox/floodgate/fg-copy.test.js
+++ b/test/tools/floodbox/floodgate/fg-copy.test.js
@@ -63,6 +63,21 @@ describe('FloodgateCopy', () => {
     expect(RequestHandler.prototype.uploadContent.firstCall.args[1]).to.include('--test-repo-fg-pink--test-org.');
   });
 
+  it('adds the floodgate color suffix to da.live/app authoring links', async () => {
+    requestHandlerStub.resolves({
+      ok: true,
+      text: async () => '<a href="https://da.live/app/test-org/test-repo/tools/da-apps/schedule-maker?schedule=x">Edit</a>',
+    });
+    RequestHandler.prototype.uploadContent.resolves({ statusCode: 200 });
+
+    await copyFiles({
+      accessToken, org, repo, paths: ['/test-org/test-repo/path1'], callback: callbackStub, fgColor,
+    });
+
+    const uploaded = RequestHandler.prototype.uploadContent.firstCall.args[1];
+    expect(uploaded).to.include('https://da.live/app/test-org/test-repo-fg-pink/tools/da-apps/schedule-maker?schedule=x');
+  });
+
   it('processes non-editable files correctly', async () => {
     requestHandlerStub.resolves({
       ok: true,

--- a/test/tools/floodbox/search-replace.test.js
+++ b/test/tools/floodbox/search-replace.test.js
@@ -15,6 +15,213 @@ describe('searchAndReplace', () => {
     expect(result).to.equal('https://main--repo--org.aem.page/folder/page1');
   });
 
+  it('should add the color suffix to preview domains (direction toFloodgate)', () => {
+    const content = 'https://main--repo--org.aem.page/folder/page1';
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'org',
+      repo: 'repo',
+      expName: 'expName',
+      color: 'pink',
+      direction: 'toFloodgate',
+    });
+    expect(result).to.equal('https://main--repo-fg-pink--org.aem.page/folder/page1');
+  });
+
+  it('should derive both repos whether given the source or floodgate repo', () => {
+    const content = 'https://main--repo-fg-pink--org.aem.page/page';
+    const fromFloodgateRepo = searchAndReplace({
+      content, searchType: 'floodgate', org: 'org', repo: 'repo-fg-pink', color: 'pink', direction: 'toSource',
+    });
+    const fromSourceRepo = searchAndReplace({
+      content, searchType: 'floodgate', org: 'org', repo: 'repo', color: 'pink', direction: 'toSource',
+    });
+    expect(fromFloodgateRepo).to.equal('https://main--repo--org.aem.page/page');
+    expect(fromSourceRepo).to.equal(fromFloodgateRepo);
+  });
+
+  it('should add the color suffix to da app links (direction toFloodgate)', () => {
+    const content = '<p><a href="https://da.live/app/adobecom/da-events/tools/da-apps/schedule-maker?schedule=xxxxxxx">Schedule: Creativity Award Block – Monday, Aug 17, 2026, 12:33 PM</a></p>';
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'adobecom',
+      repo: 'da-events-fg-pink',
+      expName: 'expName',
+      color: 'pink',
+      direction: 'toFloodgate',
+    });
+    expect(result).to.equal('<p><a href="https://da.live/app/adobecom/da-events-fg-pink/tools/da-apps/schedule-maker?schedule=xxxxxxx">Schedule: Creativity Award Block – Monday, Aug 17, 2026, 12:33 PM</a></p>');
+  });
+
+  it('should strip the color suffix from da app links back to the source repo (direction toSource)', () => {
+    const content = '<p><a href="https://da.live/app/adobecom/da-events-fg-pink/tools/da-apps/schedule-maker?schedule=xxxxxxx">Schedule</a></p>';
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'adobecom',
+      repo: 'da-events-fg-pink',
+      expName: 'expName',
+      color: 'pink',
+      direction: 'toSource',
+    });
+    expect(result).to.equal('<p><a href="https://da.live/app/adobecom/da-events/tools/da-apps/schedule-maker?schedule=xxxxxxx">Schedule</a></p>');
+  });
+
+  it('should default to toSource when no direction is provided', () => {
+    const content = '<a href="https://da.live/app/adobecom/da-events-fg-pink/page">Link</a>';
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'adobecom',
+      repo: 'da-events-fg-pink',
+      expName: 'expName',
+      color: 'pink',
+    });
+    expect(result).to.equal('<a href="https://da.live/app/adobecom/da-events/page">Link</a>');
+  });
+
+  it('should normalize mixed da app links toFloodgate (idempotent add)', () => {
+    const content = [
+      '<a href="https://da.live/app/adobecom/da-events/page-a">A</a>',
+      '<a href="https://da.live/app/adobecom/da-events-fg-pink/page-b">B</a>',
+    ].join('');
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'adobecom',
+      repo: 'da-events-fg-pink',
+      expName: 'expName',
+      color: 'pink',
+      direction: 'toFloodgate',
+    });
+    expect(result).to.equal([
+      '<a href="https://da.live/app/adobecom/da-events-fg-pink/page-a">A</a>',
+      '<a href="https://da.live/app/adobecom/da-events-fg-pink/page-b">B</a>',
+    ].join(''));
+  });
+
+  it('should normalize mixed da app links toSource (idempotent strip)', () => {
+    const content = [
+      '<a href="https://da.live/app/adobecom/da-events/page-a">A</a>',
+      '<a href="https://da.live/app/adobecom/da-events-fg-pink/page-b">B</a>',
+    ].join('');
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'adobecom',
+      repo: 'da-events-fg-pink',
+      expName: 'expName',
+      color: 'pink',
+      direction: 'toSource',
+    });
+    expect(result).to.equal([
+      '<a href="https://da.live/app/adobecom/da-events/page-a">A</a>',
+      '<a href="https://da.live/app/adobecom/da-events/page-b">B</a>',
+    ].join(''));
+  });
+
+  it('should be idempotent when run twice in the same direction', () => {
+    const content = '<a href="https://da.live/app/adobecom/da-events/page">Link</a>';
+    const args = {
+      searchType: 'floodgate',
+      org: 'adobecom',
+      repo: 'da-events-fg-blue',
+      expName: 'expName',
+      color: 'blue',
+      direction: 'toFloodgate',
+    };
+    const once = searchAndReplace({ ...args, content });
+    const twice = searchAndReplace({ ...args, content: once });
+    expect(once).to.equal('<a href="https://da.live/app/adobecom/da-events-fg-blue/page">Link</a>');
+    expect(twice).to.equal(once);
+  });
+
+  it('should use the provided color when adding the suffix', () => {
+    const content = '<a href="https://da.live/app/adobecom/da-events/page">Link</a>';
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'adobecom',
+      repo: 'da-events-fg-blue',
+      expName: 'expName',
+      color: 'blue',
+      direction: 'toFloodgate',
+    });
+    expect(result).to.equal('<a href="https://da.live/app/adobecom/da-events-fg-blue/page">Link</a>');
+  });
+
+  it('should only rewrite da app links for the org and repo being processed', () => {
+    const content = [
+      '<a href="https://da.live/app/adobecom/da-events/page">same repo</a>',
+      '<a href="https://da.live/app/adobecom/other-repo/page">other repo</a>',
+      '<a href="https://da.live/app/other-org/da-events/page">other org</a>',
+      '<a href="https://da.live/app/adobecom/da-events-legacy/page">repo name prefix</a>',
+    ].join('');
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'adobecom',
+      repo: 'da-events-fg-pink',
+      expName: 'expName',
+      color: 'pink',
+      direction: 'toFloodgate',
+    });
+    expect(result).to.equal([
+      '<a href="https://da.live/app/adobecom/da-events-fg-pink/page">same repo</a>',
+      '<a href="https://da.live/app/adobecom/other-repo/page">other repo</a>',
+      '<a href="https://da.live/app/other-org/da-events/page">other org</a>',
+      '<a href="https://da.live/app/adobecom/da-events-legacy/page">repo name prefix</a>',
+    ].join(''));
+  });
+
+  it('should adjust both preview domains and da app links together', () => {
+    const content = [
+      '<a href="https://main--da-events-fg-pink--adobecom.aem.page/folder/page1">Preview</a>',
+      '<a href="https://da.live/app/adobecom/da-events-fg-pink/tools/da-apps/schedule-maker">Edit</a>',
+    ].join('');
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'adobecom',
+      repo: 'da-events-fg-pink',
+      expName: 'expName',
+      color: 'pink',
+      direction: 'toSource',
+    });
+    expect(result).to.equal([
+      '<a href="https://main--da-events--adobecom.aem.page/folder/page1">Preview</a>',
+      '<a href="https://da.live/app/adobecom/da-events/tools/da-apps/schedule-maker">Edit</a>',
+    ].join(''));
+  });
+
+  it('should not swallow markup when the repo is the last path segment of a da app link', () => {
+    const content = '<a href="https://da.live/app/adobecom/da-events">Repo root</a>';
+    const toFloodgate = searchAndReplace({
+      content, searchType: 'floodgate', org: 'adobecom', repo: 'da-events-fg-pink', color: 'pink', direction: 'toFloodgate',
+    });
+    const backToSource = searchAndReplace({
+      content: toFloodgate, searchType: 'floodgate', org: 'adobecom', repo: 'da-events-fg-pink', color: 'pink', direction: 'toSource',
+    });
+    expect(toFloodgate).to.equal('<a href="https://da.live/app/adobecom/da-events-fg-pink">Repo root</a>');
+    expect(backToSource).to.equal(content);
+  });
+
+  it('should leave content without da app links or matching domains unchanged', () => {
+    const content = '<p><a href="https://example.com/adobecom/da-events/page">External</a></p>';
+    const result = searchAndReplace({
+      content,
+      searchType: 'floodgate',
+      org: 'org',
+      repo: 'repo-fg-pink',
+      expName: 'expName',
+      color: 'pink',
+      direction: 'toFloodgate',
+    });
+    expect(result).to.equal(content);
+  });
+
   it('should replace graybox URLs and remove graybox styles and blocks', () => {
     const content = `
       <div class="gb-style">Content</div>

--- a/tools/floodbox/floodgate/fg-copy.js
+++ b/tools/floodbox/floodgate/fg-copy.js
@@ -2,6 +2,7 @@
 import { Queue } from 'https://da.live/nx/public/utils/tree.js';
 import { DA_ORIGIN } from '../constants.js';
 import RequestHandler from '../request-handler.js';
+import searchAndReplace from '../search-replace.js';
 import { getFileExtension, getFileName, isEditableFile } from '../utils.js';
 
 class FloodgateCopy {
@@ -22,16 +23,11 @@ class FloodgateCopy {
     this.signal = signal;
 
     this.requestHandler = new RequestHandler(accessToken, { signal });
+    this.fgColor = fgColor;
     this.destRepo = `${repo}-fg-${fgColor}`;
     this.srcSitePath = `/${org}/${repo}`;
     this.destSitePath = `/${org}/${this.destRepo}`;
     this.filesToCopy = [];
-  }
-
-  adjustUrlDomains(content) {
-    const searchValue = `--${this.repo}--${this.org}.`;
-    const replaceValue = `--${this.destRepo}--${this.org}.`;
-    return content.replaceAll(searchValue, replaceValue);
   }
 
   async processFile(file) {
@@ -41,7 +37,15 @@ class FloodgateCopy {
       if (response.ok) {
         let content = isEditableFile(file.ext) ? await response.text() : await response.blob();
         if (file.ext === 'html') {
-          content = this.adjustUrlDomains(content);
+          // Copy moves content from the source repo to the floodgate repo.
+          content = searchAndReplace({
+            content,
+            searchType: 'floodgate',
+            org: this.org,
+            repo: this.repo,
+            color: this.fgColor,
+            direction: 'toFloodgate',
+          });
         }
         const destFilePath = file.path.replace(this.srcSitePath, this.destSitePath);
         const status = await this.requestHandler.uploadContent(destFilePath, content, file.ext);

--- a/tools/floodbox/promote.js
+++ b/tools/floodbox/promote.js
@@ -38,6 +38,8 @@ class Promote {
             repo: this.repo,
             expName: this.expName,
             color: this.color,
+            // Promote moves content from the floodgate repo to the source repo.
+            direction: 'toSource',
           });
         }
         let destFilePath = file.path.replace(this.srcSitePath, this.destSitePath);

--- a/tools/floodbox/search-replace.js
+++ b/tools/floodbox/search-replace.js
@@ -1,18 +1,34 @@
 /**
  * Search and replace content based on the search type (floodgate or graybox).
  *
- * This is specifically created to be used as part of the PROMOTE operations
- * performed for Floodgate and Graybox content.
+ * Used by the Floodgate COPY (direction 'toFloodgate') and PROMOTE
+ * (direction 'toSource') operations, and by Graybox PROMOTE.
  */
 
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 class SearchReplace {
-  constructor({ searchType, org, repo, expName, color }) {
+  constructor({
+    searchType, org, repo, expName, color, direction = 'toSource',
+  }) {
     this.searchType = searchType; // 'floodgate' or 'graybox'
     this.org = org;
     this.repo = repo;
     this.expName = expName;
-    const repoSuffix = searchType === 'floodgate' ? `fg-${color}` : 'graybox';
-    this.destRepo = repo.replace(`-${repoSuffix}`, '');
+    // Direction of the floodgate repo rewrite (both preview domains and
+    // da.live/app links):
+    //   'toSource'    – strip the -fg-<color> suffix (floodgate → source), promote
+    //   'toFloodgate' – add the -fg-<color> suffix (source → floodgate), copy
+    // Each direction is idempotent, so running searchAndReplace twice is safe.
+    this.direction = direction;
+    if (searchType === 'floodgate') {
+      // Accept either the source repo or the floodgate repo and derive both, so
+      // the rewrite works no matter which form the caller passes.
+      this.sourceRepo = repo.replace(`-fg-${color}`, '');
+      this.floodgateRepo = `${this.sourceRepo}-fg-${color}`;
+    }
   }
 
   searchAndReplace(content) {
@@ -36,9 +52,24 @@ class SearchReplace {
 
   adjustUrlDomains(content) {
     if (this.searchType === 'floodgate') {
-      const searchValue = `--${this.repo}--${this.org}`;
-      const replaceValue = `--${this.destRepo}--${this.org}`;
-      return content.replaceAll(searchValue, replaceValue);
+      const toFloodgate = this.direction === 'toFloodgate';
+      const fromRepo = toFloodgate ? this.sourceRepo : this.floodgateRepo;
+      const toRepo = toFloodgate ? this.floodgateRepo : this.sourceRepo;
+      // Rewrite preview/live hostnames (…--<repo>--<org>.aem.page). The trailing
+      // dot anchors the match to the hostname boundary.
+      const searchValue = `--${fromRepo}--${this.org}.`;
+      const replaceValue = `--${toRepo}--${this.org}.`;
+      const updatedContent = content.replaceAll(searchValue, replaceValue);
+      // Rewrite da.live/app authoring links, but only those pointing at this
+      // org's repo being processed — links to any other org/repo are left alone.
+      // The lookahead keeps <repo> a whole path segment (so a `repo` prefix does
+      // not match `repository`) and stops at HTML/URL delimiters, which also
+      // covers a link to the repo root with no trailing path.
+      const appLink = new RegExp(
+        `(da\\.live/app/${escapeRegExp(this.org)}/)${escapeRegExp(fromRepo)}(?=[/?#"'<>\\s\\\\]|$)`,
+        'g',
+      );
+      return updatedContent.replace(appLink, (match, prefix) => `${prefix}${toRepo}`);
     }
     if (this.searchType === 'graybox') {
       const updatedContent = content.replaceAll(`.page/${this.expName}`, '.page');
@@ -65,9 +96,11 @@ class SearchReplace {
 }
 
 function searchAndReplace({
-  content, searchType, org, repo, expName, color,
+  content, searchType, org, repo, expName, color, direction,
 }) {
-  const searchReplace = new SearchReplace({ searchType, org, repo, expName, color });
+  const searchReplace = new SearchReplace({
+    searchType, org, repo, expName, color, direction,
+  });
   return searchReplace.searchAndReplace(content);
 }
 


### PR DESCRIPTION
Switch fg-copy to also use searchAndReplace so same logic is applied to both copy and promote.

**Test URLs:**
- Before: https://main--milo--adobecom.aem.page/?martech=off
- After: https://fgcopy--milo--adobecom.aem.page/?martech=off


